### PR TITLE
[dhctl] chore: gotestsum for tests

### DIFF
--- a/dhctl/Makefile
+++ b/dhctl/Makefile
@@ -215,8 +215,8 @@ fmt:
 	gofumpt -l -w -extra .
 	golangci-lint run ./... -c .golangci.yaml --fix
 
-ci:
-	./hack/coverage.sh
+ci: bin/gotestsum
+	GOTESTSUM=$(abspath $(GOTESTSUM)) ./hack/coverage.sh
 
 devenv:
 	./hack/devenv/start.sh

--- a/dhctl/Makefile
+++ b/dhctl/Makefile
@@ -19,11 +19,14 @@ GOFUMPT_VERSION=0.1.1
 PROTOC_VERSION = 25.2
 PROTOC_GEN_GO_VERSION = 1.32
 PROTOC_GEN_GO_GROC_VERSION = 1.3
+GOTESTSUM_VERSION = 1.13.0
 
 # Build versions
 GOARCH=amd64
 
 TEST_PACKAGES := $(shell go list ./...)
+
+GOTESTSUM = bin/gotestsum
 
 DHCTL_BIN_NAME=bin/dhctl
 MINGET_EMBED_PATH=pkg/minget/embed/minget
@@ -100,6 +103,10 @@ bin/gofumpt:
 	curl -sLo "bin/gofumpt" https://github.com/mvdan/gofumpt/releases/download/v$(GOFUMPT_VERSION)/gofumpt_v$(GOFUMPT_VERSION)_$(OS)_$(GOARCH)
 	@chmod +x "./bin/gofumpt"
 
+bin/gotestsum:
+	@mkdir -p bin
+	GOBIN=$(abspath bin/) go install gotest.tools/gotestsum@v$(GOTESTSUM_VERSION)
+
 .PHONY: bin/protoc
 bin/protoc:
 	@mkdir -p bin
@@ -170,28 +177,28 @@ build/test: DHCTL_BIN_NAME = bin/dhctl-linux-amd64-test
 build/test: ADDITIONAL_BUILD_ARGS = -tags dev
 build/test: check-vars build/test/check-digests build
 
-test: check-vars
+test: check-vars bin/gotestsum
 	@echo "Tests that need external prerequisites (cloud-providers candi tree, /dhctl-tests, docker) auto-skip when those are missing."
 	@echo " - cloud-provider tests run only when /dhctl-tests + /deckhouse are populated; force-skip with DHCTL_SKIP_PROVIDER_TEST=true."
 	@echo " - gossh tests run only when docker is reachable; force-skip with DHCTL_SKIP_GOSSH_TEST=true."
 	@echo " - schema-driven tests (config/destroy/check/...) run only when /deckhouse/candi exists; override with DHCTL_TEST_CANDI_DIR."
-	go test -v -p 1 $(TEST_PACKAGES)
+	$(GOTESTSUM) -- -v -p 1 $(TEST_PACKAGES)
 
-test-skip-cloud-providers: check-vars
-	DHCTL_SKIP_PROVIDER_TEST=true go test -v -p 1 $(TEST_PACKAGES)
+test-skip-cloud-providers: check-vars bin/gotestsum
+	DHCTL_SKIP_PROVIDER_TEST=true $(GOTESTSUM) -- -v -p 1 $(TEST_PACKAGES)
 
-test-skip-gossh: check-vars
-	DHCTL_SKIP_DOCKER_TEST=true go test -v -p 1 $(TEST_PACKAGES)
+test-skip-gossh: check-vars bin/gotestsum
+	DHCTL_SKIP_DOCKER_TEST=true $(GOTESTSUM) -- -v -p 1 $(TEST_PACKAGES)
 
 check-cloud-providers-vars:
 	@[ "${YANDEX_CLOUD_CONFIG}" ] || ( echo "YANDEX_CLOUD_CONFIG is not set. Should path to dhctl bootstrap config with yandex without-nat layout"; exit 1 )
 	@[ "${GCP_CLOUD_CONFIG}" ] || ( echo "GCP_CLOUD_CONFIG is not set. Should path to dhctl bootstrap config with gcp without-nat layout"; exit 1 )
 
-test-cloud-providers: check-vars check-cloud-providers-vars
-	go test -v -p 1 ./pkg/infrastructureprovider/...
+test-cloud-providers: check-vars check-cloud-providers-vars bin/gotestsum
+	$(GOTESTSUM) -- -v -p 1 ./pkg/infrastructureprovider/...
 
-test-race: check-vars
-	go test -race -p 1 $(TEST_PACKAGES)
+test-race: check-vars bin/gotestsum
+	$(GOTESTSUM) -- -race -p 1 $(TEST_PACKAGES)
 
 deps: bin/golangci-lint bin/gofumpt bin/protoc
 	go mod tidy

--- a/dhctl/hack/coverage.sh
+++ b/dhctl/hack/coverage.sh
@@ -21,7 +21,7 @@ packages=$(go list ./pkg/... | grep -Ev '/pkg/preflight(/|$)')
 
 gotestsum="${GOTESTSUM:-gotestsum}"
 "${gotestsum}" -- -v -cover -coverprofile="${tmpfile}" -vet=off ${packages}
-coverage=$(go tool cover -func  ${tmpfile} | grep total | awk '{print $3}')
+coverage=$(go tool cover -func "${tmpfile}" | awk '$1 == "total:" {print $3}')
 
 echo "Coverage: ${coverage}"
 echo "Success!"

--- a/dhctl/hack/coverage.sh
+++ b/dhctl/hack/coverage.sh
@@ -19,7 +19,8 @@ set -euo pipefail
 tmpfile=$(mktemp /tmp/coverage-report.XXXXXX)
 packages=$(go list ./pkg/... | grep -Ev '/pkg/preflight(/|$)')
 
-go test -v -cover -coverprofile="${tmpfile}" -vet=off ${packages}
+gotestsum="${GOTESTSUM:-gotestsum}"
+"${gotestsum}" -- -v -cover -coverprofile="${tmpfile}" -vet=off ${packages}
 coverage=$(go tool cover -func  ${tmpfile} | grep total | awk '{print $3}')
 
 echo "Coverage: ${coverage}"


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Change tests output from full to compact gotestsum view

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: chore
summary: change dhctl tests display output to gotestsum
impact: 
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
