### PR TITLE
[node-manager] PSS: pod-policy-action warn for d8-cloud-instance-manager

### DIFF
--- a/modules/002-deckhouse/templates/namespace.yaml
+++ b/modules/002-deckhouse/templates/namespace.yaml
@@ -25,6 +25,7 @@ metadata:
     "extended-monitoring.deckhouse.io/enabled" ""
     "prometheus.deckhouse.io/rules-watcher-enabled" "true"
     "security.deckhouse.io/pod-policy" "restricted"
+    "security.deckhouse.io/pod-policy-action" "warn"
     "security.deckhouse.io/enable-security-policy-check" "true"
   )) | nindent 2 }}
 ---


### PR DESCRIPTION
## Description
follow https://github.com/deckhouse/deckhouse/pull/18515
Added `security.deckhouse.io/pod-policy-action: warn` label to the `d8-cloud-instance-manager` namespace.

## Why do we need it, and what problem does it solve?

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: node-manager
type: chore
summary: PSS pod-policy-action warn for d8-cloud-instance-manager
impact:
impact_level: low
```