### PR TITLE
[istio] Add deploy dependencies for Istio webhook configurations

### DIFF
--- a/modules/110-istio/templates/control-plane/mutatingwebhook-global.yaml
+++ b/modules/110-istio/templates/control-plane/mutatingwebhook-global.yaml
@@ -29,10 +29,14 @@
 ---
 {{- $versionInfo := get .Values.istio.internal.versionMap .Values.istio.internal.globalVersion }}
 {{- $fullVersion := get $versionInfo "fullVersion" }}
+{{- $revision := get $versionInfo "revision" }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: d8-istio-sidecar-injector-global
+  annotations:
+    werf.io/deploy-dependency-deployment: state=ready,kind=Deployment,name=istiod-{{ $revision }},namespace=d8-istio
+    werf.io/deploy-dependency-service: state=present,kind=Service,name=istiod-{{ $revision }},namespace=d8-istio
   {{- include "helm_lib_module_labels" (list . (dict "istio.deckhouse.io/full-version" $fullVersion) ) | nindent 2 }}
 webhooks:
 {{- /* Case 1: Namespace-wide injection */}}

--- a/modules/110-istio/templates/control-plane/mutatingwebhook-revisions.yaml
+++ b/modules/110-istio/templates/control-plane/mutatingwebhook-revisions.yaml
@@ -33,6 +33,9 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: d8-istio-sidecar-injector-{{ $revision }}
+  annotations:
+    werf.io/deploy-dependency-deployment: state=ready,kind=Deployment,name=istiod-{{ $revision }},namespace=d8-istio
+    werf.io/deploy-dependency-service: state=present,kind=Service,name=istiod-{{ $revision }},namespace=d8-istio
   {{- include "helm_lib_module_labels" (list $ (dict "istio.deckhouse.io/full-version" $fullVersion "istio.io/rev" $revision ) ) | nindent 2 }}
 webhooks:
 {{- /* Case 1: Namespace-wide injection */}}

--- a/modules/110-istio/templates/control-plane/validatingwebhook-global.yaml
+++ b/modules/110-istio/templates/control-plane/validatingwebhook-global.yaml
@@ -9,6 +9,9 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: d8-istio-validator-global
+  annotations:
+    werf.io/deploy-dependency-deployment: state=ready,kind=Deployment,name=istiod-{{ $revision }},namespace=d8-istio
+    werf.io/deploy-dependency-service: state=present,kind=Service,name=istiod-{{ $revision }},namespace=d8-istio
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 webhooks:
   - admissionReviewVersions:

--- a/modules/110-istio/templates/control-plane/validatingwebhook-revisions.yaml
+++ b/modules/110-istio/templates/control-plane/validatingwebhook-revisions.yaml
@@ -6,6 +6,9 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: d8-istio-validator-{{ $revision }}
+  annotations:
+    werf.io/deploy-dependency-deployment: state=ready,kind=Deployment,name=istiod-{{ $revision }},namespace=d8-istio
+    werf.io/deploy-dependency-service: state=present,kind=Service,name=istiod-{{ $revision }},namespace=d8-istio
   {{- include "helm_lib_module_labels" (list $ (dict "istio.io/rev" $revision )) | nindent 2 }}
 webhooks:
   - name: rev.validation.istio.io


### PR DESCRIPTION
## Description

Added werf deploy dependency annotations to Istio mutating and validating webhook configurations.

The webhook configurations are now deployed only after the corresponding `istiod` Deployment becomes ready and the related `istiod` Service is present.

## Why do we need it, and what problem does it solve?

This fixes undefined deployment ordering between Istio webhook configurations and their backing `istiod` Deployment/Service.

Without explicit deploy dependencies, the webhook configuration could be applied before its backend is ready. In an interrupted or failed rollout, this could leave the cluster with active admission webhooks pointing to unavailable services, blocking creation or updates of resources handled by Istio webhooks.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: feature
summary: Added deploy dependencies for Istio webhook configurations.
impact_level: default
```
