### PR TITLE
[docs] Bump DKP CSE version to 1.73.4 in the version menu

### DIFF
--- a/docs/site/_config.yml
+++ b/docs/site/_config.yml
@@ -19,7 +19,7 @@ github_repo_path: /deckhouse/deckhouse
 d8Revision: EE
 LTSChannel:
   version: v1.73-cse
-  versionName: v1.73.3 (CSE)
+  versionName: v1.73.4 (CSE)
 excerpt_separator: ""
 
 metrics:


### PR DESCRIPTION
## Description

Bump DKP CSE version to 1.73.4 in the version menu on the site.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Bump DKP CSE version to 1.73.4 in the version menu on the site.
impact_level: low
```
