### PR TITLE
[istio] JWKS extra root CA implementation

### DIFF
--- a/modules/110-istio/openapi/config-values.yaml
+++ b/modules/110-istio/openapi/config-values.yaml
@@ -403,7 +403,7 @@ properties:
     x-examples:
     - |
       -----BEGIN CERTIFICATE-----
-      MIIDXTCCAkWgAwIBAgIJAN...
+      ...
       -----END CERTIFICATE-----
   controlPlane:
     type: object

--- a/modules/110-istio/openapi/config-values.yaml
+++ b/modules/110-istio/openapi/config-values.yaml
@@ -396,6 +396,15 @@ properties:
       root:
         type: string
         description: The root certificate in PEM format if `cert` is an intermediate certificate.
+  jwksResolverAdditionalRootCA:
+    type: string
+    description: |
+      An additional root certificate in PEM format. It is used by istiod when resolving JWKS URIs over HTTPS.
+    x-examples:
+    - |
+      -----BEGIN CERTIFICATE-----
+      MIIDXTCCAkWgAwIBAgIJAN...
+      -----END CERTIFICATE-----
   controlPlane:
     type: object
     description: istiod specific settings.

--- a/modules/110-istio/openapi/doc-ru-config-values.yaml
+++ b/modules/110-istio/openapi/doc-ru-config-values.yaml
@@ -180,6 +180,9 @@ properties:
         description: Цепочка сертификатов в формате PEM на случай, если `cert` — промежуточный сертификат.
       root:
         description: Корневой сертификат в формате PEM на случай, если `cert` — промежуточный сертификат.
+  jwksResolverAdditionalRootCA:
+    description: |
+      Дополнительный корневой сертификат в формате PEM. Используется компонентом istiod при получении JWKS URI по HTTPS.
   controlPlane:
     description: Настройки для компонента istiod.
     properties:

--- a/modules/110-istio/openapi/openapi-case-tests.yaml
+++ b/modules/110-istio/openapi/openapi-case-tests.yaml
@@ -38,6 +38,10 @@ positive:
           envoyExtAuthzGrpc:
             service: authservice.d8-istio.svc.cluster.local
             port: 10003
+    - jwksResolverAdditionalRootCA: |
+        -----BEGIN CERTIFICATE-----
+        MIIDXTCCAkWgAwIBAgIJAN...
+        -----END CERTIFICATE-----
   values:
     - {}
 negative:

--- a/modules/110-istio/template_tests/module_test.go
+++ b/modules/110-istio/template_tests/module_test.go
@@ -136,6 +136,10 @@ const istioValues = `
         resourcesManagement: {}
 `
 
+const jwksResolverAdditionalRootCA = `-----BEGIN CERTIFICATE-----
+MIIDXTCCAkWgAwIBAgIJAN...
+-----END CERTIFICATE-----`
+
 func getSubdirs(dir string) ([]string, error) {
 	var subdirs []string
 	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
@@ -320,7 +324,6 @@ var _ = Describe("Module :: istio :: helm template :: main", func() {
 			Expect(f.KubernetesResource("Secret", "d8-istio", "d8-remote-clusters-public-metadata").Exists()).To(BeFalse())
 		})
 	})
-
 	Context("There are user extension providers", func() {
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global", globalValues)
@@ -352,6 +355,31 @@ var _ = Describe("Module :: istio :: helm template :: main", func() {
 			Expect(iopV21.Field("spec.meshConfig.extensionProviders.1.name").String()).To(Equal(`authservice-grpc`))
 			Expect(iopV21.Field("spec.meshConfig.extensionProviders.1.envoyExtAuthzGrpc.service").String()).To(Equal(`authservice.d8-istio.svc.cluster.local`))
 			Expect(iopV21.Field("spec.meshConfig.extensionProviders.1.envoyExtAuthzGrpc.port").Int()).To(Equal(int64(10003)))
+		})
+	})
+
+	Context("JWKS resolver extra root CA is configured", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", globalValues)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYaml("istio", istioValues)
+			f.ValuesSetFromYaml("istio.internal.versionsToInstall", `["1.25.2","1.21.6"]`)
+			f.ValuesSetFromYaml("istio.internal.operatorVersionsToInstall", `["1.25.2","1.21.6"]`)
+			f.ValuesSet("istio.jwksResolverAdditionalRootCA", jwksResolverAdditionalRootCA)
+			f.HelmRender()
+		})
+
+		It("passes the certificate to pilot configuration for supported Istio versions", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			istioV25 := f.KubernetesResource("Istio", "d8-istio", "v1x25x2")
+			iopV21 := f.KubernetesResource("IstioOperator", "d8-istio", "v1x21x6")
+
+			Expect(istioV25.Exists()).To(BeTrue())
+			Expect(iopV21.Exists()).To(BeTrue())
+
+			Expect(istioV25.Field("spec.values.pilot.jwksResolverExtraRootCA").String()).To(Equal(jwksResolverAdditionalRootCA))
+			Expect(iopV21.Field("spec.values.pilot.jwksResolverExtraRootCA").String()).To(Equal(jwksResolverAdditionalRootCA))
 		})
 	})
 

--- a/modules/110-istio/templates/control-plane/iop.yaml
+++ b/modules/110-istio/templates/control-plane/iop.yaml
@@ -203,6 +203,10 @@ spec:
 
     pilot:
       autoscaleEnabled: false
+  {{- with $.Values.istio.jwksResolverAdditionalRootCA }}
+      jwksResolverExtraRootCA: |-
+{{ . | indent 8 }}
+  {{- end }}
       env:
         PILOT_ENABLE_GATEWAY_API_DEPLOYMENT_CONTROLLER: false
         PILOT_ENABLE_GATEWAY_API_GATEWAYCLASS_CONTROLLER: false

--- a/modules/110-istio/templates/control-plane/istios.yaml
+++ b/modules/110-istio/templates/control-plane/istios.yaml
@@ -169,6 +169,10 @@ spec:
       cni:
         enabled: {{ eq $.Values.istio.dataPlane.trafficRedirectionSetupMode "CNIPlugin" }}
       enabled: true
+  {{- with $.Values.istio.jwksResolverAdditionalRootCA }}
+      jwksResolverExtraRootCA: |-
+{{ . | indent 8 }}
+  {{- end }}
       env:
         ISTIO_MULTIROOT_MESH: "true"
         ENABLE_ENHANCED_RESOURCE_SCOPING: "true"


### PR DESCRIPTION
## Description
Backport [PR](https://github.com/deckhouse/deckhouse/pull/20567)

Adds a module configuration option for providing an additional trusted root CA certificate for Istio JWKS resolution.

When configured, istiod uses this certificate while resolving JWKS URIs over HTTPS. The setting is supported for Istio 1.21, 1.25, and the operator-free 1.27 control plane path.

Changing this option affects Istio control plane configuration and may require istiod rollout/reconciliation for the new certificate to take effect.

## Why do we need it, and what problem does it solve?
Some environments expose JWKS endpoints with TLS certificates signed by private or custom certificate authorities. Without an additional trusted root CA, istiod cannot validate those HTTPS endpoints and may fail to fetch JWKS, which can break JWT-based authentication policies.

This change allows users to provide the required trusted CA through the Istio module configuration, enabling JWKS resolution for private PKI-backed endpoints without weakening TLS verification.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: feature
summary: JWKS extra root CA implementation
impact_level: default
```