### PR TITLE
[cloud-provider-openstack] Add patch for skipping node deletion and set SKIP_NODE_DELETION=1 in CCM Deployment

### DIFF
--- a/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/patches/1.30/003-skip-node-deletion.patch
+++ b/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/patches/1.30/003-skip-node-deletion.patch
@@ -1,0 +1,15 @@
+diff --git a/pkg/openstack/instances.go b/pkg/openstack/instances.go
+index a78e9305..c4b8e9f1 100644
+--- a/pkg/openstack/instances.go
++++ b/pkg/openstack/instances.go
+@@ -276,6 +276,10 @@ func instanceExistsByProviderID(ctx context.Context, compute *gophercloud.ServiceC
+ 	_, err = servers.Get(ctx, compute, instanceID).Extract()
+ 	if mc.ObserveRequest(err) != nil {
+ 		if errors.IsNotFound(err) {
++			if _, ok := sysos.LookupEnv("SKIP_NODE_DELETION"); ok {
++				klog.V(4).Infof("instanceExistsByProviderID(%v) not found, SKIP_NODE_DELETION is set, preventing deletion", providerID)
++				return false, cloudprovider.InstanceNotFound
++			}
+ 			return false, nil
+ 		}
+ 		return false, err

--- a/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/patches/1.30/README.md
+++ b/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/patches/1.30/README.md
@@ -5,3 +5,7 @@ This patch is for our case when we want to have a static Nodes in the cluster, m
 ## 002-fix-cve.patch
 
 Bump some go.mod deps to fix known CVEs
+
+## 003-skip-node-deletion.patch
+
+When `SKIP_NODE_DELETION` is set, `InstanceExists` returns an error instead of `(false, nil)` if the OpenStack instance is not found. This prevents `cloud-node-lifecycle` from deleting the Kubernetes Node while keeping shutdown taint handling enabled.

--- a/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/patches/1.30/README.md
+++ b/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/patches/1.30/README.md
@@ -8,4 +8,13 @@ Bump some go.mod deps to fix known CVEs
 
 ## 003-skip-node-deletion.patch
 
-When `SKIP_NODE_DELETION` is set, `InstanceExists` returns an error instead of `(false, nil)` if the OpenStack instance is not found. This prevents `cloud-node-lifecycle` from deleting the Kubernetes Node while keeping shutdown taint handling enabled.
+When `SKIP_NODE_DELETION` is set, `InstanceExists` returns an error instead of `(false, nil)` if the OpenStack instance is not found. 
+This prevents `cloud-node-lifecycle` from deleting the Kubernetes Node while keeping shutdown taint handling enabled.
+
+Planned Node deletion is not affected — those components remove Nodes directly through Kubernetes API, bypassing CCM:
+
+- Nodes of type **CloudPermanent** — `dhctl` removes Nodes during converge.
+- Nodes of type **CloudEphemeral (MCM engine)** — MCM removes the Node on Machine deletion.
+- Nodes of type **CloudEphemeral (CAPI engine)** — CAPI controller removes the Node on Machine deletion.
+
+Nodes that remain in the `NotReady` state for an extended period can be tracked using the `K8SNodeNotReady` alert — it fires when a node is `NotReady` for more than 10 minutes.

--- a/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/patches/1.31/003-skip-node-deletion.patch
+++ b/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/patches/1.31/003-skip-node-deletion.patch
@@ -1,0 +1,15 @@
+diff --git a/pkg/openstack/instances.go b/pkg/openstack/instances.go
+index a78e9305..c4b8e9f1 100644
+--- a/pkg/openstack/instances.go
++++ b/pkg/openstack/instances.go
+@@ -276,6 +276,10 @@ func instanceExistsByProviderID(ctx context.Context, compute *gophercloud.ServiceC
+ 	_, err = servers.Get(ctx, compute, instanceID).Extract()
+ 	if mc.ObserveRequest(err) != nil {
+ 		if errors.IsNotFound(err) {
++			if _, ok := sysos.LookupEnv("SKIP_NODE_DELETION"); ok {
++				klog.V(4).Infof("instanceExistsByProviderID(%v) not found, SKIP_NODE_DELETION is set, preventing deletion", providerID)
++				return false, cloudprovider.InstanceNotFound
++			}
+ 			return false, nil
+ 		}
+ 		return false, err

--- a/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/patches/1.31/README.md
+++ b/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/patches/1.31/README.md
@@ -5,3 +5,7 @@ This patch is for our case when we want to have a static Nodes in the cluster, m
 ## 002-fix-cve.patch
 
 Bump some go.mod deps to fix known CVEs
+
+## 003-skip-node-deletion.patch
+
+When `SKIP_NODE_DELETION` is set, `InstanceExists` returns an error instead of `(false, nil)` if the OpenStack instance is not found. This prevents `cloud-node-lifecycle` from deleting the Kubernetes Node while keeping shutdown taint handling enabled.

--- a/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/patches/1.31/README.md
+++ b/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/patches/1.31/README.md
@@ -8,4 +8,13 @@ Bump some go.mod deps to fix known CVEs
 
 ## 003-skip-node-deletion.patch
 
-When `SKIP_NODE_DELETION` is set, `InstanceExists` returns an error instead of `(false, nil)` if the OpenStack instance is not found. This prevents `cloud-node-lifecycle` from deleting the Kubernetes Node while keeping shutdown taint handling enabled.
+When `SKIP_NODE_DELETION` is set, `InstanceExists` returns an error instead of `(false, nil)` if the OpenStack instance is not found.
+This prevents `cloud-node-lifecycle` from deleting the Kubernetes Node while keeping shutdown taint handling enabled.
+
+Planned Node deletion is not affected — those components remove Nodes directly through Kubernetes API, bypassing CCM:
+
+- Nodes of type **CloudPermanent** — `dhctl` removes Nodes during converge.
+- Nodes of type **CloudEphemeral (MCM engine)** — MCM removes the Node on Machine deletion.
+- Nodes of type **CloudEphemeral (CAPI engine)** — CAPI controller removes the Node on Machine deletion.
+
+Nodes that remain in the `NotReady` state for an extended period can be tracked using the `K8SNodeNotReady` alert — it fires when a node is `NotReady` for more than 10 minutes.

--- a/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/patches/1.32/003-skip-node-deletion.patch
+++ b/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/patches/1.32/003-skip-node-deletion.patch
@@ -1,0 +1,15 @@
+diff --git a/pkg/openstack/instances.go b/pkg/openstack/instances.go
+index 285cad55..6c46ecf7 100644
+--- a/pkg/openstack/instances.go
++++ b/pkg/openstack/instances.go
+@@ -91,6 +91,10 @@ func (i *InstancesV2) InstanceExists(ctx context.Context, node *v1.Node) (bool,
+ 	}
+ 	_, err := i.getInstance(ctx, node)
+ 	if err == cloudprovider.InstanceNotFound {
++		if _, ok := sysos.LookupEnv("SKIP_NODE_DELETION"); ok {
++			klog.V(4).Infof("instance not found for node: %s, SKIP_NODE_DELETION is set, preventing deletion", node.Name)
++			return false, err
++		}
+ 		klog.V(6).Infof("instance not found for node: %s", node.Name)
+ 		return false, nil
+ 	}

--- a/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/patches/1.32/README.md
+++ b/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/patches/1.32/README.md
@@ -5,3 +5,7 @@ This patch is for our case when we want to have a static Nodes in the cluster, m
 ## 002-fix-cve.patch
 
 Bump some go.mod deps to fix known CVEs
+
+## 003-skip-node-deletion.patch
+
+When `SKIP_NODE_DELETION` is set, `InstanceExists` returns an error instead of `(false, nil)` if the OpenStack instance is not found. This prevents `cloud-node-lifecycle` from deleting the Kubernetes Node while keeping shutdown taint handling enabled.

--- a/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/patches/1.32/README.md
+++ b/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/patches/1.32/README.md
@@ -8,4 +8,13 @@ Bump some go.mod deps to fix known CVEs
 
 ## 003-skip-node-deletion.patch
 
-When `SKIP_NODE_DELETION` is set, `InstanceExists` returns an error instead of `(false, nil)` if the OpenStack instance is not found. This prevents `cloud-node-lifecycle` from deleting the Kubernetes Node while keeping shutdown taint handling enabled.
+When `SKIP_NODE_DELETION` is set, `InstanceExists` returns an error instead of `(false, nil)` if the OpenStack instance is not found.
+This prevents `cloud-node-lifecycle` from deleting the Kubernetes Node while keeping shutdown taint handling enabled.
+
+Planned Node deletion is not affected — those components remove Nodes directly through Kubernetes API, bypassing CCM:
+
+- Nodes of type **CloudPermanent** — `dhctl` removes Nodes during converge.
+- Nodes of type **CloudEphemeral (MCM engine)** — MCM removes the Node on Machine deletion.
+- Nodes of type **CloudEphemeral (CAPI engine)** — CAPI controller removes the Node on Machine deletion.
+
+Nodes that remain in the `NotReady` state for an extended period can be tracked using the `K8SNodeNotReady` alert — it fires when a node is `NotReady` for more than 10 minutes.

--- a/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/patches/1.33/003-skip-node-deletion.patch
+++ b/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/patches/1.33/003-skip-node-deletion.patch
@@ -1,0 +1,15 @@
+diff --git a/pkg/openstack/instances.go b/pkg/openstack/instances.go
+index 026dba1b..bf357c22 100644
+--- a/pkg/openstack/instances.go
++++ b/pkg/openstack/instances.go
+@@ -92,6 +92,10 @@ func (i *InstancesV2) InstanceExists(ctx context.Context, node *v1.Node) (bool,
+ 
+ 	_, err := i.getInstance(ctx, node)
+ 	if err == cloudprovider.InstanceNotFound {
++		if _, ok := sysos.LookupEnv("SKIP_NODE_DELETION"); ok {
++			klog.V(4).Infof("instance not found for node: %s, SKIP_NODE_DELETION is set, preventing deletion", node.Name)
++			return false, err
++		}
+ 		klog.V(6).Infof("instance not found for node: %s", node.Name)
+ 		return false, nil
+ 	}

--- a/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/patches/1.33/README.md
+++ b/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/patches/1.33/README.md
@@ -5,3 +5,7 @@ This patch is for our case when we want to have a static Nodes in the cluster, m
 ## 002-fix-cve.patch
 
 Bump some go.mod deps to fix known CVEs
+
+## 003-skip-node-deletion.patch
+
+When `SKIP_NODE_DELETION` is set, `InstanceExists` returns an error instead of `(false, nil)` if the OpenStack instance is not found. This prevents `cloud-node-lifecycle` from deleting the Kubernetes Node while keeping shutdown taint handling enabled.

--- a/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/patches/1.33/README.md
+++ b/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/patches/1.33/README.md
@@ -8,4 +8,13 @@ Bump some go.mod deps to fix known CVEs
 
 ## 003-skip-node-deletion.patch
 
-When `SKIP_NODE_DELETION` is set, `InstanceExists` returns an error instead of `(false, nil)` if the OpenStack instance is not found. This prevents `cloud-node-lifecycle` from deleting the Kubernetes Node while keeping shutdown taint handling enabled.
+When `SKIP_NODE_DELETION` is set, `InstanceExists` returns an error instead of `(false, nil)` if the OpenStack instance is not found.
+This prevents `cloud-node-lifecycle` from deleting the Kubernetes Node while keeping shutdown taint handling enabled.
+
+Planned Node deletion is not affected — those components remove Nodes directly through Kubernetes API, bypassing CCM:
+
+- Nodes of type **CloudPermanent** — `dhctl` removes Nodes during converge.
+- Nodes of type **CloudEphemeral (MCM engine)** — MCM removes the Node on Machine deletion.
+- Nodes of type **CloudEphemeral (CAPI engine)** — CAPI controller removes the Node on Machine deletion.
+
+Nodes that remain in the `NotReady` state for an extended period can be tracked using the `K8SNodeNotReady` alert — it fires when a node is `NotReady` for more than 10 minutes.

--- a/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/patches/1.34/003-skip-node-deletion.patch
+++ b/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/patches/1.34/003-skip-node-deletion.patch
@@ -1,0 +1,15 @@
+diff --git a/pkg/openstack/instances.go b/pkg/openstack/instances.go
+index 026dba1b..bf357c22 100644
+--- a/pkg/openstack/instances.go
++++ b/pkg/openstack/instances.go
+@@ -92,6 +92,10 @@ func (i *InstancesV2) InstanceExists(ctx context.Context, node *v1.Node) (bool,
+ 
+ 	_, err := i.getInstance(ctx, node)
+ 	if err == cloudprovider.InstanceNotFound {
++		if _, ok := sysos.LookupEnv("SKIP_NODE_DELETION"); ok {
++			klog.V(4).Infof("instance not found for node: %s, SKIP_NODE_DELETION is set, preventing deletion", node.Name)
++			return false, err
++		}
+ 		klog.V(6).Infof("instance not found for node: %s", node.Name)
+ 		return false, nil
+ 	}

--- a/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/patches/1.34/README.md
+++ b/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/patches/1.34/README.md
@@ -5,3 +5,7 @@ This patch is for our case when we want to have a static Nodes in the cluster, m
 ## 002-fix-cve.patch
 
 Bump some go.mod deps to fix known CVEs
+
+## 003-skip-node-deletion.patch
+
+When `SKIP_NODE_DELETION` is set, `InstanceExists` returns an error instead of `(false, nil)` if the OpenStack instance is not found. This prevents `cloud-node-lifecycle` from deleting the Kubernetes Node while keeping shutdown taint handling enabled.

--- a/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/patches/1.34/README.md
+++ b/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/patches/1.34/README.md
@@ -8,4 +8,13 @@ Bump some go.mod deps to fix known CVEs
 
 ## 003-skip-node-deletion.patch
 
-When `SKIP_NODE_DELETION` is set, `InstanceExists` returns an error instead of `(false, nil)` if the OpenStack instance is not found. This prevents `cloud-node-lifecycle` from deleting the Kubernetes Node while keeping shutdown taint handling enabled.
+When `SKIP_NODE_DELETION` is set, `InstanceExists` returns an error instead of `(false, nil)` if the OpenStack instance is not found.
+This prevents `cloud-node-lifecycle` from deleting the Kubernetes Node while keeping shutdown taint handling enabled.
+
+Planned Node deletion is not affected — those components remove Nodes directly through Kubernetes API, bypassing CCM:
+
+- Nodes of type **CloudPermanent** — `dhctl` removes Nodes during converge.
+- Nodes of type **CloudEphemeral (MCM engine)** — MCM removes the Node on Machine deletion.
+- Nodes of type **CloudEphemeral (CAPI engine)** — CAPI controller removes the Node on Machine deletion.
+
+Nodes that remain in the `NotReady` state for an extended period can be tracked using the `K8SNodeNotReady` alert — it fires when a node is `NotReady` for more than 10 minutes.

--- a/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/patches/1.35/003-skip-node-deletion.patch
+++ b/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/patches/1.35/003-skip-node-deletion.patch
@@ -1,0 +1,15 @@
+diff --git a/pkg/openstack/instances.go b/pkg/openstack/instances.go
+index 026dba1b..bf357c22 100644
+--- a/pkg/openstack/instances.go
++++ b/pkg/openstack/instances.go
+@@ -92,6 +92,10 @@ func (i *InstancesV2) InstanceExists(ctx context.Context, node *v1.Node) (bool,
+ 
+ 	_, err := i.getInstance(ctx, node)
+ 	if err == cloudprovider.InstanceNotFound {
++		if _, ok := sysos.LookupEnv("SKIP_NODE_DELETION"); ok {
++			klog.V(4).Infof("instance not found for node: %s, SKIP_NODE_DELETION is set, preventing deletion", node.Name)
++			return false, err
++		}
+ 		klog.V(6).Infof("instance not found for node: %s", node.Name)
+ 		return false, nil
+ 	}

--- a/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/patches/1.35/README.md
+++ b/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/patches/1.35/README.md
@@ -5,3 +5,7 @@ This patch is for our case when we want to have a static Nodes in the cluster, m
 ## 002-fix-cve.patch
 
 Bump some go.mod deps to fix known CVEs
+
+## 003-skip-node-deletion.patch
+
+When `SKIP_NODE_DELETION` is set, `InstanceExists` returns an error instead of `(false, nil)` if the OpenStack instance is not found. This prevents `cloud-node-lifecycle` from deleting the Kubernetes Node while keeping shutdown taint handling enabled.

--- a/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/patches/1.35/README.md
+++ b/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/patches/1.35/README.md
@@ -8,4 +8,13 @@ Bump some go.mod deps to fix known CVEs
 
 ## 003-skip-node-deletion.patch
 
-When `SKIP_NODE_DELETION` is set, `InstanceExists` returns an error instead of `(false, nil)` if the OpenStack instance is not found. This prevents `cloud-node-lifecycle` from deleting the Kubernetes Node while keeping shutdown taint handling enabled.
+When `SKIP_NODE_DELETION` is set, `InstanceExists` returns an error instead of `(false, nil)` if the OpenStack instance is not found.
+This prevents `cloud-node-lifecycle` from deleting the Kubernetes Node while keeping shutdown taint handling enabled.
+
+Planned Node deletion is not affected — those components remove Nodes directly through Kubernetes API, bypassing CCM:
+
+- Nodes of type **CloudPermanent** — `dhctl` removes Nodes during converge.
+- Nodes of type **CloudEphemeral (MCM engine)** — MCM removes the Node on Machine deletion.
+- Nodes of type **CloudEphemeral (CAPI engine)** — CAPI controller removes the Node on Machine deletion.
+
+Nodes that remain in the `NotReady` state for an extended period can be tracked using the `K8SNodeNotReady` alert — it fires when a node is `NotReady` for more than 10 minutes.

--- a/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/patches/1.36/002-skip-node-deletion.patch
+++ b/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/patches/1.36/002-skip-node-deletion.patch
@@ -1,0 +1,15 @@
+diff --git a/pkg/openstack/instances.go b/pkg/openstack/instances.go
+index 026dba1b..bf357c22 100644
+--- a/pkg/openstack/instances.go
++++ b/pkg/openstack/instances.go
+@@ -92,6 +92,10 @@ func (i *InstancesV2) InstanceExists(ctx context.Context, node *v1.Node) (bool,
+ 
+ 	_, err := i.getInstance(ctx, node)
+ 	if err == cloudprovider.InstanceNotFound {
++		if _, ok := sysos.LookupEnv("SKIP_NODE_DELETION"); ok {
++			klog.V(4).Infof("instance not found for node: %s, SKIP_NODE_DELETION is set, preventing deletion", node.Name)
++			return false, err
++		}
+ 		klog.V(6).Infof("instance not found for node: %s", node.Name)
+ 		return false, nil
+ 	}

--- a/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/patches/1.36/README.md
+++ b/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/patches/1.36/README.md
@@ -1,3 +1,7 @@
 ## 001-ignore-static-nodes.patch
 
 This patch is for our case when we want to have a static Nodes in the cluster, managed by openstack cloud provider.
+
+## 002-skip-node-deletion.patch
+
+When `SKIP_NODE_DELETION` is set, `InstanceExists` returns an error instead of `(false, nil)` if the OpenStack instance is not found. This prevents `cloud-node-lifecycle` from deleting the Kubernetes Node while keeping shutdown taint handling enabled.

--- a/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/patches/1.36/README.md
+++ b/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/patches/1.36/README.md
@@ -4,4 +4,13 @@ This patch is for our case when we want to have a static Nodes in the cluster, m
 
 ## 002-skip-node-deletion.patch
 
-When `SKIP_NODE_DELETION` is set, `InstanceExists` returns an error instead of `(false, nil)` if the OpenStack instance is not found. This prevents `cloud-node-lifecycle` from deleting the Kubernetes Node while keeping shutdown taint handling enabled.
+When `SKIP_NODE_DELETION` is set, `InstanceExists` returns an error instead of `(false, nil)` if the OpenStack instance is not found.
+This prevents `cloud-node-lifecycle` from deleting the Kubernetes Node while keeping shutdown taint handling enabled.
+
+Planned Node deletion is not affected — those components remove Nodes directly through Kubernetes API, bypassing CCM:
+
+- Nodes of type **CloudPermanent** — `dhctl` removes Nodes during converge.
+- Nodes of type **CloudEphemeral (MCM engine)** — MCM removes the Node on Machine deletion.
+- Nodes of type **CloudEphemeral (CAPI engine)** — CAPI controller removes the Node on Machine deletion.
+
+Nodes that remain in the `NotReady` state for an extended period can be tracked using the `K8SNodeNotReady` alert — it fires when a node is `NotReady` for more than 10 minutes.

--- a/ee/modules/030-cloud-provider-openstack/template_tests/module_test.go
+++ b/ee/modules/030-cloud-provider-openstack/template_tests/module_test.go
@@ -352,6 +352,12 @@ func openstackCheck(f *Config, k8sVer string) {
 		Expect(ccmCRB.Exists()).To(BeTrue())
 		Expect(ccmVPA.Exists()).To(BeTrue())
 		Expect(ccmDeploy.Exists()).To(BeTrue())
+		Expect(ccmDeploy.Field("spec.template.spec.containers.0.env").Array()).To(ContainElement(
+			And(
+				WithTransform(func(v gjson.Result) string { return v.Get("name").String() }, Equal("SKIP_NODE_DELETION")),
+				WithTransform(func(v gjson.Result) string { return v.Get("value").String() }, Equal("1")),
+			),
+		))
 		Expect(ccmSecret.Exists()).To(BeTrue())
 		ccmExpectedConfig := `
 [Global]

--- a/ee/modules/030-cloud-provider-openstack/templates/cloud-controller-manager/deployment.yaml
+++ b/ee/modules/030-cloud-provider-openstack/templates/cloud-controller-manager/deployment.yaml
@@ -2,6 +2,11 @@
 checksum/config: {{ include (print $.Template.BasePath "/cloud-controller-manager/secret.yaml") . | sha256sum }}
 {{- end -}}
 
+{{- define "openstack_ccm_envs" -}}
+- name: SKIP_NODE_DELETION
+  value: "1"
+{{- end -}}
+
 {{- define "openstack_ccm_args" -}}
 - --cluster-cidr={{ .Values.global.discovery.podSubnet }}
 - --allocate-node-cidrs=true
@@ -43,6 +48,7 @@ checksum/config: {{ include (print $.Template.BasePath "/cloud-controller-manage
 {{- if $ccmImage -}}
   {{- $ccmConfig := dict -}}
   {{- $_ := set $ccmConfig "image" $ccmImage -}}
+  {{- $_ := set $ccmConfig "additionalEnvs" (include "openstack_ccm_envs" . | fromYamlArray) -}}
   {{- $_ := set $ccmConfig "additionalArgs" (include "openstack_ccm_args" . | fromYamlArray) -}}
   {{- $_ := set $ccmConfig "additionalPodAnnotations" (include "openstack_ccm_pod_annotations" . | fromYaml) -}}
   {{- $_ := set $ccmConfig "additionalVolumeMounts" (include "openstack_ccm_volume_mounts" . | fromYamlArray) -}}


### PR DESCRIPTION
## Description

The `cloud-provider-openstack` module now sets `SKIP_NODE_DELETION=1` in the OpenStack cloud-controller-manager (CCM) Deployment and applies a patch to `InstanceExists`.

When OpenStack temporarily reports that an instance is not found, CCM no longer deletes the corresponding Kubernetes Node. The `cloud-node-lifecycle` controller remains enabled, so shutdown taint handling is preserved.

After the module update, the CCM Deployment is rolled out with a new image and updated environment variables.

## Why do we need it, and what problem does it solve?

OpenStack CCM can delete Kubernetes Nodes when `InstanceExists` returns `InstanceNotFound`, even if the VM is still running and the failure is caused by a transient OpenStack API issue (for example, provider-side outages or API glitches).

This leads to mass Node removal, unnecessary workload disruption, and uncontrolled node recreation by the machine controller.

## Why do we need it in the patch release (if we do)?

Not necessarily

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cloud-provider-openstack
type: fix
summary: Prevented the OpenStack CCM from deleting Kubernetes nodes when OpenStack temporarily reports an instance as not found.
impact_level: default
```