### PR TITLE
[docs] Fix Istio documentation name mappings

### DIFF
--- a/docs/documentation/_data/modules/sidebar.yaml
+++ b/docs/documentation/_data/modules/sidebar.yaml
@@ -18,6 +18,9 @@ titles:
   cr.html:
     en: Custom Resources
     ru: Кастомные ресурсы
+  istio-cr.html:
+    en: Custom Resources (by istio.io)
+    ru: Кастомные ресурсы (от istio.io)
   oss.html:
     en: Third-party components
     ru: Внешние компоненты

--- a/modules/110-istio/docs/CR_RU.md
+++ b/modules/110-istio/docs/CR_RU.md
@@ -1,5 +1,5 @@
 ---
-title: "Модуль istio: Custom Resources"
+title: "Модуль istio: Кастомные ресурсы"
 ---
 
 <!-- SCHEMA -->

--- a/modules/110-istio/docs/ISTIO-CR_RU.md
+++ b/modules/110-istio/docs/ISTIO-CR_RU.md
@@ -1,5 +1,5 @@
 ---
-title: "Модуль istio: Custom Resources (от istio.io)"
+title: "Модуль istio: Кастомные ресурсы (от istio.io)"
 description: "Справочник по апстрим-ресурсам Istio, используемым модулем: маршрутизация (DestinationRule, VirtualService, ServiceEntry), аутентификация (PeerAuthentication, RequestAuthentication), авторизация (AuthorizationPolicy) и Sidecar."
 ---
 


### PR DESCRIPTION
## Description

Added missing title mappings for the `istio-cr.html` page in the module documentation sidebar. The sidebar YAML already had a `weight` entry for `istio-cr.html` but lacked the corresponding `titles` entries, causing the page to render without a proper title in the sidebar navigation.

## Why do we need it, and what problem does it solve?

The Istio module documentation page "Custom Resources (by istio.io)" (`istio-cr.html`) was missing its title mappings in `docs/documentation/_data/modules/sidebar.yaml`. While the weight was defined, the absence of title entries meant the sidebar would show the page without a proper label, making navigation less user-friendly. This change adds the missing English and Russian title translations.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: fix
summary: Add missing sidebar title mappings for Istio documentation CR page.
impact_level: low
```