### PR TITLE
[prometheus] Graceful aggregating-proxy VPA rescale (preStop sleep + InPlaceOrRecreate)

### DIFF
--- a/modules/000-common/images/kube-rbac-proxy/werf.inc.yaml
+++ b/modules/000-common/images/kube-rbac-proxy/werf.inc.yaml
@@ -7,6 +7,12 @@ import:
   add: /kube-rbac-proxy
   to: /kube-rbac-proxy
   before: setup
+- image: tools/coreutils
+  add: /
+  to: /
+  includePaths:
+  - usr/bin/sleep
+  before: setup
 git:
 {{- include "image mount points" . }}
 imageSpec:

--- a/modules/000-common/images/kube-rbac-proxy/werf.inc.yaml
+++ b/modules/000-common/images/kube-rbac-proxy/werf.inc.yaml
@@ -12,6 +12,7 @@ import:
   to: /
   includePaths:
   - usr/bin/sleep
+  - usr/bin/coreutils
   before: setup
 git:
 {{- include "image mount points" . }}

--- a/modules/300-prometheus/images/mimir/werf.inc.yaml
+++ b/modules/300-prometheus/images/mimir/werf.inc.yaml
@@ -56,7 +56,13 @@ import:
     add: /src/mimir
     to: /bin/mimir
     after: setup
-git:    
+  - image: tools/coreutils
+    add: /
+    to: /
+    includePaths:
+    - usr/bin/sleep
+    before: setup
+git:
 {{- include "image mount points" . }}    
 imageSpec:
   config:

--- a/modules/300-prometheus/images/mimir/werf.inc.yaml
+++ b/modules/300-prometheus/images/mimir/werf.inc.yaml
@@ -61,6 +61,7 @@ import:
     to: /
     includePaths:
     - usr/bin/sleep
+    - usr/bin/coreutils
     before: setup
 git:
 {{- include "image mount points" . }}    

--- a/modules/300-prometheus/images/promxy/werf.inc.yaml
+++ b/modules/300-prometheus/images/promxy/werf.inc.yaml
@@ -50,6 +50,12 @@ import:
     add: /src/promxy
     to: /app/promxy
     after: setup
+  - image: tools/coreutils
+    add: /
+    to: /
+    includePaths:
+    - usr/bin/sleep
+    before: setup
 git:
 {{- include "image mount points" . }}
 imageSpec:

--- a/modules/300-prometheus/images/promxy/werf.inc.yaml
+++ b/modules/300-prometheus/images/promxy/werf.inc.yaml
@@ -55,6 +55,7 @@ import:
     to: /
     includePaths:
     - usr/bin/sleep
+    - usr/bin/coreutils
     before: setup
 git:
 {{- include "image mount points" . }}

--- a/modules/300-prometheus/templates/aggregating-proxy/deployment.yaml
+++ b/modules/300-prometheus/templates/aggregating-proxy/deployment.yaml
@@ -23,7 +23,7 @@ spec:
     kind: Deployment
     name: aggregating-proxy
   updatePolicy:
-    updateMode: "Auto"
+    updateMode: "InPlaceOrRecreate"
   resourcePolicy:
     containerPolicies:
       - containerName: mimir
@@ -80,6 +80,10 @@ spec:
         - name: mimir
           {{- include "helm_lib_module_container_security_context_pss_restricted_flexible" dict | nindent 10 }}
           image: {{ include "helm_lib_module_image" (list . "mimir") }}
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/usr/bin/sleep", "10"]
           args:
             - "-target=query-frontend"
             - "-config.file=/etc/mimir/config.yaml"
@@ -114,6 +118,10 @@ spec:
         - name: promxy
           {{- include "helm_lib_module_container_security_context_pss_restricted_flexible" dict | nindent 10 }}
           image: {{ include "helm_lib_module_image" (list . "promxy") }}
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/usr/bin/sleep", "10"]
           args:
             - "--bind-addr=127.0.0.1:8082"
             - "--config=/etc/promxy/config.yaml"
@@ -142,6 +150,10 @@ spec:
         - name: kube-rbac-proxy
           {{- include "helm_lib_module_container_security_context_pss_restricted_flexible" dict | nindent 10 }}
           image: {{ include "helm_lib_module_common_image" (list . "kubeRbacProxy") }}
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/usr/bin/sleep", "10"]
           args:
             - "--secure-listen-address=$(KUBE_RBAC_PROXY_LISTEN_ADDRESS):8443"
             - "--client-ca-file=/etc/kube-rbac-proxy/ca.crt"

--- a/modules/300-prometheus/templates/aggregating-proxy/deployment.yaml
+++ b/modules/300-prometheus/templates/aggregating-proxy/deployment.yaml
@@ -23,7 +23,11 @@ spec:
     kind: Deployment
     name: aggregating-proxy
   updatePolicy:
+{{- if semverCompare ">= 1.33" (.Values.global.discovery.kubernetesVersion | default "0.0.0") }}
     updateMode: "InPlaceOrRecreate"
+{{- else }}
+    updateMode: "Auto"
+{{- end }}
   resourcePolicy:
     containerPolicies:
       - containerName: mimir


### PR DESCRIPTION
## Description
VPA periodically recreates the aggregating-proxy pod, causing short downtime.

- Bundle the `sleep` binary from tools/coreutils into the mimir, promxy and
  common kube-rbac-proxy (distroless) images.
- Add an exec preStop `sleep 10` to all aggregating-proxy containers so
  endpoints drain before SIGTERM on recreate.
- Switch the aggregating-proxy VPA updateMode from Auto to InPlaceOrRecreate
  (in-place resize without restart on k8s >=1.33; graceful recreate otherwise).

Native KEP-3960 SleepAction is unavailable on release-1.73 (feature gate not
enabled; alpha on k8s 1.29) and the images are distroless, hence the bundled
coreutils sleep + exec preStop.

## Why do we need it, and what problem does it solve?
Prior to the changes, the VPA’s operation resulted in read metrics being temporarily unavailable.

## Why do we need it in the patch release (if we do)?
Yes, it would be nice to have this change in Deckhouse 1.73 CSE

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: prometheus
type: fix
summary: Graceful aggregating-proxy rollout
impact_level: default
```