### PR TITLE
[istio] Wrong team in module description

### DIFF
--- a/modules/110-istio/module.yaml
+++ b/modules/110-istio/module.yaml
@@ -1,7 +1,6 @@
 name: istio
 stage: General Availability
 subsystems:
-  - infrastructure
   - networking
 namespace: d8-istio
 descriptions:


### PR DESCRIPTION
## Description
The module description contains an incorrectly added team

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: chore
summary: Wrong team in module description
impact_level: low
```
