### PR TITLE
[istio] Use app: waypoint label for waypoints

### DIFF
--- a/ee/modules/110-istio/images/waypoint-controller/src/internal/waypointcontroller/controller_integration_test.go
+++ b/ee/modules/110-istio/images/waypoint-controller/src/internal/waypointcontroller/controller_integration_test.go
@@ -313,7 +313,7 @@ func TestWaypointInstanceLifecycle(t *testing.T) {
 	}
 
 	// Use apiReader (uncached) to read child resources. The manager's cache
-	// is label-filtered to app=d8-waypoint and would also work, but
+	// is label-filtered to app=waypoint and would also work, but
 	// bypassing it removes a potential cache-staleness flake source.
 	reader := te.mgr.GetAPIReader()
 

--- a/ee/modules/110-istio/images/waypoint-controller/src/internal/waypointcontroller/labels.go
+++ b/ee/modules/110-istio/images/waypoint-controller/src/internal/waypointcontroller/labels.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	AppLabelKey               = "app"
-	AppLabelValue             = "d8-waypoint"
+	AppLabelValue             = "waypoint"
 	WaypointInstanceLabelKey  = "istio.deckhouse.io/waypoint-instance"
 	WaypointComponentLabelKey = "istio.deckhouse.io/component"
 	HeritageLabelKey          = "heritage"


### PR DESCRIPTION
## Description

Change the `app` label value for waypoint resources from `d8-waypoint` to `waypoint` in the waypoint-controller. This better aligns with both Deckhouse and upstream Istio conventions.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: chore
summary: Use `app=waypoint` label instead of `app=d8-waypoint` for waypoint controller resources.
impact_level: low
```
