### PR TITLE
[user-authn] fix useroperations hook

### DIFF
--- a/modules/150-user-authn/hooks/get_dex_user_operation_crds.go
+++ b/modules/150-user-authn/hooks/get_dex_user_operation_crds.go
@@ -277,6 +277,30 @@ func executeUserOperation(input *go_hook.HookInput, operation UserOperation) err
 	}
 }
 
+// mutatePasswordObject applies mutate to a deep copy of the live Dex Password
+// object and returns the copy.
+//
+// PatchWithMutatingFunc replaces the whole object via an Update with whatever
+// the mutating function returns (and skips the call when the result is deeply
+// equal to the input). The previous implementation decoded the live object into
+// the typed Password struct and serialized it back, but Password does not model
+// every field Dex stores (groups, userID, hashUpdatedAt, previousHashes,
+// incorrectPasswordLoginAttempts). That round-trip silently dropped those
+// fields from the object - most importantly groups, which Dex needs to keep
+// matching the user's allowedGroups: resetting a password wiped groups from the
+// Password and the user could no longer log in until the groups were re-synced.
+//
+// Mutating a copy of the raw object in place preserves every field we do not
+// explicitly touch. Returning the copy (not the mutated input) keeps the
+// identity check in the patch executor intact so the Update is still issued.
+func mutatePasswordObject(obj *unstructured.Unstructured, mutate func(*unstructured.Unstructured) error) (*unstructured.Unstructured, error) {
+	patched := obj.DeepCopy()
+	if err := mutate(patched); err != nil {
+		return nil, err
+	}
+	return patched, nil
+}
+
 func executeLock(input *go_hook.HookInput, operation UserOperation) error {
 	if operation.Spec.Lock == nil {
 		input.Logger.Error("Lock spec is nil", "userOperation", operation.Name)
@@ -298,26 +322,21 @@ func executeLock(input *go_hook.HookInput, operation UserOperation) error {
 	}
 
 	input.Logger.Info("Locking user password", "user", userPassword.Username, "duration", operation.Spec.Lock.For.Duration)
+	lockedUntil := time.Now().Add(operation.Spec.Lock.For.Duration).Format(time.RFC3339)
 	input.PatchCollector.PatchWithMutatingFunc(func(obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
-		var pass Password
-		if err := sdk.FromUnstructured(obj, &pass); err != nil {
-			input.Logger.Error("Failed to convert Password object", "error", err)
-			return nil, err
-		}
-		pass.LockedUntil = ptr.To(time.Now().Add(operation.Spec.Lock.For.Duration))
-		u, err := sdk.ToUnstructured(&pass)
-		if err != nil {
-			return nil, err
-		}
-		annotations := u.GetAnnotations()
-		if annotations == nil {
-			annotations = map[string]string{}
-		}
-		// We need this annotations to find out who has banned user on user CR render later.
-		annotations[PasswordAnnotationLockedByAdministrator] = ""
-		u.SetAnnotations(annotations)
-
-		return u, nil
+		return mutatePasswordObject(obj, func(patched *unstructured.Unstructured) error {
+			if err := unstructured.SetNestedField(patched.Object, lockedUntil, "lockedUntil"); err != nil {
+				return err
+			}
+			annotations := patched.GetAnnotations()
+			if annotations == nil {
+				annotations = map[string]string{}
+			}
+			// We need this annotation to find out who has banned user on user CR render later.
+			annotations[PasswordAnnotationLockedByAdministrator] = ""
+			patched.SetAnnotations(annotations)
+			return nil
+		})
 	}, "dex.coreos.com/v1", "Password", userPassword.Namespace, userPassword.Name)
 
 	return nil
@@ -340,24 +359,20 @@ func executeUnlock(input *go_hook.HookInput, operation UserOperation) error {
 
 	input.Logger.Info("Unlocking user password", "user", userPassword.Username)
 	input.PatchCollector.PatchWithMutatingFunc(func(obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
-		var pass Password
-		if err := sdk.FromUnstructured(obj, &pass); err != nil {
-			input.Logger.Error("Failed to convert Password object", "error", err)
-			return nil, err
-		}
-		pass.LockedUntil = nil
-		u, err := sdk.ToUnstructured(&pass)
-		if err != nil {
-			return nil, err
-		}
-
-		annotations := u.GetAnnotations()
-		if annotations != nil {
-			delete(annotations, PasswordAnnotationLockedByAdministrator)
-			u.SetAnnotations(annotations)
-		}
-
-		return u, nil
+		return mutatePasswordObject(obj, func(patched *unstructured.Unstructured) error {
+			// Match the previous behaviour of writing an explicit null (the
+			// Password.lockedUntil json tag has no omitempty) rather than
+			// dropping the key entirely.
+			if err := unstructured.SetNestedField(patched.Object, nil, "lockedUntil"); err != nil {
+				return err
+			}
+			annotations := patched.GetAnnotations()
+			if annotations != nil {
+				delete(annotations, PasswordAnnotationLockedByAdministrator)
+				patched.SetAnnotations(annotations)
+			}
+			return nil
+		})
 	}, "dex.coreos.com/v1", "Password", userPassword.Namespace, userPassword.Name)
 
 	return nil
@@ -394,17 +409,14 @@ func executeResetPassword(input *go_hook.HookInput, operation UserOperation) err
 	}
 
 	input.Logger.Info("Resetting user password", "user", userPassword.Username)
+	encodedHash := base64.StdEncoding.EncodeToString([]byte(rawHash))
 	input.PatchCollector.PatchWithMutatingFunc(func(obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
-		var pass Password
-		if err := sdk.FromUnstructured(obj, &pass); err != nil {
-			input.Logger.Error("Failed to convert Password object", "error", err)
-			return nil, err
-		}
-		pass.Hash = base64.StdEncoding.EncodeToString(
-			[]byte(rawHash),
-		)
-		pass.RequireResetHashOnNextSuccLogin = true
-		return sdk.ToUnstructured(&pass)
+		return mutatePasswordObject(obj, func(patched *unstructured.Unstructured) error {
+			if err := unstructured.SetNestedField(patched.Object, encodedHash, "hash"); err != nil {
+				return err
+			}
+			return unstructured.SetNestedField(patched.Object, true, "requireResetHashOnNextSuccLogin")
+		})
 	}, "dex.coreos.com/v1", "Password", userPassword.Namespace, userPassword.Name)
 
 	return nil

--- a/modules/150-user-authn/hooks/get_dex_user_operation_crds_test.go
+++ b/modules/150-user-authn/hooks/get_dex_user_operation_crds_test.go
@@ -40,6 +40,9 @@ var _ = Describe("User Authn hooks :: handle UserOperation creation ::", func() 
 ---
 apiVersion: dex.coreos.com/v1
 email: admin@yourcompany.com
+groups:
+- Everyone
+- admins
 hash: JDJhJDEwJDlFRXFCMFNlenkyZk1ZT2JIZU1tUHVHSHo2bElZV1FCRTAxY3pYZFVmOUs5NlFJVlpVQlF1
 hashUpdatedAt: "2025-09-24T04:33:04.493729966Z"
 incorrectPasswordLoginAttempts: 0
@@ -59,6 +62,9 @@ username: admin
 ---
 apiVersion: dex.coreos.com/v1
 email: admin@yourcompany.com
+groups:
+- Everyone
+- admins
 hash: JDJhJDEwJDlFRXFCMFNlenkyZk1ZT2JIZU1tUHVHSHo2bElZV1FCRTAxY3pYZFVmOUs5NlFJVlpVQlF1
 hashUpdatedAt: "2025-09-24T04:33:04.493729966Z"
 incorrectPasswordLoginAttempts: 0
@@ -272,6 +278,11 @@ status:
 			pw := f.KubernetesResource("Password", "d8-user-authn", "mfsg22loib4w65lsmnxw24dbnz4s4y3pnxf7fhheqqrcgji")
 			Expect(pw.Field("lockedUntil").Time()).To(BeTemporally("~", time.Now().Add(1*time.Hour), 5*time.Second))
 			Expect(pw.Field("metadata.annotations").Map()).To(HaveKey("deckhouse.io/locked-by-administrator"))
+			// Locking must not drop Dex-managed fields the hook does not model
+			// (notably groups, which back the user's allowedGroups).
+			Expect(pw.Field("groups").Array()).To(HaveLen(2))
+			Expect(pw.Field("previousHashes").Array()).To(HaveLen(2))
+			Expect(pw.Field("hashUpdatedAt").String()).To(Equal("2025-09-24T04:33:04.493729966Z"))
 
 			uo := f.KubernetesGlobalResource("UserOperation", "user-operation-01")
 			Expect(uo.Field("status.phase").String()).To(Equal("Succeeded"))
@@ -289,6 +300,10 @@ status:
 			pw := f.KubernetesResource("Password", "d8-user-authn", "mfsg22loib4w65lsmnxw24dbnz4s4y3pnxf7fhheqqrcgji")
 			Expect(pw.Field("lockedUntil").Time().IsZero()).To(BeTrue())
 			Expect(pw.Field("metadata.annotations").Map()).NotTo(HaveKey("deckhouse.io/locked-by-administrator"))
+			// Unlocking must not drop Dex-managed fields the hook does not model.
+			Expect(pw.Field("groups").Array()).To(HaveLen(2))
+			Expect(pw.Field("previousHashes").Array()).To(HaveLen(2))
+			Expect(pw.Field("hashUpdatedAt").String()).To(Equal("2025-09-24T04:33:04.493729966Z"))
 
 			uo := f.KubernetesGlobalResource("UserOperation", "user-operation-01")
 			Expect(uo.Field("status.phase").String()).To(Equal("Succeeded"))
@@ -307,6 +322,13 @@ status:
 			// base64 encoded bcrypt hash from userOperationResetPassword.newPasswordHash
 			Expect(pw.Field("hash").String()).To(Equal("JDJ5JDEwJDlmZG12NGV3ZHZ6VkNUUTAxQm5BWi5DeTI3ZmRuZk5rbC5kTElnZTJZUzJnU0Y0Y3pxWFV5"))
 			Expect(pw.Field("requireResetHashOnNextSuccLogin").Bool()).To(BeTrue())
+			// Resetting the password must not drop the user's groups: Dex matches
+			// allowedGroups against Password.groups, so wiping them here left the
+			// user unable to log in until the groups were re-synced (the bug this
+			// patch fixes).
+			Expect(pw.Field("groups").Array()).To(HaveLen(2))
+			Expect(pw.Field("previousHashes").Array()).To(HaveLen(2))
+			Expect(pw.Field("hashUpdatedAt").String()).To(Equal("2025-09-24T04:33:04.493729966Z"))
 
 			uo := f.KubernetesGlobalResource("UserOperation", "user-operation-01")
 			Expect(uo.Field("status.phase").String()).To(Equal("Succeeded"))


### PR DESCRIPTION
## Description
Fix Dex `Password` mutations in the UserOperation hook (ResetPassword / Lock / Unlock) so they no longer wipe fields the hook does not model. The mutating functions now edit a deep copy of the live object in place via `unstructured` helpers instead of round-tripping it through the trimmed-down `Password` Go struct. No impact on critical cluster components.

## Why do we need it, and what problem does it solve?
`PatchWithMutatingFunc` performs a full object `Update` with whatever the mutating func returns. The previous code decoded the live `Password` into a Go struct that lacks `groups`, `userID`, `hashUpdatedAt`, `previousHashes` and `incorrectPasswordLoginAttempts`, then serialized it back — so the `Update` dropped all those fields. Losing `groups` broke logins: Dex matches `allowedGroups` against `Password.groups`, so after a password reset (or lock/unlock) the user had no groups and could not log in until groups were re-synced (e.g. by editing a `Group`).

## Why do we need it in the patch release (if we do)?
Password reset/lock is an admin-facing operation that silently locks affected users out of the cluster; the fix is small and self-contained, so it should be backported to 1.75 and 1.76.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authn
type: fix
summary: Preserve Dex Password fields (notably groups) when resetting password, locking or unlocking a user, so users are no longer locked out after these operations.
impact_level: default
```