### PR TITLE
[user-authn] Set the Dex binary version during image build

### DIFF
--- a/modules/150-user-authn/images/dex/werf.inc.yaml
+++ b/modules/150-user-authn/images/dex/werf.inc.yaml
@@ -1,3 +1,4 @@
+{{- $dexVersion := include "get_oss_version_by_id" (list "dex" $ ) }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless
@@ -22,7 +23,7 @@ final: false
 git:
   - url: {{ $.SOURCE_REPO }}/dexidp/dex.git
     to: /src
-    tag: v{{ include "get_oss_version_by_id" (list "dex" $ ) }}
+    tag: v{{ $dexVersion }}
     stageDependencies:
       install:
         - '**/*.go'
@@ -69,8 +70,9 @@ secrets:
 shell:
   install:
     - export GOPROXY=$(cat /run/secrets/GOPROXY) CGO_ENABLED=0 GOOS=linux GOARCH=amd64
+    - export LDFLAGS='-s -w -extldflags=-static -X main.version={{ $dexVersion }}'
     - cd /src
     - |
-      {{- include "image-build.build" (set $ "BuildCommand" `go build -ldflags '-s -w' -ldflags "-extldflags -static" -tags netgo -o dex ./cmd/dex`) | indent 6 }}
+      {{- include "image-build.build" (set $ "BuildCommand" `go build -ldflags "${LDFLAGS}" -tags netgo -o dex ./cmd/dex`) | indent 6 }}
     - chown 64535:64535 dex
     - chmod 0700 dex


### PR DESCRIPTION
## Description

Set the Dex binary version during image build.

## Why do we need it, and what problem does it solve?

Dex logs currently report `dex_version: DEV` because the binary version is not injected at build time. This change sets the version from `oss.yaml`.

## Why do we need it in the patch release (if we do)?

It fixes misleading version reporting in Dex logs for patch releases.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authn
type: fix
summary: Fixed Dex version reporting in logs.
impact_level: low