### PR TITLE
[docs] Update PrometheusDirectAccessDeprecated alert description

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -7093,10 +7093,12 @@ alerts:
       module: prometheus
       edition: ce
       description: |
-        The cluster has an Ingress that allows direct access to Prometheus with client certificate authentication, e.g. for [the external metrics access](https://deckhouse.io/modules/prometheus/usage.html#connecting-prometheus-to-an-external-grafana-instance)
-        This approach is deprecated and the direct access to Prometheus will not be possible in the future Deckhouse Kubernetes Platform releases.
+        The DKP cluster has an Ingress that allows direct access to Prometheus with client certificate authentication, for example, for [the external metrics access](https://deckhouse.io/modules/prometheus/usage.html#connecting-prometheus-to-an-external-grafana-instance).
+        This approach is deprecated and the direct access to Prometheus will not be possible in the future DKP releases.
 
-        To resolve this issue, remove the deprecated Ingress and use the [observability module to manage Prometheus metrics access](https://deckhouse.io/products/kubernetes-platform/modules/observability/stable/faq.html#how-to-grant-access-to-cluster-metrics-outside-of-cluster).
+        To resolve this issue, remove the deprecated Ingress and use the `observability` module to manage Prometheus metrics access.
+
+        Refer to the [module documentation](https://deckhouse.io/modules/observability/metrics.html#external-access-to-metrics) for instructions.
       summary: |
         Deprecated Ingress with direct Prometheus access found in cluster.
       severity: "6"

--- a/docs/documentation/pages/admin/configuration/update/SWITCHING_EDITIONS.md
+++ b/docs/documentation/pages/admin/configuration/update/SWITCHING_EDITIONS.md
@@ -167,7 +167,7 @@ What to consider before switching:
 
    1. Get the list of modules not supported in the desired DKP edition:
 
-      {{ check_new_modules | | regex_replace: "\n?<!REMOVE_FOR_CE>", "" | regex_replace: "<!/REMOVE_FOR_CE>\n?", "" | regex_replace: "^", "      " }}
+      {{ check_new_modules | regex_replace: "\n?<!REMOVE_FOR_CE>", "" | regex_replace: "<!/REMOVE_FOR_CE>\n?", "" | regex_replace: "^", "      " }}
 
 {{ disable_modules }}
 {% endtab %}

--- a/modules/300-prometheus/monitoring/prometheus-rules/deprecation.yaml
+++ b/modules/300-prometheus/monitoring/prometheus-rules/deprecation.yaml
@@ -12,10 +12,12 @@
         plk_grouped_by__d8_prometheus_deprecations: "PrometheusDeprecations,tier=application,prometheus=deckhouse,kubernetes=~kubernetes"
         summary: Deprecated Ingress with direct Prometheus access found in cluster.
         description: |
-          The cluster has an Ingress that allows direct access to Prometheus with client certificate authentication, e.g. for [the external metrics access](https://deckhouse.io/modules/prometheus/usage.html#connecting-prometheus-to-an-external-grafana-instance)
-          This approach is deprecated and the direct access to Prometheus will not be possible in the future Deckhouse Kubernetes Platform releases.
+          The DKP cluster has an Ingress that allows direct access to Prometheus with client certificate authentication, for example, for [the external metrics access](https://deckhouse.io/modules/prometheus/usage.html#connecting-prometheus-to-an-external-grafana-instance).
+          This approach is deprecated and the direct access to Prometheus will not be possible in the future DKP releases.
 
-          To resolve this issue, remove the deprecated Ingress and use the [observability module to manage Prometheus metrics access](https://deckhouse.io/products/kubernetes-platform/modules/observability/stable/faq.html#how-to-grant-access-to-cluster-metrics-outside-of-cluster).
+          To resolve this issue, remove the deprecated Ingress and use the `observability` module to manage Prometheus metrics access.
+          
+          Refer to the [module documentation](https://deckhouse.io/modules/observability/metrics.html#external-access-to-metrics) for instructions.
 - name: d8.grafana.interval_deprecation
   rules:
     - alert: GrafanaDashboardPanelIntervalDeprecated


### PR DESCRIPTION
## Description

This PR updates the description of the PrometheusDirectAccessDeprecated alert.
Previously, it contained a broken link.

## Changelog entries

```changes
section: docs
type: chore
summary: Updated PrometheusDirectAccessDeprecated alert description.
impact_level: low
```
