### PR TITLE
[user-authn] fix queue deadlock

### DIFF
--- a/modules/150-user-authn/hooks/get_dex_user_crds.go
+++ b/modules/150-user-authn/hooks/get_dex_user_crds.go
@@ -27,6 +27,7 @@ import (
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	"github.com/flant/shell-operator/pkg/kube/object_patch"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/utils/ptr"
@@ -156,6 +157,21 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	},
 	Kubernetes: []go_hook.KubernetesConfig{
 		{
+			// Watch the namespace the Password objects live in. On a fresh
+			// cluster it is created by the module's Helm release, which only runs
+			// after this hook (OnBeforeHelm / OperatorStartup). We gate all
+			// Password mutations on this namespace existing (see getDexUsers), and
+			// this binding re-runs the hook the moment Helm creates it so Passwords
+			// are reconciled immediately instead of waiting for the next cron tick.
+			Name:       "namespace",
+			ApiVersion: "v1",
+			Kind:       "Namespace",
+			NameSelector: &types.NameSelector{
+				MatchNames: []string{dexNamespace},
+			},
+			FilterFunc: applyNamespaceNameFilter,
+		},
+		{
 			Name:       "users",
 			ApiVersion: "deckhouse.io/v1",
 			Kind:       "User",
@@ -186,6 +202,16 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 
 func getDexUsers(_ context.Context, input *go_hook.HookInput) error {
 	now := time.Now()
+
+	// dexNamespace is created by the module's Helm release, which runs after this
+	// hook on a fresh cluster (OnBeforeHelm / OperatorStartup). Creating a Password
+	// before the namespace exists fails with "namespaces d8-user-authn not found",
+	// which fails the hook and blocks the /modules/user-authn queue - and with it
+	// OnBeforeHelm - so Helm never creates the namespace, deadlocking the deploy.
+	// Defer all Password mutations until the namespace exists; the "namespace"
+	// binding re-runs the hook as soon as Helm creates it. Values and User status
+	// patches are still written below so Helm can render and create the namespace.
+	namespaceExists := len(input.Snapshots.Get("namespace")) > 0
 
 	users := make([]DexUserInternalValues, 0, len(input.Snapshots.Get("users")))
 	mapOfUsersToGroups := map[string]map[string]bool{}
@@ -349,6 +375,10 @@ func getDexUsers(_ context.Context, input *go_hook.HookInput) error {
 		// incorrectPasswordLoginAttempts, lockedUntil, requireResetHashOnNextSuccLogin)
 		// on an existing object.
 		switch {
+		case !namespaceExists:
+			// Namespace not created by Helm yet: skip the Password mutation. The
+			// user still lands in the internal values and its status is synced
+			// below; the Password will be reconciled once the namespace appears.
 		case passwordExists:
 			reconcileExistingPassword(input, existingPassword, dexUser.Name, email, groups)
 		case isRename:
@@ -384,17 +414,21 @@ func getDexUsers(_ context.Context, input *go_hook.HookInput) error {
 		input.PatchCollector.PatchWithMerge(patchMap, "deckhouse.io/v1", "User", "", dexUser.Name, object_patch.WithSubresource("/status"))
 	}
 
-	// Delete Password objects we own that no user references anymore.
-	for _, password := range allPasswords {
-		if _, expected := expectedPasswordNames[password.Name]; expected {
-			continue
+	// Delete Password objects we own that no user references anymore. Skipped
+	// until the namespace exists: there are no Password objects to clean up yet,
+	// and issuing deletes against a missing namespace would fail the hook.
+	if namespaceExists {
+		for _, password := range allPasswords {
+			if _, expected := expectedPasswordNames[password.Name]; expected {
+				continue
+			}
+			if !isModuleManagedPassword(password) {
+				continue
+			}
+			input.Logger.Info("Deleting orphaned Password",
+				slog.String("name", password.Name), slog.String("username", password.Username))
+			input.PatchCollector.Delete("dex.coreos.com/v1", "Password", password.Namespace, password.Name)
 		}
-		if !isModuleManagedPassword(password) {
-			continue
-		}
-		input.Logger.Info("Deleting orphaned Password",
-			slog.String("name", password.Name), slog.String("username", password.Username))
-		input.PatchCollector.Delete("dex.coreos.com/v1", "Password", password.Namespace, password.Name)
 	}
 
 	input.Values.Set("userAuthn.internal.dexUsersCRDs", users)
@@ -599,6 +633,12 @@ func applyDexUserFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, e
 		return nil, fmt.Errorf("cannot convert kubernetes object: %v", err)
 	}
 	return user, nil
+}
+
+// applyNamespaceNameFilter snapshots only the namespace name: the hook just
+// needs to know whether dexNamespace exists before touching Password objects.
+func applyNamespaceNameFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	return obj.GetName(), nil
 }
 
 func applyPasswordFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {

--- a/modules/150-user-authn/hooks/get_dex_user_crds_test.go
+++ b/modules/150-user-authn/hooks/get_dex_user_crds_test.go
@@ -665,9 +665,64 @@ username: admin
 		})
 	})
 
+	Context("Fresh cluster with a User but no namespace yet", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(`
+---
+apiVersion: deckhouse.io/v1
+kind: User
+metadata:
+  name: admin
+spec:
+  email: admin@example.com
+  password: $2a$10$E/MjyzFi6GZkta9GHd8zCeuYigbLenXv18jkxOZ6vhoWsKnaxNJou
+`))
+			f.RunHook()
+		})
+		It("Should not fail and must defer Password creation until the namespace exists", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			// The namespace is created by Helm only after this hook on a fresh
+			// cluster. Creating a Password before it exists would fail the hook and
+			// deadlock the module queue, so the Password is deferred.
+			Expect(f.KubernetesResource("Password", "d8-user-authn", "mfsg22loibsxqylnobwgkltdn5w4x4u44scceizf").Exists()).To(BeFalse())
+			// Values are still filled so Helm can render and create the namespace.
+			Expect(f.ValuesGet("userAuthn.internal.dexUsersCRDs").String()).ToNot(MatchJSON("[]"))
+		})
+
+		Context("and the namespace appears", func() {
+			BeforeEach(func() {
+				f.BindingContexts.Set(f.KubeStateSet(`
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: d8-user-authn
+---
+apiVersion: deckhouse.io/v1
+kind: User
+metadata:
+  name: admin
+spec:
+  email: admin@example.com
+  password: $2a$10$E/MjyzFi6GZkta9GHd8zCeuYigbLenXv18jkxOZ6vhoWsKnaxNJou
+`))
+				f.RunHook()
+			})
+			It("Should create the Password object once the namespace exists", func() {
+				Expect(f).To(ExecuteSuccessfully())
+				Expect(f.KubernetesResource("Password", "d8-user-authn", "mfsg22loibsxqylnobwgkltdn5w4x4u44scceizf").Exists()).To(BeTrue())
+			})
+		})
+	})
+
 	Context("With a new User and no existing Password", func() {
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSet(`
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: d8-user-authn
 ---
 apiVersion: deckhouse.io/v1
 kind: User
@@ -702,6 +757,11 @@ spec:
 	Context("With an existing user-changed Password and a group change", func() {
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSet(`
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: d8-user-authn
 ---
 apiVersion: deckhouse.io/v1
 kind: User
@@ -766,6 +826,11 @@ username: admin
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSet(`
 ---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: d8-user-authn
+---
 apiVersion: dex.coreos.com/v1
 email: ghost@example.com
 hash: aGFzaA==
@@ -808,6 +873,11 @@ username: external
 			// rotated after account creation, which must survive the rename instead
 			// of being reverted to the immutable creation-time spec.password.
 			f.BindingContexts.Set(f.KubeStateSet(`
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: d8-user-authn
 ---
 apiVersion: deckhouse.io/v1
 kind: User
@@ -865,6 +935,11 @@ username: admin
 			// rejected by the CRD pattern, but the hook must never hard-fail on it:
 			// returning an error would retry forever and block the module queue.
 			f.BindingContexts.Set(f.KubeStateSet(`
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: d8-user-authn
 ---
 apiVersion: deckhouse.io/v1
 kind: User


### PR DESCRIPTION
## Description
On a fresh cluster the `get_dex_user_crds` hook tried to create Dex `Password` objects in the `d8-user-authn` namespace before Helm had created that namespace (the hook runs on `OnBeforeHelm`/`OperatorStartup`, i.e. before the module's Helm release). The create failed with `namespaces "d8-user-authn" not found`, failing the hook and blocking the `/modules/user-authn` queue — which also blocks `OnBeforeHelm`, so Helm never creates the namespace, deadlocking the deploy.

The hook now watches the `d8-user-authn` namespace and defers all `Password` mutations until it exists; the namespace binding re-runs the hook as soon as Helm creates it. Values and `User` status patches are still written on every run so Helm can render and create the namespace.

Does not restart any critical components.

## Why do we need it, and what problem does it solve?
Fixes broken deployment of fresh clusters introduced by #20847.

## Why do we need it in the patch release (if we do)?
Not necessarily

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authn
type: fix
summary: Defer Dex Password reconciliation until the module namespace exists to fix a fresh-cluster deploy deadlock.
impact_level: low