### PR TITLE
[ci] Fix missing compact fail

### DIFF
--- a/.github/scripts/python/changed_images.py
+++ b/.github/scripts/python/changed_images.py
@@ -376,10 +376,10 @@ def main() -> int:
 
     missing_compact = get_missing_compact_key_images(changed)
     if missing_compact:
-        print("ERROR: failed to map changed module images to images_digests.json keys:")
+        print("WARNING: failed to map changed module images to images_digests.json keys:")
         for item in missing_compact:
             print(f"  {item['werf_image_name']}  {item['digest']}  {item['commit']}")
-        return 1
+        print("WARNING: unmapped images will be skipped by scanners that use changed_compact")
 
     changed_compact = build_changed_compact(changed)
 


### PR DESCRIPTION
## Description
if some keys doesn't match, it trigger CI to fail. Change it to Warning in console

## Why do we need it, and what problem does it solve?
Do not failure jobs on missing keys

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
-->

```changes
section: ci
type: fix 
summary: fix py script
impact: not affected users
impact_level: low
```
