### PR TITLE
[istio] Fix of common-{rev}-kiali-frontend-build-artifact to build in CSE

### DIFF
--- a/modules/110-istio/images/common-v1x21x6/werf.inc.yaml
+++ b/modules/110-istio/images/common-v1x21x6/werf.inc.yaml
@@ -58,3 +58,4 @@ shell:
   - KIALI_ENV=production yarn run build
   - mkdir -p /src/kial-frontend-assets/static
   - cp -a build/. /src/kial-frontend-assets/static/
+  - rm -rf node_modules

--- a/modules/110-istio/images/common-v1x21x6/werf.inc.yaml
+++ b/modules/110-istio/images/common-v1x21x6/werf.inc.yaml
@@ -50,13 +50,11 @@ shell:
   install:
   - cd /src/kiali/frontend
   {{- include "node packages proxy" . | nindent 2 }}
+  {{- include "yarn3 packages proxy" . | nindent 2 }}
   {{- if .DistroPackagesProxy }}
-  - yarn config set registry "http://{{ $.DistroPackagesProxy }}/repository/npmjs/"
   - export CYPRESS_DOWNLOAD_MIRROR="http://{{ $.DistroPackagesProxy }}/repository/download.cypress.io"
   {{- end }}
   - yarn install --frozen-lockfile
-  setup:
-  - cd /src/kiali/frontend
   - KIALI_ENV=production yarn run build
   - mkdir -p /src/kial-frontend-assets/static
   - cp -a build/. /src/kial-frontend-assets/static/

--- a/modules/110-istio/images/common-v1x21x6/werf.inc.yaml
+++ b/modules/110-istio/images/common-v1x21x6/werf.inc.yaml
@@ -49,7 +49,14 @@ import:
 shell:
   install:
   - cd /src/kiali/frontend
+  {{- include "node packages proxy" . | nindent 2 }}
+  {{- if .DistroPackagesProxy }}
+  - yarn config set registry "http://{{ $.DistroPackagesProxy }}/repository/npmjs/"
+  - export CYPRESS_DOWNLOAD_MIRROR="http://{{ $.DistroPackagesProxy }}/repository/download.cypress.io"
+  {{- end }}
   - yarn install --frozen-lockfile
+  setup:
+  - cd /src/kiali/frontend
   - KIALI_ENV=production yarn run build
   - mkdir -p /src/kial-frontend-assets/static
   - cp -a build/. /src/kial-frontend-assets/static/

--- a/modules/110-istio/images/common-v1x21x6/werf.inc.yaml
+++ b/modules/110-istio/images/common-v1x21x6/werf.inc.yaml
@@ -53,6 +53,8 @@ shell:
   {{- if .DistroPackagesProxy }}
   - yarn config set registry "http://{{ $.DistroPackagesProxy }}/repository/npmjs/"
   - export CYPRESS_DOWNLOAD_MIRROR="http://{{ $.DistroPackagesProxy }}/repository/download.cypress.io"
+  - sed -i 's|https://registry.yarnpkg.com|http://{{ $.DistroPackagesProxy }}/repository/yarnpkg|g' yarn.lock
+  - sed -i 's|https://registry.npmjs.org|http://{{ $.DistroPackagesProxy }}/repository/npmjs|g' yarn.lock
   {{- end }}
   - yarn install --frozen-lockfile
   setup:

--- a/modules/110-istio/images/common-v1x21x6/werf.inc.yaml
+++ b/modules/110-istio/images/common-v1x21x6/werf.inc.yaml
@@ -53,8 +53,6 @@ shell:
   {{- if .DistroPackagesProxy }}
   - yarn config set registry "http://{{ $.DistroPackagesProxy }}/repository/npmjs/"
   - export CYPRESS_DOWNLOAD_MIRROR="http://{{ $.DistroPackagesProxy }}/repository/download.cypress.io"
-  - sed -i 's|https://registry.yarnpkg.com|http://{{ $.DistroPackagesProxy }}/repository/yarnpkg|g' yarn.lock
-  - sed -i 's|https://registry.npmjs.org|http://{{ $.DistroPackagesProxy }}/repository/npmjs|g' yarn.lock
   {{- end }}
   - yarn install --frozen-lockfile
   setup:

--- a/modules/110-istio/images/common-v1x21x6/werf.inc.yaml
+++ b/modules/110-istio/images/common-v1x21x6/werf.inc.yaml
@@ -49,9 +49,9 @@ import:
 shell:
   install:
   - cd /src/kiali/frontend
-  {{- include "node packages proxy" . | nindent 2 }}
-  {{- include "yarn3 packages proxy" . | nindent 2 }}
   {{- if .DistroPackagesProxy }}
+  - sed -i 's|https://registry.yarnpkg.com|http://{{ $.DistroPackagesProxy }}/repository/yarnpkg|g' yarn.lock
+  - sed -i 's|https://registry.npmjs.org|http://{{ $.DistroPackagesProxy }}/repository/npmjs|g' yarn.lock
   - export CYPRESS_DOWNLOAD_MIRROR="http://{{ $.DistroPackagesProxy }}/repository/download.cypress.io"
   {{- end }}
   - yarn install --frozen-lockfile

--- a/modules/110-istio/images/common-v1x21x6/werf.inc.yaml
+++ b/modules/110-istio/images/common-v1x21x6/werf.inc.yaml
@@ -52,8 +52,8 @@ shell:
   {{- if .DistroPackagesProxy }}
   - sed -i 's|https://registry.yarnpkg.com|http://{{ $.DistroPackagesProxy }}/repository/yarnpkg|g' yarn.lock
   - sed -i 's|https://registry.npmjs.org|http://{{ $.DistroPackagesProxy }}/repository/npmjs|g' yarn.lock
-  - export CYPRESS_DOWNLOAD_MIRROR="http://{{ $.DistroPackagesProxy }}/repository/download.cypress.io"
   {{- end }}
+  - export CYPRESS_INSTALL_BINARY=0
   - yarn install --frozen-lockfile
   - KIALI_ENV=production yarn run build
   - mkdir -p /src/kial-frontend-assets/static

--- a/modules/110-istio/images/common-v1x25x2/werf.inc.yaml
+++ b/modules/110-istio/images/common-v1x25x2/werf.inc.yaml
@@ -54,3 +54,4 @@ shell:
   - KIALI_ENV=production yarn run build
   - mkdir -p /src/kial-frontend-assets/static
   - cp -a build/. /src/kial-frontend-assets/static/
+  - rm -rf node_modules

--- a/modules/110-istio/images/common-v1x25x2/werf.inc.yaml
+++ b/modules/110-istio/images/common-v1x25x2/werf.inc.yaml
@@ -49,8 +49,6 @@ shell:
   {{- if .DistroPackagesProxy }}
   - yarn config set registry "http://{{ $.DistroPackagesProxy }}/repository/npmjs/"
   - export CYPRESS_DOWNLOAD_MIRROR="http://{{ $.DistroPackagesProxy }}/repository/download.cypress.io"
-  - sed -i 's|https://registry.yarnpkg.com|http://{{ $.DistroPackagesProxy }}/repository/yarnpkg|g' yarn.lock
-  - sed -i 's|https://registry.npmjs.org|http://{{ $.DistroPackagesProxy }}/repository/npmjs|g' yarn.lock
   {{- end }}
   - yarn install --frozen-lockfile
   setup:

--- a/modules/110-istio/images/common-v1x25x2/werf.inc.yaml
+++ b/modules/110-istio/images/common-v1x25x2/werf.inc.yaml
@@ -46,13 +46,11 @@ shell:
   install:
   - cd /src/kiali/frontend
   {{- include "node packages proxy" . | nindent 2 }}
+  {{- include "yarn3 packages proxy" . | nindent 2 }}
   {{- if .DistroPackagesProxy }}
-  - yarn config set registry "http://{{ $.DistroPackagesProxy }}/repository/npmjs/"
   - export CYPRESS_DOWNLOAD_MIRROR="http://{{ $.DistroPackagesProxy }}/repository/download.cypress.io"
   {{- end }}
   - yarn install --frozen-lockfile
-  setup:
-  - cd /src/kiali/frontend
   - KIALI_ENV=production yarn run build
   - mkdir -p /src/kial-frontend-assets/static
   - cp -a build/. /src/kial-frontend-assets/static/

--- a/modules/110-istio/images/common-v1x25x2/werf.inc.yaml
+++ b/modules/110-istio/images/common-v1x25x2/werf.inc.yaml
@@ -48,8 +48,8 @@ shell:
   {{- if .DistroPackagesProxy }}
   - sed -i 's|https://registry.yarnpkg.com|http://{{ $.DistroPackagesProxy }}/repository/yarnpkg|g' yarn.lock
   - sed -i 's|https://registry.npmjs.org|http://{{ $.DistroPackagesProxy }}/repository/npmjs|g' yarn.lock
-  - export CYPRESS_DOWNLOAD_MIRROR="http://{{ $.DistroPackagesProxy }}/repository/download.cypress.io"
   {{- end }}
+  - export CYPRESS_INSTALL_BINARY=0
   - yarn install --frozen-lockfile
   - KIALI_ENV=production yarn run build
   - mkdir -p /src/kial-frontend-assets/static

--- a/modules/110-istio/images/common-v1x25x2/werf.inc.yaml
+++ b/modules/110-istio/images/common-v1x25x2/werf.inc.yaml
@@ -49,6 +49,8 @@ shell:
   {{- if .DistroPackagesProxy }}
   - yarn config set registry "http://{{ $.DistroPackagesProxy }}/repository/npmjs/"
   - export CYPRESS_DOWNLOAD_MIRROR="http://{{ $.DistroPackagesProxy }}/repository/download.cypress.io"
+  - sed -i 's|https://registry.yarnpkg.com|http://{{ $.DistroPackagesProxy }}/repository/yarnpkg|g' yarn.lock
+  - sed -i 's|https://registry.npmjs.org|http://{{ $.DistroPackagesProxy }}/repository/npmjs|g' yarn.lock
   {{- end }}
   - yarn install --frozen-lockfile
   setup:

--- a/modules/110-istio/images/common-v1x25x2/werf.inc.yaml
+++ b/modules/110-istio/images/common-v1x25x2/werf.inc.yaml
@@ -45,9 +45,9 @@ import:
 shell:
   install:
   - cd /src/kiali/frontend
-  {{- include "node packages proxy" . | nindent 2 }}
-  {{- include "yarn3 packages proxy" . | nindent 2 }}
   {{- if .DistroPackagesProxy }}
+  - sed -i 's|https://registry.yarnpkg.com|http://{{ $.DistroPackagesProxy }}/repository/yarnpkg|g' yarn.lock
+  - sed -i 's|https://registry.npmjs.org|http://{{ $.DistroPackagesProxy }}/repository/npmjs|g' yarn.lock
   - export CYPRESS_DOWNLOAD_MIRROR="http://{{ $.DistroPackagesProxy }}/repository/download.cypress.io"
   {{- end }}
   - yarn install --frozen-lockfile

--- a/modules/110-istio/images/common-v1x25x2/werf.inc.yaml
+++ b/modules/110-istio/images/common-v1x25x2/werf.inc.yaml
@@ -45,7 +45,14 @@ import:
 shell:
   install:
   - cd /src/kiali/frontend
+  {{- include "node packages proxy" . | nindent 2 }}
+  {{- if .DistroPackagesProxy }}
+  - yarn config set registry "http://{{ $.DistroPackagesProxy }}/repository/npmjs/"
+  - export CYPRESS_DOWNLOAD_MIRROR="http://{{ $.DistroPackagesProxy }}/repository/download.cypress.io"
+  {{- end }}
   - yarn install --frozen-lockfile
+  setup:
+  - cd /src/kiali/frontend
   - KIALI_ENV=production yarn run build
   - mkdir -p /src/kial-frontend-assets/static
   - cp -a build/. /src/kial-frontend-assets/static/

--- a/modules/110-istio/images/common-v1x27x9/werf.inc.yaml
+++ b/modules/110-istio/images/common-v1x27x9/werf.inc.yaml
@@ -48,6 +48,8 @@ shell:
   {{- if .DistroPackagesProxy }}
   - yarn config set registry "http://{{ $.DistroPackagesProxy }}/repository/npmjs/"
   - export CYPRESS_DOWNLOAD_MIRROR="http://{{ $.DistroPackagesProxy }}/repository/download.cypress.io"
+  - sed -i 's|https://registry.yarnpkg.com|http://{{ $.DistroPackagesProxy }}/repository/yarnpkg|g' yarn.lock
+  - sed -i 's|https://registry.npmjs.org|http://{{ $.DistroPackagesProxy }}/repository/npmjs|g' yarn.lock
   {{- end }}
   - yarn install --frozen-lockfile
   setup:

--- a/modules/110-istio/images/common-v1x27x9/werf.inc.yaml
+++ b/modules/110-istio/images/common-v1x27x9/werf.inc.yaml
@@ -48,8 +48,6 @@ shell:
   {{- if .DistroPackagesProxy }}
   - yarn config set registry "http://{{ $.DistroPackagesProxy }}/repository/npmjs/"
   - export CYPRESS_DOWNLOAD_MIRROR="http://{{ $.DistroPackagesProxy }}/repository/download.cypress.io"
-  - sed -i 's|https://registry.yarnpkg.com|http://{{ $.DistroPackagesProxy }}/repository/yarnpkg|g' yarn.lock
-  - sed -i 's|https://registry.npmjs.org|http://{{ $.DistroPackagesProxy }}/repository/npmjs|g' yarn.lock
   {{- end }}
   - yarn install --frozen-lockfile
   setup:

--- a/modules/110-istio/images/common-v1x27x9/werf.inc.yaml
+++ b/modules/110-istio/images/common-v1x27x9/werf.inc.yaml
@@ -47,8 +47,8 @@ shell:
   {{- if .DistroPackagesProxy }}
   - sed -i 's|https://registry.yarnpkg.com|http://{{ $.DistroPackagesProxy }}/repository/yarnpkg|g' yarn.lock
   - sed -i 's|https://registry.npmjs.org|http://{{ $.DistroPackagesProxy }}/repository/npmjs|g' yarn.lock
-  - export CYPRESS_DOWNLOAD_MIRROR="http://{{ $.DistroPackagesProxy }}/repository/download.cypress.io"
   {{- end }}
+  - export CYPRESS_INSTALL_BINARY=0
   - yarn install --frozen-lockfile
   - KIALI_ENV=production yarn run build
 {{- end }}

--- a/modules/110-istio/images/common-v1x27x9/werf.inc.yaml
+++ b/modules/110-istio/images/common-v1x27x9/werf.inc.yaml
@@ -44,6 +44,13 @@ import:
 shell:
   install:
   - cd /src/kiali/frontend
+  {{- include "node packages proxy" . | nindent 2 }}
+  {{- if .DistroPackagesProxy }}
+  - yarn config set registry "http://{{ $.DistroPackagesProxy }}/repository/npmjs/"
+  - export CYPRESS_DOWNLOAD_MIRROR="http://{{ $.DistroPackagesProxy }}/repository/download.cypress.io"
+  {{- end }}
   - yarn install --frozen-lockfile
+  setup:
+  - cd /src/kiali/frontend
   - KIALI_ENV=production yarn run build
 {{- end }}

--- a/modules/110-istio/images/common-v1x27x9/werf.inc.yaml
+++ b/modules/110-istio/images/common-v1x27x9/werf.inc.yaml
@@ -44,9 +44,9 @@ import:
 shell:
   install:
   - cd /src/kiali/frontend
-  {{- include "node packages proxy" . | nindent 2 }}
-  {{- include "yarn3 packages proxy" . | nindent 2 }}
   {{- if .DistroPackagesProxy }}
+  - sed -i 's|https://registry.yarnpkg.com|http://{{ $.DistroPackagesProxy }}/repository/yarnpkg|g' yarn.lock
+  - sed -i 's|https://registry.npmjs.org|http://{{ $.DistroPackagesProxy }}/repository/npmjs|g' yarn.lock
   - export CYPRESS_DOWNLOAD_MIRROR="http://{{ $.DistroPackagesProxy }}/repository/download.cypress.io"
   {{- end }}
   - yarn install --frozen-lockfile

--- a/modules/110-istio/images/common-v1x27x9/werf.inc.yaml
+++ b/modules/110-istio/images/common-v1x27x9/werf.inc.yaml
@@ -45,12 +45,10 @@ shell:
   install:
   - cd /src/kiali/frontend
   {{- include "node packages proxy" . | nindent 2 }}
+  {{- include "yarn3 packages proxy" . | nindent 2 }}
   {{- if .DistroPackagesProxy }}
-  - yarn config set registry "http://{{ $.DistroPackagesProxy }}/repository/npmjs/"
   - export CYPRESS_DOWNLOAD_MIRROR="http://{{ $.DistroPackagesProxy }}/repository/download.cypress.io"
   {{- end }}
   - yarn install --frozen-lockfile
-  setup:
-  - cd /src/kiali/frontend
   - KIALI_ENV=production yarn run build
 {{- end }}

--- a/modules/110-istio/images/common-v1x27x9/werf.inc.yaml
+++ b/modules/110-istio/images/common-v1x27x9/werf.inc.yaml
@@ -51,4 +51,5 @@ shell:
   - export CYPRESS_INSTALL_BINARY=0
   - yarn install --frozen-lockfile
   - KIALI_ENV=production yarn run build
+  - rm -rf node_modules
 {{- end }}

--- a/modules/110-istio/images/kiali-v1x27x9/werf.inc.yaml
+++ b/modules/110-istio/images/kiali-v1x27x9/werf.inc.yaml
@@ -51,4 +51,5 @@ shell:
   - go build -o /src/kiali/out/kiali /src/kiali/
   - strip /src/kiali/out/kiali
   - chmod 0755 /src/kiali/out/kiali
+
 {{- end }}

--- a/modules/110-istio/images/kiali-v1x27x9/werf.inc.yaml
+++ b/modules/110-istio/images/kiali-v1x27x9/werf.inc.yaml
@@ -51,5 +51,4 @@ shell:
   - go build -o /src/kiali/out/kiali /src/kiali/
   - strip /src/kiali/out/kiali
   - chmod 0755 /src/kiali/out/kiali
-
 {{- end }}


### PR DESCRIPTION
## Description
Added proxy for common-{rev}-kiali-frontend-build-artifact images.

## Why do we need it, and what problem does it solve?
This fixes images build build for CSE after #20922 


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: chore
summary: Fixed Kiali image builds for CSE.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
