### PR TITLE
[docs] Update tags of the prompp module in the modules list in the documentation

### DIFF
--- a/docs/documentation/_data/modules/editions-addition.json
+++ b/docs/documentation/_data/modules/editions-addition.json
@@ -69,6 +69,8 @@
     "operator-prometheus",
     "operator-trivy",
     "prometheus",
+    "prometheus-metrics-adapter",
+    "prompp",
     "registry",
     "registry-packages-proxy",
     "registrypackages",

--- a/docs/documentation/_data/modules/modules-addition.json
+++ b/docs/documentation/_data/modules/modules-addition.json
@@ -599,7 +599,7 @@
       "cse-pro"
     ],
     "external": "true",
-    "path": "/modules/prompp/stable/"
+    "path": "/modules/prompp/"
   },
   "runtime-audit-engine": {
     "editions": [

--- a/docs/documentation/_data/modules/modules-addition.json
+++ b/docs/documentation/_data/modules/modules-addition.json
@@ -588,6 +588,19 @@
     "external": "true",
     "path": "/modules/prometheus-pushgateway/"
   },
+  "prompp": {
+    "editions": [
+      "ce",
+      "be",
+      "se",
+      "se-plus",
+      "ee",
+      "cse-lite",
+      "cse-pro"
+    ],
+    "external": "true",
+    "path": "/modules/prompp/stable/"
+  },
   "runtime-audit-engine": {
     "editions": [
       "ee",

--- a/docs/site/backends/docs-builder-template/data/modules_all.json
+++ b/docs/site/backends/docs-builder-template/data/modules_all.json
@@ -586,6 +586,23 @@
       "ssdlc"
     ]
   },
+  "prompp": {
+    "editions": [
+      "ce",
+      "be",
+      "se",
+      "se-plus",
+      "ee",
+      "cse-lite",
+      "cse-pro"
+    ],
+    "external": "true",
+    "path": "/modules/prompp/",
+    "tags": [
+      "observability",
+      "helper"
+    ]
+  },
   "pod-reloader": {
     "editions": [
       "ce",


### PR DESCRIPTION
## Description

This PR adds the a service module `prompp` to the general list of modules.

## Changelog entries

```changes
section: docs
type: chore
summary: Update tags of the prompp module in the modules list in the documentation.
impact_level: low
```