### PR TITLE
[docs] Sync products docs via metallb module docs

### DIFF
--- a/docs/documentation/pages/admin/configuration/network/ingress/nlb/METALLB.md
+++ b/docs/documentation/pages/admin/configuration/network/ingress/nlb/METALLB.md
@@ -114,9 +114,9 @@ This approach means:
      type: LoadBalancer
      loadBalancerClass: ingress # MetalLoadBalancerClass name.
      ports:
-     - port: 8000
-       protocol: TCP
-       targetPort: 80
+       - port: 8000
+         protocol: TCP
+         targetPort: 80
      selector:
        app: nginx
    ```
@@ -139,9 +139,9 @@ spec:
   type: LoadBalancer
   loadBalancerClass: ingress # MetalLoadBalancerClass name.
   ports:
-  - port: 8000
-    protocol: TCP
-    targetPort: 80
+    - port: 8000
+      protocol: TCP
+      targetPort: 80
   selector:
     app: nginx
 ```
@@ -242,21 +242,40 @@ Service IP addresses are announced directly to routers (or top-of-rack switches)
      name: metallb
    spec:
      enabled: true
-     settings:
-       addressPools:
-       - addresses:
-         - 192.168.219.100-192.168.219.200
-         name: mypool
-         protocol: bgp
-       bgpPeers:
-       - hold-time: 3s
-         my-asn: 64600
-         peer-address: 172.18.18.10
-         peer-asn: 64601
-       speaker:
-         nodeSelector:
-           node-role.deckhouse.io/metallb: ""
-     version: 2
+     version: 3
+   ---
+   apiVersion: network.deckhouse.io/v1alpha1
+   kind: MetalLoadBalancerPool
+   metadata:
+     name: mypool
+   spec:
+     addresses:
+       - 192.168.219.100-192.168.219.200
+   ---
+   apiVersion: network.deckhouse.io/v1alpha1
+   kind: MetalLoadBalancerBGPPeer
+   metadata:
+     name: myrouter
+   spec:
+     peerAddress: 172.18.18.10
+     peerASN: 64601
+     myASN: 64600
+     holdTime: 3s
+   ---
+   apiVersion: network.deckhouse.io/v1alpha1
+   kind: MetalLoadBalancerConfiguration
+   metadata:
+     name: defaults
+   spec:
+     mode: BGP
+     nodeSelector:
+       node-role.deckhouse.io/metallb: ""
+     bgp:
+       peerNames:
+         - myrouter
+     advertisements:
+       - poolNames:
+           - mypool
    ```
 
 1. Configure BGP peering on the network equipment.

--- a/docs/documentation/pages/admin/configuration/network/ingress/nlb/METALLB_RU.md
+++ b/docs/documentation/pages/admin/configuration/network/ingress/nlb/METALLB_RU.md
@@ -113,9 +113,9 @@ lang: ru
      type: LoadBalancer
      loadBalancerClass: ingress # Имя MetalLoadBalancerClass.
      ports:
-     - port: 8000
-       protocol: TCP
-       targetPort: 80
+       - port: 8000
+         protocol: TCP
+         targetPort: 80
      selector:
        app: nginx
    ```
@@ -138,9 +138,9 @@ spec:
   type: LoadBalancer
   loadBalancerClass: ingress # Имя MetalLoadBalancerClass.
   ports:
-  - port: 8000
-    protocol: TCP
-    targetPort: 80
+    - port: 8000
+      protocol: TCP
+      targetPort: 80
   selector:
     app: nginx
 ```
@@ -239,21 +239,40 @@ IP-адреса сервисов анонсируются напрямую в м
      name: metallb
    spec:
      enabled: true
-     settings:
-       addressPools:
-       - addresses:
-         - 192.168.219.100-192.168.219.200
-         name: mypool
-         protocol: bgp
-       bgpPeers:
-       - hold-time: 3s
-         my-asn: 64600
-         peer-address: 172.18.18.10
-         peer-asn: 64601
-       speaker:
-         nodeSelector:
-           node-role.deckhouse.io/metallb: ""
-     version: 2
+     version: 3
+   ---
+   apiVersion: network.deckhouse.io/v1alpha1
+   kind: MetalLoadBalancerPool
+   metadata:
+     name: mypool
+   spec:
+     addresses:
+       - 192.168.219.100-192.168.219.200
+   ---
+   apiVersion: network.deckhouse.io/v1alpha1
+   kind: MetalLoadBalancerBGPPeer
+   metadata:
+     name: myrouter
+   spec:
+     peerAddress: 172.18.18.10
+     peerASN: 64601
+     myASN: 64600
+     holdTime: 3s
+   ---
+   apiVersion: network.deckhouse.io/v1alpha1
+   kind: MetalLoadBalancerConfiguration
+   metadata:
+     name: defaults
+   spec:
+     mode: BGP
+     nodeSelector:
+       node-role.deckhouse.io/metallb: ""
+     bgp:
+       peerNames:
+         - myrouter
+     advertisements:
+       - poolNames:
+           - mypool
    ```
 
 1. Настройте BGP-пиринг на сетевом оборудовании.

--- a/docs/documentation/pages/user/network/ingress/NLB.md
+++ b/docs/documentation/pages/user/network/ingress/NLB.md
@@ -71,7 +71,7 @@ spec:
 ### Assigning an IPAddressPool (BGP mode)
 
 In BGP LoadBalancer mode, an IP address can be allocated from a specific address pool
-using the `metallb.universe.tf/address-pool` annotation.
+using the `network.deckhouse.io/load-balancer-pool` annotation.
 For L2 LoadBalancer mode, you need to use the [MetalLoadBalancerClass](../../../admin/configuration/network/ingress/nlb/metallb.html#example-of-using-metallb-in-l2-loadbalancer-mode) configuration.
 
 Example:

--- a/docs/documentation/pages/user/network/ingress/NLB.md
+++ b/docs/documentation/pages/user/network/ingress/NLB.md
@@ -61,8 +61,8 @@ metadata:
     network.deckhouse.io/load-balancer-ips: 192.168.217.217
 spec:
   ports:
-  - port: 80
-    targetPort: 80
+    - port: 80
+      targetPort: 80
   selector:
     app: nginx
   type: LoadBalancer
@@ -82,11 +82,11 @@ kind: Service
 metadata:
   name: nginx
   annotations:
-    metallb.universe.tf/address-pool: production-public-ips
+    network.deckhouse.io/load-balancer-pool: production-public-ips
 spec:
   ports:
-  - port: 80
-    targetPort: 80
+    - port: 80
+      targetPort: 80
   selector:
     app: nginx
   type: LoadBalancer

--- a/docs/documentation/pages/user/network/ingress/NLB_RU.md
+++ b/docs/documentation/pages/user/network/ingress/NLB_RU.md
@@ -73,7 +73,7 @@ spec:
 
 ### Назначение IPAddressPool (режим BGP)
 
-В режиме BGP LoadBalancer получение IP-адреса возможно из определённого пула адресов через аннотацию `metallb.universe.tf/address-pool`.
+В режиме BGP LoadBalancer получение IP-адреса возможно из определённого пула адресов через аннотацию `network.deckhouse.io/load-balancer-pool`.
 Для режима L2 LoadBalancer необходимо использовать настройки [MetalLoadBalancerClass](../../../admin/configuration/network/ingress/nlb/metallb.html#пример-использования-metallb-в-режиме-l2-loadbalancer).
 
 Пример:

--- a/docs/documentation/pages/user/network/ingress/NLB_RU.md
+++ b/docs/documentation/pages/user/network/ingress/NLB_RU.md
@@ -64,8 +64,8 @@ metadata:
     network.deckhouse.io/load-balancer-ips: 192.168.217.217
 spec:
   ports:
-  - port: 80
-    targetPort: 80
+    - port: 80
+      targetPort: 80
   selector:
     app: nginx
   type: LoadBalancer
@@ -84,11 +84,11 @@ kind: Service
 metadata:
   name: nginx
   annotations:
-    metallb.universe.tf/address-pool: production-public-ips
+    network.deckhouse.io/load-balancer-pool: production-public-ips
 spec:
   ports:
-  - port: 80
-    targetPort: 80
+    - port: 80
+      targetPort: 80
   selector:
     app: nginx
   type: LoadBalancer

--- a/docs/site/pages/virtualization-platform/documentation/admin/platform-management/network/ingress/nlb/METALLB.md
+++ b/docs/site/pages/virtualization-platform/documentation/admin/platform-management/network/ingress/nlb/METALLB.md
@@ -113,9 +113,9 @@ This approach means:
      type: LoadBalancer
      loadBalancerClass: ingress # MetalLoadBalancerClass name.
      ports:
-     - port: 8000
-       protocol: TCP
-       targetPort: 80
+       - port: 8000
+         protocol: TCP
+         targetPort: 80
      selector:
        app: nginx
    ```
@@ -138,9 +138,9 @@ spec:
   type: LoadBalancer
   loadBalancerClass: ingress # MetalLoadBalancerClass name.
   ports:
-  - port: 8000
-    protocol: TCP
-    targetPort: 80
+    - port: 8000
+      protocol: TCP
+      targetPort: 80
   selector:
     app: nginx
 ```
@@ -241,21 +241,40 @@ Service IP addresses are announced directly to routers (or top-of-rack switches)
      name: metallb
    spec:
      enabled: true
-     settings:
-       addressPools:
-       - addresses:
-         - 192.168.219.100-192.168.219.200
-         name: mypool
-         protocol: bgp
-       bgpPeers:
-       - hold-time: 3s
-         my-asn: 64600
-         peer-address: 172.18.18.10
-         peer-asn: 64601
-       speaker:
-         nodeSelector:
-           node-role.deckhouse.io/metallb: ""
-     version: 2
+     version: 3
+   ---
+   apiVersion: network.deckhouse.io/v1alpha1
+   kind: MetalLoadBalancerPool
+   metadata:
+     name: mypool
+   spec:
+     addresses:
+       - 192.168.219.100-192.168.219.200
+   ---
+   apiVersion: network.deckhouse.io/v1alpha1
+   kind: MetalLoadBalancerBGPPeer
+   metadata:
+     name: myrouter
+   spec:
+     peerAddress: 172.18.18.10
+     peerASN: 64601
+     myASN: 64600
+     holdTime: 3s
+   ---
+   apiVersion: network.deckhouse.io/v1alpha1
+   kind: MetalLoadBalancerConfiguration
+   metadata:
+     name: defaults
+   spec:
+     mode: BGP
+     nodeSelector:
+       node-role.deckhouse.io/metallb: ""
+     bgp:
+       peerNames:
+         - myrouter
+     advertisements:
+       - poolNames:
+           - mypool
    ```
 
 1. Configure BGP peering on the network equipment.

--- a/docs/site/pages/virtualization-platform/documentation/admin/platform-management/network/ingress/nlb/METALLB_RU.md
+++ b/docs/site/pages/virtualization-platform/documentation/admin/platform-management/network/ingress/nlb/METALLB_RU.md
@@ -112,9 +112,9 @@ lang: ru
      type: LoadBalancer
      loadBalancerClass: ingress # Имя MetalLoadBalancerClass.
      ports:
-     - port: 8000
-       protocol: TCP
-       targetPort: 80
+       - port: 8000
+         protocol: TCP
+         targetPort: 80
      selector:
        app: nginx
    ```
@@ -137,9 +137,9 @@ spec:
   type: LoadBalancer
   loadBalancerClass: ingress # Имя MetalLoadBalancerClass.
   ports:
-  - port: 8000
-    protocol: TCP
-    targetPort: 80
+    - port: 8000
+      protocol: TCP
+      targetPort: 80
   selector:
     app: nginx
 ```
@@ -238,21 +238,40 @@ IP-адреса сервисов анонсируются напрямую в м
      name: metallb
    spec:
      enabled: true
-     settings:
-       addressPools:
-       - addresses:
-         - 192.168.219.100-192.168.219.200
-         name: mypool
-         protocol: bgp
-       bgpPeers:
-       - hold-time: 3s
-         my-asn: 64600
-         peer-address: 172.18.18.10
-         peer-asn: 64601
-       speaker:
-         nodeSelector:
-           node-role.deckhouse.io/metallb: ""
-     version: 2
+     version: 3
+   ---
+   apiVersion: network.deckhouse.io/v1alpha1
+   kind: MetalLoadBalancerPool
+   metadata:
+     name: mypool
+   spec:
+     addresses:
+       - 192.168.219.100-192.168.219.200
+   ---
+   apiVersion: network.deckhouse.io/v1alpha1
+   kind: MetalLoadBalancerBGPPeer
+   metadata:
+     name: myrouter
+   spec:
+     peerAddress: 172.18.18.10
+     peerASN: 64601
+     myASN: 64600
+     holdTime: 3s
+   ---
+   apiVersion: network.deckhouse.io/v1alpha1
+   kind: MetalLoadBalancerConfiguration
+   metadata:
+     name: defaults
+   spec:
+     mode: BGP
+     nodeSelector:
+       node-role.deckhouse.io/metallb: ""
+     bgp:
+       peerNames:
+         - myrouter
+     advertisements:
+       - poolNames:
+           - mypool
    ```
 
 1. Настройте BGP-пиринг на сетевом оборудовании.


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Actualise products docs via metallb module docs (#18660).

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Products docs was actualised via metallb module docs (#18660).
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
