### PR TITLE
[candi] fix bashible step header for dhctl logs

### DIFF
--- a/candi/bashible/bashible.sh.tpl
+++ b/candi/bashible/bashible.sh.tpl
@@ -524,7 +524,9 @@ function main() {
     # parsed by dhctl-side measurement tooling to map where bashible time goes.
     local start_ts
     start_ts=$(date +%s.%N)
-    echo "=== Step ${step_base} ==="
+    echo ===
+    echo === Step: $step
+    echo ===
 
     span_ctx=$(bb-telemetry-start-span "$step_base" "${BB_TELEMETRY_PARENT_SPAN_ID:-}")
 
@@ -545,7 +547,9 @@ function main() {
       fi
       >&2 echo "Failed to execute step ${step_base}, retrying in 2 seconds"
       sleep 2
-      echo "=== Step ${step_base} retry ${attempt} ==="
+      echo ===
+      echo === Step: $step
+      echo ===
       if [ "$attempt" -gt 2 ]; then
         sx=x
       fi

--- a/candi/bashible/bootstrap/02-bootstrap-bashible.sh.tpl
+++ b/candi/bashible/bootstrap/02-bootstrap-bashible.sh.tpl
@@ -98,6 +98,7 @@ while [ "$patch_pending" = true ] ; do
     fi
 
     if d8-curl -sS --fail -x "" \
+      -o /dev/null \
       --max-time 10 \
       -XPATCH \
       -H "Authorization: Bearer $(</var/lib/bashible/bootstrap-token)" \


### PR DESCRIPTION
## Description
Follow-up for #20446. Two small fixes in bashible logs:
1. `candi/bashible/bashible.sh.tpl` — return old step header format `=== Step: <full path> ===` (main + retry).
2. `candi/bashible/bootstrap/02-bootstrap-bashible.sh.tpl` — add `-o /dev/null` to instance status PATCH.

## Why do we need it, and what problem does it solve?
#20446 changed step header to `=== Step <basename> ===`. dhctl (lib-connection) parses header with regexp `^=== Step: /var/lib/bashible/bundle_steps/(.*)$`. New format does not match, so bootstrap/converge logs disappear in dhctl. Old format fixes it.
Second fix: instance status PATCH printed full Instance object to node journal. `-o /dev/null` hides it.

## Why do we need it in the patch release (if we do)?
Not necessarily.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: dhctl
type: fix 
summary:  Restore bashible step header format so dhctl can parse bootstrap/converge logs again.
impact_level: low
```
