### PR TITLE
[cloud-provider-dvp] Do not set labels if their value is empty

### DIFF
--- a/modules/030-cloud-provider-dvp/images/dvp-common/api/disk.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-common/api/disk.go
@@ -77,10 +77,8 @@ func (d *DiskService) CreateDisk(ctx context.Context, clusterUUID, vmHostname, d
 			Name:      diskName,
 			Namespace: d.namespace,
 			Labels: map[string]string{
-				"deckhouse.io/managed-by":       "deckhouse",
-				"dvp.deckhouse.io/cluster-uuid": clusterUUID,
-				"dvp.deckhouse.io/hostname":     vmHostname,
-				diskNameLabel:                   diskName,
+				"deckhouse.io/managed-by": "deckhouse",
+				diskNameLabel:             diskName,
 			},
 			OwnerReferences: ownerRefs,
 		},


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Do not set labels `dvp.deckhouse.io/cluster-uuid` and `dvp.deckhouse.io/hostname` if their value is empty

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

The `dvp.deckhouse.io/hostname` label on disks created for PVCs in a cluster created through the dvp cloud provider is meaningless and its values ​​are always empty. Label `dvp.deckhouse.io/cluster-uuid` could potentially have the same issue when passing an empty value. These labels can be hidden for empty values ​​to improve display.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

Not necessarily

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-dvp
type: fix
summary: Stopped setting empty `dvp.deckhouse.io/cluster-uuid` and `dvp.deckhouse.io/hostname` labels.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
