### PR TITLE
[dhctl] fix(dhctl-for-commander): fix grpc stream cancel deadlock

### DIFF
--- a/dhctl/pkg/server/pkg/logger/writer.go
+++ b/dhctl/pkg/server/pkg/logger/writer.go
@@ -15,6 +15,7 @@
 package logger
 
 import (
+	"context"
 	"log/slog"
 	"sync"
 )
@@ -22,6 +23,7 @@ import (
 type LogConsumer[T any] func(lines []string) T
 
 type LogWriter[T any] struct {
+	ctx    context.Context
 	l      *slog.Logger
 	sendCh chan T
 	f      func([]string) T
@@ -30,8 +32,9 @@ type LogWriter[T any] struct {
 	prev []byte
 }
 
-func NewLogWriter[T any](l *slog.Logger, sendCh chan T, f LogConsumer[T]) *LogWriter[T] {
+func NewLogWriter[T any](ctx context.Context, l *slog.Logger, sendCh chan T, f LogConsumer[T]) *LogWriter[T] {
 	return &LogWriter[T]{
+		ctx:    ctx,
 		l:      l,
 		sendCh: sendCh,
 		f:      f,
@@ -61,7 +64,10 @@ func (w *LogWriter[T]) Write(p []byte) (int, error) {
 		for _, line := range lines {
 			w.l.Info(line)
 		}
-		w.sendCh <- w.f(lines)
+		select {
+		case w.sendCh <- w.f(lines):
+		case <-w.ctx.Done():
+		}
 	}
 
 	return len(p), nil

--- a/dhctl/pkg/server/pkg/logger/writer_test.go
+++ b/dhctl/pkg/server/pkg/logger/writer_test.go
@@ -101,7 +101,7 @@ func TestLogWriter(t *testing.T) {
 				},
 			})).With(slog.String("key", "value"))
 
-			w := logger.NewLogWriter(log, sendCh, tt.f)
+			w := logger.NewLogWriter(t.Context(), log, sendCh, tt.f)
 
 			wg := sync.WaitGroup{}
 			wg.Go(func() {

--- a/dhctl/pkg/server/rpc/dhctl/abort.go
+++ b/dhctl/pkg/server/rpc/dhctl/abort.go
@@ -69,7 +69,7 @@ func (s *Service) Abort(server pb.DHCTL_AbortServer) error {
 	f := fsm.New("initial", s.abortServerTransitions())
 
 	doneCh := make(chan struct{})
-	internalErrCh := make(chan error)
+	internalErrCh := make(chan error, internalErrChBufferSize)
 	receiveCh := make(chan *pb.AbortRequest)
 	sendCh := make(chan *pb.AbortResponse)
 	phaseSwitcher := &fsmPhaseSwitcher[*pb.AbortResponse, any]{
@@ -113,10 +113,10 @@ connectionProcessor:
 					result := s.abortSafe(ctx, &abortParams{
 						request:      message.Start,
 						switchPhase:  phaseSwitcher.switchPhase(ctx),
-						sendProgress: pt.sendProgress(),
+						sendProgress: pt.sendProgress(ctx),
 						sendCh:       sendCh,
 					})
-					sendCh <- &pb.AbortResponse{Message: &pb.AbortResponse_Result{Result: result}}
+					_ = sendResponse(server.Context(), sendCh, &pb.AbortResponse{Message: &pb.AbortResponse_Result{Result: result}})
 				}()
 
 			case *pb.AbortRequest_Continue:
@@ -128,13 +128,13 @@ connectionProcessor:
 				}
 				switch message.Continue.Continue {
 				case pb.Continue_CONTINUE_UNSPECIFIED:
-					phaseSwitcher.next <- errors.New("bad continue message")
+					sendPhaseSwitch(ctx, phaseSwitcher.next, errors.New("bad continue message"))
 				case pb.Continue_CONTINUE_NEXT_PHASE:
-					phaseSwitcher.next <- nil
+					sendPhaseSwitch(ctx, phaseSwitcher.next, nil)
 				case pb.Continue_CONTINUE_STOP_OPERATION:
-					phaseSwitcher.next <- phases.ErrStopOperationCondition
+					sendPhaseSwitch(ctx, phaseSwitcher.next, phases.ErrStopOperationCondition)
 				case pb.Continue_CONTINUE_ERROR:
-					phaseSwitcher.next <- errors.New(message.Continue.Err)
+					sendPhaseSwitch(ctx, phaseSwitcher.next, errors.New(message.Continue.Err))
 				}
 
 			case *pb.AbortRequest_Cancel:

--- a/dhctl/pkg/server/rpc/dhctl/bootstrap.go
+++ b/dhctl/pkg/server/rpc/dhctl/bootstrap.go
@@ -72,7 +72,7 @@ func (s *Service) Bootstrap(server pb.DHCTL_BootstrapServer) error {
 	f := fsm.New("initial", s.bootstrapServerTransitions())
 
 	doneCh := make(chan struct{})
-	internalErrCh := make(chan error)
+	internalErrCh := make(chan error, internalErrChBufferSize)
 	receiveCh := make(chan *pb.BootstrapRequest)
 	sendCh := make(chan *pb.BootstrapResponse)
 	phaseSwitcher := &fsmPhaseSwitcher[*pb.BootstrapResponse, any]{
@@ -116,10 +116,10 @@ connectionProcessor:
 					result := s.bootstrapSafe(ctx, &bootstrapParams{
 						request:      message.Start,
 						switchPhase:  phaseSwitcher.switchPhase(ctx),
-						sendProgress: pt.sendProgress(),
+						sendProgress: pt.sendProgress(ctx),
 						sendCh:       sendCh,
 					})
-					sendCh <- &pb.BootstrapResponse{Message: &pb.BootstrapResponse_Result{Result: result}}
+					_ = sendResponse(server.Context(), sendCh, &pb.BootstrapResponse{Message: &pb.BootstrapResponse_Result{Result: result}})
 				}()
 
 			case *pb.BootstrapRequest_Continue:
@@ -131,13 +131,13 @@ connectionProcessor:
 				}
 				switch message.Continue.Continue {
 				case pb.Continue_CONTINUE_UNSPECIFIED:
-					phaseSwitcher.next <- errors.New("bad continue message")
+					sendPhaseSwitch(ctx, phaseSwitcher.next, errors.New("bad continue message"))
 				case pb.Continue_CONTINUE_NEXT_PHASE:
-					phaseSwitcher.next <- nil
+					sendPhaseSwitch(ctx, phaseSwitcher.next, nil)
 				case pb.Continue_CONTINUE_STOP_OPERATION:
-					phaseSwitcher.next <- phases.ErrStopOperationCondition
+					sendPhaseSwitch(ctx, phaseSwitcher.next, phases.ErrStopOperationCondition)
 				case pb.Continue_CONTINUE_ERROR:
-					phaseSwitcher.next <- errors.New(message.Continue.Err)
+					sendPhaseSwitch(ctx, phaseSwitcher.next, errors.New(message.Continue.Err))
 				}
 
 			case *pb.BootstrapRequest_Cancel:

--- a/dhctl/pkg/server/rpc/dhctl/check.go
+++ b/dhctl/pkg/server/rpc/dhctl/check.go
@@ -74,7 +74,7 @@ func (s *Service) Check(server pb.DHCTL_CheckServer) error {
 	f := fsm.New("initial", s.checkServerTransitions())
 
 	doneCh := make(chan struct{})
-	internalErrCh := make(chan error)
+	internalErrCh := make(chan error, internalErrChBufferSize)
 	receiveCh := make(chan *pb.CheckRequest)
 	sendCh := make(chan *pb.CheckResponse)
 	pt := progressTracker[*pb.CheckResponse]{
@@ -114,10 +114,10 @@ connectionProcessor:
 				go func() {
 					result := s.checkSafe(ctx, &checkParams{
 						request:      message.Start,
-						sendProgress: pt.sendProgress(),
+						sendProgress: pt.sendProgress(ctx),
 						sendCh:       sendCh,
 					})
-					sendCh <- &pb.CheckResponse{Message: &pb.CheckResponse_Result{Result: result}}
+					_ = sendResponse(server.Context(), sendCh, &pb.CheckResponse{Message: &pb.CheckResponse_Result{Result: result}})
 				}()
 
 			case *pb.CheckRequest_Cancel:

--- a/dhctl/pkg/server/rpc/dhctl/commander_attach.go
+++ b/dhctl/pkg/server/rpc/dhctl/commander_attach.go
@@ -69,7 +69,7 @@ func (s *Service) CommanderAttach(server pb.DHCTL_CommanderAttachServer) error {
 	f := fsm.New("initial", s.commanderAttachServerTransitions())
 
 	doneCh := make(chan struct{})
-	internalErrCh := make(chan error)
+	internalErrCh := make(chan error, internalErrChBufferSize)
 	receiveCh := make(chan *pb.CommanderAttachRequest)
 	sendCh := make(chan *pb.CommanderAttachResponse)
 	phaseSwitcher := &fsmPhaseSwitcher[*pb.CommanderAttachResponse, attach.PhaseData]{
@@ -113,10 +113,10 @@ connectionProcessor:
 					result := s.commanderAttachSafe(ctx, &attachParams{
 						request:      message.Start,
 						switchPhase:  phaseSwitcher.switchPhase(ctx),
-						sendProgress: pt.sendProgress(),
+						sendProgress: pt.sendProgress(ctx),
 						sendCh:       sendCh,
 					})
-					sendCh <- &pb.CommanderAttachResponse{Message: &pb.CommanderAttachResponse_Result{Result: result}}
+					_ = sendResponse(server.Context(), sendCh, &pb.CommanderAttachResponse{Message: &pb.CommanderAttachResponse_Result{Result: result}})
 				}()
 
 			case *pb.CommanderAttachRequest_Continue:
@@ -128,13 +128,13 @@ connectionProcessor:
 				}
 				switch message.Continue.Continue {
 				case pb.Continue_CONTINUE_UNSPECIFIED:
-					phaseSwitcher.next <- errors.New("bad continue message")
+					sendPhaseSwitch(ctx, phaseSwitcher.next, errors.New("bad continue message"))
 				case pb.Continue_CONTINUE_NEXT_PHASE:
-					phaseSwitcher.next <- nil
+					sendPhaseSwitch(ctx, phaseSwitcher.next, nil)
 				case pb.Continue_CONTINUE_STOP_OPERATION:
-					phaseSwitcher.next <- phases.ErrStopOperationCondition
+					sendPhaseSwitch(ctx, phaseSwitcher.next, phases.ErrStopOperationCondition)
 				case pb.Continue_CONTINUE_ERROR:
-					phaseSwitcher.next <- errors.New(message.Continue.Err)
+					sendPhaseSwitch(ctx, phaseSwitcher.next, errors.New(message.Continue.Err))
 				}
 
 			case *pb.CommanderAttachRequest_Cancel:

--- a/dhctl/pkg/server/rpc/dhctl/commander_detach.go
+++ b/dhctl/pkg/server/rpc/dhctl/commander_detach.go
@@ -76,7 +76,7 @@ func (s *Service) CommanderDetach(server pb.DHCTL_CommanderDetachServer) error {
 	f := fsm.New("initial", s.commanderDetachServerTransitions())
 
 	doneCh := make(chan struct{})
-	internalErrCh := make(chan error)
+	internalErrCh := make(chan error, internalErrChBufferSize)
 	receiveCh := make(chan *pb.CommanderDetachRequest)
 	sendCh := make(chan *pb.CommanderDetachResponse)
 	pt := progressTracker[*pb.CommanderDetachResponse]{
@@ -116,10 +116,10 @@ connectionProcessor:
 				go func() {
 					result := s.commanderDetachSafe(ctx, &detachParams{
 						request:      message.Start,
-						sendProgress: pt.sendProgress(),
+						sendProgress: pt.sendProgress(ctx),
 						sendCh:       sendCh,
 					})
-					sendCh <- &pb.CommanderDetachResponse{Message: &pb.CommanderDetachResponse_Result{Result: result}}
+					_ = sendResponse(server.Context(), sendCh, &pb.CommanderDetachResponse{Message: &pb.CommanderDetachResponse_Result{Result: result}})
 				}()
 
 			case *pb.CommanderDetachRequest_Cancel:

--- a/dhctl/pkg/server/rpc/dhctl/converge.go
+++ b/dhctl/pkg/server/rpc/dhctl/converge.go
@@ -79,7 +79,7 @@ func (s *Service) Converge(server pb.DHCTL_ConvergeServer) error {
 	f := fsm.New("initial", s.convergeServerTransitions())
 
 	doneCh := make(chan struct{})
-	internalErrCh := make(chan error)
+	internalErrCh := make(chan error, internalErrChBufferSize)
 	receiveCh := make(chan *pb.ConvergeRequest)
 	sendCh := make(chan *pb.ConvergeResponse)
 	phaseSwitcher := &fsmPhaseSwitcher[*pb.ConvergeResponse, any]{
@@ -123,10 +123,10 @@ connectionProcessor:
 					result := s.convergeSafe(ctx, &convergeParams{
 						request:      message.Start,
 						switchPhase:  phaseSwitcher.switchPhase(ctx),
-						sendProgress: pt.sendProgress(),
+						sendProgress: pt.sendProgress(ctx),
 						sendCh:       sendCh,
 					})
-					sendCh <- &pb.ConvergeResponse{Message: &pb.ConvergeResponse_Result{Result: result}}
+					_ = sendResponse(server.Context(), sendCh, &pb.ConvergeResponse{Message: &pb.ConvergeResponse_Result{Result: result}})
 				}()
 
 			case *pb.ConvergeRequest_Continue:
@@ -138,13 +138,13 @@ connectionProcessor:
 				}
 				switch message.Continue.Continue {
 				case pb.Continue_CONTINUE_UNSPECIFIED:
-					phaseSwitcher.next <- errors.New("bad continue message")
+					sendPhaseSwitch(ctx, phaseSwitcher.next, errors.New("bad continue message"))
 				case pb.Continue_CONTINUE_NEXT_PHASE:
-					phaseSwitcher.next <- nil
+					sendPhaseSwitch(ctx, phaseSwitcher.next, nil)
 				case pb.Continue_CONTINUE_STOP_OPERATION:
-					phaseSwitcher.next <- phases.ErrStopOperationCondition
+					sendPhaseSwitch(ctx, phaseSwitcher.next, phases.ErrStopOperationCondition)
 				case pb.Continue_CONTINUE_ERROR:
-					phaseSwitcher.next <- errors.New(message.Continue.Err)
+					sendPhaseSwitch(ctx, phaseSwitcher.next, errors.New(message.Continue.Err))
 				}
 
 			case *pb.ConvergeRequest_Cancel:

--- a/dhctl/pkg/server/rpc/dhctl/destroy.go
+++ b/dhctl/pkg/server/rpc/dhctl/destroy.go
@@ -76,7 +76,7 @@ func (s *Service) Destroy(server pb.DHCTL_DestroyServer) error {
 	f := fsm.New("initial", s.destroyServerTransitions())
 
 	doneCh := make(chan struct{})
-	internalErrCh := make(chan error)
+	internalErrCh := make(chan error, internalErrChBufferSize)
 	receiveCh := make(chan *pb.DestroyRequest)
 	sendCh := make(chan *pb.DestroyResponse)
 	phaseSwitcher := &fsmPhaseSwitcher[*pb.DestroyResponse, any]{
@@ -120,10 +120,10 @@ connectionProcessor:
 					result := s.destroySafe(ctx, &destroyParams{
 						request:      message.Start,
 						switchPhase:  phaseSwitcher.switchPhase(ctx),
-						sendProgress: pt.sendProgress(),
+						sendProgress: pt.sendProgress(ctx),
 						sendCh:       sendCh,
 					})
-					sendCh <- &pb.DestroyResponse{Message: &pb.DestroyResponse_Result{Result: result}}
+					_ = sendResponse(server.Context(), sendCh, &pb.DestroyResponse{Message: &pb.DestroyResponse_Result{Result: result}})
 				}()
 
 			case *pb.DestroyRequest_Continue:
@@ -135,13 +135,13 @@ connectionProcessor:
 				}
 				switch message.Continue.Continue {
 				case pb.Continue_CONTINUE_UNSPECIFIED:
-					phaseSwitcher.next <- errors.New("bad continue message")
+					sendPhaseSwitch(ctx, phaseSwitcher.next, errors.New("bad continue message"))
 				case pb.Continue_CONTINUE_NEXT_PHASE:
-					phaseSwitcher.next <- nil
+					sendPhaseSwitch(ctx, phaseSwitcher.next, nil)
 				case pb.Continue_CONTINUE_STOP_OPERATION:
-					phaseSwitcher.next <- phases.ErrStopOperationCondition
+					sendPhaseSwitch(ctx, phaseSwitcher.next, phases.ErrStopOperationCondition)
 				case pb.Continue_CONTINUE_ERROR:
-					phaseSwitcher.next <- errors.New(message.Continue.Err)
+					sendPhaseSwitch(ctx, phaseSwitcher.next, errors.New(message.Continue.Err))
 				}
 
 			case *pb.DestroyRequest_Cancel:

--- a/dhctl/pkg/server/rpc/dhctl/logger.go
+++ b/dhctl/pkg/server/rpc/dhctl/logger.go
@@ -47,7 +47,7 @@ func initLoggerOptions[T any](ctx context.Context, params *initLoggerOptionsPara
 
 	loggerDefault := logger.L(ctx).With(logTypeDHCTL)
 
-	logWriter := logger.NewLogWriter(loggerDefault, params.sendCh, params.consumer)
+	logWriter := logger.NewLogWriter(ctx, loggerDefault, params.sendCh, params.consumer)
 
 	debugWriter := logger.NewDebugLogWriter(loggerDefault)
 

--- a/dhctl/pkg/server/rpc/dhctl/service.go
+++ b/dhctl/pkg/server/rpc/dhctl/service.go
@@ -105,13 +105,22 @@ type serverStream[Request proto.Message, Response proto.Message] interface {
 	grpc.ServerStream
 }
 
+// internalErrChBufferSize is enough for the two goroutines that can report a
+// stream failure concurrently: receiver and sender. Keeping the buffer bounded
+// avoids blocking those goroutines after the main handler has already returned.
+const internalErrChBufferSize = 2
+
 func startReceiver[Request, Response proto.Message](
 	server serverStream[Request, Response],
 	receiveCh chan Request,
 	doneCh chan struct{},
 	internalErrCh chan error,
-) {
+) <-chan struct{} {
+	stoppedCh := make(chan struct{})
+
 	go func() {
+		defer close(stoppedCh)
+
 		for {
 			request, err := server.Recv()
 			if errors.Is(err, io.EOF) {
@@ -119,31 +128,77 @@ func startReceiver[Request, Response proto.Message](
 				return
 			}
 			if err != nil {
-				internalErrCh <- fmt.Errorf("receiving message: %w", err)
+				sendInternalErr(internalErrCh, fmt.Errorf("receiving message: %w", err))
 				return
 			}
-			receiveCh <- request
+			select {
+			case receiveCh <- request:
+			case <-server.Context().Done():
+				return
+			}
 		}
 	}()
+
+	return stoppedCh
 }
 
 func startSender[Request, Response proto.Message](
 	server serverStream[Request, Response],
 	sendCh chan Response,
 	internalErrCh chan error,
-) {
+) <-chan struct{} {
+	stoppedCh := make(chan struct{})
+
 	go func() {
-		for response := range sendCh {
+		defer close(stoppedCh)
+
+		for {
+			var response Response
+			select {
+			case received, ok := <-sendCh:
+				if !ok {
+					return
+				}
+				response = received
+			case <-server.Context().Done():
+				return
+			}
+
 			loop := retry.NewSilentLoop("send message", 10, time.Millisecond*100)
 			err := loop.Run(func() error {
 				return server.Send(response)
 			})
 			if err != nil {
-				internalErrCh <- fmt.Errorf("sending message: %w", err)
+				sendInternalErr(internalErrCh, fmt.Errorf("sending message: %w", err))
 				return
 			}
 		}
 	}()
+
+	return stoppedCh
+}
+
+func sendInternalErr(internalErrCh chan<- error, err error) {
+	select {
+	case internalErrCh <- err:
+	default:
+	}
+}
+
+func sendResponse[T proto.Message](ctx context.Context, sendCh chan<- T, response T) error {
+	select {
+	case sendCh <- response:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func sendPhaseSwitch(ctx context.Context, next chan<- error, err error) {
+	select {
+	case next <- err:
+	case <-ctx.Done():
+	}
 }
 
 type fsmPhaseSwitcher[T proto.Message, OperationPhaseDataT any] struct {
@@ -167,7 +222,10 @@ func (b *fsmPhaseSwitcher[T, OperationPhaseDataT]) switchPhase(ctx context.Conte
 			return fmt.Errorf("switch phase data func error: %w", err)
 		}
 
-		b.sendCh <- data
+		err = sendResponse(ctx, b.sendCh, data)
+		if err != nil {
+			return fmt.Errorf("sending phase switch data: %w: %w", phases.ErrStopOperationCondition, err)
+		}
 
 		var (
 			switchErr error
@@ -243,11 +301,9 @@ type progressTracker[T proto.Message] struct {
 	dataFunc func(progress phases.Progress) T
 }
 
-func (p *progressTracker[T]) sendProgress() phases.OnProgressFunc {
+func (p *progressTracker[T]) sendProgress(ctx context.Context) phases.OnProgressFunc {
 	return func(progress phases.Progress) error {
-		p.sendCh <- p.dataFunc(progress)
-
-		return nil
+		return sendResponse(ctx, p.sendCh, p.dataFunc(progress))
 	}
 }
 

--- a/dhctl/pkg/server/rpc/dhctl/service_internal_test.go
+++ b/dhctl/pkg/server/rpc/dhctl/service_internal_test.go
@@ -1,0 +1,261 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dhctl
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
+
+	pb "github.com/deckhouse/deckhouse/dhctl/pkg/server/pb/dhctl"
+)
+
+const testNoEventTimeout = 50 * time.Millisecond
+
+func TestSendResponseReturnsContextCanceledWithoutReceiver(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	err := sendResponse(ctx, make(chan *pb.CheckResponse), &pb.CheckResponse{})
+
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestTerminalResponseCanUseStreamContextAfterOperationCancel(t *testing.T) {
+	t.Parallel()
+
+	opCtx, cancelOperation := context.WithCancel(t.Context())
+	cancelOperation()
+
+	streamCtx := t.Context()
+	sendCh := make(chan *pb.CheckResponse)
+	response := &pb.CheckResponse{}
+	received := make(chan *pb.CheckResponse, 1)
+
+	go func() {
+		received <- <-sendCh
+	}()
+
+	err := sendResponse(streamCtx, sendCh, response)
+
+	require.NoError(t, err)
+	require.ErrorIs(t, opCtx.Err(), context.Canceled)
+	require.Same(t, response, <-received)
+}
+
+func TestSendPhaseSwitchReturnsWhenContextCanceled(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		sendPhaseSwitch(ctx, make(chan error), errors.New("phase error"))
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("sendPhaseSwitch blocked after context cancellation")
+	}
+}
+
+func TestStartSenderStopsWhenSendChannelClosed(t *testing.T) {
+	t.Parallel()
+
+	sendCh := make(chan *pb.CheckResponse)
+	internalErrCh := make(chan error, internalErrChBufferSize)
+	sentCh := make(chan *pb.CheckResponse, 1)
+
+	stream := &testServerStream[*pb.CheckRequest, *pb.CheckResponse]{
+		ctx: t.Context(),
+		sendFn: func(response *pb.CheckResponse) error {
+			sentCh <- response
+
+			return nil
+		},
+	}
+
+	stoppedCh := startSender[*pb.CheckRequest, *pb.CheckResponse](stream, sendCh, internalErrCh)
+	close(sendCh)
+
+	select {
+	case <-stoppedCh:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for startSender to stop after sendCh close")
+	}
+
+	select {
+	case response := <-sentCh:
+		t.Fatalf("unexpected response sent after sendCh close: %#v", response)
+	case err := <-internalErrCh:
+		t.Fatalf("unexpected internal error after sendCh close: %v", err)
+	default:
+	}
+}
+
+func TestStartSenderReportsSendError(t *testing.T) {
+	t.Parallel()
+
+	expectedErr := errors.New("send failed")
+	sendCh := make(chan *pb.CheckResponse)
+	internalErrCh := make(chan error, internalErrChBufferSize)
+
+	stream := &testServerStream[*pb.CheckRequest, *pb.CheckResponse]{
+		ctx: t.Context(),
+		sendFn: func(*pb.CheckResponse) error {
+			return expectedErr
+		},
+	}
+
+	startSender[*pb.CheckRequest, *pb.CheckResponse](stream, sendCh, internalErrCh)
+	sendCh <- &pb.CheckResponse{}
+
+	select {
+	case err := <-internalErrCh:
+		require.ErrorContains(t, err, expectedErr.Error())
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for startSender error")
+	}
+}
+
+func TestStartReceiverClosesDoneChannelOnEOF(t *testing.T) {
+	t.Parallel()
+
+	doneCh := make(chan struct{})
+	internalErrCh := make(chan error, internalErrChBufferSize)
+	receiveCh := make(chan *pb.CheckRequest)
+
+	stream := &testServerStream[*pb.CheckRequest, *pb.CheckResponse]{
+		ctx: t.Context(),
+		recvFn: func() (*pb.CheckRequest, error) {
+			return nil, io.EOF
+		},
+	}
+
+	startReceiver[*pb.CheckRequest, *pb.CheckResponse](stream, receiveCh, doneCh, internalErrCh)
+
+	select {
+	case <-doneCh:
+	case err := <-internalErrCh:
+		t.Fatalf("unexpected internal error: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for doneCh close")
+	}
+}
+
+func TestStartReceiverReturnsWhenContextCanceledWhileDeliveringRequest(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	recvReturned := make(chan struct{})
+	doneCh := make(chan struct{})
+	internalErrCh := make(chan error, internalErrChBufferSize)
+	receiveCh := make(chan *pb.CheckRequest)
+	request := &pb.CheckRequest{}
+
+	stream := &testServerStream[*pb.CheckRequest, *pb.CheckResponse]{
+		ctx: ctx,
+		recvFn: func() (*pb.CheckRequest, error) {
+			close(recvReturned)
+
+			return request, nil
+		},
+	}
+
+	stoppedCh := startReceiver[*pb.CheckRequest, *pb.CheckResponse](stream, receiveCh, doneCh, internalErrCh)
+
+	select {
+	case <-recvReturned:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for Recv")
+	}
+
+	cancel()
+
+	select {
+	case <-stoppedCh:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for startReceiver to stop after context cancellation")
+	}
+
+	select {
+	case received := <-receiveCh:
+		t.Fatalf("unexpected request delivered after context cancellation: %#v", received)
+	case err := <-internalErrCh:
+		t.Fatalf("unexpected internal error after context cancellation: %v", err)
+	default:
+	}
+}
+
+type testServerStream[Request proto.Message, Response proto.Message] struct {
+	ctx    context.Context
+	sendFn func(Response) error
+	recvFn func() (Request, error)
+}
+
+func (s *testServerStream[Request, Response]) Send(response Response) error {
+	if s.sendFn == nil {
+		return nil
+	}
+
+	return s.sendFn(response)
+}
+
+func (s *testServerStream[Request, Response]) Recv() (Request, error) {
+	if s.recvFn == nil {
+		var zero Request
+
+		return zero, io.EOF
+	}
+
+	return s.recvFn()
+}
+
+func (s *testServerStream[Request, Response]) SetHeader(metadata.MD) error {
+	return nil
+}
+
+func (s *testServerStream[Request, Response]) SendHeader(metadata.MD) error {
+	return nil
+}
+
+func (s *testServerStream[Request, Response]) SetTrailer(metadata.MD) {}
+
+func (s *testServerStream[Request, Response]) Context() context.Context {
+	if s.ctx == nil {
+		return context.Background()
+	}
+
+	return s.ctx
+}
+
+func (s *testServerStream[Request, Response]) SendMsg(any) error {
+	return nil
+}
+
+func (s *testServerStream[Request, Response]) RecvMsg(any) error {
+	return io.EOF
+}


### PR DESCRIPTION
## Description

Fix a potential shutdown deadlock in the `dhctl` gRPC server after a client stream is interrupted.

The issue could happen when the cluster-manager connection to `dhctl` was broken while a long-running operation was still producing logs, progress updates, or phase responses. The RPC handler and stream sender/receiver could stop first, while operation goroutines continued writing to unbuffered response channels. This could block the child `_server` process during cleanup; later, when the main `dhctl` pod was terminated, the parent server could keep waiting for that child process and remain stuck in shutdown.

The change makes stream response delivery cancellation-aware, prevents internal error reporting from blocking, preserves terminal operation results during graceful soft cancellation, and adds regression tests for the low-level stream concurrency behavior.

This prevents `dhctl` pods from getting stuck in `Running` but not `Ready` after interrupted tasks and subsequent pod termination.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Fixed a gRPC stream cancel deadlock in dhctl for Commander.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
