### PR TITLE
[deckhouse] load embedded modules

### DIFF
--- a/deckhouse-controller/internal/packages/loader/loader.go
+++ b/deckhouse-controller/internal/packages/loader/loader.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/ettle/strcase"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -44,6 +45,10 @@ const (
 
 	// digestsFile is the JSON file mapping image names to their content-addressable digests.
 	digestsFile = "images_digests.json"
+
+	// embeddedDir is the directory, relative to the process working directory,
+	// that holds embedded modules and their shared images_digests.json.
+	embeddedDir = "modules"
 
 	// globalPath is the relative directory containing global hook definitions and values.
 	// LoadGlobalConf expects this path to exist relative to the process working directory.
@@ -186,7 +191,7 @@ func LoadEmbeddedConf(ctx context.Context, moduleDir string, logger *log.Logger)
 		return nil, fmt.Errorf("convert module definition: %w", err)
 	}
 
-	digests, err := loadDigests(moduleDir)
+	digests, err := loadEmbeddedDigests(def.Name)
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
 		return nil, fmt.Errorf("load digests: %w", err)
@@ -517,6 +522,34 @@ func loadDigests(packageDir string) (map[string]string, error) {
 	}
 
 	return digests, nil
+}
+
+// loadEmbeddedDigests reads the shared images_digests.json under embeddedDir and
+// returns the digest map for the given module. The embedded digests file nests
+// per-module maps keyed by the module's CamelCase name, so the lookup converts
+// packageName accordingly. Returns nil without error if the file is absent or
+// holds no entry for the module (digests are optional).
+func loadEmbeddedDigests(packageName string) (map[string]string, error) {
+	path := filepath.Join(embeddedDir, digestsFile)
+	content, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+
+		return nil, fmt.Errorf("read file '%s': %w", path, err)
+	}
+
+	digests := make(map[string]map[string]string)
+	if err = json.Unmarshal(content, &digests); err != nil {
+		return nil, fmt.Errorf("unmarshal file '%s': %w", path, err)
+	}
+
+	if packageDigests, ok := digests[strcase.ToCamel(packageName)]; ok {
+		return packageDigests, nil
+	}
+
+	return nil, nil
 }
 
 // getModuleVersion returns the version of the package at moduleDir.

--- a/deckhouse-controller/internal/packages/modules/module.go
+++ b/deckhouse-controller/internal/packages/modules/module.go
@@ -105,7 +105,7 @@ type Config struct {
 	GlobalValuesGetter GlobalValuesGetter
 }
 
-type GlobalValuesGetter func(prefix bool) addonutils.Values
+type GlobalValuesGetter func() addonutils.Values
 
 // NewModuleByConfig creates a new Module instance with the specified configuration.
 // It initializes hook storage, adds all discovered hooks, and creates values storage.
@@ -200,7 +200,7 @@ func (m *Module) GetRuntimeValues() string {
 	runtimeValues := m.getRuntimeValues()
 	marshalled, _ := json.Marshal(runtimeValues)
 
-	marshalledGlobal := m.globalValuesGetter(false)
+	marshalledGlobal := m.globalValuesGetter()
 
 	return fmt.Sprintf("Module=%s,Deckhouse=%s", marshalled, marshalledGlobal)
 }
@@ -298,7 +298,7 @@ func (m *Module) ValidateSettings(ctx context.Context, settings addonutils.Value
 func (m *Module) GetValues() addonutils.Values {
 	moduleValues := m.values.GetValues()
 	return addonutils.MergeValues(
-		addonutils.Values{"global": m.globalValuesGetter(false)},
+		addonutils.Values{"global": m.globalValuesGetter()},
 		moduleValues,
 		addonutils.Values{addonutils.ModuleNameToValuesKey(m.name): moduleValues},
 	)

--- a/deckhouse-controller/internal/packages/runtime/embedded.go
+++ b/deckhouse-controller/internal/packages/runtime/embedded.go
@@ -1,3 +1,17 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package runtime
 
 import (

--- a/deckhouse-controller/internal/packages/runtime/embedded.go
+++ b/deckhouse-controller/internal/packages/runtime/embedded.go
@@ -1,0 +1,70 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+
+	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/loader"
+	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/modules"
+)
+
+const (
+	// embeddedDir is the directory, relative to the working directory, that
+	// holds embedded modules shipped with the controller.
+	embeddedDir = "modules"
+)
+
+// loadEmbedded discovers embedded modules under embeddedDir, builds each one
+// from its on-disk config, wires the runtime's shared managers into it, and
+// registers the resulting modules in the runtime's module map.
+func (r *Runtime) loadEmbedded(ctx context.Context) error {
+	ctx, span := otel.Tracer(runtimeTracer).Start(ctx, "loadEmbedded")
+	defer span.End()
+
+	span.SetAttributes(attribute.String("path", embeddedDir))
+
+	r.logger.Debug("load embedded modules", slog.String("path", embeddedDir))
+
+	entries, err := os.ReadDir(embeddedDir)
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return fmt.Errorf("read dir: %w", err)
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		r.logger.Debug("load embedded module", slog.String("name", entry.Name()))
+
+		conf, err := loader.LoadEmbeddedConf(ctx, embeddedDir+"/"+entry.Name(), r.logger)
+		if err != nil {
+			span.SetStatus(codes.Error, err.Error())
+			return fmt.Errorf("load embedded conf: %w", err)
+		}
+
+		conf.Patcher = r.objectPatcher
+		conf.ScheduleManager = r.scheduleManager
+		conf.KubeEventsManager = r.kubeEventsManager
+		conf.GlobalValuesGetter = r.global.GetValues
+
+		module, err := modules.NewModuleByConfig(conf.Definition.Name, conf, r.logger)
+		if err != nil {
+			span.SetStatus(codes.Error, err.Error())
+			return fmt.Errorf("new module by config: %w", err)
+		}
+
+		r.mu.Lock()
+		r.modules[module.GetName()] = module
+		r.mu.Unlock()
+	}
+
+	return nil
+}

--- a/deckhouse-controller/internal/packages/runtime/embedded.go
+++ b/deckhouse-controller/internal/packages/runtime/embedded.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"slices"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -33,6 +34,11 @@ const (
 	// holds embedded modules shipped with the controller.
 	embeddedDir = "modules"
 )
+
+var dummyModules = []string{
+	"000-common",
+	"007-registrypackages",
+}
 
 // loadEmbedded discovers embedded modules under embeddedDir, builds each one
 // from its on-disk config, wires the runtime's shared managers into it, and
@@ -52,7 +58,7 @@ func (r *Runtime) loadEmbedded(ctx context.Context) error {
 	}
 
 	for _, entry := range entries {
-		if !entry.IsDir() {
+		if !entry.IsDir() || slices.Contains(dummyModules, entry.Name()) {
 			continue
 		}
 

--- a/deckhouse-controller/internal/packages/runtime/modules.go
+++ b/deckhouse-controller/internal/packages/runtime/modules.go
@@ -16,7 +16,6 @@ package runtime
 
 import (
 	"context"
-	"path/filepath"
 	"slices"
 
 	addonutils "github.com/flant/addon-operator/pkg/utils"
@@ -112,9 +111,9 @@ func (r *Runtime) loadModule(ctx context.Context, repo registry.Remote, packageP
 	conf.Patcher = r.objectPatcher
 	conf.ScheduleManager = r.scheduleManager
 	conf.KubeEventsManager = r.kubeEventsManager
-	conf.GlobalValuesGetter = r.addonModuleManager.GetGlobal().GetValues
+	conf.GlobalValuesGetter = r.global.GetValues
 
-	module, err := modules.NewModuleByConfig(filepath.Base(packagePath), conf, r.logger)
+	module, err := modules.NewModuleByConfig(conf.Definition.Name, conf, r.logger)
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
 		return "", status.NewError("LoadFailed", err)

--- a/deckhouse-controller/internal/packages/runtime/runtime.go
+++ b/deckhouse-controller/internal/packages/runtime/runtime.go
@@ -198,6 +198,10 @@ func New(cli kclient.Client, moduleManager moduleManagerI, dc dependency.Contain
 		return nil, fmt.Errorf("new global module: %w", err)
 	}
 
+	if err := r.loadEmbedded(context.Background()); err != nil {
+		return nil, fmt.Errorf("load embedded: %w", err)
+	}
+
 	r.status.NewStatus(r.global.GetName())
 
 	if err := r.registerDebugServer("/tmp/deckhouse-debug.socket"); err != nil {

--- a/deckhouse-controller/internal/packages/values/storage.go
+++ b/deckhouse-controller/internal/packages/values/storage.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/ettle/strcase"
 	addonutils "github.com/flant/addon-operator/pkg/utils"
 
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/values/schema"
@@ -68,7 +69,7 @@ func NewStorage(name string, staticValues addonutils.Values, settingsBytes, valu
 	}
 
 	s := &Storage{
-		name:          addonutils.ModuleNameToValuesKey(name),
+		name:          strcase.ToCamel(name),
 		staticValues:  staticValues,
 		schemaStorage: schemaStorage,
 	}


### PR DESCRIPTION
## Description

Adds support for **embedded modules** — modules shipped on disk with the controller (under the `modules` directory) rather than pulled from a registry.

**Runtime**
- New `Runtime.loadEmbedded` discovers each module directory under `modules/`, builds its on-disk config, wires in the runtime's shared managers (patcher, schedule/kube-events managers, global values getter), and registers the resulting modules. It runs during `runtime.New`, so embedded modules are available at startup.
- Registry-loaded modules now derive their name from `conf.Definition.Name` (instead of the package-path basename), aligning naming with embedded modules.
- Switched the global values getter wiring to the cached `r.global` reference.

**Loader**
- New `loadEmbeddedDigests` reads the shared `modules/images_digests.json`, which nests per-module digest maps keyed by the module's CamelCase name, and `LoadEmbeddedConf` now uses it instead of the per-package `loadDigests`.
- Added an `embeddedDir = "modules"` const for the embedded-module root path.

**Values**
- `values.NewStorage` now keys the values namespace via `strcase.ToCamel(name)` instead of `addonutils.ModuleNameToValuesKey`, keeping the values key consistent with the CamelCase digest lookups.

**Modules**
- Simplified `GlobalValuesGetter` from `func(prefix bool) addonutils.Values` to `func() addonutils.Values`; all call sites previously passed `false`, so the prefix parameter was dead.

**CI**
- Dropped `CSE` from the editions reference list in `post-deploy-preparation.py`.

## Why do we need it, and what problem does it solve?

Embedded modules let the controller ship and run modules directly from disk without a registry round-trip, which is needed for modules that must be present before any registry is reachable. This wires that loading path into runtime startup, adds the embedded digests lookup, and aligns module/values naming (CamelCase) across the embedded path while removing the now-unused global-values prefix argument.

Bundle-aware gating (which embedded modules a bundle actually enables) builds on this in #20870.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: chore
summary: Load embedded modules.
impact_level: low
```
