### PR TITLE
[node-manager] Fix convert static cluster configuration hook

### DIFF
--- a/modules/040-node-manager/hooks/convert_static_cluster_configuration.go
+++ b/modules/040-node-manager/hooks/convert_static_cluster_configuration.go
@@ -62,6 +62,8 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	},
 }, convertStaticClusterConfigurationHandler)
 
+const internalNetworkCIDRsPath = "nodeManager.internal.static.internalNetworkCIDRs"
+
 func convertStaticClusterConfigurationHandler(ctx context.Context, input *go_hook.HookInput) error {
 	secret := input.Snapshots.Get("static_cluster_configuration")
 
@@ -80,7 +82,17 @@ func convertStaticClusterConfigurationHandler(ctx context.Context, input *go_hoo
 		return err
 	}
 
-	input.Values.Set("nodeManager.internal.static.internalNetworkCIDRs", internalNetwork)
+	if isEmptyInternalNetwork(internalNetwork) {
+		if existing := input.Values.Get(internalNetworkCIDRsPath); len(existing.Array()) > 0 {
+			return fmt.Errorf(
+				"static-cluster-configuration.yaml no longer contains 'internalNetworkCIDRs', but %q is currently set to %s; "+
+					"refusing to silently clear it, since this looks like an accidental config change that could break node network setup",
+				internalNetworkCIDRsPath, existing.String(),
+			)
+		}
+	}
+
+	input.Values.Set(internalNetworkCIDRsPath, internalNetwork)
 	return nil
 }
 
@@ -115,4 +127,17 @@ func isBlankYAMLDocument(data []byte) bool {
 		return r == '-' || unicode.IsSpace(r)
 	})
 	return trimmed == ""
+}
+
+func isEmptyInternalNetwork(v any) bool {
+	switch t := v.(type) {
+	case nil:
+		return true
+	case []any:
+		return len(t) == 0
+	case string:
+		return t == ""
+	default:
+		return false
+	}
 }

--- a/modules/040-node-manager/hooks/convert_static_cluster_configuration.go
+++ b/modules/040-node-manager/hooks/convert_static_cluster_configuration.go
@@ -83,6 +83,10 @@ func convertStaticClusterConfigurationHandler(ctx context.Context, input *go_hoo
 }
 
 func internalNetworkFromStaticConfiguration(data []byte) (any, error) {
+	if len(data) == 0 {
+		return "", nil
+	}
+
 	if err := validation.ValidateData([]string{}, &data); err != nil {
 		if !errors.Is(err, validation.ErrSchemaNotFound) {
 			return "", err

--- a/modules/040-node-manager/hooks/convert_static_cluster_configuration.go
+++ b/modules/040-node-manager/hooks/convert_static_cluster_configuration.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
+	"unicode"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
@@ -83,19 +85,19 @@ func convertStaticClusterConfigurationHandler(ctx context.Context, input *go_hoo
 }
 
 func internalNetworkFromStaticConfiguration(data []byte) (any, error) {
-	if len(data) == 0 {
-		return "", nil
+	if isBlankYAMLDocument(data) {
+		return []any{}, nil
 	}
 
 	if err := validation.ValidateData([]string{}, &data); err != nil {
 		if !errors.Is(err, validation.ErrSchemaNotFound) {
-			return "", err
+			return nil, err
 		}
 	}
 	res := make(map[any]any)
 	err := yaml.Unmarshal(data, &res)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	intNet, ok := res["internalNetworkCIDRs"]
@@ -103,5 +105,14 @@ func internalNetworkFromStaticConfiguration(data []byte) (any, error) {
 		return intNet, nil
 	}
 
-	return "", nil
+	return []any{}, nil
+}
+
+// isBlankYAMLDocument reports whether data contains no actual YAML content:
+// only whitespace and/or "---" document separators (e.g. "", "\n", "---", "---\n").
+func isBlankYAMLDocument(data []byte) bool {
+	trimmed := strings.TrimFunc(string(data), func(r rune) bool {
+		return r == '-' || unicode.IsSpace(r)
+	})
+	return trimmed == ""
 }

--- a/modules/040-node-manager/hooks/convert_static_cluster_configuration_test.go
+++ b/modules/040-node-manager/hooks/convert_static_cluster_configuration_test.go
@@ -48,7 +48,7 @@ kind: Secret
 metadata:
   labels:
     heritage: deckhouse
-  name: d8-static-configuration
+  name: d8-static-cluster-configuration
   namespace: kube-system
 type: Opaque
 `, 0))
@@ -58,6 +58,143 @@ type: Opaque
 		It("Should fill internalNetworkCIDRs", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.ValuesGet("nodeManager.internal.static.internalNetworkCIDRs").String()).To(MatchJSON(`["192.168.199.0/24"]`))
+		})
+	})
+
+	Context("With an empty secret (no data at all)", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSetAndWaitForBindingContexts(`
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  labels:
+    heritage: deckhouse
+  name: d8-static-cluster-configuration
+  namespace: kube-system
+type: Opaque
+`, 0))
+			f.RunHook()
+		})
+
+		It("Should run and set internalNetworkCIDRs to an empty list", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("nodeManager.internal.static.internalNetworkCIDRs").String()).To(MatchJSON(`[]`))
+		})
+	})
+
+	Context("With a secret containing an empty static-cluster-configuration.yaml field", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSetAndWaitForBindingContexts(`
+apiVersion: v1
+data:
+  static-cluster-configuration.yaml: ""
+kind: Secret
+metadata:
+  labels:
+    heritage: deckhouse
+  name: d8-static-cluster-configuration
+  namespace: kube-system
+type: Opaque
+`, 0))
+			f.RunHook()
+		})
+
+		It("Should run and set internalNetworkCIDRs to an empty list", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("nodeManager.internal.static.internalNetworkCIDRs").String()).To(MatchJSON(`[]`))
+		})
+	})
+
+	Context("With a secret whose static-cluster-configuration.yaml field is just a newline", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSetAndWaitForBindingContexts(`
+apiVersion: v1
+data:
+  static-cluster-configuration.yaml: Cg==
+kind: Secret
+metadata:
+  labels:
+    heritage: deckhouse
+  name: d8-static-cluster-configuration
+  namespace: kube-system
+type: Opaque
+`, 0))
+			f.RunHook()
+		})
+
+		It("Should run and set internalNetworkCIDRs to an empty list", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("nodeManager.internal.static.internalNetworkCIDRs").String()).To(MatchJSON(`[]`))
+		})
+	})
+
+	Context("With a secret whose static-cluster-configuration.yaml field is just a document separator (---)", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSetAndWaitForBindingContexts(`
+apiVersion: v1
+data:
+  static-cluster-configuration.yaml: LS0t
+kind: Secret
+metadata:
+  labels:
+    heritage: deckhouse
+  name: d8-static-cluster-configuration
+  namespace: kube-system
+type: Opaque
+`, 0))
+			f.RunHook()
+		})
+
+		It("Should run and set internalNetworkCIDRs to an empty list", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("nodeManager.internal.static.internalNetworkCIDRs").String()).To(MatchJSON(`[]`))
+		})
+	})
+
+	Context("With a secret whose static-cluster-configuration.yaml field is a document separator followed by a newline (---\\n)", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSetAndWaitForBindingContexts(`
+apiVersion: v1
+data:
+  static-cluster-configuration.yaml: LS0tCg==
+kind: Secret
+metadata:
+  labels:
+    heritage: deckhouse
+  name: d8-static-cluster-configuration
+  namespace: kube-system
+type: Opaque
+`, 0))
+			f.RunHook()
+		})
+
+		It("Should run and set internalNetworkCIDRs to an empty list", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("nodeManager.internal.static.internalNetworkCIDRs").String()).To(MatchJSON(`[]`))
+		})
+	})
+
+	Context("With a secret whose static-cluster-configuration.yaml has no internalNetworkCIDRs", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSetAndWaitForBindingContexts(`
+apiVersion: v1
+data:
+  static-cluster-configuration.yaml: YXBpVmVyc2lvbjogZGVja2hvdXNlLmlvL3YxYWxwaGExCmtpbmQ6IFN0YXRpY0NsdXN0ZXJDb25maWd1cmF0aW9uCg==
+kind: Secret
+metadata:
+  labels:
+    heritage: deckhouse
+  name: d8-static-cluster-configuration
+  namespace: kube-system
+type: Opaque
+`, 0))
+			f.RunHook()
+		})
+
+		It("Should run and set internalNetworkCIDRs to an empty list", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("nodeManager.internal.static.internalNetworkCIDRs").String()).To(MatchJSON(`[]`))
 		})
 	})
 })

--- a/modules/040-node-manager/hooks/convert_static_cluster_configuration_test.go
+++ b/modules/040-node-manager/hooks/convert_static_cluster_configuration_test.go
@@ -197,4 +197,78 @@ type: Opaque
 			Expect(f.ValuesGet("nodeManager.internal.static.internalNetworkCIDRs").String()).To(MatchJSON(`[]`))
 		})
 	})
+
+	Context("With a previously set internalNetworkCIDRs and a document that no longer defines it", func() {
+		BeforeEach(func() {
+			f.ValuesSet("nodeManager.internal.static.internalNetworkCIDRs", []string{"192.168.199.0/24"})
+			f.BindingContexts.Set(f.KubeStateSetAndWaitForBindingContexts(`
+apiVersion: v1
+data:
+  static-cluster-configuration.yaml: YXBpVmVyc2lvbjogZGVja2hvdXNlLmlvL3YxYWxwaGExCmtpbmQ6IFN0YXRpY0NsdXN0ZXJDb25maWd1cmF0aW9uCg==
+kind: Secret
+metadata:
+  labels:
+    heritage: deckhouse
+  name: d8-static-cluster-configuration
+  namespace: kube-system
+type: Opaque
+`, 0))
+			f.RunHook()
+		})
+
+		It("Should fail instead of silently clearing internalNetworkCIDRs", func() {
+			Expect(f).NotTo(ExecuteSuccessfully())
+			Expect(f.GoHookError.Error()).To(ContainSubstring("refusing to silently clear"))
+			Expect(f.ValuesGet("nodeManager.internal.static.internalNetworkCIDRs").String()).To(MatchJSON(`["192.168.199.0/24"]`))
+		})
+	})
+
+	Context("With a previously set internalNetworkCIDRs and a secret whose field becomes blank", func() {
+		BeforeEach(func() {
+			f.ValuesSet("nodeManager.internal.static.internalNetworkCIDRs", []string{"192.168.199.0/24"})
+			f.BindingContexts.Set(f.KubeStateSetAndWaitForBindingContexts(`
+apiVersion: v1
+data:
+  static-cluster-configuration.yaml: ""
+kind: Secret
+metadata:
+  labels:
+    heritage: deckhouse
+  name: d8-static-cluster-configuration
+  namespace: kube-system
+type: Opaque
+`, 0))
+			f.RunHook()
+		})
+
+		It("Should fail instead of silently clearing internalNetworkCIDRs", func() {
+			Expect(f).NotTo(ExecuteSuccessfully())
+			Expect(f.GoHookError.Error()).To(ContainSubstring("refusing to silently clear"))
+			Expect(f.ValuesGet("nodeManager.internal.static.internalNetworkCIDRs").String()).To(MatchJSON(`["192.168.199.0/24"]`))
+		})
+	})
+
+	Context("With a previously set internalNetworkCIDRs and a document that updates it to a new non-empty value", func() {
+		BeforeEach(func() {
+			f.ValuesSet("nodeManager.internal.static.internalNetworkCIDRs", []string{"10.0.0.0/24"})
+			f.BindingContexts.Set(f.KubeStateSetAndWaitForBindingContexts(`
+apiVersion: v1
+data:
+  static-cluster-configuration.yaml: YXBpVmVyc2lvbjogZGVja2hvdXNlLmlvL3YxYWxwaGExCmtpbmQ6IFN0YXRpY0NsdXN0ZXJDb25maWd1cmF0aW9uCmludGVybmFsTmV0d29ya0NJRFJzOgotIDE5Mi4xNjguMTk5LjAvMjQK
+kind: Secret
+metadata:
+  labels:
+    heritage: deckhouse
+  name: d8-static-cluster-configuration
+  namespace: kube-system
+type: Opaque
+`, 0))
+			f.RunHook()
+		})
+
+		It("Should update internalNetworkCIDRs normally", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("nodeManager.internal.static.internalNetworkCIDRs").String()).To(MatchJSON(`["192.168.199.0/24"]`))
+		})
+	})
 })


### PR DESCRIPTION
## Description

Fix convert static cluster configuration hook

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: Fixed the convert static cluster configuration hook.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
