### PR TITLE
[deckhouse] inject registry value

### DIFF
--- a/deckhouse-controller/internal/packages/modules/module.go
+++ b/deckhouse-controller/internal/packages/modules/module.go
@@ -145,6 +145,9 @@ func NewModuleByConfig(name string, cfg *Config, logger *log.Logger) (*Module, e
 		return nil, fmt.Errorf("build values storage: %v", err)
 	}
 
+	// TODO(ipaqsa): get rid of it after migration to module v2
+	m.values.InjectRegistryValue(cfg.Repository)
+
 	return m, nil
 }
 

--- a/deckhouse-controller/internal/packages/values/storage.go
+++ b/deckhouse-controller/internal/packages/values/storage.go
@@ -19,10 +19,9 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/flant/addon-operator/pkg/utils"
 	addonutils "github.com/flant/addon-operator/pkg/utils"
 	"github.com/go-openapi/spec"
-	"github.com/go-openapi/swag"
+	"github.com/go-openapi/swag/conv"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/values/schema"
@@ -292,7 +291,7 @@ func (s *Storage) InjectRegistryValue(registry registry.Remote) {
 	s.injectRegistrySpec(schema.TypeHelm)
 
 	if s.staticValues == nil {
-		s.staticValues = utils.Values{}
+		s.staticValues = addonutils.Values{}
 	}
 
 	s.staticValues["registry"] = &structpb.Struct{
@@ -324,7 +323,7 @@ func (s *Storage) injectRegistrySpec(schemaType schema.Type) {
 			AdditionalProperties: &spec.SchemaOrBool{Allows: false},
 			Properties: map[string]spec.Schema{
 				"base": {
-					SchemaProps: spec.SchemaProps{Type: spec.StringOrArray{"string"}, MinLength: swag.Int64(1)},
+					SchemaProps: spec.SchemaProps{Type: spec.StringOrArray{"string"}, MinLength: conv.Pointer[int64](1)},
 				},
 				"dockercfg": {
 					SchemaProps: spec.SchemaProps{Type: spec.StringOrArray{"string"}},

--- a/deckhouse-controller/internal/packages/values/storage.go
+++ b/deckhouse-controller/internal/packages/values/storage.go
@@ -19,9 +19,14 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/flant/addon-operator/pkg/utils"
 	addonutils "github.com/flant/addon-operator/pkg/utils"
+	"github.com/go-openapi/spec"
+	"github.com/go-openapi/swag"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/values/schema"
+	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/registry"
 )
 
 // Storage manages package values with layering, patching, and schema validation.
@@ -273,4 +278,65 @@ func (s *Storage) validateSettings(values addonutils.Values) error {
 	}
 
 	return s.schemaStorage.ValidateTransition(schema.TypeSettings, s.name, validatableValues, oldValidatable)
+}
+
+// InjectRegistryValue sets the registry value in the static values
+// TODO(ipaqsa): get rid of it after migration to module v2
+func (s *Storage) InjectRegistryValue(registry registry.Remote) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// inject spec to values schema
+	s.injectRegistrySpec(schema.TypeSettings)
+	// inject spec to helm schema
+	s.injectRegistrySpec(schema.TypeHelm)
+
+	if s.staticValues == nil {
+		s.staticValues = utils.Values{}
+	}
+
+	s.staticValues["registry"] = &structpb.Struct{
+		Fields: map[string]*structpb.Value{
+			"base":      {Kind: &structpb.Value_StringValue{StringValue: registry.Repository}},
+			"dockercfg": {Kind: &structpb.Value_StringValue{StringValue: registry.DockerConfig}},
+			"scheme":    {Kind: &structpb.Value_StringValue{StringValue: registry.Scheme}},
+			"ca":        {Kind: &structpb.Value_StringValue{StringValue: registry.CA}},
+		},
+	}
+
+	_ = s.calculateResultValues()
+}
+
+// injectRegistrySpec mutates the module schema to add a strict-typed "registry" field
+func (s *Storage) injectRegistrySpec(schemaType schema.Type) {
+	scheme := s.schemaStorage.GetSchema(schemaType)
+	if scheme == nil {
+		return
+	}
+
+	if len(scheme.Properties) == 0 {
+		scheme.Properties = make(map[string]spec.Schema)
+	}
+
+	scheme.Properties["registry"] = spec.Schema{
+		SchemaProps: spec.SchemaProps{
+			Type:                 spec.StringOrArray{"object"},
+			AdditionalProperties: &spec.SchemaOrBool{Allows: false},
+			Properties: map[string]spec.Schema{
+				"base": {
+					SchemaProps: spec.SchemaProps{Type: spec.StringOrArray{"string"}, MinLength: swag.Int64(1)},
+				},
+				"dockercfg": {
+					SchemaProps: spec.SchemaProps{Type: spec.StringOrArray{"string"}},
+				},
+				"scheme": {
+					SchemaProps: spec.SchemaProps{Type: spec.StringOrArray{"string"}},
+				},
+				"ca": {
+					SchemaProps: spec.SchemaProps{Type: spec.StringOrArray{"string"}},
+				},
+			},
+			Required: []string{"base", "scheme"},
+		},
+	}
 }


### PR DESCRIPTION
## Description

Adds `Storage.InjectRegistryValue`, which writes a strict-typed `registry` object into a module's static values and patches the module's OpenAPI schema (both `settings` and `helm` schema types) so the injected value passes validation.

The injected `registry` value carries the remote registry coordinates derived from the package repository:

| field       | source (`registry.Remote`) | required |
| ----------- | -------------------------- | -------- |
| `base`      | `Repository`               | yes (minLength 1) |
| `dockercfg` | `DockerConfig`             | no |
| `scheme`    | `Scheme`                   | yes |
| `ca`        | `CA`                       | no |

The schema is injected with `additionalProperties: false` for both schema types, so the value would be rejected by transition validation unless the spec is injected alongside it — hence both the value and the spec are written together under the storage lock, after which result values are recalculated.

`NewModuleByConfig` calls `InjectRegistryValue(cfg.Repository)` so every module built from a config gets the registry value.

This is a deliberately temporary shim — both touch points are marked `// TODO(ipaqsa): get rid of it after migration to module v2`.

## Why do we need it, and what problem does it solve?

Modules need access to their source registry coordinates (base repo, dockercfg, scheme, CA) through their values, but the current (pre-v2) module machinery doesn't surface this. This change bridges that gap by injecting the `registry` value into module values until the module v2 migration provides it natively.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: chore
summary: Inject registry value.
impact_level: low
```
