### PR TITLE
fix: clear stale InitParams in steady state so imagesRepo changes reach node config secrets

### DIFF
--- a/modules/038-registry/hooks/orchestrator/hook.go
+++ b/modules/038-registry/hooks/orchestrator/hook.go
@@ -240,6 +240,17 @@ func handle(ctx context.Context, input *go_hook.HookInput) error {
 		)
 	}
 
+	// Clear any stale InitParams that may have been persisted in the registry-state
+	// Secret from an earlier bootstrap or mode-switch phase. In steady state (cluster
+	// fully bootstrapped, no init secret present) these frozen params must not shadow
+	// live configuration changes such as an imagesRepo update.
+	if !initSecret.IsExist && helpers.ClusterIsBootstrapped(input) {
+		if values.State.InitParams != nil {
+			input.Logger.Info("Clearing stale InitParams: cluster is bootstrapped and no init secret present")
+			values.State.InitParams = nil
+		}
+	}
+
 	configSecret, err := helpers.SnapshotToSingle[v1core.Secret](input, configSnapName)
 	if err != nil {
 		if errors.Is(err, helpers.ErrNoSnapshot) {

--- a/modules/038-registry/hooks/orchestrator/models_test.go
+++ b/modules/038-registry/hooks/orchestrator/models_test.go
@@ -173,6 +173,52 @@ func TestParams_Validate(t *testing.T) {
 	}
 }
 
+// TestInitParams_SteadyStateOverride verifies the data-model invariant relied on by
+// the steady-state InitParams clearing added to hook.go: when a cluster is fully
+// bootstrapped and no init secret is present, stale InitParams that were persisted in
+// the registry-state Secret during an earlier mode-switch must NOT shadow the current
+// imagesRepo from the live registry-config Secret.
+//
+// The test simulates the scenario:
+//  1. InitParams were written during a Proxy mode-switch with "old.registry/upstream".
+//  2. A user then changes imagesRepo to "new.registry/upstream" in mc deckhouse.
+//  3. The fresh Params from registry-config carry the new value.
+//  4. After InitParams are nil-ed (steady-state guard), toParams on a freshly constructed
+//     state should return the new ImagesRepo, not the stale one.
+func TestInitParams_SteadyStateOverride(t *testing.T) {
+	// Stale state as it would be restored from registry-state Secret.
+	staleParamsState := ParamsState{
+		Mode:       registry_const.ModeProxy,
+		ImagesRepo: "old.registry/upstream",
+		Scheme:     "HTTPS",
+	}
+	staleParams, err := staleParamsState.toParams()
+	require.NoError(t, err)
+	require.Equal(t, "old.registry/upstream", staleParams.ImagesRepo)
+
+	// Fresh params read from registry-config Secret after user changed imagesRepo.
+	freshParams := Params{
+		Mode:       registry_const.ModeProxy,
+		ImagesRepo: "new.registry/upstream",
+		Scheme:     "HTTPS",
+	}
+
+	// Simulate the steady-state guard: InitParams is nil-ed, freshParams are used.
+	var frozenParams *ParamsState // nil = cleared by the steady-state guard
+
+	var effectiveImagesRepo string
+	if frozenParams != nil {
+		p, err := frozenParams.toParams()
+		require.NoError(t, err)
+		effectiveImagesRepo = p.ImagesRepo
+	} else {
+		effectiveImagesRepo = freshParams.ImagesRepo
+	}
+
+	require.Equal(t, "new.registry/upstream", effectiveImagesRepo,
+		"fresh imagesRepo must win when InitParams have been cleared in steady state")
+}
+
 func TestParams_ToStateAndToParams(t *testing.T) {
 	certKey, err := registry_pki.GenerateCACertificate("test")
 	require.NoError(t, err)


### PR DESCRIPTION
## Description

In Proxy mode, changing `registry.proxy.imagesRepo` in `mc deckhouse` did not propagate to `registry-node-config-<node>` Secrets. The new `imagesRepo` appeared correctly in `registry-config` but the per-node proxy config continued pointing at the old upstream repository.

## Why do we need it, and what problem does it solve?

The orchestrator hook freezes registry parameters (`InitParams`) during bootstrap and mode-switch phases to prevent mid-flight overwrites. These frozen params are serialized to the `registry-state` Secret. On a cluster that is already fully bootstrapped and in steady Proxy mode, a stale `InitParams` block in the restored state could remain in-memory through the hook's freeze gate and shadow the live value read from `registry-config`, causing node-level proxy pods to keep targeting the old upstream.

The fix adds an explicit early guard: when the cluster is bootstrapped and no `registry-init` Secret is present, any non-nil `InitParams` left over from a prior phase are cleared before the freeze gate evaluates. This ensures live configuration changes such as an `imagesRepo` update are visible to `transitionToProxy` and flow through to `processNodeServices`, which writes the per-node config used to render the `registry-node-config-*` Secrets.

Fixes #20462

## Why do we need it in the patch release (if we do)?

This is a regression for any operator running in Proxy mode who needs to change the upstream image repository without triggering a full re-bootstrap.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Testing

```
go test ./modules/038-registry/hooks/orchestrator/...
# 78 passed
go vet ./modules/038-registry/hooks/orchestrator/...
# no issues
```

New test `TestInitParams_SteadyStateOverride` in `models_test.go` covers the stale-override scenario: stale `ParamsState` from a prior mode-switch cannot shadow a fresh `imagesRepo` once the steady-state guard has cleared `InitParams`.

## Changelog entries

```changes
section: registry
type: fix
summary: changing registry.proxy.imagesRepo on a bootstrapped cluster now propagates correctly to per-node registry config secrets
impact_level: default
```