### PR TITLE
[cluster-autoscaler] Bump libraries in cluster-autoscaler to fix CVEs

### DIFF
--- a/modules/040-node-manager/images/cluster-autoscaler/patches/1.32/001-go-mod.patch
+++ b/modules/040-node-manager/images/cluster-autoscaler/patches/1.32/001-go-mod.patch
@@ -1,46 +1,57 @@
 diff --git a/cluster-autoscaler/apis/go.mod b/cluster-autoscaler/apis/go.mod
-index 3ac7f47..cc9a967 100644
+index f71006248..cb1b0e555 100644
 --- a/cluster-autoscaler/apis/go.mod
 +++ b/cluster-autoscaler/apis/go.mod
-@@ -7,7 +7,6 @@ toolchain go1.23.2
+@@ -1,13 +1,11 @@
+ module k8s.io/autoscaler/cluster-autoscaler/apis
+ 
+-go 1.23.0
+-
+-toolchain go1.23.2
++go 1.25.0
+ 
  require (
  	github.com/onsi/ginkgo/v2 v2.21.0
  	github.com/onsi/gomega v1.35.1
--	k8s.io/api v0.32.0
- 	k8s.io/apimachinery v0.32.3
+-	k8s.io/apimachinery v0.32.0
++	k8s.io/apimachinery v0.32.3
  	k8s.io/client-go v0.32.0
  	k8s.io/code-generator v0.32.0
-@@ -40,18 +39,19 @@ require (
+ 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2
+@@ -38,15 +36,15 @@ require (
+ 	github.com/pkg/errors v0.9.1 // indirect
  	github.com/spf13/pflag v1.0.5 // indirect
  	github.com/x448/float16 v0.8.4 // indirect
- 	golang.org/x/mod v0.21.0 // indirect
+-	golang.org/x/mod v0.21.0 // indirect
 -	golang.org/x/net v0.30.0 // indirect
 -	golang.org/x/oauth2 v0.23.0 // indirect
 -	golang.org/x/sync v0.8.0 // indirect
 -	golang.org/x/sys v0.26.0 // indirect
 -	golang.org/x/term v0.25.0 // indirect
 -	golang.org/x/text v0.19.0 // indirect
-+	golang.org/x/net v0.38.0 // indirect
++	golang.org/x/mod v0.35.0 // indirect
++	golang.org/x/net v0.55.0 // indirect
 +	golang.org/x/oauth2 v0.27.0 // indirect
-+	golang.org/x/sync v0.12.0 // indirect
-+	golang.org/x/sys v0.31.0 // indirect
-+	golang.org/x/term v0.30.0 // indirect
-+	golang.org/x/text v0.23.0 // indirect
++	golang.org/x/sync v0.20.0 // indirect
++	golang.org/x/sys v0.45.0 // indirect
++	golang.org/x/term v0.43.0 // indirect
++	golang.org/x/text v0.37.0 // indirect
  	golang.org/x/time v0.7.0 // indirect
- 	golang.org/x/tools v0.26.0 // indirect
+-	golang.org/x/tools v0.26.0 // indirect
++	golang.org/x/tools v0.44.0 // indirect
  	google.golang.org/protobuf v1.35.1 // indirect
  	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
  	gopkg.in/inf.v0 v0.9.1 // indirect
- 	gopkg.in/yaml.v3 v3.0.1 // indirect
-+	k8s.io/api v0.32.0 // indirect
- 	k8s.io/gengo/v2 v2.0.0-20240911193312-2b36238f13e9 // indirect
- 	k8s.io/klog/v2 v2.130.1 // indirect
- 	k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f // indirect
 diff --git a/cluster-autoscaler/apis/go.sum b/cluster-autoscaler/apis/go.sum
-index 701a0e9..71711bb 100644
+index ce35bb5f8..52bc872ed 100644
 --- a/cluster-autoscaler/apis/go.sum
 +++ b/cluster-autoscaler/apis/go.sum
-@@ -94,26 +94,26 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
+@@ -90,30 +90,37 @@ golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+ golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+ golang.org/x/mod v0.21.0 h1:vvrHzRwRfVKSiLrG+d4FMl/Qi4ukBCE6kZlTUkDYRT0=
+ golang.org/x/mod v0.21.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
++golang.org/x/mod v0.35.0/go.mod h1:+GwiRhIInF8wPm+4AoT6L0FA1QWAad3OMdTRx4tFYlU=
+ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
  golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
  golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
  golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
@@ -50,6 +61,8 @@ index 701a0e9..71711bb 100644
 -golang.org/x/oauth2 v0.23.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
 +golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
 +golang.org/x/net v0.38.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
++golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
++golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
 +golang.org/x/oauth2 v0.27.0 h1:da9Vo7/tDv5RH/7nZDz1eMGS/q1Vv1N/7FCrBhI9I3M=
 +golang.org/x/oauth2 v0.27.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT8=
  golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -59,6 +72,7 @@ index 701a0e9..71711bb 100644
 -golang.org/x/sync v0.8.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 +golang.org/x/sync v0.12.0 h1:MHc5BpPuC30uJk597Ri8TV3CNZcTLu6B6z4lJy+g6Jw=
 +golang.org/x/sync v0.12.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
++golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
  golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
  golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
  golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -68,22 +82,50 @@ index 701a0e9..71711bb 100644
 -golang.org/x/term v0.25.0/go.mod h1:RPyXicDX+6vLxogjjRxjgD2TKtmAO6NZBsBRfrOLu7M=
 +golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
 +golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
++golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 +golang.org/x/term v0.30.0 h1:PQ39fJZ+mfadBm0y5WlL4vlM7Sx1Hgf13sMIY2+QS9Y=
 +golang.org/x/term v0.30.0/go.mod h1:NYYFdzHoI5wRh/h5tDMdMqCqPJZEuNqVR5xJLd/n67g=
++golang.org/x/term v0.43.0/go.mod h1:lrhlHNdQJHO+1qVYiHfFKVuVioJIheAc3fBSMFYEIsk=
  golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
  golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 -golang.org/x/text v0.19.0 h1:kTxAhCbGbxhK0IwgSKiMO5awPoDQ0RpfiVYBfK860YM=
 -golang.org/x/text v0.19.0/go.mod h1:BuEKDfySbSR4drPmRPG/7iBdf8hvFMuRexcpahXilzY=
 +golang.org/x/text v0.23.0 h1:D71I7dUrlY+VX0gQShAThNGHFxZ13dGLBHQLVl1mJlY=
 +golang.org/x/text v0.23.0/go.mod h1:/BLNzu4aZCJ1+kcD0DNRotWKage4q2rGVAg4o22unh4=
++golang.org/x/text v0.37.0/go.mod h1:a5sjxXGs9hsn/AJVwuElvCAo9v8QYLzvavO5z2PiM38=
  golang.org/x/time v0.7.0 h1:ntUhktv3OPE6TgYxXWv9vKvUSJyIFJlyohwbkEwPrKQ=
  golang.org/x/time v0.7.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
  golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+@@ -122,6 +129,7 @@ golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roY
+ golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+ golang.org/x/tools v0.26.0 h1:v/60pFQmzmT9ExmjDv2gGIfi3OqfKoEP6I5+umXlbnQ=
+ golang.org/x/tools v0.26.0/go.mod h1:TPVVj70c7JJ3WCazhD8OdXcZg/og+b9+tH/KxylGwH0=
++golang.org/x/tools v0.44.0/go.mod h1:KA0AfVErSdxRZIsOVipbv3rQhVXTnlU6UhKxHd1seDI=
+ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+ golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+@@ -142,6 +150,7 @@ k8s.io/api v0.32.0 h1:OL9JpbvAU5ny9ga2fb24X8H6xQlVp+aJMFlgtQjR9CE=
+ k8s.io/api v0.32.0/go.mod h1:4LEwHZEf6Q/cG96F3dqR965sYOfmPM7rq81BLgsE0p0=
+ k8s.io/apimachinery v0.32.0 h1:cFSE7N3rmEEtv4ei5X6DaJPHHX0C+upp+v5lVPiEwpg=
+ k8s.io/apimachinery v0.32.0/go.mod h1:GpHVgxoKlTxClKcteaeuF1Ul/lDVb74KpZcxcmLDElE=
++k8s.io/apimachinery v0.32.3/go.mod h1:GpHVgxoKlTxClKcteaeuF1Ul/lDVb74KpZcxcmLDElE=
+ k8s.io/client-go v0.32.0 h1:DimtMcnN/JIKZcrSrstiwvvZvLjG0aSxy8PxN8IChp8=
+ k8s.io/client-go v0.32.0/go.mod h1:boDWvdM1Drk4NJj/VddSLnx59X3OPgwrOo0vGbtq9+8=
+ k8s.io/code-generator v0.32.0 h1:s0lNN8VSWny8LBz5t5iy7MCdgwdOhdg7vAGVxvS+VWU=
 diff --git a/cluster-autoscaler/go.mod b/cluster-autoscaler/go.mod
-index ee33cde..1aedce7 100644
+index 503a69270..b6d03a1ef 100644
 --- a/cluster-autoscaler/go.mod
 +++ b/cluster-autoscaler/go.mod
-@@ -9,7 +9,7 @@ require (
+@@ -1,15 +1,13 @@
+ module k8s.io/autoscaler/cluster-autoscaler
+ 
+-go 1.23.0
+-
+-toolchain go1.23.2
++go 1.25.0
+ 
+ require (
+ 	cloud.google.com/go/compute/metadata v0.3.0
  	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible
  	github.com/Azure/azure-sdk-for-go-extensions v0.1.6
  	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.1
@@ -92,35 +134,47 @@ index ee33cde..1aedce7 100644
  	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v4 v4.9.0-beta.1
  	github.com/Azure/go-autorest/autorest v0.11.29
  	github.com/Azure/go-autorest/autorest/adal v0.9.24
-@@ -47,20 +47,20 @@ require (
- 	google.golang.org/protobuf v1.36.1
+@@ -34,28 +32,28 @@ require (
+ 	github.com/stretchr/testify v1.9.0
+ 	github.com/vburenin/ifacemaker v1.2.1
+ 	go.uber.org/mock v0.4.0
+-	golang.org/x/net v0.30.0
+-	golang.org/x/oauth2 v0.23.0
+-	golang.org/x/sys v0.26.0
++	golang.org/x/net v0.55.0
++	golang.org/x/oauth2 v0.27.0
++	golang.org/x/sys v0.45.0
+ 	google.golang.org/api v0.151.0
+ 	google.golang.org/grpc v1.65.0
+ 	google.golang.org/protobuf v1.35.1
  	gopkg.in/gcfg.v1 v1.2.3
  	gopkg.in/yaml.v2 v2.4.0
 -	k8s.io/api v0.32.0
-+	k8s.io/api v0.32.2
- 	k8s.io/apimachinery v0.32.3
+-	k8s.io/apimachinery v0.32.0
 -	k8s.io/apiserver v0.32.0
-+	k8s.io/apiserver v0.32.2
++	k8s.io/api v0.32.10
++	k8s.io/apimachinery v0.32.10
++	k8s.io/apiserver v0.32.10
  	k8s.io/autoscaler/cluster-autoscaler/apis v0.0.0-20240627115740-d52e4b9665d7
 -	k8s.io/client-go v0.32.0
-+	k8s.io/client-go v0.32.2
++	k8s.io/client-go v0.32.10
  	k8s.io/cloud-provider v0.30.1
  	k8s.io/cloud-provider-aws v1.27.0
  	k8s.io/cloud-provider-gcp/providers v0.28.2
 -	k8s.io/component-base v0.32.0
 -	k8s.io/component-helpers v0.32.0
-+	k8s.io/component-base v0.32.2
-+	k8s.io/component-helpers v0.32.2
++	k8s.io/component-base v0.32.10
++	k8s.io/component-helpers v0.32.10
  	k8s.io/dynamic-resource-allocation v0.0.0
  	k8s.io/klog/v2 v2.130.1
 -	k8s.io/kubelet v0.32.0
 -	k8s.io/kubernetes v1.32.0
-+	k8s.io/kubelet v0.32.2
-+	k8s.io/kubernetes v1.32.6
++	k8s.io/kubelet v0.32.10
++	k8s.io/kubernetes v1.32.10
  	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738
  	sigs.k8s.io/cloud-provider-azure v1.29.4
  	sigs.k8s.io/cloud-provider-azure/pkg/azclient v0.0.13
-@@ -69,7 +69,7 @@ require (
+@@ -64,7 +62,7 @@ require (
  
  require (
  	cel.dev/expr v0.18.0 // indirect
@@ -129,7 +183,7 @@ index ee33cde..1aedce7 100644
  	github.com/Azure/azure-sdk-for-go/sdk/keyvault/azsecrets v0.12.0 // indirect
  	github.com/Azure/azure-sdk-for-go/sdk/keyvault/internal v0.7.1 // indirect
  	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5 v5.6.0 // indirect
-@@ -90,7 +90,7 @@ require (
+@@ -85,7 +83,7 @@ require (
  	github.com/GoogleCloudPlatform/k8s-cloud-provider v1.25.0 // indirect
  	github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab // indirect
  	github.com/Microsoft/go-winio v0.6.2 // indirect
@@ -138,7 +192,7 @@ index ee33cde..1aedce7 100644
  	github.com/NYTimes/gziphandler v1.1.1 // indirect
  	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
  	github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2 // indirect
-@@ -105,7 +105,7 @@ require (
+@@ -100,7 +98,7 @@ require (
  	github.com/containerd/ttrpc v1.2.5 // indirect
  	github.com/coreos/go-semver v0.3.1 // indirect
  	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
@@ -147,18 +201,20 @@ index ee33cde..1aedce7 100644
  	github.com/dave/jennifer v1.6.0 // indirect
  	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
  	github.com/dimchansky/utfbom v1.1.1 // indirect
-@@ -125,7 +125,7 @@ require (
+@@ -121,8 +119,8 @@ require (
  	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
  	github.com/godbus/dbus/v5 v5.1.0 // indirect
  	github.com/gogo/protobuf v1.3.2 // indirect
 -	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
+-	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
 +	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
- 	github.com/golang-jwt/jwt/v5 v5.2.2 // indirect
++	github.com/golang-jwt/jwt/v5 v5.2.2 // indirect
  	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
  	github.com/golang/protobuf v1.5.4 // indirect
-@@ -159,9 +159,9 @@ require (
- 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
- 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
+ 	github.com/google/btree v1.0.1 // indirect
+@@ -157,9 +155,9 @@ require (
+ 	github.com/onsi/ginkgo/v2 v2.21.0 // indirect
+ 	github.com/onsi/gomega v1.35.1 // indirect
  	github.com/opencontainers/go-digest v1.0.0 // indirect
 -	github.com/opencontainers/runc v1.2.1 // indirect
 +	github.com/opencontainers/runc v1.2.8 // indirect
@@ -168,7 +224,7 @@ index ee33cde..1aedce7 100644
  	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
  	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
  	github.com/prometheus/client_model v0.6.1 // indirect
-@@ -176,7 +176,7 @@ require (
+@@ -174,7 +172,7 @@ require (
  	go.etcd.io/etcd/client/pkg/v3 v3.5.16 // indirect
  	go.etcd.io/etcd/client/v3 v3.5.16 // indirect
  	go.opencensus.io v0.24.0 // indirect
@@ -177,120 +233,146 @@ index ee33cde..1aedce7 100644
  	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.53.0 // indirect
  	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.53.0 // indirect
  	go.opentelemetry.io/otel v1.28.0 // indirect
-@@ -204,13 +204,13 @@ require (
+@@ -186,14 +184,15 @@ require (
+ 	go.opentelemetry.io/proto/otlp v1.3.1 // indirect
+ 	go.uber.org/multierr v1.11.0 // indirect
+ 	go.uber.org/zap v1.27.0 // indirect
+-	golang.org/x/crypto v0.28.0 // indirect
++	golang.org/x/crypto v0.52.0 // indirect
+ 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
+-	golang.org/x/mod v0.21.0 // indirect
+-	golang.org/x/sync v0.8.0 // indirect
+-	golang.org/x/term v0.25.0 // indirect
+-	golang.org/x/text v0.19.0 // indirect
++	golang.org/x/mod v0.35.0 // indirect
++	golang.org/x/sync v0.20.0 // indirect
++	golang.org/x/term v0.43.0 // indirect
++	golang.org/x/text v0.37.0 // indirect
+ 	golang.org/x/time v0.7.0 // indirect
+-	golang.org/x/tools v0.26.0 // indirect
++	golang.org/x/tools v0.44.0 // indirect
++	golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated // indirect
+ 	google.golang.org/genproto/googleapis/api v0.0.0-20240826202546-f6391c0de4c7 // indirect
+ 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240826202546-f6391c0de4c7 // indirect
+ 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
+@@ -202,13 +201,13 @@ require (
  	gopkg.in/warnings.v0 v0.1.2 // indirect
  	gopkg.in/yaml.v3 v3.0.1 // indirect
- 	k8s.io/apiextensions-apiserver v0.31.0 // indirect
+ 	k8s.io/apiextensions-apiserver v0.0.0 // indirect
 -	k8s.io/code-generator v0.32.0 // indirect
 -	k8s.io/controller-manager v0.32.0 // indirect
 -	k8s.io/cri-api v0.32.0 // indirect
-+	k8s.io/code-generator v0.32.2 // indirect
-+	k8s.io/controller-manager v0.32.2 // indirect
-+	k8s.io/cri-api v0.32.2 // indirect
++	k8s.io/code-generator v0.32.10 // indirect
++	k8s.io/controller-manager v0.32.10 // indirect
++	k8s.io/cri-api v0.32.10 // indirect
  	k8s.io/cri-client v0.0.0 // indirect
  	k8s.io/csi-translation-lib v0.27.0 // indirect
  	k8s.io/gengo/v2 v2.0.0-20240911193312-2b36238f13e9 // indirect
 -	k8s.io/kms v0.32.0 // indirect
-+	k8s.io/kms v0.32.2 // indirect
++	k8s.io/kms v0.32.10 // indirect
  	k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f // indirect
  	k8s.io/kube-scheduler v0.0.0 // indirect
  	k8s.io/kubectl v0.28.0 // indirect
-@@ -227,66 +227,66 @@ replace github.com/digitalocean/godo => github.com/digitalocean/godo v1.27.0
+@@ -225,66 +224,66 @@ replace github.com/digitalocean/godo => github.com/digitalocean/godo v1.27.0
  
  replace github.com/rancher/go-rancher => github.com/rancher/go-rancher v0.1.0
  
 -replace k8s.io/api => k8s.io/api v0.32.0
-+replace k8s.io/api => k8s.io/api v0.32.2
++replace k8s.io/api => k8s.io/api v0.32.10
  
 -replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.32.0
-+replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.32.2
++replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.32.10
  
- replace k8s.io/apimachinery => k8s.io/apimachinery v0.32.3
+-replace k8s.io/apimachinery => k8s.io/apimachinery v0.32.0
++replace k8s.io/apimachinery => k8s.io/apimachinery v0.32.10
  
 -replace k8s.io/apiserver => k8s.io/apiserver v0.32.0
-+replace k8s.io/apiserver => k8s.io/apiserver v0.32.2
++replace k8s.io/apiserver => k8s.io/apiserver v0.32.10
  
 -replace k8s.io/cli-runtime => k8s.io/cli-runtime v0.32.0
-+replace k8s.io/cli-runtime => k8s.io/cli-runtime v0.32.2
++replace k8s.io/cli-runtime => k8s.io/cli-runtime v0.32.10
  
 -replace k8s.io/client-go => k8s.io/client-go v0.32.0
-+replace k8s.io/client-go => k8s.io/client-go v0.32.2
++replace k8s.io/client-go => k8s.io/client-go v0.32.10
  
 -replace k8s.io/cloud-provider => k8s.io/cloud-provider v0.32.0
-+replace k8s.io/cloud-provider => k8s.io/cloud-provider v0.32.2
++replace k8s.io/cloud-provider => k8s.io/cloud-provider v0.32.10
  
 -replace k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.32.0
-+replace k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.32.2
++replace k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.32.10
  
 -replace k8s.io/code-generator => k8s.io/code-generator v0.32.0
-+replace k8s.io/code-generator => k8s.io/code-generator v0.32.2
++replace k8s.io/code-generator => k8s.io/code-generator v0.32.10
  
 -replace k8s.io/component-base => k8s.io/component-base v0.32.0
-+replace k8s.io/component-base => k8s.io/component-base v0.32.2
++replace k8s.io/component-base => k8s.io/component-base v0.32.10
  
 -replace k8s.io/component-helpers => k8s.io/component-helpers v0.32.0
-+replace k8s.io/component-helpers => k8s.io/component-helpers v0.32.2
++replace k8s.io/component-helpers => k8s.io/component-helpers v0.32.10
  
 -replace k8s.io/controller-manager => k8s.io/controller-manager v0.32.0
-+replace k8s.io/controller-manager => k8s.io/controller-manager v0.32.2
++replace k8s.io/controller-manager => k8s.io/controller-manager v0.32.10
  
- replace k8s.io/cri-api => k8s.io/cri-api v0.32.3
+-replace k8s.io/cri-api => k8s.io/cri-api v0.32.0
++replace k8s.io/cri-api => k8s.io/cri-api v0.32.10
  
 -replace k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.32.0
-+replace k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.32.2
++replace k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.32.10
  
 -replace k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.32.0
-+replace k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.32.2
++replace k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.32.10
  
 -replace k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.32.0
-+replace k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.32.2
++replace k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.32.10
  
 -replace k8s.io/kube-proxy => k8s.io/kube-proxy v0.32.0
-+replace k8s.io/kube-proxy => k8s.io/kube-proxy v0.32.2
++replace k8s.io/kube-proxy => k8s.io/kube-proxy v0.32.10
  
 -replace k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.32.0
-+replace k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.32.2
++replace k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.32.10
  
 -replace k8s.io/kubectl => k8s.io/kubectl v0.32.0
-+replace k8s.io/kubectl => k8s.io/kubectl v0.32.2
++replace k8s.io/kubectl => k8s.io/kubectl v0.32.10
  
 -replace k8s.io/kubelet => k8s.io/kubelet v0.32.0
-+replace k8s.io/kubelet => k8s.io/kubelet v0.32.2
++replace k8s.io/kubelet => k8s.io/kubelet v0.32.10
  
 -replace k8s.io/metrics => k8s.io/metrics v0.32.0
-+replace k8s.io/metrics => k8s.io/metrics v0.32.2
++replace k8s.io/metrics => k8s.io/metrics v0.32.10
  
- replace k8s.io/mount-utils => k8s.io/mount-utils v0.32.3
+-replace k8s.io/mount-utils => k8s.io/mount-utils v0.32.0
++replace k8s.io/mount-utils => k8s.io/mount-utils v0.32.10
  
 -replace k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.32.0
-+replace k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.32.2
++replace k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.32.10
  
 -replace k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.32.0
-+replace k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.32.2
++replace k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.32.10
  
 -replace k8s.io/sample-controller => k8s.io/sample-controller v0.32.0
-+replace k8s.io/sample-controller => k8s.io/sample-controller v0.32.2
++replace k8s.io/sample-controller => k8s.io/sample-controller v0.32.10
  
 -replace k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.32.0
-+replace k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.32.2
++replace k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.32.10
  
 -replace k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.32.0
-+replace k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.32.2
++replace k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.32.10
  
 -replace k8s.io/kms => k8s.io/kms v0.32.0
-+replace k8s.io/kms => k8s.io/kms v0.32.2
++replace k8s.io/kms => k8s.io/kms v0.32.10
  
 -replace k8s.io/endpointslice => k8s.io/endpointslice v0.32.0
-+replace k8s.io/endpointslice => k8s.io/endpointslice v0.32.2
++replace k8s.io/endpointslice => k8s.io/endpointslice v0.32.10
  
  replace k8s.io/autoscaler/cluster-autoscaler/apis => ./apis
  
 -replace k8s.io/cri-client => k8s.io/cri-client v0.32.0
-+replace k8s.io/cri-client => k8s.io/cri-client v0.32.2
++replace k8s.io/cri-client => k8s.io/cri-client v0.32.10
  
- replace k8s.io/externaljwt => k8s.io/externaljwt v0.32.3
+-replace k8s.io/externaljwt => k8s.io/externaljwt v0.32.0
++replace k8s.io/externaljwt => k8s.io/externaljwt v0.32.10
 diff --git a/cluster-autoscaler/go.sum b/cluster-autoscaler/go.sum
-index 990e503..beb8106 100644
+index 9b0cd1165..128e97da5 100644
 --- a/cluster-autoscaler/go.sum
 +++ b/cluster-autoscaler/go.sum
 @@ -11,10 +11,10 @@ github.com/Azure/azure-sdk-for-go-extensions v0.1.6 h1:EXGvDcj54u98XfaI/Cy65Ds6v
@@ -330,18 +412,22 @@ index 990e503..beb8106 100644
  github.com/dave/jennifer v1.6.0 h1:MQ/6emI2xM7wt0tJzJzyUik2Q3Tcn2eE0vtYgh4GPVI=
  github.com/dave/jennifer v1.6.0/go.mod h1:AxTG893FiZKqxy3FP1kL80VMshSMuz2G+EgvszgGRnk=
  github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-@@ -200,8 +200,9 @@ github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
+@@ -194,10 +194,11 @@ github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
  github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
  github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
  github.com/golang-jwt/jwt/v4 v4.2.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 -github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
  github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+-github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
+-github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 +github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
 +github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
- github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
- github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
++github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
++github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
  github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
-@@ -332,12 +333,12 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
+ github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
+ github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
+@@ -326,12 +327,12 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
  github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
  github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQb2IpWsCzug=
  github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
@@ -358,7 +444,7 @@ index 990e503..beb8106 100644
  github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
  github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
  github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-@@ -410,14 +411,14 @@ go.etcd.io/etcd/server/v3 v3.5.16 h1:d0/SAdJ3vVsZvF8IFVb1k8zqMZ+heGcNfft71ul9GWE
+@@ -404,14 +405,14 @@ go.etcd.io/etcd/server/v3 v3.5.16 h1:d0/SAdJ3vVsZvF8IFVb1k8zqMZ+heGcNfft71ul9GWE
  go.etcd.io/etcd/server/v3 v3.5.16/go.mod h1:ynhyZZpdDp1Gq49jkUg5mfkDWZwXnn3eIqCqtJnrD/s=
  go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
  go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
@@ -377,7 +463,104 @@ index 990e503..beb8106 100644
  go.opentelemetry.io/otel v1.28.0 h1:/SqNcYk+idO0CxKEUOtKQClMK/MimZihKYMruSMViUo=
  go.opentelemetry.io/otel v1.28.0/go.mod h1:q68ijF8Fc8CnMHKyzqL6akLO46ePnjkgfIMIjUIX9z4=
  go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.28.0 h1:3Q/xZUyC1BBkualc9ROb4G8qkH90LXEIICcs5zv1OYY=
-@@ -603,54 +604,54 @@ gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+@@ -442,8 +443,8 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
+ golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+ golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58=
+ golang.org/x/crypto v0.17.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
+-golang.org/x/crypto v0.28.0 h1:GBDwsMXVQi34v5CCYUm2jkJvu4cbtru2U4TN2PSyQnw=
+-golang.org/x/crypto v0.28.0/go.mod h1:rmgy+3RHxRZMyY0jjAJShp2zgEdOqj2AO7U0pYmeQ7U=
++golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
++golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
+ golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+ golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 h1:2dVuKD2vS7b0QIHQbpyTISPd0LeHDbnYEryqj5Q1ug8=
+ golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56/go.mod h1:M4RDyNAINzryxdtnbRXRL/OHtkFuWGRjvuhBJpk2IlY=
+@@ -455,8 +456,8 @@ golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+ golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+ golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
+ golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
+-golang.org/x/mod v0.21.0 h1:vvrHzRwRfVKSiLrG+d4FMl/Qi4ukBCE6kZlTUkDYRT0=
+-golang.org/x/mod v0.21.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
++golang.org/x/mod v0.35.0 h1:Ww1D637e6Pg+Zb2KrWfHQUnH2dQRLBQyAtpr/haaJeM=
++golang.org/x/mod v0.35.0/go.mod h1:+GwiRhIInF8wPm+4AoT6L0FA1QWAad3OMdTRx4tFYlU=
+ golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+ golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+ golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+@@ -474,12 +475,12 @@ golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug
+ golang.org/x/net v0.1.0/go.mod h1:Cx3nUiGt4eDBEyega/BKRp+/AlGL8hYe7U9odMt2Cco=
+ golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
+ golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
+-golang.org/x/net v0.30.0 h1:AcW1SDZMkb8IpzCdQUaIq2sP4sZ4zw+55h6ynffypl4=
+-golang.org/x/net v0.30.0/go.mod h1:2wGyMJ5iFasEhkwi13ChkO/t1ECNC4X4eBKkVFyYFlU=
++golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
++golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
+ golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
+ golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+-golang.org/x/oauth2 v0.23.0 h1:PbgcYx2W7i4LvjJWEbf0ngHV6qJYr86PkAV3bXdLEbs=
+-golang.org/x/oauth2 v0.23.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
++golang.org/x/oauth2 v0.27.0 h1:da9Vo7/tDv5RH/7nZDz1eMGS/q1Vv1N/7FCrBhI9I3M=
++golang.org/x/oauth2 v0.27.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT8=
+ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+@@ -489,8 +490,8 @@ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJ
+ golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+-golang.org/x/sync v0.8.0 h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=
+-golang.org/x/sync v0.8.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
++golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
++golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+ golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+@@ -507,16 +508,16 @@ golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+-golang.org/x/sys v0.26.0 h1:KHjCJyddX0LoSTb3J+vWpupP9p0oznkqVk/IfjymZbo=
+-golang.org/x/sys v0.26.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
++golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
++golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+ golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+ golang.org/x/term v0.1.0/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+ golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=
+ golang.org/x/term v0.8.0/go.mod h1:xPskH00ivmX89bAKVGSKKtLOWNx2+17Eiy94tnKShWo=
+ golang.org/x/term v0.15.0/go.mod h1:BDl952bC7+uMoWR75FIrCDx79TPU9oHkTZ9yRbYOrX0=
+-golang.org/x/term v0.25.0 h1:WtHI/ltw4NvSUig5KARz9h521QvRC8RmF/cuYqifU24=
+-golang.org/x/term v0.25.0/go.mod h1:RPyXicDX+6vLxogjjRxjgD2TKtmAO6NZBsBRfrOLu7M=
++golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=
++golang.org/x/term v0.43.0/go.mod h1:lrhlHNdQJHO+1qVYiHfFKVuVioJIheAc3fBSMFYEIsk=
+ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+ golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+ golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+@@ -525,8 +526,8 @@ golang.org/x/text v0.4.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
+ golang.org/x/text v0.7.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
+ golang.org/x/text v0.9.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=
+ golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
+-golang.org/x/text v0.19.0 h1:kTxAhCbGbxhK0IwgSKiMO5awPoDQ0RpfiVYBfK860YM=
+-golang.org/x/text v0.19.0/go.mod h1:BuEKDfySbSR4drPmRPG/7iBdf8hvFMuRexcpahXilzY=
++golang.org/x/text v0.37.0 h1:Cqjiwd9eSg8e0QAkyCaQTNHFIIzWtidPahFWR83rTrc=
++golang.org/x/text v0.37.0/go.mod h1:a5sjxXGs9hsn/AJVwuElvCAo9v8QYLzvavO5z2PiM38=
+ golang.org/x/time v0.7.0 h1:ntUhktv3OPE6TgYxXWv9vKvUSJyIFJlyohwbkEwPrKQ=
+ golang.org/x/time v0.7.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
+ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+@@ -540,8 +541,12 @@ golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4f
+ golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+ golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
+ golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
+-golang.org/x/tools v0.26.0 h1:v/60pFQmzmT9ExmjDv2gGIfi3OqfKoEP6I5+umXlbnQ=
+-golang.org/x/tools v0.26.0/go.mod h1:TPVVj70c7JJ3WCazhD8OdXcZg/og+b9+tH/KxylGwH0=
++golang.org/x/tools v0.44.0 h1:UP4ajHPIcuMjT1GqzDWRlalUEoY+uzoZKnhOjbIPD2c=
++golang.org/x/tools v0.44.0/go.mod h1:KA0AfVErSdxRZIsOVipbv3rQhVXTnlU6UhKxHd1seDI=
++golang.org/x/tools/go/expect v0.1.0-deprecated h1:jY2C5HGYR5lqex3gEniOQL0r7Dq5+VGVgY1nudX5lXY=
++golang.org/x/tools/go/expect v0.1.0-deprecated/go.mod h1:eihoPOH+FgIqa3FpoTwguz/bVUSGBlGQU67vpBeOrBY=
++golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated h1:1h2MnaIAIXISqTFKdENegdpAgUXz6NrPEsbIeWaBRvM=
++golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated/go.mod h1:RVAQXBGNv1ib0J382/DPCRS/BPnsGebyM1Gj5VSDpG8=
+ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+ golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+@@ -600,56 +605,56 @@ gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
  gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
  honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
  honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
@@ -385,24 +568,26 @@ index 990e503..beb8106 100644
 -k8s.io/api v0.32.0/go.mod h1:4LEwHZEf6Q/cG96F3dqR965sYOfmPM7rq81BLgsE0p0=
 -k8s.io/apiextensions-apiserver v0.32.0 h1:S0Xlqt51qzzqjKPxfgX1xh4HBZE+p8KKBq+k2SWNOE0=
 -k8s.io/apiextensions-apiserver v0.32.0/go.mod h1:86hblMvN5yxMvZrZFX2OhIHAuFIMJIZ19bTvzkP+Fmw=
-+k8s.io/api v0.32.2 h1:bZrMLEkgizC24G9eViHGOPbW+aRo9duEISRIJKfdJuw=
-+k8s.io/api v0.32.2/go.mod h1:hKlhk4x1sJyYnHENsrdCWw31FEmCijNGPJO5WzHiJ6Y=
-+k8s.io/apiextensions-apiserver v0.32.2 h1:2YMk285jWMk2188V2AERy5yDwBYrjgWYggscghPCvV4=
-+k8s.io/apiextensions-apiserver v0.32.2/go.mod h1:GPwf8sph7YlJT3H6aKUWtd0E+oyShk/YHWQHf/OOgCA=
- k8s.io/apimachinery v0.32.3 h1:JmDuDarhDmA/Li7j3aPrwhpNBA94Nvk5zLeOge9HH1U=
- k8s.io/apimachinery v0.32.3/go.mod h1:GpHVgxoKlTxClKcteaeuF1Ul/lDVb74KpZcxcmLDElE=
+-k8s.io/apimachinery v0.32.0 h1:cFSE7N3rmEEtv4ei5X6DaJPHHX0C+upp+v5lVPiEwpg=
+-k8s.io/apimachinery v0.32.0/go.mod h1:GpHVgxoKlTxClKcteaeuF1Ul/lDVb74KpZcxcmLDElE=
 -k8s.io/apiserver v0.32.0 h1:VJ89ZvQZ8p1sLeiWdRJpRD6oLozNZD2+qVSLi+ft5Qs=
 -k8s.io/apiserver v0.32.0/go.mod h1:HFh+dM1/BE/Hm4bS4nTXHVfN6Z6tFIZPi649n83b4Ag=
 -k8s.io/client-go v0.32.0 h1:DimtMcnN/JIKZcrSrstiwvvZvLjG0aSxy8PxN8IChp8=
 -k8s.io/client-go v0.32.0/go.mod h1:boDWvdM1Drk4NJj/VddSLnx59X3OPgwrOo0vGbtq9+8=
 -k8s.io/cloud-provider v0.32.0 h1:QXYJGmwME2q2rprymbmw2GroMChQYc/MWN6l/I4Kgp8=
 -k8s.io/cloud-provider v0.32.0/go.mod h1:cz3gVodkhgwi2ugj/JUPglIruLSdDaThxawuDyCHfr8=
-+k8s.io/apiserver v0.32.2 h1:WzyxAu4mvLkQxwD9hGa4ZfExo3yZZaYzoYvvVDlM6vw=
-+k8s.io/apiserver v0.32.2/go.mod h1:PEwREHiHNU2oFdte7BjzA1ZyjWjuckORLIK/wLV5goM=
-+k8s.io/client-go v0.32.2 h1:4dYCD4Nz+9RApM2b/3BtVvBHw54QjMFUl1OLcJG5yOA=
-+k8s.io/client-go v0.32.2/go.mod h1:fpZ4oJXclZ3r2nDOv+Ux3XcJutfrwjKTCHz2H3sww94=
-+k8s.io/cloud-provider v0.32.2 h1:8EC+fCYo0r0REczSjOZcVuQPCMxXxCKlgxDbYMrzC30=
-+k8s.io/cloud-provider v0.32.2/go.mod h1:2s8TeAXhVezp5VISaTxM6vW3yDonOZXoN4Aryz1p1PQ=
++k8s.io/api v0.32.10 h1:ocp4turNfa1V40TuBW/LuA17TeXG9g/GI2ebg0KxBNk=
++k8s.io/api v0.32.10/go.mod h1:AsMsc4b6TuampYqgMEGSv0HBFpRS4BlKTXAVCAa7oF4=
++k8s.io/apiextensions-apiserver v0.32.10 h1:mAZT8fX/jM9pl7qWkFhhsjQZ8ZkmAhEivfUNw8uKXmo=
++k8s.io/apiextensions-apiserver v0.32.10/go.mod h1:wEvqU9kFUQOYminqrroY6+fvSs6iMb7QiiFmcN3b6KY=
++k8s.io/apimachinery v0.32.10 h1:SAg2kUPLYRcBJQj66oniP1BnXSqw+l1GvJFsJlBmVvQ=
++k8s.io/apimachinery v0.32.10/go.mod h1:GpHVgxoKlTxClKcteaeuF1Ul/lDVb74KpZcxcmLDElE=
++k8s.io/apiserver v0.32.10 h1:nRUv9Q/OFHVjl/50TgNDlzw37wjTI0j+Ywp0gWqvQfs=
++k8s.io/apiserver v0.32.10/go.mod h1:BV9Wgt44Rop5I0cYsh2NYQstHu16ou4uirh95yTbioc=
++k8s.io/client-go v0.32.10 h1:MFmIjsKtcnn7mStjrJG1ZW2WzLsKKn6ZtL9hHM/W0xU=
++k8s.io/client-go v0.32.10/go.mod h1:qJy/Ws3zSwnu/nD75D+/of1uxbwWHxrYT5P3FuobVLI=
++k8s.io/cloud-provider v0.32.10 h1:S6OFOKlKYTM4PxdOFoihrXbbNuT5D1Q5pLtpfRN/LhM=
++k8s.io/cloud-provider v0.32.10/go.mod h1:+yQAZWtdYbLk72vjtaZpN9wtn4UBUoOZc7JddFcjIec=
  k8s.io/cloud-provider-aws v1.27.0 h1:PF8YrH8QcN6JoXB3Xxlaz84SBDYMPunJuCc0cPuCWXA=
  k8s.io/cloud-provider-aws v1.27.0/go.mod h1:9vUb5mnVnReSRDBWcBxB1b0HOeEc472iOPmrnwpN9SA=
  k8s.io/cloud-provider-gcp/providers v0.28.2 h1:I65pFTLNMQSj7YuW3Mg3pZIXmw0naCmF6TGAuz4/sZE=
@@ -415,36 +600,38 @@ index 990e503..beb8106 100644
 -k8s.io/component-helpers v0.32.0/go.mod h1:9RuClQatbClcokXOcDWSzFKQm1huIf0FzQlPRpizlMc=
 -k8s.io/controller-manager v0.32.0 h1:tpQl1rvH4huFB6Avl1nhowZHtZoCNWqn6OYdZPl7Ybc=
 -k8s.io/controller-manager v0.32.0/go.mod h1:JRuYnYCkKj3NgBTy+KNQKIUm/lJRoDAvGbfdEmk9LhY=
-+k8s.io/code-generator v0.32.2 h1:CIvyPrLWP7cMgrqval2qYT839YAwCDeSvGfXgWSNpHQ=
-+k8s.io/code-generator v0.32.2/go.mod h1:plh7bWk7JztAUkHM4zpbdy0KOMdrhsePcZL2HLWFH7Y=
-+k8s.io/component-base v0.32.2 h1:1aUL5Vdmu7qNo4ZsE+569PV5zFatM9hl+lb3dEea2zU=
-+k8s.io/component-base v0.32.2/go.mod h1:PXJ61Vx9Lg+P5mS8TLd7bCIr+eMJRQTyXe8KvkrvJq0=
-+k8s.io/component-helpers v0.32.2 h1:2usSAm3zNE5yu5DdAdrKBWLfSYNpU4OPjZywJY5ovP8=
-+k8s.io/component-helpers v0.32.2/go.mod h1:fvQAoiiOP7jUEUBc9qR0PXiBPuB0I56WTxTkkpcI8g8=
-+k8s.io/controller-manager v0.32.2 h1:/9XuHWEqofO2Aqa4l7KJGckJUcLVRWfx+qnVkdXoStI=
-+k8s.io/controller-manager v0.32.2/go.mod h1:o5uo2tLCQhuoMt0RfKcQd0eqaNmSKOKiT+0YELCqXOk=
- k8s.io/cri-api v0.32.3 h1:E8VXbXNn4yAgmuKTeNzg0C1MFSxzTdlHSwUvjuYlPTY=
- k8s.io/cri-api v0.32.3/go.mod h1:DCzMuTh2padoinefWME0G678Mc3QFbLMF2vEweGzBAI=
+-k8s.io/cri-api v0.32.0 h1:pzXJfyG7Tm4acrEt5HPqAq3r4cN5guLeapAN/NM2b70=
+-k8s.io/cri-api v0.32.0/go.mod h1:DCzMuTh2padoinefWME0G678Mc3QFbLMF2vEweGzBAI=
 -k8s.io/cri-client v0.32.0 h1:K6aTYDyS2AS8O4h79eI5r26562xstdybprtaaszjn+E=
 -k8s.io/cri-client v0.32.0/go.mod h1:FB8qZNj8KrwIFfVIR2zBGb+l6KUhrp+k8YFsVp3D+kw=
 -k8s.io/csi-translation-lib v0.32.0 h1:RAn9RGgYXHJQtDSb6qQ7zvq6QObOejzmsXDARI+f4OQ=
 -k8s.io/csi-translation-lib v0.32.0/go.mod h1:TjCJzkTNstdOESAXNnEImrYOMIEzP14aqM7H+vkehqw=
 -k8s.io/dynamic-resource-allocation v0.32.0 h1:0ZLSCKzlLZLVwKHxg6vafpd2U8b7jPMO3k8bbMFodis=
 -k8s.io/dynamic-resource-allocation v0.32.0/go.mod h1:MfoAUi0vCJtchNirAVk7c3IYfGGB3n+zbZ9GuyX4eeo=
-+k8s.io/cri-client v0.32.2 h1:vjowJUyu14IbmifqCKJHE9rK/BPSfkXvltqN42W1Zuo=
-+k8s.io/cri-client v0.32.2/go.mod h1:fRZhmmZW16Qviln8hfy+e8dd2wP/n9B6TiGxLE3zBe0=
-+k8s.io/csi-translation-lib v0.32.2 h1:aLzAyaoJUc5rgtLi8Xd4No1tet6UpvUsGIgRoGnPSSE=
-+k8s.io/csi-translation-lib v0.32.2/go.mod h1:PlOKan6Vc0G6a+giQbm36plJ+E1LH+GPRLAVMQMSMcY=
-+k8s.io/dynamic-resource-allocation v0.32.2 h1:6wP8/GGvhhvTJLrzwPSoMJDnspmosFj1CKmfrAH6m5U=
-+k8s.io/dynamic-resource-allocation v0.32.2/go.mod h1:+3qnQfvikLHVZrdZ0/gYkRiV96weUR9j7+Ph3Ui/hYU=
++k8s.io/code-generator v0.32.10 h1:H8MF03Ad6isbGI6tnotITdaBEwxQjVFdpC6AxhoYuaI=
++k8s.io/code-generator v0.32.10/go.mod h1:fmTm8F2FNPlr+IUvZ17U1wOTY3/soDIc++m4g+lC1PQ=
++k8s.io/component-base v0.32.10 h1:9+8Pw0fasOWPNHeQKmf38TFI7Zdi1k38sOIm0jQdSV4=
++k8s.io/component-base v0.32.10/go.mod h1:Tou3W1f6+8i5svBQ0Sef3jpkSZ0k6q2QdXbQSn4c9do=
++k8s.io/component-helpers v0.32.10 h1:hMdA0wF5GkUAqjtY/d4y5WJK1OqvdAA0xREL1OceXS0=
++k8s.io/component-helpers v0.32.10/go.mod h1:bSxQeNzLYUrll2RFtkVTXKFnjVrgb5OWSIgW4rECOus=
++k8s.io/controller-manager v0.32.10 h1:B2rGlwJfCBYSf1AXf9FQkrvS98Fqg0RZh0gud30mkZY=
++k8s.io/controller-manager v0.32.10/go.mod h1:Jl6E8fwRfg0sSY/Schef/9UKdIlxRmnyaa3ZUaVeay4=
++k8s.io/cri-api v0.32.10 h1:xdFaVDpNupzgTIRiK4onsHZqpc8exxLl1jia4p8IakQ=
++k8s.io/cri-api v0.32.10/go.mod h1:DCzMuTh2padoinefWME0G678Mc3QFbLMF2vEweGzBAI=
++k8s.io/cri-client v0.32.10 h1:N+nlAkzATstdp+mUQwtX3qqFUa7Oudb7jgRoZeM18IA=
++k8s.io/cri-client v0.32.10/go.mod h1:C6NVDMhnIUwIpGy7uFfrvFmRzVncI0JIRyW9p1Apxts=
++k8s.io/csi-translation-lib v0.32.10 h1:JP4LPb+VvN4Id/dEuqGIa8VR7kyquwQskjWt+1ujbsM=
++k8s.io/csi-translation-lib v0.32.10/go.mod h1:DR+qW9I2dvPqHdYdCVBRDFnp56JcJaWhNQbFbRHM0xg=
++k8s.io/dynamic-resource-allocation v0.32.10 h1:cfmonTCEjWCjBg+LyI+WDMk6oGzTCu1F0rbK8peCDTw=
++k8s.io/dynamic-resource-allocation v0.32.10/go.mod h1:6PInlWzINIGVruu42ytyk5PFBKK7USwepIWk/w8sRyw=
  k8s.io/gengo/v2 v2.0.0-20240911193312-2b36238f13e9 h1:si3PfKm8dDYxgfbeA6orqrtLkvvIeH8UqffFJDl0bz4=
  k8s.io/gengo/v2 v2.0.0-20240911193312-2b36238f13e9/go.mod h1:EJykeLsmFC60UQbYJezXkEsG2FLrt0GPNkU5iK5GWxU=
  k8s.io/klog/v2 v2.130.1 h1:n9Xl7H1Xvksem4KFG4PYbdQCQxqc/tTUyrgXaOhHSzk=
  k8s.io/klog/v2 v2.130.1/go.mod h1:3Jpz1GvMt720eyJH1ckRHK1EDfpxISzJ7I9OYgaDtPE=
 -k8s.io/kms v0.32.0 h1:jwOfunHIrcdYl5FRcA+uUKKtg6qiqoPCwmS2T3XTYL4=
 -k8s.io/kms v0.32.0/go.mod h1:Bk2evz/Yvk0oVrvm4MvZbgq8BD34Ksxs2SRHn4/UiOM=
-+k8s.io/kms v0.32.2 h1:7Ff23ht7W40gTcDwUC8G5WjX5W/nxD8WxbNhIYYNZCI=
-+k8s.io/kms v0.32.2/go.mod h1:Bk2evz/Yvk0oVrvm4MvZbgq8BD34Ksxs2SRHn4/UiOM=
++k8s.io/kms v0.32.10 h1:TOKCISpp+fmWZyHyfNLExW5oeYgFdqHc1j7Ibux+XdQ=
++k8s.io/kms v0.32.10/go.mod h1:Bk2evz/Yvk0oVrvm4MvZbgq8BD34Ksxs2SRHn4/UiOM=
  k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f h1:GA7//TjRY9yWGy1poLzYYJJ4JRdzg3+O6e8I+e+8T5Y=
  k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f/go.mod h1:R/HEjbvWI0qdfb8viZUeVZm0X6IZnxAydC7YU42CMw4=
 -k8s.io/kube-scheduler v0.32.0 h1:FCsF/3TPvR51ptx/gLUrqcoKqAMhQKrydYCJzPz9VGM=
@@ -455,14 +642,18 @@ index 990e503..beb8106 100644
 -k8s.io/kubelet v0.32.0/go.mod h1:lAwuVZT/Hm7EdLn0jW2D+WdrJoorjJL2rVSdhOFnegw=
 -k8s.io/kubernetes v1.32.0 h1:4BDBWSolqPrv8GC3YfZw0CJvh5kA1TPnoX0FxDVd+qc=
 -k8s.io/kubernetes v1.32.0/go.mod h1:tiIKO63GcdPRBHW2WiUFm3C0eoLczl3f7qi56Dm1W8I=
-+k8s.io/kube-scheduler v0.32.2 h1:vBm6iIjWaD10OPmtkt/503LTKvrN8dWVceeBcpKj/ns=
-+k8s.io/kube-scheduler v0.32.2/go.mod h1:dD5yuYpnsCfgZmzvncUNPdvXGJXA1hw3gXq7DH3+aCQ=
-+k8s.io/kubectl v0.32.2 h1:TAkag6+XfSBgkqK9I7ZvwtF0WVtUAvK8ZqTt+5zi1Us=
-+k8s.io/kubectl v0.32.2/go.mod h1:+h/NQFSPxiDZYX/WZaWw9fwYezGLISP0ud8nQKg+3g8=
-+k8s.io/kubelet v0.32.2 h1:WFTSYdt3BB1aTApDuKNI16x/4MYqqX8WBBBBh3KupDg=
-+k8s.io/kubelet v0.32.2/go.mod h1:cC1ms5RS+lu0ckVr6AviCQXHLSPKEBC3D5oaCBdTGkI=
-+k8s.io/kubernetes v1.32.6 h1:tp1gRjOqZjaoFBek5PN6eSmODdS1QRrH5UKiFP8ZByg=
-+k8s.io/kubernetes v1.32.6/go.mod h1:REY0Gok66BTTrbGyZaFMNKO9JhxvgBDW9B7aksWRFoY=
- k8s.io/mount-utils v0.32.3 h1:ZPXXHblfBhYP89OnaozpFg9Ojl6HhDfxBLcdWNkaxW8=
- k8s.io/mount-utils v0.32.3/go.mod h1:Kun5c2svjAPx0nnvJKYQWhfeNW+O0EpzHgRhDcYoSY0=
+-k8s.io/mount-utils v0.32.0 h1:KOQAhPzJICATXnc6XCkWoexKbkOexRnMCUW8APFfwg4=
+-k8s.io/mount-utils v0.32.0/go.mod h1:Kun5c2svjAPx0nnvJKYQWhfeNW+O0EpzHgRhDcYoSY0=
++k8s.io/kube-scheduler v0.32.10 h1:GviS8C1FtRaN7ser+YMteLjBorH/efdq28CBdcmydfQ=
++k8s.io/kube-scheduler v0.32.10/go.mod h1:NIbZnbqbw5OukAJWnvZv+wUn753u1LeZX8BvNYcFpQ0=
++k8s.io/kubectl v0.32.10 h1:sXYKAl9C/HlLrRYHrcvLqMBXOuWrQLC5R3eNz7UMKnU=
++k8s.io/kubectl v0.32.10/go.mod h1:9ZslQAVI9567FnBQxGR7npMC+HhzbVrKRaRxVdpe+LQ=
++k8s.io/kubelet v0.32.10 h1:MOogwP/TkfLJ9fl/BwzgmBXILaGu2wl+P4BIwtcmyXw=
++k8s.io/kubelet v0.32.10/go.mod h1:HmNTDI+zxjvIotTQIL50zqGySoqRIbJTgAY49iH9ILM=
++k8s.io/kubernetes v1.32.10 h1:yiRa8DyKp4Yrbv028MP6kpp5N1N3eO8Hp/tSCbBGIPE=
++k8s.io/kubernetes v1.32.10/go.mod h1:o2pRStsMR7Uq62zcugfUEQsxnuyFt9r8migMrbsVH00=
++k8s.io/mount-utils v0.32.10 h1:cSz/3jAaPTkSfJUOfOTB0HPCZYcxZaY2moDiRBS96LU=
++k8s.io/mount-utils v0.32.10/go.mod h1:Kun5c2svjAPx0nnvJKYQWhfeNW+O0EpzHgRhDcYoSY0=
  k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 h1:M3sRQVHv7vB20Xc2ybTt7ODCeFj6JSWYFzOFnYeS6Ro=
+ k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
+ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.0 h1:CPT0ExVicCzcpeN4baWEV2ko2Z/AsiZgEdwgcfwLgMo=

--- a/modules/040-node-manager/images/cluster-autoscaler/patches/1.32/001-go-mod.patch
+++ b/modules/040-node-manager/images/cluster-autoscaler/patches/1.32/001-go-mod.patch
@@ -1,5 +1,5 @@
 diff --git a/cluster-autoscaler/apis/go.mod b/cluster-autoscaler/apis/go.mod
-index ae10182dc..feacab2d1 100644
+index b36d764c7..3ccfd3e5f 100644
 --- a/cluster-autoscaler/apis/go.mod
 +++ b/cluster-autoscaler/apis/go.mod
 @@ -1,6 +1,6 @@
@@ -35,7 +35,7 @@ index ae10182dc..feacab2d1 100644
  	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
  	gopkg.in/inf.v0 v0.9.1 // indirect
 diff --git a/cluster-autoscaler/apis/go.sum b/cluster-autoscaler/apis/go.sum
-index d6df76ab4..0d592d717 100644
+index 649024af5..fe03c93c7 100644
 --- a/cluster-autoscaler/apis/go.sum
 +++ b/cluster-autoscaler/apis/go.sum
 @@ -88,40 +88,44 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
@@ -98,7 +98,7 @@ index d6df76ab4..0d592d717 100644
  golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
  golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 diff --git a/cluster-autoscaler/go.mod b/cluster-autoscaler/go.mod
-index c0a606380..607eae4ff 100644
+index 4fb700f05..945a953e0 100644
 --- a/cluster-autoscaler/go.mod
 +++ b/cluster-autoscaler/go.mod
 @@ -1,6 +1,6 @@
@@ -109,7 +109,7 @@ index c0a606380..607eae4ff 100644
  
  require (
  	cloud.google.com/go/compute/metadata v0.3.0
-@@ -31,28 +31,28 @@ require (
+@@ -32,28 +32,28 @@ require (
  	github.com/stretchr/testify v1.9.0
  	github.com/vburenin/ifacemaker v1.2.1
  	go.uber.org/mock v0.4.0
@@ -123,26 +123,26 @@ index c0a606380..607eae4ff 100644
  	google.golang.org/protobuf v1.35.1
  	gopkg.in/gcfg.v1 v1.2.3
  	gopkg.in/yaml.v2 v2.4.0
--	k8s.io/api v0.32.10
--	k8s.io/apimachinery v0.32.10
--	k8s.io/apiserver v0.32.10
+-	k8s.io/api v0.32.9
+-	k8s.io/apimachinery v0.32.9
+-	k8s.io/apiserver v0.32.9
 +	k8s.io/api v0.32.13
 +	k8s.io/apimachinery v0.32.13
 +	k8s.io/apiserver v0.32.13
  	k8s.io/autoscaler/cluster-autoscaler/apis v0.0.0-20240627115740-d52e4b9665d7
--	k8s.io/client-go v0.32.10
+-	k8s.io/client-go v0.32.9
 +	k8s.io/client-go v0.32.13
  	k8s.io/cloud-provider v0.32.7
  	k8s.io/cloud-provider-aws v1.27.0
  	k8s.io/cloud-provider-gcp/providers v0.28.2
--	k8s.io/component-base v0.32.10
--	k8s.io/component-helpers v0.32.10
+-	k8s.io/component-base v0.32.9
+-	k8s.io/component-helpers v0.32.9
 +	k8s.io/component-base v0.32.13
 +	k8s.io/component-helpers v0.32.13
  	k8s.io/dynamic-resource-allocation v0.0.0
  	k8s.io/klog/v2 v2.130.1
--	k8s.io/kubelet v0.32.10
--	k8s.io/kubernetes v1.32.10
+-	k8s.io/kubelet v0.32.9
+-	k8s.io/kubernetes v1.32.9
 +	k8s.io/kubelet v0.32.13
 +	k8s.io/kubernetes v1.32.13
  	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738
@@ -174,16 +174,16 @@ index c0a606380..607eae4ff 100644
  	gopkg.in/warnings.v0 v0.1.2 // indirect
  	gopkg.in/yaml.v3 v3.0.1 // indirect
  	k8s.io/apiextensions-apiserver v0.0.0 // indirect
--	k8s.io/code-generator v0.32.10 // indirect
--	k8s.io/controller-manager v0.32.10 // indirect
--	k8s.io/cri-api v0.32.10 // indirect
+-	k8s.io/code-generator v0.32.9 // indirect
+-	k8s.io/controller-manager v0.32.9 // indirect
+-	k8s.io/cri-api v0.32.9 // indirect
 +	k8s.io/code-generator v0.32.13 // indirect
 +	k8s.io/controller-manager v0.32.13 // indirect
 +	k8s.io/cri-api v0.32.13 // indirect
  	k8s.io/cri-client v0.0.0 // indirect
  	k8s.io/csi-translation-lib v0.27.0 // indirect
  	k8s.io/gengo/v2 v2.0.0-20240911193312-2b36238f13e9 // indirect
--	k8s.io/kms v0.32.10 // indirect
+-	k8s.io/kms v0.32.9 // indirect
 +	k8s.io/kms v0.32.13 // indirect
  	k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f // indirect
  	k8s.io/kube-scheduler v0.0.0 // indirect
@@ -192,102 +192,102 @@ index c0a606380..607eae4ff 100644
  
  replace github.com/rancher/go-rancher => github.com/rancher/go-rancher v0.1.0
  
--replace k8s.io/api => k8s.io/api v0.32.10
+-replace k8s.io/api => k8s.io/api v0.32.9
 +replace k8s.io/api => k8s.io/api v0.32.13
  
--replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.32.10
+-replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.32.9
 +replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.32.13
  
--replace k8s.io/apimachinery => k8s.io/apimachinery v0.32.10
+-replace k8s.io/apimachinery => k8s.io/apimachinery v0.32.9
 +replace k8s.io/apimachinery => k8s.io/apimachinery v0.32.13
  
--replace k8s.io/apiserver => k8s.io/apiserver v0.32.10
+-replace k8s.io/apiserver => k8s.io/apiserver v0.32.9
 +replace k8s.io/apiserver => k8s.io/apiserver v0.32.13
  
--replace k8s.io/cli-runtime => k8s.io/cli-runtime v0.32.10
+-replace k8s.io/cli-runtime => k8s.io/cli-runtime v0.32.9
 +replace k8s.io/cli-runtime => k8s.io/cli-runtime v0.32.13
  
--replace k8s.io/client-go => k8s.io/client-go v0.32.10
+-replace k8s.io/client-go => k8s.io/client-go v0.32.9
 +replace k8s.io/client-go => k8s.io/client-go v0.32.13
  
--replace k8s.io/cloud-provider => k8s.io/cloud-provider v0.32.10
+-replace k8s.io/cloud-provider => k8s.io/cloud-provider v0.32.9
 +replace k8s.io/cloud-provider => k8s.io/cloud-provider v0.32.13
  
--replace k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.32.10
+-replace k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.32.9
 +replace k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.32.13
  
--replace k8s.io/code-generator => k8s.io/code-generator v0.32.10
+-replace k8s.io/code-generator => k8s.io/code-generator v0.32.9
 +replace k8s.io/code-generator => k8s.io/code-generator v0.32.13
  
--replace k8s.io/component-base => k8s.io/component-base v0.32.10
+-replace k8s.io/component-base => k8s.io/component-base v0.32.9
 +replace k8s.io/component-base => k8s.io/component-base v0.32.13
  
--replace k8s.io/component-helpers => k8s.io/component-helpers v0.32.10
+-replace k8s.io/component-helpers => k8s.io/component-helpers v0.32.9
 +replace k8s.io/component-helpers => k8s.io/component-helpers v0.32.13
  
--replace k8s.io/controller-manager => k8s.io/controller-manager v0.32.10
+-replace k8s.io/controller-manager => k8s.io/controller-manager v0.32.9
 +replace k8s.io/controller-manager => k8s.io/controller-manager v0.32.13
  
--replace k8s.io/cri-api => k8s.io/cri-api v0.32.10
+-replace k8s.io/cri-api => k8s.io/cri-api v0.32.9
 +replace k8s.io/cri-api => k8s.io/cri-api v0.32.13
  
--replace k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.32.10
+-replace k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.32.9
 +replace k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.32.13
  
--replace k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.32.10
+-replace k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.32.9
 +replace k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.32.13
  
--replace k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.32.10
+-replace k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.32.9
 +replace k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.32.13
  
--replace k8s.io/kube-proxy => k8s.io/kube-proxy v0.32.10
+-replace k8s.io/kube-proxy => k8s.io/kube-proxy v0.32.9
 +replace k8s.io/kube-proxy => k8s.io/kube-proxy v0.32.13
  
--replace k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.32.10
+-replace k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.32.9
 +replace k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.32.13
  
--replace k8s.io/kubectl => k8s.io/kubectl v0.32.10
+-replace k8s.io/kubectl => k8s.io/kubectl v0.32.9
 +replace k8s.io/kubectl => k8s.io/kubectl v0.32.13
  
--replace k8s.io/kubelet => k8s.io/kubelet v0.32.10
+-replace k8s.io/kubelet => k8s.io/kubelet v0.32.9
 +replace k8s.io/kubelet => k8s.io/kubelet v0.32.13
  
--replace k8s.io/metrics => k8s.io/metrics v0.32.10
+-replace k8s.io/metrics => k8s.io/metrics v0.32.9
 +replace k8s.io/metrics => k8s.io/metrics v0.32.13
  
--replace k8s.io/mount-utils => k8s.io/mount-utils v0.32.10
+-replace k8s.io/mount-utils => k8s.io/mount-utils v0.32.9
 +replace k8s.io/mount-utils => k8s.io/mount-utils v0.32.13
  
--replace k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.32.10
+-replace k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.32.9
 +replace k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.32.13
  
--replace k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.32.10
+-replace k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.32.9
 +replace k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.32.13
  
--replace k8s.io/sample-controller => k8s.io/sample-controller v0.32.10
+-replace k8s.io/sample-controller => k8s.io/sample-controller v0.32.9
 +replace k8s.io/sample-controller => k8s.io/sample-controller v0.32.13
  
--replace k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.32.10
+-replace k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.32.9
 +replace k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.32.13
  
--replace k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.32.10
+-replace k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.32.9
 +replace k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.32.13
  
--replace k8s.io/kms => k8s.io/kms v0.32.10
+-replace k8s.io/kms => k8s.io/kms v0.32.9
 +replace k8s.io/kms => k8s.io/kms v0.32.13
  
--replace k8s.io/endpointslice => k8s.io/endpointslice v0.32.10
+-replace k8s.io/endpointslice => k8s.io/endpointslice v0.32.9
 +replace k8s.io/endpointslice => k8s.io/endpointslice v0.32.13
  
  replace k8s.io/autoscaler/cluster-autoscaler/apis => ./apis
  
--replace k8s.io/cri-client => k8s.io/cri-client v0.32.10
+-replace k8s.io/cri-client => k8s.io/cri-client v0.32.9
 +replace k8s.io/cri-client => k8s.io/cri-client v0.32.13
  
--replace k8s.io/externaljwt => k8s.io/externaljwt v0.32.10
+-replace k8s.io/externaljwt => k8s.io/externaljwt v0.32.9
 +replace k8s.io/externaljwt => k8s.io/externaljwt v0.32.13
 diff --git a/cluster-autoscaler/go.sum b/cluster-autoscaler/go.sum
-index a5e3f564e..c9ca3fb97 100644
+index 73d9cd6f8..c9ca3fb97 100644
 --- a/cluster-autoscaler/go.sum
 +++ b/cluster-autoscaler/go.sum
 @@ -446,8 +446,8 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
@@ -385,18 +385,18 @@ index a5e3f564e..c9ca3fb97 100644
  gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
  honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
  honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
--k8s.io/api v0.32.10 h1:ocp4turNfa1V40TuBW/LuA17TeXG9g/GI2ebg0KxBNk=
--k8s.io/api v0.32.10/go.mod h1:AsMsc4b6TuampYqgMEGSv0HBFpRS4BlKTXAVCAa7oF4=
--k8s.io/apiextensions-apiserver v0.32.10 h1:mAZT8fX/jM9pl7qWkFhhsjQZ8ZkmAhEivfUNw8uKXmo=
--k8s.io/apiextensions-apiserver v0.32.10/go.mod h1:wEvqU9kFUQOYminqrroY6+fvSs6iMb7QiiFmcN3b6KY=
--k8s.io/apimachinery v0.32.10 h1:SAg2kUPLYRcBJQj66oniP1BnXSqw+l1GvJFsJlBmVvQ=
--k8s.io/apimachinery v0.32.10/go.mod h1:GpHVgxoKlTxClKcteaeuF1Ul/lDVb74KpZcxcmLDElE=
--k8s.io/apiserver v0.32.10 h1:nRUv9Q/OFHVjl/50TgNDlzw37wjTI0j+Ywp0gWqvQfs=
--k8s.io/apiserver v0.32.10/go.mod h1:BV9Wgt44Rop5I0cYsh2NYQstHu16ou4uirh95yTbioc=
--k8s.io/client-go v0.32.10 h1:MFmIjsKtcnn7mStjrJG1ZW2WzLsKKn6ZtL9hHM/W0xU=
--k8s.io/client-go v0.32.10/go.mod h1:qJy/Ws3zSwnu/nD75D+/of1uxbwWHxrYT5P3FuobVLI=
--k8s.io/cloud-provider v0.32.10 h1:S6OFOKlKYTM4PxdOFoihrXbbNuT5D1Q5pLtpfRN/LhM=
--k8s.io/cloud-provider v0.32.10/go.mod h1:+yQAZWtdYbLk72vjtaZpN9wtn4UBUoOZc7JddFcjIec=
+-k8s.io/api v0.32.9 h1:q/59kk8lnecgG0grJqzrmXC1Jcl2hPWp9ltz0FQuoLI=
+-k8s.io/api v0.32.9/go.mod h1:jIfT3rwW4EU1IXZm9qjzSk/2j91k4CJL5vUULrxqp3Y=
+-k8s.io/apiextensions-apiserver v0.32.9 h1:tpT1dUgWqEsTyrdoGckyw8OBASW1JfU08tHGaYBzFHY=
+-k8s.io/apiextensions-apiserver v0.32.9/go.mod h1:FoCi4zCLK67LNCCssFa2Wr9q4Xbvjx7MW4tdze5tpoA=
+-k8s.io/apimachinery v0.32.9 h1:fXk8ktfsxrdThaEOAQFgkhCK7iyoyvS8nbYJ83o/SSs=
+-k8s.io/apimachinery v0.32.9/go.mod h1:GpHVgxoKlTxClKcteaeuF1Ul/lDVb74KpZcxcmLDElE=
+-k8s.io/apiserver v0.32.9 h1:ONHLA/VB6U7s0skCzmyLnjQdJ5FPCQF08yBI0j7y84o=
+-k8s.io/apiserver v0.32.9/go.mod h1:MuuqNdvkneD4kcQc5mUZQCOQYzfKMba6P36bVW+wZtI=
+-k8s.io/client-go v0.32.9 h1:ZMyIQ1TEpTDAQni3L2gH1NZzyOA/gHfNcAazzCxMJ0c=
+-k8s.io/client-go v0.32.9/go.mod h1:2OT8aFSYvUjKGadaeT+AVbhkXQSpMAkiSb88Kz2WggI=
+-k8s.io/cloud-provider v0.32.9 h1:JDHwfY0ACw3QBpz8K01z0mH2JdbIqnXklmd9IaIL99c=
+-k8s.io/cloud-provider v0.32.9/go.mod h1:f7Nm5c4syybGQRmvfir/ojgmKILO1DmIpxDnGIagDvo=
 +k8s.io/api v0.32.13 h1:CAtHUTtSau6UhSGcrypjKXc2365TncaxUtrIfnjUPGE=
 +k8s.io/api v0.32.13/go.mod h1:PXqm+/G56aRPUJWUb8nGwBDovaXcqQ+e3o6+ZJIITPY=
 +k8s.io/apiextensions-apiserver v0.32.13 h1:3M8y1UNKgAp/I+T4TDEeqXiR1wj8nrqzTqgMHRKsO8A=
@@ -413,22 +413,22 @@ index a5e3f564e..c9ca3fb97 100644
  k8s.io/cloud-provider-aws v1.27.0/go.mod h1:9vUb5mnVnReSRDBWcBxB1b0HOeEc472iOPmrnwpN9SA=
  k8s.io/cloud-provider-gcp/providers v0.28.2 h1:I65pFTLNMQSj7YuW3Mg3pZIXmw0naCmF6TGAuz4/sZE=
  k8s.io/cloud-provider-gcp/providers v0.28.2/go.mod h1:P8dxRvvLtX7xUwVUzA/QOqv8taCzBaVsVMnjnpjmYXE=
--k8s.io/code-generator v0.32.10 h1:H8MF03Ad6isbGI6tnotITdaBEwxQjVFdpC6AxhoYuaI=
--k8s.io/code-generator v0.32.10/go.mod h1:fmTm8F2FNPlr+IUvZ17U1wOTY3/soDIc++m4g+lC1PQ=
--k8s.io/component-base v0.32.10 h1:9+8Pw0fasOWPNHeQKmf38TFI7Zdi1k38sOIm0jQdSV4=
--k8s.io/component-base v0.32.10/go.mod h1:Tou3W1f6+8i5svBQ0Sef3jpkSZ0k6q2QdXbQSn4c9do=
--k8s.io/component-helpers v0.32.10 h1:hMdA0wF5GkUAqjtY/d4y5WJK1OqvdAA0xREL1OceXS0=
--k8s.io/component-helpers v0.32.10/go.mod h1:bSxQeNzLYUrll2RFtkVTXKFnjVrgb5OWSIgW4rECOus=
--k8s.io/controller-manager v0.32.10 h1:B2rGlwJfCBYSf1AXf9FQkrvS98Fqg0RZh0gud30mkZY=
--k8s.io/controller-manager v0.32.10/go.mod h1:Jl6E8fwRfg0sSY/Schef/9UKdIlxRmnyaa3ZUaVeay4=
--k8s.io/cri-api v0.32.10 h1:xdFaVDpNupzgTIRiK4onsHZqpc8exxLl1jia4p8IakQ=
--k8s.io/cri-api v0.32.10/go.mod h1:DCzMuTh2padoinefWME0G678Mc3QFbLMF2vEweGzBAI=
--k8s.io/cri-client v0.32.10 h1:N+nlAkzATstdp+mUQwtX3qqFUa7Oudb7jgRoZeM18IA=
--k8s.io/cri-client v0.32.10/go.mod h1:C6NVDMhnIUwIpGy7uFfrvFmRzVncI0JIRyW9p1Apxts=
--k8s.io/csi-translation-lib v0.32.10 h1:JP4LPb+VvN4Id/dEuqGIa8VR7kyquwQskjWt+1ujbsM=
--k8s.io/csi-translation-lib v0.32.10/go.mod h1:DR+qW9I2dvPqHdYdCVBRDFnp56JcJaWhNQbFbRHM0xg=
--k8s.io/dynamic-resource-allocation v0.32.10 h1:cfmonTCEjWCjBg+LyI+WDMk6oGzTCu1F0rbK8peCDTw=
--k8s.io/dynamic-resource-allocation v0.32.10/go.mod h1:6PInlWzINIGVruu42ytyk5PFBKK7USwepIWk/w8sRyw=
+-k8s.io/code-generator v0.32.9 h1:F9Gti/8I+nVNnQw02J36/YlSD5JMg4qDJ7sfRqpUICU=
+-k8s.io/code-generator v0.32.9/go.mod h1:fLYBG9g52EJulRebmomL0vCU0PQeMr7mnscfZtAAGV4=
+-k8s.io/component-base v0.32.9 h1:UTDZUpVQRv1M7BQtEvswLwiKij9QO7EzfZgpMD7WqLQ=
+-k8s.io/component-base v0.32.9/go.mod h1:AfJMbzLk8iyOyDPkv/HpAjYmdNGookl9O0Kva5Wu83U=
+-k8s.io/component-helpers v0.32.9 h1:HhZYbizPcNMZYdh6cC8gBoSTx5GTnWp4EsLANTslXfA=
+-k8s.io/component-helpers v0.32.9/go.mod h1:KEc8GARgvk7dmKF/136XlmQVj9+EBJA1HbQFGpjxqM4=
+-k8s.io/controller-manager v0.32.9 h1:RTAkWF8AD6fPR/9JRx0eanOcQseHP0wWYDyIzEF9xG8=
+-k8s.io/controller-manager v0.32.9/go.mod h1:tD4KidRx2h1FqTau2vl9L+LUmjbwFAbrmiKyYc8b4PA=
+-k8s.io/cri-api v0.32.9 h1:FkZzY08XwwVoWzqvmUNn+ly0ftq2WpDFZrsSpeFedZ4=
+-k8s.io/cri-api v0.32.9/go.mod h1:DCzMuTh2padoinefWME0G678Mc3QFbLMF2vEweGzBAI=
+-k8s.io/cri-client v0.32.9 h1:+bpcSeoPE60PeBqn65g69nXwUWK/zAi6hlhAf/ZZppg=
+-k8s.io/cri-client v0.32.9/go.mod h1:HsDDq036RI4PGGJNOLxdg2sVbUuJRP7Fz0RomQTxfsw=
+-k8s.io/csi-translation-lib v0.32.9 h1:i763XZSDkgXF4VyfADYyAE53i1uz+zuaFRGlLdGDdTM=
+-k8s.io/csi-translation-lib v0.32.9/go.mod h1:1F+M2Rn2+UMIu+qlj8JIQJCAdAREF+VRKtfyPHih9To=
+-k8s.io/dynamic-resource-allocation v0.32.9 h1:NXG4oNNaTOG1t0dZ3kunRiP9Nkf1GQvDJQQFi+ffqfA=
+-k8s.io/dynamic-resource-allocation v0.32.9/go.mod h1:bLh0kOgkYXh4DHL7DuIDsyKKLWE2UwAgjiomPRrgG5w=
 +k8s.io/code-generator v0.32.13 h1:s8F2Mg5el0vnDJHqIJl1WhVbbk3J38CmQc5Y6j5bmHQ=
 +k8s.io/code-generator v0.32.13/go.mod h1:rtEcqtalEPQU2cOgjWrX7RQ/x/Lr65pwu7givcfjfx0=
 +k8s.io/component-base v0.32.13 h1:QTroT4xOtYXc8ySp7Wvj5llxDNxz16YoG5Pw3zJBMds=
@@ -449,22 +449,22 @@ index a5e3f564e..c9ca3fb97 100644
  k8s.io/gengo/v2 v2.0.0-20240911193312-2b36238f13e9/go.mod h1:EJykeLsmFC60UQbYJezXkEsG2FLrt0GPNkU5iK5GWxU=
  k8s.io/klog/v2 v2.130.1 h1:n9Xl7H1Xvksem4KFG4PYbdQCQxqc/tTUyrgXaOhHSzk=
  k8s.io/klog/v2 v2.130.1/go.mod h1:3Jpz1GvMt720eyJH1ckRHK1EDfpxISzJ7I9OYgaDtPE=
--k8s.io/kms v0.32.10 h1:TOKCISpp+fmWZyHyfNLExW5oeYgFdqHc1j7Ibux+XdQ=
--k8s.io/kms v0.32.10/go.mod h1:Bk2evz/Yvk0oVrvm4MvZbgq8BD34Ksxs2SRHn4/UiOM=
+-k8s.io/kms v0.32.9 h1:G7e2Eeuit0i9XmTzk8W12hWd2YmSr7aUMHL1XGDPa5M=
+-k8s.io/kms v0.32.9/go.mod h1:Bk2evz/Yvk0oVrvm4MvZbgq8BD34Ksxs2SRHn4/UiOM=
 +k8s.io/kms v0.32.13 h1:z+h7bcmb9gZBEqunJAOVoNZsyIY2S4eTb1qcvpJ0Fu4=
 +k8s.io/kms v0.32.13/go.mod h1:Bk2evz/Yvk0oVrvm4MvZbgq8BD34Ksxs2SRHn4/UiOM=
  k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f h1:GA7//TjRY9yWGy1poLzYYJJ4JRdzg3+O6e8I+e+8T5Y=
  k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f/go.mod h1:R/HEjbvWI0qdfb8viZUeVZm0X6IZnxAydC7YU42CMw4=
--k8s.io/kube-scheduler v0.32.10 h1:GviS8C1FtRaN7ser+YMteLjBorH/efdq28CBdcmydfQ=
--k8s.io/kube-scheduler v0.32.10/go.mod h1:NIbZnbqbw5OukAJWnvZv+wUn753u1LeZX8BvNYcFpQ0=
--k8s.io/kubectl v0.32.10 h1:sXYKAl9C/HlLrRYHrcvLqMBXOuWrQLC5R3eNz7UMKnU=
--k8s.io/kubectl v0.32.10/go.mod h1:9ZslQAVI9567FnBQxGR7npMC+HhzbVrKRaRxVdpe+LQ=
--k8s.io/kubelet v0.32.10 h1:MOogwP/TkfLJ9fl/BwzgmBXILaGu2wl+P4BIwtcmyXw=
--k8s.io/kubelet v0.32.10/go.mod h1:HmNTDI+zxjvIotTQIL50zqGySoqRIbJTgAY49iH9ILM=
--k8s.io/kubernetes v1.32.10 h1:yiRa8DyKp4Yrbv028MP6kpp5N1N3eO8Hp/tSCbBGIPE=
--k8s.io/kubernetes v1.32.10/go.mod h1:o2pRStsMR7Uq62zcugfUEQsxnuyFt9r8migMrbsVH00=
--k8s.io/mount-utils v0.32.10 h1:cSz/3jAaPTkSfJUOfOTB0HPCZYcxZaY2moDiRBS96LU=
--k8s.io/mount-utils v0.32.10/go.mod h1:Kun5c2svjAPx0nnvJKYQWhfeNW+O0EpzHgRhDcYoSY0=
+-k8s.io/kube-scheduler v0.32.9 h1:7oE4exa4H+BjLIn2Bt62vPAF1ckdmfC7wXNZk8xtcsQ=
+-k8s.io/kube-scheduler v0.32.9/go.mod h1:ZV0XZKNJQWBD1zDENXEg+sFwHIuwb6enoDOzPlnVkaw=
+-k8s.io/kubectl v0.32.9 h1:y5D3bdJnenD6bFJ05NwhCa6eSBcPvLcUlgAW6Y4O4zs=
+-k8s.io/kubectl v0.32.9/go.mod h1:2Gb580dhhqMztWWdE+iIFPWcDAel4/FMOwYPOTL51DY=
+-k8s.io/kubelet v0.32.9 h1:DVbYq6iPIQJ/oQSV+Ec4dCytMKy9D5he9Ra2/pVQRNw=
+-k8s.io/kubelet v0.32.9/go.mod h1:ApPYUgb3RNG4IZrWEno5z2oQrP9K1Fh8HCDoUHLZ3CI=
+-k8s.io/kubernetes v1.32.9 h1:w4Zv/2dVwQKUqCZOSBnMzjMYZQ33TNuSZvbkJ9HEaGE=
+-k8s.io/kubernetes v1.32.9/go.mod h1:REY0Gok66BTTrbGyZaFMNKO9JhxvgBDW9B7aksWRFoY=
+-k8s.io/mount-utils v0.32.9 h1:jMo1LsBUoEB2i+KaPJVlgxc0wlBN0UFMDZUquYVVl20=
+-k8s.io/mount-utils v0.32.9/go.mod h1:Kun5c2svjAPx0nnvJKYQWhfeNW+O0EpzHgRhDcYoSY0=
 +k8s.io/kube-scheduler v0.32.13 h1:2pPLTocN7qs5LXuR0LRSGvI5C2IiDKgbdfQWSFIBcxk=
 +k8s.io/kube-scheduler v0.32.13/go.mod h1:qPbJK/ezn2V23YIPa2gsxyEXBj6F6DB9T3CKM21sHG4=
 +k8s.io/kubectl v0.32.13 h1:SgKMRUwpRIR+8DHPphU/wDskNsj0Jtf6bEVyuus+FtI=

--- a/modules/040-node-manager/images/cluster-autoscaler/patches/1.32/001-go-mod.patch
+++ b/modules/040-node-manager/images/cluster-autoscaler/patches/1.32/001-go-mod.patch
@@ -1,37 +1,28 @@
 diff --git a/cluster-autoscaler/apis/go.mod b/cluster-autoscaler/apis/go.mod
-index f71006248..cb1b0e555 100644
+index ae10182dc..feacab2d1 100644
 --- a/cluster-autoscaler/apis/go.mod
 +++ b/cluster-autoscaler/apis/go.mod
-@@ -1,13 +1,11 @@
+@@ -1,6 +1,6 @@
  module k8s.io/autoscaler/cluster-autoscaler/apis
  
--go 1.23.0
--
--toolchain go1.23.2
+-go 1.23.11
 +go 1.25.0
  
  require (
  	github.com/onsi/ginkgo/v2 v2.21.0
- 	github.com/onsi/gomega v1.35.1
--	k8s.io/apimachinery v0.32.0
-+	k8s.io/apimachinery v0.32.3
- 	k8s.io/client-go v0.32.0
- 	k8s.io/code-generator v0.32.0
- 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2
-@@ -38,15 +36,15 @@ require (
+@@ -36,15 +36,16 @@ require (
  	github.com/pkg/errors v0.9.1 // indirect
  	github.com/spf13/pflag v1.0.5 // indirect
  	github.com/x448/float16 v0.8.4 // indirect
 -	golang.org/x/mod v0.21.0 // indirect
 -	golang.org/x/net v0.30.0 // indirect
--	golang.org/x/oauth2 v0.23.0 // indirect
++	golang.org/x/mod v0.35.0 // indirect
++	golang.org/x/net v0.55.0 // indirect
+ 	golang.org/x/oauth2 v0.23.0 // indirect
 -	golang.org/x/sync v0.8.0 // indirect
 -	golang.org/x/sys v0.26.0 // indirect
 -	golang.org/x/term v0.25.0 // indirect
 -	golang.org/x/text v0.19.0 // indirect
-+	golang.org/x/mod v0.35.0 // indirect
-+	golang.org/x/net v0.55.0 // indirect
-+	golang.org/x/oauth2 v0.27.0 // indirect
 +	golang.org/x/sync v0.20.0 // indirect
 +	golang.org/x/sys v0.45.0 // indirect
 +	golang.org/x/term v0.43.0 // indirect
@@ -39,17 +30,21 @@ index f71006248..cb1b0e555 100644
  	golang.org/x/time v0.7.0 // indirect
 -	golang.org/x/tools v0.26.0 // indirect
 +	golang.org/x/tools v0.44.0 // indirect
++	golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated // indirect
  	google.golang.org/protobuf v1.35.1 // indirect
  	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
  	gopkg.in/inf.v0 v0.9.1 // indirect
 diff --git a/cluster-autoscaler/apis/go.sum b/cluster-autoscaler/apis/go.sum
-index ce35bb5f8..52bc872ed 100644
+index d6df76ab4..0d592d717 100644
 --- a/cluster-autoscaler/apis/go.sum
 +++ b/cluster-autoscaler/apis/go.sum
-@@ -90,30 +90,37 @@ golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+@@ -88,40 +88,44 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
+ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+ golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
  golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
- golang.org/x/mod v0.21.0 h1:vvrHzRwRfVKSiLrG+d4FMl/Qi4ukBCE6kZlTUkDYRT0=
- golang.org/x/mod v0.21.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
+-golang.org/x/mod v0.21.0 h1:vvrHzRwRfVKSiLrG+d4FMl/Qi4ukBCE6kZlTUkDYRT0=
+-golang.org/x/mod v0.21.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
++golang.org/x/mod v0.35.0 h1:Ww1D637e6Pg+Zb2KrWfHQUnH2dQRLBQyAtpr/haaJeM=
 +golang.org/x/mod v0.35.0/go.mod h1:+GwiRhIInF8wPm+4AoT6L0FA1QWAad3OMdTRx4tFYlU=
  golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
  golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -57,21 +52,16 @@ index ce35bb5f8..52bc872ed 100644
  golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 -golang.org/x/net v0.30.0 h1:AcW1SDZMkb8IpzCdQUaIq2sP4sZ4zw+55h6ynffypl4=
 -golang.org/x/net v0.30.0/go.mod h1:2wGyMJ5iFasEhkwi13ChkO/t1ECNC4X4eBKkVFyYFlU=
--golang.org/x/oauth2 v0.23.0 h1:PbgcYx2W7i4LvjJWEbf0ngHV6qJYr86PkAV3bXdLEbs=
--golang.org/x/oauth2 v0.23.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
-+golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
-+golang.org/x/net v0.38.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
 +golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
 +golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
-+golang.org/x/oauth2 v0.27.0 h1:da9Vo7/tDv5RH/7nZDz1eMGS/q1Vv1N/7FCrBhI9I3M=
-+golang.org/x/oauth2 v0.27.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT8=
+ golang.org/x/oauth2 v0.23.0 h1:PbgcYx2W7i4LvjJWEbf0ngHV6qJYr86PkAV3bXdLEbs=
+ golang.org/x/oauth2 v0.23.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
  golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
  golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
  golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 -golang.org/x/sync v0.8.0 h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=
 -golang.org/x/sync v0.8.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
-+golang.org/x/sync v0.12.0 h1:MHc5BpPuC30uJk597Ri8TV3CNZcTLu6B6z4lJy+g6Jw=
-+golang.org/x/sync v0.12.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
++golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
 +golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
  golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
  golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -80,160 +70,85 @@ index ce35bb5f8..52bc872ed 100644
 -golang.org/x/sys v0.26.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 -golang.org/x/term v0.25.0 h1:WtHI/ltw4NvSUig5KARz9h521QvRC8RmF/cuYqifU24=
 -golang.org/x/term v0.25.0/go.mod h1:RPyXicDX+6vLxogjjRxjgD2TKtmAO6NZBsBRfrOLu7M=
-+golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
-+golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
++golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 +golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
-+golang.org/x/term v0.30.0 h1:PQ39fJZ+mfadBm0y5WlL4vlM7Sx1Hgf13sMIY2+QS9Y=
-+golang.org/x/term v0.30.0/go.mod h1:NYYFdzHoI5wRh/h5tDMdMqCqPJZEuNqVR5xJLd/n67g=
++golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=
 +golang.org/x/term v0.43.0/go.mod h1:lrhlHNdQJHO+1qVYiHfFKVuVioJIheAc3fBSMFYEIsk=
  golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
  golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 -golang.org/x/text v0.19.0 h1:kTxAhCbGbxhK0IwgSKiMO5awPoDQ0RpfiVYBfK860YM=
 -golang.org/x/text v0.19.0/go.mod h1:BuEKDfySbSR4drPmRPG/7iBdf8hvFMuRexcpahXilzY=
-+golang.org/x/text v0.23.0 h1:D71I7dUrlY+VX0gQShAThNGHFxZ13dGLBHQLVl1mJlY=
-+golang.org/x/text v0.23.0/go.mod h1:/BLNzu4aZCJ1+kcD0DNRotWKage4q2rGVAg4o22unh4=
++golang.org/x/text v0.37.0 h1:Cqjiwd9eSg8e0QAkyCaQTNHFIIzWtidPahFWR83rTrc=
 +golang.org/x/text v0.37.0/go.mod h1:a5sjxXGs9hsn/AJVwuElvCAo9v8QYLzvavO5z2PiM38=
  golang.org/x/time v0.7.0 h1:ntUhktv3OPE6TgYxXWv9vKvUSJyIFJlyohwbkEwPrKQ=
  golang.org/x/time v0.7.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
  golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
-@@ -122,6 +129,7 @@ golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roY
+ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+ golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
  golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
- golang.org/x/tools v0.26.0 h1:v/60pFQmzmT9ExmjDv2gGIfi3OqfKoEP6I5+umXlbnQ=
- golang.org/x/tools v0.26.0/go.mod h1:TPVVj70c7JJ3WCazhD8OdXcZg/og+b9+tH/KxylGwH0=
+-golang.org/x/tools v0.26.0 h1:v/60pFQmzmT9ExmjDv2gGIfi3OqfKoEP6I5+umXlbnQ=
+-golang.org/x/tools v0.26.0/go.mod h1:TPVVj70c7JJ3WCazhD8OdXcZg/og+b9+tH/KxylGwH0=
++golang.org/x/tools v0.44.0 h1:UP4ajHPIcuMjT1GqzDWRlalUEoY+uzoZKnhOjbIPD2c=
 +golang.org/x/tools v0.44.0/go.mod h1:KA0AfVErSdxRZIsOVipbv3rQhVXTnlU6UhKxHd1seDI=
++golang.org/x/tools/go/expect v0.1.0-deprecated h1:jY2C5HGYR5lqex3gEniOQL0r7Dq5+VGVgY1nudX5lXY=
++golang.org/x/tools/go/expect v0.1.0-deprecated/go.mod h1:eihoPOH+FgIqa3FpoTwguz/bVUSGBlGQU67vpBeOrBY=
++golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated h1:1h2MnaIAIXISqTFKdENegdpAgUXz6NrPEsbIeWaBRvM=
++golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated/go.mod h1:RVAQXBGNv1ib0J382/DPCRS/BPnsGebyM1Gj5VSDpG8=
  golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
  golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
  golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-@@ -142,6 +150,7 @@ k8s.io/api v0.32.0 h1:OL9JpbvAU5ny9ga2fb24X8H6xQlVp+aJMFlgtQjR9CE=
- k8s.io/api v0.32.0/go.mod h1:4LEwHZEf6Q/cG96F3dqR965sYOfmPM7rq81BLgsE0p0=
- k8s.io/apimachinery v0.32.0 h1:cFSE7N3rmEEtv4ei5X6DaJPHHX0C+upp+v5lVPiEwpg=
- k8s.io/apimachinery v0.32.0/go.mod h1:GpHVgxoKlTxClKcteaeuF1Ul/lDVb74KpZcxcmLDElE=
-+k8s.io/apimachinery v0.32.3/go.mod h1:GpHVgxoKlTxClKcteaeuF1Ul/lDVb74KpZcxcmLDElE=
- k8s.io/client-go v0.32.0 h1:DimtMcnN/JIKZcrSrstiwvvZvLjG0aSxy8PxN8IChp8=
- k8s.io/client-go v0.32.0/go.mod h1:boDWvdM1Drk4NJj/VddSLnx59X3OPgwrOo0vGbtq9+8=
- k8s.io/code-generator v0.32.0 h1:s0lNN8VSWny8LBz5t5iy7MCdgwdOhdg7vAGVxvS+VWU=
 diff --git a/cluster-autoscaler/go.mod b/cluster-autoscaler/go.mod
-index 503a69270..b6d03a1ef 100644
+index c0a606380..607eae4ff 100644
 --- a/cluster-autoscaler/go.mod
 +++ b/cluster-autoscaler/go.mod
-@@ -1,15 +1,13 @@
+@@ -1,6 +1,6 @@
  module k8s.io/autoscaler/cluster-autoscaler
  
--go 1.23.0
--
--toolchain go1.23.2
+-go 1.23.11
 +go 1.25.0
  
  require (
  	cloud.google.com/go/compute/metadata v0.3.0
- 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible
- 	github.com/Azure/azure-sdk-for-go-extensions v0.1.6
- 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.1
--	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.5.2
-+	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.6.0
- 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v4 v4.9.0-beta.1
- 	github.com/Azure/go-autorest/autorest v0.11.29
- 	github.com/Azure/go-autorest/autorest/adal v0.9.24
-@@ -34,28 +32,28 @@ require (
+@@ -31,28 +31,28 @@ require (
  	github.com/stretchr/testify v1.9.0
  	github.com/vburenin/ifacemaker v1.2.1
  	go.uber.org/mock v0.4.0
 -	golang.org/x/net v0.30.0
--	golang.org/x/oauth2 v0.23.0
--	golang.org/x/sys v0.26.0
 +	golang.org/x/net v0.55.0
-+	golang.org/x/oauth2 v0.27.0
+ 	golang.org/x/oauth2 v0.23.0
+-	golang.org/x/sys v0.26.0
 +	golang.org/x/sys v0.45.0
  	google.golang.org/api v0.151.0
  	google.golang.org/grpc v1.65.0
  	google.golang.org/protobuf v1.35.1
  	gopkg.in/gcfg.v1 v1.2.3
  	gopkg.in/yaml.v2 v2.4.0
--	k8s.io/api v0.32.0
--	k8s.io/apimachinery v0.32.0
--	k8s.io/apiserver v0.32.0
-+	k8s.io/api v0.32.10
-+	k8s.io/apimachinery v0.32.10
-+	k8s.io/apiserver v0.32.10
+-	k8s.io/api v0.32.10
+-	k8s.io/apimachinery v0.32.10
+-	k8s.io/apiserver v0.32.10
++	k8s.io/api v0.32.13
++	k8s.io/apimachinery v0.32.13
++	k8s.io/apiserver v0.32.13
  	k8s.io/autoscaler/cluster-autoscaler/apis v0.0.0-20240627115740-d52e4b9665d7
--	k8s.io/client-go v0.32.0
-+	k8s.io/client-go v0.32.10
- 	k8s.io/cloud-provider v0.30.1
+-	k8s.io/client-go v0.32.10
++	k8s.io/client-go v0.32.13
+ 	k8s.io/cloud-provider v0.32.7
  	k8s.io/cloud-provider-aws v1.27.0
  	k8s.io/cloud-provider-gcp/providers v0.28.2
--	k8s.io/component-base v0.32.0
--	k8s.io/component-helpers v0.32.0
-+	k8s.io/component-base v0.32.10
-+	k8s.io/component-helpers v0.32.10
+-	k8s.io/component-base v0.32.10
+-	k8s.io/component-helpers v0.32.10
++	k8s.io/component-base v0.32.13
++	k8s.io/component-helpers v0.32.13
  	k8s.io/dynamic-resource-allocation v0.0.0
  	k8s.io/klog/v2 v2.130.1
--	k8s.io/kubelet v0.32.0
--	k8s.io/kubernetes v1.32.0
-+	k8s.io/kubelet v0.32.10
-+	k8s.io/kubernetes v1.32.10
+-	k8s.io/kubelet v0.32.10
+-	k8s.io/kubernetes v1.32.10
++	k8s.io/kubelet v0.32.13
++	k8s.io/kubernetes v1.32.13
  	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738
  	sigs.k8s.io/cloud-provider-azure v1.29.4
  	sigs.k8s.io/cloud-provider-azure/pkg/azclient v0.0.13
-@@ -64,7 +62,7 @@ require (
- 
- require (
- 	cel.dev/expr v0.18.0 // indirect
--	github.com/Azure/azure-sdk-for-go/sdk/internal v1.5.2 // indirect
-+	github.com/Azure/azure-sdk-for-go/sdk/internal v1.8.0 // indirect
- 	github.com/Azure/azure-sdk-for-go/sdk/keyvault/azsecrets v0.12.0 // indirect
- 	github.com/Azure/azure-sdk-for-go/sdk/keyvault/internal v0.7.1 // indirect
- 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5 v5.6.0 // indirect
-@@ -85,7 +83,7 @@ require (
- 	github.com/GoogleCloudPlatform/k8s-cloud-provider v1.25.0 // indirect
- 	github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab // indirect
- 	github.com/Microsoft/go-winio v0.6.2 // indirect
--	github.com/Microsoft/hnslib v0.0.8 // indirect
-+	github.com/Microsoft/hnslib v0.1.1 // indirect
- 	github.com/NYTimes/gziphandler v1.1.1 // indirect
- 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
- 	github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2 // indirect
-@@ -100,7 +98,7 @@ require (
- 	github.com/containerd/ttrpc v1.2.5 // indirect
- 	github.com/coreos/go-semver v0.3.1 // indirect
- 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
--	github.com/cyphar/filepath-securejoin v0.3.4 // indirect
-+	github.com/cyphar/filepath-securejoin v0.5.1 // indirect
- 	github.com/dave/jennifer v1.6.0 // indirect
- 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
- 	github.com/dimchansky/utfbom v1.1.1 // indirect
-@@ -121,8 +119,8 @@ require (
- 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
- 	github.com/godbus/dbus/v5 v5.1.0 // indirect
- 	github.com/gogo/protobuf v1.3.2 // indirect
--	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
--	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
-+	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
-+	github.com/golang-jwt/jwt/v5 v5.2.2 // indirect
- 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
- 	github.com/golang/protobuf v1.5.4 // indirect
- 	github.com/google/btree v1.0.1 // indirect
-@@ -157,9 +155,9 @@ require (
- 	github.com/onsi/ginkgo/v2 v2.21.0 // indirect
- 	github.com/onsi/gomega v1.35.1 // indirect
- 	github.com/opencontainers/go-digest v1.0.0 // indirect
--	github.com/opencontainers/runc v1.2.1 // indirect
-+	github.com/opencontainers/runc v1.2.8 // indirect
- 	github.com/opencontainers/runtime-spec v1.2.0 // indirect
--	github.com/opencontainers/selinux v1.11.1 // indirect
-+	github.com/opencontainers/selinux v1.12.0 // indirect
- 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
- 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
- 	github.com/prometheus/client_model v0.6.1 // indirect
-@@ -174,7 +172,7 @@ require (
- 	go.etcd.io/etcd/client/pkg/v3 v3.5.16 // indirect
- 	go.etcd.io/etcd/client/v3 v3.5.16 // indirect
- 	go.opencensus.io v0.24.0 // indirect
--	go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful v0.42.0 // indirect
-+	go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful v0.44.0 // indirect
- 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.53.0 // indirect
- 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.53.0 // indirect
- 	go.opentelemetry.io/otel v1.28.0 // indirect
-@@ -186,14 +184,15 @@ require (
+@@ -185,14 +185,15 @@ require (
  	go.opentelemetry.io/proto/otlp v1.3.1 // indirect
  	go.uber.org/multierr v1.11.0 // indirect
  	go.uber.org/zap v1.27.0 // indirect
@@ -255,215 +170,127 @@ index 503a69270..b6d03a1ef 100644
  	google.golang.org/genproto/googleapis/api v0.0.0-20240826202546-f6391c0de4c7 // indirect
  	google.golang.org/genproto/googleapis/rpc v0.0.0-20240826202546-f6391c0de4c7 // indirect
  	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
-@@ -202,13 +201,13 @@ require (
+@@ -201,13 +202,13 @@ require (
  	gopkg.in/warnings.v0 v0.1.2 // indirect
  	gopkg.in/yaml.v3 v3.0.1 // indirect
  	k8s.io/apiextensions-apiserver v0.0.0 // indirect
--	k8s.io/code-generator v0.32.0 // indirect
--	k8s.io/controller-manager v0.32.0 // indirect
--	k8s.io/cri-api v0.32.0 // indirect
-+	k8s.io/code-generator v0.32.10 // indirect
-+	k8s.io/controller-manager v0.32.10 // indirect
-+	k8s.io/cri-api v0.32.10 // indirect
+-	k8s.io/code-generator v0.32.10 // indirect
+-	k8s.io/controller-manager v0.32.10 // indirect
+-	k8s.io/cri-api v0.32.10 // indirect
++	k8s.io/code-generator v0.32.13 // indirect
++	k8s.io/controller-manager v0.32.13 // indirect
++	k8s.io/cri-api v0.32.13 // indirect
  	k8s.io/cri-client v0.0.0 // indirect
  	k8s.io/csi-translation-lib v0.27.0 // indirect
  	k8s.io/gengo/v2 v2.0.0-20240911193312-2b36238f13e9 // indirect
--	k8s.io/kms v0.32.0 // indirect
-+	k8s.io/kms v0.32.10 // indirect
+-	k8s.io/kms v0.32.10 // indirect
++	k8s.io/kms v0.32.13 // indirect
  	k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f // indirect
  	k8s.io/kube-scheduler v0.0.0 // indirect
  	k8s.io/kubectl v0.28.0 // indirect
-@@ -225,66 +224,66 @@ replace github.com/digitalocean/godo => github.com/digitalocean/godo v1.27.0
+@@ -224,66 +225,66 @@ replace github.com/digitalocean/godo => github.com/digitalocean/godo v1.27.0
  
  replace github.com/rancher/go-rancher => github.com/rancher/go-rancher v0.1.0
  
--replace k8s.io/api => k8s.io/api v0.32.0
-+replace k8s.io/api => k8s.io/api v0.32.10
+-replace k8s.io/api => k8s.io/api v0.32.10
++replace k8s.io/api => k8s.io/api v0.32.13
  
--replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.32.0
-+replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.32.10
+-replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.32.10
++replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.32.13
  
--replace k8s.io/apimachinery => k8s.io/apimachinery v0.32.0
-+replace k8s.io/apimachinery => k8s.io/apimachinery v0.32.10
+-replace k8s.io/apimachinery => k8s.io/apimachinery v0.32.10
++replace k8s.io/apimachinery => k8s.io/apimachinery v0.32.13
  
--replace k8s.io/apiserver => k8s.io/apiserver v0.32.0
-+replace k8s.io/apiserver => k8s.io/apiserver v0.32.10
+-replace k8s.io/apiserver => k8s.io/apiserver v0.32.10
++replace k8s.io/apiserver => k8s.io/apiserver v0.32.13
  
--replace k8s.io/cli-runtime => k8s.io/cli-runtime v0.32.0
-+replace k8s.io/cli-runtime => k8s.io/cli-runtime v0.32.10
+-replace k8s.io/cli-runtime => k8s.io/cli-runtime v0.32.10
++replace k8s.io/cli-runtime => k8s.io/cli-runtime v0.32.13
  
--replace k8s.io/client-go => k8s.io/client-go v0.32.0
-+replace k8s.io/client-go => k8s.io/client-go v0.32.10
+-replace k8s.io/client-go => k8s.io/client-go v0.32.10
++replace k8s.io/client-go => k8s.io/client-go v0.32.13
  
--replace k8s.io/cloud-provider => k8s.io/cloud-provider v0.32.0
-+replace k8s.io/cloud-provider => k8s.io/cloud-provider v0.32.10
+-replace k8s.io/cloud-provider => k8s.io/cloud-provider v0.32.10
++replace k8s.io/cloud-provider => k8s.io/cloud-provider v0.32.13
  
--replace k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.32.0
-+replace k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.32.10
+-replace k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.32.10
++replace k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.32.13
  
--replace k8s.io/code-generator => k8s.io/code-generator v0.32.0
-+replace k8s.io/code-generator => k8s.io/code-generator v0.32.10
+-replace k8s.io/code-generator => k8s.io/code-generator v0.32.10
++replace k8s.io/code-generator => k8s.io/code-generator v0.32.13
  
--replace k8s.io/component-base => k8s.io/component-base v0.32.0
-+replace k8s.io/component-base => k8s.io/component-base v0.32.10
+-replace k8s.io/component-base => k8s.io/component-base v0.32.10
++replace k8s.io/component-base => k8s.io/component-base v0.32.13
  
--replace k8s.io/component-helpers => k8s.io/component-helpers v0.32.0
-+replace k8s.io/component-helpers => k8s.io/component-helpers v0.32.10
+-replace k8s.io/component-helpers => k8s.io/component-helpers v0.32.10
++replace k8s.io/component-helpers => k8s.io/component-helpers v0.32.13
  
--replace k8s.io/controller-manager => k8s.io/controller-manager v0.32.0
-+replace k8s.io/controller-manager => k8s.io/controller-manager v0.32.10
+-replace k8s.io/controller-manager => k8s.io/controller-manager v0.32.10
++replace k8s.io/controller-manager => k8s.io/controller-manager v0.32.13
  
--replace k8s.io/cri-api => k8s.io/cri-api v0.32.0
-+replace k8s.io/cri-api => k8s.io/cri-api v0.32.10
+-replace k8s.io/cri-api => k8s.io/cri-api v0.32.10
++replace k8s.io/cri-api => k8s.io/cri-api v0.32.13
  
--replace k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.32.0
-+replace k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.32.10
+-replace k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.32.10
++replace k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.32.13
  
--replace k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.32.0
-+replace k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.32.10
+-replace k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.32.10
++replace k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.32.13
  
--replace k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.32.0
-+replace k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.32.10
+-replace k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.32.10
++replace k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.32.13
  
--replace k8s.io/kube-proxy => k8s.io/kube-proxy v0.32.0
-+replace k8s.io/kube-proxy => k8s.io/kube-proxy v0.32.10
+-replace k8s.io/kube-proxy => k8s.io/kube-proxy v0.32.10
++replace k8s.io/kube-proxy => k8s.io/kube-proxy v0.32.13
  
--replace k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.32.0
-+replace k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.32.10
+-replace k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.32.10
++replace k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.32.13
  
--replace k8s.io/kubectl => k8s.io/kubectl v0.32.0
-+replace k8s.io/kubectl => k8s.io/kubectl v0.32.10
+-replace k8s.io/kubectl => k8s.io/kubectl v0.32.10
++replace k8s.io/kubectl => k8s.io/kubectl v0.32.13
  
--replace k8s.io/kubelet => k8s.io/kubelet v0.32.0
-+replace k8s.io/kubelet => k8s.io/kubelet v0.32.10
+-replace k8s.io/kubelet => k8s.io/kubelet v0.32.10
++replace k8s.io/kubelet => k8s.io/kubelet v0.32.13
  
--replace k8s.io/metrics => k8s.io/metrics v0.32.0
-+replace k8s.io/metrics => k8s.io/metrics v0.32.10
+-replace k8s.io/metrics => k8s.io/metrics v0.32.10
++replace k8s.io/metrics => k8s.io/metrics v0.32.13
  
--replace k8s.io/mount-utils => k8s.io/mount-utils v0.32.0
-+replace k8s.io/mount-utils => k8s.io/mount-utils v0.32.10
+-replace k8s.io/mount-utils => k8s.io/mount-utils v0.32.10
++replace k8s.io/mount-utils => k8s.io/mount-utils v0.32.13
  
--replace k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.32.0
-+replace k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.32.10
+-replace k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.32.10
++replace k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.32.13
  
--replace k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.32.0
-+replace k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.32.10
+-replace k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.32.10
++replace k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.32.13
  
--replace k8s.io/sample-controller => k8s.io/sample-controller v0.32.0
-+replace k8s.io/sample-controller => k8s.io/sample-controller v0.32.10
+-replace k8s.io/sample-controller => k8s.io/sample-controller v0.32.10
++replace k8s.io/sample-controller => k8s.io/sample-controller v0.32.13
  
--replace k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.32.0
-+replace k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.32.10
+-replace k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.32.10
++replace k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.32.13
  
--replace k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.32.0
-+replace k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.32.10
+-replace k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.32.10
++replace k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.32.13
  
--replace k8s.io/kms => k8s.io/kms v0.32.0
-+replace k8s.io/kms => k8s.io/kms v0.32.10
+-replace k8s.io/kms => k8s.io/kms v0.32.10
++replace k8s.io/kms => k8s.io/kms v0.32.13
  
--replace k8s.io/endpointslice => k8s.io/endpointslice v0.32.0
-+replace k8s.io/endpointslice => k8s.io/endpointslice v0.32.10
+-replace k8s.io/endpointslice => k8s.io/endpointslice v0.32.10
++replace k8s.io/endpointslice => k8s.io/endpointslice v0.32.13
  
  replace k8s.io/autoscaler/cluster-autoscaler/apis => ./apis
  
--replace k8s.io/cri-client => k8s.io/cri-client v0.32.0
-+replace k8s.io/cri-client => k8s.io/cri-client v0.32.10
+-replace k8s.io/cri-client => k8s.io/cri-client v0.32.10
++replace k8s.io/cri-client => k8s.io/cri-client v0.32.13
  
--replace k8s.io/externaljwt => k8s.io/externaljwt v0.32.0
-+replace k8s.io/externaljwt => k8s.io/externaljwt v0.32.10
+-replace k8s.io/externaljwt => k8s.io/externaljwt v0.32.10
++replace k8s.io/externaljwt => k8s.io/externaljwt v0.32.13
 diff --git a/cluster-autoscaler/go.sum b/cluster-autoscaler/go.sum
-index 9b0cd1165..128e97da5 100644
+index a5e3f564e..c9ca3fb97 100644
 --- a/cluster-autoscaler/go.sum
 +++ b/cluster-autoscaler/go.sum
-@@ -11,10 +11,10 @@ github.com/Azure/azure-sdk-for-go-extensions v0.1.6 h1:EXGvDcj54u98XfaI/Cy65Ds6v
- github.com/Azure/azure-sdk-for-go-extensions v0.1.6/go.mod h1:27StPiXJp6Xzkq2AQL7gPK7VC0hgmCnUKlco1dO1jaM=
- github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.1 h1:E+OJmp2tPvt1W+amx48v1eqbjDYsgN+RzP4q16yV5eM=
- github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.1/go.mod h1:a6xsAQUZg+VsS3TJ05SRp524Hs4pZ/AeFSr5ENf0Yjo=
--github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.5.2 h1:FDif4R1+UUR+00q6wquyX90K7A8dN+R5E8GEadoP7sU=
--github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.5.2/go.mod h1:aiYBYui4BJ/BJCAIKs92XiPyQfTaBWqvHujDwKb6CBU=
--github.com/Azure/azure-sdk-for-go/sdk/internal v1.5.2 h1:LqbJ/WzJUwBf8UiaSzgX7aMclParm9/5Vgp+TY51uBQ=
--github.com/Azure/azure-sdk-for-go/sdk/internal v1.5.2/go.mod h1:yInRyqWXAuaPrgI7p70+lDDgh3mlBohis29jGMISnmc=
-+github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.6.0 h1:U2rTu3Ef+7w9FHKIAXM6ZyqF3UOWJZ12zIm8zECAFfg=
-+github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.6.0/go.mod h1:9kIvujWAA58nmPmWB1m23fyWic1kYZMxD9CxaWn4Qpg=
-+github.com/Azure/azure-sdk-for-go/sdk/internal v1.8.0 h1:jBQA3cKT4L2rWMpgE7Yt3Hwh2aUj8KXjIGLxjHeYNNo=
-+github.com/Azure/azure-sdk-for-go/sdk/internal v1.8.0/go.mod h1:4OG6tQ9EOP/MT0NMjDlRzWoVFxfu9rN9B2X+tlSVktg=
- github.com/Azure/azure-sdk-for-go/sdk/keyvault/azsecrets v0.12.0 h1:xnO4sFyG8UH2fElBkcqLTOZsAajvKfnSlgBBW8dXYjw=
- github.com/Azure/azure-sdk-for-go/sdk/keyvault/azsecrets v0.12.0/go.mod h1:XD3DIOOVgBCO03OleB1fHjgktVRFxlT++KwKgIOewdM=
- github.com/Azure/azure-sdk-for-go/sdk/keyvault/internal v0.7.1 h1:FbH3BbSb4bvGluTesZZ+ttN/MDsnMmQP36OSnDuSXqw=
-@@ -86,8 +86,8 @@ github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab h1:UKkYhof1njT1
- github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab/go.mod h1:3VYc5hodBMJ5+l/7J4xAyMeuM2PNuepvHlGs8yilUCA=
- github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
- github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
--github.com/Microsoft/hnslib v0.0.8 h1:EBrIiRB7i/UYIXEC2yw22dn+RLzOmsc5S0bw2xf0Qus=
--github.com/Microsoft/hnslib v0.0.8/go.mod h1:EYveQJlhKh2obmEIRB3uKN6dBd9pj1frPsrTGFppKuk=
-+github.com/Microsoft/hnslib v0.1.1 h1:JsZy681SnvSOUAfCZVAxkX4LgQGp+CZZwPbLV0/pdF8=
-+github.com/Microsoft/hnslib v0.1.1/go.mod h1:DRQR4IjLae6WHYVhW7uqe44hmFUiNhmaWA+jwMbz5tM=
- github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cqUQ3I=
- github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
- github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=
-@@ -129,8 +129,8 @@ github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8
- github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
- github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
- github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
--github.com/cyphar/filepath-securejoin v0.3.4 h1:VBWugsJh2ZxJmLFSM06/0qzQyiQX2Qs0ViKrUAcqdZ8=
--github.com/cyphar/filepath-securejoin v0.3.4/go.mod h1:8s/MCNJREmFK0H02MF6Ihv1nakJe4L/w3WZLHNkvlYM=
-+github.com/cyphar/filepath-securejoin v0.5.1 h1:eYgfMq5yryL4fbWfkLpFFy2ukSELzaJOTaUTuh+oF48=
-+github.com/cyphar/filepath-securejoin v0.5.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
- github.com/dave/jennifer v1.6.0 h1:MQ/6emI2xM7wt0tJzJzyUik2Q3Tcn2eE0vtYgh4GPVI=
- github.com/dave/jennifer v1.6.0/go.mod h1:AxTG893FiZKqxy3FP1kL80VMshSMuz2G+EgvszgGRnk=
- github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-@@ -194,10 +194,11 @@ github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
- github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
- github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
- github.com/golang-jwt/jwt/v4 v4.2.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
--github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
- github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
--github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
--github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
-+github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
-+github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
-+github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
-+github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
- github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
- github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
- github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
-@@ -326,12 +327,12 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
- github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
- github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQb2IpWsCzug=
- github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
--github.com/opencontainers/runc v1.2.1 h1:mQkmeFSUxqFaVmvIn1VQPeQIKpHFya5R07aJw0DKQa8=
--github.com/opencontainers/runc v1.2.1/go.mod h1:/PXzF0h531HTMsYQnmxXkBD7YaGShm/2zcRB79dksUc=
-+github.com/opencontainers/runc v1.2.8 h1:RnEICeDReapbZ5lZEgHvj7E9Q3Eex9toYmaGBsbvU5Q=
-+github.com/opencontainers/runc v1.2.8/go.mod h1:cC0YkmZcuvr+rtBZ6T7NBoVbMGNAdLa/21vIElJDOzI=
- github.com/opencontainers/runtime-spec v1.2.0 h1:z97+pHb3uELt/yiAWD691HNHQIF07bE7dzrbT927iTk=
- github.com/opencontainers/runtime-spec v1.2.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
--github.com/opencontainers/selinux v1.11.1 h1:nHFvthhM0qY8/m+vfhJylliSshm8G1jJ2jDMcgULaH8=
--github.com/opencontainers/selinux v1.11.1/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M586T4DlDRYpFkyec=
-+github.com/opencontainers/selinux v1.12.0 h1:6n5JV4Cf+4y0KNXW48TLj5DwfXpvWlxXplUkdTrmPb8=
-+github.com/opencontainers/selinux v1.12.0/go.mod h1:BTPX+bjVbWGXw7ZZWUbdENt8w0htPSrlgOOysQaU62U=
- github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
- github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
- github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-@@ -404,14 +405,14 @@ go.etcd.io/etcd/server/v3 v3.5.16 h1:d0/SAdJ3vVsZvF8IFVb1k8zqMZ+heGcNfft71ul9GWE
- go.etcd.io/etcd/server/v3 v3.5.16/go.mod h1:ynhyZZpdDp1Gq49jkUg5mfkDWZwXnn3eIqCqtJnrD/s=
- go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
- go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
--go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful v0.42.0 h1:Z6SbqeRZAl2OczfkFOqLx1BeYBDYehNjEnqluD7581Y=
--go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful v0.42.0/go.mod h1:XiglO+8SPMqM3Mqh5/rtxR1VHc63o8tb38QrU6tm4mU=
-+go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful v0.44.0 h1:KemlMZlVwBSEGaO91WKgp41BBFsnWqqj9sKRwmOqC40=
-+go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful v0.44.0/go.mod h1:uq8DrRaen3suIWTpdR/JNHCGpurSvMv9D5Nr5CU5TXc=
- go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.53.0 h1:9G6E0TXzGFVfTnawRzrPl83iHOAV7L8NJiR8RSGYV1g=
- go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.53.0/go.mod h1:azvtTADFQJA8mX80jIH/akaE7h+dbm/sVuaHqN13w74=
- go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.53.0 h1:4K4tsIXefpVJtvA/8srF4V4y0akAoPHkIslgAkjixJA=
- go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.53.0/go.mod h1:jjdQuTGVsXV4vSs+CJ2qYDeDPf9yIJV23qlIzBm73Vg=
--go.opentelemetry.io/contrib/propagators/b3 v1.17.0 h1:ImOVvHnku8jijXqkwCSyYKRDt2YrnGXD4BbhcpfbfJo=
--go.opentelemetry.io/contrib/propagators/b3 v1.17.0/go.mod h1:IkfUfMpKWmynvvE0264trz0sf32NRTZL4nuAN9AbWRc=
-+go.opentelemetry.io/contrib/propagators/b3 v1.19.0 h1:ulz44cpm6V5oAeg5Aw9HyqGFMS6XM7untlMEhD7YzzA=
-+go.opentelemetry.io/contrib/propagators/b3 v1.19.0/go.mod h1:OzCmE2IVS+asTI+odXQstRGVfXQ4bXv9nMBRK0nNyqQ=
- go.opentelemetry.io/otel v1.28.0 h1:/SqNcYk+idO0CxKEUOtKQClMK/MimZihKYMruSMViUo=
- go.opentelemetry.io/otel v1.28.0/go.mod h1:q68ijF8Fc8CnMHKyzqL6akLO46ePnjkgfIMIjUIX9z4=
- go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.28.0 h1:3Q/xZUyC1BBkualc9ROb4G8qkH90LXEIICcs5zv1OYY=
-@@ -442,8 +443,8 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
+@@ -446,8 +446,8 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
  golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
  golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58=
  golang.org/x/crypto v0.17.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
@@ -474,7 +301,7 @@ index 9b0cd1165..128e97da5 100644
  golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
  golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 h1:2dVuKD2vS7b0QIHQbpyTISPd0LeHDbnYEryqj5Q1ug8=
  golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56/go.mod h1:M4RDyNAINzryxdtnbRXRL/OHtkFuWGRjvuhBJpk2IlY=
-@@ -455,8 +456,8 @@ golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+@@ -459,8 +459,8 @@ golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
  golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
  golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
  golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
@@ -485,7 +312,7 @@ index 9b0cd1165..128e97da5 100644
  golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
  golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
  golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
-@@ -474,12 +475,12 @@ golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug
+@@ -478,8 +478,8 @@ golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug
  golang.org/x/net v0.1.0/go.mod h1:Cx3nUiGt4eDBEyega/BKRp+/AlGL8hYe7U9odMt2Cco=
  golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
  golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
@@ -495,14 +322,8 @@ index 9b0cd1165..128e97da5 100644
 +golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
  golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
  golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
--golang.org/x/oauth2 v0.23.0 h1:PbgcYx2W7i4LvjJWEbf0ngHV6qJYr86PkAV3bXdLEbs=
--golang.org/x/oauth2 v0.23.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
-+golang.org/x/oauth2 v0.27.0 h1:da9Vo7/tDv5RH/7nZDz1eMGS/q1Vv1N/7FCrBhI9I3M=
-+golang.org/x/oauth2 v0.27.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT8=
- golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
- golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
- golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-@@ -489,8 +490,8 @@ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJ
+ golang.org/x/oauth2 v0.23.0 h1:PbgcYx2W7i4LvjJWEbf0ngHV6qJYr86PkAV3bXdLEbs=
+@@ -493,8 +493,8 @@ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJ
  golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
  golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
  golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -513,7 +334,7 @@ index 9b0cd1165..128e97da5 100644
  golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
  golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
  golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-@@ -507,16 +508,16 @@ golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+@@ -511,16 +511,16 @@ golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
  golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
  golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
  golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
@@ -534,7 +355,7 @@ index 9b0cd1165..128e97da5 100644
  golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
  golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
  golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-@@ -525,8 +526,8 @@ golang.org/x/text v0.4.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
+@@ -529,8 +529,8 @@ golang.org/x/text v0.4.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
  golang.org/x/text v0.7.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
  golang.org/x/text v0.9.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=
  golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
@@ -545,7 +366,7 @@ index 9b0cd1165..128e97da5 100644
  golang.org/x/time v0.7.0 h1:ntUhktv3OPE6TgYxXWv9vKvUSJyIFJlyohwbkEwPrKQ=
  golang.org/x/time v0.7.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
  golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
-@@ -540,8 +541,12 @@ golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4f
+@@ -544,8 +544,12 @@ golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4f
  golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
  golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
  golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
@@ -560,100 +381,100 @@ index 9b0cd1165..128e97da5 100644
  golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
  golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
  golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-@@ -600,56 +605,56 @@ gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+@@ -604,56 +608,56 @@ gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
  gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
  honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
  honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
--k8s.io/api v0.32.0 h1:OL9JpbvAU5ny9ga2fb24X8H6xQlVp+aJMFlgtQjR9CE=
--k8s.io/api v0.32.0/go.mod h1:4LEwHZEf6Q/cG96F3dqR965sYOfmPM7rq81BLgsE0p0=
--k8s.io/apiextensions-apiserver v0.32.0 h1:S0Xlqt51qzzqjKPxfgX1xh4HBZE+p8KKBq+k2SWNOE0=
--k8s.io/apiextensions-apiserver v0.32.0/go.mod h1:86hblMvN5yxMvZrZFX2OhIHAuFIMJIZ19bTvzkP+Fmw=
--k8s.io/apimachinery v0.32.0 h1:cFSE7N3rmEEtv4ei5X6DaJPHHX0C+upp+v5lVPiEwpg=
--k8s.io/apimachinery v0.32.0/go.mod h1:GpHVgxoKlTxClKcteaeuF1Ul/lDVb74KpZcxcmLDElE=
--k8s.io/apiserver v0.32.0 h1:VJ89ZvQZ8p1sLeiWdRJpRD6oLozNZD2+qVSLi+ft5Qs=
--k8s.io/apiserver v0.32.0/go.mod h1:HFh+dM1/BE/Hm4bS4nTXHVfN6Z6tFIZPi649n83b4Ag=
--k8s.io/client-go v0.32.0 h1:DimtMcnN/JIKZcrSrstiwvvZvLjG0aSxy8PxN8IChp8=
--k8s.io/client-go v0.32.0/go.mod h1:boDWvdM1Drk4NJj/VddSLnx59X3OPgwrOo0vGbtq9+8=
--k8s.io/cloud-provider v0.32.0 h1:QXYJGmwME2q2rprymbmw2GroMChQYc/MWN6l/I4Kgp8=
--k8s.io/cloud-provider v0.32.0/go.mod h1:cz3gVodkhgwi2ugj/JUPglIruLSdDaThxawuDyCHfr8=
-+k8s.io/api v0.32.10 h1:ocp4turNfa1V40TuBW/LuA17TeXG9g/GI2ebg0KxBNk=
-+k8s.io/api v0.32.10/go.mod h1:AsMsc4b6TuampYqgMEGSv0HBFpRS4BlKTXAVCAa7oF4=
-+k8s.io/apiextensions-apiserver v0.32.10 h1:mAZT8fX/jM9pl7qWkFhhsjQZ8ZkmAhEivfUNw8uKXmo=
-+k8s.io/apiextensions-apiserver v0.32.10/go.mod h1:wEvqU9kFUQOYminqrroY6+fvSs6iMb7QiiFmcN3b6KY=
-+k8s.io/apimachinery v0.32.10 h1:SAg2kUPLYRcBJQj66oniP1BnXSqw+l1GvJFsJlBmVvQ=
-+k8s.io/apimachinery v0.32.10/go.mod h1:GpHVgxoKlTxClKcteaeuF1Ul/lDVb74KpZcxcmLDElE=
-+k8s.io/apiserver v0.32.10 h1:nRUv9Q/OFHVjl/50TgNDlzw37wjTI0j+Ywp0gWqvQfs=
-+k8s.io/apiserver v0.32.10/go.mod h1:BV9Wgt44Rop5I0cYsh2NYQstHu16ou4uirh95yTbioc=
-+k8s.io/client-go v0.32.10 h1:MFmIjsKtcnn7mStjrJG1ZW2WzLsKKn6ZtL9hHM/W0xU=
-+k8s.io/client-go v0.32.10/go.mod h1:qJy/Ws3zSwnu/nD75D+/of1uxbwWHxrYT5P3FuobVLI=
-+k8s.io/cloud-provider v0.32.10 h1:S6OFOKlKYTM4PxdOFoihrXbbNuT5D1Q5pLtpfRN/LhM=
-+k8s.io/cloud-provider v0.32.10/go.mod h1:+yQAZWtdYbLk72vjtaZpN9wtn4UBUoOZc7JddFcjIec=
+-k8s.io/api v0.32.10 h1:ocp4turNfa1V40TuBW/LuA17TeXG9g/GI2ebg0KxBNk=
+-k8s.io/api v0.32.10/go.mod h1:AsMsc4b6TuampYqgMEGSv0HBFpRS4BlKTXAVCAa7oF4=
+-k8s.io/apiextensions-apiserver v0.32.10 h1:mAZT8fX/jM9pl7qWkFhhsjQZ8ZkmAhEivfUNw8uKXmo=
+-k8s.io/apiextensions-apiserver v0.32.10/go.mod h1:wEvqU9kFUQOYminqrroY6+fvSs6iMb7QiiFmcN3b6KY=
+-k8s.io/apimachinery v0.32.10 h1:SAg2kUPLYRcBJQj66oniP1BnXSqw+l1GvJFsJlBmVvQ=
+-k8s.io/apimachinery v0.32.10/go.mod h1:GpHVgxoKlTxClKcteaeuF1Ul/lDVb74KpZcxcmLDElE=
+-k8s.io/apiserver v0.32.10 h1:nRUv9Q/OFHVjl/50TgNDlzw37wjTI0j+Ywp0gWqvQfs=
+-k8s.io/apiserver v0.32.10/go.mod h1:BV9Wgt44Rop5I0cYsh2NYQstHu16ou4uirh95yTbioc=
+-k8s.io/client-go v0.32.10 h1:MFmIjsKtcnn7mStjrJG1ZW2WzLsKKn6ZtL9hHM/W0xU=
+-k8s.io/client-go v0.32.10/go.mod h1:qJy/Ws3zSwnu/nD75D+/of1uxbwWHxrYT5P3FuobVLI=
+-k8s.io/cloud-provider v0.32.10 h1:S6OFOKlKYTM4PxdOFoihrXbbNuT5D1Q5pLtpfRN/LhM=
+-k8s.io/cloud-provider v0.32.10/go.mod h1:+yQAZWtdYbLk72vjtaZpN9wtn4UBUoOZc7JddFcjIec=
++k8s.io/api v0.32.13 h1:CAtHUTtSau6UhSGcrypjKXc2365TncaxUtrIfnjUPGE=
++k8s.io/api v0.32.13/go.mod h1:PXqm+/G56aRPUJWUb8nGwBDovaXcqQ+e3o6+ZJIITPY=
++k8s.io/apiextensions-apiserver v0.32.13 h1:3M8y1UNKgAp/I+T4TDEeqXiR1wj8nrqzTqgMHRKsO8A=
++k8s.io/apiextensions-apiserver v0.32.13/go.mod h1:IMU3eme+2CoGzlmiHVcl6v08u3dRzebcBTnop09cwpY=
++k8s.io/apimachinery v0.32.13 h1:OQ1djPkMwU8F9BQwZUW314DdYsalB8hRvBgLRqimJdo=
++k8s.io/apimachinery v0.32.13/go.mod h1:GpHVgxoKlTxClKcteaeuF1Ul/lDVb74KpZcxcmLDElE=
++k8s.io/apiserver v0.32.13 h1:oakvP13+5KyJSKo01uV6AD9n5oXOsQghSrpayYfeHeg=
++k8s.io/apiserver v0.32.13/go.mod h1:3FGYjbrMtFOUx0p37vn4cEUWWO/a90fNTe/SIn2gaaQ=
++k8s.io/client-go v0.32.13 h1:FxVdGzgrWW8QBprX/xJjoxs9tE06UJIbuy8IfNoxn0c=
++k8s.io/client-go v0.32.13/go.mod h1:XhErcCmtSRUns7g0fXYjV8NAXvJWHQCT9EaYkf4dbyw=
++k8s.io/cloud-provider v0.32.13 h1:v2iz8ukTBgK4KLF48Qzwkh5egegixCRzsfJmYrjyqfE=
++k8s.io/cloud-provider v0.32.13/go.mod h1:p5O1oZcqJNl6d5WzEtHFMUorUG9j/pk9DrxITM54xJo=
  k8s.io/cloud-provider-aws v1.27.0 h1:PF8YrH8QcN6JoXB3Xxlaz84SBDYMPunJuCc0cPuCWXA=
  k8s.io/cloud-provider-aws v1.27.0/go.mod h1:9vUb5mnVnReSRDBWcBxB1b0HOeEc472iOPmrnwpN9SA=
  k8s.io/cloud-provider-gcp/providers v0.28.2 h1:I65pFTLNMQSj7YuW3Mg3pZIXmw0naCmF6TGAuz4/sZE=
  k8s.io/cloud-provider-gcp/providers v0.28.2/go.mod h1:P8dxRvvLtX7xUwVUzA/QOqv8taCzBaVsVMnjnpjmYXE=
--k8s.io/code-generator v0.32.0 h1:s0lNN8VSWny8LBz5t5iy7MCdgwdOhdg7vAGVxvS+VWU=
--k8s.io/code-generator v0.32.0/go.mod h1:b7Q7KMZkvsYFy72A79QYjiv4aTz3GvW0f1T3UfhFq4s=
--k8s.io/component-base v0.32.0 h1:d6cWHZkCiiep41ObYQS6IcgzOUQUNpywm39KVYaUqzU=
--k8s.io/component-base v0.32.0/go.mod h1:JLG2W5TUxUu5uDyKiH2R/7NnxJo1HlPoRIIbVLkK5eM=
--k8s.io/component-helpers v0.32.0 h1:pQEEBmRt3pDJJX98cQvZshDgJFeKRM4YtYkMmfOlczw=
--k8s.io/component-helpers v0.32.0/go.mod h1:9RuClQatbClcokXOcDWSzFKQm1huIf0FzQlPRpizlMc=
--k8s.io/controller-manager v0.32.0 h1:tpQl1rvH4huFB6Avl1nhowZHtZoCNWqn6OYdZPl7Ybc=
--k8s.io/controller-manager v0.32.0/go.mod h1:JRuYnYCkKj3NgBTy+KNQKIUm/lJRoDAvGbfdEmk9LhY=
--k8s.io/cri-api v0.32.0 h1:pzXJfyG7Tm4acrEt5HPqAq3r4cN5guLeapAN/NM2b70=
--k8s.io/cri-api v0.32.0/go.mod h1:DCzMuTh2padoinefWME0G678Mc3QFbLMF2vEweGzBAI=
--k8s.io/cri-client v0.32.0 h1:K6aTYDyS2AS8O4h79eI5r26562xstdybprtaaszjn+E=
--k8s.io/cri-client v0.32.0/go.mod h1:FB8qZNj8KrwIFfVIR2zBGb+l6KUhrp+k8YFsVp3D+kw=
--k8s.io/csi-translation-lib v0.32.0 h1:RAn9RGgYXHJQtDSb6qQ7zvq6QObOejzmsXDARI+f4OQ=
--k8s.io/csi-translation-lib v0.32.0/go.mod h1:TjCJzkTNstdOESAXNnEImrYOMIEzP14aqM7H+vkehqw=
--k8s.io/dynamic-resource-allocation v0.32.0 h1:0ZLSCKzlLZLVwKHxg6vafpd2U8b7jPMO3k8bbMFodis=
--k8s.io/dynamic-resource-allocation v0.32.0/go.mod h1:MfoAUi0vCJtchNirAVk7c3IYfGGB3n+zbZ9GuyX4eeo=
-+k8s.io/code-generator v0.32.10 h1:H8MF03Ad6isbGI6tnotITdaBEwxQjVFdpC6AxhoYuaI=
-+k8s.io/code-generator v0.32.10/go.mod h1:fmTm8F2FNPlr+IUvZ17U1wOTY3/soDIc++m4g+lC1PQ=
-+k8s.io/component-base v0.32.10 h1:9+8Pw0fasOWPNHeQKmf38TFI7Zdi1k38sOIm0jQdSV4=
-+k8s.io/component-base v0.32.10/go.mod h1:Tou3W1f6+8i5svBQ0Sef3jpkSZ0k6q2QdXbQSn4c9do=
-+k8s.io/component-helpers v0.32.10 h1:hMdA0wF5GkUAqjtY/d4y5WJK1OqvdAA0xREL1OceXS0=
-+k8s.io/component-helpers v0.32.10/go.mod h1:bSxQeNzLYUrll2RFtkVTXKFnjVrgb5OWSIgW4rECOus=
-+k8s.io/controller-manager v0.32.10 h1:B2rGlwJfCBYSf1AXf9FQkrvS98Fqg0RZh0gud30mkZY=
-+k8s.io/controller-manager v0.32.10/go.mod h1:Jl6E8fwRfg0sSY/Schef/9UKdIlxRmnyaa3ZUaVeay4=
-+k8s.io/cri-api v0.32.10 h1:xdFaVDpNupzgTIRiK4onsHZqpc8exxLl1jia4p8IakQ=
-+k8s.io/cri-api v0.32.10/go.mod h1:DCzMuTh2padoinefWME0G678Mc3QFbLMF2vEweGzBAI=
-+k8s.io/cri-client v0.32.10 h1:N+nlAkzATstdp+mUQwtX3qqFUa7Oudb7jgRoZeM18IA=
-+k8s.io/cri-client v0.32.10/go.mod h1:C6NVDMhnIUwIpGy7uFfrvFmRzVncI0JIRyW9p1Apxts=
-+k8s.io/csi-translation-lib v0.32.10 h1:JP4LPb+VvN4Id/dEuqGIa8VR7kyquwQskjWt+1ujbsM=
-+k8s.io/csi-translation-lib v0.32.10/go.mod h1:DR+qW9I2dvPqHdYdCVBRDFnp56JcJaWhNQbFbRHM0xg=
-+k8s.io/dynamic-resource-allocation v0.32.10 h1:cfmonTCEjWCjBg+LyI+WDMk6oGzTCu1F0rbK8peCDTw=
-+k8s.io/dynamic-resource-allocation v0.32.10/go.mod h1:6PInlWzINIGVruu42ytyk5PFBKK7USwepIWk/w8sRyw=
+-k8s.io/code-generator v0.32.10 h1:H8MF03Ad6isbGI6tnotITdaBEwxQjVFdpC6AxhoYuaI=
+-k8s.io/code-generator v0.32.10/go.mod h1:fmTm8F2FNPlr+IUvZ17U1wOTY3/soDIc++m4g+lC1PQ=
+-k8s.io/component-base v0.32.10 h1:9+8Pw0fasOWPNHeQKmf38TFI7Zdi1k38sOIm0jQdSV4=
+-k8s.io/component-base v0.32.10/go.mod h1:Tou3W1f6+8i5svBQ0Sef3jpkSZ0k6q2QdXbQSn4c9do=
+-k8s.io/component-helpers v0.32.10 h1:hMdA0wF5GkUAqjtY/d4y5WJK1OqvdAA0xREL1OceXS0=
+-k8s.io/component-helpers v0.32.10/go.mod h1:bSxQeNzLYUrll2RFtkVTXKFnjVrgb5OWSIgW4rECOus=
+-k8s.io/controller-manager v0.32.10 h1:B2rGlwJfCBYSf1AXf9FQkrvS98Fqg0RZh0gud30mkZY=
+-k8s.io/controller-manager v0.32.10/go.mod h1:Jl6E8fwRfg0sSY/Schef/9UKdIlxRmnyaa3ZUaVeay4=
+-k8s.io/cri-api v0.32.10 h1:xdFaVDpNupzgTIRiK4onsHZqpc8exxLl1jia4p8IakQ=
+-k8s.io/cri-api v0.32.10/go.mod h1:DCzMuTh2padoinefWME0G678Mc3QFbLMF2vEweGzBAI=
+-k8s.io/cri-client v0.32.10 h1:N+nlAkzATstdp+mUQwtX3qqFUa7Oudb7jgRoZeM18IA=
+-k8s.io/cri-client v0.32.10/go.mod h1:C6NVDMhnIUwIpGy7uFfrvFmRzVncI0JIRyW9p1Apxts=
+-k8s.io/csi-translation-lib v0.32.10 h1:JP4LPb+VvN4Id/dEuqGIa8VR7kyquwQskjWt+1ujbsM=
+-k8s.io/csi-translation-lib v0.32.10/go.mod h1:DR+qW9I2dvPqHdYdCVBRDFnp56JcJaWhNQbFbRHM0xg=
+-k8s.io/dynamic-resource-allocation v0.32.10 h1:cfmonTCEjWCjBg+LyI+WDMk6oGzTCu1F0rbK8peCDTw=
+-k8s.io/dynamic-resource-allocation v0.32.10/go.mod h1:6PInlWzINIGVruu42ytyk5PFBKK7USwepIWk/w8sRyw=
++k8s.io/code-generator v0.32.13 h1:s8F2Mg5el0vnDJHqIJl1WhVbbk3J38CmQc5Y6j5bmHQ=
++k8s.io/code-generator v0.32.13/go.mod h1:rtEcqtalEPQU2cOgjWrX7RQ/x/Lr65pwu7givcfjfx0=
++k8s.io/component-base v0.32.13 h1:QTroT4xOtYXc8ySp7Wvj5llxDNxz16YoG5Pw3zJBMds=
++k8s.io/component-base v0.32.13/go.mod h1:hfuVb9GlAuoIXRimoph+0e862qEwxRA7h+6oOIFelCE=
++k8s.io/component-helpers v0.32.13 h1:3QkTkm4K8ESUof270faqsQGShad1OxYvLGquLoKlDog=
++k8s.io/component-helpers v0.32.13/go.mod h1:Hp7dV/PAyotFPhYwHDsv3Udk+X+4w+Yo+J6vF5v/Ilg=
++k8s.io/controller-manager v0.32.13 h1:2FbFxVEveGJp5Qqju9jRedZs4oBBSCyNQI5QXbO23lI=
++k8s.io/controller-manager v0.32.13/go.mod h1:Ft4FhkzDpsxdK01chn707UDeUHkcxqMzuLRSkvDNhZs=
++k8s.io/cri-api v0.32.13 h1:mfGwZwffjIgpXpeYq+PiblsOk3qPbFlhPGtqYUdHwWs=
++k8s.io/cri-api v0.32.13/go.mod h1:DCzMuTh2padoinefWME0G678Mc3QFbLMF2vEweGzBAI=
++k8s.io/cri-client v0.32.13 h1:d23awOed1UyMsTGxAYyfu/X7XWUYk6FB5dbLQCpudRI=
++k8s.io/cri-client v0.32.13/go.mod h1:iVKB6Srg9yZfNn6IOcHM4r4QCnReL7pKSOH0JDOmFV8=
++k8s.io/csi-translation-lib v0.32.13 h1:c3rk2yi4jAUnkXZYhC/bcv8skipWuptHqsalTeEqz5I=
++k8s.io/csi-translation-lib v0.32.13/go.mod h1:xviC437IUkLGiLuIwmY3xkw/3dVO6f/NJO2feDP07bU=
++k8s.io/dynamic-resource-allocation v0.32.13 h1:Qb75vl8aP0AxCMQ1SYjpK1xCTIDJ/MJ/Xn610RmKYu8=
++k8s.io/dynamic-resource-allocation v0.32.13/go.mod h1:cuv8T2IVH3+aKRBjc9S0IkYASzGvDOGQI6Ruc3LNihU=
  k8s.io/gengo/v2 v2.0.0-20240911193312-2b36238f13e9 h1:si3PfKm8dDYxgfbeA6orqrtLkvvIeH8UqffFJDl0bz4=
  k8s.io/gengo/v2 v2.0.0-20240911193312-2b36238f13e9/go.mod h1:EJykeLsmFC60UQbYJezXkEsG2FLrt0GPNkU5iK5GWxU=
  k8s.io/klog/v2 v2.130.1 h1:n9Xl7H1Xvksem4KFG4PYbdQCQxqc/tTUyrgXaOhHSzk=
  k8s.io/klog/v2 v2.130.1/go.mod h1:3Jpz1GvMt720eyJH1ckRHK1EDfpxISzJ7I9OYgaDtPE=
--k8s.io/kms v0.32.0 h1:jwOfunHIrcdYl5FRcA+uUKKtg6qiqoPCwmS2T3XTYL4=
--k8s.io/kms v0.32.0/go.mod h1:Bk2evz/Yvk0oVrvm4MvZbgq8BD34Ksxs2SRHn4/UiOM=
-+k8s.io/kms v0.32.10 h1:TOKCISpp+fmWZyHyfNLExW5oeYgFdqHc1j7Ibux+XdQ=
-+k8s.io/kms v0.32.10/go.mod h1:Bk2evz/Yvk0oVrvm4MvZbgq8BD34Ksxs2SRHn4/UiOM=
+-k8s.io/kms v0.32.10 h1:TOKCISpp+fmWZyHyfNLExW5oeYgFdqHc1j7Ibux+XdQ=
+-k8s.io/kms v0.32.10/go.mod h1:Bk2evz/Yvk0oVrvm4MvZbgq8BD34Ksxs2SRHn4/UiOM=
++k8s.io/kms v0.32.13 h1:z+h7bcmb9gZBEqunJAOVoNZsyIY2S4eTb1qcvpJ0Fu4=
++k8s.io/kms v0.32.13/go.mod h1:Bk2evz/Yvk0oVrvm4MvZbgq8BD34Ksxs2SRHn4/UiOM=
  k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f h1:GA7//TjRY9yWGy1poLzYYJJ4JRdzg3+O6e8I+e+8T5Y=
  k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f/go.mod h1:R/HEjbvWI0qdfb8viZUeVZm0X6IZnxAydC7YU42CMw4=
--k8s.io/kube-scheduler v0.32.0 h1:FCsF/3TPvR51ptx/gLUrqcoKqAMhQKrydYCJzPz9VGM=
--k8s.io/kube-scheduler v0.32.0/go.mod h1:yof3vmyx70TWoQ6XZruYEGIUT/r0H/ELGdnWiqPF5EE=
--k8s.io/kubectl v0.32.0 h1:rpxl+ng9qeG79YA4Em9tLSfX0G8W0vfaiPVrc/WR7Xw=
--k8s.io/kubectl v0.32.0/go.mod h1:qIjSX+QgPQUgdy8ps6eKsYNF+YmFOAO3WygfucIqFiE=
--k8s.io/kubelet v0.32.0 h1:uLyiKlz195Wo4an/K2tyge8o3QHx0ZkhVN3pevvp59A=
--k8s.io/kubelet v0.32.0/go.mod h1:lAwuVZT/Hm7EdLn0jW2D+WdrJoorjJL2rVSdhOFnegw=
--k8s.io/kubernetes v1.32.0 h1:4BDBWSolqPrv8GC3YfZw0CJvh5kA1TPnoX0FxDVd+qc=
--k8s.io/kubernetes v1.32.0/go.mod h1:tiIKO63GcdPRBHW2WiUFm3C0eoLczl3f7qi56Dm1W8I=
--k8s.io/mount-utils v0.32.0 h1:KOQAhPzJICATXnc6XCkWoexKbkOexRnMCUW8APFfwg4=
--k8s.io/mount-utils v0.32.0/go.mod h1:Kun5c2svjAPx0nnvJKYQWhfeNW+O0EpzHgRhDcYoSY0=
-+k8s.io/kube-scheduler v0.32.10 h1:GviS8C1FtRaN7ser+YMteLjBorH/efdq28CBdcmydfQ=
-+k8s.io/kube-scheduler v0.32.10/go.mod h1:NIbZnbqbw5OukAJWnvZv+wUn753u1LeZX8BvNYcFpQ0=
-+k8s.io/kubectl v0.32.10 h1:sXYKAl9C/HlLrRYHrcvLqMBXOuWrQLC5R3eNz7UMKnU=
-+k8s.io/kubectl v0.32.10/go.mod h1:9ZslQAVI9567FnBQxGR7npMC+HhzbVrKRaRxVdpe+LQ=
-+k8s.io/kubelet v0.32.10 h1:MOogwP/TkfLJ9fl/BwzgmBXILaGu2wl+P4BIwtcmyXw=
-+k8s.io/kubelet v0.32.10/go.mod h1:HmNTDI+zxjvIotTQIL50zqGySoqRIbJTgAY49iH9ILM=
-+k8s.io/kubernetes v1.32.10 h1:yiRa8DyKp4Yrbv028MP6kpp5N1N3eO8Hp/tSCbBGIPE=
-+k8s.io/kubernetes v1.32.10/go.mod h1:o2pRStsMR7Uq62zcugfUEQsxnuyFt9r8migMrbsVH00=
-+k8s.io/mount-utils v0.32.10 h1:cSz/3jAaPTkSfJUOfOTB0HPCZYcxZaY2moDiRBS96LU=
-+k8s.io/mount-utils v0.32.10/go.mod h1:Kun5c2svjAPx0nnvJKYQWhfeNW+O0EpzHgRhDcYoSY0=
+-k8s.io/kube-scheduler v0.32.10 h1:GviS8C1FtRaN7ser+YMteLjBorH/efdq28CBdcmydfQ=
+-k8s.io/kube-scheduler v0.32.10/go.mod h1:NIbZnbqbw5OukAJWnvZv+wUn753u1LeZX8BvNYcFpQ0=
+-k8s.io/kubectl v0.32.10 h1:sXYKAl9C/HlLrRYHrcvLqMBXOuWrQLC5R3eNz7UMKnU=
+-k8s.io/kubectl v0.32.10/go.mod h1:9ZslQAVI9567FnBQxGR7npMC+HhzbVrKRaRxVdpe+LQ=
+-k8s.io/kubelet v0.32.10 h1:MOogwP/TkfLJ9fl/BwzgmBXILaGu2wl+P4BIwtcmyXw=
+-k8s.io/kubelet v0.32.10/go.mod h1:HmNTDI+zxjvIotTQIL50zqGySoqRIbJTgAY49iH9ILM=
+-k8s.io/kubernetes v1.32.10 h1:yiRa8DyKp4Yrbv028MP6kpp5N1N3eO8Hp/tSCbBGIPE=
+-k8s.io/kubernetes v1.32.10/go.mod h1:o2pRStsMR7Uq62zcugfUEQsxnuyFt9r8migMrbsVH00=
+-k8s.io/mount-utils v0.32.10 h1:cSz/3jAaPTkSfJUOfOTB0HPCZYcxZaY2moDiRBS96LU=
+-k8s.io/mount-utils v0.32.10/go.mod h1:Kun5c2svjAPx0nnvJKYQWhfeNW+O0EpzHgRhDcYoSY0=
++k8s.io/kube-scheduler v0.32.13 h1:2pPLTocN7qs5LXuR0LRSGvI5C2IiDKgbdfQWSFIBcxk=
++k8s.io/kube-scheduler v0.32.13/go.mod h1:qPbJK/ezn2V23YIPa2gsxyEXBj6F6DB9T3CKM21sHG4=
++k8s.io/kubectl v0.32.13 h1:SgKMRUwpRIR+8DHPphU/wDskNsj0Jtf6bEVyuus+FtI=
++k8s.io/kubectl v0.32.13/go.mod h1:RpFsxWrIqcXaeCArs+Ma4nDCeCAPsEgWM6TwfskmfvI=
++k8s.io/kubelet v0.32.13 h1:pGSrLTytcmuIlq4yvuRFnF4RdQjQh1FfsmPeRZXDKTo=
++k8s.io/kubelet v0.32.13/go.mod h1:XrwKgyKhVUE8TO/w9Lqq93UTM5W6t7ePItIgjvSmV/4=
++k8s.io/kubernetes v1.32.13 h1:5TGYdZ6YZqdp6h/Rp1vX/4TIoybMPdgv97LCZCtPuNQ=
++k8s.io/kubernetes v1.32.13/go.mod h1:o2pRStsMR7Uq62zcugfUEQsxnuyFt9r8migMrbsVH00=
++k8s.io/mount-utils v0.32.13 h1:bTl8aZuNSI3P3BxlYLOcCvo+XH/wEKXXdSji96+W1fE=
++k8s.io/mount-utils v0.32.13/go.mod h1:Kun5c2svjAPx0nnvJKYQWhfeNW+O0EpzHgRhDcYoSY0=
  k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 h1:M3sRQVHv7vB20Xc2ybTt7ODCeFj6JSWYFzOFnYeS6Ro=
  k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
  sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.0 h1:CPT0ExVicCzcpeN4baWEV2ko2Z/AsiZgEdwgcfwLgMo=

--- a/modules/040-node-manager/images/cluster-autoscaler/patches/1.32/001-go-mod.patch
+++ b/modules/040-node-manager/images/cluster-autoscaler/patches/1.32/001-go-mod.patch
@@ -1,16 +1,23 @@
 diff --git a/cluster-autoscaler/apis/go.mod b/cluster-autoscaler/apis/go.mod
-index b36d764c7..3ccfd3e5f 100644
+index 3ac7f4768..5fa92f6f9 100644
 --- a/cluster-autoscaler/apis/go.mod
 +++ b/cluster-autoscaler/apis/go.mod
-@@ -1,6 +1,6 @@
+@@ -1,13 +1,10 @@
  module k8s.io/autoscaler/cluster-autoscaler/apis
  
--go 1.23.11
+-go 1.23.0
+-
+-toolchain go1.23.2
 +go 1.25.0
  
  require (
  	github.com/onsi/ginkgo/v2 v2.21.0
-@@ -36,15 +36,16 @@ require (
+ 	github.com/onsi/gomega v1.35.1
+-	k8s.io/api v0.32.0
+ 	k8s.io/apimachinery v0.32.3
+ 	k8s.io/client-go v0.32.0
+ 	k8s.io/code-generator v0.32.0
+@@ -39,19 +36,21 @@ require (
  	github.com/pkg/errors v0.9.1 // indirect
  	github.com/spf13/pflag v1.0.5 // indirect
  	github.com/x448/float16 v0.8.4 // indirect
@@ -34,8 +41,13 @@ index b36d764c7..3ccfd3e5f 100644
  	google.golang.org/protobuf v1.35.1 // indirect
  	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
  	gopkg.in/inf.v0 v0.9.1 // indirect
+ 	gopkg.in/yaml.v3 v3.0.1 // indirect
++	k8s.io/api v0.32.0 // indirect
+ 	k8s.io/gengo/v2 v2.0.0-20240911193312-2b36238f13e9 // indirect
+ 	k8s.io/klog/v2 v2.130.1 // indirect
+ 	k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f // indirect
 diff --git a/cluster-autoscaler/apis/go.sum b/cluster-autoscaler/apis/go.sum
-index 649024af5..fe03c93c7 100644
+index 701a0e94c..4c7077458 100644
 --- a/cluster-autoscaler/apis/go.sum
 +++ b/cluster-autoscaler/apis/go.sum
 @@ -88,40 +88,44 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
@@ -98,280 +110,167 @@ index 649024af5..fe03c93c7 100644
  golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
  golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 diff --git a/cluster-autoscaler/go.mod b/cluster-autoscaler/go.mod
-index 4fb700f05..945a953e0 100644
+index ee33cde31..4db6ffffc 100644
 --- a/cluster-autoscaler/go.mod
 +++ b/cluster-autoscaler/go.mod
-@@ -1,6 +1,6 @@
+@@ -1,8 +1,6 @@
  module k8s.io/autoscaler/cluster-autoscaler
  
--go 1.23.11
+-go 1.23.0
+-
+-toolchain go1.23.2
 +go 1.25.0
  
  require (
  	cloud.google.com/go/compute/metadata v0.3.0
-@@ -32,28 +32,28 @@ require (
+@@ -39,9 +37,9 @@ require (
  	github.com/stretchr/testify v1.9.0
  	github.com/vburenin/ifacemaker v1.2.1
  	go.uber.org/mock v0.4.0
--	golang.org/x/net v0.30.0
+-	golang.org/x/net v0.38.0
 +	golang.org/x/net v0.55.0
- 	golang.org/x/oauth2 v0.23.0
--	golang.org/x/sys v0.26.0
+ 	golang.org/x/oauth2 v0.27.0
+-	golang.org/x/sys v0.31.0
 +	golang.org/x/sys v0.45.0
  	google.golang.org/api v0.151.0
  	google.golang.org/grpc v1.65.0
- 	google.golang.org/protobuf v1.35.1
- 	gopkg.in/gcfg.v1 v1.2.3
- 	gopkg.in/yaml.v2 v2.4.0
--	k8s.io/api v0.32.9
--	k8s.io/apimachinery v0.32.9
--	k8s.io/apiserver v0.32.9
-+	k8s.io/api v0.32.13
-+	k8s.io/apimachinery v0.32.13
-+	k8s.io/apiserver v0.32.13
- 	k8s.io/autoscaler/cluster-autoscaler/apis v0.0.0-20240627115740-d52e4b9665d7
--	k8s.io/client-go v0.32.9
-+	k8s.io/client-go v0.32.13
- 	k8s.io/cloud-provider v0.32.7
- 	k8s.io/cloud-provider-aws v1.27.0
- 	k8s.io/cloud-provider-gcp/providers v0.28.2
--	k8s.io/component-base v0.32.9
--	k8s.io/component-helpers v0.32.9
-+	k8s.io/component-base v0.32.13
-+	k8s.io/component-helpers v0.32.13
+ 	google.golang.org/protobuf v1.36.1
+@@ -60,7 +58,7 @@ require (
  	k8s.io/dynamic-resource-allocation v0.0.0
  	k8s.io/klog/v2 v2.130.1
--	k8s.io/kubelet v0.32.9
--	k8s.io/kubernetes v1.32.9
-+	k8s.io/kubelet v0.32.13
-+	k8s.io/kubernetes v1.32.13
+ 	k8s.io/kubelet v0.32.0
+-	k8s.io/kubernetes v1.32.0
++	k8s.io/kubernetes v1.32.10
  	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738
  	sigs.k8s.io/cloud-provider-azure v1.29.4
  	sigs.k8s.io/cloud-provider-azure/pkg/azclient v0.0.13
-@@ -185,14 +185,15 @@ require (
+@@ -90,7 +88,7 @@ require (
+ 	github.com/GoogleCloudPlatform/k8s-cloud-provider v1.25.0 // indirect
+ 	github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab // indirect
+ 	github.com/Microsoft/go-winio v0.6.2 // indirect
+-	github.com/Microsoft/hnslib v0.0.8 // indirect
++	github.com/Microsoft/hnslib v0.1.1 // indirect
+ 	github.com/NYTimes/gziphandler v1.1.1 // indirect
+ 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
+ 	github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2 // indirect
+@@ -188,14 +186,15 @@ require (
  	go.opentelemetry.io/proto/otlp v1.3.1 // indirect
  	go.uber.org/multierr v1.11.0 // indirect
  	go.uber.org/zap v1.27.0 // indirect
--	golang.org/x/crypto v0.28.0 // indirect
-+	golang.org/x/crypto v0.52.0 // indirect
+-	golang.org/x/crypto v0.36.0 // indirect
++	golang.org/x/crypto v0.51.0 // indirect
  	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
--	golang.org/x/mod v0.21.0 // indirect
--	golang.org/x/sync v0.8.0 // indirect
--	golang.org/x/term v0.25.0 // indirect
--	golang.org/x/text v0.19.0 // indirect
+-	golang.org/x/mod v0.23.0 // indirect
+-	golang.org/x/sync v0.12.0 // indirect
+-	golang.org/x/term v0.30.0 // indirect
+-	golang.org/x/text v0.23.0 // indirect
 +	golang.org/x/mod v0.35.0 // indirect
 +	golang.org/x/sync v0.20.0 // indirect
 +	golang.org/x/term v0.43.0 // indirect
 +	golang.org/x/text v0.37.0 // indirect
  	golang.org/x/time v0.7.0 // indirect
--	golang.org/x/tools v0.26.0 // indirect
+-	golang.org/x/tools v0.30.0 // indirect
 +	golang.org/x/tools v0.44.0 // indirect
 +	golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated // indirect
  	google.golang.org/genproto/googleapis/api v0.0.0-20240826202546-f6391c0de4c7 // indirect
  	google.golang.org/genproto/googleapis/rpc v0.0.0-20240826202546-f6391c0de4c7 // indirect
  	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
-@@ -201,13 +202,13 @@ require (
- 	gopkg.in/warnings.v0 v0.1.2 // indirect
- 	gopkg.in/yaml.v3 v3.0.1 // indirect
- 	k8s.io/apiextensions-apiserver v0.0.0 // indirect
--	k8s.io/code-generator v0.32.9 // indirect
--	k8s.io/controller-manager v0.32.9 // indirect
--	k8s.io/cri-api v0.32.9 // indirect
-+	k8s.io/code-generator v0.32.13 // indirect
-+	k8s.io/controller-manager v0.32.13 // indirect
-+	k8s.io/cri-api v0.32.13 // indirect
- 	k8s.io/cri-client v0.0.0 // indirect
- 	k8s.io/csi-translation-lib v0.27.0 // indirect
- 	k8s.io/gengo/v2 v2.0.0-20240911193312-2b36238f13e9 // indirect
--	k8s.io/kms v0.32.9 // indirect
-+	k8s.io/kms v0.32.13 // indirect
- 	k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f // indirect
- 	k8s.io/kube-scheduler v0.0.0 // indirect
- 	k8s.io/kubectl v0.28.0 // indirect
-@@ -224,66 +225,66 @@ replace github.com/digitalocean/godo => github.com/digitalocean/godo v1.27.0
- 
- replace github.com/rancher/go-rancher => github.com/rancher/go-rancher v0.1.0
- 
--replace k8s.io/api => k8s.io/api v0.32.9
-+replace k8s.io/api => k8s.io/api v0.32.13
- 
--replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.32.9
-+replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.32.13
- 
--replace k8s.io/apimachinery => k8s.io/apimachinery v0.32.9
-+replace k8s.io/apimachinery => k8s.io/apimachinery v0.32.13
- 
--replace k8s.io/apiserver => k8s.io/apiserver v0.32.9
-+replace k8s.io/apiserver => k8s.io/apiserver v0.32.13
- 
--replace k8s.io/cli-runtime => k8s.io/cli-runtime v0.32.9
-+replace k8s.io/cli-runtime => k8s.io/cli-runtime v0.32.13
- 
--replace k8s.io/client-go => k8s.io/client-go v0.32.9
-+replace k8s.io/client-go => k8s.io/client-go v0.32.13
- 
--replace k8s.io/cloud-provider => k8s.io/cloud-provider v0.32.9
-+replace k8s.io/cloud-provider => k8s.io/cloud-provider v0.32.13
- 
--replace k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.32.9
-+replace k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.32.13
- 
--replace k8s.io/code-generator => k8s.io/code-generator v0.32.9
-+replace k8s.io/code-generator => k8s.io/code-generator v0.32.13
- 
--replace k8s.io/component-base => k8s.io/component-base v0.32.9
-+replace k8s.io/component-base => k8s.io/component-base v0.32.13
- 
--replace k8s.io/component-helpers => k8s.io/component-helpers v0.32.9
-+replace k8s.io/component-helpers => k8s.io/component-helpers v0.32.13
- 
--replace k8s.io/controller-manager => k8s.io/controller-manager v0.32.9
-+replace k8s.io/controller-manager => k8s.io/controller-manager v0.32.13
- 
--replace k8s.io/cri-api => k8s.io/cri-api v0.32.9
-+replace k8s.io/cri-api => k8s.io/cri-api v0.32.13
- 
--replace k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.32.9
-+replace k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.32.13
- 
--replace k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.32.9
-+replace k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.32.13
- 
--replace k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.32.9
-+replace k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.32.13
- 
--replace k8s.io/kube-proxy => k8s.io/kube-proxy v0.32.9
-+replace k8s.io/kube-proxy => k8s.io/kube-proxy v0.32.13
- 
--replace k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.32.9
-+replace k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.32.13
- 
--replace k8s.io/kubectl => k8s.io/kubectl v0.32.9
-+replace k8s.io/kubectl => k8s.io/kubectl v0.32.13
- 
--replace k8s.io/kubelet => k8s.io/kubelet v0.32.9
-+replace k8s.io/kubelet => k8s.io/kubelet v0.32.13
- 
--replace k8s.io/metrics => k8s.io/metrics v0.32.9
-+replace k8s.io/metrics => k8s.io/metrics v0.32.13
- 
--replace k8s.io/mount-utils => k8s.io/mount-utils v0.32.9
-+replace k8s.io/mount-utils => k8s.io/mount-utils v0.32.13
- 
--replace k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.32.9
-+replace k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.32.13
- 
--replace k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.32.9
-+replace k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.32.13
- 
--replace k8s.io/sample-controller => k8s.io/sample-controller v0.32.9
-+replace k8s.io/sample-controller => k8s.io/sample-controller v0.32.13
- 
--replace k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.32.9
-+replace k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.32.13
- 
--replace k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.32.9
-+replace k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.32.13
- 
--replace k8s.io/kms => k8s.io/kms v0.32.9
-+replace k8s.io/kms => k8s.io/kms v0.32.13
- 
--replace k8s.io/endpointslice => k8s.io/endpointslice v0.32.9
-+replace k8s.io/endpointslice => k8s.io/endpointslice v0.32.13
- 
- replace k8s.io/autoscaler/cluster-autoscaler/apis => ./apis
- 
--replace k8s.io/cri-client => k8s.io/cri-client v0.32.9
-+replace k8s.io/cri-client => k8s.io/cri-client v0.32.13
- 
--replace k8s.io/externaljwt => k8s.io/externaljwt v0.32.9
-+replace k8s.io/externaljwt => k8s.io/externaljwt v0.32.13
 diff --git a/cluster-autoscaler/go.sum b/cluster-autoscaler/go.sum
-index 73d9cd6f8..c9ca3fb97 100644
+index 990e503f5..d5cf410eb 100644
 --- a/cluster-autoscaler/go.sum
 +++ b/cluster-autoscaler/go.sum
-@@ -446,8 +446,8 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
+@@ -86,8 +86,8 @@ github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab h1:UKkYhof1njT1
+ github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab/go.mod h1:3VYc5hodBMJ5+l/7J4xAyMeuM2PNuepvHlGs8yilUCA=
+ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
+ github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
+-github.com/Microsoft/hnslib v0.0.8 h1:EBrIiRB7i/UYIXEC2yw22dn+RLzOmsc5S0bw2xf0Qus=
+-github.com/Microsoft/hnslib v0.0.8/go.mod h1:EYveQJlhKh2obmEIRB3uKN6dBd9pj1frPsrTGFppKuk=
++github.com/Microsoft/hnslib v0.1.1 h1:JsZy681SnvSOUAfCZVAxkX4LgQGp+CZZwPbLV0/pdF8=
++github.com/Microsoft/hnslib v0.1.1/go.mod h1:DRQR4IjLae6WHYVhW7uqe44hmFUiNhmaWA+jwMbz5tM=
+ github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cqUQ3I=
+ github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
+ github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=
+@@ -448,8 +448,8 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
  golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
  golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58=
  golang.org/x/crypto v0.17.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
--golang.org/x/crypto v0.28.0 h1:GBDwsMXVQi34v5CCYUm2jkJvu4cbtru2U4TN2PSyQnw=
--golang.org/x/crypto v0.28.0/go.mod h1:rmgy+3RHxRZMyY0jjAJShp2zgEdOqj2AO7U0pYmeQ7U=
-+golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
-+golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
+-golang.org/x/crypto v0.36.0 h1:AnAEvhDddvBdpY+uR+MyHmuZzzNqXSe/GvuDeob5L34=
+-golang.org/x/crypto v0.36.0/go.mod h1:Y4J0ReaxCR1IMaabaSMugxJES1EpwhBHhv2bDHklZvc=
++golang.org/x/crypto v0.51.0 h1:IBPXwPfKxY7cWQZ38ZCIRPI50YLeevDLlLnyC5wRGTI=
++golang.org/x/crypto v0.51.0/go.mod h1:8AdwkbraGNABw2kOX6YFPs3WM22XqI4EXEd8g+x7Oc8=
  golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
  golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 h1:2dVuKD2vS7b0QIHQbpyTISPd0LeHDbnYEryqj5Q1ug8=
  golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56/go.mod h1:M4RDyNAINzryxdtnbRXRL/OHtkFuWGRjvuhBJpk2IlY=
-@@ -459,8 +459,8 @@ golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+@@ -461,8 +461,8 @@ golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
  golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
  golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
  golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
--golang.org/x/mod v0.21.0 h1:vvrHzRwRfVKSiLrG+d4FMl/Qi4ukBCE6kZlTUkDYRT0=
--golang.org/x/mod v0.21.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
+-golang.org/x/mod v0.23.0 h1:Zb7khfcRGKk+kqfxFaP5tZqCnDZMjC5VtUBs87Hr6QM=
+-golang.org/x/mod v0.23.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
 +golang.org/x/mod v0.35.0 h1:Ww1D637e6Pg+Zb2KrWfHQUnH2dQRLBQyAtpr/haaJeM=
 +golang.org/x/mod v0.35.0/go.mod h1:+GwiRhIInF8wPm+4AoT6L0FA1QWAad3OMdTRx4tFYlU=
  golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
  golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
  golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
-@@ -478,8 +478,8 @@ golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug
- golang.org/x/net v0.1.0/go.mod h1:Cx3nUiGt4eDBEyega/BKRp+/AlGL8hYe7U9odMt2Cco=
+@@ -479,8 +479,8 @@ golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qx
+ golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
  golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
  golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
--golang.org/x/net v0.30.0 h1:AcW1SDZMkb8IpzCdQUaIq2sP4sZ4zw+55h6ynffypl4=
--golang.org/x/net v0.30.0/go.mod h1:2wGyMJ5iFasEhkwi13ChkO/t1ECNC4X4eBKkVFyYFlU=
+-golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
+-golang.org/x/net v0.38.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
 +golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
 +golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
  golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
  golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
- golang.org/x/oauth2 v0.23.0 h1:PbgcYx2W7i4LvjJWEbf0ngHV6qJYr86PkAV3bXdLEbs=
-@@ -493,8 +493,8 @@ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJ
+ golang.org/x/oauth2 v0.27.0 h1:da9Vo7/tDv5RH/7nZDz1eMGS/q1Vv1N/7FCrBhI9I3M=
+@@ -494,8 +494,8 @@ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJ
  golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
  golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
  golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
--golang.org/x/sync v0.8.0 h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=
--golang.org/x/sync v0.8.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+-golang.org/x/sync v0.12.0 h1:MHc5BpPuC30uJk597Ri8TV3CNZcTLu6B6z4lJy+g6Jw=
+-golang.org/x/sync v0.12.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 +golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
 +golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
  golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
  golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
  golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-@@ -511,16 +511,16 @@ golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+@@ -512,15 +512,15 @@ golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
  golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
  golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
  golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
--golang.org/x/sys v0.26.0 h1:KHjCJyddX0LoSTb3J+vWpupP9p0oznkqVk/IfjymZbo=
--golang.org/x/sys v0.26.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+-golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
+-golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 +golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 +golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
  golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
  golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
- golang.org/x/term v0.1.0/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
  golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=
  golang.org/x/term v0.8.0/go.mod h1:xPskH00ivmX89bAKVGSKKtLOWNx2+17Eiy94tnKShWo=
  golang.org/x/term v0.15.0/go.mod h1:BDl952bC7+uMoWR75FIrCDx79TPU9oHkTZ9yRbYOrX0=
--golang.org/x/term v0.25.0 h1:WtHI/ltw4NvSUig5KARz9h521QvRC8RmF/cuYqifU24=
--golang.org/x/term v0.25.0/go.mod h1:RPyXicDX+6vLxogjjRxjgD2TKtmAO6NZBsBRfrOLu7M=
+-golang.org/x/term v0.30.0 h1:PQ39fJZ+mfadBm0y5WlL4vlM7Sx1Hgf13sMIY2+QS9Y=
+-golang.org/x/term v0.30.0/go.mod h1:NYYFdzHoI5wRh/h5tDMdMqCqPJZEuNqVR5xJLd/n67g=
 +golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=
 +golang.org/x/term v0.43.0/go.mod h1:lrhlHNdQJHO+1qVYiHfFKVuVioJIheAc3fBSMFYEIsk=
  golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
  golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
  golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-@@ -529,8 +529,8 @@ golang.org/x/text v0.4.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
+@@ -528,8 +528,8 @@ golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
  golang.org/x/text v0.7.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
  golang.org/x/text v0.9.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=
  golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
--golang.org/x/text v0.19.0 h1:kTxAhCbGbxhK0IwgSKiMO5awPoDQ0RpfiVYBfK860YM=
--golang.org/x/text v0.19.0/go.mod h1:BuEKDfySbSR4drPmRPG/7iBdf8hvFMuRexcpahXilzY=
+-golang.org/x/text v0.23.0 h1:D71I7dUrlY+VX0gQShAThNGHFxZ13dGLBHQLVl1mJlY=
+-golang.org/x/text v0.23.0/go.mod h1:/BLNzu4aZCJ1+kcD0DNRotWKage4q2rGVAg4o22unh4=
 +golang.org/x/text v0.37.0 h1:Cqjiwd9eSg8e0QAkyCaQTNHFIIzWtidPahFWR83rTrc=
 +golang.org/x/text v0.37.0/go.mod h1:a5sjxXGs9hsn/AJVwuElvCAo9v8QYLzvavO5z2PiM38=
  golang.org/x/time v0.7.0 h1:ntUhktv3OPE6TgYxXWv9vKvUSJyIFJlyohwbkEwPrKQ=
  golang.org/x/time v0.7.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
  golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
-@@ -544,8 +544,12 @@ golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4f
+@@ -543,8 +543,12 @@ golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4f
  golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
  golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
  golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
--golang.org/x/tools v0.26.0 h1:v/60pFQmzmT9ExmjDv2gGIfi3OqfKoEP6I5+umXlbnQ=
--golang.org/x/tools v0.26.0/go.mod h1:TPVVj70c7JJ3WCazhD8OdXcZg/og+b9+tH/KxylGwH0=
+-golang.org/x/tools v0.30.0 h1:BgcpHewrV5AUp2G9MebG4XPFI1E2W41zU1SaqVA9vJY=
+-golang.org/x/tools v0.30.0/go.mod h1:c347cR/OJfw5TI+GfX7RUPNMdDRRbjvYTS0jPyvsVtY=
 +golang.org/x/tools v0.44.0 h1:UP4ajHPIcuMjT1GqzDWRlalUEoY+uzoZKnhOjbIPD2c=
 +golang.org/x/tools v0.44.0/go.mod h1:KA0AfVErSdxRZIsOVipbv3rQhVXTnlU6UhKxHd1seDI=
 +golang.org/x/tools/go/expect v0.1.0-deprecated h1:jY2C5HGYR5lqex3gEniOQL0r7Dq5+VGVgY1nudX5lXY=
@@ -381,100 +280,14 @@ index 73d9cd6f8..c9ca3fb97 100644
  golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
  golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
  golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-@@ -604,56 +608,56 @@ gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
- gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
- honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
- honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
--k8s.io/api v0.32.9 h1:q/59kk8lnecgG0grJqzrmXC1Jcl2hPWp9ltz0FQuoLI=
--k8s.io/api v0.32.9/go.mod h1:jIfT3rwW4EU1IXZm9qjzSk/2j91k4CJL5vUULrxqp3Y=
--k8s.io/apiextensions-apiserver v0.32.9 h1:tpT1dUgWqEsTyrdoGckyw8OBASW1JfU08tHGaYBzFHY=
--k8s.io/apiextensions-apiserver v0.32.9/go.mod h1:FoCi4zCLK67LNCCssFa2Wr9q4Xbvjx7MW4tdze5tpoA=
--k8s.io/apimachinery v0.32.9 h1:fXk8ktfsxrdThaEOAQFgkhCK7iyoyvS8nbYJ83o/SSs=
--k8s.io/apimachinery v0.32.9/go.mod h1:GpHVgxoKlTxClKcteaeuF1Ul/lDVb74KpZcxcmLDElE=
--k8s.io/apiserver v0.32.9 h1:ONHLA/VB6U7s0skCzmyLnjQdJ5FPCQF08yBI0j7y84o=
--k8s.io/apiserver v0.32.9/go.mod h1:MuuqNdvkneD4kcQc5mUZQCOQYzfKMba6P36bVW+wZtI=
--k8s.io/client-go v0.32.9 h1:ZMyIQ1TEpTDAQni3L2gH1NZzyOA/gHfNcAazzCxMJ0c=
--k8s.io/client-go v0.32.9/go.mod h1:2OT8aFSYvUjKGadaeT+AVbhkXQSpMAkiSb88Kz2WggI=
--k8s.io/cloud-provider v0.32.9 h1:JDHwfY0ACw3QBpz8K01z0mH2JdbIqnXklmd9IaIL99c=
--k8s.io/cloud-provider v0.32.9/go.mod h1:f7Nm5c4syybGQRmvfir/ojgmKILO1DmIpxDnGIagDvo=
-+k8s.io/api v0.32.13 h1:CAtHUTtSau6UhSGcrypjKXc2365TncaxUtrIfnjUPGE=
-+k8s.io/api v0.32.13/go.mod h1:PXqm+/G56aRPUJWUb8nGwBDovaXcqQ+e3o6+ZJIITPY=
-+k8s.io/apiextensions-apiserver v0.32.13 h1:3M8y1UNKgAp/I+T4TDEeqXiR1wj8nrqzTqgMHRKsO8A=
-+k8s.io/apiextensions-apiserver v0.32.13/go.mod h1:IMU3eme+2CoGzlmiHVcl6v08u3dRzebcBTnop09cwpY=
-+k8s.io/apimachinery v0.32.13 h1:OQ1djPkMwU8F9BQwZUW314DdYsalB8hRvBgLRqimJdo=
-+k8s.io/apimachinery v0.32.13/go.mod h1:GpHVgxoKlTxClKcteaeuF1Ul/lDVb74KpZcxcmLDElE=
-+k8s.io/apiserver v0.32.13 h1:oakvP13+5KyJSKo01uV6AD9n5oXOsQghSrpayYfeHeg=
-+k8s.io/apiserver v0.32.13/go.mod h1:3FGYjbrMtFOUx0p37vn4cEUWWO/a90fNTe/SIn2gaaQ=
-+k8s.io/client-go v0.32.13 h1:FxVdGzgrWW8QBprX/xJjoxs9tE06UJIbuy8IfNoxn0c=
-+k8s.io/client-go v0.32.13/go.mod h1:XhErcCmtSRUns7g0fXYjV8NAXvJWHQCT9EaYkf4dbyw=
-+k8s.io/cloud-provider v0.32.13 h1:v2iz8ukTBgK4KLF48Qzwkh5egegixCRzsfJmYrjyqfE=
-+k8s.io/cloud-provider v0.32.13/go.mod h1:p5O1oZcqJNl6d5WzEtHFMUorUG9j/pk9DrxITM54xJo=
- k8s.io/cloud-provider-aws v1.27.0 h1:PF8YrH8QcN6JoXB3Xxlaz84SBDYMPunJuCc0cPuCWXA=
- k8s.io/cloud-provider-aws v1.27.0/go.mod h1:9vUb5mnVnReSRDBWcBxB1b0HOeEc472iOPmrnwpN9SA=
- k8s.io/cloud-provider-gcp/providers v0.28.2 h1:I65pFTLNMQSj7YuW3Mg3pZIXmw0naCmF6TGAuz4/sZE=
- k8s.io/cloud-provider-gcp/providers v0.28.2/go.mod h1:P8dxRvvLtX7xUwVUzA/QOqv8taCzBaVsVMnjnpjmYXE=
--k8s.io/code-generator v0.32.9 h1:F9Gti/8I+nVNnQw02J36/YlSD5JMg4qDJ7sfRqpUICU=
--k8s.io/code-generator v0.32.9/go.mod h1:fLYBG9g52EJulRebmomL0vCU0PQeMr7mnscfZtAAGV4=
--k8s.io/component-base v0.32.9 h1:UTDZUpVQRv1M7BQtEvswLwiKij9QO7EzfZgpMD7WqLQ=
--k8s.io/component-base v0.32.9/go.mod h1:AfJMbzLk8iyOyDPkv/HpAjYmdNGookl9O0Kva5Wu83U=
--k8s.io/component-helpers v0.32.9 h1:HhZYbizPcNMZYdh6cC8gBoSTx5GTnWp4EsLANTslXfA=
--k8s.io/component-helpers v0.32.9/go.mod h1:KEc8GARgvk7dmKF/136XlmQVj9+EBJA1HbQFGpjxqM4=
--k8s.io/controller-manager v0.32.9 h1:RTAkWF8AD6fPR/9JRx0eanOcQseHP0wWYDyIzEF9xG8=
--k8s.io/controller-manager v0.32.9/go.mod h1:tD4KidRx2h1FqTau2vl9L+LUmjbwFAbrmiKyYc8b4PA=
--k8s.io/cri-api v0.32.9 h1:FkZzY08XwwVoWzqvmUNn+ly0ftq2WpDFZrsSpeFedZ4=
--k8s.io/cri-api v0.32.9/go.mod h1:DCzMuTh2padoinefWME0G678Mc3QFbLMF2vEweGzBAI=
--k8s.io/cri-client v0.32.9 h1:+bpcSeoPE60PeBqn65g69nXwUWK/zAi6hlhAf/ZZppg=
--k8s.io/cri-client v0.32.9/go.mod h1:HsDDq036RI4PGGJNOLxdg2sVbUuJRP7Fz0RomQTxfsw=
--k8s.io/csi-translation-lib v0.32.9 h1:i763XZSDkgXF4VyfADYyAE53i1uz+zuaFRGlLdGDdTM=
--k8s.io/csi-translation-lib v0.32.9/go.mod h1:1F+M2Rn2+UMIu+qlj8JIQJCAdAREF+VRKtfyPHih9To=
--k8s.io/dynamic-resource-allocation v0.32.9 h1:NXG4oNNaTOG1t0dZ3kunRiP9Nkf1GQvDJQQFi+ffqfA=
--k8s.io/dynamic-resource-allocation v0.32.9/go.mod h1:bLh0kOgkYXh4DHL7DuIDsyKKLWE2UwAgjiomPRrgG5w=
-+k8s.io/code-generator v0.32.13 h1:s8F2Mg5el0vnDJHqIJl1WhVbbk3J38CmQc5Y6j5bmHQ=
-+k8s.io/code-generator v0.32.13/go.mod h1:rtEcqtalEPQU2cOgjWrX7RQ/x/Lr65pwu7givcfjfx0=
-+k8s.io/component-base v0.32.13 h1:QTroT4xOtYXc8ySp7Wvj5llxDNxz16YoG5Pw3zJBMds=
-+k8s.io/component-base v0.32.13/go.mod h1:hfuVb9GlAuoIXRimoph+0e862qEwxRA7h+6oOIFelCE=
-+k8s.io/component-helpers v0.32.13 h1:3QkTkm4K8ESUof270faqsQGShad1OxYvLGquLoKlDog=
-+k8s.io/component-helpers v0.32.13/go.mod h1:Hp7dV/PAyotFPhYwHDsv3Udk+X+4w+Yo+J6vF5v/Ilg=
-+k8s.io/controller-manager v0.32.13 h1:2FbFxVEveGJp5Qqju9jRedZs4oBBSCyNQI5QXbO23lI=
-+k8s.io/controller-manager v0.32.13/go.mod h1:Ft4FhkzDpsxdK01chn707UDeUHkcxqMzuLRSkvDNhZs=
-+k8s.io/cri-api v0.32.13 h1:mfGwZwffjIgpXpeYq+PiblsOk3qPbFlhPGtqYUdHwWs=
-+k8s.io/cri-api v0.32.13/go.mod h1:DCzMuTh2padoinefWME0G678Mc3QFbLMF2vEweGzBAI=
-+k8s.io/cri-client v0.32.13 h1:d23awOed1UyMsTGxAYyfu/X7XWUYk6FB5dbLQCpudRI=
-+k8s.io/cri-client v0.32.13/go.mod h1:iVKB6Srg9yZfNn6IOcHM4r4QCnReL7pKSOH0JDOmFV8=
-+k8s.io/csi-translation-lib v0.32.13 h1:c3rk2yi4jAUnkXZYhC/bcv8skipWuptHqsalTeEqz5I=
-+k8s.io/csi-translation-lib v0.32.13/go.mod h1:xviC437IUkLGiLuIwmY3xkw/3dVO6f/NJO2feDP07bU=
-+k8s.io/dynamic-resource-allocation v0.32.13 h1:Qb75vl8aP0AxCMQ1SYjpK1xCTIDJ/MJ/Xn610RmKYu8=
-+k8s.io/dynamic-resource-allocation v0.32.13/go.mod h1:cuv8T2IVH3+aKRBjc9S0IkYASzGvDOGQI6Ruc3LNihU=
- k8s.io/gengo/v2 v2.0.0-20240911193312-2b36238f13e9 h1:si3PfKm8dDYxgfbeA6orqrtLkvvIeH8UqffFJDl0bz4=
- k8s.io/gengo/v2 v2.0.0-20240911193312-2b36238f13e9/go.mod h1:EJykeLsmFC60UQbYJezXkEsG2FLrt0GPNkU5iK5GWxU=
- k8s.io/klog/v2 v2.130.1 h1:n9Xl7H1Xvksem4KFG4PYbdQCQxqc/tTUyrgXaOhHSzk=
- k8s.io/klog/v2 v2.130.1/go.mod h1:3Jpz1GvMt720eyJH1ckRHK1EDfpxISzJ7I9OYgaDtPE=
--k8s.io/kms v0.32.9 h1:G7e2Eeuit0i9XmTzk8W12hWd2YmSr7aUMHL1XGDPa5M=
--k8s.io/kms v0.32.9/go.mod h1:Bk2evz/Yvk0oVrvm4MvZbgq8BD34Ksxs2SRHn4/UiOM=
-+k8s.io/kms v0.32.13 h1:z+h7bcmb9gZBEqunJAOVoNZsyIY2S4eTb1qcvpJ0Fu4=
-+k8s.io/kms v0.32.13/go.mod h1:Bk2evz/Yvk0oVrvm4MvZbgq8BD34Ksxs2SRHn4/UiOM=
- k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f h1:GA7//TjRY9yWGy1poLzYYJJ4JRdzg3+O6e8I+e+8T5Y=
- k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f/go.mod h1:R/HEjbvWI0qdfb8viZUeVZm0X6IZnxAydC7YU42CMw4=
--k8s.io/kube-scheduler v0.32.9 h1:7oE4exa4H+BjLIn2Bt62vPAF1ckdmfC7wXNZk8xtcsQ=
--k8s.io/kube-scheduler v0.32.9/go.mod h1:ZV0XZKNJQWBD1zDENXEg+sFwHIuwb6enoDOzPlnVkaw=
--k8s.io/kubectl v0.32.9 h1:y5D3bdJnenD6bFJ05NwhCa6eSBcPvLcUlgAW6Y4O4zs=
--k8s.io/kubectl v0.32.9/go.mod h1:2Gb580dhhqMztWWdE+iIFPWcDAel4/FMOwYPOTL51DY=
--k8s.io/kubelet v0.32.9 h1:DVbYq6iPIQJ/oQSV+Ec4dCytMKy9D5he9Ra2/pVQRNw=
--k8s.io/kubelet v0.32.9/go.mod h1:ApPYUgb3RNG4IZrWEno5z2oQrP9K1Fh8HCDoUHLZ3CI=
--k8s.io/kubernetes v1.32.9 h1:w4Zv/2dVwQKUqCZOSBnMzjMYZQ33TNuSZvbkJ9HEaGE=
--k8s.io/kubernetes v1.32.9/go.mod h1:REY0Gok66BTTrbGyZaFMNKO9JhxvgBDW9B7aksWRFoY=
--k8s.io/mount-utils v0.32.9 h1:jMo1LsBUoEB2i+KaPJVlgxc0wlBN0UFMDZUquYVVl20=
--k8s.io/mount-utils v0.32.9/go.mod h1:Kun5c2svjAPx0nnvJKYQWhfeNW+O0EpzHgRhDcYoSY0=
-+k8s.io/kube-scheduler v0.32.13 h1:2pPLTocN7qs5LXuR0LRSGvI5C2IiDKgbdfQWSFIBcxk=
-+k8s.io/kube-scheduler v0.32.13/go.mod h1:qPbJK/ezn2V23YIPa2gsxyEXBj6F6DB9T3CKM21sHG4=
-+k8s.io/kubectl v0.32.13 h1:SgKMRUwpRIR+8DHPphU/wDskNsj0Jtf6bEVyuus+FtI=
-+k8s.io/kubectl v0.32.13/go.mod h1:RpFsxWrIqcXaeCArs+Ma4nDCeCAPsEgWM6TwfskmfvI=
-+k8s.io/kubelet v0.32.13 h1:pGSrLTytcmuIlq4yvuRFnF4RdQjQh1FfsmPeRZXDKTo=
-+k8s.io/kubelet v0.32.13/go.mod h1:XrwKgyKhVUE8TO/w9Lqq93UTM5W6t7ePItIgjvSmV/4=
-+k8s.io/kubernetes v1.32.13 h1:5TGYdZ6YZqdp6h/Rp1vX/4TIoybMPdgv97LCZCtPuNQ=
-+k8s.io/kubernetes v1.32.13/go.mod h1:o2pRStsMR7Uq62zcugfUEQsxnuyFt9r8migMrbsVH00=
-+k8s.io/mount-utils v0.32.13 h1:bTl8aZuNSI3P3BxlYLOcCvo+XH/wEKXXdSji96+W1fE=
-+k8s.io/mount-utils v0.32.13/go.mod h1:Kun5c2svjAPx0nnvJKYQWhfeNW+O0EpzHgRhDcYoSY0=
+@@ -649,8 +653,8 @@ k8s.io/kubectl v0.32.0 h1:rpxl+ng9qeG79YA4Em9tLSfX0G8W0vfaiPVrc/WR7Xw=
+ k8s.io/kubectl v0.32.0/go.mod h1:qIjSX+QgPQUgdy8ps6eKsYNF+YmFOAO3WygfucIqFiE=
+ k8s.io/kubelet v0.32.0 h1:uLyiKlz195Wo4an/K2tyge8o3QHx0ZkhVN3pevvp59A=
+ k8s.io/kubelet v0.32.0/go.mod h1:lAwuVZT/Hm7EdLn0jW2D+WdrJoorjJL2rVSdhOFnegw=
+-k8s.io/kubernetes v1.32.0 h1:4BDBWSolqPrv8GC3YfZw0CJvh5kA1TPnoX0FxDVd+qc=
+-k8s.io/kubernetes v1.32.0/go.mod h1:tiIKO63GcdPRBHW2WiUFm3C0eoLczl3f7qi56Dm1W8I=
++k8s.io/kubernetes v1.32.10 h1:yiRa8DyKp4Yrbv028MP6kpp5N1N3eO8Hp/tSCbBGIPE=
++k8s.io/kubernetes v1.32.10/go.mod h1:o2pRStsMR7Uq62zcugfUEQsxnuyFt9r8migMrbsVH00=
+ k8s.io/mount-utils v0.32.3 h1:ZPXXHblfBhYP89OnaozpFg9Ojl6HhDfxBLcdWNkaxW8=
+ k8s.io/mount-utils v0.32.3/go.mod h1:Kun5c2svjAPx0nnvJKYQWhfeNW+O0EpzHgRhDcYoSY0=
  k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 h1:M3sRQVHv7vB20Xc2ybTt7ODCeFj6JSWYFzOFnYeS6Ro=
- k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
- sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.0 h1:CPT0ExVicCzcpeN4baWEV2ko2Z/AsiZgEdwgcfwLgMo=

--- a/modules/040-node-manager/images/cluster-autoscaler/patches/1.32/README.md
+++ b/modules/040-node-manager/images/cluster-autoscaler/patches/1.32/README.md
@@ -2,25 +2,39 @@
 
 ### 001-go-mod.patch
 
-To create this patch run commands:
+Bumps Go module dependencies to remediate CVEs reported by Trivy for the
+cluster-autoscaler binary. The vulnerabilities live in indirect/build
+dependencies that are linked into the binary (x/crypto/ssh, x/net, k8s
+staging modules), not in cluster-autoscaler logic, so the fix is a pure
+`go.mod`/`go.sum` bump. The gardener tag stays `v1.32.3`.
+
+Applied to both `cluster-autoscaler/go.mod` and `cluster-autoscaler/apis/go.mod`:
+
+- `go` directive: `1.23.0` (+ `toolchain go1.23.2`) -> `1.25.0`
+- `golang.org/x/net`: `v0.38.0` -> `v0.55.0` (HTML parser / HTTP2 / idna CVEs)
+- `golang.org/x/sys`: `v0.31.0` -> `v0.45.0`
+- `golang.org/x/crypto`: `v0.36.0` -> `v0.51.0` (x/crypto/ssh CVEs)
+- `k8s.io/kubernetes`: `v1.32.0` -> `v1.32.10`, and all `k8s.io/*` staging
+  modules (require + replace) synced to `v0.32.10` (kube-controller-manager
+  SSRF, CVE-2025-13281)
+
+To recreate this patch, check out the clean tag and re-apply the bumps:
 
 ```shell
+git clone <SOURCE_REPO>/gardener/autoscaler.git
+cd autoscaler && git checkout v1.32.3
 cd cluster-autoscaler
-go mod edit -go 1.23
-go get github.com/golang-jwt/jwt/v4@v4.5.1
-go get github.com/opencontainers/runc@v1.1.14
-go get golang.org/x/crypto@v0.31.0
-go get golang.org/x/net@v0.33.0
-
-go get k8s.io/kubernetes@v1.30.8
-go get k8s.io/kubelet@v0.30.8
-#replase all in k8s.io  v0.30.1 -> v0.30.8
-cd apis
-go get golang.org/x/net@v0.33.0
+go get golang.org/x/crypto@v0.51.0
+go get golang.org/x/net@v0.55.0
+go get golang.org/x/sys@v0.45.0
+go get k8s.io/kubernetes@v1.32.10
+# sync every k8s.io/* require and replace directive to v0.32.10
+cd apis && go get golang.org/x/net@v0.55.0 && cd ..
+go mod tidy && (cd apis && go mod tidy)
 cd ..
-go mod tidy
-git diff > patches/001-go_mod.patch
-#git apply patches/001-go_mod.patch
+git diff -- cluster-autoscaler/go.mod cluster-autoscaler/go.sum \
+            cluster-autoscaler/apis/go.mod cluster-autoscaler/apis/go.sum \
+  > 001-go-mod.patch
 ```
 
 ### 002-kruise-ads.patch

--- a/modules/040-node-manager/images/cluster-autoscaler/patches/1.33/001-go-mod.patch
+++ b/modules/040-node-manager/images/cluster-autoscaler/patches/1.33/001-go-mod.patch
@@ -1,5 +1,5 @@
 diff --git a/cluster-autoscaler/apis/go.mod b/cluster-autoscaler/apis/go.mod
-index 706e0214b..5f9fe888a 100644
+index 572ba909a..849edfe12 100644
 --- a/cluster-autoscaler/apis/go.mod
 +++ b/cluster-autoscaler/apis/go.mod
 @@ -1,6 +1,6 @@
@@ -35,7 +35,7 @@ index 706e0214b..5f9fe888a 100644
  	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
  	gopkg.in/inf.v0 v0.9.1 // indirect
 diff --git a/cluster-autoscaler/apis/go.sum b/cluster-autoscaler/apis/go.sum
-index c3153a11e..1ad901eb8 100644
+index d516de6f1..2c0095202 100644
 --- a/cluster-autoscaler/apis/go.sum
 +++ b/cluster-autoscaler/apis/go.sum
 @@ -87,40 +87,44 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
@@ -98,7 +98,7 @@ index c3153a11e..1ad901eb8 100644
  golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
  golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 diff --git a/cluster-autoscaler/go.mod b/cluster-autoscaler/go.mod
-index ef38039cd..df0fd63ec 100644
+index d300c0846..fdc4d6095 100644
 --- a/cluster-autoscaler/go.mod
 +++ b/cluster-autoscaler/go.mod
 @@ -1,6 +1,6 @@
@@ -109,7 +109,7 @@ index ef38039cd..df0fd63ec 100644
  
  require (
  	cloud.google.com/go/compute/metadata v0.5.0
-@@ -28,32 +28,32 @@ require (
+@@ -29,32 +29,32 @@ require (
  	github.com/pkg/errors v0.9.1
  	github.com/prometheus/client_golang v1.22.0
  	github.com/spf13/pflag v1.0.5
@@ -129,26 +129,26 @@ index ef38039cd..df0fd63ec 100644
  	google.golang.org/protobuf v1.36.5
  	gopkg.in/gcfg.v1 v1.2.3
  	gopkg.in/yaml.v2 v2.4.0
--	k8s.io/api v0.33.6
--	k8s.io/apimachinery v0.33.6
--	k8s.io/apiserver v0.33.6
+-	k8s.io/api v0.33.5
+-	k8s.io/apimachinery v0.33.5
+-	k8s.io/apiserver v0.33.5
 +	k8s.io/api v0.33.13
 +	k8s.io/apimachinery v0.33.13
 +	k8s.io/apiserver v0.33.13
  	k8s.io/autoscaler/cluster-autoscaler/apis v0.0.0-20240627115740-d52e4b9665d7
--	k8s.io/client-go v0.33.6
+-	k8s.io/client-go v0.33.5
 +	k8s.io/client-go v0.33.13
  	k8s.io/cloud-provider v0.33.1
  	k8s.io/cloud-provider-aws v1.27.0
  	k8s.io/cloud-provider-gcp/providers v0.28.2
--	k8s.io/component-base v0.33.6
--	k8s.io/component-helpers v0.33.6
+-	k8s.io/component-base v0.33.5
+-	k8s.io/component-helpers v0.33.5
 +	k8s.io/component-base v0.33.13
 +	k8s.io/component-helpers v0.33.13
  	k8s.io/dynamic-resource-allocation v0.33.1
  	k8s.io/klog/v2 v2.130.1
--	k8s.io/kubelet v0.33.6
--	k8s.io/kubernetes v1.33.6
+-	k8s.io/kubelet v0.33.5
+-	k8s.io/kubernetes v1.33.5
 +	k8s.io/kubelet v0.33.13
 +	k8s.io/kubernetes v1.33.13
  	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738
@@ -214,7 +214,7 @@ index ef38039cd..df0fd63ec 100644
  	golang.org/x/time v0.9.0 // indirect
 -	golang.org/x/tools v0.26.0 // indirect
 +	golang.org/x/tools v0.44.0 // indirect
-+	golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated // indirect
++	golang.org/x/tools/go/expect v0.1.1-deprecated // indirect
  	google.golang.org/genproto/googleapis/api v0.0.0-20241209162323-e6fa225c2576 // indirect
  	google.golang.org/genproto/googleapis/rpc v0.0.0-20241209162323-e6fa225c2576 // indirect
  	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
@@ -222,16 +222,16 @@ index ef38039cd..df0fd63ec 100644
  	gopkg.in/warnings.v0 v0.1.2 // indirect
  	gopkg.in/yaml.v3 v3.0.1 // indirect
  	k8s.io/apiextensions-apiserver v0.0.0 // indirect
--	k8s.io/code-generator v0.33.6 // indirect
--	k8s.io/controller-manager v0.33.6 // indirect
--	k8s.io/cri-api v0.33.6 // indirect
+-	k8s.io/code-generator v0.33.5 // indirect
+-	k8s.io/controller-manager v0.33.5 // indirect
+-	k8s.io/cri-api v0.33.5 // indirect
 +	k8s.io/code-generator v0.33.13 // indirect
 +	k8s.io/controller-manager v0.33.13 // indirect
 +	k8s.io/cri-api v0.33.13 // indirect
  	k8s.io/cri-client v0.0.0 // indirect
  	k8s.io/csi-translation-lib v0.27.0 // indirect
  	k8s.io/gengo/v2 v2.0.0-20250207200755-1244d31929d7 // indirect
--	k8s.io/kms v0.33.6 // indirect
+-	k8s.io/kms v0.33.5 // indirect
 +	k8s.io/kms v0.33.13 // indirect
  	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff // indirect
  	k8s.io/kube-scheduler v0.0.0 // indirect
@@ -240,102 +240,102 @@ index ef38039cd..df0fd63ec 100644
  	sigs.k8s.io/structured-merge-diff/v4 v4.6.0 // indirect
  )
  
--replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.33.6
+-replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.33.5
 +replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.33.13
  
--replace k8s.io/code-generator => k8s.io/code-generator v0.33.6
+-replace k8s.io/code-generator => k8s.io/code-generator v0.33.5
 +replace k8s.io/code-generator => k8s.io/code-generator v0.33.13
  
--replace k8s.io/cri-api => k8s.io/cri-api v0.33.6
+-replace k8s.io/cri-api => k8s.io/cri-api v0.33.5
 +replace k8s.io/cri-api => k8s.io/cri-api v0.33.13
  
--replace k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.33.6
+-replace k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.33.5
 +replace k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.33.13
  
--replace k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.33.6
+-replace k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.33.5
 +replace k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.33.13
  
--replace k8s.io/kubectl => k8s.io/kubectl v0.33.6
+-replace k8s.io/kubectl => k8s.io/kubectl v0.33.5
 +replace k8s.io/kubectl => k8s.io/kubectl v0.33.13
  
--replace k8s.io/mount-utils => k8s.io/mount-utils v0.33.6
+-replace k8s.io/mount-utils => k8s.io/mount-utils v0.33.5
 +replace k8s.io/mount-utils => k8s.io/mount-utils v0.33.13
  
--replace k8s.io/kms => k8s.io/kms v0.33.6
+-replace k8s.io/kms => k8s.io/kms v0.33.5
 +replace k8s.io/kms => k8s.io/kms v0.33.13
  
  replace k8s.io/autoscaler/cluster-autoscaler/apis => ./apis
  
--replace k8s.io/cri-client => k8s.io/cri-client v0.33.6
+-replace k8s.io/cri-client => k8s.io/cri-client v0.33.5
 +replace k8s.io/cri-client => k8s.io/cri-client v0.33.13
  
--replace k8s.io/api => k8s.io/api v0.33.6
+-replace k8s.io/api => k8s.io/api v0.33.5
 +replace k8s.io/api => k8s.io/api v0.33.13
  
--replace k8s.io/apimachinery => k8s.io/apimachinery v0.33.6
+-replace k8s.io/apimachinery => k8s.io/apimachinery v0.33.5
 +replace k8s.io/apimachinery => k8s.io/apimachinery v0.33.13
  
--replace k8s.io/apiserver => k8s.io/apiserver v0.33.6
+-replace k8s.io/apiserver => k8s.io/apiserver v0.33.5
 +replace k8s.io/apiserver => k8s.io/apiserver v0.33.13
  
--replace k8s.io/cli-runtime => k8s.io/cli-runtime v0.33.6
+-replace k8s.io/cli-runtime => k8s.io/cli-runtime v0.33.5
 +replace k8s.io/cli-runtime => k8s.io/cli-runtime v0.33.13
  
--replace k8s.io/client-go => k8s.io/client-go v0.33.6
+-replace k8s.io/client-go => k8s.io/client-go v0.33.5
 +replace k8s.io/client-go => k8s.io/client-go v0.33.13
  
--replace k8s.io/cloud-provider => k8s.io/cloud-provider v0.33.6
+-replace k8s.io/cloud-provider => k8s.io/cloud-provider v0.33.5
 +replace k8s.io/cloud-provider => k8s.io/cloud-provider v0.33.13
  
--replace k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.33.6
+-replace k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.33.5
 +replace k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.33.13
  
--replace k8s.io/component-base => k8s.io/component-base v0.33.6
+-replace k8s.io/component-base => k8s.io/component-base v0.33.5
 +replace k8s.io/component-base => k8s.io/component-base v0.33.13
  
--replace k8s.io/component-helpers => k8s.io/component-helpers v0.33.6
+-replace k8s.io/component-helpers => k8s.io/component-helpers v0.33.5
 +replace k8s.io/component-helpers => k8s.io/component-helpers v0.33.13
  
--replace k8s.io/controller-manager => k8s.io/controller-manager v0.33.6
+-replace k8s.io/controller-manager => k8s.io/controller-manager v0.33.5
 +replace k8s.io/controller-manager => k8s.io/controller-manager v0.33.13
  
--replace k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.33.6
+-replace k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.33.5
 +replace k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.33.13
  
--replace k8s.io/endpointslice => k8s.io/endpointslice v0.33.6
+-replace k8s.io/endpointslice => k8s.io/endpointslice v0.33.5
 +replace k8s.io/endpointslice => k8s.io/endpointslice v0.33.13
  
--replace k8s.io/externaljwt => k8s.io/externaljwt v0.33.6
+-replace k8s.io/externaljwt => k8s.io/externaljwt v0.33.5
 +replace k8s.io/externaljwt => k8s.io/externaljwt v0.33.13
  
--replace k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.33.6
+-replace k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.33.5
 +replace k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.33.13
  
--replace k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.33.6
+-replace k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.33.5
 +replace k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.33.13
  
--replace k8s.io/kube-proxy => k8s.io/kube-proxy v0.33.6
+-replace k8s.io/kube-proxy => k8s.io/kube-proxy v0.33.5
 +replace k8s.io/kube-proxy => k8s.io/kube-proxy v0.33.13
  
--replace k8s.io/kubelet => k8s.io/kubelet v0.33.6
+-replace k8s.io/kubelet => k8s.io/kubelet v0.33.5
 +replace k8s.io/kubelet => k8s.io/kubelet v0.33.13
  
--replace k8s.io/metrics => k8s.io/metrics v0.33.6
+-replace k8s.io/metrics => k8s.io/metrics v0.33.5
 +replace k8s.io/metrics => k8s.io/metrics v0.33.13
  
--replace k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.33.6
+-replace k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.33.5
 +replace k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.33.13
  
--replace k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.33.6
+-replace k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.33.5
 +replace k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.33.13
  
--replace k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.33.6
+-replace k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.33.5
 +replace k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.33.13
  
--replace k8s.io/sample-controller => k8s.io/sample-controller v0.33.6
+-replace k8s.io/sample-controller => k8s.io/sample-controller v0.33.5
 +replace k8s.io/sample-controller => k8s.io/sample-controller v0.33.13
 diff --git a/cluster-autoscaler/go.sum b/cluster-autoscaler/go.sum
-index daf0a160f..223f5b5a4 100644
+index cb1f8f025..7f64b4935 100644
 --- a/cluster-autoscaler/go.sum
 +++ b/cluster-autoscaler/go.sum
 @@ -165,8 +165,8 @@ github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyT
@@ -513,8 +513,8 @@ index daf0a160f..223f5b5a4 100644
 -golang.org/x/tools v0.26.0/go.mod h1:TPVVj70c7JJ3WCazhD8OdXcZg/og+b9+tH/KxylGwH0=
 +golang.org/x/tools v0.44.0 h1:UP4ajHPIcuMjT1GqzDWRlalUEoY+uzoZKnhOjbIPD2c=
 +golang.org/x/tools v0.44.0/go.mod h1:KA0AfVErSdxRZIsOVipbv3rQhVXTnlU6UhKxHd1seDI=
-+golang.org/x/tools/go/expect v0.1.0-deprecated h1:jY2C5HGYR5lqex3gEniOQL0r7Dq5+VGVgY1nudX5lXY=
-+golang.org/x/tools/go/expect v0.1.0-deprecated/go.mod h1:eihoPOH+FgIqa3FpoTwguz/bVUSGBlGQU67vpBeOrBY=
++golang.org/x/tools/go/expect v0.1.1-deprecated h1:jpBZDwmgPhXsKZC6WhL20P4b/wmnpsEAGHaNy0n/rJM=
++golang.org/x/tools/go/expect v0.1.1-deprecated/go.mod h1:eihoPOH+FgIqa3FpoTwguz/bVUSGBlGQU67vpBeOrBY=
 +golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated h1:1h2MnaIAIXISqTFKdENegdpAgUXz6NrPEsbIeWaBRvM=
 +golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated/go.mod h1:RVAQXBGNv1ib0J382/DPCRS/BPnsGebyM1Gj5VSDpG8=
  golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -524,18 +524,18 @@ index daf0a160f..223f5b5a4 100644
  gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
  honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
  honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
--k8s.io/api v0.33.6 h1:9O22ZqwT6CkQ3iboVpvTR5BEWuT3Xm6/8NX6MOLmc38=
--k8s.io/api v0.33.6/go.mod h1:bdon4pRFmRmdsFyltGIoCaPqutN7y//OQ4srD0uy9X0=
--k8s.io/apiextensions-apiserver v0.33.6 h1:S+18aFz53T/iHPgj9iB7bAZmRPeW8b1umsWaRdgj+6U=
--k8s.io/apiextensions-apiserver v0.33.6/go.mod h1:YUhU/Tb0GszjMK5BXb1HpP6+26TQ1xodhfntmZv7RC0=
--k8s.io/apimachinery v0.33.6 h1:Pq+px1i1t7lNgE58dIeBwJh7OWId6pfGD1dYBm/U5HI=
--k8s.io/apimachinery v0.33.6/go.mod h1:BHW0YOu7n22fFv/JkYOEfkUYNRN0fj0BlvMFWA7b+SM=
--k8s.io/apiserver v0.33.6 h1:X78/4sciWuKMM6Wlm2z4WMthhJSfsO/vcyjx7J6gEsE=
--k8s.io/apiserver v0.33.6/go.mod h1:5rRMAedHE4Vke25QGuW2kyfPIHC8nmQxNLdvJKAcmIU=
--k8s.io/client-go v0.33.6 h1:icPU5E5XHl/5mdwMUdSxpGtHnnjWzG0MSputTR9odrg=
--k8s.io/client-go v0.33.6/go.mod h1:3z/Cwqdi6/Uo+E17k+OgQi4QfXS0XuIUmfHpK6rQdZU=
--k8s.io/cloud-provider v0.33.6 h1:XLt8UhgsZgou8Ua6KQrnnHGS3lpZRHlbNhnO4kPyO0c=
--k8s.io/cloud-provider v0.33.6/go.mod h1:I08jJ7obAWjv9z5ZcabdOV3aizfo7ru495xuxlHQw84=
+-k8s.io/api v0.33.5 h1:YR+uhYj05jdRpcksv8kjSliW+v9hwXxn6Cv10aR8Juw=
+-k8s.io/api v0.33.5/go.mod h1:2gzShdwXKT5yPGiqrTrn/U/nLZ7ZyT4WuAj3XGDVgVs=
+-k8s.io/apiextensions-apiserver v0.33.5 h1:93NZh6rmrcamX/tfv/dZrTsMiQX69ufANmDcKPEgSeA=
+-k8s.io/apiextensions-apiserver v0.33.5/go.mod h1:JIbyQnNlu6nQa7b1vgFi51pmlXOk8mdn0WJwUJnz/7U=
+-k8s.io/apimachinery v0.33.5 h1:NiT64hln4TQXeYR18/ES39OrNsjGz8NguxsBgp+6QIo=
+-k8s.io/apimachinery v0.33.5/go.mod h1:BHW0YOu7n22fFv/JkYOEfkUYNRN0fj0BlvMFWA7b+SM=
+-k8s.io/apiserver v0.33.5 h1:X1Gy33r4YkRLRqTjGjofk7X1/EjSLEVSJ/A+1qjoj60=
+-k8s.io/apiserver v0.33.5/go.mod h1:Q+b5Btbc8x0PqOCeh/xBTesKk+cXQRN+PF2wdrTKDeg=
+-k8s.io/client-go v0.33.5 h1:I8BdmQGxInpkMEnJvV6iG7dqzP3JRlpZZlib3OMFc3o=
+-k8s.io/client-go v0.33.5/go.mod h1:W8PQP4MxbM4ypgagVE65mUUqK1/ByQkSALF9tzuQ6u0=
+-k8s.io/cloud-provider v0.33.5 h1:LyU8ZVID3Q8S/aEsPqv5bHCfPeo3NXKrD5iSBqHeV/U=
+-k8s.io/cloud-provider v0.33.5/go.mod h1:kSY4+DXKXhWmHLyuUDY09zTL9g9MbcOpahoVY6mzW8Q=
 +k8s.io/api v0.33.13 h1:Au/I/J8SXmcCBxp+KiS82451AEaKjVHouB1x3lUm1Wk=
 +k8s.io/api v0.33.13/go.mod h1:XCIdoR5NWEBB8xORizkh3zBSUk4Pz5KnfnGuOesy0+k=
 +k8s.io/apiextensions-apiserver v0.33.13 h1:T/79+dR0xlAEvx2Uf3EbWViMGy+NlFNmU05k8UEbrYk=
@@ -552,22 +552,22 @@ index daf0a160f..223f5b5a4 100644
  k8s.io/cloud-provider-aws v1.27.0/go.mod h1:9vUb5mnVnReSRDBWcBxB1b0HOeEc472iOPmrnwpN9SA=
  k8s.io/cloud-provider-gcp/providers v0.28.2 h1:I65pFTLNMQSj7YuW3Mg3pZIXmw0naCmF6TGAuz4/sZE=
  k8s.io/cloud-provider-gcp/providers v0.28.2/go.mod h1:P8dxRvvLtX7xUwVUzA/QOqv8taCzBaVsVMnjnpjmYXE=
--k8s.io/code-generator v0.33.6 h1:1CFzvpqz3r52zjvikYaF5bvYZkKT6brMIMSB7odPaIs=
--k8s.io/code-generator v0.33.6/go.mod h1:ndnG7E7wSIOLMl2GASBRdoRitKGN5fp/qq5nKTmiTh8=
--k8s.io/component-base v0.33.6 h1:a4HGKS3Ax68W1xO1MpVnVybgeJ3OBjvLE9SALoezTZc=
--k8s.io/component-base v0.33.6/go.mod h1:rUo6Mge+6JvNLrhRzhotfGLxI0tyaQXbL2rnth4UEFw=
--k8s.io/component-helpers v0.33.6 h1:PvmETVzr4Deym6mn1klgMvARgJY9KuDWTZ39bVlKlZc=
--k8s.io/component-helpers v0.33.6/go.mod h1:rAX3imLcTAozWTRhR13/LAR3Mf8bksoayTpUdKZFUJo=
--k8s.io/controller-manager v0.33.6 h1:md2KM5RabX7KTTly1KmNDbNr5YJvLtse7sJOX2we8tI=
--k8s.io/controller-manager v0.33.6/go.mod h1:dtCyZIG+CNFI8hY/lQY7ZAOO20VxGm+lpi1do2fmLGY=
--k8s.io/cri-api v0.33.6 h1:yQXCHwWzedRSrPhy/r0QMI9a3jc6YpHnorfDBimdxng=
--k8s.io/cri-api v0.33.6/go.mod h1:OLQvT45OpIA+tv91ZrpuFIGY+Y2Ho23poS7n115Aocs=
--k8s.io/cri-client v0.33.6 h1:pVecZ/LeA3+wKJea8Rfp5jnVu0GYe6N/iFIM+lOBSCw=
--k8s.io/cri-client v0.33.6/go.mod h1:1z3JawYGs5KTJasU+3QBhXlovZHrXIEkgTfHAWwvpmc=
--k8s.io/csi-translation-lib v0.33.6 h1:ns0+YQ8R0lbFmAOSVgTLBvav2LrvONz7Uy3M2rpf/6E=
--k8s.io/csi-translation-lib v0.33.6/go.mod h1:t266CgUYPVdST8pjPaCOEDLejWwV1Tms5igy8FVYyQo=
--k8s.io/dynamic-resource-allocation v0.33.6 h1:HrPUowR+KvxmgPNin+e424PA4rWFPd/W25W1jULKapk=
--k8s.io/dynamic-resource-allocation v0.33.6/go.mod h1:ByWsZ+8UxTvPC4UmyWdevUIGzxIrgmiyxcddLsKkGuY=
+-k8s.io/code-generator v0.33.5 h1:KwkOvhwAaorjSwF2MQhhdhL3i8bBmAal/TWhX67kdHw=
+-k8s.io/code-generator v0.33.5/go.mod h1:Ra+sdZquRakeTGcEnQAPw6BmlZ92IvxwQQTX/XOvOIE=
+-k8s.io/component-base v0.33.5 h1:4D3kxjEx1pJRy3WHAZsmX3+LCpmd4ftE+2J4v6naTnQ=
+-k8s.io/component-base v0.33.5/go.mod h1:Zma1YjBVuuGxIbspj1vGR3/5blzo2ARf1v0QTtog1to=
+-k8s.io/component-helpers v0.33.5 h1:1LDSMzn7YTreVLPaOBJK36ase/FWi2sDpeJJvbEBO2s=
+-k8s.io/component-helpers v0.33.5/go.mod h1:C3HsDU2lANSLgTTgMJ0TFnG5xZrVrxR3Ss9n7Wrsw4s=
+-k8s.io/controller-manager v0.33.5 h1:abmssknXnhOhW533583v2SYQObD5RhYiSL7Za1rezGM=
+-k8s.io/controller-manager v0.33.5/go.mod h1:KuQeAlf4vI2+qj5fwPVLaDlbtrTBA/8L/LqQvI74Ow0=
+-k8s.io/cri-api v0.33.5 h1:UBYYKZwaFTaAJj1gF6vYy/iSkWk5pIVaoTjjF6ltUCs=
+-k8s.io/cri-api v0.33.5/go.mod h1:OLQvT45OpIA+tv91ZrpuFIGY+Y2Ho23poS7n115Aocs=
+-k8s.io/cri-client v0.33.5 h1:RjkIlunp2NxKPQLvD9XlQwjliz71L0jljmIrGGxPZAU=
+-k8s.io/cri-client v0.33.5/go.mod h1:apcc+zemlSsvajH3a61bARqArBN2YkQueMe820qiVjQ=
+-k8s.io/csi-translation-lib v0.33.5 h1:CatOlpJtSJ9eliQWvGsdjWBdOFgQvIlyaVXfs1QojTY=
+-k8s.io/csi-translation-lib v0.33.5/go.mod h1:/7unRR1EEbxjjDcUN3v5Qc3vSPy3vwwFbuTPzk/raCo=
+-k8s.io/dynamic-resource-allocation v0.33.5 h1:rWNQB06AMTufOODf1H9BMM7Qw0fBKP0KA2mHEuEmkQQ=
+-k8s.io/dynamic-resource-allocation v0.33.5/go.mod h1:b9RAX4x8WFTMYonx7yZTDqC4++LwIMJNq+CuN5/s9lU=
 +k8s.io/code-generator v0.33.13 h1:Sh43djpZsCbl5pnyItPTg9lkI7MoaWWskSKEI+EBvJU=
 +k8s.io/code-generator v0.33.13/go.mod h1:O3l2FNWNulmf8U92o1QCb9MN9IBbfLUkKNeuDqA7mJg=
 +k8s.io/component-base v0.33.13 h1:WPsAyiWqSs2q06BDz5esM2FGchCMz5lxsQlLu6h9D4o=
@@ -588,22 +588,22 @@ index daf0a160f..223f5b5a4 100644
  k8s.io/gengo/v2 v2.0.0-20250207200755-1244d31929d7/go.mod h1:EJykeLsmFC60UQbYJezXkEsG2FLrt0GPNkU5iK5GWxU=
  k8s.io/klog/v2 v2.130.1 h1:n9Xl7H1Xvksem4KFG4PYbdQCQxqc/tTUyrgXaOhHSzk=
  k8s.io/klog/v2 v2.130.1/go.mod h1:3Jpz1GvMt720eyJH1ckRHK1EDfpxISzJ7I9OYgaDtPE=
--k8s.io/kms v0.33.6 h1:WLiXK7bK3rXd8UhSvjJZKUqciirM+2zCI833v0jYi7g=
--k8s.io/kms v0.33.6/go.mod h1:C1I8mjFFBNzfUZXYt9FZVJ8MJl7ynFbGgZFbBzkBJ3E=
+-k8s.io/kms v0.33.5 h1:u60sDBe4Fz6PLeiNF13sEahjIU428ajiWuIw7NSVBlg=
+-k8s.io/kms v0.33.5/go.mod h1:C1I8mjFFBNzfUZXYt9FZVJ8MJl7ynFbGgZFbBzkBJ3E=
 +k8s.io/kms v0.33.13 h1:3iOoN/SItJgPGEZKugYrTiPVcMNVyfkY/8PUosnulh0=
 +k8s.io/kms v0.33.13/go.mod h1:C1I8mjFFBNzfUZXYt9FZVJ8MJl7ynFbGgZFbBzkBJ3E=
  k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff h1:/usPimJzUKKu+m+TE36gUyGcf03XZEP0ZIKgKj35LS4=
  k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff/go.mod h1:5jIi+8yX4RIb8wk3XwBo5Pq2ccx4FP10ohkbSKCZoK8=
--k8s.io/kube-scheduler v0.33.6 h1:yBpdIRClZdvPJfVysT1cuCnT9JdHiFnjw4FSJSk/DLQ=
--k8s.io/kube-scheduler v0.33.6/go.mod h1:sBWp6XruPN0mVxNos0DW4UPhi+lX4fwSoQn2X20KI2A=
--k8s.io/kubectl v0.33.6 h1:zTZoafstb7rQ3NpTTnyN47goJOOpqIpf0mXDlVSHJ4o=
--k8s.io/kubectl v0.33.6/go.mod h1:G6iCkPDPQbCbIp01QkD29wdo5hSkBQ2c7vv9YtOUPME=
--k8s.io/kubelet v0.33.6 h1:0wlT1iyZwx+2iCgsCCgi22YU5vY82vW01f6X3pWP48A=
--k8s.io/kubelet v0.33.6/go.mod h1:Nkjry+BISpPNb0WroNJVRYjOe7YacvDYNMbFXMyHEdU=
--k8s.io/kubernetes v1.33.6 h1:NOIZqkx8M4XfdyRKllzLSBiMgSilPzSvCembfzOMk6A=
--k8s.io/kubernetes v1.33.6/go.mod h1:eJiHC143tnNSvmDkCRwGNKA80yXqBvYC3U8L/i67nAY=
--k8s.io/mount-utils v0.33.6 h1:C7WqPt0KU7wvU6ay5tu5gkzhrnYIuQOsBGI/lFcvG4Q=
--k8s.io/mount-utils v0.33.6/go.mod h1:1JR4rKymg8B8bCPo618hpSAdrpO6XLh0Acqok/xVwPE=
+-k8s.io/kube-scheduler v0.33.5 h1:eqZHF4H4F33XF7yGIK4quk1DxGACexINNuNJlO4M1ZY=
+-k8s.io/kube-scheduler v0.33.5/go.mod h1:n004Qs3SWbLMJ6PuPtwkS377CqaaKUeYFzqb1+4IaA8=
+-k8s.io/kubectl v0.33.5 h1:/wj5EjXXrVeSd8+FcZ2sIIP1PlQkq8HWsR9T1Nsl32c=
+-k8s.io/kubectl v0.33.5/go.mod h1:YrBGE7U+nz7+UatG+aNDocIQtdTyqN528dwFCv6+Kuw=
+-k8s.io/kubelet v0.33.5 h1:PYV+O8B6ZoQMDaQdYTSCzNdQTLdjAAWTspS2KkNfjLQ=
+-k8s.io/kubelet v0.33.5/go.mod h1:8SQ/0fgyNwm6zjHktBhPAUlgtji19YMa2lhSlYKUhrA=
+-k8s.io/kubernetes v1.33.5 h1:uf0/5VVQodYf61FudCbwtWjg5ApQcKKA7mwanTLjxyw=
+-k8s.io/kubernetes v1.33.5/go.mod h1:nrt8sldmckKz2fCZhgRX3SKfS2e+CzXATPv6ITNkU00=
+-k8s.io/mount-utils v0.33.5 h1:Dc+t8nfUD+k0kvDyzWqsIxYPd3+KMuVQae2Gr8BAmxs=
+-k8s.io/mount-utils v0.33.5/go.mod h1:1JR4rKymg8B8bCPo618hpSAdrpO6XLh0Acqok/xVwPE=
 +k8s.io/kube-scheduler v0.33.13 h1:LkIYb1UPpc6QIu0Jftil9aaQBbgsx3fYSYYvBe/FolA=
 +k8s.io/kube-scheduler v0.33.13/go.mod h1:sbxw0VAFQKqe8oeN0IbcfLV7wBv5pEXCG/ccLEYGKHA=
 +k8s.io/kubectl v0.33.13 h1:6RLgHYABIYqOccAyg8beGJgY48oXlrKl0kTmDrSerYc=

--- a/modules/040-node-manager/images/cluster-autoscaler/patches/1.33/001-go-mod.patch
+++ b/modules/040-node-manager/images/cluster-autoscaler/patches/1.33/001-go-mod.patch
@@ -1,44 +1,56 @@
 diff --git a/cluster-autoscaler/apis/go.mod b/cluster-autoscaler/apis/go.mod
-index 572ba909a..849edfe12 100644
+index 3ac7f4768..5fa92f6f9 100644
 --- a/cluster-autoscaler/apis/go.mod
 +++ b/cluster-autoscaler/apis/go.mod
-@@ -1,6 +1,6 @@
+@@ -1,13 +1,10 @@
  module k8s.io/autoscaler/cluster-autoscaler/apis
  
--go 1.24.0
+-go 1.23.0
+-
+-toolchain go1.23.2
 +go 1.25.0
  
  require (
  	github.com/onsi/ginkgo/v2 v2.21.0
-@@ -34,15 +34,16 @@ require (
+ 	github.com/onsi/gomega v1.35.1
+-	k8s.io/api v0.32.0
+ 	k8s.io/apimachinery v0.32.3
+ 	k8s.io/client-go v0.32.0
+ 	k8s.io/code-generator v0.32.0
+@@ -39,19 +36,21 @@ require (
  	github.com/pkg/errors v0.9.1 // indirect
  	github.com/spf13/pflag v1.0.5 // indirect
  	github.com/x448/float16 v0.8.4 // indirect
 -	golang.org/x/mod v0.21.0 // indirect
--	golang.org/x/net v0.38.0 // indirect
+-	golang.org/x/net v0.30.0 // indirect
 +	golang.org/x/mod v0.35.0 // indirect
 +	golang.org/x/net v0.55.0 // indirect
- 	golang.org/x/oauth2 v0.27.0 // indirect
--	golang.org/x/sync v0.12.0 // indirect
--	golang.org/x/sys v0.31.0 // indirect
--	golang.org/x/term v0.30.0 // indirect
--	golang.org/x/text v0.23.0 // indirect
+ 	golang.org/x/oauth2 v0.23.0 // indirect
+-	golang.org/x/sync v0.8.0 // indirect
+-	golang.org/x/sys v0.26.0 // indirect
+-	golang.org/x/term v0.25.0 // indirect
+-	golang.org/x/text v0.19.0 // indirect
 +	golang.org/x/sync v0.20.0 // indirect
 +	golang.org/x/sys v0.45.0 // indirect
 +	golang.org/x/term v0.43.0 // indirect
 +	golang.org/x/text v0.37.0 // indirect
- 	golang.org/x/time v0.9.0 // indirect
+ 	golang.org/x/time v0.7.0 // indirect
 -	golang.org/x/tools v0.26.0 // indirect
 +	golang.org/x/tools v0.44.0 // indirect
 +	golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated // indirect
- 	google.golang.org/protobuf v1.36.5 // indirect
+ 	google.golang.org/protobuf v1.35.1 // indirect
  	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
  	gopkg.in/inf.v0 v0.9.1 // indirect
+ 	gopkg.in/yaml.v3 v3.0.1 // indirect
++	k8s.io/api v0.32.0 // indirect
+ 	k8s.io/gengo/v2 v2.0.0-20240911193312-2b36238f13e9 // indirect
+ 	k8s.io/klog/v2 v2.130.1 // indirect
+ 	k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f // indirect
 diff --git a/cluster-autoscaler/apis/go.sum b/cluster-autoscaler/apis/go.sum
-index d516de6f1..2c0095202 100644
+index 701a0e94c..4c7077458 100644
 --- a/cluster-autoscaler/apis/go.sum
 +++ b/cluster-autoscaler/apis/go.sum
-@@ -87,40 +87,44 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
+@@ -88,40 +88,44 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
  golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
  golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
  golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
@@ -50,38 +62,38 @@ index d516de6f1..2c0095202 100644
  golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
  golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
  golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
--golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
--golang.org/x/net v0.38.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
+-golang.org/x/net v0.30.0 h1:AcW1SDZMkb8IpzCdQUaIq2sP4sZ4zw+55h6ynffypl4=
+-golang.org/x/net v0.30.0/go.mod h1:2wGyMJ5iFasEhkwi13ChkO/t1ECNC4X4eBKkVFyYFlU=
 +golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
 +golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
- golang.org/x/oauth2 v0.27.0 h1:da9Vo7/tDv5RH/7nZDz1eMGS/q1Vv1N/7FCrBhI9I3M=
- golang.org/x/oauth2 v0.27.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT8=
+ golang.org/x/oauth2 v0.23.0 h1:PbgcYx2W7i4LvjJWEbf0ngHV6qJYr86PkAV3bXdLEbs=
+ golang.org/x/oauth2 v0.23.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
  golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
  golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
  golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
--golang.org/x/sync v0.12.0 h1:MHc5BpPuC30uJk597Ri8TV3CNZcTLu6B6z4lJy+g6Jw=
--golang.org/x/sync v0.12.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
+-golang.org/x/sync v0.8.0 h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=
+-golang.org/x/sync v0.8.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 +golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
 +golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
  golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
  golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
  golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
--golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
--golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
--golang.org/x/term v0.30.0 h1:PQ39fJZ+mfadBm0y5WlL4vlM7Sx1Hgf13sMIY2+QS9Y=
--golang.org/x/term v0.30.0/go.mod h1:NYYFdzHoI5wRh/h5tDMdMqCqPJZEuNqVR5xJLd/n67g=
+-golang.org/x/sys v0.26.0 h1:KHjCJyddX0LoSTb3J+vWpupP9p0oznkqVk/IfjymZbo=
+-golang.org/x/sys v0.26.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+-golang.org/x/term v0.25.0 h1:WtHI/ltw4NvSUig5KARz9h521QvRC8RmF/cuYqifU24=
+-golang.org/x/term v0.25.0/go.mod h1:RPyXicDX+6vLxogjjRxjgD2TKtmAO6NZBsBRfrOLu7M=
 +golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 +golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 +golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=
 +golang.org/x/term v0.43.0/go.mod h1:lrhlHNdQJHO+1qVYiHfFKVuVioJIheAc3fBSMFYEIsk=
  golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
  golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
--golang.org/x/text v0.23.0 h1:D71I7dUrlY+VX0gQShAThNGHFxZ13dGLBHQLVl1mJlY=
--golang.org/x/text v0.23.0/go.mod h1:/BLNzu4aZCJ1+kcD0DNRotWKage4q2rGVAg4o22unh4=
+-golang.org/x/text v0.19.0 h1:kTxAhCbGbxhK0IwgSKiMO5awPoDQ0RpfiVYBfK860YM=
+-golang.org/x/text v0.19.0/go.mod h1:BuEKDfySbSR4drPmRPG/7iBdf8hvFMuRexcpahXilzY=
 +golang.org/x/text v0.37.0 h1:Cqjiwd9eSg8e0QAkyCaQTNHFIIzWtidPahFWR83rTrc=
 +golang.org/x/text v0.37.0/go.mod h1:a5sjxXGs9hsn/AJVwuElvCAo9v8QYLzvavO5z2PiM38=
- golang.org/x/time v0.9.0 h1:EsRrnYcQiGH+5FfbgvV4AP7qEZstoyrHB0DzarOQ4ZY=
- golang.org/x/time v0.9.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
+ golang.org/x/time v0.7.0 h1:ntUhktv3OPE6TgYxXWv9vKvUSJyIFJlyohwbkEwPrKQ=
+ golang.org/x/time v0.7.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
  golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
  golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
  golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
@@ -98,112 +110,57 @@ index d516de6f1..2c0095202 100644
  golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
  golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 diff --git a/cluster-autoscaler/go.mod b/cluster-autoscaler/go.mod
-index d300c0846..fdc4d6095 100644
+index ee33cde31..4db6ffffc 100644
 --- a/cluster-autoscaler/go.mod
 +++ b/cluster-autoscaler/go.mod
-@@ -1,6 +1,6 @@
+@@ -1,8 +1,6 @@
  module k8s.io/autoscaler/cluster-autoscaler
  
--go 1.24.0
+-go 1.23.0
+-
+-toolchain go1.23.2
 +go 1.25.0
  
  require (
- 	cloud.google.com/go/compute/metadata v0.5.0
-@@ -29,32 +29,32 @@ require (
- 	github.com/pkg/errors v0.9.1
- 	github.com/prometheus/client_golang v1.22.0
- 	github.com/spf13/pflag v1.0.5
--	github.com/stretchr/testify v1.10.0
-+	github.com/stretchr/testify v1.11.1
+ 	cloud.google.com/go/compute/metadata v0.3.0
+@@ -39,9 +37,9 @@ require (
+ 	github.com/stretchr/testify v1.9.0
  	github.com/vburenin/ifacemaker v1.2.1
  	go.uber.org/mock v0.4.0
--	golang.org/x/crypto v0.36.0
 -	golang.org/x/net v0.38.0
-+	golang.org/x/crypto v0.52.0
 +	golang.org/x/net v0.55.0
  	golang.org/x/oauth2 v0.27.0
 -	golang.org/x/sys v0.31.0
 +	golang.org/x/sys v0.45.0
  	google.golang.org/api v0.151.0
- 	google.golang.org/grpc v1.68.1
- 	google.golang.org/protobuf v1.36.5
- 	gopkg.in/gcfg.v1 v1.2.3
- 	gopkg.in/yaml.v2 v2.4.0
--	k8s.io/api v0.33.5
--	k8s.io/apimachinery v0.33.5
--	k8s.io/apiserver v0.33.5
-+	k8s.io/api v0.33.13
-+	k8s.io/apimachinery v0.33.13
-+	k8s.io/apiserver v0.33.13
- 	k8s.io/autoscaler/cluster-autoscaler/apis v0.0.0-20240627115740-d52e4b9665d7
--	k8s.io/client-go v0.33.5
-+	k8s.io/client-go v0.33.13
- 	k8s.io/cloud-provider v0.33.1
- 	k8s.io/cloud-provider-aws v1.27.0
- 	k8s.io/cloud-provider-gcp/providers v0.28.2
--	k8s.io/component-base v0.33.5
--	k8s.io/component-helpers v0.33.5
-+	k8s.io/component-base v0.33.13
-+	k8s.io/component-helpers v0.33.13
- 	k8s.io/dynamic-resource-allocation v0.33.1
+ 	google.golang.org/grpc v1.65.0
+ 	google.golang.org/protobuf v1.36.1
+@@ -60,7 +58,7 @@ require (
+ 	k8s.io/dynamic-resource-allocation v0.0.0
  	k8s.io/klog/v2 v2.130.1
--	k8s.io/kubelet v0.33.5
--	k8s.io/kubernetes v1.33.5
-+	k8s.io/kubelet v0.33.13
-+	k8s.io/kubernetes v1.33.13
+ 	k8s.io/kubelet v0.32.0
+-	k8s.io/kubernetes v1.32.0
++	k8s.io/kubernetes v1.32.10
  	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738
  	sigs.k8s.io/cloud-provider-azure v1.29.4
  	sigs.k8s.io/cloud-provider-azure/pkg/azclient v0.0.13
-@@ -113,7 +113,7 @@ require (
- 	github.com/felixge/httpsnoop v1.0.4 // indirect
- 	github.com/fsnotify/fsnotify v1.7.0 // indirect
- 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
--	github.com/go-logr/logr v1.4.2 // indirect
-+	github.com/go-logr/logr v1.4.3 // indirect
- 	github.com/go-logr/stdr v1.2.2 // indirect
- 	github.com/go-logr/zapr v1.3.0 // indirect
- 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
-@@ -146,7 +146,7 @@ require (
- 	github.com/mailru/easyjson v0.7.7 // indirect
- 	github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible // indirect
- 	github.com/mitchellh/go-homedir v1.1.0 // indirect
--	github.com/moby/spdystream v0.5.0 // indirect
-+	github.com/moby/spdystream v0.5.1 // indirect
- 	github.com/moby/sys/mountinfo v0.7.2 // indirect
- 	github.com/moby/sys/userns v0.1.0 // indirect
- 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-@@ -156,7 +156,7 @@ require (
- 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
- 	github.com/onsi/ginkgo/v2 v2.21.0 // indirect
- 	github.com/onsi/gomega v1.35.1 // indirect
--	github.com/opencontainers/cgroups v0.0.1 // indirect
-+	github.com/opencontainers/cgroups v0.0.3 // indirect
- 	github.com/opencontainers/go-digest v1.0.0 // indirect
- 	github.com/opencontainers/image-spec v1.1.1 // indirect
- 	github.com/opencontainers/runtime-spec v1.2.0 // indirect
-@@ -175,26 +175,27 @@ require (
- 	go.etcd.io/etcd/client/pkg/v3 v3.5.21 // indirect
- 	go.etcd.io/etcd/client/v3 v3.5.21 // indirect
- 	go.opencensus.io v0.24.0 // indirect
--	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-+	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
- 	go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful v0.42.0 // indirect
- 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.58.0 // indirect
- 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.58.0 // indirect
--	go.opentelemetry.io/otel v1.33.0 // indirect
-+	go.opentelemetry.io/otel v1.41.0 // indirect
- 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.33.0 // indirect
- 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.33.0 // indirect
--	go.opentelemetry.io/otel/metric v1.33.0 // indirect
-+	go.opentelemetry.io/otel/metric v1.41.0 // indirect
- 	go.opentelemetry.io/otel/sdk v1.33.0 // indirect
--	go.opentelemetry.io/otel/trace v1.33.0 // indirect
-+	go.opentelemetry.io/otel/trace v1.41.0 // indirect
- 	go.opentelemetry.io/proto/otlp v1.4.0 // indirect
+@@ -90,7 +88,7 @@ require (
+ 	github.com/GoogleCloudPlatform/k8s-cloud-provider v1.25.0 // indirect
+ 	github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab // indirect
+ 	github.com/Microsoft/go-winio v0.6.2 // indirect
+-	github.com/Microsoft/hnslib v0.0.8 // indirect
++	github.com/Microsoft/hnslib v0.1.1 // indirect
+ 	github.com/NYTimes/gziphandler v1.1.1 // indirect
+ 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
+ 	github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2 // indirect
+@@ -188,14 +186,15 @@ require (
+ 	go.opentelemetry.io/proto/otlp v1.3.1 // indirect
  	go.uber.org/multierr v1.11.0 // indirect
  	go.uber.org/zap v1.27.0 // indirect
+-	golang.org/x/crypto v0.36.0 // indirect
++	golang.org/x/crypto v0.51.0 // indirect
  	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
--	golang.org/x/mod v0.21.0 // indirect
+-	golang.org/x/mod v0.23.0 // indirect
 -	golang.org/x/sync v0.12.0 // indirect
 -	golang.org/x/term v0.30.0 // indirect
 -	golang.org/x/text v0.23.0 // indirect
@@ -211,248 +168,52 @@ index d300c0846..fdc4d6095 100644
 +	golang.org/x/sync v0.20.0 // indirect
 +	golang.org/x/term v0.43.0 // indirect
 +	golang.org/x/text v0.37.0 // indirect
- 	golang.org/x/time v0.9.0 // indirect
--	golang.org/x/tools v0.26.0 // indirect
+ 	golang.org/x/time v0.7.0 // indirect
+-	golang.org/x/tools v0.30.0 // indirect
 +	golang.org/x/tools v0.44.0 // indirect
-+	golang.org/x/tools/go/expect v0.1.1-deprecated // indirect
- 	google.golang.org/genproto/googleapis/api v0.0.0-20241209162323-e6fa225c2576 // indirect
- 	google.golang.org/genproto/googleapis/rpc v0.0.0-20241209162323-e6fa225c2576 // indirect
++	golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated // indirect
+ 	google.golang.org/genproto/googleapis/api v0.0.0-20240826202546-f6391c0de4c7 // indirect
+ 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240826202546-f6391c0de4c7 // indirect
  	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
-@@ -203,13 +204,13 @@ require (
- 	gopkg.in/warnings.v0 v0.1.2 // indirect
- 	gopkg.in/yaml.v3 v3.0.1 // indirect
- 	k8s.io/apiextensions-apiserver v0.0.0 // indirect
--	k8s.io/code-generator v0.33.5 // indirect
--	k8s.io/controller-manager v0.33.5 // indirect
--	k8s.io/cri-api v0.33.5 // indirect
-+	k8s.io/code-generator v0.33.13 // indirect
-+	k8s.io/controller-manager v0.33.13 // indirect
-+	k8s.io/cri-api v0.33.13 // indirect
- 	k8s.io/cri-client v0.0.0 // indirect
- 	k8s.io/csi-translation-lib v0.27.0 // indirect
- 	k8s.io/gengo/v2 v2.0.0-20250207200755-1244d31929d7 // indirect
--	k8s.io/kms v0.33.5 // indirect
-+	k8s.io/kms v0.33.13 // indirect
- 	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff // indirect
- 	k8s.io/kube-scheduler v0.0.0 // indirect
- 	k8s.io/kubectl v0.28.0 // indirect
-@@ -221,66 +222,66 @@ require (
- 	sigs.k8s.io/structured-merge-diff/v4 v4.6.0 // indirect
- )
- 
--replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.33.5
-+replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.33.13
- 
--replace k8s.io/code-generator => k8s.io/code-generator v0.33.5
-+replace k8s.io/code-generator => k8s.io/code-generator v0.33.13
- 
--replace k8s.io/cri-api => k8s.io/cri-api v0.33.5
-+replace k8s.io/cri-api => k8s.io/cri-api v0.33.13
- 
--replace k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.33.5
-+replace k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.33.13
- 
--replace k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.33.5
-+replace k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.33.13
- 
--replace k8s.io/kubectl => k8s.io/kubectl v0.33.5
-+replace k8s.io/kubectl => k8s.io/kubectl v0.33.13
- 
--replace k8s.io/mount-utils => k8s.io/mount-utils v0.33.5
-+replace k8s.io/mount-utils => k8s.io/mount-utils v0.33.13
- 
--replace k8s.io/kms => k8s.io/kms v0.33.5
-+replace k8s.io/kms => k8s.io/kms v0.33.13
- 
- replace k8s.io/autoscaler/cluster-autoscaler/apis => ./apis
- 
--replace k8s.io/cri-client => k8s.io/cri-client v0.33.5
-+replace k8s.io/cri-client => k8s.io/cri-client v0.33.13
- 
--replace k8s.io/api => k8s.io/api v0.33.5
-+replace k8s.io/api => k8s.io/api v0.33.13
- 
--replace k8s.io/apimachinery => k8s.io/apimachinery v0.33.5
-+replace k8s.io/apimachinery => k8s.io/apimachinery v0.33.13
- 
--replace k8s.io/apiserver => k8s.io/apiserver v0.33.5
-+replace k8s.io/apiserver => k8s.io/apiserver v0.33.13
- 
--replace k8s.io/cli-runtime => k8s.io/cli-runtime v0.33.5
-+replace k8s.io/cli-runtime => k8s.io/cli-runtime v0.33.13
- 
--replace k8s.io/client-go => k8s.io/client-go v0.33.5
-+replace k8s.io/client-go => k8s.io/client-go v0.33.13
- 
--replace k8s.io/cloud-provider => k8s.io/cloud-provider v0.33.5
-+replace k8s.io/cloud-provider => k8s.io/cloud-provider v0.33.13
- 
--replace k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.33.5
-+replace k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.33.13
- 
--replace k8s.io/component-base => k8s.io/component-base v0.33.5
-+replace k8s.io/component-base => k8s.io/component-base v0.33.13
- 
--replace k8s.io/component-helpers => k8s.io/component-helpers v0.33.5
-+replace k8s.io/component-helpers => k8s.io/component-helpers v0.33.13
- 
--replace k8s.io/controller-manager => k8s.io/controller-manager v0.33.5
-+replace k8s.io/controller-manager => k8s.io/controller-manager v0.33.13
- 
--replace k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.33.5
-+replace k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.33.13
- 
--replace k8s.io/endpointslice => k8s.io/endpointslice v0.33.5
-+replace k8s.io/endpointslice => k8s.io/endpointslice v0.33.13
- 
--replace k8s.io/externaljwt => k8s.io/externaljwt v0.33.5
-+replace k8s.io/externaljwt => k8s.io/externaljwt v0.33.13
- 
--replace k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.33.5
-+replace k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.33.13
- 
--replace k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.33.5
-+replace k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.33.13
- 
--replace k8s.io/kube-proxy => k8s.io/kube-proxy v0.33.5
-+replace k8s.io/kube-proxy => k8s.io/kube-proxy v0.33.13
- 
--replace k8s.io/kubelet => k8s.io/kubelet v0.33.5
-+replace k8s.io/kubelet => k8s.io/kubelet v0.33.13
- 
--replace k8s.io/metrics => k8s.io/metrics v0.33.5
-+replace k8s.io/metrics => k8s.io/metrics v0.33.13
- 
--replace k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.33.5
-+replace k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.33.13
- 
--replace k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.33.5
-+replace k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.33.13
- 
--replace k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.33.5
-+replace k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.33.13
- 
--replace k8s.io/sample-controller => k8s.io/sample-controller v0.33.5
-+replace k8s.io/sample-controller => k8s.io/sample-controller v0.33.13
 diff --git a/cluster-autoscaler/go.sum b/cluster-autoscaler/go.sum
-index cb1f8f025..7f64b4935 100644
+index 990e503f5..d5cf410eb 100644
 --- a/cluster-autoscaler/go.sum
 +++ b/cluster-autoscaler/go.sum
-@@ -165,8 +165,8 @@ github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyT
- github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv5E=
- github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXEeXQVeNoDQ=
- github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
--github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
--github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
-+github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
-+github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
- github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
- github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
- github.com/go-logr/zapr v1.3.0 h1:XGdV8XW8zdwFiwOA2Dryh1gj2KRQyOOoNmBy4EplIcQ=
-@@ -297,8 +297,8 @@ github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG
- github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
- github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=
- github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
--github.com/moby/spdystream v0.5.0 h1:7r0J1Si3QO/kjRitvSLVVFUjxMEb/YLj6S9FF62JBCU=
--github.com/moby/spdystream v0.5.0/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
-+github.com/moby/spdystream v0.5.1 h1:9sNYeYZUcci9R6/w7KDaFWEWeV4LStVG78Mpyq/Zm/Y=
-+github.com/moby/spdystream v0.5.1/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
- github.com/moby/sys/mountinfo v0.7.2 h1:1shs6aH5s4o5H2zQLn796ADW1wMrIwHsyJ2v9KouLrg=
- github.com/moby/sys/mountinfo v0.7.2/go.mod h1:1YOa8w8Ih7uW0wALDUgT1dTTSBrZ+HiBLGws92L2RU4=
- github.com/moby/sys/userns v0.1.0 h1:tVLXkFOxVu9A64/yh59slHVv9ahO9UIev4JZusOLG/g=
-@@ -318,8 +318,8 @@ github.com/onsi/ginkgo/v2 v2.21.0 h1:7rg/4f3rB88pb5obDgNZrNHrQ4e6WpjonchcpuBRnZM
- github.com/onsi/ginkgo/v2 v2.21.0/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=
- github.com/onsi/gomega v1.35.1 h1:Cwbd75ZBPxFSuZ6T+rN/WCb/gOc6YgFBXLlZLhC7Ds4=
- github.com/onsi/gomega v1.35.1/go.mod h1:PvZbdDc8J6XJEpDK4HCuRBm8a6Fzp9/DmhC9C7yFlog=
--github.com/opencontainers/cgroups v0.0.1 h1:MXjMkkFpKv6kpuirUa4USFBas573sSAY082B4CiHEVA=
--github.com/opencontainers/cgroups v0.0.1/go.mod h1:s8lktyhlGUqM7OSRL5P7eAW6Wb+kWPNvt4qvVfzA5vs=
-+github.com/opencontainers/cgroups v0.0.3 h1:Jc9dWh/0YLGjdy6J/9Ln8NM5BfTA4W2BY0GMozy3aDU=
-+github.com/opencontainers/cgroups v0.0.3/go.mod h1:s8lktyhlGUqM7OSRL5P7eAW6Wb+kWPNvt4qvVfzA5vs=
- github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
- github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
- github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
-@@ -344,8 +344,8 @@ github.com/prometheus/common v0.62.0 h1:xasJaQlnWAeyHdUBeGjXmutelfJHWMRr+Fg4QszZ
- github.com/prometheus/common v0.62.0/go.mod h1:vyBcEuLSvWos9B1+CyL7JZ2up+uFzXhkqml0W5zIY1I=
- github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
- github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
--github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
--github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
-+github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
-+github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
- github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
- github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
- github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
-@@ -368,8 +368,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
- github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
- github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
- github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
--github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
--github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
-+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
- github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75 h1:6fotK7otjonDflCTK0BCfls4SPy3NcCVb5dqqmbRknE=
- github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75/go.mod h1:KO6IkyS8Y3j8OdNO85qEYBsRPuteD+YciPomcXdrMnk=
- github.com/vburenin/ifacemaker v1.2.1 h1:3Vq8B/bfBgjWTkv+jDg4dVL1KHt3k1K4lO7XRxYA2sk=
-@@ -400,8 +400,8 @@ go.etcd.io/etcd/server/v3 v3.5.21 h1:9w0/k12majtgarGmlMVuhwXRI2ob3/d1Ik3X5TKo0yU
- go.etcd.io/etcd/server/v3 v3.5.21/go.mod h1:G1mOzdwuzKT1VRL7SqRchli/qcFrtLBTAQ4lV20sXXo=
- go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
- go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
--go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
--go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
-+go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
-+go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
- go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful v0.42.0 h1:Z6SbqeRZAl2OczfkFOqLx1BeYBDYehNjEnqluD7581Y=
- go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful v0.42.0/go.mod h1:XiglO+8SPMqM3Mqh5/rtxR1VHc63o8tb38QrU6tm4mU=
- go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.58.0 h1:PS8wXpbyaDJQ2VDHHncMe9Vct0Zn1fEjpsjrLxGJoSc=
-@@ -410,18 +410,18 @@ go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.58.0 h1:yd02MEj
- go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.58.0/go.mod h1:umTcuxiv1n/s/S6/c2AT/g2CQ7u5C59sHDNmfSwgz7Q=
- go.opentelemetry.io/contrib/propagators/b3 v1.17.0 h1:ImOVvHnku8jijXqkwCSyYKRDt2YrnGXD4BbhcpfbfJo=
- go.opentelemetry.io/contrib/propagators/b3 v1.17.0/go.mod h1:IkfUfMpKWmynvvE0264trz0sf32NRTZL4nuAN9AbWRc=
--go.opentelemetry.io/otel v1.33.0 h1:/FerN9bax5LoK51X/sI0SVYrjSE0/yUL7DpxW4K3FWw=
--go.opentelemetry.io/otel v1.33.0/go.mod h1:SUUkR6csvUQl+yjReHu5uM3EtVV7MBm5FHKRlNx4I8I=
-+go.opentelemetry.io/otel v1.41.0 h1:YlEwVsGAlCvczDILpUXpIpPSL/VPugt7zHThEMLce1c=
-+go.opentelemetry.io/otel v1.41.0/go.mod h1:Yt4UwgEKeT05QbLwbyHXEwhnjxNO6D8L5PQP51/46dE=
- go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.33.0 h1:Vh5HayB/0HHfOQA7Ctx69E/Y/DcQSMPpKANYVMQ7fBA=
- go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.33.0/go.mod h1:cpgtDBaqD/6ok/UG0jT15/uKjAY8mRA53diogHBg3UI=
- go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.33.0 h1:5pojmb1U1AogINhN3SurB+zm/nIcusopeBNp42f45QM=
- go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.33.0/go.mod h1:57gTHJSE5S1tqg+EKsLPlTWhpHMsWlVmer+LA926XiA=
--go.opentelemetry.io/otel/metric v1.33.0 h1:r+JOocAyeRVXD8lZpjdQjzMadVZp2M4WmQ+5WtEnklQ=
--go.opentelemetry.io/otel/metric v1.33.0/go.mod h1:L9+Fyctbp6HFTddIxClbQkjtubW6O9QS3Ann/M82u6M=
-+go.opentelemetry.io/otel/metric v1.41.0 h1:rFnDcs4gRzBcsO9tS8LCpgR0dxg4aaxWlJxCno7JlTQ=
-+go.opentelemetry.io/otel/metric v1.41.0/go.mod h1:xPvCwd9pU0VN8tPZYzDZV/BMj9CM9vs00GuBjeKhJps=
- go.opentelemetry.io/otel/sdk v1.33.0 h1:iax7M131HuAm9QkZotNHEfstof92xM+N8sr3uHXc2IM=
- go.opentelemetry.io/otel/sdk v1.33.0/go.mod h1:A1Q5oi7/9XaMlIWzPSxLRWOI8nG3FnzHJNbiENQuihM=
--go.opentelemetry.io/otel/trace v1.33.0 h1:cCJuF7LRjUFso9LPnEAHJDB2pqzp+hbO8eu1qqW2d/s=
--go.opentelemetry.io/otel/trace v1.33.0/go.mod h1:uIcdVUZMpTAmz0tI1z04GoVSezK37CbGV4fr1f2nBck=
-+go.opentelemetry.io/otel/trace v1.41.0 h1:Vbk2co6bhj8L59ZJ6/xFTskY+tGAbOnCtQGVVa9TIN0=
-+go.opentelemetry.io/otel/trace v1.41.0/go.mod h1:U1NU4ULCoxeDKc09yCWdWe+3QoyweJcISEVa1RBzOis=
- go.opentelemetry.io/proto/otlp v1.4.0 h1:TA9WRvW6zMwP+Ssb6fLoUIuirti1gGbP28GcKG1jgeg=
- go.opentelemetry.io/proto/otlp v1.4.0/go.mod h1:PPBWZIP98o2ElSqI35IHfu7hIhSwvc5N38Jw8pXuGFY=
- go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
-@@ -439,8 +439,8 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
+@@ -86,8 +86,8 @@ github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab h1:UKkYhof1njT1
+ github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab/go.mod h1:3VYc5hodBMJ5+l/7J4xAyMeuM2PNuepvHlGs8yilUCA=
+ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
+ github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
+-github.com/Microsoft/hnslib v0.0.8 h1:EBrIiRB7i/UYIXEC2yw22dn+RLzOmsc5S0bw2xf0Qus=
+-github.com/Microsoft/hnslib v0.0.8/go.mod h1:EYveQJlhKh2obmEIRB3uKN6dBd9pj1frPsrTGFppKuk=
++github.com/Microsoft/hnslib v0.1.1 h1:JsZy681SnvSOUAfCZVAxkX4LgQGp+CZZwPbLV0/pdF8=
++github.com/Microsoft/hnslib v0.1.1/go.mod h1:DRQR4IjLae6WHYVhW7uqe44hmFUiNhmaWA+jwMbz5tM=
+ github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cqUQ3I=
+ github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
+ github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=
+@@ -448,8 +448,8 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
  golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
  golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58=
  golang.org/x/crypto v0.17.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
 -golang.org/x/crypto v0.36.0 h1:AnAEvhDddvBdpY+uR+MyHmuZzzNqXSe/GvuDeob5L34=
 -golang.org/x/crypto v0.36.0/go.mod h1:Y4J0ReaxCR1IMaabaSMugxJES1EpwhBHhv2bDHklZvc=
-+golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
-+golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
++golang.org/x/crypto v0.51.0 h1:IBPXwPfKxY7cWQZ38ZCIRPI50YLeevDLlLnyC5wRGTI=
++golang.org/x/crypto v0.51.0/go.mod h1:8AdwkbraGNABw2kOX6YFPs3WM22XqI4EXEd8g+x7Oc8=
  golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
  golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 h1:2dVuKD2vS7b0QIHQbpyTISPd0LeHDbnYEryqj5Q1ug8=
  golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56/go.mod h1:M4RDyNAINzryxdtnbRXRL/OHtkFuWGRjvuhBJpk2IlY=
-@@ -452,8 +452,8 @@ golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+@@ -461,8 +461,8 @@ golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
  golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
  golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
  golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
--golang.org/x/mod v0.21.0 h1:vvrHzRwRfVKSiLrG+d4FMl/Qi4ukBCE6kZlTUkDYRT0=
--golang.org/x/mod v0.21.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
+-golang.org/x/mod v0.23.0 h1:Zb7khfcRGKk+kqfxFaP5tZqCnDZMjC5VtUBs87Hr6QM=
+-golang.org/x/mod v0.23.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
 +golang.org/x/mod v0.35.0 h1:Ww1D637e6Pg+Zb2KrWfHQUnH2dQRLBQyAtpr/haaJeM=
 +golang.org/x/mod v0.35.0/go.mod h1:+GwiRhIInF8wPm+4AoT6L0FA1QWAad3OMdTRx4tFYlU=
  golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
  golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
  golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
-@@ -471,8 +471,8 @@ golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug
- golang.org/x/net v0.1.0/go.mod h1:Cx3nUiGt4eDBEyega/BKRp+/AlGL8hYe7U9odMt2Cco=
+@@ -479,8 +479,8 @@ golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qx
+ golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
  golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
  golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
 -golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
@@ -462,7 +223,7 @@ index cb1f8f025..7f64b4935 100644
  golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
  golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
  golang.org/x/oauth2 v0.27.0 h1:da9Vo7/tDv5RH/7nZDz1eMGS/q1Vv1N/7FCrBhI9I3M=
-@@ -486,8 +486,8 @@ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJ
+@@ -494,8 +494,8 @@ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJ
  golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
  golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
  golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -473,7 +234,7 @@ index cb1f8f025..7f64b4935 100644
  golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
  golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
  golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-@@ -504,16 +504,16 @@ golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+@@ -512,15 +512,15 @@ golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
  golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
  golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
  golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
@@ -483,7 +244,6 @@ index cb1f8f025..7f64b4935 100644
 +golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
  golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
  golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
- golang.org/x/term v0.1.0/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
  golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=
  golang.org/x/term v0.8.0/go.mod h1:xPskH00ivmX89bAKVGSKKtLOWNx2+17Eiy94tnKShWo=
  golang.org/x/term v0.15.0/go.mod h1:BDl952bC7+uMoWR75FIrCDx79TPU9oHkTZ9yRbYOrX0=
@@ -494,7 +254,7 @@ index cb1f8f025..7f64b4935 100644
  golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
  golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
  golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-@@ -522,8 +522,8 @@ golang.org/x/text v0.4.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
+@@ -528,8 +528,8 @@ golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
  golang.org/x/text v0.7.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
  golang.org/x/text v0.9.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=
  golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
@@ -502,118 +262,32 @@ index cb1f8f025..7f64b4935 100644
 -golang.org/x/text v0.23.0/go.mod h1:/BLNzu4aZCJ1+kcD0DNRotWKage4q2rGVAg4o22unh4=
 +golang.org/x/text v0.37.0 h1:Cqjiwd9eSg8e0QAkyCaQTNHFIIzWtidPahFWR83rTrc=
 +golang.org/x/text v0.37.0/go.mod h1:a5sjxXGs9hsn/AJVwuElvCAo9v8QYLzvavO5z2PiM38=
- golang.org/x/time v0.9.0 h1:EsRrnYcQiGH+5FfbgvV4AP7qEZstoyrHB0DzarOQ4ZY=
- golang.org/x/time v0.9.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
+ golang.org/x/time v0.7.0 h1:ntUhktv3OPE6TgYxXWv9vKvUSJyIFJlyohwbkEwPrKQ=
+ golang.org/x/time v0.7.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
  golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
-@@ -537,8 +537,12 @@ golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4f
+@@ -543,8 +543,12 @@ golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4f
  golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
  golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
  golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
--golang.org/x/tools v0.26.0 h1:v/60pFQmzmT9ExmjDv2gGIfi3OqfKoEP6I5+umXlbnQ=
--golang.org/x/tools v0.26.0/go.mod h1:TPVVj70c7JJ3WCazhD8OdXcZg/og+b9+tH/KxylGwH0=
+-golang.org/x/tools v0.30.0 h1:BgcpHewrV5AUp2G9MebG4XPFI1E2W41zU1SaqVA9vJY=
+-golang.org/x/tools v0.30.0/go.mod h1:c347cR/OJfw5TI+GfX7RUPNMdDRRbjvYTS0jPyvsVtY=
 +golang.org/x/tools v0.44.0 h1:UP4ajHPIcuMjT1GqzDWRlalUEoY+uzoZKnhOjbIPD2c=
 +golang.org/x/tools v0.44.0/go.mod h1:KA0AfVErSdxRZIsOVipbv3rQhVXTnlU6UhKxHd1seDI=
-+golang.org/x/tools/go/expect v0.1.1-deprecated h1:jpBZDwmgPhXsKZC6WhL20P4b/wmnpsEAGHaNy0n/rJM=
-+golang.org/x/tools/go/expect v0.1.1-deprecated/go.mod h1:eihoPOH+FgIqa3FpoTwguz/bVUSGBlGQU67vpBeOrBY=
++golang.org/x/tools/go/expect v0.1.0-deprecated h1:jY2C5HGYR5lqex3gEniOQL0r7Dq5+VGVgY1nudX5lXY=
++golang.org/x/tools/go/expect v0.1.0-deprecated/go.mod h1:eihoPOH+FgIqa3FpoTwguz/bVUSGBlGQU67vpBeOrBY=
 +golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated h1:1h2MnaIAIXISqTFKdENegdpAgUXz6NrPEsbIeWaBRvM=
 +golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated/go.mod h1:RVAQXBGNv1ib0J382/DPCRS/BPnsGebyM1Gj5VSDpG8=
  golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
  golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
  golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-@@ -597,56 +601,56 @@ gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
- gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
- honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
- honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
--k8s.io/api v0.33.5 h1:YR+uhYj05jdRpcksv8kjSliW+v9hwXxn6Cv10aR8Juw=
--k8s.io/api v0.33.5/go.mod h1:2gzShdwXKT5yPGiqrTrn/U/nLZ7ZyT4WuAj3XGDVgVs=
--k8s.io/apiextensions-apiserver v0.33.5 h1:93NZh6rmrcamX/tfv/dZrTsMiQX69ufANmDcKPEgSeA=
--k8s.io/apiextensions-apiserver v0.33.5/go.mod h1:JIbyQnNlu6nQa7b1vgFi51pmlXOk8mdn0WJwUJnz/7U=
--k8s.io/apimachinery v0.33.5 h1:NiT64hln4TQXeYR18/ES39OrNsjGz8NguxsBgp+6QIo=
--k8s.io/apimachinery v0.33.5/go.mod h1:BHW0YOu7n22fFv/JkYOEfkUYNRN0fj0BlvMFWA7b+SM=
--k8s.io/apiserver v0.33.5 h1:X1Gy33r4YkRLRqTjGjofk7X1/EjSLEVSJ/A+1qjoj60=
--k8s.io/apiserver v0.33.5/go.mod h1:Q+b5Btbc8x0PqOCeh/xBTesKk+cXQRN+PF2wdrTKDeg=
--k8s.io/client-go v0.33.5 h1:I8BdmQGxInpkMEnJvV6iG7dqzP3JRlpZZlib3OMFc3o=
--k8s.io/client-go v0.33.5/go.mod h1:W8PQP4MxbM4ypgagVE65mUUqK1/ByQkSALF9tzuQ6u0=
--k8s.io/cloud-provider v0.33.5 h1:LyU8ZVID3Q8S/aEsPqv5bHCfPeo3NXKrD5iSBqHeV/U=
--k8s.io/cloud-provider v0.33.5/go.mod h1:kSY4+DXKXhWmHLyuUDY09zTL9g9MbcOpahoVY6mzW8Q=
-+k8s.io/api v0.33.13 h1:Au/I/J8SXmcCBxp+KiS82451AEaKjVHouB1x3lUm1Wk=
-+k8s.io/api v0.33.13/go.mod h1:XCIdoR5NWEBB8xORizkh3zBSUk4Pz5KnfnGuOesy0+k=
-+k8s.io/apiextensions-apiserver v0.33.13 h1:T/79+dR0xlAEvx2Uf3EbWViMGy+NlFNmU05k8UEbrYk=
-+k8s.io/apiextensions-apiserver v0.33.13/go.mod h1:gMQb7kUW++npZHBLo3wnGvlfJj/S5DsUPxX5PxIvbj8=
-+k8s.io/apimachinery v0.33.13 h1:e15J9pNLORqlAQ3/D2QdXvMTHJLl0PxDhike6iNcw20=
-+k8s.io/apimachinery v0.33.13/go.mod h1:a8VYBaEU2Z6n2IxTG2Hs6WX5i0wQFPGyl4YFab4kn90=
-+k8s.io/apiserver v0.33.13 h1:U4w4RKdwzsBeETIGGWV5y3LrPzhUwRw0X5fylRO0dOo=
-+k8s.io/apiserver v0.33.13/go.mod h1:n2QaM8cnu0NNQhplgqA0COZwBXmGOtULfO9cGVHt/s4=
-+k8s.io/client-go v0.33.13 h1:gyirIFpLEF9RltmrUkkObQFkxeumU2hRcxiDsVfrf1w=
-+k8s.io/client-go v0.33.13/go.mod h1:JcZUgHTHDjbLaFaGVNuGmef4iqKNqOzdtwDu3RlR058=
-+k8s.io/cloud-provider v0.33.13 h1:/KeHOuR4eAHfwtZfwMc3q8aKHYDhSi/b0+R5DMvTwJ0=
-+k8s.io/cloud-provider v0.33.13/go.mod h1:a0czTWHOO6QXoHLrHYT2A21o6lmvk84NNGSPNKX1BKo=
- k8s.io/cloud-provider-aws v1.27.0 h1:PF8YrH8QcN6JoXB3Xxlaz84SBDYMPunJuCc0cPuCWXA=
- k8s.io/cloud-provider-aws v1.27.0/go.mod h1:9vUb5mnVnReSRDBWcBxB1b0HOeEc472iOPmrnwpN9SA=
- k8s.io/cloud-provider-gcp/providers v0.28.2 h1:I65pFTLNMQSj7YuW3Mg3pZIXmw0naCmF6TGAuz4/sZE=
- k8s.io/cloud-provider-gcp/providers v0.28.2/go.mod h1:P8dxRvvLtX7xUwVUzA/QOqv8taCzBaVsVMnjnpjmYXE=
--k8s.io/code-generator v0.33.5 h1:KwkOvhwAaorjSwF2MQhhdhL3i8bBmAal/TWhX67kdHw=
--k8s.io/code-generator v0.33.5/go.mod h1:Ra+sdZquRakeTGcEnQAPw6BmlZ92IvxwQQTX/XOvOIE=
--k8s.io/component-base v0.33.5 h1:4D3kxjEx1pJRy3WHAZsmX3+LCpmd4ftE+2J4v6naTnQ=
--k8s.io/component-base v0.33.5/go.mod h1:Zma1YjBVuuGxIbspj1vGR3/5blzo2ARf1v0QTtog1to=
--k8s.io/component-helpers v0.33.5 h1:1LDSMzn7YTreVLPaOBJK36ase/FWi2sDpeJJvbEBO2s=
--k8s.io/component-helpers v0.33.5/go.mod h1:C3HsDU2lANSLgTTgMJ0TFnG5xZrVrxR3Ss9n7Wrsw4s=
--k8s.io/controller-manager v0.33.5 h1:abmssknXnhOhW533583v2SYQObD5RhYiSL7Za1rezGM=
--k8s.io/controller-manager v0.33.5/go.mod h1:KuQeAlf4vI2+qj5fwPVLaDlbtrTBA/8L/LqQvI74Ow0=
--k8s.io/cri-api v0.33.5 h1:UBYYKZwaFTaAJj1gF6vYy/iSkWk5pIVaoTjjF6ltUCs=
--k8s.io/cri-api v0.33.5/go.mod h1:OLQvT45OpIA+tv91ZrpuFIGY+Y2Ho23poS7n115Aocs=
--k8s.io/cri-client v0.33.5 h1:RjkIlunp2NxKPQLvD9XlQwjliz71L0jljmIrGGxPZAU=
--k8s.io/cri-client v0.33.5/go.mod h1:apcc+zemlSsvajH3a61bARqArBN2YkQueMe820qiVjQ=
--k8s.io/csi-translation-lib v0.33.5 h1:CatOlpJtSJ9eliQWvGsdjWBdOFgQvIlyaVXfs1QojTY=
--k8s.io/csi-translation-lib v0.33.5/go.mod h1:/7unRR1EEbxjjDcUN3v5Qc3vSPy3vwwFbuTPzk/raCo=
--k8s.io/dynamic-resource-allocation v0.33.5 h1:rWNQB06AMTufOODf1H9BMM7Qw0fBKP0KA2mHEuEmkQQ=
--k8s.io/dynamic-resource-allocation v0.33.5/go.mod h1:b9RAX4x8WFTMYonx7yZTDqC4++LwIMJNq+CuN5/s9lU=
-+k8s.io/code-generator v0.33.13 h1:Sh43djpZsCbl5pnyItPTg9lkI7MoaWWskSKEI+EBvJU=
-+k8s.io/code-generator v0.33.13/go.mod h1:O3l2FNWNulmf8U92o1QCb9MN9IBbfLUkKNeuDqA7mJg=
-+k8s.io/component-base v0.33.13 h1:WPsAyiWqSs2q06BDz5esM2FGchCMz5lxsQlLu6h9D4o=
-+k8s.io/component-base v0.33.13/go.mod h1:7eOJI3uncRXO7lRZh2tcqmJaQ/IX2RTtH3iwAGWFj70=
-+k8s.io/component-helpers v0.33.13 h1:tJYLJKzb2zXoL4aLwJ4T0ySoFlLGwfS0VgoqImsYgrE=
-+k8s.io/component-helpers v0.33.13/go.mod h1:n9Ruxgkz8jvq9I2W3hO0vw3e0VNOASbJTp9cV9oQ7ho=
-+k8s.io/controller-manager v0.33.13 h1:jJFY9aNN26QWXV3N6joNd7jJOdHEDiPHgNvpCbhs2D0=
-+k8s.io/controller-manager v0.33.13/go.mod h1:0jdrhuXkJEacOWeFf3rNOWvSKGAPxute87+S+YrJ9qE=
-+k8s.io/cri-api v0.33.13 h1:CWYbi901N93b3JJljKchDmIbpcIsd8PF10SFBeJqRXw=
-+k8s.io/cri-api v0.33.13/go.mod h1:dneNEiUPn0v27FCKSsc1vYDmBIlDRFZzGfxev68whwk=
-+k8s.io/cri-client v0.33.13 h1:lKxc84WvdDBgZY58FarIJ/QH4TjSl7/MkfDZd/1vSxI=
-+k8s.io/cri-client v0.33.13/go.mod h1:UOzCxw26ofOS+eueyeH6v2wzaROAZBPUdylXzwdphDk=
-+k8s.io/csi-translation-lib v0.33.13 h1:yfypxXuNlaJUlH0J9Ps5Gq7VU/JLzjRsf6NDIJd6F0s=
-+k8s.io/csi-translation-lib v0.33.13/go.mod h1:ta2om8pMLNsatUx+gY4aAAc8VP7cWo35UxFyPPR3wec=
-+k8s.io/dynamic-resource-allocation v0.33.13 h1:l8g2YnWQ9q2fUe5JgBPG/LzSMsPpUT48V7F7q37LuCg=
-+k8s.io/dynamic-resource-allocation v0.33.13/go.mod h1:YOkaa9HBU6gGtemgIHcqfwkSlJnqOaPQMdPRUePFGbo=
- k8s.io/gengo/v2 v2.0.0-20250207200755-1244d31929d7 h1:2OX19X59HxDprNCVrWi6jb7LW1PoqTlYqEq5H2oetog=
- k8s.io/gengo/v2 v2.0.0-20250207200755-1244d31929d7/go.mod h1:EJykeLsmFC60UQbYJezXkEsG2FLrt0GPNkU5iK5GWxU=
- k8s.io/klog/v2 v2.130.1 h1:n9Xl7H1Xvksem4KFG4PYbdQCQxqc/tTUyrgXaOhHSzk=
- k8s.io/klog/v2 v2.130.1/go.mod h1:3Jpz1GvMt720eyJH1ckRHK1EDfpxISzJ7I9OYgaDtPE=
--k8s.io/kms v0.33.5 h1:u60sDBe4Fz6PLeiNF13sEahjIU428ajiWuIw7NSVBlg=
--k8s.io/kms v0.33.5/go.mod h1:C1I8mjFFBNzfUZXYt9FZVJ8MJl7ynFbGgZFbBzkBJ3E=
-+k8s.io/kms v0.33.13 h1:3iOoN/SItJgPGEZKugYrTiPVcMNVyfkY/8PUosnulh0=
-+k8s.io/kms v0.33.13/go.mod h1:C1I8mjFFBNzfUZXYt9FZVJ8MJl7ynFbGgZFbBzkBJ3E=
- k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff h1:/usPimJzUKKu+m+TE36gUyGcf03XZEP0ZIKgKj35LS4=
- k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff/go.mod h1:5jIi+8yX4RIb8wk3XwBo5Pq2ccx4FP10ohkbSKCZoK8=
--k8s.io/kube-scheduler v0.33.5 h1:eqZHF4H4F33XF7yGIK4quk1DxGACexINNuNJlO4M1ZY=
--k8s.io/kube-scheduler v0.33.5/go.mod h1:n004Qs3SWbLMJ6PuPtwkS377CqaaKUeYFzqb1+4IaA8=
--k8s.io/kubectl v0.33.5 h1:/wj5EjXXrVeSd8+FcZ2sIIP1PlQkq8HWsR9T1Nsl32c=
--k8s.io/kubectl v0.33.5/go.mod h1:YrBGE7U+nz7+UatG+aNDocIQtdTyqN528dwFCv6+Kuw=
--k8s.io/kubelet v0.33.5 h1:PYV+O8B6ZoQMDaQdYTSCzNdQTLdjAAWTspS2KkNfjLQ=
--k8s.io/kubelet v0.33.5/go.mod h1:8SQ/0fgyNwm6zjHktBhPAUlgtji19YMa2lhSlYKUhrA=
--k8s.io/kubernetes v1.33.5 h1:uf0/5VVQodYf61FudCbwtWjg5ApQcKKA7mwanTLjxyw=
--k8s.io/kubernetes v1.33.5/go.mod h1:nrt8sldmckKz2fCZhgRX3SKfS2e+CzXATPv6ITNkU00=
--k8s.io/mount-utils v0.33.5 h1:Dc+t8nfUD+k0kvDyzWqsIxYPd3+KMuVQae2Gr8BAmxs=
--k8s.io/mount-utils v0.33.5/go.mod h1:1JR4rKymg8B8bCPo618hpSAdrpO6XLh0Acqok/xVwPE=
-+k8s.io/kube-scheduler v0.33.13 h1:LkIYb1UPpc6QIu0Jftil9aaQBbgsx3fYSYYvBe/FolA=
-+k8s.io/kube-scheduler v0.33.13/go.mod h1:sbxw0VAFQKqe8oeN0IbcfLV7wBv5pEXCG/ccLEYGKHA=
-+k8s.io/kubectl v0.33.13 h1:6RLgHYABIYqOccAyg8beGJgY48oXlrKl0kTmDrSerYc=
-+k8s.io/kubectl v0.33.13/go.mod h1:74vtwo3Il9YpytgCYq0D7kN5YQ5ubo0Mt9J8Zop1an0=
-+k8s.io/kubelet v0.33.13 h1:5JHlQPEIMhtxOJw0wu4gB6uWYW/4mOiW/mPv3KNY1zU=
-+k8s.io/kubelet v0.33.13/go.mod h1:x87gQb0hcRyPmJ7sfdNPEx7kHDkhu93lFUr9hOUtRb4=
-+k8s.io/kubernetes v1.33.13 h1:bmH31xUdSzeA5vk0wZAK9MZp11mdLuzUSeKk0qN3hPQ=
-+k8s.io/kubernetes v1.33.13/go.mod h1:I8CFdqMWuVZVMpBjzZMK0u06MUcy9EhNZ/t9WjxUmnw=
-+k8s.io/mount-utils v0.33.13 h1:1etrX+dHfXqJrkWw5Z1Osae6ROL2H46kzvCTtVeXLD4=
-+k8s.io/mount-utils v0.33.13/go.mod h1:+AWFtgfQsRNlGrrBm2bFruSB/0pQTB28yLymNf7JRNM=
+@@ -649,8 +653,8 @@ k8s.io/kubectl v0.32.0 h1:rpxl+ng9qeG79YA4Em9tLSfX0G8W0vfaiPVrc/WR7Xw=
+ k8s.io/kubectl v0.32.0/go.mod h1:qIjSX+QgPQUgdy8ps6eKsYNF+YmFOAO3WygfucIqFiE=
+ k8s.io/kubelet v0.32.0 h1:uLyiKlz195Wo4an/K2tyge8o3QHx0ZkhVN3pevvp59A=
+ k8s.io/kubelet v0.32.0/go.mod h1:lAwuVZT/Hm7EdLn0jW2D+WdrJoorjJL2rVSdhOFnegw=
+-k8s.io/kubernetes v1.32.0 h1:4BDBWSolqPrv8GC3YfZw0CJvh5kA1TPnoX0FxDVd+qc=
+-k8s.io/kubernetes v1.32.0/go.mod h1:tiIKO63GcdPRBHW2WiUFm3C0eoLczl3f7qi56Dm1W8I=
++k8s.io/kubernetes v1.32.10 h1:yiRa8DyKp4Yrbv028MP6kpp5N1N3eO8Hp/tSCbBGIPE=
++k8s.io/kubernetes v1.32.10/go.mod h1:o2pRStsMR7Uq62zcugfUEQsxnuyFt9r8migMrbsVH00=
+ k8s.io/mount-utils v0.32.3 h1:ZPXXHblfBhYP89OnaozpFg9Ojl6HhDfxBLcdWNkaxW8=
+ k8s.io/mount-utils v0.32.3/go.mod h1:Kun5c2svjAPx0nnvJKYQWhfeNW+O0EpzHgRhDcYoSY0=
  k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 h1:M3sRQVHv7vB20Xc2ybTt7ODCeFj6JSWYFzOFnYeS6Ro=
- k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
- sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 h1:jpcvIRr3GLoUoEKRkHKSmGjxb6lWwrBlJsXc+eUYQHM=

--- a/modules/040-node-manager/images/cluster-autoscaler/patches/1.33/001-go-mod.patch
+++ b/modules/040-node-manager/images/cluster-autoscaler/patches/1.33/001-go-mod.patch
@@ -1,5 +1,5 @@
 diff --git a/cluster-autoscaler/apis/go.mod b/cluster-autoscaler/apis/go.mod
-index 2f2e77110..1cd7b172a 100644
+index 572ba909a..2bd2ea52e 100644
 --- a/cluster-autoscaler/apis/go.mod
 +++ b/cluster-autoscaler/apis/go.mod
 @@ -1,6 +1,6 @@
@@ -10,10 +10,10 @@ index 2f2e77110..1cd7b172a 100644
  
  require (
  	github.com/onsi/ginkgo/v2 v2.21.0
-@@ -37,15 +37,16 @@ require (
+@@ -34,15 +34,15 @@ require (
+ 	github.com/pkg/errors v0.9.1 // indirect
+ 	github.com/spf13/pflag v1.0.5 // indirect
  	github.com/x448/float16 v0.8.4 // indirect
- 	go.yaml.in/yaml/v2 v2.4.2 // indirect
- 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 -	golang.org/x/mod v0.21.0 // indirect
 -	golang.org/x/net v0.38.0 // indirect
 +	golang.org/x/mod v0.35.0 // indirect
@@ -30,75 +30,61 @@ index 2f2e77110..1cd7b172a 100644
  	golang.org/x/time v0.9.0 // indirect
 -	golang.org/x/tools v0.26.0 // indirect
 +	golang.org/x/tools v0.44.0 // indirect
-+	golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated // indirect
  	google.golang.org/protobuf v1.36.5 // indirect
  	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
  	gopkg.in/inf.v0 v0.9.1 // indirect
 diff --git a/cluster-autoscaler/apis/go.sum b/cluster-autoscaler/apis/go.sum
-index 41f845ea6..2251631fb 100644
+index d516de6f1..70a3ea29d 100644
 --- a/cluster-autoscaler/apis/go.sum
 +++ b/cluster-autoscaler/apis/go.sum
-@@ -91,40 +91,44 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
- golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
- golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+@@ -89,12 +89,15 @@ golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
  golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
--golang.org/x/mod v0.21.0 h1:vvrHzRwRfVKSiLrG+d4FMl/Qi4ukBCE6kZlTUkDYRT0=
--golang.org/x/mod v0.21.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
-+golang.org/x/mod v0.35.0 h1:Ww1D637e6Pg+Zb2KrWfHQUnH2dQRLBQyAtpr/haaJeM=
+ golang.org/x/mod v0.21.0 h1:vvrHzRwRfVKSiLrG+d4FMl/Qi4ukBCE6kZlTUkDYRT0=
+ golang.org/x/mod v0.21.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
 +golang.org/x/mod v0.35.0/go.mod h1:+GwiRhIInF8wPm+4AoT6L0FA1QWAad3OMdTRx4tFYlU=
  golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
  golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
  golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
  golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
--golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
--golang.org/x/net v0.38.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
+ golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
+ golang.org/x/net v0.38.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
 +golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
 +golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
  golang.org/x/oauth2 v0.27.0 h1:da9Vo7/tDv5RH/7nZDz1eMGS/q1Vv1N/7FCrBhI9I3M=
  golang.org/x/oauth2 v0.27.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT8=
  golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
- golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+@@ -102,17 +105,21 @@ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJ
  golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
--golang.org/x/sync v0.12.0 h1:MHc5BpPuC30uJk597Ri8TV3CNZcTLu6B6z4lJy+g6Jw=
--golang.org/x/sync v0.12.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
-+golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
+ golang.org/x/sync v0.12.0 h1:MHc5BpPuC30uJk597Ri8TV3CNZcTLu6B6z4lJy+g6Jw=
+ golang.org/x/sync v0.12.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 +golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
  golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
  golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
  golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
--golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
--golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
--golang.org/x/term v0.30.0 h1:PQ39fJZ+mfadBm0y5WlL4vlM7Sx1Hgf13sMIY2+QS9Y=
--golang.org/x/term v0.30.0/go.mod h1:NYYFdzHoI5wRh/h5tDMdMqCqPJZEuNqVR5xJLd/n67g=
-+golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
+ golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
+ golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 +golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
-+golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=
+ golang.org/x/term v0.30.0 h1:PQ39fJZ+mfadBm0y5WlL4vlM7Sx1Hgf13sMIY2+QS9Y=
+ golang.org/x/term v0.30.0/go.mod h1:NYYFdzHoI5wRh/h5tDMdMqCqPJZEuNqVR5xJLd/n67g=
 +golang.org/x/term v0.43.0/go.mod h1:lrhlHNdQJHO+1qVYiHfFKVuVioJIheAc3fBSMFYEIsk=
  golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
  golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
--golang.org/x/text v0.23.0 h1:D71I7dUrlY+VX0gQShAThNGHFxZ13dGLBHQLVl1mJlY=
--golang.org/x/text v0.23.0/go.mod h1:/BLNzu4aZCJ1+kcD0DNRotWKage4q2rGVAg4o22unh4=
-+golang.org/x/text v0.37.0 h1:Cqjiwd9eSg8e0QAkyCaQTNHFIIzWtidPahFWR83rTrc=
+ golang.org/x/text v0.23.0 h1:D71I7dUrlY+VX0gQShAThNGHFxZ13dGLBHQLVl1mJlY=
+ golang.org/x/text v0.23.0/go.mod h1:/BLNzu4aZCJ1+kcD0DNRotWKage4q2rGVAg4o22unh4=
 +golang.org/x/text v0.37.0/go.mod h1:a5sjxXGs9hsn/AJVwuElvCAo9v8QYLzvavO5z2PiM38=
  golang.org/x/time v0.9.0 h1:EsRrnYcQiGH+5FfbgvV4AP7qEZstoyrHB0DzarOQ4ZY=
  golang.org/x/time v0.9.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
  golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
- golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
- golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+@@ -121,6 +128,7 @@ golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roY
  golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
--golang.org/x/tools v0.26.0 h1:v/60pFQmzmT9ExmjDv2gGIfi3OqfKoEP6I5+umXlbnQ=
--golang.org/x/tools v0.26.0/go.mod h1:TPVVj70c7JJ3WCazhD8OdXcZg/og+b9+tH/KxylGwH0=
-+golang.org/x/tools v0.44.0 h1:UP4ajHPIcuMjT1GqzDWRlalUEoY+uzoZKnhOjbIPD2c=
+ golang.org/x/tools v0.26.0 h1:v/60pFQmzmT9ExmjDv2gGIfi3OqfKoEP6I5+umXlbnQ=
+ golang.org/x/tools v0.26.0/go.mod h1:TPVVj70c7JJ3WCazhD8OdXcZg/og+b9+tH/KxylGwH0=
 +golang.org/x/tools v0.44.0/go.mod h1:KA0AfVErSdxRZIsOVipbv3rQhVXTnlU6UhKxHd1seDI=
-+golang.org/x/tools/go/expect v0.1.0-deprecated h1:jY2C5HGYR5lqex3gEniOQL0r7Dq5+VGVgY1nudX5lXY=
-+golang.org/x/tools/go/expect v0.1.0-deprecated/go.mod h1:eihoPOH+FgIqa3FpoTwguz/bVUSGBlGQU67vpBeOrBY=
-+golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated h1:1h2MnaIAIXISqTFKdENegdpAgUXz6NrPEsbIeWaBRvM=
-+golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated/go.mod h1:RVAQXBGNv1ib0J382/DPCRS/BPnsGebyM1Gj5VSDpG8=
  golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
  golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
  golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 diff --git a/cluster-autoscaler/go.mod b/cluster-autoscaler/go.mod
-index 5a58f093c..805581425 100644
+index d300c0846..498cbc186 100644
 --- a/cluster-autoscaler/go.mod
 +++ b/cluster-autoscaler/go.mod
 @@ -1,6 +1,6 @@
@@ -108,8 +94,8 @@ index 5a58f093c..805581425 100644
 +go 1.25.0
  
  require (
- 	cloud.google.com/go/compute/metadata v0.6.0
-@@ -32,30 +32,30 @@ require (
+ 	cloud.google.com/go/compute/metadata v0.5.0
+@@ -32,29 +32,29 @@ require (
  	github.com/stretchr/testify v1.10.0
  	github.com/vburenin/ifacemaker v1.2.1
  	go.uber.org/mock v0.4.0
@@ -121,37 +107,36 @@ index 5a58f093c..805581425 100644
 -	golang.org/x/sys v0.31.0
 +	golang.org/x/sys v0.45.0
  	google.golang.org/api v0.151.0
- 	google.golang.org/grpc v1.72.1
+ 	google.golang.org/grpc v1.68.1
  	google.golang.org/protobuf v1.36.5
  	gopkg.in/gcfg.v1 v1.2.3
  	gopkg.in/yaml.v2 v2.4.0
--	k8s.io/api v0.34.1
--	k8s.io/apimachinery v0.34.1
--	k8s.io/apiserver v0.34.1
-+	k8s.io/api v0.34.2
-+	k8s.io/apimachinery v0.34.2
-+	k8s.io/apiserver v0.34.2
+-	k8s.io/api v0.33.5
+-	k8s.io/apimachinery v0.33.5
+-	k8s.io/apiserver v0.33.5
++	k8s.io/api v0.33.6
++	k8s.io/apimachinery v0.33.6
++	k8s.io/apiserver v0.33.6
  	k8s.io/autoscaler/cluster-autoscaler/apis v0.0.0-20240627115740-d52e4b9665d7
--	k8s.io/client-go v0.34.1
-+	k8s.io/client-go v0.34.2
- 	k8s.io/cloud-provider v0.30.1
+-	k8s.io/client-go v0.33.5
++	k8s.io/client-go v0.33.6
+ 	k8s.io/cloud-provider v0.33.1
  	k8s.io/cloud-provider-aws v1.27.0
  	k8s.io/cloud-provider-gcp/providers v0.28.2
--	k8s.io/component-base v0.34.1
--	k8s.io/component-helpers v0.34.1
-+	k8s.io/component-base v0.34.2
-+	k8s.io/component-helpers v0.34.2
- 	k8s.io/dynamic-resource-allocation v0.0.0
+-	k8s.io/component-base v0.33.5
+-	k8s.io/component-helpers v0.33.5
++	k8s.io/component-base v0.33.6
++	k8s.io/component-helpers v0.33.6
+ 	k8s.io/dynamic-resource-allocation v0.33.1
  	k8s.io/klog/v2 v2.130.1
- 	k8s.io/kube-scheduler v0.0.0
--	k8s.io/kubelet v0.34.1
--	k8s.io/kubernetes v1.34.1
-+	k8s.io/kubelet v0.34.2
-+	k8s.io/kubernetes v1.34.2
- 	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397
+-	k8s.io/kubelet v0.33.5
+-	k8s.io/kubernetes v1.33.5
++	k8s.io/kubelet v0.33.6
++	k8s.io/kubernetes v1.33.6
+ 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738
  	sigs.k8s.io/cloud-provider-azure v1.29.4
  	sigs.k8s.io/cloud-provider-azure/pkg/azclient v0.0.13
-@@ -102,7 +102,7 @@ require (
+@@ -101,7 +101,7 @@ require (
  	github.com/containerd/typeurl/v2 v2.2.2 // indirect
  	github.com/coreos/go-semver v0.3.1 // indirect
  	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
@@ -160,7 +145,16 @@ index 5a58f093c..805581425 100644
  	github.com/dave/jennifer v1.6.0 // indirect
  	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
  	github.com/dimchansky/utfbom v1.1.1 // indirect
-@@ -161,7 +161,7 @@ require (
+@@ -123,7 +123,7 @@ require (
+ 	github.com/godbus/dbus/v5 v5.1.0 // indirect
+ 	github.com/gogo/protobuf v1.3.2 // indirect
+ 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
+-	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
++	github.com/golang-jwt/jwt/v5 v5.2.2 // indirect
+ 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+ 	github.com/golang/protobuf v1.5.4 // indirect
+ 	github.com/google/btree v1.1.3 // indirect
+@@ -160,7 +160,7 @@ require (
  	github.com/opencontainers/go-digest v1.0.0 // indirect
  	github.com/opencontainers/image-spec v1.1.1 // indirect
  	github.com/opencontainers/runtime-spec v1.2.0 // indirect
@@ -169,9 +163,9 @@ index 5a58f093c..805581425 100644
  	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
  	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
  	github.com/prometheus/client_model v0.6.1 // indirect
-@@ -192,12 +192,13 @@ require (
- 	go.yaml.in/yaml/v2 v2.4.2 // indirect
- 	go.yaml.in/yaml/v3 v3.0.4 // indirect
+@@ -189,12 +189,13 @@ require (
+ 	go.uber.org/multierr v1.11.0 // indirect
+ 	go.uber.org/zap v1.27.0 // indirect
  	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 -	golang.org/x/mod v0.21.0 // indirect
 -	golang.org/x/sync v0.12.0 // indirect
@@ -185,132 +179,132 @@ index 5a58f093c..805581425 100644
 -	golang.org/x/tools v0.26.0 // indirect
 +	golang.org/x/tools v0.44.0 // indirect
 +	golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated // indirect
- 	google.golang.org/genproto/googleapis/api v0.0.0-20250303144028-a0af3efb3deb // indirect
- 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250303144028-a0af3efb3deb // indirect
+ 	google.golang.org/genproto/googleapis/api v0.0.0-20241209162323-e6fa225c2576 // indirect
+ 	google.golang.org/genproto/googleapis/rpc v0.0.0-20241209162323-e6fa225c2576 // indirect
  	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
-@@ -206,13 +207,13 @@ require (
+@@ -203,13 +204,13 @@ require (
  	gopkg.in/warnings.v0 v0.1.2 // indirect
  	gopkg.in/yaml.v3 v3.0.1 // indirect
  	k8s.io/apiextensions-apiserver v0.0.0 // indirect
--	k8s.io/code-generator v0.34.1 // indirect
--	k8s.io/controller-manager v0.34.1 // indirect
--	k8s.io/cri-api v0.34.1 // indirect
-+	k8s.io/code-generator v0.34.2 // indirect
-+	k8s.io/controller-manager v0.34.2 // indirect
-+	k8s.io/cri-api v0.34.2 // indirect
+-	k8s.io/code-generator v0.33.5 // indirect
+-	k8s.io/controller-manager v0.33.5 // indirect
+-	k8s.io/cri-api v0.33.5 // indirect
++	k8s.io/code-generator v0.33.6 // indirect
++	k8s.io/controller-manager v0.33.6 // indirect
++	k8s.io/cri-api v0.33.6 // indirect
  	k8s.io/cri-client v0.0.0 // indirect
  	k8s.io/csi-translation-lib v0.27.0 // indirect
- 	k8s.io/gengo/v2 v2.0.0-20250604051438-85fd79dbfd9f // indirect
--	k8s.io/kms v0.34.1 // indirect
-+	k8s.io/kms v0.34.2 // indirect
- 	k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b // indirect
+ 	k8s.io/gengo/v2 v2.0.0-20250207200755-1244d31929d7 // indirect
+-	k8s.io/kms v0.33.5 // indirect
++	k8s.io/kms v0.33.6 // indirect
+ 	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff // indirect
+ 	k8s.io/kube-scheduler v0.0.0 // indirect
  	k8s.io/kubectl v0.28.0 // indirect
- 	k8s.io/mount-utils v0.26.0-alpha.0 // indirect
-@@ -229,66 +230,66 @@ replace github.com/digitalocean/godo => github.com/digitalocean/godo v1.27.0
+@@ -221,66 +222,66 @@ require (
+ 	sigs.k8s.io/structured-merge-diff/v4 v4.6.0 // indirect
+ )
  
- replace github.com/rancher/go-rancher => github.com/rancher/go-rancher v0.1.0
+-replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.33.5
++replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.33.6
  
--replace k8s.io/api => k8s.io/api v0.34.1
-+replace k8s.io/api => k8s.io/api v0.34.2
+-replace k8s.io/code-generator => k8s.io/code-generator v0.33.5
++replace k8s.io/code-generator => k8s.io/code-generator v0.33.6
  
--replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.34.1
-+replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.34.2
+-replace k8s.io/cri-api => k8s.io/cri-api v0.33.5
++replace k8s.io/cri-api => k8s.io/cri-api v0.33.6
  
--replace k8s.io/apimachinery => k8s.io/apimachinery v0.34.1
-+replace k8s.io/apimachinery => k8s.io/apimachinery v0.34.2
+-replace k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.33.5
++replace k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.33.6
  
--replace k8s.io/apiserver => k8s.io/apiserver v0.34.1
-+replace k8s.io/apiserver => k8s.io/apiserver v0.34.2
+-replace k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.33.5
++replace k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.33.6
  
--replace k8s.io/cli-runtime => k8s.io/cli-runtime v0.34.1
-+replace k8s.io/cli-runtime => k8s.io/cli-runtime v0.34.2
+-replace k8s.io/kubectl => k8s.io/kubectl v0.33.5
++replace k8s.io/kubectl => k8s.io/kubectl v0.33.6
  
--replace k8s.io/client-go => k8s.io/client-go v0.34.1
-+replace k8s.io/client-go => k8s.io/client-go v0.34.2
+-replace k8s.io/mount-utils => k8s.io/mount-utils v0.33.5
++replace k8s.io/mount-utils => k8s.io/mount-utils v0.33.6
  
--replace k8s.io/cloud-provider => k8s.io/cloud-provider v0.34.1
-+replace k8s.io/cloud-provider => k8s.io/cloud-provider v0.34.2
- 
--replace k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.34.1
-+replace k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.34.2
- 
--replace k8s.io/code-generator => k8s.io/code-generator v0.34.1
-+replace k8s.io/code-generator => k8s.io/code-generator v0.34.2
- 
--replace k8s.io/component-base => k8s.io/component-base v0.34.1
-+replace k8s.io/component-base => k8s.io/component-base v0.34.2
- 
--replace k8s.io/component-helpers => k8s.io/component-helpers v0.34.1
-+replace k8s.io/component-helpers => k8s.io/component-helpers v0.34.2
- 
--replace k8s.io/controller-manager => k8s.io/controller-manager v0.34.1
-+replace k8s.io/controller-manager => k8s.io/controller-manager v0.34.2
- 
--replace k8s.io/cri-api => k8s.io/cri-api v0.34.1
-+replace k8s.io/cri-api => k8s.io/cri-api v0.34.2
- 
--replace k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.34.1
-+replace k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.34.2
- 
--replace k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.34.1
-+replace k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.34.2
- 
--replace k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.34.1
-+replace k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.34.2
- 
--replace k8s.io/kube-proxy => k8s.io/kube-proxy v0.34.1
-+replace k8s.io/kube-proxy => k8s.io/kube-proxy v0.34.2
- 
--replace k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.34.1
-+replace k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.34.2
- 
--replace k8s.io/kubectl => k8s.io/kubectl v0.34.1
-+replace k8s.io/kubectl => k8s.io/kubectl v0.34.2
- 
--replace k8s.io/kubelet => k8s.io/kubelet v0.34.1
-+replace k8s.io/kubelet => k8s.io/kubelet v0.34.2
- 
--replace k8s.io/metrics => k8s.io/metrics v0.34.1
-+replace k8s.io/metrics => k8s.io/metrics v0.34.2
- 
--replace k8s.io/mount-utils => k8s.io/mount-utils v0.34.1
-+replace k8s.io/mount-utils => k8s.io/mount-utils v0.34.2
- 
--replace k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.34.1
-+replace k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.34.2
- 
--replace k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.34.1
-+replace k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.34.2
- 
--replace k8s.io/sample-controller => k8s.io/sample-controller v0.34.1
-+replace k8s.io/sample-controller => k8s.io/sample-controller v0.34.2
- 
--replace k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.34.1
-+replace k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.34.2
- 
--replace k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.34.1
-+replace k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.34.2
- 
--replace k8s.io/kms => k8s.io/kms v0.34.1
-+replace k8s.io/kms => k8s.io/kms v0.34.2
- 
--replace k8s.io/endpointslice => k8s.io/endpointslice v0.34.1
-+replace k8s.io/endpointslice => k8s.io/endpointslice v0.34.2
+-replace k8s.io/kms => k8s.io/kms v0.33.5
++replace k8s.io/kms => k8s.io/kms v0.33.6
  
  replace k8s.io/autoscaler/cluster-autoscaler/apis => ./apis
  
--replace k8s.io/cri-client => k8s.io/cri-client v0.34.1
-+replace k8s.io/cri-client => k8s.io/cri-client v0.34.2
+-replace k8s.io/cri-client => k8s.io/cri-client v0.33.5
++replace k8s.io/cri-client => k8s.io/cri-client v0.33.6
  
--replace k8s.io/externaljwt => k8s.io/externaljwt v0.34.1
-+replace k8s.io/externaljwt => k8s.io/externaljwt v0.34.2
+-replace k8s.io/api => k8s.io/api v0.33.5
++replace k8s.io/api => k8s.io/api v0.33.6
+ 
+-replace k8s.io/apimachinery => k8s.io/apimachinery v0.33.5
++replace k8s.io/apimachinery => k8s.io/apimachinery v0.33.6
+ 
+-replace k8s.io/apiserver => k8s.io/apiserver v0.33.5
++replace k8s.io/apiserver => k8s.io/apiserver v0.33.6
+ 
+-replace k8s.io/cli-runtime => k8s.io/cli-runtime v0.33.5
++replace k8s.io/cli-runtime => k8s.io/cli-runtime v0.33.6
+ 
+-replace k8s.io/client-go => k8s.io/client-go v0.33.5
++replace k8s.io/client-go => k8s.io/client-go v0.33.6
+ 
+-replace k8s.io/cloud-provider => k8s.io/cloud-provider v0.33.5
++replace k8s.io/cloud-provider => k8s.io/cloud-provider v0.33.6
+ 
+-replace k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.33.5
++replace k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.33.6
+ 
+-replace k8s.io/component-base => k8s.io/component-base v0.33.5
++replace k8s.io/component-base => k8s.io/component-base v0.33.6
+ 
+-replace k8s.io/component-helpers => k8s.io/component-helpers v0.33.5
++replace k8s.io/component-helpers => k8s.io/component-helpers v0.33.6
+ 
+-replace k8s.io/controller-manager => k8s.io/controller-manager v0.33.5
++replace k8s.io/controller-manager => k8s.io/controller-manager v0.33.6
+ 
+-replace k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.33.5
++replace k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.33.6
+ 
+-replace k8s.io/endpointslice => k8s.io/endpointslice v0.33.5
++replace k8s.io/endpointslice => k8s.io/endpointslice v0.33.6
+ 
+-replace k8s.io/externaljwt => k8s.io/externaljwt v0.33.5
++replace k8s.io/externaljwt => k8s.io/externaljwt v0.33.6
+ 
+-replace k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.33.5
++replace k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.33.6
+ 
+-replace k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.33.5
++replace k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.33.6
+ 
+-replace k8s.io/kube-proxy => k8s.io/kube-proxy v0.33.5
++replace k8s.io/kube-proxy => k8s.io/kube-proxy v0.33.6
+ 
+-replace k8s.io/kubelet => k8s.io/kubelet v0.33.5
++replace k8s.io/kubelet => k8s.io/kubelet v0.33.6
+ 
+-replace k8s.io/metrics => k8s.io/metrics v0.33.5
++replace k8s.io/metrics => k8s.io/metrics v0.33.6
+ 
+-replace k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.33.5
++replace k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.33.6
+ 
+-replace k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.33.5
++replace k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.33.6
+ 
+-replace k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.33.5
++replace k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.33.6
+ 
+-replace k8s.io/sample-controller => k8s.io/sample-controller v0.33.5
++replace k8s.io/sample-controller => k8s.io/sample-controller v0.33.6
 diff --git a/cluster-autoscaler/go.sum b/cluster-autoscaler/go.sum
-index 8668deef6..f7ed24386 100644
+index cb1f8f025..4ab752eda 100644
 --- a/cluster-autoscaler/go.sum
 +++ b/cluster-autoscaler/go.sum
 @@ -126,8 +126,8 @@ github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8
  github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
- github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+ github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
  github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 -github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=
 -github.com/cyphar/filepath-securejoin v0.4.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
@@ -319,6 +313,17 @@ index 8668deef6..f7ed24386 100644
  github.com/dave/jennifer v1.6.0 h1:MQ/6emI2xM7wt0tJzJzyUik2Q3Tcn2eE0vtYgh4GPVI=
  github.com/dave/jennifer v1.6.0/go.mod h1:AxTG893FiZKqxy3FP1kL80VMshSMuz2G+EgvszgGRnk=
  github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+@@ -193,8 +193,8 @@ github.com/golang-jwt/jwt/v4 v4.2.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzw
+ github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+ github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
+ github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+-github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
+-github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
++github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
++github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
+ github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
+ github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
+ github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
 @@ -326,8 +326,8 @@ github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJw
  github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
  github.com/opencontainers/runtime-spec v1.2.0 h1:z97+pHb3uELt/yiAWD691HNHQIF07bE7dzrbT927iTk=
@@ -330,7 +335,7 @@ index 8668deef6..f7ed24386 100644
  github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
  github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
  github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-@@ -443,8 +443,8 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
+@@ -439,8 +439,8 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
  golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
  golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58=
  golang.org/x/crypto v0.17.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
@@ -341,7 +346,7 @@ index 8668deef6..f7ed24386 100644
  golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
  golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 h1:2dVuKD2vS7b0QIHQbpyTISPd0LeHDbnYEryqj5Q1ug8=
  golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56/go.mod h1:M4RDyNAINzryxdtnbRXRL/OHtkFuWGRjvuhBJpk2IlY=
-@@ -456,8 +456,8 @@ golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+@@ -452,8 +452,8 @@ golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
  golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
  golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
  golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
@@ -352,7 +357,7 @@ index 8668deef6..f7ed24386 100644
  golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
  golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
  golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
-@@ -475,8 +475,8 @@ golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug
+@@ -471,8 +471,8 @@ golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug
  golang.org/x/net v0.1.0/go.mod h1:Cx3nUiGt4eDBEyega/BKRp+/AlGL8hYe7U9odMt2Cco=
  golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
  golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
@@ -363,7 +368,7 @@ index 8668deef6..f7ed24386 100644
  golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
  golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
  golang.org/x/oauth2 v0.27.0 h1:da9Vo7/tDv5RH/7nZDz1eMGS/q1Vv1N/7FCrBhI9I3M=
-@@ -490,8 +490,8 @@ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJ
+@@ -486,8 +486,8 @@ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJ
  golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
  golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
  golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -374,7 +379,7 @@ index 8668deef6..f7ed24386 100644
  golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
  golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
  golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-@@ -508,16 +508,16 @@ golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+@@ -504,16 +504,16 @@ golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
  golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
  golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
  golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
@@ -395,7 +400,7 @@ index 8668deef6..f7ed24386 100644
  golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
  golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
  golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-@@ -526,8 +526,8 @@ golang.org/x/text v0.4.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
+@@ -522,8 +522,8 @@ golang.org/x/text v0.4.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
  golang.org/x/text v0.7.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
  golang.org/x/text v0.9.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=
  golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
@@ -406,7 +411,7 @@ index 8668deef6..f7ed24386 100644
  golang.org/x/time v0.9.0 h1:EsRrnYcQiGH+5FfbgvV4AP7qEZstoyrHB0DzarOQ4ZY=
  golang.org/x/time v0.9.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
  golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
-@@ -541,8 +541,12 @@ golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4f
+@@ -537,8 +537,12 @@ golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4f
  golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
  golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
  golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
@@ -421,100 +426,100 @@ index 8668deef6..f7ed24386 100644
  golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
  golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
  golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-@@ -599,56 +603,56 @@ gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+@@ -597,56 +601,56 @@ gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
  gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
  honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
  honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
--k8s.io/api v0.34.1 h1:jC+153630BMdlFukegoEL8E/yT7aLyQkIVuwhmwDgJM=
--k8s.io/api v0.34.1/go.mod h1:SB80FxFtXn5/gwzCoN6QCtPD7Vbu5w2n1S0J5gFfTYk=
--k8s.io/apiextensions-apiserver v0.34.1 h1:NNPBva8FNAPt1iSVwIE0FsdrVriRXMsaWFMqJbII2CI=
--k8s.io/apiextensions-apiserver v0.34.1/go.mod h1:hP9Rld3zF5Ay2Of3BeEpLAToP+l4s5UlxiHfqRaRcMc=
--k8s.io/apimachinery v0.34.1 h1:dTlxFls/eikpJxmAC7MVE8oOeP1zryV7iRyIjB0gky4=
--k8s.io/apimachinery v0.34.1/go.mod h1:/GwIlEcWuTX9zKIg2mbw0LRFIsXwrfoVxn+ef0X13lw=
--k8s.io/apiserver v0.34.1 h1:U3JBGdgANK3dfFcyknWde1G6X1F4bg7PXuvlqt8lITA=
--k8s.io/apiserver v0.34.1/go.mod h1:eOOc9nrVqlBI1AFCvVzsob0OxtPZUCPiUJL45JOTBG0=
--k8s.io/client-go v0.34.1 h1:ZUPJKgXsnKwVwmKKdPfw4tB58+7/Ik3CrjOEhsiZ7mY=
--k8s.io/client-go v0.34.1/go.mod h1:kA8v0FP+tk6sZA0yKLRG67LWjqufAoSHA2xVGKw9Of8=
--k8s.io/cloud-provider v0.34.1 h1:FS+4C1vq9pIngd/5LR5Jha1sEbn+fo0HJitgZmUyBNc=
--k8s.io/cloud-provider v0.34.1/go.mod h1:ghyQYfQIWZAXKNS+TEgEiQ8wPuhzIVt3wFO6rKqS/rQ=
-+k8s.io/api v0.34.2 h1:fsSUNZhV+bnL6Aqrp6O7lMTy6o5x2C4XLjnh//8SLYY=
-+k8s.io/api v0.34.2/go.mod h1:MMBPaWlED2a8w4RSeanD76f7opUoypY8TFYkSM+3XHw=
-+k8s.io/apiextensions-apiserver v0.34.2 h1:WStKftnGeoKP4AZRz/BaAAEJvYp4mlZGN0UCv+uvsqo=
-+k8s.io/apiextensions-apiserver v0.34.2/go.mod h1:398CJrsgXF1wytdaanynDpJ67zG4Xq7yj91GrmYN2SE=
-+k8s.io/apimachinery v0.34.2 h1:zQ12Uk3eMHPxrsbUJgNF8bTauTVR2WgqJsTmwTE/NW4=
-+k8s.io/apimachinery v0.34.2/go.mod h1:/GwIlEcWuTX9zKIg2mbw0LRFIsXwrfoVxn+ef0X13lw=
-+k8s.io/apiserver v0.34.2 h1:2/yu8suwkmES7IzwlehAovo8dDE07cFRC7KMDb1+MAE=
-+k8s.io/apiserver v0.34.2/go.mod h1:gqJQy2yDOB50R3JUReHSFr+cwJnL8G1dzTA0YLEqAPI=
-+k8s.io/client-go v0.34.2 h1:Co6XiknN+uUZqiddlfAjT68184/37PS4QAzYvQvDR8M=
-+k8s.io/client-go v0.34.2/go.mod h1:2VYDl1XXJsdcAxw7BenFslRQX28Dxz91U9MWKjX97fE=
-+k8s.io/cloud-provider v0.34.2 h1:tNxZ6c+3cJdpNHvurzUdVvKNbB0pDxx3jE1AcZ8pMKA=
-+k8s.io/cloud-provider v0.34.2/go.mod h1:8XqzAplSoVLZzqut82sWHusz6X00C1Djk3BpeKAjfHY=
+-k8s.io/api v0.33.5 h1:YR+uhYj05jdRpcksv8kjSliW+v9hwXxn6Cv10aR8Juw=
+-k8s.io/api v0.33.5/go.mod h1:2gzShdwXKT5yPGiqrTrn/U/nLZ7ZyT4WuAj3XGDVgVs=
+-k8s.io/apiextensions-apiserver v0.33.5 h1:93NZh6rmrcamX/tfv/dZrTsMiQX69ufANmDcKPEgSeA=
+-k8s.io/apiextensions-apiserver v0.33.5/go.mod h1:JIbyQnNlu6nQa7b1vgFi51pmlXOk8mdn0WJwUJnz/7U=
+-k8s.io/apimachinery v0.33.5 h1:NiT64hln4TQXeYR18/ES39OrNsjGz8NguxsBgp+6QIo=
+-k8s.io/apimachinery v0.33.5/go.mod h1:BHW0YOu7n22fFv/JkYOEfkUYNRN0fj0BlvMFWA7b+SM=
+-k8s.io/apiserver v0.33.5 h1:X1Gy33r4YkRLRqTjGjofk7X1/EjSLEVSJ/A+1qjoj60=
+-k8s.io/apiserver v0.33.5/go.mod h1:Q+b5Btbc8x0PqOCeh/xBTesKk+cXQRN+PF2wdrTKDeg=
+-k8s.io/client-go v0.33.5 h1:I8BdmQGxInpkMEnJvV6iG7dqzP3JRlpZZlib3OMFc3o=
+-k8s.io/client-go v0.33.5/go.mod h1:W8PQP4MxbM4ypgagVE65mUUqK1/ByQkSALF9tzuQ6u0=
+-k8s.io/cloud-provider v0.33.5 h1:LyU8ZVID3Q8S/aEsPqv5bHCfPeo3NXKrD5iSBqHeV/U=
+-k8s.io/cloud-provider v0.33.5/go.mod h1:kSY4+DXKXhWmHLyuUDY09zTL9g9MbcOpahoVY6mzW8Q=
++k8s.io/api v0.33.6 h1:9O22ZqwT6CkQ3iboVpvTR5BEWuT3Xm6/8NX6MOLmc38=
++k8s.io/api v0.33.6/go.mod h1:bdon4pRFmRmdsFyltGIoCaPqutN7y//OQ4srD0uy9X0=
++k8s.io/apiextensions-apiserver v0.33.6 h1:S+18aFz53T/iHPgj9iB7bAZmRPeW8b1umsWaRdgj+6U=
++k8s.io/apiextensions-apiserver v0.33.6/go.mod h1:YUhU/Tb0GszjMK5BXb1HpP6+26TQ1xodhfntmZv7RC0=
++k8s.io/apimachinery v0.33.6 h1:Pq+px1i1t7lNgE58dIeBwJh7OWId6pfGD1dYBm/U5HI=
++k8s.io/apimachinery v0.33.6/go.mod h1:BHW0YOu7n22fFv/JkYOEfkUYNRN0fj0BlvMFWA7b+SM=
++k8s.io/apiserver v0.33.6 h1:X78/4sciWuKMM6Wlm2z4WMthhJSfsO/vcyjx7J6gEsE=
++k8s.io/apiserver v0.33.6/go.mod h1:5rRMAedHE4Vke25QGuW2kyfPIHC8nmQxNLdvJKAcmIU=
++k8s.io/client-go v0.33.6 h1:icPU5E5XHl/5mdwMUdSxpGtHnnjWzG0MSputTR9odrg=
++k8s.io/client-go v0.33.6/go.mod h1:3z/Cwqdi6/Uo+E17k+OgQi4QfXS0XuIUmfHpK6rQdZU=
++k8s.io/cloud-provider v0.33.6 h1:XLt8UhgsZgou8Ua6KQrnnHGS3lpZRHlbNhnO4kPyO0c=
++k8s.io/cloud-provider v0.33.6/go.mod h1:I08jJ7obAWjv9z5ZcabdOV3aizfo7ru495xuxlHQw84=
  k8s.io/cloud-provider-aws v1.27.0 h1:PF8YrH8QcN6JoXB3Xxlaz84SBDYMPunJuCc0cPuCWXA=
  k8s.io/cloud-provider-aws v1.27.0/go.mod h1:9vUb5mnVnReSRDBWcBxB1b0HOeEc472iOPmrnwpN9SA=
  k8s.io/cloud-provider-gcp/providers v0.28.2 h1:I65pFTLNMQSj7YuW3Mg3pZIXmw0naCmF6TGAuz4/sZE=
  k8s.io/cloud-provider-gcp/providers v0.28.2/go.mod h1:P8dxRvvLtX7xUwVUzA/QOqv8taCzBaVsVMnjnpjmYXE=
--k8s.io/code-generator v0.34.1 h1:WpphT26E+j7tEgIUfFr5WfbJrktCGzB3JoJH9149xYc=
--k8s.io/code-generator v0.34.1/go.mod h1:DeWjekbDnJWRwpw3s0Jat87c+e0TgkxoR4ar608yqvg=
--k8s.io/component-base v0.34.1 h1:v7xFgG+ONhytZNFpIz5/kecwD+sUhVE6HU7qQUiRM4A=
--k8s.io/component-base v0.34.1/go.mod h1:mknCpLlTSKHzAQJJnnHVKqjxR7gBeHRv0rPXA7gdtQ0=
--k8s.io/component-helpers v0.34.1 h1:gWhH3CCdwAx5P3oJqZKb4Lg5FYZTWVbdWtOI8n9U4XY=
--k8s.io/component-helpers v0.34.1/go.mod h1:4VgnUH7UA/shuBur+OWoQC0xfb69sy/93ss0ybZqm3c=
--k8s.io/controller-manager v0.34.1 h1:c9Cmun/zF740kmdRQWPGga+4MglT5SlrwsCXDS/KtJI=
--k8s.io/controller-manager v0.34.1/go.mod h1:fGiJDhi3OSzSAB4f40ZkJLAqMQSag9RM+7m5BRhBO3Q=
--k8s.io/cri-api v0.34.1 h1:n2bU++FqqJq0CNjP/5pkOs0nIx7aNpb1Xa053TecQkM=
--k8s.io/cri-api v0.34.1/go.mod h1:4qVUjidMg7/Z9YGZpqIDygbkPWkg3mkS1PvOx/kpHTE=
--k8s.io/cri-client v0.34.1 h1:eq6FcEPDDL379w0WhPnItj2egsMZqOtU7nv1JaJmwP0=
--k8s.io/cri-client v0.34.1/go.mod h1:Dq6mKWV2ugO5tMv4xqVgcQ8vD7csP//e4KkzcFi2Pio=
--k8s.io/csi-translation-lib v0.34.1 h1:8+QMIWBwPGFsqWw9eAvimA2GaHXGgLLYT61I1NzDnXw=
--k8s.io/csi-translation-lib v0.34.1/go.mod h1:QXytPJ1KzYQaiMgVm82ANG+RGAUf276m8l9gFT+R6Xg=
--k8s.io/dynamic-resource-allocation v0.34.1 h1:pd9qhOeAFkn8eOO4BthAiGHQc8pu+N6TK/2Fj+jaPwU=
--k8s.io/dynamic-resource-allocation v0.34.1/go.mod h1:Zlpqyh6EKhTVoQDe5BS31/8oMXGfG6c12ydj3ChXyuw=
-+k8s.io/code-generator v0.34.2 h1:9bG6jTxmsU3HXE5BNYJTC8AZ1D6hVVfkm8yYSkdkGY0=
-+k8s.io/code-generator v0.34.2/go.mod h1:dnDDEd6S/z4uZ+PG1aE58ySCi/lR4+qT3a4DddE4/2I=
-+k8s.io/component-base v0.34.2 h1:HQRqK9x2sSAsd8+R4xxRirlTjowsg6fWCPwWYeSvogQ=
-+k8s.io/component-base v0.34.2/go.mod h1:9xw2FHJavUHBFpiGkZoKuYZ5pdtLKe97DEByaA+hHbM=
-+k8s.io/component-helpers v0.34.2 h1:RIUGDdU+QFzeVKLZ9f05sXTNAtJrRJ3bnbMLrogCrvM=
-+k8s.io/component-helpers v0.34.2/go.mod h1:pLi+GByuRTeFjjcezln8gHL7LcT6HImkwVQ3A2SQaEE=
-+k8s.io/controller-manager v0.34.2 h1:bjdSLh5nnSde5jfRW/rdPDOSYbwUMxs+9JUcbyL6LP8=
-+k8s.io/controller-manager v0.34.2/go.mod h1:sR6wSdANfbdXBTtg2Fwp1ruo/1TJgSilooT6FDxZj4A=
-+k8s.io/cri-api v0.34.2 h1:YtG6Ud62gH+5LYzOWFLeRCFz64SqFFEP5umr/I3PC0Q=
-+k8s.io/cri-api v0.34.2/go.mod h1:4qVUjidMg7/Z9YGZpqIDygbkPWkg3mkS1PvOx/kpHTE=
-+k8s.io/cri-client v0.34.2 h1:uALtvKgk5qu6owHHvyE2QMqYlfZWGeIB/eO5pboKeIY=
-+k8s.io/cri-client v0.34.2/go.mod h1:hwqCdHW06vOPxHB6BQDTMCXkUDxJYMTnlWJxTO0kWtU=
-+k8s.io/csi-translation-lib v0.34.2 h1:xvpxaoDfv0kPaLqUeTKGthr1jqmJgmSHgMnJevYPhY4=
-+k8s.io/csi-translation-lib v0.34.2/go.mod h1:un/6pCiR5QgE6HD16i2AY11+wSFbeVksolat1zntCZY=
-+k8s.io/dynamic-resource-allocation v0.34.2 h1:SjlRGSWl6CZXoJwQNL+Y0wRfdH8PkJ4mHRNK6MMj0bY=
-+k8s.io/dynamic-resource-allocation v0.34.2/go.mod h1:ul6I+gfrCmC+OCuVdN0/iykyB2sPrIqh2WyKQ3RQPCU=
- k8s.io/gengo/v2 v2.0.0-20250604051438-85fd79dbfd9f h1:SLb+kxmzfA87x4E4brQzB33VBbT2+x7Zq9ROIHmGn9Q=
- k8s.io/gengo/v2 v2.0.0-20250604051438-85fd79dbfd9f/go.mod h1:EJykeLsmFC60UQbYJezXkEsG2FLrt0GPNkU5iK5GWxU=
+-k8s.io/code-generator v0.33.5 h1:KwkOvhwAaorjSwF2MQhhdhL3i8bBmAal/TWhX67kdHw=
+-k8s.io/code-generator v0.33.5/go.mod h1:Ra+sdZquRakeTGcEnQAPw6BmlZ92IvxwQQTX/XOvOIE=
+-k8s.io/component-base v0.33.5 h1:4D3kxjEx1pJRy3WHAZsmX3+LCpmd4ftE+2J4v6naTnQ=
+-k8s.io/component-base v0.33.5/go.mod h1:Zma1YjBVuuGxIbspj1vGR3/5blzo2ARf1v0QTtog1to=
+-k8s.io/component-helpers v0.33.5 h1:1LDSMzn7YTreVLPaOBJK36ase/FWi2sDpeJJvbEBO2s=
+-k8s.io/component-helpers v0.33.5/go.mod h1:C3HsDU2lANSLgTTgMJ0TFnG5xZrVrxR3Ss9n7Wrsw4s=
+-k8s.io/controller-manager v0.33.5 h1:abmssknXnhOhW533583v2SYQObD5RhYiSL7Za1rezGM=
+-k8s.io/controller-manager v0.33.5/go.mod h1:KuQeAlf4vI2+qj5fwPVLaDlbtrTBA/8L/LqQvI74Ow0=
+-k8s.io/cri-api v0.33.5 h1:UBYYKZwaFTaAJj1gF6vYy/iSkWk5pIVaoTjjF6ltUCs=
+-k8s.io/cri-api v0.33.5/go.mod h1:OLQvT45OpIA+tv91ZrpuFIGY+Y2Ho23poS7n115Aocs=
+-k8s.io/cri-client v0.33.5 h1:RjkIlunp2NxKPQLvD9XlQwjliz71L0jljmIrGGxPZAU=
+-k8s.io/cri-client v0.33.5/go.mod h1:apcc+zemlSsvajH3a61bARqArBN2YkQueMe820qiVjQ=
+-k8s.io/csi-translation-lib v0.33.5 h1:CatOlpJtSJ9eliQWvGsdjWBdOFgQvIlyaVXfs1QojTY=
+-k8s.io/csi-translation-lib v0.33.5/go.mod h1:/7unRR1EEbxjjDcUN3v5Qc3vSPy3vwwFbuTPzk/raCo=
+-k8s.io/dynamic-resource-allocation v0.33.5 h1:rWNQB06AMTufOODf1H9BMM7Qw0fBKP0KA2mHEuEmkQQ=
+-k8s.io/dynamic-resource-allocation v0.33.5/go.mod h1:b9RAX4x8WFTMYonx7yZTDqC4++LwIMJNq+CuN5/s9lU=
++k8s.io/code-generator v0.33.6 h1:1CFzvpqz3r52zjvikYaF5bvYZkKT6brMIMSB7odPaIs=
++k8s.io/code-generator v0.33.6/go.mod h1:ndnG7E7wSIOLMl2GASBRdoRitKGN5fp/qq5nKTmiTh8=
++k8s.io/component-base v0.33.6 h1:a4HGKS3Ax68W1xO1MpVnVybgeJ3OBjvLE9SALoezTZc=
++k8s.io/component-base v0.33.6/go.mod h1:rUo6Mge+6JvNLrhRzhotfGLxI0tyaQXbL2rnth4UEFw=
++k8s.io/component-helpers v0.33.6 h1:PvmETVzr4Deym6mn1klgMvARgJY9KuDWTZ39bVlKlZc=
++k8s.io/component-helpers v0.33.6/go.mod h1:rAX3imLcTAozWTRhR13/LAR3Mf8bksoayTpUdKZFUJo=
++k8s.io/controller-manager v0.33.6 h1:md2KM5RabX7KTTly1KmNDbNr5YJvLtse7sJOX2we8tI=
++k8s.io/controller-manager v0.33.6/go.mod h1:dtCyZIG+CNFI8hY/lQY7ZAOO20VxGm+lpi1do2fmLGY=
++k8s.io/cri-api v0.33.6 h1:yQXCHwWzedRSrPhy/r0QMI9a3jc6YpHnorfDBimdxng=
++k8s.io/cri-api v0.33.6/go.mod h1:OLQvT45OpIA+tv91ZrpuFIGY+Y2Ho23poS7n115Aocs=
++k8s.io/cri-client v0.33.6 h1:pVecZ/LeA3+wKJea8Rfp5jnVu0GYe6N/iFIM+lOBSCw=
++k8s.io/cri-client v0.33.6/go.mod h1:1z3JawYGs5KTJasU+3QBhXlovZHrXIEkgTfHAWwvpmc=
++k8s.io/csi-translation-lib v0.33.6 h1:ns0+YQ8R0lbFmAOSVgTLBvav2LrvONz7Uy3M2rpf/6E=
++k8s.io/csi-translation-lib v0.33.6/go.mod h1:t266CgUYPVdST8pjPaCOEDLejWwV1Tms5igy8FVYyQo=
++k8s.io/dynamic-resource-allocation v0.33.6 h1:HrPUowR+KvxmgPNin+e424PA4rWFPd/W25W1jULKapk=
++k8s.io/dynamic-resource-allocation v0.33.6/go.mod h1:ByWsZ+8UxTvPC4UmyWdevUIGzxIrgmiyxcddLsKkGuY=
+ k8s.io/gengo/v2 v2.0.0-20250207200755-1244d31929d7 h1:2OX19X59HxDprNCVrWi6jb7LW1PoqTlYqEq5H2oetog=
+ k8s.io/gengo/v2 v2.0.0-20250207200755-1244d31929d7/go.mod h1:EJykeLsmFC60UQbYJezXkEsG2FLrt0GPNkU5iK5GWxU=
  k8s.io/klog/v2 v2.130.1 h1:n9Xl7H1Xvksem4KFG4PYbdQCQxqc/tTUyrgXaOhHSzk=
  k8s.io/klog/v2 v2.130.1/go.mod h1:3Jpz1GvMt720eyJH1ckRHK1EDfpxISzJ7I9OYgaDtPE=
--k8s.io/kms v0.34.1 h1:iCFOvewDPzWM9fMTfyIPO+4MeuZ0tcZbugxLNSHFG4w=
--k8s.io/kms v0.34.1/go.mod h1:s1CFkLG7w9eaTYvctOxosx88fl4spqmixnNpys0JAtM=
-+k8s.io/kms v0.34.2 h1:91rj4MDZLyIT9KxG8J5/CcMH666Z88CF/xJQeuPfJc8=
-+k8s.io/kms v0.34.2/go.mod h1:s1CFkLG7w9eaTYvctOxosx88fl4spqmixnNpys0JAtM=
- k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b h1:MloQ9/bdJyIu9lb1PzujOPolHyvO06MXG5TUIj2mNAA=
- k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b/go.mod h1:UZ2yyWbFTpuhSbFhv24aGNOdoRdJZgsIObGBUaYVsts=
--k8s.io/kube-scheduler v0.34.1 h1:S5td6VZwC3lCqERXclerDXhJ26zYc6JroY0s03+PqJ8=
--k8s.io/kube-scheduler v0.34.1/go.mod h1:UiOkod/w+HKoGut9mz9ie4s4KcI82vmLFdq1iIgsmRs=
--k8s.io/kubectl v0.34.1 h1:1qP1oqT5Xc93K+H8J7ecpBjaz511gan89KO9Vbsh/OI=
--k8s.io/kubectl v0.34.1/go.mod h1:JRYlhJpGPyk3dEmJ+BuBiOB9/dAvnrALJEiY/C5qa6A=
--k8s.io/kubelet v0.34.1 h1:doAaTA9/Yfzbdq/u/LveZeONp96CwX9giW6b+oHn4m4=
--k8s.io/kubelet v0.34.1/go.mod h1:PtV3Ese8iOM19gSooFoQT9iyRisbmJdAPuDImuccbbA=
--k8s.io/kubernetes v1.34.1 h1:F3p8dtpv+i8zQoebZeK5zBqM1g9x1aIdnA5vthvcuUk=
--k8s.io/kubernetes v1.34.1/go.mod h1:iu+FhII+Oc/1gGWLJcer6wpyih441aNFHl7Pvm8yPto=
--k8s.io/mount-utils v0.34.1 h1:zMBEFav8Rxwm54S8srzy5FxAc4KQ3X4ZcjnqTCzHmZk=
--k8s.io/mount-utils v0.34.1/go.mod h1:MIjjYlqJ0ziYQg0MO09kc9S96GIcMkhF/ay9MncF0GA=
-+k8s.io/kube-scheduler v0.34.2 h1:TtLcaXeIpkqgzMr2ch7Ap8Cluq4M182XUDRlnOPDdoc=
-+k8s.io/kube-scheduler v0.34.2/go.mod h1:PTn4QYiSet8/00VQ2qGO/HWdo5iNJlVRCXz/7R3Ut5I=
-+k8s.io/kubectl v0.34.2 h1:+fWGrVlDONMUmmQLDaGkQ9i91oszjjRAa94cr37hzqA=
-+k8s.io/kubectl v0.34.2/go.mod h1:X2KTOdtZZNrTWmUD4oHApJ836pevSl+zvC5sI6oO2YQ=
-+k8s.io/kubelet v0.34.2 h1:Dl+1uh7xwJr70r+SHKyIpvu6XvzuoPu0uDIC4cqgJUs=
-+k8s.io/kubelet v0.34.2/go.mod h1:RfwR03iuKeVV7Z1qD9XKH98c3tlPImJpQ3qHIW40htM=
-+k8s.io/kubernetes v1.34.2 h1:WQdDvYJazkmkwSncgNwGvVtaCt4TYXIU3wSMRgvp3MI=
-+k8s.io/kubernetes v1.34.2/go.mod h1:m6pZk6a179pRo2wsTiCPORJ86iOEQmfIzUvtyEF8BwA=
-+k8s.io/mount-utils v0.34.2 h1:DiesOtAiYccJWKGRlJZhRkjCHvpQ3YmSlQp+zkkvf9Y=
-+k8s.io/mount-utils v0.34.2/go.mod h1:MIjjYlqJ0ziYQg0MO09kc9S96GIcMkhF/ay9MncF0GA=
- k8s.io/utils v0.0.0-20250604170112-4c0f3b243397 h1:hwvWFiBzdWw1FhfY1FooPn3kzWuJ8tmbZBHi4zVsl1Y=
- k8s.io/utils v0.0.0-20250604170112-4c0f3b243397/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
+-k8s.io/kms v0.33.5 h1:u60sDBe4Fz6PLeiNF13sEahjIU428ajiWuIw7NSVBlg=
+-k8s.io/kms v0.33.5/go.mod h1:C1I8mjFFBNzfUZXYt9FZVJ8MJl7ynFbGgZFbBzkBJ3E=
++k8s.io/kms v0.33.6 h1:WLiXK7bK3rXd8UhSvjJZKUqciirM+2zCI833v0jYi7g=
++k8s.io/kms v0.33.6/go.mod h1:C1I8mjFFBNzfUZXYt9FZVJ8MJl7ynFbGgZFbBzkBJ3E=
+ k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff h1:/usPimJzUKKu+m+TE36gUyGcf03XZEP0ZIKgKj35LS4=
+ k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff/go.mod h1:5jIi+8yX4RIb8wk3XwBo5Pq2ccx4FP10ohkbSKCZoK8=
+-k8s.io/kube-scheduler v0.33.5 h1:eqZHF4H4F33XF7yGIK4quk1DxGACexINNuNJlO4M1ZY=
+-k8s.io/kube-scheduler v0.33.5/go.mod h1:n004Qs3SWbLMJ6PuPtwkS377CqaaKUeYFzqb1+4IaA8=
+-k8s.io/kubectl v0.33.5 h1:/wj5EjXXrVeSd8+FcZ2sIIP1PlQkq8HWsR9T1Nsl32c=
+-k8s.io/kubectl v0.33.5/go.mod h1:YrBGE7U+nz7+UatG+aNDocIQtdTyqN528dwFCv6+Kuw=
+-k8s.io/kubelet v0.33.5 h1:PYV+O8B6ZoQMDaQdYTSCzNdQTLdjAAWTspS2KkNfjLQ=
+-k8s.io/kubelet v0.33.5/go.mod h1:8SQ/0fgyNwm6zjHktBhPAUlgtji19YMa2lhSlYKUhrA=
+-k8s.io/kubernetes v1.33.5 h1:uf0/5VVQodYf61FudCbwtWjg5ApQcKKA7mwanTLjxyw=
+-k8s.io/kubernetes v1.33.5/go.mod h1:nrt8sldmckKz2fCZhgRX3SKfS2e+CzXATPv6ITNkU00=
+-k8s.io/mount-utils v0.33.5 h1:Dc+t8nfUD+k0kvDyzWqsIxYPd3+KMuVQae2Gr8BAmxs=
+-k8s.io/mount-utils v0.33.5/go.mod h1:1JR4rKymg8B8bCPo618hpSAdrpO6XLh0Acqok/xVwPE=
++k8s.io/kube-scheduler v0.33.6 h1:yBpdIRClZdvPJfVysT1cuCnT9JdHiFnjw4FSJSk/DLQ=
++k8s.io/kube-scheduler v0.33.6/go.mod h1:sBWp6XruPN0mVxNos0DW4UPhi+lX4fwSoQn2X20KI2A=
++k8s.io/kubectl v0.33.6 h1:zTZoafstb7rQ3NpTTnyN47goJOOpqIpf0mXDlVSHJ4o=
++k8s.io/kubectl v0.33.6/go.mod h1:G6iCkPDPQbCbIp01QkD29wdo5hSkBQ2c7vv9YtOUPME=
++k8s.io/kubelet v0.33.6 h1:0wlT1iyZwx+2iCgsCCgi22YU5vY82vW01f6X3pWP48A=
++k8s.io/kubelet v0.33.6/go.mod h1:Nkjry+BISpPNb0WroNJVRYjOe7YacvDYNMbFXMyHEdU=
++k8s.io/kubernetes v1.33.6 h1:NOIZqkx8M4XfdyRKllzLSBiMgSilPzSvCembfzOMk6A=
++k8s.io/kubernetes v1.33.6/go.mod h1:eJiHC143tnNSvmDkCRwGNKA80yXqBvYC3U8L/i67nAY=
++k8s.io/mount-utils v0.33.6 h1:C7WqPt0KU7wvU6ay5tu5gkzhrnYIuQOsBGI/lFcvG4Q=
++k8s.io/mount-utils v0.33.6/go.mod h1:1JR4rKymg8B8bCPo618hpSAdrpO6XLh0Acqok/xVwPE=
+ k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 h1:M3sRQVHv7vB20Xc2ybTt7ODCeFj6JSWYFzOFnYeS6Ro=
+ k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
  sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 h1:jpcvIRr3GLoUoEKRkHKSmGjxb6lWwrBlJsXc+eUYQHM=

--- a/modules/040-node-manager/images/cluster-autoscaler/patches/1.33/001-go-mod.patch
+++ b/modules/040-node-manager/images/cluster-autoscaler/patches/1.33/001-go-mod.patch
@@ -1,5 +1,5 @@
 diff --git a/cluster-autoscaler/apis/go.mod b/cluster-autoscaler/apis/go.mod
-index 572ba909a..2bd2ea52e 100644
+index 706e0214b..5f9fe888a 100644
 --- a/cluster-autoscaler/apis/go.mod
 +++ b/cluster-autoscaler/apis/go.mod
 @@ -1,6 +1,6 @@
@@ -10,7 +10,7 @@ index 572ba909a..2bd2ea52e 100644
  
  require (
  	github.com/onsi/ginkgo/v2 v2.21.0
-@@ -34,15 +34,15 @@ require (
+@@ -34,15 +34,16 @@ require (
  	github.com/pkg/errors v0.9.1 // indirect
  	github.com/spf13/pflag v1.0.5 // indirect
  	github.com/x448/float16 v0.8.4 // indirect
@@ -30,61 +30,75 @@ index 572ba909a..2bd2ea52e 100644
  	golang.org/x/time v0.9.0 // indirect
 -	golang.org/x/tools v0.26.0 // indirect
 +	golang.org/x/tools v0.44.0 // indirect
++	golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated // indirect
  	google.golang.org/protobuf v1.36.5 // indirect
  	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
  	gopkg.in/inf.v0 v0.9.1 // indirect
 diff --git a/cluster-autoscaler/apis/go.sum b/cluster-autoscaler/apis/go.sum
-index d516de6f1..70a3ea29d 100644
+index c3153a11e..1ad901eb8 100644
 --- a/cluster-autoscaler/apis/go.sum
 +++ b/cluster-autoscaler/apis/go.sum
-@@ -89,12 +89,15 @@ golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+@@ -87,40 +87,44 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
+ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+ golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
  golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
- golang.org/x/mod v0.21.0 h1:vvrHzRwRfVKSiLrG+d4FMl/Qi4ukBCE6kZlTUkDYRT0=
- golang.org/x/mod v0.21.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
+-golang.org/x/mod v0.21.0 h1:vvrHzRwRfVKSiLrG+d4FMl/Qi4ukBCE6kZlTUkDYRT0=
+-golang.org/x/mod v0.21.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
++golang.org/x/mod v0.35.0 h1:Ww1D637e6Pg+Zb2KrWfHQUnH2dQRLBQyAtpr/haaJeM=
 +golang.org/x/mod v0.35.0/go.mod h1:+GwiRhIInF8wPm+4AoT6L0FA1QWAad3OMdTRx4tFYlU=
  golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
  golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
  golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
  golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
- golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
- golang.org/x/net v0.38.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
+-golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
+-golang.org/x/net v0.38.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
 +golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
 +golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
  golang.org/x/oauth2 v0.27.0 h1:da9Vo7/tDv5RH/7nZDz1eMGS/q1Vv1N/7FCrBhI9I3M=
  golang.org/x/oauth2 v0.27.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT8=
  golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-@@ -102,17 +105,21 @@ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJ
+ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
  golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
- golang.org/x/sync v0.12.0 h1:MHc5BpPuC30uJk597Ri8TV3CNZcTLu6B6z4lJy+g6Jw=
- golang.org/x/sync v0.12.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
+-golang.org/x/sync v0.12.0 h1:MHc5BpPuC30uJk597Ri8TV3CNZcTLu6B6z4lJy+g6Jw=
+-golang.org/x/sync v0.12.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
++golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
 +golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
  golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
  golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
  golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
- golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
- golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+-golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
+-golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+-golang.org/x/term v0.30.0 h1:PQ39fJZ+mfadBm0y5WlL4vlM7Sx1Hgf13sMIY2+QS9Y=
+-golang.org/x/term v0.30.0/go.mod h1:NYYFdzHoI5wRh/h5tDMdMqCqPJZEuNqVR5xJLd/n67g=
++golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 +golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
- golang.org/x/term v0.30.0 h1:PQ39fJZ+mfadBm0y5WlL4vlM7Sx1Hgf13sMIY2+QS9Y=
- golang.org/x/term v0.30.0/go.mod h1:NYYFdzHoI5wRh/h5tDMdMqCqPJZEuNqVR5xJLd/n67g=
++golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=
 +golang.org/x/term v0.43.0/go.mod h1:lrhlHNdQJHO+1qVYiHfFKVuVioJIheAc3fBSMFYEIsk=
  golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
  golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
- golang.org/x/text v0.23.0 h1:D71I7dUrlY+VX0gQShAThNGHFxZ13dGLBHQLVl1mJlY=
- golang.org/x/text v0.23.0/go.mod h1:/BLNzu4aZCJ1+kcD0DNRotWKage4q2rGVAg4o22unh4=
+-golang.org/x/text v0.23.0 h1:D71I7dUrlY+VX0gQShAThNGHFxZ13dGLBHQLVl1mJlY=
+-golang.org/x/text v0.23.0/go.mod h1:/BLNzu4aZCJ1+kcD0DNRotWKage4q2rGVAg4o22unh4=
++golang.org/x/text v0.37.0 h1:Cqjiwd9eSg8e0QAkyCaQTNHFIIzWtidPahFWR83rTrc=
 +golang.org/x/text v0.37.0/go.mod h1:a5sjxXGs9hsn/AJVwuElvCAo9v8QYLzvavO5z2PiM38=
  golang.org/x/time v0.9.0 h1:EsRrnYcQiGH+5FfbgvV4AP7qEZstoyrHB0DzarOQ4ZY=
  golang.org/x/time v0.9.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
  golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
-@@ -121,6 +128,7 @@ golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roY
+ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+ golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
  golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
- golang.org/x/tools v0.26.0 h1:v/60pFQmzmT9ExmjDv2gGIfi3OqfKoEP6I5+umXlbnQ=
- golang.org/x/tools v0.26.0/go.mod h1:TPVVj70c7JJ3WCazhD8OdXcZg/og+b9+tH/KxylGwH0=
+-golang.org/x/tools v0.26.0 h1:v/60pFQmzmT9ExmjDv2gGIfi3OqfKoEP6I5+umXlbnQ=
+-golang.org/x/tools v0.26.0/go.mod h1:TPVVj70c7JJ3WCazhD8OdXcZg/og+b9+tH/KxylGwH0=
++golang.org/x/tools v0.44.0 h1:UP4ajHPIcuMjT1GqzDWRlalUEoY+uzoZKnhOjbIPD2c=
 +golang.org/x/tools v0.44.0/go.mod h1:KA0AfVErSdxRZIsOVipbv3rQhVXTnlU6UhKxHd1seDI=
++golang.org/x/tools/go/expect v0.1.0-deprecated h1:jY2C5HGYR5lqex3gEniOQL0r7Dq5+VGVgY1nudX5lXY=
++golang.org/x/tools/go/expect v0.1.0-deprecated/go.mod h1:eihoPOH+FgIqa3FpoTwguz/bVUSGBlGQU67vpBeOrBY=
++golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated h1:1h2MnaIAIXISqTFKdENegdpAgUXz6NrPEsbIeWaBRvM=
++golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated/go.mod h1:RVAQXBGNv1ib0J382/DPCRS/BPnsGebyM1Gj5VSDpG8=
  golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
  golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
  golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 diff --git a/cluster-autoscaler/go.mod b/cluster-autoscaler/go.mod
-index d300c0846..498cbc186 100644
+index ef38039cd..df0fd63ec 100644
 --- a/cluster-autoscaler/go.mod
 +++ b/cluster-autoscaler/go.mod
 @@ -1,6 +1,6 @@
@@ -95,8 +109,12 @@ index d300c0846..498cbc186 100644
  
  require (
  	cloud.google.com/go/compute/metadata v0.5.0
-@@ -32,29 +32,29 @@ require (
- 	github.com/stretchr/testify v1.10.0
+@@ -28,32 +28,32 @@ require (
+ 	github.com/pkg/errors v0.9.1
+ 	github.com/prometheus/client_golang v1.22.0
+ 	github.com/spf13/pflag v1.0.5
+-	github.com/stretchr/testify v1.10.0
++	github.com/stretchr/testify v1.11.1
  	github.com/vburenin/ifacemaker v1.2.1
  	go.uber.org/mock v0.4.0
 -	golang.org/x/crypto v0.36.0
@@ -111,59 +129,77 @@ index d300c0846..498cbc186 100644
  	google.golang.org/protobuf v1.36.5
  	gopkg.in/gcfg.v1 v1.2.3
  	gopkg.in/yaml.v2 v2.4.0
--	k8s.io/api v0.33.5
--	k8s.io/apimachinery v0.33.5
--	k8s.io/apiserver v0.33.5
-+	k8s.io/api v0.33.6
-+	k8s.io/apimachinery v0.33.6
-+	k8s.io/apiserver v0.33.6
+-	k8s.io/api v0.33.6
+-	k8s.io/apimachinery v0.33.6
+-	k8s.io/apiserver v0.33.6
++	k8s.io/api v0.33.13
++	k8s.io/apimachinery v0.33.13
++	k8s.io/apiserver v0.33.13
  	k8s.io/autoscaler/cluster-autoscaler/apis v0.0.0-20240627115740-d52e4b9665d7
--	k8s.io/client-go v0.33.5
-+	k8s.io/client-go v0.33.6
+-	k8s.io/client-go v0.33.6
++	k8s.io/client-go v0.33.13
  	k8s.io/cloud-provider v0.33.1
  	k8s.io/cloud-provider-aws v1.27.0
  	k8s.io/cloud-provider-gcp/providers v0.28.2
--	k8s.io/component-base v0.33.5
--	k8s.io/component-helpers v0.33.5
-+	k8s.io/component-base v0.33.6
-+	k8s.io/component-helpers v0.33.6
+-	k8s.io/component-base v0.33.6
+-	k8s.io/component-helpers v0.33.6
++	k8s.io/component-base v0.33.13
++	k8s.io/component-helpers v0.33.13
  	k8s.io/dynamic-resource-allocation v0.33.1
  	k8s.io/klog/v2 v2.130.1
--	k8s.io/kubelet v0.33.5
--	k8s.io/kubernetes v1.33.5
-+	k8s.io/kubelet v0.33.6
-+	k8s.io/kubernetes v1.33.6
+-	k8s.io/kubelet v0.33.6
+-	k8s.io/kubernetes v1.33.6
++	k8s.io/kubelet v0.33.13
++	k8s.io/kubernetes v1.33.13
  	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738
  	sigs.k8s.io/cloud-provider-azure v1.29.4
  	sigs.k8s.io/cloud-provider-azure/pkg/azclient v0.0.13
-@@ -101,7 +101,7 @@ require (
- 	github.com/containerd/typeurl/v2 v2.2.2 // indirect
- 	github.com/coreos/go-semver v0.3.1 // indirect
- 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
--	github.com/cyphar/filepath-securejoin v0.4.1 // indirect
-+	github.com/cyphar/filepath-securejoin v0.5.1 // indirect
- 	github.com/dave/jennifer v1.6.0 // indirect
- 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
- 	github.com/dimchansky/utfbom v1.1.1 // indirect
-@@ -123,7 +123,7 @@ require (
- 	github.com/godbus/dbus/v5 v5.1.0 // indirect
- 	github.com/gogo/protobuf v1.3.2 // indirect
- 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
--	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
-+	github.com/golang-jwt/jwt/v5 v5.2.2 // indirect
- 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
- 	github.com/golang/protobuf v1.5.4 // indirect
- 	github.com/google/btree v1.1.3 // indirect
-@@ -160,7 +160,7 @@ require (
+@@ -113,7 +113,7 @@ require (
+ 	github.com/felixge/httpsnoop v1.0.4 // indirect
+ 	github.com/fsnotify/fsnotify v1.7.0 // indirect
+ 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
+-	github.com/go-logr/logr v1.4.2 // indirect
++	github.com/go-logr/logr v1.4.3 // indirect
+ 	github.com/go-logr/stdr v1.2.2 // indirect
+ 	github.com/go-logr/zapr v1.3.0 // indirect
+ 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
+@@ -146,7 +146,7 @@ require (
+ 	github.com/mailru/easyjson v0.7.7 // indirect
+ 	github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible // indirect
+ 	github.com/mitchellh/go-homedir v1.1.0 // indirect
+-	github.com/moby/spdystream v0.5.0 // indirect
++	github.com/moby/spdystream v0.5.1 // indirect
+ 	github.com/moby/sys/mountinfo v0.7.2 // indirect
+ 	github.com/moby/sys/userns v0.1.0 // indirect
+ 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+@@ -156,7 +156,7 @@ require (
+ 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
+ 	github.com/onsi/ginkgo/v2 v2.21.0 // indirect
+ 	github.com/onsi/gomega v1.35.1 // indirect
+-	github.com/opencontainers/cgroups v0.0.1 // indirect
++	github.com/opencontainers/cgroups v0.0.3 // indirect
  	github.com/opencontainers/go-digest v1.0.0 // indirect
  	github.com/opencontainers/image-spec v1.1.1 // indirect
  	github.com/opencontainers/runtime-spec v1.2.0 // indirect
--	github.com/opencontainers/selinux v1.11.1 // indirect
-+	github.com/opencontainers/selinux v1.12.0 // indirect
- 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
- 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
- 	github.com/prometheus/client_model v0.6.1 // indirect
-@@ -189,12 +189,13 @@ require (
+@@ -175,26 +175,27 @@ require (
+ 	go.etcd.io/etcd/client/pkg/v3 v3.5.21 // indirect
+ 	go.etcd.io/etcd/client/v3 v3.5.21 // indirect
+ 	go.opencensus.io v0.24.0 // indirect
+-	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
++	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
+ 	go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful v0.42.0 // indirect
+ 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.58.0 // indirect
+ 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.58.0 // indirect
+-	go.opentelemetry.io/otel v1.33.0 // indirect
++	go.opentelemetry.io/otel v1.41.0 // indirect
+ 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.33.0 // indirect
+ 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.33.0 // indirect
+-	go.opentelemetry.io/otel/metric v1.33.0 // indirect
++	go.opentelemetry.io/otel/metric v1.41.0 // indirect
+ 	go.opentelemetry.io/otel/sdk v1.33.0 // indirect
+-	go.opentelemetry.io/otel/trace v1.33.0 // indirect
++	go.opentelemetry.io/otel/trace v1.41.0 // indirect
+ 	go.opentelemetry.io/proto/otlp v1.4.0 // indirect
  	go.uber.org/multierr v1.11.0 // indirect
  	go.uber.org/zap v1.27.0 // indirect
  	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
@@ -186,17 +222,17 @@ index d300c0846..498cbc186 100644
  	gopkg.in/warnings.v0 v0.1.2 // indirect
  	gopkg.in/yaml.v3 v3.0.1 // indirect
  	k8s.io/apiextensions-apiserver v0.0.0 // indirect
--	k8s.io/code-generator v0.33.5 // indirect
--	k8s.io/controller-manager v0.33.5 // indirect
--	k8s.io/cri-api v0.33.5 // indirect
-+	k8s.io/code-generator v0.33.6 // indirect
-+	k8s.io/controller-manager v0.33.6 // indirect
-+	k8s.io/cri-api v0.33.6 // indirect
+-	k8s.io/code-generator v0.33.6 // indirect
+-	k8s.io/controller-manager v0.33.6 // indirect
+-	k8s.io/cri-api v0.33.6 // indirect
++	k8s.io/code-generator v0.33.13 // indirect
++	k8s.io/controller-manager v0.33.13 // indirect
++	k8s.io/cri-api v0.33.13 // indirect
  	k8s.io/cri-client v0.0.0 // indirect
  	k8s.io/csi-translation-lib v0.27.0 // indirect
  	k8s.io/gengo/v2 v2.0.0-20250207200755-1244d31929d7 // indirect
--	k8s.io/kms v0.33.5 // indirect
-+	k8s.io/kms v0.33.6 // indirect
+-	k8s.io/kms v0.33.6 // indirect
++	k8s.io/kms v0.33.13 // indirect
  	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff // indirect
  	k8s.io/kube-scheduler v0.0.0 // indirect
  	k8s.io/kubectl v0.28.0 // indirect
@@ -204,137 +240,195 @@ index d300c0846..498cbc186 100644
  	sigs.k8s.io/structured-merge-diff/v4 v4.6.0 // indirect
  )
  
--replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.33.5
-+replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.33.6
+-replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.33.6
++replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.33.13
  
--replace k8s.io/code-generator => k8s.io/code-generator v0.33.5
-+replace k8s.io/code-generator => k8s.io/code-generator v0.33.6
+-replace k8s.io/code-generator => k8s.io/code-generator v0.33.6
++replace k8s.io/code-generator => k8s.io/code-generator v0.33.13
  
--replace k8s.io/cri-api => k8s.io/cri-api v0.33.5
-+replace k8s.io/cri-api => k8s.io/cri-api v0.33.6
+-replace k8s.io/cri-api => k8s.io/cri-api v0.33.6
++replace k8s.io/cri-api => k8s.io/cri-api v0.33.13
  
--replace k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.33.5
-+replace k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.33.6
+-replace k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.33.6
++replace k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.33.13
  
--replace k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.33.5
-+replace k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.33.6
+-replace k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.33.6
++replace k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.33.13
  
--replace k8s.io/kubectl => k8s.io/kubectl v0.33.5
-+replace k8s.io/kubectl => k8s.io/kubectl v0.33.6
+-replace k8s.io/kubectl => k8s.io/kubectl v0.33.6
++replace k8s.io/kubectl => k8s.io/kubectl v0.33.13
  
--replace k8s.io/mount-utils => k8s.io/mount-utils v0.33.5
-+replace k8s.io/mount-utils => k8s.io/mount-utils v0.33.6
+-replace k8s.io/mount-utils => k8s.io/mount-utils v0.33.6
++replace k8s.io/mount-utils => k8s.io/mount-utils v0.33.13
  
--replace k8s.io/kms => k8s.io/kms v0.33.5
-+replace k8s.io/kms => k8s.io/kms v0.33.6
+-replace k8s.io/kms => k8s.io/kms v0.33.6
++replace k8s.io/kms => k8s.io/kms v0.33.13
  
  replace k8s.io/autoscaler/cluster-autoscaler/apis => ./apis
  
--replace k8s.io/cri-client => k8s.io/cri-client v0.33.5
-+replace k8s.io/cri-client => k8s.io/cri-client v0.33.6
+-replace k8s.io/cri-client => k8s.io/cri-client v0.33.6
++replace k8s.io/cri-client => k8s.io/cri-client v0.33.13
  
--replace k8s.io/api => k8s.io/api v0.33.5
-+replace k8s.io/api => k8s.io/api v0.33.6
+-replace k8s.io/api => k8s.io/api v0.33.6
++replace k8s.io/api => k8s.io/api v0.33.13
  
--replace k8s.io/apimachinery => k8s.io/apimachinery v0.33.5
-+replace k8s.io/apimachinery => k8s.io/apimachinery v0.33.6
+-replace k8s.io/apimachinery => k8s.io/apimachinery v0.33.6
++replace k8s.io/apimachinery => k8s.io/apimachinery v0.33.13
  
--replace k8s.io/apiserver => k8s.io/apiserver v0.33.5
-+replace k8s.io/apiserver => k8s.io/apiserver v0.33.6
+-replace k8s.io/apiserver => k8s.io/apiserver v0.33.6
++replace k8s.io/apiserver => k8s.io/apiserver v0.33.13
  
--replace k8s.io/cli-runtime => k8s.io/cli-runtime v0.33.5
-+replace k8s.io/cli-runtime => k8s.io/cli-runtime v0.33.6
+-replace k8s.io/cli-runtime => k8s.io/cli-runtime v0.33.6
++replace k8s.io/cli-runtime => k8s.io/cli-runtime v0.33.13
  
--replace k8s.io/client-go => k8s.io/client-go v0.33.5
-+replace k8s.io/client-go => k8s.io/client-go v0.33.6
+-replace k8s.io/client-go => k8s.io/client-go v0.33.6
++replace k8s.io/client-go => k8s.io/client-go v0.33.13
  
--replace k8s.io/cloud-provider => k8s.io/cloud-provider v0.33.5
-+replace k8s.io/cloud-provider => k8s.io/cloud-provider v0.33.6
+-replace k8s.io/cloud-provider => k8s.io/cloud-provider v0.33.6
++replace k8s.io/cloud-provider => k8s.io/cloud-provider v0.33.13
  
--replace k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.33.5
-+replace k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.33.6
+-replace k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.33.6
++replace k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.33.13
  
--replace k8s.io/component-base => k8s.io/component-base v0.33.5
-+replace k8s.io/component-base => k8s.io/component-base v0.33.6
+-replace k8s.io/component-base => k8s.io/component-base v0.33.6
++replace k8s.io/component-base => k8s.io/component-base v0.33.13
  
--replace k8s.io/component-helpers => k8s.io/component-helpers v0.33.5
-+replace k8s.io/component-helpers => k8s.io/component-helpers v0.33.6
+-replace k8s.io/component-helpers => k8s.io/component-helpers v0.33.6
++replace k8s.io/component-helpers => k8s.io/component-helpers v0.33.13
  
--replace k8s.io/controller-manager => k8s.io/controller-manager v0.33.5
-+replace k8s.io/controller-manager => k8s.io/controller-manager v0.33.6
+-replace k8s.io/controller-manager => k8s.io/controller-manager v0.33.6
++replace k8s.io/controller-manager => k8s.io/controller-manager v0.33.13
  
--replace k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.33.5
-+replace k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.33.6
+-replace k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.33.6
++replace k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.33.13
  
--replace k8s.io/endpointslice => k8s.io/endpointslice v0.33.5
-+replace k8s.io/endpointslice => k8s.io/endpointslice v0.33.6
+-replace k8s.io/endpointslice => k8s.io/endpointslice v0.33.6
++replace k8s.io/endpointslice => k8s.io/endpointslice v0.33.13
  
--replace k8s.io/externaljwt => k8s.io/externaljwt v0.33.5
-+replace k8s.io/externaljwt => k8s.io/externaljwt v0.33.6
+-replace k8s.io/externaljwt => k8s.io/externaljwt v0.33.6
++replace k8s.io/externaljwt => k8s.io/externaljwt v0.33.13
  
--replace k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.33.5
-+replace k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.33.6
+-replace k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.33.6
++replace k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.33.13
  
--replace k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.33.5
-+replace k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.33.6
+-replace k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.33.6
++replace k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.33.13
  
--replace k8s.io/kube-proxy => k8s.io/kube-proxy v0.33.5
-+replace k8s.io/kube-proxy => k8s.io/kube-proxy v0.33.6
+-replace k8s.io/kube-proxy => k8s.io/kube-proxy v0.33.6
++replace k8s.io/kube-proxy => k8s.io/kube-proxy v0.33.13
  
--replace k8s.io/kubelet => k8s.io/kubelet v0.33.5
-+replace k8s.io/kubelet => k8s.io/kubelet v0.33.6
+-replace k8s.io/kubelet => k8s.io/kubelet v0.33.6
++replace k8s.io/kubelet => k8s.io/kubelet v0.33.13
  
--replace k8s.io/metrics => k8s.io/metrics v0.33.5
-+replace k8s.io/metrics => k8s.io/metrics v0.33.6
+-replace k8s.io/metrics => k8s.io/metrics v0.33.6
++replace k8s.io/metrics => k8s.io/metrics v0.33.13
  
--replace k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.33.5
-+replace k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.33.6
+-replace k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.33.6
++replace k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.33.13
  
--replace k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.33.5
-+replace k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.33.6
+-replace k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.33.6
++replace k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.33.13
  
--replace k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.33.5
-+replace k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.33.6
+-replace k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.33.6
++replace k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.33.13
  
--replace k8s.io/sample-controller => k8s.io/sample-controller v0.33.5
-+replace k8s.io/sample-controller => k8s.io/sample-controller v0.33.6
+-replace k8s.io/sample-controller => k8s.io/sample-controller v0.33.6
++replace k8s.io/sample-controller => k8s.io/sample-controller v0.33.13
 diff --git a/cluster-autoscaler/go.sum b/cluster-autoscaler/go.sum
-index cb1f8f025..4ab752eda 100644
+index daf0a160f..223f5b5a4 100644
 --- a/cluster-autoscaler/go.sum
 +++ b/cluster-autoscaler/go.sum
-@@ -126,8 +126,8 @@ github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8
- github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
- github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
- github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
--github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=
--github.com/cyphar/filepath-securejoin v0.4.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
-+github.com/cyphar/filepath-securejoin v0.5.1 h1:eYgfMq5yryL4fbWfkLpFFy2ukSELzaJOTaUTuh+oF48=
-+github.com/cyphar/filepath-securejoin v0.5.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
- github.com/dave/jennifer v1.6.0 h1:MQ/6emI2xM7wt0tJzJzyUik2Q3Tcn2eE0vtYgh4GPVI=
- github.com/dave/jennifer v1.6.0/go.mod h1:AxTG893FiZKqxy3FP1kL80VMshSMuz2G+EgvszgGRnk=
- github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-@@ -193,8 +193,8 @@ github.com/golang-jwt/jwt/v4 v4.2.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzw
- github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
- github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
- github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
--github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
--github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
-+github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
-+github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
- github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
- github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
- github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
-@@ -326,8 +326,8 @@ github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJw
- github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
- github.com/opencontainers/runtime-spec v1.2.0 h1:z97+pHb3uELt/yiAWD691HNHQIF07bE7dzrbT927iTk=
- github.com/opencontainers/runtime-spec v1.2.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
--github.com/opencontainers/selinux v1.11.1 h1:nHFvthhM0qY8/m+vfhJylliSshm8G1jJ2jDMcgULaH8=
--github.com/opencontainers/selinux v1.11.1/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M586T4DlDRYpFkyec=
-+github.com/opencontainers/selinux v1.12.0 h1:6n5JV4Cf+4y0KNXW48TLj5DwfXpvWlxXplUkdTrmPb8=
-+github.com/opencontainers/selinux v1.12.0/go.mod h1:BTPX+bjVbWGXw7ZZWUbdENt8w0htPSrlgOOysQaU62U=
- github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
- github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
- github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+@@ -165,8 +165,8 @@ github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyT
+ github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv5E=
+ github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXEeXQVeNoDQ=
+ github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+-github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
+-github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
++github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
++github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
+ github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
+ github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
+ github.com/go-logr/zapr v1.3.0 h1:XGdV8XW8zdwFiwOA2Dryh1gj2KRQyOOoNmBy4EplIcQ=
+@@ -297,8 +297,8 @@ github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG
+ github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
+ github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=
+ github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
+-github.com/moby/spdystream v0.5.0 h1:7r0J1Si3QO/kjRitvSLVVFUjxMEb/YLj6S9FF62JBCU=
+-github.com/moby/spdystream v0.5.0/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
++github.com/moby/spdystream v0.5.1 h1:9sNYeYZUcci9R6/w7KDaFWEWeV4LStVG78Mpyq/Zm/Y=
++github.com/moby/spdystream v0.5.1/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
+ github.com/moby/sys/mountinfo v0.7.2 h1:1shs6aH5s4o5H2zQLn796ADW1wMrIwHsyJ2v9KouLrg=
+ github.com/moby/sys/mountinfo v0.7.2/go.mod h1:1YOa8w8Ih7uW0wALDUgT1dTTSBrZ+HiBLGws92L2RU4=
+ github.com/moby/sys/userns v0.1.0 h1:tVLXkFOxVu9A64/yh59slHVv9ahO9UIev4JZusOLG/g=
+@@ -318,8 +318,8 @@ github.com/onsi/ginkgo/v2 v2.21.0 h1:7rg/4f3rB88pb5obDgNZrNHrQ4e6WpjonchcpuBRnZM
+ github.com/onsi/ginkgo/v2 v2.21.0/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=
+ github.com/onsi/gomega v1.35.1 h1:Cwbd75ZBPxFSuZ6T+rN/WCb/gOc6YgFBXLlZLhC7Ds4=
+ github.com/onsi/gomega v1.35.1/go.mod h1:PvZbdDc8J6XJEpDK4HCuRBm8a6Fzp9/DmhC9C7yFlog=
+-github.com/opencontainers/cgroups v0.0.1 h1:MXjMkkFpKv6kpuirUa4USFBas573sSAY082B4CiHEVA=
+-github.com/opencontainers/cgroups v0.0.1/go.mod h1:s8lktyhlGUqM7OSRL5P7eAW6Wb+kWPNvt4qvVfzA5vs=
++github.com/opencontainers/cgroups v0.0.3 h1:Jc9dWh/0YLGjdy6J/9Ln8NM5BfTA4W2BY0GMozy3aDU=
++github.com/opencontainers/cgroups v0.0.3/go.mod h1:s8lktyhlGUqM7OSRL5P7eAW6Wb+kWPNvt4qvVfzA5vs=
+ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
+ github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
+ github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
+@@ -344,8 +344,8 @@ github.com/prometheus/common v0.62.0 h1:xasJaQlnWAeyHdUBeGjXmutelfJHWMRr+Fg4QszZ
+ github.com/prometheus/common v0.62.0/go.mod h1:vyBcEuLSvWos9B1+CyL7JZ2up+uFzXhkqml0W5zIY1I=
+ github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
+ github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
+-github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
+-github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
++github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
++github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
+ github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+@@ -368,8 +368,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
+ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+ github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+-github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+-github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
++github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
++github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+ github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75 h1:6fotK7otjonDflCTK0BCfls4SPy3NcCVb5dqqmbRknE=
+ github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75/go.mod h1:KO6IkyS8Y3j8OdNO85qEYBsRPuteD+YciPomcXdrMnk=
+ github.com/vburenin/ifacemaker v1.2.1 h1:3Vq8B/bfBgjWTkv+jDg4dVL1KHt3k1K4lO7XRxYA2sk=
+@@ -400,8 +400,8 @@ go.etcd.io/etcd/server/v3 v3.5.21 h1:9w0/k12majtgarGmlMVuhwXRI2ob3/d1Ik3X5TKo0yU
+ go.etcd.io/etcd/server/v3 v3.5.21/go.mod h1:G1mOzdwuzKT1VRL7SqRchli/qcFrtLBTAQ4lV20sXXo=
+ go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
+ go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
+-go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
+-go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
++go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
++go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
+ go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful v0.42.0 h1:Z6SbqeRZAl2OczfkFOqLx1BeYBDYehNjEnqluD7581Y=
+ go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful v0.42.0/go.mod h1:XiglO+8SPMqM3Mqh5/rtxR1VHc63o8tb38QrU6tm4mU=
+ go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.58.0 h1:PS8wXpbyaDJQ2VDHHncMe9Vct0Zn1fEjpsjrLxGJoSc=
+@@ -410,18 +410,18 @@ go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.58.0 h1:yd02MEj
+ go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.58.0/go.mod h1:umTcuxiv1n/s/S6/c2AT/g2CQ7u5C59sHDNmfSwgz7Q=
+ go.opentelemetry.io/contrib/propagators/b3 v1.17.0 h1:ImOVvHnku8jijXqkwCSyYKRDt2YrnGXD4BbhcpfbfJo=
+ go.opentelemetry.io/contrib/propagators/b3 v1.17.0/go.mod h1:IkfUfMpKWmynvvE0264trz0sf32NRTZL4nuAN9AbWRc=
+-go.opentelemetry.io/otel v1.33.0 h1:/FerN9bax5LoK51X/sI0SVYrjSE0/yUL7DpxW4K3FWw=
+-go.opentelemetry.io/otel v1.33.0/go.mod h1:SUUkR6csvUQl+yjReHu5uM3EtVV7MBm5FHKRlNx4I8I=
++go.opentelemetry.io/otel v1.41.0 h1:YlEwVsGAlCvczDILpUXpIpPSL/VPugt7zHThEMLce1c=
++go.opentelemetry.io/otel v1.41.0/go.mod h1:Yt4UwgEKeT05QbLwbyHXEwhnjxNO6D8L5PQP51/46dE=
+ go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.33.0 h1:Vh5HayB/0HHfOQA7Ctx69E/Y/DcQSMPpKANYVMQ7fBA=
+ go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.33.0/go.mod h1:cpgtDBaqD/6ok/UG0jT15/uKjAY8mRA53diogHBg3UI=
+ go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.33.0 h1:5pojmb1U1AogINhN3SurB+zm/nIcusopeBNp42f45QM=
+ go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.33.0/go.mod h1:57gTHJSE5S1tqg+EKsLPlTWhpHMsWlVmer+LA926XiA=
+-go.opentelemetry.io/otel/metric v1.33.0 h1:r+JOocAyeRVXD8lZpjdQjzMadVZp2M4WmQ+5WtEnklQ=
+-go.opentelemetry.io/otel/metric v1.33.0/go.mod h1:L9+Fyctbp6HFTddIxClbQkjtubW6O9QS3Ann/M82u6M=
++go.opentelemetry.io/otel/metric v1.41.0 h1:rFnDcs4gRzBcsO9tS8LCpgR0dxg4aaxWlJxCno7JlTQ=
++go.opentelemetry.io/otel/metric v1.41.0/go.mod h1:xPvCwd9pU0VN8tPZYzDZV/BMj9CM9vs00GuBjeKhJps=
+ go.opentelemetry.io/otel/sdk v1.33.0 h1:iax7M131HuAm9QkZotNHEfstof92xM+N8sr3uHXc2IM=
+ go.opentelemetry.io/otel/sdk v1.33.0/go.mod h1:A1Q5oi7/9XaMlIWzPSxLRWOI8nG3FnzHJNbiENQuihM=
+-go.opentelemetry.io/otel/trace v1.33.0 h1:cCJuF7LRjUFso9LPnEAHJDB2pqzp+hbO8eu1qqW2d/s=
+-go.opentelemetry.io/otel/trace v1.33.0/go.mod h1:uIcdVUZMpTAmz0tI1z04GoVSezK37CbGV4fr1f2nBck=
++go.opentelemetry.io/otel/trace v1.41.0 h1:Vbk2co6bhj8L59ZJ6/xFTskY+tGAbOnCtQGVVa9TIN0=
++go.opentelemetry.io/otel/trace v1.41.0/go.mod h1:U1NU4ULCoxeDKc09yCWdWe+3QoyweJcISEVa1RBzOis=
+ go.opentelemetry.io/proto/otlp v1.4.0 h1:TA9WRvW6zMwP+Ssb6fLoUIuirti1gGbP28GcKG1jgeg=
+ go.opentelemetry.io/proto/otlp v1.4.0/go.mod h1:PPBWZIP98o2ElSqI35IHfu7hIhSwvc5N38Jw8pXuGFY=
+ go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 @@ -439,8 +439,8 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
  golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
  golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58=
@@ -430,96 +524,96 @@ index cb1f8f025..4ab752eda 100644
  gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
  honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
  honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
--k8s.io/api v0.33.5 h1:YR+uhYj05jdRpcksv8kjSliW+v9hwXxn6Cv10aR8Juw=
--k8s.io/api v0.33.5/go.mod h1:2gzShdwXKT5yPGiqrTrn/U/nLZ7ZyT4WuAj3XGDVgVs=
--k8s.io/apiextensions-apiserver v0.33.5 h1:93NZh6rmrcamX/tfv/dZrTsMiQX69ufANmDcKPEgSeA=
--k8s.io/apiextensions-apiserver v0.33.5/go.mod h1:JIbyQnNlu6nQa7b1vgFi51pmlXOk8mdn0WJwUJnz/7U=
--k8s.io/apimachinery v0.33.5 h1:NiT64hln4TQXeYR18/ES39OrNsjGz8NguxsBgp+6QIo=
--k8s.io/apimachinery v0.33.5/go.mod h1:BHW0YOu7n22fFv/JkYOEfkUYNRN0fj0BlvMFWA7b+SM=
--k8s.io/apiserver v0.33.5 h1:X1Gy33r4YkRLRqTjGjofk7X1/EjSLEVSJ/A+1qjoj60=
--k8s.io/apiserver v0.33.5/go.mod h1:Q+b5Btbc8x0PqOCeh/xBTesKk+cXQRN+PF2wdrTKDeg=
--k8s.io/client-go v0.33.5 h1:I8BdmQGxInpkMEnJvV6iG7dqzP3JRlpZZlib3OMFc3o=
--k8s.io/client-go v0.33.5/go.mod h1:W8PQP4MxbM4ypgagVE65mUUqK1/ByQkSALF9tzuQ6u0=
--k8s.io/cloud-provider v0.33.5 h1:LyU8ZVID3Q8S/aEsPqv5bHCfPeo3NXKrD5iSBqHeV/U=
--k8s.io/cloud-provider v0.33.5/go.mod h1:kSY4+DXKXhWmHLyuUDY09zTL9g9MbcOpahoVY6mzW8Q=
-+k8s.io/api v0.33.6 h1:9O22ZqwT6CkQ3iboVpvTR5BEWuT3Xm6/8NX6MOLmc38=
-+k8s.io/api v0.33.6/go.mod h1:bdon4pRFmRmdsFyltGIoCaPqutN7y//OQ4srD0uy9X0=
-+k8s.io/apiextensions-apiserver v0.33.6 h1:S+18aFz53T/iHPgj9iB7bAZmRPeW8b1umsWaRdgj+6U=
-+k8s.io/apiextensions-apiserver v0.33.6/go.mod h1:YUhU/Tb0GszjMK5BXb1HpP6+26TQ1xodhfntmZv7RC0=
-+k8s.io/apimachinery v0.33.6 h1:Pq+px1i1t7lNgE58dIeBwJh7OWId6pfGD1dYBm/U5HI=
-+k8s.io/apimachinery v0.33.6/go.mod h1:BHW0YOu7n22fFv/JkYOEfkUYNRN0fj0BlvMFWA7b+SM=
-+k8s.io/apiserver v0.33.6 h1:X78/4sciWuKMM6Wlm2z4WMthhJSfsO/vcyjx7J6gEsE=
-+k8s.io/apiserver v0.33.6/go.mod h1:5rRMAedHE4Vke25QGuW2kyfPIHC8nmQxNLdvJKAcmIU=
-+k8s.io/client-go v0.33.6 h1:icPU5E5XHl/5mdwMUdSxpGtHnnjWzG0MSputTR9odrg=
-+k8s.io/client-go v0.33.6/go.mod h1:3z/Cwqdi6/Uo+E17k+OgQi4QfXS0XuIUmfHpK6rQdZU=
-+k8s.io/cloud-provider v0.33.6 h1:XLt8UhgsZgou8Ua6KQrnnHGS3lpZRHlbNhnO4kPyO0c=
-+k8s.io/cloud-provider v0.33.6/go.mod h1:I08jJ7obAWjv9z5ZcabdOV3aizfo7ru495xuxlHQw84=
+-k8s.io/api v0.33.6 h1:9O22ZqwT6CkQ3iboVpvTR5BEWuT3Xm6/8NX6MOLmc38=
+-k8s.io/api v0.33.6/go.mod h1:bdon4pRFmRmdsFyltGIoCaPqutN7y//OQ4srD0uy9X0=
+-k8s.io/apiextensions-apiserver v0.33.6 h1:S+18aFz53T/iHPgj9iB7bAZmRPeW8b1umsWaRdgj+6U=
+-k8s.io/apiextensions-apiserver v0.33.6/go.mod h1:YUhU/Tb0GszjMK5BXb1HpP6+26TQ1xodhfntmZv7RC0=
+-k8s.io/apimachinery v0.33.6 h1:Pq+px1i1t7lNgE58dIeBwJh7OWId6pfGD1dYBm/U5HI=
+-k8s.io/apimachinery v0.33.6/go.mod h1:BHW0YOu7n22fFv/JkYOEfkUYNRN0fj0BlvMFWA7b+SM=
+-k8s.io/apiserver v0.33.6 h1:X78/4sciWuKMM6Wlm2z4WMthhJSfsO/vcyjx7J6gEsE=
+-k8s.io/apiserver v0.33.6/go.mod h1:5rRMAedHE4Vke25QGuW2kyfPIHC8nmQxNLdvJKAcmIU=
+-k8s.io/client-go v0.33.6 h1:icPU5E5XHl/5mdwMUdSxpGtHnnjWzG0MSputTR9odrg=
+-k8s.io/client-go v0.33.6/go.mod h1:3z/Cwqdi6/Uo+E17k+OgQi4QfXS0XuIUmfHpK6rQdZU=
+-k8s.io/cloud-provider v0.33.6 h1:XLt8UhgsZgou8Ua6KQrnnHGS3lpZRHlbNhnO4kPyO0c=
+-k8s.io/cloud-provider v0.33.6/go.mod h1:I08jJ7obAWjv9z5ZcabdOV3aizfo7ru495xuxlHQw84=
++k8s.io/api v0.33.13 h1:Au/I/J8SXmcCBxp+KiS82451AEaKjVHouB1x3lUm1Wk=
++k8s.io/api v0.33.13/go.mod h1:XCIdoR5NWEBB8xORizkh3zBSUk4Pz5KnfnGuOesy0+k=
++k8s.io/apiextensions-apiserver v0.33.13 h1:T/79+dR0xlAEvx2Uf3EbWViMGy+NlFNmU05k8UEbrYk=
++k8s.io/apiextensions-apiserver v0.33.13/go.mod h1:gMQb7kUW++npZHBLo3wnGvlfJj/S5DsUPxX5PxIvbj8=
++k8s.io/apimachinery v0.33.13 h1:e15J9pNLORqlAQ3/D2QdXvMTHJLl0PxDhike6iNcw20=
++k8s.io/apimachinery v0.33.13/go.mod h1:a8VYBaEU2Z6n2IxTG2Hs6WX5i0wQFPGyl4YFab4kn90=
++k8s.io/apiserver v0.33.13 h1:U4w4RKdwzsBeETIGGWV5y3LrPzhUwRw0X5fylRO0dOo=
++k8s.io/apiserver v0.33.13/go.mod h1:n2QaM8cnu0NNQhplgqA0COZwBXmGOtULfO9cGVHt/s4=
++k8s.io/client-go v0.33.13 h1:gyirIFpLEF9RltmrUkkObQFkxeumU2hRcxiDsVfrf1w=
++k8s.io/client-go v0.33.13/go.mod h1:JcZUgHTHDjbLaFaGVNuGmef4iqKNqOzdtwDu3RlR058=
++k8s.io/cloud-provider v0.33.13 h1:/KeHOuR4eAHfwtZfwMc3q8aKHYDhSi/b0+R5DMvTwJ0=
++k8s.io/cloud-provider v0.33.13/go.mod h1:a0czTWHOO6QXoHLrHYT2A21o6lmvk84NNGSPNKX1BKo=
  k8s.io/cloud-provider-aws v1.27.0 h1:PF8YrH8QcN6JoXB3Xxlaz84SBDYMPunJuCc0cPuCWXA=
  k8s.io/cloud-provider-aws v1.27.0/go.mod h1:9vUb5mnVnReSRDBWcBxB1b0HOeEc472iOPmrnwpN9SA=
  k8s.io/cloud-provider-gcp/providers v0.28.2 h1:I65pFTLNMQSj7YuW3Mg3pZIXmw0naCmF6TGAuz4/sZE=
  k8s.io/cloud-provider-gcp/providers v0.28.2/go.mod h1:P8dxRvvLtX7xUwVUzA/QOqv8taCzBaVsVMnjnpjmYXE=
--k8s.io/code-generator v0.33.5 h1:KwkOvhwAaorjSwF2MQhhdhL3i8bBmAal/TWhX67kdHw=
--k8s.io/code-generator v0.33.5/go.mod h1:Ra+sdZquRakeTGcEnQAPw6BmlZ92IvxwQQTX/XOvOIE=
--k8s.io/component-base v0.33.5 h1:4D3kxjEx1pJRy3WHAZsmX3+LCpmd4ftE+2J4v6naTnQ=
--k8s.io/component-base v0.33.5/go.mod h1:Zma1YjBVuuGxIbspj1vGR3/5blzo2ARf1v0QTtog1to=
--k8s.io/component-helpers v0.33.5 h1:1LDSMzn7YTreVLPaOBJK36ase/FWi2sDpeJJvbEBO2s=
--k8s.io/component-helpers v0.33.5/go.mod h1:C3HsDU2lANSLgTTgMJ0TFnG5xZrVrxR3Ss9n7Wrsw4s=
--k8s.io/controller-manager v0.33.5 h1:abmssknXnhOhW533583v2SYQObD5RhYiSL7Za1rezGM=
--k8s.io/controller-manager v0.33.5/go.mod h1:KuQeAlf4vI2+qj5fwPVLaDlbtrTBA/8L/LqQvI74Ow0=
--k8s.io/cri-api v0.33.5 h1:UBYYKZwaFTaAJj1gF6vYy/iSkWk5pIVaoTjjF6ltUCs=
--k8s.io/cri-api v0.33.5/go.mod h1:OLQvT45OpIA+tv91ZrpuFIGY+Y2Ho23poS7n115Aocs=
--k8s.io/cri-client v0.33.5 h1:RjkIlunp2NxKPQLvD9XlQwjliz71L0jljmIrGGxPZAU=
--k8s.io/cri-client v0.33.5/go.mod h1:apcc+zemlSsvajH3a61bARqArBN2YkQueMe820qiVjQ=
--k8s.io/csi-translation-lib v0.33.5 h1:CatOlpJtSJ9eliQWvGsdjWBdOFgQvIlyaVXfs1QojTY=
--k8s.io/csi-translation-lib v0.33.5/go.mod h1:/7unRR1EEbxjjDcUN3v5Qc3vSPy3vwwFbuTPzk/raCo=
--k8s.io/dynamic-resource-allocation v0.33.5 h1:rWNQB06AMTufOODf1H9BMM7Qw0fBKP0KA2mHEuEmkQQ=
--k8s.io/dynamic-resource-allocation v0.33.5/go.mod h1:b9RAX4x8WFTMYonx7yZTDqC4++LwIMJNq+CuN5/s9lU=
-+k8s.io/code-generator v0.33.6 h1:1CFzvpqz3r52zjvikYaF5bvYZkKT6brMIMSB7odPaIs=
-+k8s.io/code-generator v0.33.6/go.mod h1:ndnG7E7wSIOLMl2GASBRdoRitKGN5fp/qq5nKTmiTh8=
-+k8s.io/component-base v0.33.6 h1:a4HGKS3Ax68W1xO1MpVnVybgeJ3OBjvLE9SALoezTZc=
-+k8s.io/component-base v0.33.6/go.mod h1:rUo6Mge+6JvNLrhRzhotfGLxI0tyaQXbL2rnth4UEFw=
-+k8s.io/component-helpers v0.33.6 h1:PvmETVzr4Deym6mn1klgMvARgJY9KuDWTZ39bVlKlZc=
-+k8s.io/component-helpers v0.33.6/go.mod h1:rAX3imLcTAozWTRhR13/LAR3Mf8bksoayTpUdKZFUJo=
-+k8s.io/controller-manager v0.33.6 h1:md2KM5RabX7KTTly1KmNDbNr5YJvLtse7sJOX2we8tI=
-+k8s.io/controller-manager v0.33.6/go.mod h1:dtCyZIG+CNFI8hY/lQY7ZAOO20VxGm+lpi1do2fmLGY=
-+k8s.io/cri-api v0.33.6 h1:yQXCHwWzedRSrPhy/r0QMI9a3jc6YpHnorfDBimdxng=
-+k8s.io/cri-api v0.33.6/go.mod h1:OLQvT45OpIA+tv91ZrpuFIGY+Y2Ho23poS7n115Aocs=
-+k8s.io/cri-client v0.33.6 h1:pVecZ/LeA3+wKJea8Rfp5jnVu0GYe6N/iFIM+lOBSCw=
-+k8s.io/cri-client v0.33.6/go.mod h1:1z3JawYGs5KTJasU+3QBhXlovZHrXIEkgTfHAWwvpmc=
-+k8s.io/csi-translation-lib v0.33.6 h1:ns0+YQ8R0lbFmAOSVgTLBvav2LrvONz7Uy3M2rpf/6E=
-+k8s.io/csi-translation-lib v0.33.6/go.mod h1:t266CgUYPVdST8pjPaCOEDLejWwV1Tms5igy8FVYyQo=
-+k8s.io/dynamic-resource-allocation v0.33.6 h1:HrPUowR+KvxmgPNin+e424PA4rWFPd/W25W1jULKapk=
-+k8s.io/dynamic-resource-allocation v0.33.6/go.mod h1:ByWsZ+8UxTvPC4UmyWdevUIGzxIrgmiyxcddLsKkGuY=
+-k8s.io/code-generator v0.33.6 h1:1CFzvpqz3r52zjvikYaF5bvYZkKT6brMIMSB7odPaIs=
+-k8s.io/code-generator v0.33.6/go.mod h1:ndnG7E7wSIOLMl2GASBRdoRitKGN5fp/qq5nKTmiTh8=
+-k8s.io/component-base v0.33.6 h1:a4HGKS3Ax68W1xO1MpVnVybgeJ3OBjvLE9SALoezTZc=
+-k8s.io/component-base v0.33.6/go.mod h1:rUo6Mge+6JvNLrhRzhotfGLxI0tyaQXbL2rnth4UEFw=
+-k8s.io/component-helpers v0.33.6 h1:PvmETVzr4Deym6mn1klgMvARgJY9KuDWTZ39bVlKlZc=
+-k8s.io/component-helpers v0.33.6/go.mod h1:rAX3imLcTAozWTRhR13/LAR3Mf8bksoayTpUdKZFUJo=
+-k8s.io/controller-manager v0.33.6 h1:md2KM5RabX7KTTly1KmNDbNr5YJvLtse7sJOX2we8tI=
+-k8s.io/controller-manager v0.33.6/go.mod h1:dtCyZIG+CNFI8hY/lQY7ZAOO20VxGm+lpi1do2fmLGY=
+-k8s.io/cri-api v0.33.6 h1:yQXCHwWzedRSrPhy/r0QMI9a3jc6YpHnorfDBimdxng=
+-k8s.io/cri-api v0.33.6/go.mod h1:OLQvT45OpIA+tv91ZrpuFIGY+Y2Ho23poS7n115Aocs=
+-k8s.io/cri-client v0.33.6 h1:pVecZ/LeA3+wKJea8Rfp5jnVu0GYe6N/iFIM+lOBSCw=
+-k8s.io/cri-client v0.33.6/go.mod h1:1z3JawYGs5KTJasU+3QBhXlovZHrXIEkgTfHAWwvpmc=
+-k8s.io/csi-translation-lib v0.33.6 h1:ns0+YQ8R0lbFmAOSVgTLBvav2LrvONz7Uy3M2rpf/6E=
+-k8s.io/csi-translation-lib v0.33.6/go.mod h1:t266CgUYPVdST8pjPaCOEDLejWwV1Tms5igy8FVYyQo=
+-k8s.io/dynamic-resource-allocation v0.33.6 h1:HrPUowR+KvxmgPNin+e424PA4rWFPd/W25W1jULKapk=
+-k8s.io/dynamic-resource-allocation v0.33.6/go.mod h1:ByWsZ+8UxTvPC4UmyWdevUIGzxIrgmiyxcddLsKkGuY=
++k8s.io/code-generator v0.33.13 h1:Sh43djpZsCbl5pnyItPTg9lkI7MoaWWskSKEI+EBvJU=
++k8s.io/code-generator v0.33.13/go.mod h1:O3l2FNWNulmf8U92o1QCb9MN9IBbfLUkKNeuDqA7mJg=
++k8s.io/component-base v0.33.13 h1:WPsAyiWqSs2q06BDz5esM2FGchCMz5lxsQlLu6h9D4o=
++k8s.io/component-base v0.33.13/go.mod h1:7eOJI3uncRXO7lRZh2tcqmJaQ/IX2RTtH3iwAGWFj70=
++k8s.io/component-helpers v0.33.13 h1:tJYLJKzb2zXoL4aLwJ4T0ySoFlLGwfS0VgoqImsYgrE=
++k8s.io/component-helpers v0.33.13/go.mod h1:n9Ruxgkz8jvq9I2W3hO0vw3e0VNOASbJTp9cV9oQ7ho=
++k8s.io/controller-manager v0.33.13 h1:jJFY9aNN26QWXV3N6joNd7jJOdHEDiPHgNvpCbhs2D0=
++k8s.io/controller-manager v0.33.13/go.mod h1:0jdrhuXkJEacOWeFf3rNOWvSKGAPxute87+S+YrJ9qE=
++k8s.io/cri-api v0.33.13 h1:CWYbi901N93b3JJljKchDmIbpcIsd8PF10SFBeJqRXw=
++k8s.io/cri-api v0.33.13/go.mod h1:dneNEiUPn0v27FCKSsc1vYDmBIlDRFZzGfxev68whwk=
++k8s.io/cri-client v0.33.13 h1:lKxc84WvdDBgZY58FarIJ/QH4TjSl7/MkfDZd/1vSxI=
++k8s.io/cri-client v0.33.13/go.mod h1:UOzCxw26ofOS+eueyeH6v2wzaROAZBPUdylXzwdphDk=
++k8s.io/csi-translation-lib v0.33.13 h1:yfypxXuNlaJUlH0J9Ps5Gq7VU/JLzjRsf6NDIJd6F0s=
++k8s.io/csi-translation-lib v0.33.13/go.mod h1:ta2om8pMLNsatUx+gY4aAAc8VP7cWo35UxFyPPR3wec=
++k8s.io/dynamic-resource-allocation v0.33.13 h1:l8g2YnWQ9q2fUe5JgBPG/LzSMsPpUT48V7F7q37LuCg=
++k8s.io/dynamic-resource-allocation v0.33.13/go.mod h1:YOkaa9HBU6gGtemgIHcqfwkSlJnqOaPQMdPRUePFGbo=
  k8s.io/gengo/v2 v2.0.0-20250207200755-1244d31929d7 h1:2OX19X59HxDprNCVrWi6jb7LW1PoqTlYqEq5H2oetog=
  k8s.io/gengo/v2 v2.0.0-20250207200755-1244d31929d7/go.mod h1:EJykeLsmFC60UQbYJezXkEsG2FLrt0GPNkU5iK5GWxU=
  k8s.io/klog/v2 v2.130.1 h1:n9Xl7H1Xvksem4KFG4PYbdQCQxqc/tTUyrgXaOhHSzk=
  k8s.io/klog/v2 v2.130.1/go.mod h1:3Jpz1GvMt720eyJH1ckRHK1EDfpxISzJ7I9OYgaDtPE=
--k8s.io/kms v0.33.5 h1:u60sDBe4Fz6PLeiNF13sEahjIU428ajiWuIw7NSVBlg=
--k8s.io/kms v0.33.5/go.mod h1:C1I8mjFFBNzfUZXYt9FZVJ8MJl7ynFbGgZFbBzkBJ3E=
-+k8s.io/kms v0.33.6 h1:WLiXK7bK3rXd8UhSvjJZKUqciirM+2zCI833v0jYi7g=
-+k8s.io/kms v0.33.6/go.mod h1:C1I8mjFFBNzfUZXYt9FZVJ8MJl7ynFbGgZFbBzkBJ3E=
+-k8s.io/kms v0.33.6 h1:WLiXK7bK3rXd8UhSvjJZKUqciirM+2zCI833v0jYi7g=
+-k8s.io/kms v0.33.6/go.mod h1:C1I8mjFFBNzfUZXYt9FZVJ8MJl7ynFbGgZFbBzkBJ3E=
++k8s.io/kms v0.33.13 h1:3iOoN/SItJgPGEZKugYrTiPVcMNVyfkY/8PUosnulh0=
++k8s.io/kms v0.33.13/go.mod h1:C1I8mjFFBNzfUZXYt9FZVJ8MJl7ynFbGgZFbBzkBJ3E=
  k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff h1:/usPimJzUKKu+m+TE36gUyGcf03XZEP0ZIKgKj35LS4=
  k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff/go.mod h1:5jIi+8yX4RIb8wk3XwBo5Pq2ccx4FP10ohkbSKCZoK8=
--k8s.io/kube-scheduler v0.33.5 h1:eqZHF4H4F33XF7yGIK4quk1DxGACexINNuNJlO4M1ZY=
--k8s.io/kube-scheduler v0.33.5/go.mod h1:n004Qs3SWbLMJ6PuPtwkS377CqaaKUeYFzqb1+4IaA8=
--k8s.io/kubectl v0.33.5 h1:/wj5EjXXrVeSd8+FcZ2sIIP1PlQkq8HWsR9T1Nsl32c=
--k8s.io/kubectl v0.33.5/go.mod h1:YrBGE7U+nz7+UatG+aNDocIQtdTyqN528dwFCv6+Kuw=
--k8s.io/kubelet v0.33.5 h1:PYV+O8B6ZoQMDaQdYTSCzNdQTLdjAAWTspS2KkNfjLQ=
--k8s.io/kubelet v0.33.5/go.mod h1:8SQ/0fgyNwm6zjHktBhPAUlgtji19YMa2lhSlYKUhrA=
--k8s.io/kubernetes v1.33.5 h1:uf0/5VVQodYf61FudCbwtWjg5ApQcKKA7mwanTLjxyw=
--k8s.io/kubernetes v1.33.5/go.mod h1:nrt8sldmckKz2fCZhgRX3SKfS2e+CzXATPv6ITNkU00=
--k8s.io/mount-utils v0.33.5 h1:Dc+t8nfUD+k0kvDyzWqsIxYPd3+KMuVQae2Gr8BAmxs=
--k8s.io/mount-utils v0.33.5/go.mod h1:1JR4rKymg8B8bCPo618hpSAdrpO6XLh0Acqok/xVwPE=
-+k8s.io/kube-scheduler v0.33.6 h1:yBpdIRClZdvPJfVysT1cuCnT9JdHiFnjw4FSJSk/DLQ=
-+k8s.io/kube-scheduler v0.33.6/go.mod h1:sBWp6XruPN0mVxNos0DW4UPhi+lX4fwSoQn2X20KI2A=
-+k8s.io/kubectl v0.33.6 h1:zTZoafstb7rQ3NpTTnyN47goJOOpqIpf0mXDlVSHJ4o=
-+k8s.io/kubectl v0.33.6/go.mod h1:G6iCkPDPQbCbIp01QkD29wdo5hSkBQ2c7vv9YtOUPME=
-+k8s.io/kubelet v0.33.6 h1:0wlT1iyZwx+2iCgsCCgi22YU5vY82vW01f6X3pWP48A=
-+k8s.io/kubelet v0.33.6/go.mod h1:Nkjry+BISpPNb0WroNJVRYjOe7YacvDYNMbFXMyHEdU=
-+k8s.io/kubernetes v1.33.6 h1:NOIZqkx8M4XfdyRKllzLSBiMgSilPzSvCembfzOMk6A=
-+k8s.io/kubernetes v1.33.6/go.mod h1:eJiHC143tnNSvmDkCRwGNKA80yXqBvYC3U8L/i67nAY=
-+k8s.io/mount-utils v0.33.6 h1:C7WqPt0KU7wvU6ay5tu5gkzhrnYIuQOsBGI/lFcvG4Q=
-+k8s.io/mount-utils v0.33.6/go.mod h1:1JR4rKymg8B8bCPo618hpSAdrpO6XLh0Acqok/xVwPE=
+-k8s.io/kube-scheduler v0.33.6 h1:yBpdIRClZdvPJfVysT1cuCnT9JdHiFnjw4FSJSk/DLQ=
+-k8s.io/kube-scheduler v0.33.6/go.mod h1:sBWp6XruPN0mVxNos0DW4UPhi+lX4fwSoQn2X20KI2A=
+-k8s.io/kubectl v0.33.6 h1:zTZoafstb7rQ3NpTTnyN47goJOOpqIpf0mXDlVSHJ4o=
+-k8s.io/kubectl v0.33.6/go.mod h1:G6iCkPDPQbCbIp01QkD29wdo5hSkBQ2c7vv9YtOUPME=
+-k8s.io/kubelet v0.33.6 h1:0wlT1iyZwx+2iCgsCCgi22YU5vY82vW01f6X3pWP48A=
+-k8s.io/kubelet v0.33.6/go.mod h1:Nkjry+BISpPNb0WroNJVRYjOe7YacvDYNMbFXMyHEdU=
+-k8s.io/kubernetes v1.33.6 h1:NOIZqkx8M4XfdyRKllzLSBiMgSilPzSvCembfzOMk6A=
+-k8s.io/kubernetes v1.33.6/go.mod h1:eJiHC143tnNSvmDkCRwGNKA80yXqBvYC3U8L/i67nAY=
+-k8s.io/mount-utils v0.33.6 h1:C7WqPt0KU7wvU6ay5tu5gkzhrnYIuQOsBGI/lFcvG4Q=
+-k8s.io/mount-utils v0.33.6/go.mod h1:1JR4rKymg8B8bCPo618hpSAdrpO6XLh0Acqok/xVwPE=
++k8s.io/kube-scheduler v0.33.13 h1:LkIYb1UPpc6QIu0Jftil9aaQBbgsx3fYSYYvBe/FolA=
++k8s.io/kube-scheduler v0.33.13/go.mod h1:sbxw0VAFQKqe8oeN0IbcfLV7wBv5pEXCG/ccLEYGKHA=
++k8s.io/kubectl v0.33.13 h1:6RLgHYABIYqOccAyg8beGJgY48oXlrKl0kTmDrSerYc=
++k8s.io/kubectl v0.33.13/go.mod h1:74vtwo3Il9YpytgCYq0D7kN5YQ5ubo0Mt9J8Zop1an0=
++k8s.io/kubelet v0.33.13 h1:5JHlQPEIMhtxOJw0wu4gB6uWYW/4mOiW/mPv3KNY1zU=
++k8s.io/kubelet v0.33.13/go.mod h1:x87gQb0hcRyPmJ7sfdNPEx7kHDkhu93lFUr9hOUtRb4=
++k8s.io/kubernetes v1.33.13 h1:bmH31xUdSzeA5vk0wZAK9MZp11mdLuzUSeKk0qN3hPQ=
++k8s.io/kubernetes v1.33.13/go.mod h1:I8CFdqMWuVZVMpBjzZMK0u06MUcy9EhNZ/t9WjxUmnw=
++k8s.io/mount-utils v0.33.13 h1:1etrX+dHfXqJrkWw5Z1Osae6ROL2H46kzvCTtVeXLD4=
++k8s.io/mount-utils v0.33.13/go.mod h1:+AWFtgfQsRNlGrrBm2bFruSB/0pQTB28yLymNf7JRNM=
  k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 h1:M3sRQVHv7vB20Xc2ybTt7ODCeFj6JSWYFzOFnYeS6Ro=
  k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
  sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 h1:jpcvIRr3GLoUoEKRkHKSmGjxb6lWwrBlJsXc+eUYQHM=

--- a/modules/040-node-manager/images/cluster-autoscaler/patches/1.33/001-go-mod.patch
+++ b/modules/040-node-manager/images/cluster-autoscaler/patches/1.33/001-go-mod.patch
@@ -1,56 +1,46 @@
 diff --git a/cluster-autoscaler/apis/go.mod b/cluster-autoscaler/apis/go.mod
-index 3ac7f4768..5fa92f6f9 100644
+index da03c7847..ad61d7644 100644
 --- a/cluster-autoscaler/apis/go.mod
 +++ b/cluster-autoscaler/apis/go.mod
-@@ -1,13 +1,10 @@
+@@ -1,8 +1,6 @@
  module k8s.io/autoscaler/cluster-autoscaler/apis
  
--go 1.23.0
+-go 1.24.0
 -
--toolchain go1.23.2
+-toolchain go1.24.5
 +go 1.25.0
  
  require (
  	github.com/onsi/ginkgo/v2 v2.21.0
- 	github.com/onsi/gomega v1.35.1
--	k8s.io/api v0.32.0
- 	k8s.io/apimachinery v0.32.3
- 	k8s.io/client-go v0.32.0
- 	k8s.io/code-generator v0.32.0
-@@ -39,19 +36,21 @@ require (
+@@ -36,15 +34,16 @@ require (
  	github.com/pkg/errors v0.9.1 // indirect
  	github.com/spf13/pflag v1.0.5 // indirect
  	github.com/x448/float16 v0.8.4 // indirect
 -	golang.org/x/mod v0.21.0 // indirect
--	golang.org/x/net v0.30.0 // indirect
+-	golang.org/x/net v0.38.0 // indirect
 +	golang.org/x/mod v0.35.0 // indirect
 +	golang.org/x/net v0.55.0 // indirect
- 	golang.org/x/oauth2 v0.23.0 // indirect
--	golang.org/x/sync v0.8.0 // indirect
--	golang.org/x/sys v0.26.0 // indirect
--	golang.org/x/term v0.25.0 // indirect
--	golang.org/x/text v0.19.0 // indirect
+ 	golang.org/x/oauth2 v0.27.0 // indirect
+-	golang.org/x/sync v0.12.0 // indirect
+-	golang.org/x/sys v0.31.0 // indirect
+-	golang.org/x/term v0.30.0 // indirect
+-	golang.org/x/text v0.23.0 // indirect
 +	golang.org/x/sync v0.20.0 // indirect
 +	golang.org/x/sys v0.45.0 // indirect
 +	golang.org/x/term v0.43.0 // indirect
 +	golang.org/x/text v0.37.0 // indirect
- 	golang.org/x/time v0.7.0 // indirect
+ 	golang.org/x/time v0.9.0 // indirect
 -	golang.org/x/tools v0.26.0 // indirect
 +	golang.org/x/tools v0.44.0 // indirect
 +	golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated // indirect
- 	google.golang.org/protobuf v1.35.1 // indirect
+ 	google.golang.org/protobuf v1.36.5 // indirect
  	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
  	gopkg.in/inf.v0 v0.9.1 // indirect
- 	gopkg.in/yaml.v3 v3.0.1 // indirect
-+	k8s.io/api v0.32.0 // indirect
- 	k8s.io/gengo/v2 v2.0.0-20240911193312-2b36238f13e9 // indirect
- 	k8s.io/klog/v2 v2.130.1 // indirect
- 	k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f // indirect
 diff --git a/cluster-autoscaler/apis/go.sum b/cluster-autoscaler/apis/go.sum
-index 701a0e94c..4c7077458 100644
+index 60a4fb618..f0586b088 100644
 --- a/cluster-autoscaler/apis/go.sum
 +++ b/cluster-autoscaler/apis/go.sum
-@@ -88,40 +88,44 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
+@@ -87,40 +87,44 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
  golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
  golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
  golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
@@ -62,38 +52,38 @@ index 701a0e94c..4c7077458 100644
  golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
  golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
  golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
--golang.org/x/net v0.30.0 h1:AcW1SDZMkb8IpzCdQUaIq2sP4sZ4zw+55h6ynffypl4=
--golang.org/x/net v0.30.0/go.mod h1:2wGyMJ5iFasEhkwi13ChkO/t1ECNC4X4eBKkVFyYFlU=
+-golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
+-golang.org/x/net v0.38.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
 +golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
 +golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
- golang.org/x/oauth2 v0.23.0 h1:PbgcYx2W7i4LvjJWEbf0ngHV6qJYr86PkAV3bXdLEbs=
- golang.org/x/oauth2 v0.23.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
+ golang.org/x/oauth2 v0.27.0 h1:da9Vo7/tDv5RH/7nZDz1eMGS/q1Vv1N/7FCrBhI9I3M=
+ golang.org/x/oauth2 v0.27.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT8=
  golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
  golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
  golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
--golang.org/x/sync v0.8.0 h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=
--golang.org/x/sync v0.8.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+-golang.org/x/sync v0.12.0 h1:MHc5BpPuC30uJk597Ri8TV3CNZcTLu6B6z4lJy+g6Jw=
+-golang.org/x/sync v0.12.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 +golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
 +golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
  golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
  golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
  golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
--golang.org/x/sys v0.26.0 h1:KHjCJyddX0LoSTb3J+vWpupP9p0oznkqVk/IfjymZbo=
--golang.org/x/sys v0.26.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
--golang.org/x/term v0.25.0 h1:WtHI/ltw4NvSUig5KARz9h521QvRC8RmF/cuYqifU24=
--golang.org/x/term v0.25.0/go.mod h1:RPyXicDX+6vLxogjjRxjgD2TKtmAO6NZBsBRfrOLu7M=
+-golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
+-golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+-golang.org/x/term v0.30.0 h1:PQ39fJZ+mfadBm0y5WlL4vlM7Sx1Hgf13sMIY2+QS9Y=
+-golang.org/x/term v0.30.0/go.mod h1:NYYFdzHoI5wRh/h5tDMdMqCqPJZEuNqVR5xJLd/n67g=
 +golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 +golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 +golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=
 +golang.org/x/term v0.43.0/go.mod h1:lrhlHNdQJHO+1qVYiHfFKVuVioJIheAc3fBSMFYEIsk=
  golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
  golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
--golang.org/x/text v0.19.0 h1:kTxAhCbGbxhK0IwgSKiMO5awPoDQ0RpfiVYBfK860YM=
--golang.org/x/text v0.19.0/go.mod h1:BuEKDfySbSR4drPmRPG/7iBdf8hvFMuRexcpahXilzY=
+-golang.org/x/text v0.23.0 h1:D71I7dUrlY+VX0gQShAThNGHFxZ13dGLBHQLVl1mJlY=
+-golang.org/x/text v0.23.0/go.mod h1:/BLNzu4aZCJ1+kcD0DNRotWKage4q2rGVAg4o22unh4=
 +golang.org/x/text v0.37.0 h1:Cqjiwd9eSg8e0QAkyCaQTNHFIIzWtidPahFWR83rTrc=
 +golang.org/x/text v0.37.0/go.mod h1:a5sjxXGs9hsn/AJVwuElvCAo9v8QYLzvavO5z2PiM38=
- golang.org/x/time v0.7.0 h1:ntUhktv3OPE6TgYxXWv9vKvUSJyIFJlyohwbkEwPrKQ=
- golang.org/x/time v0.7.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
+ golang.org/x/time v0.9.0 h1:EsRrnYcQiGH+5FfbgvV4AP7qEZstoyrHB0DzarOQ4ZY=
+ golang.org/x/time v0.9.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
  golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
  golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
  golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
@@ -110,41 +100,63 @@ index 701a0e94c..4c7077458 100644
  golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
  golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 diff --git a/cluster-autoscaler/go.mod b/cluster-autoscaler/go.mod
-index ee33cde31..4db6ffffc 100644
+index 56e4f08c3..bd5d2b169 100644
 --- a/cluster-autoscaler/go.mod
 +++ b/cluster-autoscaler/go.mod
 @@ -1,8 +1,6 @@
  module k8s.io/autoscaler/cluster-autoscaler
  
--go 1.23.0
+-go 1.24.0
 -
--toolchain go1.23.2
+-toolchain go1.24.5
 +go 1.25.0
  
  require (
- 	cloud.google.com/go/compute/metadata v0.3.0
-@@ -39,9 +37,9 @@ require (
- 	github.com/stretchr/testify v1.9.0
+ 	cloud.google.com/go/compute/metadata v0.5.0
+@@ -39,29 +37,29 @@ require (
+ 	github.com/stretchr/testify v1.10.0
  	github.com/vburenin/ifacemaker v1.2.1
  	go.uber.org/mock v0.4.0
+-	golang.org/x/crypto v0.36.0
 -	golang.org/x/net v0.38.0
++	golang.org/x/crypto v0.51.0
 +	golang.org/x/net v0.55.0
  	golang.org/x/oauth2 v0.27.0
 -	golang.org/x/sys v0.31.0
 +	golang.org/x/sys v0.45.0
  	google.golang.org/api v0.151.0
- 	google.golang.org/grpc v1.65.0
- 	google.golang.org/protobuf v1.36.1
-@@ -60,7 +58,7 @@ require (
- 	k8s.io/dynamic-resource-allocation v0.0.0
+ 	google.golang.org/grpc v1.68.1
+ 	google.golang.org/protobuf v1.36.5
+ 	gopkg.in/gcfg.v1 v1.2.3
+ 	gopkg.in/yaml.v2 v2.4.0
+-	k8s.io/api v0.33.0
+-	k8s.io/apimachinery v0.33.0
+-	k8s.io/apiserver v0.33.0
++	k8s.io/api v0.33.6
++	k8s.io/apimachinery v0.33.6
++	k8s.io/apiserver v0.33.6
+ 	k8s.io/autoscaler/cluster-autoscaler/apis v0.0.0-20240627115740-d52e4b9665d7
+-	k8s.io/client-go v0.33.0
+-	k8s.io/cloud-provider v0.30.1
++	k8s.io/client-go v0.33.6
++	k8s.io/cloud-provider v0.33.6
+ 	k8s.io/cloud-provider-aws v1.27.0
+ 	k8s.io/cloud-provider-gcp/providers v0.28.2
+-	k8s.io/component-base v0.33.0
+-	k8s.io/component-helpers v0.33.0
+-	k8s.io/dynamic-resource-allocation v0.0.0
++	k8s.io/component-base v0.33.6
++	k8s.io/component-helpers v0.33.6
++	k8s.io/dynamic-resource-allocation v0.33.6
  	k8s.io/klog/v2 v2.130.1
- 	k8s.io/kubelet v0.32.0
--	k8s.io/kubernetes v1.32.0
-+	k8s.io/kubernetes v1.32.10
+-	k8s.io/kubelet v0.33.0
+-	k8s.io/kubernetes v1.33.0
++	k8s.io/kubelet v0.33.6
++	k8s.io/kubernetes v1.33.6
  	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738
  	sigs.k8s.io/cloud-provider-azure v1.29.4
  	sigs.k8s.io/cloud-provider-azure/pkg/azclient v0.0.13
-@@ -90,7 +88,7 @@ require (
+@@ -92,7 +90,7 @@ require (
  	github.com/GoogleCloudPlatform/k8s-cloud-provider v1.25.0 // indirect
  	github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab // indirect
  	github.com/Microsoft/go-winio v0.6.2 // indirect
@@ -153,12 +165,9 @@ index ee33cde31..4db6ffffc 100644
  	github.com/NYTimes/gziphandler v1.1.1 // indirect
  	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
  	github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2 // indirect
-@@ -188,14 +186,15 @@ require (
- 	go.opentelemetry.io/proto/otlp v1.3.1 // indirect
+@@ -193,12 +191,13 @@ require (
  	go.uber.org/multierr v1.11.0 // indirect
  	go.uber.org/zap v1.27.0 // indirect
--	golang.org/x/crypto v0.36.0 // indirect
-+	golang.org/x/crypto v0.51.0 // indirect
  	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 -	golang.org/x/mod v0.23.0 // indirect
 -	golang.org/x/sync v0.12.0 // indirect
@@ -168,18 +177,47 @@ index ee33cde31..4db6ffffc 100644
 +	golang.org/x/sync v0.20.0 // indirect
 +	golang.org/x/term v0.43.0 // indirect
 +	golang.org/x/text v0.37.0 // indirect
- 	golang.org/x/time v0.7.0 // indirect
+ 	golang.org/x/time v0.9.0 // indirect
 -	golang.org/x/tools v0.30.0 // indirect
 +	golang.org/x/tools v0.44.0 // indirect
 +	golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated // indirect
- 	google.golang.org/genproto/googleapis/api v0.0.0-20240826202546-f6391c0de4c7 // indirect
- 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240826202546-f6391c0de4c7 // indirect
+ 	google.golang.org/genproto/googleapis/api v0.0.0-20241209162323-e6fa225c2576 // indirect
+ 	google.golang.org/genproto/googleapis/rpc v0.0.0-20241209162323-e6fa225c2576 // indirect
  	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
+@@ -206,18 +205,18 @@ require (
+ 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
+ 	gopkg.in/warnings.v0 v0.1.2 // indirect
+ 	gopkg.in/yaml.v3 v3.0.1 // indirect
+-	k8s.io/apiextensions-apiserver v0.31.0 // indirect
+-	k8s.io/code-generator v0.33.0 // indirect
+-	k8s.io/controller-manager v0.33.0 // indirect
+-	k8s.io/cri-api v0.33.0 // indirect
+-	k8s.io/cri-client v0.0.0 // indirect
+-	k8s.io/csi-translation-lib v0.27.0 // indirect
++	k8s.io/apiextensions-apiserver v0.33.6 // indirect
++	k8s.io/code-generator v0.33.6 // indirect
++	k8s.io/controller-manager v0.33.6 // indirect
++	k8s.io/cri-api v0.33.6 // indirect
++	k8s.io/cri-client v0.33.6 // indirect
++	k8s.io/csi-translation-lib v0.33.6 // indirect
+ 	k8s.io/gengo/v2 v2.0.0-20250207200755-1244d31929d7 // indirect
+-	k8s.io/kms v0.33.0 // indirect
++	k8s.io/kms v0.33.6 // indirect
+ 	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff // indirect
+-	k8s.io/kube-scheduler v0.0.0 // indirect
+-	k8s.io/kubectl v0.28.0 // indirect
+-	k8s.io/mount-utils v0.26.0-alpha.0 // indirect
++	k8s.io/kube-scheduler v0.33.6 // indirect
++	k8s.io/kubectl v0.33.6 // indirect
++	k8s.io/mount-utils v0.33.6 // indirect
+ 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 // indirect
+ 	sigs.k8s.io/cloud-provider-azure/pkg/azclient/configloader v0.0.4 // indirect
+ 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
 diff --git a/cluster-autoscaler/go.sum b/cluster-autoscaler/go.sum
-index 990e503f5..d5cf410eb 100644
+index b80bb9652..ca46b6c43 100644
 --- a/cluster-autoscaler/go.sum
 +++ b/cluster-autoscaler/go.sum
-@@ -86,8 +86,8 @@ github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab h1:UKkYhof1njT1
+@@ -83,8 +83,8 @@ github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab h1:UKkYhof1njT1
  github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab/go.mod h1:3VYc5hodBMJ5+l/7J4xAyMeuM2PNuepvHlGs8yilUCA=
  github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
  github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
@@ -190,7 +228,7 @@ index 990e503f5..d5cf410eb 100644
  github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cqUQ3I=
  github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
  github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=
-@@ -448,8 +448,8 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
+@@ -445,8 +445,8 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
  golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
  golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58=
  golang.org/x/crypto v0.17.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
@@ -201,7 +239,7 @@ index 990e503f5..d5cf410eb 100644
  golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
  golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 h1:2dVuKD2vS7b0QIHQbpyTISPd0LeHDbnYEryqj5Q1ug8=
  golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56/go.mod h1:M4RDyNAINzryxdtnbRXRL/OHtkFuWGRjvuhBJpk2IlY=
-@@ -461,8 +461,8 @@ golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+@@ -458,8 +458,8 @@ golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
  golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
  golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
  golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
@@ -212,7 +250,7 @@ index 990e503f5..d5cf410eb 100644
  golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
  golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
  golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
-@@ -479,8 +479,8 @@ golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qx
+@@ -476,8 +476,8 @@ golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qx
  golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
  golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
  golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
@@ -223,7 +261,7 @@ index 990e503f5..d5cf410eb 100644
  golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
  golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
  golang.org/x/oauth2 v0.27.0 h1:da9Vo7/tDv5RH/7nZDz1eMGS/q1Vv1N/7FCrBhI9I3M=
-@@ -494,8 +494,8 @@ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJ
+@@ -491,8 +491,8 @@ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJ
  golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
  golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
  golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -234,7 +272,7 @@ index 990e503f5..d5cf410eb 100644
  golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
  golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
  golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-@@ -512,15 +512,15 @@ golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+@@ -509,15 +509,15 @@ golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
  golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
  golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
  golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
@@ -254,7 +292,7 @@ index 990e503f5..d5cf410eb 100644
  golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
  golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
  golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-@@ -528,8 +528,8 @@ golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+@@ -525,8 +525,8 @@ golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
  golang.org/x/text v0.7.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
  golang.org/x/text v0.9.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=
  golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
@@ -262,10 +300,10 @@ index 990e503f5..d5cf410eb 100644
 -golang.org/x/text v0.23.0/go.mod h1:/BLNzu4aZCJ1+kcD0DNRotWKage4q2rGVAg4o22unh4=
 +golang.org/x/text v0.37.0 h1:Cqjiwd9eSg8e0QAkyCaQTNHFIIzWtidPahFWR83rTrc=
 +golang.org/x/text v0.37.0/go.mod h1:a5sjxXGs9hsn/AJVwuElvCAo9v8QYLzvavO5z2PiM38=
- golang.org/x/time v0.7.0 h1:ntUhktv3OPE6TgYxXWv9vKvUSJyIFJlyohwbkEwPrKQ=
- golang.org/x/time v0.7.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
+ golang.org/x/time v0.9.0 h1:EsRrnYcQiGH+5FfbgvV4AP7qEZstoyrHB0DzarOQ4ZY=
+ golang.org/x/time v0.9.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
  golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
-@@ -543,8 +543,12 @@ golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4f
+@@ -540,8 +540,12 @@ golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4f
  golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
  golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
  golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
@@ -280,14 +318,14 @@ index 990e503f5..d5cf410eb 100644
  golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
  golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
  golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-@@ -649,8 +653,8 @@ k8s.io/kubectl v0.32.0 h1:rpxl+ng9qeG79YA4Em9tLSfX0G8W0vfaiPVrc/WR7Xw=
- k8s.io/kubectl v0.32.0/go.mod h1:qIjSX+QgPQUgdy8ps6eKsYNF+YmFOAO3WygfucIqFiE=
- k8s.io/kubelet v0.32.0 h1:uLyiKlz195Wo4an/K2tyge8o3QHx0ZkhVN3pevvp59A=
- k8s.io/kubelet v0.32.0/go.mod h1:lAwuVZT/Hm7EdLn0jW2D+WdrJoorjJL2rVSdhOFnegw=
--k8s.io/kubernetes v1.32.0 h1:4BDBWSolqPrv8GC3YfZw0CJvh5kA1TPnoX0FxDVd+qc=
--k8s.io/kubernetes v1.32.0/go.mod h1:tiIKO63GcdPRBHW2WiUFm3C0eoLczl3f7qi56Dm1W8I=
-+k8s.io/kubernetes v1.32.10 h1:yiRa8DyKp4Yrbv028MP6kpp5N1N3eO8Hp/tSCbBGIPE=
-+k8s.io/kubernetes v1.32.10/go.mod h1:o2pRStsMR7Uq62zcugfUEQsxnuyFt9r8migMrbsVH00=
- k8s.io/mount-utils v0.32.3 h1:ZPXXHblfBhYP89OnaozpFg9Ojl6HhDfxBLcdWNkaxW8=
- k8s.io/mount-utils v0.32.3/go.mod h1:Kun5c2svjAPx0nnvJKYQWhfeNW+O0EpzHgRhDcYoSY0=
+@@ -646,8 +650,8 @@ k8s.io/kubectl v0.33.0 h1:HiRb1yqibBSCqic4pRZP+viiOBAnIdwYDpzUFejs07g=
+ k8s.io/kubectl v0.33.0/go.mod h1:gAlGBuS1Jq1fYZ9AjGWbI/5Vk3M/VW2DK4g10Fpyn/0=
+ k8s.io/kubelet v0.33.0 h1:4pJA2Ge6Rp0kDNV76KH7pTBiaV2T1a1874QHMcubuSU=
+ k8s.io/kubelet v0.33.0/go.mod h1:iDnxbJQMy9DUNaML5L/WUlt3uJtNLWh7ZAe0JSp4Yi0=
+-k8s.io/kubernetes v1.33.0 h1:BP5Y5yIzUZVeBuE/ESZvnw6TNxjXbLsCckIkljE+R0U=
+-k8s.io/kubernetes v1.33.0/go.mod h1:2nWuPk0seE4+6sd0x60wQ6rYEXcV7SoeMbU0YbFm/5k=
++k8s.io/kubernetes v1.33.6 h1:NOIZqkx8M4XfdyRKllzLSBiMgSilPzSvCembfzOMk6A=
++k8s.io/kubernetes v1.33.6/go.mod h1:eJiHC143tnNSvmDkCRwGNKA80yXqBvYC3U8L/i67nAY=
+ k8s.io/mount-utils v0.33.0 h1:hH6EcCcax4lFNIERaGMj6d7oGMW1qW3eTCwHUuLtLog=
+ k8s.io/mount-utils v0.33.0/go.mod h1:1JR4rKymg8B8bCPo618hpSAdrpO6XLh0Acqok/xVwPE=
  k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 h1:M3sRQVHv7vB20Xc2ybTt7ODCeFj6JSWYFzOFnYeS6Ro=

--- a/modules/040-node-manager/images/cluster-autoscaler/patches/1.33/README.md
+++ b/modules/040-node-manager/images/cluster-autoscaler/patches/1.33/README.md
@@ -2,7 +2,40 @@
 
 ### 001-go-mod.patch
 
-update go modules
+Bumps Go module dependencies to remediate CVEs reported by Trivy for the
+cluster-autoscaler binary. The vulnerabilities live in indirect/build
+dependencies that are linked into the binary (x/crypto/ssh, x/net, k8s
+staging modules), not in cluster-autoscaler logic, so the fix is a pure
+`go.mod`/`go.sum` bump. The gardener tag stays `v1.33.1`.
+
+Applied to both `cluster-autoscaler/go.mod` and `cluster-autoscaler/apis/go.mod`:
+
+- `go` directive: `1.24.0` (+ `toolchain go1.24.5`) -> `1.25.0`
+- `golang.org/x/net`: `v0.38.0` -> `v0.55.0` (HTML parser / HTTP2 / idna CVEs)
+- `golang.org/x/sys`: `v0.31.0` -> `v0.45.0`
+- `golang.org/x/crypto`: `v0.36.0` -> `v0.51.0` (x/crypto/ssh CVEs)
+- `k8s.io/kubernetes`: `v1.33.0` -> `v1.33.6`, and all `k8s.io/*` staging
+  modules (require + replace) synced to `v0.33.6` (kube-controller-manager
+  SSRF CVE-2025-13281; NodeRestriction/DRA bypass CVE-2025-4563)
+
+To recreate this patch, check out the clean tag and re-apply the bumps:
+
+```shell
+git clone <SOURCE_REPO>/gardener/autoscaler.git
+cd autoscaler && git checkout v1.33.1
+cd cluster-autoscaler
+go get golang.org/x/crypto@v0.51.0
+go get golang.org/x/net@v0.55.0
+go get golang.org/x/sys@v0.45.0
+go get k8s.io/kubernetes@v1.33.6
+# sync every k8s.io/* require and replace directive to v0.33.6
+cd apis && go get golang.org/x/net@v0.55.0 && cd ..
+go mod tidy && (cd apis && go mod tidy)
+cd ..
+git diff -- cluster-autoscaler/go.mod cluster-autoscaler/go.sum \
+            cluster-autoscaler/apis/go.mod cluster-autoscaler/apis/go.sum \
+  > 001-go-mod.patch
+```
 
 ### 002-kruise-ads.patch
 

--- a/modules/040-node-manager/images/cluster-autoscaler/patches/1.34/001-go-mod.patch
+++ b/modules/040-node-manager/images/cluster-autoscaler/patches/1.34/001-go-mod.patch
@@ -1,5 +1,5 @@
 diff --git a/cluster-autoscaler/apis/go.mod b/cluster-autoscaler/apis/go.mod
-index 52bf2ebdd..87e8923fc 100644
+index 24df7a83d..04c47fa8b 100644
 --- a/cluster-autoscaler/apis/go.mod
 +++ b/cluster-autoscaler/apis/go.mod
 @@ -1,6 +1,6 @@
@@ -35,7 +35,7 @@ index 52bf2ebdd..87e8923fc 100644
  	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
  	gopkg.in/inf.v0 v0.9.1 // indirect
 diff --git a/cluster-autoscaler/apis/go.sum b/cluster-autoscaler/apis/go.sum
-index f72605e2f..2789b9850 100644
+index 1a68b6714..cecd57ae2 100644
 --- a/cluster-autoscaler/apis/go.sum
 +++ b/cluster-autoscaler/apis/go.sum
 @@ -91,40 +91,44 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
@@ -98,7 +98,7 @@ index f72605e2f..2789b9850 100644
  golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
  golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 diff --git a/cluster-autoscaler/go.mod b/cluster-autoscaler/go.mod
-index e94021d12..7a7a3c2ab 100644
+index 3487260b3..6a5a58825 100644
 --- a/cluster-autoscaler/go.mod
 +++ b/cluster-autoscaler/go.mod
 @@ -1,6 +1,6 @@
@@ -129,27 +129,27 @@ index e94021d12..7a7a3c2ab 100644
  	google.golang.org/protobuf v1.36.5
  	gopkg.in/gcfg.v1 v1.2.3
  	gopkg.in/yaml.v2 v2.4.0
--	k8s.io/api v0.34.2
--	k8s.io/apimachinery v0.34.2
--	k8s.io/apiserver v0.34.2
+-	k8s.io/api v0.34.3
+-	k8s.io/apimachinery v0.34.3
+-	k8s.io/apiserver v0.34.3
 +	k8s.io/api v0.34.9
 +	k8s.io/apimachinery v0.34.9
 +	k8s.io/apiserver v0.34.9
  	k8s.io/autoscaler/cluster-autoscaler/apis v0.0.0-20240627115740-d52e4b9665d7
--	k8s.io/client-go v0.34.2
+-	k8s.io/client-go v0.34.3
 +	k8s.io/client-go v0.34.9
  	k8s.io/cloud-provider v0.30.1
  	k8s.io/cloud-provider-aws v1.27.0
  	k8s.io/cloud-provider-gcp/providers v0.28.2
--	k8s.io/component-base v0.34.2
--	k8s.io/component-helpers v0.34.2
+-	k8s.io/component-base v0.34.3
+-	k8s.io/component-helpers v0.34.3
 +	k8s.io/component-base v0.34.9
 +	k8s.io/component-helpers v0.34.9
  	k8s.io/dynamic-resource-allocation v0.0.0
  	k8s.io/klog/v2 v2.130.1
  	k8s.io/kube-scheduler v0.0.0
--	k8s.io/kubelet v0.34.2
--	k8s.io/kubernetes v1.34.2
+-	k8s.io/kubelet v0.34.3
+-	k8s.io/kubernetes v1.34.3
 +	k8s.io/kubelet v0.34.9
 +	k8s.io/kubernetes v1.34.9
  	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397
@@ -216,120 +216,120 @@ index e94021d12..7a7a3c2ab 100644
  	gopkg.in/warnings.v0 v0.1.2 // indirect
  	gopkg.in/yaml.v3 v3.0.1 // indirect
  	k8s.io/apiextensions-apiserver v0.0.0 // indirect
--	k8s.io/code-generator v0.34.2 // indirect
--	k8s.io/controller-manager v0.34.2 // indirect
--	k8s.io/cri-api v0.34.2 // indirect
+-	k8s.io/code-generator v0.34.3 // indirect
+-	k8s.io/controller-manager v0.34.3 // indirect
+-	k8s.io/cri-api v0.34.3 // indirect
 +	k8s.io/code-generator v0.34.9 // indirect
 +	k8s.io/controller-manager v0.34.9 // indirect
 +	k8s.io/cri-api v0.34.9 // indirect
  	k8s.io/cri-client v0.0.0 // indirect
  	k8s.io/csi-translation-lib v0.27.0 // indirect
  	k8s.io/gengo/v2 v2.0.0-20250604051438-85fd79dbfd9f // indirect
--	k8s.io/kms v0.34.2 // indirect
+-	k8s.io/kms v0.34.3 // indirect
 +	k8s.io/kms v0.34.9 // indirect
  	k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b // indirect
  	k8s.io/kubectl v0.28.0 // indirect
  	k8s.io/mount-utils v0.26.0-alpha.0 // indirect
-@@ -229,66 +230,66 @@ replace github.com/digitalocean/godo => github.com/digitalocean/godo v1.27.0
+@@ -223,66 +224,66 @@ require (
+ 	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
+ )
  
- replace github.com/rancher/go-rancher => github.com/rancher/go-rancher v0.1.0
- 
--replace k8s.io/api => k8s.io/api v0.34.2
+-replace k8s.io/api => k8s.io/api v0.34.3
 +replace k8s.io/api => k8s.io/api v0.34.9
  
--replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.34.2
+-replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.34.3
 +replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.34.9
  
--replace k8s.io/apimachinery => k8s.io/apimachinery v0.34.2
+-replace k8s.io/apimachinery => k8s.io/apimachinery v0.34.3
 +replace k8s.io/apimachinery => k8s.io/apimachinery v0.34.9
  
--replace k8s.io/apiserver => k8s.io/apiserver v0.34.2
+-replace k8s.io/apiserver => k8s.io/apiserver v0.34.3
 +replace k8s.io/apiserver => k8s.io/apiserver v0.34.9
  
--replace k8s.io/cli-runtime => k8s.io/cli-runtime v0.34.2
+-replace k8s.io/cli-runtime => k8s.io/cli-runtime v0.34.3
 +replace k8s.io/cli-runtime => k8s.io/cli-runtime v0.34.9
  
--replace k8s.io/client-go => k8s.io/client-go v0.34.2
+-replace k8s.io/client-go => k8s.io/client-go v0.34.3
 +replace k8s.io/client-go => k8s.io/client-go v0.34.9
  
--replace k8s.io/cloud-provider => k8s.io/cloud-provider v0.34.2
+-replace k8s.io/cloud-provider => k8s.io/cloud-provider v0.34.3
 +replace k8s.io/cloud-provider => k8s.io/cloud-provider v0.34.9
  
--replace k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.34.2
+-replace k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.34.3
 +replace k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.34.9
  
--replace k8s.io/code-generator => k8s.io/code-generator v0.34.2
+-replace k8s.io/code-generator => k8s.io/code-generator v0.34.3
 +replace k8s.io/code-generator => k8s.io/code-generator v0.34.9
  
--replace k8s.io/component-base => k8s.io/component-base v0.34.2
+-replace k8s.io/component-base => k8s.io/component-base v0.34.3
 +replace k8s.io/component-base => k8s.io/component-base v0.34.9
  
--replace k8s.io/component-helpers => k8s.io/component-helpers v0.34.2
+-replace k8s.io/component-helpers => k8s.io/component-helpers v0.34.3
 +replace k8s.io/component-helpers => k8s.io/component-helpers v0.34.9
  
--replace k8s.io/controller-manager => k8s.io/controller-manager v0.34.2
+-replace k8s.io/controller-manager => k8s.io/controller-manager v0.34.3
 +replace k8s.io/controller-manager => k8s.io/controller-manager v0.34.9
  
--replace k8s.io/cri-api => k8s.io/cri-api v0.34.2
+-replace k8s.io/cri-api => k8s.io/cri-api v0.34.3
 +replace k8s.io/cri-api => k8s.io/cri-api v0.34.9
  
--replace k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.34.2
+-replace k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.34.3
 +replace k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.34.9
  
--replace k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.34.2
+-replace k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.34.3
 +replace k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.34.9
  
--replace k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.34.2
+-replace k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.34.3
 +replace k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.34.9
  
--replace k8s.io/kube-proxy => k8s.io/kube-proxy v0.34.2
+-replace k8s.io/kube-proxy => k8s.io/kube-proxy v0.34.3
 +replace k8s.io/kube-proxy => k8s.io/kube-proxy v0.34.9
  
--replace k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.34.2
+-replace k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.34.3
 +replace k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.34.9
  
--replace k8s.io/kubectl => k8s.io/kubectl v0.34.2
+-replace k8s.io/kubectl => k8s.io/kubectl v0.34.3
 +replace k8s.io/kubectl => k8s.io/kubectl v0.34.9
  
--replace k8s.io/kubelet => k8s.io/kubelet v0.34.2
+-replace k8s.io/kubelet => k8s.io/kubelet v0.34.3
 +replace k8s.io/kubelet => k8s.io/kubelet v0.34.9
  
--replace k8s.io/metrics => k8s.io/metrics v0.34.2
+-replace k8s.io/metrics => k8s.io/metrics v0.34.3
 +replace k8s.io/metrics => k8s.io/metrics v0.34.9
  
--replace k8s.io/mount-utils => k8s.io/mount-utils v0.34.2
+-replace k8s.io/mount-utils => k8s.io/mount-utils v0.34.3
 +replace k8s.io/mount-utils => k8s.io/mount-utils v0.34.9
  
--replace k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.34.2
+-replace k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.34.3
 +replace k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.34.9
  
--replace k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.34.2
+-replace k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.34.3
 +replace k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.34.9
  
--replace k8s.io/sample-controller => k8s.io/sample-controller v0.34.2
+-replace k8s.io/sample-controller => k8s.io/sample-controller v0.34.3
 +replace k8s.io/sample-controller => k8s.io/sample-controller v0.34.9
  
--replace k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.34.2
+-replace k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.34.3
 +replace k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.34.9
  
--replace k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.34.2
+-replace k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.34.3
 +replace k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.34.9
  
--replace k8s.io/kms => k8s.io/kms v0.34.2
+-replace k8s.io/kms => k8s.io/kms v0.34.3
 +replace k8s.io/kms => k8s.io/kms v0.34.9
  
--replace k8s.io/endpointslice => k8s.io/endpointslice v0.34.2
+-replace k8s.io/endpointslice => k8s.io/endpointslice v0.34.3
 +replace k8s.io/endpointslice => k8s.io/endpointslice v0.34.9
  
  replace k8s.io/autoscaler/cluster-autoscaler/apis => ./apis
  
--replace k8s.io/cri-client => k8s.io/cri-client v0.34.2
+-replace k8s.io/cri-client => k8s.io/cri-client v0.34.3
 +replace k8s.io/cri-client => k8s.io/cri-client v0.34.9
  
--replace k8s.io/externaljwt => k8s.io/externaljwt v0.34.2
+-replace k8s.io/externaljwt => k8s.io/externaljwt v0.34.3
 +replace k8s.io/externaljwt => k8s.io/externaljwt v0.34.9
 diff --git a/cluster-autoscaler/go.sum b/cluster-autoscaler/go.sum
-index e19d2197d..e9ff9aa59 100644
+index 9fff1ce05..e9ff9aa59 100644
 --- a/cluster-autoscaler/go.sum
 +++ b/cluster-autoscaler/go.sum
 @@ -165,8 +165,8 @@ github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8
@@ -509,18 +509,18 @@ index e19d2197d..e9ff9aa59 100644
  gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
  honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
  honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
--k8s.io/api v0.34.2 h1:fsSUNZhV+bnL6Aqrp6O7lMTy6o5x2C4XLjnh//8SLYY=
--k8s.io/api v0.34.2/go.mod h1:MMBPaWlED2a8w4RSeanD76f7opUoypY8TFYkSM+3XHw=
--k8s.io/apiextensions-apiserver v0.34.2 h1:WStKftnGeoKP4AZRz/BaAAEJvYp4mlZGN0UCv+uvsqo=
--k8s.io/apiextensions-apiserver v0.34.2/go.mod h1:398CJrsgXF1wytdaanynDpJ67zG4Xq7yj91GrmYN2SE=
--k8s.io/apimachinery v0.34.2 h1:zQ12Uk3eMHPxrsbUJgNF8bTauTVR2WgqJsTmwTE/NW4=
--k8s.io/apimachinery v0.34.2/go.mod h1:/GwIlEcWuTX9zKIg2mbw0LRFIsXwrfoVxn+ef0X13lw=
--k8s.io/apiserver v0.34.2 h1:2/yu8suwkmES7IzwlehAovo8dDE07cFRC7KMDb1+MAE=
--k8s.io/apiserver v0.34.2/go.mod h1:gqJQy2yDOB50R3JUReHSFr+cwJnL8G1dzTA0YLEqAPI=
--k8s.io/client-go v0.34.2 h1:Co6XiknN+uUZqiddlfAjT68184/37PS4QAzYvQvDR8M=
--k8s.io/client-go v0.34.2/go.mod h1:2VYDl1XXJsdcAxw7BenFslRQX28Dxz91U9MWKjX97fE=
--k8s.io/cloud-provider v0.34.2 h1:tNxZ6c+3cJdpNHvurzUdVvKNbB0pDxx3jE1AcZ8pMKA=
--k8s.io/cloud-provider v0.34.2/go.mod h1:8XqzAplSoVLZzqut82sWHusz6X00C1Djk3BpeKAjfHY=
+-k8s.io/api v0.34.3 h1:D12sTP257/jSH2vHV2EDYrb16bS7ULlHpdNdNhEw2S4=
+-k8s.io/api v0.34.3/go.mod h1:PyVQBF886Q5RSQZOim7DybQjAbVs8g7gwJNhGtY5MBk=
+-k8s.io/apiextensions-apiserver v0.34.3 h1:p10fGlkDY09eWKOTeUSioxwLukJnm+KuDZdrW71y40g=
+-k8s.io/apiextensions-apiserver v0.34.3/go.mod h1:aujxvqGFRdb/cmXYfcRTeppN7S2XV/t7WMEc64zB5A0=
+-k8s.io/apimachinery v0.34.3 h1:/TB+SFEiQvN9HPldtlWOTp0hWbJ+fjU+wkxysf/aQnE=
+-k8s.io/apimachinery v0.34.3/go.mod h1:/GwIlEcWuTX9zKIg2mbw0LRFIsXwrfoVxn+ef0X13lw=
+-k8s.io/apiserver v0.34.3 h1:uGH1qpDvSiYG4HVFqc6A3L4CKiX+aBWDrrsxHYK0Bdo=
+-k8s.io/apiserver v0.34.3/go.mod h1:QPnnahMO5C2m3lm6fPW3+JmyQbvHZQ8uudAu/493P2w=
+-k8s.io/client-go v0.34.3 h1:wtYtpzy/OPNYf7WyNBTj3iUA0XaBHVqhv4Iv3tbrF5A=
+-k8s.io/client-go v0.34.3/go.mod h1:OxxeYagaP9Kdf78UrKLa3YZixMCfP6bgPwPwNBQBzpM=
+-k8s.io/cloud-provider v0.34.3 h1:+ZIj1mYPzrA0vWZMFFustsDCe1iP+xkhq0ZXZBhPW0o=
+-k8s.io/cloud-provider v0.34.3/go.mod h1:e0XM6MTHG4rPk1Fa7oWnQT9VqKca+jw7wcc+BJeUcn4=
 +k8s.io/api v0.34.9 h1:aVsK5NQL7146suJriGuvpi9giNpwIRSHJ8v5HWakwBo=
 +k8s.io/api v0.34.9/go.mod h1:8oYqD5tLKgvBSnkuDbHZTNrk7NTHybkfYjJ6lNjThjQ=
 +k8s.io/apiextensions-apiserver v0.34.9 h1:I+VcEFLE/6ueQw3v1OxPslTHD6AiGQJ1M4cUxtYelII=
@@ -537,22 +537,22 @@ index e19d2197d..e9ff9aa59 100644
  k8s.io/cloud-provider-aws v1.27.0/go.mod h1:9vUb5mnVnReSRDBWcBxB1b0HOeEc472iOPmrnwpN9SA=
  k8s.io/cloud-provider-gcp/providers v0.28.2 h1:I65pFTLNMQSj7YuW3Mg3pZIXmw0naCmF6TGAuz4/sZE=
  k8s.io/cloud-provider-gcp/providers v0.28.2/go.mod h1:P8dxRvvLtX7xUwVUzA/QOqv8taCzBaVsVMnjnpjmYXE=
--k8s.io/code-generator v0.34.2 h1:9bG6jTxmsU3HXE5BNYJTC8AZ1D6hVVfkm8yYSkdkGY0=
--k8s.io/code-generator v0.34.2/go.mod h1:dnDDEd6S/z4uZ+PG1aE58ySCi/lR4+qT3a4DddE4/2I=
--k8s.io/component-base v0.34.2 h1:HQRqK9x2sSAsd8+R4xxRirlTjowsg6fWCPwWYeSvogQ=
--k8s.io/component-base v0.34.2/go.mod h1:9xw2FHJavUHBFpiGkZoKuYZ5pdtLKe97DEByaA+hHbM=
--k8s.io/component-helpers v0.34.2 h1:RIUGDdU+QFzeVKLZ9f05sXTNAtJrRJ3bnbMLrogCrvM=
--k8s.io/component-helpers v0.34.2/go.mod h1:pLi+GByuRTeFjjcezln8gHL7LcT6HImkwVQ3A2SQaEE=
--k8s.io/controller-manager v0.34.2 h1:bjdSLh5nnSde5jfRW/rdPDOSYbwUMxs+9JUcbyL6LP8=
--k8s.io/controller-manager v0.34.2/go.mod h1:sR6wSdANfbdXBTtg2Fwp1ruo/1TJgSilooT6FDxZj4A=
--k8s.io/cri-api v0.34.2 h1:YtG6Ud62gH+5LYzOWFLeRCFz64SqFFEP5umr/I3PC0Q=
--k8s.io/cri-api v0.34.2/go.mod h1:4qVUjidMg7/Z9YGZpqIDygbkPWkg3mkS1PvOx/kpHTE=
--k8s.io/cri-client v0.34.2 h1:uALtvKgk5qu6owHHvyE2QMqYlfZWGeIB/eO5pboKeIY=
--k8s.io/cri-client v0.34.2/go.mod h1:hwqCdHW06vOPxHB6BQDTMCXkUDxJYMTnlWJxTO0kWtU=
--k8s.io/csi-translation-lib v0.34.2 h1:xvpxaoDfv0kPaLqUeTKGthr1jqmJgmSHgMnJevYPhY4=
--k8s.io/csi-translation-lib v0.34.2/go.mod h1:un/6pCiR5QgE6HD16i2AY11+wSFbeVksolat1zntCZY=
--k8s.io/dynamic-resource-allocation v0.34.2 h1:SjlRGSWl6CZXoJwQNL+Y0wRfdH8PkJ4mHRNK6MMj0bY=
--k8s.io/dynamic-resource-allocation v0.34.2/go.mod h1:ul6I+gfrCmC+OCuVdN0/iykyB2sPrIqh2WyKQ3RQPCU=
+-k8s.io/code-generator v0.34.3 h1:6ipJKsJZZ9q21BO8I2jEj4OLN3y8/1n4aihKN0xKmQk=
+-k8s.io/code-generator v0.34.3/go.mod h1:oW73UPYpGLsbRN8Ozkhd6ZzkF8hzFCiYmvEuWZDroI4=
+-k8s.io/component-base v0.34.3 h1:zsEgw6ELqK0XncCQomgO9DpUIzlrYuZYA0Cgo+JWpVk=
+-k8s.io/component-base v0.34.3/go.mod h1:5iIlD8wPfWE/xSHTRfbjuvUul2WZbI2nOUK65XL0E/c=
+-k8s.io/component-helpers v0.34.3 h1:Iws1GQfM89Lxo7IZITGmVdFOW0Bmyd7SVwwIu1/CCkE=
+-k8s.io/component-helpers v0.34.3/go.mod h1:S8HjjMTrUDVMVPo2EdNYRtQx9uIEIueQYdPMOe9UxJs=
+-k8s.io/controller-manager v0.34.3 h1:pEW6ExR3FteKkYkKRrLoi0Sy8dcbvUTAReP8OTxK5k0=
+-k8s.io/controller-manager v0.34.3/go.mod h1:YzXiwiubf6GdSC3ej2XFYhQQBwF5AvJq/3eymdsU9OU=
+-k8s.io/cri-api v0.34.3 h1:zFdQSHZuQlQXesw9ncjQRUyDpvLng/84Q4qLKd8x2zE=
+-k8s.io/cri-api v0.34.3/go.mod h1:4qVUjidMg7/Z9YGZpqIDygbkPWkg3mkS1PvOx/kpHTE=
+-k8s.io/cri-client v0.34.3 h1:P1LMB7Aa52OfIaJ383FfHYJTlokZsLYUBn6Y7IEc9Oc=
+-k8s.io/cri-client v0.34.3/go.mod h1:EEQXyjPYePB2RSBnrTs+4up14q/6lVKnHvPXUSMYR4A=
+-k8s.io/csi-translation-lib v0.34.3 h1:WGE/HPz5D3TIqffhYkk6s4KfW1mcSwSH30MzABK47Pg=
+-k8s.io/csi-translation-lib v0.34.3/go.mod h1:Lx11spUQnRzYFDrTok0/6cQMP3oXHi73+mXWvkRTxbE=
+-k8s.io/dynamic-resource-allocation v0.34.3 h1:8UGn1CTj1IljJa+r6HxnEDqLvcBZkv5c+Ooa6x1Oy+o=
+-k8s.io/dynamic-resource-allocation v0.34.3/go.mod h1:eYjQqNaHLfqXT94lbSXEy8ZLaUg1mGJ2JCEtNWM7e7M=
 +k8s.io/code-generator v0.34.9 h1:jXBgPd5FbFoN1J2uA/qISW3uLHRl8wJ9Gx6L4PiJIPk=
 +k8s.io/code-generator v0.34.9/go.mod h1:/doiEA33AIV4kFt4NTMCzV8N5Ued8kq1fZMWUUib990=
 +k8s.io/component-base v0.34.9 h1:whlBI2kU+CHKHmeByojCzHX/OTU7RjsTirkHbqDDpz0=
@@ -573,22 +573,22 @@ index e19d2197d..e9ff9aa59 100644
  k8s.io/gengo/v2 v2.0.0-20250604051438-85fd79dbfd9f/go.mod h1:EJykeLsmFC60UQbYJezXkEsG2FLrt0GPNkU5iK5GWxU=
  k8s.io/klog/v2 v2.130.1 h1:n9Xl7H1Xvksem4KFG4PYbdQCQxqc/tTUyrgXaOhHSzk=
  k8s.io/klog/v2 v2.130.1/go.mod h1:3Jpz1GvMt720eyJH1ckRHK1EDfpxISzJ7I9OYgaDtPE=
--k8s.io/kms v0.34.2 h1:91rj4MDZLyIT9KxG8J5/CcMH666Z88CF/xJQeuPfJc8=
--k8s.io/kms v0.34.2/go.mod h1:s1CFkLG7w9eaTYvctOxosx88fl4spqmixnNpys0JAtM=
+-k8s.io/kms v0.34.3 h1:QzBOD0sk1bGQVMcZQAHGjtbP1iKZJUyhC6D0I+BTxIE=
+-k8s.io/kms v0.34.3/go.mod h1:s1CFkLG7w9eaTYvctOxosx88fl4spqmixnNpys0JAtM=
 +k8s.io/kms v0.34.9 h1:lZGoqvmTxESbQM14PBveZt3gkgSOGDf56u06HrhS1O0=
 +k8s.io/kms v0.34.9/go.mod h1:sBByaFjIDNm8oPQXjREzXISZSx60On//fhvnAVhuL5g=
  k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b h1:MloQ9/bdJyIu9lb1PzujOPolHyvO06MXG5TUIj2mNAA=
  k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b/go.mod h1:UZ2yyWbFTpuhSbFhv24aGNOdoRdJZgsIObGBUaYVsts=
--k8s.io/kube-scheduler v0.34.2 h1:TtLcaXeIpkqgzMr2ch7Ap8Cluq4M182XUDRlnOPDdoc=
--k8s.io/kube-scheduler v0.34.2/go.mod h1:PTn4QYiSet8/00VQ2qGO/HWdo5iNJlVRCXz/7R3Ut5I=
--k8s.io/kubectl v0.34.2 h1:+fWGrVlDONMUmmQLDaGkQ9i91oszjjRAa94cr37hzqA=
--k8s.io/kubectl v0.34.2/go.mod h1:X2KTOdtZZNrTWmUD4oHApJ836pevSl+zvC5sI6oO2YQ=
--k8s.io/kubelet v0.34.2 h1:Dl+1uh7xwJr70r+SHKyIpvu6XvzuoPu0uDIC4cqgJUs=
--k8s.io/kubelet v0.34.2/go.mod h1:RfwR03iuKeVV7Z1qD9XKH98c3tlPImJpQ3qHIW40htM=
--k8s.io/kubernetes v1.34.2 h1:WQdDvYJazkmkwSncgNwGvVtaCt4TYXIU3wSMRgvp3MI=
--k8s.io/kubernetes v1.34.2/go.mod h1:m6pZk6a179pRo2wsTiCPORJ86iOEQmfIzUvtyEF8BwA=
--k8s.io/mount-utils v0.34.2 h1:DiesOtAiYccJWKGRlJZhRkjCHvpQ3YmSlQp+zkkvf9Y=
--k8s.io/mount-utils v0.34.2/go.mod h1:MIjjYlqJ0ziYQg0MO09kc9S96GIcMkhF/ay9MncF0GA=
+-k8s.io/kube-scheduler v0.34.3 h1:ki99I6opxUZNcIO/QIq1Jz5iTVRHPRdDRFxi5A/3Zjw=
+-k8s.io/kube-scheduler v0.34.3/go.mod h1:ECkAVWCHQjWJLasX6eznbZ/7J6YqDWiZchXpjG/w5ig=
+-k8s.io/kubectl v0.34.3 h1:vpM6//153gh5gvsYHXWHVJ4l4xmN5QFwTSmlfd8icm8=
+-k8s.io/kubectl v0.34.3/go.mod h1:zZQHtIZoUqTP1bAnPzq/3W1jfc0NeOeunFgcswrfg1c=
+-k8s.io/kubelet v0.34.3 h1:8QRev2FmasZ05yCC774qn6ULche72PYM7AQv0CVt9CM=
+-k8s.io/kubelet v0.34.3/go.mod h1:pMgblr+nVQ02UkyaTcgqzS3AIYVQkjlMFg1Pd5rGC1Q=
+-k8s.io/kubernetes v1.34.3 h1:0TfljWbhEF5DBks+WFMSrvKfxBLo4vnZuqORjLMiyT4=
+-k8s.io/kubernetes v1.34.3/go.mod h1:m6pZk6a179pRo2wsTiCPORJ86iOEQmfIzUvtyEF8BwA=
+-k8s.io/mount-utils v0.34.3 h1:+sk7PVMQhGoNkGnxmxhyjEXpFcTaD6s3a6NXZNhqERc=
+-k8s.io/mount-utils v0.34.3/go.mod h1:MIjjYlqJ0ziYQg0MO09kc9S96GIcMkhF/ay9MncF0GA=
 +k8s.io/kube-scheduler v0.34.9 h1:XmMog9CcudBrEgrltvScak5Tk2kd5yYRlsVgdBnW5ok=
 +k8s.io/kube-scheduler v0.34.9/go.mod h1:aAUgE00lVWSzG+3fgb4Vv6IgN55SQ+KI0pUFXGjK/4M=
 +k8s.io/kubectl v0.34.9 h1:nGNmsw1m9Q1lop2HtMk1jzM+JVNlQLj6gZr82vT1AmQ=

--- a/modules/040-node-manager/images/cluster-autoscaler/patches/1.34/001-go-mod.patch
+++ b/modules/040-node-manager/images/cluster-autoscaler/patches/1.34/001-go-mod.patch
@@ -1,5 +1,5 @@
 diff --git a/cluster-autoscaler/apis/go.mod b/cluster-autoscaler/apis/go.mod
-index 2f2e77110..1cd7b172a 100644
+index 52bf2ebdd..87e8923fc 100644
 --- a/cluster-autoscaler/apis/go.mod
 +++ b/cluster-autoscaler/apis/go.mod
 @@ -1,6 +1,6 @@
@@ -35,7 +35,7 @@ index 2f2e77110..1cd7b172a 100644
  	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
  	gopkg.in/inf.v0 v0.9.1 // indirect
 diff --git a/cluster-autoscaler/apis/go.sum b/cluster-autoscaler/apis/go.sum
-index 41f845ea6..2251631fb 100644
+index f72605e2f..2789b9850 100644
 --- a/cluster-autoscaler/apis/go.sum
 +++ b/cluster-autoscaler/apis/go.sum
 @@ -91,40 +91,44 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
@@ -98,7 +98,7 @@ index 41f845ea6..2251631fb 100644
  golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
  golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 diff --git a/cluster-autoscaler/go.mod b/cluster-autoscaler/go.mod
-index 5a58f093c..805581425 100644
+index e94021d12..7a7a3c2ab 100644
 --- a/cluster-autoscaler/go.mod
 +++ b/cluster-autoscaler/go.mod
 @@ -1,6 +1,6 @@
@@ -109,8 +109,12 @@ index 5a58f093c..805581425 100644
  
  require (
  	cloud.google.com/go/compute/metadata v0.6.0
-@@ -32,30 +32,30 @@ require (
- 	github.com/stretchr/testify v1.10.0
+@@ -29,33 +29,33 @@ require (
+ 	github.com/pkg/errors v0.9.1
+ 	github.com/prometheus/client_golang v1.22.0
+ 	github.com/spf13/pflag v1.0.6
+-	github.com/stretchr/testify v1.10.0
++	github.com/stretchr/testify v1.11.1
  	github.com/vburenin/ifacemaker v1.2.1
  	go.uber.org/mock v0.4.0
 -	golang.org/x/crypto v0.36.0
@@ -125,51 +129,71 @@ index 5a58f093c..805581425 100644
  	google.golang.org/protobuf v1.36.5
  	gopkg.in/gcfg.v1 v1.2.3
  	gopkg.in/yaml.v2 v2.4.0
--	k8s.io/api v0.34.1
--	k8s.io/apimachinery v0.34.1
--	k8s.io/apiserver v0.34.1
-+	k8s.io/api v0.34.2
-+	k8s.io/apimachinery v0.34.2
-+	k8s.io/apiserver v0.34.2
+-	k8s.io/api v0.34.2
+-	k8s.io/apimachinery v0.34.2
+-	k8s.io/apiserver v0.34.2
++	k8s.io/api v0.34.9
++	k8s.io/apimachinery v0.34.9
++	k8s.io/apiserver v0.34.9
  	k8s.io/autoscaler/cluster-autoscaler/apis v0.0.0-20240627115740-d52e4b9665d7
--	k8s.io/client-go v0.34.1
-+	k8s.io/client-go v0.34.2
+-	k8s.io/client-go v0.34.2
++	k8s.io/client-go v0.34.9
  	k8s.io/cloud-provider v0.30.1
  	k8s.io/cloud-provider-aws v1.27.0
  	k8s.io/cloud-provider-gcp/providers v0.28.2
--	k8s.io/component-base v0.34.1
--	k8s.io/component-helpers v0.34.1
-+	k8s.io/component-base v0.34.2
-+	k8s.io/component-helpers v0.34.2
+-	k8s.io/component-base v0.34.2
+-	k8s.io/component-helpers v0.34.2
++	k8s.io/component-base v0.34.9
++	k8s.io/component-helpers v0.34.9
  	k8s.io/dynamic-resource-allocation v0.0.0
  	k8s.io/klog/v2 v2.130.1
  	k8s.io/kube-scheduler v0.0.0
--	k8s.io/kubelet v0.34.1
--	k8s.io/kubernetes v1.34.1
-+	k8s.io/kubelet v0.34.2
-+	k8s.io/kubernetes v1.34.2
+-	k8s.io/kubelet v0.34.2
+-	k8s.io/kubernetes v1.34.2
++	k8s.io/kubelet v0.34.9
++	k8s.io/kubernetes v1.34.9
  	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397
  	sigs.k8s.io/cloud-provider-azure v1.29.4
  	sigs.k8s.io/cloud-provider-azure/pkg/azclient v0.0.13
-@@ -102,7 +102,7 @@ require (
- 	github.com/containerd/typeurl/v2 v2.2.2 // indirect
- 	github.com/coreos/go-semver v0.3.1 // indirect
- 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
--	github.com/cyphar/filepath-securejoin v0.4.1 // indirect
-+	github.com/cyphar/filepath-securejoin v0.5.1 // indirect
- 	github.com/dave/jennifer v1.6.0 // indirect
- 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
- 	github.com/dimchansky/utfbom v1.1.1 // indirect
-@@ -161,7 +161,7 @@ require (
- 	github.com/opencontainers/go-digest v1.0.0 // indirect
- 	github.com/opencontainers/image-spec v1.1.1 // indirect
- 	github.com/opencontainers/runtime-spec v1.2.0 // indirect
--	github.com/opencontainers/selinux v1.11.1 // indirect
-+	github.com/opencontainers/selinux v1.12.0 // indirect
- 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
- 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
- 	github.com/prometheus/client_model v0.6.1 // indirect
-@@ -192,12 +192,13 @@ require (
+@@ -115,7 +115,7 @@ require (
+ 	github.com/felixge/httpsnoop v1.0.4 // indirect
+ 	github.com/fsnotify/fsnotify v1.9.0 // indirect
+ 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
+-	github.com/go-logr/logr v1.4.2 // indirect
++	github.com/go-logr/logr v1.4.3 // indirect
+ 	github.com/go-logr/stdr v1.2.2 // indirect
+ 	github.com/go-logr/zapr v1.3.0 // indirect
+ 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
+@@ -147,7 +147,7 @@ require (
+ 	github.com/mailru/easyjson v0.7.7 // indirect
+ 	github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible // indirect
+ 	github.com/mitchellh/go-homedir v1.1.0 // indirect
+-	github.com/moby/spdystream v0.5.0 // indirect
++	github.com/moby/spdystream v0.5.1 // indirect
+ 	github.com/moby/sys/mountinfo v0.7.2 // indirect
+ 	github.com/moby/sys/userns v0.1.0 // indirect
+ 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+@@ -176,28 +176,29 @@ require (
+ 	go.etcd.io/etcd/client/pkg/v3 v3.6.4 // indirect
+ 	go.etcd.io/etcd/client/v3 v3.6.4 // indirect
+ 	go.opencensus.io v0.24.0 // indirect
+-	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
++	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
+ 	go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful v0.44.0 // indirect
+ 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.60.0 // indirect
+ 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.58.0 // indirect
+-	go.opentelemetry.io/otel v1.35.0 // indirect
++	go.opentelemetry.io/otel v1.41.0 // indirect
+ 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.34.0 // indirect
+ 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.34.0 // indirect
+-	go.opentelemetry.io/otel/metric v1.35.0 // indirect
++	go.opentelemetry.io/otel/metric v1.41.0 // indirect
+ 	go.opentelemetry.io/otel/sdk v1.34.0 // indirect
+-	go.opentelemetry.io/otel/trace v1.35.0 // indirect
++	go.opentelemetry.io/otel/trace v1.41.0 // indirect
+ 	go.opentelemetry.io/proto/otlp v1.5.0 // indirect
+ 	go.uber.org/multierr v1.11.0 // indirect
+ 	go.uber.org/zap v1.27.0 // indirect
  	go.yaml.in/yaml/v2 v2.4.2 // indirect
  	go.yaml.in/yaml/v3 v3.0.4 // indirect
  	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
@@ -192,17 +216,17 @@ index 5a58f093c..805581425 100644
  	gopkg.in/warnings.v0 v0.1.2 // indirect
  	gopkg.in/yaml.v3 v3.0.1 // indirect
  	k8s.io/apiextensions-apiserver v0.0.0 // indirect
--	k8s.io/code-generator v0.34.1 // indirect
--	k8s.io/controller-manager v0.34.1 // indirect
--	k8s.io/cri-api v0.34.1 // indirect
-+	k8s.io/code-generator v0.34.2 // indirect
-+	k8s.io/controller-manager v0.34.2 // indirect
-+	k8s.io/cri-api v0.34.2 // indirect
+-	k8s.io/code-generator v0.34.2 // indirect
+-	k8s.io/controller-manager v0.34.2 // indirect
+-	k8s.io/cri-api v0.34.2 // indirect
++	k8s.io/code-generator v0.34.9 // indirect
++	k8s.io/controller-manager v0.34.9 // indirect
++	k8s.io/cri-api v0.34.9 // indirect
  	k8s.io/cri-client v0.0.0 // indirect
  	k8s.io/csi-translation-lib v0.27.0 // indirect
  	k8s.io/gengo/v2 v2.0.0-20250604051438-85fd79dbfd9f // indirect
--	k8s.io/kms v0.34.1 // indirect
-+	k8s.io/kms v0.34.2 // indirect
+-	k8s.io/kms v0.34.2 // indirect
++	k8s.io/kms v0.34.9 // indirect
  	k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b // indirect
  	k8s.io/kubectl v0.28.0 // indirect
  	k8s.io/mount-utils v0.26.0-alpha.0 // indirect
@@ -210,126 +234,186 @@ index 5a58f093c..805581425 100644
  
  replace github.com/rancher/go-rancher => github.com/rancher/go-rancher v0.1.0
  
--replace k8s.io/api => k8s.io/api v0.34.1
-+replace k8s.io/api => k8s.io/api v0.34.2
+-replace k8s.io/api => k8s.io/api v0.34.2
++replace k8s.io/api => k8s.io/api v0.34.9
  
--replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.34.1
-+replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.34.2
+-replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.34.2
++replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.34.9
  
--replace k8s.io/apimachinery => k8s.io/apimachinery v0.34.1
-+replace k8s.io/apimachinery => k8s.io/apimachinery v0.34.2
+-replace k8s.io/apimachinery => k8s.io/apimachinery v0.34.2
++replace k8s.io/apimachinery => k8s.io/apimachinery v0.34.9
  
--replace k8s.io/apiserver => k8s.io/apiserver v0.34.1
-+replace k8s.io/apiserver => k8s.io/apiserver v0.34.2
+-replace k8s.io/apiserver => k8s.io/apiserver v0.34.2
++replace k8s.io/apiserver => k8s.io/apiserver v0.34.9
  
--replace k8s.io/cli-runtime => k8s.io/cli-runtime v0.34.1
-+replace k8s.io/cli-runtime => k8s.io/cli-runtime v0.34.2
+-replace k8s.io/cli-runtime => k8s.io/cli-runtime v0.34.2
++replace k8s.io/cli-runtime => k8s.io/cli-runtime v0.34.9
  
--replace k8s.io/client-go => k8s.io/client-go v0.34.1
-+replace k8s.io/client-go => k8s.io/client-go v0.34.2
+-replace k8s.io/client-go => k8s.io/client-go v0.34.2
++replace k8s.io/client-go => k8s.io/client-go v0.34.9
  
--replace k8s.io/cloud-provider => k8s.io/cloud-provider v0.34.1
-+replace k8s.io/cloud-provider => k8s.io/cloud-provider v0.34.2
+-replace k8s.io/cloud-provider => k8s.io/cloud-provider v0.34.2
++replace k8s.io/cloud-provider => k8s.io/cloud-provider v0.34.9
  
--replace k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.34.1
-+replace k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.34.2
+-replace k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.34.2
++replace k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.34.9
  
--replace k8s.io/code-generator => k8s.io/code-generator v0.34.1
-+replace k8s.io/code-generator => k8s.io/code-generator v0.34.2
+-replace k8s.io/code-generator => k8s.io/code-generator v0.34.2
++replace k8s.io/code-generator => k8s.io/code-generator v0.34.9
  
--replace k8s.io/component-base => k8s.io/component-base v0.34.1
-+replace k8s.io/component-base => k8s.io/component-base v0.34.2
+-replace k8s.io/component-base => k8s.io/component-base v0.34.2
++replace k8s.io/component-base => k8s.io/component-base v0.34.9
  
--replace k8s.io/component-helpers => k8s.io/component-helpers v0.34.1
-+replace k8s.io/component-helpers => k8s.io/component-helpers v0.34.2
+-replace k8s.io/component-helpers => k8s.io/component-helpers v0.34.2
++replace k8s.io/component-helpers => k8s.io/component-helpers v0.34.9
  
--replace k8s.io/controller-manager => k8s.io/controller-manager v0.34.1
-+replace k8s.io/controller-manager => k8s.io/controller-manager v0.34.2
+-replace k8s.io/controller-manager => k8s.io/controller-manager v0.34.2
++replace k8s.io/controller-manager => k8s.io/controller-manager v0.34.9
  
--replace k8s.io/cri-api => k8s.io/cri-api v0.34.1
-+replace k8s.io/cri-api => k8s.io/cri-api v0.34.2
+-replace k8s.io/cri-api => k8s.io/cri-api v0.34.2
++replace k8s.io/cri-api => k8s.io/cri-api v0.34.9
  
--replace k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.34.1
-+replace k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.34.2
+-replace k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.34.2
++replace k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.34.9
  
--replace k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.34.1
-+replace k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.34.2
+-replace k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.34.2
++replace k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.34.9
  
--replace k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.34.1
-+replace k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.34.2
+-replace k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.34.2
++replace k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.34.9
  
--replace k8s.io/kube-proxy => k8s.io/kube-proxy v0.34.1
-+replace k8s.io/kube-proxy => k8s.io/kube-proxy v0.34.2
+-replace k8s.io/kube-proxy => k8s.io/kube-proxy v0.34.2
++replace k8s.io/kube-proxy => k8s.io/kube-proxy v0.34.9
  
--replace k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.34.1
-+replace k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.34.2
+-replace k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.34.2
++replace k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.34.9
  
--replace k8s.io/kubectl => k8s.io/kubectl v0.34.1
-+replace k8s.io/kubectl => k8s.io/kubectl v0.34.2
+-replace k8s.io/kubectl => k8s.io/kubectl v0.34.2
++replace k8s.io/kubectl => k8s.io/kubectl v0.34.9
  
--replace k8s.io/kubelet => k8s.io/kubelet v0.34.1
-+replace k8s.io/kubelet => k8s.io/kubelet v0.34.2
+-replace k8s.io/kubelet => k8s.io/kubelet v0.34.2
++replace k8s.io/kubelet => k8s.io/kubelet v0.34.9
  
--replace k8s.io/metrics => k8s.io/metrics v0.34.1
-+replace k8s.io/metrics => k8s.io/metrics v0.34.2
+-replace k8s.io/metrics => k8s.io/metrics v0.34.2
++replace k8s.io/metrics => k8s.io/metrics v0.34.9
  
--replace k8s.io/mount-utils => k8s.io/mount-utils v0.34.1
-+replace k8s.io/mount-utils => k8s.io/mount-utils v0.34.2
+-replace k8s.io/mount-utils => k8s.io/mount-utils v0.34.2
++replace k8s.io/mount-utils => k8s.io/mount-utils v0.34.9
  
--replace k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.34.1
-+replace k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.34.2
+-replace k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.34.2
++replace k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.34.9
  
--replace k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.34.1
-+replace k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.34.2
+-replace k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.34.2
++replace k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.34.9
  
--replace k8s.io/sample-controller => k8s.io/sample-controller v0.34.1
-+replace k8s.io/sample-controller => k8s.io/sample-controller v0.34.2
+-replace k8s.io/sample-controller => k8s.io/sample-controller v0.34.2
++replace k8s.io/sample-controller => k8s.io/sample-controller v0.34.9
  
--replace k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.34.1
-+replace k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.34.2
+-replace k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.34.2
++replace k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.34.9
  
--replace k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.34.1
-+replace k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.34.2
+-replace k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.34.2
++replace k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.34.9
  
--replace k8s.io/kms => k8s.io/kms v0.34.1
-+replace k8s.io/kms => k8s.io/kms v0.34.2
+-replace k8s.io/kms => k8s.io/kms v0.34.2
++replace k8s.io/kms => k8s.io/kms v0.34.9
  
--replace k8s.io/endpointslice => k8s.io/endpointslice v0.34.1
-+replace k8s.io/endpointslice => k8s.io/endpointslice v0.34.2
+-replace k8s.io/endpointslice => k8s.io/endpointslice v0.34.2
++replace k8s.io/endpointslice => k8s.io/endpointslice v0.34.9
  
  replace k8s.io/autoscaler/cluster-autoscaler/apis => ./apis
  
--replace k8s.io/cri-client => k8s.io/cri-client v0.34.1
-+replace k8s.io/cri-client => k8s.io/cri-client v0.34.2
+-replace k8s.io/cri-client => k8s.io/cri-client v0.34.2
++replace k8s.io/cri-client => k8s.io/cri-client v0.34.9
  
--replace k8s.io/externaljwt => k8s.io/externaljwt v0.34.1
-+replace k8s.io/externaljwt => k8s.io/externaljwt v0.34.2
+-replace k8s.io/externaljwt => k8s.io/externaljwt v0.34.2
++replace k8s.io/externaljwt => k8s.io/externaljwt v0.34.9
 diff --git a/cluster-autoscaler/go.sum b/cluster-autoscaler/go.sum
-index 8668deef6..f7ed24386 100644
+index e19d2197d..e9ff9aa59 100644
 --- a/cluster-autoscaler/go.sum
 +++ b/cluster-autoscaler/go.sum
-@@ -126,8 +126,8 @@ github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8
- github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
- github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
- github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
--github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=
--github.com/cyphar/filepath-securejoin v0.4.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
-+github.com/cyphar/filepath-securejoin v0.5.1 h1:eYgfMq5yryL4fbWfkLpFFy2ukSELzaJOTaUTuh+oF48=
-+github.com/cyphar/filepath-securejoin v0.5.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
- github.com/dave/jennifer v1.6.0 h1:MQ/6emI2xM7wt0tJzJzyUik2Q3Tcn2eE0vtYgh4GPVI=
- github.com/dave/jennifer v1.6.0/go.mod h1:AxTG893FiZKqxy3FP1kL80VMshSMuz2G+EgvszgGRnk=
- github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-@@ -326,8 +326,8 @@ github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJw
- github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
- github.com/opencontainers/runtime-spec v1.2.0 h1:z97+pHb3uELt/yiAWD691HNHQIF07bE7dzrbT927iTk=
- github.com/opencontainers/runtime-spec v1.2.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
--github.com/opencontainers/selinux v1.11.1 h1:nHFvthhM0qY8/m+vfhJylliSshm8G1jJ2jDMcgULaH8=
--github.com/opencontainers/selinux v1.11.1/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M586T4DlDRYpFkyec=
-+github.com/opencontainers/selinux v1.12.0 h1:6n5JV4Cf+4y0KNXW48TLj5DwfXpvWlxXplUkdTrmPb8=
-+github.com/opencontainers/selinux v1.12.0/go.mod h1:BTPX+bjVbWGXw7ZZWUbdENt8w0htPSrlgOOysQaU62U=
- github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
- github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
- github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+@@ -165,8 +165,8 @@ github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8
+ github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
+ github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
+ github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+-github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
+-github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
++github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
++github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
+ github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
+ github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
+ github.com/go-logr/zapr v1.3.0 h1:XGdV8XW8zdwFiwOA2Dryh1gj2KRQyOOoNmBy4EplIcQ=
+@@ -296,8 +296,8 @@ github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG
+ github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
+ github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=
+ github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
+-github.com/moby/spdystream v0.5.0 h1:7r0J1Si3QO/kjRitvSLVVFUjxMEb/YLj6S9FF62JBCU=
+-github.com/moby/spdystream v0.5.0/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
++github.com/moby/spdystream v0.5.1 h1:9sNYeYZUcci9R6/w7KDaFWEWeV4LStVG78Mpyq/Zm/Y=
++github.com/moby/spdystream v0.5.1/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
+ github.com/moby/sys/mountinfo v0.7.2 h1:1shs6aH5s4o5H2zQLn796ADW1wMrIwHsyJ2v9KouLrg=
+ github.com/moby/sys/mountinfo v0.7.2/go.mod h1:1YOa8w8Ih7uW0wALDUgT1dTTSBrZ+HiBLGws92L2RU4=
+ github.com/moby/sys/userns v0.1.0 h1:tVLXkFOxVu9A64/yh59slHVv9ahO9UIev4JZusOLG/g=
+@@ -344,8 +344,8 @@ github.com/prometheus/common v0.62.0 h1:xasJaQlnWAeyHdUBeGjXmutelfJHWMRr+Fg4QszZ
+ github.com/prometheus/common v0.62.0/go.mod h1:vyBcEuLSvWos9B1+CyL7JZ2up+uFzXhkqml0W5zIY1I=
+ github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
+ github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
+-github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
+-github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
++github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
++github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
+ github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+@@ -368,8 +368,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
+ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+ github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+-github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+-github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
++github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
++github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+ github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75 h1:6fotK7otjonDflCTK0BCfls4SPy3NcCVb5dqqmbRknE=
+ github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75/go.mod h1:KO6IkyS8Y3j8OdNO85qEYBsRPuteD+YciPomcXdrMnk=
+ github.com/vburenin/ifacemaker v1.2.1 h1:3Vq8B/bfBgjWTkv+jDg4dVL1KHt3k1K4lO7XRxYA2sk=
+@@ -398,8 +398,8 @@ go.etcd.io/raft/v3 v3.6.0 h1:5NtvbDVYpnfZWcIHgGRk9DyzkBIXOi8j+DDp1IcnUWQ=
+ go.etcd.io/raft/v3 v3.6.0/go.mod h1:nLvLevg6+xrVtHUmVaTcTz603gQPHfh7kUAwV6YpfGo=
+ go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
+ go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
+-go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
+-go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
++go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
++go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
+ go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful v0.44.0 h1:KemlMZlVwBSEGaO91WKgp41BBFsnWqqj9sKRwmOqC40=
+ go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful v0.44.0/go.mod h1:uq8DrRaen3suIWTpdR/JNHCGpurSvMv9D5Nr5CU5TXc=
+ go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.60.0 h1:x7wzEgXfnzJcHDwStJT+mxOz4etr2EcexjqhBvmoakw=
+@@ -408,20 +408,20 @@ go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.58.0 h1:yd02MEj
+ go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.58.0/go.mod h1:umTcuxiv1n/s/S6/c2AT/g2CQ7u5C59sHDNmfSwgz7Q=
+ go.opentelemetry.io/contrib/propagators/b3 v1.19.0 h1:ulz44cpm6V5oAeg5Aw9HyqGFMS6XM7untlMEhD7YzzA=
+ go.opentelemetry.io/contrib/propagators/b3 v1.19.0/go.mod h1:OzCmE2IVS+asTI+odXQstRGVfXQ4bXv9nMBRK0nNyqQ=
+-go.opentelemetry.io/otel v1.35.0 h1:xKWKPxrxB6OtMCbmMY021CqC45J+3Onta9MqjhnusiQ=
+-go.opentelemetry.io/otel v1.35.0/go.mod h1:UEqy8Zp11hpkUrL73gSlELM0DupHoiq72dR+Zqel/+Y=
++go.opentelemetry.io/otel v1.41.0 h1:YlEwVsGAlCvczDILpUXpIpPSL/VPugt7zHThEMLce1c=
++go.opentelemetry.io/otel v1.41.0/go.mod h1:Yt4UwgEKeT05QbLwbyHXEwhnjxNO6D8L5PQP51/46dE=
+ go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.34.0 h1:OeNbIYk/2C15ckl7glBlOBp5+WlYsOElzTNmiPW/x60=
+ go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.34.0/go.mod h1:7Bept48yIeqxP2OZ9/AqIpYS94h2or0aB4FypJTc8ZM=
+ go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.34.0 h1:tgJ0uaNS4c98WRNUEx5U3aDlrDOI5Rs+1Vifcw4DJ8U=
+ go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.34.0/go.mod h1:U7HYyW0zt/a9x5J1Kjs+r1f/d4ZHnYFclhYY2+YbeoE=
+-go.opentelemetry.io/otel/metric v1.35.0 h1:0znxYu2SNyuMSQT4Y9WDWej0VpcsxkuklLa4/siN90M=
+-go.opentelemetry.io/otel/metric v1.35.0/go.mod h1:nKVFgxBZ2fReX6IlyW28MgZojkoAkJGaE8CpgeAU3oE=
++go.opentelemetry.io/otel/metric v1.41.0 h1:rFnDcs4gRzBcsO9tS8LCpgR0dxg4aaxWlJxCno7JlTQ=
++go.opentelemetry.io/otel/metric v1.41.0/go.mod h1:xPvCwd9pU0VN8tPZYzDZV/BMj9CM9vs00GuBjeKhJps=
+ go.opentelemetry.io/otel/sdk v1.34.0 h1:95zS4k/2GOy069d321O8jWgYsW3MzVV+KuSPKp7Wr1A=
+ go.opentelemetry.io/otel/sdk v1.34.0/go.mod h1:0e/pNiaMAqaykJGKbi+tSjWfNNHMTxoC9qANsCzbyxU=
+ go.opentelemetry.io/otel/sdk/metric v1.34.0 h1:5CeK9ujjbFVL5c1PhLuStg1wxA7vQv7ce1EK0Gyvahk=
+ go.opentelemetry.io/otel/sdk/metric v1.34.0/go.mod h1:jQ/r8Ze28zRKoNRdkjCZxfs6YvBTG1+YIqyFVFYec5w=
+-go.opentelemetry.io/otel/trace v1.35.0 h1:dPpEfJu1sDIqruz7BHFG3c7528f6ddfSWfFDVt/xgMs=
+-go.opentelemetry.io/otel/trace v1.35.0/go.mod h1:WUk7DtFp1Aw2MkvqGdwiXYDZZNvA/1J8o6xRXLrIkyc=
++go.opentelemetry.io/otel/trace v1.41.0 h1:Vbk2co6bhj8L59ZJ6/xFTskY+tGAbOnCtQGVVa9TIN0=
++go.opentelemetry.io/otel/trace v1.41.0/go.mod h1:U1NU4ULCoxeDKc09yCWdWe+3QoyweJcISEVa1RBzOis=
+ go.opentelemetry.io/proto/otlp v1.5.0 h1:xJvq7gMzB31/d406fB8U5CBdyQGw4P399D1aQWU/3i4=
+ go.opentelemetry.io/proto/otlp v1.5.0/go.mod h1:keN8WnHxOy8PG0rQZjJJ5A2ebUoafqWp0eVQ4yIXvJ4=
+ go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 @@ -443,8 +443,8 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
  golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
  golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58=
@@ -425,96 +509,96 @@ index 8668deef6..f7ed24386 100644
  gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
  honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
  honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
--k8s.io/api v0.34.1 h1:jC+153630BMdlFukegoEL8E/yT7aLyQkIVuwhmwDgJM=
--k8s.io/api v0.34.1/go.mod h1:SB80FxFtXn5/gwzCoN6QCtPD7Vbu5w2n1S0J5gFfTYk=
--k8s.io/apiextensions-apiserver v0.34.1 h1:NNPBva8FNAPt1iSVwIE0FsdrVriRXMsaWFMqJbII2CI=
--k8s.io/apiextensions-apiserver v0.34.1/go.mod h1:hP9Rld3zF5Ay2Of3BeEpLAToP+l4s5UlxiHfqRaRcMc=
--k8s.io/apimachinery v0.34.1 h1:dTlxFls/eikpJxmAC7MVE8oOeP1zryV7iRyIjB0gky4=
--k8s.io/apimachinery v0.34.1/go.mod h1:/GwIlEcWuTX9zKIg2mbw0LRFIsXwrfoVxn+ef0X13lw=
--k8s.io/apiserver v0.34.1 h1:U3JBGdgANK3dfFcyknWde1G6X1F4bg7PXuvlqt8lITA=
--k8s.io/apiserver v0.34.1/go.mod h1:eOOc9nrVqlBI1AFCvVzsob0OxtPZUCPiUJL45JOTBG0=
--k8s.io/client-go v0.34.1 h1:ZUPJKgXsnKwVwmKKdPfw4tB58+7/Ik3CrjOEhsiZ7mY=
--k8s.io/client-go v0.34.1/go.mod h1:kA8v0FP+tk6sZA0yKLRG67LWjqufAoSHA2xVGKw9Of8=
--k8s.io/cloud-provider v0.34.1 h1:FS+4C1vq9pIngd/5LR5Jha1sEbn+fo0HJitgZmUyBNc=
--k8s.io/cloud-provider v0.34.1/go.mod h1:ghyQYfQIWZAXKNS+TEgEiQ8wPuhzIVt3wFO6rKqS/rQ=
-+k8s.io/api v0.34.2 h1:fsSUNZhV+bnL6Aqrp6O7lMTy6o5x2C4XLjnh//8SLYY=
-+k8s.io/api v0.34.2/go.mod h1:MMBPaWlED2a8w4RSeanD76f7opUoypY8TFYkSM+3XHw=
-+k8s.io/apiextensions-apiserver v0.34.2 h1:WStKftnGeoKP4AZRz/BaAAEJvYp4mlZGN0UCv+uvsqo=
-+k8s.io/apiextensions-apiserver v0.34.2/go.mod h1:398CJrsgXF1wytdaanynDpJ67zG4Xq7yj91GrmYN2SE=
-+k8s.io/apimachinery v0.34.2 h1:zQ12Uk3eMHPxrsbUJgNF8bTauTVR2WgqJsTmwTE/NW4=
-+k8s.io/apimachinery v0.34.2/go.mod h1:/GwIlEcWuTX9zKIg2mbw0LRFIsXwrfoVxn+ef0X13lw=
-+k8s.io/apiserver v0.34.2 h1:2/yu8suwkmES7IzwlehAovo8dDE07cFRC7KMDb1+MAE=
-+k8s.io/apiserver v0.34.2/go.mod h1:gqJQy2yDOB50R3JUReHSFr+cwJnL8G1dzTA0YLEqAPI=
-+k8s.io/client-go v0.34.2 h1:Co6XiknN+uUZqiddlfAjT68184/37PS4QAzYvQvDR8M=
-+k8s.io/client-go v0.34.2/go.mod h1:2VYDl1XXJsdcAxw7BenFslRQX28Dxz91U9MWKjX97fE=
-+k8s.io/cloud-provider v0.34.2 h1:tNxZ6c+3cJdpNHvurzUdVvKNbB0pDxx3jE1AcZ8pMKA=
-+k8s.io/cloud-provider v0.34.2/go.mod h1:8XqzAplSoVLZzqut82sWHusz6X00C1Djk3BpeKAjfHY=
+-k8s.io/api v0.34.2 h1:fsSUNZhV+bnL6Aqrp6O7lMTy6o5x2C4XLjnh//8SLYY=
+-k8s.io/api v0.34.2/go.mod h1:MMBPaWlED2a8w4RSeanD76f7opUoypY8TFYkSM+3XHw=
+-k8s.io/apiextensions-apiserver v0.34.2 h1:WStKftnGeoKP4AZRz/BaAAEJvYp4mlZGN0UCv+uvsqo=
+-k8s.io/apiextensions-apiserver v0.34.2/go.mod h1:398CJrsgXF1wytdaanynDpJ67zG4Xq7yj91GrmYN2SE=
+-k8s.io/apimachinery v0.34.2 h1:zQ12Uk3eMHPxrsbUJgNF8bTauTVR2WgqJsTmwTE/NW4=
+-k8s.io/apimachinery v0.34.2/go.mod h1:/GwIlEcWuTX9zKIg2mbw0LRFIsXwrfoVxn+ef0X13lw=
+-k8s.io/apiserver v0.34.2 h1:2/yu8suwkmES7IzwlehAovo8dDE07cFRC7KMDb1+MAE=
+-k8s.io/apiserver v0.34.2/go.mod h1:gqJQy2yDOB50R3JUReHSFr+cwJnL8G1dzTA0YLEqAPI=
+-k8s.io/client-go v0.34.2 h1:Co6XiknN+uUZqiddlfAjT68184/37PS4QAzYvQvDR8M=
+-k8s.io/client-go v0.34.2/go.mod h1:2VYDl1XXJsdcAxw7BenFslRQX28Dxz91U9MWKjX97fE=
+-k8s.io/cloud-provider v0.34.2 h1:tNxZ6c+3cJdpNHvurzUdVvKNbB0pDxx3jE1AcZ8pMKA=
+-k8s.io/cloud-provider v0.34.2/go.mod h1:8XqzAplSoVLZzqut82sWHusz6X00C1Djk3BpeKAjfHY=
++k8s.io/api v0.34.9 h1:aVsK5NQL7146suJriGuvpi9giNpwIRSHJ8v5HWakwBo=
++k8s.io/api v0.34.9/go.mod h1:8oYqD5tLKgvBSnkuDbHZTNrk7NTHybkfYjJ6lNjThjQ=
++k8s.io/apiextensions-apiserver v0.34.9 h1:I+VcEFLE/6ueQw3v1OxPslTHD6AiGQJ1M4cUxtYelII=
++k8s.io/apiextensions-apiserver v0.34.9/go.mod h1:z+ylpz3sT+7C+H9jTTfCNR7khCMPDyZVIgvvga79uYc=
++k8s.io/apimachinery v0.34.9 h1:WuRPolTfoEST1TQe9sLcT1QAWLMT0CNE4Eqj29XuUmQ=
++k8s.io/apimachinery v0.34.9/go.mod h1:z7dd12Xd400CXIycE8nmn32xZhApV9zskHs0A5xeU/Q=
++k8s.io/apiserver v0.34.9 h1:isiEW5L0OeGi4oDvyLl+cXzKvqFROH+UqkhIYo3tAsw=
++k8s.io/apiserver v0.34.9/go.mod h1:gYau4EBEsam2O3uLF+D9KP8yHpMYdojPSMNq33FQEVA=
++k8s.io/client-go v0.34.9 h1:HlhSEGPyCFH5rQADW6NPKEziGns6ekgUCPK0OsOGU90=
++k8s.io/client-go v0.34.9/go.mod h1:bI3Sqqmwls2JKFZOQN9h8oLaeibvIA5pqqJAaSJWnrk=
++k8s.io/cloud-provider v0.34.9 h1:4SZJS8CD74w8OIU8dh45s+DPUJZpfHS9JMYI9ISGP4Q=
++k8s.io/cloud-provider v0.34.9/go.mod h1:pjbjdE3zP45y3vkl7alFSCH3UB1vz18VhgMSuDhfGIA=
  k8s.io/cloud-provider-aws v1.27.0 h1:PF8YrH8QcN6JoXB3Xxlaz84SBDYMPunJuCc0cPuCWXA=
  k8s.io/cloud-provider-aws v1.27.0/go.mod h1:9vUb5mnVnReSRDBWcBxB1b0HOeEc472iOPmrnwpN9SA=
  k8s.io/cloud-provider-gcp/providers v0.28.2 h1:I65pFTLNMQSj7YuW3Mg3pZIXmw0naCmF6TGAuz4/sZE=
  k8s.io/cloud-provider-gcp/providers v0.28.2/go.mod h1:P8dxRvvLtX7xUwVUzA/QOqv8taCzBaVsVMnjnpjmYXE=
--k8s.io/code-generator v0.34.1 h1:WpphT26E+j7tEgIUfFr5WfbJrktCGzB3JoJH9149xYc=
--k8s.io/code-generator v0.34.1/go.mod h1:DeWjekbDnJWRwpw3s0Jat87c+e0TgkxoR4ar608yqvg=
--k8s.io/component-base v0.34.1 h1:v7xFgG+ONhytZNFpIz5/kecwD+sUhVE6HU7qQUiRM4A=
--k8s.io/component-base v0.34.1/go.mod h1:mknCpLlTSKHzAQJJnnHVKqjxR7gBeHRv0rPXA7gdtQ0=
--k8s.io/component-helpers v0.34.1 h1:gWhH3CCdwAx5P3oJqZKb4Lg5FYZTWVbdWtOI8n9U4XY=
--k8s.io/component-helpers v0.34.1/go.mod h1:4VgnUH7UA/shuBur+OWoQC0xfb69sy/93ss0ybZqm3c=
--k8s.io/controller-manager v0.34.1 h1:c9Cmun/zF740kmdRQWPGga+4MglT5SlrwsCXDS/KtJI=
--k8s.io/controller-manager v0.34.1/go.mod h1:fGiJDhi3OSzSAB4f40ZkJLAqMQSag9RM+7m5BRhBO3Q=
--k8s.io/cri-api v0.34.1 h1:n2bU++FqqJq0CNjP/5pkOs0nIx7aNpb1Xa053TecQkM=
--k8s.io/cri-api v0.34.1/go.mod h1:4qVUjidMg7/Z9YGZpqIDygbkPWkg3mkS1PvOx/kpHTE=
--k8s.io/cri-client v0.34.1 h1:eq6FcEPDDL379w0WhPnItj2egsMZqOtU7nv1JaJmwP0=
--k8s.io/cri-client v0.34.1/go.mod h1:Dq6mKWV2ugO5tMv4xqVgcQ8vD7csP//e4KkzcFi2Pio=
--k8s.io/csi-translation-lib v0.34.1 h1:8+QMIWBwPGFsqWw9eAvimA2GaHXGgLLYT61I1NzDnXw=
--k8s.io/csi-translation-lib v0.34.1/go.mod h1:QXytPJ1KzYQaiMgVm82ANG+RGAUf276m8l9gFT+R6Xg=
--k8s.io/dynamic-resource-allocation v0.34.1 h1:pd9qhOeAFkn8eOO4BthAiGHQc8pu+N6TK/2Fj+jaPwU=
--k8s.io/dynamic-resource-allocation v0.34.1/go.mod h1:Zlpqyh6EKhTVoQDe5BS31/8oMXGfG6c12ydj3ChXyuw=
-+k8s.io/code-generator v0.34.2 h1:9bG6jTxmsU3HXE5BNYJTC8AZ1D6hVVfkm8yYSkdkGY0=
-+k8s.io/code-generator v0.34.2/go.mod h1:dnDDEd6S/z4uZ+PG1aE58ySCi/lR4+qT3a4DddE4/2I=
-+k8s.io/component-base v0.34.2 h1:HQRqK9x2sSAsd8+R4xxRirlTjowsg6fWCPwWYeSvogQ=
-+k8s.io/component-base v0.34.2/go.mod h1:9xw2FHJavUHBFpiGkZoKuYZ5pdtLKe97DEByaA+hHbM=
-+k8s.io/component-helpers v0.34.2 h1:RIUGDdU+QFzeVKLZ9f05sXTNAtJrRJ3bnbMLrogCrvM=
-+k8s.io/component-helpers v0.34.2/go.mod h1:pLi+GByuRTeFjjcezln8gHL7LcT6HImkwVQ3A2SQaEE=
-+k8s.io/controller-manager v0.34.2 h1:bjdSLh5nnSde5jfRW/rdPDOSYbwUMxs+9JUcbyL6LP8=
-+k8s.io/controller-manager v0.34.2/go.mod h1:sR6wSdANfbdXBTtg2Fwp1ruo/1TJgSilooT6FDxZj4A=
-+k8s.io/cri-api v0.34.2 h1:YtG6Ud62gH+5LYzOWFLeRCFz64SqFFEP5umr/I3PC0Q=
-+k8s.io/cri-api v0.34.2/go.mod h1:4qVUjidMg7/Z9YGZpqIDygbkPWkg3mkS1PvOx/kpHTE=
-+k8s.io/cri-client v0.34.2 h1:uALtvKgk5qu6owHHvyE2QMqYlfZWGeIB/eO5pboKeIY=
-+k8s.io/cri-client v0.34.2/go.mod h1:hwqCdHW06vOPxHB6BQDTMCXkUDxJYMTnlWJxTO0kWtU=
-+k8s.io/csi-translation-lib v0.34.2 h1:xvpxaoDfv0kPaLqUeTKGthr1jqmJgmSHgMnJevYPhY4=
-+k8s.io/csi-translation-lib v0.34.2/go.mod h1:un/6pCiR5QgE6HD16i2AY11+wSFbeVksolat1zntCZY=
-+k8s.io/dynamic-resource-allocation v0.34.2 h1:SjlRGSWl6CZXoJwQNL+Y0wRfdH8PkJ4mHRNK6MMj0bY=
-+k8s.io/dynamic-resource-allocation v0.34.2/go.mod h1:ul6I+gfrCmC+OCuVdN0/iykyB2sPrIqh2WyKQ3RQPCU=
+-k8s.io/code-generator v0.34.2 h1:9bG6jTxmsU3HXE5BNYJTC8AZ1D6hVVfkm8yYSkdkGY0=
+-k8s.io/code-generator v0.34.2/go.mod h1:dnDDEd6S/z4uZ+PG1aE58ySCi/lR4+qT3a4DddE4/2I=
+-k8s.io/component-base v0.34.2 h1:HQRqK9x2sSAsd8+R4xxRirlTjowsg6fWCPwWYeSvogQ=
+-k8s.io/component-base v0.34.2/go.mod h1:9xw2FHJavUHBFpiGkZoKuYZ5pdtLKe97DEByaA+hHbM=
+-k8s.io/component-helpers v0.34.2 h1:RIUGDdU+QFzeVKLZ9f05sXTNAtJrRJ3bnbMLrogCrvM=
+-k8s.io/component-helpers v0.34.2/go.mod h1:pLi+GByuRTeFjjcezln8gHL7LcT6HImkwVQ3A2SQaEE=
+-k8s.io/controller-manager v0.34.2 h1:bjdSLh5nnSde5jfRW/rdPDOSYbwUMxs+9JUcbyL6LP8=
+-k8s.io/controller-manager v0.34.2/go.mod h1:sR6wSdANfbdXBTtg2Fwp1ruo/1TJgSilooT6FDxZj4A=
+-k8s.io/cri-api v0.34.2 h1:YtG6Ud62gH+5LYzOWFLeRCFz64SqFFEP5umr/I3PC0Q=
+-k8s.io/cri-api v0.34.2/go.mod h1:4qVUjidMg7/Z9YGZpqIDygbkPWkg3mkS1PvOx/kpHTE=
+-k8s.io/cri-client v0.34.2 h1:uALtvKgk5qu6owHHvyE2QMqYlfZWGeIB/eO5pboKeIY=
+-k8s.io/cri-client v0.34.2/go.mod h1:hwqCdHW06vOPxHB6BQDTMCXkUDxJYMTnlWJxTO0kWtU=
+-k8s.io/csi-translation-lib v0.34.2 h1:xvpxaoDfv0kPaLqUeTKGthr1jqmJgmSHgMnJevYPhY4=
+-k8s.io/csi-translation-lib v0.34.2/go.mod h1:un/6pCiR5QgE6HD16i2AY11+wSFbeVksolat1zntCZY=
+-k8s.io/dynamic-resource-allocation v0.34.2 h1:SjlRGSWl6CZXoJwQNL+Y0wRfdH8PkJ4mHRNK6MMj0bY=
+-k8s.io/dynamic-resource-allocation v0.34.2/go.mod h1:ul6I+gfrCmC+OCuVdN0/iykyB2sPrIqh2WyKQ3RQPCU=
++k8s.io/code-generator v0.34.9 h1:jXBgPd5FbFoN1J2uA/qISW3uLHRl8wJ9Gx6L4PiJIPk=
++k8s.io/code-generator v0.34.9/go.mod h1:/doiEA33AIV4kFt4NTMCzV8N5Ued8kq1fZMWUUib990=
++k8s.io/component-base v0.34.9 h1:whlBI2kU+CHKHmeByojCzHX/OTU7RjsTirkHbqDDpz0=
++k8s.io/component-base v0.34.9/go.mod h1:4VmwVaGu+f+5jMIkCpmbJ0HHDu4Wu2rlWhISXAETjos=
++k8s.io/component-helpers v0.34.9 h1:vnxTF9GIowfdioxkFfptSQwf2hN8axqCW2AKUdarOfc=
++k8s.io/component-helpers v0.34.9/go.mod h1:z9IVmbGz3TBYt6RtOM86gYX4o3dK9KAFLlE3LtO/zWg=
++k8s.io/controller-manager v0.34.9 h1:7XFUgqC/2qngt881846KTUMVnJ/lobuMT7ayCZdVWO8=
++k8s.io/controller-manager v0.34.9/go.mod h1:UzcjajHcgo8DoaWICoGpYUB9spSF8h+TyfxrCuJUmXY=
++k8s.io/cri-api v0.34.9 h1:kHmQCollTinXsGWpwWsRZuuAPn9541DlYbjaCjwl8J8=
++k8s.io/cri-api v0.34.9/go.mod h1:TcHwArMKizVHhJnVZ2YbtLXFfnrNWVf3lPyky4k3970=
++k8s.io/cri-client v0.34.9 h1:+B0zP/9qg+sOFB8FQn2baQkaY4fouISYeEyd6g2qnjA=
++k8s.io/cri-client v0.34.9/go.mod h1:P81V4c2mcu7GlMrJ8E0pJKHcgQ7YFmni4kYZ5hvTdCQ=
++k8s.io/csi-translation-lib v0.34.9 h1:FNpNAIRhiodXqWKWsmrk8Lz2EwVhYlUyhx4XgDNjAGA=
++k8s.io/csi-translation-lib v0.34.9/go.mod h1:tTLEJn+w/vxD6DhUc8AVtqYBQsR7hZUOQZVvnQJQZXs=
++k8s.io/dynamic-resource-allocation v0.34.9 h1:I+GEBPZ3ijSw3RtXu05VJpAtKmhfvpH8Fe0fu+wRKdg=
++k8s.io/dynamic-resource-allocation v0.34.9/go.mod h1:0iF4OPm7jH1uC1lCLWThUyF1kVaC0S2yCqN+rHUhLyc=
  k8s.io/gengo/v2 v2.0.0-20250604051438-85fd79dbfd9f h1:SLb+kxmzfA87x4E4brQzB33VBbT2+x7Zq9ROIHmGn9Q=
  k8s.io/gengo/v2 v2.0.0-20250604051438-85fd79dbfd9f/go.mod h1:EJykeLsmFC60UQbYJezXkEsG2FLrt0GPNkU5iK5GWxU=
  k8s.io/klog/v2 v2.130.1 h1:n9Xl7H1Xvksem4KFG4PYbdQCQxqc/tTUyrgXaOhHSzk=
  k8s.io/klog/v2 v2.130.1/go.mod h1:3Jpz1GvMt720eyJH1ckRHK1EDfpxISzJ7I9OYgaDtPE=
--k8s.io/kms v0.34.1 h1:iCFOvewDPzWM9fMTfyIPO+4MeuZ0tcZbugxLNSHFG4w=
--k8s.io/kms v0.34.1/go.mod h1:s1CFkLG7w9eaTYvctOxosx88fl4spqmixnNpys0JAtM=
-+k8s.io/kms v0.34.2 h1:91rj4MDZLyIT9KxG8J5/CcMH666Z88CF/xJQeuPfJc8=
-+k8s.io/kms v0.34.2/go.mod h1:s1CFkLG7w9eaTYvctOxosx88fl4spqmixnNpys0JAtM=
+-k8s.io/kms v0.34.2 h1:91rj4MDZLyIT9KxG8J5/CcMH666Z88CF/xJQeuPfJc8=
+-k8s.io/kms v0.34.2/go.mod h1:s1CFkLG7w9eaTYvctOxosx88fl4spqmixnNpys0JAtM=
++k8s.io/kms v0.34.9 h1:lZGoqvmTxESbQM14PBveZt3gkgSOGDf56u06HrhS1O0=
++k8s.io/kms v0.34.9/go.mod h1:sBByaFjIDNm8oPQXjREzXISZSx60On//fhvnAVhuL5g=
  k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b h1:MloQ9/bdJyIu9lb1PzujOPolHyvO06MXG5TUIj2mNAA=
  k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b/go.mod h1:UZ2yyWbFTpuhSbFhv24aGNOdoRdJZgsIObGBUaYVsts=
--k8s.io/kube-scheduler v0.34.1 h1:S5td6VZwC3lCqERXclerDXhJ26zYc6JroY0s03+PqJ8=
--k8s.io/kube-scheduler v0.34.1/go.mod h1:UiOkod/w+HKoGut9mz9ie4s4KcI82vmLFdq1iIgsmRs=
--k8s.io/kubectl v0.34.1 h1:1qP1oqT5Xc93K+H8J7ecpBjaz511gan89KO9Vbsh/OI=
--k8s.io/kubectl v0.34.1/go.mod h1:JRYlhJpGPyk3dEmJ+BuBiOB9/dAvnrALJEiY/C5qa6A=
--k8s.io/kubelet v0.34.1 h1:doAaTA9/Yfzbdq/u/LveZeONp96CwX9giW6b+oHn4m4=
--k8s.io/kubelet v0.34.1/go.mod h1:PtV3Ese8iOM19gSooFoQT9iyRisbmJdAPuDImuccbbA=
--k8s.io/kubernetes v1.34.1 h1:F3p8dtpv+i8zQoebZeK5zBqM1g9x1aIdnA5vthvcuUk=
--k8s.io/kubernetes v1.34.1/go.mod h1:iu+FhII+Oc/1gGWLJcer6wpyih441aNFHl7Pvm8yPto=
--k8s.io/mount-utils v0.34.1 h1:zMBEFav8Rxwm54S8srzy5FxAc4KQ3X4ZcjnqTCzHmZk=
--k8s.io/mount-utils v0.34.1/go.mod h1:MIjjYlqJ0ziYQg0MO09kc9S96GIcMkhF/ay9MncF0GA=
-+k8s.io/kube-scheduler v0.34.2 h1:TtLcaXeIpkqgzMr2ch7Ap8Cluq4M182XUDRlnOPDdoc=
-+k8s.io/kube-scheduler v0.34.2/go.mod h1:PTn4QYiSet8/00VQ2qGO/HWdo5iNJlVRCXz/7R3Ut5I=
-+k8s.io/kubectl v0.34.2 h1:+fWGrVlDONMUmmQLDaGkQ9i91oszjjRAa94cr37hzqA=
-+k8s.io/kubectl v0.34.2/go.mod h1:X2KTOdtZZNrTWmUD4oHApJ836pevSl+zvC5sI6oO2YQ=
-+k8s.io/kubelet v0.34.2 h1:Dl+1uh7xwJr70r+SHKyIpvu6XvzuoPu0uDIC4cqgJUs=
-+k8s.io/kubelet v0.34.2/go.mod h1:RfwR03iuKeVV7Z1qD9XKH98c3tlPImJpQ3qHIW40htM=
-+k8s.io/kubernetes v1.34.2 h1:WQdDvYJazkmkwSncgNwGvVtaCt4TYXIU3wSMRgvp3MI=
-+k8s.io/kubernetes v1.34.2/go.mod h1:m6pZk6a179pRo2wsTiCPORJ86iOEQmfIzUvtyEF8BwA=
-+k8s.io/mount-utils v0.34.2 h1:DiesOtAiYccJWKGRlJZhRkjCHvpQ3YmSlQp+zkkvf9Y=
-+k8s.io/mount-utils v0.34.2/go.mod h1:MIjjYlqJ0ziYQg0MO09kc9S96GIcMkhF/ay9MncF0GA=
+-k8s.io/kube-scheduler v0.34.2 h1:TtLcaXeIpkqgzMr2ch7Ap8Cluq4M182XUDRlnOPDdoc=
+-k8s.io/kube-scheduler v0.34.2/go.mod h1:PTn4QYiSet8/00VQ2qGO/HWdo5iNJlVRCXz/7R3Ut5I=
+-k8s.io/kubectl v0.34.2 h1:+fWGrVlDONMUmmQLDaGkQ9i91oszjjRAa94cr37hzqA=
+-k8s.io/kubectl v0.34.2/go.mod h1:X2KTOdtZZNrTWmUD4oHApJ836pevSl+zvC5sI6oO2YQ=
+-k8s.io/kubelet v0.34.2 h1:Dl+1uh7xwJr70r+SHKyIpvu6XvzuoPu0uDIC4cqgJUs=
+-k8s.io/kubelet v0.34.2/go.mod h1:RfwR03iuKeVV7Z1qD9XKH98c3tlPImJpQ3qHIW40htM=
+-k8s.io/kubernetes v1.34.2 h1:WQdDvYJazkmkwSncgNwGvVtaCt4TYXIU3wSMRgvp3MI=
+-k8s.io/kubernetes v1.34.2/go.mod h1:m6pZk6a179pRo2wsTiCPORJ86iOEQmfIzUvtyEF8BwA=
+-k8s.io/mount-utils v0.34.2 h1:DiesOtAiYccJWKGRlJZhRkjCHvpQ3YmSlQp+zkkvf9Y=
+-k8s.io/mount-utils v0.34.2/go.mod h1:MIjjYlqJ0ziYQg0MO09kc9S96GIcMkhF/ay9MncF0GA=
++k8s.io/kube-scheduler v0.34.9 h1:XmMog9CcudBrEgrltvScak5Tk2kd5yYRlsVgdBnW5ok=
++k8s.io/kube-scheduler v0.34.9/go.mod h1:aAUgE00lVWSzG+3fgb4Vv6IgN55SQ+KI0pUFXGjK/4M=
++k8s.io/kubectl v0.34.9 h1:nGNmsw1m9Q1lop2HtMk1jzM+JVNlQLj6gZr82vT1AmQ=
++k8s.io/kubectl v0.34.9/go.mod h1:8FvYj6BPfeo1YPn6rvPs0kOTFBzRne89rG8LnyWPIlY=
++k8s.io/kubelet v0.34.9 h1:gL2tDk5Kdv6ghUoyIYJZiZuZYTwsz5YhqqookZfcbQk=
++k8s.io/kubelet v0.34.9/go.mod h1:74mk09f1XfTUsw6Zv97IiBQlHFlFzw3UmNWk8+MZkbg=
++k8s.io/kubernetes v1.34.9 h1:qj8W8mftZkTEBMdNjGBp+pKGbvpewrnCiuDp2l4DxtU=
++k8s.io/kubernetes v1.34.9/go.mod h1:ECvwZXn8HlXIVDdB4RwZxboj5YhwMZ+COzc6yRMFMX4=
++k8s.io/mount-utils v0.34.9 h1:PignUu11sdwMPpqqYSYi3GDuP+PtI1wt7s5KJcLPAt4=
++k8s.io/mount-utils v0.34.9/go.mod h1:DY1x4o9KaP9fXkHeWCOFWmhRdvKD8nzJ7K57xE5T95c=
  k8s.io/utils v0.0.0-20250604170112-4c0f3b243397 h1:hwvWFiBzdWw1FhfY1FooPn3kzWuJ8tmbZBHi4zVsl1Y=
  k8s.io/utils v0.0.0-20250604170112-4c0f3b243397/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
  sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 h1:jpcvIRr3GLoUoEKRkHKSmGjxb6lWwrBlJsXc+eUYQHM=

--- a/modules/040-node-manager/images/cluster-autoscaler/patches/1.34/001-go-mod.patch
+++ b/modules/040-node-manager/images/cluster-autoscaler/patches/1.34/001-go-mod.patch
@@ -1,5 +1,5 @@
 diff --git a/cluster-autoscaler/apis/go.mod b/cluster-autoscaler/apis/go.mod
-index 24df7a83d..04c47fa8b 100644
+index 2f2e77110..1cd7b172a 100644
 --- a/cluster-autoscaler/apis/go.mod
 +++ b/cluster-autoscaler/apis/go.mod
 @@ -1,6 +1,6 @@
@@ -35,7 +35,7 @@ index 24df7a83d..04c47fa8b 100644
  	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
  	gopkg.in/inf.v0 v0.9.1 // indirect
 diff --git a/cluster-autoscaler/apis/go.sum b/cluster-autoscaler/apis/go.sum
-index 1a68b6714..cecd57ae2 100644
+index 41f845ea6..2251631fb 100644
 --- a/cluster-autoscaler/apis/go.sum
 +++ b/cluster-autoscaler/apis/go.sum
 @@ -91,40 +91,44 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
@@ -98,7 +98,7 @@ index 1a68b6714..cecd57ae2 100644
  golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
  golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 diff --git a/cluster-autoscaler/go.mod b/cluster-autoscaler/go.mod
-index 3487260b3..6a5a58825 100644
+index 5740301a7..7288eb239 100644
 --- a/cluster-autoscaler/go.mod
 +++ b/cluster-autoscaler/go.mod
 @@ -1,6 +1,6 @@
@@ -109,17 +109,13 @@ index 3487260b3..6a5a58825 100644
  
  require (
  	cloud.google.com/go/compute/metadata v0.6.0
-@@ -29,33 +29,33 @@ require (
- 	github.com/pkg/errors v0.9.1
- 	github.com/prometheus/client_golang v1.22.0
- 	github.com/spf13/pflag v1.0.6
--	github.com/stretchr/testify v1.10.0
-+	github.com/stretchr/testify v1.11.1
+@@ -37,30 +37,30 @@ require (
+ 	github.com/stretchr/testify v1.10.0
  	github.com/vburenin/ifacemaker v1.2.1
  	go.uber.org/mock v0.4.0
 -	golang.org/x/crypto v0.36.0
 -	golang.org/x/net v0.38.0
-+	golang.org/x/crypto v0.52.0
++	golang.org/x/crypto v0.51.0
 +	golang.org/x/net v0.55.0
  	golang.org/x/oauth2 v0.27.0
 -	golang.org/x/sys v0.31.0
@@ -129,75 +125,40 @@ index 3487260b3..6a5a58825 100644
  	google.golang.org/protobuf v1.36.5
  	gopkg.in/gcfg.v1 v1.2.3
  	gopkg.in/yaml.v2 v2.4.0
--	k8s.io/api v0.34.3
--	k8s.io/apimachinery v0.34.3
--	k8s.io/apiserver v0.34.3
-+	k8s.io/api v0.34.9
-+	k8s.io/apimachinery v0.34.9
-+	k8s.io/apiserver v0.34.9
+-	k8s.io/api v0.34.1
+-	k8s.io/apimachinery v0.34.1
+-	k8s.io/apiserver v0.34.1
++	k8s.io/api v0.34.2
++	k8s.io/apimachinery v0.34.2
++	k8s.io/apiserver v0.34.2
  	k8s.io/autoscaler/cluster-autoscaler/apis v0.0.0-20240627115740-d52e4b9665d7
--	k8s.io/client-go v0.34.3
-+	k8s.io/client-go v0.34.9
- 	k8s.io/cloud-provider v0.30.1
+-	k8s.io/client-go v0.34.1
+-	k8s.io/cloud-provider v0.30.1
++	k8s.io/client-go v0.34.2
++	k8s.io/cloud-provider v0.34.2
  	k8s.io/cloud-provider-aws v1.27.0
  	k8s.io/cloud-provider-gcp/providers v0.28.2
--	k8s.io/component-base v0.34.3
--	k8s.io/component-helpers v0.34.3
-+	k8s.io/component-base v0.34.9
-+	k8s.io/component-helpers v0.34.9
- 	k8s.io/dynamic-resource-allocation v0.0.0
+-	k8s.io/component-base v0.34.1
+-	k8s.io/component-helpers v0.34.1
+-	k8s.io/dynamic-resource-allocation v0.0.0
++	k8s.io/component-base v0.34.2
++	k8s.io/component-helpers v0.34.2
++	k8s.io/dynamic-resource-allocation v0.34.2
  	k8s.io/klog/v2 v2.130.1
- 	k8s.io/kube-scheduler v0.0.0
--	k8s.io/kubelet v0.34.3
--	k8s.io/kubernetes v1.34.3
-+	k8s.io/kubelet v0.34.9
-+	k8s.io/kubernetes v1.34.9
+-	k8s.io/kube-scheduler v0.0.0
+-	k8s.io/kubelet v0.34.1
+-	k8s.io/kubernetes v1.34.1
++	k8s.io/kube-scheduler v0.34.2
++	k8s.io/kubelet v0.34.2
++	k8s.io/kubernetes v1.34.2
  	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397
  	sigs.k8s.io/cloud-provider-azure v1.29.4
  	sigs.k8s.io/cloud-provider-azure/pkg/azclient v0.0.13
-@@ -115,7 +115,7 @@ require (
- 	github.com/felixge/httpsnoop v1.0.4 // indirect
- 	github.com/fsnotify/fsnotify v1.9.0 // indirect
- 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
--	github.com/go-logr/logr v1.4.2 // indirect
-+	github.com/go-logr/logr v1.4.3 // indirect
- 	github.com/go-logr/stdr v1.2.2 // indirect
- 	github.com/go-logr/zapr v1.3.0 // indirect
- 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
-@@ -147,7 +147,7 @@ require (
- 	github.com/mailru/easyjson v0.7.7 // indirect
- 	github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible // indirect
- 	github.com/mitchellh/go-homedir v1.1.0 // indirect
--	github.com/moby/spdystream v0.5.0 // indirect
-+	github.com/moby/spdystream v0.5.1 // indirect
- 	github.com/moby/sys/mountinfo v0.7.2 // indirect
- 	github.com/moby/sys/userns v0.1.0 // indirect
- 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-@@ -176,28 +176,29 @@ require (
- 	go.etcd.io/etcd/client/pkg/v3 v3.6.4 // indirect
- 	go.etcd.io/etcd/client/v3 v3.6.4 // indirect
- 	go.opencensus.io v0.24.0 // indirect
--	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-+	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
- 	go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful v0.44.0 // indirect
- 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.60.0 // indirect
- 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.58.0 // indirect
--	go.opentelemetry.io/otel v1.35.0 // indirect
-+	go.opentelemetry.io/otel v1.41.0 // indirect
- 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.34.0 // indirect
- 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.34.0 // indirect
--	go.opentelemetry.io/otel/metric v1.35.0 // indirect
-+	go.opentelemetry.io/otel/metric v1.41.0 // indirect
- 	go.opentelemetry.io/otel/sdk v1.34.0 // indirect
--	go.opentelemetry.io/otel/trace v1.35.0 // indirect
-+	go.opentelemetry.io/otel/trace v1.41.0 // indirect
- 	go.opentelemetry.io/proto/otlp v1.5.0 // indirect
- 	go.uber.org/multierr v1.11.0 // indirect
- 	go.uber.org/zap v1.27.0 // indirect
+@@ -194,12 +194,13 @@ require (
  	go.yaml.in/yaml/v2 v2.4.2 // indirect
  	go.yaml.in/yaml/v3 v3.0.4 // indirect
  	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
--	golang.org/x/mod v0.21.0 // indirect
+-	golang.org/x/mod v0.23.0 // indirect
 -	golang.org/x/sync v0.12.0 // indirect
 -	golang.org/x/term v0.30.0 // indirect
 -	golang.org/x/text v0.23.0 // indirect
@@ -206,238 +167,67 @@ index 3487260b3..6a5a58825 100644
 +	golang.org/x/term v0.43.0 // indirect
 +	golang.org/x/text v0.37.0 // indirect
  	golang.org/x/time v0.9.0 // indirect
--	golang.org/x/tools v0.26.0 // indirect
+-	golang.org/x/tools v0.30.0 // indirect
 +	golang.org/x/tools v0.44.0 // indirect
-+	golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated // indirect
++	golang.org/x/tools/go/expect v0.1.1-deprecated // indirect
  	google.golang.org/genproto/googleapis/api v0.0.0-20250303144028-a0af3efb3deb // indirect
  	google.golang.org/genproto/googleapis/rpc v0.0.0-20250303144028-a0af3efb3deb // indirect
  	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
-@@ -206,13 +207,13 @@ require (
+@@ -207,17 +208,17 @@ require (
+ 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
  	gopkg.in/warnings.v0 v0.1.2 // indirect
  	gopkg.in/yaml.v3 v3.0.1 // indirect
- 	k8s.io/apiextensions-apiserver v0.0.0 // indirect
--	k8s.io/code-generator v0.34.3 // indirect
--	k8s.io/controller-manager v0.34.3 // indirect
--	k8s.io/cri-api v0.34.3 // indirect
-+	k8s.io/code-generator v0.34.9 // indirect
-+	k8s.io/controller-manager v0.34.9 // indirect
-+	k8s.io/cri-api v0.34.9 // indirect
- 	k8s.io/cri-client v0.0.0 // indirect
- 	k8s.io/csi-translation-lib v0.27.0 // indirect
+-	k8s.io/apiextensions-apiserver v0.31.0 // indirect
+-	k8s.io/code-generator v0.34.1 // indirect
+-	k8s.io/controller-manager v0.34.1 // indirect
+-	k8s.io/cri-api v0.34.1 // indirect
+-	k8s.io/cri-client v0.0.0 // indirect
+-	k8s.io/csi-translation-lib v0.27.0 // indirect
++	k8s.io/apiextensions-apiserver v0.34.2 // indirect
++	k8s.io/code-generator v0.34.2 // indirect
++	k8s.io/controller-manager v0.34.2 // indirect
++	k8s.io/cri-api v0.34.2 // indirect
++	k8s.io/cri-client v0.34.2 // indirect
++	k8s.io/csi-translation-lib v0.34.2 // indirect
  	k8s.io/gengo/v2 v2.0.0-20250604051438-85fd79dbfd9f // indirect
--	k8s.io/kms v0.34.3 // indirect
-+	k8s.io/kms v0.34.9 // indirect
+-	k8s.io/kms v0.34.1 // indirect
++	k8s.io/kms v0.34.2 // indirect
  	k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b // indirect
- 	k8s.io/kubectl v0.28.0 // indirect
- 	k8s.io/mount-utils v0.26.0-alpha.0 // indirect
-@@ -223,66 +224,66 @@ require (
- 	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
- )
- 
--replace k8s.io/api => k8s.io/api v0.34.3
-+replace k8s.io/api => k8s.io/api v0.34.9
- 
--replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.34.3
-+replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.34.9
- 
--replace k8s.io/apimachinery => k8s.io/apimachinery v0.34.3
-+replace k8s.io/apimachinery => k8s.io/apimachinery v0.34.9
- 
--replace k8s.io/apiserver => k8s.io/apiserver v0.34.3
-+replace k8s.io/apiserver => k8s.io/apiserver v0.34.9
- 
--replace k8s.io/cli-runtime => k8s.io/cli-runtime v0.34.3
-+replace k8s.io/cli-runtime => k8s.io/cli-runtime v0.34.9
- 
--replace k8s.io/client-go => k8s.io/client-go v0.34.3
-+replace k8s.io/client-go => k8s.io/client-go v0.34.9
- 
--replace k8s.io/cloud-provider => k8s.io/cloud-provider v0.34.3
-+replace k8s.io/cloud-provider => k8s.io/cloud-provider v0.34.9
- 
--replace k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.34.3
-+replace k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.34.9
- 
--replace k8s.io/code-generator => k8s.io/code-generator v0.34.3
-+replace k8s.io/code-generator => k8s.io/code-generator v0.34.9
- 
--replace k8s.io/component-base => k8s.io/component-base v0.34.3
-+replace k8s.io/component-base => k8s.io/component-base v0.34.9
- 
--replace k8s.io/component-helpers => k8s.io/component-helpers v0.34.3
-+replace k8s.io/component-helpers => k8s.io/component-helpers v0.34.9
- 
--replace k8s.io/controller-manager => k8s.io/controller-manager v0.34.3
-+replace k8s.io/controller-manager => k8s.io/controller-manager v0.34.9
- 
--replace k8s.io/cri-api => k8s.io/cri-api v0.34.3
-+replace k8s.io/cri-api => k8s.io/cri-api v0.34.9
- 
--replace k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.34.3
-+replace k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.34.9
- 
--replace k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.34.3
-+replace k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.34.9
- 
--replace k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.34.3
-+replace k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.34.9
- 
--replace k8s.io/kube-proxy => k8s.io/kube-proxy v0.34.3
-+replace k8s.io/kube-proxy => k8s.io/kube-proxy v0.34.9
- 
--replace k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.34.3
-+replace k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.34.9
- 
--replace k8s.io/kubectl => k8s.io/kubectl v0.34.3
-+replace k8s.io/kubectl => k8s.io/kubectl v0.34.9
- 
--replace k8s.io/kubelet => k8s.io/kubelet v0.34.3
-+replace k8s.io/kubelet => k8s.io/kubelet v0.34.9
- 
--replace k8s.io/metrics => k8s.io/metrics v0.34.3
-+replace k8s.io/metrics => k8s.io/metrics v0.34.9
- 
--replace k8s.io/mount-utils => k8s.io/mount-utils v0.34.3
-+replace k8s.io/mount-utils => k8s.io/mount-utils v0.34.9
- 
--replace k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.34.3
-+replace k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.34.9
- 
--replace k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.34.3
-+replace k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.34.9
- 
--replace k8s.io/sample-controller => k8s.io/sample-controller v0.34.3
-+replace k8s.io/sample-controller => k8s.io/sample-controller v0.34.9
- 
--replace k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.34.3
-+replace k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.34.9
- 
--replace k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.34.3
-+replace k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.34.9
- 
--replace k8s.io/kms => k8s.io/kms v0.34.3
-+replace k8s.io/kms => k8s.io/kms v0.34.9
- 
--replace k8s.io/endpointslice => k8s.io/endpointslice v0.34.3
-+replace k8s.io/endpointslice => k8s.io/endpointslice v0.34.9
- 
- replace k8s.io/autoscaler/cluster-autoscaler/apis => ./apis
- 
--replace k8s.io/cri-client => k8s.io/cri-client v0.34.3
-+replace k8s.io/cri-client => k8s.io/cri-client v0.34.9
- 
--replace k8s.io/externaljwt => k8s.io/externaljwt v0.34.3
-+replace k8s.io/externaljwt => k8s.io/externaljwt v0.34.9
+-	k8s.io/kubectl v0.28.0 // indirect
+-	k8s.io/mount-utils v0.26.0-alpha.0 // indirect
++	k8s.io/kubectl v0.34.2 // indirect
++	k8s.io/mount-utils v0.34.2 // indirect
+ 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 // indirect
+ 	sigs.k8s.io/cloud-provider-azure/pkg/azclient/configloader v0.0.4 // indirect
+ 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 diff --git a/cluster-autoscaler/go.sum b/cluster-autoscaler/go.sum
-index 9fff1ce05..e9ff9aa59 100644
+index 289380100..38b7a8f5f 100644
 --- a/cluster-autoscaler/go.sum
 +++ b/cluster-autoscaler/go.sum
-@@ -165,8 +165,8 @@ github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8
- github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
- github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
- github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
--github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
--github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
-+github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
-+github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
- github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
- github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
- github.com/go-logr/zapr v1.3.0 h1:XGdV8XW8zdwFiwOA2Dryh1gj2KRQyOOoNmBy4EplIcQ=
-@@ -296,8 +296,8 @@ github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG
- github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
- github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=
- github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
--github.com/moby/spdystream v0.5.0 h1:7r0J1Si3QO/kjRitvSLVVFUjxMEb/YLj6S9FF62JBCU=
--github.com/moby/spdystream v0.5.0/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
-+github.com/moby/spdystream v0.5.1 h1:9sNYeYZUcci9R6/w7KDaFWEWeV4LStVG78Mpyq/Zm/Y=
-+github.com/moby/spdystream v0.5.1/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
- github.com/moby/sys/mountinfo v0.7.2 h1:1shs6aH5s4o5H2zQLn796ADW1wMrIwHsyJ2v9KouLrg=
- github.com/moby/sys/mountinfo v0.7.2/go.mod h1:1YOa8w8Ih7uW0wALDUgT1dTTSBrZ+HiBLGws92L2RU4=
- github.com/moby/sys/userns v0.1.0 h1:tVLXkFOxVu9A64/yh59slHVv9ahO9UIev4JZusOLG/g=
-@@ -344,8 +344,8 @@ github.com/prometheus/common v0.62.0 h1:xasJaQlnWAeyHdUBeGjXmutelfJHWMRr+Fg4QszZ
- github.com/prometheus/common v0.62.0/go.mod h1:vyBcEuLSvWos9B1+CyL7JZ2up+uFzXhkqml0W5zIY1I=
- github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
- github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
--github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
--github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
-+github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
-+github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
- github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
- github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
- github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
-@@ -368,8 +368,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
- github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
- github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
- github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
--github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
--github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
-+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
- github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75 h1:6fotK7otjonDflCTK0BCfls4SPy3NcCVb5dqqmbRknE=
- github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75/go.mod h1:KO6IkyS8Y3j8OdNO85qEYBsRPuteD+YciPomcXdrMnk=
- github.com/vburenin/ifacemaker v1.2.1 h1:3Vq8B/bfBgjWTkv+jDg4dVL1KHt3k1K4lO7XRxYA2sk=
-@@ -398,8 +398,8 @@ go.etcd.io/raft/v3 v3.6.0 h1:5NtvbDVYpnfZWcIHgGRk9DyzkBIXOi8j+DDp1IcnUWQ=
- go.etcd.io/raft/v3 v3.6.0/go.mod h1:nLvLevg6+xrVtHUmVaTcTz603gQPHfh7kUAwV6YpfGo=
- go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
- go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
--go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
--go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
-+go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
-+go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
- go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful v0.44.0 h1:KemlMZlVwBSEGaO91WKgp41BBFsnWqqj9sKRwmOqC40=
- go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful v0.44.0/go.mod h1:uq8DrRaen3suIWTpdR/JNHCGpurSvMv9D5Nr5CU5TXc=
- go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.60.0 h1:x7wzEgXfnzJcHDwStJT+mxOz4etr2EcexjqhBvmoakw=
-@@ -408,20 +408,20 @@ go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.58.0 h1:yd02MEj
- go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.58.0/go.mod h1:umTcuxiv1n/s/S6/c2AT/g2CQ7u5C59sHDNmfSwgz7Q=
- go.opentelemetry.io/contrib/propagators/b3 v1.19.0 h1:ulz44cpm6V5oAeg5Aw9HyqGFMS6XM7untlMEhD7YzzA=
- go.opentelemetry.io/contrib/propagators/b3 v1.19.0/go.mod h1:OzCmE2IVS+asTI+odXQstRGVfXQ4bXv9nMBRK0nNyqQ=
--go.opentelemetry.io/otel v1.35.0 h1:xKWKPxrxB6OtMCbmMY021CqC45J+3Onta9MqjhnusiQ=
--go.opentelemetry.io/otel v1.35.0/go.mod h1:UEqy8Zp11hpkUrL73gSlELM0DupHoiq72dR+Zqel/+Y=
-+go.opentelemetry.io/otel v1.41.0 h1:YlEwVsGAlCvczDILpUXpIpPSL/VPugt7zHThEMLce1c=
-+go.opentelemetry.io/otel v1.41.0/go.mod h1:Yt4UwgEKeT05QbLwbyHXEwhnjxNO6D8L5PQP51/46dE=
- go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.34.0 h1:OeNbIYk/2C15ckl7glBlOBp5+WlYsOElzTNmiPW/x60=
- go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.34.0/go.mod h1:7Bept48yIeqxP2OZ9/AqIpYS94h2or0aB4FypJTc8ZM=
- go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.34.0 h1:tgJ0uaNS4c98WRNUEx5U3aDlrDOI5Rs+1Vifcw4DJ8U=
- go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.34.0/go.mod h1:U7HYyW0zt/a9x5J1Kjs+r1f/d4ZHnYFclhYY2+YbeoE=
--go.opentelemetry.io/otel/metric v1.35.0 h1:0znxYu2SNyuMSQT4Y9WDWej0VpcsxkuklLa4/siN90M=
--go.opentelemetry.io/otel/metric v1.35.0/go.mod h1:nKVFgxBZ2fReX6IlyW28MgZojkoAkJGaE8CpgeAU3oE=
-+go.opentelemetry.io/otel/metric v1.41.0 h1:rFnDcs4gRzBcsO9tS8LCpgR0dxg4aaxWlJxCno7JlTQ=
-+go.opentelemetry.io/otel/metric v1.41.0/go.mod h1:xPvCwd9pU0VN8tPZYzDZV/BMj9CM9vs00GuBjeKhJps=
- go.opentelemetry.io/otel/sdk v1.34.0 h1:95zS4k/2GOy069d321O8jWgYsW3MzVV+KuSPKp7Wr1A=
- go.opentelemetry.io/otel/sdk v1.34.0/go.mod h1:0e/pNiaMAqaykJGKbi+tSjWfNNHMTxoC9qANsCzbyxU=
- go.opentelemetry.io/otel/sdk/metric v1.34.0 h1:5CeK9ujjbFVL5c1PhLuStg1wxA7vQv7ce1EK0Gyvahk=
- go.opentelemetry.io/otel/sdk/metric v1.34.0/go.mod h1:jQ/r8Ze28zRKoNRdkjCZxfs6YvBTG1+YIqyFVFYec5w=
--go.opentelemetry.io/otel/trace v1.35.0 h1:dPpEfJu1sDIqruz7BHFG3c7528f6ddfSWfFDVt/xgMs=
--go.opentelemetry.io/otel/trace v1.35.0/go.mod h1:WUk7DtFp1Aw2MkvqGdwiXYDZZNvA/1J8o6xRXLrIkyc=
-+go.opentelemetry.io/otel/trace v1.41.0 h1:Vbk2co6bhj8L59ZJ6/xFTskY+tGAbOnCtQGVVa9TIN0=
-+go.opentelemetry.io/otel/trace v1.41.0/go.mod h1:U1NU4ULCoxeDKc09yCWdWe+3QoyweJcISEVa1RBzOis=
- go.opentelemetry.io/proto/otlp v1.5.0 h1:xJvq7gMzB31/d406fB8U5CBdyQGw4P399D1aQWU/3i4=
- go.opentelemetry.io/proto/otlp v1.5.0/go.mod h1:keN8WnHxOy8PG0rQZjJJ5A2ebUoafqWp0eVQ4yIXvJ4=
- go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
-@@ -443,8 +443,8 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
+@@ -449,8 +449,8 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
  golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
  golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58=
  golang.org/x/crypto v0.17.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
 -golang.org/x/crypto v0.36.0 h1:AnAEvhDddvBdpY+uR+MyHmuZzzNqXSe/GvuDeob5L34=
 -golang.org/x/crypto v0.36.0/go.mod h1:Y4J0ReaxCR1IMaabaSMugxJES1EpwhBHhv2bDHklZvc=
-+golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
-+golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
++golang.org/x/crypto v0.51.0 h1:IBPXwPfKxY7cWQZ38ZCIRPI50YLeevDLlLnyC5wRGTI=
++golang.org/x/crypto v0.51.0/go.mod h1:8AdwkbraGNABw2kOX6YFPs3WM22XqI4EXEd8g+x7Oc8=
  golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
  golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 h1:2dVuKD2vS7b0QIHQbpyTISPd0LeHDbnYEryqj5Q1ug8=
  golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56/go.mod h1:M4RDyNAINzryxdtnbRXRL/OHtkFuWGRjvuhBJpk2IlY=
-@@ -456,8 +456,8 @@ golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+@@ -462,8 +462,8 @@ golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
  golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
  golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
  golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
--golang.org/x/mod v0.21.0 h1:vvrHzRwRfVKSiLrG+d4FMl/Qi4ukBCE6kZlTUkDYRT0=
--golang.org/x/mod v0.21.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
+-golang.org/x/mod v0.23.0 h1:Zb7khfcRGKk+kqfxFaP5tZqCnDZMjC5VtUBs87Hr6QM=
+-golang.org/x/mod v0.23.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
 +golang.org/x/mod v0.35.0 h1:Ww1D637e6Pg+Zb2KrWfHQUnH2dQRLBQyAtpr/haaJeM=
 +golang.org/x/mod v0.35.0/go.mod h1:+GwiRhIInF8wPm+4AoT6L0FA1QWAad3OMdTRx4tFYlU=
  golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
  golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
  golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
-@@ -475,8 +475,8 @@ golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug
- golang.org/x/net v0.1.0/go.mod h1:Cx3nUiGt4eDBEyega/BKRp+/AlGL8hYe7U9odMt2Cco=
+@@ -480,8 +480,8 @@ golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qx
+ golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
  golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
  golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
 -golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
@@ -447,7 +237,7 @@ index 9fff1ce05..e9ff9aa59 100644
  golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
  golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
  golang.org/x/oauth2 v0.27.0 h1:da9Vo7/tDv5RH/7nZDz1eMGS/q1Vv1N/7FCrBhI9I3M=
-@@ -490,8 +490,8 @@ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJ
+@@ -495,8 +495,8 @@ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJ
  golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
  golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
  golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -458,7 +248,7 @@ index 9fff1ce05..e9ff9aa59 100644
  golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
  golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
  golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-@@ -508,16 +508,16 @@ golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+@@ -513,15 +513,15 @@ golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
  golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
  golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
  golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
@@ -468,7 +258,6 @@ index 9fff1ce05..e9ff9aa59 100644
 +golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
  golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
  golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
- golang.org/x/term v0.1.0/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
  golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=
  golang.org/x/term v0.8.0/go.mod h1:xPskH00ivmX89bAKVGSKKtLOWNx2+17Eiy94tnKShWo=
  golang.org/x/term v0.15.0/go.mod h1:BDl952bC7+uMoWR75FIrCDx79TPU9oHkTZ9yRbYOrX0=
@@ -479,7 +268,7 @@ index 9fff1ce05..e9ff9aa59 100644
  golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
  golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
  golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-@@ -526,8 +526,8 @@ golang.org/x/text v0.4.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
+@@ -529,8 +529,8 @@ golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
  golang.org/x/text v0.7.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
  golang.org/x/text v0.9.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=
  golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
@@ -490,115 +279,29 @@ index 9fff1ce05..e9ff9aa59 100644
  golang.org/x/time v0.9.0 h1:EsRrnYcQiGH+5FfbgvV4AP7qEZstoyrHB0DzarOQ4ZY=
  golang.org/x/time v0.9.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
  golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
-@@ -541,8 +541,12 @@ golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4f
+@@ -544,8 +544,12 @@ golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4f
  golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
  golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
  golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
--golang.org/x/tools v0.26.0 h1:v/60pFQmzmT9ExmjDv2gGIfi3OqfKoEP6I5+umXlbnQ=
--golang.org/x/tools v0.26.0/go.mod h1:TPVVj70c7JJ3WCazhD8OdXcZg/og+b9+tH/KxylGwH0=
+-golang.org/x/tools v0.30.0 h1:BgcpHewrV5AUp2G9MebG4XPFI1E2W41zU1SaqVA9vJY=
+-golang.org/x/tools v0.30.0/go.mod h1:c347cR/OJfw5TI+GfX7RUPNMdDRRbjvYTS0jPyvsVtY=
 +golang.org/x/tools v0.44.0 h1:UP4ajHPIcuMjT1GqzDWRlalUEoY+uzoZKnhOjbIPD2c=
 +golang.org/x/tools v0.44.0/go.mod h1:KA0AfVErSdxRZIsOVipbv3rQhVXTnlU6UhKxHd1seDI=
-+golang.org/x/tools/go/expect v0.1.0-deprecated h1:jY2C5HGYR5lqex3gEniOQL0r7Dq5+VGVgY1nudX5lXY=
-+golang.org/x/tools/go/expect v0.1.0-deprecated/go.mod h1:eihoPOH+FgIqa3FpoTwguz/bVUSGBlGQU67vpBeOrBY=
++golang.org/x/tools/go/expect v0.1.1-deprecated h1:jpBZDwmgPhXsKZC6WhL20P4b/wmnpsEAGHaNy0n/rJM=
++golang.org/x/tools/go/expect v0.1.1-deprecated/go.mod h1:eihoPOH+FgIqa3FpoTwguz/bVUSGBlGQU67vpBeOrBY=
 +golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated h1:1h2MnaIAIXISqTFKdENegdpAgUXz6NrPEsbIeWaBRvM=
 +golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated/go.mod h1:RVAQXBGNv1ib0J382/DPCRS/BPnsGebyM1Gj5VSDpG8=
  golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
  golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
  golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-@@ -599,56 +603,56 @@ gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
- gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
- honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
- honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
--k8s.io/api v0.34.3 h1:D12sTP257/jSH2vHV2EDYrb16bS7ULlHpdNdNhEw2S4=
--k8s.io/api v0.34.3/go.mod h1:PyVQBF886Q5RSQZOim7DybQjAbVs8g7gwJNhGtY5MBk=
--k8s.io/apiextensions-apiserver v0.34.3 h1:p10fGlkDY09eWKOTeUSioxwLukJnm+KuDZdrW71y40g=
--k8s.io/apiextensions-apiserver v0.34.3/go.mod h1:aujxvqGFRdb/cmXYfcRTeppN7S2XV/t7WMEc64zB5A0=
--k8s.io/apimachinery v0.34.3 h1:/TB+SFEiQvN9HPldtlWOTp0hWbJ+fjU+wkxysf/aQnE=
--k8s.io/apimachinery v0.34.3/go.mod h1:/GwIlEcWuTX9zKIg2mbw0LRFIsXwrfoVxn+ef0X13lw=
--k8s.io/apiserver v0.34.3 h1:uGH1qpDvSiYG4HVFqc6A3L4CKiX+aBWDrrsxHYK0Bdo=
--k8s.io/apiserver v0.34.3/go.mod h1:QPnnahMO5C2m3lm6fPW3+JmyQbvHZQ8uudAu/493P2w=
--k8s.io/client-go v0.34.3 h1:wtYtpzy/OPNYf7WyNBTj3iUA0XaBHVqhv4Iv3tbrF5A=
--k8s.io/client-go v0.34.3/go.mod h1:OxxeYagaP9Kdf78UrKLa3YZixMCfP6bgPwPwNBQBzpM=
--k8s.io/cloud-provider v0.34.3 h1:+ZIj1mYPzrA0vWZMFFustsDCe1iP+xkhq0ZXZBhPW0o=
--k8s.io/cloud-provider v0.34.3/go.mod h1:e0XM6MTHG4rPk1Fa7oWnQT9VqKca+jw7wcc+BJeUcn4=
-+k8s.io/api v0.34.9 h1:aVsK5NQL7146suJriGuvpi9giNpwIRSHJ8v5HWakwBo=
-+k8s.io/api v0.34.9/go.mod h1:8oYqD5tLKgvBSnkuDbHZTNrk7NTHybkfYjJ6lNjThjQ=
-+k8s.io/apiextensions-apiserver v0.34.9 h1:I+VcEFLE/6ueQw3v1OxPslTHD6AiGQJ1M4cUxtYelII=
-+k8s.io/apiextensions-apiserver v0.34.9/go.mod h1:z+ylpz3sT+7C+H9jTTfCNR7khCMPDyZVIgvvga79uYc=
-+k8s.io/apimachinery v0.34.9 h1:WuRPolTfoEST1TQe9sLcT1QAWLMT0CNE4Eqj29XuUmQ=
-+k8s.io/apimachinery v0.34.9/go.mod h1:z7dd12Xd400CXIycE8nmn32xZhApV9zskHs0A5xeU/Q=
-+k8s.io/apiserver v0.34.9 h1:isiEW5L0OeGi4oDvyLl+cXzKvqFROH+UqkhIYo3tAsw=
-+k8s.io/apiserver v0.34.9/go.mod h1:gYau4EBEsam2O3uLF+D9KP8yHpMYdojPSMNq33FQEVA=
-+k8s.io/client-go v0.34.9 h1:HlhSEGPyCFH5rQADW6NPKEziGns6ekgUCPK0OsOGU90=
-+k8s.io/client-go v0.34.9/go.mod h1:bI3Sqqmwls2JKFZOQN9h8oLaeibvIA5pqqJAaSJWnrk=
-+k8s.io/cloud-provider v0.34.9 h1:4SZJS8CD74w8OIU8dh45s+DPUJZpfHS9JMYI9ISGP4Q=
-+k8s.io/cloud-provider v0.34.9/go.mod h1:pjbjdE3zP45y3vkl7alFSCH3UB1vz18VhgMSuDhfGIA=
- k8s.io/cloud-provider-aws v1.27.0 h1:PF8YrH8QcN6JoXB3Xxlaz84SBDYMPunJuCc0cPuCWXA=
- k8s.io/cloud-provider-aws v1.27.0/go.mod h1:9vUb5mnVnReSRDBWcBxB1b0HOeEc472iOPmrnwpN9SA=
- k8s.io/cloud-provider-gcp/providers v0.28.2 h1:I65pFTLNMQSj7YuW3Mg3pZIXmw0naCmF6TGAuz4/sZE=
- k8s.io/cloud-provider-gcp/providers v0.28.2/go.mod h1:P8dxRvvLtX7xUwVUzA/QOqv8taCzBaVsVMnjnpjmYXE=
--k8s.io/code-generator v0.34.3 h1:6ipJKsJZZ9q21BO8I2jEj4OLN3y8/1n4aihKN0xKmQk=
--k8s.io/code-generator v0.34.3/go.mod h1:oW73UPYpGLsbRN8Ozkhd6ZzkF8hzFCiYmvEuWZDroI4=
--k8s.io/component-base v0.34.3 h1:zsEgw6ELqK0XncCQomgO9DpUIzlrYuZYA0Cgo+JWpVk=
--k8s.io/component-base v0.34.3/go.mod h1:5iIlD8wPfWE/xSHTRfbjuvUul2WZbI2nOUK65XL0E/c=
--k8s.io/component-helpers v0.34.3 h1:Iws1GQfM89Lxo7IZITGmVdFOW0Bmyd7SVwwIu1/CCkE=
--k8s.io/component-helpers v0.34.3/go.mod h1:S8HjjMTrUDVMVPo2EdNYRtQx9uIEIueQYdPMOe9UxJs=
--k8s.io/controller-manager v0.34.3 h1:pEW6ExR3FteKkYkKRrLoi0Sy8dcbvUTAReP8OTxK5k0=
--k8s.io/controller-manager v0.34.3/go.mod h1:YzXiwiubf6GdSC3ej2XFYhQQBwF5AvJq/3eymdsU9OU=
--k8s.io/cri-api v0.34.3 h1:zFdQSHZuQlQXesw9ncjQRUyDpvLng/84Q4qLKd8x2zE=
--k8s.io/cri-api v0.34.3/go.mod h1:4qVUjidMg7/Z9YGZpqIDygbkPWkg3mkS1PvOx/kpHTE=
--k8s.io/cri-client v0.34.3 h1:P1LMB7Aa52OfIaJ383FfHYJTlokZsLYUBn6Y7IEc9Oc=
--k8s.io/cri-client v0.34.3/go.mod h1:EEQXyjPYePB2RSBnrTs+4up14q/6lVKnHvPXUSMYR4A=
--k8s.io/csi-translation-lib v0.34.3 h1:WGE/HPz5D3TIqffhYkk6s4KfW1mcSwSH30MzABK47Pg=
--k8s.io/csi-translation-lib v0.34.3/go.mod h1:Lx11spUQnRzYFDrTok0/6cQMP3oXHi73+mXWvkRTxbE=
--k8s.io/dynamic-resource-allocation v0.34.3 h1:8UGn1CTj1IljJa+r6HxnEDqLvcBZkv5c+Ooa6x1Oy+o=
--k8s.io/dynamic-resource-allocation v0.34.3/go.mod h1:eYjQqNaHLfqXT94lbSXEy8ZLaUg1mGJ2JCEtNWM7e7M=
-+k8s.io/code-generator v0.34.9 h1:jXBgPd5FbFoN1J2uA/qISW3uLHRl8wJ9Gx6L4PiJIPk=
-+k8s.io/code-generator v0.34.9/go.mod h1:/doiEA33AIV4kFt4NTMCzV8N5Ued8kq1fZMWUUib990=
-+k8s.io/component-base v0.34.9 h1:whlBI2kU+CHKHmeByojCzHX/OTU7RjsTirkHbqDDpz0=
-+k8s.io/component-base v0.34.9/go.mod h1:4VmwVaGu+f+5jMIkCpmbJ0HHDu4Wu2rlWhISXAETjos=
-+k8s.io/component-helpers v0.34.9 h1:vnxTF9GIowfdioxkFfptSQwf2hN8axqCW2AKUdarOfc=
-+k8s.io/component-helpers v0.34.9/go.mod h1:z9IVmbGz3TBYt6RtOM86gYX4o3dK9KAFLlE3LtO/zWg=
-+k8s.io/controller-manager v0.34.9 h1:7XFUgqC/2qngt881846KTUMVnJ/lobuMT7ayCZdVWO8=
-+k8s.io/controller-manager v0.34.9/go.mod h1:UzcjajHcgo8DoaWICoGpYUB9spSF8h+TyfxrCuJUmXY=
-+k8s.io/cri-api v0.34.9 h1:kHmQCollTinXsGWpwWsRZuuAPn9541DlYbjaCjwl8J8=
-+k8s.io/cri-api v0.34.9/go.mod h1:TcHwArMKizVHhJnVZ2YbtLXFfnrNWVf3lPyky4k3970=
-+k8s.io/cri-client v0.34.9 h1:+B0zP/9qg+sOFB8FQn2baQkaY4fouISYeEyd6g2qnjA=
-+k8s.io/cri-client v0.34.9/go.mod h1:P81V4c2mcu7GlMrJ8E0pJKHcgQ7YFmni4kYZ5hvTdCQ=
-+k8s.io/csi-translation-lib v0.34.9 h1:FNpNAIRhiodXqWKWsmrk8Lz2EwVhYlUyhx4XgDNjAGA=
-+k8s.io/csi-translation-lib v0.34.9/go.mod h1:tTLEJn+w/vxD6DhUc8AVtqYBQsR7hZUOQZVvnQJQZXs=
-+k8s.io/dynamic-resource-allocation v0.34.9 h1:I+GEBPZ3ijSw3RtXu05VJpAtKmhfvpH8Fe0fu+wRKdg=
-+k8s.io/dynamic-resource-allocation v0.34.9/go.mod h1:0iF4OPm7jH1uC1lCLWThUyF1kVaC0S2yCqN+rHUhLyc=
- k8s.io/gengo/v2 v2.0.0-20250604051438-85fd79dbfd9f h1:SLb+kxmzfA87x4E4brQzB33VBbT2+x7Zq9ROIHmGn9Q=
- k8s.io/gengo/v2 v2.0.0-20250604051438-85fd79dbfd9f/go.mod h1:EJykeLsmFC60UQbYJezXkEsG2FLrt0GPNkU5iK5GWxU=
- k8s.io/klog/v2 v2.130.1 h1:n9Xl7H1Xvksem4KFG4PYbdQCQxqc/tTUyrgXaOhHSzk=
- k8s.io/klog/v2 v2.130.1/go.mod h1:3Jpz1GvMt720eyJH1ckRHK1EDfpxISzJ7I9OYgaDtPE=
--k8s.io/kms v0.34.3 h1:QzBOD0sk1bGQVMcZQAHGjtbP1iKZJUyhC6D0I+BTxIE=
--k8s.io/kms v0.34.3/go.mod h1:s1CFkLG7w9eaTYvctOxosx88fl4spqmixnNpys0JAtM=
-+k8s.io/kms v0.34.9 h1:lZGoqvmTxESbQM14PBveZt3gkgSOGDf56u06HrhS1O0=
-+k8s.io/kms v0.34.9/go.mod h1:sBByaFjIDNm8oPQXjREzXISZSx60On//fhvnAVhuL5g=
- k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b h1:MloQ9/bdJyIu9lb1PzujOPolHyvO06MXG5TUIj2mNAA=
- k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b/go.mod h1:UZ2yyWbFTpuhSbFhv24aGNOdoRdJZgsIObGBUaYVsts=
--k8s.io/kube-scheduler v0.34.3 h1:ki99I6opxUZNcIO/QIq1Jz5iTVRHPRdDRFxi5A/3Zjw=
--k8s.io/kube-scheduler v0.34.3/go.mod h1:ECkAVWCHQjWJLasX6eznbZ/7J6YqDWiZchXpjG/w5ig=
--k8s.io/kubectl v0.34.3 h1:vpM6//153gh5gvsYHXWHVJ4l4xmN5QFwTSmlfd8icm8=
--k8s.io/kubectl v0.34.3/go.mod h1:zZQHtIZoUqTP1bAnPzq/3W1jfc0NeOeunFgcswrfg1c=
--k8s.io/kubelet v0.34.3 h1:8QRev2FmasZ05yCC774qn6ULche72PYM7AQv0CVt9CM=
--k8s.io/kubelet v0.34.3/go.mod h1:pMgblr+nVQ02UkyaTcgqzS3AIYVQkjlMFg1Pd5rGC1Q=
--k8s.io/kubernetes v1.34.3 h1:0TfljWbhEF5DBks+WFMSrvKfxBLo4vnZuqORjLMiyT4=
--k8s.io/kubernetes v1.34.3/go.mod h1:m6pZk6a179pRo2wsTiCPORJ86iOEQmfIzUvtyEF8BwA=
--k8s.io/mount-utils v0.34.3 h1:+sk7PVMQhGoNkGnxmxhyjEXpFcTaD6s3a6NXZNhqERc=
--k8s.io/mount-utils v0.34.3/go.mod h1:MIjjYlqJ0ziYQg0MO09kc9S96GIcMkhF/ay9MncF0GA=
-+k8s.io/kube-scheduler v0.34.9 h1:XmMog9CcudBrEgrltvScak5Tk2kd5yYRlsVgdBnW5ok=
-+k8s.io/kube-scheduler v0.34.9/go.mod h1:aAUgE00lVWSzG+3fgb4Vv6IgN55SQ+KI0pUFXGjK/4M=
-+k8s.io/kubectl v0.34.9 h1:nGNmsw1m9Q1lop2HtMk1jzM+JVNlQLj6gZr82vT1AmQ=
-+k8s.io/kubectl v0.34.9/go.mod h1:8FvYj6BPfeo1YPn6rvPs0kOTFBzRne89rG8LnyWPIlY=
-+k8s.io/kubelet v0.34.9 h1:gL2tDk5Kdv6ghUoyIYJZiZuZYTwsz5YhqqookZfcbQk=
-+k8s.io/kubelet v0.34.9/go.mod h1:74mk09f1XfTUsw6Zv97IiBQlHFlFzw3UmNWk8+MZkbg=
-+k8s.io/kubernetes v1.34.9 h1:qj8W8mftZkTEBMdNjGBp+pKGbvpewrnCiuDp2l4DxtU=
-+k8s.io/kubernetes v1.34.9/go.mod h1:ECvwZXn8HlXIVDdB4RwZxboj5YhwMZ+COzc6yRMFMX4=
-+k8s.io/mount-utils v0.34.9 h1:PignUu11sdwMPpqqYSYi3GDuP+PtI1wt7s5KJcLPAt4=
-+k8s.io/mount-utils v0.34.9/go.mod h1:DY1x4o9KaP9fXkHeWCOFWmhRdvKD8nzJ7K57xE5T95c=
+@@ -648,8 +652,8 @@ k8s.io/kubectl v0.34.1 h1:1qP1oqT5Xc93K+H8J7ecpBjaz511gan89KO9Vbsh/OI=
+ k8s.io/kubectl v0.34.1/go.mod h1:JRYlhJpGPyk3dEmJ+BuBiOB9/dAvnrALJEiY/C5qa6A=
+ k8s.io/kubelet v0.34.1 h1:doAaTA9/Yfzbdq/u/LveZeONp96CwX9giW6b+oHn4m4=
+ k8s.io/kubelet v0.34.1/go.mod h1:PtV3Ese8iOM19gSooFoQT9iyRisbmJdAPuDImuccbbA=
+-k8s.io/kubernetes v1.34.1 h1:F3p8dtpv+i8zQoebZeK5zBqM1g9x1aIdnA5vthvcuUk=
+-k8s.io/kubernetes v1.34.1/go.mod h1:iu+FhII+Oc/1gGWLJcer6wpyih441aNFHl7Pvm8yPto=
++k8s.io/kubernetes v1.34.2 h1:WQdDvYJazkmkwSncgNwGvVtaCt4TYXIU3wSMRgvp3MI=
++k8s.io/kubernetes v1.34.2/go.mod h1:m6pZk6a179pRo2wsTiCPORJ86iOEQmfIzUvtyEF8BwA=
+ k8s.io/mount-utils v0.34.1 h1:zMBEFav8Rxwm54S8srzy5FxAc4KQ3X4ZcjnqTCzHmZk=
+ k8s.io/mount-utils v0.34.1/go.mod h1:MIjjYlqJ0ziYQg0MO09kc9S96GIcMkhF/ay9MncF0GA=
  k8s.io/utils v0.0.0-20250604170112-4c0f3b243397 h1:hwvWFiBzdWw1FhfY1FooPn3kzWuJ8tmbZBHi4zVsl1Y=
- k8s.io/utils v0.0.0-20250604170112-4c0f3b243397/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
- sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 h1:jpcvIRr3GLoUoEKRkHKSmGjxb6lWwrBlJsXc+eUYQHM=

--- a/modules/040-node-manager/images/cluster-autoscaler/patches/1.34/README.md
+++ b/modules/040-node-manager/images/cluster-autoscaler/patches/1.34/README.md
@@ -2,25 +2,43 @@
 
 ### 001-go-mod.patch
 
-To create this patch run commands:
+Bumps Go module dependencies to remediate CVEs reported by Trivy for the
+cluster-autoscaler binary. The vulnerabilities live in indirect/build
+dependencies that are linked into the binary (x/crypto/ssh, x/net, k8s
+staging modules), not in cluster-autoscaler logic, so the fix is a pure
+`go.mod`/`go.sum` bump. The gardener tag stays `v1.34.1`.
+
+This patch also covers the k8s 1.35 and 1.36 images: `werf.inc.yaml` clamps
+`$maxVersion = "1.34"`, so those images are built from gardener `v1.34.1`
+with `patches/1.34/`.
+
+Applied to both `cluster-autoscaler/go.mod` and `cluster-autoscaler/apis/go.mod`:
+
+- `go` directive: `1.24.0` -> `1.25.0`
+- `golang.org/x/net`: `v0.38.0` -> `v0.55.0` (HTML parser / HTTP2 / idna CVEs)
+- `golang.org/x/sys`: `v0.31.0` -> `v0.45.0`
+- `golang.org/x/crypto`: `v0.36.0` -> `v0.51.0` (x/crypto/ssh CVEs)
+- `k8s.io/kubernetes`: `v1.34.1` -> `v1.34.2`, and all `k8s.io/*` staging
+  modules (require + replace) synced to `v0.34.2` (kube-controller-manager
+  SSRF, CVE-2025-13281)
+
+To recreate this patch, check out the clean tag and re-apply the bumps:
 
 ```shell
+git clone <SOURCE_REPO>/gardener/autoscaler.git
+cd autoscaler && git checkout v1.34.1
 cd cluster-autoscaler
-go mod edit -go 1.23
-go get github.com/golang-jwt/jwt/v4@v4.5.1
-go get github.com/opencontainers/runc@v1.1.14
-go get golang.org/x/crypto@v0.31.0
-go get golang.org/x/net@v0.33.0
-
-go get k8s.io/kubernetes@v1.30.8
-go get k8s.io/kubelet@v0.30.8
-#replase all in k8s.io  v0.30.1 -> v0.30.8
-cd apis
-go get golang.org/x/net@v0.33.0
+go get golang.org/x/crypto@v0.51.0
+go get golang.org/x/net@v0.55.0
+go get golang.org/x/sys@v0.45.0
+go get k8s.io/kubernetes@v1.34.2
+# sync every k8s.io/* require and replace directive to v0.34.2
+cd apis && go get golang.org/x/net@v0.55.0 && cd ..
+go mod tidy && (cd apis && go mod tidy)
 cd ..
-go mod tidy
-git diff > patches/001-go_mod.patch
-#git apply patches/001-go_mod.patch
+git diff -- cluster-autoscaler/go.mod cluster-autoscaler/go.sum \
+            cluster-autoscaler/apis/go.mod cluster-autoscaler/apis/go.sum \
+  > 001-go-mod.patch
 ```
 
 ### 002-kruise-ads.patch

--- a/modules/040-node-manager/images/cluster-autoscaler/patches/README.md
+++ b/modules/040-node-manager/images/cluster-autoscaler/patches/README.md
@@ -1,5 +1,27 @@
 # Patches
 
+## Go module updates (CVE remediation)
+
+`001-go-mod.patch` bumps Go module dependencies to remediate CVEs reported by
+Trivy for the cluster-autoscaler binary. The vulnerabilities live in
+indirect/build dependencies that are linked into the binary (`x/crypto/ssh`,
+`x/net`, and the `k8s.io/*` staging modules), not in cluster-autoscaler logic,
+so the fix is a pure `go.mod`/`go.sum` bump — the gardener source tag is not
+changed. The patch touches both `cluster-autoscaler/go.mod` and
+`cluster-autoscaler/apis/go.mod`.
+
+Typical bumps: `golang.org/x/net` -> `v0.55.0`, `golang.org/x/sys` -> `v0.45.0`,
+`golang.org/x/crypto` -> `v0.51.0`, and `k8s.io/kubernetes` (plus all `k8s.io/*`
+require/replace directives) to the latest fix patch of the matching minor
+(for example `v1.32.10` / `v1.33.6` / `v1.34.2`).
+
+Because the patch is generated against a specific gardener tag, it must be
+recreated from a clean checkout of that tag; applying a patch made from a
+different base fails in CI with `patch does not apply`. Per-version target
+versions and the exact recreate commands are documented in each
+`<k8s-minor>/README.md`. Note that the `1.34/` patch is also used for the
+1.35 and 1.36 images (`werf.inc.yaml` clamps `$maxVersion = "1.34"`).
+
 ## Scale from zero
 
 We want to scale a node group from zero but our MCM revision does not support generic MachineClass CRs. 


### PR DESCRIPTION
## Description
Updates the `go.mod` patches (`001-go-mod.patch`) for the bundled gardener/cluster-autoscaler images for Kubernetes 1.32, 1.33, and 1.34 to remediate CVEs reported by the image vulnerability scanner (Trivy).

The changes are limited to dependency versions in `go.mod`/`go.sum` (both the main module and `apis/`):

- `golang.org/x/crypto` → `v0.52.0`
- `golang.org/x/net` → `v0.55.0` (main module and `apis/`)
- `golang.org/x/sys` → `≥ v0.44.0`
- `github.com/golang-jwt/jwt/v5` → `v5.2.2`
- `k8s.io/kubernetes` and all `k8s.io/*` staging modules aligned to the fixed patch versions per minor:
    - 1.32: `k8s.io/kubernetes v1.32.10` + `k8s.io/* v0.32.10`
    - 1.33: `k8s.io/kubernetes v1.33.6` + `k8s.io/* v0.33.6`
    - 1.34: `k8s.io/kubernetes v1.34.2` + `k8s.io/* v0.34.2`

No functional/behavioral changes to autoscaling logic. Impact on critical components: on update the `cluster-autoscaler` Deployment is rolled out (pod restart). Control-plane, ingress-controllers, and Prometheus are not affected.

## Why do we need it, and what problem does it solve?
The vulnerability scanner flags 27–28 CVEs per cluster-autoscaler image (in `golang.org/x/crypto`, `golang.org/x/net`, `golang.org/x/sys`, `golang-jwt`, and `k8s.io/kubernetes` — e.g. the SSH/GSSAPI/HTML-parsing/HTTP-2 issues in the `x/*` libraries, `CVE-2025-30204` in `golang-jwt`, and `CVE-2025-13281`/`CVE-2025-4563` in `k8s.io/kubernetes`).

These packages are linked into the binary but the vulnerable code paths are not reachable in cluster-autoscaler (it doesn't run an SSH/HTTP-2 server, render HTML, or run kube-apiserver/kube-controller-manager). Still, the scanner reports the module versions embedded in the binary. Bumping the upstream gardener tag does not fix them (the upstream tags stay on the old `x/crypto`/`x/net` and k8s versions), so the fixes are applied via the `go.mod` patches. This brings the images to a clean scan without changing behavior.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: Bump cluster-autoscaler go.mod dependencies (x/crypto, x/net, x/sys, golang-jwt, k8s.io/*) to remediate CVEs in the images for Kubernetes 1.32, 1.33 and 1.34.
impact: The cluster-autoscaler Deployment is restarted on update; no functional changes.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
