### PR TITLE
[cloud-provider-vcd] Added affinity for infra-controller-manager

### DIFF
--- a/ee/modules/030-cloud-provider-vcd/template_tests/module_test.go
+++ b/ee/modules/030-cloud-provider-vcd/template_tests/module_test.go
@@ -24,7 +24,6 @@ const providerID = "vcd"
 const nameLabelKey = "cloud-provider\\.deckhouse\\.io/name"
 const registrationLabelKey = "cloud-provider\\.deckhouse\\.io/registration"
 const ephemeralNodesTemplatesLabelKey = "cloud-provider\\.deckhouse\\.io/ephemeral-nodes-templates"
-const bashibleLabelKey = "cloud-provider\\.deckhouse\\.io/bashible"
 
 // fake *-crd modules are required for backward compatibility with lib_helm library
 // TODO: remove fake crd modules
@@ -934,6 +933,49 @@ node-role.deckhouse.io/control-plane: ""`))
 			icmDeployment := f.KubernetesResource("Deployment", "d8-cloud-provider-vcd", "infra-controller-manager")
 			Expect(icmDeployment.Exists()).To(BeTrue())
 			Expect(icmDeployment.Field("spec.template.spec.dnsPolicy").String()).To(Equal("Default"))
+		})
+	})
+
+	Context("VCD :: infra-controller-manager HA pod anti-affinity", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", globalValues)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYaml("cloudProviderVcd", moduleValuesA)
+			f.ValuesSet("global.discovery.clusterControlPlaneIsHighlyAvailable", true)
+			f.HelmRender()
+		})
+
+		It("must set required pod anti-affinity on HA clusters", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			icmDeployment := f.KubernetesResource("Deployment", "d8-cloud-provider-vcd", "infra-controller-manager")
+			Expect(icmDeployment.Exists()).To(BeTrue())
+			Expect(icmDeployment.Field("spec.template.spec.affinity").String()).To(MatchYAML(`
+podAntiAffinity:
+  requiredDuringSchedulingIgnoredDuringExecution:
+  - labelSelector:
+      matchLabels:
+        app: infra-controller-manager
+    topologyKey: kubernetes.io/hostname
+`))
+		})
+	})
+
+	Context("VCD :: infra-controller-manager non-HA affinity", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", globalValues)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYaml("cloudProviderVcd", moduleValuesA)
+			f.ValuesSet("global.discovery.clusterControlPlaneIsHighlyAvailable", false)
+			f.HelmRender()
+		})
+
+		It("must not set pod anti-affinity on single-master clusters", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			icmDeployment := f.KubernetesResource("Deployment", "d8-cloud-provider-vcd", "infra-controller-manager")
+			Expect(icmDeployment.Exists()).To(BeTrue())
+			Expect(icmDeployment.Field("spec.template.spec.affinity").Exists()).To(BeFalse())
 		})
 	})
 })

--- a/ee/modules/030-cloud-provider-vcd/templates/infra-controller-manager/deployment.yaml
+++ b/ee/modules/030-cloud-provider-vcd/templates/infra-controller-manager/deployment.yaml
@@ -74,6 +74,7 @@ spec:
       {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
       {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node" "with-uninitialized") | nindent 6 }}
+      {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "infra-controller-manager")) | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
       dnsPolicy: {{ include "helm_lib_dns_policy_bootstraping_state" (list . "Default" "ClusterFirstWithHostNet") }}
       automountServiceAccountToken: true


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Added `helm_lib_pod_anti_affinity_for_ha` call to `ee/modules/030-cloud-provider-vcd/templates/infra-controller-manager/deployment.yaml`, immediately after the tolerations line. This brings infra-controller-manager in line with every other deployment in the module (all of which receive anti-affinity automatically via
  their helm_lib_*_manifests helpers).

`infra-controller-manager/deployment.yaml` was missing a `helm_lib_pod_anti_affinity_for_ha` call. Added it after the tolerations line, matching the pattern every other deployment in the module already uses via their `helm_lib_*_manifests` helpers.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

In HA mode (3+ control-plane nodes), multiple `infra-controller-manager` replicas could land on the same node. The deployment was hand-written and the anti-affinity call was never added, while all sibling deployments get it automatically. This adds hard pod anti-affinity by hostname so replicas spread across nodes.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-vcd
type: fix
summary: Fixes infra-controller-manager pods scheduling on the same node in HA mode.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
