### PR TITLE
[docs] Fix ingressClass description in global settings

### DIFF
--- a/global-hooks/openapi/config-values.yaml
+++ b/global-hooks/openapi/config-values.yaml
@@ -60,11 +60,9 @@ properties:
         type: string
         default: nginx
         description: |
-          Class name of the Ingress controller ([IngressClass](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class)) used by the Deckhouse ecosystem modules.
+          [IngressClass](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class) name used by the Deckhouse ecosystem modules when creating Ingress resources.
 
-          If the IngressClass name is set to `nginx`, the corresponding Ingress controller is automatically considered the default Ingress controller for all modules.
-
-          If any other IngressClass name is used, a corresponding Ingress controller will not be used by default.
+          The default value is `nginx`. If your cluster uses a different IngressClass, specify its name in this parameter.
         x-examples: [ "nginx" ]
         pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
       publicDomainTemplate:
@@ -236,11 +234,9 @@ properties:
         type: string
         default: nginx
         description: |
-          Class name of the Ingress controller ([IngressClass](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class)) used by the Deckhouse ecosystem applications.
+          [IngressClass](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class) name used by the Deckhouse ecosystem applications when creating Ingress resources.
 
-          If the IngressClass name is set to `nginx`, the corresponding Ingress controller is automatically considered the default Ingress controller for all applications.
-
-          If any other IngressClass name is used, a corresponding Ingress controller will not be used by default.
+          The default value is `nginx`. If your cluster uses a different IngressClass, specify its name in this parameter.
         x-examples: [ "nginx" ]
         pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
       publicDomainTemplate:

--- a/global-hooks/openapi/config-values.yaml
+++ b/global-hooks/openapi/config-values.yaml
@@ -62,7 +62,7 @@ properties:
         description: |
           [IngressClass](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class) name used by the Deckhouse ecosystem modules when creating Ingress resources.
 
-          The default value is `nginx`. If your cluster uses a different IngressClass, specify its name in this parameter.
+          If your cluster uses an IngressClass different from the default one, specify its name in this parameter.
         x-examples: [ "nginx" ]
         pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
       publicDomainTemplate:
@@ -236,7 +236,7 @@ properties:
         description: |
           [IngressClass](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class) name used by the Deckhouse ecosystem applications when creating Ingress resources.
 
-          The default value is `nginx`. If your cluster uses a different IngressClass, specify its name in this parameter.
+          If your cluster uses an IngressClass different from the default one, specify its name in this parameter.
         x-examples: [ "nginx" ]
         pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
       publicDomainTemplate:

--- a/global-hooks/openapi/config-values.yaml
+++ b/global-hooks/openapi/config-values.yaml
@@ -49,20 +49,26 @@ properties:
         properties:
           name:
             type: string
+            description: |
+              Name of the Gateway object.
           namespace:
             type: string
+            description: |
+              Namespace of the Gateway object.
         required:
           - name
           - namespace
         description: |
-          Name of the Gateway object from the Gateway API used by modules of the Deckhouse ecosystem.
+          Reference to the Gateway object (from the Gateway API) used by modules of the Deckhouse ecosystem when creating Gateway API resources.
+
+          If not specified, modules use the Gateway automatically discovered in the cluster (if any).
       ingressClass:
         type: string
         default: nginx
         description: |
-          [IngressClass](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class) name used by the Deckhouse ecosystem modules when creating Ingress resources.
+          Default [IngressClass](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class) name used by the Deckhouse ecosystem modules when creating Ingress resources.
 
-          If your cluster uses an IngressClass different from the default one, specify its name in this parameter.
+          Some modules support their own `ingressClass` parameter, which lets you use a different IngressClass instead of the default one.
         x-examples: [ "nginx" ]
         pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
       publicDomainTemplate:
@@ -148,7 +154,7 @@ properties:
                   ClusterIssuer name used by modules to obtain TLS certificates.
 
                   The [`cert-manager`](/modules/cert-manager/) module offers the following ClusterIssuer options:
-                  
+
                   - `letsencrypt`
                   - `letsencrypt-staging`
                   - `selfsigned`
@@ -156,7 +162,7 @@ properties:
                   - `cloudflare`
                   - `digitalocean`
                   - `route53`
-                  
+
                   You can use your own ClusterIssuer if necessary.
           customCertificate:
             type: object
@@ -234,9 +240,9 @@ properties:
         type: string
         default: nginx
         description: |
-          [IngressClass](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class) name used by the Deckhouse ecosystem applications when creating Ingress resources.
+          Default [IngressClass](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class) name used by the Deckhouse ecosystem applications when creating Ingress resources.
 
-          If your cluster uses an IngressClass different from the default one, specify its name in this parameter.
+          Some applications support their own `ingressClass` parameter, which lets you use a different IngressClass instead of the default one.
         x-examples: [ "nginx" ]
         pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
       publicDomainTemplate:
@@ -244,7 +250,7 @@ properties:
         pattern: '^(%s([-a-z0-9]*[a-z0-9])?|[a-z0-9]([-a-z0-9]*)?%s([-a-z0-9]*)?[a-z0-9]|[a-z0-9]([-a-z0-9]*)?%s)\.(%s([-a-z0-9]*[a-z0-9])?|[a-z0-9]([-a-z0-9]*)?%s([-a-z0-9]*)?[a-z0-9]|[a-z0-9]([-a-z0-9]*)?%s)\.(%s([-a-z0-9]*[a-z0-9])?|[a-z0-9]([-a-z0-9]*)?%s([-a-z0-9]*)?[a-z0-9]|[a-z0-9]([-a-z0-9]*)?%s)(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
         description: |
           DNS name template with three `%s` keys used as the dynamic parts of the string.
-          
+
           Whenever a DNS is generated:
 
           - First key is replaced with the component name.
@@ -308,7 +314,7 @@ properties:
                   ClusterIssuer name used by applications to obtain TLS certificates.
 
                   The [`cert-manager`](/modules/cert-manager/) module offers the following ClusterIssuer options:
-                  
+
                   - `letsencrypt`
                   - `letsencrypt-staging`
                   - `selfsigned`
@@ -316,7 +322,7 @@ properties:
                   - `cloudflare`
                   - `digitalocean`
                   - `route53`
-                  
+
                   You can use your own ClusterIssuer if necessary.
           customCertificate:
             type: object

--- a/global-hooks/openapi/doc-ru-config-values.yaml
+++ b/global-hooks/openapi/doc-ru-config-values.yaml
@@ -35,11 +35,9 @@ properties:
           Имя объекта Gateway из Gateway API, используемого для модулей экосистемы Deckhouse.
       ingressClass:
         description: |
-          Имя класса Ingress-контроллера ([IngressClass](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class)), используемого модулями экосистемы Deckhouse.
+          Имя [IngressClass](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class), используемого модулями экосистемы Deckhouse при создании Ingress-ресурсов.
 
-          Если в качестве имени IngressClass указано значение `nginx`, соответствующий Ingress-контроллер автоматически считается Ingress-контроллером по умолчанию для всех модулей.
-
-          При использовании любого другого имени IngressClass такой Ingress-контроллер не будет использоваться по умолчанию.
+          По умолчанию — `nginx`. Если в кластере используется другой IngressClass, укажите его имя в этом параметре.
       publicDomainTemplate:
         description: |
           Шаблон DNS-имен c ключом `%s` в качестве динамической части строки.
@@ -135,11 +133,9 @@ properties:
     properties:
       ingressClass:
         description: |
-          Имя класса Ingress-контроллера ([IngressClass](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class)), используемого приложениями экосистемы Deckhouse.
+          Имя [IngressClass](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class), используемого приложениями экосистемы Deckhouse при создании Ingress-ресурсов.
 
-          Если в качестве имени IngressClass указано значение `nginx`, соответствующий Ingress-контроллер автоматически считается Ingress-контроллером по умолчанию для всех приложений.
-
-          При использовании любого другого имени IngressClass такой Ingress-контроллер не будет использоваться по умолчанию.
+          По умолчанию — `nginx`. Если в кластере используется другой IngressClass, укажите его имя в этом параметре.
       publicDomainTemplate:
         description: |
           Шаблон DNS-имён с тремя ключами `%s` в качестве динамических частей строки.

--- a/global-hooks/openapi/doc-ru-config-values.yaml
+++ b/global-hooks/openapi/doc-ru-config-values.yaml
@@ -32,12 +32,21 @@ properties:
     properties:
       gatewayAPIGateway:
         description: |
-          Имя объекта Gateway из Gateway API, используемого для модулей экосистемы Deckhouse.
+          Ссылка на объект Gateway (из Gateway API), используемый модулями экосистемы Deckhouse при создании ресурсов Gateway API.
+
+          Если параметр не указан, модули используют Gateway, автоматически обнаруженный в кластере (если он есть).
+        properties:
+          name:
+            description: |
+              Имя объекта Gateway.
+          namespace:
+            description: |
+              Неймспейс объекта Gateway.
       ingressClass:
         description: |
-          Имя [IngressClass](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class), используемого модулями экосистемы Deckhouse при создании Ingress-ресурсов.
+          Имя класса Ingress-контроллера ([IngressClass](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class)), используемого модулями экосистемы Deckhouse по умолчанию при создании Ingress-ресурсов.
 
-          Если в кластере используется IngressClass, отличный от применяемого по умолчанию, укажите его имя в этом параметре.
+          Некоторые модули поддерживают собственный параметр `ingressClass`, позволяющий использовать другой класс Ingress-контроллера вместо используемого по умолчанию.
       publicDomainTemplate:
         description: |
           Шаблон DNS-имен c ключом `%s` в качестве динамической части строки.
@@ -78,7 +87,7 @@ properties:
                 description: |
                   Имя ClusterIssuer, используемого модулями для получения TLS-сертификатов.
 
-                  Модуль [`cert-manager`](/modules/cert-manager/) предоставляет следующие ClusterIssuer: 
+                  Модуль [`cert-manager`](/modules/cert-manager/) предоставляет следующие ClusterIssuer:
 
                   - `letsencrypt`;
                   - `letsencrypt-staging`;
@@ -87,7 +96,7 @@ properties:
                   - `cloudflare`;
                   - `digitalocean`;
                   - `route53`.
-                  
+
                   При необходимости вы можете использовать собственный `ClusterIssuer`.
           customCertificate:
             properties:
@@ -133,15 +142,15 @@ properties:
     properties:
       ingressClass:
         description: |
-          Имя [IngressClass](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class), используемого приложениями экосистемы Deckhouse при создании Ingress-ресурсов.
+          Имя класса Ingress-контроллера ([IngressClass](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class)), используемого приложениями экосистемы Deckhouse по умолчанию при создании Ingress-ресурсов.
 
-          Если в кластере используется IngressClass, отличный от применяемого по умолчанию, укажите его имя в этом параметре.
+          Некоторые приложения поддерживают собственный параметр `ingressClass`, позволяющий использовать другой класс Ingress-контроллера вместо используемого по умолчанию.
       publicDomainTemplate:
         description: |
           Шаблон DNS-имён с тремя ключами `%s` в качестве динамических частей строки.
-          
+
           При формировании DNS-имени:
-          
+
           - первый ключ заменяется на имя компонента;
           - второй — на имя экземпляра приложения;
           - третий — на имя неймспейса приложения.

--- a/global-hooks/openapi/doc-ru-config-values.yaml
+++ b/global-hooks/openapi/doc-ru-config-values.yaml
@@ -37,7 +37,7 @@ properties:
         description: |
           Имя [IngressClass](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class), используемого модулями экосистемы Deckhouse при создании Ingress-ресурсов.
 
-          По умолчанию — `nginx`. Если в кластере используется другой IngressClass, укажите его имя в этом параметре.
+          Если в кластере используется IngressClass, отличный от применяемого по умолчанию, укажите его имя в этом параметре.
       publicDomainTemplate:
         description: |
           Шаблон DNS-имен c ключом `%s` в качестве динамической части строки.
@@ -135,7 +135,7 @@ properties:
         description: |
           Имя [IngressClass](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class), используемого приложениями экосистемы Deckhouse при создании Ingress-ресурсов.
 
-          По умолчанию — `nginx`. Если в кластере используется другой IngressClass, укажите его имя в этом параметре.
+          Если в кластере используется IngressClass, отличный от применяемого по умолчанию, укажите его имя в этом параметре.
       publicDomainTemplate:
         description: |
           Шаблон DNS-имён с тремя ключами `%s` в качестве динамических частей строки.


### PR DESCRIPTION
## Description

1 Fixed the description of settings.modules.ingressClass (and settings.applications.ingressClass) in the global settings documentation.
2. Removed the text claiming that when ingressClass is set to nginx, the corresponding Ingress controller is automatically treated as the default, and that other values are not used by default.
3. Clarified that Deckhouse relies on the IngressClass name, not the Ingress controller name.

## Why do we need it, and what problem does it solve?

## Why do we need it in the patch release (if we do)?

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: fix 
summary: Fix ingressClass description in global settings
impact_level: low
```
