### PR TITLE
[modules] drop bootstrap check from enabled scripts

### DIFF
--- a/modules/040-terraform-manager/enabled
+++ b/modules/040-terraform-manager/enabled
@@ -17,8 +17,6 @@
 source /deckhouse/shell_lib.sh
 
 function __main__() {
-  enabled::disable_module_if_cluster_is_not_bootstraped
-
   if ! kubectl -n kube-system get secret d8-provider-cluster-configuration >/dev/null 2>&1 ; then
     echo "false" > "$MODULE_ENABLED_RESULT"
     echo "secret 'kube-system/d8-provider-cluster-configuration' is not present" > "$MODULE_ENABLED_REASON"

--- a/modules/150-user-authn/enabled
+++ b/modules/150-user-authn/enabled
@@ -17,8 +17,6 @@
 source /deckhouse/shell_lib.sh
 
 function __main__() {
-  enabled::disable_module_if_cluster_is_not_bootstraped
-
   if values::has global.modules.publicDomainTemplate ; then
     https_mode=$(values::get_first_defined userAuthn.https.mode global.modules.https.mode)
     if [ "$https_mode" != "Disabled" ] ; then


### PR DESCRIPTION
## Description

Remove redundant `enabled::disable_module_if_cluster_is_not_bootstraped` from enabled scripts. The `critical: true` flag is kept — both modules remain critical.

### What changed

- Removed `enabled::disable_module_if_cluster_is_not_bootstraped` from `modules/150-user-authn/enabled`.
- Removed `enabled::disable_module_if_cluster_is_not_bootstraped` from `modules/040-terraform-manager/enabled`.

The bootstrapped check was redundant with the scheduler `Bootstrapped` extender and with other runtime guards: user-authn pods use `"system"` tolerations and cannot schedule on bootstrap-tainted nodes; terraform-manager checks for provider secrets that do not exist until bootstrap completes.

## Why do we need it, and what problem does it solve?

Both modules had a manual bootstrapped check in the enabled script alongside `critical: true` in `module.yaml`. The check is unnecessary — the modules already have sufficient runtime protections against premature startup.

## Checklist

- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authn
type: fix
summary: Remove redundant bootstrapped check from enabled script.
impact_level: low
```

```changes
section: terraform-manager
type: fix
summary: Remove redundant bootstrapped check from enabled script.
impact_level: low
```