### PR TITLE
[control-plane-manager] remove crb from template

### DIFF
--- a/modules/040-control-plane-manager/hooks/reconcile_kubeadm_cluster_admins_binding.go
+++ b/modules/040-control-plane-manager/hooks/reconcile_kubeadm_cluster_admins_binding.go
@@ -25,11 +25,13 @@ limitations under the License.
 // on cluster-admin (kubeadm-default wildcard). The supplement (extra ClusterRole bound to the same
 // kubeadm:cluster-admins group) is enabled while user-authz is on (single gate).
 //
-// The hook publishes its decision into Helm values so templates/rbac-for-us.yaml renders verbatim
-// and does NOT re-evaluate the gates:
+// The main kubeadm:cluster-admins binding is owned entirely by this hook: it left the Helm template
+// in v1.77 (Helm orphaned the live object via helm.sh/resource-policy: keep, so no binding gap ever
+// opened). The hook still publishes its decision into Helm values:
 //
-//	controlPlaneManager.internal.kubeadmClusterAdminsTargetRoleName  string
-//	controlPlaneManager.internal.kubeadmClusterAdminsSupplementEnabled bool
+//	controlPlaneManager.internal.kubeadmClusterAdminsTargetRoleName  string  (observability only)
+//	controlPlaneManager.internal.kubeadmClusterAdminsSupplementEnabled bool  (read by the template
+//	                                                                          to gate the supplement)
 //
 // Why a hook is needed at all: ClusterRoleBinding.roleRef is immutable in Kubernetes RBAC, Helm
 // SSA cannot mutate it. We Delete+Create via PatchCollector on OnBeforeHelm, before Helm runs.
@@ -67,18 +69,11 @@ const (
 	kubeadmTargetRoleNameValuePath    = "controlPlaneManager.internal.kubeadmClusterAdminsTargetRoleName"
 	kubeadmSupplementEnabledValuePath = "controlPlaneManager.internal.kubeadmClusterAdminsSupplementEnabled"
 
-	// Helm ownership keys. Helm refuses to adopt a resource that lacks all three; without them
-	// the control-plane-manager release fails on every converge on pre-v1.76 clusters.
-	helmManagedByLabel             = "app.kubernetes.io/managed-by"
-	helmManagedByValue             = "Helm"
-	helmReleaseNameAnnotation      = "meta.helm.sh/release-name"
-	helmReleaseNamespaceAnnotation = "meta.helm.sh/release-namespace"
-	cpmHelmReleaseName             = "control-plane-manager"
-	cpmHelmReleaseNamespace        = "d8-system"
-
-	// resource-policy: keep mirrors the template annotation so the live object always carries it,
-	// even right after the hook (re)creates it. This guards the eventual hook-only migration: when
-	// this CRB is dropped from the Helm template, Helm must not prune it (admin.conf would lose root).
+	// resource-policy: keep is stamped on every object the hook writes. It was the one-time guard for
+	// the v1.77 converge that dropped this CRB from the Helm template: with the annotation on the live
+	// object, Helm orphaned it (kept it) instead of pruning, so kubeadm:cluster-admins never lost its
+	// binding and admin.conf never lost root. After that converge the object is Helm-orphaned and this
+	// hook is its sole owner; the annotation is now a harmless no-op we keep for defence in depth.
 	helmResourcePolicyAnnotation = "helm.sh/resource-policy"
 	helmResourcePolicyKeep       = "keep"
 
@@ -87,10 +82,9 @@ const (
 	forceWildcardClusterAdmin = true
 )
 
-// kubeadmClusterAdminsBindingState keeps the moving pieces of the CRB we care about.
+// kubeadmClusterAdminsBindingState keeps the only moving piece of the CRB we care about.
 type kubeadmClusterAdminsBindingState struct {
-	RoleRefName      string `json:"roleRefName"`
-	HasHelmOwnership bool   `json:"hasHelmOwnership"`
+	RoleRefName string `json:"roleRefName"`
 }
 
 // userAuthzClusterAdminCRState is just a presence marker (snapshot length > 0 == role exists).
@@ -103,12 +97,8 @@ func filterKubeadmClusterAdminsBinding(obj *unstructured.Unstructured) (go_hook.
 	if err := sdk.FromUnstructured(obj, &crb); err != nil {
 		return nil, fmt.Errorf("convert ClusterRoleBinding %s: %w", obj.GetName(), err)
 	}
-	hasHelm := crb.Labels[helmManagedByLabel] == helmManagedByValue &&
-		crb.Annotations[helmReleaseNameAnnotation] == cpmHelmReleaseName &&
-		crb.Annotations[helmReleaseNamespaceAnnotation] == cpmHelmReleaseNamespace
 	return kubeadmClusterAdminsBindingState{
-		RoleRefName:      crb.RoleRef.Name,
-		HasHelmOwnership: hasHelm,
+		RoleRefName: crb.RoleRef.Name,
 	}, nil
 }
 
@@ -166,8 +156,9 @@ func reconcileKubeadmClusterAdminsBindingHook(_ context.Context, input *go_hook.
 		desiredRoleName = userAuthzClusterAdminClusterRoleName
 	}
 
-	// Single source of truth: publish the already-made decision into values so the Helm template
-	// renders verbatim. Helm picks up values updates of OnBeforeHelm hooks before rendering.
+	// Publish the already-made decision into values. supplementEnabled gates the supplement CRB that
+	// is still template-rendered; targetRoleName is exported for observability only (the main binding
+	// is hook-owned). Helm picks up values updates of OnBeforeHelm hooks before rendering.
 	input.Values.Set(kubeadmTargetRoleNameValuePath, desiredRoleName)
 	input.Values.Set(kubeadmSupplementEnabledValuePath, userAuthzEnabled)
 
@@ -194,27 +185,9 @@ func reconcileKubeadmClusterAdminsBindingHook(_ context.Context, input *go_hook.
 
 	current := bindingSnaps[len(bindingSnaps)-1]
 	if current.RoleRefName == desiredRoleName {
-		if !current.HasHelmOwnership {
-			// Pre-v1.76 clusters have this CRB without Helm ownership metadata.
-			// Helm refuses to adopt a resource that lacks all three keys and the release fails.
-			// Patch them in before Helm runs so it can take ownership cleanly.
-			logger.Info("patching helm ownership metadata onto clusterrolebinding")
-			input.PatchCollector.PatchWithMerge(
-				map[string]interface{}{
-					"metadata": map[string]interface{}{
-						"labels": map[string]string{
-							helmManagedByLabel: helmManagedByValue,
-						},
-						"annotations": map[string]string{
-							helmReleaseNameAnnotation:      cpmHelmReleaseName,
-							helmReleaseNamespaceAnnotation: cpmHelmReleaseNamespace,
-							helmResourcePolicyAnnotation:   helmResourcePolicyKeep,
-						},
-					},
-				},
-				rbacv1.SchemeGroupVersion.String(), "ClusterRoleBinding", "", kubeadmClusterAdminsBindingName,
-			)
-		}
+		// roleRef already correct: nothing to do. The hook does not touch ownership metadata — the
+		// object is Helm-orphaned (or hook-created) and this hook is its sole owner. Any residual Helm
+		// labels inherited from the pre-v1.77 template are left untouched; Helm no longer manages it.
 		return nil
 	}
 
@@ -224,9 +197,10 @@ func reconcileKubeadmClusterAdminsBindingHook(_ context.Context, input *go_hook.
 	return nil
 }
 
-// buildKubeadmClusterAdminsBinding renders the desired ClusterRoleBinding state.
-// Helm ownership metadata is included so that Helm can adopt the object on the next release run,
-// and helm.sh/resource-policy: keep is set so Helm never prunes it (mirrors the template).
+// buildKubeadmClusterAdminsBinding renders the desired ClusterRoleBinding state. This hook is the
+// sole owner of the object (it left the Helm template in v1.77), so no Helm ownership metadata is
+// set. helm.sh/resource-policy: keep is still stamped: it is the guard for the drop-from-template
+// converge (if the hook (re)creates the CRB right before that Helm run, keep prevents a prune).
 func buildKubeadmClusterAdminsBinding(roleName string) *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{
 		TypeMeta: metav1.TypeMeta{
@@ -236,14 +210,11 @@ func buildKubeadmClusterAdminsBinding(roleName string) *rbacv1.ClusterRoleBindin
 		ObjectMeta: metav1.ObjectMeta{
 			Name: kubeadmClusterAdminsBindingName,
 			Labels: map[string]string{
-				"heritage":         "deckhouse",
-				"module":           "control-plane-manager",
-				helmManagedByLabel: helmManagedByValue,
+				"heritage": "deckhouse",
+				"module":   "control-plane-manager",
 			},
 			Annotations: map[string]string{
-				helmReleaseNameAnnotation:      cpmHelmReleaseName,
-				helmReleaseNamespaceAnnotation: cpmHelmReleaseNamespace,
-				helmResourcePolicyAnnotation:   helmResourcePolicyKeep,
+				helmResourcePolicyAnnotation: helmResourcePolicyKeep,
 			},
 		},
 		RoleRef: rbacv1.RoleRef{

--- a/modules/040-control-plane-manager/hooks/reconcile_kubeadm_cluster_admins_binding_test.go
+++ b/modules/040-control-plane-manager/hooks/reconcile_kubeadm_cluster_admins_binding_test.go
@@ -149,11 +149,23 @@ rules:
 		Expect(f.ValuesGet(supplementEnabledPath).Bool()).To(Equal(supplementEnabled))
 	}
 
+	// expectHelmOwnership asserts pre-existing Helm labels are still present. Since v1.77 the hook no
+	// longer writes them, but it must not strip Helm labels inherited (orphaned) from the pre-v1.77
+	// template — Helm no longer manages the object, so thrashing those labels would be pointless churn.
 	expectHelmOwnership := func(f *HookExecutionConfig) {
 		crb := f.KubernetesGlobalResource("ClusterRoleBinding", "kubeadm:cluster-admins")
 		Expect(crb.Field(`metadata.labels.app\.kubernetes\.io/managed-by`).String()).To(Equal("Helm"))
 		Expect(crb.Field(`metadata.annotations.meta\.helm\.sh/release-name`).String()).To(Equal("control-plane-manager"))
 		Expect(crb.Field(`metadata.annotations.meta\.helm\.sh/release-namespace`).String()).To(Equal("d8-system"))
+	}
+
+	// expectNoHelmOwnership asserts the object the hook wrote carries NO Helm ownership metadata:
+	// since v1.77 the hook is the sole owner and never stamps Helm adoption keys.
+	expectNoHelmOwnership := func(f *HookExecutionConfig) {
+		crb := f.KubernetesGlobalResource("ClusterRoleBinding", "kubeadm:cluster-admins")
+		Expect(crb.Field(`metadata.labels.app\.kubernetes\.io/managed-by`).Exists()).To(BeFalse())
+		Expect(crb.Field(`metadata.annotations.meta\.helm\.sh/release-name`).Exists()).To(BeFalse())
+		Expect(crb.Field(`metadata.annotations.meta\.helm\.sh/release-namespace`).Exists()).To(BeFalse())
 	}
 
 	// expectKeepPolicy guards the hook-only migration: any object the hook writes must carry
@@ -289,18 +301,17 @@ rules:
 		})
 	})
 
-	// ── Helm ownership migration: CRB exists without Helm labels ──
-	Context("user-authz disabled, CRB on cluster-admin WITHOUT Helm labels (pre-v1.76 state)", func() {
+	// ── Hook-only ownership (v1.77+): the hook never writes Helm ownership metadata ──
+	Context("user-authz disabled, CRB on cluster-admin WITHOUT Helm labels", func() {
 		f := HookExecutionConfigInit(valuesUserAuthzOffBootstrapped, "")
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSet(crbCurrentClusterAdmin))
 			f.RunHook()
 		})
-		It("patches Helm ownership onto the existing CRB without changing roleRef", func() {
+		It("is a no-op (roleRef already correct) and does NOT stamp Helm ownership onto the CRB", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			expectDesiredCRB(f, "cluster-admin")
-			expectHelmOwnership(f)
-			expectKeepPolicy(f)
+			expectNoHelmOwnership(f)
 			expectInternalDecision(f, "cluster-admin", false)
 		})
 	})
@@ -311,23 +322,23 @@ rules:
 			f.BindingContexts.Set(f.KubeStateSet(crbUserAuthzClusterAdminWithHelmLabels + userAuthzClusterAdminCR))
 			f.RunHook()
 		})
-		It("rolls the binding back to the wildcard cluster-admin (Delete+Create) and re-stamps Helm ownership + keep", func() {
+		It("rolls the binding back to the wildcard cluster-admin (Delete+Create) with keep and NO Helm ownership", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			expectDesiredCRB(f, "cluster-admin")
-			expectHelmOwnership(f)
+			expectNoHelmOwnership(f)
 			expectKeepPolicy(f)
 			expectInternalDecision(f, "cluster-admin", true)
 		})
 	})
 
-	// ── True no-op: CRB already carries Helm labels ──
-	Context("user-authz disabled, CRB on cluster-admin WITH Helm labels already", func() {
+	// ── True no-op: CRB inherited Helm labels from the pre-v1.77 template ──
+	Context("user-authz disabled, CRB on cluster-admin WITH inherited Helm labels", func() {
 		f := HookExecutionConfigInit(valuesUserAuthzOffBootstrapped, "")
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSet(crbClusterAdminWithHelmLabels))
 			f.RunHook()
 		})
-		It("is a true no-op: roleRef correct and Helm labels already present", func() {
+		It("is a true no-op: roleRef correct and inherited Helm labels are left untouched (not stripped)", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			expectDesiredCRB(f, "cluster-admin")
 			expectHelmOwnership(f)

--- a/modules/040-control-plane-manager/template_tests/template_test.go
+++ b/modules/040-control-plane-manager/template_tests/template_test.go
@@ -1368,24 +1368,21 @@ apiserver:
 		})
 	})
 
-	// The decision (target ClusterRole + whether to render supplement) is made by the
-	// reconcile_kubeadm_cluster_admins_binding hook and published into Helm values. The template
-	// reads .Values.controlPlaneManager.internal.{kubeadmClusterAdminsTargetRoleName,kubeadmClusterAdminsSupplementEnabled}
-	// verbatim, so these tests drive the template directly via those internal values.
+	// The main kubeadm:cluster-admins binding is owned entirely by the reconcile_kubeadm_cluster_admins_binding
+	// hook and is NOT rendered by this template (it left the template in v1.77). The template only renders the
+	// additive supplement, gated by .Values.controlPlaneManager.internal.kubeadmClusterAdminsSupplementEnabled.
 	Context("kubeadm ClusterRoleBinding for admin.conf", func() {
-		Context("hook decision: target=cluster-admin, supplement=false (user-authz off)", func() {
+		Context("hook decision: supplement=false (user-authz off)", func() {
 			BeforeEach(func() {
-				// schema defaults: target=cluster-admin, supplementEnabled=false; render with no overrides.
+				// schema defaults: supplementEnabled=false; render with no overrides.
 				f.HelmRender()
 			})
 
-			It("should bind kubeadm:cluster-admins to cluster-admin and not render the supplement", func() {
+			It("should render neither the hook-owned main binding nor the supplement", func() {
 				Expect(f.RenderError).ShouldNot(HaveOccurred())
+				// The main binding is hook-owned; the template must never render it.
 				crb := f.KubernetesResource("ClusterRoleBinding", "", "kubeadm:cluster-admins")
-				Expect(crb.Exists()).To(BeTrue())
-				Expect(crb.Field("roleRef.name").String()).To(Equal("cluster-admin"))
-				// keep policy must always be present so a future hook-only migration cannot let Helm prune it.
-				Expect(crb.Field(`metadata.annotations.helm\.sh/resource-policy`).String()).To(Equal("keep"))
+				Expect(crb.Exists()).To(BeFalse())
 
 				sup := f.KubernetesResource("ClusterRoleBinding", "", "d8:control-plane-manager:kubeadm-cluster-admins-supplement")
 				Expect(sup.Exists()).To(BeFalse())
@@ -1394,40 +1391,17 @@ apiserver:
 			})
 		})
 
-		Context("hook decision: target=cluster-admin, supplement=true (user-authz on, but at least one of bootstrap/CR-presence gates is false)", func() {
+		Context("hook decision: supplement=true (user-authz on)", func() {
 			BeforeEach(func() {
-				f.ValuesSet("controlPlaneManager.internal.kubeadmClusterAdminsTargetRoleName", "cluster-admin")
 				f.ValuesSet("controlPlaneManager.internal.kubeadmClusterAdminsSupplementEnabled", true)
 				f.HelmRender()
 			})
 
-			It("should keep cluster-admin on main binding but render the supplement (purely additive on the same group)", func() {
+			It("should render the supplement (purely additive on the same group) but never the hook-owned main binding", func() {
 				Expect(f.RenderError).ShouldNot(HaveOccurred())
+				// The main binding is hook-owned; the template must not render it regardless of the hook's target decision.
 				main := f.KubernetesResource("ClusterRoleBinding", "", "kubeadm:cluster-admins")
-				Expect(main.Exists()).To(BeTrue())
-				Expect(main.Field("roleRef.name").String()).To(Equal("cluster-admin"))
-
-				sup := f.KubernetesResource("ClusterRoleBinding", "", "d8:control-plane-manager:kubeadm-cluster-admins-supplement")
-				Expect(sup.Exists()).To(BeTrue())
-				Expect(sup.Field("roleRef.name").String()).To(Equal("d8:control-plane-manager:admin-kubeconfig-supplement"))
-
-				supCR := f.KubernetesResource("ClusterRole", "", "d8:control-plane-manager:admin-kubeconfig-supplement")
-				Expect(supCR.Exists()).To(BeTrue())
-			})
-		})
-
-		Context("hook decision: target=user-authz:cluster-admin, supplement=true (all three gates satisfied)", func() {
-			BeforeEach(func() {
-				f.ValuesSet("controlPlaneManager.internal.kubeadmClusterAdminsTargetRoleName", "user-authz:cluster-admin")
-				f.ValuesSet("controlPlaneManager.internal.kubeadmClusterAdminsSupplementEnabled", true)
-				f.HelmRender()
-			})
-
-			It("should bind kubeadm:cluster-admins to user-authz:cluster-admin and add the supplement binding", func() {
-				Expect(f.RenderError).ShouldNot(HaveOccurred())
-				main := f.KubernetesResource("ClusterRoleBinding", "", "kubeadm:cluster-admins")
-				Expect(main.Exists()).To(BeTrue())
-				Expect(main.Field("roleRef.name").String()).To(Equal("user-authz:cluster-admin"))
+				Expect(main.Exists()).To(BeFalse())
 
 				sup := f.KubernetesResource("ClusterRoleBinding", "", "d8:control-plane-manager:kubeadm-cluster-admins-supplement")
 				Expect(sup.Exists()).To(BeTrue())

--- a/modules/040-control-plane-manager/templates/rbac-for-us.yaml
+++ b/modules/040-control-plane-manager/templates/rbac-for-us.yaml
@@ -103,19 +103,21 @@ roleRef:
   name: d8:control-plane-manager
   apiGroup: rbac.authorization.k8s.io
 {{- /*
-  Single source of truth for the kubeadm:cluster-admins binding lives in the Go hook
-  modules/040-control-plane-manager/hooks/reconcile_kubeadm_cluster_admins_binding.go. The hook
-  evaluates three gates (user-authz enabled, cluster bootstrapped, ClusterRole user-authz:cluster-admin
-  observed in the API) and publishes already-made decisions into Helm values:
+  The main kubeadm:cluster-admins binding is owned entirely by the Go hook
+  modules/040-control-plane-manager/hooks/reconcile_kubeadm_cluster_admins_binding.go and is NOT
+  rendered here: it left this template in v1.77. On that converge Helm orphaned the live object via
+  the helm.sh/resource-policy: keep annotation stamped in v1.76 (both by the old template block and
+  by the hook), so the binding was never pruned and admin.conf never lost root. The hook remains the
+  single source of truth for it.
 
-    .Values.controlPlaneManager.internal.kubeadmClusterAdminsTargetRoleName  string
+  This template only renders the additive supplement, gated by the hook's decision published into:
+
     .Values.controlPlaneManager.internal.kubeadmClusterAdminsSupplementEnabled bool
 
-  We read those values verbatim and do NOT re-evaluate the gates here, so hook and template
-  stay aligned by construction. Read via `dig` to keep the early-render path safe (hook runs
-  on OnBeforeHelm before each helm reconcile, but the schema defaults must work too).
+  We read that value verbatim and do NOT re-evaluate the gates here. Read via `dig` to keep the
+  early-render path safe (hook runs on OnBeforeHelm before each helm reconcile, but the schema
+  defaults must work too).
 */}}
-{{- $targetRole := dig "internal" "kubeadmClusterAdminsTargetRoleName" "cluster-admin" .Values.controlPlaneManager }}
 {{- $supplementEnabled := dig "internal" "kubeadmClusterAdminsSupplementEnabled" false .Values.controlPlaneManager }}
 {{- if $supplementEnabled }}
 ---
@@ -290,31 +292,6 @@ subjects:
 - kind: Group
   name: kubeadm:cluster-admins
 {{- end }}
-{{- /*
-  Main kubeadm:cluster-admins binding: target ClusterRole comes from the hook (see top of file).
-  Helm SSA cannot mutate roleRef (immutable), so the actual Delete+Create on role flip is done
-  by reconcile_kubeadm_cluster_admins_binding hook before Helm runs; Helm here only adopts.
-
-  helm.sh/resource-policy: keep guarantees Helm never prunes this binding. It guards the future
-  migration to hook-only ownership: once this block is dropped from the template, Helm leaves the
-  live object in place (instead of deleting it), so there is no window where kubeadm:cluster-admins
-  has no binding and admin.conf loses root access. The hook remains the single source of truth.
-*/}}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: kubeadm:cluster-admins
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
-  annotations:
-    helm.sh/resource-policy: keep
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: {{ $targetRole }}
-subjects:
-- kind: Group
-  name: kubeadm:cluster-admins
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
## Description
Completes the migration of the kubeadm:cluster-admins ClusterRoleBinding to hook-only ownership.

* Removes the kubeadm:cluster-admins ClusterRoleBinding block from templates/rbac-for-us.yaml. The helm.sh/resource-policy: keep annotation stamped in v1.76 (by both the template and the hook) makes Helm orphan the live object on this converge instead of pruning it, so the binding is never left without a subject and admin.conf never loses root.
* Drops all Helm-ownership handling from reconcile_kubeadm_cluster_admins_binding.go: the app.kubernetes.io/managed-by label, the meta.helm.sh/release-* annotations, the HasHelmOwnership snapshot field/filter, and the adoption patch branch. The hook is now the single owner; helm.sh/resource-policy: keep is still stamped on objects the hook writes as the guard for this drop-from-template converge.

No restarts of critical components. The binding keeps pointing at `cluster-admin` throughout; only its ownership moves from Helm to the hook.
## Why do we need it, and what problem does it solve?
In v1.76 the binding was made Helm-adoptable and annotated with resource-policy: keep as the first phase of moving it under sole hook ownership (ClusterRoleBinding.roleRef is immutable, so Helm SSA cannot reconcile it — only the hook's Delete+Create can). This PR is the second phase: with the binding gone from the template, Helm no longer competes for it and the hook is the unambiguous single source of truth, eliminating template/hook drift and the misleading Helm-ownership metadata on an object Helm can't actually manage.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: chore
summary: Move the kubeadm:cluster-admins ClusterRoleBinding to sole hook ownership by dropping it from the Helm template.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
