### PR TITLE
Fix reproducibility build timing check

### DIFF
--- a/.github/scripts/send-report.sh
+++ b/.github/scripts/send-report.sh
@@ -51,7 +51,7 @@ fi
 if [[ -z "$message" ]]; then
   if [[ "$branch" =~ ^release-[0-9]+\.[0-9]+$ ]] || [[ "$branch" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     message="🛑 Branch: **${branch}** Workflow: **${workflow_name}** Job: **${job_name}** failed! 🛑\n[URL]($workflow_url)"
-  elif
+  else
     message="🛑 Workflow: **${workflow_name}** Job: **${job_name}** failed! 🛑\n[URL]($workflow_url)"
   fi
 fi

--- a/.github/scripts/send-report.sh
+++ b/.github/scripts/send-report.sh
@@ -24,7 +24,7 @@ while [[ "$#" -gt 0 ]]; do
     --webhook)
       webhook_type="$2"
       message="$3"
-      shift
+      shift 2
       ;;
     --direct-post)
       direct_post_flag=true
@@ -47,11 +47,17 @@ branch="${GITHUB_REF_NAME}"
 if [[ -z "$webhook_type" ]]; then
   webhook_type="ci_fail"
 fi
-if [[ "$branch" =~ ^release-[0-9]+\.[0-9]+$ ]] || [[ "$branch" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-  message="🛑 Branch: **${branch}** Workflow: **${workflow_name}** Job: **${job_name}** failed! 🛑\n[URL]($workflow_url)"
-elif [[ -z "$message" ]]; then
-  message="🛑 Workflow: **${workflow_name}** Job: **${job_name}** failed! 🛑\n[URL]($workflow_url)"
+
+if [[ -z "$message" ]]; then
+  if [[ "$branch" =~ ^release-[0-9]+\.[0-9]+$ ]] || [[ "$branch" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    message="🛑 Branch: **${branch}** Workflow: **${workflow_name}** Job: **${job_name}** failed! 🛑\n[URL]($workflow_url)"
+  elif
+    message="🛑 Workflow: **${workflow_name}** Job: **${job_name}** failed! 🛑\n[URL]($workflow_url)"
+  fi
 fi
+
+
+
 
 file_id_array=()
 

--- a/.github/workflow_templates/reproducibility-timing-report.yml
+++ b/.github/workflow_templates/reproducibility-timing-report.yml
@@ -65,4 +65,5 @@ jobs:
         LOOP_SERVICE_NOTIFICATIONS: ${{ steps.secrets.outputs.LOOP_SERVICE_NOTIFICATIONS }}
         AVG_BUILD_TIME: ${{ steps.collect.outputs.avg_build_time }}
       run: |
-        bash ./.github/scripts/send-report.sh --webhook "ci_report" ":passport_control: **Average build time on the same commit is ${AVG_BUILD_TIME}** :passport_control:"
+        WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
+        bash ./.github/scripts/send-report.sh --webhook "ci_report" ":passport_control: **Average build time on the same commit is [${AVG_BUILD_TIME}](${WORKFLOW_URL})** :passport_control:"

--- a/.github/workflow_templates/reproducibility-timing-report.yml
+++ b/.github/workflow_templates/reproducibility-timing-report.yml
@@ -34,6 +34,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
   actions: read
 
 jobs:

--- a/.github/workflows/reproducibility-timing-report.yml
+++ b/.github/workflows/reproducibility-timing-report.yml
@@ -95,4 +95,5 @@ jobs:
         LOOP_SERVICE_NOTIFICATIONS: ${{ steps.secrets.outputs.LOOP_SERVICE_NOTIFICATIONS }}
         AVG_BUILD_TIME: ${{ steps.collect.outputs.avg_build_time }}
       run: |
-        bash ./.github/scripts/send-report.sh --webhook "ci_report" ":passport_control: **Average build time on the same commit is ${AVG_BUILD_TIME}** :passport_control:"
+        WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
+        bash ./.github/scripts/send-report.sh --webhook "ci_report" ":passport_control: **Average build time on the same commit is [${AVG_BUILD_TIME}](${WORKFLOW_URL})** :passport_control:"

--- a/.github/workflows/reproducibility-timing-report.yml
+++ b/.github/workflows/reproducibility-timing-report.yml
@@ -38,6 +38,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
   actions: read
 
 jobs:


### PR DESCRIPTION
## Description

Fix reproducibility build timing check

## Why do we need it, and what problem does it solve?

It was not working


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Fix reproducibility build timing check
impact: none
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
