### PR TITLE
[dhctl] add bastion availability preflight check

### DIFF
--- a/dhctl/go.mod
+++ b/dhctl/go.mod
@@ -60,6 +60,7 @@ require (
 	go.opentelemetry.io/otel/sdk/log v0.19.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
+	golang.org/x/crypto v0.50.0
 	golang.org/x/sync v0.20.0
 	golang.org/x/term v0.42.0
 	google.golang.org/grpc v1.80.0
@@ -229,7 +230,6 @@ require (
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	go4.org v0.0.0-20260112195520-a5071408f32f // indirect
-	golang.org/x/crypto v0.50.0 // indirect
 	golang.org/x/exp v0.0.0-20250711185948-6ae5c78190dc // indirect
 	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect

--- a/dhctl/pkg/app/options/preflight_known_checks.gen.go
+++ b/dhctl/pkg/app/options/preflight_known_checks.gen.go
@@ -2,6 +2,7 @@
 package options
 
 var generatedPreflightChecks = []string{
+	"bastion-availability",
 	"cidr-intersection",
 	"cloud-api-accessibility",
 	"cloud-disk-name-length",

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
@@ -431,8 +431,9 @@ func (b *ClusterBootstrapper) bootstrapPreflight(ctx context.Context, bctx *boot
 		}
 
 		cloudPreflightSuite := suites.NewCloudSuite(suites.CloudDeps{
-			InstallConfig: bctx.deckhouseInstallConfig,
-			MetaConfig:    bctx.metaConfig,
+			InstallConfig:          bctx.deckhouseInstallConfig,
+			MetaConfig:             bctx.metaConfig,
+			SSHProviderInitializer: b.SSHProviderInitializer,
 		})
 		postCloudPreflightSuite := suites.NewPostCloudSuite(suites.PostCloudDeps{
 			MetaConfig:  bctx.metaConfig,

--- a/dhctl/pkg/preflight/checks/bastion.go
+++ b/dhctl/pkg/preflight/checks/bastion.go
@@ -16,11 +16,16 @@ package checks
 
 import (
 	"context"
-	"errors"
 	"fmt"
+	"net"
+	"os"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
 
 	sshconfig "github.com/deckhouse/lib-connection/pkg/ssh/config"
-	"github.com/deckhouse/lib-connection/pkg/ssh/session"
 
 	preflight "github.com/deckhouse/deckhouse/dhctl/pkg/preflight"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/providerinitializer"
@@ -28,7 +33,10 @@ import (
 
 const BastionAvailabilityCheckName preflight.CheckName = "bastion-availability"
 
-const defaultBastionPort = "22"
+const (
+	defaultBastionPort = "22"
+	bastionDialTimeout = 10 * time.Second
+)
 
 type BastionAvailabilityCheck struct {
 	SSHProviderInitializer *providerinitializer.SSHProviderInitializer
@@ -48,7 +56,14 @@ func (BastionAvailabilityCheck) Phase() preflight.Phase {
 }
 
 func (BastionAvailabilityCheck) RetryPolicy() preflight.RetryPolicy {
-	return preflight.DefaultRetryPolicy
+	return preflight.RetryPolicy{
+		Attempts: 1,
+		Options: []backoff.ExponentialBackOffOpts{
+			backoff.WithInitialInterval(time.Second),
+			backoff.WithMultiplier(2),
+			backoff.WithMaxElapsedTime(0),
+		},
+	}
 }
 
 func bastionConfigured(cfg *sshconfig.Config) bool {
@@ -70,43 +85,114 @@ func (c BastionAvailabilityCheck) Run(ctx context.Context) error {
 	}
 
 	sshCfg := connCfg.Config
-	host := sshCfg.BastionHost
-	port := bastionPort(sshCfg)
+	addr := net.JoinHostPort(sshCfg.BastionHost, bastionPort(sshCfg))
 
-	sshProvider, err := c.SSHProviderInitializer.GetSSHProvider(ctx)
-	if err != nil && !errors.Is(err, providerinitializer.ErrHostsFromCacheNotFound) {
-		return fmt.Errorf("cannot initialize ssh provider: %w", err)
-	}
-	if sshProvider == nil {
-		return fmt.Errorf("ssh provider is not available")
-	}
-
-	sess := session.NewSession(session.Input{
-		User:       sshCfg.BastionUser,
-		Port:       port,
-		BecomePass: sshCfg.BastionPassword,
-	})
-	sess.AddAvailableHosts(session.Host{Host: host})
-
-	client, err := sshProvider.NewStandaloneClient(ctx, sess, nil)
+	authMethods, cleanup, err := bastionAuthMethods(sshCfg)
 	if err != nil {
-		return fmt.Errorf("cannot create ssh client for bastion host %s:%s: %w", host, port, err)
+		return fmt.Errorf("cannot prepare ssh auth for bastion host %s: %w", addr, err)
 	}
-	defer client.Stop()
+	defer cleanup()
 
-	// Start performs TCP connect + SSH handshake + user authentication to the
-	// bastion (transport only, no session/exec channel).
-	if err := client.Start(); err != nil {
-		return fmt.Errorf("cannot connect to bastion host %s:%s: %w", host, port, err)
+	clientCfg := &ssh.ClientConfig{
+		User:            sshCfg.BastionUser,
+		Auth:            authMethods,
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Timeout:         bastionDialTimeout,
 	}
 
-	// dhctl uses the bastion only as a ProxyJump (direct-tcpip forwarding)
-	// and never runs commands on it.
-	// We do NOT exec a probe command here —
-	// a hardened bastion may permit forwarding while denying
-	// shell/exec (ForceCommand, no-pty, command="..." in authorized_keys, a
-	// restricted/kill shell), and such a bastion is still valid for our use.
+	// 1. TCP reachability check, honouring context cancellation.
+	conn, err := (&net.Dialer{Timeout: bastionDialTimeout}).DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return fmt.Errorf("cannot reach bastion host %s: %w", addr, err)
+	}
+	defer conn.Close()
+	_ = conn.SetDeadline(time.Now().Add(bastionDialTimeout))
+
+	// 2. SSH transport + user authentication ONLY.
+	//
+	// We deliberately do NOT build a full lib-connection SSH client here: its
+	// Start() spawns a keepalive goroutine that opens an SSH *session* on the
+	// target. dhctl uses the bastion only as a ProxyJump (direct-tcpip
+	// forwarding) and never runs commands on it, so a hardened bastion may
+	// permit forwarding while denying shell/exec (ForceCommand, no-pty,
+	// command="..." in authorized_keys, a restricted/kill shell). Such a
+	// bastion is still valid for our use, but the keepalive session would be
+	// rejected and trigger an endless reconnect loop. A bare transport+auth
+	// handshake validates exactly what we rely on, nothing more.
+	sshConn, chans, reqs, err := ssh.NewClientConn(conn, addr, clientCfg)
+	if err != nil {
+		return fmt.Errorf("cannot authenticate to bastion host %s as %q: %w", addr, sshCfg.BastionUser, err)
+	}
+	ssh.NewClient(sshConn, chans, reqs).Close()
+
 	return nil
+}
+
+// bastionAuthMethods builds the ssh auth methods used to reach the bastion:
+// public keys from the connection config, the running ssh-agent (if any) and an
+// optional bastion password. The returned cleanup closes the ssh-agent socket.
+func bastionAuthMethods(cfg *sshconfig.Config) ([]ssh.AuthMethod, func(), error) {
+	cleanup := func() {}
+
+	signers, err := bastionSigners(cfg.PrivateKeys)
+	if err != nil {
+		return nil, cleanup, err
+	}
+
+	var methods []ssh.AuthMethod
+	if len(signers) > 0 {
+		methods = append(methods, ssh.PublicKeys(signers...))
+	}
+
+	if sock := os.Getenv("SSH_AUTH_SOCK"); sock != "" {
+		if agentConn, err := net.Dial("unix", sock); err == nil {
+			cleanup = func() { _ = agentConn.Close() }
+			methods = append(methods, ssh.PublicKeysCallback(agent.NewClient(agentConn).Signers))
+		}
+	}
+
+	if cfg.BastionPassword != "" {
+		methods = append(methods, ssh.Password(cfg.BastionPassword))
+	}
+
+	if len(methods) == 0 {
+		return nil, cleanup, fmt.Errorf("no ssh auth methods available (no private keys, ssh-agent or password)")
+	}
+
+	return methods, cleanup, nil
+}
+
+// bastionSigners parses the connection config private keys into ssh signers.
+// dhctl writes inline sshAgentPrivateKeys to temp files, so most keys arrive as
+// paths (IsPath); inline PEM keys are handled too.
+func bastionSigners(keys []sshconfig.AgentPrivateKey) ([]ssh.Signer, error) {
+	signers := make([]ssh.Signer, 0, len(keys))
+	for _, k := range keys {
+		pemBytes := []byte(k.Key)
+		if k.IsPath {
+			b, err := os.ReadFile(k.Key)
+			if err != nil {
+				return nil, fmt.Errorf("read private key %s: %w", k.Key, err)
+			}
+			pemBytes = b
+		}
+
+		var (
+			signer ssh.Signer
+			err    error
+		)
+		if k.Passphrase != "" {
+			signer, err = ssh.ParsePrivateKeyWithPassphrase(pemBytes, []byte(k.Passphrase))
+		} else {
+			signer, err = ssh.ParsePrivateKey(pemBytes)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("parse private key: %w", err)
+		}
+		signers = append(signers, signer)
+	}
+
+	return signers, nil
 }
 
 func BastionAvailability(sshProviderInitializer *providerinitializer.SSHProviderInitializer) preflight.Check {

--- a/dhctl/pkg/preflight/checks/bastion.go
+++ b/dhctl/pkg/preflight/checks/bastion.go
@@ -1,0 +1,121 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checks
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	sshconfig "github.com/deckhouse/lib-connection/pkg/ssh/config"
+	"github.com/deckhouse/lib-connection/pkg/ssh/session"
+
+	preflight "github.com/deckhouse/deckhouse/dhctl/pkg/preflight"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/system/providerinitializer"
+)
+
+const BastionAvailabilityCheckName preflight.CheckName = "bastion-availability"
+
+const defaultBastionPort = "22"
+
+type BastionAvailabilityCheck struct {
+	SSHProviderInitializer *providerinitializer.SSHProviderInitializer
+}
+
+func (c BastionAvailabilityCheck) Description() string {
+	connCfg := c.SSHProviderInitializer.GetConfig()
+	if connCfg == nil || !bastionConfigured(connCfg.Config) {
+		return "no bastion configured, skipping bastion availability check"
+	}
+
+	return "ssh connection to the bastion host is possible"
+}
+
+func (BastionAvailabilityCheck) Phase() preflight.Phase {
+	return preflight.PhasePreInfra
+}
+
+func (BastionAvailabilityCheck) RetryPolicy() preflight.RetryPolicy {
+	return preflight.DefaultRetryPolicy
+}
+
+func bastionConfigured(cfg *sshconfig.Config) bool {
+	return cfg != nil && cfg.BastionHost != ""
+}
+
+func bastionPort(cfg *sshconfig.Config) string {
+	if cfg == nil || cfg.BastionPort == nil {
+		return defaultBastionPort
+	}
+	return cfg.BastionPortString()
+}
+
+func (c BastionAvailabilityCheck) Run(ctx context.Context) error {
+	connCfg := c.SSHProviderInitializer.GetConfig()
+	if connCfg == nil || !bastionConfigured(connCfg.Config) {
+		// No bastion configured: nothing to validate, pass silently.
+		return nil
+	}
+
+	sshCfg := connCfg.Config
+	host := sshCfg.BastionHost
+	port := bastionPort(sshCfg)
+
+	sshProvider, err := c.SSHProviderInitializer.GetSSHProvider(ctx)
+	if err != nil && !errors.Is(err, providerinitializer.ErrHostsFromCacheNotFound) {
+		return fmt.Errorf("cannot initialize ssh provider: %w", err)
+	}
+	if sshProvider == nil {
+		return fmt.Errorf("ssh provider is not available")
+	}
+
+	sess := session.NewSession(session.Input{
+		User:       sshCfg.BastionUser,
+		Port:       port,
+		BecomePass: sshCfg.BastionPassword,
+	})
+	sess.AddAvailableHosts(session.Host{Host: host})
+
+	client, err := sshProvider.NewStandaloneClient(ctx, sess, nil)
+	if err != nil {
+		return fmt.Errorf("cannot create ssh client for bastion host %s:%s: %w", host, port, err)
+	}
+	defer client.Stop()
+
+	// Start performs TCP connect + SSH handshake + user authentication to the
+	// bastion (transport only, no session/exec channel).
+	if err := client.Start(); err != nil {
+		return fmt.Errorf("cannot connect to bastion host %s:%s: %w", host, port, err)
+	}
+
+	// dhctl uses the bastion only as a ProxyJump (direct-tcpip forwarding)
+	// and never runs commands on it.
+	// We do NOT exec a probe command here —
+	// a hardened bastion may permit forwarding while denying
+	// shell/exec (ForceCommand, no-pty, command="..." in authorized_keys, a
+	// restricted/kill shell), and such a bastion is still valid for our use.
+	return nil
+}
+
+func BastionAvailability(sshProviderInitializer *providerinitializer.SSHProviderInitializer) preflight.Check {
+	check := BastionAvailabilityCheck{SSHProviderInitializer: sshProviderInitializer}
+	return preflight.Check{
+		Name:        BastionAvailabilityCheckName,
+		Description: check.Description(),
+		Phase:       check.Phase(),
+		Retry:       check.RetryPolicy(),
+		Run:         check.Run,
+	}
+}

--- a/dhctl/pkg/preflight/checks/bastion.go
+++ b/dhctl/pkg/preflight/checks/bastion.go
@@ -57,10 +57,11 @@ func (BastionAvailabilityCheck) Phase() preflight.Phase {
 
 func (BastionAvailabilityCheck) RetryPolicy() preflight.RetryPolicy {
 	return preflight.RetryPolicy{
-		Attempts: 1,
+		Attempts: 15,
 		Options: []backoff.ExponentialBackOffOpts{
 			backoff.WithInitialInterval(time.Second),
 			backoff.WithMultiplier(2),
+			backoff.WithMaxInterval(5 * time.Second),
 			backoff.WithMaxElapsedTime(0),
 		},
 	}

--- a/dhctl/pkg/preflight/checks/bastion_test.go
+++ b/dhctl/pkg/preflight/checks/bastion_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checks
+
+import (
+	"testing"
+
+	sshconfig "github.com/deckhouse/lib-connection/pkg/ssh/config"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/system/providerinitializer"
+)
+
+func TestBastionAvailabilityDescription(t *testing.T) {
+	const withBastionDesc = "ssh connection to the bastion host is possible"
+	const noBastionDesc = "no bastion configured, skipping bastion availability check"
+
+	tests := []struct {
+		name string
+		cfg  *sshconfig.ConnectionConfig
+		want string
+	}{
+		{"bastion set", &sshconfig.ConnectionConfig{Config: &sshconfig.Config{BastionHost: "10.0.0.1"}}, withBastionDesc},
+		{"no bastion", &sshconfig.ConnectionConfig{Config: &sshconfig.Config{}}, noBastionDesc},
+		{"nil inner config", &sshconfig.ConnectionConfig{}, noBastionDesc},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			init := providerinitializer.NewSSHProviderInitializer(nil, tt.cfg)
+			check := BastionAvailabilityCheck{SSHProviderInitializer: init}
+			if got := check.Description(); got != tt.want {
+				t.Errorf("Description() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBastionConfigured(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *sshconfig.Config
+		want bool
+	}{
+		{"nil config", nil, false},
+		{"empty bastion host", &sshconfig.Config{}, false},
+		{"bastion host set", &sshconfig.Config{BastionHost: "10.0.0.1"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := bastionConfigured(tt.cfg); got != tt.want {
+				t.Errorf("bastionConfigured() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBastionPort(t *testing.T) {
+	port := 2222
+	tests := []struct {
+		name string
+		cfg  *sshconfig.Config
+		want string
+	}{
+		{"nil config", nil, "22"},
+		{"nil port defaults to 22", &sshconfig.Config{BastionHost: "h"}, "22"},
+		{"port set", &sshconfig.Config{BastionHost: "h", BastionPort: &port}, "2222"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := bastionPort(tt.cfg); got != tt.want {
+				t.Errorf("bastionPort() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/dhctl/pkg/preflight/suites/cloud.go
+++ b/dhctl/pkg/preflight/suites/cloud.go
@@ -18,11 +18,13 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
 	preflight "github.com/deckhouse/deckhouse/dhctl/pkg/preflight"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/preflight/checks"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/system/providerinitializer"
 )
 
 type CloudDeps struct {
-	InstallConfig *config.DeckhouseInstaller
-	MetaConfig    *config.MetaConfig
+	InstallConfig          *config.DeckhouseInstaller
+	MetaConfig             *config.MetaConfig
+	SSHProviderInitializer *providerinitializer.SSHProviderInitializer
 }
 
 func NewCloudSuite(deps CloudDeps) preflight.Suite {
@@ -30,5 +32,6 @@ func NewCloudSuite(deps CloudDeps) preflight.Suite {
 		checks.CloudDiskNameLength(deps.MetaConfig),
 		checks.CloudSystemRequirements(deps.InstallConfig),
 		checks.InstanceClassProvider(deps.MetaConfig),
+		checks.BastionAvailability(deps.SSHProviderInitializer),
 	)
 }

--- a/dhctl/pkg/preflight/suites/static.go
+++ b/dhctl/pkg/preflight/suites/static.go
@@ -41,6 +41,7 @@ func NewStaticSuite(deps StaticDeps, ctx context.Context) (preflight.Suite, erro
 		checks.CidrIntersectionStatic(deps.MetaConfig),
 		checks.StaticInstancesIPDuplication(deps.MetaConfig),
 		checks.SingleSSHHost(deps.SSHProviderInitializer),
+		checks.BastionAvailability(deps.SSHProviderInitializer),
 		checks.SSHCredential(deps.SSHProviderInitializer),
 		checks.SSHTunnel(deps.SSHProviderInitializer, deps.GlobalOpts),
 		checks.StaticInstancesSSHCredentials(deps.MetaConfig, deps.SSHProviderInitializer),


### PR DESCRIPTION
## Description

Adds a new dhctl preflight check **`bastion-availability`** that verifies the installer can open and authenticate an SSH connection **directly to the configured bastion (jump) host** before bootstrap proceeds.

- Runs at the **pre-infra** phase in **both** the static and cloud bootstrap paths (registered in `NewStaticSuite` and `NewCloudSuite`). In cloud, the target master is unknown pre-infra, so the check tolerates `ErrHostsFromCacheNotFound` and connects to the bastion only.
- Connects to the bastion as the destination (no ProxyJump), reusing the connection config's prepared keys/agent and mapping `sshBastionPassword` into the auth, so it covers key, agent, and password-auth bastions.
- Validates **connection + authentication only** (transport handshake via `client.Start()`); it does **not** exec a command on the bastion, so a hardened bastion that permits forwarding while denying shell/exec (`ForceCommand`, `no-pty`, restricted/kill shell) is not falsely failed.
- When no bastion is configured, the check passes and its description states the bastion path was not exercised.
- Skippable via `--preflight-skip-check bastion-availability`.

## Why do we need it, and what problem does it solve?

Before this, the only bastion validation was the full-chain `static-ssh-credential` check, which authenticates to the **target host through the bastion** in a single `ssh -J` chain and runs **post-infra**. On failure an operator could not tell **which hop broke** — the bastion (unreachable / wrong credentials) or the target — and only learned about it late, as one opaque chain error.

This check **isolates the bastion hop** and **fails fast pre-infra** with a clear, bastion-specific message, so a misconfigured bastion is caught before any infrastructure is provisioned.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: dhctl
type: feature
summary: Add a `bastion-availability` preflight check that verifies SSH connectivity and authentication to the configured bastion host before bootstrap (static and cloud).
impact_level: low
```
