### PR TITLE
[ci] Fix av scan jobs

### DIFF
--- a/.github/ci_templates/build.yml
+++ b/.github/ci_templates/build.yml
@@ -41,7 +41,7 @@ outputs:
   matrix:           ${{ steps.diff.outputs.matrix }}
   changed_compact:  ${{ steps.diff.outputs.changed_compact }}
 {!{- end }!}
-  tags: ${{ steps.set-pr-tag.tags }}
+  tags: ${{ steps.set-pr-tag.outputs.tags }}
 steps:
 {!{ tmpl.Exec "docker_config_isolation" | strings.Indent 2 }!}
 {!{ if eq $buildType "release" }!}

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -378,7 +378,7 @@ jobs:
       changed_count:    ${{ steps.diff.outputs.changed_count }}
       matrix:           ${{ steps.diff.outputs.matrix }}
       changed_compact:  ${{ steps.diff.outputs.changed_compact }}
-      tags: ${{ steps.set-pr-tag.tags }}
+      tags: ${{ steps.set-pr-tag.outputs.tags }}
     steps:
 
       # </template: docker-config-isolation>
@@ -1091,7 +1091,7 @@ jobs:
       changed_count:    ${{ steps.diff.outputs.changed_count }}
       matrix:           ${{ steps.diff.outputs.matrix }}
       changed_compact:  ${{ steps.diff.outputs.changed_compact }}
-      tags: ${{ steps.set-pr-tag.tags }}
+      tags: ${{ steps.set-pr-tag.outputs.tags }}
     steps:
 
       # </template: docker-config-isolation>
@@ -1506,7 +1506,7 @@ jobs:
       changed_count:    ${{ steps.diff.outputs.changed_count }}
       matrix:           ${{ steps.diff.outputs.matrix }}
       changed_compact:  ${{ steps.diff.outputs.changed_compact }}
-      tags: ${{ steps.set-pr-tag.tags }}
+      tags: ${{ steps.set-pr-tag.outputs.tags }}
     steps:
 
       # </template: docker-config-isolation>
@@ -1921,7 +1921,7 @@ jobs:
       changed_count:    ${{ steps.diff.outputs.changed_count }}
       matrix:           ${{ steps.diff.outputs.matrix }}
       changed_compact:  ${{ steps.diff.outputs.changed_compact }}
-      tags: ${{ steps.set-pr-tag.tags }}
+      tags: ${{ steps.set-pr-tag.outputs.tags }}
     steps:
 
       # </template: docker-config-isolation>
@@ -2336,7 +2336,7 @@ jobs:
       changed_count:    ${{ steps.diff.outputs.changed_count }}
       matrix:           ${{ steps.diff.outputs.matrix }}
       changed_compact:  ${{ steps.diff.outputs.changed_compact }}
-      tags: ${{ steps.set-pr-tag.tags }}
+      tags: ${{ steps.set-pr-tag.outputs.tags }}
     steps:
 
       # </template: docker-config-isolation>
@@ -2751,7 +2751,7 @@ jobs:
       changed_count:    ${{ steps.diff.outputs.changed_count }}
       matrix:           ${{ steps.diff.outputs.matrix }}
       changed_compact:  ${{ steps.diff.outputs.changed_compact }}
-      tags: ${{ steps.set-pr-tag.tags }}
+      tags: ${{ steps.set-pr-tag.outputs.tags }}
     steps:
 
       # </template: docker-config-isolation>
@@ -3166,7 +3166,7 @@ jobs:
       changed_count:    ${{ steps.diff.outputs.changed_count }}
       matrix:           ${{ steps.diff.outputs.matrix }}
       changed_compact:  ${{ steps.diff.outputs.changed_compact }}
-      tags: ${{ steps.set-pr-tag.tags }}
+      tags: ${{ steps.set-pr-tag.outputs.tags }}
     steps:
 
       # </template: docker-config-isolation>

--- a/.github/workflows/build-and-test_main.yml
+++ b/.github/workflows/build-and-test_main.yml
@@ -142,7 +142,7 @@ jobs:
     runs-on: [self-hosted, large]
     outputs:
       tests_image_name: ${{ steps.build.outputs.tests_image_name }}
-      tags: ${{ steps.set-pr-tag.tags }}
+      tags: ${{ steps.set-pr-tag.outputs.tags }}
     steps:
 
       # </template: docker-config-isolation>

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -142,7 +142,7 @@ jobs:
     runs-on: [self-hosted, large]
     outputs:
       tests_image_name: ${{ steps.build.outputs.tests_image_name }}
-      tags: ${{ steps.set-pr-tag.tags }}
+      tags: ${{ steps.set-pr-tag.outputs.tags }}
     steps:
 
       # </template: docker-config-isolation>
@@ -829,7 +829,7 @@ jobs:
     runs-on: [self-hosted, large]
     outputs:
       tests_image_name: ${{ steps.build.outputs.tests_image_name }}
-      tags: ${{ steps.set-pr-tag.tags }}
+      tags: ${{ steps.set-pr-tag.outputs.tags }}
     steps:
 
       # </template: docker-config-isolation>
@@ -1223,7 +1223,7 @@ jobs:
     runs-on: [self-hosted, large]
     outputs:
       tests_image_name: ${{ steps.build.outputs.tests_image_name }}
-      tags: ${{ steps.set-pr-tag.tags }}
+      tags: ${{ steps.set-pr-tag.outputs.tags }}
     steps:
 
       # </template: docker-config-isolation>
@@ -1617,7 +1617,7 @@ jobs:
     runs-on: [self-hosted, large]
     outputs:
       tests_image_name: ${{ steps.build.outputs.tests_image_name }}
-      tags: ${{ steps.set-pr-tag.tags }}
+      tags: ${{ steps.set-pr-tag.outputs.tags }}
     steps:
 
       # </template: docker-config-isolation>
@@ -2011,7 +2011,7 @@ jobs:
     runs-on: [self-hosted, large]
     outputs:
       tests_image_name: ${{ steps.build.outputs.tests_image_name }}
-      tags: ${{ steps.set-pr-tag.tags }}
+      tags: ${{ steps.set-pr-tag.outputs.tags }}
     steps:
 
       # </template: docker-config-isolation>
@@ -2405,7 +2405,7 @@ jobs:
     runs-on: [self-hosted, large]
     outputs:
       tests_image_name: ${{ steps.build.outputs.tests_image_name }}
-      tags: ${{ steps.set-pr-tag.tags }}
+      tags: ${{ steps.set-pr-tag.outputs.tags }}
     steps:
 
       # </template: docker-config-isolation>
@@ -2799,7 +2799,7 @@ jobs:
     runs-on: [self-hosted, large]
     outputs:
       tests_image_name: ${{ steps.build.outputs.tests_image_name }}
-      tags: ${{ steps.set-pr-tag.tags }}
+      tags: ${{ steps.set-pr-tag.outputs.tags }}
     steps:
 
       # </template: docker-config-isolation>

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -254,7 +254,7 @@ jobs:
     runs-on: [self-hosted, stage]
     outputs:
       tests_image_name: ${{ steps.build.outputs.tests_image_name }}
-      tags: ${{ steps.set-pr-tag.tags }}
+      tags: ${{ steps.set-pr-tag.outputs.tags }}
     steps:
 
       # </template: docker-config-isolation>
@@ -680,7 +680,7 @@ jobs:
     runs-on: [self-hosted, stage]
     outputs:
       tests_image_name: ${{ steps.build.outputs.tests_image_name }}
-      tags: ${{ steps.set-pr-tag.tags }}
+      tags: ${{ steps.set-pr-tag.outputs.tags }}
     steps:
 
       # </template: docker-config-isolation>
@@ -1107,7 +1107,7 @@ jobs:
     runs-on: [self-hosted, stage]
     outputs:
       tests_image_name: ${{ steps.build.outputs.tests_image_name }}
-      tags: ${{ steps.set-pr-tag.tags }}
+      tags: ${{ steps.set-pr-tag.outputs.tags }}
     steps:
 
       # </template: docker-config-isolation>
@@ -1534,7 +1534,7 @@ jobs:
     runs-on: [self-hosted, stage]
     outputs:
       tests_image_name: ${{ steps.build.outputs.tests_image_name }}
-      tags: ${{ steps.set-pr-tag.tags }}
+      tags: ${{ steps.set-pr-tag.outputs.tags }}
     steps:
 
       # </template: docker-config-isolation>
@@ -1961,7 +1961,7 @@ jobs:
     runs-on: [self-hosted, stage]
     outputs:
       tests_image_name: ${{ steps.build.outputs.tests_image_name }}
-      tags: ${{ steps.set-pr-tag.tags }}
+      tags: ${{ steps.set-pr-tag.outputs.tags }}
     steps:
 
       # </template: docker-config-isolation>
@@ -2388,7 +2388,7 @@ jobs:
     runs-on: [self-hosted, stage]
     outputs:
       tests_image_name: ${{ steps.build.outputs.tests_image_name }}
-      tags: ${{ steps.set-pr-tag.tags }}
+      tags: ${{ steps.set-pr-tag.outputs.tags }}
     steps:
 
       # </template: docker-config-isolation>

--- a/.github/workflows/reproducibility-check.yml
+++ b/.github/workflows/reproducibility-check.yml
@@ -320,7 +320,7 @@ jobs:
     runs-on: [self-hosted, large]
     outputs:
       tests_image_name: ${{ steps.build.outputs.tests_image_name }}
-      tags: ${{ steps.set-pr-tag.tags }}
+      tags: ${{ steps.set-pr-tag.outputs.tags }}
     steps:
 
       # </template: docker-config-isolation>
@@ -733,7 +733,7 @@ jobs:
       changed_count:    ${{ steps.diff.outputs.changed_count }}
       matrix:           ${{ steps.diff.outputs.matrix }}
       changed_compact:  ${{ steps.diff.outputs.changed_compact }}
-      tags: ${{ steps.set-pr-tag.tags }}
+      tags: ${{ steps.set-pr-tag.outputs.tags }}
     steps:
 
       # </template: docker-config-isolation>

--- a/.github/workflows/svace.yml
+++ b/.github/workflows/svace.yml
@@ -139,7 +139,7 @@ jobs:
     runs-on: [self-hosted, large]
     outputs:
       tests_image_name: ${{ steps.build.outputs.tests_image_name }}
-      tags: ${{ steps.set-pr-tag.tags }}
+      tags: ${{ steps.set-pr-tag.outputs.tags }}
     steps:
 
       # </template: docker-config-isolation>


### PR DESCRIPTION
## Description
Fix av scan jobs.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: fix
summary: Fix av scan jobs.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
