### PR TITLE
[admission-policy-engine][cert-manager][multitenancy-manager] add webhook deploy dependencies for werf

### DIFF
--- a/modules/015-admission-policy-engine/templates/mutatingwebhookconfiguration.yaml
+++ b/modules/015-admission-policy-engine/templates/mutatingwebhookconfiguration.yaml
@@ -4,6 +4,9 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: d8-admission-policy-engine-config
+  annotations:
+    werf.io/deploy-dependency-deployment: state=ready,kind=Deployment,name=gatekeeper-controller-manager,namespace=d8-admission-policy-engine
+    werf.io/deploy-dependency-service: state=present,kind=Service,name=gatekeeper-webhook-service,namespace=d8-admission-policy-engine
   {{- include "helm_lib_module_labels" (list . (dict "app" "gatekeeper" "control-plane" "controller-manager" "gatekeeper.sh/system" "yes")) | nindent 2 }}
 webhooks:
 - admissionReviewVersions:

--- a/modules/015-admission-policy-engine/templates/validatingwebhookconfiguration.yaml
+++ b/modules/015-admission-policy-engine/templates/validatingwebhookconfiguration.yaml
@@ -59,6 +59,9 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: d8-admission-policy-engine-config
+  annotations:
+    werf.io/deploy-dependency-deployment: state=ready,kind=Deployment,name=gatekeeper-controller-manager,namespace=d8-admission-policy-engine
+    werf.io/deploy-dependency-service: state=present,kind=Service,name=gatekeeper-webhook-service,namespace=d8-admission-policy-engine
   {{- include "helm_lib_module_labels" (list . (dict "app" "gatekeeper" "control-plane" "controller-manager" "gatekeeper.sh/system" "yes")) | nindent 2 }}
 webhooks:
   {{- if (gt (len .Values.admissionPolicyEngine.internal.trackedConstraintResources) 0) }}

--- a/modules/101-cert-manager/templates/webhook/mutatingwebhookconfiguration.yaml
+++ b/modules/101-cert-manager/templates/webhook/mutatingwebhookconfiguration.yaml
@@ -3,6 +3,9 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: cert-manager-webhook
+  annotations:
+    werf.io/deploy-dependency-deployment: state=ready,kind=Deployment,name=webhook,namespace=d8-cert-manager
+    werf.io/deploy-dependency-service: state=present,kind=Service,name=cert-manager-webhook,namespace=d8-cert-manager
   {{- include "helm_lib_module_labels" (list . (dict "app" "webhook")) | nindent 2 }}
 webhooks:
   - name: webhook.cert-manager.io

--- a/modules/101-cert-manager/templates/webhook/validatingwebhookconfiguration.yaml
+++ b/modules/101-cert-manager/templates/webhook/validatingwebhookconfiguration.yaml
@@ -2,6 +2,9 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: cert-manager-webhook
+  annotations:
+    werf.io/deploy-dependency-deployment: state=ready,kind=Deployment,name=webhook,namespace=d8-cert-manager
+    werf.io/deploy-dependency-service: state=present,kind=Service,name=cert-manager-webhook,namespace=d8-cert-manager
   {{- include "helm_lib_module_labels" (list . (dict "app" "webhook")) | nindent 2 }}
 webhooks:
   - name: webhook.cert-manager.io # don't change the name!

--- a/modules/160-multitenancy-manager/templates/admission/validation.yaml
+++ b/modules/160-multitenancy-manager/templates/admission/validation.yaml
@@ -19,6 +19,9 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: d8-multitenancy-manager-webhook
+  annotations:
+    werf.io/deploy-dependency-deployment: state=ready,kind=Deployment,name=multitenancy-manager,namespace=d8-multitenancy-manager
+    werf.io/deploy-dependency-service: state=present,kind=Service,name=multitenancy-manager,namespace=d8-multitenancy-manager
   {{- include "helm_lib_module_labels" (list . (dict "app" "multitenancy-webhook")) | nindent 2 }}
 webhooks:
   - name: projects.multitenancy-webhook.deckhouse.io

--- a/modules/160-multitenancy-manager/templates/cluster-objects-controller/protect-webhook.yaml
+++ b/modules/160-multitenancy-manager/templates/cluster-objects-controller/protect-webhook.yaml
@@ -4,6 +4,9 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: cluster-objects-grants-protect
+  annotations:
+    werf.io/deploy-dependency-deployment: state=ready,kind=Deployment,name=multitenancy-manager,namespace=d8-multitenancy-manager
+    werf.io/deploy-dependency-service: state=present,kind=Service,name=multitenancy-manager,namespace=d8-multitenancy-manager
   {{- include "helm_lib_module_labels" (list . (dict "app" "cluster-objects-controller")) | nindent 2 }}
 webhooks:
   # Keep the controller-owned catalog (AvailableClusterResource) read-only to everyone but the controller.


### PR DESCRIPTION
## Description

Adds `werf` deploy dependencies to webhook configurations in:
- `admission-policy-engine`
- `cert-manager`
- `multitenancy-manager`

For each `ValidatingWebhookConfiguration` / `MutatingWebhookConfiguration`, we now explicitly require rollout after the corresponding webhook backend `Deployment` is `ready` and `Service` is `present`.

## Why do we need it, and what problem does it solve?

Without explicit `werf` ordering, webhook configs can be applied before their backend is ready, which may cause unstable admission behavior during rollout.  
This change makes webhook deployment order deterministic and satisfies the new DMT lint rule for webhook configuration annotations.

## Why do we need it in the patch release (if we do)?

Required for compatibility with the new DMT lint rule and to avoid rollout ordering issues in affected modules. Backport is recommended.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: admission-policy-engine
type: chore
summary: Add werf deploy dependencies for webhook configurations to enforce rollout order.
impact_level: low