### PR TITLE
[deckhouse] Add VEX entries and bump x/net for web and webhook image CVEs

### DIFF
--- a/modules/002-deckhouse/images/webhook-handler/known_vulnerabilities.vex
+++ b/modules/002-deckhouse/images/webhook-handler/known_vulnerabilities.vex
@@ -1,8 +1,8 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-5a4509a04e8128126aee080324a6b663a7748bf44b58a9a4b9c74d4801844f53",
-  "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
-  "version": 15,
+  "author": "Deckhouse <contact@deckhouse.io>",
+  "version": 16,
   "statements": [
     {
       "vulnerability": {
@@ -79,7 +79,9 @@
         "name": "CVE-2026-34040"
       },
       "products": [
-        {"@id": "pkg:golang/github.com/docker/docker@v28.0.0+incompatible"}
+        {
+          "@id": "pkg:golang/github.com/docker/docker@v28.0.0+incompatible"
+        }
       ],
       "status": "not_affected",
       "justification": "vulnerable_code_not_in_execute_path",
@@ -91,7 +93,9 @@
         "name": "CVE-2026-42306"
       },
       "products": [
-        {"@id": "pkg:golang/github.com/docker/docker@v28.0.0+incompatible"}
+        {
+          "@id": "pkg:golang/github.com/docker/docker@v28.0.0+incompatible"
+        }
       ],
       "status": "not_affected",
       "justification": "vulnerable_code_not_in_execute_path",
@@ -103,7 +107,9 @@
         "name": "CVE-2026-33997"
       },
       "products": [
-        {"@id": "pkg:golang/github.com/docker/docker@v28.0.0+incompatible"}
+        {
+          "@id": "pkg:golang/github.com/docker/docker@v28.0.0+incompatible"
+        }
       ],
       "status": "not_affected",
       "justification": "vulnerable_code_not_in_execute_path",
@@ -115,7 +121,9 @@
         "name": "CVE-2026-41568"
       },
       "products": [
-        {"@id": "pkg:golang/github.com/docker/docker@v28.0.0+incompatible"}
+        {
+          "@id": "pkg:golang/github.com/docker/docker@v28.0.0+incompatible"
+        }
       ],
       "status": "not_affected",
       "justification": "vulnerable_code_not_in_execute_path",
@@ -127,14 +135,58 @@
         "name": "CVE-2026-34073"
       },
       "products": [
-        {"@id": "pkg:pypi/cryptography@44.0.1"}
+        {
+          "@id": "pkg:pypi/cryptography@44.0.1"
+        }
       ],
       "status": "not_affected",
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Функционал, связанный с шифрованием и криптографическими операциями pypi/cryptography версии 44.0.1, не используется в рамках текущих функциональных спецификаций и эксплуатационных процессов системы. Все криптографические операции выполняются через промежуточные компоненты, не предоставляющие доступа к уязвимому коду.",
       "timestamp": "2026-06-08T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-41567"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/docker/docker@v28.0.0+incompatible"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Зависимость github.com/docker/docker версии v28.0.0 поступает через бинарь promtool, импортируемый из образа prometheus/prometheus (модуль 300-prometheus). Уязвимый функционал Docker Engine API не используется в рамках работы webhook-handler — promtool применяется только для валидации правил Prometheus. Бамп требует обновления Prometheus в модуле 300-prometheus.",
+      "timestamp": "2026-07-13T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "GHSA-537c-gmf6-5ccf"
+      },
+      "products": [
+        {
+          "@id": "pkg:pypi/cryptography@44.0.1"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Функционал, связанный с шифрованием и криптографическими операциями pypi/cryptography версии 44.0.1, не используется в рамках текущих функциональных спецификаций и эксплуатационных процессов системы. Все криптографические операции выполняются через промежуточные компоненты, не предоставляющие доступа к уязвимому коду.",
+      "timestamp": "2026-07-13T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-2303"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/go.mongodb.org/mongo-driver@v1.14.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Зависимость go.mongodb.org/mongo-driver версии v1.14.0 поступает транзитивно через бандл-инструмент образа (promtool из модуля 300-prometheus); webhook-handler не подключается к MongoDB, уязвимый код mongo-драйвера не выполняется.",
+      "timestamp": "2026-07-13T12:00:00Z"
     }
   ],
   "timestamp": "2026-02-16T12:00:00Z",
-  "last_updated": "2026-06-08T12:00:00Z"
+  "last_updated": "2026-07-13T12:00:00Z"
 }

--- a/modules/002-deckhouse/images/webhook-handler/src/label-converter/go.mod
+++ b/modules/002-deckhouse/images/webhook-handler/src/label-converter/go.mod
@@ -18,8 +18,8 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
-	golang.org/x/net v0.38.0 // indirect
-	golang.org/x/text v0.23.0 // indirect
+	golang.org/x/net v0.55.0 // indirect
+	golang.org/x/text v0.37.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/modules/002-deckhouse/images/webhook-handler/src/label-converter/go.sum
+++ b/modules/002-deckhouse/images/webhook-handler/src/label-converter/go.sum
@@ -45,8 +45,8 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
-golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
-golang.org/x/net v0.38.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
+golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
+golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -55,8 +55,8 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.23.0 h1:D71I7dUrlY+VX0gQShAThNGHFxZ13dGLBHQLVl1mJlY=
-golang.org/x/text v0.23.0/go.mod h1:/BLNzu4aZCJ1+kcD0DNRotWKage4q2rGVAg4o22unh4=
+golang.org/x/text v0.37.0 h1:Cqjiwd9eSg8e0QAkyCaQTNHFIIzWtidPahFWR83rTrc=
+golang.org/x/text v0.37.0/go.mod h1:a5sjxXGs9hsn/AJVwuElvCAo9v8QYLzvavO5z2PiM38=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=

--- a/modules/800-deckhouse-tools/images/web/known_vulnerabilities.vex
+++ b/modules/800-deckhouse-tools/images/web/known_vulnerabilities.vex
@@ -1,8 +1,8 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-5a4509a04e8128126aee080324a6b663a7748bf44b58a9a4b9c74d4801844f53",
-  "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
-  "version": 14,
+  "author": "Deckhouse <contact@deckhouse.io>",
+  "version": 15,
   "statements": [
     {
       "vulnerability": {
@@ -381,8 +381,288 @@
       "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
       "impact_statement": "DoS через неограниченное чтение тела HTTP-ответа OTLP-метрик-экспортёра (otlpmetrichttp v0.44.0) достижим только от вредоносного коллектора; коллектор задаётся администратором (доверенный), подача вредоносного ответа нарушителем исключена.",
       "timestamp": "2026-06-15T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-46680"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/containerd/containerd@v1.7.27"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Использование github.com/containerd/containerd ограничено операциями с OCI-образами и манифестами, а не компонентами CRI или runtime, в которых проявляется уязвимость.",
+      "timestamp": "2026-07-13T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-53488"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/containerd/containerd@v1.7.27"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Использование github.com/containerd/containerd ограничено операциями с OCI-образами и манифестами, а не компонентами CRI или runtime, в которых проявляется уязвимость.",
+      "timestamp": "2026-07-13T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-47262"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/containerd/containerd@v1.7.27"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Использование github.com/containerd/containerd ограничено операциями с OCI-образами и манифестами, а не компонентами CRI или runtime, в которых проявляется уязвимость.",
+      "timestamp": "2026-07-13T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-34040"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/docker/docker@v25.0.6+incompatible"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. github.com/docker/docker v25.0.6 используется исключительно как клиентская библиотека Docker API; уязвимость проявляется в работе Docker-демона (dockerd), который не входит в состав d8, поэтому уязвимый код не в пути выполнения.",
+      "timestamp": "2026-07-13T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-41567"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/docker/docker@v25.0.6+incompatible"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. github.com/docker/docker v25.0.6 используется исключительно как клиентская библиотека Docker API; уязвимость проявляется в работе Docker-демона (dockerd), который не входит в состав d8, поэтому уязвимый код не в пути выполнения.",
+      "timestamp": "2026-07-13T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-42306"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/docker/docker@v25.0.6+incompatible"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. github.com/docker/docker v25.0.6 используется исключительно как клиентская библиотека Docker API; уязвимость проявляется в работе Docker-демона (dockerd), который не входит в состав d8, поэтому уязвимый код не в пути выполнения.",
+      "timestamp": "2026-07-13T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-41568"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/docker/docker@v25.0.6+incompatible"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. github.com/docker/docker v25.0.6 используется исключительно как клиентская библиотека Docker API; уязвимость проявляется в работе Docker-демона (dockerd), который не входит в состав d8, поэтому уязвимый код не в пути выполнения.",
+      "timestamp": "2026-07-13T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-44973"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/go-git/go-billy/v5@v5.6.2"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "github.com/go-git/go-billy/v5 v5.6.2 поступает транзитивно из werf/delivery-kit (файловая абстракция go-git); уязвимый функционал не используется в штатных операциях d8.",
+      "timestamp": "2026-07-13T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-44740"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/go-git/go-billy/v5@v5.6.2"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "github.com/go-git/go-billy/v5 v5.6.2 поступает транзитивно из werf/delivery-kit (файловая абстракция go-git); уязвимый функционал не используется в штатных операциях d8.",
+      "timestamp": "2026-07-13T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45022"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/go-git/go-git/v5@v5.16.2"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "github.com/go-git/go-git/v5 v5.16.2 поступает транзитивно из werf/delivery-kit для git-операций; уязвимый функционал не используется в штатных операциях d8.",
+      "timestamp": "2026-07-13T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-41506"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/go-git/go-git/v5@v5.16.2"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "github.com/go-git/go-git/v5 v5.16.2 поступает транзитивно из werf/delivery-kit для git-операций; уязвимый функционал не используется в штатных операциях d8.",
+      "timestamp": "2026-07-13T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45571"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/go-git/go-git/v5@v5.16.2"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "github.com/go-git/go-git/v5 v5.16.2 поступает транзитивно из werf/delivery-kit для git-операций; уязвимый функционал не используется в штатных операциях d8.",
+      "timestamp": "2026-07-13T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "GHSA-w5pp-99ch-qj29"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/go-git/go-git/v5@v5.16.2"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "github.com/go-git/go-git/v5 v5.16.2 поступает транзитивно из werf/delivery-kit для git-операций; уязвимый функционал не используется в штатных операциях d8.",
+      "timestamp": "2026-07-13T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-49478"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/sigstore/fulcio@v1.4.5"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "github.com/sigstore/fulcio v1.4.5 поступает транзитивно из werf/delivery-kit (выдача сертификатов при подписи образов в подкоманде d8 delivery-kit); уязвимый код не в пути выполнения штатных операций d8.",
+      "timestamp": "2026-07-13T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-48702"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/sigstore/rekor@v1.3.6"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "github.com/sigstore/rekor v1.3.6 поступает транзитивно из werf/delivery-kit (подпись/верификация образов в подкоманде d8 delivery-kit); уязвимый код не в пути выполнения штатных операций d8.",
+      "timestamp": "2026-07-13T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "GHSA-pmwq-pjrm-6p5r"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/in-toto/in-toto-golang@v0.9.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "github.com/in-toto/in-toto-golang v0.9.0 поступает транзитивно из werf/delivery-kit (attestation при подписи образов); уязвимый код не в пути выполнения штатных операций d8.",
+      "timestamp": "2026-07-13T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-41579"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/opencontainers/runc@v1.1.14"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Она проявляется в runc, а d8 delivery-kit не вызывает runc напрямую и работает с контейнерами только через Docker API.",
+      "timestamp": "2026-07-13T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-2303"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/go.mongodb.org/mongo-driver@v1.14.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "go.mongodb.org/mongo-driver v1.14.0 поступает транзитивно в составе d8 CLI; d8 не подключается к MongoDB, уязвимый код не выполняется.",
+      "timestamp": "2026-07-13T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-48978"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/oras.land/oras-go@v1.2.5"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "oras.land/oras-go v1.2.5 поступает транзитивно из werf/delivery-kit (операции с OCI-реестром); уязвимый функционал не в пути выполнения штатных операций d8.",
+      "timestamp": "2026-07-13T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "GO-2026-5932"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/crypto"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "GO-2026-5932 относится к пакету golang.org/x/crypto/openpgp, который поступает транзитивно из werf/delivery-kit в составе d8 CLI. Единственный вызов openpgp — функция getELFSigningOptions (cmd/werf/common/signature.go), отвечающая за подпись ELF-файлов в подкоманде d8 delivery-kit. Код достижим только при явной передаче base64-кодированного приватного PGP-ключа и наличии gpg в системе; в штатных операциях Deckhouse подпись ELF не выполняется и ключ не передаётся, поэтому уязвимый код не выполняется.",
+      "timestamp": "2026-07-13T12:00:00Z"
     }
   ],
   "timestamp": "2026-01-16T12:00:00Z",
-  "last_updated": "2026-06-15T12:00:00Z"
+  "last_updated": "2026-07-13T12:00:00Z"
 }


### PR DESCRIPTION
## Description

Adds OpenVEX `not_affected` entries to the `known_vulnerabilities.vex` files of the `web`
(deckhouse-tools) and `webhook-handler` (002-deckhouse) images for CVEs reported by the latest
scan, and bumps `golang.org/x/net` in the webhook-handler `label-converter` module to the fixed
version.

- `web`: 19 entries for dependencies pulled transitively into the bundled `d8` CLI via
  `werf` / `delivery-kit` / `nelm` (containerd, docker, go-git, go-billy, sigstore fulcio/rekor,
  in-toto, runc, oras, mongo-driver). `docker` and `runc` are held by `replace` directives in
  deckhouse-cli, the rest have not moved upstream, so they cannot be bumped away.
- `webhook-handler`: 3 entries — docker and mongo-driver that reach the image only through the
  bundled `promtool` binary, plus the Python `cryptography` wheel.
- `label-converter`: `golang.org/x/net` v0.38.0 -> v0.55.0 (fixes the x/net advisories in that
  binary at the source).

## Why do we need it, and what problem does it solve?

The images are flagged by the vulnerability scanner for dependencies whose vulnerable code paths
are not reachable in Deckhouse usage; the VEX entries document that as `not_affected`. The
`golang.org/x/net` bump removes the corresponding findings at their source in the `label-converter`
binary. This keeps the scan reports actionable.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: Add VEX entries and bump x/net for web and webhook image CVEs
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->


