### PR TITLE
[cloud-provider-dvp] make cloud-init secrets immutable

### DIFF
--- a/modules/030-cloud-provider-dvp/candi/terraform-modules/master/main.tf
+++ b/modules/030-cloud-provider-dvp/candi/terraform-modules/master/main.tf
@@ -25,7 +25,8 @@ resource "kubernetes_secret" "cloudinit-secret" {
       user_data      = var.cloud_config == "" ? "" : base64decode(var.cloud_config)
     })
   }
-  type = "provisioning.virtualization.deckhouse.io/cloud-init"
+  type      = "provisioning.virtualization.deckhouse.io/cloud-init"
+  immutable = true
   lifecycle {
     ignore_changes = [
       data

--- a/modules/030-cloud-provider-dvp/candi/terraform-modules/static-node/main.tf
+++ b/modules/030-cloud-provider-dvp/candi/terraform-modules/static-node/main.tf
@@ -25,7 +25,8 @@ resource "kubernetes_secret" "cloudinit-secret" {
       user_data      = var.cloud_config == "" ? "" : base64decode(var.cloud_config)
     })
   }
-  type = "provisioning.virtualization.deckhouse.io/cloud-init"
+  type      = "provisioning.virtualization.deckhouse.io/cloud-init"
+  immutable = true
   lifecycle {
     ignore_changes = [
       data

--- a/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/internal/controller/deckhousemachine_controller.go
+++ b/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/internal/controller/deckhousemachine_controller.go
@@ -331,7 +331,7 @@ func (r *DeckhouseMachineReconciler) handleVMRunning(
 
 	cloudInitSecretName := "cloud-init-" + dvpMachine.Name
 	if err := r.DVP.ComputeService.EnsureCloudInitSecretImmutable(ctx, cloudInitSecretName); err != nil {
-		logger.Error(err, "failed to ensure cloud-init secret immutable", "secret", cloudInitSecretName)
+		return ctrl.Result{}, fmt.Errorf("ensure cloud-init secret immutable %q: %w", cloudInitSecretName, err)
 	}
 
 	logger.Info("Reconciled DeckhouseMachine successfully")

--- a/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/internal/controller/deckhousemachine_controller.go
+++ b/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/internal/controller/deckhousemachine_controller.go
@@ -287,7 +287,7 @@ func (r *DeckhouseMachineReconciler) reconcileVMPhase(
 ) (ctrl.Result, error) {
 	switch vm.Status.Phase {
 	case v1alpha2.MachineRunning:
-		return r.handleVMRunning(logger, dvpMachine, vm)
+		return r.handleVMRunning(ctx, logger, dvpMachine, vm)
 	case v1alpha2.MachineStopped:
 		return r.handleVMStopped(ctx, logger, dvpMachine, vm)
 	case v1alpha2.MachineDegraded:
@@ -298,6 +298,7 @@ func (r *DeckhouseMachineReconciler) reconcileVMPhase(
 }
 
 func (r *DeckhouseMachineReconciler) handleVMRunning(
+	ctx context.Context,
 	logger logr.Logger,
 	dvpMachine *infrastructurev1a1.DeckhouseMachine,
 	vm *v1alpha2.VirtualMachine,
@@ -327,6 +328,11 @@ func (r *DeckhouseMachineReconciler) handleVMRunning(
 	// 		return ctrl.Result{}, fmt.Errorf("delete cloud-init secret %q: %w", cloudInitSecretName, err)
 	// 	}
 	// }
+
+	cloudInitSecretName := "cloud-init-" + dvpMachine.Name
+	if err := r.DVP.ComputeService.EnsureCloudInitSecretImmutable(ctx, cloudInitSecretName); err != nil {
+		logger.Error(err, "failed to ensure cloud-init secret immutable", "secret", cloudInitSecretName)
+	}
 
 	logger.Info("Reconciled DeckhouseMachine successfully")
 	return ctrl.Result{}, nil

--- a/modules/030-cloud-provider-dvp/images/dvp-common/api/compute.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-common/api/compute.go
@@ -17,6 +17,7 @@ limitations under the License.
 package api
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -450,7 +451,13 @@ func (c *ComputeService) CreateCloudInitProvisioningSecret(ctx context.Context, 
 		return nil
 	}
 
-	if string(existing.Data["userData"]) == string(userData) {
+	if bytes.Equal(existing.Data["userData"], userData) {
+		if existing.Immutable == nil || !*existing.Immutable {
+			existing.Immutable = ptr.To(true)
+			if _, updateErr := c.clientset.CoreV1().Secrets(c.namespace).Update(ctx, existing, metav1.UpdateOptions{}); updateErr != nil {
+				return fmt.Errorf("patch immutable on existing '%s[%s]' secret: %w", name, v1alpha2.SecretTypeCloudInit, updateErr)
+			}
+		}
 		return nil
 	}
 

--- a/modules/030-cloud-provider-dvp/images/dvp-common/api/compute.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-common/api/compute.go
@@ -471,6 +471,26 @@ func (c *ComputeService) CreateCloudInitProvisioningSecret(ctx context.Context, 
 	return nil
 }
 
+func (c *ComputeService) EnsureCloudInitSecretImmutable(ctx context.Context, name string) error {
+	secret, err := c.clientset.CoreV1().Secrets(c.namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("get '%s[%s]' secret: %w", name, v1alpha2.SecretTypeCloudInit, err)
+	}
+
+	if !isDeckhouseManagedSecret(secret) || (secret.Immutable != nil && *secret.Immutable) {
+		return nil
+	}
+
+	secret.Immutable = ptr.To(true)
+	if _, updateErr := c.clientset.CoreV1().Secrets(c.namespace).Update(ctx, secret, metav1.UpdateOptions{}); updateErr != nil {
+		return fmt.Errorf("patch immutable on '%s[%s]' secret: %w", name, v1alpha2.SecretTypeCloudInit, updateErr)
+	}
+	return nil
+}
+
 func (c *ComputeService) DeleteCloudInitProvisioningSecret(ctx context.Context, name string) error {
 	if err := c.clientset.CoreV1().Secrets(c.namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil {
 		if k8serrors.IsNotFound(err) {

--- a/modules/030-cloud-provider-dvp/images/dvp-common/api/compute.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-common/api/compute.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/utils/ptr"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -421,6 +422,7 @@ func (c *ComputeService) CreateCloudInitProvisioningSecret(ctx context.Context, 
 				},
 			},
 		},
+		Immutable:  ptr.To(true),
 		Type:       v1alpha2.SecretTypeCloudInit,
 		StringData: map[string]string{"userData": string(userData)},
 	}
@@ -433,7 +435,7 @@ func (c *ComputeService) CreateCloudInitProvisioningSecret(ctx context.Context, 
 		return fmt.Errorf("create '%s[%s]' secret: %w", name, v1alpha2.SecretTypeCloudInit, err)
 	}
 
-	// Secret already exists — load it and decide whether we may update userData.
+	// Secret already exists — load it and decide what to do.
 	existing, getErr := c.clientset.CoreV1().Secrets(c.namespace).Get(ctx, name, metav1.GetOptions{})
 	if getErr != nil {
 		return fmt.Errorf("get existing '%s[%s]' secret: %w", name, v1alpha2.SecretTypeCloudInit, getErr)
@@ -448,9 +450,16 @@ func (c *ComputeService) CreateCloudInitProvisioningSecret(ctx context.Context, 
 		return nil
 	}
 
-	existing.StringData = map[string]string{"userData": string(userData)}
-	if _, updateErr := c.clientset.CoreV1().Secrets(c.namespace).Update(ctx, existing, metav1.UpdateOptions{}); updateErr != nil {
-		return fmt.Errorf("update '%s[%s]' secret: %w", name, v1alpha2.SecretTypeCloudInit, updateErr)
+	if string(existing.Data["userData"]) == string(userData) {
+		return nil
+	}
+
+	// Immutable secret with different data: delete and recreate.
+	if delErr := c.clientset.CoreV1().Secrets(c.namespace).Delete(ctx, name, metav1.DeleteOptions{}); delErr != nil && !k8serrors.IsNotFound(delErr) {
+		return fmt.Errorf("delete stale '%s[%s]' secret: %w", name, v1alpha2.SecretTypeCloudInit, delErr)
+	}
+	if _, createErr := c.clientset.CoreV1().Secrets(c.namespace).Create(ctx, s, metav1.CreateOptions{}); createErr != nil {
+		return fmt.Errorf("recreate '%s[%s]' secret: %w", name, v1alpha2.SecretTypeCloudInit, createErr)
 	}
 	return nil
 }

--- a/modules/030-cloud-provider-dvp/images/dvp-common/api/compute.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-common/api/compute.go
@@ -29,8 +29,8 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	cloudprovider "k8s.io/cloud-provider"
-	"k8s.io/utils/ptr"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/deckhouse/virtualization/api/core/v1alpha2"

--- a/modules/030-cloud-provider-dvp/images/dvp-common/api/compute.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-common/api/compute.go
@@ -465,7 +465,7 @@ func (c *ComputeService) CreateCloudInitProvisioningSecret(ctx context.Context, 
 	if delErr := c.clientset.CoreV1().Secrets(c.namespace).Delete(ctx, name, metav1.DeleteOptions{}); delErr != nil && !k8serrors.IsNotFound(delErr) {
 		return fmt.Errorf("delete stale '%s[%s]' secret: %w", name, v1alpha2.SecretTypeCloudInit, delErr)
 	}
-	if _, createErr := c.clientset.CoreV1().Secrets(c.namespace).Create(ctx, s, metav1.CreateOptions{}); createErr != nil {
+	if _, createErr := c.clientset.CoreV1().Secrets(c.namespace).Create(ctx, s, metav1.CreateOptions{}); createErr != nil && !k8serrors.IsAlreadyExists(createErr) {
 		return fmt.Errorf("recreate '%s[%s]' secret: %w", name, v1alpha2.SecretTypeCloudInit, createErr)
 	}
 	return nil


### PR DESCRIPTION
## Description
Make cloud-init secrets for DVP nodes immutable (`immutable: true`).

- **Permanent nodes (Terraform):** `immutable = true` added to `kubernetes_secret.cloudinit-secret` in `master/main.tf` and `static-node/main.tf`. Existing `ignore_changes = [data]` is preserved — behaviors are consistent.
- **Ephemeral nodes (CAPI controller):** `Immutable: ptr.To(true)` set in `CreateCloudInitProvisioningSecret`. The `already-exists` branch no longer calls `Update` on data (forbidden by API for immutable secrets): if `userData` matches — no-op; if it differs — delete + recreate.
- **Converge for existing ephemeral secrets:** EnsureCloudInitSecretImmutable is called in handleVMRunning — on every reconcile of a Running VM the controller patches immutable: true on the existing mutable secret. This covers clusters upgraded from a pre-immutable release.

## Why do we need it, and what problem does it solve?
Cloud-init secrets in DVP are per-VM/per-node one-shot secrets. Making them immutable prevents accidental or erroneous mutation of bootstrap data after a node has already consumed it, which could lead to silent misconfiguration or failed re-provisioning. The transition from mutable to immutable is allowed by the Kubernetes API on existing secrets, so converge on existing clusters is safe. Without the handleVMRunning patch, secrets created before the upgrade would remain mutable until the VM is recreated.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-dvp
type: fix
summary: Made cloud-init secrets immutable to prevent post-bootstrap data mutation.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
