### PR TITLE
[ci] Move "Go generate" job to slim runners

### DIFF
--- a/.github/ci_templates/build.yml
+++ b/.github/ci_templates/build.yml
@@ -458,7 +458,7 @@ steps:
 {!{ define "go_generate_template" }!}
 {!{- $ctx := index . 0 -}!}
 # <template: go_generate_template>
-runs-on: [self-hosted, regular]
+runs-on: [self-hosted, self-slim]
 steps:
 {!{ tmpl.Exec "started_at_output"  $ctx | strings.Indent 2 }!}
 {!{ tmpl.Exec "checkout_full_step" $ctx | strings.Indent 2 }!}

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -989,7 +989,7 @@ jobs:
       - git_info
       - pull_request_info
     # <template: go_generate_template>
-    runs-on: [self-hosted, regular]
+    runs-on: [self-hosted, self-slim]
     steps:
 
       # <template: started_at_output>

--- a/.github/workflows/build-and-test_main.yml
+++ b/.github/workflows/build-and-test_main.yml
@@ -727,7 +727,7 @@ jobs:
     needs:
       - git_info
     # <template: go_generate_template>
-    runs-on: [self-hosted, regular]
+    runs-on: [self-hosted, self-slim]
     steps:
 
       # <template: started_at_output>

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -727,7 +727,7 @@ jobs:
     needs:
       - git_info
     # <template: go_generate_template>
-    runs-on: [self-hosted, regular]
+    runs-on: [self-hosted, self-slim]
     steps:
 
       # <template: started_at_output>


### PR DESCRIPTION
## Description
Move "Go generate" job to slim runners.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Move jobs
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
