### PR TITLE
[docs] Add Academy alert to Getting Started installer page

### DIFF
--- a/docs/site/pages/getting_started/getting_started_installer_ru.html
+++ b/docs/site/pages/getting_started/getting_started_installer_ru.html
@@ -19,6 +19,10 @@ toc: false
 <p>Скорее всего, вы уже ознакомились с основными <a href="/products/kubernetes-platform/">возможностями Deckhouse
   Kubernetes Platform</a>. В данном руководстве рассмотрен пошаговый процесс установки платформы.</p>
 
+{% alert level="info" %}
+Дополнительные материалы по администрированию и обучению работе с платформой представлены в курсе [«Администрирование Deckhouse Kubernetes Platform»](https://deckhouse.ru/courses/basics-administration-deckhouse-kubernetes-platform/) в [Deckhouse Академии](https://deckhouse.ru/academy/).
+{% endalert %}
+
 <p>Установка платформы Deckhouse Kubernetes Platform возможна как на физические серверы (bare metal), так и в инфраструктуру одного
   из поддерживаемых облачных провайдеров. В зависимости от выбранной инфраструктуры процесс может немного отличаться,
   поэтому ниже приведены примеры установки для разных вариантов.</p>


### PR DESCRIPTION
## Description

Added links to the Academy's courses to the documentation pages.

## Why do we need it, and what problem does it solve?

## Why do we need it in the patch release (if we do)?

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: fix 
summary: Added links to the Academy's courses to the documentation pages.
impact_level: low
```