### PR TITLE
[istio] Allow custom env vars for istiod

### DIFF
--- a/modules/110-istio/openapi/config-values.yaml
+++ b/modules/110-istio/openapi/config-values.yaml
@@ -438,6 +438,32 @@ properties:
               format: int64
             value:
               type: string
+      env:
+        type: object
+        additionalProperties:
+          type: string
+        default: {}
+        description: |
+          Additional environment variables for the istiod (pilot) container.
+
+          Keys reserved by the module cannot be overridden:
+
+          - `ISTIO_MULTIROOT_MESH`
+          - `ENABLE_ENHANCED_RESOURCE_SCOPING`
+          - `PILOT_HTTP10`
+          - `PILOT_ENABLE_AMBIENT`
+          - `PILOT_ENABLE_GATEWAY_API_DEPLOYMENT_CONTROLLER`
+          - `PILOT_ENABLE_GATEWAY_API_GATEWAYCLASS_CONTROLLER`
+        x-examples:
+        - GODEBUG: "gctrace=1"
+        not:
+          anyOf:
+          - required: ["ISTIO_MULTIROOT_MESH"]
+          - required: ["ENABLE_ENHANCED_RESOURCE_SCOPING"]
+          - required: ["PILOT_HTTP10"]
+          - required: ["PILOT_ENABLE_AMBIENT"]
+          - required: ["PILOT_ENABLE_GATEWAY_API_DEPLOYMENT_CONTROLLER"]
+          - required: ["PILOT_ENABLE_GATEWAY_API_GATEWAYCLASS_CONTROLLER"]
       replicasManagement:
         description: |
           Replication management settings and scaling of istiod.

--- a/modules/110-istio/openapi/config-values.yaml
+++ b/modules/110-istio/openapi/config-values.yaml
@@ -438,7 +438,7 @@ properties:
               format: int64
             value:
               type: string
-      env:
+      extraEnvs:
         type: object
         additionalProperties:
           type: string

--- a/modules/110-istio/openapi/doc-ru-config-values.yaml
+++ b/modules/110-istio/openapi/doc-ru-config-values.yaml
@@ -192,7 +192,7 @@ properties:
           Структура, аналогичная `spec.tolerations` пода Kubernetes.
 
           Если значение не указано или указано `false`, будет использоваться [автоматика](https://deckhouse.ru/products/kubernetes-platform/documentation/v1/#выделение-узлов-под-определенный-вид-нагрузки).
-      env:
+      extraEnvs:
         description: |
           Дополнительные переменные окружения для контейнера istiod (pilot).
 

--- a/modules/110-istio/openapi/doc-ru-config-values.yaml
+++ b/modules/110-istio/openapi/doc-ru-config-values.yaml
@@ -192,6 +192,18 @@ properties:
           Структура, аналогичная `spec.tolerations` пода Kubernetes.
 
           Если значение не указано или указано `false`, будет использоваться [автоматика](https://deckhouse.ru/products/kubernetes-platform/documentation/v1/#выделение-узлов-под-определенный-вид-нагрузки).
+      env:
+        description: |
+          Дополнительные переменные окружения для контейнера istiod (pilot).
+
+          Зарезервированные модулем ключи нельзя переопределить:
+
+          - `ISTIO_MULTIROOT_MESH`
+          - `ENABLE_ENHANCED_RESOURCE_SCOPING`
+          - `PILOT_HTTP10`
+          - `PILOT_ENABLE_AMBIENT`
+          - `PILOT_ENABLE_GATEWAY_API_DEPLOYMENT_CONTROLLER`
+          - `PILOT_ENABLE_GATEWAY_API_GATEWAYCLASS_CONTROLLER`
       replicasManagement:
         description: |
           Настройки управления репликами и горизонтальным масштабированием istiod.

--- a/modules/110-istio/template_tests/module_test.go
+++ b/modules/110-istio/template_tests/module_test.go
@@ -1050,6 +1050,54 @@ updatePolicy:
 		})
 	})
 
+	Context("istiod with custom controlPlane.env", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", globalValues)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYaml("istio", istioValues)
+			f.ValuesSetFromYaml("istio.internal.versionsToInstall", `["1.25.2","1.21.6"]`)
+			f.ValuesSetFromYaml("istio.controlPlane.env", `
+GODEBUG: "gctrace=1"
+MY_VAR: "myvalue"
+`)
+			f.HelmRender()
+		})
+
+		It("should add custom env vars to istiod in both IOP and sailoperator Istio CR", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			istioV25 := f.KubernetesResource("Istio", "d8-istio", "v1x25x2")
+			iopV21 := f.KubernetesResource("IstioOperator", "d8-istio", "v1x21x6")
+			Expect(istioV25.Exists()).To(BeTrue())
+			Expect(iopV21.Exists()).To(BeTrue())
+
+			// istioV25 (sailoperator): spec.values.pilot.env is a map
+			By("istios.yaml: custom env vars are present in spec.values.pilot.env")
+			Expect(istioV25.Field("spec.values.pilot.env.GODEBUG").String()).To(Equal("gctrace=1"))
+			Expect(istioV25.Field("spec.values.pilot.env.MY_VAR").String()).To(Equal("myvalue"))
+
+			By("istios.yaml: reserved env vars are still present")
+			Expect(istioV25.Field("spec.values.pilot.env.ISTIO_MULTIROOT_MESH").String()).To(Equal("true"))
+			Expect(istioV25.Field("spec.values.pilot.env.ENABLE_ENHANCED_RESOURCE_SCOPING").String()).To(Equal("true"))
+
+			// iopV21 (IstioOperator): spec.components.pilot.k8s.env is a list of {name, value}
+			By("iop.yaml: custom env vars are present in spec.components.pilot.k8s.env")
+			Expect(iopV21.Field("spec.components.pilot.k8s.env.2.name").String()).To(Equal("GODEBUG"))
+			Expect(iopV21.Field("spec.components.pilot.k8s.env.2.value").String()).To(Equal("gctrace=1"))
+			Expect(iopV21.Field("spec.components.pilot.k8s.env.3.name").String()).To(Equal("MY_VAR"))
+			Expect(iopV21.Field("spec.components.pilot.k8s.env.3.value").String()).To(Equal("myvalue"))
+
+			By("iop.yaml: reserved env vars are still present")
+			Expect(iopV21.Field("spec.components.pilot.k8s.env.0.name").String()).To(Equal("ISTIO_MULTIROOT_MESH"))
+			Expect(iopV21.Field("spec.components.pilot.k8s.env.0.value").String()).To(Equal("true"))
+			Expect(iopV21.Field("spec.components.pilot.k8s.env.1.name").String()).To(Equal("ENABLE_ENHANCED_RESOURCE_SCOPING"))
+			Expect(iopV21.Field("spec.components.pilot.k8s.env.1.value").String()).To(Equal("true"))
+
+			By("iop.yaml: custom env vars are placed after the reserved ones, total count is 4")
+			Expect(iopV21.Field("spec.components.pilot.k8s.env").Array()).To(HaveLen(4))
+		})
+	})
+
 	Context("ingress gateway controller with inlet NodePort is enabled", func() {
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global", globalValues)

--- a/modules/110-istio/template_tests/module_test.go
+++ b/modules/110-istio/template_tests/module_test.go
@@ -1050,13 +1050,13 @@ updatePolicy:
 		})
 	})
 
-	Context("istiod with custom controlPlane.env", func() {
+	Context("istiod with custom controlPlane.extraEnvs", func() {
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global", globalValues)
 			f.ValuesSet("global.modulesImages", GetModulesImages())
 			f.ValuesSetFromYaml("istio", istioValues)
 			f.ValuesSetFromYaml("istio.internal.versionsToInstall", `["1.25.2","1.21.6"]`)
-			f.ValuesSetFromYaml("istio.controlPlane.env", `
+			f.ValuesSetFromYaml("istio.controlPlane.extraEnvs", `
 GODEBUG: "gctrace=1"
 MY_VAR: "myvalue"
 `)

--- a/modules/110-istio/templates/control-plane/iop.yaml
+++ b/modules/110-istio/templates/control-plane/iop.yaml
@@ -51,7 +51,7 @@ spec:
         - name: PILOT_HTTP10
           value: "1"
   {{- end }}
-  {{- range $name, $value := $.Values.istio.controlPlane.env }}
+  {{- range $name, $value := $.Values.istio.controlPlane.extraEnvs }}
         - name: {{ $name }}
           value: {{ $value | quote }}
   {{- end }}

--- a/modules/110-istio/templates/control-plane/iop.yaml
+++ b/modules/110-istio/templates/control-plane/iop.yaml
@@ -51,6 +51,10 @@ spec:
         - name: PILOT_HTTP10
           value: "1"
   {{- end }}
+  {{- range $name, $value := $.Values.istio.controlPlane.env }}
+        - name: {{ $name }}
+          value: {{ $value | quote }}
+  {{- end }}
 {{- include "helm_lib_pod_anti_affinity_for_ha" (list $ (dict "app" "istiod" "istio.io/rev" $revision)) | nindent 8 }}
 
     ingressGateways:

--- a/modules/110-istio/templates/control-plane/istios.yaml
+++ b/modules/110-istio/templates/control-plane/istios.yaml
@@ -182,7 +182,7 @@ spec:
   {{- if and $supportsAmbient $.Values.istio.ambient.enabled }}
         PILOT_ENABLE_AMBIENT: "true"
   {{- end }}
-  {{- range $name, $value := $.Values.istio.controlPlane.env }}
+  {{- range $name, $value := $.Values.istio.controlPlane.extraEnvs }}
         {{ $name }}: {{ $value | quote }}
   {{- end }}
       autoscaleEnabled: false

--- a/modules/110-istio/templates/control-plane/istios.yaml
+++ b/modules/110-istio/templates/control-plane/istios.yaml
@@ -182,6 +182,9 @@ spec:
   {{- if and $supportsAmbient $.Values.istio.ambient.enabled }}
         PILOT_ENABLE_AMBIENT: "true"
   {{- end }}
+  {{- range $name, $value := $.Values.istio.controlPlane.env }}
+        {{ $name }}: {{ $value | quote }}
+  {{- end }}
       autoscaleEnabled: false
       taint:
         enabled: false


### PR DESCRIPTION
## Description

Allow users to inject additional environment variables into the istiod (pilot) container.

A new `controlPlane.extraEnvs` parameter has been added to the Istio module configuration. It accepts an object of string key-value pairs, defaulting to `{}`.

The following six keys are **reserved** by the module and cannot be overridden (the OpenAPI schema enforces this via a `not: anyOf` constraint):

- `ISTIO_MULTIROOT_MESH`
- `ENABLE_ENHANCED_RESOURCE_SCOPING`
- `PILOT_HTTP10`
- `PILOT_ENABLE_AMBIENT`
- `PILOT_ENABLE_GATEWAY_API_DEPLOYMENT_CONTROLLER`
- `PILOT_ENABLE_GATEWAY_API_GATEWAYCLASS_CONTROLLER`

Custom env vars are injected into both rendering targets:

- **sailoperator Istio CR** (`istios.yaml`): added as map entries in `spec.values.pilot.env`.
- **IstioOperator CR** (`iop.yaml`): added as `{name, value}` list items in `spec.components.pilot.k8s.env`, placed after the reserved vars.

## Why do we need it, and what problem does it solve?

Some users need to pass custom environment variables to the istiod container — for example, to enable Go runtime tracing (`GODEBUG=gctrace=1`), tune Istio internals, or inject configuration not exposed via the module's high-level API.

Previously there was no way to do this without modifying module templates or resorting to post-deployment patching. The new `controlPlane.extraEnvs` parameter provides a clean, supported path for this, while keeping the module in control of critical environment variables by forbidding overrides of its reserved keys.

## Checklist

- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: feature
summary: Allow custom environment variables for istiod.
impact_level: low
```