### PR TITLE
[deckhouse] scheduler can disable nodes

### DIFF
--- a/deckhouse-controller/internal/packages/schedule/dump.go
+++ b/deckhouse-controller/internal/packages/schedule/dump.go
@@ -32,6 +32,7 @@ type nodeDump struct {
 	Version      string                `json:"version" yaml:"version"`
 	Order        Order                 `json:"order" yaml:"order"`
 	State        nodeState             `json:"state" yaml:"state"`
+	Disabled     bool                  `json:"disabled,omitempty" yaml:"disabled,omitempty"`
 	Status       checker.Result        `json:"status" yaml:"status"`
 	Dependencies map[string]Dependency `json:"dependencies,omitempty" yaml:"dependencies,omitempty"`
 }
@@ -50,6 +51,7 @@ func (s *Scheduler) Dump() []byte {
 			Version:      n.version.String(),
 			Order:        n.order,
 			State:        n.state,
+			Disabled:     n.disabled,
 			Status:       n.status,
 			Dependencies: maps.Clone(n.dependencies),
 		}
@@ -77,6 +79,7 @@ func (s *Scheduler) DumpByName(name string) []byte {
 		Version:      n.version.String(),
 		Order:        n.order,
 		State:        n.state,
+		Disabled:     n.disabled,
 		Status:       n.status,
 		Dependencies: maps.Clone(n.dependencies),
 	}

--- a/deckhouse-controller/internal/packages/schedule/node.go
+++ b/deckhouse-controller/internal/packages/schedule/node.go
@@ -92,6 +92,8 @@ type node struct {
 	state nodeState // Lifecycle phase: idle → scheduled → active.
 	order Order     // Scheduling priority; lower values run before higher ones.
 
+	disabled bool // Explicit operator-driven disable; overrides a passing checker chain.
+
 	status checker.Result // Last computed enabled/disabled result from the checker chain.
 
 	dependencies map[string]Dependency // Declared dependency constraints — source of topological ordering and checker inputs.

--- a/deckhouse-controller/internal/packages/schedule/scheduler.go
+++ b/deckhouse-controller/internal/packages/schedule/scheduler.go
@@ -42,6 +42,11 @@ const (
 	reasonRequirementsKubernetes = "KubernetesRequirementsUnmet"
 	reasonRequirementsDeckhouse  = "DeckhouseRequirementsUnmet"
 	reasonRequirementsBootstrap  = "BootstrapRequirementsUnmet"
+
+	// reasonDisabled is the status reason recorded when a node is explicitly
+	// disabled by an operator via [Scheduler.Disable], as opposed to losing
+	// eligibility through a failed checker.
+	reasonDisabled = "PackageDisabled"
 )
 
 // Scheduler manages a dependency graph of packages and their lifecycle.
@@ -276,6 +281,43 @@ func (s *Scheduler) Complete(completed string) {
 	s.schedule()
 }
 
+// Disable explicitly turns the named package off, forcing it disabled on every
+// subsequent scheduling pass regardless of its checker chain. A scheduling pass
+// runs immediately, cascade-disabling the node (and emitting an [EventDisable]
+// if it was previously enabled). It is a no-op if the package does not exist or
+// is already disabled.
+func (s *Scheduler) Disable(name string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	n, ok := s.nodes[name]
+	if !ok || n.disabled {
+		return
+	}
+
+	n.disabled = true
+
+	s.schedule()
+}
+
+// Enable clears an explicit disable set by [Scheduler.Disable], allowing the
+// node's checker chain to govern eligibility again. A scheduling pass runs
+// immediately, re-scheduling the node if its checkers now pass. It is a no-op
+// if the package does not exist or is not explicitly disabled.
+func (s *Scheduler) Enable(name string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	n, ok := s.nodes[name]
+	if !ok || !n.disabled {
+		return
+	}
+
+	n.disabled = false
+
+	s.schedule()
+}
+
 // Reschedule reverts the named package to idle and runs a full scheduling
 // pass, causing it (and potentially its dependents) to be rescheduled.
 // It is a no-op if the package does not exist.
@@ -336,6 +378,12 @@ func (s *Scheduler) compute() []*node {
 	for _, n := range sorted {
 		current := n.status.Enabled
 		n.status = checker.Check(n.checkers...)
+		// An explicit operator disable is the final gate: it forces the node
+		// off even when every checker passes, but defers to the checker chain's
+		// more specific reason when that already disabled the node.
+		if n.disabled && n.status.Enabled {
+			n.status = checker.Result{Reason: reasonDisabled, Message: "package is explicitly disabled"}
+		}
 		if current == n.status.Enabled {
 			continue
 		}

--- a/deckhouse-controller/internal/packages/schedule/scheduler_test.go
+++ b/deckhouse-controller/internal/packages/schedule/scheduler_test.go
@@ -899,3 +899,95 @@ func (s *SchedulerSuite) TestNoneOfMemberInstallTriggersDisable() {
 
 	s.Contains(eventNames(s.collectEvents(), schedule.EventDisable), "consumer")
 }
+
+// TestDisableFlipsEnabledNode confirms an explicit Disable forces an otherwise
+// eligible node off, emitting an EventDisable with the PackageDisabled reason.
+func (s *SchedulerSuite) TestDisableFlipsEnabledNode() {
+	s.activateGlobal()
+
+	s.Require().NoError(s.sched.AddNode(&testPackage{
+		name:        "alpha",
+		version:     mustVersion("1.0.0"),
+		constraints: schedule.Constraints{Order: schedule.FunctionalOrder},
+	}))
+
+	s.Contains(eventNames(s.collectEvents(), schedule.EventSchedule), "alpha")
+
+	s.sched.Disable("alpha")
+
+	disabled := s.collectEvents()
+	s.Contains(eventNames(disabled, schedule.EventDisable), "alpha")
+	for _, e := range disabled {
+		if e.Kind == schedule.EventDisable && e.Name == "alpha" {
+			s.Equal("PackageDisabled", e.Reason)
+		}
+	}
+}
+
+// TestEnableReschedulesDisabledNode confirms that clearing an explicit disable
+// lets a node with passing checkers be scheduled again.
+func (s *SchedulerSuite) TestEnableReschedulesDisabledNode() {
+	s.activateGlobal()
+
+	s.Require().NoError(s.sched.AddNode(&testPackage{
+		name:        "alpha",
+		version:     mustVersion("1.0.0"),
+		constraints: schedule.Constraints{Order: schedule.FunctionalOrder},
+	}))
+	s.drainEvents()
+
+	s.sched.Disable("alpha")
+	s.Contains(eventNames(s.collectEvents(), schedule.EventDisable), "alpha")
+
+	s.sched.Enable("alpha")
+	s.Contains(eventNames(s.collectEvents(), schedule.EventSchedule), "alpha")
+}
+
+// TestDisableIsIdempotent confirms a repeated Disable on an already-disabled
+// node performs no enabled→disabled flip and therefore emits no further event.
+func (s *SchedulerSuite) TestDisableIsIdempotent() {
+	s.activateGlobal()
+
+	s.Require().NoError(s.sched.AddNode(&testPackage{
+		name:        "alpha",
+		version:     mustVersion("1.0.0"),
+		constraints: schedule.Constraints{Order: schedule.FunctionalOrder},
+	}))
+	s.drainEvents()
+
+	s.sched.Disable("alpha")
+	s.drainEvents()
+
+	s.sched.Disable("alpha")
+	s.Empty(s.collectEvents(), "redundant Disable must be a no-op")
+}
+
+// TestDisablePreservesCheckerReason confirms that when a node is both explicitly
+// disabled and failing a checker, the checker's specific reason wins over the
+// generic PackageDisabled reason.
+func (s *SchedulerSuite) TestDisablePreservesCheckerReason() {
+	s.activateGlobal()
+
+	s.Require().NoError(s.sched.AddNode(&testPackage{
+		name:    "consumer",
+		version: mustVersion("1.0.0"),
+		constraints: schedule.Constraints{
+			Order: schedule.FunctionalOrder,
+			Dependencies: map[string]schedule.Dependency{
+				"parent": {},
+			},
+		},
+	}))
+	s.drainEvents()
+
+	// consumer is already checker-disabled (parent absent). Explicitly disabling
+	// it must not be scheduled once parent appears.
+	s.sched.Disable("consumer")
+	s.drainEvents()
+
+	s.versions["parent"] = mustVersion("1.0.0")
+	s.sched.Schedule()
+
+	s.NotContains(eventNames(s.collectEvents(), schedule.EventSchedule), "consumer",
+		"explicitly disabled node must stay off even when its checkers pass")
+}


### PR DESCRIPTION
## Description

Adds an explicit, operator-driven disable mechanism to the package scheduler (`deckhouse-controller/internal/packages/schedule`).

Until now a node's eligibility was governed solely by its checker chain (Kubernetes/Deckhouse version constraints, dependencies, bootstrap condition). There was no way to force a package off independently of those checks.

Changes:
- **`node.disabled` field** — a per-node flag for an explicit disable, separate from checker-computed status.
- **`Scheduler.Disable(name)` / `Scheduler.Enable(name)`** — flip the flag and run a scheduling pass. Both are no-ops if the node is missing or already in the target state, so repeated calls emit no spurious events.
- **`compute()`** folds the flag into the single source of truth `n.status.Enabled`: after the checker chain runs, an explicit disable forces the node off. It is applied *after* the chain, so a checker's more specific reason still wins when the node was already disabled by a failed check. The new disable surfaces with reason `PackageDisabled`.
- **Debug dump** (`Dump` / `DumpByName`) now reports the `disabled` flag (omitted when false).

Because the disable is written into `n.status.Enabled`, the existing machinery works unchanged: the enabled→disabled flip emits `EventDisable`, `canSchedule`'s gate respects it, and the "mark disabled nodes active" loop ensures an explicitly-disabled lower-tier node does not stall higher tiers via the order gate.

Note: the flag is in-memory only. Persisting disable intent across controller restarts is the responsibility of the caller (re-apply after `AddNode` on startup).

No critical cluster components are restarted by this change.

## Why do we need it, and what problem does it solve?

Operators (and higher-level controllers) need a way to explicitly turn a package off regardless of whether its version/dependency constraints are satisfied — for example, to administratively disable a module without removing it from the graph or mutating its constraints. Previously the only levers were the checker inputs, which conflate "requirements unmet" with "intentionally off". This adds a clean, first-class disable that is distinguishable in status (`PackageDisabled`) and in the debug dump.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: feature
summary: Scheduler supports explicitly disabling and enabling packages.
impact_level: low
```
