### PR TITLE
[docs] hardened migrated modules flow docs fix

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -926,28 +926,7 @@ alerts:
       moduleUrl: 340-monitoring-deckhouse
       module: monitoring-deckhouse
       edition: ce
-      description: |
-        Deckhouse configuration contains errors.
-
-        Steps to troubleshoot:
-
-        1. Check Deckhouse logs by running the following command:
-
-           ```bash
-           d8 k -n d8-system logs -f -l app=deckhouse
-           ```
-
-        1. Edit the Deckhouse global configuration:
-
-           ```bash
-           d8 k edit mc global
-           ```
-
-           Or edit configuration of a specific module:
-
-           ```bash
-           d8 k edit mc <MODULE_NAME>
-           ```
+      description: "Deckhouse configuration contains errors.\n\nSteps to troubleshoot:\n\n1. Check Deckhouse logs by running the following command:\n\n   ```bash\n   d8 k -n d8-system logs -f -l app=deckhouse\n   ```\n\n1. Edit the Deckhouse global configuration:\n\n   ```bash\n   d8 k edit mc global\n   ```\n   \n   Or edit configuration of a specific module:\n\n   ```bash\n   d8 k edit mc <MODULE_NAME>\n   ```\n"
       summary: |
         Deckhouse configuration is invalid.
       severity: "5"
@@ -1154,16 +1133,7 @@ alerts:
       moduleUrl: 340-monitoring-deckhouse
       module: monitoring-deckhouse
       edition: ce
-      description: |
-        Initial config for module {{ $labels.module }} is not valid.
-
-        You can get more details via
-
-        ```bash
-        d8 k get mr -l module={{ $labels.module }}
-        ```
-
-        Provided error: {{ $labels.error }}
+      description: "Initial config for module {{ $labels.module }} is not valid. \n\nYou can get more details via\n\n```bash\nd8 k get mr -l module={{ $labels.module }}\n```\n\nProvided error: {{ $labels.error }}\n"
       summary: |
         Module configuration failed for module {{ $labels.module }}.
       severity: "5"
@@ -1249,24 +1219,7 @@ alerts:
       moduleUrl: 340-monitoring-deckhouse
       module: monitoring-deckhouse
       edition: ce
-      description: |
-        Deckhouse has detected an error in the client-go informer, possibly due to connection issues with the API server.
-
-        Steps to investigate:
-
-        1. Check Deckhouse logs for more information by running:
-
-           ```bash
-           d8 k -n d8-system logs deploy/deckhouse | grep error | grep -i watch
-           ```
-
-        1. This alert attempts to detect a correlation between the faulty snapshot invalidation and API server connection errors, specifically for the `handle-node-template` hook in the `node-manager` module.
-
-           To compare the snapshot with the actual node objects for this hook, run the following command:
-
-           ```bash
-           diff -u <(d8 k get nodes -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}'|sort) <(d8 k -n d8-system exec svc/deckhouse-leader -c deckhouse -- deckhouse-controller module snapshots node-manager -o json | jq '."040-node-manager/hooks/handle_node_templates.go"' | jq '.nodes.snapshot[] | .filterResult.Name' -r | sort)
-           ```
+      description: "Deckhouse has detected an error in the client-go informer, possibly due to connection issues with the API server.\n\nSteps to investigate:\n\n1. Check Deckhouse logs for more information by running:\n\n   ```bash\n   d8 k -n d8-system logs deploy/deckhouse | grep error | grep -i watch\n   ```\n\n1. This alert attempts to detect a correlation between the faulty snapshot invalidation and API server connection errors, specifically for the `handle-node-template` hook in the `node-manager` module.\n   \n   To compare the snapshot with the actual node objects for this hook, run the following command:\n\n   ```bash\n   diff -u <(d8 k get nodes -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}'|sort) <(d8 k -n d8-system exec svc/deckhouse-leader -c deckhouse -- deckhouse-controller module snapshots node-manager -o json | jq '.\"040-node-manager/hooks/handle_node_templates.go\"' | jq '.nodes.snapshot[] | .filterResult.Name' -r | sort)\n   ```\n"
       summary: |
         Possible API server connection error in the client-go informer.
       severity: "5"

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -926,7 +926,28 @@ alerts:
       moduleUrl: 340-monitoring-deckhouse
       module: monitoring-deckhouse
       edition: ce
-      description: "Deckhouse configuration contains errors.\n\nSteps to troubleshoot:\n\n1. Check Deckhouse logs by running the following command:\n\n   ```bash\n   d8 k -n d8-system logs -f -l app=deckhouse\n   ```\n\n1. Edit the Deckhouse global configuration:\n\n   ```bash\n   d8 k edit mc global\n   ```\n   \n   Or edit configuration of a specific module:\n\n   ```bash\n   d8 k edit mc <MODULE_NAME>\n   ```\n"
+      description: |
+        Deckhouse configuration contains errors.
+
+        Steps to troubleshoot:
+
+        1. Check Deckhouse logs by running the following command:
+
+           ```bash
+           d8 k -n d8-system logs -f -l app=deckhouse
+           ```
+
+        1. Edit the Deckhouse global configuration:
+
+           ```bash
+           d8 k edit mc global
+           ```
+
+           Or edit configuration of a specific module:
+
+           ```bash
+           d8 k edit mc <MODULE_NAME>
+           ```
       summary: |
         Deckhouse configuration is invalid.
       severity: "5"
@@ -1133,7 +1154,16 @@ alerts:
       moduleUrl: 340-monitoring-deckhouse
       module: monitoring-deckhouse
       edition: ce
-      description: "Initial config for module {{ $labels.module }} is not valid. \n\nYou can get more details via\n\n```bash\nd8 k get mr -l module={{ $labels.module }}\n```\n\nProvided error: {{ $labels.error }}\n"
+      description: |
+        Initial config for module {{ $labels.module }} is not valid.
+
+        You can get more details via
+
+        ```bash
+        d8 k get mr -l module={{ $labels.module }}
+        ```
+
+        Provided error: {{ $labels.error }}
       summary: |
         Module configuration failed for module {{ $labels.module }}.
       severity: "5"
@@ -1219,7 +1249,24 @@ alerts:
       moduleUrl: 340-monitoring-deckhouse
       module: monitoring-deckhouse
       edition: ce
-      description: "Deckhouse has detected an error in the client-go informer, possibly due to connection issues with the API server.\n\nSteps to investigate:\n\n1. Check Deckhouse logs for more information by running:\n\n   ```bash\n   d8 k -n d8-system logs deploy/deckhouse | grep error | grep -i watch\n   ```\n\n1. This alert attempts to detect a correlation between the faulty snapshot invalidation and API server connection errors, specifically for the `handle-node-template` hook in the `node-manager` module.\n   \n   To compare the snapshot with the actual node objects for this hook, run the following command:\n\n   ```bash\n   diff -u <(d8 k get nodes -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}'|sort) <(d8 k -n d8-system exec svc/deckhouse-leader -c deckhouse -- deckhouse-controller module snapshots node-manager -o json | jq '.\"040-node-manager/hooks/handle_node_templates.go\"' | jq '.nodes.snapshot[] | .filterResult.Name' -r | sort)\n   ```\n"
+      description: |
+        Deckhouse has detected an error in the client-go informer, possibly due to connection issues with the API server.
+
+        Steps to investigate:
+
+        1. Check Deckhouse logs for more information by running:
+
+           ```bash
+           d8 k -n d8-system logs deploy/deckhouse | grep error | grep -i watch
+           ```
+
+        1. This alert attempts to detect a correlation between the faulty snapshot invalidation and API server connection errors, specifically for the `handle-node-template` hook in the `node-manager` module.
+
+           To compare the snapshot with the actual node objects for this hook, run the following command:
+
+           ```bash
+           diff -u <(d8 k get nodes -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}'|sort) <(d8 k -n d8-system exec svc/deckhouse-leader -c deckhouse -- deckhouse-controller module snapshots node-manager -o json | jq '."040-node-manager/hooks/handle_node_templates.go"' | jq '.nodes.snapshot[] | .filterResult.Name' -r | sort)
+           ```
       summary: |
         Possible API server connection error in the client-go informer.
       severity: "5"
@@ -3932,26 +3979,34 @@ alerts:
       module: monitoring-deckhouse
       edition: ce
       description: |
-        Module `{{ $labels.module }}` specified in DeckhouseRelease was moved to an external source and is available in a ModuleSource registry, but it has not been downloaded yet (no Deployed ModuleRelease). DeckhouseRelease will be locked until the module is pre-downloaded.
+        Module `{{ $labels.module }}` specified in DeckhouseRelease was moved to an external source and is available in a ModuleSource registry, but it has not been downloaded yet (no deployed ModuleRelease exists). DeckhouseRelease will be locked until the module is downloaded.
 
-        This is usually transient: the module source controller needs time to pull the module from the registry. If the alert persists, this may indicate:
-        - The module's update policy or ModuleSource is misconfigured, so the module is never pulled.
-        - There is a network issue preventing the module download.
+        This alert is usually temporary while the module source controller downloads the module from the registry. If the alert persists, this may indicate:
 
-        To investigate, run the following commands:
+        - The module's update policy or ModuleSource is misconfigured, preventing the module from being downloaded.
+        - A network issue is preventing the module from being downloaded.
 
-        ```bash
-        # Check the ModuleRelease objects for the module
-        d8 k get mr -l module={{ $labels.module }}
+        To investigate the issue, do the following:
 
-        # Check ModuleSource status
-        d8 k get modulesources
+        - Check the ModuleRelease objects for the module:
 
-        # Check Deckhouse logs for more details
-        d8 k -n d8-system logs -f -l app=deckhouse
-        ```
+          ```bash
+          d8 k get mr -l module={{ $labels.module }}
+          ```
+
+        - Check the configured ModuleSources:
+
+          ```bash
+          d8 k get modulesources
+          ```
+
+        - Check the `deckhouse` logs for more details:
+
+          ```bash
+          d8 k -n d8-system logs -f -l app=deckhouse
+          ```
       summary: |
-        Migrated module {{ $labels.module }} is not downloaded yet.
+        Migrated module {{ $labels.module }} has not been downloaded yet.
       severity: "6"
       markupFormat: markdown
     - name: DeckhouseMigratedModuleNotFound
@@ -3960,33 +4015,41 @@ alerts:
       module: monitoring-deckhouse
       edition: ce
       description: |
-        Module `{{ $labels.module }}` specified in DeckhouseRelease was moved to external source and not found in any available ModuleSource registry. DeckhouseRelease will be lock until found module in any available ModuleSource.
+        Module `{{ $labels.module }}` specified in DeckhouseRelease was moved to an external source and was not found in any available ModuleSource registry. DeckhouseRelease will be locked until the module becomes available in one of the configured ModuleSource registries.
 
         This may indicate:
-        - The module source registry is not properly configured.
+
+        - A ModuleSource registry is misconfigured.
         - The module has not been published to the registry yet.
-        - There is a network issue preventing access to the registry.
+        - A network issue is preventing access to the registry.
 
-        Please check:
-        1. ModuleSource configurations: `d8 k get modulesources`.
-        2. Registry accessibility and credentials.
-        3. Module availability in the configured registries.
+        To investigate the issue, do the following:
 
-        To investigate, run the following commands:
+        - Check the configured ModuleSources:
 
-        ```bash
-        # Check ModuleSource status
-        d8 k get modulesources
+          ```bash
+          d8 k get modulesources
+          ```
 
-        # Check available modules in all sources
-        d8 k -n d8-system exec -it deployment/deckhouse -c deckhouse -- deckhouse-controller registry get sources
-        d8 k -n d8-system exec -it deployment/deckhouse -c deckhouse -- deckhouse-controller registry get modules <source_name>
+        - List the available module sources:
 
-        # Check Deckhouse logs for more details
-        d8 k -n d8-system logs -f -l app=deckhouse
-        ```
+          ```bash
+          d8 k -n d8-system exec -it deployment/deckhouse -c deckhouse -- deckhouse-controller registry get sources
+          ```
+
+        - List the modules available in a specific source:
+
+          ```bash
+          d8 k -n d8-system exec -it deployment/deckhouse -c deckhouse -- deckhouse-controller registry get modules <source_name>
+          ```
+
+        - Check the `deckhouse` logs for more details:
+
+          ```bash
+          d8 k -n d8-system logs -f -l app=deckhouse
+          ```
       summary: |
-        Migrated module {{ $labels.module }} not found in registry.
+        Migrated module {{ $labels.module }} was not found in any ModuleSource registry.
       severity: "6"
       markupFormat: markdown
     - name: DeckhouseModuleUpdatingFailedBrokenSequence

--- a/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
+++ b/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
@@ -580,33 +580,41 @@
       plk_create_group_if_not_exists__d8_deckhouse_malfunctioning: "D8DeckhouseMalfunctioning,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
       plk_grouped_by__d8_deckhouse_malfunctioning: "D8DeckhouseMalfunctioning,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
       plk_labels_as_annotations: "module"
-      summary: Migrated module {{ $labels.module }} not found in registry.
+      summary: Migrated module {{ $labels.module }} was not found in any ModuleSource registry.
       description: |
-        Module `{{ $labels.module }}` specified in DeckhouseRelease was moved to external source and not found in any available ModuleSource registry. DeckhouseRelease will be lock until found module in any available ModuleSource.
-        
+        Module `{{ $labels.module }}` specified in DeckhouseRelease was moved to an external source and was not found in any available ModuleSource registry. DeckhouseRelease will be locked until the module becomes available in one of the configured ModuleSource registries.
+
         This may indicate:
-        - The module source registry is not properly configured.
+
+        - A ModuleSource registry is misconfigured.
         - The module has not been published to the registry yet.
-        - There is a network issue preventing access to the registry.
-        
-        Please check:
-        1. ModuleSource configurations: `d8 k get modulesources`.
-        2. Registry accessibility and credentials.
-        3. Module availability in the configured registries.
-        
-        To investigate, run the following commands:
-        
-        ```bash
-        # Check ModuleSource status
-        d8 k get modulesources
-        
-        # Check available modules in all sources
-        d8 k -n d8-system exec -it deployment/deckhouse -c deckhouse -- deckhouse-controller registry get sources
-        d8 k -n d8-system exec -it deployment/deckhouse -c deckhouse -- deckhouse-controller registry get modules <source_name>
-        
-        # Check Deckhouse logs for more details
-        d8 k -n d8-system logs -f -l app=deckhouse
-        ```
+        - A network issue is preventing access to the registry.
+
+        To investigate the issue, do the following:
+
+        - Check the configured ModuleSources:
+
+          ```bash
+          d8 k get modulesources
+          ```
+
+        - List the available module sources:
+
+          ```bash
+          d8 k -n d8-system exec -it deployment/deckhouse -c deckhouse -- deckhouse-controller registry get sources
+          ```
+
+        - List the modules available in a specific source:
+
+          ```bash
+          d8 k -n d8-system exec -it deployment/deckhouse -c deckhouse -- deckhouse-controller registry get modules <source_name>
+          ```
+
+        - Check the `deckhouse` logs for more details:
+
+          ```bash
+          d8 k -n d8-system logs -f -l app=deckhouse
+          ```
   - alert: DeckhouseMigratedModuleNotDownloaded
     expr: d8_migrated_module_not_downloaded == 1
     for: 10m
@@ -621,26 +629,34 @@
       plk_create_group_if_not_exists__d8_deckhouse_malfunctioning: "D8DeckhouseMalfunctioning,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
       plk_grouped_by__d8_deckhouse_malfunctioning: "D8DeckhouseMalfunctioning,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
       plk_labels_as_annotations: "module"
-      summary: Migrated module {{ $labels.module }} is not downloaded yet.
+      summary: Migrated module {{ $labels.module }} has not been downloaded yet.
       description: |
-        Module `{{ $labels.module }}` specified in DeckhouseRelease was moved to an external source and is available in a ModuleSource registry, but it has not been downloaded yet (no Deployed ModuleRelease). DeckhouseRelease will be locked until the module is pre-downloaded.
+        Module `{{ $labels.module }}` specified in DeckhouseRelease was moved to an external source and is available in a ModuleSource registry, but it has not been downloaded yet (no deployed ModuleRelease exists). DeckhouseRelease will be locked until the module is downloaded.
 
-        This is usually transient: the module source controller needs time to pull the module from the registry. If the alert persists, this may indicate:
-        - The module's update policy or ModuleSource is misconfigured, so the module is never pulled.
-        - There is a network issue preventing the module download.
+        This alert is usually temporary while the module source controller downloads the module from the registry. If the alert persists, this may indicate:
 
-        To investigate, run the following commands:
+        - The module's update policy or ModuleSource is misconfigured, preventing the module from being downloaded.
+        - A network issue is preventing the module from being downloaded.
 
-        ```bash
-        # Check the ModuleRelease objects for the module
-        d8 k get mr -l module={{ $labels.module }}
+        To investigate the issue, do the following:
 
-        # Check ModuleSource status
-        d8 k get modulesources
+        - Check the ModuleRelease objects for the module:
 
-        # Check Deckhouse logs for more details
-        d8 k -n d8-system logs -f -l app=deckhouse
-        ```
+          ```bash
+          d8 k get mr -l module={{ $labels.module }}
+          ```
+
+        - Check the configured ModuleSources:
+
+          ```bash
+          d8 k get modulesources
+          ```
+
+        - Check the `deckhouse` logs for more details:
+
+          ```bash
+          d8 k -n d8-system logs -f -l app=deckhouse
+          ```
   - alert: DeckhouseEditionNotFound
     expr: |
       d8_edition_not_found > 0


### PR DESCRIPTION
## Description

This pull request improves the clarity, consistency, and troubleshooting guidance of several Deckhouse monitoring alert descriptions. 

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: chore
summary: Hardened migrated modules flow docs fix.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
