### PR TITLE
Fix/cpm kubeadm cluster admins helm adopt

### DIFF
--- a/modules/040-control-plane-manager/hooks/reconcile_kubeadm_cluster_admins_binding.go
+++ b/modules/040-control-plane-manager/hooks/reconcile_kubeadm_cluster_admins_binding.go
@@ -66,11 +66,21 @@ const (
 	clusterIsBootstrappedValuePath    = "global.clusterIsBootstrapped"
 	kubeadmTargetRoleNameValuePath    = "controlPlaneManager.internal.kubeadmClusterAdminsTargetRoleName"
 	kubeadmSupplementEnabledValuePath = "controlPlaneManager.internal.kubeadmClusterAdminsSupplementEnabled"
+
+	// Helm ownership keys. Helm refuses to adopt a resource that lacks all three; without them
+	// the control-plane-manager release fails on every converge on pre-v1.76 clusters.
+	helmManagedByLabel             = "app.kubernetes.io/managed-by"
+	helmManagedByValue             = "Helm"
+	helmReleaseNameAnnotation      = "meta.helm.sh/release-name"
+	helmReleaseNamespaceAnnotation = "meta.helm.sh/release-namespace"
+	cpmHelmReleaseName             = "control-plane-manager"
+	cpmHelmReleaseNamespace        = "d8-system"
 )
 
-// kubeadmClusterAdminsBindingState keeps the only moving piece of the CRB — the target role.
+// kubeadmClusterAdminsBindingState keeps the moving pieces of the CRB we care about.
 type kubeadmClusterAdminsBindingState struct {
-	RoleRefName string `json:"roleRefName"`
+	RoleRefName      string `json:"roleRefName"`
+	HasHelmOwnership bool   `json:"hasHelmOwnership"`
 }
 
 // userAuthzClusterAdminCRState is just a presence marker (snapshot length > 0 == role exists).
@@ -83,7 +93,13 @@ func filterKubeadmClusterAdminsBinding(obj *unstructured.Unstructured) (go_hook.
 	if err := sdk.FromUnstructured(obj, &crb); err != nil {
 		return nil, fmt.Errorf("convert ClusterRoleBinding %s: %w", obj.GetName(), err)
 	}
-	return kubeadmClusterAdminsBindingState{RoleRefName: crb.RoleRef.Name}, nil
+	hasHelm := crb.Labels[helmManagedByLabel] == helmManagedByValue &&
+		crb.Annotations[helmReleaseNameAnnotation] == cpmHelmReleaseName &&
+		crb.Annotations[helmReleaseNamespaceAnnotation] == cpmHelmReleaseNamespace
+	return kubeadmClusterAdminsBindingState{
+		RoleRefName:      crb.RoleRef.Name,
+		HasHelmOwnership: hasHelm,
+	}, nil
 }
 
 func filterUserAuthzClusterAdminCR(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
@@ -158,6 +174,26 @@ func reconcileKubeadmClusterAdminsBindingHook(_ context.Context, input *go_hook.
 
 	current := bindingSnaps[len(bindingSnaps)-1]
 	if current.RoleRefName == desiredRoleName {
+		if !current.HasHelmOwnership {
+			// Pre-v1.76 clusters have this CRB without Helm ownership metadata.
+			// Helm refuses to adopt a resource that lacks all three keys and the release fails.
+			// Patch them in before Helm runs so it can take ownership cleanly.
+			logger.Info("patching helm ownership metadata onto clusterrolebinding")
+			input.PatchCollector.PatchWithMerge(
+				map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"labels": map[string]string{
+							helmManagedByLabel: helmManagedByValue,
+						},
+						"annotations": map[string]string{
+							helmReleaseNameAnnotation:      cpmHelmReleaseName,
+							helmReleaseNamespaceAnnotation: cpmHelmReleaseNamespace,
+						},
+					},
+				},
+				rbacv1.SchemeGroupVersion.String(), "ClusterRoleBinding", "", kubeadmClusterAdminsBindingName,
+			)
+		}
 		return nil
 	}
 
@@ -168,8 +204,7 @@ func reconcileKubeadmClusterAdminsBindingHook(_ context.Context, input *go_hook.
 }
 
 // buildKubeadmClusterAdminsBinding renders the desired ClusterRoleBinding state.
-// Labels are intentionally minimal (only heritage/module): Helm SSA reconciles its full label set
-// on the next pass and we deliberately do not imitate Helm-managed metadata here.
+// Helm ownership metadata is included so that Helm can adopt the object on the next release run.
 func buildKubeadmClusterAdminsBinding(roleName string) *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{
 		TypeMeta: metav1.TypeMeta{
@@ -179,8 +214,13 @@ func buildKubeadmClusterAdminsBinding(roleName string) *rbacv1.ClusterRoleBindin
 		ObjectMeta: metav1.ObjectMeta{
 			Name: kubeadmClusterAdminsBindingName,
 			Labels: map[string]string{
-				"heritage": "deckhouse",
-				"module":   "control-plane-manager",
+				"heritage":         "deckhouse",
+				"module":           "control-plane-manager",
+				helmManagedByLabel: helmManagedByValue,
+			},
+			Annotations: map[string]string{
+				helmReleaseNameAnnotation:      cpmHelmReleaseName,
+				helmReleaseNamespaceAnnotation: cpmHelmReleaseNamespace,
 			},
 		},
 		RoleRef: rbacv1.RoleRef{

--- a/modules/040-control-plane-manager/hooks/reconcile_kubeadm_cluster_admins_binding_test.go
+++ b/modules/040-control-plane-manager/hooks/reconcile_kubeadm_cluster_admins_binding_test.go
@@ -31,12 +31,16 @@ var _ = Describe("Modules :: control-plane-manager :: hooks :: reconcile_kubeadm
 		valuesUserAuthzOnNotBootstrapped  = `{"global": {"enabledModules": ["user-authz"], "clusterIsBootstrapped": false}, "controlPlaneManager":{"internal": {}}}`
 		valuesUserAuthzOnBootstrapped     = `{"global": {"enabledModules": ["user-authz"], "clusterIsBootstrapped": true}, "controlPlaneManager":{"internal": {}}}`
 
+		// pre-v1.76: heritage:deckhouse only, no Helm ownership — triggers migration patch.
 		crbCurrentClusterAdmin = `
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: kubeadm:cluster-admins
+  labels:
+    heritage: deckhouse
+    module: control-plane-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -52,6 +56,54 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: kubeadm:cluster-admins
+  labels:
+    heritage: deckhouse
+    module: control-plane-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: user-authz:cluster-admin
+subjects:
+- kind: Group
+  name: kubeadm:cluster-admins
+`
+
+		// v1.76+: full Helm ownership present — true no-op, no patch needed.
+		crbClusterAdminWithHelmLabels = `
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubeadm:cluster-admins
+  labels:
+    heritage: deckhouse
+    module: control-plane-manager
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    meta.helm.sh/release-name: control-plane-manager
+    meta.helm.sh/release-namespace: d8-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: Group
+  name: kubeadm:cluster-admins
+`
+
+		crbUserAuthzClusterAdminWithHelmLabels = `
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubeadm:cluster-admins
+  labels:
+    heritage: deckhouse
+    module: control-plane-manager
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    meta.helm.sh/release-name: control-plane-manager
+    meta.helm.sh/release-namespace: d8-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -95,6 +147,13 @@ rules:
 	expectInternalDecision := func(f *HookExecutionConfig, targetRole string, supplementEnabled bool) {
 		Expect(f.ValuesGet(targetRolePath).String()).To(Equal(targetRole))
 		Expect(f.ValuesGet(supplementEnabledPath).Bool()).To(Equal(supplementEnabled))
+	}
+
+	expectHelmOwnership := func(f *HookExecutionConfig) {
+		crb := f.KubernetesGlobalResource("ClusterRoleBinding", "kubeadm:cluster-admins")
+		Expect(crb.Field(`metadata.labels.app\.kubernetes\.io/managed-by`).String()).To(Equal("Helm"))
+		Expect(crb.Field(`metadata.annotations.meta\.helm\.sh/release-name`).String()).To(Equal("control-plane-manager"))
+		Expect(crb.Field(`metadata.annotations.meta\.helm\.sh/release-namespace`).String()).To(Equal("d8-system"))
 	}
 
 	// ── user-authz disabled: binding must always stay on cluster-admin (kubeadm-default) ──
@@ -215,6 +274,50 @@ rules:
 			Expect(f).To(ExecuteSuccessfully())
 			expectDesiredCRB(f, "user-authz:cluster-admin")
 			expectInternalDecision(f, "user-authz:cluster-admin", true)
+		})
+	})
+
+	// ── Helm ownership migration: CRB exists without Helm labels ──
+	Context("user-authz disabled, CRB on cluster-admin WITHOUT Helm labels (pre-v1.76 state)", func() {
+		f := HookExecutionConfigInit(valuesUserAuthzOffBootstrapped, "")
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(crbCurrentClusterAdmin))
+			f.RunHook()
+		})
+		It("patches Helm ownership onto the existing CRB without changing roleRef", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			expectDesiredCRB(f, "cluster-admin")
+			expectHelmOwnership(f)
+			expectInternalDecision(f, "cluster-admin", false)
+		})
+	})
+
+	Context("user-authz enabled+bootstrapped, CRB on user-authz:cluster-admin WITHOUT Helm labels (pre-v1.76 state)", func() {
+		f := HookExecutionConfigInit(valuesUserAuthzOnBootstrapped, "")
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(crbUserAuthzClusterAdminWithHelmLabels + userAuthzClusterAdminCR))
+			f.RunHook()
+		})
+		It("is a true no-op: roleRef correct, Helm labels already present — no patch emitted", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			expectDesiredCRB(f, "user-authz:cluster-admin")
+			expectHelmOwnership(f)
+			expectInternalDecision(f, "user-authz:cluster-admin", true)
+		})
+	})
+
+	// ── True no-op: CRB already carries Helm labels ──
+	Context("user-authz disabled, CRB on cluster-admin WITH Helm labels already", func() {
+		f := HookExecutionConfigInit(valuesUserAuthzOffBootstrapped, "")
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(crbClusterAdminWithHelmLabels))
+			f.RunHook()
+		})
+		It("is a true no-op: roleRef correct and Helm labels already present", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			expectDesiredCRB(f, "cluster-admin")
+			expectHelmOwnership(f)
+			expectInternalDecision(f, "cluster-admin", false)
 		})
 	})
 


### PR DESCRIPTION
## Description
Hook `reconcile_kubeadm_cluster_admins_binding` patches Helm ownership metadata
(`app.kubernetes.io/managed-by`, `meta.helm.sh/release-name`, `meta.helm.sh/release-namespace`) onto the existing `kubeadm:cluster-admins` ClusterRoleBinding before Helm runs.
Also stamps the same keys in `buildKubeadmClusterAdminsBinding` so the Delete+Create
path on roleRef flip produces a properly labelled object.

## Why do we need it, and what problem does it solve?
On clusters upgrading from pre-v1.76, the `kubeadm:cluster-admins` CRB exists with
only `heritage: deckhouse` labels — no Helm ownership metadata. `control-plane-manager`
fails on every converge with:
```
ClusterRoleBinding "kubeadm:cluster-admins" exists and cannot be imported into the
current release: invalid ownership metadata
```

This blocks creation of the `d8:control-plane-manager:apiserver-kubelet-client` CRB,
which removes `kube-apiserver-kubelet-client`'s `system:kubelet-api-admin` rights.
As a result, `kubectl logs` and `kubectl exec` fail cluster-wide for all users,
including those using `super-admin.conf`.

Root cause introduced in #19667 (`buildKubeadmClusterAdminsBinding` deliberately
omitted Helm metadata under a false assumption that Helm SSA would reconcile it
on the next pass — it doesn't).

**Workaround until patched:**
The object has `heritage: deckhouse` so patching requires impersonating the deckhouse SA to bypass the admission webhook
```bash
kubectl --as=system:serviceaccount:d8-system:deckhouse \
  annotate clusterrolebinding kubeadm:cluster-admins \
  meta.helm.sh/release-name=control-plane-manager \
  meta.helm.sh/release-namespace=d8-system --overwrite

kubectl --as=system:serviceaccount:d8-system:deckhouse \
  label clusterrolebinding kubeadm:cluster-admins \
  app.kubernetes.io/managed-by=Helm --overwrite
```

## Why do we need it in the patch release (if we do)?
Regression in v1.76.0: all clusters upgrading from pre-v1.76 are broken on first converge.
kubectl logs/exec become unavailable cluster-wide immediately after upgrade.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: fix
summary: Fixed Helm adoption of `kubeadm:cluster-admins` ClusterRoleBinding on upgrade from a DKP version prior to 1.76.
impact: If your cluster was previously upgraded to DKP 1.76.0 from a version earlier than 1.76 and was not patched, `kubectl logs` and `kubectl exec` may fail cluster-wide for all users. Apply the manual workaround from the [PR description](https://github.com/deckhouse/deckhouse/pull/20877) before upgrading.
impact_level: high
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
