### PR TITLE
[admission-policy-engine] Add VEX entry for CVE-2026-41568 in trivy-provider

### DIFF
--- a/ee/modules/015-admission-policy-engine/images/trivy-provider/known_vulnerabilities.vex
+++ b/ee/modules/015-admission-policy-engine/images/trivy-provider/known_vulnerabilities.vex
@@ -242,6 +242,24 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Deckhouse Kubernetes Platform is not affected in admissionPolicyEngine trivyProvider context, because trivyProvider is a Go binary and does not run or expose Docker daemon code paths required to trigger this vulnerability.",
       "timestamp": "2026-06-22T14:35:00Z"
+    },
+
+    {
+      "vulnerability": {
+        "@id": "https://nvd.nist.gov/vuln/detail/CVE-2026-41568",
+        "description": "Race condition in docker cp mount setup allows creation of arbitrary empty files on the host via symlink swap",
+        "name": "CVE-2026-41568",
+        "aliases": [ "GHSA-vp62-88p7-qqf5" ]
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/docker/docker@v27.3.1+incompatible"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Moby is an open source container framework. In Docker Engine prior to version 29.5.1, a race condition during docker cp mount setup allows a malicious container to create empty files or directories at arbitrary absolute paths on the host filesystem when an operator initiates docker cp or calls PUT/HEAD /containers/{id}/archive API endpoints. Deckhouse Kubernetes Platform is not affected because admissionPolicyEngine trivyProvider is a Go binary and does not run, embed, or expose Docker daemon archive/copy code paths required to trigger this vulnerability.",
+      "timestamp": "2026-06-24T12:00:00Z"
     }
 
   ],


### PR DESCRIPTION


## Description
Add an VEX entry for CVE-2026-41568
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?
Not necessarily
<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: admission-policy-engine
type: chore
summary: Add VEX entry for CVE-2026-41568 in trivy-provider.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
