### PR TITLE
[dhctl] Add explicit error if discovered node IP is empty

### DIFF
--- a/dhctl/pkg/operations/bootstrap/steps_bashible.go
+++ b/dhctl/pkg/operations/bootstrap/steps_bashible.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"time"
 
@@ -178,6 +179,14 @@ func RunBashiblePipeline(ctx context.Context, params *BashiblePipelineParams) er
 	nodeInfo, err := bashible.ReadNodeInfo(ctx)
 	if err != nil {
 		return err
+	}
+
+	if reflect.DeepEqual(nodeInfo, &dhbashible.NodeInfo{}) {
+		return fmt.Errorf("nodeInfo is empty, seems like hostname and node IP were not discovered")
+	}
+
+	if nodeInfo.NodeIP == "" {
+		return fmt.Errorf("Discovered NodeIP is empty. Check out your StaticClusterConfiguration internalNetworkCIDRs are filled and the same as node NIC CIDRs")
 	}
 
 	modulesPreparators, controlPlanePreparator := getModulesPreparators(ctx, params)


### PR DESCRIPTION
## Description

Add explicit error if discovered node IP is empty.

## Why do we need it, and what problem does it solve?

Now, if discovered node IP is empty, error is not clear for user, like `prepare PKI: controlPlaneEndpoint is empty`. The root cause is what bashible cannot discover the node IP, if `StaticClusterConfiguration.internalNetworkCIDRs` are filled incorrect. 

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Added an explicit error when the discovered node IP is empty.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
