### PR TITLE
[docs] Fix tooltip styles

### DIFF
--- a/docs/documentation/_includes/module-stage-badge.liquid
+++ b/docs/documentation/_includes/module-stage-badge.liquid
@@ -11,7 +11,7 @@
 {%- endif %}
 {%- if stage and site.data.i18n.features[stage_long][page.lang] %}
   {%- capture alert_content %}
-{{ site.data.i18n.features['module_lifecycle_stage'][page.lang] }}: <i data-tippy-content='{{ site.data.i18n.features[stage_long][page.lang] }}'>{{ stage }}</i>
+{{ site.data.i18n.features['module_lifecycle_stage'][page.lang] }}: <span style='border-bottom: 1px dotted #000' data-tippy-content='{{ site.data.i18n.features[stage_long][page.lang] }}'>{{ stage }}</span>
   {%- if hasRequirements and site.data.i18n.features['requirements_for_alert'][page.lang] %}
   <br>{{ site.data.i18n.features['requirements_for_alert'][page.lang] | replace: "%s", moduleName }}
   {%- endif %}

--- a/docs/site/assets/css/docs.scss
+++ b/docs/site/assets/css/docs.scss
@@ -2687,6 +2687,14 @@ select#contact-select {
     }
   }
 
+  &[data-placement^='top'] .tippy-svg-arrow {
+    bottom: -15px;
+
+    svg {
+      transform: rotate(90deg);
+    }
+  }
+
   &[data-placement^='bottom'] .tippy-svg-arrow {
     top: -12px;
 

--- a/docs/site/backends/docs-builder-template/layouts/_partials/module-stage-badge.html
+++ b/docs/site/backends/docs-builder-template/layouts/_partials/module-stage-badge.html
@@ -26,7 +26,7 @@
        {{- $alertLevel = "danger" }}
     {{- end }}
 
-    {{- $content := printf "%s: <i data-tippy-content='%s'>%s</i>" (T "module_lifecycle_stage") (T (printf "module_alert_%s_long" $statusKey )) $moduleStage }}
+    {{- $content := printf "%s: <span style='border-bottom: 1px dotted #000' data-tippy-content='%s'>%s</span>" (T "module_lifecycle_stage") (T (printf "module_alert_%s_long" $statusKey )) $moduleStage }}
     {{- if $hasRequirements }}
       {{- $content = printf "%s <br>%s" $content (printf (T "requirements_for_alert") $module) }}
     {{- end }}


### PR DESCRIPTION
## Description

This pull request updates the visual presentation of module lifecycle stage badges in both the Liquid and Hugo documentation templates, and improves tooltip arrow positioning in the documentation site styles. The main changes focus on replacing the use of `<i>` tags with `<span>` elements styled with a dotted underline for better clarity and accessibility, and refining the tooltip arrow display for top-placed tooltips.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Fix tooltip styles.
impact_level: low
```
