### PR TITLE
[cert-manager] Investigate stale HTTP-01 solver resources 

### DIFF
--- a/modules/101-cert-manager/hooks/cleanup_stale_http01_solver_pods.go
+++ b/modules/101-cert-manager/hooks/cleanup_stale_http01_solver_pods.go
@@ -94,6 +94,10 @@ func applySolverPodFilter(obj *unstructured.Unstructured) (go_hook.FilterResult,
 	}, nil
 }
 
+// cleanupStaleHTTP01SolverPods removes terminal HTTP-01 solver pods left behind when
+// cert-manager treats existing solver pods as valid without checking pod phase.
+// Orphaned Challenges and solver Ingress resources after publicDomainTemplate or
+// clusterDomain changes are tracked separately.
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	Queue: internal.Queue("cleanup-stale-http01-solver-pods"),
 	Settings: &go_hook.HookConfigSettings{
@@ -160,3 +164,6 @@ func cleanupStaleHTTP01SolverPods(ctx context.Context, input *go_hook.HookInput)
 
 	return nil
 }
+
+// Orphaned Challenges and solver Ingress after publicDomainTemplate or clusterDomain
+// changes are tracked in fix/cert-manager-stale-http01-solver-domain-change.


### PR DESCRIPTION
…n change

Trigger CI image build for khisamov-cloud repro. Orphaned Challenge/Ingress on old domain after publicDomainTemplate migration is a separate issue from terminal solver pod cleanup after node reboot.

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
