### PR TITLE
[admission-policy-engine] Fix ratify Svace build

### DIFF
--- a/ee/se-plus/modules/015-admission-policy-engine/images/ratify/werf.inc.yaml
+++ b/ee/se-plus/modules/015-admission-policy-engine/images/ratify/werf.inc.yaml
@@ -43,7 +43,7 @@ shell:
     diff -qr "/src/config/crd/bases" "/module_crds/ratify"   
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
-from: {{ index $.Images ( eq $.SVACE_ENABLED "false" | ternary "builder/golang-1.26" "builder/golang-alt-svace" ) }}
+from: {{ index $.Images "builder/golang-1.26" }}
 final: false
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact


### PR DESCRIPTION
## Description
Build the ratify artifact on `builder/golang-1.26` unconditionally.

ratify requires Go >= 1.26. The Svace branch used `builder/golang-alt-svace` (Go 1.25), so `go build` failed with `go.mod requires go >= 1.26.0`. The fix drops the Svace branch and always uses `builder/golang-1.26`.

Build stage only, no runtime impact.

## Why do we need it, and what problem does it solve?
Fixes the failing build: https://github.com/deckhouse/deckhouse/actions/runs/29217090135/

## Why do we need it in the patch release (if we do)?
Not necessarily.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: ci
type: chore
summary: Build the ratify artifact on Go 1.26.
impact_level: low
```