### PR TITLE
[deckhouse] add log diagnostic command to ModuleIsNotValid alert

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -3110,8 +3110,8 @@ alerts:
 
         To resolve this issue, ensure that {{ $labels.version }} image in the registry '{{ $labels.registry }}' is valid .
 
-        To get the exact error, check the deckhouse logs:
-        `kubectl -n d8-system logs deploy/deckhouse | grep "failed to download module"`
+        To get the exact error, check Deckhouse logs:
+        `d8 k -n d8-system logs deploy/deckhouse | grep "failed to download module"`
       summary: |
         Module update has failed. Module is not valid.
       severity: "4"

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -3109,6 +3109,9 @@ alerts:
          - The Module image is corrupted.
 
         To resolve this issue, ensure that {{ $labels.version }} image in the registry '{{ $labels.registry }}' is valid .
+
+        To get the exact error, check the deckhouse logs:
+        `kubectl -n d8-system logs deploy/deckhouse | grep "failed to download module"`
       summary: |
         Module update has failed. Module is not valid.
       severity: "4"

--- a/modules/002-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
+++ b/modules/002-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
@@ -551,8 +551,8 @@
 
         To resolve this issue, ensure that {{ $labels.version }} image in the registry '{{ $labels.registry }}' is valid .
 
-        To get the exact error, check the deckhouse logs:
-        `kubectl -n d8-system logs deploy/deckhouse | grep "failed to download module"`
+        To get the exact error, check Deckhouse logs:
+        `d8 k -n d8-system logs deploy/deckhouse | grep "failed to download module"`
 
   - alert: D8DeckhouseWatchErrorOccurred
     expr: increase(deckhouse_kubernetes_client_watch_errors_total[__SCRAPE_INTERVAL_X_2__]) > 0

--- a/modules/002-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
+++ b/modules/002-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
@@ -551,6 +551,9 @@
 
         To resolve this issue, ensure that {{ $labels.version }} image in the registry '{{ $labels.registry }}' is valid .
 
+        To get the exact error, check the deckhouse logs:
+        `kubectl -n d8-system logs deploy/deckhouse | grep "failed to download module"`
+
   - alert: D8DeckhouseWatchErrorOccurred
     expr: increase(deckhouse_kubernetes_client_watch_errors_total[__SCRAPE_INTERVAL_X_2__]) > 0
     for: 1m


### PR DESCRIPTION
## Description
Added a diagnostic command to the `DeckhouseModuleUpdatingFailedModuleIsNotValid` alert description so operators can get the exact error from deckhouse logs without SSH-ing into master nodes.

```yaml
To get the exact error, check Deckhouse logs:
`d8 -n d8-system logs deploy/deckhouse | grep "failed to download module"`
```

## Why do we need it, and what problem does it solve?
When this alert fires, the description only says "The Module image is corrupted", but the real cause is often different — wrong release channel, missing tag in registry, registry unreachable, etc. The actual error (e.g. `MANIFEST_UNKNOWN: manifest unknown; map[Tag:beta]`) is only visible in the deckhouse controller logs. This change gives operators a direct, copy-pasteable command to diagnose the root cause.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: deckhouse
type: fix
summary: Add log diagnostic command to ModuleIsNotValid alert description.
impact_level: low
```