### PR TITLE
[docs-builder] fix: validate upload and delete paths

### DIFF
--- a/docs/site/backends/docs-builder/internal/docs/delete.go
+++ b/docs/site/backends/docs-builder/internal/docs/delete.go
@@ -30,6 +30,18 @@ func (svc *Service) Delete(moduleName string, channels []string) error {
 		svc.metrics.HistogramObserve(metrics.DocsBuilderDeleteDurationSeconds, dur, map[string]string{"status": status}, nil)
 	}()
 
+	if err := validateModuleName(moduleName); err != nil {
+		status = "fail"
+
+		return fmt.Errorf("validate module name: %w", err)
+	}
+
+	if err := validateChannels(channels); err != nil {
+		status = "fail"
+
+		return fmt.Errorf("validate channels: %w", err)
+	}
+
 	err := svc.cleanModulesFiles(moduleName, channels)
 	if err != nil {
 		status = "fail"

--- a/docs/site/backends/docs-builder/internal/docs/upload.go
+++ b/docs/site/backends/docs-builder/internal/docs/upload.go
@@ -36,6 +36,18 @@ func (svc *Service) Upload(body io.ReadCloser, moduleName string, version string
 		svc.metrics.HistogramObserve(metrics.DocsBuilderUploadDurationSeconds, dur, map[string]string{"status": status}, nil)
 	}()
 
+	if err := validateModuleName(moduleName); err != nil {
+		status = "fail"
+
+		return fmt.Errorf("validate module name: %w", err)
+	}
+
+	if err := validateChannels(channels); err != nil {
+		status = "fail"
+
+		return fmt.Errorf("validate channels: %w", err)
+	}
+
 	err := svc.cleanModulesFiles(moduleName, channels)
 	if err != nil {
 		status = "fail"
@@ -150,12 +162,23 @@ func (svc *Service) getLocalPath(moduleName, channel, fileName string) (string, 
 		fileName = strings.Replace(fileName, "_RU.md", ".ru.md", 1)
 	}
 
+	checked := func(path string) (string, bool) {
+		if err := ensureWithinBase(svc.baseDir, path); err != nil {
+			svc.logger.Warn("skipping path outside base directory", slog.String("path", path), slog.String("error", err.Error()))
+
+			return "", false
+		}
+
+		return path, true
+	}
+
 	if fileName, ok := strings.CutPrefix(fileName, "docs"); ok {
 		// Skip internal documentation directories that should not be published
 		if hasBlockedPrefix(fileName) {
 			return "", false
 		}
-		return filepath.Join(svc.baseDir, contentDir, moduleName, channel, fileName), true
+
+		return checked(filepath.Join(svc.baseDir, contentDir, moduleName, channel, fileName))
 	}
 
 	if isAllowedCRDPath(fileName) ||
@@ -163,11 +186,11 @@ func (svc *Service) getLocalPath(moduleName, channel, fileName string) (string, 
 		fileName == "openapi/conversions" ||
 		fileName == "openapi/config-values.yaml" ||
 		docConfValuesRegexp.MatchString(fileName) {
-		return filepath.Join(svc.baseDir, modulesDir, moduleName, channel, fileName), true
+		return checked(filepath.Join(svc.baseDir, modulesDir, moduleName, channel, fileName))
 	}
 
 	if fileName == "module.yaml" || fileName == "oss.yaml" {
-		return filepath.Join(svc.baseDir, modulesDir, moduleName, channel, fileName), true
+		return checked(filepath.Join(svc.baseDir, modulesDir, moduleName, channel, fileName))
 	}
 
 	return "", false
@@ -240,12 +263,22 @@ func hasBlockedPrefix(path string) bool {
 func (svc *Service) cleanModulesFiles(moduleName string, channels []string) error {
 	for _, channel := range channels {
 		path := filepath.Join(svc.baseDir, contentDir, moduleName, channel)
+
+		if err := ensureWithinBase(svc.baseDir, path); err != nil {
+			return fmt.Errorf("ensure within base: %w", err)
+		}
+
 		err := os.RemoveAll(path)
 		if err != nil {
 			return fmt.Errorf("remove content %s: %w", path, err)
 		}
 
 		path = filepath.Join(svc.baseDir, modulesDir, moduleName, channel)
+
+		if err := ensureWithinBase(svc.baseDir, path); err != nil {
+			return fmt.Errorf("ensure within base: %w", err)
+		}
+
 		err = os.RemoveAll(path)
 		if err != nil {
 			return fmt.Errorf("remove data %s: %w", path, err)

--- a/docs/site/backends/docs-builder/internal/docs/validate.go
+++ b/docs/site/backends/docs-builder/internal/docs/validate.go
@@ -1,0 +1,75 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docs
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// nameRegexp restricts module and channel names to a strict allow-list.
+//
+// It mirrors the RFC 1123 label naming used by Kubernetes object names (where
+// legitimate module names originate) and, crucially, forbids every character
+// usable for path traversal — a matching value contains no '/', '.' or '..'.
+// This is the primary guard against CWE-22: moduleName and channel are
+// attacker-controllable request parameters that get joined into filesystem
+// paths (see cleanModulesFiles and getLocalPath).
+var nameRegexp = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
+
+// validateModuleName rejects a module name that could escape the base
+// directory when joined into a filesystem path.
+func validateModuleName(moduleName string) error {
+	if !nameRegexp.MatchString(moduleName) {
+		return fmt.Errorf("invalid module name %q: must match %s", moduleName, nameRegexp.String())
+	}
+
+	return nil
+}
+
+// validateChannels rejects an empty channel list or any channel name that
+// could escape the base directory when joined into a filesystem path.
+func validateChannels(channels []string) error {
+	if len(channels) == 0 {
+		return fmt.Errorf("no channels provided")
+	}
+
+	for _, channel := range channels {
+		if !nameRegexp.MatchString(channel) {
+			return fmt.Errorf("invalid channel %q: must match %s", channel, nameRegexp.String())
+		}
+	}
+
+	return nil
+}
+
+// ensureWithinBase reports an error if the cleaned path escapes baseDir. It is
+// a defense-in-depth complement to validateModuleName/validateChannels: even if
+// some new path segment were to slip past name validation, a write or delete
+// outside baseDir is still refused.
+func ensureWithinBase(baseDir, path string) error {
+	rel, err := filepath.Rel(baseDir, path)
+	if err != nil {
+		return fmt.Errorf("resolve %q against %q: %w", path, baseDir, err)
+	}
+
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("path %q escapes base directory %q", path, baseDir)
+	}
+
+	return nil
+}

--- a/docs/site/backends/docs-builder/internal/docs/validate_test.go
+++ b/docs/site/backends/docs-builder/internal/docs/validate_test.go
@@ -1,0 +1,130 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docs
+
+import (
+	"testing"
+
+	"github.com/deckhouse/deckhouse/pkg/log"
+	metricsstorage "github.com/deckhouse/deckhouse/pkg/metrics-storage"
+)
+
+func TestValidateModuleName(t *testing.T) {
+	tests := []struct {
+		name    string
+		wantErr bool
+	}{
+		{"stronghold", false},
+		{"cert-manager", false},
+		{"user-authn", false},
+		{"node-local-dns", false},
+		{"m0dule1", false},
+		{"", true},
+		{"-leading", true},
+		{"trailing-", true},
+		{"Upper", true},
+		{"with.dot", true},
+		{"with/slash", true},
+		{"..", true},
+		{"../../../../app", true},
+		{"../etc", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateModuleName(tt.name)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateModuleName(%q) error = %v, wantErr %v", tt.name, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateChannels(t *testing.T) {
+	tests := []struct {
+		name     string
+		channels []string
+		wantErr  bool
+	}{
+		{"default stable", []string{"stable"}, false},
+		{"all release channels", []string{"alpha", "beta", "early-access", "rock-solid", "stable"}, false},
+		{"empty list", []string{}, true},
+		{"nil list", nil, true},
+		{"one empty channel", []string{"stable", ""}, true},
+		{"traversal channel", []string{"../../../../../../app/hugo/content"}, true},
+		{"dot in channel", []string{"a.b"}, true},
+		{"slash in channel", []string{"a/b"}, true},
+		{"one bad among good", []string{"stable", "../evil"}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateChannels(tt.channels)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateChannels(%v) error = %v, wantErr %v", tt.channels, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestEnsureWithinBase(t *testing.T) {
+	const base = "/app/hugo"
+
+	tests := []struct {
+		name    string
+		path    string
+		wantErr bool
+	}{
+		{"base itself", "/app/hugo", false},
+		{"child", "/app/hugo/content/modules/foo/stable", false},
+		{"sibling with shared prefix", "/app/hugo-init/x", true},
+		{"parent", "/app", true},
+		{"escape via join", "/app/hugo/content/modules/../../../../tmp/evil", true},
+		{"unrelated", "/tmp/evil", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ensureWithinBase(base, tt.path)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ensureWithinBase(%q, %q) error = %v, wantErr %v", base, tt.path, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestUploadRejectsTraversal(t *testing.T) {
+	svc := NewService("/app/hugo/", "", false, log.NewNop(), metricsstorage.NewMetricStorage())
+
+	if err := svc.Upload(nil, "../../../../app", "v1.0.0", []string{"stable"}); err == nil {
+		t.Error("Upload with traversal moduleName: expected error, got nil")
+	}
+
+	if err := svc.Upload(nil, "pwn", "v1.0.0", []string{"../../../../../../app/hugo/content"}); err == nil {
+		t.Error("Upload with traversal channel: expected error, got nil")
+	}
+}
+
+func TestDeleteRejectsTraversal(t *testing.T) {
+	svc := NewService("/app/hugo/", "", false, log.NewNop(), metricsstorage.NewMetricStorage())
+
+	if err := svc.Delete("../../../../app", []string{"stable"}); err == nil {
+		t.Error("Delete with traversal moduleName: expected error, got nil")
+	}
+
+	if err := svc.Delete("pwn", []string{"../../../../../../app/hugo/content"}); err == nil {
+		t.Error("Delete with traversal channel: expected error, got nil")
+	}
+}

--- a/modules/810-documentation/template_tests/network_policy_test.go
+++ b/modules/810-documentation/template_tests/network_policy_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template_tests
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/helm"
+)
+
+const globalValuesBootstrapped = `
+clusterIsBootstrapped: true
+enabledModules: ["vertical-pod-autoscaler", "documentation"]
+modules:
+  https:
+    mode: CustomCertificate
+  publicDomainTemplate: "%s.example.com"
+  placement: {}
+discovery:
+  clusterDomain: cluster.local
+  d8SpecificNodeCountByRole:
+    system: 1
+    master: 1
+`
+
+const documentationValuesBootstrapped = `
+https:
+  mode: CustomCertificate
+auth: {}
+internal:
+  deployDexAuthenticator: false
+  auth:
+    password: testpassword
+  customCertificateData:
+    tls.crt: CRTCRTCRT
+    tls.key: KEYKEYKEY
+`
+
+var _ = Describe("Module :: documentation :: helm template :: network policy", func() {
+	f := SetupHelmConfig(``)
+
+	Context("Bootstrapped cluster with public domain", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", globalValuesBootstrapped)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYaml("documentation", documentationValuesBootstrapped)
+			f.HelmRender()
+		})
+
+		It("Renders a NetworkPolicy that locks down the builder port", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			np := f.KubernetesResource("NetworkPolicy", "d8-system", "documentation")
+			Expect(np.Exists()).To(BeTrue())
+
+			Expect(np.Field("spec.podSelector.matchLabels.app").String()).To(Equal("documentation"))
+			Expect(np.Field("spec.policyTypes").String()).To(Equal(`["Ingress"]`))
+
+			ingress := np.Field("spec.ingress").Array()
+			Expect(ingress).To(HaveLen(3))
+
+			// :8081 — only from the Deckhouse controller in d8-system.
+			Expect(ingress[0].Get("ports.0.port").Int()).To(Equal(int64(8081)))
+			Expect(ingress[0].Get("from.0.namespaceSelector.matchLabels.kubernetes\\.io/metadata\\.name").String()).To(Equal("d8-system"))
+			Expect(ingress[0].Get("from.0.podSelector.matchLabels.app").String()).To(Equal("deckhouse"))
+
+			// :8443 — kube-rbac-proxy, reachable without a source restriction.
+			Expect(ingress[1].Get("ports.0.port").Int()).To(Equal(int64(8443)))
+			Expect(ingress[1].Get("from").Exists()).To(BeFalse())
+
+			// :9090 — metrics scraped from d8-monitoring.
+			Expect(ingress[2].Get("ports.0.port").Int()).To(Equal(int64(9090)))
+			Expect(ingress[2].Get("from.0.namespaceSelector.matchLabels.kubernetes\\.io/metadata\\.name").String()).To(Equal("d8-monitoring"))
+		})
+	})
+
+	Context("Non-bootstrapped cluster", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", globalValues)
+			f.ValuesSetFromYaml("documentation", customCertificatePresent)
+			f.HelmRender()
+		})
+
+		It("Does not render the NetworkPolicy", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+			Expect(f.KubernetesResource("NetworkPolicy", "d8-system", "documentation").Exists()).To(BeFalse())
+		})
+	})
+})

--- a/modules/810-documentation/templates/network-policy.yaml
+++ b/modules/810-documentation/templates/network-policy.yaml
@@ -1,0 +1,44 @@
+{{- if and .Values.global.modules.publicDomainTemplate .Values.global.clusterIsBootstrapped }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: documentation
+  namespace: d8-system
+  {{- include "helm_lib_module_labels" (list . (dict "app" "documentation")) | nindent 2 }}
+spec:
+  podSelector:
+    matchLabels:
+      app: documentation
+  policyTypes:
+    - Ingress
+  ingress:
+    # docs-builder API (:8081) has no authentication of its own, so it must be
+    # reachable only from the Deckhouse controller, which uploads/deletes module
+    # documentation. Selecting the pod for Ingress makes every other unlisted
+    # ingress flow (e.g. cross-pod access to the un-authenticated nginx :8080)
+    # denied by default. See CWE-22 hardening in docs-builder.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: d8-system
+          podSelector:
+            matchLabels:
+              app: deckhouse
+      ports:
+        - protocol: TCP
+          port: 8081
+    # Public documentation is served through kube-rbac-proxy (:8443), which
+    # enforces its own authentication; keep it reachable from Ingress/Gateway.
+    - ports:
+        - protocol: TCP
+          port: 8443
+    # Prometheus scrapes the builder metrics endpoint (:9090) from d8-monitoring.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: d8-monitoring
+      ports:
+        - protocol: TCP
+          port: 9090
+{{- end }}


### PR DESCRIPTION
## Description

Harden the `docs-builder` service in the `810-documentation` module against a path-traversal vulnerability (CWE-22) in its internal upload/delete HTTP API, and restrict network exposure of the un-authenticated builder port.

**1. Path validation (`docs/site/backends/docs-builder/internal/docs`)**

- New `validate.go` introduces a strict allow-list for the request-controlled `moduleName` and `channels` values. Names must match `^[a-z0-9]([a-z0-9-]*[a-z0-9])?$` (RFC 1123 label style), which structurally forbids `/`, `.` and `..` — the characters needed for traversal. Empty channel lists are rejected.
- `Upload` and `Delete` now call `validateModuleName` / `validateChannels` **before** any filesystem operation (i.e. before `cleanModulesFiles`).
- Defense-in-depth: `ensureWithinBase` verifies (via `filepath.Rel`) that every joined path still resolves under `svc.baseDir`. It guards both the `os.RemoveAll` calls in `cleanModulesFiles` and every write path returned by `getLocalPath`. Even if a segment slipped past name validation, a write/delete outside `baseDir` is refused.
- Added `validate_test.go` covering module-name, channel, and containment cas

**2. NetworkPolicy (`modules/810-documentation/templates/network-policy.yaml`)**

- The docs-builder API on `:8081` has no authentication of its own. The new NetworkPolicy makes it reachable **only** from the Deckhouse controller pod (`app: deckhouse` in`d8-system`), which is the sole legitimate caller for uploading/deleting module docs.
- Selecting the `documentation` pod for Ingress makes all other unlisted flows default-deny, while explicitly keeping the authenticated public path (`kube-rbac-proxy :8443`) andPrometheus metrics scraping (`:9090` from `d8-monitoring`) open.
- Added `network_policy_test.go` template test.

## Why do we need it, and what problem does it solve?

The docs-builder container exposes an internal HTTP API on port `8081` (bound directly to the pod IP) for uploading and deleting module documentation. This port is **not** behind `kube-rbac-proxy`, is not part of any Service, and shipped with **no NetworkPolicy** — so it was unauthenticated and reachable from anywhere in the cluster network.

The `moduleName` (URL path segment) and `channels` (query string) parameters were passed straight into filesystem operations (`filepath.Join` → `os.RemoveAll` / `os.OpenFile`) with no validation. Because `filepath.Join` calls `filepath.Clean`, which collapses `..` segments, a value such as `channels=../../../../../../app/hugo/content` resolved **outside** `svc.baseDir`. The existing traversal guard only checked file names inside the tar archive (`header.Name`), never `moduleName` or `channel`.

This allowed any pod with network access to the documentation pod to:

- **Denial of Service** — recursively delete arbitrary directories inside the container (`DELETE /api/v1/doc/pwn?channels=../../../../../../app/hugo/content`), destroying the documentation service filesystem.
- **Arbitrary file write** — place attacker-controlled `.md`/`.yaml`/`.json` files at arbitrary paths (`POST /api/v1/doc/pwn/1.0.0?channels=../../../../tmp/evil`).

**Severity: Medium** (CVSS 3.1 `AV:A/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N/IR:L`)

The input validation and path-containment checks are the primary fix; the NetworkPolicy reduces the blast radius by ensuring only the Deckhouse controller can reach the API even if a future regression reintroduces a traversal bug.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: Fixes an unauthenticated path traversal (CWE-22) in docs-builder by validating moduleName/channels and enforcing base-directory containment before any filesystem operation.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
