### PR TITLE
[ci] Fallback to werf if ddk does not exist

### DIFF
--- a/.github/ci_templates/steps.yml
+++ b/.github/ci_templates/steps.yml
@@ -210,13 +210,38 @@
       echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
       exit 1
     fi
+    MINIMAL_DDK_VERSION="v2.62.1"
+    if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+      minimal_ddk_major=${BASH_REMATCH[1]}
+      minimal_ddk_minor=${BASH_REMATCH[2]}
+      minimal_ddk_patch=${BASH_REMATCH[3]}
+    fi
+    if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+      werf_current_major=${BASH_REMATCH[1]}
+      werf_current_minor=${BASH_REMATCH[2]}
+      werf_current_patch=${BASH_REMATCH[3]}
+    fi
+    if (( werf_current_major > minimal_ddk_major )); then
+      werf_fallback=false
+    elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+      werf_fallback=false
+    elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+      werf_fallback=false
+    else
+      werf_fallback=true
+    fi
     WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
     echo "$WERF_PATH" >> "$GITHUB_PATH"
     CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-    if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+    if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "false" ]]; then
       echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
       mkdir -p "$WERF_PATH"
       curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
+      chmod +x "$WERF_PATH/werf"
+    elif [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "true" ]]; then
+      echo "Current werf is $CACHED_VERSION, fallback to ${WERF_VERSION}";
+      mkdir -p "$WERF_PATH"
+      curl -Lsfo "$WERF_PATH/werf" https://tuf.werf.io/targets/releases/${WERF_VERSION#v}/linux-amd64/bin/werf
       chmod +x "$WERF_PATH/werf"
     else
       echo "Current werf is $CACHED_VERSION, skipping download"

--- a/.github/workflow_templates/build-and-test_dev.yml
+++ b/.github/workflow_templates/build-and-test_dev.yml
@@ -35,6 +35,7 @@ permissions:
   contents: read
   id-token: write
   pull-requests: read
+  packages: read
 
 jobs:
 {!{ tmpl.Exec "pull_request_info_job" $ctx | strings.Indent 2 }!}

--- a/.github/workflow_templates/build-and-test_main.yml
+++ b/.github/workflow_templates/build-and-test_main.yml
@@ -34,6 +34,7 @@ permissions:
   contents: read
   id-token: write
   pull-requests: read
+  packages: read
 
 jobs:
 {!{ tmpl.Exec "git_info_job" $ctx | strings.Indent 2 }!}

--- a/.github/workflow_templates/build-and-test_pre-release.yml
+++ b/.github/workflow_templates/build-and-test_pre-release.yml
@@ -34,6 +34,7 @@ permissions:
   contents: read
   id-token: write
   pull-requests: read
+  packages: read
 
 jobs:
 {!{ tmpl.Exec "git_info_job" $ctx | strings.Indent 2 }!}

--- a/.github/workflow_templates/build-and-test_release.yml
+++ b/.github/workflow_templates/build-and-test_release.yml
@@ -51,6 +51,7 @@ permissions:
   contents: read
   id-token: write
   pull-requests: read
+  packages: read
 
 jobs:
 {!{ tmpl.Exec "git_info_job" $ctx | strings.Indent 2 }!}

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -51,6 +51,7 @@ permissions:
   contents: read
   id-token: write
   pull-requests: read
+  packages: read
 
 jobs:
 
@@ -484,13 +485,38 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
+          MINIMAL_DDK_VERSION="v2.62.1"
+          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            minimal_ddk_major=${BASH_REMATCH[1]}
+            minimal_ddk_minor=${BASH_REMATCH[2]}
+            minimal_ddk_patch=${BASH_REMATCH[3]}
+          fi
+          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            werf_current_major=${BASH_REMATCH[1]}
+            werf_current_minor=${BASH_REMATCH[2]}
+            werf_current_patch=${BASH_REMATCH[3]}
+          fi
+          if (( werf_current_major > minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          else
+            werf_fallback=true
+          fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "false" ]]; then
             echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
             curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
+            chmod +x "$WERF_PATH/werf"
+          elif [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "true" ]]; then
+            echo "Current werf is $CACHED_VERSION, fallback to ${WERF_VERSION}";
+            mkdir -p "$WERF_PATH"
+            curl -Lsfo "$WERF_PATH/werf" https://tuf.werf.io/targets/releases/${WERF_VERSION#v}/linux-amd64/bin/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"
@@ -885,13 +911,38 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
+          MINIMAL_DDK_VERSION="v2.62.1"
+          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            minimal_ddk_major=${BASH_REMATCH[1]}
+            minimal_ddk_minor=${BASH_REMATCH[2]}
+            minimal_ddk_patch=${BASH_REMATCH[3]}
+          fi
+          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            werf_current_major=${BASH_REMATCH[1]}
+            werf_current_minor=${BASH_REMATCH[2]}
+            werf_current_patch=${BASH_REMATCH[3]}
+          fi
+          if (( werf_current_major > minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          else
+            werf_fallback=true
+          fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "false" ]]; then
             echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
             curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
+            chmod +x "$WERF_PATH/werf"
+          elif [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "true" ]]; then
+            echo "Current werf is $CACHED_VERSION, fallback to ${WERF_VERSION}";
+            mkdir -p "$WERF_PATH"
+            curl -Lsfo "$WERF_PATH/werf" https://tuf.werf.io/targets/releases/${WERF_VERSION#v}/linux-amd64/bin/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"
@@ -1051,13 +1102,38 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
+          MINIMAL_DDK_VERSION="v2.62.1"
+          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            minimal_ddk_major=${BASH_REMATCH[1]}
+            minimal_ddk_minor=${BASH_REMATCH[2]}
+            minimal_ddk_patch=${BASH_REMATCH[3]}
+          fi
+          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            werf_current_major=${BASH_REMATCH[1]}
+            werf_current_minor=${BASH_REMATCH[2]}
+            werf_current_patch=${BASH_REMATCH[3]}
+          fi
+          if (( werf_current_major > minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          else
+            werf_fallback=true
+          fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "false" ]]; then
             echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
             curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
+            chmod +x "$WERF_PATH/werf"
+          elif [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "true" ]]; then
+            echo "Current werf is $CACHED_VERSION, fallback to ${WERF_VERSION}";
+            mkdir -p "$WERF_PATH"
+            curl -Lsfo "$WERF_PATH/werf" https://tuf.werf.io/targets/releases/${WERF_VERSION#v}/linux-amd64/bin/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"
@@ -1197,13 +1273,38 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
+          MINIMAL_DDK_VERSION="v2.62.1"
+          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            minimal_ddk_major=${BASH_REMATCH[1]}
+            minimal_ddk_minor=${BASH_REMATCH[2]}
+            minimal_ddk_patch=${BASH_REMATCH[3]}
+          fi
+          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            werf_current_major=${BASH_REMATCH[1]}
+            werf_current_minor=${BASH_REMATCH[2]}
+            werf_current_patch=${BASH_REMATCH[3]}
+          fi
+          if (( werf_current_major > minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          else
+            werf_fallback=true
+          fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "false" ]]; then
             echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
             curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
+            chmod +x "$WERF_PATH/werf"
+          elif [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "true" ]]; then
+            echo "Current werf is $CACHED_VERSION, fallback to ${WERF_VERSION}";
+            mkdir -p "$WERF_PATH"
+            curl -Lsfo "$WERF_PATH/werf" https://tuf.werf.io/targets/releases/${WERF_VERSION#v}/linux-amd64/bin/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"
@@ -1612,13 +1713,38 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
+          MINIMAL_DDK_VERSION="v2.62.1"
+          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            minimal_ddk_major=${BASH_REMATCH[1]}
+            minimal_ddk_minor=${BASH_REMATCH[2]}
+            minimal_ddk_patch=${BASH_REMATCH[3]}
+          fi
+          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            werf_current_major=${BASH_REMATCH[1]}
+            werf_current_minor=${BASH_REMATCH[2]}
+            werf_current_patch=${BASH_REMATCH[3]}
+          fi
+          if (( werf_current_major > minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          else
+            werf_fallback=true
+          fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "false" ]]; then
             echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
             curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
+            chmod +x "$WERF_PATH/werf"
+          elif [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "true" ]]; then
+            echo "Current werf is $CACHED_VERSION, fallback to ${WERF_VERSION}";
+            mkdir -p "$WERF_PATH"
+            curl -Lsfo "$WERF_PATH/werf" https://tuf.werf.io/targets/releases/${WERF_VERSION#v}/linux-amd64/bin/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"
@@ -2027,13 +2153,38 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
+          MINIMAL_DDK_VERSION="v2.62.1"
+          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            minimal_ddk_major=${BASH_REMATCH[1]}
+            minimal_ddk_minor=${BASH_REMATCH[2]}
+            minimal_ddk_patch=${BASH_REMATCH[3]}
+          fi
+          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            werf_current_major=${BASH_REMATCH[1]}
+            werf_current_minor=${BASH_REMATCH[2]}
+            werf_current_patch=${BASH_REMATCH[3]}
+          fi
+          if (( werf_current_major > minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          else
+            werf_fallback=true
+          fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "false" ]]; then
             echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
             curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
+            chmod +x "$WERF_PATH/werf"
+          elif [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "true" ]]; then
+            echo "Current werf is $CACHED_VERSION, fallback to ${WERF_VERSION}";
+            mkdir -p "$WERF_PATH"
+            curl -Lsfo "$WERF_PATH/werf" https://tuf.werf.io/targets/releases/${WERF_VERSION#v}/linux-amd64/bin/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"
@@ -2442,13 +2593,38 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
+          MINIMAL_DDK_VERSION="v2.62.1"
+          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            minimal_ddk_major=${BASH_REMATCH[1]}
+            minimal_ddk_minor=${BASH_REMATCH[2]}
+            minimal_ddk_patch=${BASH_REMATCH[3]}
+          fi
+          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            werf_current_major=${BASH_REMATCH[1]}
+            werf_current_minor=${BASH_REMATCH[2]}
+            werf_current_patch=${BASH_REMATCH[3]}
+          fi
+          if (( werf_current_major > minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          else
+            werf_fallback=true
+          fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "false" ]]; then
             echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
             curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
+            chmod +x "$WERF_PATH/werf"
+          elif [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "true" ]]; then
+            echo "Current werf is $CACHED_VERSION, fallback to ${WERF_VERSION}";
+            mkdir -p "$WERF_PATH"
+            curl -Lsfo "$WERF_PATH/werf" https://tuf.werf.io/targets/releases/${WERF_VERSION#v}/linux-amd64/bin/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"
@@ -2857,13 +3033,38 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
+          MINIMAL_DDK_VERSION="v2.62.1"
+          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            minimal_ddk_major=${BASH_REMATCH[1]}
+            minimal_ddk_minor=${BASH_REMATCH[2]}
+            minimal_ddk_patch=${BASH_REMATCH[3]}
+          fi
+          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            werf_current_major=${BASH_REMATCH[1]}
+            werf_current_minor=${BASH_REMATCH[2]}
+            werf_current_patch=${BASH_REMATCH[3]}
+          fi
+          if (( werf_current_major > minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          else
+            werf_fallback=true
+          fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "false" ]]; then
             echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
             curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
+            chmod +x "$WERF_PATH/werf"
+          elif [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "true" ]]; then
+            echo "Current werf is $CACHED_VERSION, fallback to ${WERF_VERSION}";
+            mkdir -p "$WERF_PATH"
+            curl -Lsfo "$WERF_PATH/werf" https://tuf.werf.io/targets/releases/${WERF_VERSION#v}/linux-amd64/bin/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"
@@ -3272,13 +3473,38 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
+          MINIMAL_DDK_VERSION="v2.62.1"
+          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            minimal_ddk_major=${BASH_REMATCH[1]}
+            minimal_ddk_minor=${BASH_REMATCH[2]}
+            minimal_ddk_patch=${BASH_REMATCH[3]}
+          fi
+          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            werf_current_major=${BASH_REMATCH[1]}
+            werf_current_minor=${BASH_REMATCH[2]}
+            werf_current_patch=${BASH_REMATCH[3]}
+          fi
+          if (( werf_current_major > minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          else
+            werf_fallback=true
+          fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "false" ]]; then
             echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
             curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
+            chmod +x "$WERF_PATH/werf"
+          elif [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "true" ]]; then
+            echo "Current werf is $CACHED_VERSION, fallback to ${WERF_VERSION}";
+            mkdir -p "$WERF_PATH"
+            curl -Lsfo "$WERF_PATH/werf" https://tuf.werf.io/targets/releases/${WERF_VERSION#v}/linux-amd64/bin/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"

--- a/.github/workflows/build-and-test_main.yml
+++ b/.github/workflows/build-and-test_main.yml
@@ -51,6 +51,7 @@ permissions:
   contents: read
   id-token: write
   pull-requests: read
+  packages: read
 
 jobs:
 
@@ -247,13 +248,38 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
+          MINIMAL_DDK_VERSION="v2.62.1"
+          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            minimal_ddk_major=${BASH_REMATCH[1]}
+            minimal_ddk_minor=${BASH_REMATCH[2]}
+            minimal_ddk_patch=${BASH_REMATCH[3]}
+          fi
+          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            werf_current_major=${BASH_REMATCH[1]}
+            werf_current_minor=${BASH_REMATCH[2]}
+            werf_current_patch=${BASH_REMATCH[3]}
+          fi
+          if (( werf_current_major > minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          else
+            werf_fallback=true
+          fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "false" ]]; then
             echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
             curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
+            chmod +x "$WERF_PATH/werf"
+          elif [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "true" ]]; then
+            echo "Current werf is $CACHED_VERSION, fallback to ${WERF_VERSION}";
+            mkdir -p "$WERF_PATH"
+            curl -Lsfo "$WERF_PATH/werf" https://tuf.werf.io/targets/releases/${WERF_VERSION#v}/linux-amd64/bin/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"
@@ -629,13 +655,38 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
+          MINIMAL_DDK_VERSION="v2.62.1"
+          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            minimal_ddk_major=${BASH_REMATCH[1]}
+            minimal_ddk_minor=${BASH_REMATCH[2]}
+            minimal_ddk_patch=${BASH_REMATCH[3]}
+          fi
+          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            werf_current_major=${BASH_REMATCH[1]}
+            werf_current_minor=${BASH_REMATCH[2]}
+            werf_current_patch=${BASH_REMATCH[3]}
+          fi
+          if (( werf_current_major > minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          else
+            werf_fallback=true
+          fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "false" ]]; then
             echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
             curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
+            chmod +x "$WERF_PATH/werf"
+          elif [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "true" ]]; then
+            echo "Current werf is $CACHED_VERSION, fallback to ${WERF_VERSION}";
+            mkdir -p "$WERF_PATH"
+            curl -Lsfo "$WERF_PATH/werf" https://tuf.werf.io/targets/releases/${WERF_VERSION#v}/linux-amd64/bin/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"
@@ -793,13 +844,38 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
+          MINIMAL_DDK_VERSION="v2.62.1"
+          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            minimal_ddk_major=${BASH_REMATCH[1]}
+            minimal_ddk_minor=${BASH_REMATCH[2]}
+            minimal_ddk_patch=${BASH_REMATCH[3]}
+          fi
+          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            werf_current_major=${BASH_REMATCH[1]}
+            werf_current_minor=${BASH_REMATCH[2]}
+            werf_current_patch=${BASH_REMATCH[3]}
+          fi
+          if (( werf_current_major > minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          else
+            werf_fallback=true
+          fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "false" ]]; then
             echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
             curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
+            chmod +x "$WERF_PATH/werf"
+          elif [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "true" ]]; then
+            echo "Current werf is $CACHED_VERSION, fallback to ${WERF_VERSION}";
+            mkdir -p "$WERF_PATH"
+            curl -Lsfo "$WERF_PATH/werf" https://tuf.werf.io/targets/releases/${WERF_VERSION#v}/linux-amd64/bin/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"
@@ -1842,13 +1918,38 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
+          MINIMAL_DDK_VERSION="v2.62.1"
+          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            minimal_ddk_major=${BASH_REMATCH[1]}
+            minimal_ddk_minor=${BASH_REMATCH[2]}
+            minimal_ddk_patch=${BASH_REMATCH[3]}
+          fi
+          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            werf_current_major=${BASH_REMATCH[1]}
+            werf_current_minor=${BASH_REMATCH[2]}
+            werf_current_patch=${BASH_REMATCH[3]}
+          fi
+          if (( werf_current_major > minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          else
+            werf_fallback=true
+          fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "false" ]]; then
             echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
             curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
+            chmod +x "$WERF_PATH/werf"
+          elif [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "true" ]]; then
+            echo "Current werf is $CACHED_VERSION, fallback to ${WERF_VERSION}";
+            mkdir -p "$WERF_PATH"
+            curl -Lsfo "$WERF_PATH/werf" https://tuf.werf.io/targets/releases/${WERF_VERSION#v}/linux-amd64/bin/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -51,6 +51,7 @@ permissions:
   contents: read
   id-token: write
   pull-requests: read
+  packages: read
 
 jobs:
 
@@ -247,13 +248,38 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
+          MINIMAL_DDK_VERSION="v2.62.1"
+          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            minimal_ddk_major=${BASH_REMATCH[1]}
+            minimal_ddk_minor=${BASH_REMATCH[2]}
+            minimal_ddk_patch=${BASH_REMATCH[3]}
+          fi
+          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            werf_current_major=${BASH_REMATCH[1]}
+            werf_current_minor=${BASH_REMATCH[2]}
+            werf_current_patch=${BASH_REMATCH[3]}
+          fi
+          if (( werf_current_major > minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          else
+            werf_fallback=true
+          fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "false" ]]; then
             echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
             curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
+            chmod +x "$WERF_PATH/werf"
+          elif [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "true" ]]; then
+            echo "Current werf is $CACHED_VERSION, fallback to ${WERF_VERSION}";
+            mkdir -p "$WERF_PATH"
+            curl -Lsfo "$WERF_PATH/werf" https://tuf.werf.io/targets/releases/${WERF_VERSION#v}/linux-amd64/bin/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"
@@ -629,13 +655,38 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
+          MINIMAL_DDK_VERSION="v2.62.1"
+          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            minimal_ddk_major=${BASH_REMATCH[1]}
+            minimal_ddk_minor=${BASH_REMATCH[2]}
+            minimal_ddk_patch=${BASH_REMATCH[3]}
+          fi
+          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            werf_current_major=${BASH_REMATCH[1]}
+            werf_current_minor=${BASH_REMATCH[2]}
+            werf_current_patch=${BASH_REMATCH[3]}
+          fi
+          if (( werf_current_major > minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          else
+            werf_fallback=true
+          fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "false" ]]; then
             echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
             curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
+            chmod +x "$WERF_PATH/werf"
+          elif [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "true" ]]; then
+            echo "Current werf is $CACHED_VERSION, fallback to ${WERF_VERSION}";
+            mkdir -p "$WERF_PATH"
+            curl -Lsfo "$WERF_PATH/werf" https://tuf.werf.io/targets/releases/${WERF_VERSION#v}/linux-amd64/bin/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"
@@ -793,13 +844,38 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
+          MINIMAL_DDK_VERSION="v2.62.1"
+          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            minimal_ddk_major=${BASH_REMATCH[1]}
+            minimal_ddk_minor=${BASH_REMATCH[2]}
+            minimal_ddk_patch=${BASH_REMATCH[3]}
+          fi
+          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            werf_current_major=${BASH_REMATCH[1]}
+            werf_current_minor=${BASH_REMATCH[2]}
+            werf_current_patch=${BASH_REMATCH[3]}
+          fi
+          if (( werf_current_major > minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          else
+            werf_fallback=true
+          fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "false" ]]; then
             echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
             curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
+            chmod +x "$WERF_PATH/werf"
+          elif [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "true" ]]; then
+            echo "Current werf is $CACHED_VERSION, fallback to ${WERF_VERSION}";
+            mkdir -p "$WERF_PATH"
+            curl -Lsfo "$WERF_PATH/werf" https://tuf.werf.io/targets/releases/${WERF_VERSION#v}/linux-amd64/bin/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"
@@ -934,13 +1010,38 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
+          MINIMAL_DDK_VERSION="v2.62.1"
+          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            minimal_ddk_major=${BASH_REMATCH[1]}
+            minimal_ddk_minor=${BASH_REMATCH[2]}
+            minimal_ddk_patch=${BASH_REMATCH[3]}
+          fi
+          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            werf_current_major=${BASH_REMATCH[1]}
+            werf_current_minor=${BASH_REMATCH[2]}
+            werf_current_patch=${BASH_REMATCH[3]}
+          fi
+          if (( werf_current_major > minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          else
+            werf_fallback=true
+          fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "false" ]]; then
             echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
             curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
+            chmod +x "$WERF_PATH/werf"
+          elif [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "true" ]]; then
+            echo "Current werf is $CACHED_VERSION, fallback to ${WERF_VERSION}";
+            mkdir -p "$WERF_PATH"
+            curl -Lsfo "$WERF_PATH/werf" https://tuf.werf.io/targets/releases/${WERF_VERSION#v}/linux-amd64/bin/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"
@@ -1328,13 +1429,38 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
+          MINIMAL_DDK_VERSION="v2.62.1"
+          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            minimal_ddk_major=${BASH_REMATCH[1]}
+            minimal_ddk_minor=${BASH_REMATCH[2]}
+            minimal_ddk_patch=${BASH_REMATCH[3]}
+          fi
+          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            werf_current_major=${BASH_REMATCH[1]}
+            werf_current_minor=${BASH_REMATCH[2]}
+            werf_current_patch=${BASH_REMATCH[3]}
+          fi
+          if (( werf_current_major > minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          else
+            werf_fallback=true
+          fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "false" ]]; then
             echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
             curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
+            chmod +x "$WERF_PATH/werf"
+          elif [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "true" ]]; then
+            echo "Current werf is $CACHED_VERSION, fallback to ${WERF_VERSION}";
+            mkdir -p "$WERF_PATH"
+            curl -Lsfo "$WERF_PATH/werf" https://tuf.werf.io/targets/releases/${WERF_VERSION#v}/linux-amd64/bin/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"
@@ -1722,13 +1848,38 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
+          MINIMAL_DDK_VERSION="v2.62.1"
+          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            minimal_ddk_major=${BASH_REMATCH[1]}
+            minimal_ddk_minor=${BASH_REMATCH[2]}
+            minimal_ddk_patch=${BASH_REMATCH[3]}
+          fi
+          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            werf_current_major=${BASH_REMATCH[1]}
+            werf_current_minor=${BASH_REMATCH[2]}
+            werf_current_patch=${BASH_REMATCH[3]}
+          fi
+          if (( werf_current_major > minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          else
+            werf_fallback=true
+          fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "false" ]]; then
             echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
             curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
+            chmod +x "$WERF_PATH/werf"
+          elif [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "true" ]]; then
+            echo "Current werf is $CACHED_VERSION, fallback to ${WERF_VERSION}";
+            mkdir -p "$WERF_PATH"
+            curl -Lsfo "$WERF_PATH/werf" https://tuf.werf.io/targets/releases/${WERF_VERSION#v}/linux-amd64/bin/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"
@@ -2116,13 +2267,38 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
+          MINIMAL_DDK_VERSION="v2.62.1"
+          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            minimal_ddk_major=${BASH_REMATCH[1]}
+            minimal_ddk_minor=${BASH_REMATCH[2]}
+            minimal_ddk_patch=${BASH_REMATCH[3]}
+          fi
+          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            werf_current_major=${BASH_REMATCH[1]}
+            werf_current_minor=${BASH_REMATCH[2]}
+            werf_current_patch=${BASH_REMATCH[3]}
+          fi
+          if (( werf_current_major > minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          else
+            werf_fallback=true
+          fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "false" ]]; then
             echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
             curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
+            chmod +x "$WERF_PATH/werf"
+          elif [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "true" ]]; then
+            echo "Current werf is $CACHED_VERSION, fallback to ${WERF_VERSION}";
+            mkdir -p "$WERF_PATH"
+            curl -Lsfo "$WERF_PATH/werf" https://tuf.werf.io/targets/releases/${WERF_VERSION#v}/linux-amd64/bin/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"
@@ -2510,13 +2686,38 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
+          MINIMAL_DDK_VERSION="v2.62.1"
+          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            minimal_ddk_major=${BASH_REMATCH[1]}
+            minimal_ddk_minor=${BASH_REMATCH[2]}
+            minimal_ddk_patch=${BASH_REMATCH[3]}
+          fi
+          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            werf_current_major=${BASH_REMATCH[1]}
+            werf_current_minor=${BASH_REMATCH[2]}
+            werf_current_patch=${BASH_REMATCH[3]}
+          fi
+          if (( werf_current_major > minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          else
+            werf_fallback=true
+          fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "false" ]]; then
             echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
             curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
+            chmod +x "$WERF_PATH/werf"
+          elif [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "true" ]]; then
+            echo "Current werf is $CACHED_VERSION, fallback to ${WERF_VERSION}";
+            mkdir -p "$WERF_PATH"
+            curl -Lsfo "$WERF_PATH/werf" https://tuf.werf.io/targets/releases/${WERF_VERSION#v}/linux-amd64/bin/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"
@@ -2904,13 +3105,38 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
+          MINIMAL_DDK_VERSION="v2.62.1"
+          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            minimal_ddk_major=${BASH_REMATCH[1]}
+            minimal_ddk_minor=${BASH_REMATCH[2]}
+            minimal_ddk_patch=${BASH_REMATCH[3]}
+          fi
+          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            werf_current_major=${BASH_REMATCH[1]}
+            werf_current_minor=${BASH_REMATCH[2]}
+            werf_current_patch=${BASH_REMATCH[3]}
+          fi
+          if (( werf_current_major > minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          else
+            werf_fallback=true
+          fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "false" ]]; then
             echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
             curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
+            chmod +x "$WERF_PATH/werf"
+          elif [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "true" ]]; then
+            echo "Current werf is $CACHED_VERSION, fallback to ${WERF_VERSION}";
+            mkdir -p "$WERF_PATH"
+            curl -Lsfo "$WERF_PATH/werf" https://tuf.werf.io/targets/releases/${WERF_VERSION#v}/linux-amd64/bin/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"
@@ -4232,13 +4458,38 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
+          MINIMAL_DDK_VERSION="v2.62.1"
+          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            minimal_ddk_major=${BASH_REMATCH[1]}
+            minimal_ddk_minor=${BASH_REMATCH[2]}
+            minimal_ddk_patch=${BASH_REMATCH[3]}
+          fi
+          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            werf_current_major=${BASH_REMATCH[1]}
+            werf_current_minor=${BASH_REMATCH[2]}
+            werf_current_patch=${BASH_REMATCH[3]}
+          fi
+          if (( werf_current_major > minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          else
+            werf_fallback=true
+          fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "false" ]]; then
             echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
             curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
+            chmod +x "$WERF_PATH/werf"
+          elif [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "true" ]]; then
+            echo "Current werf is $CACHED_VERSION, fallback to ${WERF_VERSION}";
+            mkdir -p "$WERF_PATH"
+            curl -Lsfo "$WERF_PATH/werf" https://tuf.werf.io/targets/releases/${WERF_VERSION#v}/linux-amd64/bin/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -68,6 +68,7 @@ permissions:
   contents: read
   id-token: write
   pull-requests: read
+  packages: read
 
 jobs:
 
@@ -368,13 +369,38 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
+          MINIMAL_DDK_VERSION="v2.62.1"
+          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            minimal_ddk_major=${BASH_REMATCH[1]}
+            minimal_ddk_minor=${BASH_REMATCH[2]}
+            minimal_ddk_patch=${BASH_REMATCH[3]}
+          fi
+          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            werf_current_major=${BASH_REMATCH[1]}
+            werf_current_minor=${BASH_REMATCH[2]}
+            werf_current_patch=${BASH_REMATCH[3]}
+          fi
+          if (( werf_current_major > minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          else
+            werf_fallback=true
+          fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "false" ]]; then
             echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
             curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
+            chmod +x "$WERF_PATH/werf"
+          elif [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "true" ]]; then
+            echo "Current werf is $CACHED_VERSION, fallback to ${WERF_VERSION}";
+            mkdir -p "$WERF_PATH"
+            curl -Lsfo "$WERF_PATH/werf" https://tuf.werf.io/targets/releases/${WERF_VERSION#v}/linux-amd64/bin/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"
@@ -794,13 +820,38 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
+          MINIMAL_DDK_VERSION="v2.62.1"
+          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            minimal_ddk_major=${BASH_REMATCH[1]}
+            minimal_ddk_minor=${BASH_REMATCH[2]}
+            minimal_ddk_patch=${BASH_REMATCH[3]}
+          fi
+          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            werf_current_major=${BASH_REMATCH[1]}
+            werf_current_minor=${BASH_REMATCH[2]}
+            werf_current_patch=${BASH_REMATCH[3]}
+          fi
+          if (( werf_current_major > minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          else
+            werf_fallback=true
+          fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "false" ]]; then
             echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
             curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
+            chmod +x "$WERF_PATH/werf"
+          elif [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "true" ]]; then
+            echo "Current werf is $CACHED_VERSION, fallback to ${WERF_VERSION}";
+            mkdir -p "$WERF_PATH"
+            curl -Lsfo "$WERF_PATH/werf" https://tuf.werf.io/targets/releases/${WERF_VERSION#v}/linux-amd64/bin/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"
@@ -1221,13 +1272,38 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
+          MINIMAL_DDK_VERSION="v2.62.1"
+          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            minimal_ddk_major=${BASH_REMATCH[1]}
+            minimal_ddk_minor=${BASH_REMATCH[2]}
+            minimal_ddk_patch=${BASH_REMATCH[3]}
+          fi
+          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            werf_current_major=${BASH_REMATCH[1]}
+            werf_current_minor=${BASH_REMATCH[2]}
+            werf_current_patch=${BASH_REMATCH[3]}
+          fi
+          if (( werf_current_major > minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          else
+            werf_fallback=true
+          fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "false" ]]; then
             echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
             curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
+            chmod +x "$WERF_PATH/werf"
+          elif [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "true" ]]; then
+            echo "Current werf is $CACHED_VERSION, fallback to ${WERF_VERSION}";
+            mkdir -p "$WERF_PATH"
+            curl -Lsfo "$WERF_PATH/werf" https://tuf.werf.io/targets/releases/${WERF_VERSION#v}/linux-amd64/bin/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"
@@ -1648,13 +1724,38 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
+          MINIMAL_DDK_VERSION="v2.62.1"
+          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            minimal_ddk_major=${BASH_REMATCH[1]}
+            minimal_ddk_minor=${BASH_REMATCH[2]}
+            minimal_ddk_patch=${BASH_REMATCH[3]}
+          fi
+          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            werf_current_major=${BASH_REMATCH[1]}
+            werf_current_minor=${BASH_REMATCH[2]}
+            werf_current_patch=${BASH_REMATCH[3]}
+          fi
+          if (( werf_current_major > minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          else
+            werf_fallback=true
+          fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "false" ]]; then
             echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
             curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
+            chmod +x "$WERF_PATH/werf"
+          elif [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "true" ]]; then
+            echo "Current werf is $CACHED_VERSION, fallback to ${WERF_VERSION}";
+            mkdir -p "$WERF_PATH"
+            curl -Lsfo "$WERF_PATH/werf" https://tuf.werf.io/targets/releases/${WERF_VERSION#v}/linux-amd64/bin/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"
@@ -2075,13 +2176,38 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
+          MINIMAL_DDK_VERSION="v2.62.1"
+          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            minimal_ddk_major=${BASH_REMATCH[1]}
+            minimal_ddk_minor=${BASH_REMATCH[2]}
+            minimal_ddk_patch=${BASH_REMATCH[3]}
+          fi
+          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            werf_current_major=${BASH_REMATCH[1]}
+            werf_current_minor=${BASH_REMATCH[2]}
+            werf_current_patch=${BASH_REMATCH[3]}
+          fi
+          if (( werf_current_major > minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          else
+            werf_fallback=true
+          fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "false" ]]; then
             echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
             curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
+            chmod +x "$WERF_PATH/werf"
+          elif [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "true" ]]; then
+            echo "Current werf is $CACHED_VERSION, fallback to ${WERF_VERSION}";
+            mkdir -p "$WERF_PATH"
+            curl -Lsfo "$WERF_PATH/werf" https://tuf.werf.io/targets/releases/${WERF_VERSION#v}/linux-amd64/bin/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"
@@ -2502,13 +2628,38 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
+          MINIMAL_DDK_VERSION="v2.62.1"
+          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            minimal_ddk_major=${BASH_REMATCH[1]}
+            minimal_ddk_minor=${BASH_REMATCH[2]}
+            minimal_ddk_patch=${BASH_REMATCH[3]}
+          fi
+          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            werf_current_major=${BASH_REMATCH[1]}
+            werf_current_minor=${BASH_REMATCH[2]}
+            werf_current_patch=${BASH_REMATCH[3]}
+          fi
+          if (( werf_current_major > minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          else
+            werf_fallback=true
+          fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "false" ]]; then
             echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
             curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
+            chmod +x "$WERF_PATH/werf"
+          elif [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "true" ]]; then
+            echo "Current werf is $CACHED_VERSION, fallback to ${WERF_VERSION}";
+            mkdir -p "$WERF_PATH"
+            curl -Lsfo "$WERF_PATH/werf" https://tuf.werf.io/targets/releases/${WERF_VERSION#v}/linux-amd64/bin/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"

--- a/.github/workflows/docs-pdf-daily.yml
+++ b/.github/workflows/docs-pdf-daily.yml
@@ -170,13 +170,38 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
+          MINIMAL_DDK_VERSION="v2.62.1"
+          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            minimal_ddk_major=${BASH_REMATCH[1]}
+            minimal_ddk_minor=${BASH_REMATCH[2]}
+            minimal_ddk_patch=${BASH_REMATCH[3]}
+          fi
+          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            werf_current_major=${BASH_REMATCH[1]}
+            werf_current_minor=${BASH_REMATCH[2]}
+            werf_current_patch=${BASH_REMATCH[3]}
+          fi
+          if (( werf_current_major > minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          else
+            werf_fallback=true
+          fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "false" ]]; then
             echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
             curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
+            chmod +x "$WERF_PATH/werf"
+          elif [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "true" ]]; then
+            echo "Current werf is $CACHED_VERSION, fallback to ${WERF_VERSION}";
+            mkdir -p "$WERF_PATH"
+            curl -Lsfo "$WERF_PATH/werf" https://tuf.werf.io/targets/releases/${WERF_VERSION#v}/linux-amd64/bin/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"

--- a/.github/workflows/k8s-autoupdate.yml
+++ b/.github/workflows/k8s-autoupdate.yml
@@ -69,13 +69,38 @@ jobs:
           echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
           exit 1
         fi
+        MINIMAL_DDK_VERSION="v2.62.1"
+        if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+          minimal_ddk_major=${BASH_REMATCH[1]}
+          minimal_ddk_minor=${BASH_REMATCH[2]}
+          minimal_ddk_patch=${BASH_REMATCH[3]}
+        fi
+        if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+          werf_current_major=${BASH_REMATCH[1]}
+          werf_current_minor=${BASH_REMATCH[2]}
+          werf_current_patch=${BASH_REMATCH[3]}
+        fi
+        if (( werf_current_major > minimal_ddk_major )); then
+          werf_fallback=false
+        elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+          werf_fallback=false
+        elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+          werf_fallback=false
+        else
+          werf_fallback=true
+        fi
         WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
         echo "$WERF_PATH" >> "$GITHUB_PATH"
         CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-        if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+        if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "false" ]]; then
           echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
           mkdir -p "$WERF_PATH"
           curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
+          chmod +x "$WERF_PATH/werf"
+        elif [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "true" ]]; then
+          echo "Current werf is $CACHED_VERSION, fallback to ${WERF_VERSION}";
+          mkdir -p "$WERF_PATH"
+          curl -Lsfo "$WERF_PATH/werf" https://tuf.werf.io/targets/releases/${WERF_VERSION#v}/linux-amd64/bin/werf
           chmod +x "$WERF_PATH/werf"
         else
           echo "Current werf is $CACHED_VERSION, skipping download"

--- a/.github/workflows/reproducibility-check.yml
+++ b/.github/workflows/reproducibility-check.yml
@@ -440,13 +440,38 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
+          MINIMAL_DDK_VERSION="v2.62.1"
+          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            minimal_ddk_major=${BASH_REMATCH[1]}
+            minimal_ddk_minor=${BASH_REMATCH[2]}
+            minimal_ddk_patch=${BASH_REMATCH[3]}
+          fi
+          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            werf_current_major=${BASH_REMATCH[1]}
+            werf_current_minor=${BASH_REMATCH[2]}
+            werf_current_patch=${BASH_REMATCH[3]}
+          fi
+          if (( werf_current_major > minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          else
+            werf_fallback=true
+          fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "false" ]]; then
             echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
             curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
+            chmod +x "$WERF_PATH/werf"
+          elif [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "true" ]]; then
+            echo "Current werf is $CACHED_VERSION, fallback to ${WERF_VERSION}";
+            mkdir -p "$WERF_PATH"
+            curl -Lsfo "$WERF_PATH/werf" https://tuf.werf.io/targets/releases/${WERF_VERSION#v}/linux-amd64/bin/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"
@@ -853,13 +878,38 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
+          MINIMAL_DDK_VERSION="v2.62.1"
+          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            minimal_ddk_major=${BASH_REMATCH[1]}
+            minimal_ddk_minor=${BASH_REMATCH[2]}
+            minimal_ddk_patch=${BASH_REMATCH[3]}
+          fi
+          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            werf_current_major=${BASH_REMATCH[1]}
+            werf_current_minor=${BASH_REMATCH[2]}
+            werf_current_patch=${BASH_REMATCH[3]}
+          fi
+          if (( werf_current_major > minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          else
+            werf_fallback=true
+          fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "false" ]]; then
             echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
             curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
+            chmod +x "$WERF_PATH/werf"
+          elif [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "true" ]]; then
+            echo "Current werf is $CACHED_VERSION, fallback to ${WERF_VERSION}";
+            mkdir -p "$WERF_PATH"
+            curl -Lsfo "$WERF_PATH/werf" https://tuf.werf.io/targets/releases/${WERF_VERSION#v}/linux-amd64/bin/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"

--- a/.github/workflows/stage_registry_clean.yml
+++ b/.github/workflows/stage_registry_clean.yml
@@ -119,13 +119,38 @@ jobs:
           echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
           exit 1
         fi
+        MINIMAL_DDK_VERSION="v2.62.1"
+        if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+          minimal_ddk_major=${BASH_REMATCH[1]}
+          minimal_ddk_minor=${BASH_REMATCH[2]}
+          minimal_ddk_patch=${BASH_REMATCH[3]}
+        fi
+        if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+          werf_current_major=${BASH_REMATCH[1]}
+          werf_current_minor=${BASH_REMATCH[2]}
+          werf_current_patch=${BASH_REMATCH[3]}
+        fi
+        if (( werf_current_major > minimal_ddk_major )); then
+          werf_fallback=false
+        elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+          werf_fallback=false
+        elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+          werf_fallback=false
+        else
+          werf_fallback=true
+        fi
         WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
         echo "$WERF_PATH" >> "$GITHUB_PATH"
         CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-        if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+        if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "false" ]]; then
           echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
           mkdir -p "$WERF_PATH"
           curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
+          chmod +x "$WERF_PATH/werf"
+        elif [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "true" ]]; then
+          echo "Current werf is $CACHED_VERSION, fallback to ${WERF_VERSION}";
+          mkdir -p "$WERF_PATH"
+          curl -Lsfo "$WERF_PATH/werf" https://tuf.werf.io/targets/releases/${WERF_VERSION#v}/linux-amd64/bin/werf
           chmod +x "$WERF_PATH/werf"
         else
           echo "Current werf is $CACHED_VERSION, skipping download"

--- a/.github/workflows/svace.yml
+++ b/.github/workflows/svace.yml
@@ -244,13 +244,38 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
+          MINIMAL_DDK_VERSION="v2.62.1"
+          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            minimal_ddk_major=${BASH_REMATCH[1]}
+            minimal_ddk_minor=${BASH_REMATCH[2]}
+            minimal_ddk_patch=${BASH_REMATCH[3]}
+          fi
+          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            werf_current_major=${BASH_REMATCH[1]}
+            werf_current_minor=${BASH_REMATCH[2]}
+            werf_current_patch=${BASH_REMATCH[3]}
+          fi
+          if (( werf_current_major > minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          else
+            werf_fallback=true
+          fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "false" ]]; then
             echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
             curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
+            chmod +x "$WERF_PATH/werf"
+          elif [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" && $werf_fallback == "true" ]]; then
+            echo "Current werf is $CACHED_VERSION, fallback to ${WERF_VERSION}";
+            mkdir -p "$WERF_PATH"
+            curl -Lsfo "$WERF_PATH/werf" https://tuf.werf.io/targets/releases/${WERF_VERSION#v}/linux-amd64/bin/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"


### PR DESCRIPTION
## Description
Fallback to Werf if requested DDK version does not exist.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: fix
summary: Fallback to Werf if requested DDK version does not exist.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
