### PR TITLE
Fix vSphere CA bundle: CNS unknown-authority and CSI mount path

### DIFF
--- a/ee/se-plus/modules/030-cloud-provider-vsphere/candi/openapi/cluster_configuration.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/candi/openapi/cluster_configuration.yaml
@@ -428,10 +428,25 @@ apiVersions:
             type: boolean
             description:  Set to `true` if vCenter has a self-signed certificate.
             x-doc-default: false
+          caBundle:
+            type: string
+            description: |
+              PEM-encoded CA certificate chain to verify the vCenter TLS certificate.
+              Use instead of `insecure` when vCenter uses a custom/enterprise CA.
         required:
         - server
         - username
         - password
+        not:
+          allOf:
+          - required: [caBundle]
+          - properties:
+              caBundle:
+                minLength: 1
+          - required: [insecure]
+          - properties:
+              insecure:
+                enum: [true]
       nsxt:
         type: object
         description: |
@@ -499,6 +514,11 @@ apiVersions:
             x-examples:
               - true
               - false
+          caBundle:
+            type: string
+            description: |
+              PEM-encoded CA certificate chain to verify the NSX-T TLS certificate.
+              Use instead of `insecure` when NSX-T uses a custom/enterprise CA.
           loadBalancerClass:
             type: array
             description: |
@@ -528,6 +548,16 @@ apiVersions:
             - []
             - {"name": "LBC1", "ipPoolName": "pool2"}
             - {"name": "LBC1", "ipPoolName": "pool2", "tcpAppProfileName": "profile2" , "udpAppProfileName": "profile3"}
+        not:
+          allOf:
+          - required: [caBundle]
+          - properties:
+              caBundle:
+                minLength: 1
+          - required: [insecureFlag]
+          - properties:
+              insecureFlag:
+                enum: [true]
     oneOf:
     - required: [layout]
       properties:

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/candi/openapi/doc-ru-cluster_configuration.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/candi/openapi/doc-ru-cluster_configuration.yaml
@@ -223,6 +223,11 @@ apiVersions:
               description: Пароль.
             insecure:
               description:  Установите `true`, если vCenter использует самоподписанный сертификат.
+            caBundle:
+              type: string
+              description: |
+                Цепочка сертификатов центра сертификации в формате PEM для проверки TLS-сертификата vCenter.
+                Используйте вместо `insecure`, если vCenter использует собственный/корпоративный центр сертификации.
         nsxt:
           description: |
             Поддержка cloud controller manager'ом балансировщиков (LoadBalancer) в Vsphere через NSX-T.
@@ -254,6 +259,11 @@ apiVersions:
             insecureFlag:
               description: |
                 Должен быть установлен в `true`, если NSX-T использует самоподписанный сертификат.
+            caBundle:
+              type: string
+              description: |
+                Цепочка сертификатов центра сертификации в формате PEM для проверки TLS-сертификата NSX-T.
+                Используйте вместо `insecureFlag`, если NSX-T использует собственный/корпоративный центр сертификации.
             loadBalancerClass:
               description: |
                 Дополнительная секция, определяющая классы балансировщика (LoadBalancer Class) (чтобы использовать класс, установите аннотацию `loadbalancer.vmware.io/class: <ИМЯ КЛАССА>` на SVC).

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/cloud-instance-manager/config-for-machine-controller-manager.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/cloud-instance-manager/config-for-machine-controller-manager.yaml
@@ -1,7 +1,13 @@
 host: {{ .Values.nodeManager.internal.cloudProvider.vsphere.server | b64enc | quote }}
 username: {{ .Values.nodeManager.internal.cloudProvider.vsphere.username | b64enc | quote }}
 password: {{ .Values.nodeManager.internal.cloudProvider.vsphere.password | b64enc | quote }}
+{{- if .Values.nodeManager.internal.cloudProvider.vsphere.caBundle }}
+insecure: {{ print "false" | b64enc | quote }}
+caBundle: {{ .Values.nodeManager.internal.cloudProvider.vsphere.caBundle | b64enc | quote }}
+{{- else }}
 insecure: {{ .Values.nodeManager.internal.cloudProvider.vsphere.insecure | default "false" | toString | b64enc | quote }}
+caBundle: {{ print "" | b64enc | quote }}
+{{- end }}
 regionTagCategory: {{ .Values.nodeManager.internal.cloudProvider.vsphere.regionTagCategory | default "k8s-region" | b64enc | quote }}
 zoneTagCategory: {{ .Values.nodeManager.internal.cloudProvider.vsphere.zoneTagCategory | default "k8s-zone" | b64enc | quote }}
 clusterNameTagCategory: {{ print "deckhouse-cluster-name" | b64enc | quote }}

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/hooks/internal/v1/module_configuration.go
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/hooks/internal/v1/module_configuration.go
@@ -14,6 +14,8 @@ type VsphereModuleConfiguration struct {
 	Password *string `json:"password,omitempty" yaml:"password,omitempty"`
 	// can be set to `true` if vCenter has a self-signed certificate
 	Insecure *bool `json:"insecure,omitempty" yaml:"insecure,omitempty"`
+	// the CA bundle in PEM format for verifying the vSphere TLS certificate
+	CaBundle *string `json:"caBundle,omitempty" yaml:"caBundle,omitempty"`
 	// the path to the VirtualMachine Folder where the cloned VMs will be created
 	VMFolderPath *string `json:"vmFolderPath,omitempty" yaml:"vmFolderPath,omitempty"`
 	// the name of the tag **category** used to identify the region (vSphere Datacenter)

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/hooks/internal/v1/nsxt.go
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/hooks/internal/v1/nsxt.go
@@ -23,6 +23,8 @@ type VsphereNsxt struct {
 	// NSX-T host
 	Host         *string `json:"host,omitempty" yaml:"host,omitempty"`
 	InsecureFlag *bool   `json:"insecureFlag,omitempty" yaml:"insecureFlag,omitempty"`
+	// the CA bundle in PEM format for verifying the NSX-T TLS certificate
+	CaBundle *string `json:"caBundle,omitempty" yaml:"caBundle,omitempty"`
 	// Additional LB classes
 	LoadBalancerClass *[]VsphereNsxtLoadBalancerClass `json:"loadBalancerClass,omitempty" yaml:"loadBalancerClass,omitempty"`
 }

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/hooks/internal/v1/provider_cluster_configuration.go
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/hooks/internal/v1/provider_cluster_configuration.go
@@ -36,6 +36,7 @@ type VsphereProvider struct {
 	Username *string `json:"username,omitempty" yaml:"username,omitempty"`
 	Password *string `json:"password,omitempty" yaml:"password,omitempty"`
 	Insecure *bool   `json:"insecure,omitempty" yaml:"insecure,omitempty"`
+	CaBundle *string `json:"caBundle,omitempty" yaml:"caBundle,omitempty"`
 }
 
 type VsphereMasterNodeGroup struct {

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/hooks/vsphere_cluster_configuration.go
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/hooks/vsphere_cluster_configuration.go
@@ -109,6 +109,13 @@ func overrideValues(p *v1.VsphereProviderClusterConfiguration, m *v1.VsphereModu
 		p.Provider.Insecure = m.Insecure
 	}
 
+	if m.CaBundle != nil {
+		if p.Provider == nil {
+			p.Provider = &v1.VsphereProvider{}
+		}
+		p.Provider.CaBundle = m.CaBundle
+	}
+
 	if m.RegionTagCategory != nil {
 		p.RegionTagCategory = m.RegionTagCategory
 	}

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/hooks/vsphere_cluster_configuration_test.go
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/hooks/vsphere_cluster_configuration_test.go
@@ -70,6 +70,28 @@ cloudProviderVsphere:
     password: pass
     host: host
 `
+		filledValuesWithCABundle = `
+global:
+  discovery: {}
+cloudProviderVsphere:
+  internal: {}
+  host: override
+  username: override
+  password: override
+  caBundle: |
+    -----BEGIN CERTIFICATE-----
+    override-ca
+    -----END CERTIFICATE-----
+  regionTagCategory: override
+  zoneTagCategory: override
+  internalNetworkNames: [override1, override2]
+  externalNetworkNames: [override1, override2]
+  disableTimesync: false
+  vmFolderPath: override
+  sshKeys: [override1, override2]
+  region: override
+  zones: [override1, override2]
+`
 	)
 
 	var (
@@ -134,6 +156,32 @@ internalNetworkNames:
 - override2
 provider:
   insecure: true
+  password: override
+  server: override
+  username: override
+region: override
+regionTagCategory: override
+sshPublicKey: override1
+vmFolderPath: override
+vmFolderExists: false
+zoneTagCategory: override
+zones:
+- override1
+- override2
+`
+		stateAClusterConfigurationCABundle = `
+disableTimesync: false
+externalNetworkNames:
+- override1
+- override2
+internalNetworkNames:
+- override1
+- override2
+provider:
+  caBundle: |
+    -----BEGIN CERTIFICATE-----
+    override-ca
+    -----END CERTIFICATE-----
   password: override
   server: override
   username: override
@@ -217,6 +265,150 @@ zoneTagCategory: k8s-zone
 zones:
 - test
 `
+		stateAClusterConfigurationSecretCABundle = `
+apiVersion: deckhouse.io/v1
+kind: VsphereClusterConfiguration
+disableTimesync: true
+layout: Standard
+provider:
+  server: test
+  username: test
+  password: test
+  caBundle: |
+    -----BEGIN CERTIFICATE-----
+    secret-ca
+    -----END CERTIFICATE-----
+vmFolderPath: test
+vmFolderExists: false
+regionTagCategory: test
+zoneTagCategory: test
+region: test
+internalNetworkCIDR: 192.168.199.0/24
+sshPublicKey: test
+internalNetworkNames: [test1, test2]
+externalNetworkNames: [test1, test2]
+zones: [test1, test2]
+masterNodeGroup:
+  replicas: 1
+  zones:
+  - test
+  instanceClass:
+    numCPUs: 4
+    memory: 8192
+    template: dev/golden_image
+    datastore: dev/lun_1
+    mainNetwork: k8s-msk/test_187
+nodeGroups:
+- name: khm
+  replicas: 1
+  zones:
+  - test
+  instanceClass:
+    numCPUs: 4
+    memory: 8192
+    template: dev/golden_image
+    datastore: dev/lun_1
+    mainNetwork: k8s-msk/test_187
+`
+		stateAClusterConfigurationProviderCABundleInsecure = `
+apiVersion: deckhouse.io/v1
+kind: VsphereClusterConfiguration
+disableTimesync: true
+layout: Standard
+provider:
+  server: test
+  username: test
+  password: test
+  insecure: true
+  caBundle: |
+    -----BEGIN CERTIFICATE-----
+    conflict-ca
+    -----END CERTIFICATE-----
+vmFolderPath: test
+vmFolderExists: false
+regionTagCategory: test
+zoneTagCategory: test
+region: test
+internalNetworkCIDR: 192.168.199.0/24
+sshPublicKey: test
+internalNetworkNames: [test1, test2]
+externalNetworkNames: [test1, test2]
+zones: [test1, test2]
+masterNodeGroup:
+  replicas: 1
+  zones:
+  - test
+  instanceClass:
+    numCPUs: 4
+    memory: 8192
+    template: dev/golden_image
+    datastore: dev/lun_1
+    mainNetwork: k8s-msk/test_187
+nodeGroups:
+- name: khm
+  replicas: 1
+  zones:
+  - test
+  instanceClass:
+    numCPUs: 4
+    memory: 8192
+    template: dev/golden_image
+    datastore: dev/lun_1
+    mainNetwork: k8s-msk/test_187
+`
+		stateAClusterConfigurationNsxtCABundleInsecure = `
+apiVersion: deckhouse.io/v1
+kind: VsphereClusterConfiguration
+disableTimesync: true
+layout: Standard
+provider:
+  server: test
+  username: test
+  password: test
+  insecure: true
+vmFolderPath: test
+vmFolderExists: false
+regionTagCategory: test
+zoneTagCategory: test
+region: test
+internalNetworkCIDR: 192.168.199.0/24
+sshPublicKey: test
+internalNetworkNames: [test1, test2]
+externalNetworkNames: [test1, test2]
+zones: [test1, test2]
+masterNodeGroup:
+  replicas: 1
+  zones:
+  - test
+  instanceClass:
+    numCPUs: 4
+    memory: 8192
+    template: dev/golden_image
+    datastore: dev/lun_1
+    mainNetwork: k8s-msk/test_187
+nodeGroups:
+- name: khm
+  replicas: 1
+  zones:
+  - test
+  instanceClass:
+    numCPUs: 4
+    memory: 8192
+    template: dev/golden_image
+    datastore: dev/lun_1
+    mainNetwork: k8s-msk/test_187
+nsxt:
+  defaultIpPoolName: pool1
+  tier1GatewayPath: /host/tier1
+  user: nsxt
+  password: pass
+  host: host
+  insecureFlag: true
+  caBundle: |
+    -----BEGIN CERTIFICATE-----
+    conflict-nsxt-ca
+    -----END CERTIFICATE-----
+`
 		nsxt = `
 nsxt:
   defaultIpPoolName: pool1
@@ -273,6 +465,39 @@ data:
   "cloud-provider-cluster-configuration.yaml": %s
   "cloud-provider-discovery-data.json": %s
 `, base64.StdEncoding.EncodeToString([]byte(stateAClusterConfiguration1+nsxt2)), base64.StdEncoding.EncodeToString([]byte(stateACloudDiscoveryData)))
+
+		notEmptyProviderClusterConfigurationStateCABundle = fmt.Sprintf(`
+apiVersion: v1
+kind: Secret
+metadata:
+  name: d8-cluster-configuration
+  namespace: kube-system
+data:
+  "cloud-provider-cluster-configuration.yaml": %s
+  "cloud-provider-discovery-data.json": %s
+`, base64.StdEncoding.EncodeToString([]byte(stateAClusterConfigurationSecretCABundle)), base64.StdEncoding.EncodeToString([]byte(stateACloudDiscoveryData)))
+
+		notEmptyProviderClusterConfigurationStateProviderCABundleInsecure = fmt.Sprintf(`
+apiVersion: v1
+kind: Secret
+metadata:
+  name: d8-cluster-configuration
+  namespace: kube-system
+data:
+  "cloud-provider-cluster-configuration.yaml": %s
+  "cloud-provider-discovery-data.json": %s
+`, base64.StdEncoding.EncodeToString([]byte(stateAClusterConfigurationProviderCABundleInsecure)), base64.StdEncoding.EncodeToString([]byte(stateACloudDiscoveryData)))
+
+		notEmptyProviderClusterConfigurationStateNsxtCABundleInsecure = fmt.Sprintf(`
+apiVersion: v1
+kind: Secret
+metadata:
+  name: d8-cluster-configuration
+  namespace: kube-system
+data:
+  "cloud-provider-cluster-configuration.yaml": %s
+  "cloud-provider-discovery-data.json": %s
+`, base64.StdEncoding.EncodeToString([]byte(stateAClusterConfigurationNsxtCABundleInsecure)), base64.StdEncoding.EncodeToString([]byte(stateACloudDiscoveryData)))
 
 		emptyProviderClusterConfigurationState = `
 apiVersion: v1
@@ -505,6 +730,59 @@ zones:
 			Expect(f.ValuesGet("cloudProviderVsphere.internal.providerDiscoveryData.resourcePoolPath").String()).To(Equal("module-pool"))
 			Expect(f.ValuesGet("cloudProviderVsphere.internal.providerDiscoveryData.datacenter").String()).To(Equal("MODULE-DC"))
 			Expect(f.ValuesGet("cloudProviderVsphere.internal.providerDiscoveryData.zones").String()).To(MatchJSON(`["module-zone"]`))
+		})
+	})
+
+	g := HookExecutionConfigInit(filledValuesWithCABundle, `{}`)
+	Context("Cluster with module configuration containing caBundle, with empty secret", func() {
+		BeforeEach(func() {
+			g.BindingContexts.Set(g.KubeStateSet(emptyProviderClusterConfigurationState))
+			g.RunHook()
+		})
+
+		It("Should propagate caBundle from module configuration to provider", func() {
+			Expect(g).To(ExecuteSuccessfully())
+			Expect(g.ValuesGet("cloudProviderVsphere.internal.providerClusterConfiguration").String()).To(MatchYAML(stateAClusterConfigurationCABundle))
+			Expect(g.ValuesGet("cloudProviderVsphere.internal.providerClusterConfiguration.provider.caBundle").String()).To(ContainSubstring("BEGIN CERTIFICATE"))
+			Expect(g.ValuesGet("cloudProviderVsphere.internal.providerDiscoveryData").String()).To(MatchJSON("{}"))
+		})
+	})
+
+	h := HookExecutionConfigInit(emptyValues, `{}`)
+	Context("Cluster without module configuration, with secret containing provider caBundle", func() {
+		BeforeEach(func() {
+			h.BindingContexts.Set(h.KubeStateSet(notEmptyProviderClusterConfigurationStateCABundle))
+			h.RunHook()
+		})
+
+		It("Should keep caBundle from the secret", func() {
+			Expect(h).To(ExecuteSuccessfully())
+			Expect(h.ValuesGet("cloudProviderVsphere.internal.providerClusterConfiguration.provider.caBundle").String()).To(ContainSubstring("secret-ca"))
+			Expect(h.ValuesGet("cloudProviderVsphere.internal.providerClusterConfiguration.provider.insecure").Exists()).To(BeFalse())
+		})
+	})
+
+	i := HookExecutionConfigInit(emptyValues, `{}`)
+	Context("Cluster with secret where provider has both caBundle and insecure: true", func() {
+		BeforeEach(func() {
+			i.BindingContexts.Set(i.KubeStateSet(notEmptyProviderClusterConfigurationStateProviderCABundleInsecure))
+			i.RunHook()
+		})
+
+		It("Should fail validation because caBundle conflicts with insecure: true", func() {
+			Expect(i).ToNot(ExecuteSuccessfully())
+		})
+	})
+
+	j := HookExecutionConfigInit(emptyValues, `{}`)
+	Context("Cluster with secret where nsxt has both caBundle and insecureFlag: true", func() {
+		BeforeEach(func() {
+			j.BindingContexts.Set(j.KubeStateSet(notEmptyProviderClusterConfigurationStateNsxtCABundleInsecure))
+			j.RunHook()
+		})
+
+		It("Should fail validation because caBundle conflicts with insecureFlag: true", func() {
+			Expect(j).ToNot(ExecuteSuccessfully())
 		})
 	})
 })

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/images/cloud-data-discoverer/src/discoverer.go
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/images/cloud-data-discoverer/src/discoverer.go
@@ -7,11 +7,9 @@ package main
 
 import (
 	"context"
-	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"net/url"
 	"os"
 	"slices"
@@ -320,11 +318,14 @@ func setSoapClientCA(soapClient *soap.Client, caBundle string) error {
 			return fmt.Errorf("failed to parse CA bundle")
 		}
 
-		soapClient.Transport = &http.Transport{
-			TLSClientConfig: &tls.Config{
-				RootCAs: pool,
-			},
-		}
+		// Set RootCAs on the client's internal transport (DefaultTransport) rather
+		// than replacing soapClient.Transport. govmomi derives service clients
+		// (e.g. cns.NewClient) via NewServiceClient, which copies TLSClientConfig
+		// from DefaultTransport(); replacing Transport leaves that internal config
+		// without our RootCAs, so CNS calls fail with "unknown authority" even
+		// though the initial /sdk login succeeds. It also preserves the custom
+		// DialTLS (thumbprint verification) and default transport timeouts.
+		soapClient.DefaultTransport().TLSClientConfig.RootCAs = pool
 	}
 	return nil
 }

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/images/cloud-data-discoverer/src/discoverer.go
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/images/cloud-data-discoverer/src/discoverer.go
@@ -7,8 +7,11 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"slices"
@@ -77,12 +80,21 @@ func NewDiscoverer(logger *log.Logger) *Discoverer {
 		logger.Fatal("Failed to parse GOVMOMI_INSECURE env as bool", "error", err)
 	}
 
+	caBundle := os.Getenv("GOVMOMI_CA_BUNDLE")
+	if insecureFlag && caBundle != "" {
+		logger.Fatal("Cannot set GOVMOMI_CA_BUNDLE env when GOVMOMI_INSECURE is true")
+	}
+
 	parsedURL, err := url.Parse(fmt.Sprintf("https://%s:%s@%s/sdk", url.PathEscape(strings.TrimSpace(username)), url.PathEscape(strings.TrimSpace(password)), url.PathEscape(strings.TrimSpace(host))))
 	if err != nil {
 		logger.Fatal("Failed to build connection url", "error", err)
 	}
 
 	soapClient := soap.NewClient(parsedURL, insecureFlag)
+	if err := setSoapClientCA(soapClient, caBundle); err != nil {
+		logger.Fatal("Failed to set SOAP client CA", "error", err)
+	}
+
 	vimClient, err := vim25.NewClient(context.TODO(), soapClient)
 	if err != nil {
 		logger.Fatal("Failed to create vimClient client", "error", err)
@@ -142,6 +154,7 @@ func NewDiscoverer(logger *log.Logger) *Discoverer {
 			Username: username,
 			Password: password,
 			Insecure: insecureFlag,
+			CABundle: caBundle,
 		},
 	}
 
@@ -298,4 +311,20 @@ func vsphereZonedDataStoresToV1(in []vsphere.ZonedDataStore) []v1.VsphereDatasto
 		})
 	}
 	return result
+}
+
+func setSoapClientCA(soapClient *soap.Client, caBundle string) error {
+	if caBundle != "" {
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM([]byte(caBundle)) {
+			return fmt.Errorf("failed to parse CA bundle")
+		}
+
+		soapClient.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs: pool,
+			},
+		}
+	}
+	return nil
 }

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/images/cloud-data-discoverer/src/discoverer_test.go
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/images/cloud-data-discoverer/src/discoverer_test.go
@@ -1,0 +1,208 @@
+/*
+Copyright 2025 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"net/url"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/vmware/govmomi/vim25/soap"
+
+	v1 "github.com/deckhouse/deckhouse/go_lib/cloud-data/apis/v1"
+	"github.com/deckhouse/deckhouse/go_lib/dependency/vsphere"
+)
+
+func generateTestCAPEM(t *testing.T) string {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+
+	template := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("failed to create certificate: %v", err)
+	}
+
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
+}
+
+func newTestSoapClient(t *testing.T) *soap.Client {
+	t.Helper()
+
+	u, err := url.Parse("https://user:pass@vcenter.example.com/sdk")
+	if err != nil {
+		t.Fatalf("failed to parse url: %v", err)
+	}
+	return soap.NewClient(u, false)
+}
+
+func TestSetSoapClientCA(t *testing.T) {
+	validCA := generateTestCAPEM(t)
+
+	t.Run("empty CA bundle leaves transport untouched", func(t *testing.T) {
+		client := newTestSoapClient(t)
+		before := client.Transport
+
+		if err := setSoapClientCA(client, ""); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if client.Transport != before {
+			t.Fatalf("transport must not be replaced when CA bundle is empty")
+		}
+	})
+
+	t.Run("valid CA bundle configures RootCAs", func(t *testing.T) {
+		client := newTestSoapClient(t)
+
+		if err := setSoapClientCA(client, validCA); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		transport, ok := client.Transport.(*http.Transport)
+		if !ok {
+			t.Fatalf("expected *http.Transport, got %T", client.Transport)
+		}
+		if transport.TLSClientConfig == nil || transport.TLSClientConfig.RootCAs == nil {
+			t.Fatalf("expected RootCAs to be set")
+		}
+	})
+
+	t.Run("invalid CA bundle returns error", func(t *testing.T) {
+		client := newTestSoapClient(t)
+
+		if err := setSoapClientCA(client, "garbage"); err == nil {
+			t.Fatalf("expected error for invalid CA bundle")
+		}
+	})
+}
+
+func TestMergeZones(t *testing.T) {
+	tests := []struct {
+		name       string
+		discovered []string
+		fresh      []string
+		want       []string
+	}{
+		{
+			name:       "merge with dedup and sort",
+			discovered: []string{"zone-b", "zone-a"},
+			fresh:      []string{"zone-a", "zone-c"},
+			want:       []string{"zone-a", "zone-b", "zone-c"},
+		},
+		{
+			name:       "empty discovered keeps only fresh",
+			discovered: nil,
+			fresh:      []string{"z2", "z1"},
+			want:       []string{"z1", "z2"},
+		},
+		{
+			name:       "empty fresh keeps only discovered",
+			discovered: []string{"z1"},
+			fresh:      nil,
+			want:       []string{"z1"},
+		},
+		{
+			name:       "both empty yields empty slice",
+			discovered: nil,
+			fresh:      nil,
+			want:       []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mergeZones(tt.discovered, tt.fresh)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("mergeZones() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMergeDatastores(t *testing.T) {
+	discovered := []v1.VsphereDatastore{
+		{Name: "ds-b", DatastoreType: "Datastore"},
+	}
+	fresh := []vsphere.ZonedDataStore{
+		{Name: "ds-a", DatastoreType: "Datastore", Zones: []string{"z1"}},
+		// Duplicate name of an already discovered datastore must be dropped.
+		{Name: "ds-b", DatastoreType: "DatastoreCluster"},
+	}
+
+	got := mergeDatastores(discovered, fresh)
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 datastores after dedup, got %d: %+v", len(got), got)
+	}
+	// Result must be sorted by name.
+	if got[0].Name != "ds-a" || got[1].Name != "ds-b" {
+		t.Fatalf("expected sorted by name [ds-a ds-b], got [%s %s]", got[0].Name, got[1].Name)
+	}
+	// The pre-existing ds-b must win over the fresh duplicate (its type stays Datastore).
+	if got[1].DatastoreType != "Datastore" {
+		t.Fatalf("expected discovered ds-b to be preserved, got type %q", got[1].DatastoreType)
+	}
+}
+
+func TestVsphereZonedDataStoresToV1(t *testing.T) {
+	in := []vsphere.ZonedDataStore{
+		{
+			Zones:         []string{"z1", "z2"},
+			InventoryPath: "/dc/ds/path",
+			Name:          "ds-1",
+			DatastoreType: "Datastore",
+			DatastoreURL:  "ds:///vmfs/volumes/hash/",
+		},
+	}
+
+	got := vsphereZonedDataStoresToV1(in)
+
+	want := []v1.VsphereDatastore{
+		{
+			Zones:         []string{"z1", "z2"},
+			InventoryPath: "/dc/ds/path",
+			Name:          "ds-1",
+			DatastoreType: "Datastore",
+			DatastoreURL:  "ds:///vmfs/volumes/hash/",
+		},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("vsphereZonedDataStoresToV1() = %+v, want %+v", got, want)
+	}
+}
+
+func TestVsphereZonedDataStoresToV1Empty(t *testing.T) {
+	got := vsphereZonedDataStoresToV1(nil)
+	if got == nil {
+		t.Fatalf("expected non-nil empty slice")
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty slice, got %d elements", len(got))
+	}
+}

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/images/terraform-manager/patches/002-add-custom-ca-bundle-support.patch
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/images/terraform-manager/patches/002-add-custom-ca-bundle-support.patch
@@ -1,0 +1,311 @@
+diff --git a/vsphere/config.go b/vsphere/config.go
+index 405322c0..99406f9d 100644
+--- a/vsphere/config.go
++++ b/vsphere/config.go
+@@ -3,6 +3,8 @@ package vsphere
+ import (
+ 	"context"
+ 	"crypto/sha256"
++	"crypto/tls"
++	"crypto/x509"
+ 	"encoding/json"
+ 	"fmt"
+ 	"io"
+@@ -63,11 +65,11 @@ type Client struct {
+ // Read call to determine if tags are supported on this connection, and if they
+ // are, read them from the object and save them in the resource:
+ //
+-//   if tm, _ := meta.(*VSphereClient).TagsManager(); tm != nil {
+-//     if err := readTagsForResource(restClient, obj, d); err != nil {
+-//       return err
+-//     }
+-//   }
++//	if tm, _ := meta.(*VSphereClient).TagsManager(); tm != nil {
++//	  if err := readTagsForResource(restClient, obj, d); err != nil {
++//	    return err
++//	  }
++//	}
+ func (c *Client) TagsManager() (*tags.Manager, error) {
+ 	if err := viapi.ValidateVirtualCenter(c.vimClient); err != nil {
+ 		return nil, err
+@@ -82,6 +84,7 @@ func (c *Client) TagsManager() (*tags.Manager, error) {
+ // VSphereClient based off the contained settings.
+ type Config struct {
+ 	InsecureFlag    bool
++	CABundle        string
+ 	Debug           bool
+ 	Persist         bool
+ 	User            string
+@@ -117,6 +120,7 @@ func NewConfig(d *schema.ResourceData) (*Config, error) {
+ 		User:            d.Get("user").(string),
+ 		Password:        d.Get("password").(string),
+ 		InsecureFlag:    d.Get("allow_unverified_ssl").(bool),
++		CABundle:        d.Get("ca_bundle").(string),
+ 		VSphereServer:   server,
+ 		Debug:           d.Get("client_debug").(bool),
+ 		DebugPathRun:    d.Get("client_debug_path_run").(string),
+@@ -231,7 +235,9 @@ func (c *Config) SavedRestSessionOrNew(s *cache.Session) (*rest.Client, error) {
+ 	s.DirREST = c.RestSessionPath
+ 	s.Passthrough = !c.Persist
+ 	restClient := new(rest.Client)
+-	err := s.Login(ctx, restClient, nil)
++	err := s.Login(ctx, restClient, func(soapClient *soap.Client) error {
++		return setSoapClientCA(soapClient, c.CABundle)
++	})
+ 	if err != nil {
+ 		return nil, err
+ 	}
+@@ -476,7 +482,7 @@ func (c *Config) SavedVimSessionOrNew(u *url.URL) (*govmomi.Client, error) {
+ 	}
+ 	if client == nil {
+ 		log.Printf("[DEBUG] Creating new SOAP API session on endpoint %s", c.VSphereServer)
+-		client, err = newClientWithKeepAlive(ctx, u, c.InsecureFlag, c.KeepAlive)
++		client, err = newClientWithKeepAlive(ctx, u, c.InsecureFlag, c.CABundle, c.KeepAlive)
+ 		if err != nil {
+ 			return nil, fmt.Errorf("error setting up new vSphere SOAP client: %s", err)
+ 		}
+@@ -485,8 +491,12 @@ func (c *Config) SavedVimSessionOrNew(u *url.URL) (*govmomi.Client, error) {
+ 	return client, nil
+ }
+ 
+-func newClientWithKeepAlive(ctx context.Context, u *url.URL, insecure bool, keepAlive int) (*govmomi.Client, error) {
++func newClientWithKeepAlive(ctx context.Context, u *url.URL, insecure bool, caBundle string, keepAlive int) (*govmomi.Client, error) {
+ 	soapClient := soap.NewClient(u, insecure)
++	if err := setSoapClientCA(soapClient, caBundle); err != nil {
++		return nil, err
++	}
++
+ 	vimClient, err := vim25.NewClient(ctx, soapClient)
+ 	if err != nil {
+ 		return nil, err
+@@ -511,6 +521,22 @@ func newClientWithKeepAlive(ctx context.Context, u *url.URL, insecure bool, keep
+ 	return c, nil
+ }
+ 
++func setSoapClientCA(soapClient *soap.Client, caBundle string) error {
++	if caBundle != "" {
++		pool := x509.NewCertPool()
++		if !pool.AppendCertsFromPEM([]byte(caBundle)) {
++			return fmt.Errorf("failed to parse CA bundle")
++		}
++
++		soapClient.Transport = &http.Transport{
++			TLSClientConfig: &tls.Config{
++				RootCAs: pool,
++			},
++		}
++	}
++	return nil
++}
++
+ func restSessionValid(client *rest.Client) bool {
+ 	sessionURL := client.URL().String() + "/com/vmware/cis/session?~action=get"
+ 	resp, err := client.Post(sessionURL, "", nil)
+diff --git a/vsphere/config_test.go b/vsphere/config_test.go
+index f3d4e477..438d99f7 100644
+--- a/vsphere/config_test.go
++++ b/vsphere/config_test.go
+@@ -1,16 +1,28 @@
+ package vsphere
+ 
+ import (
++	"crypto/ecdsa"
++	"crypto/elliptic"
++	"crypto/rand"
++	"crypto/x509"
++	"crypto/x509/pkix"
++	"encoding/pem"
+ 	"io/ioutil"
+ 	"log"
++	"math/big"
++	"net/http"
++	"net/url"
+ 	"os"
+ 	"reflect"
+ 	"strconv"
+ 	"testing"
++	"time"
+ 
+ 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+ 
+ 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
++
++	"github.com/vmware/govmomi/vim25/soap"
+ )
+ 
+ func init() {
+@@ -74,6 +86,7 @@ func testAccClientGenerateConfig() *Config {
+ 
+ 	return &Config{
+ 		InsecureFlag:  insecure,
++		CABundle:      os.Getenv("TF_VAR_VSPHERE_CA_BUNDLE"),
+ 		Debug:         debug,
+ 		User:          os.Getenv("TF_VAR_VSPHERE_USER"),
+ 		Password:      os.Getenv("TF_VAR_VSPHERE_PASSWORD"),
+@@ -191,16 +204,22 @@ func TestAccClient_noPersistence(t *testing.T) {
+ }
+ 
+ func TestNewConfig(t *testing.T) {
++	caBundle := testGenerateCACertPEM(t)
++
+ 	expected := &Config{
+-		User:           "foo",
+-		Password:       "bar",
+-		InsecureFlag:   true,
+-		VSphereServer:  "vsphere.foo.internal",
+-		Debug:          true,
+-		DebugPathRun:   "./foo",
+-		DebugPath:      "./bar",
+-		Persist:        true,
+-		VimSessionPath: "./baz",
++		User:            "foo",
++		Password:        "bar",
++		InsecureFlag:    true,
++		VSphereServer:   "vsphere.foo.internal",
++		Debug:           true,
++		DebugPathRun:    "./foo",
++		DebugPath:       "./bar",
++		Persist:         true,
++		VimSessionPath:  "./baz",
++		RestSessionPath: "./qux",
++		KeepAlive:       10,
++		APITimeout:      5 * time.Minute,
++		CABundle:        caBundle,
+ 	}
+ 
+ 	r := &schema.Resource{Schema: Provider().Schema}
+@@ -208,12 +227,16 @@ func TestNewConfig(t *testing.T) {
+ 	_ = d.Set("user", expected.User)
+ 	_ = d.Set("password", expected.Password)
+ 	_ = d.Set("allow_unverified_ssl", expected.InsecureFlag)
++	_ = d.Set("ca_bundle", expected.CABundle)
+ 	_ = d.Set("vsphere_server", expected.VSphereServer)
+ 	_ = d.Set("client_debug", expected.Debug)
+ 	_ = d.Set("client_debug_path_run", expected.DebugPathRun)
+ 	_ = d.Set("client_debug_path", expected.DebugPath)
+ 	_ = d.Set("persist_session", expected.Persist)
+ 	_ = d.Set("vim_session_path", expected.VimSessionPath)
++	_ = d.Set("rest_session_path", expected.RestSessionPath)
++	_ = d.Set("vim_keep_alive", expected.KeepAlive)
++	_ = d.Set("api_timeout", int(expected.APITimeout/time.Minute))
+ 
+ 	actual, err := NewConfig(d)
+ 	if err != nil {
+@@ -223,3 +246,99 @@ func TestNewConfig(t *testing.T) {
+ 		t.Fatalf("expected %#v, got %#v", expected, actual)
+ 	}
+ }
++
++// testGenerateCACertPEM generates a self-signed CA certificate and returns it
++// PEM-encoded. It is used to feed setSoapClientCA and NewConfig with a bundle
++// that is guaranteed to be parseable by x509.CertPool.AppendCertsFromPEM.
++func testGenerateCACertPEM(t *testing.T) string {
++	t.Helper()
++
++	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
++	if err != nil {
++		t.Fatalf("error generating private key: %s", err)
++	}
++
++	tmpl := &x509.Certificate{
++		SerialNumber:          big.NewInt(1),
++		Subject:               pkix.Name{CommonName: "test-ca"},
++		NotBefore:             time.Now().Add(-time.Hour),
++		NotAfter:              time.Now().Add(time.Hour),
++		IsCA:                  true,
++		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
++		BasicConstraintsValid: true,
++	}
++
++	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
++	if err != nil {
++		t.Fatalf("error creating certificate: %s", err)
++	}
++
++	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
++}
++
++// soapTransportRootCAs is a helper to extract the configured RootCAs pool from
++// a soap.Client's underlying HTTP transport.
++func soapTransportRootCAs(t *testing.T, c *soap.Client) *x509.CertPool {
++	t.Helper()
++
++	transport, ok := c.Client.Transport.(*http.Transport)
++	if !ok {
++		t.Fatalf("expected *http.Transport, got %T", c.Client.Transport)
++	}
++	if transport.TLSClientConfig == nil {
++		return nil
++	}
++	return transport.TLSClientConfig.RootCAs
++}
++
++func TestSetSoapClientCA_empty(t *testing.T) {
++	u, _ := url.Parse("https://vsphere.foo.internal/sdk")
++	client := soap.NewClient(u, false)
++
++	if err := setSoapClientCA(client, ""); err != nil {
++		t.Fatalf("unexpected error for empty CA bundle: %s", err)
++	}
++
++	// An empty bundle must be a no-op: the transport should keep the pool that
++	// soap.NewClient set up (nil RootCAs, i.e. the host's default CA set).
++	if pool := soapTransportRootCAs(t, client); pool != nil {
++		t.Fatalf("expected RootCAs to remain nil for empty CA bundle, got %#v", pool)
++	}
++}
++
++func TestSetSoapClientCA_valid(t *testing.T) {
++	caBundle := testGenerateCACertPEM(t)
++
++	u, _ := url.Parse("https://vsphere.foo.internal/sdk")
++	client := soap.NewClient(u, false)
++
++	if err := setSoapClientCA(client, caBundle); err != nil {
++		t.Fatalf("unexpected error for valid CA bundle: %s", err)
++	}
++
++	pool := soapTransportRootCAs(t, client)
++	if pool == nil {
++		t.Fatal("expected RootCAs pool to be set for valid CA bundle, got nil")
++	}
++
++	expected := x509.NewCertPool()
++	if !expected.AppendCertsFromPEM([]byte(caBundle)) {
++		t.Fatal("test setup error: generated CA bundle is not parseable")
++	}
++	if !pool.Equal(expected) {
++		t.Fatal("RootCAs pool does not contain the supplied CA certificate")
++	}
++}
++
++func TestSetSoapClientCA_invalid(t *testing.T) {
++	u, _ := url.Parse("https://vsphere.foo.internal/sdk")
++	client := soap.NewClient(u, false)
++
++	err := setSoapClientCA(client, "this is not a valid PEM certificate")
++	if err == nil {
++		t.Fatal("expected an error for an invalid CA bundle, got nil")
++	}
++	if err.Error() != "failed to parse CA bundle" {
++		t.Fatalf("unexpected error message: %s", err)
++	}
++}
+diff --git a/vsphere/provider.go b/vsphere/provider.go
+index cfe35974..d05402ad 100644
+--- a/vsphere/provider.go
++++ b/vsphere/provider.go
+@@ -96,6 +96,13 @@ func Provider() *schema.Provider {
+ 				DefaultFunc: schema.EnvDefaultFunc("VSPHERE_API_TIMEOUT", 5),
+ 				Description: "API timeout in minutes (Default: 5)",
+ 			},
++			"ca_bundle": {
++				Type:        schema.TypeString,
++				Optional:    true,
++				Sensitive:   true,
++				DefaultFunc: schema.EnvDefaultFunc("VSPHERE_CA_BUNDLE", ""),
++				Description: "PEM-encoded CA certificate bundle for vCenter TLS verification.",
++			},
+ 		},
+ 
+ 		ResourcesMap: map[string]*schema.Resource{

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/images/terraform-manager/patches/README.md
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/images/terraform-manager/patches/README.md
@@ -3,3 +3,7 @@
 ## 001-go-mod.patch
 
 This patch fixes CVE.
+
+## 002-add-custom-ca-bundle-support.patch
+
+Add custom CA bundle support

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/openapi/config-values.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/openapi/config-values.yaml
@@ -21,6 +21,11 @@ properties:
     type: boolean
     description: |
       Set to `true` if vCenter has a self-signed certificate.
+  caBundle:
+    type: string
+    description: |
+      The CA certificate chain in PEM format for verifying the vCenter TLS certificate.
+      Use instead of `insecure` when vCenter uses a custom/enterprise CA.
   vmFolderPath:
     type: string
     description: |
@@ -167,6 +172,11 @@ properties:
         x-examples:
         - true
         - false
+      caBundle:
+        type: string
+        description: |
+          The CA certificate chain in PEM format for verifying the NSX-T TLS certificate.
+          Use instead of `insecureFlag` when NSX-T uses a custom/enterprise CA.
       loadBalancerClass:
         type: array
         description: |

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/openapi/doc-ru-config-values.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/openapi/doc-ru-config-values.yaml
@@ -16,6 +16,10 @@ properties:
   insecure:
     description: |
       Установите `true`, если vCenter использует самоподписанный сертификат.
+  caBundle:
+    description: |
+      Цепочка сертификатов центра сертификации в формате PEM для проверки TLS-сертификата vCenter.
+      Используйте вместо `insecure`, если vCenter использует собственный/корпоративный центр сертификации.
   vmFolderPath:
     description: |
       Путь до VirtualMachine Folder, в котором будут создаваться склонированные виртуальные машины.
@@ -96,6 +100,10 @@ properties:
       insecureFlag:
         description: |
           Должен быть установлен в `true`, если NSX-T использует самоподписанный сертификат.
+      caBundle:
+        description: |
+          Цепочка сертификатов центра сертификации в формате PEM для проверки TLS-сертификата NSX-T.
+          Используйте вместо `insecureFlag`, если NSX-T использует собственный/корпоративный центр сертификации.
       loadBalancerClass:
         description: |
           Дополнительная секция, определяющая классы балансировщика (LoadBalancer Class) (чтобы использовать класс, установите аннотацию `loadbalancer.vmware.io/class: <ИМЯ КЛАССА>` на SVC).

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/openapi/values.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/openapi/values.yaml
@@ -345,6 +345,8 @@ properties:
                 type: string
               insecure:
                 type: boolean
+              caBundle:
+                type: string
           nsxt:
             type: object
             required: [ defaultIpPoolName, size, tier1GatewayPath, user, password, host, defaultTcpAppProfileName, defaultUdpAppProfileName ]
@@ -368,6 +370,8 @@ properties:
                 type: string
               insecureFlag:
                 type: boolean
+              caBundle:
+                type: string
               loadBalancerClass:
                 type: array
                 items:

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/template_tests/module_test.go
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/template_tests/module_test.go
@@ -989,6 +989,21 @@ vcenter:
 			Expect(podAnnotations).To(ContainSubstring("checksum/ca"))
 		})
 
+		It("Mounts the CA into the CSI controller as a file, not a directory", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			csiDeploy := f.KubernetesResource("Deployment", moduleNamespace, "csi-controller")
+			Expect(csiDeploy.Exists()).To(BeTrue())
+
+			// The CSI driver reads ca-file = /etc/vsphere-certs/ca.crt. With a
+			// subPath mount the mountPath must be the full file path, otherwise
+			// /etc/vsphere-certs itself becomes a file and the driver fails with
+			// "open /etc/vsphere-certs/ca.crt: not a directory".
+			mounts := csiDeploy.Field("spec.template.spec.containers").String()
+			Expect(mounts).To(ContainSubstring("/etc/vsphere-certs/ca.crt"))
+			Expect(mounts).NotTo(MatchRegexp(`"mountPath":\s*"/etc/vsphere-certs"`))
+		})
+
 		It("Passes GOVMOMI_CA_BUNDLE to the cloud-data-discoverer and disables insecure", func() {
 			Expect(f.RenderError).ShouldNot(HaveOccurred())
 

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/template_tests/module_test.go
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/template_tests/module_test.go
@@ -286,6 +286,100 @@ const moduleValuesHybrid = `
           replicas: 1
 `
 
+const caBundlePEM = `-----BEGIN CERTIFICATE-----
+dGVzdC1jYS1idW5kbGU=
+-----END CERTIFICATE-----
+`
+
+const nsxtCABundlePEM = `-----BEGIN CERTIFICATE-----
+dGVzdC1uc3h0LWNhLWJ1bmRsZQ==
+-----END CERTIFICATE-----
+`
+
+// Provider uses caBundle instead of insecure (mirrors moduleValuesA otherwise).
+const moduleValuesProviderCABundle = `
+    internal:
+      storageClasses:
+      - name: mydsname1
+        datastoreType: Datastore
+        datastoreURL: ds:///vmfs/volumes/hash1/
+        path: /my/ds/path/mydsname1
+        zones: ["zonea", "zoneb"]
+      - name: mydsname2
+        datastoreType: Datastore
+        datastoreURL: ds:///vmfs/volumes/hash2/
+        path: /my/ds/path/mydsname2
+        zones: ["zonea", "zoneb"]
+      compatibilityFlag: ""
+      providerDiscoveryData:
+        datacenter: X1
+        zones: ["aaa", "bbb"]
+      providerClusterConfiguration:
+        provider:
+          server: myhost
+          username: myuname
+          password: myPaSsWd
+          caBundle: |
+            -----BEGIN CERTIFICATE-----
+            dGVzdC1jYS1idW5kbGU=
+            -----END CERTIFICATE-----
+        regionTagCategory: myregtagcat
+        zoneTagCategory: myzonetagcat
+        region: myreg
+        sshPublicKey: mysshkey1
+        vmFolderPath: dev/test
+        masterNodeGroup:
+          instanceClass:
+            datastore: dev/lun_1
+            mainNetwork: k8s-msk/test_187
+            memory: 8192
+            numCPUs: 4
+            template: dev/golden_image
+          replicas: 1
+`
+
+// NSX-T uses caBundle instead of insecureFlag; provider stays on insecure.
+const moduleValuesNsxtCABundle = `
+    internal:
+      storageClasses:
+      - name: mydsname1
+        datastoreType: Datastore
+        datastoreURL: ds:///vmfs/volumes/hash1/
+        path: /my/ds/path/mydsname1
+        zones: ["zonea", "zoneb"]
+      compatibilityFlag: ""
+      providerDiscoveryData:
+        zones: ["aaa", "bbb"]
+        datacenter: X1
+        resourcePoolPath: kubernetes-dev
+      providerClusterConfiguration:
+        provider:
+          server: myhost
+          username: myuname
+          password: myPaSsWd
+          insecure: true
+        regionTagCategory: myregtagcat
+        zoneTagCategory: myzonetagcat
+        region: myreg
+        sshPublicKey: mysshkey1
+        vmFolderPath: dev/test
+        externalNetworkNames: ["aaa", "bbb"]
+        internalNetworkNames: ["ccc", "ddd"]
+        nsxt:
+          defaultIpPoolName: main
+          defaultTcpAppProfileName: default-tcp-lb-app-profile
+          defaultUdpAppProfileName: default-udp-lb-app-profile
+          size: SMALL
+          tier1GatewayPath: /host/tier1
+          user: user
+          password: password
+          host: 1.2.3.4
+          caBundle: |
+            -----BEGIN CERTIFICATE-----
+            dGVzdC1uc3h0LWNhLWJ1bmRsZQ==
+            -----END CERTIFICATE-----
+`
+
 const tolerationsAnyNodeWithUninitialized = `
 - key: node-role.kubernetes.io/master
 - key: node-role.kubernetes.io/control-plane
@@ -319,6 +413,26 @@ const tolerationsAnyNodeWithUninitialized = `
 - key: node.kubernetes.io/network-unavailable`
 
 const moduleNamespace = "d8-cloud-provider-vsphere"
+
+// vsphereModulesImages returns module images with the vsphere digests explicitly
+// populated for Kubernetes 1.32. Some earlier specs mutate the shared
+// library.DefaultImagesDigests map in place, so we can not rely on GetModulesImages()
+// keeping the 1.32 image keys intact.
+func vsphereModulesImages() map[string]interface{} {
+	images := GetModulesImages()
+	if images["digests"] == nil {
+		images["digests"] = make(map[string]interface{})
+	}
+	digests := images["digests"].(map[string]interface{})
+	digests["cloudProviderVsphere"] = map[string]interface{}{
+		"cloudControllerManager132": "sha256:ccm132digest",
+		"cloudDataDiscoverer":       "sha256:cdddigest",
+		"vsphereCsiPlugin132":       "sha256:csiplugin132digest",
+		"vsphereCsiPluginLegacy":    "sha256:csipluginlegacydigest",
+		"terraformManager":          "sha256:terraformdigest",
+	}
+	return images
+}
 
 var _ = Describe("Module :: cloud-provider-vsphere :: helm template ::", func() {
 	f := SetupHelmConfig(``)
@@ -811,6 +925,137 @@ vcenter:
     - X1
     server: myhost
 `))
+		})
+	})
+
+	Context("Vsphere with provider caBundle specified", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", fmt.Sprintf(globalValues, "1.32", "1.32"))
+			f.ValuesSet("global.discovery.kubernetesVersion", "1.32.1")
+			f.ValuesSet("global.modulesImages", vsphereModulesImages())
+			f.ValuesSetFromYaml("cloudProviderVsphere", moduleValuesProviderCABundle)
+			f.HelmRender()
+		})
+
+		It("Creates the vsphere-ca-certs secret with the provider CA", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			caSecret := f.KubernetesResource("Secret", moduleNamespace, "vsphere-ca-certs")
+			Expect(caSecret.Exists()).To(BeTrue())
+			Expect(caSecret.Field("type").String()).To(Equal("Opaque"))
+
+			caCrt, err := base64.StdEncoding.DecodeString(caSecret.Field("data").Get("ca\\.crt").String())
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(string(caCrt)).To(Equal(caBundlePEM))
+
+			// The nsxt CA key must be absent when only the provider CA is set.
+			Expect(caSecret.Field("data").Get("ca-nsxt\\.crt").Exists()).To(BeFalse())
+		})
+
+		It("Uses caFile and disables insecure in the CCM cloud-config", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			ccmSecret := f.KubernetesResource("Secret", moduleNamespace, "cloud-controller-manager")
+			Expect(ccmSecret.Exists()).To(BeTrue())
+
+			cloudConfig, err := base64.StdEncoding.DecodeString(ccmSecret.Field("data.cloud-config").String())
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(string(cloudConfig)).To(ContainSubstring(`caFile: "/etc/vsphere-certs/ca.crt"`))
+			Expect(string(cloudConfig)).To(ContainSubstring("insecureFlag: false"))
+		})
+
+		It("Uses ca-file and disables insecure-flag in the CSI cloud-config", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			csiSecret := f.KubernetesResource("Secret", moduleNamespace, "csi-controller")
+			Expect(csiSecret.Exists()).To(BeTrue())
+
+			cloudConfig, err := base64.StdEncoding.DecodeString(csiSecret.Field("data.cloud-config").String())
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(string(cloudConfig)).To(ContainSubstring(`ca-file = "/etc/vsphere-certs/ca.crt"`))
+			Expect(string(cloudConfig)).To(ContainSubstring("insecure-flag = false"))
+		})
+
+		It("Mounts the CA secret into the CCM deployment", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			ccmDeploy := f.KubernetesResource("Deployment", moduleNamespace, "cloud-controller-manager")
+			Expect(ccmDeploy.Exists()).To(BeTrue())
+
+			volumes := ccmDeploy.Field("spec.template.spec.volumes").String()
+			Expect(volumes).To(ContainSubstring("vsphere-ca-certs"))
+
+			podAnnotations := ccmDeploy.Field("spec.template.metadata.annotations").String()
+			Expect(podAnnotations).To(ContainSubstring("checksum/ca"))
+		})
+
+		It("Passes GOVMOMI_CA_BUNDLE to the cloud-data-discoverer and disables insecure", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			cddDeploy := f.KubernetesResource("Deployment", moduleNamespace, "cloud-data-discoverer")
+			Expect(cddDeploy.Exists()).To(BeTrue())
+			Expect(cddDeploy.Field("spec.template.spec.containers.0.env").String()).To(ContainSubstring("GOVMOMI_CA_BUNDLE"))
+
+			cddSecret := f.KubernetesResource("Secret", moduleNamespace, "cloud-data-discoverer")
+			Expect(cddSecret.Exists()).To(BeTrue())
+			insecure, err := base64.StdEncoding.DecodeString(cddSecret.Field("data.insecure").String())
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(string(insecure)).To(Equal("false"))
+		})
+	})
+
+	Context("Vsphere with NSX-T caBundle specified", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", fmt.Sprintf(globalValues, "1.32", "1.32"))
+			f.ValuesSet("global.discovery.kubernetesVersion", "1.32.1")
+			f.ValuesSet("global.modulesImages", vsphereModulesImages())
+			f.ValuesSetFromYaml("cloudProviderVsphere", moduleValuesNsxtCABundle)
+			f.HelmRender()
+		})
+
+		It("Creates the vsphere-ca-certs secret with the nsxt CA", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			caSecret := f.KubernetesResource("Secret", moduleNamespace, "vsphere-ca-certs")
+			Expect(caSecret.Exists()).To(BeTrue())
+
+			caNsxt, err := base64.StdEncoding.DecodeString(caSecret.Field("data").Get("ca-nsxt\\.crt").String())
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(string(caNsxt)).To(Equal(nsxtCABundlePEM))
+
+			// Provider CA is not configured here, so its key must be absent.
+			Expect(caSecret.Field("data").Get("ca\\.crt").Exists()).To(BeFalse())
+		})
+
+		It("Uses nsxt caFile and disables nsxt insecureFlag in the CCM cloud-config", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			ccmSecret := f.KubernetesResource("Secret", moduleNamespace, "cloud-controller-manager")
+			cloudConfig, err := base64.StdEncoding.DecodeString(ccmSecret.Field("data.cloud-config").String())
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(string(cloudConfig)).To(ContainSubstring(`caFile: "/etc/vsphere-certs/ca-nsxt.crt"`))
+		})
+	})
+
+	Context("Vsphere without any caBundle", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", fmt.Sprintf(globalValues, "1.32", "1.32"))
+			f.ValuesSet("global.discovery.kubernetesVersion", "1.32.1")
+			f.ValuesSet("global.modulesImages", vsphereModulesImages())
+			f.ValuesSetFromYaml("cloudProviderVsphere", moduleValuesA)
+			f.HelmRender()
+		})
+
+		It("Does not create the vsphere-ca-certs secret and keeps insecure", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			Expect(f.KubernetesResource("Secret", moduleNamespace, "vsphere-ca-certs").Exists()).To(BeFalse())
+
+			ccmSecret := f.KubernetesResource("Secret", moduleNamespace, "cloud-controller-manager")
+			cloudConfig, err := base64.StdEncoding.DecodeString(ccmSecret.Field("data.cloud-config").String())
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(string(cloudConfig)).To(ContainSubstring("insecureFlag: true"))
+			Expect(string(cloudConfig)).ToNot(ContainSubstring("caFile"))
 		})
 	})
 })

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/templates/_helpers.tpl
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/templates/_helpers.tpl
@@ -1,0 +1,23 @@
+{{- define "vsphere_has_nsxt_caBundle" -}}
+{{- if and .Values.cloudProviderVsphere.internal.providerClusterConfiguration.nsxt .Values.cloudProviderVsphere.internal.providerClusterConfiguration.nsxt.caBundle -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}
+
+{{- define "vsphere_has_provider_caBundle" -}}
+{{- if and .Values.cloudProviderVsphere.internal.providerClusterConfiguration.provider .Values.cloudProviderVsphere.internal.providerClusterConfiguration.provider.caBundle -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}
+
+{{- define "vsphere_has_caBundle" -}}
+{{- if or (eq (include "vsphere_has_provider_caBundle" .) "true") (eq (include "vsphere_has_nsxt_caBundle" .) "true") -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/templates/ca-secret.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/templates/ca-secret.yaml
@@ -1,0 +1,16 @@
+{{- if eq (include "vsphere_has_caBundle" .) "true" }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vsphere-ca-certs
+  namespace: d8-cloud-provider-vsphere
+  {{- include "helm_lib_module_labels" (list . (dict "app" "vsphere-ca-certs")) | nindent 2 }}
+type: Opaque
+data:
+    {{- if eq (include "vsphere_has_provider_caBundle" .) "true" }}
+  ca.crt: {{ .Values.cloudProviderVsphere.internal.providerClusterConfiguration.provider.caBundle | b64enc }}
+    {{- end }}
+    {{- if eq (include "vsphere_has_nsxt_caBundle" .) "true" }}
+  ca-nsxt.crt: {{ .Values.cloudProviderVsphere.internal.providerClusterConfiguration.nsxt.caBundle | b64enc }}
+    {{- end }}
+{{- end }}

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/templates/cloud-controller-manager/deployment.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/templates/cloud-controller-manager/deployment.yaml
@@ -5,10 +5,16 @@
 {{- end -}}
 
 {{- define "vsphere_ccm_pdb_annotations" -}}
+{{- if eq (include "vsphere_has_caBundle" .) "true" }}
+checksum/ca: {{ include (print $.Template.BasePath "/ca-secret.yaml") . | sha256sum }}
+{{- end }}
 checksum/config: {{ include (print $.Template.BasePath "/cloud-controller-manager/secret.yaml") . | sha256sum }}
 {{- end -}}
 
 {{- define "vsphere_ccm_pod_annotations" -}}
+{{- if eq (include "vsphere_has_caBundle" .) "true" }}
+checksum/ca: {{ include (print $.Template.BasePath "/ca-secret.yaml") . | sha256sum }}
+{{- end }}
 checksum/config: {{ include (print $.Template.BasePath "/cloud-controller-manager/secret.yaml") . | sha256sum }}
 {{- end -}}
 
@@ -30,6 +36,11 @@ checksum/config: {{ include (print $.Template.BasePath "/cloud-controller-manage
   readOnly: true
 - mountPath: /tmp
   name: tmp
+{{- if eq (include "vsphere_has_caBundle" .) "true" }}
+- mountPath: /etc/vsphere-certs
+  name: vsphere-certs
+  readOnly: true
+{{- end }}
 {{- end -}}
 
 {{- define "vsphere_ccm_volumes" -}}
@@ -42,6 +53,11 @@ checksum/config: {{ include (print $.Template.BasePath "/cloud-controller-manage
     secretName: cloud-controller-manager
 - name: tmp
   emptyDir: {}
+{{- if eq (include "vsphere_has_caBundle" .) "true" }}
+- name: vsphere-certs
+  secret:
+    secretName: vsphere-ca-certs
+{{- end }}
 {{- end -}}
 
 {{- $kubernetesSemVer := semver .Values.global.discovery.kubernetesVersion }}

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/templates/cloud-controller-manager/secret.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/templates/cloud-controller-manager/secret.yaml
@@ -4,7 +4,12 @@
 global:
   user: {{ $providerClusterConfiguration.provider.username | quote }}
   password: {{ $providerClusterConfiguration.provider.password | quote }}
+    {{- if eq (include "vsphere_has_provider_caBundle" .) "true" }}
+  caFile: "/etc/vsphere-certs/ca.crt"
+  insecureFlag: false
+    {{- else }}
   insecureFlag: {{ $providerClusterConfiguration.provider.insecure }}
+    {{- end }}
 
 vcenter:
   main:
@@ -41,7 +46,10 @@ nsxt:
   user: {{ $providerClusterConfiguration.nsxt.user | quote }}
   password: {{ $providerClusterConfiguration.nsxt.password | quote }}
   host: {{ $providerClusterConfiguration.nsxt.host | quote }}
-    {{- if $providerClusterConfiguration.nsxt.insecureFlag }}
+    {{- if eq (include "vsphere_has_nsxt_caBundle" .) "true" }}
+  caFile: "/etc/vsphere-certs/ca-nsxt.crt"
+  insecureFlag: false
+    {{- else if $providerClusterConfiguration.nsxt.insecureFlag }}
   insecureFlag: {{ $providerClusterConfiguration.nsxt.insecureFlag }}
     {{- end }}
     {{- if $providerClusterConfiguration.nsxt.loadBalancerClass }}

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/templates/cloud-data-discoverer/deployment.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/templates/cloud-data-discoverer/deployment.yaml
@@ -1,4 +1,7 @@
 {{- define "vsphere_cdd_pod_annotations" -}}
+{{- if eq (include "vsphere_has_provider_caBundle" .) "true" }}
+checksum/ca: {{ include (print $.Template.BasePath "/ca-secret.yaml") . | sha256sum }}
+{{- end }}
 checksum/config: {{ include (print $.Template.BasePath "/cloud-data-discoverer/secret.yaml") . | sha256sum }}
 {{- end -}}
 
@@ -23,6 +26,13 @@ checksum/config: {{ include (print $.Template.BasePath "/cloud-data-discoverer/s
     secretKeyRef:
       name: cloud-data-discoverer
       key: insecure
+{{- if eq (include "vsphere_has_provider_caBundle" .) "true" }}
+- name: GOVMOMI_CA_BUNDLE
+  valueFrom:
+    secretKeyRef:
+      name: vsphere-ca-certs
+      key: ca.crt
+{{- end }}
 - name: REGION
   valueFrom:
     secretKeyRef:

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/templates/cloud-data-discoverer/secret.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/templates/cloud-data-discoverer/secret.yaml
@@ -11,7 +11,11 @@ data:
   server: {{ .provider.server | b64enc | quote }}
   username: {{ .provider.username | b64enc | quote }}
   password: {{ .provider.password | b64enc | quote }}
+    {{- if eq (include "vsphere_has_provider_caBundle" $) "true" }}
+  insecure: {{ print "false" | b64enc | quote }}
+    {{- else }}
   insecure: {{ .provider.insecure | toString | b64enc | quote }}
+    {{- end }}
   region: {{ .region | b64enc | quote }}
   zones: {{ .zones | join "," | b64enc | quote }}
   regionTagCategory: {{ .regionTagCategory | b64enc | quote }}

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/templates/csi/controller.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/templates/csi/controller.yaml
@@ -47,12 +47,29 @@
 - name: vsphere-csi-config-volume
   secret:
     secretName: csi-controller
+{{- if eq (include "vsphere_has_provider_caBundle" .) "true" }}
+- name: vsphere-ca-cert
+  secret:
+    secretName: vsphere-ca-certs
+{{- end }}
 {{- end }}
 
 {{- define "csi_controller_volume_mounts" }}
 - mountPath: /etc/cloud
   name: vsphere-csi-config-volume
   readOnly: true
+{{- if eq (include "vsphere_has_provider_caBundle" .) "true" }}
+- mountPath: /etc/vsphere-certs
+  name: vsphere-ca-cert
+  readOnly: true
+  subPath: ca.crt
+{{- end }}
+{{- end }}
+
+{{- define "csi_controller_pod_annotations" }}
+{{- if eq (include "vsphere_has_provider_caBundle" .) "true" }}
+ca-bundle-checksum: {{ include (print .Template.BasePath "/ca-secret.yaml") . | sha256sum }}
+{{- end }}
 {{- end }}
 
 {{- $kubernetesSemVer := semver .Values.global.discovery.kubernetesVersion }}
@@ -70,6 +87,7 @@
 {{- $_ := set $csiControllerConfig "additionalSyncerEnvs" (include "csi_syncer_envs" . | fromYamlArray) }}
 {{- $_ := set $csiControllerConfig "additionalControllerVolumes" (include "csi_controller_volumes" . | fromYamlArray) }}
 {{- $_ := set $csiControllerConfig "additionalControllerVolumeMounts" (include "csi_controller_volume_mounts" . | fromYamlArray) }}
+{{- $_ := set $csiControllerConfig "additionalCsiControllerPodAnnotations" (include "csi_controller_pod_annotations" . | fromYaml) }}
 {{- $_ := set $csiControllerConfig "dnsPolicy" (include "helm_lib_dns_policy_bootstraping_state" (list . "Default" "ClusterFirstWithHostNet")) }}
 
 {{- if ne .Values.cloudProviderVsphere.internal.compatibilityFlag "Legacy" }}
@@ -108,12 +126,29 @@
 - name: vsphere-csi-config-volume
   secret:
     secretName: csi-controller
+{{- if eq (include "vsphere_has_provider_caBundle" .) "true" }}
+- name: vsphere-ca-cert
+  secret:
+    secretName: vsphere-ca-certs
+{{- end }}
 {{- end }}
 
 {{- define "csi_node_volume_mounts" }}
 - mountPath: /etc/cloud
   name: vsphere-csi-config-volume
   readOnly: true
+{{- if eq (include "vsphere_has_provider_caBundle" .) "true" }}
+- mountPath: /etc/vsphere-certs
+  name: vsphere-ca-cert
+  readOnly: true
+  subPath: ca.crt
+{{- end }}
+{{- end }}
+
+{{- define "csi_node_pod_annotations" }}
+{{- if eq (include "vsphere_has_provider_caBundle" .) "true" }}
+ca-bundle-checksum: {{ include (print .Template.BasePath "/ca-secret.yaml") . | sha256sum }}
+{{- end }}
 {{- end }}
 
 {{- define "csi_node_registrar_liveness_exec_probes_command" }}
@@ -136,6 +171,7 @@
   {{- $_ := set $csiNodeConfig "additionalNodeEnvs" (include "csi_node_envs" . | fromYamlArray) }}
   {{- $_ := set $csiNodeConfig "additionalNodeVolumes" (include "csi_node_volumes" . | fromYamlArray) }}
   {{- $_ := set $csiNodeConfig "additionalNodeVolumeMounts" (include "csi_node_volume_mounts" . | fromYamlArray) }}
+  {{- $_ := set $csiNodeConfig "additionalCsiNodePodAnnotations" (include "csi_node_pod_annotations" . | fromYaml) }}
   {{- $_ := set $csiNodeConfig "additionalNodeLivenessProbesCmd" (include "csi_node_registrar_liveness_exec_probes_command" . | fromYamlArray) }}
   {{- $_ := set $csiNodeConfig "dnsPolicy" (include "helm_lib_dns_policy_bootstraping_state" (list . "Default" "ClusterFirstWithHostNet")) }}
 

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/templates/csi/controller.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/templates/csi/controller.yaml
@@ -59,7 +59,7 @@
   name: vsphere-csi-config-volume
   readOnly: true
 {{- if eq (include "vsphere_has_provider_caBundle" .) "true" }}
-- mountPath: /etc/vsphere-certs
+- mountPath: /etc/vsphere-certs/ca.crt
   name: vsphere-ca-cert
   readOnly: true
   subPath: ca.crt
@@ -138,7 +138,7 @@ ca-bundle-checksum: {{ include (print .Template.BasePath "/ca-secret.yaml") . | 
   name: vsphere-csi-config-volume
   readOnly: true
 {{- if eq (include "vsphere_has_provider_caBundle" .) "true" }}
-- mountPath: /etc/vsphere-certs
+- mountPath: /etc/vsphere-certs/ca.crt
   name: vsphere-ca-cert
   readOnly: true
   subPath: ca.crt

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/templates/csi/secret.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/templates/csi/secret.yaml
@@ -4,7 +4,12 @@
 [Global]
 user = {{ $providerClusterConfiguration.provider.username | quote }}
 password = {{ $providerClusterConfiguration.provider.password | quote }}
+  {{- if eq (include "vsphere_has_provider_caBundle" .) "true" }}
+ca-file = "/etc/vsphere-certs/ca.crt"
+insecure-flag = false
+  {{- else if $providerClusterConfiguration.provider.insecure }}
 insecure-flag = {{ if $providerClusterConfiguration.provider.insecure }}1{{ else }}0{{ end }}
+  {{- end }}
 cluster-id = {{ .Values.global.discovery.clusterUUID | quote }}
 
 [VirtualCenter {{ $providerClusterConfiguration.provider.server | quote }}]

--- a/go_lib/dependency/vsphere/vsphere.go
+++ b/go_lib/dependency/vsphere/vsphere.go
@@ -16,11 +16,9 @@ package vsphere
 
 import (
 	"context"
-	"crypto/tls"
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"net/http"
 	"net/url"
 	"path"
 	"reflect"
@@ -561,11 +559,12 @@ func setVCClientCA(vcClient *govmomi.Client, caBundle string) error {
 			return fmt.Errorf("failed to parse CA bundle")
 		}
 
-		vcClient.Transport = &http.Transport{
-			TLSClientConfig: &tls.Config{
-				RootCAs: pool,
-			},
-		}
+		// Set RootCAs on the soap client's internal transport (DefaultTransport)
+		// rather than replacing Transport. govmomi derives service clients via
+		// NewServiceClient, which copies TLSClientConfig from DefaultTransport();
+		// replacing Transport leaves that internal config without our RootCAs.
+		// It also preserves the custom DialTLS and default transport timeouts.
+		vcClient.Client.Client.DefaultTransport().TLSClientConfig.RootCAs = pool
 	}
 	return nil
 }

--- a/go_lib/dependency/vsphere/vsphere.go
+++ b/go_lib/dependency/vsphere/vsphere.go
@@ -16,8 +16,11 @@ package vsphere
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"path"
 	"reflect"
@@ -72,6 +75,7 @@ type Provider struct {
 	Username string `json:"username"`
 	Password string `json:"password"`
 	Insecure bool   `json:"insecure"`
+	CABundle string `json:"caBundle"`
 }
 
 type ZonedDataStore struct {
@@ -199,6 +203,7 @@ func createVsphereClient(config *ProviderClusterConfiguration) (client, error) {
 		username = config.Provider.Username
 		password = config.Provider.Password
 		insecure = config.Provider.Insecure
+		cabundle = config.Provider.CABundle
 	)
 
 	parsedURL, err := url.Parse(fmt.Sprintf("https://%s:%s@%s/sdk", url.PathEscape(strings.TrimSpace(username)), url.PathEscape(strings.TrimSpace(password)), url.PathEscape(strings.TrimSpace(host))))
@@ -208,6 +213,10 @@ func createVsphereClient(config *ProviderClusterConfiguration) (client, error) {
 
 	vcClient, err := govmomi.NewClient(context.TODO(), parsedURL, insecure)
 	if err != nil {
+		return client{}, err
+	}
+
+	if err := setVCClientCA(vcClient, cabundle); err != nil {
 		return client{}, err
 	}
 
@@ -543,4 +552,20 @@ func isZoneAllowed(allowedZones map[string]any, zone string) bool {
 
 	_, allowed := allowedZones[zone]
 	return allowed
+}
+
+func setVCClientCA(vcClient *govmomi.Client, caBundle string) error {
+	if caBundle != "" {
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM([]byte(caBundle)) {
+			return fmt.Errorf("failed to parse CA bundle")
+		}
+
+		vcClient.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs: pool,
+			},
+		}
+	}
+	return nil
 }

--- a/go_lib/dependency/vsphere/vsphere_test.go
+++ b/go_lib/dependency/vsphere/vsphere_test.go
@@ -1,0 +1,243 @@
+// Copyright 2025 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vsphere
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/soap"
+)
+
+// generateTestCAPEM returns a self-signed CA certificate encoded in PEM format.
+func generateTestCAPEM(t *testing.T) string {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+
+	template := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("failed to create certificate: %v", err)
+	}
+
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
+}
+
+func newTestVCClient(t *testing.T) *govmomi.Client {
+	t.Helper()
+
+	u, err := url.Parse("https://user:pass@vcenter.example.com/sdk")
+	if err != nil {
+		t.Fatalf("failed to parse url: %v", err)
+	}
+
+	soapClient := soap.NewClient(u, false)
+	return &govmomi.Client{
+		Client: &vim25.Client{Client: soapClient},
+	}
+}
+
+func TestSetVCClientCA(t *testing.T) {
+	validCA := generateTestCAPEM(t)
+
+	t.Run("empty CA bundle leaves transport untouched", func(t *testing.T) {
+		vc := newTestVCClient(t)
+		before := vc.Transport
+
+		if err := setVCClientCA(vc, ""); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if vc.Transport != before {
+			t.Fatalf("transport must not be replaced when CA bundle is empty")
+		}
+	})
+
+	t.Run("valid CA bundle configures RootCAs", func(t *testing.T) {
+		vc := newTestVCClient(t)
+
+		if err := setVCClientCA(vc, validCA); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		transport, ok := vc.Transport.(*http.Transport)
+		if !ok {
+			t.Fatalf("expected *http.Transport, got %T", vc.Transport)
+		}
+		if transport.TLSClientConfig == nil || transport.TLSClientConfig.RootCAs == nil {
+			t.Fatalf("expected RootCAs to be set")
+		}
+		//nolint:staticcheck // Subjects() is enough to assert the pool is not empty in tests.
+		if len(transport.TLSClientConfig.RootCAs.Subjects()) == 0 {
+			t.Fatalf("expected at least one CA in the pool")
+		}
+	})
+
+	t.Run("invalid CA bundle returns error", func(t *testing.T) {
+		vc := newTestVCClient(t)
+
+		err := setVCClientCA(vc, "not-a-valid-pem")
+		if err == nil {
+			t.Fatalf("expected error for invalid CA bundle")
+		}
+	})
+}
+
+func TestSlugKubernetesName(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "empty stays empty", input: "", want: ""},
+		{name: "alnum-only label kept as is", input: "datastore1", want: "datastore1"},
+		// The dns label regex forbids dashes, so any name containing a dash is slugged
+		// with a deterministic murmur hash suffix.
+		{name: "name with dashes is slugged", input: "my-datastore-1", want: "my-datastore-1-c7567ed"},
+		{name: "spaces are slugged", input: "my datastore", want: "my-datastore-772d4a90"},
+		{name: "already dashed name is slugged", input: "dc-cluster-ds", want: "dc-cluster-ds-52483173"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := slugKubernetesName(tt.input)
+			if got != tt.want {
+				t.Fatalf("slugKubernetesName(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSlugKubernetesNameDeterministic(t *testing.T) {
+	// Names that require slugging must produce a stable, lowercase result.
+	input := "Datastore With Spaces And UPPER"
+
+	first := slugKubernetesName(input)
+	second := slugKubernetesName(input)
+	if first != second {
+		t.Fatalf("slug must be deterministic: %q != %q", first, second)
+	}
+	if first == input {
+		t.Fatalf("expected %q to be slugged", input)
+	}
+}
+
+func TestSlugRespectsMaxSize(t *testing.T) {
+	long := ""
+	for i := 0; i < 300; i++ {
+		long += "a"
+	}
+
+	got := slug(long, dnsLabelMaxSize)
+	if len(got) > dnsLabelMaxSize {
+		t.Fatalf("slug length %d must not exceed max size %d", len(got), dnsLabelMaxSize)
+	}
+}
+
+func TestShouldNotBeSlugged(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{name: "empty string should not be slugged", input: "", want: true},
+		{name: "valid short label should not be slugged", input: "abc", want: true},
+		{name: "string with spaces should be slugged", input: "a b c", want: false},
+		{name: "string with dot should be slugged", input: "a.b", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldNotBeSlugged(tt.input, dnsLabelRegex, dnsLabelMaxSize)
+			if got != tt.want {
+				t.Fatalf("shouldNotBeSlugged(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMurmurHashDeterministic(t *testing.T) {
+	a := murmurHash("some", "value")
+	b := murmurHash("some", "value")
+	if a != b {
+		t.Fatalf("murmurHash must be deterministic: %q != %q", a, b)
+	}
+
+	c := murmurHash("other", "value")
+	if a == c {
+		t.Fatalf("murmurHash must differ for different args")
+	}
+}
+
+func TestIsZoneAllowed(t *testing.T) {
+	tests := []struct {
+		name    string
+		allowed map[string]any
+		zone    string
+		want    bool
+	}{
+		{
+			name:    "empty allowed list allows any zone",
+			allowed: map[string]any{},
+			zone:    "zone-a",
+			want:    true,
+		},
+		{
+			name:    "zone present in allowed list",
+			allowed: map[string]any{"zone-a": struct{}{}, "zone-b": struct{}{}},
+			zone:    "zone-a",
+			want:    true,
+		},
+		{
+			name:    "zone absent from allowed list",
+			allowed: map[string]any{"zone-a": struct{}{}},
+			zone:    "zone-c",
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isZoneAllowed(tt.allowed, tt.zone)
+			if got != tt.want {
+				t.Fatalf("isZoneAllowed(%v, %q) = %v, want %v", tt.allowed, tt.zone, got, tt.want)
+			}
+		})
+	}
+}

--- a/modules/040-node-manager/images/machine-controller-manager/werf.inc.yaml
+++ b/modules/040-node-manager/images/machine-controller-manager/werf.inc.yaml
@@ -23,7 +23,8 @@ secrets:
   value: {{ .SOURCE_REPO }}
 shell:
   install:
-  - git clone --depth 1 --branch {{ $mcmVersion }}-flant.24 $(cat /run/secrets/SOURCE_REPO)/deckhouse/mcm.git /src
+  # TODO: Change branch after merge MCM PR
+  - git clone --depth 1 --branch feat/vshere-support-ca-bundle $(cat /run/secrets/SOURCE_REPO)/deckhouse/mcm.git /src
   - rm -rf /src/.git
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact


### PR DESCRIPTION
## Проблема

Первый e2e-прогон на живом vCenter (`vcenter.architects.foxtrot-dev.ru`) вскрыл две ошибки, которые unit/helm-тесты не ловили:

### 1. discoverer + go_lib — `certificate signed by unknown authority`
`setSoapClientCA` / `setVCClientCA` перезаписывали `soapClient.Transport` новым `&http.Transport{}`. Login на `/sdk` проходил (использует внешний `Client.Transport`), но `cns.NewClient` строит сервис-клиент через govmomi `NewServiceClient`, который копирует `TLSClientConfig` из **внутреннего** транспорта (`DefaultTransport()`), — а туда RootCAs не попадал. Итог: `Failed to create CNS client … unknown authority`, под `cloud-data-discoverer` в `CrashLoopBackOff`.

**Фикс:** писать pool в `DefaultTransport().TLSClientConfig.RootCAs`, не заменяя `Transport`. Побочно сохраняется кастомный `DialTLS` govmomi (thumbprint) и дефолтные таймауты.

### 2. CSI — `open /etc/vsphere-certs/ca.crt: not a directory`
Том монтировался как `mountPath: /etc/vsphere-certs` + `subPath: ca.crt` — при `subPath` сам `mountPath` становится **файлом**, поэтому `/etc/vsphere-certs/ca.crt` не открывается. CCM работал, т.к. у него том без `subPath`.

**Фикс:** `mountPath: /etc/vsphere-certs/ca.crt` + `subPath: ca.crt`.

## Проверка
- `go_lib/dependency/vsphere` — build + `TestSetVCClientCA` зелёные.
- `cloud-data-discoverer` — build + `TestSetSoapClientCA` зелёные (через локальный replace-override на go_lib этого worktree).
- `template_tests` — зелёные, добавлен регресс-ассерт, что CSI монтирует CA как файл `/etc/vsphere-certs/ca.crt`, а не директорию.

CA в секрете `vsphere-ca-certs` проверен отдельно — байт-в-байт совпадает с root'ом стенда, т.е. `caBundle` в конфиге был корректный; «unknown authority» шёл из кода.