### PR TITLE
[istio] Add logout button to kiali

### DIFF
--- a/modules/110-istio/images/common-v1x21x6/patches/002-kiali-logout.patch
+++ b/modules/110-istio/images/common-v1x21x6/patches/002-kiali-logout.patch
@@ -1,5 +1,5 @@
 diff --git a/frontend/src/components/Nav/Masthead/UserDropdown.tsx b/frontend/src/components/Nav/Masthead/UserDropdown.tsx
-index 1b4fa6f..8212ee9 100644
+index 1b4fa6f..8e8efb7 100644
 --- a/frontend/src/components/Nav/Masthead/UserDropdown.tsx
 +++ b/frontend/src/components/Nav/Masthead/UserDropdown.tsx
 @@ -9,6 +9,8 @@ import { AuthStrategy } from '../../../types/Auth';
@@ -44,12 +44,12 @@ index 1b4fa6f..8212ee9 100644
    }
  
    timeLeft = (): number => {
-@@ -87,6 +101,16 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+@@ -87,7 +101,23 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
      }
    };
  
 +
-+  handleStorageLogout = (event: StorageEvent): void => {
++  handleStorageLogout = (event: StorageEvent) => {
 +    if (event.key !== DEX_LOGOUT_STORAGE_KEY || !event.newValue) {
 +      return;
 +    }
@@ -67,7 +67,8 @@ index 1b4fa6f..8212ee9 100644
 +
      if (authenticationConfig.logoutEndpoint) {
        API.logout()
-@@ -123,8 +147,7 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+         .then(_ => {
+@@ -123,8 +153,7 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
    render() {
      const { isDropdownOpen } = this.state;
  

--- a/modules/110-istio/images/common-v1x21x6/patches/002-kiali-logout.patch
+++ b/modules/110-istio/images/common-v1x21x6/patches/002-kiali-logout.patch
@@ -1,34 +1,17 @@
-diff --git a/frontend/src/app/App.tsx b/frontend/src/app/App.tsx
-index 4ccc8ef..98f1b04 100644
---- a/frontend/src/app/App.tsx
-+++ b/frontend/src/app/App.tsx
-@@ -13,6 +13,8 @@ import { InitializingScreen } from './InitializingScreen';
- import { StartupInitializer } from './StartupInitializer';
- import { LoginPage } from '../pages/Login/LoginPage';
- import { LoginActions } from '../actions/LoginActions';
-+import { authenticationConfig } from '../config/AuthenticationConfig';
-+import { AuthStrategy } from '../types/Auth';
- 
- Visibility.change((_e, state) => {
-   // There are 3 states, visible, hidden and prerender, consider prerender as hidden.
-@@ -75,8 +77,11 @@ axios.interceptors.response.use(
-     // The response was rejected, turn off the spinning
-     decrementLoadingCounter();
- 
--    if (error.response.status === 401) {
-+    if (error.response && error.response.status === 401) {
-       store.dispatch(LoginActions.sessionExpired());
-+      if (authenticationConfig.strategy === AuthStrategy.header) {
-+        window.location.replace(`${window.location.origin}/`);
-+      }
-     }
- 
-     return Promise.reject(error);
 diff --git a/frontend/src/components/Nav/Masthead/UserDropdown.tsx b/frontend/src/components/Nav/Masthead/UserDropdown.tsx
-index 1b4fa6f..f32b21a 100644
+index 1b4fa6f..8212ee9 100644
 --- a/frontend/src/components/Nav/Masthead/UserDropdown.tsx
 +++ b/frontend/src/components/Nav/Masthead/UserDropdown.tsx
-@@ -34,6 +34,14 @@ const dropdownStyle = kialiStyle({
+@@ -9,6 +9,8 @@ import { AuthStrategy } from '../../../types/Auth';
+ import moment from 'moment';
+ import { KialiDispatch } from 'types/Redux';
+ import { LoginThunkActions } from '../../../actions/LoginThunkActions';
++import { LoginActions } from '../../../actions/LoginActions';
++import { store } from '../../../store/ConfigStore';
+ import { connect } from 'react-redux';
+ import * as API from '../../../services/Api';
+ import { kialiStyle } from 'styles/StyleUtils';
+@@ -34,6 +36,14 @@ const dropdownStyle = kialiStyle({
    paddingRight: 0
  });
  
@@ -43,7 +26,7 @@ index 1b4fa6f..f32b21a 100644
  class UserDropdownComponent extends React.Component<UserProps, UserState> {
    constructor(props: UserProps) {
      super(props);
-@@ -55,6 +63,8 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+@@ -55,6 +65,8 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
        this.setState({ timeCountDownSeconds: this.timeLeft() / MILLISECONDS });
      }, 1000);
  
@@ -52,7 +35,7 @@ index 1b4fa6f..f32b21a 100644
      this.setState({
        checkSessionTimerId: checkSessionTimerId,
        timeLeftTimerId: timeLeftTimerId
-@@ -69,6 +79,8 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+@@ -69,6 +81,8 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
      if (this.state.timeLeftTimerId) {
        clearInterval(this.state.timeLeftTimerId);
      }
@@ -61,7 +44,7 @@ index 1b4fa6f..f32b21a 100644
    }
  
    timeLeft = (): number => {
-@@ -87,7 +99,21 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+@@ -87,6 +101,16 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
      }
    };
  
@@ -70,7 +53,9 @@ index 1b4fa6f..f32b21a 100644
 +    if (event.key !== DEX_LOGOUT_STORAGE_KEY || !event.newValue) {
 +      return;
 +    }
-+    window.location.assign(headerAuthLogoutURL());
++    // Do not call /logout or reload here: only the tab that clicked Logout runs sign_out.
++    // Mark this tab as logged out locally to stop XHR polling without racing oauth2-proxy CSRF.
++    store.dispatch(LoginActions.sessionExpired());
 +  };
 +
    handleLogout = () => {
@@ -82,8 +67,7 @@ index 1b4fa6f..f32b21a 100644
 +
      if (authenticationConfig.logoutEndpoint) {
        API.logout()
-         .then(_ => {
-@@ -123,8 +149,7 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+@@ -123,8 +147,7 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
    render() {
      const { isDropdownOpen } = this.state;
  

--- a/modules/110-istio/images/common-v1x21x6/patches/002-kiali-logout.patch
+++ b/modules/110-istio/images/common-v1x21x6/patches/002-kiali-logout.patch
@@ -1,5 +1,5 @@
 diff --git a/frontend/src/app/App.tsx b/frontend/src/app/App.tsx
-index 4ccc8ef..eccf975 100644
+index 4ccc8ef..98f1b04 100644
 --- a/frontend/src/app/App.tsx
 +++ b/frontend/src/app/App.tsx
 @@ -13,6 +13,8 @@ import { InitializingScreen } from './InitializingScreen';
@@ -19,13 +19,13 @@ index 4ccc8ef..eccf975 100644
 +    if (error.response && error.response.status === 401) {
        store.dispatch(LoginActions.sessionExpired());
 +      if (authenticationConfig.strategy === AuthStrategy.header) {
-+        window.location.replace();
++        window.location.replace(`${window.location.origin}/`);
 +      }
      }
  
      return Promise.reject(error);
 diff --git a/frontend/src/components/Nav/Masthead/UserDropdown.tsx b/frontend/src/components/Nav/Masthead/UserDropdown.tsx
-index 1b4fa6f..439be9d 100644
+index 1b4fa6f..f32b21a 100644
 --- a/frontend/src/components/Nav/Masthead/UserDropdown.tsx
 +++ b/frontend/src/components/Nav/Masthead/UserDropdown.tsx
 @@ -34,6 +34,14 @@ const dropdownStyle = kialiStyle({
@@ -61,9 +61,18 @@ index 1b4fa6f..439be9d 100644
    }
  
    timeLeft = (): number => {
-@@ -88,6 +100,12 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+@@ -87,7 +99,21 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+     }
    };
  
++
++  handleStorageLogout = (event: StorageEvent): void => {
++    if (event.key !== DEX_LOGOUT_STORAGE_KEY || !event.newValue) {
++      return;
++    }
++    window.location.assign(headerAuthLogoutURL());
++  };
++
    handleLogout = () => {
 +    if (authenticationConfig.strategy === AuthStrategy.header) {
 +      localStorage.setItem(DEX_LOGOUT_STORAGE_KEY, String(Date.now()));
@@ -74,7 +83,7 @@ index 1b4fa6f..439be9d 100644
      if (authenticationConfig.logoutEndpoint) {
        API.logout()
          .then(_ => {
-@@ -123,8 +141,7 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+@@ -123,8 +149,7 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
    render() {
      const { isDropdownOpen } = this.state;
  

--- a/modules/110-istio/images/common-v1x21x6/patches/002-kiali-logout.patch
+++ b/modules/110-istio/images/common-v1x21x6/patches/002-kiali-logout.patch
@@ -2,19 +2,20 @@ diff --git a/frontend/src/components/Nav/Masthead/UserDropdown.tsx b/frontend/sr
 index 1111111..2222222 100644
 --- a/frontend/src/components/Nav/Masthead/UserDropdown.tsx
 +++ b/frontend/src/components/Nav/Masthead/UserDropdown.tsx
-@@ -88,6 +88,11 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+@@ -88,6 +88,12 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
    };
  
    handleLogout = () => {
 +    if (authenticationConfig.strategy === AuthStrategy.header) {
-+      window.location.assign('/logout');
++      const redirectURL = encodeURIComponent(`${window.location.origin}/`);
++      window.location.assign(`/logout?rd=${redirectURL}`);
 +      return;
 +    }
 +
      if (authenticationConfig.logoutEndpoint) {
        API.logout()
          .then(_ => {
-@@ -123,8 +128,7 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+@@ -123,8 +129,7 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
    render() {
      const { isDropdownOpen } = this.state;
  

--- a/modules/110-istio/images/common-v1x21x6/patches/002-kiali-logout.patch
+++ b/modules/110-istio/images/common-v1x21x6/patches/002-kiali-logout.patch
@@ -1,21 +1,80 @@
+diff --git a/frontend/src/app/App.tsx b/frontend/src/app/App.tsx
+index 4ccc8ef..eccf975 100644
+--- a/frontend/src/app/App.tsx
++++ b/frontend/src/app/App.tsx
+@@ -13,6 +13,8 @@ import { InitializingScreen } from './InitializingScreen';
+ import { StartupInitializer } from './StartupInitializer';
+ import { LoginPage } from '../pages/Login/LoginPage';
+ import { LoginActions } from '../actions/LoginActions';
++import { authenticationConfig } from '../config/AuthenticationConfig';
++import { AuthStrategy } from '../types/Auth';
+ 
+ Visibility.change((_e, state) => {
+   // There are 3 states, visible, hidden and prerender, consider prerender as hidden.
+@@ -75,8 +77,11 @@ axios.interceptors.response.use(
+     // The response was rejected, turn off the spinning
+     decrementLoadingCounter();
+ 
+-    if (error.response.status === 401) {
++    if (error.response && error.response.status === 401) {
+       store.dispatch(LoginActions.sessionExpired());
++      if (authenticationConfig.strategy === AuthStrategy.header) {
++        window.location.replace();
++      }
+     }
+ 
+     return Promise.reject(error);
 diff --git a/frontend/src/components/Nav/Masthead/UserDropdown.tsx b/frontend/src/components/Nav/Masthead/UserDropdown.tsx
-index 1111111..2222222 100644
+index 1b4fa6f..439be9d 100644
 --- a/frontend/src/components/Nav/Masthead/UserDropdown.tsx
 +++ b/frontend/src/components/Nav/Masthead/UserDropdown.tsx
-@@ -88,6 +88,12 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+@@ -34,6 +34,14 @@ const dropdownStyle = kialiStyle({
+   paddingRight: 0
+ });
+ 
++
++const DEX_LOGOUT_STORAGE_KEY = 'kiali-dex-logout';
++
++const headerAuthLogoutURL = (): string => {
++  const redirectURL = encodeURIComponent(`${window.location.origin}/`);
++  return `/logout?rd=${redirectURL}`;
++};
++
+ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+   constructor(props: UserProps) {
+     super(props);
+@@ -55,6 +63,8 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+       this.setState({ timeCountDownSeconds: this.timeLeft() / MILLISECONDS });
+     }, 1000);
+ 
++    window.addEventListener('storage', this.handleStorageLogout);
++
+     this.setState({
+       checkSessionTimerId: checkSessionTimerId,
+       timeLeftTimerId: timeLeftTimerId
+@@ -69,6 +79,8 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+     if (this.state.timeLeftTimerId) {
+       clearInterval(this.state.timeLeftTimerId);
+     }
++
++    window.removeEventListener('storage', this.handleStorageLogout);
+   }
+ 
+   timeLeft = (): number => {
+@@ -88,6 +100,12 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
    };
  
    handleLogout = () => {
 +    if (authenticationConfig.strategy === AuthStrategy.header) {
-+      const redirectURL = encodeURIComponent(`${window.location.origin}/`);
-+      window.location.assign(`/logout?rd=${redirectURL}`);
++      localStorage.setItem(DEX_LOGOUT_STORAGE_KEY, String(Date.now()));
++      window.location.assign(headerAuthLogoutURL());
 +      return;
 +    }
 +
      if (authenticationConfig.logoutEndpoint) {
        API.logout()
          .then(_ => {
-@@ -123,8 +129,7 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+@@ -123,8 +141,7 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
    render() {
      const { isDropdownOpen } = this.state;
  

--- a/modules/110-istio/images/common-v1x21x6/patches/002-kiali-logout.patch
+++ b/modules/110-istio/images/common-v1x21x6/patches/002-kiali-logout.patch
@@ -1,0 +1,26 @@
+diff --git a/frontend/src/components/Nav/Masthead/UserDropdown.tsx b/frontend/src/components/Nav/Masthead/UserDropdown.tsx
+index 1111111..2222222 100644
+--- a/frontend/src/components/Nav/Masthead/UserDropdown.tsx
++++ b/frontend/src/components/Nav/Masthead/UserDropdown.tsx
+@@ -88,6 +88,11 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+   };
+ 
+   handleLogout = () => {
++    if (authenticationConfig.strategy === AuthStrategy.header) {
++      window.location.assign('/logout');
++      return;
++    }
++
+     if (authenticationConfig.logoutEndpoint) {
+       API.logout()
+         .then(_ => {
+@@ -123,8 +128,7 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+   render() {
+     const { isDropdownOpen } = this.state;
+ 
+-    const canLogout =
+-      authenticationConfig.strategy !== AuthStrategy.anonymous && authenticationConfig.strategy !== AuthStrategy.header;
++    const canLogout = authenticationConfig.strategy !== AuthStrategy.anonymous;
+ 
+     const userDropdownItems = (
+       <DropdownItem key={'user_logout_option'} onClick={this.handleLogout} isDisabled={!canLogout}>

--- a/modules/110-istio/images/common-v1x21x6/patches/README.md
+++ b/modules/110-istio/images/common-v1x21x6/patches/README.md
@@ -14,7 +14,7 @@ Fix CVE
 
 ## 002-kiali-logout.patch
 
-Adds logout button in kiali
+Enable Logout in Kiali for header auth (DexAuthenticator) and redirect to `/logout?rd=<app-origin>/` so sign-out returns to the app and avoids stale Dex login CSRF.
 
 ## 003-istio-server_fmtText.patch
 

--- a/modules/110-istio/images/common-v1x21x6/patches/README.md
+++ b/modules/110-istio/images/common-v1x21x6/patches/README.md
@@ -14,7 +14,7 @@ Fix CVE
 
 ## 002-kiali-logout.patch
 
-Enable Logout in Kiali for header auth (DexAuthenticator). Redirects to `/logout?rd=<app-origin>/`, broadcasts logout to other tabs via `localStorage`, and on 401 forces a full-page reload to stop stale XHRs from racing the Dex auth flow.
+Enable Logout in Kiali for header auth (DexAuthenticator). The tab that clicks Logout calls `/logout?rd=<app-origin>/` once; other tabs receive a `localStorage` event and only dispatch `sessionExpired` locally (no second sign_out, no reload) to avoid oauth2-proxy CSRF races.
 
 ## 003-istio-server_fmtText.patch
 

--- a/modules/110-istio/images/common-v1x21x6/patches/README.md
+++ b/modules/110-istio/images/common-v1x21x6/patches/README.md
@@ -4,9 +4,17 @@
 
 Fix Istio Operator healt status
 
+## 001-kiali-go-mod.patch
+
+Fix CVE
+
 ## 002-istio-gomod_gosum.patch
 
 Fix CVE
+
+## 002-kiali-logout.patch
+
+Adds logout button in kiali
 
 ## 003-istio-server_fmtText.patch
 
@@ -19,7 +27,3 @@ Fix use expfmt library in pilot-agent. This library used for format metrics.
 
 Implement graceful transition for remote multicluster secrets. To prevent connectivity gaps during secret rotation, the old secret is no longer dismissed immediately. Instead, it remains active until the new secret is processed and all associated metadata is synced.
 Adopted upstream pr https://github.com/istio/istio/pull/58567.
-
-## 001-kiali-go-mod.patch
-
-Fix CVE

--- a/modules/110-istio/images/common-v1x21x6/patches/README.md
+++ b/modules/110-istio/images/common-v1x21x6/patches/README.md
@@ -14,7 +14,7 @@ Fix CVE
 
 ## 002-kiali-logout.patch
 
-Enable Logout in Kiali for header auth (DexAuthenticator) and redirect to `/logout?rd=<app-origin>/` so sign-out returns to the app and avoids stale Dex login CSRF.
+Enable Logout in Kiali for header auth (DexAuthenticator). Redirects to `/logout?rd=<app-origin>/`, broadcasts logout to other tabs via `localStorage`, and on 401 forces a full-page reload to stop stale XHRs from racing the Dex auth flow.
 
 ## 003-istio-server_fmtText.patch
 

--- a/modules/110-istio/images/common-v1x21x6/werf.inc.yaml
+++ b/modules/110-istio/images/common-v1x21x6/werf.inc.yaml
@@ -26,15 +26,6 @@ git:
   tag: {{ $kialiVersion }}
   add: /
   to: /src/kiali
-  excludePaths:
-  - frontend
-  stageDependencies:
-    install:
-    - '**/*'
-- url: {{ .SOURCE_REPO }}/istio/kiali-frontend-assets.git
-  tag: {{ $kialiVersion }}
-  add: /
-  to: /src/kial-frontend-assets
   stageDependencies:
     install:
     - '**/*'
@@ -45,3 +36,20 @@ shell:
   - cd /src/istio/ && git apply --verbose /patches/003-istio-server_fmtText.patch
   - cd /src/istio/ && git apply --verbose /patches/004-istio-multicluster_regenerate_token_timeout.patch
   - cd /src/kiali/ && git apply --verbose /patches/001-kiali-go-mod.patch
+  - cd /src/kiali/ && git apply --verbose /patches/002-kiali-logout.patch
+---
+image: {{ .ModuleName }}/{{ .ImageName }}-kiali-frontend-build-artifact
+from: {{ index $.Images "builder/node-alpine-22.16" }}
+final: false
+import:
+- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+  add: /src/kiali/frontend
+  to: /src/kiali/frontend
+  before: install
+shell:
+  install:
+  - cd /src/kiali/frontend
+  - yarn install --frozen-lockfile
+  - KIALI_ENV=production yarn run build
+  - mkdir -p /src/kial-frontend-assets/static
+  - cp -a build/. /src/kial-frontend-assets/static/

--- a/modules/110-istio/images/common-v1x25x2/patches/002-kiali-logout.patch
+++ b/modules/110-istio/images/common-v1x25x2/patches/002-kiali-logout.patch
@@ -1,5 +1,5 @@
 diff --git a/frontend/src/components/Nav/Masthead/UserDropdown.tsx b/frontend/src/components/Nav/Masthead/UserDropdown.tsx
-index d244f26..c230ca1 100644
+index d244f26..e8f304d 100644
 --- a/frontend/src/components/Nav/Masthead/UserDropdown.tsx
 +++ b/frontend/src/components/Nav/Masthead/UserDropdown.tsx
 @@ -10,6 +10,8 @@ import { AuthStrategy } from '../../../types/Auth';
@@ -44,7 +44,7 @@ index d244f26..c230ca1 100644
    }
  
    timeLeft = (): number => {
-@@ -104,6 +118,16 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+@@ -104,7 +118,23 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
      }
    };
  
@@ -67,7 +67,8 @@ index d244f26..c230ca1 100644
 +
      if (authenticationConfig.logoutEndpoint) {
        API.logout()
-@@ -143,8 +167,7 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+         .then(_ => {
+@@ -143,8 +173,7 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
      const clusterIsInSessionInfo = (cluster: string): boolean =>
        this.props.session?.clusterInfo?.[cluster] !== undefined;
  

--- a/modules/110-istio/images/common-v1x25x2/patches/002-kiali-logout.patch
+++ b/modules/110-istio/images/common-v1x25x2/patches/002-kiali-logout.patch
@@ -1,34 +1,17 @@
-diff --git a/frontend/src/app/App.tsx b/frontend/src/app/App.tsx
-index 05b7026..97df374 100644
---- a/frontend/src/app/App.tsx
-+++ b/frontend/src/app/App.tsx
-@@ -11,6 +11,8 @@ import { InitializingScreen } from './InitializingScreen';
- import { StartupInitializer } from './StartupInitializer';
- import { LoginPage } from '../pages/Login/LoginPage';
- import { LoginActions } from '../actions/LoginActions';
-+import { authenticationConfig } from '../config/AuthenticationConfig';
-+import { AuthStrategy } from '../types/Auth';
- 
- Visibility.change((_e, state) => {
-   // There are 3 states, visible, hidden and prerender, consider prerender as hidden.
-@@ -73,8 +75,11 @@ axios.interceptors.response.use(
-     // The response was rejected, turn off the spinning
-     decrementLoadingCounter();
- 
--    if (error.response.status === 401) {
-+    if (error.response && error.response.status === 401) {
-       store.dispatch(LoginActions.sessionExpired());
-+      if (authenticationConfig.strategy === AuthStrategy.header) {
-+        window.location.replace(`${window.location.origin}/`);
-+      }
-     }
- 
-     return Promise.reject(error);
 diff --git a/frontend/src/components/Nav/Masthead/UserDropdown.tsx b/frontend/src/components/Nav/Masthead/UserDropdown.tsx
-index d244f26..0a1ae5b 100644
+index d244f26..c230ca1 100644
 --- a/frontend/src/components/Nav/Masthead/UserDropdown.tsx
 +++ b/frontend/src/components/Nav/Masthead/UserDropdown.tsx
-@@ -51,6 +51,14 @@ const dropdownStyle = kialiStyle({
+@@ -10,6 +10,8 @@ import { AuthStrategy } from '../../../types/Auth';
+ import moment from 'moment';
+ import { KialiDispatch } from 'types/Redux';
+ import { LoginThunkActions } from '../../../actions/LoginThunkActions';
++import { LoginActions } from '../../../actions/LoginActions';
++import { store } from '../../../store/ConfigStore';
+ import { connect } from 'react-redux';
+ import * as API from '../../../services/Api';
+ import { kialiStyle } from 'styles/StyleUtils';
+@@ -51,6 +53,14 @@ const dropdownStyle = kialiStyle({
    paddingRight: 0
  });
  
@@ -43,7 +26,7 @@ index d244f26..0a1ae5b 100644
  class UserDropdownComponent extends React.Component<UserProps, UserState> {
    constructor(props: UserProps) {
      super(props);
-@@ -72,6 +80,8 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+@@ -72,6 +82,8 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
        this.setState({ timeCountDownSeconds: this.timeLeft() / MILLISECONDS });
      }, 1000);
  
@@ -52,7 +35,7 @@ index d244f26..0a1ae5b 100644
      this.setState({
        checkSessionTimerId: checkSessionTimerId,
        timeLeftTimerId: timeLeftTimerId
-@@ -86,6 +96,8 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+@@ -86,6 +98,8 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
      if (this.state.timeLeftTimerId) {
        clearInterval(this.state.timeLeftTimerId);
      }
@@ -61,7 +44,7 @@ index d244f26..0a1ae5b 100644
    }
  
    timeLeft = (): number => {
-@@ -104,7 +116,21 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+@@ -104,6 +118,16 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
      }
    };
  
@@ -70,7 +53,9 @@ index d244f26..0a1ae5b 100644
 +    if (event.key !== DEX_LOGOUT_STORAGE_KEY || !event.newValue) {
 +      return;
 +    }
-+    window.location.assign(headerAuthLogoutURL());
++    // Do not call /logout or reload here: only the tab that clicked Logout runs sign_out.
++    // Mark this tab as logged out locally to stop XHR polling without racing oauth2-proxy CSRF.
++    store.dispatch(LoginActions.sessionExpired());
 +  };
 +
    handleLogout = (): void => {
@@ -82,8 +67,7 @@ index d244f26..0a1ae5b 100644
 +
      if (authenticationConfig.logoutEndpoint) {
        API.logout()
-         .then(_ => {
-@@ -143,8 +169,7 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+@@ -143,8 +167,7 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
      const clusterIsInSessionInfo = (cluster: string): boolean =>
        this.props.session?.clusterInfo?.[cluster] !== undefined;
  

--- a/modules/110-istio/images/common-v1x25x2/patches/002-kiali-logout.patch
+++ b/modules/110-istio/images/common-v1x25x2/patches/002-kiali-logout.patch
@@ -1,0 +1,26 @@
+diff --git a/frontend/src/components/Nav/Masthead/UserDropdown.tsx b/frontend/src/components/Nav/Masthead/UserDropdown.tsx
+index 1111111..2222222 100644
+--- a/frontend/src/components/Nav/Masthead/UserDropdown.tsx
++++ b/frontend/src/components/Nav/Masthead/UserDropdown.tsx
+@@ -105,6 +105,11 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+   };
+ 
+   handleLogout = (): void => {
++    if (authenticationConfig.strategy === AuthStrategy.header) {
++      window.location.assign('/logout');
++      return;
++    }
++
+     if (authenticationConfig.logoutEndpoint) {
+       API.logout()
+         .then(_ => {
+@@ -143,8 +148,7 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+     const clusterIsInSessionInfo = (cluster: string): boolean =>
+       this.props.session?.clusterInfo?.[cluster] !== undefined;
+ 
+-    const canLogout =
+-      authenticationConfig.strategy !== AuthStrategy.anonymous && authenticationConfig.strategy !== AuthStrategy.header;
++    const canLogout = authenticationConfig.strategy !== AuthStrategy.anonymous;
+ 
+     // We want to show a dropdown per cluster the user is not logged into yet.
+     // The clusters you are logged into are in session.clusterInfo and all

--- a/modules/110-istio/images/common-v1x25x2/patches/002-kiali-logout.patch
+++ b/modules/110-istio/images/common-v1x25x2/patches/002-kiali-logout.patch
@@ -1,21 +1,80 @@
+diff --git a/frontend/src/app/App.tsx b/frontend/src/app/App.tsx
+index 05b7026..4bb4713 100644
+--- a/frontend/src/app/App.tsx
++++ b/frontend/src/app/App.tsx
+@@ -11,6 +11,8 @@ import { InitializingScreen } from './InitializingScreen';
+ import { StartupInitializer } from './StartupInitializer';
+ import { LoginPage } from '../pages/Login/LoginPage';
+ import { LoginActions } from '../actions/LoginActions';
++import { authenticationConfig } from '../config/AuthenticationConfig';
++import { AuthStrategy } from '../types/Auth';
+ 
+ Visibility.change((_e, state) => {
+   // There are 3 states, visible, hidden and prerender, consider prerender as hidden.
+@@ -73,8 +75,11 @@ axios.interceptors.response.use(
+     // The response was rejected, turn off the spinning
+     decrementLoadingCounter();
+ 
+-    if (error.response.status === 401) {
++    if (error.response && error.response.status === 401) {
+       store.dispatch(LoginActions.sessionExpired());
++      if (authenticationConfig.strategy === AuthStrategy.header) {
++        window.location.replace();
++      }
+     }
+ 
+     return Promise.reject(error);
 diff --git a/frontend/src/components/Nav/Masthead/UserDropdown.tsx b/frontend/src/components/Nav/Masthead/UserDropdown.tsx
-index 1111111..2222222 100644
+index d244f26..dc4e215 100644
 --- a/frontend/src/components/Nav/Masthead/UserDropdown.tsx
 +++ b/frontend/src/components/Nav/Masthead/UserDropdown.tsx
-@@ -105,6 +105,12 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+@@ -51,6 +51,14 @@ const dropdownStyle = kialiStyle({
+   paddingRight: 0
+ });
+ 
++
++const DEX_LOGOUT_STORAGE_KEY = 'kiali-dex-logout';
++
++const headerAuthLogoutURL = (): string => {
++  const redirectURL = encodeURIComponent(`${window.location.origin}/`);
++  return `/logout?rd=${redirectURL}`;
++};
++
+ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+   constructor(props: UserProps) {
+     super(props);
+@@ -72,6 +80,8 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+       this.setState({ timeCountDownSeconds: this.timeLeft() / MILLISECONDS });
+     }, 1000);
+ 
++    window.addEventListener('storage', this.handleStorageLogout);
++
+     this.setState({
+       checkSessionTimerId: checkSessionTimerId,
+       timeLeftTimerId: timeLeftTimerId
+@@ -86,6 +96,8 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+     if (this.state.timeLeftTimerId) {
+       clearInterval(this.state.timeLeftTimerId);
+     }
++
++    window.removeEventListener('storage', this.handleStorageLogout);
+   }
+ 
+   timeLeft = (): number => {
+@@ -105,6 +117,12 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
    };
  
    handleLogout = (): void => {
 +    if (authenticationConfig.strategy === AuthStrategy.header) {
-+      const redirectURL = encodeURIComponent(`${window.location.origin}/`);
-+      window.location.assign(`/logout?rd=${redirectURL}`);
++      localStorage.setItem(DEX_LOGOUT_STORAGE_KEY, String(Date.now()));
++      window.location.assign(headerAuthLogoutURL());
 +      return;
 +    }
 +
      if (authenticationConfig.logoutEndpoint) {
        API.logout()
          .then(_ => {
-@@ -143,8 +149,7 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+@@ -143,8 +161,7 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
      const clusterIsInSessionInfo = (cluster: string): boolean =>
        this.props.session?.clusterInfo?.[cluster] !== undefined;
  

--- a/modules/110-istio/images/common-v1x25x2/patches/002-kiali-logout.patch
+++ b/modules/110-istio/images/common-v1x25x2/patches/002-kiali-logout.patch
@@ -2,19 +2,20 @@ diff --git a/frontend/src/components/Nav/Masthead/UserDropdown.tsx b/frontend/sr
 index 1111111..2222222 100644
 --- a/frontend/src/components/Nav/Masthead/UserDropdown.tsx
 +++ b/frontend/src/components/Nav/Masthead/UserDropdown.tsx
-@@ -105,6 +105,11 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+@@ -105,6 +105,12 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
    };
  
    handleLogout = (): void => {
 +    if (authenticationConfig.strategy === AuthStrategy.header) {
-+      window.location.assign('/logout');
++      const redirectURL = encodeURIComponent(`${window.location.origin}/`);
++      window.location.assign(`/logout?rd=${redirectURL}`);
 +      return;
 +    }
 +
      if (authenticationConfig.logoutEndpoint) {
        API.logout()
          .then(_ => {
-@@ -143,8 +148,7 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+@@ -143,8 +149,7 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
      const clusterIsInSessionInfo = (cluster: string): boolean =>
        this.props.session?.clusterInfo?.[cluster] !== undefined;
  

--- a/modules/110-istio/images/common-v1x25x2/patches/002-kiali-logout.patch
+++ b/modules/110-istio/images/common-v1x25x2/patches/002-kiali-logout.patch
@@ -1,5 +1,5 @@
 diff --git a/frontend/src/app/App.tsx b/frontend/src/app/App.tsx
-index 05b7026..4bb4713 100644
+index 05b7026..97df374 100644
 --- a/frontend/src/app/App.tsx
 +++ b/frontend/src/app/App.tsx
 @@ -11,6 +11,8 @@ import { InitializingScreen } from './InitializingScreen';
@@ -19,13 +19,13 @@ index 05b7026..4bb4713 100644
 +    if (error.response && error.response.status === 401) {
        store.dispatch(LoginActions.sessionExpired());
 +      if (authenticationConfig.strategy === AuthStrategy.header) {
-+        window.location.replace();
++        window.location.replace(`${window.location.origin}/`);
 +      }
      }
  
      return Promise.reject(error);
 diff --git a/frontend/src/components/Nav/Masthead/UserDropdown.tsx b/frontend/src/components/Nav/Masthead/UserDropdown.tsx
-index d244f26..dc4e215 100644
+index d244f26..0a1ae5b 100644
 --- a/frontend/src/components/Nav/Masthead/UserDropdown.tsx
 +++ b/frontend/src/components/Nav/Masthead/UserDropdown.tsx
 @@ -51,6 +51,14 @@ const dropdownStyle = kialiStyle({
@@ -61,9 +61,18 @@ index d244f26..dc4e215 100644
    }
  
    timeLeft = (): number => {
-@@ -105,6 +117,12 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+@@ -104,7 +116,21 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+     }
    };
  
++
++  handleStorageLogout = (event: StorageEvent): void => {
++    if (event.key !== DEX_LOGOUT_STORAGE_KEY || !event.newValue) {
++      return;
++    }
++    window.location.assign(headerAuthLogoutURL());
++  };
++
    handleLogout = (): void => {
 +    if (authenticationConfig.strategy === AuthStrategy.header) {
 +      localStorage.setItem(DEX_LOGOUT_STORAGE_KEY, String(Date.now()));
@@ -74,7 +83,7 @@ index d244f26..dc4e215 100644
      if (authenticationConfig.logoutEndpoint) {
        API.logout()
          .then(_ => {
-@@ -143,8 +161,7 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+@@ -143,8 +169,7 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
      const clusterIsInSessionInfo = (cluster: string): boolean =>
        this.props.session?.clusterInfo?.[cluster] !== undefined;
  

--- a/modules/110-istio/images/common-v1x25x2/patches/README.md
+++ b/modules/110-istio/images/common-v1x25x2/patches/README.md
@@ -15,4 +15,4 @@ Adopted upstream pr https://github.com/istio/istio/pull/58567.
 
 ## 002-kiali-logout.patch
 
-Adds logout button in kiali
+Enable Logout in Kiali for header auth (DexAuthenticator) and redirect to `/logout?rd=<app-origin>/` so sign-out returns to the app and avoids stale Dex login CSRF.

--- a/modules/110-istio/images/common-v1x25x2/patches/README.md
+++ b/modules/110-istio/images/common-v1x25x2/patches/README.md
@@ -1,14 +1,18 @@
 # Patches
 
-## 001-kiali-go-mod.patch
-
-Fix Kiali CVE vulnerabilities
-
 ## 001-istio-gomod_gosum.patch
 
 Fix Istio CVE vulnerabilities
+
+## 001-kiali-go-mod.patch
+
+Fix Kiali CVE vulnerabilities
 
 ## 002-istio-multicluster-regenerate-token-timeout.patch
 
 Implement graceful transition for remote multicluster secrets. To prevent connectivity gaps during secret rotation, the old secret is no longer dismissed immediately. Instead, it remains active until the new secret is processed and all associated metadata is synced.
 Adopted upstream pr https://github.com/istio/istio/pull/58567.
+
+## 002-kiali-logout.patch
+
+Adds logout button in kiali

--- a/modules/110-istio/images/common-v1x25x2/patches/README.md
+++ b/modules/110-istio/images/common-v1x25x2/patches/README.md
@@ -15,4 +15,4 @@ Adopted upstream pr https://github.com/istio/istio/pull/58567.
 
 ## 002-kiali-logout.patch
 
-Enable Logout in Kiali for header auth (DexAuthenticator) and redirect to `/logout?rd=<app-origin>/` so sign-out returns to the app and avoids stale Dex login CSRF.
+Enable Logout in Kiali for header auth (DexAuthenticator). Redirects to `/logout?rd=<app-origin>/`, broadcasts logout to other tabs via `localStorage`, and on 401 forces a full-page reload to stop stale XHRs from racing the Dex auth flow.

--- a/modules/110-istio/images/common-v1x25x2/patches/README.md
+++ b/modules/110-istio/images/common-v1x25x2/patches/README.md
@@ -15,4 +15,4 @@ Adopted upstream pr https://github.com/istio/istio/pull/58567.
 
 ## 002-kiali-logout.patch
 
-Enable Logout in Kiali for header auth (DexAuthenticator). Redirects to `/logout?rd=<app-origin>/`, broadcasts logout to other tabs via `localStorage`, and on 401 forces a full-page reload to stop stale XHRs from racing the Dex auth flow.
+Enable Logout in Kiali for header auth (DexAuthenticator). The tab that clicks Logout calls `/logout?rd=<app-origin>/` once; other tabs receive a `localStorage` event and only dispatch `sessionExpired` locally (no second sign_out, no reload) to avoid oauth2-proxy CSRF races.

--- a/modules/110-istio/images/common-v1x25x2/werf.inc.yaml
+++ b/modules/110-istio/images/common-v1x25x2/werf.inc.yaml
@@ -27,15 +27,25 @@ git:
   stageDependencies:
     install:
     - '**/*'
-- url: {{ .SOURCE_REPO }}/istio/kiali-frontend-assets.git
-  tag: {{ $kialiVersion }}
-  add: /
-  to: /src/kial-frontend-assets
-  stageDependencies:
-    install:
-    - '**/*'
 shell:
   install:
   - cd /src/istio/ && git apply --verbose /patches/001-istio-gomod_gosum.patch
   - cd /src/istio/ && git apply --verbose /patches/002-istio-multicluster-regenerate-token-timeout.patch
   - cd /src/kiali/ && git apply --verbose /patches/001-kiali-go-mod.patch
+  - cd /src/kiali/ && git apply --verbose /patches/002-kiali-logout.patch
+---
+image: {{ .ModuleName }}/{{ .ImageName }}-kiali-frontend-build-artifact
+from: {{ index $.Images "builder/node-alpine-22.16" }}
+final: false
+import:
+- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+  add: /src/kiali/frontend
+  to: /src/kiali/frontend
+  before: install
+shell:
+  install:
+  - cd /src/kiali/frontend
+  - yarn install --frozen-lockfile
+  - KIALI_ENV=production yarn run build
+  - mkdir -p /src/kial-frontend-assets/static
+  - cp -a build/. /src/kial-frontend-assets/static/

--- a/modules/110-istio/images/common-v1x27x9/patches/002-kiali-logout.patch
+++ b/modules/110-istio/images/common-v1x27x9/patches/002-kiali-logout.patch
@@ -1,5 +1,5 @@
 diff --git a/frontend/src/components/Nav/Masthead/UserDropdown.tsx b/frontend/src/components/Nav/Masthead/UserDropdown.tsx
-index d244f26..c230ca1 100644
+index d244f26..e8f304d 100644
 --- a/frontend/src/components/Nav/Masthead/UserDropdown.tsx
 +++ b/frontend/src/components/Nav/Masthead/UserDropdown.tsx
 @@ -10,6 +10,8 @@ import { AuthStrategy } from '../../../types/Auth';
@@ -44,7 +44,7 @@ index d244f26..c230ca1 100644
    }
  
    timeLeft = (): number => {
-@@ -104,6 +118,16 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+@@ -104,7 +118,23 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
      }
    };
  
@@ -67,7 +67,8 @@ index d244f26..c230ca1 100644
 +
      if (authenticationConfig.logoutEndpoint) {
        API.logout()
-@@ -143,8 +167,7 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+         .then(_ => {
+@@ -143,8 +173,7 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
      const clusterIsInSessionInfo = (cluster: string): boolean =>
        this.props.session?.clusterInfo?.[cluster] !== undefined;
  

--- a/modules/110-istio/images/common-v1x27x9/patches/002-kiali-logout.patch
+++ b/modules/110-istio/images/common-v1x27x9/patches/002-kiali-logout.patch
@@ -1,34 +1,17 @@
-diff --git a/frontend/src/app/App.tsx b/frontend/src/app/App.tsx
-index 05b7026..97df374 100644
---- a/frontend/src/app/App.tsx
-+++ b/frontend/src/app/App.tsx
-@@ -11,6 +11,8 @@ import { InitializingScreen } from './InitializingScreen';
- import { StartupInitializer } from './StartupInitializer';
- import { LoginPage } from '../pages/Login/LoginPage';
- import { LoginActions } from '../actions/LoginActions';
-+import { authenticationConfig } from '../config/AuthenticationConfig';
-+import { AuthStrategy } from '../types/Auth';
- 
- Visibility.change((_e, state) => {
-   // There are 3 states, visible, hidden and prerender, consider prerender as hidden.
-@@ -73,8 +75,11 @@ axios.interceptors.response.use(
-     // The response was rejected, turn off the spinning
-     decrementLoadingCounter();
- 
--    if (error.response.status === 401) {
-+    if (error.response && error.response.status === 401) {
-       store.dispatch(LoginActions.sessionExpired());
-+      if (authenticationConfig.strategy === AuthStrategy.header) {
-+        window.location.replace(`${window.location.origin}/`);
-+      }
-     }
- 
-     return Promise.reject(error);
 diff --git a/frontend/src/components/Nav/Masthead/UserDropdown.tsx b/frontend/src/components/Nav/Masthead/UserDropdown.tsx
-index d244f26..0a1ae5b 100644
+index d244f26..c230ca1 100644
 --- a/frontend/src/components/Nav/Masthead/UserDropdown.tsx
 +++ b/frontend/src/components/Nav/Masthead/UserDropdown.tsx
-@@ -51,6 +51,14 @@ const dropdownStyle = kialiStyle({
+@@ -10,6 +10,8 @@ import { AuthStrategy } from '../../../types/Auth';
+ import moment from 'moment';
+ import { KialiDispatch } from 'types/Redux';
+ import { LoginThunkActions } from '../../../actions/LoginThunkActions';
++import { LoginActions } from '../../../actions/LoginActions';
++import { store } from '../../../store/ConfigStore';
+ import { connect } from 'react-redux';
+ import * as API from '../../../services/Api';
+ import { kialiStyle } from 'styles/StyleUtils';
+@@ -51,6 +53,14 @@ const dropdownStyle = kialiStyle({
    paddingRight: 0
  });
  
@@ -43,7 +26,7 @@ index d244f26..0a1ae5b 100644
  class UserDropdownComponent extends React.Component<UserProps, UserState> {
    constructor(props: UserProps) {
      super(props);
-@@ -72,6 +80,8 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+@@ -72,6 +82,8 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
        this.setState({ timeCountDownSeconds: this.timeLeft() / MILLISECONDS });
      }, 1000);
  
@@ -52,7 +35,7 @@ index d244f26..0a1ae5b 100644
      this.setState({
        checkSessionTimerId: checkSessionTimerId,
        timeLeftTimerId: timeLeftTimerId
-@@ -86,6 +96,8 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+@@ -86,6 +98,8 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
      if (this.state.timeLeftTimerId) {
        clearInterval(this.state.timeLeftTimerId);
      }
@@ -61,7 +44,7 @@ index d244f26..0a1ae5b 100644
    }
  
    timeLeft = (): number => {
-@@ -104,7 +116,21 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+@@ -104,6 +118,16 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
      }
    };
  
@@ -70,7 +53,9 @@ index d244f26..0a1ae5b 100644
 +    if (event.key !== DEX_LOGOUT_STORAGE_KEY || !event.newValue) {
 +      return;
 +    }
-+    window.location.assign(headerAuthLogoutURL());
++    // Do not call /logout or reload here: only the tab that clicked Logout runs sign_out.
++    // Mark this tab as logged out locally to stop XHR polling without racing oauth2-proxy CSRF.
++    store.dispatch(LoginActions.sessionExpired());
 +  };
 +
    handleLogout = (): void => {
@@ -82,8 +67,7 @@ index d244f26..0a1ae5b 100644
 +
      if (authenticationConfig.logoutEndpoint) {
        API.logout()
-         .then(_ => {
-@@ -143,8 +169,7 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+@@ -143,8 +167,7 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
      const clusterIsInSessionInfo = (cluster: string): boolean =>
        this.props.session?.clusterInfo?.[cluster] !== undefined;
  

--- a/modules/110-istio/images/common-v1x27x9/patches/002-kiali-logout.patch
+++ b/modules/110-istio/images/common-v1x27x9/patches/002-kiali-logout.patch
@@ -1,0 +1,26 @@
+diff --git a/frontend/src/components/Nav/Masthead/UserDropdown.tsx b/frontend/src/components/Nav/Masthead/UserDropdown.tsx
+index 1111111..2222222 100644
+--- a/frontend/src/components/Nav/Masthead/UserDropdown.tsx
++++ b/frontend/src/components/Nav/Masthead/UserDropdown.tsx
+@@ -105,6 +105,11 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+   };
+ 
+   handleLogout = (): void => {
++    if (authenticationConfig.strategy === AuthStrategy.header) {
++      window.location.assign('/logout');
++      return;
++    }
++
+     if (authenticationConfig.logoutEndpoint) {
+       API.logout()
+         .then(_ => {
+@@ -143,8 +148,7 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+     const clusterIsInSessionInfo = (cluster: string): boolean =>
+       this.props.session?.clusterInfo?.[cluster] !== undefined;
+ 
+-    const canLogout =
+-      authenticationConfig.strategy !== AuthStrategy.anonymous && authenticationConfig.strategy !== AuthStrategy.header;
++    const canLogout = authenticationConfig.strategy !== AuthStrategy.anonymous;
+ 
+     // We want to show a dropdown per cluster the user is not logged into yet.
+     // The clusters you are logged into are in session.clusterInfo and all

--- a/modules/110-istio/images/common-v1x27x9/patches/002-kiali-logout.patch
+++ b/modules/110-istio/images/common-v1x27x9/patches/002-kiali-logout.patch
@@ -1,21 +1,80 @@
+diff --git a/frontend/src/app/App.tsx b/frontend/src/app/App.tsx
+index 05b7026..4bb4713 100644
+--- a/frontend/src/app/App.tsx
++++ b/frontend/src/app/App.tsx
+@@ -11,6 +11,8 @@ import { InitializingScreen } from './InitializingScreen';
+ import { StartupInitializer } from './StartupInitializer';
+ import { LoginPage } from '../pages/Login/LoginPage';
+ import { LoginActions } from '../actions/LoginActions';
++import { authenticationConfig } from '../config/AuthenticationConfig';
++import { AuthStrategy } from '../types/Auth';
+ 
+ Visibility.change((_e, state) => {
+   // There are 3 states, visible, hidden and prerender, consider prerender as hidden.
+@@ -73,8 +75,11 @@ axios.interceptors.response.use(
+     // The response was rejected, turn off the spinning
+     decrementLoadingCounter();
+ 
+-    if (error.response.status === 401) {
++    if (error.response && error.response.status === 401) {
+       store.dispatch(LoginActions.sessionExpired());
++      if (authenticationConfig.strategy === AuthStrategy.header) {
++        window.location.replace();
++      }
+     }
+ 
+     return Promise.reject(error);
 diff --git a/frontend/src/components/Nav/Masthead/UserDropdown.tsx b/frontend/src/components/Nav/Masthead/UserDropdown.tsx
-index 1111111..2222222 100644
+index d244f26..dc4e215 100644
 --- a/frontend/src/components/Nav/Masthead/UserDropdown.tsx
 +++ b/frontend/src/components/Nav/Masthead/UserDropdown.tsx
-@@ -105,6 +105,12 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+@@ -51,6 +51,14 @@ const dropdownStyle = kialiStyle({
+   paddingRight: 0
+ });
+ 
++
++const DEX_LOGOUT_STORAGE_KEY = 'kiali-dex-logout';
++
++const headerAuthLogoutURL = (): string => {
++  const redirectURL = encodeURIComponent(`${window.location.origin}/`);
++  return `/logout?rd=${redirectURL}`;
++};
++
+ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+   constructor(props: UserProps) {
+     super(props);
+@@ -72,6 +80,8 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+       this.setState({ timeCountDownSeconds: this.timeLeft() / MILLISECONDS });
+     }, 1000);
+ 
++    window.addEventListener('storage', this.handleStorageLogout);
++
+     this.setState({
+       checkSessionTimerId: checkSessionTimerId,
+       timeLeftTimerId: timeLeftTimerId
+@@ -86,6 +96,8 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+     if (this.state.timeLeftTimerId) {
+       clearInterval(this.state.timeLeftTimerId);
+     }
++
++    window.removeEventListener('storage', this.handleStorageLogout);
+   }
+ 
+   timeLeft = (): number => {
+@@ -105,6 +117,12 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
    };
  
    handleLogout = (): void => {
 +    if (authenticationConfig.strategy === AuthStrategy.header) {
-+      const redirectURL = encodeURIComponent(`${window.location.origin}/`);
-+      window.location.assign(`/logout?rd=${redirectURL}`);
++      localStorage.setItem(DEX_LOGOUT_STORAGE_KEY, String(Date.now()));
++      window.location.assign(headerAuthLogoutURL());
 +      return;
 +    }
 +
      if (authenticationConfig.logoutEndpoint) {
        API.logout()
          .then(_ => {
-@@ -143,8 +149,7 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+@@ -143,8 +161,7 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
      const clusterIsInSessionInfo = (cluster: string): boolean =>
        this.props.session?.clusterInfo?.[cluster] !== undefined;
  

--- a/modules/110-istio/images/common-v1x27x9/patches/002-kiali-logout.patch
+++ b/modules/110-istio/images/common-v1x27x9/patches/002-kiali-logout.patch
@@ -2,19 +2,20 @@ diff --git a/frontend/src/components/Nav/Masthead/UserDropdown.tsx b/frontend/sr
 index 1111111..2222222 100644
 --- a/frontend/src/components/Nav/Masthead/UserDropdown.tsx
 +++ b/frontend/src/components/Nav/Masthead/UserDropdown.tsx
-@@ -105,6 +105,11 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+@@ -105,6 +105,12 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
    };
  
    handleLogout = (): void => {
 +    if (authenticationConfig.strategy === AuthStrategy.header) {
-+      window.location.assign('/logout');
++      const redirectURL = encodeURIComponent(`${window.location.origin}/`);
++      window.location.assign(`/logout?rd=${redirectURL}`);
 +      return;
 +    }
 +
      if (authenticationConfig.logoutEndpoint) {
        API.logout()
          .then(_ => {
-@@ -143,8 +148,7 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+@@ -143,8 +149,7 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
      const clusterIsInSessionInfo = (cluster: string): boolean =>
        this.props.session?.clusterInfo?.[cluster] !== undefined;
  

--- a/modules/110-istio/images/common-v1x27x9/patches/002-kiali-logout.patch
+++ b/modules/110-istio/images/common-v1x27x9/patches/002-kiali-logout.patch
@@ -1,5 +1,5 @@
 diff --git a/frontend/src/app/App.tsx b/frontend/src/app/App.tsx
-index 05b7026..4bb4713 100644
+index 05b7026..97df374 100644
 --- a/frontend/src/app/App.tsx
 +++ b/frontend/src/app/App.tsx
 @@ -11,6 +11,8 @@ import { InitializingScreen } from './InitializingScreen';
@@ -19,13 +19,13 @@ index 05b7026..4bb4713 100644
 +    if (error.response && error.response.status === 401) {
        store.dispatch(LoginActions.sessionExpired());
 +      if (authenticationConfig.strategy === AuthStrategy.header) {
-+        window.location.replace();
++        window.location.replace(`${window.location.origin}/`);
 +      }
      }
  
      return Promise.reject(error);
 diff --git a/frontend/src/components/Nav/Masthead/UserDropdown.tsx b/frontend/src/components/Nav/Masthead/UserDropdown.tsx
-index d244f26..dc4e215 100644
+index d244f26..0a1ae5b 100644
 --- a/frontend/src/components/Nav/Masthead/UserDropdown.tsx
 +++ b/frontend/src/components/Nav/Masthead/UserDropdown.tsx
 @@ -51,6 +51,14 @@ const dropdownStyle = kialiStyle({
@@ -61,9 +61,18 @@ index d244f26..dc4e215 100644
    }
  
    timeLeft = (): number => {
-@@ -105,6 +117,12 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+@@ -104,7 +116,21 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+     }
    };
  
++
++  handleStorageLogout = (event: StorageEvent): void => {
++    if (event.key !== DEX_LOGOUT_STORAGE_KEY || !event.newValue) {
++      return;
++    }
++    window.location.assign(headerAuthLogoutURL());
++  };
++
    handleLogout = (): void => {
 +    if (authenticationConfig.strategy === AuthStrategy.header) {
 +      localStorage.setItem(DEX_LOGOUT_STORAGE_KEY, String(Date.now()));
@@ -74,7 +83,7 @@ index d244f26..dc4e215 100644
      if (authenticationConfig.logoutEndpoint) {
        API.logout()
          .then(_ => {
-@@ -143,8 +161,7 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
+@@ -143,8 +169,7 @@ class UserDropdownComponent extends React.Component<UserProps, UserState> {
      const clusterIsInSessionInfo = (cluster: string): boolean =>
        this.props.session?.clusterInfo?.[cluster] !== undefined;
  

--- a/modules/110-istio/images/common-v1x27x9/patches/README.md
+++ b/modules/110-istio/images/common-v1x27x9/patches/README.md
@@ -15,4 +15,4 @@ Adopted upstream pr https://github.com/istio/istio/pull/58567.
 
 ## 002-kiali-logout.patch
 
-Adds logout button in kiali
+Enable Logout in Kiali for header auth (DexAuthenticator) and redirect to `/logout?rd=<app-origin>/` so sign-out returns to the app and avoids stale Dex login CSRF.

--- a/modules/110-istio/images/common-v1x27x9/patches/README.md
+++ b/modules/110-istio/images/common-v1x27x9/patches/README.md
@@ -15,4 +15,4 @@ Adopted upstream pr https://github.com/istio/istio/pull/58567.
 
 ## 002-kiali-logout.patch
 
-Enable Logout in Kiali for header auth (DexAuthenticator) and redirect to `/logout?rd=<app-origin>/` so sign-out returns to the app and avoids stale Dex login CSRF.
+Enable Logout in Kiali for header auth (DexAuthenticator). Redirects to `/logout?rd=<app-origin>/`, broadcasts logout to other tabs via `localStorage`, and on 401 forces a full-page reload to stop stale XHRs from racing the Dex auth flow.

--- a/modules/110-istio/images/common-v1x27x9/patches/README.md
+++ b/modules/110-istio/images/common-v1x27x9/patches/README.md
@@ -15,4 +15,4 @@ Adopted upstream pr https://github.com/istio/istio/pull/58567.
 
 ## 002-kiali-logout.patch
 
-Enable Logout in Kiali for header auth (DexAuthenticator). Redirects to `/logout?rd=<app-origin>/`, broadcasts logout to other tabs via `localStorage`, and on 401 forces a full-page reload to stop stale XHRs from racing the Dex auth flow.
+Enable Logout in Kiali for header auth (DexAuthenticator). The tab that clicks Logout calls `/logout?rd=<app-origin>/` once; other tabs receive a `localStorage` event and only dispatch `sessionExpired` locally (no second sign_out, no reload) to avoid oauth2-proxy CSRF races.

--- a/modules/110-istio/images/common-v1x27x9/patches/README.md
+++ b/modules/110-istio/images/common-v1x27x9/patches/README.md
@@ -12,3 +12,7 @@ Fix Kiali CVE vulnerabilities
 
 Implement graceful transition for remote multicluster secrets. To prevent connectivity gaps during secret rotation, the old secret is no longer dismissed immediately. Instead, it remains active until the new secret is processed and all associated metadata is synced.
 Adopted upstream pr https://github.com/istio/istio/pull/58567.
+
+## 002-kiali-logout.patch
+
+Adds logout button in kiali

--- a/modules/110-istio/images/common-v1x27x9/werf.inc.yaml
+++ b/modules/110-istio/images/common-v1x27x9/werf.inc.yaml
@@ -22,10 +22,6 @@ git:
   tag: {{ $kialiVersion }}
   add: /
   to: /src/kiali
-- url: {{ .SOURCE_REPO }}/istio/kiali-frontend-assets.git
-  tag: {{ $kialiVersion }}
-  add: /static
-  to: /src/kiali/frontend/build
 shell:
   install:
   # istio
@@ -35,4 +31,19 @@ shell:
   # kiali
   - cd /src/kiali/
   - git apply --verbose /patches/001-kiali-gomod_gosum.patch
+  - git apply --verbose /patches/002-kiali-logout.patch
+---
+image: {{ .ModuleName }}/{{ .ImageName }}-kiali-frontend-build-artifact
+from: {{ index $.Images "builder/node-alpine-22.16" }}
+final: false
+import:
+- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+  add: /src/kiali/frontend
+  to: /src/kiali/frontend
+  before: install
+shell:
+  install:
+  - cd /src/kiali/frontend
+  - yarn install --frozen-lockfile
+  - KIALI_ENV=production yarn run build
 {{- end }}

--- a/modules/110-istio/images/kiali-v1x21x6/werf.inc.yaml
+++ b/modules/110-istio/images/kiali-v1x21x6/werf.inc.yaml
@@ -11,7 +11,7 @@ import:
   add: /src/kiali/out/kiali
   to: /opt/kiali/kiali
   before: install
-- image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
+- image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-kiali-frontend-build-artifact
   add: /src/kial-frontend-assets/static
   to: /opt/kiali/console
   before: install

--- a/modules/110-istio/images/kiali-v1x25x2/werf.inc.yaml
+++ b/modules/110-istio/images/kiali-v1x25x2/werf.inc.yaml
@@ -11,7 +11,7 @@ import:
   add: /src/kiali/out/kiali
   to: /opt/kiali/kiali
   before: install
-- image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
+- image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-kiali-frontend-build-artifact
   add: /src/kial-frontend-assets/static
   to: /opt/kiali/console
   before: install

--- a/modules/110-istio/images/kiali-v1x27x9/werf.inc.yaml
+++ b/modules/110-istio/images/kiali-v1x27x9/werf.inc.yaml
@@ -31,6 +31,10 @@ import:
   add: /src/kiali
   to: /src/kiali
   before: install
+- image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-kiali-frontend-build-artifact
+  add: /src/kiali/frontend/build
+  to: /src/kiali/frontend/build
+  before: install
 secrets:
 - id: GOPROXY
   value: {{ .GOPROXY }}

--- a/modules/110-istio/templates/kiali/authenticator.yaml
+++ b/modules/110-istio/templates/kiali/authenticator.yaml
@@ -20,6 +20,7 @@ spec:
     {{- end }}
   {{- end }}
   applicationIngressClassName: {{ include "helm_lib_module_ingress_class" . | quote }}
+  signOutURL: "/logout"
   sendAuthorizationHeader: true
   {{- with .Values.istio.auth.allowedUserEmails }}
   allowedEmails:


### PR DESCRIPTION
## Description
Add proper logout for Kiali at `istio.<publicDomain>`:

- Set signOutURL: "/logout" on the Istio DexAuthenticator, so /logout is routed to dex-authenticator sign-out (same pattern as Grafana/Hubble).
- Patch Kiali UI for header auth: show Logout in the top-right user menu and redirect to /logout on click.
- Build Kiali frontend from patched sources in images for supported Istio/Kiali versions instead of using prebuilt kiali-frontend-assets.

Logout btn is in dropdown under user email.
<img width="492" height="196" alt="image" src="https://github.com/user-attachments/assets/3e00d760-6895-4d4b-96bd-8d62ef196baa" />
All other tabs sessions are expiring when user does logout in any of them and can be restored using page refresh (F5) _with the same URL_ it was before logout.
<img width="617" height="376" alt="image" src="https://github.com/user-attachments/assets/08324c31-fa50-4337-8911-db4e39cfdb63" />


## Why do we need it, and what problem does it solve?
Allows to end Dex session in Kiali.


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: chore
summary: Added a logout button to the Kiali console.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
