### PR TITLE
[deckhouse] load per-module conversions in packages runtime

### DIFF
--- a/deckhouse-controller/internal/packages/apps/app.go
+++ b/deckhouse-controller/internal/packages/apps/app.go
@@ -328,7 +328,7 @@ func (a *Application) GetSettingsChecksum() string {
 }
 
 // ValidateSettings validates settings against openAPI and call setting check if exists
-func (a *Application) ValidateSettings(ctx context.Context, settings addonutils.Values) (settingscheck.Result, error) {
+func (a *Application) ValidateSettings(ctx context.Context, _ int, settings addonutils.Values) (settingscheck.Result, error) {
 	if err := a.values.ValidateSettings(settings); err != nil {
 		return settingscheck.Result{}, err
 	}
@@ -364,7 +364,7 @@ func (a *Application) GetValues() addonutils.Values {
 // ApplySettings applies settings values to application. Before persisting the
 // user config it resolves per-project grant defaults from
 // AvailableClusterResource and stores them for the grantDefaultsTransformer.
-func (a *Application) ApplySettings(settings addonutils.Values) error {
+func (a *Application) ApplySettings(_ int, settings addonutils.Values) error {
 	if err := a.resolveGrantDefaults(context.Background()); err != nil {
 		return err
 	}

--- a/deckhouse-controller/internal/packages/apps/grants_test.go
+++ b/deckhouse-controller/internal/packages/apps/grants_test.go
@@ -96,7 +96,7 @@ func TestApplyGrantDefaults(t *testing.T) {
 	}})
 
 	t.Run("injects default into empty field", func(t *testing.T) {
-		err := app.ApplySettings(addonutils.Values{})
+		err := app.ApplySettings(0, addonutils.Values{})
 		require.NoError(t, err)
 
 		settings := app.GetSettings()
@@ -104,7 +104,7 @@ func TestApplyGrantDefaults(t *testing.T) {
 	})
 
 	t.Run("user value overrides default", func(t *testing.T) {
-		err := app.ApplySettings(addonutils.Values{"storageClass": "hdd"})
+		err := app.ApplySettings(0, addonutils.Values{"storageClass": "hdd"})
 		require.NoError(t, err)
 
 		settings := app.GetSettings()
@@ -113,7 +113,7 @@ func TestApplyGrantDefaults(t *testing.T) {
 
 	t.Run("no default when feature inactive", func(t *testing.T) {
 		inactive := newTestApp(t, grants.NoopResolver{})
-		err := inactive.ApplySettings(addonutils.Values{})
+		err := inactive.ApplySettings(0, addonutils.Values{})
 		require.NoError(t, err)
 
 		settings := inactive.GetSettings()
@@ -126,7 +126,7 @@ func TestApplyGrantDefaults(t *testing.T) {
 			Default:   "",
 			Available: []string{"ssd", "hdd"},
 		}})
-		err := noDefault.ApplySettings(addonutils.Values{})
+		err := noDefault.ApplySettings(0, addonutils.Values{})
 		require.NoError(t, err)
 
 		settings := noDefault.GetSettings()

--- a/deckhouse-controller/internal/packages/loader/loader.go
+++ b/deckhouse-controller/internal/packages/loader/loader.go
@@ -55,6 +55,10 @@ const (
 	// globalPath is the relative directory containing global hook definitions and values.
 	// LoadGlobalConf expects this path to exist relative to the process working directory.
 	globalPath = "global-hooks"
+
+	// conversionsDir is the subdirectory within a package's openapi/ directory
+	// that contains schema version conversion files (v<N>.yaml).
+	conversionsDir = "conversions"
 )
 
 // ErrPackageNotFound is returned when the requested package directory doesn't exist
@@ -582,14 +586,14 @@ func loadEmbeddedDigests(packageName string) (map[string]string, error) {
 // loadConversions reads conversion rules from the module's openapi/conversions directory.
 // Returns nil if the directory does not exist (conversions are optional).
 func loadConversions(moduleDir string) (*conversion.Converter, error) {
-	conversionsDir := filepath.Join(moduleDir, "openapi", "conversions")
-	if _, err := os.Stat(conversionsDir); err != nil {
+	d := filepath.Join(moduleDir, "openapi", conversionsDir)
+	if _, err := os.Stat(d); err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("stat conversions dir: %w", err)
 	}
-	return conversion.NewConverterFromDir(conversionsDir)
+	return conversion.NewConverterFromDir(d)
 }
 
 // getModuleVersion returns the version of the package at moduleDir.

--- a/deckhouse-controller/internal/packages/loader/loader.go
+++ b/deckhouse-controller/internal/packages/loader/loader.go
@@ -37,6 +37,7 @@ import (
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/modules/global"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/tools/verity"
 	moduletypes "github.com/deckhouse/deckhouse/deckhouse-controller/pkg/controller/moduleloader/types"
+	"github.com/deckhouse/deckhouse/go_lib/configtools/conversion"
 	"github.com/deckhouse/deckhouse/pkg/log"
 )
 
@@ -198,6 +199,12 @@ func LoadEmbeddedConf(ctx context.Context, moduleDir string, logger *log.Logger)
 		return nil, fmt.Errorf("load digests: %w", err)
 	}
 
+	conversions, err := loadConversions(moduleDir)
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return nil, fmt.Errorf("load conversions: %w", err)
+	}
+
 	return &modules.Config{
 		Path:       moduleDir,
 		Definition: moduleDef,
@@ -207,6 +214,8 @@ func LoadEmbeddedConf(ctx context.Context, moduleDir string, logger *log.Logger)
 		StaticValues: static,
 		ConfigSchema: config,
 		ValuesSchema: values,
+
+		Conversions: conversions,
 
 		Hooks: hooks,
 	}, nil
@@ -300,6 +309,12 @@ func LoadModuleConf(ctx context.Context, moduleDir string, logger *log.Logger) (
 		return nil, fmt.Errorf("load digests: %w", err)
 	}
 
+	conversions, err := loadConversions(moduleDir)
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return nil, fmt.Errorf("load conversions: %w", err)
+	}
+
 	return &modules.Config{
 		Path:       moduleDir,
 		Definition: moduleDef,
@@ -309,6 +324,8 @@ func LoadModuleConf(ctx context.Context, moduleDir string, logger *log.Logger) (
 		StaticValues: static,
 		ConfigSchema: config,
 		ValuesSchema: values,
+
+		Conversions: conversions,
 
 		Hooks: hooks.hooks,
 
@@ -560,6 +577,19 @@ func loadEmbeddedDigests(packageName string) (map[string]string, error) {
 	}
 
 	return nil, nil
+}
+
+// loadConversions reads conversion rules from the module's openapi/conversions directory.
+// Returns nil if the directory does not exist (conversions are optional).
+func loadConversions(moduleDir string) (*conversion.Converter, error) {
+	conversionsDir := filepath.Join(moduleDir, "openapi", "conversions")
+	if _, err := os.Stat(conversionsDir); err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("stat conversions dir: %w", err)
+	}
+	return conversion.NewConverterFromDir(conversionsDir)
 }
 
 // getModuleVersion returns the version of the package at moduleDir.

--- a/deckhouse-controller/internal/packages/loader/loader.go
+++ b/deckhouse-controller/internal/packages/loader/loader.go
@@ -369,12 +369,20 @@ func LoadGlobalConf(ctx context.Context, logger *log.Logger) (*global.Config, er
 		return nil, fmt.Errorf("load hooks: %w", err)
 	}
 
+	conversions, err := loadConversions(globalPath)
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return nil, fmt.Errorf("load conversions: %w", err)
+	}
+
 	return &global.Config{
 		Path: globalPath,
 
 		StaticValues: static,
 		ConfigSchema: config,
 		ValuesSchema: values,
+
+		Conversions: conversions,
 
 		Hooks: hooks,
 	}, nil

--- a/deckhouse-controller/internal/packages/modules/global/module.go
+++ b/deckhouse-controller/internal/packages/modules/global/module.go
@@ -57,8 +57,8 @@ type Module struct {
 	name string // Package name
 	path string // path to the package dir on fs
 
-	hooks   *hooks.GlobalStorage  // Hook storage with indices
-	values  *values.Storage       // Values storage with layering
+	hooks     *hooks.GlobalStorage  // Hook storage with indices
+	values    *values.Storage       // Values storage with layering
 	converter *conversion.Converter // Schema version converter for settings
 
 	// running tracks whether OnStartup hooks have completed successfully.

--- a/deckhouse-controller/internal/packages/modules/global/module.go
+++ b/deckhouse-controller/internal/packages/modules/global/module.go
@@ -49,6 +49,7 @@ import (
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/schedule"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/schedule/rule"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/values"
+	"github.com/deckhouse/deckhouse/go_lib/configtools/conversion"
 	"github.com/deckhouse/deckhouse/pkg/log"
 )
 
@@ -56,8 +57,9 @@ type Module struct {
 	name string // Package name
 	path string // path to the package dir on fs
 
-	hooks  *hooks.GlobalStorage // Hook storage with indices
-	values *values.Storage      // Values storage with layering
+	hooks   *hooks.GlobalStorage  // Hook storage with indices
+	values  *values.Storage       // Values storage with layering
+	converter *conversion.Converter // Schema version converter for settings
 
 	// running tracks whether OnStartup hooks have completed successfully.
 	// When true, subsequent OnStartup binding calls are skipped (idempotency guard).
@@ -93,6 +95,8 @@ type Config struct {
 
 	Hooks []hooks.GlobalHook // Discovered hooks
 
+	Conversions *conversion.Converter // Schema version converter
+
 	Patcher           *objectpatch.ObjectPatcher
 	ScheduleManager   schedulemanager.ScheduleManager
 	KubeEventsManager kubeeventsmanager.KubeEventsManager
@@ -111,6 +115,7 @@ func NewModuleByConfig(cfg *Config, logger *log.Logger) (*Module, error) {
 	m.configEnabled = make(map[string]bool)
 
 	m.path = cfg.Path
+	m.converter = cfg.Conversions
 	m.patcher = cfg.Patcher
 	m.scheduleManager = cfg.ScheduleManager
 	m.kubeEventsManager = cfg.KubeEventsManager
@@ -222,8 +227,17 @@ func (m *Module) GetValues() addonutils.Values {
 	)
 }
 
-// ValidateSettings validates settings against openAPI
-func (m *Module) ValidateSettings(_ context.Context, _ int, settings addonutils.Values) (settingscheck.Result, error) {
+// ValidateSettings converts settings to the latest schema version (if a converter
+// is available and settingsVersion > 0), then validates against OpenAPI schema.
+func (m *Module) ValidateSettings(_ context.Context, settingsVersion int, settings addonutils.Values) (settingscheck.Result, error) {
+	// Convert to latest schema version before validation
+	if m.converter != nil && settingsVersion > 0 {
+		var err error
+		_, settings, err = m.converter.ConvertToLatest(settingsVersion, settings)
+		if err != nil {
+			return settingscheck.Result{}, fmt.Errorf("convert settings: %w", err)
+		}
+	}
 	if err := m.values.ValidateSettings(settings); err != nil {
 		return settingscheck.Result{}, err
 	}
@@ -241,8 +255,17 @@ func (m *Module) ValidateSettings(_ context.Context, _ int, settings addonutils.
 	}, nil
 }
 
-// ApplySettings apply settings values
-func (m *Module) ApplySettings(_ int, settings addonutils.Values) error {
+// ApplySettings converts settings to the latest schema version (if a converter
+// is available), then applies them to the values storage.
+func (m *Module) ApplySettings(settingsVersion int, settings addonutils.Values) error {
+	// Convert to latest schema version before applying
+	if m.converter != nil && settingsVersion > 0 {
+		var err error
+		_, settings, err = m.converter.ConvertToLatest(settingsVersion, settings)
+		if err != nil {
+			return fmt.Errorf("convert settings: %w", err)
+		}
+	}
 	return m.values.ApplySettings(settings)
 }
 

--- a/deckhouse-controller/internal/packages/modules/global/module.go
+++ b/deckhouse-controller/internal/packages/modules/global/module.go
@@ -223,7 +223,7 @@ func (m *Module) GetValues() addonutils.Values {
 }
 
 // ValidateSettings validates settings against openAPI
-func (m *Module) ValidateSettings(_ context.Context, settings addonutils.Values) (settingscheck.Result, error) {
+func (m *Module) ValidateSettings(_ context.Context, _ int, settings addonutils.Values) (settingscheck.Result, error) {
 	if err := m.values.ValidateSettings(settings); err != nil {
 		return settingscheck.Result{}, err
 	}
@@ -242,7 +242,7 @@ func (m *Module) ValidateSettings(_ context.Context, settings addonutils.Values)
 }
 
 // ApplySettings apply settings values
-func (m *Module) ApplySettings(settings addonutils.Values) error {
+func (m *Module) ApplySettings(_ int, settings addonutils.Values) error {
 	return m.values.ApplySettings(settings)
 }
 

--- a/deckhouse-controller/internal/packages/modules/module.go
+++ b/deckhouse-controller/internal/packages/modules/module.go
@@ -44,6 +44,7 @@ import (
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/schedule"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/values"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/registry"
+	"github.com/deckhouse/deckhouse/go_lib/configtools/conversion"
 	"github.com/deckhouse/deckhouse/pkg/log"
 )
 
@@ -67,6 +68,7 @@ type Module struct {
 	definition Definition        // Module definition
 	digests    map[string]string // Package digests
 	repository registry.Remote   // Module repository
+	converter   *conversion.Converter // Schema version converter for settings
 
 	hooks         *hooks.Storage      // Hook storage with indices
 	values        *values.Storage     // Values storage with layering
@@ -97,6 +99,7 @@ type Config struct {
 	Hooks []hooks.Hook // Discovered hooks
 
 	SettingsCheck *kind.SettingsCheck
+	Conversions   *conversion.Converter // Schema version converter
 
 	Patcher           *objectpatch.ObjectPatcher
 	ScheduleManager   schedulemanager.ScheduleManager
@@ -122,6 +125,7 @@ func NewModuleByConfig(name string, cfg *Config, logger *log.Logger) (*Module, e
 	m.digests = cfg.Digests
 	m.repository = cfg.Repository
 	m.settingsCheck = cfg.SettingsCheck
+	m.converter = cfg.Conversions
 	m.patcher = cfg.Patcher
 	m.scheduleManager = cfg.ScheduleManager
 	m.kubeEventsManager = cfg.KubeEventsManager
@@ -270,6 +274,12 @@ func (m *Module) GetValuesChecksum() string {
 // Used to detect if settings changed.
 func (m *Module) GetSettingsChecksum() string {
 	return m.values.GetSettingsChecksum()
+}
+
+// GetConverter returns the schema version converter for this module's settings.
+// Returns nil if no conversions directory was present in the module package.
+func (m *Module) GetConverter() *conversion.Converter {
+	return m.converter
 }
 
 // ValidateSettings validates settings against openAPI and call setting check if exists

--- a/deckhouse-controller/internal/packages/modules/module.go
+++ b/deckhouse-controller/internal/packages/modules/module.go
@@ -282,8 +282,18 @@ func (m *Module) GetConverter() *conversion.Converter {
 	return m.converter
 }
 
-// ValidateSettings validates settings against openAPI and call setting check if exists
-func (m *Module) ValidateSettings(ctx context.Context, settings addonutils.Values) (settingscheck.Result, error) {
+// ValidateSettings converts settings to the latest schema version (if a converter
+// is available and settingsVersion > 0), then validates against OpenAPI schema
+// and calls the settings check hook if defined.
+func (m *Module) ValidateSettings(ctx context.Context, settingsVersion int, settings addonutils.Values) (settingscheck.Result, error) {
+	// Convert to latest schema version before validation
+	if m.converter != nil && settingsVersion > 0 {
+		var err error
+		_, settings, err = m.converter.ConvertToLatest(settingsVersion, settings)
+		if err != nil {
+			return settingscheck.Result{}, fmt.Errorf("convert settings: %w", err)
+		}
+	}
 	if err := m.values.ValidateSettings(settings); err != nil {
 		return settingscheck.Result{}, err
 	}
@@ -320,7 +330,17 @@ func (m *Module) GetValues() addonutils.Values {
 }
 
 // ApplySettings applies settings values
-func (m *Module) ApplySettings(settings addonutils.Values) error {
+// ApplySettings converts settings to the latest schema version (if a converter
+// is available), then applies them to the values storage.
+func (m *Module) ApplySettings(settingsVersion int, settings addonutils.Values) error {
+	// Convert to latest schema version before applying
+	if m.converter != nil && settingsVersion > 0 {
+		var err error
+		_, settings, err = m.converter.ConvertToLatest(settingsVersion, settings)
+		if err != nil {
+			return fmt.Errorf("convert settings: %w", err)
+		}
+	}
 	return m.values.ApplySettings(settings)
 }
 

--- a/deckhouse-controller/internal/packages/modules/module.go
+++ b/deckhouse-controller/internal/packages/modules/module.go
@@ -276,12 +276,6 @@ func (m *Module) GetSettingsChecksum() string {
 	return m.values.GetSettingsChecksum()
 }
 
-// GetConverter returns the schema version converter for this module's settings.
-// Returns nil if no conversions directory was present in the module package.
-func (m *Module) GetConverter() *conversion.Converter {
-	return m.converter
-}
-
 // ValidateSettings converts settings to the latest schema version (if a converter
 // is available and settingsVersion > 0), then validates against OpenAPI schema
 // and calls the settings check hook if defined.

--- a/deckhouse-controller/internal/packages/modules/module.go
+++ b/deckhouse-controller/internal/packages/modules/module.go
@@ -65,10 +65,10 @@ type Module struct {
 	// When true, subsequent OnStartup binding calls are skipped (idempotency guard).
 	running atomic.Bool
 
-	definition Definition        // Module definition
-	digests    map[string]string // Package digests
-	repository registry.Remote   // Module repository
-	converter   *conversion.Converter // Schema version converter for settings
+	definition Definition            // Module definition
+	digests    map[string]string     // Package digests
+	repository registry.Remote       // Module repository
+	converter  *conversion.Converter // Schema version converter for settings
 
 	hooks         *hooks.Storage      // Hook storage with indices
 	values        *values.Storage     // Values storage with layering

--- a/deckhouse-controller/internal/packages/runtime/apps.go
+++ b/deckhouse-controller/internal/packages/runtime/apps.go
@@ -43,10 +43,11 @@ const (
 // App represents an application instance as received from the Application controller.
 // It carries the user-specified package identity, version constraints, and settings.
 type App struct {
-	Name       string
-	Namespace  string
-	Definition apps.Definition
-	Settings   addonutils.Values
+	Name            string
+	Namespace       string
+	Definition      apps.Definition
+	Settings        addonutils.Values
+	SettingsVersion int // schema version from Application.Spec.Version (reserved for future use)
 }
 
 // UpdateApp handles application creation and version changes from the Application controller.
@@ -80,7 +81,7 @@ func (r *Runtime) UpdateApp(repo registry.Remote, app App) {
 		return
 	}
 
-	ctx := r.packages.Update(name, version, app.Settings)
+	ctx := r.packages.Update(name, version, app.SettingsVersion, app.Settings)
 	if ctx == nil {
 		r.scheduler.Reschedule(name)
 		return

--- a/deckhouse-controller/internal/packages/runtime/apps.go
+++ b/deckhouse-controller/internal/packages/runtime/apps.go
@@ -77,7 +77,7 @@ func (r *Runtime) UpdateApp(repo registry.Remote, app App) {
 	version := app.Definition.Version
 	packageName := app.Definition.Name
 
-	if !r.packages.NeedUpdate(name, version, app.Settings.Checksum()) {
+	if !r.packages.NeedUpdate(name, version, app.Settings.Checksum(), app.SettingsVersion) {
 		return
 	}
 

--- a/deckhouse-controller/internal/packages/runtime/embedded.go
+++ b/deckhouse-controller/internal/packages/runtime/embedded.go
@@ -76,7 +76,7 @@ func (r *Runtime) loadGlobal(ctx context.Context) error {
 	r.status.SetConditionTrue(r.global.GetName(), status.ConditionRequirementsMet)
 	r.status.SetConditionTrue(r.global.GetName(), status.ConditionReadyOnFilesystem)
 	r.status.SetConditionTrue(r.global.GetName(), status.ConditionLoaded)
-	r.packages.Update(r.global.GetName(), r.global.GetVersion().String(), make(addonutils.Values))
+	r.packages.Update(r.global.GetName(), r.global.GetVersion().String(), 0, make(addonutils.Values))
 
 	return nil
 }
@@ -147,7 +147,7 @@ func (r *Runtime) loadEmbedded(ctx context.Context) error {
 			r.status.SetConditionTrue(module.GetName(), status.ConditionReadyOnFilesystem)
 			r.status.SetConditionTrue(module.GetName(), status.ConditionLoaded)
 			r.status.UpdateVersion(module.GetName(), module.GetVersion().String())
-			r.packages.Update(module.GetName(), module.GetVersion().String(), make(addonutils.Values))
+			r.packages.Update(module.GetName(), module.GetVersion().String(), 0, make(addonutils.Values))
 
 			return nil
 		})

--- a/deckhouse-controller/internal/packages/runtime/lifecycle/lifecycle.go
+++ b/deckhouse-controller/internal/packages/runtime/lifecycle/lifecycle.go
@@ -47,8 +47,9 @@ const (
 //	root (ctx/cancel) — created by EventUpdate or EventRemove
 //	└── EventSchedule child — cancelled on enable↔disable transition
 type Package struct {
-	version  string            // package version, cleared on remove
-	settings addonutils.Values // pending settings, updated by Update, consumed by GetPendingSettings
+	version         string            // package version, cleared on remove
+	settingsVersion int               // schema version of pending settings (from ModuleConfig.Spec.Version)
+	settings        addonutils.Values // pending settings, updated by Update, consumed by GetPendingSettings
 
 	ctx    context.Context    // root context, cancelled on version change or remove
 	cancel context.CancelFunc // cancels root and all children

--- a/deckhouse-controller/internal/packages/runtime/lifecycle/store.go
+++ b/deckhouse-controller/internal/packages/runtime/lifecycle/store.go
@@ -63,19 +63,20 @@ func (s *Store) NeedUpdate(name, version, checksum string) bool {
 //  1. Package not in store → creates entry, returns root context
 //  2. Version differs → cancels all in-flight tasks, returns new root context
 //
-// Returns nil when only settings changed (no new context needed — settings are
-// stored and will be picked up by the scheduler via GetPendingSettings on next
-// Reschedule, or by the next Configure task in the schedule pipeline).
+// Returns nil when only settings or settingsVersion changed (no new context needed —
+// settings are stored and will be picked up by the scheduler via GetPendingSettings on
+// next Reschedule, or by the next Configure task in the schedule pipeline).
 //
 // Callers should check for nil: a nil return with a settings-only change means
 // the caller should trigger Reschedule to re-apply settings through the scheduler.
-func (s *Store) Update(name, version string, settings addonutils.Values) context.Context {
+func (s *Store) Update(name, version string, settingsVersion int, settings addonutils.Values) context.Context {
 	pkg, ok := s.packages[name]
 	if !ok {
 		s.packages[name] = &Package{
-			version:  version,
-			settings: settings,
-			cancels:  make(map[int]context.CancelFunc),
+			version:         version,
+			settingsVersion: settingsVersion,
+			settings:        settings,
+			cancels:         make(map[int]context.CancelFunc),
 		}
 
 		ctx := s.packages[name].newContext(EventUpdate)
@@ -84,40 +85,53 @@ func (s *Store) Update(name, version string, settings addonutils.Values) context
 
 	if pkg.version != version {
 		pkg.version = version
+		pkg.settingsVersion = settingsVersion
 		pkg.settings = settings
 
 		ctx := pkg.newContext(EventUpdate)
 		return ctx
 	}
 
-	if pkg.settings.Checksum() != settings.Checksum() {
+	checksumChanged := pkg.settings.Checksum() != settings.Checksum()
+	versionChanged := pkg.settingsVersion != settingsVersion
+
+	if checksumChanged {
 		pkg.settings = settings
+	}
+	if checksumChanged || versionChanged {
+		pkg.settingsVersion = settingsVersion
 	}
 
 	return nil
 }
 
-// UpdateSettings stores new pending settings for an already-tracked package
-// without touching its version or context tree. Returns true if the settings
-// checksum changed and the caller should Reschedule, false if nothing changed or
-// the package is not tracked yet.
+// UpdateSettings stores new pending settings and their schema version for an
+// already-tracked package without touching its version or context tree.
+// Returns true if the settings checksum or settingsVersion changed and the
+// caller should Reschedule, false if nothing changed or the package is not
+// tracked yet.
 //
 // Unlike Update, this never creates or cancels a context: in-flight deploy and
 // load tasks are left running. It is the settings-only counterpart to Update,
 // used when settings change independently of a version change. The ModuleConfig
-// enabled intent is tracked separately by the global module (see
-// global.Module.SetConfigEnabled), not here.
-func (s *Store) UpdateSettings(name string, settings addonutils.Values) bool {
+// enabled intent is tracked separately by the global module, not here.
+func (s *Store) UpdateSettings(name string, settingsVersion int, settings addonutils.Values) bool {
 	pkg, ok := s.packages[name]
 	if !ok {
 		return false
 	}
 
-	if pkg.settings.Checksum() == settings.Checksum() {
+	checksumChanged := pkg.settings.Checksum() != settings.Checksum()
+	versionChanged := pkg.settingsVersion != settingsVersion
+
+	if !checksumChanged && !versionChanged {
 		return false
 	}
 
-	pkg.settings = settings
+	if checksumChanged {
+		pkg.settings = settings
+	}
+	pkg.settingsVersion = settingsVersion
 
 	return true
 }
@@ -136,18 +150,20 @@ func (s *Store) HandleEvent(event int, name string) context.Context {
 
 	if event == EventRemove {
 		pkg.version = ""
+		pkg.settingsVersion = 0
 		pkg.settings = make(addonutils.Values)
 	}
 
 	return pkg.newContext(event)
 }
 
-// GetPendingSettings returns the latest settings stored for a package.
-// Called by schedulePackage to pass current settings into the Configure task.
+// GetPendingSettings returns the latest settings and their schema version stored
+// for a package. Called by schedulePackage to pass current settings and version
+// into the Configure task so it can convert from the stored version to latest.
 // This late-binding approach ensures settings changes that arrive between Update
 // and schedule are automatically picked up.
-func (s *Store) GetPendingSettings(name string) addonutils.Values {
-	return s.packages[name].settings
+func (s *Store) GetPendingSettings(name string) (addonutils.Values, int) {
+	return s.packages[name].settings, s.packages[name].settingsVersion
 }
 
 // Delete removes a package entry from the store if it still exists and is in

--- a/deckhouse-controller/internal/packages/runtime/lifecycle/store.go
+++ b/deckhouse-controller/internal/packages/runtime/lifecycle/store.go
@@ -38,9 +38,10 @@ func NewStore() *Store {
 }
 
 // NeedUpdate reports whether the package needs processing: true if the package
-// is new, the version changed, or the settings checksum differs.
+// is new, the version changed, the settings checksum differs, or the settings
+// schema version changed.
 // Used as a fast-path check before the more expensive Update call.
-func (s *Store) NeedUpdate(name, version, checksum string) bool {
+func (s *Store) NeedUpdate(name, version, checksum string, settingsVersion int) bool {
 	pkg, ok := s.packages[name]
 	if !ok {
 		return true
@@ -51,6 +52,10 @@ func (s *Store) NeedUpdate(name, version, checksum string) bool {
 	}
 
 	if pkg.settings.Checksum() != checksum {
+		return true
+	}
+
+	if pkg.settingsVersion != settingsVersion {
 		return true
 	}
 

--- a/deckhouse-controller/internal/packages/runtime/modules.go
+++ b/deckhouse-controller/internal/packages/runtime/modules.go
@@ -39,9 +39,10 @@ import (
 // Module represents a module instance as received from the module controller.
 // Unlike App, modules always run in the d8-system namespace.
 type Module struct {
-	Name       string
-	Definition modules.Definition
-	Settings   addonutils.Values
+	Name            string
+	Definition      modules.Definition
+	Settings        addonutils.Values
+	SettingsVersion int // schema version from ModuleConfig.Spec.Version
 }
 
 // UpdateModulesSettings applies a settings-and-enabled change to an
@@ -66,14 +67,14 @@ type Module struct {
 // dropped — there is no per-package store to stash them in yet; the eventual
 // UpdateModule registers the package and supplies its settings. Either way, an
 // untracked package has no node to reschedule, so no Reschedule happens here.
-func (r *Runtime) UpdateModulesSettings(name string, settings addonutils.Values, enabled *bool) {
+func (r *Runtime) UpdateModulesSettings(name string, settingsVersion int, settings addonutils.Values, enabled *bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	// Settings live in the per-package store; the ModuleConfig enabled intent
 	// lives in the global module (thread-safe for the scheduler's enabled getter).
 	// Reschedule if either actually changed.
-	settingsChanged := r.packages.UpdateSettings(name, settings)
+	settingsChanged := r.packages.UpdateSettings(name, settingsVersion, settings)
 	enabledChanged := r.global.SetConfigEnabled(name, enabled)
 
 	if settingsChanged || enabledChanged {
@@ -102,7 +103,7 @@ func (r *Runtime) UpdateModule(repo registry.Remote, module Module) {
 		return
 	}
 
-	ctx := r.packages.Update(name, version, module.Settings)
+	ctx := r.packages.Update(name, version, module.SettingsVersion, module.Settings)
 	if ctx == nil {
 		r.scheduler.Reschedule(name)
 		return

--- a/deckhouse-controller/internal/packages/runtime/modules.go
+++ b/deckhouse-controller/internal/packages/runtime/modules.go
@@ -99,7 +99,7 @@ func (r *Runtime) UpdateModule(repo registry.Remote, module Module) {
 	name := module.Name
 	version := module.Definition.Version
 
-	if !r.packages.NeedUpdate(name, version, module.Settings.Checksum()) {
+	if !r.packages.NeedUpdate(name, version, module.Settings.Checksum(), module.SettingsVersion) {
 		return
 	}
 

--- a/deckhouse-controller/internal/packages/runtime/runtime.go
+++ b/deckhouse-controller/internal/packages/runtime/runtime.go
@@ -644,8 +644,8 @@ func (r *Runtime) scheduleGlobal(enabled []string) {
 		}
 	}
 
-	settings := r.packages.GetPendingSettings(r.global.GetName())
-	r.queueService.Enqueue(ctx, r.global.GetName(), taskconfigure.NewTask(r.global, settings, r.status, r.logger))
+	settings, _ := r.packages.GetPendingSettings(r.global.GetName())
+	r.queueService.Enqueue(ctx, r.global.GetName(), taskconfigure.NewTask(r.global, settings, 0, r.status, r.logger))
 
 	// Enable initializes and syncs the global hooks; its OnStartup step is a no-op
 	// because global has no OnStartup hooks. globalrun then runs BeforeAll, ensures
@@ -687,16 +687,16 @@ func (r *Runtime) schedulePackage(name string) {
 
 	r.status.SetConditionTrue(name, status.ConditionRequirementsMet)
 
-	settings := r.packages.GetPendingSettings(name)
+	settings, settingsVersion := r.packages.GetPendingSettings(name)
 
 	if pkg := r.apps[name]; pkg != nil {
-		r.queueService.Enqueue(ctx, name, taskconfigure.NewTask(pkg, settings, r.status, r.logger))
+		r.queueService.Enqueue(ctx, name, taskconfigure.NewTask(pkg, settings, settingsVersion, r.status, r.logger))
 		r.queueService.Enqueue(ctx, name, taskenable.NewTask(pkg, r.nelmService, r.queueService, r.status, r.logger))
 		r.queueService.Enqueue(ctx, name, taskrun.NewTask(pkg, pkg.GetNamespace(), r.nelmService, r.status, r.logger), onDone)
 	}
 
 	if pkg := r.modules[name]; pkg != nil {
-		r.queueService.Enqueue(ctx, name, taskconfigure.NewTask(pkg, settings, r.status, r.logger))
+		r.queueService.Enqueue(ctx, name, taskconfigure.NewTask(pkg, settings, settingsVersion, r.status, r.logger))
 		r.queueService.Enqueue(ctx, name, taskenable.NewTask(pkg, r.nelmService, r.queueService, r.status, r.logger))
 		r.queueService.Enqueue(ctx, name, taskrun.NewTask(pkg, app.NamespaceDeckhouse, r.nelmService, r.status, r.logger), onDone)
 	}

--- a/deckhouse-controller/internal/packages/runtime/runtime.go
+++ b/deckhouse-controller/internal/packages/runtime/runtime.go
@@ -831,12 +831,12 @@ func (r *Runtime) CheckConstraints(name string, constraints schedule.Constraints
 
 // settingsValidatorI validates settings for a loaded runtime package.
 type settingsValidatorI interface {
-	ValidateSettings(ctx context.Context, settings addonutils.Values) (settingscheck.Result, error)
+	ValidateSettings(ctx context.Context, settingsVersion int, settings addonutils.Values) (settingscheck.Result, error)
 }
 
-// ValidatePackageSettings checks settings against the package's OpenAPI schema.
-// Returns valid if the package is not loaded yet (settings validated on load).
-func (r *Runtime) ValidatePackageSettings(ctx context.Context, name string, settings addonutils.Values) (settingscheck.Result, error) {
+// ValidatePackageSettings converts (if needed) and validates settings against the
+// package's OpenAPI schema. Returns valid if the package is not loaded yet.
+func (r *Runtime) ValidatePackageSettings(ctx context.Context, name string, settingsVersion int, settings addonutils.Values) (settingscheck.Result, error) {
 	ctx, span := otel.Tracer(runtimeTracer).Start(ctx, "ValidatePackageSettings")
 	defer span.End()
 
@@ -856,5 +856,5 @@ func (r *Runtime) ValidatePackageSettings(ctx context.Context, name string, sett
 		return settingscheck.Result{Valid: true}, nil
 	}
 
-	return validator.ValidateSettings(ctx, settings)
+	return validator.ValidateSettings(ctx, settingsVersion, settings)
 }

--- a/deckhouse-controller/internal/packages/runtime/tasks/configure/task.go
+++ b/deckhouse-controller/internal/packages/runtime/tasks/configure/task.go
@@ -27,16 +27,8 @@ import (
 
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/status"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/queue"
-	"github.com/deckhouse/deckhouse/go_lib/configtools/conversion"
 	"github.com/deckhouse/deckhouse/pkg/log"
 )
-
-// hasConverter is an optional interface for packages that support schema version
-// conversion of their settings. Only a subset of packages (module packages with
-// openapi/conversions) implement this.
-type hasConverter interface {
-	GetConverter() *conversion.Converter
-}
 
 const (
 	taskTracer = "configure"
@@ -45,10 +37,12 @@ const (
 // packageI abstracts the package operations needed for settings management.
 type packageI interface {
 	GetName() string
-	// ApplySettings updates the package's in-memory configuration.
-	ApplySettings(settings addonutils.Values) error
-	// ValidateSettings checks settings against package-defined constraints.
-	ValidateSettings(ctx context.Context, settings addonutils.Values) (settingscheck.Result, error)
+	// ApplySettings converts (if needed) and applies the package's configuration.
+	// settingsVersion is the schema version from ModuleConfig.Spec.Version (0 if unset).
+	ApplySettings(settingsVersion int, settings addonutils.Values) error
+	// ValidateSettings converts (if needed) and validates settings against the
+	// package's OpenAPI schema.
+	ValidateSettings(ctx context.Context, settingsVersion int, settings addonutils.Values) (settingscheck.Result, error)
 	// GetSettings returns the effective settings: user config merged with
 	// config-schema defaults. Same payload exposed to templates as .Application.Settings.
 	GetSettings() addonutils.Values
@@ -101,34 +95,15 @@ func (t *task) Execute(ctx context.Context) error {
 }
 
 // applySettings validates and applies settings to the package.
-// If the package has a converter and settingsVersion > 0, settings are
-// converted to the latest schema version before validation.
+// Conversion to the latest schema version (if needed) is handled inside
+// ValidateSettings and ApplySettings by the package itself.
 func (t *task) applySettings(ctx context.Context) error {
 	ctx, span := otel.Tracer(taskTracer).Start(ctx, "applySettings")
 	defer span.End()
 
 	t.logger.Debug("configure package")
 
-	settings := t.settings
-
-	// Convert settings to latest schema version if the package supports it
-	if p, ok := t.pkg.(hasConverter); ok && t.settingsVersion > 0 {
-		if conv := p.GetConverter(); conv != nil {
-			newVersion, converted, err := conv.ConvertToLatest(t.settingsVersion, settings)
-			if err != nil {
-				t.logger.Error("failed to convert settings",
-					slog.Int("from_version", t.settingsVersion),
-					slog.String("error", err.Error()))
-				return status.NewError("ConversionFailed", err)
-			}
-			t.logger.Debug("settings converted to latest version",
-				slog.Int("from", t.settingsVersion),
-				slog.Int("to", newVersion))
-			settings = converted
-		}
-	}
-
-	res, err := t.pkg.ValidateSettings(ctx, settings)
+	res, err := t.pkg.ValidateSettings(ctx, t.settingsVersion, t.settings)
 	if err != nil {
 		return status.NewError("ValidateFailed", err)
 	}
@@ -137,7 +112,7 @@ func (t *task) applySettings(ctx context.Context) error {
 		return status.NewError("ValidateFailed", errors.New(res.Message))
 	}
 
-	if err = t.pkg.ApplySettings(settings); err != nil {
+	if err = t.pkg.ApplySettings(t.settingsVersion, t.settings); err != nil {
 		return status.NewError("ConfigureFailed", err)
 	}
 

--- a/deckhouse-controller/internal/packages/runtime/tasks/configure/task.go
+++ b/deckhouse-controller/internal/packages/runtime/tasks/configure/task.go
@@ -27,8 +27,16 @@ import (
 
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/status"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/queue"
+	"github.com/deckhouse/deckhouse/go_lib/configtools/conversion"
 	"github.com/deckhouse/deckhouse/pkg/log"
 )
+
+// hasConverter is an optional interface for packages that support schema version
+// conversion of their settings. Only a subset of packages (module packages with
+// openapi/conversions) implement this.
+type hasConverter interface {
+	GetConverter() *conversion.Converter
+}
 
 const (
 	taskTracer = "configure"
@@ -50,8 +58,9 @@ type packageI interface {
 // On success, sets ConditionSettingsValid to True.
 // On failure, wraps errors with appropriate status conditions.
 type task struct {
-	pkg      packageI
-	settings addonutils.Values
+	pkg             packageI
+	settings        addonutils.Values
+	settingsVersion int
 
 	status *status.Service
 
@@ -59,12 +68,14 @@ type task struct {
 }
 
 // NewTask creates a task that will validate and apply the given settings.
-func NewTask(pkg packageI, settings addonutils.Values, status *status.Service, logger *log.Logger) queue.Task {
+// settingsVersion is the schema version from ModuleConfig.Spec.Version (0 if unset).
+func NewTask(pkg packageI, settings addonutils.Values, settingsVersion int, status *status.Service, logger *log.Logger) queue.Task {
 	return &task{
-		pkg:      pkg,
-		settings: settings,
-		status:   status,
-		logger:   logger.Named(taskTracer).With(slog.String("name", pkg.GetName())),
+		pkg:             pkg,
+		settings:        settings,
+		settingsVersion: settingsVersion,
+		status:          status,
+		logger:          logger.Named(taskTracer).With(slog.String("name", pkg.GetName())),
 	}
 }
 
@@ -90,13 +101,34 @@ func (t *task) Execute(ctx context.Context) error {
 }
 
 // applySettings validates and applies settings to the package.
+// If the package has a converter and settingsVersion > 0, settings are
+// converted to the latest schema version before validation.
 func (t *task) applySettings(ctx context.Context) error {
 	ctx, span := otel.Tracer(taskTracer).Start(ctx, "applySettings")
 	defer span.End()
 
 	t.logger.Debug("configure package")
 
-	res, err := t.pkg.ValidateSettings(ctx, t.settings)
+	settings := t.settings
+
+	// Convert settings to latest schema version if the package supports it
+	if p, ok := t.pkg.(hasConverter); ok && t.settingsVersion > 0 {
+		if conv := p.GetConverter(); conv != nil {
+			newVersion, converted, err := conv.ConvertToLatest(t.settingsVersion, settings)
+			if err != nil {
+				t.logger.Error("failed to convert settings",
+					slog.Int("from_version", t.settingsVersion),
+					slog.String("error", err.Error()))
+				return status.NewError("ConversionFailed", err)
+			}
+			t.logger.Debug("settings converted to latest version",
+				slog.Int("from", t.settingsVersion),
+				slog.Int("to", newVersion))
+			settings = converted
+		}
+	}
+
+	res, err := t.pkg.ValidateSettings(ctx, settings)
 	if err != nil {
 		return status.NewError("ValidateFailed", err)
 	}
@@ -105,7 +137,7 @@ func (t *task) applySettings(ctx context.Context) error {
 		return status.NewError("ValidateFailed", errors.New(res.Message))
 	}
 
-	if err = t.pkg.ApplySettings(t.settings); err != nil {
+	if err = t.pkg.ApplySettings(settings); err != nil {
 		return status.NewError("ConfigureFailed", err)
 	}
 

--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/register.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/register.go
@@ -44,7 +44,7 @@ type moduleStorage interface {
 }
 
 type packageManager interface {
-	ValidatePackageSettings(ctx context.Context, name string, settings addonutils.Values) (settingscheck.Result, error)
+	ValidatePackageSettings(ctx context.Context, name string, settingsVersion int, settings addonutils.Values) (settingscheck.Result, error)
 	CheckConstraints(name string, constraints schedule.Constraints) error
 }
 

--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_application.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_application.go
@@ -56,7 +56,7 @@ func applicationValidationHandler(cli client.Client, manager packageManager) htt
 
 		name := apps.BuildName(app.Namespace, app.Name)
 
-		res, err := manager.ValidatePackageSettings(ctx, name, app.Spec.Settings.GetMap())
+		res, err := manager.ValidatePackageSettings(ctx, name, 0, app.Spec.Settings.GetMap())
 		if err != nil {
 			return nil, err
 		}

--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_application_test.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_application_test.go
@@ -43,7 +43,7 @@ type fakePackageManager struct {
 	gotConstraints schedule.Constraints
 }
 
-func (f *fakePackageManager) ValidatePackageSettings(_ context.Context, _ string, _ addonutils.Values) (settingscheck.Result, error) {
+func (f *fakePackageManager) ValidatePackageSettings(_ context.Context, _ string, _ int, _ addonutils.Values) (settingscheck.Result, error) {
 	return f.validateResult, f.validateErr
 }
 

--- a/deckhouse-controller/pkg/controller/controller.go
+++ b/deckhouse-controller/pkg/controller/controller.go
@@ -489,7 +489,7 @@ func (c *DeckhouseController) loadInitialConfiguration(ctx context.Context) erro
 			continue
 		}
 
-		c.packageRuntime.UpdateModulesSettings(conf.Name, conf.Spec.Settings.GetMap(), conf.Spec.Enabled)
+		c.packageRuntime.UpdateModulesSettings(conf.Name, conf.Spec.Version, conf.Spec.Settings.GetMap(), conf.Spec.Enabled)
 	}
 
 	return nil

--- a/go_lib/configtools/conversion/converter.go
+++ b/go_lib/configtools/conversion/converter.go
@@ -34,7 +34,11 @@ type Converter struct {
 	conversions map[int]string
 }
 
-func newConverter(pathToConversions string) (*Converter, error) {
+// NewConverterFromDir reads conversion files from the given directory
+// and builds a Converter that can transform settings between schema versions.
+// Each file must be named v<N>.yaml and contain a "version" field and
+// a "conversions" list of jq expressions.
+func NewConverterFromDir(pathToConversions string) (*Converter, error) {
 	c := &Converter{conversions: make(map[int]string), latest: 1}
 	conversionsDir, err := os.ReadDir(pathToConversions)
 	if err != nil {
@@ -52,9 +56,6 @@ func newConverter(pathToConversions string) (*Converter, error) {
 			c.latest = v
 		}
 		c.conversions[v] = conversion
-	}
-	if err != nil {
-		return nil, fmt.Errorf("read dir: %w", err)
 	}
 	return c, nil
 }
@@ -142,7 +143,7 @@ func (c *Converter) convert(version int, settings map[string]interface{}) (map[s
 }
 
 func TestConvert(rawSettings, rawExpected, pathToConversions string, currentVersion, version int) error {
-	converter, err := newConverter(pathToConversions)
+	converter, err := NewConverterFromDir(pathToConversions)
 	if err != nil {
 		return err
 	}

--- a/go_lib/configtools/conversion/converter.go
+++ b/go_lib/configtools/conversion/converter.go
@@ -36,7 +36,7 @@ type Converter struct {
 
 // NewConverterFromDir reads conversion files from the given directory
 // and builds a Converter that can transform settings between schema versions.
-// Each file must be named v<N>.yaml and contain a "version" field and
+// Reads any *.yaml file; each file must contain a "version" field and
 // a "conversions" list of jq expressions.
 func NewConverterFromDir(pathToConversions string) (*Converter, error) {
 	c := &Converter{conversions: make(map[int]string), latest: 1}

--- a/go_lib/configtools/conversion/store.go
+++ b/go_lib/configtools/conversion/store.go
@@ -35,7 +35,7 @@ func (s *ConversionsStore) Add(module, pathToConversions string) error {
 		s.converters = make(map[string]*Converter)
 	}
 
-	converter, err := newConverter(pathToConversions)
+	converter, err := NewConverterFromDir(pathToConversions)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

Changes in deckhouse-controller:
1. **Public `NewConverterFromDir`** — constructor in `go_lib/configtools/conversion` for creating `Converter` from `<module>/openapi/conversions/v<N>.yaml` files.
2. **Load conversions per-module** in `packages/loader/loader.go` — `LoadModuleConf` and `LoadEmbeddedConf` read `<module>/openapi/conversions/` and attach a `*Converter` to `modules.Config`.
3. **Store `settingsVersion` in `lifecycle.Store`** — `Package` struct tracks schema version alongside settings; `GetPendingSettings` returns `(Values, int)`.
4. **Apply conversions in configure task** — before validation, `ConvertToLatest(settingsVersion, settings)` transforms settings to the latest schema version using the module own converter.
5. **Wire `settingsVersion` through `UpdateModule` / `UpdateModulesSettings`** — module config controller passes `ModuleConfig.Spec.Version` to the runtime.

## Why do we need it, and what problem does it solve?

Currently, conversions are loaded into a centralized `ConversionsStore` in the old module loader (`pkg/controller/moduleloader/loader.go`) and applied in `confighandler` when reading `ModuleConfig` values. The new packages runtime (`internal/packages/`) has no conversion support — settings with non-latest schema versions would fail OpenAPI validation or silently produce incorrect values.

This change moves conversions to be per-module: each module carries its own `*Converter`, loaded at package-load time and applied in the configure task right before validation. The centralized `ConversionsStore` remains for backward compatibility with the old module-controller path.

## Example

### Module with conversions (e.g., `control-plane-manager`)

Module directory:
```
modules/040-control-plane-manager/
├── openapi/
│   ├── config-values.yaml
│   └── conversions/
│       └── v3.yaml
```

`v3.yaml`:
```yaml
version: 3
conversions:
  - if .apiserver.loadBalancer != null then .apiserver.publishAPI.loadBalancer.enabled = true end
  - del(.apiserver.loadBalancer)
```

**Before** (settings with version=2):
```yaml
apiserver:
  loadBalancer:
    port: 443
```

**After** (converted to latest version=3):
```yaml
apiserver:
  publishAPI:
    loadBalancer:
      enabled: true
      port: 443
```

### Module without conversions

If `openapi/conversions/` does not exist, `loadConversions` returns `nil` — configure task skips the conversion step and validates settings as-is.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: feature
summary: Load per-module schema conversions in the packages runtime and apply them in the configure task.
impact_level: low
```