### PR TITLE
[docs-builder] fix: serialize docs builder builds

### DIFF
--- a/docs/site/.helm/templates/14-moduleslibrary.yaml
+++ b/docs/site/.helm/templates/14-moduleslibrary.yaml
@@ -96,10 +96,6 @@ spec:
             - name: HUGO_ENVIRONMENT
               value: production
             - name: GOMEMLIMIT
-              value: {{ pluck .Values.web.env .Values.docsBuilder.goMemLimit | first | default .Values.docsBuilder.goMemLimit._default | quote }}
-            # Make hugo aware of the container limits: without these it budgets
-            # in-memory caches from node RAM and sizes worker pools from node CPUs,
-            # both far above what the container is allotted → OOM (see values.yaml).
             - name: HUGO_MEMORYLIMIT
               value: {{ pluck .Values.web.env .Values.docsBuilder.hugoMemoryLimit | first | default .Values.docsBuilder.hugoMemoryLimit._default | quote }}
             - name: HUGO_NUMWORKERMULTIPLIER

--- a/docs/site/.helm/templates/14-moduleslibrary.yaml
+++ b/docs/site/.helm/templates/14-moduleslibrary.yaml
@@ -95,9 +95,6 @@ spec:
           env:
             - name: HUGO_ENVIRONMENT
               value: production
-            # Soft memory limit for the Go runtime: makes the GC collect before the
-            # heap overshoots the cgroup memory limit, which otherwise OOM-kills the
-            # builder during a full hugo rebuild.
             - name: GOMEMLIMIT
               value: {{ pluck .Values.web.env .Values.docsBuilder.goMemLimit | first | default .Values.docsBuilder.goMemLimit._default | quote }}
             - name: POD_IP

--- a/docs/site/.helm/templates/14-moduleslibrary.yaml
+++ b/docs/site/.helm/templates/14-moduleslibrary.yaml
@@ -96,6 +96,7 @@ spec:
             - name: HUGO_ENVIRONMENT
               value: production
             - name: GOMEMLIMIT
+              value: {{ pluck .Values.web.env .Values.docsBuilder.goMemLimit | first | default .Values.docsBuilder.goMemLimit._default | quote }}
             - name: HUGO_MEMORYLIMIT
               value: {{ pluck .Values.web.env .Values.docsBuilder.hugoMemoryLimit | first | default .Values.docsBuilder.hugoMemoryLimit._default | quote }}
             - name: HUGO_NUMWORKERMULTIPLIER

--- a/docs/site/.helm/templates/14-moduleslibrary.yaml
+++ b/docs/site/.helm/templates/14-moduleslibrary.yaml
@@ -95,6 +95,11 @@ spec:
           env:
             - name: HUGO_ENVIRONMENT
               value: production
+            # Soft memory limit for the Go runtime: makes the GC collect before the
+            # heap overshoots the cgroup memory limit, which otherwise OOM-kills the
+            # builder during a full hugo rebuild.
+            - name: GOMEMLIMIT
+              value: {{ pluck .Values.web.env .Values.docsBuilder.goMemLimit | first | default .Values.docsBuilder.goMemLimit._default | quote }}
             - name: POD_IP
               valueFrom:
                 fieldRef:

--- a/docs/site/.helm/templates/14-moduleslibrary.yaml
+++ b/docs/site/.helm/templates/14-moduleslibrary.yaml
@@ -97,6 +97,13 @@ spec:
               value: production
             - name: GOMEMLIMIT
               value: {{ pluck .Values.web.env .Values.docsBuilder.goMemLimit | first | default .Values.docsBuilder.goMemLimit._default | quote }}
+            # Make hugo aware of the container limits: without these it budgets
+            # in-memory caches from node RAM and sizes worker pools from node CPUs,
+            # both far above what the container is allotted → OOM (see values.yaml).
+            - name: HUGO_MEMORYLIMIT
+              value: {{ pluck .Values.web.env .Values.docsBuilder.hugoMemoryLimit | first | default .Values.docsBuilder.hugoMemoryLimit._default | quote }}
+            - name: HUGO_NUMWORKERMULTIPLIER
+              value: {{ pluck .Values.web.env .Values.docsBuilder.hugoNumWorkerMultiplier | first | default .Values.docsBuilder.hugoNumWorkerMultiplier._default | quote }}
             - name: POD_IP
               valueFrom:
                 fieldRef:

--- a/docs/site/.helm/values.yaml
+++ b/docs/site/.helm/values.yaml
@@ -52,19 +52,12 @@ docsBuilder:
     web-stage: "3600MiB"
     web-test: "3600MiB"
     web-test2: "3600MiB"
-  # HUGO_MEMORYLIMIT (in GB) caps hugo's in-memory cache budget. Hugo otherwise
-  # defaults it to node_RAM/4 (not cgroup-aware) and retains that much cache as
-  # live heap, which GOMEMLIMIT/GC cannot reclaim, so RSS blows past the container
-  # limit and gets OOM-killed. Keep it ~50% of the builder memory limit.
   hugoMemoryLimit:
     _default: "1"
     web-production: "2"
     web-stage: "2"
     web-test: "2"
     web-test2: "2"
-  # HUGO_NUMWORKERMULTIPLIER caps hugo's render/worker pools. Hugo otherwise sizes
-  # them from the node's CPU count (not cgroup/GOMAXPROCS-aware), keeping far more
-  # pages in flight than the builder's tiny CPU budget, which inflates peak RSS.
   hugoNumWorkerMultiplier:
     _default: "2"
 

--- a/docs/site/.helm/values.yaml
+++ b/docs/site/.helm/values.yaml
@@ -46,10 +46,6 @@ docsBuilder:
   highAvailability:
     _default: false
     web-production: true
-  # Soft memory limit (GOMEMLIMIT) for the builder's Go runtime. Kept a bit below
-  # resources.limits.memory.moduleslibrary.builder so the GC runs aggressively as
-  # the heap approaches the cgroup hard limit instead of overshooting it and being
-  # OOM-killed. Must be updated together with that limit.
   goMemLimit:
     _default: "1800MiB"
     web-production: "3600MiB"

--- a/docs/site/.helm/values.yaml
+++ b/docs/site/.helm/values.yaml
@@ -52,6 +52,21 @@ docsBuilder:
     web-stage: "3600MiB"
     web-test: "3600MiB"
     web-test2: "3600MiB"
+  # HUGO_MEMORYLIMIT (in GB) caps hugo's in-memory cache budget. Hugo otherwise
+  # defaults it to node_RAM/4 (not cgroup-aware) and retains that much cache as
+  # live heap, which GOMEMLIMIT/GC cannot reclaim, so RSS blows past the container
+  # limit and gets OOM-killed. Keep it ~50% of the builder memory limit.
+  hugoMemoryLimit:
+    _default: "1"
+    web-production: "2"
+    web-stage: "2"
+    web-test: "2"
+    web-test2: "2"
+  # HUGO_NUMWORKERMULTIPLIER caps hugo's render/worker pools. Hugo otherwise sizes
+  # them from the node's CPU count (not cgroup/GOMAXPROCS-aware), keeping far more
+  # pages in flight than the builder's tiny CPU budget, which inflates peak RSS.
+  hugoNumWorkerMultiplier:
+    _default: "2"
 
 vpa:
   updateMode:

--- a/docs/site/.helm/values.yaml
+++ b/docs/site/.helm/values.yaml
@@ -46,6 +46,16 @@ docsBuilder:
   highAvailability:
     _default: false
     web-production: true
+  # Soft memory limit (GOMEMLIMIT) for the builder's Go runtime. Kept a bit below
+  # resources.limits.memory.moduleslibrary.builder so the GC runs aggressively as
+  # the heap approaches the cgroup hard limit instead of overshooting it and being
+  # OOM-killed. Must be updated together with that limit.
+  goMemLimit:
+    _default: "1800MiB"
+    web-production: "3600MiB"
+    web-stage: "3600MiB"
+    web-test: "3600MiB"
+    web-test2: "3600MiB"
 
 vpa:
   updateMode:

--- a/docs/site/backends/docs-builder/internal/docs/build.go
+++ b/docs/site/backends/docs-builder/internal/docs/build.go
@@ -31,6 +31,9 @@ import (
 )
 
 func (svc *Service) Build() error {
+	svc.buildMu.Lock()
+	defer svc.buildMu.Unlock()
+
 	start := time.Now()
 	status := "ok"
 	defer func() {

--- a/docs/site/backends/docs-builder/internal/docs/build.go
+++ b/docs/site/backends/docs-builder/internal/docs/build.go
@@ -50,6 +50,10 @@ func (svc *Service) Build() error {
 		return fmt.Errorf("hugo build: %w", err)
 	}
 
+	syncer := fsync.NewSyncer()
+	syncer.NoChmod = true
+	syncer.NoTimes = true
+
 	for _, lang := range []string{"ru", "en"} {
 		// Sync modules folder
 		glob := filepath.Join(svc.destDir, "public", lang, "modules/*")
@@ -58,13 +62,9 @@ func (svc *Service) Build() error {
 			return fmt.Errorf("clear %s: %w", svc.destDir, err)
 		}
 
-		syncer := fsync.NewSyncer()
-		syncer.NoChmod = true
-		syncer.NoTimes = true
-
 		oldLocation := filepath.Join(svc.baseDir, "public", lang, "modules")
 		newLocation := filepath.Join(svc.destDir, "public", lang, "modules")
-		err = syncer.Sync(newLocation, oldLocation)
+		err = syncDir(syncer, oldLocation, newLocation)
 		if err != nil {
 			return fmt.Errorf("move %s to %s: %w", oldLocation, newLocation, err)
 		}
@@ -78,7 +78,7 @@ func (svc *Service) Build() error {
 
 		searchOldLocation := filepath.Join(svc.baseDir, "public", lang, "search")
 		searchNewLocation := filepath.Join(svc.destDir, "public", lang, "search")
-		err = syncer.Sync(searchNewLocation, searchOldLocation)
+		err = syncDir(syncer, searchOldLocation, searchNewLocation)
 		if err != nil {
 			return fmt.Errorf("move %s to %s: %w", searchOldLocation, searchNewLocation, err)
 		}
@@ -155,6 +155,23 @@ func (svc *Service) parseModulePath(modulePath string) ( /*moduleName*/ string /
 	}
 
 	return s[len(s)-2], s[len(s)-1]
+}
+
+// syncDir mirrors src into dst. If src does not exist, it is treated as an
+// empty source and the sync is skipped: Hugo does not create an output
+// directory for a language that has no module or search pages, and the
+// preceding removeGlob has already cleared any stale content in dst. Erroring
+// out on a missing source would fail the whole build in that legitimate case.
+func syncDir(syncer *fsync.Syncer, src, dst string) error {
+	if _, err := os.Stat(src); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+
+		return fmt.Errorf("stat %s: %w", src, err)
+	}
+
+	return syncer.Sync(dst, src)
 }
 
 func removeGlob(path string) error {

--- a/docs/site/backends/docs-builder/internal/docs/build_test.go
+++ b/docs/site/backends/docs-builder/internal/docs/build_test.go
@@ -15,8 +15,11 @@
 package docs
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/spf13/fsync"
 
 	"github.com/deckhouse/deckhouse/pkg/log"
 )
@@ -57,6 +60,66 @@ func TestGetModulePath(t *testing.T) {
 				t.Error("unexpected result", got)
 			}
 		})
+	}
+}
+
+func TestSyncDirMissingSource(t *testing.T) {
+	syncer := fsync.NewSyncer()
+	dst := filepath.Join(t.TempDir(), "dst")
+
+	// A missing source is a legitimate case (Hugo emits no output dir for a
+	// language with no pages): syncDir must return nil and not create dst.
+	if err := syncDir(syncer, filepath.Join(t.TempDir(), "does-not-exist"), dst); err != nil {
+		t.Fatalf("expected nil error for missing source, got %v", err)
+	}
+
+	if _, err := os.Stat(dst); !os.IsNotExist(err) {
+		t.Fatalf("expected dst not to be created, stat err = %v", err)
+	}
+}
+
+func TestSyncDirCopiesExistingSource(t *testing.T) {
+	syncer := fsync.NewSyncer()
+	src := filepath.Join(t.TempDir(), "src")
+	dst := filepath.Join(t.TempDir(), "dst")
+
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "index.html"), []byte("hi"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := syncDir(syncer, src, dst); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dst, "index.html"))
+	if err != nil {
+		t.Fatalf("expected file mirrored to dst: %v", err)
+	}
+	if string(got) != "hi" {
+		t.Fatalf("unexpected content %q", got)
+	}
+}
+
+func TestSyncDirStatError(t *testing.T) {
+	syncer := fsync.NewSyncer()
+	base := t.TempDir()
+
+	// Reference a path *under* a regular file so os.Stat fails with ENOTDIR,
+	// which is not IsNotExist and therefore must be surfaced, not swallowed.
+	file := filepath.Join(base, "file")
+	if err := os.WriteFile(file, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := syncDir(syncer, filepath.Join(file, "child"), filepath.Join(base, "dst"))
+	if err == nil {
+		t.Fatal("expected error for non-NotExist stat failure, got nil")
+	}
+	if os.IsNotExist(err) {
+		t.Fatalf("expected a non-NotExist stat error to be surfaced, got %v", err)
 	}
 }
 

--- a/docs/site/backends/docs-builder/internal/docs/service.go
+++ b/docs/site/backends/docs-builder/internal/docs/service.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -47,6 +48,12 @@ type Service struct {
 	destDir              string
 	isReady              atomic.Bool
 	channelMappingEditor *channelMappingEditor
+
+	// buildMu serializes Build() calls: baseDir is a shared, on-disk Hugo
+	// working tree, and hugo.Build() gives every call its own in-memory
+	// site model, so concurrent builds both corrupt each other's output
+	// files and multiply memory use per concurrent call.
+	buildMu sync.Mutex
 
 	logger  *log.Logger
 	metrics *metricsstorage.MetricStorage

--- a/modules/810-documentation/templates/deployment.yaml
+++ b/modules/810-documentation/templates/deployment.yaml
@@ -73,9 +73,6 @@ spec:
         env:
           - name: HUGO_ENVIRONMENT
             value: production
-          # Soft memory limit for the Go runtime: makes the GC run more
-          # aggressively as the heap approaches the limit, keeping peak RSS just
-          # under the VPA maxAllowed (2Gi) so a large hugo build is not OOM-killed.
           - name: GOMEMLIMIT
             value: "1800MiB"
           - name: POD_IP

--- a/modules/810-documentation/templates/deployment.yaml
+++ b/modules/810-documentation/templates/deployment.yaml
@@ -73,6 +73,11 @@ spec:
         env:
           - name: HUGO_ENVIRONMENT
             value: production
+          # Soft memory limit for the Go runtime: makes the GC run more
+          # aggressively as the heap approaches the limit, keeping peak RSS just
+          # under the VPA maxAllowed (2Gi) so a large hugo build is not OOM-killed.
+          - name: GOMEMLIMIT
+            value: "1800MiB"
           - name: POD_IP
             valueFrom:
               fieldRef:

--- a/modules/810-documentation/templates/deployment.yaml
+++ b/modules/810-documentation/templates/deployment.yaml
@@ -75,10 +75,6 @@ spec:
             value: production
           - name: GOMEMLIMIT
             value: "1800MiB"
-          # Make hugo aware of the container limits: without these it budgets
-          # in-memory caches from node RAM (node_RAM/4) and sizes worker pools from
-          # the node's CPU count, both far above this container's allotment → OOM.
-          # HUGO_MEMORYLIMIT (GB) stays below GOMEMLIMIT — it bounds only hugo caches.
           - name: HUGO_MEMORYLIMIT
             value: "1"
           - name: HUGO_NUMWORKERMULTIPLIER

--- a/modules/810-documentation/templates/deployment.yaml
+++ b/modules/810-documentation/templates/deployment.yaml
@@ -75,6 +75,14 @@ spec:
             value: production
           - name: GOMEMLIMIT
             value: "1800MiB"
+          # Make hugo aware of the container limits: without these it budgets
+          # in-memory caches from node RAM (node_RAM/4) and sizes worker pools from
+          # the node's CPU count, both far above this container's allotment → OOM.
+          # HUGO_MEMORYLIMIT (GB) stays below GOMEMLIMIT — it bounds only hugo caches.
+          - name: HUGO_MEMORYLIMIT
+            value: "1"
+          - name: HUGO_NUMWORKERMULTIPLIER
+            value: "2"
           - name: POD_IP
             valueFrom:
               fieldRef:

--- a/modules/810-documentation/templates/vertical-pod-autoscaler.yaml
+++ b/modules/810-documentation/templates/vertical-pod-autoscaler.yaml
@@ -37,6 +37,9 @@ spec:
         {{- include "builder_resources" . | nindent 8 }}
       maxAllowed:
         cpu: 200m
-        memory: 500Mi
+        # A full hugo rebuild covers every external module's docs at once, so peak
+        # RSS scales with the number of modules. 500Mi was too low and caused OOM
+        # kills; GOMEMLIMIT on the container keeps the Go heap just under this cap.
+        memory: 2Gi
     {{- include "helm_lib_vpa_kube_rbac_proxy_resources" . | nindent 4 }}
 {{- end }}

--- a/modules/810-documentation/templates/vertical-pod-autoscaler.yaml
+++ b/modules/810-documentation/templates/vertical-pod-autoscaler.yaml
@@ -37,9 +37,6 @@ spec:
         {{- include "builder_resources" . | nindent 8 }}
       maxAllowed:
         cpu: 200m
-        # A full hugo rebuild covers every external module's docs at once, so peak
-        # RSS scales with the number of modules. 500Mi was too low and caused OOM
-        # kills; GOMEMLIMIT on the container keeps the Go heap just under this cap.
         memory: 2Gi
     {{- include "helm_lib_vpa_kube_rbac_proxy_resources" . | nindent 4 }}
 {{- end }}


### PR DESCRIPTION
## Description

Stabilizes the documentation builder (`docs-builder` / `hugo`), which was crash-looping and getting OOM-killed. The same builder code (`docs/site/backends/docs-builder`) runs in two places, both of which are addressed:

- the in-cluster documentation module (`modules/810-documentation`, namespace `d8-system`);
- the public site `moduleslibrary` deployment (`docs/site`).

The PR bundles three related fixes:

1. Serialize builds. The builder shares a single on-disk hugo working tree, while each build gets its own in-memory site model. Concurrent build requests corrupted each other's output
files and multiplied memory usage. `Service.Build()` is now serialized with a mutex.
2. Skip missing hugo output dirs. Hugo does not create an output directory for a language that has no module/search pages. The post-build sync then failed with `move /app/hugo/public/ru/modules ...: no such file or directory`, which failed the  is now treated as empty and skipped.
3. Fix OOM / make hugo container-aware. The builder was OOM-killed even with a generous 4Gi limit. Root causes:
  - Hugo is not cgroup-aware: without `HUGO_MEMORYLIMIT` it budgets its in-memory caches at `node_RAM/4`, and without `HUGO_NUMWORKERMULTIPLIER` it sizes render/worker pools from the node'sCPU count. On large nodes this is far above the container's allotment. Hugo's caches are live (reachable) heap, so `GOMEMLIMIT/GC` alone cannot reclaim them.
  - The Go heap could also overshoot the limit before `GC`.

Fixes: set `GOMEMLIMIT` (soft cap on the Go heap), `HUGO_MEMORYLIMIT` (hugo cacher limit), and `HUGO_NUMWORKERMULTIPLIER=2` on both builder containers; and raise the module builder's VPA `maxAllowed` memory from 500Mi to 2Gi. All three env vars are read by the hugo runtime, so no image rebuild is required for them to take effect.



## Why do we need it, and what problem does it solve?

The documentation builder was stuck in an OOM/restart loop, which caused user-visible symptoms: module documentation not switching to the RU version, and the `documentation` / `moduleslibrary` pods restarting repeatedly. This PR fixes the build failures (data race, missing output dirs) and the memory blow-up (hugo over-allocating relative to the container limits) that drove the restarts.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: Fix serialize docs builder builds.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
