### PR TITLE
[kube-dns] Added deploy dependencies for webhook configuration

### DIFF
--- a/modules/042-kube-dns/templates/sts-pods-hosts-appender-webhook/webhook-configuration.yaml
+++ b/modules/042-kube-dns/templates/sts-pods-hosts-appender-webhook/webhook-configuration.yaml
@@ -4,6 +4,9 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: d8-kube-dns-sts-pods-hosts-appender-webhook
+  annotations:
+    werf.io/deploy-dependency-deployment: state=ready,kind=Deployment,name=d8-kube-dns-sts-pods-hosts-appender-webhook,namespace=kube-system
+    werf.io/deploy-dependency-service: state=present,kind=Service,name=d8-kube-dns-sts-pods-hosts-appender-webhook,namespace=kube-system
   {{- include "helm_lib_module_labels" (list . (dict "app" "sts-pods-hosts-appender-webhook")) | nindent 2 }}
 webhooks:
 - name: sts-pods-hosts-appender-conversion.flant.com


### PR DESCRIPTION
## Description
This PR adds werf deploy dependency annotations to the `kube-dns` `MutatingWebhookConfiguration`.

The webhook configuration is now deployed only after the corresponding `Deployment` is ready and the associated `Service` is available.

## Why do we need it, and what problem does it solve?
This fixes the deployment ordering between the webhook configuration and its backend `Deployment`/`Service`.

Without explicit deploy dependencies, the webhook configuration could be applied before its backend was ready. If a rollout was interrupted or failed, the cluster could be left with an active admission webhook pointing to an unavailable `Service`, potentially blocking the creation or update of resources handled by the webhook.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: kube-dns
type: fix
summary: Added deploy dependencies for webhook configuration
impact_level: low
```
