### PR TITLE
[docs-builder] fix: include module manifests in docs path checks

### DIFF
--- a/docs/site/backends/docs-builder/internal/docs/upload.go
+++ b/docs/site/backends/docs-builder/internal/docs/upload.go
@@ -86,6 +86,13 @@ func (svc *Service) Upload(body io.ReadCloser, moduleName string, version string
 				}
 				svc.logger.Info("creating file", slog.String("path", path))
 
+				// A tar archive is not guaranteed to carry a directory entry
+				// before each file (e.g. root-level module.yaml/oss.yaml have
+				// none), so ensure the parent directory exists before writing.
+				if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+					return fmt.Errorf("mkdir %q failed: %w", filepath.Dir(path), err)
+				}
+
 				outFile, err := os.OpenFile(
 					path,
 					os.O_RDWR|os.O_CREATE|os.O_TRUNC,

--- a/docs/site/backends/docs-builder/internal/docs/upload_test.go
+++ b/docs/site/backends/docs-builder/internal/docs/upload_test.go
@@ -15,6 +15,11 @@
 package docs
 
 import (
+	"archive/tar"
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/deckhouse/deckhouse/pkg/log"
@@ -245,5 +250,64 @@ func TestLoadHandlerGetLocalPath(t *testing.T) {
 				t.Errorf("getLocalPath() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+// TestUploadCreatesRootFiles is a regression test for the case where a
+// root-level file (module.yaml, oss.yaml) is not preceded by its parent
+// directory entry in the tar stream. The extractor must create the parent
+// directory itself instead of failing with "no such file or directory".
+func TestUploadCreatesRootFiles(t *testing.T) {
+	baseDir := t.TempDir()
+	svc := NewService(baseDir, "", false, log.NewNop(), metricsstorage.NewMetricStorage())
+
+	// module.yaml and oss.yaml come first, before any directory entry — this
+	// is what filepath.Walk produces for a module (crds < docs < module.yaml <
+	// oss.yaml < openapi), and modules without a crds/ dir hit this ordering.
+	entries := []struct {
+		name string
+		body string
+	}{
+		{"module.yaml", "name: test\n"},
+		{"oss.yaml", "- name: lib\n"},
+		{"docs/README.md", "# doc\n"},
+		{"crds/backup.yaml", "kind: CRD\n"},
+		{"openapi/config-values.yaml", "type: object\n"},
+	}
+
+	buf := new(bytes.Buffer)
+	tw := tar.NewWriter(buf)
+	for _, e := range entries {
+		if err := tw.WriteHeader(&tar.Header{Name: e.name, Mode: 0o644, Size: int64(len(e.body))}); err != nil {
+			t.Fatalf("write header %q: %v", e.name, err)
+		}
+		if _, err := tw.Write([]byte(e.body)); err != nil {
+			t.Fatalf("write body %q: %v", e.name, err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar: %v", err)
+	}
+
+	if err := svc.Upload(io.NopCloser(buf), "test-module", "v1.0.0", []string{"stable"}); err != nil {
+		t.Fatalf("Upload() error = %v", err)
+	}
+
+	want := map[string]string{
+		filepath.Join(baseDir, "data/modules/test-module/stable/module.yaml"):                "name: test\n",
+		filepath.Join(baseDir, "data/modules/test-module/stable/oss.yaml"):                   "- name: lib\n",
+		filepath.Join(baseDir, "data/modules/test-module/stable/crds/backup.yaml"):           "kind: CRD\n",
+		filepath.Join(baseDir, "data/modules/test-module/stable/openapi/config-values.yaml"): "type: object\n",
+		filepath.Join(baseDir, "content/modules/test-module/stable/README.md"):               "# doc\n",
+	}
+	for path, body := range want {
+		got, err := os.ReadFile(path)
+		if err != nil {
+			t.Errorf("expected file %q: %v", path, err)
+			continue
+		}
+		if string(got) != body {
+			t.Errorf("file %q = %q, want %q", path, got, body)
+		}
 	}
 }

--- a/go_lib/module/docs.go
+++ b/go_lib/module/docs.go
@@ -82,5 +82,7 @@ func extractDocumentation(rc io.ReadCloser, output io.Writer) error {
 func IsDocsPath(path string) bool {
 	return strings.HasPrefix(path, "docs") ||
 		strings.HasPrefix(path, "crds") ||
-		strings.HasPrefix(path, "openapi")
+		strings.HasPrefix(path, "openapi") ||
+		path == "module.yaml" ||
+		path == "oss.yaml"
 }

--- a/go_lib/module/docs_test.go
+++ b/go_lib/module/docs_test.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package module
+
+import (
+	"archive/tar"
+	"bytes"
+	"io"
+	"sort"
+	"testing"
+)
+
+func TestIsDocsPath(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		// documentation directories
+		{"docs", true},
+		{"docs/README.md", true},
+		{"docs/internal/dev.md", true},
+		{"crds", true},
+		{"crds/backup.yaml", true},
+		{"openapi", true},
+		{"openapi/config-values.yaml", true},
+		{"openapi/conversions/v1.yaml", true},
+		// module metadata — the whole point of this test: these must be
+		// included so the in-cluster docs builder receives module.yaml/oss.yaml.
+		{"module.yaml", true},
+		{"oss.yaml", true},
+		// exact match only: metadata is accepted at the module root, not as a
+		// prefix or nested copy.
+		{"module.yaml.bak", false},
+		{"subdir/module.yaml", false},
+		{"oss.yaml.tpl", false},
+		{"crds/module.yaml", true}, // still accepted, but via the crds/ rule
+		// everything else that ships in a module must be dropped.
+		{"Chart.yaml", false},
+		{"values.yaml", false},
+		{"templates/deployment.yaml", false},
+		{"hooks/main.go", false},
+		{"images/backend/Dockerfile", false},
+		{"README.md", false},
+		{".helmignore", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			if got := IsDocsPath(tt.path); got != tt.want {
+				t.Errorf("IsDocsPath(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractDocumentation(t *testing.T) {
+	// A representative module layout: doc content, CRDs, openapi, module
+	// metadata, plus files that must not leak into the documentation.
+	input := []tarEntry{
+		{name: "module.yaml", body: "name: test\n"},
+		{name: "oss.yaml", body: "- name: lib\n"},
+		{name: "docs", dir: true},
+		{name: "docs/README.md", body: "# doc\n"},
+		{name: "crds/backup.yaml", body: "kind: CRD\n"},
+		{name: "openapi/config-values.yaml", body: "type: object\n"},
+		// must be excluded
+		{name: "Chart.yaml", body: "name: test\n"},
+		{name: "hooks/main.go", body: "package main\n"},
+		{name: "templates/deployment.yaml", body: "kind: Deployment\n"},
+	}
+
+	out := new(bytes.Buffer)
+	if err := extractDocumentation(io.NopCloser(buildTar(t, input)), out); err != nil {
+		t.Fatalf("extractDocumentation() error = %v", err)
+	}
+
+	got := tarNames(t, out)
+	want := []string{
+		"crds/backup.yaml",
+		"docs",
+		"docs/README.md",
+		"module.yaml",
+		"openapi/config-values.yaml",
+		"oss.yaml",
+	}
+	sort.Strings(got)
+
+	if len(got) != len(want) {
+		t.Fatalf("extracted names = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("extracted names = %v, want %v", got, want)
+		}
+	}
+}
+
+type tarEntry struct {
+	name string
+	body string
+	dir  bool
+}
+
+func buildTar(t *testing.T, entries []tarEntry) *bytes.Buffer {
+	t.Helper()
+
+	buf := new(bytes.Buffer)
+	w := tar.NewWriter(buf)
+	for _, e := range entries {
+		hdr := &tar.Header{Name: e.name, Mode: 0o644, Size: int64(len(e.body))}
+		if e.dir {
+			hdr.Typeflag = tar.TypeDir
+			hdr.Mode = 0o755
+			hdr.Size = 0
+		}
+		if err := w.WriteHeader(hdr); err != nil {
+			t.Fatalf("write header %q: %v", e.name, err)
+		}
+		if !e.dir {
+			if _, err := w.Write([]byte(e.body)); err != nil {
+				t.Fatalf("write body %q: %v", e.name, err)
+			}
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close tar: %v", err)
+	}
+	return buf
+}
+
+func tarNames(t *testing.T, r io.Reader) []string {
+	t.Helper()
+
+	var names []string
+	tr := tar.NewReader(r)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("read tar: %v", err)
+		}
+		names = append(names, hdr.Name)
+	}
+	return names
+}


### PR DESCRIPTION
## Description

Two changes fix module metadata (`module.yaml`, `oss.yaml`) missing from the **in-cluster** documentation.

1. **`go_lib/module/docs.go`** — `IsDocsPath` now accepts root-level `module.yaml` and `oss.yaml`. This is the filter used by the deckhouse-controller when it builds the documentation archive for a module (both `getDocumentationFromModuleDir` and `ExtractDocs`), so these files now actually reach the docs-builder.

2. **`docs/site/backends/docs-builder/internal/docs/upload.go`** — `Upload` now `MkdirAll`s the parent directory before writing each file. A tar archive is not guaranteed to carry a directory entry before every file (root-level `module.yaml`/`oss.yaml` have none), so extraction no longer fails with `open .../stable/module.yaml: no such file or directory` for modules that ship no `crds/` directory.

Tests added:
- `go_lib/module`: `TestIsDocsPath` and `TestExtractDocumentation` (full module layout — `module.yaml`/`oss.yaml`/`docs`/`crds`/`openapi` retained, `Chart.yaml`/`*.go`/`templates/` dropped).
- `docs-builder`: `TestUploadCreatesRootFiles` — regression test that extracts a tar whose root-level files precede any directory entry.

Both fixes are required together: without (1) the files are never sent; without (2) they fail to be written for modules without `crds/`.

## Why do we need it, and what problem does it solve?

In the in-cluster documentation (the `documentation-*` pod in `d8-system`) module metadata was missing: `module.yaml` and `oss.yaml` were absent from `hugo/data/modules/<module>/<channel>/`, so the metadata-derived parts of the module pages were not rendered.

Root cause is a sync gap between two independent documentation-extraction pipelines:
- the **public site** (`registry-modules-watcher`, `isDocumentationFile`), and
- the **in-cluster builder** (deckhouse-controller → `go_lib/module.IsDocsPath` → `docs-builder`).

PR #16794 ("Get modules metadata from module.yaml") taught the site scanner and the docs-builder **receiver** (`getLocalPath`) to consume `module.yaml`/`oss.yaml`, but the in-cluster **sender** filter `IsDocsPath` was never updated. As a result the receiver expected metadata the sender never shipped — the in-cluster path was half-wired and silently dropped the files. The public site was unaffected because it uses a separate extraction path that already handled these files. This went unnoticed for ~7 months because the failure was silent, in-cluster only, and untested.

Fixing `IsDocsPath` exposed a second, latent defect: the extractor created directories only from `tar.TypeDir` entries and assumed each file was preceded by its parent directory entry. Root-level files broke that assumption, so the `MkdirAll`-per-file change makes extraction robust regardless of archive ordering or missing directory entries.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: Fix module metadata (`module.yaml`/`oss.yaml`) missing from in-cluster documentation by allowing these files in `IsDocsPath` (sender) and creating parent directories on extraction in the docs-builder (receiver).
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
