### PR TITLE
[docs] Fix the image links in the English version of the private environment guide

### DIFF
--- a/docs/site/pages/guides/PRIVATE_ENVIRONMENT.md
+++ b/docs/site/pages/guides/PRIVATE_ENVIRONMENT.md
@@ -684,19 +684,19 @@ Create a [robot account](https://goharbor.io/docs/1.10/working-with-projects/pro
 Open the `deckhouse` project and go to the **Robot Accounts** tab. Click **New Robot Account**:
 
 <div style="text-align: center;">
-<img src="/images/guides/install_to_private_environment/harbor_robot_account_ru.png" alt="Harbor robot accounts...">
+<img src="/images/guides/install_to_private_environment/harbor_robot_account.png" alt="Harbor robot accounts...">
 </div>
 
 Set the account name, optional description, and expiration (days or never expire):
 
 <div style="text-align: center;">
-<img src="/images/guides/install_to_private_environment/harbor_create_robot_account_ru.png" alt="Creating a Harbor robot account...">
+<img src="/images/guides/install_to_private_environment/harbor_create_robot_account.png" alt="Creating a Harbor robot account...">
 </div>
 
 For correct operation, grant full access under **Repository**. Adjust other permissions as needed or per your security policy.
 
 <div style="text-align: center;">
-<img src="/images/guides/install_to_private_environment/harbor_robot_permissions_ru.png" alt="Harbor robot account permissions...">
+<img src="/images/guides/install_to_private_environment/harbor_robot_permissions.png" alt="Harbor robot account permissions...">
 </div>
 
 After creation, Harbor shows the robot account secret (token).
@@ -706,7 +706,7 @@ Save the secret immediately. Harbor will not show it again, and it cannot be ret
 {% endalert %}
 
 <div style="text-align: center;">
-<img src="/images/guides/install_to_private_environment/harbor_robot_created_ru.png" alt="Harbor robot account created...">
+<img src="/images/guides/install_to_private_environment/harbor_robot_created.png" alt="Harbor robot account created...">
 </div>
 
 Harbor configuration is now complete! 🎉


### PR DESCRIPTION
## Description

Fixed the image links in the English version of the private environment guide

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: fix
summary: Fix the image links in the English version of the private environment guide.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
