### PR TITLE
[dhctl] fix(dhctl-for-commander): bind registry packages proxy to an OS-assigned local port to avoid collisions during parallel bootstrap

### DIFF
--- a/dhctl/pkg/operations/bootstrap/rpp/proxy.go
+++ b/dhctl/pkg/operations/bootstrap/rpp/proxy.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"strconv"
 
 	"github.com/name212/govalue"
 
@@ -87,9 +88,7 @@ func NewRegistryPackagesProxy(clusterDomain string, configGetter registry.Client
 	return &RegistryPackagesProxy{
 		clusterDomain:       clusterDomain,
 		configGetter:        configGetter,
-		localPort:           registryPackagesProxyPort,
 		remotePort:          registryPackagesProxyPort,
-		bootstrapLocalPort:  rppGetBinaryPort,
 		bootstrapRemotePort: rppGetBinaryPort,
 		signCheck:           false,
 		loggerProvider:      logger,
@@ -102,25 +101,9 @@ func (p *RegistryPackagesProxy) WithSignCheck(f bool) *RegistryPackagesProxy {
 	return p
 }
 
-func (p *RegistryPackagesProxy) WithLocalPort(port string) *RegistryPackagesProxy {
-	if port != "" {
-		p.localPort = port
-	}
-
-	return p
-}
-
 func (p *RegistryPackagesProxy) WithRemotePort(port string) *RegistryPackagesProxy {
 	if port != "" {
 		p.remotePort = port
-	}
-
-	return p
-}
-
-func (p *RegistryPackagesProxy) WithBootstrapLocalPort(port string) *RegistryPackagesProxy {
-	if port != "" {
-		p.bootstrapLocalPort = port
 	}
 
 	return p
@@ -156,15 +139,15 @@ func (p *RegistryPackagesProxy) Start(ctx context.Context) error {
 }
 
 func (p *RegistryPackagesProxy) upTunnel(ctx context.Context, sshCl libcon.SSHClient) error {
-	if govalue.IsNil(sshCl) {
+	if govalue.Nil(sshCl) {
 		return upTunnelError(fmt.Errorf("internal error - ssh client is nil"))
 	}
 
-	if govalue.IsNil(p.opts) {
+	if govalue.Nil(p.opts) {
 		return upTunnelError(fmt.Errorf("internal error - global options is nil"))
 	}
 
-	if govalue.IsNil(p.proxy) {
+	if govalue.Nil(p.proxy) {
 		return upTunnelError(fmt.Errorf("internal error - proxy is not started"))
 	}
 
@@ -195,13 +178,13 @@ func (p *RegistryPackagesProxy) Stop() {
 		tunnelMessage = stoppedMsg
 	}
 
-	if !govalue.IsNil(p.proxy) {
+	if !govalue.Nil(p.proxy) {
 		p.proxy.StopProxy()
 		p.proxy = nil
 		proxyMessage = stoppedMsg
 	}
 
-	if !govalue.IsNil(p.rppGetServer) {
+	if !govalue.Nil(p.rppGetServer) {
 		p.rppGetServer.Stop()
 		p.rppGetServer = nil
 		rppGetServerMessage = stoppedMsg
@@ -215,7 +198,7 @@ func (p *RegistryPackagesProxy) Stop() {
 func (p *RegistryPackagesProxy) startProxy() error {
 	p.debug("Starting registry packages proxy...")
 
-	if govalue.IsNil(p.configGetter) {
+	if govalue.Nil(p.configGetter) {
 		return fmt.Errorf("internal error: proxy configuration getter is nil")
 	}
 
@@ -233,7 +216,7 @@ func (p *RegistryPackagesProxy) startProxy() error {
 		return fmt.Errorf("failed to generate TLS certificate for registry proxy: %w", err)
 	}
 
-	addr := net.JoinHostPort(localhost, p.localPort)
+	addr := net.JoinHostPort(localhost, "0")
 	listener, err := tls.Listen("tcp", addr, &tls.Config{
 		Certificates: []tls.Certificate{*cert},
 	})
@@ -241,11 +224,24 @@ func (p *RegistryPackagesProxy) startProxy() error {
 		return fmt.Errorf("failed to listen registry proxy socket: %w", err)
 	}
 
-	bootstrapAddr := net.JoinHostPort(localhost, p.bootstrapLocalPort)
+	p.localPort, err = listenerPort(listener)
+	if err != nil {
+		_ = listener.Close()
+		return fmt.Errorf("failed to determine registry proxy socket port: %w", err)
+	}
+
+	bootstrapAddr := net.JoinHostPort(localhost, "0")
 	bootstrapListener, err := net.Listen("tcp", bootstrapAddr)
 	if err != nil {
 		_ = listener.Close()
 		return fmt.Errorf("failed to listen rpp-get socket: %w", err)
+	}
+
+	p.bootstrapLocalPort, err = listenerPort(bootstrapListener)
+	if err != nil {
+		_ = listener.Close()
+		_ = bootstrapListener.Close()
+		return fmt.Errorf("failed to determine rpp-get socket port: %w", err)
 	}
 
 	srv := &http.Server{}
@@ -302,7 +298,8 @@ func (p *RegistryPackagesProxy) startTunnel(ctx context.Context, sshCl libcon.SS
 
 func (p *RegistryPackagesProxy) upSingleTunnel(ctx context.Context, sshCl libcon.SSHClient, localPort, remotePort string, check tunnelCheckKind) (libcon.ReverseTunnel, error) {
 	listenAddress := localhost
-	addr := fmt.Sprintf("%s:%s:%s:%s", listenAddress, localPort, listenAddress, remotePort)
+	// sshCl.ReverseTunnel expects "remote_bind:remote_port:local_bind:local_port"
+	addr := fmt.Sprintf("%s:%s:%s:%s", listenAddress, remotePort, listenAddress, localPort)
 
 	// Kill script is needed both for the pre-bind reaper and as the health-monitor killer.
 	killScript, err := template.RenderAndSaveKillReverseTunnelScript(ctx, listenAddress, remotePort, p.opts)
@@ -340,6 +337,14 @@ func (p *RegistryPackagesProxy) upSingleTunnel(ctx context.Context, sshCl libcon
 	tun.StartHealthMonitor(ctx, checker, killer)
 
 	return tun, nil
+}
+
+func listenerPort(l net.Listener) (string, error) {
+	tcpAddr, ok := l.Addr().(*net.TCPAddr)
+	if !ok {
+		return "", fmt.Errorf("expected a TCP listener, got address of type %T", l.Addr())
+	}
+	return strconv.Itoa(tcpAddr.Port), nil
 }
 
 func (p *RegistryPackagesProxy) debug(f string, args ...any) {


### PR DESCRIPTION
## Description
PR fixes a port conflict in dhctl's registry packages proxy that broke parallel bootstrap tasks running in the same dhctl server pod (--server-parallel-tasks-limit > 1): the local TCP listeners previously bound to fixed ports (5444/4282), causing `bind: address already in use` when multiple child processes shared the pod's network namespace. 

Both listeners now bind to an OS-assigned port (127.0.0.1:0). 

Also fixed a latent bug where the local/remote port arguments were swapped in the tunnel address construction, and removed the unused WithLocalPort/WithBootstrapLocalPort options to prevent future misuse that would reintroduce the collision.

Replaced deprecated govalue.IsNil with govalue.Nil.

Tested parallel bootstrap, conberge, check, and destroy via commander.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Bound the registry packages proxy to an OS-assigned local port to avoid collisions during parallel bootstrap.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
