### PR TITLE
[docs] Remove fake SSH key data from examples

### DIFF
--- a/docs/site/_includes/getting_started/global/partials/installer/STEP_CLUSTER_AND_CONNECTION.md
+++ b/docs/site/_includes/getting_started/global/partials/installer/STEP_CLUSTER_AND_CONNECTION.md
@@ -23,10 +23,7 @@
 ```bash
 $ cat ~/.ssh/id_ed25519
 -----BEGIN OPENSSH PRIVATE KEY-----
-b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
 ...
-AAAEB3AcmUCQ9dd7fPhIYpQe1pBhZEanld6ZgJHmyD8XO460T3766IVjzrA+Vpgvu1l2IL
-RTAeNZpi2e6dqGhsbK6cAAAAGHpoYmVydEB6aGJlcnQtMjB3bnMxeGowOQECAwQF
 -----END OPENSSH PRIVATE KEY-----
 ```
 {% endcapture %}

--- a/docs/site/_includes/getting_started/global/partials/installer/STEP_CLUSTER_AND_CONNECTION_RU.md
+++ b/docs/site/_includes/getting_started/global/partials/installer/STEP_CLUSTER_AND_CONNECTION_RU.md
@@ -23,10 +23,7 @@
 ```bash
 $ cat ~/.ssh/id_ed25519
 -----BEGIN OPENSSH PRIVATE KEY-----
-b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
 ...
-AAAEB3AcmUCQ9dd7fPhIYpQe1pBhZEanld6ZgJHmyD8XO460T3766IVjzrA+Vpgvu1l2IL
-RTAeNZpi2e6dqGhsbK6cAAAAGHpoYmVydEB6aGJlcnQtMjB3bnMxeGowOQECAwQF
 -----END OPENSSH PRIVATE KEY-----
 ```
 {% endcapture %}

--- a/docs/site/pages/virtualization-platform/documentation/admin/platform-management/platform-scaling/node/BARE_METAL_NODE.md
+++ b/docs/site/pages/virtualization-platform/documentation/admin/platform-management/platform-scaling/node/BARE_METAL_NODE.md
@@ -58,7 +58,7 @@ DVP supports automatic addition of physical (bare-metal) servers to the cluster 
      spec:
        privateSSHKey: |
          -----BEGIN OPENSSH PRIVATE KEY-----
-         LS0tLS1CRUdJlhrdG...................VZLS0tLS0K
+         ...
          -----END OPENSSH PRIVATE KEY-----
        sshPort: 22
        sudoPassword: password

--- a/docs/site/pages/virtualization-platform/documentation/admin/platform-management/platform-scaling/node/BARE_METAL_NODE_RU.md
+++ b/docs/site/pages/virtualization-platform/documentation/admin/platform-management/platform-scaling/node/BARE_METAL_NODE_RU.md
@@ -59,7 +59,7 @@ lang: ru
      spec:
        privateSSHKey: |
          -----BEGIN OPENSSH PRIVATE KEY-----
-         LS0tLS1CRUdJlhrdG...................VZLS0tLS0K
+         ...
          -----END OPENSSH PRIVATE KEY-----
        sshPort: 22
        sudoPassword: password


### PR DESCRIPTION
## Description

This pull request updates documentation examples to improve security and clarity by replacing hardcoded private SSH key values with ellipses, indicating that users should supply their own keys:
- Replace realistic-looking SSH private key placeholders with minimal ellipsis markers across getting started guides and bare metal node scaling documentation
- Prevent example snippets from being mistaken for actual leaked credentials or triggering secret-scanning tools

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Remove fake SSH key data from examples.
impact_level: low
```
