### PR TITLE
[vertical-pod-autoscaler] Add deploy dependency annotations to MutatingWebhookConfiguration

### DIFF
--- a/modules/302-vertical-pod-autoscaler/templates/admission-controller/mutatingwebhookconfiguration.yaml
+++ b/modules/302-vertical-pod-autoscaler/templates/admission-controller/mutatingwebhookconfiguration.yaml
@@ -3,6 +3,9 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: vpa-webhook-config
+  annotations:
+    werf.io/deploy-dependency-deployment: state=ready,kind=Deployment,name=vpa-admission-controller,namespace=kube-system
+    werf.io/deploy-dependency-service: state=present,kind=Service,name=vpa-webhook,namespace=kube-system
   {{- include "helm_lib_module_labels" (list . (dict "app" "vpa-webhook-config")) | nindent 2 }}
 webhooks:
 - admissionReviewVersions:


### PR DESCRIPTION
## Description
Add werf.io/deploy-dependency-* annotations to MutatingWebhookConfiguration/vpa-webhook-config in the vertical-pod-autoscaler module.

The webhook now deploys only after:
- Deployment/vpa-admission-controller in kube-system becomes Ready
- Service/vpa-webhook in kube-system is present
This enforces a safe rollout order for nelm/werf and prevents the webhook from being applied before its backing service is available.

## Why do we need it, and what problem does it solve?
nelm applies resources in a non-deterministic order. During module rollout, MutatingWebhookConfiguration could be created before Deployment/vpa-admission-controller and Service/vpa-webhook are ready.

In that window, kube-apiserver may try to call the VPA mutating webhook for Pod or VPA objects while the backend is unavailable. Even with failurePolicy: Ignore, this creates an unnecessary race during upgrades and can leave the cluster in an inconsistent state if the rollout is interrupted.

The same approach is already used in other Deckhouse modules (for example, node-manager and deckhouse) to guarantee that webhook configurations are applied only after their backing Deployment and Service are ready.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: vertical-pod-autoscaler
type: fix
summary: Ensure VPA mutating webhook is deployed after its admission controller Deployment and Service are ready.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
