### PR TITLE
[docs] Remove user-authz RBAC change notice in the Release Notes

### DIFF
--- a/docs/documentation/_includes/release-notes/RELEASE-NOTES.md
+++ b/docs/documentation/_includes/release-notes/RELEASE-NOTES.md
@@ -2,12 +2,6 @@
 
 ### Important
 
-- With the `user-authz` module enabled, the permission model for `admin.conf` has been changed.
-  Instead of binding to the built-in `cluster-admin` role, DKP now uses its [managed RBAC model](https://deckhouse.io/modules/control-plane-manager/v1.76/faq.html#rbac-based-admin-access) with more granular permissions.
-  This improves cluster access security. [Emergency access](https://deckhouse.io/modules/control-plane-manager/v1.76/faq.html#break-glass-access) via `super-admin.conf` is still available.
-  **If your cluster uses third-party Kubernetes operators (not part of DKP),
-  make sure to explicitly grant permissions for their CRDs; otherwise, access to those resources will be restricted.**
-
 - The [fencing-agent component](https://deckhouse.io/modules/node-manager/v1.76/cr.html#nodegroup-v1-spec-fencing-mode) of the `node-manager` module now uses a gossip-based protocol ([memberlist](https://github.com/hashicorp/memberlist) library)
   for distributed node health monitoring.
   This reduces the risk of false worker node reboots when the control plane is unavailable or the API server is under heavy load.

--- a/docs/documentation/_includes/release-notes/RELEASE-NOTES_RU.md
+++ b/docs/documentation/_includes/release-notes/RELEASE-NOTES_RU.md
@@ -2,13 +2,6 @@
 
 ### Обратите внимание
 
-- При включённом модуле `user-authz` изменена модель прав для `admin.conf`:
-  вместо привязки к встроенной роли `cluster-admin` используется [управляемая DKP RBAC-модель](https://deckhouse.ru/modules/control-plane-manager/v1.76/faq.html#административный-доступ-на-основе-rbac) с более точечными правами.
-  Это повышает безопасность доступа к кластеру.
-  При этом сохраняется [аварийный доступ](https://deckhouse.ru/modules/control-plane-manager/v1.76/faq.html#аварийный-доступ-break-glass) через `super-admin.conf`.
-  **Если в кластере используются сторонние Kubernetes-операторы (не из DKP), дополнительно выдайте права на их CRD,
-  иначе доступ к таким ресурсам будет ограничен.**
-
 - [Компонент fencing-agent](https://deckhouse.ru/modules/node-manager/v1.76/cr.html#nodegroup-v1-spec-fencing-mode) модуля `node-manager` переведён на gossip-протокол ([библиотека memberlist](https://github.com/hashicorp/memberlist))
   для распределённого мониторинга состояния узлов.
   Это снижает риск ложных перезагрузок worker-узлов при недоступности control plane или высокой нагрузке на API-сервер.


### PR DESCRIPTION
## Description
This pull request removes previous release note entries related to changes in the `user-authz` module's permission model for `admin.conf`.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Remove user-authz RBAC change notice in the Release Notes.
impact_level: low
```
