### PR TITLE
[control-plane-manager] CPO etcd-defrag deadlock fix

### DIFF
--- a/modules/040-control-plane-manager/hooks/spawn_etcd_defrag_cpo.go
+++ b/modules/040-control-plane-manager/hooks/spawn_etcd_defrag_cpo.go
@@ -228,9 +228,12 @@ func handleSpawnEtcdDefragCPO(_ context.Context, input *go_hook.HookInput) error
 		return nil
 	}
 
-	// Only defragment nodes where etcd is actually deployed and Ready. Otherwise the CPO
-	// would hang in the DefragEtcd/WaitPodReady steps waiting for a pod that does not exist,
-	// occupying the single global etcd operation slot and blocking etcd join on new nodes.
+	// Defrag is only safe to run when every etcd member is healthy: defragmenting one member
+	// while another is already down (e.g. not deployed yet on a freshly added node) further
+	// reduces the serving quorum. So if even a single etcd node lacks a Ready pod, skip
+	// spawning CPOs for the whole slot rather than only for the unready node — otherwise a
+	// CPO for a healthy node could still hang waiting on the global etcd operation slot behind
+	// one for a pod that does not exist.
 	etcdReadyNodes := make(map[string]struct{})
 	for nodeName, err := range sdkobjectpatch.SnapshotIter[string](input.Snapshots.Get("etcd_pods_defrag")) {
 		if err != nil {
@@ -241,21 +244,22 @@ func handleSpawnEtcdDefragCPO(_ context.Context, input *go_hook.HookInput) error
 		}
 	}
 
-	input.Logger.Info("etcd defrag: spawning CPOs", "nodes", nodeNames, "slot", nextSlot.Format(time.RFC3339))
-
-	var skipped []string
+	var notReady []string
 	for _, nodeName := range nodeNames {
 		if _, ok := etcdReadyNodes[nodeName]; !ok {
-			skipped = append(skipped, nodeName)
-			continue
+			notReady = append(notReady, nodeName)
 		}
-		name := etcdDefragCPOName(nextSlot, nodeName)
-		input.PatchCollector.CreateIfNotExists(buildDefragCPO(name, nodeName, nextSlot, cpnUIDs[nodeName]))
-		input.Logger.Info("etcd defrag: CPO created", "name", name, "node", nodeName)
 	}
 
-	if len(skipped) > 0 {
-		input.Logger.Info("etcd defrag: skipping nodes without a ready etcd pod", "nodes", skipped)
+	if len(notReady) > 0 {
+		input.Logger.Info("etcd defrag: skipping this slot, not all etcd nodes are ready", "notReady", notReady)
+	} else {
+		input.Logger.Info("etcd defrag: spawning CPOs", "nodes", nodeNames, "slot", nextSlot.Format(time.RFC3339))
+		for _, nodeName := range nodeNames {
+			name := etcdDefragCPOName(nextSlot, nodeName)
+			input.PatchCollector.CreateIfNotExists(buildDefragCPO(name, nodeName, nextSlot, cpnUIDs[nodeName]))
+			input.Logger.Info("etcd defrag: CPO created", "name", name, "node", nodeName)
+		}
 	}
 
 	stateData := map[string]string{

--- a/modules/040-control-plane-manager/hooks/spawn_etcd_defrag_cpo.go
+++ b/modules/040-control-plane-manager/hooks/spawn_etcd_defrag_cpo.go
@@ -127,8 +127,6 @@ func filterDefragStateCM(obj *unstructured.Unstructured) (go_hook.FilterResult, 
 }
 
 // filterDefragEtcdPod returns the node name of a Ready etcd pod, or "" otherwise.
-// Only Ready pods matter for the defrag precondition, so the readiness check lives here
-// and the snapshot carries just the node names to defragment.
 func filterDefragEtcdPod(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
 	var pod corev1.Pod
 	if err := sdk.FromUnstructured(obj, &pod); err != nil {
@@ -228,12 +226,9 @@ func handleSpawnEtcdDefragCPO(_ context.Context, input *go_hook.HookInput) error
 		return nil
 	}
 
-	// Defrag is only safe to run when every etcd member is healthy: defragmenting one member
-	// while another is already down (e.g. not deployed yet on a freshly added node) further
-	// reduces the serving quorum. So if even a single etcd node lacks a Ready pod, skip
-	// spawning CPOs for the whole slot rather than only for the unready node — otherwise a
-	// CPO for a healthy node could still hang waiting on the global etcd operation slot behind
-	// one for a pod that does not exist.
+	// Defrag is only safe when every etcd member is healthy: defragmenting one member while
+	// another is down further reduces quorum. So if any etcd node lacks a Ready pod, skip
+	// spawning CPOs for the whole slot, not just for that node.
 	etcdReadyNodes := make(map[string]struct{})
 	for nodeName, err := range sdkobjectpatch.SnapshotIter[string](input.Snapshots.Get("etcd_pods_defrag")) {
 		if err != nil {

--- a/modules/040-control-plane-manager/hooks/spawn_etcd_defrag_cpo.go
+++ b/modules/040-control-plane-manager/hooks/spawn_etcd_defrag_cpo.go
@@ -90,6 +90,24 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			ExecuteHookOnEvents: ptr.To(false),
 			FilterFunc:          filterDefragStateCM,
 		},
+		{
+			Name:       "etcd_pods_defrag",
+			ApiVersion: "v1",
+			Kind:       "Pod",
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{defragStateCMNamespace},
+				},
+			},
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"component": "etcd",
+					"tier":      "control-plane",
+				},
+			},
+			ExecuteHookOnEvents: ptr.To(false),
+			FilterFunc:          filterDefragEtcdPod,
+		},
 	},
 }, handleSpawnEtcdDefragCPO)
 
@@ -106,6 +124,24 @@ func filterDefragStateCM(obj *unstructured.Unstructured) (go_hook.FilterResult, 
 		return nil, fmt.Errorf("parse defrag state ConfigMap: %w", err)
 	}
 	return cm.Data[defragLastSlotKey], nil
+}
+
+// filterDefragEtcdPod returns the node name of a Ready etcd pod, or "" otherwise.
+// Only Ready pods matter for the defrag precondition, so the readiness check lives here
+// and the snapshot carries just the node names to defragment.
+func filterDefragEtcdPod(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	var pod corev1.Pod
+	if err := sdk.FromUnstructured(obj, &pod); err != nil {
+		return nil, fmt.Errorf("parse etcd pod: %w", err)
+	}
+
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+			return pod.Spec.NodeName, nil
+		}
+	}
+
+	return "", nil
 }
 
 func handleSpawnEtcdDefragCPO(_ context.Context, input *go_hook.HookInput) error {
@@ -192,12 +228,34 @@ func handleSpawnEtcdDefragCPO(_ context.Context, input *go_hook.HookInput) error
 		return nil
 	}
 
+	// Only defragment nodes where etcd is actually deployed and Ready. Otherwise the CPO
+	// would hang in the DefragEtcd/WaitPodReady steps waiting for a pod that does not exist,
+	// occupying the single global etcd operation slot and blocking etcd join on new nodes.
+	etcdReadyNodes := make(map[string]struct{})
+	for nodeName, err := range sdkobjectpatch.SnapshotIter[string](input.Snapshots.Get("etcd_pods_defrag")) {
+		if err != nil {
+			return fmt.Errorf("iterate etcd_pods_defrag: %w", err)
+		}
+		if nodeName != "" {
+			etcdReadyNodes[nodeName] = struct{}{}
+		}
+	}
+
 	input.Logger.Info("etcd defrag: spawning CPOs", "nodes", nodeNames, "slot", nextSlot.Format(time.RFC3339))
 
+	var skipped []string
 	for _, nodeName := range nodeNames {
+		if _, ok := etcdReadyNodes[nodeName]; !ok {
+			skipped = append(skipped, nodeName)
+			continue
+		}
 		name := etcdDefragCPOName(nextSlot, nodeName)
 		input.PatchCollector.CreateIfNotExists(buildDefragCPO(name, nodeName, nextSlot, cpnUIDs[nodeName]))
 		input.Logger.Info("etcd defrag: CPO created", "name", name, "node", nodeName)
+	}
+
+	if len(skipped) > 0 {
+		input.Logger.Info("etcd defrag: skipping nodes without a ready etcd pod", "nodes", skipped)
 	}
 
 	stateData := map[string]string{

--- a/modules/040-control-plane-manager/hooks/spawn_etcd_defrag_cpo_test.go
+++ b/modules/040-control-plane-manager/hooks/spawn_etcd_defrag_cpo_test.go
@@ -91,6 +91,42 @@ data:
 `, slot)
 }
 
+// defragEtcdPodYAML renders a static etcd pod running on the given node.
+// ready controls the Ready pod condition used by the Layer 1 precondition.
+func defragEtcdPodYAML(node string, ready bool) string {
+	status := "False"
+	if ready {
+		status = "True"
+	}
+	return fmt.Sprintf(`
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: etcd-%s
+  namespace: kube-system
+  labels:
+    component: etcd
+    tier: control-plane
+spec:
+  nodeName: %s
+status:
+  phase: Running
+  conditions:
+  - type: Ready
+    status: "%s"
+`, node, node, status)
+}
+
+// defragReadyEtcdPods renders ready etcd pods for all given nodes.
+func defragReadyEtcdPods(nodes ...string) string {
+	out := ""
+	for _, n := range nodes {
+		out += defragEtcdPodYAML(n, true)
+	}
+	return out
+}
+
 const (
 	defragCPN0 = `
 ---
@@ -229,7 +265,9 @@ var _ = Describe("Modules :: control-plane-manager :: hooks :: spawn_etcd_defrag
 	Context("cron fired, 3 master nodes, past slot in ConfigMap", func() {
 		f := newDefragHook(valuesDefragEnabled)
 		BeforeEach(func() {
-			state := defragCPN0 + defragCPN1 + defragCPN2 + defragStateCMYAML(defragPastSlot)
+			state := defragCPN0 + defragCPN1 + defragCPN2 +
+				defragReadyEtcdPods("master-0", "master-1", "master-2") +
+				defragStateCMYAML(defragPastSlot)
 			f.BindingContexts.Set(f.KubeStateSet(state))
 			f.RunHook()
 		})
@@ -269,7 +307,9 @@ var _ = Describe("Modules :: control-plane-manager :: hooks :: spawn_etcd_defrag
 	Context("cron fired, 2 masters + 1 arbiter node", func() {
 		f := newDefragHook(valuesDefragEnabled)
 		BeforeEach(func() {
-			state := defragCPN0 + defragCPN1 + defragCPNArbiter + defragStateCMYAML(defragPastSlot)
+			state := defragCPN0 + defragCPN1 + defragCPNArbiter +
+				defragReadyEtcdPods("master-0", "master-1", "arbiter-0") +
+				defragStateCMYAML(defragPastSlot)
 			f.BindingContexts.Set(f.KubeStateSet(state))
 			f.RunHook()
 		})
@@ -277,6 +317,56 @@ var _ = Describe("Modules :: control-plane-manager :: hooks :: spawn_etcd_defrag
 			Expect(f).To(ExecuteSuccessfully())
 			count, _ := listCPOs(f)
 			Expect(count).To(Equal(3))
+		})
+	})
+
+	Context("cron fired, but a node has no etcd pod yet (scale-up window)", func() {
+		f := newDefragHook(valuesDefragEnabled)
+		BeforeEach(func() {
+			// master-0/master-1 have a ready etcd pod; master-2 was just added and
+			// has a ControlPlaneNode but no etcd pod yet.
+			state := defragCPN0 + defragCPN1 + defragCPN2 +
+				defragReadyEtcdPods("master-0", "master-1") +
+				defragStateCMYAML(defragPastSlot)
+			f.BindingContexts.Set(f.KubeStateSet(state))
+			f.RunHook()
+		})
+		It("creates CPOs only for nodes with a ready etcd pod and still advances the slot", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			count, cpos := listCPOs(f)
+			Expect(count).To(Equal(2))
+
+			nodes := make([]string, 0, len(cpos))
+			for _, cpo := range cpos {
+				spec, _ := cpo["spec"].(map[string]interface{})
+				nodes = append(nodes, fmt.Sprintf("%v", spec["nodeName"]))
+			}
+			Expect(nodes).To(ConsistOf("master-0", "master-1"))
+
+			cm := f.KubernetesResource("ConfigMap", "kube-system", defragStateCMName)
+			Expect(cm.Exists()).To(BeTrue())
+			Expect(cm.Field("data.lastHandledCronSlot").String()).To(Equal(defragTestNow.Truncate(time.Minute).Format(time.RFC3339)))
+		})
+	})
+
+	Context("cron fired, but etcd pod is not Ready", func() {
+		f := newDefragHook(valuesDefragEnabled)
+		BeforeEach(func() {
+			// master-0 ready; master-1 has an etcd pod that is not Ready.
+			state := defragCPN0 + defragCPN1 +
+				defragEtcdPodYAML("master-0", true) +
+				defragEtcdPodYAML("master-1", false) +
+				defragStateCMYAML(defragPastSlot)
+			f.BindingContexts.Set(f.KubeStateSet(state))
+			f.RunHook()
+		})
+		It("skips the node whose etcd pod is not Ready", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			count, cpos := listCPOs(f)
+			Expect(count).To(Equal(1))
+			spec, _ := cpos[0]["spec"].(map[string]interface{})
+			Expect(spec["nodeName"]).To(Equal("master-0"))
 		})
 	})
 

--- a/modules/040-control-plane-manager/hooks/spawn_etcd_defrag_cpo_test.go
+++ b/modules/040-control-plane-manager/hooks/spawn_etcd_defrag_cpo_test.go
@@ -331,18 +331,11 @@ var _ = Describe("Modules :: control-plane-manager :: hooks :: spawn_etcd_defrag
 			f.BindingContexts.Set(f.KubeStateSet(state))
 			f.RunHook()
 		})
-		It("creates CPOs only for nodes with a ready etcd pod and still advances the slot", func() {
+		It("creates no CPOs this slot and still advances it", func() {
 			Expect(f).To(ExecuteSuccessfully())
 
-			count, cpos := listCPOs(f)
-			Expect(count).To(Equal(2))
-
-			nodes := make([]string, 0, len(cpos))
-			for _, cpo := range cpos {
-				spec, _ := cpo["spec"].(map[string]interface{})
-				nodes = append(nodes, fmt.Sprintf("%v", spec["nodeName"]))
-			}
-			Expect(nodes).To(ConsistOf("master-0", "master-1"))
+			count, _ := listCPOs(f)
+			Expect(count).To(Equal(0))
 
 			cm := f.KubernetesResource("ConfigMap", "kube-system", defragStateCMName)
 			Expect(cm.Exists()).To(BeTrue())
@@ -350,7 +343,7 @@ var _ = Describe("Modules :: control-plane-manager :: hooks :: spawn_etcd_defrag
 		})
 	})
 
-	Context("cron fired, but etcd pod is not Ready", func() {
+	Context("cron fired, but one etcd pod is not Ready", func() {
 		f := newDefragHook(valuesDefragEnabled)
 		BeforeEach(func() {
 			// master-0 ready; master-1 has an etcd pod that is not Ready.
@@ -361,12 +354,10 @@ var _ = Describe("Modules :: control-plane-manager :: hooks :: spawn_etcd_defrag
 			f.BindingContexts.Set(f.KubeStateSet(state))
 			f.RunHook()
 		})
-		It("skips the node whose etcd pod is not Ready", func() {
+		It("skips the whole slot rather than defragmenting only the ready node", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			count, cpos := listCPOs(f)
-			Expect(count).To(Equal(1))
-			spec, _ := cpos[0]["spec"].(map[string]interface{})
-			Expect(spec["nodeName"]).To(Equal("master-0"))
+			count, _ := listCPOs(f)
+			Expect(count).To(Equal(0))
 		})
 	})
 

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/controller_test.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/controller_test.go
@@ -82,6 +82,10 @@ func newMockCompleteWithMessage(calls *[]execCall, name controlplanev1alpha1.Ste
 	return &mockCommand{name: name, result: StepResult{Outcome: OutcomeCompleted, Message: message}, calls: calls}
 }
 
+func newMockAbandon(calls *[]execCall, name controlplanev1alpha1.StepName, message string) Step {
+	return &mockCommand{name: name, result: StepResult{Outcome: OutcomeAbandoned, Message: message}, calls: calls}
+}
+
 // helpers
 
 const testNodeName = "master-1"
@@ -332,6 +336,31 @@ func (s *ControllerTestSuite) TestReconcileAlreadyFailed() {
 		require.NotNil(s.T(), completedCond)
 		require.Equal(s.T(), metav1.ConditionTrue, completedCond.Status)
 		require.Equal(s.T(), controlplanev1alpha1.CPOReasonOperationCompleted, completedCond.Reason)
+	})
+}
+
+func (s *ControllerTestSuite) TestReconcileStepAbandonStopsPipeline() {
+	s.Run("abandon outcome marks operation terminal and skips remaining steps", func() {
+		var calls []execCall
+		cmds, op := buildTestCase(controlplanev1alpha1.OperationComponentEtcd,
+			newMockAbandon(&calls, controlplanev1alpha1.StepDefragEtcd, "etcd pod not present"),
+			newMockOK(&calls, controlplanev1alpha1.StepWaitPodReady),
+		)
+		r := s.newReconciler(cmds, op, testCPMSecret(), testPKISecret())
+
+		result, err := r.Reconcile(s.ctx, reconcile.Request{NamespacedName: client.ObjectKey{Name: "test-op"}})
+		require.NoError(s.T(), err)
+		require.Equal(s.T(), reconcile.Result{}, result)
+
+		require.Len(s.T(), calls, 1, "pipeline must stop after the abandoning step")
+		require.Equal(s.T(), controlplanev1alpha1.StepDefragEtcd, calls[0].name)
+
+		got := s.getOp(r, "test-op")
+		completed := meta.FindStatusCondition(got.Status.Conditions, controlplanev1alpha1.CPOConditionCompleted)
+		require.NotNil(s.T(), completed)
+		require.Equal(s.T(), metav1.ConditionFalse, completed.Status)
+		require.Equal(s.T(), controlplanev1alpha1.CPOReasonOperationAbandoned, completed.Reason)
+		require.True(s.T(), got.IsTerminal(), "abandoned operation must be terminal so it releases the approval slot")
 	})
 }
 

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/controller_test.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/controller_test.go
@@ -18,6 +18,7 @@ package controlplaneoperation
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -31,6 +32,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/deckhouse/deckhouse/pkg/log"
@@ -181,7 +183,9 @@ func (s *ControllerTestSuite) SetupSuite() {
 	s.ctx = context.Background()
 }
 
-func (s *ControllerTestSuite) newReconciler(cmds map[controlplanev1alpha1.StepName]Step, objs ...client.Object) *Reconciler {
+// newTestReconciler builds a Reconciler backed by a fake client seeded with objs. A nil cmds
+// falls back to the real step registry; tests that mock individual steps pass their own.
+func newTestReconciler(cmds map[controlplanev1alpha1.StepName]Step, objs ...client.Object) *Reconciler {
 	c := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(objs...).
@@ -237,7 +241,7 @@ func (s *ControllerTestSuite) TestReconcileNotApproved() {
 	s.Run("not approved operation is skipped", func() {
 		op := testOperation(controlplanev1alpha1.OperationComponentKubeScheduler,
 			[]controlplanev1alpha1.StepName{controlplanev1alpha1.StepSyncManifests}, false)
-		r := s.newReconciler(nil, op, testCPMSecret(), testPKISecret())
+		r := newTestReconciler(nil, op, testCPMSecret(), testPKISecret())
 
 		result, err := r.Reconcile(s.ctx, reconcile.Request{NamespacedName: client.ObjectKey{Name: "test-op"}})
 		require.NoError(s.T(), err)
@@ -275,7 +279,7 @@ func (s *ControllerTestSuite) TestReconcileInitialConditionsPreserveExisting() {
 			},
 		}
 
-		r := s.newReconciler(nil, op, testCPMSecret(), testPKISecret())
+		r := newTestReconciler(nil, op, testCPMSecret(), testPKISecret())
 
 		result, err := r.Reconcile(s.ctx, reconcile.Request{NamespacedName: client.ObjectKey{Name: "test-op"}})
 		require.NoError(s.T(), err)
@@ -305,7 +309,7 @@ func (s *ControllerTestSuite) TestReconcileAlreadyCompleted() {
 		op.Status.Conditions = []metav1.Condition{
 			{Type: controlplanev1alpha1.CPOConditionCompleted, Status: metav1.ConditionTrue, Reason: controlplanev1alpha1.CPOReasonOperationCompleted, LastTransitionTime: metav1.Now()},
 		}
-		r := s.newReconciler(cmds, op, testCPMSecret(), testPKISecret())
+		r := newTestReconciler(cmds, op, testCPMSecret(), testPKISecret())
 
 		result, err := r.Reconcile(s.ctx, reconcile.Request{NamespacedName: client.ObjectKey{Name: "test-op"}})
 		require.NoError(s.T(), err)
@@ -323,7 +327,7 @@ func (s *ControllerTestSuite) TestReconcileAlreadyFailed() {
 		op.Status.Conditions = []metav1.Condition{
 			{Type: controlplanev1alpha1.CPOConditionCompleted, Status: metav1.ConditionFalse, Reason: controlplanev1alpha1.CPOReasonOperationFailed, Message: "boom", LastTransitionTime: metav1.Now()},
 		}
-		r := s.newReconciler(cmds, op, testCPMSecret(), testPKISecret())
+		r := newTestReconciler(cmds, op, testCPMSecret(), testPKISecret())
 
 		result, err := r.Reconcile(s.ctx, reconcile.Request{NamespacedName: client.ObjectKey{Name: "test-op"}})
 		require.NoError(s.T(), err)
@@ -346,7 +350,7 @@ func (s *ControllerTestSuite) TestReconcileStepAbandonStopsPipeline() {
 			newMockAbandon(&calls, controlplanev1alpha1.StepDefragEtcd, "etcd pod not present"),
 			newMockOK(&calls, controlplanev1alpha1.StepWaitPodReady),
 		)
-		r := s.newReconciler(cmds, op, testCPMSecret(), testPKISecret())
+		r := newTestReconciler(cmds, op, testCPMSecret(), testPKISecret())
 
 		result, err := r.Reconcile(s.ctx, reconcile.Request{NamespacedName: client.ObjectKey{Name: "test-op"}})
 		require.NoError(s.T(), err)
@@ -364,12 +368,51 @@ func (s *ControllerTestSuite) TestReconcileStepAbandonStopsPipeline() {
 	})
 }
 
+func (s *ControllerTestSuite) TestReconcileStepAbandonPatchFailureIsRetried() {
+	s.Run("abandon patch failure is surfaced as an error instead of silently stopping", func() {
+		var calls []execCall
+		cmds, op := buildTestCase(controlplanev1alpha1.OperationComponentEtcd,
+			newMockAbandon(&calls, controlplanev1alpha1.StepDefragEtcd, "etcd pod not present"),
+			newMockOK(&calls, controlplanev1alpha1.StepWaitPodReady),
+		)
+
+		// Only the patch that actually persists the Abandoned condition must fail — earlier
+		// status patches (initial conditions, in-progress markers) must go through normally,
+		// otherwise this test would fail for the wrong reason.
+		patchStatusErr := errors.New("injected status patch failure")
+		c := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(op, testCPMSecret(), testPKISecret()).
+			WithStatusSubresource(&controlplanev1alpha1.ControlPlaneOperation{}).
+			WithInterceptorFuncs(interceptor.Funcs{
+				SubResourcePatch: func(ctx context.Context, cli client.Client, subResourceName string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+					if cpo, ok := obj.(*controlplanev1alpha1.ControlPlaneOperation); ok && subResourceName == "status" {
+						if cond := meta.FindStatusCondition(cpo.Status.Conditions, controlplanev1alpha1.CPOConditionCompleted); cond != nil && cond.Reason == controlplanev1alpha1.CPOReasonOperationAbandoned {
+							return patchStatusErr
+						}
+					}
+					return cli.SubResource(subResourceName).Patch(ctx, obj, patch, opts...)
+				},
+			}).
+			Build()
+		r := &Reconciler{client: c, log: log.NewNop(), node: NodeIdentity{Name: testNodeName}, steps: cmds}
+
+		_, err := r.Reconcile(s.ctx, reconcile.Request{NamespacedName: client.ObjectKey{Name: "test-op"}})
+		require.Error(s.T(), err, "a failed abandon patch must be surfaced so controller-runtime retries reconciliation")
+		require.ErrorIs(s.T(), err, patchStatusErr)
+
+		got := s.getOp(r, "test-op")
+		require.False(s.T(), got.IsTerminal(),
+			"operation must not read as terminal on the server when the abandon patch never landed, otherwise the approval slot leaks forever")
+	})
+}
+
 func (s *ControllerTestSuite) TestReconcileChecksumMismatch() {
 	s.Run("checksum mismatch abandons operation", func() {
 		op := testOperation(controlplanev1alpha1.OperationComponentKubeScheduler,
 			[]controlplanev1alpha1.StepName{controlplanev1alpha1.StepSyncManifests}, true)
 		op.Spec.DesiredConfigChecksum = "stale-checksum"
-		r := s.newReconciler(nil, op, testCPMSecret(), testPKISecret())
+		r := newTestReconciler(nil, op, testCPMSecret(), testPKISecret())
 
 		result, err := r.Reconcile(s.ctx, reconcile.Request{NamespacedName: client.ObjectKey{Name: "test-op"}})
 		require.NoError(s.T(), err)
@@ -393,7 +436,7 @@ func (s *ControllerTestSuite) TestReconcileObserveOnlyNoSecrets() {
 		op.Spec.DesiredPKIChecksum = ""
 		op.Spec.DesiredCAChecksum = ""
 		// No secrets in cluster — CertObserve should not need them
-		r := s.newReconciler(cmds, op)
+		r := newTestReconciler(cmds, op)
 
 		result, err := r.Reconcile(s.ctx, reconcile.Request{NamespacedName: client.ObjectKey{Name: "test-op"}})
 		require.NoError(s.T(), err)
@@ -411,7 +454,7 @@ func (s *ControllerTestSuite) TestPipelineAllCommandsExecuteInOrder() {
 			newMockOK(&calls, controlplanev1alpha1.StepSyncManifests),
 			newMockOK(&calls, controlplanev1alpha1.StepWaitPodReady),
 		)
-		r := s.newReconciler(cmds, op, testCPMSecret(), testPKISecret())
+		r := newTestReconciler(cmds, op, testCPMSecret(), testPKISecret())
 
 		result, err := r.Reconcile(s.ctx, reconcile.Request{NamespacedName: client.ObjectKey{Name: "test-op"}})
 		require.NoError(s.T(), err)
@@ -444,7 +487,7 @@ func (s *ControllerTestSuite) TestPipelineSkipsCompletedCommands() {
 		op.Status.Conditions = []metav1.Condition{
 			{Type: controlplanev1alpha1.StepConditionType(controlplanev1alpha1.StepSyncCA), Status: metav1.ConditionTrue, Reason: controlplanev1alpha1.CPOReasonStepCompleted, LastTransitionTime: metav1.Now()},
 		}
-		r := s.newReconciler(cmds, op, testCPMSecret(), testPKISecret())
+		r := newTestReconciler(cmds, op, testCPMSecret(), testPKISecret())
 
 		result, err := r.Reconcile(s.ctx, reconcile.Request{NamespacedName: client.ObjectKey{Name: "test-op"}})
 		require.NoError(s.T(), err)
@@ -469,7 +512,7 @@ func (s *ControllerTestSuite) TestPipelineSkipsMultipleCompletedCommands() {
 			{Type: controlplanev1alpha1.StepConditionType(controlplanev1alpha1.StepSyncCA), Status: metav1.ConditionTrue, Reason: controlplanev1alpha1.CPOReasonStepCompleted, LastTransitionTime: metav1.Now()},
 			{Type: controlplanev1alpha1.StepConditionType(controlplanev1alpha1.StepSyncManifests), Status: metav1.ConditionTrue, Reason: controlplanev1alpha1.CPOReasonStepCompleted, LastTransitionTime: metav1.Now()},
 		}
-		r := s.newReconciler(cmds, op, testCPMSecret(), testPKISecret())
+		r := newTestReconciler(cmds, op, testCPMSecret(), testPKISecret())
 
 		result, err := r.Reconcile(s.ctx, reconcile.Request{NamespacedName: client.ObjectKey{Name: "test-op"}})
 		require.NoError(s.T(), err)
@@ -489,7 +532,7 @@ func (s *ControllerTestSuite) TestPipelineErrorStopsPipeline() {
 			newMockError(&calls, controlplanev1alpha1.StepSyncManifests, cmdErr),
 			newMockOK(&calls, controlplanev1alpha1.StepWaitPodReady),
 		)
-		r := s.newReconciler(cmds, op, testCPMSecret(), testPKISecret())
+		r := newTestReconciler(cmds, op, testCPMSecret(), testPKISecret())
 
 		_, err := r.Reconcile(s.ctx, reconcile.Request{NamespacedName: client.ObjectKey{Name: "test-op"}})
 		require.Error(s.T(), err)
@@ -524,7 +567,7 @@ func (s *ControllerTestSuite) TestPipelineRequeueStopsPipeline() {
 			newMockRequeue(&calls, controlplanev1alpha1.StepSyncManifests, 5*time.Second),
 			newMockOK(&calls, controlplanev1alpha1.StepWaitPodReady),
 		)
-		r := s.newReconciler(cmds, op, testCPMSecret(), testPKISecret())
+		r := newTestReconciler(cmds, op, testCPMSecret(), testPKISecret())
 
 		result, err := r.Reconcile(s.ctx, reconcile.Request{NamespacedName: client.ObjectKey{Name: "test-op"}})
 		require.NoError(s.T(), err)
@@ -550,7 +593,7 @@ func (s *ControllerTestSuite) TestPipelineSingleCommand() {
 		cmds, op := buildTestCase(controlplanev1alpha1.OperationComponentKubeScheduler,
 			newMockOK(&calls, controlplanev1alpha1.StepWaitPodReady),
 		)
-		r := s.newReconciler(cmds, op, testCPMSecret(), testPKISecret())
+		r := newTestReconciler(cmds, op, testCPMSecret(), testPKISecret())
 
 		result, err := r.Reconcile(s.ctx, reconcile.Request{NamespacedName: client.ObjectKey{Name: "test-op"}})
 		require.NoError(s.T(), err)
@@ -574,7 +617,7 @@ func (s *ControllerTestSuite) TestConditionsAfterSuccessfulPipeline() {
 			newMockOK(&calls, controlplanev1alpha1.StepSyncCA),
 			newMockOK(&calls, controlplanev1alpha1.StepSyncManifests),
 		)
-		r := s.newReconciler(cmds, op, testCPMSecret(), testPKISecret())
+		r := newTestReconciler(cmds, op, testCPMSecret(), testPKISecret())
 
 		_, err := r.Reconcile(s.ctx, reconcile.Request{NamespacedName: client.ObjectKey{Name: "test-op"}})
 		require.NoError(s.T(), err)
@@ -607,7 +650,7 @@ func (s *ControllerTestSuite) TestConditionsAfterError() {
 			newMockOK(&calls, controlplanev1alpha1.StepSyncCA),
 			newMockError(&calls, controlplanev1alpha1.StepSyncManifests, fmt.Errorf("write failed")),
 		)
-		r := s.newReconciler(cmds, op, testCPMSecret(), testPKISecret())
+		r := newTestReconciler(cmds, op, testCPMSecret(), testPKISecret())
 
 		_, _ = r.Reconcile(s.ctx, reconcile.Request{NamespacedName: client.ObjectKey{Name: "test-op"}})
 
@@ -639,7 +682,7 @@ func (s *ControllerTestSuite) TestConditionsAfterRequeue() {
 			newMockOK(&calls, controlplanev1alpha1.StepSyncCA),
 			newMockRequeue(&calls, controlplanev1alpha1.StepWaitPodReady, 5*time.Second),
 		)
-		r := s.newReconciler(cmds, op, testCPMSecret(), testPKISecret())
+		r := newTestReconciler(cmds, op, testCPMSecret(), testPKISecret())
 
 		_, _ = r.Reconcile(s.ctx, reconcile.Request{NamespacedName: client.ObjectKey{Name: "test-op"}})
 
@@ -681,7 +724,7 @@ func (s *ControllerTestSuite) TestPipelineKeepsCommandCompletedMessage() {
 		cmds, op := buildTestCase(controlplanev1alpha1.OperationComponentKubeScheduler,
 			newMockCompleteWithMessage(&calls, controlplanev1alpha1.StepSyncCA, controlplanev1alpha1.CPOStepResultRenewed),
 		)
-		r := s.newReconciler(cmds, op, testCPMSecret(), testPKISecret())
+		r := newTestReconciler(cmds, op, testCPMSecret(), testPKISecret())
 
 		_, err := r.Reconcile(s.ctx, reconcile.Request{NamespacedName: client.ObjectKey{Name: "test-op"}})
 		require.NoError(s.T(), err)

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/controller_test.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/controller_test.go
@@ -376,9 +376,8 @@ func (s *ControllerTestSuite) TestReconcileStepAbandonPatchFailureIsRetried() {
 			newMockOK(&calls, controlplanev1alpha1.StepWaitPodReady),
 		)
 
-		// Only the patch that actually persists the Abandoned condition must fail — earlier
-		// status patches (initial conditions, in-progress markers) must go through normally,
-		// otherwise this test would fail for the wrong reason.
+		// Only the patch persisting the Abandoned condition must fail; earlier ones must go
+		// through, otherwise this test fails for the wrong reason.
 		patchStatusErr := errors.New("injected status patch failure")
 		c := fake.NewClientBuilder().
 			WithScheme(scheme).

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/defrag.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/defrag.go
@@ -44,7 +44,7 @@ const (
 	// etcdDefragWaitPodDeadline bounds how long a defrag CPO waits for the local etcd pod
 	// before abandoning: waiting forever would hold the single global etcd slot and deadlock
 	// etcd join on other nodes. See waitEtcdPodResult.
-	etcdDefragWaitPodDeadline = 2 * time.Minute
+	etcdDefragWaitPodDeadline = 10 * time.Minute
 )
 
 // defragEtcdIfNeeded runs defragmentation if the fragmented ratio exceeds etcdDefragFragRatioThreshold.

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/defrag.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/defrag.go
@@ -40,6 +40,14 @@ const (
 
 	etcdDefragTimeout       = 2 * time.Minute
 	etcdDefragStatusTimeout = 10 * time.Second
+
+	// etcdDefragWaitPodDeadline bounds how long the DefragEtcd step waits for the local
+	// etcd pod to appear and become Ready. Defrag is periodic maintenance: if etcd is not
+	// present on this node (e.g. the node was just added and etcd has not been deployed yet),
+	// waiting forever would keep the operation approved and occupy the single global etcd slot,
+	// deadlocking etcd join on other nodes. Past the deadline we abandon the operation so the
+	// slot is released; the next scheduled defrag run will retry once etcd is up.
+	etcdDefragWaitPodDeadline = 2 * time.Minute
 )
 
 // defragEtcdIfNeeded runs defragmentation if the fragmented ratio exceeds etcdDefragFragRatioThreshold.
@@ -122,22 +130,14 @@ func (r *Reconciler) defragEtcd(ctx context.Context, state *controlplanev1alpha1
 	}, pod); err != nil {
 		if apierrors.IsNotFound(err) {
 			logger.Info("etcd pod not found, will retry before defragmentation", slog.String("pod", podName))
-			return StepResult{
-				Outcome:      OutcomePending,
-				Message:      "waiting for etcd pod to be ready before defragmentation",
-				RequeueAfter: requeueWaitPod,
-			}, nil
+			return waitEtcdPodResult(state.Raw(), podName, "not present"), nil
 		}
 		return StepResult{}, fmt.Errorf("get pod %s: %w", podName, err)
 	}
 
 	if !isPodReady(pod) {
 		logger.Info("etcd pod not ready, will retry before defragmentation", slog.String("pod", podName))
-		return StepResult{
-			Outcome:      OutcomePending,
-			Message:      "waiting for etcd pod to be ready before defragmentation",
-			RequeueAfter: requeueWaitPod,
-		}, nil
+		return waitEtcdPodResult(state.Raw(), podName, "not ready"), nil
 	}
 
 	defragged, err := defragEtcdIfNeeded(ctx, constants.KubernetesPkiPath, r.node.KubeconfigDir, logger)
@@ -149,4 +149,37 @@ func (r *Reconciler) defragEtcd(ctx context.Context, state *controlplanev1alpha1
 		return StepResult{Outcome: OutcomeCompleted, Message: "defragmented"}, nil
 	}
 	return StepResult{Outcome: OutcomeCompleted, Message: "skipped: fragmentation below threshold"}, nil
+}
+
+// waitEtcdPodResult returns a Pending result while the deadline has not elapsed, and an
+// Abandoned result once the etcd pod has been unavailable for longer than
+// etcdDefragWaitPodDeadline. Abandoning releases the global etcd operation slot so it can
+// never be held indefinitely by a defrag on a node without a running etcd pod.
+func waitEtcdPodResult(op *controlplanev1alpha1.ControlPlaneOperation, podName, reason string) StepResult {
+	if operationElapsed(op, time.Now()) > etcdDefragWaitPodDeadline {
+		return StepResult{
+			Outcome: OutcomeAbandoned,
+			Message: fmt.Sprintf("etcd pod %s %s after %s; skipping periodic defragmentation", podName, reason, etcdDefragWaitPodDeadline),
+		}
+	}
+	return StepResult{
+		Outcome:      OutcomePending,
+		Message:      "waiting for etcd pod to be ready before defragmentation",
+		RequeueAfter: requeueWaitPod,
+	}
+}
+
+// operationElapsed reports how long ago the operation started executing, based on the
+// operation-started-at annotation set by the reconciler. Returns 0 if the annotation is
+// missing or unparseable, which keeps the step in its retry loop rather than abandoning early.
+func operationElapsed(op *controlplanev1alpha1.ControlPlaneOperation, now time.Time) time.Duration {
+	started := op.Annotations[constants.OperationStartedAtAnnotationKey]
+	if started == "" {
+		return 0
+	}
+	startedAt, err := time.Parse(time.RFC3339Nano, started)
+	if err != nil {
+		return 0
+	}
+	return now.Sub(startedAt)
 }

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/defrag.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/defrag.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"log/slog"
 	"path/filepath"
+	"slices"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -41,12 +42,9 @@ const (
 	etcdDefragTimeout       = 2 * time.Minute
 	etcdDefragStatusTimeout = 10 * time.Second
 
-	// etcdDefragWaitPodDeadline bounds how long the DefragEtcd step waits for the local
-	// etcd pod to appear and become Ready. Defrag is periodic maintenance: if etcd is not
-	// present on this node (e.g. the node was just added and etcd has not been deployed yet),
-	// waiting forever would keep the operation approved and occupy the single global etcd slot,
-	// deadlocking etcd join on other nodes. Past the deadline we abandon the operation so the
-	// slot is released; the next scheduled defrag run will retry once etcd is up.
+	// etcdDefragWaitPodDeadline bounds how long a defrag CPO waits for the local etcd pod
+	// before abandoning: waiting forever would hold the single global etcd slot and deadlock
+	// etcd join on other nodes. See waitEtcdPodResult.
 	etcdDefragWaitPodDeadline = 2 * time.Minute
 )
 
@@ -151,15 +149,14 @@ func (r *Reconciler) defragEtcd(ctx context.Context, state *controlplanev1alpha1
 	return StepResult{Outcome: OutcomeCompleted, Message: "skipped: fragmentation below threshold"}, nil
 }
 
-// waitEtcdPodResult returns a Pending result while the deadline has not elapsed, and an
-// Abandoned result once the etcd pod has been unavailable for longer than
-// etcdDefragWaitPodDeadline. Abandoning releases the global etcd operation slot so it can
-// never be held indefinitely by a defrag on a node without a running etcd pod.
+// waitEtcdPodResult abandons the operation once it has run past etcdDefragWaitPodDeadline,
+// releasing the global etcd slot; otherwise it keeps retrying. Shared by DefragEtcd and
+// WaitPodReady (see waitForPodResult in pods.go).
 func waitEtcdPodResult(op *controlplanev1alpha1.ControlPlaneOperation, podName, reason string) StepResult {
 	if operationElapsed(op, time.Now()) > etcdDefragWaitPodDeadline {
 		return StepResult{
 			Outcome: OutcomeAbandoned,
-			Message: fmt.Sprintf("etcd pod %s %s after %s; skipping periodic defragmentation", podName, reason, etcdDefragWaitPodDeadline),
+			Message: fmt.Sprintf("etcd pod %s %s after %s; abandoning periodic defrag operation", podName, reason, etcdDefragWaitPodDeadline),
 		}
 	}
 	return StepResult{
@@ -169,9 +166,12 @@ func waitEtcdPodResult(op *controlplanev1alpha1.ControlPlaneOperation, podName, 
 	}
 }
 
-// operationElapsed reports how long ago the operation started executing, based on the
-// operation-started-at annotation set by the reconciler. Returns 0 if the annotation is
-// missing or unparseable, which keeps the step in its retry loop rather than abandoning early.
+// isEtcdDefragOperation reports whether op is a periodic etcd-defrag CPO (see buildDefragCPO).
+func isEtcdDefragOperation(op *controlplanev1alpha1.ControlPlaneOperation) bool {
+	return slices.Contains(op.Spec.Steps, controlplanev1alpha1.StepDefragEtcd)
+}
+
+// operationElapsed returns time since op's started-at annotation, or 0 if unset/unparseable.
 func operationElapsed(op *controlplanev1alpha1.ControlPlaneOperation, now time.Time) time.Duration {
 	started := op.Annotations[constants.OperationStartedAtAnnotationKey]
 	if started == "" {

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/defrag.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/defrag.go
@@ -166,16 +166,3 @@ func waitEtcdPodResult(op *controlplanev1alpha1.ControlPlaneOperation, podName, 
 		RequeueAfter: requeueWaitPod,
 	}
 }
-
-// operationElapsed returns time since op's started-at annotation, or 0 if unset/unparseable.
-func operationElapsed(op *controlplanev1alpha1.ControlPlaneOperation, now time.Time) time.Duration {
-	started := op.Annotations[constants.OperationStartedAtAnnotationKey]
-	if started == "" {
-		return 0
-	}
-	startedAt, err := time.Parse(time.RFC3339Nano, started)
-	if err != nil {
-		return 0
-	}
-	return now.Sub(startedAt)
-}

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/defrag.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/defrag.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"log/slog"
 	"path/filepath"
-	"slices"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -150,8 +149,10 @@ func (r *Reconciler) defragEtcd(ctx context.Context, state *controlplanev1alpha1
 }
 
 // waitEtcdPodResult abandons the operation once it has run past etcdDefragWaitPodDeadline,
-// releasing the global etcd slot; otherwise it keeps retrying. Shared by DefragEtcd and
-// WaitPodReady (see waitForPodResult in pods.go).
+// releasing the global etcd slot; otherwise it keeps retrying. Only guards DefragEtcd's wait
+// for the pod to appear before defrag even starts — WaitPodReady still waits indefinitely
+// afterwards, since giving up there could free the slot for another node's defrag while this
+// node's etcd is still down, risking a quorum loss.
 func waitEtcdPodResult(op *controlplanev1alpha1.ControlPlaneOperation, podName, reason string) StepResult {
 	if operationElapsed(op, time.Now()) > etcdDefragWaitPodDeadline {
 		return StepResult{
@@ -164,11 +165,6 @@ func waitEtcdPodResult(op *controlplanev1alpha1.ControlPlaneOperation, podName, 
 		Message:      "waiting for etcd pod to be ready before defragmentation",
 		RequeueAfter: requeueWaitPod,
 	}
-}
-
-// isEtcdDefragOperation reports whether op is a periodic etcd-defrag CPO (see buildDefragCPO).
-func isEtcdDefragOperation(op *controlplanev1alpha1.ControlPlaneOperation) bool {
-	return slices.Contains(op.Spec.Steps, controlplanev1alpha1.StepDefragEtcd)
 }
 
 // operationElapsed returns time since op's started-at annotation, or 0 if unset/unparseable.

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/defrag.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/defrag.go
@@ -41,9 +41,8 @@ const (
 	etcdDefragTimeout       = 2 * time.Minute
 	etcdDefragStatusTimeout = 10 * time.Second
 
-	// etcdDefragWaitPodDeadline bounds how long a defrag CPO waits for the local etcd pod
-	// before abandoning: waiting forever would hold the single global etcd slot and deadlock
-	// etcd join on other nodes. See waitEtcdPodResult.
+	// etcdDefragWaitPodDeadline bounds how long DefragEtcd waits for the local pod before
+	// abandoning, instead of holding the global etcd slot forever. See waitEtcdPodResult.
 	etcdDefragWaitPodDeadline = 10 * time.Minute
 )
 
@@ -148,11 +147,9 @@ func (r *Reconciler) defragEtcd(ctx context.Context, state *controlplanev1alpha1
 	return StepResult{Outcome: OutcomeCompleted, Message: "skipped: fragmentation below threshold"}, nil
 }
 
-// waitEtcdPodResult abandons the operation once it has run past etcdDefragWaitPodDeadline,
-// releasing the global etcd slot; otherwise it keeps retrying. Only guards DefragEtcd's wait
-// for the pod to appear before defrag even starts — WaitPodReady still waits indefinitely
-// afterwards, since giving up there could free the slot for another node's defrag while this
-// node's etcd is still down, risking a quorum loss.
+// waitEtcdPodResult abandons the operation past etcdDefragWaitPodDeadline, releasing the
+// global etcd slot; otherwise it keeps retrying. Only guards DefragEtcd's wait for the pod to
+// appear before defrag starts — WaitPodReady still waits indefinitely afterwards (see pods.go).
 func waitEtcdPodResult(op *controlplanev1alpha1.ControlPlaneOperation, podName, reason string) StepResult {
 	if operationElapsed(op, time.Now()) > etcdDefragWaitPodDeadline {
 		return StepResult{

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/defrag_test.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/defrag_test.go
@@ -81,10 +81,8 @@ func TestDefragEtcd_WaitPodDeadline(t *testing.T) {
 		require.NotEmpty(t, res.Message)
 	})
 
-	// WaitPodReady runs right after DefragEtcd in the same defrag CPO (see buildDefragCPO), and
-	// must keep waiting indefinitely even well past etcdDefragWaitPodDeadline: abandoning it
-	// would free the global etcd slot for another node's defrag while this node's etcd is still
-	// down, risking a quorum loss.
+	// Unlike DefragEtcd, WaitPodReady must keep waiting indefinitely even past the deadline
+	// (see pods.go) — a quorum-safety decision, not an oversight.
 	t.Run("WaitPodReady: keeps waiting past the DefragEtcd deadline", func(t *testing.T) {
 		t.Parallel()
 		r := newReconciler() // no etcd pod in cluster

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/defrag_test.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/defrag_test.go
@@ -91,4 +91,56 @@ func TestDefragEtcd_WaitPodDeadline(t *testing.T) {
 		require.Equal(t, OutcomeAbandoned, res.Outcome)
 		require.NotEmpty(t, res.Message)
 	})
+
+	// WaitPodReady runs right after DefragEtcd in the same defrag CPO (see buildDefragCPO).
+	// If the pod flips unready or disappears between the two steps, WaitPodReady must apply the
+	// same deadline instead of holding the global etcd slot forever.
+	t.Run("WaitPodReady: pending while within deadline and pod absent", func(t *testing.T) {
+		t.Parallel()
+		r := newReconciler() // no etcd pod in cluster
+		state := newEtcdDefragState(10 * time.Second)
+
+		res, err := r.waitForPod(context.Background(), state, log.NewNop())
+		require.NoError(t, err)
+		require.Equal(t, OutcomePending, res.Outcome)
+		require.Equal(t, requeueWaitPod, res.RequeueAfter)
+	})
+
+	t.Run("WaitPodReady: abandoned after deadline when pod stays absent", func(t *testing.T) {
+		t.Parallel()
+		r := newReconciler() // no etcd pod in cluster
+		state := newEtcdDefragState(etcdDefragWaitPodDeadline + time.Minute)
+
+		res, err := r.waitForPod(context.Background(), state, log.NewNop())
+		require.NoError(t, err)
+		require.Equal(t, OutcomeAbandoned, res.Outcome)
+		require.NotEmpty(t, res.Message)
+	})
+
+	// Non-defrag etcd CPOs (e.g. join, cert renewal) must keep waiting indefinitely: unlike
+	// defrag they don't self-retry on a schedule, so giving up on WaitPodReady would silently
+	// drop the operation instead of surfacing a stuck node to the operator.
+	t.Run("WaitPodReady: non-defrag operation keeps waiting past the defrag deadline", func(t *testing.T) {
+		t.Parallel()
+		r := newReconciler() // no pod in cluster
+		op := &controlplanev1alpha1.ControlPlaneOperation{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "kube-apiserver-renew",
+				Annotations: map[string]string{
+					constants.OperationStartedAtAnnotationKey: time.Now().Add(-(etcdDefragWaitPodDeadline + time.Minute)).UTC().Format(time.RFC3339Nano),
+				},
+			},
+			Spec: controlplanev1alpha1.ControlPlaneOperationSpec{
+				NodeName:  testNodeName,
+				Component: controlplanev1alpha1.OperationComponentKubeAPIServer,
+				Steps:     []controlplanev1alpha1.StepName{controlplanev1alpha1.StepWaitPodReady},
+			},
+		}
+		state := controlplanev1alpha1.NewOperationState(op)
+
+		res, err := r.waitForPod(context.Background(), state, log.NewNop())
+		require.NoError(t, err)
+		require.Equal(t, OutcomePending, res.Outcome)
+		require.Equal(t, requeueWaitPod, res.RequeueAfter)
+	})
 }

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/defrag_test.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/defrag_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/deckhouse/deckhouse/pkg/log"
 
@@ -36,17 +35,7 @@ func TestDefragEtcd_WaitPodDeadline(t *testing.T) {
 	t.Parallel()
 
 	newReconciler := func(objs ...client.Object) *Reconciler {
-		c := fake.NewClientBuilder().
-			WithScheme(scheme).
-			WithObjects(objs...).
-			WithStatusSubresource(&controlplanev1alpha1.ControlPlaneOperation{}).
-			Build()
-		return &Reconciler{
-			client: c,
-			log:    log.NewNop(),
-			node:   NodeIdentity{Name: testNodeName},
-			steps:  defaultSteps(),
-		}
+		return newTestReconciler(nil, objs...)
 	}
 
 	// newEtcdDefragState returns a defrag operation state whose start time is startedAgo in the past.

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/defrag_test.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/defrag_test.go
@@ -92,51 +92,14 @@ func TestDefragEtcd_WaitPodDeadline(t *testing.T) {
 		require.NotEmpty(t, res.Message)
 	})
 
-	// WaitPodReady runs right after DefragEtcd in the same defrag CPO (see buildDefragCPO).
-	// If the pod flips unready or disappears between the two steps, WaitPodReady must apply the
-	// same deadline instead of holding the global etcd slot forever.
-	t.Run("WaitPodReady: pending while within deadline and pod absent", func(t *testing.T) {
-		t.Parallel()
-		r := newReconciler() // no etcd pod in cluster
-		state := newEtcdDefragState(10 * time.Second)
-
-		res, err := r.waitForPod(context.Background(), state, log.NewNop())
-		require.NoError(t, err)
-		require.Equal(t, OutcomePending, res.Outcome)
-		require.Equal(t, requeueWaitPod, res.RequeueAfter)
-	})
-
-	t.Run("WaitPodReady: abandoned after deadline when pod stays absent", func(t *testing.T) {
+	// WaitPodReady runs right after DefragEtcd in the same defrag CPO (see buildDefragCPO), and
+	// must keep waiting indefinitely even well past etcdDefragWaitPodDeadline: abandoning it
+	// would free the global etcd slot for another node's defrag while this node's etcd is still
+	// down, risking a quorum loss.
+	t.Run("WaitPodReady: keeps waiting past the DefragEtcd deadline", func(t *testing.T) {
 		t.Parallel()
 		r := newReconciler() // no etcd pod in cluster
 		state := newEtcdDefragState(etcdDefragWaitPodDeadline + time.Minute)
-
-		res, err := r.waitForPod(context.Background(), state, log.NewNop())
-		require.NoError(t, err)
-		require.Equal(t, OutcomeAbandoned, res.Outcome)
-		require.NotEmpty(t, res.Message)
-	})
-
-	// Non-defrag etcd CPOs (e.g. join, cert renewal) must keep waiting indefinitely: unlike
-	// defrag they don't self-retry on a schedule, so giving up on WaitPodReady would silently
-	// drop the operation instead of surfacing a stuck node to the operator.
-	t.Run("WaitPodReady: non-defrag operation keeps waiting past the defrag deadline", func(t *testing.T) {
-		t.Parallel()
-		r := newReconciler() // no pod in cluster
-		op := &controlplanev1alpha1.ControlPlaneOperation{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "kube-apiserver-renew",
-				Annotations: map[string]string{
-					constants.OperationStartedAtAnnotationKey: time.Now().Add(-(etcdDefragWaitPodDeadline + time.Minute)).UTC().Format(time.RFC3339Nano),
-				},
-			},
-			Spec: controlplanev1alpha1.ControlPlaneOperationSpec{
-				NodeName:  testNodeName,
-				Component: controlplanev1alpha1.OperationComponentKubeAPIServer,
-				Steps:     []controlplanev1alpha1.StepName{controlplanev1alpha1.StepWaitPodReady},
-			},
-		}
-		state := controlplanev1alpha1.NewOperationState(op)
 
 		res, err := r.waitForPod(context.Background(), state, log.NewNop())
 		require.NoError(t, err)

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/defrag_test.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/defrag_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controlplaneoperation
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/deckhouse/deckhouse/pkg/log"
+
+	controlplanev1alpha1 "control-plane-manager/api/v1alpha1"
+	"control-plane-manager/internal/constants"
+)
+
+func TestDefragEtcd_WaitPodDeadline(t *testing.T) {
+	t.Parallel()
+
+	newReconciler := func(objs ...client.Object) *Reconciler {
+		c := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(objs...).
+			WithStatusSubresource(&controlplanev1alpha1.ControlPlaneOperation{}).
+			Build()
+		return &Reconciler{
+			client: c,
+			log:    log.NewNop(),
+			node:   NodeIdentity{Name: testNodeName},
+			steps:  defaultSteps(),
+		}
+	}
+
+	// newEtcdDefragState returns a defrag operation state whose start time is startedAgo in the past.
+	newEtcdDefragState := func(startedAgo time.Duration) *controlplanev1alpha1.OperationState {
+		op := &controlplanev1alpha1.ControlPlaneOperation{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "etcd-defrag",
+				Annotations: map[string]string{
+					constants.OperationStartedAtAnnotationKey: time.Now().Add(-startedAgo).UTC().Format(time.RFC3339Nano),
+				},
+			},
+			Spec: controlplanev1alpha1.ControlPlaneOperationSpec{
+				NodeName:  testNodeName,
+				Component: controlplanev1alpha1.OperationComponentEtcd,
+				Steps: []controlplanev1alpha1.StepName{
+					controlplanev1alpha1.StepDefragEtcd,
+					controlplanev1alpha1.StepWaitPodReady,
+				},
+			},
+		}
+		return controlplanev1alpha1.NewOperationState(op)
+	}
+
+	t.Run("pending while within deadline and etcd pod absent", func(t *testing.T) {
+		t.Parallel()
+		r := newReconciler() // no etcd pod in cluster
+		state := newEtcdDefragState(10 * time.Second)
+
+		res, err := r.defragEtcd(context.Background(), state, log.NewNop())
+		require.NoError(t, err)
+		require.Equal(t, OutcomePending, res.Outcome)
+		require.Equal(t, requeueWaitPod, res.RequeueAfter)
+	})
+
+	t.Run("abandoned after deadline when etcd pod stays absent", func(t *testing.T) {
+		t.Parallel()
+		r := newReconciler() // no etcd pod in cluster
+		state := newEtcdDefragState(etcdDefragWaitPodDeadline + time.Minute)
+
+		res, err := r.defragEtcd(context.Background(), state, log.NewNop())
+		require.NoError(t, err)
+		require.Equal(t, OutcomeAbandoned, res.Outcome)
+		require.NotEmpty(t, res.Message)
+	})
+}

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/metrics.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/metrics.go
@@ -92,12 +92,7 @@ func isOperationInProgressTooLong(op *controlplanev1alpha1.ControlPlaneOperation
 		return false
 	}
 
-	startedAt, ok := operationStartedAt(op)
-	if !ok {
-		return false
-	}
-
-	return now.Sub(startedAt) > operationInProgressTooLongThreshold
+	return operationElapsed(op, now) > operationInProgressTooLongThreshold
 }
 
 func operationStartedAt(op *controlplanev1alpha1.ControlPlaneOperation) (time.Time, bool) {

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/metrics.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/metrics.go
@@ -118,6 +118,15 @@ func operationStartedAt(op *controlplanev1alpha1.ControlPlaneOperation) (time.Ti
 	return startedAt, true
 }
 
+// operationElapsed returns time since op's started-at annotation, or 0 if unset/unparseable.
+func operationElapsed(op *controlplanev1alpha1.ControlPlaneOperation, now time.Time) time.Duration {
+	startedAt, ok := operationStartedAt(op)
+	if !ok {
+		return 0
+	}
+	return now.Sub(startedAt)
+}
+
 func (m *metrics) deleteOperationExecutionMetrics(operation string) {
 	if m == nil || operation == "" {
 		return

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/pipeline.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/pipeline.go
@@ -74,6 +74,11 @@ func (r *Reconciler) reconcilePipeline(ctx context.Context, state *controlplanev
 			}
 			return result, err
 		}
+		// A step may drive the whole operation to a terminal state (e.g. Abandoned).
+		// executeStep already persisted it; stop the pipeline without completing.
+		if state.IsTerminal() {
+			return result, nil
+		}
 		if result.RequeueAfter > 0 {
 			return result, nil
 		}
@@ -107,6 +112,12 @@ func (r *Reconciler) executeStep(ctx context.Context, state *controlplanev1alpha
 				stepLogger.Warn("failed to flush status on requeue", log.Err(patchErr))
 			}
 			result = reconcile.Result{RequeueAfter: res.RequeueAfter}
+		case res.Outcome == OutcomeAbandoned:
+			state.MarkOperationAbandoned(res.Message)
+			if patchErr := r.patchStatus(ctx, state); patchErr != nil {
+				stepLogger.Warn("failed to flush status on abandon", log.Err(patchErr))
+			}
+			result = reconcile.Result{}
 		default:
 			state.MarkStepCompletedWithMessage(name, res.Message)
 			if patchErr := r.patchStatus(ctx, state); patchErr != nil {

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/pipeline.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/pipeline.go
@@ -109,6 +109,9 @@ func (r *Reconciler) executeStep(ctx context.Context, state *controlplanev1alpha
 			}
 			result = reconcile.Result{RequeueAfter: res.RequeueAfter}
 		case res.Outcome == OutcomeAbandoned:
+			// Unlike the Pending/Completed cases, there's no separate step-condition call here:
+			// MarkOperationAbandoned marks both the current in-progress step (CPOReasonStepAbandoned)
+			// and the operation itself (CPOReasonOperationAbandoned) in one call.
 			state.MarkOperationAbandoned(res.Message)
 			if patchErr := r.patchStatus(ctx, state); patchErr != nil {
 				// Unlike Pending, Abandoned carries no RequeueAfter to fall back on, so a

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/pipeline.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/pipeline.go
@@ -74,9 +74,8 @@ func (r *Reconciler) reconcilePipeline(ctx context.Context, state *controlplanev
 			}
 			return result, err
 		}
-		// A step may drive the whole operation to a terminal state (e.g. Abandoned) or ask to
-		// requeue; executeStep already persisted either, so just stop the pipeline here.
-		if state.IsTerminal() || result.RequeueAfter > 0 {
+
+		if state.IsAbandoned() || result.RequeueAfter > 0 {
 			return result, nil
 		}
 	}

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/pipeline.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/pipeline.go
@@ -74,12 +74,9 @@ func (r *Reconciler) reconcilePipeline(ctx context.Context, state *controlplanev
 			}
 			return result, err
 		}
-		// A step may drive the whole operation to a terminal state (e.g. Abandoned).
-		// executeStep already persisted it; stop the pipeline without completing.
-		if state.IsTerminal() {
-			return result, nil
-		}
-		if result.RequeueAfter > 0 {
+		// A step may drive the whole operation to a terminal state (e.g. Abandoned) or ask to
+		// requeue; executeStep already persisted either, so just stop the pipeline here.
+		if state.IsTerminal() || result.RequeueAfter > 0 {
 			return result, nil
 		}
 	}
@@ -115,9 +112,12 @@ func (r *Reconciler) executeStep(ctx context.Context, state *controlplanev1alpha
 		case res.Outcome == OutcomeAbandoned:
 			state.MarkOperationAbandoned(res.Message)
 			if patchErr := r.patchStatus(ctx, state); patchErr != nil {
-				stepLogger.Warn("failed to flush status on abandon", log.Err(patchErr))
+				// Unlike Pending, Abandoned carries no RequeueAfter to fall back on, so a
+				// swallowed patch error here would leave the operation stuck non-terminal on
+				// the server forever, still holding its approval slot. Propagate the error so
+				// the pipeline treats it like the default case below and retries via backoff.
+				err = fmt.Errorf("persist operation abandon for %s: %w", name, patchErr)
 			}
-			result = reconcile.Result{}
 		default:
 			state.MarkStepCompletedWithMessage(name, res.Message)
 			if patchErr := r.patchStatus(ctx, state); patchErr != nil {

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/pipeline.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/pipeline.go
@@ -109,15 +109,11 @@ func (r *Reconciler) executeStep(ctx context.Context, state *controlplanev1alpha
 			}
 			result = reconcile.Result{RequeueAfter: res.RequeueAfter}
 		case res.Outcome == OutcomeAbandoned:
-			// Unlike the Pending/Completed cases, there's no separate step-condition call here:
-			// MarkOperationAbandoned marks both the current in-progress step (CPOReasonStepAbandoned)
-			// and the operation itself (CPOReasonOperationAbandoned) in one call.
+			// An Abandoned step outcome abandons the whole operation.
 			state.MarkOperationAbandoned(res.Message)
 			if patchErr := r.patchStatus(ctx, state); patchErr != nil {
-				// Unlike Pending, Abandoned carries no RequeueAfter to fall back on, so a
-				// swallowed patch error here would leave the operation stuck non-terminal on
-				// the server forever, still holding its approval slot. Propagate the error so
-				// the pipeline treats it like the default case below and retries via backoff.
+				// No RequeueAfter to fall back on, so a swallowed error here would strand the
+				// operation non-terminal, holding its slot forever. Propagate it instead.
 				err = fmt.Errorf("persist operation abandon for %s: %w", name, patchErr)
 			}
 		default:

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/pods.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/pods.go
@@ -33,10 +33,9 @@ import (
 )
 
 // waitForPod checks if the static pod is ready with the expected checksums annotations.
-// Waits indefinitely for every component: giving up here would free this node's approval slot
-// for another node's operation while this node's pod is still unhealthy. For etcd that slot is
-// a single global one, so proceeding to a second member's maintenance before the first is
-// confirmed healthy again risks losing quorum.
+// Waits indefinitely for every component: giving up would free this node's approval slot for
+// another node while this pod is still unhealthy — for etcd, whose slot is global, that risks
+// losing quorum.
 func (r *Reconciler) waitForPod(ctx context.Context, state *controlplanev1alpha1.OperationState, logger *log.Logger) (StepResult, error) {
 	op := state.Raw()
 	podName := fmt.Sprintf("%s-%s", op.Spec.Component.PodComponentName(), r.node.Name)

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/pods.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/pods.go
@@ -39,34 +39,35 @@ func (r *Reconciler) waitForPod(ctx context.Context, state *controlplanev1alpha1
 	pod := &corev1.Pod{}
 	if err := r.client.Get(ctx, client.ObjectKey{Name: podName, Namespace: constants.KubeSystemNamespace}, pod); err != nil {
 		logger.Info("pod not found yet, requeue", slog.String("pod", podName))
-		return StepResult{
-			Outcome:      OutcomePending,
-			Message:      waitPodInitialMessage(op),
-			RequeueAfter: requeueWaitPod,
-		}, nil
+		return waitForPodResult(op, podName, "not present", waitPodInitialMessage(op)), nil
 	}
 
 	if isPodCrashLooping(pod) {
 		logger.Warn("pod is crash looping, will retry", slog.String("pod", podName))
-		return StepResult{
-			Outcome:      OutcomePending,
-			Message:      fmt.Sprintf("pod %s is in CrashLoopBackOff, will retry", podName),
-			RequeueAfter: requeueWaitPod,
-		}, nil
+		return waitForPodResult(op, podName, "crash looping", fmt.Sprintf("pod %s is in CrashLoopBackOff, will retry", podName)), nil
 	}
 
 	expected := checksumAnnotationsFromSpec(op.Spec)
 	if !isPodReadyWithChecksums(pod, expected) {
 		logger.Info("pod not ready with expected checksums, requeue", slog.String("pod", podName))
-		return StepResult{
-			Outcome:      OutcomePending,
-			Message:      fmt.Sprintf("pod %s is not ready with expected checksums, will retry", podName),
-			RequeueAfter: requeueWaitPod,
-		}, nil
+		return waitForPodResult(op, podName, "not ready", fmt.Sprintf("pod %s is not ready with expected checksums, will retry", podName)), nil
 	}
 
 	logger.Info("pod ready with matching checksums", slog.String("pod", podName))
 	return StepResult{Outcome: OutcomeCompleted}, nil
+}
+
+// waitForPodResult returns Pending with pendingMessage, except for etcd-defrag CPOs, which
+// apply the same abandon-after-deadline rule as DefragEtcd — see waitEtcdPodResult.
+func waitForPodResult(op *controlplanev1alpha1.ControlPlaneOperation, podName, reason, pendingMessage string) StepResult {
+	if isEtcdDefragOperation(op) {
+		return waitEtcdPodResult(op, podName, reason)
+	}
+	return StepResult{
+		Outcome:      OutcomePending,
+		Message:      pendingMessage,
+		RequeueAfter: requeueWaitPod,
+	}
 }
 
 // mapPodToOperations finds in-progress CPOs for the component matching this pod.

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/pods.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/pods.go
@@ -33,41 +33,42 @@ import (
 )
 
 // waitForPod checks if the static pod is ready with the expected checksums annotations.
+// Waits indefinitely: giving up here would let the approver hand the etcd slot to another
+// node's operation while this node's etcd is still down, risking a quorum loss.
 func (r *Reconciler) waitForPod(ctx context.Context, state *controlplanev1alpha1.OperationState, logger *log.Logger) (StepResult, error) {
 	op := state.Raw()
 	podName := fmt.Sprintf("%s-%s", op.Spec.Component.PodComponentName(), r.node.Name)
 	pod := &corev1.Pod{}
 	if err := r.client.Get(ctx, client.ObjectKey{Name: podName, Namespace: constants.KubeSystemNamespace}, pod); err != nil {
 		logger.Info("pod not found yet, requeue", slog.String("pod", podName))
-		return waitForPodResult(op, podName, "not present", waitPodInitialMessage(op)), nil
+		return StepResult{
+			Outcome:      OutcomePending,
+			Message:      waitPodInitialMessage(op),
+			RequeueAfter: requeueWaitPod,
+		}, nil
 	}
 
 	if isPodCrashLooping(pod) {
 		logger.Warn("pod is crash looping, will retry", slog.String("pod", podName))
-		return waitForPodResult(op, podName, "crash looping", fmt.Sprintf("pod %s is in CrashLoopBackOff, will retry", podName)), nil
+		return StepResult{
+			Outcome:      OutcomePending,
+			Message:      fmt.Sprintf("pod %s is in CrashLoopBackOff, will retry", podName),
+			RequeueAfter: requeueWaitPod,
+		}, nil
 	}
 
 	expected := checksumAnnotationsFromSpec(op.Spec)
 	if !isPodReadyWithChecksums(pod, expected) {
 		logger.Info("pod not ready with expected checksums, requeue", slog.String("pod", podName))
-		return waitForPodResult(op, podName, "not ready", fmt.Sprintf("pod %s is not ready with expected checksums, will retry", podName)), nil
+		return StepResult{
+			Outcome:      OutcomePending,
+			Message:      fmt.Sprintf("pod %s is not ready with expected checksums, will retry", podName),
+			RequeueAfter: requeueWaitPod,
+		}, nil
 	}
 
 	logger.Info("pod ready with matching checksums", slog.String("pod", podName))
 	return StepResult{Outcome: OutcomeCompleted}, nil
-}
-
-// waitForPodResult returns Pending with pendingMessage, except for etcd-defrag CPOs, which
-// apply the same abandon-after-deadline rule as DefragEtcd — see waitEtcdPodResult.
-func waitForPodResult(op *controlplanev1alpha1.ControlPlaneOperation, podName, reason, pendingMessage string) StepResult {
-	if isEtcdDefragOperation(op) {
-		return waitEtcdPodResult(op, podName, reason)
-	}
-	return StepResult{
-		Outcome:      OutcomePending,
-		Message:      pendingMessage,
-		RequeueAfter: requeueWaitPod,
-	}
 }
 
 // mapPodToOperations finds in-progress CPOs for the component matching this pod.

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/pods.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/pods.go
@@ -33,8 +33,10 @@ import (
 )
 
 // waitForPod checks if the static pod is ready with the expected checksums annotations.
-// Waits indefinitely: giving up here would let the approver hand the etcd slot to another
-// node's operation while this node's etcd is still down, risking a quorum loss.
+// Waits indefinitely for every component: giving up here would free this node's approval slot
+// for another node's operation while this node's pod is still unhealthy. For etcd that slot is
+// a single global one, so proceeding to a second member's maintenance before the first is
+// confirmed healthy again risks losing quorum.
 func (r *Reconciler) waitForPod(ctx context.Context, state *controlplanev1alpha1.OperationState, logger *log.Logger) (StepResult, error) {
 	op := state.Raw()
 	podName := fmt.Sprintf("%s-%s", op.Spec.Component.PodComponentName(), r.node.Name)

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/steps.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/steps.go
@@ -56,6 +56,10 @@ const (
 	OutcomeCompleted StepOutcome = iota
 	// OutcomePending: the step is not finished; pipeline RequeueAfter and preserves the in-progress condition with the given Message.
 	OutcomePending
+	// OutcomeAbandoned: the step decided the whole operation is no longer applicable
+	// (e.g. periodic maintenance whose precondition can't be met). The pipeline marks the
+	// operation Abandoned (a terminal state) and stops, releasing any approval slot it held.
+	OutcomeAbandoned
 )
 
 type StepResult struct {

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/steps.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/steps.go
@@ -56,7 +56,7 @@ const (
 	OutcomeCompleted StepOutcome = iota
 	// OutcomePending: the step is not finished; pipeline RequeueAfter and preserves the in-progress condition with the given Message.
 	OutcomePending
-	// OutcomeAbandoned: the operation is no longer applicable; pipeline marks it terminal and stops.
+	// OutcomeAbandoned: the step decided the operation can't continue; pipeline marks it terminal and stops.
 	OutcomeAbandoned
 )
 

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/steps.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/steps.go
@@ -56,9 +56,7 @@ const (
 	OutcomeCompleted StepOutcome = iota
 	// OutcomePending: the step is not finished; pipeline RequeueAfter and preserves the in-progress condition with the given Message.
 	OutcomePending
-	// OutcomeAbandoned: the step decided the whole operation is no longer applicable
-	// (e.g. periodic maintenance whose precondition can't be met). The pipeline marks the
-	// operation Abandoned (a terminal state) and stops, releasing any approval slot it held.
+	// OutcomeAbandoned: the operation is no longer applicable; pipeline marks it terminal and stops.
 	OutcomeAbandoned
 )
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fixes a deadlock in the periodic etcd defragmentation feature (`DefragEtcd` CPO step).

A defrag `ControlPlaneOperation` could be created for a node whose etcd pod wasn't up yet (e.g. a freshly added node). Its first step, `DefragEtcd`, waited for that pod indefinitely before running, and since etcd operations share a single global approval slot, this permanently blocked etcd operations on every other node, including new nodes joining the cluster.

The fix adds two layers:
- the spawning hook now skips nodes without a Ready etcd pod;
- as a safety net, `DefragEtcd` now abandons the operation (releasing the slot) if the pod doesn't become ready within 10 minutes, instead of waiting forever.


## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Without this fix, a single node without a running etcd pod can stall etcd maintenance and join operations cluster-wide, requiring manual intervention. This closes that deadlock.


## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
Not necessarily

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: fix
summary: Fixed a deadlock where a periodic etcd defragmentation operation could hold the etcd operation slot forever.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
