### PR TITLE
[docs] Fix the link to the container image registry in the getting started for a private environment

### DIFF
--- a/docs/site/_includes/getting_started/global/partials/INSTALL_OTHER.liquid
+++ b/docs/site/_includes/getting_started/global/partials/INSTALL_OTHER.liquid
@@ -1,9 +1,6 @@
 {% assign revision=include.revision %}
 
 Use a container image to install the **Deckhouse Kubernetes Platform**. It is necessary to transfer configuration file to the container{%- if page.platform_type != 'existing' %} as well as SSH keys for accessing **the master node** (further, it is assumed that the SSH key `~/.ssh/<SSH_PRIVATE_KEY_FILE>` from the personal computer of the user performing the installation is used){% endif %}.
-{% if page.platform_code == 'bm-private' %}
-Log in on the **personal computer** to the container image registry you specified in the previous step.
-{%- endif %}
 
 Run the installer on the **personal computer**.
 
@@ -29,7 +26,7 @@ Run the installer on the **personal computer**.
 <!-- Linux or macOS install, BE, SE, SE+, EE -->
 Log in on the **personal computer** to the container image registry:
 ```shell
-echo <LICENSE_TOKEN> | docker login -u license-token --password-stdin registry.deckhouse.io
+echo <LICENSE_TOKEN> | docker login -u license-token --password-stdin {%- if page.platform_code == "bm-private" %} <IMAGES_REPO_URI>{%- else %} registry.deckhouse.io{% endif %}
 ```
 
 Run a container with the installer:
@@ -50,7 +47,7 @@ docker run --pull=always {% if page.platform_code == "kind" %} --network host {%
 <!-- Windows install, BE, SE, SE+, EE -->
 Log in on the **personal computer** to the container image registry by providing the license key as a password:
 ```text
-docker login -u license-token registry.deckhouse.io
+docker login -u license-token {%- if page.platform_code == "bm-private" %} <IMAGES_REPO_URI>{%- else %} registry.deckhouse.io{% endif %}
 ```
 
 Run a container with the installer:

--- a/docs/site/_includes/getting_started/global/partials/INSTALL_OTHER_RU.liquid
+++ b/docs/site/_includes/getting_started/global/partials/INSTALL_OTHER_RU.liquid
@@ -34,7 +34,7 @@ pdpl-user -i 63 <USERNAME>
 <!-- Linux or macOS install, BE, SE, SE+, EE -->
 Авторизуйтесь на **персональном компьютере** в container image registry:
 ```shell
-echo <LICENSE_TOKEN> | docker login -u license-token --password-stdin {%- if page.platform_code == "bm-private" %} <IMAGES_REPO_URI>{%- else %} registry.deckhouse.io{% endif %}
+echo <LICENSE_TOKEN> | docker login -u license-token --password-stdin {%- if page.platform_code == "bm-private" %} <IMAGES_REPO_URI>{%- else %} registry.deckhouse.ru{% endif %}
 ```
 
 Запустите контейнер с установщиком:

--- a/docs/site/_includes/getting_started/global/partials/INSTALL_OTHER_RU.liquid
+++ b/docs/site/_includes/getting_started/global/partials/INSTALL_OTHER_RU.liquid
@@ -55,7 +55,7 @@ docker run --pull=always {% if page.platform_code == "kind" %} --network host {%
 <!-- Windows install, BE, SE, SE+, EE -->
 Авторизуйтесь на **персональном компьютере** в container image registry, введя лицензионный ключ на запрос пароля:
 ```text
-docker login -u license-token {%- if page.platform_code == "bm-private" %} <IMAGES_REPO_URI>{%- else %} registry.deckhouse.io{% endif %}
+docker login -u license-token {%- if page.platform_code == "bm-private" %} <IMAGES_REPO_URI>{%- else %} registry.deckhouse.ru{% endif %}
 ```
 
 Запустите контейнер с установщиком:

--- a/docs/site/_includes/getting_started/global/partials/INSTALL_OTHER_RU.liquid
+++ b/docs/site/_includes/getting_started/global/partials/INSTALL_OTHER_RU.liquid
@@ -10,10 +10,6 @@ pdpl-user -i 63 <USERNAME>
 ```
 {%- endif %}
 
-{% if page.platform_code == 'bm-private' %}
-Авторизуйтесь на **персональном компьютере** в container image registry, который вы указали на предыдущем этапе.
-{%- endif %}
-
 Запустите установщик на **персональном компьютере**.
 
 {%- if revision == 'be' or revision == 'se' or revision == 'se-plus' or revision == 'ee' %}
@@ -38,7 +34,7 @@ pdpl-user -i 63 <USERNAME>
 <!-- Linux or macOS install, BE, SE, SE+, EE -->
 Авторизуйтесь на **персональном компьютере** в container image registry:
 ```shell
-echo <LICENSE_TOKEN> | docker login -u license-token --password-stdin registry.deckhouse.ru
+echo <LICENSE_TOKEN> | docker login -u license-token --password-stdin {%- if page.platform_code == "bm-private" %} <IMAGES_REPO_URI>{%- else %} registry.deckhouse.io{% endif %}
 ```
 
 Запустите контейнер с установщиком:
@@ -59,7 +55,7 @@ docker run --pull=always {% if page.platform_code == "kind" %} --network host {%
 <!-- Windows install, BE, SE, SE+, EE -->
 Авторизуйтесь на **персональном компьютере** в container image registry, введя лицензионный ключ на запрос пароля:
 ```text
-docker login -u license-token registry.deckhouse.ru
+docker login -u license-token {%- if page.platform_code == "bm-private" %} <IMAGES_REPO_URI>{%- else %} registry.deckhouse.io{% endif %}
 ```
 
 Запустите контейнер с установщиком:

--- a/docs/site/pages/guides/PRIVATE_ENVIRONMENT.md
+++ b/docs/site/pages/guides/PRIVATE_ENVIRONMENT.md
@@ -1131,29 +1131,25 @@ You should see a container named `squid` in the list.
   * HTTP and HTTPS proxy addresses
   * hostnames and IP addresses that **must not** use the proxy (internal names and internal IPs of your servers).
 
-* In `InitConfiguration`, add registry access settings:
+* In the `deckhouse` ModuleConfig:
+  * set [releaseChannel](/modules/deckhouse/configuration.html#parameters-releasechannel) to `Stable` to use the stable [update channel](../documentation/v1/reference/release-channels.html).
+  * in the `spec.settings.registry` section, specify access settings for the private container registry (Harbor in this guide):
+    ```yaml
+    # Settings for accessing the container registry with Deckhouse images.
+    registry:
+      mode: Unmanaged
+      unmanaged:
+        # Address of the container registry with Deckhouse images.
+        imagesRepo: <IMAGES_REPO_URI>
+        # Username for authenticating with the container registry.
+        username: <REGISTRY_USERNAME>
+        # Password for authenticating with the container registry.
+        password: <REGISTRY_PASSWORD>
+        scheme: HTTPS
+        # Root CA certificate in PEM format used to verify the container registry server certificate.
+        ca: <REGISTRY_CA>
+    ```
 
-  ```yaml
-  deckhouse:
-    # Docker registry that hosts Deckhouse images (set the DKP edition).
-    imagesRepo: harbor.example/deckhouse/<EDITION>
-    # Base64-encoded Docker client auth string for the registry.
-    registryDockerCfg: <DOCKER_CFG_BASE64>
-    # Registry protocol (HTTP or HTTPS).
-    registryScheme: HTTPS
-    # Root CA used to verify the registry certificate.
-    # Example: `cat harbor/certs/ca.crt`.
-    registryCA: |
-      -----BEGIN CERTIFICATE-----
-      ...
-      -----END CERTIFICATE-----
-  ```
-
-  `<DOCKER_CFG_BASE64>` is the contents of the Docker client config (on Linux, usually `$HOME/.docker/config.json`) for the third-party registry, encoded in Base64.
-
-  For example, for registry `harbor.example` with user `user` and password `P@ssw0rd`, the value is `eyJhdXRocyI6eyJoYXJib3IuZXhhbXBsZSI6eyJhdXRoIjoiZFhObGNqcFFRSE56ZHpCeVpBPT0ifX19` (Base64 of `{"auths":{"harbor.example":{"auth":"dXNlcjpQQHNzdzByZA=="}}}`).
-
-* In the `deckhouse` ModuleConfig, set [releaseChannel](/modules/deckhouse/configuration.html#parameters-releasechannel) to `Stable` for the stable [update channel](../documentation/v1/reference/release-channels.html).
 * In the [global](../documentation/v1/reference/api/global.html) ModuleConfig, enable self-signed certificates for modules and set `publicDomainTemplate` for system application hostnames:
 
   ```yaml

--- a/docs/site/pages/guides/PRIVATE_ENVIRONMENT.md
+++ b/docs/site/pages/guides/PRIVATE_ENVIRONMENT.md
@@ -1134,6 +1134,7 @@ You should see a container named `squid` in the list.
 * In the `deckhouse` ModuleConfig:
   * Set [`releaseChannel`](/modules/deckhouse/configuration.html#parameters-releasechannel) to `Stable` to use the stable [release channel](../documentation/v1/reference/release-channels.html).
   * In the `spec.settings.registry` section, specify access settings for the private container registry (Harbor in this guide):
+
     ```yaml
     # Settings for accessing the container registry with DKP images.
     registry:

--- a/docs/site/pages/guides/PRIVATE_ENVIRONMENT.md
+++ b/docs/site/pages/guides/PRIVATE_ENVIRONMENT.md
@@ -1133,7 +1133,7 @@ You should see a container named `squid` in the list.
 
 * In the `deckhouse` ModuleConfig:
   * Set [`releaseChannel`](/modules/deckhouse/configuration.html#parameters-releasechannel) to `Stable` to use the stable [release channel](../documentation/v1/reference/release-channels.html).
-  * in the `spec.settings.registry` section, specify access settings for the private container registry (Harbor in this guide):
+  * In the `spec.settings.registry` section, specify access settings for the private container registry (Harbor in this guide):
     ```yaml
     # Settings for accessing the container registry with Deckhouse images.
     registry:

--- a/docs/site/pages/guides/PRIVATE_ENVIRONMENT.md
+++ b/docs/site/pages/guides/PRIVATE_ENVIRONMENT.md
@@ -1135,18 +1135,18 @@ You should see a container named `squid` in the list.
   * Set [`releaseChannel`](/modules/deckhouse/configuration.html#parameters-releasechannel) to `Stable` to use the stable [release channel](../documentation/v1/reference/release-channels.html).
   * In the `spec.settings.registry` section, specify access settings for the private container registry (Harbor in this guide):
     ```yaml
-    # Settings for accessing the container registry with Deckhouse images.
+    # Settings for accessing the container registry with DKP images.
     registry:
       mode: Unmanaged
       unmanaged:
-        # Address of the container registry with Deckhouse images.
+        # Address of the registry.
         imagesRepo: <IMAGES_REPO_URI>
-        # Username for authenticating with the container registry.
+        # Username for authenticating with the registry.
         username: <REGISTRY_USERNAME>
-        # Password for authenticating with the container registry.
+        # Password for authenticating with the registry.
         password: <REGISTRY_PASSWORD>
         scheme: HTTPS
-        # Root CA certificate in PEM format used to verify the container registry server certificate.
+        # Root CA certificate in PEM format used to verify the registry server certificate.
         ca: <REGISTRY_CA>
     ```
 

--- a/docs/site/pages/guides/PRIVATE_ENVIRONMENT.md
+++ b/docs/site/pages/guides/PRIVATE_ENVIRONMENT.md
@@ -1132,7 +1132,7 @@ You should see a container named `squid` in the list.
   * hostnames and IP addresses that **must not** use the proxy (internal names and internal IPs of your servers).
 
 * In the `deckhouse` ModuleConfig:
-  * set [releaseChannel](/modules/deckhouse/configuration.html#parameters-releasechannel) to `Stable` to use the stable [update channel](../documentation/v1/reference/release-channels.html).
+  * Set [`releaseChannel`](/modules/deckhouse/configuration.html#parameters-releasechannel) to `Stable` to use the stable [release channel](../documentation/v1/reference/release-channels.html).
   * in the `spec.settings.registry` section, specify access settings for the private container registry (Harbor in this guide):
     ```yaml
     # Settings for accessing the container registry with Deckhouse images.

--- a/docs/site/pages/guides/PRIVATE_ENVIRONMENT_RU.md
+++ b/docs/site/pages/guides/PRIVATE_ENVIRONMENT_RU.md
@@ -1176,7 +1176,7 @@ Status: Downloaded newer image for ubuntu/squid:latest
 
 * В ModuleConfig `deckhouse`:
   * измените значение параметра [`releaseChannel`](/modules/deckhouse/configuration.html#parameters-releasechannel) на `Stable` для использования стабильного [канала обновлений](../documentation/v1/reference/release-channels.html);
-  * в секции `spec.settings.registry` укажите параметры доступа к приватному хранилищу образов контейнеров (в нашем случае Harbor):
+  * в секции `spec.settings.registry` укажите параметры доступа к приватному хранилищу образов контейнеров (в данном случае Harbor):
     ```yaml
     # Настройки для доступа к хранилищу образов контейнеров с образами Deckhouse.
     registry:

--- a/docs/site/pages/guides/PRIVATE_ENVIRONMENT_RU.md
+++ b/docs/site/pages/guides/PRIVATE_ENVIRONMENT_RU.md
@@ -1178,18 +1178,18 @@ Status: Downloaded newer image for ubuntu/squid:latest
   * измените значение параметра [`releaseChannel`](/modules/deckhouse/configuration.html#parameters-releasechannel) на `Stable` для использования стабильного [канала обновлений](../documentation/v1/reference/release-channels.html);
   * в секции `spec.settings.registry` укажите параметры доступа к приватному хранилищу образов контейнеров (в данном случае Harbor):
     ```yaml
-    # Настройки для доступа к хранилищу образов контейнеров с образами Deckhouse.
+    # Настройки для доступа к хранилищу образов контейнеров с образами DKP.
     registry:
       mode: Unmanaged
       unmanaged:
-        # Адрес хранилища образов контейнеров с образами Deckhouse.
+        # Адрес хранилища.
         imagesRepo: <IMAGES_REPO_URI>
-        # Имя пользователя для аутентификации в хранилище образов контейнеров.
+        # Имя пользователя для аутентификации в хранилище.
         username: <REGISTRY_USERNAME>
-        # Пароль для аутентификации в хранилище образов контейнеров.
+        # Пароль для аутентификации в хранилище.
         password: <REGISTRY_PASSWORD>
         scheme: HTTPS
-        # Корневой сертификат центра сертификации (CA) в формате PEM для проверки серверного сертификата хранилища образов контейнеров.
+        # Корневой сертификат центра сертификации (CA) в формате PEM для проверки серверного сертификата хранилища.
         ca: <REGISTRY_CA>
     ```
 

--- a/docs/site/pages/guides/PRIVATE_ENVIRONMENT_RU.md
+++ b/docs/site/pages/guides/PRIVATE_ENVIRONMENT_RU.md
@@ -1173,30 +1173,26 @@ Status: Downloaded newer image for ubuntu/squid:latest
   Здесь указываются следующие параметры:
   * адреса HTTP и HTTPS прокси-сервера;
   * список доменов и IP-адресов, которые **не будут проксироваться** через прокси-сервер (внутренние доменные имена и внутренние IP-адреса всех серверов).
-  
-* В секции `InitConfiguration` добавьте параметры доступа к registry:
 
-  ```yaml
-  deckhouse:
-    # Адрес Docker registry с образами Deckhouse (укажите редакцию DKP).
-    imagesRepo: harbor.example/deckhouse/<РЕДАКЦИЯ_DKP>
-    # Строка с ключом для доступа к Docker registry в формате Base64.
-    registryDockerCfg: <DOCKER_CFG_BASE64>
-    # Протокол доступа к registry (HTTP или HTTPS).
-    registryScheme: HTTPS
-    # Корневой сертификат, созданный ранее.
-    # Получить его можно командой: `cat harbor/certs/ca.crt`.
-    registryCA: |
-      -----BEGIN CERTIFICATE-----
-      ...
-      -----END CERTIFICATE-----
-  ```
+* В ModuleConfig `deckhouse`:
+  * измените значение параметра [releaseChannel](/modules/deckhouse/configuration.html#parameters-releasechannel) на `Stable` для использования стабильного [канала обновлений](../documentation/v1/reference/release-channels.html).
+  * в секции `spec.settings.registry` укажите параметры доступа к приватному хранилищу образов контейнеров (в нашем случае Harbor):
+    ```yaml
+    # Настройки для доступа к хранилищу образов контейнеров с образами Deckhouse.
+    registry:
+      mode: Unmanaged
+      unmanaged:
+        # Адрес хранилища образов контейнеров с образами Deckhouse.
+        imagesRepo: <IMAGES_REPO_URI>
+        # Имя пользователя для аутентификации в хранилище образов контейнеров.
+        username: <REGISTRY_USERNAME>
+        # Пароль для аутентификации в хранилище образов контейнеров.
+        password: <REGISTRY_PASSWORD>
+        scheme: HTTPS
+        # Корневой сертификат центра сертификации (CA) в формате PEM для проверки серверного сертификата хранилища образов контейнеров.
+        ca: <REGISTRY_CA>
+    ```
 
-  Здесь `<DOCKER_CFG_BASE64>` — строка авторизации из файла конфигурации Docker-клиента (в Linux обычно это `$HOME/.docker/config.json`) для доступа к стороннему container registry, закодированная в Base64.
-
-  Например, для доступа к container registry `harbor.example` под пользователем `user` с паролем `P@ssw0rd` это будет `eyJhdXRocyI6eyJoYXJib3IuZXhhbXBsZSI6eyJhdXRoIjoiZFhObGNqcFFRSE56ZHpCeVpBPT0ifX19` (строка `{"auths":{"harbor.example":{"auth":"dXNlcjpQQHNzdzByZA=="}}}` в Base64).
-
-* В параметре [releaseChannel](/modules/deckhouse/configuration.html#parameters-releasechannel) ModuleConfig `deckhouse` измените на `Stable` для использования стабильного [канала обновлений](../documentation/v1/reference/release-channels.html).
 * В ModuleConfig [global](../documentation/v1/reference/api/global.html) укажите использование самоподписанных сертификатов для компонентов кластера и укажите шаблон доменного имени для системных приложений в параметре `publicDomainTemplate`:
 
   ```yaml

--- a/docs/site/pages/guides/PRIVATE_ENVIRONMENT_RU.md
+++ b/docs/site/pages/guides/PRIVATE_ENVIRONMENT_RU.md
@@ -1177,6 +1177,7 @@ Status: Downloaded newer image for ubuntu/squid:latest
 * В ModuleConfig `deckhouse`:
   * измените значение параметра [`releaseChannel`](/modules/deckhouse/configuration.html#parameters-releasechannel) на `Stable` для использования стабильного [канала обновлений](../documentation/v1/reference/release-channels.html);
   * в секции `spec.settings.registry` укажите параметры доступа к приватному хранилищу образов контейнеров (в данном случае Harbor):
+
     ```yaml
     # Настройки для доступа к хранилищу образов контейнеров с образами DKP.
     registry:

--- a/docs/site/pages/guides/PRIVATE_ENVIRONMENT_RU.md
+++ b/docs/site/pages/guides/PRIVATE_ENVIRONMENT_RU.md
@@ -1175,7 +1175,7 @@ Status: Downloaded newer image for ubuntu/squid:latest
   * список доменов и IP-адресов, которые **не будут проксироваться** через прокси-сервер (внутренние доменные имена и внутренние IP-адреса всех серверов).
 
 * В ModuleConfig `deckhouse`:
-  * измените значение параметра [releaseChannel](/modules/deckhouse/configuration.html#parameters-releasechannel) на `Stable` для использования стабильного [канала обновлений](../documentation/v1/reference/release-channels.html).
+  * измените значение параметра [`releaseChannel`](/modules/deckhouse/configuration.html#parameters-releasechannel) на `Stable` для использования стабильного [канала обновлений](../documentation/v1/reference/release-channels.html);
   * в секции `spec.settings.registry` укажите параметры доступа к приватному хранилищу образов контейнеров (в нашем случае Harbor):
     ```yaml
     # Настройки для доступа к хранилищу образов контейнеров с образами Deckhouse.


### PR DESCRIPTION
## Description

Fixed the link to the container image registry in the getting started for a private environment.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: fix
summary: Fixed the link to the container image registry in the getting started for a private environment.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
