### PR TITLE
[docs] Add fallback empty stage span for modules lacking a stage value

### DIFF
--- a/docs/site/backends/docs-builder-template/layouts/modules/baseof.html
+++ b/docs/site/backends/docs-builder-template/layouts/modules/baseof.html
@@ -72,22 +72,22 @@
     });
 
   </script>
-{{ if .Store.Get "hasMermaid" }}
+{{- if .Store.Get "hasMermaid" }}
   <script src="/assets/js/mermaid.min.js"></script>
   <script>mermaid.initialize({ startOnLoad: true });</script>
-{{ end }}
-<script type="text/javascript">
-  // Fix second level topnav menu for GS and guides sections.
-  let subUrls = ['/modules/'];
-  subUrls.forEach(function (element) {
-    if (window.location.pathname.toLowerCase().includes(element)) {
-      $('.header.header__product-menu ul.nav li, .header__content.container ul.nav li').each(function () {
-        const href = $(this).find('a').attr('href')?.toLowerCase() || '';
-        const isActive = href.includes(element);
-        $(this).toggleClass('active', isActive);
-      });
-    }
-  });
-</script>
+{{- end }}
+  <script type="text/javascript">
+    // Fix second level topnav menu for GS and guides sections.
+    let subUrls = ['/modules/'];
+    subUrls.forEach(function (element) {
+      if (window.location.pathname.toLowerCase().includes(element)) {
+        $('.header.header__product-menu ul.nav li, .header__content.container ul.nav li').each(function () {
+          const href = $(this).find('a').attr('href')?.toLowerCase() || '';
+          const isActive = href.includes(element);
+          $(this).toggleClass('active', isActive);
+        });
+      }
+    });
+  </script>
 </body>
 </html>

--- a/docs/site/backends/docs-builder-template/layouts/modules/modules-list.html
+++ b/docs/site/backends/docs-builder-template/layouts/modules/modules-list.html
@@ -70,7 +70,7 @@
   {{- $moduleDescription := "" }}
   {{- $moduleTags := slice }}
 
-  {{/* Skip the embedded module if there is external module with the same name */}}
+  {{- /* Skip the embedded module if there is external module with the same name */}}
   {{- $embeddedModuleWithTheSameName := (where $embeddedModulesList "module" $module) }}
   {{- if gt ($embeddedModuleWithTheSameName | len) 0 }}
     {{- warnf "Found embedded module %s and external modules with the same name. Use only external module." $module }}
@@ -79,10 +79,10 @@
   {{- $moduleTags = index (index $modulesEditions $module) "tags" }}
 
   {{- range sort $channelsInfo "stability" "desc" }}
-    {{/* Skip rock-solid channel */}}
+    {{- /* Skip rock-solid channel */}}
     {{- if eq .code "rock-solid"  }}{{ continue }}{{ end }}
 
-    {{/* The condition to select the data from the available stablest module channel */}}
+    {{- /* The condition to select the data from the available stablest module channel */}}
     {{- if gt ( $moduleTitle | len ) 0  }}{{ continue }}{{ end }}
 
     {{- $channel := .code }}
@@ -92,20 +92,20 @@
       {{- end }}
       {{- if not $moduleChannel }}{{ $moduleChannel = $channel }}{{ end }}
       {{- if not $moduleDescription }}{{ $moduleDescription = .Description }}{{ end }}
-    {{- end}}
-  {{- end}}
+    {{- end }}
+  {{- end -}}
 
   {{- $moduleData := index (index hugo.Data.modules $module) $moduleChannel }}
   {{- $moduleMetadata := index $moduleData "module" }}
   {{- $moduleOss := index $moduleData "oss" }}
   {{- if and $moduleMetadata $moduleOss }}
     {{- $moduleMetadata = merge $moduleMetadata (dict "oss" $moduleOss) }}
-  {{- end }}
+  {{- end -}}
 
   {{- if not $moduleTitle }}{{ $moduleTitle = $module }}{{ end }}
   {{- if (not $moduleChannel ) }}{{ continue }}{{ end }}
   {{- $modulesList = $modulesList | append (dict "module" $module "title" $moduleTitle "channel" $moduleChannel "description" $moduleDescription "metadata" $moduleMetadata "tags" $moduleTags "url" (printf "%s/%s/" $module $moduleChannel ) ) }}
-{{- end}}
+{{- end }}
 
 {{- warnf "Found %d modules from sources." ($modulesList | len) }}
 
@@ -123,7 +123,7 @@
   {{- $modulesList = $modulesList | append $filteredEmbeddedModules }}
 {{- else }}
   {{- warnf "No embedded modules found!" }}
-{{- end }}
+{{- end -}}
 
       <div class="block__tile">
       {{- range (sort $modulesList "module" "asc") }}
@@ -134,7 +134,7 @@
         {{- if .metadata }}
           {{- $moduleStage = .metadata.stage }}
 
-          {{/* Try to get description from module metadata (module.yaml) */}}
+          {{- /* Try to get description from module metadata (module.yaml) */}}
           {{- $moduleMetadataDescriptions := index .metadata "descriptions" }}
           {{- if and $moduleMetadataDescriptions (index $moduleMetadataDescriptions $lang) (gt (index $moduleMetadataDescriptions $lang | len ) 0) }}
             {{- $moduleDescription = index $moduleMetadataDescriptions $lang }}
@@ -147,7 +147,7 @@
         {{- $moduleEditionsString := "" }}
 
         {{- if .embedded }}
-          {{/* make edition list for an embedded module */}}
+          {{- /* make edition list for an embedded module */}}
           {{- $embeddedModuleMetadata := index (where $embeddedModulesList "module" .module ) 0 }}
 
           {{- if index $embeddedModuleMetadata "editionMinimumAvailable" }}
@@ -160,32 +160,32 @@
             {{- end }}
           {{- else if index $embeddedModuleMetadata "editions" }}
             {{- $moduleEditionsData = index $embeddedModuleMetadata "editions" }}
-          {{ end }}
+          {{- end }}
 
-          {{/* remove or add edition if the embedded module is in the excludeModules in the $embeddedModulesEditionsGlobal list */}}
-          {{ range $key, $val := $embeddedModulesEditionsGlobal }}
-            {{ if and $val.excludeModules (in $val.excludeModules $moduleName) }}
-                {{ $filtered := slice }}
+          {{- /* remove or add edition if the embedded module is in the excludeModules in the $embeddedModulesEditionsGlobal list */}}
+          {{- range $key, $val := $embeddedModulesEditionsGlobal }}
+            {{- if and $val.excludeModules (in $val.excludeModules $moduleName) }}
+                {{- $filtered := slice }}
 
-                {{ range $moduleEditionsData }}
-                  {{ if ne . $key }}
-                    {{ $filtered = $filtered | append . }}
-                  {{ end }}
-                {{ end }}
-                {{ $moduleEditionsData = $filtered }}
+                {{- range $moduleEditionsData }}
+                  {{- if ne . $key }}
+                    {{- $filtered = $filtered | append . }}
+                  {{- end }}
+                {{- end }}
+                {{- $moduleEditionsData = $filtered }}
 
-            {{ end }}
-            {{ if and $val.includeModules (in $val.includeModules $moduleName) }}
-                {{ if not (in $moduleEditionsData $key) }}
-                  {{ $moduleEditionsData = $moduleEditionsData | append $key }}
-                {{ end }}
-            {{ end }}
-          {{ end }}
+            {{- end }}
+            {{- if and $val.includeModules (in $val.includeModules $moduleName) }}
+                {{- if not (in $moduleEditionsData $key) }}
+                  {{- $moduleEditionsData = $moduleEditionsData | append $key }}
+                {{- end }}
+            {{- end }}
+          {{- end }}
 
           {{- $moduleEditionsString = delimit $moduleEditionsData "," }}
 
         {{- else if isset $modulesEditions .module }}
-          {{/* make edition list for a module from source */}}
+          {{- /* make edition list for a module from source */}}
           {{- $moduleEditionsData = index $modulesEditions .module }}
           {{- $_editions := default slice (index $moduleEditionsData "editions") | append (index $moduleEditionsData "editionsWithRestrictions") |uniq }}
           {{- $moduleEditionsString = delimit $_editions "," }}
@@ -198,14 +198,15 @@
           <span class='button-tile__stage' data-stage="generalAvailability"></span>
           {{- else }}
           {{- $stageKey := lower $moduleStage }}
-          {{- $stageIcon := $stageKey }}
+          {{- $stageIcon := $stageKey -}}
           <span class='button-tile__stage button-tile__stage-{{ $stageKey }}'>
             <img src="/images/{{ $stageIcon }}.svg" alt="{{- $moduleStage }}">
           </span>
           {{- end }}
+        {{- else -}}{{/* Print epmty span in case of empty stage... It will look like GA, but it is better than incorrect badge markup */}}
+          <span class='button-tile__stage'></span>
         {{- end }}
-        <h2 class="button-tile__title">{{ .module }}</h2>
-
+          <h2 class="button-tile__title">{{ .module }}</h2>
           <p class="button-tile__descr">
             {{ $moduleDescription }}
           </p>
@@ -213,14 +214,14 @@
             <div class="button-tile__tags">
 
               {{- range $tags }}
-                {{ if eq . "embedded" }}
-                  {{ continue }}
-                {{ end }}
+                {{- if eq . "embedded" }}
+                  {{- continue }}
+                {{- end }}
                 <span class="sidebar__badge--container"><span class="sidebar__badge_v2">{{ . }}</span></span>
-              {{- end }}
+              {{- end -}}
 
             </div>
-            {{/* <div class="button-tile__time">
+            {{- /* <div class="button-tile__time">
               <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <circle cx="6" cy="6" r="5.25" stroke="#5E6697" stroke-width="1.5"/>
                 <path d="M4.25 6H6V3.375" stroke="#5E6697" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>

--- a/docs/site/backends/docs-builder-template/layouts/modules/single.html
+++ b/docs/site/backends/docs-builder-template/layouts/modules/single.html
@@ -130,7 +130,7 @@
     </div>
     {{- if ne site.Params.mode "module" }}
      {{- "<!--#include virtual=\"/includes/feedback.html\" -->"  | safeHTML }}
-    {{ end }}
+    {{- end }}
   </div>
 
   <div class="layout-sidebar__sidebar_right">


### PR DESCRIPTION
## Description
- Add fallback empty stage span for modules lacking a stage value to prevent broken badge markup in the tile grid
- Apply whitespace-trimming hyphens to Hugo template actions across module layouts to eliminate spurious blank lines and stray whitespace in rendered HTML output
- Normalise inline script indentation within the base layout to align with surrounding document structure

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Add fallback empty stage span for modules lacking a stage value.
impact_level: low
```
