### PR TITLE
[CodeScoring] Add CodeScoring SCA/OSA integration documentation

### DIFF
--- a/docs/site/pages/code/documentation/user/CODESCORING.md
+++ b/docs/site/pages/code/documentation/user/CODESCORING.md
@@ -1,0 +1,176 @@
+---
+title: "CodeScoring Integration"
+menuTitle: CodeScoring
+force_searchable: true
+description: Configure CodeScoring SCA/OSA scanner integration in Deckhouse Code for dependency and vulnerability analysis
+permalink: en/code/documentation/user/codescoring.html
+lang: en
+weight: 90
+---
+
+CodeScoring is a Software Composition Analysis (SCA/OSA) tool for auditing third-party dependencies for vulnerabilities, license risks, and security policy violations.
+
+{% alert level="info" %}
+The CodeScoring integration in Deckhouse Code covers SCA/OSA scenarios: dependency analysis, vulnerability detection, SBOM generation, and policy enforcement.
+SAST and DAST are not part of this integration.
+{% endalert %}
+
+## Integration capabilities
+
+- Dependency analysis (packages, libraries, versions).
+- Vulnerability detection using CVE databases (including FSTEC BDU and Kaspersky OSS feed).
+- SBOM generation in CycloneDX format.
+- Security policy enforcement with blocking or warning CI behavior.
+- Native report output in GitLab Dependency Scanning and Code Quality formats for MR widget display.
+
+## Prerequisites
+
+Before configuring the integration, ensure that:
+
+- A CodeScoring server is deployed (on-prem or SaaS).
+- You have obtained an API token from your CodeScoring user profile.
+- The Johnny agent is available in the CI environment (Docker image or binary).
+
+For server deployment details, refer to the official documentation: [docs.codescoring.ru](https://docs.codescoring.ru/on-premise/).
+
+## Configuring the integration in a project
+
+CodeScoring connection parameters are configured in project settings.
+
+1. Open the project in Deckhouse Code.
+2. Navigate to **Settings** → **Integrations**.
+3. Find the **CodeScoring** section and click **Configure**.
+4. Fill in the connection parameters:
+
+| Parameter | Description |
+|-----------|-------------|
+| **Server URL** | CodeScoring server address, e.g. `https://codescoring.example.com` |
+| **API token** | Token from your CodeScoring user profile |
+| **Project name** | Project name in CodeScoring (defaults to repository name) |
+| **Scan stage** | CI stage for result association: `build`, `dev`, `stage`, `test`, `prod` (default: `build`) |
+| **Enable integration** | Toggle to activate integration for this project |
+
+5. Click **Save**.
+
+## CI pipeline configuration
+
+After configuring the integration, include the CodeScoring template in the project's `.gitlab-ci.yml`.
+
+### Including the template
+
+```yaml
+include:
+  - project: "deckhouse/code/gitlab-custom"
+    file: ".gitlab/ci/includes/codescoring.gitlab-ci.yml"
+
+variables:
+  CODESCORING_ENABLED: "true"
+  CODESCORING_URL: $CODESCORING_URL         # set in CI/CD Variables
+  CODESCORING_TOKEN: $CODESCORING_TOKEN     # set as a masked variable
+  CODESCORING_PROJECT: $CI_PROJECT_NAME
+  CODESCORING_SCAN_STAGE: "build"
+  CODESCORING_POLICY_MODE: "blocking"       # or "warning"
+```
+
+Set `CODESCORING_URL` and `CODESCORING_TOKEN` via **Settings → CI/CD → Variables**, marking the token as `Masked`.
+
+### Pipeline stages
+
+The integration adds the following stages:
+
+| Job | Stage | Description |
+|-----|-------|-------------|
+| `codescoring-sbom` | `.pre` | Generates CycloneDX SBOM. Artifact is passed to downstream jobs |
+| `codescoring-dependency-scan` | `security` | Dependency analysis, outputs GitLab Dependency Scanning Report |
+| `codescoring-code-quality-scan` | `security` | Code quality checks, outputs GitLab Code Quality Report |
+| `codescoring-build-scan` | `security` | Build artifact analysis (optional, requires `CODESCORING_BUILD_PATH`) |
+
+Scan jobs run **in parallel** after SBOM generation, reducing overall scan time.
+
+## SBOM pre-stage
+
+Before scanning, a SBOM (Software Bill of Materials) is automatically generated in CycloneDX format:
+
+- SBOM captures the exact dependency composition at build time.
+- A single SBOM is reused by multiple scan jobs.
+- The artifact is available for reuse by other tools.
+
+If a SBOM artifact already exists from a previous stage, regeneration is skipped.
+
+## Policy modes
+
+### Blocking mode
+
+The pipeline fails on policy violation (exit code 1):
+
+```yaml
+variables:
+  CODESCORING_POLICY_MODE: "blocking"
+```
+
+Recommended for protected branches and release environments.
+
+### Warning mode
+
+Results are published as warnings without stopping the pipeline:
+
+```yaml
+variables:
+  CODESCORING_POLICY_MODE: "warning"
+```
+
+Recommended for pilot rollouts or feature branches.
+
+## Displaying results in Merge Requests
+
+After scanning, results appear in MR widgets:
+
+- **Security scanning** — detected vulnerabilities with CVE details, severity, and recommendations.
+- **Code Quality** — quality metric violations.
+
+Widgets appear automatically when `gl-dependency-scanning-report.json` and `gl-code-quality-report.json` artifacts are present.
+
+## Vulnerability triage
+
+Detected vulnerabilities can be triaged directly in the CodeScoring interface:
+
+- Navigate to **SCA → Vulnerabilities**.
+- Set status: `Active`, `Confirmed`, `Not affected`, `False positive`.
+- Fill in justification and response (compatible with CycloneDX VEX format).
+
+Temporary suppression of findings is available by project, technology, package, license, or CVE.
+
+## CodeScoring server deployment
+
+For self-hosted installation, refer to:
+
+- [Docker Compose](deployment-docker.html) — single-server deployment.
+- [Kubernetes/Helm](https://docs.codescoring.ru/on-premise/kubernetes/) — production environment.
+
+For system requirements, see [docs.codescoring.ru/on-premise/requirements/](https://docs.codescoring.ru/on-premise/requirements/).
+
+## Troubleshooting
+
+### Scan does not start
+
+Check:
+
+- `CODESCORING_ENABLED` is set to `"true"`.
+- `CODESCORING_URL` and `CODESCORING_TOKEN` are set and accessible to the runner.
+- The template is included in `.gitlab-ci.yml`.
+
+### Pipeline blocked on policy violation
+
+This is expected behavior in `blocking` mode. To temporarily disable blocking:
+
+- Switch to `CODESCORING_POLICY_MODE: "warning"`, or
+- Resolve the violation through triage in the CodeScoring interface.
+
+### Security widgets not displayed in MR
+
+Check:
+
+- `gl-dependency-scanning-report.json` and `gl-code-quality-report.json` artifacts are created.
+- The `artifacts.reports` section in the job configuration is correct.
+- The job completed (artifacts are collected even on failure with `when: always`).
+

--- a/docs/site/pages/code/documentation/user/CODESCORING_RU.md
+++ b/docs/site/pages/code/documentation/user/CODESCORING_RU.md
@@ -1,0 +1,176 @@
+---
+title: "Интеграция CodeScoring"
+menuTitle: CodeScoring
+force_searchable: true
+description: Настройка интеграции CodeScoring SCA/OSA-сканера в Deckhouse Code для проверки зависимостей и уязвимостей
+permalink: ru/code/documentation/user/codescoring.html
+lang: ru
+weight: 90
+---
+
+CodeScoring — это инструмент анализа состава программного обеспечения (SCA/OSA) для проверки сторонних зависимостей на наличие уязвимостей, лицензионных рисков и нарушений политик безопасности.
+
+{% alert level="info" %}
+Интеграция CodeScoring в Deckhouse Code покрывает SCA/OSA-сценарии: анализ зависимостей, обнаружение уязвимостей, SBOM-генерация и применение политик безопасности.
+SAST и DAST в эту интеграцию не входят.
+{% endalert %}
+
+## Возможности интеграции
+
+- Анализ зависимостей приложения (пакеты, библиотеки, версии).
+- Обнаружение уязвимостей по базам CVE (включая ФСТЭК БДУ и Kaspersky OSS feed).
+- Генерация SBOM в формате CycloneDX.
+- Применение политик безопасности с блокировкой или предупреждением в CI.
+- Нативный вывод отчётов в формате GitLab Dependency Scanning и Code Quality для отображения в MR-виджетах.
+
+## Предварительные требования
+
+Перед настройкой интеграции убедитесь, что:
+
+- У вас развёрнут сервер CodeScoring (on-prem или SaaS).
+- Вы получили API-токен в профиле пользователя CodeScoring.
+- Агент Johnny доступен в CI-окружении (Docker-образ или бинарный файл).
+
+Подробнее о развёртывании сервера CodeScoring см. в официальной документации: [docs.codescoring.ru](https://docs.codescoring.ru/on-premise/).
+
+## Настройка интеграции в проекте
+
+Параметры подключения к CodeScoring задаются через настройки проекта.
+
+1. Откройте проект в Deckhouse Code.
+2. Перейдите в **Настройки** → **Интеграции**.
+3. Найдите раздел **CodeScoring** и нажмите **Настроить**.
+4. Заполните параметры подключения:
+
+| Параметр | Описание |
+|----------|----------|
+| **URL сервера** | Адрес сервера CodeScoring, например `https://codescoring.example.com` |
+| **API-токен** | Токен из профиля пользователя CodeScoring |
+| **Название проекта** | Имя проекта в CodeScoring (по умолчанию — имя репозитория) |
+| **Стадия сканирования** | Стадия CI для привязки результатов: `build`, `dev`, `stage`, `test`, `prod` (по умолчанию `build`) |
+| **Включить интеграцию** | Переключатель активации интеграции для проекта |
+
+5. Нажмите **Сохранить**.
+
+## Конфигурация CI-пайплайна
+
+После настройки интеграции подключите шаблон CodeScoring в `.gitlab-ci.yml` проекта.
+
+### Подключение шаблона
+
+```yaml
+include:
+  - project: "deckhouse/code/gitlab-custom"
+    file: ".gitlab/ci/includes/codescoring.gitlab-ci.yml"
+
+variables:
+  CODESCORING_ENABLED: "true"
+  CODESCORING_URL: $CODESCORING_URL         # задайте в CI/CD Variables
+  CODESCORING_TOKEN: $CODESCORING_TOKEN     # задайте как masked переменную
+  CODESCORING_PROJECT: $CI_PROJECT_NAME
+  CODESCORING_SCAN_STAGE: "build"
+  CODESCORING_POLICY_MODE: "blocking"       # или "warning"
+```
+
+Переменные `CODESCORING_URL` и `CODESCORING_TOKEN` рекомендуется задавать через **Settings → CI/CD → Variables**, отмечая токен как `Masked`.
+
+### Стадии пайплайна
+
+Интеграция добавляет следующие стадии:
+
+| Job | Стадия | Описание |
+|-----|--------|----------|
+| `codescoring-sbom` | `.pre` | Генерация SBOM в формате CycloneDX. Артефакт передаётся следующим job |
+| `codescoring-dependency-scan` | `security` | Анализ зависимостей, вывод GitLab Dependency Scanning Report |
+| `codescoring-code-quality-scan` | `security` | Проверка качества кода, вывод GitLab Code Quality Report |
+| `codescoring-build-scan` | `security` | Анализ артефактов сборки (опционально, требует `CODESCORING_BUILD_PATH`) |
+
+Задачи сканирования запускаются **параллельно** после генерации SBOM, что сокращает общее время проверки.
+
+## SBOM-пред-стадия
+
+Перед запуском сканирования автоматически выполняется генерация SBOM (Software Bill of Materials) в формате CycloneDX:
+
+- SBOM фиксирует точный состав зависимостей на момент сборки.
+- Один SBOM используется несколькими задачами анализа.
+- Артефакт доступен для повторного использования другими инструментами.
+
+Если SBOM уже существует как артефакт предыдущей стадии, повторная генерация пропускается.
+
+## Режимы политик
+
+### Блокирующий режим (blocking)
+
+Пайплайн завершается с ошибкой при нарушении политики (exit code 1):
+
+```yaml
+variables:
+  CODESCORING_POLICY_MODE: "blocking"
+```
+
+Рекомендуется для защищённых веток и release-контуров.
+
+### Предупреждающий режим (warning)
+
+Результаты публикуются как предупреждения, пайплайн не останавливается:
+
+```yaml
+variables:
+  CODESCORING_POLICY_MODE: "warning"
+```
+
+Рекомендуется для пилотного внедрения или feature-веток.
+
+## Отображение результатов в Merge Request
+
+После выполнения сканирования результаты отображаются в виджетах MR:
+
+- **Security scanning** — найденные уязвимости с деталями CVE, severity и рекомендациями.
+- **Code Quality** — нарушения качественных метрик.
+
+Виджеты появляются автоматически при наличии артефактов `gl-dependency-scanning-report.json` и `gl-code-quality-report.json`.
+
+## Триаж уязвимостей
+
+Обнаруженные уязвимости можно разбирать непосредственно в интерфейсе CodeScoring:
+
+- Переход в **SCA → Уязвимости**.
+- Установка статуса: `Активен`, `Подтверждён`, `Не затронут`, `Ложноположительный`.
+- Заполнение обоснования и ответа (совместимо с форматом CycloneDX VEX).
+
+Временное игнорирование срабатываний возможно по проекту, технологии, пакету, лицензии или CVE.
+
+## Развёртывание сервера CodeScoring
+
+Для self-hosted установки обратитесь к инструкциям:
+
+- [Docker Compose](deployment-docker.html) — развёртывание на одном сервере.
+- [Kubernetes/Helm](https://docs.codescoring.ru/on-premise/kubernetes/) — production-окружение.
+
+Системные требования см. на странице [docs.codescoring.ru/on-premise/requirements/](https://docs.codescoring.ru/on-premise/requirements/).
+
+## Устранение неполадок
+
+### Сканирование не запускается
+
+Проверьте:
+
+- Переменная `CODESCORING_ENABLED` установлена в `"true"`.
+- Переменные `CODESCORING_URL` и `CODESCORING_TOKEN` заданы и доступны раннеру.
+- Шаблон подключён в `.gitlab-ci.yml`.
+
+### Пайплайн блокируется при нарушении политики
+
+Это ожидаемое поведение в режиме `blocking`. Для временного отключения блокировки:
+
+- Переключите `CODESCORING_POLICY_MODE: "warning"`, или
+- Устраните нарушение через триаж в интерфейсе CodeScoring.
+
+### Виджеты безопасности не отображаются в MR
+
+Проверьте:
+
+- Артефакты `gl-dependency-scanning-report.json` и `gl-code-quality-report.json` созданы.
+- Секция `artifacts.reports` в job-конфигурации указана корректно.
+- Job завершился (даже с ошибкой — артефакты собираются при `when: always`).
+


### PR DESCRIPTION
## Что

Добавляет документацию по интеграции CodeScoring (SCA/OSA-сканер) в Deckhouse Code.

## Файлы

- `docs/site/pages/code/documentation/user/CODESCORING_RU.md` — русская версия
- `docs/site/pages/code/documentation/user/CODESCORING.md` — английская версия

## Содержание

- Что такое CodeScoring (SCA/OSA, не включает SAST/DAST)
- Настройка интеграции в проекте (UI)
- Конфигурация CI-пайплайна (шаблон, переменные)
- SBOM пре-стадия (CycloneDX)
- Параллельные задачи сканирования (dependency-scan, code-quality-scan, build-scan)
- Режимы политик (blocking / warning)
- Отображение результатов в MR-виджетах
- Триаж уязвимостей
- Ссылки на self-hosted развёртывание
- Устранение неполадок

## Связанные MR (Deckhouse Code / fox.flant.com)

- `!418` — FE project settings (модель + миграция + шифрование токена)
- `!417` — CI job template + SBOM + параллельные сканы
- `!416` — Инструкции по self-hosted развёртыванию (Docker + Omnibus/k3s)

## Issue

https://fox.flant.com/deckhouse/code/gitlab-custom/-/work_items/128