### PR TITLE
[ingress-nginx] revert default controller version to 1.10

### DIFF
--- a/modules/402-ingress-nginx/openapi/config-values.yaml
+++ b/modules/402-ingress-nginx/openapi/config-values.yaml
@@ -1,7 +1,7 @@
 type: object
 properties:
   defaultControllerVersion:
-    default: "1.12"
+    default: "1.10"
     oneOf:
       - type: string
         enum: ["1.10", "1.12", "1.14"]

--- a/modules/402-ingress-nginx/template_tests/controller_test.go
+++ b/modules/402-ingress-nginx/template_tests/controller_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Module :: ingress-nginx :: helm template :: controllers", func
 		hec.ValuesSet("global.enabledModules", []string{"cert-manager", "vertical-pod-autoscaler", "operator-prometheus", "control-plane-manager"})
 		hec.ValuesSet("global.discovery.d8SpecificNodeCountByRole.system", 2)
 
-		hec.ValuesSet("ingressNginx.defaultControllerVersion", "1.12")
+		hec.ValuesSet("ingressNginx.defaultControllerVersion", "1.10")
 		hec.ValuesSet("ingressNginx.internal.admissionCertificate.ca", "test")
 		hec.ValuesSet("ingressNginx.internal.admissionCertificate.cert", "test")
 		hec.ValuesSet("ingressNginx.internal.admissionCertificate.key", "test")

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-terminating/controller/controller.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-terminating/controller/controller.yaml
@@ -39,7 +39,7 @@ kind: DaemonSet
 metadata:
   annotations:
     ingress-nginx-controller.deckhouse.io/checksum: aae2dceef3dfbb345a89425527b723dcd4e516f30d446804e8746bb70d231eeb
-    ingress-nginx-controller.deckhouse.io/controller-version: "1.12"
+    ingress-nginx-controller.deckhouse.io/controller-version: "1.10"
     ingress-nginx-controller.deckhouse.io/inlet: LoadBalancer
   labels:
     app: controller
@@ -74,7 +74,6 @@ spec:
         - --http-port=80
         - --https-port=443
         - --update-status=true
-        - --enable-metrics=true
         - --publish-service=d8-ingress-nginx/wait-lb-non-default-load-balancer
         - --shutdown-grace-period=333
         - --controller-class=ingress-nginx.deckhouse.io/%!s(<nil>)
@@ -93,7 +92,7 @@ spec:
               fieldPath: metadata.namespace
         - name: POD_IP
           value: 127.0.0.1
-        image: registry.example.com@imageHash-ingressNginx-controller112
+        image: registry.example.com@imageHash-ingressNginx-controller110
         lifecycle:
           preStop:
             exec:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Reverts default ingress-controller version in the cluster from 1.12 to 1.10.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

There are several subtle differences between 1.10 and 1.12 versions, so it makes sense to provide a full migration with alerting and requirements.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

We need it in patch to fix 1.76 DKP train.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: fix
summary: Default ingress controller version is reverted to 1.10.
impact: All ingress-nginx controller pods using default controller version will be restarted.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
