### PR TITLE
[candi] Update base images v1.1.5

### DIFF
--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -3036,7 +3036,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:0827a3308a3cd84f78f6c35448bccdb35ae3061ec6be9c7f1b87936f76e1f551"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:4d9b26a8ff77468de32e61f4cd24ddaf3b628f05381c7944589b47cbb83cfef8"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -3036,7 +3036,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:f7c770a010e563a372b3a1f2d4e248f6753b9063fe647b1966fd71441d496c01"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:4f46b3466b3a284e0a9926aa7ad835a493d3ef6b81308a5fdd4422ee5a88e62a"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -3151,7 +3151,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run node-controller tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:889c5d72b24fc14957a6c7c6dc3d4907598a3fb7ed9953f5ad8d2b999c0b3b37"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:0402dc491bceed2957bab097564d629cfa2047c7fd0f20f7111c96dd834e89fe"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -3036,7 +3036,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:4f46b3466b3a284e0a9926aa7ad835a493d3ef6b81308a5fdd4422ee5a88e62a"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:0402dc491bceed2957bab097564d629cfa2047c7fd0f20f7111c96dd834e89fe"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -3036,7 +3036,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:4d9b26a8ff77468de32e61f4cd24ddaf3b628f05381c7944589b47cbb83cfef8"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:f7c770a010e563a372b3a1f2d4e248f6753b9063fe647b1966fd71441d496c01"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/.github/workflows/build-and-test_main.yml
+++ b/.github/workflows/build-and-test_main.yml
@@ -1007,7 +1007,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:4d9b26a8ff77468de32e61f4cd24ddaf3b628f05381c7944589b47cbb83cfef8"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:f7c770a010e563a372b3a1f2d4e248f6753b9063fe647b1966fd71441d496c01"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/.github/workflows/build-and-test_main.yml
+++ b/.github/workflows/build-and-test_main.yml
@@ -1007,7 +1007,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:f7c770a010e563a372b3a1f2d4e248f6753b9063fe647b1966fd71441d496c01"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:4f46b3466b3a284e0a9926aa7ad835a493d3ef6b81308a5fdd4422ee5a88e62a"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/.github/workflows/build-and-test_main.yml
+++ b/.github/workflows/build-and-test_main.yml
@@ -1007,7 +1007,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:4f46b3466b3a284e0a9926aa7ad835a493d3ef6b81308a5fdd4422ee5a88e62a"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:0402dc491bceed2957bab097564d629cfa2047c7fd0f20f7111c96dd834e89fe"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/.github/workflows/build-and-test_main.yml
+++ b/.github/workflows/build-and-test_main.yml
@@ -1007,7 +1007,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:0827a3308a3cd84f78f6c35448bccdb35ae3061ec6be9c7f1b87936f76e1f551"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:4d9b26a8ff77468de32e61f4cd24ddaf3b628f05381c7944589b47cbb83cfef8"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -2709,7 +2709,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:4d9b26a8ff77468de32e61f4cd24ddaf3b628f05381c7944589b47cbb83cfef8"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:f7c770a010e563a372b3a1f2d4e248f6753b9063fe647b1966fd71441d496c01"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -2709,7 +2709,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:4f46b3466b3a284e0a9926aa7ad835a493d3ef6b81308a5fdd4422ee5a88e62a"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:0402dc491bceed2957bab097564d629cfa2047c7fd0f20f7111c96dd834e89fe"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -2709,7 +2709,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:0827a3308a3cd84f78f6c35448bccdb35ae3061ec6be9c7f1b87936f76e1f551"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:4d9b26a8ff77468de32e61f4cd24ddaf3b628f05381c7944589b47cbb83cfef8"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -2709,7 +2709,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:f7c770a010e563a372b3a1f2d4e248f6753b9063fe647b1966fd71441d496c01"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:4f46b3466b3a284e0a9926aa7ad835a493d3ef6b81308a5fdd4422ee5a88e62a"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/candi/alt_base_images.yml
+++ b/candi/alt_base_images.yml
@@ -1,8 +1,8 @@
-# version=v1.0.50
+# version=v1.1.1
 REGISTRY_PATH: registry.deckhouse.io/container-factory
-builder/distroless: "sha256:cd125c09e8315342655b019f970648ddbb9477e2b90b781c56cd7b8c1a3d8c54" # from: builder/scratch
-builder/golang-1.25: "sha256:05bb349637f4cffeb78a0d8f629dae2091bd8d4f1a13f6339e8ad3168eca99f5" # from: builder/distroless
-builder/golang-1.26: "sha256:0827a3308a3cd84f78f6c35448bccdb35ae3061ec6be9c7f1b87936f76e1f551" # from: builder/distroless
-builder/golang: "sha256:0827a3308a3cd84f78f6c35448bccdb35ae3061ec6be9c7f1b87936f76e1f551" # from: builder/distroless
-minget-0.1: "sha256:9e01a97af556c0523fb1a5700a99647bf20426b4b5f717352bf27fb9f9f1a15b" # from: builder/scratch
-minget: "sha256:9e01a97af556c0523fb1a5700a99647bf20426b4b5f717352bf27fb9f9f1a15b" # from: builder/scratch
+builder/distroless: "sha256:718656833982ab71801c87a2f7dbde5afa99edb56f6480aa0da9440235cbd2aa" # from: scratch
+builder/golang-1.25: "sha256:aad5aa1a19fd8ef8f41d58e010e36ba8c176dae92b3ef28177c4d22f1f78cd1e" # from: builder/distroless
+builder/golang-1.26: "sha256:4d9b26a8ff77468de32e61f4cd24ddaf3b628f05381c7944589b47cbb83cfef8" # from: builder/distroless
+builder/golang: "sha256:4d9b26a8ff77468de32e61f4cd24ddaf3b628f05381c7944589b47cbb83cfef8" # from: builder/distroless
+minget-0.1: "sha256:acfb50dadf1805c102643a5641a3ef0650f7264ffbb530d7e3ce84fe505c4dfb" # from: builder/scratch
+minget: "sha256:acfb50dadf1805c102643a5641a3ef0650f7264ffbb530d7e3ce84fe505c4dfb" # from: builder/scratch

--- a/candi/alt_base_images.yml
+++ b/candi/alt_base_images.yml
@@ -1,8 +1,8 @@
-# version=v1.1.3
+# version=v1.1.4
 REGISTRY_PATH: registry.deckhouse.io/container-factory
-builder/distroless: "sha256:1bd168287c491d71ccd25d6a2bac2a8abd5da9f08e91df01a39de33c42ccf35c" # from: scratch
-builder/golang-1.25: "sha256:062d82a85dd62ccfb1f2f9f739594b54f568e015817232186f7a68c7495409e0" # from: builder/distroless
-builder/golang-1.26: "sha256:f7c770a010e563a372b3a1f2d4e248f6753b9063fe647b1966fd71441d496c01" # from: builder/distroless
-builder/golang: "sha256:f7c770a010e563a372b3a1f2d4e248f6753b9063fe647b1966fd71441d496c01" # from: builder/distroless
+builder/distroless: "sha256:da95d1a4474fad8daa738700961f4d5adcd61317e01b7275f8aa38cb95fc452e" # from: scratch
+builder/golang-1.25: "sha256:4fffdee3e262b2553555e0966cdaa2f410ed379e66e75f1341f7a4980543805c" # from: builder/distroless
+builder/golang-1.26: "sha256:4f46b3466b3a284e0a9926aa7ad835a493d3ef6b81308a5fdd4422ee5a88e62a" # from: builder/distroless
+builder/golang: "sha256:4f46b3466b3a284e0a9926aa7ad835a493d3ef6b81308a5fdd4422ee5a88e62a" # from: builder/distroless
 minget-0.1: "sha256:acfb50dadf1805c102643a5641a3ef0650f7264ffbb530d7e3ce84fe505c4dfb" # from: builder/scratch
 minget: "sha256:acfb50dadf1805c102643a5641a3ef0650f7264ffbb530d7e3ce84fe505c4dfb" # from: builder/scratch

--- a/candi/alt_base_images.yml
+++ b/candi/alt_base_images.yml
@@ -1,8 +1,8 @@
-# version=v1.1.1
+# version=v1.1.3
 REGISTRY_PATH: registry.deckhouse.io/container-factory
-builder/distroless: "sha256:718656833982ab71801c87a2f7dbde5afa99edb56f6480aa0da9440235cbd2aa" # from: scratch
-builder/golang-1.25: "sha256:aad5aa1a19fd8ef8f41d58e010e36ba8c176dae92b3ef28177c4d22f1f78cd1e" # from: builder/distroless
-builder/golang-1.26: "sha256:4d9b26a8ff77468de32e61f4cd24ddaf3b628f05381c7944589b47cbb83cfef8" # from: builder/distroless
-builder/golang: "sha256:4d9b26a8ff77468de32e61f4cd24ddaf3b628f05381c7944589b47cbb83cfef8" # from: builder/distroless
+builder/distroless: "sha256:1bd168287c491d71ccd25d6a2bac2a8abd5da9f08e91df01a39de33c42ccf35c" # from: scratch
+builder/golang-1.25: "sha256:062d82a85dd62ccfb1f2f9f739594b54f568e015817232186f7a68c7495409e0" # from: builder/distroless
+builder/golang-1.26: "sha256:f7c770a010e563a372b3a1f2d4e248f6753b9063fe647b1966fd71441d496c01" # from: builder/distroless
+builder/golang: "sha256:f7c770a010e563a372b3a1f2d4e248f6753b9063fe647b1966fd71441d496c01" # from: builder/distroless
 minget-0.1: "sha256:acfb50dadf1805c102643a5641a3ef0650f7264ffbb530d7e3ce84fe505c4dfb" # from: builder/scratch
 minget: "sha256:acfb50dadf1805c102643a5641a3ef0650f7264ffbb530d7e3ce84fe505c4dfb" # from: builder/scratch

--- a/candi/alt_base_images.yml
+++ b/candi/alt_base_images.yml
@@ -1,8 +1,8 @@
-# version=v1.1.4
+# version=v1.1.5
 REGISTRY_PATH: registry.deckhouse.io/container-factory
-builder/distroless: "sha256:da95d1a4474fad8daa738700961f4d5adcd61317e01b7275f8aa38cb95fc452e" # from: scratch
-builder/golang-1.25: "sha256:4fffdee3e262b2553555e0966cdaa2f410ed379e66e75f1341f7a4980543805c" # from: builder/distroless
-builder/golang-1.26: "sha256:4f46b3466b3a284e0a9926aa7ad835a493d3ef6b81308a5fdd4422ee5a88e62a" # from: builder/distroless
-builder/golang: "sha256:4f46b3466b3a284e0a9926aa7ad835a493d3ef6b81308a5fdd4422ee5a88e62a" # from: builder/distroless
+builder/distroless: "sha256:db87d1809c1aea16c855d1bd1bca1afe4baa9563b1fdec3efcb5690ca7f67b36" # from: builder/scratch
+builder/golang-1.25: "sha256:5f26819f27dd2e8ef0e9ee410f9e0ad8660ab59e0037b96599a34342a85fc7f6" # from: builder/distroless
+builder/golang-1.26: "sha256:0402dc491bceed2957bab097564d629cfa2047c7fd0f20f7111c96dd834e89fe" # from: builder/distroless
+builder/golang: "sha256:0402dc491bceed2957bab097564d629cfa2047c7fd0f20f7111c96dd834e89fe" # from: builder/distroless
 minget-0.1: "sha256:acfb50dadf1805c102643a5641a3ef0650f7264ffbb530d7e3ce84fe505c4dfb" # from: builder/scratch
 minget: "sha256:acfb50dadf1805c102643a5641a3ef0650f7264ffbb530d7e3ce84fe505c4dfb" # from: builder/scratch

--- a/ee/modules/450-keepalived/images/keepalived/werf.inc.yaml
+++ b/ee/modules/450-keepalived/images/keepalived/werf.inc.yaml
@@ -20,7 +20,7 @@ import:
   before: install
 shell:
   beforeInstall:
-  - pm install m4 automake autoconf binutils linux-headers openssl-devel pcre-devel pcre2-devel net-snmp-devel pkgconf perl
+  - pm install m4 automake autoconf binutils linux-headers openssl-devel pcre-devel pcre2-devel net-snmp-devel pkgconf perl libxcrypt-devel
   install:
   - cd /src
   - ./autogen.sh

--- a/ee/modules/450-keepalived/images/keepalived/werf.inc.yaml
+++ b/ee/modules/450-keepalived/images/keepalived/werf.inc.yaml
@@ -20,7 +20,7 @@ import:
   before: install
 shell:
   beforeInstall:
-  - pm install m4 automake autoconf binutils linux-headers openssl-devel pcre-devel pcre2-devel net-snmp-devel pkgconf perl libxcrypt-devel
+  - pm install m4 automake autoconf binutils linux-headers openssl-devel pcre-devel pcre2-devel net-snmp-devel pkgconf perl
   install:
   - cd /src
   - ./autogen.sh


### PR DESCRIPTION
## Description
Update base images v1.1.5 with new builder/distroless from scratch

## Why do we need it, and what problem does it solve?
To ensure that using builder/distroless as the final image is legitimate (SBOM)

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: chore
summary: update base images v1.1.5
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
