### PR TITLE
[deckhouse] delete package resources on disable

### DIFF
--- a/deckhouse-controller/internal/packages/runtime/runtime.go
+++ b/deckhouse-controller/internal/packages/runtime/runtime.go
@@ -601,11 +601,11 @@ func (r *Runtime) disablePackage(name, reason, msg string) {
 	r.status.SetConditionFalse(name, status.ConditionRequirementsMet, reason, msg)
 
 	if pkg := r.apps[name]; pkg != nil {
-		r.queueService.Enqueue(ctx, name, taskdisable.NewTask(pkg, "", true, r.nelmService, r.queueService, r.logger))
+		r.queueService.Enqueue(ctx, name, taskdisable.NewTask(pkg, pkg.GetNamespace(), false, r.nelmService, r.queueService, r.logger))
 	}
 
 	if pkg := r.modules[name]; pkg != nil {
-		r.queueService.Enqueue(ctx, name, taskdisable.NewTask(pkg, "", true, r.nelmService, r.queueService, r.logger))
+		r.queueService.Enqueue(ctx, name, taskdisable.NewTask(pkg, modulesNamespace, false, r.nelmService, r.queueService, r.logger))
 	}
 }
 


### PR DESCRIPTION
## Description

The scheduler-driven disable task now uninstalls the package's Helm release (`keep=false` with the package namespace) instead of only removing monitors and hooks. Impact: disabling a package now tears down its workloads in the cluster.

## Why do we need it, and what problem does it solve?

When a package's requirements stopped being met, the scheduler disabled it but left all its resources running. Disable now deletes them (helm uninstall + `AfterDeleteHelm` hooks), matching the method's documented behavior. The package re-installs automatically once requirements are met again.

### Manual test (in-cluster)

Controller built from this PR. Test app with a mandatory dependency on the `documentation` module — disabling the module makes the requirement unmet, the scheduler disables the package, and its **Helm release + resources are now removed** (before: they kept running). The `Application` CR stays, so it re-installs once the requirement is met again.

```console
# before — module on, package Ready, release + resources present
$ kubectl -n default get application test
test   a-k-icon-jpeg   v0.0.2   Ready
$ kubectl -n default get secret,deploy,svc | grep -E 'sh.helm.release.v1.default.test|test-server'
sh.helm.release.v1.default.test.v1            helm.sh/release.v1   1
deployment.apps/test-server                   1/1   1   1
service/test-server                           ClusterIP  10.223.22.242  5678/TCP

# disable the dependency module
$ deckhouse-controller module disable documentation

# after — package disabled, release + resources gone
$ kubectl -n default get application test
test   a-k-icon-jpeg   v0.0.2   Pending   Installation is blocked: application requirements are not satisfied
$ kubectl -n default get secret,deploy,svc | grep -cE 'sh.helm.release.v1.default.test|test-server'
0
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix 
summary: Delete package resources on disable.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
