### PR TITLE
[deckhouse] add werf deploy-dependency annotations to capo webhook

### DIFF
--- a/ee/modules/030-cloud-provider-openstack/templates/capo-controller-manager/admission.yaml
+++ b/ee/modules/030-cloud-provider-openstack/templates/capo-controller-manager/admission.yaml
@@ -3,6 +3,9 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: capo-validating-webhook
+  annotations:
+    werf.io/deploy-dependency-deployment: state=ready,kind=Deployment,name=capo-controller-manager,namespace=d8-cloud-provider-openstack
+    werf.io/deploy-dependency-service: state=present,kind=Service,name=capo-controller-manager-webhook-service,namespace=d8-cloud-provider-openstack
   {{- include "helm_lib_module_labels" (list . (dict "app" "capo-controller-manager")) | nindent 2 }}
 webhooks:
 - admissionReviewVersions:


### PR DESCRIPTION
## Description
Add `werf.io/deploy-dependency-deployment` and `werf.io/deploy-dependency-service` annotations to `capo-validating-webhook` ValidatingWebhookConfiguration in cloud-provider-openstack module.

## Why do we need it, and what problem does it solve?
Without these annotations, nelm may apply the ValidatingWebhookConfiguration before the capo-controller-manager Deployment is ready and the webhook Service exists, causing API server webhook call failures during deploy.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: cloud-provider-openstack
type: fix
summary: Add werf deploy-dependency annotations to capo-validating-webhook.
impact_level: low
```