### PR TITLE
[cloud-provider-huaweicloud] recreate etcd disk on master vm recreate

### DIFF
--- a/ee/modules/030-cloud-provider-huaweicloud/candi/terraform-modules/kubernetes-data/main.tf
+++ b/ee/modules/030-cloud-provider-huaweicloud/candi/terraform-modules/kubernetes-data/main.tf
@@ -2,19 +2,27 @@
 # Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
 
 resource "huaweicloud_evs_volume" "kubernetes_data" {
-  name              = join("-", [var.prefix, "kubernetes-data", var.node_index])
-  description       = "volume for etcd and kubernetes certs"
-  size              = var.volume_size
-  volume_type       = var.volume_type
-  availability_zone = var.volume_zone
-  tags              = var.tags
+  name                  = join("-", [var.prefix, "kubernetes-data", var.node_index])
+  description           = "volume for etcd and kubernetes certs"
+  size                  = var.volume_size
+  volume_type           = var.volume_type
+  availability_zone     = var.volume_zone
+  tags                  = var.tags
   enterprise_project_id = var.enterprise_project_id
+
   lifecycle {
     ignore_changes = [
       tags,
       availability_zone,
     ]
+    replace_triggered_by = [
+      terraform_data.master,
+    ]
   }
+}
+
+resource "terraform_data" "master" {
+  triggers_replace = var.master_id
 }
 
 resource "huaweicloud_compute_volume_attach" "kubernetes_data" {


### PR DESCRIPTION
## Description
Recreate etcd disk on master vm recreate

## Why do we need it, and what problem does it solve?
If master VM is created during converge, Terraform tries to reattach existing etcd disk even if new VM is being created in different region.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-huaweicloud
type: fix
summary: Recreated the etcd disk when a master VM is recreated.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
