### PR TITLE
[deckhouse] expose package values under module name for backward compatibility

### DIFF
--- a/deckhouse-controller/internal/packages/modules/global/module.go
+++ b/deckhouse-controller/internal/packages/modules/global/module.go
@@ -151,9 +151,17 @@ func (m *Module) GetSettingsChecksum() string {
 	return m.values.GetSettingsChecksum()
 }
 
-// GetValues returns values for rendering
+// GetValues returns values for rendering.
+//
+// Global values are exposed both flat (.Values.replicas) and under the "global"
+// key (.Values.global.replicas) so templates written for the old addon-operator
+// layout keep working.
 func (m *Module) GetValues() addonutils.Values {
-	return m.values.GetValues()
+	v := m.values.GetValues()
+	return addonutils.MergeValues(
+		v,
+		addonutils.Values{addonutils.ModuleNameToValuesKey(m.name): v},
+	)
 }
 
 // ValidateSettings validates settings against openAPI

--- a/deckhouse-controller/internal/packages/modules/module.go
+++ b/deckhouse-controller/internal/packages/modules/module.go
@@ -290,11 +290,17 @@ func (m *Module) ValidateSettings(ctx context.Context, settings addonutils.Value
 	}, nil
 }
 
-// GetValues returns values with hooks patches
+// GetValues returns values with hooks patches.
+//
+// Module values are exposed both flat (.Values.replicas) and under the module's
+// camelCase key (.Values.<moduleName>.replicas) so templates written for the old
+// addon-operator layout keep working.
 func (m *Module) GetValues() addonutils.Values {
+	moduleValues := m.values.GetValues()
 	return addonutils.MergeValues(
 		addonutils.Values{"global": m.globalValuesGetter(false)},
-		m.values.GetValues(),
+		moduleValues,
+		addonutils.Values{addonutils.ModuleNameToValuesKey(m.name): moduleValues},
 	)
 }
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

In the packages subsystem, a module's values are now exposed to Helm templates **both** flat
(`.Values.replicas`) **and** namespaced under the module's camelCase name
(`.Values.mySuperModule.replicas`). The same applies to the global module, under the `global`
key (`.Values.global.x`). The namespaced key is built with the same `ModuleNameToValuesKey`
helper the legacy addon-operator layout uses. Applications are intentionally left flat.

Example — module `a-k-test` whose template reads values the legacy way:

```yaml
# templates/deployment.yaml
spec:
  replicas: {{ .Values.aKTest.replicas | default 1 }}
```

For module `a-k-test` (camelCase key `aKTest`), whose chart reads `replicas` the legacy way
(`{{ .Values.aKTest.replicas | default 1 }}`), templates resolve both forms after the change:

| Template access | Before | After |
|---|---|---|
| `.Values.replicas` (flat, new) | ✅ | ✅ |
| `.Values.aKTest.replicas` (namespaced, legacy) | ❌ missing → silently falls back to `default 1` | ✅ |
| `.Values.global.*` | ✅ | ✅ |

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

In the new packages system a module reads its own values flat (.Values.replicas), while in the
legacy addon-operator layout modules read them namespaced under the module name
(.Values.<moduleName>.replicas). Module templates migrated from the legacy layout would break,
because .Values.<moduleName>.* resolved to nothing. Exposing the values under the module's name
key as a fallback keeps those templates working without forcing a rewrite, while the new flat
access keeps working too.

### Manual testing

The module render path in the packages runtime isn't wired up yet, so the fallback was verified
end-to-end on an **Application** as a proxy (it uses the same `GetValues` wrapping logic). A temporary
mirror of the fallback was added on the app path (not part of this PR), and a test app chart got a probe
reading one setting three ways:

```yaml
# ConfigMap in the test app chart
viaValues:   {{ .Values.msg }}                 # flat:       .Values.<key>
viaName:     {{ .Values.aKStatusTests.msg }}   # namespaced: .Values.<name>.<key>
viaSettings: {{ .Application.Settings.msg }}   # settings:   .Application.Settings.<key>
```

Deployed with `settings.msg: hello-from-status-test` and rendered inside the running controller:

```console
$ dc packages render default.a-k-status-tests | grep -E 'via(Values|Name|Settings)'
viaValues:   hello-from-status-test
viaName:     hello-from-status-test
viaSettings: hello-from-status-test
```

All three access styles resolve to the configured value — confirming `.Values.<name>.<key>` works
alongside the flat `.Values.<key>`.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: feature
summary: Expose package values under module name for backward compatibility.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
