### PR TITLE
[registrypackages] Fix containerd and runc Svace builds

### DIFF
--- a/modules/007-registrypackages/images/containerd/werf.inc.yaml
+++ b/modules/007-registrypackages/images/containerd/werf.inc.yaml
@@ -83,6 +83,7 @@ shell:
   - |
   {{- $buildContext := deepCopy $ -}}
   {{- $parted_version := split "." $runc_version -}}
+  {{- $_ := set $buildContext "SvaceBuildOptions" "--enable-ptrace-all" -}}
   {{- $_ := set $buildContext "BuildCommand" `make COMMIT="$(cat COMMIT)" EXTRA_LDFLAGS="-s -w" static` -}}
   {{- $_ := set $buildContext "ProjectName" (printf "%s/runc-%s.%s" $.ModuleName $parted_version._0 $parted_version._1) -}}
   {{- include "image-build.build" $buildContext | indent 6 }}
@@ -198,6 +199,7 @@ shell:
   - |
   {{- $buildContext := deepCopy $ -}}
   {{- $parted_version := split "." $containerd_version -}}
+  {{- $_ := set $buildContext "SvaceBuildOptions" "--enable-ptrace-all" -}}
   {{- $_ := set $buildContext "BuildCommand" (printf "make STATIC=1 VERSION=\"$(cat VERSION)\" REVISION=\"$(cat REVISION)\" %s all" $additionalBuildOptions) -}}
   {{- $_ := set $buildContext "ProjectName" (printf "%s/containerd-%s.%s" $.ModuleName $parted_version._0 $parted_version._1) -}}
   {{- include "image-build.build" $buildContext | indent 6 }}


### PR DESCRIPTION
## Description
Pass `--enable-ptrace-all` to Svace when building the `containerd` and `runc` artifacts.

Svace traces compiler invocations via ptrace. For Go the compiler runs as a child
process of `go build`, and here also under `make`, so every Go build wrapped by Svace
must pass `--enable-ptrace-all` to trace child processes too. The `containerd` and `runc`
builds in `modules/007-registrypackages/images/containerd/werf.inc.yaml` did not set
`SvaceBuildOptions`, so Svace detected no compilation and aborted with
`No compilation activity has been detected`, exit code 255. Every other Go image under
Svace already passes this flag, including `pidumount` in the same file. Only `containerd`
and `runc` were missing it.

The fix sets `SvaceBuildOptions "--enable-ptrace-all"` for both the `containerd` and
`runc` build contexts, matching `pidumount` and the other Go images.

No runtime or cluster impact. Build stage only.

## Why do we need it, and what problem does it solve?
Without the fix the Svace pipeline fails at the "Build and push deckhouse images" step
with `No compilation activity has been detected`, exit code 255, on
`registrypackages/containerd-artifact-2-2-4`. The downstream `Deckhouse static analysis`
job is then skipped. See [build fail](https://github.com/deckhouse/deckhouse/actions/runs/28885637364/job/85685023687#step:13).

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: ci
type: chore
summary: Fix containerd and runc Svace builds by enabling ptrace tracing.
impact_level: low
```
