### PR TITLE
[multitenancy-manager] Stop grant/project webhooks from deadlocking the Deckhouse queue

### DIFF
--- a/modules/160-multitenancy-manager/hooks/configure_grant_defaulting_webhook.go
+++ b/modules/160-multitenancy-manager/hooks/configure_grant_defaulting_webhook.go
@@ -90,6 +90,7 @@ func configureDefaultingWebhook(ctx context.Context, input *go_hook.HookInput, d
 						CABundle: []byte(caBundle),
 					},
 					NamespaceSelector:       projectNamespaceSelector,
+					MatchConditions:         systemWriterMatchConditions,
 					SideEffects:             ptr.To(admissionregistrationv1.SideEffectClassNone),
 					AdmissionReviewVersions: []string{"v1"},
 					FailurePolicy:           ptr.To(admissionregistrationv1.Fail),
@@ -103,8 +104,10 @@ func configureDefaultingWebhook(ctx context.Context, input *go_hook.HookInput, d
 	}
 
 	whConfig.Webhooks[0].Rules = grantableWebhookRules(input)
-	// Reconcile selector/timeout on existing configurations too (e.g. upgrades).
+	// Reconcile selector/match-conditions/timeout on existing configurations too (e.g. upgrades), so a
+	// cluster that already has the webhook without the system-writer exclusion is healed in place.
 	whConfig.Webhooks[0].NamespaceSelector = projectNamespaceSelector
+	whConfig.Webhooks[0].MatchConditions = systemWriterMatchConditions
 	whConfig.Webhooks[0].TimeoutSeconds = ptr.To(int32(10))
 	if whConfigExists {
 		_, err = admissionClient.Update(ctx, whConfig, v1.UpdateOptions{})

--- a/modules/160-multitenancy-manager/hooks/configure_grant_validation_webhook.go
+++ b/modules/160-multitenancy-manager/hooks/configure_grant_validation_webhook.go
@@ -66,6 +66,10 @@ var systemWriterMatchConditions = []admissionregistrationv1.MatchCondition{
 		Expression: `request.userInfo.username != "system:serviceaccount:d8-system:deckhouse"`,
 	},
 	{
+		Name:       "exclude-multitenancy-manager",
+		Expression: `request.userInfo.username != "system:serviceaccount:d8-multitenancy-manager:multitenancy-manager"`,
+	},
+	{
 		Name:       "exclude-system-serviceaccounts",
 		Expression: `!request.userInfo.groups.exists(g, g == "system:serviceaccounts:d8-system" || g == "system:serviceaccounts:kube-system")`,
 	},

--- a/modules/160-multitenancy-manager/hooks/configure_grant_validation_webhook.go
+++ b/modules/160-multitenancy-manager/hooks/configure_grant_validation_webhook.go
@@ -44,6 +44,37 @@ var projectNamespaceSelector = &v1.LabelSelector{
 	MatchLabels: map[string]string{"heritage": "multitenancy-manager"},
 }
 
+// systemWriterMatchConditions make the apiserver SKIP this webhook entirely for system / module
+// writers — evaluated locally (CEL), BEFORE any network call to the webhook backend. This is the
+// anti-deadlock guarantee: the grant allow-list exists to police PROJECT USERS, but every module's
+// resources land in project namespaces via that module's Helm release applied by the
+// deckhouse-controller (system:serviceaccount:d8-system:deckhouse). With failurePolicy: Fail, if the
+// webhook is denied OR merely unreachable/slow, that server-side apply fails and addon-operator
+// retries it forever, locking the module's queue (observed: user-authz emitting
+// "RoleBinding/...:d8:user-authz:*:user" into every project namespace -> "webhook retry timed out
+// after 2m0s"). Excluding system writers at the apiserver level removes the lock unconditionally —
+// it holds even when the webhook backend is completely down, because the apiserver never calls it for
+// these requests. Project users are still policed (and get a fast, terminal denial). The in-handler
+// isSystemRequest bypass mirrors this as defense-in-depth.
+var systemWriterMatchConditions = []admissionregistrationv1.MatchCondition{
+	{
+		Name:       "exclude-apiserver",
+		Expression: `request.userInfo.username != "system:apiserver"`,
+	},
+	{
+		Name:       "exclude-deckhouse-controller",
+		Expression: `request.userInfo.username != "system:serviceaccount:d8-system:deckhouse"`,
+	},
+	{
+		Name:       "exclude-system-serviceaccounts",
+		Expression: `!request.userInfo.groups.exists(g, g == "system:serviceaccounts:d8-system" || g == "system:serviceaccounts:kube-system")`,
+	},
+	{
+		Name:       "exclude-cluster-admins-and-nodes",
+		Expression: `!request.userInfo.groups.exists(g, g == "system:masters" || g == "system:nodes")`,
+	},
+}
+
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	Queue: "/modules/160-multitenancy-manager",
 	Kubernetes: []go_hook.KubernetesConfig{
@@ -98,6 +129,7 @@ func configureGrantValidationWebhook(ctx context.Context, input *go_hook.HookInp
 						CABundle: []byte(caBundle),
 					},
 					NamespaceSelector:       projectNamespaceSelector,
+					MatchConditions:         systemWriterMatchConditions,
 					SideEffects:             ptr.To(admissionregistrationv1.SideEffectClassNone),
 					AdmissionReviewVersions: []string{"v1"},
 					FailurePolicy:           ptr.To(admissionregistrationv1.Fail),
@@ -111,8 +143,10 @@ func configureGrantValidationWebhook(ctx context.Context, input *go_hook.HookInp
 	}
 
 	whConfig.Webhooks[0].Rules = grantableWebhookRules(input)
-	// Reconcile selector/timeout on existing configurations too (e.g. upgrades).
+	// Reconcile selector/match-conditions/timeout on existing configurations too (e.g. upgrades), so a
+	// cluster that already has the webhook without the system-writer exclusion is healed in place.
 	whConfig.Webhooks[0].NamespaceSelector = projectNamespaceSelector
+	whConfig.Webhooks[0].MatchConditions = systemWriterMatchConditions
 	whConfig.Webhooks[0].TimeoutSeconds = ptr.To(int32(10))
 	if whConfigExists {
 		_, err = admissionClient.Update(ctx, whConfig, v1.UpdateOptions{})

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/cmd/main.go
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/cmd/main.go
@@ -187,9 +187,8 @@ func setupRuntimeManager(logger logr.Logger) (ctrl.Manager, error) {
 		return nil, err
 	}
 	// Honest readiness: report Ready only once the webhook server is actually serving, instead of an
-	// unconditional Ping. Otherwise the pod is Ready while its webhooks cannot answer, and the apiserver
-	// keeps routing admission calls to it — turning a not-yet-serving replica into webhook timeouts (and,
-	// with failurePolicy: Fail, a queue lock).
+	// unconditional Ping. Otherwise the pod is Ready while its webhooks cannot answer yet, and the
+	// apiserver routes admission to a not-yet-serving replica (webhook timeouts on startup/rollout).
 	if err = runtimeManager.AddReadyzCheck("readyz", runtimeManager.GetWebhookServer().StartedChecker()); err != nil {
 		logger.Error(err, "unable to set up ready check")
 		return nil, err

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/cmd/main.go
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/cmd/main.go
@@ -131,8 +131,11 @@ func main() {
 	if err = (&grantcontrollers.DefinitionReconciler{Client: runtimeManager.GetClient()}).SetupWithManager(runtimeManager); err != nil {
 		panic(err)
 	}
-	grantwebhooks.NewIsGrantedValidator(logger, runtimeManager.GetClient(), runtimeManager.GetRESTMapper(), jsonpathFactory).InstallInto(runtimeManager.GetWebhookServer())
-	grantwebhooks.NewDefaultsMutator(logger, runtimeManager.GetClient(), runtimeManager.GetRESTMapper(), jsonpathFactory).InstallInto(runtimeManager.GetWebhookServer())
+	// Use the direct (uncached) API reader for the admission webhooks: a cache-backed read lazily
+	// starts an informer and blocks on its sync inside the request, which can exceed the webhook
+	// deadline and pile up into a queue lock. A direct reader keeps reads bounded.
+	grantwebhooks.NewIsGrantedValidator(logger, runtimeManager.GetAPIReader(), runtimeManager.GetRESTMapper(), jsonpathFactory).InstallInto(runtimeManager.GetWebhookServer())
+	grantwebhooks.NewDefaultsMutator(logger, runtimeManager.GetAPIReader(), runtimeManager.GetRESTMapper(), jsonpathFactory).InstallInto(runtimeManager.GetWebhookServer())
 	grantwebhooks.NewProtectValidator(logger, serviceAccount).InstallInto(runtimeManager.GetWebhookServer())
 
 	// start runtime manager
@@ -183,7 +186,11 @@ func setupRuntimeManager(logger logr.Logger) (ctrl.Manager, error) {
 		logger.Error(err, "unable to set up health check")
 		return nil, err
 	}
-	if err = runtimeManager.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+	// Honest readiness: report Ready only once the webhook server is actually serving, instead of an
+	// unconditional Ping. Otherwise the pod is Ready while its webhooks cannot answer, and the apiserver
+	// keeps routing admission calls to it — turning a not-yet-serving replica into webhook timeouts (and,
+	// with failurePolicy: Fail, a queue lock).
+	if err = runtimeManager.AddReadyzCheck("readyz", runtimeManager.GetWebhookServer().StartedChecker()); err != nil {
 		logger.Error(err, "unable to set up ready check")
 		return nil, err
 	}

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/resolve/resolve.go
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/resolve/resolve.go
@@ -51,7 +51,7 @@ func ProjectName(ns *corev1.Namespace) string {
 
 // ApplicableGrants returns every ClusterResourceGrantPolicy whose projectSelector matches the labels of the
 // given namespace. A nil selector matches nothing; an invalid selector is skipped.
-func ApplicableGrants(ctx context.Context, cl client.Client, namespace string) ([]*v1alpha1.ClusterResourceGrantPolicy, error) {
+func ApplicableGrants(ctx context.Context, cl client.Reader, namespace string) ([]*v1alpha1.ClusterResourceGrantPolicy, error) {
 	ns := &corev1.Namespace{}
 	if err := cl.Get(ctx, client.ObjectKey{Name: namespace}, ns); err != nil {
 		if k8serrors.IsNotFound(err) {
@@ -63,7 +63,7 @@ func ApplicableGrants(ctx context.Context, cl client.Client, namespace string) (
 }
 
 // GrantsForLabels returns every ClusterResourceGrantPolicy whose projectSelector matches the given labels.
-func GrantsForLabels(ctx context.Context, cl client.Client, nsLabels map[string]string) ([]*v1alpha1.ClusterResourceGrantPolicy, error) {
+func GrantsForLabels(ctx context.Context, cl client.Reader, nsLabels map[string]string) ([]*v1alpha1.ClusterResourceGrantPolicy, error) {
 	grantList := &v1alpha1.ClusterResourceGrantPolicyList{}
 	if err := cl.List(ctx, grantList); err != nil {
 		return nil, fmt.Errorf("list ClusterResourceGrantPolicys: %w", err)
@@ -111,7 +111,7 @@ type MatchedReference struct {
 // (group, version, resource): every GrantableClusterResourceReference whose rule matches and whose
 // target definition exists and is Managed. Unbound references (dangling grantableClusterResourceName)
 // and references to External definitions are skipped — they enforce nothing here.
-func ReferencesForRequest(ctx context.Context, cl client.Client, group, version, resource string) ([]MatchedReference, error) {
+func ReferencesForRequest(ctx context.Context, cl client.Reader, group, version, resource string) ([]MatchedReference, error) {
 	refList := &v1alpha1.GrantableClusterResourceReferenceList{}
 	if err := cl.List(ctx, refList); err != nil {
 		return nil, fmt.Errorf("list GrantableClusterResourceReferences: %w", err)
@@ -211,7 +211,7 @@ func (r *Resolved) Available() []v1alpha1.AvailableObject {
 // object-backed resources it lists the live granted objects to expand allowed/denied/excluded selectors.
 func Resolve(
 	ctx context.Context,
-	cl client.Client,
+	cl client.Reader,
 	mapper meta.RESTMapper,
 	reg *v1alpha1.GrantableClusterResourceDefinition,
 	entries []v1alpha1.GrantResource,
@@ -361,7 +361,7 @@ func grantedGVK(mapper meta.RESTMapper, reg *v1alpha1.GrantableClusterResourceDe
 }
 
 // defaultFromAnnotation finds the single granted object annotated as the cluster-wide default.
-func defaultFromAnnotation(ctx context.Context, cl client.Client, mapper meta.RESTMapper, reg *v1alpha1.GrantableClusterResourceDefinition) (string, error) {
+func defaultFromAnnotation(ctx context.Context, cl client.Reader, mapper meta.RESTMapper, reg *v1alpha1.GrantableClusterResourceDefinition) (string, error) {
 	gvk, err := grantedGVK(mapper, reg)
 	if err != nil {
 		return "", err
@@ -385,7 +385,7 @@ func defaultFromAnnotation(ctx context.Context, cl client.Client, mapper meta.RE
 
 // ProjectNamespaces returns the names of namespaces belonging to the project, including the control
 // namespace (the project name). The project namespaces are those labelled projects.deckhouse.io/project.
-func ProjectNamespaces(ctx context.Context, cl client.Client, project string) ([]string, error) {
+func ProjectNamespaces(ctx context.Context, cl client.Reader, project string) ([]string, error) {
 	nsList := &corev1.NamespaceList{}
 	if err := cl.List(ctx, nsList, client.MatchingLabels{naming.ProjectLabel: project}); err != nil {
 		return nil, fmt.Errorf("list project namespaces: %w", err)

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/webhooks/common.go
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/webhooks/common.go
@@ -20,11 +20,19 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"time"
 
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
+
+// webhookDecisionTimeout hard-bounds how long a single admission decision may take. The handlers read
+// from the API on the hot path; without an internal bound a slow read would hold the request until the
+// webhook's 10s deadline and, with failurePolicy: Fail, let addon-operator pile up retries into a
+// multi-minute queue lock. A short, terminal bound guarantees the webhook always answers quickly — it
+// can never become the thing that locks a queue.
+const webhookDecisionTimeout = 3 * time.Second
 
 // decodeReview reads and decodes an AdmissionReview from a JSON request body.
 func decodeReview(r *http.Request, review *admissionv1.AdmissionReview) error {

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/webhooks/defaults.go
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/webhooks/defaults.go
@@ -45,13 +45,16 @@ var _ http.Handler = &DefaultsMutator{}
 // granted name into a referenced field, per the reference path's defaulting mode (FillEmpty/Coerce).
 type DefaultsMutator struct {
 	log     logr.Logger
-	cl      client.Client
+	cl      client.Reader
 	mapper  meta.RESTMapper
 	factory jsonpath.Factory
 }
 
-// NewDefaultsMutator builds the /defaults mutating webhook.
-func NewDefaultsMutator(log logr.Logger, cl client.Client, mapper meta.RESTMapper, factory jsonpath.Factory) *DefaultsMutator {
+// NewDefaultsMutator builds the /defaults mutating webhook. cl is a direct (uncached) API reader for the
+// same reason as the /is-granted validator: a cache-backed read lazily starts an informer and blocks on
+// its sync inside the admission request, which can exceed the webhook deadline and pile up into a queue
+// lock. A direct reader keeps reads bounded so the webhook cannot hang.
+func NewDefaultsMutator(log logr.Logger, cl client.Reader, mapper meta.RESTMapper, factory jsonpath.Factory) *DefaultsMutator {
 	return &DefaultsMutator{log: log.WithValues("component", "defaults"), cl: cl, mapper: mapper, factory: factory}
 }
 
@@ -69,7 +72,11 @@ func (m *DefaultsMutator) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	req := review.Request
-	resp, err := m.decide(r.Context(), req)
+	// Hard-bound the decision so the webhook always answers quickly and can never become a queue lock.
+	ctx, cancel := context.WithTimeout(r.Context(), webhookDecisionTimeout)
+	defer cancel()
+
+	resp, err := m.decide(ctx, req)
 	if err != nil {
 		m.log.Error(err, "defaults decision failed")
 		http.Error(w, "defaults decision failed", http.StatusInternalServerError)
@@ -80,6 +87,14 @@ func (m *DefaultsMutator) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (m *DefaultsMutator) decide(ctx context.Context, req *admissionv1.AdmissionRequest) (*admissionv1.AdmissionResponse, error) {
+	// Never mutate (nor stall) a system / cluster-component / module writer: a module's resources are
+	// applied into project namespaces by the deckhouse-controller's Helm release, and with
+	// failurePolicy: Fail a slow/erroring defaulting call fails that apply and deadlocks the module's
+	// queue. The apiserver-level matchConditions already skip this webhook for those writers; this is
+	// the handler-level backstop. Mirrors is_granted.go / protect.go.
+	if isSystemRequest(req) {
+		return allowedResponse(req.UID), nil
+	}
 	if namespaces.IsSystem(req.Namespace) || req.SubResource != "" || req.Namespace == "" {
 		return allowedResponse(req.UID), nil
 	}

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/webhooks/is_granted.go
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/webhooks/is_granted.go
@@ -42,13 +42,18 @@ var _ http.Handler = &IsGrantedValidator{}
 // object by availability (which cluster-scoped resources the project may reference).
 type IsGrantedValidator struct {
 	log     logr.Logger
-	cl      client.Client
+	cl      client.Reader
 	mapper  meta.RESTMapper
 	factory jsonpath.Factory
 }
 
-// NewIsGrantedValidator builds the /is-granted validating webhook.
-func NewIsGrantedValidator(log logr.Logger, cl client.Client, mapper meta.RESTMapper, factory jsonpath.Factory) *IsGrantedValidator {
+// NewIsGrantedValidator builds the /is-granted validating webhook. cl is a direct (uncached) API reader
+// on purpose: the cache-backed client lazily starts an informer on first read of a type and blocks on
+// its sync inside the admission request; on a large cluster that first sync can exceed the webhook
+// deadline, and the per-request cancellation prevents it from ever completing — every call then times
+// out and (with failurePolicy: Fail) piles up retries into a queue lock. A direct reader never depends
+// on informer sync, so reads are bounded and the webhook cannot hang.
+func NewIsGrantedValidator(log logr.Logger, cl client.Reader, mapper meta.RESTMapper, factory jsonpath.Factory) *IsGrantedValidator {
 	return &IsGrantedValidator{log: log.WithValues("component", "is-granted"), cl: cl, mapper: mapper, factory: factory}
 }
 
@@ -68,7 +73,11 @@ func (v *IsGrantedValidator) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	req := review.Request
 	log := v.log.WithValues("namespace", req.Namespace, "name", req.Name, "resource", req.Resource.String())
 
-	resp, err := v.decide(r.Context(), req, log)
+	// Hard-bound the decision so the webhook always answers quickly and can never become a queue lock.
+	ctx, cancel := context.WithTimeout(r.Context(), webhookDecisionTimeout)
+	defer cancel()
+
+	resp, err := v.decide(ctx, req, log)
 	if err != nil {
 		log.Error(err, "is-granted decision failed")
 		http.Error(w, "is-granted decision failed", http.StatusInternalServerError)

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/webhooks/is_granted.go
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/webhooks/is_granted.go
@@ -81,6 +81,15 @@ func (v *IsGrantedValidator) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // decide returns the admission response. Availability is enforced for every matched reference; on
 // UPDATE values already present in the old object are grandfathered so existing objects are not broken.
 func (v *IsGrantedValidator) decide(ctx context.Context, req *admissionv1.AdmissionRequest, log logr.Logger) (*admissionv1.AdmissionResponse, error) {
+	// Never police a system / cluster-component / module writer. Every module's resources land in
+	// project namespaces via that module's Helm release applied by the deckhouse-controller (group
+	// system:serviceaccounts:d8-system); denying or even stalling such a request fails the install,
+	// which addon-operator retries forever, deadlocking the module's queue. The grant allow-list is for
+	// PROJECT USERS only. This mirrors (and backstops) the apiserver-level matchConditions on the
+	// webhook configuration in case the request still reaches the handler. See protect.go.
+	if isSystemRequest(req) {
+		return allowedResponse(req.UID), nil
+	}
 	if namespaces.IsSystem(req.Namespace) || req.SubResource != "" || req.Namespace == "" {
 		return allowedResponse(req.UID), nil
 	}

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/webhooks/protect.go
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/webhooks/protect.go
@@ -56,12 +56,18 @@ func (p *ProtectValidator) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	writeReview(w, review)
 }
 
-// systemBypassGroups mirror the exemptions Deckhouse uses to protect its own
-// heritage objects (see modules/002-deckhouse validation): cluster components and
-// system controllers must never be blocked by the catalog protection. Without this,
-// the kube-system namespace-controller and garbage-collector cannot delete the
-// controller-owned AvailableClusterResource objects during namespace teardown, which
-// deadlocks namespace deletion.
+// systemBypassUsernames / systemBypassGroups mirror the exemptions Deckhouse uses to protect its own
+// heritage objects (see modules/002-deckhouse validation): cluster components and system/module
+// controllers must never be blocked by these webhooks. They MUST stay in sync with the apiserver-level
+// matchConditions on the webhook configurations (see hooks/configure_grant_*_webhook.go and
+// templates/admission/validation.yaml) so the handler-level backstop and the CEL pre-filter agree —
+// the CEL conditions match by username AND by group, so this check does too.
+var systemBypassUsernames = []string{
+	"system:apiserver",
+	"system:serviceaccount:d8-system:deckhouse",
+	"system:serviceaccount:d8-multitenancy-manager:multitenancy-manager",
+}
+
 var systemBypassGroups = []string{
 	"system:nodes",
 	"system:masters",
@@ -69,9 +75,15 @@ var systemBypassGroups = []string{
 	"system:serviceaccounts:d8-system",
 }
 
-// isSystemRequest reports whether the request comes from a cluster component or
-// system controller that must bypass catalog protection.
+// isSystemRequest reports whether the request comes from a cluster component or system/module
+// controller that must bypass these webhooks. Checks both the username and the groups to match the
+// apiserver-level matchConditions exactly.
 func isSystemRequest(req *admissionv1.AdmissionRequest) bool {
+	for _, u := range systemBypassUsernames {
+		if req.UserInfo.Username == u {
+			return true
+		}
+	}
 	for _, g := range req.UserInfo.Groups {
 		for _, b := range systemBypassGroups {
 			if g == b {

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/webhooks/webhooks_test.go
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/webhooks/webhooks_test.go
@@ -223,6 +223,25 @@ func TestIsGranted_SystemNamespaceBypass(t *testing.T) {
 	}
 }
 
+func TestIsGranted_SystemRequestBypass(t *testing.T) {
+	// A module's Helm release applies its resources into project namespaces as the deckhouse-controller
+	// (group system:serviceaccounts:d8-system). Denying — or, with failurePolicy: Fail, even stalling —
+	// such a request fails the install and addon-operator retries it forever, deadlocking the module's
+	// queue. A system request must therefore ALWAYS pass, even for a value a project user would be
+	// denied. (At the apiserver level matchConditions skip the webhook for these writers entirely; this
+	// asserts the handler-level backstop.)
+	v := isGranted(t, projectNS("proj", map[string]string{"env": "prod"}), lbDef(v1alpha1.AvailabilityNone), lbRef(v1alpha1.DefaultingNone), lbGrant())
+	r := review(admissionv1.Create, svcGVR, svcGVK, "proj", "s", lbService("forbidden", "LoadBalancer"), nil)
+	r.Request.UserInfo.Groups = []string{"system:serviceaccounts:d8-system"}
+	if resp := serve(t, v, "/is-granted", r); !resp.Allowed {
+		t.Fatal("a system (d8-system) writer must bypass the grant allow-list — it must never lock a module's Helm release")
+	}
+	// A normal project user with the same forbidden value is still denied (fast, terminal — no retry).
+	if resp := serve(t, v, "/is-granted", review(admissionv1.Create, svcGVR, svcGVK, "proj", "s", lbService("forbidden", "LoadBalancer"), nil)); resp.Allowed {
+		t.Fatal("a normal user must still be denied an ungranted value")
+	}
+}
+
 func TestIsGranted_UnboundReferenceIgnored(t *testing.T) {
 	// A reference whose definition does not exist enforces nothing.
 	v := isGranted(t, projectNS("proj", map[string]string{"env": "prod"}), lbRef(v1alpha1.DefaultingNone), lbGrant())

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/webhooks/webhooks_test.go
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/webhooks/webhooks_test.go
@@ -344,6 +344,33 @@ func TestDefaults_Coerce(t *testing.T) {
 	}
 }
 
+func TestDefaults_SystemRequestBypass(t *testing.T) {
+	// Same anti-deadlock guarantee as the validator: /defaults must never act on a system/module
+	// writer's request (the deckhouse-controller applies every module's Helm release), so a slow or
+	// failing handler can't block them. A system writer is passed through untouched (no patch); a
+	// normal user with the same out-of-list value is coerced. Covers both the group- and the
+	// username-based bypass (e.g. the multitenancy-manager controller SA).
+	m := defaults(t, projectNS("proj", map[string]string{"env": "prod"}), lbDef(v1alpha1.AvailabilityNone), lbRef(v1alpha1.DefaultingCoerce), lbGrant())
+	bad := raw(t, map[string]any{"apiVersion": "v1", "kind": "Service", "metadata": map[string]any{"name": "s", "namespace": "proj"},
+		"spec": map[string]any{"type": "LoadBalancer", "loadBalancerClass": "forbidden"}})
+
+	rSys := review(admissionv1.Create, svcGVR, svcGVK, "proj", "s", bad, nil)
+	rSys.Request.UserInfo.Groups = []string{"system:serviceaccounts:d8-system"}
+	if resp := serve(t, m, "/defaults", rSys); len(resp.Patch) != 0 {
+		t.Fatalf("a system (d8-system) writer must not be mutated by /defaults, got patch %s", resp.Patch)
+	}
+
+	rCtrl := review(admissionv1.Create, svcGVR, svcGVK, "proj", "s", bad, nil)
+	rCtrl.Request.UserInfo.Username = "system:serviceaccount:d8-multitenancy-manager:multitenancy-manager"
+	if resp := serve(t, m, "/defaults", rCtrl); len(resp.Patch) != 0 {
+		t.Fatalf("the multitenancy-manager controller SA must not be mutated by /defaults, got patch %s", resp.Patch)
+	}
+
+	if resp := serve(t, m, "/defaults", review(admissionv1.Create, svcGVR, svcGVK, "proj", "s", bad, nil)); len(resp.Patch) == 0 {
+		t.Fatal("a normal user's out-of-list value must still be coerced")
+	}
+}
+
 func TestDefaults_FillEmptyDoesNotCoerce(t *testing.T) {
 	// FillEmpty fills an empty field but never rewrites an explicit out-of-list value.
 	m := defaults(t, projectNS("proj", map[string]string{"env": "prod"}), lbDef(v1alpha1.AvailabilityNone), lbRef(v1alpha1.DefaultingFillEmpty), lbGrant())

--- a/modules/160-multitenancy-manager/templates/admission/validation.yaml
+++ b/modules/160-multitenancy-manager/templates/admission/validation.yaml
@@ -1,3 +1,19 @@
+{{- /*
+  System/module writers are excluded at the apiserver level (CEL matchConditions, evaluated BEFORE any
+  network call to the webhook backend). All of these webhooks are backed by the multitenancy-manager
+  pod with the default failurePolicy: Fail; if that backend is denying, slow or unreachable, an
+  admission call for a resource a module's Helm release applies (e.g. the deckhouse-controller creating
+  a namespace) would fail and addon-operator would retry it forever, locking the module's queue.
+  Excluding system writers makes that impossible regardless of backend health, while ordinary users are
+  still validated. Mirrors the same exclusion on the cluster-objects grant webhooks.
+*/ -}}
+{{- $excludeSystemWriters := `matchConditions:
+- name: exclude-system-writers
+  expression: >-
+    request.userInfo.username != "system:apiserver"
+    && request.userInfo.username != "system:serviceaccount:d8-system:deckhouse"
+    && request.userInfo.username != "system:serviceaccount:d8-multitenancy-manager:multitenancy-manager"
+    && !request.userInfo.groups.exists(g, g == "system:serviceaccounts:d8-system" || g == "system:serviceaccounts:kube-system" || g == "system:masters" || g == "system:nodes")` }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -20,6 +36,7 @@ webhooks:
     admissionReviewVersions:
       - v1
     matchPolicy: Equivalent
+    {{- $excludeSystemWriters | nindent 4 }}
     sideEffects: None
     clientConfig:
       caBundle: {{ .Values.multitenancyManager.internal.admissionWebhookCert.ca | b64enc }}
@@ -44,6 +61,7 @@ webhooks:
     admissionReviewVersions:
       - v1
     matchPolicy: Equivalent
+    {{- $excludeSystemWriters | nindent 4 }}
     sideEffects: None
     clientConfig:
       caBundle: {{ .Values.multitenancyManager.internal.admissionWebhookCert.ca | b64enc }}
@@ -67,6 +85,7 @@ webhooks:
     admissionReviewVersions:
       - v1
     matchPolicy: Equivalent
+    {{- $excludeSystemWriters | nindent 4 }}
     sideEffects: None
     clientConfig:
       caBundle: {{ .Values.multitenancyManager.internal.admissionWebhookCert.ca | b64enc }}


### PR DESCRIPTION
## Description
The `multitenancy-manager` admission webhooks (`/is-granted`, `/defaults`, `d8-multitenancy-manager-webhook`) run with `failurePolicy: Fail`. When the backend denied/was slow/unreachable, module Helm releases (applied by `deckhouse-controller`) failed and retried forever, deadlocking the `main` queue. Now system/module writers are excluded at the apiserver level (`matchConditions`) + in-handler bypass; handlers use a direct reader with a 3s timeout; readiness gated on the webhook server. Only the `multitenancy-manager` image/hooks are affected.

## Why do we need it, and what problem does it solve?
Ordinary `AuthorizationRule`/`ClusterAuthorizationRule` usage on a project namespace could lock the Deckhouse `main` queue indefinitely, halting all module reconciliation. The webhooks must police only project users, never system/module writers.

## Why do we need it in the patch release (if we do)?
Yes - fixes a cluster-wide control-plane deadlock; should be backported.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: multitenancy-manager
type: fix
summary: Grant and project admission webhooks no longer deadlock the Deckhouse queue when the multitenancy-manager backend denies, is slow, or is unreachable.
impact_level: default
```