### PR TITLE
[ci] install ssh for svace upload in distroless builder

### DIFF
--- a/.werf/defines/image-build.tmpl
+++ b/.werf/defines/image-build.tmpl
@@ -34,6 +34,12 @@ cat >> .svace-dir/svace.ignore <<EOF
 {{ trim $content }}
 EOF
 {{- end }}
+# Install ssh via pm if missing (distroless builder/golang has no ssh).
+if ! command -v ssh >/dev/null 2>&1; then
+  if command -v pm >/dev/null 2>&1; then
+    pm install ssh-static
+  fi
+fi
 attempt=0
 retries=5
 success=0


### PR DESCRIPTION
## Description
Install `ssh` in the Svace build template when it's missing.

The problem surfaced in the cni-cilium module: its Svace build failed with
`ssh: command not found`. The upload step in `.werf/defines/image-build.tmpl` uses
`ssh`/`rsync`, but after the GOST migration several artifacts moved to the distroless
`builder/golang` base, which has `rsync` but no `ssh`. Since the upload logic is shared,
the break hit every module whose artifacts use that base.

The fix guards the template to install `ssh-static` via `pm` only when `ssh` is absent.
It covers all affected distroless artifacts; bases that already have `ssh` are
untouched.

No runtime/cluster impact — only the build stage.

## Why do we need it, and what problem does it solve?
Without the fix, Svace builds fail ([build fail](https://github.com/deckhouse/deckhouse/actions/runs/28762131225/job/85279413236#step:13:14712))
with `ssh: command not found`. 

## Why do we need it in the patch release (if we do)?
Not necessarily.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: ci
type: chore
summary: Install ssh for Svace upload in the distroless builder.
impact_level: low
```
