### PR TITLE
[istio] Add loadBalancerClass to alliance config

### DIFF
--- a/ee/modules/110-istio/templates/alliance/ingressgateway/service.yaml
+++ b/ee/modules/110-istio/templates/alliance/ingressgateway/service.yaml
@@ -26,5 +26,8 @@ spec:
   type: NodePort
   {{- else }}
   type: LoadBalancer
+  {{- with .Values.istio.alliance.ingressGateway.loadBalancerClass }}
+  loadBalancerClass: {{ . | quote }}
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/modules/110-istio/openapi/config-values.yaml
+++ b/modules/110-istio/openapi/config-values.yaml
@@ -135,6 +135,15 @@ properties:
               - cse-pro
             example:
               yandex.cpi.flant.com/listener-subnet-id: xyz-123
+          loadBalancerClass:
+            type: string
+            description: |
+              Class of the load balancer for incoming network requests (passed to the `spec.loadBalancerClass` parameter of the provisioned service with the `LoadBalancer` type).
+
+              Applies only when `inlet` is `LoadBalancer`.
+            x-doc-d8Editions:
+              - ee
+              - cse-pro
           gatewayPodAnnotations:
             type: object
             additionalProperties:

--- a/modules/110-istio/openapi/doc-ru-config-values.yaml
+++ b/modules/110-istio/openapi/doc-ru-config-values.yaml
@@ -48,6 +48,11 @@ properties:
               Дополнительные аннотации для сервиса ingressgateway.
 
               Полезно, например, для настройки локального LB в Yandex Cloud (аннотация `yandex.cpi.flant.com/listener-subnet-id`).
+          loadBalancerClass:
+            description: |
+              Класс балансировщика входящих сетевых запросов (пробрасывается в параметр `spec.loadBalancerClass` заказанного сервиса с типом `LoadBalancer`).
+
+              Применяется только при `inlet`, равном `LoadBalancer`.
           gatewayPodAnnotations:
             description: |
               Дополнительные аннотации для подов DaemonSet'а ingressgateway.

--- a/modules/110-istio/template_tests/module_test.go
+++ b/modules/110-istio/template_tests/module_test.go
@@ -579,6 +579,7 @@ neighbour-0:
 			f.ValuesSetFromYaml("istio.alliance.ingressGateway.gatewayPodAnnotations", `
 test.deckhouse.io/annotation: test-value
 `)
+			f.ValuesSet("istio.alliance.ingressGateway.loadBalancerClass", "my-lb-class")
 			f.HelmRender()
 		})
 
@@ -616,7 +617,10 @@ test.deckhouse.io/annotation: test-value
 			Expect(ingressgatewayDaemonSet.Field("spec.template.metadata.annotations.test\\.deckhouse\\.io/annotation").String()).To(Equal("test-value"))
 			Expect(f.KubernetesResource("VerticalPodAutoscaler", "d8-istio", "ingressgateway").Exists()).To(BeTrue())
 			Expect(f.KubernetesResource("Gateway", "d8-istio", "ingressgateway").Exists()).To(BeTrue())
-			Expect(f.KubernetesResource("Service", "d8-istio", "ingressgateway").Exists()).To(BeTrue())
+			ingressgatewayService := f.KubernetesResource("Service", "d8-istio", "ingressgateway")
+			Expect(ingressgatewayService.Exists()).To(BeTrue())
+			Expect(ingressgatewayService.Field("spec.type").String()).To(Equal("LoadBalancer"))
+			Expect(ingressgatewayService.Field("spec.loadBalancerClass").String()).To(Equal("my-lb-class"))
 			Expect(f.KubernetesResource("ServiceAccount", "d8-istio", "alliance-ingressgateway").Exists()).To(BeTrue())
 			Expect(f.KubernetesResource("Role", "d8-istio", "alliance:ingressgateway").Exists()).To(BeTrue())
 			Expect(f.KubernetesResource("RoleBinding", "d8-istio", "alliance:ingressgateway").Exists()).To(BeTrue())


### PR DESCRIPTION
## Description

Add a new optional `loadBalancerClass` parameter to the Istio module's alliance ingress gateway configuration (`alliance.ingressGateway.loadBalancerClass` in the module config).

The parameter mirrors the behavior and semantics of the same option in the `ingress-nginx` module.

## Why do we need it, and what problem does it solve?

Kubernetes supports selecting a specific load balancer implementation per Service via `spec.loadBalancerClass`. Without this option, the alliance ingress gateway Service could not target a non-default load balancer class.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: feature
summary: Add `loadBalancerClass` option to the alliance ingress gateway configuration.
impact_level: low
```