### PR TITLE
[deckhouse] fix package panic

### DIFF
--- a/deckhouse-controller/internal/packages/modules/module.go
+++ b/deckhouse-controller/internal/packages/modules/module.go
@@ -205,9 +205,9 @@ func (m *Module) GetRuntimeValues() string {
 	runtimeValues := m.getRuntimeValues()
 	marshalled, _ := json.Marshal(runtimeValues)
 
-	marshalledGlobal := m.globalValuesGetter()
+	marshalledGlobal, _ := json.Marshal(m.globalValuesGetter())
 
-	return fmt.Sprintf("Module=%s,Deckhouse=%s", marshalled, marshalledGlobal)
+	return fmt.Sprintf("Module=%s,Platform=%s", marshalled, marshalledGlobal)
 }
 
 // GetName returns the full module identifier.

--- a/deckhouse-controller/internal/packages/runtime/runtime.go
+++ b/deckhouse-controller/internal/packages/runtime/runtime.go
@@ -173,6 +173,23 @@ func New(cli kclient.Client, edition *edition.Edition, moduleManager moduleManag
 		r.moduleDeployer = erofsdeploy.NewDeployer(reg, modulesDir, logger)
 	}
 
+	// Build object patcher with optimized rate limits for batch operations
+	if err := r.buildObjectPatcher(); err != nil {
+		return nil, fmt.Errorf("build object patcher: %w", err)
+	}
+
+	// Build Kubernetes events manager for watching cluster resources
+	if err := r.buildKubeEventsManager(); err != nil {
+		return nil, fmt.Errorf("build kube events manager: %w", err)
+	}
+
+	r.hookEventHandler = hookevent.NewHandler(hookevent.Config{
+		KubeEventsManager: r.kubeEventsManager,
+		ScheduleManager:   r.scheduleManager,
+		TaskBuilder:       r,
+		QueueService:      r.queueService,
+	}, r.logger)
+
 	if err := r.loadGlobal(context.Background()); err != nil {
 		return nil, fmt.Errorf("load global: %w", err)
 	}
@@ -198,23 +215,6 @@ func New(cli kclient.Client, edition *edition.Edition, moduleManager moduleManag
 	if err := r.buildHealthService(); err != nil {
 		return nil, fmt.Errorf("build health service: %w", err)
 	}
-
-	// Build object patcher with optimized rate limits for batch operations
-	if err := r.buildObjectPatcher(); err != nil {
-		return nil, fmt.Errorf("build object patcher: %w", err)
-	}
-
-	// Build Kubernetes events manager for watching cluster resources
-	if err := r.buildKubeEventsManager(); err != nil {
-		return nil, fmt.Errorf("build kube events manager: %w", err)
-	}
-
-	r.hookEventHandler = hookevent.NewHandler(hookevent.Config{
-		KubeEventsManager: r.kubeEventsManager,
-		ScheduleManager:   r.scheduleManager,
-		TaskBuilder:       r,
-		QueueService:      r.queueService,
-	}, r.logger)
 
 	if err := r.registerDebugServer("/tmp/deckhouse-debug.socket"); err != nil {
 		return nil, fmt.Errorf("register debug server: %w", err)

--- a/deckhouse-controller/internal/packages/runtime/runtime.go
+++ b/deckhouse-controller/internal/packages/runtime/runtime.go
@@ -173,6 +173,17 @@ func New(cli kclient.Client, edition *edition.Edition, moduleManager moduleManag
 		r.moduleDeployer = erofsdeploy.NewDeployer(reg, modulesDir, logger)
 	}
 
+	if err := r.loadGlobal(context.Background()); err != nil {
+		return nil, fmt.Errorf("load global: %w", err)
+	}
+
+	// Initialize scheduler with enabling/disabling callbacks
+	r.buildScheduler(cli)
+
+	if err := r.loadEmbedded(context.Background()); err != nil {
+		return nil, fmt.Errorf("load embedded: %w", err)
+	}
+
 	// Build NELM service with its own client and runtime cache for resource monitoring
 	if err := r.buildNelmService(); err != nil {
 		return nil, fmt.Errorf("build nelm service: %w", err)
@@ -204,17 +215,6 @@ func New(cli kclient.Client, edition *edition.Edition, moduleManager moduleManag
 		TaskBuilder:       r,
 		QueueService:      r.queueService,
 	}, r.logger)
-
-	if err := r.loadGlobal(context.Background()); err != nil {
-		return nil, fmt.Errorf("load global: %w", err)
-	}
-
-	// Initialize scheduler with enabling/disabling callbacks
-	r.buildScheduler(cli)
-
-	if err := r.loadEmbedded(context.Background()); err != nil {
-		return nil, fmt.Errorf("load embedded: %w", err)
-	}
 
 	if err := r.registerDebugServer("/tmp/deckhouse-debug.socket"); err != nil {
 		return nil, fmt.Errorf("register debug server: %w", err)


### PR DESCRIPTION
## Description
It fixes panic in nelm monitor service.

## Why do we need it, and what problem does it solve?
Scheduler should be built before nelm monitor service.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Fix panic in nelm monitor service.
impact_level: low
```