### PR TITLE
[candi] update base images v1.3.2

### DIFF
--- a/.github/ci_templates/tests.yml
+++ b/.github/ci_templates/tests.yml
@@ -10,7 +10,7 @@ exec_options: '-u $(id -u):$(id -g) -e HOME=/tmp -w /deckhouse'
 {!{ define "dhctl_run_args" }!}
 # <template: dhctl_run_args>
 args: 'make ci'
-docker_options: '-w /deckhouse/dhctl -v ~/go-pkg-cache:/go/pkg --tmpfs /tmp:mode=1777,exec'
+docker_options: '-u $(id -u):$(id -g) -w /deckhouse/dhctl -v ${{github.workspace}}:/deckhouse -v ~/go-pkg-cache:/go/pkg --tmpfs /tmp:mode=1777,exec -e HOME=/tmp'
 # </template: dhctl_run_args>
 {!{- end -}!}
 
@@ -23,21 +23,21 @@ docker_options: '-w /deckhouse/dhctl -v ~/go-pkg-cache:/go/pkg --tmpfs /tmp:mode
 {!{ define "golint_diff_run_args" }!}
 # <template: golint_diff_run_args>
 args: 'sh -c "git config --global --add safe.directory /deckhouse && make lint-changed"'
-docker_options: '-w /deckhouse -v ${{github.workspace}}:/deckhouse --tmpfs /tmp:mode=1777,exec -e "TERM=xterm-256color" -e "DIFF_BASE=${DIFF_BASE}" -v ~/go-pkg-cache:/go/pkg -v ~/go-pkg-cache:/root/go/pkg -v ~/go-build-cache:/root/.cache/go-build -v ~/golangci-lint-cache:/root/.cache/golangci-lint'
+docker_options: '-u $(id -u):$(id -g) -w /deckhouse -v ${{github.workspace}}:/deckhouse --tmpfs /tmp:mode=1777,exec -e HOME=/tmp -e "TERM=xterm-256color" -e "DIFF_BASE=${DIFF_BASE}" -v ~/go-pkg-cache:/go/pkg -v ~/go-pkg-cache:/root/go/pkg -v ~/go-build-cache:/root/.cache/go-build -v ~/golangci-lint-cache:/root/.cache/golangci-lint'
 # </template: golint_diff_run_args>
 {!{- end -}!}
 
 {!{ define "openapi_test_cases_run_args" }!}
 # <template: openapi_test_cases_run_args>
 args: 'ginkgo -vet=off ./testing/openapi_cases/'
-docker_options: '-v ${{github.workspace}}:/deckhouse -w /deckhouse --tmpfs /tmp:mode=1777,exec -v ~/go-pkg-cache:/go/pkg'
+docker_options: '-u $(id -u):$(id -g) -v ${{github.workspace}}:/deckhouse -w /deckhouse --tmpfs /tmp:mode=1777,exec -e HOME=/tmp -v ~/go-pkg-cache:/go/pkg'
 # </template: openapi_test_cases_run_args>
 {!{- end -}!}
 
 {!{ define "validators_run_args" }!}
 # <template: validators_run_args>
 args: 'go run gotest.tools/gotestsum@latest -- -tags=validation -run Validation -timeout=${{env.TEST_TIMEOUT}} ./testing/...'
-docker_options: '-w /deckhouse --tmpfs /tmp:mode=1777,exec -v ~/go-pkg-cache:/go/pkg'
+docker_options: '-u $(id -u):$(id -g) -w /deckhouse --tmpfs /tmp:mode=1777,exec -e HOME=/tmp -v ~/go-pkg-cache:/go/pkg'
 # </template: validators_run_args>
 {!{- end -}!}
 
@@ -79,7 +79,7 @@ steps:
       echo "⚓️ 🏎 [$(date -u)] Run tests..."
 {!{- if has $run "setup_cmd" }!}
       CONTAINER_ID=$(docker run -d {!{ $run.docker_options }!} ${TESTS_IMAGE_NAME} sleep infinity)
-      docker exec ${CONTAINER_ID} {!{ $run.setup_cmd }!}
+      docker exec -u 0:0 ${CONTAINER_ID} {!{ $run.setup_cmd }!}
       docker exec {!{ $run.exec_options }!} ${CONTAINER_ID} {!{ $run.args }!}
       docker rm -f ${CONTAINER_ID}
 {!{- else }!}
@@ -118,7 +118,7 @@ steps:
       echo "⚓️ 🏎 [$(date -u)] Run tests..."
 {!{- if has $run "setup_cmd" }!}
       CONTAINER_ID=$(docker run -d {!{ $run.docker_options }!} ${TESTS_IMAGE_NAME} sleep infinity)
-      docker exec ${CONTAINER_ID} {!{ $run.setup_cmd }!}
+      docker exec -u 0:0 ${CONTAINER_ID} {!{ $run.setup_cmd }!}
       docker exec {!{ $run.exec_options }!} ${CONTAINER_ID} {!{ $run.args }!}
       docker rm -f ${CONTAINER_ID}
 {!{- else }!}

--- a/.github/ci_templates/tests.yml
+++ b/.github/ci_templates/tests.yml
@@ -10,7 +10,7 @@ exec_options: '-u $(id -u):$(id -g) -e HOME=/tmp -w /deckhouse'
 {!{ define "dhctl_run_args" }!}
 # <template: dhctl_run_args>
 args: 'make ci'
-docker_options: '-u $(id -u):$(id -g) -w /deckhouse/dhctl -v ${{github.workspace}}:/deckhouse -v ~/go-pkg-cache:/go/pkg --tmpfs /tmp:mode=1777,exec -e HOME=/tmp'
+docker_options: '-u 0:0 -w /deckhouse/dhctl -v ~/go-pkg-cache:/go/pkg --tmpfs /tmp:mode=1777,exec -e HOME=/tmp'
 # </template: dhctl_run_args>
 {!{- end -}!}
 

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -3656,7 +3656,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:98aced736e6cc63e0185affd88f7a4f3225f1e6f494e8bb509061e590d2849e0"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:ae72d05d4d550f583af5fb4bd55c4d21fc9750f48a2fac8b65c77a49c7faa6cb"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'
@@ -3771,7 +3771,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run node-controller tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:98aced736e6cc63e0185affd88f7a4f3225f1e6f494e8bb509061e590d2849e0"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:ae72d05d4d550f583af5fb4bd55c4d21fc9750f48a2fac8b65c77a49c7faa6cb"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -3656,7 +3656,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:ae72d05d4d550f583af5fb4bd55c4d21fc9750f48a2fac8b65c77a49c7faa6cb"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:f639aa7651490569c527fa18da21ed25be69f5823ed293052acdae45bb4b3f36"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'
@@ -3664,7 +3664,7 @@ jobs:
           docker pull ${TESTS_IMAGE_NAME}
           echo "⚓️ 🏎 [$(date -u)] Run tests..."
           CONTAINER_ID=$(docker run -d -w /deckhouse -v ${{github.workspace}}:/deckhouse --tmpfs /tmp:mode=1777,exec -e HOME=/tmp -e "TERM=xterm-256color" -v ~/go-pkg-cache:/go/pkg ${TESTS_IMAGE_NAME} sleep infinity)
-          docker exec ${CONTAINER_ID} pm install git
+          docker exec -u 0:0 ${CONTAINER_ID} pm install git
           docker exec -u $(id -u):$(id -g) -e HOME=/tmp -w /deckhouse ${CONTAINER_ID} sh -c "git config --global --add safe.directory /deckhouse && make tests-controller tests-modules"
           docker rm -f ${CONTAINER_ID}
     # </template: tests_before_build_template>
@@ -3771,7 +3771,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run node-controller tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:ae72d05d4d550f583af5fb4bd55c4d21fc9750f48a2fac8b65c77a49c7faa6cb"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:f639aa7651490569c527fa18da21ed25be69f5823ed293052acdae45bb4b3f36"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'
@@ -4036,7 +4036,7 @@ jobs:
           echo "⚓️ 📥 [$(date -u)] Pull 'tests' image..."
           docker pull ${TESTS_IMAGE_NAME}
           echo "⚓️ 🏎 [$(date -u)] Run tests..."
-          docker run -w /deckhouse/dhctl -v ~/go-pkg-cache:/go/pkg --tmpfs /tmp:mode=1777,exec ${TESTS_IMAGE_NAME} make ci
+          docker run -u $(id -u):$(id -g) -w /deckhouse/dhctl -v ${{github.workspace}}:/deckhouse -v ~/go-pkg-cache:/go/pkg --tmpfs /tmp:mode=1777,exec -e HOME=/tmp ${TESTS_IMAGE_NAME} make ci
     # </template: tests_template>
 
   golint:
@@ -4159,7 +4159,7 @@ jobs:
           echo "⚓️ 📥 [$(date -u)] Pull 'tests' image..."
           docker pull ${TESTS_IMAGE_NAME}
           echo "⚓️ 🏎 [$(date -u)] Run tests..."
-          docker run -w /deckhouse -v ${{github.workspace}}:/deckhouse --tmpfs /tmp:mode=1777,exec -e "TERM=xterm-256color" -e "DIFF_BASE=${DIFF_BASE}" -v ~/go-pkg-cache:/go/pkg -v ~/go-pkg-cache:/root/go/pkg -v ~/go-build-cache:/root/.cache/go-build -v ~/golangci-lint-cache:/root/.cache/golangci-lint ${TESTS_IMAGE_NAME} sh -c "git config --global --add safe.directory /deckhouse && make lint-changed"
+          docker run -u $(id -u):$(id -g) -w /deckhouse -v ${{github.workspace}}:/deckhouse --tmpfs /tmp:mode=1777,exec -e HOME=/tmp -e "TERM=xterm-256color" -e "DIFF_BASE=${DIFF_BASE}" -v ~/go-pkg-cache:/go/pkg -v ~/go-pkg-cache:/root/go/pkg -v ~/go-build-cache:/root/.cache/go-build -v ~/golangci-lint-cache:/root/.cache/golangci-lint ${TESTS_IMAGE_NAME} sh -c "git config --global --add safe.directory /deckhouse && make lint-changed"
     # </template: tests_template>
 
   openapi_test_cases:
@@ -4280,7 +4280,7 @@ jobs:
           echo "⚓️ 📥 [$(date -u)] Pull 'tests' image..."
           docker pull ${TESTS_IMAGE_NAME}
           echo "⚓️ 🏎 [$(date -u)] Run tests..."
-          docker run -v ${{github.workspace}}:/deckhouse -w /deckhouse --tmpfs /tmp:mode=1777,exec -v ~/go-pkg-cache:/go/pkg ${TESTS_IMAGE_NAME} ginkgo -vet=off ./testing/openapi_cases/
+          docker run -u $(id -u):$(id -g) -v ${{github.workspace}}:/deckhouse -w /deckhouse --tmpfs /tmp:mode=1777,exec -e HOME=/tmp -v ~/go-pkg-cache:/go/pkg ${TESTS_IMAGE_NAME} ginkgo -vet=off ./testing/openapi_cases/
     # </template: tests_template>
 
   validators:
@@ -4401,7 +4401,7 @@ jobs:
           echo "⚓️ 📥 [$(date -u)] Pull 'tests' image..."
           docker pull ${TESTS_IMAGE_NAME}
           echo "⚓️ 🏎 [$(date -u)] Run tests..."
-          docker run -w /deckhouse --tmpfs /tmp:mode=1777,exec -v ~/go-pkg-cache:/go/pkg ${TESTS_IMAGE_NAME} go run gotest.tools/gotestsum@latest -- -tags=validation -run Validation -timeout=${{env.TEST_TIMEOUT}} ./testing/...
+          docker run -u $(id -u):$(id -g) -w /deckhouse --tmpfs /tmp:mode=1777,exec -e HOME=/tmp -v ~/go-pkg-cache:/go/pkg ${TESTS_IMAGE_NAME} go run gotest.tools/gotestsum@latest -- -tags=validation -run Validation -timeout=${{env.TEST_TIMEOUT}} ./testing/...
     # </template: tests_template>
 
   set_e2e_requirement_status:

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -4036,7 +4036,7 @@ jobs:
           echo "⚓️ 📥 [$(date -u)] Pull 'tests' image..."
           docker pull ${TESTS_IMAGE_NAME}
           echo "⚓️ 🏎 [$(date -u)] Run tests..."
-          docker run -u $(id -u):$(id -g) -w /deckhouse/dhctl -v ${{github.workspace}}:/deckhouse -v ~/go-pkg-cache:/go/pkg --tmpfs /tmp:mode=1777,exec -e HOME=/tmp ${TESTS_IMAGE_NAME} make ci
+          docker run -u 0:0 -w /deckhouse/dhctl -v ~/go-pkg-cache:/go/pkg --tmpfs /tmp:mode=1777,exec -e HOME=/tmp ${TESTS_IMAGE_NAME} make ci
     # </template: tests_template>
 
   golint:

--- a/.github/workflows/build-and-test_main.yml
+++ b/.github/workflows/build-and-test_main.yml
@@ -1171,7 +1171,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:98aced736e6cc63e0185affd88f7a4f3225f1e6f494e8bb509061e590d2849e0"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:ae72d05d4d550f583af5fb4bd55c4d21fc9750f48a2fac8b65c77a49c7faa6cb"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/.github/workflows/build-and-test_main.yml
+++ b/.github/workflows/build-and-test_main.yml
@@ -1171,7 +1171,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:ae72d05d4d550f583af5fb4bd55c4d21fc9750f48a2fac8b65c77a49c7faa6cb"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:f639aa7651490569c527fa18da21ed25be69f5823ed293052acdae45bb4b3f36"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'
@@ -1179,7 +1179,7 @@ jobs:
           docker pull ${TESTS_IMAGE_NAME}
           echo "⚓️ 🏎 [$(date -u)] Run tests..."
           CONTAINER_ID=$(docker run -d -w /deckhouse -v ${{github.workspace}}:/deckhouse --tmpfs /tmp:mode=1777,exec -e HOME=/tmp -e "TERM=xterm-256color" -v ~/go-pkg-cache:/go/pkg ${TESTS_IMAGE_NAME} sleep infinity)
-          docker exec ${CONTAINER_ID} pm install git
+          docker exec -u 0:0 ${CONTAINER_ID} pm install git
           docker exec -u $(id -u):$(id -g) -e HOME=/tmp -w /deckhouse ${CONTAINER_ID} sh -c "git config --global --add safe.directory /deckhouse && make tests-controller tests-modules"
           docker rm -f ${CONTAINER_ID}
     # </template: tests_before_build_template>
@@ -1409,7 +1409,7 @@ jobs:
           echo "⚓️ 📥 [$(date -u)] Pull 'tests' image..."
           docker pull ${TESTS_IMAGE_NAME}
           echo "⚓️ 🏎 [$(date -u)] Run tests..."
-          docker run -w /deckhouse/dhctl -v ~/go-pkg-cache:/go/pkg --tmpfs /tmp:mode=1777,exec ${TESTS_IMAGE_NAME} make ci
+          docker run -u $(id -u):$(id -g) -w /deckhouse/dhctl -v ${{github.workspace}}:/deckhouse -v ~/go-pkg-cache:/go/pkg --tmpfs /tmp:mode=1777,exec -e HOME=/tmp ${TESTS_IMAGE_NAME} make ci
     # </template: tests_template>
 
   golint:
@@ -1532,7 +1532,7 @@ jobs:
           echo "⚓️ 📥 [$(date -u)] Pull 'tests' image..."
           docker pull ${TESTS_IMAGE_NAME}
           echo "⚓️ 🏎 [$(date -u)] Run tests..."
-          docker run -w /deckhouse -v ${{github.workspace}}:/deckhouse --tmpfs /tmp:mode=1777,exec -e "TERM=xterm-256color" -e "DIFF_BASE=${DIFF_BASE}" -v ~/go-pkg-cache:/go/pkg -v ~/go-pkg-cache:/root/go/pkg -v ~/go-build-cache:/root/.cache/go-build -v ~/golangci-lint-cache:/root/.cache/golangci-lint ${TESTS_IMAGE_NAME} sh -c "git config --global --add safe.directory /deckhouse && make lint-changed"
+          docker run -u $(id -u):$(id -g) -w /deckhouse -v ${{github.workspace}}:/deckhouse --tmpfs /tmp:mode=1777,exec -e HOME=/tmp -e "TERM=xterm-256color" -e "DIFF_BASE=${DIFF_BASE}" -v ~/go-pkg-cache:/go/pkg -v ~/go-pkg-cache:/root/go/pkg -v ~/go-build-cache:/root/.cache/go-build -v ~/golangci-lint-cache:/root/.cache/golangci-lint ${TESTS_IMAGE_NAME} sh -c "git config --global --add safe.directory /deckhouse && make lint-changed"
     # </template: tests_template>
 
   openapi_test_cases:
@@ -1650,7 +1650,7 @@ jobs:
           echo "⚓️ 📥 [$(date -u)] Pull 'tests' image..."
           docker pull ${TESTS_IMAGE_NAME}
           echo "⚓️ 🏎 [$(date -u)] Run tests..."
-          docker run -v ${{github.workspace}}:/deckhouse -w /deckhouse --tmpfs /tmp:mode=1777,exec -v ~/go-pkg-cache:/go/pkg ${TESTS_IMAGE_NAME} ginkgo -vet=off ./testing/openapi_cases/
+          docker run -u $(id -u):$(id -g) -v ${{github.workspace}}:/deckhouse -w /deckhouse --tmpfs /tmp:mode=1777,exec -e HOME=/tmp -v ~/go-pkg-cache:/go/pkg ${TESTS_IMAGE_NAME} ginkgo -vet=off ./testing/openapi_cases/
     # </template: tests_template>
 
   security_scan_images:
@@ -2061,7 +2061,7 @@ jobs:
           echo "⚓️ 📥 [$(date -u)] Pull 'tests' image..."
           docker pull ${TESTS_IMAGE_NAME}
           echo "⚓️ 🏎 [$(date -u)] Run tests..."
-          docker run -w /deckhouse --tmpfs /tmp:mode=1777,exec -v ~/go-pkg-cache:/go/pkg ${TESTS_IMAGE_NAME} go run gotest.tools/gotestsum@latest -- -tags=validation -run Validation -timeout=${{env.TEST_TIMEOUT}} ./testing/...
+          docker run -u $(id -u):$(id -g) -w /deckhouse --tmpfs /tmp:mode=1777,exec -e HOME=/tmp -v ~/go-pkg-cache:/go/pkg ${TESTS_IMAGE_NAME} go run gotest.tools/gotestsum@latest -- -tags=validation -run Validation -timeout=${{env.TEST_TIMEOUT}} ./testing/...
     # </template: tests_template>
 
 

--- a/.github/workflows/build-and-test_main.yml
+++ b/.github/workflows/build-and-test_main.yml
@@ -1409,7 +1409,7 @@ jobs:
           echo "⚓️ 📥 [$(date -u)] Pull 'tests' image..."
           docker pull ${TESTS_IMAGE_NAME}
           echo "⚓️ 🏎 [$(date -u)] Run tests..."
-          docker run -u $(id -u):$(id -g) -w /deckhouse/dhctl -v ${{github.workspace}}:/deckhouse -v ~/go-pkg-cache:/go/pkg --tmpfs /tmp:mode=1777,exec -e HOME=/tmp ${TESTS_IMAGE_NAME} make ci
+          docker run -u 0:0 -w /deckhouse/dhctl -v ~/go-pkg-cache:/go/pkg --tmpfs /tmp:mode=1777,exec -e HOME=/tmp ${TESTS_IMAGE_NAME} make ci
     # </template: tests_template>
 
   golint:

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -3547,7 +3547,7 @@ jobs:
           echo "⚓️ 📥 [$(date -u)] Pull 'tests' image..."
           docker pull ${TESTS_IMAGE_NAME}
           echo "⚓️ 🏎 [$(date -u)] Run tests..."
-          docker run -u $(id -u):$(id -g) -w /deckhouse/dhctl -v ${{github.workspace}}:/deckhouse -v ~/go-pkg-cache:/go/pkg --tmpfs /tmp:mode=1777,exec -e HOME=/tmp ${TESTS_IMAGE_NAME} make ci
+          docker run -u 0:0 -w /deckhouse/dhctl -v ~/go-pkg-cache:/go/pkg --tmpfs /tmp:mode=1777,exec -e HOME=/tmp ${TESTS_IMAGE_NAME} make ci
     # </template: tests_template>
 
   golint:

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -3309,7 +3309,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:ae72d05d4d550f583af5fb4bd55c4d21fc9750f48a2fac8b65c77a49c7faa6cb"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:f639aa7651490569c527fa18da21ed25be69f5823ed293052acdae45bb4b3f36"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'
@@ -3317,7 +3317,7 @@ jobs:
           docker pull ${TESTS_IMAGE_NAME}
           echo "⚓️ 🏎 [$(date -u)] Run tests..."
           CONTAINER_ID=$(docker run -d -w /deckhouse -v ${{github.workspace}}:/deckhouse --tmpfs /tmp:mode=1777,exec -e HOME=/tmp -e "TERM=xterm-256color" -v ~/go-pkg-cache:/go/pkg ${TESTS_IMAGE_NAME} sleep infinity)
-          docker exec ${CONTAINER_ID} pm install git
+          docker exec -u 0:0 ${CONTAINER_ID} pm install git
           docker exec -u $(id -u):$(id -g) -e HOME=/tmp -w /deckhouse ${CONTAINER_ID} sh -c "git config --global --add safe.directory /deckhouse && make tests-controller tests-modules"
           docker rm -f ${CONTAINER_ID}
     # </template: tests_before_build_template>
@@ -3547,7 +3547,7 @@ jobs:
           echo "⚓️ 📥 [$(date -u)] Pull 'tests' image..."
           docker pull ${TESTS_IMAGE_NAME}
           echo "⚓️ 🏎 [$(date -u)] Run tests..."
-          docker run -w /deckhouse/dhctl -v ~/go-pkg-cache:/go/pkg --tmpfs /tmp:mode=1777,exec ${TESTS_IMAGE_NAME} make ci
+          docker run -u $(id -u):$(id -g) -w /deckhouse/dhctl -v ${{github.workspace}}:/deckhouse -v ~/go-pkg-cache:/go/pkg --tmpfs /tmp:mode=1777,exec -e HOME=/tmp ${TESTS_IMAGE_NAME} make ci
     # </template: tests_template>
 
   golint:
@@ -3670,7 +3670,7 @@ jobs:
           echo "⚓️ 📥 [$(date -u)] Pull 'tests' image..."
           docker pull ${TESTS_IMAGE_NAME}
           echo "⚓️ 🏎 [$(date -u)] Run tests..."
-          docker run -w /deckhouse -v ${{github.workspace}}:/deckhouse --tmpfs /tmp:mode=1777,exec -e "TERM=xterm-256color" -e "DIFF_BASE=${DIFF_BASE}" -v ~/go-pkg-cache:/go/pkg -v ~/go-pkg-cache:/root/go/pkg -v ~/go-build-cache:/root/.cache/go-build -v ~/golangci-lint-cache:/root/.cache/golangci-lint ${TESTS_IMAGE_NAME} sh -c "git config --global --add safe.directory /deckhouse && make lint-changed"
+          docker run -u $(id -u):$(id -g) -w /deckhouse -v ${{github.workspace}}:/deckhouse --tmpfs /tmp:mode=1777,exec -e HOME=/tmp -e "TERM=xterm-256color" -e "DIFF_BASE=${DIFF_BASE}" -v ~/go-pkg-cache:/go/pkg -v ~/go-pkg-cache:/root/go/pkg -v ~/go-build-cache:/root/.cache/go-build -v ~/golangci-lint-cache:/root/.cache/golangci-lint ${TESTS_IMAGE_NAME} sh -c "git config --global --add safe.directory /deckhouse && make lint-changed"
     # </template: tests_template>
 
   openapi_test_cases:
@@ -3788,7 +3788,7 @@ jobs:
           echo "⚓️ 📥 [$(date -u)] Pull 'tests' image..."
           docker pull ${TESTS_IMAGE_NAME}
           echo "⚓️ 🏎 [$(date -u)] Run tests..."
-          docker run -v ${{github.workspace}}:/deckhouse -w /deckhouse --tmpfs /tmp:mode=1777,exec -v ~/go-pkg-cache:/go/pkg ${TESTS_IMAGE_NAME} ginkgo -vet=off ./testing/openapi_cases/
+          docker run -u $(id -u):$(id -g) -v ${{github.workspace}}:/deckhouse -w /deckhouse --tmpfs /tmp:mode=1777,exec -e HOME=/tmp -v ~/go-pkg-cache:/go/pkg ${TESTS_IMAGE_NAME} ginkgo -vet=off ./testing/openapi_cases/
     # </template: tests_template>
 
   security_scan_images:
@@ -3995,7 +3995,7 @@ jobs:
           echo "⚓️ 📥 [$(date -u)] Pull 'tests' image..."
           docker pull ${TESTS_IMAGE_NAME}
           echo "⚓️ 🏎 [$(date -u)] Run tests..."
-          docker run -w /deckhouse --tmpfs /tmp:mode=1777,exec -v ~/go-pkg-cache:/go/pkg ${TESTS_IMAGE_NAME} go run gotest.tools/gotestsum@latest -- -tags=validation -run Validation -timeout=${{env.TEST_TIMEOUT}} ./testing/...
+          docker run -u $(id -u):$(id -g) -w /deckhouse --tmpfs /tmp:mode=1777,exec -e HOME=/tmp -v ~/go-pkg-cache:/go/pkg ${TESTS_IMAGE_NAME} go run gotest.tools/gotestsum@latest -- -tags=validation -run Validation -timeout=${{env.TEST_TIMEOUT}} ./testing/...
     # </template: tests_template>
 
   doc_pdf_build:

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -3309,7 +3309,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:98aced736e6cc63e0185affd88f7a4f3225f1e6f494e8bb509061e590d2849e0"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:ae72d05d4d550f583af5fb4bd55c4d21fc9750f48a2fac8b65c77a49c7faa6cb"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/candi/alt_base_images.yml
+++ b/candi/alt_base_images.yml
@@ -1,10 +1,9 @@
-# version=v1.1.14
+# version=v1.3.2
 REGISTRY_PATH: registry.deckhouse.io/container-factory
-base/distroless-fin: "sha256:17118e598f346a5843faf917a34e863a56b819ea406be88534e33f22dd064809" # from: builder/scratch
-builder/distroless: "sha256:478ce6063a756ae997cbf4673b3c1b1dce6465bb1e17d7e537d63afa5e81558c" # from: builder/scratch
-builder/golang-1.25: "sha256:3ca5063cbeb160619d0679b2465d1e0c4c1bc22e939687e01e1bf2ebca5b8306" # from: builder/distroless
-builder/golang-1.26: "sha256:98aced736e6cc63e0185affd88f7a4f3225f1e6f494e8bb509061e590d2849e0" # from: builder/distroless
-builder/golang: "sha256:98aced736e6cc63e0185affd88f7a4f3225f1e6f494e8bb509061e590d2849e0" # from: builder/distroless
-builder/golang-alt-1.26: "sha256:b8e362757fca1b402e6919778f06303bc8e35f5e0e3754c0bfe6eae12a6a8c52" # from: registry.altlinux.org/p11/alt:20260119
-minget-0.1: "sha256:463d8b34130357f8637eeda9ade6bb7561fa53f28bc7b5d11f29f629c60fb254" # from: builder/scratch
-minget: "sha256:463d8b34130357f8637eeda9ade6bb7561fa53f28bc7b5d11f29f629c60fb254" # from: builder/scratch
+base/distroless-fin: "sha256:014bf210c5e13d1e2ea968979a9cc5527d60a6d10ecedd51f97b6dd0dc7d554b" # from: builder/scratch
+builder/distroless: "sha256:dc1ce355189649aea0da760a3e3f7648409b0bbeaa271e72e381fefa99540e8c" # from: builder/scratch
+builder/golang-1.25: "sha256:d6c99ec7094ca8e0ac6f31abc73cad6e6c23d66c3d0c8ff7aa49b5fa9f787981" # from: builder/distroless
+builder/golang-1.26: "sha256:f639aa7651490569c527fa18da21ed25be69f5823ed293052acdae45bb4b3f36" # from: builder/distroless
+builder/golang: "sha256:f639aa7651490569c527fa18da21ed25be69f5823ed293052acdae45bb4b3f36" # from: builder/distroless
+minget-0.1: "sha256:11b24bd4add2d63f1a42f4a48f3ccd7a54f74e818c269607ceb52a9f760a9bfc" # from: builder/scratch
+minget: "sha256:11b24bd4add2d63f1a42f4a48f3ccd7a54f74e818c269607ceb52a9f760a9bfc" # from: builder/scratch


### PR DESCRIPTION
## Description
Update base images with changed ownership of final images

## Why do we need it, and what problem does it solve?
Security improvement

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: chore
summary: update base images
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
