### PR TITLE
[dhctl] [node-manager] backport of #21108

### DIFF
--- a/dhctl/pkg/state/config_hash.go
+++ b/dhctl/pkg/state/config_hash.go
@@ -28,22 +28,29 @@ func ConfigHash(paths []string) string {
 	const hashLen = 8
 
 	resolvedPaths := fs.RevealWildcardPaths(paths)
-	sort.Strings(resolvedPaths)
 
-	h := sha256.New()
+	digests := make([]string, 0, len(resolvedPaths))
 	for _, path := range resolvedPaths {
 		data, err := os.ReadFile(path)
 		if err != nil {
 			log.WarnF("cannot read config file %s for preflight cache hash: %v\n", path, err)
 			continue
 		}
-		if _, err := h.Write(data); err != nil {
-			log.WarnF("cannot hash config file %s for preflight cache hash: %v\n", path, err)
-		}
+		sum := sha256.Sum256(data)
+		digests = append(digests, hex.EncodeToString(sum[:]))
+	}
+	sort.Strings(digests)
+
+	h := sha256.New()
+	for _, d := range digests {
+		h.Write([]byte(d))
 	}
 	hash := hex.EncodeToString(h.Sum(nil))
 	if len(hash) > hashLen {
-		return hash[:hashLen]
+		hash = hash[:hashLen]
 	}
+
+	log.DebugF("computed config hash %s over %d config file(s)\n", hash, len(digests))
+
 	return hash
 }

--- a/dhctl/pkg/state/config_hash_test.go
+++ b/dhctl/pkg/state/config_hash_test.go
@@ -1,0 +1,110 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package state
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// writeBlobsToRandomTempFiles writes each blob to a freshly created, randomly
+// named temp file (mirroring dhctl-server's os.CreateTemp("", "*") behaviour)
+// and returns the resulting paths. Files live under a t.TempDir so they are
+// cleaned up automatically.
+func writeBlobsToRandomTempFiles(t *testing.T, blobs [][]byte) []string {
+	t.Helper()
+
+	dir := t.TempDir()
+	paths := make([]string, 0, len(blobs))
+	for _, blob := range blobs {
+		f, err := os.CreateTemp(dir, "*")
+		require.NoError(t, err)
+		_, err = f.Write(blob)
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+		paths = append(paths, f.Name())
+	}
+	return paths
+}
+
+// TestConfigHashDeterministicAcrossRandomTempNames is the regression test for
+// the preflight-skip-on-restart bug: dhctl-server writes each config blob to a
+// randomly named temp file, so two invocations with byte-identical config used
+// to produce different hashes (the old ConfigHash sorted by path). That flipped
+// the preflight cache salt every run and re-ran preflights on restart.
+func TestConfigHashDeterministicAcrossRandomTempNames(t *testing.T) {
+	blobs := [][]byte{
+		[]byte("apiVersion: deckhouse.io/v1\nkind: ClusterConfiguration\n"),
+		[]byte("apiVersion: deckhouse.io/v1\nkind: StaticClusterConfiguration\n"),
+		[]byte("apiVersion: deckhouse.io/v1\nkind: Resource\n"),
+	}
+
+	// Run several times: temp names are random, so a single pass could match by
+	// luck. Every run must hash equal to the first.
+	first := ConfigHash(writeBlobsToRandomTempFiles(t, blobs))
+	for range 10 {
+		got := ConfigHash(writeBlobsToRandomTempFiles(t, blobs))
+		require.Equal(t, first, got, "identical config content must hash equally regardless of random temp file names")
+	}
+}
+
+// TestConfigHashIndependentOfPathOrder ensures the slice order of paths does not
+// affect the hash (same files, shuffled argument order).
+func TestConfigHashIndependentOfPathOrder(t *testing.T) {
+	paths := writeBlobsToRandomTempFiles(t, [][]byte{
+		[]byte("blob-A"),
+		[]byte("blob-B"),
+		[]byte("blob-C"),
+	})
+
+	reversed := make([]string, len(paths))
+	for i, p := range paths {
+		reversed[len(paths)-1-i] = p
+	}
+
+	require.Equal(t, ConfigHash(paths), ConfigHash(reversed))
+}
+
+// TestConfigHashChangesOnContentChange ensures the salt still invalidates when
+// any config actually changes (e.g. a changed master IP / CIDR), so preflights
+// correctly re-run.
+func TestConfigHashChangesOnContentChange(t *testing.T) {
+	base := [][]byte{
+		[]byte("master:\n  ip: 10.0.0.1\n"),
+		[]byte("apiVersion: deckhouse.io/v1\nkind: StaticClusterConfiguration\n"),
+	}
+	changed := [][]byte{
+		[]byte("master:\n  ip: 10.0.0.2\n"), // IP changed
+		[]byte("apiVersion: deckhouse.io/v1\nkind: StaticClusterConfiguration\n"),
+	}
+
+	require.NotEqual(t,
+		ConfigHash(writeBlobsToRandomTempFiles(t, base)),
+		ConfigHash(writeBlobsToRandomTempFiles(t, changed)),
+		"changed config content must change the hash so preflights re-run")
+}
+
+// TestConfigHashStableForSameFile is a sanity check that a single fixed file
+// hashes to the same value across calls.
+func TestConfigHashStableForSameFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("kind: ClusterConfiguration\n"), 0o600))
+
+	require.Equal(t, ConfigHash([]string{path}), ConfigHash([]string{path}))
+}

--- a/modules/040-node-manager/images/caps-controller-manager/src/api/deckhouse.io/v1alpha1/staticinstance_webhook.go
+++ b/modules/040-node-manager/images/caps-controller-manager/src/api/deckhouse.io/v1alpha1/staticinstance_webhook.go
@@ -40,7 +40,7 @@ func (r *StaticInstance) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(r).
 		WithDefaulter(&StaticInstanceCustomDefaulter{}).
-		WithValidator(&StaticInstanceCustomValidator{}).
+		WithValidator(&StaticInstanceCustomValidator{Reader: mgr.GetAPIReader()}).
 		Complete()
 }
 
@@ -64,13 +64,15 @@ func (*StaticInstanceCustomDefaulter) Default(_ context.Context, obj runtime.Obj
 }
 
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
-type StaticInstanceCustomValidator struct{}
+type StaticInstanceCustomValidator struct {
+	Reader client.Reader
+}
 
 // +kubebuilder:webhook:path=/validate-deckhouse-io-v1alpha1-staticinstance,mutating=false,failurePolicy=fail,sideEffects=None,groups=deckhouse.io,resources=staticinstances,verbs=update;delete,versions=v1alpha1,name=vstaticinstance.deckhouse.io,admissionReviewVersions=v1
 var _ webhook.CustomValidator = &StaticInstanceCustomValidator{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
-func (*StaticInstanceCustomValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+func (v *StaticInstanceCustomValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	staticInstance, ok := obj.(*StaticInstance)
 	if !ok {
 		return nil, fmt.Errorf("expected an StaticInstance object but got %T", obj)
@@ -78,17 +80,17 @@ func (*StaticInstanceCustomValidator) ValidateCreate(ctx context.Context, obj ru
 
 	staticinstancelog.Info("validate create", "name", staticInstance.GetName())
 
-	mgr, err := ctrl.GetConfig()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get Kubernetes config: %w", err)
+	existing := &StaticInstance{}
+	err := v.Reader.Get(ctx, client.ObjectKey{Name: staticInstance.Name}, existing)
+	switch {
+	case err == nil:
+		staticinstancelog.Info("StaticInstance already exists, skipping address validation", "name", staticInstance.GetName())
+		return nil, nil
+	case !apierrors.IsNotFound(err):
+		return nil, fmt.Errorf("failed to get StaticInstance %q: %w", staticInstance.GetName(), err)
 	}
 
-	cli, err := client.New(mgr, client.Options{})
-	if err != nil {
-		return nil, fmt.Errorf("failed to create Kubernetes client: %w", err)
-	}
-
-	if err := staticInstance.validateAddressIfNoSkipBootstrap(ctx, cli); err != nil {
+	if err := staticInstance.validateAddressIfNoSkipBootstrap(ctx, v.Reader); err != nil {
 		return nil, field.Forbidden(field.NewPath("spec", "address"), err.Error())
 	}
 
@@ -145,7 +147,7 @@ func (*StaticInstanceCustomValidator) ValidateDelete(_ context.Context, obj runt
 // validateAddressIfNoSkipBootstrap ensures that if StaticInstance does NOT have
 // annotation "static.node.deckhouse.io/skip-bootstrap-phase",
 // then its spec.address must NOT match any existing Node address.
-func (r *StaticInstance) validateAddressIfNoSkipBootstrap(ctx context.Context, cli client.Client) error {
+func (r *StaticInstance) validateAddressIfNoSkipBootstrap(ctx context.Context, cli client.Reader) error {
 	if _, hasSkipBootstrap := r.Annotations["static.node.deckhouse.io/skip-bootstrap-phase"]; hasSkipBootstrap {
 		staticinstancelog.Info("skip-bootstrap annotation found, skipping address validation", "name", r.Name)
 		return nil

--- a/modules/040-node-manager/images/caps-controller-manager/src/api/deckhouse.io/v1alpha2/staticinstance_webhook.go
+++ b/modules/040-node-manager/images/caps-controller-manager/src/api/deckhouse.io/v1alpha2/staticinstance_webhook.go
@@ -40,7 +40,7 @@ func (r *StaticInstance) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(r).
 		WithDefaulter(&StaticInstanceCustomDefaulter{}).
-		WithValidator(&StaticInstanceCustomValidator{}).
+		WithValidator(&StaticInstanceCustomValidator{Reader: mgr.GetAPIReader()}).
 		Complete()
 }
 
@@ -67,7 +67,9 @@ func (r *StaticInstanceCustomDefaulter) Default(_ context.Context, obj runtime.O
 
 var _ webhook.CustomValidator = &StaticInstanceCustomValidator{}
 
-type StaticInstanceCustomValidator struct{}
+type StaticInstanceCustomValidator struct {
+	Reader client.Reader
+}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *StaticInstanceCustomValidator) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
@@ -79,16 +81,17 @@ func (r *StaticInstanceCustomValidator) ValidateCreate(_ context.Context, obj ru
 
 	ctx := context.Background()
 
-	mgr, err := ctrl.GetConfig()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get Kubernetes config: %w", err)
-	}
-	cli, err := client.New(mgr, client.Options{})
-	if err != nil {
-		return nil, fmt.Errorf("failed to create Kubernetes client: %w", err)
+	existing := &StaticInstance{}
+	err := r.Reader.Get(ctx, client.ObjectKey{Name: staticInstance.Name}, existing)
+	switch {
+	case err == nil:
+		staticinstancelog.Info("StaticInstance already exists, skipping address validation", "name", staticInstance.Name)
+		return nil, nil
+	case !apierrors.IsNotFound(err):
+		return nil, fmt.Errorf("failed to get StaticInstance %q: %w", staticInstance.Name, err)
 	}
 
-	if err := staticInstance.validateAddressIfNoSkipBootstrap(ctx, cli); err != nil {
+	if err := staticInstance.validateAddressIfNoSkipBootstrap(ctx, r.Reader); err != nil {
 		return nil, field.Forbidden(field.NewPath("spec", "address"), err.Error())
 	}
 	return nil, nil
@@ -140,7 +143,7 @@ func (r *StaticInstanceCustomValidator) ValidateDelete(_ context.Context, obj ru
 // validateAddressIfNoSkipBootstrap ensures that if StaticInstance does NOT have
 // annotation "static.node.deckhouse.io/skip-bootstrap-phase",
 // then its spec.address must NOT match any existing Node address.
-func (r *StaticInstance) validateAddressIfNoSkipBootstrap(ctx context.Context, cli client.Client) error {
+func (r *StaticInstance) validateAddressIfNoSkipBootstrap(ctx context.Context, cli client.Reader) error {
 	if _, hasSkipBootstrap := r.Annotations["static.node.deckhouse.io/skip-bootstrap-phase"]; hasSkipBootstrap {
 		staticinstancelog.Info("skip-bootstrap annotation found, skipping address validation", "name", r.Name)
 		return nil


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

It's backport of #21108

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

- **Preflight re-run bug:** `dhctl-server` re-ran preflight checks on every restart even with unchanged config, because the cache salt was non-deterministic across randomly named temp files.
- **StaticInstance duplicate-create bug:** creating or re-applying an already-existing `StaticInstance` could fail address validation against its own registered address.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: dhctl
type: fix
summary: Preflight checks are no longer re-run on every dhctl-server restart when the cluster config is unchanged.
impact_level: default
```

```changes
section: node-manager
type: fix
summary: Creating or re-applying an already-existing StaticInstance no longer fails address validation.
impact_level: default
```
