### PR TITLE
[istio] Add webhook validating WaypointInstance

### DIFF
--- a/ee/modules/110-istio/webhooks/validating/waypointinstances
+++ b/ee/modules/110-istio/webhooks/validating/waypointinstances
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 Flant JSC
+# Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+
+source /shell_lib.sh
+
+function __config__() {
+  cat <<EOF
+configVersion: v1
+kubernetes:
+- name: istio_mc
+  group: main
+  executeHookOnEvent: []
+  executeHookOnSynchronization: false
+  keepFullObjectsInMemory: false
+  apiVersion: deckhouse.io/v1alpha1
+  kind: ModuleConfig
+  nameSelector:
+    matchNames:
+    - istio
+  jqFilter: |
+    {
+      "ambientEnabled": .spec.settings.ambient.enabled,
+    }
+kubernetesValidating:
+- name: waypointinstances.network.deckhouse.io
+  group: main
+  includeSnapshotsFrom: ["istio_mc"]
+  rules:
+  - apiGroups:   ["network.deckhouse.io"]
+    apiVersions: ["v1alpha1"]
+    operations:  ["CREATE"]
+    resources:   ["waypointinstances"]
+    scope:       "Namespaced"
+EOF
+}
+
+function __main__() {
+  ambient_enabled=$(context::jq -r '.snapshots.istio_mc[]?.filterResult.ambientEnabled')
+  if [ "$ambient_enabled" != "true" ]; then
+    jq -nc '
+    {
+      "allowed": false,
+      "message": "WaypointInstance can only be created when ambient mesh is enabled. Enable spec.settings.ambient.enabled in the istio ModuleConfig."
+    }
+    ' > $VALIDATING_RESPONSE_PATH
+    exit 0
+  fi
+
+  jq -nc '{"allowed": true}' >"$VALIDATING_RESPONSE_PATH"
+}
+
+hook::run "$@"


### PR DESCRIPTION
## Description

Added a new Kubernetes validating webhook for `WaypointInstance` resources.

The webhook intercepts `CREATE` operations on `WaypointInstance` resources and rejects them if ambient mesh is not enabled in the `istio` `ModuleConfig` (`spec.settings.ambient.enabled`).

## Why do we need it, and what problem does it solve?

Creating a `WaypointInstance` without ambient mesh enabled in the istio ModuleConfig is invalid - waypoint proxies are a feature of ambient mesh and have no meaning without it. Previously, a user could create a `WaypointInstance` and only discover the mismatch later at runtime, leading to confusion. This webhook provides immediate feedback at admission time, preventing invalid configurations early and guiding the user to the correct ModuleConfig setting.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: feature
summary: Add validating webhook for WaypointInstance to require ambient mesh to be enabled.
impact_level: low
```