### PR TITLE
[candi] Fixed the mounting of the kubernetes data device

### DIFF
--- a/candi/bashible/common-steps/all/005_integrate_kubernetes_data_device.sh.tpl
+++ b/candi/bashible/common-steps/all/005_integrate_kubernetes_data_device.sh.tpl
@@ -114,23 +114,23 @@ fi
 # Otherwise the `mount | grep $DATA_DEVICE` checks below would fail, because `mount`
 # reports the real path. Example:
 # ```bash
-#     ~# ls -l $DATA_DEVICE
-#        lrwxrwxrwx 1 root root 9 Jul  6 11:27 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_0bfa67a18b15ba86c823528a24dc844d -> ../../sdc
-#     ~# mount | grep $DATA_DEVICE
-#     ~#
-#     ~# DATA_DEVICE=$(resolve_symlink $DATA_DEVICE)
-#     ~# echo $DATA_DEVICE
-#        /dev/sdc
-#     ~# mount | grep $DATA_DEVICE
-#        /dev/sdc on /mnt/kubernetes-data type ext4 (rw,relatime,discard,x-systemd.automount)
+#   ~# ls -l $DATA_DEVICE
+#      lrwxrwxrwx 1 root root 9 Jul  6 11:27 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_0bfa67a18b15ba86c823528a24dc844d -> ../../sdc
+#   ~# mount | grep $DATA_DEVICE
+#   ~#
+#   ~# DATA_DEVICE=$(resolve_symlink $DATA_DEVICE)
+#   ~# echo $DATA_DEVICE
+#      /dev/sdc
+#   ~# mount | grep $DATA_DEVICE
+#      /dev/sdc on /mnt/kubernetes-data type ext4 (rw,relatime,discard,x-systemd.automount)
 # ```
 DATA_DEVICE="$(resolve_symlink "$DATA_DEVICE")"
 
 mkdir -p /mnt/kubernetes-data
 
-# always format the device to ensure it's clean, because etcd will not join the cluster if the device
-# contains a filesystem with etcd database from a previous installation
-# Idempotency: skip formatting if the device is already mounted (see the next step)
+# Always format the device to ensure it's clean, because etcd will not join the cluster if the device
+# contains a filesystem with etcd database from a previous installation.
+# Idempotency: skip formatting if the device is already mounted (in the next step)
 if ! mount | grep -q $DATA_DEVICE; then
   mkfs.ext4 -F -L kubernetes-data $DATA_DEVICE
 fi

--- a/candi/bashible/common-steps/all/005_integrate_kubernetes_data_device.sh.tpl
+++ b/candi/bashible/common-steps/all/005_integrate_kubernetes_data_device.sh.tpl
@@ -130,7 +130,10 @@ mkdir -p /mnt/kubernetes-data
 
 # always format the device to ensure it's clean, because etcd will not join the cluster if the device
 # contains a filesystem with etcd database from a previous installation
-mkfs.ext4 -F -L kubernetes-data $DATA_DEVICE
+# Idempotency: skip formatting if the device is already mounted (see the next step)
+if ! mount | grep -q $DATA_DEVICE; then
+  mkfs.ext4 -F -L kubernetes-data $DATA_DEVICE
+fi
 
 if grep -qv kubernetes-data /etc/fstab; then
   cat >> /etc/fstab << EOF

--- a/candi/bashible/common-steps/all/005_integrate_kubernetes_data_device.sh.tpl
+++ b/candi/bashible/common-steps/all/005_integrate_kubernetes_data_device.sh.tpl
@@ -41,6 +41,16 @@ function get_data_device_secret() {
   fi
 }
 
+function resolve_symlink() {
+    local path="$1"
+
+    if [[ -L "$path" ]]; then
+        readlink -f "$path"
+    else
+        echo "$path"
+    fi
+}
+
 if [[ "$FIRST_BASHIBLE_RUN" != "yes" ]]; then
   exit 0
 fi
@@ -99,6 +109,22 @@ if [ $(wc -l <<< $DATA_DEVICE) -ne 1 ]; then
   >&2 echo "Could not autodetect a single unused disk, candidates: $DATA_DEVICE"
   return 1
 fi
+
+# If $DATA_DEVICE points to a symlink, resolve it to the real device path.
+# Otherwise the `mount | grep $DATA_DEVICE` checks below would fail, because `mount`
+# reports the real path. Example:
+# ```bash
+#     ~# ls -l $DATA_DEVICE
+#        lrwxrwxrwx 1 root root 9 Jul  6 11:27 /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_0bfa67a18b15ba86c823528a24dc844d -> ../../sdc
+#     ~# mount | grep $DATA_DEVICE
+#     ~#
+#     ~# DATA_DEVICE=$(resolve_symlink $DATA_DEVICE)
+#     ~# echo $DATA_DEVICE
+#        /dev/sdc
+#     ~# mount | grep $DATA_DEVICE
+#        /dev/sdc on /mnt/kubernetes-data type ext4 (rw,relatime,discard,x-systemd.automount)
+# ```
+DATA_DEVICE="$(resolve_symlink "$DATA_DEVICE")"
 
 mkdir -p /mnt/kubernetes-data
 


### PR DESCRIPTION
## Description

The PR makes the `005_integrate_kubernetes_data_device.sh.tpl` step idempotent:
1. Added `func resolve_symlink` to resolve symlinks to the real device path. This is required for the `mount | grep $DATA_DEVICE` checks to work correctly, since `mount` reports the real path rather than the symlink ([link](https://github.com/deckhouse/deckhouse/blob/18c5a0046d16f3c4626306e6fa2ffb855e85d770/candi/bashible/common-steps/all/005_integrate_kubernetes_data_device.sh.tpl#L115-L117)).
2. Added a mount check before formatting the device. This prevents the `<device> is mounted; will not make a filesystem here` error when the step is re-run on an already mounted device.

## Why do we need it, and what problem does it solve?

Making the `005_integrate_kubernetes_data_device.sh.tpl` step idempotent so that re-running it does not fail on an already formatted and mounted device.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Made the `005_integrate_kubernetes_data_device.sh.tpl` step idempotent.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
