### PR TITLE
[docs] Correct URL links to diagrams pt. 2

### DIFF
--- a/docs/documentation/pages/architecture/virtualization/API.md
+++ b/docs/documentation/pages/architecture/virtualization/API.md
@@ -53,7 +53,7 @@ The following simplifications are made in the diagram:
 The Level 2 C4 architecture of the Virtualization API component of the [`virtualization`](/modules/virtualization/) module and its interactions with other components of Deckhouse Kubernetes Platform (DKP) are shown in the following diagram:
 
 <!--- Source: structurizr code from https://fox.flant.com/team/d8-system-design/doc/-/tree/main/architecture/diagrams/C4_RU --->
-![Architecture of the Virtualization API component of virtualization module](../../../images/architecture/virtualization/c4-l2-virtualization-api.png)
+![Architecture of the Virtualization API component of virtualization module](../../images/architecture/virtualization/c4-l2-virtualization-api.png)
 
 ## Virtualization API components
 

--- a/docs/documentation/pages/architecture/virtualization/API_RU.md
+++ b/docs/documentation/pages/architecture/virtualization/API_RU.md
@@ -53,7 +53,7 @@ description: Архитектура компонента Virtualization API мо
 Архитектура компонента Virtualization API модуля [`virtualization`](/modules/virtualization/) на уровне 2 модели C4 и его взаимодействия с другими компонентами Deckhouse Kubernetes Platform (DKP) изображены на следующей диаграмме:
 
 <!--- Source: structurizr code from https://fox.flant.com/team/d8-system-design/doc/-/tree/main/architecture/diagrams/C4_RU --->
-![Архитектура компонента Virtualization API модуля virtualization](../../../images/architecture/virtualization/c4-l2-virtualization-api.ru.png)
+![Архитектура компонента Virtualization API модуля virtualization](../../images/architecture/virtualization/c4-l2-virtualization-api.ru.png)
 
 ## Компоненты Virtualization API
 


### PR DESCRIPTION
## Description

This pull request updates links to architecture diagrams taking in account documentation version.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: fix
summary: Fix URL links to diagrams
impact_level: low
```
