### PR TITLE
[ci] Fail render script/validate workflow on incorrect workflow template

### DIFF
--- a/.github/render-workflows.sh
+++ b/.github/render-workflows.sh
@@ -58,7 +58,7 @@ cat <<'SCRIPT_END' | docker run -i --rm \
 
 # Render each file in workflow_templates
 # directory and copy to /out/workflows
-set -e
+set -eo pipefail
 
 umask ${TARGET_UMASK}
 
@@ -130,7 +130,7 @@ if [[ $ACTIONLINT_RUN != "yes" ]] ; then
   for file in /out/workflows/* ; do
     # Ignore md files. '== *.md' is not working in ash.
     [[ $file != ${file%.md} ]] && continue
-    gomplate -i "$file"'{{ $_ := file.Read "'"$file"'" | yaml }} OK{{ "\n" }}' || true
+    gomplate -i "$file"'{{ $_ := file.Read "'"$file"'" | yaml }} OK{{ "\n" }}'
   done
 fi
 

--- a/.github/workflow_templates/validation.yml
+++ b/.github/workflow_templates/validation.yml
@@ -318,12 +318,11 @@ steps:
   {!{ tmpl.Exec "login_readonly_registry_step" . | strings.Indent 2 }!}
 
   - name: Render GitHub workflow
-    run: |
-      cd .github
-      ./render-workflows.sh
+    env:
+      ACTIONLINT_RUN: noop
+    run: .github/render-workflows.sh
 
   - name: Check rendered files
-    run: |
-      git diff --exit-code
+    run: git diff --exit-code
 # </template: workflow_render_template>
 {!{ end }!}

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -462,13 +462,12 @@ jobs:
       # </template: login_readonly_registry_step>
 
       - name: Render GitHub workflow
-        run: |
-          cd .github
-          ./render-workflows.sh
+        env:
+          ACTIONLINT_RUN: noop
+        run: .github/render-workflows.sh
 
       - name: Check rendered files
-        run: |
-          git diff --exit-code
+        run: git diff --exit-code
     # </template: workflow_render_template>
 
 


### PR DESCRIPTION
## Description
Fail render script/validate workflow on incorrect workflow template.
Test: https://github.com/deckhouse/deckhouse-test-1/actions/runs/29079426715/job/86318658019

## Why do we need it, and what problem does it solve?
This change allows validation workflow to fail in case if workflow templates are not correct.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: fix
summary: Fail render script on incorrect workflow template.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
