### PR TITLE
[node-manager] Fix CAPS StaticInstance duplicate create validation

### DIFF
--- a/modules/040-node-manager/images/caps-controller-manager/src/api/deckhouse.io/v1alpha1/staticinstance_webhook.go
+++ b/modules/040-node-manager/images/caps-controller-manager/src/api/deckhouse.io/v1alpha1/staticinstance_webhook.go
@@ -87,6 +87,16 @@ func (*StaticInstanceCustomValidator) ValidateCreate(ctx context.Context, obj ru
 		return nil, fmt.Errorf("failed to create Kubernetes client: %w", err)
 	}
 
+	existing := &StaticInstance{}
+	err = cli.Get(ctx, client.ObjectKey{Name: staticInstance.Name}, existing)
+	switch {
+	case err == nil:
+		staticinstancelog.Info("StaticInstance already exists, skipping address validation", "name", staticInstance.GetName())
+		return nil, nil
+	case !apierrors.IsNotFound(err):
+		return nil, fmt.Errorf("failed to get StaticInstance %q: %w", staticInstance.GetName(), err)
+	}
+
 	if err := staticInstance.validateAddressIfNoSkipBootstrap(ctx, cli); err != nil {
 		return nil, field.Forbidden(field.NewPath("spec", "address"), err.Error())
 	}

--- a/modules/040-node-manager/images/caps-controller-manager/src/api/deckhouse.io/v1alpha2/staticinstance_webhook.go
+++ b/modules/040-node-manager/images/caps-controller-manager/src/api/deckhouse.io/v1alpha2/staticinstance_webhook.go
@@ -87,6 +87,16 @@ func (r *StaticInstanceCustomValidator) ValidateCreate(_ context.Context, obj ru
 		return nil, fmt.Errorf("failed to create Kubernetes client: %w", err)
 	}
 
+	existing := &StaticInstance{}
+	err = cli.Get(ctx, client.ObjectKey{Name: staticInstance.Name}, existing)
+	switch {
+	case err == nil:
+		staticinstancelog.Info("StaticInstance already exists, skipping address validation", "name", staticInstance.Name)
+		return nil, nil
+	case !apierrors.IsNotFound(err):
+		return nil, fmt.Errorf("failed to get StaticInstance %q: %w", staticInstance.Name, err)
+	}
+
 	if err := staticInstance.validateAddressIfNoSkipBootstrap(ctx, cli); err != nil {
 		return nil, field.Forbidden(field.NewPath("spec", "address"), err.Error())
 	}


### PR DESCRIPTION
## Description
This PR fixes `StaticInstance` create validation for the case when CAPS attempts to create a `StaticInstance` that already exists.

Previously, the validating webhook checked the requested `spec.address` against existing Node addresses before Kubernetes could return the native `AlreadyExists` error. If the existing `StaticInstance` already corresponded to a Node with the same address, the webhook rejected the request with a misleading `Forbidden` error suggesting `static.node.deckhouse.io/skip-bootstrap-phase`.

Now the webhook first checks whether a `StaticInstance` with the same name already exists. If it does, the webhook skips address validation and lets the Kubernetes API server handle the duplicate create, returning the expected `AlreadyExists` error.


## Why do we need it, and what problem does it solve?
CAPS should not fail duplicate create attempts with address validation errors. When the target `StaticInstance` already exists, the correct behavior is to let Kubernetes report that the object already exists.


## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: fix CAPS StaticInstance duplicate create validation
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
