### PR TITLE
fix: module cache invalidation

### DIFF
--- a/tools/build.go
+++ b/tools/build.go
@@ -651,6 +651,7 @@ func (e *executor) executeEdition(editionName string) {
 		writeSettingsExcludeFileName.Prefix = prefix
 		writeSettingsExcludeFileName.Dir = "modules"
 		writeSettingsExcludeFileName.ExcludePaths = defaultModulesExcludes
+		writeSettingsExcludeFileName.StageDependencies = stageDependenciesSetup
 
 		writeSettingStageDeps.Prefix = prefix
 		writeSettingStageDeps.Dir = "modules"

--- a/tools/build_includes/modules-with-exclude-BE.yaml
+++ b/tools/build_includes/modules-with-exclude-BE.yaml
@@ -15,6 +15,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/002-deckhouse
   to: /deckhouse/modules/002-deckhouse
   excludePaths:
@@ -31,6 +34,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/007-registrypackages
   to: /deckhouse/modules/007-registrypackages
   excludePaths:
@@ -47,6 +53,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/015-admission-policy-engine
   to: /deckhouse/modules/015-admission-policy-engine
   excludePaths:
@@ -63,6 +72,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/021-cni-cilium
   to: /deckhouse/modules/021-cni-cilium
   excludePaths:
@@ -79,6 +91,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/030-cloud-provider-aws
   to: /deckhouse/modules/030-cloud-provider-aws
   excludePaths:
@@ -95,6 +110,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/030-cloud-provider-azure
   to: /deckhouse/modules/030-cloud-provider-azure
   excludePaths:
@@ -111,6 +129,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/030-cloud-provider-dvp
   to: /deckhouse/modules/030-cloud-provider-dvp
   excludePaths:
@@ -127,6 +148,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/030-cloud-provider-gcp
   to: /deckhouse/modules/030-cloud-provider-gcp
   excludePaths:
@@ -143,6 +167,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/030-cloud-provider-yandex
   to: /deckhouse/modules/030-cloud-provider-yandex
   excludePaths:
@@ -159,6 +186,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/031-local-path-provisioner
   to: /deckhouse/modules/031-local-path-provisioner
   excludePaths:
@@ -175,6 +205,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/035-cni-flannel
   to: /deckhouse/modules/035-cni-flannel
   excludePaths:
@@ -191,6 +224,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/035-cni-simple-bridge
   to: /deckhouse/modules/035-cni-simple-bridge
   excludePaths:
@@ -207,6 +243,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/036-kube-proxy
   to: /deckhouse/modules/036-kube-proxy
   excludePaths:
@@ -223,6 +262,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/038-registry
   to: /deckhouse/modules/038-registry
   excludePaths:
@@ -239,6 +281,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/039-registry-packages-proxy
   to: /deckhouse/modules/039-registry-packages-proxy
   excludePaths:
@@ -255,6 +300,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/040-control-plane-manager
   to: /deckhouse/modules/040-control-plane-manager
   excludePaths:
@@ -271,6 +319,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/040-node-manager
   to: /deckhouse/modules/040-node-manager
   excludePaths:
@@ -287,6 +338,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/040-terraform-manager
   to: /deckhouse/modules/040-terraform-manager
   excludePaths:
@@ -303,6 +357,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/042-kube-dns
   to: /deckhouse/modules/042-kube-dns
   excludePaths:
@@ -319,6 +376,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/050-network-policy-engine
   to: /deckhouse/modules/050-network-policy-engine
   excludePaths:
@@ -335,6 +395,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/101-cert-manager
   to: /deckhouse/modules/101-cert-manager
   excludePaths:
@@ -351,6 +414,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/110-istio
   to: /deckhouse/modules/110-istio
   excludePaths:
@@ -367,6 +433,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/140-user-authz
   to: /deckhouse/modules/140-user-authz
   excludePaths:
@@ -383,6 +452,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/150-user-authn
   to: /deckhouse/modules/150-user-authn
   excludePaths:
@@ -399,6 +471,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/160-multitenancy-manager
   to: /deckhouse/modules/160-multitenancy-manager
   excludePaths:
@@ -415,6 +490,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/200-operator-prometheus
   to: /deckhouse/modules/200-operator-prometheus
   excludePaths:
@@ -431,6 +509,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/300-prometheus
   to: /deckhouse/modules/300-prometheus
   excludePaths:
@@ -447,6 +528,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/301-prometheus-metrics-adapter
   to: /deckhouse/modules/301-prometheus-metrics-adapter
   excludePaths:
@@ -463,6 +547,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/302-vertical-pod-autoscaler
   to: /deckhouse/modules/302-vertical-pod-autoscaler
   excludePaths:
@@ -479,6 +566,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/303-prometheus-pushgateway
   to: /deckhouse/modules/303-prometheus-pushgateway
   excludePaths:
@@ -495,6 +585,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/340-extended-monitoring
   to: /deckhouse/modules/340-extended-monitoring
   excludePaths:
@@ -511,6 +604,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/340-monitoring-custom
   to: /deckhouse/modules/340-monitoring-custom
   excludePaths:
@@ -527,6 +623,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/340-monitoring-kubernetes
   to: /deckhouse/modules/340-monitoring-kubernetes
   excludePaths:
@@ -543,6 +642,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/340-monitoring-kubernetes-control-plane
   to: /deckhouse/modules/340-monitoring-kubernetes-control-plane
   excludePaths:
@@ -559,6 +661,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/340-monitoring-ping
   to: /deckhouse/modules/340-monitoring-ping
   excludePaths:
@@ -575,6 +680,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/400-descheduler
   to: /deckhouse/modules/400-descheduler
   excludePaths:
@@ -591,6 +699,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/402-ingress-nginx
   to: /deckhouse/modules/402-ingress-nginx
   excludePaths:
@@ -607,6 +718,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/460-log-shipper
   to: /deckhouse/modules/460-log-shipper
   excludePaths:
@@ -623,6 +737,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/462-loki
   to: /deckhouse/modules/462-loki
   excludePaths:
@@ -639,6 +756,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/470-chrony
   to: /deckhouse/modules/470-chrony
   excludePaths:
@@ -655,6 +775,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/500-cilium-hubble
   to: /deckhouse/modules/500-cilium-hubble
   excludePaths:
@@ -671,6 +794,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/500-okmeter
   to: /deckhouse/modules/500-okmeter
   excludePaths:
@@ -687,6 +813,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/500-openvpn
   to: /deckhouse/modules/500-openvpn
   excludePaths:
@@ -703,6 +832,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/500-upmeter
   to: /deckhouse/modules/500-upmeter
   excludePaths:
@@ -719,6 +851,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/600-namespace-configurator
   to: /deckhouse/modules/600-namespace-configurator
   excludePaths:
@@ -735,6 +870,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/600-secret-copier
   to: /deckhouse/modules/600-secret-copier
   excludePaths:
@@ -751,6 +889,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/800-deckhouse-tools
   to: /deckhouse/modules/800-deckhouse-tools
   excludePaths:
@@ -767,6 +908,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/810-documentation
   to: /deckhouse/modules/810-documentation
   excludePaths:
@@ -783,6 +927,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/be/modules/040-node-manager/openapi/openapi-case-tests.yaml
   to: /deckhouse/modules/040-node-manager/openapi/openapi-case-tests.yaml
   stageDependencies:
@@ -809,6 +956,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/be/modules/140-user-authz/templates/permission-browser-apiserver
   to: /deckhouse/modules/140-user-authz/templates/permission-browser-apiserver
   excludePaths:
@@ -825,6 +975,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/be/modules/350-node-local-dns
   to: /deckhouse/modules/350-node-local-dns
   excludePaths:
@@ -841,3 +994,6 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'

--- a/tools/build_includes/modules-with-exclude-CE.yaml
+++ b/tools/build_includes/modules-with-exclude-CE.yaml
@@ -15,6 +15,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/002-deckhouse
   to: /deckhouse/modules/002-deckhouse
   excludePaths:
@@ -31,6 +34,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/007-registrypackages
   to: /deckhouse/modules/007-registrypackages
   excludePaths:
@@ -47,6 +53,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/015-admission-policy-engine
   to: /deckhouse/modules/015-admission-policy-engine
   excludePaths:
@@ -63,6 +72,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/021-cni-cilium
   to: /deckhouse/modules/021-cni-cilium
   excludePaths:
@@ -79,6 +91,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/030-cloud-provider-aws
   to: /deckhouse/modules/030-cloud-provider-aws
   excludePaths:
@@ -95,6 +110,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/030-cloud-provider-azure
   to: /deckhouse/modules/030-cloud-provider-azure
   excludePaths:
@@ -111,6 +129,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/030-cloud-provider-dvp
   to: /deckhouse/modules/030-cloud-provider-dvp
   excludePaths:
@@ -127,6 +148,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/030-cloud-provider-gcp
   to: /deckhouse/modules/030-cloud-provider-gcp
   excludePaths:
@@ -143,6 +167,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/030-cloud-provider-yandex
   to: /deckhouse/modules/030-cloud-provider-yandex
   excludePaths:
@@ -159,6 +186,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/031-local-path-provisioner
   to: /deckhouse/modules/031-local-path-provisioner
   excludePaths:
@@ -175,6 +205,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/035-cni-flannel
   to: /deckhouse/modules/035-cni-flannel
   excludePaths:
@@ -191,6 +224,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/035-cni-simple-bridge
   to: /deckhouse/modules/035-cni-simple-bridge
   excludePaths:
@@ -207,6 +243,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/036-kube-proxy
   to: /deckhouse/modules/036-kube-proxy
   excludePaths:
@@ -223,6 +262,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/038-registry
   to: /deckhouse/modules/038-registry
   excludePaths:
@@ -239,6 +281,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/039-registry-packages-proxy
   to: /deckhouse/modules/039-registry-packages-proxy
   excludePaths:
@@ -255,6 +300,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/040-control-plane-manager
   to: /deckhouse/modules/040-control-plane-manager
   excludePaths:
@@ -271,6 +319,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/040-node-manager
   to: /deckhouse/modules/040-node-manager
   excludePaths:
@@ -287,6 +338,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/040-terraform-manager
   to: /deckhouse/modules/040-terraform-manager
   excludePaths:
@@ -303,6 +357,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/042-kube-dns
   to: /deckhouse/modules/042-kube-dns
   excludePaths:
@@ -319,6 +376,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/050-network-policy-engine
   to: /deckhouse/modules/050-network-policy-engine
   excludePaths:
@@ -335,6 +395,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/101-cert-manager
   to: /deckhouse/modules/101-cert-manager
   excludePaths:
@@ -351,6 +414,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/110-istio
   to: /deckhouse/modules/110-istio
   excludePaths:
@@ -367,6 +433,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/140-user-authz
   to: /deckhouse/modules/140-user-authz
   excludePaths:
@@ -383,6 +452,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/150-user-authn
   to: /deckhouse/modules/150-user-authn
   excludePaths:
@@ -399,6 +471,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/160-multitenancy-manager
   to: /deckhouse/modules/160-multitenancy-manager
   excludePaths:
@@ -415,6 +490,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/200-operator-prometheus
   to: /deckhouse/modules/200-operator-prometheus
   excludePaths:
@@ -431,6 +509,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/300-prometheus
   to: /deckhouse/modules/300-prometheus
   excludePaths:
@@ -447,6 +528,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/301-prometheus-metrics-adapter
   to: /deckhouse/modules/301-prometheus-metrics-adapter
   excludePaths:
@@ -463,6 +547,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/302-vertical-pod-autoscaler
   to: /deckhouse/modules/302-vertical-pod-autoscaler
   excludePaths:
@@ -479,6 +566,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/303-prometheus-pushgateway
   to: /deckhouse/modules/303-prometheus-pushgateway
   excludePaths:
@@ -495,6 +585,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/340-extended-monitoring
   to: /deckhouse/modules/340-extended-monitoring
   excludePaths:
@@ -511,6 +604,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/340-monitoring-custom
   to: /deckhouse/modules/340-monitoring-custom
   excludePaths:
@@ -527,6 +623,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/340-monitoring-kubernetes
   to: /deckhouse/modules/340-monitoring-kubernetes
   excludePaths:
@@ -543,6 +642,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/340-monitoring-kubernetes-control-plane
   to: /deckhouse/modules/340-monitoring-kubernetes-control-plane
   excludePaths:
@@ -559,6 +661,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/340-monitoring-ping
   to: /deckhouse/modules/340-monitoring-ping
   excludePaths:
@@ -575,6 +680,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/400-descheduler
   to: /deckhouse/modules/400-descheduler
   excludePaths:
@@ -591,6 +699,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/402-ingress-nginx
   to: /deckhouse/modules/402-ingress-nginx
   excludePaths:
@@ -607,6 +718,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/460-log-shipper
   to: /deckhouse/modules/460-log-shipper
   excludePaths:
@@ -623,6 +737,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/462-loki
   to: /deckhouse/modules/462-loki
   excludePaths:
@@ -639,6 +756,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/470-chrony
   to: /deckhouse/modules/470-chrony
   excludePaths:
@@ -655,6 +775,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/500-cilium-hubble
   to: /deckhouse/modules/500-cilium-hubble
   excludePaths:
@@ -671,6 +794,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/500-okmeter
   to: /deckhouse/modules/500-okmeter
   excludePaths:
@@ -687,6 +813,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/500-openvpn
   to: /deckhouse/modules/500-openvpn
   excludePaths:
@@ -703,6 +832,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/500-upmeter
   to: /deckhouse/modules/500-upmeter
   excludePaths:
@@ -719,6 +851,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/600-namespace-configurator
   to: /deckhouse/modules/600-namespace-configurator
   excludePaths:
@@ -735,6 +870,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/600-secret-copier
   to: /deckhouse/modules/600-secret-copier
   excludePaths:
@@ -751,6 +889,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/800-deckhouse-tools
   to: /deckhouse/modules/800-deckhouse-tools
   excludePaths:
@@ -767,6 +908,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/810-documentation
   to: /deckhouse/modules/810-documentation
   excludePaths:
@@ -783,3 +927,6 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'

--- a/tools/build_includes/modules-with-exclude-CSE.yaml
+++ b/tools/build_includes/modules-with-exclude-CSE.yaml
@@ -15,6 +15,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/002-deckhouse
   to: /deckhouse/modules/002-deckhouse
   excludePaths:
@@ -31,6 +34,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/007-registrypackages
   to: /deckhouse/modules/007-registrypackages
   excludePaths:
@@ -47,6 +53,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/015-admission-policy-engine
   to: /deckhouse/modules/015-admission-policy-engine
   excludePaths:
@@ -63,6 +72,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/021-cni-cilium
   to: /deckhouse/modules/021-cni-cilium
   excludePaths:
@@ -79,6 +91,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/030-cloud-provider-dvp
   to: /deckhouse/modules/030-cloud-provider-dvp
   excludePaths:
@@ -95,6 +110,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/031-local-path-provisioner
   to: /deckhouse/modules/031-local-path-provisioner
   excludePaths:
@@ -111,6 +129,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/038-registry
   to: /deckhouse/modules/038-registry
   excludePaths:
@@ -127,6 +148,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/039-registry-packages-proxy
   to: /deckhouse/modules/039-registry-packages-proxy
   excludePaths:
@@ -143,6 +167,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/040-control-plane-manager
   to: /deckhouse/modules/040-control-plane-manager
   excludePaths:
@@ -159,6 +186,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/040-node-manager
   to: /deckhouse/modules/040-node-manager
   excludePaths:
@@ -175,6 +205,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/040-terraform-manager
   to: /deckhouse/modules/040-terraform-manager
   excludePaths:
@@ -191,6 +224,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/042-kube-dns
   to: /deckhouse/modules/042-kube-dns
   excludePaths:
@@ -207,6 +243,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/101-cert-manager
   to: /deckhouse/modules/101-cert-manager
   excludePaths:
@@ -223,6 +262,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/110-istio
   to: /deckhouse/modules/110-istio
   excludePaths:
@@ -239,6 +281,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/140-user-authz
   to: /deckhouse/modules/140-user-authz
   excludePaths:
@@ -255,6 +300,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/150-user-authn
   to: /deckhouse/modules/150-user-authn
   excludePaths:
@@ -271,6 +319,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/160-multitenancy-manager
   to: /deckhouse/modules/160-multitenancy-manager
   excludePaths:
@@ -287,6 +338,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/200-operator-prometheus
   to: /deckhouse/modules/200-operator-prometheus
   excludePaths:
@@ -303,6 +357,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/300-prometheus
   to: /deckhouse/modules/300-prometheus
   excludePaths:
@@ -319,6 +376,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/301-prometheus-metrics-adapter
   to: /deckhouse/modules/301-prometheus-metrics-adapter
   excludePaths:
@@ -335,6 +395,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/302-vertical-pod-autoscaler
   to: /deckhouse/modules/302-vertical-pod-autoscaler
   excludePaths:
@@ -351,6 +414,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/340-extended-monitoring
   to: /deckhouse/modules/340-extended-monitoring
   excludePaths:
@@ -367,6 +433,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/340-monitoring-custom
   to: /deckhouse/modules/340-monitoring-custom
   excludePaths:
@@ -383,6 +452,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/340-monitoring-kubernetes
   to: /deckhouse/modules/340-monitoring-kubernetes
   excludePaths:
@@ -399,6 +471,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/340-monitoring-kubernetes-control-plane
   to: /deckhouse/modules/340-monitoring-kubernetes-control-plane
   excludePaths:
@@ -415,6 +490,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/340-monitoring-ping
   to: /deckhouse/modules/340-monitoring-ping
   excludePaths:
@@ -431,6 +509,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/400-descheduler
   to: /deckhouse/modules/400-descheduler
   excludePaths:
@@ -447,6 +528,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/402-ingress-nginx
   to: /deckhouse/modules/402-ingress-nginx
   excludePaths:
@@ -463,6 +547,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/460-log-shipper
   to: /deckhouse/modules/460-log-shipper
   excludePaths:
@@ -479,6 +566,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/462-loki
   to: /deckhouse/modules/462-loki
   excludePaths:
@@ -495,6 +585,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/470-chrony
   to: /deckhouse/modules/470-chrony
   excludePaths:
@@ -511,6 +604,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/500-cilium-hubble
   to: /deckhouse/modules/500-cilium-hubble
   excludePaths:
@@ -527,6 +623,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/500-upmeter
   to: /deckhouse/modules/500-upmeter
   excludePaths:
@@ -543,6 +642,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/600-namespace-configurator
   to: /deckhouse/modules/600-namespace-configurator
   excludePaths:
@@ -559,6 +661,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/600-secret-copier
   to: /deckhouse/modules/600-secret-copier
   excludePaths:
@@ -575,6 +680,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/800-deckhouse-tools
   to: /deckhouse/modules/800-deckhouse-tools
   excludePaths:
@@ -591,6 +699,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/810-documentation
   to: /deckhouse/modules/810-documentation
   excludePaths:
@@ -607,6 +718,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/be/modules/040-node-manager/openapi/openapi-case-tests.yaml
   to: /deckhouse/modules/040-node-manager/openapi/openapi-case-tests.yaml
   stageDependencies:
@@ -633,6 +747,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/be/modules/140-user-authz/templates/permission-browser-apiserver
   to: /deckhouse/modules/140-user-authz/templates/permission-browser-apiserver
   excludePaths:
@@ -649,6 +766,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/be/modules/350-node-local-dns
   to: /deckhouse/modules/350-node-local-dns
   excludePaths:
@@ -665,6 +785,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/se/modules/380-metallb
   to: /deckhouse/modules/380-metallb
   excludePaths:
@@ -681,6 +804,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/se-plus/modules/015-admission-policy-engine/templates/ratify
   to: /deckhouse/modules/015-admission-policy-engine/templates/ratify
   excludePaths:
@@ -697,6 +823,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/se-plus/modules/015-admission-policy-engine/crds/ratify
   to: /deckhouse/modules/015-admission-policy-engine/crds/ratify
   excludePaths:
@@ -713,6 +842,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/se-plus/modules/021-cni-cilium/crds/doc-ru-egressgatewaypolicies.yaml
   to: /deckhouse/modules/021-cni-cilium/crds/doc-ru-egressgatewaypolicies.yaml
   stageDependencies:
@@ -749,6 +881,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/se-plus/modules/021-cni-cilium/templates/egress-gateway-agent
   to: /deckhouse/modules/021-cni-cilium/templates/egress-gateway-agent
   excludePaths:
@@ -765,6 +900,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/se-plus/modules/021-cni-cilium/templates/egress-gateway-instance
   to: /deckhouse/modules/021-cni-cilium/templates/egress-gateway-instance
   excludePaths:
@@ -781,6 +919,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/se-plus/modules/021-cni-cilium/templates/egress-policy
   to: /deckhouse/modules/021-cni-cilium/templates/egress-policy
   excludePaths:
@@ -797,6 +938,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/se-plus/modules/021-cni-cilium/monitoring/prometheus-rules/egressgatewaypolicies.yaml
   to: /deckhouse/modules/021-cni-cilium/monitoring/prometheus-rules/egressgatewaypolicies.yaml
   stageDependencies:
@@ -818,6 +962,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/se-plus/modules/040-node-manager/capi/zvirt
   to: /deckhouse/modules/040-node-manager/capi/zvirt
   excludePaths:
@@ -834,6 +981,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/040-control-plane-manager/openapi/doc-ru-config-values.yaml
   to: /deckhouse/modules/040-control-plane-manager/openapi/doc-ru-config-values.yaml
   stageDependencies:
@@ -855,6 +1005,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/040-node-manager/capi/dynamix
   to: /deckhouse/modules/040-node-manager/capi/dynamix
   excludePaths:
@@ -871,6 +1024,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/040-node-manager/capi/huaweicloud
   to: /deckhouse/modules/040-node-manager/capi/huaweicloud
   excludePaths:
@@ -887,6 +1043,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/040-node-manager/capi/vcd
   to: /deckhouse/modules/040-node-manager/capi/vcd
   excludePaths:
@@ -903,6 +1062,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/040-node-manager/templates/monitoring.yaml
   to: /deckhouse/modules/040-node-manager/templates/monitoring.yaml
   stageDependencies:
@@ -929,6 +1091,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/110-istio/templates/alliance
   to: /deckhouse/modules/110-istio/templates/alliance
   excludePaths:
@@ -945,6 +1110,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/110-istio/templates/control-plane-ee
   to: /deckhouse/modules/110-istio/templates/control-plane-ee
   excludePaths:
@@ -961,6 +1129,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/110-istio/templates/federation
   to: /deckhouse/modules/110-istio/templates/federation
   excludePaths:
@@ -977,6 +1148,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/110-istio/templates/multicluster
   to: /deckhouse/modules/110-istio/templates/multicluster
   excludePaths:
@@ -993,6 +1167,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/110-istio/templates/validations.yaml
   to: /deckhouse/modules/110-istio/templates/validations.yaml
   stageDependencies:
@@ -1014,6 +1191,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/110-istio/templates/ztunnel
   to: /deckhouse/modules/110-istio/templates/ztunnel
   excludePaths:
@@ -1030,6 +1210,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/110-istio/crds/doc-ru-istiofederation.yaml
   to: /deckhouse/modules/110-istio/crds/doc-ru-istiofederation.yaml
   stageDependencies:
@@ -1106,6 +1289,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/380-metallb/templates/speaker
   to: /deckhouse/modules/380-metallb/templates/speaker
   excludePaths:
@@ -1122,6 +1308,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/380-metallb/monitoring/grafana-dashboards/kubernetes-cluster/metallb-bgp.json
   to: /deckhouse/modules/380-metallb/monitoring/grafana-dashboards/kubernetes-cluster/metallb-bgp.json
   stageDependencies:
@@ -1148,6 +1337,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/fe/modules/002-deckhouse/templates/flant-module-source.yaml
   to: /deckhouse/modules/002-deckhouse/templates/flant-module-source.yaml
   stageDependencies:
@@ -1184,6 +1376,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/cse/modules/040-node-manager/crds/mcm.yaml
   to: /deckhouse/modules/040-node-manager/crds/mcm.yaml
   stageDependencies:
@@ -1210,6 +1405,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/cse/modules/040-node-manager/templates/machine-controller-manager
   to: /deckhouse/modules/040-node-manager/templates/machine-controller-manager
   excludePaths:
@@ -1226,6 +1424,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/cse/modules/040-node-manager/templates/nvidia-gpu
   to: /deckhouse/modules/040-node-manager/templates/nvidia-gpu
   excludePaths:
@@ -1242,6 +1443,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/cse/modules/101-cert-manager/openapi/config-values.yaml
   to: /deckhouse/modules/101-cert-manager/openapi/config-values.yaml
   stageDependencies:
@@ -1268,6 +1472,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/cse/modules/150-user-authn/crds/dex-provider.yaml
   to: /deckhouse/modules/150-user-authn/crds/dex-provider.yaml
   stageDependencies:
@@ -1299,3 +1506,6 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'

--- a/tools/build_includes/modules-with-exclude-EE.yaml
+++ b/tools/build_includes/modules-with-exclude-EE.yaml
@@ -15,6 +15,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/002-deckhouse
   to: /deckhouse/modules/002-deckhouse
   excludePaths:
@@ -31,6 +34,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/007-registrypackages
   to: /deckhouse/modules/007-registrypackages
   excludePaths:
@@ -47,6 +53,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/015-admission-policy-engine
   to: /deckhouse/modules/015-admission-policy-engine
   excludePaths:
@@ -63,6 +72,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/021-cni-cilium
   to: /deckhouse/modules/021-cni-cilium
   excludePaths:
@@ -79,6 +91,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/030-cloud-provider-aws
   to: /deckhouse/modules/030-cloud-provider-aws
   excludePaths:
@@ -95,6 +110,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/030-cloud-provider-azure
   to: /deckhouse/modules/030-cloud-provider-azure
   excludePaths:
@@ -111,6 +129,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/030-cloud-provider-dvp
   to: /deckhouse/modules/030-cloud-provider-dvp
   excludePaths:
@@ -127,6 +148,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/030-cloud-provider-gcp
   to: /deckhouse/modules/030-cloud-provider-gcp
   excludePaths:
@@ -143,6 +167,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/030-cloud-provider-yandex
   to: /deckhouse/modules/030-cloud-provider-yandex
   excludePaths:
@@ -159,6 +186,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/031-local-path-provisioner
   to: /deckhouse/modules/031-local-path-provisioner
   excludePaths:
@@ -175,6 +205,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/035-cni-flannel
   to: /deckhouse/modules/035-cni-flannel
   excludePaths:
@@ -191,6 +224,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/035-cni-simple-bridge
   to: /deckhouse/modules/035-cni-simple-bridge
   excludePaths:
@@ -207,6 +243,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/036-kube-proxy
   to: /deckhouse/modules/036-kube-proxy
   excludePaths:
@@ -223,6 +262,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/038-registry
   to: /deckhouse/modules/038-registry
   excludePaths:
@@ -239,6 +281,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/039-registry-packages-proxy
   to: /deckhouse/modules/039-registry-packages-proxy
   excludePaths:
@@ -255,6 +300,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/040-control-plane-manager
   to: /deckhouse/modules/040-control-plane-manager
   excludePaths:
@@ -271,6 +319,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/040-node-manager
   to: /deckhouse/modules/040-node-manager
   excludePaths:
@@ -287,6 +338,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/040-terraform-manager
   to: /deckhouse/modules/040-terraform-manager
   excludePaths:
@@ -303,6 +357,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/042-kube-dns
   to: /deckhouse/modules/042-kube-dns
   excludePaths:
@@ -319,6 +376,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/050-network-policy-engine
   to: /deckhouse/modules/050-network-policy-engine
   excludePaths:
@@ -335,6 +395,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/101-cert-manager
   to: /deckhouse/modules/101-cert-manager
   excludePaths:
@@ -351,6 +414,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/110-istio
   to: /deckhouse/modules/110-istio
   excludePaths:
@@ -367,6 +433,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/140-user-authz
   to: /deckhouse/modules/140-user-authz
   excludePaths:
@@ -383,6 +452,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/150-user-authn
   to: /deckhouse/modules/150-user-authn
   excludePaths:
@@ -399,6 +471,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/160-multitenancy-manager
   to: /deckhouse/modules/160-multitenancy-manager
   excludePaths:
@@ -415,6 +490,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/200-operator-prometheus
   to: /deckhouse/modules/200-operator-prometheus
   excludePaths:
@@ -431,6 +509,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/300-prometheus
   to: /deckhouse/modules/300-prometheus
   excludePaths:
@@ -447,6 +528,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/301-prometheus-metrics-adapter
   to: /deckhouse/modules/301-prometheus-metrics-adapter
   excludePaths:
@@ -463,6 +547,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/302-vertical-pod-autoscaler
   to: /deckhouse/modules/302-vertical-pod-autoscaler
   excludePaths:
@@ -479,6 +566,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/303-prometheus-pushgateway
   to: /deckhouse/modules/303-prometheus-pushgateway
   excludePaths:
@@ -495,6 +585,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/340-extended-monitoring
   to: /deckhouse/modules/340-extended-monitoring
   excludePaths:
@@ -511,6 +604,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/340-monitoring-custom
   to: /deckhouse/modules/340-monitoring-custom
   excludePaths:
@@ -527,6 +623,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/340-monitoring-kubernetes
   to: /deckhouse/modules/340-monitoring-kubernetes
   excludePaths:
@@ -543,6 +642,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/340-monitoring-kubernetes-control-plane
   to: /deckhouse/modules/340-monitoring-kubernetes-control-plane
   excludePaths:
@@ -559,6 +661,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/340-monitoring-ping
   to: /deckhouse/modules/340-monitoring-ping
   excludePaths:
@@ -575,6 +680,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/400-descheduler
   to: /deckhouse/modules/400-descheduler
   excludePaths:
@@ -591,6 +699,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/402-ingress-nginx
   to: /deckhouse/modules/402-ingress-nginx
   excludePaths:
@@ -607,6 +718,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/460-log-shipper
   to: /deckhouse/modules/460-log-shipper
   excludePaths:
@@ -623,6 +737,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/462-loki
   to: /deckhouse/modules/462-loki
   excludePaths:
@@ -639,6 +756,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/470-chrony
   to: /deckhouse/modules/470-chrony
   excludePaths:
@@ -655,6 +775,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/500-cilium-hubble
   to: /deckhouse/modules/500-cilium-hubble
   excludePaths:
@@ -671,6 +794,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/500-okmeter
   to: /deckhouse/modules/500-okmeter
   excludePaths:
@@ -687,6 +813,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/500-openvpn
   to: /deckhouse/modules/500-openvpn
   excludePaths:
@@ -703,6 +832,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/500-upmeter
   to: /deckhouse/modules/500-upmeter
   excludePaths:
@@ -719,6 +851,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/600-namespace-configurator
   to: /deckhouse/modules/600-namespace-configurator
   excludePaths:
@@ -735,6 +870,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/600-secret-copier
   to: /deckhouse/modules/600-secret-copier
   excludePaths:
@@ -751,6 +889,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/800-deckhouse-tools
   to: /deckhouse/modules/800-deckhouse-tools
   excludePaths:
@@ -767,6 +908,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/810-documentation
   to: /deckhouse/modules/810-documentation
   excludePaths:
@@ -783,6 +927,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/be/modules/040-node-manager/openapi/openapi-case-tests.yaml
   to: /deckhouse/modules/040-node-manager/openapi/openapi-case-tests.yaml
   stageDependencies:
@@ -809,6 +956,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/be/modules/140-user-authz/templates/permission-browser-apiserver
   to: /deckhouse/modules/140-user-authz/templates/permission-browser-apiserver
   excludePaths:
@@ -825,6 +975,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/be/modules/350-node-local-dns
   to: /deckhouse/modules/350-node-local-dns
   excludePaths:
@@ -841,6 +994,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/se/modules/380-metallb
   to: /deckhouse/modules/380-metallb
   excludePaths:
@@ -857,6 +1013,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/se-plus/modules/015-admission-policy-engine/templates/ratify
   to: /deckhouse/modules/015-admission-policy-engine/templates/ratify
   excludePaths:
@@ -873,6 +1032,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/se-plus/modules/015-admission-policy-engine/crds/ratify
   to: /deckhouse/modules/015-admission-policy-engine/crds/ratify
   excludePaths:
@@ -889,6 +1051,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/se-plus/modules/021-cni-cilium/crds/doc-ru-egressgatewaypolicies.yaml
   to: /deckhouse/modules/021-cni-cilium/crds/doc-ru-egressgatewaypolicies.yaml
   stageDependencies:
@@ -925,6 +1090,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/se-plus/modules/021-cni-cilium/templates/egress-gateway-agent
   to: /deckhouse/modules/021-cni-cilium/templates/egress-gateway-agent
   excludePaths:
@@ -941,6 +1109,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/se-plus/modules/021-cni-cilium/templates/egress-gateway-instance
   to: /deckhouse/modules/021-cni-cilium/templates/egress-gateway-instance
   excludePaths:
@@ -957,6 +1128,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/se-plus/modules/021-cni-cilium/templates/egress-policy
   to: /deckhouse/modules/021-cni-cilium/templates/egress-policy
   excludePaths:
@@ -973,6 +1147,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/se-plus/modules/021-cni-cilium/monitoring/prometheus-rules/egressgatewaypolicies.yaml
   to: /deckhouse/modules/021-cni-cilium/monitoring/prometheus-rules/egressgatewaypolicies.yaml
   stageDependencies:
@@ -994,6 +1171,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/se-plus/modules/030-cloud-provider-zvirt
   to: /deckhouse/modules/030-cloud-provider-zvirt
   excludePaths:
@@ -1010,6 +1190,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/se-plus/modules/030-csi-vsphere
   to: /deckhouse/modules/030-csi-vsphere
   excludePaths:
@@ -1026,6 +1209,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/se-plus/modules/040-node-manager/cloud-providers/vsphere
   to: /deckhouse/modules/040-node-manager/cloud-providers/vsphere
   excludePaths:
@@ -1042,6 +1228,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/se-plus/modules/040-node-manager/capi/zvirt
   to: /deckhouse/modules/040-node-manager/capi/zvirt
   excludePaths:
@@ -1058,6 +1247,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/030-cloud-provider-dynamix
   to: /deckhouse/modules/030-cloud-provider-dynamix
   excludePaths:
@@ -1074,6 +1266,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/030-cloud-provider-huaweicloud
   to: /deckhouse/modules/030-cloud-provider-huaweicloud
   excludePaths:
@@ -1090,6 +1285,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/030-cloud-provider-openstack
   to: /deckhouse/modules/030-cloud-provider-openstack
   excludePaths:
@@ -1106,6 +1304,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/030-cloud-provider-vcd
   to: /deckhouse/modules/030-cloud-provider-vcd
   excludePaths:
@@ -1122,6 +1323,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/040-control-plane-manager/openapi/config-values.yaml
   to: /deckhouse/modules/040-control-plane-manager/openapi/config-values.yaml
   stageDependencies:
@@ -1148,6 +1352,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/040-node-manager/capi/dynamix
   to: /deckhouse/modules/040-node-manager/capi/dynamix
   excludePaths:
@@ -1164,6 +1371,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/040-node-manager/capi/huaweicloud
   to: /deckhouse/modules/040-node-manager/capi/huaweicloud
   excludePaths:
@@ -1180,6 +1390,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/040-node-manager/capi/vcd
   to: /deckhouse/modules/040-node-manager/capi/vcd
   excludePaths:
@@ -1196,6 +1409,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/040-node-manager/templates/monitoring.yaml
   to: /deckhouse/modules/040-node-manager/templates/monitoring.yaml
   stageDependencies:
@@ -1217,6 +1433,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/040-node-manager/templates/podmonitor.yaml
   to: /deckhouse/modules/040-node-manager/templates/podmonitor.yaml
   stageDependencies:
@@ -1238,6 +1457,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/110-istio/templates/alliance
   to: /deckhouse/modules/110-istio/templates/alliance
   excludePaths:
@@ -1254,6 +1476,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/110-istio/templates/control-plane-ee
   to: /deckhouse/modules/110-istio/templates/control-plane-ee
   excludePaths:
@@ -1270,6 +1495,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/110-istio/templates/federation
   to: /deckhouse/modules/110-istio/templates/federation
   excludePaths:
@@ -1286,6 +1514,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/110-istio/templates/multicluster
   to: /deckhouse/modules/110-istio/templates/multicluster
   excludePaths:
@@ -1302,6 +1533,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/110-istio/templates/validations.yaml
   to: /deckhouse/modules/110-istio/templates/validations.yaml
   stageDependencies:
@@ -1323,6 +1557,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/110-istio/templates/ztunnel
   to: /deckhouse/modules/110-istio/templates/ztunnel
   excludePaths:
@@ -1339,6 +1576,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/110-istio/crds/doc-ru-istiofederation.yaml
   to: /deckhouse/modules/110-istio/crds/doc-ru-istiofederation.yaml
   stageDependencies:
@@ -1415,6 +1655,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/380-metallb/templates/speaker
   to: /deckhouse/modules/380-metallb/templates/speaker
   excludePaths:
@@ -1431,6 +1674,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/380-metallb/monitoring/grafana-dashboards/kubernetes-cluster/metallb-bgp.json
   to: /deckhouse/modules/380-metallb/monitoring/grafana-dashboards/kubernetes-cluster/metallb-bgp.json
   stageDependencies:
@@ -1457,6 +1703,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/450-network-gateway
   to: /deckhouse/modules/450-network-gateway
   excludePaths:
@@ -1473,6 +1722,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/610-service-with-healthchecks
   to: /deckhouse/modules/610-service-with-healthchecks
   excludePaths:
@@ -1489,3 +1741,6 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'

--- a/tools/build_includes/modules-with-exclude-FE.yaml
+++ b/tools/build_includes/modules-with-exclude-FE.yaml
@@ -15,6 +15,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/002-deckhouse
   to: /deckhouse/modules/002-deckhouse
   excludePaths:
@@ -31,6 +34,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/007-registrypackages
   to: /deckhouse/modules/007-registrypackages
   excludePaths:
@@ -47,6 +53,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/015-admission-policy-engine
   to: /deckhouse/modules/015-admission-policy-engine
   excludePaths:
@@ -63,6 +72,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/021-cni-cilium
   to: /deckhouse/modules/021-cni-cilium
   excludePaths:
@@ -79,6 +91,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/030-cloud-provider-aws
   to: /deckhouse/modules/030-cloud-provider-aws
   excludePaths:
@@ -95,6 +110,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/030-cloud-provider-azure
   to: /deckhouse/modules/030-cloud-provider-azure
   excludePaths:
@@ -111,6 +129,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/030-cloud-provider-dvp
   to: /deckhouse/modules/030-cloud-provider-dvp
   excludePaths:
@@ -127,6 +148,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/030-cloud-provider-gcp
   to: /deckhouse/modules/030-cloud-provider-gcp
   excludePaths:
@@ -143,6 +167,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/030-cloud-provider-yandex
   to: /deckhouse/modules/030-cloud-provider-yandex
   excludePaths:
@@ -159,6 +186,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/031-local-path-provisioner
   to: /deckhouse/modules/031-local-path-provisioner
   excludePaths:
@@ -175,6 +205,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/035-cni-flannel
   to: /deckhouse/modules/035-cni-flannel
   excludePaths:
@@ -191,6 +224,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/035-cni-simple-bridge
   to: /deckhouse/modules/035-cni-simple-bridge
   excludePaths:
@@ -207,6 +243,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/036-kube-proxy
   to: /deckhouse/modules/036-kube-proxy
   excludePaths:
@@ -223,6 +262,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/038-registry
   to: /deckhouse/modules/038-registry
   excludePaths:
@@ -239,6 +281,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/039-registry-packages-proxy
   to: /deckhouse/modules/039-registry-packages-proxy
   excludePaths:
@@ -255,6 +300,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/040-control-plane-manager
   to: /deckhouse/modules/040-control-plane-manager
   excludePaths:
@@ -271,6 +319,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/040-node-manager
   to: /deckhouse/modules/040-node-manager
   excludePaths:
@@ -287,6 +338,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/040-terraform-manager
   to: /deckhouse/modules/040-terraform-manager
   excludePaths:
@@ -303,6 +357,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/042-kube-dns
   to: /deckhouse/modules/042-kube-dns
   excludePaths:
@@ -319,6 +376,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/050-network-policy-engine
   to: /deckhouse/modules/050-network-policy-engine
   excludePaths:
@@ -335,6 +395,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/101-cert-manager
   to: /deckhouse/modules/101-cert-manager
   excludePaths:
@@ -351,6 +414,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/110-istio
   to: /deckhouse/modules/110-istio
   excludePaths:
@@ -367,6 +433,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/140-user-authz
   to: /deckhouse/modules/140-user-authz
   excludePaths:
@@ -383,6 +452,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/150-user-authn
   to: /deckhouse/modules/150-user-authn
   excludePaths:
@@ -399,6 +471,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/160-multitenancy-manager
   to: /deckhouse/modules/160-multitenancy-manager
   excludePaths:
@@ -415,6 +490,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/200-operator-prometheus
   to: /deckhouse/modules/200-operator-prometheus
   excludePaths:
@@ -431,6 +509,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/300-prometheus
   to: /deckhouse/modules/300-prometheus
   excludePaths:
@@ -447,6 +528,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/301-prometheus-metrics-adapter
   to: /deckhouse/modules/301-prometheus-metrics-adapter
   excludePaths:
@@ -463,6 +547,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/302-vertical-pod-autoscaler
   to: /deckhouse/modules/302-vertical-pod-autoscaler
   excludePaths:
@@ -479,6 +566,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/303-prometheus-pushgateway
   to: /deckhouse/modules/303-prometheus-pushgateway
   excludePaths:
@@ -495,6 +585,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/340-extended-monitoring
   to: /deckhouse/modules/340-extended-monitoring
   excludePaths:
@@ -511,6 +604,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/340-monitoring-custom
   to: /deckhouse/modules/340-monitoring-custom
   excludePaths:
@@ -527,6 +623,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/340-monitoring-kubernetes
   to: /deckhouse/modules/340-monitoring-kubernetes
   excludePaths:
@@ -543,6 +642,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/340-monitoring-kubernetes-control-plane
   to: /deckhouse/modules/340-monitoring-kubernetes-control-plane
   excludePaths:
@@ -559,6 +661,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/340-monitoring-ping
   to: /deckhouse/modules/340-monitoring-ping
   excludePaths:
@@ -575,6 +680,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/400-descheduler
   to: /deckhouse/modules/400-descheduler
   excludePaths:
@@ -591,6 +699,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/402-ingress-nginx
   to: /deckhouse/modules/402-ingress-nginx
   excludePaths:
@@ -607,6 +718,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/460-log-shipper
   to: /deckhouse/modules/460-log-shipper
   excludePaths:
@@ -623,6 +737,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/462-loki
   to: /deckhouse/modules/462-loki
   excludePaths:
@@ -639,6 +756,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/470-chrony
   to: /deckhouse/modules/470-chrony
   excludePaths:
@@ -655,6 +775,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/500-cilium-hubble
   to: /deckhouse/modules/500-cilium-hubble
   excludePaths:
@@ -671,6 +794,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/500-okmeter
   to: /deckhouse/modules/500-okmeter
   excludePaths:
@@ -687,6 +813,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/500-openvpn
   to: /deckhouse/modules/500-openvpn
   excludePaths:
@@ -703,6 +832,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/500-upmeter
   to: /deckhouse/modules/500-upmeter
   excludePaths:
@@ -719,6 +851,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/600-namespace-configurator
   to: /deckhouse/modules/600-namespace-configurator
   excludePaths:
@@ -735,6 +870,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/600-secret-copier
   to: /deckhouse/modules/600-secret-copier
   excludePaths:
@@ -751,6 +889,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/800-deckhouse-tools
   to: /deckhouse/modules/800-deckhouse-tools
   excludePaths:
@@ -767,6 +908,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/810-documentation
   to: /deckhouse/modules/810-documentation
   excludePaths:
@@ -783,6 +927,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/be/modules/040-node-manager/openapi/openapi-case-tests.yaml
   to: /deckhouse/modules/040-node-manager/openapi/openapi-case-tests.yaml
   stageDependencies:
@@ -809,6 +956,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/be/modules/140-user-authz/templates/permission-browser-apiserver
   to: /deckhouse/modules/140-user-authz/templates/permission-browser-apiserver
   excludePaths:
@@ -825,6 +975,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/be/modules/350-node-local-dns
   to: /deckhouse/modules/350-node-local-dns
   excludePaths:
@@ -841,6 +994,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/se/modules/380-metallb
   to: /deckhouse/modules/380-metallb
   excludePaths:
@@ -857,6 +1013,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/se-plus/modules/015-admission-policy-engine/templates/ratify
   to: /deckhouse/modules/015-admission-policy-engine/templates/ratify
   excludePaths:
@@ -873,6 +1032,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/se-plus/modules/015-admission-policy-engine/crds/ratify
   to: /deckhouse/modules/015-admission-policy-engine/crds/ratify
   excludePaths:
@@ -889,6 +1051,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/se-plus/modules/021-cni-cilium/crds/doc-ru-egressgatewaypolicies.yaml
   to: /deckhouse/modules/021-cni-cilium/crds/doc-ru-egressgatewaypolicies.yaml
   stageDependencies:
@@ -925,6 +1090,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/se-plus/modules/021-cni-cilium/templates/egress-gateway-agent
   to: /deckhouse/modules/021-cni-cilium/templates/egress-gateway-agent
   excludePaths:
@@ -941,6 +1109,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/se-plus/modules/021-cni-cilium/templates/egress-gateway-instance
   to: /deckhouse/modules/021-cni-cilium/templates/egress-gateway-instance
   excludePaths:
@@ -957,6 +1128,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/se-plus/modules/021-cni-cilium/templates/egress-policy
   to: /deckhouse/modules/021-cni-cilium/templates/egress-policy
   excludePaths:
@@ -973,6 +1147,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/se-plus/modules/021-cni-cilium/monitoring/prometheus-rules/egressgatewaypolicies.yaml
   to: /deckhouse/modules/021-cni-cilium/monitoring/prometheus-rules/egressgatewaypolicies.yaml
   stageDependencies:
@@ -994,6 +1171,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/se-plus/modules/030-cloud-provider-zvirt
   to: /deckhouse/modules/030-cloud-provider-zvirt
   excludePaths:
@@ -1010,6 +1190,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/se-plus/modules/030-csi-vsphere
   to: /deckhouse/modules/030-csi-vsphere
   excludePaths:
@@ -1026,6 +1209,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/se-plus/modules/040-node-manager/cloud-providers/vsphere
   to: /deckhouse/modules/040-node-manager/cloud-providers/vsphere
   excludePaths:
@@ -1042,6 +1228,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/se-plus/modules/040-node-manager/capi/zvirt
   to: /deckhouse/modules/040-node-manager/capi/zvirt
   excludePaths:
@@ -1058,6 +1247,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/030-cloud-provider-dynamix
   to: /deckhouse/modules/030-cloud-provider-dynamix
   excludePaths:
@@ -1074,6 +1266,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/030-cloud-provider-huaweicloud
   to: /deckhouse/modules/030-cloud-provider-huaweicloud
   excludePaths:
@@ -1090,6 +1285,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/030-cloud-provider-openstack
   to: /deckhouse/modules/030-cloud-provider-openstack
   excludePaths:
@@ -1106,6 +1304,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/030-cloud-provider-vcd
   to: /deckhouse/modules/030-cloud-provider-vcd
   excludePaths:
@@ -1122,6 +1323,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/040-control-plane-manager/openapi/config-values.yaml
   to: /deckhouse/modules/040-control-plane-manager/openapi/config-values.yaml
   stageDependencies:
@@ -1148,6 +1352,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/040-node-manager/capi/dynamix
   to: /deckhouse/modules/040-node-manager/capi/dynamix
   excludePaths:
@@ -1164,6 +1371,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/040-node-manager/capi/huaweicloud
   to: /deckhouse/modules/040-node-manager/capi/huaweicloud
   excludePaths:
@@ -1180,6 +1390,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/040-node-manager/capi/vcd
   to: /deckhouse/modules/040-node-manager/capi/vcd
   excludePaths:
@@ -1196,6 +1409,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/040-node-manager/templates/monitoring.yaml
   to: /deckhouse/modules/040-node-manager/templates/monitoring.yaml
   stageDependencies:
@@ -1217,6 +1433,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/040-node-manager/templates/podmonitor.yaml
   to: /deckhouse/modules/040-node-manager/templates/podmonitor.yaml
   stageDependencies:
@@ -1238,6 +1457,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/110-istio/templates/alliance
   to: /deckhouse/modules/110-istio/templates/alliance
   excludePaths:
@@ -1254,6 +1476,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/110-istio/templates/control-plane-ee
   to: /deckhouse/modules/110-istio/templates/control-plane-ee
   excludePaths:
@@ -1270,6 +1495,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/110-istio/templates/federation
   to: /deckhouse/modules/110-istio/templates/federation
   excludePaths:
@@ -1286,6 +1514,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/110-istio/templates/multicluster
   to: /deckhouse/modules/110-istio/templates/multicluster
   excludePaths:
@@ -1302,6 +1533,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/110-istio/templates/validations.yaml
   to: /deckhouse/modules/110-istio/templates/validations.yaml
   stageDependencies:
@@ -1323,6 +1557,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/110-istio/templates/ztunnel
   to: /deckhouse/modules/110-istio/templates/ztunnel
   excludePaths:
@@ -1339,6 +1576,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/110-istio/crds/doc-ru-istiofederation.yaml
   to: /deckhouse/modules/110-istio/crds/doc-ru-istiofederation.yaml
   stageDependencies:
@@ -1415,6 +1655,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/380-metallb/templates/speaker
   to: /deckhouse/modules/380-metallb/templates/speaker
   excludePaths:
@@ -1431,6 +1674,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/380-metallb/monitoring/grafana-dashboards/kubernetes-cluster/metallb-bgp.json
   to: /deckhouse/modules/380-metallb/monitoring/grafana-dashboards/kubernetes-cluster/metallb-bgp.json
   stageDependencies:
@@ -1457,6 +1703,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/450-network-gateway
   to: /deckhouse/modules/450-network-gateway
   excludePaths:
@@ -1473,6 +1722,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/modules/610-service-with-healthchecks
   to: /deckhouse/modules/610-service-with-healthchecks
   excludePaths:
@@ -1489,6 +1741,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/fe/modules/002-deckhouse/templates/flant-module-source.yaml
   to: /deckhouse/modules/002-deckhouse/templates/flant-module-source.yaml
   stageDependencies:
@@ -1515,6 +1770,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/fe/modules/500-basic-auth
   to: /deckhouse/modules/500-basic-auth
   excludePaths:
@@ -1531,6 +1789,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/fe/modules/500-okmeter/templates/daemonset.yaml
   to: /deckhouse/modules/500-okmeter/templates/daemonset.yaml
   stageDependencies:

--- a/tools/build_includes/modules-with-exclude-SE-plus.yaml
+++ b/tools/build_includes/modules-with-exclude-SE-plus.yaml
@@ -15,6 +15,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/002-deckhouse
   to: /deckhouse/modules/002-deckhouse
   excludePaths:
@@ -31,6 +34,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/007-registrypackages
   to: /deckhouse/modules/007-registrypackages
   excludePaths:
@@ -47,6 +53,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/015-admission-policy-engine
   to: /deckhouse/modules/015-admission-policy-engine
   excludePaths:
@@ -63,6 +72,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/021-cni-cilium
   to: /deckhouse/modules/021-cni-cilium
   excludePaths:
@@ -79,6 +91,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/030-cloud-provider-aws
   to: /deckhouse/modules/030-cloud-provider-aws
   excludePaths:
@@ -95,6 +110,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/030-cloud-provider-azure
   to: /deckhouse/modules/030-cloud-provider-azure
   excludePaths:
@@ -111,6 +129,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/030-cloud-provider-dvp
   to: /deckhouse/modules/030-cloud-provider-dvp
   excludePaths:
@@ -127,6 +148,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/030-cloud-provider-gcp
   to: /deckhouse/modules/030-cloud-provider-gcp
   excludePaths:
@@ -143,6 +167,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/030-cloud-provider-yandex
   to: /deckhouse/modules/030-cloud-provider-yandex
   excludePaths:
@@ -159,6 +186,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/031-local-path-provisioner
   to: /deckhouse/modules/031-local-path-provisioner
   excludePaths:
@@ -175,6 +205,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/035-cni-flannel
   to: /deckhouse/modules/035-cni-flannel
   excludePaths:
@@ -191,6 +224,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/035-cni-simple-bridge
   to: /deckhouse/modules/035-cni-simple-bridge
   excludePaths:
@@ -207,6 +243,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/036-kube-proxy
   to: /deckhouse/modules/036-kube-proxy
   excludePaths:
@@ -223,6 +262,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/038-registry
   to: /deckhouse/modules/038-registry
   excludePaths:
@@ -239,6 +281,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/039-registry-packages-proxy
   to: /deckhouse/modules/039-registry-packages-proxy
   excludePaths:
@@ -255,6 +300,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/040-control-plane-manager
   to: /deckhouse/modules/040-control-plane-manager
   excludePaths:
@@ -271,6 +319,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/040-node-manager
   to: /deckhouse/modules/040-node-manager
   excludePaths:
@@ -287,6 +338,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/040-terraform-manager
   to: /deckhouse/modules/040-terraform-manager
   excludePaths:
@@ -303,6 +357,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/042-kube-dns
   to: /deckhouse/modules/042-kube-dns
   excludePaths:
@@ -319,6 +376,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/050-network-policy-engine
   to: /deckhouse/modules/050-network-policy-engine
   excludePaths:
@@ -335,6 +395,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/101-cert-manager
   to: /deckhouse/modules/101-cert-manager
   excludePaths:
@@ -351,6 +414,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/110-istio
   to: /deckhouse/modules/110-istio
   excludePaths:
@@ -367,6 +433,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/140-user-authz
   to: /deckhouse/modules/140-user-authz
   excludePaths:
@@ -383,6 +452,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/150-user-authn
   to: /deckhouse/modules/150-user-authn
   excludePaths:
@@ -399,6 +471,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/160-multitenancy-manager
   to: /deckhouse/modules/160-multitenancy-manager
   excludePaths:
@@ -415,6 +490,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/200-operator-prometheus
   to: /deckhouse/modules/200-operator-prometheus
   excludePaths:
@@ -431,6 +509,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/300-prometheus
   to: /deckhouse/modules/300-prometheus
   excludePaths:
@@ -447,6 +528,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/301-prometheus-metrics-adapter
   to: /deckhouse/modules/301-prometheus-metrics-adapter
   excludePaths:
@@ -463,6 +547,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/302-vertical-pod-autoscaler
   to: /deckhouse/modules/302-vertical-pod-autoscaler
   excludePaths:
@@ -479,6 +566,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/303-prometheus-pushgateway
   to: /deckhouse/modules/303-prometheus-pushgateway
   excludePaths:
@@ -495,6 +585,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/340-extended-monitoring
   to: /deckhouse/modules/340-extended-monitoring
   excludePaths:
@@ -511,6 +604,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/340-monitoring-custom
   to: /deckhouse/modules/340-monitoring-custom
   excludePaths:
@@ -527,6 +623,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/340-monitoring-kubernetes
   to: /deckhouse/modules/340-monitoring-kubernetes
   excludePaths:
@@ -543,6 +642,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/340-monitoring-kubernetes-control-plane
   to: /deckhouse/modules/340-monitoring-kubernetes-control-plane
   excludePaths:
@@ -559,6 +661,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/340-monitoring-ping
   to: /deckhouse/modules/340-monitoring-ping
   excludePaths:
@@ -575,6 +680,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/400-descheduler
   to: /deckhouse/modules/400-descheduler
   excludePaths:
@@ -591,6 +699,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/402-ingress-nginx
   to: /deckhouse/modules/402-ingress-nginx
   excludePaths:
@@ -607,6 +718,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/460-log-shipper
   to: /deckhouse/modules/460-log-shipper
   excludePaths:
@@ -623,6 +737,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/462-loki
   to: /deckhouse/modules/462-loki
   excludePaths:
@@ -639,6 +756,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/470-chrony
   to: /deckhouse/modules/470-chrony
   excludePaths:
@@ -655,6 +775,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/500-cilium-hubble
   to: /deckhouse/modules/500-cilium-hubble
   excludePaths:
@@ -671,6 +794,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/500-okmeter
   to: /deckhouse/modules/500-okmeter
   excludePaths:
@@ -687,6 +813,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/500-openvpn
   to: /deckhouse/modules/500-openvpn
   excludePaths:
@@ -703,6 +832,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/500-upmeter
   to: /deckhouse/modules/500-upmeter
   excludePaths:
@@ -719,6 +851,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/600-namespace-configurator
   to: /deckhouse/modules/600-namespace-configurator
   excludePaths:
@@ -735,6 +870,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/600-secret-copier
   to: /deckhouse/modules/600-secret-copier
   excludePaths:
@@ -751,6 +889,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/800-deckhouse-tools
   to: /deckhouse/modules/800-deckhouse-tools
   excludePaths:
@@ -767,6 +908,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/810-documentation
   to: /deckhouse/modules/810-documentation
   excludePaths:
@@ -783,6 +927,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/be/modules/040-node-manager/openapi/openapi-case-tests.yaml
   to: /deckhouse/modules/040-node-manager/openapi/openapi-case-tests.yaml
   stageDependencies:
@@ -809,6 +956,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/be/modules/140-user-authz/templates/permission-browser-apiserver
   to: /deckhouse/modules/140-user-authz/templates/permission-browser-apiserver
   excludePaths:
@@ -825,6 +975,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/be/modules/350-node-local-dns
   to: /deckhouse/modules/350-node-local-dns
   excludePaths:
@@ -841,6 +994,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/se/modules/380-metallb
   to: /deckhouse/modules/380-metallb
   excludePaths:
@@ -857,6 +1013,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/se-plus/modules/015-admission-policy-engine/templates/ratify
   to: /deckhouse/modules/015-admission-policy-engine/templates/ratify
   excludePaths:
@@ -873,6 +1032,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/se-plus/modules/015-admission-policy-engine/crds/ratify
   to: /deckhouse/modules/015-admission-policy-engine/crds/ratify
   excludePaths:
@@ -889,6 +1051,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/se-plus/modules/021-cni-cilium/crds/doc-ru-egressgatewaypolicies.yaml
   to: /deckhouse/modules/021-cni-cilium/crds/doc-ru-egressgatewaypolicies.yaml
   stageDependencies:
@@ -925,6 +1090,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/se-plus/modules/021-cni-cilium/templates/egress-gateway-agent
   to: /deckhouse/modules/021-cni-cilium/templates/egress-gateway-agent
   excludePaths:
@@ -941,6 +1109,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/se-plus/modules/021-cni-cilium/templates/egress-gateway-instance
   to: /deckhouse/modules/021-cni-cilium/templates/egress-gateway-instance
   excludePaths:
@@ -957,6 +1128,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/se-plus/modules/021-cni-cilium/templates/egress-policy
   to: /deckhouse/modules/021-cni-cilium/templates/egress-policy
   excludePaths:
@@ -973,6 +1147,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/se-plus/modules/021-cni-cilium/monitoring/prometheus-rules/egressgatewaypolicies.yaml
   to: /deckhouse/modules/021-cni-cilium/monitoring/prometheus-rules/egressgatewaypolicies.yaml
   stageDependencies:
@@ -994,6 +1171,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/se-plus/modules/030-cloud-provider-zvirt
   to: /deckhouse/modules/030-cloud-provider-zvirt
   excludePaths:
@@ -1010,6 +1190,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/se-plus/modules/030-csi-vsphere
   to: /deckhouse/modules/030-csi-vsphere
   excludePaths:
@@ -1026,6 +1209,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/se-plus/modules/040-node-manager/cloud-providers/vsphere
   to: /deckhouse/modules/040-node-manager/cloud-providers/vsphere
   excludePaths:
@@ -1042,6 +1228,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/se-plus/modules/040-node-manager/capi/zvirt
   to: /deckhouse/modules/040-node-manager/capi/zvirt
   excludePaths:
@@ -1058,3 +1247,6 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'

--- a/tools/build_includes/modules-with-exclude-SE.yaml
+++ b/tools/build_includes/modules-with-exclude-SE.yaml
@@ -15,6 +15,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/002-deckhouse
   to: /deckhouse/modules/002-deckhouse
   excludePaths:
@@ -31,6 +34,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/007-registrypackages
   to: /deckhouse/modules/007-registrypackages
   excludePaths:
@@ -47,6 +53,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/015-admission-policy-engine
   to: /deckhouse/modules/015-admission-policy-engine
   excludePaths:
@@ -63,6 +72,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/021-cni-cilium
   to: /deckhouse/modules/021-cni-cilium
   excludePaths:
@@ -79,6 +91,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/030-cloud-provider-aws
   to: /deckhouse/modules/030-cloud-provider-aws
   excludePaths:
@@ -95,6 +110,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/030-cloud-provider-azure
   to: /deckhouse/modules/030-cloud-provider-azure
   excludePaths:
@@ -111,6 +129,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/030-cloud-provider-dvp
   to: /deckhouse/modules/030-cloud-provider-dvp
   excludePaths:
@@ -127,6 +148,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/030-cloud-provider-gcp
   to: /deckhouse/modules/030-cloud-provider-gcp
   excludePaths:
@@ -143,6 +167,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/030-cloud-provider-yandex
   to: /deckhouse/modules/030-cloud-provider-yandex
   excludePaths:
@@ -159,6 +186,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/031-local-path-provisioner
   to: /deckhouse/modules/031-local-path-provisioner
   excludePaths:
@@ -175,6 +205,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/035-cni-flannel
   to: /deckhouse/modules/035-cni-flannel
   excludePaths:
@@ -191,6 +224,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/035-cni-simple-bridge
   to: /deckhouse/modules/035-cni-simple-bridge
   excludePaths:
@@ -207,6 +243,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/036-kube-proxy
   to: /deckhouse/modules/036-kube-proxy
   excludePaths:
@@ -223,6 +262,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/038-registry
   to: /deckhouse/modules/038-registry
   excludePaths:
@@ -239,6 +281,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/039-registry-packages-proxy
   to: /deckhouse/modules/039-registry-packages-proxy
   excludePaths:
@@ -255,6 +300,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/040-control-plane-manager
   to: /deckhouse/modules/040-control-plane-manager
   excludePaths:
@@ -271,6 +319,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/040-node-manager
   to: /deckhouse/modules/040-node-manager
   excludePaths:
@@ -287,6 +338,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/040-terraform-manager
   to: /deckhouse/modules/040-terraform-manager
   excludePaths:
@@ -303,6 +357,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/042-kube-dns
   to: /deckhouse/modules/042-kube-dns
   excludePaths:
@@ -319,6 +376,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/050-network-policy-engine
   to: /deckhouse/modules/050-network-policy-engine
   excludePaths:
@@ -335,6 +395,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/101-cert-manager
   to: /deckhouse/modules/101-cert-manager
   excludePaths:
@@ -351,6 +414,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/110-istio
   to: /deckhouse/modules/110-istio
   excludePaths:
@@ -367,6 +433,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/140-user-authz
   to: /deckhouse/modules/140-user-authz
   excludePaths:
@@ -383,6 +452,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/150-user-authn
   to: /deckhouse/modules/150-user-authn
   excludePaths:
@@ -399,6 +471,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/160-multitenancy-manager
   to: /deckhouse/modules/160-multitenancy-manager
   excludePaths:
@@ -415,6 +490,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/200-operator-prometheus
   to: /deckhouse/modules/200-operator-prometheus
   excludePaths:
@@ -431,6 +509,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/300-prometheus
   to: /deckhouse/modules/300-prometheus
   excludePaths:
@@ -447,6 +528,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/301-prometheus-metrics-adapter
   to: /deckhouse/modules/301-prometheus-metrics-adapter
   excludePaths:
@@ -463,6 +547,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/302-vertical-pod-autoscaler
   to: /deckhouse/modules/302-vertical-pod-autoscaler
   excludePaths:
@@ -479,6 +566,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/303-prometheus-pushgateway
   to: /deckhouse/modules/303-prometheus-pushgateway
   excludePaths:
@@ -495,6 +585,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/340-extended-monitoring
   to: /deckhouse/modules/340-extended-monitoring
   excludePaths:
@@ -511,6 +604,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/340-monitoring-custom
   to: /deckhouse/modules/340-monitoring-custom
   excludePaths:
@@ -527,6 +623,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/340-monitoring-kubernetes
   to: /deckhouse/modules/340-monitoring-kubernetes
   excludePaths:
@@ -543,6 +642,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/340-monitoring-kubernetes-control-plane
   to: /deckhouse/modules/340-monitoring-kubernetes-control-plane
   excludePaths:
@@ -559,6 +661,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/340-monitoring-ping
   to: /deckhouse/modules/340-monitoring-ping
   excludePaths:
@@ -575,6 +680,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/400-descheduler
   to: /deckhouse/modules/400-descheduler
   excludePaths:
@@ -591,6 +699,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/402-ingress-nginx
   to: /deckhouse/modules/402-ingress-nginx
   excludePaths:
@@ -607,6 +718,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/460-log-shipper
   to: /deckhouse/modules/460-log-shipper
   excludePaths:
@@ -623,6 +737,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/462-loki
   to: /deckhouse/modules/462-loki
   excludePaths:
@@ -639,6 +756,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/470-chrony
   to: /deckhouse/modules/470-chrony
   excludePaths:
@@ -655,6 +775,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/500-cilium-hubble
   to: /deckhouse/modules/500-cilium-hubble
   excludePaths:
@@ -671,6 +794,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/500-okmeter
   to: /deckhouse/modules/500-okmeter
   excludePaths:
@@ -687,6 +813,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/500-openvpn
   to: /deckhouse/modules/500-openvpn
   excludePaths:
@@ -703,6 +832,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/500-upmeter
   to: /deckhouse/modules/500-upmeter
   excludePaths:
@@ -719,6 +851,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/600-namespace-configurator
   to: /deckhouse/modules/600-namespace-configurator
   excludePaths:
@@ -735,6 +870,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/600-secret-copier
   to: /deckhouse/modules/600-secret-copier
   excludePaths:
@@ -751,6 +889,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/800-deckhouse-tools
   to: /deckhouse/modules/800-deckhouse-tools
   excludePaths:
@@ -767,6 +908,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /modules/810-documentation
   to: /deckhouse/modules/810-documentation
   excludePaths:
@@ -783,6 +927,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/be/modules/040-node-manager/openapi/openapi-case-tests.yaml
   to: /deckhouse/modules/040-node-manager/openapi/openapi-case-tests.yaml
   stageDependencies:
@@ -809,6 +956,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/be/modules/140-user-authz/templates/permission-browser-apiserver
   to: /deckhouse/modules/140-user-authz/templates/permission-browser-apiserver
   excludePaths:
@@ -825,6 +975,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/be/modules/350-node-local-dns
   to: /deckhouse/modules/350-node-local-dns
   excludePaths:
@@ -841,6 +994,9 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'
 - add: /ee/se/modules/380-metallb
   to: /deckhouse/modules/380-metallb
   excludePaths:
@@ -857,3 +1013,6 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+  stageDependencies:
+    setup:
+        - '**/*'

--- a/tools/lint-changed.sh
+++ b/tools/lint-changed.sh
@@ -43,6 +43,7 @@ mapfile -t MODULE_DIRS < <(
   find . -name go.mod -type f \
     -not -path '*/.git/*' \
     -not -path '*/node_modules/*' \
+    -not -path './tools/*' \
     -exec dirname {} \; \
     | sed -e 's|^\./||' \
     | awk '{ print length, $0 }' \


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Currently, module caches in the dev-prebuild image are not always invalidated when a module is changed.
The following configuration was rendered:
```yaml
- add: /modules/040-node-manager
  to: /deckhouse/modules/040-node-manager
  excludePaths:
    - docs
    - README.md
    - images
    - hooks/**/*.go
    - hooks/*.go
    - hooks/**/testdata
    - apis
    - requirements
    - hack
    - template_tests
    - .namespace
    - values_matrix_test.yaml
    - .build.yaml
- add: /modules/040-terraform-manager
```
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
We need to force werf to invalidate dev-prebuild image when changing the code in the modules.
```yaml
- add: /modules/040-node-manager
  to: /deckhouse/modules/040-node-manager
  excludePaths:
    - docs
    - README.md
    - images
    - hooks/**/*.go
    - hooks/*.go
    - hooks/**/testdata
    - apis
    - requirements
    - hack
    - template_tests
    - .namespace
    - values_matrix_test.yaml
    - .build.yaml
  stageDependencies:
    setup:
        - '**/*'
- add: /modules/040-terraform-manager
```
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
not related to release
## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: fix
summary: Module cache invalidation.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
