### PR TITLE
[docs] Small fixes at DVP hybrid documentation

### DIFF
--- a/docs/documentation/pages/admin/configuration/integrations/hybrid/DVP_HYBRID_RU.md
+++ b/docs/documentation/pages/admin/configuration/integrations/hybrid/DVP_HYBRID_RU.md
@@ -85,15 +85,11 @@ description: Подготовка к гибридной интеграции с 
          kubeconfigDataBase64: ${DVP_KUBECONFIG_B64}
          namespace: ${DVP_NAMESPACE}
        zones:
-         - <ZONE_NAME>
+         - ${DVP_ZONE}
    EOF
    ```
 
-   Где:
-
-   - `provider.kubeconfigDataBase64` — kubeconfig для доступа к API DVP в кодировке Base64;
-   - `provider.namespace` — неймспейс DVP, в котором будут создаваться виртуальные машины и диски;
-   - `zones` — список зон DVP, в которых разрешено создавать узлы.
+   В манифесте используются значения переменных окружения, заданных на предыдущих шагах: `DVP_KUBECONFIG_B64`, `DVP_NAMESPACE` и `DVP_ZONE`.
 
 1. Примените ModuleConfig:
 


### PR DESCRIPTION
## Description
Small fixes in DVP hybrid documentation.

## Why do we need it, and what problem does it solve?


## Why do we need it in the patch release (if we do)?



## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: docs
type: chore
summary: Small fixes in DVP hybrid documentation.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
