### PR TITLE
[deckhouse] enforce parent-module requirements from Module CR in webhook

### DIFF
--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module_config.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module_config.go
@@ -226,7 +226,69 @@ func (v *moduleConfigValidator) validateModuleEnabling(ctx context.Context, cfg 
 		return rejectResult(err.Error())
 	}
 
-	return v.checkExperimentalFromModuleCR(ctx, cfg.Name, allowExperimental, rejectMissingModuleCR)
+	// The Module CR is fetched once and feeds both the experimental gate and the
+	// dependency fallback below. The global module has no Module CR.
+	if cfg.Name == globalModuleName {
+		return nil, nil
+	}
+
+	module := new(v1alpha1.Module)
+	if err := v.client.Get(ctx, client.ObjectKey{Name: cfg.Name}, module); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("get the '%s' module: %w", cfg.Name, err)
+		}
+
+		if rejectMissingModuleCR {
+			return rejectResult(fmt.Sprintf("the '%s' module not found", cfg.Name))
+		}
+
+		return nil, nil
+	}
+
+	if module.IsExperimental() && !allowExperimental {
+		return rejectResult(experimentalRejectMessage(cfg.Name))
+	}
+
+	// Fallback for the dependency extender: enforce the parent-module
+	// requirements declared on the Module CR when the extender has no registered
+	// constraints for the module (e.g. the module is not yet downloaded to disk,
+	// so its module.yaml requirements were never loaded into the extender).
+	if res, err := v.checkDependenciesFromModuleCR(module); res != nil || err != nil {
+		return res, err
+	}
+
+	return nil, nil
+}
+
+// checkDependenciesFromModuleCR enforces the "parent module must be enabled" part
+// of the requirements declared on the Module CR. It is a fallback for the
+// dependency extender, which only knows about modules whose module.yaml has been
+// loaded from disk; a module whose requirements are synced from the registry but
+// not yet downloaded would otherwise pass the extender's CheckEnabling silently.
+// Version constraints are intentionally not validated here: they are enforced by
+// the extender once the module is downloaded and its constraints are registered.
+func (v *moduleConfigValidator) checkDependenciesFromModuleCR(module *v1alpha1.Module) (*kwhvalidating.ValidatorResult, error) {
+	if module.Properties.Requirements == nil || len(module.Properties.Requirements.ParentModules) == 0 {
+		return nil, nil
+	}
+
+	missing := make([]string, 0, len(module.Properties.Requirements.ParentModules))
+	for parent := range module.Properties.Requirements.ParentModules {
+		if parent == module.Name {
+			continue
+		}
+		if !v.moduleManager.IsModuleEnabled(parent) {
+			missing = append(missing, parent)
+		}
+	}
+
+	if len(missing) == 0 {
+		return nil, nil
+	}
+
+	slices.Sort(missing)
+
+	return rejectResult(fmt.Sprintf("the '%s' module depends on disabled module(s): %s", module.Name, strings.Join(missing, ", ")))
 }
 
 // checkExperimentalFromStorage applies the experimental gate using the downloaded
@@ -239,32 +301,6 @@ func (v *moduleConfigValidator) checkExperimentalFromStorage(moduleName string, 
 	}
 
 	if module.GetModuleDefinition().IsExperimental() && !allowExperimental {
-		return rejectResult(experimentalRejectMessage(moduleName))
-	}
-
-	return nil, nil
-}
-
-// checkExperimentalFromModuleCR applies the experimental gate using the Module CR
-// (whose properties are synced from the registry even before the module is
-// downloaded). The global module has no Module CR and is skipped.
-func (v *moduleConfigValidator) checkExperimentalFromModuleCR(ctx context.Context, moduleName string, allowExperimental, rejectMissing bool) (*kwhvalidating.ValidatorResult, error) {
-	if moduleName == globalModuleName {
-		return nil, nil
-	}
-
-	module := new(v1alpha1.Module)
-	if err := v.client.Get(ctx, client.ObjectKey{Name: moduleName}, module); err != nil {
-		if !apierrors.IsNotFound(err) {
-			return nil, fmt.Errorf("get the '%s' module: %w", moduleName, err)
-		}
-		if rejectMissing {
-			return rejectResult(fmt.Sprintf("the '%s' module not found", moduleName))
-		}
-		return nil, nil
-	}
-
-	if module.IsExperimental() && !allowExperimental {
 		return rejectResult(experimentalRejectMessage(moduleName))
 	}
 

--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module_config_test.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module_config_test.go
@@ -134,6 +134,15 @@ func newModuleCR(name string, availableSources []string, stage string) *v1alpha1
 	}
 }
 
+// newModuleCRWithRequirements builds a Module CR that declares parent-module
+// requirements, to exercise the dependency extender fallback that reads them
+// from the Module CR when the extender itself has no registered constraints.
+func newModuleCRWithRequirements(name string, availableSources []string, stage string, parentModules map[string]string) *v1alpha1.Module {
+	m := newModuleCR(name, availableSources, stage)
+	m.Properties.Requirements = &v1alpha1.ModuleRequirements{ParentModules: parentModules}
+	return m
+}
+
 func newModuleConfigFull(name string, enabled *bool, source, updatePolicy string) *v1alpha1.ModuleConfig {
 	cfg := newModuleConfig(name, enabled, nil)
 	cfg.Spec.Source = source
@@ -911,6 +920,125 @@ func TestModuleConfigValidationHandler_ExperimentalOnUpdate(t *testing.T) {
 				newModuleConfigFull(moduleName, boolPtr(true), "alpha", ""),
 				newModuleConfigFull(moduleName, boolPtr(false), "", ""),
 			)
+
+			resp := callHandler(t, handler, review)
+
+			if tt.wantAllowed {
+				assert.True(t, resp.Allowed)
+				return
+			}
+
+			require.False(t, resp.Allowed)
+			require.NotNil(t, resp.Result)
+			assert.Contains(t, resp.Result.Message, tt.wantMessage)
+		})
+	}
+}
+
+// TestModuleConfigValidationHandler_DependencyFallbackFromModuleCR covers the
+// fallback that enforces parent-module requirements read from the Module CR when
+// the dependency extender has no registered constraints for the module (the
+// extender only knows about modules whose module.yaml has been loaded from disk).
+func TestModuleConfigValidationHandler_DependencyFallbackFromModuleCR(t *testing.T) {
+	const moduleName = "dependent-module"
+
+	requirements := map[string]string{"log-shipper": ">= 0.0.0", "loki": ">= 0.0.0"}
+
+	tests := []struct {
+		name             string
+		operation        string
+		newConfig        *v1alpha1.ModuleConfig
+		oldConfig        *v1alpha1.ModuleConfig
+		moduleCR         *v1alpha1.Module
+		enabledParents   map[string]bool
+		dependencyErr    error
+		wantAllowed      bool
+		wantMessage      string
+	}{
+		{
+			name:           "create: both required parents disabled is rejected from the Module CR",
+			operation:      "CREATE",
+			newConfig:      newModuleConfig(moduleName, boolPtr(true), nil),
+			moduleCR:       newModuleCRWithRequirements(moduleName, []string{"deckhouse"}, "", requirements),
+			enabledParents: map[string]bool{},
+			wantAllowed:    false,
+			wantMessage:    "depends on disabled module(s)",
+		},
+		{
+			name:           "create: one required parent disabled is rejected from the Module CR",
+			operation:      "CREATE",
+			newConfig:      newModuleConfig(moduleName, boolPtr(true), nil),
+			moduleCR:       newModuleCRWithRequirements(moduleName, []string{"deckhouse"}, "", requirements),
+			enabledParents: map[string]bool{"loki": true},
+			wantAllowed:    false,
+			wantMessage:    "depends on disabled module(s): log-shipper",
+		},
+		{
+			name:           "create: all required parents enabled is allowed",
+			operation:      "CREATE",
+			newConfig:      newModuleConfig(moduleName, boolPtr(true), nil),
+			moduleCR:       newModuleCRWithRequirements(moduleName, []string{"deckhouse"}, "", requirements),
+			enabledParents: map[string]bool{"loki": true, "log-shipper": true},
+			wantAllowed:    true,
+		},
+		{
+			name:           "update: both required parents enabled is allowed",
+			operation:      "UPDATE",
+			newConfig:      newModuleConfigFull(moduleName, boolPtr(true), "deckhouse", ""),
+			oldConfig:      newModuleConfigFull(moduleName, boolPtr(false), "", ""),
+			moduleCR:       newModuleCRWithRequirements(moduleName, []string{"deckhouse"}, "", requirements),
+			enabledParents: map[string]bool{"loki": true, "log-shipper": true},
+			wantAllowed:    true,
+		},
+		{
+			name:           "module CR without requirements is allowed",
+			operation:      "CREATE",
+			newConfig:      newModuleConfig(moduleName, boolPtr(true), nil),
+			moduleCR:       newModuleCR(moduleName, []string{"deckhouse"}, ""),
+			enabledParents: map[string]bool{},
+			wantAllowed:    true,
+		},
+		{
+			name:           "update: missing Module CR skips the dependency fallback and is allowed",
+			operation:      "UPDATE",
+			newConfig:      newModuleConfigFull(moduleName, boolPtr(true), "deckhouse", ""),
+			oldConfig:      newModuleConfigFull(moduleName, boolPtr(false), "", ""),
+			moduleCR:       nil,
+			enabledParents: map[string]bool{},
+			wantAllowed:    true,
+		},
+		{
+			name:           "extender rejection takes precedence over the Module CR fallback",
+			operation:      "CREATE",
+			newConfig:      newModuleConfig(moduleName, boolPtr(true), nil),
+			moduleCR:       newModuleCRWithRequirements(moduleName, []string{"deckhouse"}, "", requirements),
+			enabledParents: map[string]bool{"loki": true, "log-shipper": true},
+			dependencyErr:  fmt.Errorf("module %q depends on a disabled module", moduleName),
+			wantAllowed:    false,
+			wantMessage:    "depends on a disabled module",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			storage := &fakeModuleStorage{
+				modules: map[string]*moduletypes.Module{
+					moduleName: newStorageModule(t, moduleName, "", ""),
+				},
+			}
+			manager := &fakeModuleManager{enabled: tt.enabledParents}
+
+			dependencyExtender := moduledependency.NewIExtenderMock(t)
+			dependencyExtender.CheckEnablingMock.Expect(moduleName).Return(tt.dependencyErr)
+
+			var objs []client.Object
+			if tt.moduleCR != nil {
+				objs = append(objs, tt.moduleCR)
+			}
+
+			handler := newTestHandlerWithObjects(t, storage, manager, dependencyExtender, false, objs...)
+
+			review := newModuleConfigAdmissionReview(tt.operation, tt.newConfig, tt.oldConfig)
 
 			resp := callHandler(t, handler, review)
 


### PR DESCRIPTION
## Description

The `ModuleConfig` validation webhook did not enforce parent-module requirements (`requirements.modules`) declared on the `Module` CR when the in-memory dependency extender had no registered constraints for the module. This adds a fallback in `validateModuleEnabling`: when the dependency extender has no constraints for the module, the webhook reads `requirements.modules` from the `Module` CR and rejects the enable if any required parent module is not enabled (via `moduleManager.IsModuleEnabled`). The fallback is scoped to the enabled-state gate only — version constraints continue to be enforced by the extender once the module is downloaded and its constraints are registered. When the extender does have registered constraints (the normal case for a fully downloaded module), it takes precedence and the fallback is not reached.

## Why do we need it, and what problem does it solve?

The dependency extender (`moduledependency.Extender`) is populated only from the on-disk `module.yaml` via `moduleloader` → `exts.AddConstraints` during module loading. The `Module` CR — whose `properties.requirements` are synced from registry metadata by the source controller while the module is in the `Available` phase — was never consulted by the webhook as a fallback. This creates a window where a `Module` CR exists and already carries requirements.modules, but the module has not yet been downloaded to disk (no `ModuleRelease`, or the on-disk `module.yaml` lacks the modules: section). In that window, `CheckEnabling` finds no entry in the extender's internal map and returns `nil`, silently allowing the enable regardless of declared requirements. As a result, a module whose dependencies (e.g. `loki`, `log-shipper`) are disabled could be enabled through the webhook without error — defeating the purpose of declaring `requirements.modules` for external modules before their first release is downloaded.

## Example
### Before
```bash
# Dependencies are disabled
➜ kubectl get module loki -o jsonpath='{.status.conditions[?(@.type=="EnabledByModuleManager")].status}'; echo
 False
➜ kubectl get module log-shipper -o jsonpath='{.status.conditions[?(@.type=="EnabledByModuleManager")].status}'; echo
 False

# Module CR has requirements.modules populated from the registry
➜ kubectl get module r-g-test -o jsonpath='{.properties.requirements.modules}'; echo
   {"log-shipper":"\u003e= 0.0.0","loki":"\u003e= 0.0.0"}

# Enabling succeeds despite both required parents being disabled — bug
➜ d8 p module enable r-g-test
   Module r-g-test enabled
```
 
 ### After
```bash
# Same conditions: both dependencies disabled, requirements present on Module CR
➜ kubectl get module r-g-test -o jsonpath='{.properties.requirements.modules}'; echo
   {"log-shipper":"\u003e= 0.0.0","loki":"\u003e= 0.0.0"}

# Now the webhook rejects the enable
➜ d8 p module enable r-g-test
Error: enable module: update the 'r-g-test' module config: admission webhook "module-configs.deckhouse-webhook.deckhouse.io" denied the request: the 'r-g-test' module depends on
 disabled module(s): log-shipper, loki
 ```

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: feature
summary: Enforce parent-module requirements from the Module CR in the ModuleConfig validation webhook when the dependency extender has no registered constraints for the module.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
