### PR TITLE
[deckhouse] cap package task retry backoff at 2h

### DIFF
--- a/deckhouse-controller/internal/queue/queue.go
+++ b/deckhouse-controller/internal/queue/queue.go
@@ -141,7 +141,7 @@ func (q *queue) Enqueue(ctx context.Context, task Task, opts ...EnqueueOption) {
 		task:   task,
 		backoff: backoff.NewExponentialBackOff(
 			backoff.WithMaxElapsedTime(0),
-			backoff.WithMaxInterval(time.Minute),
+			backoff.WithMaxInterval(2*time.Hour),
 			backoff.WithInitialInterval(15*time.Second)),
 		nextRetry:  time.Now(),
 		enqueuedAt: time.Now(),


### PR DESCRIPTION
## Description

Raise the package task queue's retry backoff cap from 1 minute to 2 hours
(`internal/queue`, the per-package task queue used for configure/enable/run/disable).

A failing task still ramps exponentially (15s → 30s → 1m → 2m → …), but a
chronically failing one now settles to one retry every 2h instead of once a minute.

No restarts of critical components.

## Why do we need it, and what problem does it solve?

A package whose install never becomes Ready (bad image, unschedulable, …) retries
forever (`MaxElapsedTime = 0`). With the 1-minute cap it re-runs the nelm install
~once a minute indefinitely, generating constant load — install attempts, resource
tracking and status churn. Capping the backoff at 2h cuts that load by ~100x for
chronic failures, while the early exponential retries keep transient failures
recovering quickly.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Cap package task retry backoff at 2h so chronically failing installs stop hammering.
impact_level: low
```
