### PR TITLE
[deckhouse] add /app/hugo to docs-builder mount points

### DIFF
--- a/modules/810-documentation/images/docs-builder/mount-points.yaml
+++ b/modules/810-documentation/images/docs-builder/mount-points.yaml
@@ -1,4 +1,5 @@
 dirs:
+- /app/hugo
 - /mount/public/en/modules
 - /mount/public/ru/modules
 - /mount/public/en/search


### PR DESCRIPTION
## Description

### Why do we need it, and what problem does it solve?
The `/app/hugo` mount is used by the docs-builder container (defined in deployment.yaml) but is not listed in mount-points.yaml, which is required for proper bind-mount setup during image build.

### What has been done
- Added `/app/hugo` to the dirs list in mount-points.yaml

## Checklist
- [ ] The code is covered by unit tests.
- [ ] Changes were tested in the Kubernetes cluster manually.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.

## Changelog entries
```changes
section: documentation
type: fix
summary: Add /app/hugo to docs-builder mount points
impact_level: low
```