### PR TITLE
[admission-policy-engine] Change label for container security-policy-exceptions

### DIFF
--- a/modules/015-admission-policy-engine/charts/constraint-templates/files/libs/common.rego
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/files/libs/common.rego
@@ -40,11 +40,11 @@ get_field(obj, path, _default) := out if {
 
 # Backwards-compatible exception label lookup (uses input.review)
 get_exception_label(container) := label if {
-  key := sprintf("security.deckhouse.io/security-policy-exception/%v", [container.name])
+  key := sprintf("security.deckhouse.io/security-policy-exception.container.%v", [container.name])
   label := input.review.object.metadata.labels[key]
   label != ""
 } else := label if {
-  key := sprintf("security.deckhouse.io/security-policy-exception/%v", [container.name])
+  key := sprintf("security.deckhouse.io/security-policy-exception.container.%v", [container.name])
   object.get(input.review.object.metadata.labels, key, "") == ""
   label := object.get(input.review.object.metadata.labels, "security.deckhouse.io/security-policy-exception", "")
   label != ""
@@ -54,11 +54,11 @@ get_exception_label(container) := label if {
 
 # Parameterized exception label lookup (uses labels map)
 get_exception_label_from_labels(container, labels) := label if {
-  key := sprintf("security.deckhouse.io/security-policy-exception/%v", [container.name])
+  key := sprintf("security.deckhouse.io/security-policy-exception.container.%v", [container.name])
   label := object.get(labels, key, "")
   label != ""
 } else := label if {
-  key := sprintf("security.deckhouse.io/security-policy-exception/%v", [container.name])
+  key := sprintf("security.deckhouse.io/security-policy-exception.container.%v", [container.name])
   object.get(labels, key, "") == ""
   label := object.get(labels, "security.deckhouse.io/security-policy-exception", "")
   label != ""

--- a/modules/015-admission-policy-engine/charts/constraint-templates/files/libs/common_test.rego
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/files/libs/common_test.rego
@@ -49,7 +49,7 @@ test_get_field_default if {
 
 test_get_exception_label_container_specific if {
   labels := {
-    "security.deckhouse.io/security-policy-exception/app": "spe-1",
+    "security.deckhouse.io/security-policy-exception.container.app": "spe-1",
     "security.deckhouse.io/security-policy-exception": "spe-global"
   }
   container := {"name": "app"}

--- a/modules/015-admission-policy-engine/charts/constraint-templates/files/libs/exception_test.rego
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/files/libs/exception_test.rego
@@ -23,7 +23,7 @@ test_resolve_spe_from_labels_missing_label if {
 # resolve_spe_for_container resolves by container-specific label
 
 test_resolve_spe_for_container_specific_label if {
-  labels := {"security.deckhouse.io/security-policy-exception/app": "spe"}
+  labels := {"security.deckhouse.io/security-policy-exception.container.app": "spe"}
   container := {"name": "app"}
   namespace := "default"
   result := exception.resolve_spe_for_container(container, labels, namespace) with data.inventory as inventory_spe

--- a/modules/015-admission-policy-engine/charts/constraint-templates/templates/security/verify-image-signature.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/templates/security/verify-image-signature.yaml
@@ -49,7 +49,7 @@ spec:
 
         get_data(filtered_images) = response {
           not is_test_mode
-          response := external_data_from_inventory("ratify-provider", filtered_images)
+          response := external_data({"provider": "ratify-provider", "keys": filtered_images})
         }
 
         external_data_from_inventory(provider, keys) = response {

--- a/modules/015-admission-policy-engine/charts/constraint-templates/tests/test_cases/constraints/security/allow-privilege-escalation/test-matrix.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/tests/test_cases/constraints/security/allow-privilege-escalation/test-matrix.yaml
@@ -336,7 +336,7 @@ spec:
             merge:
               metadata:
                 labels:
-                  security.deckhouse.io/security-policy-exception/nginx: allow-privilege-escalation-true-container
+                  security.deckhouse.io/security-policy-exception.container.nginx: allow-privilege-escalation-true-container
                 name: allowed-by-container-exception-allowprivilegeescalation-true
               spec:
                 containers:

--- a/modules/015-admission-policy-engine/charts/constraint-templates/tests/test_cases/constraints/security/allow-privileged/test-matrix.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/tests/test_cases/constraints/security/allow-privileged/test-matrix.yaml
@@ -278,7 +278,7 @@ spec:
             merge:
               metadata:
                 labels:
-                  security.deckhouse.io/security-policy-exception/nginx: allow-privileged-true-container
+                  security.deckhouse.io/security-policy-exception.container.nginx: allow-privileged-true-container
                 name: allowed-by-container-exception-privileged-true
               spec:
                 containers:

--- a/modules/015-admission-policy-engine/charts/constraint-templates/tests/test_cases/constraints/security/allowed-apparmor-profiles/test-matrix.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/tests/test_cases/constraints/security/allowed-apparmor-profiles/test-matrix.yaml
@@ -409,7 +409,7 @@ spec:
             merge:
               metadata:
                 labels:
-                  security.deckhouse.io/security-policy-exception/nginx: allow-unconfined-container
+                  security.deckhouse.io/security-policy-exception.container.nginx: allow-unconfined-container
                 name: allowed-by-container-exception-unconfined
               spec:
                 containers:

--- a/modules/015-admission-policy-engine/charts/constraint-templates/tests/test_cases/constraints/security/allowed-apparmor-profiles/test_samples/security_policy_exceptions/pods/028-allowed-by-container-exception-unconfined.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/tests/test_cases/constraints/security/allowed-apparmor-profiles/test_samples/security_policy_exceptions/pods/028-allowed-by-container-exception-unconfined.yaml
@@ -4,7 +4,7 @@ metadata:
   name: allowed-by-container-exception-unconfined
   namespace: testns
   labels:
-    security.deckhouse.io/security-policy-exception/nginx: allow-unconfined-container
+    security.deckhouse.io/security-policy-exception.container.nginx: allow-unconfined-container
 spec:
   containers:
     - name: nginx

--- a/modules/015-admission-policy-engine/charts/constraint-templates/tests/test_cases/constraints/security/allowed-capabilities/test-matrix.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/tests/test_cases/constraints/security/allowed-capabilities/test-matrix.yaml
@@ -476,7 +476,7 @@ spec:
             merge:
               metadata:
                 labels:
-                  security.deckhouse.io/security-policy-exception/nginx: allow-net-admin-container
+                  security.deckhouse.io/security-policy-exception.container.nginx: allow-net-admin-container
                 name: allowed-by-container-exception-net-admin
               spec:
                 containers:
@@ -522,7 +522,7 @@ spec:
             merge:
               metadata:
                 labels:
-                  security.deckhouse.io/security-policy-exception/nginx: allow-net-admin-container
+                  security.deckhouse.io/security-policy-exception.container.nginx: allow-net-admin-container
                 name: allowed-by-container-exception-nginx-only
               spec:
                 containers:
@@ -568,7 +568,7 @@ spec:
             merge:
               metadata:
                 labels:
-                  security.deckhouse.io/security-policy-exception/nginx: allow-drop-all-container
+                  security.deckhouse.io/security-policy-exception.container.nginx: allow-drop-all-container
                 name: allowed-by-container-exception-drop-all
               spec:
                 containers:

--- a/modules/015-admission-policy-engine/charts/constraint-templates/tests/test_cases/constraints/security/allowed-proc-mount/test-matrix.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/tests/test_cases/constraints/security/allowed-proc-mount/test-matrix.yaml
@@ -372,7 +372,7 @@ spec:
         merge:
           metadata:
             labels:
-              security.deckhouse.io/security-policy-exception/nginx: allow-unmasked-container
+              security.deckhouse.io/security-policy-exception.container.nginx: allow-unmasked-container
             name: allowed-by-container-exception-unmasked
           spec:
             containers:

--- a/modules/015-admission-policy-engine/charts/constraint-templates/tests/test_cases/constraints/security/allowed-seccomp/test-matrix.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/tests/test_cases/constraints/security/allowed-seccomp/test-matrix.yaml
@@ -771,7 +771,7 @@ spec:
         merge:
           metadata:
             labels:
-              security.deckhouse.io/security-policy-exception/nginx: allow-unconfined-container
+              security.deckhouse.io/security-policy-exception.container.nginx: allow-unconfined-container
             name: allowed-by-container-exception-unconfined
           spec:
             containers:

--- a/modules/015-admission-policy-engine/charts/constraint-templates/tests/test_cases/constraints/security/allowed-selinux/test-matrix.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/tests/test_cases/constraints/security/allowed-selinux/test-matrix.yaml
@@ -438,7 +438,7 @@ spec:
         merge:
           metadata:
             labels:
-              security.deckhouse.io/security-policy-exception/nginx: allow-custom-selinux-options
+              security.deckhouse.io/security-policy-exception.container.nginx: allow-custom-selinux-options
             name: allowed-by-exception-custom-selinux-options-container
           spec:
             containers:
@@ -563,7 +563,7 @@ spec:
         merge:
           metadata:
             labels:
-              security.deckhouse.io/security-policy-exception/nginx: allow-spc-t
+              security.deckhouse.io/security-policy-exception.container.nginx: allow-spc-t
             name: disallowed-by-exception-multiple-containers-one-mismatch
           spec:
             containers:

--- a/modules/015-admission-policy-engine/charts/constraint-templates/tests/test_cases/constraints/security/allowed-users/test-matrix.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/tests/test_cases/constraints/security/allowed-users/test-matrix.yaml
@@ -1337,7 +1337,7 @@ spec:
             merge:
               metadata:
                 labels:
-                  security.deckhouse.io/security-policy-exception/nginx: allow-root-user
+                  security.deckhouse.io/security-policy-exception.container.nginx: allow-root-user
                 name: allowed-by-exception-multiple-containers-all-allowed
               spec:
                 containers:

--- a/modules/015-admission-policy-engine/charts/constraint-templates/tests/test_cases/constraints/security/read-only-root-filesystem/test-matrix.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/tests/test_cases/constraints/security/read-only-root-filesystem/test-matrix.yaml
@@ -318,7 +318,7 @@ spec:
             merge:
               metadata:
                 labels:
-                  security.deckhouse.io/security-policy-exception/nginx: allow-writable-container
+                  security.deckhouse.io/security-policy-exception.container.nginx: allow-writable-container
                 name: allowed-by-container-exception-writable
               spec:
                 containers:
@@ -357,7 +357,7 @@ spec:
               metadata:
                 labels:
                   security.deckhouse.io/security-policy-exception: allow-writable-root-filesystem
-                  security.deckhouse.io/security-policy-exception/nginx: empty-spec
+                  security.deckhouse.io/security-policy-exception.container.nginx: empty-spec
                 name: disallowed-by-container-label-over-global-valid
               spec:
                 containers:


### PR DESCRIPTION
## Description
Updated container-specific SPE label key format to a Kubernetes-valid and unambiguous form:
- from `security.deckhouse.io/security-policy-exception/<container>`
- to `security.deckhouse.io/security-policy-exception.container.<container>`

Fix signature check (external_data call to ratify) in `securityPolicy`

## Why do we need it, and what problem does it solve?

Pevious container-specific key used an extra `/`, which violates Kubernetes label key format constraints (only one `/` separator between prefix and name).

The new key format preserves existing SPE semantics while making label keys valid and deterministic for parsing, including container names with dashes. This prevents invalid manifests and keeps exception matching stable across all affected constraints.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: admission-policy-engine
type: fix 
summary: Changed the label for container SecurityPolicyExceptions.
impact_level: default
```
