### PR TITLE
[docs] Update release notes for 1.76

### DIFF
--- a/docs/documentation/_includes/release-notes/RELEASE-NOTES.md
+++ b/docs/documentation/_includes/release-notes/RELEASE-NOTES.md
@@ -8,9 +8,6 @@
   **If your cluster uses third-party Kubernetes operators (not part of DKP),
   make sure to explicitly grant permissions for their CRDs; otherwise, access to those resources will be restricted.**
 
-- The [default version](https://deckhouse.io/modules/ingress-nginx/v1.76/configuration.html#parameters-defaultcontrollerversion) of the Ingress NGINX Controller has been updated from 1.10 to 1.12.
-  Controllers using the default version will be upgraded automatically.
-
 - The [fencing-agent component](https://deckhouse.io/modules/node-manager/v1.76/cr.html#nodegroup-v1-spec-fencing-mode) of the `node-manager` module now uses a gossip-based protocol ([memberlist](https://github.com/hashicorp/memberlist) library)
   for distributed node health monitoring.
   This reduces the risk of false worker node reboots when the control plane is unavailable or the API server is under heavy load.

--- a/docs/documentation/_includes/release-notes/RELEASE-NOTES_RU.md
+++ b/docs/documentation/_includes/release-notes/RELEASE-NOTES_RU.md
@@ -9,9 +9,6 @@
   **Если в кластере используются сторонние Kubernetes-операторы (не из DKP), дополнительно выдайте права на их CRD,
   иначе доступ к таким ресурсам будет ограничен.**
 
-- [Используемая по умолчанию](https://deckhouse.ru/modules/ingress-nginx/v1.76/configuration.html#parameters-defaultcontrollerversion) версия Ingress NGINX Controller повышена с 1.10 до 1.12.
-  Контроллеры, использующие версию по умолчанию, будут обновлены автоматически.
-
 - [Компонент fencing-agent](https://deckhouse.ru/modules/node-manager/v1.76/cr.html#nodegroup-v1-spec-fencing-mode) модуля `node-manager` переведён на gossip-протокол ([библиотека memberlist](https://github.com/hashicorp/memberlist))
   для распределённого мониторинга состояния узлов.
   Это снижает риск ложных перезагрузок worker-узлов при недоступности control plane или высокой нагрузке на API-сервер.


### PR DESCRIPTION
## Description

Remove the default controller version upgrade entry (1.10 to 1.12) from release notes to reflect revised release scope

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Update release notes for 1.76
impact_level: low
```
