### PR TITLE
Fix testenv controller setup

### DIFF
--- a/modules/040-node-manager/images/node-controller/src/internal/testenv/testenv.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/testenv/testenv.go
@@ -146,7 +146,7 @@ func NewManager(cfg *rest.Config, scheme *runtime.Scheme) (manager.Manager, erro
 	if err != nil {
 		return nil, fmt.Errorf("new manager: %w", err)
 	}
-	if err := register.SetupAll(mgr, "", 1, nil); err != nil {
+	if err := register.SetupAll(mgr, mgr.GetClient(), "", 1, nil); err != nil {
 		return nil, fmt.Errorf("setup controllers: %w", err)
 	}
 	return mgr, nil


### PR DESCRIPTION
## Description
Fix the envtest manager helper after the `register.SetupAll` signature changed.

## Why do we need it, and what problem does it solve?
`internal/testenv.NewManager` still called `register.SetupAll` without a controller-runtime client. This broke `golangci-lint run --fix` on typecheck. The helper now passes `mgr.GetClient()` to controller registration.

## Why do we need it in the patch release (if we do)?
Not necessarily.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: node-manager
type: fix
summary: Fixed the node-controller envtest helper build after the controller registration API change.
impact_level: low
```