### PR TITLE
[cloud-provider-vcd] add werf deploy-dependency annotations to capcd webhooks

### DIFF
--- a/ee/modules/030-cloud-provider-vcd/templates/capcd-controller-manager/admission.yaml
+++ b/ee/modules/030-cloud-provider-vcd/templates/capcd-controller-manager/admission.yaml
@@ -3,6 +3,9 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
+  annotations:
+    werf.io/deploy-dependency-deployment: state=ready,kind=Deployment,name=capcd-controller-manager,namespace=d8-cloud-provider-vcd
+    werf.io/deploy-dependency-service: state=present,kind=Service,name=capcd-controller-manager-webhook-service,namespace=d8-cloud-provider-vcd
   name: capcd-mutating-webhook
   {{- include "helm_lib_module_labels" (list . (dict "app" "capcd-controller-manager")) | nindent 2 }}
 webhooks:
@@ -53,6 +56,9 @@ webhooks:
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
+  annotations:
+    werf.io/deploy-dependency-deployment: state=ready,kind=Deployment,name=capcd-controller-manager,namespace=d8-cloud-provider-vcd
+    werf.io/deploy-dependency-service: state=present,kind=Service,name=capcd-controller-manager-webhook-service,namespace=d8-cloud-provider-vcd
   name: capcd-validating-webhook
   {{- include "helm_lib_module_labels" (list . (dict "app" "capcd-controller-manager")) | nindent 2 }}
 webhooks:


### PR DESCRIPTION
## Description
Add `werf.io/deploy-dependency-*` annotations to `capcd-mutating-webhook` and `capcd-validating-webhook` in the `capcd-controller-manager` admission template.

## Why do we need it, and what problem does it solve?
DMT lint rule requires that every `MutatingWebhookConfiguration` / `ValidatingWebhookConfiguration` carries either `werf.io/weight` or at least one `werf.io/deploy-dependency-*` annotation. Without them the DMT Lint Verify job fails for this module.

The added annotations also fix a real race condition: werf previously had no ordering guarantee and could apply the webhook configurations before the backing Deployment and Service were ready, causing admission calls to fail on fresh installs and upgrades.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-vcd
type: fix
summary: add werf deploy-dependency annotations to capcd webhook configurations to fix DMT lint and prevent race on install/upgrade
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
