### PR TITLE
[control-plane-manager] Add monitoring for etcd arbiter

### DIFF
--- a/modules/040-control-plane-manager/hooks/handle_etcd_arbiter_node_test.go
+++ b/modules/040-control-plane-manager/hooks/handle_etcd_arbiter_node_test.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+
+User-stories:
+1. Hook must discover nodes with label node.deckhouse.io/etcd-arbiter and set controlPlaneManager.internal.hasEtcdArbiterNode to true if exactly one such node exists, else — to false.
+2. If more than one node has label node.deckhouse.io/etcd-arbiter — hook must fail.
+
+*/
+
+package hooks
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("Modules :: control-plane-manager :: hooks :: handle_etcd_arbiter_node ::", func() {
+	const (
+		initValuesString       = `{"controlPlaneManager":{"internal":{}},"global":{"enabledModules":[]}}`
+		initConfigValuesString = `{}`
+	)
+
+	const (
+		stateFirstEtcdArbiterNode = `
+apiVersion: v1
+kind: Node
+metadata:
+  name: arbiter-0
+  labels:
+    node.deckhouse.io/etcd-arbiter: ""`
+
+		stateSecondEtcdArbiterNode = `
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: arbiter-1
+  labels:
+    node.deckhouse.io/etcd-arbiter: ""`
+
+		stateThirdEtcdArbiterNode = `
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: arbiter-2
+  labels:
+    node.deckhouse.io/etcd-arbiter: ""`
+	)
+
+	f := HookExecutionConfigInit(initValuesString, initConfigValuesString)
+
+	Context("Empty cluster", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext(), f.KubeStateSet(``))
+			f.RunHook()
+		})
+
+		It("Must be executed successfully", func() {
+			Expect(f).To(ExecuteSuccessfully())
+		})
+
+		It("`controlPlaneManager.internal.hasEtcdArbiterNode` must be false", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.BindingContexts.Array()).ShouldNot(BeEmpty())
+
+			Expect(f.ValuesGet("controlPlaneManager.internal.hasEtcdArbiterNode").Bool()).To(BeFalse())
+		})
+	})
+
+	Context("One etcd arbiter node in cluster", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext(), f.KubeStateSet(stateFirstEtcdArbiterNode))
+			f.RunHook()
+		})
+
+		It("`controlPlaneManager.internal.hasEtcdArbiterNode` must be true", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.BindingContexts.Array()).ShouldNot(BeEmpty())
+
+			Expect(f.ValuesGet("controlPlaneManager.internal.hasEtcdArbiterNode").Bool()).To(BeTrue())
+		})
+	})
+
+	Context("More than one etcd arbiter node in cluster", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext(), f.KubeStateSet(stateFirstEtcdArbiterNode+stateSecondEtcdArbiterNode))
+			f.RunHook()
+		})
+
+		It("Must fail", func() {
+			Expect(f).NotTo(ExecuteSuccessfully())
+		})
+	})
+
+	Context("More than two etcd arbiter nodes in cluster", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext(), f.KubeStateSet(stateFirstEtcdArbiterNode+stateSecondEtcdArbiterNode+stateThirdEtcdArbiterNode))
+			f.RunHook()
+		})
+
+		It("Must fail", func() {
+			Expect(f).NotTo(ExecuteSuccessfully())
+		})
+	})
+})

--- a/modules/040-control-plane-manager/template_tests/template_test.go
+++ b/modules/040-control-plane-manager/template_tests/template_test.go
@@ -406,12 +406,43 @@ apiserver:
 				Expect(f.KubernetesGlobalResource("ClusterRole", "d8:control-plane-manager:scraper").Exists()).To(BeTrue())
 				Expect(f.KubernetesGlobalResource("ClusterRoleBinding", "d8:control-plane-manager:scraper").Exists()).To(BeTrue())
 				Expect(f.KubernetesGlobalResource("ClusterRoleBinding", "d8:control-plane-manager:control-plane-proxy:rbac-proxy").Exists()).To(BeTrue())
+
+				// Don't render etcd-arbiter as it's disabled by default
+				Expect(f.KubernetesResource("DaemonSet", "kube-system", "control-plane-proxy-etcd-arbiter").Exists()).To(BeFalse())
+				Expect(f.KubernetesResource("Service", "kube-system", "control-plane-proxy-etcd-arbiter").Exists()).To(BeFalse())
+				Expect(f.KubernetesResource("ServiceMonitor", "d8-monitoring", "control-plane-proxy-etcd-arbiter").Exists()).To(BeFalse())
+			})
+		})
+
+		Context("With etcd arbiter node and prometheus enabled", func() {
+			BeforeEach(func() {
+				f.ValuesSetFromYaml("global.enabledModules", `["prometheus"]`)
+				f.ValuesSet("controlPlaneManager.internal.hasEtcdArbiterNode", true)
+				f.HelmRender()
+			})
+
+			It("should render control-plane-proxy and control-plane-proxy-etcd-arbiter", func() {
+				Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+				Expect(f.KubernetesResource("DaemonSet", "kube-system", "control-plane-proxy").Exists()).To(BeTrue())
+				Expect(f.KubernetesResource("DaemonSet", "kube-system", "control-plane-proxy-etcd-arbiter").Exists()).To(BeTrue())
+				Expect(f.KubernetesResource("Service", "kube-system", "control-plane-proxy").Exists()).To(BeTrue())
+				Expect(f.KubernetesResource("Service", "kube-system", "control-plane-proxy-etcd-arbiter").Exists()).To(BeTrue())
+				Expect(f.KubernetesResource("ServiceAccount", "kube-system", "d8-control-plane-manager-control-plane-proxy").Exists()).To(BeTrue())
+				Expect(f.KubernetesResource("ServiceMonitor", "d8-monitoring", "control-plane-proxy").Exists()).To(BeTrue())
+				Expect(f.KubernetesResource("ServiceMonitor", "d8-monitoring", "control-plane-proxy-etcd-arbiter").Exists()).To(BeTrue())
+				Expect(f.KubernetesResource("ServiceMonitor", "d8-monitoring", "kube-apiserver").Exists()).To(BeTrue())
+
+				Expect(f.KubernetesGlobalResource("ClusterRole", "d8:control-plane-manager:scraper").Exists()).To(BeTrue())
+				Expect(f.KubernetesGlobalResource("ClusterRoleBinding", "d8:control-plane-manager:scraper").Exists()).To(BeTrue())
+				Expect(f.KubernetesGlobalResource("ClusterRoleBinding", "d8:control-plane-manager:control-plane-proxy:rbac-proxy").Exists()).To(BeTrue())
 			})
 		})
 
 		Context("Prometheus module disabled", func() {
 			BeforeEach(func() {
 				f.ValuesSetFromYaml("global.enabledModules", `[]`)
+				f.ValuesSet("controlPlaneManager.internal.hasEtcdArbiterNode", true)
 				f.HelmRender()
 			})
 
@@ -421,6 +452,10 @@ apiserver:
 				Expect(f.KubernetesResource("DaemonSet", "kube-system", "control-plane-proxy").Exists()).To(BeFalse())
 				Expect(f.KubernetesResource("ServiceMonitor", "d8-monitoring", "kube-apiserver").Exists()).To(BeFalse())
 				Expect(f.KubernetesGlobalResource("ClusterRole", "d8:control-plane-manager:scraper").Exists()).To(BeFalse())
+
+				Expect(f.KubernetesResource("DaemonSet", "kube-system", "control-plane-proxy-etcd-arbiter").Exists()).To(BeFalse())
+				Expect(f.KubernetesResource("Service", "kube-system", "control-plane-proxy-etcd-arbiter").Exists()).To(BeFalse())
+				Expect(f.KubernetesResource("ServiceMonitor", "d8-monitoring", "control-plane-proxy-etcd-arbiter").Exists()).To(BeFalse())
 			})
 		})
 	})

--- a/modules/040-control-plane-manager/templates/control-plane-proxy-service-monitor.yaml
+++ b/modules/040-control-plane-manager/templates/control-plane-proxy-service-monitor.yaml
@@ -8,7 +8,7 @@
 {{- if ne $profile "main" }}
   {{- $appLabel = printf "%s-%s" $appLabel $profile }}
 {{- end }}
-{{- if (.Values.global.enabledModules | has "prometheus") }}
+{{- if ($.Values.global.enabledModules | has "prometheus") }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/modules/040-control-plane-manager/templates/control-plane-proxy-service-monitor.yaml
+++ b/modules/040-control-plane-manager/templates/control-plane-proxy-service-monitor.yaml
@@ -1,3 +1,4 @@
+{{- if (.Values.global.enabledModules | has "prometheus") }}
 {{- $profiles := list "main" }}
 {{- if .Values.controlPlaneManager.internal.hasEtcdArbiterNode }}
   {{- $profiles = append $profiles "etcd-arbiter" }}
@@ -8,7 +9,6 @@
 {{- if ne $profile "main" }}
   {{- $appLabel = printf "%s-%s" $appLabel $profile }}
 {{- end }}
-{{- if ($.Values.global.enabledModules | has "prometheus") }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/modules/040-control-plane-manager/templates/control-plane-proxy-service-monitor.yaml
+++ b/modules/040-control-plane-manager/templates/control-plane-proxy-service-monitor.yaml
@@ -1,18 +1,29 @@
+{{- $profiles := list "main" }}
+{{- if .Values.controlPlaneManager.internal.hasEtcdArbiterNode }}
+  {{- $profiles = append $profiles "etcd-arbiter" }}
+{{- end }}
+
+{{- range $profile := $profiles }}
+{{- $appLabel := "control-plane-proxy" }}
+{{- if ne $profile "main" }}
+  {{- $appLabel = printf "%s-%s" $appLabel $profile }}
+{{- end }}
 {{- if (.Values.global.enabledModules | has "prometheus") }}
+---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: control-plane-proxy
+  name: control-plane-proxy{{- if ne $profile "main" }}-{{ $profile }}{{- end }}
   namespace: d8-monitoring
-  {{- include "helm_lib_module_labels" (list . (dict "prometheus" "main")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list $ (dict "prometheus" "main")) | nindent 2 }}
 spec:
   selector:
     matchLabels:
-      app: control-plane-proxy
+      app: {{ $appLabel }}
       heritage: deckhouse
   namespaceSelector:
     matchNames:
-    - kube-system
+    - d8-monitoring
   endpoints:
   - scheme: https
     port: https-metrics
@@ -34,6 +45,7 @@ spec:
     - sourceLabels: [__meta_kubernetes_endpointslice_endpoint_conditions_ready]
       regex: "true"
       action: keep
+  {{- if eq $profile "main" }}
   - scheme: https
     port: https-metrics
     path: /scheduler/metrics
@@ -71,4 +83,6 @@ spec:
     - sourceLabels: [__meta_kubernetes_endpointslice_endpoint_conditions_ready]
       regex: "true"
       action: keep
+  {{- end }}
+{{- end }}
 {{- end }}

--- a/modules/040-control-plane-manager/templates/control-plane-proxy-service-monitor.yaml
+++ b/modules/040-control-plane-manager/templates/control-plane-proxy-service-monitor.yaml
@@ -23,7 +23,7 @@ spec:
       heritage: deckhouse
   namespaceSelector:
     matchNames:
-    - d8-monitoring
+    - kube-system
   endpoints:
   - scheme: https
     port: https-metrics

--- a/modules/040-control-plane-manager/templates/control-plane-proxy/daemonset.yaml
+++ b/modules/040-control-plane-manager/templates/control-plane-proxy/daemonset.yaml
@@ -3,27 +3,37 @@ cpu: 10m
 memory: 15Mi
 {{- end }}
 
+{{- $profiles := list "main" }}
+{{- if .Values.controlPlaneManager.internal.hasEtcdArbiterNode }}
+  {{- $profiles = append $profiles "etcd-arbiter" }}
+{{- end }}
+
+{{- range $profile := $profiles }}
+  {{- $appLabel := "control-plane-proxy" }}
+  {{- if ne $profile "main" }}
+    {{- $appLabel = printf "%s-%s" $appLabel $profile }}
+  {{- end }}
 {{- if (.Values.global.enabledModules | has "prometheus") }}
-{{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler") }}
+{{- if ($.Values.global.enabledModules | has "vertical-pod-autoscaler") }}
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
-  name: control-plane-proxy
-  namespace: kube-system
-  {{- include "helm_lib_module_labels" (list . (dict "app" "control-plane-proxy")) | nindent 2 }}
+  name: control-plane-proxy{{- if ne $profile "main" }}-{{ $profile }}{{- end }}
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list $ (dict "app" $appLabel)) | nindent 2 }}
 spec:
   targetRef:
     apiVersion: "apps/v1"
     kind: DaemonSet
-    name: control-plane-proxy
+    name: control-plane-proxy{{- if ne $profile "main" }}-{{ $profile }}{{- end }}
   updatePolicy:
     updateMode: "InPlaceOrRecreate"
   resourcePolicy:
     containerPolicies:
     - containerName: kube-rbac-proxy
       minAllowed:
-        {{- include "control_plane_proxy_resources" . | nindent 8 }}
+        {{- include "control_plane_proxy_resources" $ | nindent 8 }}
       maxAllowed:
         cpu: 20m
         memory: 30Mi
@@ -32,31 +42,36 @@ spec:
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: control-plane-proxy
-  namespace: kube-system
-  {{- include "helm_lib_module_labels" (list . (dict "app" "control-plane-proxy")) | nindent 2 }}
+  name: control-plane-proxy{{- if ne $profile "main" }}-{{ $profile }}{{- end }}
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list $ (dict "app" $appLabel)) | nindent 2 }}
 spec:
   selector:
     matchLabels:
-      app: control-plane-proxy
+      app: {{ $appLabel }}
   template:
     metadata:
       labels:
-        app: control-plane-proxy
+        app: {{ $appLabel }}
     spec:
-      serviceAccountName: d8-control-plane-manager-control-plane-proxy
+      serviceAccountName: control-plane-proxy
       automountServiceAccountToken: true
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
-      {{- include "helm_lib_priority_class" (tuple . "cluster-medium") | nindent 6 }}
-      {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
-      {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
+      {{- include "helm_lib_priority_class" (tuple $ "cluster-medium") | nindent 6 }}
+      {{- if eq $profile "main" }}
+      {{- include "helm_lib_node_selector" (tuple $ "master") | nindent 6 }}
+      {{- else }}
+      nodeSelector:
+        node.deckhouse.io/etcd-arbiter: ""
+      {{- end }}
+      {{- include "helm_lib_tolerations" (tuple $ "any-node") | nindent 6 }}
       imagePullSecrets:
       - name: deckhouse-registry
       containers:
       - name: kube-rbac-proxy
         {{- include "helm_lib_module_container_security_context_pss_restricted_flexible" dict | nindent 8 }}
-        image: {{ include "helm_lib_module_common_image" (list . "kubeRbacProxy") }}
+        image: {{ include "helm_lib_module_common_image" (list $ "kubeRbacProxy") }}
         args:
           - "--secure-listen-address=$(KUBE_RBAC_PROXY_LISTEN_ADDRESS):4209"
           - "--v=2"
@@ -84,12 +99,15 @@ spec:
         - name: KUBE_RBAC_PROXY_CONFIG
           value: |
             upstreams:
+            {{- if eq $profile "main" }}
             - upstream: https://127.0.0.1:10257/metrics
               upstreamInsecureSkipVerify: true
               path: /controller-manager/metrics
             - upstream: https://127.0.0.1:10259/metrics
               upstreamInsecureSkipVerify: true
               path: /scheduler/metrics
+            {{- end }}
             - upstream: http://127.0.0.1:2381/metrics
               path: /etcd/metrics
+{{- end }}
 {{- end }}

--- a/modules/040-control-plane-manager/templates/control-plane-proxy/daemonset.yaml
+++ b/modules/040-control-plane-manager/templates/control-plane-proxy/daemonset.yaml
@@ -55,7 +55,7 @@ spec:
       labels:
         app: {{ $appLabel }}
     spec:
-      serviceAccountName: control-plane-proxy
+      serviceAccountName: d8-control-plane-manager-control-plane-proxy
       automountServiceAccountToken: true
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/modules/040-control-plane-manager/templates/control-plane-proxy/daemonset.yaml
+++ b/modules/040-control-plane-manager/templates/control-plane-proxy/daemonset.yaml
@@ -1,8 +1,10 @@
+
 {{- define "control_plane_proxy_resources" }}
 cpu: 10m
 memory: 15Mi
 {{- end }}
 
+{{- if (.Values.global.enabledModules | has "prometheus") }}
 {{- $profiles := list "main" }}
 {{- if .Values.controlPlaneManager.internal.hasEtcdArbiterNode }}
   {{- $profiles = append $profiles "etcd-arbiter" }}
@@ -13,14 +15,13 @@ memory: 15Mi
   {{- if ne $profile "main" }}
     {{- $appLabel = printf "%s-%s" $appLabel $profile }}
   {{- end }}
-{{- if ($.Values.global.enabledModules | has "prometheus") }}
 {{- if ($.Values.global.enabledModules | has "vertical-pod-autoscaler") }}
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: control-plane-proxy{{- if ne $profile "main" }}-{{ $profile }}{{- end }}
-  namespace: d8-monitoring
+  namespace: kube-system
   {{- include "helm_lib_module_labels" (list $ (dict "app" $appLabel)) | nindent 2 }}
 spec:
   targetRef:
@@ -43,7 +44,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: control-plane-proxy{{- if ne $profile "main" }}-{{ $profile }}{{- end }}
-  namespace: d8-monitoring
+  namespace: kube-system
   {{- include "helm_lib_module_labels" (list $ (dict "app" $appLabel)) | nindent 2 }}
 spec:
   selector:

--- a/modules/040-control-plane-manager/templates/control-plane-proxy/daemonset.yaml
+++ b/modules/040-control-plane-manager/templates/control-plane-proxy/daemonset.yaml
@@ -13,7 +13,7 @@ memory: 15Mi
   {{- if ne $profile "main" }}
     {{- $appLabel = printf "%s-%s" $appLabel $profile }}
   {{- end }}
-{{- if (.Values.global.enabledModules | has "prometheus") }}
+{{- if ($.Values.global.enabledModules | has "prometheus") }}
 {{- if ($.Values.global.enabledModules | has "vertical-pod-autoscaler") }}
 ---
 apiVersion: autoscaling.k8s.io/v1

--- a/modules/040-control-plane-manager/templates/control-plane-proxy/service.yaml
+++ b/modules/040-control-plane-manager/templates/control-plane-proxy/service.yaml
@@ -1,3 +1,4 @@
+{{- if (.Values.global.enabledModules | has "prometheus") }}
 {{- $profiles := list "main" }}
 {{- if .Values.controlPlaneManager.internal.hasEtcdArbiterNode }}
   {{- $profiles = append $profiles "etcd-arbiter" }}
@@ -8,13 +9,12 @@
 {{- if ne $profile "main" }}
   {{- $appLabel = printf "%s-%s" $appLabel $profile }}
 {{- end }}
-{{- if ($.Values.global.enabledModules | has "prometheus") }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: {{ $appLabel }}
-  namespace: d8-monitoring
+  namespace: kube-system
   {{- include "helm_lib_module_labels" (list $ (dict "app" $appLabel)) | nindent 2 }}
 spec:
   selector:

--- a/modules/040-control-plane-manager/templates/control-plane-proxy/service.yaml
+++ b/modules/040-control-plane-manager/templates/control-plane-proxy/service.yaml
@@ -1,5 +1,5 @@
 {{- $profiles := list "main" }}
-{{- if .Values.monitoringKubernetesControlPlane.internal.hasEtcdArbiterNode }}
+{{- if .Values.controlPlaneManager.internal.hasEtcdArbiterNode }}
   {{- $profiles = append $profiles "etcd-arbiter" }}
 {{- end }}
 
@@ -8,7 +8,7 @@
 {{- if ne $profile "main" }}
   {{- $appLabel = printf "%s-%s" $appLabel $profile }}
 {{- end }}
-{{- if (.Values.global.enabledModules | has "prometheus") }}
+{{- if ($.Values.global.enabledModules | has "prometheus") }}
 ---
 apiVersion: v1
 kind: Service

--- a/modules/040-control-plane-manager/templates/control-plane-proxy/service.yaml
+++ b/modules/040-control-plane-manager/templates/control-plane-proxy/service.yaml
@@ -1,17 +1,28 @@
+{{- $profiles := list "main" }}
+{{- if .Values.monitoringKubernetesControlPlane.internal.hasEtcdArbiterNode }}
+  {{- $profiles = append $profiles "etcd-arbiter" }}
+{{- end }}
+
+{{- range $profile := $profiles }}
+{{- $appLabel := "control-plane-proxy" }}
+{{- if ne $profile "main" }}
+  {{- $appLabel = printf "%s-%s" $appLabel $profile }}
+{{- end }}
 {{- if (.Values.global.enabledModules | has "prometheus") }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: control-plane-proxy
-  namespace: kube-system
-  {{- include "helm_lib_module_labels" (list . (dict "app" "control-plane-proxy")) | nindent 2 }}
+  name: {{ $appLabel }}
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list $ (dict "app" $appLabel)) | nindent 2 }}
 spec:
   selector:
-    app: control-plane-proxy
+    app: {{ $appLabel }}
   ports:
   - name: https-metrics
     port: 8080
     protocol: TCP
     targetPort: https-metrics
+{{- end }}
 {{- end }}


### PR DESCRIPTION
## Description
Add separate daemonset for `control-plane-proxy-etcd-arbiter` for arbiter etcd (as well as service and servicemonitor), and add test for `handle_etcd_arbiter_node.go`


## Why do we need it, and what problem does it solve?
Metrics were not collected from etcd arbiter and dashboards couldn't show the arbiter info.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: fix
summary: Add metrics proxy for etcd on arbiter node.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
