### PR TITLE
[control-plane-manager] Run make generate from etcd-defrag changes

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -1324,6 +1324,31 @@ alerts:
         HuaweiCloudMachine {{ $labels.name }} is stuck in Deleting for more than 24h.
       severity: "6"
       markupFormat: markdown
+    - name: D8InvalidEtcdDefragCronSchedule
+      sourceFile: modules/040-control-plane-manager/monitoring/prometheus-rules/etcd-maintenance.yaml
+      moduleUrl: 040-control-plane-manager
+      module: control-plane-manager
+      edition: ce
+      description: |-
+        The `controlPlaneManager.etcd.defrag.cronSchedule` value `{{ $labels.cron_schedule }}` is not a valid cron expression.
+
+        Deckhouse has fallen back to the default schedule (`0 1 * * *`) to keep defragmentation running.
+
+        **To fix this, set a valid 5-field cron expression:**
+
+        ```bash
+        d8 k patch moduleconfig control-plane-manager --type merge \
+          -p '{"spec":{"settings":{"etcd":{"defrag":{"cronSchedule":"0 1 * * *"}}}}}'
+        ```
+
+        Valid examples:
+        - `0 1 * * *` — daily at 01:00 UTC
+        - `0 */6 * * *` — every 6 hours
+        - `30 2 * * 0` — weekly on Sunday at 02:30 UTC
+      summary: |
+        Invalid etcd defragmentation cron schedule in ModuleConfig.
+      severity: "6"
+      markupFormat: markdown
     - name: D8IstioActiveWaypointsWithAmbientDisabled
       sourceFile: ee/modules/110-istio/monitoring/prometheus-rules/ambient.tpl
       moduleUrl: 110-istio
@@ -1352,31 +1377,6 @@ alerts:
         If ambient mesh cannot be re-enabled, manually remove the managed waypoint resources and then remove the WaypointInstance finalizer only after verifying that no managed resources remain.
       summary: |
         Active Istio waypoint exists while ambient mesh is disabled.
-      severity: "6"
-      markupFormat: markdown
-    - name: D8InvalidEtcdDefragCronSchedule
-      sourceFile: modules/040-control-plane-manager/monitoring/prometheus-rules/etcd-maintenance.yaml
-      moduleUrl: 040-control-plane-manager
-      module: control-plane-manager
-      edition: ce
-      description: |-
-        The `controlPlaneManager.etcd.defrag.cronSchedule` value `{{ $labels.cron_schedule }}` is not a valid cron expression.
-
-        Deckhouse has fallen back to the default schedule (`0 1 * * *`) to keep defragmentation running.
-
-        **To fix this, set a valid 5-field cron expression:**
-
-        ```bash
-        d8 k patch moduleconfig control-plane-manager --type merge \
-          -p '{"spec":{"settings":{"etcd":{"defrag":{"cronSchedule":"0 1 * * *"}}}}}'
-        ```
-
-        Valid examples:
-        - `0 1 * * *` — daily at 01:00 UTC
-        - `0 */6 * * *` — every 6 hours
-        - `30 2 * * 0` — weekly on Sunday at 02:30 UTC
-      summary: |
-        Invalid etcd defragmentation cron schedule in ModuleConfig.
       severity: "6"
       markupFormat: markdown
     - name: D8IstioActualDataPlaneVersionNotEqualDesired


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
 Run make generate from etcd-defrag changes.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: chore
summary:  Run make generate from etcd-defrag changes
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
