### PR TITLE
[docs] Fix broken-link "Enabling the Module via CLI"

### DIFF
--- a/docs/site/_includes/getting_started/stronghold/existing-dkp/ENABLE.md
+++ b/docs/site/_includes/getting_started/stronghold/existing-dkp/ENABLE.md
@@ -5,7 +5,7 @@ To install Deckhouse Stronghold, enable the stronghold module. The module can be
 
 ## Enabling the Module via CLI
 
-On a host with access to the DKP cluster, execute the following command using the [Deckhouse CLI](/products/stronghold/reference/cli/d8/):
+On a host with access to the DKP cluster, execute the following command using the [Deckhouse CLI](/products/kubernetes-platform/documentation/v1/cli/d8/):
 
 ```bash
 d8 system module enable stronghold

--- a/docs/site/_includes/getting_started/stronghold/existing-dkp/ENABLE_RU.md
+++ b/docs/site/_includes/getting_started/stronghold/existing-dkp/ENABLE_RU.md
@@ -12,7 +12,7 @@
 
 ## Включение модуля через CLI
 
-На хосте, имеющем доступ к кластеру DKP, выполните следующую команду, используя утилиту [Deckhouse CLI](/products/stronghold/reference/cli/d8/):
+На хосте, имеющем доступ к кластеру DKP, выполните следующую команду, используя утилиту [Deckhouse CLI](/products/kubernetes-platform/documentation/v1/cli/d8/):
 
 ```bash
 d8 system module enable stronghold


### PR DESCRIPTION
## Description
Page :https://deckhouse.io/products/stronghold/gs/existing-dkp/step2.html
Broken-link https://deckhouse.io/products/stronghold/reference/cli/d8/

## Why do we need it, and what problem does it solve?

## Why do we need it in the patch release (if we do)?

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: fix 
summary: Fix broken-link
impact_level: low
```

