### PR TITLE
[dhctl] Add verbose logging to bootstrap phases

### DIFF
--- a/dhctl/cmd/dhctl/action.go
+++ b/dhctl/cmd/dhctl/action.go
@@ -345,9 +345,9 @@ func (i *actionIniter) initLogger(c *kingpin.ParseContext, tmpDir string) (onShu
 	// DHCTL_DEBUG (isDebug) deliberately does NOT touch the terminal — it only enriches the .log file
 	// (full DEBUG is always captured there, plus shell-operator/klog internals via BindShellOperator).
 	// So the terminal looks identical with or without DHCTL_DEBUG.
-	stdoutTTY := input.IsTerminal()
-	interactive := stdoutTTY && !i.opts.Global.ShowProgress
 	verbose := i.opts.Global.ShowProgress
+	stdoutTTY := input.IsTerminal() || verbose
+	interactive := stdoutTTY && !verbose
 
 	commandName := getCommandName(c)
 

--- a/dhctl/cmd/dhctl/commands/bootstrap/phase.go
+++ b/dhctl/cmd/dhctl/commands/bootstrap/phase.go
@@ -44,6 +44,8 @@ func DefineBootstrapInstallDeckhouseCommand(cmd *kingpin.CmdClause, opts *option
 	app.DefineDeckhouseInstallFlags(cmd, &opts.Bootstrap)
 	app.DefineImgBundleFlags(cmd, &opts.Registry)
 
+	forceVerboseLogging(cmd, opts)
+
 	return cmd.Action(func(c *kingpin.ParseContext) error {
 		ctx := kpcontext.ExtractContext(c)
 
@@ -82,6 +84,8 @@ func DefineBootstrapExecuteBashibleCommand(cmd *kingpin.CmdClause, opts *options
 	app.DefineBashibleBundleFlags(cmd, &opts.Bootstrap)
 	app.DefineImgBundleFlags(cmd, &opts.Registry)
 
+	forceVerboseLogging(cmd, opts)
+
 	return cmd.Action(func(c *kingpin.ParseContext) error {
 		ctx := kpcontext.ExtractContext(c)
 
@@ -115,6 +119,8 @@ func DefineCreateResourcesCommand(cmd *kingpin.CmdClause, opts *options.Options)
 	app.DefineConfigsForResourcesPhaseFlags(cmd, &opts.Global)
 	app.DefineResourcesFlags(cmd, &opts.Bootstrap, false)
 	app.DefineKubeFlags(cmd, &opts.Kube)
+
+	forceVerboseLogging(cmd, opts)
 
 	return cmd.Action(func(c *kingpin.ParseContext) error {
 		ctx := kpcontext.ExtractContext(c)
@@ -207,6 +213,8 @@ func DefineBaseInfrastructureCommand(cmd *kingpin.CmdClause, opts *options.Optio
 	app.DefineDropCacheFlags(cmd, &opts.Cache)
 	app.DefineImgBundleFlags(cmd, &opts.Registry)
 
+	forceVerboseLogging(cmd, opts)
+
 	return cmd.Action(func(c *kingpin.ParseContext) error {
 		ctx := kpcontext.ExtractContext(c)
 
@@ -243,6 +251,8 @@ func DefineExecPostBootstrapScript(cmd *kingpin.CmdClause, opts *options.Options
 	app.DefineBecomeFlags(cmd, &opts.Become)
 	app.DefinePostBootstrapScriptFlags(cmd, &opts.Bootstrap)
 
+	forceVerboseLogging(cmd, opts)
+
 	return cmd.Action(func(c *kingpin.ParseContext) error {
 		ctx := kpcontext.ExtractContext(c)
 
@@ -268,5 +278,14 @@ func DefineExecPostBootstrapScript(cmd *kingpin.CmdClause, opts *options.Options
 		})
 
 		return bootstraper.ExecPostBootstrap(ctx)
+	})
+}
+
+// forceVerboseLogging makes the command behave as if -v/--verbose was passed,
+// regardless of what the user actually specified on the command line.
+func forceVerboseLogging(cmd *kingpin.CmdClause, opts *options.Options) {
+	cmd.PreAction(func(c *kingpin.ParseContext) error {
+		opts.Global.ShowProgress = true
+		return nil
 	})
 }


### PR DESCRIPTION
## Description

Add verbose logging to `bootstrap-phase` subcommands in dhctl. Verbose logging will be forced to such subcommands

## Why do we need it, and what problem does it solve?

It's hard to find out, what went wrong with phases like `install-deckhouse` if we don't see any logs

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Added verbose logging to bootstrap-phase subcommands in dhctl.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
