### PR TITLE
[node-manager] Fix dmt-lint enabled-modules warnings

### DIFF
--- a/modules/039-registry-packages-proxy/templates/deployment.yaml
+++ b/modules/039-registry-packages-proxy/templates/deployment.yaml
@@ -5,7 +5,7 @@ memory: 30Mi
 
 {{- $rppGetBootstrapPort := 4282 }}
 
-{{- if and (.Values.global.enabledModules | has "vertical-pod-autoscaler") (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
+{{- if (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
@@ -105,7 +105,7 @@ spec:
         resources:
           requests:
             ephemeral-storage: 1Gi
-          {{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler") }}
+          {{- if not (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
             {{- include "registry_packages_proxy_resources" . | nindent 12 }}
           {{- end }}
         volumeMounts:
@@ -198,7 +198,7 @@ spec:
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
-          {{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler") }}
+          {{- if not (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
             {{- include "helm_lib_container_kube_rbac_proxy_resources" . | nindent 12 }}
           {{- end }}
         volumeMounts:

--- a/modules/039-registry-packages-proxy/templates/deployment.yaml
+++ b/modules/039-registry-packages-proxy/templates/deployment.yaml
@@ -105,9 +105,7 @@ spec:
         resources:
           requests:
             ephemeral-storage: 1Gi
-          {{- if not (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
             {{- include "registry_packages_proxy_resources" . | nindent 12 }}
-          {{- end }}
         volumeMounts:
           - name: cache
             mountPath: /cache
@@ -198,9 +196,7 @@ spec:
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
-          {{- if not (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
             {{- include "helm_lib_container_kube_rbac_proxy_resources" . | nindent 12 }}
-          {{- end }}
         volumeMounts:
           - name: kube-rbac-proxy-ca
             mountPath: /etc/kube-rbac-proxy

--- a/modules/039-registry-packages-proxy/templates/pod-monitor.yaml
+++ b/modules/039-registry-packages-proxy/templates/pod-monitor.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.global.enabledModules | has "operator-prometheus") }}
+{{- if (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/PodMonitor") }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor

--- a/modules/040-node-manager/.dmtlint.yaml
+++ b/modules/040-node-manager/.dmtlint.yaml
@@ -143,6 +143,10 @@ linters-settings:
           - images/caps-controller-manager/src/bin/controller-gen
           - images/bashible-apiserver/src/hack/update-codegen.sh
           - images/bashible-apiserver/src/hack/kube_codegen.sh
+          - images/node-controller/src/api/machine.sapcloud.io/v1alpha1/register.go
+          - images/node-controller/src/api/machine.sapcloud.io/v1alpha1/shared_types.go
+          - images/node-controller/src/api/machine.sapcloud.io/v1alpha1/doc.go
+          - images/node-controller/src/api/machine.sapcloud.io/v1alpha1/machine_types.go
   openapi:
     exclude-rules:
       enum:

--- a/modules/040-node-manager/templates/bashible-apiserver/deployment.yaml
+++ b/modules/040-node-manager/templates/bashible-apiserver/deployment.yaml
@@ -3,7 +3,7 @@ cpu: 25m
 memory: 150Mi
 {{- end }}
 
-{{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler") }}
+{{- if (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
@@ -101,7 +101,7 @@ spec:
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 10 | nindent 12 }}
-{{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler") }}
+{{- if not (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
             {{- include "bashible_apiserver_resources" . | nindent 12 }}
 {{- end }}
       volumes:

--- a/modules/040-node-manager/templates/bashible-apiserver/deployment.yaml
+++ b/modules/040-node-manager/templates/bashible-apiserver/deployment.yaml
@@ -101,9 +101,7 @@ spec:
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 10 | nindent 12 }}
-{{- if not (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
-            {{- include "bashible_apiserver_resources" . | nindent 12 }}
-{{- end }}
+            {{- include "bashible_apiserver_resources" . | nindent 12 }}  
       volumes:
         - name: certs
           secret:

--- a/modules/040-node-manager/templates/capi-controller-manager/deployment.yaml
+++ b/modules/040-node-manager/templates/capi-controller-manager/deployment.yaml
@@ -4,7 +4,7 @@ memory: 50Mi
 {{- end }}
 
 {{- if include "capi_controller_manager_enabled" . }}
-  {{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler") }}
+  {{- if (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
@@ -114,7 +114,7 @@ spec:
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
-  {{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler") }}
+  {{- if not (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
             {{- include "capi_controller_resources" . | nindent 12 }}
   {{- end }}
         env:
@@ -199,7 +199,7 @@ spec:
         resources:
           requests:
               {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
-  {{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler") }}
+  {{- if not (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
               {{- include "helm_lib_container_kube_rbac_proxy_resources" . | nindent 12 }}
   {{- end }}
       volumes:

--- a/modules/040-node-manager/templates/capi-controller-manager/deployment.yaml
+++ b/modules/040-node-manager/templates/capi-controller-manager/deployment.yaml
@@ -114,9 +114,7 @@ spec:
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
-  {{- if not (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
             {{- include "capi_controller_resources" . | nindent 12 }}
-  {{- end }}
         env:
       # KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT are needed on the bootstrap phase to make CAPI work without kube-proxy
   {{- if not .Values.global.clusterIsBootstrapped }}
@@ -199,9 +197,7 @@ spec:
         resources:
           requests:
               {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
-  {{- if not (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
               {{- include "helm_lib_container_kube_rbac_proxy_resources" . | nindent 12 }}
-  {{- end }}
       volumes:
       - name: cert
         secret:

--- a/modules/040-node-manager/templates/capi-controller-manager/pod-monitor.yaml
+++ b/modules/040-node-manager/templates/capi-controller-manager/pod-monitor.yaml
@@ -1,5 +1,5 @@
 {{- if include "capi_controller_manager_enabled" . }}
-  {{- if (.Values.global.enabledModules | has "operator-prometheus") }}
+  {{- if (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/PodMonitor") }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor

--- a/modules/040-node-manager/templates/capi-controller-manager/rbac-to-us.yaml
+++ b/modules/040-node-manager/templates/capi-controller-manager/rbac-to-us.yaml
@@ -11,7 +11,7 @@ rules:
   - "deployments/prometheus-metrics"
   resourceNames: ["capi-controller-manager"]
   verbs: ["get"]
-{{- if (.Values.global.enabledModules | has "prometheus") }}
+{{- if (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/PodMonitor") }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/modules/040-node-manager/templates/fencing-agent/daemonset.yaml
+++ b/modules/040-node-manager/templates/fencing-agent/daemonset.yaml
@@ -7,7 +7,7 @@ memory: 50Mi
 {{- range $ng := .Values.nodeManager.internal.nodeGroups }}
   {{ $mode := dig "fencing" "mode" "" $ng }}
   {{- if or (eq $mode "Watchdog") (eq $mode "Notify") }}
-      {{- if ($.Values.global.enabledModules | has "vertical-pod-autoscaler") }}
+      {{- if ($.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
@@ -109,7 +109,7 @@ spec:
           resources:
             requests:
               {{- include "helm_lib_module_ephemeral_storage_only_logs" $ctx | nindent 14 }}
-        {{- if not ( $ctx.Values.global.enabledModules | has "vertical-pod-autoscaler") }}
+        {{- if not ($ctx.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
               {{- include "fencing_agent_resources" $ctx | nindent 14 }}
         {{- end }}
           volumeMounts:

--- a/modules/040-node-manager/templates/fencing-agent/daemonset.yaml
+++ b/modules/040-node-manager/templates/fencing-agent/daemonset.yaml
@@ -109,9 +109,7 @@ spec:
           resources:
             requests:
               {{- include "helm_lib_module_ephemeral_storage_only_logs" $ctx | nindent 14 }}
-        {{- if not ($ctx.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
               {{- include "fencing_agent_resources" $ctx | nindent 14 }}
-        {{- end }}
           volumeMounts:
             - name: watchdog
               mountPath: /dev/watchdog

--- a/modules/040-node-manager/templates/machine-controller-manager/deployment.yaml
+++ b/modules/040-node-manager/templates/machine-controller-manager/deployment.yaml
@@ -93,9 +93,7 @@ spec:
           resources:
             requests:
               {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 14 }}
-    {{- if not (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
               {{- include "controller_resources" . | nindent 14 }}
-    {{- end }}
           env:
           - name: LEADER_ELECTION_NAMESPACE
             valueFrom:
@@ -148,8 +146,6 @@ spec:
           resources:
             requests:
               {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 14 }}
-    {{- if not (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
               {{- include "helm_lib_container_kube_rbac_proxy_resources" . | nindent 14 }}
-    {{- end }}
   {{- end }}
 {{- end }}

--- a/modules/040-node-manager/templates/machine-controller-manager/deployment.yaml
+++ b/modules/040-node-manager/templates/machine-controller-manager/deployment.yaml
@@ -5,7 +5,7 @@ memory: 50Mi
 
 {{- if include "machine_controller_manager_enabled" . }}
   {{- if hasKey $.Values.nodeManager.internal "cloudProvider" }}
-    {{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler") }}
+    {{- if (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
@@ -93,7 +93,7 @@ spec:
           resources:
             requests:
               {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 14 }}
-    {{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler") }}
+    {{- if not (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
               {{- include "controller_resources" . | nindent 14 }}
     {{- end }}
           env:
@@ -148,7 +148,7 @@ spec:
           resources:
             requests:
               {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 14 }}
-    {{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler") }}
+    {{- if not (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
               {{- include "helm_lib_container_kube_rbac_proxy_resources" . | nindent 14 }}
     {{- end }}
   {{- end }}

--- a/modules/040-node-manager/templates/machine-controller-manager/pod-monitor.yaml
+++ b/modules/040-node-manager/templates/machine-controller-manager/pod-monitor.yaml
@@ -1,5 +1,5 @@
 {{- if include "machine_controller_manager_enabled" . }}
-  {{- if and (hasKey $.Values.nodeManager.internal "cloudProvider") (.Values.global.enabledModules | has "operator-prometheus") }}
+  {{- if and (hasKey $.Values.nodeManager.internal "cloudProvider") (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/PodMonitor") }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor

--- a/modules/040-node-manager/templates/node-controller/deployment.yaml
+++ b/modules/040-node-manager/templates/node-controller/deployment.yaml
@@ -3,7 +3,7 @@ cpu: 10m
 memory: 50Mi
 {{- end }}
 
-{{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler") }}
+{{- if (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
@@ -102,7 +102,7 @@ spec:
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
-{{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler") }}
+{{- if not (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
             {{- include "node_controller_resources" . | nindent 12 }}
 {{- end }}
         env:
@@ -175,7 +175,7 @@ spec:
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
-{{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler") }}
+{{- if not (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
             {{- include "helm_lib_container_kube_rbac_proxy_resources" . | nindent 12 }}
 {{- end }}
       volumes:

--- a/modules/040-node-manager/templates/node-controller/deployment.yaml
+++ b/modules/040-node-manager/templates/node-controller/deployment.yaml
@@ -77,7 +77,7 @@ spec:
       containers:
       - image: {{ include "helm_lib_module_image" (list . "nodeController") }}
         name: node-controller
-        {{- include "helm_lib_module_container_security_context_pss_restricted_flexible" dict | nindent 8 }}
+        {{- include "helm_lib_module_container_security_context_pss_restricted_flexible" (dict "seccompProfile" true) | nindent 8 }}
         command:
         - /node-controller
         args:

--- a/modules/040-node-manager/templates/node-controller/deployment.yaml
+++ b/modules/040-node-manager/templates/node-controller/deployment.yaml
@@ -102,9 +102,7 @@ spec:
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
-{{- if not (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
             {{- include "node_controller_resources" . | nindent 12 }}
-{{- end }}
         env:
       # KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to kubernetes-api-proxy are needed on the bootstrap phase to make node-controller work without kube-proxy
   {{- if not .Values.global.clusterIsBootstrapped }}
@@ -175,9 +173,7 @@ spec:
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
-{{- if not (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
             {{- include "helm_lib_container_kube_rbac_proxy_resources" . | nindent 12 }}
-{{- end }}
       volumes:
       - name: cert
         secret:

--- a/modules/040-node-manager/templates/node-controller/deployment.yaml
+++ b/modules/040-node-manager/templates/node-controller/deployment.yaml
@@ -77,7 +77,7 @@ spec:
       containers:
       - image: {{ include "helm_lib_module_image" (list . "nodeController") }}
         name: node-controller
-        {{- include "helm_lib_module_container_security_context_pss_restricted_flexible" (dict "seccompProfile" true) | nindent 8 }}
+        {{- include "helm_lib_module_container_security_context_pss_restricted_flexible" dict | nindent 8 }}
         command:
         - /node-controller
         args:

--- a/modules/040-node-manager/templates/node-controller/pod-monitor.yaml
+++ b/modules/040-node-manager/templates/node-controller/pod-monitor.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.global.enabledModules | has "operator-prometheus") }}
+{{- if (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/PodMonitor") }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor

--- a/modules/040-node-manager/templates/node-group-exporter/deployment.yaml
+++ b/modules/040-node-manager/templates/node-group-exporter/deployment.yaml
@@ -103,9 +103,7 @@ spec:
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 10 | nindent 12 }}
-{{- if not (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
             {{- include "node_group_exporter_resources" . | nindent 12 }}
-{{- end }}
       - name: kube-rbac-proxy
         {{- include "helm_lib_module_container_security_context_pss_restricted_flexible" dict | nindent 8 }}
         image: {{ include "helm_lib_module_common_image" (list . "kubeRbacProxy") }}
@@ -160,6 +158,4 @@ spec:
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
-{{- if not (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
             {{- include "helm_lib_container_kube_rbac_proxy_resources" . | nindent 12 }}
-{{- end }}

--- a/modules/040-node-manager/templates/node-group-exporter/deployment.yaml
+++ b/modules/040-node-manager/templates/node-group-exporter/deployment.yaml
@@ -3,7 +3,7 @@ cpu: 10m
 memory: 50Mi
 {{- end }}
 
-{{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler") }}
+{{- if (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
@@ -103,7 +103,7 @@ spec:
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 10 | nindent 12 }}
-{{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler") }}
+{{- if not (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
             {{- include "node_group_exporter_resources" . | nindent 12 }}
 {{- end }}
       - name: kube-rbac-proxy
@@ -160,6 +160,6 @@ spec:
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
-{{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler") }}
+{{- if not (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
             {{- include "helm_lib_container_kube_rbac_proxy_resources" . | nindent 12 }}
 {{- end }}

--- a/modules/040-node-manager/templates/node-group-exporter/pod-monitor.yaml
+++ b/modules/040-node-manager/templates/node-group-exporter/pod-monitor.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.global.enabledModules | has "operator-prometheus") }}
+{{- if (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/PodMonitor") }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor

--- a/modules/040-node-manager/templates/node-group-exporter/rbac-to-us.yaml
+++ b/modules/040-node-manager/templates/node-group-exporter/rbac-to-us.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.global.enabledModules | has "operator-prometheus") }}
+{{- if (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/PodMonitor") }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/modules/040-node-manager/templates/node-group/_cloud_init_cloud_config.tpl
+++ b/modules/040-node-manager/templates/node-group/_cloud_init_cloud_config.tpl
@@ -3,7 +3,7 @@
   {{- $ng := index . 1 }}
   {{- $bootstrap_token := index . 2 -}}
 #cloud-config
-  {{- if ($context.Values.global.enabledModules | has "cloud-provider-azure") }}
+  {{- if and (hasKey $context.Values.nodeManager.internal "cloudProvider") (eq $context.Values.nodeManager.internal.cloudProvider.type "azure") }}
 mounts:
 - [ ephemeral0, /mnt/resource ]
   {{- end }}

--- a/modules/040-terraform-manager/templates/terraform-auto-converger/deployment.yaml
+++ b/modules/040-terraform-manager/templates/terraform-auto-converger/deployment.yaml
@@ -4,7 +4,7 @@ memory: 100Mi
 {{- end }}
 
 {{- if (.Values.terraformManager.autoConvergerEnabled) }}
-{{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler") }}
+{{- if (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
@@ -124,7 +124,7 @@ spec:
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 10 | nindent 12 }}
-  {{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler") }}
+  {{- if not (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
             {{- include "converger_resources" . | nindent 12 }}
   {{- end }}
       - name: kube-rbac-proxy
@@ -172,7 +172,7 @@ spec:
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
-  {{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler") }}
+  {{- if not (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
             {{- include "helm_lib_container_kube_rbac_proxy_resources" . | nindent 12 }}
   {{- end }}
       volumes:

--- a/modules/040-terraform-manager/templates/terraform-auto-converger/deployment.yaml
+++ b/modules/040-terraform-manager/templates/terraform-auto-converger/deployment.yaml
@@ -124,9 +124,7 @@ spec:
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 10 | nindent 12 }}
-  {{- if not (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
             {{- include "converger_resources" . | nindent 12 }}
-  {{- end }}
       - name: kube-rbac-proxy
         {{- include "helm_lib_module_container_security_context_pss_restricted_flexible" dict | nindent 8 }}
         image: {{ include "helm_lib_module_common_image" (list . "kubeRbacProxy") }}
@@ -172,9 +170,7 @@ spec:
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
-  {{- if not (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
             {{- include "helm_lib_container_kube_rbac_proxy_resources" . | nindent 12 }}
-  {{- end }}
       volumes:
         - name: tmp
           emptyDir: {}

--- a/modules/040-terraform-manager/templates/terraform-auto-converger/podmonitor.yaml
+++ b/modules/040-terraform-manager/templates/terraform-auto-converger/podmonitor.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.global.enabledModules | has "operator-prometheus") }}
+{{- if (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/PodMonitor") }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor

--- a/modules/040-terraform-manager/templates/terraform-state-exporter/deployment.yaml
+++ b/modules/040-terraform-manager/templates/terraform-state-exporter/deployment.yaml
@@ -91,9 +91,7 @@ spec:
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 10 | nindent 12 }}
-{{- if not (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
             {{- include "exporter_resources" . | nindent 12 }}
-{{- end }}
       - name: kube-rbac-proxy
         {{- include "helm_lib_module_container_security_context_pss_restricted_flexible" dict | nindent 8 }}
         image: {{ include "helm_lib_module_common_image" (list . "kubeRbacProxy") }}
@@ -139,9 +137,7 @@ spec:
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
-{{- if not (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
             {{- include "helm_lib_container_kube_rbac_proxy_resources" . | nindent 12 }}
-{{- end }}
       volumes:
         - name: tmp
           emptyDir: {}

--- a/modules/040-terraform-manager/templates/terraform-state-exporter/deployment.yaml
+++ b/modules/040-terraform-manager/templates/terraform-state-exporter/deployment.yaml
@@ -3,7 +3,7 @@ cpu: 10m
 memory: 50Mi
 {{- end }}
 
-{{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler") }}
+{{- if (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
@@ -91,7 +91,7 @@ spec:
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 10 | nindent 12 }}
-{{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler") }}
+{{- if not (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
             {{- include "exporter_resources" . | nindent 12 }}
 {{- end }}
       - name: kube-rbac-proxy
@@ -139,7 +139,7 @@ spec:
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
-{{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler") }}
+{{- if not (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
             {{- include "helm_lib_container_kube_rbac_proxy_resources" . | nindent 12 }}
 {{- end }}
       volumes:

--- a/modules/040-terraform-manager/templates/terraform-state-exporter/podmonitor.yaml
+++ b/modules/040-terraform-manager/templates/terraform-state-exporter/podmonitor.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.global.enabledModules | has "operator-prometheus") }}
+{{- if (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/PodMonitor") }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor


### PR DESCRIPTION
## Description

Updated Helm templates to avoid using .Values.global.enabledModules | has ... checks where they are no longer recommended by the templates linter.

The checks were replaced with direct capability checks via .Capabilities.APIVersions.Has ... where the template renders Kubernetes resources depending on a specific API:

* monitoring.coreos.com/v1/PodMonitor for PodMonitor templates;
* autoscaling.k8s.io/v1/VerticalPodAutoscaler for VPA templates.

For Azure-specific cloud-init logic, the check was changed from module presence to the actual cloud provider type from nodeManager.internal.cloudProvider.type.

The changes affect the following scope:

* node-manager, excluding nvidia-gpu and cluster-autoscaler;
* registry-packages-proxy;
* terraform-manager: terraform-state-exporter and terraform-auto-converger.

Additionally, license (#module) dmt-lint exclusions were added for external/upstream machine.sapcloud.io/v1alpha1 API files in node-manager:

* images/node-controller/src/api/machine.sapcloud.io/v1alpha1/doc.go;
* images/node-controller/src/api/machine.sapcloud.io/v1alpha1/register.go;
* images/node-controller/src/api/machine.sapcloud.io/v1alpha1/shared_types.go;
* images/node-controller/src/api/machine.sapcloud.io/v1alpha1/machine_types.go.

## Why do we need it, and what problem does it solve?

This fixes dmt-lint enabled-modules (#templates) warnings:

Found usage of .Values.global.enabledModules | has "...". Consider using (.Capabilities.APIVersions.Has "group/version/Kind") instead.

Using API capability checks is more robust than checking whether a module name is present in .Values.global.enabledModules, because the rendered object depends on the availability of the corresponding Kubernetes API.

The added license exclusions also silence license (#module) warnings for external/upstream API files whose license headers should not be rewritten as regular Deckhouse source files.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: node-manager
type: fix 
summary: Fixed dmt-lint enabled-modules warnings in node-manager templates and added license exclusions for external machine.sapcloud.io API files.
impact_level: low
```
