### PR TITLE
fix(multitenancy-manager): bump containerd to v1.7.32 for CVE-2026-46680

### DIFF
--- a/ee/modules/500-operator-trivy/images/operator/known_vulnerabilities.vex
+++ b/ee/modules/500-operator-trivy/images/operator/known_vulnerabilities.vex
@@ -211,6 +211,21 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Prior to version 29.3.1, a security vulnerability has been detected that allows plugins privilege validation to be bypassed during docker plugin install. Due to an error in the daemon's privilege comparison logic, the daemon may incorrectly accept a privilege set that differs from the one approved by the user. Plugins that request exactly one privilege are also affected, because no comparison is performed at all. This issue has been patched in version 29.3.1. Deckhouse Kubernetes Platform is not affeceted by this since it does not ship or use Docker daemon or it's plugins in any way.",
       "timestamp": "2026-05-16T12:31:20Z"
+    },
+    {
+      "vulnerability": {
+        "@id": "https://nvd.nist.gov/vuln/detail/CVE-2026-41567",
+        "description": "Docker: PUT /containers/{id}/archive executes container binary on the host",
+        "name": "CVE-2026-41567"
+      },
+      "products": [
+        { "@id": "pkg:golang/github.com/docker/docker@v27.1.1+incompatible" },
+        { "@id": "pkg:golang/github.com/docker/docker@v27.3.1+incompatible" }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "The vulnerability affects Docker daemon archive extraction behavior. Deckhouse Kubernetes Platform is not affected because it does not ship or use Docker daemon API endpoints in this execution path for operator-trivy and trivy binaries.",
+      "timestamp": "2026-06-19T14:09:00Z"
     }
 
   ],

--- a/ee/modules/500-operator-trivy/images/trivy/known_vulnerabilities.vex
+++ b/ee/modules/500-operator-trivy/images/trivy/known_vulnerabilities.vex
@@ -211,6 +211,21 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Prior to version 29.3.1, a security vulnerability has been detected that allows plugins privilege validation to be bypassed during docker plugin install. Due to an error in the daemon's privilege comparison logic, the daemon may incorrectly accept a privilege set that differs from the one approved by the user. Plugins that request exactly one privilege are also affected, because no comparison is performed at all. This issue has been patched in version 29.3.1. Deckhouse Kubernetes Platform is not affeceted by this since it does not ship or use Docker daemon or it's plugins in any way.",
       "timestamp": "2026-05-16T12:31:20Z"
+    },
+    {
+      "vulnerability": {
+        "@id": "https://nvd.nist.gov/vuln/detail/CVE-2026-41567",
+        "description": "Docker: PUT /containers/{id}/archive executes container binary on the host",
+        "name": "CVE-2026-41567"
+      },
+      "products": [
+        { "@id": "pkg:golang/github.com/docker/docker@v27.1.1+incompatible" },
+        { "@id": "pkg:golang/github.com/docker/docker@v27.3.1+incompatible" }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "The vulnerability affects Docker daemon archive extraction behavior. Deckhouse Kubernetes Platform is not affected because it does not ship or use Docker daemon API endpoints in this execution path for operator-trivy and trivy binaries.",
+      "timestamp": "2026-06-19T14:09:00Z"
     }
 
   ],

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/go.mod
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/chai2010/gettext-go v1.0.2 // indirect
-	github.com/containerd/containerd v1.7.30 // indirect
+	github.com/containerd/containerd v1.7.32 // indirect
 	github.com/containerd/errdefs v0.3.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v0.2.1 // indirect

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/go.sum
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/go.sum
@@ -34,8 +34,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chai2010/gettext-go v1.0.2 h1:1Lwwip6Q2QGsAdl/ZKPCwTe9fe0CjlUbqj5bFNSjIRk=
 github.com/chai2010/gettext-go v1.0.2/go.mod h1:y+wnP2cHYaVj19NZhYKAwEMH2CI1gNHeQQ+5AjwawxA=
-github.com/containerd/containerd v1.7.30 h1:/2vezDpLDVGGmkUXmlNPLCCNKHJ5BbC5tJB5JNzQhqE=
-github.com/containerd/containerd v1.7.30/go.mod h1:fek494vwJClULlTpExsmOyKCMUAbuVjlFsJQc4/j44M=
+github.com/containerd/containerd v1.7.32 h1:S54xuVcPxeLaYgaRABtpJ2VyVUVsy0IGf7qHBs+sbY8=
+github.com/containerd/containerd v1.7.32/go.mod h1:jdwD6s/BhV4XVJGrvtziNPVA+83n66TwptVaPKprq4E=
 github.com/containerd/errdefs v0.3.0 h1:FSZgGOeK4yuT/+DnF07/Olde/q4KBoMsaamhXxIMDp4=
 github.com/containerd/errdefs v0.3.0/go.mod h1:+YBYIdtsnF4Iw6nWZhJcqGSg/dwvV7tyJ/kCkyJ2k+M=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Fixed 
**CVE-2026-46680** 
** CVE-2026-41567**
** CVE-2026-42306** 

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->


## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: multitenancy-manager
type: fix
summary: Bump containerd to v1.7.32 to fix CVE-2026-46680.
impact_level: low