### PR TITLE
[deckhouse][control-plane-manager] Delete obsolete ClusterObservabilityDashboards after module merges on beforeHelm

### DIFF
--- a/modules/002-deckhouse/hooks/migrate/delete_obsolete_monitoring_deckhouse_dashboard.go
+++ b/modules/002-deckhouse/hooks/migrate/delete_obsolete_monitoring_deckhouse_dashboard.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migrate
+
+import (
+	"context"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+
+	"github.com/deckhouse/deckhouse/go_lib/set"
+)
+
+// The monitoring-deckhouse module was merged into the deckhouse module (#20727), and its
+// Grafana dashboard main/deckhouse.json moved along with it. helm-lib builds the
+// ClusterObservabilityDashboard name as d8-<Chart.Name>-<path>, so the very same dashboard is
+// now rendered as d8-deckhouse-main-deckhouse instead of the former
+// d8-monitoring-deckhouse-main-deckhouse. The JSON is byte-identical, hence the uid inside it is
+// the same, and the observability webhook rejects a second ClusterObservabilityDashboard carrying
+// an already-present uid. Module deploy order cannot be changed, so the deckhouse module can start
+// rendering the new resource while the stale monitoring-deckhouse one still lingers in the cluster.
+// Delete the stale resource in beforeHelm so the new one applies cleanly.
+const obsoleteMonitoringDeckhouseDashboard = "d8-monitoring-deckhouse-main-deckhouse"
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	OnBeforeHelm: &go_hook.OrderedConfig{Order: 10},
+}, deleteObsoleteMonitoringDeckhouseDashboard)
+
+func deleteObsoleteMonitoringDeckhouseDashboard(_ context.Context, input *go_hook.HookInput) error {
+	// The ClusterObservabilityDashboard CRD exists only when the observability module is enabled;
+	// without it there is nothing to delete (and the resource cannot exist).
+	if !set.NewFromValues(input.Values, "global.enabledModules").Has("observability") {
+		return nil
+	}
+
+	// Delete is idempotent: a missing resource is not an error.
+	input.PatchCollector.Delete(
+		"observability.deckhouse.io/v1alpha1",
+		"ClusterObservabilityDashboard",
+		"", // cluster-scoped
+		obsoleteMonitoringDeckhouseDashboard,
+	)
+
+	return nil
+}

--- a/modules/002-deckhouse/hooks/migrate/delete_obsolete_monitoring_deckhouse_dashboard_test.go
+++ b/modules/002-deckhouse/hooks/migrate/delete_obsolete_monitoring_deckhouse_dashboard_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migrate
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("Modules :: deckhouse :: hooks :: migrate :: delete obsolete monitoring-deckhouse ClusterObservabilityDashboard", func() {
+	const obsoleteDashboard = `
+---
+apiVersion: observability.deckhouse.io/v1alpha1
+kind: ClusterObservabilityDashboard
+metadata:
+  name: d8-monitoring-deckhouse-main-deckhouse
+spec:
+  definition: "{}"
+`
+	const currentDashboard = `
+---
+apiVersion: observability.deckhouse.io/v1alpha1
+kind: ClusterObservabilityDashboard
+metadata:
+  name: d8-deckhouse-main-deckhouse
+spec:
+  definition: "{}"
+`
+
+	Context("When the observability module is enabled and the obsolete dashboard exists", func() {
+		f := HookExecutionConfigInit(`{}`, `{}`)
+		f.RegisterCRD("observability.deckhouse.io", "v1alpha1", "ClusterObservabilityDashboard", false)
+
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global.enabledModules", []byte(`[deckhouse, observability]`))
+			f.KubeStateSet(obsoleteDashboard + currentDashboard)
+			f.RunHook()
+		})
+
+		It("Deletes the obsolete dashboard and keeps the current one", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.KubernetesGlobalResource("ClusterObservabilityDashboard", "d8-monitoring-deckhouse-main-deckhouse").Exists()).To(BeFalse())
+			Expect(f.KubernetesGlobalResource("ClusterObservabilityDashboard", "d8-deckhouse-main-deckhouse").Exists()).To(BeTrue())
+		})
+	})
+
+	Context("When the observability module is disabled", func() {
+		f := HookExecutionConfigInit(`{}`, `{}`)
+		f.RegisterCRD("observability.deckhouse.io", "v1alpha1", "ClusterObservabilityDashboard", false)
+
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global.enabledModules", []byte(`[deckhouse]`))
+			f.KubeStateSet(obsoleteDashboard)
+			f.RunHook()
+		})
+
+		It("Keeps the obsolete dashboard untouched", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.KubernetesGlobalResource("ClusterObservabilityDashboard", "d8-monitoring-deckhouse-main-deckhouse").Exists()).To(BeTrue())
+		})
+	})
+
+	Context("When the observability module is enabled and the obsolete dashboard is absent", func() {
+		f := HookExecutionConfigInit(`{}`, `{}`)
+		f.RegisterCRD("observability.deckhouse.io", "v1alpha1", "ClusterObservabilityDashboard", false)
+
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global.enabledModules", []byte(`[deckhouse, observability]`))
+			f.KubeStateSet(currentDashboard)
+			f.RunHook()
+		})
+
+		It("Runs successfully and keeps the current dashboard", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.KubernetesGlobalResource("ClusterObservabilityDashboard", "d8-deckhouse-main-deckhouse").Exists()).To(BeTrue())
+		})
+	})
+})

--- a/modules/040-control-plane-manager/hooks/delete_obsolete_monitoring_kubernetes_control_plane_dashboards.go
+++ b/modules/040-control-plane-manager/hooks/delete_obsolete_monitoring_kubernetes_control_plane_dashboards.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"context"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+
+	"github.com/deckhouse/deckhouse/go_lib/set"
+)
+
+// The monitoring-kubernetes-control-plane module was merged into the control-plane-manager module
+// (#20734), and its Grafana dashboards moved along with it. helm-lib builds the
+// ClusterObservabilityDashboard name as d8-<Chart.Name>-<path>, so the very same dashboards are now
+// rendered as d8-control-plane-manager-* instead of the former
+// d8-monitoring-kubernetes-control-plane-*. The JSON is byte-identical, hence the uid inside each is
+// the same, and the observability webhook rejects a second ClusterObservabilityDashboard carrying
+// an already-present uid. Module deploy order cannot be changed, so the control-plane-manager module
+// can start rendering the new resources while the stale monitoring-kubernetes-control-plane ones
+// still linger in the cluster. Delete the stale resources in beforeHelm so the new ones apply
+// cleanly.
+var obsoleteMonitoringKubernetesControlPlaneDashboards = []string{
+	"d8-monitoring-kubernetes-control-plane-kubernetes-cluster-control-plane-status",
+	"d8-monitoring-kubernetes-control-plane-kubernetes-cluster-kube-etcd3",
+	"d8-monitoring-kubernetes-control-plane-kubernetes-cluster-deprecated-resources",
+}
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	OnBeforeHelm: &go_hook.OrderedConfig{Order: 10},
+}, deleteObsoleteMonitoringKubernetesControlPlaneDashboards)
+
+func deleteObsoleteMonitoringKubernetesControlPlaneDashboards(_ context.Context, input *go_hook.HookInput) error {
+	// The ClusterObservabilityDashboard CRD exists only when the observability module is enabled;
+	// without it there is nothing to delete (and the resources cannot exist).
+	if !set.NewFromValues(input.Values, "global.enabledModules").Has("observability") {
+		return nil
+	}
+
+	// Delete is idempotent: a missing resource is not an error.
+	for _, name := range obsoleteMonitoringKubernetesControlPlaneDashboards {
+		input.PatchCollector.Delete(
+			"observability.deckhouse.io/v1alpha1",
+			"ClusterObservabilityDashboard",
+			"", // cluster-scoped
+			name,
+		)
+	}
+
+	return nil
+}

--- a/modules/040-control-plane-manager/hooks/delete_obsolete_monitoring_kubernetes_control_plane_dashboards_test.go
+++ b/modules/040-control-plane-manager/hooks/delete_obsolete_monitoring_kubernetes_control_plane_dashboards_test.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("Modules :: control-plane-manager :: hooks :: delete obsolete monitoring-kubernetes-control-plane ClusterObservabilityDashboards", func() {
+	const obsoleteDashboards = `
+---
+apiVersion: observability.deckhouse.io/v1alpha1
+kind: ClusterObservabilityDashboard
+metadata:
+  name: d8-monitoring-kubernetes-control-plane-kubernetes-cluster-control-plane-status
+spec:
+  definition: "{}"
+---
+apiVersion: observability.deckhouse.io/v1alpha1
+kind: ClusterObservabilityDashboard
+metadata:
+  name: d8-monitoring-kubernetes-control-plane-kubernetes-cluster-kube-etcd3
+spec:
+  definition: "{}"
+---
+apiVersion: observability.deckhouse.io/v1alpha1
+kind: ClusterObservabilityDashboard
+metadata:
+  name: d8-monitoring-kubernetes-control-plane-kubernetes-cluster-deprecated-resources
+spec:
+  definition: "{}"
+`
+	const currentDashboards = `
+---
+apiVersion: observability.deckhouse.io/v1alpha1
+kind: ClusterObservabilityDashboard
+metadata:
+  name: d8-control-plane-manager-kubernetes-cluster-control-plane-status
+spec:
+  definition: "{}"
+`
+
+	Context("When the observability module is enabled and the obsolete dashboards exist", func() {
+		f := HookExecutionConfigInit(`{}`, `{}`)
+		f.RegisterCRD("observability.deckhouse.io", "v1alpha1", "ClusterObservabilityDashboard", false)
+
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global.enabledModules", []byte(`[control-plane-manager, observability]`))
+			f.KubeStateSet(obsoleteDashboards + currentDashboards)
+			f.RunHook()
+		})
+
+		It("Deletes all obsolete dashboards and keeps the current one", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.KubernetesGlobalResource("ClusterObservabilityDashboard", "d8-monitoring-kubernetes-control-plane-kubernetes-cluster-control-plane-status").Exists()).To(BeFalse())
+			Expect(f.KubernetesGlobalResource("ClusterObservabilityDashboard", "d8-monitoring-kubernetes-control-plane-kubernetes-cluster-kube-etcd3").Exists()).To(BeFalse())
+			Expect(f.KubernetesGlobalResource("ClusterObservabilityDashboard", "d8-monitoring-kubernetes-control-plane-kubernetes-cluster-deprecated-resources").Exists()).To(BeFalse())
+			Expect(f.KubernetesGlobalResource("ClusterObservabilityDashboard", "d8-control-plane-manager-kubernetes-cluster-control-plane-status").Exists()).To(BeTrue())
+		})
+	})
+
+	Context("When the observability module is disabled", func() {
+		f := HookExecutionConfigInit(`{}`, `{}`)
+		f.RegisterCRD("observability.deckhouse.io", "v1alpha1", "ClusterObservabilityDashboard", false)
+
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global.enabledModules", []byte(`[control-plane-manager]`))
+			f.KubeStateSet(obsoleteDashboards)
+			f.RunHook()
+		})
+
+		It("Keeps the obsolete dashboards untouched", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.KubernetesGlobalResource("ClusterObservabilityDashboard", "d8-monitoring-kubernetes-control-plane-kubernetes-cluster-control-plane-status").Exists()).To(BeTrue())
+			Expect(f.KubernetesGlobalResource("ClusterObservabilityDashboard", "d8-monitoring-kubernetes-control-plane-kubernetes-cluster-kube-etcd3").Exists()).To(BeTrue())
+			Expect(f.KubernetesGlobalResource("ClusterObservabilityDashboard", "d8-monitoring-kubernetes-control-plane-kubernetes-cluster-deprecated-resources").Exists()).To(BeTrue())
+		})
+	})
+
+	Context("When the observability module is enabled and the obsolete dashboards are absent", func() {
+		f := HookExecutionConfigInit(`{}`, `{}`)
+		f.RegisterCRD("observability.deckhouse.io", "v1alpha1", "ClusterObservabilityDashboard", false)
+
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global.enabledModules", []byte(`[control-plane-manager, observability]`))
+			f.KubeStateSet(currentDashboards)
+			f.RunHook()
+		})
+
+		It("Runs successfully and keeps the current dashboard", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.KubernetesGlobalResource("ClusterObservabilityDashboard", "d8-control-plane-manager-kubernetes-cluster-control-plane-status").Exists()).To(BeTrue())
+		})
+	})
+})


### PR DESCRIPTION
## Description

Adds `beforeHelm` hooks that delete stale `ClusterObservabilityDashboard` resources left over
after two module merges, before Helm applies the receiving module's release:

- **deckhouse** — deletes `d8-monitoring-deckhouse-main-deckhouse`.
- **control-plane-manager** — deletes `d8-monitoring-kubernetes-control-plane-kubernetes-cluster-{control-plane-status,kube-etcd3,deprecated-resources}`.

Both hooks are guarded by `global.enabledModules` — they do nothing unless the `observability`
module (which owns the CRD) is enabled. The delete is idempotent, so repeated reconciles and
clusters that never had the old modules are unaffected.

## Why do we need it, and what problem does it solve?

Grafana dashboards moved between modules during two merges:

- `monitoring-deckhouse` → `deckhouse` (#20727)
- `monitoring-kubernetes-control-plane` → `control-plane-manager` (#20734)

`helm-lib` names the generated `ClusterObservabilityDashboard` as `d8-<Chart.Name>-<path>`. After a
move the same dashboard JSON (byte-identical, so the same embedded `uid`) is rendered under a **new**
name derived from the receiving chart. The `observability` webhook rejects a second
`ClusterObservabilityDashboard` that carries an already-present `uid`.

On upgrade the receiving module renders the new resource before the removed module's release is
garbage-collected, and module deploy order cannot be changed — so the receiving module's release
fails to deploy. Removing the stale resources in `beforeHelm` lets the new ones apply cleanly.

## Why do we need it in the patch release (if we do)?

Yes — without it the upgrade breaks the `deckhouse` / `control-plane-manager` module deploy on
clusters that have the `observability` module enabled.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Remove the obsolete monitoring-deckhouse ClusterObservabilityDashboard so the deckhouse module deploys without a uid conflict.
```
```changes
section: control-plane-manager
type: fix
summary: Remove the obsolete monitoring-kubernetes-control-plane ClusterObservabilityDashboards so the control-plane-manager module deploys without a uid conflict.
```