### PR TITLE
[deckhouse] bump addon-operator with ConversionWebhook Helm ownership fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/cloudflare/cfssl v1.6.5
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/fatih/color v1.18.0 // indirect
-	github.com/flant/addon-operator v1.24.1
+	github.com/flant/addon-operator v1.24.2-0.20260714154516-ab312074559a
 	github.com/flant/kube-client v1.9.1
 	github.com/flant/shell-operator v1.20.2
 	github.com/go-openapi/spec v0.22.1

--- a/go.sum
+++ b/go.sum
@@ -220,6 +220,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/flant/addon-operator v1.24.1 h1:O1zzpAfKUQ0umC5ckMJ5b122hxZrm36IC96vM/s1QCI=
 github.com/flant/addon-operator v1.24.1/go.mod h1:GlDlzwuEHLhT4VheDwUrTfEcnWgRkRzmho1+w9toxec=
+github.com/flant/addon-operator v1.24.2-0.20260714154516-ab312074559a h1:057lPdgXjGbAKiOdWWpPHAUVGoIN0i/xLci7EFLX+00=
+github.com/flant/addon-operator v1.24.2-0.20260714154516-ab312074559a/go.mod h1:GlDlzwuEHLhT4VheDwUrTfEcnWgRkRzmho1+w9toxec=
 github.com/flant/kube-client v1.9.1 h1:B5Sa++5arl3N/KBdL1KNMlUBtzQXKz1o2FIiFb4X+VA=
 github.com/flant/kube-client v1.9.1/go.mod h1:jAQ01+f5Q8UJJ4RYZlk5xqoA+OOalpr/QJ3e3Q/saqw=
 github.com/flant/shell-operator v1.20.2 h1:rI2lIkhZxIfMVR0NFMSZ5xyXMvtBj+Wai2MPopb/Yp0=

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -66,7 +66,7 @@ require (
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/fatih/structtag v1.2.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/flant/addon-operator v1.24.1 // indirect
+	github.com/flant/addon-operator v1.24.2-0.20260714154516-ab312074559a // indirect
 	github.com/flant/kube-client v1.9.1 // indirect
 	github.com/flant/shell-operator v1.20.2 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -239,6 +239,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/flant/addon-operator v1.24.1 h1:O1zzpAfKUQ0umC5ckMJ5b122hxZrm36IC96vM/s1QCI=
 github.com/flant/addon-operator v1.24.1/go.mod h1:GlDlzwuEHLhT4VheDwUrTfEcnWgRkRzmho1+w9toxec=
+github.com/flant/addon-operator v1.24.2-0.20260714154516-ab312074559a h1:057lPdgXjGbAKiOdWWpPHAUVGoIN0i/xLci7EFLX+00=
+github.com/flant/addon-operator v1.24.2-0.20260714154516-ab312074559a/go.mod h1:GlDlzwuEHLhT4VheDwUrTfEcnWgRkRzmho1+w9toxec=
 github.com/flant/kube-client v1.9.1 h1:B5Sa++5arl3N/KBdL1KNMlUBtzQXKz1o2FIiFb4X+VA=
 github.com/flant/kube-client v1.9.1/go.mod h1:jAQ01+f5Q8UJJ4RYZlk5xqoA+OOalpr/QJ3e3Q/saqw=
 github.com/flant/shell-operator v1.20.2 h1:rI2lIkhZxIfMVR0NFMSZ5xyXMvtBj+Wai2MPopb/Yp0=


### PR DESCRIPTION
## Description
Bumps `github.com/flant/addon-operator` to `v1.24.2-0.20260714154516-ab312074559a`, which includes the ConversionWebhook Helm-ownership fix ([flant/addon-operator#802](https://github.com/flant/addon-operator/pull/802)). `EnsureConversionWebhooks` now stamps the Helm ownership markers (`app.kubernetes.io/managed-by=Helm`, `meta.helm.sh/release-name`, `meta.helm.sh/release-namespace`) onto the ConversionWebhook it applies before the module's Helm release.

## Why do we need it, and what problem does it solve?
Since the ensure-conversion-webhooks feature landed, a module that ships a ConversionWebhook (for example `log-shipper`) fails its `helm upgrade` with `invalid ownership metadata`. The pre-apply step created/updated the resource without Helm's ownership markers, so Helm refused to adopt its own object and the module never reached `Ready` — convergence stayed stuck in a retry loop. This bump pulls the upstream fix so Helm adopts the pre-applied ConversionWebhook.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: Bump addon-operator with ConversionWebhook Helm ownership fix
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
