### PR TITLE
[deckhouse-controller] 1.75 forbid create mr if embedded module enabled

### DIFF
--- a/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"time"
 
+	addonmodules "github.com/flant/addon-operator/pkg/module_manager/models/modules"
 	"github.com/iancoleman/strcase"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -173,6 +174,7 @@ type reconciler struct {
 
 type moduleManager interface {
 	AreModulesInited() bool
+	GetModule(name string) *addonmodules.BasicModule
 }
 
 func (r *reconciler) preflight(ctx context.Context) error {

--- a/deckhouse-controller/pkg/controller/module-controllers/source/controller_test.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/controller_test.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
+	addonmodules "github.com/flant/addon-operator/pkg/module_manager/models/modules"
 	"github.com/gojuno/minimock/v3"
 	crv1 "github.com/google/go-containerregistry/pkg/v1"
 	crfake "github.com/google/go-containerregistry/pkg/v1/fake"
@@ -94,6 +95,25 @@ func withDependencyContainer(dc dependency.Container) reconcilerOption {
 	}
 }
 
+// fakeModuleManager is a configurable moduleManager for tests. modulePaths maps a
+// module name to the filesystem path it is registered with in the module manager;
+// a module absent from the map is treated as not registered (GetModule returns nil).
+// With an empty map no module is registered as embedded, so isEmbeddedModule always
+// returns false and the release-ensure flow behaves as if only external sources exist.
+type fakeModuleManager struct {
+	modulePaths map[string]string
+}
+
+func (fakeModuleManager) AreModulesInited() bool { return true }
+
+func (m fakeModuleManager) GetModule(name string) *addonmodules.BasicModule {
+	path, ok := m.modulePaths[name]
+	if !ok {
+		return nil
+	}
+	return &addonmodules.BasicModule{Path: path}
+}
+
 func (suite *ControllerTestSuite) setupTestController(raw string, options ...reconcilerOption) {
 	manifests := releaseutil.SplitManifests(raw)
 
@@ -125,6 +145,7 @@ func (suite *ControllerTestSuite) setupTestController(raw string, options ...rec
 			Bundle: "Default",
 		},
 		metricStorage: metricStorage,
+		moduleManager: fakeModuleManager{},
 		deckhouseSettings: helpers.NewDeckhouseSettingsContainer(&helpers.DeckhouseSettings{
 			Update: struct {
 				Mode                   string                            `json:"mode"`
@@ -148,6 +169,46 @@ func (suite *ControllerTestSuite) setupTestController(raw string, options ...rec
 	}
 
 	suite.r = rec
+}
+
+func TestIsEmbeddedModule(t *testing.T) {
+	const downloadedModulesDir = "/deckhouse/downloaded/"
+
+	tests := []struct {
+		name        string
+		modulePaths map[string]string
+		module      string
+		want        bool
+	}{
+		{
+			name:        "embedded module registered under /deckhouse/modules",
+			modulePaths: map[string]string{"dashboard": "/deckhouse/modules/500-dashboard"},
+			module:      "dashboard",
+			want:        true,
+		},
+		{
+			name:        "downloaded module registered under downloadedModulesDir",
+			modulePaths: map[string]string{"dashboard": "/deckhouse/downloaded/modules/dashboard/v1.76.4"},
+			module:      "dashboard",
+			want:        false,
+		},
+		{
+			name:        "module not registered in the module manager",
+			modulePaths: map[string]string{},
+			module:      "dashboard",
+			want:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &reconciler{
+				downloadedModulesDir: downloadedModulesDir,
+				moduleManager:        fakeModuleManager{modulePaths: tt.modulePaths},
+			}
+			assert.Equal(t, tt.want, r.isEmbeddedModule(tt.module))
+		})
+	}
 }
 
 func (suite *ControllerTestSuite) parseKubernetesObject(raw []byte) client.Object {

--- a/deckhouse-controller/pkg/controller/module-controllers/source/helpers.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/helpers.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"log/slog"
 	"slices"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -185,6 +186,28 @@ func (r *reconciler) needToEnsureRelease(
 		return false
 	}
 
+	// Do not create/pre-stage an external release for a module whose embedded copy is
+	// still shipped with Deckhouse: the embedded copy is the source of truth while
+	// present, and an external release would activate a duplicate of the module (e.g.
+	// the d8-dashboard namespace and its ingresses), colliding with it.
+	//
+	// The module.Properties.Source guard below is not enough on its own: at the first
+	// reconcile Source can still be empty (a startup race with the embedded module
+	// loader, which only sets Source == "Embedded" while it is unset), and once an
+	// external release is staged Source gets pinned to that source, so the race is lost
+	// permanently. The module manager, in contrast, has the embedded copy registered
+	// before Source is set (preflight waits for AreModulesInited), so it is a reliable
+	// signal that does not depend on the racy CR field. After the embedded copy is
+	// dropped on a Deckhouse upgrade the module is no longer registered as embedded and
+	// the external release is staged as usual.
+	if r.isEmbeddedModule(module.Name) {
+		r.logger.Debug("module is shipped embedded, skip external release ensure",
+			slog.String("source_name", source.Name),
+			slog.String("name", module.Name))
+
+		return false
+	}
+
 	// check the active source
 	if module.Properties.Source != "" && module.Properties.Source != source.Name {
 		r.logger.Debug("source not active, skip module",
@@ -214,6 +237,23 @@ func (r *reconciler) needToEnsureRelease(
 	}
 
 	return sourceModule.Checksum != meta.Checksum || !releaseExists
+}
+
+// isEmbeddedModule reports whether a copy of the module is currently shipped embedded
+// with Deckhouse. It relies on the module manager instead of Module.Properties.Source:
+// the embedded copy is registered in the module manager before the source field is set
+// on the Module resource (preflight waits for AreModulesInited), so this signal is not
+// affected by the startup race between the source controller and the embedded module
+// loader. A module downloaded from an external source lives under downloadedModulesDir,
+// so its path prefix distinguishes it from an embedded copy (shipped under
+// /deckhouse/modules).
+func (r *reconciler) isEmbeddedModule(moduleName string) bool {
+	basicModule := r.moduleManager.GetModule(moduleName)
+	if basicModule == nil {
+		return false
+	}
+
+	return !strings.HasPrefix(basicModule.GetPath(), r.downloadedModulesDir)
 }
 
 func (r *reconciler) ensureModule(ctx context.Context, sourceName, moduleName, releaseChannel string) (*v1alpha1.Module, error) {


### PR DESCRIPTION
## Description

The module source controller could create an external `ModuleRelease` (and switch `Module.Properties.Source` to the external source) for a module that is still shipped **embedded** with Deckhouse. This activated a second, external copy of the module — e.g. it created the `d8-dashboard` namespace and its ingresses — which collided with the embedded module and, in one cluster, with a user's own vanilla Dashboard (overlapping ingress hosts stalled the queue).

The existing guard in `needToEnsureRelease` keyed off `Module.Properties.Source`, which is unreliable here:

- at the first reconcile `Source` can still be empty (a startup race with the embedded module loader, which only sets `Source == "Embedded"` while it is unset);
- once an external release is staged, `Source` gets pinned to that source, so the state sticks across restarts and the guard keeps passing.

This PR adds a guard that keys off the **module manager** instead: if a copy of the module is registered as embedded (its path is not under `downloadedModulesDir`), no external release is created and `Source` is not overwritten. The module manager is populated before `AreModulesInited()` flips true (which the source controller's preflight waits on), so the signal does not depend on the racy CR field and also covers disabled modules. After the embedded copy is dropped on a Deckhouse upgrade, the module is no longer registered as embedded and external releases are staged as usual.

Note: while the embedded copy is shipped, this intentionally forbids pre-staging/switching the module to an external source (e.g. `Embedded` → `deckhouse`). The external release is created only after the embedded copy is removed from the image on upgrade.

No impact on running components — it prevents an unintended module from being installed.

## Why do we need it, and what problem does it solve?

It stops auto-enabled external modules from unexpectedly landing on clusters and duplicating an embedded module of the same name, which created colliding resources (namespace/ingresses) and could disrupt user workloads.

## Why do we need it in the patch release (if we do)?

The bug is actively hitting clusters (an unwanted `dashboard` release was deployed and collided with a user's Dashboard). This is a minimal, targeted fix for the symptom, suitable for a patch release.

## Checklist

- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse-controller
type: fix
summary: Don't create an external module release for a module that is still shipped embedded, so it can't replace or duplicate the embedded copy.
impact_level: default
```
