### PR TITLE
[docs] Add StorageClass alert at DVP hybrid documentation 

### DIFF
--- a/docs/documentation/pages/admin/configuration/integrations/hybrid/DVP_HYBRID.md
+++ b/docs/documentation/pages/admin/configuration/integrations/hybrid/DVP_HYBRID.md
@@ -34,6 +34,12 @@ Before you begin, make sure that the following requirements are met:
 [DVPInstanceClass](/modules/cloud-provider-dvp/cr.html#dvpinstanceclass) parameters use resources from the DVP cluster: VirtualMachineClass, ClusterVirtualImage, VirtualImage, VirtualDisk, and StorageClass from DVP, not from the target DKP cluster.
 {% endalert %}
 
+{% alert level="warning" %}
+Make sure there are no StorageClass resources in the static DKP cluster whose names match the names of StorageClass resources in the DVP cluster.
+
+When the `cloud-provider-dvp` module is enabled, the corresponding StorageClass resources are automatically synchronized from DVP to the DKP cluster. If a StorageClass with the same name already exists in the static cluster, a resource conflict may occur, causing the module installation or upgrade to fail.
+{% endalert %}
+
 ## Adding automatically created nodes
 
 1. On the administrator's machine where access to the DVP cluster is configured, prepare a kubeconfig for the `cloud-provider-dvp` module to access the DVP API.

--- a/docs/documentation/pages/admin/configuration/integrations/hybrid/DVP_HYBRID_RU.md
+++ b/docs/documentation/pages/admin/configuration/integrations/hybrid/DVP_HYBRID_RU.md
@@ -34,6 +34,12 @@ description: Подготовка к гибридной интеграции с 
 В параметрах [DVPInstanceClass](/modules/cloud-provider-dvp/cr.html#dvpinstanceclass) используются ресурсы кластера DVP: VirtualMachineClass, ClusterVirtualImage, VirtualImage, VirtualDisk и StorageClass из DVP, а не из подключаемого DKP-кластера.
 {% endalert %}
 
+{% alert level="warning" %}
+Убедитесь, что в статическом DKP-кластере отсутствуют StorageClass с именами, совпадающими с именами StorageClass в кластере DVP.
+
+При включении модуля `cloud-provider-dvp` соответствующие StorageClass автоматически синхронизируются из DVP в DKP-кластер. Если StorageClass с таким именем уже существует в статическом кластере, может возникнуть конфликт ресурсов, из-за которого установка или обновление модуля завершится с ошибкой.
+{% endalert %}
+
 ## Добавление автоматически создаваемых узлов
 
 1. На машине администратора, где настроен доступ к кластеру DVP, подготовьте kubeconfig для доступа модуля `cloud-provider-dvp` к API DVP.


### PR DESCRIPTION
## Description
Add StorageClass alert at DVP hybrid documentation.

## Why do we need it, and what problem does it solve?

## Why do we need it in the patch release (if we do)?



## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: docs
type: chore
summary: Add StorageClass alert at DVP hybrid documentation.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
