### PR TITLE
[docs] Small fixes at hybrid clusters documenation

### DIFF
--- a/docs/documentation/pages/admin/configuration/integrations/hybrid/VCD_HYBRID.md
+++ b/docs/documentation/pages/admin/configuration/integrations/hybrid/VCD_HYBRID.md
@@ -69,8 +69,6 @@ Before you begin, make sure that the following conditions are met:
    provider:
      server: <API_URL>
      apiToken: <API_TOKEN>
-     username: ""
-     password: ""
      insecure: false
    ```
 
@@ -172,7 +170,7 @@ Before you begin, make sure that the following conditions are met:
 - The following value is set in the VM advanced parameters in VCD:
 
   ```text
-  disk.EnableUUID = 1
+  disk.EnableUUID = TRUE
   ```
 
 - The virtual machine is connected to the VCD network used as the main network for the cluster's cloud nodes. Usually, this is the network specified in the [`mainNetwork`](/modules/cloud-provider-vcd/cr.html#vcdinstanceclass-v1-spec-mainnetwork) parameter of the `cloud-provider-vcd` configuration or in the VCDInstanceClass being used.

--- a/docs/documentation/pages/admin/configuration/integrations/hybrid/VCD_HYBRID_RU.md
+++ b/docs/documentation/pages/admin/configuration/integrations/hybrid/VCD_HYBRID_RU.md
@@ -69,8 +69,6 @@ description: Подготовка к гибридной интеграции с 
    provider:
      server: <API_URL>
      apiToken: <API_TOKEN>
-     username: ""
-     password: ""
      insecure: false
    ```
 
@@ -172,7 +170,7 @@ description: Подготовка к гибридной интеграции с 
 - В дополнительных параметрах ВМ в VCD задано значение:
 
   ```text
-  disk.EnableUUID = 1
+  disk.EnableUUID = TRUE
   ```
 
 - Виртуальная машина подключена к сети VCD, используемой как основная сеть для облачных узлов кластера. Обычно это сеть, указанная в параметре [`mainNetwork`](/modules/cloud-provider-vcd/cr.html#vcdinstanceclass-v1-spec-mainnetwork) конфигурации `cloud-provider-vcd` или в используемом VCDInstanceClass.


### PR DESCRIPTION
## Description
Small fixes at hybrid clusters documenation.

## Why do we need it, and what problem does it solve?


## Why do we need it in the patch release (if we do)?


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: docs
type: chore
summary: Small fixes at hybrid clusters documenation.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
