### PR TITLE
[node-manager] Add leader label and leader-only service for node-controller

### DIFF
--- a/modules/040-node-manager/hooks/set_node_controller_leader_pod.go
+++ b/modules/040-node-manager/hooks/set_node_controller_leader_pod.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2022 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	coordinationv1 "k8s.io/api/coordination/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
+)
+
+const (
+	nodeControllerNamespace = "d8-cloud-instance-manager"
+	nodeControllerApp       = "node-controller"
+	nodeControllerLeaseName = "node-controller.deckhouse.io"
+)
+
+type nodeControllerLeaseInfo struct {
+	HolderIdentity string
+}
+
+type nodeControllerPodInfo struct {
+	Name string
+}
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	Queue: "/modules/node-manager/set_node_controller_leader_pod",
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:       "lease",
+			ApiVersion: "coordination.k8s.io/v1",
+			Kind:       "Lease",
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{nodeControllerNamespace},
+				},
+			},
+			NameSelector: &types.NameSelector{
+				MatchNames: []string{nodeControllerLeaseName},
+			},
+			FilterFunc: nodeControllerLeaseFilter,
+		},
+		{
+			Name:       "pods",
+			ApiVersion: "v1",
+			Kind:       "Pod",
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{nodeControllerNamespace},
+				},
+			},
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": nodeControllerApp,
+				},
+			},
+			FilterFunc: nodeControllerPodFilter,
+		},
+	},
+}, setNodeControllerLeaderPod)
+
+func setNodeControllerLeaderPod(_ context.Context, input *go_hook.HookInput) error {
+	var leaderPodName string
+
+	for lease, err := range sdkobjectpatch.SnapshotIter[nodeControllerLeaseInfo](input.Snapshots.Get("lease")) {
+		if err != nil {
+			return fmt.Errorf("cannot iterate over 'lease' snapshot: %w", err)
+		}
+
+		leaderPodName = podNameFromHolderIdentity(lease.HolderIdentity)
+		break
+	}
+
+	for pod, err := range sdkobjectpatch.SnapshotIter[nodeControllerPodInfo](input.Snapshots.Get("pods")) {
+		if err != nil {
+			return fmt.Errorf("cannot iterate over 'pods' snapshot: %w", err)
+		}
+
+		patch := map[string]any{
+			"metadata": map[string]any{
+				"labels": map[string]any{
+					"leader": trueOrNil(pod.Name == leaderPodName && leaderPodName != ""),
+				},
+			},
+		}
+
+		input.PatchCollector.PatchWithMerge(patch, "v1", "Pod", nodeControllerNamespace, pod.Name)
+	}
+
+	return nil
+}
+
+func nodeControllerLeaseFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	var lease coordinationv1.Lease
+
+	if err := sdk.FromUnstructured(obj, &lease); err != nil {
+		return nil, err
+	}
+
+	if lease.Spec.HolderIdentity == nil {
+		return nodeControllerLeaseInfo{}, nil
+	}
+
+	return nodeControllerLeaseInfo{
+		HolderIdentity: *lease.Spec.HolderIdentity,
+	}, nil
+}
+
+func nodeControllerPodFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	var pod corev1.Pod
+
+	if err := sdk.FromUnstructured(obj, &pod); err != nil {
+		return nil, err
+	}
+
+	return nodeControllerPodInfo{
+		Name: pod.Name,
+	}, nil
+}
+
+func podNameFromHolderIdentity(holderIdentity string) string {
+	podName, _, _ := strings.Cut(holderIdentity, "_")
+	return podName
+}
+
+func trueOrNil(b bool) any {
+	if b {
+		return "true"
+	}
+	return nil
+}

--- a/modules/040-node-manager/hooks/set_node_controller_leader_pod_test.go
+++ b/modules/040-node-manager/hooks/set_node_controller_leader_pod_test.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2022 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("Modules :: node-manager :: hooks :: set_node_controller_leader_pod ::", func() {
+	f := HookExecutionConfigInit(`{"global":{},"nodeManager":{"internal":{}}}`, `{}`)
+
+	f.RegisterCRD("coordination.k8s.io", "v1", "Lease", true)
+
+	Context("Leader lease exists", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(
+				f.KubeStateSetAndWaitForBindingContexts(
+					nodeControllerLease+
+						nodeControllerLeaderPod+
+						nodeControllerFollowerPod,
+					3,
+				),
+			)
+
+			f.RunHook()
+		})
+
+		It("Should set leader label only on leader pod", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			leader := f.KubernetesResource(
+				"Pod",
+				nodeControllerNamespace,
+				"leader-pod",
+			)
+
+			Expect(leader.Exists()).To(BeTrue())
+			Expect(leader.Field("metadata.labels.leader").Exists()).To(BeTrue())
+			Expect(leader.Field("metadata.labels.leader").String()).To(Equal("true"))
+
+			follower := f.KubernetesResource(
+				"Pod",
+				nodeControllerNamespace,
+				"follower-pod",
+			)
+
+			Expect(follower.Exists()).To(BeTrue())
+			Expect(follower.Field("metadata.labels.leader").Exists()).To(BeFalse())
+		})
+	})
+})
+
+const (
+	nodeControllerLease = `
+---
+apiVersion: coordination.k8s.io/v1
+kind: Lease
+metadata:
+  name: node-controller.deckhouse.io
+  namespace: d8-cloud-instance-manager
+spec:
+  holderIdentity: leader-pod_test-uuid
+`
+
+	nodeControllerLeaderPod = `
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: leader-pod
+  namespace: d8-cloud-instance-manager
+  labels:
+    app: node-controller
+spec:
+  containers:
+    - name: node-controller
+      image: node-controller:test
+`
+
+	nodeControllerFollowerPod = `
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: follower-pod
+  namespace: d8-cloud-instance-manager
+  labels:
+    app: node-controller
+    leader: "true"
+spec:
+  containers:
+    - name: node-controller
+      image: node-controller:test
+`
+)

--- a/modules/040-node-manager/templates/node-controller/rbac-for-us.yaml
+++ b/modules/040-node-manager/templates/node-controller/rbac-for-us.yaml
@@ -237,6 +237,23 @@ rules:
       - list
       - watch
       - patch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/modules/040-node-manager/templates/node-controller/service.yaml
+++ b/modules/040-node-manager/templates/node-controller/service.yaml
@@ -12,3 +12,18 @@ spec:
     protocol: TCP
   selector:
     app: node-controller
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: node-controller-leader
+  namespace: d8-cloud-instance-manager
+  {{- include "helm_lib_module_labels" (list . (dict "app" "node-controller")) | nindent 2 }}
+spec:
+  ports:
+    - port: 443
+      targetPort: webhook-server
+      protocol: TCP
+  selector:
+    app: node-controller
+    leader: "true"


### PR DESCRIPTION
## Description

Add automatic leader pod labeling for node-controller based on the Kubernetes Lease object and introduce a dedicated Service that targets only the current leader replica.

A new Deckhouse hook watches the node-controller.deckhouse.io Lease and synchronizes the leader=true label on node-controller Pods. This label is then used by a dedicated Service to route requests only to the active leader instance.

Unit tests were added to verify correct leader label assignment and cleanup during leader changes.

## Why do we need it, and what problem does it solve?

Node-controller uses Kubernetes leader election, but there is currently no simple way to address only the active leader Pod.

Some operational scenarios, troubleshooting procedures, metrics collection, and future integrations require stable access to the leader replica instead of routing traffic to any node-controller Pod.

This change introduces a mechanism similar to the one already used by Deckhouse itself:

* the current leader is detected from the Lease object;
* the leader Pod receives the label leader=true;
* a dedicated Service selects only the leader Pod.

As a result, consumers can reliably communicate with the active node-controller instance.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: node-manager
type: feature
summary: Added leader detection and leader-only Service for node-controller.
impact_level: low
```
