### PR TITLE
[common] Fix CVE-2026-40898 in CoreDNS

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -7507,5 +7507,5 @@ modules-having-alerts:
     - terraform-manager
     - upmeter
     - user-authn
-    - vertical-pod-autoscaler
     - user-authz
+    - vertical-pod-autoscaler

--- a/modules/000-common/images/coredns/patches/go-mod.patch
+++ b/modules/000-common/images/coredns/patches/go-mod.patch
@@ -1,5 +1,5 @@
 diff --git a/go.mod b/go.mod
-index b83633d..bdfa066 100644
+index b83633d..40ca099 100644
 --- a/go.mod
 +++ b/go.mod
 @@ -18,7 +18,7 @@ require (
@@ -11,7 +11,13 @@ index b83633d..bdfa066 100644
  	github.com/farsightsec/golang-framestream v0.3.0
  	github.com/go-logr/logr v1.4.3
  	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645
-@@ -38,10 +38,10 @@ require (
+@@ -33,15 +33,15 @@ require (
+ 	github.com/prometheus/client_golang v1.23.0
+ 	github.com/prometheus/client_model v0.6.2
+ 	github.com/prometheus/common v0.67.4
+-	github.com/quic-go/quic-go v0.57.0
++	github.com/quic-go/quic-go v0.59.1
+ 	github.com/stretchr/testify v1.11.1
  	go.etcd.io/etcd/api/v3 v3.6.6
  	go.etcd.io/etcd/client/v3 v3.6.6
  	go.uber.org/automaxprocs v1.6.0
@@ -68,7 +74,7 @@ index b83633d..bdfa066 100644
  	gopkg.in/inf.v0 v0.9.1 // indirect
  	gopkg.in/ini.v1 v1.67.0 // indirect
 diff --git a/go.sum b/go.sum
-index 59fe8a0..1d5211a 100644
+index 59fe8a0..01dfe32 100644
 --- a/go.sum
 +++ b/go.sum
 @@ -138,8 +138,8 @@ github.com/ebitengine/purego v0.8.4 h1:CF7LEKg5FFOsASUj0+QwaXf8Ht6TlFxg09+S9wz0o
@@ -82,6 +88,17 @@ index 59fe8a0..1d5211a 100644
  github.com/farsightsec/golang-framestream v0.3.0 h1:/spFQHucTle/ZIPkYqrfshQqPe2VQEzesH243TjIwqA=
  github.com/farsightsec/golang-framestream v0.3.0/go.mod h1:eNde4IQyEiA5br02AouhEHCu3p3UzrCdFR4LuQHklMI=
  github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
+@@ -321,8 +321,8 @@ github.com/puzpuzpuz/xsync/v3 v3.5.1 h1:GJYJZwO6IdxN/IKbneznS6yPkVC+c3zyY/j19c++
+ github.com/puzpuzpuz/xsync/v3 v3.5.1/go.mod h1:VjzYrABPabuM4KyBh1Ftq6u8nhwY5tBPKP9jpmh0nnA=
+ github.com/quic-go/qpack v0.6.0 h1:g7W+BMYynC1LbYLSqRt8PBg5Tgwxn214ZZR34VIOjz8=
+ github.com/quic-go/qpack v0.6.0/go.mod h1:lUpLKChi8njB4ty2bFLX2x4gzDqXwUpaO1DP9qMDZII=
+-github.com/quic-go/quic-go v0.57.0 h1:AsSSrrMs4qI/hLrKlTH/TGQeTMY0ib1pAOX7vA3AdqE=
+-github.com/quic-go/quic-go v0.57.0/go.mod h1:ly4QBAjHA2VhdnxhojRsCUOeJwKYg+taDlos92xb1+s=
++github.com/quic-go/quic-go v0.59.1 h1:0Gmua0HW1Tv7ANR7hUYwRyD0MG5OJfgvYSZasGZzBic=
++github.com/quic-go/quic-go v0.59.1/go.mod h1:upnsH4Ju1YkqpLXC305eW3yDZ4NfnNbmQRCMWS58IKU=
+ github.com/richardartoul/molecule v1.0.1-0.20240531184615-7ca0df43c0b3 h1:4+LEVOB87y175cLJC/mbsgKmoDOjrBldtXvioEy96WY=
+ github.com/richardartoul/molecule v1.0.1-0.20240531184615-7ca0df43c0b3/go.mod h1:vl5+MqJ1nBINuSsUI2mGgH79UweUT/B5Fy8857PqyyI=
+ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 @@ -415,20 +415,20 @@ go.opentelemetry.io/contrib/bridges/otelzap v0.12.0 h1:FGre0nZh5BSw7G73VpT3xs38H
  go.opentelemetry.io/contrib/bridges/otelzap v0.12.0/go.mod h1:X2PYPViI2wTPIMIOBjG17KNybTzsrATnvPJ02kkz7LM=
  go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 h1:F7Jx+6hwnZ41NSFTO5q4LYDtJRXBf2PD0rNBkeB/lus=


### PR DESCRIPTION
## Description

Bump the `quic-go` dependency in CoreDNS to `v0.59.1` to fix CVE-2026-40898.

## Why do we need it, and what problem does it solve?

This PR addresses the CVE-2026-40898 vulnerability found in the `quic-go` library, which is used by CoreDNS.

## Why do we need it in the patch release (if we do)?

This is a critical security fix that must be delivered to users as quickly as possible via a patch release to mitigate potential exploitation risks.

## Checklist

- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: common
type: fix
summary: Fixed CVE-2026-40898 in CoreDNS by updating the quic-go dependency.
```