### PR TITLE
[cloud-provider-vcd] Add legacy mode support for VCD cloud provider CCM

### DIFF
--- a/ee/modules/030-cloud-provider-vcd/template_tests/module_test.go
+++ b/ee/modules/030-cloud-provider-vcd/template_tests/module_test.go
@@ -191,6 +191,84 @@ const moduleValuesC = `
             storageProfile: nvme
 `
 
+const moduleValuesLegacyNoLB = `
+    internal:
+      legacyMode: true
+      capcdControllerManagerWebhookCert:
+        ca: ca
+        crt: crt
+        key: key
+      providerDiscoveryData:
+        kind: VCDCloudProviderDiscoveryData
+        apiVersion: deckhouse.io/v1
+        vcdInstallationVersion: "10.4.2"
+        vcdAPIVersion: "37.1"
+        zones:
+        - default
+      providerClusterConfiguration:
+        apiVersion: deckhouse.io/v1
+        kind: VCDClusterConfiguration
+        provider:
+          username: myuname
+          password: myPaSsWd
+          insecure: true
+          server: "http://server/api/"
+        layout: Standard
+        sshPublicKey: rsa-aaaa
+        organization: org
+        virtualDataCenter: dc
+        virtualApplicationName: v1rtual-app
+        mainNetwork: internal
+        masterNodeGroup:
+          replicas: 1
+          instanceClass:
+            template: Templates/ubuntu-focal-20.04
+            sizingPolicy: 4cpu8ram
+            rootDiskSizeGb: 20
+            etcdDiskSizeGb: 20
+            storageProfile: nvme
+`
+
+const moduleValuesLegacyWithLB = `
+    internal:
+      legacyMode: true
+      capcdControllerManagerWebhookCert:
+        ca: ca
+        crt: crt
+        key: key
+      providerDiscoveryData:
+        kind: VCDCloudProviderDiscoveryData
+        apiVersion: deckhouse.io/v1
+        vcdInstallationVersion: "10.4.2"
+        vcdAPIVersion: "37.1"
+        loadBalancer:
+          enabled: true
+        zones:
+        - default
+      providerClusterConfiguration:
+        apiVersion: deckhouse.io/v1
+        kind: VCDClusterConfiguration
+        provider:
+          username: myuname
+          password: myPaSsWd
+          insecure: true
+          server: "http://server/api/"
+        layout: Standard
+        sshPublicKey: rsa-aaaa
+        organization: org
+        virtualDataCenter: dc
+        virtualApplicationName: v1rtual-app
+        mainNetwork: internal
+        masterNodeGroup:
+          replicas: 1
+          instanceClass:
+            template: Templates/ubuntu-focal-20.04
+            sizingPolicy: 4cpu8ram
+            rootDiskSizeGb: 20
+            etcdDiskSizeGb: 20
+            storageProfile: nvme
+`
+
 const tolerationsAnyNodeWithUninitialized = `
 - key: node-role.kubernetes.io/master
 - key: node-role.kubernetes.io/control-plane
@@ -695,6 +773,60 @@ node-role.deckhouse.io/control-plane: ""`))
 - --allow-untagged-cloud=true
 - --configure-cloud-routes=false
 - --controllers=cloud-node-controller,cloud-node-lifecycle-controller,service-lb-controller
+- --v=4
+`))
+		})
+	})
+
+	Context("VCD Suite Legacy :: legacyMode without load balancer", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", globalValues)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYaml("cloudProviderVcd", moduleValuesLegacyNoLB)
+			f.HelmRender()
+		})
+
+		It("must use legacy CCM controller names", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			ccmDeployment := f.KubernetesResource("Deployment", "d8-cloud-provider-vcd", "cloud-controller-manager")
+			Expect(ccmDeployment.Exists()).To(BeTrue())
+			Expect(ccmDeployment.Field("spec.template.spec.containers.0.args").String()).To(MatchYAML(`
+- --leader-elect=true
+- --bind-address=127.0.0.1
+- --secure-port=10471
+- --cloud-config=/etc/cloud/cloud-config
+- --cloud-provider=vmware-cloud-director
+- --allow-untagged-cloud=true
+- --configure-cloud-routes=false
+- --controllers=cloud-node,cloud-node-lifecycle
+- --v=4
+`))
+		})
+	})
+
+	Context("VCD Suite Legacy :: legacyMode with load balancer", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", globalValues)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYaml("cloudProviderVcd", moduleValuesLegacyWithLB)
+			f.HelmRender()
+		})
+
+		It("must use legacy CCM controller names including service controller", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			ccmDeployment := f.KubernetesResource("Deployment", "d8-cloud-provider-vcd", "cloud-controller-manager")
+			Expect(ccmDeployment.Exists()).To(BeTrue())
+			Expect(ccmDeployment.Field("spec.template.spec.containers.0.args").String()).To(MatchYAML(`
+- --leader-elect=true
+- --bind-address=127.0.0.1
+- --secure-port=10471
+- --cloud-config=/etc/cloud/cloud-config
+- --cloud-provider=vmware-cloud-director
+- --allow-untagged-cloud=true
+- --configure-cloud-routes=false
+- --controllers=cloud-node,cloud-node-lifecycle,service
 - --v=4
 `))
 		})

--- a/ee/modules/030-cloud-provider-vcd/templates/cloud-controller-manager/deployment.yaml
+++ b/ee/modules/030-cloud-provider-vcd/templates/cloud-controller-manager/deployment.yaml
@@ -40,11 +40,20 @@ checksum/config: {{ printf "%s%s" (include (print $.Template.BasePath "/registra
   {{- $ccmImageName = "cloudControllerManager" -}}
 {{- end -}}
 
-{{- $ccmEnabledControllers := "cloud-node-controller,cloud-node-lifecycle-controller" -}}
+{{- $ccmNodeController := "cloud-node-controller" -}}
+{{- $ccmNodeLifecycleController := "cloud-node-lifecycle-controller" -}}
+{{- $ccmServiceLBController := "service-lb-controller" -}}
+{{- if eq .Values.cloudProviderVcd.internal.legacyMode true -}}
+  {{- $ccmNodeController = "cloud-node" -}}
+  {{- $ccmNodeLifecycleController = "cloud-node-lifecycle" -}}
+  {{- $ccmServiceLBController = "service" -}}
+{{- end -}}
+
+{{- $ccmEnabledControllers := printf "%s,%s" $ccmNodeController $ccmNodeLifecycleController -}}
 {{- if hasKey .Values.cloudProviderVcd.internal.providerDiscoveryData "loadBalancer" -}}
   {{- if hasKey .Values.cloudProviderVcd.internal.providerDiscoveryData.loadBalancer "enabled" -}}
     {{- if .Values.cloudProviderVcd.internal.providerDiscoveryData.loadBalancer.enabled -}}
-      {{- $ccmEnabledControllers = printf "%s,service-lb-controller" $ccmEnabledControllers -}}
+      {{- $ccmEnabledControllers = printf "%s,%s" $ccmEnabledControllers $ccmServiceLBController -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}


### PR DESCRIPTION
 ## Description

Fixes the CCM controller list rendering for `cloud-provider-vcd`. The `--controllers` flag was built with a broken `printf` format string (`"%s,$s"` instead of `"%s,%s"`), producing an invalid value like `--controllers=cloud-node,$s%!(EXTRA string=cloud-node-lifecycle)`.

  Also restores support for legacy CCM controller names for VCD Legacy mode:
  - legacy (`legacyMode: true`): `cloud-node`, `cloud-node-lifecycle`, and `service` (when the load balancer is enabled);
  - current: `cloud-node-controller`, `cloud-node-lifecycle-controller`, and `service-lb-controller`.

  ## Why do we need it, and what problem does it solve?

  On clusters installed from the `main` branch, the VCD CCM was in `CrashLoop` because the `--controllers` argument was malformed and old CCM controller names were no longer supported for VCD Legacy. This change fixes the malformed argument and returns the legacy controller names, so CCM works for
  both legacy and current VCD API versions.

  ## Why do we need it in the patch release (if we do)?

Not necessarily

  ## Checklist
  - [x] The code is covered by unit tests.
  - [ ] e2e tests passed.
  - [ ] Documentation updated according to the changes.
  - [ ] Changes were tested in the Kubernetes cluster manually.

  ## Changelog entries
                                                                                                                                                                                                                                                                                         
  ```changes
section: cloud-provider-vcd
type: fix
summary: Fixed a malformed CCM --controllers argument and restored legacy controller names for VCD Legacy.
impact_level: default
```
