### PR TITLE
[deckhouse] global package

### DIFF
--- a/deckhouse-controller/internal/packages/modules/global/info.go
+++ b/deckhouse-controller/internal/packages/modules/global/info.go
@@ -1,0 +1,42 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package global
+
+import (
+	addonutils "github.com/flant/addon-operator/pkg/utils"
+)
+
+type Info struct {
+	Name    string            `json:"name" yaml:"name"`
+	Running bool              `json:"running" yaml:"running"`
+	Path    string            `json:"path" yaml:"path"`
+	Values  addonutils.Values `json:"values,omitempty" yaml:"values,omitempty"`
+	Hooks   []string          `json:"hooks,omitempty" yaml:"hooks,omitempty"`
+}
+
+func (m *Module) GetInfo() Info {
+	hooks := make([]string, len(m.hooks.GetHooks()))
+	for idx, hook := range m.hooks.GetHooks() {
+		hooks[idx] = hook.GetName()
+	}
+
+	return Info{
+		Name:    m.name,
+		Running: m.running.Load(),
+		Path:    m.path,
+		Values:  m.values.GetValues(),
+		Hooks:   hooks,
+	}
+}

--- a/deckhouse-controller/internal/packages/modules/global/module.go
+++ b/deckhouse-controller/internal/packages/modules/global/module.go
@@ -16,10 +16,13 @@ package global
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 	"sync/atomic"
 
+	sdkutils "github.com/deckhouse/module-sdk/pkg/utils"
 	"github.com/flant/addon-operator/pkg"
 	addontypes "github.com/flant/addon-operator/pkg/hook/types"
 	addonutils "github.com/flant/addon-operator/pkg/utils"
@@ -300,4 +303,24 @@ func (m *Module) runHook(ctx context.Context, h hooks.GlobalHook, bctx []bctx.Bi
 	}
 
 	return nil
+}
+
+// SetEnabledModules inject enabledModules to the global values
+// enabledModules are injected as a patch, to recalculate on every global values change
+func (m *Module) SetEnabledModules(enabledModules []string) {
+	if len(enabledModules) == 0 {
+		return
+	}
+
+	// keep them sorted to prevent helm rollout on each restart
+	sort.Strings(enabledModules)
+	data, _ := json.Marshal(enabledModules)
+
+	_ = m.values.ApplyValuesPatch(addonutils.ValuesPatch{Operations: []*sdkutils.ValuesPatchOperation{
+		{
+			Op:    "add",
+			Path:  "/global/enabledModules",
+			Value: data,
+		},
+	}})
 }

--- a/deckhouse-controller/internal/packages/modules/global/module.go
+++ b/deckhouse-controller/internal/packages/modules/global/module.go
@@ -22,7 +22,6 @@ import (
 	"sort"
 	"sync/atomic"
 
-	sdkutils "github.com/deckhouse/module-sdk/pkg/utils"
 	"github.com/flant/addon-operator/pkg"
 	addontypes "github.com/flant/addon-operator/pkg/hook/types"
 	addonutils "github.com/flant/addon-operator/pkg/utils"
@@ -37,6 +36,7 @@ import (
 	"go.opentelemetry.io/otel/codes"
 
 	"github.com/deckhouse/module-sdk/pkg/settingscheck"
+	sdkutils "github.com/deckhouse/module-sdk/pkg/utils"
 
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/hooks"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/values"

--- a/deckhouse-controller/internal/packages/modules/global/module.go
+++ b/deckhouse-controller/internal/packages/modules/global/module.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sync/atomic"
 
 	"github.com/flant/addon-operator/pkg"
 	addontypes "github.com/flant/addon-operator/pkg/hook/types"
@@ -45,6 +46,10 @@ type Module struct {
 
 	hooks  *hooks.GlobalStorage // Hook storage with indices
 	values *values.Storage      // Values storage with layering
+
+	// running tracks whether OnStartup hooks have completed successfully.
+	// When true, subsequent OnStartup binding calls are skipped (idempotency guard).
+	running atomic.Bool
 
 	patcher           *objectpatch.ObjectPatcher
 	scheduleManager   schedulemanager.ScheduleManager
@@ -76,6 +81,7 @@ func NewModuleByConfig(cfg *Config, logger *log.Logger) (*Module, error) {
 	m := new(Module)
 
 	m.name = "global"
+	m.running = atomic.Bool{}
 
 	m.path = cfg.Path
 	m.patcher = cfg.Patcher
@@ -241,6 +247,8 @@ func (m *Module) RunHooksByBinding(ctx context.Context, binding shtypes.BindingT
 			return fmt.Errorf("run hook '%s': %w", hook.GetName(), err)
 		}
 	}
+
+	m.running.Store(true)
 
 	return nil
 }

--- a/deckhouse-controller/internal/packages/modules/global/module.go
+++ b/deckhouse-controller/internal/packages/modules/global/module.go
@@ -319,7 +319,7 @@ func (m *Module) SetEnabledModules(enabledModules []string) {
 	patch := addonutils.ValuesPatch{Operations: []*sdkutils.ValuesPatchOperation{
 		{
 			Op:    "add",
-			Path:  "/global/enabledModules",
+			Path:  "/enabledModules",
 			Value: data,
 		},
 	}}

--- a/deckhouse-controller/internal/packages/modules/global/module.go
+++ b/deckhouse-controller/internal/packages/modules/global/module.go
@@ -316,11 +316,15 @@ func (m *Module) SetEnabledModules(enabledModules []string) {
 	sort.Strings(enabledModules)
 	data, _ := json.Marshal(enabledModules)
 
-	_ = m.values.ApplyValuesPatch(addonutils.ValuesPatch{Operations: []*sdkutils.ValuesPatchOperation{
+	patch := addonutils.ValuesPatch{Operations: []*sdkutils.ValuesPatchOperation{
 		{
 			Op:    "add",
 			Path:  "/global/enabledModules",
 			Value: data,
 		},
-	}})
+	}}
+
+	if err := m.values.ApplyValuesPatch(patch); err != nil {
+		m.logger.Error(fmt.Sprintf("failed to set enabled modules to global: %v", err.Error()))
+	}
 }

--- a/deckhouse-controller/internal/packages/runtime/apps.go
+++ b/deckhouse-controller/internal/packages/runtime/apps.go
@@ -105,7 +105,7 @@ func (r *Runtime) UpdateApp(repo registry.Remote, app App) {
 		return
 	}
 
-	r.status.ClearStatus(name)
+	r.status.NewStatus(name)
 
 	tasks := []queue.Task{
 		taskdeploy.NewAppTask(name, packageName, version, repo, r.appDeployer, r.status, r.logger),

--- a/deckhouse-controller/internal/packages/runtime/dump.go
+++ b/deckhouse-controller/internal/packages/runtime/dump.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/apps"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/modules"
+	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/modules/global"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/status"
 )
 
@@ -42,6 +43,35 @@ type appDump struct {
 type moduleDump struct {
 	Status status.Status `json:"status"`
 	modules.Info
+}
+
+// globalDump carries the package info and status conditions for the global module.
+type globalDump struct {
+	Status status.Status `json:"status"`
+	global.Info
+}
+
+// DumpGlobal returns a YAML snapshot of the global module's package info.
+//
+// The snapshot mirrors global.Info: instance name, running state, filesystem
+// path, current values, and the names of registered hooks. Returns nil when the
+// global module has not been initialized (r.global is nil), which the debug
+// handler surfaces as an empty body.
+func (r *Runtime) DumpGlobal() []byte {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	if r.global == nil {
+		return nil
+	}
+
+	d := globalDump{
+		Status: r.status.GetStatus(r.global.GetName()),
+		Info:   r.global.GetInfo(),
+	}
+
+	marshalled, _ := yaml.Marshal(d)
+	return marshalled
 }
 
 // Dump returns a YAML snapshot of all packages and their current state.

--- a/deckhouse-controller/internal/packages/runtime/modules.go
+++ b/deckhouse-controller/internal/packages/runtime/modules.go
@@ -75,7 +75,7 @@ func (r *Runtime) UpdateModule(repo registry.Remote, module Module) {
 		return
 	}
 
-	r.status.ClearStatus(name)
+	r.status.NewStatus(name)
 
 	tasks := []queue.Task{
 		taskdeploy.NewModuleTask(name, version, repo, r.moduleDeployer, r.status, r.logger),

--- a/deckhouse-controller/internal/packages/runtime/runtime.go
+++ b/deckhouse-controller/internal/packages/runtime/runtime.go
@@ -537,7 +537,13 @@ func (r *Runtime) buildScheduler(cli kclient.Client) {
 		return version
 	}
 
+	onScheduleHook := func(enabled []string) {
+		r.logger.Info("enabled packages", "packages", enabled)
+		r.global.SetEnabledModules(enabled)
+	}
+
 	r.scheduler = schedule.NewScheduler(
+		schedule.WithOnScheduleHook(onScheduleHook),
 		schedule.WithBootstrapCondition(bootstrapCondition),
 		schedule.WithDependencyGetter(dependencyGetter),
 		schedule.WithDeckhouseVersionGetter(deckhouseVersionGetter),

--- a/deckhouse-controller/internal/packages/runtime/runtime.go
+++ b/deckhouse-controller/internal/packages/runtime/runtime.go
@@ -42,7 +42,9 @@ import (
 	erofsdeploy "github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/deployer/erofs"
 	symlinkdeploy "github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/deployer/symlink"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/health"
+	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/loader"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/modules"
+	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/modules/global"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/nelm"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/runtime/debug"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/runtime/hookevent"
@@ -97,6 +99,8 @@ type Runtime struct {
 	objectPatcher     *objectpatch.ObjectPatcher          // Applies resource patches from hooks
 	scheduleManager   schedulemanager.ScheduleManager     // Cron-based schedule triggers
 	kubeEventsManager kubeeventsmanager.KubeEventsManager // Watches Kubernetes resources for hooks
+
+	global *global.Module
 
 	mu       sync.RWMutex
 	packages *lifecycle.Store
@@ -184,6 +188,18 @@ func New(cli kclient.Client, moduleManager moduleManagerI, dc dependency.Contain
 		QueueService:      r.queueService,
 	}, r.logger)
 
+	conf, err := loader.LoadGlobalConf(context.Background(), r.logger)
+	if err != nil {
+		return nil, fmt.Errorf("load global conf: %w", err)
+	}
+
+	r.global, err = global.NewModuleByConfig(conf, r.logger)
+	if err != nil {
+		return nil, fmt.Errorf("new global module: %w", err)
+	}
+
+	r.status.NewStatus(r.global.GetName())
+
 	if err := r.registerDebugServer("/tmp/deckhouse-debug.socket"); err != nil {
 		return nil, fmt.Errorf("register debug server: %w", err)
 	}
@@ -192,7 +208,7 @@ func New(cli kclient.Client, moduleManager moduleManagerI, dc dependency.Contain
 }
 
 // registerDebugServer starts a Unix socket HTTP server exposing debug endpoints
-// for package state introspection (/packages/dump, /packages/queues/dump, /packages/render/{name}).
+// for package state introspection (/packages/dump, /packages/global/dump, /packages/queues/dump, /packages/render/{name}).
 func (r *Runtime) registerDebugServer(socketPath string) error {
 	r.debugServer = debug.NewServer(r.logger)
 	if err := r.debugServer.Start(socketPath); err != nil {
@@ -208,6 +224,13 @@ func (r *Runtime) registerDebugServer(socketPath string) error {
 		} else {
 			w.Write(r.Dump()) //nolint:errcheck
 		}
+	})
+
+	r.debugServer.Register(http.MethodGet, "/packages/global/dump", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/yaml")
+		w.WriteHeader(http.StatusOK)
+
+		w.Write(r.DumpGlobal()) //nolint:errcheck
 	})
 
 	r.debugServer.Register(http.MethodGet, "/packages/queues/dump", func(w http.ResponseWriter, req *http.Request) {
@@ -497,7 +520,6 @@ func (r *Runtime) buildScheduler(cli kclient.Client) {
 		err := retry.OnError(retry.DefaultRetry, apierrors.IsServiceUnavailable, func() error {
 			return cli.Get(context.Background(), kclient.ObjectKey{Name: name}, module)
 		})
-
 		if err != nil {
 			return nil
 		}

--- a/deckhouse-controller/internal/packages/schedule/event.go
+++ b/deckhouse-controller/internal/packages/schedule/event.go
@@ -31,7 +31,6 @@ type Event struct {
 	Name    string
 	Reason  string
 	Message string
-	Enabled []string
 }
 
 // Ch returns a read-only channel that emits [Event] values as the graph

--- a/deckhouse-controller/internal/packages/schedule/event.go
+++ b/deckhouse-controller/internal/packages/schedule/event.go
@@ -22,9 +22,6 @@ const (
 	EventSchedule EventKind = iota
 	// EventDisable is emitted when a node loses eligibility during a scheduling pass.
 	EventDisable
-	// EventGlobalDone is emitted when the global sentinel node completes,
-	// carrying the list of currently enabled package names.
-	EventGlobalDone
 )
 
 // Event represents a single lifecycle transition in the scheduling graph.

--- a/deckhouse-controller/internal/packages/schedule/scheduler.go
+++ b/deckhouse-controller/internal/packages/schedule/scheduler.go
@@ -26,10 +26,6 @@ import (
 )
 
 const (
-	// packageGlobal is the sentinel node that all other nodes implicitly depend on.
-	// It acts as the root of the dependency graph and must complete before any scheduling begins.
-	packageGlobal = "global"
-
 	// FunctionalOrder is the Order value assigned to functional (non-critical) packages.
 	// It is higher than any critical package order, ensuring functional packages are
 	// scheduled only after all critical packages have been processed.
@@ -58,6 +54,8 @@ type Scheduler struct {
 	kubeVersionGetter      version.Getter      // Gets current Kubernetes version
 	deckhouseVersionGetter version.Getter      // Gets current Deckhouse version
 	bootstrapCondition     condition.Condition // Bootstrap readiness check
+
+	onScheduleHook func(enabled []string)
 
 	pause atomic.Bool // When true, no state changes are processed
 }
@@ -90,6 +88,13 @@ func WithBootstrapCondition(cond condition.Condition) Option {
 func WithDependencyGetter(getter dependency.Getter) Option {
 	return func(s *Scheduler) {
 		s.dependencyGetter = getter
+	}
+}
+
+// WithOnScheduleHook sets the hook to be called after scheduling is computed.
+func WithOnScheduleHook(hook func(enabled []string)) Option {
+	return func(s *Scheduler) {
+		s.onScheduleHook = hook
 	}
 }
 
@@ -294,15 +299,14 @@ func (s *Scheduler) schedule() {
 		return
 	}
 
-	enabled, computed := s.compute()
-	for _, n := range computed {
+	for _, n := range s.compute() {
 		if n.state != nodeStateIdle {
 			continue
 		}
 
 		if s.canSchedule(n) {
 			n.state = nodeStateScheduled
-			s.send(Event{Name: n.name, Kind: EventSchedule, Enabled: enabled})
+			s.send(Event{Name: n.name, Kind: EventSchedule})
 		}
 	}
 }
@@ -314,7 +318,7 @@ func (s *Scheduler) schedule() {
 // [EventDisable]. No global reconverge happens — canSchedule no longer gates
 // on per-dep state, so one node's status change cannot invalidate another
 // node's schedulability beyond the live order-tier check.
-func (s *Scheduler) compute() ([]string, []*node) {
+func (s *Scheduler) compute() []*node {
 	// AddNode is the authoritative cycle gate, so topoSort should never
 	// return an error here. The disabled-mark-active loop below walks `sorted`
 	// and relies on that invariant; a cycle slipping through (gate bug) would
@@ -329,30 +333,28 @@ func (s *Scheduler) compute() ([]string, []*node) {
 			continue
 		}
 
-		// Status flipped — reset this node so the next schedule pass can
-		// either re-schedule it (now enabled) or mark it active via the
-		// disabled-mark-active loop below (now disabled).
-		n.state = nodeStateIdle
-
 		if !n.status.Enabled {
+			// Disabled nodes have nothing to wait for — mark them active so they do
+			// not block higher-order nodes via canSchedule's order-tier gate. Nodes
+			// that later flip back to enabled are reset to idle by the loop above and
+			// go through normal scheduling from there.
+			n.state = nodeStateActive
 			s.send(Event{Name: n.name, Kind: EventDisable, Reason: n.status.Reason, Message: n.status.Message})
 			continue
 		}
 
+		// Status flipped — reset this node so the next schedule pass can
+		// either re-schedule it (now enabled) or mark it active via the
+		// disabled-mark-active loop below (now disabled).
+		n.state = nodeStateIdle
 		enabled = append(enabled, n.name)
 	}
 
-	// Disabled nodes have nothing to wait for — mark them active so they do
-	// not block higher-order nodes via canSchedule's order-tier gate. Nodes
-	// that later flip back to enabled are reset to idle by the loop above and
-	// go through normal scheduling from there.
-	for _, n := range sorted {
-		if n.state == nodeStateIdle && !n.status.Enabled {
-			n.state = nodeStateActive
-		}
+	if s.onScheduleHook != nil {
+		s.onScheduleHook(enabled)
 	}
 
-	return enabled, sorted
+	return sorted
 }
 
 // canSchedule returns true if a node is eligible to transition from idle to

--- a/deckhouse-controller/internal/packages/schedule/scheduler.go
+++ b/deckhouse-controller/internal/packages/schedule/scheduler.go
@@ -325,7 +325,6 @@ func (s *Scheduler) compute() []*node {
 	// leave its members frozen at nodeStateIdle, surfaced quickly by stalled
 	// higher-tier nodes via canSchedule's order-tier gate.
 	sorted, _ := topoSort(s.nodes)
-	var enabled []string
 	for _, n := range sorted {
 		current := n.status.Enabled
 		n.status = checker.Check(n.checkers...)
@@ -340,8 +339,6 @@ func (s *Scheduler) compute() []*node {
 
 		if !n.status.Enabled {
 			s.send(Event{Name: n.name, Kind: EventDisable, Reason: n.status.Reason, Message: n.status.Message})
-		} else {
-			enabled = append(enabled, n.name)
 		}
 	}
 
@@ -358,6 +355,12 @@ func (s *Scheduler) compute() []*node {
 	}
 
 	if s.onScheduleHook != nil {
+		var enabled []string
+		for _, n := range sorted {
+			if n.status.Enabled {
+				enabled = append(enabled, n.name)
+			}
+		}
 		s.onScheduleHook(enabled)
 	}
 

--- a/deckhouse-controller/internal/packages/schedule/scheduler.go
+++ b/deckhouse-controller/internal/packages/schedule/scheduler.go
@@ -333,21 +333,28 @@ func (s *Scheduler) compute() []*node {
 			continue
 		}
 
-		if !n.status.Enabled {
-			// Disabled nodes have nothing to wait for — mark them active so they do
-			// not block higher-order nodes via canSchedule's order-tier gate. Nodes
-			// that later flip back to enabled are reset to idle by the loop above and
-			// go through normal scheduling from there.
-			n.state = nodeStateActive
-			s.send(Event{Name: n.name, Kind: EventDisable, Reason: n.status.Reason, Message: n.status.Message})
-			continue
-		}
-
 		// Status flipped — reset this node so the next schedule pass can
 		// either re-schedule it (now enabled) or mark it active via the
 		// disabled-mark-active loop below (now disabled).
 		n.state = nodeStateIdle
-		enabled = append(enabled, n.name)
+
+		if !n.status.Enabled {
+			s.send(Event{Name: n.name, Kind: EventDisable, Reason: n.status.Reason, Message: n.status.Message})
+		} else {
+			enabled = append(enabled, n.name)
+		}
+	}
+
+	// Disabled nodes have nothing to wait for — mark them active so they do
+	// not block higher-order nodes via canSchedule's order-tier gate. This
+	// sweep is unconditional (not gated on a status flip), so nodes that are
+	// born disabled — never enabled to begin with — are parked active too.
+	// Nodes that later flip back to enabled are reset to idle by the loop
+	// above and go through normal scheduling from there.
+	for _, n := range sorted {
+		if n.state == nodeStateIdle && !n.status.Enabled {
+			n.state = nodeStateActive
+		}
 	}
 
 	if s.onScheduleHook != nil {

--- a/deckhouse-controller/internal/packages/schedule/scheduler.go
+++ b/deckhouse-controller/internal/packages/schedule/scheduler.go
@@ -260,19 +260,6 @@ func (s *Scheduler) Complete(completed string) {
 		n.state = nodeStateActive
 	}
 
-	if completed == packageGlobal {
-		var enabled []string
-		for _, n := range s.compute() {
-			if n.name == packageGlobal || !n.status.Enabled {
-				continue
-			}
-
-			enabled = append(enabled, n.name)
-		}
-
-		s.send(Event{Kind: EventGlobalDone, Enabled: enabled})
-	}
-
 	s.schedule()
 }
 
@@ -307,14 +294,15 @@ func (s *Scheduler) schedule() {
 		return
 	}
 
-	for _, n := range s.compute() {
+	enabled, computed := s.compute()
+	for _, n := range computed {
 		if n.state != nodeStateIdle {
 			continue
 		}
 
 		if s.canSchedule(n) {
 			n.state = nodeStateScheduled
-			s.send(Event{Name: n.name, Kind: EventSchedule})
+			s.send(Event{Name: n.name, Kind: EventSchedule, Enabled: enabled})
 		}
 	}
 }
@@ -326,13 +314,14 @@ func (s *Scheduler) schedule() {
 // [EventDisable]. No global reconverge happens — canSchedule no longer gates
 // on per-dep state, so one node's status change cannot invalidate another
 // node's schedulability beyond the live order-tier check.
-func (s *Scheduler) compute() []*node {
+func (s *Scheduler) compute() ([]string, []*node) {
 	// AddNode is the authoritative cycle gate, so topoSort should never
 	// return an error here. The disabled-mark-active loop below walks `sorted`
 	// and relies on that invariant; a cycle slipping through (gate bug) would
 	// leave its members frozen at nodeStateIdle, surfaced quickly by stalled
 	// higher-tier nodes via canSchedule's order-tier gate.
 	sorted, _ := topoSort(s.nodes)
+	var enabled []string
 	for _, n := range sorted {
 		current := n.status.Enabled
 		n.status = checker.Check(n.checkers...)
@@ -347,7 +336,10 @@ func (s *Scheduler) compute() []*node {
 
 		if !n.status.Enabled {
 			s.send(Event{Name: n.name, Kind: EventDisable, Reason: n.status.Reason, Message: n.status.Message})
+			continue
 		}
+
+		enabled = append(enabled, n.name)
 	}
 
 	// Disabled nodes have nothing to wait for — mark them active so they do
@@ -360,7 +352,7 @@ func (s *Scheduler) compute() []*node {
 		}
 	}
 
-	return sorted
+	return enabled, sorted
 }
 
 // canSchedule returns true if a node is eligible to transition from idle to

--- a/deckhouse-controller/internal/packages/status/service.go
+++ b/deckhouse-controller/internal/packages/status/service.go
@@ -382,10 +382,10 @@ func (s *Status) IsConditionTrue(condType ConditionType) bool {
 	return false
 }
 
-// ClearStatus creates a new status or resets conditions. If a health event
+// NewStatus creates a new status or resets conditions. If a health event
 // was buffered by UpdateHealth before this name was registered, it is
 // applied here and the buffer entry is dropped.
-func (s *Service) ClearStatus(name string) {
+func (s *Service) NewStatus(name string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 

--- a/deckhouse-controller/pkg/debug/packages.go
+++ b/deckhouse-controller/pkg/debug/packages.go
@@ -62,6 +62,34 @@ func DefinePackagesCommands(rootCmd *cobra.Command) {
 	}
 
 	{
+		globalCmd := &cobra.Command{Use: "global", Short: "Global module operations."}
+		packagesCmd.AddCommand(globalCmd)
+
+		dumpCmd := &cobra.Command{
+			Use:   "dump",
+			Short: "Dump the global module state from memory.",
+			RunE: func(_ *cobra.Command, _ []string) error {
+				client, err := debug.NewClient(packagesDebugSocket)
+				if err != nil {
+					return err
+				}
+				defer client.Close()
+
+				ctx := context.Background()
+				out, err := client.Get(ctx, "packages/global/dump")
+				if err != nil {
+					return err
+				}
+				fmt.Println(string(out))
+
+				return nil
+			},
+		}
+		definePackagesDebugSocketFlag(dumpCmd)
+		globalCmd.AddCommand(dumpCmd)
+	}
+
+	{
 		schedulerCmd := &cobra.Command{Use: "scheduler", Short: "Scheduler operations."}
 		packagesCmd.AddCommand(schedulerCmd)
 


### PR DESCRIPTION
## Description

Introduces the **global package** into the package runtime and wires it through scheduling, status, and debug introspection.

### Global module

- The `Runtime` now owns a `global *global.Module`, loaded in `Runtime.New` via `loader.LoadGlobalConf` + `global.NewModuleByConfig`, and registered with the status service (`NewStatus`).
- The module tracks a `running` flag (`atomic.Bool`) that flips to `true` once its `OnStartup`/`BeforeAll` bindings have completed, used as an idempotency guard and surfaced in the dump.
- `SetEnabledModules` injects the set of currently-enabled packages into global values at `/global/enabledModules` as a values patch (sorted, so it does not churn Helm releases on restart) — making the enabled-package set available to global hooks and recalculated on every global values change.

### Scheduler

- Added the `WithOnScheduleHook` option. After every scheduling pass the scheduler reports the **full set of currently-enabled packages** to the hook; the runtime wires this to log `enabled packages` and call `global.SetEnabledModules`.
- Removed the now-unused `EventGlobalDone` event kind and the `Enabled` field on `Event` — the global-sentinel completion machinery is replaced by the schedule hook.
- `compute()` keeps the unconditional "disabled → active" sweep as a separate pass after flip detection, so nodes that are *born disabled* (e.g. a missing mandatory dependency, or a dependency rejected for a cycle) are still parked `active` and do not stall higher `Order` tiers through `canSchedule`'s order-tier gate.

### Debug introspection

- New `Runtime.DumpGlobal()` serializes the global module's `Info` (name, running state, path, values, hooks) to YAML.
- New debug endpoint `GET /packages/global/dump` and CLI command `dc packages global dump`.

### Status service

- Renamed `Service.ClearStatus` → `Service.NewStatus` to reflect intent (creates a fresh status entry / resets conditions, applying any buffered health event). Call sites in `apps.go`, `modules.go`, and the new global registration updated.

## Why do we need it, and what problem does it solve?

Packages (apps and modules) need access to the global module's values and the live set of enabled packages. This PR loads the global module inside the package runtime, keeps `global.enabledModules` in sync with scheduler decisions, and exposes the global module's runtime state for debugging alongside the existing per-package dump endpoints.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: feature
summary: Provide global package.
impact_level: low
```
