### PR TITLE
[deckhouse-controller] Show warnings while kubectl edit

### DIFF
--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/response_remapper.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/response_remapper.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -40,11 +41,13 @@ func withInvalidReason(next http.Handler) http.Handler {
 		var review admissionv1.AdmissionReview
 		if err := json.Unmarshal(body, &review); err == nil && review.Response != nil && !review.Response.Allowed {
 			msg := ""
-			causes := []metav1.StatusCause{}
+			var details *metav1.StatusDetails
 
 			if review.Response.Result != nil {
-				msg += review.Response.Result.Message
-				causes = []metav1.StatusCause{{Message: review.Response.Result.Message}}
+				msg = review.Response.Result.Message
+				if causes := messageToCauses(msg); len(causes) > 0 {
+					details = &metav1.StatusDetails{Causes: causes}
+				}
 			}
 
 			review.Response.Result = &metav1.Status{
@@ -52,9 +55,7 @@ func withInvalidReason(next http.Handler) http.Handler {
 				Reason:  metav1.StatusReasonInvalid,
 				Code:    http.StatusUnprocessableEntity,
 				Message: msg,
-				Details: &metav1.StatusDetails{
-					Causes: causes,
-				},
+				Details: details,
 			}
 			if patched, err := json.Marshal(review); err == nil {
 				body = patched
@@ -67,4 +68,24 @@ func withInvalidReason(next http.Handler) http.Handler {
 		w.WriteHeader(rec.Code)
 		_, _ = w.Write(body)
 	})
+}
+
+// messageToCauses splits a composite validation message into one cause per
+// line so that `kubectl edit` renders each reason on its own bullet instead of
+// a single blob. Validators often join several reasons with "\n- " (see
+// validate_deckhouse_release.go), so we strip leading bullet markers and drop
+// blank lines. A single-line message yields a single cause; an empty or
+// blank-only message yields no causes.
+func messageToCauses(msg string) []metav1.StatusCause {
+	var causes []metav1.StatusCause
+	for _, line := range strings.Split(msg, "\n") {
+		line = strings.TrimSpace(line)
+		line = strings.TrimPrefix(line, "- ")
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		causes = append(causes, metav1.StatusCause{Message: line})
+	}
+	return causes
 }

--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/response_remapper.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/response_remapper.go
@@ -40,11 +40,6 @@ func withInvalidReason(next http.Handler) http.Handler {
 		var review admissionv1.AdmissionReview
 		if err := json.Unmarshal(body, &review); err == nil && review.Response != nil && !review.Response.Allowed {
 			msg := ""
-			if len(review.Response.Warnings) > 0 {
-				for _, warning := range review.Response.Warnings {
-					msg += warning + "\n"
-				}
-			}
 			if review.Response.Result != nil {
 				msg += review.Response.Result.Message
 			}
@@ -53,6 +48,9 @@ func withInvalidReason(next http.Handler) http.Handler {
 				Reason:  metav1.StatusReasonInvalid,
 				Code:    http.StatusUnprocessableEntity,
 				Message: msg,
+				Details: &metav1.StatusDetails{
+					Causes: review.Response.Result.Details.Causes,
+				},
 			}
 			if patched, err := json.Marshal(review); err == nil {
 				body = patched

--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/response_remapper.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/response_remapper.go
@@ -40,16 +40,26 @@ func withInvalidReason(next http.Handler) http.Handler {
 		var review admissionv1.AdmissionReview
 		if err := json.Unmarshal(body, &review); err == nil && review.Response != nil && !review.Response.Allowed {
 			msg := ""
+			causes := []metav1.StatusCause{}
+
 			if review.Response.Result != nil {
 				msg += review.Response.Result.Message
+				causes = append(causes, metav1.StatusCause{Message: review.Response.Result.Message})
 			}
+
+			if len(review.Response.Warnings) > 0 {
+				for _, warning := range review.Response.Warnings {
+					causes = append(causes, metav1.StatusCause{Message: warning})
+				}
+			}
+
 			review.Response.Result = &metav1.Status{
 				Status:  metav1.StatusFailure,
 				Reason:  metav1.StatusReasonInvalid,
 				Code:    http.StatusUnprocessableEntity,
 				Message: msg,
 				Details: &metav1.StatusDetails{
-					Causes: review.Response.Result.Details.Causes,
+					Causes: causes,
 				},
 			}
 			if patched, err := json.Marshal(review); err == nil {

--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/response_remapper.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/response_remapper.go
@@ -44,13 +44,7 @@ func withInvalidReason(next http.Handler) http.Handler {
 
 			if review.Response.Result != nil {
 				msg += review.Response.Result.Message
-				causes = append(causes, metav1.StatusCause{Message: review.Response.Result.Message})
-			}
-
-			if len(review.Response.Warnings) > 0 {
-				for _, warning := range review.Response.Warnings {
-					causes = append(causes, metav1.StatusCause{Message: warning})
-				}
+				causes = []metav1.StatusCause{{Message: review.Response.Result.Message}}
 			}
 
 			review.Response.Result = &metav1.Status{

--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/response_remapper.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/response_remapper.go
@@ -40,8 +40,13 @@ func withInvalidReason(next http.Handler) http.Handler {
 		var review admissionv1.AdmissionReview
 		if err := json.Unmarshal(body, &review); err == nil && review.Response != nil && !review.Response.Allowed {
 			msg := ""
+			if len(review.Response.Warnings) > 0 {
+				for _, warning := range review.Response.Warnings {
+					msg += warning + "\n"
+				}
+			}
 			if review.Response.Result != nil {
-				msg = review.Response.Result.Message
+				msg += review.Response.Result.Message
 			}
 			review.Response.Result = &metav1.Status{
 				Status:  metav1.StatusFailure,

--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/response_remapper_test.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/response_remapper_test.go
@@ -42,6 +42,18 @@ func TestWithInvalidReason(t *testing.T) {
 		},
 	})
 
+	multiReasonBody := mustMarshalReview(t, admissionv1.AdmissionReview{
+		TypeMeta: metav1.TypeMeta{APIVersion: "admission.k8s.io/v1", Kind: "AdmissionReview"},
+		Response: &admissionv1.AdmissionResponse{
+			UID:     "uid-multi",
+			Allowed: false,
+			Result: &metav1.Status{
+				Message: "\n cannot approve DeckhouseRelease \"v1.0.0\": requirements not met: \n- reason one\n- reason two",
+				Code:    http.StatusBadRequest,
+			},
+		},
+	})
+
 	allowedBody := mustMarshalReview(t, admissionv1.AdmissionReview{
 		TypeMeta: metav1.TypeMeta{APIVersion: "admission.k8s.io/v1", Kind: "AdmissionReview"},
 		Response: &admissionv1.AdmissionResponse{
@@ -73,6 +85,31 @@ func TestWithInvalidReason(t *testing.T) {
 				assert.Equal(t, int32(http.StatusUnprocessableEntity), got.Response.Result.Code)
 				assert.Equal(t, metav1.StatusFailure, got.Response.Result.Status)
 				assert.Equal(t, "spec.version=999 is unsupported", got.Response.Result.Message)
+				require.NotNil(t, got.Response.Result.Details)
+				assert.Equal(t, []metav1.StatusCause{
+					{Message: "spec.version=999 is unsupported"},
+				}, got.Response.Result.Details.Causes)
+			},
+		},
+		{
+			name:     "composite message split into one cause per reason",
+			giveBody: multiReasonBody,
+			giveCode: http.StatusOK,
+			wantCode: http.StatusOK,
+			wantCheck: func(t *testing.T, body []byte) {
+				var got admissionv1.AdmissionReview
+				require.NoError(t, json.Unmarshal(body, &got))
+				require.NotNil(t, got.Response)
+				require.NotNil(t, got.Response.Result)
+				assert.Equal(t, metav1.StatusReasonInvalid, got.Response.Result.Reason)
+				// Full message is preserved as-is.
+				assert.Equal(t, "\n cannot approve DeckhouseRelease \"v1.0.0\": requirements not met: \n- reason one\n- reason two", got.Response.Result.Message)
+				require.NotNil(t, got.Response.Result.Details)
+				assert.Equal(t, []metav1.StatusCause{
+					{Message: "cannot approve DeckhouseRelease \"v1.0.0\": requirements not met:"},
+					{Message: "reason one"},
+					{Message: "reason two"},
+				}, got.Response.Result.Details.Causes)
 			},
 		},
 		{


### PR DESCRIPTION
## Description
Added detailed warning if there are error while kubectl edit deckhouse resources.

Before:
```yaml
# Please edit the object below. Lines beginning with a '#' will be ignored,
# and an empty file will abort the edit. If an error occurs while saving this file will be
# reopened with the relevant failures.
#
# moduleconfigs.deckhouse.io "stronghold" was not valid
#
apiVersion: deckhouse.io/v1alpha1
kind: ModuleConfig
...
```
After:
```yaml
# Please edit the object below. Lines beginning with a '#' will be ignored,
# and an empty file will abort the edit. If an error occurs while saving this file will be
# reopened with the relevant failures.
#
# moduleconfigs.deckhouse.io "stronghold" was not valid:
# * : spec.version is required when spec.settings are specified
#
apiVersion: deckhouse.io/v1alpha1
kind: ModuleConfig
...
```

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: Fixed showing warnings while errors during kubectl edit.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
