### PR TITLE
[admission-policy-engine] Fix constraint-template check of AssignImage crd

### DIFF
--- a/modules/015-admission-policy-engine/images/constraint-exporter/src/pkg/gatekeeper/mutations.go
+++ b/modules/015-admission-policy-engine/images/constraint-exporter/src/pkg/gatekeeper/mutations.go
@@ -19,19 +19,26 @@ package gatekeeper
 import (
 	"context"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 	controllerClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
-	mutationsGroup        = "mutations.gatekeeper.sh"
-	mutationsGroupVersion = "v1"
-	mutationsGV           = mutationsGroup + "/" + mutationsGroupVersion
+	mutationsGroup               = "mutations.gatekeeper.sh"
+	mutationsGroupVersionV1      = "v1"
+	mutationsGroupVersionV1Alpha = "v1alpha1"
 )
+
+var mutationsGVs = []string{
+	mutationsGroup + "/" + mutationsGroupVersionV1,
+	mutationsGroup + "/" + mutationsGroupVersionV1Alpha,
+}
 
 type MutationMeta struct {
 	Kind string
@@ -51,41 +58,58 @@ func (m Mutation) GetMatchKinds() []MatchKind {
 	return m.Spec.Match.Kinds
 }
 
-func GetMutations(cClient controllerClient.Client, client *kubernetes.Clientset) ([]Mutation, error) {
-	c, err := client.ServerResourcesForGroupVersion(mutationsGV)
-	if err != nil {
-		return nil, err
-	}
+type listClient interface {
+	List(ctx context.Context, list controllerClient.ObjectList, opts ...controllerClient.ListOption) error
+}
 
-	var mutations []Mutation
-	for _, r := range c.APIResources {
-		canList := false
-		for _, verb := range r.Verbs {
-			if verb == "list" {
-				canList = true
-				break
-			}
-		}
+func GetMutations(cClient controllerClient.Client, client kubernetes.Interface) ([]Mutation, error) {
+	return getMutations(cClient, client.Discovery(), mutationsGVs)
+}
 
-		if !canList {
+func getMutations(cClient listClient, discoveryClient discovery.DiscoveryInterface, groupVersions []string) ([]Mutation, error) {
+	var (
+		mutations []Mutation
+		lastErr   error
+	)
+
+	seen := make(map[string]struct{})
+
+	for _, mutationsGV := range groupVersions {
+		c, err := discoveryClient.ServerResourcesForGroupVersion(mutationsGV)
+		if err != nil {
+			lastErr = err
 			continue
 		}
-		actual := &unstructured.UnstructuredList{}
-		actual.SetGroupVersionKind(schema.GroupVersionKind{
-			Group:   mutationsGroup,
-			Kind:    r.Kind,
-			Version: mutationsGroupVersion,
-		})
 
-		err = cClient.List(context.TODO(), actual)
+		gv, err := schema.ParseGroupVersion(c.GroupVersion)
 		if err != nil {
 			return nil, err
 		}
 
-		if len(actual.Items) > 0 {
-			for _, item := range actual.Items {
-				var mutation Mutation
+		for _, r := range c.APIResources {
+			if !canListResource(r) {
+				continue
+			}
 
+			actual := &unstructured.UnstructuredList{}
+			actual.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   mutationsGroup,
+				Kind:    r.Kind,
+				Version: gv.Version,
+			})
+
+			err = cClient.List(context.TODO(), actual)
+			if err != nil {
+				return nil, err
+			}
+
+			for _, item := range actual.Items {
+				uniqKey := item.GetKind() + "/" + item.GetName()
+				if _, ok := seen[uniqKey]; ok {
+					continue
+				}
+
+				var mutation Mutation
 				err := runtime.DefaultUnstructuredConverter.FromUnstructured(item.UnstructuredContent(), &mutation)
 				if err != nil {
 					klog.Error(err)
@@ -94,10 +118,25 @@ func GetMutations(cClient controllerClient.Client, client *kubernetes.Clientset)
 
 				mutation.Meta.Kind = item.GetKind()
 				mutation.Meta.Name = item.GetName()
-
 				mutations = append(mutations, mutation)
+				seen[uniqKey] = struct{}{}
 			}
 		}
 	}
+
+	if len(mutations) == 0 && lastErr != nil {
+		return nil, lastErr
+	}
+
 	return mutations, nil
+}
+
+func canListResource(resource metav1.APIResource) bool {
+	for _, verb := range resource.Verbs {
+		if verb == "list" {
+			return true
+		}
+	}
+
+	return false
 }

--- a/modules/015-admission-policy-engine/images/constraint-exporter/src/pkg/gatekeeper/mutations_test.go
+++ b/modules/015-admission-policy-engine/images/constraint-exporter/src/pkg/gatekeeper/mutations_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package gatekeeper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestGetMutations_V1Alpha1Only(t *testing.T) {
+	obj := newMutationObject("mutations.gatekeeper.sh/v1alpha1", "AssignImage", "assign-image-v1alpha1")
+	client := ctrlfake.NewClientBuilder().WithRuntimeObjects(obj).Build()
+	kubeClient := k8sfake.NewSimpleClientset()
+
+	discovery := kubeClient.Discovery().(*fakediscovery.FakeDiscovery)
+	discovery.Resources = []*metav1.APIResourceList{
+		{
+			GroupVersion: "mutations.gatekeeper.sh/v1alpha1",
+			APIResources: []metav1.APIResource{
+				{Name: "assignimages", Kind: "AssignImage", Verbs: metav1.Verbs{"list"}},
+			},
+		},
+	}
+
+	mutations, err := GetMutations(client, kubeClient)
+	require.NoError(t, err)
+	require.Len(t, mutations, 1)
+	require.Equal(t, "AssignImage", mutations[0].Meta.Kind)
+	require.Equal(t, "assign-image-v1alpha1", mutations[0].Meta.Name)
+	require.Equal(t, []MatchKind{{APIGroups: []string{""}, Kinds: []string{"Pod"}}}, mutations[0].Spec.Match.Kinds)
+}
+
+func TestGetMutations_V1Only(t *testing.T) {
+	obj := newMutationObject("mutations.gatekeeper.sh/v1", "AssignImage", "assign-image-v1")
+	client := ctrlfake.NewClientBuilder().WithRuntimeObjects(obj).Build()
+	kubeClient := k8sfake.NewSimpleClientset()
+
+	discovery := kubeClient.Discovery().(*fakediscovery.FakeDiscovery)
+	discovery.Resources = []*metav1.APIResourceList{
+		{
+			GroupVersion: "mutations.gatekeeper.sh/v1",
+			APIResources: []metav1.APIResource{
+				{Name: "assignimages", Kind: "AssignImage", Verbs: metav1.Verbs{"list"}},
+			},
+		},
+	}
+
+	mutations, err := GetMutations(client, kubeClient)
+	require.NoError(t, err)
+	require.Len(t, mutations, 1)
+	require.Equal(t, "AssignImage", mutations[0].Meta.Kind)
+	require.Equal(t, "assign-image-v1", mutations[0].Meta.Name)
+	require.Equal(t, []MatchKind{{APIGroups: []string{""}, Kinds: []string{"Pod"}}}, mutations[0].Spec.Match.Kinds)
+}
+
+func newMutationObject(apiVersion, kind, name string) runtime.Object {
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": apiVersion,
+		"kind":       kind,
+		"metadata": map[string]interface{}{
+			"name": name,
+		},
+		"spec": map[string]interface{}{
+			"match": map[string]interface{}{
+				"kinds": []interface{}{
+					map[string]interface{}{
+						"apiGroups": []interface{}{""},
+						"kinds":     []interface{}{"Pod"},
+					},
+				},
+			},
+		},
+	}}
+}


### PR DESCRIPTION

## Description

Fix mutation resource discovery in admission-policy-engine constraint-exporter for Gatekeeper mutation APIs.

The exporter now supports both` mutations.gatekeeper.sh/v1` and `mutations.gatekeeper.sh/v1alpha1`, so mutation tracking is populated even on clusters where only `v1alpha1` mutation CRDs are served (including AssignImage).

Also added unit tests for version-specific discovery scenarios.

## Why do we need it, and what problem does it solve?

AssignImage did not trigger rendering of MutatingWebhookConfiguration because tracked mutate resources stayed empty.

This change makes mutation discovery resilient across both versions and restores the chain:
mutation CRs -> tracked mutate resources -> webhook rules rendering.

## Why do we need it in the patch release (if we do)?
This is a bugfix for existing installations where mutation resources are served via v1alpha1 only. Without it, mutation webhook rules are not generated, and mutation policies (including AssignImage) are effectively non-working.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: admission-policy-engine
type: fix
summary: Fixed the constraint-template check for the AssignImage CRD.
impact_level: default
```
