### PR TITLE
[docs] Fix the filter bug

### DIFF
--- a/docs/site/assets/js/adaptive/header-mobile.js
+++ b/docs/site/assets/js/adaptive/header-mobile.js
@@ -220,12 +220,8 @@ document.addEventListener('DOMContentLoaded', function () {
 
     function closeFilter() {
         const filterBlock = document.querySelector('.filter__block');
-        const filterOverlay = document.querySelector('.filter__sidebar-overlay');
         const isOpen = filterBlock !== null && filterBlock.classList.contains('show');
         if (filterBlock) filterBlock.classList.remove('show');
-        if (filterOverlay && filterOverlay.parentNode) {
-            filterOverlay.parentNode.removeChild(filterOverlay);
-        }
         return isOpen;
     }
 

--- a/docs/site/assets/js/filter.js
+++ b/docs/site/assets/js/filter.js
@@ -1,5 +1,4 @@
 document.addEventListener('DOMContentLoaded', () => {
-  const body = document.querySelector('body');
   const articles = document.querySelectorAll('.button-tile');
   const selectedFiltersList = document.querySelector('.selected__filters--list');
   const filterCheckboxesTags = document.querySelector('.filter__checkboxes--tags');
@@ -552,27 +551,18 @@ document.addEventListener('DOMContentLoaded', () => {
   if (openMobile) {
     const filter = document.querySelector('.filter__block');
     const hamburgerCollapse = document.querySelector('.hamburger--collapse');
-    const content = document.querySelector('.content');
-    const filterOverlay = document.createElement('div');
-    filterOverlay.className = 'sidebar-overlay filter__sidebar-overlay';
 
     function closeFilterMobilePanel() {
       if (filter) filter.classList.remove('show');
-      if (body) body.classList.remove('sidebar-opened');
       if (hamburgerCollapse) hamburgerCollapse.classList.remove('show');
-      if (filterOverlay.parentNode) filterOverlay.parentNode.removeChild(filterOverlay);
     }
 
     openMobile.addEventListener('click', () => {
       if (!filter) return;
       filter.classList.add('show');
-      if (body) body.classList.add('sidebar-opened');
       if (hamburgerCollapse) hamburgerCollapse.classList.add('show');
-      const overlayParent = content || body;
-      if (overlayParent) overlayParent.appendChild(filterOverlay);
     });
 
-    filterOverlay.addEventListener('click', closeFilterMobilePanel);
     if (applyButtonBlock) {
       applyButtonBlock.addEventListener('click', () => {
         if (applyButton && !applyButton.disabled) {


### PR DESCRIPTION
## Description

This pull request simplifies the mobile filter sidebar logic by removing the dynamically created overlay element and its related event handling. This reduces complexity and streamlines the code for opening and closing the mobile filter panel.

Fixes https://github.com/deckhouse/deckhouse/pull/19472

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Fix the filter bug.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
