### PR TITLE
[dhctl] Bump dhctl Go version to 1.26.4

### DIFF
--- a/dhctl/cmd/dhctl/action.go
+++ b/dhctl/cmd/dhctl/action.go
@@ -67,8 +67,7 @@ func newActionIniter(opts *options.Options) *actionIniter {
 }
 
 func (i *actionIniter) setParams(params actionIniterParams) *actionIniter {
-	paramsCopy := params
-	i.params = &paramsCopy
+	i.params = new(params)
 	return i
 }
 

--- a/dhctl/cmd/dhctl/commands/ssh.go
+++ b/dhctl/cmd/dhctl/commands/ssh.go
@@ -202,8 +202,7 @@ func DefineTestUploadExecCommand(cmd *kingpin.CmdClause, opts *options.Options) 
 		var stdout []byte
 		stdout, err = cmd.Execute(ctx)
 		if err != nil {
-			var ee *exec.ExitError
-			if errors.As(err, &ee) {
+			if ee, ok := errors.AsType[*exec.ExitError](err); ok {
 				return fmt.Errorf("script '%s' error: %w\nstderr: %s", ScriptPath, err, string(ee.Stderr))
 			}
 			return fmt.Errorf("script '%s' error: %w", ScriptPath, err)
@@ -265,8 +264,7 @@ func DefineTestBundle(cmd *kingpin.CmdClause, opts *options.Options) *kingpin.Cm
 
 		stdout, err := cmd.ExecuteBundle(ctx, parentDir, bundleDir)
 		if err != nil {
-			var ee *exec.ExitError
-			if errors.As(err, &ee) {
+			if ee, ok := errors.AsType[*exec.ExitError](err); ok {
 				return fmt.Errorf("bundle '%s' error: %w\nstderr: %s\n", bundleDir, err, string(ee.Stderr))
 			}
 			return fmt.Errorf("bundle '%s' error: %w", bundleDir, err)

--- a/dhctl/go.mod
+++ b/dhctl/go.mod
@@ -1,6 +1,6 @@
 module github.com/deckhouse/deckhouse/dhctl
 
-go 1.25.8
+go 1.26.4
 
 require (
 	github.com/090809/oteljsonl v0.0.2

--- a/dhctl/pkg/apis/deckhouse/v1/nodegroup.go
+++ b/dhctl/pkg/apis/deckhouse/v1/nodegroup.go
@@ -41,7 +41,7 @@ type NodeGroup struct {
 	// Standard object's metadata.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	// +optional
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+	metav1.ObjectMeta `json:"metadata"`
 
 	// Spec defines the behavior of a node group.
 	Spec NodeGroupSpec `json:"spec"`
@@ -49,7 +49,7 @@ type NodeGroup struct {
 	// Most recently observed status of the node.
 	// Populated by the system.
 
-	Status NodeGroupStatus `json:"status,omitempty"`
+	Status NodeGroupStatus `json:"status"`
 }
 
 type NodeGroupSpec struct {
@@ -57,7 +57,7 @@ type NodeGroupSpec struct {
 	NodeType NodeType `json:"nodeType,omitempty"`
 
 	// cloudInstances. Optional.
-	CloudInstances CloudInstances `json:"cloudInstances,omitempty"`
+	CloudInstances CloudInstances `json:"cloudInstances"`
 }
 
 // CloudInstances is an extra parameters for NodeGroup with type Cloud.
@@ -84,7 +84,7 @@ type CloudInstances struct {
 	Standby *intstr.IntOrString `json:"standby,omitempty"`
 
 	// Settings for overprovisioned Node holder.
-	StandbyHolder StandbyHolder `json:"standbyHolder,omitempty"`
+	StandbyHolder StandbyHolder `json:"standbyHolder"`
 
 	// Reference to a ClassInstance resource. Required.
 	ClassReference ClassReference `json:"classReference"`
@@ -97,15 +97,15 @@ type StandbyHolder struct {
 	// Percent of the node-group's node capacity which will be overprovisioned with standby-holder pod.
 	OverprovisioningRate *int64 `json:"overprovisioningRate,omitempty"`
 	// Deprecated: Describes the amount of resources, that will not be held by standby holder.
-	NotHeldResources Resources `json:"notHeldResources,omitempty"`
+	NotHeldResources Resources `json:"notHeldResources"`
 }
 
 type Resources struct {
 	// Describes the amount of CPU that will not be held by standby holder on Nodes from this NodeGroup.
-	CPU intstr.IntOrString `json:"cpu,omitempty"`
+	CPU intstr.IntOrString `json:"cpu"`
 
 	// Describes the amount of memory that will not be held by standby holder on Nodes from this NodeGroup.
-	Memory intstr.IntOrString `json:"memory,omitempty"`
+	Memory intstr.IntOrString `json:"memory"`
 }
 
 type ClassReference struct {
@@ -148,7 +148,7 @@ type NodeGroupStatus struct {
 	LastMachineFailures []MachineFailure `json:"lastMachineFailures,omitempty"`
 
 	// Status' summary.
-	ConditionSummary ConditionSummary `json:"conditionSummary,omitempty"`
+	ConditionSummary ConditionSummary `json:"conditionSummary"`
 }
 
 type MachineFailure struct {
@@ -162,7 +162,7 @@ type MachineFailure struct {
 	OwnerRef string `json:"ownerRef,omitempty"`
 
 	// Last operation with machine.
-	LastOperation MachineOperation `json:"lastOperation,omitempty"`
+	LastOperation MachineOperation `json:"lastOperation"`
 }
 
 type MachineOperation struct {

--- a/dhctl/pkg/apis/deckhouse/v1/nodeuser.go
+++ b/dhctl/pkg/apis/deckhouse/v1/nodeuser.go
@@ -45,7 +45,7 @@ const NodeUserList = "NodeUserList"
 // NodeUser is an system user on nodes.
 type NodeUser struct {
 	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+	metav1.ObjectMeta `json:"metadata"`
 	Spec              NodeUserSpec `json:"spec"`
 }
 

--- a/dhctl/pkg/apis/deckhouse/v1alpha1/deckhouse_release.go
+++ b/dhctl/pkg/apis/deckhouse/v1alpha1/deckhouse_release.go
@@ -52,24 +52,24 @@ type DeckhouseRelease struct {
 	// Standard object's metadata.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	// +optional
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+	metav1.ObjectMeta `json:"metadata"`
 
 	Approved bool `json:"approved"`
 
 	Spec DeckhouseReleaseSpec `json:"spec"`
 
-	Status DeckhouseReleaseStatus `json:"status,omitempty"`
+	Status DeckhouseReleaseStatus `json:"status"`
 }
 
 // +k8s:deepcopy-gen=false
 
 type DeckhouseReleaseSpec struct {
-	Version       string                 `json:"version,omitempty"`
-	ApplyAfter    *time.Time             `json:"applyAfter,omitempty"`
-	Requirements  map[string]string      `json:"requirements,omitempty"`
-	Disruptions   []string               `json:"disruptions,omitempty"`
-	Changelog     map[string]interface{} `json:"changelog,omitempty"`
-	ChangelogLink string                 `json:"changelogLink,omitempty"`
+	Version       string            `json:"version,omitempty"`
+	ApplyAfter    *time.Time        `json:"applyAfter,omitempty"`
+	Requirements  map[string]string `json:"requirements,omitempty"`
+	Disruptions   []string          `json:"disruptions,omitempty"`
+	Changelog     map[string]any    `json:"changelog,omitempty"`
+	ChangelogLink string            `json:"changelogLink,omitempty"`
 }
 
 // +k8s:deepcopy-gen=false
@@ -77,7 +77,7 @@ type DeckhouseReleaseSpec struct {
 type DeckhouseReleaseStatus struct {
 	Phase          string    `json:"phase,omitempty"`
 	Approved       bool      `json:"approved"`
-	TransitionTime time.Time `json:"transitionTime,omitempty"`
+	TransitionTime time.Time `json:"transitionTime"`
 	Message        string    `json:"message"`
 }
 
@@ -104,7 +104,7 @@ func (d Duration) MarshalJSON() ([]byte, error) {
 }
 
 func (d *Duration) UnmarshalJSON(b []byte) error {
-	var v interface{}
+	var v any
 	if err := json.Unmarshal(b, &v); err != nil {
 		return err
 	}

--- a/dhctl/pkg/apis/deckhouse/v1alpha1/node_group_configuration.go
+++ b/dhctl/pkg/apis/deckhouse/v1alpha1/node_group_configuration.go
@@ -24,7 +24,7 @@ const NodeGroupConfigurationDefaultWeight = 100
 
 type NodeGroupConfiguration struct {
 	metav1.TypeMeta   `json:",inline" yaml:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	metav1.ObjectMeta `json:"metadata" yaml:"metadata,omitempty"`
 	Spec              NodeGroupConfigurationSpec `json:"spec" yaml:"spec"`
 }
 

--- a/dhctl/pkg/app/options/preflight.go
+++ b/dhctl/pkg/app/options/preflight.go
@@ -16,6 +16,7 @@ package options
 
 import (
 	"fmt"
+	"slices"
 
 	otattribute "go.opentelemetry.io/otel/attribute"
 )
@@ -53,12 +54,7 @@ func (o *PreflightOptions) IsCheckDisabled(name string) bool {
 	if o.SkipAll {
 		return true
 	}
-	for _, skip := range o.SkipChecks {
-		if skip == name {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(o.SkipChecks, name)
 }
 
 // Validate ensures every entry in SkipChecks matches a known check name.

--- a/dhctl/pkg/app/options/ssh.go
+++ b/dhctl/pkg/app/options/ssh.go
@@ -115,8 +115,8 @@ func ParseSSHPrivateKeyPaths(pathSets []string) ([]string, error) {
 	}
 
 	for _, pathSet := range pathSets {
-		keys := strings.Split(pathSet, ",")
-		for _, k := range keys {
+		keys := strings.SplitSeq(pathSet, ",")
+		for k := range keys {
 			if strings.HasPrefix(k, "~") {
 				home := os.Getenv("HOME")
 				if home == "" {

--- a/dhctl/pkg/config/base.go
+++ b/dhctl/pkg/config/base.go
@@ -381,9 +381,9 @@ func detectMergedDocuments(doc string) error {
 	// if we have multiple root-level apiVersion/kind fields
 	var rootLevelKinds []string
 	var rootLevelAPIVersions []string
-	lines := strings.Split(doc, "\n")
+	lines := strings.SplitSeq(doc, "\n")
 
-	for _, line := range lines {
+	for line := range lines {
 		trimmed := strings.TrimSpace(line)
 		// Skip comments and empty lines
 		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
@@ -395,13 +395,13 @@ func detectMergedDocuments(doc string) error {
 
 		// Only consider fields at root level (indent 0)
 		if leadingWhitespace == 0 {
-			if strings.HasPrefix(trimmed, "apiVersion:") {
-				apiVersionValue := strings.TrimSpace(strings.TrimPrefix(trimmed, "apiVersion:"))
+			if after, ok := strings.CutPrefix(trimmed, "apiVersion:"); ok {
+				apiVersionValue := strings.TrimSpace(after)
 				if apiVersionValue != "" {
 					rootLevelAPIVersions = append(rootLevelAPIVersions, apiVersionValue)
 				}
-			} else if strings.HasPrefix(trimmed, "kind:") {
-				kindValue := strings.TrimSpace(strings.TrimPrefix(trimmed, "kind:"))
+			} else if after, ok := strings.CutPrefix(trimmed, "kind:"); ok {
+				kindValue := strings.TrimSpace(after)
 				if kindValue != "" {
 					rootLevelKinds = append(rootLevelKinds, kindValue)
 				}

--- a/dhctl/pkg/config/bashible.go
+++ b/dhctl/pkg/config/bashible.go
@@ -21,7 +21,7 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-func ParseBashibleConfig(paths []string, specPath string) (map[string]interface{}, error) {
+func ParseBashibleConfig(paths []string, specPath string) (map[string]any, error) {
 	fileContent := ""
 	for _, path := range paths {
 		content, err := os.ReadFile(path)
@@ -44,7 +44,7 @@ func ParseBashibleConfig(paths []string, specPath string) (map[string]interface{
 		return nil, fmt.Errorf("config validation: %v", err)
 	}
 
-	var data map[string]interface{}
+	var data map[string]any
 	if err = yaml.Unmarshal(fileContentBytes, &data); err != nil {
 		return nil, fmt.Errorf("config unmarshal: %v", err)
 	}

--- a/dhctl/pkg/config/cnibootstrap.go
+++ b/dhctl/pkg/config/cnibootstrap.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -274,9 +275,7 @@ func cniBootstrapConfirmMessage(a *CNIBootstrapAnalysis) string {
 // key (overwrite, not deep merge).
 func resolveCNIBootstrapSettings(b cniBootstrap, providerCfg map[string]json.RawMessage) (map[string]any, error) {
 	settings := map[string]any{}
-	for k, v := range b.Config.Default {
-		settings[k] = v
-	}
+	maps.Copy(settings, b.Config.Default)
 
 	if len(b.Config.Rules) == 0 {
 		return settings, nil
@@ -299,9 +298,7 @@ func resolveCNIBootstrapSettings(b cniBootstrap, providerCfg map[string]json.Raw
 		if !cniBootstrapMatches(value, r.Match.Values) {
 			continue
 		}
-		for k, v := range r.Settings {
-			settings[k] = v
-		}
+		maps.Copy(settings, r.Settings)
 	}
 
 	return settings, nil

--- a/dhctl/pkg/config/connection.go
+++ b/dhctl/pkg/config/connection.go
@@ -22,7 +22,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/yaml"
 
 	"github.com/deckhouse/lib-connection/pkg/ssh/session"
@@ -79,7 +78,7 @@ func ParseConnectionConfig(
 
 	appendValidationError := func(msg string, docNumber int, gvk *schema.GroupVersionKind, obj *unstructured.Unstructured) {
 		err := Error{
-			Index:    ptr.To(docNumber),
+			Index:    new(docNumber),
 			Messages: []string{msg},
 		}
 
@@ -114,7 +113,7 @@ func ParseConnectionConfig(
 		err := yaml.Unmarshal(docData, &obj)
 		if err != nil {
 			errs.Append(ErrKindInvalidYAML, Error{
-				Index:    ptr.To(i),
+				Index:    new(i),
 				Messages: []string{unmarshallError(err, "Unstructured", i)},
 			})
 			continue

--- a/dhctl/pkg/config/connection_test.go
+++ b/dhctl/pkg/config/connection_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app/options"
 	"github.com/stretchr/testify/require"
-	"k8s.io/utils/ptr"
 )
 
 func TestLoadDHCTLConfigSchema(t *testing.T) {
@@ -66,7 +65,7 @@ func TestParseConnectionConfig(t *testing.T) {
 			expected: &ConnectionConfig{
 				SSHConfig: &SSHConfig{
 					SSHUser:      "ubuntu",
-					SSHPort:      ptr.To(int32(22)),
+					SSHPort:      new(int32(22)),
 					SSHExtraArgs: "-vvv",
 					SSHAgentPrivateKeys: []SSHAgentPrivateKey{
 						{
@@ -79,7 +78,7 @@ func TestParseConnectionConfig(t *testing.T) {
 						},
 					},
 					SSHBastionHost: "158.160.111.65",
-					SSHBastionPort: ptr.To(int32(22)),
+					SSHBastionPort: new(int32(22)),
 					SSHBastionUser: "ubuntu",
 					SudoPassword:   "gfhjkm",
 					LegacyMode:     true,
@@ -104,7 +103,7 @@ func TestParseConnectionConfig(t *testing.T) {
 			expected: &ConnectionConfig{
 				SSHConfig: &SSHConfig{
 					SSHUser:      "ubuntu",
-					SSHPort:      ptr.To(int32(22)),
+					SSHPort:      new(int32(22)),
 					SSHExtraArgs: "-vvv",
 					SSHAgentPrivateKeys: []SSHAgentPrivateKey{
 						{
@@ -185,7 +184,6 @@ func TestParseConnectionConfig(t *testing.T) {
 	}
 
 	for name, tt := range tests {
-		tt := tt
 		t.Run(name, func(t *testing.T) {
 			config, err := ParseConnectionConfig(tt.config, newStore, tt.opts...)
 			if tt.errContains == "" {

--- a/dhctl/pkg/config/control_plane_manager_settings.go
+++ b/dhctl/pkg/config/control_plane_manager_settings.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"fmt"
+	"maps"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 )
@@ -28,7 +29,7 @@ const controlPlaneManagerModuleName = "control-plane-manager"
 // ready for template rendering. Returns nil when the ModuleConfig is absent.
 // resourcesRequests.{cpu,memory} are replaced with milliCPU and memoryBytes (int64)
 // so templates can use them directly in arithmetic.
-func (m *MetaConfig) controlPlaneManagerSettings() (map[string]interface{}, error) {
+func (m *MetaConfig) controlPlaneManagerSettings() (map[string]any, error) {
 	var mc *ModuleConfig
 	for _, c := range m.ModuleConfigs {
 		if c.GetName() == controlPlaneManagerModuleName {
@@ -40,17 +41,15 @@ func (m *MetaConfig) controlPlaneManagerSettings() (map[string]interface{}, erro
 		return nil, nil
 	}
 
-	out := make(map[string]interface{}, len(mc.Spec.Settings))
-	for k, v := range mc.Spec.Settings {
-		out[k] = v
-	}
+	out := make(map[string]any, len(mc.Spec.Settings))
+	maps.Copy(out, mc.Spec.Settings)
 
-	if rr, ok := mc.Spec.Settings["resourcesRequests"].(map[string]interface{}); ok {
+	if rr, ok := mc.Spec.Settings["resourcesRequests"].(map[string]any); ok {
 		milliCPU, memoryBytes, err := parseResourceRequests(rr)
 		if err != nil {
 			return nil, fmt.Errorf("parse resourcesRequests: %w", err)
 		}
-		parsed := map[string]interface{}{}
+		parsed := map[string]any{}
 		if milliCPU != 0 {
 			parsed["milliCPU"] = milliCPU
 		}
@@ -63,7 +62,7 @@ func (m *MetaConfig) controlPlaneManagerSettings() (map[string]interface{}, erro
 	return out, nil
 }
 
-func parseResourceRequests(rr map[string]interface{}) (int64, int64, error) {
+func parseResourceRequests(rr map[string]any) (int64, int64, error) {
 	var milliCPU int64
 	var memoryBytes int64
 

--- a/dhctl/pkg/config/controlplane_template_config.go
+++ b/dhctl/pkg/config/controlplane_template_config.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package config
 
+import "maps"
+
 // ControlPlaneTemplateConfig is the data passed to control-plane template rendering.
 //
 // Settings holds ModuleConfig control-plane-manager spec.settings (authoritative source).
@@ -23,26 +25,24 @@ package config
 // Templates choose the source explicitly: `coalesce .settings.field .clusterConfiguration.field`.
 // ToMap is the only boundary with the Go template engine.
 type ControlPlaneTemplateConfig struct {
-	RunType    string                 `json:"runType"`
-	NodeIP     string                 `json:"nodeIP"`
-	NodeName   string                 `json:"nodeName"`
-	Registry   map[string]interface{} `json:"registry"`
-	Images     map[string]interface{} `json:"images"`
-	VersionMap map[string]interface{} `json:"-"`
+	RunType    string         `json:"runType"`
+	NodeIP     string         `json:"nodeIP"`
+	NodeName   string         `json:"nodeName"`
+	Registry   map[string]any `json:"registry"`
+	Images     map[string]any `json:"images"`
+	VersionMap map[string]any `json:"-"`
 
-	Settings             map[string]interface{} `json:"settings"`
-	ClusterConfiguration map[string]interface{} `json:"clusterConfiguration"`
+	Settings             map[string]any `json:"settings"`
+	ClusterConfiguration map[string]any `json:"clusterConfiguration"`
 }
 
 // ToMap is the only entry point into the Go template engine. It converts the typed struct
 // to a flat map so templates can access all fields uniformly. VersionMap keys (k8s version
 // data, image digests, etc.) are merged into the root. Explicit fields win over VersionMap
 // keys with the same name.
-func (c *ControlPlaneTemplateConfig) ToMap() map[string]interface{} {
-	m := make(map[string]interface{})
-	for k, v := range c.VersionMap {
-		m[k] = v
-	}
+func (c *ControlPlaneTemplateConfig) ToMap() map[string]any {
+	m := make(map[string]any)
+	maps.Copy(m, c.VersionMap)
 	m["runType"] = c.RunType
 	m["nodeIP"] = c.NodeIP
 	m["nodeName"] = c.NodeName

--- a/dhctl/pkg/config/controlplane_template_config_test.go
+++ b/dhctl/pkg/config/controlplane_template_config_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config/registry"
 )
 
-func mustRawMessage(v interface{}) json.RawMessage {
+func mustRawMessage(v any) json.RawMessage {
 	b, err := json.Marshal(v)
 	if err != nil {
 		panic(err)
@@ -85,7 +85,7 @@ func TestConfigForControlPlaneTemplates_ModuleConfigWins(t *testing.T) {
 	m := newMetaConfig(t, baseClusterConfig(), []*ModuleConfig{
 		newModuleConfig("control-plane-manager", SettingsValues{
 			"encryptionAlgorithm": "ECDSA-P256",
-			"resourcesRequests": map[string]interface{}{
+			"resourcesRequests": map[string]any{
 				"cpu":    "500m",
 				"memory": "512Mi",
 			},
@@ -96,7 +96,7 @@ func TestConfigForControlPlaneTemplates_ModuleConfigWins(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, "ECDSA-P256", cfg.Settings["encryptionAlgorithm"])
-	rr, ok := cfg.Settings["resourcesRequests"].(map[string]interface{})
+	rr, ok := cfg.Settings["resourcesRequests"].(map[string]any)
 	require.True(t, ok)
 	require.Equal(t, int64(500), rr["milliCPU"])
 	require.Equal(t, int64(512*1024*1024), rr["memoryBytes"])
@@ -117,7 +117,7 @@ func TestConfigForControlPlaneTemplates_KubernetesVersionAutomatic(t *testing.T)
 func TestConfigForControlPlaneTemplates_PartialResourcesRequests(t *testing.T) {
 	m := newMetaConfig(t, baseClusterConfig(), []*ModuleConfig{
 		newModuleConfig("control-plane-manager", SettingsValues{
-			"resourcesRequests": map[string]interface{}{
+			"resourcesRequests": map[string]any{
 				"cpu": "500m",
 				// memory not set
 			},
@@ -127,7 +127,7 @@ func TestConfigForControlPlaneTemplates_PartialResourcesRequests(t *testing.T) {
 	cfg, err := m.ConfigForControlPlaneTemplates("")
 	require.NoError(t, err)
 
-	rr, ok := cfg.Settings["resourcesRequests"].(map[string]interface{})
+	rr, ok := cfg.Settings["resourcesRequests"].(map[string]any)
 	require.True(t, ok)
 	require.Contains(t, rr, "milliCPU")
 	require.NotContains(t, rr, "memoryBytes")
@@ -136,7 +136,7 @@ func TestConfigForControlPlaneTemplates_PartialResourcesRequests(t *testing.T) {
 func TestConfigForControlPlaneTemplates_ToMap(t *testing.T) {
 	m := newMetaConfig(t, baseClusterConfig(), []*ModuleConfig{
 		newModuleConfig("control-plane-manager", SettingsValues{
-			"resourcesRequests": map[string]interface{}{
+			"resourcesRequests": map[string]any{
 				"cpu":    "1000m",
 				"memory": "1Gi",
 			},

--- a/dhctl/pkg/config/deckhouse_config_test.go
+++ b/dhctl/pkg/config/deckhouse_config_test.go
@@ -64,18 +64,18 @@ internalNetworkCIDRs:
 {{- end }}
 `
 
-func assertModuleConfig(t *testing.T, mc *ModuleConfig, enabled bool, version int, setting map[string]interface{}) {
+func assertModuleConfig(t *testing.T, mc *ModuleConfig, enabled bool, version int, setting map[string]any) {
 	require.NotNil(t, mc.Spec.Enabled)
 	require.Equal(t, *mc.Spec.Enabled, enabled)
 	require.Equal(t, mc.Spec.Version, version)
 	require.Equal(t, mc.Spec.Settings, SettingsValues(setting))
 }
 
-func generateMetaConfigForDeckhouseConfigTest(t *testing.T, data map[string]interface{}) *MetaConfig {
+func generateMetaConfigForDeckhouseConfigTest(t *testing.T, data map[string]any) *MetaConfig {
 	return generateMetaConfig(t, configOverridesTemplate, data, false)
 }
 
-func generateMetaConfigForDeckhouseConfigTestWithErr(t *testing.T, data map[string]interface{}) *MetaConfig {
+func generateMetaConfigForDeckhouseConfigTestWithErr(t *testing.T, data map[string]any) *MetaConfig {
 	return generateMetaConfig(t, configOverridesTemplate, data, true)
 }
 
@@ -230,7 +230,7 @@ spec:
 
 func TestModuleDeckhouseConfigOverridesAndMc(t *testing.T) {
 	t.Run("Use default bundle and logLevel", func(t *testing.T) {
-		metaConfig := generateMetaConfigForDeckhouseConfigTest(t, map[string]interface{}{
+		metaConfig := generateMetaConfigForDeckhouseConfigTest(t, map[string]any{
 			"moduleConfigs": `
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
@@ -258,7 +258,7 @@ spec:
 	})
 
 	t.Run("Use bundle and logLevel from module config", func(t *testing.T) {
-		metaConfig := generateMetaConfigForDeckhouseConfigTest(t, map[string]interface{}{
+		metaConfig := generateMetaConfigForDeckhouseConfigTest(t, map[string]any{
 			"moduleConfigs": `
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
@@ -283,7 +283,7 @@ spec:
 	})
 
 	t.Run("Forbid to use configOverrides", func(t *testing.T) {
-		generateMetaConfigForDeckhouseConfigTestWithErr(t, map[string]interface{}{
+		generateMetaConfigForDeckhouseConfigTestWithErr(t, map[string]any{
 			"configOverrides": `
 configOverrides:
   istioEnabled: false
@@ -300,25 +300,25 @@ configOverrides:
 	})
 
 	t.Run("Forbid to use releaseChannel", func(t *testing.T) {
-		generateMetaConfigForDeckhouseConfigTestWithErr(t, map[string]interface{}{
+		generateMetaConfigForDeckhouseConfigTestWithErr(t, map[string]any{
 			"releaseChannel": "Beta",
 		})
 	})
 
 	t.Run("Forbid to use bundle", func(t *testing.T) {
-		generateMetaConfigForDeckhouseConfigTestWithErr(t, map[string]interface{}{
+		generateMetaConfigForDeckhouseConfigTestWithErr(t, map[string]any{
 			"bundle": "Default",
 		})
 	})
 
 	t.Run("Forbid to use logLevel", func(t *testing.T) {
-		generateMetaConfigForDeckhouseConfigTestWithErr(t, map[string]interface{}{
+		generateMetaConfigForDeckhouseConfigTestWithErr(t, map[string]any{
 			"logLevel": "Info",
 		})
 	})
 
 	t.Run("Correct parse module configs", func(t *testing.T) {
-		metaConfig := generateMetaConfigForDeckhouseConfigTest(t, map[string]interface{}{
+		metaConfig := generateMetaConfigForDeckhouseConfigTest(t, map[string]any{
 			"moduleConfigs": `
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
@@ -345,12 +345,12 @@ spec:
 
 		require.Len(t, iCfg.ModuleConfigs, 2)
 
-		assertModuleConfig(t, iCfg.ModuleConfigs[0], true, 1, map[string]interface{}{
+		assertModuleConfig(t, iCfg.ModuleConfigs[0], true, 1, map[string]any{
 			"bundle":   "Minimal",
 			"logLevel": "Debug",
-			"registry": map[string]interface{}{
+			"registry": map[string]any{
 				"mode": "Direct",
-				"direct": map[string]interface{}{
+				"direct": map[string]any{
 					"imagesRepo": "registry.deckhouse.io/deckhouse/ce",
 					"scheme":     "HTTPS",
 				},
@@ -361,7 +361,7 @@ spec:
 	})
 
 	t.Run("Fail settings without version", func(t *testing.T) {
-		metaConfig := generateMetaConfigForDeckhouseConfigTestWithErr(t, map[string]interface{}{
+		metaConfig := generateMetaConfigForDeckhouseConfigTestWithErr(t, map[string]any{
 			"moduleConfigs": `
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
@@ -381,7 +381,7 @@ spec:
 	})
 
 	t.Run("Fail with incorrect settings", func(t *testing.T) {
-		metaConfig := generateMetaConfigForDeckhouseConfigTestWithErr(t, map[string]interface{}{
+		metaConfig := generateMetaConfigForDeckhouseConfigTestWithErr(t, map[string]any{
 			"moduleConfigs": `
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
@@ -402,7 +402,7 @@ spec:
 	})
 
 	t.Run("Module without spec file should ok without settings", func(t *testing.T) {
-		metaConfig := generateMetaConfigForDeckhouseConfigTest(t, map[string]interface{}{
+		metaConfig := generateMetaConfigForDeckhouseConfigTest(t, map[string]any{
 			"moduleConfigs": `
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
@@ -422,7 +422,7 @@ spec:
 	})
 
 	t.Run("Module without spec file should fail with settings", func(t *testing.T) {
-		metaConfig := generateMetaConfigForDeckhouseConfigTestWithErr(t, map[string]interface{}{
+		metaConfig := generateMetaConfigForDeckhouseConfigTestWithErr(t, map[string]any{
 			"moduleConfigs": `
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig

--- a/dhctl/pkg/config/load.go
+++ b/dhctl/pkg/config/load.go
@@ -126,8 +126,8 @@ func NewSchemaStore(globalOptions *options.GlobalOptions, paths ...string) *Sche
 
 	pathsStr := strings.TrimSpace(os.Getenv("DHCTL_CLI_ADDITIONAL_SCHEMAS_PATHS"))
 	if pathsStr != "" {
-		pathsNoTrimmed := strings.Split(pathsStr, ",")
-		for _, p := range pathsNoTrimmed {
+		pathsNoTrimmed := strings.SplitSeq(pathsStr, ",")
+		for p := range pathsNoTrimmed {
 			paths = append(paths, strings.TrimSpace(p))
 		}
 	}
@@ -448,7 +448,7 @@ func (s *SchemaStore) upload(fileContent []byte) error {
 func openAPIValidate(dataObj *[]byte, schema *spec.Schema, options validateOptions) (bool, error) {
 	validator := validate.NewSchemaValidator(schema, nil, "", strfmt.Default)
 
-	var blank map[string]interface{}
+	var blank map[string]any
 
 	if options.strictUnmarshal {
 		err := yaml.UnmarshalStrict(*dataObj, &blank)
@@ -506,7 +506,7 @@ func (s *SchemaStore) applyConversions(mc ModuleConfig) ([]byte, error) {
 	conversion := s.conversionsStore.Get(mc.GetName())
 	log.DebugF("Starting conversion for module %s. Latest version: %d\n", mc.GetName(), conversion.LatestVersion())
 	var err error
-	var conversed map[string]interface{}
+	var conversed map[string]any
 	if mc.Spec.Version < conversion.LatestVersion() {
 		set := &mc.Spec.Settings
 		unstructured, err := runtime.DefaultUnstructuredConverter.ToUnstructured(set)

--- a/dhctl/pkg/config/load_test.go
+++ b/dhctl/pkg/config/load_test.go
@@ -17,9 +17,10 @@ package config
 import (
 	"testing"
 
-	"github.com/deckhouse/deckhouse/dhctl/pkg/app/options"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/app/options"
 )
 
 func TestVersionBackwardCompatibility(t *testing.T) {
@@ -48,19 +49,17 @@ apiVersions:
 	err := newStore.upload(schema)
 	require.NoError(t, err)
 
-	oldDoc := []byte(`
+	_, err = newStore.Validate(new([]byte(`
 apiVersion: deckhouse.io/v1alpha1
 kind: ClusterConfiguration
 clusterType: Cloud
-`)
-	newDoc := []byte(`
+`)))
+	assert.NoError(t, err)
+	_, err = newStore.Validate(new([]byte(`
 apiVersion: deckhouse.io/v1
 kind: ClusterConfiguration
 clusterType: Cloud
-`)
-	_, err = newStore.Validate(&oldDoc)
-	assert.NoError(t, err)
-	_, err = newStore.Validate(&newDoc)
+`)))
 	assert.NoError(t, err)
 }
 
@@ -88,12 +87,11 @@ apiVersions:
 	err := newStore.upload(schema)
 	require.NoError(t, err)
 
-	errorDoc := []byte(`
+	_, err = newStore.Validate(new([]byte(`
 apiVersion: deckhouse.io/v1
 kind: ClusterConfiguration
 jsonObject: "error"
-`)
-	_, err = newStore.Validate(&errorDoc)
+`)))
 	assert.Error(t, err)
 	assert.Equal(t, err.Error(), `Document validation failed:
 ---
@@ -108,13 +106,11 @@ jsonObject: "error"
 
 `)
 
-	okDoc := []byte(`
+	_, err = newStore.Validate(new([]byte(`
 apiVersion: deckhouse.io/v1
 kind: ClusterConfiguration
 jsonObject: " {}"
-`)
-
-	_, err = newStore.Validate(&okDoc)
+`)))
 	assert.NoError(t, err)
 }
 
@@ -198,9 +194,7 @@ one: "1"
 	}
 
 	for _, tc := range tests {
-		content := []byte(tc.content)
-
-		_, err := newStore.Validate(&content)
+		_, err := newStore.Validate(new([]byte(tc.content)))
 		if err != nil && !tc.wantErr {
 			t.Errorf("%s: %v", tc.name, err)
 		}

--- a/dhctl/pkg/config/meta.go
+++ b/dhctl/pkg/config/meta.go
@@ -19,6 +19,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net"
 	"os"
 	"path/filepath"
@@ -59,7 +60,7 @@ type MetaConfig struct {
 	ProviderClusterConfig map[string]json.RawMessage `json:"providerClusterConfiguration,omitempty"`
 	StaticClusterConfig   map[string]json.RawMessage `json:"staticClusterConfiguration,omitempty"`
 
-	VersionMap                map[string]interface{}  `json:"-"`
+	VersionMap                map[string]any          `json:"-"`
 	Images                    imagesDigests           `json:"-"`
 	Registry                  registry.Config         `json:"-"`
 	UUID                      string                  `json:"clusterUUID,omitempty"`
@@ -77,7 +78,7 @@ type MetaConfig struct {
 	VersionFilePath string `json:"-"`
 }
 
-type imagesDigests map[string]map[string]interface{}
+type imagesDigests map[string]map[string]any
 
 type ClusterMasterEndpoint struct {
 	Address                string `json:"address" yaml:"address"`
@@ -286,8 +287,8 @@ func (m *MetaConfig) IsStatic() bool {
 	return m.ClusterType == "Static"
 }
 
-func (m *MetaConfig) ExtractMasterNodeGroupStaticSettings() map[string]interface{} {
-	static := make(map[string]interface{})
+func (m *MetaConfig) ExtractMasterNodeGroupStaticSettings() map[string]any {
+	static := make(map[string]any)
 
 	if len(m.StaticClusterConfig) == 0 {
 		return static
@@ -307,19 +308,19 @@ func (m *MetaConfig) ExtractMasterNodeGroupStaticSettings() map[string]interface
 }
 
 // NodeGroupManifest prepares NodeGroup custom resource for static nodes, which were ordered by infrastructure utility
-func (m *MetaConfig) NodeGroupManifest(terraNodeGroup TerraNodeGroupSpec) map[string]interface{} {
+func (m *MetaConfig) NodeGroupManifest(terraNodeGroup TerraNodeGroupSpec) map[string]any {
 	if terraNodeGroup.NodeTemplate == nil {
-		terraNodeGroup.NodeTemplate = make(map[string]interface{})
+		terraNodeGroup.NodeTemplate = make(map[string]any)
 	}
-	return map[string]interface{}{
+	return map[string]any{
 		"apiVersion": "deckhouse.io/v1",
 		"kind":       "NodeGroup",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name": terraNodeGroup.Name,
 		},
-		"spec": map[string]interface{}{
+		"spec": map[string]any{
 			"nodeType": "CloudPermanent",
-			"disruptions": map[string]interface{}{
+			"disruptions": map[string]any{
 				"approvalMode": "Manual",
 			},
 			"nodeTemplate": terraNodeGroup.NodeTemplate,
@@ -367,10 +368,10 @@ func resolveKubernetesVersion(v string) string {
 	return v
 }
 
-func clusterConfigToMap(raw map[string]json.RawMessage) (map[string]interface{}, error) {
-	out := make(map[string]interface{}, len(raw))
+func clusterConfigToMap(raw map[string]json.RawMessage) (map[string]any, error) {
+	out := make(map[string]any, len(raw))
 	for k, v := range raw {
-		var a interface{}
+		var a any
 		if err := json.Unmarshal(v, &a); err != nil {
 			return nil, fmt.Errorf("unmarshal ClusterConfiguration field %q: %w", k, err)
 		}
@@ -409,17 +410,17 @@ func (m *MetaConfig) ConfigForControlPlaneTemplates(nodeIP string) (*ControlPlan
 	if mcSettings != nil {
 		cfg.Settings = mcSettings
 	} else {
-		cfg.Settings = make(map[string]interface{})
+		cfg.Settings = make(map[string]any)
 	}
 
 	return cfg, nil
 }
 
-func (m *MetaConfig) ConfigForBashibleBundleTemplate(nodeIP string) (map[string]interface{}, error) {
-	data := make(map[string]interface{}, len(m.ClusterConfig))
+func (m *MetaConfig) ConfigForBashibleBundleTemplate(nodeIP string) (map[string]any, error) {
+	data := make(map[string]any, len(m.ClusterConfig))
 
 	for key, value := range m.ClusterConfig {
-		var t interface{}
+		var t any
 		err := json.Unmarshal(value, &t)
 		if err != nil {
 			return nil, fmt.Errorf("cluster config unmarshal: %v", err)
@@ -431,19 +432,19 @@ func (m *MetaConfig) ConfigForBashibleBundleTemplate(nodeIP string) (map[string]
 		data["kubernetesVersion"] = DefaultKubernetesVersion
 	}
 
-	clusterBootstrap := map[string]interface{}{
+	clusterBootstrap := map[string]any{
 		"clusterDomain":     data["clusterDomain"],
 		"clusterDNSAddress": m.ClusterDNSAddress,
 	}
 
 	if nodeIP != "" {
-		clusterBootstrap["cloud"] = map[string]interface{}{"nodeIP": nodeIP}
+		clusterBootstrap["cloud"] = map[string]any{"nodeIP": nodeIP}
 	}
 
-	nodeGroup := map[string]interface{}{
+	nodeGroup := map[string]any{
 		"name":     "master",
 		"nodeType": "CloudPermanent",
-		"cloudInstances": map[string]interface{}{
+		"cloudInstances": map[string]any{
 			"classReference": map[string]string{
 				"name": "master",
 			},
@@ -455,10 +456,8 @@ func (m *MetaConfig) ConfigForBashibleBundleTemplate(nodeIP string) (map[string]
 		nodeGroup["static"] = m.ExtractMasterNodeGroupStaticSettings()
 	}
 
-	configForBashibleBundleTemplate := make(map[string]interface{})
-	for key, value := range m.VersionMap {
-		configForBashibleBundleTemplate[key] = value
-	}
+	configForBashibleBundleTemplate := make(map[string]any)
+	maps.Copy(configForBashibleBundleTemplate, m.VersionMap)
 
 	configForBashibleBundleTemplate["runType"] = "ClusterBootstrap"
 
@@ -470,7 +469,7 @@ func (m *MetaConfig) ConfigForBashibleBundleTemplate(nodeIP string) (map[string]
 	configForBashibleBundleTemplate["kubernetesVersion"] = data["kubernetesVersion"]
 	configForBashibleBundleTemplate["nodeGroup"] = nodeGroup
 	configForBashibleBundleTemplate["clusterBootstrap"] = clusterBootstrap
-	configForBashibleBundleTemplate["proxy"] = make(map[string]interface{})
+	configForBashibleBundleTemplate["proxy"] = make(map[string]any)
 	if data["proxy"] != nil {
 		proxyData, err := m.EnrichProxyData()
 		if err != nil {
@@ -513,7 +512,7 @@ func (m *MetaConfig) ConfigForBashibleBundleTemplate(nodeIP string) (map[string]
 
 // NodeGroupConfig returns values for infrastructure utility to order master node or static node
 func (m *MetaConfig) NodeGroupConfig(nodeGroupName string, nodeIndex int, cloudConfig string) []byte {
-	result := map[string]interface{}{
+	result := map[string]any{
 		"clusterConfiguration":         m.ClusterConfig,
 		"providerClusterConfiguration": m.ProviderClusterConfig,
 		"nodeIndex":                    nodeIndex,
@@ -545,33 +544,25 @@ func (m *MetaConfig) DeepCopy() *MetaConfig {
 
 	if m.ClusterConfig != nil {
 		config := make(map[string]json.RawMessage, len(m.ClusterConfig))
-		for k, v := range m.ClusterConfig {
-			config[k] = v
-		}
+		maps.Copy(config, m.ClusterConfig)
 		out.ClusterConfig = config
 	}
 
 	if m.InitClusterConfig != nil {
 		config := make(map[string]json.RawMessage, len(m.InitClusterConfig))
-		for k, v := range m.InitClusterConfig {
-			config[k] = v
-		}
+		maps.Copy(config, m.InitClusterConfig)
 		out.InitClusterConfig = config
 	}
 
 	if m.ProviderClusterConfig != nil {
 		config := make(map[string]json.RawMessage, len(m.ProviderClusterConfig))
-		for k, v := range m.ProviderClusterConfig {
-			config[k] = v
-		}
+		maps.Copy(config, m.ProviderClusterConfig)
 		out.ProviderClusterConfig = config
 	}
 
 	if m.StaticClusterConfig != nil {
 		config := make(map[string]json.RawMessage, len(m.StaticClusterConfig))
-		for k, v := range m.StaticClusterConfig {
-			config[k] = v
-		}
+		maps.Copy(config, m.StaticClusterConfig)
 		out.StaticClusterConfig = config
 	}
 
@@ -617,12 +608,12 @@ func (m *MetaConfig) DeepCopy() *MetaConfig {
 	return out
 }
 
-func (m *MetaConfig) clusterMasterEndpointsBashibleContext() []map[string]interface{} {
+func (m *MetaConfig) clusterMasterEndpointsBashibleContext() []map[string]any {
 	clusterMasterEndpoints := m.effectiveClusterMasterEndpoints()
-	endpoints := make([]map[string]interface{}, 0, len(clusterMasterEndpoints))
+	endpoints := make([]map[string]any, 0, len(clusterMasterEndpoints))
 
 	for _, endpoint := range clusterMasterEndpoints {
-		item := map[string]interface{}{
+		item := map[string]any{
 			"address": endpoint.Address,
 		}
 
@@ -642,7 +633,7 @@ func (m *MetaConfig) clusterMasterEndpointsBashibleContext() []map[string]interf
 	return endpoints
 }
 
-func clusterMasterEndpointAddresses(endpoints []map[string]interface{}, portName string) []string {
+func clusterMasterEndpointAddresses(endpoints []map[string]any, portName string) []string {
 	addresses := make([]string, 0, len(endpoints))
 
 	for _, endpoint := range endpoints {
@@ -677,7 +668,7 @@ func (m *MetaConfig) effectiveClusterMasterEndpoints() []ClusterMasterEndpoint {
 }
 
 func (m *MetaConfig) LoadVersionMap(filename string) error {
-	versionMap := make(map[string]interface{})
+	versionMap := make(map[string]any)
 
 	versionMapFile, err := os.ReadFile(filename)
 	if err != nil {
@@ -694,7 +685,7 @@ func (m *MetaConfig) LoadVersionMap(filename string) error {
 	return nil
 }
 
-func (m *MetaConfig) EnrichProxyData() (map[string]interface{}, error) {
+func (m *MetaConfig) EnrichProxyData() (map[string]any, error) {
 	type proxy struct {
 		HTTPProxy  string   `json:"httpProxy" yaml:"httpProxy"`
 		HTTPSProxy string   `json:"httpsProxy" yaml:"httpsProxy"`
@@ -732,7 +723,7 @@ func (m *MetaConfig) EnrichProxyData() (map[string]interface{}, error) {
 
 	p.NoProxy = append(p.NoProxy, "127.0.0.1", "169.254.169.254", clusterDomain, podSubnetCIDR, serviceSubnetCIDR)
 
-	ret := make(map[string]interface{})
+	ret := make(map[string]any)
 	if p.HTTPProxy != "" {
 		ret["httpProxy"] = p.HTTPProxy
 	}
@@ -842,8 +833,8 @@ func getDNSAddress(serviceCIDR string) string {
 	return clusterDNS
 }
 
-func (i *imagesDigests) ConvertToMap() map[string]interface{} {
-	res := make(map[string]interface{})
+func (i *imagesDigests) ConvertToMap() map[string]any {
+	res := make(map[string]any)
 	for k, v := range *i {
 		res[k] = v
 	}

--- a/dhctl/pkg/config/meta_test.go
+++ b/dhctl/pkg/config/meta_test.go
@@ -163,7 +163,7 @@ provider:
 {{- end }}
 `
 
-func renderTestConfig(data map[string]interface{}, config string) string {
+func renderTestConfig(data map[string]any, config string) string {
 	t := template.New("testconfig_template").Funcs(sprig.TxtFuncMap())
 	t, err := t.Parse(config)
 	if err != nil {
@@ -190,9 +190,9 @@ func generateDockerCfg(host, username, password string) string {
 }
 
 func generateOldDockerCfg(host string, username, password *string) string {
-	res := map[string]interface{}{
-		"auths": map[string]interface{}{
-			host: make(map[string]interface{}),
+	res := map[string]any{
+		"auths": map[string]any{
+			host: make(map[string]any),
 		},
 	}
 
@@ -218,7 +218,7 @@ func generateOldDockerCfg(host string, username, password *string) string {
 	return string(auth)
 }
 
-func generateMetaConfig(t *testing.T, template string, data map[string]interface{}, hasErr bool) *MetaConfig {
+func generateMetaConfig(t *testing.T, template string, data map[string]any, hasErr bool) *MetaConfig {
 	configData := renderTestConfig(data, template)
 
 	cfg, err := ParseConfigFromData(context.TODO(), configData, DummyPreparatorProvider(), &options.New().Global)
@@ -232,7 +232,7 @@ func generateMetaConfig(t *testing.T, template string, data map[string]interface
 	return cfg
 }
 
-func generateMetaConfigForMetaConfigTest(t *testing.T, data map[string]interface{}) *MetaConfig {
+func generateMetaConfigForMetaConfigTest(t *testing.T, data map[string]any) *MetaConfig {
 	return generateMetaConfig(t, metaConfigTestsTemplate, data, false)
 }
 
@@ -303,17 +303,17 @@ spec:
 
 func TestEnrichProxyData(t *testing.T) {
 	t.Run("proxy config is absent", func(t *testing.T) {
-		cfg := generateMetaConfigForMetaConfigTest(t, map[string]interface{}{})
+		cfg := generateMetaConfigForMetaConfigTest(t, map[string]any{})
 
 		p, err := cfg.EnrichProxyData()
 		require.NoError(t, err)
 
-		require.Equal(t, p, map[string]interface{}(nil))
+		require.Equal(t, p, map[string]any(nil))
 	})
 
 	t.Run("proxy config is present, httpProxy is set", func(t *testing.T) {
-		cfg := generateMetaConfigForMetaConfigTest(t, map[string]interface{}{
-			"proxy": map[string]interface{}{
+		cfg := generateMetaConfigForMetaConfigTest(t, map[string]any{
+			"proxy": map[string]any{
 				"httpProxy": "http://1.2.3.4",
 			},
 		})
@@ -321,15 +321,15 @@ func TestEnrichProxyData(t *testing.T) {
 		p, err := cfg.EnrichProxyData()
 		require.NoError(t, err)
 
-		require.Equal(t, p, map[string]interface{}{
+		require.Equal(t, p, map[string]any{
 			"httpProxy": "http://1.2.3.4",
 			"noProxy":   []string{"127.0.0.1", "169.254.169.254", "cluster.local", "10.111.0.0/16", "10.222.0.0/16"},
 		})
 	})
 
 	t.Run("proxy config is present, httpsProxy is set", func(t *testing.T) {
-		cfg := generateMetaConfigForMetaConfigTest(t, map[string]interface{}{
-			"proxy": map[string]interface{}{
+		cfg := generateMetaConfigForMetaConfigTest(t, map[string]any{
+			"proxy": map[string]any{
 				"httpsProxy": "https://2.3.4.5",
 			},
 		})
@@ -337,15 +337,15 @@ func TestEnrichProxyData(t *testing.T) {
 		p, err := cfg.EnrichProxyData()
 		require.NoError(t, err)
 
-		require.Equal(t, p, map[string]interface{}{
+		require.Equal(t, p, map[string]any{
 			"httpsProxy": "https://2.3.4.5",
 			"noProxy":    []string{"127.0.0.1", "169.254.169.254", "cluster.local", "10.111.0.0/16", "10.222.0.0/16"},
 		})
 	})
 
 	t.Run("proxy config is present, all options is set", func(t *testing.T) {
-		cfg := generateMetaConfigForMetaConfigTest(t, map[string]interface{}{
-			"proxy": map[string]interface{}{
+		cfg := generateMetaConfigForMetaConfigTest(t, map[string]any{
+			"proxy": map[string]any{
 				"httpProxy":  "http://1.2.3.4",
 				"httpsProxy": "https://2.3.4.5",
 				"noProxy":    []string{"example.com", ".example.com"},
@@ -355,7 +355,7 @@ func TestEnrichProxyData(t *testing.T) {
 		p, err := cfg.EnrichProxyData()
 		require.NoError(t, err)
 
-		require.Equal(t, p, map[string]interface{}{
+		require.Equal(t, p, map[string]any{
 			"httpProxy":  "http://1.2.3.4",
 			"httpsProxy": "https://2.3.4.5",
 			"noProxy":    []string{"example.com", ".example.com", "127.0.0.1", "169.254.169.254", "cluster.local", "10.111.0.0/16", "10.222.0.0/16"},
@@ -364,7 +364,7 @@ func TestEnrichProxyData(t *testing.T) {
 }
 
 func TestConfigForBashibleBundleTemplateClusterMasterEndpoints(t *testing.T) {
-	cfg := generateMetaConfigForMetaConfigTest(t, map[string]interface{}{})
+	cfg := generateMetaConfigForMetaConfigTest(t, map[string]any{})
 	mingetPath := filepath.Join(t.TempDir(), "minget")
 	require.NoError(t, os.WriteFile(mingetPath, []byte("test-minget"), 0o600))
 	t.Setenv("DHCTL_MINGET_PATH", mingetPath)
@@ -380,10 +380,10 @@ func TestConfigForBashibleBundleTemplateClusterMasterEndpoints(t *testing.T) {
 	data, err := cfg.ConfigForBashibleBundleTemplate("10.0.0.2")
 	require.NoError(t, err)
 
-	endpoints, ok := data["clusterMasterEndpoints"].([]map[string]interface{})
+	endpoints, ok := data["clusterMasterEndpoints"].([]map[string]any)
 	require.True(t, ok)
 	require.Len(t, endpoints, 1)
-	require.Equal(t, map[string]interface{}{
+	require.Equal(t, map[string]any{
 		"address":                "127.0.0.1",
 		"kubeApiPort":            6443,
 		"rppServerPort":          5444,
@@ -395,7 +395,7 @@ func TestConfigForBashibleBundleTemplateClusterMasterEndpoints(t *testing.T) {
 }
 
 func TestConfigForBashibleBundleTemplateDefaultClusterMasterEndpoints(t *testing.T) {
-	cfg := generateMetaConfigForMetaConfigTest(t, map[string]interface{}{})
+	cfg := generateMetaConfigForMetaConfigTest(t, map[string]any{})
 	mingetPath := filepath.Join(t.TempDir(), "minget")
 	expectedMingetBytes := []byte("test-minget")
 	require.NoError(t, os.WriteFile(mingetPath, expectedMingetBytes, 0o600))
@@ -404,10 +404,10 @@ func TestConfigForBashibleBundleTemplateDefaultClusterMasterEndpoints(t *testing
 	data, err := cfg.ConfigForBashibleBundleTemplate("10.0.0.2")
 	require.NoError(t, err)
 
-	endpoints, ok := data["clusterMasterEndpoints"].([]map[string]interface{})
+	endpoints, ok := data["clusterMasterEndpoints"].([]map[string]any)
 	require.True(t, ok)
 	require.Len(t, endpoints, 1)
-	require.Equal(t, map[string]interface{}{
+	require.Equal(t, map[string]any{
 		"address":                "127.0.0.1",
 		"rppServerPort":          5444,
 		"rppBootstrapServerPort": defaultClusterMasterRPPBootstrapServerPort,

--- a/dhctl/pkg/config/module_config.go
+++ b/dhctl/pkg/config/module_config.go
@@ -40,13 +40,13 @@ var ModuleConfigGVR = schema.GroupVersionResource{
 // ModuleConfig is a configuration for module or for global config values.
 type ModuleConfig struct {
 	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+	metav1.ObjectMeta `json:"metadata"`
 
 	Spec ModuleConfigSpec `json:"spec"`
 }
 
 // SettingsValues empty interface in needed to handle DeepCopy generation. DeepCopy does not work with unnamed empty interfaces
-type SettingsValues map[string]interface{}
+type SettingsValues map[string]any
 
 type ModuleConfigSpec struct {
 	Version  int            `json:"version,omitempty"`

--- a/dhctl/pkg/config/registry/config_test.go
+++ b/dhctl/pkg/config/registry/config_test.go
@@ -340,29 +340,25 @@ func TestConfig_DeepCopy(t *testing.T) {
 			{
 				name: "Direct mode",
 				config: func() *Config {
-					c := ConfigBuilder(WithModeDirect())
-					return &c
+					return new(ConfigBuilder(WithModeDirect()))
 				}(),
 			},
 			{
 				name: "Proxy mode",
 				config: func() *Config {
-					c := ConfigBuilder(WithModeProxy())
-					return &c
+					return new(ConfigBuilder(WithModeProxy()))
 				}(),
 			},
 			{
 				name: "Unmanaged mode",
 				config: func() *Config {
-					c := ConfigBuilder(WithModeUnmanaged())
-					return &c
+					return new(ConfigBuilder(WithModeUnmanaged()))
 				}(),
 			},
 			{
 				name: "Local mode",
 				config: func() *Config {
-					c := ConfigBuilder(WithModeLocal())
-					return &c
+					return new(ConfigBuilder(WithModeLocal()))
 				}(),
 			},
 		}

--- a/dhctl/pkg/config/schema/additional-properties.go
+++ b/dhctl/pkg/config/schema/additional-properties.go
@@ -37,8 +37,7 @@ func (t *AdditionalPropertiesTransformer) Transform(s *spec.Schema) *spec.Schema
 			prop.AdditionalProperties = &spec.SchemaOrBool{
 				Allows: false,
 			}
-			ts := prop
-			s.Properties[k] = *t.Transform(&ts)
+			s.Properties[k] = *t.Transform(new(prop))
 		}
 	}
 
@@ -47,8 +46,7 @@ func (t *AdditionalPropertiesTransformer) Transform(s *spec.Schema) *spec.Schema
 			s.Items.Schema = t.Transform(s.Items.Schema)
 		}
 		for i, item := range s.Items.Schemas {
-			ts := item
-			s.Items.Schemas[i] = *t.Transform(&ts)
+			s.Items.Schemas[i] = *t.Transform(new(item))
 		}
 	}
 

--- a/dhctl/pkg/config/spec_extensions_test.go
+++ b/dhctl/pkg/config/spec_extensions_test.go
@@ -20,8 +20,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/deckhouse/deckhouse/dhctl/pkg/app/options"
 	"github.com/stretchr/testify/require"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/app/options"
 )
 
 func TestRulesExtension_sshPrivateKey(t *testing.T) {
@@ -112,9 +113,7 @@ key: |
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			content := []byte(tt.content)
-
-			_, err := newStore.Validate(&content, ValidateOptionValidateExtensions(true))
+			_, err := newStore.Validate(new([]byte(tt.content)), ValidateOptionValidateExtensions(true))
 			if tt.errContains == "" {
 				require.NoError(t, err)
 			} else {

--- a/dhctl/pkg/config/spec_extensions_test.go
+++ b/dhctl/pkg/config/spec_extensions_test.go
@@ -111,7 +111,6 @@ key: |
 	}
 
 	for name, tt := range tests {
-		tt := tt
 		t.Run(name, func(t *testing.T) {
 			content := []byte(tt.content)
 

--- a/dhctl/pkg/config/types.go
+++ b/dhctl/pkg/config/types.go
@@ -43,8 +43,8 @@ type OpenAPISchema struct {
 }
 
 type OpenAPISchemaVersion struct {
-	Version string      `json:"apiVersion"`
-	Schema  interface{} `json:"openAPISpec"`
+	Version string `json:"apiVersion"`
+	Schema  any    `json:"openAPISpec"`
 }
 
 type ClusterConfigCloudSpec struct {
@@ -57,21 +57,21 @@ type MasterNodeGroupSpec struct {
 }
 
 type TerraNodeGroupSpec struct {
-	Replicas     int                    `json:"replicas"`
-	Name         string                 `json:"name"`
-	NodeTemplate map[string]interface{} `json:"nodeTemplate"`
+	Replicas     int            `json:"replicas"`
+	Name         string         `json:"name"`
+	NodeTemplate map[string]any `json:"nodeTemplate"`
 }
 
 type DeckhouseClusterConfig struct {
-	ReleaseChannel    string                 `json:"releaseChannel,omitempty"` // Deprecated
-	DevBranch         string                 `json:"devBranch,omitempty"`
-	Bundle            string                 `json:"bundle,omitempty"`   // Deprecated
-	LogLevel          string                 `json:"logLevel,omitempty"` // Deprecated
-	ImagesRepo        string                 `json:"imagesRepo"`
-	RegistryDockerCfg string                 `json:"registryDockerCfg,omitempty"`
-	RegistryCA        string                 `json:"registryCA,omitempty"`
-	RegistryScheme    string                 `json:"registryScheme,omitempty"`
-	ConfigOverrides   map[string]interface{} `json:"configOverrides"` // Deprecated
+	ReleaseChannel    string         `json:"releaseChannel,omitempty"` // Deprecated
+	DevBranch         string         `json:"devBranch,omitempty"`
+	Bundle            string         `json:"bundle,omitempty"`   // Deprecated
+	LogLevel          string         `json:"logLevel,omitempty"` // Deprecated
+	ImagesRepo        string         `json:"imagesRepo"`
+	RegistryDockerCfg string         `json:"registryDockerCfg,omitempty"`
+	RegistryCA        string         `json:"registryCA,omitempty"`
+	RegistryScheme    string         `json:"registryScheme,omitempty"`
+	ConfigOverrides   map[string]any `json:"configOverrides"` // Deprecated
 }
 
 type ByClusterType[T any] interface {

--- a/dhctl/pkg/config/validation.go
+++ b/dhctl/pkg/config/validation.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8sYAML "k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/yaml"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/phases"
@@ -85,7 +84,7 @@ func ValidateResources(configData string, opts ...ValidateOption) error {
 		_, gvk, err := scheme.Codecs.UniversalDecoder().Decode(docData, nil, obj)
 		if err != nil {
 			errs.Append(ErrKindInvalidYAML, Error{
-				Index:    ptr.To(i),
+				Index:    new(i),
 				Messages: []string{fmt.Errorf("unmarshal: %w", err).Error()},
 			})
 			continue
@@ -103,7 +102,7 @@ func ValidateResources(configData string, opts ...ValidateOption) error {
 
 		if len(errMessages) != 0 {
 			errs.Append(ErrKindValidationFailed, Error{
-				Index:    ptr.To(i),
+				Index:    new(i),
 				Group:    gvk.Group,
 				Version:  gvk.Version,
 				Kind:     gvk.Kind,
@@ -139,7 +138,7 @@ func ValidateInitConfiguration(configData string, schemaStore *SchemaStore, opts
 		err := yaml.Unmarshal(docData, &obj)
 		if err != nil {
 			errs.Append(ErrKindInvalidYAML, Error{
-				Index:    ptr.To(i),
+				Index:    new(i),
 				Messages: []string{fmt.Errorf("unmarshal: %w", err).Error()},
 			})
 			continue
@@ -170,7 +169,7 @@ func ValidateInitConfiguration(configData string, schemaStore *SchemaStore, opts
 
 		if len(errMessages) != 0 {
 			errs.Append(ErrKindValidationFailed, Error{
-				Index:    ptr.To(i),
+				Index:    new(i),
 				Group:    gvk.Group,
 				Version:  gvk.Version,
 				Kind:     gvk.Kind,
@@ -219,7 +218,7 @@ func ValidateClusterConfiguration(
 		err := yaml.Unmarshal(docData, &obj)
 		if err != nil {
 			errs.Append(ErrKindInvalidYAML, Error{
-				Index:    ptr.To(i),
+				Index:    new(i),
 				Messages: []string{fmt.Errorf("unmarshal: %w", err).Error()},
 			})
 			continue
@@ -253,7 +252,7 @@ func ValidateClusterConfiguration(
 
 		if len(errMessages) != 0 {
 			errs.Append(ErrKindValidationFailed, Error{
-				Index:    ptr.To(i),
+				Index:    new(i),
 				Group:    gvk.Group,
 				Version:  gvk.Version,
 				Kind:     gvk.Kind,
@@ -331,7 +330,7 @@ func ValidateProviderSpecificClusterConfiguration(
 		err := yaml.Unmarshal(docData, &obj)
 		if err != nil {
 			errs.Append(ErrKindInvalidYAML, Error{
-				Index:    ptr.To(i),
+				Index:    new(i),
 				Messages: []string{fmt.Errorf("unmarshal: %w", err).Error()},
 			})
 			continue
@@ -361,7 +360,7 @@ func ValidateProviderSpecificClusterConfiguration(
 
 		if len(errMessages) != 0 {
 			errs.Append(ErrKindValidationFailed, Error{
-				Index:    ptr.To(i),
+				Index:    new(i),
 				Group:    gvk.Group,
 				Version:  gvk.Version,
 				Kind:     gvk.Kind,
@@ -406,7 +405,7 @@ func ValidateStaticClusterConfiguration(
 		err := yaml.Unmarshal(docData, &obj)
 		if err != nil {
 			errs.Append(ErrKindInvalidYAML, Error{
-				Index:    ptr.To(i),
+				Index:    new(i),
 				Messages: []string{fmt.Errorf("unmarshal: %w", err).Error()},
 			})
 			continue
@@ -436,7 +435,7 @@ func ValidateStaticClusterConfiguration(
 
 		if len(errMessages) != 0 {
 			errs.Append(ErrKindValidationFailed, Error{
-				Index:    ptr.To(i),
+				Index:    new(i),
 				Group:    gvk.Group,
 				Version:  gvk.Version,
 				Kind:     gvk.Kind,

--- a/dhctl/pkg/config/validation_rules.go
+++ b/dhctl/pkg/config/validation_rules.go
@@ -192,15 +192,15 @@ func ValidateSSHPublicKey(value json.RawMessage) error {
 	}
 
 	lines := strings.Split(string(data), "\n")
-	var base64Str string
+	var base64Str strings.Builder
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
 		if strings.HasPrefix(line, "----") || strings.Contains(line, ":") || line == "" {
 			continue
 		}
-		base64Str += line
+		base64Str.WriteString(line)
 	}
-	keyBytes, err := base64.StdEncoding.DecodeString(base64Str)
+	keyBytes, err := base64.StdEncoding.DecodeString(base64Str.String())
 	if err != nil {
 		return fmt.Errorf("%w: failed to decode base64 string: %w", ErrValidationRuleFailed, err)
 	}

--- a/dhctl/pkg/config/validation_rules_test.go
+++ b/dhctl/pkg/config/validation_rules_test.go
@@ -320,7 +320,6 @@ masterNodeGroup:
 	}
 
 	for name, tt := range tests {
-		tt := tt
 		t.Run(name, func(t *testing.T) {
 			err := ValidateClusterSettingsChanges(tt.phase, tt.oldConfig, tt.newConfig, tt.schema, validateOpts...)
 			if tt.errContains == "" {

--- a/dhctl/pkg/config/validation_test.go
+++ b/dhctl/pkg/config/validation_test.go
@@ -67,7 +67,6 @@ metadata:
 	}
 
 	for name, tt := range tests {
-		tt := tt
 		t.Run(name, func(t *testing.T) {
 			err := ValidateResources(tt.config, validateOpts...)
 			if tt.errContains == "" {
@@ -166,7 +165,6 @@ metadata:
 	}
 
 	for name, tt := range tests {
-		tt := tt
 		t.Run(name, func(t *testing.T) {
 			err := ValidateInitConfiguration(tt.config, newStore, validateOpts...)
 			if tt.errContains == "" {
@@ -259,7 +257,6 @@ clusterType: Static
 	}
 
 	for name, tt := range tests {
-		tt := tt
 		t.Run(name, func(t *testing.T) {
 			clusterConfig, err := ValidateClusterConfiguration(tt.config, newStore, validateOpts...)
 			require.Equal(t, tt.expected, clusterConfig)
@@ -453,7 +450,6 @@ sshPublicKey: ssh-key`,
 	}
 
 	for name, tt := range tests {
-		tt := tt
 		t.Run(name, func(t *testing.T) {
 			err := ValidateProviderSpecificClusterConfiguration(tt.config, tt.clusterConfig, newStore, validateOpts...)
 			if tt.errContains == "" {
@@ -517,7 +513,6 @@ internalNetworkCIDRs:
 	}
 
 	for name, tt := range tests {
-		tt := tt
 		t.Run(name, func(t *testing.T) {
 			err := ValidateStaticClusterConfiguration(tt.config, newStore, validateOpts...)
 			if tt.errContains == "" {

--- a/dhctl/pkg/config/validation_test.go
+++ b/dhctl/pkg/config/validation_test.go
@@ -19,8 +19,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/deckhouse/deckhouse/dhctl/pkg/app/options"
 	"github.com/stretchr/testify/require"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/app/options"
 )
 
 func TestValidateResources(t *testing.T) {
@@ -625,10 +626,9 @@ func TestError_JSONOmitemptyAllFields(t *testing.T) {
 }
 
 func TestError_JSONOmitemptyKeepsNonZeroFields(t *testing.T) {
-	idx := 2
 	e := Error{
 		Reason:   ErrKindValidationFailed,
-		Index:    &idx,
+		Index:    new(2),
 		Group:    "deckhouse.io",
 		Version:  "v1alpha1",
 		Kind:     "ModuleConfig",

--- a/dhctl/pkg/config/validators.go
+++ b/dhctl/pkg/config/validators.go
@@ -46,8 +46,7 @@ func validateUserResources(_ context.Context, payload string, _ *SchemaStore, op
 	if err == nil {
 		return nil
 	}
-	var ve *ValidationError
-	if errors.As(err, &ve) {
+	if ve, ok := errors.AsType[*ValidationError](err); ok {
 		return ve
 	}
 	out := &ValidationError{}
@@ -66,8 +65,7 @@ func validateConfigSchema(ctx context.Context, payload string, _ *SchemaStore, o
 	}
 	opts = append(opts, ValidateOptionCollectAllErrors(true))
 	if _, err := ParseConfigFromData(ctx, payload, DummyPreparatorProvider(), nil, opts...); err != nil {
-		var ve *ValidationError
-		if errors.As(err, &ve) {
+		if ve, ok := errors.AsType[*ValidationError](err); ok {
 			return ve
 		}
 		out := &ValidationError{}

--- a/dhctl/pkg/infrastructure/pipeline.go
+++ b/dhctl/pkg/infrastructure/pipeline.go
@@ -208,7 +208,7 @@ func CheckPipeline(
 type BaseInfrastructureDestructiveChanges struct {
 	plan.DestructiveChanges
 	OutputBrokenReason string           `json:"output_broken_reason,omitempty"`
-	OutputZonesChanged plan.ValueChange `json:"output_zones_changed,omitempty"`
+	OutputZonesChanged plan.ValueChange `json:"output_zones_changed"`
 }
 
 func CheckBaseInfrastructurePipeline(

--- a/dhctl/pkg/infrastructure/pipeline.go
+++ b/dhctl/pkg/infrastructure/pipeline.go
@@ -81,8 +81,7 @@ func GetMasterIPAddressForSSH(ctx context.Context, statePath string, executor Ou
 			OutFields: []string{k},
 		})
 		if err != nil {
-			var ee *exec.ExitError
-			if errors.As(err, &ee) {
+			if ee, ok := errors.AsType[*exec.ExitError](err); ok {
 				err = fmt.Errorf("%s\n%v", string(ee.Stderr), err)
 			}
 			if matchNoOutput(err.Error()) {

--- a/dhctl/pkg/infrastructure/plan/types.go
+++ b/dhctl/pkg/infrastructure/plan/types.go
@@ -14,6 +14,8 @@
 
 package plan
 
+import "slices"
+
 type Action string
 
 const (
@@ -38,9 +40,9 @@ type DestructiveChanges struct {
 }
 
 type ValueChange struct {
-	CurrentValue interface{} `json:"current_value,omitempty"`
-	NextValue    interface{} `json:"next_value,omitempty"`
-	Type         string      `json:"type,omitempty"`
+	CurrentValue any    `json:"current_value,omitempty"`
+	NextValue    any    `json:"next_value,omitempty"`
+	Type         string `json:"type,omitempty"`
 }
 
 type InfrastructurePlan struct {
@@ -56,16 +58,11 @@ type ResourceChange struct {
 
 func (r *ResourceChange) HasAction(findAction Action) bool {
 	act := string(findAction)
-	for _, action := range r.Change.Actions {
-		if action == act {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(r.Change.Actions, act)
 }
 
 type ChangeOp struct {
-	Actions []string               `json:"actions"`
-	Before  map[string]interface{} `json:"before,omitempty"`
-	After   map[string]interface{} `json:"after,omitempty"`
+	Actions []string       `json:"actions"`
+	Before  map[string]any `json:"before,omitempty"`
+	After   map[string]any `json:"after,omitempty"`
 }

--- a/dhctl/pkg/infrastructure/runner.go
+++ b/dhctl/pkg/infrastructure/runner.go
@@ -502,8 +502,7 @@ func (r *Runner) ShowPlan(ctx context.Context) ([]byte, error) {
 		PlanPath: r.GetPlanPath(),
 	})
 	if err != nil {
-		var ee *exec.ExitError
-		if errors.As(err, &ee) {
+		if ee, ok := errors.AsType[*exec.ExitError](err); ok {
 			err = fmt.Errorf("%s\n%v", string(ee.Stderr), err)
 		}
 		return nil, fmt.Errorf("Can't get infrastructure plan for %q\n%v", r.GetPlanPath(), err)
@@ -661,8 +660,7 @@ func (r *Runner) GetInfrastructureOutput(ctx context.Context, output string) ([]
 		return 0, nil
 	})
 	if err != nil {
-		var ee *exec.ExitError
-		if errors.As(err, &ee) {
+		if ee, ok := errors.AsType[*exec.ExitError](err); ok {
 			err = fmt.Errorf("%s\n%v", string(ee.Stderr), err)
 		}
 		return nil, fmt.Errorf("Can't get infrastructure output for %q\n%v", output, err)
@@ -837,8 +835,7 @@ func (r *Runner) getPlanDestructiveChanges(ctx context.Context, planFile string)
 		return 0, nil
 	})
 	if err != nil {
-		var ee *exec.ExitError
-		if errors.As(err, &ee) {
+		if ee, ok := errors.AsType[*exec.ExitError](err); ok {
 			err = fmt.Errorf("%s\n%v", string(ee.Stderr), err)
 		}
 		return nil, fmt.Errorf("Can't get infrastructure plan for %q\n%v", planFile, err)
@@ -900,8 +897,7 @@ func (r *Runner) planHasDestructiveChanges(ctx context.Context, planFile string)
 		return 0, nil
 	})
 	if err != nil {
-		var ee *exec.ExitError
-		if errors.As(err, &ee) {
+		if ee, ok := errors.AsType[*exec.ExitError](err); ok {
 			err = fmt.Errorf("%s\n%v", string(ee.Stderr), err)
 		}
 		return false, fmt.Errorf("can't get infrastructure plan for %q\n%v", planFile, err)

--- a/dhctl/pkg/infrastructure/runner.go
+++ b/dhctl/pkg/infrastructure/runner.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"slices"
 	"sync/atomic"
 	"time"
 
@@ -906,10 +907,8 @@ func (r *Runner) planHasDestructiveChanges(ctx context.Context, planFile string)
 		return false, fmt.Errorf("can't get infrastructure plan for %q\n%v", planFile, err)
 	}
 
-	for _, action := range result {
-		if action == "delete" {
-			return true, nil
-		}
+	if slices.Contains(result, "delete") {
+		return true, nil
 	}
 
 	return false, nil

--- a/dhctl/pkg/infrastructure/state_saver.go
+++ b/dhctl/pkg/infrastructure/state_saver.go
@@ -155,7 +155,6 @@ func (s *StateSaver) FsEventHandler(event fsnotify.Event) {
 	for _, saver := range s.saversDestinations {
 		svr := saver
 		wg.Go(func() {
-
 			err = svr.SaveState(ctx, outputs)
 			if err != nil {
 				log.ErrorF("Save intermediate state error: %v\n", err)

--- a/dhctl/pkg/infrastructure/state_saver.go
+++ b/dhctl/pkg/infrastructure/state_saver.go
@@ -154,9 +154,7 @@ func (s *StateSaver) FsEventHandler(event fsnotify.Event) {
 	hasError := int32(0)
 	for _, saver := range s.saversDestinations {
 		svr := saver
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 
 			err = svr.SaveState(ctx, outputs)
 			if err != nil {
@@ -164,7 +162,7 @@ func (s *StateSaver) FsEventHandler(event fsnotify.Event) {
 				atomic.StoreInt32(&hasError, 1)
 				return
 			}
-		}()
+		})
 	}
 
 	wg.Wait()

--- a/dhctl/pkg/infrastructureprovider/cloud/fsprovider/file_settings_provider.go
+++ b/dhctl/pkg/infrastructureprovider/cloud/fsprovider/file_settings_provider.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 	"sync"
 
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/yaml"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/infrastructureprovider/cloud"
@@ -121,18 +120,18 @@ func simpleFromMap(s any, terraformVersion, openTofuVersion string) (*settings.S
 	}
 
 	if set.UseOpenTofu() {
-		set.InfrastructureVersionVal = ptr.To(openTofuVersion)
+		set.InfrastructureVersionVal = new(openTofuVersion)
 	} else {
-		set.InfrastructureVersionVal = ptr.To(terraformVersion)
+		set.InfrastructureVersionVal = new(terraformVersion)
 	}
 
-	set.CloudNameVal = ptr.To(strings.ToLower(*set.CloudNameVal))
+	set.CloudNameVal = new(strings.ToLower(*set.CloudNameVal))
 
 	return &set, nil
 }
 
 func loadTerraformVersionFileSettings(filename string, logger log.Logger) (settingsStore, error) {
-	infrastructureProviders := make(map[string]interface{})
+	infrastructureProviders := make(map[string]any)
 
 	file, err := os.ReadFile(filename)
 	if err != nil {

--- a/dhctl/pkg/infrastructureprovider/cloud/kubernetes/manifest.go
+++ b/dhctl/pkg/infrastructureprovider/cloud/kubernetes/manifest.go
@@ -25,7 +25,7 @@ func IsManifest(change plan.ChangeOp, kind string, logger log.Logger) bool {
 	return strings.EqualFold(extractManifestKind(change.After, logger), kind)
 }
 
-func extractManifestKind(state map[string]interface{}, logger log.Logger) string {
+func extractManifestKind(state map[string]any, logger log.Logger) string {
 	v, ok := state["manifest"]
 	if !ok || v == nil {
 		logger.LogDebugF("State does not have a manifest. Returning empty kind\n")

--- a/dhctl/pkg/infrastructureprovider/cloud/version/content.go
+++ b/dhctl/pkg/infrastructureprovider/cloud/version/content.go
@@ -34,5 +34,5 @@ terraform {
 
 func GetVersionContent(settings settings.ProviderSettings, version string) []byte {
 	source := settings.Namespace() + "/" + settings.Type()
-	return []byte(fmt.Sprintf(template, settings.Type(), source, version))
+	return fmt.Appendf(nil, template, settings.Type(), source, version)
 }

--- a/dhctl/pkg/infrastructureprovider/provider_getter_params.go
+++ b/dhctl/pkg/infrastructureprovider/provider_getter_params.go
@@ -60,7 +60,7 @@ func (p *CloudProviderGetterParams) getProvidersCache() (CloudProvidersCache, er
 		providersCache = defaultProvidersCache
 	}
 
-	logger.LogDebugF(providersCacheLogMessage)
+	logger.LogDebugF("%s", providersCacheLogMessage)
 
 	return providersCache, nil
 }
@@ -126,7 +126,7 @@ func (p *CloudProviderGetterParams) setVersionsContentProviderGetter(di *cloud.P
 		versionProviderGetter = p.VersionProviderGetter
 	}
 
-	logger.LogDebugF(logMessage)
+	logger.LogDebugF("%s", logMessage)
 	di.VersionsContentProviderGetter = versionProviderGetter
 
 	return nil

--- a/dhctl/pkg/kubernetes/actions/deckhouse/converge.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/converge.go
@@ -74,15 +74,15 @@ func getTasksForRunning(ctx context.Context, kubeCl *client.KubernetesClient, co
 	tasks := []actions.ManifestTask{
 		{
 			Name:     `Secret "d8-cluster-configuration"`,
-			Manifest: func() interface{} { return manifests.SecretWithClusterConfig(clusterConfig) },
-			CreateFunc: func(ctx context.Context, manifest interface{}) error {
+			Manifest: func() any { return manifests.SecretWithClusterConfig(clusterConfig) },
+			CreateFunc: func(ctx context.Context, manifest any) error {
 				_, err := kubeCl.
 					CoreV1().Secrets("kube-system").
 					Create(ctx, manifest.(*apiv1.Secret), metav1.CreateOptions{})
 
 				return err
 			},
-			UpdateFunc: func(ctx context.Context, manifest interface{}) error {
+			UpdateFunc: func(ctx context.Context, manifest any) error {
 				_, err := kubeCl.
 					CoreV1().Secrets("kube-system").
 					Update(ctx, manifest.(*apiv1.Secret), metav1.UpdateOptions{})
@@ -92,17 +92,17 @@ func getTasksForRunning(ctx context.Context, kubeCl *client.KubernetesClient, co
 		},
 		{
 			Name: `ConfigMap "d8-cluster-uuid"`,
-			Manifest: func() interface{} {
+			Manifest: func() any {
 				return manifests.ClusterUUIDConfigMap(clusterUUID)
 			},
-			CreateFunc: func(ctx context.Context, manifest interface{}) error {
+			CreateFunc: func(ctx context.Context, manifest any) error {
 				_, err := kubeCl.
 					CoreV1().ConfigMaps(manifests.ClusterUUIDCmNamespace).
 					Create(ctx, manifest.(*apiv1.ConfigMap), metav1.CreateOptions{})
 
 				return err
 			},
-			UpdateFunc: func(ctx context.Context, manifest interface{}) error {
+			UpdateFunc: func(ctx context.Context, manifest any) error {
 				// NOTE: Uuid configmap uses "more careful" update task,
 				// NOTE: which will create configmap only if it does not exist,
 				// NOTE: or update configmap only if actual uuid in configmap does not match target uuid.
@@ -187,15 +187,15 @@ func (t *taskProviderForCluster) Cloud(ctx context.Context, metaConfig *config.M
 
 	return &actions.ManifestTask{
 		Name: fmt.Sprintf(`Secret "%s"`, secretName),
-		Manifest: func() interface{} {
+		Manifest: func() any {
 			return manifests.SecretWithProviderClusterConfig(
 				providerClusterConfig, nil,
 			)
 		},
-		CreateFunc: func(ctx context.Context, manifest interface{}) error {
+		CreateFunc: func(ctx context.Context, manifest any) error {
 			return convergeManifestsCreateSecret(ctx, kubeCl, manifest, secretName)
 		},
-		UpdateFunc: func(ctx context.Context, manifest interface{}) error {
+		UpdateFunc: func(ctx context.Context, manifest any) error {
 			return convergeManifestsPatchSecret(ctx, kubeCl, manifest, secretName)
 		},
 	}, nil
@@ -218,13 +218,13 @@ func (t *taskProviderForCluster) Static(ctx context.Context, metaConfig *config.
 
 	return &actions.ManifestTask{
 		Name: fmt.Sprintf(`Secret "%s"`, secretName),
-		Manifest: func() interface{} {
+		Manifest: func() any {
 			return manifests.SecretWithStaticClusterConfig(staticClusterConfig)
 		},
-		CreateFunc: func(ctx context.Context, manifest interface{}) error {
+		CreateFunc: func(ctx context.Context, manifest any) error {
 			return convergeManifestsCreateSecret(ctx, kubeCl, manifest, secretName)
 		},
-		UpdateFunc: func(ctx context.Context, manifest interface{}) error {
+		UpdateFunc: func(ctx context.Context, manifest any) error {
 			return convergeManifestsPatchSecret(ctx, kubeCl, manifest, secretName)
 		},
 	}, nil

--- a/dhctl/pkg/kubernetes/actions/deckhouse/converge_test.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/converge_test.go
@@ -93,7 +93,7 @@ func TestStaticClusterClusterManifestConverge(t *testing.T) {
 	require.NotEqual(t, kubeVersionBefore, kubeVersionAfter)
 
 	paramsBefore := commander.CommanderModeParams{
-		ClusterConfigurationData: []byte(fmt.Sprintf(clusterConfigurationStaticTmp, kubeVersionBefore)),
+		ClusterConfigurationData: fmt.Appendf(nil, clusterConfigurationStaticTmp, kubeVersionBefore),
 		ProviderClusterConfigurationData: []byte(`
 apiVersion: deckhouse.io/v1
 kind: StaticClusterConfiguration
@@ -102,7 +102,7 @@ internalNetworkCIDRs:
 `),
 	}
 	paramsAfter := commander.CommanderModeParams{
-		ClusterConfigurationData: []byte(fmt.Sprintf(clusterConfigurationStaticTmp, kubeVersionAfter)),
+		ClusterConfigurationData: fmt.Appendf(nil, clusterConfigurationStaticTmp, kubeVersionAfter),
 		ProviderClusterConfigurationData: []byte(`
 apiVersion: deckhouse.io/v1
 kind: StaticClusterConfiguration
@@ -180,11 +180,11 @@ func TestCloudClusterManifestConverge(t *testing.T) {
 	require.NotEqual(t, kubeVersionBefore, kubeVersionAfter)
 
 	paramsBefore := commander.CommanderModeParams{
-		ClusterConfigurationData:         []byte(fmt.Sprintf(clusterConfigurationYandexTmp, kubeVersionBefore)),
+		ClusterConfigurationData:         fmt.Appendf(nil, clusterConfigurationYandexTmp, kubeVersionBefore),
 		ProviderClusterConfigurationData: []byte(clusterConfigurationYandexBeforeValid),
 	}
 	paramsAfter := commander.CommanderModeParams{
-		ClusterConfigurationData: []byte(fmt.Sprintf(clusterConfigurationYandexTmp, kubeVersionAfter)),
+		ClusterConfigurationData: fmt.Appendf(nil, clusterConfigurationYandexTmp, kubeVersionAfter),
 		ProviderClusterConfigurationData: []byte(`
 apiVersion: deckhouse.io/v1
 kind: YandexClusterConfiguration
@@ -280,10 +280,10 @@ func TestErrorConvergeManifests(t *testing.T) {
 
 	staticClusterConvergeParams := testConvergeManifestsParams{
 		commanderStateBefore: commander.CommanderModeParams{
-			ClusterConfigurationData: []byte(fmt.Sprintf(clusterConfigurationStaticTmp, kubeVersionBefore)),
+			ClusterConfigurationData: fmt.Appendf(nil, clusterConfigurationStaticTmp, kubeVersionBefore),
 		},
 		commanderStateAfter: commander.CommanderModeParams{
-			ClusterConfigurationData: []byte(fmt.Sprintf(clusterConfigurationStaticTmp, kubeVersionBefore)),
+			ClusterConfigurationData: fmt.Appendf(nil, clusterConfigurationStaticTmp, kubeVersionBefore),
 		},
 	}
 
@@ -294,11 +294,11 @@ func TestErrorConvergeManifests(t *testing.T) {
 
 	yandexClusterConvergeParams := testConvergeManifestsParams{
 		commanderStateBefore: commander.CommanderModeParams{
-			ClusterConfigurationData:         []byte(fmt.Sprintf(clusterConfigurationYandexTmp, kubeVersionBefore)),
+			ClusterConfigurationData:         fmt.Appendf(nil, clusterConfigurationYandexTmp, kubeVersionBefore),
 			ProviderClusterConfigurationData: []byte(clusterConfigurationYandexBeforeValid),
 		},
 		commanderStateAfter: commander.CommanderModeParams{
-			ClusterConfigurationData:         []byte(fmt.Sprintf(clusterConfigurationYandexTmp, kubeVersionBefore)),
+			ClusterConfigurationData:         fmt.Appendf(nil, clusterConfigurationYandexTmp, kubeVersionBefore),
 			ProviderClusterConfigurationData: []byte(clusterConfigurationYandexBeforeValid),
 		},
 	}

--- a/dhctl/pkg/kubernetes/actions/deckhouse/delete.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/delete.go
@@ -56,7 +56,7 @@ func isCAPIClusterUnsupportedErr(err error) bool {
 }
 
 func DeleteValidatingWebhookConfigurations(ctx context.Context, kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Delete validating webhook configurations", 225, 1*time.Second).WithShowError(false).RunContext(ctx, func() error {
+	return retry.NewLoop("Delete validating webhook configurations", 45, 5*time.Second).WithShowError(false).RunContext(ctx, func() error {
 		vwcs, err := kubeCl.AdmissionregistrationV1().ValidatingWebhookConfigurations().List(ctx, metav1.ListOptions{
 			LabelSelector: "heritage=deckhouse",
 		})
@@ -78,8 +78,7 @@ func DeleteValidatingWebhookConfigurations(ctx context.Context, kubeCl *client.K
 
 func DeleteDeckhouseDeployment(ctx context.Context, kubeCl *client.KubernetesClient) error {
 	return retry.NewLoop("Delete Deckhouse", 225, 1*time.Second).WithShowError(false).RunContext(ctx, func() error {
-		foregroundPolicy := metav1.DeletePropagationForeground
-		err := kubeCl.AppsV1().Deployments(deckhouseDeploymentNamespace).Delete(ctx, deckhouseDeploymentName, metav1.DeleteOptions{PropagationPolicy: &foregroundPolicy})
+		err := kubeCl.AppsV1().Deployments(deckhouseDeploymentNamespace).Delete(ctx, deckhouseDeploymentName, metav1.DeleteOptions{PropagationPolicy: new(metav1.DeletePropagationForeground)})
 		if err != nil && !errors.IsNotFound(err) {
 			return err
 		}
@@ -110,7 +109,7 @@ func DeleteClusters(ctx context.Context, kubeCl *client.KubernetesClient) error 
 }
 
 func DeletePDBs(ctx context.Context, kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Delete pdbs", 225, 1*time.Second).WithShowError(false).RunContext(ctx, func() error {
+	return retry.NewLoop("Delete pdbs", 45, 5*time.Second).WithShowError(false).RunContext(ctx, func() error {
 		foregroundPolicy := metav1.DeletePropagationForeground
 		namespaces, err := kubeCl.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
 		if err != nil {
@@ -158,7 +157,7 @@ func DeleteD8StorageResources(ctx context.Context, kubeCl *client.KubernetesClie
 }
 
 func DeleteAllD8StorageResources(ctx context.Context, kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Delete Deckhouse Storage CRs", 225, 1*time.Second).WithShowError(false).RunContext(ctx, func() error {
+	return retry.NewLoop("Delete Deckhouse Storage CRs", 45, 5*time.Second).WithShowError(false).RunContext(ctx, func() error {
 		for _, cr := range v1alpha1.D8StoragesGVRs() {
 			storageCRs, err := ListD8StorageResources(ctx, kubeCl, cr)
 			if err != nil {
@@ -180,7 +179,7 @@ func DeleteAllD8StorageResources(ctx context.Context, kubeCl *client.KubernetesC
 }
 
 func DeleteStorageClasses(ctx context.Context, kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Delete StorageClasses", 225, 1*time.Second).WithShowError(false).RunContext(ctx, func() error {
+	return retry.NewLoop("Delete StorageClasses", 45, 5*time.Second).WithShowError(false).RunContext(ctx, func() error {
 		list, err := kubeCl.StorageV1().StorageClasses().List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return err
@@ -203,7 +202,7 @@ func DeleteStorageClasses(ctx context.Context, kubeCl *client.KubernetesClient) 
 }
 
 func DeletePods(ctx context.Context, kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Delete Pods", 225, 1*time.Second).WithShowError(false).RunContext(ctx, func() error {
+	return retry.NewLoop("Delete Pods", 45, 5*time.Second).WithShowError(false).RunContext(ctx, func() error {
 		pods, err := kubeCl.CoreV1().Pods(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return err
@@ -240,7 +239,7 @@ func DeletePods(ctx context.Context, kubeCl *client.KubernetesClient) error {
 }
 
 func DeleteServices(ctx context.Context, kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Delete Services", 225, 1*time.Second).WithShowError(false).RunContext(ctx, func() error {
+	return retry.NewLoop("Delete Services", 45, 5*time.Second).WithShowError(false).RunContext(ctx, func() error {
 		allServices, err := kubeCl.CoreV1().Services(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return err
@@ -262,7 +261,7 @@ func DeleteServices(ctx context.Context, kubeCl *client.KubernetesClient) error 
 }
 
 func DeletePVC(ctx context.Context, kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Delete PersistentVolumeClaims", 225, 1*time.Second).WithShowError(false).RunContext(ctx, func() error {
+	return retry.NewLoop("Delete PersistentVolumeClaims", 45, 5*time.Second).WithShowError(false).RunContext(ctx, func() error {
 		volumeClaims, err := kubeCl.CoreV1().PersistentVolumeClaims(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return err
@@ -280,7 +279,7 @@ func DeletePVC(ctx context.Context, kubeCl *client.KubernetesClient) error {
 }
 
 func WaitForDeckhouseDeploymentDeletion(ctx context.Context, kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Wait for Deckhouse Deployment deletion", 150, 1*time.Second).WithShowError(false).RunContext(ctx, func() error {
+	return retry.NewLoop("Wait for Deckhouse Deployment deletion", 30, 5*time.Second).WithShowError(false).RunContext(ctx, func() error {
 		_, err := kubeCl.AppsV1().Deployments(deckhouseDeploymentNamespace).Get(ctx, deckhouseDeploymentName, metav1.GetOptions{})
 		if errors.IsNotFound(err) {
 			log.InfoLn("Deckhouse Deployment and its dependents are removed")
@@ -322,7 +321,7 @@ func WaitForClustersDeletion(ctx context.Context, kubeCl *client.KubernetesClien
 }
 
 func WaitForServicesDeletion(ctx context.Context, kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Wait for Services deletion", 600, 1*time.Second).WithShowError(false).RunContext(ctx, func() error {
+	return retry.NewLoop("Wait for Services deletion", 45, 15*time.Second).WithShowError(false).RunContext(ctx, func() error {
 		resources, err := kubeCl.CoreV1().Services(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return err
@@ -349,7 +348,7 @@ func WaitForServicesDeletion(ctx context.Context, kubeCl *client.KubernetesClien
 }
 
 func WaitForPVDeletion(ctx context.Context, kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Wait for PersistentVolumes deletion", 600, 1*time.Second).WithShowError(false).RunContext(ctx, func() error {
+	return retry.NewLoop("Wait for PersistentVolumes deletion", 45, 15*time.Second).WithShowError(false).RunContext(ctx, func() error {
 		resources, err := kubeCl.CoreV1().PersistentVolumes().List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return err
@@ -390,7 +389,7 @@ func WaitForPVDeletion(ctx context.Context, kubeCl *client.KubernetesClient) err
 }
 
 func WaitForPVCDeletion(ctx context.Context, kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Wait for PersistentVolumeClaims deletion", 600, 1*time.Second).WithShowError(false).RunContext(ctx, func() error {
+	return retry.NewLoop("Wait for PersistentVolumeClaims deletion", 45, 15*time.Second).WithShowError(false).RunContext(ctx, func() error {
 		resources, err := kubeCl.CoreV1().PersistentVolumeClaims(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return err
@@ -439,7 +438,7 @@ func checkMachinesAPI(kubeCl *client.KubernetesClient, gv schema.GroupVersion) e
 }
 
 func DeleteMCMMachineDeployments(ctx context.Context, kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Delete MCM MachineDeployments", 225, 1*time.Second).RunContext(ctx, func() error {
+	return retry.NewLoop("Delete MCM MachineDeployments", 45, 5*time.Second).RunContext(ctx, func() error {
 		allMachines, err := kubeCl.Dynamic().Resource(sapcloud.MachineGVR).Namespace(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return fmt.Errorf("get machines: %v", err)
@@ -481,7 +480,7 @@ func DeleteMCMMachineDeployments(ctx context.Context, kubeCl *client.KubernetesC
 }
 
 func WaitForMCMMachinesDeletion(ctx context.Context, kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Wait for MCM Machines deletion", 600, 1*time.Second).WithShowError(false).RunContext(ctx, func() error {
+	return retry.NewLoop("Wait for MCM Machines deletion", 45, 15*time.Second).WithShowError(false).RunContext(ctx, func() error {
 		resources, err := kubeCl.Dynamic().Resource(sapcloud.MachineGVR).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return err
@@ -505,7 +504,7 @@ func checkMCMMachinesAPI(kubeCl *client.KubernetesClient) error {
 }
 
 func DeleteMachinesIfResourcesExist(ctx context.Context, kubeCl *client.KubernetesClient) error {
-	err := retry.NewLoop("Get Kubernetes cluster resources for MCM group/version", 25, 1*time.Second).WithShowError(false).
+	err := retry.NewLoop("Get Kubernetes cluster resources for MCM group/version", 5, 5*time.Second).WithShowError(false).
 		RunContext(ctx, func() error {
 			return checkMCMMachinesAPI(kubeCl)
 		})
@@ -530,7 +529,7 @@ func DeleteMachinesIfResourcesExist(ctx context.Context, kubeCl *client.Kubernet
 	}
 
 	// try to remove CAPI machines it needs for static clusters and cluster with cluster api support
-	err = retry.NewLoop("Get Kubernetes cluster resources for CAPI group/version", 25, 1*time.Second).WithShowError(false).
+	err = retry.NewLoop("Get Kubernetes cluster resources for CAPI group/version", 5, 5*time.Second).WithShowError(false).
 		RunContext(ctx, func() error {
 			return checkCAPIMachinesAPI(kubeCl)
 		})
@@ -558,7 +557,7 @@ func checkCAPIMachinesAPI(kubeCl *client.KubernetesClient) error {
 }
 
 func DeleteCAPIMachineDeployments(ctx context.Context, kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Delete CAPI MachineDeployments", 225, 1*time.Second).RunContext(ctx, func() error {
+	return retry.NewLoop("Delete CAPI MachineDeployments", 45, 5*time.Second).RunContext(ctx, func() error {
 		allMachines, err := kubeCl.Dynamic().Resource(capi.MachineGVR).Namespace(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return fmt.Errorf("get machines: %v", err)
@@ -603,7 +602,7 @@ func DeleteCAPIMachineDeployments(ctx context.Context, kubeCl *client.Kubernetes
 }
 
 func WaitForCAPIMachinesDeletion(ctx context.Context, kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Wait for CAPI Machines deletion", 600, 1*time.Second).WithShowError(false).RunContext(ctx, func() error {
+	return retry.NewLoop("Wait for CAPI Machines deletion", 45, 15*time.Second).WithShowError(false).RunContext(ctx, func() error {
 		resources, err := kubeCl.Dynamic().Resource(capi.MachineGVR).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return err

--- a/dhctl/pkg/kubernetes/actions/deckhouse/install.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/install.go
@@ -81,14 +81,14 @@ func controllerDeploymentTask(
 ) actions.ManifestTask {
 	return actions.ManifestTask{
 		Name: `Deployment "deckhouse"`,
-		Manifest: func() interface{} {
+		Manifest: func() any {
 			return CreateDeckhouseDeploymentManifest(cfg)
 		},
-		CreateFunc: func(ctx context.Context, manifest interface{}) error {
+		CreateFunc: func(ctx context.Context, manifest any) error {
 			_, err := kubeCl.AppsV1().Deployments("d8-system").Create(ctx, manifest.(*appsv1.Deployment), metav1.CreateOptions{})
 			return err
 		},
-		UpdateFunc: func(ctx context.Context, manifest interface{}) error {
+		UpdateFunc: func(ctx context.Context, manifest any) error {
 			preparedManifest, err := prepareDeckhouseDeploymentForUpdate(ctx, kubeCl, cfg, manifest.(*appsv1.Deployment))
 			if err != nil {
 				return err
@@ -132,7 +132,7 @@ func LockDeckhouseQueueBeforeCreatingModuleConfigs(
 
 	return &actions.ManifestTask{
 		Name: `ConfigMap "deckhouse-bootstrap-lock"`,
-		Manifest: func() interface{} {
+		Manifest: func() any {
 			return &apiv1.ConfigMap{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "ConfigMap",
@@ -144,7 +144,7 @@ func LockDeckhouseQueueBeforeCreatingModuleConfigs(
 				},
 			}
 		},
-		CreateFunc: func(ctx context.Context, manifest interface{}) error {
+		CreateFunc: func(ctx context.Context, manifest any) error {
 			cm := manifest.(*apiv1.ConfigMap)
 
 			_, err := kubeCl.
@@ -152,7 +152,7 @@ func LockDeckhouseQueueBeforeCreatingModuleConfigs(
 				Create(ctx, cm, metav1.CreateOptions{})
 			return err
 		},
-		UpdateFunc: func(ctx context.Context, manifest interface{}) error {
+		UpdateFunc: func(ctx context.Context, manifest any) error {
 			return nil
 		},
 	}, nil
@@ -204,8 +204,8 @@ func CreateDeckhouseManifests(
 		},
 		{
 			Name:     `Admin ClusterRole "cluster-admin"`,
-			Manifest: func() interface{} { return manifests.DeckhouseAdminClusterRole() },
-			CreateFunc: func(ctx context.Context, manifest interface{}) error {
+			Manifest: func() any { return manifests.DeckhouseAdminClusterRole() },
+			CreateFunc: func(ctx context.Context, manifest any) error {
 				_, err := kubeCl.
 					RbacV1().ClusterRoles().
 					Get(ctx, manifest.(*rbacv1.ClusterRole).GetName(), metav1.GetOptions{})
@@ -219,7 +219,7 @@ func CreateDeckhouseManifests(
 
 				return err
 			},
-			UpdateFunc: func(ctx context.Context, manifest interface{}) error {
+			UpdateFunc: func(ctx context.Context, manifest any) error {
 				_, err := kubeCl.
 					RbacV1().ClusterRoles().
 					Update(ctx, manifest.(*rbacv1.ClusterRole), metav1.UpdateOptions{})
@@ -229,8 +229,8 @@ func CreateDeckhouseManifests(
 		},
 		{
 			Name:     `ClusterRoleBinding "deckhouse"`,
-			Manifest: func() interface{} { return manifests.DeckhouseAdminClusterRoleBinding() },
-			CreateFunc: func(ctx context.Context, manifest interface{}) error {
+			Manifest: func() any { return manifests.DeckhouseAdminClusterRoleBinding() },
+			CreateFunc: func(ctx context.Context, manifest any) error {
 				_, err := kubeCl.
 					RbacV1().ClusterRoleBindings().
 					Get(ctx, manifest.(*rbacv1.ClusterRoleBinding).GetName(), metav1.GetOptions{})
@@ -244,7 +244,7 @@ func CreateDeckhouseManifests(
 
 				return err
 			},
-			UpdateFunc: func(ctx context.Context, manifest interface{}) error {
+			UpdateFunc: func(ctx context.Context, manifest any) error {
 				_, err := kubeCl.
 					RbacV1().ClusterRoleBindings().
 					Update(ctx, manifest.(*rbacv1.ClusterRoleBinding), metav1.UpdateOptions{})
@@ -254,8 +254,8 @@ func CreateDeckhouseManifests(
 		},
 		{
 			Name:     `ServiceAccount "deckhouse"`,
-			Manifest: func() interface{} { return manifests.DeckhouseServiceAccount() },
-			CreateFunc: func(ctx context.Context, manifest interface{}) error {
+			Manifest: func() any { return manifests.DeckhouseServiceAccount() },
+			CreateFunc: func(ctx context.Context, manifest any) error {
 				_, err := kubeCl.
 					CoreV1().ServiceAccounts("d8-system").
 					Get(ctx, manifest.(*apiv1.ServiceAccount).GetName(), metav1.GetOptions{})
@@ -269,7 +269,7 @@ func CreateDeckhouseManifests(
 
 				return err
 			},
-			UpdateFunc: func(ctx context.Context, manifest interface{}) error {
+			UpdateFunc: func(ctx context.Context, manifest any) error {
 				_, err := kubeCl.
 					CoreV1().ServiceAccounts("d8-system").
 					Update(ctx, manifest.(*apiv1.ServiceAccount), metav1.UpdateOptions{})
@@ -279,7 +279,7 @@ func CreateDeckhouseManifests(
 		},
 		{
 			Name: `ConfigMap "install-data"`,
-			Manifest: func() interface{} {
+			Manifest: func() any {
 				return &apiv1.ConfigMap{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "ConfigMap",
@@ -294,7 +294,7 @@ func CreateDeckhouseManifests(
 					},
 				}
 			},
-			CreateFunc: func(ctx context.Context, manifest interface{}) error {
+			CreateFunc: func(ctx context.Context, manifest any) error {
 				cm := manifest.(*apiv1.ConfigMap)
 
 				_, err := kubeCl.
@@ -303,7 +303,7 @@ func CreateDeckhouseManifests(
 
 				return err
 			},
-			UpdateFunc: func(ctx context.Context, manifest interface{}) error {
+			UpdateFunc: func(ctx context.Context, manifest any) error {
 				cm := manifest.(*apiv1.ConfigMap)
 
 				_, err := kubeCl.
@@ -394,8 +394,8 @@ func CreateDeckhouseManifests(
 	if len(cfg.InfrastructureState) > 0 {
 		tasks = append(tasks, actions.ManifestTask{
 			Name:     `Secret "d8-cluster-terraform-state"`,
-			Manifest: func() interface{} { return manifests.SecretWithInfrastructureState(cfg.InfrastructureState) },
-			CreateFunc: func(ctx context.Context, manifest interface{}) error {
+			Manifest: func() any { return manifests.SecretWithInfrastructureState(cfg.InfrastructureState) },
+			CreateFunc: func(ctx context.Context, manifest any) error {
 				_, err := kubeCl.
 					CoreV1().Secrets("d8-system").
 					Get(ctx, manifest.(*apiv1.Secret).GetName(), metav1.GetOptions{})
@@ -411,7 +411,7 @@ func CreateDeckhouseManifests(
 
 				return err
 			},
-			UpdateFunc: func(ctx context.Context, manifest interface{}) error {
+			UpdateFunc: func(ctx context.Context, manifest any) error {
 				_, err := kubeCl.
 					CoreV1().Secrets("d8-system").
 					Update(ctx, manifest.(*apiv1.Secret), metav1.UpdateOptions{})
@@ -422,13 +422,13 @@ func CreateDeckhouseManifests(
 	}
 
 	for nodeName, tfState := range cfg.NodesInfrastructureState {
-		getManifest := func() interface{} {
+		getManifest := func() any {
 			return manifests.SecretWithNodeInfrastructureState(nodeName, "master", tfState, nil)
 		}
 		tasks = append(tasks, actions.ManifestTask{
 			Name:     fmt.Sprintf(`Secret "d8-node-terraform-state-%s"`, nodeName),
 			Manifest: getManifest,
-			CreateFunc: func(ctx context.Context, manifest interface{}) error {
+			CreateFunc: func(ctx context.Context, manifest any) error {
 				_, err := kubeCl.
 					CoreV1().Secrets("d8-system").
 					Get(ctx, manifest.(*apiv1.Secret).GetName(), metav1.GetOptions{})
@@ -445,7 +445,7 @@ func CreateDeckhouseManifests(
 
 				return err
 			},
-			UpdateFunc: func(ctx context.Context, manifest interface{}) error {
+			UpdateFunc: func(ctx context.Context, manifest any) error {
 				_, err := kubeCl.
 					CoreV1().Secrets("d8-system").
 					Update(ctx, manifest.(*apiv1.Secret), metav1.UpdateOptions{})
@@ -458,8 +458,8 @@ func CreateDeckhouseManifests(
 	if len(cfg.ClusterConfig) > 0 {
 		tasks = append(tasks, actions.ManifestTask{
 			Name:     `Secret "d8-cluster-configuration"`,
-			Manifest: func() interface{} { return manifests.SecretWithClusterConfig(cfg.ClusterConfig) },
-			CreateFunc: func(ctx context.Context, manifest interface{}) error {
+			Manifest: func() any { return manifests.SecretWithClusterConfig(cfg.ClusterConfig) },
+			CreateFunc: func(ctx context.Context, manifest any) error {
 				_, err := kubeCl.
 					CoreV1().Secrets("kube-system").
 					Get(ctx, manifest.(*apiv1.Secret).GetName(), metav1.GetOptions{})
@@ -475,7 +475,7 @@ func CreateDeckhouseManifests(
 
 				return err
 			},
-			UpdateFunc: func(ctx context.Context, manifest interface{}) error {
+			UpdateFunc: func(ctx context.Context, manifest any) error {
 				_, err := kubeCl.
 					CoreV1().Secrets("kube-system").
 					Update(ctx, manifest.(*apiv1.Secret), metav1.UpdateOptions{})
@@ -488,12 +488,12 @@ func CreateDeckhouseManifests(
 	if len(cfg.ProviderClusterConfig) > 0 {
 		tasks = append(tasks, actions.ManifestTask{
 			Name: `Secret "d8-provider-cluster-configuration"`,
-			Manifest: func() interface{} {
+			Manifest: func() any {
 				return manifests.SecretWithProviderClusterConfig(
 					cfg.ProviderClusterConfig, cfg.CloudDiscovery,
 				)
 			},
-			CreateFunc: func(ctx context.Context, manifest interface{}) error {
+			CreateFunc: func(ctx context.Context, manifest any) error {
 				_, err := kubeCl.
 					CoreV1().Secrets("kube-system").
 					Get(ctx, manifest.(*apiv1.Secret).GetName(), metav1.GetOptions{})
@@ -509,7 +509,7 @@ func CreateDeckhouseManifests(
 
 				return err
 			},
-			UpdateFunc: func(ctx context.Context, manifest interface{}) error {
+			UpdateFunc: func(ctx context.Context, manifest any) error {
 				data, err := json.Marshal(manifest.(*apiv1.Secret))
 				if err != nil {
 					return err
@@ -532,10 +532,10 @@ func CreateDeckhouseManifests(
 	if len(cfg.StaticClusterConfig) > 0 {
 		tasks = append(tasks, actions.ManifestTask{
 			Name: `Secret "d8-static-cluster-configuration"`,
-			Manifest: func() interface{} {
+			Manifest: func() any {
 				return manifests.SecretWithStaticClusterConfig(cfg.StaticClusterConfig)
 			},
-			CreateFunc: func(ctx context.Context, manifest interface{}) error {
+			CreateFunc: func(ctx context.Context, manifest any) error {
 				_, err := kubeCl.
 					CoreV1().Secrets("kube-system").
 					Get(ctx, manifest.(*apiv1.Secret).GetName(), metav1.GetOptions{})
@@ -551,7 +551,7 @@ func CreateDeckhouseManifests(
 
 				return err
 			},
-			UpdateFunc: func(ctx context.Context, manifest interface{}) error {
+			UpdateFunc: func(ctx context.Context, manifest any) error {
 				data, err := json.Marshal(manifest.(*apiv1.Secret))
 				if err != nil {
 					return err
@@ -574,17 +574,17 @@ func CreateDeckhouseManifests(
 	if len(cfg.UUID) > 0 {
 		tasks = append(tasks, actions.ManifestTask{
 			Name: `ConfigMap "d8-cluster-uuid"`,
-			Manifest: func() interface{} {
+			Manifest: func() any {
 				return manifests.ClusterUUIDConfigMap(cfg.UUID)
 			},
-			CreateFunc: func(ctx context.Context, manifest interface{}) error {
+			CreateFunc: func(ctx context.Context, manifest any) error {
 				_, err := kubeCl.
 					CoreV1().ConfigMaps(manifests.ClusterUUIDCmNamespace).
 					Create(ctx, manifest.(*apiv1.ConfigMap), metav1.CreateOptions{})
 
 				return err
 			},
-			UpdateFunc: func(ctx context.Context, manifest interface{}) error {
+			UpdateFunc: func(ctx context.Context, manifest any) error {
 				_, err := kubeCl.
 					CoreV1().ConfigMaps(manifests.ClusterUUIDCmNamespace).
 					Update(ctx, manifest.(*apiv1.ConfigMap), metav1.UpdateOptions{})
@@ -601,10 +601,10 @@ func CreateDeckhouseManifests(
 	if cfg.KubeDNSAddress != "" {
 		tasks = append(tasks, actions.ManifestTask{
 			Name: `Service "kube-dns"`,
-			Manifest: func() interface{} {
+			Manifest: func() any {
 				return manifests.KubeDNSService(cfg.KubeDNSAddress)
 			},
-			CreateFunc: func(ctx context.Context, manifest interface{}) error {
+			CreateFunc: func(ctx context.Context, manifest any) error {
 				_, err := kubeCl.
 					CoreV1().Services("kube-system").
 					Get(ctx, manifest.(*apiv1.Service).GetName(), metav1.GetOptions{})
@@ -624,7 +624,7 @@ func CreateDeckhouseManifests(
 
 				return err
 			},
-			UpdateFunc: func(ctx context.Context, manifest interface{}) error {
+			UpdateFunc: func(ctx context.Context, manifest any) error {
 				_, err := kubeCl.
 					CoreV1().Services("kube-system").
 					Update(ctx, manifest.(*apiv1.Service), metav1.UpdateOptions{})

--- a/dhctl/pkg/kubernetes/actions/deckhouse/install_test.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/install_test.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/utils/ptr"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
 	registry_mocks "github.com/deckhouse/deckhouse/dhctl/pkg/config/registrymocks"
@@ -257,9 +256,9 @@ func TestDeckhouseInstallWithModuleConfig(t *testing.T) {
 		Kind:    config.ModuleConfigKind,
 	})
 	mc1.SetName("global")
-	mc1.Spec.Enabled = ptr.To(true)
+	mc1.Spec.Enabled = new(true)
 	mc1.Spec.Version = 1
-	mc1.Spec.Settings = config.SettingsValues(map[string]interface{}{
+	mc1.Spec.Settings = config.SettingsValues(map[string]any{
 		"ha": true,
 	})
 
@@ -308,9 +307,9 @@ func TestDeckhouseInstallWithModuleConfigs(t *testing.T) {
 		Kind:    config.ModuleConfigKind,
 	})
 	mc1.SetName("global")
-	mc1.Spec.Enabled = ptr.To(true)
+	mc1.Spec.Enabled = new(true)
 	mc1.Spec.Version = 1
-	mc1.Spec.Settings = config.SettingsValues(map[string]interface{}{
+	mc1.Spec.Settings = config.SettingsValues(map[string]any{
 		"ha": true,
 	})
 
@@ -321,9 +320,9 @@ func TestDeckhouseInstallWithModuleConfigs(t *testing.T) {
 		Kind:    config.ModuleConfigKind,
 	})
 	mc2.SetName("deckhouse")
-	mc2.Spec.Enabled = ptr.To(true)
+	mc2.Spec.Enabled = new(true)
 	mc2.Spec.Version = 1
-	mc2.Spec.Settings = config.SettingsValues(map[string]interface{}{
+	mc2.Spec.Settings = config.SettingsValues(map[string]any{
 		"bundle": "Minimal",
 	})
 
@@ -367,7 +366,7 @@ func TestDeckhouseInstallWithModuleConfigsReturnsResults(t *testing.T) {
 				config.ModuleConfigGVR: "ModuleConfigList",
 			})
 
-			mc := createMC("deckhouse", map[string]interface{}{
+			mc := createMC("deckhouse", map[string]any{
 				"bundle":         "Minimal",
 				"logLevel":       "Debug",
 				"releaseChannel": "Alpha",
@@ -394,7 +393,7 @@ func TestDeckhouseInstallWithModuleConfigsReturnsResults(t *testing.T) {
 
 			require.Len(t, mcs.Items, 1)
 
-			require.NotContains(t, mcs.Items[0].Object["spec"].(map[string]interface{})["settings"], "releaseChannel")
+			require.NotContains(t, mcs.Items[0].Object["spec"].(map[string]any)["settings"], "releaseChannel")
 		})
 	})
 
@@ -404,11 +403,11 @@ func TestDeckhouseInstallWithModuleConfigsReturnsResults(t *testing.T) {
 				config.ModuleConfigGVR: "ModuleConfigList",
 			})
 
-			mc := createMC("global", map[string]interface{}{
+			mc := createMC("global", map[string]any{
 				"highAvailability": true,
-				"modules": map[string]interface{}{
-					"https": map[string]interface{}{
-						"customCertificate": map[string]interface{}{
+				"modules": map[string]any{
+					"https": map[string]any{
+						"customCertificate": map[string]any{
 							"secretName": "secret",
 						},
 					},
@@ -437,7 +436,7 @@ func TestDeckhouseInstallWithModuleConfigsReturnsResults(t *testing.T) {
 
 			require.Len(t, mcs.Items, 1)
 
-			require.NotContains(t, mcs.Items[0].Object["spec"].(map[string]interface{})["settings"].(map[string]interface{})["modules"], "https")
+			require.NotContains(t, mcs.Items[0].Object["spec"].(map[string]any)["settings"].(map[string]any)["modules"], "https")
 		})
 	})
 
@@ -447,7 +446,7 @@ func TestDeckhouseInstallWithModuleConfigsReturnsResults(t *testing.T) {
 				config.ModuleConfigGVR: "ModuleConfigList",
 			})
 
-			mc := createMC("prometheus", map[string]interface{}{
+			mc := createMC("prometheus", map[string]any{
 				"highAvailability": true,
 			})
 
@@ -479,17 +478,17 @@ func TestDeckhouseInstallWithModuleConfigsReturnsResults(t *testing.T) {
 				config.ModuleConfigGVR: "ModuleConfigList",
 			})
 
-			mcDeckhouse := createMC("deckhouse", map[string]interface{}{
+			mcDeckhouse := createMC("deckhouse", map[string]any{
 				"bundle":         "Minimal",
 				"logLevel":       "Debug",
 				"releaseChannel": "Alpha",
 			})
 
-			mcGlobal := createMC("global", map[string]interface{}{
+			mcGlobal := createMC("global", map[string]any{
 				"highAvailability": true,
-				"modules": map[string]interface{}{
-					"https": map[string]interface{}{
-						"customCertificate": map[string]interface{}{
+				"modules": map[string]any{
+					"https": map[string]any{
+						"customCertificate": map[string]any{
 							"secretName": "secret",
 						},
 					},

--- a/dhctl/pkg/kubernetes/actions/deckhouse/log.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/log.go
@@ -188,8 +188,7 @@ func (d *LogPrinter) printErrorsForTask(ctx context.Context, taskID string, erro
 
 	logOptions := corev1.PodLogOptions{Container: "deckhouse", TailLines: int64Pointer(100)}
 	if !d.lastErrorTime.IsZero() {
-		t := metav1.NewTime(d.lastErrorTime)
-		logOptions = corev1.PodLogOptions{Container: "deckhouse", SinceTime: &t}
+		logOptions = corev1.PodLogOptions{Container: "deckhouse", SinceTime: new(metav1.NewTime(d.lastErrorTime))}
 	}
 	// kubelet certificate on master can be changed before finish Deckhouse installation
 	// and dhctl can not get logs from Deckhouse pod
@@ -354,10 +353,9 @@ func (d *LogPrinter) Print(ctx context.Context) (bool, error) {
 			d.printLogsByLine(ctx, result)
 
 			time.Sleep(time.Second)
-			currentTime := metav1.NewTime(time.Now())
 			logOptions = corev1.PodLogOptions{
 				Container: "deckhouse",
-				SinceTime: &currentTime,
+				SinceTime: new(metav1.NewTime(time.Now())),
 				// see above
 				InsecureSkipTLSVerifyBackend: true,
 			}
@@ -366,6 +364,5 @@ func (d *LogPrinter) Print(ctx context.Context) (bool, error) {
 }
 
 func int64Pointer(i int) *int64 {
-	r := int64(i)
-	return &r
+	return new(int64(i))
 }

--- a/dhctl/pkg/kubernetes/actions/deckhouse/log.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/log.go
@@ -52,7 +52,7 @@ type logLine struct {
 	Component string    `json:"operator.component,omitempty"`
 	TaskID    string    `json:"task.id,omitempty"`
 	Source    string    `json:"source,omitempty"`
-	Time      time.Time `json:"time,omitempty"`
+	Time      time.Time `json:"time"`
 }
 
 func (l *logLine) String() string {

--- a/dhctl/pkg/kubernetes/actions/deckhouse/module_config.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/module_config.go
@@ -47,10 +47,10 @@ func createModuleConfigManifestTask(kubeCl *client.KubernetesClient, mc *config.
 
 	return actions.ManifestTask{
 		Name: fmt.Sprintf(`ModuleConfig "%s"`, mc.GetName()),
-		Manifest: func() interface{} {
+		Manifest: func() any {
 			return mcUnstruct
 		},
-		CreateFunc: func(ctx context.Context, manifest interface{}) error {
+		CreateFunc: func(ctx context.Context, manifest any) error {
 			if createMsg != "" {
 				log.InfoLn(createMsg)
 			}
@@ -77,7 +77,7 @@ func createModuleConfigManifestTask(kubeCl *client.KubernetesClient, mc *config.
 
 			return err
 		},
-		UpdateFunc: func(ctx context.Context, manifest interface{}) error {
+		UpdateFunc: func(ctx context.Context, manifest any) error {
 			// fake client does not support cache
 			if _, ok := os.LookupEnv("DHCTL_TEST"); !ok {
 				// need for invalidate cache
@@ -122,7 +122,7 @@ func prepareModuleConfig(ctx context.Context, mc *config.ModuleConfig, res *Mani
 	}
 }
 
-func setSettingToModuleConfig(ctx context.Context, kubeCl *client.KubernetesClient, mcName string, value interface{}, field []string) error {
+func setSettingToModuleConfig(ctx context.Context, kubeCl *client.KubernetesClient, mcName string, value any, field []string) error {
 	log.DebugF("setSettingToModuleConfig for mc %s, field %v, value %v", mcName, field, value)
 
 	cm, err := kubeCl.Dynamic().Resource(config.ModuleConfigGVR).Get(ctx, mcName, metav1.GetOptions{})
@@ -185,7 +185,7 @@ func prepareGlobalMC(ctx context.Context, mc *config.ModuleConfig, res *Manifest
 
 	log.DebugLn("Found global mc. Trying to prepare...")
 
-	var httpsSettings map[string]interface{}
+	var httpsSettings map[string]any
 
 	modulesRaw, hasModules := mc.Spec.Settings["modules"]
 	if !hasModules {
@@ -193,7 +193,7 @@ func prepareGlobalMC(ctx context.Context, mc *config.ModuleConfig, res *Manifest
 		return
 	}
 
-	modules, ok := modulesRaw.(map[string]interface{})
+	modules, ok := modulesRaw.(map[string]any)
 	if !ok {
 		log.ErrorLn("modules is not a map in global mc. Finished preparing")
 		return
@@ -205,7 +205,7 @@ func prepareGlobalMC(ctx context.Context, mc *config.ModuleConfig, res *Manifest
 		return
 	}
 
-	httpsSettings, ok = HTTPSRaw.(map[string]interface{})
+	httpsSettings, ok = HTTPSRaw.(map[string]any)
 	if !ok {
 		log.ErrorLn("https is not a map in global mc. Finished preparing")
 		return

--- a/dhctl/pkg/kubernetes/actions/deckhouse/module_config_test.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/module_config_test.go
@@ -22,7 +22,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/utils/ptr"
 
 	sdk "github.com/deckhouse/module-sdk/pkg/utils"
 
@@ -31,7 +30,7 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 )
 
-func createMC(name string, settings map[string]interface{}) *config.ModuleConfig {
+func createMC(name string, settings map[string]any) *config.ModuleConfig {
 	mc := &config.ModuleConfig{}
 	mc.SetGroupVersionKind(schema.GroupVersionKind{
 		Group:   config.ModuleConfigGroup,
@@ -39,7 +38,7 @@ func createMC(name string, settings map[string]interface{}) *config.ModuleConfig
 		Kind:    config.ModuleConfigKind,
 	})
 	mc.SetName(name)
-	mc.Spec.Enabled = ptr.To(true)
+	mc.Spec.Enabled = new(true)
 	mc.Spec.Version = 1
 	mc.Spec.Settings = config.SettingsValues(settings)
 
@@ -55,7 +54,7 @@ func TestPrepareDeckhouseModuleConfig(t *testing.T) {
 			config.ModuleConfigGVR: "ModuleConfigList",
 		})
 
-		mc := createMC("deckhouse", map[string]interface{}{
+		mc := createMC("deckhouse", map[string]any{
 			"bundle":         "Minimal",
 			"logLevel":       "Debug",
 			"releaseChannel": "Alpha",
@@ -108,7 +107,7 @@ func TestPrepareDeckhouseModuleConfig(t *testing.T) {
 			config.ModuleConfigGVR: "ModuleConfigList",
 		})
 
-		mc := createMC("deckhouse", map[string]interface{}{
+		mc := createMC("deckhouse", map[string]any{
 			"bundle": "Minimal",
 		})
 
@@ -156,8 +155,8 @@ func TestPrepareGlobalModuleConfig(t *testing.T) {
 		https, found, err := unstructured.NestedMap(mc.Object, "spec", "settings", "modules", "https")
 		require.NoError(t, err)
 		require.True(t, found)
-		require.Equal(t, https, map[string]interface{}{
-			"customCertificate": map[string]interface{}{
+		require.Equal(t, https, map[string]any{
+			"customCertificate": map[string]any{
 				"secretName": "secret",
 			},
 		})
@@ -167,7 +166,7 @@ func TestPrepareGlobalModuleConfig(t *testing.T) {
 		require.Contains(t, mc.Spec.Settings, "modules")
 		require.NotContains(t, mc.Spec.Settings["modules"], "https")
 		require.True(t, mc.Spec.Settings["highAvailability"].(bool))
-		require.Equal(t, mc.Spec.Settings["modules"].(map[string]interface{})["publicDomainTemplate"], "template")
+		require.Equal(t, mc.Spec.Settings["modules"].(map[string]any)["publicDomainTemplate"], "template")
 	}
 
 	t.Run("ModuleConfig global with https setting and another modules settings should remove https from mc and adds to result task with returning https to with resources tasks", func(t *testing.T) {
@@ -176,11 +175,11 @@ func TestPrepareGlobalModuleConfig(t *testing.T) {
 				config.ModuleConfigGVR: "ModuleConfigList",
 			})
 
-			mc := createMC("global", map[string]interface{}{
+			mc := createMC("global", map[string]any{
 				"highAvailability": true,
-				"modules": map[string]interface{}{
-					"https": map[string]interface{}{
-						"customCertificate": map[string]interface{}{
+				"modules": map[string]any{
+					"https": map[string]any{
+						"customCertificate": map[string]any{
 							"secretName": "secret",
 						},
 					},
@@ -221,11 +220,11 @@ func TestPrepareGlobalModuleConfig(t *testing.T) {
 				config.ModuleConfigGVR: "ModuleConfigList",
 			})
 
-			mc := createMC("global", map[string]interface{}{
+			mc := createMC("global", map[string]any{
 				"highAvailability": true,
-				"modules": map[string]interface{}{
-					"https": map[string]interface{}{
-						"customCertificate": map[string]interface{}{
+				"modules": map[string]any{
+					"https": map[string]any{
+						"customCertificate": map[string]any{
 							"secretName": "secret",
 						},
 					},
@@ -265,9 +264,9 @@ func TestPrepareGlobalModuleConfig(t *testing.T) {
 			config.ModuleConfigGVR: "ModuleConfigList",
 		})
 
-		mc := createMC("global", map[string]interface{}{
+		mc := createMC("global", map[string]any{
 			"highAvailability": true,
-			"modules": map[string]interface{}{
+			"modules": map[string]any{
 				"publicDomainTemplate": "template",
 			},
 		})

--- a/dhctl/pkg/kubernetes/actions/deckhouse/pod.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/pod.go
@@ -62,8 +62,7 @@ func GetPod(ctx context.Context, kubeCl *client.KubernetesClient, leaderElection
 	}
 
 	if len(pods.Items) == 1 {
-		pod := pods.Items[0]
-		return &pod, nil
+		return new(pods.Items[0]), nil
 	}
 
 	return getLeaderElectionLeaseHolderPod(ctx, kubeCl, leaderElectionLeaseName, pods)
@@ -103,8 +102,7 @@ func getLeaderElectionLeaseHolderPod(
 
 	for _, pod := range pods.Items {
 		if pod.Name == strings.Split(*lease.Spec.HolderIdentity, ".")[0] {
-			podCopy := pod
-			return &podCopy, nil
+			return new(pod), nil
 		}
 	}
 

--- a/dhctl/pkg/kubernetes/actions/entity/node.go
+++ b/dhctl/pkg/kubernetes/actions/entity/node.go
@@ -292,13 +292,13 @@ func WaitForNodesBecomeReady(ctx context.Context, kubeCl *client.KubernetesClien
 			}
 
 			var message strings.Builder
-			message.WriteString(fmt.Sprintf("Nodes Ready %v of %v\n", len(readyNodes), desiredReadyNodes))
+			fmt.Fprintf(&message, "Nodes Ready %d of %d\n", len(readyNodes), desiredReadyNodes)
 			for _, node := range nodes.Items {
 				condition := "NotReady"
 				if _, ok := readyNodes[node.Name]; ok {
 					condition = "Ready"
 				}
-				message.WriteString(fmt.Sprintf("* %s | %s\n", node.Name, condition))
+				fmt.Fprintf(&message, "* %s | %s\n", node.Name, condition)
 			}
 
 			if len(readyNodes) >= desiredReadyNodes {
@@ -350,13 +350,13 @@ func WaitForNodesListBecomeReady(ctx context.Context, kubeCl *client.KubernetesC
 			}
 
 			var message strings.Builder
-			message.WriteString(fmt.Sprintf("Nodes Ready %v of %v\n", len(readyNodes), desiredReadyNodes))
+			fmt.Fprintf(&message, "Nodes Ready %d of %v\n", len(readyNodes), desiredReadyNodes)
 			for _, node := range nodesList.Items {
 				condition := "NotReady"
 				if _, ok := readyNodes[node.Name]; ok {
 					condition = "Ready"
 				}
-				message.WriteString(fmt.Sprintf("* %s | %s\n", node.Name, condition))
+				fmt.Fprintf(&message, "* %s | %s\n", node.Name, condition)
 			}
 
 			if len(readyNodes) >= desiredReadyNodes {

--- a/dhctl/pkg/kubernetes/actions/entity/node.go
+++ b/dhctl/pkg/kubernetes/actions/entity/node.go
@@ -146,7 +146,7 @@ func GetCloudConfig(ctx context.Context, kubeCl *client.KubernetesClient, nodeGr
 	})
 }
 
-func CreateNodeGroup(ctx context.Context, kubeCl *client.KubernetesClient, nodeGroupName string, logger log.Logger, data map[string]interface{}) error {
+func CreateNodeGroup(ctx context.Context, kubeCl *client.KubernetesClient, nodeGroupName string, logger log.Logger, data map[string]any) error {
 	doc := unstructured.Unstructured{}
 	doc.SetUnstructuredContent(data)
 
@@ -291,21 +291,22 @@ func WaitForNodesBecomeReady(ctx context.Context, kubeCl *client.KubernetesClien
 				}
 			}
 
-			message := fmt.Sprintf("Nodes Ready %v of %v\n", len(readyNodes), desiredReadyNodes)
+			var message strings.Builder
+			message.WriteString(fmt.Sprintf("Nodes Ready %v of %v\n", len(readyNodes), desiredReadyNodes))
 			for _, node := range nodes.Items {
 				condition := "NotReady"
 				if _, ok := readyNodes[node.Name]; ok {
 					condition = "Ready"
 				}
-				message += fmt.Sprintf("* %s | %s\n", node.Name, condition)
+				message.WriteString(fmt.Sprintf("* %s | %s\n", node.Name, condition))
 			}
 
 			if len(readyNodes) >= desiredReadyNodes {
-				log.InfoLn(message)
+				log.InfoLn(message.String())
 				return nil
 			}
 
-			return fmt.Errorf("%s", strings.TrimSuffix(message, "\n"))
+			return fmt.Errorf("%s", strings.TrimSuffix(message.String(), "\n"))
 		})
 }
 
@@ -348,26 +349,27 @@ func WaitForNodesListBecomeReady(ctx context.Context, kubeCl *client.KubernetesC
 				}
 			}
 
-			message := fmt.Sprintf("Nodes Ready %v of %v\n", len(readyNodes), desiredReadyNodes)
+			var message strings.Builder
+			message.WriteString(fmt.Sprintf("Nodes Ready %v of %v\n", len(readyNodes), desiredReadyNodes))
 			for _, node := range nodesList.Items {
 				condition := "NotReady"
 				if _, ok := readyNodes[node.Name]; ok {
 					condition = "Ready"
 				}
-				message += fmt.Sprintf("* %s | %s\n", node.Name, condition)
+				message.WriteString(fmt.Sprintf("* %s | %s\n", node.Name, condition))
 			}
 
 			if len(readyNodes) >= desiredReadyNodes {
-				log.InfoLn(message)
+				log.InfoLn(message.String())
 				return nil
 			}
 
-			return fmt.Errorf("%s", strings.TrimSuffix(message, "\n"))
+			return fmt.Errorf("%s", strings.TrimSuffix(message.String(), "\n"))
 		})
 }
 
-func GetNodeGroupTemplates(ctx context.Context, kubeCl *client.KubernetesClient) (map[string]map[string]interface{}, error) {
-	nodeTemplates := make(map[string]map[string]interface{})
+func GetNodeGroupTemplates(ctx context.Context, kubeCl *client.KubernetesClient) (map[string]map[string]any, error) {
+	nodeTemplates := make(map[string]map[string]any)
 
 	err := retry.NewLoop("Get NodeGroups node template settings", 50, 1*time.Second).
 		RunContext(ctx, func() error {
@@ -377,9 +379,9 @@ func GetNodeGroupTemplates(ctx context.Context, kubeCl *client.KubernetesClient)
 			}
 
 			for _, group := range nodeGroups.Items {
-				var nodeTemplate map[string]interface{}
-				if spec, ok := group.Object["spec"].(map[string]interface{}); ok {
-					nodeTemplate, _ = spec["nodeTemplate"].(map[string]interface{})
+				var nodeTemplate map[string]any
+				if spec, ok := group.Object["spec"].(map[string]any); ok {
+					nodeTemplate, _ = spec["nodeTemplate"].(map[string]any)
 					// if we do not set node template in cluster provider configuration
 					// we get nil node template from config,
 					// but k8s always returns empty map (not nil)

--- a/dhctl/pkg/kubernetes/actions/entity/node_user_test.go
+++ b/dhctl/pkg/kubernetes/actions/entity/node_user_test.go
@@ -16,6 +16,7 @@ package entity
 
 import (
 	"context"
+	"maps"
 	"testing"
 	"time"
 
@@ -470,9 +471,7 @@ func testCreateTestControlPlaneNodeWithAdditionalLabels(name string, labels map[
 		"some-annotation": "test",
 	})
 
-	for k, v := range labels {
-		n.labels[k] = v
-	}
+	maps.Copy(n.labels, labels)
 
 	return n
 }
@@ -482,9 +481,7 @@ func testCreateTestWorkerNodeWithAdditionalLabels(name string, labels map[string
 		"some-annotation-worker": "test",
 	})
 
-	for k, v := range labels {
-		n.labels[k] = v
-	}
+	maps.Copy(n.labels, labels)
 
 	return n
 }

--- a/dhctl/pkg/kubernetes/actions/manager/deployment.go
+++ b/dhctl/pkg/kubernetes/actions/manager/deployment.go
@@ -67,11 +67,11 @@ func checkAndRestartDeployment(ctx context.Context, kubeClProvider kubernetes.Ku
 			if err != nil {
 				return err
 			}
-			patch, err := json.Marshal(map[string]interface{}{
-				"spec": map[string]interface{}{
-					"template": map[string]interface{}{
-						"metadata": map[string]interface{}{
-							"annotations": map[string]interface{}{
+			patch, err := json.Marshal(map[string]any{
+				"spec": map[string]any{
+					"template": map[string]any{
+						"metadata": map[string]any{
+							"annotations": map[string]any{
 								"dhctl.deckhouse.io/restart-infra-deployment": time.Now().Format(time.RFC3339),
 							},
 						},

--- a/dhctl/pkg/kubernetes/actions/manifests/manifests.go
+++ b/dhctl/pkg/kubernetes/actions/manifests/manifests.go
@@ -16,6 +16,7 @@ package manifests
 
 import (
 	"fmt"
+	"maps"
 	"os"
 	"strings"
 	"time"
@@ -25,7 +26,6 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/ptr"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config/digests"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
@@ -175,7 +175,7 @@ func DeckhouseDeployment(params DeckhouseDeploymentParams) *appsv1.Deployment {
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
-			RevisionHistoryLimit: ptr.To(int32(0)),
+			RevisionHistoryLimit: new(int32(0)),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"app": "deckhouse",
@@ -200,7 +200,7 @@ func DeckhouseDeployment(params DeckhouseDeploymentParams) *appsv1.Deployment {
 			HostNetwork:                  true,
 			DNSPolicy:                    apiv1.DNSDefault,
 			ServiceAccountName:           "deckhouse",
-			AutomountServiceAccountToken: ptr.To(true),
+			AutomountServiceAccountToken: new(true),
 			// system-cluster-critical: protects the bootstrap pod from eviction
 			// under any node pressure while the cluster is being assembled, and
 			// gives it scheduling priority over everything else. The helm chart
@@ -208,9 +208,9 @@ func DeckhouseDeployment(params DeckhouseDeploymentParams) *appsv1.Deployment {
 			// Deployment with its own, priority does not change.
 			PriorityClassName: "system-cluster-critical",
 			SecurityContext: &apiv1.PodSecurityContext{
-				RunAsUser:    ptr.To(int64(0)),
-				RunAsGroup:   ptr.To(int64(0)),
-				RunAsNonRoot: ptr.To(false),
+				RunAsUser:    new(int64(0)),
+				RunAsGroup:   new(int64(0)),
+				RunAsNonRoot: new(false),
 			},
 			Tolerations: []apiv1.Toleration{
 				{Operator: apiv1.TolerationOpExists},
@@ -311,11 +311,11 @@ func DeckhouseDeployment(params DeckhouseDeploymentParams) *appsv1.Deployment {
 			},
 		},
 		SecurityContext: &apiv1.SecurityContext{
-			ReadOnlyRootFilesystem: ptr.To(true),
-			RunAsUser:              ptr.To(int64(0)),
-			RunAsGroup:             ptr.To(int64(0)),
-			RunAsNonRoot:           ptr.To(false),
-			Privileged:             ptr.To(true),
+			ReadOnlyRootFilesystem: new(true),
+			RunAsUser:              new(int64(0)),
+			RunAsGroup:             new(int64(0)),
+			RunAsNonRoot:           new(false),
+			Privileged:             new(true),
 		},
 	}
 
@@ -334,7 +334,7 @@ func DeckhouseDeployment(params DeckhouseDeploymentParams) *appsv1.Deployment {
 			},
 		},
 		SecurityContext: &apiv1.SecurityContext{
-			ReadOnlyRootFilesystem: ptr.To(true),
+			ReadOnlyRootFilesystem: new(true),
 		},
 	}
 
@@ -521,7 +521,7 @@ func DeckhouseServiceAccount() *apiv1.ServiceAccount {
 				"meta.helm.sh/release-namespace": "d8-system",
 			},
 		},
-		AutomountServiceAccountToken: ptr.To(false),
+		AutomountServiceAccountToken: new(false),
 	}
 }
 
@@ -613,9 +613,7 @@ func RegistryBashibleConfigSecret(data map[string][]byte) *apiv1.Secret {
 
 func generateSecret(name, namespace string, data map[string][]byte, labels map[string]string) *apiv1.Secret {
 	preparedLabels := make(map[string]string)
-	for key, value := range labels {
-		preparedLabels[key] = value
-	}
+	maps.Copy(preparedLabels, labels)
 	return &apiv1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -641,9 +639,9 @@ func SecretWithInfrastructureState(data []byte) *apiv1.Secret {
 	)
 }
 
-func PatchWithInfrastructureState(stateData []byte) interface{} {
-	return map[string]interface{}{
-		"data": map[string]interface{}{
+func PatchWithInfrastructureState(stateData []byte) any {
+	return map[string]any{
+		"data": map[string]any{
 			"cluster-tf-state.json": stateData,
 		},
 	}
@@ -711,9 +709,9 @@ func SecretWithNodeInfrastructureState(nodeName, nodeGroup string, data, setting
 	)
 }
 
-func PatchWithNodeInfrastructureState(stateData []byte) interface{} {
-	return map[string]interface{}{
-		"data": map[string]interface{}{
+func PatchWithNodeInfrastructureState(stateData []byte) any {
+	return map[string]any{
+		"data": map[string]any{
 			"node-tf-state.json": stateData,
 		},
 	}

--- a/dhctl/pkg/kubernetes/actions/resources/cluster_is_bootstrap.go
+++ b/dhctl/pkg/kubernetes/actions/resources/cluster_is_bootstrap.go
@@ -189,7 +189,8 @@ func (n *clusterIsBootstrapCheck) outputNodeGroups(ctx context.Context) string {
 	}
 
 	fs := "%-30s %-8s %-8s %-9s %-8s %-17s\n"
-	out := fmt.Sprintf(fs, "NAME", "READY", "NODES", "INSTANCES", "DESIRED", "STATUS")
+	var out strings.Builder
+	out.WriteString(fmt.Sprintf(fs, "NAME", "READY", "NODES", "INSTANCES", "DESIRED", "STATUS"))
 	for _, ng := range ngs {
 		stat := ng.Status
 		o := fmt.Sprintf(fs,
@@ -199,10 +200,10 @@ func (n *clusterIsBootstrapCheck) outputNodeGroups(ctx context.Context) string {
 			fmt.Sprint(stat.Instances),
 			fmt.Sprint(stat.Desired),
 			stat.Error)
-		out += o
+		out.WriteString(o)
 	}
 
-	return strings.TrimSuffix(out, "\n")
+	return strings.TrimSuffix(out.String(), "\n")
 }
 
 func (n *clusterIsBootstrapCheck) outputMachineFailures(ctx context.Context) {

--- a/dhctl/pkg/kubernetes/actions/resources/cluster_is_bootstrap.go
+++ b/dhctl/pkg/kubernetes/actions/resources/cluster_is_bootstrap.go
@@ -61,8 +61,7 @@ func (n *kubeNgGetter) NodeGroups(ctx context.Context) ([]*v1.NodeGroup, error) 
 	nodegroups := make([]*v1.NodeGroup, 0)
 	var errs error
 	for _, n := range ngs {
-		nn := n
-		ng, err := entity.UnstructuredToNodeGroup(&nn)
+		ng, err := entity.UnstructuredToNodeGroup(new(n))
 		if err != nil {
 			errs = multierr.Append(errs, err)
 			continue
@@ -190,7 +189,7 @@ func (n *clusterIsBootstrapCheck) outputNodeGroups(ctx context.Context) string {
 
 	fs := "%-30s %-8s %-8s %-9s %-8s %-17s\n"
 	var out strings.Builder
-	out.WriteString(fmt.Sprintf(fs, "NAME", "READY", "NODES", "INSTANCES", "DESIRED", "STATUS"))
+	fmt.Fprintf(&out, fs, "NAME", "READY", "NODES", "INSTANCES", "DESIRED", "STATUS")
 	for _, ng := range ngs {
 		stat := ng.Status
 		o := fmt.Sprintf(fs,

--- a/dhctl/pkg/kubernetes/actions/resources/readiness/checker.go
+++ b/dhctl/pkg/kubernetes/actions/resources/readiness/checker.go
@@ -20,7 +20,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/utils/ptr"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 )
@@ -157,17 +156,17 @@ type byConditionsParams struct {
 
 var kindsByConditions = map[string]byConditionsParams{
 	"Deployment": {
-		waitAttemptsBeforeCheck: ptr.To(3),
+		waitAttemptsBeforeCheck: new(3),
 		conditionsForCheck:      availableConditions,
 		checkAll:                false,
 	},
 	"APIService": {
-		waitAttemptsBeforeCheck: ptr.To(2),
+		waitAttemptsBeforeCheck: new(2),
 		conditionsForCheck:      availableConditions,
 		checkAll:                false,
 	},
 	"NodeGroup": {
-		waitAttemptsBeforeCheck: ptr.To(5),
+		waitAttemptsBeforeCheck: new(5),
 		conditionsForCheck: Conditions{
 			readyCondition: trueCondition,
 		},

--- a/dhctl/pkg/kubernetes/actions/resources/resources.go
+++ b/dhctl/pkg/kubernetes/actions/resources/resources.go
@@ -260,14 +260,14 @@ func (c *Creator) createSingleResource(ctx context.Context, resource *template.R
 		namespace := docCopy.GetNamespace()
 		manifestTask := actions.ManifestTask{
 			Name:     getUnstructuredName(docCopy),
-			Manifest: func() interface{} { return nil },
-			CreateFunc: func(ctx context.Context, manifest interface{}) error {
+			Manifest: func() any { return nil },
+			CreateFunc: func(ctx context.Context, manifest any) error {
 				_, err := c.kubeCl.Dynamic().Resource(*gvr).
 					Namespace(namespace).
 					Create(ctx, docCopy, metav1.CreateOptions{})
 				return err
 			},
-			UpdateFunc: func(ctx context.Context, manifest interface{}) error {
+			UpdateFunc: func(ctx context.Context, manifest any) error {
 				content, err := docCopy.MarshalJSON()
 				if err != nil {
 					return err

--- a/dhctl/pkg/kubernetes/actions/resources/resources.go
+++ b/dhctl/pkg/kubernetes/actions/resources/resources.go
@@ -119,13 +119,13 @@ func (c *Creator) createAll(ctx context.Context) error {
 
 	for indx, resource := range c.resources {
 		if _, shouldSkip := resourcesToSkipInCurrentIteration[indx]; shouldSkip {
-			log.DebugF("Resource %s with index % should be skipped from creation in the current iteration because the namespace does not exist\n", resource.String())
+			log.DebugF("Resource %s with index %d should be skipped from creation in the current iteration because the namespace does not exist\n", resource.String(), indx)
 			continue
 		}
 
 		resourcesList, err := apiResourceGetter.Get(ctx, &resource.GVK)
 		if err != nil {
-			log.DebugF("apiResourceGetter returns error: %w\n", err)
+			log.DebugF("apiResourceGetter returns error: %v\n", err)
 			continue
 		}
 

--- a/dhctl/pkg/kubernetes/actions/resources/waiter.go
+++ b/dhctl/pkg/kubernetes/actions/resources/waiter.go
@@ -45,7 +45,7 @@ func GetCheckers(kubeCl *client.KubernetesClient, resources template.Resources, 
 	errRes := &multierror.Error{}
 
 	checkers := make([]Checker, 0)
-	singleConstructors := make(map[string]interface{})
+	singleConstructors := make(map[string]any)
 
 	tryToAppendCheck := func(check Checker, err error) {
 		if err != nil {

--- a/dhctl/pkg/kubernetes/actions/task.go
+++ b/dhctl/pkg/kubernetes/actions/task.go
@@ -27,10 +27,10 @@ import (
 
 type ManifestTask struct {
 	Name       string
-	CreateFunc func(ctx context.Context, manifest interface{}) error
-	UpdateFunc func(ctx context.Context, manifest interface{}) error
-	Manifest   func() interface{}
-	PatchData  func() interface{}
+	CreateFunc func(ctx context.Context, manifest any) error
+	UpdateFunc func(ctx context.Context, manifest any) error
+	Manifest   func() any
+	PatchData  func() any
 	PatchFunc  func(ctx context.Context, patchData []byte) error
 }
 

--- a/dhctl/pkg/kubernetes/client/informer.go
+++ b/dhctl/pkg/kubernetes/client/informer.go
@@ -93,19 +93,19 @@ func (p *DeploymentInformer) CreateSharedInformer() error {
 	return nil
 }
 
-func (p *DeploymentInformer) OnAdd(obj interface{}, _ bool) {
+func (p *DeploymentInformer) OnAdd(obj any, _ bool) {
 	p.HandleWatchEvent(obj, "Added")
 }
 
-func (p *DeploymentInformer) OnUpdate(oldObj, newObj interface{}) {
+func (p *DeploymentInformer) OnUpdate(oldObj, newObj any) {
 	p.HandleWatchEvent(newObj, "Modified")
 }
 
-func (p *DeploymentInformer) OnDelete(obj interface{}) {
+func (p *DeploymentInformer) OnDelete(obj any) {
 	p.HandleWatchEvent(obj, "Deleted")
 }
 
-func (p *DeploymentInformer) HandleWatchEvent(object interface{}, eventType string) {
+func (p *DeploymentInformer) HandleWatchEvent(object any, eventType string) {
 	if staleObj, stale := object.(cache.DeletedFinalStateUnknown); stale {
 		object = staleObj.Obj
 	}
@@ -163,19 +163,19 @@ func (p *CRDInformer) CreateSharedInformer() error {
 	return nil
 }
 
-func (p *CRDInformer) OnAdd(obj interface{}, _ bool) {
+func (p *CRDInformer) OnAdd(obj any, _ bool) {
 	p.HandleWatchEvent(obj, "Added")
 }
 
-func (p *CRDInformer) OnUpdate(oldObj, newObj interface{}) {
+func (p *CRDInformer) OnUpdate(oldObj, newObj any) {
 	p.HandleWatchEvent(newObj, "Modified")
 }
 
-func (p *CRDInformer) OnDelete(obj interface{}) {
+func (p *CRDInformer) OnDelete(obj any) {
 	p.HandleWatchEvent(obj, "Deleted")
 }
 
-func (p *CRDInformer) HandleWatchEvent(object interface{}, eventType string) {
+func (p *CRDInformer) HandleWatchEvent(object any, eventType string) {
 	if staleObj, stale := object.(cache.DeletedFinalStateUnknown); stale {
 		object = staleObj.Obj
 	}

--- a/dhctl/pkg/kubernetes/client/state_cache.go
+++ b/dhctl/pkg/kubernetes/client/state_cache.go
@@ -20,6 +20,7 @@ import (
 	"encoding/base64"
 	"encoding/gob"
 	"fmt"
+	"maps"
 	"path/filepath"
 	"sort"
 	"time"
@@ -118,9 +119,7 @@ func (c *StateCache) populateSecret(ctx context.Context) (*v1.Secret, error) {
 		labelKey("cluster-name"): c.secretName,
 	}
 
-	for k, v := range c.labels {
-		preparedLabels[k] = v
-	}
+	maps.Copy(preparedLabels, c.labels)
 
 	err = retry.NewSilentLoop("save cache secret", 6, 1*time.Second).Run(func() error {
 		var err error
@@ -197,7 +196,7 @@ func (c *StateCache) Save(ctx context.Context, name string, content []byte) erro
 	)
 }
 
-func (c *StateCache) SaveStruct(ctx context.Context, name string, v interface{}) error {
+func (c *StateCache) SaveStruct(ctx context.Context, name string, v any) error {
 	b := new(bytes.Buffer)
 	err := gob.NewEncoder(b).Encode(v)
 	if err != nil {
@@ -217,7 +216,7 @@ func (c *StateCache) Load(ctx context.Context, name string) ([]byte, error) {
 	return c.get(s, name)
 }
 
-func (c *StateCache) LoadStruct(ctx context.Context, name string, v interface{}) error {
+func (c *StateCache) LoadStruct(ctx context.Context, name string, v any) error {
 	d, err := c.Load(ctx, name)
 	if err != nil {
 		return err

--- a/dhctl/pkg/log/deprecated.go
+++ b/dhctl/pkg/log/deprecated.go
@@ -133,29 +133,29 @@ func (d *DummyLogger) LogProcess(_, t string, run func() error) error {
 	return err
 }
 
-func (d *DummyLogger) LogInfoF(format string, a ...interface{}) {
+func (d *DummyLogger) LogInfoF(format string, a ...any) {
 	fmt.Printf(format, a...)
 }
 
-func (d *DummyLogger) LogInfoLn(a ...interface{}) {
+func (d *DummyLogger) LogInfoLn(a ...any) {
 	fmt.Println(a...)
 }
 
-func (d *DummyLogger) LogErrorF(format string, a ...interface{}) {
+func (d *DummyLogger) LogErrorF(format string, a ...any) {
 	fmt.Printf(format, a...)
 }
 
-func (d *DummyLogger) LogErrorLn(a ...interface{}) {
+func (d *DummyLogger) LogErrorLn(a ...any) {
 	fmt.Println(a...)
 }
 
-func (d *DummyLogger) LogDebugF(format string, a ...interface{}) {
+func (d *DummyLogger) LogDebugF(format string, a ...any) {
 	if debugEnabled {
 		fmt.Printf(format, a...)
 	}
 }
 
-func (d *DummyLogger) LogDebugLn(a ...interface{}) {
+func (d *DummyLogger) LogDebugLn(a ...any) {
 	if debugEnabled {
 		fmt.Println(a...)
 	}
@@ -173,11 +173,11 @@ func (d *DummyLogger) LogFailRetry(l string) {
 	d.LogFail(l)
 }
 
-func (d *DummyLogger) LogWarnLn(a ...interface{}) {
+func (d *DummyLogger) LogWarnLn(a ...any) {
 	fmt.Println(a...)
 }
 
-func (d *DummyLogger) LogWarnF(format string, a ...interface{}) {
+func (d *DummyLogger) LogWarnF(format string, a ...any) {
 	fmt.Printf(format, a...)
 }
 
@@ -219,35 +219,35 @@ func (w *externalDummyLoggerWrapper) Process(p external.Process, title string, a
 	return w.parent.LogProcess(string(p), title, action)
 }
 
-func (w *externalDummyLoggerWrapper) InfoFWithoutLn(format string, a ...interface{}) {
+func (w *externalDummyLoggerWrapper) InfoFWithoutLn(format string, a ...any) {
 	w.parent.LogInfoF(format, a...)
 }
 
-func (w *externalDummyLoggerWrapper) InfoLn(a ...interface{}) {
+func (w *externalDummyLoggerWrapper) InfoLn(a ...any) {
 	w.parent.LogInfoLn(a...)
 }
 
-func (w *externalDummyLoggerWrapper) ErrorFWithoutLn(format string, a ...interface{}) {
+func (w *externalDummyLoggerWrapper) ErrorFWithoutLn(format string, a ...any) {
 	w.parent.LogErrorF(format, a...)
 }
 
-func (w *externalDummyLoggerWrapper) ErrorLn(a ...interface{}) {
+func (w *externalDummyLoggerWrapper) ErrorLn(a ...any) {
 	w.parent.LogErrorLn(a...)
 }
 
-func (w *externalDummyLoggerWrapper) DebugFWithoutLn(format string, a ...interface{}) {
+func (w *externalDummyLoggerWrapper) DebugFWithoutLn(format string, a ...any) {
 	w.parent.LogDebugF(format, a...)
 }
 
-func (w *externalDummyLoggerWrapper) DebugLn(a ...interface{}) {
+func (w *externalDummyLoggerWrapper) DebugLn(a ...any) {
 	w.parent.LogDebugLn(a...)
 }
 
-func (w *externalDummyLoggerWrapper) WarnFWithoutLn(format string, a ...interface{}) {
+func (w *externalDummyLoggerWrapper) WarnFWithoutLn(format string, a ...any) {
 	w.parent.LogWarnF(format, a...)
 }
 
-func (w *externalDummyLoggerWrapper) WarnLn(a ...interface{}) {
+func (w *externalDummyLoggerWrapper) WarnLn(a ...any) {
 	w.parent.LogWarnLn(a...)
 }
 

--- a/dhctl/pkg/log/deprecated_in_memory.go
+++ b/dhctl/pkg/log/deprecated_in_memory.go
@@ -162,42 +162,42 @@ func (l *InMemoryLogger) LogProcess(p, t string, action func() error) error {
 	return err
 }
 
-func (l *InMemoryLogger) LogInfoF(format string, a ...interface{}) {
+func (l *InMemoryLogger) LogInfoF(format string, a ...any) {
 	l.writeEntityFormatted(format, a...)
 	l.parent.LogInfoF(format, a...)
 }
 
-func (l *InMemoryLogger) LogInfoLn(a ...interface{}) {
+func (l *InMemoryLogger) LogInfoLn(a ...any) {
 	l.writeEntityFormatted("%v\n", a)
 	l.parent.LogInfoLn(a...)
 }
 
-func (l *InMemoryLogger) LogErrorF(format string, a ...interface{}) {
+func (l *InMemoryLogger) LogErrorF(format string, a ...any) {
 	l.writeEntityWithPrefix(l.errorPrefix, format, a...)
 	l.parent.LogErrorF(format, a...)
 }
 
-func (l *InMemoryLogger) LogErrorLn(a ...interface{}) {
+func (l *InMemoryLogger) LogErrorLn(a ...any) {
 	l.writeEntityWithPrefix(l.errorPrefix, "%v\n", a)
 	l.parent.LogErrorLn(a...)
 }
 
-func (l *InMemoryLogger) LogDebugF(format string, a ...interface{}) {
+func (l *InMemoryLogger) LogDebugF(format string, a ...any) {
 	l.writeEntityWithPrefix(l.debugPrefix, format, a...)
 	l.parent.LogDebugF(format, a...)
 }
 
-func (l *InMemoryLogger) LogDebugLn(a ...interface{}) {
+func (l *InMemoryLogger) LogDebugLn(a ...any) {
 	l.writeEntityWithPrefix(l.debugPrefix, "%v\n", a)
 	l.parent.LogDebugLn(a...)
 }
 
-func (l *InMemoryLogger) LogWarnF(format string, a ...interface{}) {
+func (l *InMemoryLogger) LogWarnF(format string, a ...any) {
 	l.writeEntityFormatted(format, a...)
 	l.parent.LogWarnF(format, a...)
 }
 
-func (l *InMemoryLogger) LogWarnLn(a ...interface{}) {
+func (l *InMemoryLogger) LogWarnLn(a ...any) {
 	l.writeEntityFormatted("%v\n", a)
 	l.parent.LogWarnLn(a...)
 }

--- a/dhctl/pkg/log/interactive.go
+++ b/dhctl/pkg/log/interactive.go
@@ -164,7 +164,7 @@ func (i *InteractiveLogger) LogProcess(p, t string, run func() error) error {
 	return nil
 }
 
-func (i *InteractiveLogger) LogInfoF(format string, a ...interface{}) {
+func (i *InteractiveLogger) LogInfoF(format string, a ...any) {
 	if i.interactive {
 		i.logger.DebugF(format, a...)
 		if i.pbStarted {
@@ -175,7 +175,7 @@ func (i *InteractiveLogger) LogInfoF(format string, a ...interface{}) {
 	}
 }
 
-func (i *InteractiveLogger) LogInfoLn(a ...interface{}) {
+func (i *InteractiveLogger) LogInfoLn(a ...any) {
 	if i.interactive {
 		i.logger.DebugLn(a...)
 		if i.pbStarted {
@@ -186,7 +186,7 @@ func (i *InteractiveLogger) LogInfoLn(a ...interface{}) {
 	}
 }
 
-func (i *InteractiveLogger) LogErrorF(format string, a ...interface{}) {
+func (i *InteractiveLogger) LogErrorF(format string, a ...any) {
 	if i.interactive {
 		i.logger.DebugF(format, a...)
 		if i.pbStarted {
@@ -197,7 +197,7 @@ func (i *InteractiveLogger) LogErrorF(format string, a ...interface{}) {
 	}
 }
 
-func (i *InteractiveLogger) LogErrorLn(a ...interface{}) {
+func (i *InteractiveLogger) LogErrorLn(a ...any) {
 	if i.interactive {
 		i.logger.DebugLn(a...)
 		if i.pbStarted {
@@ -208,11 +208,11 @@ func (i *InteractiveLogger) LogErrorLn(a ...interface{}) {
 	}
 }
 
-func (i *InteractiveLogger) LogDebugF(format string, a ...interface{}) {
+func (i *InteractiveLogger) LogDebugF(format string, a ...any) {
 	i.logger.DebugF(format, a...)
 }
 
-func (i *InteractiveLogger) LogDebugLn(a ...interface{}) {
+func (i *InteractiveLogger) LogDebugLn(a ...any) {
 	i.logger.DebugF("%v", a...)
 }
 
@@ -234,7 +234,7 @@ func (i *InteractiveLogger) LogFailRetry(l string) {
 	}
 }
 
-func (i *InteractiveLogger) LogWarnLn(a ...interface{}) {
+func (i *InteractiveLogger) LogWarnLn(a ...any) {
 	if i.interactive {
 		i.logger.DebugF("%v", a...)
 		if i.pbStarted {
@@ -245,7 +245,7 @@ func (i *InteractiveLogger) LogWarnLn(a ...interface{}) {
 	}
 }
 
-func (i *InteractiveLogger) LogWarnF(format string, a ...interface{}) {
+func (i *InteractiveLogger) LogWarnF(format string, a ...any) {
 	if i.interactive {
 		i.logger.DebugF(format, a...)
 		if i.pbStarted {
@@ -397,7 +397,7 @@ func (i *InteractiveLoggerWrapper) Process(p external.Process, t string, run fun
 	return nil
 }
 
-func (i *InteractiveLoggerWrapper) InfoFWithoutLn(format string, a ...interface{}) {
+func (i *InteractiveLoggerWrapper) InfoFWithoutLn(format string, a ...any) {
 	if i.interactive {
 		i.logger.DebugFWithoutLn(format, a...)
 		if isPbStarted() {
@@ -408,7 +408,7 @@ func (i *InteractiveLoggerWrapper) InfoFWithoutLn(format string, a ...interface{
 	}
 }
 
-func (i *InteractiveLoggerWrapper) InfoLn(a ...interface{}) {
+func (i *InteractiveLoggerWrapper) InfoLn(a ...any) {
 	if i.interactive {
 		i.logger.DebugLn(a...)
 		if isPbStarted() {
@@ -419,7 +419,7 @@ func (i *InteractiveLoggerWrapper) InfoLn(a ...interface{}) {
 	}
 }
 
-func (i *InteractiveLoggerWrapper) InfoF(format string, a ...interface{}) {
+func (i *InteractiveLoggerWrapper) InfoF(format string, a ...any) {
 	if i.interactive {
 		i.logger.DebugF(format, a...)
 		if isPbStarted() {
@@ -430,7 +430,7 @@ func (i *InteractiveLoggerWrapper) InfoF(format string, a ...interface{}) {
 	}
 }
 
-func (i *InteractiveLoggerWrapper) ErrorFWithoutLn(format string, a ...interface{}) {
+func (i *InteractiveLoggerWrapper) ErrorFWithoutLn(format string, a ...any) {
 	if i.interactive {
 		i.logger.DebugFWithoutLn(format, a...)
 		if isPbStarted() {
@@ -441,7 +441,7 @@ func (i *InteractiveLoggerWrapper) ErrorFWithoutLn(format string, a ...interface
 	}
 }
 
-func (i *InteractiveLoggerWrapper) ErrorLn(a ...interface{}) {
+func (i *InteractiveLoggerWrapper) ErrorLn(a ...any) {
 	if i.interactive {
 		i.logger.DebugLn(a...)
 		if isPbStarted() {
@@ -452,7 +452,7 @@ func (i *InteractiveLoggerWrapper) ErrorLn(a ...interface{}) {
 	}
 }
 
-func (i *InteractiveLoggerWrapper) ErrorF(format string, a ...interface{}) {
+func (i *InteractiveLoggerWrapper) ErrorF(format string, a ...any) {
 	if i.interactive {
 		i.logger.DebugF(format, a...)
 		if isPbStarted() {
@@ -463,19 +463,19 @@ func (i *InteractiveLoggerWrapper) ErrorF(format string, a ...interface{}) {
 	}
 }
 
-func (i *InteractiveLoggerWrapper) DebugFWithoutLn(format string, a ...interface{}) {
+func (i *InteractiveLoggerWrapper) DebugFWithoutLn(format string, a ...any) {
 	i.logger.DebugFWithoutLn(format, a...)
 }
 
-func (i *InteractiveLoggerWrapper) DebugLn(a ...interface{}) {
+func (i *InteractiveLoggerWrapper) DebugLn(a ...any) {
 	i.logger.DebugLn(a...)
 }
 
-func (i *InteractiveLoggerWrapper) DebugF(format string, a ...interface{}) {
+func (i *InteractiveLoggerWrapper) DebugF(format string, a ...any) {
 	i.logger.DebugF(format, a...)
 }
 
-func (i *InteractiveLoggerWrapper) WarnFWithoutLn(format string, a ...interface{}) {
+func (i *InteractiveLoggerWrapper) WarnFWithoutLn(format string, a ...any) {
 	if i.interactive {
 		i.logger.DebugFWithoutLn(format, a...)
 		if isPbStarted() {
@@ -486,7 +486,7 @@ func (i *InteractiveLoggerWrapper) WarnFWithoutLn(format string, a ...interface{
 	}
 }
 
-func (i *InteractiveLoggerWrapper) WarnLn(a ...interface{}) {
+func (i *InteractiveLoggerWrapper) WarnLn(a ...any) {
 	if i.interactive {
 		i.logger.DebugLn(a...)
 		if isPbStarted() {
@@ -497,7 +497,7 @@ func (i *InteractiveLoggerWrapper) WarnLn(a ...interface{}) {
 	}
 }
 
-func (i *InteractiveLoggerWrapper) WarnF(format string, a ...interface{}) {
+func (i *InteractiveLoggerWrapper) WarnF(format string, a ...any) {
 	if i.interactive {
 		i.logger.DebugF(format, a...)
 		if isPbStarted() {

--- a/dhctl/pkg/log/logger.go
+++ b/dhctl/pkg/log/logger.go
@@ -55,17 +55,17 @@ type Logger interface {
 	LogProcessCtx(context.Context, string, string, func(context.Context) error) error
 	LogProcess(string, string, func() error) error
 
-	LogInfoF(format string, a ...interface{})
-	LogInfoLn(a ...interface{})
+	LogInfoF(format string, a ...any)
+	LogInfoLn(a ...any)
 
-	LogErrorF(format string, a ...interface{})
-	LogErrorLn(a ...interface{})
+	LogErrorF(format string, a ...any)
+	LogErrorLn(a ...any)
 
-	LogDebugF(format string, a ...interface{})
-	LogDebugLn(a ...interface{})
+	LogDebugF(format string, a ...any)
+	LogDebugLn(a ...any)
 
-	LogWarnF(format string, a ...interface{})
-	LogWarnLn(a ...interface{})
+	LogWarnF(format string, a ...any)
+	LogWarnLn(a ...any)
 
 	LogSuccess(string)
 	LogFail(string)
@@ -289,27 +289,27 @@ func (e *ExternalLogger) LogProcess(p, t string, run func() error) error {
 	return e.logger.Process(external.Process(p), t, run)
 }
 
-func (e *ExternalLogger) LogInfoF(format string, a ...interface{}) {
+func (e *ExternalLogger) LogInfoF(format string, a ...any) {
 	e.logger.InfoFWithoutLn(format, a...)
 }
 
-func (e *ExternalLogger) LogInfoLn(a ...interface{}) {
+func (e *ExternalLogger) LogInfoLn(a ...any) {
 	e.logger.InfoLn(a...)
 }
 
-func (e *ExternalLogger) LogErrorF(format string, a ...interface{}) {
+func (e *ExternalLogger) LogErrorF(format string, a ...any) {
 	e.logger.ErrorF(format, a...)
 }
 
-func (e *ExternalLogger) LogErrorLn(a ...interface{}) {
+func (e *ExternalLogger) LogErrorLn(a ...any) {
 	e.logger.ErrorF("%v", a...)
 }
 
-func (e *ExternalLogger) LogDebugF(format string, a ...interface{}) {
+func (e *ExternalLogger) LogDebugF(format string, a ...any) {
 	e.logger.DebugF(format, a...)
 }
 
-func (e *ExternalLogger) LogDebugLn(a ...interface{}) {
+func (e *ExternalLogger) LogDebugLn(a ...any) {
 	e.logger.DebugF("%v", a...)
 }
 
@@ -325,11 +325,11 @@ func (e *ExternalLogger) LogFailRetry(l string) {
 	e.logger.FailRetry(l)
 }
 
-func (e *ExternalLogger) LogWarnLn(a ...interface{}) {
+func (e *ExternalLogger) LogWarnLn(a ...any) {
 	e.logger.WarnF("%s", a...)
 }
 
-func (e *ExternalLogger) LogWarnF(format string, a ...interface{}) {
+func (e *ExternalLogger) LogWarnF(format string, a ...any) {
 	e.logger.WarnFWithoutLn(format, a...)
 }
 
@@ -353,27 +353,27 @@ func Process(p, t string, run func() error) error {
 	return defaultLogger.LogProcess(p, t, run)
 }
 
-func InfoF(format string, a ...interface{}) {
+func InfoF(format string, a ...any) {
 	defaultLogger.LogInfoF(format, a...)
 }
 
-func InfoLn(a ...interface{}) {
+func InfoLn(a ...any) {
 	defaultLogger.LogInfoLn(a...)
 }
 
-func ErrorF(format string, a ...interface{}) {
+func ErrorF(format string, a ...any) {
 	defaultLogger.LogErrorF(format, a...)
 }
 
-func ErrorLn(a ...interface{}) {
+func ErrorLn(a ...any) {
 	defaultLogger.LogErrorLn(a...)
 }
 
-func DebugF(format string, a ...interface{}) {
+func DebugF(format string, a ...any) {
 	defaultLogger.LogDebugF(format, a...)
 }
 
-func DebugLn(a ...interface{}) {
+func DebugLn(a ...any) {
 	defaultLogger.LogDebugLn(a...)
 }
 
@@ -385,11 +385,11 @@ func Fail(l string) {
 	defaultLogger.LogFail(l)
 }
 
-func WarnF(format string, a ...interface{}) {
+func WarnF(format string, a ...any) {
 	defaultLogger.LogWarnF(format, a...)
 }
 
-func WarnLn(a ...interface{}) {
+func WarnLn(a ...any) {
 	defaultLogger.LogWarnLn(a...)
 }
 

--- a/dhctl/pkg/operations/bootstrap/bashible/runner.go
+++ b/dhctl/pkg/operations/bootstrap/bashible/runner.go
@@ -238,8 +238,7 @@ func (r *Runner) attemptExecuteBundle(
 
 	_, err := bundleCmd.ExecuteBundle(ctx, parentDir, bundleDir)
 	if err != nil {
-		var ee *exec.ExitError
-		if errors.As(err, &ee) {
+		if ee, ok := errors.AsType[*exec.ExitError](err); ok {
 			return fmt.Errorf("bundle '%s' error: %w\nstderr: %s", bundleDir, err, string(ee.Stderr))
 		}
 
@@ -320,9 +319,8 @@ func (r *Runner) runCmd(ctx context.Context, cmd libcon.Command, desc string) er
 	cmd.Sudo(ctx)
 	cmd.WithTimeout(10 * time.Second)
 	if err := cmd.Run(ctx); err != nil {
-		var ee *exec.ExitError
 		// ssh exits with the exit status of the remote command or with 255 if an error occurred.
-		if errors.As(err, &ee) {
+		if ee, ok := errors.AsType[*exec.ExitError](err); ok {
 			logger.DebugF("'%s' got exit code: %d and stderr %s", desc, ee.ExitCode(), string(ee.Stderr))
 			if ee.ExitCode() == 255 {
 				return err

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
@@ -200,7 +200,7 @@ type bootstrapContext struct {
 	bootstrapState          *State
 	nodeIP                  string
 	devicePath              string
-	resourcesTemplateData   map[string]interface{}
+	resourcesTemplateData   map[string]any
 	resourcesToCreateBefore template.Resources
 	resourcesToCreateAfter  template.Resources
 	installDeckhouseResult  *InstallDeckhouseResult
@@ -500,13 +500,13 @@ func (b *ClusterBootstrapper) bootstrapBaseInfra(ctx context.Context, bctx *boot
 			log.DebugLn("Base infrastructure was created")
 			b.PhasedExecutionContext.CompleteSubPhase(phases.BaseInfraSubPhaseBaseInfra)
 
-			var cloudDiscoveryData map[string]interface{}
+			var cloudDiscoveryData map[string]any
 			err = json.Unmarshal(baseOutputs.CloudDiscovery, &cloudDiscoveryData)
 			if err != nil {
 				return err
 			}
 
-			bctx.resourcesTemplateData = map[string]interface{}{
+			bctx.resourcesTemplateData = map[string]any{
 				"cloudDiscovery": cloudDiscoveryData,
 			}
 

--- a/dhctl/pkg/operations/bootstrap/deps/check.go
+++ b/dhctl/pkg/operations/bootstrap/deps/check.go
@@ -62,7 +62,7 @@ var (
 		"join", "cat", "ps", "kill",
 	}
 
-	checkDepsDefaultOpts = retry.AttemptsWithWaitOpts(50, 1*time.Second)
+	checkDepsDefaultOpts = retry.AttemptsWithWaitOpts(10, 5*time.Second)
 )
 
 func NewDependenciesChecker(nodeInterface libcon.Interface, loggerProvider log.LoggerProvider) *DependenciesChecker {
@@ -264,8 +264,7 @@ func (c *DependenciesChecker) sshErrorBreakPredicate(err error) bool {
 	if err == nil {
 		return true
 	}
-	var ee *exec.ExitError
-	if errors.As(err, &ee) && ee.ExitCode() == 255 {
+	if ee, ok := errors.AsType[*exec.ExitError](err); ok && ee.ExitCode() == 255 {
 		c.loggerProvider().WarnF("SSH connection failed (exit 255), retrying in 1 second...")
 		return false
 	}

--- a/dhctl/pkg/operations/bootstrap/steps_bashible.go
+++ b/dhctl/pkg/operations/bootstrap/steps_bashible.go
@@ -232,8 +232,7 @@ func prepareMasterNode(ctx context.Context, nodeInterface libcon.Interface, cont
 		if err != nil {
 			stderr := ""
 
-			var exitErr *exec.ExitError
-			if errors.As(err, &exitErr) {
+			if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
 				stderr = string(exitErr.Stderr)
 			}
 

--- a/dhctl/pkg/operations/check/check.go
+++ b/dhctl/pkg/operations/check/check.go
@@ -68,7 +68,7 @@ type NodeGroupCheckResult struct {
 type Statistics struct {
 	Node               []NodeCheckResult                     `json:"nodes,omitempty"`
 	NodeTemplates      []NodeGroupCheckResult                `json:"node_templates,omitempty"`
-	Cluster            ClusterCheckResult                    `json:"cluster,omitempty"`
+	Cluster            ClusterCheckResult                    `json:"cluster"`
 	InfrastructurePlan []plan.Plan                           `json:"terraform_plan,omitempty"`
 	TerraformVersion   *infrastructurestate.TerraformVersion `json:"terraform_version,omitempty"`
 }
@@ -515,7 +515,7 @@ func CheckState(
 
 func expectedNodeNames(cfg *config.MetaConfig, nodeGroupName string, replicas int) []string {
 	names := make([]string, 0, replicas)
-	for i := 0; i < replicas; i++ {
+	for i := range replicas {
 		names = append(names, fmt.Sprintf("%s-%s-%v", cfg.ClusterPrefix, nodeGroupName, i))
 	}
 

--- a/dhctl/pkg/operations/check/destructive_change_id_test.go
+++ b/dhctl/pkg/operations/check/destructive_change_id_test.go
@@ -269,7 +269,6 @@ func TestDestructiveChangeID(t *testing.T) {
 	}
 
 	for name, tt := range tests {
-		tt := tt
 		t.Run(name, func(t *testing.T) {
 			id, err := destructiveChangeID(tt.statistics)
 			require.NoError(t, err)

--- a/dhctl/pkg/operations/commander/attach/attacher.go
+++ b/dhctl/pkg/operations/commander/attach/attacher.go
@@ -444,6 +444,6 @@ type nodeState struct {
 	Outputs struct {
 		MasterIPAddressForSSH struct {
 			Value string `json:"value,omitempty"`
-		} `json:"master_ip_address_for_ssh,omitempty"`
-	} `json:"outputs,omitempty"`
+		} `json:"master_ip_address_for_ssh"`
+	} `json:"outputs"`
 }

--- a/dhctl/pkg/operations/commander/helpers.go
+++ b/dhctl/pkg/operations/commander/helpers.go
@@ -69,17 +69,17 @@ func CheckShouldUpdateCommanderUUID(ctx context.Context, kubeCl *client.Kubernet
 func ConstructManagedByCommanderConfigMapTask(ctx context.Context, commanderUUID uuid.UUID, kubeCl *client.KubernetesClient) actions.ManifestTask {
 	return actions.ManifestTask{
 		Name: `ConfigMap "d8-commander-uuid"`,
-		Manifest: func() interface{} {
+		Manifest: func() any {
 			return manifests.CommanderUUIDConfigMap(commanderUUID.String())
 		},
-		CreateFunc: func(ctx context.Context, manifest interface{}) error {
+		CreateFunc: func(ctx context.Context, manifest any) error {
 			_, err := kubeCl.
 				CoreV1().ConfigMaps(manifests.CommanderUUIDCmNamespace).
 				Create(ctx, manifest.(*v1.ConfigMap), metav1.CreateOptions{})
 
 			return err
 		},
-		UpdateFunc: func(ctx context.Context, manifest interface{}) error {
+		UpdateFunc: func(ctx context.Context, manifest any) error {
 			existingCm, err := kubeCl.
 				CoreV1().ConfigMaps(manifests.CommanderUUIDCmNamespace).
 				Get(ctx, manifests.CommanderUUIDCm, metav1.GetOptions{})

--- a/dhctl/pkg/operations/converge/context/converge_state.go
+++ b/dhctl/pkg/operations/converge/context/converge_state.go
@@ -121,10 +121,10 @@ func (s *inSecretStateStore) SetState(convergeCtx *Context, state *State) error 
 
 	task := actions.ManifestTask{
 		Name: fmt.Sprintf(`Secret "%s"`, stateSecretName),
-		Manifest: func() interface{} {
+		Manifest: func() any {
 			return manifests.SecretConvergeState(stateBytes)
 		},
-		CreateFunc: func(ctx context.Context, manifest interface{}) error {
+		CreateFunc: func(ctx context.Context, manifest any) error {
 			c, cancel := convergeCtx.WithTimeout(10 * time.Second)
 			defer cancel()
 
@@ -135,7 +135,7 @@ func (s *inSecretStateStore) SetState(convergeCtx *Context, state *State) error 
 
 			return nil
 		},
-		UpdateFunc: func(ctx context.Context, manifest interface{}) error {
+		UpdateFunc: func(ctx context.Context, manifest any) error {
 			c, cancel := convergeCtx.WithTimeout(10 * time.Second)
 			defer cancel()
 

--- a/dhctl/pkg/operations/converge/controller/node_group_controller.go
+++ b/dhctl/pkg/operations/converge/controller/node_group_controller.go
@@ -352,8 +352,7 @@ func (c *NodeGroupController) getSpec(ctx *context.Context, name string) (*confi
 	}
 	for _, terranodeGroup := range metaConfig.GetTerraNodeGroups() {
 		if terranodeGroup.Name == name {
-			cc := terranodeGroup
-			return &cc, nil
+			return new(terranodeGroup), nil
 		}
 	}
 

--- a/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/hook_for_destroy_pipeline.go
+++ b/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/hook_for_destroy_pipeline.go
@@ -151,7 +151,7 @@ func removeLabelsFromNode(ctx context.Context, kubeCl *client.KubernetesClient, 
 
 		nodeLabels := node.GetLabels()
 
-		patchOperations := make([]map[string]interface{}, 0, len(labels))
+		patchOperations := make([]map[string]any, 0, len(labels))
 
 		for _, label := range labels {
 			// Check if the label exists on the node before trying to remove it
@@ -160,7 +160,7 @@ func removeLabelsFromNode(ctx context.Context, kubeCl *client.KubernetesClient, 
 				continue
 			}
 
-			patchOperations = append(patchOperations, map[string]interface{}{
+			patchOperations = append(patchOperations, map[string]any{
 				"op": "remove",
 				// JSON patch requires slashes to be escaped with ~1
 				"path": fmt.Sprintf("/metadata/labels/%s", strings.ReplaceAll(label, "/", "~1")),

--- a/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/hook_for_update_pipeline.go
+++ b/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/hook_for_update_pipeline.go
@@ -259,7 +259,7 @@ func (h *HookForUpdatePipeline) IsReady() error {
 }
 
 func (h *HookForUpdatePipeline) saveKubernetesDataDevicePath(ctx context.Context, devicePath string) error {
-	getDevicePathManifest := func() interface{} {
+	getDevicePathManifest := func() any {
 		return manifests.SecretMasterDevicePath(h.nodeToConverge, []byte(devicePath))
 	}
 
@@ -271,7 +271,7 @@ func (h *HookForUpdatePipeline) saveKubernetesDataDevicePath(ctx context.Context
 	task := actions.ManifestTask{
 		Name:     `Secret "d8-masters-kubernetes-data-device-path"`,
 		Manifest: getDevicePathManifest,
-		CreateFunc: func(ctx context.Context, manifest interface{}) error {
+		CreateFunc: func(ctx context.Context, manifest any) error {
 			_, err := kubeClient.CoreV1().Secrets("d8-system").Create(ctx, manifest.(*apiv1.Secret), metav1.CreateOptions{})
 			if err != nil {
 				return err
@@ -279,7 +279,7 @@ func (h *HookForUpdatePipeline) saveKubernetesDataDevicePath(ctx context.Context
 
 			return nil
 		},
-		UpdateFunc: func(ctx context.Context, manifest interface{}) error {
+		UpdateFunc: func(ctx context.Context, manifest any) error {
 			data, err := json.Marshal(manifest.(*apiv1.Secret))
 			if err != nil {
 				return err

--- a/dhctl/pkg/operations/converge/infrastructure/utils/drain.go
+++ b/dhctl/pkg/operations/converge/infrastructure/utils/drain.go
@@ -142,7 +142,7 @@ func isNodeUnreachable(node *corev1.Node) bool {
 
 // writer implements io.Writer interface as a pass-through for klog.
 type writer struct {
-	logFunc func(elems ...interface{})
+	logFunc func(elems ...any)
 }
 
 func (w writer) Write(p []byte) (int, error) {

--- a/dhctl/pkg/operations/destroy/common_test.go
+++ b/dhctl/pkg/operations/destroy/common_test.go
@@ -230,7 +230,6 @@ func testCreateResourcesGeneral(t *testing.T, kubeCl *client.KubernetesClient) [
 		},
 	})
 
-	minAvailable := intstr.FromString("25%")
 	pdb := policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test",
@@ -242,7 +241,7 @@ func testCreateResourcesGeneral(t *testing.T, kubeCl *client.KubernetesClient) [
 					"app": "test",
 				},
 			},
-			MaxUnavailable: &minAvailable,
+			MaxUnavailable: new(intstr.FromString("25%")),
 		},
 	}
 	_, err = kubeCl.PolicyV1().PodDisruptionBudgets(pdb.GetNamespace()).Create(ctx, &pdb, metav1.CreateOptions{})
@@ -460,7 +459,6 @@ spec:
 		createdResources = append(createdResources, testAddDeckhouseStorageClass(t, ctx, kubeCl, sc.gvr, sc.resourceYAML))
 	}
 
-	reclame := corev1.PersistentVolumeReclaimDelete
 	scDefault := storagev1.StorageClass{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "default",
@@ -470,7 +468,7 @@ spec:
 		Parameters: map[string]string{
 			"type": "__DEFAULT__",
 		},
-		ReclaimPolicy: &reclame,
+		ReclaimPolicy: new(corev1.PersistentVolumeReclaimDelete),
 	}
 
 	_, err = kubeCl.StorageV1().StorageClasses().Create(ctx, &scDefault, metav1.CreateOptions{})

--- a/dhctl/pkg/operations/destroy/destroy_static_test.go
+++ b/dhctl/pkg/operations/destroy/destroy_static_test.go
@@ -1267,10 +1267,8 @@ func (w *testNodeUserWaiter) waitAll() {
 }
 
 func (w *testNodeUserWaiter) goWaitNodeUserAddUserToNodes(ctx context.Context, kubeCl *client.KubernetesClient, hosts []session.Host) {
-	w.wg.Add(1)
 
-	go func() {
-		defer w.wg.Done()
+	w.wg.Go(func() {
 		err := retry.NewSilentLoop("wait node user", 20, 500*time.Millisecond).RunContext(ctx, func() error {
 			_, err := kubeCl.Dynamic().Resource(v1.NodeUserGVR).Get(ctx, global.ConvergeNodeUserName, metav1.GetOptions{})
 			return err
@@ -1300,7 +1298,7 @@ func (w *testNodeUserWaiter) goWaitNodeUserAddUserToNodes(ctx context.Context, k
 		}
 
 		w.setErr(nil)
-	}()
+	})
 }
 
 type testStaticDestroyTest struct {

--- a/dhctl/pkg/operations/destroy/static/destroyer.go
+++ b/dhctl/pkg/operations/destroy/static/destroyer.go
@@ -286,8 +286,7 @@ func (d *Destroyer) processStaticHost(ctx context.Context, sshClient libcon.SSHC
 		c.WithStderrHandler(stdOutErrHandler)
 		err := c.Run(ctx)
 		if err != nil {
-			var ee *exec.ExitError
-			if errors.As(err, &ee) {
+			if ee, ok := errors.AsType[*exec.ExitError](err); ok {
 				// script reboot node
 				if ee.ExitCode() == 255 {
 					return nil

--- a/dhctl/pkg/operations/nodebootstrap.go
+++ b/dhctl/pkg/operations/nodebootstrap.go
@@ -324,7 +324,7 @@ func ParallelCreateNodeGroup(
 	var msg strings.Builder
 	msg.WriteString("Create NodeGroups ")
 	for _, group := range terraNodeGroups {
-		msg.WriteString(fmt.Sprintf("%s (replicas: %v)️; ", group.Name, group.Replicas))
+		fmt.Fprintf(&msg, "%s (replicas: %v)️; ", group.Name, group.Replicas)
 	}
 
 	return log.ProcessCtx(ctx, "converge", msg.String(), func(ctx context.Context) error {

--- a/dhctl/pkg/operations/nodebootstrap.go
+++ b/dhctl/pkg/operations/nodebootstrap.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 
 	"github.com/hashicorp/go-multierror"
@@ -320,12 +321,13 @@ func ParallelCreateNodeGroup(
 	infrastructureContext *infrastructure.Context,
 	globalOptions *options.GlobalOptions,
 ) error {
-	msg := "Create NodeGroups "
+	var msg strings.Builder
+	msg.WriteString("Create NodeGroups ")
 	for _, group := range terraNodeGroups {
-		msg += fmt.Sprintf("%s (replicas: %v)️; ", group.Name, group.Replicas)
+		msg.WriteString(fmt.Sprintf("%s (replicas: %v)️; ", group.Name, group.Replicas))
 	}
 
-	return log.ProcessCtx(ctx, "converge", msg, func(ctx context.Context) error {
+	return log.ProcessCtx(ctx, "converge", msg.String(), func(ctx context.Context) error {
 		var (
 			mu sync.Mutex
 			wg sync.WaitGroup

--- a/dhctl/pkg/operations/phases/progress.go
+++ b/dhctl/pkg/operations/phases/progress.go
@@ -57,8 +57,7 @@ func (p Progress) Clone() Progress {
 		}
 
 		if phase.Action != nil {
-			clonedAction := *phase.Action
-			clonedPhase.Action = &clonedAction
+			clonedPhase.Action = new(*phase.Action)
 		}
 
 		clonedPhases[i] = clonedPhase

--- a/dhctl/pkg/operations/phases/progress.go
+++ b/dhctl/pkg/operations/phases/progress.go
@@ -21,8 +21,6 @@ import (
 	"os"
 	"slices"
 	"sync"
-
-	"k8s.io/utils/ptr"
 )
 
 type OnProgressFunc func(Progress) error
@@ -179,10 +177,10 @@ func (p *ProgressTracker) Complete(lastCompletedPhase OperationPhase) error {
 		}
 
 		if i <= lastCompletedPhaseIndex {
-			p.progress.Phases[i].Action = ptr.To(ProgressActionDefault)
+			p.progress.Phases[i].Action = new(ProgressActionDefault)
 			continue
 		}
-		p.progress.Phases[i].Action = ptr.To(ProgressActionSkip)
+		p.progress.Phases[i].Action = new(ProgressActionSkip)
 	}
 
 	// Check if the last completed phase was skipped
@@ -273,7 +271,7 @@ func calculatePhaseProgress(p Progress, completedPhase, currentPhase OperationPh
 		if idx > completedPhaseIndex {
 			for i := completedPhaseIndex + 1; i < idx; i++ {
 				if p.Phases[i].Action == nil {
-					p.Phases[i].Action = ptr.To(ProgressActionSkip)
+					p.Phases[i].Action = new(ProgressActionSkip)
 				}
 			}
 			currentPhaseIndex = idx

--- a/dhctl/pkg/operations/phases/progress_test.go
+++ b/dhctl/pkg/operations/phases/progress_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"k8s.io/utils/ptr"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/phases"
 )
@@ -217,7 +216,7 @@ func TestProgressTracker_Complete(t *testing.T) {
 		if i <= 1 {
 			continue
 		}
-		lastPhases[i].Action = ptr.To(phases.ProgressActionSkip)
+		lastPhases[i].Action = new(phases.ProgressActionSkip)
 	}
 
 	expected := []phases.Progress{

--- a/dhctl/pkg/preflight/checks/check_cloud_api_test.go
+++ b/dhctl/pkg/preflight/checks/check_cloud_api_test.go
@@ -68,7 +68,6 @@ func TestGetCloudApiURLFromMetaConfig(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			s := require.New(t)
 			clusterConfigYAML := `

--- a/dhctl/pkg/preflight/checks/cidr_intersection_test.go
+++ b/dhctl/pkg/preflight/checks/cidr_intersection_test.go
@@ -166,7 +166,7 @@ func TestCheckCidrIntersection(t *testing.T) {
 					"serviceSubnetCIDR": []byte(`"10.111.110.0/18"`),
 				},
 			}},
-			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+			wantErr: func(t assert.TestingT, err error, i ...any) bool {
 				return assert.ErrorContains(t, err, "intersect")
 			},
 		},
@@ -177,7 +177,7 @@ func TestCheckCidrIntersection(t *testing.T) {
 					"serviceSubnetCIDR": []byte(`"10.0.0.0/8"`),
 				},
 			}},
-			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+			wantErr: func(t assert.TestingT, err error, i ...any) bool {
 				return assert.ErrorContains(t, err, "missing podSubnetCIDR field in ClusterConfiguration")
 			},
 		},
@@ -188,7 +188,7 @@ func TestCheckCidrIntersection(t *testing.T) {
 					"podSubnetCIDR": []byte(`"10.0.0.0/8"`),
 				},
 			}},
-			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+			wantErr: func(t assert.TestingT, err error, i ...any) bool {
 				return assert.ErrorContains(t, err, "missing serviceSubnetCIDR field in ClusterConfiguration")
 			},
 		},
@@ -200,7 +200,7 @@ func TestCheckCidrIntersection(t *testing.T) {
 					"serviceSubnetCIDR": []byte(`"10.222.0.0/16"`),
 				},
 			}},
-			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+			wantErr: func(t assert.TestingT, err error, i ...any) bool {
 				return assert.ErrorContains(t, err, "invalid CIDR address: invalidCIDR")
 			},
 		},
@@ -212,7 +212,7 @@ func TestCheckCidrIntersection(t *testing.T) {
 					"serviceSubnetCIDR": []byte(`"invalidCIDR"`),
 				},
 			}},
-			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+			wantErr: func(t assert.TestingT, err error, i ...any) bool {
 				return assert.ErrorContains(t, err, "invalid CIDR address: invalidCIDR")
 			},
 		},
@@ -268,7 +268,7 @@ func TestCheckCidrIntersectionStatic(t *testing.T) {
 					"internalNetworkCIDRs": []byte(`["10.0.0.0/8"]`),
 				},
 			}},
-			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+			wantErr: func(t assert.TestingT, err error, i ...any) bool {
 				return assert.ErrorContains(t, err, "intersect")
 			},
 		},
@@ -283,7 +283,7 @@ func TestCheckCidrIntersectionStatic(t *testing.T) {
 					"internalNetworkCIDRs": []byte(`["10.222.128.0/24"]`),
 				},
 			}},
-			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+			wantErr: func(t assert.TestingT, err error, i ...any) bool {
 				return assert.ErrorContains(t, err, "intersect")
 			},
 		},
@@ -297,7 +297,7 @@ func TestCheckCidrIntersectionStatic(t *testing.T) {
 					"internalNetworkCIDRs": []byte(`["10.128.0.0/24"]`),
 				},
 			}},
-			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+			wantErr: func(t assert.TestingT, err error, i ...any) bool {
 				return assert.ErrorContains(t, err, "missing podSubnetCIDR field in ClusterConfiguration")
 			},
 		},
@@ -311,7 +311,7 @@ func TestCheckCidrIntersectionStatic(t *testing.T) {
 					"internalNetworkCIDRs": []byte(`["10.128.0.0/24"]`),
 				},
 			}},
-			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+			wantErr: func(t assert.TestingT, err error, i ...any) bool {
 				return assert.ErrorContains(t, err, "missing serviceSubnetCIDR field in ClusterConfiguration")
 			},
 		},
@@ -326,7 +326,7 @@ func TestCheckCidrIntersectionStatic(t *testing.T) {
 					"internalNetworkCIDRs": []byte(`["10.128.0.0/24"]`),
 				},
 			}},
-			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+			wantErr: func(t assert.TestingT, err error, i ...any) bool {
 				return assert.ErrorContains(t, err, "invalid CIDR address: invalidCIDR")
 			},
 		},
@@ -341,7 +341,7 @@ func TestCheckCidrIntersectionStatic(t *testing.T) {
 					"internalNetworkCIDRs": []byte(`["10.128.0.0/24"]`),
 				},
 			}},
-			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+			wantErr: func(t assert.TestingT, err error, i ...any) bool {
 				return assert.ErrorContains(t, err, "invalid CIDR address: invalidCIDR")
 			},
 		},
@@ -356,7 +356,7 @@ func TestCheckCidrIntersectionStatic(t *testing.T) {
 					"internalNetworkCIDRs": []byte(`["invalidCIDR"]`),
 				},
 			}},
-			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+			wantErr: func(t assert.TestingT, err error, i ...any) bool {
 				return assert.ErrorContains(t, err, "invalid CIDR address: invalidCIDR")
 			},
 		},

--- a/dhctl/pkg/preflight/checks/deckhouse_user.go
+++ b/dhctl/pkg/preflight/checks/deckhouse_user.go
@@ -60,8 +60,7 @@ func (c DeckhouseUserCheck) Run(ctx context.Context) error {
 		if outMsg != "" {
 			return fmt.Errorf("Deckhouse user check failed: %s", outMsg)
 		}
-		var ee *exec.ExitError
-		if errors.As(err, &ee) {
+		if ee, ok := errors.AsType[*exec.ExitError](err); ok {
 			return fmt.Errorf("Deckhouse user check failed: %w, %s", err, string(ee.Stderr))
 		}
 		return fmt.Errorf("Could not execute a script to check deckhouse user and group aren't present on the node: %w", err)

--- a/dhctl/pkg/preflight/checks/localhost.go
+++ b/dhctl/pkg/preflight/checks/localhost.go
@@ -56,8 +56,7 @@ func (c LocalhostDomainCheck) Run(ctx context.Context) error {
 	cmd := c.NodeInterface.UploadScript(file)
 	out, err := cmd.Execute(ctx)
 	if err != nil {
-		var ee *exec.ExitError
-		if errors.As(err, &ee) {
+		if ee, ok := errors.AsType[*exec.ExitError](err); ok {
 			return fmt.Errorf("Localhost domain resolving check failed: %w, %s", err, string(ee.Stderr))
 		}
 		return fmt.Errorf("Could not execute a script to check for localhost domain resolution: %w", err)

--- a/dhctl/pkg/preflight/checks/ports.go
+++ b/dhctl/pkg/preflight/checks/ports.go
@@ -71,8 +71,7 @@ func checkAvailabilityPorts(ctx context.Context, nodeInterface libcon.Interface,
 			return fmt.Errorf("required ports check failed: %s", outMsg)
 		}
 
-		var ee *exec.ExitError
-		if errors.As(err, &ee) {
+		if ee, ok := errors.AsType[*exec.ExitError](err); ok {
 			return fmt.Errorf("required ports check failed: %w, %s", err, string(ee.Stderr))
 		}
 		return fmt.Errorf("Could not execute a script to check if all necessary ports are open on the node: %w", err)

--- a/dhctl/pkg/preflight/checks/public_domain_template_test.go
+++ b/dhctl/pkg/preflight/checks/public_domain_template_test.go
@@ -121,8 +121,8 @@ func TestCheckPublicDomainTemplate(t *testing.T) {
 							Name: "global",
 						},
 						Spec: config.ModuleConfigSpec{
-							Settings: map[string]interface{}{
-								"modules": map[string]interface{}{
+							Settings: map[string]any{
+								"modules": map[string]any{
 									"publicDomainTemplate": "example.com",
 								},
 							},
@@ -143,8 +143,8 @@ func TestCheckPublicDomainTemplate(t *testing.T) {
 							Name: "global",
 						},
 						Spec: config.ModuleConfigSpec{
-							Settings: map[string]interface{}{
-								"modules": map[string]interface{}{
+							Settings: map[string]any{
+								"modules": map[string]any{
 									"publicDomainTemplate": "cluster.local",
 								},
 							},
@@ -166,8 +166,8 @@ func TestCheckPublicDomainTemplate(t *testing.T) {
 							Name: "global",
 						},
 						Spec: config.ModuleConfigSpec{
-							Settings: map[string]interface{}{
-								"modules": map[string]interface{}{
+							Settings: map[string]any{
+								"modules": map[string]any{
 									"publicDomainTemplate": "test.cluster.local",
 								},
 							},

--- a/dhctl/pkg/preflight/checks/python.go
+++ b/dhctl/pkg/preflight/checks/python.go
@@ -63,8 +63,7 @@ func (c PythonCheck) Run(ctx context.Context) error {
 		for _, moduleName := range moduleSet {
 			cmd := c.NodeInterface.Command(pythonBinary, "-c", "import "+moduleName)
 			if err := cmd.Run(ctx); err != nil {
-				var ee *exec.ExitError
-				if errors.As(err, &ee) && ee.ExitCode() != 255 {
+				if ee, ok := errors.AsType[*exec.ExitError](err); ok && ee.ExitCode() != 255 {
 					continue
 				}
 				return fmt.Errorf("Unexpected error during python modules validation: %w", err)
@@ -88,8 +87,7 @@ func detectPythonBinary(ctx context.Context, nodeInterface libcon.Interface) (st
 		if err == nil {
 			return binary, nil
 		}
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) && exitErr.ExitCode() != 255 {
+		if exitErr, ok := errors.AsType[*exec.ExitError](err); ok && exitErr.ExitCode() != 255 {
 			continue
 		}
 		return "", fmt.Errorf("Unexpected error during python binary lookup: %w", err)

--- a/dhctl/pkg/preflight/checks/specs_cloud_test.go
+++ b/dhctl/pkg/preflight/checks/specs_cloud_test.go
@@ -51,7 +51,7 @@ func TestCloudSystemRequirementsCheck(t *testing.T) {
 			installConfig: &config.DeckhouseInstaller{
 				ProviderClusterConfig: invalidPCC,
 			},
-			assertionCheck: func(t assert.TestingT, err error, i ...interface{}) bool {
+			assertionCheck: func(t assert.TestingT, err error, i ...any) bool {
 				return assert.ErrorContains(t, err, "expected at least")
 			},
 		},
@@ -60,7 +60,7 @@ func TestCloudSystemRequirementsCheck(t *testing.T) {
 			installConfig: &config.DeckhouseInstaller{
 				ProviderClusterConfig: malformedPCC,
 			},
-			assertionCheck: func(t assert.TestingT, err error, i ...interface{}) bool {
+			assertionCheck: func(t assert.TestingT, err error, i ...any) bool {
 				return assert.ErrorContains(t, err, "malformed provider cluster configuration")
 			},
 		},

--- a/dhctl/pkg/preflight/checks/static_instances_ip_duplication.go
+++ b/dhctl/pkg/preflight/checks/static_instances_ip_duplication.go
@@ -52,17 +52,17 @@ func (c StaticInstancesIPDuplicationCheck) Run(ctx context.Context) error {
 	instances := make(map[string]string)
 
 	for _, doc := range documents {
-		var result map[string]interface{}
+		var result map[string]any
 		err := yaml.Unmarshal([]byte(doc), &result)
 		if err != nil {
 			return fmt.Errorf("cannot unmarshal YAML: %v", err)
 		}
 
 		if result["kind"] == "StaticInstance" {
-			meta := result["metadata"].(map[string]interface{})
+			meta := result["metadata"].(map[string]any)
 			name := meta["name"].(string)
 
-			spec := result["spec"].(map[string]interface{})
+			spec := result["spec"].(map[string]any)
 			address := spec["address"].(string)
 
 			instName, ok := instances[address]

--- a/dhctl/pkg/preflight/checks/static_instances_ssh_credentials.go
+++ b/dhctl/pkg/preflight/checks/static_instances_ssh_credentials.go
@@ -95,7 +95,7 @@ func parseResources(docs []string) ([]staticInstance, map[string]*v1alpha2.SSHCr
 			continue
 		}
 
-		var m map[string]interface{}
+		var m map[string]any
 		if err := yaml.Unmarshal([]byte(doc), &m); err != nil {
 			return nil, nil, fmt.Errorf("Cannot unmarshal YAML: %w", err)
 		}

--- a/dhctl/pkg/preflight/checks/staticinstances_ip_duplication_test.go
+++ b/dhctl/pkg/preflight/checks/staticinstances_ip_duplication_test.go
@@ -128,7 +128,7 @@ spec:
     name: credentials
 `,
 			}},
-			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+			wantErr: func(t assert.TestingT, err error, i ...any) bool {
 				return assert.ErrorContains(t, err, "Duplicate address")
 			},
 		},

--- a/dhctl/pkg/preflight/checks/sudo.go
+++ b/dhctl/pkg/preflight/checks/sudo.go
@@ -48,8 +48,7 @@ func (c SudoAllowedCheck) Run(ctx context.Context) error {
 	cmd.Sudo(ctx)
 
 	if err := cmd.Run(ctx); err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) && exitErr.ExitCode() != 255 {
+		if exitErr, ok := errors.AsType[*exec.ExitError](err); ok && exitErr.ExitCode() != 255 {
 			return errors.New("Provided SSH user is not allowed to sudo, please check that your password is correct and that this user is in the sudoers file.")
 		}
 		return fmt.Errorf("Unexpected error when checking sudoers permissions for SSH user: %v", err)

--- a/dhctl/pkg/preflight/checks/sudo_test.go
+++ b/dhctl/pkg/preflight/checks/sudo_test.go
@@ -111,11 +111,11 @@ func (m *mockProcessState) Success() bool {
 	return m.exitCode == 0
 }
 
-func (m *mockProcessState) Sys() interface{} {
+func (m *mockProcessState) Sys() any {
 	return nil
 }
 
-func (m *mockProcessState) SysUsage() interface{} {
+func (m *mockProcessState) SysUsage() any {
 	return nil
 }
 

--- a/dhctl/pkg/server/pkg/fsm/fsm_test.go
+++ b/dhctl/pkg/server/pkg/fsm/fsm_test.go
@@ -107,7 +107,6 @@ func TestFiniteStateMachine(t *testing.T) {
 	}
 
 	for name, tt := range tests {
-		tt := tt
 		t.Run(name, func(t *testing.T) {
 			f := fsm.New(tt.initialState, tt.transitions)
 			for _, e := range tt.events {

--- a/dhctl/pkg/server/pkg/interceptors/interceptors.go
+++ b/dhctl/pkg/server/pkg/interceptors/interceptors.go
@@ -103,7 +103,7 @@ func UnaryParallelTasksLimiter(sem chan struct{}, prefix string) grpc.UnaryServe
 }
 
 func StreamParallelTasksLimiter(sem chan struct{}, prefix string) grpc.StreamServerInterceptor {
-	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	return func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		if !strings.HasPrefix(info.FullMethod, prefix) {
 			return handler(srv, ss)
 		}

--- a/dhctl/pkg/server/pkg/logger/writer_test.go
+++ b/dhctl/pkg/server/pkg/logger/writer_test.go
@@ -86,7 +86,6 @@ func TestLogWriter(t *testing.T) {
 	}
 
 	for name, tt := range tests {
-		tt := tt
 
 		t.Run(name, func(t *testing.T) {
 			sendCh := make(chan []string)
@@ -105,16 +104,14 @@ func TestLogWriter(t *testing.T) {
 			w := logger.NewLogWriter(log, sendCh, tt.f)
 
 			wg := sync.WaitGroup{}
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				var writes int
 				for writes < len(tt.lines) {
 					lines := <-sendCh
 					assert.Equal(t, tt.lines[writes], lines)
 					writes++
 				}
-			}()
+			})
 
 			for _, input := range tt.input {
 				n, err := w.Write(input)

--- a/dhctl/pkg/server/pkg/util/util.go
+++ b/dhctl/pkg/server/pkg/util/util.go
@@ -62,12 +62,9 @@ func PortToString(p *int32) string {
 
 func PortToInt(p *int32) *int {
 	if p == nil {
-		port := 22
-		return &port
+		return new(22)
 	}
-	port := *p
-	portInt := int(port)
-	return &portInt
+	return new(int(*p))
 }
 
 func StringToBytes(data string) []byte {

--- a/dhctl/pkg/server/rpc/status/get_status.go
+++ b/dhctl/pkg/server/rpc/status/get_status.go
@@ -21,9 +21,8 @@ import (
 )
 
 func (s *Service) GetStatus(context.Context, *pb.GetStatusRequest) (*pb.GetStatusResponse, error) {
-	currentRequestCount := s.requestsCounter.CountCurrentRequests()
 	return &pb.GetStatusResponse{
 		RequestsByMethod:   s.requestsCounter.CountRecentRequests(),
-		RequestsInProgress: &currentRequestCount,
+		RequestsInProgress: new(s.requestsCounter.CountCurrentRequests()),
 	}, nil
 }

--- a/dhctl/pkg/server/server/proxy.go
+++ b/dhctl/pkg/server/server/proxy.go
@@ -152,12 +152,10 @@ func (d *StreamDirector) Director() proxy.StreamDirector {
 
 		log.Info("started new dhctl instance")
 
-		d.wg.Add(1)
-		go func() {
-			defer d.wg.Done()
+		d.wg.Go(func() {
 			exitErr := cmd.Wait()
 			log.Info("stopped dhctl instance", logger.Err(exitErr))
-		}()
+		})
 
 		conn, err := createDHCTLServerConnRetried(ctx, log, address)
 		if err != nil {

--- a/dhctl/pkg/state/cache.go
+++ b/dhctl/pkg/state/cache.go
@@ -20,10 +20,10 @@ const TombstoneKey = ".tombstone"
 
 type Cache interface {
 	Save(context.Context, string, []byte) error
-	SaveStruct(context.Context, string, interface{}) error
+	SaveStruct(context.Context, string, any) error
 
 	Load(context.Context, string) ([]byte, error)
-	LoadStruct(context.Context, string, interface{}) error
+	LoadStruct(context.Context, string, any) error
 
 	Delete(context.Context, string)
 	Clean(ctx context.Context)

--- a/dhctl/pkg/state/infrastructure/state.go
+++ b/dhctl/pkg/state/infrastructure/state.go
@@ -282,17 +282,17 @@ func SaveNodeInfrastructureState(
 
 	task := actions.ManifestTask{
 		Name: fmt.Sprintf(`Secret "d8-node-terraform-state-%s"`, nodeName),
-		Manifest: func() interface{} {
+		Manifest: func() any {
 			return manifests.SecretWithNodeInfrastructureState(nodeName, nodeGroup, tfState, settings)
 		},
-		CreateFunc: func(ctx context.Context, manifest interface{}) error {
+		CreateFunc: func(ctx context.Context, manifest any) error {
 			_, err := kubeCl.
 				CoreV1().Secrets("d8-system").
 				Create(ctx, manifest.(*v1.Secret), metav1.CreateOptions{})
 
 			return err
 		},
-		UpdateFunc: func(ctx context.Context, manifest interface{}) error {
+		UpdateFunc: func(ctx context.Context, manifest any) error {
 			_, err := kubeCl.
 				CoreV1().Secrets("d8-system").
 				Update(ctx, manifest.(*v1.Secret), metav1.UpdateOptions{})
@@ -310,10 +310,10 @@ func SaveMasterNodeInfrastructureState(ctx context.Context, kubeCl *client.Kuber
 		return ErrNoInfrastructureState
 	}
 
-	getInfrastructureStateManifest := func() interface{} {
+	getInfrastructureStateManifest := func() any {
 		return manifests.SecretWithNodeInfrastructureState(nodeName, global.MasterNodeGroupName, tfState, nil)
 	}
-	getDevicePathManifest := func() interface{} {
+	getDevicePathManifest := func() any {
 		return manifests.SecretMasterDevicePath(nodeName, devicePath)
 	}
 
@@ -321,14 +321,14 @@ func SaveMasterNodeInfrastructureState(ctx context.Context, kubeCl *client.Kuber
 		{
 			Name:     fmt.Sprintf(`Secret "d8-node-terraform-state-%s"`, nodeName),
 			Manifest: getInfrastructureStateManifest,
-			CreateFunc: func(ctx context.Context, manifest interface{}) error {
+			CreateFunc: func(ctx context.Context, manifest any) error {
 				_, err := kubeCl.
 					CoreV1().Secrets("d8-system").
 					Create(ctx, manifest.(*v1.Secret), metav1.CreateOptions{})
 
 				return err
 			},
-			UpdateFunc: func(ctx context.Context, manifest interface{}) error {
+			UpdateFunc: func(ctx context.Context, manifest any) error {
 				_, err := kubeCl.
 					CoreV1().Secrets("d8-system").
 					Update(ctx, manifest.(*v1.Secret), metav1.UpdateOptions{})
@@ -339,14 +339,14 @@ func SaveMasterNodeInfrastructureState(ctx context.Context, kubeCl *client.Kuber
 		{
 			Name:     `Secret "d8-masters-kubernetes-data-device-path"`,
 			Manifest: getDevicePathManifest,
-			CreateFunc: func(ctx context.Context, manifest interface{}) error {
+			CreateFunc: func(ctx context.Context, manifest any) error {
 				_, err := kubeCl.
 					CoreV1().Secrets("d8-system").
 					Create(ctx, manifest.(*v1.Secret), metav1.CreateOptions{})
 
 				return err
 			},
-			UpdateFunc: func(ctx context.Context, manifest interface{}) error {
+			UpdateFunc: func(ctx context.Context, manifest any) error {
 				data, err := json.Marshal(manifest.(*v1.Secret))
 				if err != nil {
 					return err
@@ -386,15 +386,15 @@ func SaveClusterInfrastructureState(ctx context.Context, kubeCl *client.Kubernet
 
 	task := actions.ManifestTask{
 		Name:     `Secret "d8-cluster-terraform-state"`,
-		Manifest: func() interface{} { return manifests.SecretWithInfrastructureState(outputs.InfrastructureState) },
-		CreateFunc: func(ctx context.Context, manifest interface{}) error {
+		Manifest: func() any { return manifests.SecretWithInfrastructureState(outputs.InfrastructureState) },
+		CreateFunc: func(ctx context.Context, manifest any) error {
 			_, err := kubeCl.
 				CoreV1().Secrets("d8-system").
 				Create(ctx, manifest.(*v1.Secret), metav1.CreateOptions{})
 
 			return err
 		},
-		UpdateFunc: func(ctx context.Context, manifest interface{}) error {
+		UpdateFunc: func(ctx context.Context, manifest any) error {
 			_, err := kubeCl.
 				CoreV1().Secrets("d8-system").
 				Update(ctx, manifest.(*v1.Secret), metav1.UpdateOptions{})
@@ -414,8 +414,8 @@ func SaveClusterInfrastructureState(ctx context.Context, kubeCl *client.Kubernet
 		return err
 	}
 
-	patch, err := json.Marshal(map[string]interface{}{
-		"data": map[string]interface{}{
+	patch, err := json.Marshal(map[string]any{
+		"data": map[string]any{
 			"cloud-provider-discovery-data.json": outputs.CloudDiscovery,
 		},
 	})

--- a/dhctl/pkg/state/infrastructure/state_saver.go
+++ b/dhctl/pkg/state/infrastructure/state_saver.go
@@ -103,7 +103,7 @@ func (s *ClusterStateSaver) SaveState(ctx context.Context, outputs *infrastructu
 		msg = fmt.Sprintf("Intermediate base infra was not saved in cluster: %v\n", err)
 	}
 
-	log.DebugF(msg)
+	log.DebugF("%s", msg)
 	return err
 }
 
@@ -177,7 +177,7 @@ func (s *NodeStateSaver) SaveState(ctx context.Context, outputs *infrastructure.
 		msg = fmt.Sprintf("Intermediate state for node %s was not saved in cluster: %v\n", s.nodeName, err)
 	}
 
-	log.DebugF(msg)
+	log.DebugF("%s", msg)
 
 	return err
 }

--- a/dhctl/pkg/state/infrastructure/state_saver.go
+++ b/dhctl/pkg/state/infrastructure/state_saver.go
@@ -69,7 +69,7 @@ func (s *ClusterStateSaver) SaveState(ctx context.Context, outputs *infrastructu
 
 	task := actions.ManifestTask{
 		Name: `Secret "d8-cluster-terraform-state"`,
-		PatchData: func() interface{} {
+		PatchData: func() any {
 			return manifests.PatchWithInfrastructureState(outputs.InfrastructureState)
 		},
 		PatchFunc: func(ctx context.Context, patch []byte) error {
@@ -142,16 +142,16 @@ func (s *NodeStateSaver) SaveState(ctx context.Context, outputs *infrastructure.
 
 	task := actions.ManifestTask{
 		Name: fmt.Sprintf(`Secret "d8-node-terraform-state-%s"`, s.nodeName),
-		Manifest: func() interface{} {
+		Manifest: func() any {
 			return manifests.SecretWithNodeInfrastructureState(s.nodeName, s.nodeGroup, outputs.InfrastructureState, s.nodeGroupSettings)
 		},
-		CreateFunc: func(ctx context.Context, manifest interface{}) error {
+		CreateFunc: func(ctx context.Context, manifest any) error {
 			ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 			defer cancel()
 			_, err := kubeClient.CoreV1().Secrets("d8-system").Create(ctx, manifest.(*apiv1.Secret), metav1.CreateOptions{})
 			return err
 		},
-		PatchData: func() interface{} {
+		PatchData: func() any {
 			return manifests.PatchWithNodeInfrastructureState(outputs.InfrastructureState)
 		},
 		PatchFunc: func(ctx context.Context, patchData []byte) error {

--- a/dhctl/pkg/template/bashbooster.go
+++ b/dhctl/pkg/template/bashbooster.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 )
 
-func RenderBashBooster(templatesDir string, data map[string]interface{}) (string, error) {
+func RenderBashBooster(templatesDir string, data map[string]any) (string, error) {
 	files, err := os.ReadDir(templatesDir)
 	if err != nil {
 		return "", fmt.Errorf("bashbooster read dir: %v", err)

--- a/dhctl/pkg/template/bashible_test.go
+++ b/dhctl/pkg/template/bashible_test.go
@@ -32,14 +32,14 @@ func TestRenderBashibleTemplateUsesOnlyKubeAPIEndpoints(t *testing.T) {
 	tplContent, err := os.ReadFile("/deckhouse/candi/bashible/bashible.sh.tpl")
 	require.NoError(t, err)
 
-	data := map[string]interface{}{
+	data := map[string]any{
 		"runType":     "Normal",
 		"clusterUUID": "848c3b2c-eda6-11ec-9289-dff550c719eb",
-		"nodeGroup": map[string]interface{}{
+		"nodeGroup": map[string]any{
 			"name":     "master",
 			"nodeType": "CloudPermanent",
 		},
-		"clusterMasterEndpoints": []map[string]interface{}{
+		"clusterMasterEndpoints": []map[string]any{
 			{
 				"address":     "10.0.0.1",
 				"kubeApiPort": 6443,
@@ -53,12 +53,12 @@ func TestRenderBashibleTemplateUsesOnlyKubeAPIEndpoints(t *testing.T) {
 		"clusterMasterKubeAPIEndpoints": []string{
 			"10.0.0.1:6443",
 		},
-		"images": map[string]interface{}{
-			"registrypackages": map[string]interface{}{
+		"images": map[string]any{
+			"registrypackages": map[string]any{
 				"rppGet": "sha256:test",
 			},
 		},
-		"registry": map[string]interface{}{
+		"registry": map[string]any{
 			"registryModuleEnable": "false",
 		},
 	}

--- a/dhctl/pkg/template/bundle.go
+++ b/dhctl/pkg/template/bundle.go
@@ -41,12 +41,12 @@ const (
 type saveFromTo struct {
 	from        string
 	to          string
-	data        map[string]interface{}
+	data        map[string]any
 	ignorePaths map[string]struct{}
 }
 
-func logTemplatesData(name string, data map[string]interface{}) {
-	dataForLog := make(map[string]interface{})
+func logTemplatesData(name string, data map[string]any) {
+	dataForLog := make(map[string]any)
 	for k, v := range data {
 		switch k {
 		case "k8s", "bashible", "images":
@@ -97,7 +97,7 @@ func PrepareBundle(
 func PrepareBashibleBundle(
 	ctx context.Context,
 	templateController *Controller,
-	templateData map[string]interface{},
+	templateData map[string]any,
 	provider string,
 	devicePath string,
 	globalOptions *options.GlobalOptions,

--- a/dhctl/pkg/template/bundle_pki_test.go
+++ b/dhctl/pkg/template/bundle_pki_test.go
@@ -51,7 +51,7 @@ var caFiles = []string{
 
 func newPKITemplateConfig(clusterDomain, serviceSubnetCIDR string) *config.ControlPlaneTemplateConfig {
 	return &config.ControlPlaneTemplateConfig{
-		ClusterConfiguration: map[string]interface{}{
+		ClusterConfiguration: map[string]any{
 			"clusterDomain":     clusterDomain,
 			"serviceSubnetCIDR": serviceSubnetCIDR,
 		},
@@ -188,7 +188,7 @@ func TestGeneratePKIArtifacts_ValidationErrors(t *testing.T) {
 			nodeIP:   "10.0.0.1",
 			endpoint: "10.0.0.1",
 			cfg: &config.ControlPlaneTemplateConfig{
-				ClusterConfiguration: map[string]interface{}{
+				ClusterConfiguration: map[string]any{
 					"serviceSubnetCIDR": "10.96.0.0/12",
 				},
 			},
@@ -201,7 +201,7 @@ func TestGeneratePKIArtifacts_ValidationErrors(t *testing.T) {
 			nodeIP:   "10.0.0.1",
 			endpoint: "10.0.0.1",
 			cfg: &config.ControlPlaneTemplateConfig{
-				ClusterConfiguration: map[string]interface{}{
+				ClusterConfiguration: map[string]any{
 					"clusterDomain": "cluster.local",
 				},
 			},

--- a/dhctl/pkg/template/controlplane_manifests_test.go
+++ b/dhctl/pkg/template/controlplane_manifests_test.go
@@ -90,13 +90,13 @@ func testManifestsRendering(t *testing.T) {
 		for _, version := range versions {
 			t.Run("Version "+version, func(t *testing.T) {
 				data := getBaseTemplateData(version)
-				data["apiserver"] = map[string]interface{}{
+				data["apiserver"] = map[string]any{
 					"webhookURL":        "https://webhook.example.com",
 					"oidcIssuerURL":     "https://oidc.example.com",
 					"oidcIssuerAddress": "192.168.1.100",
 				}
-				data["images"] = map[string]interface{}{
-					"controlPlaneManager": map[string]interface{}{
+				data["images"] = map[string]any{
+					"controlPlaneManager": map[string]any{
 						"etcd":                     "sha256:62c84f",
 						"kubeApiserver131":         "sha256:5db2b9",
 						"kubeApiserver132":         "sha256:b4b2b5",
@@ -106,12 +106,12 @@ func testManifestsRendering(t *testing.T) {
 						"kubeScheduler132":         "sha256:268cf6",
 					},
 				}
-				data["registry"] = map[string]interface{}{
+				data["registry"] = map[string]any{
 					"address": "registry.example.com",
 					"path":    "/deckhouse",
 				}
-				data["settings"] = map[string]interface{}{
-					"resourcesRequests": map[string]interface{}{
+				data["settings"] = map[string]any{
+					"resourcesRequests": map[string]any{
 						"milliCPU":    int64(1000),
 						"memoryBytes": int64(1073741824),
 					},
@@ -218,7 +218,7 @@ func testAPIServerConfiguration(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Run("Webhook Configuration", func(t *testing.T) {
 				data := getBaseTemplateData(tt.k8sVersion)
-				data["apiserver"] = map[string]interface{}{
+				data["apiserver"] = map[string]any{
 					"webhookURL": "https://webhook.example.com",
 				}
 
@@ -250,7 +250,7 @@ func testAPIServerConfiguration(t *testing.T) {
 
 			t.Run("Authentication Webhook", func(t *testing.T) {
 				data := getBaseTemplateData(tt.k8sVersion)
-				data["apiserver"] = map[string]interface{}{
+				data["apiserver"] = map[string]any{
 					"authnWebhookURL":      "https://authn.example.com",
 					"authnWebhookCacheTTL": "10m",
 				}
@@ -274,9 +274,9 @@ func testAPIServerConfiguration(t *testing.T) {
 
 			t.Run("Audit Configuration - File Output", func(t *testing.T) {
 				data := getBaseTemplateData(tt.k8sVersion)
-				data["apiserver"] = map[string]interface{}{
+				data["apiserver"] = map[string]any{
 					"auditPolicy": "some-policy",
-					"auditLog": map[string]interface{}{
+					"auditLog": map[string]any{
 						"output": "File",
 						"path":   "/var/log/audit",
 					},
@@ -304,9 +304,9 @@ func testAPIServerConfiguration(t *testing.T) {
 
 			t.Run("Audit Configuration - Stdout Output", func(t *testing.T) {
 				data := getBaseTemplateData(tt.k8sVersion)
-				data["apiserver"] = map[string]interface{}{
+				data["apiserver"] = map[string]any{
 					"auditPolicy": "some-policy",
-					"auditLog": map[string]interface{}{
+					"auditLog": map[string]any{
 						"output": "Stdout",
 					},
 				}
@@ -325,7 +325,7 @@ func testAPIServerConfiguration(t *testing.T) {
 
 			t.Run("Audit Webhook", func(t *testing.T) {
 				data := getBaseTemplateData(tt.k8sVersion)
-				data["apiserver"] = map[string]interface{}{
+				data["apiserver"] = map[string]any{
 					"auditWebhookURL": "https://audit.example.com",
 				}
 
@@ -342,7 +342,7 @@ func testAPIServerConfiguration(t *testing.T) {
 
 			t.Run("OIDC Configuration", func(t *testing.T) {
 				data := getBaseTemplateData(tt.k8sVersion)
-				data["apiserver"] = map[string]interface{}{
+				data["apiserver"] = map[string]any{
 					"oidcIssuerURL": "https://oidc.example.com",
 				}
 
@@ -360,26 +360,26 @@ func testAPIServerConfiguration(t *testing.T) {
 			t.Run("Bind Address Configuration", func(t *testing.T) {
 				bindTests := []struct {
 					name         string
-					apiserver    map[string]interface{}
+					apiserver    map[string]any
 					nodeIP       string
 					expectedAddr string
 				}{
 					{
 						name: "Bind to wildcard",
-						apiserver: map[string]interface{}{
+						apiserver: map[string]any{
 							"bindToWildcard": true,
 						},
 						expectedAddr: "0.0.0.0",
 					},
 					{
 						name:         "Bind to nodeIP",
-						apiserver:    map[string]interface{}{},
+						apiserver:    map[string]any{},
 						nodeIP:       "192.168.1.100",
 						expectedAddr: "192.168.1.100",
 					},
 					{
 						name:         "Default bind address",
-						apiserver:    map[string]interface{}{},
+						apiserver:    map[string]any{},
 						expectedAddr: "127.0.0.1",
 					},
 				}
@@ -413,7 +413,7 @@ func testAPIServerConfiguration(t *testing.T) {
 
 			t.Run("ETCD Servers Configuration", func(t *testing.T) {
 				data := getBaseTemplateData(tt.k8sVersion)
-				data["apiserver"] = map[string]interface{}{
+				data["apiserver"] = map[string]any{
 					"etcdServers": []string{
 						"https://etcd1.example.com:2379",
 						"https://etcd2.example.com:2379",
@@ -443,7 +443,7 @@ func testAPIServerConfiguration(t *testing.T) {
 			t.Run("Secret Encryption", func(t *testing.T) {
 				data := getBaseTemplateData(tt.k8sVersion)
 				data["runType"] = "Runtime" // encryption is only added in runtime mode
-				data["apiserver"] = map[string]interface{}{
+				data["apiserver"] = map[string]any{
 					"secretEncryptionKey": "some-key",
 				}
 
@@ -486,7 +486,7 @@ func testClusterTypes(t *testing.T) {
 		for _, tt := range tests {
 			t.Run(fmt.Sprintf("%s (v%s)", tt.name, version), func(t *testing.T) {
 				data := getBaseTemplateData(version)
-				data["clusterConfiguration"].(map[string]interface{})["clusterType"] = tt.clusterType
+				data["clusterConfiguration"].(map[string]any)["clusterType"] = tt.clusterType
 
 				result, err := renderFullManifests(data, "kube-controller-manager")
 				if err != nil {
@@ -598,8 +598,8 @@ func testServiceAccountConfiguration(t *testing.T) {
 	for _, version := range versions {
 		t.Run(fmt.Sprintf("Custom Service Account Issuer (v%s)", version), func(t *testing.T) {
 			data := getBaseTemplateData(version)
-			data["apiserver"] = map[string]interface{}{
-				"serviceAccount": map[string]interface{}{
+			data["apiserver"] = map[string]any{
+				"serviceAccount": map[string]any{
 					"issuer": "https://custom.issuer.com",
 				},
 			}
@@ -622,8 +622,8 @@ func testServiceAccountConfiguration(t *testing.T) {
 	for _, version := range versions {
 		t.Run(fmt.Sprintf("Additional API Issuers (v%s)", version), func(t *testing.T) {
 			data := getBaseTemplateData(version)
-			data["apiserver"] = map[string]interface{}{
-				"serviceAccount": map[string]interface{}{
+			data["apiserver"] = map[string]any{
+				"serviceAccount": map[string]any{
 					"issuer": "https://primary.issuer.com",
 					"additionalAPIIssuers": []string{
 						"https://additional1.issuer.com",
@@ -660,8 +660,8 @@ func testServiceAccountConfiguration(t *testing.T) {
 	for _, version := range versions {
 		t.Run(fmt.Sprintf("Additional API Audiences (v%s)", version), func(t *testing.T) {
 			data := getBaseTemplateData(version)
-			data["apiserver"] = map[string]interface{}{
-				"serviceAccount": map[string]interface{}{
+			data["apiserver"] = map[string]any{
+				"serviceAccount": map[string]any{
 					"issuer": "https://primary.issuer.com",
 					"additionalAPIAudiences": []string{
 						"https://audience1.com",
@@ -715,7 +715,7 @@ func testETCDConfiguration(t *testing.T) {
 	for _, version := range versions {
 		t.Run(fmt.Sprintf("Existing Cluster ETCD (v%s)", version), func(t *testing.T) {
 			data := getBaseTemplateData(version)
-			data["etcd"] = map[string]interface{}{
+			data["etcd"] = map[string]any{
 				"existingCluster": true,
 			}
 
@@ -740,7 +740,7 @@ func testETCDConfiguration(t *testing.T) {
 	for _, version := range versions {
 		t.Run(fmt.Sprintf("ETCD with Quota (v%s)", version), func(t *testing.T) {
 			data := getBaseTemplateData(version)
-			data["etcd"] = map[string]interface{}{
+			data["etcd"] = map[string]any{
 				"existingCluster":   true,
 				"quotaBackendBytes": "8589934592",
 			}
@@ -764,7 +764,7 @@ func testOptionalArguments(t *testing.T) {
 	for _, version := range versions {
 		t.Run(fmt.Sprintf("Node Monitor Arguments (v%s)", version), func(t *testing.T) {
 			data := getBaseTemplateData(version)
-			data["arguments"] = map[string]interface{}{
+			data["arguments"] = map[string]any{
 				"nodeMonitorPeriod":      30,
 				"nodeMonitorGracePeriod": 60,
 			}
@@ -787,7 +787,7 @@ func testOptionalArguments(t *testing.T) {
 	for _, version := range versions {
 		t.Run(fmt.Sprintf("Pod Eviction Timeout (v%s)", version), func(t *testing.T) {
 			data := getBaseTemplateData(version)
-			data["arguments"] = map[string]interface{}{
+			data["arguments"] = map[string]any{
 				"podEvictionTimeout":                  120,
 				"defaultUnreachableTolerationSeconds": 300,
 			}
@@ -815,25 +815,25 @@ func testPatchesRendering(t *testing.T) {
 		for _, version := range versions {
 			t.Run("Version "+version, func(t *testing.T) {
 				data := getBaseTemplateData(version)
-				data["apiserver"] = map[string]interface{}{
+				data["apiserver"] = map[string]any{
 					"webhookURL":        "https://webhook.example.com",
 					"oidcIssuerURL":     "https://oidc.example.com",
 					"oidcIssuerAddress": "192.168.1.100",
 				}
-				data["images"] = map[string]interface{}{
-					"controlPlaneManager": map[string]interface{}{
+				data["images"] = map[string]any{
+					"controlPlaneManager": map[string]any{
 						"kubeApiserverHealthcheck": "sha256:abcd1234",
 						"kubeApiserver131":         "sha256:efgh5678",
 						"kubeApiserver130":         "sha256:ijkl9012",
 						"kubeApiserver129":         "sha256:mnop3456",
 					},
 				}
-				data["registry"] = map[string]interface{}{
+				data["registry"] = map[string]any{
 					"address": "registry.example.com",
 					"path":    "/deckhouse",
 				}
-				data["settings"] = map[string]interface{}{
-					"resourcesRequests": map[string]interface{}{
+				data["settings"] = map[string]any{
+					"resourcesRequests": map[string]any{
 						"milliCPU":    int64(1000),
 						"memoryBytes": int64(1073741824),
 					},
@@ -869,7 +869,7 @@ func testEdgeCases(t *testing.T) {
 			data := getBaseTemplateData(version)
 			data["runType"] = "Runtime"
 			data["nodeIP"] = "192.168.1.100"
-			data["apiserver"] = map[string]interface{}{
+			data["apiserver"] = map[string]any{
 				"webhookURL":          "https://webhook.example.com",
 				"authnWebhookURL":     "https://authn.example.com",
 				"auditWebhookURL":     "https://audit.example.com",
@@ -882,23 +882,23 @@ func testEdgeCases(t *testing.T) {
 				"admissionPlugins": []string{
 					"CustomAdmissionPlugin",
 				},
-				"serviceAccount": map[string]interface{}{
+				"serviceAccount": map[string]any{
 					"issuer": "https://custom.issuer.com",
 					"additionalAPIIssuers": []string{
 						"https://additional.issuer.com",
 					},
 				},
 				"auditPolicy": "complex-policy",
-				"auditLog": map[string]interface{}{
+				"auditLog": map[string]any{
 					"output": "File",
 					"path":   "/var/log/audit",
 				},
 			}
-			data["etcd"] = map[string]interface{}{
+			data["etcd"] = map[string]any{
 				"existingCluster":   true,
 				"quotaBackendBytes": "8589934592",
 			}
-			data["arguments"] = map[string]interface{}{
+			data["arguments"] = map[string]any{
 				"nodeMonitorPeriod":                   45,
 				"nodeMonitorGracePeriod":              90,
 				"podEvictionTimeout":                  180,
@@ -984,11 +984,11 @@ func testEdgeCases(t *testing.T) {
 	}
 }
 
-func getBaseTemplateData(k8sVersion string) map[string]interface{} {
-	return map[string]interface{}{
+func getBaseTemplateData(k8sVersion string) map[string]any {
+	return map[string]any{
 		"nodeIP":  "127.0.0.1",
 		"runType": "ClusterBootstrap",
-		"clusterConfiguration": map[string]interface{}{
+		"clusterConfiguration": map[string]any{
 			"kubernetesVersion":       k8sVersion,
 			"clusterType":             "Static",
 			"serviceSubnetCIDR":       "10.222.0.0/16",
@@ -997,21 +997,21 @@ func getBaseTemplateData(k8sVersion string) map[string]interface{} {
 			"clusterDomain":           "cluster.local",
 			"encryptionAlgorithm":     "ECDSA-P256",
 		},
-		"k8s": map[string]interface{}{
-			k8sVersion: map[string]interface{}{
+		"k8s": map[string]any{
+			k8sVersion: map[string]any{
 				"patch": 1,
 			},
 		},
-		"registry": map[string]interface{}{
+		"registry": map[string]any{
 			"address": "registry.deckhouse.io",
 			"path":    "/deckhouse/ce",
 		},
-		"images": map[string]interface{}{},
+		"images": map[string]any{},
 	}
 }
 
 // Don't pass requestedManifests to get all manifests
-func renderFullManifests(data map[string]interface{}, requestedManifests ...string) (map[string]string, error) {
+func renderFullManifests(data map[string]any, requestedManifests ...string) (map[string]string, error) {
 	templatesPath := "/deckhouse/candi/control-plane"
 	manifests := make(map[string]string)
 
@@ -1080,7 +1080,7 @@ func testMissingCoverage(t *testing.T) {
 		t.Run(fmt.Sprintf("No NodeIP Configuration (v%s)", version), func(t *testing.T) {
 			data := getBaseTemplateData(version)
 			delete(data, "nodeIP")
-			data["registry"] = map[string]interface{}{
+			data["registry"] = map[string]any{
 				"address": "registry.example.com",
 				"path":    "/deckhouse",
 			}
@@ -1108,12 +1108,12 @@ func testMissingCoverage(t *testing.T) {
 		t.Run(fmt.Sprintf("Manifests Without NodeIP (v%s)", version), func(t *testing.T) {
 			data := getBaseTemplateData(version)
 			delete(data, "nodeIP")
-			data["images"] = map[string]interface{}{
-				"controlPlaneManager": map[string]interface{}{
+			data["images"] = map[string]any{
+				"controlPlaneManager": map[string]any{
 					"kubeApiserverHealthcheck": "sha256:abcd1234",
 				},
 			}
-			data["registry"] = map[string]interface{}{
+			data["registry"] = map[string]any{
 				"address": "registry.example.com",
 				"path":    "/deckhouse",
 			}
@@ -1137,8 +1137,8 @@ func testMissingCoverage(t *testing.T) {
 	for _, version := range versions {
 		t.Run(fmt.Sprintf("Service Account Edge Cases (v%s)", version), func(t *testing.T) {
 			data := getBaseTemplateData(version)
-			data["apiserver"] = map[string]interface{}{
-				"serviceAccount": map[string]interface{}{
+			data["apiserver"] = map[string]any{
+				"serviceAccount": map[string]any{
 					"additionalAPIIssuers": []string{
 						"https://external.issuer.com",
 					},
@@ -1160,7 +1160,7 @@ func testMissingCoverage(t *testing.T) {
 	for _, version := range versions {
 		t.Run(fmt.Sprintf("ETCD Without Existing Cluster (v%s)", version), func(t *testing.T) {
 			data := getBaseTemplateData(version)
-			data["etcd"] = map[string]interface{}{
+			data["etcd"] = map[string]any{
 				"existingCluster": false,
 			}
 
@@ -1179,7 +1179,7 @@ func testMissingCoverage(t *testing.T) {
 	for _, version := range versions {
 		t.Run(fmt.Sprintf("Audit Volume Mount Edge Cases (v%s)", version), func(t *testing.T) {
 			data := getBaseTemplateData(version)
-			data["apiserver"] = map[string]interface{}{
+			data["apiserver"] = map[string]any{
 				"auditPolicy": "some-policy",
 			}
 
@@ -1225,7 +1225,7 @@ func testMissingCoverage(t *testing.T) {
 		t.Run(fmt.Sprintf("Bind Address Configuration (v%s)", version), func(t *testing.T) {
 			data := getBaseTemplateData(version)
 			data["runType"] = "Runtime"
-			data["apiserver"] = map[string]interface{}{
+			data["apiserver"] = map[string]any{
 				"bindToWildcard": true,
 			}
 

--- a/dhctl/pkg/template/engine.go
+++ b/dhctl/pkg/template/engine.go
@@ -27,7 +27,7 @@ import (
 
 type Engine struct {
 	Name string
-	Data map[string]interface{}
+	Data map[string]any
 }
 
 // Render
@@ -41,12 +41,12 @@ func (e Engine) initFunMap(t *template.Template) {
 	funcMap := FuncMap()
 
 	// include function isn't required in candi templates
-	funcMap["include"] = func(name string, data interface{}) (string, error) {
+	funcMap["include"] = func(name string, data any) (string, error) {
 		return "NotImplemented", nil
 	}
 
 	// Add the 'tpl' function here
-	funcMap["tpl"] = func(tpl string, vals map[string]interface{}) (string, error) {
+	funcMap["tpl"] = func(tpl string, vals map[string]any) (string, error) {
 		clone, err := t.Clone()
 		if err != nil {
 			return "", errors.Errorf("clone template failed: %v", err)
@@ -60,7 +60,7 @@ func (e Engine) initFunMap(t *template.Template) {
 	}
 
 	// Add the `required` function here so we can use lintMode
-	funcMap["required"] = func(warn string, val interface{}) (interface{}, error) {
+	funcMap["required"] = func(warn string, val any) (any, error) {
 		if val == nil {
 			return val, errors.Errorf("%s", warnWrap(warn))
 		} else if _, ok := val.(string); ok {

--- a/dhctl/pkg/template/execute.go
+++ b/dhctl/pkg/template/execute.go
@@ -38,7 +38,7 @@ type RenderedTemplate struct {
 // RenderTemplatesDir renders each file in templatesDir.
 // Files are rendered separately, so no support for
 // libraries, like in Helm.
-func RenderTemplatesDir(templatesDir string, data map[string]interface{}, ignoreMap map[string]struct{}) ([]RenderedTemplate, error) {
+func RenderTemplatesDir(templatesDir string, data map[string]any, ignoreMap map[string]struct{}) ([]RenderedTemplate, error) {
 	files, err := os.ReadDir(templatesDir)
 	if os.IsNotExist(err) {
 		log.InfoF("Templates directory %q does not exist. Skipping...\n", templatesDir)
@@ -81,7 +81,7 @@ func RenderTemplatesDir(templatesDir string, data map[string]interface{}, ignore
 	return renders, nil
 }
 
-func RenderTemplate(name string, content []byte, data map[string]interface{}) (*RenderedTemplate, error) {
+func RenderTemplate(name string, content []byte, data map[string]any) (*RenderedTemplate, error) {
 	// render chart with prepared values
 	e := Engine{
 		Name: name,
@@ -124,7 +124,7 @@ func NewTemplateController(tmpDir string) *Controller {
 	return &Controller{TmpDir: tmpDir}
 }
 
-func (t *Controller) RenderAndSaveTemplates(fromDir, toDir string, data map[string]interface{}, ignoreMap map[string]struct{}) error {
+func (t *Controller) RenderAndSaveTemplates(fromDir, toDir string, data map[string]any, ignoreMap map[string]struct{}) error {
 	renderedTemplates, err := RenderTemplatesDir(fromDir, data, ignoreMap)
 	if err != nil {
 		return fmt.Errorf("render templates: %v", err)
@@ -138,7 +138,7 @@ func (t *Controller) RenderAndSaveTemplates(fromDir, toDir string, data map[stri
 	return nil
 }
 
-func (t *Controller) RenderBashBooster(fromDir, toDir string, data map[string]interface{}) error {
+func (t *Controller) RenderBashBooster(fromDir, toDir string, data map[string]any) error {
 	bashBooster, err := RenderBashBooster(fromDir, data)
 	if err != nil {
 		return fmt.Errorf("render bashboster: %v", err)

--- a/dhctl/pkg/template/execute_test.go
+++ b/dhctl/pkg/template/execute_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestExecuteTemplate_DefineAndInclude(t *testing.T) {
-	var data map[string]interface{}
+	var data map[string]any
 
 	err := yaml.Unmarshal([]byte(`
 nodeIP: "127.0.0.1"

--- a/dhctl/pkg/template/funcs.go
+++ b/dhctl/pkg/template/funcs.go
@@ -33,6 +33,7 @@ package template
 import (
 	"bytes"
 	"encoding/json"
+	"maps"
 	"strings"
 	"text/template"
 
@@ -81,19 +82,17 @@ func FuncMap() template.FuncMap {
 		// This is a placeholder for the "include" function, which is
 		// late-bound to a template. By declaring it here, we preserve the
 		// integrity of the linter.
-		"include":  func(string, interface{}) string { return "not implemented" },
-		"tpl":      func(string, interface{}) interface{} { return "not implemented" },
-		"required": func(string, interface{}) (interface{}, error) { return "not implemented", nil },
+		"include":  func(string, any) string { return "not implemented" },
+		"tpl":      func(string, any) any { return "not implemented" },
+		"required": func(string, any) (any, error) { return "not implemented", nil },
 		// Provide a placeholder for the "lookup" function, which requires a kubernetes
 		// connection.
-		"lookup": func(string, string, string, string) (map[string]interface{}, error) {
-			return map[string]interface{}{}, nil
+		"lookup": func(string, string, string, string) (map[string]any, error) {
+			return map[string]any{}, nil
 		},
 	}
 
-	for k, v := range extra {
-		f[k] = v
-	}
+	maps.Copy(f, extra)
 
 	return f
 }
@@ -102,7 +101,7 @@ func FuncMap() template.FuncMap {
 // always return a string, even on marshal error (empty string).
 //
 // This is designed to be called from a template.
-func toYAML(v interface{}) string {
+func toYAML(v any) string {
 	data, err := yaml.Marshal(v)
 	if err != nil {
 		// Swallow errors inside of a template.
@@ -117,8 +116,8 @@ func toYAML(v interface{}) string {
 // YAML documents. Additionally, because its intended use is within templates
 // it tolerates errors. It will insert the returned error message string into
 // m["Error"] in the returned map.
-func fromYAML(str string) map[string]interface{} {
-	m := map[string]interface{}{}
+func fromYAML(str string) map[string]any {
+	m := map[string]any{}
 
 	if err := yaml.Unmarshal([]byte(str), &m); err != nil {
 		m["Error"] = err.Error()
@@ -132,11 +131,11 @@ func fromYAML(str string) map[string]interface{} {
 // YAML documents. Additionally, because its intended use is within templates
 // it tolerates errors. It will insert the returned error message string as
 // the first and only item in the returned array.
-func fromYAMLArray(str string) []interface{} {
-	a := []interface{}{}
+func fromYAMLArray(str string) []any {
+	a := []any{}
 
 	if err := yaml.Unmarshal([]byte(str), &a); err != nil {
-		a = []interface{}{err.Error()}
+		a = []any{err.Error()}
 	}
 	return a
 }
@@ -145,7 +144,7 @@ func fromYAMLArray(str string) []interface{} {
 // always return a string, even on marshal error (empty string).
 //
 // This is designed to be called from a template.
-func toTOML(v interface{}) string {
+func toTOML(v any) string {
 	b := bytes.NewBuffer(nil)
 	e := toml.NewEncoder(b)
 	err := e.Encode(v)
@@ -159,7 +158,7 @@ func toTOML(v interface{}) string {
 // always return a string, even on marshal error (empty string).
 //
 // This is designed to be called from a template.
-func toJSON(v interface{}) string {
+func toJSON(v any) string {
 	data, err := json.Marshal(v)
 	if err != nil {
 		// Swallow errors inside of a template.
@@ -174,8 +173,8 @@ func toJSON(v interface{}) string {
 // JSON documents. Additionally, because its intended use is within templates
 // it tolerates errors. It will insert the returned error message string into
 // m["Error"] in the returned map.
-func fromJSON(str string) map[string]interface{} {
-	m := make(map[string]interface{})
+func fromJSON(str string) map[string]any {
+	m := make(map[string]any)
 
 	if err := json.Unmarshal([]byte(str), &m); err != nil {
 		m["Error"] = err.Error()
@@ -189,11 +188,11 @@ func fromJSON(str string) map[string]interface{} {
 // JSON documents. Additionally, because its intended use is within templates
 // it tolerates errors. It will insert the returned error message string as
 // the first and only item in the returned array.
-func fromJSONArray(str string) []interface{} {
-	a := []interface{}{}
+func fromJSONArray(str string) []any {
+	a := []any{}
 
 	if err := json.Unmarshal([]byte(str), &a); err != nil {
-		a = []interface{}{err.Error()}
+		a = []any{err.Error()}
 	}
 	return a
 }

--- a/dhctl/pkg/template/node_group_configuration.go
+++ b/dhctl/pkg/template/node_group_configuration.go
@@ -27,7 +27,7 @@ func prepareNodeGroupConfigurationSteps(
 	ctx context.Context,
 	templateController *Controller,
 	resourcesYAML string,
-	templateData map[string]interface{},
+	templateData map[string]any,
 ) error {
 	ngc, err := config.ParseInternalBootstrapNodeGroupConfiguration(ctx, resourcesYAML)
 	if err != nil {

--- a/dhctl/pkg/template/node_group_configuration_test.go
+++ b/dhctl/pkg/template/node_group_configuration_test.go
@@ -42,11 +42,11 @@ spec:
     - "*"
 `
 
-	templateData := map[string]interface{}{
-		"nodeGroup": map[string]interface{}{
+	templateData := map[string]any{
+		"nodeGroup": map[string]any{
 			"name": "master",
 		},
-		"clusterBootstrap": map[string]interface{}{
+		"clusterBootstrap": map[string]any{
 			"clusterDomain": "cluster.local",
 		},
 	}
@@ -65,7 +65,7 @@ func TestPrepareNodeGroupConfigurationSteps_NoNGC(t *testing.T) {
 	templateController := NewTemplateController("")
 	t.Cleanup(templateController.Close)
 
-	err := prepareNodeGroupConfigurationSteps(context.Background(), templateController, "", map[string]interface{}{})
+	err := prepareNodeGroupConfigurationSteps(context.Background(), templateController, "", map[string]any{})
 	require.NoError(t, err)
 
 	stepsPath := filepath.Join(templateController.TmpDir, stepsDir)
@@ -91,7 +91,7 @@ spec:
     - "*"
 `
 
-	err := prepareNodeGroupConfigurationSteps(context.Background(), templateController, resourcesYAML, map[string]interface{}{})
+	err := prepareNodeGroupConfigurationSteps(context.Background(), templateController, resourcesYAML, map[string]any{})
 	require.NoError(t, err)
 
 	stepsPath := filepath.Join(templateController.TmpDir, stepsDir)

--- a/dhctl/pkg/template/preflight.go
+++ b/dhctl/pkg/template/preflight.go
@@ -35,14 +35,14 @@ func RenderAndSavePreflightCheckPortsScript(globalOptions *options.GlobalOptions
 	log.DebugLn("Rendering check ports script")
 	scriptPath := filepath.Join(globalOptions.CandiDir, "bashible", checkPortsScriptPath)
 
-	return RenderAndSaveTemplate("check_ports.sh", scriptPath, map[string]interface{}{})
+	return RenderAndSaveTemplate("check_ports.sh", scriptPath, map[string]any{})
 }
 
 func RenderAndSavePreflightCheckDeckhouseUserScript(globalOptions *options.GlobalOptions) (string, error) {
 	log.DebugLn("Rendering check user script")
 	scriptPath := filepath.Join(globalOptions.CandiDir, "bashible", checkDeckhouseUserScriptPath)
 
-	return RenderAndSaveTemplate("check_deckhouse_user.sh", scriptPath, map[string]interface{}{})
+	return RenderAndSaveTemplate("check_deckhouse_user.sh", scriptPath, map[string]any{})
 }
 
 func RenderAndSavePreflightCheckLocalhostScript(globalOptions *options.GlobalOptions) (string, error) {
@@ -52,7 +52,7 @@ func RenderAndSavePreflightCheckLocalhostScript(globalOptions *options.GlobalOpt
 	return RenderAndSaveTemplate(
 		"check_localhost.sh",
 		scriptPath,
-		map[string]interface{}{},
+		map[string]any{},
 	)
 }
 
@@ -63,7 +63,7 @@ func RenderAndSavePreflightReverseTunnelOpenScript(url string, globalOptions *op
 	return RenderAndSaveTemplate(
 		"check_reverse_tunnel_open.sh",
 		scriptPath,
-		map[string]interface{}{
+		map[string]any{
 			"url": url,
 		},
 	)
@@ -76,7 +76,7 @@ func RenderAndSaveKillReverseTunnelScript(host, port string, globalOptions *opti
 	return RenderAndSaveTemplate(
 		"kill_reverse_tunnel.sh",
 		scriptPath,
-		map[string]interface{}{
+		map[string]any{
 			"host": host,
 			"port": port,
 		},
@@ -98,7 +98,7 @@ func RenderAndSavePreflightReverseTunnelReachableScript(url string, globalOption
 
 func RenderAndSavePreflightCheckScript(
 	filename string,
-	params map[string]interface{},
+	params map[string]any,
 	globalOptions *options.GlobalOptions,
 ) (string, error) {
 	log.DebugLn("Rendering check localhost script")

--- a/dhctl/pkg/template/resources.go
+++ b/dhctl/pkg/template/resources.go
@@ -127,7 +127,7 @@ func (r Resources) Less(i, j int) bool {
 	return firstOrder < secondOrder
 }
 
-func ParseResourcesContent(content string, data map[string]interface{}) (Resources, error) {
+func ParseResourcesContent(content string, data map[string]any) (Resources, error) {
 	if data != nil {
 		t := template.New("resource_render").Funcs(FuncMap())
 		t, err := t.Parse(content)
@@ -189,7 +189,7 @@ func (r Resources) String() string {
 	return strings.Join(s, ";")
 }
 
-func loadResources(path string, data map[string]interface{}) (Resources, error) {
+func loadResources(path string, data map[string]any) (Resources, error) {
 	fileContent, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("loading resources file: %v", err)
@@ -200,7 +200,7 @@ func loadResources(path string, data map[string]interface{}) (Resources, error) 
 	return ParseResourcesContent(content, data)
 }
 
-func ParseResources(path string, data map[string]interface{}) (Resources, error) {
+func ParseResources(path string, data map[string]any) (Resources, error) {
 	resources, err := loadResources(path, data)
 	if err != nil {
 		return nil, err

--- a/dhctl/pkg/template/resources_test.go
+++ b/dhctl/pkg/template/resources_test.go
@@ -28,7 +28,7 @@ var (
 	cmKind = schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"}
 )
 
-func fromUnstructured(unstructuredObj unstructured.Unstructured, obj interface{}) {
+func fromUnstructured(unstructuredObj unstructured.Unstructured, obj any) {
 	err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredObj.UnstructuredContent(), obj)
 	if err != nil {
 		panic(err)
@@ -92,9 +92,9 @@ func TestResourcesOrderWithSameKind(t *testing.T) {
 func TestResourcesWithTemplateData(t *testing.T) {
 	const expectedValueFromCloudData = "id1"
 	t.Run("parses template resources and put data in manifests", func(t *testing.T) {
-		resources, err := ParseResources("testdata/resources/with_tmp.yaml", map[string]interface{}{
-			"cloudDiscovery": map[string]interface{}{
-				"networkId": map[string]interface{}{
+		resources, err := ParseResources("testdata/resources/with_tmp.yaml", map[string]any{
+			"cloudDiscovery": map[string]any{
+				"networkId": map[string]any{
 					"ru-central1-a": expectedValueFromCloudData,
 					"ru-central1-b": expectedValueFromCloudData + "1",
 					"ru-central1-c": expectedValueFromCloudData + "2",
@@ -123,8 +123,8 @@ func TestResourcesWithTemplateData(t *testing.T) {
 
 func TestResourcesNotExistsTemplateDataReturnError(t *testing.T) {
 	t.Run("returns error if value not found in data", func(t *testing.T) {
-		resources, err := ParseResources("testdata/resources/with_tmp.yaml", map[string]interface{}{
-			"cloudDiscovery": map[string]interface{}{
+		resources, err := ParseResources("testdata/resources/with_tmp.yaml", map[string]any{
+			"cloudDiscovery": map[string]any{
 				"anotherKey": "anotherValue",
 			},
 		})
@@ -136,7 +136,7 @@ func TestResourcesNotExistsTemplateDataReturnError(t *testing.T) {
 
 func TestResourcesWithEmptyDocs(t *testing.T) {
 	t.Run("returns only not empty resources", func(t *testing.T) {
-		resources, err := ParseResources("testdata/resources/empties_docs.yaml", make(map[string]interface{}))
+		resources, err := ParseResources("testdata/resources/empties_docs.yaml", make(map[string]any))
 
 		require.NoError(t, err)
 		require.Len(t, resources, 2)

--- a/dhctl/pkg/template/template.go
+++ b/dhctl/pkg/template/template.go
@@ -21,7 +21,7 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 )
 
-func RenderAndSaveTemplate(outFileName, templatePath string, data map[string]interface{}) (string, error) {
+func RenderAndSaveTemplate(outFileName, templatePath string, data map[string]any) (string, error) {
 	fileContent, err := os.ReadFile(templatePath)
 	if err != nil {
 		return "", fmt.Errorf("loading %s: %v", templatePath, err)

--- a/dhctl/pkg/terminal/ask-password.go
+++ b/dhctl/pkg/terminal/ask-password.go
@@ -48,7 +48,7 @@ func AskPassword(prompt string) ([]byte, error) {
 		return nil, fmt.Errorf("stdin is not a terminal, cannot read password")
 	}
 
-	log.InfoF(prompt)
+	log.InfoF("%s", prompt)
 	data, err := terminal.ReadPassword(fd)
 	log.InfoLn()
 
@@ -87,7 +87,7 @@ func readPassword(prompt string) ([]byte, error) {
 	if !terminal.IsTerminal(fd) {
 		data, err = io.ReadAll(os.Stdin)
 	} else {
-		log.InfoF(prompt)
+		log.InfoF("%s", prompt)
 		data, err = terminal.ReadPassword(fd)
 	}
 

--- a/dhctl/pkg/util/cache/cache.go
+++ b/dhctl/pkg/util/cache/cache.go
@@ -99,7 +99,7 @@ func (s *StateCache) Save(ctx context.Context, name string, content []byte) erro
 }
 
 // SaveStruct saves go struct into the cache as a blob
-func (s *StateCache) SaveStruct(ctx context.Context, name string, v interface{}) error {
+func (s *StateCache) SaveStruct(ctx context.Context, name string, v any) error {
 	b := new(bytes.Buffer)
 	err := gob.NewEncoder(b).Encode(v)
 	if err != nil {
@@ -176,7 +176,7 @@ func (s *StateCache) Load(ctx context.Context, name string) ([]byte, error) {
 }
 
 // LoadStruct loads go struct from the cache
-func (s *StateCache) LoadStruct(ctx context.Context, name string, v interface{}) error {
+func (s *StateCache) LoadStruct(ctx context.Context, name string, v any) error {
 	d, err := s.Load(ctx, name)
 	if err != nil {
 		return fmt.Errorf("can't load struct for key %s: %v", name, err)
@@ -225,18 +225,18 @@ func (s *StateCache) Dir() string {
 // DummyCache is a cache implementation which saves nothing and nowhere
 type DummyCache struct{}
 
-func (d *DummyCache) Save(ctx context.Context, n string, c []byte) error            { return nil }
-func (d *DummyCache) SaveStruct(ctx context.Context, n string, v interface{}) error { return nil }
-func (d *DummyCache) InCache(ctx context.Context, n string) (bool, error)           { return false, nil }
-func (d *DummyCache) Clean(ctx context.Context)                                     {}
-func (d *DummyCache) CleanWithExceptions(ctx context.Context, e ...string)          {}
-func (d *DummyCache) Delete(ctx context.Context, n string)                          {}
-func (d *DummyCache) Load(ctx context.Context, n string) ([]byte, error)            { return nil, nil }
-func (d *DummyCache) LoadStruct(ctx context.Context, n string, v interface{}) error { return nil }
-func (d *DummyCache) GetPath(n string) string                                       { return "" }
-func (d *DummyCache) Iterate(context.Context, func(string, []byte) error) error     { return nil }
-func (d *DummyCache) NeedIntermediateSave() bool                                    { return false }
-func (d *DummyCache) Dir() string                                                   { return "" }
+func (d *DummyCache) Save(ctx context.Context, n string, c []byte) error        { return nil }
+func (d *DummyCache) SaveStruct(ctx context.Context, n string, v any) error     { return nil }
+func (d *DummyCache) InCache(ctx context.Context, n string) (bool, error)       { return false, nil }
+func (d *DummyCache) Clean(ctx context.Context)                                 {}
+func (d *DummyCache) CleanWithExceptions(ctx context.Context, e ...string)      {}
+func (d *DummyCache) Delete(ctx context.Context, n string)                      {}
+func (d *DummyCache) Load(ctx context.Context, n string) ([]byte, error)        { return nil, nil }
+func (d *DummyCache) LoadStruct(ctx context.Context, n string, v any) error     { return nil }
+func (d *DummyCache) GetPath(n string) string                                   { return "" }
+func (d *DummyCache) Iterate(context.Context, func(string, []byte) error) error { return nil }
+func (d *DummyCache) NeedIntermediateSave() bool                                { return false }
+func (d *DummyCache) Dir() string                                               { return "" }
 
 type TestCache struct {
 	Store map[string][]byte
@@ -280,7 +280,7 @@ func (d *TestCache) Load(ctx context.Context, n string) ([]byte, error) {
 	return d.Store[n], nil
 }
 
-func (d *TestCache) LoadStruct(ctx context.Context, n string, v interface{}) error {
+func (d *TestCache) LoadStruct(ctx context.Context, n string, v any) error {
 	data, err := d.Load(ctx, n)
 	if err != nil {
 		return fmt.Errorf("can't load struct for key %s: %v", n, err)
@@ -289,7 +289,7 @@ func (d *TestCache) LoadStruct(ctx context.Context, n string, v interface{}) err
 	return gob.NewDecoder(bytes.NewBuffer(data)).Decode(v)
 }
 
-func (d *TestCache) SaveStruct(ctx context.Context, n string, v interface{}) error {
+func (d *TestCache) SaveStruct(ctx context.Context, n string, v any) error {
 	b := new(bytes.Buffer)
 	err := gob.NewEncoder(b).Encode(v)
 	if err != nil {

--- a/dhctl/pkg/util/cache/tmp.go
+++ b/dhctl/pkg/util/cache/tmp.go
@@ -307,6 +307,6 @@ func remove(fullPath string, logger log.Logger, msg string) {
 	logger.LogDebugF("%s: '%s'\n", msg, fullPath)
 	err := os.Remove(fullPath)
 	if err != nil && !os.IsNotExist(err) {
-		logger.LogInfoF("%s % did not success'%s': %v\n", cleanupErrorPrefix, msg, fullPath, err)
+		logger.LogInfoF("%s %s did not success'%s': %v\n", cleanupErrorPrefix, msg, fullPath, err)
 	}
 }

--- a/dhctl/pkg/util/fs/random_test.go
+++ b/dhctl/pkg/util/fs/random_test.go
@@ -22,7 +22,7 @@ const selectionSize = 10000
 
 func TestRandomTmpFileName(t *testing.T) {
 	set := make(map[string]bool, selectionSize) // Use a map as a set
-	for i := 0; i < selectionSize; i++ {
+	for range selectionSize {
 		set[RandomTmpFileName()] = true
 	}
 	difference := selectionSize - len(set)
@@ -34,7 +34,7 @@ func TestRandomTmpFileName(t *testing.T) {
 // technically, this one has already being tested as part of TestRandomTmpFileName
 func TestRandomNumberSuffix(t *testing.T) {
 	set := make(map[string]bool, selectionSize) // Use a map as a set
-	for i := 0; i < selectionSize; i++ {
+	for range selectionSize {
 		set[RandomNumberSuffix("dhctl-tst-touch")] = true
 	}
 	difference := selectionSize - len(set)

--- a/dhctl/pkg/util/image/image.go
+++ b/dhctl/pkg/util/image/image.go
@@ -215,7 +215,7 @@ func getHash(digest, dstPath string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("cannot open file %s: %w", path, err)
 	}
-	var hashs map[string]interface{}
+	var hashs map[string]any
 	err = json.Unmarshal(data, &hashs)
 	if err != nil {
 		return "", fmt.Errorf("unmarshalling json: %w", err)

--- a/dhctl/pkg/util/input/yaml_test.go
+++ b/dhctl/pkg/util/input/yaml_test.go
@@ -161,7 +161,6 @@ kind: ModuleConfig
 	}
 
 	for name, tt := range tests {
-		tt := tt
 		t.Run(name, func(t *testing.T) {
 			out := input.CombineYAMLs(tt.in...)
 			assert.Equal(t, tt.out, out)

--- a/dhctl/pkg/util/maputil/maputil.go
+++ b/dhctl/pkg/util/maputil/maputil.go
@@ -14,6 +14,8 @@
 
 package maputil
 
+import "maps"
+
 func ExcludeKeys(m map[string]string, excludeKeys ...string) map[string]string {
 	excludeKeysSet := make(map[string]struct{})
 	for _, k := range excludeKeys {
@@ -35,17 +37,13 @@ func ExcludeKeys(m map[string]string, excludeKeys ...string) map[string]string {
 
 func Join[K comparable, V any](dst map[K]V, sources ...map[K]V) {
 	for _, src := range sources {
-		for k, v := range src {
-			dst[k] = v
-		}
+		maps.Copy(dst, src)
 	}
 }
 
 func Clone[K comparable, V any](in map[K]V) map[K]V {
 	out := make(map[K]V)
-	for k, v := range in {
-		out[k] = v
-	}
+	maps.Copy(out, in)
 	return out
 }
 

--- a/dhctl/pkg/util/retry/retry_test.go
+++ b/dhctl/pkg/util/retry/retry_test.go
@@ -60,8 +60,7 @@ func TestLoop_Run_BreakIfPredicate(t *testing.T) {
 }
 
 func TestLoop_RunContext_SuccessOnFirstAttempt(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	log.InitLogger("json", false)
 	loop := NewLoop("test loop", 3, 10*time.Millisecond)
@@ -72,8 +71,7 @@ func TestLoop_RunContext_SuccessOnFirstAttempt(t *testing.T) {
 }
 
 func TestLoop_RunContext_SuccessAfterRetries(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	log.InitLogger("json", false)
 	attempt := 0

--- a/dhctl/pkg/util/stringsutil/strings_test.go
+++ b/dhctl/pkg/util/stringsutil/strings_test.go
@@ -93,7 +93,7 @@ func TestRandomStrElement(t *testing.T) {
 	const stringsSize = 10000
 	const maximumConsecutiveRepetitionsThreshold = 4 // allow for no more than 4+1 consecutive elements (can very rarely happen due to the nature of random numbers)
 	strings := make([]string, 0, stringsSize)
-	for i := 0; i < stringsSize; i++ {
+	for i := range stringsSize {
 		strings = append(strings, strconv.Itoa(i)) // this will yield a different value for each string in the array
 	}
 	// as the string size is very big, consecutive repetitions should be extremely rare
@@ -105,7 +105,7 @@ func TestRandomStrElement(t *testing.T) {
 			maximumConsecutiveRepetitions = consecutiveRepetitions
 		}
 	}
-	for i := 0; i < selectionSize; i++ {
+	for range selectionSize {
 		v, index := RandomStrElement(strings)
 		require.Equal(t, strings[index], v, "index does not agree with the value after RandomStrElement")
 		if v == previousValue {

--- a/dhctl/pkg/util/tls/gen_cert.go
+++ b/dhctl/pkg/util/tls/gen_cert.go
@@ -62,8 +62,8 @@ func GenerateCertificate(serviceName, clusterDomain string, keyType CertKeyType,
 	}
 
 	var (
-		priv interface{}
-		pub  interface{}
+		priv any
+		pub  any
 		err  error
 	)
 	switch keyType {

--- a/dhctl/pkg/util/tomb/tomb_test.go
+++ b/dhctl/pkg/util/tomb/tomb_test.go
@@ -139,8 +139,7 @@ func runAction(t *testing.T, p *testActionParams) *testRunResult {
 	err = cmd.Wait()
 
 	exitCode := 0
-	var exitError *exec.ExitError
-	if errors.As(err, &exitError) {
+	if exitError, ok := errors.AsType[*exec.ExitError](err); ok {
 		exitCode = exitError.ExitCode()
 	}
 


### PR DESCRIPTION
## Description

Bumped the Go version for dhctl to 1.26.4.

Updated the codebase to comply with Go 1.26 tooling and syntax recommendations, including fixes for new vet checks and automatic syntax modernizations suggested by GoLand and go fix.

## Why do we need it, and what problem does it solve?

Keeps dhctl aligned with the latest Go toolchain and prevents build and lint issues caused by stricter Go 1.26 checks.

The changes also modernize several code patterns according to Go 1.26 recommendations, reducing technical debt and improving compatibility with future Go releases.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: dhctl
type: feature 
summary: Bump Go version to 1.26.4 and apply Go 1.26 syntax and tooling updates.
impact_level: low
```