### PR TITLE
Backport: [cloud-provider-dvp] Add LoadBalancer provisioning skip mechanism (#21296)

### DIFF
--- a/modules/030-cloud-provider-dvp/hooks/disable_load_balancer.go
+++ b/modules/030-cloud-provider-dvp/hooks/disable_load_balancer.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"context"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const (
+	disableLoadBalancerConfigMapName      = "dvp-cloud-controller-manager-disable-lb"
+	disableLoadBalancerConfigMapNamespace = "d8-cloud-provider-dvp"
+)
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	OnBeforeHelm: &go_hook.OrderedConfig{Order: 20},
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:       "disable_load_balancer_config_map",
+			ApiVersion: "v1",
+			Kind:       "ConfigMap",
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{disableLoadBalancerConfigMapNamespace},
+				},
+			},
+			NameSelector: &types.NameSelector{
+				MatchNames: []string{disableLoadBalancerConfigMapName},
+			},
+			FilterFunc: applyDisableLoadBalancerConfigMapFilter,
+		},
+	},
+}, handleDisableLoadBalancer)
+
+func applyDisableLoadBalancerConfigMapFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	return obj.GetName(), nil
+}
+
+func handleDisableLoadBalancer(_ context.Context, input *go_hook.HookInput) error {
+	lbSettings := map[string]any{
+		"disabled": len(input.Snapshots.Get("disable_load_balancer_config_map")) > 0,
+	}
+	input.Values.Set("cloudProviderDvp.internal.loadBalancer", lbSettings)
+	return nil
+}

--- a/modules/030-cloud-provider-dvp/hooks/disable_load_balancer_test.go
+++ b/modules/030-cloud-provider-dvp/hooks/disable_load_balancer_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("Modules :: cloud-provider-dvp :: hooks :: disable_load_balancer ::", func() {
+	const initValues = `
+cloudProviderDvp:
+  internal: {}
+`
+
+	const disableConfigMap = `
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dvp-cloud-controller-manager-disable-lb
+  namespace: d8-cloud-provider-dvp
+`
+
+	Context("When the disable ConfigMap is absent", func() {
+		f := HookExecutionConfigInit(initValues, `{}`)
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext(), f.KubeStateSet(``))
+			f.RunHook()
+		})
+
+		It("Should set loadBalancer.disabled to false", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("cloudProviderDvp.internal.loadBalancer.disabled").Bool()).To(BeFalse())
+		})
+	})
+
+	Context("When the disable ConfigMap is present", func() {
+		f := HookExecutionConfigInit(initValues, `{}`)
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext(), f.KubeStateSet(disableConfigMap))
+			f.RunHook()
+		})
+
+		It("Should set loadBalancer.disabled to true", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("cloudProviderDvp.internal.loadBalancer.disabled").Bool()).To(BeTrue())
+		})
+	})
+})

--- a/modules/030-cloud-provider-dvp/openapi/values.yaml
+++ b/modules/030-cloud-provider-dvp/openapi/values.yaml
@@ -8,6 +8,26 @@ properties:
     properties:
       cniSecretData:
         type: string
+        x-examples:
+        - "Y25pOiBZMmxzYVhWdApjaWxpdW06IGV5SnRiMlJsSWpvZ0lsWllURUZPSW4wPQo="
+      loadBalancer:
+        type: object
+        default: {}
+        properties:
+          disabled:
+            type: boolean
+            default: false
+            description: |
+              Disables the LoadBalancer functionality of the cloud controller manager.
+
+              Set to `true` by the disable-lb ConfigMap hook when the ConfigMap is present,
+              which excludes the `service-lb-controller` from the cloud controller manager.
+
+              > If Services of type `LoadBalancer` have already been created and you disable the LoadBalancer
+              functionality, the cloud controller manager will stop reconciling them. All management of these Services
+              (creating, updating and deleting the underlying load balancers) becomes fully manual.
+            x-examples:
+            - true
       providerClusterConfiguration:
         type: object
         additionalProperties: false
@@ -469,7 +489,7 @@ properties:
                 type: string
                 description: |
                   Control rules for network traffic to and from workloads running in the Project resource.
-                
+
                   * `Isolated`: Applies a restrictive NetworkPolicy that allows only network traffic required for platform system components to function. All other traffic is denied.
                   * `NotRestricted`: Neither network policies nor any additional network restrictions are applied.
 

--- a/modules/030-cloud-provider-dvp/template_tests/module_test.go
+++ b/modules/030-cloud-provider-dvp/template_tests/module_test.go
@@ -217,4 +217,44 @@ var _ = Describe("Module :: cloud-provider-dvp :: helm template ::", func() {
 			Expect(providerSpecificBashibleBootstrapSecret.Exists()).To(BeFalse())
 		})
 	})
+
+	Context("DVP with LoadBalancer enabled (default)", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", globalValues)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYaml("cloudProviderDvp", moduleValuesA)
+			f.ValuesSet("cloudProviderDvp.internal.loadBalancer.disabled", false)
+			f.HelmRender()
+		})
+
+		It("Should include service-lb-controller in the cloud-controller-manager controllers", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			ccmDeployment := f.KubernetesResource("Deployment", moduleNamespace, "cloud-controller-manager")
+			Expect(ccmDeployment.Exists()).To(BeTrue())
+			Expect(ccmDeployment.Field(`spec.template.spec.containers.0.args`).String()).
+				To(ContainSubstring(`--controllers=cloud-node,cloud-node-lifecycle,service-lb-controller`))
+		})
+	})
+
+	Context("DVP with LoadBalancer disabled", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", globalValues)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYaml("cloudProviderDvp", moduleValuesA)
+			f.ValuesSet("cloudProviderDvp.internal.loadBalancer.disabled", true)
+			f.HelmRender()
+		})
+
+		It("Should exclude service-lb-controller from the cloud-controller-manager controllers", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			ccmDeployment := f.KubernetesResource("Deployment", moduleNamespace, "cloud-controller-manager")
+			Expect(ccmDeployment.Exists()).To(BeTrue())
+			Expect(ccmDeployment.Field(`spec.template.spec.containers.0.args`).String()).
+				To(ContainSubstring(`--controllers=cloud-node,cloud-node-lifecycle`))
+			Expect(ccmDeployment.Field(`spec.template.spec.containers.0.args`).String()).
+				ToNot(ContainSubstring(`service-lb-controller`))
+		})
+	})
 })

--- a/modules/030-cloud-provider-dvp/templates/cloud-controller-manager/deployment.yaml
+++ b/modules/030-cloud-provider-dvp/templates/cloud-controller-manager/deployment.yaml
@@ -3,6 +3,12 @@ cpu: 25m
 memory: 50Mi
 {{- end }}
 
+{{- $ccmEnabledControllers := "cloud-node,cloud-node-lifecycle" -}}
+{{- $loadBalancerDisabled := dig "loadBalancer" "disabled" false .Values.cloudProviderDvp.internal -}}
+{{- if not $loadBalancerDisabled -}}
+  {{- $ccmEnabledControllers = printf "%s,service-lb-controller" $ccmEnabledControllers -}}
+{{- end -}}
+
 {{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler") }}
 ---
 apiVersion: autoscaling.k8s.io/v1
@@ -20,12 +26,12 @@ spec:
     updateMode: "InPlaceOrRecreate"
   resourcePolicy:
     containerPolicies:
-    - containerName: "dvp-cloud-controller-manager"
-      minAllowed:
+      - containerName: "dvp-cloud-controller-manager"
+        minAllowed:
         {{- include "dvp_cloud_controller_manager_resources" . | nindent 8 }}
-      maxAllowed:
-        cpu: 50m
-        memory: 50Mi
+        maxAllowed:
+          cpu: 50m
+          memory: 50Mi
 {{- end }}
 ---
 apiVersion: policy/v1
@@ -62,7 +68,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/cloud-controller-manager/secret.yaml") . | sha256sum }}
     spec:
       imagePullSecrets:
-      - name: deckhouse-registry
+        - name: deckhouse-registry
       {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
       {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "cloud-controller-manager")) | nindent 6 }}
       {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
@@ -76,44 +82,44 @@ spec:
           {{- include "helm_lib_module_container_security_context_pss_restricted_flexible" dict | nindent 10 }}
           image: {{ include "helm_lib_module_image" (list . "cloudControllerManager") }}
           args:
-          - --leader-elect=true
-          - --cloud-provider=dvp
-          - --allow-untagged-cloud=true
-          - --configure-cloud-routes=false
-          - --controllers=cloud-node,cloud-node-lifecycle,service-lb-controller
-          - --bind-address=127.0.0.1
-          - --secure-port=10471
-          - --v=4
+            - --leader-elect=true
+            - --cloud-provider=dvp
+            - --allow-untagged-cloud=true
+            - --configure-cloud-routes=false
+            - --controllers={{ $ccmEnabledControllers }}
+            - --bind-address=127.0.0.1
+            - --secure-port=10471
+            - --v=4
           env:
-      # KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT are needed on the bootstrap phase to make CCM work without kube-proxy
+            # KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT are needed on the bootstrap phase to make CCM work without kube-proxy
       {{- if not .Values.global.clusterIsBootstrapped }}
-          - name: KUBERNETES_SERVICE_HOST
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: status.hostIP
-          - name: KUBERNETES_SERVICE_PORT
-            value: "6443"
+            - name: KUBERNETES_SERVICE_HOST
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.hostIP
+            - name: KUBERNETES_SERVICE_PORT
+              value: "6443"
       {{- end }}
-          - name: HOST_IP
-            valueFrom:
-              fieldRef:
-                fieldPath: status.hostIP
-          - name: DVP_KUBERNETES_CONFIG_BASE64
-            valueFrom:
-              secretKeyRef:
-                name: dvp-credentials
-                key: kubernetesConfigBase64
-          - name: CLUSTER_UUID
-            valueFrom:
-              secretKeyRef:
-                name: dvp-credentials
-                key: clusterUUID
-          - name: DVP_NAMESPACE
-            valueFrom:
-              secretKeyRef:
-                name: dvp-credentials
-                key: namespace
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: DVP_KUBERNETES_CONFIG_BASE64
+              valueFrom:
+                secretKeyRef:
+                  name: dvp-credentials
+                  key: kubernetesConfigBase64
+            - name: CLUSTER_UUID
+              valueFrom:
+                secretKeyRef:
+                  name: dvp-credentials
+                  key: clusterUUID
+            - name: DVP_NAMESPACE
+              valueFrom:
+                secretKeyRef:
+                  name: dvp-credentials
+                  key: namespace
           {{- include "helm_lib_envs_for_proxy" . | nindent 10 }}
           livenessProbe:
             httpGet:

--- a/modules/030-cloud-provider-dvp/templates/cloud-controller-manager/deployment.yaml
+++ b/modules/030-cloud-provider-dvp/templates/cloud-controller-manager/deployment.yaml
@@ -26,12 +26,12 @@ spec:
     updateMode: "InPlaceOrRecreate"
   resourcePolicy:
     containerPolicies:
-      - containerName: "dvp-cloud-controller-manager"
-        minAllowed:
+    - containerName: "dvp-cloud-controller-manager"
+      minAllowed:
         {{- include "dvp_cloud_controller_manager_resources" . | nindent 8 }}
-        maxAllowed:
-          cpu: 50m
-          memory: 50Mi
+      maxAllowed:
+        cpu: 50m
+        memory: 50Mi
 {{- end }}
 ---
 apiVersion: policy/v1
@@ -68,7 +68,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/cloud-controller-manager/secret.yaml") . | sha256sum }}
     spec:
       imagePullSecrets:
-        - name: deckhouse-registry
+      - name: deckhouse-registry
       {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
       {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "cloud-controller-manager")) | nindent 6 }}
       {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
@@ -82,44 +82,44 @@ spec:
           {{- include "helm_lib_module_container_security_context_pss_restricted_flexible" dict | nindent 10 }}
           image: {{ include "helm_lib_module_image" (list . "cloudControllerManager") }}
           args:
-            - --leader-elect=true
-            - --cloud-provider=dvp
-            - --allow-untagged-cloud=true
-            - --configure-cloud-routes=false
-            - --controllers={{ $ccmEnabledControllers }}
-            - --bind-address=127.0.0.1
-            - --secure-port=10471
-            - --v=4
+          - --leader-elect=true
+          - --cloud-provider=dvp
+          - --allow-untagged-cloud=true
+          - --configure-cloud-routes=false
+          - --controllers={{ $ccmEnabledControllers }}
+          - --bind-address=127.0.0.1
+          - --secure-port=10471
+          - --v=4
           env:
-            # KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT are needed on the bootstrap phase to make CCM work without kube-proxy
+      # KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT are needed on the bootstrap phase to make CCM work without kube-proxy
       {{- if not .Values.global.clusterIsBootstrapped }}
-            - name: KUBERNETES_SERVICE_HOST
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: status.hostIP
-            - name: KUBERNETES_SERVICE_PORT
-              value: "6443"
+          - name: KUBERNETES_SERVICE_HOST
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.hostIP
+          - name: KUBERNETES_SERVICE_PORT
+            value: "6443"
       {{- end }}
-            - name: HOST_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.hostIP
-            - name: DVP_KUBERNETES_CONFIG_BASE64
-              valueFrom:
-                secretKeyRef:
-                  name: dvp-credentials
-                  key: kubernetesConfigBase64
-            - name: CLUSTER_UUID
-              valueFrom:
-                secretKeyRef:
-                  name: dvp-credentials
-                  key: clusterUUID
-            - name: DVP_NAMESPACE
-              valueFrom:
-                secretKeyRef:
-                  name: dvp-credentials
-                  key: namespace
+          - name: HOST_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+          - name: DVP_KUBERNETES_CONFIG_BASE64
+            valueFrom:
+              secretKeyRef:
+                name: dvp-credentials
+                key: kubernetesConfigBase64
+          - name: CLUSTER_UUID
+            valueFrom:
+              secretKeyRef:
+                name: dvp-credentials
+                key: clusterUUID
+          - name: DVP_NAMESPACE
+            valueFrom:
+              secretKeyRef:
+                name: dvp-credentials
+                key: namespace
           {{- include "helm_lib_envs_for_proxy" . | nindent 10 }}
           livenessProbe:
             httpGet:


### PR DESCRIPTION
## Description

  Adds the ability to disable the LoadBalancer functionality of the DVP cloud controller manager (CCM) in the `cloud-provider-dvp` module.

  When a `ConfigMap` named `dvp-cloud-controller-manager-disable-lb` is present in the `d8-cloud-provider-dvp` namespace, an `OnBeforeHelm` hook sets `internal.loadBalancer.disabled=true`, and the CCM Deployment is rendered without the `service-lb-controller`.

  ## Why do we need it, and what problem does it solve?

  Some DVP-based clusters need to require the CCM to stop competing for reconciliation of `Service` type `LoadBalancer`. Previously there was no supported way to exclude the `service-lb-controller` from the DVP CCM. This provides an opt-in switch (via a ConfigMap) to disable LB management without disabling the whole cloud provider.

  ## Why do we need it in the patch release (if we do)?

  Not necessarily.
                                                                                                                                                                                                                                                                       
  ## Checklist
  - [x] The code is covered by unit tests.
  - [x] e2e tests passed.
  - [x] Documentation updated according to the changes.
  - [x] Changes were tested in the Kubernetes cluster manually.

  ## Changelog entries
                                                                                                                                                                                                                                                                       
```changes
section: cloud-provider-dvp
type: feature
summary: Add an option to disable the CCM LoadBalancer functionality via ConfigMap.
impact_level: default
```
