### PR TITLE
[cloud-provider-yandex] include networkType in machine-class checksum

### DIFF
--- a/modules/030-cloud-provider-yandex/cloud-instance-manager/machine-class.checksum
+++ b/modules/030-cloud-provider-yandex/cloud-instance-manager/machine-class.checksum
@@ -30,6 +30,9 @@
 {{- if hasKey .nodeGroup.instanceClass "additionalLabels" -}}
   {{- $_ := set $options "additionalLabels" .nodeGroup.instanceClass.additionalLabels -}}
 {{- end -}}
+{{- if hasKey .nodeGroup.instanceClass "networkType" -}}
+  {{- $_ := set $options "networkType" .nodeGroup.instanceClass.networkType -}}
+{{- end -}}
 {{- if (index .nodeGroup "manualRolloutID") -}}
   {{ $_ := set $options "manualRolloutID" (index .nodeGroup "manualRolloutID") -}}
 {{- end -}}


### PR DESCRIPTION
## Description
Add `networkType` field to the `machine-class.checksum` template for `cloud-provider-yandex`.

When `networkType` is changed in `YandexCloudInstanceClass`, the affected nodes will be recreated via a rolling update.

> **Note:** Upon upgrade, a one-time rolling update will be triggered for all Yandex cloud nodes
> belonging to NodeGroups that have `networkType` explicitly set in their `YandexCloudInstanceClass`.
> NodeGroups without `networkType` are not affected.

## Why do we need it, and what problem does it solve?
The `assignMachineClassChecksum` hook computes a checksum of the `MachineClass` configuration after each Helm render and patches `MachineDeployment.spec.template.metadata.annotations.checksum/machine-class`. When the checksum changes, MCM triggers a rolling update of the nodes.

The `networkType` field was missing from the `cloud-instance-manager/machine-class.checksum` template, while being present in the analogous CAPI template (`capi/instance-class.checksum`). As a result, changing `networkType` in `YandexCloudInstanceClass` (e.g., from `SoftwareAccelerated` to `Standard`) correctly updated the `YandexMachineClass` object, but the checksum remained unchanged — so MCM considered existing nodes as `UPTODATE` and never recreated them with the new network acceleration type.


## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-yandex
type: fix
summary: changing networkType in YandexCloudInstanceClass now triggers a rolling update of cloud nodes
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
