### PR TITLE
[istio] Custom extension providers

### DIFF
--- a/modules/110-istio/openapi/config-values.yaml
+++ b/modules/110-istio/openapi/config-values.yaml
@@ -741,8 +741,6 @@ properties:
               type: string
               description: Unique extension provider name.
               pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
-              not:
-                enum: ["main-access-log-format"]
             envoyExtAuthzGrpc:
               type: object
               additionalProperties: false

--- a/modules/110-istio/openapi/config-values.yaml
+++ b/modules/110-istio/openapi/config-values.yaml
@@ -720,6 +720,55 @@ properties:
               user_agent: "%REQ(USER-AGENT)%"
               authority: "%REQ(:AUTHORITY)%"
               upstream_host: "%UPSTREAM_HOST%"
+      extensionProviders:
+        type: array
+        description: |
+          Additional Istio extension providers to register in the mesh configuration.
+
+          The provider name `main-access-log-format` is reserved by Deckhouse.
+        default: []
+        x-examples:
+        - - name: authservice-grpc
+            envoyExtAuthzGrpc:
+              service: authservice.example.svc.cluster.local
+              port: 10003
+        items:
+          type: object
+          additionalProperties: false
+          required: ["name", "envoyExtAuthzGrpc"]
+          properties:
+            name:
+              type: string
+              description: Unique extension provider name.
+              pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
+              not:
+                enum: ["main-access-log-format"]
+            envoyExtAuthzGrpc:
+              type: object
+              additionalProperties: false
+              description: External authorization provider that implements Envoy ext_authz gRPC API.
+              required: ["service", "port"]
+              properties:
+                service:
+                  type: string
+                  description: Service that implements Envoy ext_authz gRPC API. The format is `[<namespace>/]<hostname>`.
+                port:
+                  type: integer
+                  description: Service port.
+                  minimum: 1
+                  maximum: 65535
+                failOpen:
+                  type: boolean
+                  description: Allow requests when the authorization service is unavailable or returns a 5xx error.
+                timeout:
+                  type: string
+                  description: Maximum duration the proxy waits for the authorization service response.
+                statusOnError:
+                  type: string
+                  description: HTTP status returned to the client when communication with the authorization service fails.
+                clearRouteCache:
+                  type: boolean
+                  description: Clear route cache to let the external authorization service affect routing decisions.
       trafficRedirectionSetupMode:
         type: string
         description: |

--- a/modules/110-istio/openapi/doc-ru-config-values.yaml
+++ b/modules/110-istio/openapi/doc-ru-config-values.yaml
@@ -324,6 +324,30 @@ properties:
             description: Тестовый формат access-логов sidecar-контейнера. Операторы шаблона описаны в [документации envoy](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators).
           jsonLabels:
             description: JSON формат access-логов sidecar-контейнера. Операторы шаблона описаны в [документации envoy](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators).
+      extensionProviders:
+        description: |
+          Дополнительные Istio extension providers, которые будут зарегистрированы в mesh configuration.
+
+          Имя provider'а `main-access-log-format` зарезервировано Deckhouse.
+        items:
+          properties:
+            name:
+              description: Уникальное имя extension provider'а.
+            envoyExtAuthzGrpc:
+              description: Внешний сервис авторизации, который реализует Envoy ext_authz gRPC API.
+              properties:
+                service:
+                  description: Сервис, который реализует Envoy ext_authz gRPC API. Формат значения — `[<namespace>/]<hostname>`.
+                port:
+                  description: Порт сервиса.
+                failOpen:
+                  description: Разрешать запросы, если сервис авторизации недоступен или вернул ошибку 5xx.
+                timeout:
+                  description: Максимальное время ожидания ответа от сервиса авторизации.
+                statusOnError:
+                  description: HTTP-статус, который будет возвращён клиенту при ошибке взаимодействия с сервисом авторизации.
+                clearRouteCache:
+                  description: Очищать route cache, чтобы внешний сервис авторизации мог влиять на маршрутизацию.
       trafficRedirectionSetupMode:
         description: |
           Управление режимом перенаправления прикладного трафика для передачи под управление Istio в сетевом пространстве имён пода.

--- a/modules/110-istio/openapi/openapi-case-tests.yaml
+++ b/modules/110-istio/openapi/openapi-case-tests.yaml
@@ -70,9 +70,3 @@ negative:
           envoyExtAuthzGrpc:
             service: authservice.istio-system.svc.cluster.local
             port: "10003"
-    - dataPlane:
-        extensionProviders:
-        - name: main-access-log-format
-          envoyExtAuthzGrpc:
-            service: authservice.istio-system.svc.cluster.local
-            port: 10003

--- a/modules/110-istio/openapi/openapi-case-tests.yaml
+++ b/modules/110-istio/openapi/openapi-case-tests.yaml
@@ -38,6 +38,12 @@ positive:
         enabled: true
       dataPlane:
         trafficRedirectionSetupMode: CNIPlugin
+    - dataPlane:
+        extensionProviders:
+        - name: authservice-grpc
+          envoyExtAuthzGrpc:
+            service: authservice.d8-istio.svc.cluster.local
+            port: 10003
   values:
     - {}
 negative:
@@ -58,3 +64,15 @@ negative:
         enabled: true
       dataPlane:
         trafficRedirectionSetupMode: InitContainer
+    - dataPlane:
+        extensionProviders:
+        - name: authservice-grpc
+          envoyExtAuthzGrpc:
+            service: authservice.istio-system.svc.cluster.local
+            port: "10003"
+    - dataPlane:
+        extensionProviders:
+        - name: main-access-log-format
+          envoyExtAuthzGrpc:
+            service: authservice.istio-system.svc.cluster.local
+            port: 10003

--- a/modules/110-istio/template_tests/module_test.go
+++ b/modules/110-istio/template_tests/module_test.go
@@ -353,15 +353,8 @@ var _ = Describe("Module :: istio :: helm template :: main", func() {
 		It("", func() {
 			Expect(f.RenderError).ShouldNot(HaveOccurred())
 
-			istioV27 := f.KubernetesResource("Istio", "d8-istio", "v1x27x9")
 			istioV25 := f.KubernetesResource("Istio", "d8-istio", "v1x25x2")
 			iopV21 := f.KubernetesResource("IstioOperator", "d8-istio", "v1x21x6")
-
-			Expect(istioV27.Exists()).To(BeTrue())
-			Expect(istioV27.Field("spec.values.meshConfig.extensionProviders.0.name").String()).To(Equal(`main-access-log-format`))
-			Expect(istioV27.Field("spec.values.meshConfig.extensionProviders.1.name").String()).To(Equal(`authservice-grpc`))
-			Expect(istioV27.Field("spec.values.meshConfig.extensionProviders.1.envoyExtAuthzGrpc.service").String()).To(Equal(`authservice.d8-istio.svc.cluster.local`))
-			Expect(istioV27.Field("spec.values.meshConfig.extensionProviders.1.envoyExtAuthzGrpc.port").Int()).To(Equal(int64(10003)))
 
 			Expect(istioV25.Field("spec.values.meshConfig.extensionProviders.0.name").String()).To(Equal(`main-access-log-format`))
 			Expect(istioV25.Field("spec.values.meshConfig.extensionProviders.1.name").String()).To(Equal(`authservice-grpc`))

--- a/modules/110-istio/template_tests/module_test.go
+++ b/modules/110-istio/template_tests/module_test.go
@@ -334,6 +334,47 @@ var _ = Describe("Module :: istio :: helm template :: main", func() {
 		})
 	})
 
+	Context("There are user extension providers", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", globalValues)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYaml("istio", istioValues)
+			f.ValuesSetFromYaml("istio.internal.versionsToInstall", `["1.25.2","1.21.6"]`)
+			f.ValuesSetFromYaml("istio.internal.operatorVersionsToInstall", `["1.25.2","1.21.6"]`)
+			f.ValuesSetFromYaml("istio.dataPlane.extensionProviders", `
+- name: authservice-grpc
+  envoyExtAuthzGrpc:
+    service: authservice.d8-istio.svc.cluster.local
+    port: 10003
+`)
+			f.HelmRender()
+		})
+
+		It("", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			istioV27 := f.KubernetesResource("Istio", "d8-istio", "v1x27x9")
+			istioV25 := f.KubernetesResource("Istio", "d8-istio", "v1x25x2")
+			iopV21 := f.KubernetesResource("IstioOperator", "d8-istio", "v1x21x6")
+
+			Expect(istioV27.Exists()).To(BeTrue())
+			Expect(istioV27.Field("spec.values.meshConfig.extensionProviders.0.name").String()).To(Equal(`main-access-log-format`))
+			Expect(istioV27.Field("spec.values.meshConfig.extensionProviders.1.name").String()).To(Equal(`authservice-grpc`))
+			Expect(istioV27.Field("spec.values.meshConfig.extensionProviders.1.envoyExtAuthzGrpc.service").String()).To(Equal(`authservice.d8-istio.svc.cluster.local`))
+			Expect(istioV27.Field("spec.values.meshConfig.extensionProviders.1.envoyExtAuthzGrpc.port").Int()).To(Equal(int64(10003)))
+
+			Expect(istioV25.Field("spec.values.meshConfig.extensionProviders.0.name").String()).To(Equal(`main-access-log-format`))
+			Expect(istioV25.Field("spec.values.meshConfig.extensionProviders.1.name").String()).To(Equal(`authservice-grpc`))
+			Expect(istioV25.Field("spec.values.meshConfig.extensionProviders.1.envoyExtAuthzGrpc.service").String()).To(Equal(`authservice.d8-istio.svc.cluster.local`))
+			Expect(istioV25.Field("spec.values.meshConfig.extensionProviders.1.envoyExtAuthzGrpc.port").Int()).To(Equal(int64(10003)))
+
+			Expect(iopV21.Field("spec.meshConfig.extensionProviders.0.name").String()).To(Equal(`main-access-log-format`))
+			Expect(iopV21.Field("spec.meshConfig.extensionProviders.1.name").String()).To(Equal(`authservice-grpc`))
+			Expect(iopV21.Field("spec.meshConfig.extensionProviders.1.envoyExtAuthzGrpc.service").String()).To(Equal(`authservice.d8-istio.svc.cluster.local`))
+			Expect(iopV21.Field("spec.meshConfig.extensionProviders.1.envoyExtAuthzGrpc.port").Int()).To(Equal(int64(10003)))
+		})
+	})
+
 	Context("There is one federation", func() {
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global", globalValues)

--- a/modules/110-istio/templates/_helpers.tpl
+++ b/modules/110-istio/templates/_helpers.tpl
@@ -39,3 +39,21 @@
     true
   {{- end -}}
 {{- end -}}
+
+{{- define "istioUserExtensionProviders" -}}
+  {{- $providers := .Values.istio.dataPlane.extensionProviders | default list -}}
+  {{- $seen := dict -}}
+  {{- range $provider := $providers -}}
+    {{- $name := $provider.name -}}
+    {{- if eq $name "main-access-log-format" -}}
+      {{- fail "istio.dataPlane.extensionProviders must not use reserved provider name main-access-log-format" -}}
+    {{- end -}}
+    {{- if hasKey $seen $name -}}
+      {{- fail (printf "istio.dataPlane.extensionProviders contains duplicate provider name %q" $name) -}}
+    {{- end -}}
+    {{- $_ := set $seen $name true -}}
+  {{- end -}}
+  {{- if $providers -}}
+    {{- toYaml $providers -}}
+  {{- end -}}
+{{- end -}}

--- a/modules/110-istio/templates/control-plane/iop.yaml
+++ b/modules/110-istio/templates/control-plane/iop.yaml
@@ -89,6 +89,7 @@ spec:
           {{- end }}
         {{- end }}
       name: main-access-log-format
+{{- include "istioUserExtensionProviders" $ | nindent 4 }}
 
     # The rules below exclude upmeter-related namespaces from istiod's point of view.
     # So, upmeter's events used to affect the traffic between control-plane and data-plane will be reduced.

--- a/modules/110-istio/templates/control-plane/istios.yaml
+++ b/modules/110-istio/templates/control-plane/istios.yaml
@@ -9,12 +9,12 @@
 
 {{- range $version := .Values.istio.internal.versionsToInstall }}
   {{- $versionInfo := get $.Values.istio.internal.versionMap $version }}
-  {{- if get $versionInfo "supportsOperator" }}
   {{- $revision := get $versionInfo "revision"}}
   {{- $imageSuffix := get $versionInfo "imageSuffix" }}
   {{- $fullVersion := get $versionInfo "fullVersion" }}
   {{- $supportsAmbient := get $versionInfo "supportsAmbient" }}
-  {{- if (hasPrefix "1.25" $fullVersion) }}  {{/* Checks if fullVersion starts with "1.25" */}}
+  {{- $supportsOperator := get $versionInfo "supportsOperator" }}
+  {{- if or (hasPrefix "1.25" $fullVersion) (not $supportsOperator) }}
     {{- if ($.Values.global.enabledModules | has "vertical-pod-autoscaler") }}
 ---
 apiVersion: autoscaling.k8s.io/v1
@@ -123,6 +123,7 @@ spec:
             {{- end }}
           {{- end }}
         name: main-access-log-format
+{{- include "istioUserExtensionProviders" $ | nindent 6 }}
 
       # The rules below exclude upmeter-related namespaces from istiod's point of view.
       # So, upmeter's events used to affect the traffic between control-plane and data-plane will be reduced.
@@ -260,6 +261,5 @@ spec:
       - matchExpressions:
         - key: job-name
           operator: Exists
-  {{- end }}
   {{- end }}
 {{- end }}

--- a/modules/110-istio/templates/control-plane/istios.yaml
+++ b/modules/110-istio/templates/control-plane/istios.yaml
@@ -13,8 +13,7 @@
   {{- $imageSuffix := get $versionInfo "imageSuffix" }}
   {{- $fullVersion := get $versionInfo "fullVersion" }}
   {{- $supportsAmbient := get $versionInfo "supportsAmbient" }}
-  {{- $supportsOperator := get $versionInfo "supportsOperator" }}
-  {{- if or (hasPrefix "1.25" $fullVersion) (not $supportsOperator) }}
+  {{- if (hasPrefix "1.25" $fullVersion) }}  {{/* Checks if fullVersion starts with "1.25" */}}
     {{- if ($.Values.global.enabledModules | has "vertical-pod-autoscaler") }}
 ---
 apiVersion: autoscaling.k8s.io/v1


### PR DESCRIPTION
## Description
Adds support for configuring custom Istio extensionProviders through the Istio module configuration.

Example: The current implementation supports `envoyExtAuthzGrpc` providers for external authorization services. User-defined providers are appended to the existing mesh configuration, so the built-in access log provider remains unchanged.

Changing this setting updates the Istio control plane configuration and may trigger reconciliation/restart of Istio control plane components.

## Why do we need it, and what problem does it solve?
Users need a supported way to register external authorization providers in Istio `MeshConfig` without manually patching Deckhouse-managed Istio resources.

This enables workloads to use Istio `AuthorizationPolicy` with CUSTOM action and delegate authorization decisions to a user-provided gRPC ext_authz service, while keeping Deckhouse-owned mesh settings intact.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: feature
summary: Added support for custom extension providers.
impact_level: default
```
