### PR TITLE
[docs] Add deep-link anchors and auto-expand logic for collapsible sections

### DIFF
--- a/docs/documentation/_includes/module-configure.liquid
+++ b/docs/documentation/_includes/module-configure.liquid
@@ -10,8 +10,7 @@
 <div id='настройки'></div>
 
 {% offtopic title="Как настроить модуль..." %}
-
-Настроить модуль можно одним из следующих способов:
+<span id="setup"></span>Настроить модуль можно одним из следующих способов:
 - **С помощью [веб-интерфейса Deckhouse](/products/kubernetes-platform/documentation/v1/user/web/ui.html).**
 
   В разделе «Система» → «Управление системой» → «Deckhouse» → «Модули», откройте модуль `{{ moduleKebabName }}`, включите переключатель «Дополнительные настройки». Заполните необходимые поля формы на вкладке «Конфигурация», или укажите настройки модуля в формате YAML на вкладке «YAML», **не включая секцию settings**. Сохраните изменения.
@@ -58,8 +57,7 @@
 <div id='settings'></div>
 
 {% offtopic title="How to configure the module..." %}
-
-You can configure the module in one of the following ways:
+<span id="setup"></span>You can configure the module in one of the following ways:
 
 - **Via [Deckhouse web UI](/products/kubernetes-platform/documentation/v1/user/web/ui.html).**
 

--- a/docs/documentation/_includes/module-enable.liquid
+++ b/docs/documentation/_includes/module-enable.liquid
@@ -2,7 +2,7 @@
 
 {% if page.lang == 'ru' -%}
 {% offtopic title="Как явно включить или отключить модуль..." %}
-Явно включить или выключить модуль можно одним из следующих способов:
+<span id="enable"></span>Явно включить или выключить модуль можно одним из следующих способов:
 - **С помощью [веб-интерфейса Deckhouse](/products/kubernetes-platform/documentation/v1/user/web/ui.html).** В разделе «Система» → «Управление системой» → «Deckhouse» → «Модули», откройте модуль `{{ moduleKebabName }}`, включите (или выключите) переключатель «Модуль включен». Сохраните изменения.
 
   Пример:
@@ -36,7 +36,7 @@
 {% endofftopic %}
 {% else %}
 {% offtopic title="How to explicitly enable the module..." %}
-You may explicitly enable or disable the module in one of the following ways:
+<span id="enable"></span>You may explicitly enable or disable the module in one of the following ways:
 - **Via [Deckhouse web UI](/products/kubernetes-platform/documentation/v1/user/web/ui.html).** In the "System" → "System Management" → "Deckhouse" → "Modules" section, open the `{{ moduleKebabName }}` module and enable (or disable) the "Module enabled" toggle. Save changes.
 
   Example:

--- a/docs/site/assets/js/details.js
+++ b/docs/site/assets/js/details.js
@@ -2,4 +2,27 @@ $( document ).ready(function() {
   $('.details__summary').on('click tap', function() {
     $(this).closest('.details').toggleClass('active');
   });
+
+  function expandDetailsForHash(hash) {
+    if (!hash) return;
+    var target = document.getElementById(decodeURIComponent(hash.replace('#', '')));
+    if (!target) return;
+    var details = $(target).closest('.details');
+    if (!details.length) return;
+    details.addClass('active');
+    setTimeout(function() {
+      var stickyHeader = document.querySelector('.header-container');
+      var offset = stickyHeader ? stickyHeader.getBoundingClientRect().height : 0;
+      var top = details[0].getBoundingClientRect().top;
+      if (top < offset) {
+        window.scrollBy({ top: top - offset });
+      }
+    }, 50);
+  }
+
+  expandDetailsForHash(window.location.hash);
+
+  $(window).on('hashchange', function() {
+    expandDetailsForHash(window.location.hash);
+  });
 });

--- a/docs/site/assets/js/details.js
+++ b/docs/site/assets/js/details.js
@@ -9,15 +9,10 @@ $( document ).ready(function() {
     if (!target) return;
     var details = $(target).closest('.details');
     if (!details.length) return;
+    var stickyHeader = document.querySelector('.header-container');
+    target.style.scrollMarginTop = (stickyHeader ? stickyHeader.getBoundingClientRect().height : 0) + 'px';
     details.addClass('active');
-    setTimeout(function() {
-      var stickyHeader = document.querySelector('.header-container');
-      var offset = stickyHeader ? stickyHeader.getBoundingClientRect().height : 0;
-      var top = details[0].getBoundingClientRect().top;
-      if (top < offset) {
-        window.scrollBy({ top: top - offset });
-      }
-    }, 50);
+    target.scrollIntoView();
   }
 
   expandDetailsForHash(window.location.hash);

--- a/docs/site/backends/docs-builder-template/i18n/en.yaml
+++ b/docs/site/backends/docs-builder-template/i18n/en.yaml
@@ -10,7 +10,7 @@ modules2: modules
 module: module
 module_enabling_details_title: How to explicitly enable the module…
 module_enabling_details_content: |
-  You may explicitly enable or disable the module in one of the following ways:
+  <span id="enable"></span>You may explicitly enable or disable the module in one of the following ways:
   - **Via [Deckhouse web UI](/products/kubernetes-platform/documentation/v1/user/web/ui.html).** In the "System" → "System Management" → "Deckhouse" → "Modules" section, open the `<ModuleName>` module and enable (or disable) the "Module enabled" toggle. Save changes.
 
     Example:
@@ -44,7 +44,7 @@ module_enabling_details_content: |
 module_settings: settings
 module_settings_details_title: How to configure the module...
 module_settings_details_content: |
-  You can configure the module in one of the following ways:
+  <span id="setup"></span>You can configure the module in one of the following ways:
 
   - **Via [Deckhouse web UI](/products/kubernetes-platform/documentation/v1/user/web/ui.html).**
 

--- a/docs/site/backends/docs-builder-template/i18n/ru.yaml
+++ b/docs/site/backends/docs-builder-template/i18n/ru.yaml
@@ -10,7 +10,7 @@ modules2: модулей
 module: модуль
 module_enabling_details_title: Как явно включить или отключить модуль…
 module_enabling_details_content: |
-  Явно включить или выключить модуль можно одним из следующих способов:
+  <span id="enable"></span>Явно включить или выключить модуль можно одним из следующих способов:
   - **С помощью [веб-интерфейса Deckhouse](/products/kubernetes-platform/documentation/v1/user/web/ui.html).** В разделе «Система» → «Управление системой» → «Deckhouse» → «Модули», откройте модуль `<ModuleName>`, включите (или выключите) переключатель «Модуль включен». Сохраните изменения.
 
     Пример:
@@ -44,7 +44,7 @@ module_enabling_details_content: |
 module_settings: настройки
 module_settings_details_title: Как настроить модуль...
 module_settings_details_content: |
-  Настроить модуль можно одним из следующих способов:
+  <span id="setup"></span>Настроить модуль можно одним из следующих способов:
   - **С помощью [веб-интерфейса Deckhouse](/products/kubernetes-platform/documentation/v1/user/web/ui.html).**
 
     В разделе «Система» → «Управление системой» → «Deckhouse» → «Модули», откройте модуль `<ModuleName>`, включите переключатель «Дополнительные настройки». Заполните необходимые поля формы на вкладке «Конфигурация», или укажите настройки модуля в формате YAML на вкладке «YAML», **не включая секцию settings**. Сохраните изменения.


### PR DESCRIPTION
## Description

This pull request improves the documentation and user experience for module configuration and enabling/disabling in Deckhouse by adding anchor tags for direct linking and updating the UI to auto-expand relevant sections when navigated via hash links. The changes ensure that users can link directly to specific instructions and that the documentation interface responds appropriately.

Enhancements to documentation for direct linking:

* Added `setup` and `enable` anchors to the beginning of configuration and enable/disable instructions

User interface improvements:

* Updated `details.js` to automatically expand the relevant `.details` section and adjust scrolling when a hash link (e.g., `#setup` or `#enable`) is used, improving accessibility and navigation for users following direct links.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: feature
summary: Add deep-link anchors and auto-expand logic for collapsible sections.
impact_level: low
```
