### PR TITLE
[docs] Fix anyOf rendering on levels deepest than 1

### DIFF
--- a/docs/documentation/_plugins/render-jsonschema.rb
+++ b/docs/documentation/_plugins/render-jsonschema.rb
@@ -217,6 +217,56 @@ module JSONSchemaRenderer
         result
     end
 
+    # Methods for processing `anyOf` at a depth greater than 1
+    
+    def anyof_oneof_variants(attributes)
+        return nil unless attributes.is_a?(Hash)
+
+        attributes['anyOf'] || attributes['oneOf']
+    end
+
+    def resolve_attributes_type(attributes)
+        return nil unless attributes.is_a?(Hash)
+        return attributes['type'] if attributes.key?('type')
+        return 'x-kubernetes-int-or-string' if attributes.key?('x-kubernetes-int-or-string')
+
+        variants = anyof_oneof_variants(attributes)
+        return nil unless variants.is_a?(Array) && !variants.empty?
+
+        types = variants.map { |variant| variant.is_a?(Hash) ? variant['type'] : nil }.compact.uniq
+        return nil if types.empty?
+        return 'x-kubernetes-int-or-string' if types.sort == ['integer', 'string']
+        return types[0] if types.length == 1
+
+        types.map { |type| format_type(type, nil) }.join(' or ')
+    end
+
+    def merge_anyof_schema_attributes(attributes)
+        return attributes unless attributes.is_a?(Hash)
+
+        variants = anyof_oneof_variants(attributes)
+        return attributes unless variants.is_a?(Array) && !variants.empty?
+
+        merged = attributes.dup
+        %w[pattern minimum maximum exclusiveMinimum exclusiveMaximum minLength maxLength enum default x-doc-default description example x-doc-example].each do |key|
+            next if merged.key?(key)
+
+            values = variants.map { |variant| variant.is_a?(Hash) ? variant[key] : nil }.compact
+            values.uniq! { |value| value.to_s }
+            next if values.empty?
+
+            if values.length == 1
+                merged[key] = values[0]
+            elsif key == 'pattern'
+                merged['_anyof_patterns'] = values
+            elsif %w[example x-doc-example].include?(key) && !merged.key?('x-doc-examples') && !merged.key?('x-examples')
+                merged['x-doc-examples'] = values
+            end
+        end
+
+        merged
+    end
+
     def format_examples(name, attributes)
         result = Array.new()
         exampleObject = nil
@@ -438,7 +488,13 @@ module JSONSchemaRenderer
             result.push(enum_result)
         end
 
-        if attributes.has_key?('pattern')
+        # Processing anyOf at a level deeper than 1
+        
+        if attributes.has_key?('_anyof_patterns')
+            attributes['_anyof_patterns'].each do |pattern|
+                result.push(sprintf(%q(<p class="resources__attrs"><span class="resources__attrs_name">%s:</span> <code class="resources__attrs_content">%s</code></p>), get_i18n_term("pattern").capitalize, CGI.escapeHTML(pattern)))
+            end
+        elsif attributes.has_key?('pattern')
             result.push(sprintf(%q(<p class="resources__attrs"><span class="resources__attrs_name">%s:</span> <code class="resources__attrs_content">%s</code></p>),get_i18n_term("pattern").capitalize, CGI.escapeHTML(attributes['pattern']) ))
         end
 
@@ -556,14 +612,7 @@ module JSONSchemaRenderer
                 result.push('<li>')
             end
             result.push('<div class="resources__prop_wrap">')
-            attributesType = ''
-            if attributes.is_a?(Hash)
-              if attributes.has_key?('type')
-                 attributesType = attributes["type"]
-              elsif attributes.has_key?('x-kubernetes-int-or-string')
-                 attributesType = "x-kubernetes-int-or-string"
-              end
-            end
+            attributesType = resolve_attributes_type(attributes) || ''
 
             if ( get_hash_value(attributes, 'x-doc-deprecated') or get_hash_value(attributes, 'deprecated') )
                 parameterTextContent = sprintf(%q(<div id="%s" data-anchor-id="%s" class="resources__prop_name anchored">
@@ -578,7 +627,9 @@ module JSONSchemaRenderer
             end
 
             if attributesType != ''
-                if attributes.is_a?(Hash) and attributes.has_key?("items")
+                if attributesType.include?(' or ')
+                    parameterTextContent += sprintf(%q(<span class="resources__prop_type">%s</span>), attributesType)
+                elsif attributes.is_a?(Hash) and attributes.has_key?("items")
                     parameterTextContent += sprintf(%q(<span class="resources__prop_type">%s</span>), format_type(attributesType, attributes["items"]["type"]))
                 else
                     parameterTextContent += sprintf(%q(<span class="resources__prop_type">%s</span>), format_type(attributesType, nil))
@@ -588,7 +639,10 @@ module JSONSchemaRenderer
             result.push(parameterTextContent)
         end
 
-        result.push(format_attribute(name, attributes, parent, primaryLanguage, fallbackLanguage)) if attributes.is_a?(Hash)
+        if attributes.is_a?(Hash)
+            displayAttributes = merge_anyof_schema_attributes(attributes)
+            result.push(format_attribute(name, displayAttributes, parent, primaryLanguage, fallbackLanguage))
+        end
 
         if (@moduleName != '') and attributes.has_key?('x-doc-d8Revision')
           case attributes['x-doc-d8Revision']

--- a/docs/site/_plugins/render-jsonschema.rb
+++ b/docs/site/_plugins/render-jsonschema.rb
@@ -201,6 +201,56 @@ module JSONSchemaRenderer
         result
     end
 
+    # Methods for processing `anyOf` at a depth greater than 1
+    
+    def anyof_oneof_variants(attributes)
+        return nil unless attributes.is_a?(Hash)
+
+        attributes['anyOf'] || attributes['oneOf']
+    end
+
+    def resolve_attributes_type(attributes)
+        return nil unless attributes.is_a?(Hash)
+        return attributes['type'] if attributes.key?('type')
+        return 'x-kubernetes-int-or-string' if attributes.key?('x-kubernetes-int-or-string')
+
+        variants = anyof_oneof_variants(attributes)
+        return nil unless variants.is_a?(Array) && !variants.empty?
+
+        types = variants.map { |variant| variant.is_a?(Hash) ? variant['type'] : nil }.compact.uniq
+        return nil if types.empty?
+        return 'x-kubernetes-int-or-string' if types.sort == ['integer', 'string']
+        return types[0] if types.length == 1
+
+        types.map { |type| format_type(type, nil) }.join(' or ')
+    end
+
+    def merge_anyof_schema_attributes(attributes)
+        return attributes unless attributes.is_a?(Hash)
+
+        variants = anyof_oneof_variants(attributes)
+        return attributes unless variants.is_a?(Array) && !variants.empty?
+
+        merged = attributes.dup
+        %w[pattern minimum maximum exclusiveMinimum exclusiveMaximum minLength maxLength enum default x-doc-default description example x-doc-example].each do |key|
+            next if merged.key?(key)
+
+            values = variants.map { |variant| variant.is_a?(Hash) ? variant[key] : nil }.compact
+            values.uniq! { |value| value.to_s }
+            next if values.empty?
+
+            if values.length == 1
+                merged[key] = values[0]
+            elsif key == 'pattern'
+                merged['_anyof_patterns'] = values
+            elsif %w[example x-doc-example].include?(key) && !merged.key?('x-doc-examples') && !merged.key?('x-examples')
+                merged['x-doc-examples'] = values
+            end
+        end
+
+        merged
+    end
+
     def format_examples(name, attributes)
         result = Array.new()
         exampleObject = nil
@@ -374,7 +424,13 @@ module JSONSchemaRenderer
             result.push(enum_result + ':</span> <span class="resources__attrs_content">'+ [*attributes['enum']].map { |e| "<code>#{e}</code>" }.join(', ') + '</span></p>')
         end
 
-        if attributes.has_key?('pattern')
+        # Processing anyOf at a level deeper than 1
+        
+        if attributes.has_key?('_anyof_patterns')
+            attributes['_anyof_patterns'].each do |pattern|
+                result.push(sprintf(%q(<p class="resources__attrs"><span class="resources__attrs_name">%s:</span> <code class="resources__attrs_content">%s</code></p>), get_i18n_term("pattern").capitalize, CGI.escapeHTML(pattern)))
+            end
+        elsif attributes.has_key?('pattern')
             result.push(sprintf(%q(<p class="resources__attrs"><span class="resources__attrs_name">%s:</span> <code class="resources__attrs_content">%s</code></p>),get_i18n_term("pattern").capitalize, CGI.escapeHTML(attributes['pattern']) ))
         end
 
@@ -476,14 +532,7 @@ module JSONSchemaRenderer
             parameterTextContent = ''
             result.push('<li>')
             result.push('<div class="resources__prop_wrap">')
-            attributesType = ''
-            if attributes.is_a?(Hash)
-              if attributes.has_key?('type')
-                 attributesType = attributes["type"]
-              elsif attributes.has_key?('x-kubernetes-int-or-string')
-                 attributesType = "x-kubernetes-int-or-string"
-              end
-            end
+            attributesType = resolve_attributes_type(attributes) || ''
 
             if ( get_hash_value(attributes, 'x-doc-deprecated') or get_hash_value(attributes, 'deprecated') )
                 parameterTextContent = sprintf(%q(<div id="%s" data-anchor-id="%s" class="resources__prop_name anchored">
@@ -498,7 +547,9 @@ module JSONSchemaRenderer
             end
 
             if attributesType != ''
-                if attributes.is_a?(Hash) and attributes.has_key?("items")
+                if attributesType.include?(' or ')
+                    parameterTextContent += sprintf(%q(<span class="resources__prop_type">%s</span>), attributesType)
+                elsif attributes.is_a?(Hash) and attributes.has_key?("items")
                     parameterTextContent += sprintf(%q(<span class="resources__prop_type">%s</span>), format_type(attributesType, attributes["items"]["type"]))
                 else
                     parameterTextContent += sprintf(%q(<span class="resources__prop_type">%s</span>), format_type(attributesType, nil))
@@ -508,7 +559,10 @@ module JSONSchemaRenderer
             result.push(parameterTextContent)
         end
 
-        result.push(format_attribute(name, attributes, parent, primaryLanguage, fallbackLanguage)) if attributes.is_a?(Hash)
+        if attributes.is_a?(Hash)
+            displayAttributes = merge_anyof_schema_attributes(attributes)
+            result.push(format_attribute(name, displayAttributes, parent, primaryLanguage, fallbackLanguage))
+        end
 
         if (@moduleName != '') and attributes.has_key?('x-doc-d8Revision')
           case attributes['x-doc-d8Revision']


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Fix broken anyOf rendering on levels deepest than 1.

Before:

<img width="889" height="126" alt="before" src="https://github.com/user-attachments/assets/befdec6a-acdb-48e4-81e5-4f309d58b217" />

After:

<img width="914" height="367" alt="after" src="https://github.com/user-attachments/assets/29dd9c42-c993-4981-a97c-1e1b769f908e" />

Add new methods in schema render.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Broken anyOf rendering on levels deepest than 1 was fixed.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
