### PR TITLE
[dhctl] Fixed RequiredSSHHost

### DIFF
--- a/dhctl/pkg/system/providerinitializer/providers.go
+++ b/dhctl/pkg/system/providerinitializer/providers.go
@@ -151,17 +151,24 @@ func getProviderInitializer(baseProviderSettings *settings.BaseProviders, opts .
 		}
 	} else {
 		// loggerProvider should be forced to non-interactive to ask for password, because our wrapper hides all Info* and Warn* output
-		sett := baseProviderSettings.Clone()
-		loggerProvider := log.NonInteractiveLoggerProvider()
-		sett.WithLogger(loggerProvider)
+		sett := baseProviderSettings.
+			Clone().
+			WithLogger(log.NonInteractiveLoggerProvider())
+
 		parser := libcon_config.NewFlagsParser(sett)
 		parser.WithEnvsPrefix(global.SSHEnvsPrefix)
-		fset := flag.NewFlagSet("my-set", flag.ExitOnError)
-		flags, err := parser.InitFlags(fset)
+
+		flags, err := parser.InitFlags(
+			flag.NewFlagSet("my-set", flag.ExitOnError),
+		)
 		if err != nil {
 			return nil, fmt.Errorf("init flags: %w", err)
 		}
-		config, err = flags.ExtractConfig(os.Args[1:])
+
+		config, err = flags.ExtractConfig(
+			os.Args[1:],
+			libcon_config.ParseWithRequiredSSHHost(false),
+		)
 		if err != nil {
 			if strings.Contains(err.Error(), "Failed to read private keys from flags") && options.kubeFlagsDefined {
 				return nil, nil


### PR DESCRIPTION
## Description

Fix connection config validation. SSHHost should be optional. Otherwise, bootstrap fails for cloud installations.

In the future, we need to upgrade to a new version of lib-connection where the default check has been removed - https://github.com/deckhouse/lib-connection/pull/34

## Why do we need it, and what problem does it solve?

Fix connection config validation.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Fixed connection configuration validation.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
