### PR TITLE
[docs] Add the installer startup command to GS

### DIFF
--- a/docs/site/_includes/getting_started/global/partials/installer/STEP_START_INSTALLER.md
+++ b/docs/site/_includes/getting_started/global/partials/installer/STEP_START_INSTALLER.md
@@ -56,6 +56,7 @@ docker run --rm --pull always -v $HOME/.d8installer:$HOME/.d8installer -v /var/r
 ```
 {% endcapture %}
 {{ command | markdownify }}
+<p>Open <a href="http://localhost:8080">http://localhost:8080</a>.</p>
 </div>
 <div id="tab-mac-content-trdl" class="tabs__container tabs__container--descr" markdown="1">
 {%- include getting_started/global/partials/installer/installer_rosetta_alert_ru.html %}
@@ -84,6 +85,14 @@ trdl add $REPO $URL $ROOT_VERSION $ROOT_SHA512
 {{ command | markdownify }}
 <p>If you do not want to run <code>. $(trdl use -d d8-installer 1 ea)</code> before each installer usage, add the line <code>source $(trdl use -d d8-installer 1 ea)</code> to your shell RC file.</p>
 </li>
+<li>
+  Run the installer with the <code>d8install -b</code> command.
+  <div markdown="1">
+  {% alert level="warning" %}
+    If the browser does not open automatically, go to <a href="http://localhost:8080">http://localhost:8080</a>.
+  {% endalert %}
+  </div>
+</li>
   </ol>
 </div>
 <div id="tab-mac-content-file" class="tabs__container tabs__container--descr" markdown="1">
@@ -101,6 +110,11 @@ xattr -c d8install
 ```
 {% endcapture %}
 {{ command | markdownify }}
+  <div markdown="1">
+  {% alert level="warning" %}
+    If the browser does not open automatically, go to <a href="http://localhost:8080">http://localhost:8080</a>.
+  {% endalert %}
+  </div>
 </div>
 </div>
   </div>
@@ -135,6 +149,7 @@ docker run --rm --pull always -v $HOME/.d8installer:$HOME/.d8installer -v /var/r
 ```
 {% endcapture %}
 {{ command | markdownify }}
+  <p>Open <a href="http://localhost:8080">http://localhost:8080</a>.</p>
 </div>
 <div id="tab-linux-content-trdl" class="tabs__container tabs__container--descr" markdown="1">
   <p>Starting from version 0.5.0, the installer can be installed on your machine using <a href="https://ru.trdl.dev/">trdl</a>.</p>
@@ -162,6 +177,14 @@ trdl add $REPO $URL $ROOT_VERSION $ROOT_SHA512
 {{ command | markdownify }}
 <p>If you do not want to run <code>. $(trdl use -d d8-installer 1 ea)</code> before each installer usage, add the line <code>source $(trdl use -d d8-installer 1 ea)</code> to your shell RC file.</p>
 </li>
+<li>
+  Run the installer with the <code>d8install -b</code> command.
+  <div markdown="1">
+  {% alert level="warning" %}
+    If the browser does not open automatically, go to <a href="http://localhost:8080">http://localhost:8080</a>.
+  {% endalert %}
+  </div>
+</li>
   </ol>
 </div>
 <div id="tab-linux-content-file" class="tabs__container tabs__container--descr" markdown="1">
@@ -174,6 +197,11 @@ chmod +x d8install
 ```
 {% endcapture %}
 {{ command | markdownify }}
+  <div markdown="1">
+  {% alert level="warning" %}
+    If the browser does not open automatically, go to <a href="http://localhost:8080">http://localhost:8080</a>.
+  {% endalert %}
+  </div>
 </div>
 </div>
   </div>
@@ -195,9 +223,9 @@ docker run --rm --pull always -v /mnt/host/c/Users/$env:USERNAME/.d8installer:/m
 ```
 {% endcapture %}
 {{ command | markdownify }}
+<p>Open <a href="http://localhost:8080">http://localhost:8080</a>.</p>
   </div>
   </div>
 </li>
-<li>Open <a href="http://localhost:8080">http://localhost:8080</a></li>
 </ol>
 </div>

--- a/docs/site/_includes/getting_started/global/partials/installer/STEP_START_INSTALLER_RU.md
+++ b/docs/site/_includes/getting_started/global/partials/installer/STEP_START_INSTALLER_RU.md
@@ -49,13 +49,14 @@
 <div id="tab-mac-content-container" class="tabs__container tabs__container--descr active" markdown="1">
 {%- include getting_started/global/partials/installer/installer_rosetta_alert_ru.html %}
   <p>Выполните команду:</p>
-  <p><b>Если при включенном VPN контейнер с установщиком не может получить доступ к сети, воспользуйтесь <a href="/products/kubernetes-platform/documentation/v1/faq.html#что-делать-если-при-включенном-vpn-контейнер-с-установщиком-не-м">инструкцией</a></b></p>
+  <p><b>Если при включенном VPN контейнер с установщиком не может получить доступ к сети, воспользуйтесь <a href="/products/kubernetes-platform/documentation/v1/faq.html#что-делать-если-при-включенном-vpn-контейнер-с-установщиком-не-м">инструкцией</a></b>.</p>
 {% capture command %}
 ```bash
 docker run --rm --pull always -v $HOME/.d8installer:$HOME/.d8installer -v /var/run/docker.sock:/var/run/docker.sock -p 127.0.0.1:8080:8080 registry.deckhouse.ru/deckhouse/installer:latest -r $HOME/.d8installer
 ```
 {% endcapture %}
 {{ command | markdownify }}
+<p>Откройте <a href="http://localhost:8080">http://localhost:8080</a>.</p>
 </div>
 <div id="tab-mac-content-trdl" class="tabs__container tabs__container--descr" markdown="1">
 {%- include getting_started/global/partials/installer/installer_rosetta_alert_ru.html %}
@@ -84,6 +85,14 @@ trdl add $REPO $URL $ROOT_VERSION $ROOT_SHA512
 {{ command | markdownify }}
 <p>Если вы не хотите вызывать <code>. $(trdl use -d d8-installer 1 ea)</code> перед каждым использованием установщика, добавьте строку <code>source $(trdl use -d d8-installer 1 ea)</code> в RC-файл вашей командной оболочки.</p>
 </li>
+<li>
+  Запустите установщик командой <code>d8install -b</code>.
+  <div markdown="1">
+  {% alert level="warning" %}
+    Если браузер автоматически не запустился, перейдите по ссылке <a href="http://localhost:8080">http://localhost:8080</a>.
+  {% endalert %}
+  </div>
+</li>
   </ol>
 </div>
 <div id="tab-mac-content-file" class="tabs__container tabs__container--descr" markdown="1">
@@ -101,6 +110,11 @@ xattr -c d8install
 ```
 {% endcapture %}
 {{ command | markdownify }}
+  <div markdown="1">
+  {% alert level="warning" %}
+    Если браузер автоматически не запустился, перейдите по ссылке <a href="http://localhost:8080">http://localhost:8080</a>.
+  {% endalert %}
+  </div>
 </div>
 </div>
   </div>
@@ -128,13 +142,14 @@ xattr -c d8install
   </ul>
 <div id="tab-linux-content-container" class="tabs__container tabs__container--descr active" markdown="1">
   <p>Выполните команду:</p>
-  <p><b>Если при включенном VPN контейнер с установщиком не может получить доступ к сети, воспользуйтесь <a href="/products/kubernetes-platform/documentation/v1/faq.html#что-делать-если-при-включенном-vpn-контейнер-с-установщиком-не-м">инструкцией</a></b></p>
+  <p><b>Если при включенном VPN контейнер с установщиком не может получить доступ к сети, воспользуйтесь <a href="/products/kubernetes-platform/documentation/v1/faq.html#что-делать-если-при-включенном-vpn-контейнер-с-установщиком-не-м">инструкцией</a>.</b></p>
 {% capture command %}
 ```bash
 docker run --rm --pull always -v $HOME/.d8installer:$HOME/.d8installer -v /var/run/docker.sock:/var/run/docker.sock -p 127.0.0.1:8080:8080 registry.deckhouse.ru/deckhouse/installer:latest -r $HOME/.d8installer
 ```
 {% endcapture %}
 {{ command | markdownify }}
+  <p>Откройте <a href="http://localhost:8080">http://localhost:8080</a>.</p>
 </div>
 <div id="tab-linux-content-trdl" class="tabs__container tabs__container--descr" markdown="1">
   <p>Начиная с версии 0.5.0 установщик можно установить на вашу машину с помощью <a href="https://ru.trdl.dev/">trdl</a>.</p>
@@ -162,6 +177,14 @@ trdl add $REPO $URL $ROOT_VERSION $ROOT_SHA512
 {{ command | markdownify }}
 <p>Если вы не хотите вызывать <code>. $(trdl use -d d8-installer 1 ea)</code> перед каждым использованием установщика, добавьте строку <code>source $(trdl use -d d8-installer 1 ea)</code> в RC-файл вашей командной оболочки.</p>
 </li>
+<li>
+  Запустите установщик командой <code>d8install -b</code>.
+  <div markdown="1">
+  {% alert level="warning" %}
+    Если браузер автоматически не запустился, перейдите по ссылке <a href="http://localhost:8080">http://localhost:8080</a>.
+  {% endalert %}
+  </div>
+</li>
   </ol>
 </div>
 <div id="tab-linux-content-file" class="tabs__container tabs__container--descr" markdown="1">
@@ -174,6 +197,11 @@ chmod +x d8install
 ```
 {% endcapture %}
 {{ command | markdownify }}
+  <div markdown="1">
+  {% alert level="warning" %}
+    Если браузер автоматически не запустился, перейдите по ссылке <a href="http://localhost:8080">http://localhost:8080</a>.
+  {% endalert %}
+  </div>
 </div>
 </div>
   </div>
@@ -195,9 +223,9 @@ docker run --rm --pull always -v /mnt/host/c/Users/$env:USERNAME/.d8installer:/m
 ```
 {% endcapture %}
 {{ command | markdownify }}
+<p>Откройте <a href="http://localhost:8080">http://localhost:8080</a>.</p>
   </div>
   </div>
 </li>
-<li>Откройте <a href="http://localhost:8080">http://localhost:8080</a></li>
 </ol>
 </div>


### PR DESCRIPTION
## Description

Added the installer startup command to GS.

## Why do we need it, and what problem does it solve?

Previously, the launch command was not specified.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: fix
summary: Added the installer startup command to GS.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
