### PR TITLE
[cloud-provider-dvp] Separate zone defaults from migration path

### DIFF
--- a/modules/030-cloud-provider-dvp/hooks/create_migration_resources.go
+++ b/modules/030-cloud-provider-dvp/hooks/create_migration_resources.go
@@ -93,8 +93,11 @@ func handleDVPMigrationResources(_ context.Context, input *go_hook.HookInput) er
 	if err := json.Unmarshal([]byte(input.Values.Get("cloudProviderDvp").String()), &moduleConfiguration); err != nil {
 		return fmt.Errorf("parse module configuration: %w", err)
 	}
-	if err := overrideValues(&pcc, &moduleConfiguration); err != nil {
-		return fmt.Errorf("override values: %w", err)
+
+	overrideProviderClusterConfigValues(&pcc, &moduleConfiguration)
+
+	if err := validateProviderClusterConfig(pcc); err != nil {
+		return fmt.Errorf("validate provider cluster config: %w", err)
 	}
 
 	if err := createProviderClusterConfigurationResources(input, &pcc); err != nil {

--- a/modules/030-cloud-provider-dvp/hooks/create_migration_resources_test.go
+++ b/modules/030-cloud-provider-dvp/hooks/create_migration_resources_test.go
@@ -194,6 +194,110 @@ data:
 			classReference, ok := cloudInstances["classReference"].(map[string]any)
 			Expect(ok).To(BeTrue(), "NodeGroup spec.cloudInstances.classReference must be a map")
 			Expect(classReference["name"]).To(Equal(expectedInstanceClassName))
+
+			// Zones from the source PCC ("default") must be preserved through the
+			// migration pipeline — see State B (no zones) for the empty case.
+			Expect(cloudInstances["zones"]).To(Equal([]any{"default"}),
+				"zones from the source PCC must be preserved in the migrated NodeGroup")
+		})
+	})
+
+	clusterConfigNoZones := `
+apiVersion: deckhouse.io/v1
+kind: DVPClusterConfiguration
+layout: Standard
+masterNodeGroup:
+  instanceClass:
+    etcdDisk:
+      size: 15Gi
+      storageClass: ceph-pool-r2-csi-rbd-immediate
+    rootDisk:
+      image:
+        kind: ClusterVirtualImage
+        name: ubuntu-2204
+      size: 50Gi
+      storageClass: ceph-pool-r2-csi-rbd-immediate
+    virtualMachine:
+      virtualMachineClassName: superbe-class
+      bootloader: EFI
+      cpu:
+        coreFraction: 100%
+        cores: 4
+      memory:
+        size: 8Gi
+  replicas: 1
+provider:
+  kubeconfigDataBase64: YXBpVmV=
+  namespace: cloud-provider01
+sshPublicKey: ssh-rsa AAAAB3N
+region: ru-msk-1
+`
+
+	pccSecretNoZones := fmt.Sprintf(`
+apiVersion: v1
+kind: Secret
+metadata:
+  name: d8-provider-cluster-configuration
+  namespace: kube-system
+data:
+  "cloud-provider-cluster-configuration.yaml": %s
+`, base64.StdEncoding.EncodeToString([]byte(clusterConfigNoZones)))
+
+	// ---- State B (no zones): PCC without zones — fallback must NOT add "default" ----
+	Context("State B (no zones): PCC without zones — NodeGroup must have empty zones", func() {
+		f := HookExecutionConfigInit(migrationValues, `{}`)
+		f.RegisterCRD("deckhouse.io", "v1alpha1", "ModuleConfig", false)
+		f.RegisterCRD("deckhouse.io", "v1alpha1", "DVPInstanceClass", false)
+		f.RegisterCRD("deckhouse.io", "v1", "NodeGroup", false)
+
+		BeforeEach(func() {
+			f.KubeStateSet(pccSecretNoZones)
+			f.BindingContexts.Set(f.GenerateAfterHelmContext())
+			f.RunHook()
+		})
+
+		It("should not add default zone to NodeGroup when PCC has no zones", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			migrationSecret := f.KubernetesResource("Secret", "d8-cloud-provider-dvp", "d8-migration-resources")
+			Expect(migrationSecret.Exists()).To(BeTrue())
+
+			resourcesYAML := migrationSecret.Field("data.resources\\.yaml").String()
+			Expect(resourcesYAML).NotTo(BeEmpty())
+
+			rawBytes, err := base64.StdEncoding.DecodeString(resourcesYAML)
+			Expect(err).NotTo(HaveOccurred())
+
+			var nodeGroupDoc map[string]any
+			for _, doc := range splitYAMLDocuments(string(rawBytes)) {
+				var obj map[string]any
+				if err := yaml.Unmarshal([]byte(doc), &obj); err != nil {
+					continue
+				}
+				if obj["kind"] == "NodeGroup" {
+					nodeGroupDoc = obj
+					break
+				}
+			}
+			Expect(nodeGroupDoc).NotTo(BeNil(), "NodeGroup document must be present in resources.yaml")
+
+			spec, ok := nodeGroupDoc["spec"].(map[string]any)
+			Expect(ok).To(BeTrue(), "NodeGroup spec must be a map")
+			cloudInstances, ok := spec["cloudInstances"].(map[string]any)
+			Expect(ok).To(BeTrue(), "NodeGroup spec.cloudInstances must be a map")
+
+			// zones must NOT contain the synthetic "default" when the source PCC had
+			// no zones. The migration path returns nil so the rendered NodeGroup has
+			// zones: null (or the key is absent), letting node-manager apply its own
+			// fallback rather than forcing "default".
+			switch zones := cloudInstances["zones"].(type) {
+			case []any:
+				Expect(zones).To(BeEmpty(), "zones must be empty when PCC has no zones, not [default]")
+			case nil:
+				// zones: null or absent — acceptable, no synthetic default injected.
+			default:
+				Fail(fmt.Sprintf("unexpected zones type %T: %#v", zones, zones))
+			}
 		})
 	})
 

--- a/modules/030-cloud-provider-dvp/hooks/dvp_cluster_configuration.go
+++ b/modules/030-cloud-provider-dvp/hooks/dvp_cluster_configuration.go
@@ -277,8 +277,20 @@ func handleDVPClusterConfiguration(_ context.Context, input *go_hook.HookInput) 
 	if err := json.Unmarshal([]byte(input.Values.Get("cloudProviderDvp").String()), &moduleConfiguration); err != nil {
 		return fmt.Errorf("parse module configuration: %w", err)
 	}
-	if err := overrideValues(&pcc, &moduleConfiguration); err != nil {
-		return fmt.Errorf("override values: %w", err)
+
+	overrideProviderClusterConfigValues(&pcc, &moduleConfiguration)
+
+	// setDefaultZones preserves the "default" zone fallback for the live
+	// cluster-configuration hook. node-manager's get_crds.go
+	// (modules/040-node-manager/hooks/get_crds.go) substitutes defaultZones for
+	// NodeGroups whose zones are nil; keeping a non-empty zone here preserves the
+	// historical behavior for clusters that relied on the synthetic "default"
+	// zone. The migration path (create_migration_resources.go) intentionally does
+	// NOT call this, so migrated NodeGroups faithfully reflect the source PCC.
+	setDefaultZones(&pcc)
+
+	if err := validateProviderClusterConfig(pcc); err != nil {
+		return fmt.Errorf("validate provider cluster config: %w", err)
 	}
 
 	return mergeAndSetDiscoveryData(input, discoveryData)
@@ -470,7 +482,7 @@ func convertJSONRawMessageToStruct(in map[string]json.RawMessage, out any) error
 	return json.Unmarshal(b, out)
 }
 
-func overrideValues(p *v1.DvpProviderClusterConfiguration, m *v1.DvpModuleConfiguration) error {
+func overrideProviderClusterConfigValues(p *v1.DvpProviderClusterConfiguration, m *v1.DvpModuleConfiguration) {
 	if m.Provider != nil {
 		if p.Provider == nil {
 			p.Provider = &v1.DvpProvider{}
@@ -486,7 +498,9 @@ func overrideValues(p *v1.DvpProviderClusterConfiguration, m *v1.DvpModuleConfig
 	if m.Zones != nil {
 		p.Zones = m.Zones
 	}
+}
 
+func validateProviderClusterConfig(p v1.DvpProviderClusterConfiguration) error {
 	if p.Provider == nil {
 		return errors.New("provider section is required")
 	}
@@ -497,21 +511,27 @@ func overrideValues(p *v1.DvpProviderClusterConfiguration, m *v1.DvpModuleConfig
 		return errors.New("provider.namespace cannot be empty")
 	}
 
-	cloudManaged := p.APIVersion != nil || p.Kind != nil
-	if cloudManaged {
+	hasObjectMeta := p.APIVersion != nil || p.Kind != nil
+	if hasObjectMeta {
 		if p.APIVersion == nil || len(*p.APIVersion) == 0 {
 			return errors.New("apiVersion cannot be empty")
 		}
 		if p.Kind == nil || len(*p.Kind) == 0 {
 			return errors.New("kind cannot be empty")
 		}
+	}
+
+	return nil
+}
+
+func setDefaultZones(p *v1.DvpProviderClusterConfiguration) {
+	hasObjectMeta := p.APIVersion != nil || p.Kind != nil
+	if hasObjectMeta {
 		if p.Zones == nil || len(*p.Zones) == 0 {
 			def := []string{"default"}
 			p.Zones = &def
 		}
 	}
-
-	return nil
 }
 
 func mergeDiscoveryData(newValue cloudDataV1.DVPCloudProviderDiscoveryData, currentValue cloudDataV1.DVPCloudProviderDiscoveryData) cloudDataV1.DVPCloudProviderDiscoveryData {

--- a/modules/030-cloud-provider-dvp/hooks/dvp_cluster_configuration_test.go
+++ b/modules/030-cloud-provider-dvp/hooks/dvp_cluster_configuration_test.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	v1 "github.com/deckhouse/deckhouse/modules/030-cloud-provider-dvp/hooks/internal/v1"
 	. "github.com/deckhouse/deckhouse/testing/hooks"
 )
 
@@ -202,6 +203,39 @@ metadata:
 			// Resources should NOT be created directly by the hook.
 			moduleConfig := b.KubernetesGlobalResource("ModuleConfig", "cloud-provider-dvp")
 			Expect(moduleConfig.Exists()).To(BeFalse())
+		})
+	})
+
+	// ---- setDefaultZones: direct unit test for the live-hook default-zone fallback ----
+	Context("setDefaultZones default-zone fallback", func() {
+		strPtr := func(s string) *string { return &s }
+		zonesPtr := func(z []string) *[]string { return &z }
+
+		It("injects [default] when PCC has object metadata and no zones", func() {
+			p := v1.DvpProviderClusterConfiguration{
+				APIVersion: strPtr("deckhouse.io/v1"),
+				Kind:       strPtr("DVPClusterConfiguration"),
+			}
+			setDefaultZones(&p)
+			Expect(p.Zones).NotTo(BeNil(), "zones must be set to the synthetic default")
+			Expect(*p.Zones).To(Equal([]string{"default"}))
+		})
+
+		It("preserves existing zones when PCC already has zones", func() {
+			p := v1.DvpProviderClusterConfiguration{
+				APIVersion: strPtr("deckhouse.io/v1"),
+				Kind:       strPtr("DVPClusterConfiguration"),
+				Zones:      zonesPtr([]string{"ru-msk-1", "ru-msk-2"}),
+			}
+			setDefaultZones(&p)
+			Expect(*p.Zones).To(Equal([]string{"ru-msk-1", "ru-msk-2"}),
+				"existing zones must not be overwritten")
+		})
+
+		It("does not inject default when PCC has no object metadata", func() {
+			p := v1.DvpProviderClusterConfiguration{}
+			setDefaultZones(&p)
+			Expect(p.Zones).To(BeNil(), "default zone must only apply to cluster-stored objects")
 		})
 	})
 

--- a/modules/030-cloud-provider-dvp/hooks/migration.go
+++ b/modules/030-cloud-provider-dvp/hooks/migration.go
@@ -282,15 +282,18 @@ func createNodeGroupResources(name string, nodeGroup map[string]any, master bool
 		return nil, fmt.Errorf("%s.replicas: %w", name, err)
 	}
 
-	zones := zonesFromNodeGroup(nodeGroup, clusterZones)
 	cloudInstances := map[string]any{
-		"zones":      zones,
 		"minPerZone": int64(replicas),
 		"maxPerZone": int64(replicas),
 		"classReference": map[string]any{
 			"kind": dvpInstanceClassKind,
 			"name": instanceClassName,
 		},
+	}
+
+	zones := zonesFromNodeGroup(nodeGroup, clusterZones)
+	if zones != nil {
+		cloudInstances["zones"] = zones
 	}
 
 	nodeGroupSpec := map[string]any{
@@ -369,7 +372,12 @@ func zonesFromNodeGroup(nodeGroup map[string]any, clusterZones *[]string) []any 
 		return stringsToAnySlice(*clusterZones)
 	}
 
-	return []any{"default"}
+	// Return nil (not an empty slice) so the rendered NodeGroup has zones: null.
+	// node-manager's get_crds.go distinguishes nil from []string{}: a nil Zones
+	// field engages its defaultZones fallback, while a non-nil empty slice does
+	// not. Returning nil keeps the migrated NodeGroup faithful to a source PCC
+	// that had no zones, and lets node-manager apply its own fallback.
+	return nil
 }
 
 func stringsToAnySlice(values []string) []any {


### PR DESCRIPTION
## Description

+ Splits `overrideValues` into `overrideProviderClusterConfigValues`/`validateProviderClusterConfig`/`setDefaultZones`. 
+ Migration path (`zonesFromNodeGroup`) now returns `nil` instead of injecting `"default"`, so migrated NodeGroups faithfully reflect the source PCC.

Affects only the cloud-provider-dvp migration flow (State B); no restarts or resource recreation.

## Why do we need it, and what problem does it solve?

Migration resources should reproduce the source cluster faithfully. Previously a synthetic `"default"` zone was silently injected into migrated NodeGroups even when the source PCC had no zones, hiding the real source state.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cloud-provider-dvp
type: fix
summary: Migrated NodeGroups no longer receive a synthetic "default" zone when the source PCC has no zones; the live hook keeps the fallback.
impact_level: default
```