### PR TITLE
[registry-package-proxy] Serve plugin contract from manifest

### DIFF
--- a/go_lib/registry-packages-proxy/proxy/cli_handler_test.go
+++ b/go_lib/registry-packages-proxy/proxy/cli_handler_test.go
@@ -58,10 +58,15 @@ func TestParseCLIPath(t *testing.T) {
 		{url: "/v1/images/deckhouse-cli/plugins/foo/images/v2", wantImg: "deckhouse-cli/plugins/foo", wantAction: cliActionPullImage, wantTag: "v2"},
 		// A plugin named after the action word must still parse (anchor on the last segment).
 		{url: "/v1/images/deckhouse-cli/plugins/images/images/v1.0.0", wantImg: "deckhouse-cli/plugins/images", wantAction: cliActionPullImage, wantTag: "v1.0.0"},
+		{url: "/v1/images/deckhouse-cli/manifests/v1.0.1", wantImg: "deckhouse-cli", wantAction: cliActionGetManifest, wantTag: "v1.0.1"},
+		{url: "/v1/images/deckhouse-cli/plugins/foo/manifests/v2", wantImg: "deckhouse-cli/plugins/foo", wantAction: cliActionGetManifest, wantTag: "v2"},
+		// A digest ref (colon, no slash) is a valid manifest ref.
+		{url: "/v1/images/deckhouse-cli/plugins/foo/manifests/sha256:abc", wantImg: "deckhouse-cli/plugins/foo", wantAction: cliActionGetManifest, wantTag: "sha256:abc"},
 		{url: "/v1/images/", wantErr: true},
 		{url: "/v1/images/just-image", wantErr: true},
 		{url: "/v1/images/deckhouse-cli/images", wantErr: true},
 		{url: "/v1/images/deckhouse-cli/images/with/slash", wantErr: true},
+		{url: "/v1/images/deckhouse-cli/manifests", wantErr: true},
 	}
 
 	for _, tc := range cases {
@@ -118,14 +123,18 @@ type fakeCLIRegistryClient struct {
 	lastPlatform        string
 	packageBody         []byte
 	layerDigest         string
+	// rawManifests maps "path:ref" -> raw manifest bytes for GetRawManifest.
+	rawManifests map[string]string
 
 	getPackageCalls int32
 	listTagsCalls   int32
 	resolveTagCalls int32
+	manifestCalls   int32
 
 	listTagsErr   error
 	resolveTagErr error
 	getPackageErr error
+	manifestErr   error
 }
 
 func (f *fakeCLIRegistryClient) ListTags(_ context.Context, _ pkgLog.Logger, _ *registry.ClientConfig, path string) ([]string, error) {
@@ -168,6 +177,20 @@ func (f *fakeCLIRegistryClient) GetPackage(_ context.Context, _ pkgLog.Logger, _
 		return 0, "", nil, f.getPackageErr
 	}
 	return int64(len(f.packageBody)), f.layerDigest, io.NopCloser(bytes.NewReader(f.packageBody)), nil
+}
+
+func (f *fakeCLIRegistryClient) GetRawManifest(_ context.Context, _ pkgLog.Logger, _ *registry.ClientConfig, path, ref string) ([]byte, string, error) {
+	atomic.AddInt32(&f.manifestCalls, 1)
+	if f.manifestErr != nil {
+		return nil, "", f.manifestErr
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	raw, ok := f.rawManifests[path+":"+ref]
+	if !ok {
+		return nil, "", registry.ErrPackageNotFound
+	}
+	return []byte(raw), "application/vnd.oci.image.manifest.v1+json", nil
 }
 
 type fakeCLIGetter struct {
@@ -486,4 +509,48 @@ func TestCLIHandler_PullImage_InvalidPlatform(t *testing.T) {
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	assert.Equal(t, int32(0), atomic.LoadInt32(&fake.resolveTagCalls))
+}
+
+func TestCLIHandler_GetManifest_HappyPath(t *testing.T) {
+	const manifestJSON = `{"annotations":{"contract":"e30="}}`
+	fake := &fakeCLIRegistryClient{
+		rawManifests: map[string]string{
+			"deckhouse-cli/plugins/foo:v1.0.0": manifestJSON,
+		},
+	}
+	p := newTestProxy(t, fake, &fakeCLIGetter{}, nil)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(cliImagesPathPrefix, p.CLIHandler())
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/v1/images/deckhouse-cli/plugins/foo/manifests/v1.0.0")
+	require.NoError(t, err)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "application/vnd.oci.image.manifest.v1+json", resp.Header.Get("Content-Type"))
+	// The proxy returns the manifest bytes verbatim - it does not decode the contract.
+	assert.Equal(t, manifestJSON, string(body))
+	assert.Equal(t, int32(1), atomic.LoadInt32(&fake.manifestCalls))
+	// The manifest fetch pulls no image/layer.
+	assert.Equal(t, int32(0), atomic.LoadInt32(&fake.getPackageCalls))
+}
+
+func TestCLIHandler_GetManifest_NotFound(t *testing.T) {
+	fake := &fakeCLIRegistryClient{rawManifests: map[string]string{}}
+	p := newTestProxy(t, fake, &fakeCLIGetter{}, nil)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(cliImagesPathPrefix, p.CLIHandler())
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/v1/images/deckhouse-cli/plugins/foo/manifests/v9.9.9")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 }

--- a/go_lib/registry-packages-proxy/proxy/proxy.go
+++ b/go_lib/registry-packages-proxy/proxy/proxy.go
@@ -80,6 +80,7 @@ const (
 	//
 	//   /v1/images/<image>/tags               -> list tags
 	//   /v1/images/<image>/images/<version>   -> download OCI image tar.gz
+	//   /v1/images/<image>/manifests/<ref>    -> raw image manifest
 	//
 	// where <image> must match the allowlist (deckhouse-cli or deckhouse-cli/plugins/<plugin>).
 	// kube-rbac-proxy (the standard sidecar listening on :4219) gates /v1/images/* with its
@@ -282,11 +283,12 @@ func (p *Proxy) Serve(cfg *Config) {
 // CLIHandler returns an http.HandlerFunc that serves the /v1/images/* CLI download routes
 // (image tag listing and binary pulling) for this Proxy.
 //
-// Two URL shapes are supported under /v1/images/<image>/:
+// Three URL shapes are supported under /v1/images/<image>/:
 //
 //	GET /v1/images/<image>/tags               -> JSON list of available tags
 //	GET /v1/images/<image>/images/<version>   -> stream OCI image tar.gz
 //	                                              as application/x-gzip
+//	GET /v1/images/<image>/manifests/<ref>    -> raw image manifest bytes
 //
 // <image> must match the deckhouse-cli allowlist (deckhouse-cli or
 // deckhouse-cli/plugins/<plugin>); other paths return 404.
@@ -556,6 +558,7 @@ const (
 	cliActionUnknown cliAction = iota
 	cliActionListTags
 	cliActionPullImage
+	cliActionGetManifest
 )
 
 type cliTagsResponse struct {
@@ -581,6 +584,8 @@ func (h *cliHandler) serveHTTP(w http.ResponseWriter, r *http.Request) {
 		h.handleListTags(w, r, imagePath)
 	case cliActionPullImage:
 		h.handlePullImage(w, r, imagePath, ref)
+	case cliActionGetManifest:
+		h.handleGetManifest(w, r, imagePath, ref)
 	default:
 		http.NotFound(w, r)
 	}
@@ -642,6 +647,44 @@ func (h *cliHandler) handleListTags(w http.ResponseWriter, r *http.Request, imag
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Content-Length", strconv.Itoa(len(body)))
 	_, _ = w.Write(body)
+}
+
+// handleGetManifest serves an image's raw manifest without pulling any layers, so
+// the CLI can read the plugin contract from its annotations itself. Returns the
+// manifest bytes (200) with the upstream media type, or 404 when ref does not exist.
+func (h *cliHandler) handleGetManifest(w http.ResponseWriter, r *http.Request, imagePath, ref string) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	clientIP := getRequestIP(r)
+	logger := h.proxy.logger
+	logger.Infof("CLI get-manifest for image %q ref %q from client %s", imagePath, ref, clientIP)
+
+	cfg, ok := h.cliClientConfig(w, logger)
+	if !ok {
+		return
+	}
+
+	manifest, mediaType, err := h.proxy.registryClient.GetRawManifest(r.Context(), logger, cfg, imagePath, ref)
+	if err != nil {
+		if errors.Is(err, registry.ErrPackageNotFound) {
+			http.Error(w, "manifest not found", http.StatusNotFound)
+			return
+		}
+		logger.Errorf("get manifest for %q ref %q: %v", imagePath, ref, err)
+		http.Error(w, "failed to read manifest", http.StatusBadGateway)
+		return
+	}
+
+	if mediaType == "" {
+		mediaType = "application/vnd.oci.image.manifest.v1+json"
+	}
+
+	w.Header().Set("Content-Type", mediaType)
+	w.Header().Set("Content-Length", strconv.Itoa(len(manifest)))
+	_, _ = w.Write(manifest)
 }
 
 func (h *cliHandler) handlePullImage(w http.ResponseWriter, r *http.Request, imagePath, version string) {
@@ -780,6 +823,10 @@ func parseCLIPath(urlPath string) (string, cliAction, string, error) {
 
 	if imagePath, version, ok := cutCLIActionSegment(rest, "images"); ok {
 		return imagePath, cliActionPullImage, version, nil
+	}
+
+	if imagePath, ref, ok := cutCLIActionSegment(rest, "manifests"); ok {
+		return imagePath, cliActionGetManifest, ref, nil
 	}
 
 	return "", cliActionUnknown, "", errors.New("unexpected path suffix")

--- a/go_lib/registry-packages-proxy/registry/client.go
+++ b/go_lib/registry-packages-proxy/registry/client.go
@@ -40,4 +40,7 @@ type Client interface {
 	ResolveTag(ctx context.Context, log log.Logger, config *ClientConfig, path string, tag string, platform *v1.Platform) (string, error)
 	// ListTags returns all tags available for an image identified by repository path.
 	ListTags(ctx context.Context, log log.Logger, config *ClientConfig, path string) ([]string, error)
+	// GetRawManifest returns the raw manifest bytes (and its media type) of an image
+	// identified by repository path and ref (tag or digest), without pulling its layers.
+	GetRawManifest(ctx context.Context, log log.Logger, config *ClientConfig, path string, ref string) ([]byte, string, error)
 }

--- a/go_lib/registry-packages-proxy/registry/default_client.go
+++ b/go_lib/registry-packages-proxy/registry/default_client.go
@@ -204,6 +204,46 @@ func childDigestForPlatform(idx v1.ImageIndex, platform *v1.Platform) (string, e
 	return "", ErrPackageNotFound
 }
 
+// GetRawManifest returns the raw manifest bytes and media type for path:ref without
+// pulling layers. ref is a tag or a digest. remote.Get fetches only the manifest, so
+// this is cheap; the caller (the CLI) parses whatever it needs from the bytes.
+func (c *DefaultClient) GetRawManifest(ctx context.Context, log log.Logger, config *ClientConfig, path string, ref string) ([]byte, string, error) {
+	repo := config.Repository
+	if path != "" {
+		repo = fmt.Sprintf("%s/%s", repo, path)
+	}
+
+	nameOpts := newNameOptions(config.Scheme)
+	repository, err := name.NewRepository(repo, nameOpts...)
+	if err != nil {
+		return nil, "", err
+	}
+
+	remoteOpts, err := newRemoteOptions(ctx, config)
+	if err != nil {
+		return nil, "", err
+	}
+
+	var reference name.Reference = repository.Tag(ref)
+	if strings.Contains(ref, "@") || strings.HasPrefix(ref, "sha256:") {
+		reference = repository.Digest(ref)
+	}
+
+	desc, err := remote.Get(reference, remoteOpts...)
+	if err != nil {
+		e := &transport.Error{}
+		if errors.As(err, &e) {
+			log.Error(e.Error())
+			if e.StatusCode == http.StatusNotFound {
+				return nil, "", ErrPackageNotFound
+			}
+		}
+		return nil, "", err
+	}
+
+	return desc.Manifest, string(desc.MediaType), nil
+}
+
 func (c *DefaultClient) ListTags(ctx context.Context, log log.Logger, config *ClientConfig, path string) ([]string, error) {
 	repo := config.Repository
 	if path != "" {

--- a/go_lib/registry-packages-proxy/registry/default_client_extra_test.go
+++ b/go_lib/registry-packages-proxy/registry/default_client_extra_test.go
@@ -256,3 +256,47 @@ func TestDefaultClient_ListTags(t *testing.T) {
 	_, err = c.ListTags(context.Background(), testLogger{}, cfg, "unknown-image")
 	require.ErrorIs(t, err, ErrPackageNotFound)
 }
+
+func TestDefaultClient_GetRawManifest(t *testing.T) {
+	host := newTestRegistry(t)
+
+	c := &DefaultClient{}
+	cfg := &ClientConfig{Repository: host + "/deckhouse", Scheme: "http"}
+
+	// Single image: the raw manifest is returned verbatim, annotations and all, with
+	// no layers pulled.
+	img, err := random.Image(256, 1)
+	require.NoError(t, err)
+	img, ok := mutate.Annotations(img, map[string]string{"contract": "Zm9v"}).(v1.Image)
+	require.True(t, ok)
+	pushImage(t, host, img, "deckhouse/deckhouse-cli/plugins/single", "v1.0.0")
+
+	raw, mediaType, err := c.GetRawManifest(context.Background(), testLogger{}, cfg, "deckhouse-cli/plugins/single", "v1.0.0")
+	require.NoError(t, err)
+	assert.NotEmpty(t, mediaType)
+	assert.Contains(t, string(raw), "Zm9v")
+
+	// Multi-platform index: the contract is a top-level index annotation. The raw
+	// index manifest is returned as-is - the proxy never descends into a child.
+	amd64, err := random.Image(256, 1)
+	require.NoError(t, err)
+	arm64, err := random.Image(256, 1)
+	require.NoError(t, err)
+	idx := mutate.AppendManifests(empty.Index,
+		mutate.IndexAddendum{Add: amd64, Descriptor: v1.Descriptor{Platform: &v1.Platform{OS: "linux", Architecture: "amd64"}}},
+		mutate.IndexAddendum{Add: arm64, Descriptor: v1.Descriptor{Platform: &v1.Platform{OS: "linux", Architecture: "arm64"}}},
+	)
+	idx, ok = mutate.Annotations(idx, map[string]string{"contract": "YmFy"}).(v1.ImageIndex)
+	require.True(t, ok)
+	ref, err := name.NewTag(host+"/deckhouse/deckhouse-cli/plugins/multi:v2.0.0", name.WeakValidation)
+	require.NoError(t, err)
+	require.NoError(t, v1remote.WriteIndex(ref, idx))
+
+	raw, _, err = c.GetRawManifest(context.Background(), testLogger{}, cfg, "deckhouse-cli/plugins/multi", "v2.0.0")
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), "YmFy")
+
+	// Missing tag -> not found.
+	_, _, err = c.GetRawManifest(context.Background(), testLogger{}, cfg, "deckhouse-cli/plugins/single", "v9.9.9")
+	require.ErrorIs(t, err, ErrPackageNotFound)
+}


### PR DESCRIPTION
> [!IMPORTANT]
> **🧩 Stacked PR · registry-packages-proxy · `d8` CLI-download · 2 / 2 · Direct manifest download**
> Merge in this order:
> 1. Multiplatform support - #20795
> 2. **Direct manifest download** - #20800 ← this PR
>
> CLI side: deckhouse/deckhouse-cli#386 · deckhouse/deckhouse-cli#387 · deckhouse/deckhouse-cli#388

- Paired with deckhouse/deckhouse-cli#388.


## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Adds a route that returns an image manifest as-is:
- the CLI now can read a plugin's contract annotation without pulling the image. 
- The proxy does no decoding, it forwards the manifest bytes only. 
- New route `GET /v1/images/<image>/manifests/<ref>`, where `<ref>` is a tag or a digest.
- `GetRawManifest` fetches only the manifest (no layers) and returns its bytes with the upstream media type. A missing ref is a 404.
- The CLI reads the `contract` annotation itself and, for an index without a top-level annotation, follows a child by digest.

**Before:** the only way for the CLI to read a contract was to download the image and untar `contract.yaml`.

**After:** the CLI fetches the manifest and reads the contract annotation; layers are pulled only when the binary is installed.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Faster contract reading by the client (d8-cli), idiomatically more proper solution for dependency solving. (Manifests for meta, images for content).

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: registry-packages-proxy
type: feature
summary: Served the plugin contract from the image manifest in registry-packages-proxy.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
