### PR TITLE
[prometheus] Fix promxy and mimir Svace builds

### DIFF
--- a/modules/300-prometheus/images/mimir/werf.inc.yaml
+++ b/modules/300-prometheus/images/mimir/werf.inc.yaml
@@ -39,10 +39,13 @@ secrets:
   value: {{ .GOPROXY }}
 shell:
   beforeInstall:
+  {{- if eq $.SVACE_ENABLED "false" }}
     - pm install git
+  {{- end }}
   install:
     - cd /src
     - export CGO_ENABLED=0 GOOS=linux GOARCH=amd64
+    - export PATH="$PATH:$(go env GOPATH)/bin"
     - GOPROXY=$(cat /run/secrets/GOPROXY) go mod download
     - go mod vendor
     - GOPROXY=$(cat /run/secrets/GOPROXY) go install golang.org/x/tools/cmd/goyacc@latest

--- a/modules/300-prometheus/images/mimir/werf.inc.yaml
+++ b/modules/300-prometheus/images/mimir/werf.inc.yaml
@@ -38,8 +38,8 @@ secrets:
 - id: GOPROXY
   value: {{ .GOPROXY }}
 shell:
-  beforeInstall:
   {{- if eq $.SVACE_ENABLED "false" }}
+  beforeInstall:
     - pm install git
   {{- end }}
   install:

--- a/modules/300-prometheus/images/promxy/werf.inc.yaml
+++ b/modules/300-prometheus/images/promxy/werf.inc.yaml
@@ -39,8 +39,8 @@ secrets:
 - id: GOPROXY
   value: {{ .GOPROXY }}
 shell:
-  beforeInstall:
   {{- if eq $.SVACE_ENABLED "false" }}
+  beforeInstall:
   - pm install git
   {{- end }}
   install:

--- a/modules/300-prometheus/images/promxy/werf.inc.yaml
+++ b/modules/300-prometheus/images/promxy/werf.inc.yaml
@@ -40,10 +40,13 @@ secrets:
   value: {{ .GOPROXY }}
 shell:
   beforeInstall:
+  {{- if eq $.SVACE_ENABLED "false" }}
   - pm install git
+  {{- end }}
   install:
   - cd /src
   - export CGO_ENABLED=0 GOOS=linux GOARCH=amd64
+  - export PATH="$PATH:$(go env GOPATH)/bin"
   - GOPROXY=$(cat /run/secrets/GOPROXY) go mod vendor
   - GOPROXY=$(cat /run/secrets/GOPROXY) go install golang.org/x/tools/cmd/goyacc@latest
   - cp /patches/op_func.go.tpl /src/vendor/github.com/prometheus/prometheus/promql/op_func.go


### PR DESCRIPTION
## Description
Fix Svace builds for the `prometheus/promxy-artifact` and `prometheus/mimir-artifact` images.

These artifacts are built from different base builders depending on `SVACE_ENABLED`:
`builder/golang-1.25` (non-Svace) or `builder/golang-alt-svace` (Svace).

Two problems came from that:

1. `pm install git` in `beforeInstall` was run unconditionally. The Alt-based Svace
   builder has no `pm`, so the build failed at `beforeInstall` with
   `pm: command not found` (exit code 127). git is already present in the Alt base
   image and is only missing in `builder/golang-1.25`, so the install is now guarded
   with `{{- if eq $.SVACE_ENABLED "false" }}`.

2. In the Alt-based builder `$GOPATH/bin` is not in `PATH`, so `goyacc` installed via
   `go install` was not found on the `install` stage. Added
   `export PATH="$PATH:$(go env GOPATH)/bin"`.

No runtime/cluster impact — the changes only affect the build stage of these images.


## Why do we need it, and what problem does it solve?
Without the fix, the Svace image build fails ([link to build fail](https://github.com/deckhouse/deckhouse/actions/runs/28343966931/)): `prometheus/promxy-artifact` (and the
same for `prometheus/mimir-artifact`) dies on the `beforeInstall` stage with
`pm: command not found`, and even past that the `install` stage cannot find `goyacc`.
The fix makes both artifacts build successfully both with and without Svace.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Fix promxy and mimir Svace image builds.
impact_level: low
```
