### PR TITLE
[registry-packages-proxy] Handle default repository alias in RPP

### DIFF
--- a/modules/039-registry-packages-proxy/images/registry-packages-proxy/src/internal/cache/cache.go
+++ b/modules/039-registry-packages-proxy/images/registry-packages-proxy/src/internal/cache/cache.go
@@ -181,7 +181,7 @@ func (c *Cache) deleteOrphanedOrCorruptedEntries() {
 	// delete corrupted entries
 	for k, v := range c.storage {
 		if v.isCorrupted || v.layerDigest == "" {
-			c.logger.Info("delete corrupted entry", slog.String("digest", k), slog.String("layerDigest", v.layerDigest))
+			c.logger.Info("delete corrupted entry", slog.String("digest", k), slog.String("layer_digest", v.layerDigest))
 			delete(c.storage, k)
 		}
 	}
@@ -324,7 +324,7 @@ func (c *Cache) checkHashIsOK(layerDigest string) bool {
 	}
 	hsum := fmt.Sprintf("%x", h.Sum(nil))
 	if hsum != layerDigest {
-		c.logger.Warn("entry with layer digest corrupted in the cache", slog.String("path", path), slog.String("hash", hsum), slog.String("layerHash", layerDigest))
+		c.logger.Warn("entry with layer digest corrupted in the cache", slog.String("path", path), slog.String("hash", hsum), slog.String("layer_hash", layerDigest))
 		return false
 	}
 

--- a/modules/039-registry-packages-proxy/images/registry-packages-proxy/src/internal/credentials/watcher.go
+++ b/modules/039-registry-packages-proxy/images/registry-packages-proxy/src/internal/credentials/watcher.go
@@ -150,12 +150,24 @@ func (w *Watcher) processSecretEvent(secretEvent watch.Event) error {
 		w.Lock()
 		w.logger.Info("added registry config for main repo")
 		w.registryClientConfigs[registry.DefaultRepository] = registryConfig
+		w.registryClientConfigs[registryConfig.Repository] = registryConfig
 		w.Unlock()
 
 	case watch.Deleted:
+
+		var input registrySecretData
+
+		input.FromSecretData(secret.Data)
+
+		registryConfig, err := input.toClientConfig()
+		if err != nil {
+			return err
+		}
+
 		w.Lock()
 		w.logger.Info("deleted registry config for main repo")
 		delete(w.registryClientConfigs, registry.DefaultRepository)
+		delete(w.registryClientConfigs, registryConfig.Repository)
 		w.Unlock()
 	}
 

--- a/modules/039-registry-packages-proxy/images/registry-packages-proxy/src/internal/credentials/watcher.go
+++ b/modules/039-registry-packages-proxy/images/registry-packages-proxy/src/internal/credentials/watcher.go
@@ -137,7 +137,6 @@ func (w *Watcher) processSecretEvent(secretEvent watch.Event) error {
 
 	switch secretEvent.Type {
 	case watch.Added, watch.Modified:
-
 		var input registrySecretData
 
 		input.FromSecretData(secret.Data)
@@ -147,14 +146,20 @@ func (w *Watcher) processSecretEvent(secretEvent watch.Event) error {
 			return err
 		}
 
+		repoHost := strings.Split(registryConfig.Repository, "/")[0]
+
 		w.Lock()
-		w.logger.Info("added registry config for main repo")
+		w.logger.Info(
+			"added registry config for main repo",
+			slog.String("repo", registryConfig.Repository),
+			slog.String("repo_host", repoHost),
+		)
 		w.registryClientConfigs[registry.DefaultRepository] = registryConfig
 		w.registryClientConfigs[registryConfig.Repository] = registryConfig
+		w.registryClientConfigs[repoHost] = registryConfig
 		w.Unlock()
 
 	case watch.Deleted:
-
 		var input registrySecretData
 
 		input.FromSecretData(secret.Data)
@@ -164,10 +169,17 @@ func (w *Watcher) processSecretEvent(secretEvent watch.Event) error {
 			return err
 		}
 
+		repoHost := strings.Split(registryConfig.Repository, "/")[0]
+
 		w.Lock()
-		w.logger.Info("deleted registry config for main repo")
+		w.logger.Info(
+			"deleted registry config for main repo",
+			slog.String("repo", registryConfig.Repository),
+			slog.String("repo_host", repoHost),
+		)
 		delete(w.registryClientConfigs, registry.DefaultRepository)
 		delete(w.registryClientConfigs, registryConfig.Repository)
+		delete(w.registryClientConfigs, repoHost)
 		w.Unlock()
 	}
 

--- a/modules/039-registry-packages-proxy/images/registry-packages-proxy/src/internal/credentials/watcher.go
+++ b/modules/039-registry-packages-proxy/images/registry-packages-proxy/src/internal/credentials/watcher.go
@@ -106,7 +106,7 @@ func (w *Watcher) watchSecret(ctx context.Context) {
 		})
 	}
 
-	secretWatcher, err := toolsWatch.NewRetryWatcher("1", &cache.ListWatch{WatchFunc: watchFunc})
+	secretWatcher, err := toolsWatch.NewRetryWatcherWithContext(ctx, "1", &cache.ListWatch{WatchFunc: watchFunc})
 	if err != nil {
 		w.logger.Error("Watch secrets: %v", err)
 		return
@@ -180,7 +180,7 @@ func (w *Watcher) watchModuleSources(ctx context.Context) {
 		return w.k8sDynamicClient.Resource(ModuleSourceGVR).Watch(ctx, metav1.ListOptions{})
 	}
 
-	moduleSourcesWatcher, err := toolsWatch.NewRetryWatcher("1", &cache.ListWatch{WatchFunc: watchFunc})
+	moduleSourcesWatcher, err := toolsWatch.NewRetryWatcherWithContext(ctx, "1", &cache.ListWatch{WatchFunc: watchFunc})
 	if err != nil {
 		w.logger.Error("Watch module sources: %v", err)
 		return
@@ -214,7 +214,7 @@ func (w *Watcher) processModuleSourceEvent(moduleSourceEvent watch.Event) error 
 		return fmt.Errorf("unmarshal module source event: %v", err)
 	}
 
-	w.logger.Info("event from module source received", slog.String("event", string(moduleSourceEvent.Type)), slog.String("module source", moduleSource.Name))
+	w.logger.Info("event from module source received", slog.String("event", string(moduleSourceEvent.Type)), slog.String("module_source", moduleSource.Name))
 
 	switch moduleSourceEvent.Type {
 	case watch.Added, watch.Modified:


### PR DESCRIPTION
## Description

Updated registry-packages-proxy credentials watcher to register the main registry client config not only by the internal default repository alias, but also by aliases derived from the actual repository value from the registry config.

Now the main registry config is stored under the internal __default__ alias, the full repository value from the registry config, and the repository host alias.

This change affects registry-packages-proxy and may cause its Pod to restart after the module update.

## Why do we need it, and what problem does it solve?

RPP uses the internal __default__ alias for the main registry repository. However, some requests may pass the actual default repository host explicitly, for example dev-registry.deckhouse.io.

Before this change, the registry client config for the main repository was stored only under the internal __default__ alias. As a result, requests with the actual default repository host could fail because RPP could not find the corresponding registry client config.

In the tested environment, the main registry config was loaded with the full repository value dev-registry.deckhouse.io/sys/deckhouse-oss, while the request used only the repository host dev-registry.deckhouse.io. Therefore, registering only the full repository value was not enough. The config also needs to be available by the repository host alias.

This change makes requests using both the internal default alias and the actual default repository host resolve to the same main registry config.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

The RPP logs confirmed that the main registry config was loaded with the full repository value dev-registry.deckhouse.io/sys/deckhouse-oss and the derived repository host alias dev-registry.deckhouse.io.

Before adding the host alias, a request with repository=dev-registry.deckhouse.io failed with HTTP/2 500 and the error registry client config for repository 'dev-registry.deckhouse.io' not found.

After registering the host alias, the same request reached the registry package lookup stage and returned HTTP/2 404 package not found. The logs also showed that RPP attempted to request the manifest from dev-registry.deckhouse.io, which confirms that the registry client config was successfully resolved and the previous config lookup error was fixed.

## Changelog entries

```changes
section: registry-packages-proxy
type: fix 
summary: Fixed registry client config lookup when the actual default repository name is passed to RPP.
impact_level: low
```
