### PR TITLE
[registry-package-proxy] Platform-aware CLI images pull

### DIFF
--- a/go_lib/registry-packages-proxy/proxy/cli_handler_test.go
+++ b/go_lib/registry-packages-proxy/proxy/cli_handler_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 	"time"
 
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -51,13 +52,16 @@ func TestParseCLIPath(t *testing.T) {
 		wantErr    bool
 	}{
 		{url: "/v1/images/deckhouse-cli/tags", wantImg: "deckhouse-cli", wantAction: cliActionListTags},
-		{url: "/v1/images/deckhouse-cli/tags/v1.0.1", wantImg: "deckhouse-cli", wantAction: cliActionPullTag, wantTag: "v1.0.1"},
+		{url: "/v1/images/deckhouse-cli/images/v1.0.1", wantImg: "deckhouse-cli", wantAction: cliActionPullImage, wantTag: "v1.0.1"},
 		{url: "/v1/images/deckhouse-cli/plugins/tags", wantImg: "deckhouse-cli/plugins", wantAction: cliActionListTags},
 		{url: "/v1/images/deckhouse-cli/plugins/foo/tags", wantImg: "deckhouse-cli/plugins/foo", wantAction: cliActionListTags},
-		{url: "/v1/images/deckhouse-cli/plugins/foo/tags/v2", wantImg: "deckhouse-cli/plugins/foo", wantAction: cliActionPullTag, wantTag: "v2"},
+		{url: "/v1/images/deckhouse-cli/plugins/foo/images/v2", wantImg: "deckhouse-cli/plugins/foo", wantAction: cliActionPullImage, wantTag: "v2"},
+		// A plugin named after the action word must still parse (anchor on the last segment).
+		{url: "/v1/images/deckhouse-cli/plugins/images/images/v1.0.0", wantImg: "deckhouse-cli/plugins/images", wantAction: cliActionPullImage, wantTag: "v1.0.0"},
 		{url: "/v1/images/", wantErr: true},
 		{url: "/v1/images/just-image", wantErr: true},
-		{url: "/v1/images/img/tags/with/slashes", wantErr: true},
+		{url: "/v1/images/deckhouse-cli/images", wantErr: true},
+		{url: "/v1/images/deckhouse-cli/images/with/slash", wantErr: true},
 	}
 
 	for _, tc := range cases {
@@ -110,6 +114,8 @@ type fakeCLIRegistryClient struct {
 	mu                  sync.Mutex
 	tags                map[string][]string
 	tagToManifestDigest map[string]string
+	platformDigests     map[string]string
+	lastPlatform        string
 	packageBody         []byte
 	layerDigest         string
 
@@ -136,13 +142,19 @@ func (f *fakeCLIRegistryClient) ListTags(_ context.Context, _ pkgLog.Logger, _ *
 	return tags, nil
 }
 
-func (f *fakeCLIRegistryClient) ResolveTag(_ context.Context, _ pkgLog.Logger, _ *registry.ClientConfig, path, tag string) (string, error) {
+func (f *fakeCLIRegistryClient) ResolveTag(_ context.Context, _ pkgLog.Logger, _ *registry.ClientConfig, path, tag string, platform *v1.Platform) (string, error) {
 	atomic.AddInt32(&f.resolveTagCalls, 1)
 	if f.resolveTagErr != nil {
 		return "", f.resolveTagErr
 	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	if platform != nil {
+		f.lastPlatform = platform.String()
+		if d, ok := f.platformDigests[path+":"+tag+":"+platform.String()]; ok {
+			return d, nil
+		}
+	}
 	d, ok := f.tagToManifestDigest[path+":"+tag]
 	if !ok {
 		return "", registry.ErrPackageNotFound
@@ -321,7 +333,7 @@ func TestCLIHandler_DisallowedImagePath(t *testing.T) {
 	assert.Equal(t, int32(0), atomic.LoadInt32(&fake.listTagsCalls))
 }
 
-func TestCLIHandler_PullTag_HappyPathAndCache(t *testing.T) {
+func TestCLIHandler_PullImage_HappyPathAndCache(t *testing.T) {
 	const payload = "hello, world"
 	fake := &fakeCLIRegistryClient{
 		tagToManifestDigest: map[string]string{
@@ -339,7 +351,7 @@ func TestCLIHandler_PullTag_HappyPathAndCache(t *testing.T) {
 	defer srv.Close()
 
 	// First request: cache miss, registry consulted.
-	resp, err := http.Get(srv.URL + "/v1/images/deckhouse-cli/tags/v1.0.1")
+	resp, err := http.Get(srv.URL + "/v1/images/deckhouse-cli/images/v1.0.1")
 	require.NoError(t, err)
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
@@ -363,7 +375,7 @@ func TestCLIHandler_PullTag_HappyPathAndCache(t *testing.T) {
 	}, cliEventuallyTimeout, cliEventuallyInterval)
 
 	// Second request: should be served from cache, registry GetPackage NOT called again.
-	resp2, err := http.Get(srv.URL + "/v1/images/deckhouse-cli/tags/v1.0.1")
+	resp2, err := http.Get(srv.URL + "/v1/images/deckhouse-cli/images/v1.0.1")
 	require.NoError(t, err)
 	body2, err := io.ReadAll(resp2.Body)
 	require.NoError(t, err)
@@ -375,7 +387,7 @@ func TestCLIHandler_PullTag_HappyPathAndCache(t *testing.T) {
 	assert.GreaterOrEqual(t, atomic.LoadInt32(&cache.hits), int32(1))
 }
 
-func TestCLIHandler_PullTag_NotFound(t *testing.T) {
+func TestCLIHandler_PullImage_NotFound(t *testing.T) {
 	fake := &fakeCLIRegistryClient{
 		tagToManifestDigest: map[string]string{},
 	}
@@ -386,13 +398,13 @@ func TestCLIHandler_PullTag_NotFound(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
-	resp, err := http.Get(srv.URL + "/v1/images/deckhouse-cli/tags/v99.99.99")
+	resp, err := http.Get(srv.URL + "/v1/images/deckhouse-cli/images/v99.99.99")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 }
 
-func TestCLIHandler_PullTag_BadGatewayOnRegistryError(t *testing.T) {
+func TestCLIHandler_PullImage_BadGatewayOnRegistryError(t *testing.T) {
 	fake := &fakeCLIRegistryClient{
 		resolveTagErr: errors.New("boom"),
 	}
@@ -403,8 +415,75 @@ func TestCLIHandler_PullTag_BadGatewayOnRegistryError(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
-	resp, err := http.Get(srv.URL + "/v1/images/deckhouse-cli/tags/v1.0.0")
+	resp, err := http.Get(srv.URL + "/v1/images/deckhouse-cli/images/v1.0.0")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusBadGateway, resp.StatusCode)
+}
+
+func TestCLIHandler_PullImage_PlatformSelectsChildDigest(t *testing.T) {
+	const payload = "platform-specific binary"
+	fake := &fakeCLIRegistryClient{
+		platformDigests: map[string]string{
+			"deckhouse-cli:v1.0.1:linux/amd64": "sha256:aaaaamd64",
+			"deckhouse-cli:v1.0.1:linux/arm64": "sha256:bbbbarm64",
+		},
+		packageBody: []byte(payload),
+		layerDigest: "layer123",
+	}
+	cache := newCLIMemCache()
+	p := newTestProxy(t, fake, &fakeCLIGetter{}, cache)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(cliImagesPathPrefix, p.CLIHandler())
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	// arm64: the proxy resolves the arm64 child digest and stamps it as the ETag.
+	// The CLI sends os-arch (dash); the proxy maps it to the OCI os/arch platform.
+	resp, err := http.Get(srv.URL + "/v1/images/deckhouse-cli/images/v1.0.1?platform=linux-arm64")
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, `"sha256:bbbbarm64"`, resp.Header.Get("ETag"))
+	assert.Equal(t, "linux/arm64", fake.lastPlatform)
+
+	// amd64: a different child digest.
+	resp, err = http.Get(srv.URL + "/v1/images/deckhouse-cli/images/v1.0.1?platform=linux-amd64")
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, `"sha256:aaaaamd64"`, resp.Header.Get("ETag"))
+
+	// Different platforms resolved to different digests, so the cache holds two
+	// distinct entries - one platform can never serve another's bytes.
+	require.Eventually(t, func() bool {
+		_, r1, e1 := cache.Get("sha256:aaaaamd64")
+		_, r2, e2 := cache.Get("sha256:bbbbarm64")
+		if e1 == nil && e2 == nil {
+			_ = r1.Close()
+			_ = r2.Close()
+			return true
+		}
+		return false
+	}, cliEventuallyTimeout, cliEventuallyInterval)
+}
+
+func TestCLIHandler_PullImage_InvalidPlatform(t *testing.T) {
+	fake := &fakeCLIRegistryClient{
+		tagToManifestDigest: map[string]string{"deckhouse-cli:v1.0.1": "sha256:deadbeef"},
+	}
+	p := newTestProxy(t, fake, &fakeCLIGetter{}, nil)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(cliImagesPathPrefix, p.CLIHandler())
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	// Not an <os>-<arch> pair: the handler answers 400 and never consults the registry.
+	resp, err := http.Get(srv.URL + "/v1/images/deckhouse-cli/images/v1.0.1?platform=linux-amd64-v8-oops")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, int32(0), atomic.LoadInt32(&fake.resolveTagCalls))
 }

--- a/go_lib/registry-packages-proxy/proxy/proxy.go
+++ b/go_lib/registry-packages-proxy/proxy/proxy.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 
 	"github.com/deckhouse/deckhouse/go_lib/registry-packages-proxy/cache"
 	"github.com/deckhouse/deckhouse/go_lib/registry-packages-proxy/log"
@@ -77,8 +78,8 @@ const (
 	// cliImagesPathPrefix is the URL prefix served on the standard proxy mux for
 	// deckhouse-cli (and plugin) downloads. Paths under it look like:
 	//
-	//   /v1/images/<image>/tags                 -> list tags
-	//   /v1/images/<image>/tags/<tag>           -> download OCI image tar.gz
+	//   /v1/images/<image>/tags               -> list tags
+	//   /v1/images/<image>/images/<version>   -> download OCI image tar.gz
 	//
 	// where <image> must match the allowlist (deckhouse-cli or deckhouse-cli/plugins/<plugin>).
 	// kube-rbac-proxy (the standard sidecar listening on :4219) gates /v1/images/* with its
@@ -283,9 +284,9 @@ func (p *Proxy) Serve(cfg *Config) {
 //
 // Two URL shapes are supported under /v1/images/<image>/:
 //
-//	GET /v1/images/<image>/tags                 -> JSON list of available tags
-//	GET /v1/images/<image>/tags/<tag>           -> stream OCI image tar.gz
-//	                                                as application/x-gzip
+//	GET /v1/images/<image>/tags               -> JSON list of available tags
+//	GET /v1/images/<image>/images/<version>   -> stream OCI image tar.gz
+//	                                              as application/x-gzip
 //
 // <image> must match the deckhouse-cli allowlist (deckhouse-cli or
 // deckhouse-cli/plugins/<plugin>); other paths return 404.
@@ -554,7 +555,7 @@ type cliAction int
 const (
 	cliActionUnknown cliAction = iota
 	cliActionListTags
-	cliActionPullTag
+	cliActionPullImage
 )
 
 type cliTagsResponse struct {
@@ -563,7 +564,7 @@ type cliTagsResponse struct {
 }
 
 func (h *cliHandler) serveHTTP(w http.ResponseWriter, r *http.Request) {
-	imagePath, action, tag, err := parseCLIPath(r.URL.Path)
+	imagePath, action, ref, err := parseCLIPath(r.URL.Path)
 	if err != nil {
 		http.NotFound(w, r)
 		return
@@ -578,8 +579,8 @@ func (h *cliHandler) serveHTTP(w http.ResponseWriter, r *http.Request) {
 	switch action {
 	case cliActionListTags:
 		h.handleListTags(w, r, imagePath)
-	case cliActionPullTag:
-		h.handlePullTag(w, r, imagePath, tag)
+	case cliActionPullImage:
+		h.handlePullImage(w, r, imagePath, ref)
 	default:
 		http.NotFound(w, r)
 	}
@@ -643,7 +644,7 @@ func (h *cliHandler) handleListTags(w http.ResponseWriter, r *http.Request, imag
 	_, _ = w.Write(body)
 }
 
-func (h *cliHandler) handlePullTag(w http.ResponseWriter, r *http.Request, imagePath, tag string) {
+func (h *cliHandler) handlePullImage(w http.ResponseWriter, r *http.Request, imagePath, version string) {
 	if r.Method != http.MethodGet && r.Method != http.MethodHead {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
@@ -651,21 +652,29 @@ func (h *cliHandler) handlePullTag(w http.ResponseWriter, r *http.Request, image
 
 	clientIP := getRequestIP(r)
 	logger := h.proxy.logger
-	logger.Infof("CLI pull image %q tag %q from client %s", imagePath, tag, clientIP)
+
+	platform, err := parsePlatformQuery(r)
+	if err != nil {
+		logger.Errorf("CLI pull image %q version %q from client %s: invalid platform: %v", imagePath, version, clientIP, err)
+		http.Error(w, "invalid platform", http.StatusBadRequest)
+		return
+	}
+
+	logger.Infof("CLI pull image %q version %q platform %q from client %s", imagePath, version, platformString(platform), clientIP)
 
 	cfg, ok := h.cliClientConfig(w, logger)
 	if !ok {
 		return
 	}
 
-	manifestDigest, err := h.proxy.registryClient.ResolveTag(r.Context(), logger, cfg, imagePath, tag)
+	manifestDigest, err := h.proxy.registryClient.ResolveTag(r.Context(), logger, cfg, imagePath, version, platform)
 	if err != nil {
 		if errors.Is(err, registry.ErrPackageNotFound) {
-			http.Error(w, "tag not found", http.StatusNotFound)
+			http.Error(w, "version not found", http.StatusNotFound)
 			return
 		}
-		logger.Errorf("resolve tag %q for %q: %v", tag, imagePath, err)
-		http.Error(w, "failed to resolve tag", http.StatusBadGateway)
+		logger.Errorf("resolve version %q for %q: %v", version, imagePath, err)
+		http.Error(w, "failed to resolve version", http.StatusBadGateway)
 		return
 	}
 
@@ -700,7 +709,7 @@ func (h *cliHandler) handlePullTag(w http.ResponseWriter, r *http.Request, image
 	}
 
 	w.Header().Set("Content-Type", "application/x-gzip")
-	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s-%s.tar.gz"`, fileBase, tag))
+	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s-%s.tar.gz"`, fileBase, version))
 	w.Header().Set("Content-Length", strconv.FormatInt(size, 10))
 	w.Header().Set("Cache-Control", "public, max-age=31536000")
 	w.Header().Set("ETag", `"`+manifestDigest+`"`)
@@ -715,50 +724,85 @@ func (h *cliHandler) handlePullTag(w http.ResponseWriter, r *http.Request, image
 	}
 }
 
+// parsePlatformQuery reads the optional ?platform=<os>-<arch> selector a CLI
+// client attaches to a pull. Absent -> nil, which keeps the legacy single-manifest
+// behavior (the registry default platform). The dash separator keeps the value a
+// single unescaped URL token; go-containerregistry's Platform uses os/arch, so we
+// build it directly. A malformed value is an error so the handler answers 400
+// instead of silently serving the wrong architecture.
+func parsePlatformQuery(r *http.Request) (*v1.Platform, error) {
+	raw := r.URL.Query().Get("platform")
+	if raw == "" {
+		return nil, nil
+	}
+
+	parts := strings.Split(raw, "-")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return nil, fmt.Errorf("platform %q is not <os>-<arch>", raw)
+	}
+
+	return &v1.Platform{OS: parts[0], Architecture: parts[1]}, nil
+}
+
+// platformString renders a platform for logs ("any" when none was requested).
+func platformString(p *v1.Platform) string {
+	if p == nil {
+		return "any"
+	}
+
+	return p.String()
+}
+
 // parseCLIPath splits an HTTP path of the form
 //
 //	/v1/images/<image-path>/tags
-//	/v1/images/<image-path>/tags/<tag>
+//	/v1/images/<image-path>/images/<version>
 //
-// into its components. <image-path> may contain slashes; the split anchors on the final
-// /tags segment.
+// into its components. <image-path> may contain slashes; the split anchors on the
+// action segment, taking its last occurrence so a plugin named after a segment word
+// is not misparsed. The returned third value is the version (empty for a tags list).
 func parseCLIPath(urlPath string) (string, cliAction, string, error) {
 	if !strings.HasPrefix(urlPath, cliImagesPathPrefix) {
 		return "", cliActionUnknown, "", errors.New("not a CLI path")
 	}
-	// rest is the part of the path after the /v1/images/ prefix
-	rest := strings.TrimPrefix(urlPath, cliImagesPathPrefix)
-	rest = strings.Trim(rest, "/")
+
+	rest := strings.Trim(strings.TrimPrefix(urlPath, cliImagesPathPrefix), "/")
 	if rest == "" {
 		return "", cliActionUnknown, "", errors.New("missing image path")
 	}
 
-	const sep = "/tags"
-	idx := strings.LastIndex(rest, sep)
-	if idx < 0 {
-		return "", cliActionUnknown, "", errors.New("missing tags segment")
-	}
-
-	// imagePath is the part of the path before the tags segment
-	imagePath := rest[:idx]
-	if imagePath == "" {
-		return "", cliActionUnknown, "", errors.New("empty image path")
-	}
-
-	// suffix is the part of the path after the tags segment
-	suffix := rest[idx+len(sep):]
-	switch {
-	case suffix == "" || suffix == "/":
-		return imagePath, cliActionListTags, "", nil
-	case strings.HasPrefix(suffix, "/"):
-		tag := strings.Trim(suffix[1:], "/")
-		if tag == "" || strings.Contains(tag, "/") {
-			return "", cliActionUnknown, "", errors.New("invalid tag")
+	if imagePath, ok := strings.CutSuffix(rest, "/tags"); ok {
+		if imagePath == "" {
+			return "", cliActionUnknown, "", errors.New("empty image path")
 		}
-		return imagePath, cliActionPullTag, tag, nil
-	default:
-		return "", cliActionUnknown, "", errors.New("unexpected path suffix")
+		return imagePath, cliActionListTags, "", nil
 	}
+
+	if imagePath, version, ok := cutCLIActionSegment(rest, "images"); ok {
+		return imagePath, cliActionPullImage, version, nil
+	}
+
+	return "", cliActionUnknown, "", errors.New("unexpected path suffix")
+}
+
+// cutCLIActionSegment splits rest of the form "<image-path>/<segment>/<value>" into
+// (imagePath, value, true). It anchors on the LAST "/<segment>/" so a plugin whose
+// name equals the segment word is not confused. value must be a single non-empty,
+// slash-free path component.
+func cutCLIActionSegment(rest, segment string) (string, string, bool) {
+	marker := "/" + segment + "/"
+	idx := strings.LastIndex(rest, marker)
+	if idx <= 0 {
+		return "", "", false
+	}
+
+	imagePath := rest[:idx]
+	value := rest[idx+len(marker):]
+	if value == "" || strings.Contains(value, "/") {
+		return "", "", false
+	}
+
+	return imagePath, value, true
 }
 
 // isAllowedCLIImagePath enforces the allowlist:
@@ -893,7 +937,7 @@ func (p *Proxy) handleGetIcon(w http.ResponseWriter, r *http.Request, cfg *regis
 	// Icons are immutable for a given manifest digest, so cache aggressively
 	// downstream. Content-Type and the filename extension come from which
 	// file we actually found inside the OCI image (see iconCandidates).
-	// ETag mirrors what cliHandler.handlePullTag does so the header surface
+	// ETag mirrors what cliHandler.handlePullImage does so the header surface
 	// is consistent between routes.
 	w.Header().Set("Content-Type", cand.contentType)
 	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s.%s"`, packageName, cand.ext))
@@ -950,7 +994,7 @@ func (p *Proxy) resolveLatestVersion(w http.ResponseWriter, r *http.Request, cfg
 }
 
 func (p *Proxy) resolveManifestDigest(w http.ResponseWriter, r *http.Request, cfg *registry.ClientConfig, imagePath, version string) (string, bool) {
-	manifestDigest, err := p.registryClient.ResolveTag(r.Context(), p.logger, cfg, imagePath, version)
+	manifestDigest, err := p.registryClient.ResolveTag(r.Context(), p.logger, cfg, imagePath, version, nil)
 	if err != nil {
 		if errors.Is(err, registry.ErrPackageNotFound) {
 			http.Error(w, "tag not found", http.StatusNotFound)

--- a/go_lib/registry-packages-proxy/registry/client.go
+++ b/go_lib/registry-packages-proxy/registry/client.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"io"
 
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/pkg/errors"
 
 	"github.com/deckhouse/deckhouse/go_lib/registry-packages-proxy/log"
@@ -34,7 +35,9 @@ type Client interface {
 	GetPackage(ctx context.Context, log log.Logger, config *ClientConfig, digest string, path string) (int64, string, io.ReadCloser, error)
 	// ResolveTag returns the manifest digest of an image identified by repository path and tag.
 	// The returned digest is suitable for passing as the `digest` argument to GetPackage.
-	ResolveTag(ctx context.Context, log log.Logger, config *ClientConfig, path string, tag string) (string, error)
+	// When platform is non-nil and the tag is a multi-platform image index, the digest of the
+	// matching per-platform child manifest is returned.
+	ResolveTag(ctx context.Context, log log.Logger, config *ClientConfig, path string, tag string, platform *v1.Platform) (string, error)
 	// ListTags returns all tags available for an image identified by repository path.
 	ListTags(ctx context.Context, log log.Logger, config *ClientConfig, path string) ([]string, error)
 }

--- a/go_lib/registry-packages-proxy/registry/default_client.go
+++ b/go_lib/registry-packages-proxy/registry/default_client.go
@@ -131,7 +131,7 @@ func selectImageLayer(image v1.Image, flatten bool) (v1.Layer, error) {
 	})
 }
 
-func (c *DefaultClient) ResolveTag(ctx context.Context, log log.Logger, config *ClientConfig, path string, tag string) (string, error) {
+func (c *DefaultClient) ResolveTag(ctx context.Context, log log.Logger, config *ClientConfig, path string, tag string, platform *v1.Platform) (string, error) {
 	repo := config.Repository
 	if path != "" {
 		repo = fmt.Sprintf("%s/%s", repo, path)
@@ -160,7 +160,48 @@ func (c *DefaultClient) ResolveTag(ctx context.Context, log log.Logger, config *
 		return "", err
 	}
 
+	// For a multi-platform image index, resolve to the per-platform child manifest
+	// digest. The downstream cache is keyed by manifest digest, so returning the
+	// shared index digest would make platforms collide on one cache entry.
+	if platform != nil && desc.MediaType.IsIndex() {
+		idx, err := desc.ImageIndex()
+		if err != nil {
+			return "", err
+		}
+
+		return childDigestForPlatform(idx, platform)
+	}
+
 	return desc.Digest.String(), nil
+}
+
+// childDigestForPlatform returns the digest of the index child manifest matching
+// platform.
+//
+// Walking the index manually (instead of remote.Image + WithPlatform)
+// lets us return ErrPackageNotFound for an absent platform, which the handler maps
+// to a clean 404 rather than a generic error.
+func childDigestForPlatform(idx v1.ImageIndex, platform *v1.Platform) (string, error) {
+	manifest, err := idx.IndexManifest()
+	if err != nil {
+		return "", err
+	}
+
+	for _, m := range manifest.Manifests {
+		if m.Platform == nil {
+			continue
+		}
+		if m.Platform.OS != platform.OS || m.Platform.Architecture != platform.Architecture {
+			continue
+		}
+		if platform.Variant != "" && m.Platform.Variant != platform.Variant {
+			continue
+		}
+
+		return m.Digest.String(), nil
+	}
+
+	return "", ErrPackageNotFound
 }
 
 func (c *DefaultClient) ListTags(ctx context.Context, log log.Logger, config *ClientConfig, path string) ([]string, error) {

--- a/go_lib/registry-packages-proxy/registry/default_client_extra_test.go
+++ b/go_lib/registry-packages-proxy/registry/default_client_extra_test.go
@@ -75,11 +75,59 @@ func TestDefaultClient_ResolveTag(t *testing.T) {
 		Scheme:     "http",
 	}
 
-	got, err := c.ResolveTag(context.Background(), testLogger{}, cfg, "deckhouse-cli", "v1.0.1")
+	got, err := c.ResolveTag(context.Background(), testLogger{}, cfg, "deckhouse-cli", "v1.0.1", nil)
 	require.NoError(t, err)
 	assert.Equal(t, wantDigest, got)
 
-	_, err = c.ResolveTag(context.Background(), testLogger{}, cfg, "deckhouse-cli", "missing-tag")
+	_, err = c.ResolveTag(context.Background(), testLogger{}, cfg, "deckhouse-cli", "missing-tag", nil)
+	require.ErrorIs(t, err, ErrPackageNotFound)
+}
+
+func TestDefaultClient_ResolveTag_Platform(t *testing.T) {
+	host := newTestRegistry(t)
+
+	amd64, err := random.Image(256, 1)
+	require.NoError(t, err)
+	arm64, err := random.Image(256, 1)
+	require.NoError(t, err)
+
+	idx := mutate.AppendManifests(empty.Index,
+		mutate.IndexAddendum{Add: amd64, Descriptor: v1.Descriptor{Platform: &v1.Platform{OS: "linux", Architecture: "amd64"}}},
+		mutate.IndexAddendum{Add: arm64, Descriptor: v1.Descriptor{Platform: &v1.Platform{OS: "linux", Architecture: "arm64"}}},
+	)
+
+	ref, err := name.NewTag(host+"/deckhouse/deckhouse-cli:v2.0.0", name.WeakValidation)
+	require.NoError(t, err)
+	require.NoError(t, v1remote.WriteIndex(ref, idx))
+
+	indexDigest, err := idx.Digest()
+	require.NoError(t, err)
+	amd64Digest, err := amd64.Digest()
+	require.NoError(t, err)
+	arm64Digest, err := arm64.Digest()
+	require.NoError(t, err)
+	require.NotEqual(t, amd64Digest.String(), arm64Digest.String())
+
+	c := &DefaultClient{}
+	cfg := &ClientConfig{Repository: host + "/deckhouse", Scheme: "http"}
+
+	// A requested platform resolves to that child manifest, not the index.
+	got, err := c.ResolveTag(context.Background(), testLogger{}, cfg, "deckhouse-cli", "v2.0.0", &v1.Platform{OS: "linux", Architecture: "arm64"})
+	require.NoError(t, err)
+	assert.Equal(t, arm64Digest.String(), got)
+
+	// Different platforms resolve to different child digests (so the cache can never collide).
+	got, err = c.ResolveTag(context.Background(), testLogger{}, cfg, "deckhouse-cli", "v2.0.0", &v1.Platform{OS: "linux", Architecture: "amd64"})
+	require.NoError(t, err)
+	assert.Equal(t, amd64Digest.String(), got)
+
+	// No platform requested -> the index digest itself (legacy behavior).
+	got, err = c.ResolveTag(context.Background(), testLogger{}, cfg, "deckhouse-cli", "v2.0.0", nil)
+	require.NoError(t, err)
+	assert.Equal(t, indexDigest.String(), got)
+
+	// A platform absent from the index is a clean not-found.
+	_, err = c.ResolveTag(context.Background(), testLogger{}, cfg, "deckhouse-cli", "v2.0.0", &v1.Platform{OS: "windows", Architecture: "amd64"})
 	require.ErrorIs(t, err, ErrPackageNotFound)
 }
 


### PR DESCRIPTION
> [!IMPORTANT]
> **🧩 Stacked PR · registry-packages-proxy · `d8` CLI-download · 1 / 2 · Multiplatform support**
> Merge in this order:
> 1. **Multiplatform support** - #20795 ← this PR
> 2. Direct manifest download - #20800
>
> CLI side: deckhouse/deckhouse-cli#386 · deckhouse/deckhouse-cli#387 · deckhouse/deckhouse-cli#388


## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

The CLI download route now serves the binary for a requested OS/arch. 
When a tag points at a multi-platform image index, the proxy resolves it to the matching per-platform child.

**How it works:**
- The download route is `GET /v1/images/<image>/images/<version>?platform=<os>-<arch>`. The value is split on the dash into OS and architecture.
- `ResolveTag` walks the image index and returns the child manifest digest for that platform.
- A request without a platform keeps the previous behavior and returns the tag's own digest.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

**Before:** The proxy returns same default image for different client's platforms, which leads to broken binary scenarios.
**After:** The CLI pull names its platform and gets the matching child; an unknown platform is a 404.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: registry-packages-proxy
type: feature
summary: Made CLI image pulls in registry-packages-proxy platform-aware.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
