### PR TITLE
[cloud-provider-dvp] Fix double mounting of volume and race condition in NodePublishVolume

### DIFF
--- a/modules/030-cloud-provider-dvp/images/dvp-csi-driver/src/pkg/dvp-csi-driver/service/node.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-csi-driver/src/pkg/dvp-csi-driver/service/node.go
@@ -42,6 +42,7 @@ type NodeService struct {
 	csi.UnimplementedNodeServer
 	nodeName    string
 	dvpCloudAPI *dvpapi.DVPCloudAPI
+	volumeLocks *volumeLocks
 }
 
 var NodeCaps = []csi.NodeServiceCapability_RPC_Type{
@@ -57,6 +58,7 @@ func NewNode(
 	return &NodeService{
 		nodeName:    nodeName,
 		dvpCloudAPI: dvpCloudAPI,
+		volumeLocks: newVolumeLocks(),
 	}
 }
 
@@ -118,6 +120,17 @@ func (n *NodeService) NodePublishVolume(
 	}
 	diskName := req.VolumeId
 
+	targetPath := req.GetTargetPath()
+	if targetPath == "" {
+		return nil, status.Error(codes.InvalidArgument, "target path not provided")
+	}
+
+	lockKey := volumeLockKey(diskName, targetPath)
+	if !n.volumeLocks.tryAcquire(lockKey) {
+		return nil, status.Errorf(codes.Aborted, "volume %q operation already in progress for %q", diskName, targetPath)
+	}
+	defer n.volumeLocks.release(lockKey)
+
 	device, err := n.getDevicePath(ctx, diskName)
 	if err != nil {
 		klog.Errorf("Failed to fetch device by for volume %v", diskName)
@@ -128,7 +141,6 @@ func (n *NodeService) NodePublishVolume(
 		return n.publishBlockVolume(req, device)
 	}
 
-	targetPath := req.GetTargetPath()
 	err = os.MkdirAll(targetPath, 0o644)
 	if err != nil {
 		return nil, errors.New(err.Error())
@@ -247,6 +259,12 @@ func (n *NodeService) NodeUnpublishVolume(
 	if target == "" {
 		return nil, status.Error(codes.InvalidArgument, "targetpath not provided")
 	}
+
+	lockKey := volumeLockKey(req.GetVolumeId(), target)
+	if !n.volumeLocks.tryAcquire(lockKey) {
+		return nil, status.Errorf(codes.Aborted, "volume %q operation already in progress for %q", req.GetVolumeId(), target)
+	}
+	defer n.volumeLocks.release(lockKey)
 
 	klog.Infof("NodeUnpublishVolume: unmounting %s", target)
 

--- a/modules/030-cloud-provider-dvp/images/dvp-csi-driver/src/pkg/dvp-csi-driver/service/node.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-csi-driver/src/pkg/dvp-csi-driver/service/node.go
@@ -65,7 +65,7 @@ func (n *NodeService) NodeStageVolume(
 	req *csi.NodeStageVolumeRequest,
 ) (*csi.NodeStageVolumeResponse, error) {
 	if len(req.VolumeId) == 0 {
-		return nil, fmt.Errorf("error required request paramater VolumeId wasn't set")
+		return nil, fmt.Errorf("error required request parameter VolumeId wasn't set")
 	}
 	diskName := req.VolumeId
 
@@ -114,7 +114,7 @@ func (n *NodeService) NodePublishVolume(
 	req *csi.NodePublishVolumeRequest,
 ) (*csi.NodePublishVolumeResponse, error) {
 	if len(req.VolumeId) == 0 {
-		return nil, fmt.Errorf("error required request paramater VolumeId wasn't set")
+		return nil, fmt.Errorf("error required request parameter VolumeId wasn't set")
 	}
 	diskName := req.VolumeId
 
@@ -127,6 +127,7 @@ func (n *NodeService) NodePublishVolume(
 	if req.VolumeCapability.GetBlock() != nil {
 		return n.publishBlockVolume(req, device)
 	}
+
 	targetPath := req.GetTargetPath()
 	err = os.MkdirAll(targetPath, 0o644)
 	if err != nil {
@@ -134,9 +135,24 @@ func (n *NodeService) NodePublishVolume(
 	}
 
 	fsType := req.VolumeCapability.GetMount().FsType
+
+	mounter := mount.New("")
+	notMnt, err := mount.IsNotMountPoint(mounter, targetPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("failed to check mount point %s: %w", targetPath, err)
+		}
+
+		notMnt = true
+	}
+	if !notMnt {
+		klog.Infof("Target path %s is already mounted, skipping publish", targetPath)
+		return &csi.NodePublishVolumeResponse{}, nil
+	}
+
 	klog.Infof("Mounting devicePath %s, on targetPath: %s with FS type: %s",
 		device, targetPath, fsType)
-	mounter := mount.New("")
+
 	err = mounter.Mount(device, targetPath, fsType, []string{})
 	if err != nil {
 		klog.Errorf("Failed mounting %v", err)
@@ -183,19 +199,34 @@ func (n *NodeService) getDevicePath(ctx context.Context, diskName string) (strin
 func (n *NodeService) publishBlockVolume(req *csi.NodePublishVolumeRequest, device string) (*csi.NodePublishVolumeResponse, error) {
 	klog.Infof("Publishing block volume, device: %s, req: %+v", device, req)
 	file, err := os.OpenFile(req.TargetPath, os.O_CREATE, os.FileMode(0o644))
-	defer func() {
-		err = file.Close()
-		if err != nil {
-			klog.Errorf("Failed to close file %s, err: %v", req.TargetPath, err)
-		}
-	}()
 	if err != nil {
 		if !os.IsExist(err) {
 			return nil, status.Errorf(codes.Internal, "Failed to create targetPath %s, err: %v", req.TargetPath, err)
 		}
 	}
+	defer func() {
+		if file == nil {
+			return
+		}
+		if closeErr := file.Close(); closeErr != nil {
+			klog.Errorf("Failed to close file %s, err: %v", req.TargetPath, closeErr)
+		}
+	}()
 
 	mounter := mount.New("")
+	notMnt, err := mount.IsNotMountPoint(mounter, req.TargetPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return nil, status.Errorf(codes.Internal, "failed to check mount point %s: %v", req.TargetPath, err)
+		}
+
+		notMnt = true
+	}
+	if !notMnt {
+		klog.Infof("Target path %s is already mounted, skipping publish", req.TargetPath)
+		return &csi.NodePublishVolumeResponse{}, nil
+	}
+
 	err = mounter.Mount(device, req.TargetPath, "", []string{"bind"})
 	if err != nil {
 		if removeErr := os.Remove(req.TargetPath); removeErr != nil {

--- a/modules/030-cloud-provider-dvp/images/dvp-csi-driver/src/pkg/dvp-csi-driver/service/node.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-csi-driver/src/pkg/dvp-csi-driver/service/node.go
@@ -158,7 +158,7 @@ func (n *NodeService) NodePublishVolume(
 		notMnt = true
 	}
 	if !notMnt {
-		klog.Infof("Target path %s is already mounted, skipping publish", targetPath)
+		klog.Infof("Filesystem target path %s is already mounted, skipping publish", targetPath)
 		return &csi.NodePublishVolumeResponse{}, nil
 	}
 
@@ -209,7 +209,6 @@ func (n *NodeService) getDevicePath(ctx context.Context, diskName string) (strin
 }
 
 func (n *NodeService) publishBlockVolume(req *csi.NodePublishVolumeRequest, device string) (*csi.NodePublishVolumeResponse, error) {
-	klog.Infof("Publishing block volume, device: %s, req: %+v", device, req)
 	file, err := os.OpenFile(req.TargetPath, os.O_CREATE, os.FileMode(0o644))
 	if err != nil {
 		if !os.IsExist(err) {
@@ -235,9 +234,11 @@ func (n *NodeService) publishBlockVolume(req *csi.NodePublishVolumeRequest, devi
 		notMnt = true
 	}
 	if !notMnt {
-		klog.Infof("Target path %s is already mounted, skipping publish", req.TargetPath)
+		klog.Infof("Block target path %s is already mounted, skipping publish", req.TargetPath)
 		return &csi.NodePublishVolumeResponse{}, nil
 	}
+
+	klog.Infof("Publishing block volume, device: %s, req: %+v", device, req)
 
 	err = mounter.Mount(device, req.TargetPath, "", []string{"bind"})
 	if err != nil {

--- a/modules/030-cloud-provider-dvp/images/dvp-csi-driver/src/pkg/dvp-csi-driver/service/volume_locks.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-csi-driver/src/pkg/dvp-csi-driver/service/volume_locks.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import "sync"
+
+type volumeLocks struct {
+	mu    sync.Mutex
+	locks map[string]struct{}
+}
+
+func newVolumeLocks() *volumeLocks {
+	return &volumeLocks{
+		locks: make(map[string]struct{}),
+	}
+}
+
+func (vl *volumeLocks) tryAcquire(key string) bool {
+	vl.mu.Lock()
+	defer vl.mu.Unlock()
+
+	if _, held := vl.locks[key]; held {
+		return false
+	}
+
+	vl.locks[key] = struct{}{}
+	return true
+}
+
+func (vl *volumeLocks) release(key string) {
+	vl.mu.Lock()
+	defer vl.mu.Unlock()
+
+	delete(vl.locks, key)
+}
+
+func volumeLockKey(volumeID, targetPath string) string {
+	return volumeID + "\x00" + targetPath
+}


### PR DESCRIPTION
## Description

`dvp-csi-driver` now lock volume while working with it and checks whether a volume target path is already mounted before calling `mount(2)` in `NodePublishVolume`:

- filesystem and block volumes (bind mount) use `mount.IsNotMountPoint`.

## Why do we need it, and what problem does it solve?

On DKP clusters deployed on DVP, repeated `NodePublishVolume` calls (for example, after kubelet restarts or volume sync retries) could mount the same device to the same path again. Linux allows this without an error, but duplicate entries appear in the mount table. This breaks filesystem metrics and can affect monitoring for PVC-backed workloads.

The driver now skips mounting when the target path is already published, making `NodePublishVolume` idempotent and preventing new duplicate mount entries.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cloud-provider-dvp
type: fix
summary: Fixed duplicate volume mounts in the DVP CSI driver on kubelet retries.
impact_level: default
```