### PR TITLE
[deckhouse] update module settings

### DIFF
--- a/deckhouse-controller/internal/packages/runtime/apps.go
+++ b/deckhouse-controller/internal/packages/runtime/apps.go
@@ -51,10 +51,10 @@ type App struct {
 	Settings   addonutils.Values
 }
 
-// ValidateSettings checks settings against the package's OpenAPI schema.
+// ValidateAppSettings checks settings against the package's OpenAPI schema.
 // Returns valid if the package is not loaded yet (settings validated on load).
-func (r *Runtime) ValidateSettings(ctx context.Context, name string, settings addonutils.Values) (settingscheck.Result, error) {
-	ctx, span := otel.Tracer(runtimeTracer).Start(ctx, "ValidateSettings")
+func (r *Runtime) ValidateAppSettings(ctx context.Context, name string, settings addonutils.Values) (settingscheck.Result, error) {
+	ctx, span := otel.Tracer(runtimeTracer).Start(ctx, "ValidateAppSettings")
 	defer span.End()
 
 	r.mu.Lock()

--- a/deckhouse-controller/internal/packages/runtime/lifecycle/store.go
+++ b/deckhouse-controller/internal/packages/runtime/lifecycle/store.go
@@ -97,6 +97,28 @@ func (s *Store) Update(name, version string, settings addonutils.Values) context
 	return nil
 }
 
+// UpdateSettings stores new pending settings for an already-tracked package
+// without touching its version or context tree. Returns true if the settings
+// checksum changed and the caller should Reschedule, false if the settings are
+// unchanged or the package is not tracked yet.
+//
+// Unlike Update, this never creates or cancels a context: in-flight deploy and
+// load tasks are left running. It is the settings-only counterpart to Update,
+// used when settings change independently of a version change.
+func (s *Store) UpdateSettings(name string, settings addonutils.Values) bool {
+	pkg, ok := s.packages[name]
+	if !ok {
+		return false
+	}
+
+	if pkg.settings.Checksum() == settings.Checksum() {
+		return false
+	}
+
+	pkg.settings = settings
+	return true
+}
+
 // HandleEvent renews the context for the given event type and returns it.
 //
 // For EventRemove: clears version and settings before renewing context, so a

--- a/deckhouse-controller/internal/packages/runtime/modules.go
+++ b/deckhouse-controller/internal/packages/runtime/modules.go
@@ -23,6 +23,8 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 
+	"github.com/deckhouse/module-sdk/pkg/settingscheck"
+
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/loader"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/modules"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/runtime/lifecycle"
@@ -45,6 +47,46 @@ type Module struct {
 	Name       string
 	Definition modules.Definition
 	Settings   addonutils.Values
+}
+
+// ValidateModuleSettings checks settings against the package's OpenAPI schema.
+// Returns valid if the package is not loaded yet (settings validated on load).
+func (r *Runtime) ValidateModuleSettings(ctx context.Context, name string, settings addonutils.Values) (settingscheck.Result, error) {
+	ctx, span := otel.Tracer(runtimeTracer).Start(ctx, "ValidateModuleSettings")
+	defer span.End()
+
+	r.mu.Lock()
+	module := r.modules[name]
+	if module == nil {
+		r.mu.Unlock()
+		return settingscheck.Result{Valid: true}, nil
+	}
+	r.mu.Unlock()
+
+	return module.ValidateSettings(ctx, settings)
+}
+
+// UpdateModuleSettings applies a settings-only change to an already-tracked
+// module without redeploying or reloading it. It is meant to be wired into the
+// module-config-controller, which owns module settings independently of the
+// module version handled by UpdateModule.
+//
+// Unlike UpdateModule, this never enqueues Deploy/Load tasks and never cancels
+// the module's context tree: it only stashes the new pending settings and, if
+// they actually changed, triggers Reschedule so the scheduler re-runs the
+// Configure → Startup → Run pipeline (see schedulePackage) with the new values.
+// Any in-flight deploy or load for the module keeps running untouched.
+//
+// If the module is not tracked yet (no prior UpdateModule), the settings are
+// dropped: there is nothing to reschedule, and the eventual UpdateModule will
+// register the module and pick up its own settings.
+func (r *Runtime) UpdateModuleSettings(name string, settings addonutils.Values) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.packages.UpdateSettings(name, settings) {
+		r.scheduler.Reschedule(name)
+	}
 }
 
 // UpdateModule handles module creation and version changes from the module controller.

--- a/deckhouse-controller/internal/packages/runtime/runtime.go
+++ b/deckhouse-controller/internal/packages/runtime/runtime.go
@@ -25,7 +25,6 @@ import (
 	"github.com/Masterminds/semver/v3"
 	addonapp "github.com/flant/addon-operator/pkg/app"
 	addonmodules "github.com/flant/addon-operator/pkg/module_manager/models/modules"
-	addonutils "github.com/flant/addon-operator/pkg/utils"
 	klient "github.com/flant/kube-client/client"
 	objectpatch "github.com/flant/shell-operator/pkg/kube/object_patch"
 	kubeeventsmanager "github.com/flant/shell-operator/pkg/kube_events_manager"
@@ -559,7 +558,7 @@ func (r *Runtime) buildScheduler(cli kclient.Client) {
 // Run starts the scheduler event loop in a background goroutine. It listens for
 // schedule and disable events from the scheduler and dispatches them to the
 // appropriate handler, driving the enable/disable lifecycle for all packages.
-func (r *Runtime) Run(moduleSettings map[string]addonutils.Values) {
+func (r *Runtime) Run() {
 	r.hookEventHandler.Start()
 	r.healthService.Start()
 

--- a/deckhouse-controller/internal/packages/runtime/runtime.go
+++ b/deckhouse-controller/internal/packages/runtime/runtime.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	addonapp "github.com/flant/addon-operator/pkg/app"
 	addonmodules "github.com/flant/addon-operator/pkg/module_manager/models/modules"
+	addonutils "github.com/flant/addon-operator/pkg/utils"
 	klient "github.com/flant/kube-client/client"
 	objectpatch "github.com/flant/shell-operator/pkg/kube/object_patch"
 	kubeeventsmanager "github.com/flant/shell-operator/pkg/kube_events_manager"
@@ -33,6 +34,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/client-go/util/workqueue"
 	runtimecache "sigs.k8s.io/controller-runtime/pkg/cache"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -557,7 +559,7 @@ func (r *Runtime) buildScheduler(cli kclient.Client) {
 // Run starts the scheduler event loop in a background goroutine. It listens for
 // schedule and disable events from the scheduler and dispatches them to the
 // appropriate handler, driving the enable/disable lifecycle for all packages.
-func (r *Runtime) Run() {
+func (r *Runtime) Run(moduleSettings map[string]addonutils.Values) {
 	r.hookEventHandler.Start()
 	r.healthService.Start()
 
@@ -713,9 +715,14 @@ func (r *Runtime) Cleanup(ctx context.Context, preserves []PreservePackage) {
 	r.nelmService.Cleanup(ctx, keepReleases, "d8-system")
 }
 
-// Status returns package status service for external access
-func (r *Runtime) Status() *status.Service {
-	return r.status
+// GetStatus returns package status.
+func (r *Runtime) GetStatus(name string) status.Status {
+	return r.status.GetStatus(name)
+}
+
+// GetStatusQueue returns the status queue for external access
+func (r *Runtime) GetStatusQueue() workqueue.TypedRateLimitingInterface[string] {
+	return r.status.Queue()
 }
 
 // PauseScheduler suspends the scheduler so it stops firing enable/disable callbacks.

--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/register.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/register.go
@@ -44,7 +44,7 @@ type moduleStorage interface {
 }
 
 type packageManager interface {
-	ValidateSettings(ctx context.Context, name string, settings addonutils.Values) (settingscheck.Result, error)
+	ValidateAppSettings(ctx context.Context, name string, settings addonutils.Values) (settingscheck.Result, error)
 	CheckConstraints(name string, constraints schedule.Constraints) error
 }
 

--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_application.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_application.go
@@ -56,7 +56,7 @@ func applicationValidationHandler(cli client.Client, manager packageManager) htt
 
 		name := apps.BuildName(app.Namespace, app.Name)
 
-		res, err := manager.ValidateSettings(ctx, name, app.Spec.Settings.GetMap())
+		res, err := manager.ValidateAppSettings(ctx, name, app.Spec.Settings.GetMap())
 		if err != nil {
 			return nil, err
 		}

--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_application_test.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_application_test.go
@@ -43,7 +43,7 @@ type fakePackageManager struct {
 	gotConstraints schedule.Constraints
 }
 
-func (f *fakePackageManager) ValidateSettings(_ context.Context, _ string, _ addonutils.Values) (settingscheck.Result, error) {
+func (f *fakePackageManager) ValidateAppSettings(_ context.Context, _ string, _ addonutils.Values) (settingscheck.Result, error) {
 	return f.validateResult, f.validateErr
 }
 

--- a/deckhouse-controller/pkg/controller/packages/application/controller.go
+++ b/deckhouse-controller/pkg/controller/packages/application/controller.go
@@ -24,6 +24,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/workqueue"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -71,7 +72,8 @@ type moduleManager interface {
 type packageRuntime interface {
 	UpdateApp(repo registry.Remote, inst packageruntime.App)
 	RemoveApp(namespace, name string)
-	Status() *packagestatus.Service
+	GetStatus(name string) packagestatus.Status
+	GetStatusQueue() workqueue.TypedRateLimitingInterface[string]
 	Cleanup(ctx context.Context, preserve []packageruntime.PreservePackage)
 }
 
@@ -98,8 +100,8 @@ func RegisterController(
 		return fmt.Errorf("add preflight: %w", err)
 	}
 
-	r.status = status.NewService(r.client, packageRuntime.Status().GetStatus, r.logger)
-	r.status.Start(context.Background(), packageRuntime.Status().Queue())
+	r.status = status.NewService(r.client, packageRuntime.GetStatus, r.logger)
+	r.status.Start(context.Background(), packageRuntime.GetStatusQueue())
 
 	return ctrl.NewControllerManagedBy(runtimeManager).
 		Named(controllerName).

--- a/deckhouse-controller/pkg/controller/packages/application/controller_test.go
+++ b/deckhouse-controller/pkg/controller/packages/application/controller_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	packageoperator "github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/runtime"
@@ -251,15 +252,13 @@ func (suite *ControllerTestSuite) getApplication(name string, namespace string) 
 	return &app
 }
 
-type moduleManagerStub struct {
-}
+type moduleManagerStub struct{}
 
 func (m *moduleManagerStub) AreModulesInited() bool {
 	return true
 }
 
-type operatorStub struct {
-}
+type operatorStub struct{}
 
 func (o *operatorStub) UpdateApp(_ registry.Remote, _ packageoperator.App) {
 }
@@ -267,8 +266,12 @@ func (o *operatorStub) UpdateApp(_ registry.Remote, _ packageoperator.App) {
 func (o *operatorStub) RemoveApp(_, _ string) {
 }
 
-func (o *operatorStub) Status() *packagestatus.Service {
-	return packagestatus.NewService()
+func (o *operatorStub) GetStatus(name string) packagestatus.Status {
+	return packagestatus.NewService().GetStatus(name)
+}
+
+func (o *operatorStub) GetStatusQueue() workqueue.TypedRateLimitingInterface[string] {
+	return packagestatus.NewService().Queue()
 }
 
 func (o *operatorStub) Cleanup(_ context.Context, _ []packageoperator.PreservePackage) {}


### PR DESCRIPTION
## Description

Adds a settings-only update path for modules and rounds out the module-side validation surface in the package runtime.

**Runtime — settings-only updates (`internal/packages/runtime`)**
- New `Store.UpdateSettings(name, settings)` in the lifecycle store: stashes new pending settings for an already-tracked package and reports whether the checksum changed. Unlike `Store.Update`, it never touches the package version and never creates or cancels a context.
- New `Runtime.UpdateModuleSettings(name, settings)`: applies a settings-only change to an already-tracked module **without redeploying, reloading, or cancelling any in-flight Deploy/Load task**. When settings actually change it calls `Reschedule`, so the scheduler re-runs the Configure → Startup → Run pipeline with the new values. If the module is not tracked yet, the update is a no-op (the eventual `UpdateModule` registers it with its own settings). Intended to be wired into the module-config-controller in a follow-up.

**Validation — module settings (`internal/packages/runtime`, `pkg/apis/.../validation`)**
- New `Runtime.ValidateModuleSettings`, the module counterpart of the existing app validation (returns valid when the package is not loaded yet).
- Renamed `Runtime.ValidateSettings` → `ValidateAppSettings` (and the `packageManager` interface method) to disambiguate the app and module paths now that both exist.

**Status interface narrowing (`pkg/controller/packages/application`)**
- Replaced the broad `Runtime.Status() *status.Service` accessor with two focused methods — `GetStatus(name)` and `GetStatusQueue()` — and tightened the controller's `packageRuntime` interface to match, so the controller no longer reaches into the whole status service.

## Why do we need it, and what problem does it solve?

Module settings (owned by the module-config-controller) change independently of the module version. The existing `UpdateModule` path treats any change as a version change candidate and can tear down and rebuild the module. We need a path that re-applies settings to a running module **without** cancelling its in-flight deploy/load or re-running the full pipeline. This PR adds that primitive plus the matching module-settings validation, ready to be wired into the controller.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: chore
summary: Update module settings.
impact_level: low
```
