### PR TITLE
[istio] Add orphan waypoint alert

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -1706,6 +1706,36 @@ alerts:
         Prometheus can't scrape metrics of image-availability-exporter.
       severity: "8"
       markupFormat: markdown
+    - name: D8IstioActiveWaypointsWithAmbientDisabled
+      sourceFile: ee/modules/110-istio/monitoring/prometheus-rules/ambient.tpl
+      moduleUrl: 110-istio
+      module: istio
+      edition: ee
+      description: |
+        Deckhouse has detected an active waypoint Deployment `{{$labels.deployment}}` in namespace `{{$labels.namespace}}`, created for WaypointInstance `{{$labels.waypoint_instance}}`, while ambient mesh is disabled.
+
+        This usually happens if ambient mesh was enabled, a WaypointInstance was created, and then ambient mesh was disabled. In this state the waypoint-controller is not running, so it cannot reconcile or clean up WaypointInstance resources.
+
+        To inspect affected resources, run:
+
+        ```bash
+        d8 k -n {{$labels.namespace}} get waypointinstance {{$labels.waypoint_instance}} -o yaml
+        d8 k -n {{$labels.namespace}} get deploy,svc,sa,gateway,pdb,hpa,vpa -l istio.deckhouse.io/waypoint-instance={{$labels.waypoint_instance}}
+        ```
+
+        Recommended remediation:
+
+        1. Temporarily enable ambient mesh.
+        2. Wait until waypoint-controller starts.
+        3. Delete the affected WaypointInstance or change configuration as needed.
+        4. Wait until managed waypoint resources are reconciled as needed or removed.
+        5. Disable ambient mesh again.
+
+        If ambient mesh cannot be re-enabled, manually remove the managed waypoint resources and then remove the WaypointInstance finalizer only after verifying that no managed resources remain.
+      summary: |
+        Active Istio waypoint exists while ambient mesh is disabled.
+      severity: "6"
+      markupFormat: markdown
     - name: D8IstioActualDataPlaneVersionNotEqualDesired
       sourceFile: ee/modules/110-istio/monitoring/prometheus-rules/dataplane.yaml
       moduleUrl: 110-istio
@@ -7547,5 +7577,5 @@ modules-having-alerts:
     - terraform-manager
     - upmeter
     - user-authn
-    - vertical-pod-autoscaler
     - user-authz
+    - vertical-pod-autoscaler

--- a/ee/modules/110-istio/monitoring/prometheus-rules/ambient.tpl
+++ b/ee/modules/110-istio/monitoring/prometheus-rules/ambient.tpl
@@ -1,0 +1,53 @@
+{{- if not .Values.istio.ambient.enabled }}
+- name: d8.istio.ambient
+  rules:
+    - alert: D8IstioActiveWaypointsWithAmbientDisabled
+      expr: |
+        max by (namespace, deployment, waypoint_instance) (
+          label_replace(
+            kube_deployment_labels{
+              label_app="d8-waypoint",
+              label_heritage="deckhouse",
+              label_istio_deckhouse_io_waypoint_instance!="",
+              label_gateway_istio_io_managed="istio.io-mesh-controller"
+            },
+            "waypoint_instance",
+            "$1",
+            "label_istio_deckhouse_io_waypoint_instance",
+            "(.+)"
+          )
+          * on (namespace, deployment) group_left()
+            (kube_deployment_spec_replicas > 0)
+        )
+      for: 5m
+      labels:
+        severity_level: "6"
+        tier: cluster
+      annotations:
+        plk_markup_format: markdown
+        plk_protocol_version: "1"
+        plk_create_group_if_not_exists__d8_istio_ambient_misconfigurations: D8IstioAmbientMisconfigurations,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+        plk_grouped_by__d8_istio_ambient_misconfigurations: D8IstioAmbientMisconfigurations,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+        summary: Active Istio waypoint exists while ambient mesh is disabled.
+        description: |
+          Deckhouse has detected an active waypoint Deployment `{{"{{$labels.deployment}}"}}` in namespace `{{"{{$labels.namespace}}"}}`, created for WaypointInstance `{{"{{$labels.waypoint_instance}}"}}`, while ambient mesh is disabled.
+
+          This usually happens if ambient mesh was enabled, a WaypointInstance was created, and then ambient mesh was disabled. In this state the waypoint-controller is not running, so it cannot reconcile or clean up WaypointInstance resources.
+
+          To inspect affected resources, run:
+
+          ```bash
+          d8 k -n {{"{{$labels.namespace}}"}} get waypointinstance {{"{{$labels.waypoint_instance}}"}} -o yaml
+          d8 k -n {{"{{$labels.namespace}}"}} get deploy,svc,sa,gateway,pdb,hpa,vpa -l istio.deckhouse.io/waypoint-instance={{"{{$labels.waypoint_instance}}"}}
+          ```
+
+          Recommended remediation:
+
+          1. Temporarily enable ambient mesh.
+          2. Wait until waypoint-controller starts.
+          3. Delete the affected WaypointInstance or change configuration as needed.
+          4. Wait until managed waypoint resources are reconciled as needed or removed.
+          5. Disable ambient mesh again.
+
+          If ambient mesh cannot be re-enabled, manually remove the managed waypoint resources and then remove the WaypointInstance finalizer only after verifying that no managed resources remain.
+{{- end }}

--- a/tools/build_includes/modules-tests-CSE.yaml
+++ b/tools/build_includes/modules-tests-CSE.yaml
@@ -798,6 +798,11 @@
   stageDependencies:
     install:
         - '**/*'
+- add: /ee/modules/110-istio/monitoring/prometheus-rules/ambient.tpl
+  to: /deckhouse/modules/110-istio/monitoring/prometheus-rules/ambient.tpl
+  stageDependencies:
+    install:
+        - '**/*'
 - add: /ee/modules/110-istio/monitoring/prometheus-rules/dataplane.yaml
   to: /deckhouse/modules/110-istio/monitoring/prometheus-rules/dataplane.yaml
   stageDependencies:

--- a/tools/build_includes/modules-tests-EE.yaml
+++ b/tools/build_includes/modules-tests-EE.yaml
@@ -1012,6 +1012,11 @@
   stageDependencies:
     install:
         - '**/*'
+- add: /ee/modules/110-istio/monitoring/prometheus-rules/ambient.tpl
+  to: /deckhouse/modules/110-istio/monitoring/prometheus-rules/ambient.tpl
+  stageDependencies:
+    install:
+        - '**/*'
 - add: /ee/modules/110-istio/monitoring/prometheus-rules/dataplane.yaml
   to: /deckhouse/modules/110-istio/monitoring/prometheus-rules/dataplane.yaml
   stageDependencies:

--- a/tools/build_includes/modules-tests-FE.yaml
+++ b/tools/build_includes/modules-tests-FE.yaml
@@ -1012,6 +1012,11 @@
   stageDependencies:
     install:
         - '**/*'
+- add: /ee/modules/110-istio/monitoring/prometheus-rules/ambient.tpl
+  to: /deckhouse/modules/110-istio/monitoring/prometheus-rules/ambient.tpl
+  stageDependencies:
+    install:
+        - '**/*'
 - add: /ee/modules/110-istio/monitoring/prometheus-rules/dataplane.yaml
   to: /deckhouse/modules/110-istio/monitoring/prometheus-rules/dataplane.yaml
   stageDependencies:

--- a/tools/build_includes/modules-with-exclude-CSE.yaml
+++ b/tools/build_includes/modules-with-exclude-CSE.yaml
@@ -1086,6 +1086,11 @@
   stageDependencies:
     install:
         - '**/*'
+- add: /ee/modules/110-istio/monitoring/prometheus-rules/ambient.tpl
+  to: /deckhouse/modules/110-istio/monitoring/prometheus-rules/ambient.tpl
+  stageDependencies:
+    install:
+        - '**/*'
 - add: /ee/modules/110-istio/monitoring/prometheus-rules/dataplane.yaml
   to: /deckhouse/modules/110-istio/monitoring/prometheus-rules/dataplane.yaml
   stageDependencies:

--- a/tools/build_includes/modules-with-exclude-EE.yaml
+++ b/tools/build_includes/modules-with-exclude-EE.yaml
@@ -1395,6 +1395,11 @@
   stageDependencies:
     install:
         - '**/*'
+- add: /ee/modules/110-istio/monitoring/prometheus-rules/ambient.tpl
+  to: /deckhouse/modules/110-istio/monitoring/prometheus-rules/ambient.tpl
+  stageDependencies:
+    install:
+        - '**/*'
 - add: /ee/modules/110-istio/monitoring/prometheus-rules/dataplane.yaml
   to: /deckhouse/modules/110-istio/monitoring/prometheus-rules/dataplane.yaml
   stageDependencies:

--- a/tools/build_includes/modules-with-exclude-FE.yaml
+++ b/tools/build_includes/modules-with-exclude-FE.yaml
@@ -1395,6 +1395,11 @@
   stageDependencies:
     install:
         - '**/*'
+- add: /ee/modules/110-istio/monitoring/prometheus-rules/ambient.tpl
+  to: /deckhouse/modules/110-istio/monitoring/prometheus-rules/ambient.tpl
+  stageDependencies:
+    install:
+        - '**/*'
 - add: /ee/modules/110-istio/monitoring/prometheus-rules/dataplane.yaml
   to: /deckhouse/modules/110-istio/monitoring/prometheus-rules/dataplane.yaml
   stageDependencies:

--- a/tools/helm_generate/runners/alert_templates/template_values/110-istio.yaml
+++ b/tools/helm_generate/runners/alert_templates/template_values/110-istio.yaml
@@ -4,3 +4,6 @@ global:
     https:
       mode: Disabled
   deckhouseVersion: v1
+istio:
+  ambient:
+    enabled: false


### PR DESCRIPTION
## Description

Add a Prometheus alert that detects orphan Istio waypoint Deployments — active waypoint resources that remain in the cluster after ambient mesh has been disabled.

## Why do we need it, and what problem does it solve?

When ambient mesh is enabled, a WaypointInstance is created, and then ambient mesh is disabled, the waypoint-controller stops running. This leaves orphaned waypoint Deployments (and associated resources like Services, ServiceAccounts, etc.) in the cluster with no reconciler to clean them up. These stale resources can cause confusion and waste cluster resources.

The new alert `D8IstioActiveWaypointsWithAmbientDisabled` fires when active waypoint Deployments exist while ambient mesh is disabled.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: feature
summary: Add alert for orphan waypoint Deployments when ambient mesh is disabled.
impact_level: low
```