### PR TITLE
[dhctl] Add auto-approve flag

### DIFF
--- a/dhctl/cmd/dhctl/commands/converge.go
+++ b/dhctl/cmd/dhctl/commands/converge.go
@@ -37,6 +37,7 @@ import (
 )
 
 func DefineConvergeCommand(cmd *kingpin.CmdClause, opts *options.Options) *kingpin.CmdClause {
+	app.DefineConvergeFlags(cmd, &opts.Converge)
 	app.DefineSSHFlags(cmd, &opts.SSH, config.NewConnectionConfigParser(opts))
 	app.DefineBecomeFlags(cmd, &opts.Become)
 	app.DefineKubeFlags(cmd, &opts.Kube)
@@ -76,7 +77,7 @@ func DefineConvergeCommand(cmd *kingpin.CmdClause, opts *options.Options) *kingp
 					AutoDismissChanges:     false,
 					AutoDismissDestructive: false,
 					AutoApproveSettings: infrastructure.AutoApproveSettings{
-						AutoApprove: false,
+						AutoApprove: opts.Converge.DestructiveApproved,
 					},
 				},
 			},

--- a/dhctl/pkg/app/converge.go
+++ b/dhctl/pkg/app/converge.go
@@ -35,6 +35,12 @@ func DefineConvergeExporterFlags(cmd *kingpin.CmdClause, o *options.ConvergeOpti
 		DurationVar(&o.CheckInterval)
 }
 
+func DefineConvergeFlags(cmd *kingpin.CmdClause, o *options.ConvergeOptions) {
+	cmd.Flag("converge-destructive-approved", "Destructive changes are approved").
+		Envar(configEnvName("DESTRUCTIVE_APPROVED")).
+		BoolVar(&o.DestructiveApproved)
+}
+
 // DefineOutputFlag registers --output / -o for the check-style commands.
 func DefineOutputFlag(cmd *kingpin.CmdClause, o *options.ConvergeOptions) {
 	cmd.Flag("output", "Output format").

--- a/dhctl/pkg/app/converge.go
+++ b/dhctl/pkg/app/converge.go
@@ -36,7 +36,7 @@ func DefineConvergeExporterFlags(cmd *kingpin.CmdClause, o *options.ConvergeOpti
 }
 
 func DefineConvergeFlags(cmd *kingpin.CmdClause, o *options.ConvergeOptions) {
-	cmd.Flag("converge-destructive-auto-approve", "Destructive changes are auto-approved").
+	cmd.Flag("converge-destructive-auto-approve", "Destructive changes are auto-approved, only for test and dev purposes, use carefully!").
 		Envar(configEnvName("DESTRUCTIVE_APPROVED")).
 		BoolVar(&o.DestructiveApproved)
 }

--- a/dhctl/pkg/app/converge.go
+++ b/dhctl/pkg/app/converge.go
@@ -36,7 +36,7 @@ func DefineConvergeExporterFlags(cmd *kingpin.CmdClause, o *options.ConvergeOpti
 }
 
 func DefineConvergeFlags(cmd *kingpin.CmdClause, o *options.ConvergeOptions) {
-	cmd.Flag("converge-destructive-approved", "Destructive changes are approved").
+	cmd.Flag("converge-destructive-auto-approve", "Destructive changes are auto-approved").
 		Envar(configEnvName("DESTRUCTIVE_APPROVED")).
 		BoolVar(&o.DestructiveApproved)
 }

--- a/dhctl/pkg/app/options/converge.go
+++ b/dhctl/pkg/app/options/converge.go
@@ -22,10 +22,11 @@ import (
 
 // ConvergeOptions covers the converge / converge-exporter / migration commands.
 type ConvergeOptions struct {
-	MetricsPath   string
-	ListenAddress string
-	CheckInterval time.Duration
-	OutputFormat  string
+	MetricsPath         string
+	ListenAddress       string
+	CheckInterval       time.Duration
+	OutputFormat        string
+	DestructiveApproved bool
 
 	CheckHasTerraformStateBeforeMigrateToTofu bool
 }


### PR DESCRIPTION
## Description

Add flag `converge-destructive-auto-approve` and environment variable `DHCTL_CLI_DESTRUCTIVE_APPROVED` to dhctl converge command, to auto-approve any destructive changes

## Why do we need it, and what problem does it solve?

For some testing purposes, we don't want to manually approve any destructive action during converge

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: feature
summary: Add auto-approve flag to dhctl converge command.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
