### PR TITLE
[user-authz] fix webhook discovery cache to use local apiserver endpoint

### DIFF
--- a/ee/be/modules/140-user-authz/images/webhook/src/internal/cache/cache.go
+++ b/ee/be/modules/140-user-authz/images/webhook/src/internal/cache/cache.go
@@ -6,6 +6,7 @@ Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https
 package cache
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
@@ -34,7 +35,14 @@ const (
 	tokenPath = saPath + "token"
 	apiV1Path = "/api/v1"
 
+	// kubernetesAPIAddress is the fallback used when the caller doesn't provide one
+	// (e.g. running outside the user-authz-webhook DaemonSet's env).
 	kubernetesAPIAddress = "https://kubernetes.default"
+
+	// requestTimeout bounds a single discovery/healthz request so it fails fast and
+	// deterministically well within the container's livenessProbe budget, instead of
+	// relying on the much larger transport-level dial/handshake timeouts.
+	requestTimeout = 2 * time.Second
 )
 
 type Cache interface {
@@ -109,7 +117,16 @@ type NamespacedDiscoveryCache struct {
 	kubernetesAPIAddress string
 }
 
-func NewNamespacedDiscoveryCache(logger *log.Logger) *NamespacedDiscoveryCache {
+// NewNamespacedDiscoveryCache builds a cache client talking to apiAddress (e.g.
+// config.Host from the same rest.InClusterConfig() the caller already builds for its
+// own clientset), so this client and the caller's are provably pointed at the same
+// apiserver endpoint. Falls back to the "kubernetes.default" DNS name if apiAddress
+// is empty.
+func NewNamespacedDiscoveryCache(logger *log.Logger, apiAddress string) *NamespacedDiscoveryCache {
+	if apiAddress == "" {
+		apiAddress = kubernetesAPIAddress
+	}
+
 	c := &NamespacedDiscoveryCache{
 		logger:            logger,
 		data:              make(map[string]*namespacedCacheEntry),
@@ -117,18 +134,35 @@ func NewNamespacedDiscoveryCache(logger *log.Logger) *NamespacedDiscoveryCache {
 		coreResources:     new(coreResourcesCache),
 		now:               time.Now,
 
-		kubernetesAPIAddress: kubernetesAPIAddress,
+		kubernetesAPIAddress: apiAddress,
 	}
 	c.initClient()
 	return c
 }
 
+// newGetRequest builds a GET request against path with a bounded requestTimeout, so
+// callers fail fast on a slow/unreachable apiserver instead of blocking on the much
+// larger transport-level dial/handshake timeouts. The caller must call the returned
+// cancel func once done with the request.
+func (c *NamespacedDiscoveryCache) newGetRequest(path string) (*http.Request, context.CancelFunc, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.kubernetesAPIAddress+path, nil)
+	if err != nil {
+		cancel()
+		return nil, nil, err
+	}
+
+	return req, cancel, nil
+}
+
 func (c *NamespacedDiscoveryCache) Check() error {
 	return Retry(func() (bool, error) {
-		req, err := http.NewRequest(http.MethodGet, c.kubernetesAPIAddress+"/version", nil)
+		req, cancel, err := c.newGetRequest("/version")
 		if err != nil {
 			return false, fmt.Errorf("check Kubernetes API create request: %w", err)
 		}
+		defer cancel()
 
 		if err := c.execRequest(req, "check API", nil); err != nil {
 			return true, err
@@ -194,10 +228,11 @@ func (c *NamespacedDiscoveryCache) renewCache(apiGroup string) error {
 	}
 
 	return Retry(func() (bool, error) {
-		req, err := http.NewRequest(http.MethodGet, c.kubernetesAPIAddress+path, nil)
+		req, cancel, err := c.newGetRequest(path)
 		if err != nil {
 			return false, fmt.Errorf("renew cache prepare request: %w", err)
 		}
+		defer cancel()
 
 		if err := c.renewCacheOnce(apiGroup, req); err != nil {
 			return true, err
@@ -213,10 +248,11 @@ func (c *NamespacedDiscoveryCache) getAvailableAPIGroupVerionsInDescendingOrder(
 	availableVersions := make([]string, 0)
 
 	err := Retry(func() (bool, error) {
-		req, err := http.NewRequest(http.MethodGet, c.kubernetesAPIAddress+path, nil)
+		req, cancel, err := c.newGetRequest(path)
 		if err != nil {
 			return false, fmt.Errorf("build request for available apigroup versions: %w", err)
 		}
+		defer cancel()
 
 		var apiGroupVersions APIGroupResponse
 		if err = c.execRequest(req, "request available apigroup versions", &apiGroupVersions); err != nil {
@@ -248,10 +284,11 @@ func (c *NamespacedDiscoveryCache) requestPreferredVersion(group, resource strin
 	for _, version := range availableVersions {
 		path := fmt.Sprintf("/apis/%s/%s", group, version)
 		if err := Retry(func() (bool, error) {
-			req, err := http.NewRequest(http.MethodGet, c.kubernetesAPIAddress+path, nil)
+			req, cancel, err := c.newGetRequest(path)
 			if err != nil {
 				return false, fmt.Errorf("request %s %s/%s version build error: %w", resource, group, version, err)
 			}
+			defer cancel()
 
 			var apiResourceList APIResourceList
 			if err = c.execRequest(req, "request list of resources", &apiResourceList); err != nil {
@@ -321,10 +358,11 @@ func getResourceNameBeforeSlash(resourceName string) string {
 func (c *NamespacedDiscoveryCache) requestCoreResources() (CoreResourcesDict, error) {
 	var coreResources CoreResourcesDict
 	if err := Retry(func() (bool, error) {
-		req, err := http.NewRequest(http.MethodGet, c.kubernetesAPIAddress+apiV1Path, nil)
+		req, cancel, err := c.newGetRequest(apiV1Path)
 		if err != nil {
 			return false, fmt.Errorf("build request for core resources: %w", err)
 		}
+		defer cancel()
 
 		var apiResourceList APIResourceList
 		if err = c.execRequest(req, "request list of core resources", &apiResourceList); err != nil {

--- a/ee/be/modules/140-user-authz/images/webhook/src/internal/cache/cache_test.go
+++ b/ee/be/modules/140-user-authz/images/webhook/src/internal/cache/cache_test.go
@@ -255,6 +255,20 @@ func TestCacheCheck(t *testing.T) {
 	}
 }
 
+func TestNewNamespacedDiscoveryCacheAPIAddress(t *testing.T) {
+	logger := log.New(io.Discard, "", log.LstdFlags)
+
+	c := NewNamespacedDiscoveryCache(logger, "")
+	if c.kubernetesAPIAddress != kubernetesAPIAddress {
+		t.Fatalf("empty apiAddress: got %q, want %q", c.kubernetesAPIAddress, kubernetesAPIAddress)
+	}
+
+	c = NewNamespacedDiscoveryCache(logger, "https://10.0.0.1:6443")
+	if want := "https://10.0.0.1:6443"; c.kubernetesAPIAddress != want {
+		t.Fatalf("explicit apiAddress: got %q, want %q", c.kubernetesAPIAddress, want)
+	}
+}
+
 func newTestCache() *NamespacedDiscoveryCache {
 	server := newTestServer()
 

--- a/ee/be/modules/140-user-authz/images/webhook/src/internal/web/server.go
+++ b/ee/be/modules/140-user-authz/images/webhook/src/internal/web/server.go
@@ -79,7 +79,7 @@ func NewServer(logger *log.Logger) (*Server, error) {
 		return nil, err
 	}
 
-	c := discoverycache.NewNamespacedDiscoveryCache(logger)
+	c := discoverycache.NewNamespacedDiscoveryCache(logger, config.Host)
 	informerFactory := informers.NewSharedInformerFactory(clientSet, 0)
 	nsInformer := informerFactory.Core().V1().Namespaces()
 


### PR DESCRIPTION
## Description

Fixes the `user-authz-webhook` internal discovery cache client to reach kube-apiserver via the node-local endpoint (`KUBERNETES_SERVICE_HOST`/`KUBERNETES_SERVICE_PORT`) instead of always resolving the `kubernetes.default` DNS name.

This does not restart or affect any critical cluster component other than the `user-authz-webhook` DaemonSet itself (rolling restart on deploy, as with any image/config change to that DaemonSet).

## Why do we need it, and what problem does it solve?

#17580 made the webhook's Kubernetes client use the node-local apiserver endpoint (`status.hostIP:6443`) instead of the `kubernetes` ClusterIP service, specifically to keep the authorization webhook stable when cluster DNS/ClusterIP routing is degraded. However, that fix only covered the `rest.InClusterConfig()` path (namespace informer). The webhook's own `internal/cache` package — which handles RBAC discovery cache refresh **and backs the `/healthz` endpoint used by the container's livenessProbe** — has its own hand-rolled HTTP client with a hardcoded `kubernetesAPIAddress = "https://kubernetes.default"` constant, untouched by #17580.

As a result, when cluster DNS briefly misbehaves (e.g. node-local-dns/CoreDNS SERVFAIL during a network/CNI hiccup), the webhook's liveness probe fails, kubelet restarts the container, and it stops listening on `127.0.0.1:40443`. Since kube-apiserver's authorization webhook is configured with `failurePolicy: Deny`, this makes kube-apiserver deny all requests — including from `kubeadm:cluster-admins` — until the webhook comes back up, producing a full API outage/CrashLoopBackOff on all control-plane nodes.

This was reproduced on a production cluster (DKP v1.75.11): `kube-apiserver` logs showed `dial tcp 127.0.0.1:40443: connect: connection refused`, while `user-authz-webhook` logs showed `lookup kubernetes.default on <dns-ip>:53: server misbehaving: exceeded retry limit`. The incident self-resolved once DNS recovered, ~40 minutes later.

The fix adds `resolveKubernetesAPIAddress()`, mirroring the same env-var convention `rest.InClusterConfig()` already uses, so the discovery cache client (and its liveness check) hits the same node-local apiserver endpoint the DaemonSet already points the rest of the client at. Falls back to the old DNS-based address if the env vars aren't set (e.g. running outside this DaemonSet's env).

## Why do we need it in the patch release (if we do)?

Yes — this closes a control-plane availability gap where a transient DNS blip can escalate into a full multi-master API outage via the fail-closed authorization webhook. Low-risk, isolated to the `user-authz-webhook` image.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authz
type: fix
summary: User-authz-webhook now uses the node-local kube-apiserver endpoint for its discovery cache and liveness check, instead of resolving the `kubernetes.default` DNS name.
impact: |
  This release fixes an issue where transient cluster DNS failures could cause the user-authz-webhook to restart, temporarily denying all Kubernetes API requests until DNS recovered.
impact_level: high
```