### PR TITLE
[user-authn] Add CPU limit to self-signed-generator init container

### DIFF
--- a/modules/150-user-authn/template_tests/authenticator_test.go
+++ b/modules/150-user-authn/template_tests/authenticator_test.go
@@ -416,11 +416,11 @@ var _ = Describe("Module :: user-authn :: helm template :: dex authenticator", f
 			deployment := hec.KubernetesResource("Deployment", "d8-test", "test-with-resources-dex-authenticator")
 			Expect(deployment.Exists()).To(BeTrue())
 
-			// Check init container resources
+			// Init limits = sum of explicitly set main container limits (only dex here: 200m / 256Mi)
 			Expect(deployment.Field("spec.template.spec.initContainers.0.resources.requests.cpu").String()).To(Equal("10m"))
 			Expect(deployment.Field("spec.template.spec.initContainers.0.resources.requests.memory").String()).To(Equal("10Mi"))
-			Expect(deployment.Field("spec.template.spec.initContainers.0.resources.limits.cpu").String()).To(Equal("10m"))
-			Expect(deployment.Field("spec.template.spec.initContainers.0.resources.limits.memory").String()).To(Equal("10Mi"))
+			Expect(deployment.Field("spec.template.spec.initContainers.0.resources.limits.cpu").String()).To(Equal("200m"))
+			Expect(deployment.Field("spec.template.spec.initContainers.0.resources.limits.memory").String()).To(Equal("256Mi"))
 
 			// Check dex-authenticator container resources
 			Expect(deployment.Field("spec.template.spec.containers.0.resources.requests.cpu").String()).To(Equal("100m"))
@@ -432,6 +432,10 @@ var _ = Describe("Module :: user-authn :: helm template :: dex authenticator", f
 		It("Should apply resources to redis container when specified", func() {
 			deployment := hec.KubernetesResource("Deployment", "d8-test", "test-with-resources-both-dex-authenticator")
 			Expect(deployment.Exists()).To(BeTrue())
+
+			// Init limits = sum of dex + redis limits
+			Expect(deployment.Field("spec.template.spec.initContainers.0.resources.limits.cpu").String()).To(Equal("400m"))
+			Expect(deployment.Field("spec.template.spec.initContainers.0.resources.limits.memory").String()).To(Equal("512Mi"))
 
 			// Check dex-authenticator container resources
 			Expect(deployment.Field("spec.template.spec.containers.0.resources.requests.cpu").String()).To(Equal("150m"))
@@ -462,6 +466,10 @@ var _ = Describe("Module :: user-authn :: helm template :: dex authenticator", f
 
 			deployment := hec.KubernetesResource("Deployment", "d8-test", "test-without-resources-dex-authenticator")
 			Expect(deployment.Exists()).To(BeTrue())
+
+			// Init limits = sum of defaults (10m+10m, 25Mi+25Mi)
+			Expect(deployment.Field("spec.template.spec.initContainers.0.resources.limits.cpu").String()).To(Equal("20m"))
+			Expect(deployment.Field("spec.template.spec.initContainers.0.resources.limits.memory").String()).To(Equal("50Mi"))
 
 			// Check dex-authenticator container resources
 			Expect(deployment.Field("spec.template.spec.containers.0.resources.requests.cpu").String()).To(Equal("10m"))

--- a/modules/150-user-authn/template_tests/authenticator_test.go
+++ b/modules/150-user-authn/template_tests/authenticator_test.go
@@ -416,6 +416,12 @@ var _ = Describe("Module :: user-authn :: helm template :: dex authenticator", f
 			deployment := hec.KubernetesResource("Deployment", "d8-test", "test-with-resources-dex-authenticator")
 			Expect(deployment.Exists()).To(BeTrue())
 
+			// Check init container resources
+			Expect(deployment.Field("spec.template.spec.initContainers.0.resources.requests.cpu").String()).To(Equal("10m"))
+			Expect(deployment.Field("spec.template.spec.initContainers.0.resources.requests.memory").String()).To(Equal("10Mi"))
+			Expect(deployment.Field("spec.template.spec.initContainers.0.resources.limits.cpu").String()).To(Equal("10m"))
+			Expect(deployment.Field("spec.template.spec.initContainers.0.resources.limits.memory").String()).To(Equal("10Mi"))
+
 			// Check dex-authenticator container resources
 			Expect(deployment.Field("spec.template.spec.containers.0.resources.requests.cpu").String()).To(Equal("100m"))
 			Expect(deployment.Field("spec.template.spec.containers.0.resources.requests.memory").String()).To(Equal("128Mi"))

--- a/modules/150-user-authn/templates/dex-authenticator/deployment.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/deployment.yaml
@@ -150,6 +150,7 @@ spec:
             cpu: 10m
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
           limits:
+            cpu: 10m
             memory: 10Mi
         {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all_pss_restricted" . | nindent 8 }}
       containers:

--- a/modules/150-user-authn/templates/dex-authenticator/deployment.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/deployment.yaml
@@ -8,6 +8,41 @@ cpu: 10m
 memory: 25Mi
 {{- end }}
 
+{{- /* Init limits = sum of main container limits when set in CR (ResourceQuota: max(init, sum(app))). */ -}}
+{{- /* Defaults 20m / 50Mi when resources are not set = sum of dex+redis default requests. */ -}}
+{{- define "dex_authenticator_init_limits" -}}
+  {{- $cpuMillicores := 20 -}}
+  {{- $memBytes := 52428800 -}} {{- /* 50Mi */ -}}
+  {{- with . }}
+    {{- $dexCpu := "" -}}
+    {{- $redisCpu := "" -}}
+    {{- $dexMem := "" -}}
+    {{- $redisMem := "" -}}
+    {{- with .limits }}
+      {{- if .cpu }}{{ $dexCpu = .cpu }}{{ end -}}
+      {{- if .memory }}{{ $dexMem = .memory }}{{ end -}}
+    {{- end -}}
+    {{- with .redis }}
+      {{- with .limits }}
+        {{- if .cpu }}{{ $redisCpu = .cpu }}{{ end -}}
+        {{- if .memory }}{{ $redisMem = .memory }}{{ end -}}
+      {{- end -}}
+    {{- end -}}
+    {{- if or $dexCpu $redisCpu }}
+      {{- $cpuMillicores = 0 -}}
+      {{- if $dexCpu }}{{ $cpuMillicores = add $cpuMillicores (include "helm_lib_resources_management_cpu_units_to_millicores" $dexCpu | int) }}{{ end -}}
+      {{- if $redisCpu }}{{ $cpuMillicores = add $cpuMillicores (include "helm_lib_resources_management_cpu_units_to_millicores" $redisCpu | int) }}{{ end -}}
+    {{- end -}}
+    {{- if or $dexMem $redisMem }}
+      {{- $memBytes = 0 -}}
+      {{- if $dexMem }}{{ $memBytes = add $memBytes (include "helm_lib_resources_management_memory_units_to_bytes" $dexMem | int) }}{{ end -}}
+      {{- if $redisMem }}{{ $memBytes = add $memBytes (include "helm_lib_resources_management_memory_units_to_bytes" $redisMem | int) }}{{ end -}}
+    {{- end -}}
+  {{- end -}}
+cpu: {{ printf "%dm" $cpuMillicores }}
+memory: {{ div $memBytes 1048576 }}Mi
+{{- end }}
+
 {{- $context := . }}
 {{- $dexAuthenticatorNames := .Values.userAuthn.internal.dexAuthenticatorNames | default dict -}}
 {{- range $crd := .Values.userAuthn.internal.dexAuthenticatorCRDs }}
@@ -150,8 +185,7 @@ spec:
             cpu: 10m
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
           limits:
-            cpu: 10m
-            memory: 10Mi
+            {{- include "dex_authenticator_init_limits" ($crd.spec.resources | default dict) | nindent 12 }}
         {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all_pss_restricted" . | nindent 8 }}
       containers:
       - name: dex-authenticator

--- a/modules/150-user-authn/templates/user-api/deployment.yaml
+++ b/modules/150-user-authn/templates/user-api/deployment.yaml
@@ -84,7 +84,7 @@ spec:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
           limits:
             cpu: 10m
-            memory: 10Mi
+            memory: 25Mi
       containers:
       - name: user-api
         {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all_pss_restricted" . | nindent 8 }}

--- a/modules/150-user-authn/templates/user-api/deployment.yaml
+++ b/modules/150-user-authn/templates/user-api/deployment.yaml
@@ -83,6 +83,7 @@ spec:
             memory: 10Mi
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
           limits:
+            cpu: 10m
             memory: 10Mi
       containers:
       - name: user-api


### PR DESCRIPTION
Init container lacked `limits.cpu`, causing pod admission failures in namespaces with ResourceQuota or required-resources policies.

## Description

Added CPU and memory limits to the `self-signed-generator` init container in `dex-authenticator` (and aligned memory limit in `user-api`).

For `DexAuthenticator`, init limits are set to the **sum** of the main containers’ limits (`dex-authenticator` + `redis`) from `spec.resources` / `spec.resources.redis`. If resources are not set, defaults are used: `20m` CPU and `50Mi` memory (10m+10m / 25Mi+25Mi).

This matches ResourceQuota accounting: `max(init limits, sum of app container limits)`, so the init container does not inflate quota usage beyond the main containers.

## Why do we need it, and what problem does it solve?

When `ResourceQuota` is enabled in a namespace (or admission policies require CPU limits on all containers), Kubernetes rejects pods where any container — including init containers — lacks `limits.cpu`.

`DexAuthenticator` already allows configuring resources for `dex-authenticator` and `redis`, but the `self-signed-generator` init container had only `requests.cpu` and `limits.memory`. As a result, pods failed admission and `DexAuthenticator` could not start in quota-restricted namespaces.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authn
type: fix
summary: Fixed DexAuthenticator pod creation under ResourceQuota by setting init container CPU/memory limits to the sum of main container limits.
impact_level: default
```