### PR TITLE
[deckhouse] Add VEX entries for release-1.73 image CVEs

### DIFF
--- a/deckhouse-controller/known_vulnerabilities.vex
+++ b/deckhouse-controller/known_vulnerabilities.vex
@@ -2,7 +2,7 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-5a4509a04e8128126aee080324a6b663a7748bf44b58a9a4b9c74d4801844f53",
   "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
-  "version": 19,
+  "version": 20,
   "statements": [
     {
       "vulnerability": {
@@ -342,8 +342,64 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Функционал загрузки функциональности из недоверенных источников (CWE-829) pip версии 25.3 не используется в рамках текущих функциональных спецификаций и эксплуатационных процессов системы. Python-зависимости не обновляются, чтобы не нарушить совместимость с shell-operator; установка пакетов выполняется только из доверенных источников на этапе сборки образа.",
       "timestamp": "2026-06-03T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-46680"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/containerd/containerd@v1.7.29"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Зависимость github.com/containerd/containerd v1.7.29 транзитивна через werf/nelm и используется только на чтение OCI-артефактов из registry; CRI/runtime-функционал containerd, к которому относится уязвимость, не используется.",
+      "timestamp": "2026-06-24T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-41567"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/docker/docker@v28.5.2+incompatible"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Зависимость github.com/docker/docker является транзитивной, поступающей через цепочку werf (delivery-kit-sdk) и go-containerregistry; демон Docker Engine не запускается в составе deckhouse-controller, уязвимый код не в пути выполнения.",
+      "timestamp": "2026-06-24T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-42306"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/docker/docker@v28.5.2+incompatible"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Зависимость github.com/docker/docker является транзитивной, поступающей через цепочку werf (delivery-kit-sdk) и go-containerregistry; демон Docker Engine не запускается в составе deckhouse-controller, уязвимый код не в пути выполнения.",
+      "timestamp": "2026-06-24T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-41568"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/docker/docker@v28.5.2+incompatible"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Зависимость github.com/docker/docker является транзитивной, поступающей через цепочку werf (delivery-kit-sdk) и go-containerregistry; демон Docker Engine не запускается в составе deckhouse-controller, уязвимый код не в пути выполнения.",
+      "timestamp": "2026-06-24T12:00:00Z"
     }
   ],
   "timestamp": "2026-03-05T12:00:00Z",
-  "last_updated": "2026-06-03T12:00:00Z"
+  "last_updated": "2026-06-24T12:00:00Z"
 }

--- a/modules/002-deckhouse/images/webhook-handler/known_vulnerabilities.vex
+++ b/modules/002-deckhouse/images/webhook-handler/known_vulnerabilities.vex
@@ -2,7 +2,7 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-5a4509a04e8128126aee080324a6b663a7748bf44b58a9a4b9c74d4801844f53",
   "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
-  "version": 16,
+  "version": 17,
   "statements": [
     {
       "vulnerability": {
@@ -179,8 +179,50 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Функционал загрузки функциональности из недоверенных источников (CWE-829) pip версии 25.3 не используется в рамках текущих функциональных спецификаций и эксплуатационных процессов системы. Установка пакетов выполняется только из доверенных источников на этапе сборки образа; версия Python не обновляется для сохранения совместимости с shell-operator.",
       "timestamp": "2026-06-01T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-41567"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/docker/docker@v28.0.0+incompatible"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Зависимость github.com/docker/docker версии v28.0.0 поступает через бинарь promtool, импортируемый из образа prometheus/prometheus; уязвимый функционал Docker Engine (демон dockerd) в webhook-handler не запускается, код не в пути выполнения.",
+      "timestamp": "2026-06-24T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-42306"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/docker/docker@v28.0.0+incompatible"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Зависимость github.com/docker/docker версии v28.0.0 поступает через бинарь promtool, импортируемый из образа prometheus/prometheus; уязвимый функционал Docker Engine (демон dockerd) в webhook-handler не запускается, код не в пути выполнения.",
+      "timestamp": "2026-06-24T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-41568"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/docker/docker@v28.0.0+incompatible"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Зависимость github.com/docker/docker версии v28.0.0 поступает через бинарь promtool, импортируемый из образа prometheus/prometheus; уязвимый функционал Docker Engine (демон dockerd) в webhook-handler не запускается, код не в пути выполнения.",
+      "timestamp": "2026-06-24T12:00:00Z"
     }
   ],
   "timestamp": "2026-03-04T12:00:00Z",
-  "last_updated": "2026-06-01T12:00:00Z"
+  "last_updated": "2026-06-24T12:00:00Z"
 }

--- a/modules/007-registrypackages/images/containerd/known_vulnerabilities.vex
+++ b/modules/007-registrypackages/images/containerd/known_vulnerabilities.vex
@@ -2,7 +2,7 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-0a7dee882b0213b53ce1f13791d223657afca21285b99e07e15b935fa0456093",
   "author": "Deckhouse <contact@deckhouse.io>",
-  "version": 10,
+  "version": 11,
   "statements": [
     {
       "vulnerability": {
@@ -140,10 +140,13 @@
       "products": [
         {
           "@id": "pkg:golang/github.com/containerd/containerd/v2"
+        },
+        {
+          "@id": "pkg:golang/github.com/containerd/containerd"
         }
       ],
       "status": "fixed",
-      "status_notes": "Уязвимость CVE-2026-46680 не может быть эксплуатирована в рамках Deckhouse: используемая версия containerd v2.1.8 уже содержит необходимое исправление безопасности, устраняющее данную уязвимость. Уязвимый код, присутствовавший в более ранних версиях, отсутствует в используемой сборке.",
+      "status_notes": "Уязвимость CVE-2026-46680 не может быть эксплуатирована в рамках Deckhouse: используемые сборки containerd уже содержат необходимое исправление безопасности — v1.7.32 (ветка 1.7) и v2.1.8 (ветка 2.1). Уязвимый код, присутствовавший в более ранних версиях (1.7.30, 2.1.6), отсутствует в используемых сборках.",
       "timestamp": "2026-04-13T14:49:31.087251Z"
     },
     {
@@ -190,5 +193,5 @@
     }
   ],
   "timestamp": "2026-03-04T12:00:38Z",
-  "last_updated": "2026-06-18T12:31:00Z"
+  "last_updated": "2026-06-24T12:00:00Z"
 }

--- a/modules/007-registrypackages/images/d8/known_vulnerabilities.vex
+++ b/modules/007-registrypackages/images/d8/known_vulnerabilities.vex
@@ -2,7 +2,7 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-7c114e6cee1182ff2b165cba363ae5cfbf773e4da8518c90d80049d24c627e94",
   "author": "Deckhouse Deckhouse <contact@deckhouse.io>",
-  "version": 16,
+  "version": 17,
   "statements": [
     {
       "vulnerability": {
@@ -551,8 +551,92 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Уязвимость в github.com/in-toto/in-toto-golang v0.9.0 связана с верификацией supply-chain attestations (in-toto layout/link metadata) в составе цепочки cosign/sigstore. d8 не верифицирует недоверенные in-toto-аттестации в рамках текущих сценариев эксплуатации — соответствующий исполняемый путь не вызывается, что исключает возможность эксплуатации.",
       "timestamp": "2026-06-02T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-46680"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/containerd/containerd@v1.7.27"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Использование github.com/containerd/containerd ограничено операциями с OCI-образами и манифестами, а не компонентами CRI или runtime, в которых проявляется уязвимость.",
+      "timestamp": "2026-06-24T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-41567"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/docker/docker@v25.0.6+incompatible"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Зависимость github.com/docker/docker зафиксирована на версии v25.0.6; демон Docker Engine не запускается, уязвимый код не в пути выполнения.",
+      "timestamp": "2026-06-24T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-42306"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/docker/docker@v25.0.6+incompatible"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Зависимость github.com/docker/docker зафиксирована на версии v25.0.6; демон Docker Engine не запускается, уязвимый код не в пути выполнения.",
+      "timestamp": "2026-06-24T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-41568"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/docker/docker@v25.0.6+incompatible"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Зависимость github.com/docker/docker зафиксирована на версии v25.0.6; демон Docker Engine не запускается, уязвимый код не в пути выполнения.",
+      "timestamp": "2026-06-24T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45571"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/go-git/go-git/v5@v5.16.2"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Уязвимость github.com/go-git/go-git/v5 v5.16.2 проявляется при обработке вредоносных Git-данных из недоверенного источника, недостижимых в штатных операциях d8.",
+      "timestamp": "2026-06-24T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "GHSA-w5pp-99ch-qj29"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/go-git/go-git/v5@v5.16.2"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Уязвимость github.com/go-git/go-git/v5 v5.16.2 проявляется при обработке вредоносных Git-данных из недоверенного источника, недостижимых в штатных операциях d8.",
+      "timestamp": "2026-06-24T12:00:00Z"
     }
   ],
   "timestamp": "2025-10-09T14:21:14Z",
-  "last_updated": "2026-06-02T12:00:00Z"
+  "last_updated": "2026-06-24T12:00:00Z"
 }

--- a/modules/800-deckhouse-tools/images/web/known_vulnerabilities.vex
+++ b/modules/800-deckhouse-tools/images/web/known_vulnerabilities.vex
@@ -2,7 +2,7 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-7c114e6cee1182ff2b165cba363ae5cfbf773e4da8518c90d80049d24c627e94",
   "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
-  "version": 18,
+  "version": 19,
   "statements": [
     {
       "vulnerability": {
@@ -535,8 +535,106 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Уязвимость в github.com/in-toto/in-toto-golang v0.9.0 связана с верификацией supply-chain attestations (in-toto layout/link metadata) в составе цепочки cosign/sigstore. В рамках deckhouse-tools web недоверенные in-toto-аттестации не верифицируются — соответствующий исполняемый путь не вызывается, что исключает возможность эксплуатации.",
       "timestamp": "2026-06-03T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-46680"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/containerd/containerd@v1.7.27"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Использование github.com/containerd/containerd ограничено операциями с OCI-образами и манифестами, а не компонентами CRI или runtime, в которых проявляется уязвимость.",
+      "timestamp": "2026-06-24T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-41567"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/docker/docker@v25.0.6+incompatible"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Зависимость github.com/docker/docker зафиксирована на версии v25.0.6; демон Docker Engine не запускается, уязвимый код не в пути выполнения.",
+      "timestamp": "2026-06-24T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-42306"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/docker/docker@v25.0.6+incompatible"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Зависимость github.com/docker/docker зафиксирована на версии v25.0.6; демон Docker Engine не запускается, уязвимый код не в пути выполнения.",
+      "timestamp": "2026-06-24T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-41568"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/docker/docker@v25.0.6+incompatible"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Зависимость github.com/docker/docker зафиксирована на версии v25.0.6; демон Docker Engine не запускается, уязвимый код не в пути выполнения.",
+      "timestamp": "2026-06-24T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45571"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/go-git/go-git/v5@v5.16.2"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Уязвимость github.com/go-git/go-git/v5 v5.16.2 проявляется при обработке вредоносных Git-данных из недоверенного источника, недостижимых в штатных операциях d8.",
+      "timestamp": "2026-06-24T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45570"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/go-git/go-git/v5@v5.16.2"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Уязвимость github.com/go-git/go-git/v5 v5.16.2 проявляется при обработке вредоносных Git-данных из недоверенного источника, недостижимых в штатных операциях d8.",
+      "timestamp": "2026-06-24T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "GHSA-w5pp-99ch-qj29"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/go-git/go-git/v5@v5.16.2"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Уязвимость github.com/go-git/go-git/v5 v5.16.2 проявляется при обработке вредоносных Git-данных из недоверенного источника, недостижимых в штатных операциях d8.",
+      "timestamp": "2026-06-24T12:00:00Z"
     }
   ],
   "timestamp": "2026-03-05T12:00:00Z",
-  "last_updated": "2026-06-03T12:00:00Z"
+  "last_updated": "2026-06-24T12:00:00Z"
 }


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Add VEX entries for release-1.73 image CVEs

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix 
summary: Add VEX entries for release-1.73 image CVEs.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
