### PR TITLE
[istio] Fix supported versions table

### DIFF
--- a/modules/110-istio/docs/README.md
+++ b/modules/110-istio/docs/README.md
@@ -11,7 +11,7 @@ The table below shows Istio versions and their support status in Deckhouse Kuber
 
 | Istio version | [Kubernetes versions supported by Istio](https://istio.io/latest/docs/releases/supported-releases/#support-status-of-istio-releases) |          Status in DKP          |
 |:-------------:|:-----------------------------------------------------------------------------------------------------------------------------:|:------------------------------:|
-|     1.27      |                                                1.29, 1.30, 1.31, 1.32, 1.34, 1.35, 1.36                                                | Supported |
+|     1.27      |                                                1.29, 1.30, 1.31, 1.32, 1.33, 1.34, 1.35, 1.36                                                | Supported |
 |     1.25      |                                                1.29, 1.30, 1.31, 1.32, 1.33, 1.34, 1.35, 1.36                                          | Supported |
 |     1.21      |                                                1.26, 1.27, 1.28, 1.29, 1.30, 1.31, 1.32, 1.33, 1.34, 1.35, 1.36                        | Deprecated and will be deleted |
 


### PR DESCRIPTION
## Description

Fix the supported Kubernetes versions table in the Istio module documentation: Istio 1.27 was missing 1.33 from its list of supported Kubernetes versions, while the adjacent Istio 1.25 row already included it.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: fix
summary: Fix supported Kubernetes versions table for Istio 1.27 (add missing 1.33 entry).
impact_level: low
```