### PR TITLE
[user-authn] fix error template

### DIFF
--- a/modules/150-user-authn/images/dex/patches/015-fix-error-template-buildid.patch
+++ b/modules/150-user-authn/images/dex/patches/015-fix-error-template-buildid.patch
@@ -1,0 +1,21 @@
+diff --git a/server/templates.go b/server/templates.go
+index 09f68e1b..883c0a38 100644
+--- a/server/templates.go
++++ b/server/templates.go
+@@ -504,10 +504,11 @@ func (t *templates) oob(r *http.Request, w http.ResponseWriter, code string) err
+ func (t *templates) err(r *http.Request, w http.ResponseWriter, errCode int, errMsg string) error {
+ 	w.WriteHeader(errCode)
+ 	data := struct {
+-		ErrType string
+-		ErrMsg  string
+-		ReqPath string
+-	}{http.StatusText(errCode), errMsg, r.URL.Path}
++		ErrType         string
++		ErrMsg          string
++		ReqPath         string
++		BuildIdentifier string
++	}{http.StatusText(errCode), errMsg, r.URL.Path, buildIdentifier()}
+ 	if err := t.errorTmpl.Execute(w, data); err != nil {
+ 		return fmt.Errorf("rendering template %s failed: %s", t.errorTmpl.Name(), err)
+ 	}
+

--- a/modules/150-user-authn/images/dex/patches/README.md
+++ b/modules/150-user-authn/images/dex/patches/README.md
@@ -86,3 +86,7 @@ Adds refresh token support to the SAML connector. The SAML connector now impleme
 ### 014-build-id-cache-invalidation.patch
 
 Added cache get parameter to main CSS file URL that gets opaque dex build identifier assigned to it. This prevents stale caches from breaking the login page.
+
+ ### 015-fix-error-template-buildid.patch
+
+  Fix error template


### PR DESCRIPTION
## Description
Add patch `015-fix-error-template-buildid.patch` to dex: include the `BuildIdentifier` field in the error page template data struct.

## Why do we need it, and what problem does it solve?
Patch `014` added `.BuildIdentifier` to `header.html` but missed the `err` template data struct. Rendering any dex error page (e.g. `Invalid client_id`) failed and users got a blank white page instead of the error. This restores error pages.

## Why do we need it in the patch release (if we do)?
Yes — `014` is already released and breaks all dex error pages, masking real auth errors.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authn
type: fix
summary: Fix blank dex error page caused by missing BuildIdentifier in the error template data struct.
impact_level: low
```