### PR TITLE
[istio] Fix operator v1.25 cleanup on revision change

### DIFF
--- a/modules/110-istio/hooks/discovery_operator_versions_to_install.go
+++ b/modules/110-istio/hooks/discovery_operator_versions_to_install.go
@@ -65,9 +65,14 @@ func applyIstioFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, err
 		return nil, err
 	}
 
+	revision := istio.Spec.Revision
+	if revision == "" {
+		revision = istio.GetName()
+	}
+
 	return IstioOperatorCrdInfo{
 		Name:     istio.GetName(),
-		Revision: istio.Spec.Revision,
+		Revision: revision,
 	}, nil
 }
 
@@ -128,7 +133,7 @@ func operatorRevisionsToInstallDiscovery(_ context.Context, input *go_hook.HookI
 		}
 	}
 
-	istios, err := k8sClient.Dynamic().Resource(istioGVR).Namespace(istioNamespace).List(context.TODO(), metav1.ListOptions{})
+	istios, err := k8sClient.Dynamic().Resource(istioGVR).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		// The CRD can be absent on old control planes; this is expected.
 		if !k8serrors.IsNotFound(err) {

--- a/modules/110-istio/hooks/discovery_operator_versions_to_install_test.go
+++ b/modules/110-istio/hooks/discovery_operator_versions_to_install_test.go
@@ -26,7 +26,7 @@ import (
 var _ = Describe("Istio hooks :: discovery_operator_versions_to_install ::", func() {
 	f := HookExecutionConfigInit(`{"istio":{}}`, "")
 	f.RegisterCRD("install.istio.io", "v1alpha1", "IstioOperator", true)
-	f.RegisterCRD("sailoperator.io", "v1", "Istio", true)
+	f.RegisterCRD("sailoperator.io", "v1", "Istio", false)
 
 	Context("Empty cluster and minimal settings", func() {
 		BeforeEach(func() {
@@ -134,17 +134,15 @@ apiVersion: sailoperator.io/v1
 kind: Istio
 metadata:
   name: v1x8
-  namespace: d8-istio
 spec:
-  revision: v1x8
+  namespace: d8-istio
 ---
 apiVersion: sailoperator.io/v1
 kind: Istio
 metadata:
   name: v1x2
-  namespace: d8-istio
 spec:
-  revision: v1x2
+  namespace: d8-istio
 `))
 
 			f.RunHook()
@@ -265,6 +263,39 @@ spec:
 		It("Should not add operator-free version from CRD", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.ValuesGet("istio.internal.operatorVersionsToInstall").AsStringSlice()).To(BeEmpty())
+		})
+	})
+
+	Context("Retiring Sail Istio CR keeps operator version", func() {
+		BeforeEach(func() {
+			values := `
+internal:
+  versionMap:
+    "1.25":
+        revision: "v1x25"
+        supportsOperator: true
+    "1.27":
+        revision: "v1x27"
+        supportsOperator: false
+  versionsToInstall: ["1.27"]
+`
+			f.ValuesSetFromYaml("istio", []byte(values))
+			f.BindingContexts.Set(f.KubeStateSet(`
+---
+apiVersion: sailoperator.io/v1
+kind: Istio
+metadata:
+  name: v1x25
+spec:
+  namespace: d8-istio
+  version: v1.25.2
+`))
+			f.RunHook()
+		})
+
+		It("Should keep operator for retiring revision from cluster Istio CR", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("istio.internal.operatorVersionsToInstall").AsStringSlice()).To(Equal([]string{"1.25"}))
 		})
 	})
 


### PR DESCRIPTION
## Description
Fixed flow of revision change, when `operator-v1x25` just disappeared and left other non-Helm CRs of v1.25 in place.

## Why do we need it, and what problem does it solve?
When you have v1.25 installed and remove it from `additionalVersions` or swap `globalVersion` to another - CR `istio-v1x25` was just deleted with no chance for other istio v1.25 CRs to follow its deleting.

Keep operator-v1x25 in operatorVersionsToInstall while retiring Istio CR still exists, so the operator can cascade-delete istiod instead of being removed with the CR in the same Helm pass.

Now hard (global to global) and soft (add additional, swap global and additional, remove additional) change of revision works properly.


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: fix
summary: More stable switching between Istio revisions.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
