### PR TITLE
[istio] Tweak waypoint rolling update strategy

### DIFF
--- a/ee/modules/110-istio/images/waypoint-controller/src/internal/waypointcontroller/controller_integration_test.go
+++ b/ee/modules/110-istio/images/waypoint-controller/src/internal/waypointcontroller/controller_integration_test.go
@@ -379,6 +379,19 @@ func TestWaypointInstanceLifecycle(t *testing.T) {
 		if dep.Spec.Template.Spec.Affinity == nil || dep.Spec.Template.Spec.Affinity.PodAntiAffinity == nil {
 			t.Errorf("expected pod anti-affinity for replicas >= 2")
 		}
+		// Verify the hardcoded one-at-a-time rolling update strategy.
+		if dep.Spec.Strategy.Type != appsv1.RollingUpdateDeploymentStrategyType {
+			t.Errorf("deployment strategy type = %q, want RollingUpdate", dep.Spec.Strategy.Type)
+		}
+		if dep.Spec.Strategy.RollingUpdate == nil {
+			t.Fatal("expected RollingUpdate config")
+		}
+		if dep.Spec.Strategy.RollingUpdate.MaxSurge == nil || dep.Spec.Strategy.RollingUpdate.MaxSurge.IntVal != 1 {
+			t.Errorf("expected maxSurge = 1, got %v", dep.Spec.Strategy.RollingUpdate.MaxSurge)
+		}
+		if dep.Spec.Strategy.RollingUpdate.MaxUnavailable == nil || dep.Spec.Strategy.RollingUpdate.MaxUnavailable.IntVal != 1 {
+			t.Errorf("expected maxUnavailable = 1, got %v", dep.Spec.Strategy.RollingUpdate.MaxUnavailable)
+		}
 	})
 
 	t.Run("create/Service-ports", func(t *testing.T) {

--- a/ee/modules/110-istio/images/waypoint-controller/src/internal/waypointcontroller/deployment.go
+++ b/ee/modules/110-istio/images/waypoint-controller/src/internal/waypointcontroller/deployment.go
@@ -12,7 +12,9 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	networkv1alpha1 "waypoint-controller/pkg/apis/network.deckhouse.io/v1alpha1"
@@ -131,6 +133,15 @@ func (r *WaypointController) mutateDeployment(deploy *appsv1.Deployment, instanc
 		return err
 	}
 	deploy.Spec.Template.Spec = podSpec
+
+	// Use a predictable one-pod-at-a-time rolling update strategy.
+	deploy.Spec.Strategy = appsv1.DeploymentStrategy{
+		Type: appsv1.RollingUpdateDeploymentStrategyType,
+		RollingUpdate: &appsv1.RollingUpdateDeployment{
+			MaxSurge:       ptr.To(intstr.FromInt32(1)),
+			MaxUnavailable: ptr.To(intstr.FromInt32(1)),
+		},
+	}
 
 	if err := controllerutil.SetControllerReference(instance, deploy, r.scheme); err != nil {
 		return err


### PR DESCRIPTION
## Description

Set an explicit rolling update strategy (`maxSurge=1`, `maxUnavailable=1`) on waypoint proxy Deployments created by the waypoint controller. Previously the strategy was left to the default, which could lead to multiple waypoint pods being replaced simultaneously, causing brief connectivity gaps for workloads using ambient mode.

With this change, waypoint proxies are updated one pod at a time — the controller waits for the new pod to become ready before terminating the old one.

## Why do we need it, and what problem does it solve?

Waypoint proxies act as the L4 entry point for ambient-mode traffic in a namespace. When a waypoint Deployment is rolling-updated (e.g. on a configuration change or image update), Kubernetes' default rolling update strategy may terminate multiple old pods before the new ones are ready, temporarily dropping traffic for all services in that namespace.

By pinning `maxSurge=1` and `maxUnavailable=1`, we ensure a predictable one-at-a-time rollout that preserves availability of the waypoint proxy throughout the update.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: chore
summary: Set one-at-a-time rolling update strategy (maxSurge=1, maxUnavailable=1) for waypoint proxy Deployments.
impact_level: low
```