### PR TITLE
[descheduler] add new drs lens rules

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -6105,6 +6105,7 @@ modules-having-alerts:
     - cni-cilium
     - control-plane-manager
     - deckhouse
+    - descheduler
     - documentation
     - istio
     - kube-dns

--- a/modules/400-descheduler/monitoring/grafana-dashboards/descheduler/drs-lens.json
+++ b/modules/400-descheduler/monitoring/grafana-dashboards/descheduler/drs-lens.json
@@ -97,7 +97,7 @@
         },
         "enable": false,
         "iconColor": "blue",
-        "expr": "sum(increase(descheduler_loop_duration_seconds_count{job=\"descheduler\"}[1m])) > 0",
+        "expr": "sum(increase(descheduler_loop_duration_seconds_count{job=\"descheduler\"}[$__rate_interval])) > 0",
         "titleFormat": "descheduler cycle"
       }
     ]
@@ -133,7 +133,7 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "count(descheduler:workload_happiness_bucket{bucket=\"happy\", namespace=~\"$namespace\"})",
+          "expr": "count(descheduler:workload_happiness_bucket{bucket=\"happy\", namespace=~\"$namespace\"}) or vector(0)",
           "instant": true
         }
       ],
@@ -177,7 +177,7 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "count(descheduler:workload_happiness_bucket{bucket=\"warning\", namespace=~\"$namespace\"})",
+          "expr": "count(descheduler:workload_happiness_bucket{bucket=\"warning\", namespace=~\"$namespace\"}) or vector(0)",
           "instant": true
         }
       ],
@@ -221,7 +221,7 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "count(descheduler:workload_happiness_bucket{bucket=\"unhappy\", namespace=~\"$namespace\"})",
+          "expr": "count(descheduler:workload_happiness_bucket{bucket=\"unhappy\", namespace=~\"$namespace\"}) or vector(0)",
           "instant": true
         }
       ],
@@ -565,17 +565,17 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "count(descheduler:workload_happiness_bucket{bucket=\"happy\", namespace=~\"$namespace\"})",
+          "expr": "count(descheduler:workload_happiness_bucket{bucket=\"happy\", namespace=~\"$namespace\"}) or vector(0)",
           "legendFormat": "happy"
         },
         {
           "refId": "B",
-          "expr": "count(descheduler:workload_happiness_bucket{bucket=\"warning\", namespace=~\"$namespace\"})",
+          "expr": "count(descheduler:workload_happiness_bucket{bucket=\"warning\", namespace=~\"$namespace\"}) or vector(0)",
           "legendFormat": "warning"
         },
         {
           "refId": "C",
-          "expr": "count(descheduler:workload_happiness_bucket{bucket=\"unhappy\", namespace=~\"$namespace\"})",
+          "expr": "count(descheduler:workload_happiness_bucket{bucket=\"unhappy\", namespace=~\"$namespace\"}) or vector(0)",
           "legendFormat": "unhappy"
         }
       ],
@@ -707,6 +707,24 @@
           "expr": "max by (namespace, workload_kind, workload_name) (descheduler:workload_eviction_penalty{namespace=~\"$namespace\"})",
           "format": "table",
           "instant": true
+        },
+        {
+          "refId": "K",
+          "expr": "max by (namespace, workload_kind, workload_name) (descheduler:workload_cpu_usage_ratio{namespace=~\"$namespace\"})",
+          "format": "table",
+          "instant": true
+        },
+        {
+          "refId": "L",
+          "expr": "max by (namespace, workload_kind, workload_name) (descheduler:workload_memory_request_usage_ratio{namespace=~\"$namespace\"})",
+          "format": "table",
+          "instant": true
+        },
+        {
+          "refId": "M",
+          "expr": "max by (namespace, workload_kind, workload_name) (descheduler:workload_memory_limit_usage_ratio{namespace=~\"$namespace\"})",
+          "format": "table",
+          "instant": true
         }
       ],
       "transformations": [
@@ -730,7 +748,10 @@
               "Value #G": "cpu",
               "Value #H": "memory",
               "Value #I": "node",
-              "Value #J": "eviction"
+              "Value #J": "eviction",
+              "Value #K": "cpu ratio",
+              "Value #L": "mem req ratio",
+              "Value #M": "mem lim ratio"
             }
           }
         }
@@ -771,6 +792,42 @@
                     }
                   ]
                 }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "cpu ratio"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percentunit"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "mem req ratio"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percentunit"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "mem lim ratio"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percentunit"
               }
             ]
           }

--- a/modules/400-descheduler/monitoring/grafana-dashboards/descheduler/drs-lens.json
+++ b/modules/400-descheduler/monitoring/grafana-dashboards/descheduler/drs-lens.json
@@ -1,0 +1,1696 @@
+{
+  "title": "Descheduler / DRS-Lens",
+  "uid": "descheduler-drs-lens",
+  "schemaVersion": 39,
+  "editable": false,
+  "graphTooltip": 1,
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "ds_prometheus",
+        "type": "datasource",
+        "query": "prometheus",
+        "label": "Prometheus",
+        "current": {}
+      },
+      {
+        "name": "profile",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$ds_prometheus"
+        },
+        "query": {
+          "query": "label_values(descheduler_pod_evictions_total{job=\"descheduler\"}, profile)",
+          "refId": "var-profile"
+        },
+        "refresh": 2,
+        "multi": true,
+        "includeAll": true,
+        "allValue": ".*",
+        "current": {}
+      },
+      {
+        "name": "strategy",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$ds_prometheus"
+        },
+        "query": {
+          "query": "label_values(descheduler_pod_evictions_total{job=\"descheduler\"}, strategy)",
+          "refId": "var-strategy"
+        },
+        "refresh": 2,
+        "multi": true,
+        "includeAll": true,
+        "allValue": ".*",
+        "current": {}
+      },
+      {
+        "name": "namespace",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$ds_prometheus"
+        },
+        "query": {
+          "query": "label_values(descheduler:workload_happiness_score, namespace)",
+          "refId": "var-namespace"
+        },
+        "refresh": 2,
+        "multi": true,
+        "includeAll": true,
+        "allValue": ".*",
+        "current": {}
+      },
+      {
+        "name": "node",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$ds_prometheus"
+        },
+        "query": {
+          "query": "label_values(kube_pod_info, node)",
+          "refId": "var-node"
+        },
+        "refresh": 2,
+        "multi": true,
+        "includeAll": true,
+        "allValue": ".*",
+        "current": {}
+      }
+    ]
+  },
+  "annotations": {
+    "list": [
+      {
+        "name": "Descheduler cycle",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$ds_prometheus"
+        },
+        "enable": false,
+        "iconColor": "blue",
+        "expr": "sum(increase(descheduler_loop_duration_seconds_count{job=\"descheduler\"}[1m])) > 0",
+        "titleFormat": "descheduler cycle"
+      },
+      {
+        "name": "Eviction success",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$ds_prometheus"
+        },
+        "enable": true,
+        "iconColor": "green",
+        "expr": "sum(increase(descheduler_pod_evictions_total{job=\"descheduler\", result=\"success\"}[1m])) > 0",
+        "titleFormat": "eviction success"
+      },
+      {
+        "name": "Eviction error",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$ds_prometheus"
+        },
+        "enable": true,
+        "iconColor": "red",
+        "expr": "sum(increase(descheduler_pod_evictions_total{job=\"descheduler\", result=\"error\"}[1m])) > 0",
+        "titleFormat": "eviction error"
+      },
+      {
+        "name": "Eviction blocked",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$ds_prometheus"
+        },
+        "enable": true,
+        "iconColor": "orange",
+        "expr": "sum(increase(descheduler_pod_evictions_total{job=\"descheduler\", result=\"blocked\"}[1m])) > 0",
+        "titleFormat": "eviction blocked"
+      },
+      {
+        "name": "OOM burst",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$ds_prometheus"
+        },
+        "enable": false,
+        "iconColor": "purple",
+        "expr": "sum(increase(klog_pod_oomkill[5m])) > 3",
+        "titleFormat": "OOM burst"
+      },
+      {
+        "name": "Unhappy spike",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$ds_prometheus"
+        },
+        "enable": false,
+        "iconColor": "yellow",
+        "expr": "delta(count(descheduler:workload_happiness_bucket{bucket=\"unhappy\"})[10m:]) > 5",
+        "titleFormat": "unhappy spike"
+      },
+      {
+        "name": "Imbalance jump",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$ds_prometheus"
+        },
+        "enable": false,
+        "iconColor": "yellow",
+        "expr": "abs(delta(descheduler:cluster_imbalance_score{resource=\"cpu\"}[10m:])) > 0.2",
+        "titleFormat": "imbalance jump"
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 100,
+      "type": "row",
+      "title": "Summary",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "panels": []
+    },
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Happy workloads",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 1
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "count(descheduler:workload_happiness_bucket{bucket=\"happy\", namespace=~\"$namespace\"})",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      }
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Warning workloads",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 1
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "count(descheduler:workload_happiness_bucket{bucket=\"warning\", namespace=~\"$namespace\"})",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "yellow",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      }
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Unhappy workloads",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 1
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "count(descheduler:workload_happiness_bucket{bucket=\"unhappy\", namespace=~\"$namespace\"})",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      }
+    },
+    {
+      "id": 4,
+      "type": "gauge",
+      "title": "Avg happiness score",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 1
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "avg(descheduler:workload_happiness_score{namespace=~\"$namespace\"})",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 60
+              },
+              {
+                "color": "green",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      }
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "Evictions (range)",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 1
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(increase(descheduler_pod_evictions_total{job=\"descheduler\", profile=~\"$profile\", strategy=~\"$strategy\"}[$__range]))",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      }
+    },
+    {
+      "id": 6,
+      "type": "stat",
+      "title": "Failed/blocked evictions",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 1
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(increase(descheduler_pod_evictions_total{job=\"descheduler\", result=~\"error|blocked\", profile=~\"$profile\", strategy=~\"$strategy\"}[$__range]))",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      }
+    },
+    {
+      "id": 7,
+      "type": "stat",
+      "title": "Imbalance CPU",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 5
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "descheduler:cluster_imbalance_score{resource=\"cpu\"}",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      }
+    },
+    {
+      "id": 8,
+      "type": "stat",
+      "title": "Imbalance Memory",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 5
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "descheduler:cluster_imbalance_score{resource=\"memory\"}",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      }
+    },
+    {
+      "id": 9,
+      "type": "stat",
+      "title": "Imbalance Pods",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 5
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "descheduler:cluster_imbalance_score{resource=\"pods\"}",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      }
+    },
+    {
+      "id": 10,
+      "type": "stat",
+      "title": "Last cycle duration (avg)",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 5
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "rate(descheduler_loop_duration_seconds_sum{job=\"descheduler\"}[$__rate_interval]) / rate(descheduler_loop_duration_seconds_count{job=\"descheduler\"}[$__rate_interval])",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      }
+    },
+    {
+      "id": 11,
+      "type": "stat",
+      "title": "Descheduler version",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 5
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "descheduler_build_info{job=\"descheduler\"}",
+          "instant": true,
+          "legendFormat": "{{version}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "textMode": "name"
+      }
+    },
+    {
+      "id": 12,
+      "type": "bargauge",
+      "title": "Top-10 unhappy workloads",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "bottomk(10, descheduler:workload_happiness_score{namespace=~\"$namespace\"})",
+          "instant": true,
+          "legendFormat": "{{namespace}}/{{workload_kind}}/{{workload_name}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 60
+              },
+              {
+                "color": "green",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "displayMode": "gradient",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      }
+    },
+    {
+      "id": 13,
+      "type": "bargauge",
+      "title": "Top namespaces by unhappy",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "topk(10, count by (namespace)(descheduler:workload_happiness_bucket{bucket=\"unhappy\", namespace=~\"$namespace\"}))",
+          "instant": true,
+          "legendFormat": "{{namespace}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "displayMode": "gradient",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      }
+    },
+    {
+      "id": 101,
+      "type": "row",
+      "title": "Workloads Happiness",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "panels": []
+    },
+    {
+      "id": 20,
+      "type": "timeseries",
+      "title": "Workloads by bucket",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 18
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "count(descheduler:workload_happiness_bucket{bucket=\"happy\", namespace=~\"$namespace\"})",
+          "legendFormat": "happy"
+        },
+        {
+          "refId": "B",
+          "expr": "count(descheduler:workload_happiness_bucket{bucket=\"warning\", namespace=~\"$namespace\"})",
+          "legendFormat": "warning"
+        },
+        {
+          "refId": "C",
+          "expr": "count(descheduler:workload_happiness_bucket{bucket=\"unhappy\", namespace=~\"$namespace\"})",
+          "legendFormat": "unhappy"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "bars",
+            "stacking": {
+              "mode": "normal"
+            },
+            "fillOpacity": 80
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 21,
+      "type": "timeseries",
+      "title": "Avg score by namespace",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 18
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "avg by (namespace)(descheduler:workload_happiness_score{namespace=~\"$namespace\"})",
+          "legendFormat": "{{namespace}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 22,
+      "type": "table",
+      "title": "Workloads",
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "max by (namespace, workload_kind, workload_name) (descheduler:workload_happiness_score{namespace=~\"$namespace\"})",
+          "format": "table",
+          "instant": true
+        },
+        {
+          "refId": "B",
+          "expr": "max by (namespace, workload_kind, workload_name) (descheduler:workload_replicas{namespace=~\"$namespace\"})",
+          "format": "table",
+          "instant": true
+        },
+        {
+          "refId": "C",
+          "expr": "max by (namespace, workload_kind, workload_name) (descheduler:workload_phase_penalty{namespace=~\"$namespace\"})",
+          "format": "table",
+          "instant": true
+        },
+        {
+          "refId": "D",
+          "expr": "max by (namespace, workload_kind, workload_name) (descheduler:workload_readiness_penalty{namespace=~\"$namespace\"})",
+          "format": "table",
+          "instant": true
+        },
+        {
+          "refId": "E",
+          "expr": "max by (namespace, workload_kind, workload_name) (descheduler:workload_restart_penalty{namespace=~\"$namespace\"})",
+          "format": "table",
+          "instant": true
+        },
+        {
+          "refId": "F",
+          "expr": "max by (namespace, workload_kind, workload_name) (descheduler:workload_oom_penalty{namespace=~\"$namespace\"})",
+          "format": "table",
+          "instant": true
+        },
+        {
+          "refId": "G",
+          "expr": "max by (namespace, workload_kind, workload_name) (descheduler:workload_cpu_penalty{namespace=~\"$namespace\"})",
+          "format": "table",
+          "instant": true
+        },
+        {
+          "refId": "H",
+          "expr": "max by (namespace, workload_kind, workload_name) (descheduler:workload_memory_penalty{namespace=~\"$namespace\"})",
+          "format": "table",
+          "instant": true
+        },
+        {
+          "refId": "I",
+          "expr": "max by (namespace, workload_kind, workload_name) (descheduler:workload_node_penalty{namespace=~\"$namespace\"})",
+          "format": "table",
+          "instant": true
+        },
+        {
+          "refId": "J",
+          "expr": "max by (namespace, workload_kind, workload_name) (descheduler:workload_eviction_penalty{namespace=~\"$namespace\"})",
+          "format": "table",
+          "instant": true
+        }
+      ],
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "renameByName": {
+              "Value #A": "score",
+              "Value #B": "replicas",
+              "Value #C": "phase",
+              "Value #D": "readiness",
+              "Value #E": "restarts",
+              "Value #F": "oom",
+              "Value #G": "cpu",
+              "Value #H": "memory",
+              "Value #I": "node",
+              "Value #J": "eviction"
+            }
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "score"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 60
+                    },
+                    {
+                      "color": "green",
+                      "value": 80
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "sortBy": [
+          {
+            "displayName": "score",
+            "desc": false
+          }
+        ]
+      }
+    },
+    {
+      "id": 102,
+      "type": "row",
+      "title": "Cluster Balance",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 38
+      },
+      "panels": []
+    },
+    {
+      "id": 30,
+      "type": "timeseries",
+      "title": "Imbalance (max-min)",
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 39
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "descheduler:cluster_imbalance_score{resource=\"cpu\"}",
+          "legendFormat": "{{resource}}"
+        },
+        {
+          "refId": "B",
+          "expr": "descheduler:cluster_imbalance_score{resource=\"memory\"}",
+          "legendFormat": "{{resource}}"
+        },
+        {
+          "refId": "C",
+          "expr": "descheduler:cluster_imbalance_score{resource=\"pods\"}",
+          "legendFormat": "{{resource}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 31,
+      "type": "timeseries",
+      "title": "Imbalance (stddev)",
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 39
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "descheduler:cluster_imbalance_stddev{resource=\"cpu\"}",
+          "legendFormat": "{{resource}}"
+        },
+        {
+          "refId": "B",
+          "expr": "descheduler:cluster_imbalance_stddev{resource=\"memory\"}",
+          "legendFormat": "{{resource}}"
+        },
+        {
+          "refId": "C",
+          "expr": "descheduler:cluster_imbalance_stddev{resource=\"pods\"}",
+          "legendFormat": "{{resource}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 32,
+      "type": "heatmap",
+      "title": "Node CPU usage",
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 39
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "descheduler:node_cpu_usage_ratio{node=~\"$node\"}",
+          "legendFormat": "{{node}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "options": {
+        "calculate": false
+      }
+    },
+    {
+      "id": 34,
+      "type": "heatmap",
+      "title": "Node Memory usage",
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 39
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "descheduler:node_memory_usage_ratio{node=~\"$node\"}",
+          "legendFormat": "{{node}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "options": {
+        "calculate": false
+      }
+    },
+    {
+      "id": 33,
+      "type": "table",
+      "title": "Nodes",
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 47
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "max by (node) (descheduler:node_cpu_usage_ratio{node=~\"$node\"})",
+          "format": "table",
+          "instant": true
+        },
+        {
+          "refId": "B",
+          "expr": "max by (node) (descheduler:node_cpu_request_ratio{node=~\"$node\"})",
+          "format": "table",
+          "instant": true
+        },
+        {
+          "refId": "C",
+          "expr": "max by (node) (descheduler:node_memory_usage_ratio{node=~\"$node\"})",
+          "format": "table",
+          "instant": true
+        },
+        {
+          "refId": "D",
+          "expr": "max by (node) (descheduler:node_memory_request_ratio{node=~\"$node\"})",
+          "format": "table",
+          "instant": true
+        },
+        {
+          "refId": "E",
+          "expr": "max by (node) (descheduler:node_pod_allocation_ratio{node=~\"$node\"})",
+          "format": "table",
+          "instant": true
+        },
+        {
+          "refId": "F",
+          "expr": "count by (node)(max by (namespace, workload_kind, workload_name, node)(descheduler:pod_workload{node=~\"$node\"}) and on (namespace, workload_kind, workload_name) descheduler:workload_happiness_bucket{bucket=\"unhappy\"})",
+          "format": "table",
+          "instant": true
+        },
+        {
+          "refId": "G",
+          "expr": "sum by (node)(increase(descheduler_pod_evictions_total{job=\"descheduler\", node=~\"$node\"}[$__range]))",
+          "format": "table",
+          "instant": true
+        },
+        {
+          "refId": "H",
+          "expr": "sum by (node)(increase(descheduler_pod_evictions_total{job=\"descheduler\", node=~\"$node\", result=~\"error|blocked\"}[$__range]))",
+          "format": "table",
+          "instant": true
+        },
+        {
+          "refId": "I",
+          "expr": "count by (node) (kube_node_status_condition{job=\"kube-state-metrics\", condition=~\"MemoryPressure|DiskPressure|PIDPressure\", status=\"true\"} == 1)",
+          "format": "table",
+          "instant": true
+        }
+      ],
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "renameByName": {
+              "Value #A": "cpu use",
+              "Value #B": "cpu req",
+              "Value #C": "mem use",
+              "Value #D": "mem req",
+              "Value #E": "pods",
+              "Value #F": "unhappy wl",
+              "Value #G": "evictions",
+              "Value #H": "failed",
+              "Value #I": "pressure conds"
+            }
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "unhappy wl"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "short"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "evictions"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "short"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "failed"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "short"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "pressure conds"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "short"
+              }
+            ]
+          }
+        ]
+      },
+      "options": {}
+    },
+    {
+      "id": 103,
+      "type": "row",
+      "title": "Descheduler Actions",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 59
+      },
+      "panels": []
+    },
+    {
+      "id": 40,
+      "type": "timeseries",
+      "title": "Evictions by result",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 60
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (result)(increase(descheduler_pod_evictions_total{job=\"descheduler\", profile=~\"$profile\", strategy=~\"$strategy\"}[$__rate_interval]))",
+          "legendFormat": "{{result}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "bars",
+            "stacking": {
+              "mode": "normal"
+            },
+            "fillOpacity": 80
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 41,
+      "type": "timeseries",
+      "title": "Evictions by strategy",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 60
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (strategy)(increase(descheduler_pod_evictions_total{job=\"descheduler\", profile=~\"$profile\", strategy=~\"$strategy\"}[$__rate_interval]))",
+          "legendFormat": "{{strategy}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 42,
+      "type": "timeseries",
+      "title": "Evictions by profile",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 60
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (profile)(increase(descheduler_pod_evictions_total{job=\"descheduler\", profile=~\"$profile\", strategy=~\"$strategy\"}[$__rate_interval]))",
+          "legendFormat": "{{profile}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 43,
+      "type": "timeseries",
+      "title": "Evictions by namespace",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 68
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (namespace)(increase(descheduler_pod_evictions_total{job=\"descheduler\", namespace=~\"$namespace\", profile=~\"$profile\", strategy=~\"$strategy\"}[$__rate_interval]))",
+          "legendFormat": "{{namespace}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 44,
+      "type": "timeseries",
+      "title": "Evictions by node",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 68
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (node)(increase(descheduler_pod_evictions_total{job=\"descheduler\", node=~\"$node\", profile=~\"$profile\", strategy=~\"$strategy\"}[$__rate_interval]))",
+          "legendFormat": "{{node}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 45,
+      "type": "timeseries",
+      "title": "Loop duration",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 68
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "rate(descheduler_loop_duration_seconds_sum{job=\"descheduler\"}[$__rate_interval]) / rate(descheduler_loop_duration_seconds_count{job=\"descheduler\"}[$__rate_interval])",
+          "legendFormat": "avg"
+        },
+        {
+          "refId": "B",
+          "expr": "histogram_quantile(0.95, rate(descheduler_loop_duration_seconds_bucket{job=\"descheduler\"}[$__rate_interval]))",
+          "legendFormat": "p95"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 46,
+      "type": "timeseries",
+      "title": "Strategy duration (avg)",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 76
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (strategy, profile)(rate(descheduler_strategy_duration_seconds_sum{job=\"descheduler\"}[$__rate_interval])) / sum by (strategy, profile)(rate(descheduler_strategy_duration_seconds_count{job=\"descheduler\"}[$__rate_interval]))",
+          "legendFormat": "{{profile}}/{{strategy}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 47,
+      "type": "table",
+      "title": "Build info",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 76
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "descheduler_build_info{job=\"descheduler\"}",
+          "format": "table",
+          "instant": true
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true
+            },
+            "renameByName": {}
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "options": {}
+    },
+    {
+      "id": 104,
+      "type": "row",
+      "title": "Operations Timeline",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 84
+      },
+      "panels": []
+    },
+    {
+      "id": 50,
+      "type": "timeseries",
+      "title": "Happiness vs Imbalance",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 85
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "avg(descheduler:workload_happiness_score)",
+          "legendFormat": "avg score"
+        },
+        {
+          "refId": "B",
+          "expr": "descheduler:cluster_imbalance_score{resource=\"cpu\"} * 100",
+          "legendFormat": "imbalance cpu x100"
+        },
+        {
+          "refId": "C",
+          "expr": "descheduler:cluster_imbalance_score{resource=\"memory\"} * 100",
+          "legendFormat": "imbalance mem x100"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 51,
+      "type": "timeseries",
+      "title": "Events",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 85
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (result)(increase(descheduler_pod_evictions_total{job=\"descheduler\"}[5m]))",
+          "legendFormat": "evictions {{result}}"
+        },
+        {
+          "refId": "B",
+          "expr": "sum(increase(klog_pod_oomkill[5m]))",
+          "legendFormat": "oom kills"
+        },
+        {
+          "refId": "C",
+          "expr": "sum(descheduler:pod_restarts_15m) or vector(0)",
+          "legendFormat": "restarts (15m)"
+        },
+        {
+          "refId": "D",
+          "expr": "count(max by (node)(kube_node_status_condition{condition=~\"MemoryPressure|DiskPressure|PIDPressure\", status=\"true\"} == 1)) or vector(0)",
+          "legendFormat": "nodes under pressure"
+        },
+        {
+          "refId": "E",
+          "expr": "increase(descheduler_loop_duration_seconds_count{job=\"descheduler\"}[1m]) > 0",
+          "legendFormat": "cycle"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "bars"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    }
+  ]
+}

--- a/modules/400-descheduler/monitoring/grafana-dashboards/descheduler/drs-lens.json
+++ b/modules/400-descheduler/monitoring/grafana-dashboards/descheduler/drs-lens.json
@@ -1594,7 +1594,7 @@
     {
       "id": 50,
       "type": "timeseries",
-      "title": "Happiness vs Imbalance",
+      "title": "Avg happiness per workload",
       "gridPos": {
         "h": 8,
         "w": 12,
@@ -1608,23 +1608,50 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "avg(descheduler:workload_happiness_score)",
-          "legendFormat": "avg score"
-        },
-        {
-          "refId": "B",
-          "expr": "descheduler:cluster_imbalance_score{resource=\"cpu\"} * 100",
-          "legendFormat": "imbalance cpu x100"
-        },
-        {
-          "refId": "C",
-          "expr": "descheduler:cluster_imbalance_score{resource=\"memory\"} * 100",
-          "legendFormat": "imbalance mem x100"
+          "expr": "descheduler:workload_happiness_score{namespace=~\"$namespace\"}",
+          "legendFormat": "{{namespace}}/{{workload_kind}}/{{workload_name}}"
         }
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "short"
+          "unit": "short",
+          "min": 0,
+          "max": 100
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 52,
+      "type": "timeseries",
+      "title": "Cluster imbalance",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 85
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "descheduler:cluster_imbalance_score",
+          "legendFormat": "{{resource}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0
         },
         "overrides": []
       },
@@ -1641,9 +1668,9 @@
       "title": "Events",
       "gridPos": {
         "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 85
+        "w": 24,
+        "x": 0,
+        "y": 93
       },
       "datasource": {
         "type": "prometheus",

--- a/modules/400-descheduler/monitoring/grafana-dashboards/descheduler/drs-lens.json
+++ b/modules/400-descheduler/monitoring/grafana-dashboards/descheduler/drs-lens.json
@@ -338,47 +338,12 @@
       }
     },
     {
-      "id": 6,
-      "type": "stat",
-      "title": "Failed/blocked evictions",
-      "gridPos": {
-        "h": 4,
-        "w": 4,
-        "x": 20,
-        "y": 1
-      },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$ds_prometheus"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "expr": "sum(increase(descheduler_pod_evictions_total{job=\"descheduler\", result=~\"error|blocked\", profile=~\"$profile\", strategy=~\"$strategy\"}[$__range]))",
-          "instant": true
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "options": {
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ]
-        }
-      }
-    },
-    {
       "id": 7,
       "type": "stat",
       "title": "Imbalance CPU",
       "gridPos": {
         "h": 4,
-        "w": 4,
+        "w": 8,
         "x": 0,
         "y": 5
       },
@@ -413,8 +378,8 @@
       "title": "Imbalance Memory",
       "gridPos": {
         "h": 4,
-        "w": 4,
-        "x": 4,
+        "w": 8,
+        "x": 8,
         "y": 5
       },
       "datasource": {
@@ -448,8 +413,8 @@
       "title": "Imbalance Pods",
       "gridPos": {
         "h": 4,
-        "w": 4,
-        "x": 8,
+        "w": 8,
+        "x": 16,
         "y": 5
       },
       "datasource": {
@@ -466,41 +431,6 @@
       "fieldConfig": {
         "defaults": {
           "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "options": {
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ]
-        }
-      }
-    },
-    {
-      "id": 10,
-      "type": "stat",
-      "title": "Last cycle duration (avg)",
-      "gridPos": {
-        "h": 4,
-        "w": 4,
-        "x": 12,
-        "y": 5
-      },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$ds_prometheus"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "expr": "rate(descheduler_loop_duration_seconds_sum{job=\"descheduler\"}[$__rate_interval]) / rate(descheduler_loop_duration_seconds_count{job=\"descheduler\"}[$__rate_interval])",
-          "instant": true
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "s"
         },
         "overrides": []
       },
@@ -960,7 +890,7 @@
     },
     {
       "id": 32,
-      "type": "heatmap",
+      "type": "timeseries",
       "title": "Node CPU usage",
       "gridPos": {
         "h": 8,
@@ -981,17 +911,29 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "percentunit"
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "spanNulls": true
+          }
         },
         "overrides": []
       },
       "options": {
-        "calculate": false
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": ["lastNotNull", "max"]
+        }
       }
     },
     {
       "id": 34,
-      "type": "heatmap",
+      "type": "timeseries",
       "title": "Node Memory usage",
       "gridPos": {
         "h": 8,
@@ -1012,12 +954,24 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "percentunit"
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "spanNulls": true
+          }
         },
         "overrides": []
       },
       "options": {
-        "calculate": false
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": ["lastNotNull", "max"]
+        }
       }
     },
     {

--- a/modules/400-descheduler/monitoring/grafana-dashboards/descheduler/drs-lens.json
+++ b/modules/400-descheduler/monitoring/grafana-dashboards/descheduler/drs-lens.json
@@ -1401,7 +1401,7 @@
       "title": "Evictions by namespace",
       "gridPos": {
         "h": 8,
-        "w": 8,
+        "w": 12,
         "x": 0,
         "y": 68
       },
@@ -1435,8 +1435,8 @@
       "title": "Evictions by node",
       "gridPos": {
         "h": 8,
-        "w": 8,
-        "x": 8,
+        "w": 12,
+        "x": 12,
         "y": 68
       },
       "datasource": {
@@ -1464,51 +1464,12 @@
       }
     },
     {
-      "id": 45,
-      "type": "timeseries",
-      "title": "Loop duration",
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 16,
-        "y": 68
-      },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$ds_prometheus"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "expr": "rate(descheduler_loop_duration_seconds_sum{job=\"descheduler\"}[$__rate_interval]) / rate(descheduler_loop_duration_seconds_count{job=\"descheduler\"}[$__rate_interval])",
-          "legendFormat": "avg"
-        },
-        {
-          "refId": "B",
-          "expr": "histogram_quantile(0.95, rate(descheduler_loop_duration_seconds_bucket{job=\"descheduler\"}[$__rate_interval]))",
-          "legendFormat": "p95"
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "options": {
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom"
-        }
-      }
-    },
-    {
       "id": 46,
       "type": "timeseries",
       "title": "Strategy duration (avg)",
       "gridPos": {
         "h": 8,
-        "w": 12,
+        "w": 24,
         "x": 0,
         "y": 76
       },
@@ -1519,64 +1480,30 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "sum by (strategy, profile)(rate(descheduler_strategy_duration_seconds_sum{job=\"descheduler\"}[$__rate_interval])) / sum by (strategy, profile)(rate(descheduler_strategy_duration_seconds_count{job=\"descheduler\"}[$__rate_interval]))",
+          "expr": "sum by (strategy, profile)(increase(descheduler_strategy_duration_seconds_sum{job=\"descheduler\"}[15m])) / sum by (strategy, profile)(increase(descheduler_strategy_duration_seconds_count{job=\"descheduler\"}[15m]))",
           "legendFormat": "{{profile}}/{{strategy}}"
         }
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "s"
+          "unit": "s",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 15,
+            "spanNulls": true
+          }
         },
         "overrides": []
       },
       "options": {
         "legend": {
-          "displayMode": "list",
-          "placement": "bottom"
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": ["lastNotNull", "max"]
         }
       }
-    },
-    {
-      "id": 47,
-      "type": "table",
-      "title": "Build info",
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 76
-      },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$ds_prometheus"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "expr": "descheduler_build_info{job=\"descheduler\"}",
-          "format": "table",
-          "instant": true
-        }
-      ],
-      "transformations": [
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": true,
-              "Value": true
-            },
-            "renameByName": {}
-          }
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "options": {}
     },
     {
       "id": 104,

--- a/modules/400-descheduler/monitoring/grafana-dashboards/descheduler/drs-lens.json
+++ b/modules/400-descheduler/monitoring/grafana-dashboards/descheduler/drs-lens.json
@@ -1696,11 +1696,6 @@
           "refId": "D",
           "expr": "count(max by (node)(kube_node_status_condition{condition=~\"MemoryPressure|DiskPressure|PIDPressure\", status=\"true\"} == 1)) or vector(0)",
           "legendFormat": "nodes under pressure"
-        },
-        {
-          "refId": "E",
-          "expr": "increase(descheduler_loop_duration_seconds_count{job=\"descheduler\"}[1m]) > 0",
-          "legendFormat": "cycle"
         }
       ],
       "fieldConfig": {

--- a/modules/400-descheduler/monitoring/grafana-dashboards/descheduler/drs-lens.json
+++ b/modules/400-descheduler/monitoring/grafana-dashboards/descheduler/drs-lens.json
@@ -99,72 +99,6 @@
         "iconColor": "blue",
         "expr": "sum(increase(descheduler_loop_duration_seconds_count{job=\"descheduler\"}[1m])) > 0",
         "titleFormat": "descheduler cycle"
-      },
-      {
-        "name": "Eviction success",
-        "datasource": {
-          "type": "prometheus",
-          "uid": "$ds_prometheus"
-        },
-        "enable": true,
-        "iconColor": "green",
-        "expr": "sum(increase(descheduler_pod_evictions_total{job=\"descheduler\", result=\"success\"}[1m])) > 0",
-        "titleFormat": "eviction success"
-      },
-      {
-        "name": "Eviction error",
-        "datasource": {
-          "type": "prometheus",
-          "uid": "$ds_prometheus"
-        },
-        "enable": true,
-        "iconColor": "red",
-        "expr": "sum(increase(descheduler_pod_evictions_total{job=\"descheduler\", result=\"error\"}[1m])) > 0",
-        "titleFormat": "eviction error"
-      },
-      {
-        "name": "Eviction blocked",
-        "datasource": {
-          "type": "prometheus",
-          "uid": "$ds_prometheus"
-        },
-        "enable": true,
-        "iconColor": "orange",
-        "expr": "sum(increase(descheduler_pod_evictions_total{job=\"descheduler\", result=\"blocked\"}[1m])) > 0",
-        "titleFormat": "eviction blocked"
-      },
-      {
-        "name": "OOM burst",
-        "datasource": {
-          "type": "prometheus",
-          "uid": "$ds_prometheus"
-        },
-        "enable": false,
-        "iconColor": "purple",
-        "expr": "sum(increase(klog_pod_oomkill[5m])) > 3",
-        "titleFormat": "OOM burst"
-      },
-      {
-        "name": "Unhappy spike",
-        "datasource": {
-          "type": "prometheus",
-          "uid": "$ds_prometheus"
-        },
-        "enable": false,
-        "iconColor": "yellow",
-        "expr": "delta(count(descheduler:workload_happiness_bucket{bucket=\"unhappy\"})[10m:]) > 5",
-        "titleFormat": "unhappy spike"
-      },
-      {
-        "name": "Imbalance jump",
-        "datasource": {
-          "type": "prometheus",
-          "uid": "$ds_prometheus"
-        },
-        "enable": false,
-        "iconColor": "yellow",
-        "expr": "abs(delta(descheduler:cluster_imbalance_score{resource=\"cpu\"}[10m:])) > 0.2",
-        "titleFormat": "imbalance jump"
       }
     ]
   },
@@ -1523,6 +1457,7 @@
       "id": 51,
       "type": "timeseries",
       "title": "Events",
+      "interval": "1m",
       "gridPos": {
         "h": 8,
         "w": 24,
@@ -1536,12 +1471,12 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "round(sum by (result)(increase(descheduler_pod_evictions_total{job=\"descheduler\"}[$__rate_interval])))",
+          "expr": "round(sum by (result)(increase(descheduler_pod_evictions_total{job=\"descheduler\"}[$__interval])))",
           "legendFormat": "evictions {{result}}"
         },
         {
           "refId": "B",
-          "expr": "round(sum(increase(klog_pod_oomkill[$__rate_interval])))",
+          "expr": "round(sum(increase(klog_pod_oomkill[$__interval])))",
           "legendFormat": "oom kills"
         },
         {

--- a/modules/400-descheduler/monitoring/grafana-dashboards/descheduler/drs-lens.json
+++ b/modules/400-descheduler/monitoring/grafana-dashboards/descheduler/drs-lens.json
@@ -974,7 +974,8 @@
     {
       "id": 30,
       "type": "timeseries",
-      "title": "Imbalance (max-min)",
+      "title": "Imbalance: hottest vs coldest node",
+      "description": "max(node usage) - min(node usage), per resource. Highlights the gap between the single busiest and single idlest node; sensitive to one outlier.",
       "gridPos": {
         "h": 8,
         "w": 6,
@@ -1018,7 +1019,8 @@
     {
       "id": 31,
       "type": "timeseries",
-      "title": "Imbalance (stddev)",
+      "title": "Imbalance: spread across nodes",
+      "description": "stddev of node usage across all nodes, per resource. Shows whether the imbalance is systemic or just one outlier; robust to a single hot node.",
       "gridPos": {
         "h": 8,
         "w": 6,
@@ -1524,7 +1526,7 @@
       "title": "Avg happiness per workload",
       "gridPos": {
         "h": 8,
-        "w": 12,
+        "w": 24,
         "x": 0,
         "y": 85
       },
@@ -1544,41 +1546,6 @@
           "unit": "short",
           "min": 0,
           "max": 100
-        },
-        "overrides": []
-      },
-      "options": {
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom"
-        }
-      }
-    },
-    {
-      "id": 52,
-      "type": "timeseries",
-      "title": "Cluster imbalance",
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 85
-      },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$ds_prometheus"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "expr": "descheduler:cluster_imbalance_score",
-          "legendFormat": "{{resource}}"
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "percentunit",
-          "min": 0
         },
         "overrides": []
       },

--- a/modules/400-descheduler/monitoring/grafana-dashboards/descheduler/drs-lens.json
+++ b/modules/400-descheduler/monitoring/grafana-dashboards/descheduler/drs-lens.json
@@ -579,43 +579,6 @@
       }
     },
     {
-      "id": 11,
-      "type": "stat",
-      "title": "Descheduler version",
-      "gridPos": {
-        "h": 4,
-        "w": 4,
-        "x": 16,
-        "y": 5
-      },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$ds_prometheus"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "expr": "descheduler_build_info{job=\"descheduler\"}",
-          "instant": true,
-          "legendFormat": "{{version}}"
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "options": {
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ]
-        },
-        "textMode": "name"
-      }
-    },
-    {
       "id": 12,
       "type": "bargauge",
       "title": "Top-10 unhappy workloads",
@@ -1573,12 +1536,12 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "sum by (result)(increase(descheduler_pod_evictions_total{job=\"descheduler\"}[5m]))",
+          "expr": "round(sum by (result)(increase(descheduler_pod_evictions_total{job=\"descheduler\"}[$__rate_interval])))",
           "legendFormat": "evictions {{result}}"
         },
         {
           "refId": "B",
-          "expr": "sum(increase(klog_pod_oomkill[5m]))",
+          "expr": "round(sum(increase(klog_pod_oomkill[$__rate_interval])))",
           "legendFormat": "oom kills"
         },
         {

--- a/modules/400-descheduler/monitoring/prometheus-rules/drs-lens.yaml
+++ b/modules/400-descheduler/monitoring/prometheus-rules/drs-lens.yaml
@@ -203,18 +203,20 @@
           ),
         25)
 
+  # "no request" and the usage rungs are additive and independent: each term falls
+  # back to 0 via `or replicas*0`, so a workload with a limit but no request still
+  # accrues the limit-proximity penalty instead of only the flat no-request 10.
   - record: descheduler:workload_memory_penalty
     expr: |
       clamp_max(
-          ((descheduler:workload_replicas unless descheduler:workload_memory_request_bytes) > bool 0) * 10
-        or
-          (
-              (descheduler:workload_memory_request_usage_ratio > bool 1) * 10
-            + ((descheduler:workload_memory_limit_usage_ratio > bool 0.8) * 20
-                or descheduler:workload_memory_request_usage_ratio * 0)
-            + ((descheduler:workload_memory_limit_usage_ratio > bool 0.95) * 15
-                or descheduler:workload_memory_request_usage_ratio * 0)
-          ),
+          (((descheduler:workload_replicas unless descheduler:workload_memory_request_bytes) > bool 0) * 10
+            or descheduler:workload_replicas * 0)
+        + ((descheduler:workload_memory_request_usage_ratio > bool 1) * 10
+            or descheduler:workload_replicas * 0)
+        + ((descheduler:workload_memory_limit_usage_ratio > bool 0.8) * 20
+            or descheduler:workload_replicas * 0)
+        + ((descheduler:workload_memory_limit_usage_ratio > bool 0.95) * 15
+            or descheduler:workload_replicas * 0),
         35)
 
   # --- node/eviction penalties ---

--- a/modules/400-descheduler/monitoring/prometheus-rules/drs-lens.yaml
+++ b/modules/400-descheduler/monitoring/prometheus-rules/drs-lens.yaml
@@ -1,0 +1,328 @@
+- name: descheduler.drs-lens.happiness
+  rules:
+  # RS -> its controller owner of any kind (e.g. Deployment, Rollout).
+  # Anchor: one series per ReplicaSet that has a controller owner.
+  - record: descheduler:replicaset_workload
+    expr: |
+      max by (namespace, replicaset, workload_kind, workload_name) (
+        label_replace(label_replace(
+          kube_replicaset_owner{job="kube-state-metrics", owner_is_controller="true", owner_kind!="<none>"},
+          "workload_kind", "$1", "owner_kind", "(.*)"),
+          "workload_name", "$1", "owner_name", "(.*)")
+      )
+
+  # Anchor: one series per live pod in descheduler scope (excludes d8-*/kube-system
+  # namespaces and Succeeded pods), resolved to its owning workload.
+  # Branch 1: pod's controller owner is not a ReplicaSet (StatefulSet, DaemonSet,
+  # Job, bare pod via owner_kind="<none>", etc.) - used directly.
+  # Branch 2: pod's controller owner is a ReplicaSet that itself has a controller
+  # owner (e.g. Deployment, Rollout) - resolved one hop further.
+  # Branch 3: pod's controller owner is an orphan ReplicaSet (no controller owner)
+  # - the ReplicaSet itself is reported as the workload.
+  - record: descheduler:pod_workload
+    expr: |
+      max by (namespace, pod, node, workload_kind, workload_name) (
+        (
+            label_replace(label_replace(
+              kube_pod_owner{job="kube-state-metrics", namespace!~"d8-.*|kube-system",
+                             owner_kind!="ReplicaSet", owner_is_controller=~"true|<none>"},
+              "workload_kind", "$1", "owner_kind", "(.*)"),
+              "workload_name", "$1", "owner_name", "(.*)")
+          or
+            label_replace(
+              kube_pod_owner{job="kube-state-metrics", namespace!~"d8-.*|kube-system",
+                             owner_kind="ReplicaSet", owner_is_controller="true"},
+              "replicaset", "$1", "owner_name", "(.*)")
+            * on (namespace, replicaset) group_left (workload_kind, workload_name)
+            descheduler:replicaset_workload
+          or
+            label_replace(label_replace(
+              (
+                label_replace(
+                  kube_pod_owner{job="kube-state-metrics", namespace!~"d8-.*|kube-system",
+                                 owner_kind="ReplicaSet", owner_is_controller="true"},
+                  "replicaset", "$1", "owner_name", "(.*)")
+                unless on (namespace, replicaset) descheduler:replicaset_workload
+              ),
+              "workload_kind", "$1", "owner_kind", "(.*)"),
+              "workload_name", "$1", "owner_name", "(.*)")
+        )
+        * on (namespace, pod) group_left (node)
+        topk by (namespace, pod) (1, kube_pod_info{job="kube-state-metrics"})
+      )
+      unless on (namespace, pod)
+        (kube_pod_status_phase{job="kube-state-metrics", phase="Succeeded"} == 1)
+
+  # Anchor: one series per workload, counting its currently live pods (replicas).
+  - record: descheduler:workload_replicas
+    expr: count by (namespace, workload_kind, workload_name) (descheduler:pod_workload)
+
+  # --- per-pod helper rules ---
+
+  # Helper: keeps only pods that restarted within the last 15m; value = rounded restart count over 15m.
+  - record: descheduler:pod_restarts_15m
+    expr: |
+      round(sum by (namespace, pod) (
+        increase(kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace!~"d8-.*|kube-system"}[15m])
+      )) > 0
+
+  # Helper: pods OOM-killed within the last 15m; primary source is klog_pod_oomkill,
+  # fallback is last_terminated_reason gated by a recent restart.
+  - record: descheduler:pod_oom_15m
+    expr: |
+      max by (namespace, pod) (
+        label_replace(
+          increase(klog_pod_oomkill{namespace!~"d8-.*|kube-system"}[15m]),
+          "pod", "$1", "pod_name", "(.+)") > 0
+      )
+      or
+      (
+        max by (namespace, pod) (
+          kube_pod_container_status_last_terminated_reason{job="kube-state-metrics",
+            namespace!~"d8-.*|kube-system", reason="OOMKilled"} == 1
+        )
+        and on (namespace, pod) (descheduler:pod_restarts_15m > 0)
+      )
+
+  # --- state penalties (per namespace, workload_kind, workload_name) ---
+
+  # Weighted average over pod phases; max 60.
+  - record: descheduler:workload_phase_penalty
+    expr: |
+      sum by (namespace, workload_kind, workload_name) (
+        (
+            (kube_pod_status_phase{job="kube-state-metrics", phase="Pending"} == 1) * 40
+          or (kube_pod_status_phase{job="kube-state-metrics", phase="Failed"}  == 1) * 60
+          or (kube_pod_status_phase{job="kube-state-metrics", phase="Unknown"} == 1) * 50
+        )
+        * on (namespace, pod) group_left (workload_kind, workload_name)
+        max by (namespace, pod, workload_kind, workload_name) (descheduler:pod_workload)
+      )
+      / descheduler:workload_replicas
+
+  # 30 x share of not-ready pods; container-level penalty absorbed by pod Ready=False; max 30.
+  - record: descheduler:workload_readiness_penalty
+    expr: |
+      30 * sum by (namespace, workload_kind, workload_name) (
+        (kube_pod_status_ready{job="kube-state-metrics", condition="false"} == 1)
+        * on (namespace, pod) group_left (workload_kind, workload_name)
+        max by (namespace, pod, workload_kind, workload_name) (descheduler:pod_workload)
+      )
+      / descheduler:workload_replicas
+
+  # 20 x share(pods with >0 restarts) + 15 x share(pods with >=3 restarts); max 35.
+  - record: descheduler:workload_restart_penalty
+    expr: |
+      sum by (namespace, workload_kind, workload_name) (
+        (
+            (descheduler:pod_restarts_15m > bool 0) * 20
+          + (descheduler:pod_restarts_15m >= bool 3) * 15
+        )
+        * on (namespace, pod) group_left (workload_kind, workload_name)
+        max by (namespace, pod, workload_kind, workload_name) (descheduler:pod_workload)
+      )
+      / descheduler:workload_replicas
+
+  # 35 x share of pods OOM-killed within 15m; max 35.
+  - record: descheduler:workload_oom_penalty
+    expr: |
+      35 * sum by (namespace, workload_kind, workload_name) (
+        (descheduler:pod_oom_15m > bool 0)
+        * on (namespace, pod) group_left (workload_kind, workload_name)
+        max by (namespace, pod, workload_kind, workload_name) (descheduler:pod_workload)
+      )
+      / descheduler:workload_replicas
+
+  # --- resource aggregates and ratios (rolled up over the anchor) ---
+
+  - record: descheduler:workload_cpu_request_cores
+    expr: |
+      sum by (namespace, workload_kind, workload_name) (
+        kube_pod_container_resource_requests{job="kube-state-metrics", resource="cpu", unit="core"}
+        * on (namespace, pod) group_left (workload_kind, workload_name)
+        max by (namespace, pod, workload_kind, workload_name) (descheduler:pod_workload)
+      )
+
+  - record: descheduler:workload_cpu_usage_cores
+    expr: |
+      sum by (namespace, workload_kind, workload_name) (
+        rate(container_cpu_usage_seconds_total{job="kubelet", container!~"|POD"}[5m])
+        * on (namespace, pod) group_left (workload_kind, workload_name)
+        max by (namespace, pod, workload_kind, workload_name) (descheduler:pod_workload)
+      )
+
+  - record: descheduler:workload_memory_request_bytes
+    expr: |
+      sum by (namespace, workload_kind, workload_name) (
+        kube_pod_container_resource_requests{job="kube-state-metrics", resource="memory", unit="byte"}
+        * on (namespace, pod) group_left (workload_kind, workload_name)
+        max by (namespace, pod, workload_kind, workload_name) (descheduler:pod_workload)
+      )
+
+  - record: descheduler:workload_memory_usage_bytes
+    expr: |
+      sum by (namespace, workload_kind, workload_name) (
+        container_memory_working_set_bytes{job="kubelet", container!~"|POD"}
+        * on (namespace, pod) group_left (workload_kind, workload_name)
+        max by (namespace, pod, workload_kind, workload_name) (descheduler:pod_workload)
+      )
+
+  # ratios -- the `> 0` guard: zero/absent denominator yields no series (handled in penalties)
+  - record: descheduler:workload_cpu_usage_ratio
+    expr: descheduler:workload_cpu_usage_cores / (descheduler:workload_cpu_request_cores > 0)
+
+  - record: descheduler:workload_memory_request_usage_ratio
+    expr: descheduler:workload_memory_usage_bytes / (descheduler:workload_memory_request_bytes > 0)
+
+  # MAX over pods: OOM proximity is per-pod physics
+  - record: descheduler:workload_memory_limit_usage_ratio
+    expr: |
+      max by (namespace, workload_kind, workload_name) (
+        (
+          sum by (namespace, pod) (
+            container_memory_working_set_bytes{job="kubelet", container!~"|POD", namespace!~"d8-.*|kube-system"})
+          / (sum by (namespace, pod) (
+              kube_pod_container_resource_limits{job="kube-state-metrics", resource="memory", unit="byte",
+                                                 namespace!~"d8-.*|kube-system"}) > 0)
+        )
+        * on (namespace, pod) group_left (workload_kind, workload_name)
+        max by (namespace, pod, workload_kind, workload_name) (descheduler:pod_workload)
+      )
+
+  # --- resource penalties ---
+  # "no request" = the workload has NO aggregate series at all (detected via unless -- absent series != 0)
+
+  - record: descheduler:workload_cpu_penalty
+    expr: |
+      clamp_max(
+          ((descheduler:workload_replicas unless descheduler:workload_cpu_request_cores) > bool 0) * 10
+        or
+          (
+              (descheduler:workload_cpu_usage_ratio > bool 1) * 15
+            + (descheduler:workload_cpu_usage_ratio > bool 2) * 10
+          ),
+        25)
+
+  - record: descheduler:workload_memory_penalty
+    expr: |
+      clamp_max(
+          ((descheduler:workload_replicas unless descheduler:workload_memory_request_bytes) > bool 0) * 10
+        or
+          (
+              (descheduler:workload_memory_request_usage_ratio > bool 1) * 10
+            + ((descheduler:workload_memory_limit_usage_ratio > bool 0.8) * 20
+                or descheduler:workload_memory_request_usage_ratio * 0)
+            + ((descheduler:workload_memory_limit_usage_ratio > bool 0.95) * 15
+                or descheduler:workload_memory_request_usage_ratio * 0)
+          ),
+        35)
+
+  # --- node/eviction penalties ---
+
+  # node penalty: sum(node weight of each pod's node)/replicas; node weight = max of conditions; max 50
+  - record: descheduler:workload_node_penalty
+    expr: |
+      sum by (namespace, workload_kind, workload_name) (
+        descheduler:pod_workload
+        * on (node) group_left ()
+        max by (node) (
+            (kube_node_status_condition{job="kube-state-metrics", condition="MemoryPressure", status="true"} == 1) * 20
+          or (kube_node_status_condition{job="kube-state-metrics", condition="DiskPressure",   status="true"} == 1) * 15
+          or (kube_node_status_condition{job="kube-state-metrics", condition="PIDPressure",    status="true"} == 1) * 15
+          or (kube_node_status_condition{job="kube-state-metrics", condition="Ready",          status!="true"} == 1) * 50
+          or (kube_node_spec_unschedulable{job="kube-state-metrics"} == 1) * 10
+        )
+      )
+      / descheduler:workload_replicas
+
+  # eviction penalty: binary, native from the workload-scoped metric; max 25
+  - record: descheduler:workload_eviction_penalty
+    expr: |
+      max by (namespace, workload_kind, workload_name) (
+          (increase(descheduler_pod_evictions_total{job="descheduler", result="success"}[15m]) > bool 0) * 10
+        or (increase(descheduler_pod_evictions_total{job="descheduler", result="error"}[15m])   > bool 0) * 25
+        or (increase(descheduler_pod_evictions_total{job="descheduler", result="blocked"}[15m]) > bool 0) * 15
+      )
+
+  # --- final score ---
+  # Each term defaults to 0 via `or replicas*0` -- an absent penalty series must not drop the workload.
+  # Intersection with the anchor drops eviction-penalty series of deleted workloads (they live 15m after deletion).
+  - record: descheduler:workload_happiness_score
+    expr: |
+      clamp_min(clamp_max(
+        100
+        - (descheduler:workload_phase_penalty     or descheduler:workload_replicas * 0)
+        - (descheduler:workload_readiness_penalty or descheduler:workload_replicas * 0)
+        - (descheduler:workload_restart_penalty   or descheduler:workload_replicas * 0)
+        - (descheduler:workload_oom_penalty       or descheduler:workload_replicas * 0)
+        - (descheduler:workload_cpu_penalty       or descheduler:workload_replicas * 0)
+        - (descheduler:workload_memory_penalty    or descheduler:workload_replicas * 0)
+        - (descheduler:workload_node_penalty      or descheduler:workload_replicas * 0)
+        - (descheduler:workload_eviction_penalty  or descheduler:workload_replicas * 0)
+      , 100), 0)
+
+  # buckets -- filter form (series exists only for workloads in the category; value = score); count via count()
+  - record: descheduler:workload_happiness_bucket
+    labels: { bucket: happy }
+    expr: descheduler:workload_happiness_score >= 80
+  - record: descheduler:workload_happiness_bucket
+    labels: { bucket: warning }
+    expr: (descheduler:workload_happiness_score >= 60) and (descheduler:workload_happiness_score < 80)
+  - record: descheduler:workload_happiness_bucket
+    labels: { bucket: unhappy }
+    expr: descheduler:workload_happiness_score < 60
+
+- name: descheduler.drs-lens.balance
+  rules:
+  # --- per-node ratios ---
+  - record: descheduler:node_pod_allocation_ratio
+    expr: |
+      count by (node) (kube_pod_info{job="kube-state-metrics"})
+        / on (node) group_left ()
+        max by (node) (kube_node_status_allocatable{job="kube-state-metrics", resource="pods", unit="integer"})
+
+  # by(node) aggregation is mandatory for node-exporter metrics: the instance label survives relabeling
+  - record: descheduler:node_cpu_usage_ratio
+    expr: 1 - avg by (node) (rate(node_cpu_seconds_total{job="node-exporter", mode="idle"}[5m]))
+
+  - record: descheduler:node_memory_usage_ratio
+    expr: |
+      1 - (
+        max by (node) (node_memory_MemAvailable_bytes{job="node-exporter"})
+        / max by (node) (node_memory_MemTotal_bytes{job="node-exporter"})
+      )
+
+  - record: descheduler:node_cpu_request_ratio
+    expr: |
+      sum by (node) (kube_pod_container_resource_requests{job="kube-state-metrics", resource="cpu", unit="core"})
+        / on (node) group_left ()
+        max by (node) (kube_node_status_allocatable{job="kube-state-metrics", resource="cpu", unit="core"})
+
+  - record: descheduler:node_memory_request_ratio
+    expr: |
+      sum by (node) (kube_pod_container_resource_requests{job="kube-state-metrics", resource="memory", unit="byte"})
+        / on (node) group_left ()
+        max by (node) (kube_node_status_allocatable{job="kube-state-metrics", resource="memory", unit="byte"})
+
+  # --- cluster aggregates ---
+  # cluster imbalance: spread between the most and least loaded node, per resource
+  - record: descheduler:cluster_imbalance_score
+    labels: { resource: pods }
+    expr: max(descheduler:node_pod_allocation_ratio) - min(descheduler:node_pod_allocation_ratio)
+  - record: descheduler:cluster_imbalance_score
+    labels: { resource: cpu }
+    expr: max(descheduler:node_cpu_usage_ratio) - min(descheduler:node_cpu_usage_ratio)
+  - record: descheduler:cluster_imbalance_score
+    labels: { resource: memory }
+    expr: max(descheduler:node_memory_usage_ratio) - min(descheduler:node_memory_usage_ratio)
+
+  # dispersion complement to the max-min spread
+  - record: descheduler:cluster_imbalance_stddev
+    labels: { resource: pods }
+    expr: stddev(descheduler:node_pod_allocation_ratio)
+  - record: descheduler:cluster_imbalance_stddev
+    labels: { resource: cpu }
+    expr: stddev(descheduler:node_cpu_usage_ratio)
+  - record: descheduler:cluster_imbalance_stddev
+    labels: { resource: memory }
+    expr: stddev(descheduler:node_memory_usage_ratio)

--- a/modules/400-descheduler/monitoring/prometheus-rules/drs-lens.yaml
+++ b/modules/400-descheduler/monitoring/prometheus-rules/drs-lens.yaml
@@ -1,7 +1,5 @@
 - name: descheduler.drs-lens.happiness
   rules:
-  # RS -> its controller owner of any kind (e.g. Deployment, Rollout).
-  # Anchor: one series per ReplicaSet that has a controller owner.
   - record: descheduler:replicaset_workload
     expr: |
       max by (namespace, replicaset, workload_kind, workload_name) (
@@ -11,14 +9,6 @@
           "workload_name", "$1", "owner_name", "(.*)")
       )
 
-  # Anchor: one series per live pod in descheduler scope (excludes d8-*/kube-system
-  # namespaces and Succeeded pods), resolved to its owning workload.
-  # Branch 1: pod's controller owner is not a ReplicaSet (StatefulSet, DaemonSet,
-  # Job, bare pod via owner_kind="<none>", etc.) - used directly.
-  # Branch 2: pod's controller owner is a ReplicaSet that itself has a controller
-  # owner (e.g. Deployment, Rollout) - resolved one hop further.
-  # Branch 3: pod's controller owner is an orphan ReplicaSet (no controller owner)
-  # - the ReplicaSet itself is reported as the workload.
   - record: descheduler:pod_workload
     expr: |
       max by (namespace, pod, node, workload_kind, workload_name) (
@@ -53,21 +43,16 @@
       unless on (namespace, pod)
         (kube_pod_status_phase{job="kube-state-metrics", phase="Succeeded"} == 1)
 
-  # Anchor: one series per workload, counting its currently live pods (replicas).
   - record: descheduler:workload_replicas
     expr: count by (namespace, workload_kind, workload_name) (descheduler:pod_workload)
 
-  # --- per-pod helper rules ---
-
-  # Helper: keeps only pods that restarted within the last 15m; value = rounded restart count over 15m.
   - record: descheduler:pod_restarts_15m
     expr: |
       round(sum by (namespace, pod) (
         increase(kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace!~"d8-.*|kube-system"}[15m])
       )) > 0
 
-  # Helper: pods OOM-killed within the last 15m; primary source is klog_pod_oomkill,
-  # fallback is last_terminated_reason gated by a recent restart.
+  # Primary source klog_pod_oomkill; fallback last_terminated_reason gated by a recent restart.
   - record: descheduler:pod_oom_15m
     expr: |
       max by (namespace, pod) (
@@ -84,9 +69,7 @@
         and on (namespace, pod) (descheduler:pod_restarts_15m > 0)
       )
 
-  # --- state penalties (per namespace, workload_kind, workload_name) ---
-
-  # Weighted average over pod phases; max 60.
+  # State penalties are share-weighted: sum of per-pod weight over the anchor / replicas.
   - record: descheduler:workload_phase_penalty
     expr: |
       sum by (namespace, workload_kind, workload_name) (
@@ -100,7 +83,7 @@
       )
       / descheduler:workload_replicas
 
-  # 30 x share of not-ready pods; container-level penalty absorbed by pod Ready=False; max 30.
+  # Container-level readiness penalty is absorbed here: pod Ready=False already covers it.
   - record: descheduler:workload_readiness_penalty
     expr: |
       30 * sum by (namespace, workload_kind, workload_name) (
@@ -110,7 +93,6 @@
       )
       / descheduler:workload_replicas
 
-  # 20 x share(pods with >0 restarts) + 15 x share(pods with >=3 restarts); max 35.
   - record: descheduler:workload_restart_penalty
     expr: |
       sum by (namespace, workload_kind, workload_name) (
@@ -123,7 +105,6 @@
       )
       / descheduler:workload_replicas
 
-  # 35 x share of pods OOM-killed within 15m; max 35.
   - record: descheduler:workload_oom_penalty
     expr: |
       35 * sum by (namespace, workload_kind, workload_name) (
@@ -132,8 +113,6 @@
         max by (namespace, pod, workload_kind, workload_name) (descheduler:pod_workload)
       )
       / descheduler:workload_replicas
-
-  # --- resource aggregates and ratios (rolled up over the anchor) ---
 
   - record: descheduler:workload_cpu_request_cores
     expr: |
@@ -167,14 +146,14 @@
         max by (namespace, pod, workload_kind, workload_name) (descheduler:pod_workload)
       )
 
-  # ratios -- the `> 0` guard: zero/absent denominator yields no series (handled in penalties)
+  # The `> 0` guard drops zero/absent denominators so the ratio yields no series (not +Inf/NaN).
   - record: descheduler:workload_cpu_usage_ratio
     expr: descheduler:workload_cpu_usage_cores / (descheduler:workload_cpu_request_cores > 0)
 
   - record: descheduler:workload_memory_request_usage_ratio
     expr: descheduler:workload_memory_usage_bytes / (descheduler:workload_memory_request_bytes > 0)
 
-  # MAX over pods: OOM proximity is per-pod physics
+  # MAX over pods: OOM proximity is per-pod physics.
   - record: descheduler:workload_memory_limit_usage_ratio
     expr: |
       max by (namespace, workload_kind, workload_name) (
@@ -189,9 +168,7 @@
         max by (namespace, pod, workload_kind, workload_name) (descheduler:pod_workload)
       )
 
-  # --- resource penalties ---
-  # "no request" = the workload has NO aggregate series at all (detected via unless -- absent series != 0)
-
+  # "no request" = workload has no aggregate request series at all (detected via `unless`).
   - record: descheduler:workload_cpu_penalty
     expr: |
       clamp_max(
@@ -203,9 +180,7 @@
           ),
         25)
 
-  # "no request" and the usage rungs are additive and independent: each term falls
-  # back to 0 via `or replicas*0`, so a workload with a limit but no request still
-  # accrues the limit-proximity penalty instead of only the flat no-request 10.
+  # Terms are additive; each falls back to 0 via `or replicas*0`, so a limit-only workload still scores the limit rungs.
   - record: descheduler:workload_memory_penalty
     expr: |
       clamp_max(
@@ -219,9 +194,6 @@
             or descheduler:workload_replicas * 0),
         35)
 
-  # --- node/eviction penalties ---
-
-  # node penalty: sum(node weight of each pod's node)/replicas; node weight = max of conditions; max 50
   - record: descheduler:workload_node_penalty
     expr: |
       sum by (namespace, workload_kind, workload_name) (
@@ -237,7 +209,6 @@
       )
       / descheduler:workload_replicas
 
-  # eviction penalty: binary, native from the workload-scoped metric; max 25
   - record: descheduler:workload_eviction_penalty
     expr: |
       max by (namespace, workload_kind, workload_name) (
@@ -246,9 +217,6 @@
         or (increase(descheduler_pod_evictions_total{job="descheduler", result="blocked"}[15m]) > bool 0) * 15
       )
 
-  # --- final score ---
-  # Each term defaults to 0 via `or replicas*0` -- an absent penalty series must not drop the workload.
-  # Intersection with the anchor drops eviction-penalty series of deleted workloads (they live 15m after deletion).
   - record: descheduler:workload_happiness_score
     expr: |
       clamp_min(clamp_max(
@@ -263,7 +231,6 @@
         - (descheduler:workload_eviction_penalty  or descheduler:workload_replicas * 0)
       , 100), 0)
 
-  # buckets -- filter form (series exists only for workloads in the category; value = score); count via count()
   - record: descheduler:workload_happiness_bucket
     labels: { bucket: happy }
     expr: descheduler:workload_happiness_score >= 80
@@ -276,14 +243,12 @@
 
 - name: descheduler.drs-lens.balance
   rules:
-  # --- per-node ratios ---
   - record: descheduler:node_pod_allocation_ratio
     expr: |
       count by (node) (kube_pod_info{job="kube-state-metrics"})
         / on (node) group_left ()
         max by (node) (kube_node_status_allocatable{job="kube-state-metrics", resource="pods", unit="integer"})
 
-  # by(node) aggregation is mandatory for node-exporter metrics: the instance label survives relabeling
   - record: descheduler:node_cpu_usage_ratio
     expr: 1 - avg by (node) (rate(node_cpu_seconds_total{job="node-exporter", mode="idle"}[5m]))
 
@@ -306,8 +271,6 @@
         / on (node) group_left ()
         max by (node) (kube_node_status_allocatable{job="kube-state-metrics", resource="memory", unit="byte"})
 
-  # --- cluster aggregates ---
-  # cluster imbalance: spread between the most and least loaded node, per resource
   - record: descheduler:cluster_imbalance_score
     labels: { resource: pods }
     expr: max(descheduler:node_pod_allocation_ratio) - min(descheduler:node_pod_allocation_ratio)
@@ -318,7 +281,6 @@
     labels: { resource: memory }
     expr: max(descheduler:node_memory_usage_ratio) - min(descheduler:node_memory_usage_ratio)
 
-  # dispersion complement to the max-min spread
   - record: descheduler:cluster_imbalance_stddev
     labels: { resource: pods }
     expr: stddev(descheduler:node_pod_allocation_ratio)

--- a/modules/400-descheduler/templates/monitoring.yaml
+++ b/modules/400-descheduler/templates/monitoring.yaml
@@ -1,0 +1,4 @@
+{{- if len .Values.descheduler.internal.deschedulers }}
+  {{- include "helm_lib_prometheus_rules" (list . "d8-descheduler") }}
+{{- end }}
+{{- include "helm_lib_grafana_dashboard_definitions" . }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
This PR adds a **DRS-Lens** Grafana dashboard for the `descheduler` module. It shows how healthy workloads are (happiness score), how evenly the load is spread across nodes (cluster balance), and what the descheduler actually did (evictions, strategies, timeline).

### New metrics (recording rules)

All happiness metrics are **workload-scoped** with identity labels `namespace`, `workload_kind`, `workload_name` (pod → owning workload resolved the same way as in the descheduler's `descheduler_pod_evictions_total` metric: `Pod → ReplicaSet → Deployment/Rollout/...`; bare pods get `<none>`). Succeeded pods and `d8-*`/`kube-system` namespaces are out of scope.

Anchors and helpers:

| Metric | Labels | Meaning |
|---|---|---|
| `descheduler:pod_workload` | `namespace, pod, node, workload_kind, workload_name` | One series per live pod in descheduler scope, resolved to its owning workload; the join anchor for everything below. |
| `descheduler:replicaset_workload` | `namespace, replicaset, workload_kind, workload_name` | ReplicaSet → its controller owner (internal helper for the anchor). |
| `descheduler:workload_replicas` | `namespace, workload_kind, workload_name` | Count of currently live pods of the workload (denominator for share-weighted penalties). |
| `descheduler:pod_restarts_15m` | `namespace, pod` | Restart count over the last 15m; series exists only for pods that restarted. |
| `descheduler:pod_oom_15m` | `namespace, pod` | Pod was OOM-killed within 15m; primary source `klog_pod_oomkill` (oom-kills exporter), fallback `kube_pod_container_status_last_terminated_reason{reason="OOMKilled"}` gated by a recent restart. |


Penalty components (all `namespace, workload_kind, workload_name`; state penalties are share-weighted — `weight × fraction of affected replicas`, so one bad pod out of two yields half the weight):

| Metric | Max | Triggers |
|---|---|---|
| `descheduler:workload_phase_penalty` | 60 | Pending 40, Failed 60, Unknown 50 per pod |
| `descheduler:workload_readiness_penalty` | 30 | pod `Ready=False` (container-level unreadiness is covered by this) |
| `descheduler:workload_restart_penalty` | 35 | >0 restarts in 15m → 20, ≥3 → +15 |
| `descheduler:workload_oom_penalty` | 35 | OOM kill within 15m |
| `descheduler:workload_cpu_penalty` | 25 | no CPU request → 10; usage/request >1 → 15, >2 → +10 |
| `descheduler:workload_memory_penalty` | 35 | no memory request → 10; usage/request >1 → +10; usage/limit >0.8 → +20, >0.95 → +15 |
| `descheduler:workload_node_penalty` | 50 | node of the pod: NotReady 50, MemoryPressure 20, Disk/PIDPressure 15, unschedulable 10 |
| `descheduler:workload_eviction_penalty` | 25 | descheduler eviction within 15m: success 10, blocked 15, error 25 (from `descheduler_pod_evictions_total`) |


The final score:

| Metric | Labels | Meaning |
|---|---|---|
| `descheduler:workload_happiness_score` | `namespace, workload_kind, workload_name` | `100 − sum of all 8 penalties`, clamped to 0..100. 100 = fully healthy workload. |
| `descheduler:workload_happiness_bucket` | + `bucket=happy\|warning\|unhappy` | Filter-form series (exists only for workloads in the category, value = score): happy ≥ 80, warning 60–79, unhappy < 60. |

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Descheduler currently runs as a black box: it evicts pods, but operators have no way to see when it acted, why, whether the cluster actually became more balanced, or whether workloads suffered from the evictions.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: descheduler
type: feature
summary: Added a DRS-Lens Grafana dashboard showing the workload happiness score.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
