### PR TITLE
[cert-manager] Cleanup stale HTTP-01 solver pods after node reboot

### DIFF
--- a/modules/101-cert-manager/hooks/cleanup_stale_http01_solver_pods.go
+++ b/modules/101-cert-manager/hooks/cleanup_stale_http01_solver_pods.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2021 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"context"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/deckhouse/deckhouse/modules/101-cert-manager/hooks/internal"
+)
+
+const solverPodsSnapshot = "solverPods"
+
+type solverPod struct {
+	Namespace      string
+	Name           string
+	Phase          corev1.PodPhase
+	BeingDeleted   bool
+}
+
+func applySolverPodFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	var pod corev1.Pod
+	if err := sdk.FromUnstructured(obj, &pod); err != nil {
+		return nil, err
+	}
+
+	return solverPod{
+		Namespace:    pod.GetNamespace(),
+		Name:         pod.GetName(),
+		Phase:        pod.Status.Phase,
+		BeingDeleted: pod.GetDeletionTimestamp() != nil,
+	}, nil
+}
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	Queue: internal.Queue("cleanup-stale-http01-solver-pods"),
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:       solverPodsSnapshot,
+			ApiVersion: "v1",
+			Kind:       "Pod",
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"acme.cert-manager.io/http01-solver": "true",
+				},
+			},
+			FilterFunc: applySolverPodFilter,
+		},
+	},
+}, cleanupStaleHTTP01SolverPods)
+
+func cleanupStaleHTTP01SolverPods(_ context.Context, input *go_hook.HookInput) error {
+	for _, podSnap := range input.Snapshots.Get(solverPodsSnapshot) {
+		var pod solverPod
+		if err := podSnap.UnmarshalTo(&pod); err != nil {
+			return err
+		}
+
+		if pod.BeingDeleted {
+			continue
+		}
+
+		if pod.Phase != corev1.PodSucceeded && pod.Phase != corev1.PodFailed && pod.Phase != corev1.PodUnknown {
+			continue
+		}
+
+		input.PatchCollector.DeleteInBackground("v1", "Pod", pod.Namespace, pod.Name)
+	}
+
+	return nil
+}

--- a/modules/101-cert-manager/hooks/cleanup_stale_http01_solver_pods.go
+++ b/modules/101-cert-manager/hooks/cleanup_stale_http01_solver_pods.go
@@ -89,12 +89,18 @@ func applySolverPodFilter(obj *unstructured.Unstructured) (go_hook.FilterResult,
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	Queue: internal.Queue("cleanup-stale-http01-solver-pods"),
+	Schedule: []go_hook.ScheduleConfig{
+		{
+			Name:    "cleanup_stale_http01_solver_pods",
+			Crontab: "* * * * *",
+		},
+	},
 	Kubernetes: []go_hook.KubernetesConfig{
 		{
 			Name:                         solverPodsSnapshot,
 			ApiVersion:                   "v1",
 			Kind:                         "Pod",
-			ExecuteHookOnEvents:          ptr.To(true),
+			ExecuteHookOnEvents:          ptr.To(false),
 			ExecuteHookOnSynchronization: ptr.To(true),
 			LabelSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{

--- a/modules/101-cert-manager/hooks/cleanup_stale_http01_solver_pods.go
+++ b/modules/101-cert-manager/hooks/cleanup_stale_http01_solver_pods.go
@@ -64,8 +64,15 @@ func solverPodTerminalSince(pod corev1.Pod) *time.Time {
 func isStaleTerminalSolverPod(pod solverPod, now time.Time) bool {
 	since := pod.TerminalSince
 	if since == nil {
+		if pod.CreatedAt.IsZero() {
+			return false
+		}
 		createdAt := pod.CreatedAt
 		since = &createdAt
+	}
+
+	if since.IsZero() {
+		return false
 	}
 
 	return now.Sub(*since) >= staleSolverGracePeriod
@@ -92,6 +99,12 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	Settings: &go_hook.HookConfigSettings{
 		ExecutionMinInterval: 15 * time.Second,
 		ExecutionBurst:       1,
+	},
+	Schedule: []go_hook.ScheduleConfig{
+		{
+			Name:    "cleanup_stale_http01_solver_pods",
+			Crontab: "*/30 * * * *",
+		},
 	},
 	Kubernetes: []go_hook.KubernetesConfig{
 		{

--- a/modules/101-cert-manager/hooks/cleanup_stale_http01_solver_pods.go
+++ b/modules/101-cert-manager/hooks/cleanup_stale_http01_solver_pods.go
@@ -18,23 +18,57 @@ package hooks
 
 import (
 	"context"
+	"time"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/ptr"
 
 	"github.com/deckhouse/deckhouse/modules/101-cert-manager/hooks/internal"
 )
 
-const solverPodsSnapshot = "solverPods"
+const (
+	solverPodsSnapshot     = "solverPods"
+	staleSolverGracePeriod = 60 * time.Second
+)
 
 type solverPod struct {
-	Namespace    string
-	Name         string
-	Phase        corev1.PodPhase
-	BeingDeleted bool
+	Namespace     string
+	Name          string
+	Phase         corev1.PodPhase
+	BeingDeleted  bool
+	CreatedAt     time.Time
+	TerminalSince *time.Time
+}
+
+func solverPodTerminalSince(pod corev1.Pod) *time.Time {
+	var latest *time.Time
+
+	for _, cs := range pod.Status.ContainerStatuses {
+		if cs.State.Terminated == nil {
+			continue
+		}
+
+		t := cs.State.Terminated.FinishedAt.Time
+		if latest == nil || t.After(*latest) {
+			latest = &t
+		}
+	}
+
+	return latest
+}
+
+func isStaleTerminalSolverPod(pod solverPod, now time.Time) bool {
+	since := pod.TerminalSince
+	if since == nil {
+		createdAt := pod.CreatedAt
+		since = &createdAt
+	}
+
+	return now.Sub(*since) >= staleSolverGracePeriod
 }
 
 func applySolverPodFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
@@ -44,10 +78,12 @@ func applySolverPodFilter(obj *unstructured.Unstructured) (go_hook.FilterResult,
 	}
 
 	return solverPod{
-		Namespace:    pod.GetNamespace(),
-		Name:         pod.GetName(),
-		Phase:        pod.Status.Phase,
-		BeingDeleted: pod.GetDeletionTimestamp() != nil,
+		Namespace:     pod.GetNamespace(),
+		Name:          pod.GetName(),
+		Phase:         pod.Status.Phase,
+		BeingDeleted:  pod.GetDeletionTimestamp() != nil,
+		CreatedAt:     pod.GetCreationTimestamp().Time,
+		TerminalSince: solverPodTerminalSince(pod),
 	}, nil
 }
 
@@ -55,9 +91,11 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	Queue: internal.Queue("cleanup-stale-http01-solver-pods"),
 	Kubernetes: []go_hook.KubernetesConfig{
 		{
-			Name:       solverPodsSnapshot,
-			ApiVersion: "v1",
-			Kind:       "Pod",
+			Name:                         solverPodsSnapshot,
+			ApiVersion:                   "v1",
+			Kind:                         "Pod",
+			ExecuteHookOnEvents:          ptr.To(true),
+			ExecuteHookOnSynchronization: ptr.To(true),
 			LabelSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"acme.cert-manager.io/http01-solver": "true",
@@ -68,8 +106,16 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	},
 }, cleanupStaleHTTP01SolverPods)
 
-func cleanupStaleHTTP01SolverPods(_ context.Context, input *go_hook.HookInput) error {
+func cleanupStaleHTTP01SolverPods(ctx context.Context, input *go_hook.HookInput) error {
+	now := time.Now()
+
 	for _, podSnap := range input.Snapshots.Get(solverPodsSnapshot) {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
 		var pod solverPod
 		if err := podSnap.UnmarshalTo(&pod); err != nil {
 			return err
@@ -83,6 +129,15 @@ func cleanupStaleHTTP01SolverPods(_ context.Context, input *go_hook.HookInput) e
 			continue
 		}
 
+		if !isStaleTerminalSolverPod(pod, now) {
+			continue
+		}
+
+		input.Logger.Info("Deleting stale HTTP-01 solver pod",
+			"namespace", pod.Namespace,
+			"name", pod.Name,
+			"phase", pod.Phase,
+		)
 		input.PatchCollector.DeleteInBackground("v1", "Pod", pod.Namespace, pod.Name)
 	}
 

--- a/modules/101-cert-manager/hooks/cleanup_stale_http01_solver_pods.go
+++ b/modules/101-cert-manager/hooks/cleanup_stale_http01_solver_pods.go
@@ -89,18 +89,16 @@ func applySolverPodFilter(obj *unstructured.Unstructured) (go_hook.FilterResult,
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	Queue: internal.Queue("cleanup-stale-http01-solver-pods"),
-	Schedule: []go_hook.ScheduleConfig{
-		{
-			Name:    "cleanup_stale_http01_solver_pods",
-			Crontab: "* * * * *",
-		},
+	Settings: &go_hook.HookConfigSettings{
+		ExecutionMinInterval: 15 * time.Second,
+		ExecutionBurst:       1,
 	},
 	Kubernetes: []go_hook.KubernetesConfig{
 		{
 			Name:                         solverPodsSnapshot,
 			ApiVersion:                   "v1",
 			Kind:                         "Pod",
-			ExecuteHookOnEvents:          ptr.To(false),
+			ExecuteHookOnEvents:          ptr.To(true),
 			ExecuteHookOnSynchronization: ptr.To(true),
 			LabelSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{

--- a/modules/101-cert-manager/hooks/cleanup_stale_http01_solver_pods.go
+++ b/modules/101-cert-manager/hooks/cleanup_stale_http01_solver_pods.go
@@ -31,10 +31,10 @@ import (
 const solverPodsSnapshot = "solverPods"
 
 type solverPod struct {
-	Namespace      string
-	Name           string
-	Phase          corev1.PodPhase
-	BeingDeleted   bool
+	Namespace    string
+	Name         string
+	Phase        corev1.PodPhase
+	BeingDeleted bool
 }
 
 func applySolverPodFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {

--- a/modules/101-cert-manager/hooks/cleanup_stale_http01_solver_pods_test.go
+++ b/modules/101-cert-manager/hooks/cleanup_stale_http01_solver_pods_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2021 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"fmt"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+func genSolverPodManifest(name, namespace, phase string, withDeletionTimestamp bool) string {
+	deletionTimestamp := ""
+	if withDeletionTimestamp {
+		deletionTimestamp = `  deletionTimestamp: "2026-01-01T00:00:00Z"`
+	}
+
+	return fmt.Sprintf(`
+apiVersion: v1
+kind: Pod
+metadata:
+  name: %s
+  namespace: %s
+  labels:
+    acme.cert-manager.io/http01-solver: "true"
+%s
+status:
+  phase: %s
+`, name, namespace, deletionTimestamp, phase)
+}
+
+func setPodsState(f *HookExecutionConfig, manifests ...string) {
+	state := strings.Join(manifests, "\n---")
+	f.BindingContexts.Set(f.KubeStateSetAndWaitForBindingContexts(state, 0))
+}
+
+var _ = Describe("Cert Manager hooks :: cleanup stale http01 solver pods ::", func() {
+	f := HookExecutionConfigInit(`{"global":{}}`, "")
+
+	const ns = "cm-repro"
+
+	Context("Empty cluster", func() {
+		BeforeEach(func() {
+			setPodsState(f, ``)
+			f.RunHook()
+		})
+
+		It("runs successfully", func() {
+			Expect(f).To(ExecuteSuccessfully())
+		})
+	})
+
+	Context("Terminal solver pod", func() {
+		BeforeEach(func() {
+			setPodsState(f, genSolverPodManifest("solver-succeeded", ns, "Succeeded", false))
+			f.RunHook()
+		})
+
+		It("deletes the pod", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.KubernetesResource("Pod", ns, "solver-succeeded")).To(BeEmpty())
+		})
+	})
+
+	Context("Running solver pod", func() {
+		BeforeEach(func() {
+			setPodsState(f, genSolverPodManifest("solver-running", ns, "Running", false))
+			f.RunHook()
+		})
+
+		It("keeps the pod", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.KubernetesResource("Pod", ns, "solver-running")).ToNot(BeEmpty())
+		})
+	})
+
+	Context("Solver pod marked for deletion", func() {
+		BeforeEach(func() {
+			setPodsState(f, genSolverPodManifest("solver-terminating", ns, "Succeeded", true))
+			f.RunHook()
+		})
+
+		It("does not attempt to delete the pod again", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.KubernetesResource("Pod", ns, "solver-terminating")).ToNot(BeEmpty())
+		})
+	})
+})

--- a/modules/101-cert-manager/hooks/cleanup_stale_http01_solver_pods_test.go
+++ b/modules/101-cert-manager/hooks/cleanup_stale_http01_solver_pods_test.go
@@ -19,6 +19,7 @@ package hooks
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -26,10 +27,24 @@ import (
 	. "github.com/deckhouse/deckhouse/testing/hooks"
 )
 
-func genSolverPodManifest(name, namespace, phase string, withDeletionTimestamp bool) string {
+func genSolverPodManifest(name, namespace, phase string, withDeletionTimestamp bool, createdAt, finishedAt time.Time) string {
 	deletionTimestamp := ""
 	if withDeletionTimestamp {
 		deletionTimestamp = `  deletionTimestamp: "2026-01-01T00:00:00Z"`
+	}
+
+	containerStatuses := ""
+	if !finishedAt.IsZero() {
+		containerStatuses = fmt.Sprintf(`  containerStatuses:
+  - name: acmesolver
+    state:
+      terminated:
+        finishedAt: "%s"`, finishedAt.UTC().Format(time.RFC3339))
+	}
+
+	creationTimestamp := createdAt.UTC().Format(time.RFC3339)
+	if createdAt.IsZero() {
+		creationTimestamp = time.Now().UTC().Format(time.RFC3339)
 	}
 
 	return fmt.Sprintf(`
@@ -38,12 +53,14 @@ kind: Pod
 metadata:
   name: %s
   namespace: %s
+  creationTimestamp: "%s"
   labels:
     acme.cert-manager.io/http01-solver: "true"
 %s
 status:
   phase: %s
-`, name, namespace, deletionTimestamp, phase)
+%s
+`, name, namespace, creationTimestamp, deletionTimestamp, phase, containerStatuses)
 }
 
 func setPodsState(f *HookExecutionConfig, manifests ...string) {
@@ -67,9 +84,10 @@ var _ = Describe("Cert Manager hooks :: cleanup stale http01 solver pods ::", fu
 		})
 	})
 
-	Context("Terminal solver pod", func() {
+	Context("Terminal solver pod past grace period", func() {
 		BeforeEach(func() {
-			setPodsState(f, genSolverPodManifest("solver-succeeded", ns, "Succeeded", false))
+			terminalAt := time.Now().Add(-2 * time.Minute)
+			setPodsState(f, genSolverPodManifest("solver-succeeded", ns, "Succeeded", false, terminalAt, terminalAt))
 			f.RunHook()
 		})
 
@@ -79,9 +97,61 @@ var _ = Describe("Cert Manager hooks :: cleanup stale http01 solver pods ::", fu
 		})
 	})
 
+	Context("Failed solver pod past grace period", func() {
+		BeforeEach(func() {
+			terminalAt := time.Now().Add(-2 * time.Minute)
+			setPodsState(f, genSolverPodManifest("solver-failed", ns, "Failed", false, terminalAt, terminalAt))
+			f.RunHook()
+		})
+
+		It("deletes the pod", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.KubernetesResource("Pod", ns, "solver-failed")).To(BeEmpty())
+		})
+	})
+
+	Context("Unknown solver pod past grace period", func() {
+		BeforeEach(func() {
+			terminalAt := time.Now().Add(-2 * time.Minute)
+			setPodsState(f, genSolverPodManifest("solver-unknown", ns, "Unknown", false, terminalAt, terminalAt))
+			f.RunHook()
+		})
+
+		It("deletes the pod", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.KubernetesResource("Pod", ns, "solver-unknown")).To(BeEmpty())
+		})
+	})
+
+	Context("Terminal solver pod past grace period without finishedAt", func() {
+		BeforeEach(func() {
+			createdAt := time.Now().Add(-2 * time.Minute)
+			setPodsState(f, genSolverPodManifest("solver-fallback", ns, "Succeeded", false, createdAt, time.Time{}))
+			f.RunHook()
+		})
+
+		It("deletes the pod using creationTimestamp fallback", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.KubernetesResource("Pod", ns, "solver-fallback")).To(BeEmpty())
+		})
+	})
+
+	Context("Terminal solver pod within grace period", func() {
+		BeforeEach(func() {
+			terminalAt := time.Now().Add(-10 * time.Second)
+			setPodsState(f, genSolverPodManifest("solver-fresh", ns, "Succeeded", false, terminalAt, terminalAt))
+			f.RunHook()
+		})
+
+		It("keeps the pod", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.KubernetesResource("Pod", ns, "solver-fresh")).ToNot(BeEmpty())
+		})
+	})
+
 	Context("Running solver pod", func() {
 		BeforeEach(func() {
-			setPodsState(f, genSolverPodManifest("solver-running", ns, "Running", false))
+			setPodsState(f, genSolverPodManifest("solver-running", ns, "Running", false, time.Time{}, time.Time{}))
 			f.RunHook()
 		})
 
@@ -93,7 +163,8 @@ var _ = Describe("Cert Manager hooks :: cleanup stale http01 solver pods ::", fu
 
 	Context("Solver pod marked for deletion", func() {
 		BeforeEach(func() {
-			setPodsState(f, genSolverPodManifest("solver-terminating", ns, "Succeeded", true))
+			terminalAt := time.Now().Add(-2 * time.Minute)
+			setPodsState(f, genSolverPodManifest("solver-terminating", ns, "Succeeded", true, terminalAt, terminalAt))
 			f.RunHook()
 		})
 

--- a/modules/101-cert-manager/hooks/cleanup_stale_http01_solver_pods_test.go
+++ b/modules/101-cert-manager/hooks/cleanup_stale_http01_solver_pods_test.go
@@ -63,6 +63,20 @@ status:
 `, name, namespace, creationTimestamp, deletionTimestamp, phase, containerStatuses)
 }
 
+func genSolverPodManifestWithoutCreationTimestamp(name, namespace, phase string) string {
+	return fmt.Sprintf(`
+apiVersion: v1
+kind: Pod
+metadata:
+  name: %s
+  namespace: %s
+  labels:
+    acme.cert-manager.io/http01-solver: "true"
+status:
+  phase: %s
+`, name, namespace, phase)
+}
+
 func setPodsState(f *HookExecutionConfig, manifests ...string) {
 	state := strings.Join(manifests, "\n---")
 	f.BindingContexts.Set(f.KubeStateSetAndWaitForBindingContexts(state, 0))
@@ -70,6 +84,7 @@ func setPodsState(f *HookExecutionConfig, manifests ...string) {
 
 var _ = Describe("Cert Manager hooks :: cleanup stale http01 solver pods ::", func() {
 	f := HookExecutionConfigInit(`{"global":{}}`, "")
+	fSecondRun := HookExecutionConfigInit(`{"global":{}}`, "")
 
 	const ns = "cm-repro"
 
@@ -170,7 +185,37 @@ var _ = Describe("Cert Manager hooks :: cleanup stale http01 solver pods ::", fu
 
 		It("does not attempt to delete the pod again", func() {
 			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.PatchCollector.Operations()).To(BeEmpty())
 			Expect(f.KubernetesResource("Pod", ns, "solver-terminating")).ToNot(BeEmpty())
+		})
+	})
+
+	Context("Second hook run after stale pod was deleted", func() {
+		It("runs successfully without issuing delete patches", func() {
+			terminalAt := time.Now().Add(-2 * time.Minute)
+			setPodsState(f, genSolverPodManifest("solver-idempotent", ns, "Succeeded", false, terminalAt, terminalAt))
+			f.RunHook()
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.PatchCollector.Operations()).To(HaveLen(1))
+			Expect(f.KubernetesResource("Pod", ns, "solver-idempotent")).To(BeEmpty())
+
+			setPodsState(fSecondRun, ``)
+			fSecondRun.RunHook()
+			Expect(fSecondRun).To(ExecuteSuccessfully())
+			Expect(fSecondRun.PatchCollector.Operations()).To(BeEmpty())
+		})
+	})
+
+	Context("Terminal solver pod with zero creationTimestamp", func() {
+		BeforeEach(func() {
+			setPodsState(f, genSolverPodManifestWithoutCreationTimestamp("solver-no-ts", ns, "Succeeded"))
+			f.RunHook()
+		})
+
+		It("keeps the pod", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.PatchCollector.Operations()).To(BeEmpty())
+			Expect(f.KubernetesResource("Pod", ns, "solver-no-ts")).ToNot(BeEmpty())
 		})
 	})
 })


### PR DESCRIPTION
## Description

Add a Deckhouse hook in the `cert-manager` module that removes stale `cm-acme-http-solver` pods in terminal phases (`Succeeded` / `Failed` / `Unknown`) after a node reboot or shutdown.

cert-manager treats any existing solver pod as valid and does not recreate it, even when the pod is `Completed` and no longer serves HTTP-01 traffic. The hook deletes only solver pods with label `acme.cert-manager.io/http01-solver=true` that are already in a terminal phase. Running pods and pods with `deletionTimestamp` are not touched. Orders and Challenges are not modified.

## Why do we need it, and what problem does it solve?

After a node reboot during ACME HTTP-01 issuance, solver pods can remain in `Completed` or `Unknown` state. cert-manager keeps reconciling them (`found one existing HTTP01 solver pod`) and HTTP-01 self-check fails with `503 expected 200`. Certificate issuance stalls until the solver pod is deleted manually.

Reproduced on dev cluster: reboot of a master node during HTTP-01 left a `Completed` solver pod; Challenge stayed in processing with `503`. Manual pod deletion triggered creation of a new solver (workaround confirmed).

This hook automates that cleanup so cert-manager can recreate the solver and continue the challenge.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist

- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cert-manager
type: fix
summary: Automatically remove stale HTTP-01 solver pods after node reboot
impact_level: default