### PR TITLE
[ci] Fix extract images_digests

### DIFF
--- a/.github/ci_templates/build.yml
+++ b/.github/ci_templates/build.yml
@@ -372,14 +372,15 @@ steps:
   - name: Extract images_digests.json
     env:
       DEV_REGISTRY: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_HOST }}
-      CI_COMMIT_REF_SLUG: ${{needs.pull_request_info.outputs.ref_slug}}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
     run: |
       set -euo pipefail
-      if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
-        IMAGE_EDITION=${WERF_ENV,,}
-      fi
       REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
-      IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+      if [[ ${REPO_SUFFIX} == ${GITHUB_REPOSITORY} ]] ; then
+        IMAGE_TAG="pr${PR_NUMBER}"
+      else
+        IMAGE_TAG="pr${PR_NUMBER}-${REPO_SUFFIX}"
+      fi
       regctl image get-file "${DEV_REGISTRY}/sys/deckhouse-oss:${IMAGE_TAG}" \
         /deckhouse/modules/images_digests.json > images_digests.json
       modules=$(jq 'keys | length' images_digests.json)

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -744,14 +744,15 @@ jobs:
       - name: Extract images_digests.json
         env:
           DEV_REGISTRY: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_HOST }}
-          CI_COMMIT_REF_SLUG: ${{needs.pull_request_info.outputs.ref_slug}}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
-          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
-            IMAGE_EDITION=${WERF_ENV,,}
-          fi
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          if [[ ${REPO_SUFFIX} == ${GITHUB_REPOSITORY} ]] ; then
+            IMAGE_TAG="pr${PR_NUMBER}"
+          else
+            IMAGE_TAG="pr${PR_NUMBER}-${REPO_SUFFIX}"
+          fi
           regctl image get-file "${DEV_REGISTRY}/sys/deckhouse-oss:${IMAGE_TAG}" \
             /deckhouse/modules/images_digests.json > images_digests.json
           modules=$(jq 'keys | length' images_digests.json)
@@ -1456,14 +1457,15 @@ jobs:
       - name: Extract images_digests.json
         env:
           DEV_REGISTRY: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_HOST }}
-          CI_COMMIT_REF_SLUG: ${{needs.pull_request_info.outputs.ref_slug}}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
-          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
-            IMAGE_EDITION=${WERF_ENV,,}
-          fi
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          if [[ ${REPO_SUFFIX} == ${GITHUB_REPOSITORY} ]] ; then
+            IMAGE_TAG="pr${PR_NUMBER}"
+          else
+            IMAGE_TAG="pr${PR_NUMBER}-${REPO_SUFFIX}"
+          fi
           regctl image get-file "${DEV_REGISTRY}/sys/deckhouse-oss:${IMAGE_TAG}" \
             /deckhouse/modules/images_digests.json > images_digests.json
           modules=$(jq 'keys | length' images_digests.json)
@@ -1870,14 +1872,15 @@ jobs:
       - name: Extract images_digests.json
         env:
           DEV_REGISTRY: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_HOST }}
-          CI_COMMIT_REF_SLUG: ${{needs.pull_request_info.outputs.ref_slug}}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
-          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
-            IMAGE_EDITION=${WERF_ENV,,}
-          fi
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          if [[ ${REPO_SUFFIX} == ${GITHUB_REPOSITORY} ]] ; then
+            IMAGE_TAG="pr${PR_NUMBER}"
+          else
+            IMAGE_TAG="pr${PR_NUMBER}-${REPO_SUFFIX}"
+          fi
           regctl image get-file "${DEV_REGISTRY}/sys/deckhouse-oss:${IMAGE_TAG}" \
             /deckhouse/modules/images_digests.json > images_digests.json
           modules=$(jq 'keys | length' images_digests.json)
@@ -2284,14 +2287,15 @@ jobs:
       - name: Extract images_digests.json
         env:
           DEV_REGISTRY: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_HOST }}
-          CI_COMMIT_REF_SLUG: ${{needs.pull_request_info.outputs.ref_slug}}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
-          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
-            IMAGE_EDITION=${WERF_ENV,,}
-          fi
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          if [[ ${REPO_SUFFIX} == ${GITHUB_REPOSITORY} ]] ; then
+            IMAGE_TAG="pr${PR_NUMBER}"
+          else
+            IMAGE_TAG="pr${PR_NUMBER}-${REPO_SUFFIX}"
+          fi
           regctl image get-file "${DEV_REGISTRY}/sys/deckhouse-oss:${IMAGE_TAG}" \
             /deckhouse/modules/images_digests.json > images_digests.json
           modules=$(jq 'keys | length' images_digests.json)
@@ -2698,14 +2702,15 @@ jobs:
       - name: Extract images_digests.json
         env:
           DEV_REGISTRY: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_HOST }}
-          CI_COMMIT_REF_SLUG: ${{needs.pull_request_info.outputs.ref_slug}}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
-          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
-            IMAGE_EDITION=${WERF_ENV,,}
-          fi
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          if [[ ${REPO_SUFFIX} == ${GITHUB_REPOSITORY} ]] ; then
+            IMAGE_TAG="pr${PR_NUMBER}"
+          else
+            IMAGE_TAG="pr${PR_NUMBER}-${REPO_SUFFIX}"
+          fi
           regctl image get-file "${DEV_REGISTRY}/sys/deckhouse-oss:${IMAGE_TAG}" \
             /deckhouse/modules/images_digests.json > images_digests.json
           modules=$(jq 'keys | length' images_digests.json)
@@ -3112,14 +3117,15 @@ jobs:
       - name: Extract images_digests.json
         env:
           DEV_REGISTRY: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_HOST }}
-          CI_COMMIT_REF_SLUG: ${{needs.pull_request_info.outputs.ref_slug}}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
-          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
-            IMAGE_EDITION=${WERF_ENV,,}
-          fi
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          if [[ ${REPO_SUFFIX} == ${GITHUB_REPOSITORY} ]] ; then
+            IMAGE_TAG="pr${PR_NUMBER}"
+          else
+            IMAGE_TAG="pr${PR_NUMBER}-${REPO_SUFFIX}"
+          fi
           regctl image get-file "${DEV_REGISTRY}/sys/deckhouse-oss:${IMAGE_TAG}" \
             /deckhouse/modules/images_digests.json > images_digests.json
           modules=$(jq 'keys | length' images_digests.json)
@@ -3525,14 +3531,15 @@ jobs:
       - name: Extract images_digests.json
         env:
           DEV_REGISTRY: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_HOST }}
-          CI_COMMIT_REF_SLUG: ${{needs.pull_request_info.outputs.ref_slug}}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
-          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
-            IMAGE_EDITION=${WERF_ENV,,}
-          fi
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          if [[ ${REPO_SUFFIX} == ${GITHUB_REPOSITORY} ]] ; then
+            IMAGE_TAG="pr${PR_NUMBER}"
+          else
+            IMAGE_TAG="pr${PR_NUMBER}-${REPO_SUFFIX}"
+          fi
           regctl image get-file "${DEV_REGISTRY}/sys/deckhouse-oss:${IMAGE_TAG}" \
             /deckhouse/modules/images_digests.json > images_digests.json
           modules=$(jq 'keys | length' images_digests.json)

--- a/.github/workflows/reproducibility-check.yml
+++ b/.github/workflows/reproducibility-check.yml
@@ -1113,14 +1113,15 @@ jobs:
       - name: Extract images_digests.json
         env:
           DEV_REGISTRY: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_HOST }}
-          CI_COMMIT_REF_SLUG: ${{needs.pull_request_info.outputs.ref_slug}}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
-          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
-            IMAGE_EDITION=${WERF_ENV,,}
-          fi
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+          if [[ ${REPO_SUFFIX} == ${GITHUB_REPOSITORY} ]] ; then
+            IMAGE_TAG="pr${PR_NUMBER}"
+          else
+            IMAGE_TAG="pr${PR_NUMBER}-${REPO_SUFFIX}"
+          fi
           regctl image get-file "${DEV_REGISTRY}/sys/deckhouse-oss:${IMAGE_TAG}" \
             /deckhouse/modules/images_digests.json > images_digests.json
           modules=$(jq 'keys | length' images_digests.json)


### PR DESCRIPTION
## Description
Fix extract images_digests.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: fix
summary: Fix extract images_digests.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
