### PR TITLE
[webhook-handler] fix: move webhook bindings before kubernetes unlock

### DIFF
--- a/modules/002-deckhouse/images/webhook-handler/operator/cmd/main.go
+++ b/modules/002-deckhouse/images/webhook-handler/operator/cmd/main.go
@@ -27,6 +27,8 @@ import (
 	"sync"
 	"time"
 
+	deckhouseiov1alpha1 "deckhouse.io/webhook/api/v1alpha1"
+	"deckhouse.io/webhook/internal/controller"
 	sh_pkg "github.com/flant/shell-operator/pkg"
 	sh_app "github.com/flant/shell-operator/pkg/app"
 	hook_types "github.com/flant/shell-operator/pkg/hook/types"
@@ -49,9 +51,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	"github.com/deckhouse/deckhouse/pkg/log"
-
-	deckhouseiov1alpha1 "deckhouse.io/webhook/api/v1alpha1"
-	"deckhouse.io/webhook/internal/controller"
 )
 
 var (
@@ -135,6 +134,36 @@ func reloadHooks(ctx context.Context, shOp *shell_operator.ShellOperator, logger
 		shOp.ConversionWebhookManager.ClientConfigs = make(map[string]*conversion.CrdClientConfig)
 	}
 
+	// Enable admission bindings on every newly loaded hook so that
+	// AdmissionLinks are populated and CanHandleEvent works.
+	admissionHookNames, err := shOp.HookManager.GetHooksInOrder(hook_types.KubernetesValidating)
+	if err != nil {
+		return fmt.Errorf("get validating hooks: %w", err)
+	}
+	mutatingHookNames, err := shOp.HookManager.GetHooksInOrder(hook_types.KubernetesMutating)
+	if err != nil {
+		return fmt.Errorf("get mutating hooks: %w", err)
+	}
+	for _, name := range append(admissionHookNames, mutatingHookNames...) {
+		h := shOp.HookManager.GetHook(name)
+		if h != nil {
+			h.HookController.EnableAdmissionBindings()
+		}
+	}
+
+	// Enable conversion bindings on every newly loaded hook so that
+	// CanHandleConversionEvent works.
+	conversionHookNames, err := shOp.HookManager.GetHooksInOrder(hook_types.KubernetesConversion)
+	if err != nil {
+		return fmt.Errorf("get conversion hooks: %w", err)
+	}
+	for _, name := range conversionHookNames {
+		h := shOp.HookManager.GetHook(name)
+		if h != nil {
+			h.HookController.EnableConversionBindings()
+		}
+	}
+
 	// Re-enable kubernetes bindings on every newly loaded hook so that the
 	// monitors that maintain object caches (snapshots) are recreated and
 	// wired to the freshly rebuilt HookController.
@@ -164,36 +193,6 @@ func reloadHooks(ctx context.Context, shOp *shell_operator.ShellOperator, logger
 		}
 		// Allow the monitors to emit events now that their caches are filled.
 		h.HookController.UnlockKubernetesEvents()
-	}
-
-	// Enable admission bindings on every newly loaded hook so that
-	// AdmissionLinks are populated and CanHandleEvent works.
-	admissionHookNames, err := shOp.HookManager.GetHooksInOrder(hook_types.KubernetesValidating)
-	if err != nil {
-		return fmt.Errorf("get validating hooks: %w", err)
-	}
-	mutatingHookNames, err := shOp.HookManager.GetHooksInOrder(hook_types.KubernetesMutating)
-	if err != nil {
-		return fmt.Errorf("get mutating hooks: %w", err)
-	}
-	for _, name := range append(admissionHookNames, mutatingHookNames...) {
-		h := shOp.HookManager.GetHook(name)
-		if h != nil {
-			h.HookController.EnableAdmissionBindings()
-		}
-	}
-
-	// Enable conversion bindings on every newly loaded hook so that
-	// CanHandleConversionEvent works.
-	conversionHookNames, err := shOp.HookManager.GetHooksInOrder(hook_types.KubernetesConversion)
-	if err != nil {
-		return fmt.Errorf("get conversion hooks: %w", err)
-	}
-	for _, name := range conversionHookNames {
-		h := shOp.HookManager.GetHook(name)
-		if h != nil {
-			h.HookController.EnableConversionBindings()
-		}
 	}
 
 	if err := syncAdmissionWebhookConfigurations(ctx, shOp, oldValidatingResources, oldMutatingResources); err != nil {

--- a/modules/002-deckhouse/images/webhook-handler/operator/cmd/main.go
+++ b/modules/002-deckhouse/images/webhook-handler/operator/cmd/main.go
@@ -27,8 +27,6 @@ import (
 	"sync"
 	"time"
 
-	deckhouseiov1alpha1 "deckhouse.io/webhook/api/v1alpha1"
-	"deckhouse.io/webhook/internal/controller"
 	sh_pkg "github.com/flant/shell-operator/pkg"
 	sh_app "github.com/flant/shell-operator/pkg/app"
 	hook_types "github.com/flant/shell-operator/pkg/hook/types"
@@ -51,6 +49,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	"github.com/deckhouse/deckhouse/pkg/log"
+
+	deckhouseiov1alpha1 "deckhouse.io/webhook/api/v1alpha1"
+	"deckhouse.io/webhook/internal/controller"
 )
 
 var (


### PR DESCRIPTION
## Description
In `reloadHooks` (webhook-handler operator), the order of binding setup during a hook reload was incorrect: `EnableKubernetesBindings` + `UnlockKubernetesEvents` ran first, and only afterwards were admission (`EnableAdmissionBindings`) and conversion (`EnableConversionBindings`) bindings enabled on the freshly re-created `HookControllers`. This left a window after the kubernetes event queue was unlocked but before the admission/conversion links were populated, during which the controllers processed events with an incomplete binding state. The change moves the admission and conversion binding setup to run before the kubernetes bindings are enabled and unlocked, so that by the time the controllers start dispatching events, all binding types are fully wired

## Why do we need it, and what problem does it solve?
During a hook reload (e.g. after `ModuleConfig` changes or hook file edits), `HookManager.Init()` replaces every `Hook` and its `HookController` with brand-new instances that have no registered bindings. The previous ordering re-enabled kubernetes monitors and unlocked their event queue before re-enabling admission and conversion bindings on those new controllers. As a result, in the window between `UnlockKubernetesEvents` and `EnableAdmissionBindings/EnableConversionBindings`, the hook controllers had no admission links and no conversion bindings, so validating/mutating webhook requests and CRD conversion calls arriving in that window could not be matched to a handler and were effectively dropped or mishandled. Enabling admission and conversion bindings first, and only then enabling kubernetes bindings and unlocking events, closes that race and guarantees the webhook handler serves admission and conversion requests correctly throughout the entire reload

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix 
summary: Move webhook bindings before kubernetes unlock
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
