### PR TITLE
[docs] Correct the link from direct to relative in the alert about the module requirements

### DIFF
--- a/docs/documentation/_data/i18n.yml
+++ b/docs/documentation/_data/i18n.yml
@@ -486,8 +486,8 @@ features:
     en: "The module <a href='/products/kubernetes-platform/documentation/v1/architecture/module-development/versioning/#module-lifecycle'>lifecycle stage</a>"
     ru: "<a href='/products/kubernetes-platform/documentation/v1/architecture/module-development/versioning/#жизненный-цикл-модуля'>Стадия жизненного цикла</a> модуля"
   requirements_for_alert:
-    en: "The module has [requirements](/modules/%s/configuration.html#requirements) for installation"
-    ru: "У модуля есть [требования](/modules/%s/configuration.html#требования) для установки"
+    en: "The module has [requirements](./configuration.html#requirements) for installation"
+    ru: "У модуля есть [требования](./configuration.html#требования) для установки"
   currency_sign:
     en: "&#36;"
     ru: "&#8381;"

--- a/docs/documentation/_includes/module-stage-badge.liquid
+++ b/docs/documentation/_includes/module-stage-badge.liquid
@@ -13,7 +13,7 @@
   {%- capture alert_content %}
 {{ site.data.i18n.features['module_lifecycle_stage'][page.lang] }}: <span style='border-bottom: 1px dotted #000' data-tippy-content='{{ site.data.i18n.features[stage_long][page.lang] }}'>{{ stage }}</span>
   {%- if hasRequirements and site.data.i18n.features['requirements_for_alert'][page.lang] %}
-  <br>{{ site.data.i18n.features['requirements_for_alert'][page.lang] | replace: "%s", moduleName }}
+  <br>{{ site.data.i18n.features['requirements_for_alert'][page.lang] }}
   {%- endif %}
   {% endcapture %}
   {%- if stage == "Experimental" or stage == "Preview" %}


### PR DESCRIPTION
## Description

Corrected the link from direct to relative in the alert about the module requirements.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: fix
summary: Corrected the link from direct to relative in the alert about the module requirements.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
