### PR TITLE
[dhctl] Add resource name to create/update errors

### DIFF
--- a/dhctl/pkg/kubernetes/actions/task.go
+++ b/dhctl/pkg/kubernetes/actions/task.go
@@ -43,13 +43,13 @@ func (task *ManifestTask) CreateOrUpdate(ctx context.Context) error {
 	err := task.CreateFunc(ctx, manifest)
 	if err != nil {
 		if !errors.IsAlreadyExists(err) {
-			return fmt.Errorf("create resource: %v", err)
+			return fmt.Errorf("create resource %q: %v", task.Name, err)
 		}
 		log.InfoF("%s already exists. Trying to update ... ", task.Name)
 		err = task.UpdateFunc(ctx, manifest)
 		if err != nil {
 			log.ErrorLn("ERROR!")
-			return fmt.Errorf("update resource: %v", err)
+			return fmt.Errorf("update resource %q: %v", task.Name, err)
 		}
 		log.InfoLn("OK!")
 	}
@@ -63,13 +63,13 @@ func (task *ManifestTask) CreateOrUpdateSilent(ctx context.Context) error {
 	err := task.CreateFunc(ctx, manifest)
 	if err != nil {
 		if !errors.IsAlreadyExists(err) {
-			return fmt.Errorf("create resource: %v", err)
+			return fmt.Errorf("create resource %q: %v", task.Name, err)
 		}
 		log.DebugF("%s already exists. Trying to update ... ", task.Name)
 		err = task.UpdateFunc(ctx, manifest)
 		if err != nil {
 			log.ErrorLn("ERROR!")
-			return fmt.Errorf("update resource: %v", err)
+			return fmt.Errorf("update resource %q: %v", task.Name, err)
 		}
 		log.DebugLn("OK!")
 	}

--- a/dhctl/pkg/kubernetes/actions/task_test.go
+++ b/dhctl/pkg/kubernetes/actions/task_test.go
@@ -1,0 +1,51 @@
+// Copyright 2021 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package actions
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestManifestTaskCreateOrUpdateSilentIncludesResourceNameOnCreateError(t *testing.T) {
+	task := &ManifestTask{
+		Name: "Secret d8-system/bad-secret",
+		Manifest: func() interface{} {
+			return nil
+		},
+		CreateFunc: func(ctx context.Context, manifest interface{}) error {
+			return errors.New(`Secret in version "v1" cannot be handled as a Secret: illegal base64 data at input byte 2204`)
+		},
+		UpdateFunc: func(ctx context.Context, manifest interface{}) error {
+			t.Fatal("update should not be called")
+			return nil
+		},
+	}
+
+	err := task.CreateOrUpdateSilent(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	if !strings.Contains(err.Error(), `create resource "Secret d8-system/bad-secret"`) {
+		t.Fatalf("expected error to contain resource name, got: %v", err)
+	}
+
+	if !strings.Contains(err.Error(), "illegal base64 data") {
+		t.Fatalf("expected original error to be preserved, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Description

Updated dhctl manifest task error messages to include the resource name when a resource create or update operation fails.

The change affects errors returned by manifest tasks during resource creation/update. It does not affect cluster components and does not cause any workload restarts by itself.

## Why do we need it, and what problem does it solve?

During bootstrap resource creation, dhctl may fail while creating a group of resources with the same API version and kind. Previously, the error message included only the operation and resource kind, for example Create /v1, Kind=Secret resources, but did not show which exact object failed.

This made troubleshooting difficult when several resources of the same kind were being created. For example, if one of several Secret resources contained invalid base64 data, the error only said that a Secret failed, without showing its metadata.name or namespace.

After this change, create and update errors include the manifest task name, which contains the resource kind and object name, and namespace for namespaced resources. This makes it possible to identify the exact resource that caused the failure.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: dhctl
type: feature 
summary: Added resource names to dhctl create and update error messages.
impact_level: low
```