### PR TITLE
[deckhouse] drop critical from user-authn

### DIFF
--- a/modules/150-user-authn/module.yaml
+++ b/modules/150-user-authn/module.yaml
@@ -1,5 +1,5 @@
 name: user-authn
-critical: true
+critical: false
 stage: General Availability
 subsystems:
   - security


### PR DESCRIPTION
## Description

Remove `critical: true` from user-authn module. This resolves the issue where user-authn templates depended on cert-manager being available at startup.

## Why do we need it, and what problem does it solve?

user-authn has templates that reference cert-manager resources (Certificate, TLS in Ingress/HTTPRoute, ListenerSet). When cert-manager is not yet available, the module fails at `CanRunHelm` phase. Instead of wrapping every template with `has "cert-manager" .Values.global.enabledModules` guards, we simply mark the module non-critical. Users who need user-authn must ensure cert-manager is available.

## Checklist

- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: user-authn
type: fix
summary: Remove critical flag from user-authn module.
impact_level: low
```