### PR TITLE
[deckhouse] Build web image on distroless builder/golang to fix Go stdlib CVEs

### DIFF
--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -3972,7 +3972,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:f639aa7651490569c527fa18da21ed25be69f5823ed293052acdae45bb4b3f36"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:0a64048dd8c1e8fa01e3bb028564ffc48032897f45c9b899d1963976ac8ed5a0"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'
@@ -4087,7 +4087,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run node-controller tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:f639aa7651490569c527fa18da21ed25be69f5823ed293052acdae45bb4b3f36"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:0a64048dd8c1e8fa01e3bb028564ffc48032897f45c9b899d1963976ac8ed5a0"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -3972,7 +3972,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:0a64048dd8c1e8fa01e3bb028564ffc48032897f45c9b899d1963976ac8ed5a0"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:50cc08c2e61e6ecd8e6586ab4e91f47f3eefadebf9a26a126b99a082362c0769"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'
@@ -4087,7 +4087,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run node-controller tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:0a64048dd8c1e8fa01e3bb028564ffc48032897f45c9b899d1963976ac8ed5a0"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:50cc08c2e61e6ecd8e6586ab4e91f47f3eefadebf9a26a126b99a082362c0769"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/.github/workflows/build-and-test_main.yml
+++ b/.github/workflows/build-and-test_main.yml
@@ -1228,7 +1228,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:f639aa7651490569c527fa18da21ed25be69f5823ed293052acdae45bb4b3f36"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:0a64048dd8c1e8fa01e3bb028564ffc48032897f45c9b899d1963976ac8ed5a0"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/.github/workflows/build-and-test_main.yml
+++ b/.github/workflows/build-and-test_main.yml
@@ -1228,7 +1228,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:0a64048dd8c1e8fa01e3bb028564ffc48032897f45c9b899d1963976ac8ed5a0"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:50cc08c2e61e6ecd8e6586ab4e91f47f3eefadebf9a26a126b99a082362c0769"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -3435,7 +3435,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:f639aa7651490569c527fa18da21ed25be69f5823ed293052acdae45bb4b3f36"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:0a64048dd8c1e8fa01e3bb028564ffc48032897f45c9b899d1963976ac8ed5a0"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -3435,7 +3435,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:0a64048dd8c1e8fa01e3bb028564ffc48032897f45c9b899d1963976ac8ed5a0"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:50cc08c2e61e6ecd8e6586ab4e91f47f3eefadebf9a26a126b99a082362c0769"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/candi/alt_base_images.yml
+++ b/candi/alt_base_images.yml
@@ -1,9 +1,9 @@
-# version=v1.3.2
+# version=v1.3.8
 REGISTRY_PATH: registry.deckhouse.io/container-factory
 base/distroless-fin: "sha256:014bf210c5e13d1e2ea968979a9cc5527d60a6d10ecedd51f97b6dd0dc7d554b" # from: builder/scratch
-builder/distroless: "sha256:dc1ce355189649aea0da760a3e3f7648409b0bbeaa271e72e381fefa99540e8c" # from: builder/scratch
-builder/golang-1.25: "sha256:d6c99ec7094ca8e0ac6f31abc73cad6e6c23d66c3d0c8ff7aa49b5fa9f787981" # from: builder/distroless
-builder/golang-1.26: "sha256:f639aa7651490569c527fa18da21ed25be69f5823ed293052acdae45bb4b3f36" # from: builder/distroless
-builder/golang: "sha256:f639aa7651490569c527fa18da21ed25be69f5823ed293052acdae45bb4b3f36" # from: builder/distroless
-minget-0.1: "sha256:11b24bd4add2d63f1a42f4a48f3ccd7a54f74e818c269607ceb52a9f760a9bfc" # from: builder/scratch
-minget: "sha256:11b24bd4add2d63f1a42f4a48f3ccd7a54f74e818c269607ceb52a9f760a9bfc" # from: builder/scratch
+builder/distroless: "sha256:216c3bd427548a1f2c29b1e944d086681e70e16f2b4d9806b3a417d370660bd0" # from: builder/scratch
+builder/golang-1.25: "sha256:1d9b2fa1b66c4cb25f587725e0114a9b0b1178b686d63904c3198e9960c8639c" # from: builder/distroless
+builder/golang-1.26: "sha256:0a64048dd8c1e8fa01e3bb028564ffc48032897f45c9b899d1963976ac8ed5a0" # from: builder/distroless
+builder/golang: "sha256:0a64048dd8c1e8fa01e3bb028564ffc48032897f45c9b899d1963976ac8ed5a0" # from: builder/distroless
+minget-0.1: "sha256:eb53006583279ce86d498004cc308dfa90993ab3e9d4928f8f400d2ef2b19f9e" # from: builder/scratch
+minget: "sha256:eb53006583279ce86d498004cc308dfa90993ab3e9d4928f8f400d2ef2b19f9e" # from: builder/scratch

--- a/candi/alt_base_images.yml
+++ b/candi/alt_base_images.yml
@@ -1,9 +1,9 @@
-# version=v1.3.8
+# version=v1.3.9
 REGISTRY_PATH: registry.deckhouse.io/container-factory
 base/distroless-fin: "sha256:014bf210c5e13d1e2ea968979a9cc5527d60a6d10ecedd51f97b6dd0dc7d554b" # from: builder/scratch
-builder/distroless: "sha256:216c3bd427548a1f2c29b1e944d086681e70e16f2b4d9806b3a417d370660bd0" # from: builder/scratch
-builder/golang-1.25: "sha256:1d9b2fa1b66c4cb25f587725e0114a9b0b1178b686d63904c3198e9960c8639c" # from: builder/distroless
-builder/golang-1.26: "sha256:0a64048dd8c1e8fa01e3bb028564ffc48032897f45c9b899d1963976ac8ed5a0" # from: builder/distroless
-builder/golang: "sha256:0a64048dd8c1e8fa01e3bb028564ffc48032897f45c9b899d1963976ac8ed5a0" # from: builder/distroless
+builder/distroless: "sha256:4a8c6e8084386e5afa35c2074429942d55cb20a7efb2a28090bc51451fe60c5e" # from: builder/scratch
+builder/golang-1.25: "sha256:917fae1374278f88b120713d7c078ac2c0ed3f654613d9cf4584c61536df18c7" # from: builder/distroless
+builder/golang-1.26: "sha256:50cc08c2e61e6ecd8e6586ab4e91f47f3eefadebf9a26a126b99a082362c0769" # from: builder/distroless
+builder/golang: "sha256:50cc08c2e61e6ecd8e6586ab4e91f47f3eefadebf9a26a126b99a082362c0769" # from: builder/distroless
 minget-0.1: "sha256:eb53006583279ce86d498004cc308dfa90993ab3e9d4928f8f400d2ef2b19f9e" # from: builder/scratch
 minget: "sha256:eb53006583279ce86d498004cc308dfa90993ab3e9d4928f8f400d2ef2b19f9e" # from: builder/scratch

--- a/modules/800-deckhouse-tools/images/web/werf.inc.yaml
+++ b/modules/800-deckhouse-tools/images/web/werf.inc.yaml
@@ -43,8 +43,6 @@ shell:
   - sed -i "s|sh:\ git describe --tags|sh:\ cat VERSION|" Taskfile.yml
   - rm -rf /src/deckhouse-cli/.git
 ---
-# Build the bundled d8 CLI on the distroless builder/golang (Go 1.26) to pick up an
-# up-to-date Go standard library and fix the Go stdlib CVEs in the web image.
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 final: false
 from: {{ index $.Images "builder/golang" }}
@@ -74,9 +72,9 @@ secrets:
   value: {{ .DECKHOUSE_PRIVATE_REPO }}
 shell:
   beforeInstall:
-    # btrfs-progs-devel provides the btrfs headers (ioctl.h, ctree.h, version.h) that the
-    # containers/storage btrfs graphdriver includes when d8 is built with CGO.
     - pm install git ssh-static make coreutils findutils file jq pkgconf gnu-glibc-devel elfutils-devel openssl-devel libuv-devel zstd-devel btrfs-progs-devel
+    # The d8 static build links libuv from /usr/local/lib/libuv.a; pm ships it under a
+    # different name and path.
     - mkdir -p /usr/local/lib
     - ln -fs "$(find /usr/lib /usr/lib64 /usr/lib/x86_64-linux-gnu -name 'libuv*.a' 2>/dev/null | head -n1)" /usr/local/lib/libuv.a
   install:

--- a/modules/800-deckhouse-tools/images/web/werf.inc.yaml
+++ b/modules/800-deckhouse-tools/images/web/werf.inc.yaml
@@ -43,9 +43,11 @@ shell:
   - sed -i "s|sh:\ git describe --tags|sh:\ cat VERSION|" Taskfile.yml
   - rm -rf /src/deckhouse-cli/.git
 ---
+# Build the bundled d8 CLI on the distroless builder/golang (Go 1.26) to pick up an
+# up-to-date Go standard library and fix the Go stdlib CVEs in the web image.
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 final: false
-from: {{ index $.Images "builder/golang-bookworm" }}
+from: {{ index $.Images "builder/golang" }}
 import:
   - image: {{ .ModuleName }}/{{ .ImageName }}-frontend-artifact
     add: /app/dist
@@ -72,19 +74,11 @@ secrets:
   value: {{ .DECKHOUSE_PRIVATE_REPO }}
 shell:
   beforeInstall:
-    {{- include "debian packages proxy" . | nindent 4 }}
-    - |
-      apt-get update && apt-get install -y \
-      libbtrfs-dev \
-      apt-utils \
-      libbtrfs-dev \
-      libelf-dev \
-      libssl-dev \
-      libuv1-dev \
-      libzstd-dev \
-      file git gcc dnsutils jq
-    - ln -fs "$(dpkg -L libuv1-dev | grep -F '/libuv_a.a')" /usr/local/lib/libuv.a
-    - find /var/lib/apt/ /var/cache/apt/ -type f -delete
+    # btrfs-progs-devel provides the btrfs headers (ioctl.h, ctree.h, version.h) that the
+    # containers/storage btrfs graphdriver includes when d8 is built with CGO.
+    - pm install git ssh-static make coreutils findutils file jq pkgconf gnu-glibc-devel elfutils-devel openssl-devel libuv-devel zstd-devel btrfs-progs-devel
+    - mkdir -p /usr/local/lib
+    - ln -fs "$(find /usr/lib /usr/lib64 /usr/lib/x86_64-linux-gnu -name 'libuv*.a' 2>/dev/null | head -n1)" /usr/local/lib/libuv.a
   install:
     - export GOPROXY=$(cat /run/secrets/GOPROXY)
     - export PRIVATE_REPO=$(cat /run/secrets/DECKHOUSE_PRIVATE_REPO)


### PR DESCRIPTION
## Description

Switches the `deckhouse-tools/web` builder from `builder/golang-bookworm` (Go 1.25.10) to the
distroless `builder/golang` (Go 1.26.5), so the bundled `d8` CLI is compiled against an up-to-date
Go standard library.

The distroless builder has no `apt`, so the C build dependencies are installed via `pm` instead,
including `btrfs-progs-devel` — the `containers/storage` btrfs graphdriver includes the btrfs
headers when `d8` is built with CGO.

Also bumps the container-factory base images to v1.3.9 and re-renders the workflows that embed the
`builder/golang` digest.

## Why do we need it, and what problem does it solve?

Fixes Go standard-library CVEs reported for the web image: CVE-2026-27145, CVE-2026-42504,
CVE-2026-42505, CVE-2026-42507. They are fixed in Go 1.25.12 / 1.26.5, but the bookworm builder
bundle is still on 1.25.10. Switching the image to the distroless `builder/golang` (Go 1.26.5) is
the established way this repository fixes Go stdlib CVEs (see #20111, #20531).

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: Build web image on distroless builder/golang to fix Go stdlib CVEs
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->



