### PR TITLE
[control-plane-manager] Add helm.sh/resource-policy: keep annotation

### DIFF
--- a/modules/040-control-plane-manager/hooks/reconcile_kubeadm_cluster_admins_binding.go
+++ b/modules/040-control-plane-manager/hooks/reconcile_kubeadm_cluster_admins_binding.go
@@ -75,6 +75,12 @@ const (
 	helmReleaseNamespaceAnnotation = "meta.helm.sh/release-namespace"
 	cpmHelmReleaseName             = "control-plane-manager"
 	cpmHelmReleaseNamespace        = "d8-system"
+
+	// resource-policy: keep mirrors the template annotation so the live object always carries it,
+	// even right after the hook (re)creates it. This guards the eventual hook-only migration: when
+	// this CRB is dropped from the Helm template, Helm must not prune it (admin.conf would lose root).
+	helmResourcePolicyAnnotation = "helm.sh/resource-policy"
+	helmResourcePolicyKeep       = "keep"
 )
 
 // kubeadmClusterAdminsBindingState keeps the moving pieces of the CRB we care about.
@@ -188,6 +194,7 @@ func reconcileKubeadmClusterAdminsBindingHook(_ context.Context, input *go_hook.
 						"annotations": map[string]string{
 							helmReleaseNameAnnotation:      cpmHelmReleaseName,
 							helmReleaseNamespaceAnnotation: cpmHelmReleaseNamespace,
+							helmResourcePolicyAnnotation:   helmResourcePolicyKeep,
 						},
 					},
 				},
@@ -204,7 +211,8 @@ func reconcileKubeadmClusterAdminsBindingHook(_ context.Context, input *go_hook.
 }
 
 // buildKubeadmClusterAdminsBinding renders the desired ClusterRoleBinding state.
-// Helm ownership metadata is included so that Helm can adopt the object on the next release run.
+// Helm ownership metadata is included so that Helm can adopt the object on the next release run,
+// and helm.sh/resource-policy: keep is set so Helm never prunes it (mirrors the template).
 func buildKubeadmClusterAdminsBinding(roleName string) *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{
 		TypeMeta: metav1.TypeMeta{
@@ -221,6 +229,7 @@ func buildKubeadmClusterAdminsBinding(roleName string) *rbacv1.ClusterRoleBindin
 			Annotations: map[string]string{
 				helmReleaseNameAnnotation:      cpmHelmReleaseName,
 				helmReleaseNamespaceAnnotation: cpmHelmReleaseNamespace,
+				helmResourcePolicyAnnotation:   helmResourcePolicyKeep,
 			},
 		},
 		RoleRef: rbacv1.RoleRef{

--- a/modules/040-control-plane-manager/hooks/reconcile_kubeadm_cluster_admins_binding_test.go
+++ b/modules/040-control-plane-manager/hooks/reconcile_kubeadm_cluster_admins_binding_test.go
@@ -156,6 +156,13 @@ rules:
 		Expect(crb.Field(`metadata.annotations.meta\.helm\.sh/release-namespace`).String()).To(Equal("d8-system"))
 	}
 
+	// expectKeepPolicy guards the hook-only migration: any object the hook writes must carry
+	// helm.sh/resource-policy: keep so Helm never prunes it once the CRB leaves the template.
+	expectKeepPolicy := func(f *HookExecutionConfig) {
+		crb := f.KubernetesGlobalResource("ClusterRoleBinding", "kubeadm:cluster-admins")
+		Expect(crb.Field(`metadata.annotations.helm\.sh/resource-policy`).String()).To(Equal("keep"))
+	}
+
 	// ── user-authz disabled: binding must always stay on cluster-admin (kubeadm-default) ──
 	Context("user-authz disabled and not bootstrapped, no CRB", func() {
 		f := HookExecutionConfigInit(valuesUserAuthzOffNotBootstrapped, "")
@@ -166,6 +173,7 @@ rules:
 		It("creates the binding pointing to cluster-admin and publishes target=cluster-admin, supplement=false", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			expectDesiredCRB(f, "cluster-admin")
+			expectKeepPolicy(f)
 			expectInternalDecision(f, "cluster-admin", false)
 		})
 	})
@@ -288,6 +296,7 @@ rules:
 			Expect(f).To(ExecuteSuccessfully())
 			expectDesiredCRB(f, "cluster-admin")
 			expectHelmOwnership(f)
+			expectKeepPolicy(f)
 			expectInternalDecision(f, "cluster-admin", false)
 		})
 	})

--- a/modules/040-control-plane-manager/template_tests/template_test.go
+++ b/modules/040-control-plane-manager/template_tests/template_test.go
@@ -1311,6 +1311,8 @@ apiserver:
 				crb := f.KubernetesResource("ClusterRoleBinding", "", "kubeadm:cluster-admins")
 				Expect(crb.Exists()).To(BeTrue())
 				Expect(crb.Field("roleRef.name").String()).To(Equal("cluster-admin"))
+				// keep policy must always be present so a future hook-only migration cannot let Helm prune it.
+				Expect(crb.Field(`metadata.annotations.helm\.sh/resource-policy`).String()).To(Equal("keep"))
 
 				sup := f.KubernetesResource("ClusterRoleBinding", "", "d8:control-plane-manager:kubeadm-cluster-admins-supplement")
 				Expect(sup.Exists()).To(BeFalse())

--- a/modules/040-control-plane-manager/templates/rbac-for-us.yaml
+++ b/modules/040-control-plane-manager/templates/rbac-for-us.yaml
@@ -293,6 +293,11 @@ subjects:
   Main kubeadm:cluster-admins binding: target ClusterRole comes from the hook (see top of file).
   Helm SSA cannot mutate roleRef (immutable), so the actual Delete+Create on role flip is done
   by reconcile_kubeadm_cluster_admins_binding hook before Helm runs; Helm here only adopts.
+
+  helm.sh/resource-policy: keep guarantees Helm never prunes this binding. It guards the future
+  migration to hook-only ownership: once this block is dropped from the template, Helm leaves the
+  live object in place (instead of deleting it), so there is no window where kubeadm:cluster-admins
+  has no binding and admin.conf loses root access. The hook remains the single source of truth.
 */}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -300,6 +305,8 @@ kind: ClusterRoleBinding
 metadata:
   name: kubeadm:cluster-admins
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+  annotations:
+    helm.sh/resource-policy: keep
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
## Description
Add `helm.sh/resource-policy: keep` to the `kubeadm:cluster-admins` ClusterRoleBinding in both the Helm template and the reconcile hook (create/patch paths).

## Why do we need it, and what problem does it solve?
Prepares the future hook-only ownership migration: when this binding is dropped from the template, Helm must not prune it. Otherwise there is a window with no binding and admin.conf loses root access.

## Why do we need it in the patch release (if we do)?
Not necessarily.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: control-plane-manager
type: chore
summary: Mark kubeadm:cluster-admins ClusterRoleBinding with helm.sh/resource-policy keep so Helm never prunes it.
impact_level: low