### PR TITLE
[deckhouse] fix: handle not found on concurrent module delete

### DIFF
--- a/deckhouse-controller/pkg/controller/ctrlutils/update.go
+++ b/deckhouse-controller/pkg/controller/ctrlutils/update.go
@@ -87,6 +87,10 @@ func UpdateWithRetry(ctx context.Context, c client.Client, obj client.Object, f 
 			if options.statusUpdate {
 				err := c.Status().Update(ctx, obj)
 				if err != nil {
+					if apierrors.IsNotFound(err) {
+						return nil
+					}
+
 					return fmt.Errorf("status update: %w", err)
 				}
 
@@ -95,6 +99,10 @@ func UpdateWithRetry(ctx context.Context, c client.Client, obj client.Object, f 
 
 			err := c.Update(ctx, obj)
 			if err != nil {
+				if apierrors.IsNotFound(err) {
+					return nil
+				}
+
 				return fmt.Errorf("update: %w", err)
 			}
 

--- a/deckhouse-controller/pkg/controller/ctrlutils/update_test.go
+++ b/deckhouse-controller/pkg/controller/ctrlutils/update_test.go
@@ -1,0 +1,93 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ctrlutils
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
+)
+
+// TestUpdateStatusWithRetry_ConcurrentDelete reproduces the startup crash where a
+// Module CR is still resolvable on the initial Get, but is deleted by another actor
+// (another controller, a background loop, cache/apiserver skew) before Status().Update
+// runs, so the API server answers NotFound. Such a concurrent deletion means there is
+// nothing left to update and must NOT be treated as a fatal error.
+func TestUpdateStatusWithRetry_ConcurrentDelete(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1alpha1.SchemeBuilder.AddToScheme(scheme))
+
+	module := &v1alpha1.Module{
+		ObjectMeta: metav1.ObjectMeta{Name: "prometheus-metrics-adapter"},
+		Properties: v1alpha1.ModuleProperties{Source: v1alpha1.ModuleSourceEmbedded},
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(module).
+		WithStatusSubresource(&v1alpha1.Module{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			// Simulate the object being deleted concurrently between the Get inside
+			// UpdateWithRetry and this status update.
+			SubResourceUpdate: func(_ context.Context, _ client.Client, _ string, obj client.Object, _ ...client.SubResourceUpdateOption) error {
+				return apierrors.NewNotFound(v1alpha1.ModuleGVR.GroupResource(), obj.GetName())
+			},
+		}).
+		Build()
+
+	err := UpdateStatusWithRetry(context.Background(), cl, module, func() error {
+		module.SetConditionUnknown(v1alpha1.ModuleConditionEnabledByModuleConfig, "", "")
+		return nil
+	})
+
+	require.NoError(t, err, "a concurrent delete during status update must not be fatal")
+}
+
+// TestUpdateWithRetry_ConcurrentDelete is the same guarantee for the non-status Update path.
+func TestUpdateWithRetry_ConcurrentDelete(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1alpha1.SchemeBuilder.AddToScheme(scheme))
+
+	module := &v1alpha1.Module{
+		ObjectMeta: metav1.ObjectMeta{Name: "prometheus-metrics-adapter"},
+		Properties: v1alpha1.ModuleProperties{Source: v1alpha1.ModuleSourceEmbedded},
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(module).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(_ context.Context, _ client.WithWatch, obj client.Object, _ ...client.UpdateOption) error {
+				return apierrors.NewNotFound(v1alpha1.ModuleGVR.GroupResource(), obj.GetName())
+			},
+		}).
+		Build()
+
+	err := UpdateWithRetry(context.Background(), cl, module, func() error {
+		module.Properties.Version = "v1.2.3"
+		return nil
+	})
+
+	require.NoError(t, err, "a concurrent delete during update must not be fatal")
+}

--- a/deckhouse-controller/pkg/controller/moduleloader/cleanup_test.go
+++ b/deckhouse-controller/pkg/controller/moduleloader/cleanup_test.go
@@ -1,0 +1,63 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package moduleloader
+
+import (
+	"context"
+	"testing"
+
+	addonmodules "github.com/flant/addon-operator/pkg/module_manager/models/modules"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
+	"github.com/deckhouse/deckhouse/go_lib/dependency"
+	"github.com/deckhouse/deckhouse/pkg/log"
+)
+
+// TestCleanupDeletedModules_ConcurrentDelete reproduces the startup crash: a Module CR
+// with no matching ModuleConfig is deleted by another actor while cleanupDeletedModules
+// is updating its EnabledByModuleConfig condition. The status update then hits the API
+// server with NotFound. This must not abort controller startup.
+func TestCleanupDeletedModules_ConcurrentDelete(t *testing.T) {
+	// source != Embedded so the module skips the delete branch and reaches the
+	// status-update branch — the exact path that crashed on prometheus-metrics-adapter.
+	module := testModule("prometheus-metrics-adapter", "deckhouse")
+
+	cl := fake.NewClientBuilder().
+		WithScheme(newTestScheme(t)).
+		WithObjects(module).
+		WithStatusSubresource(&v1alpha1.Module{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			// Another actor deletes the module between the Get and the status update.
+			SubResourceUpdate: func(_ context.Context, _ client.Client, _ string, obj client.Object, _ ...client.SubResourceUpdateOption) error {
+				return apierrors.NewNotFound(v1alpha1.ModuleGVR.GroupResource(), obj.GetName())
+			},
+		}).
+		Build()
+
+	l := &Loader{
+		client:              cl,
+		logger:              log.NewNop(),
+		registries:          make(map[string]*addonmodules.Registry),
+		dependencyContainer: dependency.NewDependencyContainer(),
+	}
+
+	require.NoError(t, l.cleanupDeletedModules(context.Background()),
+		"a Module deleted concurrently during status update must not fail cleanup")
+}

--- a/deckhouse-controller/pkg/controller/moduleloader/loader.go
+++ b/deckhouse-controller/pkg/controller/moduleloader/loader.go
@@ -410,6 +410,10 @@ func (l *Loader) cleanupDeletedModules(ctx context.Context) error {
 			}
 			deletedCount++
 			deleteSpan.End()
+
+			// The module has just been deleted; skip the status update below so we
+			// don't try to update a non-existent module.
+			continue
 		}
 
 		var found bool


### PR DESCRIPTION
## Description

`cleanupDeletedModules` updates a `Module`'s status during controller startup. If the `Module` is deleted concurrently (by another controller, a background loop, or cache/apiserver skew) between the `Get` and the `Status().Update`, the API server returns `NotFound` — and this aborted the whole `deckhouse-controller` startup with:

start deckhouse controller: load modules from fs: cleanup deleted modules: update status for the '<module>' module: on error: status update: modules.deckhouse.io "<module>" not found

The root cause is an asymmetry in `UpdateWithRetry` (`ctrlutils/update.go`): `NotFound` was ignored on the `Get` but treated as fatal on the write.

**Changes:**
- `ctrlutils/update.go` — treat `NotFound` from `Update` / `Status().Update` as success (nothing left to update), mirroring the existing `Get` handling.
- `moduleloader/loader.go` — `continue` after deleting an orphaned embedded module in `cleanupDeletedModules`, so its status is never touched afterwards.
- Added deterministic tests that reproduce the concurrent-delete race via a fake-client interceptor (`update_test.go`, `cleanup_test.go`); they fail on the old code with the exact production error and pass with the fix.

## Why do we need it, and what problem does it solve?

A single `Module` object deleted at the wrong moment could crash `deckhouse-controller` on startup and send it into CrashLoopBackOff, taking down the platform control plane. This was hit in production on `prometheus-metrics-adapter` (an embedded→source-migrated module whose stale on-disk state under `/var/lib/deckhouse` kept it from loading), and the only workaround was manually wiping `/var/lib/deckhouse/*`. The fix removes the crash entirely: a concurrent deletion during a status update is now a no-op instead of a fatal error, so startup stays resilient regardless of on-disk state or reconcile timing.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: Fix startup crash when a Module is deleted concurrently during its status update.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
