### PR TITLE
[registry, registry-packages-proxy] backport missing gateway api objects

### DIFF
--- a/modules/038-registry/templates/ingress/custom-certificate.yaml
+++ b/modules/038-registry/templates/ingress/custom-certificate.yaml
@@ -12,5 +12,11 @@
 
 {{- include "helm_lib_module_https_copy_custom_certificate" (list . "d8-system" "registry-ingress-tls") -}}
 
+{{- $moduleGateway := dict }}
+{{- include "helm_lib_module_gateway" (list . $moduleGateway) }}
+{{- if $moduleGateway }}
+{{- include "helm_lib_module_https_copy_custom_certificate" (list . "d8-system" "registry-httproute-tls") -}}
+{{- end }}
+
 {{- end }}
 {{- end }}

--- a/modules/039-registry-packages-proxy/templates/custom-certificate.yaml
+++ b/modules/039-registry-packages-proxy/templates/custom-certificate.yaml
@@ -1,3 +1,9 @@
 {{- if and .Values.global.modules.publicDomainTemplate .Values.global.clusterIsBootstrapped }}
 {{ include "helm_lib_module_https_copy_custom_certificate" (list . "d8-cloud-instance-manager" "ingress-tls") }}
+
+{{ $moduleGateway := dict }}
+{{ include "helm_lib_module_gateway" (list . $moduleGateway) }}
+{{ if $moduleGateway }}
+{{ include "helm_lib_module_https_copy_custom_certificate" (list . "d8-cloud-instance-manager" "registry-packages-proxy-httproute-tls") }}
+{{- end }}
 {{- end }}

--- a/modules/039-registry-packages-proxy/templates/httproute.yaml
+++ b/modules/039-registry-packages-proxy/templates/httproute.yaml
@@ -1,0 +1,134 @@
+{{- $moduleGateway := dict }}
+{{- include "helm_lib_module_gateway" (list . $moduleGateway) }}
+{{- if and $moduleGateway .Values.global.modules.publicDomainTemplate .Values.global.clusterIsBootstrapped (include "helm_lib_kind_exists" (list . "HTTPRoute")) (include "helm_lib_kind_exists" (list . "ListenerSet")) -}}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  {{- include "helm_lib_module_labels" (list . (dict "app" "registry-packages-proxy")) | nindent 2 }}
+  name: registry-packages-proxy
+  namespace: d8-cloud-instance-manager
+spec:
+  listeners:
+{{- if (include "helm_lib_module_https_route_tls_enabled" .) }}
+  - allowedRoutes:
+      namespaces:
+        from: Same
+    hostname: {{ include "helm_lib_module_public_domain" (list . "registry-packages-proxy") }}
+    name: registry-packages-proxy
+    port: 443
+    protocol: HTTPS
+    tls:
+      certificateRefs:
+      - group: ""
+        kind: Secret
+        name: {{ include "helm_lib_module_https_secret_name" (list . "registry-packages-proxy-httproute-tls") }}
+        namespace: d8-cloud-instance-manager
+      mode: Terminate
+  - allowedRoutes:
+      namespaces:
+        from: Same
+    hostname: {{ include "helm_lib_module_public_domain" (list . "registry-packages-proxy") }}
+    name: registry-packages-proxy-redirect
+    port: 80
+    protocol: HTTP
+{{- else }}
+  - allowedRoutes:
+      namespaces:
+        from: Same
+    hostname: {{ include "helm_lib_module_public_domain" (list . "registry-packages-proxy") }}
+    name: registry-packages-proxy
+    port: 80
+    protocol: HTTP
+{{- end }}
+  parentRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: {{ $moduleGateway.name }}
+    namespace: {{ $moduleGateway.namespace }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: registry-packages-proxy
+  namespace: d8-cloud-instance-manager
+  annotations:
+    alb.network.deckhouse.io/backend-tls-settings: '{"mode": "SIMPLE", "insecureSkipVerify": true}'
+  {{- if or (eq (include "helm_lib_module_https_mode" .) "CertManager") (eq (include "helm_lib_module_https_mode" .) "CustomCertificate") }}
+    alb.network.deckhouse.io/response-headers-to-add: '{"Strict-Transport-Security":"max-age=31536000; includeSubDomains"}'
+  {{- end }}
+    alb.network.deckhouse.io/idle-timeout: "300"
+  {{- include "helm_lib_module_labels" (list . (dict "app" "registry-packages-proxy")) | nindent 2 }}
+spec:
+  hostnames:
+  - {{ include "helm_lib_module_public_domain" (list . "registry-packages-proxy") }}
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: ListenerSet
+    name: registry-packages-proxy
+    namespace: d8-cloud-instance-manager
+    sectionName: registry-packages-proxy
+  rules:
+  - backendRefs:
+    - group: ""
+      kind: Service
+      name: registry-packages-proxy
+      port: 443
+      weight: 1
+    matches:
+    - path:
+      # Only /v1/images/* (Deckhouse CLI downloads, RBAC-authenticated) is exposed
+      # through the public Ingress. /v1/packages/*/metadata/icon[/<version>] is
+      # intentionally NOT routed here: icons are served anonymously
+      # (kube-rbac-proxy excludePaths) and must stay reachable only from inside
+      # the cluster via the Service (and the master-node hostPort 4219 during
+      # bootstrap), never via the public domain.
+        type: PathPrefix
+        value: /v1/images/
+{{- if (include "helm_lib_module_https_route_tls_enabled" . ) }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: registry-packages-proxy-redirect
+  namespace: d8-cloud-instance-manager
+  {{- include "helm_lib_module_labels" (list . (dict "app" "registry-packages-proxy")) | nindent 2 }}
+spec:
+  hostnames:
+  - {{ include "helm_lib_module_public_domain" (list . "registry-packages-proxy") }}
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: ListenerSet
+    name: registry-packages-proxy
+    namespace: d8-cloud-instance-manager
+    sectionName: registry-packages-proxy-redirect
+  rules:
+  - filters:
+    - type: RequestRedirect
+      requestRedirect:
+        scheme: https
+        statusCode: 301
+    matches:
+    - path:
+        type: PathPrefix
+        value: /
+{{- end }}
+{{- if and $moduleGateway (eq (include "helm_lib_module_https_mode" .) "CertManager") }}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: registry-packages-proxy-httproute-tls
+  namespace: d8-cloud-instance-manager
+  {{- include "helm_lib_module_labels" (list . (dict "app" "registry-packages-proxy")) | nindent 2 }}
+spec:
+  certificateOwnerRef: false
+  secretName: {{ include "helm_lib_module_https_secret_name" (list . "registry-packages-proxy-httproute-tls") }}
+  {{ include "helm_lib_module_generate_common_name" (list . "registry-packages-proxy") | nindent 2 }}
+  dnsNames:
+  - {{ include "helm_lib_module_public_domain" (list . "registry-packages-proxy") }}
+  issuerRef:
+    name: {{ printf "letsencrypt-gateway-%s" $moduleGateway.name }}
+    kind: ClusterIssuer
+{{- end }}
+{{- end }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Backports some Gateway API related updates to 1.76 from https://github.com/deckhouse/deckhouse/pull/20928.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

It provides Gateway API support.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

It provides Gateway API support.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: registry
type: fix
summary: Missing copy_custom_certificate for Gateway API path was added.
impact_level: low
```

```changes
section: registry-packages-proxy
type: fix
summary: Missing Gateway API objects were added.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
