### PR TITLE
[registrypackages] Containerd integrity users ca

### DIFF
--- a/modules/007-registrypackages/images/containerd/patches/containerd/2.2.4/000-gomod.patch
+++ b/modules/007-registrypackages/images/containerd/patches/containerd/2.2.4/000-gomod.patch
@@ -1,5 +1,5 @@
 diff --git a/go.mod b/go.mod
-index 0eb18826d..0a42fcc9f 100644
+index 0eb18826d..5a456c181 100644
 --- a/go.mod
 +++ b/go.mod
 @@ -1,6 +1,6 @@
@@ -29,7 +29,15 @@ index 0eb18826d..0a42fcc9f 100644
  	github.com/google/uuid v1.6.0
  	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0
  	github.com/intel/goresctrl v0.10.0
-@@ -68,37 +71,44 @@ require (
+@@ -59,6 +62,7 @@ require (
+ 	github.com/opencontainers/selinux v1.13.1
+ 	github.com/pelletier/go-toml/v2 v2.2.4
+ 	github.com/prometheus/client_golang v1.23.2
++	github.com/sigstore/sigstore v1.8.8
+ 	github.com/sirupsen/logrus v1.9.3
+ 	github.com/stretchr/testify v1.11.1
+ 	github.com/tchap/go-patricia/v2 v2.3.3
+@@ -68,37 +72,44 @@ require (
  	go.etcd.io/bbolt v1.4.3
  	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.60.0
  	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.60.0
@@ -83,7 +91,7 @@ index 0eb18826d..0a42fcc9f 100644
  	github.com/felixge/httpsnoop v1.0.4 // indirect
  	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
  	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
-@@ -109,16 +119,30 @@ require (
+@@ -109,16 +120,30 @@ require (
  	github.com/gogo/protobuf v1.3.2 // indirect
  	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
  	github.com/golang/protobuf v1.5.4 // indirect
@@ -114,7 +122,7 @@ index 0eb18826d..0a42fcc9f 100644
  	github.com/moby/spdystream v0.5.1 // indirect
  	github.com/moby/sys/capability v0.4.0 // indirect
  	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-@@ -127,32 +151,38 @@ require (
+@@ -127,32 +152,37 @@ require (
  	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
  	github.com/petermattis/goid v0.0.0-20240813172612-4fcff4a6cae7 // indirect
  	github.com/pkg/errors v0.9.1 // indirect
@@ -128,7 +136,6 @@ index 0eb18826d..0a42fcc9f 100644
 +	github.com/samber/lo v1.51.0 // indirect
  	github.com/sasha-s/go-deadlock v0.3.5 // indirect
 +	github.com/secure-systems-lab/go-securesystemslib v0.9.0 // indirect
-+	github.com/sigstore/sigstore v1.8.8 // indirect
  	github.com/smallstep/pkcs7 v0.1.1 // indirect
  	github.com/stefanberger/go-pkcs11uri v0.0.0-20230803200340-78284954bff6 // indirect
  	github.com/tetratelabs/wazero v1.10.1 // indirect

--- a/modules/007-registrypackages/images/containerd/werf.inc.yaml
+++ b/modules/007-registrypackages/images/containerd/werf.inc.yaml
@@ -154,7 +154,7 @@ shell:
   install:
 {{- if and (eq $.Env "CSE") $is_v2 }}
   - echo "Attention! Use integrity patches!"
-  - git clone --depth 1 --branch users-ca git@$(cat /run/secrets/DECKHOUSE_PRIVATE_REPO):deckhouse/kubernetes/platform/containerd-integrity-patches.git /src/integrity-patches
+  - git clone --depth 1 --branch v{{ $containerd_version }}-{{ $containerd_integrity_patches_version }} git@$(cat /run/secrets/DECKHOUSE_PRIVATE_REPO):deckhouse/kubernetes/platform/containerd-integrity-patches.git /src/integrity-patches
   - alias cp='cp'
   - cp /src/integrity-patches/patches/*.patch /patches
   - rm -rf /src/integrity-patches

--- a/modules/007-registrypackages/images/containerd/werf.inc.yaml
+++ b/modules/007-registrypackages/images/containerd/werf.inc.yaml
@@ -154,7 +154,7 @@ shell:
   install:
 {{- if and (eq $.Env "CSE") $is_v2 }}
   - echo "Attention! Use integrity patches!"
-  - git clone --depth 1 --branch v{{ $containerd_version }}-{{ $containerd_integrity_patches_version }} git@$(cat /run/secrets/DECKHOUSE_PRIVATE_REPO):deckhouse/kubernetes/platform/containerd-integrity-patches.git /src/integrity-patches
+  - git clone --depth 1 --branch users-ca git@$(cat /run/secrets/DECKHOUSE_PRIVATE_REPO):deckhouse/kubernetes/platform/containerd-integrity-patches.git /src/integrity-patches
   - alias cp='cp'
   - cp /src/integrity-patches/patches/*.patch /patches
   - rm -rf /src/integrity-patches

--- a/modules/007-registrypackages/images/containerd/werf.inc.yaml
+++ b/modules/007-registrypackages/images/containerd/werf.inc.yaml
@@ -1,7 +1,7 @@
 {{- $containerd_versions := list "1.7.32" "2.2.4" }}
 {{- $runc_versions := list "1.3.5" }}
 {{- $containerd2runc := dict "1.7.32" "1.3.5" "2.2.4" "1.3.5" }}
-{{- $containerd_integrity_patches_version := .IntegrityPatchesVersion | default "0" }} # may be redefine in CSE
+{{- $containerd_integrity_patches_version := .IntegrityPatchesVersion | default "1" }} # may be redefine in CSE
 
 # calculate additional build options for containerd
 # skip for v1 and not CSE. Now we calculate namespaces for integrity check


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix containerd patches for new integrity feature with user's ca.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: registrypackages
type: feature
summary: Fixed containerd patches for the integrity feature when using a custom CA.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
