### PR TITLE
Feature/error on disable confirmation

### DIFF
--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module_config.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module_config.go
@@ -19,6 +19,7 @@ package validation
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"slices"
@@ -613,5 +614,5 @@ func rejectResult(msg string) (*kwhvalidating.ValidatorResult, error) {
 	return &kwhvalidating.ValidatorResult{
 		Valid:   false,
 		Message: msg,
-	}, nil
+	}, errors.New(msg)
 }

--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module_config.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module_config.go
@@ -614,5 +614,5 @@ func rejectResult(msg string) (*kwhvalidating.ValidatorResult, error) {
 	return &kwhvalidating.ValidatorResult{
 		Valid:   false,
 		Message: msg,
-	}, errors.New(msg)
+	}, errors.New("error during resource validation")
 }


### PR DESCRIPTION
## Description

Before:
```bash
Warning: Disabling this module will remove all unseal keys from the cluster. You should back them up if you want to restore a cluster backup.Please annotate ModuleConfig with `modules.deckhouse.io/allow-disabling=true` if you're sure that you want to disable the module.
moduleconfig.deckhouse.io/stronghold configured
```
After:
```
kaf mc-stronghold.yaml
Error from server (InternalError): error when applying patch:
{"metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"deckhouse.io/v1alpha1\",\"kind\":\"ModuleConfig\",\"metadata\":{\"annotations\":{},\"name\":\"stronghold\"},\"spec\":{\"enabled\":false,\"source\":\"deckhouse\"}}\n"}},"spec":{"enabled":false}}
to:
Resource: "deckhouse.io/v1alpha1, Resource=moduleconfigs", GroupVersionKind: "deckhouse.io/v1alpha1, Kind=ModuleConfig"
Name: "stronghold", Namespace: ""
for: "mc-stronghold.yaml": error when patching "mc-stronghold.yaml": Internal error occurred: failed calling webhook "module-configs.deckhouse-webhook.deckhouse.io": failed to call webhook: an error on the server ("{\"kind\":\"AdmissionReview\",\"apiVersion\":\"admission.k8s.io/v1\",\"response\":{\"uid\":\"20f9a8ff-1121-44be-b082-f2d22341902c\",\"allowed\":false,\"status\":{\"metadata\":{},\"status\":\"Failure\",\"message\":\"validator error: error during resource validation\",\"reason\":\"Invalid\",\"code\":422}}}") has prevented the request from succeeding

```
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: Now disabling moduleconfig with confirmation will throw error.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
