### PR TITLE
[candi] update kube version

### DIFF
--- a/candi/openapi/cluster_configuration.yaml
+++ b/candi/openapi/cluster_configuration.yaml
@@ -1,6 +1,7 @@
 # WARNING!
-# Please evaluate to add changes to ee/cse/candi/openapi/cluster_configuration.yaml
-# After change this file!
+# if you change this file please evaluate to change files
+# /candi/openapi/cluster_configuration.yaml
+# /ee/cse/candi/openapi/cluster_configuration.yaml
 
 kind: ClusterConfiguration
 apiVersions:

--- a/ee/cse/candi/openapi/README.md
+++ b/ee/cse/candi/openapi/README.md
@@ -2,5 +2,5 @@
 
 ## cluster_configuration.yaml
 
-1. Unnecessary versions have been removed from `kubernetesVersion`. Only 1.31 (for updates) and 1.33 (the current version for this release) remain.
+1. Unnecessary versions have been removed from `kubernetesVersion`. Only 1.31 (for updates) and 1.34 (the current version for this release) remain.
 2. Only DVP remains in `cloud.provider`.

--- a/ee/cse/candi/openapi/cluster_configuration.yaml
+++ b/ee/cse/candi/openapi/cluster_configuration.yaml
@@ -1,6 +1,7 @@
 # WARNING!
-# Please evaluate to add changes to candi/openapi/cluster_configuration.yaml
-# After change this file!
+# if you change this file please evaluate to change files
+# /candi/openapi/cluster_configuration.yaml
+# /ee/cse/candi/openapi/cluster_configuration.yaml
 
 kind: ClusterConfiguration
 apiVersions:
@@ -25,7 +26,7 @@ apiVersions:
       podSubnetNodeCIDRPrefix: "24"
       podSubnetCIDR: 10.244.0.0/16
       serviceSubnetCIDR: 192.168.0.0/16
-      kubernetesVersion: "1.31"
+      kubernetesVersion: "1.32"
       clusterDomain: k8s.internal
       clusterType: "Cloud"
       cloud:
@@ -121,7 +122,7 @@ apiVersions:
           If `ContainerdV2` is set, `CgroupsV2` will be used (providing improved security and resource management). To use `ContainerdV2` as the container runtime, cluster nodes must meet the following requirements:
 
           - Support for `CgroupsV2`.
-          - Linux kernel version `5.8` or newer.
+          - Linux kernel version 5.8 or newer, except for the ranges 6.12.0–6.12.28 or 6.14.0–6.14.6 (these versions are affected by CVE-2025-37999 in EROFS).
           - Systemd version `244` or newer.
           - Support for `erofs` kernel module.
         enum:
@@ -140,13 +141,14 @@ apiVersions:
           The version may change when the minor version of the Deckhouse release is changed (see a corresponding release message).
         enum:
         - "1.31"
-        - "1.33"
+        - "1.34"
         - "Automatic"
       encryptionAlgorithm:
         type: string
         x-doc-deprecated: true
         description: |
           **Deprecated.** Use `encryptionAlgorithm` in the `control-plane-manager` ModuleConfig instead.
+          
           When the ModuleConfig field is set, it takes precedence over this field.
 
           Starting from version **1.31**, kubeadm use the specified asymmetric encryption algorithm


### PR DESCRIPTION
## Description
Added Kube version 1.34 as an option in the CSE cluster.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Kube version 1.34 is not available for selection when creating a cluster.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: chore
summary: update kube version
impact: 
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
