### PR TITLE
[cloud-provider-dvp] Add ModuleConfig migration resources for hybrids

### DIFF
--- a/modules/030-cloud-provider-dvp/hooks/create_migration_resources.go
+++ b/modules/030-cloud-provider-dvp/hooks/create_migration_resources.go
@@ -68,8 +68,8 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 func handleDVPMigrationResources(_ context.Context, input *go_hook.HookInput) error {
 	pccSnaps := input.Snapshots.Get("provider_cluster_configuration")
 	if len(pccSnaps) == 0 {
-		// State A: no PCC - nothing to create; deletion is handled by dvp_cluster_configuration.go.
-		return nil
+		// State A: no PCC - hybrid migrations can still need credentials from legacy ModuleConfig v1.
+		return createLegacyModuleConfigMigrationResources(input)
 	}
 
 	var pccResult pccSecretFilterResult
@@ -105,5 +105,51 @@ func handleDVPMigrationResources(_ context.Context, input *go_hook.HookInput) er
 	}
 
 	createMigrationConfigMap(input)
+	return nil
+}
+
+func createLegacyModuleConfigMigrationResources(input *go_hook.HookInput) error {
+	mcSnaps := input.Snapshots.Get("module_config")
+	if len(mcSnaps) == 0 {
+		return nil
+	}
+
+	var mc moduleConfigFilterResult
+	if err := mcSnaps[0].UnmarshalTo(&mc); err != nil {
+		return fmt.Errorf("unmarshal ModuleConfig snapshot: %w", err)
+	}
+
+	if mc.Version != 1 || len(mc.Provider) == 0 {
+		return nil
+	}
+
+	var provider v1.DvpProvider
+	if err := json.Unmarshal(mc.Provider, &provider); err != nil {
+		return fmt.Errorf("parse ModuleConfig provider settings: %w", err)
+	}
+
+	if provider.KubeconfigDataBase64 == nil || *provider.KubeconfigDataBase64 == "" {
+		return nil
+	}
+
+	namespace := ""
+	if provider.Namespace != nil {
+		namespace = *provider.Namespace
+	}
+
+	// The hybrid bundle upgrades the admin's stored config to the v2 schema: a
+	// ModuleConfig v2 (kubeconfig removed, moved into the Secret) plus the
+	// d8-credentials Secret. Hybrid clusters order only CloudEphemeral nodes that
+	// already exist as user-managed resources, so no NodeGroups/DVPInstanceClasses
+	// are generated (unlike the PCC path).
+	resources := []any{
+		buildModuleConfigForHybrid(namespace, mc.Zones),
+		buildD8CredentialsSecret(*provider.KubeconfigDataBase64),
+	}
+	if err := createMigrationResourcesSecret(input, resources); err != nil {
+		return fmt.Errorf("create migration resources: %w", err)
+	}
+	createMigrationConfigMap(input)
+
 	return nil
 }

--- a/modules/030-cloud-provider-dvp/hooks/create_migration_resources_test.go
+++ b/modules/030-cloud-provider-dvp/hooks/create_migration_resources_test.go
@@ -422,8 +422,20 @@ spec:
 			providerParams, ok := provider["parameters"].(map[string]any)
 			Expect(ok).To(BeTrue(), "settings.provider.parameters must be a map")
 			Expect(providerParams["namespace"]).To(Equal("cloud-provider01"))
-			_, hasKubeconfig := provider["kubeconfigDataBase64"]
-			Expect(hasKubeconfig).To(BeFalse(), "kubeconfigDataBase64 must not be present in ModuleConfig v2")
+
+			// Tombstones: JSON-merge-patch delete markers so that `kubectl apply`
+			// over an existing stored v1 ModuleConfig strips the legacy fields
+			// instead of unioning them into a version:2 object (which the webhook
+			// rejects). Keys must be PRESENT with a null value.
+			namespaceTombstone, hasNamespaceTombstone := provider["namespace"]
+			Expect(hasNamespaceTombstone).To(BeTrue(), "legacy provider.namespace tombstone must be present")
+			Expect(namespaceTombstone).To(BeNil(), "legacy provider.namespace tombstone must be null")
+			kubeconfigTombstone, hasKubeconfigTombstone := provider["kubeconfigDataBase64"]
+			Expect(hasKubeconfigTombstone).To(BeTrue(), "legacy provider.kubeconfigDataBase64 tombstone must be present")
+			Expect(kubeconfigTombstone).To(BeNil(), "legacy provider.kubeconfigDataBase64 tombstone must be null")
+			zonesTombstone, hasZonesTombstone := settings["zones"]
+			Expect(hasZonesTombstone).To(BeTrue(), "legacy top-level zones tombstone must be present")
+			Expect(zonesTombstone).To(BeNil(), "legacy top-level zones tombstone must be null")
 
 			nodes, ok := settings["nodes"].(map[string]any)
 			Expect(ok).To(BeTrue(), "settings.nodes must be a map")
@@ -473,12 +485,22 @@ spec:
 			Expect(mcDocs).To(HaveLen(1))
 
 			settings := mcDocs[0]["spec"].(map[string]any)["settings"].(map[string]any)
-			providerParams := settings["provider"].(map[string]any)["parameters"].(map[string]any)
+			provider := settings["provider"].(map[string]any)
+			providerParams := provider["parameters"].(map[string]any)
 			Expect(providerParams["namespace"]).To(Equal("default"))
 
 			nodesParams := settings["nodes"].(map[string]any)["parameters"].(map[string]any)
 			_, hasZones := nodesParams["zones"]
 			Expect(hasZones).To(BeFalse(), "zones must be absent when the legacy ModuleConfig has none")
+
+			// Tombstones must be emitted regardless of whether the legacy fields
+			// were set, so `kubectl apply` always deletes any stale v1 keys.
+			_, hasNamespaceTombstone := provider["namespace"]
+			Expect(hasNamespaceTombstone).To(BeTrue(), "provider.namespace tombstone must be present")
+			_, hasKubeconfigTombstone := provider["kubeconfigDataBase64"]
+			Expect(hasKubeconfigTombstone).To(BeTrue(), "provider.kubeconfigDataBase64 tombstone must be present")
+			_, hasZonesTombstone := settings["zones"]
+			Expect(hasZonesTombstone).To(BeTrue(), "top-level zones tombstone must be present")
 		})
 	})
 })

--- a/modules/030-cloud-provider-dvp/hooks/create_migration_resources_test.go
+++ b/modules/030-cloud-provider-dvp/hooks/create_migration_resources_test.go
@@ -39,7 +39,8 @@ cloudProviderDvp:
 `
 	)
 
-	clusterConfig := `
+	kubeconfigDataBase64 := base64.StdEncoding.EncodeToString([]byte("apiVe"))
+	clusterConfig := fmt.Sprintf(`
 apiVersion: deckhouse.io/v1
 kind: DVPClusterConfiguration
 layout: Standard
@@ -58,19 +59,19 @@ masterNodeGroup:
       virtualMachineClassName: superbe-class
       bootloader: EFI
       cpu:
-        coreFraction: 100%
+        coreFraction: 100%%
         cores: 4
       memory:
         size: 8Gi
   replicas: 1
 provider:
-  kubeconfigDataBase64: YXBpVmV=
+  kubeconfigDataBase64: %s
   namespace: cloud-provider01
 sshPublicKey: ssh-rsa AAAAB3N
 region: ru-msk-1
 zones:
   - default
-`
+`, kubeconfigDataBase64)
 
 	pccSecret := fmt.Sprintf(`
 apiVersion: v1
@@ -202,7 +203,7 @@ data:
 		})
 	})
 
-	clusterConfigNoZones := `
+	clusterConfigNoZones := fmt.Sprintf(`
 apiVersion: deckhouse.io/v1
 kind: DVPClusterConfiguration
 layout: Standard
@@ -221,17 +222,17 @@ masterNodeGroup:
       virtualMachineClassName: superbe-class
       bootloader: EFI
       cpu:
-        coreFraction: 100%
+        coreFraction: 100%%
         cores: 4
       memory:
         size: 8Gi
   replicas: 1
 provider:
-  kubeconfigDataBase64: YXBpVmV=
+  kubeconfigDataBase64: %s
   namespace: cloud-provider01
 sshPublicKey: ssh-rsa AAAAB3N
 region: ru-msk-1
-`
+`, kubeconfigDataBase64)
 
 	pccSecretNoZones := fmt.Sprintf(`
 apiVersion: v1
@@ -322,6 +323,162 @@ data:
 
 			migrationCM := f.KubernetesResource("ConfigMap", "d8-cloud-provider-dvp", "d8-module-is-migrating")
 			Expect(migrationCM.Exists()).To(BeFalse())
+		})
+	})
+
+	// migrationResourceDocuments decodes the resources.yaml bundle and indexes documents by kind.
+	migrationResourceDocuments := func(f *HookExecutionConfig) map[string][]map[string]any {
+		migrationSecret := f.KubernetesResource("Secret", "d8-cloud-provider-dvp", "d8-migration-resources")
+		resourcesYAML := migrationSecret.Field("data.resources\\.yaml").String()
+		Expect(resourcesYAML).NotTo(BeEmpty())
+
+		rawBytes, err := base64.StdEncoding.DecodeString(resourcesYAML)
+		Expect(err).NotTo(HaveOccurred())
+
+		byKind := map[string][]map[string]any{}
+		for _, doc := range splitYAMLDocuments(string(rawBytes)) {
+			var obj map[string]any
+			if err := yaml.Unmarshal([]byte(doc), &obj); err != nil {
+				continue
+			}
+			kind, _ := obj["kind"].(string)
+			byKind[kind] = append(byKind[kind], obj)
+		}
+		return byKind
+	}
+
+	Context("Hybrid migration: no PCC and legacy ModuleConfig v1 has kubeconfig", func() {
+		f := HookExecutionConfigInit(migrationValues, `{}`)
+		f.RegisterCRD("deckhouse.io", "v1alpha1", "ModuleConfig", false)
+		f.RegisterCRD("deckhouse.io", "v1alpha1", "DVPInstanceClass", false)
+		f.RegisterCRD("deckhouse.io", "v1", "NodeGroup", false)
+		BeforeEach(func() {
+			f.KubeStateSet(fmt.Sprintf(`
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: cloud-provider-dvp
+spec:
+  version: 1
+  enabled: true
+  settings:
+    provider:
+      kubeconfigDataBase64: %s
+      namespace: cloud-provider01
+    zones:
+      - zone-a
+      - zone-b
+`, kubeconfigDataBase64))
+			f.BindingContexts.Set(f.GenerateAfterHelmContext())
+			f.RunHook()
+		})
+
+		It("should create migration resources with d8-credentials Secret from legacy ModuleConfig kubeconfig", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			credentialsSecret := f.KubernetesResource("Secret", "d8-cloud-provider-dvp", "d8-credentials")
+			Expect(credentialsSecret.Exists()).To(BeFalse())
+
+			migrationSecret := f.KubernetesResource("Secret", "d8-cloud-provider-dvp", "d8-migration-resources")
+			Expect(migrationSecret.Exists()).To(BeTrue())
+
+			migrationCM := f.KubernetesResource("ConfigMap", "d8-cloud-provider-dvp", "d8-module-is-migrating")
+			Expect(migrationCM.Exists()).To(BeTrue())
+
+			docs := migrationResourceDocuments(f)
+
+			credentialsSecretDoc := docs["Secret"]
+			Expect(credentialsSecretDoc).To(HaveLen(1), "exactly one Secret document expected in resources.yaml")
+			Expect(credentialsSecretDoc[0]["type"]).To(Equal("cloud-provider.deckhouse.io/credentials"))
+
+			stringData, ok := credentialsSecretDoc[0]["stringData"].(map[string]any)
+			Expect(ok).To(BeTrue(), "d8-credentials stringData must be a map")
+			Expect(stringData["authScheme"]).To(Equal("kubeconfig"))
+			Expect(stringData["secret"]).To(Equal(kubeconfigDataBase64))
+		})
+
+		It("should include a ModuleConfig v2 mirroring the v1->v2 conversion and no node resources", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			docs := migrationResourceDocuments(f)
+
+			Expect(docs["NodeGroup"]).To(BeEmpty(), "hybrid migration must not generate NodeGroups")
+			Expect(docs["DVPInstanceClass"]).To(BeEmpty(), "hybrid migration must not generate DVPInstanceClasses")
+
+			mcDocs := docs["ModuleConfig"]
+			Expect(mcDocs).To(HaveLen(1), "hybrid migration must include exactly one ModuleConfig v2")
+			mc := mcDocs[0]
+
+			spec, ok := mc["spec"].(map[string]any)
+			Expect(ok).To(BeTrue(), "ModuleConfig spec must be a map")
+			Expect(spec["enabled"]).To(Equal(true))
+			Expect(spec["version"]).To(BeNumerically("==", 2))
+
+			settings, ok := spec["settings"].(map[string]any)
+			Expect(ok).To(BeTrue(), "ModuleConfig spec.settings must be a map")
+
+			provider, ok := settings["provider"].(map[string]any)
+			Expect(ok).To(BeTrue(), "settings.provider must be a map")
+			providerParams, ok := provider["parameters"].(map[string]any)
+			Expect(ok).To(BeTrue(), "settings.provider.parameters must be a map")
+			Expect(providerParams["namespace"]).To(Equal("cloud-provider01"))
+			_, hasKubeconfig := provider["kubeconfigDataBase64"]
+			Expect(hasKubeconfig).To(BeFalse(), "kubeconfigDataBase64 must not be present in ModuleConfig v2")
+
+			nodes, ok := settings["nodes"].(map[string]any)
+			Expect(ok).To(BeTrue(), "settings.nodes must be a map")
+			_, hasNodesDisabled := nodes["disabled"]
+			Expect(hasNodesDisabled).To(BeFalse(), "nodes.disabled must not be explicitly set (schema default)")
+			nodesParams, ok := nodes["parameters"].(map[string]any)
+			Expect(ok).To(BeTrue(), "settings.nodes.parameters must be a map")
+			Expect(nodesParams["layout"]).To(Equal("Standard"))
+			Expect(nodesParams["sshPublicKey"]).To(Equal("ssh-rsa PLACEHOLDER_REPLACE_ME"))
+			Expect(nodesParams["zones"]).To(Equal([]any{"zone-a", "zone-b"}),
+				"legacy top-level zones must move into nodes.parameters.zones")
+
+			storage, ok := settings["storage"].(map[string]any)
+			Expect(ok).To(BeTrue(), "settings.storage must be a map")
+			_, hasStorageDisabled := storage["disabled"]
+			Expect(hasStorageDisabled).To(BeFalse(), "storage.disabled must not be explicitly set (schema default)")
+		})
+	})
+
+	Context("Hybrid migration: no PCC and legacy ModuleConfig v1 without namespace or zones", func() {
+		f := HookExecutionConfigInit(migrationValues, `{}`)
+		f.RegisterCRD("deckhouse.io", "v1alpha1", "ModuleConfig", false)
+		f.RegisterCRD("deckhouse.io", "v1alpha1", "DVPInstanceClass", false)
+		f.RegisterCRD("deckhouse.io", "v1", "NodeGroup", false)
+		BeforeEach(func() {
+			f.KubeStateSet(fmt.Sprintf(`
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: cloud-provider-dvp
+spec:
+  version: 1
+  enabled: true
+  settings:
+    provider:
+      kubeconfigDataBase64: %s
+`, kubeconfigDataBase64))
+			f.BindingContexts.Set(f.GenerateAfterHelmContext())
+			f.RunHook()
+		})
+
+		It("should default namespace to 'default' and omit zones", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			docs := migrationResourceDocuments(f)
+			mcDocs := docs["ModuleConfig"]
+			Expect(mcDocs).To(HaveLen(1))
+
+			settings := mcDocs[0]["spec"].(map[string]any)["settings"].(map[string]any)
+			providerParams := settings["provider"].(map[string]any)["parameters"].(map[string]any)
+			Expect(providerParams["namespace"]).To(Equal("default"))
+
+			nodesParams := settings["nodes"].(map[string]any)["parameters"].(map[string]any)
+			_, hasZones := nodesParams["zones"]
+			Expect(hasZones).To(BeFalse(), "zones must be absent when the legacy ModuleConfig has none")
 		})
 	})
 })

--- a/modules/030-cloud-provider-dvp/hooks/credentials_test.go
+++ b/modules/030-cloud-provider-dvp/hooks/credentials_test.go
@@ -52,6 +52,19 @@ data:
   secret: %s
 `, base64.StdEncoding.EncodeToString([]byte("kubeconfig")), base64.StdEncoding.EncodeToString([]byte("apiVe")))
 
+	kubeconfigDataBase64 := base64.StdEncoding.EncodeToString([]byte("apiVe"))
+	migratedCredentialSecret := fmt.Sprintf(`
+apiVersion: v1
+kind: Secret
+metadata:
+  name: d8-credentials
+  namespace: d8-cloud-provider-dvp
+type: cloud-provider.deckhouse.io/credentials
+data:
+  authScheme: %s
+  secret: %s
+`, base64.StdEncoding.EncodeToString([]byte("kubeconfig")), base64.StdEncoding.EncodeToString([]byte(kubeconfigDataBase64)))
+
 	credSecret2 := fmt.Sprintf(`
 apiVersion: v1
 kind: Secret
@@ -68,7 +81,7 @@ data:
   secret: %s
 `, base64.StdEncoding.EncodeToString([]byte("userpass")), base64.StdEncoding.EncodeToString([]byte("user1")), base64.StdEncoding.EncodeToString([]byte("pass1")))
 
-	nonCredSecret := `
+	nonCredSecret := fmt.Sprintf(`
 apiVersion: v1
 kind: Secret
 metadata:
@@ -76,8 +89,8 @@ metadata:
   namespace: d8-cloud-provider-dvp
 type: Opaque
 data:
-  key: dmFsdWU=
-`
+  key: %s
+`, base64.StdEncoding.EncodeToString([]byte("value")))
 
 	Context("Single credential secret", func() {
 		f := HookExecutionConfigInit(initValues, `{}`)
@@ -95,6 +108,24 @@ data:
 			entry := secrets.Get("d8-credentials")
 			Expect(entry.Get("authScheme").String()).To(Equal("kubeconfig"))
 			Expect(entry.Get("secret").String()).To(Equal("apiVe"))
+			Expect(entry.Get("identity").Exists()).To(BeFalse())
+		})
+	})
+
+	Context("Credential secret from migration resources", func() {
+		f := HookExecutionConfigInit(initValues, `{}`)
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(migratedCredentialSecret))
+			f.RunHook()
+		})
+
+		It("should populate credentialSecrets with d8-credentials", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			entry := f.ValuesGet("cloudProviderDvp.internal.credentialSecrets.d8-credentials")
+			Expect(entry.Exists()).To(BeTrue())
+			Expect(entry.Get("authScheme").String()).To(Equal("kubeconfig"))
+			Expect(entry.Get("secret").String()).To(Equal(kubeconfigDataBase64))
 			Expect(entry.Get("identity").Exists()).To(BeFalse())
 		})
 	})

--- a/modules/030-cloud-provider-dvp/hooks/dvp_cluster_configuration.go
+++ b/modules/030-cloud-provider-dvp/hooks/dvp_cluster_configuration.go
@@ -51,6 +51,7 @@ type moduleConfigFilterResult struct {
 	Version  int64           `json:"version"`
 	Enabled  bool            `json:"enabled"`
 	Provider json.RawMessage `json:"provider,omitempty"`
+	Zones    []string        `json:"zones,omitempty"`
 }
 
 type namedResourceResult struct {
@@ -108,10 +109,19 @@ func filterModuleConfig(obj *unstructured.Unstructured) (go_hook.FilterResult, e
 	}
 
 	if mc.Spec.Settings != nil {
-		if providerRaw, ok := mc.Spec.Settings.GetMap()["provider"]; ok {
+		settings := mc.Spec.Settings.GetMap()
+		if providerRaw, ok := settings["provider"]; ok {
 			providerBytes, err := json.Marshal(providerRaw)
 			if err == nil {
 				result.Provider = json.RawMessage(providerBytes)
+			}
+		}
+
+		if zonesRaw, ok := settings["zones"].([]any); ok {
+			for _, zoneRaw := range zonesRaw {
+				if zone, ok := zoneRaw.(string); ok && zone != "" {
+					result.Zones = append(result.Zones, zone)
+				}
 			}
 		}
 	}
@@ -235,8 +245,15 @@ func handleDVPClusterConfiguration(_ context.Context, input *go_hook.HookInput) 
 	pccPresent := len(pccSnaps) > 0
 
 	if !pccPresent {
-		// no PCC: new cluster, standard flow
-		deleteMigrationArtifacts(input)
+		legacyCredentialsPresent, err := mapLegacyModuleConfigCredentialsToRootValues(input)
+		if err != nil {
+			return fmt.Errorf("map legacy ModuleConfig credentials to root values: %w", err)
+		}
+
+		if !legacyCredentialsPresent {
+			deleteMigrationArtifacts(input)
+		}
+
 		return mergeAndSetDiscoveryData(input, discoveryData)
 	}
 
@@ -429,23 +446,59 @@ func mapPCCtoRootValues(input *go_hook.HookInput, pcc *v1.DvpProviderClusterConf
 		input.Values.Set("cloudProviderDvp.nodes", nodes)
 	}
 
-	// inject synthetic creds only if credentials.go (Order 19) hasn't populated yet
-	if _, exists := input.Values.GetOk("cloudProviderDvp.internal.credentialSecrets.d8-credentials"); !exists {
-		if pcc.Provider != nil && pcc.Provider.KubeconfigDataBase64 != nil && len(*pcc.Provider.KubeconfigDataBase64) > 0 {
-			// set whole map at once; JSON-patch fails on missing intermediate path
-			existing := make(map[string]any)
-			if v, ok := input.Values.GetOk("cloudProviderDvp.internal.credentialSecrets"); ok {
-				if err := json.Unmarshal([]byte(v.Raw), &existing); err != nil {
-					return fmt.Errorf("unmarshal credentialSecrets: %w", err)
-				}
-			}
-			existing[dvpCredentialSecretName] = map[string]any{
-				"authScheme": dvpAuthSchemeKubeconfig,
-				"secret":     *pcc.Provider.KubeconfigDataBase64,
-			}
-			input.Values.Set("cloudProviderDvp.internal.credentialSecrets", existing)
+	if pcc.Provider != nil && pcc.Provider.KubeconfigDataBase64 != nil && len(*pcc.Provider.KubeconfigDataBase64) > 0 {
+		if err := setD8CredentialValuesIfAbsent(input, *pcc.Provider.KubeconfigDataBase64); err != nil {
+			return err
 		}
 	}
+
+	return nil
+}
+
+func mapLegacyModuleConfigCredentialsToRootValues(input *go_hook.HookInput) (bool, error) {
+	mcSnaps := input.Snapshots.Get("module_config")
+	if len(mcSnaps) == 0 {
+		return false, nil
+	}
+
+	var mc moduleConfigFilterResult
+	if err := mcSnaps[0].UnmarshalTo(&mc); err != nil {
+		return false, fmt.Errorf("unmarshal ModuleConfig snapshot: %w", err)
+	}
+
+	if mc.Version != 1 || len(mc.Provider) == 0 {
+		return false, nil
+	}
+
+	var provider v1.DvpProvider
+	if err := json.Unmarshal(mc.Provider, &provider); err != nil {
+		return false, fmt.Errorf("parse ModuleConfig provider settings: %w", err)
+	}
+
+	if provider.KubeconfigDataBase64 == nil || *provider.KubeconfigDataBase64 == "" {
+		return false, nil
+	}
+
+	return true, setD8CredentialValuesIfAbsent(input, *provider.KubeconfigDataBase64)
+}
+
+func setD8CredentialValuesIfAbsent(input *go_hook.HookInput, kubeconfigDataBase64 string) error {
+	if _, exists := input.Values.GetOk("cloudProviderDvp.internal.credentialSecrets.d8-credentials"); exists {
+		return nil
+	}
+
+	existing := make(map[string]any)
+	if v, ok := input.Values.GetOk("cloudProviderDvp.internal.credentialSecrets"); ok {
+		if err := json.Unmarshal([]byte(v.Raw), &existing); err != nil {
+			return fmt.Errorf("unmarshal credentialSecrets: %w", err)
+		}
+	}
+
+	existing[dvpCredentialSecretName] = map[string]any{
+		"authScheme": dvpAuthSchemeKubeconfig,
+		"secret":     kubeconfigDataBase64,
+	}
+	input.Values.Set("cloudProviderDvp.internal.credentialSecrets", existing)
 
 	return nil
 }

--- a/modules/030-cloud-provider-dvp/hooks/dvp_cluster_configuration_test.go
+++ b/modules/030-cloud-provider-dvp/hooks/dvp_cluster_configuration_test.go
@@ -46,7 +46,8 @@ cloudProviderDvp:
    "zones": ["default"]
 }
 `
-	stateAClusterConfiguration1 := `
+	kubeconfigDataBase64 := base64.StdEncoding.EncodeToString([]byte("apiVe"))
+	stateAClusterConfiguration1 := fmt.Sprintf(`
 apiVersion: deckhouse.io/v1
 kind: DVPClusterConfiguration
 layout: Standard
@@ -65,7 +66,7 @@ masterNodeGroup:
       virtualMachineClassName: superbe-class
       bootloader: EFI
       cpu:
-        coreFraction: 100%
+        coreFraction: 100%%
         cores: 4
       liveMigrationPolicy: PreferForced
       runPolicy: AlwaysOnUnlessStoppedManually
@@ -75,13 +76,13 @@ masterNodeGroup:
         size: 8Gi
   replicas: 3
 provider:
-  kubeconfigDataBase64: YXBpVmV=
+  kubeconfigDataBase64: %s
   namespace: cloud-provider01
 sshPublicKey: ssh-rsa AAAAB3N
 region: ru-msk-1
 zones:
 - default
-`
+`, kubeconfigDataBase64)
 
 	notEmptyPCCState := fmt.Sprintf(`
 apiVersion: v1
@@ -121,6 +122,58 @@ data:
 			Expect(f.ValuesGet("cloudProviderDvp.internal.providerDiscoveryData.apiVersion").String()).To(Equal("deckhouse.io/v1"))
 			Expect(f.ValuesGet("cloudProviderDvp.internal.providerDiscoveryData.kind").String()).To(Equal("DVPCloudDiscoveryData"))
 			Expect(f.ValuesGet("cloudProviderDvp.internal.providerDiscoveryData.zones").String()).To(MatchJSON(`["default"]`))
+		})
+	})
+
+	Context("State A: no PCC and legacy ModuleConfig v1 has kubeconfig", func() {
+		f := HookExecutionConfigInit(emptyValues, `{}`)
+		f.RegisterCRD("deckhouse.io", "v1alpha1", "ModuleConfig", false)
+		f.RegisterCRD("deckhouse.io", "v1alpha1", "DVPInstanceClass", false)
+		f.RegisterCRD("deckhouse.io", "v1", "NodeGroup", false)
+
+		BeforeEach(func() {
+			f.KubeStateSet(fmt.Sprintf(`
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: cloud-provider-dvp
+spec:
+  version: 1
+  enabled: true
+  settings:
+    provider:
+      kubeconfigDataBase64: %s
+      namespace: cloud-provider01
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: d8-migration-resources
+  namespace: d8-cloud-provider-dvp
+type: Opaque
+data: {}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: d8-module-is-migrating
+  namespace: d8-cloud-provider-dvp
+`, kubeconfigDataBase64))
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.RunHook()
+		})
+
+		It("should fill credential values before migration resources are applied", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			Expect(f.ValuesGet("cloudProviderDvp.internal.credentialSecrets.d8-credentials.authScheme").String()).To(Equal("kubeconfig"))
+			Expect(f.ValuesGet("cloudProviderDvp.internal.credentialSecrets.d8-credentials.secret").String()).To(Equal(kubeconfigDataBase64))
+
+			migrationSecret := f.KubernetesResource("Secret", "d8-cloud-provider-dvp", "d8-migration-resources")
+			Expect(migrationSecret.Exists()).To(BeTrue())
+
+			migrationCM := f.KubernetesResource("ConfigMap", "d8-cloud-provider-dvp", "d8-module-is-migrating")
+			Expect(migrationCM.Exists()).To(BeTrue())
 		})
 	})
 
@@ -189,7 +242,7 @@ metadata:
 
 			// Synthetic d8-credentials should be injected from PCC kubeconfigDataBase64.
 			Expect(b.ValuesGet("cloudProviderDvp.internal.credentialSecrets.d8-credentials.authScheme").String()).To(Equal("kubeconfig"))
-			Expect(b.ValuesGet("cloudProviderDvp.internal.credentialSecrets.d8-credentials.secret").String()).To(Equal("YXBpVmV="))
+			Expect(b.ValuesGet("cloudProviderDvp.internal.credentialSecrets.d8-credentials.secret").String()).To(Equal(kubeconfigDataBase64))
 
 			Expect(b.ValuesGet("cloudProviderDvp.internal.providerDiscoveryData").String()).To(MatchJSON(stateACloudDiscoveryData))
 

--- a/modules/030-cloud-provider-dvp/hooks/migration.go
+++ b/modules/030-cloud-provider-dvp/hooks/migration.go
@@ -45,8 +45,6 @@ const (
 	dvpCredentialSecretType       = "cloud-provider.deckhouse.io/credentials"
 	moduleConfigAPIVersion        = "deckhouse.io/v1alpha1"
 	pccSecretName                 = "d8-provider-cluster-configuration"
-	pccSecretNamespace            = "kube-system"
-	pccClusterConfigKey           = "cloud-provider-cluster-configuration.yaml"
 	dvpCandiDiscoverySecretName   = "d8-candi-cloud-provider-discovery-data"
 )
 
@@ -55,98 +53,22 @@ func createProviderClusterConfigurationResources(input *go_hook.HookInput, cfg *
 		return nil
 	}
 
-	providerSettings := map[string]any{
-		"parameters": map[string]any{
-			"namespace": *cfg.Provider.Namespace,
-		},
-	}
-
-	layout := ""
-	if cfg.Layout != nil {
-		layout = *cfg.Layout
-	}
-	sshPublicKey := ""
-	if cfg.SSHPublicKey != nil {
-		sshPublicKey = *cfg.SSHPublicKey
-	}
-	nodesSettings := map[string]any{
-		"parameters": map[string]any{
-			"layout":       layout,
-			"sshPublicKey": sshPublicKey,
-		},
-	}
-	nodesParameters := nodesSettings["parameters"].(map[string]any)
-	if cfg.Region != nil {
-		nodesParameters["region"] = *cfg.Region
-	}
-	if cfg.Zones != nil {
-		nodesParameters["zones"] = stringsToAnySlice(*cfg.Zones)
-	}
-
 	resources := make([]any, 0, 4+len(cfg.NodeGroups))
+	resources = append(resources, buildD8CredentialsSecret(*cfg.Provider.KubeconfigDataBase64))
+
+	moduleConfig, err := buildModuleConfigFromPCC(cfg)
+	if err != nil {
+		return err
+	}
+	resources = append(resources, moduleConfig)
 
 	masterNodeGroup, err := mapFromAny(cfg.MasterNodeGroup)
 	if err != nil {
 		return fmt.Errorf("convert masterNodeGroup: %w", err)
 	}
 
-	ipAddressesMap := make(map[string][]string)
-	if addrs := extractIPAddresses("master", masterNodeGroup); len(addrs) > 0 {
-		ipAddressesMap["master"] = addrs
-	}
-	for _, rawNodeGroup := range cfg.NodeGroups {
-		nodeGroup, err := mapFromAny(rawNodeGroup)
-		if err != nil {
-			return fmt.Errorf("convert nodeGroup: %w", err)
-		}
-		ngName, _ := nodeGroup["name"].(string)
-		if ngName != "" {
-			if addrs := extractIPAddresses(ngName, nodeGroup); len(addrs) > 0 {
-				ipAddressesMap[ngName] = addrs
-			}
-		}
-	}
-	if len(ipAddressesMap) > 0 {
-		nodesParameters["ipAddresses"] = ipAddressesMap
-	}
-
-	moduleConfig := map[string]any{
-		"apiVersion": moduleConfigAPIVersion,
-		"kind":       "ModuleConfig",
-		"metadata": map[string]any{
-			"name": dvpModuleName,
-		},
-		"spec": map[string]any{
-			"enabled": true,
-			"version": int(2),
-			"settings": map[string]any{
-				"provider": providerSettings,
-				"storage": map[string]any{
-					"parameters": map[string]any{},
-				},
-				"nodes": nodesSettings,
-			},
-		},
-	}
-	resources = append(resources, moduleConfig)
-
-	credentialSecret := map[string]any{
-		"apiVersion": "v1",
-		"kind":       "Secret",
-		"metadata": map[string]any{
-			"name":      dvpCredentialSecretName,
-			"namespace": dvpNamespace,
-		},
-		"type": dvpCredentialSecretType,
-		"stringData": map[string]any{
-			"authScheme": dvpAuthSchemeKubeconfig,
-			"secret":     *cfg.Provider.KubeconfigDataBase64,
-		},
-	}
-	resources = append(resources, credentialSecret)
-
 	if len(masterNodeGroup) != 0 {
-		masterResources, err := createNodeGroupResources("master", masterNodeGroup, true, cfg.Zones)
+		masterResources, err := buildNodeGroupAndInstanceClassResources("master", masterNodeGroup, true, cfg.Zones)
 		if err != nil {
 			return err
 		}
@@ -164,7 +86,7 @@ func createProviderClusterConfigurationResources(input *go_hook.HookInput, cfg *
 			return errors.New("nodeGroups[].name cannot be empty")
 		}
 
-		nodeGroupResources, err := createNodeGroupResources(name, nodeGroup, false, cfg.Zones)
+		nodeGroupResources, err := buildNodeGroupAndInstanceClassResources(name, nodeGroup, false, cfg.Zones)
 		if err != nil {
 			return err
 		}
@@ -172,6 +94,157 @@ func createProviderClusterConfigurationResources(input *go_hook.HookInput, cfg *
 	}
 
 	return createMigrationResourcesSecret(input, resources)
+}
+
+// buildD8CredentialsSecret returns the managed d8-credentials Secret manifest,
+// shared by the PCC and hybrid v1 migration paths.
+func buildD8CredentialsSecret(kubeconfigDataBase64 string) map[string]any {
+	return map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Secret",
+		"metadata": map[string]any{
+			"name":      dvpCredentialSecretName,
+			"namespace": dvpNamespace,
+		},
+		"type": dvpCredentialSecretType,
+		"stringData": map[string]any{
+			"authScheme": dvpAuthSchemeKubeconfig,
+			"secret":     kubeconfigDataBase64,
+		},
+	}
+}
+
+// buildModuleConfigFromPCC builds the ModuleConfig v2 manifest for the PCC (cloud
+// DVP) migration path. Provider and nodes settings are derived from the
+// ProviderClusterConfiguration: namespace, layout, sshPublicKey, region, zones
+// and the per-NodeGroup ipAddresses aggregated from the master and worker
+// NodeGroups. storage.parameters is emitted empty and disabled flags are omitted
+// so schema defaults apply, matching buildModuleConfigForHybrid.
+func buildModuleConfigFromPCC(cfg *v1.DvpProviderClusterConfiguration) (map[string]any, error) {
+	providerSettings := map[string]any{
+		"parameters": map[string]any{
+			"namespace": *cfg.Provider.Namespace,
+		},
+	}
+
+	layout := ""
+	if cfg.Layout != nil {
+		layout = *cfg.Layout
+	}
+	sshPublicKey := ""
+	if cfg.SSHPublicKey != nil {
+		sshPublicKey = *cfg.SSHPublicKey
+	}
+	nodesParameters := map[string]any{
+		"layout":       layout,
+		"sshPublicKey": sshPublicKey,
+	}
+	if cfg.Region != nil {
+		nodesParameters["region"] = *cfg.Region
+	}
+	if cfg.Zones != nil {
+		nodesParameters["zones"] = stringsToAnySlice(*cfg.Zones)
+	}
+
+	masterNodeGroup, err := mapFromAny(cfg.MasterNodeGroup)
+	if err != nil {
+		return nil, fmt.Errorf("convert masterNodeGroup: %w", err)
+	}
+
+	ipAddressesMap := make(map[string][]string)
+	if addrs := extractIPAddresses("master", masterNodeGroup); len(addrs) > 0 {
+		ipAddressesMap["master"] = addrs
+	}
+
+	for _, rawNodeGroup := range cfg.NodeGroups {
+		nodeGroup, err := mapFromAny(rawNodeGroup)
+		if err != nil {
+			return nil, fmt.Errorf("convert nodeGroup: %w", err)
+		}
+
+		ngName, _ := nodeGroup["name"].(string)
+		if ngName == "" {
+			continue
+		}
+
+		if addrs := extractIPAddresses(ngName, nodeGroup); len(addrs) > 0 {
+			ipAddressesMap[ngName] = addrs
+		}
+	}
+
+	if len(ipAddressesMap) > 0 {
+		nodesParameters["ipAddresses"] = ipAddressesMap
+	}
+
+	return map[string]any{
+		"apiVersion": moduleConfigAPIVersion,
+		"kind":       "ModuleConfig",
+		"metadata": map[string]any{
+			"name": dvpModuleName,
+		},
+		"spec": map[string]any{
+			"enabled": true,
+			"version": int(2),
+			"settings": map[string]any{
+				"provider": providerSettings,
+				"storage": map[string]any{
+					"parameters": map[string]any{},
+				},
+				"nodes": map[string]any{
+					"parameters": nodesParameters,
+				},
+			},
+		},
+	}, nil
+}
+
+// buildModuleConfigForHybrid builds the ModuleConfig v2 manifest for the hybrid v1
+// migration path. The shape mirrors the declarative v1->v2 conversion in
+// openapi/conversions/v2.yaml: the legacy provider.namespace becomes
+// provider.parameters.namespace (defaulting to "default"), the legacy top-level
+// zones move into nodes.parameters.zones, kubeconfigDataBase64 is dropped (it now
+// lives in the d8-credentials Secret), and nodes.parameters gets the required
+// layout/sshPublicKey placeholders the admin must review.
+//
+// disabled flags (nodes/storage/ccm) are intentionally omitted: they carry schema
+// defaults, matching createProviderClusterConfigurationResources.
+func buildModuleConfigForHybrid(namespace string, zones []string) map[string]any {
+	if namespace == "" {
+		namespace = "default"
+	}
+
+	nodesParameters := map[string]any{
+		"layout":       "Standard",
+		"sshPublicKey": "ssh-rsa PLACEHOLDER_REPLACE_ME",
+	}
+	if len(zones) > 0 {
+		nodesParameters["zones"] = stringsToAnySlice(zones)
+	}
+
+	return map[string]any{
+		"apiVersion": moduleConfigAPIVersion,
+		"kind":       "ModuleConfig",
+		"metadata": map[string]any{
+			"name": dvpModuleName,
+		},
+		"spec": map[string]any{
+			"enabled": true,
+			"version": int(2),
+			"settings": map[string]any{
+				"provider": map[string]any{
+					"parameters": map[string]any{
+						"namespace": namespace,
+					},
+				},
+				"storage": map[string]any{
+					"parameters": map[string]any{},
+				},
+				"nodes": map[string]any{
+					"parameters": nodesParameters,
+				},
+			},
+		},
+	}
 }
 
 func createMigrationResourcesSecret(input *go_hook.HookInput, resources []any) error {
@@ -249,7 +322,7 @@ func marshalResourcesManifest(resources []any) ([]byte, error) {
 	return buffer.Bytes(), nil
 }
 
-func createNodeGroupResources(name string, nodeGroup map[string]any, master bool, clusterZones *[]string) ([]any, error) {
+func buildNodeGroupAndInstanceClassResources(name string, nodeGroup map[string]any, master bool, clusterZones *[]string) ([]any, error) {
 	instanceClassSpec, ok := nodeGroup["instanceClass"].(map[string]any)
 	if !ok || len(instanceClassSpec) == 0 {
 		return nil, fmt.Errorf("%s.instanceClass cannot be empty", name)

--- a/modules/030-cloud-provider-dvp/hooks/migration.go
+++ b/modules/030-cloud-provider-dvp/hooks/migration.go
@@ -208,6 +208,15 @@ func buildModuleConfigFromPCC(cfg *v1.DvpProviderClusterConfiguration) (map[stri
 //
 // disabled flags (nodes/storage/ccm) are intentionally omitted: they carry schema
 // defaults, matching createProviderClusterConfigurationResources.
+//
+// The legacy provider.namespace, provider.kubeconfigDataBase64 and top-level zones
+// fields are emitted with a null value on purpose. A hybrid cluster already has a
+// stored v1 ModuleConfig, and this bundle is applied by the admin via
+// `kubectl apply -f -`. Without a prior last-applied-configuration annotation,
+// kubectl computes a JSON-merge-patch that only ADDS the new v2 keys, leaving the
+// old v1 keys in place; the merged object then fails v2 validation (provider is
+// additionalProperties:false). JSON-merge-patch treats null as a delete marker, so
+// these tombstones strip the stale v1 keys on apply.
 func buildModuleConfigForHybrid(namespace string, zones []string) map[string]any {
 	if namespace == "" {
 		namespace = "default"
@@ -232,10 +241,13 @@ func buildModuleConfigForHybrid(namespace string, zones []string) map[string]any
 			"version": int(2),
 			"settings": map[string]any{
 				"provider": map[string]any{
+					"namespace":            nil,
+					"kubeconfigDataBase64": nil,
 					"parameters": map[string]any{
 						"namespace": namespace,
 					},
 				},
+				"zones": nil,
 				"storage": map[string]any{
 					"parameters": map[string]any{},
 				},


### PR DESCRIPTION
## Description

Fixed migration of legacy `cloud-provider-dvp` ModuleConfig v1 for hybrid clusters without ProviderClusterConfiguration.

The migration hook now creates migration resources containing `Secret/d8-credentials` from `provider.kubeconfigDataBase64`.

## Why do we need it, and what problem does it solve?

Hybrid DVP clusters may have no PCC during migration and keep credentials only in old ModuleConfig v1. In this case credentials were not migrated, so rendered cloud-provider secrets could get an empty kubeconfig.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cloud-provider-dvp
type: fix
summary: Fixed credentials migration for hybrid clusters with legacy ModuleConfig v1 and no ProviderClusterConfiguration.
impact_level: default
```