### PR TITLE
[docs] OpenSearch Search API

### DIFF
--- a/docs/site/_data/sidebars/code.yml
+++ b/docs/site/_data/sidebars/code.yml
@@ -24,6 +24,10 @@ entries:
           ru: Мониторинг и управление
         url: /code/documentation/admin/configuration/monitoring.html
       - title:
+          en: OpenSearch API
+          ru: OpenSearch API
+        url: /code/documentation/admin/configuration/opensearch-api.html
+      - title:
           en: Service account
           ru: Сервисный аккаунт
         url: /code/documentation/admin/service-account.html
@@ -111,6 +115,10 @@ entries:
           en: Search
           ru: Поиск
         url: /code/documentation/user/search.html
+      - title:
+          en: Search API
+          ru: Search API
+        url: /code/documentation/user/search-api.html
       - title:
           en: Push rules
           ru: Правила отправки изменений

--- a/docs/site/pages/code/documentation/admin/configuration/OPENSEARCH_API.md
+++ b/docs/site/pages/code/documentation/admin/configuration/OPENSEARCH_API.md
@@ -1,0 +1,80 @@
+---
+title: "OpenSearch API"
+menuTitle: OpenSearch API
+searchable: true
+description: "Admin REST API for OpenSearch index recreation and indexing queue stats"
+permalink: en/code/documentation/admin/configuration/opensearch-api.html
+lang: en
+weight: 38
+---
+
+This page documents Deckhouse Code admin OpenSearch endpoints.
+
+## Permissions
+
+- `POST /admin/opensearch/recreate_indices`: admin only (`authenticated_as_admin!`).
+- `GET /admin/opensearch/indexing_queue_stats`: authenticated user with permission `read_admin_search_indexing_queue_stats` on `:global`.
+
+## POST `/api/v4/admin/opensearch/recreate_indices`
+
+Synchronously recreates OpenSearch index(es) and enqueues background reindex jobs.
+
+### Request body
+
+| Field | Type | Required | Allowed values |
+|---|---|---:|---|
+| `schema_class` | string | ✅ | `recreate_all`, `Search::Opensearch::IndicesSchema::Code`, `Search::Opensearch::IndicesSchema::Wiki`, `Search::Opensearch::IndicesSchema::Note`, `Search::Opensearch::IndicesSchema::Milestone`, `Search::Opensearch::IndicesSchema::WorkItem`, `Search::Opensearch::IndicesSchema::MergeRequest` |
+
+### Responses
+
+- `202 Accepted`
+
+```json
+{
+  "message": "OpenSearch indices were reset; reindex jobs were enqueued."
+}
+```
+
+- `400 Bad Request` (for example, OpenSearch disabled or service error)
+
+```json
+{
+  "message": "OpenSearch is disabled"
+}
+```
+
+### Example
+
+```bash
+curl --request POST \
+  --header "PRIVATE-TOKEN: <admin_token>" \
+  --header "Content-Type: application/json" \
+  --data '{"schema_class":"recreate_all"}' \
+  --url "https://code.example.com/api/v4/admin/opensearch/recreate_indices"
+```
+
+## GET `/api/v4/admin/opensearch/indexing_queue_stats`
+
+Returns Sidekiq queue stats for OpenSearch indexing.
+
+### Response (`200 OK`)
+
+```json
+{
+  "total": 42,
+  "updated_at": "2026-07-01T12:34:56.789Z"
+}
+```
+
+Fields:
+
+- `total` — total number of queued indexing jobs.
+- `updated_at` — ISO8601 timestamp with milliseconds (or `null`).
+
+### Example
+
+```bash
+curl --request GET \
+  --header "PRIVATE-TOKEN: <token>" \
+  --url "https://code.example.com/api/v4/admin/opensearch/indexing_queue_stats"
+```

--- a/docs/site/pages/code/documentation/admin/configuration/OPENSEARCH_API.md
+++ b/docs/site/pages/code/documentation/admin/configuration/OPENSEARCH_API.md
@@ -12,8 +12,8 @@ This page documents Deckhouse Code admin OpenSearch endpoints.
 
 ## Permissions
 
-- `POST /admin/opensearch/recreate_indices`: admin only (`authenticated_as_admin!`).
-- `GET /admin/opensearch/indexing_queue_stats`: authenticated user with permission `read_admin_search_indexing_queue_stats` on `:global`.
+- `POST /api/v4/admin/opensearch/recreate_indices`: admin only (`authenticated_as_admin!`).
+- `GET /api/v4/admin/opensearch/indexing_queue_stats`: authenticated user with permission `read_admin_search_indexing_queue_stats` on `:global`.
 
 ## POST `/api/v4/admin/opensearch/recreate_indices`
 
@@ -47,10 +47,10 @@ Synchronously recreates OpenSearch index(es) and enqueues background reindex job
 
 ```bash
 curl --request POST \
-  --header "PRIVATE-TOKEN: <admin_token>" \
+  --header "PRIVATE-TOKEN: <your_access_token>" \
   --header "Content-Type: application/json" \
   --data '{"schema_class":"recreate_all"}' \
-  --url "https://code.example.com/api/v4/admin/opensearch/recreate_indices"
+  --url "https://gitlab.example.com/api/v4/admin/opensearch/recreate_indices"
 ```
 
 ## GET `/api/v4/admin/opensearch/indexing_queue_stats`
@@ -75,6 +75,6 @@ Fields:
 
 ```bash
 curl --request GET \
-  --header "PRIVATE-TOKEN: <token>" \
-  --url "https://code.example.com/api/v4/admin/opensearch/indexing_queue_stats"
+  --header "PRIVATE-TOKEN: <your_access_token>" \
+  --url "https://gitlab.example.com/api/v4/admin/opensearch/indexing_queue_stats"
 ```

--- a/docs/site/pages/code/documentation/admin/configuration/OPENSEARCH_API_RU.md
+++ b/docs/site/pages/code/documentation/admin/configuration/OPENSEARCH_API_RU.md
@@ -12,8 +12,8 @@ weight: 38
 
 ## Права доступа
 
-- `POST /admin/opensearch/recreate_indices`: только администратор (`authenticated_as_admin!`).
-- `GET /admin/opensearch/indexing_queue_stats`: аутентифицированный пользователь с правом `read_admin_search_indexing_queue_stats` на `:global`.
+- `POST /api/v4/admin/opensearch/recreate_indices`: только администратор (`authenticated_as_admin!`).
+- `GET /api/v4/admin/opensearch/indexing_queue_stats`: аутентифицированный пользователь с правом `read_admin_search_indexing_queue_stats` на `:global`.
 
 ## POST `/api/v4/admin/opensearch/recreate_indices`
 
@@ -47,10 +47,10 @@ weight: 38
 
 ```bash
 curl --request POST \
-  --header "PRIVATE-TOKEN: <admin_token>" \
+  --header "PRIVATE-TOKEN: <your_access_token>" \
   --header "Content-Type: application/json" \
   --data '{"schema_class":"recreate_all"}' \
-  --url "https://code.example.com/api/v4/admin/opensearch/recreate_indices"
+  --url "https://gitlab.example.com/api/v4/admin/opensearch/recreate_indices"
 ```
 
 ## GET `/api/v4/admin/opensearch/indexing_queue_stats`
@@ -75,6 +75,6 @@ curl --request POST \
 
 ```bash
 curl --request GET \
-  --header "PRIVATE-TOKEN: <token>" \
-  --url "https://code.example.com/api/v4/admin/opensearch/indexing_queue_stats"
+  --header "PRIVATE-TOKEN: <your_access_token>" \
+  --url "https://gitlab.example.com/api/v4/admin/opensearch/indexing_queue_stats"
 ```

--- a/docs/site/pages/code/documentation/admin/configuration/OPENSEARCH_API_RU.md
+++ b/docs/site/pages/code/documentation/admin/configuration/OPENSEARCH_API_RU.md
@@ -1,0 +1,80 @@
+---
+title: "OpenSearch API"
+menuTitle: OpenSearch API
+searchable: true
+description: "Административный REST API для пересоздания индексов OpenSearch и статистики очереди индексации"
+permalink: ru/code/documentation/admin/configuration/opensearch-api.html
+lang: ru
+weight: 38
+---
+
+На этой странице описаны административные OpenSearch-эндпоинты Deckhouse Code.
+
+## Права доступа
+
+- `POST /admin/opensearch/recreate_indices`: только администратор (`authenticated_as_admin!`).
+- `GET /admin/opensearch/indexing_queue_stats`: аутентифицированный пользователь с правом `read_admin_search_indexing_queue_stats` на `:global`.
+
+## POST `/api/v4/admin/opensearch/recreate_indices`
+
+Синхронно пересоздает индекс(ы) OpenSearch и ставит фоновые задачи реиндексации.
+
+### Тело запроса
+
+| Поле | Тип | Обязательное | Допустимые значения |
+|---|---|---:|---|
+| `schema_class` | string | ✅ | `recreate_all`, `Search::Opensearch::IndicesSchema::Code`, `Search::Opensearch::IndicesSchema::Wiki`, `Search::Opensearch::IndicesSchema::Note`, `Search::Opensearch::IndicesSchema::Milestone`, `Search::Opensearch::IndicesSchema::WorkItem`, `Search::Opensearch::IndicesSchema::MergeRequest` |
+
+### Ответы
+
+- `202 Accepted`
+
+```json
+{
+  "message": "OpenSearch indices were reset; reindex jobs were enqueued."
+}
+```
+
+- `400 Bad Request` (например, OpenSearch выключен или сервис вернул ошибку)
+
+```json
+{
+  "message": "OpenSearch is disabled"
+}
+```
+
+### Пример
+
+```bash
+curl --request POST \
+  --header "PRIVATE-TOKEN: <admin_token>" \
+  --header "Content-Type: application/json" \
+  --data '{"schema_class":"recreate_all"}' \
+  --url "https://code.example.com/api/v4/admin/opensearch/recreate_indices"
+```
+
+## GET `/api/v4/admin/opensearch/indexing_queue_stats`
+
+Возвращает статистику Sidekiq-очереди индексации OpenSearch.
+
+### Ответ (`200 OK`)
+
+```json
+{
+  "total": 42,
+  "updated_at": "2026-07-01T12:34:56.789Z"
+}
+```
+
+Поля:
+
+- `total` — общее количество задач индексации в очереди.
+- `updated_at` — timestamp ISO8601 с миллисекундами (или `null`).
+
+### Пример
+
+```bash
+curl --request GET \
+  --header "PRIVATE-TOKEN: <token>" \
+  --url "https://code.example.com/api/v4/admin/opensearch/indexing_queue_stats"
+```

--- a/docs/site/pages/code/documentation/user/SEARCH_API.md
+++ b/docs/site/pages/code/documentation/user/SEARCH_API.md
@@ -1,0 +1,146 @@
+---
+title: "Search API"
+menuTitle: Search API
+searchable: true
+description: "Reference for Deckhouse Code Search REST API with OpenSearch and FE-specific filters"
+permalink: en/code/documentation/user/search-api.html
+lang: en
+weight: 46
+---
+
+This page documents the Search REST API implemented in Deckhouse Code.
+
+Source of truth: API and FE extension code on branch `feature/api-search-update-plan` (not upstream GitLab `doc/api/search.md`, which has different behavior for some filters/scopes).
+
+## Endpoints
+
+- `GET /api/v4/search`
+- `GET /api/v4/groups/:id/-/search`
+- `GET /api/v4/projects/:id/-/search`
+
+All endpoints require authentication.
+
+## Scopes and backend
+
+`scope` is required. Supported values differ by endpoint.
+
+| Scope | Instance | Group | Project | Backend when OpenSearch is enabled |
+|---|---:|---:|---:|---|
+| `projects` | ✅ | ✅ | ❌ | CE/Postgres |
+| `users` | ✅ | ✅ | ✅ | CE/Postgres |
+| `snippet_titles` | ✅ | ❌ | ❌ | CE/Postgres |
+| `issues` | ✅ | ✅ | ✅ | OpenSearch (`advanced`) |
+| `work_items` | ✅ | ✅ | ✅ | OpenSearch (`advanced`) |
+| `merge_requests` | ✅ | ✅ | ✅ | OpenSearch (`advanced`) |
+| `milestones` | ✅ | ✅ | ✅ | OpenSearch (`advanced`) |
+| `notes` | ❌ | ❌ | ✅ | OpenSearch (`advanced`) |
+| `wiki_blobs` | ❌ | ❌ | ✅ | OpenSearch (`advanced`) |
+| `commits` | ❌ | ❌ | ✅ | OpenSearch (`advanced`) |
+| `blobs` | ❌ | ❌ | ✅ | OpenSearch (`advanced`) |
+
+Response header `X-Search-Type` returns the resolved search type (`advanced`/other).
+
+## Request parameters
+
+### Common
+
+| Parameter | Type | Required | Endpoints | Notes |
+|---|---|---:|---|---|
+| `search` | string | ✅ | all | Search query |
+| `scope` | string | ✅ | all | See matrix above |
+| `state` | string | ❌ | all | `all`, `opened`, `closed`, `merged` |
+| `confidential` | boolean | ❌ | all | Passed to search service |
+| `type` | array[string] | ❌ | all | Work item type filter (effective for `work_items`) |
+| `page` / `per_page` | integer | ❌ | all | Offset pagination |
+| `include_archived` | boolean | ❌ | instance, group | Not available for project endpoint |
+| `ref` | string | ❌ | project | Branch/tag for project search |
+
+### OpenSearch / FE filter parameters
+
+When parameter scope is invalid, API returns `400` with message:
+`<param_name> is supported only for <scope list>`.
+
+| Parameter | Type | Applies to `scope` | Validation |
+|---|---|---|---|
+| `fields` | array[string] | `work_items`, `issues` | only `title`; otherwise `400` |
+| `exclude_forks` | boolean | `work_items`, `issues` | only in those scopes |
+| `num_context_lines` | integer | `blobs` | range `0..20` |
+| `regex` | boolean | `blobs` | query length `3..512` and at least one alphanumeric literal; otherwise `400` |
+| `language` | array[string] | `blobs` | comma-separated values supported |
+| `label_name` | array[string] | `work_items`, `issues`, `merge_requests` | comma-separated values supported |
+| `source_branch` | string | `merge_requests` | exact branch filter |
+| `target_branch` | string | `merge_requests` | exact branch filter |
+| `not_source_branch` | string | `merge_requests` | exclusion filter |
+| `not_target_branch` | string | `merge_requests` | exclusion filter |
+| `author_username` | string | `merge_requests` | author filter |
+| `not_author_username` | string | `merge_requests` | author exclusion filter |
+
+## Response headers
+
+- `X-Search-Type`: resolved search type for current request.
+- `X-Search-Aggregations`: present only when OpenSearch is enabled and aggregations exist for the requested scope.
+
+`X-Search-Aggregations` is JSON with aggregation buckets. Aggregations are returned for:
+
+- `blobs` (`language` buckets),
+- `work_items`/`issues` (`work_item_type_ids` and `labels` buckets),
+- `merge_requests` (`labels` buckets).
+
+## Examples
+
+### Instance search: issues/work items with labels and fields
+
+```bash
+curl --request GET \
+  --header "PRIVATE-TOKEN: <token>" \
+  --url "https://code.example.com/api/v4/search?scope=issues&search=deploy&fields=title&label_name=team%3Aplatform&exclude_forks=true"
+```
+
+### Group search: merge requests with FE MR filters
+
+```bash
+curl --request GET \
+  --header "PRIVATE-TOKEN: <token>" \
+  --url "https://code.example.com/api/v4/groups/my-group/-/search?scope=merge_requests&search=release&source_branch=release%2F1.2&not_author_username=bot"
+```
+
+### Project search: code blobs with regex and context lines
+
+```bash
+curl --request GET \
+  --header "PRIVATE-TOKEN: <token>" \
+  --url "https://code.example.com/api/v4/projects/my-group%2Fmy-project/-/search?scope=blobs&search=deploy.*job&regex=true&num_context_lines=5&language=Ruby"
+```
+
+## Error cases (`400`)
+
+### Wrong scope for parameter
+
+Example: `regex=true` with `scope=work_items`:
+
+```json
+{
+  "message": "regex is supported only for blobs"
+}
+```
+
+### Invalid regex query constraints
+
+Regex mode requires query length `3..512` and at least one alphanumeric literal.
+
+Example response:
+
+```json
+{
+  "message": "regex search requires 3-512 chars and at least one alphanumeric literal"
+}
+```
+
+## Notes on divergence from upstream GitLab docs
+
+Compared to upstream GitLab `doc/api/search.md`, Deckhouse Code FE implementation differs in notable points:
+
+- `fields` is supported only for `work_items` and `issues` (not `merge_requests`).
+- `exclude_forks` is scoped to `work_items` and `issues` (not code-search-only semantics).
+- Additional FE filters are implemented and documented on this page (`language`, `label_name`, MR branch/author filters, `not_*` filters).
+- `X-Search-Aggregations` response header is available when OpenSearch aggregations exist.

--- a/docs/site/pages/code/documentation/user/SEARCH_API.md
+++ b/docs/site/pages/code/documentation/user/SEARCH_API.md
@@ -10,13 +10,13 @@ weight: 46
 
 This page documents the Search REST API implemented in Deckhouse Code.
 
-Source of truth: API and FE extension code on branch `feature/api-search-update-plan` (not upstream GitLab `doc/api/search.md`, which has different behavior for some filters/scopes).
+Source of truth: the Deckhouse Code FE search extension code (not upstream GitLab `doc/api/search.md`, which has different behavior for some filters/scopes).
 
 ## Endpoints
 
 - `GET /api/v4/search`
-- `GET /api/v4/groups/:id/-/search`
-- `GET /api/v4/projects/:id/-/search`
+- `GET /api/v4/groups/:id/search` (the `-/` variant `/api/v4/groups/:id/-/search` is also accepted)
+- `GET /api/v4/projects/:id/search` (the `-/` variant `/api/v4/projects/:id/-/search` is also accepted)
 
 All endpoints require authentication.
 
@@ -48,12 +48,12 @@ Response header `X-Search-Type` returns the resolved search type (`advanced`/oth
 |---|---|---:|---|---|
 | `search` | string | ✅ | all | Search query |
 | `scope` | string | ✅ | all | See matrix above |
-| `state` | string | ❌ | all | `all`, `opened`, `closed`, `merged` |
 | `confidential` | boolean | ❌ | all | Passed to search service |
-| `type` | array[string] | ❌ | all | Work item type filter (effective for `work_items`) |
-| `page` / `per_page` | integer | ❌ | all | Offset pagination |
 | `include_archived` | boolean | ❌ | instance, group | Not available for project endpoint |
+| `page` / `per_page` | integer | ❌ | all | Offset pagination |
 | `ref` | string | ❌ | project | Branch/tag for project search |
+| `state` | string | ❌ | all | `all`, `opened`, `closed`, `merged` |
+| `type` | array[string] | ❌ | all | Work item type filter (effective for `work_items`) |
 
 ### OpenSearch / FE filter parameters
 
@@ -62,18 +62,18 @@ When parameter scope is invalid, API returns `400` with message:
 
 | Parameter | Type | Applies to `scope` | Validation |
 |---|---|---|---|
-| `fields` | array[string] | `work_items`, `issues` | only `title`; otherwise `400` |
+| `author_username` | string | `merge_requests` | author filter |
 | `exclude_forks` | boolean | `work_items`, `issues` | only in those scopes |
-| `num_context_lines` | integer | `blobs` | range `0..20` |
-| `regex` | boolean | `blobs` | query length `3..512` and at least one alphanumeric literal; otherwise `400` |
-| `language` | array[string] | `blobs` | comma-separated values supported |
+| `fields` | array[string] | `work_items`, `issues` | only `title`; otherwise `400` |
 | `label_name` | array[string] | `work_items`, `issues`, `merge_requests` | comma-separated values supported |
-| `source_branch` | string | `merge_requests` | exact branch filter |
-| `target_branch` | string | `merge_requests` | exact branch filter |
+| `language` | array[string] | `blobs` | comma-separated values supported |
+| `not_author_username` | string | `merge_requests` | author exclusion filter |
 | `not_source_branch` | string | `merge_requests` | exclusion filter |
 | `not_target_branch` | string | `merge_requests` | exclusion filter |
-| `author_username` | string | `merge_requests` | author filter |
-| `not_author_username` | string | `merge_requests` | author exclusion filter |
+| `num_context_lines` | integer | `blobs` | range `0..20` |
+| `regex` | boolean | `blobs` | query length `3..512` and at least one alphanumeric literal; otherwise `400` |
+| `source_branch` | string | `merge_requests` | exact branch filter |
+| `target_branch` | string | `merge_requests` | exact branch filter |
 
 ## Response headers
 
@@ -86,30 +86,63 @@ When parameter scope is invalid, API returns `400` with message:
 - `work_items`/`issues` (`work_item_type_ids` and `labels` buckets),
 - `merge_requests` (`labels` buckets).
 
+## Response body
+
+The endpoint returns a JSON array of scope-specific entities:
+
+| Scope | Entity type |
+|---|---|
+| `issues` | `IssueBasic` |
+| `work_items` | `WorkItem` |
+| `merge_requests` | `MergeRequestBasic` |
+| `milestones` | `Milestone` |
+| `notes` | `Note` |
+| `commits` | `Commit` |
+| `blobs` | `Blob` |
+| `wiki_blobs` | `Blob` |
+| `projects` | `BasicProjectDetails` |
+| `users` | `UserBasic` |
+| `snippet_titles` | `Snippet` |
+
+Example response for `scope=issues`:
+
+```json
+[
+  {
+    "id": 1001,
+    "iid": 42,
+    "title": "Deploy pipeline fails on main",
+    "state": "opened",
+    "project_id": 7,
+    "web_url": "https://gitlab.example.com/my-group/my-project/-/issues/42"
+  }
+]
+```
+
 ## Examples
 
 ### Instance search: issues/work items with labels and fields
 
 ```bash
 curl --request GET \
-  --header "PRIVATE-TOKEN: <token>" \
-  --url "https://code.example.com/api/v4/search?scope=issues&search=deploy&fields=title&label_name=team%3Aplatform&exclude_forks=true"
+  --header "PRIVATE-TOKEN: <your_access_token>" \
+  --url "https://gitlab.example.com/api/v4/search?scope=issues&search=deploy&fields=title&label_name=team%3Aplatform&exclude_forks=true"
 ```
 
 ### Group search: merge requests with FE MR filters
 
 ```bash
 curl --request GET \
-  --header "PRIVATE-TOKEN: <token>" \
-  --url "https://code.example.com/api/v4/groups/my-group/-/search?scope=merge_requests&search=release&source_branch=release%2F1.2&not_author_username=bot"
+  --header "PRIVATE-TOKEN: <your_access_token>" \
+  --url "https://gitlab.example.com/api/v4/groups/my-group/-/search?scope=merge_requests&search=release&source_branch=release%2F1.2&not_author_username=bot"
 ```
 
 ### Project search: code blobs with regex and context lines
 
 ```bash
 curl --request GET \
-  --header "PRIVATE-TOKEN: <token>" \
-  --url "https://code.example.com/api/v4/projects/my-group%2Fmy-project/-/search?scope=blobs&search=deploy.*job&regex=true&num_context_lines=5&language=Ruby"
+  --header "PRIVATE-TOKEN: <your_access_token>" \
+  --url "https://gitlab.example.com/api/v4/projects/my-group%2Fmy-project/-/search?scope=blobs&search=deploy.*job&regex=true&num_context_lines=5&language=Ruby"
 ```
 
 ## Error cases (`400`)

--- a/docs/site/pages/code/documentation/user/SEARCH_API_RU.md
+++ b/docs/site/pages/code/documentation/user/SEARCH_API_RU.md
@@ -1,0 +1,146 @@
+---
+title: "Search API"
+menuTitle: Search API
+searchable: true
+description: "Справочник по Search REST API в Deckhouse Code: OpenSearch и FE-фильтры"
+permalink: ru/code/documentation/user/search-api.html
+lang: ru
+weight: 46
+---
+
+На этой странице описан Search REST API в Deckhouse Code.
+
+Источник истины: API и FE-расширения в ветке `feature/api-search-update-plan` (а не upstream GitLab `doc/api/search.md`, где часть семантики фильтров/скоупов отличается).
+
+## Эндпоинты
+
+- `GET /api/v4/search`
+- `GET /api/v4/groups/:id/-/search`
+- `GET /api/v4/projects/:id/-/search`
+
+Все эндпоинты требуют аутентификацию.
+
+## Скоупы и backend
+
+Параметр `scope` обязателен. Поддерживаемые значения зависят от эндпоинта.
+
+| Scope | Instance | Group | Project | Backend при включенном OpenSearch |
+|---|---:|---:|---:|---|
+| `projects` | ✅ | ✅ | ❌ | CE/Postgres |
+| `users` | ✅ | ✅ | ✅ | CE/Postgres |
+| `snippet_titles` | ✅ | ❌ | ❌ | CE/Postgres |
+| `issues` | ✅ | ✅ | ✅ | OpenSearch (`advanced`) |
+| `work_items` | ✅ | ✅ | ✅ | OpenSearch (`advanced`) |
+| `merge_requests` | ✅ | ✅ | ✅ | OpenSearch (`advanced`) |
+| `milestones` | ✅ | ✅ | ✅ | OpenSearch (`advanced`) |
+| `notes` | ❌ | ❌ | ✅ | OpenSearch (`advanced`) |
+| `wiki_blobs` | ❌ | ❌ | ✅ | OpenSearch (`advanced`) |
+| `commits` | ❌ | ❌ | ✅ | OpenSearch (`advanced`) |
+| `blobs` | ❌ | ❌ | ✅ | OpenSearch (`advanced`) |
+
+В заголовке ответа `X-Search-Type` возвращается итоговый тип поиска (`advanced`/другой).
+
+## Параметры запроса
+
+### Общие
+
+| Параметр | Тип | Обязательный | Эндпоинты | Примечание |
+|---|---|---:|---|---|
+| `search` | string | ✅ | все | Поисковый запрос |
+| `scope` | string | ✅ | все | См. матрицу выше |
+| `state` | string | ❌ | все | `all`, `opened`, `closed`, `merged` |
+| `confidential` | boolean | ❌ | все | Передается в search service |
+| `type` | array[string] | ❌ | все | Фильтр типа work item (фактически для `work_items`) |
+| `page` / `per_page` | integer | ❌ | все | Пагинация offset-based |
+| `include_archived` | boolean | ❌ | instance, group | Для project-эндпоинта недоступен |
+| `ref` | string | ❌ | project | Ветка/тег для поиска в проекте |
+
+### Параметры OpenSearch / FE-фильтры
+
+Если параметр передан для неподдерживаемого scope, API возвращает `400`:
+`<param_name> is supported only for <scope list>`.
+
+| Параметр | Тип | Применяется к `scope` | Валидация |
+|---|---|---|---|
+| `fields` | array[string] | `work_items`, `issues` | допустимо только `title`; иначе `400` |
+| `exclude_forks` | boolean | `work_items`, `issues` | только в этих scope |
+| `num_context_lines` | integer | `blobs` | диапазон `0..20` |
+| `regex` | boolean | `blobs` | длина запроса `3..512` и минимум один буквенно-цифровой литерал; иначе `400` |
+| `language` | array[string] | `blobs` | поддерживается comma-separated |
+| `label_name` | array[string] | `work_items`, `issues`, `merge_requests` | поддерживается comma-separated |
+| `source_branch` | string | `merge_requests` | точный фильтр по source branch |
+| `target_branch` | string | `merge_requests` | точный фильтр по target branch |
+| `not_source_branch` | string | `merge_requests` | исключающий фильтр |
+| `not_target_branch` | string | `merge_requests` | исключающий фильтр |
+| `author_username` | string | `merge_requests` | фильтр по автору |
+| `not_author_username` | string | `merge_requests` | исключение по автору |
+
+## Заголовки ответа
+
+- `X-Search-Type`: итоговый тип поиска для запроса.
+- `X-Search-Aggregations`: присутствует только когда OpenSearch включен и для выбранного scope есть агрегаты.
+
+`X-Search-Aggregations` — JSON с корзинами агрегатов. Агрегаты возвращаются для:
+
+- `blobs` (`language` buckets),
+- `work_items`/`issues` (`work_item_type_ids` и `labels` buckets),
+- `merge_requests` (`labels` buckets).
+
+## Примеры
+
+### Instance search: issues/work items с labels и fields
+
+```bash
+curl --request GET \
+  --header "PRIVATE-TOKEN: <token>" \
+  --url "https://code.example.com/api/v4/search?scope=issues&search=deploy&fields=title&label_name=team%3Aplatform&exclude_forks=true"
+```
+
+### Group search: merge requests с FE MR-фильтрами
+
+```bash
+curl --request GET \
+  --header "PRIVATE-TOKEN: <token>" \
+  --url "https://code.example.com/api/v4/groups/my-group/-/search?scope=merge_requests&search=release&source_branch=release%2F1.2&not_author_username=bot"
+```
+
+### Project search: code blobs с regex и context lines
+
+```bash
+curl --request GET \
+  --header "PRIVATE-TOKEN: <token>" \
+  --url "https://code.example.com/api/v4/projects/my-group%2Fmy-project/-/search?scope=blobs&search=deploy.*job&regex=true&num_context_lines=5&language=Ruby"
+```
+
+## Ошибки (`400`)
+
+### Неверный scope для параметра
+
+Пример: `regex=true` с `scope=work_items`:
+
+```json
+{
+  "message": "regex is supported only for blobs"
+}
+```
+
+### Невалидные ограничения regex-запроса
+
+В regex-режиме запрос должен иметь длину `3..512` и содержать минимум один буквенно-цифровой литерал.
+
+Пример ответа:
+
+```json
+{
+  "message": "regex search requires 3-512 chars and at least one alphanumeric literal"
+}
+```
+
+## Расхождения с upstream GitLab docs
+
+Относительно upstream GitLab `doc/api/search.md` в Deckhouse Code FE-реализация отличается:
+
+- `fields` поддерживается только для `work_items` и `issues` (не для `merge_requests`).
+- `exclude_forks` ограничен `work_items` и `issues` (а не только code search).
+- Реализованы дополнительные FE-фильтры (`language`, `label_name`, MR branch/author, `not_*`).
+- Добавлен заголовок ответа `X-Search-Aggregations` при наличии агрегатов OpenSearch.

--- a/docs/site/pages/code/documentation/user/SEARCH_API_RU.md
+++ b/docs/site/pages/code/documentation/user/SEARCH_API_RU.md
@@ -10,13 +10,13 @@ weight: 46
 
 На этой странице описан Search REST API в Deckhouse Code.
 
-Источник истины: API и FE-расширения в ветке `feature/api-search-update-plan` (а не upstream GitLab `doc/api/search.md`, где часть семантики фильтров/скоупов отличается).
+Источник истины: код FE-расширения поиска Deckhouse Code (а не upstream GitLab `doc/api/search.md`, где часть семантики фильтров/скоупов отличается).
 
 ## Эндпоинты
 
 - `GET /api/v4/search`
-- `GET /api/v4/groups/:id/-/search`
-- `GET /api/v4/projects/:id/-/search`
+- `GET /api/v4/groups/:id/search` (вариант с `-/`: `/api/v4/groups/:id/-/search` тоже принимается)
+- `GET /api/v4/projects/:id/search` (вариант с `-/`: `/api/v4/projects/:id/-/search` тоже принимается)
 
 Все эндпоинты требуют аутентификацию.
 
@@ -48,12 +48,12 @@ weight: 46
 |---|---|---:|---|---|
 | `search` | string | ✅ | все | Поисковый запрос |
 | `scope` | string | ✅ | все | См. матрицу выше |
-| `state` | string | ❌ | все | `all`, `opened`, `closed`, `merged` |
 | `confidential` | boolean | ❌ | все | Передается в search service |
-| `type` | array[string] | ❌ | все | Фильтр типа work item (фактически для `work_items`) |
-| `page` / `per_page` | integer | ❌ | все | Пагинация offset-based |
 | `include_archived` | boolean | ❌ | instance, group | Для project-эндпоинта недоступен |
+| `page` / `per_page` | integer | ❌ | все | Пагинация offset-based |
 | `ref` | string | ❌ | project | Ветка/тег для поиска в проекте |
+| `state` | string | ❌ | все | `all`, `opened`, `closed`, `merged` |
+| `type` | array[string] | ❌ | все | Фильтр типа work item (фактически для `work_items`) |
 
 ### Параметры OpenSearch / FE-фильтры
 
@@ -62,18 +62,18 @@ weight: 46
 
 | Параметр | Тип | Применяется к `scope` | Валидация |
 |---|---|---|---|
-| `fields` | array[string] | `work_items`, `issues` | допустимо только `title`; иначе `400` |
+| `author_username` | string | `merge_requests` | фильтр по автору |
 | `exclude_forks` | boolean | `work_items`, `issues` | только в этих scope |
-| `num_context_lines` | integer | `blobs` | диапазон `0..20` |
-| `regex` | boolean | `blobs` | длина запроса `3..512` и минимум один буквенно-цифровой литерал; иначе `400` |
-| `language` | array[string] | `blobs` | поддерживается comma-separated |
+| `fields` | array[string] | `work_items`, `issues` | допустимо только `title`; иначе `400` |
 | `label_name` | array[string] | `work_items`, `issues`, `merge_requests` | поддерживается comma-separated |
-| `source_branch` | string | `merge_requests` | точный фильтр по source branch |
-| `target_branch` | string | `merge_requests` | точный фильтр по target branch |
+| `language` | array[string] | `blobs` | поддерживается comma-separated |
+| `not_author_username` | string | `merge_requests` | исключение по автору |
 | `not_source_branch` | string | `merge_requests` | исключающий фильтр |
 | `not_target_branch` | string | `merge_requests` | исключающий фильтр |
-| `author_username` | string | `merge_requests` | фильтр по автору |
-| `not_author_username` | string | `merge_requests` | исключение по автору |
+| `num_context_lines` | integer | `blobs` | диапазон `0..20` |
+| `regex` | boolean | `blobs` | длина запроса `3..512` и минимум один буквенно-цифровой литерал; иначе `400` |
+| `source_branch` | string | `merge_requests` | точный фильтр по source branch |
+| `target_branch` | string | `merge_requests` | точный фильтр по target branch |
 
 ## Заголовки ответа
 
@@ -86,30 +86,63 @@ weight: 46
 - `work_items`/`issues` (`work_item_type_ids` и `labels` buckets),
 - `merge_requests` (`labels` buckets).
 
+## Тело ответа
+
+Эндпоинт возвращает JSON-массив объектов, тип которых зависит от scope:
+
+| Scope | Тип объекта |
+|---|---|
+| `issues` | `IssueBasic` |
+| `work_items` | `WorkItem` |
+| `merge_requests` | `MergeRequestBasic` |
+| `milestones` | `Milestone` |
+| `notes` | `Note` |
+| `commits` | `Commit` |
+| `blobs` | `Blob` |
+| `wiki_blobs` | `Blob` |
+| `projects` | `BasicProjectDetails` |
+| `users` | `UserBasic` |
+| `snippet_titles` | `Snippet` |
+
+Пример ответа для `scope=issues`:
+
+```json
+[
+  {
+    "id": 1001,
+    "iid": 42,
+    "title": "Deploy pipeline fails on main",
+    "state": "opened",
+    "project_id": 7,
+    "web_url": "https://gitlab.example.com/my-group/my-project/-/issues/42"
+  }
+]
+```
+
 ## Примеры
 
 ### Instance search: issues/work items с labels и fields
 
 ```bash
 curl --request GET \
-  --header "PRIVATE-TOKEN: <token>" \
-  --url "https://code.example.com/api/v4/search?scope=issues&search=deploy&fields=title&label_name=team%3Aplatform&exclude_forks=true"
+  --header "PRIVATE-TOKEN: <your_access_token>" \
+  --url "https://gitlab.example.com/api/v4/search?scope=issues&search=deploy&fields=title&label_name=team%3Aplatform&exclude_forks=true"
 ```
 
 ### Group search: merge requests с FE MR-фильтрами
 
 ```bash
 curl --request GET \
-  --header "PRIVATE-TOKEN: <token>" \
-  --url "https://code.example.com/api/v4/groups/my-group/-/search?scope=merge_requests&search=release&source_branch=release%2F1.2&not_author_username=bot"
+  --header "PRIVATE-TOKEN: <your_access_token>" \
+  --url "https://gitlab.example.com/api/v4/groups/my-group/-/search?scope=merge_requests&search=release&source_branch=release%2F1.2&not_author_username=bot"
 ```
 
 ### Project search: code blobs с regex и context lines
 
 ```bash
 curl --request GET \
-  --header "PRIVATE-TOKEN: <token>" \
-  --url "https://code.example.com/api/v4/projects/my-group%2Fmy-project/-/search?scope=blobs&search=deploy.*job&regex=true&num_context_lines=5&language=Ruby"
+  --header "PRIVATE-TOKEN: <your_access_token>" \
+  --url "https://gitlab.example.com/api/v4/projects/my-group%2Fmy-project/-/search?scope=blobs&search=deploy.*job&regex=true&num_context_lines=5&language=Ruby"
 ```
 
 ## Ошибки (`400`)


### PR DESCRIPTION
## Description

Adds reference documentation for the Deckhouse Code (FE) **OpenSearch Search REST API** — both the public/user-facing Search API and the admin OpenSearch management API — in **English and Russian**, and registers the new pages in the Code documentation sidebar.

The documented API is the Flant Edition (FE) OpenSearch-backed search extension. The user-facing page notes the source of truth is the Deckhouse Code FE search extension code, not upstream GitLab's `doc/api/search.md`.

## Why do we need it, and what problem does it solve?

Documents requirement #6 of the OpenSearch Search API task: the public Search API (3 endpoints, scopes, FE-specific filters, `X-Search-Type` / `X-Search-Aggregations` headers) and the admin OpenSearch endpoints (`recreate_indices`, `indexing_queue_stats`) — bilingual EN + RU.

## Why do we need it in the patch release (if we do)?

N/A — documentation only.

## Checklist

- [ ] The code is covered by unit tests. *(n/a — docs only)*
- [ ] e2e tests passed. *(n/a — docs only)*
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually. *(n/a — docs only)*

## Changelog entries

```changes
section: docs
type: chore
summary: Add OpenSearch Search API reference documentation (public + admin, EN + RU).
impact_level: low
```