### PR TITLE
[candi] Fix oss.yaml merge script

### DIFF
--- a/tools/dmt-lint.sh
+++ b/tools/dmt-lint.sh
@@ -57,6 +57,40 @@ function install_dmt() {
 
 }
 
+function install_yq() {
+  platform_name=$(uname -m)
+  os_name=$(uname)
+
+  case "$os_name" in
+    Linux)
+      local platform="linux"
+      ;;
+    Darwin)
+      local platform="darwin"
+      ;;
+    *)
+      echo "Unsupported OS: $os_name"
+      return 1
+      ;;
+  esac
+
+  case "$platform_name" in
+    x86_64)
+      local arch="amd64"
+      ;;
+    arm64|aarch64)
+      local arch="arm64"
+      ;;
+    *)
+      echo "Unsupported architecture: $platform_name"
+      return 1
+      ;;
+  esac
+
+  curl -sSfL "https://github.com/mikefarah/yq/releases/download/v4.45.1/yq_${platform}_${arch}" -o /usr/local/bin/yq
+  chmod +x /usr/local/bin/yq
+}
+
 function structure_prepare {
   modules_dir=("ee/modules" "ee/be/modules" "ee/fe/modules" "ee/se/modules" "ee/se-plus/modules")
   cloud_providers_glob="030-cloud-provider-*"
@@ -106,6 +140,7 @@ function structure_prepare {
 
 apt update > /dev/null
 apt install curl -y > /dev/null
+install_yq
 structure_prepare
 install_dmt
 dmt lint -l INFO /deckhouse/modules

--- a/tools/dmt-lint.sh
+++ b/tools/dmt-lint.sh
@@ -74,9 +74,7 @@ function structure_prepare {
 
       if [[ -f "${target_module_dir}/oss.yaml" && -f "${source_module_dir}/oss.yaml" ]]; then
         merged_oss_tmp=$(mktemp)
-        cat "${target_module_dir}/oss.yaml" > "${merged_oss_tmp}"
-        printf "\n" >> "${merged_oss_tmp}"
-        cat "${source_module_dir}/oss.yaml" >> "${merged_oss_tmp}"
+        yq eval-all '. as $item ireduce ({}; . * $item)' "${target_module_dir}/oss.yaml" "${source_module_dir}/oss.yaml" > "${merged_oss_tmp}"
       fi
 
       if [[ -d "${target_module_dir}" ]]; then

--- a/tools/dmt-lint.sh
+++ b/tools/dmt-lint.sh
@@ -74,7 +74,15 @@ function structure_prepare {
 
       if [[ -f "${target_module_dir}/oss.yaml" && -f "${source_module_dir}/oss.yaml" ]]; then
         merged_oss_tmp=$(mktemp)
-        yq eval-all '. as $item ireduce ({}; . * $item)' "${target_module_dir}/oss.yaml" "${source_module_dir}/oss.yaml" > "${merged_oss_tmp}"
+        # Properly merge the two oss.yaml arrays into one via yq
+        yq eval-all '[.] | flatten' "${target_module_dir}/oss.yaml" "${source_module_dir}/oss.yaml" > "${merged_oss_tmp}"
+        # Check for duplicate object ids in the merged result
+        local dup_ids
+        dup_ids=$(yq -o=json '[.[].id] | group_by(.) | map(select(length > 1)[0])' "${merged_oss_tmp}")
+        if [[ -n "${dup_ids}" && "${dup_ids}" != "[]" ]]; then
+          echo "Error: duplicate oss object ids in module ${module_name}: ${dup_ids}"
+          exit 1
+        fi
       fi
 
       if [[ -d "${target_module_dir}" ]]; then


### PR DESCRIPTION
## Description

Fix oss.yaml merge. Implemented merge via yq.

## Why do we need it, and what problem does it solve?

Previously there was no check for the uniqueness of objects, merging through yq solves this problem

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: candi
type: fix
summary:  Fix oss.yaml merge script
impact_level: default
```
