### PR TITLE
[cni-cilium] Added additional information to HubbleMonitoringConfig

### DIFF
--- a/modules/021-cni-cilium/crds/doc-ru-hubble-monitoring-config.yaml
+++ b/modules/021-cni-cilium/crds/doc-ru-hubble-monitoring-config.yaml
@@ -17,7 +17,10 @@ spec:
                     Для получения дополнительной информации смотрите [документацию Cilium](https://docs.cilium.io/en/v1.17/observability/metrics/#monitoring-metrics).
                   properties:
                     enabled:
-                      description: Включает экспорт расширенных метрик с агентов Cilium.
+                      description: |
+                        Включает экспорт расширенных метрик с агентов Cilium.
+
+                        > Все экспортируемые метрики имеют префикс `hubble_*`.
                     collectors:
                       description: |
                         Список расширенных метрик Hubble для экспорта.
@@ -55,7 +58,7 @@ spec:
                       description: |
                         Включает ведение журналов событий для агентов Cilium.
 
-                        Файл журнала расположен на файловой системе узла по пути `/var/log/cilium/hubble/flow.log`.
+                        > Файл журнала расположен на файловой системе узла по пути `/var/log/cilium/hubble/flow.log`.
                     allowFilterList:
                       description: >
                         Определяет фильтры, которые управляют тем, какие события экспортируются в лог.

--- a/modules/021-cni-cilium/crds/hubble-monitoring-config.yaml
+++ b/modules/021-cni-cilium/crds/hubble-monitoring-config.yaml
@@ -47,7 +47,10 @@ spec:
                     enabled:
                       type: boolean
                       default: false
-                      description: Enables the export of extended metrics from Cilium agents.
+                      description: |
+                        Enables the export of extended metrics from Cilium agents.
+
+                        > All exported metrics have the prefix `hubble_*`.
                     collectors:
                       type: array
                       description: |
@@ -121,7 +124,8 @@ spec:
                       default: false
                       description: |
                         Enables event logging for Cilium agents.
-                        The log file is located on the node's filesystem at `/var/log/cilium/hubble/flow.log`.
+
+                        > The log file is located on the node's filesystem at `/var/log/cilium/hubble/flow.log`.
                     allowFilterList:
                       type: array
                       description: >

--- a/modules/021-cni-cilium/docs/README.md
+++ b/modules/021-cni-cilium/docs/README.md
@@ -132,3 +132,8 @@ To enable export, [create a HubbleMonitoringConfig resource](examples.html#hubbl
 {% alert level="warning" %}
 Creating or modifying the HubbleMonitoringConfig resource will **restart all Cilium agents** in the cluster.
 {% endalert %}
+
+After the manifest is applied:
+
+* Hubble metrics become available in Prometheus. All exported metrics have the `hubble_*` prefix;
+* Hubble logs are written to the `/var/log/cilium/hubble/flow.log` file on each node.

--- a/modules/021-cni-cilium/docs/README_RU.md
+++ b/modules/021-cni-cilium/docs/README_RU.md
@@ -132,3 +132,8 @@ Deckhouse Kubernetes Platform позволяет настраивать эксп
 {% alert level="warning" %}
 Создание или изменение ресурса HubbleMonitoringConfig приведёт **к перезапуску всех агентов Cilium** в кластере.
 {% endalert %}
+
+После применения манифеста:
+
+* метрики Hubble станут доступны в Prometheus. Все экспортируемые метрики имеют префикс `hubble_*`;
+* логи Hubble будут записываться на каждом узле в файл `/var/log/cilium/hubble/flow.log`.


### PR DESCRIPTION
## Description
Improves the `HubbleMonitoringConfig` documentation

## Why do we need it, and what problem does it solve?
The previous documentation did not explain how to find the exported metrics and logs. This PR provides the missing information and clarifies the impact of updating `HubbleMonitoringConfig`, making the feature easier to configure and troubleshoot

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: cni-cilium
type: chore
summary: Added additional information to HubbleMonitoringConfig
impact_level: low
```