### PR TITLE
[admission-policy-engine] Fix ratify Svace build on Go 1.26

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -447,6 +447,7 @@ BASE_LIMIT_KEYS := REGISTRY_PATH \
                 builder/golang-1.25 \
                 builder/golang-1.26 \
                 builder/golang \
+                builder/golang-alt-1.26 \
                 minget-0.1 \
                 minget
 

--- a/candi/alt_base_images.yml
+++ b/candi/alt_base_images.yml
@@ -5,5 +5,6 @@ builder/distroless: "sha256:478ce6063a756ae997cbf4673b3c1b1dce6465bb1e17d7e537d6
 builder/golang-1.25: "sha256:3ca5063cbeb160619d0679b2465d1e0c4c1bc22e939687e01e1bf2ebca5b8306" # from: builder/distroless
 builder/golang-1.26: "sha256:98aced736e6cc63e0185affd88f7a4f3225f1e6f494e8bb509061e590d2849e0" # from: builder/distroless
 builder/golang: "sha256:98aced736e6cc63e0185affd88f7a4f3225f1e6f494e8bb509061e590d2849e0" # from: builder/distroless
+builder/golang-alt-1.26: "sha256:b8e362757fca1b402e6919778f06303bc8e35f5e0e3754c0bfe6eae12a6a8c52" # from: registry.altlinux.org/p11/alt:20260119
 minget-0.1: "sha256:463d8b34130357f8637eeda9ade6bb7561fa53f28bc7b5d11f29f629c60fb254" # from: builder/scratch
 minget: "sha256:463d8b34130357f8637eeda9ade6bb7561fa53f28bc7b5d11f29f629c60fb254" # from: builder/scratch

--- a/ee/se-plus/modules/015-admission-policy-engine/images/ratify/werf.inc.yaml
+++ b/ee/se-plus/modules/015-admission-policy-engine/images/ratify/werf.inc.yaml
@@ -43,7 +43,7 @@ shell:
     diff -qr "/src/config/crd/bases" "/module_crds/ratify"   
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
-from: {{ index $.Images ( eq $.SVACE_ENABLED "false" | ternary "builder/golang-1.26" "builder/golang-alt-svace" ) }}
+from: {{ index $.Images ( eq $.SVACE_ENABLED "false" | ternary "builder/golang-1.26" "builder/golang-alt-1.26" ) }}
 final: false
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact


### PR DESCRIPTION
## Description
Build the ratify Svace artifact on Go 1.26.

ratify requires Go >= 1.26. The regular build already uses `builder/golang-1.26`, but the
Svace branch used `builder/golang-alt-svace`, which is pinned to Go 1.25.10. With
`GOTOOLCHAIN=local` Go cannot fetch a newer toolchain on the fly, so `go build` fails
immediately with `go.mod requires go >= 1.26.0`.

The fix points the Svace branch to `builder/golang-alt-1.26`, a Go 1.26 builder that
already bundles Svace. This image comes from the container-factory base-images project,
which deckhouse already consumes through `candi/alt_base_images.yml`. Its key is added to
`BASE_LIMIT_KEYS` so `update-container-factory` keeps it, and `alt_base_images.yml` is
regenerated at the current version v1.1.14. Only one line is added, all other digests
stay the same.

No runtime or cluster impact. Build stage only.

## Why do we need it, and what problem does it solve?
Without the fix the Svace pipeline fails at the "Build and push deckhouse images" step
with `go.mod requires go >= 1.26.0` while building `admission-policy-engine/ratify-artifact`,
and the downstream `Deckhouse static analysis` job is skipped. See [build fail](https://github.com/deckhouse/deckhouse-test-2/actions/runs/28933995365/job/85839751418#step:13)
([tested](https://github.com/deckhouse/deckhouse-test-2/actions/runs/28939513168/job/85858009654) in deckhouse-test-2 repo).

## Why do we need it in the patch release (if we do)?
Not necessarily.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: ci
type: chore
summary: Build the ratify Svace artifact on Go 1.26.
impact_level: low
```
