### PR TITLE
[cni-cilium] Add enable-host-firewall option to --allow-config-keys

### DIFF
--- a/modules/021-cni-cilium/templates/_agent-daemonset.tpl
+++ b/modules/021-cni-cilium/templates/_agent-daemonset.tpl
@@ -360,7 +360,7 @@ spec:
         command:
         - cilium-dbg
         - build-config
-        - --allow-config-keys=debug,single-cluster-route,mtu,bpf-map-dynamic-size-ratio,monitor-aggregation,monitor-aggregation-flags,monitor-aggregation-interval,bpf-events-trace-enabled
+        - --allow-config-keys=debug,single-cluster-route,mtu,bpf-map-dynamic-size-ratio,monitor-aggregation,monitor-aggregation-flags,monitor-aggregation-interval,bpf-events-trace-enabled,enable-host-firewall
         env:
         - name: K8S_NODE_NAME
           valueFrom:


### PR DESCRIPTION
## Description
This PR allows cluster-operator switching `enable-host-firewall` using `CiliumNodeConfiguration`
This is a more acceptable version of pull request https://github.com/deckhouse/deckhouse/pull/19686

## Why do we need it, and what problem does it solve?
Sometimes you may want to set up additional cni in your cluster. Deckhouse supports it - otherwise, why do `exclusiveCNIPlugin` parameter exists? But additional CNI might not work, in my case it was multus + whereabouts which were implementing optional additional interface in Pod. Everything was broken once I tried to enable IPv6 in multus IPAM - and there is the place where Cilium's host-firewall blocked all requests, as it was "unknown IP family" for it.

The only way I can use it now is this flow:

* set `spec.maintenance` to `NoResourceReconciliation` in cilium ModuleConfig
* edit configmap `d8-cni-cilium` / `cilium-config` - set `enable-host-firewall` to `false`
* live without cilium updates on cluster updates at all

## Why do we need it in the patch release (if we do)?
Not necessarily

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cni-cilium
type: feature
summary: Added the ability to configure Cilium Host Firewall via the `CiliumNodeConfiguration` CR.
impact_level: low
```