### PR TITLE
[tools] Add prometheus-pushgateway namespace to CSE integrity check

### DIFF
--- a/tools/build_includes/integrity-check-namespaces-CSE.yaml
+++ b/tools/build_includes/integrity-check-namespaces-CSE.yaml
@@ -44,4 +44,5 @@ namespaces_for_integrity:
     - d8-user-authn
     - d8-user-authz
     - d8-virtualization
+    - kube-prometheus-pushgateway
     - kube-system

--- a/tools/integrity_check_namespaces/CSE.yaml
+++ b/tools/integrity_check_namespaces/CSE.yaml
@@ -1,6 +1,7 @@
 excludeNamespaces: []
 additionalNamespaces:
   - kube-system
+  - kube-prometheus-pushgateway
   - d8-alb
   - d8-commander
   - d8-commander-agent


### PR DESCRIPTION
## Description

Add `kube-prometheus-pushgateway` namespace to CSE integrity check configuration and regenerate include files.

## Why do we need it, and what problem does it solve?

Without this change, pods in this namespace won't be covered by CSE integrity checks.

## Why do we need it in the patch release (if we do)?

No need 

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: tools
type: chore
summary: Add prometheus-pushgateway namespace to CSE integrity check
impact_level: default
```
