### PR TITLE
Fix error handling in module configuration validation by returning an…

### DIFF
--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module_config.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module_config.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"slices"
@@ -325,5 +324,5 @@ func rejectResult(msg string) (*kwhvalidating.ValidatorResult, error) {
 	return &kwhvalidating.ValidatorResult{
 		Valid:   false,
 		Message: msg,
-	}, errors.New("error during resource validation")
+	}, nil
 }

--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module_config.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module_config.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"slices"
@@ -324,5 +325,5 @@ func rejectResult(msg string) (*kwhvalidating.ValidatorResult, error) {
 	return &kwhvalidating.ValidatorResult{
 		Valid:   false,
 		Message: msg,
-	}, nil
+	}, errors.New("error during resource validation")
 }

--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module_config.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module_config.go
@@ -204,7 +204,7 @@ func moduleConfigValidationHandler(
 				// we can disable unknown module without any further check
 				if module, err := moduleStorage.GetModuleByName(obj.GetName()); err == nil {
 					if reason, needConfirm := module.GetConfirmationDisableReason(); needConfirm {
-						warnings = append(warnings, confirmationDisableWarning(reason))
+						return rejectResult(reason)
 					}
 				}
 			}


### PR DESCRIPTION
## Description
Fixed a bug where the user could disable ModuleConfig without confirmation for modules where confirmation was required.

Before:
```bash
Warning: Disabling this module will remove all unseal keys from the cluster. You should back them up if you want to restore a cluster backup.Please annotate ModuleConfig with `modules.deckhouse.io/allow-disabling=true` if you're sure that you want to disable the module.
moduleconfig.deckhouse.io/stronghold configured
```
After:
```bash
Error from server: error when applying patch:
{"metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"deckhouse.io/v1alpha1\",\"kind\":\"ModuleConfig\",\"metadata\":{\"annotations\":{},\"name\":\"stronghold\"},\"spec\":{\"enabled\":false,\"source\":\"deckhouse\"}}\n"}},"spec":{"enabled":false}}
to:
Resource: "deckhouse.io/v1alpha1, Resource=moduleconfigs", GroupVersionKind: "deckhouse.io/v1alpha1, Kind=ModuleConfig"
Name: "stronghold", Namespace: ""
for: "mc-stronghold.yaml": error when patching "mc-stronghold.yaml": admission webhook "module-configs.deckhouse-webhook.deckhouse.io" denied the request: Disabling this module will remove all unseal keys from the cluster. You should back them up if you want to restore a cluster backup.
```

## Why do we need it, and what problem does it solve?
Disabling modules that require confirmation without confirmation may impact cluster operation.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: Disabling modules with confirmation will be rejected without using the annotation.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
