### PR TITLE
[deckhouse] Add missing VEX entry for CVE-2026-45570 in d8 image

### DIFF
--- a/modules/007-registrypackages/images/d8/known_vulnerabilities.vex
+++ b/modules/007-registrypackages/images/d8/known_vulnerabilities.vex
@@ -2,7 +2,7 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-7c114e6cee1182ff2b165cba363ae5cfbf773e4da8518c90d80049d24c627e94",
   "author": "Deckhouse Deckhouse <contact@deckhouse.io>",
-  "version": 17,
+  "version": 18,
   "statements": [
     {
       "vulnerability": {
@@ -624,6 +624,20 @@
     },
     {
       "vulnerability": {
+        "name": "CVE-2026-45570"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/go-git/go-git/v5@v5.16.2"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Уязвимость github.com/go-git/go-git/v5 v5.16.2 проявляется при обработке вредоносных Git-данных из недоверенного источника, недостижимых в штатных операциях d8.",
+      "timestamp": "2026-06-30T12:00:00Z"
+    },
+    {
+      "vulnerability": {
         "name": "GHSA-w5pp-99ch-qj29"
       },
       "products": [
@@ -638,5 +652,5 @@
     }
   ],
   "timestamp": "2025-10-09T14:21:14Z",
-  "last_updated": "2026-06-24T12:00:00Z"
+  "last_updated": "2026-06-30T12:00:00Z"
 }


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Add missing VEX entry for CVE-2026-45570 (github.com/go-git/go-git/v5) in the d8 image.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
After the VEX batch in #20872 one finding remained for the d8 image: CVE-2026-45570 on `github.com/go-git/go-git/v5` v5.16.2. The same `not_affected` statement already exists for the web image but was missing for d8. Not exploitable: go-git is only reachable via the `d8 delivery-kit` subcommand when processing malicious Git data from an untrusted source, which does not occur in normal d8 operations.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: Add missing VEX entry for CVE-2026-45570 in the d8 image.
impact_level: low
```
