### PR TITLE
[docs] Delete the note about the beta version of the graphical installer on the DKP installation page

### DIFF
--- a/docs/documentation/pages/installing/README_RU.md
+++ b/docs/documentation/pages/installing/README_RU.md
@@ -36,7 +36,7 @@ relatedLinks:
 Установить DKP можно следующими способами:
 
 - с помощью CLI-установщика (доступен в виде образа контейнера и основан на утилите [dhctl](<https://github.com{{ site.github_repo_path }}/tree/main/dhctl/>));
-- с помощью [графического установщика]({% if site.mode == 'module' %}{{ site.urls[page.lang] }}{% endif %}/products/kubernetes-platform/gs/#gui-install) (находится в режиме бета-тестирования).
+- с помощью [графического установщика]({% if site.mode == 'module' %}{{ site.urls[page.lang] }}{% endif %}/products/kubernetes-platform/gs/#gui-install).
 
 Далее рассмотрен процесс установки с помощью **CLI-установщика**.
 


### PR DESCRIPTION
## Description

Deleted the note about the beta version of the graphical installer on the DKP installation page.

## Why do we need it, and what problem does it solve?

## Why do we need it in the patch release (if we do)?

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: fix 
summary: Deleted the note about the beta version of the graphical installer on the DKP installation page.
impact_level: low
```
