### PR TITLE
[node-manager] Fix env tests for node-controller

### DIFF
--- a/modules/040-node-manager/images/node-controller/src/internal/controller/bashiblecleanup/suite_test.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/bashiblecleanup/suite_test.go
@@ -65,7 +65,7 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping the envtest environment (Node is core, no CRDs needed)")
 	var err error
-	testEnv, cfg, k8sClient, err = testenv.Start(scheme, nil)
+	testEnv, cfg, k8sClient, err = testenv.Start(scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	// The bashible-cleanup controller registered itself via its package init(); since only this

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/draining/suite_test.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/draining/suite_test.go
@@ -67,7 +67,12 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping the envtest environment with the NodeGroup CRD")
 	var err error
-	testEnv, cfg, k8sClient, err = testenv.Start(scheme, testenv.NodeGroupCRDFile)
+	testEnv, cfg, k8sClient, err = testenv.Start(
+		scheme,
+		testenv.CRDPaths(
+			testenv.WithNodeGroupCRDFile(),
+		)...,
+	)
 	Expect(err).NotTo(HaveOccurred())
 
 	// The draining controller registered itself via its package init(); since only this package is

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/draining/suite_test.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/draining/suite_test.go
@@ -22,7 +22,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -68,7 +67,7 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping the envtest environment with the NodeGroup CRD")
 	var err error
-	testEnv, cfg, k8sClient, err = testenv.Start(scheme, testenv.CRDPaths("node_group.yaml"))
+	testEnv, cfg, k8sClient, err = testenv.Start(scheme, testenv.NodeGroupCRDFile)
 	Expect(err).NotTo(HaveOccurred())
 
 	// The draining controller registered itself via its package init(); since only this package is

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/instance/suite_test.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/instance/suite_test.go
@@ -22,7 +22,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
 	corev1 "k8s.io/api/core/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -77,7 +76,11 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping the envtest environment with deckhouse CRDs")
 	var err error
-	testEnv, cfg, k8sClient, err = testenv.Start(scheme, testenv.CRDPaths("instance.yaml", "machine.yaml", "mcm.yaml"))
+	testEnv, cfg, k8sClient, err = testenv.Start(scheme,
+		testenv.InstanceCRDFile,
+		testenv.MCMCRDFile,
+		testenv.MachineCRDFile,
+	)
 	Expect(err).NotTo(HaveOccurred())
 
 	By("creating the machine namespace")

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/instance/suite_test.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/instance/suite_test.go
@@ -76,10 +76,13 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping the envtest environment with deckhouse CRDs")
 	var err error
-	testEnv, cfg, k8sClient, err = testenv.Start(scheme,
-		testenv.InstanceCRDFile,
-		testenv.MCMCRDFile,
-		testenv.MachineCRDFile,
+	testEnv, cfg, k8sClient, err = testenv.Start(
+		scheme,
+		testenv.CRDPaths(
+			testenv.WithInstanceCRDFile(),
+			testenv.WithMCMCRDFile(),
+			testenv.WithMachineCRDFile(),
+		)...,
 	)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/nodegroup/suite_test.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/nodegroup/suite_test.go
@@ -74,11 +74,14 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping the envtest environment with the nodegroup CRDs")
 	var err error
-	testEnv, cfg, k8sClient, err = testenv.Start(scheme,
-		testenv.NodeGroupCRDFile,
-		testenv.MCMCRDFile,
-		testenv.MachineCRDFile,
-		testenv.MachineDeploymentCRDFile,
+	testEnv, cfg, k8sClient, err = testenv.Start(
+		scheme,
+		testenv.CRDPaths(
+			testenv.WithNodeGroupCRDFile(),
+			testenv.WithMCMCRDFile(),
+			testenv.WithMachineCRDFile(),
+			testenv.WithMachineDeploymentCRDFile(),
+		)...,
 	)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/nodegroup/suite_test.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/nodegroup/suite_test.go
@@ -22,7 +22,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
 	corev1 "k8s.io/api/core/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -75,8 +74,12 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping the envtest environment with the nodegroup CRDs")
 	var err error
-	testEnv, cfg, k8sClient, err = testenv.Start(scheme, testenv.CRDPaths(
-		"node_group.yaml", "mcm.yaml", "machine.yaml", "machine-deployment.yaml"))
+	testEnv, cfg, k8sClient, err = testenv.Start(scheme,
+		testenv.NodeGroupCRDFile,
+		testenv.MCMCRDFile,
+		testenv.MachineCRDFile,
+		testenv.MachineDeploymentCRDFile,
+	)
 	Expect(err).NotTo(HaveOccurred())
 
 	By("creating the machine namespace")

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/nodetemplate/suite_test.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/nodetemplate/suite_test.go
@@ -22,7 +22,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -68,7 +67,7 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping the envtest environment with the NodeGroup CRD")
 	var err error
-	testEnv, cfg, k8sClient, err = testenv.Start(scheme, testenv.CRDPaths("node_group.yaml"))
+	testEnv, cfg, k8sClient, err = testenv.Start(scheme, testenv.NodeGroupCRDFile)
 	Expect(err).NotTo(HaveOccurred())
 
 	// The node-template controller registered itself via its package init(); since only this

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/nodetemplate/suite_test.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/nodetemplate/suite_test.go
@@ -67,7 +67,12 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping the envtest environment with the NodeGroup CRD")
 	var err error
-	testEnv, cfg, k8sClient, err = testenv.Start(scheme, testenv.NodeGroupCRDFile)
+	testEnv, cfg, k8sClient, err = testenv.Start(
+		scheme,
+		testenv.CRDPaths(
+			testenv.WithNodeGroupCRDFile(),
+		)...,
+	)
 	Expect(err).NotTo(HaveOccurred())
 
 	// The node-template controller registered itself via its package init(); since only this

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/staticproviderid/suite_test.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/staticproviderid/suite_test.go
@@ -67,7 +67,7 @@ var _ = BeforeSuite(func() {
 	// The controller only reads and writes core Node objects, so no CRDs are needed.
 	By("bootstrapping the envtest environment")
 	var err error
-	testEnv, cfg, k8sClient, err = testenv.Start(scheme, nil)
+	testEnv, cfg, k8sClient, err = testenv.Start(scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	// The static-provider-id controller registered itself via its package init(); since only this

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/updateapproval/suite_test.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/updateapproval/suite_test.go
@@ -22,7 +22,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
 	corev1 "k8s.io/api/core/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -74,7 +73,7 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping the envtest environment with the NodeGroup CRD")
 	var err error
-	testEnv, cfg, k8sClient, err = testenv.Start(scheme, testenv.CRDPaths("node_group.yaml"))
+	testEnv, cfg, k8sClient, err = testenv.Start(scheme, testenv.NodeGroupCRDFile)
 	Expect(err).NotTo(HaveOccurred())
 
 	By("creating the machine namespace")

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/updateapproval/suite_test.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/updateapproval/suite_test.go
@@ -73,7 +73,12 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping the envtest environment with the NodeGroup CRD")
 	var err error
-	testEnv, cfg, k8sClient, err = testenv.Start(scheme, testenv.NodeGroupCRDFile)
+	testEnv, cfg, k8sClient, err = testenv.Start(
+		scheme,
+		testenv.CRDPaths(
+			testenv.WithNodeGroupCRDFile(),
+		)...,
+	)
 	Expect(err).NotTo(HaveOccurred())
 
 	By("creating the machine namespace")

--- a/modules/040-node-manager/images/node-controller/src/internal/testenv/crd.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/testenv/crd.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testenv
+
+import (
+	"maps"
+	"slices"
+)
+
+type (
+	ControllerCRDFile  string
+	NodeManagerCRDFile string
+)
+
+const (
+	MachineCRDFile           ControllerCRDFile = "machine.yaml"
+	MachineDeploymentCRDFile ControllerCRDFile = "machine-deployment.yaml"
+
+	NodeGroupCRDFile NodeManagerCRDFile = "node_group.yaml"
+	MCMCRDFile       NodeManagerCRDFile = "mcm.yaml"
+	InstanceCRDFile  NodeManagerCRDFile = "instance.yaml"
+)
+
+func ControllerCRDPaths(crds ...ControllerCRDFile) []string {
+	return resolveUpPaths("node-controller/crds", crds)
+}
+
+func NodeManagerCRDPaths(crds ...NodeManagerCRDFile) []string {
+	return resolveUpPaths("040-node-manager/crds", crds)
+}
+
+type crdSet struct {
+	controller  map[ControllerCRDFile]struct{}
+	nodeManager map[NodeManagerCRDFile]struct{}
+}
+
+func (s *crdSet) controllerCRDFiles() []ControllerCRDFile {
+	if len(s.controller) == 0 {
+		return nil
+	}
+	return slices.Collect(maps.Keys(s.controller))
+}
+
+func (s *crdSet) nodeManagerCRDFiles() []NodeManagerCRDFile {
+	if len(s.nodeManager) == 0 {
+		return nil
+	}
+	return slices.Collect(maps.Keys(s.nodeManager))
+}
+
+type crdOpt func(*crdSet)
+
+func WithController(crds ...ControllerCRDFile) crdOpt {
+	return func(s *crdSet) {
+		for _, crd := range crds {
+			s.controller[crd] = struct{}{}
+		}
+	}
+}
+
+func WithNodeManager(crds ...NodeManagerCRDFile) crdOpt {
+	return func(s *crdSet) {
+		for _, crd := range crds {
+			s.nodeManager[crd] = struct{}{}
+		}
+	}
+}
+
+func WithMachineCRDFile() crdOpt {
+	return WithController(MachineCRDFile)
+}
+
+func WithMachineDeploymentCRDFile() crdOpt {
+	return WithController(MachineDeploymentCRDFile)
+}
+
+func WithNodeGroupCRDFile() crdOpt {
+	return WithNodeManager(NodeGroupCRDFile)
+}
+
+func WithMCMCRDFile() crdOpt {
+	return WithNodeManager(MCMCRDFile)
+}
+
+func WithInstanceCRDFile() crdOpt {
+	return WithNodeManager(InstanceCRDFile)
+}
+
+func CRDPaths(opts ...crdOpt) []string {
+	s := &crdSet{
+		controller:  make(map[ControllerCRDFile]struct{}),
+		nodeManager: make(map[NodeManagerCRDFile]struct{}),
+	}
+
+	for _, opt := range opts {
+		opt(s)
+	}
+
+	return slices.Concat(
+		ControllerCRDPaths(s.controllerCRDFiles()...),
+		NodeManagerCRDPaths(s.nodeManagerCRDFiles()...),
+	)
+}

--- a/modules/040-node-manager/images/node-controller/src/internal/testenv/doc.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/testenv/doc.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package testenv holds controller-agnostic helpers for envtest-based integration suites.
+// It boots a real apiserver, wires registered controllers into a manager, and provides
+// common test plumbing (unique names, finalizer stripping, kubectl-style dumps, a pause
+// hook). It is free of Ginkgo/Gomega so it can back any test runner.
+//
+// # Bootstrap
+//
+// [Start] boots an envtest apiserver and returns a client; stop it in AfterSuite.
+// [BinaryAssetsDir] locates kubebuilder assets (KUBEBUILDER_ASSETS overrides); use
+// [AssetsAvailable] to Skip when missing. [NewManager] builds a manager with metrics
+// and leader-election off, wiring controllers registered via register.RegisterController.
+//
+// # CRD paths
+//
+// [ControllerCRDPaths] and [NodeManagerCRDPaths] resolve CRD YAMLs from
+// node-controller/crds and 040-node-manager/crds by walking up to the module root.
+//
+// # Test plumbing
+//
+// [UniqueName] yields unique DNS-safe names. [RemoveFinalizers] strips finalizers with
+// re-get/retry. [SetupLogger] silences logs (ENVTEST_LOGS=1 turns them on). [DebugEnabled]
+// gates dumps from [KubectlDumpNodeObjects]. [PauseForKubectl] blocks for manual kubectl.
+package testenv

--- a/modules/040-node-manager/images/node-controller/src/internal/testenv/path.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/testenv/path.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testenv
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func findDirUp(name string) string {
+	dir, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	for {
+		candidate := filepath.Join(dir, name)
+		if fi, err := os.Stat(candidate); err == nil && fi.IsDir() {
+			return candidate
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
+}
+
+func resolveUpPaths[T ~string](dirUp string, subpath []T) []string {
+	if len(subpath) == 0 {
+		return nil
+	}
+
+	base := findDirUp(dirUp)
+	ret := make([]string, 0, len(subpath))
+
+	for _, f := range subpath {
+		ret = append(ret, filepath.Join(base, string(f)))
+	}
+	return ret
+}

--- a/modules/040-node-manager/images/node-controller/src/internal/testenv/testenv.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/testenv/testenv.go
@@ -14,11 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package testenv holds controller-agnostic helpers for envtest-based integration suites.
-// Any node-controller controller can use it to bootstrap a real apiserver, wire its
-// registered controllers into a manager, and get the common test plumbing (unique names,
-// finalizer stripping, kubectl-style dumps, a kubectl pause hook). It is intentionally
-// free of Ginkgo/Gomega so it can back any test runner.
 package testenv
 
 import (
@@ -57,17 +52,6 @@ const (
 // KubeconfigPath is where PauseForKubectl writes the envtest kubeconfig.
 const KubeconfigPath = "/tmp/envtest.kubeconfig"
 
-// CRD manifest file names loaded by envtest.
-type CRDFile string
-
-const (
-	MachineCRDFile           CRDFile = "machine.yaml"
-	MachineDeploymentCRDFile CRDFile = "machine-deployment.yaml"
-	NodeGroupCRDFile         CRDFile = "node_group.yaml"
-	MCMCRDFile               CRDFile = "mcm.yaml"
-	InstanceCRDFile          CRDFile = "instance.yaml"
-)
-
 // BinaryAssetsDir returns the kubebuilder assets directory: KUBEBUILDER_ASSETS if set,
 // otherwise the first versioned directory under the nearest bin/k8s (populated by
 // `make envtest`), discovered by walking up from the test working directory.
@@ -97,63 +81,11 @@ func AssetsAvailable() bool {
 	return BinaryAssetsDir() != ""
 }
 
-// crdPaths resolves the given CRD file names against the node-controller/crds and
-// 040-node-manager/crds directories (found by walking up from the test working directory),
-// falling back to the bare file name when the CRD is found in neither, e.g.
-// crdPaths("instance.yaml", "machine.yaml").
-func crdPaths(files ...CRDFile) []string {
-	if len(files) == 0 {
-		return nil
-	}
-
-	controllerCRDs := findDirUp("node-controller/crds")
-	nodeManagerCRDs := findDirUp("040-node-manager/crds")
-
-	ret := make([]string, 0, len(files))
-
-	for _, file := range files {
-		candidate := filepath.Join(controllerCRDs, string(file))
-
-		if _, err := os.Stat(candidate); err == nil {
-			ret = append(ret, candidate)
-			continue
-		}
-
-		candidate = filepath.Join(nodeManagerCRDs, string(file))
-
-		if _, err := os.Stat(candidate); err == nil {
-			ret = append(ret, candidate)
-			continue
-		}
-
-		ret = append(ret, string(file))
-	}
-	return ret
-}
-
-func findDirUp(name string) string {
-	dir, err := os.Getwd()
-	if err != nil {
-		return ""
-	}
-	for {
-		candidate := filepath.Join(dir, name)
-		if fi, err := os.Stat(candidate); err == nil && fi.IsDir() {
-			return candidate
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			return ""
-		}
-		dir = parent
-	}
-}
-
 // Start boots an envtest apiserver with the given scheme and CRD files and returns a client.
 // Call testEnv.Stop() in AfterSuite.
-func Start(scheme *runtime.Scheme, crdFiles ...CRDFile) (*envtest.Environment, *rest.Config, client.Client, error) {
+func Start(scheme *runtime.Scheme, crdPaths ...string) (*envtest.Environment, *rest.Config, client.Client, error) {
 	env := &envtest.Environment{
-		CRDDirectoryPaths:     crdPaths(crdFiles...),
+		CRDDirectoryPaths:     crdPaths,
 		ErrorIfCRDPathMissing: true,
 		BinaryAssetsDirectory: BinaryAssetsDir(),
 	}

--- a/modules/040-node-manager/images/node-controller/src/internal/testenv/testenv.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/testenv/testenv.go
@@ -57,6 +57,17 @@ const (
 // KubeconfigPath is where PauseForKubectl writes the envtest kubeconfig.
 const KubeconfigPath = "/tmp/envtest.kubeconfig"
 
+// CRD manifest file names loaded by envtest.
+type CRDFile string
+
+const (
+	MachineCRDFile           CRDFile = "machine.yaml"
+	MachineDeploymentCRDFile CRDFile = "machine-deployment.yaml"
+	NodeGroupCRDFile         CRDFile = "node_group.yaml"
+	MCMCRDFile               CRDFile = "mcm.yaml"
+	InstanceCRDFile          CRDFile = "instance.yaml"
+)
+
 // BinaryAssetsDir returns the kubebuilder assets directory: KUBEBUILDER_ASSETS if set,
 // otherwise the first versioned directory under the nearest bin/k8s (populated by
 // `make envtest`), discovered by walking up from the test working directory.
@@ -86,15 +97,38 @@ func AssetsAvailable() bool {
 	return BinaryAssetsDir() != ""
 }
 
-// CRDPaths resolves the given CRD file names against the module's crds/ directory (found by
-// walking up from the test working directory), e.g. CRDPaths("instance.yaml", "machine.yaml").
-func CRDPaths(files ...string) []string {
-	crds := findDirUp("crds")
-	paths := make([]string, 0, len(files))
-	for _, f := range files {
-		paths = append(paths, filepath.Join(crds, f))
+// crdPaths resolves the given CRD file names against the node-controller/crds and
+// 040-node-manager/crds directories (found by walking up from the test working directory),
+// falling back to the bare file name when the CRD is found in neither, e.g.
+// crdPaths("instance.yaml", "machine.yaml").
+func crdPaths(files ...CRDFile) []string {
+	if len(files) == 0 {
+		return nil
 	}
-	return paths
+
+	controllerCRDs := findDirUp("node-controller/crds")
+	nodeManagerCRDs := findDirUp("040-node-manager/crds")
+
+	ret := make([]string, 0, len(files))
+
+	for _, file := range files {
+		candidate := filepath.Join(controllerCRDs, string(file))
+
+		if _, err := os.Stat(candidate); err == nil {
+			ret = append(ret, candidate)
+			continue
+		}
+
+		candidate = filepath.Join(nodeManagerCRDs, string(file))
+
+		if _, err := os.Stat(candidate); err == nil {
+			ret = append(ret, candidate)
+			continue
+		}
+
+		ret = append(ret, string(file))
+	}
+	return ret
 }
 
 func findDirUp(name string) string {
@@ -117,9 +151,9 @@ func findDirUp(name string) string {
 
 // Start boots an envtest apiserver with the given scheme and CRD files and returns a client.
 // Call testEnv.Stop() in AfterSuite.
-func Start(scheme *runtime.Scheme, crdPaths []string) (*envtest.Environment, *rest.Config, client.Client, error) {
+func Start(scheme *runtime.Scheme, crdFiles ...CRDFile) (*envtest.Environment, *rest.Config, client.Client, error) {
 	env := &envtest.Environment{
-		CRDDirectoryPaths:     crdPaths,
+		CRDDirectoryPaths:     crdPaths(crdFiles...),
 		ErrorIfCRDPathMissing: true,
 		BinaryAssetsDirectory: BinaryAssetsDir(),
 	}


### PR DESCRIPTION
## Description

This PR fixes env tests in node-controller.

## Why do we need it, and what problem does it solve?

This PR fixes env tests in node-controller.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: Fixed env tests in node-controller.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
