### PR TITLE
[istio] Improve Gateway API CRD handling

### DIFF
--- a/ee/modules/110-istio/images/waypoint-controller/src/go.mod
+++ b/ee/modules/110-istio/images/waypoint-controller/src/go.mod
@@ -3,6 +3,7 @@ module waypoint-controller
 go 1.25.0
 
 require (
+	golang.org/x/mod v0.33.0
 	k8s.io/api v0.35.1
 	k8s.io/apiextensions-apiserver v0.35.0
 	k8s.io/apimachinery v0.35.1
@@ -58,7 +59,6 @@ require (
 	github.com/x448/float16 v0.8.4 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/mod v0.33.0 // indirect
 	golang.org/x/net v0.50.0 // indirect
 	golang.org/x/oauth2 v0.35.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect

--- a/ee/modules/110-istio/images/waypoint-controller/src/internal/waypointcontroller/crds_gateway_api.go
+++ b/ee/modules/110-istio/images/waypoint-controller/src/internal/waypointcontroller/crds_gateway_api.go
@@ -15,24 +15,39 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/mod/semver"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sversion "k8s.io/apimachinery/pkg/version"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/yaml"
 )
 
-const gatewayAPICRDComplianceRetryInterval = time.Minute
+const (
+	gatewayAPICRDComplianceRetryInterval = time.Minute
+	gatewayAPIBundleVersionAnnotation    = "gateway.networking.k8s.io/bundle-version"
+)
 
 //go:embed crds_gateway_api/*.yaml
 var gatewayAPICRDManifests embed.FS
 
 type bundledGatewayAPICRD struct {
-	manifestPath   string
-	crd            *apiextensionsv1.CustomResourceDefinition
-	storageVersion string
+	manifestPath               string
+	crd                        *apiextensionsv1.CustomResourceDefinition
+	minimumBundleVersion       string
+	minimumServedVersion       string
+	requiredExactServedVersion string
+}
+
+// requiredGatewayAPIEndpoints lists API endpoints used directly by this
+// controller. Unlike the CRDs installed for the wider Gateway API ecosystem,
+// these must serve the exact version against which the controller is compiled.
+var requiredGatewayAPIEndpoints = map[string]string{
+	"gateways." + gatewayv1.GroupName: gatewayv1.GroupVersion.Version,
 }
 
 func WaitForGatewayAPICRDCompliance(ctx context.Context) error {
@@ -92,7 +107,8 @@ func ensureGatewayAPICRDComplianceOnce(ctx context.Context, clientset apiextensi
 		klog.V(4).InfoS(
 			"Checking Gateway API CRD",
 			"name", bundledCRD.crd.Name,
-			"expectedStorageVersion", bundledCRD.storageVersion,
+			"minimumBundleVersion", bundledCRD.minimumBundleVersion,
+			"minimumServedVersion", bundledCRD.minimumServedVersion,
 		)
 		clusterCRD, err := clientset.ApiextensionsV1().CustomResourceDefinitions().Get(
 			ctx,
@@ -103,7 +119,8 @@ func ensureGatewayAPICRDComplianceOnce(ctx context.Context, clientset apiextensi
 			klog.V(1).InfoS(
 				"Gateway API CRD is missing from cluster and will be created",
 				"name", bundledCRD.crd.Name,
-				"expectedStorageVersion", bundledCRD.storageVersion,
+				"minimumBundleVersion", bundledCRD.minimumBundleVersion,
+				"minimumServedVersion", bundledCRD.minimumServedVersion,
 			)
 			continue
 		}
@@ -114,100 +131,123 @@ func ensureGatewayAPICRDComplianceOnce(ctx context.Context, clientset apiextensi
 		clusterCRDs[bundledCRD.crd.Name] = clusterCRD
 	}
 
-	toCreate, mismatches, err := evaluateGatewayAPICRDState(bundledCRDs, clusterCRDs)
-	if err != nil {
-		return "", err
-	}
+	toCreate, mismatches := evaluateGatewayAPICRDState(bundledCRDs, clusterCRDs)
 	if len(mismatches) > 0 {
 		return fmt.Sprintf(
-			"Gateway API CRD storage version mismatch detected, controller startup is blocked and will retry in %s: %s",
+			"incompatible Gateway API CRDs detected, controller startup is blocked and will retry in %s: %s",
 			gatewayAPICRDComplianceRetryInterval,
 			strings.Join(mismatches, "; "),
 		), nil
 	}
 
-	for _, crd := range toCreate {
-		storageVersion, err := storageVersionForCRD(crd)
-		if err != nil {
-			return "", fmt.Errorf("determine storage version for bundled Gateway API CRD %q before create: %w", crd.Name, err)
-		}
-
+	for _, bundledCRD := range toCreate {
 		klog.V(4).InfoS(
 			"Creating bundled Gateway API CRD",
-			"name", crd.Name,
-			"storageVersion", storageVersion,
+			"name", bundledCRD.crd.Name,
+			"minimumBundleVersion", bundledCRD.minimumBundleVersion,
 		)
 
-		_, err = clientset.ApiextensionsV1().CustomResourceDefinitions().Create(
+		_, err := clientset.ApiextensionsV1().CustomResourceDefinitions().Create(
 			ctx,
-			crd,
+			bundledCRD.crd.DeepCopy(),
 			metav1.CreateOptions{},
 		)
 		if err == nil {
 			klog.V(1).InfoS(
 				"Created bundled Gateway API CRD",
-				"name", crd.Name,
-				"storageVersion", storageVersion,
+				"name", bundledCRD.crd.Name,
+				"minimumBundleVersion", bundledCRD.minimumBundleVersion,
 			)
 
 			continue
 		}
 		if apierrors.IsAlreadyExists(err) {
-			klog.V(4).InfoS(
-				"Gateway API CRD already exists while creating, continuing",
-				"name", crd.Name,
-			)
-
-			continue
+			// Another actor created the CRD after the read above. Do not assume it
+			// is compatible; make the next pass fetch and validate it.
+			return fmt.Sprintf(
+				"Gateway API CRD %q was created concurrently, controller startup is blocked until it is validated on the next retry in %s",
+				bundledCRD.crd.Name,
+				gatewayAPICRDComplianceRetryInterval,
+			), nil
 		}
 
-		return "", fmt.Errorf("create bundled Gateway API CRD %q: %w", crd.Name, err)
+		return "", fmt.Errorf("create bundled Gateway API CRD %q: %w", bundledCRD.crd.Name, err)
 	}
 
 	return "", nil
 }
 
-func evaluateGatewayAPICRDState(bundledCRDs []bundledGatewayAPICRD, clusterCRDs map[string]*apiextensionsv1.CustomResourceDefinition) ([]*apiextensionsv1.CustomResourceDefinition, []string, error) {
+func evaluateGatewayAPICRDState(bundledCRDs []bundledGatewayAPICRD, clusterCRDs map[string]*apiextensionsv1.CustomResourceDefinition) ([]bundledGatewayAPICRD, []string) {
 	var (
-		toCreate   []*apiextensionsv1.CustomResourceDefinition
+		toCreate   []bundledGatewayAPICRD
 		mismatches []string
 	)
 
 	for _, bundledCRD := range bundledCRDs {
 		clusterCRD, exists := clusterCRDs[bundledCRD.crd.Name]
 		if !exists {
-			toCreate = append(toCreate, bundledCRD.crd.DeepCopy())
+			toCreate = append(toCreate, bundledCRD)
 			continue
 		}
 
-		clusterStorageVersion, err := storageVersionForCRD(clusterCRD)
-		if err != nil {
-			return nil, nil, fmt.Errorf("determine storage version for cluster CRD %q: %w", clusterCRD.Name, err)
-		}
-		if clusterStorageVersion != bundledCRD.storageVersion {
-			klog.V(4).InfoS(
-				"Gateway API CRD storage version mismatch detected",
-				"name", clusterCRD.Name,
-				"clusterStorageVersion", clusterStorageVersion,
-				"expectedStorageVersion", bundledCRD.storageVersion,
-			)
+		clusterBundleVersion := clusterCRD.Annotations[gatewayAPIBundleVersionAnnotation]
+		if bundledCRD.requiredExactServedVersion != "" && !servesVersion(clusterCRD, bundledCRD.requiredExactServedVersion) {
 			mismatches = append(mismatches, fmt.Sprintf(
-				"%s (cluster=%s, bundled=%s)",
+				"%s (required API version %s is not served)",
 				clusterCRD.Name,
-				clusterStorageVersion,
-				bundledCRD.storageVersion,
+				bundledCRD.requiredExactServedVersion,
+			))
+			continue
+		}
+		if !servesVersionOrHigher(clusterCRD, bundledCRD.minimumServedVersion) {
+			mismatches = append(mismatches, fmt.Sprintf(
+				"%s (minimum API version %s or higher is not served)",
+				clusterCRD.Name,
+				bundledCRD.minimumServedVersion,
 			))
 			continue
 		}
 
-		klog.V(4).InfoS(
-			"Gateway API CRD storage version matches bundled manifest",
-			"name", clusterCRD.Name,
-			"storageVersion", clusterStorageVersion,
+		if semver.IsValid(clusterBundleVersion) {
+			if semver.Compare(clusterBundleVersion, bundledCRD.minimumBundleVersion) < 0 {
+				klog.V(4).InfoS(
+					"Gateway API CRD bundle version is older than bundled manifest",
+					"name", clusterCRD.Name,
+					"clusterBundleVersion", clusterBundleVersion,
+					"minimumBundleVersion", bundledCRD.minimumBundleVersion,
+				)
+				mismatches = append(mismatches, fmt.Sprintf(
+					"%s (cluster bundle=%s, minimum bundle=%s)",
+					clusterCRD.Name,
+					clusterBundleVersion,
+					bundledCRD.minimumBundleVersion,
+				))
+				continue
+			}
+
+			klog.V(4).InfoS(
+				"Gateway API CRD bundle version is compatible",
+				"name", clusterCRD.Name,
+				"clusterBundleVersion", clusterBundleVersion,
+				"minimumBundleVersion", bundledCRD.minimumBundleVersion,
+			)
+			continue
+		}
+
+		// The bundle-version annotation is metadata added by upstream release
+		// bundles, not part of the CRD's API contract. User- or vendor-supplied
+		// compatible CRDs may omit it, so accept the CRD based on the served API
+		// version validated above.
+		klog.Warningf(
+			"Gateway API CRD %q has missing or invalid %q annotation %q; accepting it because API version %q or higher is served",
+			clusterCRD.Name,
+			gatewayAPIBundleVersionAnnotation,
+			clusterBundleVersion,
+			bundledCRD.minimumServedVersion,
 		)
 	}
 
-	return toCreate, mismatches, nil
+	return toCreate, mismatches
 }
 
 func loadBundledGatewayAPICRDs() ([]bundledGatewayAPICRD, error) {
@@ -229,15 +269,21 @@ func loadBundledGatewayAPICRDs() ([]bundledGatewayAPICRD, error) {
 			return nil, fmt.Errorf("decode bundled Gateway API CRD manifest %q: %w", manifestPath, err)
 		}
 
-		storageVersion, err := storageVersionForCRD(crd)
+		bundleVersion, err := bundleVersionForCRD(crd)
 		if err != nil {
-			return nil, fmt.Errorf("determine storage version for bundled Gateway API CRD manifest %q: %w", manifestPath, err)
+			return nil, fmt.Errorf("determine bundle version for bundled Gateway API CRD manifest %q: %w", manifestPath, err)
+		}
+		minimumServedVersion, err := minimumServedVersionForCRD(crd)
+		if err != nil {
+			return nil, fmt.Errorf("determine minimum served version for bundled Gateway API CRD manifest %q: %w", manifestPath, err)
 		}
 
 		bundledCRDs = append(bundledCRDs, bundledGatewayAPICRD{
-			manifestPath:   manifestPath,
-			crd:            crd,
-			storageVersion: storageVersion,
+			manifestPath:               manifestPath,
+			crd:                        crd,
+			minimumBundleVersion:       bundleVersion,
+			minimumServedVersion:       minimumServedVersion,
+			requiredExactServedVersion: requiredGatewayAPIEndpoints[crd.Name],
 		})
 	}
 
@@ -246,6 +292,60 @@ func loadBundledGatewayAPICRDs() ([]bundledGatewayAPICRD, error) {
 	}
 
 	return bundledCRDs, nil
+}
+
+func bundleVersionForCRD(crd *apiextensionsv1.CustomResourceDefinition) (string, error) {
+	bundleVersion := crd.Annotations[gatewayAPIBundleVersionAnnotation]
+	if bundleVersion == "" {
+		return "", fmt.Errorf("CRD %q does not have the %q annotation", crd.Name, gatewayAPIBundleVersionAnnotation)
+	}
+	if !semver.IsValid(bundleVersion) {
+		return "", fmt.Errorf("CRD %q has invalid bundle version %q in the %q annotation", crd.Name, bundleVersion, gatewayAPIBundleVersionAnnotation)
+	}
+
+	return bundleVersion, nil
+}
+
+// minimumServedVersionForCRD returns the minimum API version a compatible
+// cluster CRD must serve. The storage version is used because it is unique per
+// CRD and makes the choice deterministic and independent of the ordering of
+// spec.versions. The bundled manifests always mark their storage version as
+// served; this is verified here so an invalid manifest fails fast at load time.
+func minimumServedVersionForCRD(crd *apiextensionsv1.CustomResourceDefinition) (string, error) {
+	storageVersion, err := storageVersionForCRD(crd)
+	if err != nil {
+		return "", err
+	}
+	if !servesVersion(crd, storageVersion) {
+		return "", fmt.Errorf("CRD %q does not serve its storage version %q", crd.Name, storageVersion)
+	}
+
+	return storageVersion, nil
+}
+
+func servesVersion(crd *apiextensionsv1.CustomResourceDefinition, requiredVersion string) bool {
+	for _, version := range crd.Spec.Versions {
+		if version.Name == requiredVersion && version.Served {
+			return true
+		}
+	}
+
+	return false
+}
+
+// servesVersionOrHigher reports whether the CRD serves an API version whose
+// Kubernetes version priority is equal to or higher than minimumVersion. This
+// is intentionally a compatibility heuristic, not a schema compatibility
+// guarantee: newer or more stable API versions are accepted without requiring
+// an exact version match.
+func servesVersionOrHigher(crd *apiextensionsv1.CustomResourceDefinition, minimumVersion string) bool {
+	for _, version := range crd.Spec.Versions {
+		if version.Served && k8sversion.CompareKubeAwareVersionStrings(version.Name, minimumVersion) >= 0 {
+			return true
+		}
+	}
+
+	return false
 }
 
 func storageVersionForCRD(crd *apiextensionsv1.CustomResourceDefinition) (string, error) {

--- a/ee/modules/110-istio/images/waypoint-controller/src/internal/waypointcontroller/crds_gateway_api_test.go
+++ b/ee/modules/110-istio/images/waypoint-controller/src/internal/waypointcontroller/crds_gateway_api_test.go
@@ -32,8 +32,18 @@ func TestLoadBundledGatewayAPICRDs(t *testing.T) {
 		if bundledCRD.crd.Name == "" {
 			t.Fatal("expected bundled CRD name to be populated")
 		}
-		if bundledCRD.storageVersion == "" {
-			t.Fatalf("expected storage version for %q to be populated", bundledCRD.crd.Name)
+		if bundledCRD.minimumBundleVersion == "" {
+			t.Fatalf("expected minimum bundle version for %q to be populated", bundledCRD.crd.Name)
+		}
+		if bundledCRD.minimumServedVersion == "" {
+			t.Fatalf("expected minimum served version for %q to be populated", bundledCRD.crd.Name)
+		}
+		if bundledCRD.crd.Name == "gateways.gateway.networking.k8s.io" {
+			if bundledCRD.requiredExactServedVersion != "v1" {
+				t.Fatalf("expected Gateway CRD to require exact served version v1, got %q", bundledCRD.requiredExactServedVersion)
+			}
+		} else if bundledCRD.requiredExactServedVersion != "" {
+			t.Fatalf("did not expect exact served version requirement for %q", bundledCRD.crd.Name)
 		}
 		if !strings.HasPrefix(bundledCRD.manifestPath, "crds_gateway_api/") {
 			t.Fatalf("unexpected manifest path %q", bundledCRD.manifestPath)
@@ -46,22 +56,22 @@ func TestEvaluateGatewayAPICRDState(t *testing.T) {
 
 	bundledCRDs := []bundledGatewayAPICRD{
 		{
-			crd:            testCRD("gateways.gateway.networking.k8s.io", "v1"),
-			storageVersion: "v1",
+			crd:                        testCRD("gateways.gateway.networking.k8s.io", "v1.5.1", "v1"),
+			minimumBundleVersion:       "v1.5.1",
+			minimumServedVersion:       "v1",
+			requiredExactServedVersion: "v1",
 		},
 		{
-			crd:            testCRD("httproutes.gateway.networking.k8s.io", "v1"),
-			storageVersion: "v1",
+			crd:                  testCRD("httproutes.gateway.networking.k8s.io", "v1.5.1", "v1"),
+			minimumBundleVersion: "v1.5.1",
+			minimumServedVersion: "v1",
 		},
 	}
 
 	t.Run("creates missing CRDs", func(t *testing.T) {
 		t.Parallel()
 
-		toCreate, mismatches, err := evaluateGatewayAPICRDState(bundledCRDs, map[string]*apiextensionsv1.CustomResourceDefinition{})
-		if err != nil {
-			t.Fatalf("evaluateGatewayAPICRDState returned error: %v", err)
-		}
+		toCreate, mismatches := evaluateGatewayAPICRDState(bundledCRDs, map[string]*apiextensionsv1.CustomResourceDefinition{})
 		if len(mismatches) != 0 {
 			t.Fatalf("expected no mismatches, got %v", mismatches)
 		}
@@ -70,34 +80,223 @@ func TestEvaluateGatewayAPICRDState(t *testing.T) {
 		}
 	})
 
-	t.Run("reports storage version mismatches", func(t *testing.T) {
+	t.Run("accepts equal and newer bundle versions when minimum API version is served", func(t *testing.T) {
 		t.Parallel()
 
 		clusterCRDs := map[string]*apiextensionsv1.CustomResourceDefinition{
-			"gateways.gateway.networking.k8s.io":   testCRD("gateways.gateway.networking.k8s.io", "v1beta1"),
-			"httproutes.gateway.networking.k8s.io": testCRD("httproutes.gateway.networking.k8s.io", "v1"),
+			"gateways.gateway.networking.k8s.io":   testCRD("gateways.gateway.networking.k8s.io", "v1.5.1", "v1"),
+			"httproutes.gateway.networking.k8s.io": testCRD("httproutes.gateway.networking.k8s.io", "v1.6.0", "v1"),
 		}
 
-		toCreate, mismatches, err := evaluateGatewayAPICRDState(bundledCRDs, clusterCRDs)
+		toCreate, mismatches := evaluateGatewayAPICRDState(bundledCRDs, clusterCRDs)
+		if len(toCreate) != 0 || len(mismatches) != 0 {
+			t.Fatalf("expected all CRDs to be compatible, got toCreate=%d mismatches=%v", len(toCreate), mismatches)
+		}
+	})
+
+	t.Run("accepts missing or invalid bundle version when minimum API version is served", func(t *testing.T) {
+		t.Parallel()
+
+		clusterCRDs := map[string]*apiextensionsv1.CustomResourceDefinition{
+			"gateways.gateway.networking.k8s.io":   testCRD("gateways.gateway.networking.k8s.io", "", "v1"),
+			"httproutes.gateway.networking.k8s.io": testCRD("httproutes.gateway.networking.k8s.io", "not-semver", "v1"),
+		}
+
+		toCreate, mismatches := evaluateGatewayAPICRDState(bundledCRDs, clusterCRDs)
+		if len(toCreate) != 0 || len(mismatches) != 0 {
+			t.Fatalf("expected all CRDs to be compatible, got toCreate=%d mismatches=%v", len(toCreate), mismatches)
+		}
+	})
+
+	t.Run("requires the exact API endpoint used by the controller", func(t *testing.T) {
+		t.Parallel()
+
+		for _, tc := range []struct {
+			name     string
+			versions []apiextensionsv1.CustomResourceDefinitionVersion
+			wantOK   bool
+		}{
+			{
+				name:     "only higher version",
+				versions: []apiextensionsv1.CustomResourceDefinitionVersion{{Name: "v2", Served: true, Storage: true}},
+			},
+			{
+				name: "exact and higher versions",
+				versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+					{Name: "v1", Served: true},
+					{Name: "v2", Served: true, Storage: true},
+				},
+				wantOK: true,
+			},
+			{
+				name: "exact version not served",
+				versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+					{Name: "v1", Served: false},
+					{Name: "v2", Served: true, Storage: true},
+				},
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				gatewayCRD := testCRD("gateways.gateway.networking.k8s.io", "v1.5.1", "v1")
+				gatewayCRD.Spec.Versions = tc.versions
+				clusterCRDs := map[string]*apiextensionsv1.CustomResourceDefinition{
+					"gateways.gateway.networking.k8s.io":   gatewayCRD,
+					"httproutes.gateway.networking.k8s.io": testCRD("httproutes.gateway.networking.k8s.io", "v1.5.1", "v1"),
+				}
+
+				_, mismatches := evaluateGatewayAPICRDState(bundledCRDs, clusterCRDs)
+				if tc.wantOK && len(mismatches) != 0 {
+					t.Fatalf("expected Gateway CRD to be compatible, got %v", mismatches)
+				}
+				if !tc.wantOK && (len(mismatches) != 1 || !strings.Contains(mismatches[0], "required API version v1 is not served")) {
+					t.Fatalf("expected exact version mismatch, got %v", mismatches)
+				}
+			})
+		}
+	})
+
+	t.Run("continues to accept a higher served API version for indirectly used resources", func(t *testing.T) {
+		t.Parallel()
+
+		minimumV1Beta1 := append([]bundledGatewayAPICRD(nil), bundledCRDs...)
+		minimumV1Beta1[1].minimumServedVersion = "v1beta1"
+		clusterCRDs := map[string]*apiextensionsv1.CustomResourceDefinition{
+			"gateways.gateway.networking.k8s.io":   testCRD("gateways.gateway.networking.k8s.io", "v1.5.1", "v1"),
+			"httproutes.gateway.networking.k8s.io": testCRD("httproutes.gateway.networking.k8s.io", "v1.5.1", "v1"),
+		}
+
+		toCreate, mismatches := evaluateGatewayAPICRDState(minimumV1Beta1, clusterCRDs)
+		if len(toCreate) != 0 || len(mismatches) != 0 {
+			t.Fatalf("expected all CRDs to be compatible, got toCreate=%d mismatches=%v", len(toCreate), mismatches)
+		}
+	})
+
+	for _, tc := range []struct {
+		name          string
+		bundleVersion string
+		servedVersion string
+		wantSubstring string
+	}{
+		{name: "reports older valid bundle versions", bundleVersion: "v1.5.0", servedVersion: "v1", wantSubstring: "cluster bundle=v1.5.0"},
+		{name: "reports equal bundle version when required API endpoint is not served", bundleVersion: "v1.5.1", servedVersion: "v1beta1", wantSubstring: "required API version v1 is not served"},
+		{name: "reports missing bundle version when required API endpoint is not served", bundleVersion: "", servedVersion: "v1beta1", wantSubstring: "required API version v1 is not served"},
+		{name: "reports invalid bundle version when required API endpoint is not served", bundleVersion: "1.6.0", servedVersion: "v1beta1", wantSubstring: "required API version v1 is not served"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			clusterCRDs := map[string]*apiextensionsv1.CustomResourceDefinition{
+				"gateways.gateway.networking.k8s.io":   testCRD("gateways.gateway.networking.k8s.io", tc.bundleVersion, tc.servedVersion),
+				"httproutes.gateway.networking.k8s.io": testCRD("httproutes.gateway.networking.k8s.io", "v1.5.1", "v1"),
+			}
+
+			toCreate, mismatches := evaluateGatewayAPICRDState(bundledCRDs, clusterCRDs)
+			if len(toCreate) != 0 {
+				t.Fatalf("expected no CRDs to create when all exist, got %d", len(toCreate))
+			}
+			if len(mismatches) != 1 || !strings.Contains(mismatches[0], tc.wantSubstring) {
+				t.Fatalf("expected one mismatch containing %q, got %v", tc.wantSubstring, mismatches)
+			}
+		})
+	}
+}
+
+func TestMinimumServedVersionForCRD(t *testing.T) {
+	t.Parallel()
+
+	newCRD := func(versions ...apiextensionsv1.CustomResourceDefinitionVersion) *apiextensionsv1.CustomResourceDefinition {
+		return &apiextensionsv1.CustomResourceDefinition{
+			ObjectMeta: metav1.ObjectMeta{Name: "example.gateway.networking.k8s.io"},
+			Spec:       apiextensionsv1.CustomResourceDefinitionSpec{Versions: versions},
+		}
+	}
+
+	t.Run("returns the storage version regardless of ordering", func(t *testing.T) {
+		t.Parallel()
+
+		// A served, non-storage version precedes the storage version. The result
+		// must be the storage version, not the first served version, so the
+		// compatibility contract does not depend on spec.versions ordering.
+		crd := newCRD(
+			apiextensionsv1.CustomResourceDefinitionVersion{Name: "v1beta1", Served: true, Storage: false},
+			apiextensionsv1.CustomResourceDefinitionVersion{Name: "v1", Served: true, Storage: true},
+		)
+
+		got, err := minimumServedVersionForCRD(crd)
 		if err != nil {
-			t.Fatalf("evaluateGatewayAPICRDState returned error: %v", err)
+			t.Fatalf("minimumServedVersionForCRD returned error: %v", err)
 		}
-		if len(toCreate) != 0 {
-			t.Fatalf("expected no CRDs to create when all exist, got %d", len(toCreate))
+		if got != "v1" {
+			t.Fatalf("expected minimum served version v1, got %q", got)
 		}
-		if len(mismatches) != 1 {
-			t.Fatalf("expected 1 mismatch, got %d (%v)", len(mismatches), mismatches)
+	})
+
+	t.Run("errors when the storage version is not served", func(t *testing.T) {
+		t.Parallel()
+
+		crd := newCRD(
+			apiextensionsv1.CustomResourceDefinitionVersion{Name: "v1beta1", Served: true, Storage: false},
+			apiextensionsv1.CustomResourceDefinitionVersion{Name: "v1", Served: false, Storage: true},
+		)
+
+		if _, err := minimumServedVersionForCRD(crd); err == nil {
+			t.Fatal("expected an error when the storage version is not served")
 		}
-		if !strings.Contains(mismatches[0], "gateways.gateway.networking.k8s.io") {
-			t.Fatalf("expected mismatch to mention CRD name, got %q", mismatches[0])
+	})
+
+	t.Run("errors when no storage version is declared", func(t *testing.T) {
+		t.Parallel()
+
+		crd := newCRD(
+			apiextensionsv1.CustomResourceDefinitionVersion{Name: "v1", Served: true, Storage: false},
+		)
+
+		if _, err := minimumServedVersionForCRD(crd); err == nil {
+			t.Fatal("expected an error when no storage version is declared")
 		}
 	})
 }
 
-func testCRD(name, storageVersion string) *apiextensionsv1.CustomResourceDefinition {
+func TestServesVersionOrHigher(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name           string
+		minimumVersion string
+		servedVersion  string
+		served         bool
+		want           bool
+	}{
+		{name: "exact version", minimumVersion: "v1beta1", servedVersion: "v1beta1", served: true, want: true},
+		{name: "stable satisfies beta minimum", minimumVersion: "v1beta1", servedVersion: "v1", served: true, want: true},
+		{name: "newer alpha satisfies minimum", minimumVersion: "v1alpha2", servedVersion: "v1alpha3", served: true, want: true},
+		{name: "older alpha does not satisfy minimum", minimumVersion: "v1alpha3", servedVersion: "v1alpha2", served: true, want: false},
+		{name: "non-served higher version does not satisfy minimum", minimumVersion: "v1beta1", servedVersion: "v1", served: false, want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			crd := testCRD("example.gateway.networking.k8s.io", "", tc.servedVersion)
+			crd.Spec.Versions[0].Served = tc.served
+			if got := servesVersionOrHigher(crd, tc.minimumVersion); got != tc.want {
+				t.Fatalf("servesVersionOrHigher() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func testCRD(name, bundleVersion, storageVersion string) *apiextensionsv1.CustomResourceDefinition {
+	annotations := map[string]string{}
+	if bundleVersion != "" {
+		annotations[gatewayAPIBundleVersionAnnotation] = bundleVersion
+	}
+
 	return &apiextensionsv1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
+			Name:        name,
+			Annotations: annotations,
 		},
 		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
 			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{


### PR DESCRIPTION
## Description

Improves how the istio `waypoint-controller` validates and reconciles the bundled Gateway API CRDs during its startup preflight.

Previously the preflight required the cluster CRD's **storage version** to exactly match the storage version of the bundled manifest. This was too rigid: a cluster running a newer, backward-compatible Gateway API bundle (or a vendor/user-supplied compatible CRD) would be flagged as a mismatch and block the controller from starting.

The preflight now evaluates compatibility along three explicit dimensions:

- **Minimum served API version** — a cluster CRD must serve the bundled CRD's   storage version *or a higher/more stable one* (compared using Kubernetes version-priority ordering). The storage version is used as the anchor because it is unique per CRD, making the check deterministic and independent of `spec.versions` ordering.
- **Required exact API endpoint** — CRDs the controller talks to directly (the `gateways.gateway.networking.k8s.io` resource, pinned to the `v1` version the controller is compiled against) must serve that exact version. Other ecosystem CRDs are validated only against the minimum-served-version heuristic.
- **Bundle version** — when a cluster CRD carries the upstream `gateway.networking.k8s.io/bundle-version` annotation and it is valid semver, it must be greater than or equal to the bundled minimum. Missing or invalid annotations are accepted (with a warning), since the annotation is upstream release metadata and not part of the CRD's API contract.

## Why do we need it, and what problem does it solve?

The strict storage-version equality check caused false-positive incompatibility reports that blocked the waypoint-controller from starting in clusters that had a compatible — but not byte-identical — set of Gateway API CRDs installed (e.g. a newer upstream bundle, or CRDs managed by another component). The new compatibility model accepts these valid configurations while still guaranteeing that the exact API version the controller depends on is served, preventing the controller from running against an incompatible Gateway API surface.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: fix
summary: Improve Gateway API CRD compatibility handling in the waypoint-controller preflight to avoid false-positive version mismatches.
impact_level: low
```