### PR TITLE
[ci] AV scan only changed images in PR

### DIFF
--- a/.github/ci_templates/antivirus_tests.yml
+++ b/.github/ci_templates/antivirus_tests.yml
@@ -1,19 +1,26 @@
 {!{ define "av_semver_regexp" }!}^v?[0-9]+.[0-9]+.[0-9]+${!{ end }!}
 
-{!{ define "av_scan_step" }!}
+  {!{ define "av_scan_step" }!}
 - name: Run {!{ .container_name }!} scan
   id: scan
   {!{- if .only_images_expr }!}
   env:
     # `ONLY_IMAGES` comes from needs.changed_images.outputs.changed_compact
-    # (JSON array of "<module>.<image>" keys). Wired here for PR runs of both
-    # drweb-scan and kaspersky-scan when their templates are called with
-    # `withChangedImages: true` (see security-scan-images.yml). In weekly /
-    # release runs the templates pass empty `only_images_expr`, so this env
-    # block is omitted and the Go scanner falls back to full-scan.
-    # Empty value / "[]" is treated by the Go scanner as full-scan, so the
-    # bash side does not need to branch on it.
+    # (JSON array of "<module>.<image>" keys from images_digests.json).
+    # Wired here for PR runs of both drweb-scan and kaspersky-scan when their
+    # templates are called with `withChangedImages: true`
+    # (see security-scan-images.yml).
+    #
+    # `CHANGED_COUNT` is the total number of rebuilt final images from
+    # changed_images.py, including non-module/static images that do not have
+    # compact keys in images_digests.json.
+    #
+    # If CHANGED_COUNT is 0, there is nothing to scan.
+    # If CHANGED_COUNT is greater than 0 but ONLY_IMAGES is empty, run a full
+    # scan fallback to cover static/non-module images.
+    # Weekly / release runs do not pass these envs and still run full-scan.
     ONLY_IMAGES: {!{ .only_images_expr }!}
+    CHANGED_COUNT: {!{ .changed_count_expr }!}
   {!{- end }!}
   run: |
     registry_image_path=/sys/deckhouse-oss
@@ -43,20 +50,36 @@
     SCAN_DIR=/opt/actions-runners/scans/{!{ .container_name }!}
     echo "scan_id=${SCAN_ID}" >> $GITHUB_OUTPUT
     echo "scan_dir=${SCAN_DIR}" >> $GITHUB_OUTPUT
+    echo "skipped=false" >> $GITHUB_OUTPUT
     echo $CONTAINER_NAME
     {!{- if .only_images_expr }!}
     echo "----------------------------------------------"
-    if [[ -n "${ONLY_IMAGES:-}" ]] && [[ "${ONLY_IMAGES}" != "[]" ]]; then
+    if [[ -z "${ONLY_IMAGES:-}" || "${ONLY_IMAGES}" == "[]" || "${ONLY_IMAGES}" == "null" ]]; then
+      if [[ "${CHANGED_COUNT:-0}" == "0" ]]; then
+        echo "Skip {!{ .container_name }!} scan: no rebuilt images in this PR. Nothing to scan."
+        echo "skipped=true" >> "$GITHUB_OUTPUT"
+        echo "----------------------------------------------"
+        exit 0
+      fi
+
+      echo "Changed images detected (${CHANGED_COUNT}), but no module compact keys found."
+      echo "Run full {!{ .container_name }!} scan fallback to cover static/non-module images."
+      unset ONLY_IMAGES
+    else
       keys_count=$(jq -r 'length' <<< "${ONLY_IMAGES}")
       echo "🎯 Delta-scan: forwarding ONLY_IMAGES (${keys_count} key(s)) to the {!{ .container_name }!} scanner."
       jq -r '.[] | "    • " + .' <<< "${ONLY_IMAGES}"
-    else
-      echo "📋 Full-scan: ONLY_IMAGES is empty (no delta in this PR)."
     fi
     echo "----------------------------------------------"
+
     {!{- end }!}
-    docker exec -e ONLY_IMAGES="${ONLY_IMAGES:-}" ${CONTAINER_NAME} \
-      scanner "${ref}" "${registry_host}${registry_image_path}" "${SCAN_ID}"
+    if [[ -n "${ONLY_IMAGES:-}" ]]; then
+      docker exec -e ONLY_IMAGES="${ONLY_IMAGES}" ${CONTAINER_NAME} \
+        scanner "${ref}" "${registry_host}${registry_image_path}" "${SCAN_ID}"
+    else
+      docker exec ${CONTAINER_NAME} \
+        scanner "${ref}" "${registry_host}${registry_image_path}" "${SCAN_ID}"
+    fi
     # Drop container-uid ownership so the host-side Upload/Cleanup steps below
     # (and the `${SCAN_DIR}/.../scan_results_threats.md` read just below) can
     # touch the bind-mounted scan artifacts under the runner's UID (this step
@@ -83,7 +106,7 @@
     echo "✅ ${CONTAINER_NAME} scan completed for ${{ matrix.branch }}"
 
 - name: Upload scan artifacts
-  if: github.repository == 'deckhouse/deckhouse' && always()
+  if: github.repository == 'deckhouse/deckhouse' && always() && steps.scan.outputs.skipped != 'true'
   uses: {!{ index (ds "actions") "actions/upload-artifact" }!}
   with:
     name: {!{ .container_name }!}-scan-results-${{ steps.scan.outputs.scan_id }}
@@ -103,110 +126,114 @@
     if [[ -d ${SCAN_DIR}/${SCAN_ID} ]]; then
       rm -rf ${SCAN_DIR}/${SCAN_ID} || true
     fi
-{!{ end }!}
+  {!{ end }!}
 
-{!{ define "drweb_scan_job" }!}
-{!{ $ctx := . -}!}
-{!{ $withChangedImages := false -}!}
-{!{ if coll.Has $ctx "withChangedImages" -}!}
-{!{   $withChangedImages = (index $ctx "withChangedImages") -}!}
-{!{ end -}!}
-# <template: drweb_scan_job>
+  {!{ define "drweb_scan_job" }!}
+  {!{ $ctx := . -}!}
+  {!{ $withChangedImages := false -}!}
+  {!{ if coll.Has $ctx "withChangedImages" -}!}
+  {!{   $withChangedImages = (index $ctx "withChangedImages") -}!}
+  {!{ end -}!}
+  # <template: drweb_scan_job>
 drweb-scan:
   name: Dr.Web Scan ${{ matrix.branch }}
   runs-on: [self-hosted, antivirus]
-  if: ${{ false }}
-{!{- if $withChangedImages }!}
-  # PR mode: filter scanned images by the changed_images diff (delta-only scan).
-  needs: [get-tags, changed_images]
-{!{- else }!}
+  if: github.repository == 'deckhouse/deckhouse'
+  {!{- if $withChangedImages }!}
+needs: [changed_images, get-tags]
+  {!{- else }!}
   # Weekly/release mode: no changed_images upstream; full-scan every matrix entry.
-  needs: [get-tags]
-{!{- end }!}
-  strategy:
-    matrix:
-      branch: ${{ fromJson(needs.get-tags.outputs.tags) }}
-    fail-fast: false
-  permissions:
-    id-token: write
-  outputs:
-    scan_id: ${{ steps.scan.outputs.scan_id }}
-  steps:
-    {!{- $secrets := slice -}!}
-    {!{- $secrets = append ( slice "projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/registry_host" "DECKHOUSE_DEV_REGISTRY_HOST" "DECKHOUSE_DEV_REGISTRY_HOST" ) $secrets -}!}
-    {!{- $secrets = append ( slice "projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/registry_host" "DECKHOUSE_REGISTRY_STAGE_HOST" "DECKHOUSE_STAGE_REGISTRY_HOST" ) $secrets -}!}
-    {!{ tmpl.Exec "import_secrets" $secrets | strings.Indent 4 }!}
+needs: [get-tags]
+  {!{- end }!}
+strategy:
+  matrix:
+    branch: ${{ fromJson(needs.get-tags.outputs.tags) }}
+  fail-fast: false
+permissions:
+  id-token: write
+outputs:
+  scan_id: ${{ steps.scan.outputs.scan_id }}
+  skipped: ${{ steps.scan.outputs.skipped }}
+steps:
+  {!{- $secrets := slice -}!}
+  {!{- $secrets = append ( slice "projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/registry_host" "DECKHOUSE_DEV_REGISTRY_HOST" "DECKHOUSE_DEV_REGISTRY_HOST" ) $secrets -}!}
+  {!{- $secrets = append ( slice "projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/registry_host" "DECKHOUSE_REGISTRY_STAGE_HOST" "DECKHOUSE_STAGE_REGISTRY_HOST" ) $secrets -}!}
+  {!{ tmpl.Exec "import_secrets" $secrets | strings.Indent 4 }!}
 
-    {!{- $args := dict
-        "container_name"      "drweb"
-        "scan_path"           "drweb"
-        "only_images_expr"    ""
+  {!{- $args := dict
+         "container_name"      "drweb"
+         "scan_path"           "drweb"
+         "only_images_expr"    ""
+         "changed_count_expr"  ""
     -}!}
-{!{- if $withChangedImages -}!}
-    {!{- $args = dict
-        "container_name"      "drweb"
-        "scan_path"           "drweb"
-        "only_images_expr"    "${{ needs.changed_images.outputs.changed_compact }}"
+  {!{- if $withChangedImages -}!}
+  {!{- $args = dict
+         "container_name"      "drweb"
+         "scan_path"           "drweb"
+         "only_images_expr"    "${{ needs.changed_images.outputs.changed_compact }}"
+         "changed_count_expr"  "${{ needs.changed_images.outputs.changed_count }}"
     -}!}
-{!{- end }!}
-    {!{ tmpl.Exec "av_scan_step" $args | strings.Indent 4 }!}
-# </template: drweb_scan_job>
-{!{ end }!}
+  {!{- end }!}
+  {!{ tmpl.Exec "av_scan_step" $args | strings.Indent 4 }!}
+  # </template: drweb_scan_job>
+  {!{ end }!}
 
-{!{ define "kaspersky_scan_job" }!}
-{!{ $ctx := . -}!}
-{!{ $withChangedImages := false -}!}
-{!{ if coll.Has $ctx "withChangedImages" -}!}
-{!{   $withChangedImages = (index $ctx "withChangedImages") -}!}
-{!{ end -}!}
-# <template: kaspersky_scan_job>
+  {!{ define "kaspersky_scan_job" }!}
+  {!{ $ctx := . -}!}
+  {!{ $withChangedImages := false -}!}
+  {!{ if coll.Has $ctx "withChangedImages" -}!}
+  {!{   $withChangedImages = (index $ctx "withChangedImages") -}!}
+  {!{ end -}!}
+  # <template: kaspersky_scan_job>
 kaspersky-scan:
   name: Kaspersky Scan ${{ matrix.branch }}
   runs-on: [self-hosted, antivirus]
-  if: ${{ false }}
-{!{- if $withChangedImages }!}
-  # PR mode: filter scanned images by the changed_images diff (delta-only scan).
-  needs: [get-tags, changed_images]
-{!{- else }!}
+  if: github.repository == 'deckhouse/deckhouse'
+  {!{- if $withChangedImages }!}
+needs: [changed_images, get-tags]
+  {!{- else }!}
   # Weekly/release mode: no changed_images upstream; full-scan every matrix entry.
-  needs: [get-tags]
-{!{- end }!}
-  strategy:
-    matrix:
-      branch: ${{ fromJson(needs.get-tags.outputs.tags) }}
-    fail-fast: false
-  permissions:
-    id-token: write
-  outputs:
-    scan_id: ${{ steps.scan.outputs.scan_id }}
-  steps:
-    {!{- $secrets := slice -}!}
-    {!{- $secrets = append ( slice "projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/registry_host" "DECKHOUSE_DEV_REGISTRY_HOST" "DECKHOUSE_DEV_REGISTRY_HOST" ) $secrets -}!}
-    {!{- $secrets = append ( slice "projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/registry_host" "DECKHOUSE_REGISTRY_STAGE_HOST" "DECKHOUSE_STAGE_REGISTRY_HOST" ) $secrets -}!}
-    {!{ tmpl.Exec "import_secrets" $secrets | strings.Indent 4 }!}
+needs: [get-tags]
+  {!{- end }!}
+strategy:
+  matrix:
+    branch: ${{ fromJson(needs.get-tags.outputs.tags) }}
+  fail-fast: false
+permissions:
+  id-token: write
+outputs:
+  scan_id: ${{ steps.scan.outputs.scan_id }}
+  skipped: ${{ steps.scan.outputs.skipped }}
+steps:
+  {!{- $secrets := slice -}!}
+  {!{- $secrets = append ( slice "projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/registry_host" "DECKHOUSE_DEV_REGISTRY_HOST" "DECKHOUSE_DEV_REGISTRY_HOST" ) $secrets -}!}
+  {!{- $secrets = append ( slice "projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/registry_host" "DECKHOUSE_REGISTRY_STAGE_HOST" "DECKHOUSE_STAGE_REGISTRY_HOST" ) $secrets -}!}
+  {!{ tmpl.Exec "import_secrets" $secrets | strings.Indent 4 }!}
 
-    {!{- $args := dict
-        "container_name"    "kaspersky"
-        "scan_path"         "antivirus"
-        "only_images_expr"  ""
+  {!{- $args := dict
+         "container_name"      "kaspersky"
+         "scan_path"           "antivirus"
+         "only_images_expr"    ""
+         "changed_count_expr"  ""
     -}!}
-{!{- if $withChangedImages -}!}
-    {!{- $args = dict
-        "container_name"    "kaspersky"
-        "scan_path"         "antivirus"
-        "only_images_expr"  "${{ needs.changed_images.outputs.changed_compact }}"
+  {!{- if $withChangedImages -}!}
+  {!{- $args = dict
+         "container_name"      "kaspersky"
+         "scan_path"           "antivirus"
+         "only_images_expr"    "${{ needs.changed_images.outputs.changed_compact }}"
+         "changed_count_expr"  "${{ needs.changed_images.outputs.changed_count }}"
     -}!}
-{!{- end }!}
-    {!{ tmpl.Exec "av_scan_step" $args | strings.Indent 4 }!}
-# </template: kaspersky_scan_job>
-{!{ end }!}
+  {!{- end }!}
+  {!{ tmpl.Exec "av_scan_step" $args | strings.Indent 4 }!}
+  # </template: kaspersky_scan_job>
+  {!{ end }!}
 
-{!{ define "set_security_antivirus_requirement_status" }!}
-# <template: set_security_antivirus_requirement_status>
+  {!{ define "set_security_antivirus_requirement_status" }!}
+  # <template: set_security_antivirus_requirement_status>
 set_security_antivirus_requirement_status:
   name: Set commit status after antivirus scan run
   runs-on: "self-slim"
-  needs: [drweb-scan, kaspersky-scan]
+  needs: [changed_images, drweb-scan, kaspersky-scan]
   if: ${{ always() }}
   permissions:
     contents: read
@@ -220,22 +247,34 @@ set_security_antivirus_requirement_status:
       env:
         PR_NUMBER: ${{ github.event.pull_request.number }}
         GH_REPO: ${{ github.repository }}
+        CHANGED_COUNT: ${{ needs.changed_images.outputs.changed_count }}
         DRWEB: ${{ needs.drweb-scan.result }}
         KASPERSKY: ${{ needs.kaspersky-scan.result }}
       run: |
-        echo "PR Number: $PR_NUMBER | Dr.Web: $DRWEB | Kaspersky: $KASPERSKY"
-        if [ "$DRWEB" == "success" ] && [ "$KASPERSKY" == "success" ]; then
-          gh pr edit "$PR_NUMBER" --add-label "security/antivirus/success" --remove-label "security/antivirus/failed"
-        elif [ "$DRWEB" == "skipped" ] && [ "$KASPERSKY" == "skipped" ]; then
+        echo "PR Number: $PR_NUMBER | changed_count=$CHANGED_COUNT | Dr.Web: $DRWEB | Kaspersky: $KASPERSKY"
+
+        if [[ "$GH_REPO" != "deckhouse/deckhouse" && "$DRWEB" == "skipped" && "$KASPERSKY" == "skipped" ]]; then
+          echo "Both antivirus scans were skipped in test repository. Antivirus labels are not set."
           gh pr edit "$PR_NUMBER" --remove-label "security/antivirus/success" --remove-label "security/antivirus/failed"
+          exit 0
+        fi
+
+        if [[ "${CHANGED_COUNT:-0}" == "0" ]]; then
+          echo "No rebuilt images in this PR. Antivirus labels are not set."
+          gh pr edit "$PR_NUMBER" --remove-label "security/antivirus/success" --remove-label "security/antivirus/failed"
+          exit 0
+        fi
+
+        if [[ "$DRWEB" == "success" && "$KASPERSKY" == "success" ]]; then
+          gh pr edit "$PR_NUMBER" --add-label "security/antivirus/success" --remove-label "security/antivirus/failed"
         else
           gh pr edit "$PR_NUMBER" --add-label "security/antivirus/failed" --remove-label "security/antivirus/success"
         fi
-# </template: set_security_antivirus_requirement_status>
-{!{- end -}!}
+  # </template: set_security_antivirus_requirement_status>
+  {!{- end -}!}
 
-{!{ define "antivirus_notify_failure_job" }!}
-# <template: antivirus_notify_failure_job>
+  {!{ define "antivirus_notify_failure_job" }!}
+  # <template: antivirus_notify_failure_job>
 notify-failure:
   name: Send failure notification
   runs-on: [self-hosted, regular]
@@ -244,41 +283,41 @@ notify-failure:
   permissions:
     id-token: write
   steps:
-    {!{- $secrets := slice -}!}
-    {!{- $secrets = append ( slice "projects/data/b050f3bd-733f-4746-9640-9df80d484074/n8n_jobs_fails_url" "N8N_LOOP_NOTIFIER_URL" "N8N_LOOP_NOTIFIER_URL" ) $secrets -}!}
-    {!{ tmpl.Exec "import_secrets" $secrets | strings.Indent 4 }!}
+  {!{- $secrets := slice -}!}
+  {!{- $secrets = append ( slice "projects/data/b050f3bd-733f-4746-9640-9df80d484074/n8n_jobs_fails_url" "N8N_LOOP_NOTIFIER_URL" "N8N_LOOP_NOTIFIER_URL" ) $secrets -}!}
+  {!{ tmpl.Exec "import_secrets" $secrets | strings.Indent 4 }!}
 
-    - name: Check which jobs failed
-      id: check-failures
-      run: |
-        FAILED_JOBS=""
-        if [[ "${{ needs.drweb-scan.result }}" == "failure" ]]; then
-          FAILED_JOBS="$FAILED_JOBS• Dr.Web Scan\n"
-        fi
-        if [[ "${{ needs.kaspersky-scan.result }}" == "failure" ]]; then
-          FAILED_JOBS="$FAILED_JOBS• Kaspersky Scan\n"
-        fi
+- name: Check which jobs failed
+  id: check-failures
+  run: |
+    FAILED_JOBS=""
+    if [[ "${{ needs.drweb-scan.result }}" == "failure" ]]; then
+      FAILED_JOBS="$FAILED_JOBS• Dr.Web Scan\n"
+    fi
+    if [[ "${{ needs.kaspersky-scan.result }}" == "failure" ]]; then
+      FAILED_JOBS="$FAILED_JOBS• Kaspersky Scan\n"
+    fi
 
-        echo "failed_jobs=${FAILED_JOBS}" >> $GITHUB_OUTPUT
-        echo "Failed jobs:"
-        echo "${FAILED_JOBS}"
+    echo "failed_jobs=${FAILED_JOBS}" >> $GITHUB_OUTPUT
+    echo "Failed jobs:"
+    echo "${FAILED_JOBS}"
 
-    - name: Send notification
-      run: |
-        workflow_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+- name: Send notification
+  run: |
+    workflow_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
-        MESSAGE="🛑 Github Antivirus Scan Failed!\n\n"
-        MESSAGE+="**Failed jobs:**\n"
-        MESSAGE+="${{ steps.check-failures.outputs.failed_jobs }}\n"
-        PR_NUMBER="${{ github.event.pull_request.number }}"
-        if [ -n "$PR_NUMBER" ]; then
-          pr_url="https://github.com/${{ github.repository }}/pull/${PR_NUMBER}"
-          MESSAGE+="**PR:** [#${PR_NUMBER}]($pr_url)\n"
-        fi
-        MESSAGE+="**Workflow URL:** [View Run]($workflow_url)\n"
+    MESSAGE="🛑 Github Antivirus Scan Failed!\n\n"
+    MESSAGE+="**Failed jobs:**\n"
+    MESSAGE+="${{ steps.check-failures.outputs.failed_jobs }}\n"
+    PR_NUMBER="${{ github.event.pull_request.number }}"
+    if [ -n "$PR_NUMBER" ]; then
+      pr_url="https://github.com/${{ github.repository }}/pull/${PR_NUMBER}"
+      MESSAGE+="**PR:** [#${PR_NUMBER}]($pr_url)\n"
+    fi
+    MESSAGE+="**Workflow URL:** [View Run]($workflow_url)\n"
 
-        curl -f -L -X POST "${{ steps.secrets.outputs.N8N_LOOP_NOTIFIER_URL }}" \
-          -H "Content-Type: application/json" \
-          --data "{\"type\": \"ci_fail\",\"message\":\"$MESSAGE\"}"
-# </template: antivirus_notify_failure_job>
-{!{ end }!}
+    curl -f -L -X POST "${{ steps.secrets.outputs.N8N_LOOP_NOTIFIER_URL }}" \
+      -H "Content-Type: application/json" \
+      --data "{\"type\": \"ci_fail\",\"message\":\"$MESSAGE\"}"
+  # </template: antivirus_notify_failure_job>
+  {!{ end }!}

--- a/.github/ci_templates/antivirus_tests.yml
+++ b/.github/ci_templates/antivirus_tests.yml
@@ -1,6 +1,6 @@
 {!{ define "av_semver_regexp" }!}^v?[0-9]+.[0-9]+.[0-9]+${!{ end }!}
 
-  {!{ define "av_scan_step" }!}
+{!{ define "av_scan_step" }!}
 - name: Run {!{ .container_name }!} scan
   id: scan
   {!{- if .only_images_expr }!}
@@ -126,110 +126,112 @@
     if [[ -d ${SCAN_DIR}/${SCAN_ID} ]]; then
       rm -rf ${SCAN_DIR}/${SCAN_ID} || true
     fi
-  {!{ end }!}
+{!{ end }!}
 
-  {!{ define "drweb_scan_job" }!}
-  {!{ $ctx := . -}!}
-  {!{ $withChangedImages := false -}!}
-  {!{ if coll.Has $ctx "withChangedImages" -}!}
-  {!{   $withChangedImages = (index $ctx "withChangedImages") -}!}
-  {!{ end -}!}
-  # <template: drweb_scan_job>
+{!{ define "drweb_scan_job" }!}
+{!{ $ctx := . -}!}
+{!{ $withChangedImages := false -}!}
+{!{ if coll.Has $ctx "withChangedImages" -}!}
+{!{   $withChangedImages = (index $ctx "withChangedImages") -}!}
+{!{ end -}!}
+# <template: drweb_scan_job>
 drweb-scan:
-  name: Dr.Web Scan ${{ matrix.branch }}
+  name: Dr.Web Scan
   runs-on: [self-hosted, antivirus]
   if: github.repository == 'deckhouse/deckhouse'
-  {!{- if $withChangedImages }!}
-needs: [changed_images, get-tags]
-  {!{- else }!}
+{!{- if $withChangedImages }!}
+  # PR mode: filter scanned images by the changed_images diff (delta-only scan).
+  needs: [get-tags, changed_images]
+{!{- else }!}
   # Weekly/release mode: no changed_images upstream; full-scan every matrix entry.
-needs: [get-tags]
-  {!{- end }!}
-strategy:
-  matrix:
-    branch: ${{ fromJson(needs.get-tags.outputs.tags) }}
-  fail-fast: false
-permissions:
-  id-token: write
-outputs:
-  scan_id: ${{ steps.scan.outputs.scan_id }}
-  skipped: ${{ steps.scan.outputs.skipped }}
-steps:
-  {!{- $secrets := slice -}!}
-  {!{- $secrets = append ( slice "projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/registry_host" "DECKHOUSE_DEV_REGISTRY_HOST" "DECKHOUSE_DEV_REGISTRY_HOST" ) $secrets -}!}
-  {!{- $secrets = append ( slice "projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/registry_host" "DECKHOUSE_REGISTRY_STAGE_HOST" "DECKHOUSE_STAGE_REGISTRY_HOST" ) $secrets -}!}
-  {!{ tmpl.Exec "import_secrets" $secrets | strings.Indent 4 }!}
+  needs: [get-tags]
+{!{- end }!}
+  strategy:
+    matrix:
+      branch: ${{ fromJson(needs.get-tags.outputs.tags) }}
+    fail-fast: false
+  permissions:
+    id-token: write
+  outputs:
+    scan_id: ${{ steps.scan.outputs.scan_id }}
+    skipped: ${{ steps.scan.outputs.skipped }}
+  steps:
+    {!{- $secrets := slice -}!}
+    {!{- $secrets = append ( slice "projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/registry_host" "DECKHOUSE_DEV_REGISTRY_HOST" "DECKHOUSE_DEV_REGISTRY_HOST" ) $secrets -}!}
+    {!{- $secrets = append ( slice "projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/registry_host" "DECKHOUSE_REGISTRY_STAGE_HOST" "DECKHOUSE_STAGE_REGISTRY_HOST" ) $secrets -}!}
+    {!{ tmpl.Exec "import_secrets" $secrets | strings.Indent 4 }!}
 
-  {!{- $args := dict
-         "container_name"      "drweb"
-         "scan_path"           "drweb"
-         "only_images_expr"    ""
-         "changed_count_expr"  ""
+    {!{- $args := dict
+        "container_name"      "drweb"
+        "scan_path"           "drweb"
+        "only_images_expr"    ""
+        "changed_count_expr"  ""
     -}!}
-  {!{- if $withChangedImages -}!}
-  {!{- $args = dict
-         "container_name"      "drweb"
-         "scan_path"           "drweb"
-         "only_images_expr"    "${{ needs.changed_images.outputs.changed_compact }}"
-         "changed_count_expr"  "${{ needs.changed_images.outputs.changed_count }}"
+{!{- if $withChangedImages -}!}
+    {!{- $args = dict
+        "container_name"      "drweb"
+        "scan_path"           "drweb"
+        "only_images_expr"    "${{ needs.changed_images.outputs.changed_compact }}"
+        "changed_count_expr"  "${{ needs.changed_images.outputs.changed_count }}"
     -}!}
-  {!{- end }!}
-  {!{ tmpl.Exec "av_scan_step" $args | strings.Indent 4 }!}
-  # </template: drweb_scan_job>
-  {!{ end }!}
+{!{- end }!}
+    {!{ tmpl.Exec "av_scan_step" $args | strings.Indent 4 }!}
+# </template: drweb_scan_job>
+{!{ end }!}
 
-  {!{ define "kaspersky_scan_job" }!}
-  {!{ $ctx := . -}!}
-  {!{ $withChangedImages := false -}!}
-  {!{ if coll.Has $ctx "withChangedImages" -}!}
-  {!{   $withChangedImages = (index $ctx "withChangedImages") -}!}
-  {!{ end -}!}
-  # <template: kaspersky_scan_job>
+{!{ define "kaspersky_scan_job" }!}
+{!{ $ctx := . -}!}
+{!{ $withChangedImages := false -}!}
+{!{ if coll.Has $ctx "withChangedImages" -}!}
+{!{   $withChangedImages = (index $ctx "withChangedImages") -}!}
+{!{ end -}!}
+# <template: kaspersky_scan_job>
 kaspersky-scan:
-  name: Kaspersky Scan ${{ matrix.branch }}
+  name: Kaspersky Scan
   runs-on: [self-hosted, antivirus]
   if: github.repository == 'deckhouse/deckhouse'
-  {!{- if $withChangedImages }!}
-needs: [changed_images, get-tags]
-  {!{- else }!}
+{!{- if $withChangedImages }!}
+  # PR mode: filter scanned images by the changed_images diff (delta-only scan).
+  needs: [get-tags, changed_images]
+{!{- else }!}
   # Weekly/release mode: no changed_images upstream; full-scan every matrix entry.
-needs: [get-tags]
-  {!{- end }!}
-strategy:
-  matrix:
-    branch: ${{ fromJson(needs.get-tags.outputs.tags) }}
-  fail-fast: false
-permissions:
-  id-token: write
-outputs:
-  scan_id: ${{ steps.scan.outputs.scan_id }}
-  skipped: ${{ steps.scan.outputs.skipped }}
-steps:
-  {!{- $secrets := slice -}!}
-  {!{- $secrets = append ( slice "projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/registry_host" "DECKHOUSE_DEV_REGISTRY_HOST" "DECKHOUSE_DEV_REGISTRY_HOST" ) $secrets -}!}
-  {!{- $secrets = append ( slice "projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/registry_host" "DECKHOUSE_REGISTRY_STAGE_HOST" "DECKHOUSE_STAGE_REGISTRY_HOST" ) $secrets -}!}
-  {!{ tmpl.Exec "import_secrets" $secrets | strings.Indent 4 }!}
+  needs: [get-tags]
+{!{- end }!}
+  strategy:
+    matrix:
+      branch: ${{ fromJson(needs.get-tags.outputs.tags) }}
+    fail-fast: false
+  permissions:
+    id-token: write
+  outputs:
+    scan_id: ${{ steps.scan.outputs.scan_id }}
+    skipped: ${{ steps.scan.outputs.skipped }}
+  steps:
+    {!{- $secrets := slice -}!}
+    {!{- $secrets = append ( slice "projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/registry_host" "DECKHOUSE_DEV_REGISTRY_HOST" "DECKHOUSE_DEV_REGISTRY_HOST" ) $secrets -}!}
+    {!{- $secrets = append ( slice "projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/registry_host" "DECKHOUSE_REGISTRY_STAGE_HOST" "DECKHOUSE_STAGE_REGISTRY_HOST" ) $secrets -}!}
+    {!{ tmpl.Exec "import_secrets" $secrets | strings.Indent 4 }!}
 
-  {!{- $args := dict
-         "container_name"      "kaspersky"
-         "scan_path"           "antivirus"
-         "only_images_expr"    ""
-         "changed_count_expr"  ""
+    {!{- $args := dict
+        "container_name"      "kaspersky"
+        "scan_path"           "antivirus"
+        "only_images_expr"    ""
+        "changed_count_expr"  ""
     -}!}
-  {!{- if $withChangedImages -}!}
-  {!{- $args = dict
-         "container_name"      "kaspersky"
-         "scan_path"           "antivirus"
-         "only_images_expr"    "${{ needs.changed_images.outputs.changed_compact }}"
-         "changed_count_expr"  "${{ needs.changed_images.outputs.changed_count }}"
+{!{- if $withChangedImages -}!}
+    {!{- $args = dict
+        "container_name"      "kaspersky"
+        "scan_path"           "antivirus"
+        "only_images_expr"    "${{ needs.changed_images.outputs.changed_compact }}"
+        "changed_count_expr"  "${{ needs.changed_images.outputs.changed_count }}"
     -}!}
-  {!{- end }!}
-  {!{ tmpl.Exec "av_scan_step" $args | strings.Indent 4 }!}
-  # </template: kaspersky_scan_job>
-  {!{ end }!}
+{!{- end }!}
+    {!{ tmpl.Exec "av_scan_step" $args | strings.Indent 4 }!}
+# </template: kaspersky_scan_job>
+{!{ end }!}
 
-  {!{ define "set_security_antivirus_requirement_status" }!}
-  # <template: set_security_antivirus_requirement_status>
+{!{ define "set_security_antivirus_requirement_status" }!}
+# <template: set_security_antivirus_requirement_status>
 set_security_antivirus_requirement_status:
   name: Set commit status after antivirus scan run
   runs-on: "self-slim"
@@ -270,11 +272,11 @@ set_security_antivirus_requirement_status:
         else
           gh pr edit "$PR_NUMBER" --add-label "security/antivirus/failed" --remove-label "security/antivirus/success"
         fi
-  # </template: set_security_antivirus_requirement_status>
-  {!{- end -}!}
+# </template: set_security_antivirus_requirement_status>
+{!{- end -}!}
 
-  {!{ define "antivirus_notify_failure_job" }!}
-  # <template: antivirus_notify_failure_job>
+{!{ define "antivirus_notify_failure_job" }!}
+# <template: antivirus_notify_failure_job>
 notify-failure:
   name: Send failure notification
   runs-on: [self-hosted, regular]
@@ -283,41 +285,41 @@ notify-failure:
   permissions:
     id-token: write
   steps:
-  {!{- $secrets := slice -}!}
-  {!{- $secrets = append ( slice "projects/data/b050f3bd-733f-4746-9640-9df80d484074/n8n_jobs_fails_url" "N8N_LOOP_NOTIFIER_URL" "N8N_LOOP_NOTIFIER_URL" ) $secrets -}!}
-  {!{ tmpl.Exec "import_secrets" $secrets | strings.Indent 4 }!}
+    {!{- $secrets := slice -}!}
+    {!{- $secrets = append ( slice "projects/data/b050f3bd-733f-4746-9640-9df80d484074/n8n_jobs_fails_url" "N8N_LOOP_NOTIFIER_URL" "N8N_LOOP_NOTIFIER_URL" ) $secrets -}!}
+    {!{ tmpl.Exec "import_secrets" $secrets | strings.Indent 4 }!}
 
-- name: Check which jobs failed
-  id: check-failures
-  run: |
-    FAILED_JOBS=""
-    if [[ "${{ needs.drweb-scan.result }}" == "failure" ]]; then
-      FAILED_JOBS="$FAILED_JOBS• Dr.Web Scan\n"
-    fi
-    if [[ "${{ needs.kaspersky-scan.result }}" == "failure" ]]; then
-      FAILED_JOBS="$FAILED_JOBS• Kaspersky Scan\n"
-    fi
+    - name: Check which jobs failed
+      id: check-failures
+      run: |
+        FAILED_JOBS=""
+        if [[ "${{ needs.drweb-scan.result }}" == "failure" ]]; then
+          FAILED_JOBS="$FAILED_JOBS• Dr.Web Scan\n"
+        fi
+        if [[ "${{ needs.kaspersky-scan.result }}" == "failure" ]]; then
+          FAILED_JOBS="$FAILED_JOBS• Kaspersky Scan\n"
+        fi
 
-    echo "failed_jobs=${FAILED_JOBS}" >> $GITHUB_OUTPUT
-    echo "Failed jobs:"
-    echo "${FAILED_JOBS}"
+        echo "failed_jobs=${FAILED_JOBS}" >> $GITHUB_OUTPUT
+        echo "Failed jobs:"
+        echo "${FAILED_JOBS}"
 
-- name: Send notification
-  run: |
-    workflow_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+    - name: Send notification
+      run: |
+        workflow_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
-    MESSAGE="🛑 Github Antivirus Scan Failed!\n\n"
-    MESSAGE+="**Failed jobs:**\n"
-    MESSAGE+="${{ steps.check-failures.outputs.failed_jobs }}\n"
-    PR_NUMBER="${{ github.event.pull_request.number }}"
-    if [ -n "$PR_NUMBER" ]; then
-      pr_url="https://github.com/${{ github.repository }}/pull/${PR_NUMBER}"
-      MESSAGE+="**PR:** [#${PR_NUMBER}]($pr_url)\n"
-    fi
-    MESSAGE+="**Workflow URL:** [View Run]($workflow_url)\n"
+        MESSAGE="🛑 Github Antivirus Scan Failed!\n\n"
+        MESSAGE+="**Failed jobs:**\n"
+        MESSAGE+="${{ steps.check-failures.outputs.failed_jobs }}\n"
+        PR_NUMBER="${{ github.event.pull_request.number }}"
+        if [ -n "$PR_NUMBER" ]; then
+          pr_url="https://github.com/${{ github.repository }}/pull/${PR_NUMBER}"
+          MESSAGE+="**PR:** [#${PR_NUMBER}]($pr_url)\n"
+        fi
+        MESSAGE+="**Workflow URL:** [View Run]($workflow_url)\n"
 
-    curl -f -L -X POST "${{ steps.secrets.outputs.N8N_LOOP_NOTIFIER_URL }}" \
-      -H "Content-Type: application/json" \
-      --data "{\"type\": \"ci_fail\",\"message\":\"$MESSAGE\"}"
-  # </template: antivirus_notify_failure_job>
-  {!{ end }!}
+        curl -f -L -X POST "${{ steps.secrets.outputs.N8N_LOOP_NOTIFIER_URL }}" \
+          -H "Content-Type: application/json" \
+          --data "{\"type\": \"ci_fail\",\"message\":\"$MESSAGE\"}"
+# </template: antivirus_notify_failure_job>
+{!{ end }!}

--- a/.github/scripts/python/changed_images.py
+++ b/.github/scripts/python/changed_images.py
@@ -15,177 +15,383 @@
 # limitations under the License.
 
 """
-Detect module images that actually changed in this PR.
-
-Inputs (env):
-  BUILD_REPORT_PATH   - path to werf build report (images_tags_werf.json)
-                        from the **first successful Build FE run of this PR**
-                        (NOT the current run — see security-scan-images.yml,
-                        step "Find baseline Build FE run"). On that build,
-                        werf cache could only contain layers from main, so
-                        `Rebuilt: false` reliably means "identical to main".
-  IMAGES_DIGESTS_PATH - path to images_digests.json extracted from the
-                        assembled dev image of the **current** run
-                        (/deckhouse/modules/images_digests.json).
-  OUTPUT_OLD_DIGESTS  - where to write digests_old_main.json (default: ./digests_old_main.json).
-  OUTPUT_CHANGED      - where to write changed_images.json (default: ./changed_images.json).
-  GITHUB_OUTPUT       - if set, also emit `changed_count`, `matrix` and
-                        `changed_compact` as job outputs.
-
-Why "first successful build"? werf's cache is content-addressable and
-shared across the PR's build history. On the very first build, the cache
-contains only main-published layers, so `Rebuilt: false` truly means
-"matches main". On any subsequent build, `Rebuilt: false` can also mean
-"matches a layer this PR built earlier" — which would silently mask
-images already modified by the PR. Anchoring the baseline to the first
-successful build sidesteps that.
+Detect final werf images that should be scanned for the current PR.
 
 Algorithm:
-  1. Read the baseline build report. werf's `Images` is a map keyed by
-     werf image name in kebab-case (e.g. "node-manager/bashible-apiserver").
-     Each entry has booleans `Final` / `Rebuilt` and a content
-     `DockerImageDigest`. Keep only entries with `Final: true` and
-     `Rebuilt: false` (= final, taken from main cache on the first PR
-     build) -> "digests_old_main.json".
-  2. Read images_digests.json from the assembled dev image of the current
-     run. werf populates it with the same content `ImageDigest` values
-     produced by the current build, keyed by {moduleCamel: {imageCamel: digest}}.
-  3. Build a *set* of digests from digests_old_main.json. For every entry
-     in images_digests.json, if its digest is not in that set, mark it as
-     CHANGED. Comparing by digest (not by name) is robust:
-       - it auto-handles the kebab<->camel name conversion, and
-       - it correctly groups images whose content is bit-identical
-         (e.g. csiExternalSnapshotter127..131 share one digest in the
-         repo's real images_digests.json snapshots).
+  1. Get PR commits.
+  2. Read current images_tags_werf.json.
+  3. Keep only entries with:
+       Final == true
+       Commit in PR commits
+  4. Convert werf image name into module/image fields for matrix output.
+  5. Read images_digests.json and map changed digests to scanner keys.
+  6. Write changed_images.json and GitHub Actions outputs.
+
+changed_compact must use keys from images_digests.json, for example:
+  nodeManager.bashibleApiserver
+
+It must not be built from WerfImageName, for example:
+  node-manager.bashible-apiserver
+
+The AV scanner and rootless scanner match ONLY_IMAGES against keys from
+images_digests.json.
 """
 
 import json
 import os
+import subprocess
 import sys
+from typing import Any, Optional
+
+
+NON_MODULE_WERF_IMAGE_NAMES = {
+    "dev",
+    "dev-prebuild",
+    "dev-vex-artifact",
+    "release-channel-version",
+    "deckhouse-main",
+    "deckhouse-install",
+    "deckhouse-install-standalone",
+    "install",
+    "install-standalone",
+    "install-vex-artifact",
+}
+
+NON_MODULE_WERF_IMAGE_PREFIXES = (
+    "dev/",
+)
+
+
+def run(cmd: list[str]) -> str:
+    return subprocess.check_output(cmd, text=True).strip()
+
+
+def load_json(path: str) -> Any:
+    with open(path) as fp:
+        return json.load(fp)
 
 
 def load_build_report(path: str) -> dict:
-    with open(path) as fp:
-        report = json.load(fp)
+    report = load_json(path)
+
     images = report.get("Images")
     if isinstance(images, list):
         normalized = {}
+
         for entry in images:
+            if not isinstance(entry, dict):
+                continue
+
             key = entry.get("WerfImageName") or entry.get("Name") or entry.get("Image")
             if key:
                 normalized[key] = entry
+
         images = normalized
+
     if not isinstance(images, dict):
         raise SystemExit(f"unexpected build report shape at {path}: no Images map")
+
     return images
 
 
-def collect_old_main_digests(images: dict) -> dict:
-    """Return { werf_image_name: { "DockerImageDigest": "..." } } for every
-    final image that werf reused from cache on the *first* PR build
-    (Final == True and Rebuilt == False)."""
-    out = {}
+def load_images_digests(path: str) -> dict:
+    data = load_json(path)
+
+    if not isinstance(data, dict):
+        raise SystemExit(f"unexpected images digests shape at {path}: root is not object")
+
+    return data
+
+
+def is_zero_sha(value: str) -> bool:
+    return bool(value) and set(value) == {"0"}
+
+
+def get_before_commit_from_event() -> Optional[str]:
+    before = os.environ.get("GITHUB_EVENT_BEFORE")
+    if before:
+        return before
+
+    event_path = os.environ.get("GITHUB_EVENT_PATH")
+    if not event_path or not os.path.exists(event_path):
+        return None
+
+    try:
+        event = load_json(event_path)
+    except (OSError, json.JSONDecodeError):
+        return None
+
+    before = event.get("before")
+    if isinstance(before, str) and before:
+        return before
+
+    return None
+
+
+def get_commits_from_range(revision_range: str) -> set[str]:
+    commits = run(["git", "log", "--format=%H", revision_range])
+    return set(commits.splitlines()) if commits else set()
+
+
+def get_pr_commits() -> set[str]:
+    base_ref = os.environ.get("GITHUB_BASE_REF")
+
+    if base_ref:
+        if not base_ref.startswith("origin/"):
+            base_ref = f"origin/{base_ref}"
+
+        merge_base = run(["git", "merge-base", base_ref, "HEAD"])
+        return get_commits_from_range(f"{merge_base}..HEAD")
+
+    before = get_before_commit_from_event()
+    if before and not is_zero_sha(before):
+        return get_commits_from_range(f"{before}..HEAD")
+
+    head = run(["git", "rev-parse", "HEAD"])
+    return {head}
+
+
+def split_werf_image_name(name: str) -> tuple[str, str]:
+    if "/" not in name:
+        return name, name
+
+    module, image = name.split("/", 1)
+    return module, image
+
+
+def normalize_digest(value: str) -> Optional[str]:
+    if not value:
+        return None
+
+    marker = "sha256:"
+    index = value.find(marker)
+    if index == -1:
+        return None
+
+    return value[index:]
+
+
+def extract_digest(value: Any) -> Optional[str]:
+    if isinstance(value, str):
+        return normalize_digest(value)
+
+    if not isinstance(value, dict):
+        return None
+
+    digest_keys = (
+        "digest",
+        "Digest",
+        "dockerImageDigest",
+        "DockerImageDigest",
+        "docker_image_digest",
+        "imageDigest",
+        "ImageDigest",
+    )
+
+    for key in digest_keys:
+        digest = value.get(key)
+        if isinstance(digest, str):
+            normalized = normalize_digest(digest)
+            if normalized:
+                return normalized
+
+    return None
+
+
+def build_compact_keys_by_digest(images_digests: dict) -> dict[str, list[str]]:
+    compact_keys_by_digest: dict[str, list[str]] = {}
+
+    for module, images in images_digests.items():
+        if not isinstance(module, str):
+            continue
+
+        if not isinstance(images, dict):
+            continue
+
+        for image, value in images.items():
+            if not isinstance(image, str):
+                continue
+
+            digest = extract_digest(value)
+            if not digest:
+                continue
+
+            compact_key = f"{module}.{image}"
+            compact_keys_by_digest.setdefault(digest, []).append(compact_key)
+
+    for keys in compact_keys_by_digest.values():
+        keys.sort()
+
+    return compact_keys_by_digest
+
+
+def is_non_module_werf_image(name: str) -> bool:
+    if name in NON_MODULE_WERF_IMAGE_NAMES:
+        return True
+
+    return name.startswith(NON_MODULE_WERF_IMAGE_PREFIXES)
+
+
+def requires_compact_key(name: str) -> bool:
+    if "/" not in name:
+        return False
+
+    if is_non_module_werf_image(name):
+        return False
+
+    return True
+
+
+def compute_changed(
+    images: dict,
+    pr_commits: set[str],
+    compact_keys_by_digest: dict[str, list[str]],
+) -> list:
+    changed = []
+
     for name, entry in images.items():
         if not isinstance(entry, dict):
             continue
-        if not entry.get("Final"):
+
+        if entry.get("Final") is not True:
             continue
-        if entry.get("Rebuilt") is True:
+
+        commit = entry.get("Commit")
+        if not commit or commit not in pr_commits:
             continue
-        digest = entry.get("DockerImageDigest")
+
+        digest = normalize_digest(str(entry.get("DockerImageDigest", "")))
         if not digest:
             continue
-        out[name] = {"DockerImageDigest": digest}
-    return out
 
+        werf_image_name = entry.get("WerfImageName") or name
+        module, image = split_werf_image_name(werf_image_name)
 
-def compute_changed(images_digests: dict, old_digest_set: set) -> list:
-    changed = []
-    for module, mod_images in (images_digests or {}).items():
-        if not isinstance(mod_images, dict):
-            continue
-        for image, digest in mod_images.items():
-            if not isinstance(digest, str):
-                continue
-            if digest in old_digest_set:
-                continue
-            changed.append({"module": module, "image": image, "digest": digest})
+        compact_keys = compact_keys_by_digest.get(digest, [])
+
+        changed.append({
+            "module": module,
+            "image": image,
+            "digest": digest,
+            "commit": commit,
+            "werf_image_name": werf_image_name,
+            "compact_keys": compact_keys,
+        })
+
     changed.sort(key=lambda c: (c["module"], c["image"]))
     return changed
+
+
+def get_missing_compact_key_images(changed: list) -> list:
+    missing = []
+
+    for item in changed:
+        werf_image_name = item.get("werf_image_name", "")
+        compact_keys = item.get("compact_keys", [])
+
+        if requires_compact_key(werf_image_name) and not compact_keys:
+            missing.append(item)
+
+    return missing
+
+
+def build_changed_compact(changed: list) -> list[str]:
+    compact = set()
+
+    for item in changed:
+        for compact_key in item.get("compact_keys", []):
+            compact.add(compact_key)
+
+    return sorted(compact)
+
+
+def build_matrix(changed: list) -> dict:
+    include = []
+
+    for item in changed:
+        include.append({
+            "module": item["module"],
+            "image": item["image"],
+            "digest": item["digest"],
+            "commit": item["commit"],
+            "werf_image_name": item["werf_image_name"],
+        })
+
+    return {"include": include}
 
 
 def emit_github_outputs(changed: list) -> None:
     out_path = os.environ.get("GITHUB_OUTPUT")
     if not out_path:
         return
-    matrix = {"include": changed}
-    compact = [f"{c['module']}.{c['image']}" for c in changed]
+
+    matrix = build_matrix(changed)
+    compact = build_changed_compact(changed)
+
     with open(out_path, "a") as fp:
         fp.write(f"changed_count={len(changed)}\n")
         fp.write(f"matrix={json.dumps(matrix, separators=(',', ':'))}\n")
         fp.write(f"changed_compact={json.dumps(compact, separators=(',', ':'))}\n")
 
 
+def print_changed(changed: list) -> None:
+    if not changed:
+        return
+
+    print("Images for scan:")
+
+    for item in changed:
+        compact_keys = item.get("compact_keys") or ["<no compact key>"]
+        print(
+            f"  {item['werf_image_name']}  "
+            f"{','.join(compact_keys)}  "
+            f"{item['commit']}  "
+            f"{item['digest']}"
+        )
+
+
 def main() -> int:
     build_report_path = os.environ.get("BUILD_REPORT_PATH", "images_tags_werf.json")
     images_digests_path = os.environ.get("IMAGES_DIGESTS_PATH", "images_digests.json")
-    out_old = os.environ.get("OUTPUT_OLD_DIGESTS", "digests_old_main.json")
     out_changed = os.environ.get("OUTPUT_CHANGED", "changed_images.json")
 
     if not os.path.exists(build_report_path):
-        # The baseline build_report_FE artifact (from the first successful
-        # Build FE run of this PR) is gone — most likely older than the
-        # GitHub Actions artifact retention window. Without it we cannot
-        # compute a meaningful main-vs-PR digest diff, so we degrade
-        # gracefully: emit empty outputs. Downstream CVE / rootless /
-        # antivirus scanners treat an empty `changed_compact` as "no
-        # filter" and fall back to scanning every image.
-        print(
-            "WARNING: baseline build report not found at "
-            f"{build_report_path}.\n"
-            "  The first successful Build FE artifact of this PR has likely\n"
-            "  expired (GitHub Actions retention). A reliable diff against\n"
-            "  main cannot be computed; emitting an empty changed_compact\n"
-            "  filter. Downstream image scans will run in FULL-SCAN mode\n"
-            "  (every image scanned)."
-        )
-        with open(out_old, "w") as fp:
-            json.dump({}, fp)
-        with open(out_changed, "w") as fp:
-            json.dump([], fp)
-        emit_github_outputs([])
-        return 0
+        raise SystemExit(f"ERROR: build report not found: {build_report_path}")
+
+    if not os.path.exists(images_digests_path):
+        raise SystemExit(f"ERROR: images digests not found: {images_digests_path}")
+
+    pr_commits = get_pr_commits()
+    print(f"PR commits: {len(pr_commits)}")
 
     images = load_build_report(build_report_path)
-    old_main = collect_old_main_digests(images)
+    print(f"Build report total entries: {len(images)}")
 
-    with open(out_old, "w") as fp:
-        json.dump(old_main, fp, indent=2, sort_keys=True)
-    print(f"Baseline build report total entries: {len(images)}")
-    print(f"digests_old_main.json entries:       {len(old_main)}  (kept Final=true && Rebuilt=false)")
+    images_digests = load_images_digests(images_digests_path)
+    compact_keys_by_digest = build_compact_keys_by_digest(images_digests)
+    compact_keys_count = sum(len(keys) for keys in compact_keys_by_digest.values())
+    print(f"Images digests compact keys: {compact_keys_count}")
 
-    with open(images_digests_path) as fp:
-        images_digests = json.load(fp)
+    changed = compute_changed(images, pr_commits, compact_keys_by_digest)
 
-    old_digest_set = {v["DockerImageDigest"] for v in old_main.values()}
-    changed = compute_changed(images_digests, old_digest_set)
+    missing_compact = get_missing_compact_key_images(changed)
+    if missing_compact:
+        print("ERROR: failed to map changed module images to images_digests.json keys:")
+        for item in missing_compact:
+            print(f"  {item['werf_image_name']}  {item['digest']}  {item['commit']}")
+        return 1
 
-    total = sum(
-        1
-        for m in (images_digests or {}).values()
-        if isinstance(m, dict)
-        for _ in m.values()
-    )
+    changed_compact = build_changed_compact(changed)
+
     with open(out_changed, "w") as fp:
         json.dump(changed, fp, indent=2)
-    print(f"Module images in images_digests.json: {total}")
-    print(f"Changed module images:                {len(changed)}")
-    if changed:
-        print("First 10 changed:")
-        for c in changed[:10]:
-            print(f"  {c['module']}.{c['image']}  {c['digest']}")
 
+    print(f"Changed final images: {len(changed)}")
+    print(f"Changed compact keys: {len(changed_compact)}")
+
+    print_changed(changed)
     emit_github_outputs(changed)
+
     return 0
 
 

--- a/.github/workflow_templates/security-scan-images.yml
+++ b/.github/workflow_templates/security-scan-images.yml
@@ -165,14 +165,10 @@ jobs:
 
   # ============================================================================
   # CVE — Trivy scan on PR images.
-  # TEMPORARILY DISABLED: PR-mode CVE scan currently misbehaves (false-positive
-  # noise / wrong PR-diff filter). Re-enable by removing the `if: false` guard
-  # once the underlying script is fixed. While disabled, the aggregator below
-  # explicitly allows `cve: skipped`, so it does not block PR merges.
   # ============================================================================
   test_cve_report_main:
     name: Trivy scan dev images
-    if: ${{ false }}
+    if: ${{ needs.changed_images.outputs.changed_count != '0' }}
     # External/fork PRs gated by 'status/ok-to-test' via pull_request_info (setFailed → this job is skipped).
     needs:
       - pull_request_info

--- a/.github/workflow_templates/security-scan-images.yml
+++ b/.github/workflow_templates/security-scan-images.yml
@@ -1,40 +1,40 @@
 # Copyright 2026 Flant JSC
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+  # Licensed under the Apache License, Version 2.0 (the "License");
+  # you may not use this file except in compliance with the License.
+  # You may obtain a copy of the License at
+  #
+  #     http://www.apache.org/licenses/LICENSE-2.0
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS,
+  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  # See the License for the specific language governing permissions and
+  # limitations under the License.
 
-{!{- $pullRequestContext := coll.Dict "pullRequestRefField" "needs.pull_request_info.outputs.ref" "withChangedImages" true -}!}
-{!{- $ctx := coll.Merge $pullRequestContext . }!}
+  {!{- $pullRequestContext := coll.Dict "pullRequestRefField" "needs.pull_request_info.outputs.ref" "withChangedImages" true -}!}
+  {!{- $ctx := coll.Merge $pullRequestContext . }!}
 
 name: Security Scan Images
 
-# Image-based scans (CVE / rootless / antivirus). Invoked as a reusable
-# workflow from the Build workflow once `Build FE` succeeds — see the
-# `security_scan_images` job in build-and-test_dev. Because this workflow is
-# called via `uses:`, its jobs run as part of the parent's workflow run and
-# automatically appear on the PR's "Checks" tab (no commit-status plumbing
-# needed). The pull-request event context (head SHA, PR number, run_id) is
-# inherited from the calling workflow, so we read it straight from
-# `github.event.pull_request.*` / `github.run_id`.
-#
-# Re-run semantics: there is no "Re-run all jobs" entry-point on this workflow
-# alone — it is part of the parent. To re-execute the image scans, re-run the
-# Build workflow ("Build and test for dev branches"). The parent's
-# `concurrency.cancel-in-progress` automatically cancels any in-flight nested
-# scan when a new build for the same PR starts, so this workflow intentionally
-# does NOT declare its own `concurrency:` block: under workflow_call,
-# `github.workflow` is inherited from the parent, which would resolve into the
-# same group as the parent and produce a self-deadlock (GitHub then cancels
-# both runs with: "deadlock was detected for concurrency group … between a top
+  # Image-based scans (CVE / rootless / antivirus). Invoked as a reusable
+  # workflow from the Build workflow once `Build FE` succeeds — see the
+  # `security_scan_images` job in build-and-test_dev. Because this workflow is
+  # called via `uses:`, its jobs run as part of the parent's workflow run and
+  # automatically appear on the PR's "Checks" tab (no commit-status plumbing
+  # needed). The pull-request event context (head SHA, PR number, run_id) is
+  # inherited from the calling workflow, so we read it straight from
+  # `github.event.pull_request.*` / `github.run_id`.
+  #
+  # Re-run semantics: there is no "Re-run all jobs" entry-point on this workflow
+  # alone — it is part of the parent. To re-execute the image scans, re-run the
+  # Build workflow ("Build and test for dev branches"). The parent's
+  # `concurrency.cancel-in-progress` automatically cancels any in-flight nested
+  # scan when a new build for the same PR starts, so this workflow intentionally
+  # does NOT declare its own `concurrency:` block: under workflow_call,
+  # `github.workflow` is inherited from the parent, which would resolve into the
+  # same group as the parent and produce a self-deadlock (GitHub then cancels
+  # both runs with: "deadlock was detected for concurrency group … between a top
 # level workflow and 'Security scan images'").
 on:
   workflow_call:
@@ -45,40 +45,21 @@ permissions:
   pull-requests: write
 
 jobs:
-{!{ tmpl.Exec "pull_request_info_job" $ctx | strings.Indent 2 }!}
+  {!{ tmpl.Exec "pull_request_info_job" $ctx | strings.Indent 2 }!}
 
   # ============================================================================
-  # Compute the set of module images that actually changed in this PR.
-  #
-  # Baseline source: the FIRST `Build and test for dev branches` run of THIS
-  # PR whose `Build FE` job finished with conclusion=success — discovered via
-  # GitHub API, see the "Find baseline ..." step below. On the very first PR
-  # build werf's cache could only contain main-published layers, so
-  # `Rebuilt: false` in that report reliably means "identical to main". On
-  # any *later* build `Rebuilt: false` can also mean "identical to a layer
-  # this PR itself built earlier", which would silently mask images already
-  # modified by the PR. Anchoring the baseline to the first successful Build
-  # FE run sidesteps that.
-  #
-  # First PR build is naturally covered: the "first successful Build FE" is
-  # the current run itself, so digests_old_main is derived from this run's
-  # report. Images with `Rebuilt: true` are absent from digests_old_main and
-  # therefore correctly surface as "changed" in the diff against the current
-  # PR image.
-  #
-  # If the baseline run's `build_report_FE` artifact is no longer available
-  # (retention window elapsed), the download step stays soft and
-  # changed_images.py emits an empty filter (`changed_compact=[]`); downstream
-  # CVE / rootless / antivirus scans then fall back to full-scan mode (every
-  # image scanned), with an explicit log line stating the reason.
+  # Compute the set of module images that should be scanned in this PR.
   #
   # Flow:
-  #   1. Resolve baseline run_id (first PR run with Build FE success).
-  #   2. Download `build_report_FE` from that run (soft; missing = full-scan).
-  #   3. Keep only Final=true && Rebuilt=false entries -> digests_old_main.json
-  #      (.github/scripts/python/changed_images.py).
-  #   4. Extract images_digests.json from the current PR image and diff its
-  #      digests against digests_old_main by content (digest), not by name.
+  #   1. Download the current run's `build_report_FE` artifact.
+  #   2. Extract images_digests.json from the current PR dev image.
+  #   3. changed_images.py gets PR commits with:
+  #        git log --format=%H $(git merge-base origin/$GITHUB_BASE_REF HEAD)..HEAD
+  #   4. From images_tags_werf.json it keeps only final images whose Commit
+  #      belongs to the PR commit list.
+  #   5. It maps matching DockerImageDigest values to scanner keys from
+  #      images_digests.json, producing changed_compact as JSON array of
+  #      "<module>.<image>" keys.
   #
   # Outputs (changed_count / matrix / changed_compact) drive subsequent
   # CVE / rootless / antivirus scans.
@@ -100,9 +81,8 @@ jobs:
       changed_count:    ${{ steps.diff.outputs.changed_count }}
       matrix:           ${{ steps.diff.outputs.matrix }}
       changed_compact:  ${{ steps.diff.outputs.changed_compact }}
-      baseline_run_id:  ${{ steps.baseline.outputs.run_id }}
     steps:
-{!{ tmpl.Exec "checkout_full_step" $ctx | strings.Indent 6 }!}
+      {!{ tmpl.Exec "checkout_full_step" $ctx | strings.Indent 6 }!}
 
       - name: Set PR tag
         id: tag
@@ -116,99 +96,28 @@ jobs:
             TAG="pr${PR_NUMBER}-${REPO_SUFFIX}"
           fi
           echo "TAG=${TAG}" >> $GITHUB_OUTPUT
-{!{- /*
-  No LOOP_SERVICE_NOTIFICATIONS secret imported here on purpose: this job is
-  a pure plumbing step (computes the changed-image diff for downstream
-  scanners) and not a security scanner. Its failures are technical and visible
-  via the PR's Checks tab + the downstream `security/*` labels — we do not
-  page Loop for them. See the "no fail report" comment after the steps below.
-*/ -}!}
-{!{- $secrets := slice -}!}
-{!{- $secrets = append ( slice "projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/registry_host" "DECKHOUSE_DEV_REGISTRY_HOST" "DECKHOUSE_DEV_REGISTRY_HOST" ) $secrets -}!}
-{!{- $secrets = append ( slice "projects/data/101ceaca-97cd-462f-aed5-070d9b9de175/dev-registry/writetoken" "login" "DECKHOUSE_DEV_REGISTRY_USER" ) $secrets -}!}
-{!{- $secrets = append ( slice "projects/data/101ceaca-97cd-462f-aed5-070d9b9de175/dev-registry/writetoken" "password" "DECKHOUSE_DEV_REGISTRY_PASSWORD" ) $secrets -}!}
-{!{ tmpl.Exec "import_secrets" $secrets | strings.Indent 6 }!}
 
-      # Resolve the baseline: the first build-and-test_dev run of this PR
-      # whose `Build FE` job finished with conclusion=success.
-      #
-      # API strategy (important for main `deckhouse/deckhouse` scale, where
-      # build-and-test_dev has ~40k total runs):
-      #   * Filter at the API layer by the PR's head branch + status=success.
-      #     `listWorkflowRunsForRepo?branch=<head>&workflow_id=...&status=success`
-      #     normally returns a single-digit list — usually 1..20 runs.
-      #   * A run with conclusion=success means every required top-level job
-      #     succeeded, so `Build FE` (which is required) is implicitly success.
-      #     This avoids the N+1 `listJobsForWorkflowRun` calls we used to do.
-      #
-      # Soft degrade: if for any reason we cannot resolve a baseline (API rate
-      # limit, branch came from a fork without success runs yet, etc.) — emit
-      # an empty `run_id` and let the download step / changed_images.py
-      # fall back to full-scan with a clear warning. We intentionally do NOT
-      # `setFailed` here, because changed_images is plumbing, not a scanner.
-      - name: Find baseline Build FE run for this PR
-        id: baseline
-        timeout-minutes: 3
-        uses: {!{ index (ds "actions") "actions/github-script" }!}
-        with:
-          github-token: ${{ secrets.BOATSWAIN_GITHUB_TOKEN }}
-          script: |
-            const pr = context.payload.pull_request;
-            const prNumber = pr.number;
-            const headRef  = pr.head.ref;
-            core.info(`PR #${prNumber} head ref: ${headRef}`);
+      {!{- /*
+           No LOOP_SERVICE_NOTIFICATIONS secret imported here on purpose: this job is
+           a pure plumbing step (computes the changed-image diff for downstream
+           scanners) and not a security scanner. Its failures are technical and visible
+           via the PR's Checks tab + the downstream `security/*` labels — we do not
+           page Loop for them. See the "no fail report" comment after the steps below.
+           */ -}!}
+      {!{- $secrets := slice -}!}
+      {!{- $secrets = append ( slice "projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/registry_host" "DECKHOUSE_DEV_REGISTRY_HOST" "DECKHOUSE_DEV_REGISTRY_HOST" ) $secrets -}!}
+      {!{- $secrets = append ( slice "projects/data/101ceaca-97cd-462f-aed5-070d9b9de175/dev-registry/writetoken" "login" "DECKHOUSE_DEV_REGISTRY_USER" ) $secrets -}!}
+      {!{- $secrets = append ( slice "projects/data/101ceaca-97cd-462f-aed5-070d9b9de175/dev-registry/writetoken" "password" "DECKHOUSE_DEV_REGISTRY_PASSWORD" ) $secrets -}!}
+      {!{ tmpl.Exec "import_secrets" $secrets | strings.Indent 6 }!}
 
-            try {
-              const runs = await github.paginate(
-                github.rest.actions.listWorkflowRunsForRepo,
-                {
-                  owner: context.repo.owner,
-                  repo:  context.repo.repo,
-                  workflow_id: 'build-and-test_dev.yml',
-                  branch: headRef,
-                  status: 'success',
-                  per_page: 100,
-                },
-              );
-              core.info(`Found ${runs.length} successful build-and-test_dev run(s) on '${headRef}'`);
-
-              if (runs.length === 0) {
-                core.warning(
-                  `No successful build-and-test_dev run on '${headRef}' yet. ` +
-                  `Emitting empty baseline -> downstream scanners run in full-scan mode.`,
-                );
-                core.setOutput('run_id', '');
-                return;
-              }
-
-              runs.sort((a, b) => new Date(a.created_at) - new Date(b.created_at));
-              const chosen = runs[0];
-              core.info(`Baseline run: id=${chosen.id} created_at=${chosen.created_at}`);
-              core.setOutput('run_id', String(chosen.id));
-            } catch (err) {
-              core.warning(
-                `Failed to resolve baseline run (${err.message}). ` +
-                `Emitting empty baseline -> downstream scanners run in full-scan mode.`,
-              );
-              core.setOutput('run_id', '');
-            }
-
-      # Skipped when the baseline step could not find a successful Build FE
-      # run on this branch (empty run_id). In that case no build_report
-      # is fetched and changed_images.py degrades to full-scan with a
-      # warning logged from the "Compute changed images" step.
-      - name: Download build_report_FE from baseline run
-        if: ${{ steps.baseline.outputs.run_id != '' }}
+      - name: Download build_report_FE from current run
         uses: dawidd6/action-download-artifact@v21
         with:
           github_token: ${{ secrets.BOATSWAIN_GITHUB_TOKEN }}
-          run_id: ${{ steps.baseline.outputs.run_id }}
+          run_id: ${{ github.run_id }}
           name: build_report_FE
           path: ./build_report
-          # Soft on missing/expired: changed_images.py detects the absent
-          # report and falls back to full-scan (empty filter) with a clear
-          # log line, instead of failing the whole image-scan workflow.
-          if_no_artifact_found: warn
+          if_no_artifact_found: fail
 
       - name: Login to dev registry
         uses: {!{ index (ds "actions") "docker/login-action" }!}
@@ -233,15 +142,10 @@ jobs:
       - name: Compute changed images
         id: diff
         env:
-          # Baseline (first successful PR build) for digests_old_main:
           BUILD_REPORT_PATH:   ./build_report/images_tags_werf.json
-          # Current PR image (this run):
           IMAGES_DIGESTS_PATH: ./images_digests.json
-          OUTPUT_OLD_DIGESTS:  ./digests_old_main.json
           OUTPUT_CHANGED:      ./changed_images.json
-          BASELINE_RUN_ID:     ${{ steps.baseline.outputs.run_id }}
         run: |
-          echo "Baseline build_report_FE source: run_id=${BASELINE_RUN_ID}"
           python3 .github/scripts/python/changed_images.py
 
       - name: Upload diff artifacts
@@ -250,16 +154,14 @@ jobs:
         with:
           name: changed-images-pr${{ github.event.pull_request.number }}
           path: |
-            digests_old_main.json
             changed_images.json
           retention-days: 14
-      # NOTE: no `send_fail_report` here. Loop notifications on this workflow
-      # are reserved for actual scanner findings (rootless / antivirus) and
-      # for the gitleaks workflow. `changed_images` is plumbing — its
-      # failures (GitHub API unavailable, baseline build_report_FE expired,
-      # regctl pull failed, etc.) surface in Actions UI and indirectly via
-      # downstream scan jobs that will skip and turn the `security/*` PR
-      # labels red. Adding a Loop ping here would only create noise.
+    # NOTE: no `send_fail_report` here. Loop notifications on this workflow
+    # are reserved for actual scanner findings (rootless / antivirus) and
+    # for the gitleaks workflow. `changed_images` is plumbing — its
+    # failures surface in Actions UI and indirectly via downstream scan jobs
+    # that will skip and turn the `security/*` PR labels red. Adding a Loop
+    # ping here would only create noise.
 
   # ============================================================================
   # CVE — Trivy scan on PR images.
@@ -282,24 +184,24 @@ jobs:
     env:
       WORKDIR: "cve-scan"
     steps:
-{!{ tmpl.Exec "checkout_full_step"           $ctx | strings.Indent 6 }!}
-{!{ tmpl.Exec "link_bin_step"                     | strings.Indent 6 }!}
-{!{ tmpl.Exec "cve_scan_type_pr"                  | strings.Indent 6 }!}
-{!{ tmpl.Exec "cve_scan_deckhouse_images"    $ctx | strings.Indent 6 }!}
-{!{ tmpl.Exec "cve_tests_upload_reports_artifacts"| strings.Indent 6 }!}
-{!{ tmpl.Exec "unlink_bin_step"                   | strings.Indent 6 }!}
-      # NOTE: no `send_fail_report` here. PR-time CVE notifications are
-      # intentionally silent — Loop pings on this workflow are reserved for
-      # rootless / antivirus findings (and gitleaks lives in security-scan-src).
-      # CVE-found vs technical-fail aren't distinguishable from the current
-      # cve_scan.sh exit code, so a blanket failure() ping would be noisy.
-      # Weekly CVE (`cve-weekly`) keeps its own `send_fail_report` independent
-      # of this template — that behaviour is unchanged.
-      # The shared `cve_scan_deckhouse_images` step still imports
-      # LOOP_SERVICE_NOTIFICATIONS because that secret block is reused by
-      # cve-weekly; leaving it as-is here is intentional and harmless.
+      {!{ tmpl.Exec "checkout_full_step"           $ctx | strings.Indent 6 }!}
+        {!{ tmpl.Exec "link_bin_step"                     | strings.Indent 6 }!}
+        {!{ tmpl.Exec "cve_scan_type_pr"                  | strings.Indent 6 }!}
+        {!{ tmpl.Exec "cve_scan_deckhouse_images"    $ctx | strings.Indent 6 }!}
+        {!{ tmpl.Exec "cve_tests_upload_reports_artifacts"| strings.Indent 6 }!}
+        {!{ tmpl.Exec "unlink_bin_step"                   | strings.Indent 6 }!}
+    # NOTE: no `send_fail_report` here. PR-time CVE notifications are
+    # intentionally silent — Loop pings on this workflow are reserved for
+    # rootless / antivirus findings (and gitleaks lives in security-scan-src).
+    # CVE-found vs technical-fail aren't distinguishable from the current
+    # cve_scan.sh exit code, so a blanket failure() ping would be noisy.
+    # Weekly CVE (`cve-weekly`) keeps its own `send_fail_report` independent
+    # of this template — that behaviour is unchanged.
+    # The shared `cve_scan_deckhouse_images` step still imports
+    # LOOP_SERVICE_NOTIFICATIONS because that secret block is reused by
+    # cve-weekly; leaving it as-is here is intentional and harmless.
 
-{!{ tmpl.Exec "set_security_scan_requirement_status" slice | strings.Indent 2 }!}
+  {!{ tmpl.Exec "set_security_scan_requirement_status" slice | strings.Indent 2 }!}
 
   # ============================================================================
   # Rootless — default-user validation on PR images.
@@ -310,9 +212,9 @@ jobs:
     needs:
       - pull_request_info
       - changed_images
-{!{ tmpl.Exec "security_scan_template" (slice $ctx "pr" "with_fail_report") | strings.Indent 4 }!}
+    {!{ tmpl.Exec "security_scan_template" (slice $ctx "pr" "with_fail_report") | strings.Indent 4 }!}
 
-{!{ tmpl.Exec "set_security_rootless_requirement_status" $ctx | strings.Indent 2 }!}
+  {!{ tmpl.Exec "set_security_rootless_requirement_status" $ctx | strings.Indent 2 }!}
 
   # ============================================================================
   # Antivirus — Dr.Web and Kaspersky scans on PR images.
@@ -341,13 +243,13 @@ jobs:
           echo "PR tag to scan: $TAG"
           echo "tags=$(printf '%s' "$TAG" | jq -R -s -c 'split("\n") | map(select(length > 0))')" >> $GITHUB_OUTPUT
 
-{!{ tmpl.Exec "drweb_scan_job" $ctx | strings.Indent 2 }!}
+  {!{ tmpl.Exec "drweb_scan_job" $ctx | strings.Indent 2 }!}
 
-{!{ tmpl.Exec "kaspersky_scan_job" $ctx | strings.Indent 2 }!}
+  {!{ tmpl.Exec "kaspersky_scan_job" $ctx | strings.Indent 2 }!}
 
-{!{ tmpl.Exec "set_security_antivirus_requirement_status" . | strings.Indent 2 }!}
+  {!{ tmpl.Exec "set_security_antivirus_requirement_status" . | strings.Indent 2 }!}
 
-{!{ tmpl.Exec "antivirus_notify_failure_job" . | strings.Indent 2 }!}
+  {!{ tmpl.Exec "antivirus_notify_failure_job" . | strings.Indent 2 }!}
 
   # ============================================================================
   # Aggregator — single required check for branch protection.
@@ -360,7 +262,7 @@ jobs:
   security_scan_images_required:
     name: Security scan images required
     runs-on: self-slim
-    if: ${{ false }}
+    if: ${{ always() && needs.pull_request_info.result == 'success' }}
     needs:
       - pull_request_info
       - changed_images

--- a/.github/workflow_templates/security-scan-images.yml
+++ b/.github/workflow_templates/security-scan-images.yml
@@ -292,9 +292,9 @@ jobs:
               echo "✅ $name: $r"
               continue
             fi
-            # CVE PR-mode is temporarily disabled (test_cve_report_main has `if: false`); allow skipped until re-enabled.
-            if [[ "$name" == "cve" && "$r" == "skipped" ]]; then
-              echo "ℹ️  $name: $r (temporarily disabled)"
+            # nothing to scan
+            if [[ "$name" == "cve" && "$r" == "skipped" && "${{ needs.changed_images.outputs.changed_count }}" == "0" ]]; then
+              echo "ℹ️  $name: $r (no changed images)"
               continue
             fi
             if [[ "$IS_MAIN_REPO" == "false" && ( "$name" == "drweb" || "$name" == "kaspersky" ) && "$r" == "skipped" ]]; then

--- a/.github/workflow_templates/security-scan-images.yml
+++ b/.github/workflow_templates/security-scan-images.yml
@@ -1,16 +1,16 @@
 # Copyright 2026 Flant JSC
 #
-  # Licensed under the Apache License, Version 2.0 (the "License");
-  # you may not use this file except in compliance with the License.
-  # You may obtain a copy of the License at
-  #
-  #     http://www.apache.org/licenses/LICENSE-2.0
-  #
-  # Unless required by applicable law or agreed to in writing, software
-  # distributed under the License is distributed on an "AS IS" BASIS,
-  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  # See the License for the specific language governing permissions and
-  # limitations under the License.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
   {!{- $pullRequestContext := coll.Dict "pullRequestRefField" "needs.pull_request_info.outputs.ref" "withChangedImages" true -}!}
   {!{- $ctx := coll.Merge $pullRequestContext . }!}

--- a/.github/workflow_templates/security-scan-images.yml
+++ b/.github/workflow_templates/security-scan-images.yml
@@ -165,10 +165,14 @@ jobs:
 
   # ============================================================================
   # CVE — Trivy scan on PR images.
+  # TEMPORARILY DISABLED:
+  # Re-enable by set the `if: ${{ needs.changed_images.outputs.changed_count != '0' }}`
+  # guard once the underlying script is fixed. While disabled, the aggregator
+  # below explicitly allows `cve: skipped`, so it does not block PR merges.
   # ============================================================================
   test_cve_report_main:
     name: Trivy scan dev images
-    if: ${{ needs.changed_images.outputs.changed_count != '0' }}
+    if: ${{ false }}
     # External/fork PRs gated by 'status/ok-to-test' via pull_request_info (setFailed → this job is skipped).
     needs:
       - pull_request_info
@@ -292,9 +296,9 @@ jobs:
               echo "✅ $name: $r"
               continue
             fi
-            # nothing to scan
-            if [[ "$name" == "cve" && "$r" == "skipped" && "${{ needs.changed_images.outputs.changed_count }}" == "0" ]]; then
-              echo "ℹ️  $name: $r (no changed images)"
+       # CVE SCAN is intentionally DISABLED for PR mode.
+            if [[ "$name" == "cve" && "$r" == "skipped" ]]; then
+              echo "ℹ️  $name: $r (temporarily disabled)"
               continue
             fi
             if [[ "$IS_MAIN_REPO" == "false" && ( "$name" == "drweb" || "$name" == "kaspersky" ) && "$r" == "skipped" ]]; then

--- a/.github/workflows/antivirus-scan.yml
+++ b/.github/workflows/antivirus-scan.yml
@@ -115,23 +115,23 @@ jobs:
           fi
 
 
-    # <template: drweb_scan_job>
+  # <template: drweb_scan_job>
   drweb-scan:
-    name: Dr.Web Scan ${{ matrix.branch }}
+    name: Dr.Web Scan
     runs-on: [self-hosted, antivirus]
     if: github.repository == 'deckhouse/deckhouse'
     # Weekly/release mode: no changed_images upstream; full-scan every matrix entry.
-  needs: [get-tags]
-  strategy:
-    matrix:
-      branch: ${{ fromJson(needs.get-tags.outputs.tags) }}
-    fail-fast: false
-  permissions:
-    id-token: write
-  outputs:
-    scan_id: ${{ steps.scan.outputs.scan_id }}
-    skipped: ${{ steps.scan.outputs.skipped }}
-  steps:
+    needs: [get-tags]
+    strategy:
+      matrix:
+        branch: ${{ fromJson(needs.get-tags.outputs.tags) }}
+      fail-fast: false
+    permissions:
+      id-token: write
+    outputs:
+      scan_id: ${{ steps.scan.outputs.scan_id }}
+      skipped: ${{ steps.scan.outputs.skipped }}
+    steps:
       # <template: import_secrets>
       - name: Split repository name
         id: split
@@ -244,27 +244,27 @@ jobs:
             rm -rf ${SCAN_DIR}/${SCAN_ID} || true
           fi
 
-    # </template: drweb_scan_job>
+  # </template: drweb_scan_job>
 
 
 
-    # <template: kaspersky_scan_job>
+  # <template: kaspersky_scan_job>
   kaspersky-scan:
-    name: Kaspersky Scan ${{ matrix.branch }}
+    name: Kaspersky Scan
     runs-on: [self-hosted, antivirus]
     if: github.repository == 'deckhouse/deckhouse'
     # Weekly/release mode: no changed_images upstream; full-scan every matrix entry.
-  needs: [get-tags]
-  strategy:
-    matrix:
-      branch: ${{ fromJson(needs.get-tags.outputs.tags) }}
-    fail-fast: false
-  permissions:
-    id-token: write
-  outputs:
-    scan_id: ${{ steps.scan.outputs.scan_id }}
-    skipped: ${{ steps.scan.outputs.skipped }}
-  steps:
+    needs: [get-tags]
+    strategy:
+      matrix:
+        branch: ${{ fromJson(needs.get-tags.outputs.tags) }}
+      fail-fast: false
+    permissions:
+      id-token: write
+    outputs:
+      scan_id: ${{ steps.scan.outputs.scan_id }}
+      skipped: ${{ steps.scan.outputs.skipped }}
+    steps:
       # <template: import_secrets>
       - name: Split repository name
         id: split
@@ -377,11 +377,11 @@ jobs:
             rm -rf ${SCAN_DIR}/${SCAN_ID} || true
           fi
 
-    # </template: kaspersky_scan_job>
+  # </template: kaspersky_scan_job>
 
 
 
-    # <template: antivirus_notify_failure_job>
+  # <template: antivirus_notify_failure_job>
   notify-failure:
     name: Send failure notification
     runs-on: [self-hosted, regular]
@@ -415,37 +415,37 @@ jobs:
 
       # </template: import_secrets>
 
-  - name: Check which jobs failed
-    id: check-failures
-    run: |
-      FAILED_JOBS=""
-      if [[ "${{ needs.drweb-scan.result }}" == "failure" ]]; then
-        FAILED_JOBS="$FAILED_JOBS• Dr.Web Scan\n"
-      fi
-      if [[ "${{ needs.kaspersky-scan.result }}" == "failure" ]]; then
-        FAILED_JOBS="$FAILED_JOBS• Kaspersky Scan\n"
-      fi
+      - name: Check which jobs failed
+        id: check-failures
+        run: |
+          FAILED_JOBS=""
+          if [[ "${{ needs.drweb-scan.result }}" == "failure" ]]; then
+            FAILED_JOBS="$FAILED_JOBS• Dr.Web Scan\n"
+          fi
+          if [[ "${{ needs.kaspersky-scan.result }}" == "failure" ]]; then
+            FAILED_JOBS="$FAILED_JOBS• Kaspersky Scan\n"
+          fi
 
-      echo "failed_jobs=${FAILED_JOBS}" >> $GITHUB_OUTPUT
-      echo "Failed jobs:"
-      echo "${FAILED_JOBS}"
+          echo "failed_jobs=${FAILED_JOBS}" >> $GITHUB_OUTPUT
+          echo "Failed jobs:"
+          echo "${FAILED_JOBS}"
 
-  - name: Send notification
-    run: |
-      workflow_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+      - name: Send notification
+        run: |
+          workflow_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
-      MESSAGE="🛑 Github Antivirus Scan Failed!\n\n"
-      MESSAGE+="**Failed jobs:**\n"
-      MESSAGE+="${{ steps.check-failures.outputs.failed_jobs }}\n"
-      PR_NUMBER="${{ github.event.pull_request.number }}"
-      if [ -n "$PR_NUMBER" ]; then
-        pr_url="https://github.com/${{ github.repository }}/pull/${PR_NUMBER}"
-        MESSAGE+="**PR:** [#${PR_NUMBER}]($pr_url)\n"
-      fi
-      MESSAGE+="**Workflow URL:** [View Run]($workflow_url)\n"
+          MESSAGE="🛑 Github Antivirus Scan Failed!\n\n"
+          MESSAGE+="**Failed jobs:**\n"
+          MESSAGE+="${{ steps.check-failures.outputs.failed_jobs }}\n"
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          if [ -n "$PR_NUMBER" ]; then
+            pr_url="https://github.com/${{ github.repository }}/pull/${PR_NUMBER}"
+            MESSAGE+="**PR:** [#${PR_NUMBER}]($pr_url)\n"
+          fi
+          MESSAGE+="**Workflow URL:** [View Run]($workflow_url)\n"
 
-      curl -f -L -X POST "${{ steps.secrets.outputs.N8N_LOOP_NOTIFIER_URL }}" \
-        -H "Content-Type: application/json" \
-        --data "{\"type\": \"ci_fail\",\"message\":\"$MESSAGE\"}"
-    # </template: antivirus_notify_failure_job>
+          curl -f -L -X POST "${{ steps.secrets.outputs.N8N_LOOP_NOTIFIER_URL }}" \
+            -H "Content-Type: application/json" \
+            --data "{\"type\": \"ci_fail\",\"message\":\"$MESSAGE\"}"
+  # </template: antivirus_notify_failure_job>
 

--- a/.github/workflows/antivirus-scan.yml
+++ b/.github/workflows/antivirus-scan.yml
@@ -115,22 +115,23 @@ jobs:
           fi
 
 
-  # <template: drweb_scan_job>
+    # <template: drweb_scan_job>
   drweb-scan:
     name: Dr.Web Scan ${{ matrix.branch }}
     runs-on: [self-hosted, antivirus]
-    if: ${{ false }}
+    if: github.repository == 'deckhouse/deckhouse'
     # Weekly/release mode: no changed_images upstream; full-scan every matrix entry.
-    needs: [get-tags]
-    strategy:
-      matrix:
-        branch: ${{ fromJson(needs.get-tags.outputs.tags) }}
-      fail-fast: false
-    permissions:
-      id-token: write
-    outputs:
-      scan_id: ${{ steps.scan.outputs.scan_id }}
-    steps:
+  needs: [get-tags]
+  strategy:
+    matrix:
+      branch: ${{ fromJson(needs.get-tags.outputs.tags) }}
+    fail-fast: false
+  permissions:
+    id-token: write
+  outputs:
+    scan_id: ${{ steps.scan.outputs.scan_id }}
+    skipped: ${{ steps.scan.outputs.skipped }}
+  steps:
       # <template: import_secrets>
       - name: Split repository name
         id: split
@@ -187,9 +188,15 @@ jobs:
           SCAN_DIR=/opt/actions-runners/scans/drweb
           echo "scan_id=${SCAN_ID}" >> $GITHUB_OUTPUT
           echo "scan_dir=${SCAN_DIR}" >> $GITHUB_OUTPUT
+          echo "skipped=false" >> $GITHUB_OUTPUT
           echo $CONTAINER_NAME
-          docker exec -e ONLY_IMAGES="${ONLY_IMAGES:-}" ${CONTAINER_NAME} \
-            scanner "${ref}" "${registry_host}${registry_image_path}" "${SCAN_ID}"
+          if [[ -n "${ONLY_IMAGES:-}" ]]; then
+            docker exec -e ONLY_IMAGES="${ONLY_IMAGES}" ${CONTAINER_NAME} \
+              scanner "${ref}" "${registry_host}${registry_image_path}" "${SCAN_ID}"
+          else
+            docker exec ${CONTAINER_NAME} \
+              scanner "${ref}" "${registry_host}${registry_image_path}" "${SCAN_ID}"
+          fi
           # Drop container-uid ownership so the host-side Upload/Cleanup steps below
           # (and the `${SCAN_DIR}/.../scan_results_threats.md` read just below) can
           # touch the bind-mounted scan artifacts under the runner's UID (this step
@@ -216,7 +223,7 @@ jobs:
           echo "✅ ${CONTAINER_NAME} scan completed for ${{ matrix.branch }}"
 
       - name: Upload scan artifacts
-        if: github.repository == 'deckhouse/deckhouse' && always()
+        if: github.repository == 'deckhouse/deckhouse' && always() && steps.scan.outputs.skipped != 'true'
         uses: actions/upload-artifact@v4.4.0
         with:
           name: drweb-scan-results-${{ steps.scan.outputs.scan_id }}
@@ -237,26 +244,27 @@ jobs:
             rm -rf ${SCAN_DIR}/${SCAN_ID} || true
           fi
 
-  # </template: drweb_scan_job>
+    # </template: drweb_scan_job>
 
 
 
-  # <template: kaspersky_scan_job>
+    # <template: kaspersky_scan_job>
   kaspersky-scan:
     name: Kaspersky Scan ${{ matrix.branch }}
     runs-on: [self-hosted, antivirus]
-    if: ${{ false }}
+    if: github.repository == 'deckhouse/deckhouse'
     # Weekly/release mode: no changed_images upstream; full-scan every matrix entry.
-    needs: [get-tags]
-    strategy:
-      matrix:
-        branch: ${{ fromJson(needs.get-tags.outputs.tags) }}
-      fail-fast: false
-    permissions:
-      id-token: write
-    outputs:
-      scan_id: ${{ steps.scan.outputs.scan_id }}
-    steps:
+  needs: [get-tags]
+  strategy:
+    matrix:
+      branch: ${{ fromJson(needs.get-tags.outputs.tags) }}
+    fail-fast: false
+  permissions:
+    id-token: write
+  outputs:
+    scan_id: ${{ steps.scan.outputs.scan_id }}
+    skipped: ${{ steps.scan.outputs.skipped }}
+  steps:
       # <template: import_secrets>
       - name: Split repository name
         id: split
@@ -313,9 +321,15 @@ jobs:
           SCAN_DIR=/opt/actions-runners/scans/kaspersky
           echo "scan_id=${SCAN_ID}" >> $GITHUB_OUTPUT
           echo "scan_dir=${SCAN_DIR}" >> $GITHUB_OUTPUT
+          echo "skipped=false" >> $GITHUB_OUTPUT
           echo $CONTAINER_NAME
-          docker exec -e ONLY_IMAGES="${ONLY_IMAGES:-}" ${CONTAINER_NAME} \
-            scanner "${ref}" "${registry_host}${registry_image_path}" "${SCAN_ID}"
+          if [[ -n "${ONLY_IMAGES:-}" ]]; then
+            docker exec -e ONLY_IMAGES="${ONLY_IMAGES}" ${CONTAINER_NAME} \
+              scanner "${ref}" "${registry_host}${registry_image_path}" "${SCAN_ID}"
+          else
+            docker exec ${CONTAINER_NAME} \
+              scanner "${ref}" "${registry_host}${registry_image_path}" "${SCAN_ID}"
+          fi
           # Drop container-uid ownership so the host-side Upload/Cleanup steps below
           # (and the `${SCAN_DIR}/.../scan_results_threats.md` read just below) can
           # touch the bind-mounted scan artifacts under the runner's UID (this step
@@ -342,7 +356,7 @@ jobs:
           echo "✅ ${CONTAINER_NAME} scan completed for ${{ matrix.branch }}"
 
       - name: Upload scan artifacts
-        if: github.repository == 'deckhouse/deckhouse' && always()
+        if: github.repository == 'deckhouse/deckhouse' && always() && steps.scan.outputs.skipped != 'true'
         uses: actions/upload-artifact@v4.4.0
         with:
           name: kaspersky-scan-results-${{ steps.scan.outputs.scan_id }}
@@ -363,11 +377,11 @@ jobs:
             rm -rf ${SCAN_DIR}/${SCAN_ID} || true
           fi
 
-  # </template: kaspersky_scan_job>
+    # </template: kaspersky_scan_job>
 
 
 
-  # <template: antivirus_notify_failure_job>
+    # <template: antivirus_notify_failure_job>
   notify-failure:
     name: Send failure notification
     runs-on: [self-hosted, regular]
@@ -401,37 +415,37 @@ jobs:
 
       # </template: import_secrets>
 
-      - name: Check which jobs failed
-        id: check-failures
-        run: |
-          FAILED_JOBS=""
-          if [[ "${{ needs.drweb-scan.result }}" == "failure" ]]; then
-            FAILED_JOBS="$FAILED_JOBS• Dr.Web Scan\n"
-          fi
-          if [[ "${{ needs.kaspersky-scan.result }}" == "failure" ]]; then
-            FAILED_JOBS="$FAILED_JOBS• Kaspersky Scan\n"
-          fi
+  - name: Check which jobs failed
+    id: check-failures
+    run: |
+      FAILED_JOBS=""
+      if [[ "${{ needs.drweb-scan.result }}" == "failure" ]]; then
+        FAILED_JOBS="$FAILED_JOBS• Dr.Web Scan\n"
+      fi
+      if [[ "${{ needs.kaspersky-scan.result }}" == "failure" ]]; then
+        FAILED_JOBS="$FAILED_JOBS• Kaspersky Scan\n"
+      fi
 
-          echo "failed_jobs=${FAILED_JOBS}" >> $GITHUB_OUTPUT
-          echo "Failed jobs:"
-          echo "${FAILED_JOBS}"
+      echo "failed_jobs=${FAILED_JOBS}" >> $GITHUB_OUTPUT
+      echo "Failed jobs:"
+      echo "${FAILED_JOBS}"
 
-      - name: Send notification
-        run: |
-          workflow_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+  - name: Send notification
+    run: |
+      workflow_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
-          MESSAGE="🛑 Github Antivirus Scan Failed!\n\n"
-          MESSAGE+="**Failed jobs:**\n"
-          MESSAGE+="${{ steps.check-failures.outputs.failed_jobs }}\n"
-          PR_NUMBER="${{ github.event.pull_request.number }}"
-          if [ -n "$PR_NUMBER" ]; then
-            pr_url="https://github.com/${{ github.repository }}/pull/${PR_NUMBER}"
-            MESSAGE+="**PR:** [#${PR_NUMBER}]($pr_url)\n"
-          fi
-          MESSAGE+="**Workflow URL:** [View Run]($workflow_url)\n"
+      MESSAGE="🛑 Github Antivirus Scan Failed!\n\n"
+      MESSAGE+="**Failed jobs:**\n"
+      MESSAGE+="${{ steps.check-failures.outputs.failed_jobs }}\n"
+      PR_NUMBER="${{ github.event.pull_request.number }}"
+      if [ -n "$PR_NUMBER" ]; then
+        pr_url="https://github.com/${{ github.repository }}/pull/${PR_NUMBER}"
+        MESSAGE+="**PR:** [#${PR_NUMBER}]($pr_url)\n"
+      fi
+      MESSAGE+="**Workflow URL:** [View Run]($workflow_url)\n"
 
-          curl -f -L -X POST "${{ steps.secrets.outputs.N8N_LOOP_NOTIFIER_URL }}" \
-            -H "Content-Type: application/json" \
-            --data "{\"type\": \"ci_fail\",\"message\":\"$MESSAGE\"}"
-  # </template: antivirus_notify_failure_job>
+      curl -f -L -X POST "${{ steps.secrets.outputs.N8N_LOOP_NOTIFIER_URL }}" \
+        -H "Content-Type: application/json" \
+        --data "{\"type\": \"ci_fail\",\"message\":\"$MESSAGE\"}"
+    # </template: antivirus_notify_failure_job>
 

--- a/.github/workflows/security-scan-images.yml
+++ b/.github/workflows/security-scan-images.yml
@@ -4,38 +4,38 @@
 
 # Copyright 2026 Flant JSC
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+  # Licensed under the Apache License, Version 2.0 (the "License");
+  # you may not use this file except in compliance with the License.
+  # You may obtain a copy of the License at
+  #
+  #     http://www.apache.org/licenses/LICENSE-2.0
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS,
+  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  # See the License for the specific language governing permissions and
+  # limitations under the License.
 
 name: Security Scan Images
 
-# Image-based scans (CVE / rootless / antivirus). Invoked as a reusable
-# workflow from the Build workflow once `Build FE` succeeds — see the
-# `security_scan_images` job in build-and-test_dev. Because this workflow is
-# called via `uses:`, its jobs run as part of the parent's workflow run and
-# automatically appear on the PR's "Checks" tab (no commit-status plumbing
-# needed). The pull-request event context (head SHA, PR number, run_id) is
-# inherited from the calling workflow, so we read it straight from
-# `github.event.pull_request.*` / `github.run_id`.
-#
-# Re-run semantics: there is no "Re-run all jobs" entry-point on this workflow
-# alone — it is part of the parent. To re-execute the image scans, re-run the
-# Build workflow ("Build and test for dev branches"). The parent's
-# `concurrency.cancel-in-progress` automatically cancels any in-flight nested
-# scan when a new build for the same PR starts, so this workflow intentionally
-# does NOT declare its own `concurrency:` block: under workflow_call,
-# `github.workflow` is inherited from the parent, which would resolve into the
-# same group as the parent and produce a self-deadlock (GitHub then cancels
-# both runs with: "deadlock was detected for concurrency group … between a top
+  # Image-based scans (CVE / rootless / antivirus). Invoked as a reusable
+  # workflow from the Build workflow once `Build FE` succeeds — see the
+  # `security_scan_images` job in build-and-test_dev. Because this workflow is
+  # called via `uses:`, its jobs run as part of the parent's workflow run and
+  # automatically appear on the PR's "Checks" tab (no commit-status plumbing
+  # needed). The pull-request event context (head SHA, PR number, run_id) is
+  # inherited from the calling workflow, so we read it straight from
+  # `github.event.pull_request.*` / `github.run_id`.
+  #
+  # Re-run semantics: there is no "Re-run all jobs" entry-point on this workflow
+  # alone — it is part of the parent. To re-execute the image scans, re-run the
+  # Build workflow ("Build and test for dev branches"). The parent's
+  # `concurrency.cancel-in-progress` automatically cancels any in-flight nested
+  # scan when a new build for the same PR starts, so this workflow intentionally
+  # does NOT declare its own `concurrency:` block: under workflow_call,
+  # `github.workflow` is inherited from the parent, which would resolve into the
+  # same group as the parent and produce a self-deadlock (GitHub then cancels
+  # both runs with: "deadlock was detected for concurrency group … between a top
 # level workflow and 'Security scan images'").
 on:
   workflow_call:
@@ -279,37 +279,18 @@ jobs:
   # </template: pull_request_info>
 
   # ============================================================================
-  # Compute the set of module images that actually changed in this PR.
-  #
-  # Baseline source: the FIRST `Build and test for dev branches` run of THIS
-  # PR whose `Build FE` job finished with conclusion=success — discovered via
-  # GitHub API, see the "Find baseline ..." step below. On the very first PR
-  # build werf's cache could only contain main-published layers, so
-  # `Rebuilt: false` in that report reliably means "identical to main". On
-  # any *later* build `Rebuilt: false` can also mean "identical to a layer
-  # this PR itself built earlier", which would silently mask images already
-  # modified by the PR. Anchoring the baseline to the first successful Build
-  # FE run sidesteps that.
-  #
-  # First PR build is naturally covered: the "first successful Build FE" is
-  # the current run itself, so digests_old_main is derived from this run's
-  # report. Images with `Rebuilt: true` are absent from digests_old_main and
-  # therefore correctly surface as "changed" in the diff against the current
-  # PR image.
-  #
-  # If the baseline run's `build_report_FE` artifact is no longer available
-  # (retention window elapsed), the download step stays soft and
-  # changed_images.py emits an empty filter (`changed_compact=[]`); downstream
-  # CVE / rootless / antivirus scans then fall back to full-scan mode (every
-  # image scanned), with an explicit log line stating the reason.
+  # Compute the set of module images that should be scanned in this PR.
   #
   # Flow:
-  #   1. Resolve baseline run_id (first PR run with Build FE success).
-  #   2. Download `build_report_FE` from that run (soft; missing = full-scan).
-  #   3. Keep only Final=true && Rebuilt=false entries -> digests_old_main.json
-  #      (.github/scripts/python/changed_images.py).
-  #   4. Extract images_digests.json from the current PR image and diff its
-  #      digests against digests_old_main by content (digest), not by name.
+  #   1. Download the current run's `build_report_FE` artifact.
+  #   2. Extract images_digests.json from the current PR dev image.
+  #   3. changed_images.py gets PR commits with:
+  #        git log --format=%H $(git merge-base origin/$GITHUB_BASE_REF HEAD)..HEAD
+  #   4. From images_tags_werf.json it keeps only final images whose Commit
+  #      belongs to the PR commit list.
+  #   5. It maps matching DockerImageDigest values to scanner keys from
+  #      images_digests.json, producing changed_compact as JSON array of
+  #      "<module>.<image>" keys.
   #
   # Outputs (changed_count / matrix / changed_compact) drive subsequent
   # CVE / rootless / antivirus scans.
@@ -331,7 +312,6 @@ jobs:
       changed_count:    ${{ steps.diff.outputs.changed_count }}
       matrix:           ${{ steps.diff.outputs.matrix }}
       changed_compact:  ${{ steps.diff.outputs.changed_compact }}
-      baseline_run_id:  ${{ steps.baseline.outputs.run_id }}
     steps:
 
       # <template: checkout_full_step>
@@ -381,86 +361,14 @@ jobs:
 
       # </template: import_secrets>
 
-      # Resolve the baseline: the first build-and-test_dev run of this PR
-      # whose `Build FE` job finished with conclusion=success.
-      #
-      # API strategy (important for main `deckhouse/deckhouse` scale, where
-      # build-and-test_dev has ~40k total runs):
-      #   * Filter at the API layer by the PR's head branch + status=success.
-      #     `listWorkflowRunsForRepo?branch=<head>&workflow_id=...&status=success`
-      #     normally returns a single-digit list — usually 1..20 runs.
-      #   * A run with conclusion=success means every required top-level job
-      #     succeeded, so `Build FE` (which is required) is implicitly success.
-      #     This avoids the N+1 `listJobsForWorkflowRun` calls we used to do.
-      #
-      # Soft degrade: if for any reason we cannot resolve a baseline (API rate
-      # limit, branch came from a fork without success runs yet, etc.) — emit
-      # an empty `run_id` and let the download step / changed_images.py
-      # fall back to full-scan with a clear warning. We intentionally do NOT
-      # `setFailed` here, because changed_images is plumbing, not a scanner.
-      - name: Find baseline Build FE run for this PR
-        id: baseline
-        timeout-minutes: 3
-        uses: actions/github-script@v6.4.1
-        with:
-          github-token: ${{ secrets.BOATSWAIN_GITHUB_TOKEN }}
-          script: |
-            const pr = context.payload.pull_request;
-            const prNumber = pr.number;
-            const headRef  = pr.head.ref;
-            core.info(`PR #${prNumber} head ref: ${headRef}`);
-
-            try {
-              const runs = await github.paginate(
-                github.rest.actions.listWorkflowRunsForRepo,
-                {
-                  owner: context.repo.owner,
-                  repo:  context.repo.repo,
-                  workflow_id: 'build-and-test_dev.yml',
-                  branch: headRef,
-                  status: 'success',
-                  per_page: 100,
-                },
-              );
-              core.info(`Found ${runs.length} successful build-and-test_dev run(s) on '${headRef}'`);
-
-              if (runs.length === 0) {
-                core.warning(
-                  `No successful build-and-test_dev run on '${headRef}' yet. ` +
-                  `Emitting empty baseline -> downstream scanners run in full-scan mode.`,
-                );
-                core.setOutput('run_id', '');
-                return;
-              }
-
-              runs.sort((a, b) => new Date(a.created_at) - new Date(b.created_at));
-              const chosen = runs[0];
-              core.info(`Baseline run: id=${chosen.id} created_at=${chosen.created_at}`);
-              core.setOutput('run_id', String(chosen.id));
-            } catch (err) {
-              core.warning(
-                `Failed to resolve baseline run (${err.message}). ` +
-                `Emitting empty baseline -> downstream scanners run in full-scan mode.`,
-              );
-              core.setOutput('run_id', '');
-            }
-
-      # Skipped when the baseline step could not find a successful Build FE
-      # run on this branch (empty run_id). In that case no build_report
-      # is fetched and changed_images.py degrades to full-scan with a
-      # warning logged from the "Compute changed images" step.
-      - name: Download build_report_FE from baseline run
-        if: ${{ steps.baseline.outputs.run_id != '' }}
+      - name: Download build_report_FE from current run
         uses: dawidd6/action-download-artifact@v21
         with:
           github_token: ${{ secrets.BOATSWAIN_GITHUB_TOKEN }}
-          run_id: ${{ steps.baseline.outputs.run_id }}
+          run_id: ${{ github.run_id }}
           name: build_report_FE
           path: ./build_report
-          # Soft on missing/expired: changed_images.py detects the absent
-          # report and falls back to full-scan (empty filter) with a clear
-          # log line, instead of failing the whole image-scan workflow.
-          if_no_artifact_found: warn
+          if_no_artifact_found: fail
 
       - name: Login to dev registry
         uses: docker/login-action@v2.1.0
@@ -485,15 +393,10 @@ jobs:
       - name: Compute changed images
         id: diff
         env:
-          # Baseline (first successful PR build) for digests_old_main:
           BUILD_REPORT_PATH:   ./build_report/images_tags_werf.json
-          # Current PR image (this run):
           IMAGES_DIGESTS_PATH: ./images_digests.json
-          OUTPUT_OLD_DIGESTS:  ./digests_old_main.json
           OUTPUT_CHANGED:      ./changed_images.json
-          BASELINE_RUN_ID:     ${{ steps.baseline.outputs.run_id }}
         run: |
-          echo "Baseline build_report_FE source: run_id=${BASELINE_RUN_ID}"
           python3 .github/scripts/python/changed_images.py
 
       - name: Upload diff artifacts
@@ -502,16 +405,14 @@ jobs:
         with:
           name: changed-images-pr${{ github.event.pull_request.number }}
           path: |
-            digests_old_main.json
             changed_images.json
           retention-days: 14
-      # NOTE: no `send_fail_report` here. Loop notifications on this workflow
-      # are reserved for actual scanner findings (rootless / antivirus) and
-      # for the gitleaks workflow. `changed_images` is plumbing — its
-      # failures (GitHub API unavailable, baseline build_report_FE expired,
-      # regctl pull failed, etc.) surface in Actions UI and indirectly via
-      # downstream scan jobs that will skip and turn the `security/*` PR
-      # labels red. Adding a Loop ping here would only create noise.
+    # NOTE: no `send_fail_report` here. Loop notifications on this workflow
+    # are reserved for actual scanner findings (rootless / antivirus) and
+    # for the gitleaks workflow. `changed_images` is plumbing — its
+    # failures surface in Actions UI and indirectly via downstream scan jobs
+    # that will skip and turn the `security/*` PR labels red. Adding a Loop
+    # ping here would only create noise.
 
   # ============================================================================
   # CVE — Trivy scan on PR images.
@@ -564,7 +465,7 @@ jobs:
           echo "TAG=${TAG}" >> $GITHUB_OUTPUT
           echo "SCAN_SEVERAL_LATEST_RELEASES=False" >> $GITHUB_OUTPUT
           echo "LATEST_RELEASES_AMOUNT=0" >> $GITHUB_OUTPUT
-      # <template: cve_scan_deckhouse_images>
+              # <template: cve_scan_deckhouse_images>
       # <template: import_secrets>
       - name: Split repository name
         id: split
@@ -678,16 +579,16 @@ jobs:
         run: |
           rm bin
       # </template: unlink_bin_step>
-      # NOTE: no `send_fail_report` here. PR-time CVE notifications are
-      # intentionally silent — Loop pings on this workflow are reserved for
-      # rootless / antivirus findings (and gitleaks lives in security-scan-src).
-      # CVE-found vs technical-fail aren't distinguishable from the current
-      # cve_scan.sh exit code, so a blanket failure() ping would be noisy.
-      # Weekly CVE (`cve-weekly`) keeps its own `send_fail_report` independent
-      # of this template — that behaviour is unchanged.
-      # The shared `cve_scan_deckhouse_images` step still imports
-      # LOOP_SERVICE_NOTIFICATIONS because that secret block is reused by
-      # cve-weekly; leaving it as-is here is intentional and harmless.
+    # NOTE: no `send_fail_report` here. PR-time CVE notifications are
+    # intentionally silent — Loop pings on this workflow are reserved for
+    # rootless / antivirus findings (and gitleaks lives in security-scan-src).
+    # CVE-found vs technical-fail aren't distinguishable from the current
+    # cve_scan.sh exit code, so a blanket failure() ping would be noisy.
+    # Weekly CVE (`cve-weekly`) keeps its own `send_fail_report` independent
+    # of this template — that behaviour is unchanged.
+    # The shared `cve_scan_deckhouse_images` step still imports
+    # LOOP_SERVICE_NOTIFICATIONS because that secret block is reused by
+    # cve-weekly; leaving it as-is here is intentional and harmless.
 
 
 
@@ -730,7 +631,7 @@ jobs:
     needs:
       - pull_request_info
       - changed_images
-    # <template: security_scan_template>
+        # <template: security_scan_template>
     steps:
 
       # <template: checkout_full_step>
@@ -1373,7 +1274,7 @@ jobs:
   security_scan_images_required:
     name: Security scan images required
     runs-on: self-slim
-    if: ${{ false }}
+    if: ${{ always() && needs.pull_request_info.result == 'success' }}
     needs:
       - pull_request_info
       - changed_images

--- a/.github/workflows/security-scan-images.yml
+++ b/.github/workflows/security-scan-images.yml
@@ -416,14 +416,10 @@ jobs:
 
   # ============================================================================
   # CVE — Trivy scan on PR images.
-  # TEMPORARILY DISABLED: PR-mode CVE scan currently misbehaves (false-positive
-  # noise / wrong PR-diff filter). Re-enable by removing the `if: false` guard
-  # once the underlying script is fixed. While disabled, the aggregator below
-  # explicitly allows `cve: skipped`, so it does not block PR merges.
   # ============================================================================
   test_cve_report_main:
     name: Trivy scan dev images
-    if: ${{ false }}
+    if: ${{ needs.changed_images.outputs.changed_count != '0' }}
     # External/fork PRs gated by 'status/ok-to-test' via pull_request_info (setFailed → this job is skipped).
     needs:
       - pull_request_info

--- a/.github/workflows/security-scan-images.yml
+++ b/.github/workflows/security-scan-images.yml
@@ -4,17 +4,17 @@
 
 # Copyright 2026 Flant JSC
 #
-  # Licensed under the Apache License, Version 2.0 (the "License");
-  # you may not use this file except in compliance with the License.
-  # You may obtain a copy of the License at
-  #
-  #     http://www.apache.org/licenses/LICENSE-2.0
-  #
-  # Unless required by applicable law or agreed to in writing, software
-  # distributed under the License is distributed on an "AS IS" BASIS,
-  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  # See the License for the specific language governing permissions and
-  # limitations under the License.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 name: Security Scan Images
 

--- a/.github/workflows/security-scan-images.yml
+++ b/.github/workflows/security-scan-images.yml
@@ -913,22 +913,23 @@ jobs:
           echo "tags=$(printf '%s' "$TAG" | jq -R -s -c 'split("\n") | map(select(length > 0))')" >> $GITHUB_OUTPUT
 
 
-    # <template: drweb_scan_job>
+  # <template: drweb_scan_job>
   drweb-scan:
-    name: Dr.Web Scan ${{ matrix.branch }}
+    name: Dr.Web Scan
     runs-on: [self-hosted, antivirus]
     if: github.repository == 'deckhouse/deckhouse'
-  needs: [changed_images, get-tags]
-  strategy:
-    matrix:
-      branch: ${{ fromJson(needs.get-tags.outputs.tags) }}
-    fail-fast: false
-  permissions:
-    id-token: write
-  outputs:
-    scan_id: ${{ steps.scan.outputs.scan_id }}
-    skipped: ${{ steps.scan.outputs.skipped }}
-  steps:
+    # PR mode: filter scanned images by the changed_images diff (delta-only scan).
+    needs: [get-tags, changed_images]
+    strategy:
+      matrix:
+        branch: ${{ fromJson(needs.get-tags.outputs.tags) }}
+      fail-fast: false
+    permissions:
+      id-token: write
+    outputs:
+      scan_id: ${{ steps.scan.outputs.scan_id }}
+      skipped: ${{ steps.scan.outputs.skipped }}
+    steps:
       # <template: import_secrets>
       - name: Split repository name
         id: split
@@ -1076,26 +1077,27 @@ jobs:
             rm -rf ${SCAN_DIR}/${SCAN_ID} || true
           fi
 
-    # </template: drweb_scan_job>
+  # </template: drweb_scan_job>
 
 
 
-    # <template: kaspersky_scan_job>
+  # <template: kaspersky_scan_job>
   kaspersky-scan:
-    name: Kaspersky Scan ${{ matrix.branch }}
+    name: Kaspersky Scan
     runs-on: [self-hosted, antivirus]
     if: github.repository == 'deckhouse/deckhouse'
-  needs: [changed_images, get-tags]
-  strategy:
-    matrix:
-      branch: ${{ fromJson(needs.get-tags.outputs.tags) }}
-    fail-fast: false
-  permissions:
-    id-token: write
-  outputs:
-    scan_id: ${{ steps.scan.outputs.scan_id }}
-    skipped: ${{ steps.scan.outputs.skipped }}
-  steps:
+    # PR mode: filter scanned images by the changed_images diff (delta-only scan).
+    needs: [get-tags, changed_images]
+    strategy:
+      matrix:
+        branch: ${{ fromJson(needs.get-tags.outputs.tags) }}
+      fail-fast: false
+    permissions:
+      id-token: write
+    outputs:
+      scan_id: ${{ steps.scan.outputs.scan_id }}
+      skipped: ${{ steps.scan.outputs.skipped }}
+    steps:
       # <template: import_secrets>
       - name: Split repository name
         id: split
@@ -1243,11 +1245,11 @@ jobs:
             rm -rf ${SCAN_DIR}/${SCAN_ID} || true
           fi
 
-    # </template: kaspersky_scan_job>
+  # </template: kaspersky_scan_job>
 
 
 
-    # <template: set_security_antivirus_requirement_status>
+  # <template: set_security_antivirus_requirement_status>
   set_security_antivirus_requirement_status:
     name: Set commit status after antivirus scan run
     runs-on: "self-slim"
@@ -1288,10 +1290,10 @@ jobs:
           else
             gh pr edit "$PR_NUMBER" --add-label "security/antivirus/failed" --remove-label "security/antivirus/success"
           fi
-    # </template: set_security_antivirus_requirement_status>
+  # </template: set_security_antivirus_requirement_status>
 
 
-    # <template: antivirus_notify_failure_job>
+  # <template: antivirus_notify_failure_job>
   notify-failure:
     name: Send failure notification
     runs-on: [self-hosted, regular]
@@ -1325,39 +1327,39 @@ jobs:
 
       # </template: import_secrets>
 
-  - name: Check which jobs failed
-    id: check-failures
-    run: |
-      FAILED_JOBS=""
-      if [[ "${{ needs.drweb-scan.result }}" == "failure" ]]; then
-        FAILED_JOBS="$FAILED_JOBS• Dr.Web Scan\n"
-      fi
-      if [[ "${{ needs.kaspersky-scan.result }}" == "failure" ]]; then
-        FAILED_JOBS="$FAILED_JOBS• Kaspersky Scan\n"
-      fi
+      - name: Check which jobs failed
+        id: check-failures
+        run: |
+          FAILED_JOBS=""
+          if [[ "${{ needs.drweb-scan.result }}" == "failure" ]]; then
+            FAILED_JOBS="$FAILED_JOBS• Dr.Web Scan\n"
+          fi
+          if [[ "${{ needs.kaspersky-scan.result }}" == "failure" ]]; then
+            FAILED_JOBS="$FAILED_JOBS• Kaspersky Scan\n"
+          fi
 
-      echo "failed_jobs=${FAILED_JOBS}" >> $GITHUB_OUTPUT
-      echo "Failed jobs:"
-      echo "${FAILED_JOBS}"
+          echo "failed_jobs=${FAILED_JOBS}" >> $GITHUB_OUTPUT
+          echo "Failed jobs:"
+          echo "${FAILED_JOBS}"
 
-  - name: Send notification
-    run: |
-      workflow_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+      - name: Send notification
+        run: |
+          workflow_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
-      MESSAGE="🛑 Github Antivirus Scan Failed!\n\n"
-      MESSAGE+="**Failed jobs:**\n"
-      MESSAGE+="${{ steps.check-failures.outputs.failed_jobs }}\n"
-      PR_NUMBER="${{ github.event.pull_request.number }}"
-      if [ -n "$PR_NUMBER" ]; then
-        pr_url="https://github.com/${{ github.repository }}/pull/${PR_NUMBER}"
-        MESSAGE+="**PR:** [#${PR_NUMBER}]($pr_url)\n"
-      fi
-      MESSAGE+="**Workflow URL:** [View Run]($workflow_url)\n"
+          MESSAGE="🛑 Github Antivirus Scan Failed!\n\n"
+          MESSAGE+="**Failed jobs:**\n"
+          MESSAGE+="${{ steps.check-failures.outputs.failed_jobs }}\n"
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          if [ -n "$PR_NUMBER" ]; then
+            pr_url="https://github.com/${{ github.repository }}/pull/${PR_NUMBER}"
+            MESSAGE+="**PR:** [#${PR_NUMBER}]($pr_url)\n"
+          fi
+          MESSAGE+="**Workflow URL:** [View Run]($workflow_url)\n"
 
-      curl -f -L -X POST "${{ steps.secrets.outputs.N8N_LOOP_NOTIFIER_URL }}" \
-        -H "Content-Type: application/json" \
-        --data "{\"type\": \"ci_fail\",\"message\":\"$MESSAGE\"}"
-    # </template: antivirus_notify_failure_job>
+          curl -f -L -X POST "${{ steps.secrets.outputs.N8N_LOOP_NOTIFIER_URL }}" \
+            -H "Content-Type: application/json" \
+            --data "{\"type\": \"ci_fail\",\"message\":\"$MESSAGE\"}"
+  # </template: antivirus_notify_failure_job>
 
 
   # ============================================================================

--- a/.github/workflows/security-scan-images.yml
+++ b/.github/workflows/security-scan-images.yml
@@ -913,22 +913,22 @@ jobs:
           echo "tags=$(printf '%s' "$TAG" | jq -R -s -c 'split("\n") | map(select(length > 0))')" >> $GITHUB_OUTPUT
 
 
-  # <template: drweb_scan_job>
+    # <template: drweb_scan_job>
   drweb-scan:
     name: Dr.Web Scan ${{ matrix.branch }}
     runs-on: [self-hosted, antivirus]
-    if: ${{ false }}
-    # PR mode: filter scanned images by the changed_images diff (delta-only scan).
-    needs: [get-tags, changed_images]
-    strategy:
-      matrix:
-        branch: ${{ fromJson(needs.get-tags.outputs.tags) }}
-      fail-fast: false
-    permissions:
-      id-token: write
-    outputs:
-      scan_id: ${{ steps.scan.outputs.scan_id }}
-    steps:
+    if: github.repository == 'deckhouse/deckhouse'
+  needs: [changed_images, get-tags]
+  strategy:
+    matrix:
+      branch: ${{ fromJson(needs.get-tags.outputs.tags) }}
+    fail-fast: false
+  permissions:
+    id-token: write
+  outputs:
+    scan_id: ${{ steps.scan.outputs.scan_id }}
+    skipped: ${{ steps.scan.outputs.skipped }}
+  steps:
       # <template: import_secrets>
       - name: Split repository name
         id: split
@@ -959,14 +959,21 @@ jobs:
         id: scan
         env:
           # `ONLY_IMAGES` comes from needs.changed_images.outputs.changed_compact
-          # (JSON array of "<module>.<image>" keys). Wired here for PR runs of both
-          # drweb-scan and kaspersky-scan when their templates are called with
-          # `withChangedImages: true` (see security-scan-images.yml). In weekly /
-          # release runs the templates pass empty `only_images_expr`, so this env
-          # block is omitted and the Go scanner falls back to full-scan.
-          # Empty value / "[]" is treated by the Go scanner as full-scan, so the
-          # bash side does not need to branch on it.
+          # (JSON array of "<module>.<image>" keys from images_digests.json).
+          # Wired here for PR runs of both drweb-scan and kaspersky-scan when their
+          # templates are called with `withChangedImages: true`
+          # (see security-scan-images.yml).
+          #
+          # `CHANGED_COUNT` is the total number of rebuilt final images from
+          # changed_images.py, including non-module/static images that do not have
+          # compact keys in images_digests.json.
+          #
+          # If CHANGED_COUNT is 0, there is nothing to scan.
+          # If CHANGED_COUNT is greater than 0 but ONLY_IMAGES is empty, run a full
+          # scan fallback to cover static/non-module images.
+          # Weekly / release runs do not pass these envs and still run full-scan.
           ONLY_IMAGES: ${{ needs.changed_images.outputs.changed_compact }}
+          CHANGED_COUNT: ${{ needs.changed_images.outputs.changed_count }}
         run: |
           registry_image_path=/sys/deckhouse-oss
           ref=$(echo "${{ matrix.branch }}" | awk -F':' '{ print $2 }' | tr -d '\n')
@@ -995,18 +1002,33 @@ jobs:
           SCAN_DIR=/opt/actions-runners/scans/drweb
           echo "scan_id=${SCAN_ID}" >> $GITHUB_OUTPUT
           echo "scan_dir=${SCAN_DIR}" >> $GITHUB_OUTPUT
+          echo "skipped=false" >> $GITHUB_OUTPUT
           echo $CONTAINER_NAME
           echo "----------------------------------------------"
-          if [[ -n "${ONLY_IMAGES:-}" ]] && [[ "${ONLY_IMAGES}" != "[]" ]]; then
+          if [[ -z "${ONLY_IMAGES:-}" || "${ONLY_IMAGES}" == "[]" || "${ONLY_IMAGES}" == "null" ]]; then
+            if [[ "${CHANGED_COUNT:-0}" == "0" ]]; then
+              echo "Skip drweb scan: no rebuilt images in this PR. Nothing to scan."
+              echo "skipped=true" >> "$GITHUB_OUTPUT"
+              echo "----------------------------------------------"
+              exit 0
+            fi
+
+            echo "Changed images detected (${CHANGED_COUNT}), but no module compact keys found."
+            echo "Run full drweb scan fallback to cover static/non-module images."
+            unset ONLY_IMAGES
+          else
             keys_count=$(jq -r 'length' <<< "${ONLY_IMAGES}")
             echo "🎯 Delta-scan: forwarding ONLY_IMAGES (${keys_count} key(s)) to the drweb scanner."
             jq -r '.[] | "    • " + .' <<< "${ONLY_IMAGES}"
-          else
-            echo "📋 Full-scan: ONLY_IMAGES is empty (no delta in this PR)."
           fi
           echo "----------------------------------------------"
-          docker exec -e ONLY_IMAGES="${ONLY_IMAGES:-}" ${CONTAINER_NAME} \
-            scanner "${ref}" "${registry_host}${registry_image_path}" "${SCAN_ID}"
+          if [[ -n "${ONLY_IMAGES:-}" ]]; then
+            docker exec -e ONLY_IMAGES="${ONLY_IMAGES}" ${CONTAINER_NAME} \
+              scanner "${ref}" "${registry_host}${registry_image_path}" "${SCAN_ID}"
+          else
+            docker exec ${CONTAINER_NAME} \
+              scanner "${ref}" "${registry_host}${registry_image_path}" "${SCAN_ID}"
+          fi
           # Drop container-uid ownership so the host-side Upload/Cleanup steps below
           # (and the `${SCAN_DIR}/.../scan_results_threats.md` read just below) can
           # touch the bind-mounted scan artifacts under the runner's UID (this step
@@ -1033,7 +1055,7 @@ jobs:
           echo "✅ ${CONTAINER_NAME} scan completed for ${{ matrix.branch }}"
 
       - name: Upload scan artifacts
-        if: github.repository == 'deckhouse/deckhouse' && always()
+        if: github.repository == 'deckhouse/deckhouse' && always() && steps.scan.outputs.skipped != 'true'
         uses: actions/upload-artifact@v4.4.0
         with:
           name: drweb-scan-results-${{ steps.scan.outputs.scan_id }}
@@ -1054,26 +1076,26 @@ jobs:
             rm -rf ${SCAN_DIR}/${SCAN_ID} || true
           fi
 
-  # </template: drweb_scan_job>
+    # </template: drweb_scan_job>
 
 
 
-  # <template: kaspersky_scan_job>
+    # <template: kaspersky_scan_job>
   kaspersky-scan:
     name: Kaspersky Scan ${{ matrix.branch }}
     runs-on: [self-hosted, antivirus]
-    if: ${{ false }}
-    # PR mode: filter scanned images by the changed_images diff (delta-only scan).
-    needs: [get-tags, changed_images]
-    strategy:
-      matrix:
-        branch: ${{ fromJson(needs.get-tags.outputs.tags) }}
-      fail-fast: false
-    permissions:
-      id-token: write
-    outputs:
-      scan_id: ${{ steps.scan.outputs.scan_id }}
-    steps:
+    if: github.repository == 'deckhouse/deckhouse'
+  needs: [changed_images, get-tags]
+  strategy:
+    matrix:
+      branch: ${{ fromJson(needs.get-tags.outputs.tags) }}
+    fail-fast: false
+  permissions:
+    id-token: write
+  outputs:
+    scan_id: ${{ steps.scan.outputs.scan_id }}
+    skipped: ${{ steps.scan.outputs.skipped }}
+  steps:
       # <template: import_secrets>
       - name: Split repository name
         id: split
@@ -1104,14 +1126,21 @@ jobs:
         id: scan
         env:
           # `ONLY_IMAGES` comes from needs.changed_images.outputs.changed_compact
-          # (JSON array of "<module>.<image>" keys). Wired here for PR runs of both
-          # drweb-scan and kaspersky-scan when their templates are called with
-          # `withChangedImages: true` (see security-scan-images.yml). In weekly /
-          # release runs the templates pass empty `only_images_expr`, so this env
-          # block is omitted and the Go scanner falls back to full-scan.
-          # Empty value / "[]" is treated by the Go scanner as full-scan, so the
-          # bash side does not need to branch on it.
+          # (JSON array of "<module>.<image>" keys from images_digests.json).
+          # Wired here for PR runs of both drweb-scan and kaspersky-scan when their
+          # templates are called with `withChangedImages: true`
+          # (see security-scan-images.yml).
+          #
+          # `CHANGED_COUNT` is the total number of rebuilt final images from
+          # changed_images.py, including non-module/static images that do not have
+          # compact keys in images_digests.json.
+          #
+          # If CHANGED_COUNT is 0, there is nothing to scan.
+          # If CHANGED_COUNT is greater than 0 but ONLY_IMAGES is empty, run a full
+          # scan fallback to cover static/non-module images.
+          # Weekly / release runs do not pass these envs and still run full-scan.
           ONLY_IMAGES: ${{ needs.changed_images.outputs.changed_compact }}
+          CHANGED_COUNT: ${{ needs.changed_images.outputs.changed_count }}
         run: |
           registry_image_path=/sys/deckhouse-oss
           ref=$(echo "${{ matrix.branch }}" | awk -F':' '{ print $2 }' | tr -d '\n')
@@ -1140,18 +1169,33 @@ jobs:
           SCAN_DIR=/opt/actions-runners/scans/kaspersky
           echo "scan_id=${SCAN_ID}" >> $GITHUB_OUTPUT
           echo "scan_dir=${SCAN_DIR}" >> $GITHUB_OUTPUT
+          echo "skipped=false" >> $GITHUB_OUTPUT
           echo $CONTAINER_NAME
           echo "----------------------------------------------"
-          if [[ -n "${ONLY_IMAGES:-}" ]] && [[ "${ONLY_IMAGES}" != "[]" ]]; then
+          if [[ -z "${ONLY_IMAGES:-}" || "${ONLY_IMAGES}" == "[]" || "${ONLY_IMAGES}" == "null" ]]; then
+            if [[ "${CHANGED_COUNT:-0}" == "0" ]]; then
+              echo "Skip kaspersky scan: no rebuilt images in this PR. Nothing to scan."
+              echo "skipped=true" >> "$GITHUB_OUTPUT"
+              echo "----------------------------------------------"
+              exit 0
+            fi
+
+            echo "Changed images detected (${CHANGED_COUNT}), but no module compact keys found."
+            echo "Run full kaspersky scan fallback to cover static/non-module images."
+            unset ONLY_IMAGES
+          else
             keys_count=$(jq -r 'length' <<< "${ONLY_IMAGES}")
             echo "🎯 Delta-scan: forwarding ONLY_IMAGES (${keys_count} key(s)) to the kaspersky scanner."
             jq -r '.[] | "    • " + .' <<< "${ONLY_IMAGES}"
-          else
-            echo "📋 Full-scan: ONLY_IMAGES is empty (no delta in this PR)."
           fi
           echo "----------------------------------------------"
-          docker exec -e ONLY_IMAGES="${ONLY_IMAGES:-}" ${CONTAINER_NAME} \
-            scanner "${ref}" "${registry_host}${registry_image_path}" "${SCAN_ID}"
+          if [[ -n "${ONLY_IMAGES:-}" ]]; then
+            docker exec -e ONLY_IMAGES="${ONLY_IMAGES}" ${CONTAINER_NAME} \
+              scanner "${ref}" "${registry_host}${registry_image_path}" "${SCAN_ID}"
+          else
+            docker exec ${CONTAINER_NAME} \
+              scanner "${ref}" "${registry_host}${registry_image_path}" "${SCAN_ID}"
+          fi
           # Drop container-uid ownership so the host-side Upload/Cleanup steps below
           # (and the `${SCAN_DIR}/.../scan_results_threats.md` read just below) can
           # touch the bind-mounted scan artifacts under the runner's UID (this step
@@ -1178,7 +1222,7 @@ jobs:
           echo "✅ ${CONTAINER_NAME} scan completed for ${{ matrix.branch }}"
 
       - name: Upload scan artifacts
-        if: github.repository == 'deckhouse/deckhouse' && always()
+        if: github.repository == 'deckhouse/deckhouse' && always() && steps.scan.outputs.skipped != 'true'
         uses: actions/upload-artifact@v4.4.0
         with:
           name: kaspersky-scan-results-${{ steps.scan.outputs.scan_id }}
@@ -1199,15 +1243,15 @@ jobs:
             rm -rf ${SCAN_DIR}/${SCAN_ID} || true
           fi
 
-  # </template: kaspersky_scan_job>
+    # </template: kaspersky_scan_job>
 
 
 
-  # <template: set_security_antivirus_requirement_status>
+    # <template: set_security_antivirus_requirement_status>
   set_security_antivirus_requirement_status:
     name: Set commit status after antivirus scan run
     runs-on: "self-slim"
-    needs: [drweb-scan, kaspersky-scan]
+    needs: [changed_images, drweb-scan, kaspersky-scan]
     if: ${{ always() }}
     permissions:
       contents: read
@@ -1221,21 +1265,33 @@ jobs:
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           GH_REPO: ${{ github.repository }}
+          CHANGED_COUNT: ${{ needs.changed_images.outputs.changed_count }}
           DRWEB: ${{ needs.drweb-scan.result }}
           KASPERSKY: ${{ needs.kaspersky-scan.result }}
         run: |
-          echo "PR Number: $PR_NUMBER | Dr.Web: $DRWEB | Kaspersky: $KASPERSKY"
-          if [ "$DRWEB" == "success" ] && [ "$KASPERSKY" == "success" ]; then
-            gh pr edit "$PR_NUMBER" --add-label "security/antivirus/success" --remove-label "security/antivirus/failed"
-          elif [ "$DRWEB" == "skipped" ] && [ "$KASPERSKY" == "skipped" ]; then
+          echo "PR Number: $PR_NUMBER | changed_count=$CHANGED_COUNT | Dr.Web: $DRWEB | Kaspersky: $KASPERSKY"
+
+          if [[ "$GH_REPO" != "deckhouse/deckhouse" && "$DRWEB" == "skipped" && "$KASPERSKY" == "skipped" ]]; then
+            echo "Both antivirus scans were skipped in test repository. Antivirus labels are not set."
             gh pr edit "$PR_NUMBER" --remove-label "security/antivirus/success" --remove-label "security/antivirus/failed"
+            exit 0
+          fi
+
+          if [[ "${CHANGED_COUNT:-0}" == "0" ]]; then
+            echo "No rebuilt images in this PR. Antivirus labels are not set."
+            gh pr edit "$PR_NUMBER" --remove-label "security/antivirus/success" --remove-label "security/antivirus/failed"
+            exit 0
+          fi
+
+          if [[ "$DRWEB" == "success" && "$KASPERSKY" == "success" ]]; then
+            gh pr edit "$PR_NUMBER" --add-label "security/antivirus/success" --remove-label "security/antivirus/failed"
           else
             gh pr edit "$PR_NUMBER" --add-label "security/antivirus/failed" --remove-label "security/antivirus/success"
           fi
-  # </template: set_security_antivirus_requirement_status>
+    # </template: set_security_antivirus_requirement_status>
 
 
-  # <template: antivirus_notify_failure_job>
+    # <template: antivirus_notify_failure_job>
   notify-failure:
     name: Send failure notification
     runs-on: [self-hosted, regular]
@@ -1269,39 +1325,39 @@ jobs:
 
       # </template: import_secrets>
 
-      - name: Check which jobs failed
-        id: check-failures
-        run: |
-          FAILED_JOBS=""
-          if [[ "${{ needs.drweb-scan.result }}" == "failure" ]]; then
-            FAILED_JOBS="$FAILED_JOBS• Dr.Web Scan\n"
-          fi
-          if [[ "${{ needs.kaspersky-scan.result }}" == "failure" ]]; then
-            FAILED_JOBS="$FAILED_JOBS• Kaspersky Scan\n"
-          fi
+  - name: Check which jobs failed
+    id: check-failures
+    run: |
+      FAILED_JOBS=""
+      if [[ "${{ needs.drweb-scan.result }}" == "failure" ]]; then
+        FAILED_JOBS="$FAILED_JOBS• Dr.Web Scan\n"
+      fi
+      if [[ "${{ needs.kaspersky-scan.result }}" == "failure" ]]; then
+        FAILED_JOBS="$FAILED_JOBS• Kaspersky Scan\n"
+      fi
 
-          echo "failed_jobs=${FAILED_JOBS}" >> $GITHUB_OUTPUT
-          echo "Failed jobs:"
-          echo "${FAILED_JOBS}"
+      echo "failed_jobs=${FAILED_JOBS}" >> $GITHUB_OUTPUT
+      echo "Failed jobs:"
+      echo "${FAILED_JOBS}"
 
-      - name: Send notification
-        run: |
-          workflow_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+  - name: Send notification
+    run: |
+      workflow_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
-          MESSAGE="🛑 Github Antivirus Scan Failed!\n\n"
-          MESSAGE+="**Failed jobs:**\n"
-          MESSAGE+="${{ steps.check-failures.outputs.failed_jobs }}\n"
-          PR_NUMBER="${{ github.event.pull_request.number }}"
-          if [ -n "$PR_NUMBER" ]; then
-            pr_url="https://github.com/${{ github.repository }}/pull/${PR_NUMBER}"
-            MESSAGE+="**PR:** [#${PR_NUMBER}]($pr_url)\n"
-          fi
-          MESSAGE+="**Workflow URL:** [View Run]($workflow_url)\n"
+      MESSAGE="🛑 Github Antivirus Scan Failed!\n\n"
+      MESSAGE+="**Failed jobs:**\n"
+      MESSAGE+="${{ steps.check-failures.outputs.failed_jobs }}\n"
+      PR_NUMBER="${{ github.event.pull_request.number }}"
+      if [ -n "$PR_NUMBER" ]; then
+        pr_url="https://github.com/${{ github.repository }}/pull/${PR_NUMBER}"
+        MESSAGE+="**PR:** [#${PR_NUMBER}]($pr_url)\n"
+      fi
+      MESSAGE+="**Workflow URL:** [View Run]($workflow_url)\n"
 
-          curl -f -L -X POST "${{ steps.secrets.outputs.N8N_LOOP_NOTIFIER_URL }}" \
-            -H "Content-Type: application/json" \
-            --data "{\"type\": \"ci_fail\",\"message\":\"$MESSAGE\"}"
-  # </template: antivirus_notify_failure_job>
+      curl -f -L -X POST "${{ steps.secrets.outputs.N8N_LOOP_NOTIFIER_URL }}" \
+        -H "Content-Type: application/json" \
+        --data "{\"type\": \"ci_fail\",\"message\":\"$MESSAGE\"}"
+    # </template: antivirus_notify_failure_job>
 
 
   # ============================================================================

--- a/.github/workflows/security-scan-images.yml
+++ b/.github/workflows/security-scan-images.yml
@@ -1304,9 +1304,9 @@ jobs:
               echo "✅ $name: $r"
               continue
             fi
-            # CVE PR-mode is temporarily disabled (test_cve_report_main has `if: false`); allow skipped until re-enabled.
-            if [[ "$name" == "cve" && "$r" == "skipped" ]]; then
-              echo "ℹ️  $name: $r (temporarily disabled)"
+            # nothing to scan
+            if [[ "$name" == "cve" && "$r" == "skipped" && "${{ needs.changed_images.outputs.changed_count }}" == "0" ]]; then
+              echo "ℹ️  $name: $r (no changed images)"
               continue
             fi
             if [[ "$IS_MAIN_REPO" == "false" && ( "$name" == "drweb" || "$name" == "kaspersky" ) && "$r" == "skipped" ]]; then

--- a/.github/workflows/security-scan-images.yml
+++ b/.github/workflows/security-scan-images.yml
@@ -416,10 +416,14 @@ jobs:
 
   # ============================================================================
   # CVE — Trivy scan on PR images.
+  # TEMPORARILY DISABLED:
+  # Re-enable by set the `if: ${{ needs.changed_images.outputs.changed_count != '0' }}`
+  # guard once the underlying script is fixed. While disabled, the aggregator
+  # below explicitly allows `cve: skipped`, so it does not block PR merges.
   # ============================================================================
   test_cve_report_main:
     name: Trivy scan dev images
-    if: ${{ needs.changed_images.outputs.changed_count != '0' }}
+    if: ${{ false }}
     # External/fork PRs gated by 'status/ok-to-test' via pull_request_info (setFailed → this job is skipped).
     needs:
       - pull_request_info
@@ -1304,9 +1308,9 @@ jobs:
               echo "✅ $name: $r"
               continue
             fi
-            # nothing to scan
-            if [[ "$name" == "cve" && "$r" == "skipped" && "${{ needs.changed_images.outputs.changed_count }}" == "0" ]]; then
-              echo "ℹ️  $name: $r (no changed images)"
+       # CVE SCAN is intentionally DISABLED for PR mode.
+            if [[ "$name" == "cve" && "$r" == "skipped" ]]; then
+              echo "ℹ️  $name: $r (temporarily disabled)"
               continue
             fi
             if [[ "$IS_MAIN_REPO" == "false" && ( "$name" == "drweb" || "$name" == "kaspersky" ) && "$r" == "skipped" ]]; then


### PR DESCRIPTION
## Description
This PR updates PR-time image security scan selection.
The changed image detection now uses the current Build FE report and selects final werf images whose Commit belongs to the current PR commit range.
The antivirus scan jobs now receive this changed_compact list through ONLY_IMAGES. If the list is empty, Dr.Web and Kaspersky scans are skipped with an explicit log message:
`No rebuilt images in this PR. Nothing to scan.`
Scan artifacts are not uploaded for skipped antivirus scans. The antivirus status label logic was also updated so skipped scans caused by an empty image diff remove both success and failed antivirus labels instead of marking the scan as successful.
## Why do we need it, and what problem does it solve?
Before this change, PR image scans could fall back to scanning all images when the changed image diff was empty. This wastes runner time and scanner capacity.
Using Rebuilt is also not reliable enough for PR diff detection. A module image can be rebuilt in an earlier PR run and then reused from cache in a later run. In that case Rebuilt can be false even though the image still belongs to the PR changes.
This PR uses the image Commit from the Build FE report instead. If a final image points to a commit from the current PR range, it is selected for scanning. This keeps scan selection stable across reruns and cached builds.
## Why do we need it in the patch release (if we do)?
This is needed in a patch release only if we want to reduce unnecessary PR-time antivirus scans and avoid full antivirus scans when no module images changed.
The change affects CI scan selection only. It does not change Deckhouse runtime behavior.
## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: ci
type: fix
summary: Fix diff images logic and add skip PR antivirus image scans when no module images were changed.
impact: PR antivirus scans now use the changed image list from the Build FE report. If no module images were changed in a PR, Dr.Web and Kaspersky scans are skipped with a clear log message instead of running a full scan.
impact_level: low
```
