### PR TITLE
[candi] update base-image to v1.1.13

### DIFF
--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -3022,7 +3022,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:e3ce5d01ca717933f9f9e232bb39e0699fae86b4ef0da4520ee251cc4be956b8"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:a3f1fac5643b72b112e7bb6698e2d63bb15a729bf4f7550a014001b54dd944d1"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'
@@ -3137,7 +3137,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run node-controller tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:e3ce5d01ca717933f9f9e232bb39e0699fae86b4ef0da4520ee251cc4be956b8"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:a3f1fac5643b72b112e7bb6698e2d63bb15a729bf4f7550a014001b54dd944d1"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/.github/workflows/build-and-test_main.yml
+++ b/.github/workflows/build-and-test_main.yml
@@ -1005,7 +1005,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:e3ce5d01ca717933f9f9e232bb39e0699fae86b4ef0da4520ee251cc4be956b8"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:a3f1fac5643b72b112e7bb6698e2d63bb15a729bf4f7550a014001b54dd944d1"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -2695,7 +2695,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:e3ce5d01ca717933f9f9e232bb39e0699fae86b4ef0da4520ee251cc4be956b8"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:a3f1fac5643b72b112e7bb6698e2d63bb15a729bf4f7550a014001b54dd944d1"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/candi/alt_base_images.yml
+++ b/candi/alt_base_images.yml
@@ -1,8 +1,8 @@
-# version=v1.1.8
+# version=v1.1.13
 REGISTRY_PATH: registry.deckhouse.io/container-factory
-builder/distroless: "sha256:41d274923c274a9f7167d5492dbfce9625c100adf4a75d7138be66e0dfcebe43" # from: builder/scratch
-builder/golang-1.25: "sha256:0880f74c5c1694f6f5ca0ee8138b7294f8334eb956fa067737a9a0217f881369" # from: builder/distroless
-builder/golang-1.26: "sha256:e3ce5d01ca717933f9f9e232bb39e0699fae86b4ef0da4520ee251cc4be956b8" # from: builder/distroless
-builder/golang: "sha256:e3ce5d01ca717933f9f9e232bb39e0699fae86b4ef0da4520ee251cc4be956b8" # from: builder/distroless
+builder/distroless: "sha256:07957eb53c30330dd5372358ba236b1ef93a4c237d0b6aeffd7acd1aeea0f437" # from: builder/scratch
+builder/golang-1.25: "sha256:1aec23d71036ade2c4cfef45e240e0980b7d9bf7e2b94ead2e190749a4e53034" # from: builder/distroless
+builder/golang-1.26: "sha256:a3f1fac5643b72b112e7bb6698e2d63bb15a729bf4f7550a014001b54dd944d1" # from: builder/distroless
+builder/golang: "sha256:a3f1fac5643b72b112e7bb6698e2d63bb15a729bf4f7550a014001b54dd944d1" # from: builder/distroless
 minget-0.1: "sha256:463d8b34130357f8637eeda9ade6bb7561fa53f28bc7b5d11f29f629c60fb254" # from: builder/scratch
 minget: "sha256:463d8b34130357f8637eeda9ade6bb7561fa53f28bc7b5d11f29f629c60fb254" # from: builder/scratch


### PR DESCRIPTION
## Description
update base-images to v1.1.13
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
update tls priority in golang
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: chore
summary: update base-images to v1.1.13
impact: 
impact_level:  low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
