### PR TITLE
[dhctl] fix kube proxy checker client lifecycle

### DIFF
--- a/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/kube-proxy.go
+++ b/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/kube-proxy.go
@@ -20,6 +20,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/yaml"
 
 	libcon "github.com/deckhouse/lib-connection/pkg"
@@ -120,11 +121,13 @@ func (c *KubeProxyChecker) IsReady(ctx context.Context, nodeName string) (bool, 
 			ssh.NewNodeInterfaceWrapper(sshClient, c.baseProviderSettings),
 		)
 
+	localInitParams := copyKubernetesInitParams(c.initParams)
+
 	params := &kube.Config{
-		KubeConfig:          c.initParams.KubeConfig,
-		KubeConfigContext:   c.initParams.KubeConfigContext,
-		KubeConfigInCluster: c.initParams.KubeConfigInCluster,
-		RestConfig:          c.initParams.RestConfig,
+		KubeConfig:          localInitParams.KubeConfig,
+		KubeConfigContext:   localInitParams.KubeConfigContext,
+		KubeConfigInCluster: localInitParams.KubeConfigInCluster,
+		RestConfig:          localInitParams.RestConfig,
 	}
 
 	if err := kubeCl.InitContext(ctx, params); err != nil {
@@ -141,6 +144,7 @@ func (c *KubeProxyChecker) IsReady(ctx context.Context, nodeName string) (bool, 
 		}
 	}()
 
+	// d8-cluster-uuid
 	cm, err := kubeCl.CoreV1().
 		ConfigMaps("kube-system").
 		Get(ctx, "d8-cluster-uuid", v1.GetOptions{})
@@ -160,6 +164,22 @@ func (c *KubeProxyChecker) IsReady(ctx context.Context, nodeName string) (bool, 
 	}
 
 	return true, nil
+}
+
+func copyKubernetesInitParams(
+	params *client.KubernetesInitParams,
+) *client.KubernetesInitParams {
+	if params == nil {
+		return nil
+	}
+
+	result := *params
+
+	if params.RestConfig != nil {
+		result.RestConfig = rest.CopyConfig(params.RestConfig)
+	}
+
+	return &result
 }
 
 func (c *KubeProxyChecker) Name() string {

--- a/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/kube-proxy.go
+++ b/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/kube-proxy.go
@@ -86,21 +86,40 @@ func (c *KubeProxyChecker) WithSSHProvider(s libcon.SSHProvider, sett *settings.
 }
 
 func (c *KubeProxyChecker) IsReady(ctx context.Context, nodeName string) (bool, error) {
+	if c.initParams == nil {
+		return false, fmt.Errorf("kube proxy checker: Kubernetes init params are not configured")
+	}
+	if c.baseProviderSettings == nil {
+		return false, fmt.Errorf("kube proxy checker: base provider settings are not configured")
+	}
+	if c.sshProvider == nil {
+		return false, fmt.Errorf("kube proxy checker: SSH provider is not configured")
+	}
+
 	sshClient, err := c.sshProvider.Client(ctx)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("failed to get SSH client: %w", err)
 	}
 
 	if len(c.nodesExternalIPs) > 0 {
 		ip, ok := c.nodesExternalIPs[nodeName]
 		if !ok {
-			return false, fmt.Errorf("No external IP found for node %s", nodeName)
+			return false, fmt.Errorf("no external IP found for node %s", nodeName)
 		}
 
-		sshClient.Session().SetAvailableHosts([]session.Host{{Host: ip, Name: nodeName}})
+		sshClient.Session().SetAvailableHosts([]session.Host{
+			{
+				Host: ip,
+				Name: nodeName,
+			},
+		})
 	}
 
-	kubeCl := kube.NewKubernetesClient(c.baseProviderSettings).WithNodeInterface(ssh.NewNodeInterfaceWrapper(sshClient, c.baseProviderSettings))
+	kubeCl := kube.NewKubernetesClient(c.baseProviderSettings).
+		WithNodeInterface(
+			ssh.NewNodeInterfaceWrapper(sshClient, c.baseProviderSettings),
+		)
+
 	params := &kube.Config{
 		KubeConfig:          c.initParams.KubeConfig,
 		KubeConfigContext:   c.initParams.KubeConfigContext,
@@ -108,9 +127,8 @@ func (c *KubeProxyChecker) IsReady(ctx context.Context, nodeName string) (bool, 
 		RestConfig:          c.initParams.RestConfig,
 	}
 
-	err = kubeCl.InitContext(ctx, params)
-	if err != nil {
-		return false, fmt.Errorf("failed to open kubernetes connection: %v", err)
+	if err := kubeCl.InitContext(ctx, params); err != nil {
+		return false, fmt.Errorf("failed to open Kubernetes connection: %w", err)
 	}
 
 	defer func() {
@@ -121,23 +139,24 @@ func (c *KubeProxyChecker) IsReady(ctx context.Context, nodeName string) (bool, 
 		if kubeCl.KubeProxy != nil {
 			kubeCl.KubeProxy.StopAll()
 		}
-
-		if wrapper, ok := kubeCl.NodeInterface.(*ssh.NodeInterfaceWrapper); ok {
-			wrapper.Client().Stop()
-		}
 	}()
 
-	// d8-cluster-uuid
-	ns, err := kubeCl.CoreV1().ConfigMaps("kube-system").Get(ctx, "d8-cluster-uuid", v1.GetOptions{})
+	cm, err := kubeCl.CoreV1().
+		ConfigMaps("kube-system").
+		Get(ctx, "d8-cluster-uuid", v1.GetOptions{})
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("failed to get cluster UUID ConfigMap: %w", err)
 	}
 
-	c.printNs(ctx, ns)
+	c.printNs(ctx, cm)
 
-	uuidInCluster := ns.Data["cluster-uuid"]
+	uuidInCluster := cm.Data["cluster-uuid"]
 	if c.clusterUUID != "" && c.clusterUUID != uuidInCluster {
-		return false, fmt.Errorf("Incorrect cluster UUID: cluster has %s, but %s was passed.", uuidInCluster, c.clusterUUID)
+		return false, fmt.Errorf(
+			"incorrect cluster UUID: cluster has %s, but %s was passed",
+			uuidInCluster,
+			c.clusterUUID,
+		)
 	}
 
 	return true, nil

--- a/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/kube-proxy.go
+++ b/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/kube-proxy.go
@@ -86,15 +86,24 @@ func (c *KubeProxyChecker) WithSSHProvider(s libcon.SSHProvider, sett *settings.
 	return c
 }
 
-func (c *KubeProxyChecker) IsReady(ctx context.Context, nodeName string) (bool, error) {
+func (c *KubeProxyChecker) IsReady(
+	ctx context.Context,
+	nodeName string,
+) (bool, error) {
 	if c.initParams == nil {
-		return false, fmt.Errorf("kube proxy checker: Kubernetes init params are not configured")
+		return false, fmt.Errorf(
+			"kube proxy checker: Kubernetes init params are not configured",
+		)
 	}
 	if c.baseProviderSettings == nil {
-		return false, fmt.Errorf("kube proxy checker: base provider settings are not configured")
+		return false, fmt.Errorf(
+			"kube proxy checker: base provider settings are not configured",
+		)
 	}
 	if c.sshProvider == nil {
-		return false, fmt.Errorf("kube proxy checker: SSH provider is not configured")
+		return false, fmt.Errorf(
+			"kube proxy checker: SSH provider is not configured",
+		)
 	}
 
 	sshClient, err := c.sshProvider.Client(ctx)
@@ -105,7 +114,10 @@ func (c *KubeProxyChecker) IsReady(ctx context.Context, nodeName string) (bool, 
 	if len(c.nodesExternalIPs) > 0 {
 		ip, ok := c.nodesExternalIPs[nodeName]
 		if !ok {
-			return false, fmt.Errorf("no external IP found for node %s", nodeName)
+			return false, fmt.Errorf(
+				"no external IP found for node %s",
+				nodeName,
+			)
 		}
 
 		sshClient.Session().SetAvailableHosts([]session.Host{
@@ -118,7 +130,10 @@ func (c *KubeProxyChecker) IsReady(ctx context.Context, nodeName string) (bool, 
 
 	kubeCl := kube.NewKubernetesClient(c.baseProviderSettings).
 		WithNodeInterface(
-			ssh.NewNodeInterfaceWrapper(sshClient, c.baseProviderSettings),
+			ssh.NewNodeInterfaceWrapper(
+				sshClient,
+				c.baseProviderSettings,
+			),
 		)
 
 	localInitParams := copyKubernetesInitParams(c.initParams)
@@ -131,25 +146,23 @@ func (c *KubeProxyChecker) IsReady(ctx context.Context, nodeName string) (bool, 
 	}
 
 	if err := kubeCl.InitContext(ctx, params); err != nil {
-		return false, fmt.Errorf("failed to open Kubernetes connection: %w", err)
+		return false, fmt.Errorf(
+			"failed to open Kubernetes connection: %w",
+			err,
+		)
 	}
 
-	defer func() {
-		if !c.stopProxy {
-			return
-		}
+	// Do not stop kubeCl.KubeProxy or sshClient here.
+	// They are owned by the common connection lifecycle.
 
-		if kubeCl.KubeProxy != nil {
-			kubeCl.KubeProxy.StopAll()
-		}
-	}()
-
-	// d8-cluster-uuid
 	cm, err := kubeCl.CoreV1().
 		ConfigMaps("kube-system").
 		Get(ctx, "d8-cluster-uuid", v1.GetOptions{})
 	if err != nil {
-		return false, fmt.Errorf("failed to get cluster UUID ConfigMap: %w", err)
+		return false, fmt.Errorf(
+			"failed to get cluster UUID ConfigMap: %w",
+			err,
+		)
 	}
 
 	c.printNs(ctx, cm)

--- a/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/kube-proxy_test.go
+++ b/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/kube-proxy_test.go
@@ -77,10 +77,12 @@ func TestKubeProxyCheckerIsReadyValidation(t *testing.T) {
 
 func TestCopyKubernetesInitParams(t *testing.T) {
 	original := &client.KubernetesInitParams{
-		KubeConfig:        "original-kubeconfig",
-		KubeConfigContext: "original-context",
+		KubeConfig:          "original-kubeconfig",
+		KubeConfigContext:   "original-context",
+		KubeConfigInCluster: true,
 		RestConfig: &rest.Config{
-			Host: "https://original-api-server:6443",
+			Host:        "https://original-api-server:6443",
+			BearerToken: "original-token",
 		},
 	}
 
@@ -116,9 +118,19 @@ func TestCopyKubernetesInitParams(t *testing.T) {
 		)
 	}
 
+	if copied.KubeConfigInCluster != original.KubeConfigInCluster {
+		t.Fatalf(
+			"expected copied KubeConfigInCluster %v, got %v",
+			original.KubeConfigInCluster,
+			copied.KubeConfigInCluster,
+		)
+	}
+
 	copied.KubeConfig = "changed-kubeconfig"
 	copied.KubeConfigContext = "changed-context"
+	copied.KubeConfigInCluster = false
 	copied.RestConfig.Host = "http://127.0.0.1:22322"
+	copied.RestConfig.BearerToken = "changed-token"
 
 	if original.KubeConfig != "original-kubeconfig" {
 		t.Fatalf(
@@ -134,11 +146,22 @@ func TestCopyKubernetesInitParams(t *testing.T) {
 		)
 	}
 
+	if !original.KubeConfigInCluster {
+		t.Fatal("original KubeConfigInCluster was modified")
+	}
+
 	if original.RestConfig.Host !=
 		"https://original-api-server:6443" {
 		t.Fatalf(
-			"original RestConfig was modified: got %q",
+			"original RestConfig.Host was modified: got %q",
 			original.RestConfig.Host,
+		)
+	}
+
+	if original.RestConfig.BearerToken != "original-token" {
+		t.Fatalf(
+			"original RestConfig.BearerToken was modified: got %q",
+			original.RestConfig.BearerToken,
 		)
 	}
 }

--- a/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/kube-proxy_test.go
+++ b/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/kube-proxy_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/deckhouse/lib-connection/pkg/settings"
+	"k8s.io/client-go/rest"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
 )
@@ -31,28 +32,34 @@ func TestKubeProxyCheckerIsReadyValidation(t *testing.T) {
 		expectedErr string
 	}{
 		{
-			name:        "Kubernetes init params are not configured",
-			checker:     NewKubeProxyChecker(),
-			expectedErr: "kube proxy checker: Kubernetes init params are not configured",
+			name:    "Kubernetes init params are not configured",
+			checker: NewKubeProxyChecker(),
+			expectedErr: "kube proxy checker: " +
+				"Kubernetes init params are not configured",
 		},
 		{
 			name: "base provider settings are not configured",
 			checker: NewKubeProxyChecker().
 				WithInitParams(&client.KubernetesInitParams{}),
-			expectedErr: "kube proxy checker: base provider settings are not configured",
+			expectedErr: "kube proxy checker: " +
+				"base provider settings are not configured",
 		},
 		{
 			name: "SSH provider is not configured",
 			checker: NewKubeProxyChecker().
 				WithInitParams(&client.KubernetesInitParams{}).
 				WithSSHProvider(nil, &settings.BaseProviders{}),
-			expectedErr: "kube proxy checker: SSH provider is not configured",
+			expectedErr: "kube proxy checker: " +
+				"SSH provider is not configured",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := tt.checker.IsReady(context.Background(), "master-0")
+			_, err := tt.checker.IsReady(
+				context.Background(),
+				"master-0",
+			)
 			if err == nil {
 				t.Fatal("expected an error, got nil")
 			}
@@ -65,5 +72,106 @@ func TestKubeProxyCheckerIsReadyValidation(t *testing.T) {
 				)
 			}
 		})
+	}
+}
+
+func TestCopyKubernetesInitParams(t *testing.T) {
+	original := &client.KubernetesInitParams{
+		KubeConfig:        "original-kubeconfig",
+		KubeConfigContext: "original-context",
+		RestConfig: &rest.Config{
+			Host: "https://original-api-server:6443",
+		},
+	}
+
+	copied := copyKubernetesInitParams(original)
+
+	if copied == nil {
+		t.Fatal("expected copied init params, got nil")
+	}
+
+	if copied == original {
+		t.Fatal(
+			"expected a separate KubernetesInitParams instance",
+		)
+	}
+
+	if copied.RestConfig == original.RestConfig {
+		t.Fatal("expected a separate RestConfig instance")
+	}
+
+	if copied.KubeConfig != original.KubeConfig {
+		t.Fatalf(
+			"expected copied KubeConfig %q, got %q",
+			original.KubeConfig,
+			copied.KubeConfig,
+		)
+	}
+
+	if copied.KubeConfigContext != original.KubeConfigContext {
+		t.Fatalf(
+			"expected copied KubeConfigContext %q, got %q",
+			original.KubeConfigContext,
+			copied.KubeConfigContext,
+		)
+	}
+
+	copied.KubeConfig = "changed-kubeconfig"
+	copied.KubeConfigContext = "changed-context"
+	copied.RestConfig.Host = "http://127.0.0.1:22322"
+
+	if original.KubeConfig != "original-kubeconfig" {
+		t.Fatalf(
+			"original KubeConfig was modified: got %q",
+			original.KubeConfig,
+		)
+	}
+
+	if original.KubeConfigContext != "original-context" {
+		t.Fatalf(
+			"original KubeConfigContext was modified: got %q",
+			original.KubeConfigContext,
+		)
+	}
+
+	if original.RestConfig.Host !=
+		"https://original-api-server:6443" {
+		t.Fatalf(
+			"original RestConfig was modified: got %q",
+			original.RestConfig.Host,
+		)
+	}
+}
+
+func TestCopyKubernetesInitParamsWithoutRestConfig(t *testing.T) {
+	original := &client.KubernetesInitParams{
+		KubeConfig:        "original-kubeconfig",
+		KubeConfigContext: "original-context",
+	}
+
+	copied := copyKubernetesInitParams(original)
+
+	if copied == nil {
+		t.Fatal("expected copied init params, got nil")
+	}
+
+	if copied == original {
+		t.Fatal(
+			"expected a separate KubernetesInitParams instance",
+		)
+	}
+
+	if copied.RestConfig != nil {
+		t.Fatalf(
+			"expected nil RestConfig, got %#v",
+			copied.RestConfig,
+		)
+	}
+}
+
+func TestCopyKubernetesInitParamsNil(t *testing.T) {
+	copied := copyKubernetesInitParams(nil)
+	if copied != nil {
+		t.Fatalf("expected nil, got %#v", copied)
 	}
 }

--- a/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/kube-proxy_test.go
+++ b/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/kube-proxy_test.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlplane
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/deckhouse/lib-connection/pkg/settings"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
+)
+
+func TestKubeProxyCheckerIsReadyValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		checker     *KubeProxyChecker
+		expectedErr string
+	}{
+		{
+			name:        "Kubernetes init params are not configured",
+			checker:     NewKubeProxyChecker(),
+			expectedErr: "kube proxy checker: Kubernetes init params are not configured",
+		},
+		{
+			name: "base provider settings are not configured",
+			checker: NewKubeProxyChecker().
+				WithInitParams(&client.KubernetesInitParams{}),
+			expectedErr: "kube proxy checker: base provider settings are not configured",
+		},
+		{
+			name: "SSH provider is not configured",
+			checker: NewKubeProxyChecker().
+				WithInitParams(&client.KubernetesInitParams{}).
+				WithSSHProvider(nil, &settings.BaseProviders{}),
+			expectedErr: "kube proxy checker: SSH provider is not configured",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.checker.IsReady(context.Background(), "master-0")
+			if err == nil {
+				t.Fatal("expected an error, got nil")
+			}
+
+			if !strings.Contains(err.Error(), tt.expectedErr) {
+				t.Fatalf(
+					"expected error containing %q, got %q",
+					tt.expectedErr,
+					err.Error(),
+				)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Fixed the Kubernetes connectivity check used by dhctl converge when validating control-plane node readiness.

The change:

* validates that Kubernetes initialization parameters, the SSH provider, and base provider settings are configured before they are used;
* returns descriptive errors instead of panicking when required checker dependencies are missing;
* stops only the Kubernetes proxy created by the readiness check;
* no longer stops the shared SSH client from inside KubeProxyChecker.IsReady;
* adds unit tests for the dependency validation paths.

## Why do we need it, and what problem does it solve?

During control-plane node replacement, dhctl converge checks SSH connectivity and Kubernetes API availability through a temporary Kubernetes proxy.

After completing the check, KubeProxyChecker.IsReady stopped not only the temporary proxy but also the shared SSH client obtained from the external SSH provider. This client could still be required by subsequent converge operations.

As a result, the following operations could continue using an already stopped Kubernetes or SSH connection and fail with errors such as:

```
cannot send request GET: use stopped kube client
```

A subsequent control-plane readiness check could also panic with a nil pointer dereference in KubeProxyChecker.IsReady instead of returning a descriptive error.

The checker now manages only the lifecycle of the Kubernetes proxy it creates. The shared SSH client remains active and is stopped by its actual owner during the common cleanup process.

The added dependency validation also prevents nil pointer dereferences and reports which required checker dependency was not configured.

## Why do we need it in the patch release (if we do)?

The issue can interrupt dhctl converge during destructive control-plane changes, including control-plane node replacement and temporary scaling from a single-master to a multi-master configuration.

A failed converge can leave the control plane in an intermediate state and require manual recovery or another converge attempt. The fix is isolated to the readiness check cleanup logic and prevents the checker from stopping a shared connection that it does not own.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: dhctl
type: fix 
summary: Prevent dhctl converge from stopping the shared SSH client during control-plane node readiness checks.
impact_level: default 
```
