### PR TITLE
[cloud-providers] Revert legacy d8-cni-configuration hooks and templates removal

### DIFF
--- a/ee/modules/030-cloud-provider-dynamix/hooks/get_cni_secret.go
+++ b/ee/modules/030-cloud-provider-dynamix/hooks/get_cni_secret.go
@@ -1,0 +1,10 @@
+/*
+Copyright 2024 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package hooks
+
+import "github.com/deckhouse/deckhouse/go_lib/hooks/get_cni_secret"
+
+var _ = get_cni_secret.RegisterHook("cloudProviderDynamix")

--- a/ee/modules/030-cloud-provider-dynamix/openapi/values.yaml
+++ b/ee/modules/030-cloud-provider-dynamix/openapi/values.yaml
@@ -305,6 +305,10 @@ properties:
                 isDefault:
                   type: boolean
             description: List of storage classes.
+      cniSecretData:
+        type: string
+        x-examples:
+        - "Y25pOiBZMmxzYVhWdApjaWxpdW06IGV5SnRiMlJsSWpvZ0lsWllURUZPSW4wPQo="
       storageClasses:
         type: array
         items:

--- a/ee/modules/030-cloud-provider-dynamix/template_tests/module_test.go
+++ b/ee/modules/030-cloud-provider-dynamix/template_tests/module_test.go
@@ -59,6 +59,7 @@ const globalValues = `
 
 const moduleValuesA = `
 internal:
+  cniSecretData: "base64-encoded-string-or-placeholder"
   providerClusterConfiguration:
     apiVersion: deckhouse.io/v1
     kind: DynamixClusterConfiguration

--- a/ee/modules/030-cloud-provider-dynamix/templates/cni.yaml
+++ b/ee/modules/030-cloud-provider-dynamix/templates/cni.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: d8-cni-configuration
+  namespace: kube-system
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+data:
+{{- if hasKey .Values.cloudProviderDynamix.internal "cniSecretData" }}
+  {{- .Values.cloudProviderDynamix.internal.cniSecretData | b64dec | nindent 2 }}
+{{- else }}
+  cni: {{ b64enc "cilium" | quote }}
+  cilium: {{ b64enc "{\"mode\": \"VXLAN\"}" | quote }}
+{{- end }}

--- a/ee/modules/030-cloud-provider-huaweicloud/hooks/get_cni_secret.go
+++ b/ee/modules/030-cloud-provider-huaweicloud/hooks/get_cni_secret.go
@@ -1,0 +1,10 @@
+/*
+Copyright 2024 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package hooks
+
+import "github.com/deckhouse/deckhouse/go_lib/hooks/get_cni_secret"
+
+var _ = get_cni_secret.RegisterHook("cloudProviderHuaweicloud")

--- a/ee/modules/030-cloud-provider-huaweicloud/openapi/values.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/openapi/values.yaml
@@ -6,6 +6,10 @@ properties:
     type: object
     default: {}
     properties:
+      cniSecretData:
+        type: string
+        x-examples:
+        - "Y25pOiBZMmxzYVhWdApjaWxpdW06IGV5SnRiMlJsSWpvZ0lsWllURUZPSW4wPQo="
       providerClusterConfiguration:
         type: object
         additionalProperties: false

--- a/ee/modules/030-cloud-provider-huaweicloud/template_tests/module_test.go
+++ b/ee/modules/030-cloud-provider-huaweicloud/template_tests/module_test.go
@@ -58,6 +58,7 @@ const globalValues = `
 
 const moduleValuesA = `
 internal:
+  cniSecretData: "base64-encoded-string-or-placeholder"
   providerClusterConfiguration:
     apiVersion: deckhouse.io/v1
     kind: HuaweiCloudClusterConfiguration

--- a/ee/modules/030-cloud-provider-huaweicloud/templates/cni.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/templates/cni.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: d8-cni-configuration
+  namespace: kube-system
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+data:
+{{- if hasKey .Values.cloudProviderHuaweicloud.internal "cniSecretData" }}
+  {{- .Values.cloudProviderHuaweicloud.internal.cniSecretData | b64dec | nindent 2 }}
+{{- else }}
+  cni: {{ b64enc "cilium" | quote }}
+  cilium: {{ b64enc "{\"mode\": \"VXLAN\"}" | quote }}
+{{- end }}

--- a/ee/modules/030-cloud-provider-openstack/hooks/get_cni_secret.go
+++ b/ee/modules/030-cloud-provider-openstack/hooks/get_cni_secret.go
@@ -1,0 +1,10 @@
+/*
+Copyright 2022 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package hooks
+
+import "github.com/deckhouse/deckhouse/go_lib/hooks/get_cni_secret"
+
+var _ = get_cni_secret.RegisterHook("cloudProviderOpenstack")

--- a/ee/modules/030-cloud-provider-openstack/openapi/values.yaml
+++ b/ee/modules/030-cloud-provider-openstack/openapi/values.yaml
@@ -103,6 +103,10 @@ properties:
               type: string
             name:
               type: string
+      cniSecretData:
+        type: string
+        x-examples:
+        - "Y25pOiBZMmxzYVhWdApjaWxpdW06IGV5SnRiMlJsSWpvZ0lrUnBjbVZqZEZkcGRHaE9iMlJsVW05MWRHVnpJaXdnSW0xaGMzRjFaWEpoWkdWTmIyUmxJam9nSWs1bGRHWnBiSFJsY2lKOQo="
       discoveryData:
         type: object
         description: |

--- a/ee/modules/030-cloud-provider-openstack/templates/cni.yaml
+++ b/ee/modules/030-cloud-provider-openstack/templates/cni.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: d8-cni-configuration
+  namespace: kube-system
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+data:
+{{- if hasKey .Values.cloudProviderOpenstack.internal "cniSecretData" }}
+  {{- .Values.cloudProviderOpenstack.internal.cniSecretData | b64dec | nindent 2 }}
+{{- else }}
+  cni: {{ b64enc "cilium" | quote }}
+  {{- if or (eq .Values.cloudProviderOpenstack.internal.podNetworkMode "DirectRouting") (eq .Values.cloudProviderOpenstack.internal.podNetworkMode "DirectRoutingWithPortSecurityEnabled") }}
+  cilium: {{ b64enc "{\"mode\": \"DirectWithNodeRoutes\", \"masqueradeMode\": \"Netfilter\"}" | quote }}
+  {{- else if eq .Values.cloudProviderOpenstack.internal.podNetworkMode "VXLAN" }}
+  cilium: {{ b64enc "{\"mode\": \"VXLAN\", \"masqueradeMode\": \"BPF\"}" | quote }}
+  {{- end }}
+{{- end }}

--- a/ee/modules/030-cloud-provider-vcd/hooks/get_cni_secret.go
+++ b/ee/modules/030-cloud-provider-vcd/hooks/get_cni_secret.go
@@ -1,0 +1,10 @@
+/*
+Copyright 2023 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package hooks
+
+import "github.com/deckhouse/deckhouse/go_lib/hooks/get_cni_secret"
+
+var _ = get_cni_secret.RegisterHook("cloudProviderVcd")

--- a/ee/modules/030-cloud-provider-vcd/openapi/values.yaml
+++ b/ee/modules/030-cloud-provider-vcd/openapi/values.yaml
@@ -8,6 +8,10 @@ properties:
     properties:
       apiServerIp:
         type: string
+      cniSecretData:
+        type: string
+        x-examples:
+        - "Y25pOiBZMmxzYVhWdApjaWxpdW06IGV5SnRiMlJsSWpvZ0lrUnBjbVZqZEZkcGRHaE9iMlJsVW05MWRHVnpJbjA9Cg=="
       providerClusterConfiguration:
         type: object
         additionalProperties: false

--- a/ee/modules/030-cloud-provider-vcd/templates/cni.yaml
+++ b/ee/modules/030-cloud-provider-vcd/templates/cni.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: d8-cni-configuration
+  namespace: kube-system
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+data:
+{{- if hasKey .Values.cloudProviderVcd.internal "cniSecretData" }}
+  {{- .Values.cloudProviderVcd.internal.cniSecretData | b64dec | nindent 2 }}
+{{- else }}
+  cni: {{ b64enc "cilium" | quote }}
+  cilium: {{ b64enc "{\"mode\": \"DirectWithNodeRoutes\"}" | quote }}
+{{- end }}

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/hooks/get_cni_secret.go
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/hooks/get_cni_secret.go
@@ -1,0 +1,10 @@
+/*
+Copyright 2022 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package hooks
+
+import "github.com/deckhouse/deckhouse/go_lib/hooks/get_cni_secret"
+
+var _ = get_cni_secret.RegisterHook("cloudProviderVsphere")

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/openapi/values.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/openapi/values.yaml
@@ -441,3 +441,7 @@ properties:
                   type: string
                   minLength: 1
             description: List of storage policies
+      cniSecretData:
+        type: string
+        x-examples:
+        - "Y25pOiBZMmxzYVhWdApjaWxpdW06IGV5SnRiMlJsSWpvZ0lrUnBjbVZqZEZkcGRHaE9iMlJsVW05MWRHVnpJbjA9Cg=="

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/templates/cni.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/templates/cni.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: d8-cni-configuration
+  namespace: kube-system
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+data:
+{{- if hasKey .Values.cloudProviderVsphere.internal "cniSecretData" }}
+  {{- .Values.cloudProviderVsphere.internal.cniSecretData | b64dec | nindent 2 }}
+{{- else }}
+  cni: {{ b64enc "cilium" | quote }}
+  cilium: {{ b64enc "{\"mode\": \"DirectWithNodeRoutes\"}" | quote }}
+{{- end }}

--- a/ee/se-plus/modules/030-cloud-provider-zvirt/hooks/get_cni_secret.go
+++ b/ee/se-plus/modules/030-cloud-provider-zvirt/hooks/get_cni_secret.go
@@ -1,0 +1,10 @@
+/*
+Copyright 2025 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package hooks
+
+import "github.com/deckhouse/deckhouse/go_lib/hooks/get_cni_secret"
+
+var _ = get_cni_secret.RegisterHook("cloudProviderZvirt")

--- a/ee/se-plus/modules/030-cloud-provider-zvirt/openapi/values.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-zvirt/openapi/values.yaml
@@ -6,6 +6,10 @@ properties:
     type: object
     default: {}
     properties:
+      cniSecretData:
+        type: string
+        x-examples:
+        - "Y25pOiBZMmxzYVhWdApjaWxpdW06IGV5SnRiMlJsSWpvZ0lrUnBjbVZqZEZkcGRHaE9iMlJsVW05MWRHVnpJbjA9Cg=="
       providerClusterConfiguration:
         type: object
         additionalProperties: false

--- a/ee/se-plus/modules/030-cloud-provider-zvirt/templates/cni.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-zvirt/templates/cni.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: d8-cni-configuration
+  namespace: kube-system
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+data:
+{{- if hasKey .Values.cloudProviderZvirt.internal "cniSecretData" }}
+  {{- .Values.cloudProviderZvirt.internal.cniSecretData | b64dec | nindent 2 }}
+{{- else }}
+  cni: {{ b64enc "cilium" | quote }}
+  cilium: {{ b64enc "{\"mode\": \"DirectWithNodeRoutes\"}" | quote }}
+{{- end }}

--- a/go_lib/hooks/get_cni_secret/hook.go
+++ b/go_lib/hooks/get_cni_secret/hook.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2021 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package get_cni_secret
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
+)
+
+func applyCNISecretFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	secret := &v1.Secret{}
+	err := sdk.FromUnstructured(obj, secret)
+	if err != nil {
+		return "", fmt.Errorf("from unstructured: %w", err)
+	}
+
+	if _, ok := secret.Data["cni"]; !ok {
+		return "", fmt.Errorf("kube-system/d8-cni-configuration secret data field `cni` is absent: %q", secret.Data)
+	}
+
+	dataYAML, err := yaml.Marshal(secret.Data)
+	if err != nil {
+		return "", fmt.Errorf("marshal: %w", err)
+	}
+
+	return base64.StdEncoding.EncodeToString(dataYAML), nil
+}
+
+func RegisterHook(moduleName string) bool {
+	return sdk.RegisterFunc(&go_hook.HookConfig{
+		OnBeforeHelm: &go_hook.OrderedConfig{Order: 10},
+		Kubernetes: []go_hook.KubernetesConfig{
+			{
+				Name:       "cni_secret",
+				ApiVersion: "v1",
+				Kind:       "Secret",
+				NamespaceSelector: &types.NamespaceSelector{
+					NameSelector: &types.NameSelector{
+						MatchNames: []string{"kube-system"},
+					},
+				},
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{"d8-cni-configuration"},
+				},
+				FilterFunc: applyCNISecretFilter,
+			},
+		},
+	}, setCNISecretData(moduleName))
+}
+
+func setCNISecretData(moduleName string) func(_ context.Context, input *go_hook.HookInput) error {
+	return func(_ context.Context, input *go_hook.HookInput) error {
+		cniSecretSnap := input.Snapshots.Get("cni_secret")
+		if len(cniSecretSnap) == 0 {
+			input.Logger.Info("No cni secret received, skipping setting values")
+			return nil
+		}
+
+		if len(cniSecretSnap) > 1 {
+			input.Logger.Info("Multiple secret received, skipping setting values")
+			return nil
+		}
+
+		path := fmt.Sprintf("%s.internal.cniSecretData", moduleName)
+
+		var cniSecret string
+
+		err := cniSecretSnap[0].UnmarshalTo(&cniSecret)
+		if err != nil {
+			return fmt.Errorf("cannot unmarshal cni secret data: %w", err)
+		}
+
+		input.Values.Set(path, cniSecret)
+
+		return nil
+	}
+}

--- a/modules/000-common/hooks/get_cni_secret.go
+++ b/modules/000-common/hooks/get_cni_secret.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2022 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import "github.com/deckhouse/deckhouse/go_lib/hooks/get_cni_secret"
+
+var _ = get_cni_secret.RegisterHook("common")

--- a/modules/000-common/hooks/get_cni_secret_test.go
+++ b/modules/000-common/hooks/get_cni_secret_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2022 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"encoding/base64"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("Modules :: common :: hooks :: check_cni_secret ::", func() {
+	const (
+		cniSecret = `
+---
+apiVersion: v1
+data:
+  cni: Zmxhbm5lbA==
+  flannel: eyJwb2ROZXR3b3JrTW9kZSI6Imhvc3QtZ3cifQ==
+kind: Secret
+metadata:
+  name: d8-cni-configuration
+  namespace: kube-system
+type: Opaque
+`
+	)
+
+	f := HookExecutionConfigInit(`{"common":{"internal": {}}}`, `{}`)
+	Context("Empti cluster", func() {
+		BeforeEach(func() {
+			f.KubeStateSet(``)
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.RunHook()
+		})
+
+		It("Hook must fail", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("common.internal.cniSecretData").Exists()).To(BeFalse())
+		})
+	})
+
+	Context("Cluster with valid secret", func() {
+		BeforeEach(func() {
+			f.KubeStateSet(cniSecret)
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.RunHook()
+		})
+
+		It("Hook must not fail", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			d := f.ValuesGet("common.internal.cniSecretData").String()
+			dataYaml, _ := base64.StdEncoding.DecodeString(d)
+			Expect(dataYaml).To(MatchYAML(`cni: Zmxhbm5lbA==
+flannel: eyJwb2ROZXR3b3JrTW9kZSI6Imhvc3QtZ3cifQ==
+`))
+		})
+	})
+
+})

--- a/modules/000-common/openapi/values.yaml
+++ b/modules/000-common/openapi/values.yaml
@@ -17,6 +17,8 @@ properties:
               - type: string
               - type: boolean
                 enum: [ false ]
+      cniSecretData:
+        type: string
       customCertificateData:
         type: object
         properties:

--- a/modules/030-cloud-provider-aws/candi/cni-bootstrap.yml
+++ b/modules/030-cloud-provider-aws/candi/cni-bootstrap.yml
@@ -1,4 +1,6 @@
 schemaVersion: 1
-name: simple-bridge
+name: cilium
 config:
-  default: {}
+  default:
+    tunnelMode: VXLAN
+    masqueradeMode: BPF

--- a/modules/030-cloud-provider-aws/hooks/get_cni_secret.go
+++ b/modules/030-cloud-provider-aws/hooks/get_cni_secret.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import "github.com/deckhouse/deckhouse/go_lib/hooks/get_cni_secret"
+
+var _ = get_cni_secret.RegisterHook("cloudProviderAws")

--- a/modules/030-cloud-provider-aws/openapi/values.yaml
+++ b/modules/030-cloud-provider-aws/openapi/values.yaml
@@ -50,6 +50,10 @@ properties:
               additionalProperties: false
         x-examples:
         - [{"name": "gp3", "type": "gp3", "iops": "6000", "throughput": "300"}]
+      cniSecretData:
+        type: string
+        x-examples:
+        - "Y25pOiBZMmxzYVhWdApjaWxpdW06IGV3b2dJQ0p0YjJSbElqb2dJbFpZVEVGT0lpd0tJQ0FpYldGemNYVmxjbUZrWlUxdlpHVWlPaUFpUWxCR0lncDkK"
       instances:
         type: object
         properties:

--- a/modules/030-cloud-provider-aws/template_tests/module_test.go
+++ b/modules/030-cloud-provider-aws/template_tests/module_test.go
@@ -181,6 +181,8 @@ var _ = Describe("Module :: cloud-provider-aws :: helm template ::", func() {
 
 			cddDeployment := f.KubernetesResource("Deployment", moduleNamespace, "cloud-data-discoverer")
 
+			cniSecret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+
 			Expect(namespace.Exists()).To(BeTrue())
 			Expect(registrySecret.Exists()).To(BeTrue())
 			Expect(userAuthzUser.Exists()).To(BeTrue())
@@ -205,6 +207,15 @@ var _ = Describe("Module :: cloud-provider-aws :: helm template ::", func() {
   - deletecollection
   - patch
   - update`))
+
+			Expect(cniSecret.Exists()).To(BeTrue())
+			Expect(cniSecret.Field("data.cni").String()).To(Equal(base64.StdEncoding.EncodeToString([]byte("cilium"))))
+			actualCiliumConfig, err := base64.StdEncoding.DecodeString(cniSecret.Field("data.cilium").String())
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(string(actualCiliumConfig)).To(MatchJSON(`{
+  "mode": "VXLAN",
+  "masqueradeMode": "BPF"
+}`))
 
 			// user story #1
 			providerRegistrationSecret := f.KubernetesResource("Secret", "kube-system", "d8-node-manager-cloud-provider")
@@ -424,4 +435,28 @@ storageclass.kubernetes.io/is-default-class: "true"
 		})
 	})
 
+	Context("AWS with existing CNI secret data", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", globalValues)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYaml("cloudProviderAws", moduleValues)
+			f.ValuesSet("cloudProviderAws.internal.cniSecretData", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`cni: %s
+flannel: %s
+`,
+				base64.StdEncoding.EncodeToString([]byte("flannel")),
+				base64.StdEncoding.EncodeToString([]byte(`{"podNetworkMode":"host-gw"}`)),
+			))))
+			f.HelmRender()
+		})
+
+		It("Should render CNI secret from internal value", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			cniSecret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+			Expect(cniSecret.Exists()).To(BeTrue())
+			Expect(cniSecret.Field("data.cni").String()).To(Equal(base64.StdEncoding.EncodeToString([]byte("flannel"))))
+			Expect(cniSecret.Field("data.flannel").String()).To(Equal(base64.StdEncoding.EncodeToString([]byte(`{"podNetworkMode":"host-gw"}`))))
+			Expect(cniSecret.Field("data.cilium").Exists()).To(BeFalse())
+		})
+	})
 })

--- a/modules/030-cloud-provider-aws/templates/cni.yaml
+++ b/modules/030-cloud-provider-aws/templates/cni.yaml
@@ -1,0 +1,18 @@
+{{- $ciliumConfig := `{
+  "mode": "VXLAN",
+  "masqueradeMode": "BPF"
+}` }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: d8-cni-configuration
+  namespace: kube-system
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+data:
+{{- if hasKey .Values.cloudProviderAws.internal "cniSecretData" }}
+  {{- .Values.cloudProviderAws.internal.cniSecretData | b64dec | nindent 2 }}
+{{- else }}
+  cni: {{ b64enc "cilium" | quote }}
+  cilium: {{ $ciliumConfig | b64enc | quote }}
+{{- end }}

--- a/modules/030-cloud-provider-azure/hooks/get_cni_secret.go
+++ b/modules/030-cloud-provider-azure/hooks/get_cni_secret.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import "github.com/deckhouse/deckhouse/go_lib/hooks/get_cni_secret"
+
+var _ = get_cni_secret.RegisterHook("cloudProviderAzure")

--- a/modules/030-cloud-provider-azure/openapi/values.yaml
+++ b/modules/030-cloud-provider-azure/openapi/values.yaml
@@ -6,6 +6,10 @@ properties:
     type: object
     default: {}
     properties:
+      cniSecretData:
+        type: string
+        x-examples:
+        - "Y25pOiBjMmx0Y0d4bExXSnlhV1JuWlE9PQo="
       storageClasses:
         type: array
         additionalProperties:

--- a/modules/030-cloud-provider-azure/templates/cni.yaml
+++ b/modules/030-cloud-provider-azure/templates/cni.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: d8-cni-configuration
+  namespace: kube-system
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+data:
+{{- if hasKey .Values.cloudProviderAzure.internal "cniSecretData" }}
+  {{- .Values.cloudProviderAzure.internal.cniSecretData | b64dec | nindent 2 }}
+{{- else }}
+  cni: {{ b64enc "simple-bridge" | quote }}
+{{- end }}

--- a/modules/030-cloud-provider-dvp/hooks/get_cni_secret.go
+++ b/modules/030-cloud-provider-dvp/hooks/get_cni_secret.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import "github.com/deckhouse/deckhouse/go_lib/hooks/get_cni_secret"
+
+var _ = get_cni_secret.RegisterHook("cloudProviderDvp")

--- a/modules/030-cloud-provider-dvp/openapi/values.yaml
+++ b/modules/030-cloud-provider-dvp/openapi/values.yaml
@@ -6,6 +6,10 @@ properties:
     type: object
     default: {}
     properties:
+      cniSecretData:
+        type: string
+        x-examples:
+        - "Y25pOiBZMmxzYVhWdApjaWxpdW06IGV5SnRiMlJsSWpvZ0lsWllURUZPSW4wPQo="
       providerClusterConfiguration:
         type: object
         additionalProperties: false

--- a/modules/030-cloud-provider-dvp/templates/cni.yaml
+++ b/modules/030-cloud-provider-dvp/templates/cni.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: d8-cni-configuration
+  namespace: kube-system
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+data:
+{{- if hasKey .Values.cloudProviderDvp.internal "cniSecretData" }}
+  {{- .Values.cloudProviderDvp.internal.cniSecretData | b64dec | nindent 2 }}
+{{- else }}
+  cni: {{ b64enc "cilium" | quote }}
+  cilium: {{ b64enc "{\"mode\": \"VXLAN\"}" | quote }}
+{{- end }}

--- a/modules/030-cloud-provider-gcp/hooks/get_cni_secret.go
+++ b/modules/030-cloud-provider-gcp/hooks/get_cni_secret.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import "github.com/deckhouse/deckhouse/go_lib/hooks/get_cni_secret"
+
+var _ = get_cni_secret.RegisterHook("cloudProviderGcp")

--- a/modules/030-cloud-provider-gcp/openapi/values.yaml
+++ b/modules/030-cloud-provider-gcp/openapi/values.yaml
@@ -6,6 +6,10 @@ properties:
     type: object
     default: {}
     properties:
+      cniSecretData:
+        type: string
+        x-examples:
+        - "Y25pOiBjMmx0Y0d4bExXSnlhV1JuWlE9PQo="
       storageClasses:
         type: array
         additionalProperties:

--- a/modules/030-cloud-provider-gcp/templates/cni.yaml
+++ b/modules/030-cloud-provider-gcp/templates/cni.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: d8-cni-configuration
+  namespace: kube-system
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+data:
+{{- if hasKey .Values.cloudProviderGcp.internal "cniSecretData" }}
+  {{- .Values.cloudProviderGcp.internal.cniSecretData | b64dec | nindent 2 }}
+{{- else }}
+  cni: {{ b64enc "simple-bridge" | quote }}
+{{- end }}

--- a/modules/030-cloud-provider-yandex/hooks/get_cni_secret.go
+++ b/modules/030-cloud-provider-yandex/hooks/get_cni_secret.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import "github.com/deckhouse/deckhouse/go_lib/hooks/get_cni_secret"
+
+var _ = get_cni_secret.RegisterHook("cloudProviderYandex")

--- a/modules/030-cloud-provider-yandex/openapi/values.yaml
+++ b/modules/030-cloud-provider-yandex/openapi/values.yaml
@@ -24,6 +24,10 @@ properties:
             type: string
             x-examples: [ "YjY0ZW5jX3N0cmluZwo=" ]
 
+      cniSecretData:
+        type: string
+        x-examples:
+        - "Y25pOiBZMmxzYVhWdApjaWxpdW06IGV3b2dJQ0p0YjJSbElqb2dJbFpZVEVGT0lpd0tJQ0FpYldGemNYVmxjbUZrWlUxdlpHVWlPaUFpUWxCR0lncDkK"
       storageClasses:
         type: array
         additionalProperties:

--- a/modules/030-cloud-provider-yandex/templates/cni.yaml
+++ b/modules/030-cloud-provider-yandex/templates/cni.yaml
@@ -1,0 +1,18 @@
+{{- $ciliumConfig := `{
+  "mode": "VXLAN",
+  "masqueradeMode": "BPF"
+}` }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: d8-cni-configuration
+  namespace: kube-system
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+data:
+{{- if hasKey .Values.cloudProviderYandex.internal "cniSecretData" }}
+  {{- .Values.cloudProviderYandex.internal.cniSecretData | b64dec | nindent 2 }}
+{{- else }}
+  cni: {{ b64enc "cilium" | quote }}
+  cilium: {{ $ciliumConfig | b64enc | quote }}
+{{- end }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

This PR reverts https://github.com/deckhouse/deckhouse/pull/20834

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

The changes were made as a result of a miscommunication.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

We don't.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-aws
type: chore
summary: Reverted the removal of the legacy d8-cni-configuration hook and Helm template.
impact_level: default
---
section: cloud-provider-azure
type: chore
summary: Reverted the removal of the legacy d8-cni-configuration hook and Helm template.
impact_level: default
---
section: cloud-provider-dvp
type: chore
summary: Reverted the removal of the legacy d8-cni-configuration hook and Helm template.
impact_level: default
---
section: cloud-provider-gcp
type: chore
summary: Reverted the removal of the legacy d8-cni-configuration hook and Helm template.
impact_level: default
---
section: cloud-provider-yandex
type: chore
summary: Reverted the removal of the legacy d8-cni-configuration hook and Helm template.
impact_level: default
---
section: cloud-provider-openstack
type: chore
summary: Reverted the removal of the legacy d8-cni-configuration hook and Helm template.
impact_level: default
---
section: cloud-provider-huaweicloud
type: chore
summary: Reverted the removal of the legacy d8-cni-configuration hook and Helm template.
impact_level: default
---
section: cloud-provider-dynamix
type: chore
summary: Reverted the removal of the legacy d8-cni-configuration hook and Helm template.
impact_level: default
---
section: cloud-provider-vcd
type: chore
summary: Reverted the removal of the legacy d8-cni-configuration hook and Helm template.
impact_level: default
---
section: cloud-provider-vsphere
type: chore
summary: Reverted the removal of the legacy d8-cni-configuration hook and Helm template.
impact_level: default
---
section: cloud-provider-zvirt
type: chore
summary: Reverted the removal of the legacy d8-cni-configuration hook and Helm template.
impact_level: default
---
section: common
type: chore
summary: Reverted the removal of the legacy get_cni_secret hook and cniSecretData values field.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
