### PR TITLE
[node-manager] Fix code block syntax in e2e docs

### DIFF
--- a/modules/040-node-manager/e2e/cluster-autoscaler/tests/ca-scale-from-zero-node-label-dvp/ca_scale_from_zero_node_label_dvp.md
+++ b/modules/040-node-manager/e2e/cluster-autoscaler/tests/ca-scale-from-zero-node-label-dvp/ca_scale_from_zero_node_label_dvp.md
@@ -55,7 +55,7 @@ Before the fix, the `serializeLabels` function only included labels from `spec.n
 
 The test explicitly checks that the MachineDeployment annotation contains the system label:
 
-```
+```text
 capacity.cluster-autoscaler.kubernetes.io/labels: node.deckhouse.io/group=e2e-worker-infra
 ```
 


### PR DESCRIPTION
## Description

Specify explicit text language hint for fenced code block to fix markdown linter.

Fix: #20788 

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: chore
summary: Fix code block syntax in e2e docs.
impact_level: low
```
