### PR TITLE
[cloud-provider-vsphere] filter DatastoreCluster before default SC selection

### DIFF
--- a/ee/se-plus/modules/030-cloud-provider-vsphere/hooks/discover.go
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/hooks/discover.go
@@ -200,8 +200,24 @@ func handleDiscoveryDataVolumeTypes(input *go_hook.HookInput, zonedDataStores []
 		return storageClasses[i].Name < storageClasses[j].Name
 	})
 
+	storageClasses = filterStorageClassesForCSICompatibility(input, storageClasses)
+
 	input.Logger.Info("Found vSphere storage classes using cloud_provider_discovery_data", slog.Any("data", storageClasses))
 	input.Values.Set("cloudProviderVsphere.internal.storageClasses", storageClasses)
+}
+
+func filterStorageClassesForCSICompatibility(input *go_hook.HookInput, storageClasses []storageClass) []storageClass {
+	if v, ok := input.Values.GetOk("cloudProviderVsphere.storageClass.compatibilityFlag"); ok && v.String() == "Legacy" {
+		return storageClasses
+	}
+	filtered := make([]storageClass, 0, len(storageClasses))
+	for _, sc := range storageClasses {
+		if sc.DatastoreType == "DatastoreCluster" {
+			continue
+		}
+		filtered = append(filtered, sc)
+	}
+	return filtered
 }
 
 // Get StorageClass name from Volume type name to match Kubernetes restrictions from https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/hooks/discover_test.go
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/hooks/discover_test.go
@@ -116,6 +116,23 @@ cloudProviderVsphere:
     - .*
     default: other-bar
 `
+		initValuesStringF = `
+cloudProviderVsphere:
+  internal:
+    providerClusterConfiguration:
+      provider:
+        server: test.test.com
+        username: test
+        password: test
+        insecure: true
+      region: Test
+      regionTagCategory: test-region
+      zoneTagCategory: test-zone
+      sshPublicKey: test
+      vmFolderPath: test
+  storageClass:
+    compatibilityFlag: Legacy
+`
 	)
 
 	//nolint:misspell
@@ -242,6 +259,163 @@ parameters:
 			Expect(f.ValuesGet("cloudProviderVsphere.internal.storageClasses").String()).To(MatchJSON(`
 [
           {
+            "name": "test-1-lun101-b39d82fa",
+            "path": "/DCTEST/datastore/test_1_Lun101",
+            "zones": [
+              "ZONE-TEST"
+            ],
+            "datastoreType": "Datastore",
+            "datastoreURL": "ds:///vmfs/volumes/503a9af1-291d17b0-52e0-1d01842f428c/",
+            "storagePolicyName": ""
+          },
+          {
+            "name": "test-1-lun101-b39d82fa-management-storage-policy---large",
+            "path": "/DCTEST/datastore/test_1_Lun101",
+            "zones": [
+              "ZONE-TEST"
+            ],
+            "datastoreType": "Datastore",
+            "datastoreURL": "ds:///vmfs/volumes/503a9af1-291d17b0-52e0-1d01842f428c/",
+            "storagePolicyName": "Management Storage Policy - Large"
+          },
+          {
+            "name": "test-1-lun101-b39d82fa-vvol-no-requirements-policy",
+            "path": "/DCTEST/datastore/test_1_Lun101",
+            "zones": [
+              "ZONE-TEST"
+            ],
+            "datastoreType": "Datastore",
+            "datastoreURL": "ds:///vmfs/volumes/503a9af1-291d17b0-52e0-1d01842f428c/",
+            "storagePolicyName": "VVol No Requirements Policy"
+          },
+          {
+            "name": "test-1-lun102-0403073a",
+            "path": "/DCTEST/datastore/test_1_Lun102",
+            "zones": [
+              "ZONE-TEST"
+            ],
+            "datastoreType": "Datastore",
+            "datastoreURL": "ds:///vmfs/volumes/55832249-30a68048-496f-33f77fed3c5c/",
+            "storagePolicyName": ""
+          },
+          {
+            "name": "test-1-lun102-0403073a-management-storage-policy---large",
+            "path": "/DCTEST/datastore/test_1_Lun102",
+            "zones": [
+              "ZONE-TEST"
+            ],
+            "datastoreType": "Datastore",
+            "datastoreURL": "ds:///vmfs/volumes/55832249-30a68048-496f-33f77fed3c5c/",
+            "storagePolicyName": "Management Storage Policy - Large"
+          },
+          {
+            "name": "test-1-lun102-0403073a-vvol-no-requirements-policy",
+            "path": "/DCTEST/datastore/test_1_Lun102",
+            "zones": [
+              "ZONE-TEST"
+            ],
+            "datastoreType": "Datastore",
+            "datastoreURL": "ds:///vmfs/volumes/55832249-30a68048-496f-33f77fed3c5c/",
+            "storagePolicyName": "VVol No Requirements Policy"
+          }
+        ]
+`))
+		})
+
+	})
+
+	b := HookExecutionConfigInit(initValuesStringB, `{}`)
+
+	Context("Cluster has minimal cloudProviderVsphere configuration with excluded storage classes", func() {
+		BeforeEach(func() {
+			b.BindingContexts.Set(b.KubeStateSet(state))
+			b.BindingContexts.Set(b.GenerateBeforeHelmContext())
+			b.RunHook()
+		})
+
+		It("Should discover volumeTypes without excluded", func() {
+			Expect(b).To(ExecuteSuccessfully())
+			Expect(b.ValuesGet("cloudProviderVsphere.internal.storageClasses").String()).To(MatchJSON(`[]`))
+		})
+	})
+
+	e := HookExecutionConfigInit(initValuesStringE, `{}`)
+
+	Context("When all discovered storage classes are excluded", func() {
+		BeforeEach(func() {
+			e.BindingContexts.Set(e.KubeStateSet(state))
+			e.BindingContexts.Set(e.GenerateBeforeHelmContext())
+			e.RunHook()
+		})
+
+		It("Should result empty storageClasses list", func() {
+			Expect(e).To(ExecuteSuccessfully())
+			Expect(e.ValuesGet("cloudProviderVsphere.internal.storageClasses").String()).To(MatchJSON(`[]`))
+		})
+	})
+
+	g := HookExecutionConfigInit(initValuesStringA, `{}`)
+
+	Context("Cluster without discovery data secret, but with deckhouse storage classes", func() {
+		BeforeEach(func() {
+			g.BindingContexts.Set(g.KubeStateSet(storageClassesState))
+			g.BindingContexts.Set(g.GenerateBeforeHelmContext())
+			g.RunHook()
+		})
+
+		It("Should restore storageClasses from storage class snapshots", func() {
+			Expect(g).To(ExecuteSuccessfully())
+			Expect(g.ValuesGet("cloudProviderVsphere.internal.storageClasses").String()).To(MatchJSON(`
+[
+  {
+    "name": "deckhouse-default",
+    "path": "",
+    "zones": ["zone-c"],
+    "datastoreType": "",
+    "datastoreURL": "ds:///vmfs/volumes/default/",
+    "storagePolicyName": ""
+  },
+  {
+    "name": "deckhouse-gold",
+    "path": "",
+    "zones": ["zone-a", "zone-b"],
+    "datastoreType": "",
+    "datastoreURL": "ds:///vmfs/volumes/gold/",
+    "storagePolicyName": "Gold Policy"
+  }
+]
+`))
+		})
+	})
+
+	h := HookExecutionConfigInit(initValuesStringA, `{}`)
+
+	Context("Cluster without discovery data secret and without deckhouse storage classes", func() {
+		BeforeEach(func() {
+			h.BindingContexts.Set(h.GenerateBeforeHelmContext())
+			h.RunHook()
+		})
+
+		It("Should not fail and should keep storageClasses empty", func() {
+			Expect(h).To(ExecuteSuccessfully())
+			Expect(h.ValuesGet("cloudProviderVsphere.internal.storageClasses").String()).To(BeEmpty())
+		})
+	})
+
+	legacyF := HookExecutionConfigInit(initValuesStringF, `{}`)
+
+	Context("Legacy CSI mode: DatastoreCluster entries are preserved", func() {
+		BeforeEach(func() {
+			legacyF.BindingContexts.Set(legacyF.KubeStateSet(state))
+			legacyF.BindingContexts.Set(legacyF.GenerateBeforeHelmContext())
+			legacyF.RunHook()
+		})
+
+		It("Should keep DatastoreCluster entries in Legacy mode", func() {
+			Expect(legacyF).To(ExecuteSuccessfully())
+			Expect(legacyF.ValuesGet("cloudProviderVsphere.internal.storageClasses").String()).To(MatchJSON(`
+[
+          {
             "name": "test-1-k8s-3cf5ce84",
             "path": "/DCTEST/datastore/test_1_k8s",
             "zones": [
@@ -333,118 +507,6 @@ parameters:
           }
         ]
 `))
-		})
-
-	})
-
-	b := HookExecutionConfigInit(initValuesStringB, `{}`)
-
-	Context("Cluster has minimal cloudProviderVsphere configuration with excluded storage classes", func() {
-		BeforeEach(func() {
-			b.BindingContexts.Set(b.KubeStateSet(state))
-			b.BindingContexts.Set(b.GenerateBeforeHelmContext())
-			b.RunHook()
-		})
-
-		It("Should discover volumeTypes without excluded", func() {
-			Expect(b).To(ExecuteSuccessfully())
-			Expect(b.ValuesGet("cloudProviderVsphere.internal.storageClasses").String()).To(MatchJSON(`
-[
-          {
-            "name": "test-1-k8s-3cf5ce84",
-            "path": "/DCTEST/datastore/test_1_k8s",
-            "zones": [
-              "ZONE-TEST"
-            ],
-            "datastoreType": "DatastoreCluster",
-            "datastoreURL": "",
-            "storagePolicyName": ""
-          },
-          {
-            "name": "test-1-k8s-3cf5ce84-management-storage-policy---large",
-            "path": "/DCTEST/datastore/test_1_k8s",
-            "zones": [
-              "ZONE-TEST"
-            ],
-            "datastoreType": "DatastoreCluster",
-            "datastoreURL": "",
-            "storagePolicyName": "Management Storage Policy - Large"
-          },
-          {
-            "name": "test-1-k8s-3cf5ce84-vvol-no-requirements-policy",
-            "path": "/DCTEST/datastore/test_1_k8s",
-            "zones": [
-              "ZONE-TEST"
-            ],
-            "datastoreType": "DatastoreCluster",
-            "datastoreURL": "",
-            "storagePolicyName": "VVol No Requirements Policy"
-          }
-]
-`))
-		})
-	})
-
-	e := HookExecutionConfigInit(initValuesStringE, `{}`)
-
-	Context("When all discovered storage classes are excluded", func() {
-		BeforeEach(func() {
-			e.BindingContexts.Set(e.KubeStateSet(state))
-			e.BindingContexts.Set(e.GenerateBeforeHelmContext())
-			e.RunHook()
-		})
-
-		It("Should result empty storageClasses list", func() {
-			Expect(e).To(ExecuteSuccessfully())
-			Expect(e.ValuesGet("cloudProviderVsphere.internal.storageClasses").String()).To(MatchJSON(`[]`))
-		})
-	})
-
-	g := HookExecutionConfigInit(initValuesStringA, `{}`)
-
-	Context("Cluster without discovery data secret, but with deckhouse storage classes", func() {
-		BeforeEach(func() {
-			g.BindingContexts.Set(g.KubeStateSet(storageClassesState))
-			g.BindingContexts.Set(g.GenerateBeforeHelmContext())
-			g.RunHook()
-		})
-
-		It("Should restore storageClasses from storage class snapshots", func() {
-			Expect(g).To(ExecuteSuccessfully())
-			Expect(g.ValuesGet("cloudProviderVsphere.internal.storageClasses").String()).To(MatchJSON(`
-[
-  {
-    "name": "deckhouse-default",
-    "path": "",
-    "zones": ["zone-c"],
-    "datastoreType": "",
-    "datastoreURL": "ds:///vmfs/volumes/default/",
-    "storagePolicyName": ""
-  },
-  {
-    "name": "deckhouse-gold",
-    "path": "",
-    "zones": ["zone-a", "zone-b"],
-    "datastoreType": "",
-    "datastoreURL": "ds:///vmfs/volumes/gold/",
-    "storagePolicyName": "Gold Policy"
-  }
-]
-`))
-		})
-	})
-
-	h := HookExecutionConfigInit(initValuesStringA, `{}`)
-
-	Context("Cluster without discovery data secret and without deckhouse storage classes", func() {
-		BeforeEach(func() {
-			h.BindingContexts.Set(h.GenerateBeforeHelmContext())
-			h.RunHook()
-		})
-
-		It("Should not fail and should keep storageClasses empty", func() {
-			Expect(h).To(ExecuteSuccessfully())
-			Expect(h.ValuesGet("cloudProviderVsphere.internal.storageClasses").String()).To(BeEmpty())
 		})
 	})
 })

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/template_tests/module_test.go
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/template_tests/module_test.go
@@ -247,6 +247,36 @@ const moduleValuesD = `
             tcpAppProfileName: profile1
 `
 
+const moduleValuesDatastoreOnly = `
+    internal:
+      storageClasses:
+      - name: aaa-datastore
+        datastoreType: Datastore
+        datastoreURL: ds:///vmfs/volumes/aaa/
+        path: /dc/datastore/aaa
+        zones: ["zone-a"]
+      - name: bbb-datastore
+        datastoreType: Datastore
+        datastoreURL: ds:///vmfs/volumes/bbb/
+        path: /dc/datastore/bbb
+        zones: ["zone-a"]
+      compatibilityFlag: ""
+      providerDiscoveryData:
+        datacenter: X1
+        zones: ["zone-a"]
+      providerClusterConfiguration:
+        provider:
+          server: myhost
+          username: myuname
+          password: myPaSsWd
+          insecure: true
+        regionTagCategory: myregtagcat
+        zoneTagCategory: myzonetagcat
+        region: myreg
+        sshPublicKey: mysshkey1
+        vmFolderPath: dev/test
+`
+
 const moduleValuesHybrid = `
     internal:
       storageClasses:
@@ -744,6 +774,31 @@ nodes:
   externalVmNetworkName: aaa,bbb
   internalVmNetworkName: ccc,ddd
 `))
+		})
+	})
+
+	Context("Vsphere DatastoreCluster filtered by hook: first Datastore gets default annotation", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", fmt.Sprintf(globalValues, "1.32", "1.32"))
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYaml("cloudProviderVsphere", moduleValuesDatastoreOnly)
+			f.HelmRender()
+		})
+
+		It("first StorageClass gets default annotation, second does not", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			scAaa := f.KubernetesGlobalResource("StorageClass", "aaa-datastore")
+			scBbb := f.KubernetesGlobalResource("StorageClass", "bbb-datastore")
+
+			Expect(scAaa.Exists()).To(BeTrue())
+			Expect(scBbb.Exists()).To(BeTrue())
+
+			Expect(scAaa.Field("metadata.annotations").String()).To(MatchYAML(`
+storageclass.deckhouse.io/volume-expansion-mode: offline
+storageclass.kubernetes.io/is-default-class: "true"
+`))
+			Expect(scBbb.Field(`metadata.annotations.storageclass\.kubernetes\.io/is-default-class`).Exists()).To(BeFalse())
 		})
 	})
 

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/template_tests/module_test.go
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/template_tests/module_test.go
@@ -247,18 +247,23 @@ const moduleValuesD = `
             tcpAppProfileName: profile1
 `
 
-const moduleValuesDatastoreOnly = `
+const moduleValuesDCClusterFirst = `
     internal:
       storageClasses:
-      - name: aaa-datastore
-        datastoreType: Datastore
-        datastoreURL: ds:///vmfs/volumes/aaa/
-        path: /dc/datastore/aaa
+      - name: aaa-dscluster
+        datastoreType: DatastoreCluster
+        datastoreURL: ""
+        path: /dc/datastore/aaa-dscluster
         zones: ["zone-a"]
       - name: bbb-datastore
         datastoreType: Datastore
         datastoreURL: ds:///vmfs/volumes/bbb/
         path: /dc/datastore/bbb
+        zones: ["zone-a"]
+      - name: ccc-datastore
+        datastoreType: Datastore
+        datastoreURL: ds:///vmfs/volumes/ccc/
+        path: /dc/datastore/ccc
         zones: ["zone-a"]
       compatibilityFlag: ""
       providerDiscoveryData:
@@ -777,28 +782,24 @@ nodes:
 		})
 	})
 
-	Context("Vsphere DatastoreCluster filtered by hook: first Datastore gets default annotation", func() {
+	Context("Vsphere: DatastoreCluster at index 0 is not rendered (defense-in-depth)", func() {
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global", fmt.Sprintf(globalValues, "1.32", "1.32"))
 			f.ValuesSet("global.modulesImages", GetModulesImages())
-			f.ValuesSetFromYaml("cloudProviderVsphere", moduleValuesDatastoreOnly)
+			f.ValuesSetFromYaml("cloudProviderVsphere", moduleValuesDCClusterFirst)
 			f.HelmRender()
 		})
 
-		It("first StorageClass gets default annotation, second does not", func() {
+		It("DatastoreCluster StorageClass is not created; Datastore StorageClasses are rendered", func() {
 			Expect(f.RenderError).ShouldNot(HaveOccurred())
 
-			scAaa := f.KubernetesGlobalResource("StorageClass", "aaa-datastore")
+			scDC := f.KubernetesGlobalResource("StorageClass", "aaa-dscluster")
 			scBbb := f.KubernetesGlobalResource("StorageClass", "bbb-datastore")
+			scCcc := f.KubernetesGlobalResource("StorageClass", "ccc-datastore")
 
-			Expect(scAaa.Exists()).To(BeTrue())
+			Expect(scDC.Exists()).To(BeFalse())
 			Expect(scBbb.Exists()).To(BeTrue())
-
-			Expect(scAaa.Field("metadata.annotations").String()).To(MatchYAML(`
-storageclass.deckhouse.io/volume-expansion-mode: offline
-storageclass.kubernetes.io/is-default-class: "true"
-`))
-			Expect(scBbb.Field(`metadata.annotations.storageclass\.kubernetes\.io/is-default-class`).Exists()).To(BeFalse())
+			Expect(scCcc.Exists()).To(BeTrue())
 		})
 	})
 

--- a/ee/se-plus/modules/030-csi-vsphere/hooks/discover.go
+++ b/ee/se-plus/modules/030-csi-vsphere/hooks/discover.go
@@ -226,9 +226,25 @@ func handleDiscoveryDataVolumeTypes(input *go_hook.HookInput, zonedDataStores []
 		return storageClasses[i].Name < storageClasses[j].Name
 	})
 
+	storageClasses = filterStorageClassesForCSICompatibility(input, storageClasses)
+
 	input.Logger.Info("Found vSphere storage classes using cloud_provider_discovery_data", slog.Any("data", storageClasses))
 	input.Values.Set("csiVsphere.internal.storageClasses", storageClasses)
 	return nil
+}
+
+func filterStorageClassesForCSICompatibility(input *go_hook.HookInput, storageClasses []storageClass) []storageClass {
+	if v, ok := input.Values.GetOk("csiVsphere.storageClass.compatibilityFlag"); ok && v.String() == "Legacy" {
+		return storageClasses
+	}
+	filtered := make([]storageClass, 0, len(storageClasses))
+	for _, sc := range storageClasses {
+		if sc.DatastoreType == "DatastoreCluster" {
+			continue
+		}
+		filtered = append(filtered, sc)
+	}
+	return filtered
 }
 
 // Get StorageClass name from Volume type name to match Kubernetes restrictions from https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names

--- a/ee/se-plus/modules/030-csi-vsphere/hooks/discover_test.go
+++ b/ee/se-plus/modules/030-csi-vsphere/hooks/discover_test.go
@@ -116,6 +116,23 @@ csiVsphere:
     - .*
     default: other-bar
 `
+		initValuesStringF = `
+csiVsphere:
+  internal:
+    providerClusterConfiguration:
+      provider:
+        server: test.test.com
+        username: test
+        password: test
+        insecure: true
+      region: Test
+      regionTagCategory: test-region
+      zoneTagCategory: test-zone
+      sshPublicKey: test
+      vmFolderPath: test
+  storageClass:
+    compatibilityFlag: Legacy
+`
 	)
 
 	//nolint:misspell
@@ -190,6 +207,92 @@ data:
 			Expect(f.ValuesGet("csiVsphere.internal.storageClasses").String()).To(MatchJSON(`
 [
   {
+	"datastoreType": "Datastore",
+    "datastoreURL":"ds:///vmfs/volumes/503a9af1-291d17b0-52e0-1d01842f428c/",
+	"name": "test-1-lun101-b39d82fa",
+	"path": "/DCTEST/datastore/test_1_Lun101",
+	"zones": [
+	  "ZONE-TEST"
+	]
+  },
+  {
+	"datastoreType": "Datastore",
+    "datastoreURL":"ds:///vmfs/volumes/503a9af1-291d17b0-52e0-1d01842f428c/",
+	"name": "test-1-lun101-b39d82fa-gold-policy",
+	"path": "/DCTEST/datastore/test_1_Lun101",
+	"storagePolicyName": "Gold Policy",
+	"zones": [
+	  "ZONE-TEST"
+	]
+  },
+  {
+	"datastoreType": "Datastore",
+    "datastoreURL":"ds:///vmfs/volumes/55832249-30a68048-496f-33f77fed3c5c/",
+	"name": "test-1-lun102-0403073a",
+	"path": "/DCTEST/datastore/test_1_Lun102",
+	"zones": [
+	  "ZONE-TEST"
+	]
+  },
+  {
+	"datastoreType": "Datastore",
+    "datastoreURL":"ds:///vmfs/volumes/55832249-30a68048-496f-33f77fed3c5c/",
+	"name": "test-1-lun102-0403073a-gold-policy",
+	"path": "/DCTEST/datastore/test_1_Lun102",
+	"storagePolicyName": "Gold Policy",
+	"zones": [
+	  "ZONE-TEST"
+	]
+  }
+]
+`))
+		})
+	})
+
+	b := HookExecutionConfigInit(initValuesStringB, `{}`)
+
+	Context("Cluster has minimal csiVsphere configuration with excluded storage classes", func() {
+		BeforeEach(func() {
+			b.BindingContexts.Set(b.KubeStateSet(state))
+			b.BindingContexts.Set(b.GenerateBeforeHelmContext())
+			b.RunHook()
+		})
+
+		It("Should discover volumeTypes without excluded", func() {
+			Expect(b).To(ExecuteSuccessfully())
+			Expect(b.ValuesGet("csiVsphere.internal.storageClasses").String()).To(MatchJSON(`[]`))
+		})
+	})
+
+	e := HookExecutionConfigInit(initValuesStringE, `{}`)
+
+	Context("When all discovered storage classes are excluded", func() {
+		BeforeEach(func() {
+			e.BindingContexts.Set(e.KubeStateSet(state))
+			e.BindingContexts.Set(e.GenerateBeforeHelmContext())
+			e.RunHook()
+		})
+
+		It("Should result empty storageClasses list", func() {
+			Expect(e).To(ExecuteSuccessfully())
+			Expect(e.ValuesGet("csiVsphere.internal.storageClasses").String()).To(MatchJSON(`[]`))
+		})
+	})
+
+	legacyF := HookExecutionConfigInit(initValuesStringF, `{}`)
+
+	Context("Legacy CSI mode: DatastoreCluster entries are preserved", func() {
+		BeforeEach(func() {
+			legacyF.BindingContexts.Set(legacyF.KubeStateSet(state))
+			legacyF.BindingContexts.Set(legacyF.GenerateBeforeHelmContext())
+			legacyF.RunHook()
+		})
+
+		It("Should keep DatastoreCluster entries in Legacy mode", func() {
+			Expect(legacyF).To(ExecuteSuccessfully())
+			Expect(legacyF.ValuesGet("csiVsphere.internal.storageClasses").String()).To(MatchJSON(`
+[
+  {
 	"datastoreType": "DatastoreCluster",
 	"datastoreURL": "",
 	"name": "test-1-k8s-3cf5ce84",
@@ -248,58 +351,6 @@ data:
   }
 ]
 `))
-		})
-	})
-
-	b := HookExecutionConfigInit(initValuesStringB, `{}`)
-
-	Context("Cluster has minimal csiVsphere configuration with excluded storage classes", func() {
-		BeforeEach(func() {
-			b.BindingContexts.Set(b.KubeStateSet(state))
-			b.BindingContexts.Set(b.GenerateBeforeHelmContext())
-			b.RunHook()
-		})
-
-		It("Should discover volumeTypes without excluded", func() {
-			Expect(b).To(ExecuteSuccessfully())
-			Expect(b.ValuesGet("csiVsphere.internal.storageClasses").String()).To(MatchJSON(`
-[
-  {
-	"datastoreType": "DatastoreCluster",
-	"datastoreURL": "",
-	"name": "test-1-k8s-3cf5ce84",
-	"path": "/DCTEST/datastore/test_1_k8s",
-	"zones": [
-	  "ZONE-TEST"
-	]
-  },
-  {
-	"datastoreType": "DatastoreCluster",
-	"datastoreURL": "",
-	"name": "test-1-k8s-3cf5ce84-gold-policy",
-	"path": "/DCTEST/datastore/test_1_k8s",
-	"storagePolicyName": "Gold Policy",
-	"zones": [
-	  "ZONE-TEST"
-	]
-  }
-]
-`))
-		})
-	})
-
-	e := HookExecutionConfigInit(initValuesStringE, `{}`)
-
-	Context("When all discovered storage classes are excluded", func() {
-		BeforeEach(func() {
-			e.BindingContexts.Set(e.KubeStateSet(state))
-			e.BindingContexts.Set(e.GenerateBeforeHelmContext())
-			e.RunHook()
-		})
-
-		It("Should result empty storageClasses list", func() {
-			Expect(e).To(ExecuteSuccessfully())
-			Expect(e.ValuesGet("csiVsphere.internal.storageClasses").String()).To(MatchJSON(`[]`))
 		})
 	})
 })

--- a/ee/se-plus/modules/030-csi-vsphere/template_tests/module_test.go
+++ b/ee/se-plus/modules/030-csi-vsphere/template_tests/module_test.go
@@ -95,7 +95,7 @@ internal:
     vmFolderPath: dev/test
 `
 
-const moduleValuesDatastoreOnly = `
+const moduleValuesDCClusterFirst = `
 host: myhost
 username: myuname
 password: myPaSsWd
@@ -106,15 +106,20 @@ region: myreg
 zones: ["zone-a"]
 internal:
   storageClasses:
-  - name: aaa-datastore
-    datastoreType: Datastore
-    datastoreURL: ds:///vmfs/volumes/aaa/
-    path: /dc/datastore/aaa
+  - name: aaa-dscluster
+    datastoreType: DatastoreCluster
+    datastoreURL: ""
+    path: /dc/datastore/aaa-dscluster
     zones: ["zone-a"]
   - name: bbb-datastore
     datastoreType: Datastore
     datastoreURL: ds:///vmfs/volumes/bbb/
     path: /dc/datastore/bbb
+    zones: ["zone-a"]
+  - name: ccc-datastore
+    datastoreType: Datastore
+    datastoreURL: ds:///vmfs/volumes/ccc/
+    path: /dc/datastore/ccc
     zones: ["zone-a"]
   compatibilityFlag: ""
   providerDiscoveryData:
@@ -290,27 +295,24 @@ var _ = Describe("Module :: csi-vsphere :: helm template ::", func() {
 		})
 	})
 
-	Context("Vsphere DatastoreCluster filtered by hook: first Datastore gets default annotation", func() {
+	Context("Vsphere: DatastoreCluster at index 0 is not rendered (defense-in-depth)", func() {
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global", fmt.Sprintf(globalValues, "1.32", "1.32"))
 			f.ValuesSet("global.modulesImages", GetModulesImages())
-			f.ValuesSetFromYaml("csiVsphere", moduleValuesDatastoreOnly)
+			f.ValuesSetFromYaml("csiVsphere", moduleValuesDCClusterFirst)
 			f.HelmRender()
 		})
 
-		It("first StorageClass gets default annotation, second does not", func() {
+		It("DatastoreCluster StorageClass is not created; Datastore StorageClasses are rendered", func() {
 			Expect(f.RenderError).ShouldNot(HaveOccurred())
 
-			scAaa := f.KubernetesGlobalResource("StorageClass", "aaa-datastore")
+			scDC := f.KubernetesGlobalResource("StorageClass", "aaa-dscluster")
 			scBbb := f.KubernetesGlobalResource("StorageClass", "bbb-datastore")
+			scCcc := f.KubernetesGlobalResource("StorageClass", "ccc-datastore")
 
-			Expect(scAaa.Exists()).To(BeTrue())
+			Expect(scDC.Exists()).To(BeFalse())
 			Expect(scBbb.Exists()).To(BeTrue())
-
-			Expect(scAaa.Field("metadata.annotations").String()).To(MatchYAML(`
-storageclass.kubernetes.io/is-default-class: "true"
-`))
-			Expect(scBbb.Field(`metadata.annotations.storageclass\.kubernetes\.io/is-default-class`).Exists()).To(BeFalse())
+			Expect(scCcc.Exists()).To(BeTrue())
 		})
 	})
 

--- a/ee/se-plus/modules/030-csi-vsphere/template_tests/module_test.go
+++ b/ee/se-plus/modules/030-csi-vsphere/template_tests/module_test.go
@@ -95,6 +95,43 @@ internal:
     vmFolderPath: dev/test
 `
 
+const moduleValuesDatastoreOnly = `
+host: myhost
+username: myuname
+password: myPaSsWd
+vmFolderPath: dev/test
+regionTagCategory: myregtagcat
+zoneTagCategory: myzonetagcat
+region: myreg
+zones: ["zone-a"]
+internal:
+  storageClasses:
+  - name: aaa-datastore
+    datastoreType: Datastore
+    datastoreURL: ds:///vmfs/volumes/aaa/
+    path: /dc/datastore/aaa
+    zones: ["zone-a"]
+  - name: bbb-datastore
+    datastoreType: Datastore
+    datastoreURL: ds:///vmfs/volumes/bbb/
+    path: /dc/datastore/bbb
+    zones: ["zone-a"]
+  compatibilityFlag: ""
+  providerDiscoveryData:
+    datacenter: X1
+    zones: ["zone-a"]
+  providerClusterConfiguration:
+    provider:
+      server: myhost
+      username: myuname
+      password: myPaSsWd
+      insecure: true
+    regionTagCategory: myregtagcat
+    zoneTagCategory: myzonetagcat
+    region: myreg
+    vmFolderPath: dev/test
+`
+
 const moduleValuesB = `
     host: myhost
     username: myuname
@@ -250,6 +287,30 @@ var _ = Describe("Module :: csi-vsphere :: helm template ::", func() {
 				Expect(f.RenderError).ShouldNot(HaveOccurred())
 				Expect(f.KubernetesResource("Deployment", moduleNamespace, "csi-controller").Exists()).To(BeFalse())
 			})
+		})
+	})
+
+	Context("Vsphere DatastoreCluster filtered by hook: first Datastore gets default annotation", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", fmt.Sprintf(globalValues, "1.32", "1.32"))
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYaml("csiVsphere", moduleValuesDatastoreOnly)
+			f.HelmRender()
+		})
+
+		It("first StorageClass gets default annotation, second does not", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			scAaa := f.KubernetesGlobalResource("StorageClass", "aaa-datastore")
+			scBbb := f.KubernetesGlobalResource("StorageClass", "bbb-datastore")
+
+			Expect(scAaa.Exists()).To(BeTrue())
+			Expect(scBbb.Exists()).To(BeTrue())
+
+			Expect(scAaa.Field("metadata.annotations").String()).To(MatchYAML(`
+storageclass.kubernetes.io/is-default-class: "true"
+`))
+			Expect(scBbb.Field(`metadata.annotations.storageclass\.kubernetes\.io/is-default-class`).Exists()).To(BeFalse())
 		})
 	})
 


### PR DESCRIPTION
## Description
In discover hook for both `cloud-provider-vsphere` and `csi-vsphere` modules, `DatastoreCluster` entries are now excluded from `internal.storageClasses` before Helm rendering (modern CSI mode only). This ensures the index-0 default annotation is applied to a StorageClass that is actually rendered in `csi/storageclass.yaml`.

## Why do we need it, and what problem does it solve?
The discover hook collects all datastores (including `DatastoreCluster`) into `internal.storageClasses`, sorted by name. The `csi/storageclass.yaml` template renders StorageClasses only for `datastoreType == "Datastore"`, but the
`helm_lib_module_storage_class_annotations` helper assigns the default annotation based on the original list index (`$index == 0`).

When a `DatastoreCluster` entry sorts first alphabetically, it occupies index 0 but is skipped by the template — so no StorageClass gets the default annotation.

The fix filters `DatastoreCluster` entries in the hook before setting values, so index 0 always belongs to a rendered StorageClass.

Legacy CSI mode (`storageClass.compatibilityFlag: Legacy`) is unaffected — `csi-legacy/storageclass.yaml` renders all datastore types.


## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-vsphere
type: fix
summary: fix missing default StorageClass annotation when a DatastoreCluster entry sorts before all Datastore entries
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
