### PR TITLE
[chore] update acl patch for 1.36

### DIFF
--- a/modules/000-common/images/kubernetes/patches/1.36/007-namespace-list-acl-filtering.patch
+++ b/modules/000-common/images/kubernetes/patches/1.36/007-namespace-list-acl-filtering.patch
@@ -1,9 +1,470 @@
+diff --git a/pkg/registry/core/namespace/storage/storage.go b/pkg/registry/core/namespace/storage/storage.go
+index e67cedeb15e..1315e000829 100644
+--- a/pkg/registry/core/namespace/storage/storage.go
++++ b/pkg/registry/core/namespace/storage/storage.go
+@@ -18,20 +18,27 @@ package storage
+ 
+ import (
+ 	"context"
++	"errors"
+ 	"fmt"
++	"time"
+ 
+ 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+ 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
+ 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
++	"k8s.io/apimachinery/pkg/fields"
++	"k8s.io/apimachinery/pkg/labels"
+ 	"k8s.io/apimachinery/pkg/runtime"
+ 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+ 	"k8s.io/apimachinery/pkg/watch"
++	"k8s.io/apiserver/pkg/endpoints/filters"
+ 	"k8s.io/apiserver/pkg/registry/generic"
+ 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
+ 	"k8s.io/apiserver/pkg/registry/rest"
+ 	"k8s.io/apiserver/pkg/storage"
+ 	storageerr "k8s.io/apiserver/pkg/storage/errors"
+ 	"k8s.io/apiserver/pkg/util/dryrun"
++	restclient "k8s.io/client-go/rest"
++	"k8s.io/klog/v2"
+ 	api "k8s.io/kubernetes/pkg/apis/core"
+ 	"k8s.io/kubernetes/pkg/printers"
+ 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
+@@ -40,10 +47,45 @@ import (
+ 	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
+ )
+ 
+-// rest implements a RESTStorage for namespaces
++// errCannotListNamespaces / errCannotGetNamespace / errCannotWatchNamespaces
++// are the opaque error messages we surface to clients when ACL filtering is
++// active but cannot decide one way or the other (typically: missing user
++// info in context, or the permission service is unreachable). We never leak
++// the underlying cause to the client — that goes to klog instead.
++var (
++	errCannotListNamespaces  = errors.New("cannot list namespaces")
++	errCannotGetNamespace    = errors.New("cannot get namespace")
++	errCannotWatchNamespaces = errors.New("cannot watch namespaces")
++)
++
++// defaultACLRefreshInterval is the polling cadence the watch path uses to
++// re-fetch a user's accessible-namespace set when no explicit interval was
++// configured. One second balances responsiveness for permission changes
++// against load on the upstream permission service; tune via Option if you
++// need otherwise.
++const defaultACLRefreshInterval = time.Second
++
++// REST implements a RESTStorage for namespaces.
++//
++// When accessibleFetcher is non-nil and the request context carries
++// filters.IsNamespaceFilteringMode (set by the authorization filter for users
++// who lack RBAC for list/get on namespaces but should still see the subset
++// they have *some* access to), List/Get/Watch transparently switch to the
++// ACL-filtered code path. Otherwise the calls fall straight through to the
++// generic registry store, preserving vanilla Kubernetes semantics.
+ type REST struct {
+ 	store  *genericregistry.Store
+ 	status *genericregistry.Store
++
++	// accessibleFetcher resolves a user's accessible-namespace set against
++	// the upstream permission service. nil disables Deckhouse filtering
++	// entirely (vanilla behavior).
++	accessibleFetcher AccessibleNamespaceFetcher
++
++	// aclRefreshInterval controls how often the Watch path re-polls the
++	// fetcher to detect permission changes mid-watch. Coerced to
++	// defaultACLRefreshInterval at construction if non-positive.
++	aclRefreshInterval time.Duration
+ }
+ 
+ // StatusREST implements the REST endpoint for changing the status of a namespace.
+@@ -56,8 +98,73 @@ type FinalizeREST struct {
+ 	store *genericregistry.Store
+ }
+ 
+-// NewREST returns a RESTStorage object that will work against namespaces.
+-func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, *FinalizeREST, error) {
++// restConfig collects the Deckhouse-specific settings supplied to NewREST
++// via functional options. The zero value disables filtering — i.e. plain
++// upstream behavior — which is what NewREST(optsGetter) gives you.
++type restConfig struct {
++	// fetcher is the AccessibleNamespaceFetcher to use directly, when the
++	// caller already has one (typically tests).
++	fetcher AccessibleNamespaceFetcher
++
++	// loopbackConfig, when set, asks NewREST to build a
++	// LoopbackAccessibleNamespaceFetcher itself. If both fetcher and
++	// loopbackConfig are set, fetcher wins.
++	loopbackConfig *restclient.Config
++
++	// refreshInterval overrides defaultACLRefreshInterval for the
++	// watch-path ACL poller.
++	refreshInterval time.Duration
++}
++
++// Option configures the namespace REST storage. Options are applied in
++// order; later options override earlier ones for the same field.
++type Option func(*restConfig)
++
++// WithAccessibleNamespaceFetcher enables Deckhouse ACL filtering with the
++// caller-supplied fetcher. Pass nil to leave filtering disabled.
++func WithAccessibleNamespaceFetcher(f AccessibleNamespaceFetcher) Option {
++	return func(c *restConfig) { c.fetcher = f }
++}
++
++// WithLoopbackFetcher enables Deckhouse ACL filtering by constructing a
++// LoopbackAccessibleNamespaceFetcher from the supplied loopback REST
++// config. Nil config or fetcher-build failure degrades to vanilla
++// behavior with a klog warning — kube-apiserver still boots.
++func WithLoopbackFetcher(cfg *restclient.Config) Option {
++	return func(c *restConfig) { c.loopbackConfig = cfg }
++}
++
++// WithACLRefreshInterval overrides the watch-path ACL polling cadence.
++// Non-positive values fall back to defaultACLRefreshInterval.
++func WithACLRefreshInterval(d time.Duration) Option {
++	return func(c *restConfig) { c.refreshInterval = d }
++}
++
++// NewREST returns a RESTStorage object for namespaces.
++//
++// Called with no options, NewREST(optsGetter) reproduces vanilla upstream
++// behavior — this is what the upstream storage_test.go relies on.
++//
++// Pass WithAccessibleNamespaceFetcher / WithLoopbackFetcher to enable
++// Deckhouse ACL filtering. If a fetcher cannot be built (e.g. malformed
++// loopback config) filtering is silently disabled with a klog warning so
++// the apiserver remains bootstrappable.
++func NewREST(optsGetter generic.RESTOptionsGetter, opts ...Option) (*REST, *StatusREST, *FinalizeREST, error) {
++	var cfg restConfig
++	for _, opt := range opts {
++		opt(&cfg)
++	}
++
++	fetcher := cfg.fetcher
++	if fetcher == nil && cfg.loopbackConfig != nil {
++		f, err := NewLoopbackAccessibleNamespaceFetcher(cfg.loopbackConfig)
++		if err != nil {
++			klog.Warningf("namespace ACL: failed to build loopback accessible-namespace fetcher: %v; filtering disabled", err)
++		} else {
++			fetcher = f
++		}
++	}
++
+ 	store := &genericregistry.Store{
+ 		NewFunc:                   func() runtime.Object { return &api.Namespace{} },
+ 		NewListFunc:               func() runtime.Object { return &api.NamespaceList{} },
+@@ -75,8 +182,8 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, *Finaliz
+ 
+ 		TableConvertor: printerstorage.TableConvertor{TableGenerator: printers.NewTableGenerator().With(printersinternal.AddHandlers)},
+ 	}
+-	options := &generic.StoreOptions{RESTOptions: optsGetter, AttrFunc: namespace.GetAttrs}
+-	if err := store.CompleteWithOptions(options); err != nil {
++	storeOptions := &generic.StoreOptions{RESTOptions: optsGetter, AttrFunc: namespace.GetAttrs}
++	if err := store.CompleteWithOptions(storeOptions); err != nil {
+ 		return nil, nil, nil, err
+ 	}
+ 
+@@ -88,7 +195,18 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, *Finaliz
+ 	finalizeStore.UpdateStrategy = namespace.FinalizeStrategy
+ 	finalizeStore.ResetFieldsStrategy = namespace.FinalizeStrategy
+ 
+-	return &REST{store: store, status: &statusStore}, &StatusREST{store: &statusStore}, &FinalizeREST{store: &finalizeStore}, nil
++	refresh := cfg.refreshInterval
++	if refresh <= 0 {
++		refresh = defaultACLRefreshInterval
++	}
++
++	r := &REST{
++		store:              store,
++		status:             &statusStore,
++		accessibleFetcher:  fetcher,
++		aclRefreshInterval: refresh,
++	}
++	return r, &StatusREST{store: &statusStore}, &FinalizeREST{store: &finalizeStore}, nil
+ }
+ 
+ func (r *REST) NamespaceScoped() bool {
+@@ -114,8 +232,69 @@ func (r *REST) NewList() runtime.Object {
+ 	return r.store.NewList()
+ }
+ 
++// shouldFilter returns true when the request should run through the ACL
++// filtering path. Two preconditions must hold:
++//
++//  1. A fetcher is configured at construction time (Deckhouse mode).
++//  2. The request context was tagged by the authorization filter as
++//     "namespace filtering mode" — i.e. the user was denied by the regular
++//     authorizer chain but the filter chose to bypass the 403 specifically
++//     to let the storage layer return a filtered subset.
++//
++// Without (2), users with full RBAC see vanilla behavior with no extra
++// fetcher round-trips on the hot path.
++func (r *REST) shouldFilter(ctx context.Context) bool {
++	return r.accessibleFetcher != nil && filters.IsNamespaceFilteringMode(ctx)
++}
++
++// List returns a list of namespaces. When ACL filtering is active, the user-
++// supplied selectors are AND-combined with a metadata.name-set membership
++// selector and the request is served via Store.ListPredicate, so all the
++// usual storage-layer machinery (pagination, single-key optimization via
++// MatchesSingle, etc.) keeps working without any post-processing.
+ func (r *REST) List(ctx context.Context, options *metainternalversion.ListOptions) (runtime.Object, error) {
+-	return r.store.List(ctx, options)
++	if !r.shouldFilter(ctx) {
++		return r.store.List(ctx, options)
++	}
++
++	u, err := userFromContext(ctx)
++	if err != nil {
++		klog.V(4).InfoS("namespace ACL: missing user info on List", "err", err)
++		return nil, apierrors.NewForbidden(api.Resource("namespaces"), "", errCannotListNamespaces)
++	}
++
++	names, err := r.accessibleFetcher.FetchAccessibleNamespaces(ctx, u)
++	if err != nil {
++		klog.Warningf("namespace ACL: failed to fetch accessible namespaces for user %q: %v; returning forbidden", u.GetName(), err)
++		return nil, apierrors.NewForbidden(api.Resource("namespaces"), "", errCannotListNamespaces)
++	}
++
++	predicate := r.aclPredicate(options, newAccessibleNamesSelector(namesToSet(names)))
++	out, err := r.store.ListPredicate(ctx, predicate, options)
++	if err != nil {
++		return nil, storageerr.InterpretListError(err, api.Resource("namespaces"))
++	}
++	return out, nil
++}
++
++// aclPredicate builds the SelectionPredicate used by List and Watch in
++// filtering mode. It composes the user-supplied label/field selectors from
++// options with our metadata.name set selector via fields.AndSelectors and
++// hands the result to the registered PredicateFunc, which sets up GetAttrs
++// the way the upstream namespace strategy expects.
++func (r *REST) aclPredicate(options *metainternalversion.ListOptions, accessibleSel *accessibleNamesSelector) storage.SelectionPredicate {
++	label := labels.Everything()
++	field := fields.Everything()
++	if options != nil {
++		if options.LabelSelector != nil {
++			label = options.LabelSelector
++		}
++		if options.FieldSelector != nil {
++			field = options.FieldSelector
++		}
++	}
++	combined := fields.AndSelectors(field, accessibleSel)
++	return r.store.PredicateFunc(label, combined)
+ }
+ 
+ func (r *REST) Create(ctx context.Context, obj runtime.Object, createValidation rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {
+@@ -126,12 +305,88 @@ func (r *REST) Update(ctx context.Context, name string, objInfo rest.UpdatedObje
+ 	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation, forceAllowCreate, options)
+ }
+ 
++// Get retrieves a single namespace, applying the ACL fast path when filtering
++// is active: a single point-query against the permission service answers
++// whether the user can see this namespace, with NotFound returned in place
++// of Forbidden to avoid leaking existence to unprivileged callers.
+ func (r *REST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
++	if !r.shouldFilter(ctx) {
++		return r.store.Get(ctx, name, options)
++	}
++
++	u, err := userFromContext(ctx)
++	if err != nil {
++		klog.V(4).InfoS("namespace ACL: missing user info on Get", "namespace", name, "err", err)
++		return nil, apierrors.NewForbidden(api.Resource("namespaces"), name, errCannotGetNamespace)
++	}
++
++	accessible, err := r.accessibleFetcher.IsNamespaceAccessible(ctx, u, name)
++	if err != nil {
++		klog.Warningf("namespace ACL: failed to check accessibility for user %q on namespace %q: %v; returning forbidden", u.GetName(), name, err)
++		return nil, apierrors.NewForbidden(api.Resource("namespaces"), name, errCannotGetNamespace)
++	}
++	if !accessible {
++		return nil, apierrors.NewNotFound(api.Resource("namespaces"), name)
++	}
++
+ 	return r.store.Get(ctx, name, options)
+ }
+ 
++// Watch streams namespace events. When ACL filtering is active, it:
++//
++//  1. Fetches the user's initial accessible-namespace set.
++//  2. Builds a live accessibleNamesSelector seeded with that set, ANDs it
++//     with the caller's field selector, and starts the underlying storage
++//     watch with that predicate. The cacher will then drop events for any
++//     namespace the user cannot see, with no extra plumbing.
++//  3. Returns a wrapper that polls the fetcher every aclRefreshInterval and
++//     synthesizes ADDED/DELETED events when the user gains or loses access
++//     to a namespace mid-watch — the canonical OpenShift userProjectWatcher
++//     pattern.
++//
++// Without filtering this is a straight pass-through to Store.Watch.
+ func (r *REST) Watch(ctx context.Context, options *metainternalversion.ListOptions) (watch.Interface, error) {
+-	return r.store.Watch(ctx, options)
++	if !r.shouldFilter(ctx) {
++		return r.store.Watch(ctx, options)
++	}
++
++	u, err := userFromContext(ctx)
++	if err != nil {
++		klog.V(4).InfoS("namespace ACL: missing user info on Watch", "err", err)
++		return nil, apierrors.NewForbidden(api.Resource("namespaces"), "", errCannotWatchNamespaces)
++	}
++
++	names, err := r.accessibleFetcher.FetchAccessibleNamespaces(ctx, u)
++	if err != nil {
++		klog.Warningf("namespace ACL: failed to fetch accessible namespaces for user %q on Watch: %v; returning forbidden", u.GetName(), err)
++		return nil, apierrors.NewForbidden(api.Resource("namespaces"), "", errCannotWatchNamespaces)
++	}
++	initial := namesToSet(names)
++	selector := newAccessibleNamesSelector(initial)
++
++	predicate := r.aclPredicate(options, selector)
++	resourceVersion := ""
++	var sendInitialEvents *bool
++	if options != nil {
++		resourceVersion = options.ResourceVersion
++		predicate.AllowWatchBookmarks = options.AllowWatchBookmarks
++		sendInitialEvents = options.SendInitialEvents
++	}
++
++	inner, err := r.store.WatchPredicate(ctx, predicate, resourceVersion, sendInitialEvents)
++	if err != nil {
++		return nil, err
++	}
++
++	return newFilteredWatch(ctx, filteredWatchConfig{
++		inner:           inner,
++		selector:        selector,
++		getter:          r.store,
++		fetcher:         r.accessibleFetcher,
++		user:            u,
++		initial:         initial,
++		refreshInterval: r.aclRefreshInterval,
++	}), nil
+ }
+ 
+ // Delete enforces life-cycle rules for namespace termination
+diff --git a/pkg/registry/core/rest/storage_core_generic.go b/pkg/registry/core/rest/storage_core_generic.go
+index 9d82ca85633..0a9f149c3eb 100644
+--- a/pkg/registry/core/rest/storage_core_generic.go
++++ b/pkg/registry/core/rest/storage_core_generic.go
+@@ -106,7 +106,21 @@ func (c *GenericConfig) NewRESTStorage(apiResourceConfigSource serverstorage.API
+ 		return genericapiserver.APIGroupInfo{}, err
+ 	}
+ 
+-	namespaceStorage, namespaceStatusStorage, namespaceFinalizeStorage, err := namespacestore.NewREST(restOptionsGetter)
++	// Deckhouse: always wire the filtering-capable namespace storage. The
++	// fetcher is constructed from the loopback client so impersonation
++	// against permission-browser-apiserver works out of the box. Actual
++	// per-request filtering only kicks in when filters.IsNamespaceFilteringMode(ctx)
++	// is true — set by WithAuthorization when a user lacks RBAC for
++	// list/get on namespaces but should still see their accessible subset.
++	//
++	// We omit WithACLRefreshInterval to accept the package default (1s),
++	// which controls how quickly synthetic ADDED/DELETED events surface on
++	// long-lived watches when permissions change. Add WithACLRefreshInterval
++	// to override at runtime if needed.
++	namespaceStorage, namespaceStatusStorage, namespaceFinalizeStorage, err := namespacestore.NewREST(
++		restOptionsGetter,
++		namespacestore.WithLoopbackFetcher(c.LoopbackClientConfig),
++	)
+ 	if err != nil {
+ 		return genericapiserver.APIGroupInfo{}, err
+ 	}
+diff --git a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authorization.go b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authorization.go
+index 6c6c94ba718..86bd915e96c 100644
+--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authorization.go
++++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authorization.go
+@@ -45,8 +45,58 @@ const (
+ 	decisionAllow  = "allow"
+ 	decisionForbid = "forbid"
+ 	reasonError    = "internal error"
++
++	// Deckhouse: audit annotation values used when the authorization filter
++	// hands a denied namespace list/get/watch over to the storage layer for
++	// ACL-based filtering instead of 403'ing.
++	decisionAllowFiltered = "allow-filtered"
++	reasonNamespaceFilter = "namespace filtering mode"
+ )
+ 
++// Deckhouse: namespaceFilteringModeKey is the context-value key that the
++// authorization filter uses to flag a request as "denied by RBAC but routed
++// to the namespace-filtering code path in storage". It is intentionally an
++// unexported zero-size struct so external packages cannot synthesize it
++// without going through WithNamespaceFilteringMode (which is only meant for
++// tests).
++type namespaceFilteringModeKey struct{}
++
++// IsNamespaceFilteringMode reports whether the request context was tagged for
++// ACL-based namespace filtering (see the WithAuthorization branch below).
++// The storage layer reads this to decide whether to invoke the accessible-
++// namespace fetcher.
++func IsNamespaceFilteringMode(ctx context.Context) bool {
++	val, ok := ctx.Value(namespaceFilteringModeKey{}).(bool)
++	return ok && val
++}
++
++// WithNamespaceFilteringMode returns a derivative context with the namespace
++// filtering flag set. Production code reaches this state via the
++// authorization filter; tests use this helper to construct a context that
++// pretends an authorizer denial happened.
++func WithNamespaceFilteringMode(ctx context.Context) context.Context {
++	return context.WithValue(ctx, namespaceFilteringModeKey{}, true)
++}
++
++// isNamespaceListGetOrWatchRequest reports whether the request targets the
++// core /v1/namespaces list/get/watch endpoint. These three verbs are the
++// only ones we bypass 403 for: create/update/delete still reject denied
++// users with the standard error so we don't accidentally let unauthorized
++// callers mutate cluster state.
++func isNamespaceListGetOrWatchRequest(requestInfo *request.RequestInfo) bool {
++	if requestInfo == nil || !requestInfo.IsResourceRequest {
++		return false
++	}
++	if requestInfo.APIGroup != "" || requestInfo.Resource != "namespaces" || requestInfo.Subresource != "" {
++		return false
++	}
++	switch requestInfo.Verb {
++	case "list", "get", "watch":
++		return true
++	}
++	return false
++}
++
+ type recordAuthorizationMetricsFunc func(ctx context.Context, authorized authorizer.Decision, err error, authStart time.Time, authFinish time.Time)
+ 
+ // WithAuthorization passes all authorized requests on to handler, and returns a forbidden error otherwise.
+@@ -90,6 +140,23 @@ func withAuthorization(handler http.Handler, a authorizer.Authorizer, s runtime.
+ 			return
+ 		}
+ 
++		// Deckhouse: bypass 403 for namespace list/get/watch and let the
++		// storage layer return an ACL-filtered response instead. This is
++		// strictly a relaxation for *read* verbs; mutating verbs still
++		// hit the standard Forbidden path below. The storage layer keys
++		// off IsNamespaceFilteringMode() so other consumers of this
++		// filter chain are unaffected.
++		requestInfo, _ := request.RequestInfoFrom(ctx)
++		if isNamespaceListGetOrWatchRequest(requestInfo) {
++			klog.V(4).InfoS("namespace ACL: bypassing authorization denial for namespace read; storage will filter",
++				"URI", req.RequestURI, "verb", requestInfo.Verb, "reason", reason)
++			audit.AddAuditAnnotations(ctx,
++				decisionAnnotationKey, decisionAllowFiltered,
++				reasonAnnotationKey, reasonNamespaceFilter)
++			handler.ServeHTTP(w, req.WithContext(WithNamespaceFilteringMode(ctx)))
++			return
++		}
++
+ 		klog.V(4).InfoS("Forbidden", "URI", req.RequestURI, "reason", reason)
+ 		audit.AddAuditAnnotations(ctx,
+ 			decisionAnnotationKey, decisionForbid,
 diff --git a/pkg/registry/core/namespace/storage/accessible_fetcher.go b/pkg/registry/core/namespace/storage/accessible_fetcher.go
 new file mode 100644
-index 00000000000..1e31f66de0f
+index 00000000000..aca532cb899
 --- /dev/null
 +++ b/pkg/registry/core/namespace/storage/accessible_fetcher.go
-@@ -0,0 +1,176 @@
+@@ -0,0 +1,234 @@
 +/*
 +Copyright 2025 The Kubernetes Authors.
 +
@@ -25,91 +486,145 @@ index 00000000000..1e31f66de0f
 +import (
 +	"context"
 +	"encoding/json"
++	"errors"
 +	"fmt"
 +	"io"
 +	"net/http"
++	"net/url"
 +	"strings"
 +	"time"
 +
++	"k8s.io/apiserver/pkg/authentication/user"
 +	restclient "k8s.io/client-go/rest"
 +	"k8s.io/client-go/transport"
 +	"k8s.io/klog/v2"
 +)
 +
 +const (
-+	// accessibleNamespacesAPIPath is the path to the accessiblenamespaces API
-+	// provided by permission-browser-apiserver (Deckhouse extension).
++	// accessibleNamespacesAPIPath is the URL path under which Deckhouse's
++	// permission-browser-apiserver registers its AccessibleNamespaces API.
++	// Calls are routed via kube-apiserver's loopback connection so they hit
++	// the aggregated APIServer with full TLS/cert plumbing intact.
 +	accessibleNamespacesAPIPath = "/apis/authorization.deckhouse.io/v1alpha1/accessiblenamespaces"
 +
-+	// DefaultHTTPTimeout is the default timeout for HTTP requests.
-+	DefaultHTTPTimeout = 10 * time.Second
++	// defaultHTTPTimeout caps every fetcher call. It must be short enough
++	// that a hung permission service does not stall a List/Watch request,
++	// and long enough that a busy service still completes during normal
++	// load. Ten seconds matches client-go's default RESTClient timeout.
++	defaultHTTPTimeout = 10 * time.Second
++
++	// errorBodyByteLimit bounds how much of an error response body we
++	// read into memory and surface in error messages. Permission-browser
++	// is trusted, but a misconfigured proxy could splice in arbitrarily
++	// large payloads; 8 KiB is plenty for any sane Status object.
++	errorBodyByteLimit = 8 * 1024
 +)
 +
-+// AccessibleNamespaceResponse represents a single accessible namespace from the API response.
-+type AccessibleNamespaceResponse struct {
++// accessibleNamespaceItem matches the on-the-wire shape of one entry in the
++// permission-browser-apiserver list response. We deliberately decode only
++// the fields we use; new fields added upstream will not break this code.
++type accessibleNamespaceItem struct {
 +	Metadata struct {
 +		Name string `json:"name"`
 +	} `json:"metadata"`
 +}
 +
-+// AccessibleNamespaceListResponse represents the list response from the accessible namespaces API.
-+type AccessibleNamespaceListResponse struct {
-+	Items []AccessibleNamespaceResponse `json:"items"`
++// accessibleNamespaceList matches the on-the-wire shape of the LIST response.
++type accessibleNamespaceList struct {
++	Items []accessibleNamespaceItem `json:"items"`
 +}
 +
-+// LoopbackAccessibleNamespaceFetcher implements AccessibleNamespaceFetcher by calling
-+// the permission-browser-apiserver's accessiblenamespaces API through kube-apiserver's
-+// loopback connection. This ensures proper authentication via loopback client credentials
-+// while using impersonation to act as the target user.
-+//
-+// Deckhouse-specific: used for ACL-based namespace filtering.
++// AccessibleNamespaceFetcher returns the set of namespaces a given user is
++// allowed to see. The watch code path takes advantage of repeated calls
++// returning different results (as the user's bindings change) to synthesize
++// ADDED/DELETED events while a watch is open.
++type AccessibleNamespaceFetcher interface {
++	// FetchAccessibleNamespaces lists all namespace names the user can
++	// see. Used by List and Watch.
++	FetchAccessibleNamespaces(ctx context.Context, u user.Info) ([]string, error)
++
++	// IsNamespaceAccessible answers whether a single named namespace is
++	// accessible to the user. Used by Get as a fast path that avoids
++	// pulling the full accessible set when the client only asks for one.
++	IsNamespaceAccessible(ctx context.Context, u user.Info, namespace string) (bool, error)
++}
++
++// LoopbackAccessibleNamespaceFetcher resolves a user's accessible namespaces
++// by calling permission-browser-apiserver through kube-apiserver's loopback
++// HTTPS endpoint. Authentication is provided by the loopback client's TLS
++// credentials; user identity is conveyed via standard impersonation headers
++// (Impersonate-User/-Group/-Extra-*), which the aggregated APIServer
++// validates against its RBAC for the impersonate verb on the loopback
++// service account — the same path SubjectAccessReviews take.
 +type LoopbackAccessibleNamespaceFetcher struct {
-+	// baseURL is the base URL for API requests (typically https://127.0.0.1:6443)
++	// baseURL is the scheme+host portion of the loopback config (no path).
 +	baseURL string
 +
-+	// roundTripper is the authenticated transport from loopback config
++	// roundTripper is the authenticated transport built once from the
++	// loopback config. Per-request impersonation is layered on top via
++	// transport.NewImpersonatingRoundTripper, which simply prepends the
++	// impersonation headers and delegates to this base RT — so all users
++	// share the same TLS connection pool.
 +	roundTripper http.RoundTripper
 +
-+	// timeout for HTTP requests
++	// timeout caps every individual HTTP call.
 +	timeout time.Duration
 +}
 +
-+// NewLoopbackAccessibleNamespaceFetcher creates a new fetcher that uses the kube-apiserver's
-+// loopback client configuration to call the accessiblenamespaces API with impersonation.
++// Compile-time guard.
++var _ AccessibleNamespaceFetcher = (*LoopbackAccessibleNamespaceFetcher)(nil)
++
++// NewLoopbackAccessibleNamespaceFetcher builds a fetcher from a loopback
++// REST config. The config is copied internally; callers may safely mutate
++// it after this returns.
 +func NewLoopbackAccessibleNamespaceFetcher(loopbackConfig *restclient.Config) (*LoopbackAccessibleNamespaceFetcher, error) {
 +	if loopbackConfig == nil {
-+		return nil, fmt.Errorf("loopback config is required")
++		return nil, errors.New("loopback config is required")
 +	}
 +
 +	cfg := restclient.CopyConfig(loopbackConfig)
 +	transportConfig, err := cfg.TransportConfig()
 +	if err != nil {
-+		return nil, fmt.Errorf("failed to get transport config: %w", err)
++		return nil, fmt.Errorf("get transport config: %w", err)
 +	}
 +
 +	rt, err := transport.New(transportConfig)
 +	if err != nil {
-+		return nil, fmt.Errorf("failed to create transport: %w", err)
++		return nil, fmt.Errorf("build loopback transport: %w", err)
 +	}
 +
-+	baseURL := strings.TrimRight(cfg.Host, "/")
-+
 +	return &LoopbackAccessibleNamespaceFetcher{
-+		baseURL:      baseURL,
++		baseURL:      strings.TrimRight(cfg.Host, "/"),
 +		roundTripper: rt,
-+		timeout:      DefaultHTTPTimeout,
++		timeout:      defaultHTTPTimeout,
 +	}, nil
 +}
 +
-+func (f *LoopbackAccessibleNamespaceFetcher) httpClientFor(username string, groups []string, extra map[string][]string) *http.Client {
-+	// IMPORTANT:
-+	// User extra keys may contain characters that are invalid in HTTP header field-names (e.g. '/').
-+	// Kubernetes solves this by escaping extra keys in impersonation headers.
-+	// Use client-go's impersonating round-tripper to match upstream behavior.
++// readErrorBody reads up to errorBodyByteLimit bytes of an HTTP response
++// body for inclusion in error messages. The read error is intentionally
++// swallowed — we are already on the error path and the partial body is
++// more useful than nothing.
++func readErrorBody(body io.Reader) string {
++	b, _ := io.ReadAll(io.LimitReader(body, errorBodyByteLimit))
++	return string(b)
++}
++
++// httpClientFor returns an http.Client whose transport prepends impersonation
++// headers identifying the supplied user, then delegates to the shared base
++// roundTripper. The returned client is cheap to construct: no new pools, no
++// new TLS sessions. We deliberately do NOT cache per-user clients because
++// the fetcher is shared across all users on the apiserver, and caching
++// would either grow unbounded or require an LRU; per-call construction is
++// simpler and the allocations are noise.
++func (f *LoopbackAccessibleNamespaceFetcher) httpClientFor(u user.Info) *http.Client {
++	// NOTE: extra keys may contain characters that are illegal in HTTP
++	// header field names (e.g. '/'). transport.NewImpersonatingRoundTripper
++	// applies the same key-escaping that kube-apiserver uses on the receive
++	// side, so we get cross-component agreement for free.
 +	impRT := transport.NewImpersonatingRoundTripper(transport.ImpersonationConfig{
-+		UserName: username,
-+		Groups:   groups,
-+		Extra:    extra,
++		UserName: u.GetName(),
++		Groups:   u.GetGroups(),
++		Extra:    u.GetExtra(),
 +	}, f.roundTripper)
 +
 +	return &http.Client{
@@ -118,55 +633,60 @@ index 00000000000..1e31f66de0f
 +	}
 +}
 +
-+// FetchAccessibleNamespaces fetches the list of accessible namespace names for the user.
-+func (f *LoopbackAccessibleNamespaceFetcher) FetchAccessibleNamespaces(ctx context.Context, username string, groups []string, extra map[string][]string) ([]string, error) {
-+	url := f.baseURL + accessibleNamespacesAPIPath
++// FetchAccessibleNamespaces lists all namespace names visible to the user.
++func (f *LoopbackAccessibleNamespaceFetcher) FetchAccessibleNamespaces(ctx context.Context, u user.Info) ([]string, error) {
++	endpoint := f.baseURL + accessibleNamespacesAPIPath
 +
-+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
++	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 +	if err != nil {
-+		return nil, fmt.Errorf("failed to create request: %w", err)
++		return nil, fmt.Errorf("build LIST accessiblenamespaces request: %w", err)
 +	}
++	req.Header.Set("Accept", "application/json")
 +
-+	klog.V(4).Infof("Fetching accessible namespaces for user %s via loopback at %s", username, url)
++	klog.V(4).InfoS("namespace ACL: fetching accessible namespaces", "user", u.GetName(), "url", endpoint)
 +
-+	client := f.httpClientFor(username, groups, extra)
-+	resp, err := client.Do(req)
++	resp, err := f.httpClientFor(u).Do(req)
 +	if err != nil {
-+		return nil, fmt.Errorf("failed to fetch accessible namespaces: %w", err)
++		return nil, fmt.Errorf("LIST accessiblenamespaces for user %q: %w", u.GetName(), err)
 +	}
 +	defer resp.Body.Close()
 +
 +	if resp.StatusCode != http.StatusOK {
-+		body, _ := io.ReadAll(resp.Body)
-+		return nil, fmt.Errorf("unexpected status code %d: %s", resp.StatusCode, string(body))
++		return nil, fmt.Errorf("LIST accessiblenamespaces for user %q: unexpected status %d: %s", u.GetName(), resp.StatusCode, readErrorBody(resp.Body))
 +	}
 +
-+	var listResponse AccessibleNamespaceListResponse
-+	if err := json.NewDecoder(resp.Body).Decode(&listResponse); err != nil {
-+		return nil, fmt.Errorf("failed to decode response: %w", err)
++	var list accessibleNamespaceList
++	if err := json.NewDecoder(resp.Body).Decode(&list); err != nil {
++		return nil, fmt.Errorf("decode LIST accessiblenamespaces response for user %q: %w", u.GetName(), err)
 +	}
 +
-+	names := make([]string, len(listResponse.Items))
-+	for i, item := range listResponse.Items {
++	names := make([]string, len(list.Items))
++	for i, item := range list.Items {
 +		names[i] = item.Metadata.Name
 +	}
-+
 +	return names, nil
 +}
 +
-+// IsNamespaceAccessible checks if a specific namespace is accessible to the user.
-+func (f *LoopbackAccessibleNamespaceFetcher) IsNamespaceAccessible(ctx context.Context, username string, groups []string, extra map[string][]string, namespace string) (bool, error) {
-+	url := fmt.Sprintf("%s%s/%s", f.baseURL, accessibleNamespacesAPIPath, namespace)
++// IsNamespaceAccessible answers whether a single namespace is visible to
++// the user. It maps directly to a GET on the per-name endpoint, with 404
++// meaning "not accessible" — semantically identical to how the apiserver
++// itself translates a denied namespace lookup.
++func (f *LoopbackAccessibleNamespaceFetcher) IsNamespaceAccessible(ctx context.Context, u user.Info, namespace string) (bool, error) {
++	// url.PathEscape guards against pathological names. Namespace name
++	// validation in upstream is strict (DNS-1123 label), so this is mostly
++	// belt-and-suspenders, but it costs nothing and prevents a crafted
++	// name from injecting a path segment.
++	endpoint := fmt.Sprintf("%s%s/%s", f.baseURL, accessibleNamespacesAPIPath, url.PathEscape(namespace))
 +
-+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
++	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 +	if err != nil {
-+		return false, fmt.Errorf("failed to create request: %w", err)
++		return false, fmt.Errorf("build GET accessiblenamespace request: %w", err)
 +	}
++	req.Header.Set("Accept", "application/json")
 +
-+	client := f.httpClientFor(username, groups, extra)
-+	resp, err := client.Do(req)
++	resp, err := f.httpClientFor(u).Do(req)
 +	if err != nil {
-+		return false, fmt.Errorf("failed to check namespace accessibility: %w", err)
++		return false, fmt.Errorf("GET accessiblenamespace %q for user %q: %w", namespace, u.GetName(), err)
 +	}
 +	defer resp.Body.Close()
 +
@@ -176,16 +696,15 @@ index 00000000000..1e31f66de0f
 +	case http.StatusNotFound:
 +		return false, nil
 +	default:
-+		body, _ := io.ReadAll(resp.Body)
-+		return false, fmt.Errorf("unexpected status code %d: %s", resp.StatusCode, string(body))
++		return false, fmt.Errorf("GET accessiblenamespace %q for user %q: unexpected status %d: %s", namespace, u.GetName(), resp.StatusCode, readErrorBody(resp.Body))
 +	}
 +}
-diff --git a/pkg/registry/core/namespace/storage/filtering_test.go b/pkg/registry/core/namespace/storage/filtering_test.go
+diff --git a/pkg/registry/core/namespace/storage/accessible_filtered_watch.go b/pkg/registry/core/namespace/storage/accessible_filtered_watch.go
 new file mode 100644
-index 00000000000..c3ce9f7d232
+index 00000000000..bfc5bf4f71a
 --- /dev/null
-+++ b/pkg/registry/core/namespace/storage/filtering_test.go
-@@ -0,0 +1,256 @@
++++ b/pkg/registry/core/namespace/storage/accessible_filtered_watch.go
+@@ -0,0 +1,464 @@
 +/*
 +Copyright 2025 The Kubernetes Authors.
 +
@@ -206,11 +725,611 @@ index 00000000000..c3ce9f7d232
 +
 +import (
 +	"context"
-+	"fmt"
-+	"testing"
++	"errors"
++	"net/http"
++	"sync"
++	"time"
 +
 +	apierrors "k8s.io/apimachinery/pkg/api/errors"
 +	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
++	"k8s.io/apimachinery/pkg/runtime"
++	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
++	"k8s.io/apimachinery/pkg/watch"
++	"k8s.io/apiserver/pkg/authentication/user"
++	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
++	"k8s.io/klog/v2"
++	api "k8s.io/kubernetes/pkg/apis/core"
++)
++
++// filteredWatchBufferSize controls the per-watch buffered channel that merges
++// events coming from the underlying storage watch with events synthesized by
++// the ACL poller. Sized to absorb a full namespace re-list during a
++// steady-state ACL rotation; on overflow the watch errors out and the client
++// is expected to reconnect with a fresh LIST. Mirrors openshift's
++// pkg/project/auth/watch.go (1000).
++const filteredWatchBufferSize = 1000
++
++// errChannelOverflow is the error message emitted via a watch.Error event when
++// the merge buffer overflows.
++var errChannelOverflow = errors.New("namespace ACL filtered watch: outgoing channel overflow; reconnect")
++
++// errNoUserInContext is returned when a request reaches the storage layer
++// without an authenticated user — should be impossible in practice but we
++// fail closed if it happens.
++var errNoUserInContext = errors.New("no user info in context")
++
++// namespaceGetter is the minimal subset of the storage REST surface used by
++// the filtered watch when synthesizing ADDED events for namespaces that just
++// became accessible. The signature matches genericregistry.Store.Get exactly,
++// kept as a tiny interface so tests can plug in a fake without spinning up
++// etcd.
++type namespaceGetter interface {
++	Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error)
++}
++
++// filteredWatchConfig groups the dependencies of a filteredWatch into a
++// single value so the constructor stays at two parameters (ctx + config).
++// All fields are required unless documented otherwise.
++type filteredWatchConfig struct {
++	// inner is the storage-layer watch already filtered through the
++	// live predicate. filteredWatch takes ownership and will Stop() it.
++	inner watch.Interface
++
++	// selector is the live fields.Selector whose accessible-name set is
++	// updated on every poll tick. Shared with the SelectionPredicate
++	// passed to inner; updates are seen by both immediately.
++	selector *accessibleNamesSelector
++
++	// getter performs a server-side GET to materialize Namespace objects
++	// for synthesized ADDED events.
++	getter namespaceGetter
++
++	// fetcher answers "which namespaces is this user allowed to see"
++	// on every poll tick.
++	fetcher AccessibleNamespaceFetcher
++
++	// user identifies the watching client for impersonated fetcher calls.
++	user user.Info
++
++	// initial is the accessible name set at watch open. Seeds knownNames
++	// so the first poll tick does not synthesize ADDED events for
++	// namespaces the inner watch is about to replay.
++	initial map[string]struct{}
++
++	// refreshInterval governs how often the ACL poller wakes up. A value
++	// <=0 disables polling (storage events still flow).
++	refreshInterval time.Duration
++}
++
++// filteredWatch wraps a storage-layer watch.Interface for namespaces and
++// merges in synthetic events derived from changes to a user's accessible-
++// namespace set (the ACL).
++//
++// Architecture mirrors OpenShift's userProjectWatcher:
++//
++//   - The underlying storage watch is started with a SelectionPredicate that
++//     contains a live accessibleNamesSelector. The selector's atomic state is
++//     updated on every ACL poll tick, so storage-layer events for namespaces
++//     the user no longer has access to are silently dropped at the predicate
++//     layer (no extra round-trips, no work in the cacher).
++//
++//   - In parallel, this wrapper polls the AccessibleNamespaceFetcher every
++//     refreshInterval (default 1s, configurable). On each tick it computes
++//     the diff against knownNames and synthesizes ADDED/DELETED events.
++//     ADDED events fetch the actual Namespace via the supplied getter (a
++//     server-side Get against the storage layer); DELETED events emit a stub
++//     object carrying only metadata.name.
++//
++//   - All events — both pass-through from storage and synthetic from the
++//     poller — are funneled through a single buffered channel and emitted to
++//     the client in arrival order, so the client sees a consistent stream.
++//
++//   - On unrecoverable failure (channel overflow, inner watch closure) the
++//     watch emits a watch.Error, stops itself, and CLOSES the outgoing
++//     channel — clients ranging over ResultChan() unblock cleanly and let
++//     their reflector reconnect.
++type filteredWatch struct {
++	inner    watch.Interface
++	selector *accessibleNamesSelector
++	getter   namespaceGetter
++	fetcher  AccessibleNamespaceFetcher
++
++	// user is captured at watch-open and is immutable for the life of
++	// the watch. We do not store the request context: cancellation flows
++	// through the cancel func below.
++	user user.Info
++
++	refreshInterval time.Duration
++
++	// outgoing carries every event delivered to the client. Buffered so a
++	// slow storage layer and a slow poller cannot back each other up; on
++	// overflow we emit a watch.Error and tear the watch down. Closed by
++	// the lifecycle goroutine once both senders have exited, so a client
++	// doing `for ev := range w.ResultChan()` always terminates.
++	outgoing chan watch.Event
++
++	// knownNames is the set of namespace names this watch has surfaced to
++	// the client and not yet retracted. It is the source of truth for
++	// ADDED-vs-MODIFIED decisions and DELETED synthesis. Guarded by mu.
++	mu         sync.Mutex
++	knownNames map[string]struct{}
++
++	stopOnce sync.Once
++	stopCh   chan struct{}
++	cancel   context.CancelFunc
++
++	// senders is signalled once by each background goroutine when it
++	// exits; the lifecycle goroutine waits on it before closing outgoing,
++	// guaranteeing no "send on closed channel" panic.
++	senders sync.WaitGroup
++}
++
++// newFilteredWatch wires together a storage watch with an ACL poller. The
++// returned watch owns cfg.inner and will Stop() it when the watch ends.
++func newFilteredWatch(parentCtx context.Context, cfg filteredWatchConfig) *filteredWatch {
++	ctx, cancel := context.WithCancel(parentCtx)
++
++	known := make(map[string]struct{}, len(cfg.initial))
++	for n := range cfg.initial {
++		known[n] = struct{}{}
++	}
++
++	w := &filteredWatch{
++		inner:           cfg.inner,
++		selector:        cfg.selector,
++		getter:          cfg.getter,
++		fetcher:         cfg.fetcher,
++		user:            cfg.user,
++		refreshInterval: cfg.refreshInterval,
++		outgoing:        make(chan watch.Event, filteredWatchBufferSize),
++		knownNames:      known,
++		stopCh:          make(chan struct{}),
++		cancel:          cancel,
++	}
++
++	w.senders.Add(2)
++	go w.runStoragePump(ctx)
++	go w.runACLPoller(ctx)
++	go w.closeWhenDone()
++
++	return w
++}
++
++// ResultChan implements watch.Interface.
++func (w *filteredWatch) ResultChan() <-chan watch.Event {
++	return w.outgoing
++}
++
++// Stop implements watch.Interface. Idempotent.
++func (w *filteredWatch) Stop() {
++	w.stopOnce.Do(func() {
++		// Cancel first so background goroutines unblock from their
++		// selects before we tear down the inner watch.
++		w.cancel()
++		w.inner.Stop()
++		close(w.stopCh)
++	})
++}
++
++// closeWhenDone waits for both sender goroutines (storage pump and ACL
++// poller) to finish, then closes the outgoing channel exactly once. This
++// is the canonical "single closer" pattern from the Go memory model and
++// guarantees no send-on-closed-channel panic.
++func (w *filteredWatch) closeWhenDone() {
++	w.senders.Wait()
++	close(w.outgoing)
++}
++
++// runStoragePump forwards events from the underlying storage watch into the
++// outgoing channel, maintaining knownNames so that subsequent ACL diffs make
++// correct ADDED/DELETED decisions.
++func (w *filteredWatch) runStoragePump(ctx context.Context) {
++	defer utilruntime.HandleCrash()
++	defer w.senders.Done()
++	defer w.Stop()
++
++	in := w.inner.ResultChan()
++	for {
++		select {
++		case <-ctx.Done():
++			return
++		case ev, ok := <-in:
++			if !ok {
++				// Inner watch closed (etcd disconnect, server
++				// shutdown). Propagate by stopping ourselves;
++				// client will reconnect with a fresh LIST.
++				return
++			}
++			ev = w.observeStorageEvent(ev)
++			if !w.emit(ev) {
++				return
++			}
++		}
++	}
++}
++
++// observeStorageEvent updates knownNames for an event the predicate just let
++// through and returns a (possibly mutated) event for emission. The event type
++// is demoted from ADDED to MODIFIED if the name was already in knownNames —
++// this happens, very rarely, when the ACL poller synthesized an ADDED for a
++// namespace at almost the same instant a real etcd CREATE event for it
++// crossed the predicate. Mirroring OpenShift's userProjectWatcher, we never
++// emit two ADDEDs for the same name without an intervening DELETED.
++func (w *filteredWatch) observeStorageEvent(ev watch.Event) watch.Event {
++	name, ok := nameOfNamespaceEvent(ev)
++	if !ok {
++		return ev
++	}
++
++	w.mu.Lock()
++	defer w.mu.Unlock()
++	switch ev.Type {
++	case watch.Added:
++		if _, already := w.knownNames[name]; already {
++			ev.Type = watch.Modified
++		}
++		w.knownNames[name] = struct{}{}
++	case watch.Modified:
++		w.knownNames[name] = struct{}{}
++	case watch.Deleted:
++		delete(w.knownNames, name)
++	}
++	return ev
++}
++
++// runACLPoller periodically refetches the user's accessible namespaces and
++// synthesizes ADDED/DELETED events for the diff. The constructor seeds
++// knownNames with the initial ACL, so the first poll iteration sees no diff
++// in the steady state and only acts on subsequent changes.
++func (w *filteredWatch) runACLPoller(ctx context.Context) {
++	defer utilruntime.HandleCrash()
++	defer w.senders.Done()
++	defer w.Stop()
++
++	if w.refreshInterval <= 0 {
++		// Misconfigured: a 0/negative interval would spin. Park the
++		// goroutine until shutdown; the storage pump still works, ACL
++		// changes won't be reflected until the client reconnects.
++		<-ctx.Done()
++		return
++	}
++
++	ticker := time.NewTicker(w.refreshInterval)
++	defer ticker.Stop()
++
++	for {
++		select {
++		case <-ctx.Done():
++			return
++		case <-ticker.C:
++			if !w.tickACL(ctx) {
++				return
++			}
++		}
++	}
++}
++
++// tickACL performs one ACL poll iteration: fetch the latest accessible set,
++// update the live selector, and synthesize events for the diff. Returns
++// false if the watch must be torn down (e.g. on emit overflow).
++func (w *filteredWatch) tickACL(ctx context.Context) bool {
++	names, err := w.fetcher.FetchAccessibleNamespaces(ctx, w.user)
++	if err != nil {
++		// Watch is shutting down: ctx cancellation propagates into the
++		// fetcher's HTTP client and yields a context-canceled error.
++		// This is normal teardown, not a real failure — keep silent.
++		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
++			return true
++		}
++		// Anything else is operationally interesting: surface it at
++		// Warning so operators don't need -v=4 to notice. We keep the
++		// previous ACL state — strictly safer than flipping to
++		// deny-everything which would synthesize spurious DELETEDs
++		// across the whole accessible set.
++		klog.Warningf("namespace ACL: failed to refresh accessible set for user %q (keeping previous state): %v", w.user.GetName(), err)
++		return true
++	}
++
++	newACL := namesToSet(names)
++	w.selector.update(newACL)
++
++	w.mu.Lock()
++	gained, lost := diffNameSets(newACL, w.knownNames)
++	w.mu.Unlock()
++
++	for _, n := range lost {
++		ev := watch.Event{
++			Type: watch.Deleted,
++			// We don't have the original object in hand (recovering
++			// it from etcd is racy). Emit a stub with just the name;
++			// matches OpenShift's userProjectWatcher behavior and is
++			// enough for client-go reflectors to evict their cache.
++			Object: &api.Namespace{ObjectMeta: metav1.ObjectMeta{Name: n}},
++		}
++		w.mu.Lock()
++		delete(w.knownNames, n)
++		w.mu.Unlock()
++		klog.V(4).InfoS("namespace ACL: synthesizing DELETED for lost access", "user", w.user.GetName(), "namespace", n)
++		if !w.emit(ev) {
++			return false
++		}
++	}
++
++	for _, n := range gained {
++		obj, err := w.getter.Get(ctx, n, &metav1.GetOptions{})
++		if err != nil {
++			if apierrors.IsNotFound(err) {
++				// Namespace exists in the user's ACL view but not
++				// in storage (likely a race with deletion). Skip —
++				// the client never saw it as ADDED and never will.
++				continue
++			}
++			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
++				// Shutting down; quietly drop.
++				return true
++			}
++			klog.Warningf("namespace ACL: failed to fetch namespace %q for synthesized ADDED (user %q): %v", n, w.user.GetName(), err)
++			continue
++		}
++
++		// Re-check under lock just before emitting: between gathering
++		// `gained` above and arriving here we released the lock, and
++		// the storage pump may have raced through and announced an
++		// ADDED for this same name (real etcd CREATE event passing
++		// the now-updated predicate). If so, the pump already updated
++		// knownNames; skip to avoid a duplicate ADDED. Best-effort; a
++		// tighter window would require holding the lock across the
++		// Get, which can be slow.
++		w.mu.Lock()
++		if _, already := w.knownNames[n]; already {
++			w.mu.Unlock()
++			continue
++		}
++		w.knownNames[n] = struct{}{}
++		w.mu.Unlock()
++
++		klog.V(4).InfoS("namespace ACL: synthesizing ADDED for gained access", "user", w.user.GetName(), "namespace", n)
++		if !w.emit(watch.Event{Type: watch.Added, Object: obj}) {
++			return false
++		}
++	}
++
++	return true
++}
++
++// diffNameSets returns names present in newACL but not in known (gained) and
++// names present in known but not in newACL (lost). Caller must hold the
++// lock guarding `known` for the duration of the call.
++func diffNameSets(newACL, known map[string]struct{}) (gained, lost []string) {
++	for n := range newACL {
++		if _, ok := known[n]; !ok {
++			gained = append(gained, n)
++		}
++	}
++	for n := range known {
++		if _, ok := newACL[n]; !ok {
++			lost = append(lost, n)
++		}
++	}
++	return gained, lost
++}
++
++// emit pushes an event to the outgoing channel. Returns false if the watch
++// is being torn down or the outgoing buffer overflowed, so callers stop.
++//
++// On overflow we attempt a single non-blocking delivery of a watch.Error so
++// the client learns why their stream just ended; if even that fails (because
++// the buffer is genuinely full and the client is unresponsive) the error is
++// dropped — the client will notice anyway when ResultChan closes.
++func (w *filteredWatch) emit(ev watch.Event) bool {
++	select {
++	case <-w.stopCh:
++		return false
++	case w.outgoing <- ev:
++		return true
++	default:
++		errEvt := watch.Event{
++			Type: watch.Error,
++			Object: &metav1.Status{
++				Status:  metav1.StatusFailure,
++				Message: errChannelOverflow.Error(),
++				Reason:  metav1.StatusReasonInternalError,
++				Code:    http.StatusInternalServerError,
++			},
++		}
++		select {
++		case w.outgoing <- errEvt:
++		default:
++		}
++		klog.Warningf("namespace ACL filtered watch: outgoing channel full for user %q; closing watch", w.user.GetName())
++		return false
++	}
++}
++
++// nameOfNamespaceEvent extracts the namespace name from a watch event.
++// Returns ("", false) for unexpected payloads (defensive — storage emits
++// *api.Namespace, but a corrupt object should not panic the pump).
++func nameOfNamespaceEvent(ev watch.Event) (string, bool) {
++	if ev.Object == nil {
++		return "", false
++	}
++	ns, ok := ev.Object.(*api.Namespace)
++	if !ok {
++		return "", false
++	}
++	return ns.Name, true
++}
++
++// userFromContext extracts the authenticated user.Info from a request
++// context. Fails closed if no user is present.
++func userFromContext(ctx context.Context) (user.Info, error) {
++	u, ok := genericapirequest.UserFrom(ctx)
++	if !ok {
++		return nil, errNoUserInContext
++	}
++	return u, nil
++}
+diff --git a/pkg/registry/core/namespace/storage/accessible_selector.go b/pkg/registry/core/namespace/storage/accessible_selector.go
+new file mode 100644
+index 00000000000..907d06ee686
+--- /dev/null
++++ b/pkg/registry/core/namespace/storage/accessible_selector.go
+@@ -0,0 +1,119 @@
++/*
++Copyright 2025 The Kubernetes Authors.
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++    http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/
++
++package storage
++
++import (
++	"sync/atomic"
++
++	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
++	"k8s.io/apimachinery/pkg/fields"
++)
++
++// accessibleNamesSelector is a fields.Selector implementation that matches an
++// object iff its metadata.name is contained in a dynamically-updated set of
++// accessible namespace names.
++//
++// It is meant to be combined with the user-supplied field selector via
++// fields.AndSelectors and passed inside a storage.SelectionPredicate to
++// genericregistry.Store's ListPredicate/WatchPredicate. The Kubernetes
++// storage layer always populates metadata.name in storeElement.Fields, so we
++// reuse the existing predicate machinery for both filtering and watch
++// streaming without any custom plumbing.
++//
++// The set is held behind an atomic.Pointer so that a background goroutine
++// can update which names are accessible without any locking on the hot
++// Matches() path. The selector is shared (not copied) between the storage
++// predicate and the ACL poller; both see the same atomic value.
++//
++// Notes on the fields.Selector method contract:
++//
++//   - Empty() returns false unconditionally; otherwise an AndSelector
++//     containing this selector would silently degrade to "match everything".
++//   - RequiresExactMatch() returns ("", false): the selector represents a
++//     set-membership test, not equality on a single value. Reporting an
++//     equality match would defeat MatchesSingle/MatchesSingleNamespace
++//     optimizations in the storage layer for user-supplied terms ANDed
++//     alongside this selector.
++//   - String() returns "" so we don't leak a (potentially large, per-user)
++//     ACL set into error messages or audit logs.
++//   - DeepCopySelector() returns self — the shared atomic state is the
++//     point. apimachinery never strictly relies on copy semantics.
++type accessibleNamesSelector struct {
++	// names points to the current (immutable) set of accessible names.
++	// A nil pointer means "deny everything" — used as a safe default
++	// before the first fetch and after a permanent error.
++	names atomic.Pointer[map[string]struct{}]
++}
++
++// newAccessibleNamesSelector creates a selector that matches the given
++// initial set of names. Pass nil to start in deny-everything mode.
++func newAccessibleNamesSelector(initial map[string]struct{}) *accessibleNamesSelector {
++	s := &accessibleNamesSelector{}
++	if initial != nil {
++		s.names.Store(&initial)
++	}
++	return s
++}
++
++// update atomically replaces the accessible-name set. The passed map MUST
++// NOT be mutated by the caller afterwards — it is shared with concurrent
++// Matches() calls. Pass nil to switch into deny-everything mode.
++func (s *accessibleNamesSelector) update(set map[string]struct{}) {
++	if set == nil {
++		s.names.Store(nil)
++		return
++	}
++	s.names.Store(&set)
++}
++
++// Matches implements fields.Selector. Returns true iff the object's
++// metadata.name is contained in the current accessible set.
++func (s *accessibleNamesSelector) Matches(f fields.Fields) bool {
++	set := s.names.Load()
++	if set == nil {
++		return false
++	}
++	_, ok := (*set)[f.Get(metav1.ObjectNameField)]
++	return ok
++}
++
++func (s *accessibleNamesSelector) Empty() bool { return false }
++
++func (s *accessibleNamesSelector) RequiresExactMatch(string) (string, bool) {
++	return "", false
++}
++
++func (s *accessibleNamesSelector) Transform(fields.TransformFunc) (fields.Selector, error) {
++	return s, nil
++}
++
++func (s *accessibleNamesSelector) Requirements() fields.Requirements { return nil }
++
++func (s *accessibleNamesSelector) String() string { return "" }
++
++func (s *accessibleNamesSelector) DeepCopySelector() fields.Selector { return s }
++
++// namesToSet converts a slice of names into a set with a pre-sized backing
++// map. The returned map is owned by the caller and may be handed off to
++// update() without further copying.
++func namesToSet(names []string) map[string]struct{} {
++	set := make(map[string]struct{}, len(names))
++	for _, n := range names {
++		set[n] = struct{}{}
++	}
++	return set
++}
+diff --git a/pkg/registry/core/namespace/storage/filtering_test.go b/pkg/registry/core/namespace/storage/filtering_test.go
+new file mode 100644
+index 00000000000..9621931772d
+--- /dev/null
++++ b/pkg/registry/core/namespace/storage/filtering_test.go
+@@ -0,0 +1,524 @@
++/*
++Copyright 2025 The Kubernetes Authors.
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++    http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/
++
++package storage
++
++import (
++	"context"
++	"errors"
++	"slices"
++	"sync"
++	"testing"
++	"time"
++
++	apierrors "k8s.io/apimachinery/pkg/api/errors"
++	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
++	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
++	"k8s.io/apimachinery/pkg/watch"
 +	"k8s.io/apiserver/pkg/authentication/user"
 +	"k8s.io/apiserver/pkg/endpoints/filters"
 +	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
@@ -222,524 +1341,486 @@ index 00000000000..c3ce9f7d232
 +	"k8s.io/kubernetes/pkg/registry/registrytest"
 +)
 +
-+// mockAccessibleFetcher implements AccessibleNamespaceFetcher for testing
-+type mockAccessibleFetcher struct {
-+	accessibleNamespaces []string
-+	accessibleMap        map[string]bool
-+	fetchError           error
++// fakeFetcher is a programmable AccessibleNamespaceFetcher. The accessible
++// set is held behind a mutex so tests can mutate it concurrently with a
++// running watch and observe synthetic events.
++type fakeFetcher struct {
++	mu        sync.Mutex
++	names     []string
++	err       error
++	listCalls int
 +}
 +
-+func (m *mockAccessibleFetcher) FetchAccessibleNamespaces(ctx context.Context, username string, groups []string, extra map[string][]string) ([]string, error) {
-+	if m.fetchError != nil {
-+		return nil, m.fetchError
-+	}
-+	return m.accessibleNamespaces, nil
++func (f *fakeFetcher) setNames(names []string) {
++	f.mu.Lock()
++	defer f.mu.Unlock()
++	f.names = slices.Clone(names)
 +}
 +
-+func (m *mockAccessibleFetcher) IsNamespaceAccessible(ctx context.Context, username string, groups []string, extra map[string][]string, namespace string) (bool, error) {
-+	if m.fetchError != nil {
-+		return false, m.fetchError
-+	}
-+	if m.accessibleMap != nil {
-+		return m.accessibleMap[namespace], nil
-+	}
-+	for _, ns := range m.accessibleNamespaces {
-+		if ns == namespace {
-+			return true, nil
-+		}
-+	}
-+	return false, nil
++func (f *fakeFetcher) setError(err error) {
++	f.mu.Lock()
++	defer f.mu.Unlock()
++	f.err = err
 +}
 +
-+// newStorageWithFiltering creates a storage with filtering enabled
-+func newStorageWithFiltering(t *testing.T, fetcher *mockAccessibleFetcher) (*REST, *etcd3testing.EtcdTestServer) {
++func (f *fakeFetcher) snapshotListCalls() int {
++	f.mu.Lock()
++	defer f.mu.Unlock()
++	return f.listCalls
++}
++
++func (f *fakeFetcher) FetchAccessibleNamespaces(_ context.Context, _ user.Info) ([]string, error) {
++	f.mu.Lock()
++	defer f.mu.Unlock()
++	f.listCalls++
++	if f.err != nil {
++		return nil, f.err
++	}
++	return slices.Clone(f.names), nil
++}
++
++func (f *fakeFetcher) IsNamespaceAccessible(_ context.Context, _ user.Info, namespace string) (bool, error) {
++	f.mu.Lock()
++	defer f.mu.Unlock()
++	if f.err != nil {
++		return false, f.err
++	}
++	return slices.Contains(f.names, namespace), nil
++}
++
++// Compile-time guard: the fake must always implement the production
++// interface. Any breaking change there fails the test build first.
++var _ AccessibleNamespaceFetcher = (*fakeFetcher)(nil)
++
++// ----- helpers --------------------------------------------------------------
++
++func newStorageWithFiltering(t *testing.T, fetcher AccessibleNamespaceFetcher, refresh time.Duration) (*REST, *etcd3testing.EtcdTestServer) {
++	t.Helper()
 +	etcdStorage, server := registrytest.NewEtcdStorage(t, "")
-+	restOptions := generic.RESTOptions{StorageConfig: etcdStorage, Decorator: generic.UndecoratedStorage, DeleteCollectionWorkers: 1, ResourcePrefix: "namespaces"}
-+
-+	namespaceStorage, _, _, err := NewRESTWithFiltering(restOptions, fetcher)
-+	if err != nil {
-+		t.Fatalf("unexpected error from REST storage: %v", err)
++	restOptions := generic.RESTOptions{
++		StorageConfig:           etcdStorage,
++		Decorator:               generic.UndecoratedStorage,
++		DeleteCollectionWorkers: 1,
++		ResourcePrefix:          "namespaces",
 +	}
-+	return namespaceStorage, server
++	r, _, _, err := NewREST(
++		restOptions,
++		WithAccessibleNamespaceFetcher(fetcher),
++		WithACLRefreshInterval(refresh),
++	)
++	if err != nil {
++		t.Fatalf("NewREST: %v", err)
++	}
++	return r, server
 +}
 +
-+// createNamespace creates a namespace in storage
-+func createNamespace(t *testing.T, storage *REST, name string) {
-+	ns := &api.Namespace{
-+		ObjectMeta: metav1.ObjectMeta{Name: name},
-+	}
-+	// namespaces are cluster-scoped, so use NamespaceNone
++func createNamespace(t *testing.T, storage *REST, name string) *api.Namespace {
++	t.Helper()
++	ns := &api.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
 +	ctx := genericapirequest.WithNamespace(genericapirequest.NewContext(), metav1.NamespaceNone)
-+	_, err := storage.Create(ctx, ns, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
++	obj, err := storage.Create(ctx, ns, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
 +	if err != nil {
-+		t.Fatalf("failed to create namespace %s: %v", name, err)
++		t.Fatalf("create namespace %q: %v", name, err)
 +	}
++	return obj.(*api.Namespace)
 +}
 +
-+// ctxWithUser creates a context with user info
 +func ctxWithUser(username string, groups []string) context.Context {
-+	ctx := genericapirequest.NewContext()
-+	ctx = genericapirequest.WithUser(ctx, &user.DefaultInfo{Name: username, Groups: groups})
-+	return ctx
++	return genericapirequest.WithUser(genericapirequest.NewContext(), &user.DefaultInfo{Name: username, Groups: groups})
 +}
 +
-+// ctxWithFilteringMode creates a context with namespace filtering mode enabled
-+func ctxWithFilteringMode(ctx context.Context) context.Context {
-+	return filters.WithNamespaceFilteringMode(ctx)
++func ctxFiltered(username string, groups []string) context.Context {
++	return filters.WithNamespaceFilteringMode(ctxWithUser(username, groups))
 +}
 +
-+func TestListWithFiltering_NoFilteringMode_ReturnsAll(t *testing.T) {
-+	fetcher := &mockAccessibleFetcher{accessibleNamespaces: []string{"ns-a"}}
-+	storage, server := newStorageWithFiltering(t, fetcher)
++// emptyListOptions is the minimal ListOptions value the watch path expects:
++// no RV, no selectors, no initial-events flag. Returned as a fresh value on
++// every call so tests can mutate without cross-contamination.
++func emptyListOptions() *metainternalversion.ListOptions {
++	return &metainternalversion.ListOptions{}
++}
++
++// sortedNsNames returns namespace names sorted ascending. Sorting keeps
++// assertions stable against List's unordered output.
++func sortedNsNames(list *api.NamespaceList) []string {
++	out := make([]string, len(list.Items))
++	for i := range list.Items {
++		out[i] = list.Items[i].Name
++	}
++	slices.Sort(out)
++	return out
++}
++
++// drainUntil consumes events from ch until match returns true or timeout
++// fires. Earlier events that did not match are discarded (intentionally —
++// they are the initial replay that storage emits when the watch opens).
++// The returned bool indicates whether the matching event was found.
++func drainUntil(ch <-chan watch.Event, timeout time.Duration, match func(watch.Event) bool) (watch.Event, bool) {
++	deadline := time.NewTimer(timeout)
++	defer deadline.Stop()
++	for {
++		select {
++		case ev := <-ch:
++			if match(ev) {
++				return ev, true
++			}
++		case <-deadline.C:
++			return watch.Event{}, false
++		}
++	}
++}
++
++// expectNamespaceEvent returns a matcher for a watch event of the given type
++// targeting a namespace with the given name. Anything else is ignored
++// (including initial replay events for other namespaces).
++func expectNamespaceEvent(evType watch.EventType, name string) func(watch.Event) bool {
++	return func(ev watch.Event) bool {
++		if ev.Type != evType {
++			return false
++		}
++		ns, ok := ev.Object.(*api.Namespace)
++		return ok && ns.Name == name
++	}
++}
++
++// ----- List path ------------------------------------------------------------
++
++func TestREST_List(t *testing.T) {
++	tests := []struct {
++		name       string
++		fetcher    *fakeFetcher
++		filterMode bool
++		toCreate   []string
++		wantNames  []string
++		wantErr    func(error) bool // nil => expect no error
++	}{
++		{
++			name:       "no filtering mode returns all namespaces",
++			fetcher:    &fakeFetcher{names: []string{"ns-a"}}, // fetcher must not be consulted
++			filterMode: false,
++			toCreate:   []string{"ns-a", "ns-b", "ns-c"},
++			wantNames:  []string{"ns-a", "ns-b", "ns-c"},
++		},
++		{
++			name:       "filtering mode restricts to ACL set",
++			fetcher:    &fakeFetcher{names: []string{"ns-a", "ns-c"}},
++			filterMode: true,
++			toCreate:   []string{"ns-a", "ns-b", "ns-c"},
++			wantNames:  []string{"ns-a", "ns-c"},
++		},
++		{
++			name:       "filtering mode with empty ACL yields empty list",
++			fetcher:    &fakeFetcher{names: nil},
++			filterMode: true,
++			toCreate:   []string{"ns-a", "ns-b"},
++			wantNames:  []string{},
++		},
++		{
++			name:       "filtering mode with fetcher error returns Forbidden",
++			fetcher:    &fakeFetcher{err: errors.New("permission service down")},
++			filterMode: true,
++			toCreate:   nil,
++			wantErr:    apierrors.IsForbidden,
++		},
++	}
++
++	for _, tt := range tests {
++		t.Run(tt.name, func(t *testing.T) {
++			storage, server := newStorageWithFiltering(t, tt.fetcher, 0)
++			defer server.Terminate(t)
++			defer storage.store.DestroyFunc()
++
++			for _, n := range tt.toCreate {
++				createNamespace(t, storage, n)
++			}
++
++			ctx := ctxWithUser("alice", nil)
++			if tt.filterMode {
++				ctx = ctxFiltered("alice", nil)
++			}
++
++			list, err := storage.List(ctx, nil)
++			switch {
++			case tt.wantErr != nil:
++				if err == nil {
++					t.Fatalf("List: want error, got nil")
++				}
++				if !tt.wantErr(err) {
++					t.Fatalf("List: unexpected error kind: %v", err)
++				}
++				return
++			case err != nil:
++				t.Fatalf("List: %v", err)
++			}
++
++			got := sortedNsNames(list.(*api.NamespaceList))
++			want := append([]string(nil), tt.wantNames...)
++			slices.Sort(want)
++			if !slices.Equal(got, want) {
++				t.Fatalf("List items: want %v, got %v", want, got)
++			}
++		})
++	}
++}
++
++// ----- Get path -------------------------------------------------------------
++
++func TestREST_Get(t *testing.T) {
++	tests := []struct {
++		name       string
++		fetcher    *fakeFetcher
++		filterMode bool
++		create     []string
++		target     string
++		wantErr    func(error) bool // nil => expect success
++	}{
++		{
++			name:       "no filtering mode passes through",
++			fetcher:    &fakeFetcher{names: nil}, // fetcher must not be consulted
++			filterMode: false,
++			create:     []string{"ns-a"},
++			target:     "ns-a",
++		},
++		{
++			name:       "filtering mode accessible passes through",
++			fetcher:    &fakeFetcher{names: []string{"ns-a"}},
++			filterMode: true,
++			create:     []string{"ns-a"},
++			target:     "ns-a",
++		},
++		{
++			name:       "filtering mode inaccessible returns NotFound",
++			fetcher:    &fakeFetcher{names: nil},
++			filterMode: true,
++			create:     []string{"ns-a"},
++			target:     "ns-a",
++			wantErr:    apierrors.IsNotFound,
++		},
++		{
++			name:       "filtering mode fetcher error returns Forbidden",
++			fetcher:    &fakeFetcher{err: errors.New("permission service down")},
++			filterMode: true,
++			create:     []string{"ns-a"},
++			target:     "ns-a",
++			wantErr:    apierrors.IsForbidden,
++		},
++	}
++
++	for _, tt := range tests {
++		t.Run(tt.name, func(t *testing.T) {
++			storage, server := newStorageWithFiltering(t, tt.fetcher, 0)
++			defer server.Terminate(t)
++			defer storage.store.DestroyFunc()
++
++			for _, n := range tt.create {
++				createNamespace(t, storage, n)
++			}
++
++			ctx := ctxWithUser("alice", nil)
++			if tt.filterMode {
++				ctx = ctxFiltered("alice", nil)
++			}
++
++			obj, err := storage.Get(ctx, tt.target, &metav1.GetOptions{})
++			switch {
++			case tt.wantErr != nil:
++				if err == nil {
++					t.Fatalf("Get: want error, got nil")
++				}
++				if !tt.wantErr(err) {
++					t.Fatalf("Get: unexpected error kind: %v", err)
++				}
++				return
++			case err != nil:
++				t.Fatalf("Get: %v", err)
++			}
++
++			if got := obj.(*api.Namespace).Name; got != tt.target {
++				t.Fatalf("Get name: want %q, got %q", tt.target, got)
++			}
++		})
++	}
++}
++
++// ----- Watch path: synthetic events on ACL changes --------------------------
++
++func TestWatch_NoFilteringMode_PassesThrough(t *testing.T) {
++	storage, server := newStorageWithFiltering(t, &fakeFetcher{names: []string{"ns-a"}}, 0)
++	defer server.Terminate(t)
++	defer storage.store.DestroyFunc()
++
++	w, err := storage.Watch(ctxWithUser("alice", nil), emptyListOptions())
++	if err != nil {
++		t.Fatalf("Watch: %v", err)
++	}
++	defer w.Stop()
++	if w.ResultChan() == nil {
++		t.Fatal("ResultChan is nil")
++	}
++}
++
++// TestWatch_SynthesizesAddedWhenAccessGained mirrors the canonical OpenShift
++// userProjectWatcher contract: when the user's accessible-namespace set
++// expands mid-watch, we MUST surface an ADDED event for the new namespace
++// — without the client reconnecting.
++//
++// Note: the underlying etcd3 storage replays existing objects matching the
++// predicate as initial ADDED events when a watch opens with empty RV (the
++// legacy "send-everything-then-stream-changes" path). Those events for
++// ns-a are expected and skipped via drainUntil; the assertion is solely
++// about the synthesized ADDED for ns-b.
++func TestWatch_SynthesizesAddedWhenAccessGained(t *testing.T) {
++	fetcher := &fakeFetcher{names: []string{"ns-a"}}
++	storage, server := newStorageWithFiltering(t, fetcher, 50*time.Millisecond)
 +	defer server.Terminate(t)
 +	defer storage.store.DestroyFunc()
 +
 +	createNamespace(t, storage, "ns-a")
 +	createNamespace(t, storage, "ns-b")
-+	createNamespace(t, storage, "ns-c")
 +
-+	ctx := ctxWithUser("test-user", []string{"system:authenticated"})
-+	result, err := storage.List(ctx, nil)
++	ctx, cancel := context.WithCancel(ctxFiltered("alice", nil))
++	defer cancel()
++
++	w, err := storage.Watch(ctx, emptyListOptions())
 +	if err != nil {
-+		t.Fatalf("unexpected error: %v", err)
++		t.Fatalf("Watch: %v", err)
 +	}
++	defer w.Stop()
 +
-+	nsList := result.(*api.NamespaceList)
-+	if len(nsList.Items) != 3 {
-+		t.Errorf("expected 3 namespaces, got %d", len(nsList.Items))
++	fetcher.setNames([]string{"ns-a", "ns-b"})
++
++	if _, ok := drainUntil(w.ResultChan(), 3*time.Second, expectNamespaceEvent(watch.Added, "ns-b")); !ok {
++		t.Fatal("did not observe synthetic ADDED for ns-b within 3s after ACL expansion")
 +	}
 +}
 +
-+func TestListWithFiltering_FilteringMode_FilteredList(t *testing.T) {
-+	fetcher := &mockAccessibleFetcher{accessibleNamespaces: []string{"ns-a", "ns-c"}}
-+	storage, server := newStorageWithFiltering(t, fetcher)
-+	defer server.Terminate(t)
-+	defer storage.store.DestroyFunc()
-+
-+	createNamespace(t, storage, "ns-a")
-+	createNamespace(t, storage, "ns-b")
-+	createNamespace(t, storage, "ns-c")
-+
-+	ctx := ctxWithFilteringMode(ctxWithUser("test-user", []string{"system:authenticated"}))
-+	result, err := storage.List(ctx, nil)
-+	if err != nil {
-+		t.Fatalf("unexpected error: %v", err)
-+	}
-+
-+	nsList := result.(*api.NamespaceList)
-+	if len(nsList.Items) != 2 {
-+		t.Errorf("expected 2 namespaces, got %d", len(nsList.Items))
-+	}
-+}
-+
-+func TestListWithFiltering_FilteringMode_EmptyList(t *testing.T) {
-+	fetcher := &mockAccessibleFetcher{accessibleNamespaces: []string{}}
-+	storage, server := newStorageWithFiltering(t, fetcher)
++// TestWatch_SynthesizesDeletedWhenAccessLost mirrors the converse: when the
++// user loses access to a namespace they previously saw, we surface a stub
++// DELETED so the client's reflector evicts its cache entry.
++func TestWatch_SynthesizesDeletedWhenAccessLost(t *testing.T) {
++	fetcher := &fakeFetcher{names: []string{"ns-a", "ns-b"}}
++	storage, server := newStorageWithFiltering(t, fetcher, 50*time.Millisecond)
 +	defer server.Terminate(t)
 +	defer storage.store.DestroyFunc()
 +
 +	createNamespace(t, storage, "ns-a")
 +	createNamespace(t, storage, "ns-b")
 +
-+	ctx := ctxWithFilteringMode(ctxWithUser("test-user", []string{"system:authenticated"}))
-+	result, err := storage.List(ctx, nil)
++	ctx, cancel := context.WithCancel(ctxFiltered("alice", nil))
++	defer cancel()
++
++	w, err := storage.Watch(ctx, emptyListOptions())
 +	if err != nil {
-+		t.Fatalf("unexpected error: %v", err)
++		t.Fatalf("Watch: %v", err)
 +	}
++	defer w.Stop()
 +
-+	nsList := result.(*api.NamespaceList)
-+	if len(nsList.Items) != 0 {
-+		t.Errorf("expected 0 namespaces, got %d", len(nsList.Items))
-+	}
-+}
++	fetcher.setNames([]string{"ns-a"})
 +
-+func TestListWithFiltering_FetchError_ReturnsForbidden(t *testing.T) {
-+	fetcher := &mockAccessibleFetcher{fetchError: fmt.Errorf("service unavailable")}
-+	storage, server := newStorageWithFiltering(t, fetcher)
-+	defer server.Terminate(t)
-+	defer storage.store.DestroyFunc()
-+
-+	ctx := ctxWithFilteringMode(ctxWithUser("test-user", []string{"system:authenticated"}))
-+	_, err := storage.List(ctx, nil)
-+	if err == nil {
-+		t.Fatal("expected error, got nil")
-+	}
-+	if !apierrors.IsForbidden(err) {
-+		t.Errorf("expected Forbidden error, got %v", err)
++	if _, ok := drainUntil(w.ResultChan(), 3*time.Second, expectNamespaceEvent(watch.Deleted, "ns-b")); !ok {
++		t.Fatal("did not observe synthetic DELETED for ns-b within 3s after ACL contraction")
 +	}
 +}
 +
-+func TestGetWithFiltering_NoFilteringMode_ReturnsNamespace(t *testing.T) {
-+	fetcher := &mockAccessibleFetcher{accessibleNamespaces: []string{"ns-a"}}
-+	storage, server := newStorageWithFiltering(t, fetcher)
++// TestWatch_TransientFetcherErrorPreservesState: a hiccup in the upstream
++// permission service must NOT tear down a live watch, nor flip the user
++// into deny-all. Last known state is preserved until the next successful
++// tick.
++func TestWatch_TransientFetcherErrorPreservesState(t *testing.T) {
++	fetcher := &fakeFetcher{names: []string{"ns-a"}}
++	storage, server := newStorageWithFiltering(t, fetcher, 30*time.Millisecond)
 +	defer server.Terminate(t)
 +	defer storage.store.DestroyFunc()
 +
 +	createNamespace(t, storage, "ns-a")
 +
-+	ctx := ctxWithUser("test-user", []string{"system:authenticated"})
-+	result, err := storage.Get(ctx, "ns-a", &metav1.GetOptions{})
++	ctx, cancel := context.WithCancel(ctxFiltered("alice", nil))
++	defer cancel()
++
++	w, err := storage.Watch(ctx, emptyListOptions())
 +	if err != nil {
-+		t.Fatalf("unexpected error: %v", err)
++		t.Fatalf("Watch: %v", err)
 +	}
-+	ns := result.(*api.Namespace)
-+	if ns.Name != "ns-a" {
-+		t.Errorf("expected ns-a, got %s", ns.Name)
-+	}
-+}
++	defer w.Stop()
 +
-+func TestGetWithFiltering_FilteringMode_AccessibleNamespace(t *testing.T) {
-+	fetcher := &mockAccessibleFetcher{accessibleNamespaces: []string{"ns-a"}, accessibleMap: map[string]bool{"ns-a": true}}
-+	storage, server := newStorageWithFiltering(t, fetcher)
-+	defer server.Terminate(t)
-+	defer storage.store.DestroyFunc()
++	fetcher.setError(errors.New("temporary"))
++	time.Sleep(150 * time.Millisecond)
 +
-+	createNamespace(t, storage, "ns-a")
-+
-+	ctx := ctxWithFilteringMode(ctxWithUser("test-user", []string{"system:authenticated"}))
-+	result, err := storage.Get(ctx, "ns-a", &metav1.GetOptions{})
-+	if err != nil {
-+		t.Fatalf("unexpected error: %v", err)
-+	}
-+	ns := result.(*api.Namespace)
-+	if ns.Name != "ns-a" {
-+		t.Errorf("expected ns-a, got %s", ns.Name)
-+	}
-+}
-+
-+func TestGetWithFiltering_FilteringMode_InaccessibleNamespace_ReturnsNotFound(t *testing.T) {
-+	fetcher := &mockAccessibleFetcher{accessibleNamespaces: []string{}, accessibleMap: map[string]bool{"ns-a": false}}
-+	storage, server := newStorageWithFiltering(t, fetcher)
-+	defer server.Terminate(t)
-+	defer storage.store.DestroyFunc()
-+
-+	createNamespace(t, storage, "ns-a")
-+
-+	ctx := ctxWithFilteringMode(ctxWithUser("test-user", []string{"system:authenticated"}))
-+	_, err := storage.Get(ctx, "ns-a", &metav1.GetOptions{})
-+	if err == nil {
-+		t.Fatal("expected error, got nil")
-+	}
-+	if !apierrors.IsNotFound(err) {
-+		t.Errorf("expected NotFound error, got %v", err)
-+	}
-+}
-+
-+func TestGetWithFiltering_FetchError_ReturnsForbidden(t *testing.T) {
-+	fetcher := &mockAccessibleFetcher{fetchError: fmt.Errorf("service unavailable")}
-+	storage, server := newStorageWithFiltering(t, fetcher)
-+	defer server.Terminate(t)
-+	defer storage.store.DestroyFunc()
-+
-+	createNamespace(t, storage, "ns-a")
-+
-+	ctx := ctxWithFilteringMode(ctxWithUser("test-user", []string{"system:authenticated"}))
-+	_, err := storage.Get(ctx, "ns-a", &metav1.GetOptions{})
-+	if err == nil {
-+		t.Fatal("expected error, got nil")
-+	}
-+	if !apierrors.IsForbidden(err) {
-+		t.Errorf("expected Forbidden error, got %v", err)
-+	}
-+}
-diff --git a/pkg/registry/core/namespace/storage/storage.go b/pkg/registry/core/namespace/storage/storage.go
-index e67cedeb15e..8552fc47b79 100644
---- a/pkg/registry/core/namespace/storage/storage.go
-+++ b/pkg/registry/core/namespace/storage/storage.go
-@@ -26,12 +26,16 @@ import (
- 	"k8s.io/apimachinery/pkg/runtime"
- 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
- 	"k8s.io/apimachinery/pkg/watch"
-+	"k8s.io/apiserver/pkg/endpoints/filters"
-+	"k8s.io/apiserver/pkg/endpoints/request"
- 	"k8s.io/apiserver/pkg/registry/generic"
- 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
- 	"k8s.io/apiserver/pkg/registry/rest"
- 	"k8s.io/apiserver/pkg/storage"
- 	storageerr "k8s.io/apiserver/pkg/storage/errors"
- 	"k8s.io/apiserver/pkg/util/dryrun"
-+	restclient "k8s.io/client-go/rest"
-+	"k8s.io/klog/v2"
- 	api "k8s.io/kubernetes/pkg/apis/core"
- 	"k8s.io/kubernetes/pkg/printers"
- 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
-@@ -40,10 +44,25 @@ import (
- 	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
- )
- 
-+// AccessibleNamespaceFetcher is an interface for fetching accessible namespaces for a user.
-+// This is typically implemented by calling an external service (e.g., permission-browser-apiserver).
-+type AccessibleNamespaceFetcher interface {
-+	// FetchAccessibleNamespaces returns a list of namespace names that the user has access to.
-+	FetchAccessibleNamespaces(ctx context.Context, username string, groups []string, extra map[string][]string) ([]string, error)
-+
-+	// IsNamespaceAccessible checks if a specific namespace is accessible to the user.
-+	IsNamespaceAccessible(ctx context.Context, username string, groups []string, extra map[string][]string, namespace string) (bool, error)
-+}
-+
- // rest implements a RESTStorage for namespaces
- type REST struct {
- 	store  *genericregistry.Store
- 	status *genericregistry.Store
-+
-+	// Deckhouse: namespace filtering support.
-+	// If set, namespaces will be filtered based on user permissions
-+	// when IsNamespaceFilteringMode(ctx) is true.
-+	accessibleFetcher AccessibleNamespaceFetcher
- }
- 
- // StatusREST implements the REST endpoint for changing the status of a namespace.
-@@ -58,6 +77,30 @@ type FinalizeREST struct {
- 
- // NewREST returns a RESTStorage object that will work against namespaces.
- func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, *FinalizeREST, error) {
-+	return NewRESTWithFiltering(optsGetter, nil)
-+}
-+
-+// NewRESTWithDeckhouseFiltering returns a RESTStorage object with Deckhouse namespace filtering enabled.
-+// It uses the loopback client config to call permission-browser-apiserver through kube-apiserver's
-+// aggregated API mechanism with impersonation.
-+// Filtering is triggered when IsNamespaceFilteringMode(ctx) is true (set by WithAuthorization filter).
-+// If loopbackConfig is nil, filtering is disabled (vanilla Kubernetes behavior).
-+func NewRESTWithDeckhouseFiltering(optsGetter generic.RESTOptionsGetter, loopbackConfig *restclient.Config) (*REST, *StatusREST, *FinalizeREST, error) {
-+	var fetcher AccessibleNamespaceFetcher
-+	if loopbackConfig != nil {
-+		var err error
-+		fetcher, err = NewLoopbackAccessibleNamespaceFetcher(loopbackConfig)
-+		if err != nil {
-+			klog.Warningf("Failed to create loopback accessible namespace fetcher: %v, namespace filtering disabled", err)
-+			fetcher = nil
++	select {
++	case ev := <-w.ResultChan():
++		if ev.Type == watch.Error {
++			t.Fatalf("transient fetcher error must not yield watch.Error, got %+v", ev)
 +		}
++	default:
++		// healthy: no event pending
 +	}
-+	return NewRESTWithFiltering(optsGetter, fetcher)
++
++	createNamespace(t, storage, "ns-b")
++	fetcher.setError(nil)
++	fetcher.setNames([]string{"ns-a", "ns-b"})
++
++	if _, ok := drainUntil(w.ResultChan(), 3*time.Second, expectNamespaceEvent(watch.Added, "ns-b")); !ok {
++		t.Fatal("did not observe ADDED for ns-b after fetcher recovery within 3s")
++	}
 +}
 +
-+// NewRESTWithFiltering returns a RESTStorage object with optional namespace filtering support.
-+// If fetcher is nil, filtering is disabled (default Kubernetes behavior).
-+func NewRESTWithFiltering(optsGetter generic.RESTOptionsGetter, fetcher AccessibleNamespaceFetcher) (*REST, *StatusREST, *FinalizeREST, error) {
- 	store := &genericregistry.Store{
- 		NewFunc:                   func() runtime.Object { return &api.Namespace{} },
- 		NewListFunc:               func() runtime.Object { return &api.NamespaceList{} },
-@@ -88,7 +131,8 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, *Finaliz
- 	finalizeStore.UpdateStrategy = namespace.FinalizeStrategy
- 	finalizeStore.ResetFieldsStrategy = namespace.FinalizeStrategy
- 
--	return &REST{store: store, status: &statusStore}, &StatusREST{store: &statusStore}, &FinalizeREST{store: &finalizeStore}, nil
-+	r := &REST{store: store, status: &statusStore, accessibleFetcher: fetcher}
-+	return r, &StatusREST{store: &statusStore}, &FinalizeREST{store: &finalizeStore}, nil
- }
- 
- func (r *REST) NamespaceScoped() bool {
-@@ -115,7 +159,32 @@ func (r *REST) NewList() runtime.Object {
- }
- 
- func (r *REST) List(ctx context.Context, options *metainternalversion.ListOptions) (runtime.Object, error) {
--	return r.store.List(ctx, options)
-+	// Fast path: no filtering needed (either disabled or user has full access)
-+	if !r.shouldFilter(ctx) {
-+		return r.store.List(ctx, options)
-+	}
++// TestWatch_ResultChanClosesOnStop verifies the watch.Interface contract:
++// after Stop(), ResultChan must close so clients ranging over it terminate.
++// Without this, a `for ev := range w.ResultChan()` loop would block forever.
++func TestWatch_ResultChanClosesOnStop(t *testing.T) {
++	storage, server := newStorageWithFiltering(t, &fakeFetcher{names: []string{"ns-a"}}, 50*time.Millisecond)
++	defer server.Terminate(t)
++	defer storage.store.DestroyFunc()
 +
-+	accessibleNames, err := r.getAccessibleNamespaces(ctx)
++	createNamespace(t, storage, "ns-a")
++
++	w, err := storage.Watch(ctxFiltered("alice", nil), emptyListOptions())
 +	if err != nil {
-+		klog.Warningf("Failed to fetch accessible namespaces: %v, returning forbidden", err)
-+		return nil, apierrors.NewForbidden(api.Resource("namespaces"), "", fmt.Errorf("cannot list namespaces"))
++		t.Fatalf("Watch: %v", err)
 +	}
 +
-+	if len(accessibleNames) == 0 {
-+		return &api.NamespaceList{
-+			TypeMeta: metav1.TypeMeta{
-+				Kind:       "NamespaceList",
-+				APIVersion: "v1",
-+			},
-+		}, nil
-+	}
-+
-+	fullList, err := r.store.List(ctx, options)
-+	if err != nil {
-+		return nil, apierrors.NewInternalError(err)
-+	}
-+
-+	return r.filterNamespaceList(fullList, accessibleNames), nil
- }
- 
- func (r *REST) Create(ctx context.Context, obj runtime.Object, createValidation rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {
-@@ -127,13 +196,101 @@ func (r *REST) Update(ctx context.Context, name string, objInfo rest.UpdatedObje
- }
- 
- func (r *REST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
-+	// Fast path: no filtering needed (either disabled or user has full access)
-+	if !r.shouldFilter(ctx) {
-+		return r.store.Get(ctx, name, options)
-+	}
-+
-+	accessible, err := r.isNamespaceAccessibleToUser(ctx, name)
-+	if err != nil {
-+		// Return Forbidden when permission-browser-apiserver is unavailable.
-+		klog.Warningf("Failed to check namespace accessibility for %s: %v, returning forbidden", name, err)
-+		return nil, apierrors.NewForbidden(api.Resource("namespaces"), name, fmt.Errorf("cannot get namespace"))
-+	}
-+
-+	if !accessible {
-+		// Return NotFound instead of Forbidden to avoid existence disclosure.
-+		return nil, apierrors.NewNotFound(api.Resource("namespaces"), name)
-+	}
-+
- 	return r.store.Get(ctx, name, options)
- }
- 
- func (r *REST) Watch(ctx context.Context, options *metainternalversion.ListOptions) (watch.Interface, error) {
-+	// Note: Watch filtering is not implemented in MVP.
- 	return r.store.Watch(ctx, options)
- }
- 
-+// isFilteringEnabled returns true if namespace filtering is configured.
-+func (r *REST) isFilteringEnabled() bool {
-+	return r.accessibleFetcher != nil
-+}
-+
-+// shouldFilter checks if filtering should be applied for this request.
-+// Filtering is triggered when:
-+// 1. accessibleFetcher is configured
-+// 2. IsNamespaceFilteringMode(ctx) is true (user was denied by authorizer but bypassed)
-+func (r *REST) shouldFilter(ctx context.Context) bool {
-+	return r.isFilteringEnabled() && filters.IsNamespaceFilteringMode(ctx)
-+}
-+
-+// getAccessibleNamespaces fetches accessible namespace names for the user from external service.
-+func (r *REST) getAccessibleNamespaces(ctx context.Context) ([]string, error) {
-+	userInfo, ok := request.UserFrom(ctx)
-+	if !ok {
-+		return nil, fmt.Errorf("no user info in context")
-+	}
-+
-+	extra := make(map[string][]string)
-+	for k, v := range userInfo.GetExtra() {
-+		extra[k] = v
-+	}
-+
-+	return r.accessibleFetcher.FetchAccessibleNamespaces(ctx, userInfo.GetName(), userInfo.GetGroups(), extra)
-+}
-+
-+// isNamespaceAccessibleToUser checks if a specific namespace is accessible to the user.
-+func (r *REST) isNamespaceAccessibleToUser(ctx context.Context, name string) (bool, error) {
-+	userInfo, ok := request.UserFrom(ctx)
-+	if !ok {
-+		return false, fmt.Errorf("no user info in context")
-+	}
-+
-+	extra := make(map[string][]string)
-+	for k, v := range userInfo.GetExtra() {
-+		extra[k] = v
-+	}
-+
-+	return r.accessibleFetcher.IsNamespaceAccessible(ctx, userInfo.GetName(), userInfo.GetGroups(), extra, name)
-+}
-+
-+// filterNamespaceList filters a NamespaceList to only include accessible namespaces.
-+func (r *REST) filterNamespaceList(list runtime.Object, accessibleNames []string) runtime.Object {
-+	nsList, ok := list.(*api.NamespaceList)
-+	if !ok {
-+		return list
-+	}
-+
-+	accessibleSet := make(map[string]struct{}, len(accessibleNames))
-+	for _, name := range accessibleNames {
-+		accessibleSet[name] = struct{}{}
-+	}
-+
-+	filtered := &api.NamespaceList{
-+		TypeMeta: nsList.TypeMeta,
-+		ListMeta: nsList.ListMeta,
-+		Items:    make([]api.Namespace, 0, len(accessibleNames)),
-+	}
-+
-+	for _, ns := range nsList.Items {
-+		if _, ok := accessibleSet[ns.Name]; ok {
-+			filtered.Items = append(filtered.Items, ns)
++	done := make(chan struct{})
++	go func() {
++		defer close(done)
++		for range w.ResultChan() {
++			// drain
 +		}
++	}()
++
++	w.Stop()
++
++	select {
++	case <-done:
++		// ResultChan closed, range loop exited — good.
++	case <-time.After(3 * time.Second):
++		t.Fatal("ResultChan was not closed within 3s of Stop()")
++	}
++}
++
++// TestWatch_StopIsIdempotent: Stop() is safe to call multiple times and
++// fully halts the ACL poller — verified by snapshotting the fetcher call
++// count before and after a quiet interval.
++func TestWatch_StopIsIdempotent(t *testing.T) {
++	fetcher := &fakeFetcher{names: []string{"ns-a"}}
++	storage, server := newStorageWithFiltering(t, fetcher, 20*time.Millisecond)
++	defer server.Terminate(t)
++	defer storage.store.DestroyFunc()
++
++	createNamespace(t, storage, "ns-a")
++
++	w, err := storage.Watch(ctxFiltered("alice", nil), emptyListOptions())
++	if err != nil {
++		t.Fatalf("Watch: %v", err)
 +	}
 +
-+	return filtered
++	w.Stop()
++	w.Stop() // must not panic, must not double-close.
++
++	time.Sleep(60 * time.Millisecond)
++	beforeCalls := fetcher.snapshotListCalls()
++	time.Sleep(150 * time.Millisecond)
++	afterCalls := fetcher.snapshotListCalls()
++	if afterCalls != beforeCalls {
++		t.Fatalf("ACL poller still ticking after Stop: before=%d after=%d", beforeCalls, afterCalls)
++	}
 +}
-+
- // Delete enforces life-cycle rules for namespace termination
- func (r *REST) Delete(ctx context.Context, name string, deleteValidation rest.ValidateObjectFunc, options *metav1.DeleteOptions) (runtime.Object, bool, error) {
- 	nsObj, err := r.Get(ctx, name, &metav1.GetOptions{})
-diff --git a/pkg/registry/core/rest/storage_core_generic.go b/pkg/registry/core/rest/storage_core_generic.go
-index 9d82ca85633..a02d7078145 100644
---- a/pkg/registry/core/rest/storage_core_generic.go
-+++ b/pkg/registry/core/rest/storage_core_generic.go
-@@ -106,7 +106,10 @@ func (c *GenericConfig) NewRESTStorage(apiResourceConfigSource serverstorage.API
- 		return genericapiserver.APIGroupInfo{}, err
- 	}
- 
--	namespaceStorage, namespaceStatusStorage, namespaceFinalizeStorage, err := namespacestore.NewREST(restOptionsGetter)
-+	// Deckhouse: Always use filtering-capable namespace storage with loopback client for proper auth.
-+	// Actual filtering only happens when filters.IsNamespaceFilteringMode(ctx) is true
-+	// (set by WithAuthorization filter when user does not have list/get namespaces permission).
-+	namespaceStorage, namespaceStatusStorage, namespaceFinalizeStorage, err := namespacestore.NewRESTWithDeckhouseFiltering(restOptionsGetter, c.LoopbackClientConfig)
- 	if err != nil {
- 		return genericapiserver.APIGroupInfo{}, err
- 	}
-diff --git a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authorization.go b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authorization.go
-index 439696d07ab..6831f210f7e 100644
---- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authorization.go
-+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authorization.go
-@@ -47,6 +47,35 @@ const (
- 	reasonError    = "internal error"
- )
- 
-+// Deckhouse: Context key for namespace filtering mode.
-+// When set to true, indicates that the request was denied by authorizer but bypassed
-+// because it's a namespace list/get request that should be filtered by accessible namespaces.
-+type namespaceFilteringModeKey struct{}
-+
-+// IsNamespaceFilteringMode returns true if the request context indicates that
-+// namespace filtering should be applied (user doesn't have full list/get namespaces permission).
-+func IsNamespaceFilteringMode(ctx context.Context) bool {
-+	val, ok := ctx.Value(namespaceFilteringModeKey{}).(bool)
-+	return ok && val
-+}
-+
-+// WithNamespaceFilteringMode returns a new context with namespace filtering mode set.
-+// This is primarily for testing purposes.
-+func WithNamespaceFilteringMode(ctx context.Context) context.Context {
-+	return context.WithValue(ctx, namespaceFilteringModeKey{}, true)
-+}
-+
-+// isNamespaceListOrGetRequest checks if the request is for listing or getting namespaces.
-+// Deckhouse-specific: these requests are bypassed from 403 to allow filtered responses.
-+func isNamespaceListOrGetRequest(requestInfo *request.RequestInfo) bool {
-+	return requestInfo != nil &&
-+		requestInfo.IsResourceRequest &&
-+		requestInfo.APIGroup == "" &&
-+		requestInfo.Resource == "namespaces" &&
-+		requestInfo.Subresource == "" &&
-+		(requestInfo.Verb == "list" || requestInfo.Verb == "get")
-+}
-+
- type recordAuthorizationMetricsFunc func(ctx context.Context, authorized authorizer.Decision, err error, authStart time.Time, authFinish time.Time)
- 
- // WithAuthorization passes all authorized requests on to handler, and returns a forbidden error otherwise.
-@@ -90,6 +119,20 @@ func withAuthorization(handler http.Handler, a authorizer.Authorizer, s runtime.
- 			return
- 		}
- 
-+		// Deckhouse: bypass 403 for namespace list/get requests to allow filtered responses.
-+		// The storage layer will check IsNamespaceFilteringMode() and filter accordingly.
-+		requestInfo, _ := request.RequestInfoFrom(ctx)
-+		if isNamespaceListOrGetRequest(requestInfo) {
-+			klog.V(4).InfoS("Bypassing authorization denial for namespace request, will filter in storage",
-+				"URI", req.RequestURI, "verb", requestInfo.Verb, "reason", reason)
-+			audit.AddAuditAnnotations(ctx,
-+				decisionAnnotationKey, "allow-filtered",
-+				reasonAnnotationKey, "namespace filtering mode")
-+			filteredCtx := context.WithValue(ctx, namespaceFilteringModeKey{}, true)
-+			handler.ServeHTTP(w, req.WithContext(filteredCtx))
-+			return
-+		}
-+
- 		klog.V(4).InfoS("Forbidden", "URI", req.RequestURI, "reason", reason)
- 		audit.AddAuditAnnotations(ctx,
- 			decisionAnnotationKey, decisionForbid,


### PR DESCRIPTION
## Description

Refactor of the existing patch. The previous version filtered the `List` path via post-processing; **`Watch` was not implemented at all**. We rewrote List/Get/Watch on top of `storage.SelectionPredicate` and added a real ACL poller for Watch. Upstream contract and the `permission-browser-apiserver` integration are unchanged.

**What's new vs the previous patch**

- `List` now uses `Store.ListPredicate` with a live `fields.Selector` (atomic name-set), AND'd with caller selectors. No more in-memory post-scan.
- **`Watch` is implemented**:
  - storage watch opens with the same predicate, so events for namespaces outside the user's set are dropped at the cacher layer;
  - a 1 s background poller diffs the accessible set against `knownNames` and synthesizes `ADDED` on grant, `DELETED`;

**Critical components affected**

- `kube-apiserver` image is rebuilt → **all control-plane pods will be restarted on update**.

## Why do we need it, and what problem does it solve?

Users with namespace-scoped access (e.g. `Editor` on `tier=prod` label-scoped `ClusterAuthorizationRule`) could already see filtered `d8 k get ns` via the old patch, but `d8 k get ns -w` was missing — k9s/Lens/Dashboard couldn't observe permission changes without reconnecting. This PR closes it gap.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist

- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: common
type: feature
summary: Added real-time namespace watching via `d8 k get ns -w`.
impact_level: default
```