### PR TITLE
[deckhouse] enabled script for packages

### DIFF
--- a/deckhouse-controller/internal/packages/apps/app.go
+++ b/deckhouse-controller/internal/packages/apps/app.go
@@ -47,6 +47,7 @@ import (
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/grants"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/hooks"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/schedule"
+	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/schedule/rule/script"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/values"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/values/schema"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/registry"
@@ -281,6 +282,11 @@ func (a *Application) GetVersion() *semver.Version {
 // GetPath returns path to the package dir
 func (a *Application) GetPath() string {
 	return a.path
+}
+
+// GetEnabledScriptDescriptor is a stub that returns nil
+func (a *Application) GetEnabledScriptDescriptor() *script.Descriptor {
+	return nil
 }
 
 // GetHooksQueues returns package queues from all hooks

--- a/deckhouse-controller/internal/packages/modules/module.go
+++ b/deckhouse-controller/internal/packages/modules/module.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"slices"
 	"sync/atomic"
 
@@ -42,6 +43,7 @@ import (
 
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/hooks"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/schedule"
+	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/schedule/rule/script"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/values"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/registry"
 	"github.com/deckhouse/deckhouse/pkg/log"
@@ -223,6 +225,24 @@ func (m *Module) GetVersion() *semver.Version {
 // GetPath returns path to the package dir
 func (m *Module) GetPath() string {
 	return m.path
+}
+
+// GetEnabledScriptDescriptor returns the enabled script descriptor for the package
+func (m *Module) GetEnabledScriptDescriptor() *script.Descriptor {
+	path := filepath.Join(m.path, "enabled")
+	if _, err := os.Stat(path); err != nil {
+		return nil
+	}
+
+	return &script.Descriptor{
+		Path:     path,
+		Settings: m.GetSettings(),
+		Values: addonutils.MergeValues(
+			addonutils.Values{},
+			m.values.GetValues(),
+			m.globalValuesGetter(),
+		),
+	}
 }
 
 // GetHooksQueues returns package queues from all hooks

--- a/deckhouse-controller/internal/packages/modules/module.go
+++ b/deckhouse-controller/internal/packages/modules/module.go
@@ -238,9 +238,8 @@ func (m *Module) GetEnabledScriptDescriptor() *script.Descriptor {
 		Path:     path,
 		Settings: m.GetSettings(),
 		Values: addonutils.MergeValues(
-			addonutils.Values{},
-			m.values.GetValues(),
-			m.globalValuesGetter(),
+			addonutils.Values{"global": m.globalValuesGetter()},
+			addonutils.Values{addonutils.ModuleNameToValuesKey(m.name): m.values.GetValues()},
 		),
 	}
 }

--- a/deckhouse-controller/internal/packages/runtime/runtime.go
+++ b/deckhouse-controller/internal/packages/runtime/runtime.go
@@ -573,6 +573,7 @@ func (r *Runtime) buildScheduler(cli kclient.Client) {
 	}
 
 	r.scheduler = schedule.NewScheduler(
+		r.logger,
 		schedule.WithDynamicGetter(r.global.IsEnabled),
 		schedule.WithBundleChecker(r.edition.IsEnabled),
 		schedule.WithBootstrapCondition(bootstrapCondition),

--- a/deckhouse-controller/internal/packages/schedule/node.go
+++ b/deckhouse-controller/internal/packages/schedule/node.go
@@ -202,10 +202,15 @@ func (s *Scheduler) addNode(pkg Package) {
 	// override the floor's Static(Disable) (gates still veto via Forbid from any
 	// position). Order within is least-to-most authoritative:
 	//   - bundle: enable-only; turns the module on for its edition/bundle.
-	//   - dynamic: the resolved ModuleConfig + dynamic intent. It is last, so an
-	//     explicit user disable overrides the bundle's enable, and a user enable
-	//     turns on a module the bundle ignores. Hooks are enable-only; the disable
-	//     direction comes solely from ModuleConfig.
+	//   - dynamic: the resolved ModuleConfig + dynamic intent. It overrides the
+	//     bundle, so an explicit user disable beats the bundle's enable and a user
+	//     enable turns on a module the bundle ignores. Hooks are enable-only; the
+	//     disable direction comes solely from ModuleConfig.
+	//   - script: the module's enabled script, evaluated last and thus the most
+	//     authoritative soft vote — a true result (soft Enable) turns the module on
+	//     over any earlier vote, including a user disable. A false result or a
+	//     script that cannot be evaluated vetoes the module via Forbid (which wins
+	//     from any position anyway). Modules without an enabled script abstain.
 	if isModule {
 		if s.bundleChecker != nil {
 			n.rules = append(n.rules, bundle.NewRule(s.bundleChecker, constraints.Licensing))

--- a/deckhouse-controller/internal/packages/schedule/node.go
+++ b/deckhouse-controller/internal/packages/schedule/node.go
@@ -200,17 +200,16 @@ func (s *Scheduler) addNode(pkg Package) {
 
 	// Module intent rules, appended after the floor and gates so their soft votes
 	// override the floor's Static(Disable) (gates still veto via Forbid from any
-	// position). Order within is least-to-most authoritative:
+	// position):
 	//   - bundle: enable-only; turns the module on for its edition/bundle.
-	//   - dynamic: the resolved ModuleConfig + dynamic intent. It overrides the
-	//     bundle, so an explicit user disable beats the bundle's enable and a user
-	//     enable turns on a module the bundle ignores. Hooks are enable-only; the
-	//     disable direction comes solely from ModuleConfig.
-	//   - script: the module's enabled script, evaluated last and thus the most
-	//     authoritative soft vote — a true result (soft Enable) turns the module on
-	//     over any earlier vote, including a user disable. A false result or a
-	//     script that cannot be evaluated vetoes the module via Forbid (which wins
-	//     from any position anyway). Modules without an enabled script abstain.
+	//   - dynamic: the resolved ModuleConfig + dynamic intent. An enable intent is
+	//     a soft Enable that turns on a module the bundle ignores; a disable intent
+	//     is a hard Forbid, so an explicit user disable is final — it beats the
+	//     bundle enable and short-circuits resolution before the script even runs.
+	//   - script: the module's enabled script. A true result is a soft Enable that
+	//     can turn the module on; a false result or a script that cannot be
+	//     evaluated vetoes it via Forbid. It is appended last, but placement does
+	//     not affect a user disable, which the dynamic Forbid already settled.
 	if isModule {
 		if s.bundleChecker != nil {
 			n.rules = append(n.rules, bundle.NewRule(s.bundleChecker, constraints.Licensing))

--- a/deckhouse-controller/internal/packages/schedule/node.go
+++ b/deckhouse-controller/internal/packages/schedule/node.go
@@ -24,6 +24,7 @@ import (
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/schedule/rule/condition"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/schedule/rule/dependency"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/schedule/rule/dynamic"
+	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/schedule/rule/script"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/schedule/rule/version"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/edition"
 )
@@ -43,6 +44,7 @@ type Package interface {
 	GetName() string
 	GetVersion() *semver.Version
 	GetConstraints() Constraints
+	GetEnabledScriptDescriptor() *script.Descriptor
 }
 
 // Constraints defines the scheduling requirements for a Package:
@@ -212,6 +214,8 @@ func (s *Scheduler) addNode(pkg Package) {
 		if s.dynamicGetter != nil {
 			n.rules = append(n.rules, dynamic.NewRule(s.dynamicGetter, pkg.GetName()))
 		}
+
+		n.rules = append(n.rules, script.NewRule(pkg, s.logger))
 	}
 
 	s.nodes[pkg.GetName()] = n

--- a/deckhouse-controller/internal/packages/schedule/rule/dynamic/rule.go
+++ b/deckhouse-controller/internal/packages/schedule/rule/dynamic/rule.go
@@ -12,12 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package dynamic provides the module enablement intent rule: the single
-// highest-precedence soft vote that folds the external enable/disable signals a
-// module carries (explicit ModuleConfig intent and the deprecated global-hook
-// dynamic enable). The two signals are resolved upstream into one tri-state by
-// the getter (the global module's IsEnabled), so the rule itself is a thin
-// adapter that turns that tri-state into a soft Enable/Disable vote.
+// Package dynamic provides the module enablement intent rule: the highest-
+// precedence enablement signal a module carries, folding the external
+// enable/disable signals (explicit ModuleConfig intent and the deprecated
+// global-hook dynamic enable). The two signals are resolved upstream into one
+// tri-state by the getter (the global module's IsEnabled), which the rule turns
+// into an asymmetric verdict: an enable intent is a soft Enable vote (requirement
+// gates can still veto it), while a disable intent is a hard Forbid — an explicit
+// user disable is final and cannot be re-enabled by any other rule.
 package dynamic
 
 import (
@@ -29,7 +31,8 @@ import (
 // ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
 const reasonEnabled = "Enabled"
 
-// reasonDisabled is the condition reason attached to a Disable vote.
+// reasonDisabled is the condition reason attached to the Forbid a disable intent
+// produces.
 const reasonDisabled = "Disabled"
 
 // Getter reports a module's resolved enablement intent as a tri-state:
@@ -38,10 +41,11 @@ const reasonDisabled = "Disabled"
 //   - nil    - no opinion; resolution defers to the rest of the chain.
 type Getter func(module string) *bool
 
-// Rule is the module enablement intent rule. It is the highest-precedence soft
-// vote: a non-nil getter result both enables and disables, overriding the floor
-// and the bundle vote. It never vetoes — requirement gates still Forbid from any
-// position, so an Enable cannot override an unmet requirement.
+// Rule is the module enablement intent rule. An enable intent is a soft Enable
+// that overrides the floor and the bundle vote but not a requirement gate (those
+// still Forbid from any position, so an Enable cannot override an unmet
+// requirement). A disable intent is a hard Forbid: an explicit user disable is
+// final and no other rule — bundle, enabled script, or floor — can re-enable it.
 type Rule struct {
 	getter Getter
 	module string
@@ -56,8 +60,8 @@ func NewRule(getter Getter, module string) *Rule {
 	}
 }
 
-// Decide returns a soft Enable when the module is intended enabled, a soft
-// Disable when it is intended disabled, and Undefined when there is no opinion.
+// Decide returns a soft Enable when the module is intended enabled, a hard
+// Forbid when it is intended disabled, and Undefined when there is no opinion.
 func (r *Rule) Decide() rule.Decision {
 	enabled := r.getter(r.module)
 	if enabled == nil {
@@ -72,7 +76,7 @@ func (r *Rule) Decide() rule.Decision {
 	}
 
 	return rule.Decision{
-		Kind:   rule.Disable,
+		Kind:   rule.Forbid,
 		Reason: reasonDisabled,
 	}
 }

--- a/deckhouse-controller/internal/packages/schedule/rule/script/rule.go
+++ b/deckhouse-controller/internal/packages/schedule/rule/script/rule.go
@@ -1,0 +1,97 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package script models a module's enabled script as a scheduler rule. A module
+// may ship an `enabled` shell script that inspects the values of the
+// already-enabled modules and reports whether this module should run. Its true
+// result is a soft Enable vote and its false result a hard Forbid; a script that
+// cannot be evaluated also forbids the module, so a broken script never leaves a
+// module running by default.
+package script
+
+import (
+	"context"
+
+	addonutils "github.com/flant/addon-operator/pkg/utils"
+
+	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/schedule/rule"
+	"github.com/deckhouse/deckhouse/pkg/log"
+)
+
+// Reason constants attached to the decisions this rule emits. Each matches the
+// Kubernetes condition reason pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$.
+const (
+	// reasonEnabledByScript is set when the enabled script ran and reported true.
+	reasonEnabledByScript = "EnabledByScript"
+	// reasonDisabledByScript is set when the enabled script ran and reported false.
+	reasonDisabledByScript = "DisabledByScript"
+	// reasonScriptError is set when the enabled script could not be run or parsed.
+	reasonScriptError = "EnabledScriptError"
+)
+
+// Rule is driven by a module's enabled script: a true result votes to enable the
+// module (a soft Enable), a false result vetoes it (Forbid), and a script that
+// cannot be evaluated also vetoes it.
+type Rule struct {
+	pkg    Package
+	logger *log.Logger
+}
+
+// Package is the slice of a module this rule inspects: its enabled script, if any.
+type Package interface {
+	// GetEnabledScriptDescriptor returns the module's enabled script descriptor, or nil when the
+	// module ships none.
+	GetEnabledScriptDescriptor() *Descriptor
+}
+
+// Descriptor describes a module's enabled script and the values handed to it. Values
+// carries the global block (including the enabledModules list) the script reads;
+// Settings carries the module's own config values.
+type Descriptor struct {
+	Path     string
+	Settings addonutils.Values
+	Values   addonutils.Values
+}
+
+// NewRule constructs a Rule that evaluates the given package's enabled script.
+func NewRule(pkg Package, logger *log.Logger) *Rule {
+	return &Rule{
+		pkg:    pkg,
+		logger: logger,
+	}
+}
+
+// Decide runs the module's enabled script and folds its outcome onto the rule
+// lattice: a missing script is no opinion (Undefined); a true result is a soft
+// Enable vote; a false result vetoes the module (Forbid); a failure to run or
+// parse the script also vetoes it, so a broken script cannot leave a module
+// running by default. The rule.Rule interface carries no context and one must
+// not be stored on the Rule, so the script runs under context.Background.
+func (r *Rule) Decide() rule.Decision {
+	script := r.pkg.GetEnabledScriptDescriptor()
+	if script == nil {
+		return rule.Decision{Kind: rule.Undefined}
+	}
+
+	res, err := runScript(context.Background(), script.Path, script.Settings, script.Values, r.logger)
+	if err != nil {
+		return rule.Decision{Kind: rule.Forbid, Reason: reasonScriptError, Message: err.Error()}
+	}
+
+	if !res.enabled {
+		return rule.Decision{Kind: rule.Forbid, Reason: reasonDisabledByScript, Message: res.reason}
+	}
+
+	return rule.Decision{Kind: rule.Enable, Reason: reasonEnabledByScript}
+}

--- a/deckhouse-controller/internal/packages/schedule/rule/script/script.go
+++ b/deckhouse-controller/internal/packages/schedule/rule/script/script.go
@@ -1,0 +1,214 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package script
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+
+	addonutils "github.com/flant/addon-operator/pkg/utils"
+	"github.com/flant/shell-operator/pkg/executor"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/deckhouse/deckhouse/pkg/log"
+)
+
+// scriptResult is the outcome of one enabled-script run: whether the module
+// should be enabled and, when it should not, the human-readable reason the
+// script wrote to MODULE_ENABLED_REASON.
+type scriptResult struct {
+	enabled bool
+	reason  string
+}
+
+// runScript executes a module's enabled script and reports its verdict. It
+// follows the addon-operator enabled-script protocol: settings and values are
+// written to temporary JSON files exposed to the script as CONFIG_VALUES_PATH
+// and VALUES_PATH, and the script writes its boolean verdict to
+// MODULE_ENABLED_RESULT and an optional reason to MODULE_ENABLED_REASON. All
+// four temporary files are removed before returning. It errors if a temp file
+// cannot be prepared, the script exits non-zero, or the result cannot be parsed.
+func runScript(ctx context.Context, path string, settings, values addonutils.Values, logger *log.Logger) (*scriptResult, error) {
+	_, span := otel.Tracer("enabled-script").Start(ctx, "RunEnabledScript")
+	defer span.End()
+
+	span.SetAttributes(attribute.String("path", path))
+
+	logger.Info("run enabled script", slog.String("path", path))
+
+	settingsFile, err := prepareTmpFile(os.TempDir(), settings)
+	if err != nil {
+		return nil, fmt.Errorf("failed to prepare tmp settings file: %w", err)
+	}
+
+	defer func() {
+		if err = os.Remove(settingsFile); err != nil {
+			logger.Error("remove tmp settings file", slog.String("path", settingsFile), log.Err(err))
+		}
+	}()
+
+	valuesFile, err := prepareTmpFile(os.TempDir(), values)
+	if err != nil {
+		return nil, fmt.Errorf("failed to prepare tmp values file: %w", err)
+	}
+
+	defer func() {
+		if err = os.Remove(valuesFile); err != nil {
+			logger.Error("remove tmp values file", slog.String("path", valuesFile), log.Err(err))
+		}
+	}()
+
+	resultPath, err := prepareTmpEmptyFile(os.TempDir())
+	if err != nil {
+		return nil, fmt.Errorf("failed to prepare tmp result file: %w", err)
+	}
+
+	defer func() {
+		if err = os.Remove(resultPath); err != nil {
+			logger.Error("remove tmp result file", slog.String("path", resultPath), log.Err(err))
+		}
+	}()
+
+	reasonPath, err := prepareTmpEmptyFile(os.TempDir())
+	if err != nil {
+		return nil, fmt.Errorf("failed to prepare tmp reason file: %w", err)
+	}
+
+	defer func() {
+		if err = os.Remove(reasonPath); err != nil {
+			logger.Error("remove tmp reason file", slog.String("path", reasonPath), log.Err(err))
+		}
+	}()
+
+	environ := os.Environ()
+
+	envs := make([]string, 0, len(environ))
+	envs = append(envs, environ...)
+
+	envs = append(envs, fmt.Sprintf("CONFIG_VALUES_PATH=%s", settingsFile))
+	envs = append(envs, fmt.Sprintf("VALUES_PATH=%s", valuesFile))
+	envs = append(envs, fmt.Sprintf("MODULE_ENABLED_RESULT=%s", resultPath))
+	envs = append(envs, fmt.Sprintf("MODULE_ENABLED_REASON=%s", reasonPath))
+
+	cmd := executor.NewExecutor(
+		"",
+		path,
+		[]string{},
+		envs).
+		WithLogger(logger.Named("executor")).
+		WithCMDStdout(nil)
+
+	if _, err = cmd.RunAndLogLines(ctx, make(map[string]string)); err != nil {
+		logger.Error("failed to run enabled script", slog.String("path", path), log.Err(err))
+
+		return nil, fmt.Errorf("failed to run enabled script: %w", err)
+	}
+
+	result, err := parseScriptResult(resultPath, reasonPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse script result: %w", err)
+	}
+
+	return &result, nil
+}
+
+// prepareTmpFile writes the given values as JSON into a fresh, uniquely named
+// file under dir and returns its path. The file is created with owner-only
+// permissions (0o600) because it may carry secret module values.
+func prepareTmpFile(dir string, settings addonutils.Values) (string, error) {
+	data, err := settings.JsonBytes()
+	if err != nil {
+		return "", err
+	}
+
+	file, err := os.CreateTemp(dir, "*.json")
+	if err != nil {
+		return "", fmt.Errorf("create temp file: %w", err)
+	}
+	defer file.Close()
+
+	if _, err := file.Write(data); err != nil {
+		return "", fmt.Errorf("write temp file: %w", err)
+	}
+
+	return file.Name(), nil
+}
+
+// prepareTmpEmptyFile creates a fresh, uniquely named empty file under dir for
+// the script to write its result into and returns its path. Like prepareTmpFile
+// it uses owner-only permissions (0o600).
+func prepareTmpEmptyFile(dir string) (string, error) {
+	file, err := os.CreateTemp(dir, "*.tmp")
+	if err != nil {
+		return "", fmt.Errorf("create temp file: %w", err)
+	}
+
+	if err := file.Close(); err != nil {
+		return "", fmt.Errorf("close temp file: %w", err)
+	}
+
+	return file.Name(), nil
+}
+
+// parseScriptResult reads the verdict and reason the script left in its two
+// output files and combines them into a scriptResult.
+func parseScriptResult(resultPath, reasonPath string) (scriptResult, error) {
+	enabled, err := readScriptResult(resultPath)
+	if err != nil {
+		return scriptResult{}, err
+	}
+
+	reason, err := readScriptReason(reasonPath)
+	if err != nil {
+		return scriptResult{}, err
+	}
+
+	return scriptResult{enabled: enabled, reason: reason}, nil
+}
+
+// readScriptResult reads MODULE_ENABLED_RESULT and parses its single trimmed
+// token, which must be exactly "true" or "false"; any other content is an error.
+func readScriptResult(filePath string) (bool, error) {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return false, fmt.Errorf("read %s: %s", filePath, err)
+	}
+
+	value := strings.TrimSpace(string(data))
+
+	switch value {
+	case "true":
+		return true, nil
+	case "false":
+		return false, nil
+	}
+
+	return false, fmt.Errorf("expected 'true' or 'false', got '%s'", value)
+}
+
+// readScriptReason reads MODULE_ENABLED_REASON and returns its trimmed contents.
+// The reason is optional, so an empty file yields an empty string.
+func readScriptReason(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read %s: %s", path, err)
+	}
+
+	return strings.TrimSpace(string(data)), nil
+}

--- a/deckhouse-controller/internal/packages/schedule/scheduler.go
+++ b/deckhouse-controller/internal/packages/schedule/scheduler.go
@@ -25,6 +25,7 @@ import (
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/schedule/rule/dependency"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/schedule/rule/dynamic"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/schedule/rule/version"
+	"github.com/deckhouse/deckhouse/pkg/log"
 )
 
 const (
@@ -62,6 +63,8 @@ type Scheduler struct {
 	dynamicGetter          dynamic.Getter      // Reports a module's resolved enablement intent (ModuleConfig + dynamic), answered by the global module
 
 	pause atomic.Bool // When true, no state changes are processed
+
+	logger *log.Logger
 }
 
 // Option configures a Scheduler during construction.
@@ -113,10 +116,11 @@ func WithBundleChecker(getter bundle.BundleChecker) Option {
 // NewScheduler creates a Scheduler with an empty dependency graph and a
 // buffered event channel. Use functional options to configure version
 // providers and conditions. Call [Scheduler.Ch] to consume lifecycle events.
-func NewScheduler(opts ...Option) *Scheduler {
+func NewScheduler(logger *log.Logger, opts ...Option) *Scheduler {
 	s := &Scheduler{
 		nodes:   make(map[string]*node),
 		eventCh: make(chan Event, defaultBufferSize),
+		logger:  logger,
 	}
 
 	for _, opt := range opts {

--- a/deckhouse-controller/internal/packages/schedule/scheduler_test.go
+++ b/deckhouse-controller/internal/packages/schedule/scheduler_test.go
@@ -22,7 +22,9 @@ import (
 
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/schedule"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/schedule/rule"
+	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/schedule/rule/script"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/edition"
+	"github.com/deckhouse/deckhouse/pkg/log"
 )
 
 // globalName is the literal sentinel used by Scheduler internally; it lives
@@ -56,6 +58,10 @@ func (p *testPackage) GetConstraints() schedule.Constraints {
 	return p.constraints
 }
 
+func (p *testPackage) GetEnabledScriptDescriptor() *script.Descriptor {
+	return nil
+}
+
 // mustVersion parses s into a *semver.Version or panics; tests use known-good values.
 func mustVersion(s string) *semver.Version {
 	v, err := semver.NewVersion(s)
@@ -85,6 +91,7 @@ func TestSchedulerSuite(t *testing.T) {
 func (s *SchedulerSuite) SetupTest() {
 	s.versions = make(map[string]*semver.Version)
 	s.sched = schedule.NewScheduler(
+		log.NewNop(),
 		schedule.WithDependencyGetter(func(name string) *semver.Version {
 			return s.versions[name]
 		}),
@@ -1040,6 +1047,7 @@ func (s *SchedulerSuite) useDynamicScheduler() map[string]*bool {
 
 	s.sched.Stop()
 	s.sched = schedule.NewScheduler(
+		log.NewNop(),
 		schedule.WithDependencyGetter(func(name string) *semver.Version {
 			return s.versions[name]
 		}),
@@ -1103,6 +1111,7 @@ func (s *SchedulerSuite) TestDynamicRuleDisableOverridesBundle() {
 
 	s.sched.Stop()
 	s.sched = schedule.NewScheduler(
+		log.NewNop(),
 		schedule.WithDependencyGetter(func(name string) *semver.Version {
 			return s.versions[name]
 		}),

--- a/deckhouse-controller/internal/packages/schedule/scheduler_test.go
+++ b/deckhouse-controller/internal/packages/schedule/scheduler_test.go
@@ -15,9 +15,12 @@
 package schedule_test
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/Masterminds/semver/v3"
+	addonutils "github.com/flant/addon-operator/pkg/utils"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/schedule"
@@ -35,9 +38,10 @@ const globalName = "global"
 // testPackage is a minimal Package implementation used to drive Scheduler
 // behavior from tests; production code uses apps.Application / modules.Module.
 type testPackage struct {
-	name        string
-	version     *semver.Version
-	constraints schedule.Constraints
+	name          string
+	version       *semver.Version
+	constraints   schedule.Constraints
+	enabledScript *script.Descriptor
 }
 
 // GetName returns the package identifier.
@@ -58,8 +62,10 @@ func (p *testPackage) GetConstraints() schedule.Constraints {
 	return p.constraints
 }
 
+// GetEnabledScriptDescriptor returns the package's enabled-script descriptor,
+// or nil when the case does not exercise the script rule.
 func (p *testPackage) GetEnabledScriptDescriptor() *script.Descriptor {
-	return nil
+	return p.enabledScript
 }
 
 // mustVersion parses s into a *semver.Version or panics; tests use known-good values.
@@ -1141,4 +1147,124 @@ func (s *SchedulerSuite) TestDynamicRuleDisableOverridesBundle() {
 	}))
 	s.NotContains(eventNames(s.collectEvents(), schedule.EventSchedule), "bundle-off",
 		"a disable intent must override the bundle enable")
+}
+
+// writeEnabledScript writes an executable enabled script with the given /bin/sh
+// body into a per-test temp dir and returns a descriptor pointing at it. The
+// body runs with the MODULE_ENABLED_RESULT / MODULE_ENABLED_REASON environment
+// variables the runner sets.
+func (s *SchedulerSuite) writeEnabledScript(body string) *script.Descriptor {
+	path := filepath.Join(s.T().TempDir(), "enabled")
+	s.Require().NoError(os.WriteFile(path, []byte("#!/bin/sh\n"+body+"\n"), 0o755))
+
+	return &script.Descriptor{
+		Path:     path,
+		Settings: addonutils.Values{},
+		Values:   addonutils.Values{},
+	}
+}
+
+// TestScriptRuleEnablesOverFloor verifies a true enabled-script result is a soft
+// Enable vote that turns on a module whose Disable floor would otherwise keep it
+// off. Order 0 keeps the module in global's tier so the reschedule-on-enable
+// revert does not gate it behind global re-completing (see TestDynamicRuleEnablesOverFloor).
+func (s *SchedulerSuite) TestScriptRuleEnablesOverFloor() {
+	s.activateGlobal()
+
+	s.Require().NoError(s.sched.AddNode(&testPackage{
+		name:    "mod",
+		version: mustVersion("1.0.0"),
+		constraints: schedule.Constraints{
+			Order: 0,
+			Floor: rule.Static(rule.Disable),
+		},
+		enabledScript: s.writeEnabledScript("echo true > $MODULE_ENABLED_RESULT"),
+	}))
+
+	s.Contains(eventNames(s.collectEvents(), schedule.EventSchedule), "mod",
+		"a true enabled-script result must override the module's Disable floor")
+}
+
+// TestScriptRuleFalseForbids verifies a false enabled-script result vetoes the
+// module even when another intent rule would enable it: the dynamic enable is
+// overridden by the script's Forbid (which wins from any position).
+func (s *SchedulerSuite) TestScriptRuleFalseForbids() {
+	enabledState := s.useDynamicScheduler()
+	s.activateGlobal()
+
+	enabledState["mod"] = boolPtr(true) // dynamic intent alone would enable it
+	s.Require().NoError(s.sched.AddNode(&testPackage{
+		name:    "mod",
+		version: mustVersion("1.0.0"),
+		constraints: schedule.Constraints{
+			Order: 0,
+			Floor: rule.Static(rule.Disable),
+		},
+		enabledScript: s.writeEnabledScript("echo false > $MODULE_ENABLED_RESULT"),
+	}))
+
+	s.NotContains(eventNames(s.collectEvents(), schedule.EventSchedule), "mod",
+		"a false enabled-script result must veto the module despite the dynamic enable")
+}
+
+// TestScriptRuleErrorForbids verifies that a script which fails to run vetoes the
+// module (fail-closed), so a broken enabled script never leaves a module running.
+func (s *SchedulerSuite) TestScriptRuleErrorForbids() {
+	enabledState := s.useDynamicScheduler()
+	s.activateGlobal()
+
+	enabledState["mod"] = boolPtr(true)
+	s.Require().NoError(s.sched.AddNode(&testPackage{
+		name:    "mod",
+		version: mustVersion("1.0.0"),
+		constraints: schedule.Constraints{
+			Order: 0,
+			Floor: rule.Static(rule.Disable),
+		},
+		enabledScript: s.writeEnabledScript("exit 1"),
+	}))
+
+	s.NotContains(eventNames(s.collectEvents(), schedule.EventSchedule), "mod",
+		"a failing enabled script must veto the module (fail-closed)")
+}
+
+// TestScriptRuleDisableSurfacesReason verifies that when a module flips off
+// because its enabled script now reports false, the EventDisable carries the
+// script's reason and the DisabledByScript condition reason. The same descriptor
+// path is rewritten between passes to change the verdict.
+func (s *SchedulerSuite) TestScriptRuleDisableSurfacesReason() {
+	s.activateGlobal()
+
+	descriptor := s.writeEnabledScript("echo true > $MODULE_ENABLED_RESULT")
+	s.Require().NoError(s.sched.AddNode(&testPackage{
+		name:    "mod",
+		version: mustVersion("1.0.0"),
+		constraints: schedule.Constraints{
+			Order: 0,
+			Floor: rule.Static(rule.Disable),
+		},
+		enabledScript: descriptor,
+	}))
+	s.Require().Contains(eventNames(s.collectEvents(), schedule.EventSchedule), "mod")
+
+	// Rewrite the same script to report false with a reason, then reschedule so
+	// the module flips off and emits a disable event.
+	s.Require().NoError(os.WriteFile(descriptor.Path,
+		[]byte("#!/bin/sh\necho false > $MODULE_ENABLED_RESULT\necho 'not today' > $MODULE_ENABLED_REASON\n"),
+		0o755))
+	s.sched.Schedule()
+
+	var disable *schedule.Event
+	for _, e := range s.collectEvents() {
+		if e.Kind == schedule.EventDisable && e.Name == "mod" {
+			event := e
+			disable = &event
+
+			break
+		}
+	}
+
+	s.Require().NotNil(disable, "flipping the script to false must emit an EventDisable")
+	s.Equal("DisabledByScript", disable.Reason)
+	s.Contains(disable.Message, "not today")
 }


### PR DESCRIPTION
## Description

Implements support for module `enabled` scripts in the package runtime scheduler, porting the mechanism from addon-operator.

A module may ship an executable `enabled` script at the root of its directory. On each scheduling pass the scheduler runs the script and folds its verdict into the module's rule chain:

- the module's settings and values are written to temporary JSON files exposed to the script as `CONFIG_VALUES_PATH` and `VALUES_PATH`; the latter carries `global.enabledModules`, so a script can branch on which modules are already enabled;
- the script writes its boolean verdict to `MODULE_ENABLED_RESULT` and an optional human-readable reason to `MODULE_ENABLED_REASON`;
- the verdict maps onto the scheduler rule lattice:
  - no script → `Undefined` (no opinion);
  - `true` → soft `Enable` vote;
  - `false` → `Forbid` (with the script's reason surfaced on the status condition);
  - a script that cannot be run or parsed → `Forbid` (fail-closed), so a broken script never leaves a module running by default.

The rule participates only for modules (floor = `Disable`) and is appended after the `bundle` and `dynamic` intent rules.

### Implementation

- `schedule/rule/script/rule.go` — the `Rule` (maps the script verdict onto `rule.Decision`) and the `Package`/`Descriptor` contract it reads.
- `schedule/rule/script/script.go` — the script runner implementing the addon-operator enabled-script file protocol (temp-file prep with `0o600` permissions, execution, result/reason parsing).
- `schedule.Package` gains `GetEnabledScriptDescriptor()`; `modules.Module` returns a descriptor when an `enabled` file exists, while apps and the global module return `nil`.
- `schedule.NewScheduler` now takes a `*log.Logger` (needed to run scripts).

## Why do we need it, and what problem does it solve?

Modules migrating from addon-operator use `enabled` scripts to express conditional enablement (for example, "enable me only when module X is already enabled"). This ports that capability to the package runtime scheduler so those modules behave the same under the new runtime.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: chore
summary: Implement enabled script for packages.
impact_level: low
```
