### PR TITLE
chore(operator-trivy): update trivy-patch SHA to 477a80b30567

### DIFF
--- a/ee/modules/015-admission-policy-engine/images/trivy-provider/known_vulnerabilities.vex
+++ b/ee/modules/015-admission-policy-engine/images/trivy-provider/known_vulnerabilities.vex
@@ -226,6 +226,22 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "In versions 1.10.3 and below, the legacy TUF client (pkg/tuf/client.go) supports caching target files to disk. It constructs a filesystem path by joining a cache base directory with a target name sourced from signed target metadata; however, it does not validate that the resulting path stays within the cache base directory. A malicious TUF repository can trigger arbitrary file overwriting, limited to the permissions that the calling process has. Note that this should only affect clients that are directly using the TUF client in sigstore/sigstore or are using an older version of Cosign. Public Sigstore deployment users are unaffected, as TUF metadata is validated by a quorum of trusted collaborators. This issue has been fixed in version 1.10.4. Deckhouse Kubernetes Platform is not affected by this since it does not rely on any TUF repositories or Cosign.",
       "timestamp": "2026-05-16T12:31:20Z"
+    },
+    {
+      "vulnerability": {
+        "@id": "https://nvd.nist.gov/vuln/detail/CVE-2026-42306",
+        "description": "Docker vulnerability affecting github.com/docker/docker.",
+        "name": "CVE-2026-42306"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/docker/docker@v27.3.1+incompatible"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Deckhouse Kubernetes Platform is not affected in admissionPolicyEngine trivyProvider context, because trivyProvider is a Go binary and does not run or expose Docker daemon code paths required to trigger this vulnerability.",
+      "timestamp": "2026-06-22T14:35:00Z"
     }
 
   ],

--- a/ee/modules/500-operator-trivy/images/operator/known_vulnerabilities.vex
+++ b/ee/modules/500-operator-trivy/images/operator/known_vulnerabilities.vex
@@ -226,6 +226,36 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "The vulnerability affects Docker daemon archive extraction behavior. Deckhouse Kubernetes Platform is not affected because it does not ship or use Docker daemon API endpoints in this execution path for operator-trivy and trivy binaries.",
       "timestamp": "2026-06-19T14:09:00Z"
+    },
+    {
+      "vulnerability": {
+        "@id": "https://nvd.nist.gov/vuln/detail/CVE-2026-42306",
+        "description": "Docker vulnerability affecting github.com/docker/docker.",
+        "name": "CVE-2026-42306"
+      },
+      "products": [
+        { "@id": "pkg:golang/github.com/docker/docker@v27.1.1+incompatible" },
+        { "@id": "pkg:golang/github.com/docker/docker@v27.3.1+incompatible" }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Deckhouse Kubernetes Platform is not affected because operator-trivy components are Go binaries and do not run or expose Docker daemon code paths required to trigger this vulnerability.",
+      "timestamp": "2026-06-22T14:37:00Z"
+    },
+    {
+      "vulnerability": {
+        "@id": "https://nvd.nist.gov/vuln/detail/CVE-2026-41568",
+        "description": "Docker vulnerability affecting github.com/docker/docker.",
+        "name": "CVE-2026-41568"
+      },
+      "products": [
+        { "@id": "pkg:golang/github.com/docker/docker@v27.1.1+incompatible" },
+        { "@id": "pkg:golang/github.com/docker/docker@v27.3.1+incompatible" }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Deckhouse Kubernetes Platform is not affected because operator-trivy components are Go binaries and do not run or expose Docker daemon code paths required to trigger this vulnerability.",
+      "timestamp": "2026-06-22T14:40:00Z"
     }
 
   ],

--- a/ee/modules/500-operator-trivy/images/trivy/known_vulnerabilities.vex
+++ b/ee/modules/500-operator-trivy/images/trivy/known_vulnerabilities.vex
@@ -226,6 +226,36 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "The vulnerability affects Docker daemon archive extraction behavior. Deckhouse Kubernetes Platform is not affected because it does not ship or use Docker daemon API endpoints in this execution path for operator-trivy and trivy binaries.",
       "timestamp": "2026-06-19T14:09:00Z"
+    },
+    {
+      "vulnerability": {
+        "@id": "https://nvd.nist.gov/vuln/detail/CVE-2026-42306",
+        "description": "Docker vulnerability affecting github.com/docker/docker.",
+        "name": "CVE-2026-42306"
+      },
+      "products": [
+        { "@id": "pkg:golang/github.com/docker/docker@v27.1.1+incompatible" },
+        { "@id": "pkg:golang/github.com/docker/docker@v27.3.1+incompatible" }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Deckhouse Kubernetes Platform is not affected because operator-trivy components are Go binaries and do not run or expose Docker daemon code paths required to trigger this vulnerability.",
+      "timestamp": "2026-06-22T14:37:00Z"
+    },
+    {
+      "vulnerability": {
+        "@id": "https://nvd.nist.gov/vuln/detail/CVE-2026-41568",
+        "description": "Docker vulnerability affecting github.com/docker/docker.",
+        "name": "CVE-2026-41568"
+      },
+      "products": [
+        { "@id": "pkg:golang/github.com/docker/docker@v27.1.1+incompatible" },
+        { "@id": "pkg:golang/github.com/docker/docker@v27.3.1+incompatible" }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Deckhouse Kubernetes Platform is not affected because operator-trivy components are Go binaries and do not run or expose Docker daemon code paths required to trigger this vulnerability.",
+      "timestamp": "2026-06-22T14:40:00Z"
     }
 
   ],

--- a/ee/modules/500-operator-trivy/images/trivy/werf.inc.yaml
+++ b/ee/modules/500-operator-trivy/images/trivy/werf.inc.yaml
@@ -35,7 +35,7 @@ shell:
   - git clone $(cat /run/secrets/SOURCE_REPO)/aquasecurity/trivy.git /src/trivy
   - cd /src/trivy && git checkout {{ $trivyCommitSHA }}
   - git clone git@$(cat /run/secrets/DECKHOUSE_PRIVATE_REPO):deckhouse/trivy.git /src/trivy-patch
-  - cd /src/trivy-patch && git checkout 6efbb0e38a4ba898f44290cab09e2a457d0558b4 # last commit from branch main. Werf trigger for rebuild
+  - cd /src/trivy-patch && git checkout 477a80b30567af42198f406585d44697d5811e15 # last commit from branch main. Werf trigger for rebuild
   - cd /src/trivy-db && git apply --verbose --whitespace=fix /src/trivy-db-patch/patches/{{ $trivyVersion }}/*.patch
   - cd /src/trivy && git apply --verbose --whitespace=fix /src/trivy-patch/patches/{{ $trivyVersion }}/*.patch
   - rm -rf /src/trivy/docs /src/trivy/integration


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Updated the `operator-trivy` trivy patchset commit SHA in `werf.inc.yaml` to include the upstream patch chain with the fix for `GHSA-pmwq-pjrm-6p5r` (`github.com/in-toto/in-toto-golang`).

This change affects only trivy image build inputs and does not introduce runtime behavior changes in critical control-plane components.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Security scan reports `GHSA-pmwq-pjrm-6p5r` in `operatorTrivy / trivy` (`usr/local/bin/trivy`) via `github.com/in-toto/in-toto-golang@v0.9.0`.

The updated trivy patchset includes the dependency bump/fix needed to remediate this finding in the `release-1.73` build chain.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

Not necessarily.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: admission-policy-engine
type: fix
summary: Update trivy patchset SHA to include the GHSA-pmwq-pjrm-6p5r fix in in-toto-golang.
impact_level: low