### PR TITLE
[cloud-provider-dvp] treat missing VMBDA as success on disk detach

### DIFF
--- a/modules/030-cloud-provider-dvp/images/dvp-common/api/compute.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-common/api/compute.go
@@ -348,7 +348,7 @@ func (c *ComputeService) DetachDiskFromVM(ctx context.Context, diskName string, 
 	vmbda, err := c.getVMBDA(ctx, diskName, vmName)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
-			return nil // already attached
+			return nil // already detached
 		}
 		return err
 	}

--- a/modules/030-cloud-provider-dvp/images/dvp-common/api/compute.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-common/api/compute.go
@@ -347,6 +347,9 @@ func (c *ComputeService) AttachDiskToVM(ctx context.Context, diskName string, vm
 func (c *ComputeService) DetachDiskFromVM(ctx context.Context, diskName string, vmName string) error {
 	vmbda, err := c.getVMBDA(ctx, diskName, vmName)
 	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return nil // already attached
+		}
 		return err
 	}
 


### PR DESCRIPTION
## Description
In DetachDiskFromVM (dvp-common/api/compute.go), a missing VirtualMachineBlockDeviceAttachment (VMBDA) when detaching a disk from a VM is now treated as a successful operation rather than an error.

This makes detach idempotent: a repeated call, or a case where the VMBDA has already been removed (a previous reconcile, garbage collection via OwnerReference, or manual cleanup), no longer blocks further progress.

## Why do we need it, and what problem does it solve?
When detaching a disk, getVMBDA returns ErrNotFound if no VMBDA with the expected labels exists in the parent DVP cluster. Before this fix, DetachDiskFromVM propagated that error, which could cause:

DeckhouseMachine deletion to get stuck at DetachDisksFromVM if the attachment had already been removed;
cleanup after a failed attach in CSI (ControllerPublishVolume) to log a false error;
unpublish to fail due to a race between checking attachment state and calling delete, even though the disk was already detached.
This mirrors existing attach behavior (AttachDiskToVM does not fail if the VMBDA already exists or is created again).

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-dvp
type: fix
summary: Treated a missing VMBDA as success on disk detach.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
