### PR TITLE
chore(registry): update subsystem

### DIFF
--- a/modules/038-registry/module.yaml
+++ b/modules/038-registry/module.yaml
@@ -3,9 +3,7 @@ critical: true
 weight: 38
 stage: Preview
 subsystems:
-  - deckhouse
   - infrastructure
-  - kubernetes
 namespace: d8-system
 disable:
   confirmation: true


### PR DESCRIPTION
## Description
Update registry module subsystem metadata.

## Why do we need it, and what problem does it solve?
Keep the registry module in the infrastructure subsystem only.

## Why do we need it in the patch release (if we do)?
Not necessarily.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: registry
type: chore
summary: Keep the registry module in the infrastructure subsystem only.
impact_level: low
```