### PR TITLE
[deckhouse] fix: preserve legacy bash completion flag

### DIFF
--- a/deckhouse-controller/cmd/deckhouse-controller/main.go
+++ b/deckhouse-controller/cmd/deckhouse-controller/main.go
@@ -127,8 +127,10 @@ func main() {
 			// External callers (and our own image's /etc/bashrc) still invoke
 			// `deckhouse-controller --completion-script-bash`, so keep emitting
 			// the bash completion script and exit early when the flag is set.
+			// Use GenBashCompletionV2 (with descriptions) so the output is
+			// byte-for-byte identical to the `completion bash` subcommand.
 			if legacyBashCompletion {
-				if err := cmd.Root().GenBashCompletion(os.Stdout); err != nil {
+				if err := cmd.Root().GenBashCompletionV2(os.Stdout, true); err != nil {
 					return err
 				}
 				os.Exit(0)

--- a/deckhouse-controller/cmd/deckhouse-controller/main.go
+++ b/deckhouse-controller/cmd/deckhouse-controller/main.go
@@ -67,6 +67,10 @@ const (
 	AppDescription = "controller for Kubernetes platform from Flant"
 )
 
+// legacyBashCompletion is bound to the backward-compatibility flag
+// `--completion-script-bash` (see rootCmd setup in main).
+var legacyBashCompletion bool
+
 func main() {
 	sh_app.Version = ShellOperatorVersion
 	ad_app.Version = AddonOperatorVersion
@@ -116,11 +120,34 @@ func main() {
 	rootCmd := &cobra.Command{
 		Use:   fileName,
 		Short: fmt.Sprintf("%s %s: %s", AppName, DeckhouseVersion, AppDescription),
-		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+			// Backward-compatibility alias for the legacy kingpin flag
+			// `--completion-script-bash`, which was replaced by the cobra
+			// `completion bash` subcommand after the migration to cobra.
+			// External callers (and our own image's /etc/bashrc) still invoke
+			// `deckhouse-controller --completion-script-bash`, so keep emitting
+			// the bash completion script and exit early when the flag is set.
+			if legacyBashCompletion {
+				if err := cmd.Root().GenBashCompletion(os.Stdout); err != nil {
+					return err
+				}
+				os.Exit(0)
+			}
+
 			klogtolog.InitAdapter(cfg.Debug.KubernetesAPI, logger.Named("klog"))
 			stdliblogtolog.InitAdapter(logger)
 			return nil
 		},
+	}
+
+	// Legacy kingpin completion flag alias. Hidden from help output: the
+	// canonical interface is the `completion` subcommand, this only preserves
+	// backward compatibility for `--completion-script-bash`.
+	rootCmd.PersistentFlags().BoolVar(&legacyBashCompletion, "completion-script-bash", false,
+		"Generate the bash autocompletion script (alias for `completion bash`).")
+	if err := rootCmd.PersistentFlags().MarkHidden("completion-script-bash"); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to hide completion-script-bash flag: %v\n", err)
+		os.Exit(1)
 	}
 
 	rootCmd.AddCommand(&cobra.Command{

--- a/deckhouse-controller/cmd/deckhouse-controller/main.go
+++ b/deckhouse-controller/cmd/deckhouse-controller/main.go
@@ -133,11 +133,13 @@ func main() {
 				if err := cmd.Root().GenBashCompletionV2(os.Stdout, true); err != nil {
 					return err
 				}
+
 				os.Exit(0)
 			}
 
 			klogtolog.InitAdapter(cfg.Debug.KubernetesAPI, logger.Named("klog"))
 			stdliblogtolog.InitAdapter(logger)
+
 			return nil
 		},
 	}

--- a/deckhouse-controller/files/bashrc.tpl
+++ b/deckhouse-controller/files/bashrc.tpl
@@ -56,4 +56,4 @@ case "$kubernetes_version" in
 esac
 
 eval "$(kubectl-${kubectl_version} completion bash | sed 's/_get_comp_words_by_ref/_comp_get_words/g')"
-eval "$(deckhouse-controller --completion-script-bash | sed -e s/deckhouse/deckhouse-controller/g | sed 's/_get_comp_words_by_ref/_comp_get_words/g')"
+eval "$(deckhouse-controller --completion-script-bash | sed 's/_get_comp_words_by_ref/_comp_get_words/g')"


### PR DESCRIPTION
## Description
After the migration of deckhouse-controller from kingpin to cobra, the legacy `--completion-script-bash` flag was removed in favor of the canonical completion bash subcommand. However, the bash completion setup shipped inside the `Deckhouse` image (`/etc/bashrc`, rendered from `deckhouse-controller/files/bashrc.tpl`) still invokes `deckhouse-controller --completion-script-bash`, so the autocompletion script stopped being generated and `deckhouse-controller` tab-completion broke inside the pod.

This change:
 - Adds a hidden `--completion-script-bash` persistent flag on the root cobra command, bound to a package-level `legacyBashCompletion` variable.
 - In `PersistentPreRunE`, when the flag is set, the bash completion script is generated via `cmd.Root().GenBashCompletionV2(os.Stdout)` and the process exits early, mirroring the previous kingpin behavior.
 - Simplifies the corresponding eval line in `bashrc.tpl`, dropping the now-unnecessary `sed -e s/deckhouse/deckhouse-controller/g` substitution (cobra generates the script for `deckhouse-controller` directly, while kingpin produced one named `deckhouse`).

The flag is hidden from help output to keep the completion subcommand as the canonical interface; the legacy flag exists solely for backward compatibility.

## Why do we need it, and what problem does it solve?
The cobra migration silently dropped the `--completion-script-bash` flag that the in-image `/etc/bashrc` relies on to enable bash completion for `deckhouse-controller`. As a result, every new shell inside a `Deckhouse` pod failed to load completions (the eval of the missing-flag command produced no usable script), degrading the operator experience in the pod shell with no visible error.

This PR restores the flag as a backward-compatible alias, so existing `bashrc` entries and any external callers/scripts that still use `--completion-script-bash` keep working without changes, while the completion subcommand remains the documented, canonical path going forward.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: Add alias for legacy bash completion flag.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
