### PR TITLE
[istio][api-proxy] Allowed request via ALB

### DIFF
--- a/ee/modules/110-istio/images/api-proxy/src/main.go
+++ b/ee/modules/110-istio/images/api-proxy/src/main.go
@@ -51,8 +51,9 @@ func httpHandlerAPIProxy(p *Proxy) http.HandlerFunc {
 			return
 		}
 
-		if r.TLS.PeerCertificates[0].Subject.Organization[0] != "ingress-nginx:auth" {
-			errstring := "[api-proxy] Only requests from ingress are allowed."
+		org := r.TLS.PeerCertificates[0].Subject.Organization[0]
+		if org != "ingress-nginx:auth" && org != "alb:auth" {
+			errstring := "[api-proxy] Only requests from ingress or alb are allowed."
 			http.Error(w, errstring, http.StatusUnauthorized)
 			logger.Println(r.RemoteAddr, r.Method, r.UserAgent(), r.URL.Path, http.StatusUnauthorized, errstring)
 			return


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Fixed the `api-proxy` TLS client certificate check to accept requests from both nginx-ingress and ALB Gateway (HTTPRoute).

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

When traffic reaches `api-proxy` through an HTTPRoute (ALB), the gateway presents a client certificate with Organization `alb:auth`. The `api-proxy` was rejecting these requests with `401 Unauthorized: "Only requests from ingress are allowed"`, because it only accepted `ingress-nginx:auth`.

This prevented access to the Istio multicluster API proxy when routing through HTTPRoute instead of classic Ingress. Other Deckhouse modules already handle both auth groups (`ingress-nginx:auth` and `alb:auth`) in their RBAC rules, this fix aligns the api-proxy with that pattern.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: fix
summary: Fixed access to api-proxy via ALB.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
