### PR TITLE
[cilium-hubble] Added dependency for UI on module user-authz

### DIFF
--- a/modules/500-cilium-hubble/templates/ui/deployment.yaml
+++ b/modules/500-cilium-hubble/templates/ui/deployment.yaml
@@ -123,7 +123,7 @@ spec:
           value: /var/lib/hubble-ui/certs/client.crt
         - name: TLS_RELAY_CLIENT_KEY_FILE
           value: /var/lib/hubble-ui/certs/client.key
-        {{- if and (ne (include "helm_lib_module_https_mode" .) "Disabled") .Values.ciliumHubble.auth.externalAuthentication }}
+        {{- if and (ne (include "helm_lib_module_https_mode" .) "Disabled") .Values.ciliumHubble.auth.externalAuthentication (.Values.global.enabledModules | has "user-authz") }}
         - name: ENABLE_AUTH
           value: "true"
         {{- end }}

--- a/modules/500-cilium-hubble/templates/ui/httproute.yaml
+++ b/modules/500-cilium-hubble/templates/ui/httproute.yaml
@@ -60,7 +60,7 @@ metadata:
   {{- if or (eq (include "helm_lib_module_https_mode" .) "CertManager") (eq (include "helm_lib_module_https_mode" .) "CustomCertificate") }}
     alb.network.deckhouse.io/response-headers-to-add: '{"Strict-Transport-Security":"max-age=31536000; includeSubDomains"}'
   {{- end }}
-  {{- if and (ne (include "helm_lib_module_https_mode" .) "Disabled") .Values.ciliumHubble.auth.externalAuthentication }}
+  {{- if and (ne (include "helm_lib_module_https_mode" .) "Disabled") .Values.ciliumHubble.auth.externalAuthentication (.Values.global.enabledModules | has "user-authz") }}
     alb.network.deckhouse.io/auth-response-headers: Authorization
     alb.network.deckhouse.io/auth-signin: {{ replace "$host" (include "helm_lib_module_public_domain" (list . "hubble")) .Values.ciliumHubble.auth.externalAuthentication.authSignInURL | quote }}
     alb.network.deckhouse.io/auth-url: {{ .Values.ciliumHubble.auth.externalAuthentication.authURL | quote }}

--- a/modules/500-cilium-hubble/templates/ui/ingress.yaml
+++ b/modules/500-cilium-hubble/templates/ui/ingress.yaml
@@ -13,7 +13,7 @@ metadata:
     nginx.ingress.kubernetes.io/affinity: cookie
     nginx.ingress.kubernetes.io/affinity-mode: persistent
     nginx.ingress.kubernetes.io/session-cookie-name: d8-hubble-affinity
-    {{- if and (ne (include "helm_lib_module_https_mode" .) "Disabled") .Values.ciliumHubble.auth.externalAuthentication }}
+    {{- if and (ne (include "helm_lib_module_https_mode" .) "Disabled") .Values.ciliumHubble.auth.externalAuthentication (.Values.global.enabledModules | has "user-authz") }}
     nginx.ingress.kubernetes.io/auth-response-headers: Authorization
     nginx.ingress.kubernetes.io/auth-signin: {{ .Values.ciliumHubble.auth.externalAuthentication.authSignInURL | quote }}
     nginx.ingress.kubernetes.io/auth-url: {{ .Values.ciliumHubble.auth.externalAuthentication.authURL | quote }}


### PR DESCRIPTION
## Description
This PR adds a dependency on the `user-authz` module when external authentication via OIDC is enabled.

## Why do we need it, and what problem does it solve?
Previously, if the `user-authz` module was disabled while OIDC authentication was enabled, the UI prompted users to authenticate, but authorization bindings were not created because `user-authz` was unavailable. As a result, users were unable to access the UI even after successful authentication.

This change ensures that the required `user-authz` module is enabled whenever OIDC authentication is configured.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: cilium-hubble
type: fix
summary: Added dependency for UI on module user-authz
impact_level: low
```