### PR TITLE
[ci] Update CODEOWNERS for documentation and tools

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -123,7 +123,7 @@ docs/documentation/pages/architecture/   @voitenkov
 helm_lib/                                @ldmonster
 crds/                                    @z9r5
 openapi/                                 @z9r5
-tools/docs/                               @z9r5
+tools/docs/                              @z9r5
 /pkg/                                    @ldmonster
 testing/cloud_layouts/                   @Nikolay1224 @KraMorK @Taior @himax1991
 /monitoring/prometheus-rules/            @sudoroot-null

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -105,7 +105,7 @@
 600-namespace-configurator/                                      @nabokihms @AlwxSin
 610-service-with-healthchecks                                    @AndreyPavlovFlant @apolovov
 800-deckhouse-tools/                                             @RomanenkoDenys @borg-z @090809
-810-documentation/                                               @zhbert
+810-documentation/                                               @z9r5
 
 /candi/                                  @borg-z @090809
 /candi/control-plane/                    @sprait
@@ -118,11 +118,12 @@ cloud-controller-manager/                @aleksey-su @pabateman
 csi/                                     @AleksZimin @duckhawk @szhem
 deckhouse-controller/                    @ldmonster
 dhctl/                                   @borg-z @090809
-docs/                                    @zhbert
+docs/                                    @z9r5
 docs/documentation/pages/architecture/   @voitenkov
 helm_lib/                                @ldmonster
-crds/                                    @zhbert
-openapi/                                 @zhbert
+crds/                                    @z9r5
+openapi/                                 @z9r5
+tools/docs/                               @z9r5
 /pkg/                                    @ldmonster
 testing/cloud_layouts/                   @Nikolay1224 @KraMorK @Taior @himax1991
 /monitoring/prometheus-rules/            @sudoroot-null


### PR DESCRIPTION
## Description

This pull request updates the code ownership assignments in the `.github/CODEOWNERS` file, reassigning documentation and related directories from `@zhbert` to `@z9r5`. 

Ref: https://github.com/deckhouse/deckhouse/pull/20445

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: ci
type: chore
summary: Update code documentation ownership assignments.
impact_level: low
```
