### PR TITLE
[deckhouse] fix stale application conditions during update over a failed version

### DIFF
--- a/deckhouse-controller/pkg/controller/packages/application/status/rules.go
+++ b/deckhouse-controller/pkg/controller/packages/application/status/rules.go
@@ -40,7 +40,8 @@ const (
 	// /Managed can stay True while UpdateInstalled reports a problem with the new
 	// version. False means the update is blocked or has failed.
 	// Possible reasons: Pending, DownloadFailed, LoadFromFilesystemFailed,
-	// SettingsInvalid, HookInitializationFailed, HookFailed, ManifestsApplyFailed.
+	// SettingsInvalid, HookInitializationFailed, HookFailed, ManifestsApplyFailed,
+	// ApplyingManifests (the new version's manifests are still being applied).
 	ConditionUpdateInstalled = "UpdateInstalled"
 
 	// ConditionReady reflects user-facing readiness of the application.
@@ -51,7 +52,8 @@ const (
 	// not affect Ready because the running version's settings are unchanged.
 	// Possible reasons: Pending, RequirementsUnmet, DownloadFailed,
 	// LoadFromFilesystemFailed, SettingsInvalid, HookInitializationFailed,
-	// HookFailed, ManifestsApplyFailed, Ready (when True).
+	// HookFailed, ManifestsApplyFailed, ApplyingManifests (mid-apply over a
+	// non-serving previous version), Ready (when True).
 	ConditionReady = "Ready"
 
 	// ConditionScaled reflects the runtime scaling state of the application.
@@ -70,7 +72,8 @@ const (
 	// is disabled under the running app — managing is meaningless until the
 	// dependency returns, but the cause is external rather than a controller failure.
 	// Possible reasons: RequirementsUnmet, DownloadFailed, HookInitializationFailed,
-	// HookFailed, ManifestsApplyFailed, Managed (when True).
+	// HookFailed, ManifestsApplyFailed, ApplyingManifests (mid-apply over a
+	// non-managed previous version), Managed (when True).
 	ConditionManaged = "Managed"
 
 	// ConditionConfigurationApplied reflects whether the desired configuration —
@@ -81,6 +84,7 @@ const (
 	// also forces Unknown — the desired configuration is no longer being maintained.
 	// Possible reasons: RequirementsUnmet, DownloadFailed, SettingsInvalid,
 	// HookInitializationFailed, HookFailed, ManifestsApplyFailed,
+	// ApplyingManifests (the new version's manifests are still being applied),
 	// ConfigurationApplied (when True).
 	ConditionConfigurationApplied = "ConfigurationApplied"
 )
@@ -240,6 +244,24 @@ func isApplyingManifests(state condmap.State, cond string) bool {
 	return reason == string(intstatus.ConditionReasonApplyingManifests)
 }
 
+// applyingProgress refreshes a mapped condition during an update's manifest-apply
+// window. While manifests apply, the True gate is unmet and the update mappers
+// return empty, leaving the condition as-is — right when it is already True (the
+// previous version still serves, don't flap it), wrong when it carries a stale
+// failure from an earlier attempt. In that case emit False/ApplyingManifests so it
+// tracks the apply, matching summaryUpdating. Returns false outside the window or
+// when the condition is already True.
+func applyingProgress(state condmap.State, ext string) (metav1.Condition, bool) {
+	if !isApplyingManifests(state, intManifestsApplied) {
+		return metav1.Condition{}, false
+	}
+	if state.ExtEqual(ext, metav1.ConditionTrue) {
+		return metav1.Condition{}, false
+	}
+
+	return emit(state, ext, metav1.ConditionFalse, intManifestsApplied), true
+}
+
 // pipelineBlocker returns the highest-priority blocker for an install or
 // update flow: Pending=True wins over any False condition in chain.
 func pipelineBlocker(state condmap.State, chain []string) (string, bool) {
@@ -326,6 +348,11 @@ func mapUpdateInstalled(state condmap.State) metav1.Condition {
 	if state.IntEqual(intManifestsApplied, metav1.ConditionTrue) {
 		return emit(state, ConditionUpdateInstalled, metav1.ConditionTrue, intManifestsApplied)
 	}
+	if updating {
+		if cond, ok := applyingProgress(state, ConditionUpdateInstalled); ok {
+			return cond
+		}
+	}
 
 	return metav1.Condition{}
 }
@@ -342,10 +369,12 @@ func mapReady(state condmap.State) metav1.Condition {
 		return emit(state, ConditionReady, metav1.ConditionFalse, intRequirementsMet)
 	}
 
+	ph := phaseOf(state)
+
 	var blocker string
 	var ok bool
 
-	switch phaseOf(state) {
+	switch ph {
 	case phaseInstall:
 		blocker, ok = pipelineBlocker(state, installPipeline)
 	case phaseUpdate:
@@ -359,6 +388,11 @@ func mapReady(state condmap.State) metav1.Condition {
 	}
 	if state.IntEqual(intScaled, metav1.ConditionTrue) {
 		return emit(state, ConditionReady, metav1.ConditionTrue, intScaled)
+	}
+	if ph == phaseUpdate {
+		if cond, ok := applyingProgress(state, ConditionReady); ok {
+			return cond
+		}
 	}
 
 	return metav1.Condition{}
@@ -429,8 +463,10 @@ func mapManaged(state condmap.State) metav1.Condition {
 		return emit(state, ConditionManaged, metav1.ConditionUnknown, intRequirementsMet)
 	}
 
+	ph := phaseOf(state)
+
 	chain := lateStage
-	switch phaseOf(state) {
+	switch ph {
 	case phaseInstall:
 		// why: during the first install a HookInitializationFailed means we
 		// never started managing the workload — there is nothing to "stop
@@ -454,6 +490,11 @@ func mapManaged(state condmap.State) metav1.Condition {
 	if state.AllIntEqual(metav1.ConditionTrue, intLoaded, intScaled, intHooksProcessed, intManifestsApplied) {
 		return emit(state, ConditionManaged, metav1.ConditionTrue, intLoaded)
 	}
+	if ph == phaseUpdate {
+		if cond, ok := applyingProgress(state, ConditionManaged); ok {
+			return cond
+		}
+	}
 
 	return metav1.Condition{}
 }
@@ -469,7 +510,9 @@ func mapConfigurationApplied(state condmap.State) metav1.Condition {
 		return emit(state, ConditionConfigurationApplied, metav1.ConditionUnknown, intRequirementsMet)
 	}
 
-	switch phaseOf(state) {
+	ph := phaseOf(state)
+
+	switch ph {
 	case phaseInstall:
 		if cond, ok := firstFalse(state, configPipeline); ok {
 			return emit(state, ConditionConfigurationApplied, metav1.ConditionFalse, cond)
@@ -489,6 +532,11 @@ func mapConfigurationApplied(state condmap.State) metav1.Condition {
 
 	if state.AllIntEqual(metav1.ConditionTrue, intConfigured, intHooksProcessed, intManifestsApplied) {
 		return emit(state, ConditionConfigurationApplied, metav1.ConditionTrue, intConfigured)
+	}
+	if ph == phaseUpdate {
+		if cond, ok := applyingProgress(state, ConditionConfigurationApplied); ok {
+			return cond
+		}
 	}
 
 	return metav1.Condition{}

--- a/deckhouse-controller/pkg/controller/packages/application/status/rules_test.go
+++ b/deckhouse-controller/pkg/controller/packages/application/status/rules_test.go
@@ -242,14 +242,16 @@ func TestUpdateInstalledRule(t *testing.T) {
 			},
 		},
 		{
-			name: "absent while manifests are still applying",
+			name: "applying over a failed update refreshes the stale failure",
 			opts: []mappingOption{
 				withExternalCondition(ConditionInstalled, metav1.ConditionTrue, "Installed"),
+				// Previous update failed at manifests; the new version is now re-applying.
+				withExternalCondition(ConditionUpdateInstalled, metav1.ConditionFalse, "ManifestsApplyFailed"),
 				withInternalCondition(string(intstatus.ConditionManifestsApplied), metav1.ConditionFalse, string(intstatus.ConditionReasonApplyingManifests)),
 				withVersionChanged(),
 			},
 			expected: map[string]*expectedCondition{
-				ConditionUpdateInstalled: nil,
+				ConditionUpdateInstalled: {status: metav1.ConditionFalse, reason: string(intstatus.ConditionReasonApplyingManifests)},
 			},
 		},
 	}
@@ -296,6 +298,32 @@ func TestReadyRule(t *testing.T) {
 			},
 			expected: map[string]*expectedCondition{
 				ConditionReady: {status: metav1.ConditionTrue, reason: ConditionReady},
+			},
+		},
+		{
+			name: "applying over a failed update refreshes the stale failure",
+			opts: []mappingOption{
+				withExternalCondition(ConditionInstalled, metav1.ConditionTrue, "Installed"),
+				withExternalCondition(ConditionReady, metav1.ConditionFalse, "ManifestsApplyFailed"),
+				withInternalCondition(string(intstatus.ConditionManifestsApplied), metav1.ConditionFalse, string(intstatus.ConditionReasonApplyingManifests)),
+				withVersionChanged(),
+			},
+			expected: map[string]*expectedCondition{
+				ConditionReady: {status: metav1.ConditionFalse, reason: string(intstatus.ConditionReasonApplyingManifests)},
+			},
+		},
+		{
+			name: "applying does not flap a healthy update still serving",
+			opts: []mappingOption{
+				// Healthy update: the previous version still serves (Ready=True),
+				// so the apply window must leave it untouched, not flap it to False.
+				withExternalCondition(ConditionInstalled, metav1.ConditionTrue, "Installed"),
+				withExternalCondition(ConditionReady, metav1.ConditionTrue, ConditionReady),
+				withInternalCondition(string(intstatus.ConditionManifestsApplied), metav1.ConditionFalse, string(intstatus.ConditionReasonApplyingManifests)),
+				withVersionChanged(),
+			},
+			expected: map[string]*expectedCondition{
+				ConditionReady: nil,
 			},
 		},
 	}
@@ -455,6 +483,18 @@ func TestManagedRule(t *testing.T) {
 				ConditionManaged: {status: metav1.ConditionTrue, reason: ConditionManaged},
 			},
 		},
+		{
+			name: "applying over a failed update refreshes the stale failure",
+			opts: []mappingOption{
+				withExternalCondition(ConditionInstalled, metav1.ConditionTrue, "Installed"),
+				withExternalCondition(ConditionManaged, metav1.ConditionFalse, "ManifestsApplyFailed"),
+				withInternalCondition(string(intstatus.ConditionManifestsApplied), metav1.ConditionFalse, string(intstatus.ConditionReasonApplyingManifests)),
+				withVersionChanged(),
+			},
+			expected: map[string]*expectedCondition{
+				ConditionManaged: {status: metav1.ConditionFalse, reason: string(intstatus.ConditionReasonApplyingManifests)},
+			},
+		},
 	}
 
 	runTestCases(t, cases)
@@ -504,6 +544,19 @@ func TestConfigurationAppliedRule(t *testing.T) {
 			},
 			expected: map[string]*expectedCondition{
 				ConditionConfigurationApplied: {status: metav1.ConditionFalse, reason: "ManifestsApplyFailed"},
+			},
+		},
+		{
+			name: "applying over a failed update refreshes the stale failure",
+			opts: []mappingOption{
+				withExternalCondition(ConditionInstalled, metav1.ConditionTrue, "Installed"),
+				withExternalCondition(ConditionConfigurationApplied, metav1.ConditionFalse, "ManifestsApplyFailed"),
+				withInternalCondition(string(intstatus.ConditionConfigured), metav1.ConditionTrue, "SettingsOK"),
+				withInternalCondition(string(intstatus.ConditionManifestsApplied), metav1.ConditionFalse, string(intstatus.ConditionReasonApplyingManifests)),
+				withVersionChanged(),
+			},
+			expected: map[string]*expectedCondition{
+				ConditionConfigurationApplied: {status: metav1.ConditionFalse, reason: string(intstatus.ConditionReasonApplyingManifests)},
 			},
 		},
 	}


### PR DESCRIPTION
## Description

Application status conditions are write-only: the mapper keeps the previous value when it returns empty. During an update, while the new version's manifests apply (`ManifestsApplied=False/ApplyingManifests`), the mapper skips that transient state to avoid flapping — so `Ready`/`Managed`/`UpdateInstalled`/`ConfigurationApplied` kept a stale failure from a previously failed version for the whole apply window.

This refreshes them to `False/ApplyingManifests` during the update apply window when they are not already `True` (a healthy `True` is left untouched — no flapping), matching `summary=Updating`. No impact on critical components.

## Why do we need it, and what problem does it solve?

Conditions are not updated on a revert/recovery update: working → broken (manifests fail) → update again leaves the conditions stuck at `False/ManifestsApplyFailed` while the new version is simply applying, contradicting `summary=Updating` and misleading users.

### Manual testing

Dev cluster, image `pr20735`, package `test` (`v0.0.3`/`v0.0.5` fail at manifests apply — they deploy a `Deployment` that never becomes Ready, so nelm tracking times out → `ManifestsApplyFailed`).

1. Application on a working version (`v0.0.8`) → `Ready`.

2. Update to a manifests-failing version (`v0.0.5`) — the failed update:

```
summary=Failed
  Installed=True/Installed
  Ready=False/ManifestsApplyFailed
  Scaled=False/ManifestsApplyFailed
  ConfigurationApplied=False/ManifestsApplyFailed
  UpdateInstalled=False/ManifestsApplyFailed
  Managed=False/ManifestsApplyFailed
```

3. Update to a recovery version (`v0.0.6`) — during the apply window the stale failure is replaced (the fix):

```
summary=Updating
  Installed=True/Installed
  Ready=False/ApplyingManifests
  ConfigurationApplied=False/ApplyingManifests
  UpdateInstalled=False/ApplyingManifests
  Managed=False/ApplyingManifests
```

4. After the apply completes:

```
version=0.0.6  summary=Ready
  Installed=True/Installed
  Ready=True/Ready
  Scaled=True/Scaled
  ConfigurationApplied=True/ConfigurationApplied
  UpdateInstalled=True/UpdateInstalled
  Managed=True/Managed
```

Before the fix, step 3 left the conditions at `False/ManifestsApplyFailed` for the whole apply window — the reported bug. `ApplyingManifests` as a `Ready`/`Managed`/`UpdateInstalled`/`ConfigurationApplied` reason is only producible by this change, which confirms the fixed binary was exercised.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Fix stale application conditions during update over a failed version
impact_level: low
```

