### PR TITLE
[deckhouse-controller] 1.76 harden migrated modules check

### DIFF
--- a/deckhouse-controller/internal/metrics/metrics.go
+++ b/deckhouse-controller/internal/metrics/metrics.go
@@ -33,6 +33,7 @@ const (
 	// ============================================================================
 	// Migration and experimental module tracking
 	MigratedModuleNotFoundMetricName        = "d8_migrated_module_not_found"
+	MigratedModuleNotDownloadedMetricName   = "d8_migrated_module_not_downloaded"
 	ExperimentalModulesAreAllowedMetricName = "is_experimental_modules_allowed"
 	ExperimentalModuleIsEnabled             = "is_experimental_module_enabled"
 	DeprecatedModuleIsEnabled               = "is_deprecated_module_enabled"
@@ -78,10 +79,11 @@ const (
 // Metric Groups
 // ============================================================================
 const (
-	MigratedModuleNotFoundGroup = "migrated_module_not_found"
-	D8Updating                  = "d8_updating"
-	D8ModuleUpdatingGroup       = "d8_module_updating_group"
-	ModuleReleaseGroup          = "module_release_group"
+	MigratedModuleNotFoundGroup      = "migrated_module_not_found"
+	MigratedModuleNotDownloadedGroup = "migrated_module_not_downloaded"
+	D8Updating                       = "d8_updating"
+	D8ModuleUpdatingGroup            = "d8_module_updating_group"
+	ModuleReleaseGroup               = "module_release_group"
 )
 
 // Group templates for dynamic metric names using fmt.Sprintf
@@ -172,6 +174,18 @@ func RegisterModuleManagerMetrics(metricStorage metricsstorage.Storage) error {
 	)
 	if err != nil {
 		return fmt.Errorf("failed to register %s: %w", MigratedModuleNotFoundMetricName, err)
+	}
+
+	// Register migrated module not-downloaded metric. Unlike the not-found metric,
+	// this tracks the transient case where the module is offered by a ModuleSource
+	// but has not been pre-staged on the filesystem yet.
+	_, err = metricStorage.RegisterGauge(
+		MigratedModuleNotDownloadedMetricName,
+		moduleLabels,
+		options.WithHelp("Gauge indicating migrated modules that are available in a ModuleSource but not downloaded yet (1.0 = not downloaded)"),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to register %s: %w", MigratedModuleNotDownloadedMetricName, err)
 	}
 
 	return nil

--- a/deckhouse-controller/internal/module/installer/erofs/installer.go
+++ b/deckhouse-controller/internal/module/installer/erofs/installer.go
@@ -136,6 +136,96 @@ func (i *Installer) Install(ctx context.Context, module, version, tempModulePath
 	return nil
 }
 
+// Stage creates an erofs module image on the filesystem WITHOUT mounting it
+// (no device mapper, no mount). The image ends up at
+// /deckhouse/downloaded/<module>/<version>.erofs but the module is not exposed to
+// the operator, so an embedded copy of the same name keeps serving the module.
+// The image is mounted later (by Install/Restore) once the embedded copy is gone.
+func (i *Installer) Stage(ctx context.Context, module, version, tempModulePath string) error {
+	ctx, span := otel.Tracer(tracerName).Start(ctx, "Stage")
+	defer span.End()
+
+	span.SetAttributes(attribute.String("module", module))
+	span.SetAttributes(attribute.String("version", version))
+	span.SetAttributes(attribute.String("path", tempModulePath))
+
+	logger := i.logger.With(slog.String("name", module), slog.String("version", version))
+
+	logger.Debug("stage module without mount")
+
+	// /deckhouse/downloaded/<module>
+	modulePath := filepath.Join(i.downloaded, module)
+	if err := os.MkdirAll(modulePath, 0755); err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return fmt.Errorf("create module dir '%s': %w", modulePath, err)
+	}
+
+	// <version>.erofs
+	image := fmt.Sprintf("%s.erofs", version)
+	// /deckhouse/downloaded/<module>/<version>.erofs
+	imagePath := filepath.Join(modulePath, image)
+
+	logger.Debug("create erofs image", slog.String("path", imagePath))
+	if err := verity.CreateImage(ctx, tempModulePath, imagePath); err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return fmt.Errorf("create image from the temp path '%s': %w", tempModulePath, err)
+	}
+
+	logger.Debug("module staged")
+
+	return nil
+}
+
+// StageFromRegistry ensures the erofs module image is present on the filesystem
+// WITHOUT mounting it (no device mapper, no mount). Mirrors Restore but skips
+// activation.
+func (i *Installer) StageFromRegistry(ctx context.Context, ms *v1alpha1.ModuleSource, module, version string) error {
+	ctx, span := otel.Tracer(tracerName).Start(ctx, "StageFromRegistry")
+	defer span.End()
+
+	span.SetAttributes(attribute.String("module", module))
+	span.SetAttributes(attribute.String("version", version))
+	span.SetAttributes(attribute.String("source", ms.GetName()))
+
+	logger := i.logger.With(slog.String("name", module), slog.String("version", version))
+	logger.Debug("stage module from registry without mount")
+
+	// /deckhouse/downloaded/<module>
+	modulePath := filepath.Join(i.downloaded, module)
+	if err := os.MkdirAll(modulePath, 0755); err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return fmt.Errorf("create module dir '%s': %w", modulePath, err)
+	}
+
+	// <version>.erofs
+	image := fmt.Sprintf("%s.erofs", version)
+	// /deckhouse/downloaded/<module>/<version>.erofs
+	imagePath := filepath.Join(modulePath, image)
+
+	// image already present on the filesystem - nothing to do
+	if err := i.verifyModule(ctx, module, version, ""); err == nil {
+		logger.Debug("erofs image already present, skip staging", slog.String("path", imagePath))
+		return nil
+	}
+
+	img, err := i.registry.GetImageReader(ctx, registry.BuildRemote(ms), module, version)
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return fmt.Errorf("download module image: %w", err)
+	}
+	defer img.Close()
+
+	logger.Debug("create erofs image from module image", slog.String("path", imagePath))
+	if err = verity.CreateImageByTar(ctx, img, imagePath); err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return fmt.Errorf("extract module image to erofs: %w", err)
+	}
+
+	logger.Debug("module staged")
+
+	return nil
+}
+
 // Uninstall disables(umount the erofs image) and deletes the module(delete all images)
 func (i *Installer) Uninstall(ctx context.Context, module string) error {
 	ctx, span := otel.Tracer(tracerName).Start(ctx, "Uninstall")

--- a/deckhouse-controller/internal/module/installer/installer.go
+++ b/deckhouse-controller/internal/module/installer/installer.go
@@ -37,6 +37,7 @@ type Installer struct {
 	registry *registry.Service
 
 	downloaded string
+	embedded   string
 	installer  installer
 }
 
@@ -44,12 +45,20 @@ type installer interface {
 	Restore(ctx context.Context, source *v1alpha1.ModuleSource, module, version string) error
 	Install(ctx context.Context, module, version, tempModulePath string) error
 	Uninstall(ctx context.Context, module string) error
+	// Stage materializes a module on the filesystem from a temp dir without
+	// activating it (no symlink/mount). Used to pre-download a module while an
+	// embedded copy of the same name is still serving it.
+	Stage(ctx context.Context, module, version, tempModulePath string) error
+	// StageFromRegistry materializes a module on the filesystem from the registry
+	// without activating it (no symlink/mount).
+	StageFromRegistry(ctx context.Context, source *v1alpha1.ModuleSource, module, version string) error
 }
 
 func New(dc dependency.Container, logger *log.Logger) *Installer {
 	i := new(Installer)
 
 	i.downloaded = d8env.GetDownloadedModulesDir()
+	i.embedded = d8env.GetEmbeddedModulesDir()
 	i.registry = registry.NewService(dc, logger)
 	i.installer = symlink.NewInstaller(i.registry, logger)
 
@@ -112,6 +121,59 @@ func (i *Installer) Download(ctx context.Context, source *v1alpha1.ModuleSource,
 
 func (i *Installer) Install(ctx context.Context, module, version, tempModulePath string) error {
 	return i.installer.Install(ctx, module, version, tempModulePath)
+}
+
+// Stage materializes a module on the filesystem from a temp dir without activating
+// it (no symlink/mount), so an embedded copy of the same name keeps serving the
+// module until Deckhouse drops the embedded copy on upgrade.
+func (i *Installer) Stage(ctx context.Context, module, version, tempModulePath string) error {
+	return i.installer.Stage(ctx, module, version, tempModulePath)
+}
+
+// StageFromRegistry materializes a module on the filesystem from the registry
+// without activating it (no symlink/mount).
+func (i *Installer) StageFromRegistry(ctx context.Context, source *v1alpha1.ModuleSource, module, version string) error {
+	return i.installer.StageFromRegistry(ctx, source, module, version)
+}
+
+// IsEmbeddedPresent reports whether an embedded copy of the module is shipped on
+// the filesystem. While it is present, the module search path resolves the module
+// to its embedded copy, so a downloaded module of the same name must not be
+// activated (only staged).
+//
+// Embedded modules are shipped with an optional weight prefix in their directory
+// name (e.g. 040-node-manager), while module holds the bare name (node-manager),
+// so the lookup must strip the prefix instead of stat'ing the bare name directly.
+func (i *Installer) IsEmbeddedPresent(module string) bool {
+	if i.embedded == "" {
+		return false
+	}
+
+	entries, err := os.ReadDir(i.embedded)
+	if err != nil {
+		// no embedded modules dir (or it is unreadable) - nothing is embedded
+		return false
+	}
+
+	// Match an optional weight prefix: 040-node-manager -> node-manager.
+	weightPattern := regexp.MustCompile(`^(?:[0-9]+-)?(.+)$`)
+	for _, entry := range entries {
+		// embedded modules are plain directories, but tolerate symlinks too
+		if !entry.IsDir() && entry.Type()&os.ModeSymlink == 0 {
+			continue
+		}
+
+		name := entry.Name()
+		if matches := weightPattern.FindStringSubmatch(name); len(matches) > 1 {
+			name = matches[1]
+		}
+
+		if name == module {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (i *Installer) Uninstall(ctx context.Context, module string) error {

--- a/deckhouse-controller/internal/module/installer/installer_test.go
+++ b/deckhouse-controller/internal/module/installer/installer_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package installer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestIsEmbeddedPresent(t *testing.T) {
+	embedded := t.TempDir()
+
+	// Embedded modules are shipped with a weight prefix in their directory name.
+	for _, dir := range []string{"040-node-manager", "ingress-nginx", "values-default.yaml"} {
+		if err := os.MkdirAll(filepath.Join(embedded, dir), 0755); err != nil {
+			t.Fatalf("prepare embedded dir: %v", err)
+		}
+	}
+
+	cases := []struct {
+		name     string
+		embedded string
+		module   string
+		want     bool
+	}{
+		{name: "prefixed embedded module", embedded: embedded, module: "node-manager", want: true},
+		{name: "unprefixed embedded module", embedded: embedded, module: "ingress-nginx", want: true},
+		{name: "bare name does not match prefixed dir literally", embedded: embedded, module: "040-node-manager", want: false},
+		{name: "absent module", embedded: embedded, module: "cilium", want: false},
+		{name: "empty embedded dir setting", embedded: "", module: "node-manager", want: false},
+		{name: "missing embedded dir", embedded: filepath.Join(embedded, "does-not-exist"), module: "node-manager", want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			i := &Installer{embedded: tc.embedded}
+			if got := i.IsEmbeddedPresent(tc.module); got != tc.want {
+				t.Errorf("IsEmbeddedPresent(%q) = %v, want %v", tc.module, got, tc.want)
+			}
+		})
+	}
+}

--- a/deckhouse-controller/internal/module/installer/mock/installer_mock.go
+++ b/deckhouse-controller/internal/module/installer/mock/installer_mock.go
@@ -20,17 +20,87 @@ import (
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
 )
 
+// Installer is a configurable mock. Any *Func field left nil falls back to the
+// default behavior, so a zero-value &Installer{} keeps the historical stub
+// semantics used across the existing tests.
 type Installer struct {
+	InstallFunc           func(ctx context.Context, module, version, tempModulePath string) error
+	StageFunc             func(ctx context.Context, module, version, tempModulePath string) error
+	StageFromRegistryFunc func(ctx context.Context, source *v1alpha1.ModuleSource, module, version string) error
+	RestoreFunc           func(ctx context.Context, source *v1alpha1.ModuleSource, module, version string) error
+	IsEmbeddedPresentFunc func(module string) bool
+	UninstallFunc         func(ctx context.Context, module string) error
+	DownloadFunc          func(ctx context.Context, source *v1alpha1.ModuleSource, module, version string) (string, error)
+	GetImageDigestFunc    func(ctx context.Context, source *v1alpha1.ModuleSource, module, version string) (string, error)
+	GetInstalledFunc      func() (map[string]struct{}, error)
+	SetClusterUUIDFunc    func(id string)
 }
 
-func (i *Installer) Install(_ context.Context, _, _, _ string) error {
+func (i *Installer) Install(ctx context.Context, module, version, tempModulePath string) error {
+	if i.InstallFunc != nil {
+		return i.InstallFunc(ctx, module, version, tempModulePath)
+	}
 	return nil
 }
 
-func (i *Installer) Uninstall(_ context.Context, _ string) error {
+func (i *Installer) Stage(ctx context.Context, module, version, tempModulePath string) error {
+	if i.StageFunc != nil {
+		return i.StageFunc(ctx, module, version, tempModulePath)
+	}
 	return nil
 }
 
-func (i *Installer) Download(_ context.Context, _ *v1alpha1.ModuleSource, _ string, _ string) (string, error) {
+func (i *Installer) StageFromRegistry(ctx context.Context, source *v1alpha1.ModuleSource, module, version string) error {
+	if i.StageFromRegistryFunc != nil {
+		return i.StageFromRegistryFunc(ctx, source, module, version)
+	}
+	return nil
+}
+
+func (i *Installer) Restore(ctx context.Context, source *v1alpha1.ModuleSource, module, version string) error {
+	if i.RestoreFunc != nil {
+		return i.RestoreFunc(ctx, source, module, version)
+	}
+	return nil
+}
+
+func (i *Installer) IsEmbeddedPresent(module string) bool {
+	if i.IsEmbeddedPresentFunc != nil {
+		return i.IsEmbeddedPresentFunc(module)
+	}
+	return false
+}
+
+func (i *Installer) Uninstall(ctx context.Context, module string) error {
+	if i.UninstallFunc != nil {
+		return i.UninstallFunc(ctx, module)
+	}
+	return nil
+}
+
+func (i *Installer) Download(ctx context.Context, source *v1alpha1.ModuleSource, module, version string) (string, error) {
+	if i.DownloadFunc != nil {
+		return i.DownloadFunc(ctx, source, module, version)
+	}
 	return "testdata/validation/module", nil
+}
+
+func (i *Installer) GetImageDigest(ctx context.Context, source *v1alpha1.ModuleSource, module, version string) (string, error) {
+	if i.GetImageDigestFunc != nil {
+		return i.GetImageDigestFunc(ctx, source, module, version)
+	}
+	return "", nil
+}
+
+func (i *Installer) GetInstalled() (map[string]struct{}, error) {
+	if i.GetInstalledFunc != nil {
+		return i.GetInstalledFunc()
+	}
+	return map[string]struct{}{}, nil
+}
+
+func (i *Installer) SetClusterUUID(id string) {
+	if i.SetClusterUUIDFunc != nil {
+		i.SetClusterUUIDFunc(id)
+	}
 }

--- a/deckhouse-controller/internal/module/installer/symlink/installer.go
+++ b/deckhouse-controller/internal/module/installer/symlink/installer.go
@@ -128,6 +128,83 @@ func (i *Installer) Install(ctx context.Context, module, version, tempModulePath
 	return nil
 }
 
+// Stage copies a module from temp location to permanent storage WITHOUT creating
+// the symlink. The files end up at /deckhouse/downloaded/<module>/<version>/ but
+// the module is not exposed to the operator, so an embedded copy of the same name
+// keeps serving the module. The symlink is created later (by Install/Restore) once
+// the embedded copy is gone.
+func (i *Installer) Stage(ctx context.Context, module, version, tempModulePath string) error {
+	_, span := otel.Tracer(tracerName).Start(ctx, "Stage")
+	defer span.End()
+
+	span.SetAttributes(attribute.String("module", module))
+	span.SetAttributes(attribute.String("version", version))
+	span.SetAttributes(attribute.String("path", tempModulePath))
+
+	logger := i.logger.With(slog.String("name", module), slog.String("version", version))
+
+	logger.Debug("stage module without symlink")
+
+	// Create permanent module directory: /deckhouse/downloaded/<module>
+	modulePath := filepath.Join(i.downloaded, module)
+	if err := os.MkdirAll(modulePath, 0755); err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return fmt.Errorf("create module dir '%s': %w", modulePath, err)
+	}
+
+	// /deckhouse/downloaded/<module>/<version>
+	versionPath := filepath.Join(modulePath, version)
+
+	// Remove old version if exists (for atomic update)
+	if _, err := os.Stat(versionPath); err == nil {
+		if err = os.RemoveAll(versionPath); err != nil {
+			return fmt.Errorf("delete old version '%s': %w", versionPath, err)
+		}
+	}
+
+	// Copy module files to permanent location, but do NOT create the symlink.
+	if err := cp.Copy(tempModulePath, versionPath); err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return fmt.Errorf("copy module '%s': %w", modulePath, err)
+	}
+
+	return nil
+}
+
+// StageFromRegistry downloads a module from the registry to permanent storage
+// WITHOUT creating the symlink. Mirrors Restore but skips activation.
+func (i *Installer) StageFromRegistry(ctx context.Context, ms *v1alpha1.ModuleSource, module, version string) error {
+	ctx, span := otel.Tracer(tracerName).Start(ctx, "StageFromRegistry")
+	defer span.End()
+
+	span.SetAttributes(attribute.String("module", module))
+	span.SetAttributes(attribute.String("version", version))
+	span.SetAttributes(attribute.String("source", ms.GetName()))
+
+	logger := i.logger.With(slog.String("name", module), slog.String("version", version))
+	logger.Debug("stage module from registry without symlink")
+
+	// Create permanent module directory: /deckhouse/downloaded/<module>
+	modulePath := filepath.Join(i.downloaded, module)
+	if err := os.MkdirAll(modulePath, 0755); err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return fmt.Errorf("create module dir '%s': %w", modulePath, err)
+	}
+
+	// /deckhouse/downloaded/<module>/<version>
+	versionPath := filepath.Join(modulePath, version)
+
+	// Download module only if it is not present on the filesystem yet.
+	if _, err := os.Stat(versionPath); err != nil {
+		if err = i.registry.Download(ctx, registry.BuildRemote(ms), versionPath, module, version); err != nil {
+			span.SetStatus(codes.Error, err.Error())
+			return fmt.Errorf("download module '%s': %w", module, err)
+		}
+	}
+
+	return nil
+}
+
 // Uninstall removes module symlink and cleans up module files.
 // Process:
 //  1. Check if symlink exists (returns early if not)

--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_deckhouse_release_test.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_deckhouse_release_test.go
@@ -163,6 +163,28 @@ func createDisabledModuleConfig(name string) *v1alpha1.ModuleConfig {
 	}
 }
 
+func createModuleReleaseWithPhase(moduleName, phase string) *v1alpha1.ModuleRelease {
+	return &v1alpha1.ModuleRelease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: moduleName + "-v1.0.0",
+			Labels: map[string]string{
+				v1alpha1.ModuleReleaseLabelModule: moduleName,
+			},
+		},
+		Spec: v1alpha1.ModuleReleaseSpec{
+			ModuleName: moduleName,
+			Version:    "1.0.0",
+		},
+		Status: v1alpha1.ModuleReleaseStatus{
+			Phase: phase,
+		},
+	}
+}
+
+func createDeployedModuleRelease(moduleName string) *v1alpha1.ModuleRelease {
+	return createModuleReleaseWithPhase(moduleName, v1alpha1.ModuleReleasePhaseDeployed)
+}
+
 func createAdmissionReview(operation string, obj, oldObj interface{}) *admissionv1.AdmissionReview {
 	review := &admissionv1.AdmissionReview{
 		TypeMeta: metav1.TypeMeta{
@@ -410,6 +432,35 @@ func TestDeckhouseReleaseValidationHandler(t *testing.T) {
 			wantAllowed: true,
 			wantMessage: "",
 			description: "Absent ModuleConfig and absence in ModuleSource allows",
+		},
+		{
+			name:           "allow when enabled migrated module has a Deployed ModuleRelease",
+			enabledModules: []string{"staged-module"},
+			kubernetesObjs: []client.Object{
+				createClusterConfigSecret("1.28.0"),
+				createModuleConfig("staged-module"),
+				createModule("staged-module"),
+				createDeployedModuleRelease("staged-module"),
+			},
+			operation:   "CREATE",
+			release:     createDeckhouseRelease("test-release", true, map[string]string{"migratedModules": "staged-module"}),
+			wantAllowed: true,
+			description: "Enabled migrated module pre-staged on the filesystem (Deployed ModuleRelease) should be allowed",
+		},
+		{
+			name:           "reject when enabled migrated module has only a Pending ModuleRelease",
+			enabledModules: []string{"pending-module"},
+			kubernetesObjs: []client.Object{
+				createClusterConfigSecret("1.28.0"),
+				createModuleConfig("pending-module"),
+				createModule("pending-module"),
+				createModuleReleaseWithPhase("pending-module", v1alpha1.ModuleReleasePhasePending),
+			},
+			operation:   "CREATE",
+			release:     createDeckhouseRelease("test-release", true, map[string]string{"migratedModules": "pending-module"}),
+			wantAllowed: false,
+			wantMessage: "requirements not met",
+			description: "Enabled migrated module not yet downloaded (no Deployed ModuleRelease) should be rejected",
 		},
 	}
 

--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module_config_test.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module_config_test.go
@@ -134,6 +134,16 @@ func newModuleCR(name string, availableSources []string, stage string) *v1alpha1
 	}
 }
 
+// newEmbeddedModuleCR builds a Module CR that is still embedded (Source ==
+// "Embedded") but already published in external sources, i.e. a module mid
+// embedded->external migration. It is used to assert that the source-availability
+// check guards this case at admission time too.
+func newEmbeddedModuleCR(name string, availableSources []string) *v1alpha1.Module {
+	m := newModuleCR(name, availableSources, "")
+	m.Properties.Source = v1alpha1.ModuleSourceEmbedded
+	return m
+}
+
 func newModuleConfigFull(name string, enabled *bool, source, updatePolicy string) *v1alpha1.ModuleConfig {
 	cfg := newModuleConfig(name, enabled, nil)
 	cfg.Spec.Source = source
@@ -631,6 +641,28 @@ func TestModuleConfigValidationHandler_ModuleResolution(t *testing.T) {
 			expectCheckEnabling: true,
 			wantAllowed:         true,
 			wantWarning:         "multiple sources",
+		},
+		{
+			// migration scenario: an embedded module pinned to a source that does
+			// not offer it (stale/mistyped .spec.source) must be rejected at
+			// admission, not silently accepted to stall later.
+			name:        "embedded module referencing an unavailable source is rejected",
+			operation:   "UPDATE",
+			newConfig:   newModuleConfigFull(moduleName, boolPtr(false), "beta", ""),
+			oldConfig:   newModuleConfigFull(moduleName, boolPtr(false), "", ""),
+			moduleCR:    newEmbeddedModuleCR(moduleName, []string{"alpha"}),
+			wantAllowed: false,
+			wantMessage: "unavailable source",
+		},
+		{
+			// the embedded module is published in the chosen source, so pinning it
+			// for migration is allowed.
+			name:        "embedded module referencing an available source is allowed",
+			operation:   "UPDATE",
+			newConfig:   newModuleConfigFull(moduleName, boolPtr(false), "alpha", ""),
+			oldConfig:   newModuleConfigFull(moduleName, boolPtr(false), "", ""),
+			moduleCR:    newEmbeddedModuleCR(moduleName, []string{"alpha", "beta"}),
+			wantAllowed: true,
 		},
 	}
 

--- a/deckhouse-controller/pkg/controller/deckhouse-release/client_test.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/client_test.go
@@ -146,6 +146,8 @@ func assembleInitObject(t *testing.T, obj string) client.Object {
 		res = unmarshalRelease[v1alpha1.Module](obj, t)
 	case "ModuleConfig":
 		res = unmarshalRelease[v1alpha1.ModuleConfig](obj, t)
+	case "ModuleRelease":
+		res = unmarshalRelease[v1alpha1.ModuleRelease](obj, t)
 
 	default:
 		require.Fail(t, "unknown Kind:"+typ.Kind)

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/migrated-modules-mc-enabled-in-source.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/migrated-modules-mc-enabled-in-source.yaml
@@ -5,31 +5,34 @@ kind: DeckhouseRelease
 metadata:
   creationTimestamp: null
   name: v1.49.0
-  resourceVersion: "999"
+  resourceVersion: "1000"
 spec:
   version: v1.49.0
 status:
   approved: true
   message: ""
-  phase: Deployed
-  transitionTime: "2019-10-17T15:32:00Z"
+  phase: Superseded
+  transitionTime: "2019-10-17T15:33:00Z"
 ---
 apiVersion: deckhouse.io/v1alpha1
 approved: false
 kind: DeckhouseRelease
 metadata:
+  annotations:
+    release.deckhouse.io/isUpdating: "true"
+    release.deckhouse.io/notified: "false"
+    release.deckhouse.io/update-info: '{"taskCalculation":{"taskType":"process","isPatch":false,"isMajor":false,"isFromTo":false,"isSingle":false,"isLatest":true},"updatePolicy":{"mode":"Auto"},"forceRelease":{"isForced":false},"podReadiness":{"isReady":true},"requirementsCheck":{"requirementsMet":true}}'
   creationTimestamp: null
   name: v1.50.0
-  resourceVersion: "1000"
+  resourceVersion: "1001"
 spec:
   requirements:
-    migratedModules: enabled-module-not-found
+    migratedModules: test-module-1
   version: v1.50.0
 status:
   approved: false
-  message: 'migrated module ''enabled-module-not-found'' not found in any ModuleSource
-    registry: publish it in a ModuleSource (or fix the module''s source) before upgrading'
-  phase: Pending
+  message: ""
+  phase: Deployed
   transitionTime: "2019-10-17T15:33:00Z"
 ---
 apiVersion: apps/v1
@@ -38,7 +41,7 @@ metadata:
   creationTimestamp: null
   name: deckhouse
   namespace: d8-system
-  resourceVersion: "999"
+  resourceVersion: "1000"
 spec:
   replicas: 1
   selector:
@@ -52,7 +55,7 @@ spec:
         app: deckhouse
     spec:
       containers:
-      - image: dev-registry.deckhouse.io/deckhouse/deckhouse:v1.49.0
+      - image: my.registry.com/deckhouse:v1.50.0
         name: deckhouse
         resources: {}
 status:

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/migrated-modules-mc-enabled-in-source.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/migrated-modules-mc-enabled-in-source.yaml
@@ -5,34 +5,31 @@ kind: DeckhouseRelease
 metadata:
   creationTimestamp: null
   name: v1.49.0
-  resourceVersion: "1000"
+  resourceVersion: "999"
 spec:
   version: v1.49.0
 status:
   approved: true
   message: ""
-  phase: Superseded
-  transitionTime: "2019-10-17T15:33:00Z"
+  phase: Deployed
+  transitionTime: "2019-10-17T15:32:00Z"
 ---
 apiVersion: deckhouse.io/v1alpha1
 approved: false
 kind: DeckhouseRelease
 metadata:
-  annotations:
-    release.deckhouse.io/isUpdating: "true"
-    release.deckhouse.io/notified: "false"
-    release.deckhouse.io/update-info: '{"taskCalculation":{"taskType":"process","isPatch":false,"isMajor":false,"isFromTo":false,"isSingle":false,"isLatest":true},"updatePolicy":{"mode":"Auto"},"forceRelease":{"isForced":false},"podReadiness":{"isReady":true},"requirementsCheck":{"requirementsMet":true}}'
   creationTimestamp: null
   name: v1.50.0
-  resourceVersion: "1001"
+  resourceVersion: "1000"
 spec:
   requirements:
-    migratedModules: test-module-1
+    migratedModules: enabled-module-not-found
   version: v1.50.0
 status:
   approved: false
-  message: ""
-  phase: Deployed
+  message: 'migrated module ''enabled-module-not-found'' not found in any ModuleSource
+    registry: publish it in a ModuleSource (or fix the module''s source) before upgrading'
+  phase: Pending
   transitionTime: "2019-10-17T15:33:00Z"
 ---
 apiVersion: apps/v1
@@ -41,7 +38,7 @@ metadata:
   creationTimestamp: null
   name: deckhouse
   namespace: d8-system
-  resourceVersion: "1000"
+  resourceVersion: "999"
 spec:
   replicas: 1
   selector:
@@ -55,7 +52,7 @@ spec:
         app: deckhouse
     spec:
       containers:
-      - image: my.registry.com/deckhouse:v1.50.0
+      - image: dev-registry.deckhouse.io/deckhouse/deckhouse:v1.49.0
         name: deckhouse
         resources: {}
 status:

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/migrated-modules-mc-enabled-not-in-source.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/migrated-modules-mc-enabled-not-in-source.yaml
@@ -27,8 +27,8 @@ spec:
   version: v1.50.0
 status:
   approved: false
-  message: migrated module 'enabled-module-not-found' not found in any ModuleSource
-    registry
+  message: 'migrated module ''enabled-module-not-found'' not found in any ModuleSource
+    registry: publish it in a ModuleSource (or fix the module''s source) before upgrading'
   phase: Pending
   transitionTime: "2019-10-17T15:33:00Z"
 ---

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/migrated-modules-module-missing.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/migrated-modules-module-missing.yaml
@@ -5,34 +5,32 @@ kind: DeckhouseRelease
 metadata:
   creationTimestamp: null
   name: v1.49.0
-  resourceVersion: "1000"
+  resourceVersion: "999"
 spec:
   version: v1.49.0
 status:
   approved: true
   message: ""
-  phase: Superseded
-  transitionTime: "2019-10-17T15:33:00Z"
+  phase: Deployed
+  transitionTime: "2019-10-17T15:32:00Z"
 ---
 apiVersion: deckhouse.io/v1alpha1
 approved: false
 kind: DeckhouseRelease
 metadata:
-  annotations:
-    release.deckhouse.io/isUpdating: "true"
-    release.deckhouse.io/notified: "false"
-    release.deckhouse.io/update-info: '{"taskCalculation":{"taskType":"process","isPatch":false,"isMajor":false,"isFromTo":false,"isSingle":false,"isLatest":true},"updatePolicy":{"mode":"Auto"},"forceRelease":{"isForced":false},"podReadiness":{"isReady":true},"requirementsCheck":{"requirementsMet":true}}'
   creationTimestamp: null
   name: v1.50.0
-  resourceVersion: "1001"
+  resourceVersion: "1000"
 spec:
   requirements:
     migratedModules: test-module-1, test-module-missing
   version: v1.50.0
 status:
   approved: false
-  message: ""
-  phase: Deployed
+  message: 'migrated module ''test-module-1'' is not pre-downloaded yet: no Deployed
+    ModuleRelease found, wait for the module to be downloaded from a ModuleSource
+    before upgrading'
+  phase: Pending
   transitionTime: "2019-10-17T15:33:00Z"
 ---
 apiVersion: apps/v1
@@ -41,7 +39,7 @@ metadata:
   creationTimestamp: null
   name: deckhouse
   namespace: d8-system
-  resourceVersion: "1000"
+  resourceVersion: "999"
 spec:
   replicas: 1
   selector:
@@ -55,7 +53,7 @@ spec:
         app: deckhouse
     spec:
       containers:
-      - image: my.registry.com/deckhouse:v1.50.0
+      - image: dev-registry.deckhouse.io/deckhouse/deckhouse:v1.49.0
         name: deckhouse
         resources: {}
 status:

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/migrated-modules-module-pull-error.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/migrated-modules-module-pull-error.yaml
@@ -27,7 +27,8 @@ spec:
   version: v1.50.0
 status:
   approved: false
-  message: migrated module 'test-module-1' not found in any ModuleSource registry
+  message: 'migrated module ''test-module-1'' not found in any ModuleSource registry:
+    publish it in a ModuleSource (or fix the module''s source) before upgrading'
   phase: Pending
   transitionTime: "2019-10-17T15:33:00Z"
 ---

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/migrated-modules-modules-available.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/migrated-modules-modules-available.yaml
@@ -27,7 +27,7 @@ metadata:
   resourceVersion: "1001"
 spec:
   requirements:
-    migratedModules: test-module-1, test-module-2
+    migratedModules: ""
   version: v1.50.0
 status:
   approved: false

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/migrated-modules-modules-available.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/migrated-modules-modules-available.yaml
@@ -27,7 +27,7 @@ metadata:
   resourceVersion: "1001"
 spec:
   requirements:
-    migratedModules: ""
+    migratedModules: test-module-1, test-module-2
   version: v1.50.0
 status:
   approved: false

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/migrated-modules-mc-enabled-in-source.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/migrated-modules-mc-enabled-in-source.yaml
@@ -55,6 +55,18 @@ spec:
   enabled: true
 ---
 apiVersion: deckhouse.io/v1alpha1
+kind: ModuleRelease
+metadata:
+  name: test-module-1-v1.0.0
+  labels:
+    module: test-module-1
+spec:
+  moduleName: test-module-1
+  version: 1.0.0
+status:
+  phase: Deployed
+---
+apiVersion: deckhouse.io/v1alpha1
 kind: ModuleSource
 metadata:
   name: source-2

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/migrated-modules-modules-available.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/migrated-modules-modules-available.yaml
@@ -56,6 +56,30 @@ spec:
   enabled: true
 ---
 apiVersion: deckhouse.io/v1alpha1
+kind: ModuleRelease
+metadata:
+  name: test-module-1-v1.0.0
+  labels:
+    module: test-module-1
+spec:
+  moduleName: test-module-1
+  version: 1.0.0
+status:
+  phase: Deployed
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleRelease
+metadata:
+  name: test-module-2-v1.0.0
+  labels:
+    module: test-module-2
+spec:
+  moduleName: test-module-2
+  version: 1.0.0
+status:
+  phase: Deployed
+---
+apiVersion: deckhouse.io/v1alpha1
 kind: Module
 metadata:
   name: test-module-2

--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -143,6 +143,8 @@ type MetricsUpdater interface {
 
 type Installer interface {
 	Install(ctx context.Context, moduleName string, moduleVersion, modulePath string) error
+	Stage(ctx context.Context, moduleName string, moduleVersion, modulePath string) error
+	IsEmbeddedPresent(moduleName string) bool
 	Uninstall(ctx context.Context, moduleName string) error
 	Download(ctx context.Context, source *v1alpha1.ModuleSource, moduleName string, moduleVersion string) (string, error)
 }
@@ -1417,10 +1419,45 @@ func (r *reconciler) deployModule(ctx context.Context, release *v1alpha1.ModuleR
 		return fmt.Errorf("the '%s:v%s' module validation: %w", release.GetModuleName(), release.GetVersion().String(), err)
 	}
 
+	// While an embedded copy of the module is still shipped on the filesystem it
+	// wins the module search path, so the downloaded module must only be staged
+	// (no symlink/mount), not activated. Pre-staging guarantees the module is
+	// already on disk when the embedded copy is dropped on Deckhouse upgrade,
+	// avoiding a download race that could leave the module temporarily unavailable.
+	// The module is activated later by the moduleloader restore once the embedded
+	// copy is gone.
+	if r.installer.IsEmbeddedPresent(moduleName) {
+		logger.Info("module is still embedded, stage the release without activating it")
+
+		if err = r.installer.Stage(ctx, moduleName, moduleVersion, modulePath); err != nil {
+			r.log.Error("failed to stage module", slog.String("module", modulePath), log.Err(err))
+
+			return fmt.Errorf("stage the module '%s': %w", moduleName, err)
+		}
+
+		// the embedded copy keeps running, so its hooks must not be disabled
+		return nil
+	}
+
 	if err = r.installer.Install(ctx, moduleName, moduleVersion, modulePath); err != nil {
 		r.log.Error("failed to install module", slog.String("module", modulePath), log.Err(err))
 
 		return fmt.Errorf("install the module '%s': %w", moduleName, err)
+	}
+
+	// The module was activated (Install, not Stage), so its embedded copy is no
+	// longer shipped. Flip the active source off the "Embedded" sentinel so the
+	// controller-side view (module.IsEmbedded()) stays consistent with the on-disk
+	// reality and the module is handed over to the regular source-owned flow. This
+	// mirrors the transition done by the moduleloader restore.
+	module := &v1alpha1.Module{ObjectMeta: metav1.ObjectMeta{Name: moduleName}}
+	if err = ctrlutils.UpdateWithRetry(ctx, r.client, module, func() error {
+		if module.Properties.Source == v1alpha1.ModuleSourceEmbedded {
+			module.Properties.Source = source.Name
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("switch the active source for the module '%s': %w", moduleName, err)
 	}
 
 	// disable target module hooks so as not to invoke them before restart

--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller_test.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller_test.go
@@ -178,6 +178,42 @@ func (suite *ReleaseControllerTestSuite) TestCreateReconcile() {
 		})
 	})
 
+	// The module was still embedded but its embedded copy is no longer on disk
+	// (IsEmbeddedPresent == false), so the release is activated (Install) and the
+	// active source is switched off the "Embedded" sentinel to the real source.
+	suite.Run("embedded module switches source on install", func() {
+		suite.setupReleaseController(
+			suite.fetchTestFileData("embedded-module-source-switch.yaml"),
+			withInstaller(&installermock.Installer{
+				IsEmbeddedPresentFunc: func(string) bool { return false },
+			}),
+		)
+
+		repeatTest(func() {
+			mr := suite.getModuleRelease(suite.testMRName)
+			_, err = suite.ctr.handleRelease(context.TODO(), mr)
+			require.NoError(suite.T(), err)
+		})
+	})
+
+	// The embedded copy is still on disk (IsEmbeddedPresent == true), so the release
+	// is only staged: the module stays pinned to its embedded copy and the active
+	// source must remain "Embedded".
+	suite.Run("embedded module keeps source while staged", func() {
+		suite.setupReleaseController(
+			suite.fetchTestFileData("embedded-module-stage-keep-source.yaml"),
+			withInstaller(&installermock.Installer{
+				IsEmbeddedPresentFunc: func(string) bool { return true },
+			}),
+		)
+
+		repeatTest(func() {
+			mr := suite.getModuleRelease(suite.testMRName)
+			_, err = suite.ctr.handleRelease(context.TODO(), mr)
+			require.NoError(suite.T(), err)
+		})
+	})
+
 	suite.Run("deckhouse suitable version", func() {
 		suite.setupReleaseController(suite.fetchTestFileData("dVersion-suitable.yaml"))
 
@@ -857,6 +893,12 @@ func withDependencyContainer(dc dependency.Container) reconcilerOption {
 func withBasicModulePhase(phase addonmodules.ModuleRunPhase) reconcilerOption {
 	return func(r *reconciler) {
 		r.moduleManager = stubModulesManager{modulePhase: phase}
+	}
+}
+
+func withInstaller(inst Installer) reconcilerOption {
+	return func(r *reconciler) {
+		r.installer = inst
 	}
 }
 

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/embedded-module-source-switch.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/embedded-module-source-switch.yaml
@@ -1,0 +1,68 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  annotations:
+    modules.deckhouse.io/registry-spec-checksum: 38557e472e4e2bd8695fc58a255ec3dd
+  finalizers:
+    - modules.deckhouse.io/release-exists
+  name: foxtrot
+spec:
+  registry:
+    ca: ""
+    dockerCfg: YXNiCg==
+    repo: dev-registry.deckhouse.io/team/foxtrot/modules
+    scheme: HTTPS
+status:
+  message: ""
+  modules:
+    - name: parca
+      policy: foxtrot-alpha
+  modulesCount: 1
+  syncTime: "2024-05-03T21:05:05Z"
+---
+apiVersion: deckhouse.io/v1alpha2
+kind: ModuleUpdatePolicy
+metadata:
+  name: foxtrot-alpha
+spec:
+  releaseChannel: Alpha
+  update:
+    mode: Auto
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleRelease
+metadata:
+  labels:
+    module: parca
+    modules.deckhouse.io/update-policy: foxtrot-alpha
+    release-checksum: 98d00f741c99e06e6c6c4d18b763c550
+    source: foxtrot
+  name: parca-v1.4.3
+  ownerReferences:
+    - apiVersion: deckhouse.io/v1alpha1
+      controller: true
+      kind: ModuleSource
+      name: foxtrot
+      uid: 71d2300f-700b-452a-896a-6a3805f9cef7
+spec:
+  changelog:
+    features:
+      - Bump parca version
+  moduleName: parca
+  version: 1.4.3
+  weight: 900
+status:
+  approved: false
+  message: ""
+  phase: Pending
+  pullDuration: 0s
+  size: 0
+  transitionTime: "2024-05-03T20:55:49Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: Module
+metadata:
+  name: parca
+properties:
+  source: Embedded

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/embedded-module-stage-keep-source.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/embedded-module-stage-keep-source.yaml
@@ -1,0 +1,68 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  annotations:
+    modules.deckhouse.io/registry-spec-checksum: 38557e472e4e2bd8695fc58a255ec3dd
+  finalizers:
+    - modules.deckhouse.io/release-exists
+  name: foxtrot
+spec:
+  registry:
+    ca: ""
+    dockerCfg: YXNiCg==
+    repo: dev-registry.deckhouse.io/team/foxtrot/modules
+    scheme: HTTPS
+status:
+  message: ""
+  modules:
+    - name: parca
+      policy: foxtrot-alpha
+  modulesCount: 1
+  syncTime: "2024-05-03T21:05:05Z"
+---
+apiVersion: deckhouse.io/v1alpha2
+kind: ModuleUpdatePolicy
+metadata:
+  name: foxtrot-alpha
+spec:
+  releaseChannel: Alpha
+  update:
+    mode: Auto
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleRelease
+metadata:
+  labels:
+    module: parca
+    modules.deckhouse.io/update-policy: foxtrot-alpha
+    release-checksum: 98d00f741c99e06e6c6c4d18b763c550
+    source: foxtrot
+  name: parca-v1.4.3
+  ownerReferences:
+    - apiVersion: deckhouse.io/v1alpha1
+      controller: true
+      kind: ModuleSource
+      name: foxtrot
+      uid: 71d2300f-700b-452a-896a-6a3805f9cef7
+spec:
+  changelog:
+    features:
+      - Bump parca version
+  moduleName: parca
+  version: 1.4.3
+  weight: 900
+status:
+  approved: false
+  message: ""
+  phase: Pending
+  pullDuration: 0s
+  size: 0
+  transitionTime: "2024-05-03T20:55:49Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: Module
+metadata:
+  name: parca
+properties:
+  source: Embedded

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/embedded-module-source-switch.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/embedded-module-source-switch.yaml
@@ -4,20 +4,24 @@ kind: ModuleSource
 metadata:
   annotations:
     modules.deckhouse.io/registry-spec-checksum: 38557e472e4e2bd8695fc58a255ec3dd
+  creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/release-exists
   name: foxtrot
   resourceVersion: "999"
 spec:
   registry:
+    ca: ""
     dockerCfg: YXNiCg==
     repo: dev-registry.deckhouse.io/team/foxtrot/modules
     scheme: HTTPS
 status:
+  message: ""
   modules:
   - name: parca
     policy: foxtrot-alpha
   modulesCount: 1
+  phase: ""
   syncTime: "2024-05-03T21:05:05Z"
 ---
 apiVersion: deckhouse.io/v1alpha1
@@ -26,6 +30,7 @@ metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "true"
     modules.deckhouse.io/notified: "true"
+  creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/metrics-registered
   - modules.deckhouse.io/exist-on-fs
@@ -52,13 +57,16 @@ spec:
   weight: 900
 status:
   approved: false
+  message: ""
   phase: Deployed
   pullDuration: 0s
+  size: 0
   transitionTime: "2024-05-03T20:55:49Z"
 ---
 apiVersion: deckhouse.io/v1alpha1
 kind: Module
 metadata:
+  creationTimestamp: null
   name: parca
   resourceVersion: "1001"
 properties:

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/embedded-module-source-switch.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/embedded-module-source-switch.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  annotations:
+    modules.deckhouse.io/registry-spec-checksum: 38557e472e4e2bd8695fc58a255ec3dd
+  finalizers:
+  - modules.deckhouse.io/release-exists
+  name: foxtrot
+  resourceVersion: "999"
+spec:
+  registry:
+    dockerCfg: YXNiCg==
+    repo: dev-registry.deckhouse.io/team/foxtrot/modules
+    scheme: HTTPS
+status:
+  modules:
+  - name: parca
+    policy: foxtrot-alpha
+  modulesCount: 1
+  syncTime: "2024-05-03T21:05:05Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleRelease
+metadata:
+  annotations:
+    modules.deckhouse.io/isUpdating: "true"
+    modules.deckhouse.io/notified: "true"
+  finalizers:
+  - modules.deckhouse.io/metrics-registered
+  - modules.deckhouse.io/exist-on-fs
+  labels:
+    module: parca
+    modules.deckhouse.io/update-policy: foxtrot-alpha
+    release-checksum: 98d00f741c99e06e6c6c4d18b763c550
+    source: foxtrot
+    status: deployed
+  name: parca-v1.4.3
+  ownerReferences:
+  - apiVersion: deckhouse.io/v1alpha1
+    controller: true
+    kind: ModuleSource
+    name: foxtrot
+    uid: 71d2300f-700b-452a-896a-6a3805f9cef7
+  resourceVersion: "1005"
+spec:
+  changelog:
+    features:
+    - Bump parca version
+  moduleName: parca
+  version: 1.4.3
+  weight: 900
+status:
+  approved: false
+  phase: Deployed
+  pullDuration: 0s
+  transitionTime: "2024-05-03T20:55:49Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: Module
+metadata:
+  name: parca
+  resourceVersion: "1001"
+properties:
+  source: foxtrot
+status:
+  conditions:
+  - lastProbeTime: "2019-10-17T15:33:00Z"
+    lastTransitionTime: "2019-10-17T15:33:00Z"
+    status: "True"
+    type: LastReleaseDeployed

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/embedded-module-stage-keep-source.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/embedded-module-stage-keep-source.yaml
@@ -4,20 +4,24 @@ kind: ModuleSource
 metadata:
   annotations:
     modules.deckhouse.io/registry-spec-checksum: 38557e472e4e2bd8695fc58a255ec3dd
+  creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/release-exists
   name: foxtrot
   resourceVersion: "999"
 spec:
   registry:
+    ca: ""
     dockerCfg: YXNiCg==
     repo: dev-registry.deckhouse.io/team/foxtrot/modules
     scheme: HTTPS
 status:
+  message: ""
   modules:
   - name: parca
     policy: foxtrot-alpha
   modulesCount: 1
+  phase: ""
   syncTime: "2024-05-03T21:05:05Z"
 ---
 apiVersion: deckhouse.io/v1alpha1
@@ -26,6 +30,7 @@ metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "true"
     modules.deckhouse.io/notified: "true"
+  creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/metrics-registered
   - modules.deckhouse.io/exist-on-fs
@@ -52,13 +57,16 @@ spec:
   weight: 900
 status:
   approved: false
+  message: ""
   phase: Deployed
   pullDuration: 0s
+  size: 0
   transitionTime: "2024-05-03T20:55:49Z"
 ---
 apiVersion: deckhouse.io/v1alpha1
 kind: Module
 metadata:
+  creationTimestamp: null
   name: parca
   resourceVersion: "1000"
 properties:

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/embedded-module-stage-keep-source.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/embedded-module-stage-keep-source.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  annotations:
+    modules.deckhouse.io/registry-spec-checksum: 38557e472e4e2bd8695fc58a255ec3dd
+  finalizers:
+  - modules.deckhouse.io/release-exists
+  name: foxtrot
+  resourceVersion: "999"
+spec:
+  registry:
+    dockerCfg: YXNiCg==
+    repo: dev-registry.deckhouse.io/team/foxtrot/modules
+    scheme: HTTPS
+status:
+  modules:
+  - name: parca
+    policy: foxtrot-alpha
+  modulesCount: 1
+  syncTime: "2024-05-03T21:05:05Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleRelease
+metadata:
+  annotations:
+    modules.deckhouse.io/isUpdating: "true"
+    modules.deckhouse.io/notified: "true"
+  finalizers:
+  - modules.deckhouse.io/metrics-registered
+  - modules.deckhouse.io/exist-on-fs
+  labels:
+    module: parca
+    modules.deckhouse.io/update-policy: foxtrot-alpha
+    release-checksum: 98d00f741c99e06e6c6c4d18b763c550
+    source: foxtrot
+    status: deployed
+  name: parca-v1.4.3
+  ownerReferences:
+  - apiVersion: deckhouse.io/v1alpha1
+    controller: true
+    kind: ModuleSource
+    name: foxtrot
+    uid: 71d2300f-700b-452a-896a-6a3805f9cef7
+  resourceVersion: "1005"
+spec:
+  changelog:
+    features:
+    - Bump parca version
+  moduleName: parca
+  version: 1.4.3
+  weight: 900
+status:
+  approved: false
+  phase: Deployed
+  pullDuration: 0s
+  transitionTime: "2024-05-03T20:55:49Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: Module
+metadata:
+  name: parca
+  resourceVersion: "1000"
+properties:
+  source: Embedded
+status:
+  conditions:
+  - lastProbeTime: "2019-10-17T15:33:00Z"
+    lastTransitionTime: "2019-10-17T15:33:00Z"
+    status: "True"
+    type: LastReleaseDeployed

--- a/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
@@ -452,7 +452,58 @@ func (r *reconciler) processModules(ctx context.Context, source *v1alpha1.Module
 			continue
 		}
 
-		if r.needToEnsureRelease(source, module, availableModule, meta, exists) {
+		// Resolve which source an embedded module should be pre-staged from while its
+		// embedded copy is still shipped. The module keeps Source == "Embedded", so the
+		// choice is driven by the operator's ModuleConfig .spec.source, the only real
+		// source, or the canonical "deckhouse" source - see resolveEmbeddedTargetSource.
+		// Being offered by several sources is not automatically a conflict: "deckhouse"
+		// + a mirror like "deckhouse-upstream-ee", or "Embedded" + one real source, both
+		// resolve cleanly. A real conflict only arises from a stale .spec.source or from
+		// several non-default sources with no selection.
+		var embeddedTargetSource string
+		if module.IsEmbedded() {
+			chosenSource, err := r.getConfiguredModuleSource(ctx, moduleName)
+			if err != nil {
+				logger.Error("failed to get module config, skipping", slog.String("name", moduleName), log.Err(err))
+				availableModule.Error = err.Error()
+				availableModule.Version = "unknown"
+				errorsExist = true
+				availableModules = append(availableModules, availableModule)
+				continue
+			}
+
+			var conflict bool
+			embeddedTargetSource, conflict = resolveEmbeddedTargetSource(chosenSource, module.Properties.AvailableSources)
+			if conflict {
+				// Skip pre-staging with a diagnostic warning; do NOT raise a user-facing
+				// ModuleAtConflict alert. This branch is embedded-only (see the
+				// module.IsEmbedded() guard), and the embedded copy keeps serving the
+				// module regardless of which source a future release would come from, so
+				// this is a deferred pre-staging decision, not a runtime conflict. The
+				// module-config controller likewise skips embedded modules when setting the
+				// conflict metric; firing d8_module_at_conflict here would both contradict
+				// that and - because this runs once per source - register the same
+				// module-labelled series under several metric groups, making the whole self
+				// /metrics page fail to collect (up=0 -> D8DeckhouseSelfTargetDown).
+				if chosenSource != "" {
+					logger.Warn("embedded module's configured source does not offer the module, cannot pre-stage a release until the ModuleConfig .spec.source is fixed",
+						slog.String("name", moduleName),
+						slog.String("configured_source", chosenSource),
+						slog.Any("available_sources", module.Properties.AvailableSources))
+				} else {
+					logger.Warn("embedded module is offered by several non-default sources and none is selected via ModuleConfig, cannot pre-stage a release until the conflict is resolved",
+						slog.String("name", moduleName),
+						slog.Any("available_sources", module.Properties.AvailableSources))
+				}
+
+				availableModule.Checksum = meta.Checksum
+				availableModule.Version = meta.ModuleVersion
+				availableModules = append(availableModules, availableModule)
+				continue
+			}
+		}
+
+		if r.needToEnsureRelease(source, module, availableModule, meta, exists, embeddedTargetSource) {
 			logger.Debug("ensure release")
 
 			err = ctrlutils.UpdateStatusWithRetry(ctx, r.client, module, func() error {
@@ -473,7 +524,13 @@ func (r *reconciler) processModules(ctx context.Context, source *v1alpha1.Module
 			}
 
 			err = ctrlutils.UpdateWithRetry(ctx, r.client, module, func() error {
-				module.Properties.Source = source.Name
+				// Keep an embedded module pinned to its embedded copy while it is
+				// still shipped: the release is only pre-staged on the filesystem,
+				// not activated. The active source is switched to the external one
+				// only after the embedded copy is dropped on Deckhouse upgrade.
+				if !module.IsEmbedded() {
+					module.Properties.Source = source.Name
+				}
 
 				return nil
 			})

--- a/deckhouse-controller/pkg/controller/module-controllers/source/controller_test.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/controller_test.go
@@ -422,6 +422,81 @@ func (suite *ControllerTestSuite) TestCreateReconcile() {
 		// Should NOT contain intermediate version
 		assert.NotContains(suite.T(), releasesStr, "testmodule-v0.5.0")
 	})
+
+	// A module that is still embedded but already published in an external source is
+	// pre-staged: a single source resolves automatically, so a ModuleRelease is created.
+	suite.Run("embedded module with a single source", func() {
+		dc := newMockedContainerWithData(suite.T(),
+			"v1.2.3",
+			[]string{"ingressnginx"},
+			[]string{})
+		suite.setupTestController("embedded-module-single-source.yaml", withDependencyContainer(dc))
+		_, err := suite.r.handleModuleSource(context.TODO(), suite.moduleSource("test-source-1"))
+		require.NoError(suite.T(), err)
+	})
+
+	// Several sources offer the embedded module and none is chosen via ModuleConfig:
+	// it is a conflict, so no ModuleRelease is created.
+	suite.Run("embedded module with several sources and no choice", func() {
+		dc := newMockedContainerWithData(suite.T(),
+			"v1.2.3",
+			[]string{"ingressnginx"},
+			[]string{})
+		suite.setupTestController("embedded-module-several-sources-conflict.yaml", withDependencyContainer(dc))
+		_, err := suite.r.handleModuleSource(context.TODO(), suite.moduleSource("test-source-1"))
+		require.NoError(suite.T(), err)
+	})
+
+	// The operator pinned a source via ModuleConfig that does not offer the module
+	// (a stale or mistyped .spec.source - e.g. the source stopped publishing the
+	// module after the config was admitted). It must be treated as a conflict, not
+	// silently skipped: no ModuleRelease is created and the conflict alert fires.
+	suite.Run("embedded module with a chosen source that is not available", func() {
+		dc := newMockedContainerWithData(suite.T(),
+			"v1.2.3",
+			[]string{"ingressnginx"},
+			[]string{})
+		suite.setupTestController("embedded-module-stale-chosen-source.yaml", withDependencyContainer(dc))
+		_, err := suite.r.handleModuleSource(context.TODO(), suite.moduleSource("test-source-1"))
+		require.NoError(suite.T(), err)
+	})
+
+	// Several sources, but the operator pinned the reconciled source via ModuleConfig:
+	// a ModuleRelease is created from the chosen source.
+	suite.Run("embedded module with several sources and a chosen source", func() {
+		dc := newMockedContainerWithData(suite.T(),
+			"v1.2.3",
+			[]string{"ingressnginx"},
+			[]string{})
+		suite.setupTestController("embedded-module-chosen-source.yaml", withDependencyContainer(dc))
+		_, err := suite.r.handleModuleSource(context.TODO(), suite.moduleSource("test-source-1"))
+		require.NoError(suite.T(), err)
+	})
+
+	// Several sources and ModuleConfig pins a different source than the reconciled one:
+	// the reconciled source must not pre-stage a release.
+	suite.Run("embedded module with several sources and a different chosen source", func() {
+		dc := newMockedContainerWithData(suite.T(),
+			"v1.2.3",
+			[]string{"ingressnginx"},
+			[]string{})
+		suite.setupTestController("embedded-module-other-chosen-source.yaml", withDependencyContainer(dc))
+		_, err := suite.r.handleModuleSource(context.TODO(), suite.moduleSource("test-source-1"))
+		require.NoError(suite.T(), err)
+	})
+
+	// "Embedded" is the sentinel for the built-in copy, not a real source, so a
+	// ModuleConfig with source: Embedded is treated as "no choice" - several sources
+	// remain a conflict and no ModuleRelease is created.
+	suite.Run("embedded module with several sources and Embedded chosen source", func() {
+		dc := newMockedContainerWithData(suite.T(),
+			"v1.2.3",
+			[]string{"ingressnginx"},
+			[]string{})
+		suite.setupTestController("embedded-module-embedded-chosen-source.yaml", withDependencyContainer(dc))
+		_, err := suite.r.handleModuleSource(context.TODO(), suite.moduleSource("test-source-1"))
+		require.NoError(suite.T(), err)
+	})
 }
 
 func (suite *ControllerTestSuite) parseTestdata(filename string) []byte {

--- a/deckhouse-controller/pkg/controller/module-controllers/source/controller_test.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/controller_test.go
@@ -182,6 +182,12 @@ func (suite *ControllerTestSuite) parseKubernetesObject(raw []byte) client.Objec
 		err = yaml.Unmarshal(raw, module)
 		require.NoError(suite.T(), err)
 		obj = module
+
+	case v1alpha1.ModuleConfigGVK.Kind:
+		config := new(v1alpha1.ModuleConfig)
+		err = yaml.Unmarshal(raw, config)
+		require.NoError(suite.T(), err)
+		obj = config
 	}
 
 	return obj
@@ -430,7 +436,7 @@ func (suite *ControllerTestSuite) TestCreateReconcile() {
 			"v1.2.3",
 			[]string{"ingressnginx"},
 			[]string{})
-		suite.setupTestController("embedded-module-single-source.yaml", withDependencyContainer(dc))
+		suite.setupTestController(string(suite.parseTestdata("embedded-module-single-source.yaml")), withDependencyContainer(dc))
 		_, err := suite.r.handleModuleSource(context.TODO(), suite.moduleSource("test-source-1"))
 		require.NoError(suite.T(), err)
 	})
@@ -442,7 +448,7 @@ func (suite *ControllerTestSuite) TestCreateReconcile() {
 			"v1.2.3",
 			[]string{"ingressnginx"},
 			[]string{})
-		suite.setupTestController("embedded-module-several-sources-conflict.yaml", withDependencyContainer(dc))
+		suite.setupTestController(string(suite.parseTestdata("embedded-module-several-sources-conflict.yaml")), withDependencyContainer(dc))
 		_, err := suite.r.handleModuleSource(context.TODO(), suite.moduleSource("test-source-1"))
 		require.NoError(suite.T(), err)
 	})
@@ -456,7 +462,7 @@ func (suite *ControllerTestSuite) TestCreateReconcile() {
 			"v1.2.3",
 			[]string{"ingressnginx"},
 			[]string{})
-		suite.setupTestController("embedded-module-stale-chosen-source.yaml", withDependencyContainer(dc))
+		suite.setupTestController(string(suite.parseTestdata("embedded-module-stale-chosen-source.yaml")), withDependencyContainer(dc))
 		_, err := suite.r.handleModuleSource(context.TODO(), suite.moduleSource("test-source-1"))
 		require.NoError(suite.T(), err)
 	})
@@ -468,7 +474,7 @@ func (suite *ControllerTestSuite) TestCreateReconcile() {
 			"v1.2.3",
 			[]string{"ingressnginx"},
 			[]string{})
-		suite.setupTestController("embedded-module-chosen-source.yaml", withDependencyContainer(dc))
+		suite.setupTestController(string(suite.parseTestdata("embedded-module-chosen-source.yaml")), withDependencyContainer(dc))
 		_, err := suite.r.handleModuleSource(context.TODO(), suite.moduleSource("test-source-1"))
 		require.NoError(suite.T(), err)
 	})
@@ -480,7 +486,7 @@ func (suite *ControllerTestSuite) TestCreateReconcile() {
 			"v1.2.3",
 			[]string{"ingressnginx"},
 			[]string{})
-		suite.setupTestController("embedded-module-other-chosen-source.yaml", withDependencyContainer(dc))
+		suite.setupTestController(string(suite.parseTestdata("embedded-module-other-chosen-source.yaml")), withDependencyContainer(dc))
 		_, err := suite.r.handleModuleSource(context.TODO(), suite.moduleSource("test-source-1"))
 		require.NoError(suite.T(), err)
 	})
@@ -493,7 +499,7 @@ func (suite *ControllerTestSuite) TestCreateReconcile() {
 			"v1.2.3",
 			[]string{"ingressnginx"},
 			[]string{})
-		suite.setupTestController("embedded-module-embedded-chosen-source.yaml", withDependencyContainer(dc))
+		suite.setupTestController(string(suite.parseTestdata("embedded-module-embedded-chosen-source.yaml")), withDependencyContainer(dc))
 		_, err := suite.r.handleModuleSource(context.TODO(), suite.moduleSource("test-source-1"))
 		require.NoError(suite.T(), err)
 	})

--- a/deckhouse-controller/pkg/controller/module-controllers/source/helpers.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/helpers.go
@@ -175,7 +175,8 @@ func (r *reconciler) needToEnsureRelease(
 	module *v1alpha1.Module,
 	sourceModule v1alpha1.AvailableModule,
 	meta *downloader.ModuleDownloadResult,
-	releaseExists bool) bool {
+	releaseExists bool,
+	embeddedTargetSource string) bool {
 	// skip experimental modules when deckhouse does not allow them
 	if module.IsExperimental() && !r.deckhouseSettings.Get().AllowExperimentalModules {
 		r.logger.Debug("experimental module not allowed, skip release ensure",
@@ -185,8 +186,19 @@ func (r *reconciler) needToEnsureRelease(
 		return false
 	}
 
-	// check the active source
-	if module.Properties.Source != "" && module.Properties.Source != source.Name {
+	// An embedded module keeps Source == "Embedded" while its embedded copy is
+	// shipped, so the active-source check below would always skip it. Instead
+	// pre-stage the release from the source resolved for migration so the module is
+	// already on the filesystem when the embedded copy is dropped on upgrade.
+	// embeddedTargetSource is the resolved source (operator's ModuleConfig
+	// .spec.source, or the only available source); it is empty when the source is
+	// undecided (several sources, none chosen) - a conflict handled in processModules.
+	if module.IsEmbedded() {
+		if embeddedTargetSource == "" || embeddedTargetSource != source.Name {
+			return false
+		}
+	} else if module.Properties.Source != "" && module.Properties.Source != source.Name {
+		// check the active source
 		r.logger.Debug("source not active, skip module",
 			slog.String("source_name", source.Name),
 			slog.String("name", module.Name))
@@ -214,6 +226,78 @@ func (r *reconciler) needToEnsureRelease(
 	}
 
 	return sourceModule.Checksum != meta.Checksum || !releaseExists
+}
+
+// getConfiguredModuleSource returns the source explicitly selected by the operator
+// in the module's ModuleConfig (.spec.source), or an empty string if there is no
+// config or no source is set. It is used to resolve which source to pre-stage an
+// embedded module from while its embedded copy is still shipped (the module-config
+// controller skips embedded modules, so .spec.source is not reflected in
+// Module.Properties.Source).
+func (r *reconciler) getConfiguredModuleSource(ctx context.Context, moduleName string) (string, error) {
+	moduleConfig := new(v1alpha1.ModuleConfig)
+	if err := r.client.Get(ctx, client.ObjectKey{Name: moduleName}, moduleConfig); err != nil {
+		if apierrors.IsNotFound(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("get the '%s' module config: %w", moduleName, err)
+	}
+
+	// "Embedded" is the sentinel for the built-in copy, not a real ModuleSource, so
+	// it can never be a valid externally selected source - treat it as not chosen.
+	if moduleConfig.Spec.Source == v1alpha1.ModuleSourceEmbedded {
+		return "", nil
+	}
+
+	return moduleConfig.Spec.Source, nil
+}
+
+// defaultModuleSourceName is the name of the built-in OSS ModuleSource that ships
+// with Deckhouse. When a module is offered by it alongside mirrors (e.g. the EE
+// source), it is the canonical choice rather than an ambiguous conflict.
+const defaultModuleSourceName = "deckhouse"
+
+// resolveEmbeddedTargetSource decides which source an embedded module should be
+// pre-staged from while its embedded copy is still shipped, and whether the choice
+// is a genuine conflict.
+//
+// Being offered by several sources is not automatically a conflict:
+//   - an explicitly chosen source wins (if it still offers the module);
+//   - the "Embedded" sentinel is not a real source, so "Embedded" + one real source
+//     is not a conflict - the real source is used;
+//   - the built-in "deckhouse" source is the canonical default and wins over mirrors
+//     such as "deckhouse-upstream-ee".
+//
+// It is a conflict only when the chosen source no longer offers the module, or when
+// several real, non-default sources offer it and none is selected.
+func resolveEmbeddedTargetSource(chosenSource string, availableSources []string) (string, bool) {
+	if chosenSource != "" {
+		if slices.Contains(availableSources, chosenSource) {
+			return chosenSource, false
+		}
+		// the configured .spec.source does not (or no longer does) offer the module
+		return "", true
+	}
+
+	// "Embedded" is a sentinel for the built-in copy, not a selectable source.
+	candidates := make([]string, 0, len(availableSources))
+	for _, source := range availableSources {
+		if source != v1alpha1.ModuleSourceEmbedded {
+			candidates = append(candidates, source)
+		}
+	}
+
+	switch {
+	case len(candidates) == 0:
+		// nothing but the embedded copy is available - nothing to pre-stage, not a conflict
+		return "", false
+	case len(candidates) == 1:
+		return candidates[0], false
+	case slices.Contains(candidates, defaultModuleSourceName):
+		return defaultModuleSourceName, false
+	default:
+		return "", true
+	}
 }
 
 func (r *reconciler) ensureModule(ctx context.Context, sourceName, moduleName, releaseChannel string) (*v1alpha1.Module, error) {

--- a/deckhouse-controller/pkg/controller/module-controllers/source/helpers_test.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/helpers_test.go
@@ -1,0 +1,107 @@
+// Copyright 2025 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package source
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
+)
+
+func TestResolveEmbeddedTargetSource(t *testing.T) {
+	const embedded = v1alpha1.ModuleSourceEmbedded
+
+	tests := []struct {
+		name             string
+		chosenSource     string
+		availableSources []string
+		wantTarget       string
+		wantConflict     bool
+	}{
+		{
+			name:             "explicitly chosen source that is offered wins",
+			chosenSource:     "deckhouse-upstream-ee",
+			availableSources: []string{"deckhouse", "deckhouse-upstream-ee"},
+			wantTarget:       "deckhouse-upstream-ee",
+			wantConflict:     false,
+		},
+		{
+			name:             "chosen source that is no longer offered is a conflict",
+			chosenSource:     "gone",
+			availableSources: []string{"deckhouse", "deckhouse-upstream-ee"},
+			wantTarget:       "",
+			wantConflict:     true,
+		},
+		{
+			name:             "single real source is used",
+			availableSources: []string{"deckhouse-upstream-ee"},
+			wantTarget:       "deckhouse-upstream-ee",
+			wantConflict:     false,
+		},
+		{
+			// the case that produced the false-positive ModuleAtConflict alert
+			name:             "deckhouse plus a mirror resolves to deckhouse, not a conflict",
+			availableSources: []string{"deckhouse", "deckhouse-upstream-ee"},
+			wantTarget:       "deckhouse",
+			wantConflict:     false,
+		},
+		{
+			name:             "source order does not matter, deckhouse still wins",
+			availableSources: []string{"deckhouse-upstream-ee", "deckhouse"},
+			wantTarget:       "deckhouse",
+			wantConflict:     false,
+		},
+		{
+			name:             "Embedded sentinel plus one real source is not a conflict",
+			availableSources: []string{embedded, "deckhouse-upstream-ee"},
+			wantTarget:       "deckhouse-upstream-ee",
+			wantConflict:     false,
+		},
+		{
+			name:             "Embedded plus deckhouse plus a mirror resolves to deckhouse",
+			availableSources: []string{embedded, "deckhouse", "deckhouse-upstream-ee"},
+			wantTarget:       "deckhouse",
+			wantConflict:     false,
+		},
+		{
+			name:             "only the Embedded sentinel is available - nothing to pre-stage, not a conflict",
+			availableSources: []string{embedded},
+			wantTarget:       "",
+			wantConflict:     false,
+		},
+		{
+			name:             "several non-default real sources with no selection is a genuine conflict",
+			availableSources: []string{"vendor-a", "vendor-b"},
+			wantTarget:       "",
+			wantConflict:     true,
+		},
+		{
+			name:             "no sources at all is not a conflict",
+			availableSources: nil,
+			wantTarget:       "",
+			wantConflict:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			target, conflict := resolveEmbeddedTargetSource(tt.chosenSource, tt.availableSources)
+			assert.Equal(t, tt.wantTarget, target, "target source")
+			assert.Equal(t, tt.wantConflict, conflict, "conflict")
+		})
+	}
+}

--- a/deckhouse-controller/pkg/controller/module-controllers/source/testdata/embedded-module-chosen-source.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/testdata/embedded-module-chosen-source.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  annotations:
+    modules.deckhouse.io/registry-spec-checksum: 912e02634dd8b7222cc42906e35f1e79
+  name: test-source-1
+spec:
+  scanInterval: 6h30m
+  registry:
+    dockerCfg: YXNiCg==
+    repo: dev-registry.deckhouse.io/deckhouse/modules
+    scheme: HTTPS
+status:
+  message: ""
+  modules:
+    - name: ingressnginx
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  name: test-source-2
+spec:
+  scanInterval: 6h30m
+  registry:
+    dockerCfg: YXNiCg==
+    repo: dev-registry.deckhouse.io/deckhouse/modules-2
+    scheme: HTTPS
+status:
+  message: ""
+  modules:
+    - name: ingressnginx
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: Module
+metadata:
+  name: ingressnginx
+properties:
+  source: Embedded
+  availableSources:
+    - test-source-1
+    - test-source-2
+status:
+  phase: Available
+  conditions:
+    - type: EnabledByModuleConfig
+      status: "True"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: ingressnginx
+spec:
+  enabled: true
+  source: test-source-1

--- a/deckhouse-controller/pkg/controller/module-controllers/source/testdata/embedded-module-chosen-source.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/testdata/embedded-module-chosen-source.yaml
@@ -3,7 +3,7 @@ apiVersion: deckhouse.io/v1alpha1
 kind: ModuleSource
 metadata:
   annotations:
-    modules.deckhouse.io/registry-spec-checksum: 912e02634dd8b7222cc42906e35f1e79
+    modules.deckhouse.io/registry-spec-checksum: 90f0955ee984feab5c50611987008def
   name: test-source-1
 spec:
   scanInterval: 6h30m

--- a/deckhouse-controller/pkg/controller/module-controllers/source/testdata/embedded-module-embedded-chosen-source.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/testdata/embedded-module-embedded-chosen-source.yaml
@@ -3,7 +3,7 @@ apiVersion: deckhouse.io/v1alpha1
 kind: ModuleSource
 metadata:
   annotations:
-    modules.deckhouse.io/registry-spec-checksum: 912e02634dd8b7222cc42906e35f1e79
+    modules.deckhouse.io/registry-spec-checksum: 90f0955ee984feab5c50611987008def
   name: test-source-1
 spec:
   scanInterval: 6h30m

--- a/deckhouse-controller/pkg/controller/module-controllers/source/testdata/embedded-module-embedded-chosen-source.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/testdata/embedded-module-embedded-chosen-source.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  annotations:
+    modules.deckhouse.io/registry-spec-checksum: 912e02634dd8b7222cc42906e35f1e79
+  name: test-source-1
+spec:
+  scanInterval: 6h30m
+  registry:
+    dockerCfg: YXNiCg==
+    repo: dev-registry.deckhouse.io/deckhouse/modules
+    scheme: HTTPS
+status:
+  message: ""
+  modules:
+    - name: ingressnginx
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  name: test-source-2
+spec:
+  scanInterval: 6h30m
+  registry:
+    dockerCfg: YXNiCg==
+    repo: dev-registry.deckhouse.io/deckhouse/modules-2
+    scheme: HTTPS
+status:
+  message: ""
+  modules:
+    - name: ingressnginx
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: Module
+metadata:
+  name: ingressnginx
+properties:
+  source: Embedded
+  availableSources:
+    - test-source-1
+    - test-source-2
+status:
+  phase: Available
+  conditions:
+    - type: EnabledByModuleConfig
+      status: "True"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: ingressnginx
+spec:
+  enabled: true
+  source: Embedded

--- a/deckhouse-controller/pkg/controller/module-controllers/source/testdata/embedded-module-other-chosen-source.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/testdata/embedded-module-other-chosen-source.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  annotations:
+    modules.deckhouse.io/registry-spec-checksum: 912e02634dd8b7222cc42906e35f1e79
+  name: test-source-1
+spec:
+  scanInterval: 6h30m
+  registry:
+    dockerCfg: YXNiCg==
+    repo: dev-registry.deckhouse.io/deckhouse/modules
+    scheme: HTTPS
+status:
+  message: ""
+  modules:
+    - name: ingressnginx
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  name: test-source-2
+spec:
+  scanInterval: 6h30m
+  registry:
+    dockerCfg: YXNiCg==
+    repo: dev-registry.deckhouse.io/deckhouse/modules-2
+    scheme: HTTPS
+status:
+  message: ""
+  modules:
+    - name: ingressnginx
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: Module
+metadata:
+  name: ingressnginx
+properties:
+  source: Embedded
+  availableSources:
+    - test-source-1
+    - test-source-2
+status:
+  phase: Available
+  conditions:
+    - type: EnabledByModuleConfig
+      status: "True"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: ingressnginx
+spec:
+  enabled: true
+  source: test-source-2

--- a/deckhouse-controller/pkg/controller/module-controllers/source/testdata/embedded-module-other-chosen-source.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/testdata/embedded-module-other-chosen-source.yaml
@@ -3,7 +3,7 @@ apiVersion: deckhouse.io/v1alpha1
 kind: ModuleSource
 metadata:
   annotations:
-    modules.deckhouse.io/registry-spec-checksum: 912e02634dd8b7222cc42906e35f1e79
+    modules.deckhouse.io/registry-spec-checksum: 90f0955ee984feab5c50611987008def
   name: test-source-1
 spec:
   scanInterval: 6h30m

--- a/deckhouse-controller/pkg/controller/module-controllers/source/testdata/embedded-module-several-sources-conflict.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/testdata/embedded-module-several-sources-conflict.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  annotations:
+    modules.deckhouse.io/registry-spec-checksum: 912e02634dd8b7222cc42906e35f1e79
+  name: test-source-1
+spec:
+  scanInterval: 6h30m
+  registry:
+    dockerCfg: YXNiCg==
+    repo: dev-registry.deckhouse.io/deckhouse/modules
+    scheme: HTTPS
+status:
+  message: ""
+  modules:
+    - name: ingressnginx
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  name: test-source-2
+spec:
+  scanInterval: 6h30m
+  registry:
+    dockerCfg: YXNiCg==
+    repo: dev-registry.deckhouse.io/deckhouse/modules-2
+    scheme: HTTPS
+status:
+  message: ""
+  modules:
+    - name: ingressnginx
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: Module
+metadata:
+  name: ingressnginx
+properties:
+  source: Embedded
+  availableSources:
+    - test-source-1
+    - test-source-2
+status:
+  phase: Available
+  conditions:
+    - type: EnabledByModuleConfig
+      status: "True"

--- a/deckhouse-controller/pkg/controller/module-controllers/source/testdata/embedded-module-several-sources-conflict.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/testdata/embedded-module-several-sources-conflict.yaml
@@ -3,7 +3,7 @@ apiVersion: deckhouse.io/v1alpha1
 kind: ModuleSource
 metadata:
   annotations:
-    modules.deckhouse.io/registry-spec-checksum: 912e02634dd8b7222cc42906e35f1e79
+    modules.deckhouse.io/registry-spec-checksum: 90f0955ee984feab5c50611987008def
   name: test-source-1
 spec:
   scanInterval: 6h30m

--- a/deckhouse-controller/pkg/controller/module-controllers/source/testdata/embedded-module-single-source.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/testdata/embedded-module-single-source.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  annotations:
+    modules.deckhouse.io/registry-spec-checksum: 912e02634dd8b7222cc42906e35f1e79
+  name: test-source-1
+spec:
+  scanInterval: 6h30m
+  registry:
+    dockerCfg: YXNiCg==
+    repo: dev-registry.deckhouse.io/deckhouse/modules
+    scheme: HTTPS
+status:
+  message: ""
+  modules:
+    - name: ingressnginx
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: Module
+metadata:
+  name: ingressnginx
+properties:
+  source: Embedded
+  availableSources:
+    - test-source-1
+status:
+  phase: Available
+  conditions:
+    - type: EnabledByModuleConfig
+      status: "True"

--- a/deckhouse-controller/pkg/controller/module-controllers/source/testdata/embedded-module-single-source.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/testdata/embedded-module-single-source.yaml
@@ -3,7 +3,7 @@ apiVersion: deckhouse.io/v1alpha1
 kind: ModuleSource
 metadata:
   annotations:
-    modules.deckhouse.io/registry-spec-checksum: 912e02634dd8b7222cc42906e35f1e79
+    modules.deckhouse.io/registry-spec-checksum: 90f0955ee984feab5c50611987008def
   name: test-source-1
 spec:
   scanInterval: 6h30m

--- a/deckhouse-controller/pkg/controller/module-controllers/source/testdata/embedded-module-stale-chosen-source.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/testdata/embedded-module-stale-chosen-source.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  annotations:
+    modules.deckhouse.io/registry-spec-checksum: 912e02634dd8b7222cc42906e35f1e79
+  name: test-source-1
+spec:
+  scanInterval: 6h30m
+  registry:
+    dockerCfg: YXNiCg==
+    repo: dev-registry.deckhouse.io/deckhouse/modules
+    scheme: HTTPS
+status:
+  message: ""
+  modules:
+    - name: ingressnginx
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: Module
+metadata:
+  name: ingressnginx
+properties:
+  source: Embedded
+  availableSources:
+    - test-source-1
+status:
+  phase: Available
+  conditions:
+    - type: EnabledByModuleConfig
+      status: "True"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: ingressnginx
+spec:
+  enabled: true
+  source: test-source-2

--- a/deckhouse-controller/pkg/controller/module-controllers/source/testdata/embedded-module-stale-chosen-source.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/testdata/embedded-module-stale-chosen-source.yaml
@@ -3,7 +3,7 @@ apiVersion: deckhouse.io/v1alpha1
 kind: ModuleSource
 metadata:
   annotations:
-    modules.deckhouse.io/registry-spec-checksum: 912e02634dd8b7222cc42906e35f1e79
+    modules.deckhouse.io/registry-spec-checksum: 90f0955ee984feab5c50611987008def
   name: test-source-1
 spec:
   scanInterval: 6h30m

--- a/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/embedded-module-chosen-source.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/embedded-module-chosen-source.yaml
@@ -3,18 +3,21 @@ apiVersion: deckhouse.io/v1alpha1
 kind: ModuleSource
 metadata:
   annotations:
-    modules.deckhouse.io/registry-spec-checksum: 912e02634dd8b7222cc42906e35f1e79
+    modules.deckhouse.io/registry-spec-checksum: 90f0955ee984feab5c50611987008def
+  creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/module-exists
   name: test-source-1
   resourceVersion: "1001"
 spec:
   registry:
+    ca: ""
     dockerCfg: YXNiCg==
     repo: dev-registry.deckhouse.io/deckhouse/modules
     scheme: HTTPS
   scanInterval: 6h30m0s
 status:
+  message: ""
   modules:
   - checksum: 'sha256:'
     name: ingressnginx
@@ -26,17 +29,22 @@ status:
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleSource
 metadata:
+  creationTimestamp: null
   name: test-source-2
   resourceVersion: "999"
 spec:
   registry:
+    ca: ""
     dockerCfg: YXNiCg==
     repo: dev-registry.deckhouse.io/deckhouse/modules-2
     scheme: HTTPS
   scanInterval: 6h30m0s
 status:
+  message: ""
   modules:
   - name: ingressnginx
+  modulesCount: 0
+  phase: ""
   syncTime: null
 ---
 apiVersion: deckhouse.io/v1alpha1
@@ -45,6 +53,7 @@ metadata:
   annotations:
     modules.deckhouse.io/apply-now: "true"
     modules.deckhouse.io/change-cause: check release (no releases in cluster)
+  creationTimestamp: null
   labels:
     module: ingressnginx
     modules.deckhouse.io/update-policy: ""
@@ -66,5 +75,7 @@ spec:
   weight: 900
 status:
   approved: false
+  message: ""
   pullDuration: 0s
+  size: 0
   transitionTime: null

--- a/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/embedded-module-chosen-source.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/embedded-module-chosen-source.yaml
@@ -1,0 +1,70 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  annotations:
+    modules.deckhouse.io/registry-spec-checksum: 912e02634dd8b7222cc42906e35f1e79
+  finalizers:
+  - modules.deckhouse.io/module-exists
+  name: test-source-1
+  resourceVersion: "1001"
+spec:
+  registry:
+    dockerCfg: YXNiCg==
+    repo: dev-registry.deckhouse.io/deckhouse/modules
+    scheme: HTTPS
+  scanInterval: 6h30m0s
+status:
+  modules:
+  - checksum: 'sha256:'
+    name: ingressnginx
+    version: v1.2.3
+  modulesCount: 1
+  phase: Active
+  syncTime: "2019-10-17T15:33:00Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  name: test-source-2
+  resourceVersion: "999"
+spec:
+  registry:
+    dockerCfg: YXNiCg==
+    repo: dev-registry.deckhouse.io/deckhouse/modules-2
+    scheme: HTTPS
+  scanInterval: 6h30m0s
+status:
+  modules:
+  - name: ingressnginx
+  syncTime: null
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleRelease
+metadata:
+  annotations:
+    modules.deckhouse.io/apply-now: "true"
+    modules.deckhouse.io/change-cause: check release (no releases in cluster)
+  labels:
+    module: ingressnginx
+    modules.deckhouse.io/update-policy: ""
+    release-checksum: 1beb143dffb1b662137094e7faea1e17
+    source: test-source-1
+  name: ingressnginx-v1.2.3
+  ownerReferences:
+  - apiVersion: deckhouse.io/v1alpha1
+    controller: true
+    kind: ModuleSource
+    name: test-source-1
+    uid: ""
+  resourceVersion: "1"
+spec:
+  moduleName: ingressnginx
+  requirements:
+    kubernetes: '>= 1.27'
+  version: 1.2.3
+  weight: 900
+status:
+  approved: false
+  pullDuration: 0s
+  transitionTime: null

--- a/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/embedded-module-embedded-chosen-source.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/embedded-module-embedded-chosen-source.yaml
@@ -3,18 +3,21 @@ apiVersion: deckhouse.io/v1alpha1
 kind: ModuleSource
 metadata:
   annotations:
-    modules.deckhouse.io/registry-spec-checksum: 912e02634dd8b7222cc42906e35f1e79
+    modules.deckhouse.io/registry-spec-checksum: 90f0955ee984feab5c50611987008def
+  creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/module-exists
   name: test-source-1
   resourceVersion: "1001"
 spec:
   registry:
+    ca: ""
     dockerCfg: YXNiCg==
     repo: dev-registry.deckhouse.io/deckhouse/modules
     scheme: HTTPS
   scanInterval: 6h30m0s
 status:
+  message: ""
   modules:
   - checksum: 'sha256:'
     name: ingressnginx
@@ -26,15 +29,20 @@ status:
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleSource
 metadata:
+  creationTimestamp: null
   name: test-source-2
   resourceVersion: "999"
 spec:
   registry:
+    ca: ""
     dockerCfg: YXNiCg==
     repo: dev-registry.deckhouse.io/deckhouse/modules-2
     scheme: HTTPS
   scanInterval: 6h30m0s
 status:
+  message: ""
   modules:
   - name: ingressnginx
+  modulesCount: 0
+  phase: ""
   syncTime: null

--- a/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/embedded-module-embedded-chosen-source.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/embedded-module-embedded-chosen-source.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  annotations:
+    modules.deckhouse.io/registry-spec-checksum: 912e02634dd8b7222cc42906e35f1e79
+  finalizers:
+  - modules.deckhouse.io/module-exists
+  name: test-source-1
+  resourceVersion: "1001"
+spec:
+  registry:
+    dockerCfg: YXNiCg==
+    repo: dev-registry.deckhouse.io/deckhouse/modules
+    scheme: HTTPS
+  scanInterval: 6h30m0s
+status:
+  modules:
+  - checksum: 'sha256:'
+    name: ingressnginx
+    version: v1.2.3
+  modulesCount: 1
+  phase: Active
+  syncTime: "2019-10-17T15:33:00Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  name: test-source-2
+  resourceVersion: "999"
+spec:
+  registry:
+    dockerCfg: YXNiCg==
+    repo: dev-registry.deckhouse.io/deckhouse/modules-2
+    scheme: HTTPS
+  scanInterval: 6h30m0s
+status:
+  modules:
+  - name: ingressnginx
+  syncTime: null

--- a/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/embedded-module-other-chosen-source.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/embedded-module-other-chosen-source.yaml
@@ -3,18 +3,21 @@ apiVersion: deckhouse.io/v1alpha1
 kind: ModuleSource
 metadata:
   annotations:
-    modules.deckhouse.io/registry-spec-checksum: 912e02634dd8b7222cc42906e35f1e79
+    modules.deckhouse.io/registry-spec-checksum: 90f0955ee984feab5c50611987008def
+  creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/module-exists
   name: test-source-1
   resourceVersion: "1001"
 spec:
   registry:
+    ca: ""
     dockerCfg: YXNiCg==
     repo: dev-registry.deckhouse.io/deckhouse/modules
     scheme: HTTPS
   scanInterval: 6h30m0s
 status:
+  message: ""
   modules:
   - checksum: 'sha256:'
     name: ingressnginx
@@ -26,15 +29,20 @@ status:
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleSource
 metadata:
+  creationTimestamp: null
   name: test-source-2
   resourceVersion: "999"
 spec:
   registry:
+    ca: ""
     dockerCfg: YXNiCg==
     repo: dev-registry.deckhouse.io/deckhouse/modules-2
     scheme: HTTPS
   scanInterval: 6h30m0s
 status:
+  message: ""
   modules:
   - name: ingressnginx
+  modulesCount: 0
+  phase: ""
   syncTime: null

--- a/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/embedded-module-other-chosen-source.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/embedded-module-other-chosen-source.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  annotations:
+    modules.deckhouse.io/registry-spec-checksum: 912e02634dd8b7222cc42906e35f1e79
+  finalizers:
+  - modules.deckhouse.io/module-exists
+  name: test-source-1
+  resourceVersion: "1001"
+spec:
+  registry:
+    dockerCfg: YXNiCg==
+    repo: dev-registry.deckhouse.io/deckhouse/modules
+    scheme: HTTPS
+  scanInterval: 6h30m0s
+status:
+  modules:
+  - checksum: 'sha256:'
+    name: ingressnginx
+    version: v1.2.3
+  modulesCount: 1
+  phase: Active
+  syncTime: "2019-10-17T15:33:00Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  name: test-source-2
+  resourceVersion: "999"
+spec:
+  registry:
+    dockerCfg: YXNiCg==
+    repo: dev-registry.deckhouse.io/deckhouse/modules-2
+    scheme: HTTPS
+  scanInterval: 6h30m0s
+status:
+  modules:
+  - name: ingressnginx
+  syncTime: null

--- a/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/embedded-module-several-sources-conflict.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/embedded-module-several-sources-conflict.yaml
@@ -3,18 +3,21 @@ apiVersion: deckhouse.io/v1alpha1
 kind: ModuleSource
 metadata:
   annotations:
-    modules.deckhouse.io/registry-spec-checksum: 912e02634dd8b7222cc42906e35f1e79
+    modules.deckhouse.io/registry-spec-checksum: 90f0955ee984feab5c50611987008def
+  creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/module-exists
   name: test-source-1
   resourceVersion: "1001"
 spec:
   registry:
+    ca: ""
     dockerCfg: YXNiCg==
     repo: dev-registry.deckhouse.io/deckhouse/modules
     scheme: HTTPS
   scanInterval: 6h30m0s
 status:
+  message: ""
   modules:
   - checksum: 'sha256:'
     name: ingressnginx
@@ -26,15 +29,20 @@ status:
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleSource
 metadata:
+  creationTimestamp: null
   name: test-source-2
   resourceVersion: "999"
 spec:
   registry:
+    ca: ""
     dockerCfg: YXNiCg==
     repo: dev-registry.deckhouse.io/deckhouse/modules-2
     scheme: HTTPS
   scanInterval: 6h30m0s
 status:
+  message: ""
   modules:
   - name: ingressnginx
+  modulesCount: 0
+  phase: ""
   syncTime: null

--- a/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/embedded-module-several-sources-conflict.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/embedded-module-several-sources-conflict.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  annotations:
+    modules.deckhouse.io/registry-spec-checksum: 912e02634dd8b7222cc42906e35f1e79
+  finalizers:
+  - modules.deckhouse.io/module-exists
+  name: test-source-1
+  resourceVersion: "1001"
+spec:
+  registry:
+    dockerCfg: YXNiCg==
+    repo: dev-registry.deckhouse.io/deckhouse/modules
+    scheme: HTTPS
+  scanInterval: 6h30m0s
+status:
+  modules:
+  - checksum: 'sha256:'
+    name: ingressnginx
+    version: v1.2.3
+  modulesCount: 1
+  phase: Active
+  syncTime: "2019-10-17T15:33:00Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  name: test-source-2
+  resourceVersion: "999"
+spec:
+  registry:
+    dockerCfg: YXNiCg==
+    repo: dev-registry.deckhouse.io/deckhouse/modules-2
+    scheme: HTTPS
+  scanInterval: 6h30m0s
+status:
+  modules:
+  - name: ingressnginx
+  syncTime: null

--- a/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/embedded-module-single-source.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/embedded-module-single-source.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  annotations:
+    modules.deckhouse.io/registry-spec-checksum: 912e02634dd8b7222cc42906e35f1e79
+  finalizers:
+  - modules.deckhouse.io/module-exists
+  name: test-source-1
+  resourceVersion: "1001"
+spec:
+  registry:
+    dockerCfg: YXNiCg==
+    repo: dev-registry.deckhouse.io/deckhouse/modules
+    scheme: HTTPS
+  scanInterval: 6h30m0s
+status:
+  modules:
+  - checksum: 'sha256:'
+    name: ingressnginx
+    version: v1.2.3
+  modulesCount: 1
+  phase: Active
+  syncTime: "2019-10-17T15:33:00Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleRelease
+metadata:
+  annotations:
+    modules.deckhouse.io/apply-now: "true"
+    modules.deckhouse.io/change-cause: check release (no releases in cluster)
+  labels:
+    module: ingressnginx
+    modules.deckhouse.io/update-policy: ""
+    release-checksum: 1beb143dffb1b662137094e7faea1e17
+    source: test-source-1
+  name: ingressnginx-v1.2.3
+  ownerReferences:
+  - apiVersion: deckhouse.io/v1alpha1
+    controller: true
+    kind: ModuleSource
+    name: test-source-1
+    uid: ""
+  resourceVersion: "1"
+spec:
+  moduleName: ingressnginx
+  requirements:
+    kubernetes: '>= 1.27'
+  version: 1.2.3
+  weight: 900
+status:
+  approved: false
+  pullDuration: 0s
+  transitionTime: null

--- a/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/embedded-module-single-source.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/embedded-module-single-source.yaml
@@ -3,18 +3,21 @@ apiVersion: deckhouse.io/v1alpha1
 kind: ModuleSource
 metadata:
   annotations:
-    modules.deckhouse.io/registry-spec-checksum: 912e02634dd8b7222cc42906e35f1e79
+    modules.deckhouse.io/registry-spec-checksum: 90f0955ee984feab5c50611987008def
+  creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/module-exists
   name: test-source-1
   resourceVersion: "1001"
 spec:
   registry:
+    ca: ""
     dockerCfg: YXNiCg==
     repo: dev-registry.deckhouse.io/deckhouse/modules
     scheme: HTTPS
   scanInterval: 6h30m0s
 status:
+  message: ""
   modules:
   - checksum: 'sha256:'
     name: ingressnginx
@@ -29,6 +32,7 @@ metadata:
   annotations:
     modules.deckhouse.io/apply-now: "true"
     modules.deckhouse.io/change-cause: check release (no releases in cluster)
+  creationTimestamp: null
   labels:
     module: ingressnginx
     modules.deckhouse.io/update-policy: ""
@@ -50,5 +54,7 @@ spec:
   weight: 900
 status:
   approved: false
+  message: ""
   pullDuration: 0s
+  size: 0
   transitionTime: null

--- a/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/embedded-module-stale-chosen-source.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/embedded-module-stale-chosen-source.yaml
@@ -3,18 +3,21 @@ apiVersion: deckhouse.io/v1alpha1
 kind: ModuleSource
 metadata:
   annotations:
-    modules.deckhouse.io/registry-spec-checksum: 912e02634dd8b7222cc42906e35f1e79
+    modules.deckhouse.io/registry-spec-checksum: 90f0955ee984feab5c50611987008def
+  creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/module-exists
   name: test-source-1
   resourceVersion: "1001"
 spec:
   registry:
+    ca: ""
     dockerCfg: YXNiCg==
     repo: dev-registry.deckhouse.io/deckhouse/modules
     scheme: HTTPS
   scanInterval: 6h30m0s
 status:
+  message: ""
   modules:
   - checksum: 'sha256:'
     name: ingressnginx

--- a/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/embedded-module-stale-chosen-source.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/embedded-module-stale-chosen-source.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  annotations:
+    modules.deckhouse.io/registry-spec-checksum: 912e02634dd8b7222cc42906e35f1e79
+  finalizers:
+  - modules.deckhouse.io/module-exists
+  name: test-source-1
+  resourceVersion: "1001"
+spec:
+  registry:
+    dockerCfg: YXNiCg==
+    repo: dev-registry.deckhouse.io/deckhouse/modules
+    scheme: HTTPS
+  scanInterval: 6h30m0s
+status:
+  modules:
+  - checksum: 'sha256:'
+    name: ingressnginx
+    version: v1.2.3
+  modulesCount: 1
+  phase: Active
+  syncTime: "2019-10-17T15:33:00Z"

--- a/deckhouse-controller/pkg/controller/moduleloader/loader.go
+++ b/deckhouse-controller/pkg/controller/moduleloader/loader.go
@@ -78,6 +78,23 @@ var (
 
 var _ loader.ModuleLoader = &Loader{}
 
+// Installer abstracts *installer.Installer so tests can inject a mock and assert
+// which installation path a module took (Restore vs StageFromRegistry) without
+// touching the registry or filesystem. It mirrors the public method set of
+// *installer.Installer that the loader and its getter expose to other controllers.
+type Installer interface {
+	SetClusterUUID(id string)
+	GetInstalled() (map[string]struct{}, error)
+	GetImageDigest(ctx context.Context, source *v1alpha1.ModuleSource, moduleName, version string) (string, error)
+	Download(ctx context.Context, source *v1alpha1.ModuleSource, moduleName, version string) (string, error)
+	Install(ctx context.Context, module, version, tempModulePath string) error
+	Stage(ctx context.Context, module, version, tempModulePath string) error
+	StageFromRegistry(ctx context.Context, source *v1alpha1.ModuleSource, module, version string) error
+	Restore(ctx context.Context, source *v1alpha1.ModuleSource, module, version string) error
+	IsEmbeddedPresent(module string) bool
+	Uninstall(ctx context.Context, module string) error
+}
+
 type Loader struct {
 	client         client.Client
 	logger         *log.Logger
@@ -88,7 +105,7 @@ type Loader struct {
 	// global module dir
 	globalDir string
 
-	installer *installer.Installer
+	installer Installer
 
 	registries map[string]*addonmodules.Registry
 
@@ -148,7 +165,7 @@ func (l *Loader) Sync(ctx context.Context) error {
 }
 
 // Installer returns installer instance
-func (l *Loader) Installer() *installer.Installer {
+func (l *Loader) Installer() Installer {
 	return l.installer
 }
 

--- a/deckhouse-controller/pkg/controller/moduleloader/sync.go
+++ b/deckhouse-controller/pkg/controller/moduleloader/sync.go
@@ -244,11 +244,13 @@ func (l *Loader) restoreModulesByReleases(ctx context.Context) error {
 		}
 
 		// update module version
+		moduleExists := true
 		module := new(v1alpha1.Module)
 		if err = l.client.Get(ctx, client.ObjectKey{Name: moduleName}, module); err != nil {
 			if !apierrors.IsNotFound(err) {
 				return fmt.Errorf("get the module '%s': %w", moduleName, err)
 			}
+			moduleExists = false
 			l.logger.Warn("module is missing, skip setting version", slog.String("name", release.Spec.ModuleName))
 		} else {
 			l.logger.Debug("set module version", slog.String("name", moduleName), slog.String("version", release.GetModuleVersion()))
@@ -267,8 +269,49 @@ func (l *Loader) restoreModulesByReleases(ctx context.Context) error {
 			return fmt.Errorf("get the module source '%s' for the module '%s': %w", source.Name, moduleName, err)
 		}
 
+		// While the embedded copy of the module is still shipped on the filesystem
+		// it wins the module search path, so a downloaded module of the same name
+		// must only be staged (no symlink/mount), not activated. Once the embedded
+		// copy is dropped on Deckhouse upgrade, this restore activates the staged
+		// module instead.
+		if l.installer.IsEmbeddedPresent(moduleName) {
+			l.logger.Info("module is still embedded, stage the release without activating it", slog.String("name", moduleName))
+			if err = l.installer.StageFromRegistry(ctx, source, moduleName, release.GetModuleVersion()); err != nil {
+				return fmt.Errorf("stage the module '%s': %w", moduleName, err)
+			}
+
+			// The embedded copy is still serving the module, so it must keep rendering
+			// images from the embedded registry (digests baked into the Deckhouse image).
+			// Do NOT inject the source registry here: that would make the embedded module
+			// pull <sourceRepo>/modules/<name>@<embeddedDigest>, a path that does not exist
+			// (the digest belongs to the embedded image, not the source's module image),
+			// breaking the module with ImagePullBackOff. The source registry is injected
+			// only once the embedded copy is dropped and the module is activated (below).
+			continue
+		}
+
 		if err = l.installer.Restore(ctx, source, moduleName, release.GetModuleVersion()); err != nil {
 			return fmt.Errorf("restore the module '%s': %w", moduleName, err)
+		}
+
+		// The embedded copy is gone (otherwise it would have been staged above),
+		// so the module is now served from the downloaded source. Flip its active
+		// source off the "Embedded" sentinel: this keeps the controller-side view
+		// (module.IsEmbedded()) consistent with the on-disk reality reported by
+		// IsEmbeddedPresent, and hands the module over to the regular source-owned
+		// flow (release ensuring, source switching). This is the single point where
+		// a migrated module transitions from embedded to external.
+		if moduleExists && module.IsEmbedded() {
+			l.logger.Info("embedded copy is gone, switch the module active source", slog.String("name", moduleName), slog.String("source_name", source.Name))
+			err = ctrlutils.UpdateWithRetry(ctx, l.client, module, func() error {
+				if module.Properties.Source == v1alpha1.ModuleSourceEmbedded {
+					module.Properties.Source = source.Name
+				}
+				return nil
+			})
+			if err != nil {
+				return fmt.Errorf("switch the active source for the module '%s': %w", moduleName, err)
+			}
 		}
 
 		l.registries[moduleName] = utils.BuildRegistryValue(source)

--- a/deckhouse-controller/pkg/controller/moduleloader/sync_test.go
+++ b/deckhouse-controller/pkg/controller/moduleloader/sync_test.go
@@ -16,1109 +16,393 @@ package moduleloader
 
 import (
 	"context"
-	"flag"
-	"fmt"
-	"os"
-	"path/filepath"
 	"testing"
+	"time"
 
 	addonmodules "github.com/flant/addon-operator/pkg/module_manager/models/modules"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
-	"helm.sh/helm/v3/pkg/releaseutil"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"sigs.k8s.io/yaml"
 
+	installermock "github.com/deckhouse/deckhouse/deckhouse-controller/internal/module/installer/mock"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha2"
-	"github.com/deckhouse/deckhouse/go_lib/d8env"
 	"github.com/deckhouse/deckhouse/go_lib/dependency"
 	"github.com/deckhouse/deckhouse/pkg/log"
 )
 
 const (
-	values = `
-type: object
-x-extend:
-  schema: config-values.yaml
-properties:
-  registry:
-    type: object
-    default: {}
-    properties:
-      base:
-        type: string
-        default: dev-registry.deckhouse.io/deckhouse/losev/external-modules
-      dockercfg:
-        type: string
-        default: YXNiCg==
-      scheme:
-        type: string
-        default: HTTP
-      ca:
-        type: string
-        default:
-  internal:
-    default: {}
-    properties:
-      pythonVersions:
-        default: []
-        items:
-          type: string
-        type: array
-    type: object`
+	testNodeName = "dev-master-0"
+	testRepo     = "dev-registry.example.io/deckhouse/modules"
 )
 
-type ModuleLoaderTestSuite struct {
-	suite.Suite
-
-	client client.Client
-	loader *Loader
-
-	testDataFileName string
-
-	tmpDir string
+// installerCall records a single (module, version) installer invocation so a test
+// can assert which path (Restore vs StageFromRegistry) a module took.
+type installerCall struct {
+	module  string
+	version string
 }
 
-func TestModuleLoaderTestSuite(t *testing.T) {
-	suite.Run(t, new(ModuleLoaderTestSuite))
+// installerCalls captures everything the loader asked the installer to do.
+type installerCalls struct {
+	restore           []installerCall
+	stageFromRegistry []installerCall
+	uninstall         []string
 }
 
-func (suite *ModuleLoaderTestSuite) setupModuleLoader(raw string) { //nolint:revive,unused
-	manifests := releaseutil.SplitManifests(raw)
-
-	var objects = make([]client.Object, 0, len(manifests))
-	for _, manifest := range manifests {
-		obj := suite.parseKubernetesObject([]byte(manifest))
-		objects = append(objects, obj)
+// newRecordingInstaller returns a mock installer that records its calls and reports
+// the modules in embedded as having an embedded copy still shipped on the filesystem.
+func newRecordingInstaller(calls *installerCalls, embedded map[string]bool) *installermock.Installer {
+	return &installermock.Installer{
+		IsEmbeddedPresentFunc: func(module string) bool { return embedded[module] },
+		RestoreFunc: func(_ context.Context, _ *v1alpha1.ModuleSource, module, version string) error {
+			calls.restore = append(calls.restore, installerCall{module, version})
+			return nil
+		},
+		StageFromRegistryFunc: func(_ context.Context, _ *v1alpha1.ModuleSource, module, version string) error {
+			calls.stageFromRegistry = append(calls.stageFromRegistry, installerCall{module, version})
+			return nil
+		},
+		UninstallFunc: func(_ context.Context, module string) error {
+			calls.uninstall = append(calls.uninstall, module)
+			return nil
+		},
 	}
+}
 
+func newTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
 	sc := runtime.NewScheme()
-	_ = v1alpha1.SchemeBuilder.AddToScheme(sc)
-	_ = v1alpha2.SchemeBuilder.AddToScheme(sc)
-	_ = corev1.AddToScheme(sc)
-	suite.client = fake.NewClientBuilder().
-		WithScheme(sc).
+	require.NoError(t, v1alpha1.SchemeBuilder.AddToScheme(sc))
+	require.NoError(t, v1alpha2.SchemeBuilder.AddToScheme(sc))
+	require.NoError(t, corev1.AddToScheme(sc))
+	return sc
+}
+
+func newTestLoader(t *testing.T, inst Installer, objects ...client.Object) *Loader {
+	t.Helper()
+
+	cl := fake.NewClientBuilder().
+		WithScheme(newTestScheme(t)).
 		WithObjects(objects...).
-		WithStatusSubresource(&v1alpha1.ModuleRelease{}, &v1alpha1.ModuleSource{}, &v1alpha2.ModulePullOverride{}).
+		WithStatusSubresource(&v1alpha1.Module{}, &v1alpha1.ModuleRelease{}, &v1alpha1.ModuleSource{}, &v1alpha2.ModulePullOverride{}).
 		Build()
 
-	suite.loader = &Loader{
-		client:               suite.client,
+	tmp := t.TempDir()
+
+	return &Loader{
+		client:               cl,
 		logger:               log.NewNop(),
-		downloadedModulesDir: d8env.GetDownloadedModulesDir(),
-		symlinksDir:          filepath.Join(d8env.GetDownloadedModulesDir(), "modules"),
-		dependencyContainer:  dependency.NewDependencyContainer(),
+		installer:            inst,
 		registries:           make(map[string]*addonmodules.Registry),
+		dependencyContainer:  dependency.NewDependencyContainer(),
+		downloadedModulesDir: tmp,
+		symlinksDir:          tmp + "/modules",
 	}
 }
 
-func (suite *ModuleLoaderTestSuite) parseKubernetesObject(raw []byte) client.Object { //nolint:revive,unused
-	metaType := new(runtime.TypeMeta)
-	err := yaml.Unmarshal(raw, metaType)
-	require.NoError(suite.T(), err)
+// --- object builders -------------------------------------------------------
 
-	var obj client.Object
-
-	switch metaType.Kind {
-	case v1alpha1.ModuleSourceGVK.Kind:
-		source := new(v1alpha1.ModuleSource)
-		err = yaml.Unmarshal(raw, source)
-		require.NoError(suite.T(), err)
-		obj = source
-
-	case v1alpha1.ModuleReleaseGVK.Kind:
-		release := new(v1alpha1.ModuleRelease)
-		err = yaml.Unmarshal(raw, release)
-		require.NoError(suite.T(), err)
-		obj = release
-
-	case v1alpha2.ModuleUpdatePolicyGVK.Kind:
-		policy := new(v1alpha2.ModuleUpdatePolicy)
-		err = yaml.Unmarshal(raw, policy)
-		require.NoError(suite.T(), err)
-		obj = policy
-
-	case v1alpha2.ModulePullOverrideGVK.Kind:
-		mpo := new(v1alpha2.ModulePullOverride)
-		err = yaml.Unmarshal(raw, mpo)
-		require.NoError(suite.T(), err)
-		obj = mpo
-
-	case v1alpha1.ModuleGVK.Kind:
-		module := new(v1alpha1.Module)
-		err = yaml.Unmarshal(raw, module)
-		require.NoError(suite.T(), err)
-		obj = module
-	}
-
-	return obj
-}
-
-func (suite *ModuleLoaderTestSuite) SetupSuite() {
-	flag.Parse()
-	suite.T().Setenv("D8_IS_TESTS_ENVIRONMENT", "true")
-	suite.T().Setenv("DECKHOUSE_NODE_NAME", "dev-master-0")
-	suite.tmpDir = suite.T().TempDir()
-	suite.T().Setenv(d8env.DownloadedModulesDir, suite.tmpDir)
-	_ = os.MkdirAll(filepath.Join(suite.tmpDir, "modules"), 0777)
-}
-
-// func (suite *ModuleLoaderTestSuite) TestRestoreModulesByOverrides() {
-// 	module := moduleSuite{
-// 		name:          "echo",
-// 		version:       downloader.DefaultDevVersion,
-// 		weight:        900,
-// 		downloadedDir: suite.tmpDir,
-// 	}
-//
-// 	manifestStub := func() (*crv1.Manifest, error) {
-// 		return &crv1.Manifest{
-// 			Layers: []crv1.Descriptor{},
-// 		}, nil
-// 	}
-//
-// 	type testCase struct {
-// 		name           string
-// 		filename       string
-// 		layersStab     func() ([]crv1.Layer, error)
-// 		symlinkChanged bool
-// 		valuesChanged  bool
-// 		checkValues    bool
-// 	}
-//
-// 	testCases := []testCase{
-// 		{
-// 			// should not do anything
-// 			name:           "Ok",
-// 			filename:       "mpo.yaml",
-// 			symlinkChanged: false,
-// 			valuesChanged:  false,
-// 			checkValues:    true,
-// 		},
-// 		{
-// 			// should set default weight for module
-// 			name:     "NoWeightNoDefinition",
-// 			filename: "mpo-without-weight.yaml",
-// 			layersStab: func() ([]crv1.Layer, error) {
-// 				return []crv1.Layer{&utils.FakeLayer{
-// 					FilesContent: map[string]string{"version.json": `{"version": "v1.16.0"}`}}}, nil
-// 			},
-// 			symlinkChanged: false,
-// 			valuesChanged:  false,
-// 			checkValues:    true,
-// 		},
-// 		{
-// 			// should set mpo`s the weight from module.yaml
-// 			name:     "NoWeightWithDefinition",
-// 			filename: "mpo-without-weight.yaml",
-// 			layersStab: func() ([]crv1.Layer, error) {
-// 				return []crv1.Layer{&utils.FakeLayer{
-// 					FilesContent: map[string]string{"version.json": `{"version": "v1.16.0"}`}},
-// 					&utils.FakeLayer{FilesContent: map[string]string{"module.yaml": "weight: 900"}}}, nil
-// 			},
-// 			symlinkChanged: false,
-// 			valuesChanged:  false,
-// 			checkValues:    true,
-// 		},
-// 		{
-// 			// should update deployed-on annotation
-// 			name:     "WrongDeployedOnAnnotation",
-// 			filename: "mpo-with-old-deployed-on.yaml",
-// 			layersStab: func() ([]crv1.Layer, error) {
-// 				return []crv1.Layer{&utils.FakeLayer{
-// 					FilesContent: map[string]string{"version.json": `{"version": "v1.16.0"}`}},
-// 					&utils.FakeLayer{FilesContent: map[string]string{"module.yaml": "weight: 900"}}}, nil
-// 			},
-// 			symlinkChanged: true,
-// 			valuesChanged:  true,
-// 			checkValues:    false,
-// 		},
-// 	}
-//
-// 	for _, tc := range testCases {
-// 		suite.Run(tc.name, func() {
-// 			if tc.layersStab != nil {
-// 				dependency.TestDC.CRClient.ImageMock.Return(&crfake.FakeImage{
-// 					ManifestStub: manifestStub,
-// 					LayersStub:   tc.layersStab,
-// 				}, nil)
-// 			}
-//
-// 			require.NoError(suite.T(), module.prepare(true, true))
-//
-// 			statValues, err := os.Stat(module.valuesPath)
-// 			require.NoError(suite.T(), err)
-//
-// 			statSymlink, err := os.Lstat(module.symlinkPath)
-// 			require.NoError(suite.T(), err)
-//
-// 			time.Sleep(50 * time.Millisecond)
-//
-// 			suite.setupModuleLoader(string(suite.parseTestdata("overrides", tc.filename)))
-// 			require.NoError(suite.T(), suite.loader.restoreModulesByOverrides(context.TODO()))
-//
-// 			if tc.checkValues {
-// 				newStatValues, err := os.Stat(module.valuesPath)
-// 				require.NoError(suite.T(), err)
-//
-// 				if tc.valuesChanged {
-// 					assert.False(suite.T(), statValues.ModTime().Equal(newStatValues.ModTime()), "values.yaml must be modified")
-// 				} else {
-// 					assert.True(suite.T(), statValues.ModTime().Equal(newStatValues.ModTime()), "values.yaml mustn't be modified")
-// 				}
-// 			}
-//
-// 			newStatSymlink, err := os.Lstat(module.symlinkPath)
-// 			require.NoError(suite.T(), err)
-//
-// 			if tc.symlinkChanged {
-// 				assert.False(suite.T(), statSymlink.ModTime().Equal(newStatSymlink.ModTime()), "Module's symlink must be modified")
-// 			} else {
-// 				assert.True(suite.T(), statSymlink.ModTime().Equal(newStatSymlink.ModTime()), "Module's symlink mustn't be modified")
-// 			}
-//
-// 			mpo := suite.modulePullOverride(module.name)
-// 			assert.Equal(suite.T(), mpo.Status.Weight, uint32(module.weight), "ModulePullOverride weight must equal to module's weight")
-//
-// 			suite.cleanupPaths([]string{module.downloadedPath, module.symlinkPath})
-// 		})
-// 	}
-//
-// 	// should ensure symlink
-// 	suite.Run("NoSymlink", func() {
-// 		dependency.TestDC.CRClient.ImageMock.Return(&crfake.FakeImage{
-// 			ManifestStub: manifestStub,
-// 			LayersStub: func() ([]crv1.Layer, error) {
-// 				return []crv1.Layer{&utils.FakeLayer{}}, nil
-// 			},
-// 		}, nil)
-//
-// 		require.NoError(suite.T(), module.prepare(true, false))
-//
-// 		statValues, err := os.Stat(module.valuesPath)
-// 		require.NoError(suite.T(), err)
-//
-// 		time.Sleep(50 * time.Millisecond)
-//
-// 		suite.setupModuleLoader(string(suite.parseTestdata("overrides", "mpo.yaml")))
-// 		require.NoError(suite.T(), suite.loader.restoreModulesByOverrides(context.TODO()))
-//
-// 		newStatValues, err := os.Stat(module.valuesPath)
-// 		require.NoError(suite.T(), err)
-//
-// 		assert.True(suite.T(), statValues.ModTime().Equal(newStatValues.ModTime()), "values.yaml mustn't be modified")
-//
-// 		_, err = os.Lstat(module.symlinkPath)
-// 		require.NoError(suite.T(), err)
-//
-// 		mpo := suite.modulePullOverride(module.name)
-// 		assert.Equal(suite.T(), mpo.Status.Weight, uint32(module.weight), "ModulePullOverride weight must equal to module's weight")
-//
-// 		suite.cleanupPaths([]string{module.downloadedPath, module.symlinkPath})
-// 	})
-//
-// 	// should ensure downloaded module`s dir
-// 	suite.Run("NoDownloadedModule", func() {
-// 		dependency.TestDC.CRClient.ImageMock.Return(&crfake.FakeImage{
-// 			ManifestStub: manifestStub,
-// 			LayersStub: func() ([]crv1.Layer, error) {
-// 				return []crv1.Layer{&utils.FakeLayer{}}, nil
-// 			},
-// 		}, nil)
-//
-// 		require.NoError(suite.T(), module.prepare(false, false))
-//
-// 		time.Sleep(50 * time.Millisecond)
-//
-// 		suite.setupModuleLoader(string(suite.parseTestdata("overrides", "mpo.yaml")))
-// 		require.NoError(suite.T(), suite.loader.restoreModulesByOverrides(context.TODO()))
-//
-// 		_, err := os.Lstat(module.symlinkPath)
-// 		require.NoError(suite.T(), err)
-//
-// 		mpo := suite.modulePullOverride(module.name)
-// 		assert.Equal(suite.T(), mpo.Status.Weight, uint32(module.weight), "ModulePullOverride weight must equal to module's weight")
-//
-// 		suite.cleanupPaths([]string{module.downloadedPath, module.symlinkPath})
-// 	})
-//
-// 	// should remove extra symlink
-// 	suite.Run("ExtraSymlinks", func() {
-// 		dependency.TestDC.CRClient.ImageMock.Return(&crfake.FakeImage{
-// 			ManifestStub: manifestStub,
-// 			LayersStub: func() ([]crv1.Layer, error) {
-// 				return []crv1.Layer{&utils.FakeLayer{}}, nil
-// 			},
-// 		}, nil)
-//
-// 		require.NoError(suite.T(), module.prepare(true, false))
-//
-// 		statValues, err := os.Stat(module.valuesPath)
-// 		require.NoError(suite.T(), err)
-//
-// 		_, err = os.Lstat(module.symlinkPath)
-// 		assert.True(suite.T(), os.IsNotExist(err), "Module's symlink mustn't exist")
-//
-// 		symlink1 := filepath.Join(suite.tmpDir, "modules", fmt.Sprintf("901-%s", module.name))
-// 		symlink2 := filepath.Join(suite.tmpDir, "modules", fmt.Sprintf("902-%s", module.name))
-// 		symlink3 := filepath.Join(suite.tmpDir, "modules", fmt.Sprintf("903-%s", module.name))
-//
-// 		// extra symlinks
-// 		require.NoError(suite.T(), os.Symlink(module.downloadedDir, symlink1))
-// 		require.NoError(suite.T(), os.Symlink(module.downloadedDir, symlink2))
-// 		require.NoError(suite.T(), os.Symlink(module.downloadedDir, symlink3))
-//
-// 		time.Sleep(50 * time.Millisecond)
-//
-// 		suite.setupModuleLoader(string(suite.parseTestdata("overrides", "mpo.yaml")))
-// 		require.NoError(suite.T(), suite.loader.restoreModulesByOverrides(context.TODO()))
-//
-// 		newStatValues, err := os.Stat(module.valuesPath)
-// 		require.NoError(suite.T(), err)
-// 		assert.True(suite.T(), statValues.ModTime().Equal(newStatValues.ModTime()), "values.yaml mustn't be modified")
-//
-// 		_, err = os.Lstat(module.symlinkPath)
-// 		assert.Equal(suite.T(), err, nil, "Module's symlink must be created")
-//
-// 		_, err = os.Lstat(symlink1)
-// 		assert.True(suite.T(), os.IsNotExist(err), "Extra symlink mustn't exist")
-// 		_, err = os.Lstat(symlink2)
-// 		assert.True(suite.T(), os.IsNotExist(err), "Extra symlink mustn't exist")
-// 		_, err = os.Lstat(symlink3)
-// 		assert.True(suite.T(), os.IsNotExist(err), "Extra symlink mustn't exist")
-//
-// 		mpo := suite.modulePullOverride(module.name)
-// 		assert.Equal(suite.T(), mpo.Status.Weight, uint32(module.weight), "ModulePullOverride weight must equal to module's weight")
-//
-// 		suite.cleanupPaths([]string{module.downloadedPath, module.symlinkPath})
-// 	})
-//
-// 	// should remove wrong symlink and ensure new
-// 	suite.Run("WrongSymlink", func() {
-// 		dependency.TestDC.CRClient.ImageMock.Return(&crfake.FakeImage{
-// 			ManifestStub: manifestStub,
-// 			LayersStub: func() ([]crv1.Layer, error) {
-// 				return []crv1.Layer{&utils.FakeLayer{}}, nil
-// 			},
-// 		}, nil)
-//
-// 		require.NoError(suite.T(), module.prepare(true, false))
-//
-// 		require.NoError(suite.T(), os.MkdirAll(filepath.Join(suite.tmpDir, "echo", "fakeVersion"), 0750))
-//
-// 		symlink := filepath.Join(suite.tmpDir, "modules", fmt.Sprintf("900-%s", module.name))
-// 		require.NoError(suite.T(), os.Symlink(filepath.Join(suite.tmpDir, "echo", "fakeVersion"), symlink))
-//
-// 		statValues, err := os.Stat(module.valuesPath)
-// 		require.NoError(suite.T(), err)
-//
-// 		statSymlink, err := os.Lstat(symlink)
-// 		require.NoError(suite.T(), err)
-//
-// 		time.Sleep(50 * time.Millisecond)
-//
-// 		suite.setupModuleLoader(string(suite.parseTestdata("overrides", "mpo.yaml")))
-// 		require.NoError(suite.T(), suite.loader.restoreModulesByOverrides(context.TODO()))
-//
-// 		newStatValues, err := os.Stat(module.valuesPath)
-// 		require.NoError(suite.T(), err)
-// 		assert.True(suite.T(), statValues.ModTime().Equal(newStatValues.ModTime()), "values.yaml mustn't be modified")
-//
-// 		newStatSymlink, err := os.Lstat(symlink)
-// 		require.NoError(suite.T(), err)
-// 		assert.False(suite.T(), statSymlink.ModTime().Equal(newStatSymlink.ModTime()), "Module's symlink must be modified")
-//
-// 		mpo := suite.modulePullOverride(module.name)
-// 		assert.Equal(suite.T(), mpo.Status.Weight, uint32(module.weight), "ModulePullOverride weight must equal to module's weight")
-//
-// 		suite.cleanupPaths([]string{symlink, module.downloadedPath, module.symlinkPath})
-// 	})
-// }
-
-// func (suite *ModuleLoaderTestSuite) TestRestoreModulesByOverridesWithMultipleReleases() {
-// 	module := moduleSuite{
-// 		name:          "test-module",
-// 		weight:        900,
-// 		downloadedDir: suite.tmpDir,
-// 		version:       downloader.DefaultDevVersion,
-// 	}
-//
-// 	manifestStub := func() (*crv1.Manifest, error) {
-// 		return &crv1.Manifest{
-// 			Layers: []crv1.Descriptor{},
-// 		}, nil
-// 	}
-//
-// 	// Test case 1: Multiple releases, all in Deployed status
-// 	// Expected: MPO should set module version but not change release statuses
-// 	// This test verifies that restoreAbsentModulesFromOverrides correctly handles MPO
-// 	// without affecting the existing ModuleRelease statuses
-// 	suite.Run("MultipleReleasesAllDeployed", func() {
-// 		dependency.TestDC.CRClient.ImageMock.Return(&crfake.FakeImage{
-// 			ManifestStub: manifestStub,
-// 			LayersStub: func() ([]crv1.Layer, error) {
-// 				return []crv1.Layer{&utils.FakeLayer{}}, nil
-// 			},
-// 		}, nil)
-//
-// 		require.NoError(suite.T(), module.prepare(true, true))
-//
-// 		suite.setupModuleLoader(string(suite.parseTestdata("overrides", "multiple-releases-all-deployed.yaml")))
-// 		require.NoError(suite.T(), suite.loader.restoreModulesByOverrides(context.TODO()))
-//
-// 		// Check that the module symlink was created
-// 		_, err := os.Lstat(module.symlinkPath)
-// 		require.NoError(suite.T(), err, "Module symlink should exist")
-//
-// 		// Check that the module files exist
-// 		_, err = os.Stat(module.valuesPath)
-// 		require.NoError(suite.T(), err, "Module values should exist")
-//
-// 		// Verify that the module version in the Module resource is set to v1.0.2 (from MPO)
-// 		moduleObj := new(v1alpha1.Module)
-// 		err = suite.client.Get(context.TODO(), client.ObjectKey{Name: "test-module"}, moduleObj)
-// 		require.NoError(suite.T(), err)
-// 		assert.Equal(suite.T(), "v1.0.2", moduleObj.Properties.Version, "Module version should be set from MPO")
-//
-// 		// Verify the ModuleRelease statuses remain unchanged (MPO should not affect release statuses)
-// 		releases := new(v1alpha1.ModuleReleaseList)
-// 		err = suite.client.List(context.TODO(), releases, client.MatchingLabels{"module": "test-module"})
-// 		require.NoError(suite.T(), err)
-// 		require.Len(suite.T(), releases.Items, 3, "Should have 3 releases")
-//
-// 		// Check specific statuses for each release to ensure MPO doesn't change them
-// 		// MPO should only affect module version, not release statuses
-// 		var deployedCount int
-// 		for _, release := range releases.Items {
-// 			switch release.GetModuleVersion() {
-// 			case "v1.0.0":
-// 				assert.Equal(suite.T(), v1alpha1.ModuleReleasePhaseDeployed, release.Status.Phase, "v1.0.0 should remain Deployed")
-// 				deployedCount++
-// 			case "v1.0.1":
-// 				assert.Equal(suite.T(), v1alpha1.ModuleReleasePhaseDeployed, release.Status.Phase, "v1.0.1 should remain Deployed")
-// 				deployedCount++
-// 			case "v1.0.2":
-// 				assert.Equal(suite.T(), v1alpha1.ModuleReleasePhaseDeployed, release.Status.Phase, "v1.0.2 should remain Deployed")
-// 				deployedCount++
-// 			default:
-// 				suite.T().Fatalf("Unexpected release version: %s", release.GetModuleVersion())
-// 			}
-// 		}
-// 		assert.Equal(suite.T(), 3, deployedCount, "Should have 3 deployed releases")
-//
-// 		suite.cleanupPaths([]string{module.downloadedPath, module.symlinkPath})
-// 	})
-//
-// 	// Test case 2: Multiple releases, all Superseded except last in Deployed
-// 	// Expected: MPO should set module version but not change release statuses
-// 	// This test verifies that restoreAbsentModulesFromOverrides correctly handles MPO
-// 	// with mixed release statuses without affecting them
-// 	suite.Run("MultipleReleasesSupersededExceptLast", func() {
-// 		dependency.TestDC.CRClient.ImageMock.Return(&crfake.FakeImage{
-// 			ManifestStub: manifestStub,
-// 			LayersStub: func() ([]crv1.Layer, error) {
-// 				return []crv1.Layer{&utils.FakeLayer{}}, nil
-// 			},
-// 		}, nil)
-//
-// 		require.NoError(suite.T(), module.prepare(true, true))
-//
-// 		suite.setupModuleLoader(string(suite.parseTestdata("overrides", "multiple-releases-superseded-except-last.yaml")))
-// 		require.NoError(suite.T(), suite.loader.restoreModulesByOverrides(context.TODO()))
-//
-// 		// Check that the module symlink was created
-// 		_, err := os.Lstat(module.symlinkPath)
-// 		require.NoError(suite.T(), err, "Module symlink should exist")
-//
-// 		// Check that the module files exist
-// 		_, err = os.Stat(module.valuesPath)
-// 		require.NoError(suite.T(), err, "Module values should exist")
-//
-// 		// Verify that the module version in the Module resource is set to v1.0.3 (from MPO)
-// 		moduleObj := new(v1alpha1.Module)
-// 		err = suite.client.Get(context.TODO(), client.ObjectKey{Name: "test-module"}, moduleObj)
-// 		require.NoError(suite.T(), err)
-// 		assert.Equal(suite.T(), "v1.0.3", moduleObj.Properties.Version, "Module version should be set from MPO")
-//
-// 		// Verify the ModuleRelease statuses remain unchanged (MPO should not affect release statuses)
-// 		releases := new(v1alpha1.ModuleReleaseList)
-// 		err = suite.client.List(context.TODO(), releases, client.MatchingLabels{"module": "test-module"})
-// 		require.NoError(suite.T(), err)
-// 		require.Len(suite.T(), releases.Items, 4, "Should have 4 releases")
-//
-// 		// Check specific statuses for each release to ensure MPO doesn't change them
-// 		var supersededCount, deployedCount int
-// 		for _, release := range releases.Items {
-// 			switch release.GetModuleVersion() {
-// 			case "v1.0.0":
-// 				assert.Equal(suite.T(), v1alpha1.ModuleReleasePhaseSuperseded, release.Status.Phase, "v1.0.0 should remain Superseded")
-// 				supersededCount++
-// 			case "v1.0.1":
-// 				assert.Equal(suite.T(), v1alpha1.ModuleReleasePhaseSuperseded, release.Status.Phase, "v1.0.1 should remain Superseded")
-// 				supersededCount++
-// 			case "v1.0.2":
-// 				assert.Equal(suite.T(), v1alpha1.ModuleReleasePhaseSuperseded, release.Status.Phase, "v1.0.2 should remain Superseded")
-// 				supersededCount++
-// 			case "v1.0.3":
-// 				assert.Equal(suite.T(), v1alpha1.ModuleReleasePhaseDeployed, release.Status.Phase, "v1.0.3 should remain Deployed")
-// 				deployedCount++
-// 			default:
-// 				suite.T().Fatalf("Unexpected release version: %s", release.GetModuleVersion())
-// 			}
-// 		}
-// 		assert.Equal(suite.T(), 3, supersededCount, "Should have 3 superseded releases")
-// 		assert.Equal(suite.T(), 1, deployedCount, "Should have 1 deployed release")
-//
-// 		suite.cleanupPaths([]string{module.downloadedPath, module.symlinkPath})
-// 	})
-//
-// 	// Test case 3: Multiple releases, first Superseded, several Deployed
-// 	// Expected: MPO should set module version but not change release statuses
-// 	// This test verifies that restoreAbsentModulesFromOverrides correctly handles MPO
-// 	// with complex release status patterns without affecting them
-// 	suite.Run("MultipleReleasesMixedStatus", func() {
-// 		dependency.TestDC.CRClient.ImageMock.Return(&crfake.FakeImage{
-// 			ManifestStub: manifestStub,
-// 			LayersStub: func() ([]crv1.Layer, error) {
-// 				return []crv1.Layer{&utils.FakeLayer{}}, nil
-// 			},
-// 		}, nil)
-//
-// 		require.NoError(suite.T(), module.prepare(true, true))
-//
-// 		suite.setupModuleLoader(string(suite.parseTestdata("overrides", "multiple-releases-mixed-status.yaml")))
-// 		require.NoError(suite.T(), suite.loader.restoreModulesByOverrides(context.TODO()))
-//
-// 		// Check that the module symlink was created
-// 		_, err := os.Lstat(module.symlinkPath)
-// 		require.NoError(suite.T(), err, "Module symlink should exist")
-//
-// 		// Check that the module files exist
-// 		_, err = os.Stat(module.valuesPath)
-// 		require.NoError(suite.T(), err, "Module values should exist")
-//
-// 		// Verify that the module version in the Module resource is set to v1.0.2 (from MPO)
-// 		moduleObj := new(v1alpha1.Module)
-// 		err = suite.client.Get(context.TODO(), client.ObjectKey{Name: "test-module"}, moduleObj)
-// 		require.NoError(suite.T(), err)
-// 		assert.Equal(suite.T(), "v1.0.2", moduleObj.Properties.Version, "Module version should be set from MPO")
-//
-// 		// Verify the ModuleRelease statuses remain unchanged (MPO should not affect release statuses)
-// 		releases := new(v1alpha1.ModuleReleaseList)
-// 		err = suite.client.List(context.TODO(), releases, client.MatchingLabels{"module": "test-module"})
-// 		require.NoError(suite.T(), err)
-// 		require.Len(suite.T(), releases.Items, 4, "Should have 4 releases")
-//
-// 		// Check specific statuses for each release to ensure MPO doesn't change them
-// 		var supersededCount, deployedCount int
-// 		for _, release := range releases.Items {
-// 			switch release.GetModuleVersion() {
-// 			case "v1.0.0":
-// 				assert.Equal(suite.T(), v1alpha1.ModuleReleasePhaseSuperseded, release.Status.Phase, "v1.0.0 should remain Superseded")
-// 				supersededCount++
-// 			case "v1.0.1":
-// 				assert.Equal(suite.T(), v1alpha1.ModuleReleasePhaseDeployed, release.Status.Phase, "v1.0.1 should remain Deployed")
-// 				deployedCount++
-// 			case "v1.0.2":
-// 				assert.Equal(suite.T(), v1alpha1.ModuleReleasePhaseDeployed, release.Status.Phase, "v1.0.2 should remain Deployed")
-// 				deployedCount++
-// 			case "v1.0.3":
-// 				assert.Equal(suite.T(), v1alpha1.ModuleReleasePhaseDeployed, release.Status.Phase, "v1.0.3 should remain Deployed")
-// 				deployedCount++
-// 			default:
-// 				suite.T().Fatalf("Unexpected release version: %s", release.GetModuleVersion())
-// 			}
-// 		}
-// 		assert.Equal(suite.T(), 1, supersededCount, "Should have 1 superseded release")
-// 		assert.Equal(suite.T(), 3, deployedCount, "Should have 3 deployed releases")
-//
-// 		suite.cleanupPaths([]string{module.downloadedPath, module.symlinkPath})
-// 	})
-//
-// 	// Test with different release statuses and ensure correct version selection
-// 	suite.Run("MultipleReleasesWithDifferentVersionPrecedence", func() {
-// 		dependency.TestDC.CRClient.ImageMock.Return(&crfake.FakeImage{
-// 			ManifestStub: manifestStub,
-// 			LayersStub: func() ([]crv1.Layer, error) {
-// 				return []crv1.Layer{&utils.FakeLayer{}}, nil
-// 			},
-// 		}, nil)
-//
-// 		// Delete the module first to start fresh
-// 		suite.cleanupPaths([]string{module.downloadedPath, module.symlinkPath})
-// 		require.NoError(suite.T(), module.prepare(true, true))
-//
-// 		// Test with multiple deployed releases - MPO should override all
-// 		suite.setupModuleLoader(string(suite.parseTestdata("overrides", "multiple-releases-all-deployed.yaml")))
-// 		require.NoError(suite.T(), suite.loader.restoreModulesByOverrides(context.TODO()))
-//
-// 		// Check symlink exists
-// 		_, err := os.Lstat(module.symlinkPath)
-// 		require.NoError(suite.T(), err, "Module symlink should exist")
-//
-// 		// MPO version should take precedence
-// 		moduleObj := new(v1alpha1.Module)
-// 		err = suite.client.Get(context.TODO(), client.ObjectKey{Name: "test-module"}, moduleObj)
-// 		require.NoError(suite.T(), err)
-// 		assert.Equal(suite.T(), "v1.0.2", moduleObj.Properties.Version, "MPO version should override any deployed release version")
-//
-// 		suite.cleanupPaths([]string{module.downloadedPath, module.symlinkPath})
-// 	})
-// }
-
-// func (suite *ModuleLoaderTestSuite) TestRestoreModulesByReleases() {
-// 	module := moduleSuite{
-// 		name:          "echo",
-// 		weight:        900,
-// 		downloadedDir: suite.tmpDir,
-// 		version:       "v1.0.0",
-// 	}
-//
-// 	manifestStub := func() (*crv1.Manifest, error) {
-// 		return &crv1.Manifest{
-// 			Layers: []crv1.Descriptor{},
-// 		}, nil
-// 	}
-//
-// 	// should ensure symlink
-// 	suite.Run("NoSymlink", func() {
-// 		dependency.TestDC.CRClient.ImageMock.Return(&crfake.FakeImage{
-// 			ManifestStub: manifestStub,
-// 			LayersStub: func() ([]crv1.Layer, error) {
-// 				return []crv1.Layer{&utils.FakeLayer{}}, nil
-// 			},
-// 		}, nil)
-//
-// 		require.NoError(suite.T(), module.prepare(true, false))
-//
-// 		statValues, err := os.Stat(module.valuesPath)
-// 		require.NoError(suite.T(), err)
-//
-// 		time.Sleep(50 * time.Millisecond)
-//
-// 		suite.setupModuleLoader(string(suite.parseTestdata("releases", "release.yaml")))
-// 		require.NoError(suite.T(), suite.loader.restoreModulesByReleases(context.TODO()))
-//
-// 		newStatValues, err := os.Stat(module.valuesPath)
-// 		require.NoError(suite.T(), err)
-//
-// 		assert.True(suite.T(), statValues.ModTime().Equal(newStatValues.ModTime()), "values.yaml mustn't be modified")
-//
-// 		_, err = os.Lstat(module.symlinkPath)
-// 		require.NoError(suite.T(), err)
-//
-// 		suite.cleanupPaths([]string{module.downloadedPath, module.symlinkPath})
-// 	})
-//
-// 	// should ensure downloaded module`s dir
-// 	suite.Run("NoDownloadedModule", func() {
-// 		dependency.TestDC.CRClient.ImageMock.Return(&crfake.FakeImage{
-// 			ManifestStub: manifestStub,
-// 			LayersStub: func() ([]crv1.Layer, error) {
-// 				return []crv1.Layer{&utils.FakeLayer{}}, nil
-// 			},
-// 		}, nil)
-//
-// 		require.NoError(suite.T(), module.prepare(false, false))
-//
-// 		time.Sleep(50 * time.Millisecond)
-//
-// 		suite.setupModuleLoader(string(suite.parseTestdata("releases", "release.yaml")))
-// 		require.NoError(suite.T(), suite.loader.restoreModulesByReleases(context.TODO()))
-//
-// 		_, err := os.Lstat(module.symlinkPath)
-// 		require.NoError(suite.T(), err)
-//
-// 		suite.cleanupPaths([]string{module.downloadedPath, module.symlinkPath})
-// 	})
-//
-// 	// should remove extra symlink
-// 	suite.Run("ExtraSymlinks", func() {
-// 		dependency.TestDC.CRClient.ImageMock.Return(&crfake.FakeImage{
-// 			ManifestStub: manifestStub,
-// 			LayersStub: func() ([]crv1.Layer, error) {
-// 				return []crv1.Layer{&utils.FakeLayer{}}, nil
-// 			},
-// 		}, nil)
-//
-// 		require.NoError(suite.T(), module.prepare(true, false))
-//
-// 		statValues, err := os.Stat(module.valuesPath)
-// 		require.NoError(suite.T(), err)
-//
-// 		_, err = os.Lstat(module.symlinkPath)
-// 		assert.True(suite.T(), os.IsNotExist(err), "Module's symlink mustn't exist")
-//
-// 		symlink1 := filepath.Join(suite.tmpDir, "modules", fmt.Sprintf("901-%s", module.name))
-// 		symlink2 := filepath.Join(suite.tmpDir, "modules", fmt.Sprintf("902-%s", module.name))
-// 		symlink3 := filepath.Join(suite.tmpDir, "modules", fmt.Sprintf("903-%s", module.name))
-//
-// 		// extra symlinks
-// 		require.NoError(suite.T(), os.Symlink(module.downloadedDir, symlink1))
-// 		require.NoError(suite.T(), os.Symlink(module.downloadedDir, symlink2))
-// 		require.NoError(suite.T(), os.Symlink(module.downloadedDir, symlink3))
-//
-// 		time.Sleep(50 * time.Millisecond)
-//
-// 		suite.setupModuleLoader(string(suite.parseTestdata("releases", "release.yaml")))
-// 		require.NoError(suite.T(), suite.loader.restoreModulesByReleases(context.TODO()))
-//
-// 		newStatValues, err := os.Stat(module.valuesPath)
-// 		require.NoError(suite.T(), err)
-// 		assert.True(suite.T(), statValues.ModTime().Equal(newStatValues.ModTime()), "values.yaml mustn't be modified")
-//
-// 		_, err = os.Lstat(module.symlinkPath)
-// 		assert.Equal(suite.T(), err, nil, "Module's symlink must be created")
-//
-// 		_, err = os.Lstat(symlink1)
-// 		assert.True(suite.T(), os.IsNotExist(err), "Extra symlink mustn't exist")
-// 		_, err = os.Lstat(symlink2)
-// 		assert.True(suite.T(), os.IsNotExist(err), "Extra symlink mustn't exist")
-// 		_, err = os.Lstat(symlink3)
-// 		assert.True(suite.T(), os.IsNotExist(err), "Extra symlink mustn't exist")
-//
-// 		suite.cleanupPaths([]string{module.downloadedPath, module.symlinkPath})
-// 	})
-//
-// 	// HA deckhouse installations could have previous version symlink on the standby masters
-// 	// have to delete it and add an actual one
-// 	suite.Run("Old version symlink", func() {
-// 		dependency.TestDC.CRClient.ImageMock.Return(&crfake.FakeImage{
-// 			ManifestStub: manifestStub,
-// 			LayersStub: func() ([]crv1.Layer, error) {
-// 				return []crv1.Layer{&utils.FakeLayer{}}, nil
-// 			},
-// 		}, nil)
-//
-// 		require.NoError(suite.T(), module.prepare(true, false))
-//
-// 		require.NoError(suite.T(), os.MkdirAll(filepath.Join(suite.tmpDir, "echo", "v0.9.0"), 0750))
-//
-// 		symlink := filepath.Join(suite.tmpDir, "modules", fmt.Sprintf("900-%s", module.name))
-// 		require.NoError(suite.T(), os.Symlink(filepath.Join(suite.tmpDir, "echo", "v0.9.0"), symlink))
-//
-// 		time.Sleep(50 * time.Millisecond)
-//
-// 		suite.setupModuleLoader(string(suite.parseTestdata("releases", "release.yaml")))
-// 		require.NoError(suite.T(), suite.loader.restoreModulesByReleases(context.TODO()))
-//
-// 		symlinkTarget, err := filepath.EvalSymlinks(symlink)
-// 		require.NoError(suite.T(), err)
-//
-// 		assert.True(suite.T(), strings.HasSuffix(symlinkTarget, "echo/v1.0.0"), "module have to be restored to the v1.0.0 version")
-//
-// 		suite.cleanupPaths([]string{symlink, module.downloadedPath, module.symlinkPath})
-// 	})
-//
-// 	suite.Run("WrongSymlink", func() {
-// 		dependency.TestDC.CRClient.ImageMock.Return(&crfake.FakeImage{
-// 			ManifestStub: manifestStub,
-// 			LayersStub: func() ([]crv1.Layer, error) {
-// 				return []crv1.Layer{&utils.FakeLayer{}}, nil
-// 			},
-// 		}, nil)
-//
-// 		require.NoError(suite.T(), module.prepare(true, false))
-//
-// 		require.NoError(suite.T(), os.MkdirAll(filepath.Join(suite.tmpDir, "echo", "fakeVersion"), 0750))
-//
-// 		symlink := filepath.Join(suite.tmpDir, "modules", fmt.Sprintf("900-%s", module.name))
-// 		require.NoError(suite.T(), os.Symlink(filepath.Join(suite.tmpDir, "echo", "fakeVersion"), symlink))
-//
-// 		statValues, err := os.Stat(module.valuesPath)
-// 		require.NoError(suite.T(), err)
-//
-// 		statSymlink, err := os.Lstat(symlink)
-// 		require.NoError(suite.T(), err)
-//
-// 		time.Sleep(50 * time.Millisecond)
-//
-// 		suite.setupModuleLoader(string(suite.parseTestdata("releases", "release.yaml")))
-// 		require.NoError(suite.T(), suite.loader.restoreModulesByReleases(context.TODO()))
-//
-// 		newStatValues, err := os.Stat(module.valuesPath)
-// 		require.NoError(suite.T(), err)
-// 		assert.True(suite.T(), statValues.ModTime().Equal(newStatValues.ModTime()), "values.yaml mustn't be modified")
-//
-// 		newStatSymlink, err := os.Lstat(symlink)
-// 		require.NoError(suite.T(), err)
-// 		assert.False(suite.T(), statSymlink.ModTime().Equal(newStatSymlink.ModTime()), "Module's symlink must be modified")
-//
-// 		suite.cleanupPaths([]string{symlink, module.downloadedPath, module.symlinkPath})
-// 	})
-//
-// 	// Test case 1: Multiple releases, all in Deployed status
-// 	// Expected: only the latest version should remain deployed, older versions should become superseded
-// 	// This test verifies that restoreAbsentModulesFromReleases correctly handles multiple deployed releases
-// 	// by keeping only the latest version deployed and marking older versions as superseded
-// 	suite.Run("MultipleReleasesAllDeployed", func() {
-// 		testModule := moduleSuite{
-// 			name:          "test-module",
-// 			weight:        900,
-// 			downloadedDir: suite.tmpDir,
-// 			version:       "v1.0.2", // latest version
-// 		}
-//
-// 		dependency.TestDC.CRClient.ImageMock.Return(&crfake.FakeImage{
-// 			ManifestStub: manifestStub,
-// 			LayersStub: func() ([]crv1.Layer, error) {
-// 				return []crv1.Layer{&utils.FakeLayer{}}, nil
-// 			},
-// 		}, nil)
-//
-// 		require.NoError(suite.T(), testModule.prepare(true, false))
-//
-// 		suite.setupModuleLoader(string(suite.parseTestdata("releases", "multiple-releases-all-deployed.yaml")))
-//
-// 		// Verify initial state - all releases should be Deployed
-// 		initialReleases := new(v1alpha1.ModuleReleaseList)
-// 		initialErr := suite.client.List(context.TODO(), initialReleases, client.MatchingLabels{"module": "test-module"})
-// 		require.NoError(suite.T(), initialErr)
-// 		for _, release := range initialReleases.Items {
-// 			assert.Equal(suite.T(), v1alpha1.ModuleReleasePhaseDeployed, release.Status.Phase,
-// 				"Initial state: %s should be Deployed", release.GetModuleVersion())
-// 		}
-//
-// 		require.NoError(suite.T(), suite.loader.restoreModulesByReleases(context.TODO()))
-//
-// 		// Check that the module symlink was created
-// 		_, err := os.Lstat(testModule.symlinkPath)
-// 		require.NoError(suite.T(), err, "Module symlink should exist")
-//
-// 		// Check that the module files exist
-// 		_, err = os.Stat(testModule.valuesPath)
-// 		require.NoError(suite.T(), err, "Module values should exist")
-//
-// 		// Verify that the module version is set to the latest deployed release
-// 		moduleObj := new(v1alpha1.Module)
-// 		err = suite.client.Get(context.TODO(), client.ObjectKey{Name: "test-module"}, moduleObj)
-// 		require.NoError(suite.T(), err)
-// 		assert.Equal(suite.T(), "v1.0.2", moduleObj.Properties.Version, "Module version should be set to latest deployed release")
-//
-// 		// Verify the ModuleRelease statuses were updated correctly
-// 		releases := new(v1alpha1.ModuleReleaseList)
-// 		err = suite.client.List(context.TODO(), releases, client.MatchingLabels{"module": "test-module"})
-// 		require.NoError(suite.T(), err)
-// 		require.Len(suite.T(), releases.Items, 3, "Should have 3 releases")
-//
-// 		// Check specific statuses for each release to ensure the function correctly
-// 		// changed the statuses according to its logic (only latest version remains deployed)
-// 		var deployedCount, supersededCount int
-// 		for _, release := range releases.Items {
-// 			switch release.GetModuleVersion() {
-// 			case "v1.0.0":
-// 				assert.Equal(suite.T(), v1alpha1.ModuleReleasePhaseSuperseded, release.Status.Phase, "v1.0.0 should be superseded")
-// 				supersededCount++
-// 			case "v1.0.1":
-// 				assert.Equal(suite.T(), v1alpha1.ModuleReleasePhaseSuperseded, release.Status.Phase, "v1.0.1 should be superseded")
-// 				supersededCount++
-// 			case "v1.0.2":
-// 				assert.Equal(suite.T(), v1alpha1.ModuleReleasePhaseDeployed, release.Status.Phase, "v1.0.2 should be deployed")
-// 				deployedCount++
-// 			default:
-// 				suite.T().Fatalf("Unexpected release version: %s", release.GetModuleVersion())
-// 			}
-// 		}
-// 		assert.Equal(suite.T(), 1, deployedCount, "Should have 1 deployed release")
-// 		assert.Equal(suite.T(), 2, supersededCount, "Should have 2 superseded releases")
-//
-// 		suite.cleanupPaths([]string{testModule.downloadedPath, testModule.symlinkPath})
-// 	})
-//
-// 	// Test case 2: Multiple releases, all Superseded except last in Deployed
-// 	// Expected: only the deployed release should be processed
-// 	suite.Run("MultipleReleasesSupersededExceptLast", func() {
-// 		testModule := moduleSuite{
-// 			name:          "test-module",
-// 			weight:        900,
-// 			downloadedDir: suite.tmpDir,
-// 			version:       "v1.0.3",
-// 		}
-//
-// 		dependency.TestDC.CRClient.ImageMock.Return(&crfake.FakeImage{
-// 			ManifestStub: manifestStub,
-// 			LayersStub: func() ([]crv1.Layer, error) {
-// 				return []crv1.Layer{&utils.FakeLayer{}}, nil
-// 			},
-// 		}, nil)
-//
-// 		require.NoError(suite.T(), testModule.prepare(true, false))
-//
-// 		suite.setupModuleLoader(string(suite.parseTestdata("releases", "multiple-releases-superseded-except-last.yaml")))
-// 		require.NoError(suite.T(), suite.loader.restoreModulesByReleases(context.TODO()))
-//
-// 		// Check that the module symlink was created
-// 		_, err := os.Lstat(testModule.symlinkPath)
-// 		require.NoError(suite.T(), err, "Module symlink should exist")
-//
-// 		// Check that the module files exist
-// 		_, err = os.Stat(testModule.valuesPath)
-// 		require.NoError(suite.T(), err, "Module values should exist")
-//
-// 		// Verify that the module version is set to v1.0.3 (the only deployed release)
-// 		moduleObj := new(v1alpha1.Module)
-// 		err = suite.client.Get(context.TODO(), client.ObjectKey{Name: "test-module"}, moduleObj)
-// 		require.NoError(suite.T(), err)
-// 		assert.Equal(suite.T(), "v1.0.3", moduleObj.Properties.Version, "Module version should be set to the deployed release")
-//
-// 		// Verify the ModuleRelease statuses remain unchanged
-// 		releases := new(v1alpha1.ModuleReleaseList)
-// 		err = suite.client.List(context.TODO(), releases, client.MatchingLabels{"module": "test-module"})
-// 		require.NoError(suite.T(), err)
-// 		require.Len(suite.T(), releases.Items, 4, "Should have 4 releases")
-//
-// 		// Check specific statuses for each release
-// 		var supersededCount, deployedCount int
-// 		for _, release := range releases.Items {
-// 			switch release.GetModuleVersion() {
-// 			case "v1.0.0":
-// 				assert.Equal(suite.T(), v1alpha1.ModuleReleasePhaseSuperseded, release.Status.Phase, "v1.0.0 should be superseded")
-// 				supersededCount++
-// 			case "v1.0.1":
-// 				assert.Equal(suite.T(), v1alpha1.ModuleReleasePhaseSuperseded, release.Status.Phase, "v1.0.1 should be superseded")
-// 				supersededCount++
-// 			case "v1.0.2":
-// 				assert.Equal(suite.T(), v1alpha1.ModuleReleasePhaseSuperseded, release.Status.Phase, "v1.0.2 should be superseded")
-// 				supersededCount++
-// 			case "v1.0.3":
-// 				assert.Equal(suite.T(), v1alpha1.ModuleReleasePhaseDeployed, release.Status.Phase, "v1.0.3 should be deployed")
-// 				deployedCount++
-// 			default:
-// 				suite.T().Fatalf("Unexpected release version: %s", release.GetModuleVersion())
-// 			}
-// 		}
-// 		assert.Equal(suite.T(), 3, supersededCount, "Should have 3 superseded releases")
-// 		assert.Equal(suite.T(), 1, deployedCount, "Should have 1 deployed release")
-//
-// 		suite.cleanupPaths([]string{testModule.downloadedPath, testModule.symlinkPath})
-// 	})
-//
-// 	// Test case 3: Multiple releases, first Superseded, several Deployed
-// 	// Expected: only the latest deployed version should remain deployed
-// 	suite.Run("MultipleReleasesMixedStatus", func() {
-// 		testModule := moduleSuite{
-// 			name:          "test-module",
-// 			weight:        900,
-// 			downloadedDir: suite.tmpDir,
-// 			version:       "v1.0.3", // latest deployed version
-// 		}
-//
-// 		dependency.TestDC.CRClient.ImageMock.Return(&crfake.FakeImage{
-// 			ManifestStub: manifestStub,
-// 			LayersStub: func() ([]crv1.Layer, error) {
-// 				return []crv1.Layer{&utils.FakeLayer{}}, nil
-// 			},
-// 		}, nil)
-//
-// 		require.NoError(suite.T(), testModule.prepare(true, false))
-//
-// 		suite.setupModuleLoader(string(suite.parseTestdata("releases", "multiple-releases-mixed-status.yaml")))
-// 		require.NoError(suite.T(), suite.loader.restoreModulesByReleases(context.TODO()))
-//
-// 		// Check that the module symlink was created
-// 		_, err := os.Lstat(testModule.symlinkPath)
-// 		require.NoError(suite.T(), err, "Module symlink should exist")
-//
-// 		// Check that the module files exist
-// 		_, err = os.Stat(testModule.valuesPath)
-// 		require.NoError(suite.T(), err, "Module values should exist")
-//
-// 		// Verify that the module version is set to the latest deployed version (v1.0.3)
-// 		moduleObj := new(v1alpha1.Module)
-// 		err = suite.client.Get(context.TODO(), client.ObjectKey{Name: "test-module"}, moduleObj)
-// 		require.NoError(suite.T(), err)
-// 		assert.Equal(suite.T(), "v1.0.3", moduleObj.Properties.Version, "Module version should be set to latest deployed release")
-//
-// 		// Verify the ModuleRelease statuses were updated correctly
-// 		releases := new(v1alpha1.ModuleReleaseList)
-// 		err = suite.client.List(context.TODO(), releases, client.MatchingLabels{"module": "test-module"})
-// 		require.NoError(suite.T(), err)
-// 		require.Len(suite.T(), releases.Items, 4, "Should have 4 releases")
-//
-// 		// Check specific statuses for each release
-// 		var supersededCount, deployedCount int
-// 		for _, release := range releases.Items {
-// 			switch release.GetModuleVersion() {
-// 			case "v1.0.0":
-// 				assert.Equal(suite.T(), v1alpha1.ModuleReleasePhaseSuperseded, release.Status.Phase, "v1.0.0 should be superseded")
-// 				supersededCount++
-// 			case "v1.0.1":
-// 				assert.Equal(suite.T(), v1alpha1.ModuleReleasePhaseSuperseded, release.Status.Phase, "v1.0.1 should be superseded")
-// 				supersededCount++
-// 			case "v1.0.2":
-// 				assert.Equal(suite.T(), v1alpha1.ModuleReleasePhaseSuperseded, release.Status.Phase, "v1.0.2 should be superseded")
-// 				supersededCount++
-// 			case "v1.0.3":
-// 				assert.Equal(suite.T(), v1alpha1.ModuleReleasePhaseDeployed, release.Status.Phase, "v1.0.3 should be deployed")
-// 				deployedCount++
-// 			default:
-// 				suite.T().Fatalf("Unexpected release version: %s", release.GetModuleVersion())
-// 			}
-// 		}
-// 		assert.Equal(suite.T(), 3, supersededCount, "Should have 3 superseded releases")
-// 		assert.Equal(suite.T(), 1, deployedCount, "Should have 1 deployed release")
-//
-// 		suite.cleanupPaths([]string{testModule.downloadedPath, testModule.symlinkPath})
-// 	})
-// }
-
-func (suite *ModuleLoaderTestSuite) modulePullOverride(name string) *v1alpha2.ModulePullOverride { //nolint:revive,unused
-	mpo := new(v1alpha2.ModulePullOverride)
-	err := suite.client.Get(context.TODO(), client.ObjectKey{Name: name}, mpo)
-	require.NoError(suite.T(), err)
-
-	return mpo
-}
-
-func (suite *ModuleLoaderTestSuite) parseTestdata(scope, filename string) []byte { //nolint:revive,unused
-	data, err := os.ReadFile(filepath.Join("./testdata", scope, filename))
-	require.NoError(suite.T(), err)
-
-	suite.testDataFileName = filename
-
-	return data
-}
-
-func (suite *ModuleLoaderTestSuite) cleanupPaths(paths []string) { //nolint:revive,unused
-	for _, path := range paths {
-		require.NoError(suite.T(), os.RemoveAll(path))
+func testModuleSource(name, repo string) *v1alpha1.ModuleSource {
+	return &v1alpha1.ModuleSource{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: v1alpha1.ModuleSourceSpec{
+			Registry: v1alpha1.ModuleSourceSpecRegistry{
+				Repo:      repo,
+				DockerCFG: "YXNiCg==",
+				Scheme:    "HTTP",
+			},
+		},
 	}
 }
 
-type moduleSuite struct { //nolint:revive,unused
-	name           string
-	version        string
-	weight         int
-	valuesPath     string
-	symlinkPath    string
-	downloadedPath string
-	downloadedDir  string
+func testModule(name, source string, availableSources ...string) *v1alpha1.Module {
+	return &v1alpha1.Module{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Properties: v1alpha1.ModuleProperties{
+			Source:           source,
+			AvailableSources: availableSources,
+			Weight:           900,
+		},
+	}
 }
 
-func (suite *moduleSuite) prepare(ensureDownloaded, ensureSymlink bool) error { //nolint:revive,unused
-	suite.downloadedPath = filepath.Join(suite.downloadedDir, suite.name, suite.version)
-	suite.symlinkPath = filepath.Join(suite.downloadedDir, "modules", fmt.Sprintf("%d-%s", suite.weight, suite.name))
-	suite.valuesPath = filepath.Join(suite.downloadedPath, "openapi", "values.yaml")
+func testDeployedRelease(module, sourceName, version string) *v1alpha1.ModuleRelease {
+	return &v1alpha1.ModuleRelease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: module + "-v" + version,
+			Labels: map[string]string{
+				"module":                          module,
+				"source":                          sourceName,
+				v1alpha1.ModuleReleaseLabelStatus: v1alpha1.ModuleReleaseLabelDeployed,
+			},
+		},
+		Spec:   v1alpha1.ModuleReleaseSpec{ModuleName: module, Version: version, Weight: 900},
+		Status: v1alpha1.ModuleReleaseStatus{Phase: v1alpha1.ModuleReleasePhaseDeployed},
+	}
+}
 
-	if ensureDownloaded {
-		if err := os.MkdirAll(filepath.Join(suite.downloadedPath, "openapi"), 0750); err != nil {
-			return err
+// enabled marks the module as enabled by ModuleConfig, which restoreModulesByOverrides
+// requires before it will restore an overridden module.
+func enabled(module *v1alpha1.Module) *v1alpha1.Module {
+	module.Status.Conditions = append(module.Status.Conditions, v1alpha1.ModuleCondition{
+		Type:   v1alpha1.ModuleConditionEnabledByModuleConfig,
+		Status: corev1.ConditionTrue,
+	})
+	return module
+}
+
+func testReadyMPO(name, imageTag, deployedOn string) *v1alpha2.ModulePullOverride {
+	return &v1alpha2.ModulePullOverride{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Annotations: map[string]string{v1alpha1.ModulePullOverrideAnnotationDeployedOn: deployedOn},
+		},
+		Spec:   v1alpha2.ModulePullOverrideSpec{ImageTag: imageTag},
+		Status: v1alpha2.ModulePullOverrideStatus{Message: v1alpha1.ModulePullOverrideMessageReady},
+	}
+}
+
+func getModule(t *testing.T, l *Loader, name string) *v1alpha1.Module {
+	t.Helper()
+	module := new(v1alpha1.Module)
+	require.NoError(t, l.client.Get(context.Background(), client.ObjectKey{Name: name}, module))
+	return module
+}
+
+func getRelease(t *testing.T, l *Loader, name string) *v1alpha1.ModuleRelease {
+	t.Helper()
+	release := new(v1alpha1.ModuleRelease)
+	require.NoError(t, l.client.Get(context.Background(), client.ObjectKey{Name: name}, release))
+	return release
+}
+
+// --- restoreModulesByReleases ----------------------------------------------
+
+func TestRestoreModulesByReleases(t *testing.T) {
+	t.Run("non-embedded module is activated and pinned to its source registry", func(t *testing.T) {
+		calls := new(installerCalls)
+		l := newTestLoader(t, newRecordingInstaller(calls, nil),
+			testModuleSource("example", testRepo),
+			testModule("echo", "losev-test", "losev-test"),
+			testDeployedRelease("echo", "example", "1.0.0"),
+		)
+
+		require.NoError(t, l.restoreModulesByReleases(context.Background()))
+
+		assert.Equal(t, []installerCall{{"echo", "v1.0.0"}}, calls.restore, "non-embedded module must be restored")
+		assert.Empty(t, calls.stageFromRegistry, "non-embedded module must not be staged")
+
+		reg, ok := l.registries["echo"]
+		require.True(t, ok, "registry override must be set for an activated module")
+		assert.Equal(t, testRepo, reg.Base)
+
+		assert.Equal(t, "v1.0.0", getModule(t, l, "echo").Properties.Version)
+	})
+
+	// Regression: a module whose embedded copy is still shipped must be staged
+	// (downloaded, not activated) and must NOT receive the source registry override,
+	// otherwise it renders <sourceRepo>/modules/<name>@<embeddedDigest> and fails with
+	// ImagePullBackOff. See moduleloader/sync.go restoreModulesByReleases.
+	t.Run("embedded module is staged and keeps the embedded registry", func(t *testing.T) {
+		calls := new(installerCalls)
+		l := newTestLoader(t, newRecordingInstaller(calls, map[string]bool{"echo": true}),
+			testModuleSource("example", testRepo),
+			testModule("echo", "losev-test", "losev-test"),
+			testDeployedRelease("echo", "example", "1.0.0"),
+		)
+
+		require.NoError(t, l.restoreModulesByReleases(context.Background()))
+
+		assert.Equal(t, []installerCall{{"echo", "v1.0.0"}}, calls.stageFromRegistry, "embedded module must be staged")
+		assert.Empty(t, calls.restore, "embedded module must not be activated")
+
+		_, ok := l.registries["echo"]
+		assert.False(t, ok, "embedded module must keep its embedded registry (no source override)")
+
+		// version is still tracked even while the module stays embedded
+		assert.Equal(t, "v1.0.0", getModule(t, l, "echo").Properties.Version)
+	})
+
+	t.Run("migrated module switches active source once the embedded copy is gone", func(t *testing.T) {
+		calls := new(installerCalls)
+		l := newTestLoader(t, newRecordingInstaller(calls, nil),
+			testModuleSource("example", testRepo),
+			testModule("echo", v1alpha1.ModuleSourceEmbedded, "example"),
+			testDeployedRelease("echo", "example", "1.0.0"),
+		)
+
+		require.NoError(t, l.restoreModulesByReleases(context.Background()))
+
+		assert.Equal(t, []installerCall{{"echo", "v1.0.0"}}, calls.restore)
+		reg, ok := l.registries["echo"]
+		require.True(t, ok)
+		assert.Equal(t, testRepo, reg.Base)
+
+		// the embedded sentinel must be flipped to the real source
+		assert.Equal(t, "example", getModule(t, l, "echo").Properties.Source)
+	})
+
+	t.Run("multiple deployed releases: newest wins, older are superseded", func(t *testing.T) {
+		calls := new(installerCalls)
+		l := newTestLoader(t, newRecordingInstaller(calls, nil),
+			testModuleSource("example", testRepo),
+			testModule("echo", "losev-test", "losev-test"),
+			testDeployedRelease("echo", "example", "1.0.0"),
+			testDeployedRelease("echo", "example", "1.0.2"),
+			testDeployedRelease("echo", "example", "1.0.1"),
+		)
+
+		require.NoError(t, l.restoreModulesByReleases(context.Background()))
+
+		// the module ends up pinned to the highest version
+		assert.Equal(t, "v1.0.2", getModule(t, l, "echo").Properties.Version)
+
+		assert.Equal(t, v1alpha1.ModuleReleasePhaseSuperseded, getRelease(t, l, "echo-v1.0.0").Status.Phase)
+		assert.Equal(t, v1alpha1.ModuleReleasePhaseSuperseded, getRelease(t, l, "echo-v1.0.1").Status.Phase)
+		assert.Equal(t, v1alpha1.ModuleReleasePhaseDeployed, getRelease(t, l, "echo-v1.0.2").Status.Phase)
+
+		require.Len(t, calls.restore, 3, "every deployed release is processed in version order")
+		assert.Equal(t, "v1.0.2", calls.restore[len(calls.restore)-1].version, "the last processed release is the newest")
+	})
+
+	t.Run("module with a pull override is skipped in the releases path", func(t *testing.T) {
+		calls := new(installerCalls)
+		l := newTestLoader(t, newRecordingInstaller(calls, nil),
+			testModuleSource("example", testRepo),
+			testModule("echo", "losev-test", "losev-test"),
+			testDeployedRelease("echo", "example", "1.0.0"),
+			testReadyMPO("echo", "v1.0.0", testNodeName),
+		)
+
+		require.NoError(t, l.restoreModulesByReleases(context.Background()))
+
+		assert.Empty(t, calls.restore, "MPO-managed module must not be restored by the releases path")
+		assert.Empty(t, calls.stageFromRegistry)
+		_, ok := l.registries["echo"]
+		assert.False(t, ok)
+	})
+}
+
+// --- restoreModulesByOverrides ---------------------------------------------
+
+func TestRestoreModulesByOverrides(t *testing.T) {
+	t.Run("non-embedded module is restored and pinned to its source registry", func(t *testing.T) {
+		t.Setenv("DECKHOUSE_NODE_NAME", testNodeName)
+
+		calls := new(installerCalls)
+		l := newTestLoader(t, newRecordingInstaller(calls, nil),
+			testModuleSource("example", testRepo),
+			enabled(testModule("echo", "example", "example")),
+			testReadyMPO("echo", "v1.0.0", testNodeName),
+		)
+
+		require.NoError(t, l.restoreModulesByOverrides(context.Background()))
+
+		assert.Equal(t, []installerCall{{"echo", "v1.0.0"}}, calls.restore)
+		assert.Empty(t, calls.uninstall, "no uninstall when deployed-on matches the current node")
+
+		reg, ok := l.registries["echo"]
+		require.True(t, ok)
+		assert.Equal(t, testRepo, reg.Base)
+	})
+
+	t.Run("embedded module is skipped", func(t *testing.T) {
+		t.Setenv("DECKHOUSE_NODE_NAME", testNodeName)
+
+		calls := new(installerCalls)
+		l := newTestLoader(t, newRecordingInstaller(calls, nil),
+			testModuleSource("example", testRepo),
+			testModule("echo", v1alpha1.ModuleSourceEmbedded, "example"),
+			testReadyMPO("echo", "v1.0.0", testNodeName),
+		)
+
+		require.NoError(t, l.restoreModulesByOverrides(context.Background()))
+
+		assert.Empty(t, calls.restore, "embedded module must not be restored from a pull override")
+	})
+
+	t.Run("stale deployed-on annotation triggers a reinstall", func(t *testing.T) {
+		t.Setenv("DECKHOUSE_NODE_NAME", testNodeName)
+
+		calls := new(installerCalls)
+		l := newTestLoader(t, newRecordingInstaller(calls, nil),
+			testModuleSource("example", testRepo),
+			enabled(testModule("echo", "example", "example")),
+			testReadyMPO("echo", "v1.0.0", "some-old-master"),
+		)
+
+		require.NoError(t, l.restoreModulesByOverrides(context.Background()))
+
+		assert.Equal(t, []string{"echo"}, calls.uninstall, "stale deployed-on must trigger uninstall")
+		assert.Equal(t, []installerCall{{"echo", "v1.0.0"}}, calls.restore)
+	})
+
+	t.Run("not-ready override is skipped", func(t *testing.T) {
+		t.Setenv("DECKHOUSE_NODE_NAME", testNodeName)
+
+		mpo := testReadyMPO("echo", "v1.0.0", testNodeName)
+		mpo.Status.Message = "Downloading"
+
+		calls := new(installerCalls)
+		l := newTestLoader(t, newRecordingInstaller(calls, nil),
+			testModuleSource("example", testRepo),
+			testModule("echo", "example", "example"),
+			mpo,
+		)
+
+		require.NoError(t, l.restoreModulesByOverrides(context.Background()))
+
+		assert.Empty(t, calls.restore, "an override that is not Ready must be skipped")
+	})
+}
+
+// --- deleteStaleModuleReleases ---------------------------------------------
+
+func TestDeleteStaleModuleReleases(t *testing.T) {
+	staleModule := func(name, source string) *v1alpha1.Module {
+		module := testModule(name, source, source)
+		module.Status.Conditions = []v1alpha1.ModuleCondition{
+			{
+				Type:               v1alpha1.ModuleConditionEnabledByModuleConfig,
+				Status:             corev1.ConditionFalse,
+				LastTransitionTime: metav1.NewTime(time.Now().Add(-100 * time.Hour)),
+			},
 		}
-
-		if err := os.WriteFile(suite.valuesPath, []byte(values), 0750); err != nil {
-			return err
-		}
+		return module
 	}
 
-	if ensureSymlink {
-		if err := os.Symlink(suite.downloadedPath, suite.symlinkPath); err != nil {
-			return err
-		}
-	}
+	t.Run("releases of a long-disabled non-embedded module are pruned", func(t *testing.T) {
+		l := newTestLoader(t, newRecordingInstaller(new(installerCalls), nil),
+			staleModule("echo", "example"),
+			testDeployedRelease("echo", "example", "1.0.0"),
+		)
 
-	return nil
+		require.NoError(t, l.deleteStaleModuleReleases(context.Background()))
+
+		err := l.client.Get(context.Background(), client.ObjectKey{Name: "echo-v1.0.0"}, new(v1alpha1.ModuleRelease))
+		assert.True(t, apierrors.IsNotFound(err), "stale module release must be deleted")
+
+		module := getModule(t, l, "echo")
+		assert.Equal(t, v1alpha1.ModulePhaseAvailable, module.Status.Phase)
+		assert.Empty(t, module.Properties.Source, "module properties must be cleared")
+		assert.Equal(t, []string{"example"}, module.Properties.AvailableSources, "available sources must be preserved")
+	})
+
+	t.Run("embedded module is never pruned", func(t *testing.T) {
+		l := newTestLoader(t, newRecordingInstaller(new(installerCalls), nil),
+			staleModule("echo", v1alpha1.ModuleSourceEmbedded),
+			testDeployedRelease("echo", "example", "1.0.0"),
+		)
+
+		require.NoError(t, l.deleteStaleModuleReleases(context.Background()))
+
+		err := l.client.Get(context.Background(), client.ObjectKey{Name: "echo-v1.0.0"}, new(v1alpha1.ModuleRelease))
+		assert.NoError(t, err, "embedded module release must be kept")
+	})
 }

--- a/deckhouse-controller/pkg/releaseupdater/requirements_checker.go
+++ b/deckhouse-controller/pkg/releaseupdater/requirements_checker.go
@@ -406,6 +406,7 @@ func (c *migratedModulesCheck) GetName() string {
 
 func (c *migratedModulesCheck) Verify(ctx context.Context, dr *v1alpha1.DeckhouseRelease) error {
 	c.metricStorage.Grouped().ExpireGroupMetrics(metrics.MigratedModuleNotFoundGroup)
+	c.metricStorage.Grouped().ExpireGroupMetrics(metrics.MigratedModuleNotDownloadedGroup)
 	requirements := dr.GetRequirements()
 	migratedModules, exists := requirements[MigratedModulesRequirementFieldName]
 	if !exists || migratedModules == "" {
@@ -433,45 +434,63 @@ func (c *migratedModulesCheck) Verify(ctx context.Context, dr *v1alpha1.Deckhous
 		return fmt.Errorf("failed to list Modules: %w", err)
 	}
 
-	moduleSources := &v1alpha1.ModuleSourceList{}
-	if err := c.k8sclient.List(ctx, moduleSources); err != nil {
+	releaseList := &v1alpha1.ModuleReleaseList{}
+	if err := c.k8sclient.List(ctx, releaseList); err != nil {
+		return fmt.Errorf("failed to list ModuleReleases: %w", err)
+	}
+
+	sourceList := &v1alpha1.ModuleSourceList{}
+	if err := c.k8sclient.List(ctx, sourceList); err != nil {
 		return fmt.Errorf("failed to list ModuleSources: %w", err)
 	}
 
 	for _, moduleName := range modules {
-		foundMS := false
-		ModuleEnabled := false
-		// Check if module exists in ModuleList and is disabled
+		moduleEnabled := false
+		// Check if module exists in ModuleList and is enabled
 		for _, module := range moduleList.Items {
 			if module.Name == moduleName {
 				if module.IsCondition(v1alpha1.ModuleConditionEnabledByModuleManager, corev1.ConditionTrue) {
 					c.logger.Debug("migrated module is enabled", slog.String("module", moduleName))
-					ModuleEnabled = true
+					moduleEnabled = true
 				} else {
 					c.logger.Debug("migrated module is disabled", slog.String("module", moduleName))
 				}
 				break
 			}
 		}
-		if !ModuleEnabled {
+		if !moduleEnabled {
 			continue
 		}
 
-		// If module is not in ModuleConfig or is enabled, check ModuleSource
-		for _, source := range moduleSources.Items {
-			if c.isModuleAvailableInSource(moduleName, &source) {
-				foundMS = true
-				c.logger.Debug("migrated module found in source", slog.String("module", moduleName), slog.String("sourceName", source.Name))
-				break
-			}
+		// An enabled migrated module must already be pre-staged on the filesystem
+		// before the upgrade drops its embedded copy. A Deployed ModuleRelease means
+		// the module is downloaded and present on disk, so the upgrade will not race
+		// a registry download that could leave the module unavailable.
+		if c.hasDeployedRelease(moduleName, releaseList) {
+			c.logger.Debug("migrated module is pre-downloaded", slog.String("module", moduleName))
+			continue
 		}
 
-		if !foundMS {
-			c.logger.Warn("migrated module not found in any ModuleSource registry", slog.String("module", moduleName))
+		// No Deployed ModuleRelease - the upgrade is blocked either way, but the two
+		// causes need different operator actions, so distinguish them with separate
+		// metrics/alerts:
+		if !c.isAvailableInAnySource(moduleName, sourceList) {
+			// Terminal: no ModuleSource offers the module at all. Waiting will not
+			// help - the operator must publish it in a ModuleSource (or fix the
+			// module's configured source) before upgrading.
 			c.setMigratedModuleNotFoundAlert(moduleName)
+			c.logger.Warn("migrated module is not available in any ModuleSource registry", slog.String("module", moduleName))
 
-			return fmt.Errorf(`migrated module '%s' not found in any ModuleSource registry`, moduleName)
+			return fmt.Errorf(`migrated module '%s' not found in any ModuleSource registry: publish it in a ModuleSource (or fix the module's source) before upgrading`, moduleName)
 		}
+
+		// Transient: a ModuleSource offers the module, but it has not been downloaded
+		// yet. Waiting for the source controller to pre-stage it resolves this, so this
+		// is not the terminal "not found" case and gets its own metric/alert.
+		c.setMigratedModuleNotDownloadedAlert(moduleName)
+		c.logger.Warn("migrated module has no Deployed ModuleRelease, it is not pre-downloaded yet", slog.String("module", moduleName))
+
+		return fmt.Errorf(`migrated module '%s' is not pre-downloaded yet: no Deployed ModuleRelease found, wait for the module to be downloaded from a ModuleSource before upgrading`, moduleName)
 	}
 
 	c.logger.Debug("all migrated modules validation passed")
@@ -479,24 +498,62 @@ func (c *migratedModulesCheck) Verify(ctx context.Context, dr *v1alpha1.Deckhous
 	return nil
 }
 
-// isModuleAvailableInSource checks if a module is available in a specific ModuleSource
+// hasDeployedRelease reports whether the module has a Deployed ModuleRelease,
+// i.e. the module is downloaded and present on the filesystem.
+func (c *migratedModulesCheck) hasDeployedRelease(moduleName string, releaseList *v1alpha1.ModuleReleaseList) bool {
+	for _, release := range releaseList.Items {
+		if release.GetModuleName() == moduleName && release.Status.Phase == v1alpha1.ModuleReleasePhaseDeployed {
+			return true
+		}
+	}
+	return false
+}
+
+// isAvailableInAnySource reports whether at least one ModuleSource advertises the
+// module without a pull error. It distinguishes a module that simply has not been
+// downloaded yet (available, transient) from one that no source offers at all
+// (terminal).
+func (c *migratedModulesCheck) isAvailableInAnySource(moduleName string, sourceList *v1alpha1.ModuleSourceList) bool {
+	for i := range sourceList.Items {
+		if c.isModuleAvailableInSource(moduleName, &sourceList.Items[i]) {
+			return true
+		}
+	}
+	return false
+}
+
+// isModuleAvailableInSource checks if a module is available in a specific ModuleSource.
 func (c *migratedModulesCheck) isModuleAvailableInSource(moduleName string, source *v1alpha1.ModuleSource) bool {
-	// Check if module is in the available modules list
 	for _, availableModule := range source.Status.AvailableModules {
 		if availableModule.Name == moduleName {
-			// If there's a pull error, the module is not actually available
+			// a pull error means the module is not actually available
 			return availableModule.Error == ""
 		}
 	}
 	return false
 }
 
-// setMigratedModuleNotFoundAlert generates a Prometheus alert for missing migrated module
+// setMigratedModuleNotFoundAlert generates a Prometheus alert for a migrated module
+// that no ModuleSource offers at all (terminal case).
 func (c *migratedModulesCheck) setMigratedModuleNotFoundAlert(moduleName string) {
 	// Set the metric value to 1 to trigger alert
 	c.metricStorage.Grouped().GaugeSet(
 		metrics.MigratedModuleNotFoundGroup,
 		metrics.MigratedModuleNotFoundMetricName,
+		1,
+		map[string]string{
+			metrics.LabelModule: moduleName,
+		})
+}
+
+// setMigratedModuleNotDownloadedAlert generates a Prometheus alert for a migrated
+// module that is available in a ModuleSource but has not been pre-downloaded yet
+// (transient case).
+func (c *migratedModulesCheck) setMigratedModuleNotDownloadedAlert(moduleName string) {
+	// Set the metric value to 1 to trigger alert
+	c.metricStorage.Grouped().GaugeSet(
+		metrics.MigratedModuleNotDownloadedGroup,
+		metrics.MigratedModuleNotDownloadedMetricName,
 		1,
 		map[string]string{
 			metrics.LabelModule: moduleName,

--- a/deckhouse-controller/pkg/releaseupdater/requirements_checker_test.go
+++ b/deckhouse-controller/pkg/releaseupdater/requirements_checker_test.go
@@ -1,0 +1,197 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package releaseupdater
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/metrics"
+	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
+	"github.com/deckhouse/deckhouse/pkg/log"
+	metricstorage "github.com/deckhouse/deckhouse/pkg/metrics-storage"
+)
+
+func enabledModule(name string) *v1alpha1.Module {
+	return &v1alpha1.Module{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status: v1alpha1.ModuleStatus{
+			Conditions: []v1alpha1.ModuleCondition{
+				{Type: v1alpha1.ModuleConditionEnabledByModuleManager, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+}
+
+func moduleReleaseWithPhase(moduleName, phase string) *v1alpha1.ModuleRelease {
+	return &v1alpha1.ModuleRelease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   moduleName + "-v1.0.0",
+			Labels: map[string]string{v1alpha1.ModuleReleaseLabelModule: moduleName},
+		},
+		Spec:   v1alpha1.ModuleReleaseSpec{ModuleName: moduleName, Version: "1.0.0"},
+		Status: v1alpha1.ModuleReleaseStatus{Phase: phase},
+	}
+}
+
+func moduleSourceWith(name string, modules []v1alpha1.AvailableModule) *v1alpha1.ModuleSource {
+	return &v1alpha1.ModuleSource{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status:     v1alpha1.ModuleSourceStatus{AvailableModules: modules},
+	}
+}
+
+// TestMigratedModulesCheck_DistinctErrors locks down that the migrated-modules
+// gate distinguishes the terminal "no source offers the module at all" case from
+// the transient "available but not downloaded yet" case, so the operator gets the
+// right diagnostic instead of a misleading "wait for it to download" for a module
+// that no source will ever provide.
+func TestMigratedModulesCheck_DistinctErrors(t *testing.T) {
+	const moduleName = "test-module-1"
+
+	tests := []struct {
+		name        string
+		objects     []client.Object
+		wantErr     bool
+		wantErrText string
+		// wantMetric is the metric expected to be set to 1; the other migrated-module
+		// metric must stay unset. Empty means neither metric should be set.
+		wantMetric string
+	}{
+		{
+			name: "not available in any source -> not found in any ModuleSource registry",
+			objects: []client.Object{
+				enabledModule(moduleName),
+				moduleSourceWith("src", []v1alpha1.AvailableModule{{Name: "other-module"}}),
+			},
+			wantErr:     true,
+			wantErrText: "not found in any ModuleSource registry",
+			wantMetric:  metrics.MigratedModuleNotFoundMetricName,
+		},
+		{
+			name: "available with a pull error -> treated as not found",
+			objects: []client.Object{
+				enabledModule(moduleName),
+				moduleSourceWith("src", []v1alpha1.AvailableModule{{Name: moduleName, Error: "pull failed"}}),
+			},
+			wantErr:     true,
+			wantErrText: "not found in any ModuleSource registry",
+			wantMetric:  metrics.MigratedModuleNotFoundMetricName,
+		},
+		{
+			name: "available in a source but not downloaded yet -> not pre-downloaded yet",
+			objects: []client.Object{
+				enabledModule(moduleName),
+				moduleSourceWith("src", []v1alpha1.AvailableModule{{Name: moduleName}}),
+				moduleReleaseWithPhase(moduleName, v1alpha1.ModuleReleasePhasePending),
+			},
+			wantErr:     true,
+			wantErrText: "is not pre-downloaded yet",
+			wantMetric:  metrics.MigratedModuleNotDownloadedMetricName,
+		},
+		{
+			name: "deployed release -> allowed",
+			objects: []client.Object{
+				enabledModule(moduleName),
+				moduleSourceWith("src", []v1alpha1.AvailableModule{{Name: moduleName}}),
+				moduleReleaseWithPhase(moduleName, v1alpha1.ModuleReleasePhaseDeployed),
+			},
+			wantErr: false,
+		},
+		{
+			name: "disabled module is skipped -> allowed even with no source",
+			objects: []client.Object{
+				&v1alpha1.Module{
+					ObjectMeta: metav1.ObjectMeta{Name: moduleName},
+					Status: v1alpha1.ModuleStatus{Conditions: []v1alpha1.ModuleCondition{
+						{Type: v1alpha1.ModuleConditionEnabledByModuleManager, Status: corev1.ConditionFalse},
+					}},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			require.NoError(t, v1alpha1.AddToScheme(scheme))
+			require.NoError(t, corev1.AddToScheme(scheme))
+
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tt.objects...).Build()
+			metricStorage := metricstorage.NewMetricStorage(metricstorage.WithNewRegistry(), metricstorage.WithLogger(log.NewNop()))
+
+			check := newMigratedModulesCheck(fakeClient, metricStorage, log.NewNop())
+
+			dr := &v1alpha1.DeckhouseRelease{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-release"},
+				Spec: v1alpha1.DeckhouseReleaseSpec{
+					Version:      "v1.60.0",
+					Requirements: map[string]string{MigratedModulesRequirementFieldName: moduleName},
+				},
+			}
+
+			err := check.Verify(context.Background(), dr)
+
+			if !tt.wantErr {
+				require.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErrText)
+
+			// Exactly one of the two migrated-module metrics must fire, matching the
+			// error branch: the terminal "not found" metric must not be a false-positive
+			// for the transient "not downloaded yet" case and vice versa.
+			assertGaugeSet(t, metricStorage, metrics.MigratedModuleNotFoundMetricName,
+				tt.wantMetric == metrics.MigratedModuleNotFoundMetricName)
+			assertGaugeSet(t, metricStorage, metrics.MigratedModuleNotDownloadedMetricName,
+				tt.wantMetric == metrics.MigratedModuleNotDownloadedMetricName)
+		})
+	}
+}
+
+// assertGaugeSet asserts whether a grouped gauge metric is set to 1 for moduleName.
+func assertGaugeSet(t *testing.T, storage *metricstorage.MetricStorage, metricName string, want bool) {
+	t.Helper()
+
+	families, err := storage.Gather()
+	require.NoError(t, err)
+
+	set := false
+	for _, family := range families {
+		if family.GetName() != metricName {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			if metric.GetGauge().GetValue() == 1 {
+				set = true
+			}
+		}
+	}
+
+	assert.Equalf(t, want, set, "metric %s set=%v, want %v", metricName, set, want)
+}

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -3927,8 +3927,8 @@ alerts:
       severity: "3"
       markupFormat: markdown
     - name: DeckhouseMigratedModuleNotDownloaded
-      sourceFile: modules/002-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
-      moduleUrl: 002-deckhouse
+      sourceFile: modules/340-monitoring-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
+      moduleUrl: 340-monitoring-deckhouse
       module: deckhouse
       edition: ce
       description: |

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -3929,7 +3929,7 @@ alerts:
     - name: DeckhouseMigratedModuleNotDownloaded
       sourceFile: modules/340-monitoring-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
       moduleUrl: 340-monitoring-deckhouse
-      module: deckhouse
+      module: monitoring-deckhouse
       edition: ce
       description: |
         Module `{{ $labels.module }}` specified in DeckhouseRelease was moved to an external source and is available in a ModuleSource registry, but it has not been downloaded yet (no Deployed ModuleRelease). DeckhouseRelease will be locked until the module is pre-downloaded.

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -3926,6 +3926,34 @@ alerts:
         Deckhouse memory usage is too high.
       severity: "3"
       markupFormat: markdown
+    - name: DeckhouseMigratedModuleNotDownloaded
+      sourceFile: modules/002-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
+      moduleUrl: 002-deckhouse
+      module: deckhouse
+      edition: ce
+      description: |
+        Module `{{ $labels.module }}` specified in DeckhouseRelease was moved to an external source and is available in a ModuleSource registry, but it has not been downloaded yet (no Deployed ModuleRelease). DeckhouseRelease will be locked until the module is pre-downloaded.
+
+        This is usually transient: the module source controller needs time to pull the module from the registry. If the alert persists, this may indicate:
+        - The module's update policy or ModuleSource is misconfigured, so the module is never pulled.
+        - There is a network issue preventing the module download.
+
+        To investigate, run the following commands:
+
+        ```bash
+        # Check the ModuleRelease objects for the module
+        d8 k get mr -l module={{ $labels.module }}
+
+        # Check ModuleSource status
+        d8 k get modulesources
+
+        # Check Deckhouse logs for more details
+        d8 k -n d8-system logs -f -l app=deckhouse
+        ```
+      summary: |
+        Migrated module {{ $labels.module }} is not downloaded yet.
+      severity: "6"
+      markupFormat: markdown
     - name: DeckhouseMigratedModuleNotFound
       sourceFile: modules/340-monitoring-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
       moduleUrl: 340-monitoring-deckhouse

--- a/go_lib/d8env/env.go
+++ b/go_lib/d8env/env.go
@@ -22,6 +22,9 @@ import (
 
 const (
 	DownloadedModulesDir = "DOWNLOADED_MODULES_DIR"
+	EmbeddedModulesDir   = "EMBEDDED_MODULES_DIR"
+
+	defaultEmbeddedModulesDir = "/deckhouse/modules"
 )
 
 func GetDownloadedModulesDir() string {
@@ -30,4 +33,15 @@ func GetDownloadedModulesDir() string {
 		return value
 	}
 	return os.Getenv("EXTERNAL_MODULES_DIR")
+}
+
+// GetEmbeddedModulesDir returns the directory where embedded (built-in) modules
+// are shipped within the Deckhouse image. It is the first entry of the module
+// search path, so a module present here always wins over a downloaded one.
+func GetEmbeddedModulesDir() string {
+	value := os.Getenv(EmbeddedModulesDir)
+	if len(value) != 0 {
+		return value
+	}
+	return defaultEmbeddedModulesDir
 }

--- a/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
+++ b/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
@@ -607,6 +607,40 @@
         # Check Deckhouse logs for more details
         d8 k -n d8-system logs -f -l app=deckhouse
         ```
+  - alert: DeckhouseMigratedModuleNotDownloaded
+    expr: d8_migrated_module_not_downloaded == 1
+    for: 10m
+    labels:
+      severity_level: "6"
+      tier: cluster
+      d8_module: deckhouse
+      d8_component: deckhouse
+    annotations:
+      plk_protocol_version: "1"
+      plk_markup_format: "markdown"
+      plk_create_group_if_not_exists__d8_deckhouse_malfunctioning: "D8DeckhouseMalfunctioning,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+      plk_grouped_by__d8_deckhouse_malfunctioning: "D8DeckhouseMalfunctioning,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+      plk_labels_as_annotations: "module"
+      summary: Migrated module {{ $labels.module }} is not downloaded yet.
+      description: |
+        Module `{{ $labels.module }}` specified in DeckhouseRelease was moved to an external source and is available in a ModuleSource registry, but it has not been downloaded yet (no Deployed ModuleRelease). DeckhouseRelease will be locked until the module is pre-downloaded.
+
+        This is usually transient: the module source controller needs time to pull the module from the registry. If the alert persists, this may indicate:
+        - The module's update policy or ModuleSource is misconfigured, so the module is never pulled.
+        - There is a network issue preventing the module download.
+
+        To investigate, run the following commands:
+
+        ```bash
+        # Check the ModuleRelease objects for the module
+        d8 k get mr -l module={{ $labels.module }}
+
+        # Check ModuleSource status
+        d8 k get modulesources
+
+        # Check Deckhouse logs for more details
+        d8 k -n d8-system logs -f -l app=deckhouse
+        ```
   - alert: DeckhouseEditionNotFound
     expr: |
       d8_edition_not_found > 0


### PR DESCRIPTION
## Description

Backport: https://github.com/deckhouse/deckhouse/pull/20949

When a module is migrating from embedded (shipped inside the Deckhouse image) to an external `ModuleSource`, this change downloads it onto the filesystem **ahead of the upgrade** that drops the embedded copy, instead of downloading it afterwards.

Mechanics (the single invariant: files are always materialized on the filesystem, but the module is *activated* — symlink for the symlink backend, mount for the erofs backend — only when no embedded copy of the same name is present on disk):

1. **A ModuleRelease is created for an embedded module** once it appears in an external source. The release source is chosen as follows: if `ModuleConfig.spec.source` selects a source that offers the module, that one is used; otherwise, if exactly one source offers it, that one is used. If the source is undecided — several sources offer it and none is selected, **or** the configured `.spec.source` no longer offers it (a stale/mistyped `ModuleConfig`) — the `ModuleAtConflict` alert is fired and no release is created (the running embedded module is left untouched).
2. **The ModuleRelease reaches `Deployed` and is downloaded to the filesystem without being activated** (no symlink/mount), so the embedded copy keeps serving the module and its hooks are not disabled.
3. **After the upgrade drops the embedded copy**, the moduleloader restore activates the already-staged module (symlink/mount), so it is mounted immediately without a registry download on the critical path.
4. **The `migratedModules` DeckhouseRelease gate is hardened**: an enabled migrated module must now have a `Deployed` ModuleRelease (i.e. be physically on disk) before the upgrade is allowed, instead of merely being listed as available in a `ModuleSource`.

`Stage`/`StageFromRegistry` are implemented for both the symlink and erofs backends.

### Alerts

Three alerts surface the states above so an operator always has a diagnostic signal instead of a silently-stuck upgrade:

| Alert | Metric | Severity | When it fires | Operator action |
| --- | --- | --- | --- | --- |
| `ModuleAtConflict` | `d8_module_at_conflict` | 4 | The release source for an embedded module is undecided: several sources offer it and none is selected via `ModuleConfig`, or the configured `.spec.source` does not (or no longer does) offer it. No release is pre-staged; the embedded module keeps running. | Set/fix `ModuleConfig.spec.source` to the correct source. |
| `DeckhouseMigratedModuleNotDownloaded` | `d8_migrated_module_not_downloaded` | 6 | **(new)** At the upgrade gate, a `ModuleSource` offers the migrated module but it has not been pre-downloaded yet (no `Deployed` ModuleRelease). The DeckhouseRelease is locked until the module is on disk. | Usually transient — wait for the source controller to pull the module. If it persists, check the update policy / `ModuleSource` config and registry connectivity. |
| `DeckhouseMigratedModuleNotFound` | `d8_migrated_module_not_found` | 6 | At the upgrade gate, **no** `ModuleSource` offers the migrated module at all (terminal). The DeckhouseRelease is locked. | Publish the module in a `ModuleSource`, or fix the module's configured source, before upgrading. |

Previously a single `DeckhouseMigratedModuleNotFound` alert covered both the "no source offers it" and the "offered but not downloaded yet" cases. They are now split because they require different operator actions — the not-downloaded case is transient and self-resolves once the source controller pre-stages the module, while the not-found case needs manual intervention.

Influence on critical cluster components: no extra restarts are introduced. For migrating modules (e.g. `ingress-nginx`) this *reduces* the risk of a restart/outage window, because the module is on disk before the upgrade rather than being downloaded during it.

## Why do we need it, and what problem does it solve?

Today a migrating module is only downloaded **after** Deckhouse is upgraded and the embedded copy is removed. The `migratedModules` requirement check only verifies that the module is *listed* in a `ModuleSource`, not that it is actually on disk. If, right after the upgrade, the registry is unavailable or slow, the module is not yet on the filesystem when the reconcile queue reaches it — causing a temporary outage of the module (for `ingress-nginx` this means real ingress downtime).

This change pre-downloads the module while the embedded copy is still running and blocks the upgrade until the module is physically present on disk, eliminating the download-during-upgrade race.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse-controller
type: feature
summary: harden migrated modules check
impact_level: default
```
