### PR TITLE
Fixed containerd creds screening [release-1.76]

### DIFF
--- a/candi/bashible/common-steps/all/030_configure_containerd_registry.sh.tpl
+++ b/candi/bashible/common-steps/all/030_configure_containerd_registry.sh.tpl
@@ -61,7 +61,7 @@ mkdir -p "/etc/containerd/registry.d/{{ $host_name }}"
 {{- range $mirror := $host_values.mirrors }}
   {{- $mirror_ca_file_path := printf "/etc/containerd/registry.d/%s/%s-%s-ca.crt" $host_name $mirror.scheme $mirror.host }}
   {{- if $mirror.ca }}
-bb-sync-file {{ $mirror_ca_file_path | quote }} - << EOF
+bb-sync-file {{ $mirror_ca_file_path | quote }} - << "EOF"
 {{ $mirror.ca }}
 EOF
   {{- end }}
@@ -86,11 +86,10 @@ bb-sync-file "/etc/containerd/registry.d/{{ $host_name }}/hosts.toml" - << EOF
     {{- with $mirror.auth }}
       {{- if or .auth .username }}
     [host.{{ $mirror_host_with_scheme | quote }}.auth]
-        {{- if .auth }}
-      auth = {{ .auth | quote }}
+        {{- if .username }}
+      auth = {{ printf "%s:%s" .username ( .password | default "" ) | b64enc | quote }}
         {{- else }}
-      username = {{ .username | quote }}
-      password = {{ .password | default "" | quote }}
+      auth = {{ .auth | quote }}
         {{- end }}
       {{- end }}
     {{- end }}
@@ -112,7 +111,7 @@ EOF
 
 # Sync module sources host.toml and ca.crt
 mkdir -p "/etc/containerd/registry.d/{{ $host_name }}"
-bb-sync-file "/etc/containerd/registry.d/{{ $host_name }}/ca.crt" - << EOF
+bb-sync-file "/etc/containerd/registry.d/{{ $host_name }}/ca.crt" - << "EOF"
 {{ $CA }}
 EOF
 

--- a/candi/bashible/common-steps/all/032_configure_containerd.sh.tpl
+++ b/candi/bashible/common-steps/all/032_configure_containerd.sh.tpl
@@ -385,8 +385,7 @@ oom_score = 0
       [plugins."io.containerd.grpc.v1.cri".registry.configs]
         [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ $mirror.host }}".auth]
           {{- if (($mirror).auth).username }}
-          username = {{ $mirror.auth.username | quote }}
-          password = {{ $mirror.auth.password | default "" | quote }}
+          auth = {{ printf "%s:%s" ($mirror.auth.username) ($mirror.auth.password | default "") | b64enc | quote }}
           {{- else }}
           auth = {{ (($mirror).auth).auth | default "" | quote }}
           {{- end }}


### PR DESCRIPTION
## Description

If the `username` and `password` parameters in the containerd auth configuration contained a `$` character, bashible rendered the manifests without escaping the parameters. This resulted in an incorrect containerd configuration.

This PR fixes the credential escaping issue. The `username` and `password` parameters are now rendered into an `auth` string.

### Why We Cannot Escape the Entire Manifest Rendering

- **`host.toml`** manifest: During the bootstrap process in `Local`/`Proxy` mode, the `discovered_node_ip` is used for manifest rendering. This value can only be obtained during bashible runtime and comes from an environment variable. Therefore, we cannot escape the rendering of the entire manifest.

- **`config.toml`** manifest: The `systemd_cgroup` environment variable is used for manifest rendering. Therefore, we cannot escape the rendering of the entire manifest.

### After fix (containerd v1)

**Old configuration:**
<img width="6944" height="1120" alt="image" src="https://github.com/user-attachments/assets/63d8bf8d-65da-4c37-b507-497007bfa592" />
<img width="6944" height="1176" alt="image" src="https://github.com/user-attachments/assets/ea6fd0ae-5a56-4325-b1b7-2a7c6c668278" />


**New configuration:**
<img width="6920" height="1200" alt="image" src="https://github.com/user-attachments/assets/597971e6-cc29-4e20-ac96-cd3ef7d734ee" />
<img width="6920" height="1104" alt="image" src="https://github.com/user-attachments/assets/48842b9c-d050-4dbe-8bde-8d6e49cef7ce" />



### After fix (containerd v2)

**New configuration only:**
<img width="6944" height="1216" alt="image" src="https://github.com/user-attachments/assets/12960022-054a-41b2-8316-3e1dff51ea68" />
<img width="6920" height="1200" alt="image" src="https://github.com/user-attachments/assets/b892d99d-f02e-45b2-9fd8-3133dd921da2" />


> [!WARNING]  
> These changes may restart containerd v1 to apply the new configuration.

## Why do we need it, and what problem does it solve?

Fix containerd credential escaping.

## Why do we need it in the patch release (if we do)?

Fix containerd credential escaping.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

<!-- ```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
``` -->

```changes
section: candi
type: fix
summary: Fix containerd credential escaping by rendering username/password into auth string.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
