### PR TITLE
[docs] Add werf no-activity timeout for modules library

### DIFF
--- a/docs/site/.helm/templates/14-moduleslibrary.yaml
+++ b/docs/site/.helm/templates/14-moduleslibrary.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     "werf.io/replicas-on-creation": "1"
     "pod-reloader.deckhouse.io/auto": "true"
+    "werf.io/no-activity-timeout": "10m"
   labels:
     service: moduleslibrary
     app.kubernetes.io/part-of: deckhouse-docs


### PR DESCRIPTION
## Description

Set a ten-minute inactivity timeout on the modules library deployment.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: ci
type: chore
summary: Increase timeout for modules library readiness on deploy.
impact_level: low
```
