### PR TITLE
[cloud-provider-huaweicloud] bump CAPI version to v1.12

### DIFF
--- a/ee/modules/030-cloud-provider-huaweicloud/images/caphc-controller-manager/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/images/caphc-controller-manager/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $version := "v0.6.2" }}
+{{- $version := "fix/machine-initialization-provisioned" }}
 {{- $version_common := "v0.8.0" }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}

--- a/ee/modules/030-cloud-provider-huaweicloud/images/caphc-controller-manager/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/images/caphc-controller-manager/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $version := "fix/machine-initialization-provisioned" }}
+{{- $version := "v0.6.4" }}
 {{- $version_common := "v0.8.0" }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}


### PR DESCRIPTION
## Description
Bump `caphc-controller-manager` image tag `v0.6.2` → `v0.6.4`.

`v0.6.3` adds `status.initialization.provisioned` on `HuaweiCloudMachine`
when the VM reaches `ACTIVE` state — the missing piece of the CAPI v1.12
initialization contract (cluster side was already implemented).

The fork was migrated to `cluster-api v1.12.2` / `api/core/v1beta2` earlier;
this tag finalizes that work.

## Why do we need it, and what problem does it solve?
`cluster-api v1.12` requires infrastructure providers to set
`status.initialization.provisioned = true` on both Cluster and Machine objects
before proceeding with node bootstrapping. Without `HuaweiCloudMachine`
setting this field, new nodes would never join the cluster.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-huaweicloud
type: feature
summary: Bumped the CAPI provider to cluster-api v1.12 and fixed the Machine initialization contract.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
