### PR TITLE
[istio] Increase kiali validation reconcile interval

### DIFF
--- a/modules/110-istio/templates/kiali/configmap.yaml
+++ b/modules/110-istio/templates/kiali/configmap.yaml
@@ -1,5 +1,6 @@
 {{- $versionInfo := get .Values.istio.internal.versionMap .Values.istio.internal.globalVersion }}
 {{- $revision := get $versionInfo "revision" }}
+{{- $fullVersion := get $versionInfo "fullVersion" }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -33,6 +34,9 @@ data:
         istiod_deployment_name: istiod-{{ $revision }}
         config_map_name: istio-{{ $revision }}
         istio_sidecar_injector_config_map_name: istio-sidecar-injector-{{ $revision }}
+{{- if (semverCompare ">= 1.25.0" $fullVersion) }}
+        validation_reconcile_interval: 5m
+{{- end }}
       prometheus:
         url: https://trickster.d8-monitoring/trickster/main
         auth:


### PR DESCRIPTION
## Description

Add the `validation_reconcile_interval` option to the Kiali ConfigMap with a value of `5m` for Istio versions >= 1.25.0.

The change is conditionally applied - it only takes effect when running Istio >= 1.25.0, based on the detected full version of Istio. This is because older versions of Istio ship with a Kiali version that does not support validation.

## Why do we need it, and what problem does it solve?

In some clusters, the default validation interval (1 minute) is too short for Kiali to finish a full validation reconciliation cycle. With this change, Kiali still performs validation — just less often (every 5 minutes instead of every 1 minute).

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: chore
summary: "Increase Kiali validation reconcile interval to 5 minutes for Istio >= 1.25."
impact_level: low
```