### PR TITLE
[istio] Fix nelm rollout ordering for Certificate resources

### DIFF
--- a/ee/modules/110-istio/templates/multicluster/api-proxy/ingress.yaml
+++ b/ee/modules/110-istio/templates/multicluster/api-proxy/ingress.yaml
@@ -45,6 +45,8 @@ kind: Certificate
 metadata:
   name: api-proxy
   namespace: d8-{{ $.Chart.Name }}
+  annotations:
+    werf.io/deploy-dependency-api-proxy: state=ready,kind=Deployment,name=api-proxy,namespace=d8-{{ $.Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "api-proxy")) | nindent 2 }}
 spec:
   certificateOwnerRef: false

--- a/modules/110-istio/templates/certificate.yaml
+++ b/modules/110-istio/templates/certificate.yaml
@@ -8,9 +8,7 @@ metadata:
   name: istio
   namespace: d8-{{ $.Chart.Name }}
   annotations:
-    # Don't work readiness probe with NELM
-    werf.io/fail-mode: IgnoreAndContinueDeployProcess
-    werf.io/track-termination-mode: NonBlocking
+    werf.io/deploy-dependency-kiali: state=ready,kind=Deployment,name=kiali,namespace=d8-{{ $.Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "istio")) | nindent 2 }}
 spec:
   certificateOwnerRef: false
@@ -31,8 +29,7 @@ metadata:
   name: istio-httproute
   namespace: d8-{{ $.Chart.Name }}
   annotations:
-    werf.io/fail-mode: IgnoreAndContinueDeployProcess
-    werf.io/track-termination-mode: NonBlocking
+    werf.io/deploy-dependency-kiali: state=ready,kind=Deployment,name=kiali,namespace=d8-{{ $.Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "istio")) | nindent 2 }}
 spec:
   certificateOwnerRef: false
@@ -52,8 +49,7 @@ metadata:
   name: api-proxy-httproute
   namespace: d8-{{ $.Chart.Name }}
   annotations:
-    werf.io/fail-mode: IgnoreAndContinueDeployProcess
-    werf.io/track-termination-mode: NonBlocking
+    werf.io/deploy-dependency-api-proxy: state=ready,kind=Deployment,name=api-proxy,namespace=d8-{{ $.Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "api-proxy")) | nindent 2 }}
 spec:
   certificateOwnerRef: false


### PR DESCRIPTION
## Description

Updated the Istio module manifests to use explicit Nelm rollout dependencies for cert-manager `Certificate` resources.

The previous `werf.io/fail-mode: IgnoreAndContinueDeployProcess` and `werf.io/track-termination-mode: NonBlocking` workaround was removed from Istio certificates. Instead, certificates now wait for the relevant backend deployments to become ready:

- `istio` and `istio-httproute` certificates depend on `Deployment/kiali`;
- `api-proxy-httproute` and EE `api-proxy` certificates depend on `Deployment/api-proxy`.

This change does not intentionally restart critical cluster components, but it changes the rollout order of Istio TLS certificate resources.

## Why do we need it, and what problem does it solve?

When Nelm is enabled, Istio `Certificate` resources may block the module rollout queue while waiting for readiness. In this scenario, the certificate rollout depends on workloads that are applied later in the same release, which can lead to a rollout deadlock.

The previous workaround disabled normal tracking for these certificates, allowing the rollout to continue but hiding the real dependency. This change replaces that workaround with explicit rollout dependencies, so Nelm applies and tracks certificates only after the deployments required for successful certificate issuance are ready.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: fix
summary: Fixed nelm rollout ordering for Certificate resources.
impact_level: default
```
