### PR TITLE
[node-manager] drop Unknown shutdown condition status

### DIFF
--- a/ee/modules/040-node-manager/images/d8-shutdown-inhibitor/src/pkg/app/nodecondition/condition.go
+++ b/ee/modules/040-node-manager/images/d8-shutdown-inhibitor/src/pkg/app/nodecondition/condition.go
@@ -6,7 +6,6 @@ Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https
 package nodecondition
 
 const (
-	StatusTrue    = "True"
-	StatusFalse   = "False"
-	StatusUnknown = "Unknown"
+	StatusTrue  = "True"
+	StatusFalse = "False"
 )

--- a/ee/modules/040-node-manager/images/d8-shutdown-inhibitor/src/pkg/app/nodecondition/graceful_shutdown_postpone.go
+++ b/ee/modules/040-node-manager/images/d8-shutdown-inhibitor/src/pkg/app/nodecondition/graceful_shutdown_postpone.go
@@ -22,7 +22,7 @@ const (
 	ReasonOnStart                = "ShutdownInhibitorIsStarted"
 	ReasonOnUnlock               = "NoRunningPodsWithLabel"
 	ReasonPodsArePresent         = "PodsWithLabelAreRunningOnNode"
-	ReasonPendindgState          = "Pending"
+	ReasonArmed                  = "WaitingForShutdownSignal"
 )
 
 func GracefulShutdownPostpone(klient *kubernetes.Klient) *gracefulShutdownPostpone {
@@ -41,19 +41,23 @@ func (g *gracefulShutdownPostpone) SetOnStart(ctx context.Context, nodeName stri
 	if !afterReboot {
 		return nil
 	}
-	return g.SetStatusUnknow(ctx, nodeName)
+	return g.SetArmed(ctx, nodeName)
 }
 
-func (g *gracefulShutdownPostpone) SetStatusUnknow(ctx context.Context, nodeName string) error {
-	return g.patchGracefulShutdownPostponeCondition(ctx, nodeName, StatusUnknown, ReasonPendindgState)
+// SetArmed puts the condition into its steady state while the node runs.
+// Status is True (not Unknown) on purpose: the frozen kubelet patch treats
+// True as "postpone", so shutdown stays blocked by default until the inhibitor
+// decides, which closes the race on the shutdown signal.
+func (g *gracefulShutdownPostpone) SetArmed(ctx context.Context, nodeName string) error {
+	return g.patchGracefulShutdownPostponeCondition(ctx, nodeName, StatusTrue, ReasonArmed, "Node is armed; graceful shutdown will be postponed until stateful pods are evicted")
 }
 
 func (g *gracefulShutdownPostpone) SetPodsArePresent(ctx context.Context, nodeName string) error {
-	return g.patchGracefulShutdownPostponeCondition(ctx, nodeName, StatusTrue, ReasonPodsArePresent)
+	return g.patchGracefulShutdownPostponeCondition(ctx, nodeName, StatusTrue, ReasonPodsArePresent, "")
 }
 
 func (g *gracefulShutdownPostpone) UnsetOnUnlock(ctx context.Context, nodeName string) error {
-	return g.patchGracefulShutdownPostponeCondition(ctx, nodeName, StatusFalse, ReasonOnUnlock)
+	return g.patchGracefulShutdownPostponeCondition(ctx, nodeName, StatusFalse, ReasonOnUnlock, "")
 }
 
 // patchGracefulShutdownPostponeCondition updates GracefulShutdownPostpone condition.
@@ -66,9 +70,9 @@ kubectl patch node/static-vm-node-00 --type strategic
 -p '{"status":{"conditions":[{"type":"GracefulShutdownPostpone", "status":"False", "reason":"NoRunningPodsWithLabel"}]}}'
 --subresource=status
 */
-func (g *gracefulShutdownPostpone) patchGracefulShutdownPostponeCondition(ctx context.Context, nodeName, status, reason string) error {
+func (g *gracefulShutdownPostpone) patchGracefulShutdownPostponeCondition(ctx context.Context, nodeName, status, reason, message string) error {
 	return g.Klient.GetNode(ctx, nodeName).
-		PatchCondition(ctx, GracefulShutdownPostponeType, status, reason, "").
+		PatchCondition(ctx, GracefulShutdownPostponeType, status, reason, message).
 		Err()
 }
 

--- a/ee/modules/040-node-manager/images/d8-shutdown-inhibitor/src/pkg/kubernetes/node.go
+++ b/ee/modules/040-node-manager/images/d8-shutdown-inhibitor/src/pkg/kubernetes/node.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -164,14 +165,33 @@ func (n *Node) RemoveCordonAnnotation(ctx context.Context) *Node {
 	})
 }
 
+// conditionTransitionTime returns the lastTransitionTime to set for a condition of
+// condType moving to status: the existing time when the status is unchanged, and the
+// current time when the status flips or the condition is new. This matches the
+// Kubernetes meaning of lastTransitionTime, which tracks status changes, not reason changes.
+func (n *Node) conditionTransitionTime(condType, status string) string {
+	for _, c := range n.Status.Conditions {
+		if string(c.Type) != condType {
+			continue
+		}
+		if string(c.Status) == status && !c.LastTransitionTime.Time.IsZero() {
+			return c.LastTransitionTime.UTC().Format(time.RFC3339)
+		}
+		break
+	}
+	return time.Now().UTC().Format(time.RFC3339)
+}
+
 func (n *Node) PatchCondition(ctx context.Context, condType, status, reason, message string) *Node {
 	if n.err != nil {
 		return n
 	}
 
+	lastTransitionTime := n.conditionTransitionTime(condType, status)
+
 	patch := fmt.Sprintf(
-		`{"status":{"conditions":[{"type":"%s", "status":"%s", "reason":"%s", "message":"%s"}]}}`,
-		condType, status, reason, message,
+		`{"status":{"conditions":[{"type":"%s", "status":"%s", "reason":"%s", "message":"%s", "lastTransitionTime":"%s"}]}}`,
+		condType, status, reason, message, lastTransitionTime,
 	)
 
 	var lastErr error


### PR DESCRIPTION
## Description

shutdown-inhibitor no longer sets the `GracefulShutdownPostpone` node condition to `status: Unknown`. The idle (armed) state now uses `status: True` with `reason: WaitingForShutdownSignal`. So the condition now has only `True` or `False`.

## Why do we need it, and what problem does it solve?

`status: Unknown` looks like a problem in `kubectl describe node` and in monitoring, but it is only the normal idle state. The kubelet patch already treats `True` as "postpone", so node behavior does not change and the race on the shutdown signal stays closed.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: node-manager
type: fix
summary: Made shutdown-inhibitor set the GracefulShutdownPostpone condition only to True or False.
```
