### PR TITLE
[istio] Use values helper for template tests

### DIFF
--- a/modules/110-istio/template_tests/module_test.go
+++ b/modules/110-istio/template_tests/module_test.go
@@ -57,17 +57,14 @@ modules:
       clusterIssuerName: letsencrypt
     mode: CertManager
 discovery:
-  clusterControlPlaneIsHighlyAvailable: true
   d8SpecificNodeCountByRole:
     system: 3
-  kubernetesVersion: "1.19.0"
   clusterDomain: my.domain
   clusterUUID: aa-bb-cc
 `
 
 const istioValues = `
     internal:
-      applicationNamespaces: []
       globalVersion: "1.21.6"
       versionMap:
         "1.27.9":
@@ -89,11 +86,6 @@ const istioValues = `
           supportsAmbient: false
           supportsOperator: true
       kialiSigningKey: "kiali"
-      operatorVersionsToInstall: []
-      versionsToInstall: []
-      federations: []
-      federationServiceEntries: []
-      multiclusters: []
       remoteAuthnKeypair:
         priv: aaa
         pub: bbb
@@ -104,69 +96,13 @@ const istioValues = `
         chain: mychain
       auth:
         password: qqq
-    auth:
-      externalAuthentication: {}
-    outboundTrafficPolicyMode: AllowAny
     sidecar:
       includeOutboundIPRanges: ["10.0.0.0/24"]
       excludeOutboundIPRanges: ["1.2.3.4/32"]
       excludeInboundPorts: ["1", "2"]
       excludeOutboundPorts: ["3", "4"]
-    multicluster:
-      enabled: false
-    federation:
-      enabled: false
-    alliance:
-      ingressGateway:
-        inlet: LoadBalancer
-        nodePort: {}
-    tracing:
-      collector:
-        opentelemetry: {}
-        zipkin: {}
-    controlPlane:
-      replicasManagement:
-        mode: Standard
-      resourcesManagement:
-        mode: VPA
-        vpa:
-          mode: Auto
-          cpu:
-            min: "50m"
-            max: "2"
-          memory:
-            min: "256Mi"
-            max: "2Gi"
     dataPlane:
       trafficRedirectionSetupMode: CNIPlugin
-      proxyConfig: {}
-      accessLog:
-        type: "Text"
-        textFormat: '[%START_TIME%] "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %RESPONSE_CODE_DETAILS% %CONNECTION_TERMINATION_DETAILS% "%UPSTREAM_TRANSPORT_FAILURE_REASON%" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% "%REQ(X-FORWARDED-FOR)%" "%REQ(USER-AGENT)%" "%REQ(X-REQUEST-ID)%" "%REQ(:AUTHORITY)%" "%UPSTREAM_HOST%" %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME% %ROUTE_NAME%'
-      ztunnel:
-        resourcesManagement:
-          mode: VPA
-          vpa:
-            mode: InPlaceOrRecreate
-            cpu:
-              max: "1"
-              min: "25m"
-            memory:
-              max: "2Gi"
-              min: "64Mi"
-    ambient:
-      enabled: false
-      waypointController:
-        resourcesManagement:
-          mode: VPA
-          vpa:
-            mode: InPlaceOrRecreate
-            cpu:
-              max: "1"
-              min: "25m"
-            memory:
-              max: "1Gi"
-              min: "64Mi"
 `
 
 const jwksResolverAdditionalRootCA = `-----BEGIN CERTIFICATE-----
@@ -225,7 +161,7 @@ var _ = Describe("Module :: istio :: helm template :: main", func() {
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global", globalValues)
 			f.ValuesSet("global.modulesImages", GetModulesImages())
-			f.ValuesSetFromYaml("istio", istioValues)
+			f.ValuesSetFromYamlWithOpenAPIDefaults("istio", istioValues)
 			f.HelmRender()
 		})
 
@@ -267,7 +203,7 @@ var _ = Describe("Module :: istio :: helm template :: main", func() {
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global", globalValues)
 			f.ValuesSet("global.modulesImages", GetModulesImages())
-			f.ValuesSetFromYaml("istio", istioValues)
+			f.ValuesSetFromYamlWithOpenAPIDefaults("istio", istioValues)
 		})
 
 		It("always creates access log Telemetry and omits metrics when Telemetry API mode is disabled", func() {
@@ -371,7 +307,7 @@ var _ = Describe("Module :: istio :: helm template :: main", func() {
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global", globalValues)
 			f.ValuesSet("global.modulesImages", GetModulesImages())
-			f.ValuesSetFromYaml("istio", istioValues)
+			f.ValuesSetFromYamlWithOpenAPIDefaults("istio", istioValues)
 			f.ValuesSetFromYaml("istio.internal.versionsToInstall", `["1.25.2","1.21.6"]`)
 			f.ValuesSetFromYaml("istio.internal.operatorVersionsToInstall", `["1.25.2","1.21.6"]`)
 			f.ValuesSet("istio.telemetryAPI.enabled", true)
@@ -397,7 +333,7 @@ var _ = Describe("Module :: istio :: helm template :: main", func() {
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global", globalValues)
 			f.ValuesSet("global.modulesImages", GetModulesImages())
-			f.ValuesSetFromYaml("istio", istioValues)
+			f.ValuesSetFromYamlWithOpenAPIDefaults("istio", istioValues)
 			f.ValuesSetFromYaml("istio.internal.versionsToInstall", `["1.25.2","1.21.6"]`)
 			f.ValuesSetFromYaml("istio.internal.operatorVersionsToInstall", `["1.25.2","1.21.6"]`)
 			f.ValuesSetFromYaml("istio.internal.applicationNamespaces", `[foo,bar]`)
@@ -492,7 +428,7 @@ var _ = Describe("Module :: istio :: helm template :: main", func() {
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global", globalValues)
 			f.ValuesSet("global.modulesImages", GetModulesImages())
-			f.ValuesSetFromYaml("istio", istioValues)
+			f.ValuesSetFromYamlWithOpenAPIDefaults("istio", istioValues)
 			f.ValuesSetFromYaml("istio.internal.versionsToInstall", `["1.25.2","1.21.6"]`)
 			f.ValuesSetFromYaml("istio.internal.operatorVersionsToInstall", `["1.25.2","1.21.6"]`)
 			f.ValuesSetFromYaml("istio.dataPlane.extensionProviders", `
@@ -526,7 +462,7 @@ var _ = Describe("Module :: istio :: helm template :: main", func() {
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global", globalValues)
 			f.ValuesSet("global.modulesImages", GetModulesImages())
-			f.ValuesSetFromYaml("istio", istioValues)
+			f.ValuesSetFromYamlWithOpenAPIDefaults("istio", istioValues)
 			f.ValuesSetFromYaml("istio.internal.versionsToInstall", `["1.21.6","1.25.2","1.27.9"]`)
 			f.ValuesSet("istio.jwksResolverAdditionalRootCA", jwksResolverAdditionalRootCA)
 			f.HelmRender()
@@ -558,7 +494,7 @@ var _ = Describe("Module :: istio :: helm template :: main", func() {
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global", globalValues)
 			f.ValuesSet("global.modulesImages", GetModulesImages())
-			f.ValuesSetFromYaml("istio", istioValues)
+			f.ValuesSetFromYamlWithOpenAPIDefaults("istio", istioValues)
 			f.ValuesSetFromYaml("istio.internal.versionsToInstall", `["1.21.6"]`)
 			f.ValuesSetFromYaml("istio.internal.operatorVersionsToInstall", `["1.21.6"]`)
 			f.ValuesSet("istio.federation.enabled", true)
@@ -653,7 +589,7 @@ test.deckhouse.io/annotation: test-value
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global", globalValues)
 			f.ValuesSet("global.modulesImages", GetModulesImages())
-			f.ValuesSetFromYaml("istio", istioValues)
+			f.ValuesSetFromYamlWithOpenAPIDefaults("istio", istioValues)
 			f.ValuesSetFromYaml("istio.internal.versionsToInstall", `["1.21.6"]`)
 			f.ValuesSetFromYaml("istio.internal.operatorVersionsToInstall", `["1.21.6"]`)
 			f.ValuesSet("istio.federation.enabled", true)
@@ -746,7 +682,7 @@ cluster-b:
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global", globalValues)
 			f.ValuesSet("global.modulesImages", GetModulesImages())
-			f.ValuesSetFromYaml("istio", istioValues)
+			f.ValuesSetFromYamlWithOpenAPIDefaults("istio", istioValues)
 			f.ValuesSetFromYaml("istio.internal.versionsToInstall", `["1.21.6"]`)
 			f.ValuesSetFromYaml("istio.internal.operatorVersionsToInstall", `["1.21.6"]`)
 			f.ValuesSet("istio.federation.enabled", true)
@@ -856,7 +792,7 @@ cluster-b:
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global", globalValues)
 			f.ValuesSet("global.modulesImages", GetModulesImages())
-			f.ValuesSetFromYaml("istio", istioValues)
+			f.ValuesSetFromYamlWithOpenAPIDefaults("istio", istioValues)
 			f.ValuesSetFromYaml("istio.internal.versionsToInstall", `["1.21.6"]`)
 			f.ValuesSetFromYaml("istio.internal.operatorVersionsToInstall", `["1.21.6"]`)
 			f.HelmRender()
@@ -874,7 +810,7 @@ cluster-b:
 			f.ValuesSetFromYaml("global", globalValues)
 			f.ValuesSet("global.modulesImages", GetModulesImages())
 			f.ValuesSet("global.clusterConfiguration.cloud.provider", "AWS")
-			f.ValuesSetFromYaml("istio", istioValues)
+			f.ValuesSetFromYamlWithOpenAPIDefaults("istio", istioValues)
 			f.ValuesSetFromYaml("istio.internal.versionsToInstall", `["1.21.6"]`)
 			f.ValuesSetFromYaml("istio.internal.operatorVersionsToInstall", `["1.21.6"]`)
 			f.HelmRender()
@@ -891,7 +827,7 @@ cluster-b:
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global", globalValues)
 			f.ValuesSet("global.modulesImages", GetModulesImages())
-			f.ValuesSetFromYaml("istio", istioValues)
+			f.ValuesSetFromYamlWithOpenAPIDefaults("istio", istioValues)
 			f.ValuesSetFromYaml("istio.internal.versionsToInstall", `["1.21.6"]`)
 			f.ValuesSetFromYaml("istio.internal.operatorVersionsToInstall", `["1.21.6"]`)
 			f.ValuesSet("istio.multicluster.enabled", true)
@@ -1032,7 +968,7 @@ a-b-c-1-2-3:
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global", globalValues)
 			f.ValuesSet("global.modulesImages", GetModulesImages())
-			f.ValuesSetFromYaml("istio", istioValues)
+			f.ValuesSetFromYamlWithOpenAPIDefaults("istio", istioValues)
 			f.ValuesSetFromYaml("istio.internal.versionsToInstall", `["1.21.6"]`)
 			f.HelmRender()
 		})
@@ -1055,7 +991,7 @@ targetRef:
   kind: Deployment
   name: istiod-v1x21x6
 updatePolicy:
-  updateMode: Auto
+  updateMode: InPlaceOrRecreate
 resourcePolicy:
   containerPolicies:
   - containerName: discovery
@@ -1074,7 +1010,7 @@ resourcePolicy:
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global", globalValues)
 			f.ValuesSet("global.modulesImages", GetModulesImages())
-			f.ValuesSetFromYaml("istio", istioValues)
+			f.ValuesSetFromYamlWithOpenAPIDefaults("istio", istioValues)
 			f.ValuesSetFromYaml("istio.internal.versionsToInstall", `["1.21.6"]`)
 			f.ValuesSetFromYaml("istio.controlPlane.resourcesManagement", `
 mode: Static
@@ -1118,7 +1054,7 @@ updatePolicy:
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global", globalValues)
 			f.ValuesSet("global.modulesImages", GetModulesImages())
-			f.ValuesSetFromYaml("istio", istioValues)
+			f.ValuesSetFromYamlWithOpenAPIDefaults("istio", istioValues)
 			f.ValuesSetFromYaml("istio.internal.versionsToInstall", `["1.21.6"]`)
 			f.HelmRender()
 		})
@@ -1134,7 +1070,7 @@ updatePolicy:
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global", globalValues)
 			f.ValuesSet("global.modulesImages", GetModulesImages())
-			f.ValuesSetFromYaml("istio", istioValues)
+			f.ValuesSetFromYamlWithOpenAPIDefaults("istio", istioValues)
 			f.ValuesSetFromYaml("istio.internal.versionsToInstall", `["1.21.6"]`)
 			f.ValuesSetFromYaml("istio.sidecar.resourcesManagement", `
 mode: Static
@@ -1165,7 +1101,7 @@ limits:
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global", globalValues)
 			f.ValuesSet("global.modulesImages", GetModulesImages())
-			f.ValuesSetFromYaml("istio", istioValues)
+			f.ValuesSetFromYamlWithOpenAPIDefaults("istio", istioValues)
 			f.ValuesSetFromYaml("istio.internal.versionsToInstall", `["1.21.6"]`)
 			f.ValuesSetFromYaml("istio.controlPlane.resourcesManagement", `
 mode: VPA
@@ -1222,7 +1158,7 @@ updatePolicy:
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global", globalValues)
 			f.ValuesSet("global.modulesImages", GetModulesImages())
-			f.ValuesSetFromYaml("istio", istioValues)
+			f.ValuesSetFromYamlWithOpenAPIDefaults("istio", istioValues)
 			f.ValuesSetFromYaml("istio.internal.versionsToInstall", `["1.21.6"]`)
 			f.ValuesSetFromYaml("istio.controlPlane.resourcesManagement", `
 mode: VPA
@@ -1279,7 +1215,7 @@ updatePolicy:
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global", globalValues)
 			f.ValuesSet("global.modulesImages", GetModulesImages())
-			f.ValuesSetFromYaml("istio", istioValues)
+			f.ValuesSetFromYamlWithOpenAPIDefaults("istio", istioValues)
 			f.ValuesSetFromYaml("istio.internal.versionsToInstall", `["1.25.2","1.21.6"]`)
 			f.ValuesSetFromYaml("istio.controlPlane.extraEnvs", `
 GODEBUG: "gctrace=1"
@@ -1327,7 +1263,7 @@ MY_VAR: "myvalue"
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global", globalValues)
 			f.ValuesSet("global.modulesImages", GetModulesImages())
-			f.ValuesSetFromYaml("istio", istioValues)
+			f.ValuesSetFromYamlWithOpenAPIDefaults("istio", istioValues)
 			f.ValuesSetFromYaml("istio.internal.ingressControllers", `
 - name: nodeport-test
   spec:
@@ -1367,7 +1303,7 @@ MY_VAR: "myvalue"
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global", globalValues)
 			f.ValuesSet("global.modulesImages", GetModulesImages())
-			f.ValuesSetFromYaml("istio", istioValues)
+			f.ValuesSetFromYamlWithOpenAPIDefaults("istio", istioValues)
 			f.ValuesSetFromYaml("istio.internal.ingressControllers", `
 - name: loadbalancer-test
   spec:
@@ -1407,7 +1343,7 @@ MY_VAR: "myvalue"
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global", globalValues)
 			f.ValuesSet("global.modulesImages", GetModulesImages())
-			f.ValuesSetFromYaml("istio", istioValues)
+			f.ValuesSetFromYamlWithOpenAPIDefaults("istio", istioValues)
 			f.ValuesSetFromYaml("istio.internal.ingressControllers", `
 - name: hostport-test
   spec:
@@ -1454,7 +1390,7 @@ MY_VAR: "myvalue"
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global", globalValues)
 			f.ValuesSet("global.modulesImages", GetModulesImages())
-			f.ValuesSetFromYaml("istio", istioValues)
+			f.ValuesSetFromYamlWithOpenAPIDefaults("istio", istioValues)
 			f.ValuesSetFromYaml("istio.internal.applicationNamespacesToMonitor", `
 - "myns"
 - "review-123"
@@ -1476,7 +1412,7 @@ MY_VAR: "myvalue"
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global", globalValues)
 			f.ValuesSet("global.modulesImages", GetModulesImages())
-			f.ValuesSetFromYaml("istio", istioValues)
+			f.ValuesSetFromYamlWithOpenAPIDefaults("istio", istioValues)
 			f.ValuesSetFromYaml("istio.internal.versionMap", `
 "1.27":
   revision: "v1x27"
@@ -1523,7 +1459,7 @@ MY_VAR: "myvalue"
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global", globalValues)
 			f.ValuesSet("global.modulesImages", GetModulesImages())
-			f.ValuesSetFromYaml("istio", istioValues)
+			f.ValuesSetFromYamlWithOpenAPIDefaults("istio", istioValues)
 			f.ValuesSetFromYaml("istio.internal.versionMap", `
 "1.27":
   revision: "v1x27"
@@ -1560,7 +1496,7 @@ static:
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global", globalValues)
 			f.ValuesSet("global.modulesImages", GetModulesImages())
-			f.ValuesSetFromYaml("istio", istioValues)
+			f.ValuesSetFromYamlWithOpenAPIDefaults("istio", istioValues)
 			f.ValuesSetFromYaml("istio.internal.versionMap", `
 "1.27":
   revision: "v1x27"

--- a/modules/110-istio/template_tests/waypoint_controller_test.go
+++ b/modules/110-istio/template_tests/waypoint_controller_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Module :: istio :: helm template :: waypoint-controller", func
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global", globalValues)
 			f.ValuesSet("global.modulesImages", GetModulesImages())
-			f.ValuesSetFromYaml("istio", istioValues)
+			f.ValuesSetFromYamlWithOpenAPIDefaults("istio", istioValues)
 			f.ValuesSet("istio.internal.globalVersion", "1.25.2")
 			f.ValuesSet("istio.ambient.enabled", true)
 			f.HelmRender()
@@ -104,7 +104,7 @@ var _ = Describe("Module :: istio :: helm template :: waypoint-controller", func
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global", globalValues)
 			f.ValuesSet("global.modulesImages", GetModulesImages())
-			f.ValuesSetFromYaml("istio", istioValues)
+			f.ValuesSetFromYamlWithOpenAPIDefaults("istio", istioValues)
 			f.ValuesSet("istio.internal.globalVersion", "1.21.6")
 			f.ValuesSet("istio.ambient.enabled", true)
 			f.HelmRender()
@@ -126,7 +126,7 @@ var _ = Describe("Module :: istio :: helm template :: waypoint-controller", func
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global", globalValues)
 			f.ValuesSet("global.modulesImages", GetModulesImages())
-			f.ValuesSetFromYaml("istio", istioValues)
+			f.ValuesSetFromYamlWithOpenAPIDefaults("istio", istioValues)
 			f.ValuesSet("istio.internal.globalVersion", "1.25.2")
 			f.ValuesSet("istio.ambient.enabled", false)
 			f.HelmRender()
@@ -150,7 +150,7 @@ var _ = Describe("Module :: istio :: helm template :: waypoint-controller", func
 			// Remove vertical-pod-autoscaler from enabledModules
 			f.ValuesSetFromYaml("global.enabledModules", `["operator-prometheus","cert-manager","cni-cilium"]`)
 			f.ValuesSet("global.modulesImages", GetModulesImages())
-			f.ValuesSetFromYaml("istio", istioValues)
+			f.ValuesSetFromYamlWithOpenAPIDefaults("istio", istioValues)
 			f.ValuesSet("istio.internal.globalVersion", "1.25.2")
 			f.ValuesSet("istio.ambient.enabled", true)
 			f.HelmRender()
@@ -175,7 +175,7 @@ var _ = Describe("Module :: istio :: helm template :: waypoint-controller", func
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global", globalValues)
 			f.ValuesSet("global.modulesImages", GetModulesImages())
-			f.ValuesSetFromYaml("istio", istioValues)
+			f.ValuesSetFromYamlWithOpenAPIDefaults("istio", istioValues)
 			f.ValuesSet("istio.internal.globalVersion", "1.25.2")
 			f.ValuesSet("istio.ambient.enabled", true)
 			f.ValuesSetFromYaml("istio.ambient.waypointController.resourcesManagement", `
@@ -219,7 +219,7 @@ limits:
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global", globalValues)
 			f.ValuesSet("global.modulesImages", GetModulesImages())
-			f.ValuesSetFromYaml("istio", istioValues)
+			f.ValuesSetFromYamlWithOpenAPIDefaults("istio", istioValues)
 			f.ValuesSet("istio.internal.globalVersion", "1.25.2")
 			f.ValuesSet("istio.ambient.enabled", true)
 			f.ValuesSetFromYaml("istio.ambient.waypointController.resourcesManagement", `
@@ -268,7 +268,7 @@ resourcePolicy:
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global", globalValues)
 			f.ValuesSet("global.modulesImages", GetModulesImages())
-			f.ValuesSetFromYaml("istio", istioValues)
+			f.ValuesSetFromYamlWithOpenAPIDefaults("istio", istioValues)
 			f.ValuesSet("istio.internal.globalVersion", "1.25.2")
 			f.ValuesSet("istio.ambient.enabled", true)
 			f.ValuesSet("global.highAvailability", false)
@@ -297,7 +297,7 @@ resourcePolicy:
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global", globalValues)
 			f.ValuesSet("global.modulesImages", GetModulesImages())
-			f.ValuesSetFromYaml("istio", istioValues)
+			f.ValuesSetFromYamlWithOpenAPIDefaults("istio", istioValues)
 			f.ValuesSet("istio.internal.globalVersion", "1.25.2")
 			f.ValuesSet("istio.ambient.enabled", true)
 			f.HelmRender()
@@ -352,7 +352,7 @@ resourcePolicy:
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global", globalValues)
 			f.ValuesSet("global.modulesImages", GetModulesImages())
-			f.ValuesSetFromYaml("istio", istioValues)
+			f.ValuesSetFromYamlWithOpenAPIDefaults("istio", istioValues)
 			f.ValuesSet("istio.internal.globalVersion", "1.25.2")
 			f.ValuesSet("istio.ambient.enabled", true)
 			f.HelmRender()
@@ -377,7 +377,7 @@ resourcePolicy:
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global", globalValues)
 			f.ValuesSet("global.modulesImages", GetModulesImages())
-			f.ValuesSetFromYaml("istio", istioValues)
+			f.ValuesSetFromYamlWithOpenAPIDefaults("istio", istioValues)
 			f.ValuesSet("istio.internal.globalVersion", "1.25.2")
 			f.ValuesSet("istio.ambient.enabled", true)
 			f.HelmRender()

--- a/modules/110-istio/template_tests/ztunnel_test.go
+++ b/modules/110-istio/template_tests/ztunnel_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Module :: istio :: helm template :: ztunnel", func() {
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global", globalValues)
 			f.ValuesSet("global.modulesImages", GetModulesImages())
-			f.ValuesSetFromYaml("istio", istioValues)
+			f.ValuesSetFromYamlWithOpenAPIDefaults("istio", istioValues)
 			f.ValuesSet("istio.internal.globalVersion", "1.25.2")
 			f.ValuesSet("istio.ambient.enabled", true)
 			f.HelmRender()
@@ -61,7 +61,7 @@ var _ = Describe("Module :: istio :: helm template :: ztunnel", func() {
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global", globalValues)
 			f.ValuesSet("global.modulesImages", GetModulesImages())
-			f.ValuesSetFromYaml("istio", istioValues)
+			f.ValuesSetFromYamlWithOpenAPIDefaults("istio", istioValues)
 			f.ValuesSet("istio.internal.globalVersion", "1.21.6")
 			f.ValuesSet("istio.ambient.enabled", true)
 			f.HelmRender()
@@ -81,7 +81,7 @@ var _ = Describe("Module :: istio :: helm template :: ztunnel", func() {
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global", globalValues)
 			f.ValuesSet("global.modulesImages", GetModulesImages())
-			f.ValuesSetFromYaml("istio", istioValues)
+			f.ValuesSetFromYamlWithOpenAPIDefaults("istio", istioValues)
 			f.ValuesSet("istio.internal.globalVersion", "1.25.2")
 			f.ValuesSet("istio.ambient.enabled", false)
 			f.HelmRender()


### PR DESCRIPTION
## Description

Migrate Istio Helm template tests to use the new `ValuesSetFromYamlWithOpenAPIDefaults` helper that automatically applies OpenAPI schema defaults from `config-values.yaml` and `values.yaml`.

## Why do we need it, and what problem does it solve?

The Istio module's `config-values.yaml` and `values.yaml` define OpenAPI schema defaults for many configuration fields (e.g., `outboundTrafficPolicyMode: AllowAny`, `ambient.enabled: false`, resource management VPAs, etc.). These defaults are applied by addon-operator at runtime before rendering Helm templates. However, the Helm template tests manually duplicated these defaults in a `istioValues` const.

This duplication meant that adding, changing, or removing an OpenAPI default required updating both the schema file and the test const. If the test const was not updated, tests would either fail or diverge from production behavior. The new approach eliminates this gap by applying OpenAPI defaults directly in tests, just as production does.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: chore
summary: Migrate template tests to apply OpenAPI defaults via helper, removing duplicated default values from test fixtures.
impact_level: low
```