### PR TITLE
[deckhouse] fix consistent package counts in PackageRepositoryOperation and PackageRepository status

### DIFF
--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/operation-service.go
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/operation-service.go
@@ -169,9 +169,6 @@ func (s *OperationService) UpdateRepositoryStatus(ctx context.Context, packages 
 		if pkgType == "" {
 			pkgType = cachedTypes[pkg.Name]
 		}
-		if pkgType == "" {
-			continue
-		}
 		s.repo.Status.Packages = append(s.repo.Status.Packages, v1alpha1.PackageRepositoryStatusPackage{
 			Name: pkg.Name,
 			Type: pkgType,

--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/invalid-package-type.yaml
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/invalid-package-type.yaml
@@ -59,5 +59,9 @@ status:
     type: LastScanSucceeded
   lastNewVersions: 0
   lastScanTime: "2025-10-31T12:00:00Z"
+  packages:
+  - name: test-package
+    type: ""
+  packagesCount: 1
   partialScanAvailable: false
   phase: Active

--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/legacy-module.yaml
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/legacy-module.yaml
@@ -59,5 +59,9 @@ status:
     type: LastScanSucceeded
   lastNewVersions: 0
   lastScanTime: "2025-10-31T12:00:00Z"
+  packages:
+  - name: test-package
+    type: ""
+  packagesCount: 1
   partialScanAvailable: false
   phase: Active

--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/old-image-no-metadata.yaml
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/old-image-no-metadata.yaml
@@ -59,5 +59,9 @@ status:
     type: LastScanSucceeded
   lastNewVersions: 0
   lastScanTime: "2025-10-31T12:00:00Z"
+  packages:
+  - name: test-package
+    type: ""
+  packagesCount: 1
   partialScanAvailable: false
   phase: Active

--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/successful-discovery.yaml
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/successful-discovery.yaml
@@ -54,5 +54,9 @@ status:
     type: LastScanSucceeded
   lastNewVersions: 0
   lastScanTime: "2025-10-31T12:00:00Z"
+  packages:
+  - name: test-package
+    type: ""
+  packagesCount: 1
   partialScanAvailable: false
   phase: Active


### PR DESCRIPTION
## Description

### Why do we need it, and what problem does it solve?

Fix an inconsistency where `PackageRepositoryOperation.status.packages` shows all processed packages (e.g. 26), but `PackageRepository.status.packages` shows fewer (e.g. 21).

Root cause: `UpdateRepositoryStatus` skipped packages with empty `Type` via `continue` when no cached type existed from a previous scan. Packages whose type could not be determined (no labels, no package.yaml, or invalid type value) were counted in the operation status but silently dropped from the repository status.

### What has been done

- Removed the `continue` that filtered out packages with empty package type in `UpdateRepositoryStatus`
- Package type is still recovered from previous repository status (`cachedTypes`) when the current scan returns empty type

## Example

Cluster data before and after the fix (repository `test`, 26 packages in registry):

**Old operation (before fix)** — 26 processed, repository shows only 21 because 5 packages with undetermined type were filtered by `continue`:

```json
// Operation: test-scan-1781215749 (old binary)
{
  "processed": 26,
  "types": [
    { "type": null,  "count": 25 },
    { "type": "Module", "count": 1  }
  ]
}

// Repository: test
{
  "packagesCount": 21,
  "types": [
    { "type": "Application", "count": 20 },
    { "type": "Module",      "count": 1  }
  ]
}
```

**After fix (new scan)** — 26 processed, repository now shows 26. The 5 packages that had no cached type are included in the repository status with `type: ""`:

```json
// New operation after fix: test-scan-1781791620
{
  "processed": 26,
  "types": [
    { "type": null,       "count": 24 },
    { "type": "Application", "count": 1 },
    { "type": "Module",      "count": 1 }
  ]
}

// Repository: test (after fix)
{
  "packagesCount": 26,
  "types": [
    { "type": "",          "count": 5  },
    { "type": "Application", "count": 20 },
    { "type": "Module",      "count": 1  }
  ]
}
```

The counts are now consistent: 26 in both the operation and the repository.

## Checklist

- [x] The code is covered by unit tests.
- [x] Changes were tested in the Kubernetes cluster manually.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.

## Changelog entries

```changes
section: deckhouse-controller
type: fix
summary: Fix inconsistent package count between PackageRepositoryOperation and PackageRepository status
impact_level: low
```