### PR TITLE
[node-manager] Fix cluster-autoscaler alert rules for MCM mode

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -810,19 +810,19 @@ alerts:
         1. Check availability and status of cluster-autoscaler Pods:
 
            ```shell
-           d8 k -n d8-cloud-instance-manager get pods -l app=cluster-autoscaler
+           d8 k -n d8-cloud-instance-manager get pods -l 'app in (cluster-autoscaler,cluster-autoscaler-mcm)'
            ```
 
         2. Verify that the cluster-autoscaler Deployment exists:
 
            ```shell
-           d8 k -n d8-cloud-instance-manager get deploy cluster-autoscaler
+           d8 k -n d8-cloud-instance-manager get deploy -l 'app in (cluster-autoscaler,cluster-autoscaler-mcm)'
            ```
 
         3. Check the Deployment's status:
 
            ```bash
-           d8 k -n d8-cloud-instance-manager describe deploy cluster-autoscaler
+           d8 k -n d8-cloud-instance-manager describe deploy <deployment-name>
            ```
       summary: |
         Cluster-autoscaler target is missing in Prometheus.

--- a/modules/040-node-manager/monitoring/prometheus-rules/cluster-autoscaler.tpl
+++ b/modules/040-node-manager/monitoring/prometheus-rules/cluster-autoscaler.tpl
@@ -1,3 +1,22 @@
+{{- $clusterAutoscalerJobs := list -}}
+{{- if not (include "cluster_autoscaler_split_mode" .) -}}
+  {{- $clusterAutoscalerJobs = append $clusterAutoscalerJobs "cluster-autoscaler" -}}
+{{- else -}}
+  {{- if include "cluster_autoscaler_capi_enabled" . -}}
+    {{- $clusterAutoscalerJobs = append $clusterAutoscalerJobs "cluster-autoscaler" -}}
+  {{- end -}}
+  {{- if include "cluster_autoscaler_mcm_enabled" . -}}
+    {{- $clusterAutoscalerJobs = append $clusterAutoscalerJobs "cluster-autoscaler-mcm" -}}
+  {{- end -}}
+{{- end -}}
+{{- $clusterAutoscalerJobsRegex := join "|" $clusterAutoscalerJobs -}}
+{{- $clusterAutoscalerTargetDownExpr := printf `max by (job) (up{job=~"%s", namespace="d8-cloud-instance-manager"} == 0)` $clusterAutoscalerJobsRegex -}}
+{{- $clusterAutoscalerTargetAbsentExprs := list -}}
+{{- range $job := $clusterAutoscalerJobs -}}
+  {{- $clusterAutoscalerTargetAbsentExprs = append $clusterAutoscalerTargetAbsentExprs (printf `absent(up{job="%s", namespace="d8-cloud-instance-manager"} == 1)` $job) -}}
+{{- end -}}
+{{- $clusterAutoscalerTargetAbsentExpr := join " or " $clusterAutoscalerTargetAbsentExprs -}}
+
 - name: d8.cluster-autoscaler.availability
   rules:
   - alert: D8ClusterAutoscalerManagerPodIsNotReady
@@ -47,7 +66,7 @@
         ```
 
   - alert: D8ClusterAutoscalerTargetDown
-    expr: max by (job) (up{job="cluster-autoscaler", namespace="d8-cloud-instance-manager"} == 0)
+    expr: {{ $clusterAutoscalerTargetDownExpr | quote }}
     for: 5m
     labels:
       severity_level: "8"
@@ -64,7 +83,7 @@
       summary: Prometheus is unable to scrape cluster-autoscaler's metrics.
 
   - alert: D8ClusterAutoscalerTargetAbsent
-    expr: absent(up{job="cluster-autoscaler", namespace="d8-cloud-instance-manager"} == 1)
+    expr: {{ $clusterAutoscalerTargetAbsentExpr | quote }}
     for: 5m
     labels:
       severity_level: "8"
@@ -87,19 +106,19 @@
         1. Check availability and status of cluster-autoscaler Pods:
 
            ```shell
-           d8 k -n d8-cloud-instance-manager get pods -l app=cluster-autoscaler
+           d8 k -n d8-cloud-instance-manager get pods -l 'app in (cluster-autoscaler,cluster-autoscaler-mcm)'
            ```
 
         2. Verify that the cluster-autoscaler Deployment exists:
 
            ```shell
-           d8 k -n d8-cloud-instance-manager get deploy cluster-autoscaler
+           d8 k -n d8-cloud-instance-manager get deploy -l 'app in (cluster-autoscaler,cluster-autoscaler-mcm)'
            ```
 
         3. Check the Deployment's status:
 
            ```bash
-           d8 k -n d8-cloud-instance-manager describe deploy cluster-autoscaler
+           d8 k -n d8-cloud-instance-manager describe deploy <deployment-name>
            ```
 
 - name: d8.cluster-autoscaler.malfunctioning

--- a/modules/040-node-manager/template_tests/module_test.go
+++ b/modules/040-node-manager/template_tests/module_test.go
@@ -821,6 +821,48 @@ var _ = Describe("Module :: node-manager :: helm template ::", func() {
 
 				})
 			})
+
+			Context("cluster auto-scaler split mode with MCM only", func() {
+				BeforeEach(func() {
+					f.ValuesSetFromYaml("nodeManager", nodeManagerConfigValues+nodeManagerAWS)
+					f.ValuesSetFromYaml("nodeManager.internal.deployAutoscalerMCM", "true")
+					f.ValuesSetFromYaml("nodeManager.internal.autoscalerMCMNodes", `["--nodes=0:2:d8-cloud-instance-manager.myprefix-worker-02320933"]`)
+					f.ValuesSetFromYaml("nodeManager.internal.deployAutoscaler", "false")
+					f.ValuesSetFromYaml("nodeManager.internal.autoscalerNodes", `[]`)
+					setBashibleAPIServerTLSValues(f)
+					f.HelmRender()
+				})
+
+				It("renders MCM autoscaler target alerts against the MCM job", func() {
+					Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+					rule := f.KubernetesResource("PrometheusRule", "d8-cloud-instance-manager", "node-manager-cluster-autoscaler")
+					Expect(rule.Exists()).Should(BeTrue())
+					Expect(rule.Field("spec.groups.0.rules.2.expr").String()).To(Equal(`max by (job) (up{job=~"cluster-autoscaler-mcm", namespace="d8-cloud-instance-manager"} == 0)`))
+					Expect(rule.Field("spec.groups.0.rules.3.expr").String()).To(Equal(`absent(up{job="cluster-autoscaler-mcm", namespace="d8-cloud-instance-manager"} == 1)`))
+				})
+			})
+
+			Context("cluster auto-scaler split mode with MCM and CAPI", func() {
+				BeforeEach(func() {
+					f.ValuesSetFromYaml("nodeManager", nodeManagerConfigValues+nodeManagerAWS)
+					f.ValuesSetFromYaml("nodeManager.internal.deployAutoscaler", "true")
+					f.ValuesSetFromYaml("nodeManager.internal.autoscalerNodes", `["--nodes=0:2:d8-cloud-instance-manager.myprefix-worker-02320933"]`)
+					f.ValuesSetFromYaml("nodeManager.internal.deployAutoscalerMCM", "true")
+					f.ValuesSetFromYaml("nodeManager.internal.autoscalerMCMNodes", `["--nodes=0:2:d8-cloud-instance-manager.myprefix-worker-6bdb5b0d"]`)
+					setBashibleAPIServerTLSValues(f)
+					f.HelmRender()
+				})
+
+				It("renders target alerts for both autoscaler jobs", func() {
+					Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+					rule := f.KubernetesResource("PrometheusRule", "d8-cloud-instance-manager", "node-manager-cluster-autoscaler")
+					Expect(rule.Exists()).Should(BeTrue())
+					Expect(rule.Field("spec.groups.0.rules.2.expr").String()).To(Equal(`max by (job) (up{job=~"cluster-autoscaler|cluster-autoscaler-mcm", namespace="d8-cloud-instance-manager"} == 0)`))
+					Expect(rule.Field("spec.groups.0.rules.3.expr").String()).To(Equal(`absent(up{job="cluster-autoscaler", namespace="d8-cloud-instance-manager"} == 1) or absent(up{job="cluster-autoscaler-mcm", namespace="d8-cloud-instance-manager"} == 1)`))
+				})
+			})
 		})
 
 		Context("For machine controller manager", func() {


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
This PR updates cluster-autoscaler alert rules to handle split mode correctly when the MCM autoscaler job is used. It also updates the alert runbook examples and adds template tests for MCM-only and mixed MCM+CAPI setups.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
In MCM-based providers, the existing alerts check only the cluster-autoscaler job, while the actual metrics can come from cluster-autoscaler-mcm. This causes false TargetDown/TargetAbsent alerts and misleading troubleshooting steps, so the PR aligns alerting with the real deployment modes.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix 
summary: Fixed cluster-autoscaler alert rules for MCM mode.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
