### PR TITLE
[control-plane-manager] Temporarily pin the kubeadm:cluster-admins ClusterRoleBinding back to the wildcard cluster-admin role

### DIFF
--- a/modules/040-control-plane-manager/docs/FAQ.md
+++ b/modules/040-control-plane-manager/docs/FAQ.md
@@ -711,7 +711,7 @@ The control-plane-manager module maintains several kubeconfig files on master no
 
 | File | Identity | Purpose |
 | --- | --- | --- |
-| `/etc/kubernetes/admin.conf` | `kubernetes-admin` (`kubeadm:cluster-admins` group) | Machine kubeconfig for kubeadm internals (join, renewal). With the [user-authz](/modules/user-authz/) module enabled, RBAC uses `user-authz:cluster-admin` plus an additional ClusterRole; with `user-authz` disabled, the group is bound to the built-in `cluster-admin` role. |
+| `/etc/kubernetes/admin.conf` | `kubernetes-admin` (`kubeadm:cluster-admins` group) | Machine kubeconfig for kubeadm internals (join, renewal). The group is bound to the built-in wildcard `cluster-admin` role. |
 | `/etc/kubernetes/super-admin.conf` | `kubernetes-super-admin` (`system:masters` group) | Break-glass emergency credential. Bypasses RBAC entirely. Restrict access to this file to trusted recovery scenarios. |
 | `/etc/kubernetes/controller-manager.conf` | `system:kube-controller-manager` | Used by kube-controller-manager. |
 | `/etc/kubernetes/scheduler.conf` | `system:kube-scheduler` | Used by kube-scheduler. |
@@ -720,9 +720,7 @@ The control-plane-manager module maintains several kubeconfig files on master no
 
 Starting from Kubernetes 1.29, kubeadm generates `admin.conf` with the `kubeadm:cluster-admins` group instead of `system:masters`. This provides RBAC-controlled admin access that can be revoked by removing the RBAC binding objects for `kubeadm:cluster-admins`.
 
-When the [user-authz](/modules/user-authz/) module is **disabled**, Deckhouse binds the `kubeadm:cluster-admins` group to the built-in wildcard ClusterRole `cluster-admin` (same effective model as a plain kubeadm cluster without extra RBAC).
-
-When **user-authz** is **enabled**, the group is bound to `user-authz:cluster-admin`, and a second RBAC binding adds the ClusterRole `d8:control-plane-manager:admin-kubeconfig-supplement` (rules beyond the high-level role, e.g. for certificates and cluster machinery). Together they replace a single wildcard `cluster-admin` for this identity. For full unrestricted access, use `super-admin.conf`.
+Deckhouse binds the `kubeadm:cluster-admins` group to the built-in wildcard ClusterRole `cluster-admin` (the same effective model as a plain kubeadm cluster without extra RBAC), regardless of whether the [user-authz](/modules/user-authz/) module is enabled. For full unrestricted access that also bypasses RBAC, use `super-admin.conf`.
 
 ### Recommended admin access
 

--- a/modules/040-control-plane-manager/docs/FAQ_RU.md
+++ b/modules/040-control-plane-manager/docs/FAQ_RU.md
@@ -717,7 +717,7 @@ Finished defragmenting etcd member[https://localhost:2379]. took 848.948927ms
 
 | Файл | Идентификация | Назначение |
 | --- | --- | --- |
-| `/etc/kubernetes/admin.conf` | `kubernetes-admin` (группа `kubeadm:cluster-admins`) | Машинный kubeconfig для внутренних операций kubeadm (join, обновление). При включённом модуле [user-authz](/modules/user-authz/) RBAC использует `user-authz:cluster-admin` и дополнительную ClusterRole; при выключенном `user-authz` группа привязана к встроенной роли `cluster-admin`. |
+| `/etc/kubernetes/admin.conf` | `kubernetes-admin` (группа `kubeadm:cluster-admins`) | Машинный kubeconfig для внутренних операций kubeadm (join, обновление). Группа привязана к встроенной wildcard-роли `cluster-admin`. |
 | `/etc/kubernetes/super-admin.conf` | `kubernetes-super-admin` (группа `system:masters`) | Аварийный доступ (break-glass). Обходит RBAC полностью. Ограничьте доступ к файлу сценариями восстановления. |
 | `/etc/kubernetes/controller-manager.conf` | `system:kube-controller-manager` | Используется kube-controller-manager. |
 | `/etc/kubernetes/scheduler.conf` | `system:kube-scheduler` | Используется kube-scheduler. |
@@ -726,9 +726,7 @@ Finished defragmenting etcd member[https://localhost:2379]. took 848.948927ms
 
 Начиная с Kubernetes 1.29, kubeadm генерирует `admin.conf` с группой `kubeadm:cluster-admins` вместо `system:masters`. Это обеспечивает управляемый через RBAC административный доступ, который может быть отозван путём удаления объектов привязки RBAC для `kubeadm:cluster-admins` (или нескольких таких записей).
 
-Если модуль [user-authz](/modules/user-authz/) **выключен**, Deckhouse привязывает группу `kubeadm:cluster-admins` к встроенной роли `cluster-admin` с wildcard-правами (как в обычном кластере kubeadm без дополнительной настройки RBAC).
-
-Если модуль **user-authz** **включён**, группа привязывается к `user-authz:cluster-admin`, а вторая привязка RBAC добавляет роль `d8:control-plane-manager:admin-kubeconfig-supplement` (правила сверх высокоуровневой роли, например для сертификатов и компонентов control plane). Вместе они заменяют одну wildcard-роль `cluster-admin` для этой идентичности. Для полного неограниченного доступа используйте `super-admin.conf`.
+Deckhouse привязывает группу `kubeadm:cluster-admins` к встроенной wildcard-роли `cluster-admin` (как в обычном кластере kubeadm без дополнительной настройки RBAC) независимо от того, включён ли модуль [user-authz](/modules/user-authz/). Для полного неограниченного доступа в обход RBAC используйте `super-admin.conf`.
 
 ### Рекомендуемый административный доступ
 

--- a/modules/040-control-plane-manager/hooks/reconcile_kubeadm_cluster_admins_binding.go
+++ b/modules/040-control-plane-manager/hooks/reconcile_kubeadm_cluster_admins_binding.go
@@ -81,6 +81,10 @@ const (
 	// this CRB is dropped from the Helm template, Helm must not prune it (admin.conf would lose root).
 	helmResourcePolicyAnnotation = "helm.sh/resource-policy"
 	helmResourcePolicyKeep       = "keep"
+
+	// forceWildcardClusterAdmin temporarily pins kubeadm:cluster-admins to the wildcard cluster-admin
+	// role, pausing the granular user-authz:cluster-admin rollout. Set to false to re-enable granular.
+	forceWildcardClusterAdmin = true
 )
 
 // kubeadmClusterAdminsBindingState keeps the moving pieces of the CRB we care about.
@@ -147,8 +151,18 @@ func reconcileKubeadmClusterAdminsBindingHook(_ context.Context, input *go_hook.
 	}
 	userAuthzCRAvailable := len(userAuthzCRSnaps) > 0
 
+	// TEMPORARY: the granular user-authz:cluster-admin rollout for kubeadm:cluster-admins is paused.
+	// The binding is pinned back to the wildcard cluster-admin role for every cluster. The gate
+	// computation below is kept intact so re-enabling is a one-liner: drop forceWildcardClusterAdmin
+	// (and restore the granular test expectations).
+	//
+	// Safety during the rollback flip (granular -> wildcard, an immutable-roleRef Delete+Create):
+	// the supplement binding stays enabled (supplementEnabled = userAuthzEnabled), so the group keeps
+	// nodes/proxy (kubectl exec/logs/port-forward) and impersonate through the whole window. Wildcard
+	// is a strict superset of granular, so no permission is ever lost — only the sub-second core-rbac
+	// window of the Delete+Create, which the hook self-heals on the CRB delete event / next OnBeforeHelm.
 	desiredRoleName := clusterAdminWildcardClusterRoleName
-	if userAuthzEnabled && clusterBootstrapped && userAuthzCRAvailable {
+	if !forceWildcardClusterAdmin && userAuthzEnabled && clusterBootstrapped && userAuthzCRAvailable {
 		desiredRoleName = userAuthzClusterAdminClusterRoleName
 	}
 

--- a/modules/040-control-plane-manager/hooks/reconcile_kubeadm_cluster_admins_binding_test.go
+++ b/modules/040-control-plane-manager/hooks/reconcile_kubeadm_cluster_admins_binding_test.go
@@ -245,43 +245,47 @@ rules:
 		})
 	})
 
-	// ── user-authz enabled, bootstrapped, granular role in API: switch happens ──
-	Context("user-authz enabled, bootstrapped, granular role in API, no CRB", func() {
+	// ── user-authz enabled+bootstrapped, granular role in API, BUT granular rollout paused:
+	//    forceWildcardClusterAdmin pins the binding to the wildcard cluster-admin regardless. ──
+	Context("user-authz enabled, bootstrapped, granular role in API, no CRB (granular rollout paused)", func() {
 		f := HookExecutionConfigInit(valuesUserAuthzOnBootstrapped, "")
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSet(userAuthzClusterAdminCR))
 			f.RunHook()
 		})
-		It("creates the binding pointing to user-authz:cluster-admin and publishes target=user-authz:cluster-admin, supplement=true", func() {
+		It("creates the binding on the wildcard cluster-admin and publishes target=cluster-admin, supplement=true", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			expectDesiredCRB(f, "user-authz:cluster-admin")
-			expectInternalDecision(f, "user-authz:cluster-admin", true)
+			expectDesiredCRB(f, "cluster-admin")
+			expectKeepPolicy(f)
+			expectInternalDecision(f, "cluster-admin", true)
 		})
 	})
 
-	Context("user-authz enabled, bootstrapped, granular role in API, CRB on cluster-admin", func() {
+	Context("user-authz enabled, bootstrapped, granular role in API, CRB on cluster-admin (granular rollout paused)", func() {
 		f := HookExecutionConfigInit(valuesUserAuthzOnBootstrapped, "")
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSet(crbCurrentClusterAdmin + userAuthzClusterAdminCR))
 			f.RunHook()
 		})
-		It("rebinds to user-authz:cluster-admin (immutable roleRef → Delete+Create) and publishes target=user-authz:cluster-admin, supplement=true", func() {
+		It("keeps the wildcard cluster-admin binding (no flip) and publishes target=cluster-admin, supplement=true", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			expectDesiredCRB(f, "user-authz:cluster-admin")
-			expectInternalDecision(f, "user-authz:cluster-admin", true)
+			expectDesiredCRB(f, "cluster-admin")
+			expectInternalDecision(f, "cluster-admin", true)
 		})
 	})
 
-	Context("user-authz enabled, bootstrapped, granular role in API, CRB already on user-authz:cluster-admin", func() {
+	// Rollback path: a cluster that already moved to granular must be flipped back to wildcard.
+	Context("user-authz enabled, bootstrapped, granular role in API, CRB already on user-authz:cluster-admin (rollback to wildcard)", func() {
 		f := HookExecutionConfigInit(valuesUserAuthzOnBootstrapped, "")
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSet(crbCurrentUserAuthzClusterAdmin + userAuthzClusterAdminCR))
 			f.RunHook()
 		})
-		It("is a no-op and keeps target=user-authz:cluster-admin, supplement=true", func() {
+		It("rolls the binding back to the wildcard cluster-admin (immutable roleRef → Delete+Create) and publishes target=cluster-admin, supplement=true", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			expectDesiredCRB(f, "user-authz:cluster-admin")
-			expectInternalDecision(f, "user-authz:cluster-admin", true)
+			expectDesiredCRB(f, "cluster-admin")
+			expectKeepPolicy(f)
+			expectInternalDecision(f, "cluster-admin", true)
 		})
 	})
 
@@ -301,17 +305,18 @@ rules:
 		})
 	})
 
-	Context("user-authz enabled+bootstrapped, CRB on user-authz:cluster-admin WITHOUT Helm labels (pre-v1.76 state)", func() {
+	Context("user-authz enabled+bootstrapped, CRB on user-authz:cluster-admin WITH Helm labels (rollback to wildcard)", func() {
 		f := HookExecutionConfigInit(valuesUserAuthzOnBootstrapped, "")
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSet(crbUserAuthzClusterAdminWithHelmLabels + userAuthzClusterAdminCR))
 			f.RunHook()
 		})
-		It("is a true no-op: roleRef correct, Helm labels already present — no patch emitted", func() {
+		It("rolls the binding back to the wildcard cluster-admin (Delete+Create) and re-stamps Helm ownership + keep", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			expectDesiredCRB(f, "user-authz:cluster-admin")
+			expectDesiredCRB(f, "cluster-admin")
 			expectHelmOwnership(f)
-			expectInternalDecision(f, "user-authz:cluster-admin", true)
+			expectKeepPolicy(f)
+			expectInternalDecision(f, "cluster-admin", true)
 		})
 	})
 
@@ -330,17 +335,17 @@ rules:
 		})
 	})
 
-	Context("OnBeforeHelm tick (Helm-driven reconcile) with all three gates satisfied", func() {
+	Context("OnBeforeHelm tick (Helm-driven reconcile) with all three gates satisfied but rollout paused", func() {
 		f := HookExecutionConfigInit(valuesUserAuthzOnBootstrapped, "")
 		BeforeEach(func() {
 			f.KubeStateSet(crbCurrentClusterAdmin + userAuthzClusterAdminCR)
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
 			f.RunHook()
 		})
-		It("rebinds the snapshot CRB to user-authz:cluster-admin on OnBeforeHelm too and publishes target=user-authz:cluster-admin, supplement=true", func() {
+		It("keeps the wildcard cluster-admin binding on OnBeforeHelm too and publishes target=cluster-admin, supplement=true", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			expectDesiredCRB(f, "user-authz:cluster-admin")
-			expectInternalDecision(f, "user-authz:cluster-admin", true)
+			expectDesiredCRB(f, "cluster-admin")
+			expectInternalDecision(f, "cluster-admin", true)
 		})
 	})
 })


### PR DESCRIPTION
## Description
Backport #20942 
Temporarily pin the `kubeadm:cluster-admins` ClusterRoleBinding back to the wildcard `cluster-admin` role via the `forceWildcardClusterAdmin` flag in the reconcile hook, pausing the granular `user-authz:cluster-admin` rollout. The supplement ClusterRole/binding stays enabled, so `nodes/proxy` (kubectl exec/logs/port-forward) and impersonate are preserved through any rebind.

## Why do we need it, and what problem does it solve?
The granular `user-authz:cluster-admin` rollout for admin.conf is being paused. Pinning back to the wildcard role keeps root access intact for all clients: new clusters get the wildcard binding directly, clusters already on wildcard are untouched, and clusters that moved to granular are safely flipped back (wildcard is a strict superset, so no permission is lost). No control-plane restarts.

## Why do we need it in the patch release (if we do)?
Yes — needed to restore the previous wildcard behavior on clusters that already received the granular rollout.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: control-plane-manager
type: fix
summary: Temporarily pin kubeadm:cluster-admins back to the wildcard cluster-admin role, pausing the granular rollout.
impact_level: low