### PR TITLE
[docs] Raise readiness probe tolerance for modules library

### DIFF
--- a/docs/site/.helm/templates/14-moduleslibrary.yaml
+++ b/docs/site/.helm/templates/14-moduleslibrary.yaml
@@ -70,7 +70,7 @@ spec:
             httpGet:
               path: /healthz
               port: 8080
-            {{- include "readiness_probe" . | indent 12 }}
+            {{- include "readiness_probe_moduleslibrary" . | indent 12 }}
           volumeMounts:
             - mountPath: /app/en/modules
               name: modules-docs-en
@@ -139,7 +139,7 @@ spec:
             httpGet:
               path: /readyz
               port: 8081
-            {{- include "readiness_probe" . | indent 12 }}
+            {{- include "readiness_probe_moduleslibrary" . | indent 12 }}
           volumeMounts:
             - mountPath: "/mount/public/en/modules"
               name: modules-docs-en

--- a/docs/site/.helm/templates/_helpers.tpl
+++ b/docs/site/.helm/templates/_helpers.tpl
@@ -56,6 +56,11 @@ failureThreshold: 5
 periodSeconds: 10
 timeoutSeconds: 5
 {{- end }}
+{{- define "readiness_probe_moduleslibrary" }}
+failureThreshold: 60
+periodSeconds: 10
+timeoutSeconds: 5
+{{- end }}
 {{- define "liveness_probe" }}
 failureThreshold: 10
 periodSeconds: 10


### PR DESCRIPTION
## Description

Fix deploy for module library deployment:
- Introduce a dedicated readiness probe helper with a higher failure threshold of 60 to accommodate slower startup times for the modules library containers
- Switch both container readiness probes to reference the new specialised helper instead of the shared default definition

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Raise readiness probe tolerance for modules library.
impact_level: low
```
