### PR TITLE
[registry] Migrate to Golang GOST

### DIFF
--- a/modules/038-registry/images/docker-auth/werf.inc.yaml
+++ b/modules/038-registry/images/docker-auth/werf.inc.yaml
@@ -21,7 +21,7 @@ shell:
     - rm -rf /src/docker_auth/.git
 ---
 image: "{{ $.ModuleName }}/{{ $.ImageName }}-artifact"
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 final: false
 import:
   - image: "{{ $.ModuleName }}/{{ $.ImageName }}-src-artifact"
@@ -33,9 +33,6 @@ secrets:
   - id: GOPROXY
     value: "{{ $.GOPROXY }}"
 shell:
-  beforeInstall:
-    {{- include "alpine packages proxy" . | nindent 4 }}
-    - apk add --no-cache make
   install:
     - export GOPROXY=$(cat /run/secrets/GOPROXY)
     - export GOOS=linux

--- a/modules/038-registry/images/docker-distribution/werf.inc.yaml
+++ b/modules/038-registry/images/docker-distribution/werf.inc.yaml
@@ -21,7 +21,7 @@ shell:
     - rm -rf /src/distribution/.git
 ---
 image: "{{ $.ModuleName }}/{{ $.ImageName }}-artifact"
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 final: false
 import:
   - image: "{{ $.ModuleName }}/{{ $.ImageName }}-src-artifact"
@@ -33,9 +33,6 @@ secrets:
   - id: GOPROXY
     value: "{{ $.GOPROXY }}"
 shell:
-  beforeInstall:
-    {{- include "alpine packages proxy" . | nindent 4 }}
-    - apk add --no-cache make
   install:
     - export GOPROXY=$(cat /run/secrets/GOPROXY)
     - export GOOS=linux

--- a/modules/038-registry/images/mirrorer/werf.inc.yaml
+++ b/modules/038-registry/images/mirrorer/werf.inc.yaml
@@ -15,7 +15,7 @@ shell:
     - mkdir -m 1777 /src/tmp
 ---
 image: "{{ $.ModuleName }}/{{ $.ImageName }}-artifact"
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 final: false
 import:
   - image: "{{ $.ModuleName }}/{{ $.ImageName }}-src-artifact"

--- a/modules/038-registry/images/nodeservices-manager/werf.inc.yaml
+++ b/modules/038-registry/images/nodeservices-manager/werf.inc.yaml
@@ -20,7 +20,7 @@ shell:
   - cd /src
 ---
 image: "{{ $.ModuleName }}/{{ $.ImageName }}-artifact"
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 final: false
 import:
   - image: "{{ $.ModuleName }}/{{ $.ImageName }}-src-artifact"

--- a/modules/038-registry/images/registry-proxy/werf.inc.yaml
+++ b/modules/038-registry/images/registry-proxy/werf.inc.yaml
@@ -12,7 +12,7 @@ imageSpec:
     entrypoint: ["/opt/nginx-static/sbin/nginx", "-g", "daemon off;"]
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 final: false
 import:
   - image: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact

--- a/modules/038-registry/images/syncer/werf.inc.yaml
+++ b/modules/038-registry/images/syncer/werf.inc.yaml
@@ -18,7 +18,7 @@ shell:
   - set -e
 ---
 image: "{{ $.ModuleName }}/{{ $.ImageName }}-artifact"
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 final: false
 import:
   - image: "{{ $.ModuleName }}/{{ $.ImageName }}-src-artifact"

--- a/modules/039-registry-packages-proxy/images/registry-packages-proxy/werf.inc.yaml
+++ b/modules/039-registry-packages-proxy/images/registry-packages-proxy/werf.inc.yaml
@@ -43,7 +43,7 @@ shell:
 {{ $rppSignCheck := ternary "true" "false" (eq .Env "CSE") -}}
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 import:
 - image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src


### PR DESCRIPTION
## Description
Replace builder/golang-alpine for builder/golang in module's images.

## Why do we need it, and what problem does it solve?
Converging on one Go builder image and the pm package workflow

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: registry
type: chore
summary: Use unified golang builder and pm-based tooling for 038(-039)-registry image builds 
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
