### PR TITLE
[istio] istio run from DH user

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -1620,13 +1620,13 @@ alerts:
       module: istio
       edition: ce
       description: |
-        Container `{{$labels.container}}` in pod `{{$labels.pod}}` in namespace `{{$labels.namespace}}` is running as UID `1337`.
+        Container `{{$labels.container}}` in pod `{{$labels.pod}}` in namespace `{{$labels.namespace}}` runs as UID `{{$labels.reserved_uid}}`.
 
-        UID `1337` is reserved by Istio for the `istio-proxy` sidecar container. When application containers run with this UID, their traffic bypasses Istio completely — no routing rules, mTLS, or telemetry will be applied.
+        UID `{{$labels.reserved_uid}}` is reserved by Istio for the `istio-proxy` sidecar container. When application containers run with this UID, their traffic bypasses Istio completely — no routing rules, mTLS, or telemetry will be applied.
 
         To fix the issue, change the `runAsUser` in the container's or pod's `securityContext` to a different UID.
       summary: |
-        Application container is running as UID 1337 (reserved by Istio).
+        Application container runs as Istio bypass UID {{$labels.reserved_uid}}.
       severity: "4"
       markupFormat: markdown
     - name: D8IstioVersionIsIncompatibleWithK8sVersion

--- a/ee/modules/110-istio/images/alliance-healthcheck/src/checker.go
+++ b/ee/modules/110-istio/images/alliance-healthcheck/src/checker.go
@@ -10,7 +10,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -52,6 +54,7 @@ type CheckerConfig struct {
 	MulticlusterEnabled bool
 	CheckInterval       time.Duration
 	RequestTimeout      time.Duration
+	HTTPProxyPort       string
 }
 
 type Checker struct {
@@ -62,6 +65,16 @@ type Checker struct {
 }
 
 func NewChecker(dynClient dynamic.Interface, reg prometheus.Registerer, cfg CheckerConfig) *Checker {
+	cfg.HTTPProxyPort = strings.TrimSpace(cfg.HTTPProxyPort)
+	if cfg.HTTPProxyPort != "" {
+		port, err := strconv.Atoi(cfg.HTTPProxyPort)
+		if err != nil || port < 1 || port > 65535 {
+			logger.Printf("Invalid ISTIO_HTTP_PROXY_PORT %q, explicit proxy disabled", cfg.HTTPProxyPort)
+			cfg.HTTPProxyPort = ""
+		} else {
+			cfg.HTTPProxyPort = strconv.Itoa(port)
+		}
+	}
 	metric := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "d8_istio_alliance_dataplane_health_check",
@@ -236,6 +249,11 @@ func (c *Checker) curlHealthzWithBody(ctx context.Context, url string) (bool, st
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return false, "", fmt.Sprintf("request build failed: %v", err)
+	}
+	if c.config.HTTPProxyPort != "" {
+		authority := req.URL.Hostname()
+		req.URL.Host = net.JoinHostPort("127.0.0.1", c.config.HTTPProxyPort)
+		req.Host = authority
 	}
 	req.Header.Set("User-Agent", allianceHealthcheckUserAgent)
 	req.Header.Set("X-alliance-healthcheck-from", c.config.ClusterUUID)

--- a/ee/modules/110-istio/images/alliance-healthcheck/src/main.go
+++ b/ee/modules/110-istio/images/alliance-healthcheck/src/main.go
@@ -30,6 +30,7 @@ func main() {
 	clusterDomain := os.Getenv("CLUSTER_DOMAIN")
 	federationEnabled := os.Getenv("FEDERATION_ENABLED") == "true"
 	multiclusterEnabled := os.Getenv("MULTICLUSTER_ENABLED") == "true"
+	httpProxyPort := os.Getenv("ISTIO_HTTP_PROXY_PORT")
 
 	if clusterDomain == "" {
 		clusterDomain = "cluster.local"
@@ -53,6 +54,7 @@ func main() {
 		ClusterDomain:       clusterDomain,
 		FederationEnabled:   federationEnabled,
 		MulticlusterEnabled: multiclusterEnabled,
+		HTTPProxyPort:       httpProxyPort,
 		CheckInterval:       60 * time.Second,
 		RequestTimeout:      5 * time.Second,
 	})

--- a/ee/modules/110-istio/images/ztunnel-v1x25x2/werf.inc.yaml
+++ b/ee/modules/110-istio/images/ztunnel-v1x25x2/werf.inc.yaml
@@ -6,8 +6,8 @@ import:
   - image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
     add: /src/ztunnel/bin/ztunnel
     to: /usr/local/bin/ztunnel
-    owner: 1337
-    group: 1337
+    owner: 64535
+    group: 64535
     before: install
   - from: {{ index $.Images "libs/glibc-v2.41" }}
     add: /lib64/libc.so.6
@@ -31,8 +31,8 @@ import:
     before: install
 imageSpec:
   config:
-    user: "1337:1337"
-    env:  
+    user: "64535:64535"
+    env:
       ISTIO_META_ISTIO_VERSION: {{ $istioVersion }}
     entrypoint: ["/usr/local/bin/ztunnel"]
 ---

--- a/ee/modules/110-istio/templates/alliance/healthcheck/deployment.yaml
+++ b/ee/modules/110-istio/templates/alliance/healthcheck/deployment.yaml
@@ -49,6 +49,13 @@ spec:
         app: alliance-healthcheck
         sidecar.istio.io/inject: "true"
         istio.io/rev: default
+      annotations:
+        traffic.sidecar.istio.io/includeOutboundIPRanges: ""
+        proxy.istio.io/config: |-
+          proxyMetadata:
+            ISTIO_META_HTTP_PROXY_PORT: "15007"
+            ISTIO_META_DNS_CAPTURE: "false"
+            ISTIO_META_DNS_AUTO_ALLOCATE: "false"
     spec:
       {{- include "helm_lib_node_selector" (tuple . "system") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "system") | nindent 6 }}
@@ -69,6 +76,8 @@ spec:
           value: {{ .Values.global.discovery.clusterUUID }}
         - name: CLUSTER_DOMAIN
           value: {{ $.Values.global.discovery.clusterDomain | quote }}
+        - name: ISTIO_HTTP_PROXY_PORT
+          value: "15007"
   {{- if .Values.istio.federation.enabled }}
         - name: FEDERATION_ENABLED
           value: "true"

--- a/ee/modules/110-istio/templates/alliance/ingressgateway/daemonset.yaml
+++ b/ee/modules/110-istio/templates/alliance/ingressgateway/daemonset.yaml
@@ -178,9 +178,9 @@ spec:
           timeoutSeconds: 3
           failureThreshold: 30
         securityContext:
-          runAsGroup: 1337
+          runAsGroup: 64535
           runAsNonRoot: true
-          runAsUser: 1337
+          runAsUser: 64535
           readOnlyRootFilesystem: true
         resources:
           requests:

--- a/ee/modules/110-istio/templates/ztunnel/daemonset.yaml
+++ b/ee/modules/110-istio/templates/ztunnel/daemonset.yaml
@@ -64,7 +64,7 @@ spec:
             - SYS_ADMIN # Required for `setns` - doing things in other netns
             - NET_RAW # Required for RAW/PACKET sockets, TPROXY
           readOnlyRootFilesystem: true
-          runAsGroup: 1337
+          runAsGroup: 64535
           runAsNonRoot: false
           runAsUser: 0
         readinessProbe:

--- a/modules/110-istio/hooks/reserved_uid_monitoring.go
+++ b/modules/110-istio/hooks/reserved_uid_monitoring.go
@@ -33,16 +33,28 @@ import (
 )
 
 const (
-	istioReservedUID        int64 = 1337
-	istioProxyContainerName       = "istio-proxy"
-	istioCanonicalNameLabel       = "service.istio.io/canonical-name"
-	reservedUIDMetricsGroup       = "d8_istio_reserved_uid"
+	deckhouseProxyUID int64 = 64535
+	legacyProxyUID    int64 = 1337
+
+	istioProxyContainerName = "istio-proxy"
+	istioCanonicalNameLabel = "service.istio.io/canonical-name"
+	reservedUIDMetricsGroup = "d8_istio_reserved_uid"
 )
 
+var reservedUIDs = map[int64]string{
+	deckhouseProxyUID: "64535",
+	legacyProxyUID:    "1337",
+}
+
+type reservedContainer struct {
+	Name string
+	UID  string
+}
+
 type podReservedUIDInfo struct {
-	Namespace              string
-	Pod                    string
-	ImproperContainerNames []string
+	Namespace          string
+	Pod                string
+	ImproperContainers []reservedContainer
 }
 
 func applyReservedUIDFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
@@ -58,7 +70,7 @@ func applyReservedUIDFilter(obj *unstructured.Unstructured) (go_hook.FilterResul
 		podRunAsUser = pod.Spec.SecurityContext.RunAsUser
 	}
 
-	var matchingContainers []string
+	var matchingContainers []reservedContainer
 	for _, container := range pod.Spec.Containers {
 		if container.Name == istioProxyContainerName {
 			continue
@@ -71,8 +83,11 @@ func applyReservedUIDFilter(obj *unstructured.Unstructured) (go_hook.FilterResul
 			effectiveRunAsUser = podRunAsUser
 		}
 
-		if effectiveRunAsUser != nil && *effectiveRunAsUser == istioReservedUID {
-			matchingContainers = append(matchingContainers, container.Name)
+		if effectiveRunAsUser == nil {
+			continue
+		}
+		if uidStr, ok := reservedUIDs[*effectiveRunAsUser]; ok {
+			matchingContainers = append(matchingContainers, reservedContainer{Name: container.Name, UID: uidStr})
 		}
 	}
 
@@ -81,9 +96,9 @@ func applyReservedUIDFilter(obj *unstructured.Unstructured) (go_hook.FilterResul
 	}
 
 	return podReservedUIDInfo{
-		Namespace:              pod.Namespace,
-		Pod:                    pod.Name,
-		ImproperContainerNames: matchingContainers,
+		Namespace:          pod.Namespace,
+		Pod:                pod.Name,
+		ImproperContainers: matchingContainers,
 	}, nil
 }
 
@@ -120,14 +135,15 @@ func handleReservedUIDMonitoring(_ context.Context, input *go_hook.HookInput) er
 			return fmt.Errorf("failed to iterate over pod snapshots: %w", err)
 		}
 
-		for _, containerName := range info.ImproperContainerNames {
+		for _, c := range info.ImproperContainers {
 			input.MetricsCollector.Set(
 				"d8_istio_pod_container_reserved_uid",
 				1,
 				map[string]string{
-					"namespace": info.Namespace,
-					"pod":       info.Pod,
-					"container": containerName,
+					"namespace":    info.Namespace,
+					"pod":          info.Pod,
+					"container":    c.Name,
+					"reserved_uid": c.UID,
 				},
 				metrics.WithGroup(reservedUIDMetricsGroup),
 			)

--- a/modules/110-istio/hooks/reserved_uid_monitoring_test.go
+++ b/modules/110-istio/hooks/reserved_uid_monitoring_test.go
@@ -50,9 +50,29 @@ var _ = Describe("Istio hooks :: reserved UID monitoring ::", func() {
 			Expect(m).To(HaveLen(2))
 			Expect(m[1].Name).To(Equal("d8_istio_pod_container_reserved_uid"))
 			Expect(m[1].Labels).To(BeEquivalentTo(map[string]string{
-				"namespace": "default",
-				"pod":       "app-pod",
-				"container": "app",
+				"namespace":      "default",
+				"pod":            "app-pod",
+				"container":      "app",
+				"reserved_uid":   "1337",
+			}))
+		})
+	})
+
+	Context("Pod with app container running as UID 64535 and istio-proxy present", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(podAppUser64535WithProxy))
+			f.RunHook()
+		})
+
+		It("Should emit metric with reserved_uid 64535", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			m := f.MetricsCollector.CollectedMetrics()
+			Expect(m).To(HaveLen(2))
+			Expect(m[1].Labels).To(BeEquivalentTo(map[string]string{
+				"namespace":      "default",
+				"pod":            "app-pod-deckhouse-uid",
+				"container":      "app",
+				"reserved_uid":   "64535",
 			}))
 		})
 	})
@@ -95,9 +115,10 @@ var _ = Describe("Istio hooks :: reserved UID monitoring ::", func() {
 			Expect(m).To(HaveLen(2))
 			Expect(m[1].Name).To(Equal("d8_istio_pod_container_reserved_uid"))
 			Expect(m[1].Labels).To(BeEquivalentTo(map[string]string{
-				"namespace": "default",
-				"pod":       "pod-level-uid",
-				"container": "app",
+				"namespace":      "default",
+				"pod":            "pod-level-uid",
+				"container":      "app",
+				"reserved_uid":   "1337",
 			}))
 		})
 	})
@@ -115,18 +136,20 @@ var _ = Describe("Istio hooks :: reserved UID monitoring ::", func() {
 		})
 	})
 
-	Context("Multiple app containers with UID 1337 in one pod with istio-proxy", func() {
+	Context("Multiple app containers with reserved UIDs in one pod with istio-proxy", func() {
 		BeforeEach(func() {
-			f.BindingContexts.Set(f.KubeStateSet(podMultipleContainers1337))
+			f.BindingContexts.Set(f.KubeStateSet(podMultipleContainersMixedReserved))
 			f.RunHook()
 		})
 
-		It("Should emit metrics for each non-istio-proxy container", func() {
+		It("Should emit metrics for each non-istio-proxy container with correct reserved_uid", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			m := f.MetricsCollector.CollectedMetrics()
 			Expect(m).To(HaveLen(3))
 			Expect(m[1].Name).To(Equal("d8_istio_pod_container_reserved_uid"))
 			Expect(m[2].Name).To(Equal("d8_istio_pod_container_reserved_uid"))
+			Expect(m[1].Labels["reserved_uid"]).NotTo(Equal(m[2].Labels["reserved_uid"]))
+			Expect([]string{m[1].Labels["reserved_uid"], m[2].Labels["reserved_uid"]}).To(ConsistOf("1337", "64535"))
 		})
 	})
 
@@ -152,6 +175,27 @@ spec:
     image: istio/proxyv2:latest
     securityContext:
       runAsUser: 1337
+`
+
+	podAppUser64535WithProxy = `
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: app-pod-deckhouse-uid
+  namespace: default
+  labels:
+    service.istio.io/canonical-name: app-deckhouse
+spec:
+  containers:
+  - name: app
+    image: app:latest
+    securityContext:
+      runAsUser: 64535
+  - name: istio-proxy
+    image: istio/proxyv2:latest
+    securityContext:
+      runAsUser: 64535
 `
 
 	podOnlyProxyUser1337 = `
@@ -230,7 +274,7 @@ spec:
     image: istio/proxyv2:latest
 `
 
-	podMultipleContainers1337 = `
+	podMultipleContainersMixedReserved = `
 ---
 apiVersion: v1
 kind: Pod
@@ -248,11 +292,11 @@ spec:
   - name: sidecar
     image: sidecar:latest
     securityContext:
-      runAsUser: 1337
+      runAsUser: 64535
   - name: istio-proxy
     image: istio/proxyv2:latest
     securityContext:
-      runAsUser: 1337
+      runAsUser: 64535
 `
 
 )

--- a/modules/110-istio/images/cni-v1x21x6/werf.inc.yaml
+++ b/modules/110-istio/images/cni-v1x21x6/werf.inc.yaml
@@ -11,14 +11,14 @@ import:
 - image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /src/istio/out/istio-cni
   to: /opt/cni/bin/istio-cni
-  owner: 1337
-  group: 1337
+  owner: 64535
+  group: 64535
   after: setup
 - image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /src/istio/out/install-cni
   to: /usr/local/bin/install-cni
-  owner: 1337
-  group: 1337
+  owner: 64535
+  group: 64535
   after: setup
 - image: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
   add: /relocate
@@ -38,9 +38,10 @@ import:
 {{- include "image mount points" . }}
 imageSpec:
   config:
-    env: {"PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/cni/bin"}
+    env:
+      PATH: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/cni/bin"
     workingDir: "/opt/cni/bin"
-    user: "1337:1337"
+    user: "64535:64535"
     entrypoint: ["/usr/local/bin/install-cni"]
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
@@ -82,7 +83,7 @@ shell:
   - strip /src/istio/out/install-cni
   - strip /src/istio/out/istio-cni
   - chmod 0700 /src/istio/out/install-cni /src/istio/out/istio-cni
-  - chown 1337:1337 /src/istio/out/istio-cni
+  - chown 64535:64535 /src/istio/out/istio-cni
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
 from: {{ index $.Images "builder/distroless" }}

--- a/modules/110-istio/images/cni-v1x25x2/werf.inc.yaml
+++ b/modules/110-istio/images/cni-v1x25x2/werf.inc.yaml
@@ -11,14 +11,14 @@ import:
 - image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /src/istio/out/istio-cni
   to: /opt/cni/bin/istio-cni
-  owner: 1337
-  group: 1337
+  owner: 64535
+  group: 64535
   after: setup
 - image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /src/istio/out/install-cni
   to: /usr/local/bin/install-cni
-  owner: 1337
-  group: 1337
+  owner: 64535
+  group: 64535
   after: setup
 - image: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
   add: /relocate
@@ -38,9 +38,10 @@ import:
 {{- include "image mount points" . }}
 imageSpec:
   config:
-    env: {"PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/cni/bin"}
+    env:
+      PATH: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/cni/bin"
     workingDir: "/opt/cni/bin"
-    user: "1337:1337"
+    user: "64535:64535"
     entrypoint: ["/usr/local/bin/install-cni"]
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
@@ -82,7 +83,7 @@ shell:
   - strip /src/istio/out/install-cni
   - strip /src/istio/out/istio-cni
   - chmod 0700 /src/istio/out/install-cni /src/istio/out/istio-cni
-  - chown 1337:1337 /src/istio/out/istio-cni
+  - chown 64535:64535 /src/istio/out/istio-cni
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
 from: {{ index $.Images "builder/distroless" }}

--- a/modules/110-istio/images/common-v1x25x2/patches/003-change-to-deckhouse-user.patch
+++ b/modules/110-istio/images/common-v1x25x2/patches/003-change-to-deckhouse-user.patch
@@ -1,0 +1,308 @@
+diff --git a/cni/pkg/plugin/sidecar_redirect.go b/cni/pkg/plugin/sidecar_redirect.go
+index cb9e209726..9e283c6ea2 100644
+--- a/cni/pkg/plugin/sidecar_redirect.go
++++ b/cni/pkg/plugin/sidecar_redirect.go
+@@ -31,8 +31,8 @@ const (
+ 	redirectModeTPROXY           = "TPROXY"
+ 	defaultProxyStatusPort       = "15020"
+ 	defaultRedirectToPort        = "15001"
+-	defaultNoRedirectUID         = "1337"
+-	defaultNoRedirectGID         = "1337"
++	defaultNoRedirectUID         = "64535,1337"
++	defaultNoRedirectGID         = "64535,1337"
+ 	defaultRedirectMode          = redirectModeREDIRECT
+ 	defaultRedirectIPCidr        = "*"
+ 	defaultRedirectExcludeIPCidr = ""
+@@ -221,13 +221,13 @@ func NewRedirect(pi *PodInfo) (*Redirect, error) {
+ 	}
+ 
+ 	if pi.ProxyUID != nil && *pi.ProxyUID != 0 {
+-		redir.noRedirectUID = fmt.Sprintf("%d", *pi.ProxyUID)
++		redir.noRedirectUID = fmt.Sprintf("%d,1337", *pi.ProxyUID)
+ 	} else {
+ 		redir.noRedirectUID = defaultNoRedirectUID
+ 	}
+ 
+ 	if pi.ProxyGID != nil && *pi.ProxyGID != 0 {
+-		redir.noRedirectGID = fmt.Sprintf("%d", *pi.ProxyGID)
++		redir.noRedirectGID = fmt.Sprintf("%d,1337", *pi.ProxyGID)
+ 	} else {
+ 		redir.noRedirectGID = defaultNoRedirectGID
+ 	}
+diff --git a/docker/Dockerfile.base b/docker/Dockerfile.base
+index 382eb51855..6b803b27f5 100644
+--- a/docker/Dockerfile.base
++++ b/docker/Dockerfile.base
+@@ -30,5 +30,5 @@ RUN apt-get update && \
+   && update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+ 
+ # Sudoers used to allow tcpdump and other debug utilities.
+-RUN useradd -m --uid 1337 istio-proxy && \
++RUN useradd -m --uid 64535 istio-proxy && \
+   echo "istio-proxy ALL=NOPASSWD: ALL" >> /etc/sudoers
+diff --git a/docker/Dockerfile.distroless b/docker/Dockerfile.distroless
+index f6d2b0d9c1..38b9f443e7 100644
+--- a/docker/Dockerfile.distroless
++++ b/docker/Dockerfile.distroless
+@@ -7,8 +7,8 @@ FROM ubuntu:noble AS ubuntu_source
+ # Modify contents of container
+ COPY --from=distroless_source /etc/ /home/etc
+ COPY --from=distroless_source /home/nonroot /home/nonroot
+-RUN echo istio-proxy:x:1337: >> /home/etc/group
+-RUN echo istio-proxy:x:1337:1337:istio-proxy:/nonexistent:/sbin/nologin >> /home/etc/passwd
++RUN echo istio-proxy:x:64535: >> /home/etc/group
++RUN echo istio-proxy:x:64535:64535:istio-proxy:/nonexistent:/sbin/nologin >> /home/etc/passwd
+ 
+ # Customize distroless with the following:
+ # - password file
+diff --git a/manifests/charts/gateway/templates/deployment.yaml b/manifests/charts/gateway/templates/deployment.yaml
+index 9db59d8b97..3789afb1fa 100644
+--- a/manifests/charts/gateway/templates/deployment.yaml
++++ b/manifests/charts/gateway/templates/deployment.yaml
+@@ -78,8 +78,8 @@ spec:
+             privileged: false
+             readOnlyRootFilesystem: true
+             {{- if not (eq (.Values.platform | default "") "openshift") }}
+-            runAsUser: 1337
+-            runAsGroup: 1337
++            runAsUser: 64535
++            runAsGroup: 64535
+             {{- end }}
+             runAsNonRoot: true
+           {{- end }}
+diff --git a/manifests/charts/gateways/istio-egress/templates/deployment.yaml b/manifests/charts/gateways/istio-egress/templates/deployment.yaml
+index 2da44f14c8..bb555fea8b 100644
+--- a/manifests/charts/gateways/istio-egress/templates/deployment.yaml
++++ b/manifests/charts/gateways/istio-egress/templates/deployment.yaml
+@@ -66,8 +66,8 @@ spec:
+ {{- if not $gateway.runAsRoot }}
+       securityContext:
+ {{- if not (eq ((coalesce .Values.platform .Values.global.platform) | default "") "openshift") }}
+-        runAsUser: 1337
+-        runAsGroup: 1337
++        runAsUser: 64535
++        runAsGroup: 64535
+ {{- end }}
+         runAsNonRoot: true
+ {{- end }}
+diff --git a/manifests/charts/gateways/istio-egress/templates/injected-deployment.yaml b/manifests/charts/gateways/istio-egress/templates/injected-deployment.yaml
+index 241f9fb267..18fc3f84d6 100644
+--- a/manifests/charts/gateways/istio-egress/templates/injected-deployment.yaml
++++ b/manifests/charts/gateways/istio-egress/templates/injected-deployment.yaml
+@@ -64,8 +64,8 @@ spec:
+ {{- if not $gateway.runAsRoot }}
+       securityContext:
+ {{- if not (eq (coalesce .Values.platform .Values.global.platform) "openshift") }}
+-        runAsUser: 1337
+-        runAsGroup: 1337
++        runAsUser: 64535
++        runAsGroup: 64535
+ {{- end }}
+         runAsNonRoot: true
+ {{- end }}
+diff --git a/manifests/charts/gateways/istio-ingress/templates/deployment.yaml b/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
+index 9fff771614..6d1bb40efe 100644
+--- a/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
++++ b/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
+@@ -66,8 +66,8 @@ spec:
+ {{- if not $gateway.runAsRoot }}
+       securityContext:
+ {{- if not (eq ((coalesce .Values.platform .Values.global.platform) | default "") "openshift") }}
+-        runAsUser: 1337
+-        runAsGroup: 1337
++        runAsUser: 64535
++        runAsGroup: 64535
+ {{- end }}
+         runAsNonRoot: true
+ {{- end }}
+diff --git a/manifests/charts/gateways/istio-ingress/templates/injected-deployment.yaml b/manifests/charts/gateways/istio-ingress/templates/injected-deployment.yaml
+index 05cabac6e3..2fb1a04afb 100644
+--- a/manifests/charts/gateways/istio-ingress/templates/injected-deployment.yaml
++++ b/manifests/charts/gateways/istio-ingress/templates/injected-deployment.yaml
+@@ -64,8 +64,8 @@ spec:
+ {{- if not $gateway.runAsRoot }}
+       securityContext:
+ {{- if not (eq (coalesce .Values.platform .Values.global.platform) "openshift") }}
+-        runAsUser: 1337
+-        runAsGroup: 1337
++        runAsUser: 64535
++        runAsGroup: 64535
+ {{- end }}
+         runAsNonRoot: true
+ {{- end }}
+diff --git a/manifests/charts/istio-control/istio-discovery/files/gateway-injection-template.yaml b/manifests/charts/istio-control/istio-discovery/files/gateway-injection-template.yaml
+index dbd83cc57d..46177a8834 100644
+--- a/manifests/charts/istio-control/istio-discovery/files/gateway-injection-template.yaml
++++ b/manifests/charts/istio-control/istio-discovery/files/gateway-injection-template.yaml
+@@ -53,8 +53,8 @@ spec:
+       {{ toYaml .Values.global.proxy.lifecycle | indent 6 }}
+   {{- end }}
+     securityContext:
+-      runAsUser: {{ .ProxyUID | default "1337" }}
+-      runAsGroup: {{ .ProxyGID | default "1337" }}
++      runAsUser: {{ .ProxyUID | default "64535" }}
++      runAsGroup: {{ .ProxyGID | default "64535" }}
+     env:
+     - name: PILOT_CERT_PROVIDER
+       value: {{ .Values.global.pilotCertProvider }}
+diff --git a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+index 3b3f69cd9d..74d87b5240 100644
+--- a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
++++ b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+@@ -88,7 +88,7 @@ spec:
+     - "-z"
+     - {{ .MeshConfig.ProxyInboundListenPort | default "15006" | quote }}
+     - "-u"
+-    - {{ .ProxyUID | default "1337" | quote }}
++    - {{ printf "%d,1337" (.ProxyUID | default 64535) | quote }}
+     - "-m"
+     - "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}"
+     - "-i"
+@@ -161,8 +161,8 @@ spec:
+       runAsUser: 0
+     {{- else }}
+       readOnlyRootFilesystem: true
+-      runAsGroup: {{ .ProxyGID | default "1337" }}
+-      runAsUser: {{ .ProxyUID | default "1337" }}
++      runAsGroup: {{ .ProxyGID | default "64535" }}
++      runAsUser: {{ .ProxyUID | default "64535" }}
+       runAsNonRoot: true
+     {{- end }}
+   {{ end -}}
+@@ -362,7 +362,7 @@ spec:
+         - ALL
+       privileged: true
+       readOnlyRootFilesystem: true
+-      runAsGroup: {{ .ProxyGID | default "1337" }}
++      runAsGroup: {{ .ProxyGID | default "64535" }}
+       runAsNonRoot: false
+       runAsUser: 0
+       {{- else }}
+@@ -381,13 +381,13 @@ spec:
+         - ALL
+       privileged: {{ .Values.global.proxy.privileged }}
+       readOnlyRootFilesystem: true
+-      runAsGroup: {{ .ProxyGID | default "1337" }}
++      runAsGroup: {{ .ProxyGID | default "64535" }}
+       {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
+       runAsNonRoot: false
+       runAsUser: 0
+       {{- else -}}
+       runAsNonRoot: true
+-      runAsUser: {{ .ProxyUID | default "1337" }}
++      runAsUser: {{ .ProxyUID | default "64535" }}
+       {{- end }}
+       {{- end }}
+     resources:
+diff --git a/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml b/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
+index dbe158de1f..b0564fb38f 100644
+--- a/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
++++ b/manifests/charts/istio-control/istio-discovery/files/kube-gateway.yaml
+@@ -99,8 +99,8 @@ spec:
+           allowPrivilegeEscalation: false
+           privileged: false
+           readOnlyRootFilesystem: true
+-          runAsUser: {{ .ProxyUID | default "1337" }}
+-          runAsGroup: {{ .ProxyGID | default "1337" }}
++          runAsUser: {{ .ProxyUID | default "64535" }}
++          runAsGroup: {{ .ProxyGID | default "64535" }}
+           runAsNonRoot: true
+         ports:
+         - containerPort: 15020
+diff --git a/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml b/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
+index 2600e98e21..f60bd41655 100644
+--- a/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
++++ b/manifests/charts/istio-control/istio-discovery/files/waypoint.yaml
+@@ -232,8 +232,8 @@ spec:
+         securityContext:
+           privileged: false
+         {{- if not (eq .Values.global.platform "openshift") }}
+-          runAsGroup: 1337
+-          runAsUser: 1337
++          runAsGroup: 64535
++          runAsUser: 64535
+         {{- end }}
+           allowPrivilegeEscalation: false
+           readOnlyRootFilesystem: true
+diff --git a/manifests/charts/ztunnel/templates/daemonset.yaml b/manifests/charts/ztunnel/templates/daemonset.yaml
+index ee5775d70b..1a1cfa6879 100644
+--- a/manifests/charts/ztunnel/templates/daemonset.yaml
++++ b/manifests/charts/ztunnel/templates/daemonset.yaml
+@@ -87,7 +87,7 @@ spec:
+             - SYS_ADMIN # Required for `setns` - doing things in other netns
+             - NET_RAW # Required for RAW/PACKET sockets, TPROXY
+           readOnlyRootFilesystem: true
+-          runAsGroup: 1337
++          runAsGroup: 64535
+           runAsNonRoot: false
+           runAsUser: 0
+ {{- if .Values.seLinuxOptions }}
+diff --git a/pkg/config/analysis/analyzers/deployment/pod.go b/pkg/config/analysis/analyzers/deployment/pod.go
+index 7d727deb95..cd7560dabe 100644
+--- a/pkg/config/analysis/analyzers/deployment/pod.go
++++ b/pkg/config/analysis/analyzers/deployment/pod.go
+@@ -31,7 +31,7 @@ type ApplicationUIDAnalyzer struct{}
+ var _ analysis.Analyzer = &ApplicationUIDAnalyzer{}
+ 
+ const (
+-	UserID = int64(1337)
++	UserID = int64(64535)
+ )
+ 
+ func (appUID *ApplicationUIDAnalyzer) Metadata() analysis.Metadata {
+diff --git a/pkg/envoy/proxy.go b/pkg/envoy/proxy.go
+index 576234fc54..217d8892b5 100644
+--- a/pkg/envoy/proxy.go
++++ b/pkg/envoy/proxy.go
+@@ -209,8 +209,8 @@ func (e *envoy) Run(abort <-chan error) error {
+ 	if e.AgentIsRoot {
+ 		cmd.SysProcAttr = &syscall.SysProcAttr{}
+ 		cmd.SysProcAttr.Credential = &syscall.Credential{
+-			Uid: 1337,
+-			Gid: 1337,
++			Uid: 64535,
++			Gid: 64535,
+ 		}
+ 	}
+ 
+diff --git a/pkg/kube/inject/inject.go b/pkg/kube/inject/inject.go
+index d875f44783..0d6fd41845 100644
+--- a/pkg/kube/inject/inject.go
++++ b/pkg/kube/inject/inject.go
+@@ -904,7 +904,7 @@ func updateClusterEnvs(container *corev1.Container, newKVs map[string]string) {
+ }
+ 
+ // GetProxyIDs returns the UID and GID to be used in the RunAsUser and RunAsGroup fields in the template
+-// Inspects the namespace metadata for hints and fallbacks to the usual value of 1337.
++// Inspects the namespace metadata for hints and fallbacks to the usual value of 64535.
+ func GetProxyIDs(namespace *corev1.Namespace) (uid int64, gid int64) {
+ 	uid = constants.DefaultProxyUIDInt
+ 	gid = constants.DefaultProxyUIDInt
+diff --git a/pkg/kube/inject/webhook.go b/pkg/kube/inject/webhook.go
+index 0ace3752ca..487fcc7f5c 100644
+--- a/pkg/kube/inject/webhook.go
++++ b/pkg/kube/inject/webhook.go
+@@ -644,7 +644,7 @@ func adjustInitContainerUser(finalPod *corev1.Pod, originalPod *corev1.Pod, prox
+ 	}
+ 	for i := range initContainer.Args {
+ 		if initContainer.Args[i] == "-u" {
+-			initContainer.Args[i+1] = fmt.Sprintf("%d", *userContainer.SecurityContext.RunAsUser)
++			initContainer.Args[i+1] = fmt.Sprintf("%d,1337", *userContainer.SecurityContext.RunAsUser)
+ 			return
+ 		}
+ 	}
+diff --git a/tools/istio-iptables/pkg/constants/constants.go b/tools/istio-iptables/pkg/constants/constants.go
+index 6ac71c5619..06c8f579f8 100644
+--- a/tools/istio-iptables/pkg/constants/constants.go
++++ b/tools/istio-iptables/pkg/constants/constants.go
+@@ -116,8 +116,8 @@ Only applies when traffic from all groups (i.e. "*") is being redirected to Envo
+ )
+ 
+ const (
+-	DefaultProxyUID    = "1337"
+-	DefaultProxyUIDInt = int64(1337)
++	DefaultProxyUID    = "64535"
++	DefaultProxyUIDInt = int64(64535)
+ )
+ 
+ // Constants used in environment variables

--- a/modules/110-istio/images/common-v1x25x2/patches/README.md
+++ b/modules/110-istio/images/common-v1x25x2/patches/README.md
@@ -16,3 +16,7 @@ Adopted upstream pr https://github.com/istio/istio/pull/58567.
 ## 002-kiali-logout.patch
 
 Enable Logout in Kiali for header auth (DexAuthenticator). The tab that clicks Logout calls `/logout?rd=<app-origin>/` once; other tabs receive a `localStorage` event and only dispatch `sessionExpired` locally (no second sign_out, no reload) to avoid oauth2-proxy CSRF races.
+=======
+## 003-change-to-deckhouse-user.patch
+
+Change runAsUser from 1337 to 64535 in istio templates, changed istio-init.iptables user arg to both 1337 and 64535 UIDs in injection-template.yaml

--- a/modules/110-istio/images/common-v1x25x2/werf.inc.yaml
+++ b/modules/110-istio/images/common-v1x25x2/werf.inc.yaml
@@ -31,6 +31,7 @@ shell:
   install:
   - cd /src/istio/ && git apply --verbose /patches/001-istio-gomod_gosum.patch
   - cd /src/istio/ && git apply --verbose /patches/002-istio-multicluster-regenerate-token-timeout.patch
+  - cd /src/istio/ && git apply --verbose /patches/003-change-to-deckhouse-user.patch
   - cd /src/kiali/ && git apply --verbose /patches/001-kiali-go-mod.patch
   - cd /src/kiali/ && git apply --verbose /patches/002-kiali-logout.patch
 ---

--- a/modules/110-istio/images/kiali-v1x21x6/werf.inc.yaml
+++ b/modules/110-istio/images/kiali-v1x21x6/werf.inc.yaml
@@ -10,15 +10,19 @@ import:
 - image: {{ .ModuleName }}/{{ .ImageName }}-backend-build-artifact
   add: /src/kiali/out/kiali
   to: /opt/kiali/kiali
+  owner: 64535
+  group: 64535
   before: install
 - image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-kiali-frontend-build-artifact
   add: /src/kial-frontend-assets/static
   to: /opt/kiali/console
+  owner: 64535
+  group: 64535
   before: install
 {{- include "image mount points" . }}
 imageSpec:
   config:
-    user: "1000"
+    user: "64535:64535"
     workingDir: "/opt/kiali"
     entrypoint: ["/opt/kiali/kiali"]
 ---

--- a/modules/110-istio/images/kiali-v1x25x2/werf.inc.yaml
+++ b/modules/110-istio/images/kiali-v1x25x2/werf.inc.yaml
@@ -10,15 +10,19 @@ import:
 - image: {{ .ModuleName }}/{{ .ImageName }}-backend-build-artifact
   add: /src/kiali/out/kiali
   to: /opt/kiali/kiali
+  owner: 64535
+  group: 64535
   before: install
 - image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-kiali-frontend-build-artifact
   add: /src/kial-frontend-assets/static
   to: /opt/kiali/console
+  owner: 64535
+  group: 64535
   before: install
 {{- include "image mount points" . }}
 imageSpec:
   config:
-    user: "1000"
+    user: "64535:64535"
     workingDir: "/opt/kiali"
     entrypoint: ["/opt/kiali/kiali"]
 ---

--- a/modules/110-istio/images/operator-v1x21x6/werf.inc.yaml
+++ b/modules/110-istio/images/operator-v1x21x6/werf.inc.yaml
@@ -9,8 +9,8 @@ import:
 - image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /src/istio/out/operator
   to: /usr/local/bin/operator
-  owner: 1337
-  group: 1337
+  owner: 64535
+  group: 64535
   after: setup
 - image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /src/istio/manifests
@@ -18,7 +18,7 @@ import:
   after: setup
 imageSpec:
   config:
-    user: "1337:1337"
+    user: "64535:64535"
     entrypoint: ["/usr/local/bin/operator"]
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact

--- a/modules/110-istio/images/operator-v1x25x2/patches/003-change-to-deckhouse-user.patch
+++ b/modules/110-istio/images/operator-v1x25x2/patches/003-change-to-deckhouse-user.patch
@@ -1,0 +1,122 @@
+diff --git a/resources/v1.25.2/charts/gateway/templates/deployment.yaml b/resources/v1.25.2/charts/gateway/templates/deployment.yaml
+index 9db59d8b..3789afb1 100644
+--- a/resources/v1.25.2/charts/gateway/templates/deployment.yaml
++++ b/resources/v1.25.2/charts/gateway/templates/deployment.yaml
+@@ -78,8 +78,8 @@ spec:
+             privileged: false
+             readOnlyRootFilesystem: true
+             {{- if not (eq (.Values.platform | default "") "openshift") }}
+-            runAsUser: 1337
+-            runAsGroup: 1337
++            runAsUser: 64535
++            runAsGroup: 64535
+             {{- end }}
+             runAsNonRoot: true
+           {{- end }}
+diff --git a/resources/v1.25.2/charts/istiod/files/gateway-injection-template.yaml b/resources/v1.25.2/charts/istiod/files/gateway-injection-template.yaml
+index dbd83cc5..46177a88 100644
+--- a/resources/v1.25.2/charts/istiod/files/gateway-injection-template.yaml
++++ b/resources/v1.25.2/charts/istiod/files/gateway-injection-template.yaml
+@@ -53,8 +53,8 @@ spec:
+       {{ toYaml .Values.global.proxy.lifecycle | indent 6 }}
+   {{- end }}
+     securityContext:
+-      runAsUser: {{ .ProxyUID | default "1337" }}
+-      runAsGroup: {{ .ProxyGID | default "1337" }}
++      runAsUser: {{ .ProxyUID | default "64535" }}
++      runAsGroup: {{ .ProxyGID | default "64535" }}
+     env:
+     - name: PILOT_CERT_PROVIDER
+       value: {{ .Values.global.pilotCertProvider }}
+diff --git a/resources/v1.25.2/charts/istiod/files/injection-template.yaml b/resources/v1.25.2/charts/istiod/files/injection-template.yaml
+index 3b3f69cd..74d87b52 100644
+--- a/resources/v1.25.2/charts/istiod/files/injection-template.yaml
++++ b/resources/v1.25.2/charts/istiod/files/injection-template.yaml
+@@ -88,7 +88,7 @@ spec:
+     - "-z"
+     - {{ .MeshConfig.ProxyInboundListenPort | default "15006" | quote }}
+     - "-u"
+-    - {{ .ProxyUID | default "1337" | quote }}
++    - {{ printf "%d,1337" (.ProxyUID | default 64535) | quote }}
+     - "-m"
+     - "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}"
+     - "-i"
+@@ -161,8 +161,8 @@ spec:
+       runAsUser: 0
+     {{- else }}
+       readOnlyRootFilesystem: true
+-      runAsGroup: {{ .ProxyGID | default "1337" }}
+-      runAsUser: {{ .ProxyUID | default "1337" }}
++      runAsGroup: {{ .ProxyGID | default "64535" }}
++      runAsUser: {{ .ProxyUID | default "64535" }}
+       runAsNonRoot: true
+     {{- end }}
+   {{ end -}}
+@@ -362,7 +362,7 @@ spec:
+         - ALL
+       privileged: true
+       readOnlyRootFilesystem: true
+-      runAsGroup: {{ .ProxyGID | default "1337" }}
++      runAsGroup: {{ .ProxyGID | default "64535" }}
+       runAsNonRoot: false
+       runAsUser: 0
+       {{- else }}
+@@ -381,13 +381,13 @@ spec:
+         - ALL
+       privileged: {{ .Values.global.proxy.privileged }}
+       readOnlyRootFilesystem: true
+-      runAsGroup: {{ .ProxyGID | default "1337" }}
++      runAsGroup: {{ .ProxyGID | default "64535" }}
+       {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
+       runAsNonRoot: false
+       runAsUser: 0
+       {{- else -}}
+       runAsNonRoot: true
+-      runAsUser: {{ .ProxyUID | default "1337" }}
++      runAsUser: {{ .ProxyUID | default "64535" }}
+       {{- end }}
+       {{- end }}
+     resources:
+diff --git a/resources/v1.25.2/charts/istiod/files/kube-gateway.yaml b/resources/v1.25.2/charts/istiod/files/kube-gateway.yaml
+index dbe158de..b0564fb3 100644
+--- a/resources/v1.25.2/charts/istiod/files/kube-gateway.yaml
++++ b/resources/v1.25.2/charts/istiod/files/kube-gateway.yaml
+@@ -99,8 +99,8 @@ spec:
+           allowPrivilegeEscalation: false
+           privileged: false
+           readOnlyRootFilesystem: true
+-          runAsUser: {{ .ProxyUID | default "1337" }}
+-          runAsGroup: {{ .ProxyGID | default "1337" }}
++          runAsUser: {{ .ProxyUID | default "64535" }}
++          runAsGroup: {{ .ProxyGID | default "64535" }}
+           runAsNonRoot: true
+         ports:
+         - containerPort: 15020
+diff --git a/resources/v1.25.2/charts/istiod/files/waypoint.yaml b/resources/v1.25.2/charts/istiod/files/waypoint.yaml
+index 2600e98e..f60bd416 100644
+--- a/resources/v1.25.2/charts/istiod/files/waypoint.yaml
++++ b/resources/v1.25.2/charts/istiod/files/waypoint.yaml
+@@ -232,8 +232,8 @@ spec:
+         securityContext:
+           privileged: false
+         {{- if not (eq .Values.global.platform "openshift") }}
+-          runAsGroup: 1337
+-          runAsUser: 1337
++          runAsGroup: 64535
++          runAsUser: 64535
+         {{- end }}
+           allowPrivilegeEscalation: false
+           readOnlyRootFilesystem: true
+diff --git a/resources/v1.25.2/charts/ztunnel/templates/daemonset.yaml b/resources/v1.25.2/charts/ztunnel/templates/daemonset.yaml
+index ee5775d7..1a1cfa68 100644
+--- a/resources/v1.25.2/charts/ztunnel/templates/daemonset.yaml
++++ b/resources/v1.25.2/charts/ztunnel/templates/daemonset.yaml
+@@ -87,7 +87,7 @@ spec:
+             - SYS_ADMIN # Required for `setns` - doing things in other netns
+             - NET_RAW # Required for RAW/PACKET sockets, TPROXY
+           readOnlyRootFilesystem: true
+-          runAsGroup: 1337
++          runAsGroup: 64535
+           runAsNonRoot: false
+           runAsUser: 0
+ {{- if .Values.seLinuxOptions }}

--- a/modules/110-istio/images/operator-v1x25x2/patches/README.md
+++ b/modules/110-istio/images/operator-v1x25x2/patches/README.md
@@ -7,3 +7,7 @@ Fix Istio CVE vulnerabilities
 ## 002-istio-operato-cni_status_restrict.patch
 
 Fix Sails operator check status about CNI
+
+## 003-change-to-deckhouse-user.patch
+
+Change runAsUser from 1337 to 64535 in istio templates, changed istio-init.iptables user arg to both 1337 and 64535 UIDs in injection-template.yaml

--- a/modules/110-istio/images/operator-v1x25x2/werf.inc.yaml
+++ b/modules/110-istio/images/operator-v1x25x2/werf.inc.yaml
@@ -9,8 +9,8 @@ import:
 - image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /src/operator/out/operator
   to: /usr/local/bin/operator
-  owner: 1337
-  group: 1337
+  owner: 64535
+  group: 64535
   after: setup
 - image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
   add: /src/istio/manifests
@@ -22,7 +22,7 @@ import:
   after: setup
 imageSpec:
   config:
-    user: "1337:1337"
+    user: "64535:64535"
     workingDir: "/"
     entrypoint: ["/usr/local/bin/operator"]
 ---
@@ -52,7 +52,7 @@ shell:
   - strip /src/operator/out/main
   - mv /src/operator/out/main /src/operator/out/operator
   - chmod 0700 /src/operator/out/operator
-  - chown 1337:1337 /src/operator/out/operator
+  - chown 64535:64535 /src/operator/out/operator
 #=====================================================================================================
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
@@ -75,4 +75,5 @@ shell:
   install:
   - cd /src/operator && git apply --verbose /patches/001-istio-go-mod.patch
   - cd /src/operator && git apply --verbose /patches/002-istio-operato-cni_status_restrict.patch
+  - cd /src/operator && git apply --verbose /patches/003-change-to-deckhouse-user.patch
 ---

--- a/modules/110-istio/images/pilot-v1x21x6/werf.inc.yaml
+++ b/modules/110-istio/images/pilot-v1x21x6/werf.inc.yaml
@@ -9,25 +9,25 @@ import:
 - image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /src/istio/out/pilot-discovery
   to: /usr/local/bin/pilot-discovery
-  owner: 1337
-  group: 1337
+  owner: 64535
+  group: 64535
   after: setup
 - image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
   add: /src/istio/tools/packaging/common/envoy_bootstrap.json
   to: /var/lib/istio/envoy/envoy_bootstrap_tmpl.json
-  owner: 1337
-  group: 1337
+  owner: 64535
+  group: 64535
   after: setup
 - image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
   add: /src/istio/tools/packaging/common/gcp_envoy_bootstrap.json
   to: /var/lib/istio/envoy/gcp_envoy_bootstrap_tmpl.json
-  owner: 1337
-  group: 1337
+  owner: 64535
+  group: 64535
   after: setup
 {{- include "image mount points" . }}
 imageSpec:
   config:
-    user: "1337:1337"
+    user: "64535:64535"
     entrypoint: ["/usr/local/bin/pilot-discovery"]
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
@@ -67,6 +67,6 @@ shell:
   - common/scripts/gobuild.sh /src/istio/out/ -tags=agent,disable_pgv /src/istio/pilot/cmd/pilot-discovery/
   - strip /src/istio/out/pilot-discovery
   - chmod 0700 /src/istio/out/pilot-discovery
-  - chown 1337:1337 /src/istio/out/pilot-discovery
+  - chown 64535:64535 /src/istio/out/pilot-discovery
 ---
 {{- include "vex mitigation" (list $ (printf "%s/%s" $.ModuleName $.ImageName)) }}

--- a/modules/110-istio/images/pilot-v1x25x2/werf.inc.yaml
+++ b/modules/110-istio/images/pilot-v1x25x2/werf.inc.yaml
@@ -9,19 +9,19 @@ import:
 - image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /src/istio/out/pilot-discovery
   to: /usr/local/bin/pilot-discovery
-  owner: 1337
-  group: 1337
+  owner: 64535
+  group: 64535
   after: setup
 - image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
   add: /src/istio/tools/packaging/common/envoy_bootstrap.json
   to: /var/lib/istio/envoy/envoy_bootstrap_tmpl.json
-  owner: 1337
-  group: 1337
+  owner: 64535
+  group: 64535
   after: setup
 {{- include "image mount points" . }}
 imageSpec:
   config:
-    user: "1337:1337"
+    user: "64535:64535"
     entrypoint: ["/usr/local/bin/pilot-discovery"]
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
@@ -61,6 +61,6 @@ shell:
   - common/scripts/gobuild.sh /src/istio/out/ -tags=disable_pgv /src/istio/pilot/cmd/pilot-discovery/
   - strip /src/istio/out/pilot-discovery
   - chmod 0700 /src/istio/out/pilot-discovery
-  - chown 1337:1337 /src/istio/out/pilot-discovery
+  - chown 64535:64535 /src/istio/out/pilot-discovery
 ---
 {{- include "vex mitigation" (list $ (printf "%s/%s" $.ModuleName $.ImageName)) }}

--- a/modules/110-istio/images/proxyv2-v1x21x6/werf.inc.yaml
+++ b/modules/110-istio/images/proxyv2-v1x21x6/werf.inc.yaml
@@ -18,26 +18,26 @@ import:
 - image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
   add: /src/istio/tools/packaging/common/envoy_bootstrap.json
   to: /var/lib/istio/envoy/envoy_bootstrap_tmpl.json
-  owner: 1337
-  group: 1337
+  owner: 64535
+  group: 64535
   after: setup
 - image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
   add: /src/istio/tools/packaging/common/gcp_envoy_bootstrap.json
   to: /var/lib/istio/envoy/gcp_envoy_bootstrap_tmpl.json
-  owner: 1337
-  group: 1337
+  owner: 64535
+  group: 64535
   after: setup
 - image: {{ .ModuleName }}/{{ .ImageName }}-agent-artifact
   add: /src/istio/out/pilot-agent
   to: /usr/local/bin/pilot-agent
-  owner: 1337
-  group: 1337
+  owner: 64535
+  group: 64535
   after: setup
 - image: {{ .ModuleName }}/{{ .ImageName }}-build-envoy-artifact
   add: /src/proxy/bin/envoy
   to: /usr/local/bin/envoy
-  owner: 1337
-  group: 1337
+  owner: 64535
+  group: 64535
   after: setup
 - from: {{ index $.Images "libs/glibc-v2.41" }}
   add: /lib64/libm.so.6
@@ -73,8 +73,10 @@ import:
 {{- include "image mount points" . }}
 imageSpec:
   config:
-    user: "1337:1337"
-    env: { "ISTIO_META_ISTIO_PROXY_SHA": "istio-proxy:78bd2d9b284978e170a49cd13decd5f952544489", "ISTIO_META_ISTIO_VERSION": "{{ $istioVersion }}" }
+    user: "64535:64535"
+    env:
+      ISTIO_META_ISTIO_PROXY_SHA: "istio-proxy:78bd2d9b284978e170a49cd13decd5f952544489"
+      ISTIO_META_ISTIO_VERSION: {{ $istioVersion }}
     workingDir: "/"
     entrypoint: ["/usr/local/bin/pilot-agent"]
 ---
@@ -120,7 +122,7 @@ shell:
   - strip /src/istio/out/pilot-agent
   #
   - chmod 0555 /src/istio/out/pilot-agent
-  - chown 1337:1337 /src/istio/out/pilot-agent
+  - chown 64535:64535 /src/istio/out/pilot-agent
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-build-envoy-artifact
 fromImage: {{ $.ModuleName }}/{{ .ImageName }}-build-image-artifact
@@ -333,7 +335,12 @@ shell:
   - rm -r /tmp/bazel
 imageSpec:
   config:
-    env: {"GOROOT": "/usr/local/go", "GOPATH": "/go", "PATH": "${PATH}:/usr/local/go/bin:/go/bin", "GOOS": "linux", "GOARCH": "amd64"}
+    env:
+      GOROOT: "/usr/local/go"
+      GOPATH: "/go"
+      PATH: "${PATH}:/usr/local/go/bin:/go/bin"
+      GOOS: "linux"
+      GOARCH: "amd64"
 ---
 #=====================================================================================================
 ---

--- a/modules/110-istio/images/proxyv2-v1x25x2/werf.inc.yaml
+++ b/modules/110-istio/images/proxyv2-v1x25x2/werf.inc.yaml
@@ -18,20 +18,20 @@ import:
 - image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
   add: /src/istio/tools/packaging/common/envoy_bootstrap.json
   to: /var/lib/istio/envoy/envoy_bootstrap_tmpl.json
-  owner: 1337
-  group: 1337
+  owner: 64535
+  group: 64535
   after: setup
 - image: {{ .ModuleName }}/{{ .ImageName }}-agent-artifact
   add: /src/istio/out/pilot-agent
   to: /usr/local/bin/pilot-agent
-  owner: 1337
-  group: 1337
+  owner: 64535
+  group: 64535
   after: setup
 - image: {{ .ModuleName }}/{{ .ImageName }}-build-envoy-artifact
   add: /src/proxy/bin/envoy
   to: /usr/local/bin/envoy
-  owner: 1337
-  group: 1337
+  owner: 64535
+  group: 64535
   after: setup
 - from: {{ index $.Images "libs/glibc-v2.41" }}
   add: /lib64/libc.so.6
@@ -67,7 +67,7 @@ import:
 {{- include "image mount points" . }}
 imageSpec:
   config:
-    user: "1337:1337"
+    user: "64535:64535"
     env: 
       ISTIO_META_ISTIO_PROXY_SHA: "istio-proxy:78bd2d9b284978e170a49cd13decd5f952544489"
       ISTIO_META_ISTIO_VERSION: {{ $istioVersion }}
@@ -116,7 +116,7 @@ shell:
   - strip /src/istio/out/pilot-agent
   #
   - chmod 0555 /src/istio/out/pilot-agent
-  - chown 1337:1337 /src/istio/out/pilot-agent
+  - chown 64535:64535 /src/istio/out/pilot-agent
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-build-envoy-artifact
 fromImage: {{ $.ModuleName }}/{{ .ImageName }}-build-image-artifact
@@ -261,7 +261,12 @@ shell:
   - rm -r /tmp/bazel
 imageSpec:
   config:
-    env: {"GOROOT": "/usr/local/go", "GOPATH": "/go", "PATH": "${PATH}:${GOROOT}/bin:${GOPATH}/bin", "GOOS": "linux", "GOARCH": "amd64"}
+    env:
+      GOROOT: "/usr/local/go"
+      GOPATH: "/go"
+      PATH: "${PATH}:${GOROOT}/bin:${GOPATH}/bin"
+      GOOS: "linux"
+      GOARCH: "amd64"
 ---
 #=====================================================================================================
 ---

--- a/modules/110-istio/monitoring/prometheus-rules/reserved-uid.yaml
+++ b/modules/110-istio/monitoring/prometheus-rules/reserved-uid.yaml
@@ -1,7 +1,7 @@
 - name: d8.istio.reserved-uid
   rules:
   - alert: D8IstioReservedUIDConflict
-    expr: max by (namespace, pod, container) (d8_istio_pod_container_reserved_uid == 1)
+    expr: max by (namespace, pod, container, reserved_uid) (d8_istio_pod_container_reserved_uid == 1)
     for: 10m
     labels:
       severity_level: "4"
@@ -9,12 +9,12 @@
     annotations:
       plk_markup_format: "markdown"
       plk_protocol_version: "1"
-      plk_create_group_if_not_exists__istio_applications_using_reserved_uid: IstioApplicationsUsingReservedUID,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
-      plk_grouped_by__istio_applications_using_reserved_uid: IstioApplicationsUsingReservedUID,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
-      summary: Application container is running as UID 1337 (reserved by Istio).
+      plk_create_group_if_not_exists__istio_applications_using_reserved_uid: IstioApplicationsUsingReservedUID,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes,reserved_uid=~reserved_uid
+      plk_grouped_by__istio_applications_using_reserved_uid: IstioApplicationsUsingReservedUID,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes,reserved_uid=~reserved_uid
+      summary: Application container runs as Istio bypass UID {{$labels.reserved_uid}}.
       description: |
-        Container `{{$labels.container}}` in pod `{{$labels.pod}}` in namespace `{{$labels.namespace}}` is running as UID `1337`.
+        Container `{{$labels.container}}` in pod `{{$labels.pod}}` in namespace `{{$labels.namespace}}` runs as UID `{{$labels.reserved_uid}}`.
 
-        UID `1337` is reserved by Istio for the `istio-proxy` sidecar container. When application containers run with this UID, their traffic bypasses Istio completely — no routing rules, mTLS, or telemetry will be applied.
+        UID `{{$labels.reserved_uid}}` is reserved by Istio for the `istio-proxy` sidecar container. When application containers run with this UID, their traffic bypasses Istio completely — no routing rules, mTLS, or telemetry will be applied.
 
         To fix the issue, change the `runAsUser` in the container's or pod's `securityContext` to a different UID.

--- a/modules/110-istio/templates/kiali/deployment.yaml
+++ b/modules/110-istio/templates/kiali/deployment.yaml
@@ -54,7 +54,7 @@ spec:
       {{- include "helm_lib_tolerations" (tuple . "system") | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple . "cluster-low") | nindent 6 }}
       {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "kiali")) | nindent 6 }}
-      {{- include "helm_lib_module_pod_security_context_run_as_user_custom" (list . 1000 1000) | nindent 6 }}
+      {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
       automountServiceAccountToken: true
       serviceAccountName: kiali
       imagePullSecrets:
@@ -62,7 +62,7 @@ spec:
       containers:
       - name: kiali
         image: {{ include "helm_lib_module_image" (list $ (printf "kiali%s" $imageSuffix)) }}
-        {{- include "helm_lib_module_container_security_context_pss_restricted_flexible" (dict "uid" 1000 ) | nindent 8 }}
+        {{- include "helm_lib_module_container_security_context_run_as_user_deckhouse_pss_restricted" . | nindent 8 }}
         imagePullPolicy: IfNotPresent
         command:
         - "/opt/kiali/kiali"

--- a/modules/110-istio/templates/operator/deployment.yaml
+++ b/modules/110-istio/templates/operator/deployment.yaml
@@ -92,8 +92,8 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: true
-          runAsGroup: 1337
-          runAsUser: 1337
+          runAsGroup: 64535
+          runAsUser: 64535
           runAsNonRoot: true
         imagePullPolicy: IfNotPresent
         {{- if (hasPrefix "1.25" $fullVersion) }}
@@ -105,10 +105,9 @@ spec:
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 10 | nindent 12 }}
-  {{- if not ($.Values.global.enabledModules | has "vertical-pod-autoscaler") }}
-            {{- include "istio_proxy_resources" . | nindent 12 }}
-  {{- end }}
-
+            {{- if not ($.Values.global.enabledModules | has "vertical-pod-autoscaler") }}
+              {{- include "istio_proxy_resources" . | nindent 12 }}
+            {{- end }}
         ports:
         {{- if (hasPrefix "1.25" $fullVersion) }}
         - containerPort: 8443


### PR DESCRIPTION
…8851)" (#20074)"

This reverts commit 3db9e30730e13143ca9d78db1048a3727ddaf455.

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: chore
summary: >-
  Migrated the Istio sidecar and control-plane runtime UID/GID from 1337 to 64535.
impact: >-
  Istio control-plane and injected sidecars restart; sidecar UID/GID changes
  from 1337 to 64535. Pods annotated with `traffic.sidecar.istio.io/outboundSocketMark`
  use the `proxyv2-*-mark` image (requires CAP_NET_RAW, kernel >= 5.17).
impact_level: high
```
