### PR TITLE
[docs] Added ml/ai tag to ai-models module

### DIFF
--- a/docs/documentation/_data/modules/modules-addition.json
+++ b/docs/documentation/_data/modules/modules-addition.json
@@ -41,7 +41,7 @@
       "ee"
     ],
     "external": "true",
-    "path": "/modules/ai-models/stable/",
+    "path": "/modules/ai-models/",
     "tags": [
       "ml/ai"
     ]

--- a/docs/documentation/_data/modules/modules-addition.json
+++ b/docs/documentation/_data/modules/modules-addition.json
@@ -36,6 +36,16 @@
     "external": "true",
     "path": "/modules/alb/"
   },
+  "ai-models": {
+    "editions": [
+      "ee"
+    ],
+    "external": "true",
+    "path": "/modules/ai-models/stable/",
+    "tags": [
+      "ml/ai"
+    ]
+  },
   "cloud-provider-vsphere": {
     "editionFullyAvailable": [
       "se-plus",

--- a/docs/documentation/_data/modules/modules-addition.json
+++ b/docs/documentation/_data/modules/modules-addition.json
@@ -41,10 +41,7 @@
       "ee"
     ],
     "external": "true",
-    "path": "/modules/ai-models/",
-    "tags": [
-      "ml/ai"
-    ]
+    "path": "/modules/ai-models/"
   },
   "cloud-provider-vsphere": {
     "editionFullyAvailable": [

--- a/docs/site/backends/docs-builder-template/data/modules_all.json
+++ b/docs/site/backends/docs-builder-template/data/modules_all.json
@@ -25,6 +25,17 @@
       "ssdlc"
     ]
   },
+  "ai-models": {
+    "editions": [
+      "ee"
+    ],
+    "external": "true",
+    "path": "/modules/ai-models/stable/",
+    "tags": [
+      "ml/ai",
+      "ssdlc"
+    ]
+  },
   "code": {
     "editions": [
       "ee",

--- a/docs/site/backends/docs-builder-template/data/modules_all.json
+++ b/docs/site/backends/docs-builder-template/data/modules_all.json
@@ -30,7 +30,7 @@
       "ee"
     ],
     "external": "true",
-    "path": "/modules/ai-models/stable/",
+    "path": "/modules/ai-models/",
     "tags": [
       "ml/ai",
       "ssdlc"


### PR DESCRIPTION
## Description

Added the ml/ai tag to the ai-models module on the modules homepage.

## Why do we need it, and what problem does it solve?

## Why do we need it in the patch release (if we do)?

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: fix 
summary: Added the ml/ai tag to the ai-models module on the modules homepage.
impact_level: low
```
