### PR TITLE
[deckhouse] fix package status deadlock via coalescing workqueue

### DIFF
--- a/deckhouse-controller/internal/packages/runtime/runtime.go
+++ b/deckhouse-controller/internal/packages/runtime/runtime.go
@@ -639,6 +639,9 @@ func (r *Runtime) Stop() {
 
 	// Close scheduler event channel
 	r.scheduler.Stop()
+
+	// Stop reflecting status to CRs (unblocks the status consumer loop)
+	r.status.Shutdown()
 }
 
 // PreservePackage identifies one installed Package instance to preserve during Cleanup.

--- a/deckhouse-controller/internal/packages/status/service.go
+++ b/deckhouse-controller/internal/packages/status/service.go
@@ -21,6 +21,7 @@ import (
 	addonutils "github.com/flant/addon-operator/pkg/utils"
 	"github.com/werf/nelm/pkg/legacy/progrep"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/workqueue"
 
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/health"
 )
@@ -45,6 +46,9 @@ const (
 
 	// ConditionReasonApplyingManifests indicates that nelm is applying manifests to the cluster
 	ConditionReasonApplyingManifests ConditionReason = "ApplyingManifests"
+
+	// queueName labels the notification workqueue for metrics.
+	queueName = "package-status"
 )
 
 // Error wraps an error with associated status conditions
@@ -81,7 +85,12 @@ type Service struct {
 	// name drains the entry, so a startup-race event is not lost.
 	pendingHealth map[string]health.Event
 
-	ch chan string // notification channel for status changes
+	// queue carries names of packages whose status changed. It coalesces
+	// repeated notifications for the same package into a single item, so a
+	// flood of updates (e.g. nelm progress) cannot outgrow the number of
+	// packages. Notifications are enqueued outside s.mu, so a slow consumer
+	// can never block a producer that holds the lock.
+	queue workqueue.TypedRateLimitingInterface[string]
 }
 
 // Status represents the current state of a package
@@ -108,15 +117,24 @@ type Condition struct {
 
 func NewService() *Service {
 	return &Service{
-		ch:            make(chan string, 10000),
+		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[string](),
+			workqueue.TypedRateLimitingQueueConfig[string]{Name: queueName},
+		),
 		statuses:      make(map[string]*Status),
 		pendingHealth: make(map[string]health.Event),
 	}
 }
 
-// GetCh returns a read-only channel that receives package names when their status changes
-func (s *Service) GetCh() <-chan string {
-	return s.ch
+// Queue returns the notification queue. Consumers pull changed package names
+// via Get/Done and requeue transient failures via AddRateLimited.
+func (s *Service) Queue() workqueue.TypedRateLimitingInterface[string] {
+	return s.queue
+}
+
+// Shutdown stops the notification queue; the consumer loop exits on the next Get.
+func (s *Service) Shutdown() {
+	s.queue.ShutDown()
 }
 
 // GetStatus retrieves a copy of the current status for a package by name ("namespace.name")
@@ -155,69 +173,72 @@ func (s *Service) DeleteStatus(name string) {
 // SetConditionTrue marks a condition as successful and notifies listeners if changed
 func (s *Service) SetConditionTrue(name string, condition ConditionType) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if _, ok := s.statuses[name]; !ok {
+	status, ok := s.statuses[name]
+	if !ok {
+		s.mu.Unlock()
 		return
 	}
 
 	// Notify only if the condition actually changed
-	if s.statuses[name].setCondition(Condition{Type: condition, Status: metav1.ConditionTrue}) {
-		s.ch <- name
+	notify := status.setCondition(Condition{Type: condition, Status: metav1.ConditionTrue})
+	s.mu.Unlock()
+
+	if notify {
+		s.queue.Add(name)
 	}
 }
 
 // SetConditionFalse marks a condition as successful and notifies listeners if changed
 func (s *Service) SetConditionFalse(name string, condition ConditionType, reason, message string) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if _, ok := s.statuses[name]; !ok {
+	status, ok := s.statuses[name]
+	if !ok {
+		s.mu.Unlock()
 		return
 	}
 
 	// Notify only if the condition actually changed
-	notify := s.statuses[name].setCondition(Condition{
+	notify := status.setCondition(Condition{
 		Type:    condition,
 		Status:  metav1.ConditionFalse,
 		Reason:  ConditionReason(reason),
 		Message: message,
 	})
+	s.mu.Unlock()
 
 	if notify {
-		s.ch <- name
+		s.queue.Add(name)
 	}
 }
 
 // UpdateVersion sets the current version of package
 func (s *Service) UpdateVersion(name string, version string) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	status, ok := s.statuses[name]
 	if !ok {
+		s.mu.Unlock()
 		return
 	}
 
 	status.Version = version
 	status.setCondition(Condition{Type: ConditionLoaded, Status: metav1.ConditionTrue})
 	status.setCondition(Condition{Type: ConditionPending, Status: metav1.ConditionTrue, Message: "waiting for processing"})
+	s.mu.Unlock()
 
-	s.ch <- name
+	s.queue.Add(name)
 }
 
 // UpdateTracking updates the nelm progress report for a package and notifies listeners.
 // If the package is not tracked by the service, the update is silently ignored.
 func (s *Service) UpdateTracking(name string, report progrep.ProgressReport) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	status, ok := s.statuses[name]
 	if !ok {
+		s.mu.Unlock()
 		return
 	}
 
-	s.statuses[name].setCondition(Condition{
+	status.setCondition(Condition{
 		Type:   ConditionManifestsApplied,
 		Status: metav1.ConditionFalse,
 		Reason: ConditionReasonApplyingManifests,
@@ -242,8 +263,9 @@ func (s *Service) UpdateTracking(name string, report progrep.ProgressReport) {
 		status.Tracking = Tracking{Completed: completed, Remaining: remaining, Report: r}
 		break
 	}
+	s.mu.Unlock()
 
-	s.ch <- name
+	s.queue.Add(name)
 }
 
 // UpdateSettings stores the effective settings of a package.
@@ -274,16 +296,18 @@ func (s *Service) UpdateSettings(name string, settings addonutils.Values) {
 // the package is registered.
 func (s *Service) UpdateHealth(name string, event health.Event) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	status, ok := s.statuses[name]
 	if !ok {
 		s.pendingHealth[name] = event
+		s.mu.Unlock()
 		return
 	}
 
-	if applyHealthEventLocked(status, event) {
-		s.ch <- name
+	notify := applyHealthEventLocked(status, event)
+	s.mu.Unlock()
+
+	if notify {
+		s.queue.Add(name)
 	}
 }
 
@@ -309,27 +333,28 @@ func applyHealthEventLocked(status *Status, event health.Event) bool {
 // HandleError processes an error and extracts status conditions from it
 // Notifies listeners if any conditions changed
 func (s *Service) HandleError(name string, cond ConditionType, err error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	statusErr := new(Error)
 	if !errors.As(err, &statusErr) {
 		return
 	}
 
-	if _, ok := s.statuses[name]; !ok {
+	s.mu.Lock()
+	status, ok := s.statuses[name]
+	if !ok {
+		s.mu.Unlock()
 		return
 	}
 
-	notify := s.statuses[name].setCondition(Condition{
+	notify := status.setCondition(Condition{
 		Type:    cond,
 		Status:  metav1.ConditionFalse,
 		Reason:  statusErr.reason,
 		Message: statusErr.message,
 	})
+	s.mu.Unlock()
 
 	if notify {
-		s.ch <- name
+		s.queue.Add(name)
 	}
 }
 
@@ -387,7 +412,6 @@ func (s *Status) IsConditionTrue(condType ConditionType) bool {
 // applied here and the buffer entry is dropped.
 func (s *Service) ClearStatus(name string) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	s.statuses[name] = &Status{
 		Conditions: []Condition{
@@ -404,11 +428,15 @@ func (s *Service) ClearStatus(name string) {
 
 	event, ok := s.pendingHealth[name]
 	if !ok {
+		s.mu.Unlock()
 		return
 	}
 	delete(s.pendingHealth, name)
 
-	if applyHealthEventLocked(s.statuses[name], event) {
-		s.ch <- name
+	notify := applyHealthEventLocked(s.statuses[name], event)
+	s.mu.Unlock()
+
+	if notify {
+		s.queue.Add(name)
 	}
 }

--- a/deckhouse-controller/pkg/controller/packages/application/controller.go
+++ b/deckhouse-controller/pkg/controller/packages/application/controller.go
@@ -99,7 +99,7 @@ func RegisterController(
 	}
 
 	r.status = status.NewService(r.client, packageRuntime.Status().GetStatus, r.logger)
-	r.status.Start(context.Background(), packageRuntime.Status().GetCh())
+	r.status.Start(context.Background(), packageRuntime.Status().Queue())
 
 	return ctrl.NewControllerManagedBy(runtimeManager).
 		Named(controllerName).

--- a/deckhouse-controller/pkg/controller/packages/application/status/service.go
+++ b/deckhouse-controller/pkg/controller/packages/application/status/service.go
@@ -17,12 +17,15 @@ package status
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"strings"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/condmap"
@@ -51,38 +54,50 @@ func NewService(client client.Client, getter getter, logger *log.Logger) *Servic
 	}
 }
 
-// Start begins the status service event loop in a goroutine
-// It listens for package status change events and updates Application resources accordingly
-func (s *Service) Start(ctx context.Context, ch <-chan string) {
+// Start begins the status service event loop in a goroutine. It pulls changed
+// package names from the queue and reflects them onto Application resources.
+// The loop exits when the queue is shut down.
+func (s *Service) Start(ctx context.Context, queue workqueue.TypedRateLimitingInterface[string]) {
 	go func() {
 		for {
-			select {
-			case <-ctx.Done():
+			name, shutdown := queue.Get()
+			if shutdown {
 				return
-			case event := <-ch:
-				s.handleEvent(ctx, event)
 			}
+
+			if err := s.handleEvent(ctx, name); err != nil {
+				s.logger.Warn("handle status event, requeued", slog.String("name", name), log.Err(err))
+				queue.AddRateLimited(name)
+			} else {
+				queue.Forget(name)
+			}
+
+			queue.Done(name)
 		}
 	}()
 }
 
-// handleEvent processes a status change event for a package
-// Event format is "namespace.name" identifying the Application resource
-func (s *Service) handleEvent(ctx context.Context, ev string) {
+// handleEvent reflects a package status change onto its Application resource.
+// Event format is "namespace.name". A returned error is retryable; nil means
+// done — including a malformed name or a missing Application, which never
+// become valid on retry.
+func (s *Service) handleEvent(ctx context.Context, ev string) error {
 	logger := s.logger.With(slog.String("name", ev))
 
 	// Parse event name: "namespace.name"
 	splits := strings.Split(ev, ".")
 	if len(splits) != 2 {
 		logger.Warn("invalid event format, expected 'namespace.name'")
-		return
+		return nil
 	}
 
 	// Fetch the Application resource
 	app := new(v1alpha1.Application)
 	if err := s.client.Get(ctx, client.ObjectKey{Namespace: splits[0], Name: splits[1]}, app); err != nil {
-		logger.Warn("failed to get application", log.Err(err))
-		return
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("get application: %w", err)
 	}
 
 	original := app.DeepCopy()
@@ -91,8 +106,10 @@ func (s *Service) handleEvent(ctx context.Context, ev string) {
 	s.computeAndApplyConditions(ev, app)
 
 	if err := s.client.Status().Patch(ctx, app, client.MergeFrom(original)); err != nil {
-		logger.Warn("failed to patch application status", log.Err(err))
+		return fmt.Errorf("patch application status: %w", err)
 	}
+
+	return nil
 }
 
 func (s *Service) computeAndApplyConditions(ev string, app *v1alpha1.Application) {


### PR DESCRIPTION
## Description

Replaces the package status service's blocking notification channel with a
coalescing client-go `workqueue`, fixing a deadlock in `deckhouse-controller`'s
packages subsystem.

`internal/packages/status` sent change notifications on a buffered channel
**while holding the mutex** that `GetStatus` (the only consumer) also needs. Once
the buffer (10000) filled, the sender blocked under the lock and the consumer
could never take it — a deadlock that propagated through `Runtime.mu` and froze
package reconciliation.

Change:
- producers `Add(name)` **after** releasing the mutex — `Add` never blocks and
  deduplicates;
- consumer pulls via `Get`/`Done`, retries transient failures via
  `AddRateLimited`/`Forget`;
- status consumer stops cleanly on `Runtime.Stop()`.

Store, mutex and `GetStatus` are unchanged. No restarts of ingress-controllers,
control-plane, Prometheus, etc.

## Why do we need it, and what problem does it solve?

A single failing install that keeps retrying floods status notifications, fills
the buffer and deadlocks the controller. Through `Runtime.mu` it also hangs
`Application` reconciliation and the `Application` validating webhook (so
`kubectl apply` of an `Application` times out); the only recovery was restarting
the `deckhouse-controller` pod. Confirmed on a test stand via a goroutine dump.
The workqueue is bounded by the number of packages, so the buffer can no longer
fill and the deadlock cannot form.

### How it works

`status.Service` owns two things — the status **store** (`statuses`, read via
`GetStatus`) and the **notification queue** — and keeps them decoupled:

- Every producer (the status mutators and the nelm progress callback) mutates the
  store under `s.mu`, **releases the lock, and only then calls `queue.Add(name)`**.
  `Add` is non-blocking and coalesces by name, so a producer can never stall while
  holding `s.mu`, and a flood of updates collapses to one queue item per package.
- A single consumer pulls a name (`Get`), reads the current status (`GetStatus`)
  and patches the `Application`, then `Done`. Transient `Get`/`Patch` failures are
  retried with backoff (`AddRateLimited` / `Forget`).
- `s.mu` guards only the store — it never spans `Add` or `Get`. That removes the
  circular wait (lock ↔ channel) that caused the deadlock.
- The queue shuts down on `Runtime.Stop()`, so the consumer exits cleanly.

The queue is keyed by package name, so its size is bounded by the number of
packages, not the number of events — the unbounded buffer is gone.

```mermaid
flowchart LR
    P["producers<br/>SetConditionTrue/False, UpdateTracking, UpdateHealth, ..."]
    S[("statuses store<br/>s.mu-guarded")]
    Q["workqueue package-status<br/>coalescing, name-keyed"]
    C["consumer loop<br/>Get, handleEvent, Done"]
    CR["Application .status"]

    P -->|"mutate, under s.mu"| S
    P -->|"Add name: after Unlock, non-blocking, dedup"| Q
    Q -->|"Get / Done"| C
    C -->|"GetStatus"| S
    C -->|"Status Patch"| CR
    C -.->|"on error: AddRateLimited"| Q
```

Key invariant: `s.mu` is held only for the store mutation, never across `Add`/`Get`,
so no lock spans the producer→consumer handoff.

### Manual testing

Reproduced the exact failing-install flood that wedged the stand, on a dev cluster
running this PR build (`deckhouse-oss:pr20676`):

1. Published `a-k-icon-jpeg` `v0.0.3` with a non-pullable image
   (`registry.invalid/nope:v0`), so the install never becomes Ready.
2. Deployed 5 `Application`s on it.

**The flood** — each install fails, nelm keeps tracking a Deployment that never
becomes Ready, the run task fails, and the queue retries it ~every 15–40s.
Resource tracking from nelm:

```text
controller   "msg":"reconcile application","name":"badapp","namespace":"default"
nelm         Start release "default.badapp" (namespace: "default")
nelm         RESOURCE (→READY)          STATE    INFO
             Deployment/badapp-server   WAITING  Ready:0/1
             • Pod/badapp-server-…       UNKNOWN  ErrImagePull "registry.invalid/nope:v0": … no such host
nelm         RESOURCE (→READY)          STATE    INFO
             Deployment/badapp-server   FAILED   Ready:0/1
             • Pod/badapp-server-…       UNKNOWN  ImagePullBackOff
queue        "level":"warn","msg":"task failed","name":"Run"
nelm         Start release "default.badapp" (namespace: "default")   # retried — flood continues
```

The package task queues ~1.5h in — all 5 `Run` tasks still retrying, none piling up:

```text
$ deckhouse-controller packages queue dump
queues:
  default.badapp:                 # retrying for ~1h30m
    length: 1
    tasks:
    - name: Run
      enqueued: 1h30m42s
      error: "install nelm release 'default.badapp': context timed out: action timed out after 3m0s"
      next_retry: -2m31s          # overdue -> retries now
  default.badapp2:                # badapp3..badapp5 identical
    length: 1
    tasks:
    - name: Run
      enqueued: 1h28m55s
      error: "install nelm release 'default.badapp2': ... track deployment readiness failed"
      next_retry: 10s
  default.test:                   # the working package — idle
    length: 0
```

**Result** — under that flood the controller stays healthy:

```text
# validating webhook (takes Runtime.mu) responsive — hangs for minutes during the deadlock:
$ time kubectl label application test x=1 --overwrite
application.deckhouse.io/test labeled
real    0m0.602s

# statuses keep updating across all failing apps:
$ kubectl get app
NAME      PACKAGE         VERSION   STATE     MESSAGE
badapp    a-k-icon-jpeg   v0.0.3    Failed    Installation failed: Helm could not apply manifests
badapp2   a-k-icon-jpeg   v0.0.3    Failed    Installation failed: Helm could not apply manifests
badapp3   a-k-icon-jpeg   v0.0.3    Pending   Installation is waiting for dependent modules to converge
badapp4   a-k-icon-jpeg   v0.0.3    Pending   Installation is waiting for dependent modules to converge
badapp5   a-k-icon-jpeg   v0.0.3    Failed    Installation failed: Helm could not apply manifests
test      a-k-icon-jpeg   v0.0.2    Ready

# controller pod — no restarts:
$ kubectl -n d8-system get pod -l app=deckhouse
NAME                        READY   STATUS    RESTARTS   AGE
deckhouse-5c76b8bf6-wtwhx   2/2     Running   0          90m
```

The controller stayed responsive for ~1.5h of sustained flood from 5 packages —
past the ~89 minutes it took to deadlock in the original incident, under heavier
load. Deadlock not reproduced.

For contrast, on the pre-fix build the same load fills the 10000-entry buffer and
deadlocks — from the original goroutine dump:

```text
goroutine [chan send, 89 min]        status.(*Service).UpdateTracking          service.go:246   # writer holds s.mu, stuck on a full channel
goroutine [sync.Mutex.Lock, 89 min]  status.(*Service).GetStatus               service.go:125   # consumer can't acquire s.mu
goroutine [sync.Mutex.Lock, 49 min]  (*Runtime).schedulePackage → SetConditionTrue  runtime.go:570   # holds Runtime.mu, waits on s.mu
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix 
summary: Fix package status deadlock via coalescing workqueue.
impact_level: default 
```
