### PR TITLE
[docs] Reduce external artifacts cache invalidation rate

### DIFF
--- a/docs/site/werf-web-frontend.inc.yaml
+++ b/docs/site/werf-web-frontend.inc.yaml
@@ -15,7 +15,7 @@
 
 {{- if and (ne $.Env "development") (ne $.Env "module") (ne $.Env "local") }}
 image: site-external-artifacts
-fromCacheVersion: {{ div .Commit.Date.Unix (mul 60 60) }}v1
+fromCacheVersion: v{{ div .Commit.Date.Unix (mul 60 60 24) }}
 from: {{ index $.Images "builder/alpine" }}
 final: false
 shell:


### PR DESCRIPTION
## Description

Reduce external artifacts cache invalidation rate in the documentation:
- Extend cache version granularity from hourly to daily by multiplying the divisor to include a full 24-hour period
- Reposition the version prefix to precede the computed value for consistent cache key formatting

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Reduce external artifacts cache invalidation rate in the documentation.
impact_level: low
```
