### PR TITLE
[installer] Set UTF-8 locale for images

### DIFF
--- a/.werf/defines/image-labels.tmpl
+++ b/.werf/defines/image-labels.tmpl
@@ -12,7 +12,7 @@
 {{- $context := . }}
 imageSpec:
   config:
-    env: { "EDITOR": "vim" }
+    env: { "EDITOR": "vim", "LANG": "en_US.UTF-8", "LC_ALL": "en_US.UTF-8" }
     labels: {
       "io.deckhouse.version": "{{ $context.CI_COMMIT_TAG }}",
       "io.deckhouse.edition": "{{ $context.Env }}",


### PR DESCRIPTION
## Description

Set UTF-8 locale for the installer image.

The installer image can be started with a POSIX/C locale environment, which does not handle non-ASCII characters correctly in interactive shell tools. This change sets LANG=en_US.UTF-8 and LC_ALL=en_US.UTF-8 at the image environment level.

The change does not restart or directly affect any running cluster components.

## Why do we need it, and what problem does it solve?

When the installer container uses a POSIX/C locale, some CLI tools inside the container can handle non-ASCII input incorrectly. In particular, Cyrillic characters may be displayed or processed incorrectly in tools such as ls and vim.

Previously, the locale problem was addressed at the dhctl process level, but this does not fix the environment of the installer container itself. The actual issue is related to the image runtime environment, not to dhctl logic.

This PR sets UTF-8 locale variables for the installer image, making UTF-8 handling consistent for shell tools and other processes started inside the container.

## Why do we need it in the patch release (if we do)?

The change is safe for patch releases because it only adjusts locale environment variables in the installer image and does not change cluster state, bootstrap logic, or running cluster components.

It can be useful in patch releases because it fixes incorrect handling of Cyrillic and other UTF-8 characters during interactive usage of the installer container.
## Checklist

- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: tools
type: fix
summary: Set UTF-8 locale for the installer image.
impact_level: low
```