### PR TITLE
[istio] Fix typo in RBAC template

### DIFF
--- a/modules/110-istio/templates/control-plane/iop/istiod/_rules_v-1-25.tpl
+++ b/modules/110-istio/templates/control-plane/iop/istiod/_rules_v-1-25.tpl
@@ -239,7 +239,7 @@
   - referencegrants
   - tcproutes
   - tlsroutes
-  - updroutes
+  - udproutes
   verbs:
   - get
   - watch


### PR DESCRIPTION
## Description

Fixed a typo in the istiod ClusterRole template (`_rules_v-1-25.tpl`) where the Gateway API resource `udproutes` (UDPRoute) was misspelled as `updroutes` (transposed letters).

## Why do we need it, and what problem does it solve?

The RBAC rule intended to grant istiod access to `udproutes` resources (UDPRoute from the `gateway.networking.k8s.io` API group) was written as `updroutes` - a resource name that does not exist. This means istiod would fail RBAC checks when attempting to read or watch UDPRoute objects, potentially breaking Ambient Mesh or Gateway API functionality relying on UDPRoutes.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: fix
summary: Fix typo in istiod RBAC template.
impact_level: low
```
