### PR TITLE
[user-authz] feat: release requirement and alert for legacy RBACv2 custom roles

### DIFF
--- a/deckhouse-controller/cmd/deckhouse-controller/register-go-hooks.go
+++ b/deckhouse-controller/cmd/deckhouse-controller/register-go-hooks.go
@@ -76,6 +76,7 @@ import (
 	_ "github.com/deckhouse/deckhouse/modules/110-istio/hooks/lib/istio_versions"
 	_ "github.com/deckhouse/deckhouse/modules/110-istio/requirements"
 	_ "github.com/deckhouse/deckhouse/modules/140-user-authz/hooks"
+	_ "github.com/deckhouse/deckhouse/modules/140-user-authz/requirements"
 	_ "github.com/deckhouse/deckhouse/modules/150-user-authn/hooks"
 	_ "github.com/deckhouse/deckhouse/modules/150-user-authn/hooks/https"
 	_ "github.com/deckhouse/deckhouse/modules/160-multitenancy-manager/hooks"

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -2934,7 +2934,7 @@ alerts:
         Until every such role is migrated, the upgrade to DKP 1.78 is blocked by the `legacyRBACv2CustomRolesCount` release requirement.
 
         Migrate the role to the new scheme:
-        
+
         - Rename it using the `d8:custom:` name prefix.
         - Replace the labels with the `rbac.deckhouse.io/kind: custom-role` or `custom-capability` label.
         - Update aggregation selectors to use the new labels.
@@ -2943,7 +2943,9 @@ alerts:
 
         List all legacy custom roles:
 
-        
+        ```bash
+        d8 k get clusterroles -o json | jq -r '.items[] | select((.metadata.name | startswith("custom:")) and ((.metadata.labels["rbac.deckhouse.io/kind"] // "" | IN("manage", "use")) or ([.aggregationRule.clusterRoleSelectors[]?.matchLabels["rbac.deckhouse.io/kind"] // ""] | any(IN("manage", "use"))))) | .metadata.name'
+        ```
       summary: |
         A legacy RBACv2 custom role is present in the cluster.
       severity: "7"

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -2921,6 +2921,26 @@ alerts:
         Prometheus can't scrape terraform-state-exporter.
       severity: "8"
       markupFormat: markdown
+    - name: D8UserAuthzLegacyRBACv2CustomRoleFound
+      sourceFile: modules/140-user-authz/monitoring/prometheus-rules/legacy-rbacv2-custom-roles.yaml
+      moduleUrl: 140-user-authz
+      module: user-authz
+      edition: ce
+      description: |-
+        The ClusterRole `{{ $labels.name }}` is a custom role or capability created with the legacy experimental RBACv2 scheme (a `custom:*` name with the `rbac.deckhouse.io/kind: manage` or `use` labels or aggregation selectors).
+
+        In DKP 1.78 the role model changes the labels that drive aggregation, and custom roles get **no compatibility aliases** — this role will stop aggregating permissions entirely. Until every such role is migrated, the upgrade to DKP 1.78 is blocked by the `legacyRBACv2CustomRolesCount` release requirement.
+
+        Migrate the role to the new scheme (the `d8:custom:` name prefix, the `rbac.deckhouse.io/kind: custom-role`/`custom-capability` label, and the new aggregation selectors) — see the user-authz module FAQ, section "How do I migrate custom roles to the new scheme in DKP 1.78?".
+
+        List all legacy custom roles:
+        ```bash
+        d8 k get clusterroles -o json | jq -r '.items[] | select((.metadata.name | startswith("custom:")) and ((.metadata.labels["rbac.deckhouse.io/kind"] // "" | IN("manage", "use")) or ([.aggregationRule.clusterRoleSelectors[]?.matchLabels["rbac.deckhouse.io/kind"] // ""] | any(IN("manage", "use"))))) | .metadata.name'
+        ```
+      summary: |
+        A custom role of the legacy RBACv2 scheme is present in the cluster.
+      severity: "7"
+      markupFormat: markdown
     - name: D8UserAuthzPermissionBrowserUnavailable
       sourceFile: modules/140-user-authz/monitoring/prometheus-rules/permission-browser-apiserver.yaml
       moduleUrl: 140-user-authz

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -2927,18 +2927,25 @@ alerts:
       module: user-authz
       edition: ce
       description: |-
-        The ClusterRole `{{ $labels.name }}` is a custom role or capability created with the legacy experimental RBACv2 scheme (a `custom:*` name with the `rbac.deckhouse.io/kind: manage` or `use` labels or aggregation selectors).
+        The ClusterRole `{{ $labels.name }}` is a custom role or capability created with the legacy experimental RBACv2 scheme. Such roles have a `custom:*` name and use either the `rbac.deckhouse.io/kind: manage` or `use` labels, or aggregation selectors based on these labels.
 
-        In DKP 1.78 the role model changes the labels that drive aggregation, and custom roles get **no compatibility aliases** — this role will stop aggregating permissions entirely. Until every such role is migrated, the upgrade to DKP 1.78 is blocked by the `legacyRBACv2CustomRolesCount` release requirement.
+        In DKP 1.78, the role model changes the labels that drive aggregation. Legacy custom roles get **no compatibility aliases** and will stop aggregating permissions entirely after the upgrade.
 
-        Migrate the role to the new scheme (the `d8:custom:` name prefix, the `rbac.deckhouse.io/kind: custom-role`/`custom-capability` label, and the new aggregation selectors) — see the user-authz module FAQ, section "How do I migrate custom roles to the new scheme in DKP 1.78?".
+        Until every such role is migrated, the upgrade to DKP 1.78 is blocked by the `legacyRBACv2CustomRolesCount` release requirement.
+
+        Migrate the role to the new scheme:
+        
+        - Rename it using the `d8:custom:` name prefix.
+        - Replace the labels with the `rbac.deckhouse.io/kind: custom-role` or `custom-capability` label.
+        - Update aggregation selectors to use the new labels.
+
+        For migration instructions, refer to the [corresponding section](https://deckhouse.io/modules/user-authz/faq.html#how-do-i-migrate-custom-roles-to-the-new-scheme-in-dkp-178) in the `user-authz` module FAQ.
 
         List all legacy custom roles:
-        ```bash
-        d8 k get clusterroles -o json | jq -r '.items[] | select((.metadata.name | startswith("custom:")) and ((.metadata.labels["rbac.deckhouse.io/kind"] // "" | IN("manage", "use")) or ([.aggregationRule.clusterRoleSelectors[]?.matchLabels["rbac.deckhouse.io/kind"] // ""] | any(IN("manage", "use"))))) | .metadata.name'
-        ```
+
+        
       summary: |
-        A custom role of the legacy RBACv2 scheme is present in the cluster.
+        A legacy RBACv2 custom role is present in the cluster.
       severity: "7"
       markupFormat: markdown
     - name: D8UserAuthzPermissionBrowserUnavailable

--- a/modules/140-user-authz/hooks/discovery_legacy_custom_roles.go
+++ b/modules/140-user-authz/hooks/discovery_legacy_custom_roles.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Discovers custom ClusterRoles of the LEGACY experimental RBACv2 scheme ("custom:*" names with the
+// rbac.deckhouse.io/kind: manage|use labels or aggregation selectors). The new scheme renames the
+// labels that drive aggregation, so such roles stop aggregating permissions in DKP 1.78 and have no
+// compatibility aliases (unlike the built-in d8:manage:*/d8:use:role:* roles). The discovered names
+// are stored as a release requirement value: the DKP 1.78 release carries the
+// legacyRBACv2CustomRolesCount requirement and stays Pending until the roles are migrated to the new
+// d8:custom:* scheme (see the user-authz FAQ, "How do I migrate custom roles to the new scheme in
+// DKP 1.78?").
+
+package hooks
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook/metrics"
+	"github.com/flant/addon-operator/sdk"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency/requirements"
+	"github.com/deckhouse/deckhouse/modules/140-user-authz/hooks/internal"
+)
+
+const (
+	legacyCustomRolesSnapshot = "legacy_custom_roles"
+
+	// LegacyRBACv2CustomRolesValueKey is the requirements memory-storage key holding the sorted names
+	// of the legacy custom roles found in the cluster. The requirement check function
+	// (modules/140-user-authz/requirements) reads it when a release carries the
+	// legacyRBACv2CustomRolesCount requirement.
+	LegacyRBACv2CustomRolesValueKey = "userAuthz:legacyRBACv2CustomRoles"
+
+	// legacyCustomRolePrefix is the name prefix the legacy scheme prescribed for user-created roles
+	// and capabilities (the new scheme uses d8:custom:).
+	legacyCustomRolePrefix = "custom:"
+
+	// legacyCustomRoleMetric drives the D8UserAuthzLegacyRBACv2CustomRoleFound alert: one time series
+	// per legacy custom role found in the cluster, so operators learn about the upcoming DKP 1.78
+	// breakage (and release block) before attempting the upgrade.
+	legacyCustomRoleMetric = "d8_rbacv2_legacy_custom_role"
+
+	rbacKindLabel = "rbac.deckhouse.io/kind"
+)
+
+// legacyRBACKinds are the rbac.deckhouse.io/kind label values of the LEGACY scheme. In the new
+// scheme built-in objects use role|capability and custom ones use custom-role|custom-capability, so
+// manage|use unambiguously identifies a leftover legacy object.
+var legacyRBACKinds = map[string]struct{}{
+	"manage": {},
+	"use":    {},
+}
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	Queue: internal.Queue("legacy_custom_roles"),
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:       legacyCustomRolesSnapshot,
+			ApiVersion: "rbac.authorization.k8s.io/v1",
+			Kind:       "ClusterRole",
+			FilterFunc: applyLegacyCustomRoleFilter,
+		},
+	},
+}, discoveryLegacyCustomRolesHandler)
+
+// applyLegacyCustomRoleFilter keeps only the legacy-scheme custom roles, so the snapshot never holds
+// the rest of the cluster's ClusterRoles.
+func applyLegacyCustomRoleFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	role := new(rbacv1.ClusterRole)
+	if err := sdk.FromUnstructured(obj, role); err != nil {
+		return nil, err
+	}
+	if !isLegacyCustomRole(role) {
+		return nil, nil
+	}
+	return role.Name, nil
+}
+
+// isLegacyCustomRole reports whether a ClusterRole is a user-created role/capability of the legacy
+// experimental RBACv2 scheme: a "custom:*" name combined with the legacy kind label — on the object
+// itself (roles and capabilities both carried it) or inside its aggregation selectors (a role whose
+// selectors require the legacy kind stops matching the relabeled built-in capabilities just as well).
+// A "custom:*" ClusterRole unrelated to the role model (no legacy markers) is not counted: it does
+// not break in DKP 1.78 and must not block the release.
+func isLegacyCustomRole(role *rbacv1.ClusterRole) bool {
+	if !strings.HasPrefix(role.Name, legacyCustomRolePrefix) {
+		return false
+	}
+	// Built-in objects are never named "custom:*"; the heritage check is defense in depth.
+	if role.Labels["heritage"] == "deckhouse" {
+		return false
+	}
+
+	if _, ok := legacyRBACKinds[role.Labels[rbacKindLabel]]; ok {
+		return true
+	}
+
+	if role.AggregationRule == nil {
+		return false
+	}
+	for _, selector := range role.AggregationRule.ClusterRoleSelectors {
+		if _, ok := legacyRBACKinds[selector.MatchLabels[rbacKindLabel]]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// discoveryLegacyCustomRolesHandler publishes the sorted legacy role names as a requirement value
+// and a per-role alert metric on every synchronization/event, so the DKP 1.78 release unblocks
+// itself (and the alert resolves) as soon as the operator migrates or deletes the roles.
+func discoveryLegacyCustomRolesHandler(_ context.Context, input *go_hook.HookInput) error {
+	names := make([]string, 0)
+	for name, err := range sdkobjectpatch.SnapshotIter[string](input.Snapshots.Get(legacyCustomRolesSnapshot)) {
+		if err != nil {
+			return fmt.Errorf("failed to iterate over '%s' snapshot: %w", legacyCustomRolesSnapshot, err)
+		}
+		names = append(names, name)
+	}
+	slices.Sort(names)
+
+	requirements.SaveValue(LegacyRBACv2CustomRolesValueKey, names)
+
+	input.MetricsCollector.Expire(legacyCustomRoleMetric)
+	for _, name := range names {
+		input.MetricsCollector.Set(legacyCustomRoleMetric, 1,
+			map[string]string{"name": name},
+			metrics.WithGroup(legacyCustomRoleMetric))
+	}
+	return nil
+}

--- a/modules/140-user-authz/hooks/discovery_legacy_custom_roles_test.go
+++ b/modules/140-user-authz/hooks/discovery_legacy_custom_roles_test.go
@@ -1,0 +1,189 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/utils/ptr"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency/requirements"
+	"github.com/deckhouse/deckhouse/pkg/metrics-storage/operation"
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+const stateLegacyCustomRoles = `
+---
+# legacy custom role: custom:* name + kind: manage label
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: custom:manage:mycustom:manager
+  labels:
+    rbac.deckhouse.io/kind: manage
+    rbac.deckhouse.io/level: subsystem
+aggregationRule:
+  clusterRoleSelectors:
+    - matchLabels:
+        rbac.deckhouse.io/kind: manage
+        rbac.deckhouse.io/aggregate-to-deckhouse-as: manager
+rules: []
+---
+# legacy custom capability: custom:* name + kind: use label
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: custom:use:capability:mycustom:superresource:view
+  labels:
+    rbac.deckhouse.io/kind: use
+    rbac.deckhouse.io/aggregate-to-kubernetes-as: user
+rules:
+  - apiGroups: ["deckhouse.io"]
+    resources: ["mysuperresources"]
+    verbs: ["get", "list", "watch"]
+---
+# legacy custom role without its own kind label, but with legacy aggregation selectors
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: custom:manage:selectors-only:manager
+aggregationRule:
+  clusterRoleSelectors:
+    - matchLabels:
+        rbac.deckhouse.io/kind: use
+        rbac.deckhouse.io/aggregate-to-kubernetes-as: manager
+rules: []
+---
+# NOT counted: custom:* name, but unrelated to the RBACv2 role model
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: custom:totally-unrelated
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get"]
+---
+# NOT counted: new-scheme custom role
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: d8:custom:subsystem:mycustom:manager
+  labels:
+    rbac.deckhouse.io/kind: custom-role
+    rbac.deckhouse.io/scope: subsystem
+aggregationRule:
+  clusterRoleSelectors:
+    - matchLabels:
+        rbac.deckhouse.io/aggregate-to-deckhouse-as: manager
+rules: []
+---
+# NOT counted: legacy labels but a built-in (heritage: deckhouse) object
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: custom:heritage-stray
+  labels:
+    heritage: deckhouse
+    rbac.deckhouse.io/kind: manage
+rules: []
+---
+# NOT counted: legacy kind label but the name does not follow the custom:* convention
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: my-own-role
+  labels:
+    rbac.deckhouse.io/kind: manage
+rules: []
+`
+
+var _ = Describe("User Authz hooks :: discovery legacy custom roles ::", func() {
+	f := HookExecutionConfigInit(`{"userAuthz":{"internal":{}}}`, `{}`)
+
+	It("value key matches the contract with modules/140-user-authz/requirements", func() {
+		// The requirements package duplicates this literal (module requirements packages stay
+		// import-free of the hooks package); this assertion and its counterpart in
+		// requirements/check_test.go pin both copies to the same string.
+		Expect(LegacyRBACv2CustomRolesValueKey).To(Equal("userAuthz:legacyRBACv2CustomRoles"))
+	})
+
+	Context("Empty cluster", func() {
+		BeforeEach(func() {
+			requirements.RemoveValue("userAuthz:legacyRBACv2CustomRoles")
+			f.BindingContexts.Set(f.KubeStateSet(``))
+			f.RunHook()
+		})
+
+		It("saves an empty list to the requirement value", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			value, exists := requirements.GetValue(LegacyRBACv2CustomRolesValueKey)
+			Expect(exists).To(BeTrue())
+			Expect(value).To(BeEmpty())
+		})
+
+		It("emits no alert metrics, only the group expiration", func() {
+			m := f.MetricsCollector.CollectedMetrics()
+			Expect(m).To(HaveLen(1))
+			Expect(m[0]).To(BeEquivalentTo(operation.MetricOperation{
+				Group:  "d8_rbacv2_legacy_custom_role",
+				Action: operation.ActionExpireMetrics,
+			}))
+		})
+	})
+
+	Context("Cluster with a mix of legacy, new-scheme and unrelated roles", func() {
+		BeforeEach(func() {
+			requirements.RemoveValue("userAuthz:legacyRBACv2CustomRoles")
+			f.BindingContexts.Set(f.KubeStateSet(stateLegacyCustomRoles))
+			f.RunHook()
+		})
+
+		It("saves only the legacy custom roles, sorted", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			value, exists := requirements.GetValue(LegacyRBACv2CustomRolesValueKey)
+			Expect(exists).To(BeTrue())
+			Expect(value).To(Equal([]string{
+				"custom:manage:mycustom:manager",
+				"custom:manage:selectors-only:manager",
+				"custom:use:capability:mycustom:superresource:view",
+			}))
+		})
+
+		It("emits one alert metric per legacy custom role", func() {
+			m := f.MetricsCollector.CollectedMetrics()
+			Expect(m).To(HaveLen(4))
+			Expect(m[0]).To(BeEquivalentTo(operation.MetricOperation{
+				Group:  "d8_rbacv2_legacy_custom_role",
+				Action: operation.ActionExpireMetrics,
+			}))
+			for i, name := range []string{
+				"custom:manage:mycustom:manager",
+				"custom:manage:selectors-only:manager",
+				"custom:use:capability:mycustom:superresource:view",
+			} {
+				Expect(m[i+1]).To(BeEquivalentTo(operation.MetricOperation{
+					Name:   "d8_rbacv2_legacy_custom_role",
+					Group:  "d8_rbacv2_legacy_custom_role",
+					Action: operation.ActionGaugeSet,
+					Value:  ptr.To(1.0),
+					Labels: map[string]string{"name": name},
+				}))
+			}
+		})
+	})
+})

--- a/modules/140-user-authz/monitoring/prometheus-rules/legacy-rbacv2-custom-roles.yaml
+++ b/modules/140-user-authz/monitoring/prometheus-rules/legacy-rbacv2-custom-roles.yaml
@@ -37,4 +37,6 @@
 
         List all legacy custom roles:
 
-        
+        ```bash
+        d8 k get clusterroles -o json | jq -r '.items[] | select((.metadata.name | startswith("custom:")) and ((.metadata.labels["rbac.deckhouse.io/kind"] // "" | IN("manage", "use")) or ([.aggregationRule.clusterRoleSelectors[]?.matchLabels["rbac.deckhouse.io/kind"] // ""] | any(IN("manage", "use"))))) | .metadata.name'
+        ```

--- a/modules/140-user-authz/monitoring/prometheus-rules/legacy-rbacv2-custom-roles.yaml
+++ b/modules/140-user-authz/monitoring/prometheus-rules/legacy-rbacv2-custom-roles.yaml
@@ -1,0 +1,33 @@
+- name: d8.user-authz.rbacv2.legacy-custom-roles
+  rules:
+  # A custom role/capability of the legacy experimental RBACv2 scheme ("custom:*" name with the
+  # rbac.deckhouse.io/kind: manage|use markers). The DKP 1.78 role model renames the aggregation
+  # labels, and custom roles get NO compatibility aliases — such roles stop aggregating permissions,
+  # and the DKP 1.78 release is blocked by the legacyRBACv2CustomRolesCount requirement until they
+  # are migrated.
+  - alert: D8UserAuthzLegacyRBACv2CustomRoleFound
+    expr: |
+      max by (name) (d8_rbacv2_legacy_custom_role) > 0
+    for: 15m
+    labels:
+      severity_level: "7"
+      tier: cluster
+      d8_module: user-authz
+      d8_component: rbacv2
+    annotations:
+      plk_protocol_version: "1"
+      plk_markup_format: "markdown"
+      plk_create_group_if_not_exists__d8_user_authz_legacy_rbacv2_custom_roles: "D8UserAuthzLegacyRBACv2CustomRoleFound,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+      plk_grouped_by__d8_user_authz_legacy_rbacv2_custom_roles: "D8UserAuthzLegacyRBACv2CustomRoleFound,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+      summary: A custom role of the legacy RBACv2 scheme is present in the cluster.
+      description: |-
+        The ClusterRole `{{ $labels.name }}` is a custom role or capability created with the legacy experimental RBACv2 scheme (a `custom:*` name with the `rbac.deckhouse.io/kind: manage` or `use` labels or aggregation selectors).
+
+        In DKP 1.78 the role model changes the labels that drive aggregation, and custom roles get **no compatibility aliases** — this role will stop aggregating permissions entirely. Until every such role is migrated, the upgrade to DKP 1.78 is blocked by the `legacyRBACv2CustomRolesCount` release requirement.
+
+        Migrate the role to the new scheme (the `d8:custom:` name prefix, the `rbac.deckhouse.io/kind: custom-role`/`custom-capability` label, and the new aggregation selectors) — see the user-authz module FAQ, section "How do I migrate custom roles to the new scheme in DKP 1.78?".
+
+        List all legacy custom roles:
+        ```bash
+        d8 k get clusterroles -o json | jq -r '.items[] | select((.metadata.name | startswith("custom:")) and ((.metadata.labels["rbac.deckhouse.io/kind"] // "" | IN("manage", "use")) or ([.aggregationRule.clusterRoleSelectors[]?.matchLabels["rbac.deckhouse.io/kind"] // ""] | any(IN("manage", "use"))))) | .metadata.name'
+        ```

--- a/modules/140-user-authz/monitoring/prometheus-rules/legacy-rbacv2-custom-roles.yaml
+++ b/modules/140-user-authz/monitoring/prometheus-rules/legacy-rbacv2-custom-roles.yaml
@@ -19,15 +19,22 @@
       plk_markup_format: "markdown"
       plk_create_group_if_not_exists__d8_user_authz_legacy_rbacv2_custom_roles: "D8UserAuthzLegacyRBACv2CustomRoleFound,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
       plk_grouped_by__d8_user_authz_legacy_rbacv2_custom_roles: "D8UserAuthzLegacyRBACv2CustomRoleFound,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
-      summary: A custom role of the legacy RBACv2 scheme is present in the cluster.
+      summary: A legacy RBACv2 custom role is present in the cluster.
       description: |-
-        The ClusterRole `{{ $labels.name }}` is a custom role or capability created with the legacy experimental RBACv2 scheme (a `custom:*` name with the `rbac.deckhouse.io/kind: manage` or `use` labels or aggregation selectors).
+        The ClusterRole `{{ $labels.name }}` is a custom role or capability created with the legacy experimental RBACv2 scheme. Such roles have a `custom:*` name and use either the `rbac.deckhouse.io/kind: manage` or `use` labels, or aggregation selectors based on these labels.
 
-        In DKP 1.78 the role model changes the labels that drive aggregation, and custom roles get **no compatibility aliases** — this role will stop aggregating permissions entirely. Until every such role is migrated, the upgrade to DKP 1.78 is blocked by the `legacyRBACv2CustomRolesCount` release requirement.
+        In DKP 1.78, the role model changes the labels that drive aggregation. Legacy custom roles get **no compatibility aliases** and will stop aggregating permissions entirely after the upgrade.
 
-        Migrate the role to the new scheme (the `d8:custom:` name prefix, the `rbac.deckhouse.io/kind: custom-role`/`custom-capability` label, and the new aggregation selectors) — see the user-authz module FAQ, section "How do I migrate custom roles to the new scheme in DKP 1.78?".
+        Until every such role is migrated, the upgrade to DKP 1.78 is blocked by the `legacyRBACv2CustomRolesCount` release requirement.
+
+        Migrate the role to the new scheme:
+
+        - Rename it using the `d8:custom:` name prefix.
+        - Replace the labels with the `rbac.deckhouse.io/kind: custom-role` or `custom-capability` label.
+        - Update aggregation selectors to use the new labels.
+
+        For migration instructions, refer to the [corresponding section](https://deckhouse.io/modules/user-authz/faq.html#how-do-i-migrate-custom-roles-to-the-new-scheme-in-dkp-178) in the `user-authz` module FAQ.
 
         List all legacy custom roles:
-        ```bash
-        d8 k get clusterroles -o json | jq -r '.items[] | select((.metadata.name | startswith("custom:")) and ((.metadata.labels["rbac.deckhouse.io/kind"] // "" | IN("manage", "use")) or ([.aggregationRule.clusterRoleSelectors[]?.matchLabels["rbac.deckhouse.io/kind"] // ""] | any(IN("manage", "use"))))) | .metadata.name'
-        ```
+
+        

--- a/modules/140-user-authz/requirements/check.go
+++ b/modules/140-user-authz/requirements/check.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package requirements
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency/requirements"
+)
+
+const (
+	// legacyRBACv2CustomRolesRequirementKey is the release requirement key. The DKP 1.78 release.yaml
+	// sets it to the maximum allowed number of legacy custom roles (0), which blocks the release
+	// until every legacy-scheme custom role is migrated to the new d8:custom:* scheme.
+	legacyRBACv2CustomRolesRequirementKey = "legacyRBACv2CustomRolesCount"
+
+	// legacyRBACv2CustomRolesValueKey mirrors hooks.LegacyRBACv2CustomRolesValueKey (the packages
+	// must not import each other's internals; the contract is locked by tests).
+	legacyRBACv2CustomRolesValueKey = "userAuthz:legacyRBACv2CustomRoles"
+
+	migrationFAQReference = "see the user-authz module FAQ, section \"How do I migrate custom roles to the new scheme in DKP 1.78?\""
+)
+
+func init() {
+	checkLegacyCustomRolesFunc := func(requirementValue string, getter requirements.ValueGetter) (bool, error) {
+		allowed, err := strconv.Atoi(requirementValue)
+		if err != nil {
+			return false, fmt.Errorf("parse requirement value %q: %w", requirementValue, err)
+		}
+
+		raw, exists := getter.Get(legacyRBACv2CustomRolesValueKey)
+		if !exists {
+			// The discovery hook has not published a value (the module is disabled or has not synced
+			// yet) — nothing to enforce.
+			return true, nil
+		}
+
+		names := toStringSlice(raw)
+		if len(names) <= allowed {
+			return true, nil
+		}
+
+		return false, fmt.Errorf(
+			"the cluster has %d custom role(s) of the legacy experimental RBACv2 scheme: %s; "+
+				"they will stop aggregating permissions in DKP 1.78 — migrate them to the new d8:custom:* scheme, %s",
+			len(names), strings.Join(names, ", "), migrationFAQReference)
+	}
+
+	requirements.RegisterCheck(legacyRBACv2CustomRolesRequirementKey, checkLegacyCustomRolesFunc)
+}
+
+// toStringSlice tolerates both the in-memory ([]string) and a deserialized ([]any) representation
+// of the stored value.
+func toStringSlice(raw any) []string {
+	switch v := raw.(type) {
+	case []string:
+		return v
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}

--- a/modules/140-user-authz/requirements/check_test.go
+++ b/modules/140-user-authz/requirements/check_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package requirements
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency/requirements"
+)
+
+func TestLegacyRBACv2CustomRolesRequirement(t *testing.T) {
+	// Pins the duplicated value-key literal to the hooks package contract (see the counterpart
+	// assertion in hooks/discovery_legacy_custom_roles_test.go).
+	assert.Equal(t, "userAuthz:legacyRBACv2CustomRoles", legacyRBACv2CustomRolesValueKey)
+
+	t.Run("no value stored (module disabled or not synced) — pass", func(t *testing.T) {
+		requirements.RemoveValue(legacyRBACv2CustomRolesValueKey)
+		ok, err := requirements.CheckRequirement(legacyRBACv2CustomRolesRequirementKey, "0")
+		assert.True(t, ok)
+		require.NoError(t, err)
+	})
+
+	t.Run("no legacy roles in the cluster — pass", func(t *testing.T) {
+		requirements.SaveValue(legacyRBACv2CustomRolesValueKey, []string{})
+		ok, err := requirements.CheckRequirement(legacyRBACv2CustomRolesRequirementKey, "0")
+		assert.True(t, ok)
+		require.NoError(t, err)
+	})
+
+	t.Run("legacy roles present — block with names in the error", func(t *testing.T) {
+		requirements.SaveValue(legacyRBACv2CustomRolesValueKey, []string{
+			"custom:manage:mycustom:manager",
+			"custom:use:capability:mycustom:superresource:view",
+		})
+		ok, err := requirements.CheckRequirement(legacyRBACv2CustomRolesRequirementKey, "0")
+		assert.False(t, ok)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "custom:manage:mycustom:manager")
+		assert.Contains(t, err.Error(), "custom:use:capability:mycustom:superresource:view")
+		assert.Contains(t, err.Error(), "d8:custom:")
+	})
+
+	t.Run("deserialized []any representation is tolerated", func(t *testing.T) {
+		requirements.SaveValue(legacyRBACv2CustomRolesValueKey, []any{"custom:manage:mycustom:manager"})
+		ok, err := requirements.CheckRequirement(legacyRBACv2CustomRolesRequirementKey, "0")
+		assert.False(t, ok)
+		require.Error(t, err)
+	})
+
+	t.Run("unparsable requirement value — error", func(t *testing.T) {
+		requirements.SaveValue(legacyRBACv2CustomRolesValueKey, []string{"custom:manage:mycustom:manager"})
+		ok, err := requirements.CheckRequirement(legacyRBACv2CustomRolesRequirementKey, "not-a-number")
+		assert.False(t, ok)
+		require.Error(t, err)
+	})
+
+	requirements.RemoveValue(legacyRBACv2CustomRolesValueKey)
+}

--- a/tools/build_includes/modules-with-dependencies-BE.yaml
+++ b/tools/build_includes/modules-with-dependencies-BE.yaml
@@ -223,6 +223,14 @@
   stageDependencies:
     install:
         - '**/*'
+- add: /modules/140-user-authz/requirements
+  to: /deckhouse/modules/140-user-authz/requirements
+  excludePaths:
+    - '**/*_test.go'
+    - '**/*.sh'
+  stageDependencies:
+    install:
+        - '**/*'
 - add: /modules/150-user-authn/hooks
   to: /deckhouse/modules/150-user-authn/hooks
   excludePaths:

--- a/tools/build_includes/modules-with-dependencies-CE.yaml
+++ b/tools/build_includes/modules-with-dependencies-CE.yaml
@@ -223,6 +223,14 @@
   stageDependencies:
     install:
         - '**/*'
+- add: /modules/140-user-authz/requirements
+  to: /deckhouse/modules/140-user-authz/requirements
+  excludePaths:
+    - '**/*_test.go'
+    - '**/*.sh'
+  stageDependencies:
+    install:
+        - '**/*'
 - add: /modules/150-user-authn/hooks
   to: /deckhouse/modules/150-user-authn/hooks
   excludePaths:

--- a/tools/build_includes/modules-with-dependencies-CSE.yaml
+++ b/tools/build_includes/modules-with-dependencies-CSE.yaml
@@ -143,6 +143,14 @@
   stageDependencies:
     install:
         - '**/*'
+- add: /modules/140-user-authz/requirements
+  to: /deckhouse/modules/140-user-authz/requirements
+  excludePaths:
+    - '**/*_test.go'
+    - '**/*.sh'
+  stageDependencies:
+    install:
+        - '**/*'
 - add: /modules/150-user-authn/hooks
   to: /deckhouse/modules/150-user-authn/hooks
   excludePaths:

--- a/tools/build_includes/modules-with-dependencies-EE.yaml
+++ b/tools/build_includes/modules-with-dependencies-EE.yaml
@@ -223,6 +223,14 @@
   stageDependencies:
     install:
         - '**/*'
+- add: /modules/140-user-authz/requirements
+  to: /deckhouse/modules/140-user-authz/requirements
+  excludePaths:
+    - '**/*_test.go'
+    - '**/*.sh'
+  stageDependencies:
+    install:
+        - '**/*'
 - add: /modules/150-user-authn/hooks
   to: /deckhouse/modules/150-user-authn/hooks
   excludePaths:

--- a/tools/build_includes/modules-with-dependencies-FE.yaml
+++ b/tools/build_includes/modules-with-dependencies-FE.yaml
@@ -223,6 +223,14 @@
   stageDependencies:
     install:
         - '**/*'
+- add: /modules/140-user-authz/requirements
+  to: /deckhouse/modules/140-user-authz/requirements
+  excludePaths:
+    - '**/*_test.go'
+    - '**/*.sh'
+  stageDependencies:
+    install:
+        - '**/*'
 - add: /modules/150-user-authn/hooks
   to: /deckhouse/modules/150-user-authn/hooks
   excludePaths:

--- a/tools/build_includes/modules-with-dependencies-SE-plus.yaml
+++ b/tools/build_includes/modules-with-dependencies-SE-plus.yaml
@@ -223,6 +223,14 @@
   stageDependencies:
     install:
         - '**/*'
+- add: /modules/140-user-authz/requirements
+  to: /deckhouse/modules/140-user-authz/requirements
+  excludePaths:
+    - '**/*_test.go'
+    - '**/*.sh'
+  stageDependencies:
+    install:
+        - '**/*'
 - add: /modules/150-user-authn/hooks
   to: /deckhouse/modules/150-user-authn/hooks
   excludePaths:

--- a/tools/build_includes/modules-with-dependencies-SE.yaml
+++ b/tools/build_includes/modules-with-dependencies-SE.yaml
@@ -223,6 +223,14 @@
   stageDependencies:
     install:
         - '**/*'
+- add: /modules/140-user-authz/requirements
+  to: /deckhouse/modules/140-user-authz/requirements
+  excludePaths:
+    - '**/*_test.go'
+    - '**/*.sh'
+  stageDependencies:
+    install:
+        - '**/*'
 - add: /modules/150-user-authn/hooks
   to: /deckhouse/modules/150-user-authn/hooks
   excludePaths:


### PR DESCRIPTION
## Description

Adds the groundwork for blocking the DKP 1.78 upgrade while custom roles of the legacy experimental RBACv2 scheme are present in the cluster:

- **Discovery hook** (`modules/140-user-authz/hooks/discovery_legacy_custom_roles.go`): watches ClusterRoles and detects user-created roles/capabilities of the legacy scheme — a `custom:*` name combined with the `rbac.deckhouse.io/kind: manage|use` label on the object or inside its `aggregationRule` selectors. Built-in objects (`heritage: deckhouse`) and `custom:*` roles unrelated to the role model are not counted. The sorted list of names is published on every synchronization/event, so the state stays fresh without restarts.
- **Release requirement check** (`modules/140-user-authz/requirements/check.go`): registers the `legacyRBACv2CustomRolesCount` requirement. The DKP 1.78 release will carry this key in `release.yaml` (value `"0"`) and stay `Pending` until every legacy custom role is migrated; the error message lists all offending role names and points to the migration FAQ. The key is deliberately **not** added to `release.yaml` in this PR: the check must ship one release before the requirement (this two-step order is enforced by `tools/validation`).
- **Alert**: the hook also emits the `d8_rbacv2_legacy_custom_role` metric driving the new `D8UserAuthzLegacyRBACv2CustomRoleFound` alert (severity 7), so operators learn about the upcoming breakage — and the future upgrade block — before attempting the upgrade. The alert description explains what breaks and why, links the migration FAQ section, and includes a ready-made command to list all legacy custom roles.

No restarts of ingress-controllers, control-plane or Prometheus. Only the user-authz hooks are affected.

## Why do we need it, and what problem does it solve?

In DKP 1.78 the RBACv2 role model renames the labels that drive aggregation (`rbac.deckhouse.io/kind: manage|use` disappears from the built-in capabilities, `aggregate-to-all-as` becomes `aggregate-to-system-as`, etc.). Built-in role names survive one release via compatibility aliases, but **custom roles get no aliases**: a legacy-scheme custom role silently stops aggregating permissions, and its users silently lose access.

This PR makes that failure impossible to hit unnoticed: the operator is alerted in 1.77, and the 1.78 release will not apply until the roles are migrated to the new `d8:custom:*` scheme (see the user-authz FAQ, "How do I migrate custom roles to the new scheme in DKP 1.78?", #21290).


## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authz
type: feature
summary: Added alert and DKP 1.78 release requirement for custom roles of the legacy experimental RBACv2 scheme.
impact: |
  Custom roles of the legacy experimental RBACv2 scheme must be migrated to the new `d8:custom:*` scheme before upgrading to DKP 1.78. The `D8UserAuthzLegacyRBACv2CustomRoleFound` alert identifies affected roles. Refer to the `user-authz` module FAQ for migration instructions.
impact_level: high
```