### PR TITLE
[tools] Add  d8-security-events-manager  namespace to CSE integrity check

### DIFF
--- a/tools/build_includes/integrity-check-namespaces-CSE.yaml
+++ b/tools/build_includes/integrity-check-namespaces-CSE.yaml
@@ -36,6 +36,7 @@ namespaces_for_integrity:
     - d8-sds-node-configurator
     - d8-secrets-store-integration
     - d8-service-with-healthchecks
+    - d8-security-events-manager
     - d8-snapshot-controller
     - d8-static-routing-manager
     - d8-storage-volume-data-manager

--- a/tools/build_includes/integrity-check-namespaces-CSE.yaml
+++ b/tools/build_includes/integrity-check-namespaces-CSE.yaml
@@ -35,8 +35,8 @@ namespaces_for_integrity:
     - d8-sds-local-volume
     - d8-sds-node-configurator
     - d8-secrets-store-integration
-    - d8-service-with-healthchecks
     - d8-security-events-manager
+    - d8-service-with-healthchecks
     - d8-snapshot-controller
     - d8-static-routing-manager
     - d8-storage-volume-data-manager

--- a/tools/integrity_check_namespaces/CSE.yaml
+++ b/tools/integrity_check_namespaces/CSE.yaml
@@ -22,6 +22,7 @@ additionalNamespaces:
   - d8-sds-local-volume
   - d8-sds-node-configurator
   - d8-secrets-store-integration
+  - d8-security-events-manager  
   - d8-snapshot-controller
   - d8-static-routing-manager
   - d8-storage-volume-data-manager


### PR DESCRIPTION
## Description

Add  d8-security-events-manager to the list of additional namespaces tracked by the CSE integrity check, and regenerate the build_includes file.

## Why do we need it, and what problem does it solve?
CSE requirements


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: tools
type: chore
summary: Added the `d8-security-events-manager` namespace to the CSE integrity check.
impact:
impact_level: default
```
