### PR TITLE
[node-manager] Fix static node bootstrap hang caused by empty cluster UUID

### DIFF
--- a/dhctl/pkg/kubernetes/actions/deckhouse/install.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/install.go
@@ -661,41 +661,39 @@ func CreateDeckhouseManifests(
 		tasks = append(tasks, *lockCmTask)
 	}
 
+	// The deckhouse controller Deployment is kept out of the prerequisite task
+	// list and applied only after all of them exist. The pod and its hooks read
+	// those resources on startup (registry pull secret, RBAC/ServiceAccount,
+	// cluster-configuration secrets, d8-cluster-uuid, ...); racing the Deployment
+	// against them can yield a pod that cannot pull images, or hooks that observe
+	// half-initialized state — e.g. an empty global.discovery.clusterUUID, which
+	// makes node-manager render node bootstrap scripts without the cluster-UUID
+	// prefix for registry-packages-proxy and hangs CAPS-adopted nodes ~20m.
 	deploymentTask, err := controllerDeploymentTask(kubeCl, cfg)
 	if err != nil {
 		return nil, err
 	}
-	tasks = append(tasks, deploymentTask)
 
 	result := &ManifestsResult{}
 
+	// ModuleConfigs are applied last: their CRD is installed by the running
+	// deckhouse pod, so these retry-wait for it to appear.
+	var moduleConfigTasks []actions.ManifestTask
 	if len(cfg.ModuleConfigs) > 0 {
 		prepareModuleConfig(ctx, cfg.ModuleConfigs[0], result)
-		tasks = append(tasks, createModuleConfigManifestTask(kubeCl, cfg.ModuleConfigs[0], "Waiting for creating ModuleConfig CRD..."))
+		moduleConfigTasks = append(moduleConfigTasks, createModuleConfigManifestTask(kubeCl, cfg.ModuleConfigs[0], "Waiting for creating ModuleConfig CRD..."))
 
 		for i := 1; i < len(cfg.ModuleConfigs); i++ {
 			prepareModuleConfig(ctx, cfg.ModuleConfigs[i], result)
-			tasks = append(tasks, createModuleConfigManifestTask(kubeCl, cfg.ModuleConfigs[i], ""))
+			moduleConfigTasks = append(moduleConfigTasks, createModuleConfigManifestTask(kubeCl, cfg.ModuleConfigs[i], ""))
 		}
 	}
 
 	err = dhlog.RunProcess(ctx, dhlog.FromContext(ctx), "Create Manifests", func(ctx context.Context) error {
-		if len(tasks) == 0 {
-			return nil
-		}
-
-		// The first task is the d8-system Namespace; everything else (RBAC,
-		// SAs, ConfigMaps, ModuleConfigs, the controller Deployment, etc.) is
-		// either cluster-scoped or namespace-scoped to d8-system. Run the
-		// Namespace serially first, then fan out the remaining tasks through
-		// errgroup. Tasks use Get-then-Create or simple Create-or-Update flows
-		// and target distinct API resources, so they are independent.
-		// Retry interval was 5s, which dominates the create-manifests phase
-		// whenever a task hits a transient error (e.g. ModuleConfig CRD not yet
-		// installed by the deckhouse Deployment that is being applied in
-		// parallel). The total deadline stays the same (60 attempts × 1s = 60s
-		// per task) but the loop reacts to the CRD appearing in ~1s instead of
-		// dead-waiting 5s.
+		// Tasks use Get-then-Create or simple Create-or-Update flows and target
+		// distinct API resources. Retry interval is 1s (was 5s): the loop reacts to
+		// a transient error clearing (e.g. the ModuleConfig CRD appearing) in ~1s
+		// instead of dead-waiting; the total deadline stays 600 attempts × 1s.
 		runTask := func(task actions.ManifestTask) error {
 			return retry.NewSilentLoop(task.Name, 600, 1*time.Second).RunContext(
 				ctx,
@@ -705,39 +703,57 @@ func CreateDeckhouseManifests(
 			)
 		}
 
-		if err := runTask(tasks[0]); err != nil {
+		// runParallel applies independent tasks concurrently, capping the number of
+		// parallel writes so we don't hammer the freshly bootstrapped apiserver.
+		runParallel := func(parallelTasks []actions.ManifestTask) error {
+			const maxParallel = 8
+			eg, egCtx := errgroup.WithContext(ctx)
+			eg.SetLimit(maxParallel)
+
+			var logMu sync.Mutex
+			for i := range parallelTasks {
+				task := parallelTasks[i]
+				eg.Go(func() error {
+					if egCtx.Err() != nil {
+						return egCtx.Err()
+					}
+					if err := runTask(task); err != nil {
+						logMu.Lock()
+						dhlog.FromContext(ctx).ErrorContext(ctx, fmt.Sprintf("manifest task %q failed: %v", task.Name, err))
+						logMu.Unlock()
+						return err
+					}
+					return nil
+				})
+			}
+
+			return eg.Wait()
+		}
+
+		if len(tasks) > 0 {
+			// The d8-system Namespace comes first; everything else lives in it or
+			// references it.
+			if err := runTask(tasks[0]); err != nil {
+				return err
+			}
+
+			// All deckhouse prerequisites (RBAC, ServiceAccount, registry pull
+			// secret, cluster-configuration secrets, d8-cluster-uuid, queue lock,
+			// ...) are independent of each other and applied concurrently — but
+			// before the controller Deployment below, which reads them on startup.
+			if err := runParallel(tasks[1:]); err != nil {
+				return err
+			}
+		}
+
+		// The controller Deployment, once all its prerequisites exist.
+		if err := runTask(deploymentTask); err != nil {
 			return err
 		}
 
-		rest := tasks[1:]
-		if len(rest) == 0 {
-			return nil
-		}
-
-		// Cap concurrency to avoid hammering the freshly-bootstrapped
-		// apiserver with too many parallel writes.
-		const maxParallel = 8
-		eg, egCtx := errgroup.WithContext(ctx)
-		eg.SetLimit(maxParallel)
-
-		var logMu sync.Mutex
-		for i := range rest {
-			task := rest[i]
-			eg.Go(func() error {
-				if egCtx.Err() != nil {
-					return egCtx.Err()
-				}
-				if err := runTask(task); err != nil {
-					logMu.Lock()
-					dhlog.FromContext(ctx).ErrorContext(ctx, fmt.Sprintf("manifest task %q failed: %v", task.Name, err))
-					logMu.Unlock()
-					return err
-				}
-				return nil
-			})
-		}
-
-		return eg.Wait()
+		// ModuleConfigs last: their CRD is installed by the now-running deckhouse
+		// pod, so these retry-wait for it to appear.
+		return runParallel(moduleConfigTasks)
 	})
 	if err != nil {
 		return nil, err

--- a/dhctl/pkg/kubernetes/actions/deckhouse/install_test.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/install_test.go
@@ -517,3 +517,38 @@ func TestDeckhouseInstallWithModuleConfigsReturnsResults(t *testing.T) {
 		})
 	})
 }
+
+// When a cluster UUID is provided, the d8-cluster-uuid ConfigMap must be
+// created. It is applied serially, ahead of the parallel manifest fan-out (so it
+// lands before the deckhouse Deployment): node-manager renders the node bootstrap
+// script from global.discovery.clusterUUID, and an empty UUID makes CAPS-adopted
+// nodes stall the whole StaticInstanceBootstrapTimeout (~20m) on a 404 from
+// registry-packages-proxy. This guards against the extraction regressing that task.
+func TestDeckhouseInstallCreatesClusterUUIDConfigMap(t *testing.T) {
+	ctx := context.Background()
+	require.NoError(t, os.Setenv("DHCTL_TEST", "yes"))
+	require.NoError(t, os.Setenv("DHCTL_TEST_VERSION_TAG", "1.54.1"))
+	defer func() {
+		os.Unsetenv("DHCTL_TEST")
+		os.Unsetenv("DHCTL_TEST_VERSION_TAG")
+	}()
+
+	fakeClient := client.NewFakeKubernetesClient()
+
+	const clusterUUID = "3c179956-30ee-4b90-bc14-71a7bc73ab6d"
+
+	_, err := CreateDeckhouseManifests(ctx, fakeClient, &config.DeckhouseInstaller{
+		UUID: clusterUUID,
+		Registry: registry_mocks.ConfigBuilder(
+			registry_mocks.WithModeUnmanaged(),
+			registry_mocks.WithLegacyMode(),
+		),
+	}, func() error {
+		return nil
+	})
+	require.NoError(t, err)
+
+	cm, err := fakeClient.CoreV1().ConfigMaps("kube-system").Get(ctx, "d8-cluster-uuid", metav1.GetOptions{})
+	require.NoError(t, err, "d8-cluster-uuid ConfigMap must be created when UUID is set")
+	require.Equal(t, clusterUUID, cm.Data["cluster-uuid"])
+}

--- a/modules/040-node-manager/templates/node-group/_bootstrap.tpl
+++ b/modules/040-node-manager/templates/node-group/_bootstrap.tpl
@@ -29,7 +29,7 @@
   {{- $_ := set $tpl_context "clusterMasterKubeAPIEndpoints" $clusterMasterKubeAPIEndpoints }}
   {{- $_ := set $tpl_context "clusterMasterRPPAddresses" $clusterMasterRPPAddresses }}
   {{- $_ := set $tpl_context "clusterMasterRPPBootstrapAddresses" $clusterMasterRPPBootstrapAddresses }}
-  {{- $_ := set $tpl_context "clusterUUID" ($context.Values.global.discovery.clusterUUID | default "") }}
+  {{- $_ := set $tpl_context "clusterUUID" ($context.Values.global.discovery.clusterUUID | required "global.discovery.clusterUUID is required to render the node bootstrap script: an empty UUID makes rpp-get query registry-packages-proxy at the prefix-less \"/rpp-get\" path, which the proxy rejects with 404, so the node stalls the whole StaticInstanceBootstrapTimeout (~20m) before CAPS retries") }}
   {{- $_ := set $tpl_context "images" $context.Values.global.modulesImages.digests }}
   {{- $packagesProxy := $context.Values.nodeManager.internal.packagesProxy | default (dict) }}
   {{- $_ := set $tpl_context "packagesProxy" $packagesProxy }}


### PR DESCRIPTION
## Description

Fixes a race that makes Static / CAPS-adopted nodes hang ~20 minutes during bootstrap.

On a fresh cluster, `node-manager` could render the node bootstrap bundle with an empty `global.discovery.clusterUUID`. With an empty UUID, the on-node `rpp-get` installer queries `registry-packages-proxy` at the prefix-less `/rpp-get` path; the proxy expects `/<clusterUUID>/rpp-get` and answers `404`, so bashible never installs `rpp-get` and the **first** bootstrap attempt stalls until `StaticInstanceBootstrapTimeout` (~20m) fires → the StaticInstance goes to `Cleaning` → a replacement Machine retries (by then the UUID is populated, so it succeeds). Net effect: ~20 wasted minutes per affected node, intermittently.

No restarts of critical components. The dhctl change affects the bootstrap `Create Manifests` flow only.

## Why do we need it, and what problem does it solve?

Root cause is a startup ordering race in `dhctl`. During `Create Manifests`, every install manifest **except** the `d8-system` Namespace was applied in a single parallel fan-out — so the `deckhouse` Deployment could be created **before its own prerequisites**: the registry pull secret, RBAC/ServiceAccount, the cluster-configuration secrets, and the `d8-cluster-uuid` ConfigMap. The `cluster_uuid` global hook only sets `global.discovery.clusterUUID` after it observes that ConfigMap, so in the window before it existed, `_bootstrap.tpl` rendered the bundle with `clusterUUID | default ""` — a broken bundle that the on-node `rpp-get` / `registry-packages-proxy` path rejects.

Fixes:
- **dhctl** — split the manifest tasks into ordered phases instead of one fan-out: `Namespace` → **all prerequisites** (RBAC, ServiceAccount, registry pull secret, cluster-configuration secrets, `d8-cluster-uuid`, queue lock, ...) applied concurrently → **deckhouse Deployment** → **ModuleConfigs**. The controller pod now always starts with its prerequisites in place (this also removes the latent races for the pull secret, RBAC and cluster-config secrets, not just the UUID).
- **node-manager** — `required` the cluster UUID in `_bootstrap.tpl` instead of `default ""`, so a bootstrap bundle is never emitted with an empty UUID (fail-fast; node-manager re-renders once discovery completes).

The two changes are complementary: dhctl removes the race at the source, the template guard prevents shipping a broken bundle for any other reason the UUID could be empty.

## Why do we need it in the patch release (if we do)?

Worth backporting — it removes an intermittent ~20-minute stall (and the associated `Cleaning`/retry churn) from every static/hybrid cluster bootstrap and static-node adoption.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

<!--
Manual verification (multi-node Static cluster: 1 master + 3 CAPS worker StaticInstances):
- Before the fix: worker bundles carried an empty PACKAGES_PROXY_BOOTSTRAP_CLUSTER_UUID, rpp-get got 404 from registry-packages-proxy ("unexpected path /rpp-get, expected /<uuid>/rpp-get"), all three workers stalled ~20m in Bootstrapping -> Cleaning -> retry.
- After the dhctl fix: d8-cluster-uuid ConfigMap (and the other prerequisites) are created before the deckhouse Deployment, worker bundles carry a non-empty UUID, rpp-get installs, and all three workers reach Running on the first attempt with zero Cleaning cycles.
- node-manager template change verified with `helm template`: empty clusterUUID now fails the render with the `required` message; a set value renders as before. Unit test added on the dhctl side (asserts the d8-cluster-uuid ConfigMap is created).
-->

## Changelog entries

```changes
section: dhctl
type: fix
summary: Apply all deckhouse prerequisites (registry pull secret, RBAC, cluster-configuration secrets, d8-cluster-uuid, ...) before the deckhouse Deployment during bootstrap, so the controller never starts ahead of resources it and its hooks read.
```
```changes
section: node-manager
type: fix
summary: Require a non-empty cluster UUID when rendering the node bootstrap script, preventing static nodes from stalling ~20m on a registry-packages-proxy 404.
```
