### PR TITLE
[docs] Update documentation on SCSI-based data storage

### DIFF
--- a/docs/documentation/pages/admin/configuration/storage/external/SCSI.md
+++ b/docs/documentation/pages/admin/configuration/storage/external/SCSI.md
@@ -33,7 +33,7 @@ The following requirements are applicable to the infrastructure and cluster node
 - A deployed and configured storage system providing access to LUN via iSCSI or Fibre Channel.
 
 - For iSCSI connections:
-  - A unique iSCSI Qualified Name (IQN) must be configured on each Kubernetes node in the `/etc/iscsi/initiatorname.iscsi` file.
+  - A unique iSCSI Qualified Name (IQN) must be configured on each cluster node in the `/etc/iscsi/initiatorname.iscsi` file.
   - The `multipath-tools` package must be installed on nodes.
 
 - For Fibre Channel connections:

--- a/docs/documentation/pages/admin/configuration/storage/external/SCSI.md
+++ b/docs/documentation/pages/admin/configuration/storage/external/SCSI.md
@@ -73,7 +73,7 @@ d8 k get module csi-scsi-generic -w
 
 ### Creating an SCSITarget
 
-The [SCSITarget](/modules/csi-scsi-generic/cr.html#scsitarget) resource describes connection to a single SCSI target. Under `spec`, specify one of the connection types: [`iSCSI`](/modules/csi-scsi-generic/cr.html#scsitarget-v1alpha1-spec-iscsi) or [`fibreChannel`](/modules/csi-scsi-generic/cr.html#scsitarget-v1alpha1-spec-fibrechannel).
+The [SCSITarget](/modules/csi-scsi-generic/cr.html#scsitarget) resource describes connection to a single SCSI target. When creating a resource in `spec`, specify one of the connection types: [`iSCSI`](/modules/csi-scsi-generic/cr.html#scsitarget-v1alpha1-spec-iscsi) or [`fibreChannel`](/modules/csi-scsi-generic/cr.html#scsitarget-v1alpha1-spec-fibrechannel).
 
 #### iSCSI
 

--- a/docs/documentation/pages/admin/configuration/storage/external/SCSI.md
+++ b/docs/documentation/pages/admin/configuration/storage/external/SCSI.md
@@ -3,40 +3,55 @@ title: "SCSI-based data storage"
 permalink: en/admin/configuration/storage/external/scsi.html
 ---
 
-Deckhouse supports managing storage connected via iSCSI or Fibre Channel, enabling working with volumes at the block device level. This allows for the integration of storage systems with Kubernetes and management through a CSI driver.
+Deckhouse Kubernetes Platform (DKP) supports managing storage connected via iSCSI or Fibre Channel, enabling working with volumes at the block device level. This allows for the integration of storage systems with Kubernetes and management through a CSI driver.
 
-This page provides instructions for connecting SCSI devices in Deckhouse, creating SCSITarget, StorageClass, and verifying system functionality.
+This page provides instructions for connecting SCSI devices in DKP, creating SCSITarget, StorageClass, and verifying system functionality.
 
 ## Supported features
 
-- Detecting LUN via iSCSI/FC.
-- Creating PersistentVolume from pre-provisioned LUN.
+DKP supports:
+
+- Detecting Logical Unit Numbers (LUN) via iSCSI or Fibre Channel.
+- Creating PersistentVolume (PV) from pre-provisioned LUN.
 - Deleting PersistentVolume and wiping data on LUN.
-- Attaching LUN to nodes via iSCSI/FC.
-- Creating `multipath` devices and mounting them in Pods.
+- Attaching LUN to nodes via iSCSI or Fibre Channel.
+- Creating multipath devices and mounting them in pods.
 - Detaching LUN from nodes.
 
 ## Limitations
 
-- Creating LUN on storage is not supported.
-- Resizing LUN is not possible.
-- Snapshots are not supported.
+DKP doesn't support:
+
+- Creating LUN on storage systems.
+- Resizing LUN.
+- Creating snapshots.
 
 ## System requirements
 
-- A deployed and configured storage system with SCSI connections.
-- Unique IQN values in `/etc/iscsi/initiatorname.iscsi` on each Kubernetes node.
+The following requirements are applicable to the infrastructure and cluster nodes:
+
+- A deployed and configured storage system providing access to LUN via iSCSI or Fibre Channel.
+
+- For iSCSI connections:
+  - A unique iSCSI Qualified Name (IQN) must be configured on each Kubernetes node in the `/etc/iscsi/initiatorname.iscsi` file.
+  - The `multipath-tools` package must be installed on nodes.
+
+- For Fibre Channel connections:
+  - Fibre Channel Host Bus Adapters (FC HBA) must be installed and available on cluster nodes (`/sys/class/fc_host/host*`).
+  - In the Storage Area Network (SAN), LUN zoning and masking must be configured, providing node initiators with access to the storage target ports.
+  - Necessary LUNs must be pre-provisioned on the storage system. DKP does not create LUNs.
+  - The `multipath-tools` package must be installed on nodes.
 
 ## Quick start
 
 All commands should be executed on a machine with access to the Kubernetes API and administrator rights.
 
-### Enabling the module
+### Enabling the csi-scsi-generic module
 
-Enable the [`csi-scsi-generic`](/modules/csi-scsi-generic/) module. This will ensure that the following happens on all cluster nodes:
+Enable the [`csi-scsi-generic`](/modules/csi-scsi-generic/) module using the command below. This will ensure that the following happens on all cluster nodes:
 
 - The CSI driver is registered.
-- Auxiliary Pods for the `csi-scsi-generic` components are launched.
+- Auxiliary pods for the `csi-scsi-generic` components are running.
 
 ```shell
 d8 k apply -f - <<EOF
@@ -58,7 +73,14 @@ d8 k get module csi-scsi-generic -w
 
 ### Creating an SCSITarget
 
-To create an SCSITarget, use the [SCSITarget](/modules/csi-scsi-generic/cr.html#scsitarget). An example of commands to create such a resource:
+The [SCSITarget](/modules/csi-scsi-generic/cr.html#scsitarget) resource describes connection to a single SCSI target. Under `spec`, specify one of the connection types: [`iSCSI`](/modules/csi-scsi-generic/cr.html#scsitarget-v1alpha1-spec-iscsi) or [`fibreChannel`](/modules/csi-scsi-generic/cr.html#scsitarget-v1alpha1-spec-fibrechannel).
+
+#### iSCSI
+
+The following is a configuration example for connecting via iSCSI.
+In this example, two [SCSITarget](/modules/csi-scsi-generic/cr.html#scsitarget) resources are created.
+
+You can create multiple resources for either the same or different storage systems. This lets you use multipath to improve failover and performance.
 
 ```shell
 d8 k apply -f -<<EOF
@@ -100,17 +122,92 @@ EOF
 
 ```
 
-Note that the example above uses two SCSITargets. You can create multiple SCSITargets for either the same or different storage systems. This allows for the use of multipath to improve failover and performance.
-
-To verify that the object has been created (`Phase` should be `Created`), run:
+To verify that the object has been created, run:
 
 ```shell
 d8 k get scsitargets.storage.deckhouse.io <name-of-scsitarget>
 ```
 
+An object is considered to be created successfully if it says `Created` in the corresponding `Phase` column in the output.
+
+#### Fibre Channel
+
+To configure a connection based on Fibre Channel, do the following:
+
+1. Before creating the SCSITarget resource, configure zoning and LUN masking on the SAN so that cluster nodes can access the necessary LUNs.
+
+1. Create the SCSITarget resource. In the [`spec.fibreChannel.WWNs`](/modules/csi-scsi-generic/cr.html#scsitarget-v1alpha1-spec-fibrechannel-wwns) field, define a World Wide Port Name (WWPN) of the target storage ports, which expose the necessary LUNs. DKP discovers devices by matching the defined WWPNs against paths under `/dev/disk/by-path/`.
+
+   Define the WWPNs in one of the following formats:
+
+   - 16 hexadecimal characters (`2001c89f1acd6117`)
+   - With colons (`20:01:c8:9f:1a:cd:61:17`)
+   - With the `0x` prefix (`0x2001c89f1acd6117`)
+
+   DKP triggers an FC host scan during discovery and volume attach. It does not configure the commutators or log in to targets.
+
+   Configuration example with two target storage system ports for multipath:
+
+   ```shell
+   kubectl apply -f -<<EOF
+   apiVersion: storage.deckhouse.io/v1alpha1
+   kind: SCSITarget
+   metadata:
+     name: hpe-3par-fc-1
+   spec:
+     deviceTemplate:
+       metadata:
+         labels:
+           my-key: some-label-value
+     fibreChannel:
+       WWNs:
+       - 2001c89f1acd6117
+
+   ---
+   apiVersion: storage.deckhouse.io/v1alpha1
+   kind: SCSITarget
+   metadata:
+     name: hpe-3par-fc-2
+   spec:
+     deviceTemplate:
+       metadata:
+         labels:
+           my-key: some-label-value
+     fibreChannel:
+       WWNs:
+       - 2001c89f1acd6118
+   EOF
+   ```
+
+1. Before applying the resource verify that FC HBA are available on the node and that LUN paths are visible after SAN zoning:
+
+   ```shell
+   # FC hosts present.
+   ls /sys/class/fc_host/
+   
+   # Target WWPNs and LUNs available after zoning.
+   ls -l /dev/disk/by-path/ | grep -E 'fc-|/fc-'
+   ```
+
+   Possible results:
+
+   - If the `/sys/class/fc_host/` directory is empty, the node has no FC HBA or the corresponding driver is not loaded.
+   - If there are no `fc-*` entries in the `/dev/disk/by-path/` directory, check zoning and LUN masking settings on the storage system.
+   - If the FC paths are displayed, the node is ready to detect LUN provided via Fibre Channel.
+
+1. After the SCSITarget is created, the controller discovers available LUNs and creates SCSIDevice objects. Use the same [SCSIStorageClass](/modules/csi-scsi-generic/cr.html#scsistorageclass) resource and [`scsiDeviceSelector`](/modules/csi-scsi-generic/cr.html#scsistorageclass-v1alpha1-spec-scsideviceselector) workflow as for iSCSI.
+
+1. To verify that the object has been created, run the following command:
+
+   ```shell
+   d8 k get scsitargets.storage.deckhouse.io <name-of-scsitarget>
+   ```
+
+   An object is considered to be created successfully if it says `Created` in the corresponding `Phase` column in the output.
+
 ### Creating a StorageClass
 
-To create a StorageClass, use the [SCSIStorageClass](/modules/csi-scsi-generic/cr.html#scsistorageclass). An example of commands to create such a resource:
+To create a StorageClass, use the [SCSIStorageClass](/modules/csi-scsi-generic/cr.html#scsistorageclass) resource. A command example to create such a resource:
 
 ```shell
 d8 k apply -f -<<EOF
@@ -126,17 +223,19 @@ spec:
 EOF
 ```
 
-Pay attention to the `scsiDeviceSelector`. This field is used to select the SCSITarget for PV creation based on labels. In the example above, all SCSITargets with the label `my-key: some-label-value` are selected. This label will be applied to all devices detected within the specified SCSITarget.
+The [`scsiDeviceSelector`](/modules/csi-scsi-generic/cr.html#scsistorageclass-v1alpha1-spec-scsideviceselector) field is used to select the SCSITarget for PV creation based on labels. In the example above, all SCSITargets with the label `my-key: some-label-value` are selected. This label will be applied to all devices detected within the specified SCSITarget.
 
-To verify that the object has been created (`Phase` should be `Created`), run:
+To verify that the object has been created, run:
 
 ```shell
 d8 k get scsistorageclasses.storage.deckhouse.io <name-of-scsistorageclass>
 ```
 
-### Module health check
+An object is considered to be created successfully if it says `Created` in the corresponding `Phase` column in the output.
 
-Check the status of Pods in the `d8-csi-scsi-generic` namespace using the following command. All Pods should be in the `Running` or `Completed` state and deployed on all nodes.
+### Csi-scsi-generic module health check
+
+Check the status of pods in the `d8-csi-scsi-generic` namespace using the command below. All pods should be in the `Running` or `Completed` state and deployed on all nodes.
 
 ```shell
 d8 k -n d8-csi-scsi-generic get pod -owide -w

--- a/docs/documentation/pages/admin/configuration/storage/external/SCSI_RU.md
+++ b/docs/documentation/pages/admin/configuration/storage/external/SCSI_RU.md
@@ -34,7 +34,7 @@ DKP не поддерживает:
 - Развёрнутая и настроенная СХД, предоставляющая доступ к LUN по iSCSI или Fibre Channel.
 
 - Для подключения по iSCSI:
-  - на каждом узле Kubernetes должен быть настроен уникальный идентификатор iSCSI-инициатора (iSCSI Qualified Name, IQN) в файле `/etc/iscsi/initiatorname.iscsi`;
+  - на каждом узле кластера должен быть настроен уникальный идентификатор iSCSI-инициатора (iSCSI Qualified Name, IQN) в файле `/etc/iscsi/initiatorname.iscsi`;
   - на узлах должен быть установлен пакет `multipath-tools`.
 
 - Для подключения по Fibre Channel:

--- a/docs/documentation/pages/admin/configuration/storage/external/SCSI_RU.md
+++ b/docs/documentation/pages/admin/configuration/storage/external/SCSI_RU.md
@@ -4,7 +4,7 @@ permalink: ru/admin/configuration/storage/external/scsi.html
 lang: ru
 ---
 
-Deckhouse Kubernetes Platform (DKP) поддерживает управление хранилищами, подключёнными через iSCSI или Fibre Channel, обеспечивая возможность работы с томами на уровне блоковых устройств. Это позволяет интегрировать системы хранения данных с Kubernetes и управлять ими через CSI-драйвер.
+Deckhouse Kubernetes Platform (DKP) поддерживает управление хранилищами, подключёнными через iSCSI или Fibre Channel, обеспечивая возможность работы с томами на уровне блочных устройств. Это позволяет интегрировать системы хранения данных с Kubernetes и управлять ими через CSI-драйвер.
 
 На этой странице представлены инструкции по подключению SCSI-устройств в DKP, созданию SCSITarget, StorageClass, а также проверке работоспособности системы.
 
@@ -74,7 +74,7 @@ d8 k get module csi-scsi-generic -w
 
 ### Создание SCSITarget
 
-Ресурс [SCSITarget](/modules/csi-scsi-generic/cr.html#scsitarget) описывает подключение к одной SCSI-цели. В `spec` укажите один из способов подключения: [`iSCSI`](/modules/csi-scsi-generic/cr.html#scsitarget-v1alpha1-spec-iscsi) или [`fibreChannel`](/modules/csi-scsi-generic/cr.html#scsitarget-v1alpha1-spec-fibrechannel).
+Ресурс [SCSITarget](/modules/csi-scsi-generic/cr.html#scsitarget) описывает подключение к одной SCSI-цели. При создании ресурса в`spec` укажите один из способов подключения: [`iSCSI`](/modules/csi-scsi-generic/cr.html#scsitarget-v1alpha1-spec-iscsi) или [`fibreChannel`](/modules/csi-scsi-generic/cr.html#scsitarget-v1alpha1-spec-fibrechannel).
 
 #### iSCSI
 
@@ -236,7 +236,7 @@ d8 k get scsistorageclasses.storage.deckhouse.io <имя-scsistorageclass>
 
 ### Проверка работоспособности модуля csi-scsi-generic
 
-Проверьте состояние подов в пространстве `d8-csi-scsi-generic` при помощи команды ниже. Все поды должны быть в состоянии `Running` или `Completed` и запущены на всех узлах.
+Проверьте состояние подов в неймспейсе `d8-csi-scsi-generic` при помощи команды ниже. Все поды должны быть в состоянии `Running` или `Completed` и запущены на всех узлах.
 
 ```shell
 d8 k -n d8-csi-scsi-generic get pod -owide -w

--- a/docs/documentation/pages/admin/configuration/storage/external/SCSI_RU.md
+++ b/docs/documentation/pages/admin/configuration/storage/external/SCSI_RU.md
@@ -4,39 +4,54 @@ permalink: ru/admin/configuration/storage/external/scsi.html
 lang: ru
 ---
 
-Deckhouse поддерживает управление хранилищами, подключёнными через iSCSI или Fibre Channel, обеспечивая возможность работы с томами на уровне блоковых устройств. Это позволяет интегрировать системы хранения данных с Kubernetes и управлять ими через CSI-драйвер.
+Deckhouse Kubernetes Platform (DKP) поддерживает управление хранилищами, подключёнными через iSCSI или Fibre Channel, обеспечивая возможность работы с томами на уровне блоковых устройств. Это позволяет интегрировать системы хранения данных с Kubernetes и управлять ими через CSI-драйвер.
 
-На этой странице представлены инструкции по подключению SCSI-устройств в Deckhouse, созданию SCSITarget, StorageClass, а также проверке работоспособности системы.
+На этой странице представлены инструкции по подключению SCSI-устройств в DKP, созданию SCSITarget, StorageClass, а также проверке работоспособности системы.
 
 ## Поддерживаемые возможности
 
-- Обнаружение LUN через iSCSI/FC.
-- Создание PersistentVolume из заранее подготовленных LUN.
-- Удаление PersistentVolume и очистка данных на LUN.
-- Подключение LUN к узлам через iSCSI/FC.
-- Создание `multipath`-устройств и их монтирование в поды.
-- Отключение LUN от узлов.
+DKP поддерживает:
+
+- обнаружение логических томов хранения данных (Logical Unit Number, LUN) через iSCSI или Fibre Channel;
+- создание PersistentVolume (PV) из заранее подготовленных LUN;
+- удаление PV и обнуление данных на LUN;
+- подключение LUN к узлам через iSCSI или Fibre Channel;
+- создание multipath-устройств и их монтирование в поды;
+- отключение LUN от узлов.
 
 ## Ограничения
 
-- Невозможно создать LUN на СХД.
-- Нельзя изменить размер LUN.
-- Снимки (snapshots) не поддерживаются.
+DKP не поддерживает:
+
+- создание LUN на СХД;
+- изменение размера LUN;
+- создание снимков (snapshots).
 
 ## Системные требования
 
-- Наличие развернутой и настроенной СХД с подключением через SCSI.
-- Уникальные IQN в `/etc/iscsi/initiatorname.iscsi` на каждом узле Kubernetes.
+Требования к инфраструктуре и узлам кластера:
+
+- Развёрнутая и настроенная СХД, предоставляющая доступ к LUN по iSCSI или Fibre Channel.
+
+- Для подключения по iSCSI:
+  - на каждом узле Kubernetes должен быть настроен уникальный идентификатор iSCSI-инициатора (iSCSI Qualified Name, IQN) в файле `/etc/iscsi/initiatorname.iscsi`;
+  - на узлах должен быть установлен пакет `multipath-tools`.
+
+- Для подключения по Fibre Channel:
+  - на узлах кластера должны быть установлены и доступны адаптеры Fibre Channel (Fibre Channel Host Bus Adapter, FC HBA) (`/sys/class/fc_host/host*`);
+  - в сети хранения данных (Storage Area Network, SAN) должны быть настроены зонирование и маскирование LUN, обеспечивающие доступ инициаторов узлов к портам СХД;
+  - необходимые LUN должны быть заранее созданы в СХД. DKP не создаёт LUN;
+  - на узлах должен быть установлен пакет `multipath-tools`.
 
 ## Быстрый старт
 
 Все команды следует выполнять на машине, имеющей доступ к API Kubernetes с правами администратора.
 
-### Включение модуля
+### Включение модуля csi-scsi-generic
 
-Включите [модуль `csi-scsi-generic`](/modules/csi-scsi-generic/). Это приведет к тому, что на всех узлах кластера будет:
+Включите [модуль `csi-scsi-generic`](/modules/csi-scsi-generic/) с помощью команды ниже. Это приведет к тому, что на всех узлах кластера будет:
 
-- зарегистрирован CSI драйвер;
+- зарегистрирован CSI-драйвер;
 - запущены служебные поды компонентов `csi-scsi-generic`.
 
 ```shell
@@ -59,7 +74,14 @@ d8 k get module csi-scsi-generic -w
 
 ### Создание SCSITarget
 
-Для создания SCSITarget необходимо использовать ресурс [SCSITarget](/modules/csi-scsi-generic/cr.html#scsitarget). Пример команд для создания такого ресурса:
+Ресурс [SCSITarget](/modules/csi-scsi-generic/cr.html#scsitarget) описывает подключение к одной SCSI-цели. В `spec` укажите один из способов подключения: [`iSCSI`](/modules/csi-scsi-generic/cr.html#scsitarget-v1alpha1-spec-iscsi) или [`fibreChannel`](/modules/csi-scsi-generic/cr.html#scsitarget-v1alpha1-spec-fibrechannel).
+
+#### iSCSI
+
+Далее приведён пример конфигурации для подключения по iSCSI.
+В этом примере создаются два ресурса [SCSITarget](/modules/csi-scsi-generic/cr.html#scsitarget).
+
+Можно создать несколько ресурсов как для одной, так и для разных СХД, что позволяет использовать multipath для повышения отказоустойчивости и производительности.
 
 ```shell
 d8 k apply -f -<<EOF
@@ -101,17 +123,92 @@ EOF
 
 ```
 
-Обратите внимание, что в примере выше используются два SCSITarget. Таким образом можно создать несколько SCSITarget как для одного, так и для разных СХД. Это позволяет использовать multipath для повышения отказоустойчивости и производительности.
-
-Проверить создание объекта можно командой (`Phase` должен быть `Created`):
+Проверить создание объекта можно следующей командой:
 
 ```shell
-d8 k get scsitargets.storage.deckhouse.io <имя scsitarget>
+d8 k get scsitargets.storage.deckhouse.io <имя-scsitarget>
 ```
+
+Объект считается успешно созданным, если в колонке его состояния (`Phase`) в выводе указано `Created`.
+
+#### Fibre Channel
+
+Для настройки подключения по Fibre Channel выполните следующие шаги:
+
+1. Перед созданием ресурса SCSITarget настройте на SAN зонирование и маскирование LUN, чтобы узлы кластера получили доступ к необходимым томам.
+
+1. Создайте ресурс SCSITarget. В поле [`spec.fibreChannel.WWNs`](/modules/csi-scsi-generic/cr.html#scsitarget-v1alpha1-spec-fibrechannel-wwns) укажите World Wide Port Name (WWPN) портов СХД, через которые доступны необходимые LUN. DKP обнаруживает устройства, сопоставляя указанные WWPN с путями в директории `/dev/disk/by-path/`.
+
+   WWPN следует указывать в одном из следующих форматов:
+
+   - 16 шестнадцатеричных символов (`2001c89f1acd6117`);
+   - с двоеточиями (`20:01:c8:9f:1a:cd:61:17`);
+   - с префиксом `0x` (`0x2001c89f1acd6117`).
+
+   При обнаружении и подключении тома DKP выполняет сканирование FC-хостов. При этом он не настраивает коммутаторы и не выполняет вход на целевые устройства.
+
+   Пример конфигурации с двумя портами СХД для организации multipath:
+
+   ```shell
+   d8 k apply -f -<<EOF
+   apiVersion: storage.deckhouse.io/v1alpha1
+   kind: SCSITarget
+   metadata:
+     name: hpe-3par-fc-1
+   spec:
+     deviceTemplate:
+       metadata:
+         labels:
+           my-key: some-label-value
+     fibreChannel:
+       WWNs:
+       - 2001c89f1acd6117
+
+   ---
+   apiVersion: storage.deckhouse.io/v1alpha1
+   kind: SCSITarget
+   metadata:
+     name: hpe-3par-fc-2
+   spec:
+     deviceTemplate:
+       metadata:
+         labels:
+           my-key: some-label-value
+     fibreChannel:
+       WWNs:
+       - 2001c89f1acd6118
+   EOF
+   ```
+
+1. Перед применением ресурса убедитесь, что на узле доступны адаптеры FC HBA и что после настройки зонирования на SAN видны пути к LUN:
+
+   ```shell
+   # FC-хосты присутствуют.
+   ls /sys/class/fc_host/
+
+   # WWPN целевых устройств и LUN доступны после настройки зонирования.
+   ls -l /dev/disk/by-path/ | grep -E 'fc-|/fc-'
+   ```
+
+   Результаты проверки:
+
+   - Если директория `/sys/class/fc_host/` пуста, на узле отсутствуют FC HBA или не загружен драйвер для них.
+   - Если в директории `/dev/disk/by-path/` отсутствуют записи вида `fc-*`, проверьте настройки зонирования и маскирование LUN на СХД.
+   - Если FC-пути отображаются, узел готов обнаруживать LUN, предоставленные через Fibre Channel.
+
+1. После создания SCSITarget контроллер обнаружит доступные LUN и создаст объекты SCSIDevice. В дальнейшем используйте тот же ресурс [SCSIStorageClass](/modules/csi-scsi-generic/cr.html#scsistorageclass) и селектор [`scsiDeviceSelector`](/modules/csi-scsi-generic/cr.html#scsistorageclass-v1alpha1-spec-scsideviceselector), что и для iSCSI.
+
+1. Проверьте создание объекта следующей командой:
+
+   ```shell
+   d8 k get scsitargets.storage.deckhouse.io <имя-scsitarget>
+   ```
+
+   Объект считается успешно созданным, если в колонке его состояния (`Phase`) в выводе указано `Created`.
 
 ### Создание StorageClass
 
-Для создания StorageClass необходимо использовать ресурс [SCSIStorageClass](/modules/csi-scsi-generic/cr.html#scsistorageclass). Пример команды для создания такого ресурса:
+Для создания StorageClass используйте ресурс [SCSIStorageClass](/modules/csi-scsi-generic/cr.html#scsistorageclass). Пример команды для создания такого ресурса:
 
 ```shell
 d8 k apply -f -<<EOF
@@ -127,17 +224,19 @@ spec:
 EOF
 ```
 
-Обратите внимание на `scsiDeviceSelector`. Этот параметр позволяет выбрать SCSITarget для создания PV по лейблам. В примере выше выбираются все SCSITarget с лейблом `my-key: some-label-value`. Этот лейбл будет назначен на все девайсы, которые будут обнаружены в указанных SCSITarget.
+Параметр [`scsiDeviceSelector`](/modules/csi-scsi-generic/cr.html#scsistorageclass-v1alpha1-spec-scsideviceselector) позволяет выбрать SCSITarget для создания PV по лейблам. В примере выше выбираются все SCSITarget с лейблом `my-key: some-label-value`. Этот лейбл будет назначен на все устройства, которые будут обнаружены в указанных SCSITarget.
 
-Проверить создание объекта можно командой (`Phase` должен быть `Created`):
+Проверить создание объекта можно следующей командой:
 
 ```shell
-d8 k get scsistorageclasses.storage.deckhouse.io <имя scsistorageclass>
+d8 k get scsistorageclasses.storage.deckhouse.io <имя-scsistorageclass>
 ```
 
-### Проверка работоспособности модуля
+Объект считается успешно созданным, если в колонке его состояния (`Phase`) в выводе указано `Created`.
 
-Проверьте состояние подов в пространстве `d8-csi-scsi-generic` при помощи следующей команды. Все поды должны быть в состоянии `Running` или `Completed` и запущены на всех узлах.
+### Проверка работоспособности модуля csi-scsi-generic
+
+Проверьте состояние подов в пространстве `d8-csi-scsi-generic` при помощи команды ниже. Все поды должны быть в состоянии `Running` или `Completed` и запущены на всех узлах.
 
 ```shell
 d8 k -n d8-csi-scsi-generic get pod -owide -w


### PR DESCRIPTION
## Description

This PR updates the DKP documentation page describing the SCSI-based data storage configuration.

## Changelog entries

```changes
section: docs
type: chore
summary: Updated documentation on SCSI-based data storage.
impact_level: low
```