### PR TITLE
[ci] Check if used Werf version actually support signing

### DIFF
--- a/.github/ci_templates/build.yml
+++ b/.github/ci_templates/build.yml
@@ -233,21 +233,48 @@ steps:
       IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
     {!{- end }!}
 
-      # Prepare for image and binary signing
-      export WERF_VAULT_AUTH_JWT=$(jq -r .value <<< $(curl -qfsH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=github-access-aud" ))
-      if [ -n "${WERF_VAULT_AUTH_JWT}" ]; then
-        echo "Received Actions token";
-      else
-        echo "Actions token empty";
+      # Check whether current DDK version supports signing
+      sign_minimal_version="v2.71.0-dk"
+      sign_current_version="$(werf version)"
+      sign_supported=true
+      if [[ $sign_minimal_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+        sign_minimal_major=${BASH_REMATCH[1]}
+        sign_minimal_minor=${BASH_REMATCH[2]}
       fi
-      export VAULT_TOKEN="$(curl -sfX POST "${VAULT_ADDR}/v1/auth/${WERF_VAULT_AUTH_PATH}/login" -d '{"role":"'${WERF_VAULT_AUTH_ROLE}'","jwt":"'${WERF_VAULT_AUTH_JWT}'"}' | jq -r '.auth.client_token')"
-      if [ -n "${VAULT_TOKEN}" ]; then
-        echo "Received Vault token";
+      if [[ $sign_current_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+        sign_current_major=${BASH_REMATCH[1]}
+        sign_current_minor=${BASH_REMATCH[2]}
       else
-        echo "Vault token empty";
+        sign_supported=false
       fi
-      export WERF_SIGN_INTERMEDIATES=$(curl -sf "${VAULT_ADDR}/v1/${INTERMEDIARY_CERT_PATH}" | base64 -w0)
-      export WERF_SIGN_CERT=$(curl -sf --header "X-Vault-Token: ${VAULT_TOKEN}" "${VAULT_ADDR}/v1/${SIGNING_CERT_PATH}" | jq -r '.data.certificate' | base64 -w0)
+      if (( sign_current_major < sign_minimal_major )); then
+        sign_supported=false
+      elif (( sign_current_major == sign_minimal_major && sign_current_minor < sign_minimal_minor )); then
+        sign_supported=false
+      fi
+
+      if $sign_supported; then
+        # Prepare for image and binary signing
+        echo "Using WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+        export WERF_VAULT_AUTH_JWT=$(jq -r .value <<< $(curl -qfsH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=github-access-aud" ))
+        if [ -n "${WERF_VAULT_AUTH_JWT}" ]; then
+          echo "Received Actions token";
+        else
+          echo "Actions token empty";
+        fi
+        export VAULT_TOKEN="$(curl -sfX POST "${VAULT_ADDR}/v1/auth/${WERF_VAULT_AUTH_PATH}/login" -d '{"role":"'${WERF_VAULT_AUTH_ROLE}'","jwt":"'${WERF_VAULT_AUTH_JWT}'"}' | jq -r '.auth.client_token')"
+        if [ -n "${VAULT_TOKEN}" ]; then
+          echo "Received Vault token";
+        else
+          echo "Vault token empty";
+        fi
+        export WERF_SIGN_INTERMEDIATES=$(curl -sf "${VAULT_ADDR}/v1/${INTERMEDIARY_CERT_PATH}" | base64 -w0)
+        export WERF_SIGN_CERT=$(curl -sf --header "X-Vault-Token: ${VAULT_TOKEN}" "${VAULT_ADDR}/v1/${SIGNING_CERT_PATH}" | jq -r '.data.certificate' | base64 -w0)
+      else
+        # fallback to non-signed version
+        export WERF_SIGN_MANIFEST="0"
+        echo "Fallback to WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+      fi
 
       type werf && source $(werf ci-env github --verbose --as-file)
       werf build \

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -624,21 +624,48 @@ jobs:
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
           IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          # Prepare for image and binary signing
-          export WERF_VAULT_AUTH_JWT=$(jq -r .value <<< $(curl -qfsH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=github-access-aud" ))
-          if [ -n "${WERF_VAULT_AUTH_JWT}" ]; then
-            echo "Received Actions token";
-          else
-            echo "Actions token empty";
+          # Check whether current DDK version supports signing
+          sign_minimal_version="v2.71.0-dk"
+          sign_current_version="$(werf version)"
+          sign_supported=true
+          if [[ $sign_minimal_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+            sign_minimal_major=${BASH_REMATCH[1]}
+            sign_minimal_minor=${BASH_REMATCH[2]}
           fi
-          export VAULT_TOKEN="$(curl -sfX POST "${VAULT_ADDR}/v1/auth/${WERF_VAULT_AUTH_PATH}/login" -d '{"role":"'${WERF_VAULT_AUTH_ROLE}'","jwt":"'${WERF_VAULT_AUTH_JWT}'"}' | jq -r '.auth.client_token')"
-          if [ -n "${VAULT_TOKEN}" ]; then
-            echo "Received Vault token";
+          if [[ $sign_current_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+            sign_current_major=${BASH_REMATCH[1]}
+            sign_current_minor=${BASH_REMATCH[2]}
           else
-            echo "Vault token empty";
+            sign_supported=false
           fi
-          export WERF_SIGN_INTERMEDIATES=$(curl -sf "${VAULT_ADDR}/v1/${INTERMEDIARY_CERT_PATH}" | base64 -w0)
-          export WERF_SIGN_CERT=$(curl -sf --header "X-Vault-Token: ${VAULT_TOKEN}" "${VAULT_ADDR}/v1/${SIGNING_CERT_PATH}" | jq -r '.data.certificate' | base64 -w0)
+          if (( sign_current_major < sign_minimal_major )); then
+            sign_supported=false
+          elif (( sign_current_major == sign_minimal_major && sign_current_minor < sign_minimal_minor )); then
+            sign_supported=false
+          fi
+
+          if $sign_supported; then
+            # Prepare for image and binary signing
+            echo "Using WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+            export WERF_VAULT_AUTH_JWT=$(jq -r .value <<< $(curl -qfsH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=github-access-aud" ))
+            if [ -n "${WERF_VAULT_AUTH_JWT}" ]; then
+              echo "Received Actions token";
+            else
+              echo "Actions token empty";
+            fi
+            export VAULT_TOKEN="$(curl -sfX POST "${VAULT_ADDR}/v1/auth/${WERF_VAULT_AUTH_PATH}/login" -d '{"role":"'${WERF_VAULT_AUTH_ROLE}'","jwt":"'${WERF_VAULT_AUTH_JWT}'"}' | jq -r '.auth.client_token')"
+            if [ -n "${VAULT_TOKEN}" ]; then
+              echo "Received Vault token";
+            else
+              echo "Vault token empty";
+            fi
+            export WERF_SIGN_INTERMEDIATES=$(curl -sf "${VAULT_ADDR}/v1/${INTERMEDIARY_CERT_PATH}" | base64 -w0)
+            export WERF_SIGN_CERT=$(curl -sf --header "X-Vault-Token: ${VAULT_TOKEN}" "${VAULT_ADDR}/v1/${SIGNING_CERT_PATH}" | jq -r '.data.certificate' | base64 -w0)
+          else
+            # fallback to non-signed version
+            export WERF_SIGN_MANIFEST="0"
+            echo "Fallback to WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+          fi
 
           type werf && source $(werf ci-env github --verbose --as-file)
           werf build \
@@ -1297,21 +1324,48 @@ jobs:
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
           IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          # Prepare for image and binary signing
-          export WERF_VAULT_AUTH_JWT=$(jq -r .value <<< $(curl -qfsH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=github-access-aud" ))
-          if [ -n "${WERF_VAULT_AUTH_JWT}" ]; then
-            echo "Received Actions token";
-          else
-            echo "Actions token empty";
+          # Check whether current DDK version supports signing
+          sign_minimal_version="v2.71.0-dk"
+          sign_current_version="$(werf version)"
+          sign_supported=true
+          if [[ $sign_minimal_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+            sign_minimal_major=${BASH_REMATCH[1]}
+            sign_minimal_minor=${BASH_REMATCH[2]}
           fi
-          export VAULT_TOKEN="$(curl -sfX POST "${VAULT_ADDR}/v1/auth/${WERF_VAULT_AUTH_PATH}/login" -d '{"role":"'${WERF_VAULT_AUTH_ROLE}'","jwt":"'${WERF_VAULT_AUTH_JWT}'"}' | jq -r '.auth.client_token')"
-          if [ -n "${VAULT_TOKEN}" ]; then
-            echo "Received Vault token";
+          if [[ $sign_current_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+            sign_current_major=${BASH_REMATCH[1]}
+            sign_current_minor=${BASH_REMATCH[2]}
           else
-            echo "Vault token empty";
+            sign_supported=false
           fi
-          export WERF_SIGN_INTERMEDIATES=$(curl -sf "${VAULT_ADDR}/v1/${INTERMEDIARY_CERT_PATH}" | base64 -w0)
-          export WERF_SIGN_CERT=$(curl -sf --header "X-Vault-Token: ${VAULT_TOKEN}" "${VAULT_ADDR}/v1/${SIGNING_CERT_PATH}" | jq -r '.data.certificate' | base64 -w0)
+          if (( sign_current_major < sign_minimal_major )); then
+            sign_supported=false
+          elif (( sign_current_major == sign_minimal_major && sign_current_minor < sign_minimal_minor )); then
+            sign_supported=false
+          fi
+
+          if $sign_supported; then
+            # Prepare for image and binary signing
+            echo "Using WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+            export WERF_VAULT_AUTH_JWT=$(jq -r .value <<< $(curl -qfsH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=github-access-aud" ))
+            if [ -n "${WERF_VAULT_AUTH_JWT}" ]; then
+              echo "Received Actions token";
+            else
+              echo "Actions token empty";
+            fi
+            export VAULT_TOKEN="$(curl -sfX POST "${VAULT_ADDR}/v1/auth/${WERF_VAULT_AUTH_PATH}/login" -d '{"role":"'${WERF_VAULT_AUTH_ROLE}'","jwt":"'${WERF_VAULT_AUTH_JWT}'"}' | jq -r '.auth.client_token')"
+            if [ -n "${VAULT_TOKEN}" ]; then
+              echo "Received Vault token";
+            else
+              echo "Vault token empty";
+            fi
+            export WERF_SIGN_INTERMEDIATES=$(curl -sf "${VAULT_ADDR}/v1/${INTERMEDIARY_CERT_PATH}" | base64 -w0)
+            export WERF_SIGN_CERT=$(curl -sf --header "X-Vault-Token: ${VAULT_TOKEN}" "${VAULT_ADDR}/v1/${SIGNING_CERT_PATH}" | jq -r '.data.certificate' | base64 -w0)
+          else
+            # fallback to non-signed version
+            export WERF_SIGN_MANIFEST="0"
+            echo "Fallback to WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+          fi
 
           type werf && source $(werf ci-env github --verbose --as-file)
           werf build \
@@ -1638,21 +1692,48 @@ jobs:
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
           IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          # Prepare for image and binary signing
-          export WERF_VAULT_AUTH_JWT=$(jq -r .value <<< $(curl -qfsH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=github-access-aud" ))
-          if [ -n "${WERF_VAULT_AUTH_JWT}" ]; then
-            echo "Received Actions token";
-          else
-            echo "Actions token empty";
+          # Check whether current DDK version supports signing
+          sign_minimal_version="v2.71.0-dk"
+          sign_current_version="$(werf version)"
+          sign_supported=true
+          if [[ $sign_minimal_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+            sign_minimal_major=${BASH_REMATCH[1]}
+            sign_minimal_minor=${BASH_REMATCH[2]}
           fi
-          export VAULT_TOKEN="$(curl -sfX POST "${VAULT_ADDR}/v1/auth/${WERF_VAULT_AUTH_PATH}/login" -d '{"role":"'${WERF_VAULT_AUTH_ROLE}'","jwt":"'${WERF_VAULT_AUTH_JWT}'"}' | jq -r '.auth.client_token')"
-          if [ -n "${VAULT_TOKEN}" ]; then
-            echo "Received Vault token";
+          if [[ $sign_current_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+            sign_current_major=${BASH_REMATCH[1]}
+            sign_current_minor=${BASH_REMATCH[2]}
           else
-            echo "Vault token empty";
+            sign_supported=false
           fi
-          export WERF_SIGN_INTERMEDIATES=$(curl -sf "${VAULT_ADDR}/v1/${INTERMEDIARY_CERT_PATH}" | base64 -w0)
-          export WERF_SIGN_CERT=$(curl -sf --header "X-Vault-Token: ${VAULT_TOKEN}" "${VAULT_ADDR}/v1/${SIGNING_CERT_PATH}" | jq -r '.data.certificate' | base64 -w0)
+          if (( sign_current_major < sign_minimal_major )); then
+            sign_supported=false
+          elif (( sign_current_major == sign_minimal_major && sign_current_minor < sign_minimal_minor )); then
+            sign_supported=false
+          fi
+
+          if $sign_supported; then
+            # Prepare for image and binary signing
+            echo "Using WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+            export WERF_VAULT_AUTH_JWT=$(jq -r .value <<< $(curl -qfsH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=github-access-aud" ))
+            if [ -n "${WERF_VAULT_AUTH_JWT}" ]; then
+              echo "Received Actions token";
+            else
+              echo "Actions token empty";
+            fi
+            export VAULT_TOKEN="$(curl -sfX POST "${VAULT_ADDR}/v1/auth/${WERF_VAULT_AUTH_PATH}/login" -d '{"role":"'${WERF_VAULT_AUTH_ROLE}'","jwt":"'${WERF_VAULT_AUTH_JWT}'"}' | jq -r '.auth.client_token')"
+            if [ -n "${VAULT_TOKEN}" ]; then
+              echo "Received Vault token";
+            else
+              echo "Vault token empty";
+            fi
+            export WERF_SIGN_INTERMEDIATES=$(curl -sf "${VAULT_ADDR}/v1/${INTERMEDIARY_CERT_PATH}" | base64 -w0)
+            export WERF_SIGN_CERT=$(curl -sf --header "X-Vault-Token: ${VAULT_TOKEN}" "${VAULT_ADDR}/v1/${SIGNING_CERT_PATH}" | jq -r '.data.certificate' | base64 -w0)
+          else
+            # fallback to non-signed version
+            export WERF_SIGN_MANIFEST="0"
+            echo "Fallback to WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+          fi
 
           type werf && source $(werf ci-env github --verbose --as-file)
           werf build \
@@ -1979,21 +2060,48 @@ jobs:
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
           IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          # Prepare for image and binary signing
-          export WERF_VAULT_AUTH_JWT=$(jq -r .value <<< $(curl -qfsH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=github-access-aud" ))
-          if [ -n "${WERF_VAULT_AUTH_JWT}" ]; then
-            echo "Received Actions token";
-          else
-            echo "Actions token empty";
+          # Check whether current DDK version supports signing
+          sign_minimal_version="v2.71.0-dk"
+          sign_current_version="$(werf version)"
+          sign_supported=true
+          if [[ $sign_minimal_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+            sign_minimal_major=${BASH_REMATCH[1]}
+            sign_minimal_minor=${BASH_REMATCH[2]}
           fi
-          export VAULT_TOKEN="$(curl -sfX POST "${VAULT_ADDR}/v1/auth/${WERF_VAULT_AUTH_PATH}/login" -d '{"role":"'${WERF_VAULT_AUTH_ROLE}'","jwt":"'${WERF_VAULT_AUTH_JWT}'"}' | jq -r '.auth.client_token')"
-          if [ -n "${VAULT_TOKEN}" ]; then
-            echo "Received Vault token";
+          if [[ $sign_current_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+            sign_current_major=${BASH_REMATCH[1]}
+            sign_current_minor=${BASH_REMATCH[2]}
           else
-            echo "Vault token empty";
+            sign_supported=false
           fi
-          export WERF_SIGN_INTERMEDIATES=$(curl -sf "${VAULT_ADDR}/v1/${INTERMEDIARY_CERT_PATH}" | base64 -w0)
-          export WERF_SIGN_CERT=$(curl -sf --header "X-Vault-Token: ${VAULT_TOKEN}" "${VAULT_ADDR}/v1/${SIGNING_CERT_PATH}" | jq -r '.data.certificate' | base64 -w0)
+          if (( sign_current_major < sign_minimal_major )); then
+            sign_supported=false
+          elif (( sign_current_major == sign_minimal_major && sign_current_minor < sign_minimal_minor )); then
+            sign_supported=false
+          fi
+
+          if $sign_supported; then
+            # Prepare for image and binary signing
+            echo "Using WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+            export WERF_VAULT_AUTH_JWT=$(jq -r .value <<< $(curl -qfsH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=github-access-aud" ))
+            if [ -n "${WERF_VAULT_AUTH_JWT}" ]; then
+              echo "Received Actions token";
+            else
+              echo "Actions token empty";
+            fi
+            export VAULT_TOKEN="$(curl -sfX POST "${VAULT_ADDR}/v1/auth/${WERF_VAULT_AUTH_PATH}/login" -d '{"role":"'${WERF_VAULT_AUTH_ROLE}'","jwt":"'${WERF_VAULT_AUTH_JWT}'"}' | jq -r '.auth.client_token')"
+            if [ -n "${VAULT_TOKEN}" ]; then
+              echo "Received Vault token";
+            else
+              echo "Vault token empty";
+            fi
+            export WERF_SIGN_INTERMEDIATES=$(curl -sf "${VAULT_ADDR}/v1/${INTERMEDIARY_CERT_PATH}" | base64 -w0)
+            export WERF_SIGN_CERT=$(curl -sf --header "X-Vault-Token: ${VAULT_TOKEN}" "${VAULT_ADDR}/v1/${SIGNING_CERT_PATH}" | jq -r '.data.certificate' | base64 -w0)
+          else
+            # fallback to non-signed version
+            export WERF_SIGN_MANIFEST="0"
+            echo "Fallback to WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+          fi
 
           type werf && source $(werf ci-env github --verbose --as-file)
           werf build \
@@ -2320,21 +2428,48 @@ jobs:
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
           IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          # Prepare for image and binary signing
-          export WERF_VAULT_AUTH_JWT=$(jq -r .value <<< $(curl -qfsH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=github-access-aud" ))
-          if [ -n "${WERF_VAULT_AUTH_JWT}" ]; then
-            echo "Received Actions token";
-          else
-            echo "Actions token empty";
+          # Check whether current DDK version supports signing
+          sign_minimal_version="v2.71.0-dk"
+          sign_current_version="$(werf version)"
+          sign_supported=true
+          if [[ $sign_minimal_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+            sign_minimal_major=${BASH_REMATCH[1]}
+            sign_minimal_minor=${BASH_REMATCH[2]}
           fi
-          export VAULT_TOKEN="$(curl -sfX POST "${VAULT_ADDR}/v1/auth/${WERF_VAULT_AUTH_PATH}/login" -d '{"role":"'${WERF_VAULT_AUTH_ROLE}'","jwt":"'${WERF_VAULT_AUTH_JWT}'"}' | jq -r '.auth.client_token')"
-          if [ -n "${VAULT_TOKEN}" ]; then
-            echo "Received Vault token";
+          if [[ $sign_current_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+            sign_current_major=${BASH_REMATCH[1]}
+            sign_current_minor=${BASH_REMATCH[2]}
           else
-            echo "Vault token empty";
+            sign_supported=false
           fi
-          export WERF_SIGN_INTERMEDIATES=$(curl -sf "${VAULT_ADDR}/v1/${INTERMEDIARY_CERT_PATH}" | base64 -w0)
-          export WERF_SIGN_CERT=$(curl -sf --header "X-Vault-Token: ${VAULT_TOKEN}" "${VAULT_ADDR}/v1/${SIGNING_CERT_PATH}" | jq -r '.data.certificate' | base64 -w0)
+          if (( sign_current_major < sign_minimal_major )); then
+            sign_supported=false
+          elif (( sign_current_major == sign_minimal_major && sign_current_minor < sign_minimal_minor )); then
+            sign_supported=false
+          fi
+
+          if $sign_supported; then
+            # Prepare for image and binary signing
+            echo "Using WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+            export WERF_VAULT_AUTH_JWT=$(jq -r .value <<< $(curl -qfsH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=github-access-aud" ))
+            if [ -n "${WERF_VAULT_AUTH_JWT}" ]; then
+              echo "Received Actions token";
+            else
+              echo "Actions token empty";
+            fi
+            export VAULT_TOKEN="$(curl -sfX POST "${VAULT_ADDR}/v1/auth/${WERF_VAULT_AUTH_PATH}/login" -d '{"role":"'${WERF_VAULT_AUTH_ROLE}'","jwt":"'${WERF_VAULT_AUTH_JWT}'"}' | jq -r '.auth.client_token')"
+            if [ -n "${VAULT_TOKEN}" ]; then
+              echo "Received Vault token";
+            else
+              echo "Vault token empty";
+            fi
+            export WERF_SIGN_INTERMEDIATES=$(curl -sf "${VAULT_ADDR}/v1/${INTERMEDIARY_CERT_PATH}" | base64 -w0)
+            export WERF_SIGN_CERT=$(curl -sf --header "X-Vault-Token: ${VAULT_TOKEN}" "${VAULT_ADDR}/v1/${SIGNING_CERT_PATH}" | jq -r '.data.certificate' | base64 -w0)
+          else
+            # fallback to non-signed version
+            export WERF_SIGN_MANIFEST="0"
+            echo "Fallback to WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+          fi
 
           type werf && source $(werf ci-env github --verbose --as-file)
           werf build \
@@ -2661,21 +2796,48 @@ jobs:
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
           IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          # Prepare for image and binary signing
-          export WERF_VAULT_AUTH_JWT=$(jq -r .value <<< $(curl -qfsH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=github-access-aud" ))
-          if [ -n "${WERF_VAULT_AUTH_JWT}" ]; then
-            echo "Received Actions token";
-          else
-            echo "Actions token empty";
+          # Check whether current DDK version supports signing
+          sign_minimal_version="v2.71.0-dk"
+          sign_current_version="$(werf version)"
+          sign_supported=true
+          if [[ $sign_minimal_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+            sign_minimal_major=${BASH_REMATCH[1]}
+            sign_minimal_minor=${BASH_REMATCH[2]}
           fi
-          export VAULT_TOKEN="$(curl -sfX POST "${VAULT_ADDR}/v1/auth/${WERF_VAULT_AUTH_PATH}/login" -d '{"role":"'${WERF_VAULT_AUTH_ROLE}'","jwt":"'${WERF_VAULT_AUTH_JWT}'"}' | jq -r '.auth.client_token')"
-          if [ -n "${VAULT_TOKEN}" ]; then
-            echo "Received Vault token";
+          if [[ $sign_current_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+            sign_current_major=${BASH_REMATCH[1]}
+            sign_current_minor=${BASH_REMATCH[2]}
           else
-            echo "Vault token empty";
+            sign_supported=false
           fi
-          export WERF_SIGN_INTERMEDIATES=$(curl -sf "${VAULT_ADDR}/v1/${INTERMEDIARY_CERT_PATH}" | base64 -w0)
-          export WERF_SIGN_CERT=$(curl -sf --header "X-Vault-Token: ${VAULT_TOKEN}" "${VAULT_ADDR}/v1/${SIGNING_CERT_PATH}" | jq -r '.data.certificate' | base64 -w0)
+          if (( sign_current_major < sign_minimal_major )); then
+            sign_supported=false
+          elif (( sign_current_major == sign_minimal_major && sign_current_minor < sign_minimal_minor )); then
+            sign_supported=false
+          fi
+
+          if $sign_supported; then
+            # Prepare for image and binary signing
+            echo "Using WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+            export WERF_VAULT_AUTH_JWT=$(jq -r .value <<< $(curl -qfsH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=github-access-aud" ))
+            if [ -n "${WERF_VAULT_AUTH_JWT}" ]; then
+              echo "Received Actions token";
+            else
+              echo "Actions token empty";
+            fi
+            export VAULT_TOKEN="$(curl -sfX POST "${VAULT_ADDR}/v1/auth/${WERF_VAULT_AUTH_PATH}/login" -d '{"role":"'${WERF_VAULT_AUTH_ROLE}'","jwt":"'${WERF_VAULT_AUTH_JWT}'"}' | jq -r '.auth.client_token')"
+            if [ -n "${VAULT_TOKEN}" ]; then
+              echo "Received Vault token";
+            else
+              echo "Vault token empty";
+            fi
+            export WERF_SIGN_INTERMEDIATES=$(curl -sf "${VAULT_ADDR}/v1/${INTERMEDIARY_CERT_PATH}" | base64 -w0)
+            export WERF_SIGN_CERT=$(curl -sf --header "X-Vault-Token: ${VAULT_TOKEN}" "${VAULT_ADDR}/v1/${SIGNING_CERT_PATH}" | jq -r '.data.certificate' | base64 -w0)
+          else
+            # fallback to non-signed version
+            export WERF_SIGN_MANIFEST="0"
+            echo "Fallback to WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+          fi
 
           type werf && source $(werf ci-env github --verbose --as-file)
           werf build \
@@ -3002,21 +3164,48 @@ jobs:
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
           IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          # Prepare for image and binary signing
-          export WERF_VAULT_AUTH_JWT=$(jq -r .value <<< $(curl -qfsH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=github-access-aud" ))
-          if [ -n "${WERF_VAULT_AUTH_JWT}" ]; then
-            echo "Received Actions token";
-          else
-            echo "Actions token empty";
+          # Check whether current DDK version supports signing
+          sign_minimal_version="v2.71.0-dk"
+          sign_current_version="$(werf version)"
+          sign_supported=true
+          if [[ $sign_minimal_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+            sign_minimal_major=${BASH_REMATCH[1]}
+            sign_minimal_minor=${BASH_REMATCH[2]}
           fi
-          export VAULT_TOKEN="$(curl -sfX POST "${VAULT_ADDR}/v1/auth/${WERF_VAULT_AUTH_PATH}/login" -d '{"role":"'${WERF_VAULT_AUTH_ROLE}'","jwt":"'${WERF_VAULT_AUTH_JWT}'"}' | jq -r '.auth.client_token')"
-          if [ -n "${VAULT_TOKEN}" ]; then
-            echo "Received Vault token";
+          if [[ $sign_current_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+            sign_current_major=${BASH_REMATCH[1]}
+            sign_current_minor=${BASH_REMATCH[2]}
           else
-            echo "Vault token empty";
+            sign_supported=false
           fi
-          export WERF_SIGN_INTERMEDIATES=$(curl -sf "${VAULT_ADDR}/v1/${INTERMEDIARY_CERT_PATH}" | base64 -w0)
-          export WERF_SIGN_CERT=$(curl -sf --header "X-Vault-Token: ${VAULT_TOKEN}" "${VAULT_ADDR}/v1/${SIGNING_CERT_PATH}" | jq -r '.data.certificate' | base64 -w0)
+          if (( sign_current_major < sign_minimal_major )); then
+            sign_supported=false
+          elif (( sign_current_major == sign_minimal_major && sign_current_minor < sign_minimal_minor )); then
+            sign_supported=false
+          fi
+
+          if $sign_supported; then
+            # Prepare for image and binary signing
+            echo "Using WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+            export WERF_VAULT_AUTH_JWT=$(jq -r .value <<< $(curl -qfsH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=github-access-aud" ))
+            if [ -n "${WERF_VAULT_AUTH_JWT}" ]; then
+              echo "Received Actions token";
+            else
+              echo "Actions token empty";
+            fi
+            export VAULT_TOKEN="$(curl -sfX POST "${VAULT_ADDR}/v1/auth/${WERF_VAULT_AUTH_PATH}/login" -d '{"role":"'${WERF_VAULT_AUTH_ROLE}'","jwt":"'${WERF_VAULT_AUTH_JWT}'"}' | jq -r '.auth.client_token')"
+            if [ -n "${VAULT_TOKEN}" ]; then
+              echo "Received Vault token";
+            else
+              echo "Vault token empty";
+            fi
+            export WERF_SIGN_INTERMEDIATES=$(curl -sf "${VAULT_ADDR}/v1/${INTERMEDIARY_CERT_PATH}" | base64 -w0)
+            export WERF_SIGN_CERT=$(curl -sf --header "X-Vault-Token: ${VAULT_TOKEN}" "${VAULT_ADDR}/v1/${SIGNING_CERT_PATH}" | jq -r '.data.certificate' | base64 -w0)
+          else
+            # fallback to non-signed version
+            export WERF_SIGN_MANIFEST="0"
+            echo "Fallback to WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+          fi
 
           type werf && source $(werf ci-env github --verbose --as-file)
           werf build \

--- a/.github/workflows/build-and-test_main.yml
+++ b/.github/workflows/build-and-test_main.yml
@@ -389,21 +389,48 @@ jobs:
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
           IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          # Prepare for image and binary signing
-          export WERF_VAULT_AUTH_JWT=$(jq -r .value <<< $(curl -qfsH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=github-access-aud" ))
-          if [ -n "${WERF_VAULT_AUTH_JWT}" ]; then
-            echo "Received Actions token";
-          else
-            echo "Actions token empty";
+          # Check whether current DDK version supports signing
+          sign_minimal_version="v2.71.0-dk"
+          sign_current_version="$(werf version)"
+          sign_supported=true
+          if [[ $sign_minimal_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+            sign_minimal_major=${BASH_REMATCH[1]}
+            sign_minimal_minor=${BASH_REMATCH[2]}
           fi
-          export VAULT_TOKEN="$(curl -sfX POST "${VAULT_ADDR}/v1/auth/${WERF_VAULT_AUTH_PATH}/login" -d '{"role":"'${WERF_VAULT_AUTH_ROLE}'","jwt":"'${WERF_VAULT_AUTH_JWT}'"}' | jq -r '.auth.client_token')"
-          if [ -n "${VAULT_TOKEN}" ]; then
-            echo "Received Vault token";
+          if [[ $sign_current_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+            sign_current_major=${BASH_REMATCH[1]}
+            sign_current_minor=${BASH_REMATCH[2]}
           else
-            echo "Vault token empty";
+            sign_supported=false
           fi
-          export WERF_SIGN_INTERMEDIATES=$(curl -sf "${VAULT_ADDR}/v1/${INTERMEDIARY_CERT_PATH}" | base64 -w0)
-          export WERF_SIGN_CERT=$(curl -sf --header "X-Vault-Token: ${VAULT_TOKEN}" "${VAULT_ADDR}/v1/${SIGNING_CERT_PATH}" | jq -r '.data.certificate' | base64 -w0)
+          if (( sign_current_major < sign_minimal_major )); then
+            sign_supported=false
+          elif (( sign_current_major == sign_minimal_major && sign_current_minor < sign_minimal_minor )); then
+            sign_supported=false
+          fi
+
+          if $sign_supported; then
+            # Prepare for image and binary signing
+            echo "Using WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+            export WERF_VAULT_AUTH_JWT=$(jq -r .value <<< $(curl -qfsH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=github-access-aud" ))
+            if [ -n "${WERF_VAULT_AUTH_JWT}" ]; then
+              echo "Received Actions token";
+            else
+              echo "Actions token empty";
+            fi
+            export VAULT_TOKEN="$(curl -sfX POST "${VAULT_ADDR}/v1/auth/${WERF_VAULT_AUTH_PATH}/login" -d '{"role":"'${WERF_VAULT_AUTH_ROLE}'","jwt":"'${WERF_VAULT_AUTH_JWT}'"}' | jq -r '.auth.client_token')"
+            if [ -n "${VAULT_TOKEN}" ]; then
+              echo "Received Vault token";
+            else
+              echo "Vault token empty";
+            fi
+            export WERF_SIGN_INTERMEDIATES=$(curl -sf "${VAULT_ADDR}/v1/${INTERMEDIARY_CERT_PATH}" | base64 -w0)
+            export WERF_SIGN_CERT=$(curl -sf --header "X-Vault-Token: ${VAULT_TOKEN}" "${VAULT_ADDR}/v1/${SIGNING_CERT_PATH}" | jq -r '.data.certificate' | base64 -w0)
+          else
+            # fallback to non-signed version
+            export WERF_SIGN_MANIFEST="0"
+            echo "Fallback to WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+          fi
 
           type werf && source $(werf ci-env github --verbose --as-file)
           werf build \

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -389,21 +389,48 @@ jobs:
           IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           export WERF_DISABLE_META_TAGS=true
 
-          # Prepare for image and binary signing
-          export WERF_VAULT_AUTH_JWT=$(jq -r .value <<< $(curl -qfsH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=github-access-aud" ))
-          if [ -n "${WERF_VAULT_AUTH_JWT}" ]; then
-            echo "Received Actions token";
-          else
-            echo "Actions token empty";
+          # Check whether current DDK version supports signing
+          sign_minimal_version="v2.71.0-dk"
+          sign_current_version="$(werf version)"
+          sign_supported=true
+          if [[ $sign_minimal_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+            sign_minimal_major=${BASH_REMATCH[1]}
+            sign_minimal_minor=${BASH_REMATCH[2]}
           fi
-          export VAULT_TOKEN="$(curl -sfX POST "${VAULT_ADDR}/v1/auth/${WERF_VAULT_AUTH_PATH}/login" -d '{"role":"'${WERF_VAULT_AUTH_ROLE}'","jwt":"'${WERF_VAULT_AUTH_JWT}'"}' | jq -r '.auth.client_token')"
-          if [ -n "${VAULT_TOKEN}" ]; then
-            echo "Received Vault token";
+          if [[ $sign_current_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+            sign_current_major=${BASH_REMATCH[1]}
+            sign_current_minor=${BASH_REMATCH[2]}
           else
-            echo "Vault token empty";
+            sign_supported=false
           fi
-          export WERF_SIGN_INTERMEDIATES=$(curl -sf "${VAULT_ADDR}/v1/${INTERMEDIARY_CERT_PATH}" | base64 -w0)
-          export WERF_SIGN_CERT=$(curl -sf --header "X-Vault-Token: ${VAULT_TOKEN}" "${VAULT_ADDR}/v1/${SIGNING_CERT_PATH}" | jq -r '.data.certificate' | base64 -w0)
+          if (( sign_current_major < sign_minimal_major )); then
+            sign_supported=false
+          elif (( sign_current_major == sign_minimal_major && sign_current_minor < sign_minimal_minor )); then
+            sign_supported=false
+          fi
+
+          if $sign_supported; then
+            # Prepare for image and binary signing
+            echo "Using WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+            export WERF_VAULT_AUTH_JWT=$(jq -r .value <<< $(curl -qfsH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=github-access-aud" ))
+            if [ -n "${WERF_VAULT_AUTH_JWT}" ]; then
+              echo "Received Actions token";
+            else
+              echo "Actions token empty";
+            fi
+            export VAULT_TOKEN="$(curl -sfX POST "${VAULT_ADDR}/v1/auth/${WERF_VAULT_AUTH_PATH}/login" -d '{"role":"'${WERF_VAULT_AUTH_ROLE}'","jwt":"'${WERF_VAULT_AUTH_JWT}'"}' | jq -r '.auth.client_token')"
+            if [ -n "${VAULT_TOKEN}" ]; then
+              echo "Received Vault token";
+            else
+              echo "Vault token empty";
+            fi
+            export WERF_SIGN_INTERMEDIATES=$(curl -sf "${VAULT_ADDR}/v1/${INTERMEDIARY_CERT_PATH}" | base64 -w0)
+            export WERF_SIGN_CERT=$(curl -sf --header "X-Vault-Token: ${VAULT_TOKEN}" "${VAULT_ADDR}/v1/${SIGNING_CERT_PATH}" | jq -r '.data.certificate' | base64 -w0)
+          else
+            # fallback to non-signed version
+            export WERF_SIGN_MANIFEST="0"
+            echo "Fallback to WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+          fi
 
           type werf && source $(werf ci-env github --verbose --as-file)
           werf build \
@@ -1031,21 +1058,48 @@ jobs:
           IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           export WERF_DISABLE_META_TAGS=true
 
-          # Prepare for image and binary signing
-          export WERF_VAULT_AUTH_JWT=$(jq -r .value <<< $(curl -qfsH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=github-access-aud" ))
-          if [ -n "${WERF_VAULT_AUTH_JWT}" ]; then
-            echo "Received Actions token";
-          else
-            echo "Actions token empty";
+          # Check whether current DDK version supports signing
+          sign_minimal_version="v2.71.0-dk"
+          sign_current_version="$(werf version)"
+          sign_supported=true
+          if [[ $sign_minimal_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+            sign_minimal_major=${BASH_REMATCH[1]}
+            sign_minimal_minor=${BASH_REMATCH[2]}
           fi
-          export VAULT_TOKEN="$(curl -sfX POST "${VAULT_ADDR}/v1/auth/${WERF_VAULT_AUTH_PATH}/login" -d '{"role":"'${WERF_VAULT_AUTH_ROLE}'","jwt":"'${WERF_VAULT_AUTH_JWT}'"}' | jq -r '.auth.client_token')"
-          if [ -n "${VAULT_TOKEN}" ]; then
-            echo "Received Vault token";
+          if [[ $sign_current_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+            sign_current_major=${BASH_REMATCH[1]}
+            sign_current_minor=${BASH_REMATCH[2]}
           else
-            echo "Vault token empty";
+            sign_supported=false
           fi
-          export WERF_SIGN_INTERMEDIATES=$(curl -sf "${VAULT_ADDR}/v1/${INTERMEDIARY_CERT_PATH}" | base64 -w0)
-          export WERF_SIGN_CERT=$(curl -sf --header "X-Vault-Token: ${VAULT_TOKEN}" "${VAULT_ADDR}/v1/${SIGNING_CERT_PATH}" | jq -r '.data.certificate' | base64 -w0)
+          if (( sign_current_major < sign_minimal_major )); then
+            sign_supported=false
+          elif (( sign_current_major == sign_minimal_major && sign_current_minor < sign_minimal_minor )); then
+            sign_supported=false
+          fi
+
+          if $sign_supported; then
+            # Prepare for image and binary signing
+            echo "Using WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+            export WERF_VAULT_AUTH_JWT=$(jq -r .value <<< $(curl -qfsH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=github-access-aud" ))
+            if [ -n "${WERF_VAULT_AUTH_JWT}" ]; then
+              echo "Received Actions token";
+            else
+              echo "Actions token empty";
+            fi
+            export VAULT_TOKEN="$(curl -sfX POST "${VAULT_ADDR}/v1/auth/${WERF_VAULT_AUTH_PATH}/login" -d '{"role":"'${WERF_VAULT_AUTH_ROLE}'","jwt":"'${WERF_VAULT_AUTH_JWT}'"}' | jq -r '.auth.client_token')"
+            if [ -n "${VAULT_TOKEN}" ]; then
+              echo "Received Vault token";
+            else
+              echo "Vault token empty";
+            fi
+            export WERF_SIGN_INTERMEDIATES=$(curl -sf "${VAULT_ADDR}/v1/${INTERMEDIARY_CERT_PATH}" | base64 -w0)
+            export WERF_SIGN_CERT=$(curl -sf --header "X-Vault-Token: ${VAULT_TOKEN}" "${VAULT_ADDR}/v1/${SIGNING_CERT_PATH}" | jq -r '.data.certificate' | base64 -w0)
+          else
+            # fallback to non-signed version
+            export WERF_SIGN_MANIFEST="0"
+            echo "Fallback to WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+          fi
 
           type werf && source $(werf ci-env github --verbose --as-file)
           werf build \
@@ -1380,21 +1434,48 @@ jobs:
           IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           export WERF_DISABLE_META_TAGS=true
 
-          # Prepare for image and binary signing
-          export WERF_VAULT_AUTH_JWT=$(jq -r .value <<< $(curl -qfsH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=github-access-aud" ))
-          if [ -n "${WERF_VAULT_AUTH_JWT}" ]; then
-            echo "Received Actions token";
-          else
-            echo "Actions token empty";
+          # Check whether current DDK version supports signing
+          sign_minimal_version="v2.71.0-dk"
+          sign_current_version="$(werf version)"
+          sign_supported=true
+          if [[ $sign_minimal_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+            sign_minimal_major=${BASH_REMATCH[1]}
+            sign_minimal_minor=${BASH_REMATCH[2]}
           fi
-          export VAULT_TOKEN="$(curl -sfX POST "${VAULT_ADDR}/v1/auth/${WERF_VAULT_AUTH_PATH}/login" -d '{"role":"'${WERF_VAULT_AUTH_ROLE}'","jwt":"'${WERF_VAULT_AUTH_JWT}'"}' | jq -r '.auth.client_token')"
-          if [ -n "${VAULT_TOKEN}" ]; then
-            echo "Received Vault token";
+          if [[ $sign_current_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+            sign_current_major=${BASH_REMATCH[1]}
+            sign_current_minor=${BASH_REMATCH[2]}
           else
-            echo "Vault token empty";
+            sign_supported=false
           fi
-          export WERF_SIGN_INTERMEDIATES=$(curl -sf "${VAULT_ADDR}/v1/${INTERMEDIARY_CERT_PATH}" | base64 -w0)
-          export WERF_SIGN_CERT=$(curl -sf --header "X-Vault-Token: ${VAULT_TOKEN}" "${VAULT_ADDR}/v1/${SIGNING_CERT_PATH}" | jq -r '.data.certificate' | base64 -w0)
+          if (( sign_current_major < sign_minimal_major )); then
+            sign_supported=false
+          elif (( sign_current_major == sign_minimal_major && sign_current_minor < sign_minimal_minor )); then
+            sign_supported=false
+          fi
+
+          if $sign_supported; then
+            # Prepare for image and binary signing
+            echo "Using WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+            export WERF_VAULT_AUTH_JWT=$(jq -r .value <<< $(curl -qfsH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=github-access-aud" ))
+            if [ -n "${WERF_VAULT_AUTH_JWT}" ]; then
+              echo "Received Actions token";
+            else
+              echo "Actions token empty";
+            fi
+            export VAULT_TOKEN="$(curl -sfX POST "${VAULT_ADDR}/v1/auth/${WERF_VAULT_AUTH_PATH}/login" -d '{"role":"'${WERF_VAULT_AUTH_ROLE}'","jwt":"'${WERF_VAULT_AUTH_JWT}'"}' | jq -r '.auth.client_token')"
+            if [ -n "${VAULT_TOKEN}" ]; then
+              echo "Received Vault token";
+            else
+              echo "Vault token empty";
+            fi
+            export WERF_SIGN_INTERMEDIATES=$(curl -sf "${VAULT_ADDR}/v1/${INTERMEDIARY_CERT_PATH}" | base64 -w0)
+            export WERF_SIGN_CERT=$(curl -sf --header "X-Vault-Token: ${VAULT_TOKEN}" "${VAULT_ADDR}/v1/${SIGNING_CERT_PATH}" | jq -r '.data.certificate' | base64 -w0)
+          else
+            # fallback to non-signed version
+            export WERF_SIGN_MANIFEST="0"
+            echo "Fallback to WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+          fi
 
           type werf && source $(werf ci-env github --verbose --as-file)
           werf build \
@@ -1729,21 +1810,48 @@ jobs:
           IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           export WERF_DISABLE_META_TAGS=true
 
-          # Prepare for image and binary signing
-          export WERF_VAULT_AUTH_JWT=$(jq -r .value <<< $(curl -qfsH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=github-access-aud" ))
-          if [ -n "${WERF_VAULT_AUTH_JWT}" ]; then
-            echo "Received Actions token";
-          else
-            echo "Actions token empty";
+          # Check whether current DDK version supports signing
+          sign_minimal_version="v2.71.0-dk"
+          sign_current_version="$(werf version)"
+          sign_supported=true
+          if [[ $sign_minimal_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+            sign_minimal_major=${BASH_REMATCH[1]}
+            sign_minimal_minor=${BASH_REMATCH[2]}
           fi
-          export VAULT_TOKEN="$(curl -sfX POST "${VAULT_ADDR}/v1/auth/${WERF_VAULT_AUTH_PATH}/login" -d '{"role":"'${WERF_VAULT_AUTH_ROLE}'","jwt":"'${WERF_VAULT_AUTH_JWT}'"}' | jq -r '.auth.client_token')"
-          if [ -n "${VAULT_TOKEN}" ]; then
-            echo "Received Vault token";
+          if [[ $sign_current_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+            sign_current_major=${BASH_REMATCH[1]}
+            sign_current_minor=${BASH_REMATCH[2]}
           else
-            echo "Vault token empty";
+            sign_supported=false
           fi
-          export WERF_SIGN_INTERMEDIATES=$(curl -sf "${VAULT_ADDR}/v1/${INTERMEDIARY_CERT_PATH}" | base64 -w0)
-          export WERF_SIGN_CERT=$(curl -sf --header "X-Vault-Token: ${VAULT_TOKEN}" "${VAULT_ADDR}/v1/${SIGNING_CERT_PATH}" | jq -r '.data.certificate' | base64 -w0)
+          if (( sign_current_major < sign_minimal_major )); then
+            sign_supported=false
+          elif (( sign_current_major == sign_minimal_major && sign_current_minor < sign_minimal_minor )); then
+            sign_supported=false
+          fi
+
+          if $sign_supported; then
+            # Prepare for image and binary signing
+            echo "Using WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+            export WERF_VAULT_AUTH_JWT=$(jq -r .value <<< $(curl -qfsH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=github-access-aud" ))
+            if [ -n "${WERF_VAULT_AUTH_JWT}" ]; then
+              echo "Received Actions token";
+            else
+              echo "Actions token empty";
+            fi
+            export VAULT_TOKEN="$(curl -sfX POST "${VAULT_ADDR}/v1/auth/${WERF_VAULT_AUTH_PATH}/login" -d '{"role":"'${WERF_VAULT_AUTH_ROLE}'","jwt":"'${WERF_VAULT_AUTH_JWT}'"}' | jq -r '.auth.client_token')"
+            if [ -n "${VAULT_TOKEN}" ]; then
+              echo "Received Vault token";
+            else
+              echo "Vault token empty";
+            fi
+            export WERF_SIGN_INTERMEDIATES=$(curl -sf "${VAULT_ADDR}/v1/${INTERMEDIARY_CERT_PATH}" | base64 -w0)
+            export WERF_SIGN_CERT=$(curl -sf --header "X-Vault-Token: ${VAULT_TOKEN}" "${VAULT_ADDR}/v1/${SIGNING_CERT_PATH}" | jq -r '.data.certificate' | base64 -w0)
+          else
+            # fallback to non-signed version
+            export WERF_SIGN_MANIFEST="0"
+            echo "Fallback to WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+          fi
 
           type werf && source $(werf ci-env github --verbose --as-file)
           werf build \
@@ -2078,21 +2186,48 @@ jobs:
           IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           export WERF_DISABLE_META_TAGS=true
 
-          # Prepare for image and binary signing
-          export WERF_VAULT_AUTH_JWT=$(jq -r .value <<< $(curl -qfsH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=github-access-aud" ))
-          if [ -n "${WERF_VAULT_AUTH_JWT}" ]; then
-            echo "Received Actions token";
-          else
-            echo "Actions token empty";
+          # Check whether current DDK version supports signing
+          sign_minimal_version="v2.71.0-dk"
+          sign_current_version="$(werf version)"
+          sign_supported=true
+          if [[ $sign_minimal_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+            sign_minimal_major=${BASH_REMATCH[1]}
+            sign_minimal_minor=${BASH_REMATCH[2]}
           fi
-          export VAULT_TOKEN="$(curl -sfX POST "${VAULT_ADDR}/v1/auth/${WERF_VAULT_AUTH_PATH}/login" -d '{"role":"'${WERF_VAULT_AUTH_ROLE}'","jwt":"'${WERF_VAULT_AUTH_JWT}'"}' | jq -r '.auth.client_token')"
-          if [ -n "${VAULT_TOKEN}" ]; then
-            echo "Received Vault token";
+          if [[ $sign_current_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+            sign_current_major=${BASH_REMATCH[1]}
+            sign_current_minor=${BASH_REMATCH[2]}
           else
-            echo "Vault token empty";
+            sign_supported=false
           fi
-          export WERF_SIGN_INTERMEDIATES=$(curl -sf "${VAULT_ADDR}/v1/${INTERMEDIARY_CERT_PATH}" | base64 -w0)
-          export WERF_SIGN_CERT=$(curl -sf --header "X-Vault-Token: ${VAULT_TOKEN}" "${VAULT_ADDR}/v1/${SIGNING_CERT_PATH}" | jq -r '.data.certificate' | base64 -w0)
+          if (( sign_current_major < sign_minimal_major )); then
+            sign_supported=false
+          elif (( sign_current_major == sign_minimal_major && sign_current_minor < sign_minimal_minor )); then
+            sign_supported=false
+          fi
+
+          if $sign_supported; then
+            # Prepare for image and binary signing
+            echo "Using WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+            export WERF_VAULT_AUTH_JWT=$(jq -r .value <<< $(curl -qfsH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=github-access-aud" ))
+            if [ -n "${WERF_VAULT_AUTH_JWT}" ]; then
+              echo "Received Actions token";
+            else
+              echo "Actions token empty";
+            fi
+            export VAULT_TOKEN="$(curl -sfX POST "${VAULT_ADDR}/v1/auth/${WERF_VAULT_AUTH_PATH}/login" -d '{"role":"'${WERF_VAULT_AUTH_ROLE}'","jwt":"'${WERF_VAULT_AUTH_JWT}'"}' | jq -r '.auth.client_token')"
+            if [ -n "${VAULT_TOKEN}" ]; then
+              echo "Received Vault token";
+            else
+              echo "Vault token empty";
+            fi
+            export WERF_SIGN_INTERMEDIATES=$(curl -sf "${VAULT_ADDR}/v1/${INTERMEDIARY_CERT_PATH}" | base64 -w0)
+            export WERF_SIGN_CERT=$(curl -sf --header "X-Vault-Token: ${VAULT_TOKEN}" "${VAULT_ADDR}/v1/${SIGNING_CERT_PATH}" | jq -r '.data.certificate' | base64 -w0)
+          else
+            # fallback to non-signed version
+            export WERF_SIGN_MANIFEST="0"
+            echo "Fallback to WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+          fi
 
           type werf && source $(werf ci-env github --verbose --as-file)
           werf build \
@@ -2427,21 +2562,48 @@ jobs:
           IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           export WERF_DISABLE_META_TAGS=true
 
-          # Prepare for image and binary signing
-          export WERF_VAULT_AUTH_JWT=$(jq -r .value <<< $(curl -qfsH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=github-access-aud" ))
-          if [ -n "${WERF_VAULT_AUTH_JWT}" ]; then
-            echo "Received Actions token";
-          else
-            echo "Actions token empty";
+          # Check whether current DDK version supports signing
+          sign_minimal_version="v2.71.0-dk"
+          sign_current_version="$(werf version)"
+          sign_supported=true
+          if [[ $sign_minimal_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+            sign_minimal_major=${BASH_REMATCH[1]}
+            sign_minimal_minor=${BASH_REMATCH[2]}
           fi
-          export VAULT_TOKEN="$(curl -sfX POST "${VAULT_ADDR}/v1/auth/${WERF_VAULT_AUTH_PATH}/login" -d '{"role":"'${WERF_VAULT_AUTH_ROLE}'","jwt":"'${WERF_VAULT_AUTH_JWT}'"}' | jq -r '.auth.client_token')"
-          if [ -n "${VAULT_TOKEN}" ]; then
-            echo "Received Vault token";
+          if [[ $sign_current_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+            sign_current_major=${BASH_REMATCH[1]}
+            sign_current_minor=${BASH_REMATCH[2]}
           else
-            echo "Vault token empty";
+            sign_supported=false
           fi
-          export WERF_SIGN_INTERMEDIATES=$(curl -sf "${VAULT_ADDR}/v1/${INTERMEDIARY_CERT_PATH}" | base64 -w0)
-          export WERF_SIGN_CERT=$(curl -sf --header "X-Vault-Token: ${VAULT_TOKEN}" "${VAULT_ADDR}/v1/${SIGNING_CERT_PATH}" | jq -r '.data.certificate' | base64 -w0)
+          if (( sign_current_major < sign_minimal_major )); then
+            sign_supported=false
+          elif (( sign_current_major == sign_minimal_major && sign_current_minor < sign_minimal_minor )); then
+            sign_supported=false
+          fi
+
+          if $sign_supported; then
+            # Prepare for image and binary signing
+            echo "Using WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+            export WERF_VAULT_AUTH_JWT=$(jq -r .value <<< $(curl -qfsH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=github-access-aud" ))
+            if [ -n "${WERF_VAULT_AUTH_JWT}" ]; then
+              echo "Received Actions token";
+            else
+              echo "Actions token empty";
+            fi
+            export VAULT_TOKEN="$(curl -sfX POST "${VAULT_ADDR}/v1/auth/${WERF_VAULT_AUTH_PATH}/login" -d '{"role":"'${WERF_VAULT_AUTH_ROLE}'","jwt":"'${WERF_VAULT_AUTH_JWT}'"}' | jq -r '.auth.client_token')"
+            if [ -n "${VAULT_TOKEN}" ]; then
+              echo "Received Vault token";
+            else
+              echo "Vault token empty";
+            fi
+            export WERF_SIGN_INTERMEDIATES=$(curl -sf "${VAULT_ADDR}/v1/${INTERMEDIARY_CERT_PATH}" | base64 -w0)
+            export WERF_SIGN_CERT=$(curl -sf --header "X-Vault-Token: ${VAULT_TOKEN}" "${VAULT_ADDR}/v1/${SIGNING_CERT_PATH}" | jq -r '.data.certificate' | base64 -w0)
+          else
+            # fallback to non-signed version
+            export WERF_SIGN_MANIFEST="0"
+            echo "Fallback to WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+          fi
 
           type werf && source $(werf ci-env github --verbose --as-file)
           werf build \
@@ -2776,21 +2938,48 @@ jobs:
           IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           export WERF_DISABLE_META_TAGS=true
 
-          # Prepare for image and binary signing
-          export WERF_VAULT_AUTH_JWT=$(jq -r .value <<< $(curl -qfsH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=github-access-aud" ))
-          if [ -n "${WERF_VAULT_AUTH_JWT}" ]; then
-            echo "Received Actions token";
-          else
-            echo "Actions token empty";
+          # Check whether current DDK version supports signing
+          sign_minimal_version="v2.71.0-dk"
+          sign_current_version="$(werf version)"
+          sign_supported=true
+          if [[ $sign_minimal_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+            sign_minimal_major=${BASH_REMATCH[1]}
+            sign_minimal_minor=${BASH_REMATCH[2]}
           fi
-          export VAULT_TOKEN="$(curl -sfX POST "${VAULT_ADDR}/v1/auth/${WERF_VAULT_AUTH_PATH}/login" -d '{"role":"'${WERF_VAULT_AUTH_ROLE}'","jwt":"'${WERF_VAULT_AUTH_JWT}'"}' | jq -r '.auth.client_token')"
-          if [ -n "${VAULT_TOKEN}" ]; then
-            echo "Received Vault token";
+          if [[ $sign_current_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+            sign_current_major=${BASH_REMATCH[1]}
+            sign_current_minor=${BASH_REMATCH[2]}
           else
-            echo "Vault token empty";
+            sign_supported=false
           fi
-          export WERF_SIGN_INTERMEDIATES=$(curl -sf "${VAULT_ADDR}/v1/${INTERMEDIARY_CERT_PATH}" | base64 -w0)
-          export WERF_SIGN_CERT=$(curl -sf --header "X-Vault-Token: ${VAULT_TOKEN}" "${VAULT_ADDR}/v1/${SIGNING_CERT_PATH}" | jq -r '.data.certificate' | base64 -w0)
+          if (( sign_current_major < sign_minimal_major )); then
+            sign_supported=false
+          elif (( sign_current_major == sign_minimal_major && sign_current_minor < sign_minimal_minor )); then
+            sign_supported=false
+          fi
+
+          if $sign_supported; then
+            # Prepare for image and binary signing
+            echo "Using WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+            export WERF_VAULT_AUTH_JWT=$(jq -r .value <<< $(curl -qfsH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=github-access-aud" ))
+            if [ -n "${WERF_VAULT_AUTH_JWT}" ]; then
+              echo "Received Actions token";
+            else
+              echo "Actions token empty";
+            fi
+            export VAULT_TOKEN="$(curl -sfX POST "${VAULT_ADDR}/v1/auth/${WERF_VAULT_AUTH_PATH}/login" -d '{"role":"'${WERF_VAULT_AUTH_ROLE}'","jwt":"'${WERF_VAULT_AUTH_JWT}'"}' | jq -r '.auth.client_token')"
+            if [ -n "${VAULT_TOKEN}" ]; then
+              echo "Received Vault token";
+            else
+              echo "Vault token empty";
+            fi
+            export WERF_SIGN_INTERMEDIATES=$(curl -sf "${VAULT_ADDR}/v1/${INTERMEDIARY_CERT_PATH}" | base64 -w0)
+            export WERF_SIGN_CERT=$(curl -sf --header "X-Vault-Token: ${VAULT_TOKEN}" "${VAULT_ADDR}/v1/${SIGNING_CERT_PATH}" | jq -r '.data.certificate' | base64 -w0)
+          else
+            # fallback to non-signed version
+            export WERF_SIGN_MANIFEST="0"
+            echo "Fallback to WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+          fi
 
           type werf && source $(werf ci-env github --verbose --as-file)
           werf build \

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -520,21 +520,48 @@ jobs:
           IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
           export WERF_DISABLE_META_TAGS=true
 
-          # Prepare for image and binary signing
-          export WERF_VAULT_AUTH_JWT=$(jq -r .value <<< $(curl -qfsH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=github-access-aud" ))
-          if [ -n "${WERF_VAULT_AUTH_JWT}" ]; then
-            echo "Received Actions token";
-          else
-            echo "Actions token empty";
+          # Check whether current DDK version supports signing
+          sign_minimal_version="v2.71.0-dk"
+          sign_current_version="$(werf version)"
+          sign_supported=true
+          if [[ $sign_minimal_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+            sign_minimal_major=${BASH_REMATCH[1]}
+            sign_minimal_minor=${BASH_REMATCH[2]}
           fi
-          export VAULT_TOKEN="$(curl -sfX POST "${VAULT_ADDR}/v1/auth/${WERF_VAULT_AUTH_PATH}/login" -d '{"role":"'${WERF_VAULT_AUTH_ROLE}'","jwt":"'${WERF_VAULT_AUTH_JWT}'"}' | jq -r '.auth.client_token')"
-          if [ -n "${VAULT_TOKEN}" ]; then
-            echo "Received Vault token";
+          if [[ $sign_current_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+            sign_current_major=${BASH_REMATCH[1]}
+            sign_current_minor=${BASH_REMATCH[2]}
           else
-            echo "Vault token empty";
+            sign_supported=false
           fi
-          export WERF_SIGN_INTERMEDIATES=$(curl -sf "${VAULT_ADDR}/v1/${INTERMEDIARY_CERT_PATH}" | base64 -w0)
-          export WERF_SIGN_CERT=$(curl -sf --header "X-Vault-Token: ${VAULT_TOKEN}" "${VAULT_ADDR}/v1/${SIGNING_CERT_PATH}" | jq -r '.data.certificate' | base64 -w0)
+          if (( sign_current_major < sign_minimal_major )); then
+            sign_supported=false
+          elif (( sign_current_major == sign_minimal_major && sign_current_minor < sign_minimal_minor )); then
+            sign_supported=false
+          fi
+
+          if $sign_supported; then
+            # Prepare for image and binary signing
+            echo "Using WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+            export WERF_VAULT_AUTH_JWT=$(jq -r .value <<< $(curl -qfsH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=github-access-aud" ))
+            if [ -n "${WERF_VAULT_AUTH_JWT}" ]; then
+              echo "Received Actions token";
+            else
+              echo "Actions token empty";
+            fi
+            export VAULT_TOKEN="$(curl -sfX POST "${VAULT_ADDR}/v1/auth/${WERF_VAULT_AUTH_PATH}/login" -d '{"role":"'${WERF_VAULT_AUTH_ROLE}'","jwt":"'${WERF_VAULT_AUTH_JWT}'"}' | jq -r '.auth.client_token')"
+            if [ -n "${VAULT_TOKEN}" ]; then
+              echo "Received Vault token";
+            else
+              echo "Vault token empty";
+            fi
+            export WERF_SIGN_INTERMEDIATES=$(curl -sf "${VAULT_ADDR}/v1/${INTERMEDIARY_CERT_PATH}" | base64 -w0)
+            export WERF_SIGN_CERT=$(curl -sf --header "X-Vault-Token: ${VAULT_TOKEN}" "${VAULT_ADDR}/v1/${SIGNING_CERT_PATH}" | jq -r '.data.certificate' | base64 -w0)
+          else
+            # fallback to non-signed version
+            export WERF_SIGN_MANIFEST="0"
+            echo "Fallback to WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+          fi
 
           type werf && source $(werf ci-env github --verbose --as-file)
           werf build \
@@ -888,21 +915,48 @@ jobs:
           IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
           export WERF_DISABLE_META_TAGS=true
 
-          # Prepare for image and binary signing
-          export WERF_VAULT_AUTH_JWT=$(jq -r .value <<< $(curl -qfsH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=github-access-aud" ))
-          if [ -n "${WERF_VAULT_AUTH_JWT}" ]; then
-            echo "Received Actions token";
-          else
-            echo "Actions token empty";
+          # Check whether current DDK version supports signing
+          sign_minimal_version="v2.71.0-dk"
+          sign_current_version="$(werf version)"
+          sign_supported=true
+          if [[ $sign_minimal_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+            sign_minimal_major=${BASH_REMATCH[1]}
+            sign_minimal_minor=${BASH_REMATCH[2]}
           fi
-          export VAULT_TOKEN="$(curl -sfX POST "${VAULT_ADDR}/v1/auth/${WERF_VAULT_AUTH_PATH}/login" -d '{"role":"'${WERF_VAULT_AUTH_ROLE}'","jwt":"'${WERF_VAULT_AUTH_JWT}'"}' | jq -r '.auth.client_token')"
-          if [ -n "${VAULT_TOKEN}" ]; then
-            echo "Received Vault token";
+          if [[ $sign_current_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+            sign_current_major=${BASH_REMATCH[1]}
+            sign_current_minor=${BASH_REMATCH[2]}
           else
-            echo "Vault token empty";
+            sign_supported=false
           fi
-          export WERF_SIGN_INTERMEDIATES=$(curl -sf "${VAULT_ADDR}/v1/${INTERMEDIARY_CERT_PATH}" | base64 -w0)
-          export WERF_SIGN_CERT=$(curl -sf --header "X-Vault-Token: ${VAULT_TOKEN}" "${VAULT_ADDR}/v1/${SIGNING_CERT_PATH}" | jq -r '.data.certificate' | base64 -w0)
+          if (( sign_current_major < sign_minimal_major )); then
+            sign_supported=false
+          elif (( sign_current_major == sign_minimal_major && sign_current_minor < sign_minimal_minor )); then
+            sign_supported=false
+          fi
+
+          if $sign_supported; then
+            # Prepare for image and binary signing
+            echo "Using WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+            export WERF_VAULT_AUTH_JWT=$(jq -r .value <<< $(curl -qfsH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=github-access-aud" ))
+            if [ -n "${WERF_VAULT_AUTH_JWT}" ]; then
+              echo "Received Actions token";
+            else
+              echo "Actions token empty";
+            fi
+            export VAULT_TOKEN="$(curl -sfX POST "${VAULT_ADDR}/v1/auth/${WERF_VAULT_AUTH_PATH}/login" -d '{"role":"'${WERF_VAULT_AUTH_ROLE}'","jwt":"'${WERF_VAULT_AUTH_JWT}'"}' | jq -r '.auth.client_token')"
+            if [ -n "${VAULT_TOKEN}" ]; then
+              echo "Received Vault token";
+            else
+              echo "Vault token empty";
+            fi
+            export WERF_SIGN_INTERMEDIATES=$(curl -sf "${VAULT_ADDR}/v1/${INTERMEDIARY_CERT_PATH}" | base64 -w0)
+            export WERF_SIGN_CERT=$(curl -sf --header "X-Vault-Token: ${VAULT_TOKEN}" "${VAULT_ADDR}/v1/${SIGNING_CERT_PATH}" | jq -r '.data.certificate' | base64 -w0)
+          else
+            # fallback to non-signed version
+            export WERF_SIGN_MANIFEST="0"
+            echo "Fallback to WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+          fi
 
           type werf && source $(werf ci-env github --verbose --as-file)
           werf build \
@@ -1257,21 +1311,48 @@ jobs:
           IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
           export WERF_DISABLE_META_TAGS=true
 
-          # Prepare for image and binary signing
-          export WERF_VAULT_AUTH_JWT=$(jq -r .value <<< $(curl -qfsH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=github-access-aud" ))
-          if [ -n "${WERF_VAULT_AUTH_JWT}" ]; then
-            echo "Received Actions token";
-          else
-            echo "Actions token empty";
+          # Check whether current DDK version supports signing
+          sign_minimal_version="v2.71.0-dk"
+          sign_current_version="$(werf version)"
+          sign_supported=true
+          if [[ $sign_minimal_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+            sign_minimal_major=${BASH_REMATCH[1]}
+            sign_minimal_minor=${BASH_REMATCH[2]}
           fi
-          export VAULT_TOKEN="$(curl -sfX POST "${VAULT_ADDR}/v1/auth/${WERF_VAULT_AUTH_PATH}/login" -d '{"role":"'${WERF_VAULT_AUTH_ROLE}'","jwt":"'${WERF_VAULT_AUTH_JWT}'"}' | jq -r '.auth.client_token')"
-          if [ -n "${VAULT_TOKEN}" ]; then
-            echo "Received Vault token";
+          if [[ $sign_current_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+            sign_current_major=${BASH_REMATCH[1]}
+            sign_current_minor=${BASH_REMATCH[2]}
           else
-            echo "Vault token empty";
+            sign_supported=false
           fi
-          export WERF_SIGN_INTERMEDIATES=$(curl -sf "${VAULT_ADDR}/v1/${INTERMEDIARY_CERT_PATH}" | base64 -w0)
-          export WERF_SIGN_CERT=$(curl -sf --header "X-Vault-Token: ${VAULT_TOKEN}" "${VAULT_ADDR}/v1/${SIGNING_CERT_PATH}" | jq -r '.data.certificate' | base64 -w0)
+          if (( sign_current_major < sign_minimal_major )); then
+            sign_supported=false
+          elif (( sign_current_major == sign_minimal_major && sign_current_minor < sign_minimal_minor )); then
+            sign_supported=false
+          fi
+
+          if $sign_supported; then
+            # Prepare for image and binary signing
+            echo "Using WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+            export WERF_VAULT_AUTH_JWT=$(jq -r .value <<< $(curl -qfsH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=github-access-aud" ))
+            if [ -n "${WERF_VAULT_AUTH_JWT}" ]; then
+              echo "Received Actions token";
+            else
+              echo "Actions token empty";
+            fi
+            export VAULT_TOKEN="$(curl -sfX POST "${VAULT_ADDR}/v1/auth/${WERF_VAULT_AUTH_PATH}/login" -d '{"role":"'${WERF_VAULT_AUTH_ROLE}'","jwt":"'${WERF_VAULT_AUTH_JWT}'"}' | jq -r '.auth.client_token')"
+            if [ -n "${VAULT_TOKEN}" ]; then
+              echo "Received Vault token";
+            else
+              echo "Vault token empty";
+            fi
+            export WERF_SIGN_INTERMEDIATES=$(curl -sf "${VAULT_ADDR}/v1/${INTERMEDIARY_CERT_PATH}" | base64 -w0)
+            export WERF_SIGN_CERT=$(curl -sf --header "X-Vault-Token: ${VAULT_TOKEN}" "${VAULT_ADDR}/v1/${SIGNING_CERT_PATH}" | jq -r '.data.certificate' | base64 -w0)
+          else
+            # fallback to non-signed version
+            export WERF_SIGN_MANIFEST="0"
+            echo "Fallback to WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+          fi
 
           type werf && source $(werf ci-env github --verbose --as-file)
           werf build \
@@ -1626,21 +1707,48 @@ jobs:
           IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
           export WERF_DISABLE_META_TAGS=true
 
-          # Prepare for image and binary signing
-          export WERF_VAULT_AUTH_JWT=$(jq -r .value <<< $(curl -qfsH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=github-access-aud" ))
-          if [ -n "${WERF_VAULT_AUTH_JWT}" ]; then
-            echo "Received Actions token";
-          else
-            echo "Actions token empty";
+          # Check whether current DDK version supports signing
+          sign_minimal_version="v2.71.0-dk"
+          sign_current_version="$(werf version)"
+          sign_supported=true
+          if [[ $sign_minimal_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+            sign_minimal_major=${BASH_REMATCH[1]}
+            sign_minimal_minor=${BASH_REMATCH[2]}
           fi
-          export VAULT_TOKEN="$(curl -sfX POST "${VAULT_ADDR}/v1/auth/${WERF_VAULT_AUTH_PATH}/login" -d '{"role":"'${WERF_VAULT_AUTH_ROLE}'","jwt":"'${WERF_VAULT_AUTH_JWT}'"}' | jq -r '.auth.client_token')"
-          if [ -n "${VAULT_TOKEN}" ]; then
-            echo "Received Vault token";
+          if [[ $sign_current_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+            sign_current_major=${BASH_REMATCH[1]}
+            sign_current_minor=${BASH_REMATCH[2]}
           else
-            echo "Vault token empty";
+            sign_supported=false
           fi
-          export WERF_SIGN_INTERMEDIATES=$(curl -sf "${VAULT_ADDR}/v1/${INTERMEDIARY_CERT_PATH}" | base64 -w0)
-          export WERF_SIGN_CERT=$(curl -sf --header "X-Vault-Token: ${VAULT_TOKEN}" "${VAULT_ADDR}/v1/${SIGNING_CERT_PATH}" | jq -r '.data.certificate' | base64 -w0)
+          if (( sign_current_major < sign_minimal_major )); then
+            sign_supported=false
+          elif (( sign_current_major == sign_minimal_major && sign_current_minor < sign_minimal_minor )); then
+            sign_supported=false
+          fi
+
+          if $sign_supported; then
+            # Prepare for image and binary signing
+            echo "Using WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+            export WERF_VAULT_AUTH_JWT=$(jq -r .value <<< $(curl -qfsH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=github-access-aud" ))
+            if [ -n "${WERF_VAULT_AUTH_JWT}" ]; then
+              echo "Received Actions token";
+            else
+              echo "Actions token empty";
+            fi
+            export VAULT_TOKEN="$(curl -sfX POST "${VAULT_ADDR}/v1/auth/${WERF_VAULT_AUTH_PATH}/login" -d '{"role":"'${WERF_VAULT_AUTH_ROLE}'","jwt":"'${WERF_VAULT_AUTH_JWT}'"}' | jq -r '.auth.client_token')"
+            if [ -n "${VAULT_TOKEN}" ]; then
+              echo "Received Vault token";
+            else
+              echo "Vault token empty";
+            fi
+            export WERF_SIGN_INTERMEDIATES=$(curl -sf "${VAULT_ADDR}/v1/${INTERMEDIARY_CERT_PATH}" | base64 -w0)
+            export WERF_SIGN_CERT=$(curl -sf --header "X-Vault-Token: ${VAULT_TOKEN}" "${VAULT_ADDR}/v1/${SIGNING_CERT_PATH}" | jq -r '.data.certificate' | base64 -w0)
+          else
+            # fallback to non-signed version
+            export WERF_SIGN_MANIFEST="0"
+            echo "Fallback to WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+          fi
 
           type werf && source $(werf ci-env github --verbose --as-file)
           werf build \
@@ -1995,21 +2103,48 @@ jobs:
           IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
           export WERF_DISABLE_META_TAGS=true
 
-          # Prepare for image and binary signing
-          export WERF_VAULT_AUTH_JWT=$(jq -r .value <<< $(curl -qfsH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=github-access-aud" ))
-          if [ -n "${WERF_VAULT_AUTH_JWT}" ]; then
-            echo "Received Actions token";
-          else
-            echo "Actions token empty";
+          # Check whether current DDK version supports signing
+          sign_minimal_version="v2.71.0-dk"
+          sign_current_version="$(werf version)"
+          sign_supported=true
+          if [[ $sign_minimal_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+            sign_minimal_major=${BASH_REMATCH[1]}
+            sign_minimal_minor=${BASH_REMATCH[2]}
           fi
-          export VAULT_TOKEN="$(curl -sfX POST "${VAULT_ADDR}/v1/auth/${WERF_VAULT_AUTH_PATH}/login" -d '{"role":"'${WERF_VAULT_AUTH_ROLE}'","jwt":"'${WERF_VAULT_AUTH_JWT}'"}' | jq -r '.auth.client_token')"
-          if [ -n "${VAULT_TOKEN}" ]; then
-            echo "Received Vault token";
+          if [[ $sign_current_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+            sign_current_major=${BASH_REMATCH[1]}
+            sign_current_minor=${BASH_REMATCH[2]}
           else
-            echo "Vault token empty";
+            sign_supported=false
           fi
-          export WERF_SIGN_INTERMEDIATES=$(curl -sf "${VAULT_ADDR}/v1/${INTERMEDIARY_CERT_PATH}" | base64 -w0)
-          export WERF_SIGN_CERT=$(curl -sf --header "X-Vault-Token: ${VAULT_TOKEN}" "${VAULT_ADDR}/v1/${SIGNING_CERT_PATH}" | jq -r '.data.certificate' | base64 -w0)
+          if (( sign_current_major < sign_minimal_major )); then
+            sign_supported=false
+          elif (( sign_current_major == sign_minimal_major && sign_current_minor < sign_minimal_minor )); then
+            sign_supported=false
+          fi
+
+          if $sign_supported; then
+            # Prepare for image and binary signing
+            echo "Using WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+            export WERF_VAULT_AUTH_JWT=$(jq -r .value <<< $(curl -qfsH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=github-access-aud" ))
+            if [ -n "${WERF_VAULT_AUTH_JWT}" ]; then
+              echo "Received Actions token";
+            else
+              echo "Actions token empty";
+            fi
+            export VAULT_TOKEN="$(curl -sfX POST "${VAULT_ADDR}/v1/auth/${WERF_VAULT_AUTH_PATH}/login" -d '{"role":"'${WERF_VAULT_AUTH_ROLE}'","jwt":"'${WERF_VAULT_AUTH_JWT}'"}' | jq -r '.auth.client_token')"
+            if [ -n "${VAULT_TOKEN}" ]; then
+              echo "Received Vault token";
+            else
+              echo "Vault token empty";
+            fi
+            export WERF_SIGN_INTERMEDIATES=$(curl -sf "${VAULT_ADDR}/v1/${INTERMEDIARY_CERT_PATH}" | base64 -w0)
+            export WERF_SIGN_CERT=$(curl -sf --header "X-Vault-Token: ${VAULT_TOKEN}" "${VAULT_ADDR}/v1/${SIGNING_CERT_PATH}" | jq -r '.data.certificate' | base64 -w0)
+          else
+            # fallback to non-signed version
+            export WERF_SIGN_MANIFEST="0"
+            echo "Fallback to WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+          fi
 
           type werf && source $(werf ci-env github --verbose --as-file)
           werf build \
@@ -2364,21 +2499,48 @@ jobs:
           IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
           export WERF_DISABLE_META_TAGS=true
 
-          # Prepare for image and binary signing
-          export WERF_VAULT_AUTH_JWT=$(jq -r .value <<< $(curl -qfsH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=github-access-aud" ))
-          if [ -n "${WERF_VAULT_AUTH_JWT}" ]; then
-            echo "Received Actions token";
-          else
-            echo "Actions token empty";
+          # Check whether current DDK version supports signing
+          sign_minimal_version="v2.71.0-dk"
+          sign_current_version="$(werf version)"
+          sign_supported=true
+          if [[ $sign_minimal_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+            sign_minimal_major=${BASH_REMATCH[1]}
+            sign_minimal_minor=${BASH_REMATCH[2]}
           fi
-          export VAULT_TOKEN="$(curl -sfX POST "${VAULT_ADDR}/v1/auth/${WERF_VAULT_AUTH_PATH}/login" -d '{"role":"'${WERF_VAULT_AUTH_ROLE}'","jwt":"'${WERF_VAULT_AUTH_JWT}'"}' | jq -r '.auth.client_token')"
-          if [ -n "${VAULT_TOKEN}" ]; then
-            echo "Received Vault token";
+          if [[ $sign_current_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+            sign_current_major=${BASH_REMATCH[1]}
+            sign_current_minor=${BASH_REMATCH[2]}
           else
-            echo "Vault token empty";
+            sign_supported=false
           fi
-          export WERF_SIGN_INTERMEDIATES=$(curl -sf "${VAULT_ADDR}/v1/${INTERMEDIARY_CERT_PATH}" | base64 -w0)
-          export WERF_SIGN_CERT=$(curl -sf --header "X-Vault-Token: ${VAULT_TOKEN}" "${VAULT_ADDR}/v1/${SIGNING_CERT_PATH}" | jq -r '.data.certificate' | base64 -w0)
+          if (( sign_current_major < sign_minimal_major )); then
+            sign_supported=false
+          elif (( sign_current_major == sign_minimal_major && sign_current_minor < sign_minimal_minor )); then
+            sign_supported=false
+          fi
+
+          if $sign_supported; then
+            # Prepare for image and binary signing
+            echo "Using WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+            export WERF_VAULT_AUTH_JWT=$(jq -r .value <<< $(curl -qfsH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=github-access-aud" ))
+            if [ -n "${WERF_VAULT_AUTH_JWT}" ]; then
+              echo "Received Actions token";
+            else
+              echo "Actions token empty";
+            fi
+            export VAULT_TOKEN="$(curl -sfX POST "${VAULT_ADDR}/v1/auth/${WERF_VAULT_AUTH_PATH}/login" -d '{"role":"'${WERF_VAULT_AUTH_ROLE}'","jwt":"'${WERF_VAULT_AUTH_JWT}'"}' | jq -r '.auth.client_token')"
+            if [ -n "${VAULT_TOKEN}" ]; then
+              echo "Received Vault token";
+            else
+              echo "Vault token empty";
+            fi
+            export WERF_SIGN_INTERMEDIATES=$(curl -sf "${VAULT_ADDR}/v1/${INTERMEDIARY_CERT_PATH}" | base64 -w0)
+            export WERF_SIGN_CERT=$(curl -sf --header "X-Vault-Token: ${VAULT_TOKEN}" "${VAULT_ADDR}/v1/${SIGNING_CERT_PATH}" | jq -r '.data.certificate' | base64 -w0)
+          else
+            # fallback to non-signed version
+            export WERF_SIGN_MANIFEST="0"
+            echo "Fallback to WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+          fi
 
           type werf && source $(werf ci-env github --verbose --as-file)
           werf build \

--- a/.github/workflows/reproducibility-check.yml
+++ b/.github/workflows/reproducibility-check.yml
@@ -582,21 +582,48 @@ jobs:
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
           IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          # Prepare for image and binary signing
-          export WERF_VAULT_AUTH_JWT=$(jq -r .value <<< $(curl -qfsH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=github-access-aud" ))
-          if [ -n "${WERF_VAULT_AUTH_JWT}" ]; then
-            echo "Received Actions token";
-          else
-            echo "Actions token empty";
+          # Check whether current DDK version supports signing
+          sign_minimal_version="v2.71.0-dk"
+          sign_current_version="$(werf version)"
+          sign_supported=true
+          if [[ $sign_minimal_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+            sign_minimal_major=${BASH_REMATCH[1]}
+            sign_minimal_minor=${BASH_REMATCH[2]}
           fi
-          export VAULT_TOKEN="$(curl -sfX POST "${VAULT_ADDR}/v1/auth/${WERF_VAULT_AUTH_PATH}/login" -d '{"role":"'${WERF_VAULT_AUTH_ROLE}'","jwt":"'${WERF_VAULT_AUTH_JWT}'"}' | jq -r '.auth.client_token')"
-          if [ -n "${VAULT_TOKEN}" ]; then
-            echo "Received Vault token";
+          if [[ $sign_current_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+            sign_current_major=${BASH_REMATCH[1]}
+            sign_current_minor=${BASH_REMATCH[2]}
           else
-            echo "Vault token empty";
+            sign_supported=false
           fi
-          export WERF_SIGN_INTERMEDIATES=$(curl -sf "${VAULT_ADDR}/v1/${INTERMEDIARY_CERT_PATH}" | base64 -w0)
-          export WERF_SIGN_CERT=$(curl -sf --header "X-Vault-Token: ${VAULT_TOKEN}" "${VAULT_ADDR}/v1/${SIGNING_CERT_PATH}" | jq -r '.data.certificate' | base64 -w0)
+          if (( sign_current_major < sign_minimal_major )); then
+            sign_supported=false
+          elif (( sign_current_major == sign_minimal_major && sign_current_minor < sign_minimal_minor )); then
+            sign_supported=false
+          fi
+
+          if $sign_supported; then
+            # Prepare for image and binary signing
+            echo "Using WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+            export WERF_VAULT_AUTH_JWT=$(jq -r .value <<< $(curl -qfsH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=github-access-aud" ))
+            if [ -n "${WERF_VAULT_AUTH_JWT}" ]; then
+              echo "Received Actions token";
+            else
+              echo "Actions token empty";
+            fi
+            export VAULT_TOKEN="$(curl -sfX POST "${VAULT_ADDR}/v1/auth/${WERF_VAULT_AUTH_PATH}/login" -d '{"role":"'${WERF_VAULT_AUTH_ROLE}'","jwt":"'${WERF_VAULT_AUTH_JWT}'"}' | jq -r '.auth.client_token')"
+            if [ -n "${VAULT_TOKEN}" ]; then
+              echo "Received Vault token";
+            else
+              echo "Vault token empty";
+            fi
+            export WERF_SIGN_INTERMEDIATES=$(curl -sf "${VAULT_ADDR}/v1/${INTERMEDIARY_CERT_PATH}" | base64 -w0)
+            export WERF_SIGN_CERT=$(curl -sf --header "X-Vault-Token: ${VAULT_TOKEN}" "${VAULT_ADDR}/v1/${SIGNING_CERT_PATH}" | jq -r '.data.certificate' | base64 -w0)
+          else
+            # fallback to non-signed version
+            export WERF_SIGN_MANIFEST="0"
+            echo "Fallback to WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+          fi
 
           type werf && source $(werf ci-env github --verbose --as-file)
           werf build \
@@ -948,21 +975,48 @@ jobs:
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
           IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          # Prepare for image and binary signing
-          export WERF_VAULT_AUTH_JWT=$(jq -r .value <<< $(curl -qfsH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=github-access-aud" ))
-          if [ -n "${WERF_VAULT_AUTH_JWT}" ]; then
-            echo "Received Actions token";
-          else
-            echo "Actions token empty";
+          # Check whether current DDK version supports signing
+          sign_minimal_version="v2.71.0-dk"
+          sign_current_version="$(werf version)"
+          sign_supported=true
+          if [[ $sign_minimal_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+            sign_minimal_major=${BASH_REMATCH[1]}
+            sign_minimal_minor=${BASH_REMATCH[2]}
           fi
-          export VAULT_TOKEN="$(curl -sfX POST "${VAULT_ADDR}/v1/auth/${WERF_VAULT_AUTH_PATH}/login" -d '{"role":"'${WERF_VAULT_AUTH_ROLE}'","jwt":"'${WERF_VAULT_AUTH_JWT}'"}' | jq -r '.auth.client_token')"
-          if [ -n "${VAULT_TOKEN}" ]; then
-            echo "Received Vault token";
+          if [[ $sign_current_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+            sign_current_major=${BASH_REMATCH[1]}
+            sign_current_minor=${BASH_REMATCH[2]}
           else
-            echo "Vault token empty";
+            sign_supported=false
           fi
-          export WERF_SIGN_INTERMEDIATES=$(curl -sf "${VAULT_ADDR}/v1/${INTERMEDIARY_CERT_PATH}" | base64 -w0)
-          export WERF_SIGN_CERT=$(curl -sf --header "X-Vault-Token: ${VAULT_TOKEN}" "${VAULT_ADDR}/v1/${SIGNING_CERT_PATH}" | jq -r '.data.certificate' | base64 -w0)
+          if (( sign_current_major < sign_minimal_major )); then
+            sign_supported=false
+          elif (( sign_current_major == sign_minimal_major && sign_current_minor < sign_minimal_minor )); then
+            sign_supported=false
+          fi
+
+          if $sign_supported; then
+            # Prepare for image and binary signing
+            echo "Using WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+            export WERF_VAULT_AUTH_JWT=$(jq -r .value <<< $(curl -qfsH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=github-access-aud" ))
+            if [ -n "${WERF_VAULT_AUTH_JWT}" ]; then
+              echo "Received Actions token";
+            else
+              echo "Actions token empty";
+            fi
+            export VAULT_TOKEN="$(curl -sfX POST "${VAULT_ADDR}/v1/auth/${WERF_VAULT_AUTH_PATH}/login" -d '{"role":"'${WERF_VAULT_AUTH_ROLE}'","jwt":"'${WERF_VAULT_AUTH_JWT}'"}' | jq -r '.auth.client_token')"
+            if [ -n "${VAULT_TOKEN}" ]; then
+              echo "Received Vault token";
+            else
+              echo "Vault token empty";
+            fi
+            export WERF_SIGN_INTERMEDIATES=$(curl -sf "${VAULT_ADDR}/v1/${INTERMEDIARY_CERT_PATH}" | base64 -w0)
+            export WERF_SIGN_CERT=$(curl -sf --header "X-Vault-Token: ${VAULT_TOKEN}" "${VAULT_ADDR}/v1/${SIGNING_CERT_PATH}" | jq -r '.data.certificate' | base64 -w0)
+          else
+            # fallback to non-signed version
+            export WERF_SIGN_MANIFEST="0"
+            echo "Fallback to WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+          fi
 
           type werf && source $(werf ci-env github --verbose --as-file)
           werf build \

--- a/.github/workflows/svace.yml
+++ b/.github/workflows/svace.yml
@@ -386,21 +386,48 @@ jobs:
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
           IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          # Prepare for image and binary signing
-          export WERF_VAULT_AUTH_JWT=$(jq -r .value <<< $(curl -qfsH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=github-access-aud" ))
-          if [ -n "${WERF_VAULT_AUTH_JWT}" ]; then
-            echo "Received Actions token";
-          else
-            echo "Actions token empty";
+          # Check whether current DDK version supports signing
+          sign_minimal_version="v2.71.0-dk"
+          sign_current_version="$(werf version)"
+          sign_supported=true
+          if [[ $sign_minimal_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+            sign_minimal_major=${BASH_REMATCH[1]}
+            sign_minimal_minor=${BASH_REMATCH[2]}
           fi
-          export VAULT_TOKEN="$(curl -sfX POST "${VAULT_ADDR}/v1/auth/${WERF_VAULT_AUTH_PATH}/login" -d '{"role":"'${WERF_VAULT_AUTH_ROLE}'","jwt":"'${WERF_VAULT_AUTH_JWT}'"}' | jq -r '.auth.client_token')"
-          if [ -n "${VAULT_TOKEN}" ]; then
-            echo "Received Vault token";
+          if [[ $sign_current_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+            sign_current_major=${BASH_REMATCH[1]}
+            sign_current_minor=${BASH_REMATCH[2]}
           else
-            echo "Vault token empty";
+            sign_supported=false
           fi
-          export WERF_SIGN_INTERMEDIATES=$(curl -sf "${VAULT_ADDR}/v1/${INTERMEDIARY_CERT_PATH}" | base64 -w0)
-          export WERF_SIGN_CERT=$(curl -sf --header "X-Vault-Token: ${VAULT_TOKEN}" "${VAULT_ADDR}/v1/${SIGNING_CERT_PATH}" | jq -r '.data.certificate' | base64 -w0)
+          if (( sign_current_major < sign_minimal_major )); then
+            sign_supported=false
+          elif (( sign_current_major == sign_minimal_major && sign_current_minor < sign_minimal_minor )); then
+            sign_supported=false
+          fi
+
+          if $sign_supported; then
+            # Prepare for image and binary signing
+            echo "Using WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+            export WERF_VAULT_AUTH_JWT=$(jq -r .value <<< $(curl -qfsH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=github-access-aud" ))
+            if [ -n "${WERF_VAULT_AUTH_JWT}" ]; then
+              echo "Received Actions token";
+            else
+              echo "Actions token empty";
+            fi
+            export VAULT_TOKEN="$(curl -sfX POST "${VAULT_ADDR}/v1/auth/${WERF_VAULT_AUTH_PATH}/login" -d '{"role":"'${WERF_VAULT_AUTH_ROLE}'","jwt":"'${WERF_VAULT_AUTH_JWT}'"}' | jq -r '.auth.client_token')"
+            if [ -n "${VAULT_TOKEN}" ]; then
+              echo "Received Vault token";
+            else
+              echo "Vault token empty";
+            fi
+            export WERF_SIGN_INTERMEDIATES=$(curl -sf "${VAULT_ADDR}/v1/${INTERMEDIARY_CERT_PATH}" | base64 -w0)
+            export WERF_SIGN_CERT=$(curl -sf --header "X-Vault-Token: ${VAULT_TOKEN}" "${VAULT_ADDR}/v1/${SIGNING_CERT_PATH}" | jq -r '.data.certificate' | base64 -w0)
+          else
+            # fallback to non-signed version
+            export WERF_SIGN_MANIFEST="0"
+            echo "Fallback to WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+          fi
 
           type werf && source $(werf ci-env github --verbose --as-file)
           werf build \


### PR DESCRIPTION
## Description
Check if used Werf version actually support signing.
Tests:
Actual version: https://github.com/deckhouse/deckhouse-test-1/actions/runs/28808543157/job/85431016317
Fallback: https://github.com/deckhouse/deckhouse-test-1/actions/runs/28808675316/job/85430691919

## Why do we need it, and what problem does it solve?
Current implementation will fail on builds using older Werf version, as they do not support keys used for signing.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: fix
summary: Check if used Werf version actually support signing.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
