### PR TITLE
[dhctl] Add deprecation warning mechanism

### DIFF
--- a/dhctl/pkg/config/deprecation.go
+++ b/dhctl/pkg/config/deprecation.go
@@ -1,0 +1,119 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/go-openapi/spec"
+	"sigs.k8s.io/yaml"
+
+	dhlog "github.com/deckhouse/lib-dhctl/pkg/logger"
+)
+
+// xDocDeprecatedExtension is the vendor extension openapi schemas use to mark
+// a field as deprecated. It is the same marker the docs generator reads
+// (see pkg/crd-enricher and candi/openapi/*.yaml), so any field already
+// documented as deprecated is picked up here for free.
+const xDocDeprecatedExtension = "x-doc-deprecated"
+
+// warnDeprecatedFields logs a warning for every field actually set in doc
+// whose schema node carries "x-doc-deprecated: true". It works for any
+// document validated against a schema from the SchemaStore -
+// ClusterConfiguration, InitConfiguration, StaticClusterConfiguration,
+// provider-specific cluster configurations, ModuleConfig settings, and so on -
+// so a field only needs to be marked deprecated in its openapi schema to
+// start warning users, with no dhctl code change required.
+//
+// name is the document's metadata.name, if it has one (e.g. a ModuleConfig),
+// so the warning identifies which resource is affected; it is empty for
+// documents that don't carry a metadata.name, such as ClusterConfiguration.
+func warnDeprecatedFields(ctx context.Context, index *SchemaIndex, name string, doc json.RawMessage, schema *spec.Schema) {
+	warnDeprecatedProperties(ctx, index, name, "", doc, schema)
+}
+
+// extractMetadataName reads metadata.name out of a raw document, or returns
+// an empty string if the document has none.
+func extractMetadataName(doc []byte) string {
+	var idx namedIndex
+	if err := yaml.Unmarshal(doc, &idx); err != nil {
+		return ""
+	}
+	return idx.Metadata.Name
+}
+
+func warnDeprecatedProperties(ctx context.Context, index *SchemaIndex, name, pathPrefix string, doc json.RawMessage, schema *spec.Schema) {
+	if schema == nil || len(doc) == 0 {
+		return
+	}
+
+	if len(schema.Properties) > 0 {
+		var properties map[string]json.RawMessage
+		if err := yaml.Unmarshal(doc, &properties); err != nil {
+			return
+		}
+
+		for field, fieldSchema := range schema.Properties {
+			raw, ok := properties[field]
+			if !ok {
+				continue
+			}
+
+			path := joinFieldPath(pathPrefix, field)
+
+			if deprecated, _ := fieldSchema.Extensions.GetBool(xDocDeprecatedExtension); deprecated {
+				warnDeprecatedField(ctx, index, name, path)
+			}
+
+			warnDeprecatedProperties(ctx, index, name, path, raw, &fieldSchema)
+		}
+	}
+
+	if itemSchema := schema.Items; itemSchema != nil && itemSchema.Schema != nil {
+		var items []json.RawMessage
+		if err := yaml.Unmarshal(doc, &items); err != nil {
+			return
+		}
+
+		for i, item := range items {
+			warnDeprecatedProperties(ctx, index, name, fmt.Sprintf("%s[%d]", pathPrefix, i), item, itemSchema.Schema)
+		}
+	}
+}
+
+func joinFieldPath(prefix, field string) string {
+	if prefix == "" {
+		return field
+	}
+	return prefix + "." + field
+}
+
+func warnDeprecatedField(ctx context.Context, index *SchemaIndex, name, path string) {
+	logger := dhlog.FromContext(ctx)
+	logger.WarnContext(ctx, "=================================================================")
+	logger.WarnContext(ctx, fmt.Sprintf("DEPRECATED: %q in %s is deprecated.", path, kindLabel(index, name)))
+	logger.WarnContext(ctx, "Support for this field will be removed in a future release.")
+	logger.WarnContext(ctx, "=================================================================")
+}
+
+// kindLabel renders "Kind" or, when the document has a metadata.name, `Kind "name"`.
+func kindLabel(index *SchemaIndex, name string) string {
+	if name == "" {
+		return index.Kind
+	}
+	return fmt.Sprintf("%s %q", index.Kind, name)
+}

--- a/dhctl/pkg/config/deprecation_test.go
+++ b/dhctl/pkg/config/deprecation_test.go
@@ -1,0 +1,130 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	dhlog "github.com/deckhouse/lib-dhctl/pkg/logger"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/app/options"
+)
+
+// captureSlog installs a buffer-backed slog logger as the process default so
+// that warnDeprecatedFields, which logs via dhlog.FromContext(context.Background())
+// under a plain context.Background(), is captured. These tests do not run in
+// parallel, so mutating the global slog default is safe.
+func captureSlog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(dhlog.NewBufferLogger(&buf))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	return &buf
+}
+
+func TestWarnDeprecatedFields(t *testing.T) {
+	newStore := newSchemaStore(&options.New().Global, []string{"/tmp"})
+
+	err := newStore.upload([]byte(`
+kind: TestDeprecationKind
+apiVersions:
+- apiVersion: test
+  openAPISpec:
+    type: object
+    properties:
+      kind:
+        type: string
+      apiVersion:
+        type: string
+      oldOption:
+        type: string
+        x-doc-deprecated: true
+        description: |
+          Deprecated. Use newOption instead.
+      newOption:
+        type: string
+      metadata:
+        type: object
+        properties:
+          name:
+            type: string
+`))
+	require.NoError(t, err)
+
+	tests := map[string]struct {
+		content        string
+		wantWarning    bool
+		wantContains   []string
+		wantNotContain []string
+	}{
+		"deprecated field set": {
+			content: `
+kind: TestDeprecationKind
+apiVersion: test
+oldOption: legacy-value
+`,
+			wantWarning:    true,
+			wantContains:   []string{"DEPRECATED", "oldOption", "TestDeprecationKind"},
+			wantNotContain: []string{"Deprecated. Use newOption instead."},
+		},
+		"deprecated field set with metadata name": {
+			content: `
+kind: TestDeprecationKind
+apiVersion: test
+metadata:
+  name: my-resource
+oldOption: legacy-value
+`,
+			wantWarning:  true,
+			wantContains: []string{"DEPRECATED", "oldOption", "TestDeprecationKind", "my-resource"},
+		},
+		"deprecated field absent": {
+			content: `
+kind: TestDeprecationKind
+apiVersion: test
+newOption: current-value
+`,
+			wantWarning: false,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			buf := captureSlog(t)
+
+			_, err := newStore.Validate(new([]byte(tt.content)))
+			require.NoError(t, err)
+
+			if !tt.wantWarning {
+				require.NotContains(t, buf.String(), "DEPRECATED")
+				return
+			}
+
+			for _, s := range tt.wantContains {
+				require.Contains(t, buf.String(), s)
+			}
+			for _, s := range tt.wantNotContain {
+				require.NotContains(t, buf.String(), s)
+			}
+		})
+	}
+}

--- a/dhctl/pkg/config/load.go
+++ b/dhctl/pkg/config/load.go
@@ -393,6 +393,8 @@ func (s *SchemaStore) ValidateWithIndex(index *SchemaIndex, doc *[]byte, opts ..
 
 	schema = transformer.TransformSchema(schema, &transformer.AdditionalPropertiesTransformer{})
 
+	warnDeprecatedFields(ctx, index, extractMetadataName(*doc), docForValidate, schema)
+
 	isValid, err := openAPIValidate(&docForValidate, schema, options)
 	if !isValid {
 		if options.omitDocInError || options.commanderMode {

--- a/dhctl/pkg/config/meta.go
+++ b/dhctl/pkg/config/meta.go
@@ -107,32 +107,9 @@ func validateAndPrepareMetaConfig(ctx context.Context, preparatorProvider MetaCo
 	return m, nil
 }
 
-var deprecatedClusterConfigFields = []struct {
-	field   string
-	message string
-}{
-	{
-		field:   "encryptionAlgorithm",
-		message: "Please migrate it to the \"control-plane-manager\" ModuleConfig: spec.settings.encryptionAlgorithm.",
-	},
-}
-
-func (m *MetaConfig) warnDeprecatedClusterConfigFields(ctx context.Context) {
-	for _, d := range deprecatedClusterConfigFields {
-		if _, ok := m.ClusterConfig[d.field]; ok {
-			dhlog.FromContext(ctx).WarnContext(ctx, "=================================================================")
-			dhlog.FromContext(ctx).WarnContext(ctx, fmt.Sprintf("DEPRECATED: %q in ClusterConfiguration is deprecated.", d.field))
-			dhlog.FromContext(ctx).WarnContext(ctx, d.message)
-			dhlog.FromContext(ctx).WarnContext(ctx, "Support for this field in ClusterConfiguration will be removed in a future release.")
-			dhlog.FromContext(ctx).WarnContext(ctx, "=================================================================")
-		}
-	}
-}
-
 // Prepare extracts all necessary information from raw json messages to the root structure
 func (m *MetaConfig) Prepare(ctx context.Context, preparatorProvider MetaConfigPreparatorProvider) (*MetaConfig, error) {
 	if len(m.ClusterConfig) > 0 {
-		m.warnDeprecatedClusterConfigFields(ctx)
 		if err := json.Unmarshal(m.ClusterConfig["clusterType"], &m.ClusterType); err != nil {
 			return nil, fmt.Errorf("unable to parse cluster type from cluster configuration: %v", err)
 		}


### PR DESCRIPTION
## Description

Add deprecation warnings to dhctl about all all deprecated fields in resources

## Why do we need it, and what problem does it solve?

If the user is using outdated manifests with deprecated fields, he won't know about it. Now dhctl will show a warning about all deprecated fields.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: feature
summary: Added deprecation warnings in dhctl for deprecated fields in resources.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
