### PR TITLE
[cloud-provider-huaweicloud] add ignore static nodes in the ccm

### DIFF
--- a/ee/modules/030-cloud-provider-huaweicloud/images/cloud-controller-manager/patches/006-ignore-static-nodes.patch
+++ b/ee/modules/030-cloud-provider-huaweicloud/images/cloud-controller-manager/patches/006-ignore-static-nodes.patch
@@ -1,0 +1,61 @@
+diff --git a/pkg/cloudprovider/huaweicloud/instances.go b/pkg/cloudprovider/huaweicloud/instances.go
+index 7dba24a..418ca19 100644
+--- a/pkg/cloudprovider/huaweicloud/instances.go
++++ b/pkg/cloudprovider/huaweicloud/instances.go
+@@ -54,6 +54,10 @@ func (i *Instances) NodeAddresses(ctx context.Context, name types.NodeName) ([]v
+ // NodeAddressesByProviderID returns the addresses of the specified instance.
+ func (i *Instances) NodeAddressesByProviderID(_ context.Context, providerID string) ([]v1.NodeAddress, error) {
+ 	klog.Infof("NodeAddressesByProviderID is called with provider ID %s", providerID)
++	if strings.HasPrefix(providerID, "static://") {
++		return nil, nil
++	}
++
+ 	instanceID, err := parseInstanceID(providerID)
+ 	if err != nil {
+ 		return nil, err
+@@ -146,6 +150,10 @@ func (i *Instances) CurrentNodeName(_ context.Context, hostname string) (types.N
+ // InstanceExistsByProviderID returns true if the instance for the given provider exists.
+ func (i *Instances) InstanceExistsByProviderID(_ context.Context, providerID string) (bool, error) {
+ 	klog.Infof("InstanceExistsByProviderID is called with provider ID %s", providerID)
++	if strings.HasPrefix(providerID, "static://") {
++		return true, nil
++	}
++
+ 	instanceID, err := parseInstanceID(providerID)
+ 	if err != nil {
+ 		return false, err
+@@ -165,6 +173,10 @@ func (i *Instances) InstanceExistsByProviderID(_ context.Context, providerID str
+ // InstanceShutdownByProviderID returns true if the instance is shutdown in cloudprovider
+ func (i *Instances) InstanceShutdownByProviderID(_ context.Context, providerID string) (bool, error) {
+ 	klog.Infof("InstanceShutdownByProviderID is called with provider ID %s", providerID)
++	if strings.HasPrefix(providerID, "static://") {
++		return false, nil
++	}
++
+ 	instanceID, err := parseInstanceID(providerID)
+ 	if err != nil {
+ 		return false, err
+@@ -180,6 +192,10 @@ func (i *Instances) InstanceShutdownByProviderID(_ context.Context, providerID s
+ // InstanceExists returns true if the instance for the given node exists according to the cloud provider.
+ func (i *Instances) InstanceExists(ctx context.Context, node *v1.Node) (bool, error) {
+ 	klog.Infof("InstanceExists is called with node %s", node.Name)
++	if strings.HasPrefix(node.Spec.ProviderID, "static://") {
++		return true, nil
++	}
++
+ 	_, err := i.ecsClient.GetByNodeName(node.Name)
+
+ 	if err != nil {
+@@ -201,6 +217,12 @@ func (i *Instances) InstanceShutdown(ctx context.Context, node *v1.Node) (bool,
+ // translated into specific fields in the Node object on registration.
+ func (i *Instances) InstanceMetadata(ctx context.Context, node *v1.Node) (*cloudprovider.InstanceMetadata, error) {
+ 	klog.Infof("InstanceMetadata is called with node %s", node.Name)
++	if strings.HasPrefix(node.Spec.ProviderID, "static://") {
++		return &cloudprovider.InstanceMetadata{
++			ProviderID: node.Spec.ProviderID,
++		}, nil
++	}
++
+ 	providerID := node.Spec.ProviderID
+ 	if providerID == "" {
+ 		klog.V(4).Infof("node.Spec.ProviderID is empty, query ECS details by hostname: %s", node.Name)

--- a/ee/modules/030-cloud-provider-huaweicloud/images/cloud-controller-manager/patches/README.md
+++ b/ee/modules/030-cloud-provider-huaweicloud/images/cloud-controller-manager/patches/README.md
@@ -21,3 +21,7 @@ Fix providerID format and exclude 127.0.0.0/8 in node IP selections
 ### 005-default-lb-class-and-algorithm.patch
 
 Add default values for `elb.class` (`shared`) and `lb-algorithm` (`ROUND_ROBIN`) so that LoadBalancer services work without requiring these annotations to be set explicitly.
+
+### 006-ignore-static-nodes.patch
+
+Static nodes are registered with `providerID` set to `static://`, which does not match the cloud provider's expected instance ID format. Without this patch, the CCM fails to resolve such nodes in `InstanceExistsByProviderID`, `InstanceExists`, `InstanceShutdownByProviderID`, `NodeAddressesByProviderID` and `InstanceMetadata`. In particular, a failing `InstanceMetadata` call prevents the CCM from ever removing the `node.cloudprovider.kubernetes.io/uninitialized` taint from a freshly added static node, so the node never finishes initialization and gets recreated once the StaticMachine bootstrap timeout is reached. This patch makes the CCM treat any `static://` provider ID as a node the cloud provider does not manage, returning safe defaults instead of errors.


### PR DESCRIPTION
## Description

When attempting to add a static node (StaticInstance) to a Deckhouse cluster, the node is continuously recreated and never registers successfully. This happens because upstream controllers delete the Node object almost immediately after it is created, leaving no time for the node to complete registration.

This PR adds patches to the upstream version to make it ignore static nodes, preventing premature deletion of the Node object and allowing static instances to register properly.

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

The client is unable to add a static node in a hybrid huaweicloud cluster.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?
client impact
<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-huaweicloud
type: fix
summary: Adds patches to the upstream version to make it ignore static nodes
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
