### PR TITLE
feat(dhctl): add forceUseSSHAgent support to SSHConfig

### DIFF
--- a/candi/openapi/dhctl/ssh_configuration.yaml
+++ b/candi/openapi/dhctl/ssh_configuration.yaml
@@ -9,6 +9,7 @@ apiVersions:
     anyOf:
       - required: [apiVersion, kind, sshUser, sshAgentPrivateKeys]
       - required: [apiVersion, kind, sshUser, sudoPassword]
+      - required: [apiVersion, kind, sshUser, forceUseSSHAgent]
     x-examples:
       - apiVersion: dhctl.deckhouse.io/v1
         kind: SSHConfig
@@ -74,4 +75,10 @@ apiVersions:
         description: |
           Switch to modern SSH mode (gossh).
         type: boolean
+      forceUseSSHAgent:
+        description: |
+          Force use SSH agent passed with env SSH_AUTH_SOCK instead of inline private keys.
+          When set to true, sshAgentPrivateKeys may be omitted.
+        type: boolean
+        default: false
 

--- a/dhctl/pkg/app/options/ssh.go
+++ b/dhctl/pkg/app/options/ssh.go
@@ -53,6 +53,10 @@ type SSHOptions struct {
 	LegacyMode bool
 	ModernMode bool
 
+	// ForceUseSSHAgent instructs dhctl to use the SSH agent via SSH_AUTH_SOCK
+	// instead of inline private keys. Set from connection-config forceUseSSHAgent field.
+	ForceUseSSHAgent bool
+
 	// PrivateKeysToPassPhrasesFromConfig is populated by the connection-config parser.
 	PrivateKeysToPassPhrasesFromConfig PrivateKeyFileToPassphrase
 }
@@ -74,7 +78,12 @@ func NewSSHOptions() SSHOptions {
 // ProcessConnectionConfigFlags fills PrivateKeys from AgentPrivateKeys, applying
 // the default agent key when no key is configured. It used to live in pkg/app
 // as the unexported processConnectionConfigFlags.
+// When ForceUseSSHAgent is set, key injection is skipped: authentication happens
+// via the forwarded SSH_AUTH_SOCK socket instead.
 func (o *SSHOptions) ProcessConnectionConfigFlags() error {
+	if o.ForceUseSSHAgent {
+		return nil
+	}
 	if len(o.AgentPrivateKeys) == 0 {
 		o.AgentPrivateKeys = append(o.AgentPrivateKeys, DefaultSSHAgentPrivateKeys)
 	}

--- a/dhctl/pkg/config/connection.go
+++ b/dhctl/pkg/config/connection.go
@@ -48,6 +48,7 @@ type SSHConfig struct {
 	SudoPassword        string               `json:"sudoPassword,omitempty"`
 	LegacyMode          bool                 `json:"legacyMode,omitempty"`
 	ModernMode          bool                 `json:"modernMode,omitempty"`
+	ForceUseSSHAgent    bool                 `json:"forceUseSSHAgent,omitempty"`
 }
 
 type SSHAgentPrivateKey struct {
@@ -255,6 +256,7 @@ func (p *ConnectionConfigParser) ParseConnectionConfigFromFile() error {
 	p.opts.SSH.BastionPass = cfg.SSHConfig.SSHBastionPassword
 	p.opts.SSH.LegacyMode = cfg.SSHConfig.LegacyMode
 	p.opts.SSH.ModernMode = cfg.SSHConfig.ModernMode
+	p.opts.SSH.ForceUseSSHAgent = cfg.SSHConfig.ForceUseSSHAgent
 	// todo it is ugly solution
 	p.opts.SSH.PrivateKeysToPassPhrasesFromConfig = pathToPassPhrase
 

--- a/dhctl/pkg/config/connection_test.go
+++ b/dhctl/pkg/config/connection_test.go
@@ -159,6 +159,20 @@ func TestParseConnectionConfig(t *testing.T) {
 
 `,
 		},
+		"valid config: force use ssh agent (no inline keys)": {
+			config: validSSHConfigAgentOnly,
+			expected: &ConnectionConfig{
+				SSHConfig: &SSHConfig{
+					SSHUser:          "ubuntu",
+					SSHPort:          new(int32(22)),
+					ForceUseSSHAgent: true,
+				},
+				SSHHosts: []SSHHost{
+					{Host: "10.0.0.1"},
+				},
+			},
+			opts: []ValidateOption{ValidateOptionValidateExtensions(true)},
+		},
 		"invalid config: empty host": {
 			config: configFunc(
 				invalidSSHConfigNoHosts,
@@ -284,4 +298,16 @@ sshAgentPrivateKeys:
 ---
 apiVersion: dhctl.deckhouse.io/v1
 kind: SSHHost
+`
+
+var validSSHConfigAgentOnly = `
+apiVersion: dhctl.deckhouse.io/v1
+kind: SSHConfig
+sshUser: ubuntu
+sshPort: 22
+forceUseSSHAgent: true
+---
+apiVersion: dhctl.deckhouse.io/v1
+kind: SSHHost
+host: 10.0.0.1
 `


### PR DESCRIPTION
Add a third anyOf branch to candi/openapi/dhctl/ssh_configuration.yaml allowing agent-only authentication (no inline sshAgentPrivateKeys required) when forceUseSSHAgent: true is set.

- candi/openapi/dhctl/ssh_configuration.yaml: add forceUseSSHAgent property (boolean, default false) and third anyOf branch requiring it; mirrors the already-released lib-connection v0.11.0 embedded schema.
- dhctl/pkg/config/connection.go: add ForceUseSSHAgent field to SSHConfig; propagate to opts.SSH.ForceUseSSHAgent in ParseConnectionConfigFromFile.
- dhctl/pkg/app/options/ssh.go: add ForceUseSSHAgent to SSHOptions; skip default-key injection in ProcessConnectionConfigFlags when set (auth goes via the forwarded SSH_AUTH_SOCK socket instead).
- dhctl/pkg/config/connection_test.go: add test case validating that a config with forceUseSSHAgent: true and no sshAgentPrivateKeys passes validation.

Tests: 9 passed, 0 failed (TestParseConnectionConfig).

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
