### PR TITLE
[docs] Change the position of the marketplace in the sidebar in the architecture section

### DIFF
--- a/docs/documentation/_data/sidebars/main.yml
+++ b/docs/documentation/_data/sidebars/main.yml
@@ -1223,6 +1223,30 @@ entries:
                 ru: Разработка и отладка
               url: /architecture/module-development/development/
         - title:
+            en: Marketplace
+            ru: Marketplace
+          folders:
+            - title:
+                en: Overview
+                ru: Обзор
+              url: /architecture/marketplace/
+            - title:
+                en: Concepts
+                ru: Концепции
+              url: /architecture/marketplace/concepts.html
+            - title:
+                en: Application development
+                ru: Разработка приложений
+              url: /architecture/marketplace/application-development.html
+            - title:
+                en: Nelm annotations
+                ru: Аннотации Nelm
+              url: /architecture/marketplace/nelm-annotations.html
+            - title:
+                en: Hooks
+                ru: Хуки
+              url: /architecture/marketplace/hooks.html
+        - title:
             en: Disaster resilience
             ru: Катастрофоустойчивость
           folders:
@@ -1258,30 +1282,6 @@ entries:
                 en: Direct mode of registry module
                 ru: Режим Direct модуля registry
               url: /architecture/deckhouse/registry-direct-mode.html
-        - title:
-            en: Marketplace
-            ru: Marketplace
-          folders:
-            - title:
-                en: Overview
-                ru: Обзор
-              url: /architecture/marketplace/
-            - title:
-                en: Concepts
-                ru: Концепции
-              url: /architecture/marketplace/concepts.html
-            - title:
-                en: Application development
-                ru: Разработка приложений
-              url: /architecture/marketplace/application-development.html
-            - title:
-                en: Nelm annotations
-                ru: Аннотации Nelm
-              url: /architecture/marketplace/nelm-annotations.html
-            - title:
-                en: Hooks
-                ru: Хуки
-              url: /architecture/marketplace/hooks.html
         - title:
             en: Kubernetes & Scheduling subsystem
             ru: Подсистема Kubernetes & Scheduling


### PR DESCRIPTION
## Description

Move Marketplace section after Modules in the Architecture sidebar

## Why do we need it, and what problem does it solve?

## Why do we need it in the patch release (if we do)?

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: fix 
summary: Changed the position of the marketplace in the sidebar in the architecture section.
impact_level: low
```