### PR TITLE
[candi] disable apiserver watch cache for ManifestCheckpointContentChunk

### DIFF
--- a/candi/control-plane-kubeadm/v1beta4/patches/kube-apiserver.yaml.tpl
+++ b/candi/control-plane-kubeadm/v1beta4/patches/kube-apiserver.yaml.tpl
@@ -137,3 +137,14 @@ spec:
     {{- end }}
   {{- end }}
 {{- end }}
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kube-apiserver
+  namespace: kube-system
+spec:
+  containers:
+  - name: kube-apiserver
+    args:
+    - --watch-cache-sizes=manifestcheckpointcontentchunks.state-snapshotter.deckhouse.io#0

--- a/modules/040-control-plane-manager/template_tests/template_test.go
+++ b/modules/040-control-plane-manager/template_tests/template_test.go
@@ -492,7 +492,7 @@ resources:
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(kubeApiserver).To(ContainSubstring("--service-account-issuer"))
 				documents := strings.Split(string(kubeApiserver), "---")
-				Expect(documents).To(HaveLen(7))
+				Expect(documents).To(HaveLen(8))
 				podWithExtraArgs := []byte(documents[6])
 				var pod corev1.Pod
 				expectedServiceAccountIssuers := []string{
@@ -534,7 +534,7 @@ resources:
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(kubeApiserver).To(ContainSubstring("--service-account-issuer"))
 				documents := strings.Split(string(kubeApiserver), "---")
-				Expect(documents).To(HaveLen(7))
+				Expect(documents).To(HaveLen(8))
 				podWithExtraArgs := []byte(documents[6])
 				var pod corev1.Pod
 				expectedServiceAccountIssuers := []string{
@@ -579,7 +579,7 @@ resources:
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(kubeApiserver).To(ContainSubstring("--service-account-issuer"))
 				documents := strings.Split(string(kubeApiserver), "---")
-				Expect(documents).To(HaveLen(7))
+				Expect(documents).To(HaveLen(8))
 				podWithExtraArgs := []byte(documents[6])
 				var pod corev1.Pod
 				expectedServiceAccountIssuers := []string{
@@ -624,7 +624,7 @@ resources:
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(kubeApiserver).To(ContainSubstring("--service-account-issuer"))
 				documents := strings.Split(string(kubeApiserver), "---")
-				Expect(documents).To(HaveLen(7))
+				Expect(documents).To(HaveLen(8))
 				podWithExtraArgs := []byte(documents[6])
 				var pod corev1.Pod
 				expectedServiceAccountIssuers := []string{
@@ -667,7 +667,7 @@ resources:
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(kubeApiserver).To(ContainSubstring("--service-account-issuer"))
 				documents := strings.Split(string(kubeApiserver), "---")
-				Expect(documents).To(HaveLen(7))
+				Expect(documents).To(HaveLen(8))
 				podWithExtraArgs := []byte(documents[6])
 				var pod corev1.Pod
 				expectedServiceAccountIssuers := []string{


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Disable kube-apiserver watch cache for `manifestcheckpointcontentchunks.state-snapshotter.deckhouse.io` via `--watch-cache-sizes=...#0`.

Manual backport https://github.com/deckhouse/deckhouse/pull/21208

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Other module requirements

## Why do we need it in the patch release (if we do)?
Required for the operation of another module

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: kube-apiserver no longer caches watches for `ManifestCheckpointContentChunk` resources from `state-snapshotter`.
impact: kube-apiserver static pod is reconfigured and restarts on the next control-plane sync.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
