### PR TITLE
[docs] Add LB annotation at Dynamix docs

### DIFF
--- a/docs/documentation/pages/admin/configuration/integrations/private/dynamix/STORAGE_BALANSING_AND_FEATURES_RU.md
+++ b/docs/documentation/pages/admin/configuration/integrations/private/dynamix/STORAGE_BALANSING_AND_FEATURES_RU.md
@@ -47,3 +47,23 @@ masterNodeGroup:
 {% alert level="info" %}
 Поддержка BGP-режима зависит от сетевой инфраструктуры и не гарантируется в Basis Dynamix.
 {% endalert %}
+
+### Настройка Service типа LoadBalancer
+
+Для настройки Service типа LoadBalancer добавьте в манифест Service следующие аннотации:
+
+```yaml
+metadata:
+  annotations:
+    dynamix.cpi.flant.com/internal-network-name: <internal_name>
+    dynamix.cpi.flant.com/external-network-name: <external_name>
+```
+
+Обе аннотации обязательны:
+
+- `dynamix.cpi.flant.com/internal-network-name` — имя внутренней сети в Basis Dynamix;
+- `dynamix.cpi.flant.com/external-network-name` — имя внешней сети в Basis Dynamix.
+
+Термины «внутренняя сеть» и «внешняя сеть» используются в контексте Basis Dynamix. Внешняя сеть не обязательно должна быть публичной и может использовать серые IP-адреса.
+
+Если одна из аннотаций не указана, cloud-controller-manager завершит обработку Service с ошибкой.

--- a/ee/modules/030-cloud-provider-dynamix/docs/FAQ.md
+++ b/ee/modules/030-cloud-provider-dynamix/docs/FAQ.md
@@ -1,14 +1,23 @@
 ---
 title: "Cloud provider — Basis Dynamix: FAQ"
 ---
-### How to configure an INTERNAL LoadBalancer?
 
-To configure an **INTERNAL** LoadBalancer, add the following annotation to your Service manifest:
+## How to configure a LoadBalancer?
 
-- `dynamix.cpi.flant.com/internal-network-name: <internal_name>`
+o configure a Service of the LoadBalancer type, add the following annotations to the Service manifest:
 
-### How to configure an EXTERNAL LoadBalancer?
+```yaml
+metadata:
+  annotations:
+    dynamix.cpi.flant.com/internal-network-name: <internal_name>
+    dynamix.cpi.flant.com/external-network-name: <external_name>
+```
 
-To configure an **EXTERNAL** LoadBalancer, add the following annotation to your Service manifest:
+Both annotations are required:
 
-- `dynamix.cpi.flant.com/external-network-name: <external_name>`
+- `dynamix.cpi.flant.com/internal-network-name` — the name of the internal network in Basis Dynamix
+- `dynamix.cpi.flant.com/external-network-name` — the name of the external network in Basis Dynamix
+
+The terms "internal network" and "external network" are used in the context of Basis Dynamix. The external network does not have to be public and may use private IP addresses.
+
+If one of the annotations is not specified, cloud-controller-manager will fail to process the Service.

--- a/ee/modules/030-cloud-provider-dynamix/docs/FAQ_RU.md
+++ b/ee/modules/030-cloud-provider-dynamix/docs/FAQ_RU.md
@@ -1,14 +1,23 @@
 ---
 title: "Cloud provider — Basis Dynamix: FAQ"
 ---
-### Как настроить INTERNAL LoadBalancer?
 
-Для настройки **INTERNAL** LoadBalancer’а установите в манифесте Service следующую аннотацию:
+## Как настроить LoadBalancer?
 
-- `dynamix.cpi.flant.com/internal-network-name: <internal_name>`
+Для настройки Service типа LoadBalancer добавьте в манифест Service следующие аннотации:
 
-### Как настроить EXTERNAL LoadBalancer?
+```yaml
+metadata:
+  annotations:
+    dynamix.cpi.flant.com/internal-network-name: <internal_name>
+    dynamix.cpi.flant.com/external-network-name: <external_name>
+```
 
-Для настройки **EXTERNAL** LoadBalancer’а установите в манифесте Service следующую аннотацию:
+Обе аннотации обязательны:
 
-- `dynamix.cpi.flant.com/external-network-name: <external_name>`
+- `dynamix.cpi.flant.com/internal-network-name` — имя внутренней сети в Basis Dynamix;
+- `dynamix.cpi.flant.com/external-network-name` — имя внешней сети в Basis Dynamix.
+
+Термины «внутренняя сеть» и «внешняя сеть» используются в контексте Basis Dynamix. Внешняя сеть не обязательно должна быть публичной и может использовать серые IP-адреса.
+
+Если одна из аннотаций не указана, cloud-controller-manager завершит обработку Service с ошибкой.


### PR DESCRIPTION
## Description
Added LB annotation at Dynamix docs.

## Why do we need it, and what problem does it solve?

## Why do we need it in the patch release (if we do)?



## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: docs
type: chore
summary: Added LB annotation at Dynamix docs.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
