### PR TITLE
[loki] Add mount points for containerv2

### DIFF
--- a/modules/462-loki/images/loki/mount-points.yaml
+++ b/modules/462-loki/images/loki/mount-points.yaml
@@ -2,3 +2,6 @@ files:
 - /etc/loki/config.yaml
 dirs:
 - /loki
+- /tmp
+- /etc/kube-rbac-proxy/ca
+- /etc/kube-rbac-proxy/tls


### PR DESCRIPTION
## Description

Add new mount points for containers


## Why do we need it, and what problem does it solve?

Not all mount points are specified in the mount_point.yaml file. Without it, pods won't be created in containerV2. This PR solve this issue.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section:  loki
type: fix 
summary: Add mount points for containerV2
impact_level: low
```
