### PR TITLE
[node-manager]  Fix keep-policy hook failing when CAPI conversion webhook is unavailable.

### DIFF
--- a/modules/040-node-manager/hooks/set_keep_policy_on_capi_resources.go
+++ b/modules/040-node-manager/hooks/set_keep_policy_on_capi_resources.go
@@ -19,14 +19,16 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
 
 	"github.com/deckhouse/deckhouse/go_lib/dependency"
 )
@@ -34,15 +36,25 @@ import (
 const (
 	helmResourcePolicyAnnotation = "helm.sh/resource-policy"
 	capiNamespace                = "d8-cloud-instance-manager"
+	helmManagedSelector          = "app.kubernetes.io/managed-by=Helm"
 )
 
-// TODO(v1beta2): GVR uses v1beta1 for rolling upgrade from CSE 1.73 which still
-// serves v1beta1. Switch to v1beta2 once v1beta1 is no longer served.
-var capiResources = []schema.GroupVersionResource{
-	{Group: "cluster.x-k8s.io", Version: "v1beta1", Resource: "clusters"},
-	{Group: "cluster.x-k8s.io", Version: "v1beta1", Resource: "machinehealthchecks"},
-	{Group: "cluster.x-k8s.io", Version: "v1beta1", Resource: "machinedeployments"},
+var capiResources = []struct {
+	Group    string
+	Resource string
+}{
+	{Group: "cluster.x-k8s.io", Resource: "clusters"},
+	{Group: "cluster.x-k8s.io", Resource: "machinehealthchecks"},
+	{Group: "cluster.x-k8s.io", Resource: "machinedeployments"},
 }
+
+var crdGVR = schema.GroupVersionResource{
+	Group:    "apiextensions.k8s.io",
+	Version:  "v1",
+	Resource: "customresourcedefinitions",
+}
+
+var storedVersionPreference = []string{"v1beta1", "v1beta2"}
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	Queue:        "/modules/node-manager/set-keep-policy-on-capi-resources",
@@ -64,55 +76,81 @@ func setKeepPolicyOnCapiResources(_ context.Context, input *go_hook.HookInput, d
 		},
 	})
 
-	for _, gvr := range capiResources {
-		list, err := dynClient.Resource(gvr).Namespace(capiNamespace).List(context.TODO(), metav1.ListOptions{})
+	for _, res := range capiResources {
+		version, ok, err := pickStoredVersion(dynClient, res.Group, res.Resource)
 		if err != nil {
-			if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
-				input.Logger.Info("skipping resource, not served", slog.String("resource", gvr.Resource), slog.Any("error", err))
+			return fmt.Errorf("resolve stored version for %s: %w", res.Resource, err)
+		}
+		if !ok {
+			continue
+		}
+		gvr := schema.GroupVersionResource{Group: res.Group, Version: version, Resource: res.Resource}
+
+		list, err := dynClient.Resource(gvr).Namespace(capiNamespace).List(context.TODO(), metav1.ListOptions{LabelSelector: helmManagedSelector})
+		if err != nil {
+			if isConversionUnavailable(err) {
+				input.Logger.Info("skipping resource, conversion webhook unavailable", slog.String("resource", res.Resource), slog.String("version", version))
 				continue
 			}
-			return fmt.Errorf("list %s: %w", gvr.Resource, err)
+			return fmt.Errorf("list %s/%s: %w", res.Resource, version, err)
 		}
 
 		for _, item := range list.Items {
-			annotations := item.GetAnnotations()
-			if annotations == nil {
+			if item.GetAnnotations()[helmResourcePolicyAnnotation] == "keep" {
 				continue
 			}
-			if _, hasHelm := annotations["meta.helm.sh/release-name"]; !hasHelm {
-				continue
-			}
-			if annotations[helmResourcePolicyAnnotation] == "keep" {
-				continue
-			}
-
-			_, err := dynClient.Resource(gvr).Namespace(item.GetNamespace()).Patch(
+			if _, err := dynClient.Resource(gvr).Namespace(item.GetNamespace()).Patch(
 				context.TODO(),
 				item.GetName(),
 				types.MergePatchType,
 				patch,
 				metav1.PatchOptions{},
-			)
-			if err != nil {
-				return fmt.Errorf("patch %s/%s: %w", gvr.Resource, item.GetName(), err)
+			); err != nil {
+				return fmt.Errorf("patch %s/%s: %w", res.Resource, item.GetName(), err)
 			}
-			input.Logger.Info("stamped keep policy", slog.String("resource", gvr.Resource), slog.String("name", item.GetName()))
+			input.Logger.Info("stamped keep policy", slog.String("resource", res.Resource), slog.String("name", item.GetName()))
 		}
 
-		verify, err := dynClient.Resource(gvr).Namespace(capiNamespace).List(context.TODO(), metav1.ListOptions{})
+		verify, err := dynClient.Resource(gvr).Namespace(capiNamespace).List(context.TODO(), metav1.ListOptions{LabelSelector: helmManagedSelector})
 		if err != nil {
-			return fmt.Errorf("verify list %s: %w", gvr.Resource, err)
+			return fmt.Errorf("verify list %s/%s: %w", res.Resource, version, err)
 		}
 		for _, item := range verify.Items {
-			annotations := item.GetAnnotations()
-			if _, hasHelm := annotations["meta.helm.sh/release-name"]; !hasHelm {
-				continue
-			}
-			if annotations[helmResourcePolicyAnnotation] != "keep" {
-				return fmt.Errorf("keep policy not set on helm-managed %s/%s: refusing to proceed to avoid prune", gvr.Resource, item.GetName())
+			if item.GetAnnotations()[helmResourcePolicyAnnotation] != "keep" {
+				return fmt.Errorf("keep policy not set on %s/%s: refusing to proceed to avoid prune", res.Resource, item.GetName())
 			}
 		}
 	}
 
 	return nil
+}
+
+func pickStoredVersion(dynClient dynamic.Interface, group, resource string) (string, bool, error) {
+	crd, err := dynClient.Resource(crdGVR).Get(context.TODO(), resource+"."+group, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	stored, _, err := unstructured.NestedStringSlice(crd.Object, "status", "storedVersions")
+	if err != nil {
+		return "", false, err
+	}
+	for _, want := range storedVersionPreference {
+		for _, have := range stored {
+			if have == want {
+				return want, true, nil
+			}
+		}
+	}
+	return "", false, nil
+}
+
+func isConversionUnavailable(err error) bool {
+	if apierrors.IsServiceUnavailable(err) {
+		return true
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "conversion webhook") || strings.Contains(msg, "(re)initializing")
 }


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix the keep-policy hook failing the deploy when the CAPI conversion webhook isn't up yet: it now skips resources on a temporary webhook outage and reads the CRD's real stored version  instead of assuming v1beta1.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: Fixed the keep-policy hook failing when the CAPI conversion webhook is unavailable.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
