### PR TITLE
[admission-policy-engine] Add complex nodeAffinity selector for gatekeeper controller-manager

### DIFF
--- a/modules/015-admission-policy-engine/template_tests/gatekeeper_deployment_test.go
+++ b/modules/015-admission-policy-engine/template_tests/gatekeeper_deployment_test.go
@@ -92,7 +92,6 @@ admissionPolicyEngine:
 			Expect(rendered).To(ContainSubstring("key: node-role.deckhouse.io/admission-policy-engine"))
 			Expect(rendered).To(ContainSubstring("key: node-role.kubernetes.io/control-plane"))
 			Expect(rendered).To(ContainSubstring("key: node-role.kubernetes.io/master"))
-			Expect(rendered).To(ContainSubstring("key: node-role.kubernetes.io/master"))
 		})
 	})
 

--- a/modules/015-admission-policy-engine/template_tests/gatekeeper_deployment_test.go
+++ b/modules/015-admission-policy-engine/template_tests/gatekeeper_deployment_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template_tests
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/helm"
+)
+
+var _ = Describe("Module :: admissionPolicyEngine :: gatekeeper deployment scheduling", func() {
+	f := SetupHelmConfig(`
+admissionPolicyEngine:
+  podSecurityStandards: {}
+  internal:
+    bootstrapped: true
+    ratify:
+      webhook:
+        ca: test-ca-placeholder
+        crt: test-crt-placeholder
+        key: test-key-placeholder
+    podSecurityStandards:
+      enforcementActions:
+        - deny
+    trackedConstraintResources: []
+    trackedMutateResources: []
+    webhook:
+      ca: test-ca-placeholder
+      crt: test-crt-placeholder
+      key: test-key-placeholder
+`)
+
+	BeforeEach(func() {
+		f.ValuesSetFromYaml("global", globalValues)
+		f.ValuesSet("global.modulesImages", GetModulesImages())
+	})
+
+	Context("When system nodes are available", func() {
+		BeforeEach(func() {
+			f.HelmRender()
+		})
+
+		It("must keep webhook Gatekeeper on system nodes", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			dp := f.KubernetesResource("Deployment", nsName, "gatekeeper-controller-manager")
+			Expect(dp.Exists()).To(BeTrue())
+
+			Expect(dp.Field("spec.template.spec.nodeSelector").Exists()).To(BeFalse())
+			rendered := dp.ToYaml()
+			Expect(rendered).To(ContainSubstring("requiredDuringSchedulingIgnoredDuringExecution"))
+			Expect(rendered).To(ContainSubstring("preferredDuringSchedulingIgnoredDuringExecution"))
+			Expect(rendered).To(ContainSubstring("key: node-role.deckhouse.io/system"))
+			Expect(rendered).To(ContainSubstring("key: node-role.deckhouse.io/admission-policy-engine"))
+			Expect(rendered).To(ContainSubstring("key: node-role.kubernetes.io/control-plane"))
+			Expect(rendered).To(ContainSubstring("key: node-role.kubernetes.io/master"))
+		})
+	})
+
+	Context("When system nodes are absent", func() {
+		BeforeEach(func() {
+			f.ValuesSet("global.discovery.d8SpecificNodeCountByRole.system", 0)
+			f.HelmRender()
+		})
+
+		It("must fallback webhook Gatekeeper to control-plane nodes", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			dp := f.KubernetesResource("Deployment", nsName, "gatekeeper-controller-manager")
+			Expect(dp.Exists()).To(BeTrue())
+
+			Expect(dp.Field("spec.template.spec.nodeSelector").Exists()).To(BeFalse())
+			rendered := dp.ToYaml()
+			Expect(rendered).To(ContainSubstring("requiredDuringSchedulingIgnoredDuringExecution"))
+			Expect(rendered).To(ContainSubstring("preferredDuringSchedulingIgnoredDuringExecution"))
+			Expect(rendered).To(ContainSubstring("key: node-role.deckhouse.io/system"))
+			Expect(rendered).To(ContainSubstring("key: node-role.deckhouse.io/admission-policy-engine"))
+			Expect(rendered).To(ContainSubstring("key: node-role.kubernetes.io/control-plane"))
+			Expect(rendered).To(ContainSubstring("key: node-role.kubernetes.io/master"))
+			Expect(rendered).To(ContainSubstring("key: node-role.kubernetes.io/master"))
+		})
+	})
+
+	Context("When system node counter is not set", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global.discovery.d8SpecificNodeCountByRole", `{}`)
+			f.HelmRender()
+		})
+
+		It("must fallback webhook Gatekeeper to control-plane nodes", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			dp := f.KubernetesResource("Deployment", nsName, "gatekeeper-controller-manager")
+			Expect(dp.Exists()).To(BeTrue())
+
+			Expect(dp.Field("spec.template.spec.nodeSelector").Exists()).To(BeFalse())
+			rendered := dp.ToYaml()
+			Expect(rendered).To(ContainSubstring("requiredDuringSchedulingIgnoredDuringExecution"))
+			Expect(rendered).To(ContainSubstring("preferredDuringSchedulingIgnoredDuringExecution"))
+			Expect(rendered).To(ContainSubstring("key: node-role.deckhouse.io/system"))
+			Expect(rendered).To(ContainSubstring("key: node-role.deckhouse.io/admission-policy-engine"))
+			Expect(rendered).To(ContainSubstring("key: node-role.kubernetes.io/control-plane"))
+		})
+	})
+})

--- a/modules/015-admission-policy-engine/templates/gatekeeper-deployment.yaml
+++ b/modules/015-admission-policy-engine/templates/gatekeeper-deployment.yaml
@@ -51,10 +51,54 @@ spec:
         control-plane: controller-manager
         gatekeeper.sh/operation: webhook
     spec:
-      {{- include "helm_lib_node_selector" (tuple . "system") | nindent 6 }}
-      {{- include "helm_lib_tolerations" (tuple . "system" "with-no-csi") | nindent 6 }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.deckhouse.io/{{ .Chart.Name }}
+                operator: In
+                values: [""]
+            - matchExpressions:
+              - key: node-role.deckhouse.io/system
+                operator: In
+                values: [""]
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: In
+                values: [""]
+            - matchExpressions:
+              - key: node-role.deckhouse.io/control-plane
+                operator: In
+                values: [""]
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: In
+                values: [""]
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: node-role.deckhouse.io/system
+                operator: In
+                values: [""]
+          - weight: 90
+            preference:
+              matchExpressions:
+              - key: node-role.deckhouse.io/{{ .Chart.Name }}
+                operator: In
+                values: [""]
+        {{- if (include "helm_lib_ha_enabled" .) }}
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app: "gatekeeper"
+                control-plane: "controller-manager"
+            topologyKey: kubernetes.io/hostname
+        {{- end }}
+      {{- include "helm_lib_tolerations" (tuple . "any-node" "with-no-csi") | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
-      {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "gatekeeper" "control-plane" "controller-manager")) | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
       automountServiceAccountToken: true
       containers:


### PR DESCRIPTION
## Description

This improvement allows pods and the Gatekeeper controller-manager to be deployed to master nodes if other types are unavailable.

## Why do we need it, and what problem does it solve?

Currently, webhook auditing for Gatekeeper is set to mandatory. Therefore, all deployed workloads must receive a response from this hook. If the Gatekeeper controller-manager is unavailable, the workload cannot be replaced.

This can lead to a situation where pods and the Gatekeeper controller-manager cannot be deployed to nodes because there are no suitable nodes, and suitable nodes cannot be created because they depend on pods that cannot be deployed due to an unavailable hook. This results in a dead loop.


## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: admission-policy-engine
type: feature
summary: Added a complex nodeAffinity selector for the Gatekeeper controller-manager.
impact_level: default
```
