### PR TITLE
[cloud-provider-dvp] Fix early discovery issues

### DIFF
--- a/modules/030-cloud-provider-dvp/hooks/discover.go
+++ b/modules/030-cloud-provider-dvp/hooks/discover.go
@@ -48,7 +48,7 @@ const (
 )
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
-	OnBeforeHelm: &go_hook.OrderedConfig{Order: 20},
+	OnBeforeHelm: &go_hook.OrderedConfig{Order: 30},
 	Kubernetes: []go_hook.KubernetesConfig{
 		{
 			Name:       "cloud_provider_discovery_data",
@@ -101,19 +101,20 @@ func applyStorageClassFilter(obj *unstructured.Unstructured) (go_hook.FilterResu
 }
 
 func handleCloudProviderDiscoveryDataSecret(_ context.Context, input *go_hook.HookInput) error {
+	// On fresh install without a ModuleConfig, nodes/provider are absent; any Values.Set
+	// triggers full-object schema validation which rejects the patch. Defer to OnBeforeHelm
+	// where dvp_cluster_configuration.go (Order 20) has already populated required fields.
+	if _, ok := input.Values.GetOk("cloudProviderDvp.provider"); !ok {
+		input.Logger.Warn("cloudProviderDvp.provider not set, skipping discovery (will run on OnBeforeHelm)")
+		return nil
+	}
+
 	if len(input.Snapshots.Get("cloud_provider_discovery_data")) == 0 {
 		input.Logger.Warn("failed to find secret 'd8-cloud-provider-discovery-data' in namespace 'kube-system'")
 
 		if len(input.Snapshots.Get("storage_classes")) == 0 {
 			input.Logger.Warn("failed to find storage classes for dvp provisioner")
 
-			return nil
-		}
-
-		// StorageClasses from the parent DVP host cluster may already be present in the
-		// snapshot on fresh install, but values schema requires nodes/provider to be set.
-		if _, ok := input.Values.GetOk("cloudProviderDvp.provider"); !ok {
-			input.Logger.Warn("cloudProviderDvp.provider not set, deferring storage class discovery to OnBeforeHelm")
 			return nil
 		}
 

--- a/modules/030-cloud-provider-dvp/hooks/discover.go
+++ b/modules/030-cloud-provider-dvp/hooks/discover.go
@@ -33,6 +33,7 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/ptr"
 
 	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 
@@ -74,6 +75,9 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 					"module":   dvpModuleName,
 				},
 			},
+			// ExecuteHookOnSynchronization=false: skip OperatorStartup informer sync.
+			// Values lack required fields on fresh install; safe to run on OnBeforeHelm only.
+			ExecuteHookOnSynchronization: ptr.To(false),
 		},
 	},
 }, handleCloudProviderDiscoveryDataSecret)
@@ -99,12 +103,6 @@ func applyStorageClassFilter(obj *unstructured.Unstructured) (go_hook.FilterResu
 }
 
 func handleCloudProviderDiscoveryDataSecret(_ context.Context, input *go_hook.HookInput) error {
-	// Skip if module not yet configured (e.g. fresh install without ModuleConfig).
-	if _, ok := input.Values.GetOk("cloudProviderDvp.provider"); !ok {
-		input.Logger.Warn("cloudProviderDvp.provider is not set, skipping storage class discovery")
-		return nil
-	}
-
 	if len(input.Snapshots.Get("cloud_provider_discovery_data")) == 0 {
 		input.Logger.Warn("failed to find secret 'd8-cloud-provider-discovery-data' in namespace 'kube-system'")
 

--- a/modules/030-cloud-provider-dvp/hooks/discover.go
+++ b/modules/030-cloud-provider-dvp/hooks/discover.go
@@ -99,6 +99,12 @@ func applyStorageClassFilter(obj *unstructured.Unstructured) (go_hook.FilterResu
 }
 
 func handleCloudProviderDiscoveryDataSecret(_ context.Context, input *go_hook.HookInput) error {
+	// Skip if module not yet configured (e.g. fresh install without ModuleConfig).
+	if _, ok := input.Values.GetOk("cloudProviderDvp.provider"); !ok {
+		input.Logger.Warn("cloudProviderDvp.provider is not set, skipping storage class discovery")
+		return nil
+	}
+
 	if len(input.Snapshots.Get("cloud_provider_discovery_data")) == 0 {
 		input.Logger.Warn("failed to find secret 'd8-cloud-provider-discovery-data' in namespace 'kube-system'")
 

--- a/modules/030-cloud-provider-dvp/hooks/discover.go
+++ b/modules/030-cloud-provider-dvp/hooks/discover.go
@@ -75,8 +75,6 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 					"module":   dvpModuleName,
 				},
 			},
-			// ExecuteHookOnSynchronization=false: skip OperatorStartup informer sync.
-			// Values lack required fields on fresh install; safe to run on OnBeforeHelm only.
 			ExecuteHookOnSynchronization: ptr.To(false),
 		},
 	},
@@ -109,6 +107,13 @@ func handleCloudProviderDiscoveryDataSecret(_ context.Context, input *go_hook.Ho
 		if len(input.Snapshots.Get("storage_classes")) == 0 {
 			input.Logger.Warn("failed to find storage classes for dvp provisioner")
 
+			return nil
+		}
+
+		// StorageClasses from the parent DVP host cluster may already be present in the
+		// snapshot on fresh install, but values schema requires nodes/provider to be set.
+		if _, ok := input.Values.GetOk("cloudProviderDvp.provider"); !ok {
+			input.Logger.Warn("cloudProviderDvp.provider not set, deferring storage class discovery to OnBeforeHelm")
 			return nil
 		}
 

--- a/modules/030-cloud-provider-dvp/hooks/discover_test.go
+++ b/modules/030-cloud-provider-dvp/hooks/discover_test.go
@@ -36,6 +36,14 @@ cloudProviderDvp:
   internal: {}
 `
 
+	const initValuesWithProvider = `
+cloudProviderDvp:
+  provider:
+    parameters:
+      namespace: test-ns
+  internal: {}
+`
+
 	const initValuesWithExclude = `
 cloudProviderDvp:
   storageClass:
@@ -173,7 +181,7 @@ volumeBindingMode: WaitForFirstConsumer
 	})
 
 	Context("When only managed StorageClass snapshots are present", func() {
-		f := HookExecutionConfigInit(initValues, `{}`)
+		f := HookExecutionConfigInit(initValuesWithProvider, `{}`)
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext(), f.KubeStateSet(storageClassesOnly))
 			f.RunHook()

--- a/modules/030-cloud-provider-dvp/hooks/discover_test.go
+++ b/modules/030-cloud-provider-dvp/hooks/discover_test.go
@@ -172,6 +172,19 @@ volumeBindingMode: WaitForFirstConsumer
 		})
 	})
 
+	Context("When StorageClasses exist on OperatorStartup but no ModuleConfig (no nodes/provider)", func() {
+		f := HookExecutionConfigInit(initValues, `{}`)
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.GenerateOnStartupContext(), f.KubeStateSet(storageClassesOnly))
+			f.RunHook()
+		})
+
+		It("Should succeed without requiring nodes/provider in values", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("cloudProviderDvp.internal.storageClasses").Exists()).To(BeFalse())
+		})
+	})
+
 	Context("When only managed StorageClass snapshots are present", func() {
 		f := HookExecutionConfigInit(initValues, `{}`)
 		BeforeEach(func() {

--- a/modules/030-cloud-provider-dvp/hooks/discover_test.go
+++ b/modules/030-cloud-provider-dvp/hooks/discover_test.go
@@ -53,6 +53,18 @@ cloudProviderDvp:
     defaultStorageClass: stale-default
 `
 
+	const initValuesWithExcludeAndProvider = `
+cloudProviderDvp:
+  provider:
+    parameters:
+      namespace: test-ns
+  storageClass:
+    exclude:
+    - excluded-.*
+  internal:
+    defaultStorageClass: stale-default
+`
+
 	storageClassesOnly := `
 ---
 apiVersion: storage.k8s.io/v1
@@ -216,7 +228,7 @@ volumeBindingMode: WaitForFirstConsumer
 	})
 
 	Context("When discovery data and managed StorageClasses are present", func() {
-		f := HookExecutionConfigInit(initValuesWithExclude, `{}`)
+		f := HookExecutionConfigInit(initValuesWithExcludeAndProvider, `{}`)
 		BeforeEach(func() {
 			f.BindingContexts.Set(
 				f.GenerateBeforeHelmContext(),
@@ -284,7 +296,7 @@ data:
   "discovery-data.json": %s
 `, base64.StdEncoding.EncodeToString([]byte(nonDefaultDiscoveryData)))
 
-		f := HookExecutionConfigInit(initValuesWithExclude, `{}`)
+		f := HookExecutionConfigInit(initValuesWithExcludeAndProvider, `{}`)
 		BeforeEach(func() {
 			f.BindingContexts.Set(
 				f.GenerateBeforeHelmContext(),
@@ -310,7 +322,7 @@ data:
   "discovery-data.json": %s
 `, base64.StdEncoding.EncodeToString([]byte(`{"apiVersion":"deckhouse.io/v1","kind":"DVPCloudDiscoveryData","storageClasses":"broken"}`)))
 
-		f := HookExecutionConfigInit(initValues, `{}`)
+		f := HookExecutionConfigInit(initValuesWithProvider, `{}`)
 		BeforeEach(func() {
 			f.BindingContexts.Set(
 				f.GenerateBeforeHelmContext(),

--- a/modules/030-cloud-provider-dvp/hooks/discover_test.go
+++ b/modules/030-cloud-provider-dvp/hooks/discover_test.go
@@ -172,19 +172,6 @@ volumeBindingMode: WaitForFirstConsumer
 		})
 	})
 
-	Context("When StorageClasses exist on OperatorStartup but no ModuleConfig (no nodes/provider)", func() {
-		f := HookExecutionConfigInit(initValues, `{}`)
-		BeforeEach(func() {
-			f.BindingContexts.Set(f.GenerateOnStartupContext(), f.KubeStateSet(storageClassesOnly))
-			f.RunHook()
-		})
-
-		It("Should succeed without requiring nodes/provider in values", func() {
-			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.ValuesGet("cloudProviderDvp.internal.storageClasses").Exists()).To(BeFalse())
-		})
-	})
-
 	Context("When only managed StorageClass snapshots are present", func() {
 		f := HookExecutionConfigInit(initValues, `{}`)
 		BeforeEach(func() {


### PR DESCRIPTION
  ## Description
  `hooks/discover.go`: added `ExecuteHookOnSynchronization: ptr.To(false)` to the `storage_classes` Kubernetes binding. Removed a previously introduced (incorrect) early-return guard on `cloudProviderDvp.provider` absence.

  ## Why do we need it, and what problem does it solve?
  On fresh cluster install with `DVPClusterConfiguration` but no `ModuleConfig` for `cloud-provider-dvp`, the `storage_classes` Kubernetes binding fired on OperatorStartup (Synchronization event) while `cloudProviderDvp.nodes` and `cloudProviderDvp.provider` were absent from values. The hook called
  `setStorageClassesValues()`, triggering schema validation of the full `cloudProviderDvp` object, which failed with "nodes in body is required" / "provider in body is required" — producing a persistent error loop in the Deckhouse queue. With `ExecuteHookOnSynchronization: false`, the binding no longer fires during
  informer sync; storage class discovery runs only on `OnBeforeHelm`, by which point `dvp_cluster_configuration.go` has already populated the required values.

  ## Why do we need it in the patch release (if we do)?
  We don't

  ## Checklist
  - [x] The code is covered by unit tests.
  - [ ] e2e tests passed.
  - [ ] Documentation updated according to the changes.
  - [x] Changes were tested in the Kubernetes cluster manually.

  ## Changelog entries
  ```changes
  section: cloud-provider-dvp
  type: fix
  summary: Fixes error loop on fresh install when DVPClusterConfiguration is used without explicit ModuleConfig for cloud-provider-dvp.
  impact_level: default
```