### PR TITLE
Backport: [ci] Fix extract images_digests (#21295)

### DIFF
--- a/.github/ci_templates/build.yml
+++ b/.github/ci_templates/build.yml
@@ -282,6 +282,34 @@ steps:
       name: build_report_${{ env.WERF_ENV }}
       path: images_tags_werf.json
 
+{!{- if eq $buildType "dev" }!}
+  - name: Extract images_digests.json
+    env:
+      DEV_REGISTRY: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_HOST }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+    run: |
+      set -euo pipefail
+      REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+      if [[ ${REPO_SUFFIX} == ${GITHUB_REPOSITORY} ]] ; then
+        IMAGE_TAG="pr${PR_NUMBER}"
+      else
+        IMAGE_TAG="pr${PR_NUMBER}-${REPO_SUFFIX}"
+      fi
+      regctl image get-file "${DEV_REGISTRY}/sys/deckhouse-oss:${IMAGE_TAG}" \
+        /deckhouse/modules/images_digests.json > images_digests.json
+      modules=$(jq 'keys | length' images_digests.json)
+      images=$(jq '[.[] | to_entries[]] | length' images_digests.json)
+      echo "images_digests.json: ${modules} modules, ${images} module images."
+  - name: Compute changed images
+    id: diff
+    env:
+      BUILD_REPORT_PATH:   ./images_tags_werf.json
+      IMAGES_DIGESTS_PATH: ./images_digests.json
+      OUTPUT_CHANGED:      ./changed_images.json
+    run: |
+      python3 .github/scripts/python/changed_images.py
+{!{ end }!}
+
   - name: Cleanup workdir
     if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
     run: rm images_tags_werf.json

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -660,6 +660,32 @@ jobs:
         with:
           name: build_report_${{ env.WERF_ENV }}
           path: images_tags_werf.json
+      - name: Extract images_digests.json
+        env:
+          DEV_REGISTRY: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_HOST }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ ${REPO_SUFFIX} == ${GITHUB_REPOSITORY} ]] ; then
+            IMAGE_TAG="pr${PR_NUMBER}"
+          else
+            IMAGE_TAG="pr${PR_NUMBER}-${REPO_SUFFIX}"
+          fi
+          regctl image get-file "${DEV_REGISTRY}/sys/deckhouse-oss:${IMAGE_TAG}" \
+            /deckhouse/modules/images_digests.json > images_digests.json
+          modules=$(jq 'keys | length' images_digests.json)
+          images=$(jq '[.[] | to_entries[]] | length' images_digests.json)
+          echo "images_digests.json: ${modules} modules, ${images} module images."
+      - name: Compute changed images
+        id: diff
+        env:
+          BUILD_REPORT_PATH:   ./images_tags_werf.json
+          IMAGES_DIGESTS_PATH: ./images_digests.json
+          OUTPUT_CHANGED:      ./changed_images.json
+        run: |
+          python3 .github/scripts/python/changed_images.py
+
 
       - name: Cleanup workdir
         if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
@@ -960,6 +986,32 @@ jobs:
         with:
           name: build_report_${{ env.WERF_ENV }}
           path: images_tags_werf.json
+      - name: Extract images_digests.json
+        env:
+          DEV_REGISTRY: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_HOST }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ ${REPO_SUFFIX} == ${GITHUB_REPOSITORY} ]] ; then
+            IMAGE_TAG="pr${PR_NUMBER}"
+          else
+            IMAGE_TAG="pr${PR_NUMBER}-${REPO_SUFFIX}"
+          fi
+          regctl image get-file "${DEV_REGISTRY}/sys/deckhouse-oss:${IMAGE_TAG}" \
+            /deckhouse/modules/images_digests.json > images_digests.json
+          modules=$(jq 'keys | length' images_digests.json)
+          images=$(jq '[.[] | to_entries[]] | length' images_digests.json)
+          echo "images_digests.json: ${modules} modules, ${images} module images."
+      - name: Compute changed images
+        id: diff
+        env:
+          BUILD_REPORT_PATH:   ./images_tags_werf.json
+          IMAGES_DIGESTS_PATH: ./images_digests.json
+          OUTPUT_CHANGED:      ./changed_images.json
+        run: |
+          python3 .github/scripts/python/changed_images.py
+
 
       - name: Cleanup workdir
         if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
@@ -1259,6 +1311,32 @@ jobs:
         with:
           name: build_report_${{ env.WERF_ENV }}
           path: images_tags_werf.json
+      - name: Extract images_digests.json
+        env:
+          DEV_REGISTRY: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_HOST }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ ${REPO_SUFFIX} == ${GITHUB_REPOSITORY} ]] ; then
+            IMAGE_TAG="pr${PR_NUMBER}"
+          else
+            IMAGE_TAG="pr${PR_NUMBER}-${REPO_SUFFIX}"
+          fi
+          regctl image get-file "${DEV_REGISTRY}/sys/deckhouse-oss:${IMAGE_TAG}" \
+            /deckhouse/modules/images_digests.json > images_digests.json
+          modules=$(jq 'keys | length' images_digests.json)
+          images=$(jq '[.[] | to_entries[]] | length' images_digests.json)
+          echo "images_digests.json: ${modules} modules, ${images} module images."
+      - name: Compute changed images
+        id: diff
+        env:
+          BUILD_REPORT_PATH:   ./images_tags_werf.json
+          IMAGES_DIGESTS_PATH: ./images_digests.json
+          OUTPUT_CHANGED:      ./changed_images.json
+        run: |
+          python3 .github/scripts/python/changed_images.py
+
 
       - name: Cleanup workdir
         if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
@@ -1558,6 +1636,32 @@ jobs:
         with:
           name: build_report_${{ env.WERF_ENV }}
           path: images_tags_werf.json
+      - name: Extract images_digests.json
+        env:
+          DEV_REGISTRY: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_HOST }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ ${REPO_SUFFIX} == ${GITHUB_REPOSITORY} ]] ; then
+            IMAGE_TAG="pr${PR_NUMBER}"
+          else
+            IMAGE_TAG="pr${PR_NUMBER}-${REPO_SUFFIX}"
+          fi
+          regctl image get-file "${DEV_REGISTRY}/sys/deckhouse-oss:${IMAGE_TAG}" \
+            /deckhouse/modules/images_digests.json > images_digests.json
+          modules=$(jq 'keys | length' images_digests.json)
+          images=$(jq '[.[] | to_entries[]] | length' images_digests.json)
+          echo "images_digests.json: ${modules} modules, ${images} module images."
+      - name: Compute changed images
+        id: diff
+        env:
+          BUILD_REPORT_PATH:   ./images_tags_werf.json
+          IMAGES_DIGESTS_PATH: ./images_digests.json
+          OUTPUT_CHANGED:      ./changed_images.json
+        run: |
+          python3 .github/scripts/python/changed_images.py
+
 
       - name: Cleanup workdir
         if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
@@ -1857,6 +1961,32 @@ jobs:
         with:
           name: build_report_${{ env.WERF_ENV }}
           path: images_tags_werf.json
+      - name: Extract images_digests.json
+        env:
+          DEV_REGISTRY: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_HOST }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ ${REPO_SUFFIX} == ${GITHUB_REPOSITORY} ]] ; then
+            IMAGE_TAG="pr${PR_NUMBER}"
+          else
+            IMAGE_TAG="pr${PR_NUMBER}-${REPO_SUFFIX}"
+          fi
+          regctl image get-file "${DEV_REGISTRY}/sys/deckhouse-oss:${IMAGE_TAG}" \
+            /deckhouse/modules/images_digests.json > images_digests.json
+          modules=$(jq 'keys | length' images_digests.json)
+          images=$(jq '[.[] | to_entries[]] | length' images_digests.json)
+          echo "images_digests.json: ${modules} modules, ${images} module images."
+      - name: Compute changed images
+        id: diff
+        env:
+          BUILD_REPORT_PATH:   ./images_tags_werf.json
+          IMAGES_DIGESTS_PATH: ./images_digests.json
+          OUTPUT_CHANGED:      ./changed_images.json
+        run: |
+          python3 .github/scripts/python/changed_images.py
+
 
       - name: Cleanup workdir
         if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
@@ -2156,6 +2286,32 @@ jobs:
         with:
           name: build_report_${{ env.WERF_ENV }}
           path: images_tags_werf.json
+      - name: Extract images_digests.json
+        env:
+          DEV_REGISTRY: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_HOST }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ ${REPO_SUFFIX} == ${GITHUB_REPOSITORY} ]] ; then
+            IMAGE_TAG="pr${PR_NUMBER}"
+          else
+            IMAGE_TAG="pr${PR_NUMBER}-${REPO_SUFFIX}"
+          fi
+          regctl image get-file "${DEV_REGISTRY}/sys/deckhouse-oss:${IMAGE_TAG}" \
+            /deckhouse/modules/images_digests.json > images_digests.json
+          modules=$(jq 'keys | length' images_digests.json)
+          images=$(jq '[.[] | to_entries[]] | length' images_digests.json)
+          echo "images_digests.json: ${modules} modules, ${images} module images."
+      - name: Compute changed images
+        id: diff
+        env:
+          BUILD_REPORT_PATH:   ./images_tags_werf.json
+          IMAGES_DIGESTS_PATH: ./images_digests.json
+          OUTPUT_CHANGED:      ./changed_images.json
+        run: |
+          python3 .github/scripts/python/changed_images.py
+
 
       - name: Cleanup workdir
         if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
@@ -2455,6 +2611,32 @@ jobs:
         with:
           name: build_report_${{ env.WERF_ENV }}
           path: images_tags_werf.json
+      - name: Extract images_digests.json
+        env:
+          DEV_REGISTRY: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_HOST }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ ${REPO_SUFFIX} == ${GITHUB_REPOSITORY} ]] ; then
+            IMAGE_TAG="pr${PR_NUMBER}"
+          else
+            IMAGE_TAG="pr${PR_NUMBER}-${REPO_SUFFIX}"
+          fi
+          regctl image get-file "${DEV_REGISTRY}/sys/deckhouse-oss:${IMAGE_TAG}" \
+            /deckhouse/modules/images_digests.json > images_digests.json
+          modules=$(jq 'keys | length' images_digests.json)
+          images=$(jq '[.[] | to_entries[]] | length' images_digests.json)
+          echo "images_digests.json: ${modules} modules, ${images} module images."
+      - name: Compute changed images
+        id: diff
+        env:
+          BUILD_REPORT_PATH:   ./images_tags_werf.json
+          IMAGES_DIGESTS_PATH: ./images_digests.json
+          OUTPUT_CHANGED:      ./changed_images.json
+        run: |
+          python3 .github/scripts/python/changed_images.py
+
 
       - name: Cleanup workdir
         if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}

--- a/.github/workflows/reproducibility-check.yml
+++ b/.github/workflows/reproducibility-check.yml
@@ -1,0 +1,1332 @@
+#
+# THIS FILE IS GENERATED, PLEASE DO NOT EDIT.
+#
+
+# Copyright 2026 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build reproducibility check, runs 4 times a day.
+#
+# Trigger: schedule (every 6 hours) or workflow_dispatch.
+# On schedule the latest 'main' commit is taken; on manual run the commit SHA
+# is provided as an input.
+#
+# The baseline build_report_FE artifact is fetched from the matching
+# 'build-and-test_main.yml' (main commits) or 'build-and-test_dev.yml' (PR commits)
+# successful run. If no such run exists for the target SHA the workflow fails.
+#
+# Then the FE build is repeated for the same SHA in the same style as the
+# baseline (main-style or dev-style), and the two build_report_FE JSONs are
+# diffed by DockerImageDigest. Both reports are saved as workflow artifacts.
+
+name: 'Build reproducibility check'
+
+on:
+  # 4 times a day, every 6 hours: 00:00, 06:00, 12:00, 18:00 UTC
+  # (03:00, 09:00, 15:00, 21:00 MSK, UTC+3, no DST).
+  schedule:
+    - cron: '0 */6 * * *'
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: 'PR commit SHA that already has a successful build-and-test_dev.yml run (empty = newest main commit with a successful build)'
+        required: false
+        type: string
+
+env:
+
+  # <template: werf_envs>
+  WERF_ENV: "FE"
+  TEST_TIMEOUT: "15m"
+  # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in GitHub.
+  REGISTRY_PATH: "sys/deckhouse-oss"
+  # Registry for additional repositories used for testing Github Actions workflows.
+  GHA_TEST_REGISTRY_PATH: "ghcr.io/${{ github.repository }}"
+  # Need for ssh: default.
+  DOCKER_BUILDKIT: "1"
+  WERF_FINAL_IMAGES_ONLY: true
+  WERF_LOG_TERMINAL_WIDTH: "200"
+  WERF_LOG_TIME: true
+  WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  GOPROXY: "${{vars.GOPROXY}}"
+  # </template: werf_envs>
+  WERF_LOG_DEBUG: true
+
+# Serialize runs for the same target SHA. cancel-in-progress is false because
+# rebuilds are expensive and we don't want a queued run to abort an in-flight one.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.inputs.commit_sha || 'scheduled' }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+  actions: read
+
+jobs:
+  resolve_target:
+    name: Resolve target commit and baseline
+    runs-on: "self-slim"
+    outputs:
+      sha: ${{ steps.resolve.outputs.sha }}
+      baseline_run_id: ${{ steps.resolve.outputs.baseline_run_id }}
+      baseline_run_url: ${{ steps.resolve.outputs.baseline_run_url }}
+      baseline_workflow: ${{ steps.resolve.outputs.baseline_workflow }}
+      pr_number: ${{ steps.resolve.outputs.pr_number }}
+      ci_commit_ref_name: ${{ steps.resolve.outputs.ci_commit_ref_name }}
+    steps:
+      - name: Resolve target SHA and locate baseline
+        id: resolve
+        uses: actions/github-script@v6.4.1
+        with:
+          github-token: ${{ secrets.BOATSWAIN_GITHUB_TOKEN }}
+          script: |
+            const eventName = context.eventName;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            if (eventName !== 'schedule' && eventName !== 'workflow_dispatch') {
+              return core.setFailed(`Unsupported event: ${eventName}`);
+            }
+
+            const inputSha = ((context.payload.inputs || {}).commit_sha || '').trim();
+
+            // Baseline selection:
+            //   schedule, or manual run WITHOUT a commit -> newest 'main' commit that
+            //     HAS a successful build (baseline in build-and-test_main.yml)
+            //   manual run WITH a commit                 -> that exact commit, treated
+            //     as a dev/PR build (baseline in build-and-test_dev.yml)
+            const useMainBaseline = (eventName === 'schedule') || !inputSha;
+
+            let sha = '';
+            let baselineKind = '';
+            let baselineWorkflowId = '';
+            let baseline = null;
+            if (useMainBaseline) {
+              baselineKind = 'main';
+              baselineWorkflowId = 'build-and-test_main.yml';
+              if (eventName === 'workflow_dispatch') {
+                core.notice(`Manual run without commit_sha: falling back to newest successful 'main' build.`);
+              }
+              // Do NOT pin to HEAD of 'main': the latest commit's build may still
+              // be running, may have failed, or may not be queued yet. Instead pick
+              // the most recent SUCCESSFUL build-and-test_main.yml run on 'main' and
+              // use its head commit. listWorkflowRuns returns runs newest-first, so
+              // the first success is the freshest 'main' commit with a usable
+              // build_report_FE artifact.
+              const runs = await github.rest.actions.listWorkflowRuns({
+                owner, repo,
+                workflow_id: baselineWorkflowId,
+                branch: 'main',
+                status: 'success',
+                per_page: 30,
+              });
+              baseline = (runs.data.workflow_runs || [])[0];
+              if (!baseline) {
+                return core.setFailed(
+                  `No successful '${baselineWorkflowId}' run found on 'main'. ` +
+                  `Reproducibility check requires an existing baseline build_report_FE artifact.`
+                );
+              }
+              sha = baseline.head_sha;
+              core.notice(
+                `Using newest successful 'main' build for commit ${sha} ` +
+                `(run ${baseline.id}, ${baseline.html_url})`
+              );
+            } else {
+              sha = inputSha;
+              try {
+                const r = await github.rest.repos.getCommit({ owner, repo, ref: sha });
+                sha = r.data.sha;
+              } catch (e) {
+                return core.setFailed(`Commit ${sha} not found in ${owner}/${repo}: ${e.message}`);
+              }
+              baselineKind = 'dev';
+              baselineWorkflowId = 'build-and-test_dev.yml';
+              core.notice(`Manual run: using commit ${sha}, baseline workflow=${baselineWorkflowId}`);
+
+              // Locate the latest successful baseline run for this exact SHA.
+              // API supports a server-side head_sha filter, so we only fetch matching runs.
+              const runs = await github.rest.actions.listWorkflowRuns({
+                owner, repo,
+                workflow_id: baselineWorkflowId,
+                head_sha: sha,
+                status: 'success',
+                per_page: 10,
+              });
+              // Runs are returned newest-first; pick the most recent success.
+              baseline = (runs.data.workflow_runs || [])[0];
+              if (!baseline) {
+                return core.setFailed(
+                  `No successful '${baselineWorkflowId}' run found for SHA ${sha}. ` +
+                  `Reproducibility check requires an existing baseline build_report_FE artifact. ` +
+                  `Ensure the regular build pipeline has completed for this commit first.`
+                );
+              }
+            }
+
+            // For dev mode we reconstruct the exact CI_COMMIT_* context the baseline
+            // build-and-test_dev.yml run used, so the rerun produces identical digests:
+            //   CI_COMMIT_REF_SLUG = prN  (always)
+            //   CI_COMMIT_REF_NAME = PR head branch name for internal PRs, prN for forks
+            // (this mirrors git_info_job in ci_templates/helper_jobs.yml).
+            // CI_COMMIT_REF_NAME is baked into release-channel-version(-prebuild) via
+            // .werf/werf-release-channel.yaml, so an incorrect value makes those images
+            // look non-reproducible even on the same commit.
+            //
+            // We need the PR number first. Prefer the PR attached to the baseline run
+            // itself: it is always the exact PR this SHA was built on. Fall back to
+            // commit-associated PRs only if the run object has no pull_requests payload.
+            let prNumber = '';
+            let ciCommitRefName = '';
+            if (baselineKind === 'dev') {
+              const runPr = (baseline.pull_requests || [])[0];
+              if (runPr && runPr.number) {
+                prNumber = runPr.number.toString();
+                core.notice(`dev baseline: PR #${prNumber} (from baseline run)`);
+              } else {
+                const prs = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                  owner, repo, commit_sha: sha,
+                });
+                if (prs.data.length > 0) {
+                  prNumber = prs.data[0].number.toString();
+                  core.notice(`dev baseline: PR #${prNumber} (from commit association)`);
+                } else {
+                  return core.setFailed(
+                    `dev-style baseline found for SHA ${sha}, but no associated PR. ` +
+                    `Cannot reconstruct dev build context (PR number is required for ref_slug).`
+                  );
+                }
+              }
+
+              // Reconstruct CI_COMMIT_REF_NAME exactly like git_info_job:
+              //   refName = (prRepo === targetRepo) ? pr.head.ref : `pr${number}`
+              const targetRepo = `${owner}/${repo}`;
+              try {
+                const pr = (await github.rest.pulls.get({
+                  owner, repo, pull_number: Number(prNumber),
+                })).data;
+                const prRepo = (pr.head && pr.head.repo) ? pr.head.repo.full_name : '';
+                const prRef  = (pr.head && pr.head.ref)  ? pr.head.ref            : '';
+                ciCommitRefName = (prRepo === targetRepo && prRef) ? prRef : `pr${prNumber}`;
+                core.notice(
+                  `dev baseline: CI_COMMIT_REF_NAME='${ciCommitRefName}' ` +
+                  `(PR head '${prRepo}:${prRef}', target '${targetRepo}')`
+                );
+              } catch (e) {
+                return core.setFailed(
+                  `Failed to fetch PR #${prNumber} to reconstruct CI_COMMIT_REF_NAME: ${e.message}`
+                );
+              }
+            }
+
+            core.notice(`Baseline run: ${baseline.html_url} (workflow=${baselineKind}, id=${baseline.id})`);
+            core.setOutput('sha', sha);
+            core.setOutput('baseline_run_id', baseline.id.toString());
+            core.setOutput('baseline_run_url', baseline.html_url);
+            core.setOutput('baseline_workflow', baselineKind);
+            core.setOutput('pr_number', prNumber);
+            core.setOutput('ci_commit_ref_name', ciCommitRefName);
+
+  # Synthetic git_info: build_template reads needs.git_info.outputs.*. We
+  # construct the values from the resolved target SHA and baseline workflow kind
+  # so the rerun build mirrors the original build context as closely as possible.
+  git_info:
+    name: Get git info (synthetic)
+    needs:
+      - resolve_target
+    runs-on: "self-slim"
+    outputs:
+      ci_commit_tag: ${{ steps.set.outputs.ci_commit_tag }}
+      ci_commit_branch: ${{ steps.set.outputs.ci_commit_branch }}
+      ci_commit_ref_name: ${{ steps.set.outputs.ci_commit_ref_name }}
+      ci_commit_ref_slug: ${{ steps.set.outputs.ci_commit_ref_slug }}
+      github_sha: ${{ steps.set.outputs.github_sha }}
+    steps:
+      - id: set
+        env:
+          SHA: ${{ needs.resolve_target.outputs.sha }}
+          WF: ${{ needs.resolve_target.outputs.baseline_workflow }}
+          PR_NUMBER: ${{ needs.resolve_target.outputs.pr_number }}
+          REF_NAME: ${{ needs.resolve_target.outputs.ci_commit_ref_name }}
+        run: |
+          # Reproduce the baseline build's CI_COMMIT_* context. In the real builds
+          # (git_info_job, ci_templates/helper_jobs.yml):
+          #   main: ref_slug = ref_name = branch = "main"
+          #   dev:  ref_slug = "prN"; ref_name = branch = PR head branch (internal)
+          #         or "prN" (fork). ref_name is resolved upstream in resolve_target.
+          if [[ "$WF" == "main" ]]; then
+            REF_SLUG="main"
+            REF_NAME="main"
+          elif [[ "$WF" == "dev" ]]; then
+            REF_SLUG="pr${PR_NUMBER}"
+            if [[ -z "$REF_NAME" ]]; then
+              echo "::error::ci_commit_ref_name is empty in dev mode"
+              exit 1
+            fi
+          else
+            echo "::error::Unknown baseline_workflow: '$WF'"
+            exit 1
+          fi
+          {
+            echo "ci_commit_tag="
+            echo "ci_commit_branch=${REF_NAME}"
+            echo "ci_commit_ref_name=${REF_NAME}"
+            echo "ci_commit_ref_slug=${REF_SLUG}"
+            echo "github_sha=${SHA}"
+          } >> $GITHUB_OUTPUT
+
+  # Synthetic pull_request_info: build_template in dev mode reads
+  # needs.pull_request_info.outputs.ref_slug. Only created for dev baselines.
+  pull_request_info:
+    name: Pull request info (synthetic, dev mode only)
+    needs:
+      - resolve_target
+    if: needs.resolve_target.outputs.baseline_workflow == 'dev'
+    runs-on: "self-slim"
+    outputs:
+      ref_slug: ${{ steps.set.outputs.ref_slug }}
+    steps:
+      - id: set
+        env:
+          PR_NUMBER: ${{ needs.resolve_target.outputs.pr_number }}
+        run: |
+          if [[ -z "$PR_NUMBER" ]]; then
+            echo "::error::pr_number is empty in dev mode"
+            exit 1
+          fi
+          echo "ref_slug=pr${PR_NUMBER}" >> $GITHUB_OUTPUT
+
+  build_fe_main:
+    name: Build FE (main-style)
+    needs:
+      - resolve_target
+      - git_info
+    if: needs.resolve_target.outputs.baseline_workflow == 'main'
+    env:
+      WERF_ENV: "FE"
+    # <template: build_template>
+    runs-on: [self-hosted, large]
+    outputs:
+      tests_image_name: ${{ steps.build.outputs.tests_image_name }}
+      tags: ${{ steps.set-pr-tag.tags }}
+    steps:
+
+      # </template: docker-config-isolation>
+      - name: Isolate docker config
+        id: docker-config-isolation
+        run: |
+          mkdir -p $RUNNER_TEMP/.docker
+          echo "DOCKER_CONFIG=$RUNNER_TEMP/.docker" >> $GITHUB_ENV
+
+      # </template: docker_config_isolation>
+
+      # <template: import_secrets>
+      - name: Split repository name
+        id: split
+        env:
+          REPO: ${{ github.repository }}
+        run: |
+          if [ $REPO == "deckhouse/deckhouse" ]; then
+            echo "name=deckhouse" >> $GITHUB_OUTPUT
+          else
+            echo "name=deckhouse-test" >> $GITHUB_OUTPUT
+          fi
+      - name: Import secrets
+        id: secrets
+        uses: hashicorp/vault-action@v2
+        with:
+          url: https://seguro.flant.com
+          path: github
+          role: "${{ steps.split.outputs.name }}"
+          method: jwt
+          jwtGithubAudience: github-access-aud
+          secrets: |
+            projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/registry_host DECKHOUSE_DEV_REGISTRY_HOST | DECKHOUSE_DEV_REGISTRY_HOST ;
+            projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/registry_host DECKHOUSE_REGISTRY_STAGE_HOST | DECKHOUSE_REGISTRY_STAGE_HOST ;
+            projects/data/101ceaca-97cd-462f-aed5-070d9b9de175/dev-registry/writetoken login | DECKHOUSE_DEV_REGISTRY_USER ;
+            projects/data/101ceaca-97cd-462f-aed5-070d9b9de175/dev-registry/writetoken password | DECKHOUSE_DEV_REGISTRY_PASSWORD ;
+            projects/data/101ceaca-97cd-462f-aed5-070d9b9de175/stage-registry/writetoken login | DECKHOUSE_REGISTRY_STAGE_USER ;
+            projects/data/101ceaca-97cd-462f-aed5-070d9b9de175/stage-registry/writetoken password | DECKHOUSE_REGISTRY_STAGE_PASSWORD ;
+            projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/fox_pull_secret SOURCE_REPO_GIT | SOURCE_REPO_GIT ;
+            projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/fox_pull_secret CLOUD_PROVIDERS_SOURCE_REPO | CLOUD_PROVIDERS_SOURCE_REPO ;
+            projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/fox_pull_secret OBSERVABILITY_SOURCE_REPO | OBSERVABILITY_SOURCE_REPO ;
+            projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/fox_pull_secret DECKHOUSE_PRIVATE_REPO | DECKHOUSE_PRIVATE_REPO ;
+            projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/fox_pull_secret SOURCE_REPO_SSH_KEY | SOURCE_REPO_SSH_KEY ;
+            projects/data/24cb1d7c-717a-4f92-8547-26f632916a7a/Svace_CI SVACE_ANALYZE_SSH_PRIVATE_KEY | SVACE_ANALYZE_SSH_PRIVATE_KEY ;
+            projects/data/24cb1d7c-717a-4f92-8547-26f632916a7a/Svace_CI SVACE_ANALYZE_HOST | SVACE_ANALYZE_HOST ;
+            projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/team-ssdlc/loop webhook_url | LOOP_SERVICE_NOTIFICATIONS ;
+
+      # </template: import_secrets>
+
+      # <template: checkout_full_step>
+      - name: Checkout sources
+        uses: actions/checkout@v3.5.2
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.resolve_target.outputs.sha }}
+      # </template: checkout_full_step>
+      - name: Print git context
+        run: |
+          # Diagnostic: which commit werf will actually build from.
+          # GITHUB_SHA is the workflow run's commit (immutable, runner-injected);
+          # git HEAD is what actions/checkout left in the work tree (may differ
+          # for runs that override `ref`, e.g. reproducibility-check.yml).
+          echo "==== git context ===="
+          echo "GITHUB_SHA env:        ${GITHUB_SHA}"
+          echo "GITHUB_REF env:        ${GITHUB_REF}"
+          echo "git HEAD (full):       $(git rev-parse HEAD)"
+          echo "git HEAD (short):      $(git rev-parse --short HEAD)"
+          git log -1 --pretty='format:  commit:  %H%n  author:  %an <%ae>%n  date:    %ad%n  subject: %s'
+          echo
+          echo "====================="
+
+      # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then
+            echo "has_credentials=true" >> $GITHUB_OUTPUT
+            echo "web_registry_path=${{steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_HOST }}/deckhouse/site" >> $GITHUB_OUTPUT
+          fi
+      - name: Login to dev registry
+        uses: docker/login-action@v2.1.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
+        with:
+          registry: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_HOST }}
+          username: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_USER }}
+          password: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
+          logout: false
+      # </template: login_dev_registry_step>
+
+
+      # <template: read_werf_version_step>
+      - name: Read werf version from werf_envs.yml
+        id: read_werf_version
+        run: |
+          set -euo pipefail
+          WERF_ENVS_FILE=".github/ci_includes/werf_envs.yml"
+          if [[ ! -f "$WERF_ENVS_FILE" ]]; then
+            echo "::error title=WERF version::File ${WERF_ENVS_FILE} not found"
+            exit 1
+          fi
+          WERF_VERSION="$(grep -E '^[[:space:]]*WERF_VERSION:' "$WERF_ENVS_FILE" | head -1 | sed -E 's/^[[:space:]]*WERF_VERSION:[[:space:]]*"?([^"#[:space:]]+)"?.*/\1/')"
+          if [[ ! "$WERF_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z"
+            exit 1
+          fi
+          echo "Detected WERF_VERSION=${WERF_VERSION}"
+          echo "WERF_VERSION=${WERF_VERSION}" >> "$GITHUB_ENV"
+          echo "werf_version=${WERF_VERSION}" >> "$GITHUB_OUTPUT"
+      # </template: read_werf_version_step>
+
+      # <template: werf_install_step>
+      - name: Install werf-dk CLI
+        run: |
+          if [[ -z "${WERF_VERSION:-}" ]]; then
+            echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
+            exit 1
+          fi
+          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
+          echo "$WERF_PATH" >> "$GITHUB_PATH"
+          CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+            echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
+            mkdir -p "$WERF_PATH"
+            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
+            chmod +x "$WERF_PATH/werf"
+          else
+            echo "Current werf is $CACHED_VERSION, skipping download"
+          fi
+      # </template: werf_install_step>
+
+      # <template: add_ssh_keys>
+      - name: Start ssh-agent
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: |
+            ${{ steps.secrets.outputs.SOURCE_REPO_SSH_KEY }}
+            ${{ steps.secrets.outputs.SVACE_ANALYZE_SSH_PRIVATE_KEY }}
+      - name: Add ssh_known_hosts
+        run: |
+          HOST=$(grep -oP '(?<=@)[^/:]+' <<< ${{ steps.secrets.outputs.SOURCE_REPO_GIT }})
+          echo "::add-mask::$HOST"
+          IPS=$(nslookup "$HOST" | awk '/^Address: / { print $2 }')
+          for IP in $IPS; do
+            echo "::add-mask::$IP"
+          done
+          mkdir -p ~/.ssh
+          touch ~/.ssh/known_hosts
+          HOST_KEYS=$(ssh-keyscan -H "$HOST" 2>/dev/null)
+          while IFS= read -r KEY_LINE; do
+            CONSTANT_PART=$(awk '{print $2, $3}' <<< "$KEY_LINE")
+            if ! grep -q "$CONSTANT_PART" ~/.ssh/known_hosts; then
+              echo "$KEY_LINE" >> ~/.ssh/known_hosts
+            fi
+          done <<< "$HOST_KEYS"
+      - name: Add svace analyze server to ssh_known_hosts
+        continue-on-error: true
+        run: |
+          host=${{ steps.secrets.outputs.SVACE_ANALYZE_HOST }}
+          host_ip=$(nslookup "$host" | awk '/^Address: / { print $2 }')
+          echo "::add-mask::$host_ip"
+          mkdir -p ~/.ssh
+          touch ~/.ssh/known_hosts
+          HOST_KEYS=$(ssh-keyscan -H "$host" 2>/dev/null)
+          while IFS= read -r KEY_LINE; do
+              CONSTANT_PART=$(awk '{print $2, $3}' <<< "$KEY_LINE")
+              if grep -q "$CONSTANT_PART" ~/.ssh/known_hosts; then
+                  ssh-keygen -R $host
+                  ssh-keygen -R $host_ip
+              fi
+              echo "$KEY_LINE" >> ~/.ssh/known_hosts
+          done <<< "$HOST_KEYS"
+      # </template: add_ssh_keys>
+      - name: Set PR tag
+        id: set-pr-tag
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ ${REPO_SUFFIX} == ${GITHUB_REPOSITORY} ]] ; then
+            TAG="pr${PR_NUMBER}"
+          else
+            TAG="pr${PR_NUMBER}-${REPO_SUFFIX}"
+          fi
+          echo "PR tag to scan: $TAG"
+          echo "tags=$(printf '%s' "$TAG" | jq -R -s -c 'split("\n") | map(select(length > 0))')" >> $GITHUB_OUTPUT
+
+      - name: Build and push deckhouse images
+        id: build
+        env:
+          WERF_EXPERIMENTAL_IMPORT_BY_SOURCE_IMAGE_TAG: 1
+          WERF_DOCKER_REGISTRY_DEBUG: 1
+          WERF_TELEMETRY: "1"
+          WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
+          DECKHOUSE_DEV_REGISTRY_USER : ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_USER }}
+          DECKHOUSE_DEV_REGISTRY_PASSWORD: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
+          DEV_REGISTRY_HOST: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_HOST }}
+          SOURCE_REPO: "${{ steps.secrets.outputs.SOURCE_REPO_GIT }}"
+          CLOUD_PROVIDERS_SOURCE_REPO: "${{ steps.secrets.outputs.CLOUD_PROVIDERS_SOURCE_REPO }}"
+          OBSERVABILITY_SOURCE_REPO: "${{ steps.secrets.outputs.OBSERVABILITY_SOURCE_REPO }}"
+          DECKHOUSE_PRIVATE_REPO: "${{ steps.secrets.outputs.DECKHOUSE_PRIVATE_REPO }}"
+          VAULT_ADDR: "https://seguro.flant.com"
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          WERF_SIGN_KEY: "hashivault://dh-dev-v01"
+          TRANSIT_SECRET_ENGINE_PATH: "dev-int-signer"
+          WERF_VAULT_AUTH_ROLE: "dh-signer-dev_dh-signer-dev"
+          INTERMEDIARY_CERT_PATH: "dev-int-pki/issuer/default/pem"
+          SIGNING_CERT_PATH: "dev-int-pki/cert/56:61:03:74:72:94:e1:e7:7b:d9:ac:44:f1:4c:57:aa:2b:b2:8d:9d"
+          REGISTRY_USER: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_USER }}
+          REGISTRY_PASSWORD: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
+          SVACE_ANALYZE_HOST: "${{ secrets.SVACE_ANALYZE_HOST }}"
+          SVACE_ANALYZE_SSH_USER: "${{ secrets.SVACE_ANALYZE_SSH_USER }}"
+          WERF_SIGN_ELF_FILES: "0"
+          WERF_SIGN_MANIFEST: "1"
+          WERF_ANNOTATE_LAYERS_WITH_DM_VERITY_ROOT_HASH: "1"
+          WERF_VAULT_AUTH_PATH: "github"
+          WERF_ACTIONS_AUDIENCE: "github-access-aud"
+        run: |
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
+
+          # Put tags on produced images and push to dev and release repositories.
+          #
+          # There are 2 modes: "dev" and "release".
+          # The "dev" mode builds branches only:
+          # - Build using dev-registry as primary and deckhouse registry as secondary.
+          # - Push dev and dev/install images with prNUM tags and push to dev-registry.
+          # The "release" mode builds branches and tags:
+          # - Build using deckhouse registry as final and dev-registry as primary.
+          # - Push dev and dev/install images to dev-registry with tag equal to a branch name (main or release-X.Y).
+          # - Push dev, dev/install and release-channel-version images to deckhouse registry with tag equels to a Git tag.
+
+          # IMAGE_NAME is a name of image from werf.yaml.
+          # IMAGE_DST is an image name for docker push.
+          function publish_image() {
+            IMAGE_NAME=$1
+            IMAGE_DST_REPO=$2
+            IMAGE_DST_TAG=$3
+            IMAGE_SRC_REPO="$(jq -r ".Images.\"${IMAGE_NAME}\".DockerRepo" images_tags_werf.json)"
+            IMAGE_SRC_TAG="$(jq -r ".Images.\"${IMAGE_NAME}\".DockerTag" images_tags_werf.json)"
+            IMAGE_DIGEST="$(jq -r ".Images.\"${IMAGE_NAME}\".DockerImageDigest" images_tags_werf.json)"
+            IMAGE_DIGEST="${IMAGE_DIGEST#sha256:}"
+            echo "⚓️ 💫 [$(date -u)] Publishing '${IMAGE_NAME}' image to ${IMAGE_DST_REPO}:${IMAGE_DST_TAG}".
+            regctl image copy "${IMAGE_SRC_REPO}:${IMAGE_SRC_TAG}" "${IMAGE_DST_REPO}:${IMAGE_DST_TAG}"
+            if (regctl image manifest "${IMAGE_SRC_REPO}:sha256-${IMAGE_DIGEST}.att" > /dev/null 2>&1); then
+              echo "⚓️ 💫 [$(date -u)] Copying '${IMAGE_NAME}' attestation"
+              regctl image copy "${IMAGE_SRC_REPO}:sha256-${IMAGE_DIGEST}.att" "${IMAGE_DST_REPO}:sha256-${IMAGE_DIGEST}.att"
+            else
+              echo "⚓️ 💫 [$(date -u)] Attestation for '${IMAGE_NAME}' not found, skipping..."
+            fi
+          }
+
+          # CE/EE/FE -> ce/ee/fe
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          DEV_REGISTRY_PATH="${DECKHOUSE_DEV_REGISTRY_HOST}/${REGISTRY_PATH}"
+          export REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          export WERF_REPO="${DEV_REGISTRY_PATH}"
+
+          # Determine image tag
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
+          fi
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+
+          # Check whether current DDK version supports signing
+          sign_minimal_version="v2.71.0-dk"
+          sign_current_version="$(werf version)"
+          sign_supported=true
+          if [[ $sign_minimal_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+            sign_minimal_major=${BASH_REMATCH[1]}
+            sign_minimal_minor=${BASH_REMATCH[2]}
+          fi
+          if [[ $sign_current_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+            sign_current_major=${BASH_REMATCH[1]}
+            sign_current_minor=${BASH_REMATCH[2]}
+          else
+            sign_supported=false
+          fi
+          if (( sign_current_major < sign_minimal_major )); then
+            sign_supported=false
+          elif (( sign_current_major == sign_minimal_major && sign_current_minor < sign_minimal_minor )); then
+            sign_supported=false
+          fi
+
+          # Prepare for image and binary signing
+          export WERF_VAULT_AUTH_JWT=$(jq -r .value <<< $(curl -qfsH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=github-access-aud" ))
+          if [ -n "${WERF_VAULT_AUTH_JWT}" ]; then
+            echo "Received Actions token";
+          else
+            echo "Actions token empty";
+          fi
+          export VAULT_TOKEN="$(curl -sfX POST "${VAULT_ADDR}/v1/auth/${WERF_VAULT_AUTH_PATH}/login" -d '{"role":"'${WERF_VAULT_AUTH_ROLE}'","jwt":"'${WERF_VAULT_AUTH_JWT}'"}' | jq -r '.auth.client_token')"
+          if [ -n "${VAULT_TOKEN}" ]; then
+            echo "Received Vault token";
+          else
+            echo "Vault token empty";
+          fi
+
+          if $sign_supported; then
+            echo "Using WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+            export WERF_SIGN_INTERMEDIATES=$(curl -sf "${VAULT_ADDR}/v1/${INTERMEDIARY_CERT_PATH}" | base64 -w0)
+            export WERF_SIGN_CERT=$(curl -sf --header "X-Vault-Token: ${VAULT_TOKEN}" "${VAULT_ADDR}/v1/${SIGNING_CERT_PATH}" | jq -r '.data.certificate' | base64 -w0)
+          else
+            # fallback to non-signed version
+            export WERF_SIGN_MANIFEST="0"
+            echo "Fallback to WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+          fi
+
+          type werf && source $(werf ci-env github --verbose --as-file)
+          werf build \
+            --parallel=true --parallel-tasks-limit=5 \
+            --save-build-report=true \
+            --build-report-path images_tags_werf.json
+
+          # Publish images for Git branch.
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            echo "⚓️ 💫 [$(date -u)] Publish images to dev-registry for branch '${CI_COMMIT_BRANCH}' and edition '${WERF_ENV}' using tag '${IMAGE_TAG}' ..."
+            publish_image 'dev' "${REGISTRY_PATH}" "${IMAGE_TAG}"
+            publish_image 'dev/install' "${REGISTRY_PATH}/install" "${IMAGE_TAG}"
+            publish_image 'dev/install-standalone' "${REGISTRY_PATH}/install-standalone" "${IMAGE_TAG}"
+            publish_image 'e2e-opentofu-eks' "${REGISTRY_PATH}/e2e-opentofu-eks" "${IMAGE_TAG}"
+
+            # For release branches, also push release-channel to dev
+            if [[ ${WERF_ENV,,} == "fe" && "${CI_COMMIT_BRANCH}" =~ release-([0-9]+\.[0-9]+) ]]; then
+              publish_image 'dev' "${REGISTRY_PATH}" "v${BASH_REMATCH[1]}.0"
+              publish_image 'dev/install' "${REGISTRY_PATH}/install" "v${BASH_REMATCH[1]}.0"
+              publish_image 'dev/install-standalone' "${REGISTRY_PATH}/install-standalone" "v${BASH_REMATCH[1]}.0"
+              publish_image 'release-channel-version' "${REGISTRY_PATH}/release-channel" "v${BASH_REMATCH[1]}.0"
+              publish_image 'e2e-opentofu-eks' "${REGISTRY_PATH}/e2e-opentofu-eks" "v${BASH_REMATCH[1]}.0"
+            fi
+          else
+            echo "Branch unset, skipping branch publish."
+          fi
+
+          # Publish images for Git tag.
+          if [[ "${CI_COMMIT_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "⚓️ 💫 [$(date -u)] Publish images for Git tag '${CI_COMMIT_TAG}' and registry suffix '${REGISTRY_SUFFIX}' using tag '${IMAGE_TAG}' ..."
+            publish_image 'dev' "${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}" "${IMAGE_TAG}"
+            publish_image 'dev/install' "${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install" "${IMAGE_TAG}"
+            publish_image 'dev/install-standalone' "${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install-standalone" "${IMAGE_TAG}"
+            publish_image 'release-channel-version' "${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel" "${IMAGE_TAG}"
+            publish_image 'e2e-opentofu-eks' "${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/e2e-opentofu-eks" "${IMAGE_TAG}"
+          else
+            echo "Not a release tag, skipping tag publish."
+          fi
+
+          # Save 'tests' image name to pass it as output for 'tests' jobs.
+          TESTS_IMAGE_NAME="$(jq -r '.Images."tests".DockerImageName' images_tags_werf.json)"
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'
+          # Encode as gzip+base64 to evade github's SecretMasker error: "Skip output since it may contain secret".
+          echo "tests_image_name=$(echo ${TESTS_IMAGE_NAME} | gzip | base64 -w0)" >> $GITHUB_OUTPUT
+
+          # Filter out data from build report
+          egrep -v '(DockerRepo|DockerImageName)' images_tags_werf.json > images_tags_werf_filtered.json
+          mv images_tags_werf_filtered.json images_tags_werf.json
+
+
+
+      - name: Save build report
+        if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
+        uses: actions/upload-artifact@v4.4.0
+        with:
+          name: build_report_${{ env.WERF_ENV }}
+          path: images_tags_werf.json
+      - name: Cleanup workdir
+        if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
+        run: |
+          rm images_tags_werf.json || true
+          rm changed_images.json || true
+          rm images_digests.json || true
+
+      # <template: send_fail_report>
+      - name: Send fail report
+        if: ${{ failure() && github.repository == 'deckhouse/deckhouse' }}
+        env:
+          LOOP_SERVICE_NOTIFICATIONS: ${{ steps.secrets.outputs.LOOP_SERVICE_NOTIFICATIONS }}
+          JOB_NAME: ${{ github.job }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+          WORKFLOW_URL: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}/
+        run: |
+          bash ./.github/scripts/send-report.sh --webhook "ci_fail"
+      # </template: send_fail_report>
+    # </template: build_template>
+
+
+  build_fe_dev:
+    name: Build FE (dev-style)
+    needs:
+      - resolve_target
+      - git_info
+      - pull_request_info
+    if: needs.resolve_target.outputs.baseline_workflow == 'dev'
+    env:
+      WERF_ENV: "FE"
+    # <template: build_template>
+    runs-on: [self-hosted, large]
+    outputs:
+      tests_image_name: ${{ steps.build.outputs.tests_image_name }}
+      changed_count:    ${{ steps.diff.outputs.changed_count }}
+      matrix:           ${{ steps.diff.outputs.matrix }}
+      changed_compact:  ${{ steps.diff.outputs.changed_compact }}
+      tags: ${{ steps.set-pr-tag.tags }}
+    steps:
+
+      # </template: docker-config-isolation>
+      - name: Isolate docker config
+        id: docker-config-isolation
+        run: |
+          mkdir -p $RUNNER_TEMP/.docker
+          echo "DOCKER_CONFIG=$RUNNER_TEMP/.docker" >> $GITHUB_ENV
+
+      # </template: docker_config_isolation>
+
+      # <template: import_secrets>
+      - name: Split repository name
+        id: split
+        env:
+          REPO: ${{ github.repository }}
+        run: |
+          if [ $REPO == "deckhouse/deckhouse" ]; then
+            echo "name=deckhouse" >> $GITHUB_OUTPUT
+          else
+            echo "name=deckhouse-test" >> $GITHUB_OUTPUT
+          fi
+      - name: Import secrets
+        id: secrets
+        uses: hashicorp/vault-action@v2
+        with:
+          url: https://seguro.flant.com
+          path: github
+          role: "${{ steps.split.outputs.name }}"
+          method: jwt
+          jwtGithubAudience: github-access-aud
+          secrets: |
+            projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/registry_host DECKHOUSE_DEV_REGISTRY_HOST | DECKHOUSE_DEV_REGISTRY_HOST ;
+            projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/registry_host DECKHOUSE_REGISTRY_STAGE_HOST | DECKHOUSE_REGISTRY_STAGE_HOST ;
+            projects/data/101ceaca-97cd-462f-aed5-070d9b9de175/dev-registry/writetoken login | DECKHOUSE_DEV_REGISTRY_USER ;
+            projects/data/101ceaca-97cd-462f-aed5-070d9b9de175/dev-registry/writetoken password | DECKHOUSE_DEV_REGISTRY_PASSWORD ;
+            projects/data/101ceaca-97cd-462f-aed5-070d9b9de175/stage-registry/writetoken login | DECKHOUSE_REGISTRY_STAGE_USER ;
+            projects/data/101ceaca-97cd-462f-aed5-070d9b9de175/stage-registry/writetoken password | DECKHOUSE_REGISTRY_STAGE_PASSWORD ;
+            projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/fox_pull_secret SOURCE_REPO_GIT | SOURCE_REPO_GIT ;
+            projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/fox_pull_secret CLOUD_PROVIDERS_SOURCE_REPO | CLOUD_PROVIDERS_SOURCE_REPO ;
+            projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/fox_pull_secret OBSERVABILITY_SOURCE_REPO | OBSERVABILITY_SOURCE_REPO ;
+            projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/fox_pull_secret DECKHOUSE_PRIVATE_REPO | DECKHOUSE_PRIVATE_REPO ;
+            projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/fox_pull_secret SOURCE_REPO_SSH_KEY | SOURCE_REPO_SSH_KEY ;
+            projects/data/24cb1d7c-717a-4f92-8547-26f632916a7a/Svace_CI SVACE_ANALYZE_SSH_PRIVATE_KEY | SVACE_ANALYZE_SSH_PRIVATE_KEY ;
+            projects/data/24cb1d7c-717a-4f92-8547-26f632916a7a/Svace_CI SVACE_ANALYZE_HOST | SVACE_ANALYZE_HOST ;
+            projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/team-ssdlc/loop webhook_url | LOOP_SERVICE_NOTIFICATIONS ;
+
+      # </template: import_secrets>
+
+      # <template: checkout_full_step>
+      - name: Checkout sources
+        uses: actions/checkout@v3.5.2
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.resolve_target.outputs.sha }}
+      # </template: checkout_full_step>
+      - name: Print git context
+        run: |
+          # Diagnostic: which commit werf will actually build from.
+          # GITHUB_SHA is the workflow run's commit (immutable, runner-injected);
+          # git HEAD is what actions/checkout left in the work tree (may differ
+          # for runs that override `ref`, e.g. reproducibility-check.yml).
+          echo "==== git context ===="
+          echo "GITHUB_SHA env:        ${GITHUB_SHA}"
+          echo "GITHUB_REF env:        ${GITHUB_REF}"
+          echo "git HEAD (full):       $(git rev-parse HEAD)"
+          echo "git HEAD (short):      $(git rev-parse --short HEAD)"
+          git log -1 --pretty='format:  commit:  %H%n  author:  %an <%ae>%n  date:    %ad%n  subject: %s'
+          echo
+          echo "====================="
+
+      # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then
+            echo "has_credentials=true" >> $GITHUB_OUTPUT
+            echo "web_registry_path=${{steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_HOST }}/deckhouse/site" >> $GITHUB_OUTPUT
+          fi
+      - name: Login to dev registry
+        uses: docker/login-action@v2.1.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
+        with:
+          registry: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_HOST }}
+          username: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_USER }}
+          password: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
+          logout: false
+      # </template: login_dev_registry_step>
+
+
+      # <template: read_werf_version_step>
+      - name: Read werf version from werf_envs.yml
+        id: read_werf_version
+        run: |
+          set -euo pipefail
+          WERF_ENVS_FILE=".github/ci_includes/werf_envs.yml"
+          if [[ ! -f "$WERF_ENVS_FILE" ]]; then
+            echo "::error title=WERF version::File ${WERF_ENVS_FILE} not found"
+            exit 1
+          fi
+          WERF_VERSION="$(grep -E '^[[:space:]]*WERF_VERSION:' "$WERF_ENVS_FILE" | head -1 | sed -E 's/^[[:space:]]*WERF_VERSION:[[:space:]]*"?([^"#[:space:]]+)"?.*/\1/')"
+          if [[ ! "$WERF_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z"
+            exit 1
+          fi
+          echo "Detected WERF_VERSION=${WERF_VERSION}"
+          echo "WERF_VERSION=${WERF_VERSION}" >> "$GITHUB_ENV"
+          echo "werf_version=${WERF_VERSION}" >> "$GITHUB_OUTPUT"
+      # </template: read_werf_version_step>
+
+      # <template: werf_install_step>
+      - name: Install werf-dk CLI
+        run: |
+          if [[ -z "${WERF_VERSION:-}" ]]; then
+            echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
+            exit 1
+          fi
+          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
+          echo "$WERF_PATH" >> "$GITHUB_PATH"
+          CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+            echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
+            mkdir -p "$WERF_PATH"
+            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
+            chmod +x "$WERF_PATH/werf"
+          else
+            echo "Current werf is $CACHED_VERSION, skipping download"
+          fi
+      # </template: werf_install_step>
+
+      # <template: add_ssh_keys>
+      - name: Start ssh-agent
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: |
+            ${{ steps.secrets.outputs.SOURCE_REPO_SSH_KEY }}
+            ${{ steps.secrets.outputs.SVACE_ANALYZE_SSH_PRIVATE_KEY }}
+      - name: Add ssh_known_hosts
+        run: |
+          HOST=$(grep -oP '(?<=@)[^/:]+' <<< ${{ steps.secrets.outputs.SOURCE_REPO_GIT }})
+          echo "::add-mask::$HOST"
+          IPS=$(nslookup "$HOST" | awk '/^Address: / { print $2 }')
+          for IP in $IPS; do
+            echo "::add-mask::$IP"
+          done
+          mkdir -p ~/.ssh
+          touch ~/.ssh/known_hosts
+          HOST_KEYS=$(ssh-keyscan -H "$HOST" 2>/dev/null)
+          while IFS= read -r KEY_LINE; do
+            CONSTANT_PART=$(awk '{print $2, $3}' <<< "$KEY_LINE")
+            if ! grep -q "$CONSTANT_PART" ~/.ssh/known_hosts; then
+              echo "$KEY_LINE" >> ~/.ssh/known_hosts
+            fi
+          done <<< "$HOST_KEYS"
+      - name: Add svace analyze server to ssh_known_hosts
+        continue-on-error: true
+        run: |
+          host=${{ steps.secrets.outputs.SVACE_ANALYZE_HOST }}
+          host_ip=$(nslookup "$host" | awk '/^Address: / { print $2 }')
+          echo "::add-mask::$host_ip"
+          mkdir -p ~/.ssh
+          touch ~/.ssh/known_hosts
+          HOST_KEYS=$(ssh-keyscan -H "$host" 2>/dev/null)
+          while IFS= read -r KEY_LINE; do
+              CONSTANT_PART=$(awk '{print $2, $3}' <<< "$KEY_LINE")
+              if grep -q "$CONSTANT_PART" ~/.ssh/known_hosts; then
+                  ssh-keygen -R $host
+                  ssh-keygen -R $host_ip
+              fi
+              echo "$KEY_LINE" >> ~/.ssh/known_hosts
+          done <<< "$HOST_KEYS"
+      # </template: add_ssh_keys>
+      - name: Set PR tag
+        id: set-pr-tag
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ ${REPO_SUFFIX} == ${GITHUB_REPOSITORY} ]] ; then
+            TAG="pr${PR_NUMBER}"
+          else
+            TAG="pr${PR_NUMBER}-${REPO_SUFFIX}"
+          fi
+          echo "PR tag to scan: $TAG"
+          echo "tags=$(printf '%s' "$TAG" | jq -R -s -c 'split("\n") | map(select(length > 0))')" >> $GITHUB_OUTPUT
+
+      - name: Build and push deckhouse images
+        id: build
+        env:
+          WERF_EXPERIMENTAL_IMPORT_BY_SOURCE_IMAGE_TAG: 1
+          WERF_DOCKER_REGISTRY_DEBUG: 1
+          WERF_TELEMETRY: "1"
+          WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
+          WERF_DISABLE_PUBLISH_TAG_CACHE_SYNC: 1
+          DECKHOUSE_DEV_REGISTRY_USER : ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_USER }}
+          DECKHOUSE_DEV_REGISTRY_PASSWORD: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
+          DEV_REGISTRY_HOST: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_HOST }}
+          SOURCE_REPO: "${{ steps.secrets.outputs.SOURCE_REPO_GIT }}"
+          CLOUD_PROVIDERS_SOURCE_REPO: "${{ steps.secrets.outputs.CLOUD_PROVIDERS_SOURCE_REPO }}"
+          OBSERVABILITY_SOURCE_REPO: "${{ steps.secrets.outputs.OBSERVABILITY_SOURCE_REPO }}"
+          DECKHOUSE_PRIVATE_REPO: "${{ steps.secrets.outputs.DECKHOUSE_PRIVATE_REPO }}"
+          VAULT_ADDR: "https://seguro.flant.com"
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+          CI_COMMIT_REF_SLUG: ${{needs.pull_request_info.outputs.ref_slug}}
+          WERF_SIGN_KEY: "hashivault://dh-dev-v01"
+          TRANSIT_SECRET_ENGINE_PATH: "dev-int-signer"
+          WERF_VAULT_AUTH_ROLE: "dh-signer-dev_dh-signer-dev"
+          INTERMEDIARY_CERT_PATH: "dev-int-pki/issuer/default/pem"
+          SIGNING_CERT_PATH: "dev-int-pki/cert/56:61:03:74:72:94:e1:e7:7b:d9:ac:44:f1:4c:57:aa:2b:b2:8d:9d"
+          REGISTRY_USER: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_USER }}
+          REGISTRY_PASSWORD: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
+          SVACE_ANALYZE_HOST: "${{ secrets.SVACE_ANALYZE_HOST }}"
+          SVACE_ANALYZE_SSH_USER: "${{ secrets.SVACE_ANALYZE_SSH_USER }}"
+          WERF_SIGN_ELF_FILES: "0"
+          WERF_SIGN_MANIFEST: "1"
+          WERF_ANNOTATE_LAYERS_WITH_DM_VERITY_ROOT_HASH: "1"
+          WERF_VAULT_AUTH_PATH: "github"
+          WERF_ACTIONS_AUDIENCE: "github-access-aud"
+        run: |
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
+
+          # Put tags on produced images and push to dev and release repositories.
+          #
+          # There are 2 modes: "dev" and "release".
+          # The "dev" mode builds branches only:
+          # - Build using dev-registry as primary and deckhouse registry as secondary.
+          # - Push dev and dev/install images with prNUM tags and push to dev-registry.
+          # The "release" mode builds branches and tags:
+          # - Build using deckhouse registry as final and dev-registry as primary.
+          # - Push dev and dev/install images to dev-registry with tag equal to a branch name (main or release-X.Y).
+          # - Push dev, dev/install and release-channel-version images to deckhouse registry with tag equels to a Git tag.
+
+          # IMAGE_NAME is a name of image from werf.yaml.
+          # IMAGE_DST is an image name for docker push.
+          function publish_image() {
+            IMAGE_NAME=$1
+            IMAGE_DST_REPO=$2
+            IMAGE_DST_TAG=$3
+            IMAGE_SRC_REPO="$(jq -r ".Images.\"${IMAGE_NAME}\".DockerRepo" images_tags_werf.json)"
+            IMAGE_SRC_TAG="$(jq -r ".Images.\"${IMAGE_NAME}\".DockerTag" images_tags_werf.json)"
+            IMAGE_DIGEST="$(jq -r ".Images.\"${IMAGE_NAME}\".DockerImageDigest" images_tags_werf.json)"
+            IMAGE_DIGEST="${IMAGE_DIGEST#sha256:}"
+            echo "⚓️ 💫 [$(date -u)] Publishing '${IMAGE_NAME}' image to ${IMAGE_DST_REPO}:${IMAGE_DST_TAG}".
+            regctl image copy "${IMAGE_SRC_REPO}:${IMAGE_SRC_TAG}" "${IMAGE_DST_REPO}:${IMAGE_DST_TAG}"
+            if (regctl image manifest "${IMAGE_SRC_REPO}:sha256-${IMAGE_DIGEST}.att" > /dev/null 2>&1); then
+              echo "⚓️ 💫 [$(date -u)] Copying '${IMAGE_NAME}' attestation"
+              regctl image copy "${IMAGE_SRC_REPO}:sha256-${IMAGE_DIGEST}.att" "${IMAGE_DST_REPO}:sha256-${IMAGE_DIGEST}.att"
+            else
+              echo "⚓️ 💫 [$(date -u)] Attestation for '${IMAGE_NAME}' not found, skipping..."
+            fi
+          }
+
+          # CE/EE/FE -> ce/ee/fe
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          DEV_REGISTRY_PATH="${DECKHOUSE_DEV_REGISTRY_HOST}/${REGISTRY_PATH}"
+          export REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          export WERF_REPO="${DEV_REGISTRY_PATH}"
+
+          # Determine image tag
+          if [[ -n ${WERF_ENV} && ${WERF_ENV,,} != "fe" ]]; then
+            IMAGE_EDITION=${WERF_ENV,,}
+          fi
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
+
+          # Check whether current DDK version supports signing
+          sign_minimal_version="v2.71.0-dk"
+          sign_current_version="$(werf version)"
+          sign_supported=true
+          if [[ $sign_minimal_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+            sign_minimal_major=${BASH_REMATCH[1]}
+            sign_minimal_minor=${BASH_REMATCH[2]}
+          fi
+          if [[ $sign_current_version =~ v([0-9]+)\.([0-9]+)\.([0-9]+)-dk ]]; then
+            sign_current_major=${BASH_REMATCH[1]}
+            sign_current_minor=${BASH_REMATCH[2]}
+          else
+            sign_supported=false
+          fi
+          if (( sign_current_major < sign_minimal_major )); then
+            sign_supported=false
+          elif (( sign_current_major == sign_minimal_major && sign_current_minor < sign_minimal_minor )); then
+            sign_supported=false
+          fi
+
+          # Prepare for image and binary signing
+          export WERF_VAULT_AUTH_JWT=$(jq -r .value <<< $(curl -qfsH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=github-access-aud" ))
+          if [ -n "${WERF_VAULT_AUTH_JWT}" ]; then
+            echo "Received Actions token";
+          else
+            echo "Actions token empty";
+          fi
+          export VAULT_TOKEN="$(curl -sfX POST "${VAULT_ADDR}/v1/auth/${WERF_VAULT_AUTH_PATH}/login" -d '{"role":"'${WERF_VAULT_AUTH_ROLE}'","jwt":"'${WERF_VAULT_AUTH_JWT}'"}' | jq -r '.auth.client_token')"
+          if [ -n "${VAULT_TOKEN}" ]; then
+            echo "Received Vault token";
+          else
+            echo "Vault token empty";
+          fi
+
+          if $sign_supported; then
+            echo "Using WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+            export WERF_SIGN_INTERMEDIATES=$(curl -sf "${VAULT_ADDR}/v1/${INTERMEDIARY_CERT_PATH}" | base64 -w0)
+            export WERF_SIGN_CERT=$(curl -sf --header "X-Vault-Token: ${VAULT_TOKEN}" "${VAULT_ADDR}/v1/${SIGNING_CERT_PATH}" | jq -r '.data.certificate' | base64 -w0)
+          else
+            # fallback to non-signed version
+            export WERF_SIGN_MANIFEST="0"
+            echo "Fallback to WERF_SIGN_MANIFEST=$WERF_SIGN_MANIFEST"
+          fi
+
+          type werf && source $(werf ci-env github --verbose --as-file)
+          werf build \
+            --parallel=true --parallel-tasks-limit=5 \
+            --save-build-report=true \
+            --build-report-path images_tags_werf.json
+
+          # Publish images for Git branch.
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            echo "⚓️ 💫 [$(date -u)] Publish images to dev-registry for branch '${CI_COMMIT_BRANCH}' and edition '${WERF_ENV}' using tag '${IMAGE_TAG}' ..."
+            publish_image 'dev' "${REGISTRY_PATH}" "${IMAGE_TAG}"
+            publish_image 'dev/install' "${REGISTRY_PATH}/install" "${IMAGE_TAG}"
+            publish_image 'dev/install-standalone' "${REGISTRY_PATH}/install-standalone" "${IMAGE_TAG}"
+            publish_image 'e2e-opentofu-eks' "${REGISTRY_PATH}/e2e-opentofu-eks" "${IMAGE_TAG}"
+
+            # For release branches, also push release-channel to dev
+            if [[ ${WERF_ENV,,} == "fe" && "${CI_COMMIT_BRANCH}" =~ release-([0-9]+\.[0-9]+) ]]; then
+              publish_image 'dev' "${REGISTRY_PATH}" "v${BASH_REMATCH[1]}.0"
+              publish_image 'dev/install' "${REGISTRY_PATH}/install" "v${BASH_REMATCH[1]}.0"
+              publish_image 'dev/install-standalone' "${REGISTRY_PATH}/install-standalone" "v${BASH_REMATCH[1]}.0"
+              publish_image 'release-channel-version' "${REGISTRY_PATH}/release-channel" "v${BASH_REMATCH[1]}.0"
+              publish_image 'e2e-opentofu-eks' "${REGISTRY_PATH}/e2e-opentofu-eks" "v${BASH_REMATCH[1]}.0"
+            fi
+          else
+            echo "Branch unset, skipping branch publish."
+          fi
+
+          # Publish images for Git tag.
+          if [[ "${CI_COMMIT_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "⚓️ 💫 [$(date -u)] Publish images for Git tag '${CI_COMMIT_TAG}' and registry suffix '${REGISTRY_SUFFIX}' using tag '${IMAGE_TAG}' ..."
+            publish_image 'dev' "${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}" "${IMAGE_TAG}"
+            publish_image 'dev/install' "${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install" "${IMAGE_TAG}"
+            publish_image 'dev/install-standalone' "${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install-standalone" "${IMAGE_TAG}"
+            publish_image 'release-channel-version' "${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel" "${IMAGE_TAG}"
+            publish_image 'e2e-opentofu-eks' "${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/e2e-opentofu-eks" "${IMAGE_TAG}"
+          else
+            echo "Not a release tag, skipping tag publish."
+          fi
+
+          # Save 'tests' image name to pass it as output for 'tests' jobs.
+          TESTS_IMAGE_NAME="$(jq -r '.Images."tests".DockerImageName' images_tags_werf.json)"
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'
+          # Encode as gzip+base64 to evade github's SecretMasker error: "Skip output since it may contain secret".
+          echo "tests_image_name=$(echo ${TESTS_IMAGE_NAME} | gzip | base64 -w0)" >> $GITHUB_OUTPUT
+
+          # Filter out data from build report
+          egrep -v '(DockerRepo|DockerImageName)' images_tags_werf.json > images_tags_werf_filtered.json
+          mv images_tags_werf_filtered.json images_tags_werf.json
+
+
+
+      - name: Save build report
+        if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
+        uses: actions/upload-artifact@v4.4.0
+        with:
+          name: build_report_${{ env.WERF_ENV }}
+          path: images_tags_werf.json
+      - name: Extract images_digests.json
+        env:
+          DEV_REGISTRY: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_HOST }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ ${REPO_SUFFIX} == ${GITHUB_REPOSITORY} ]] ; then
+            IMAGE_TAG="pr${PR_NUMBER}"
+          else
+            IMAGE_TAG="pr${PR_NUMBER}-${REPO_SUFFIX}"
+          fi
+          regctl image get-file "${DEV_REGISTRY}/sys/deckhouse-oss:${IMAGE_TAG}" \
+            /deckhouse/modules/images_digests.json > images_digests.json
+          modules=$(jq 'keys | length' images_digests.json)
+          images=$(jq '[.[] | to_entries[]] | length' images_digests.json)
+          echo "images_digests.json: ${modules} modules, ${images} module images."
+      - name: Compute changed images
+        id: diff
+        env:
+          BUILD_REPORT_PATH:   ./images_tags_werf.json
+          IMAGES_DIGESTS_PATH: ./images_digests.json
+          OUTPUT_CHANGED:      ./changed_images.json
+        run: |
+          python3 .github/scripts/python/changed_images.py
+
+      - name: Cleanup workdir
+        if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
+        run: |
+          rm images_tags_werf.json || true
+          rm changed_images.json || true
+          rm images_digests.json || true
+
+    # </template: build_template>
+
+
+  compare_reports:
+    name: Compare build reports
+    runs-on: "self-slim"
+    needs:
+      - resolve_target
+      - build_fe_main
+      - build_fe_dev
+    if: ${{ always() && (needs.build_fe_main.result == 'success' || needs.build_fe_dev.result == 'success') }}
+    steps:
+      # Plain checkout (no ref override): we need the reproducibility_check.py
+      # from the workflow's branch (main), NOT from the historical target SHA.
+
+      # <template: checkout_step>
+      - name: Checkout sources
+        uses: actions/checkout@v3.5.2
+
+      # </template: checkout_step>
+
+      - name: Download baseline build_report_FE
+        uses: actions/download-artifact@v4.1.8
+        with:
+          name: build_report_FE
+          path: baseline/build_report_FE
+          run-id: ${{ needs.resolve_target.outputs.baseline_run_id }}
+          github-token: ${{ secrets.BOATSWAIN_GITHUB_TOKEN }}
+
+      - name: Download rerun build_report_FE
+        uses: actions/download-artifact@v4.1.8
+        with:
+          name: build_report_FE
+          path: rerun/build_report_FE
+
+      - name: Upload baseline build_report as workflow artifact
+        uses: actions/upload-artifact@v4.4.0
+        with:
+          name: baseline_build_report_FE
+          path: baseline/build_report_FE/images_tags_werf.json
+
+      - name: Upload rerun build_report as workflow artifact
+        uses: actions/upload-artifact@v4.4.0
+        with:
+          name: rerun_build_report_FE
+          path: rerun/build_report_FE/images_tags_werf.json
+
+      - name: Print resolved context
+        run: |
+          echo "Target SHA:        ${{ needs.resolve_target.outputs.sha }}"
+          echo "Baseline workflow: ${{ needs.resolve_target.outputs.baseline_workflow }}"
+          echo "Baseline run:      ${{ needs.resolve_target.outputs.baseline_run_url }}"
+          echo "PR number (dev):   ${{ needs.resolve_target.outputs.pr_number }}"
+
+      - name: Compare digests
+        run: |
+          python3 .github/scripts/python/reproducibility_check.py \
+            baseline/build_report_FE/images_tags_werf.json \
+            rerun/build_report_FE/images_tags_werf.json
+
+  # Single Loop alert for the build reproducibility check. Runs on any trigger
+  # (run_attempt == 1, deckhouse/deckhouse only) and picks ONE reason to report,
+  # evaluated in priority order: a slow rebuild first (so it does not clash with
+  # the failure conditions), then a digest mismatch, then a failed FE rebuild,
+  # then a baseline-resolution error. If nothing is wrong, nothing is sent.
+  send_alert_about_workflow_problem:
+    name: Send alert about workflow problem
+    runs-on: "regular"
+    needs:
+      - resolve_target
+      - build_fe_main
+      - build_fe_dev
+      - compare_reports
+    if: ${{ always() && github.repository == 'deckhouse/deckhouse' && github.run_attempt == 1 }}
+    steps:
+    # <template: import_secrets>
+    - name: Split repository name
+      id: split
+      env:
+        REPO: ${{ github.repository }}
+      run: |
+        if [ $REPO == "deckhouse/deckhouse" ]; then
+          echo "name=deckhouse" >> $GITHUB_OUTPUT
+        else
+          echo "name=deckhouse-test" >> $GITHUB_OUTPUT
+        fi
+    - name: Import secrets
+      id: secrets
+      uses: hashicorp/vault-action@v2
+      with:
+        url: https://seguro.flant.com
+        path: github
+        role: "${{ steps.split.outputs.name }}"
+        method: jwt
+        jwtGithubAudience: github-access-aud
+        secrets: |
+          projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/team-ssdlc/loop token | LOOP_CVE_REPORTS_SEND_TOKEN ;
+          projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/team-ssdlc/loop channel_id | LOOP_E2E_REPORT_CHANNEL_ID ;
+
+    # </template: import_secrets>
+    - name: Measure rebuild job duration
+      id: duration
+      if: always()
+      uses: actions/github-script@v6.4.1
+      with:
+        github-token: ${{ secrets.BOATSWAIN_GITHUB_TOKEN }}
+        script: |
+          const THRESHOLD_SECONDS = 300; // 5 minutes
+
+          const jobs = await github.paginate(
+            github.rest.actions.listJobsForWorkflowRun,
+            { owner: context.repo.owner, repo: context.repo.repo, run_id: context.runId, per_page: 100 },
+          );
+          const buildJob = jobs.find(j => j.name && j.name.startsWith('Build FE'));
+          if (!buildJob || buildJob.conclusion !== 'success' || !buildJob.started_at || !buildJob.completed_at) {
+            core.info(`No completed-successful Build FE job (conclusion=${buildJob ? buildJob.conclusion : 'absent'}); slow check skipped.`);
+            core.setOutput('slow', 'false');
+            return;
+          }
+
+          const durSec = Math.round((new Date(buildJob.completed_at) - new Date(buildJob.started_at)) / 1000);
+          const durHuman = `${Math.floor(durSec / 60)}m ${durSec % 60}s`;
+          core.info(`Build FE job '${buildJob.name}' duration: ${durHuman} (${durSec}s); threshold ${THRESHOLD_SECONDS}s`);
+          if (durSec > THRESHOLD_SECONDS) {
+            core.setOutput('slow', 'true');
+            core.setOutput('duration_human', durHuman);
+            core.setOutput('job_url', buildJob.html_url);
+          } else {
+            core.setOutput('slow', 'false');
+          }
+    - name: Check loop alerting credentials
+      id: check_loop_alerting
+      if: always()
+      env:
+        LOOP_TOKEN: ${{ steps.secrets.outputs.LOOP_CVE_REPORTS_SEND_TOKEN }}
+      run: |
+        if [[ -n $LOOP_TOKEN ]]; then echo "has_credentials=true" >> $GITHUB_OUTPUT; fi
+    - name: Send loop alert
+      if: ${{ always() && steps.check_loop_alerting.outputs.has_credentials == 'true' }}
+      env:
+        LOOP_TOKEN: ${{ steps.secrets.outputs.LOOP_CVE_REPORTS_SEND_TOKEN }}
+        LOOP_CHANNEL_ID: ${{ steps.secrets.outputs.LOOP_E2E_REPORT_CHANNEL_ID }}
+        SLOW: ${{ steps.duration.outputs.slow }}
+        DURATION_HUMAN: ${{ steps.duration.outputs.duration_human }}
+        JOB_URL: ${{ steps.duration.outputs.job_url }}
+        COMPARE_RESULT: ${{ needs.compare_reports.result }}
+        BUILD_MAIN_RESULT: ${{ needs.build_fe_main.result }}
+        BUILD_DEV_RESULT: ${{ needs.build_fe_dev.result }}
+        RESOLVE_RESULT: ${{ needs.resolve_target.result }}
+        TARGET_SHA: ${{ needs.resolve_target.outputs.sha }}
+      run: |
+        WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
+
+        # Priority order: a slow (but successful) rebuild is checked first so it
+        # does not clash with the failure/mismatch conditions below.
+        if [[ "$SLOW" == "true" ]]; then
+          MESSAGE="🐢Build reproducibility rebuild is slow🐢\nBuild FE job took ${DURATION_HUMAN} (threshold 5m)\nSHA: ${TARGET_SHA}\n[URL](${JOB_URL})"
+        elif [[ "$COMPARE_RESULT" == "failure" ]]; then
+          MESSAGE="🛑Build reproducibility check failed🛑\nReason: digest mismatch on rebuild (build is not reproducible)\nSHA: ${TARGET_SHA}\n[URL](${WORKFLOW_URL})"
+        elif [[ "$BUILD_MAIN_RESULT" == "failure" || "$BUILD_DEV_RESULT" == "failure" ]]; then
+          MESSAGE="🛑Build reproducibility check failed🛑\nReason: FE rebuild failed\nSHA: ${TARGET_SHA}\n[URL](${WORKFLOW_URL})"
+        elif [[ "$RESOLVE_RESULT" == "failure" ]]; then
+          MESSAGE="🛑Build reproducibility check failed🛑\nReason: failed to resolve baseline / workflow error\nSHA: ${TARGET_SHA}\n[URL](${WORKFLOW_URL})"
+        else
+          echo "Nothing to alert about (build succeeded within the time budget)."
+          exit 0
+        fi
+
+        alertData=$(cat <<EOF
+        {
+        "channel_id": "${LOOP_CHANNEL_ID}",
+        "message": "${MESSAGE}"
+        }
+        EOF
+        )
+
+        for (( iter = 1; iter < 60; iter++ )); do
+          if curl -f -L -X POST "https://loop.flant.ru/api/v4/posts" -H "Content-Type: application/json" -H "Authorization: Bearer ${LOOP_TOKEN}" --data "${alertData}"; then
+            exit 0
+          fi
+
+          echo "Alert was not sent. Wait 5 seconds before next attempt"
+          sleep 5
+        done
+
+        echo "Alert was not sent. Timeout"
+        exit 1


### PR DESCRIPTION
## Description
Optimize build workflow by lowering the amount of jobs in a build workflow.
Decreases the total amount of jobs form 35 to 29, and the longest path from 6 to 4 jobs.
Tests:
https://github.com/deckhouse/deckhouse-test-1/actions/runs/29070463260
https://github.com/deckhouse/deckhouse-test-1/actions/runs/29003704816
https://github.com/deckhouse/deckhouse-test-1/actions/runs/29003899475
https://github.com/deckhouse/deckhouse-test-1/actions/runs/29004564825

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: ci
type: chore
summary: Optimize build workflow.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
