### PR TITLE
[vertical-pod-autoscaler] Upgrade Vertical Pod Autoscaler to v1.7.0 and update base image to builder/golang.

### DIFF
--- a/modules/302-vertical-pod-autoscaler/images/vertical-pod-autoscaler/patches/004-daemonset-scope-node-label.patch
+++ b/modules/302-vertical-pod-autoscaler/images/vertical-pod-autoscaler/patches/004-daemonset-scope-node-label.patch
@@ -1,8 +1,8 @@
 diff --git a/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml b/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml
-index 32290bc1c..360e32d7e 100644
+index 1ffdae98a..8a77e6940 100644
 --- a/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml
 +++ b/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml
-@@ -302,6 +302,11 @@ spec:
+@@ -310,6 +310,11 @@ spec:
                    - name
                    type: object
                  type: array
@@ -14,7 +14,7 @@ index 32290bc1c..360e32d7e 100644
                resourcePolicy:
                  description: |-
                    Controls how the autoscaler computes recommended resources.
-@@ -519,6 +524,82 @@ spec:
+@@ -668,6 +673,82 @@ spec:
                    - type
                    type: object
                  type: array
@@ -94,10 +94,10 @@ index 32290bc1c..360e32d7e 100644
 +                  - scopeValue
 +                  type: object
 +                type: array
-               recommendation:
-                 description: |-
-                   The most recently computed amount of resources recommended by the
-@@ -549,6 +630,10 @@ spec:
+               observedGeneration:
+                 description: observedGeneration is the most recent generation observed
+                   by this autoscaler.
+@@ -704,6 +785,10 @@ spec:
                              This amount is not guaranteed to be sufficient for the application to operate in a stable way, however
                              running with less resources is likely to have significant impact on performance/availability.
                            type: object
@@ -109,10 +109,10 @@ index 32290bc1c..360e32d7e 100644
                            additionalProperties:
                              anyOf:
 diff --git a/vertical-pod-autoscaler/pkg/admission-controller/main.go b/vertical-pod-autoscaler/pkg/admission-controller/main.go
-index e46a7c465..92dff3771 100644
+index 215773196..00aa7788e 100644
 --- a/vertical-pod-autoscaler/pkg/admission-controller/main.go
 +++ b/vertical-pod-autoscaler/pkg/admission-controller/main.go
-@@ -113,7 +113,7 @@ func main() {
+@@ -88,7 +88,7 @@ func main() {
  		klog.ErrorS(err, "Failed to create limitRangeCalculator, falling back to not checking limits.")
  		limitRangeCalculator = limitrange.NewNoopLimitsCalculator()
  	}
@@ -120,12 +120,12 @@ index e46a7c465..92dff3771 100644
 +	recommendationProvider := recommendation.NewProvider(limitRangeCalculator, vpa_api_util.NewCappingRecommendationProcessorWithNodeGetter(limitRangeCalculator, kubeClient.CoreV1().Nodes()))
  	vpaMatcher := vpa.NewMatcher(vpaLister, targetSelectorFetcher, controllerFetcher)
  
- 	stopCh := make(chan struct{})
+ 	factory.Start(stopCh)
 diff --git a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation/recommendation_provider.go b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation/recommendation_provider.go
-index 5cb9cbd96..5a4a92aae 100644
+index 9bcbae835..f3b2194f5 100644
 --- a/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation/recommendation_provider.go
 +++ b/vertical-pod-autoscaler/pkg/admission-controller/resource/pod/recommendation/recommendation_provider.go
-@@ -123,13 +123,16 @@ func (p *recommendationProvider) GetContainersResourcesForPod(pod *core.Pod, vpa
+@@ -123,13 +123,16 @@ func (p *recommendationProvider) GetContainersResourcesForPod(pod *corev1.Pod, v
  	var annotations vpa_api_util.ContainerToAnnotationsMap
  	recommendedPodResources := &vpa_types.RecommendedPodResources{}
  
@@ -144,25 +144,27 @@ index 5cb9cbd96..5a4a92aae 100644
  	containerLimitRange, err := p.limitsRangeCalculator.GetContainerLimitRangeItem(pod.Namespace)
  	if err != nil {
 diff --git a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
-index 0b27e9a6b..baca503a5 100644
+index 1334200c7..4d907c979 100644
 --- a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
 +++ b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
-@@ -108,13 +108,23 @@ type VerticalPodAutoscalerSpec struct {
- 	// recommendation) or contain exactly one recommender.
+@@ -114,8 +114,16 @@ type VerticalPodAutoscalerSpec struct {
+ 	// startupBoost specifies the startup boost policy for the pod.
  	// +optional
- 	Recommenders []*VerticalPodAutoscalerRecommenderSelector `json:"recommenders,omitempty" protobuf:"bytes,4,opt,name=recommenders"`
+ 	StartupBoost *StartupBoost `json:"startupBoost,omitempty"`
 +
 +	// Scope controls additional recommendation partitioning for DaemonSet targets.
 +	// The value must be a node label key (for example: node.kubernetes.io/instance-type).
 +	// +optional
-+	Scope VerticalPodAutoscalerScopeType `json:"scope,omitempty" protobuf:"bytes,5,opt,name=scope"`
++	Scope VerticalPodAutoscalerScopeType `json:"scope,omitempty"`
  }
  
 +// VerticalPodAutoscalerScopeType are the valid scopes of a VerticalPodAutoscaler.
 +type VerticalPodAutoscalerScopeType string
 +
- // EvictionChangeRequirement refers to the relationship between the new target recommendation for a Pod and its current requests, what kind of change is necessary for the Pod to be evicted
- // +kubebuilder:validation:Enum:=TargetHigherThanRequests;TargetLowerThanRequests
+ // StartupBoost defines the startup boost policy.
+ type StartupBoost struct {
+ 	// cpu specifies the CPU startup boost policy.
+@@ -170,6 +178,8 @@ const (
  type EvictionChangeRequirement string
  
  const (
@@ -171,41 +173,41 @@ index 0b27e9a6b..baca503a5 100644
  	// TargetHigherThanRequests means the new target recommendation for a Pod is higher than its current requests, i.e. the Pod is scaled up
  	TargetHigherThanRequests EvictionChangeRequirement = "TargetHigherThanRequests"
  	// TargetLowerThanRequests means the new target recommendation for a Pod is lower than its current requests, i.e. the Pod is scaled down
-@@ -279,6 +289,10 @@ type VerticalPodAutoscalerStatus struct {
- 	// +patchMergeKey=type
- 	// +patchStrategy=merge
- 	Conditions []VerticalPodAutoscalerCondition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,2,rep,name=conditions"`
+@@ -374,6 +384,10 @@ type VerticalPodAutoscalerStatus struct {
+ 	// +optional
+ 	// +kubebuilder:validation:Minimum=0
+ 	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 +
 +	// Groups contains per-scope-value recommendations when spec.scope is used.
 +	// +optional
-+	Groups []RecommendedPodResourcesGroup `json:"groups,omitempty" protobuf:"bytes,3,rep,name=groups"`
++	Groups []RecommendedPodResourcesGroup `json:"groups,omitempty"`
  }
  
  // RecommendedPodResources is the recommendation of resources computed by
-@@ -318,6 +332,18 @@ type RecommendedContainerResources struct {
+@@ -413,6 +427,18 @@ type RecommendedContainerResources struct {
  	// Used only as status indication, will not affect actual resource assignment.
  	// +optional
- 	UncappedTarget v1.ResourceList `json:"uncappedTarget,omitempty" protobuf:"bytes,5,opt,name=uncappedTarget"`
+ 	UncappedTarget corev1.ResourceList `json:"uncappedTarget,omitempty"`
 +	// Scope binds this recommendation to a specific scope value in form "<scopeKey>=<scopeValue>".
 +	// +optional
-+	Scope string `json:"scope,omitempty" protobuf:"bytes,6,opt,name=scope"`
++	Scope string `json:"scope,omitempty"`
 +}
 +
 +// RecommendedPodResourcesGroup is a recommendation group for a single scope value.
 +type RecommendedPodResourcesGroup struct {
 +	// ScopeValue is the value of spec.scope label key for this group.
-+	ScopeValue string `json:"scopeValue" protobuf:"bytes,1,opt,name=scopeValue"`
++	ScopeValue string `json:"scopeValue"`
 +	// Resources recommended by autoscaler for each container in this group.
 +	// +optional
-+	ContainerRecommendations []RecommendedContainerResources `json:"containerRecommendations,omitempty" protobuf:"bytes,2,rep,name=containerRecommendations"`
++	ContainerRecommendations []RecommendedContainerResources `json:"containerRecommendations,omitempty"`
  }
  
  // VerticalPodAutoscalerConditionType are the valid conditions of
 diff --git a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/zz_generated.deepcopy.go b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/zz_generated.deepcopy.go
-index 86ff44f69..844cf3e11 100644
+index 860d40d95..496e5a249 100644
 --- a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/zz_generated.deepcopy.go
 +++ b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/zz_generated.deepcopy.go
-@@ -258,6 +258,29 @@ func (in *RecommendedPodResources) DeepCopy() *RecommendedPodResources {
+@@ -309,6 +309,29 @@ func (in *RecommendedPodResources) DeepCopy() *RecommendedPodResources {
  	return out
  }
  
@@ -233,11 +235,11 @@ index 86ff44f69..844cf3e11 100644
 +}
 +
  // DeepCopyInto is an autogenerated deepcopy function, copying the receiver, writing into out. in must be non-nil.
- func (in *VerticalPodAutoscaler) DeepCopyInto(out *VerticalPodAutoscaler) {
+ func (in *StartupBoost) DeepCopyInto(out *StartupBoost) {
  	*out = *in
-@@ -507,6 +530,13 @@ func (in *VerticalPodAutoscalerStatus) DeepCopyInto(out *VerticalPodAutoscalerSt
- 			(*in)[i].DeepCopyInto(&(*out)[i])
- 		}
+@@ -589,6 +612,13 @@ func (in *VerticalPodAutoscalerStatus) DeepCopyInto(out *VerticalPodAutoscalerSt
+ 		*out = new(int64)
+ 		**out = **in
  	}
 +	if in.Groups != nil {
 +		in, out := &in.Groups, &out.Groups
@@ -250,26 +252,26 @@ index 86ff44f69..844cf3e11 100644
  }
  
 diff --git a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
-index 3eb484174..7fd94d77f 100644
+index dda0612b9..777903e9a 100644
 --- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
 +++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
-@@ -45,6 +45,7 @@ import (
- 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/target"
+@@ -46,6 +46,7 @@ import (
  	controllerfetcher "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/target/controller_fetcher"
+ 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/client"
  	metrics_recommender "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/recommender"
 +	scopeutil "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/scope"
  )
  
  const (
-@@ -84,6 +85,7 @@ type ClusterStateFeederFactory struct {
+@@ -85,6 +86,7 @@ type ClusterStateFeederFactory struct {
  	VpaCheckpointLister vpa_lister.VerticalPodAutoscalerCheckpointLister
  	VpaLister           vpa_lister.VerticalPodAutoscalerLister
- 	PodLister           v1lister.PodLister
-+	NodeLister          v1lister.NodeLister
+ 	PodLister           listersv1.PodLister
++	NodeLister          listersv1.NodeLister
  	OOMObserver         oom.Observer
  	SelectorFetcher     target.VpaTargetSelectorFetcher
  	MemorySaveMode      bool
-@@ -103,7 +105,7 @@ func (m ClusterStateFeederFactory) Make() *clusterStateFeeder {
+@@ -104,7 +106,7 @@ func (m ClusterStateFeederFactory) Make() *clusterStateFeeder {
  		vpaCheckpointLister: m.VpaCheckpointLister,
  		vpaLister:           m.VpaLister,
  		clusterState:        m.ClusterState,
@@ -278,7 +280,7 @@ index 3eb484174..7fd94d77f 100644
  		selectorFetcher:     m.SelectorFetcher,
  		memorySaveMode:      m.MemorySaveMode,
  		controllerFetcher:   m.ControllerFetcher,
-@@ -483,7 +485,8 @@ func (feeder *clusterStateFeeder) LoadPods() {
+@@ -490,7 +492,8 @@ func (feeder *clusterStateFeeder) LoadPods() {
  		if feeder.memorySaveMode && !feeder.matchesVPA(pod) {
  			continue
  		}
@@ -288,7 +290,7 @@ index 3eb484174..7fd94d77f 100644
  		for _, container := range pod.Containers {
  			if err = feeder.clusterState.AddOrUpdateContainer(container.ID, container.Request); err != nil {
  				klog.V(0).InfoS("Failed to add container", "container", container.ID, "error", err)
-@@ -496,6 +499,31 @@ func (feeder *clusterStateFeeder) LoadPods() {
+@@ -506,6 +509,31 @@ func (feeder *clusterStateFeeder) LoadPods() {
  	}
  }
  
@@ -321,7 +323,7 @@ index 3eb484174..7fd94d77f 100644
  	containersMetrics, err := feeder.metricsClient.GetContainersMetrics(ctx)
  	if err != nil {
 diff --git a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder_test.go b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder_test.go
-index c84e5d0e6..9149a1874 100644
+index b3ec81e96..c5968d4a4 100644
 --- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder_test.go
 +++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder_test.go
 @@ -42,6 +42,7 @@ import (
@@ -332,7 +334,7 @@ index c84e5d0e6..9149a1874 100644
  	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/test"
  )
  
-@@ -485,6 +486,83 @@ func TestClusterStateFeeder_LoadPods_ContainerTracking(t *testing.T) {
+@@ -517,6 +518,83 @@ func TestClusterStateFeeder_LoadPods_ContainerTracking(t *testing.T) {
  	assert.Equal(t, len(feeder.clusterState.Pods()[podWithoutInitContainersID].InitContainers), 0)
  }
  
@@ -417,13 +419,13 @@ index c84e5d0e6..9149a1874 100644
  	for _, tc := range []struct {
  		Name              string
 diff --git a/vertical-pod-autoscaler/pkg/recommender/input/spec/spec_client.go b/vertical-pod-autoscaler/pkg/recommender/input/spec/spec_client.go
-index 0076809e7..7c7b999b6 100644
+index 6fb91e49d..1f8a47863 100644
 --- a/vertical-pod-autoscaler/pkg/recommender/input/spec/spec_client.go
 +++ b/vertical-pod-autoscaler/pkg/recommender/input/spec/spec_client.go
 @@ -20,6 +20,7 @@ import (
- 	v1 "k8s.io/api/core/v1"
+ 	corev1 "k8s.io/api/core/v1"
  	"k8s.io/apimachinery/pkg/labels"
- 	v1lister "k8s.io/client-go/listers/core/v1"
+ 	listersv1 "k8s.io/client-go/listers/core/v1"
 +	"k8s.io/klog/v2"
  
  	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/model"
@@ -431,7 +433,7 @@ index 0076809e7..7c7b999b6 100644
 @@ -37,6 +38,10 @@ type BasicPodSpec struct {
  	InitContainers []BasicContainerSpec
  	// PodPhase describing current life cycle phase of the Pod.
- 	Phase v1.PodPhase
+ 	Phase corev1.PodPhase
 +	// NodeName where pod is (or will be) scheduled.
 +	NodeName string
 +	// Labels of a node where pod is scheduled.
@@ -443,15 +445,15 @@ index 0076809e7..7c7b999b6 100644
  }
  
  type specClient struct {
--	podLister v1lister.PodLister
-+	podLister  v1lister.PodLister
-+	nodeLister v1lister.NodeLister
+-	podLister listersv1.PodLister
++	podLister  listersv1.PodLister
++	nodeLister listersv1.NodeLister
  }
  
  // NewSpecClient creates new client which can be used to get basic information about pods specification
  // It requires PodLister which is a data source for this client.
--func NewSpecClient(podLister v1lister.PodLister) SpecClient {
-+func NewSpecClient(podLister v1lister.PodLister, nodeLister v1lister.NodeLister) SpecClient {
+-func NewSpecClient(podLister listersv1.PodLister) SpecClient {
++func NewSpecClient(podLister listersv1.PodLister, nodeLister listersv1.NodeLister) SpecClient {
  	return &specClient{
 -		podLister: podLister,
 +		podLister:  podLister,
@@ -477,7 +479,7 @@ index 0076809e7..7c7b999b6 100644
  		podSpecs = append(podSpecs, basicPodSpec)
  	}
  	return podSpecs, nil
-@@ -91,6 +109,7 @@ func newBasicPodSpec(pod *v1.Pod) *BasicPodSpec {
+@@ -91,6 +109,7 @@ func newBasicPodSpec(pod *corev1.Pod) *BasicPodSpec {
  		Containers:     containerSpecs,
  		InitContainers: initContainerSpecs,
  		Phase:          pod.Status.Phase,
@@ -486,7 +488,7 @@ index 0076809e7..7c7b999b6 100644
  	return basicPodSpec
  }
 diff --git a/vertical-pod-autoscaler/pkg/recommender/input/spec/spec_client_test_util.go b/vertical-pod-autoscaler/pkg/recommender/input/spec/spec_client_test_util.go
-index 3e55e3cb8..17c2a6551 100644
+index c988b5712..831bdbbfd 100644
 --- a/vertical-pod-autoscaler/pkg/recommender/input/spec/spec_client_test_util.go
 +++ b/vertical-pod-autoscaler/pkg/recommender/input/spec/spec_client_test_util.go
 @@ -193,7 +193,7 @@ func (tc *specClientTestCase) createFakeSpecClient() SpecClient {
@@ -497,15 +499,15 @@ index 3e55e3cb8..17c2a6551 100644
 +	return NewSpecClient(podListerMock, nil)
  }
  
- func (tc *specClientTestCase) getFakePods() []*v1.Pod {
+ func (tc *specClientTestCase) getFakePods() []*corev1.Pod {
 diff --git a/vertical-pod-autoscaler/pkg/recommender/logic/recommender.go b/vertical-pod-autoscaler/pkg/recommender/logic/recommender.go
-index b7b6f8a75..233944e14 100644
+index e3b530448..cb9d600d0 100644
 --- a/vertical-pod-autoscaler/pkg/recommender/logic/recommender.go
 +++ b/vertical-pod-autoscaler/pkg/recommender/logic/recommender.go
-@@ -181,6 +181,25 @@ func CreatePodResourceRecommender() PodResourceRecommender {
+@@ -191,6 +191,25 @@ func CreatePodResourceRecommender(config RecommendationConfig) PodResourceRecomm
  // MapToListOfRecommendedContainerResources converts the map of RecommendedContainerResources into a stable sorted list
  // This can be used to get a stable sequence while ranging on the data
- func MapToListOfRecommendedContainerResources(resources RecommendedPodResources) *vpa_types.RecommendedPodResources {
+ func MapToListOfRecommendedContainerResources(resources RecommendedPodResources, format RecommendationFormat) *vpa_types.RecommendedPodResources {
 +	if len(resources) == 0 {
 +		return &vpa_types.RecommendedPodResources{}
 +	}
@@ -516,10 +518,10 @@ index b7b6f8a75..233944e14 100644
 +			return &vpa_types.RecommendedPodResources{
 +				ContainerRecommendations: []vpa_types.RecommendedContainerResources{{
 +					ContainerName:  name,
-+					Target:         model.ResourcesAsResourceList(recommendation.Target, *humanizeMemory, *roundCPUMillicores, *roundMemoryBytes),
-+					LowerBound:     model.ResourcesAsResourceList(recommendation.LowerBound, *humanizeMemory, *roundCPUMillicores, *roundMemoryBytes),
-+					UpperBound:     model.ResourcesAsResourceList(recommendation.UpperBound, *humanizeMemory, *roundCPUMillicores, *roundMemoryBytes),
-+					UncappedTarget: model.ResourcesAsResourceList(recommendation.Target, *humanizeMemory, *roundCPUMillicores, *roundMemoryBytes),
++					Target:         model.ResourcesAsResourceList(recommendation.Target, format.HumanizeMemory, format.RoundCPUMillicores, format.RoundMemoryBytes),
++					LowerBound:     model.ResourcesAsResourceList(recommendation.LowerBound, format.HumanizeMemory, format.RoundCPUMillicores, format.RoundMemoryBytes),
++					UpperBound:     model.ResourcesAsResourceList(recommendation.UpperBound, format.HumanizeMemory, format.RoundCPUMillicores, format.RoundMemoryBytes),
++					UncappedTarget: model.ResourcesAsResourceList(recommendation.Target, format.HumanizeMemory, format.RoundCPUMillicores, format.RoundMemoryBytes),
 +				}},
 +			}
 +		}
@@ -528,31 +530,11 @@ index b7b6f8a75..233944e14 100644
  	containerResources := make([]vpa_types.RecommendedContainerResources, 0, len(resources))
  	// Sort the container names from the map. This is because maps are an
  	// unordered data structure, and iterating through the map will return
-diff --git a/vertical-pod-autoscaler/pkg/recommender/main.go b/vertical-pod-autoscaler/pkg/recommender/main.go
-index cda2d831d..5320ca68e 100644
---- a/vertical-pod-autoscaler/pkg/recommender/main.go
-+++ b/vertical-pod-autoscaler/pkg/recommender/main.go
-@@ -247,6 +247,7 @@ func run(ctx context.Context, healthCheck *metrics.HealthCheck, commonFlag *comm
- 	kubeClient := kube_client.NewForConfigOrDie(config)
- 	clusterState := model.NewClusterState(aggregateContainerStateGCInterval)
- 	factory := informers.NewSharedInformerFactoryWithOptions(kubeClient, defaultResyncPeriod, informers.WithNamespace(commonFlag.VpaObjectNamespace))
-+	nodeLister := factory.Core().V1().Nodes().Lister()
- 	controllerFetcher := controllerfetcher.NewControllerFetcher(config, kubeClient, factory, scaleCacheEntryFreshnessTime, scaleCacheEntryLifetime, scaleCacheEntryJitterFactor)
- 	podLister, oomObserver := input.NewPodListerAndOOMObserver(ctx, kubeClient, commonFlag.VpaObjectNamespace, stopCh)
- 
-@@ -292,6 +293,7 @@ func run(ctx context.Context, healthCheck *metrics.HealthCheck, commonFlag *comm
- 
- 	clusterStateFeeder := input.ClusterStateFeederFactory{
- 		PodLister:           podLister,
-+		NodeLister:          nodeLister,
- 		OOMObserver:         oomObserver,
- 		KubeClient:          kubeClient,
- 		MetricsClient:       input_metrics.NewMetricsClient(source, commonFlag.VpaObjectNamespace, "default-metrics-client"),
 diff --git a/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go b/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
-index e6274af72..4ac5f0eb5 100644
+index 0e1a645d2..29d8c72a7 100644
 --- a/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
 +++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
-@@ -361,6 +361,58 @@ func AggregateStateByContainerName(aggregateContainerStateMap aggregateContainer
+@@ -393,6 +393,58 @@ func AggregateStateByContainerName(aggregateContainerStateMap aggregateContainer
  	return containerNameToAggregateStateMap
  }
  
@@ -612,10 +594,10 @@ index e6274af72..4ac5f0eb5 100644
  // that creates ContainerStateAgregator for container if it is no longer
  // present in the cluster state.
 diff --git a/vertical-pod-autoscaler/pkg/recommender/model/cluster.go b/vertical-pod-autoscaler/pkg/recommender/model/cluster.go
-index 4bf55e867..eea9fcce2 100644
+index eba44bb8f..8ad38b644 100644
 --- a/vertical-pod-autoscaler/pkg/recommender/model/cluster.go
 +++ b/vertical-pod-autoscaler/pkg/recommender/model/cluster.go
-@@ -252,6 +252,13 @@ func (cluster *clusterState) AddSample(sample *ContainerUsageSampleWithKey) erro
+@@ -265,6 +265,13 @@ func (cluster *clusterState) AddSample(sample *ContainerUsageSampleWithKey) erro
  	if !containerState.AddSample(&sample.ContainerUsageSample) {
  		return errors.New("sample discarded (invalid or out of order)")
  	}
@@ -629,7 +611,7 @@ index 4bf55e867..eea9fcce2 100644
  	return nil
  }
  
-@@ -269,6 +276,13 @@ func (cluster *clusterState) RecordOOM(containerID ContainerID, timestamp time.T
+@@ -282,6 +289,13 @@ func (cluster *clusterState) RecordOOM(containerID ContainerID, timestamp time.T
  	if err != nil {
  		return fmt.Errorf("error while recording OOM for %v, Reason: %v", containerID, err)
  	}
@@ -643,7 +625,7 @@ index 4bf55e867..eea9fcce2 100644
  	return nil
  }
  
-@@ -306,6 +320,12 @@ func (cluster *clusterState) AddOrUpdateVpa(apiObject *vpa_types.VerticalPodAuto
+@@ -319,6 +333,12 @@ func (cluster *clusterState) AddOrUpdateVpa(apiObject *vpa_types.VerticalPodAuto
  		vpa.PodCount = len(cluster.GetMatchingPods(vpa))
  	}
  	vpa.TargetRef = apiObject.Spec.TargetRef
@@ -657,7 +639,7 @@ index 4bf55e867..eea9fcce2 100644
  	vpa.SetConditionsMap(conditionsMap)
  	vpa.SetRecommendationDirect(currentRecommendation)
 diff --git a/vertical-pod-autoscaler/pkg/recommender/model/vpa.go b/vertical-pod-autoscaler/pkg/recommender/model/vpa.go
-index c1dce049b..6708af359 100644
+index f68e2993c..cd3d51548 100644
 --- a/vertical-pod-autoscaler/pkg/recommender/model/vpa.go
 +++ b/vertical-pod-autoscaler/pkg/recommender/model/vpa.go
 @@ -20,10 +20,12 @@ import (
@@ -667,8 +649,8 @@ index c1dce049b..6708af359 100644
 +	"sync/atomic"
  	"time"
  
- 	autoscaling "k8s.io/api/autoscaling/v1"
- 	apiv1 "k8s.io/api/core/v1"
+ 	autoscalingv1 "k8s.io/api/autoscaling/v1"
+ 	corev1 "k8s.io/api/core/v1"
 +	apiequality "k8s.io/apimachinery/pkg/api/equality"
  	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
  	"k8s.io/apimachinery/pkg/labels"
@@ -676,7 +658,7 @@ index c1dce049b..6708af359 100644
 @@ -203,9 +205,16 @@ type Vpa struct {
  	APIVersion string
  	// TargetRef points to the controller managing the set of pods.
- 	TargetRef *autoscaling.CrossVersionObjectReference
+ 	TargetRef *autoscalingv1.CrossVersionObjectReference
 +	// Scope is an optional grouping key (node label key) for DaemonSet recommendations.
 +	Scope string
  	// PodCount contains number of live Pods matching a given VPA object.
@@ -689,8 +671,8 @@ index c1dce049b..6708af359 100644
 +
  	// mutex protects concurrent access to conditions and recommendation fields
  	mutex sync.RWMutex
- }
-@@ -254,6 +263,7 @@ func (vpa *Vpa) UseAggregationIfMatching(aggregationKey AggregateStateKey, aggre
+ 
+@@ -258,6 +267,7 @@ func (vpa *Vpa) UseAggregationIfMatching(aggregationKey AggregateStateKey, aggre
  		aggregation.IsUnderVPA = true
  		aggregation.UpdateMode = vpa.UpdateMode
  		aggregation.UpdateFromPolicy(vpa_api_util.GetContainerResourcePolicy(aggregationKey.ContainerName(), vpa.ResourcePolicy))
@@ -698,7 +680,7 @@ index c1dce049b..6708af359 100644
  	}
  }
  
-@@ -294,6 +304,7 @@ func (vpa *Vpa) DeleteAggregation(aggregationKey AggregateStateKey) {
+@@ -298,6 +308,7 @@ func (vpa *Vpa) DeleteAggregation(aggregationKey AggregateStateKey) {
  	}
  	state.MarkNotAutoscaled()
  	delete(vpa.aggregateContainerStates, aggregationKey)
@@ -706,7 +688,7 @@ index c1dce049b..6708af359 100644
  }
  
  // MergeCheckpointedState adds checkpointed VPA aggregations to the given aggregateStateMap.
-@@ -316,6 +327,11 @@ func (vpa *Vpa) AggregateStateByContainerName() ContainerNameToAggregateStateMap
+@@ -320,6 +331,11 @@ func (vpa *Vpa) AggregateStateByContainerName() ContainerNameToAggregateStateMap
  	return containerNameToAggregateStateMap
  }
  
@@ -718,7 +700,7 @@ index c1dce049b..6708af359 100644
  // HasRecommendation returns if the VPA object contains any recommendation
  func (vpa *Vpa) HasRecommendation() bool {
  	vpa.mutex.RLock()
-@@ -334,13 +350,24 @@ func (vpa *Vpa) matchesAggregation(aggregationKey AggregateStateKey) bool {
+@@ -338,13 +354,24 @@ func (vpa *Vpa) matchesAggregation(aggregationKey AggregateStateKey) bool {
  // SetResourcePolicy updates the resource policy of the VPA and the scaling
  // policies of aggregators under this VPA.
  func (vpa *Vpa) SetResourcePolicy(resourcePolicy *vpa_types.PodResourcePolicy) {
@@ -745,18 +727,18 @@ index c1dce049b..6708af359 100644
  
  // SetUpdateMode updates the update mode of the VPA and aggregators under this VPA.
 diff --git a/vertical-pod-autoscaler/pkg/recommender/routines/recommender.go b/vertical-pod-autoscaler/pkg/recommender/routines/recommender.go
-index c86871fa9..38fbce7a5 100644
+index 778e06694..6f161d4ca 100644
 --- a/vertical-pod-autoscaler/pkg/recommender/routines/recommender.go
 +++ b/vertical-pod-autoscaler/pkg/recommender/routines/recommender.go
-@@ -19,6 +19,7 @@ package routines
+@@ -18,6 +18,7 @@ package routines
+ 
  import (
  	"context"
- 	"flag"
 +	"sort"
  	"sync"
  	"time"
  
-@@ -32,6 +33,7 @@ import (
+@@ -31,6 +32,7 @@ import (
  	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/model"
  	controllerfetcher "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/target/controller_fetcher"
  	metrics_recommender "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/recommender"
@@ -764,7 +746,7 @@ index c86871fa9..38fbce7a5 100644
  	vpa_utils "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/vpa"
  )
  
-@@ -70,6 +72,16 @@ type recommender struct {
+@@ -65,6 +67,16 @@ type recommender struct {
  	lastAggregateContainerStateGC time.Time
  	recommendationPostProcessor   []RecommendationPostProcessor
  	updateWorkerCount             int
@@ -776,16 +758,16 @@ index c86871fa9..38fbce7a5 100644
 +
 +type scopedRecommendationCacheEntry struct {
 +	generation     uint64
-+	recommendation *v1.RecommendedPodResources
-+	groups         []v1.RecommendedPodResourcesGroup
++	recommendation *vpaautoscalingv1.RecommendedPodResources
++	groups         []vpaautoscalingv1.RecommendedPodResourcesGroup
  }
  
  func (r *recommender) GetClusterState() model.ClusterState {
-@@ -80,17 +92,103 @@ func (r *recommender) GetClusterStateFeeder() input.ClusterStateFeeder {
+@@ -75,17 +87,103 @@ func (r *recommender) GetClusterStateFeeder() input.ClusterStateFeeder {
  	return r.clusterStateFeeder
  }
  
-+func (r *recommender) getScopedRecommendationCache(vpaID model.VpaID, generation uint64) (*v1.RecommendedPodResources, []v1.RecommendedPodResourcesGroup, bool) {
++func (r *recommender) getScopedRecommendationCache(vpaID model.VpaID, generation uint64) (*vpaautoscalingv1.RecommendedPodResources, []vpaautoscalingv1.RecommendedPodResourcesGroup, bool) {
 +	r.scopedRecommendationCacheMutex.RLock()
 +	defer r.scopedRecommendationCacheMutex.RUnlock()
 +	entry, found := r.scopedRecommendationCache[vpaID]
@@ -795,7 +777,7 @@ index c86871fa9..38fbce7a5 100644
 +	return entry.recommendation, entry.groups, true
 +}
 +
-+func (r *recommender) setScopedRecommendationCache(vpaID model.VpaID, generation uint64, recommendation *v1.RecommendedPodResources, groups []v1.RecommendedPodResourcesGroup) {
++func (r *recommender) setScopedRecommendationCache(vpaID model.VpaID, generation uint64, recommendation *vpaautoscalingv1.RecommendedPodResources, groups []vpaautoscalingv1.RecommendedPodResourcesGroup) {
 +	r.scopedRecommendationCacheMutex.Lock()
 +	defer r.scopedRecommendationCacheMutex.Unlock()
 +	if r.scopedRecommendationCache == nil {
@@ -808,12 +790,12 @@ index c86871fa9..38fbce7a5 100644
 +	}
 +}
 +
- func processVPAUpdate(r *recommender, vpa *model.Vpa, observedVpa *v1.VerticalPodAutoscaler) {
+ func processVPAUpdate(r *recommender, vpa *model.Vpa, observedVpa *vpaautoscalingv1.VerticalPodAutoscaler) {
 -	resources := r.podResourceRecommender.GetRecommendedPodResources(GetContainerNameToAggregateStateMap(vpa))
  	had := vpa.HasRecommendation()
 +	isScopedDaemonSet := observedVpa.Spec.TargetRef != nil && scopeutil.IsScopedDaemonSet(observedVpa.Spec.TargetRef.Kind, string(observedVpa.Spec.Scope))
-+	var recommendation *v1.RecommendedPodResources
-+	var groups []v1.RecommendedPodResourcesGroup
++	var recommendation *vpaautoscalingv1.RecommendedPodResources
++	var groups []vpaautoscalingv1.RecommendedPodResourcesGroup
 +
 +	scopedGeneration := vpa.ScopedRecommendationGeneration()
 +	cacheHit := false
@@ -828,10 +810,10 @@ index c86871fa9..38fbce7a5 100644
 +	}
 +	if !cacheHit {
 +		resources := r.podResourceRecommender.GetRecommendedPodResources(GetContainerNameToAggregateStateMap(vpa))
-+		recommendation = logic.MapToListOfRecommendedContainerResources(resources)
++		recommendation = logic.MapToListOfRecommendedContainerResources(resources, r.recommendationFormat)
 +	}
  
--	listOfResourceRecommendation := logic.MapToListOfRecommendedContainerResources(resources)
+-	listOfResourceRecommendation := logic.MapToListOfRecommendedContainerResources(resources, r.recommendationFormat)
 +	if isScopedDaemonSet && !cacheHit {
 +		recommendationByScopeValue := GetContainerNameToAggregateStateMapByScopeValue(vpa)
 +		scopeValues := make([]string, 0, len(recommendationByScopeValue))
@@ -840,11 +822,11 @@ index c86871fa9..38fbce7a5 100644
 +		}
 +		sort.Strings(scopeValues)
 +		// Preallocate output groups to avoid repeated slice growth for large scoped DaemonSets.
-+		groups = make([]v1.RecommendedPodResourcesGroup, 0, len(scopeValues))
++		groups = make([]vpaautoscalingv1.RecommendedPodResourcesGroup, 0, len(scopeValues))
 +		for _, scopeValue := range scopeValues {
 +			resources := r.podResourceRecommender.GetRecommendedPodResources(recommendationByScopeValue[scopeValue])
-+			groupRecommendation := logic.MapToListOfRecommendedContainerResources(resources)
-+			groups = append(groups, v1.RecommendedPodResourcesGroup{
++			groupRecommendation := logic.MapToListOfRecommendedContainerResources(resources, r.recommendationFormat)
++			groups = append(groups, vpaautoscalingv1.RecommendedPodResourcesGroup{
 +				ScopeValue:               scopeValue,
 +				ContainerRecommendations: groupRecommendation.ContainerRecommendations,
 +			})
@@ -857,7 +839,7 @@ index c86871fa9..38fbce7a5 100644
 +		for _, postProcessor := range r.recommendationPostProcessor {
 +			recommendation = postProcessor.Process(observedVpa, recommendation)
 +			for i := range groups {
-+				groupRec := &v1.RecommendedPodResources{ContainerRecommendations: groups[i].ContainerRecommendations}
++				groupRec := &vpaautoscalingv1.RecommendedPodResources{ContainerRecommendations: groups[i].ContainerRecommendations}
 +				groupRec = postProcessor.Process(observedVpa, groupRec)
 +				groups[i].ContainerRecommendations = groupRec.ContainerRecommendations
 +			}
@@ -890,7 +872,7 @@ index c86871fa9..38fbce7a5 100644
  	if vpa.HasRecommendation() && !had {
  		metrics_recommender.ObserveRecommendationLatency(vpa.Created)
  	}
-@@ -108,10 +206,13 @@ func processVPAUpdate(r *recommender, vpa *model.Vpa, observedVpa *v1.VerticalPo
+@@ -103,10 +201,13 @@ func processVPAUpdate(r *recommender, vpa *model.Vpa, observedVpa *vpaautoscalin
  	}
  
  	_, err := vpa_utils.UpdateVpaStatusIfNeeded(
@@ -905,7 +887,7 @@ index c86871fa9..38fbce7a5 100644
  }
  
  // UpdateVPAs update VPA CRD objects' status.
-@@ -231,6 +332,7 @@ func (c RecommenderFactory) Make() Recommender {
+@@ -230,6 +331,7 @@ func (c RecommenderFactory) Make() Recommender {
  		lastAggregateContainerStateGC: time.Now(),
  		lastCheckpointGC:              time.Now(),
  		updateWorkerCount:             c.UpdateWorkerCount,
@@ -913,8 +895,28 @@ index c86871fa9..38fbce7a5 100644
  	}
  	klog.V(3).InfoS("New Recommender created", "recommender", recommender)
  	return recommender
+diff --git a/vertical-pod-autoscaler/pkg/recommender/routines/recommender_controller.go b/vertical-pod-autoscaler/pkg/recommender/routines/recommender_controller.go
+index 42e265dfd..5b7bef020 100644
+--- a/vertical-pod-autoscaler/pkg/recommender/routines/recommender_controller.go
++++ b/vertical-pod-autoscaler/pkg/recommender/routines/recommender_controller.go
+@@ -74,6 +74,7 @@ func NewRecommenderController(
+ 	commonFlags := config.CommonFlags
+ 
+ 	clusterState := model.NewClusterState(aggregateContainerStateGCInterval)
++	nodeLister := factory.Core().V1().Nodes().Lister()
+ 	controllerFetcher := controllerfetcher.NewControllerFetcher(kubeConfig, kubeClient, factory, scaleCacheEntryFreshnessTime, scaleCacheEntryLifetime, scaleCacheEntryJitterFactor, stopCh)
+ 	podLister, oomObserver := input.NewPodListerAndOOMObserver(ctx, kubeClient, commonFlags.VpaObjectNamespace, stopCh)
+ 
+@@ -120,6 +121,7 @@ func NewRecommenderController(
+ 
+ 	clusterStateFeeder := input.ClusterStateFeederFactory{
+ 		PodLister:           podLister,
++		NodeLister:          nodeLister,
+ 		OOMObserver:         oomObserver,
+ 		KubeClient:          kubeClient,
+ 		MetricsClient:       input_metrics.NewMetricsClient(source, commonFlags.VpaObjectNamespace, "default-metrics-client"),
 diff --git a/vertical-pod-autoscaler/pkg/recommender/routines/recommender_test.go b/vertical-pod-autoscaler/pkg/recommender/routines/recommender_test.go
-index e5f386f37..50c8d97b5 100644
+index 69414c055..4c064730d 100644
 --- a/vertical-pod-autoscaler/pkg/recommender/routines/recommender_test.go
 +++ b/vertical-pod-autoscaler/pkg/recommender/routines/recommender_test.go
 @@ -17,6 +17,7 @@ limitations under the License.
@@ -977,11 +979,11 @@ index e5f386f37..50c8d97b5 100644
 +	}
 +}
 +
-+func setupProcessVPAUpdateBenchmark(b *testing.B, podCount int, scoped bool) (*recommender, *model.Vpa, *v1.VerticalPodAutoscaler) {
++func setupProcessVPAUpdateBenchmark(b *testing.B, podCount int, scoped bool) (*recommender, *model.Vpa, *vpaautoscalingv1.VerticalPodAutoscaler) {
 +	return setupProcessVPAUpdateScenario(b, podCount, scoped, &mockPodResourceRecommender{})
 +}
 +
-+func setupProcessVPAUpdateScenario(tb testing.TB, podCount int, scoped bool, podResourceRecommender logic.PodResourceRecommender) (*recommender, *model.Vpa, *v1.VerticalPodAutoscaler) {
++func setupProcessVPAUpdateScenario(tb testing.TB, podCount int, scoped bool, podResourceRecommender logic.PodResourceRecommender) (*recommender, *model.Vpa, *vpaautoscalingv1.VerticalPodAutoscaler) {
 +	tb.Helper()
 +	clusterState := model.NewClusterState(time.Minute)
 +	selector, err := labels.Parse("app=daemon")
@@ -1001,7 +1003,7 @@ index e5f386f37..50c8d97b5 100644
 +		}).
 +		Get()
 +	if scoped {
-+		observedVpa.Spec.Scope = v1.VerticalPodAutoscalerScopeType("node.kubernetes.io/instance-type")
++		observedVpa.Spec.Scope = vpaautoscalingv1.VerticalPodAutoscalerScopeType("node.kubernetes.io/instance-type")
 +	}
 +
 +	if err := clusterState.AddOrUpdateVpa(observedVpa, selector); err != nil {
@@ -1060,7 +1062,7 @@ index e5f386f37..50c8d97b5 100644
 +			APIVersion: "apps/v1",
 +		}).
 +		Get()
-+	observedVpa.Spec.Scope = v1.VerticalPodAutoscalerScopeType("node.deckhouse.io/group")
++	observedVpa.Spec.Scope = vpaautoscalingv1.VerticalPodAutoscalerScopeType("node.deckhouse.io/group")
 +
 +	fakeClient := vpa_fake.NewSimpleClientset(observedVpa).AutoscalingV1() //nolint:staticcheck // https://github.com/kubernetes/autoscaler/issues/8954
 +	r := &recommender{
@@ -1265,600 +1267,6 @@ index d7cfd66fc..62a6a815c 100644
 +
 +	return filteredGroups
 +}
-diff --git a/vertical-pod-autoscaler/pkg/updater/main.go b/vertical-pod-autoscaler/pkg/updater/main.go
-index 409c72256..f7683781f 100644
---- a/vertical-pod-autoscaler/pkg/updater/main.go
-+++ b/vertical-pod-autoscaler/pkg/updater/main.go
-@@ -211,7 +211,7 @@ func run(healthCheck *metrics.HealthCheck, commonFlag *common.CommonFlags) {
- 
- 	ignoredNamespaces := strings.Split(commonFlag.IgnoredVpaObjectNamespaces, ",")
- 
--	recommendationProvider := recommendation.NewProvider(limitRangeCalculator, vpa_api_util.NewCappingRecommendationProcessor(limitRangeCalculator))
-+	recommendationProvider := recommendation.NewProvider(limitRangeCalculator, vpa_api_util.NewCappingRecommendationProcessorWithNodeGetter(limitRangeCalculator, kubeClient.CoreV1().Nodes()))
- 
- 	calculators := []patch.Calculator{inplace.NewResourceInPlaceUpdatesCalculator(recommendationProvider), inplace.NewInPlaceUpdatedCalculator()}
- 
-@@ -226,7 +226,7 @@ func run(healthCheck *metrics.HealthCheck, commonFlag *common.CommonFlags) {
- 		*useAdmissionControllerStatus,
- 		*inPlaceSkipDisruptionBudget,
- 		admissionControllerStatusNamespace,
--		vpa_api_util.NewCappingRecommendationProcessor(limitRangeCalculator),
-+		vpa_api_util.NewCappingRecommendationProcessorWithNodeGetter(limitRangeCalculator, kubeClient.CoreV1().Nodes()),
- 		priority.NewScalingDirectionPodEvictionAdmission(),
- 		targetSelectorFetcher,
- 		controllerFetcher,
-diff --git a/vertical-pod-autoscaler/pkg/utils/vpa/api.go b/vertical-pod-autoscaler/pkg/utils/vpa/api.go
-index 448591d22..5018a6d49 100644
---- a/vertical-pod-autoscaler/pkg/utils/vpa/api.go
-+++ b/vertical-pod-autoscaler/pkg/utils/vpa/api.go
-@@ -25,7 +25,6 @@ import (
- 	"time"
- 
- 	core "k8s.io/api/core/v1"
--	apiequality "k8s.io/apimachinery/pkg/api/equality"
- 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
- 	"k8s.io/apimachinery/pkg/fields"
- 	"k8s.io/apimachinery/pkg/labels"
-@@ -62,16 +61,98 @@ func patchVpaStatus(vpaClient vpa_api.VerticalPodAutoscalerInterface, vpaName st
- 	return vpaClient.Patch(context.TODO(), vpaName, types.JSONPatchType, bytes, meta.PatchOptions{}, "status")
- }
- 
-+func resourceListEqual(a, b core.ResourceList) bool {
-+	if len(a) != len(b) {
-+		return false
-+	}
-+	for resourceName, quantityA := range a {
-+		quantityB, found := b[resourceName]
-+		if !found || quantityA.Cmp(quantityB) != 0 {
-+			return false
-+		}
-+	}
-+	return true
-+}
-+
-+func containerRecommendationEqual(a, b vpa_types.RecommendedContainerResources) bool {
-+	return a.ContainerName == b.ContainerName &&
-+		a.Scope == b.Scope &&
-+		resourceListEqual(a.Target, b.Target) &&
-+		resourceListEqual(a.LowerBound, b.LowerBound) &&
-+		resourceListEqual(a.UpperBound, b.UpperBound) &&
-+		resourceListEqual(a.UncappedTarget, b.UncappedTarget)
-+}
-+
-+func recommendedPodResourcesEqual(a, b *vpa_types.RecommendedPodResources) bool {
-+	if a == nil || b == nil {
-+		return a == b
-+	}
-+	if len(a.ContainerRecommendations) != len(b.ContainerRecommendations) {
-+		return false
-+	}
-+	for i := range a.ContainerRecommendations {
-+		if !containerRecommendationEqual(a.ContainerRecommendations[i], b.ContainerRecommendations[i]) {
-+			return false
-+		}
-+	}
-+	return true
-+}
-+
-+func recommendationGroupsEqual(a, b []vpa_types.RecommendedPodResourcesGroup) bool {
-+	if len(a) != len(b) {
-+		return false
-+	}
-+	for i := range a {
-+		if a[i].ScopeValue != b[i].ScopeValue {
-+			return false
-+		}
-+		if len(a[i].ContainerRecommendations) != len(b[i].ContainerRecommendations) {
-+			return false
-+		}
-+		for j := range a[i].ContainerRecommendations {
-+			if !containerRecommendationEqual(a[i].ContainerRecommendations[j], b[i].ContainerRecommendations[j]) {
-+				return false
-+			}
-+		}
-+	}
-+	return true
-+}
-+
-+func conditionsEqual(a, b []vpa_types.VerticalPodAutoscalerCondition) bool {
-+	if len(a) != len(b) {
-+		return false
-+	}
-+	for i := range a {
-+		if a[i].Type != b[i].Type ||
-+			a[i].Status != b[i].Status ||
-+			a[i].Reason != b[i].Reason ||
-+			a[i].Message != b[i].Message ||
-+			!a[i].LastTransitionTime.Equal(&b[i].LastTransitionTime) {
-+			return false
-+		}
-+	}
-+	return true
-+}
-+
-+func vpaStatusEqual(oldStatus, newStatus *vpa_types.VerticalPodAutoscalerStatus) bool {
-+	return recommendedPodResourcesEqual(oldStatus.Recommendation, newStatus.Recommendation) &&
-+		conditionsEqual(oldStatus.Conditions, newStatus.Conditions) &&
-+		recommendationGroupsEqual(oldStatus.Groups, newStatus.Groups)
-+}
-+
- // UpdateVpaStatusIfNeeded updates the status field of the VPA API object.
- func UpdateVpaStatusIfNeeded(vpaClient vpa_api.VerticalPodAutoscalerInterface, vpaName string, newStatus,
- 	oldStatus *vpa_types.VerticalPodAutoscalerStatus) (result *vpa_types.VerticalPodAutoscaler, err error) {
--	patches := []patchRecord{{
--		Op:    "add",
--		Path:  "/status",
--		Value: *newStatus,
--	}}
--
--	if !apiequality.Semantic.DeepEqual(*oldStatus, *newStatus) {
-+	// Fast structural comparison avoids reflection-heavy DeepEqual allocations
-+	// on large grouped status payloads.
-+	if !vpaStatusEqual(oldStatus, newStatus) {
-+		// Build patch payload only when status changed; this avoids copying large status objects
-+		// in the common no-op update path.
-+		patches := []patchRecord{{
-+			Op:    "add",
-+			Path:  "/status",
-+			Value: *newStatus,
-+		}}
- 		return patchVpaStatus(vpaClient, vpaName, patches)
- 	}
- 	return nil, nil
-diff --git a/vertical-pod-autoscaler/pkg/utils/vpa/capping.go b/vertical-pod-autoscaler/pkg/utils/vpa/capping.go
-index 565fd430d..71bcb62d2 100644
---- a/vertical-pod-autoscaler/pkg/utils/vpa/capping.go
-+++ b/vertical-pod-autoscaler/pkg/utils/vpa/capping.go
-@@ -17,22 +17,32 @@ limitations under the License.
- package api
- 
- import (
-+	"context"
- 	"errors"
- 	"fmt"
-+	"sync"
-+	"time"
- 
- 	apiv1 "k8s.io/api/core/v1"
- 	"k8s.io/apimachinery/pkg/api/resource"
-+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
- 	"k8s.io/klog/v2"
- 
- 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
- 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/limitrange"
- 	resourcehelpers "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/resources"
-+	scopeutil "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/scope"
- )
- 
- // NewCappingRecommendationProcessor constructs new RecommendationsProcessor that adjusts recommendation
- // for given pod to obey VPA resources policy and container limits
- func NewCappingRecommendationProcessor(limitsRangeCalculator limitrange.LimitRangeCalculator) RecommendationProcessor {
--	return &cappingRecommendationProcessor{limitsRangeCalculator: limitsRangeCalculator}
-+	return &cappingRecommendationProcessor{
-+		limitsRangeCalculator: limitsRangeCalculator,
-+		scopeCache:            map[string]cachedScopeValue{},
-+		scopeCacheTTL:         time.Minute,
-+		groupLookup:           map[string]map[string]vpa_types.RecommendedContainerResources{},
-+	}
- }
- 
- type cappingAction string
-@@ -51,6 +61,34 @@ func toCappingAnnotation(resourceName apiv1.ResourceName, action cappingAction)
- 
- type cappingRecommendationProcessor struct {
- 	limitsRangeCalculator limitrange.LimitRangeCalculator
-+	nodeGetter            NodeGetter
-+	scopeCache            map[string]cachedScopeValue
-+	scopeCacheTTL         time.Duration
-+	scopeCacheMu          sync.RWMutex
-+	groupLookupKey        string
-+	groupLookup           map[string]map[string]vpa_types.RecommendedContainerResources
-+	groupLookupMu         sync.RWMutex
-+}
-+
-+type cachedScopeValue struct {
-+	value      string
-+	cachedTime time.Time
-+}
-+
-+// NodeGetter allows fetching node metadata for scope-aware recommendations.
-+type NodeGetter interface {
-+	Get(ctx context.Context, name string, opts metav1.GetOptions) (*apiv1.Node, error)
-+}
-+
-+// NewCappingRecommendationProcessorWithNodeGetter constructs new processor with node metadata support.
-+func NewCappingRecommendationProcessorWithNodeGetter(limitsRangeCalculator limitrange.LimitRangeCalculator, nodeGetter NodeGetter) RecommendationProcessor {
-+	return &cappingRecommendationProcessor{
-+		limitsRangeCalculator: limitsRangeCalculator,
-+		nodeGetter:            nodeGetter,
-+		scopeCache:            map[string]cachedScopeValue{},
-+		scopeCacheTTL:         time.Minute,
-+		groupLookup:           map[string]map[string]vpa_types.RecommendedContainerResources{},
-+	}
- }
- 
- // Apply returns a recommendation for the given pod, adjusted to obey policy and limits.
-@@ -68,8 +106,11 @@ func (c *cappingRecommendationProcessor) Apply(
- 
- 	policy := vpa.Spec.ResourcePolicy
- 	podRecommendation := vpa.Status.Recommendation
-+	hasScopedGroups := len(vpa.Status.Groups) > 0 &&
-+		vpa.Spec.TargetRef != nil &&
-+		scopeutil.IsScopedDaemonSet(vpa.Spec.TargetRef.Kind, string(vpa.Spec.Scope))
- 
--	if podRecommendation == nil && policy == nil {
-+	if podRecommendation == nil && policy == nil && !hasScopedGroups {
- 		// If there is no recommendation and no policies have been defined then no recommendation can be computed.
- 		return nil, nil, nil
- 	}
-@@ -77,9 +118,13 @@ func (c *cappingRecommendationProcessor) Apply(
- 		// Policies have been specified. Create an empty recommendation so that the policies can be applied correctly.
- 		podRecommendation = new(vpa_types.RecommendedPodResources)
- 	}
-+	containerRecommendations, err := c.selectRecommendationsForScope(vpa, pod, podRecommendation)
-+	if err != nil {
-+		return nil, nil, err
-+	}
- 	updatedRecommendations := []vpa_types.RecommendedContainerResources{}
- 	containerToAnnotationsMap := ContainerToAnnotationsMap{}
--	limitAdjustedRecommendation, err := c.capProportionallyToPodLimitRange(podRecommendation.ContainerRecommendations, pod)
-+	limitAdjustedRecommendation, err := c.capProportionallyToPodLimitRange(containerRecommendations, pod)
- 	if err != nil {
- 		return nil, nil, err
- 	}
-@@ -110,6 +155,100 @@ func (c *cappingRecommendationProcessor) Apply(
- 	return &vpa_types.RecommendedPodResources{ContainerRecommendations: updatedRecommendations}, containerToAnnotationsMap, nil
- }
- 
-+func (c *cappingRecommendationProcessor) selectRecommendationsForScope(
-+	vpa *vpa_types.VerticalPodAutoscaler,
-+	pod *apiv1.Pod,
-+	podRecommendation *vpa_types.RecommendedPodResources,
-+) ([]vpa_types.RecommendedContainerResources, error) {
-+	if vpa.Spec.TargetRef == nil || !scopeutil.IsScopedDaemonSet(vpa.Spec.TargetRef.Kind, string(vpa.Spec.Scope)) {
-+		return podRecommendation.ContainerRecommendations, nil
-+	}
-+
-+	scopeValue, err := c.resolvePodScopeValue(pod, string(vpa.Spec.Scope))
-+	if err != nil {
-+		return nil, err
-+	}
-+
-+	groupLookup := c.getGroupRecommendationLookup(vpa)
-+	if group, found := groupLookup[scopeValue]; found {
-+		selected := make([]vpa_types.RecommendedContainerResources, 0, len(group))
-+		for _, recommendation := range group {
-+			selected = append(selected, recommendation)
-+		}
-+		return selected, nil
-+	}
-+
-+	return []vpa_types.RecommendedContainerResources{}, nil
-+}
-+
-+func (c *cappingRecommendationProcessor) getGroupRecommendationLookup(vpa *vpa_types.VerticalPodAutoscaler) map[string]map[string]vpa_types.RecommendedContainerResources {
-+	cacheKey := vpa.Namespace + "/" + vpa.Name + "/" + vpa.ResourceVersion + "/" + string(vpa.Spec.Scope)
-+
-+	c.groupLookupMu.RLock()
-+	if c.groupLookupKey == cacheKey {
-+		lookup := c.groupLookup
-+		c.groupLookupMu.RUnlock()
-+		return lookup
-+	}
-+	c.groupLookupMu.RUnlock()
-+
-+	lookup := buildGroupRecommendationLookup(vpa.Status.Groups)
-+	c.groupLookupMu.Lock()
-+	c.groupLookupKey = cacheKey
-+	c.groupLookup = lookup
-+	c.groupLookupMu.Unlock()
-+	return lookup
-+}
-+
-+func buildGroupRecommendationLookup(groups []vpa_types.RecommendedPodResourcesGroup) map[string]map[string]vpa_types.RecommendedContainerResources {
-+	lookup := make(map[string]map[string]vpa_types.RecommendedContainerResources, len(groups))
-+	for _, group := range groups {
-+		byContainer := make(map[string]vpa_types.RecommendedContainerResources, len(group.ContainerRecommendations))
-+		for _, recommendation := range group.ContainerRecommendations {
-+			byContainer[recommendation.ContainerName] = recommendation
-+		}
-+		if len(byContainer) > 0 {
-+			lookup[group.ScopeValue] = byContainer
-+		}
-+	}
-+	return lookup
-+}
-+
-+func (c *cappingRecommendationProcessor) resolvePodScopeValue(pod *apiv1.Pod, scopeKey string) (string, error) {
-+	nodeName := getPodNode(pod)
-+	if nodeName == "" {
-+		return "", nil
-+	}
-+	if scopeKey == string(vpa_types.ScopeNode) {
-+		return nodeName, nil
-+	}
-+
-+	cacheKey := nodeName + "\n" + scopeKey
-+	c.scopeCacheMu.RLock()
-+	cached, found := c.scopeCache[cacheKey]
-+	c.scopeCacheMu.RUnlock()
-+	if found && time.Since(cached.cachedTime) <= c.scopeCacheTTL {
-+		return cached.value, nil
-+	}
-+
-+	if c.nodeGetter == nil {
-+		return scopeutil.AbsentLabelValue, nil
-+	}
-+	node, err := c.nodeGetter.Get(context.Background(), nodeName, metav1.GetOptions{})
-+	if err != nil {
-+		return "", fmt.Errorf("failed to resolve node label %q for node %q: %w", scopeKey, nodeName, err)
-+	}
-+	scopeValue := scopeutil.AbsentLabelValue
-+	if labelValue, found := node.Labels[scopeKey]; found {
-+		scopeValue = labelValue
-+	}
-+
-+	c.scopeCacheMu.Lock()
-+	c.scopeCache[cacheKey] = cachedScopeValue{value: scopeValue, cachedTime: time.Now()}
-+	c.scopeCacheMu.Unlock()
-+	return scopeValue, nil
-+}
-+
- // getCappedRecommendationForContainer returns a recommendation for the given container, adjusted to obey policy and limits.
- func getCappedRecommendationForContainer(
- 	pod *apiv1.Pod,
-@@ -316,6 +455,30 @@ func getContainer(containerName string, pod *apiv1.Pod) *apiv1.Container {
- 	return nil
- }
- 
-+func getPodNode(pod *apiv1.Pod) string {
-+	if pod.Spec.NodeName != "" {
-+		return pod.Spec.NodeName
-+	}
-+	if pod.Spec.Affinity == nil || pod.Spec.Affinity.NodeAffinity == nil {
-+		return ""
-+	}
-+	required := pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
-+	if required == nil {
-+		return ""
-+	}
-+	for _, term := range required.NodeSelectorTerms {
-+		for _, field := range term.MatchFields {
-+			if field.Key != "metadata.name" {
-+				continue
-+			}
-+			if field.Operator == apiv1.NodeSelectorOpIn && len(field.Values) == 1 {
-+				return field.Values[0]
-+			}
-+		}
-+	}
-+	return ""
-+}
-+
- // applyContainerLimitRange updates recommendation if recommended resources are outside of limits defined in VPA resources policy
- func applyContainerLimitRange(recommendation apiv1.ResourceList,
- 	containerRequests apiv1.ResourceList, containerLimits apiv1.ResourceList,
-diff --git a/vertical-pod-autoscaler/pkg/utils/vpa/capping_test.go b/vertical-pod-autoscaler/pkg/utils/vpa/capping_test.go
-index 8096f2d95..bc9c3e17f 100644
---- a/vertical-pod-autoscaler/pkg/utils/vpa/capping_test.go
-+++ b/vertical-pod-autoscaler/pkg/utils/vpa/capping_test.go
-@@ -17,13 +17,17 @@ limitations under the License.
- package api
- 
- import (
-+	"context"
- 	"testing"
- 
- 	"github.com/stretchr/testify/assert"
-+	autoscalingv1 "k8s.io/api/autoscaling/v1"
- 	apiv1 "k8s.io/api/core/v1"
- 	"k8s.io/apimachinery/pkg/api/resource"
-+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
- 
- 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
-+	scopeutil "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/scope"
- 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/test"
- )
- 
-@@ -1652,3 +1656,198 @@ func TestCapPodMemoryWithUnderByteSplit(t *testing.T) {
- 		})
- 	}
- }
-+
-+type fakeNodeGetter struct {
-+	nodes map[string]*apiv1.Node
-+}
-+
-+func (f *fakeNodeGetter) Get(_ context.Context, name string, _ metav1.GetOptions) (*apiv1.Node, error) {
-+	if node, found := f.nodes[name]; found {
-+		return node, nil
-+	}
-+	return nil, assert.AnError
-+}
-+
-+func TestApplyScopedRecommendationForDaemonSetByNodeLabelRequiresGroups(t *testing.T) {
-+	const containerName = "agent"
-+	const scopeKey = "node.kubernetes.io/instance-type"
-+	pod := test.Pod().
-+		WithName("agent-pod").
-+		AddContainer(test.Container().WithName(containerName).Get()).
-+		Get()
-+	pod.Spec.NodeName = "node-a"
-+
-+	vpa := test.VerticalPodAutoscaler().
-+		WithContainer(containerName).
-+		WithTargetRef(&autoscalingv1.CrossVersionObjectReference{
-+			Kind:       "DaemonSet",
-+			Name:       "agent-ds",
-+			APIVersion: "apps/v1",
-+		}).
-+		Get()
-+	vpa.Spec.Scope = vpa_types.VerticalPodAutoscalerScopeType(scopeKey)
-+	vpa.Status.Recommendation = &vpa_types.RecommendedPodResources{
-+		ContainerRecommendations: []vpa_types.RecommendedContainerResources{
-+			{
-+				ContainerName: containerName,
-+				Target: apiv1.ResourceList{
-+					apiv1.ResourceMemory: resource.MustParse("1Gi"),
-+				},
-+			},
-+		},
-+	}
-+
-+	processor := NewCappingRecommendationProcessorWithNodeGetter(
-+		&fakeLimitRangeCalculator{},
-+		&fakeNodeGetter{
-+			nodes: map[string]*apiv1.Node{
-+				"node-a": {
-+					ObjectMeta: metav1.ObjectMeta{
-+						Name: "node-a",
-+						Labels: map[string]string{
-+							scopeKey: "c3.large",
-+						},
-+					},
-+				},
-+			},
-+		},
-+	)
-+
-+	res, _, err := processor.Apply(vpa, pod)
-+	assert.NoError(t, err)
-+	assert.Empty(t, res.ContainerRecommendations)
-+}
-+
-+func TestApplyScopedRecommendationFromCompactGroups(t *testing.T) {
-+	const containerName = "agent"
-+	const scopeKey = "node.deckhouse.io/group"
-+	pod := test.Pod().
-+		WithName("agent-pod").
-+		AddContainer(test.Container().WithName(containerName).Get()).
-+		Get()
-+	pod.Spec.NodeName = "node-a"
-+
-+	vpa := test.VerticalPodAutoscaler().
-+		WithContainer(containerName).
-+		WithTargetRef(&autoscalingv1.CrossVersionObjectReference{
-+			Kind:       "DaemonSet",
-+			Name:       "agent-ds",
-+			APIVersion: "apps/v1",
-+		}).
-+		Get()
-+	vpa.Spec.Scope = vpa_types.VerticalPodAutoscalerScopeType(scopeKey)
-+	vpa.Status.Recommendation = &vpa_types.RecommendedPodResources{
-+		ContainerRecommendations: []vpa_types.RecommendedContainerResources{
-+			{
-+				ContainerName: containerName,
-+				Target: apiv1.ResourceList{
-+					apiv1.ResourceMemory: resource.MustParse("1Gi"),
-+				},
-+			},
-+		},
-+	}
-+	vpa.Status.Groups = []vpa_types.RecommendedPodResourcesGroup{
-+		{
-+			ScopeValue: scopeutil.AbsentLabelValue,
-+			ContainerRecommendations: []vpa_types.RecommendedContainerResources{
-+				{
-+					ContainerName: containerName,
-+					Target: apiv1.ResourceList{
-+						apiv1.ResourceMemory: resource.MustParse("32Mi"),
-+					},
-+				},
-+			},
-+		},
-+		{
-+			ScopeValue: "",
-+			ContainerRecommendations: []vpa_types.RecommendedContainerResources{
-+				{
-+					ContainerName: containerName,
-+					Target: apiv1.ResourceList{
-+						apiv1.ResourceMemory: resource.MustParse("50Mi"),
-+					},
-+				},
-+			},
-+		},
-+		{
-+			ScopeValue: "master",
-+			ContainerRecommendations: []vpa_types.RecommendedContainerResources{
-+				{
-+					ContainerName: containerName,
-+					Target: apiv1.ResourceList{
-+						apiv1.ResourceMemory: resource.MustParse("50Mi"),
-+					},
-+				},
-+			},
-+		},
-+		{
-+			ScopeValue: "worker",
-+			ContainerRecommendations: []vpa_types.RecommendedContainerResources{
-+				{
-+					ContainerName: containerName,
-+					Target: apiv1.ResourceList{
-+						apiv1.ResourceMemory: resource.MustParse("500Mi"),
-+					},
-+				},
-+			},
-+		},
-+	}
-+
-+	processor := NewCappingRecommendationProcessorWithNodeGetter(
-+		&fakeLimitRangeCalculator{},
-+		&fakeNodeGetter{
-+			nodes: map[string]*apiv1.Node{
-+				"node-a": {
-+					ObjectMeta: metav1.ObjectMeta{
-+						Name: "node-a",
-+						Labels: map[string]string{
-+							scopeKey: "worker",
-+						},
-+					},
-+				},
-+			},
-+		},
-+	)
-+	res, _, err := processor.Apply(vpa, pod)
-+	assert.NoError(t, err)
-+	if assert.Len(t, res.ContainerRecommendations, 1) {
-+		assert.Equal(t, resource.MustParse("500Mi"), res.ContainerRecommendations[0].Target[apiv1.ResourceMemory])
-+	}
-+
-+	podEmpty := pod.DeepCopy()
-+	podEmpty.Spec.NodeName = "node-empty"
-+	podAbsent := pod.DeepCopy()
-+	podAbsent.Spec.NodeName = "node-absent"
-+
-+	processor = NewCappingRecommendationProcessorWithNodeGetter(
-+		&fakeLimitRangeCalculator{},
-+		&fakeNodeGetter{
-+			nodes: map[string]*apiv1.Node{
-+				"node-empty": {
-+					ObjectMeta: metav1.ObjectMeta{
-+						Name:   "node-empty",
-+						Labels: map[string]string{scopeKey: ""},
-+					},
-+				},
-+				"node-absent": {
-+					ObjectMeta: metav1.ObjectMeta{
-+						Name:   "node-absent",
-+						Labels: map[string]string{"kubernetes.io/hostname": "node-absent"},
-+					},
-+				},
-+			},
-+		},
-+	)
-+
-+	resEmpty, _, err := processor.Apply(vpa, podEmpty)
-+	assert.NoError(t, err)
-+	if assert.Len(t, resEmpty.ContainerRecommendations, 1) {
-+		assert.Equal(t, resource.MustParse("50Mi"), resEmpty.ContainerRecommendations[0].Target[apiv1.ResourceMemory])
-+	}
-+
-+	resAbsent, _, err := processor.Apply(vpa, podAbsent)
-+	assert.NoError(t, err)
-+	if assert.Len(t, resAbsent.ContainerRecommendations, 1) {
-+		assert.Equal(t, resource.MustParse("32Mi"), resAbsent.ContainerRecommendations[0].Target[apiv1.ResourceMemory])
-+	}
-+}
 diff --git a/vertical-pod-autoscaler/pkg/recommender/routines/vpa_scope_test.go b/vertical-pod-autoscaler/pkg/recommender/routines/vpa_scope_test.go
 new file mode 100644
 index 000000000..392c59e17
@@ -2018,6 +1426,28 @@ index 000000000..392c59e17
 +	}
 +	return vpa
 +}
+diff --git a/vertical-pod-autoscaler/pkg/updater/main.go b/vertical-pod-autoscaler/pkg/updater/main.go
+index 327f3c254..d2e993fb6 100644
+--- a/vertical-pod-autoscaler/pkg/updater/main.go
++++ b/vertical-pod-autoscaler/pkg/updater/main.go
+@@ -169,7 +169,7 @@ func run(healthCheck *metrics.HealthCheck, commonFlag *common.CommonFlags) {
+ 
+ 	ignoredNamespaces := strings.Split(commonFlag.IgnoredVpaObjectNamespaces, ",")
+ 
+-	recommendationProvider := recommendation.NewProvider(limitRangeCalculator, vpa_api_util.NewCappingRecommendationProcessor(limitRangeCalculator))
++	recommendationProvider := recommendation.NewProvider(limitRangeCalculator, vpa_api_util.NewCappingRecommendationProcessorWithNodeGetter(limitRangeCalculator, kubeClient.CoreV1().Nodes()))
+ 
+ 	calculators := []patch.Calculator{inplace.NewResourceInPlaceUpdatesCalculator(recommendationProvider), inplace.NewInPlaceUpdatedCalculator(), inplace.NewUnboostAnnotationCalculator()}
+ 
+@@ -188,7 +188,7 @@ func run(healthCheck *metrics.HealthCheck, commonFlag *common.CommonFlags) {
+ 		config.PodLifetimeUpdateThreshold,
+ 		config.EvictAfterOOMThreshold,
+ 		admissionControllerStatusNamespace,
+-		vpa_api_util.NewCappingRecommendationProcessor(limitRangeCalculator),
++		vpa_api_util.NewCappingRecommendationProcessorWithNodeGetter(limitRangeCalculator, kubeClient.CoreV1().Nodes()),
+ 		priority.NewScalingDirectionPodEvictionAdmission(),
+ 		targetSelectorFetcher,
+ 		controllerFetcher,
 diff --git a/vertical-pod-autoscaler/pkg/utils/scope/scope.go b/vertical-pod-autoscaler/pkg/utils/scope/scope.go
 new file mode 100644
 index 000000000..fb2ce6dc4
@@ -2050,3 +1480,583 @@ index 000000000..fb2ce6dc4
 +	return fmt.Sprintf("%s%x", labelPrefix, h.Sum32())
 +}
 +
+diff --git a/vertical-pod-autoscaler/pkg/utils/vpa/api.go b/vertical-pod-autoscaler/pkg/utils/vpa/api.go
+index 2a8fa8284..c07bda144 100644
+--- a/vertical-pod-autoscaler/pkg/utils/vpa/api.go
++++ b/vertical-pod-autoscaler/pkg/utils/vpa/api.go
+@@ -25,7 +25,6 @@ import (
+ 	"time"
+ 
+ 	corev1 "k8s.io/api/core/v1"
+-	apiequality "k8s.io/apimachinery/pkg/api/equality"
+ 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+ 	"k8s.io/apimachinery/pkg/fields"
+ 	"k8s.io/apimachinery/pkg/labels"
+@@ -64,16 +63,106 @@ func patchVpaStatus(vpaClient vpa_api.VerticalPodAutoscalerInterface, vpaName st
+ 	return vpaClient.Patch(context.TODO(), vpaName, types.JSONPatchType, bytes, metav1.PatchOptions{}, "status")
+ }
+ 
++func resourceListEqual(a, b corev1.ResourceList) bool {
++	if len(a) != len(b) {
++		return false
++	}
++	for resourceName, quantityA := range a {
++		quantityB, found := b[resourceName]
++		if !found || quantityA.Cmp(quantityB) != 0 {
++			return false
++		}
++	}
++	return true
++}
++
++func containerRecommendationEqual(a, b vpa_types.RecommendedContainerResources) bool {
++	return a.ContainerName == b.ContainerName &&
++		a.Scope == b.Scope &&
++		resourceListEqual(a.Target, b.Target) &&
++		resourceListEqual(a.LowerBound, b.LowerBound) &&
++		resourceListEqual(a.UpperBound, b.UpperBound) &&
++		resourceListEqual(a.UncappedTarget, b.UncappedTarget)
++}
++
++func recommendedPodResourcesEqual(a, b *vpa_types.RecommendedPodResources) bool {
++	if a == nil || b == nil {
++		return a == b
++	}
++	if len(a.ContainerRecommendations) != len(b.ContainerRecommendations) {
++		return false
++	}
++	for i := range a.ContainerRecommendations {
++		if !containerRecommendationEqual(a.ContainerRecommendations[i], b.ContainerRecommendations[i]) {
++			return false
++		}
++	}
++	return true
++}
++
++func recommendationGroupsEqual(a, b []vpa_types.RecommendedPodResourcesGroup) bool {
++	if len(a) != len(b) {
++		return false
++	}
++	for i := range a {
++		if a[i].ScopeValue != b[i].ScopeValue {
++			return false
++		}
++		if len(a[i].ContainerRecommendations) != len(b[i].ContainerRecommendations) {
++			return false
++		}
++		for j := range a[i].ContainerRecommendations {
++			if !containerRecommendationEqual(a[i].ContainerRecommendations[j], b[i].ContainerRecommendations[j]) {
++				return false
++			}
++		}
++	}
++	return true
++}
++
++func conditionsEqual(a, b []vpa_types.VerticalPodAutoscalerCondition) bool {
++	if len(a) != len(b) {
++		return false
++	}
++	for i := range a {
++		if a[i].Type != b[i].Type ||
++			a[i].Status != b[i].Status ||
++			a[i].Reason != b[i].Reason ||
++			a[i].Message != b[i].Message ||
++			!a[i].LastTransitionTime.Equal(&b[i].LastTransitionTime) {
++			return false
++		}
++	}
++	return true
++}
++
++func observedGenerationEqual(a, b *int64) bool {
++	if a == nil || b == nil {
++		return a == b
++	}
++	return *a == *b
++}
++
++func vpaStatusEqual(oldStatus, newStatus *vpa_types.VerticalPodAutoscalerStatus) bool {
++	return recommendedPodResourcesEqual(oldStatus.Recommendation, newStatus.Recommendation) &&
++		conditionsEqual(oldStatus.Conditions, newStatus.Conditions) &&
++		observedGenerationEqual(oldStatus.ObservedGeneration, newStatus.ObservedGeneration) &&
++		recommendationGroupsEqual(oldStatus.Groups, newStatus.Groups)
++}
++
+ // UpdateVpaStatusIfNeeded updates the status field of the VPA API object.
+ func UpdateVpaStatusIfNeeded(vpaClient vpa_api.VerticalPodAutoscalerInterface, vpaName string, newStatus,
+ 	oldStatus *vpa_types.VerticalPodAutoscalerStatus) (result *vpa_types.VerticalPodAutoscaler, err error) {
+-	patches := []patchRecord{{
+-		Op:    "add",
+-		Path:  "/status",
+-		Value: *newStatus,
+-	}}
+-
+-	if !apiequality.Semantic.DeepEqual(*oldStatus, *newStatus) {
++	// Fast structural comparison avoids reflection-heavy DeepEqual allocations
++	// on large grouped status payloads.
++	if !vpaStatusEqual(oldStatus, newStatus) {
++		// Build patch payload only when status changed; this avoids copying large status objects
++		// in the common no-op update path.
++		patches := []patchRecord{{
++			Op:    "add",
++			Path:  "/status",
++			Value: *newStatus,
++		}}
+ 		return patchVpaStatus(vpaClient, vpaName, patches)
+ 	}
+ 	return nil, nil
+diff --git a/vertical-pod-autoscaler/pkg/utils/vpa/capping.go b/vertical-pod-autoscaler/pkg/utils/vpa/capping.go
+index 021810fa6..2b4b6e78e 100644
+--- a/vertical-pod-autoscaler/pkg/utils/vpa/capping.go
++++ b/vertical-pod-autoscaler/pkg/utils/vpa/capping.go
+@@ -17,22 +17,32 @@ limitations under the License.
+ package api
+ 
+ import (
++	"context"
+ 	"errors"
+ 	"fmt"
++	"sync"
++	"time"
+ 
+ 	corev1 "k8s.io/api/core/v1"
+ 	"k8s.io/apimachinery/pkg/api/resource"
++	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+ 	"k8s.io/klog/v2"
+ 
+ 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+ 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/limitrange"
+ 	resourcehelpers "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/resources"
++	scopeutil "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/scope"
+ )
+ 
+ // NewCappingRecommendationProcessor constructs new RecommendationsProcessor that adjusts recommendation
+ // for given pod to obey VPA resources policy and container limits
+ func NewCappingRecommendationProcessor(limitsRangeCalculator limitrange.LimitRangeCalculator) RecommendationProcessor {
+-	return &cappingRecommendationProcessor{limitsRangeCalculator: limitsRangeCalculator}
++	return &cappingRecommendationProcessor{
++		limitsRangeCalculator: limitsRangeCalculator,
++		scopeCache:            map[string]cachedScopeValue{},
++		scopeCacheTTL:         time.Minute,
++		groupLookup:           map[string]map[string]vpa_types.RecommendedContainerResources{},
++	}
+ }
+ 
+ type cappingAction string
+@@ -51,6 +61,34 @@ func toCappingAnnotation(resourceName corev1.ResourceName, action cappingAction)
+ 
+ type cappingRecommendationProcessor struct {
+ 	limitsRangeCalculator limitrange.LimitRangeCalculator
++	nodeGetter            NodeGetter
++	scopeCache            map[string]cachedScopeValue
++	scopeCacheTTL         time.Duration
++	scopeCacheMu          sync.RWMutex
++	groupLookupKey        string
++	groupLookup           map[string]map[string]vpa_types.RecommendedContainerResources
++	groupLookupMu         sync.RWMutex
++}
++
++type cachedScopeValue struct {
++	value      string
++	cachedTime time.Time
++}
++
++// NodeGetter allows fetching node metadata for scope-aware recommendations.
++type NodeGetter interface {
++	Get(ctx context.Context, name string, opts metav1.GetOptions) (*corev1.Node, error)
++}
++
++// NewCappingRecommendationProcessorWithNodeGetter constructs new processor with node metadata support.
++func NewCappingRecommendationProcessorWithNodeGetter(limitsRangeCalculator limitrange.LimitRangeCalculator, nodeGetter NodeGetter) RecommendationProcessor {
++	return &cappingRecommendationProcessor{
++		limitsRangeCalculator: limitsRangeCalculator,
++		nodeGetter:            nodeGetter,
++		scopeCache:            map[string]cachedScopeValue{},
++		scopeCacheTTL:         time.Minute,
++		groupLookup:           map[string]map[string]vpa_types.RecommendedContainerResources{},
++	}
+ }
+ 
+ // Apply returns a recommendation for the given pod, adjusted to obey policy and limits.
+@@ -68,8 +106,11 @@ func (c *cappingRecommendationProcessor) Apply(
+ 
+ 	policy := vpa.Spec.ResourcePolicy
+ 	podRecommendation := vpa.Status.Recommendation
++	hasScopedGroups := len(vpa.Status.Groups) > 0 &&
++		vpa.Spec.TargetRef != nil &&
++		scopeutil.IsScopedDaemonSet(vpa.Spec.TargetRef.Kind, string(vpa.Spec.Scope))
+ 
+-	if podRecommendation == nil && policy == nil {
++	if podRecommendation == nil && policy == nil && !hasScopedGroups {
+ 		// If there is no recommendation and no policies have been defined then no recommendation can be computed.
+ 		return nil, nil, nil
+ 	}
+@@ -77,9 +118,13 @@ func (c *cappingRecommendationProcessor) Apply(
+ 		// Policies have been specified. Create an empty recommendation so that the policies can be applied correctly.
+ 		podRecommendation = new(vpa_types.RecommendedPodResources)
+ 	}
++	containerRecommendations, err := c.selectRecommendationsForScope(vpa, pod, podRecommendation)
++	if err != nil {
++		return nil, nil, err
++	}
+ 	updatedRecommendations := []vpa_types.RecommendedContainerResources{}
+ 	containerToAnnotationsMap := ContainerToAnnotationsMap{}
+-	limitAdjustedRecommendation, err := c.capProportionallyToPodLimitRange(podRecommendation.ContainerRecommendations, pod)
++	limitAdjustedRecommendation, err := c.capProportionallyToPodLimitRange(containerRecommendations, pod)
+ 	if err != nil {
+ 		return nil, nil, err
+ 	}
+@@ -110,6 +155,100 @@ func (c *cappingRecommendationProcessor) Apply(
+ 	return &vpa_types.RecommendedPodResources{ContainerRecommendations: updatedRecommendations}, containerToAnnotationsMap, nil
+ }
+ 
++func (c *cappingRecommendationProcessor) selectRecommendationsForScope(
++	vpa *vpa_types.VerticalPodAutoscaler,
++	pod *corev1.Pod,
++	podRecommendation *vpa_types.RecommendedPodResources,
++) ([]vpa_types.RecommendedContainerResources, error) {
++	if vpa.Spec.TargetRef == nil || !scopeutil.IsScopedDaemonSet(vpa.Spec.TargetRef.Kind, string(vpa.Spec.Scope)) {
++		return podRecommendation.ContainerRecommendations, nil
++	}
++
++	scopeValue, err := c.resolvePodScopeValue(pod, string(vpa.Spec.Scope))
++	if err != nil {
++		return nil, err
++	}
++
++	groupLookup := c.getGroupRecommendationLookup(vpa)
++	if group, found := groupLookup[scopeValue]; found {
++		selected := make([]vpa_types.RecommendedContainerResources, 0, len(group))
++		for _, recommendation := range group {
++			selected = append(selected, recommendation)
++		}
++		return selected, nil
++	}
++
++	return []vpa_types.RecommendedContainerResources{}, nil
++}
++
++func (c *cappingRecommendationProcessor) getGroupRecommendationLookup(vpa *vpa_types.VerticalPodAutoscaler) map[string]map[string]vpa_types.RecommendedContainerResources {
++	cacheKey := vpa.Namespace + "/" + vpa.Name + "/" + vpa.ResourceVersion + "/" + string(vpa.Spec.Scope)
++
++	c.groupLookupMu.RLock()
++	if c.groupLookupKey == cacheKey {
++		lookup := c.groupLookup
++		c.groupLookupMu.RUnlock()
++		return lookup
++	}
++	c.groupLookupMu.RUnlock()
++
++	lookup := buildGroupRecommendationLookup(vpa.Status.Groups)
++	c.groupLookupMu.Lock()
++	c.groupLookupKey = cacheKey
++	c.groupLookup = lookup
++	c.groupLookupMu.Unlock()
++	return lookup
++}
++
++func buildGroupRecommendationLookup(groups []vpa_types.RecommendedPodResourcesGroup) map[string]map[string]vpa_types.RecommendedContainerResources {
++	lookup := make(map[string]map[string]vpa_types.RecommendedContainerResources, len(groups))
++	for _, group := range groups {
++		byContainer := make(map[string]vpa_types.RecommendedContainerResources, len(group.ContainerRecommendations))
++		for _, recommendation := range group.ContainerRecommendations {
++			byContainer[recommendation.ContainerName] = recommendation
++		}
++		if len(byContainer) > 0 {
++			lookup[group.ScopeValue] = byContainer
++		}
++	}
++	return lookup
++}
++
++func (c *cappingRecommendationProcessor) resolvePodScopeValue(pod *corev1.Pod, scopeKey string) (string, error) {
++	nodeName := getPodNode(pod)
++	if nodeName == "" {
++		return "", nil
++	}
++	if scopeKey == string(vpa_types.ScopeNode) {
++		return nodeName, nil
++	}
++
++	cacheKey := nodeName + "\n" + scopeKey
++	c.scopeCacheMu.RLock()
++	cached, found := c.scopeCache[cacheKey]
++	c.scopeCacheMu.RUnlock()
++	if found && time.Since(cached.cachedTime) <= c.scopeCacheTTL {
++		return cached.value, nil
++	}
++
++	if c.nodeGetter == nil {
++		return scopeutil.AbsentLabelValue, nil
++	}
++	node, err := c.nodeGetter.Get(context.Background(), nodeName, metav1.GetOptions{})
++	if err != nil {
++		return "", fmt.Errorf("failed to resolve node label %q for node %q: %w", scopeKey, nodeName, err)
++	}
++	scopeValue := scopeutil.AbsentLabelValue
++	if labelValue, found := node.Labels[scopeKey]; found {
++		scopeValue = labelValue
++	}
++
++	c.scopeCacheMu.Lock()
++	c.scopeCache[cacheKey] = cachedScopeValue{value: scopeValue, cachedTime: time.Now()}
++	c.scopeCacheMu.Unlock()
++	return scopeValue, nil
++}
++
+ // getCappedRecommendationForContainer returns a recommendation for the given container, adjusted to obey policy and limits.
+ func getCappedRecommendationForContainer(
+ 	pod *corev1.Pod,
+@@ -316,6 +455,30 @@ func getContainer(containerName string, pod *corev1.Pod) *corev1.Container {
+ 	return nil
+ }
+ 
++func getPodNode(pod *corev1.Pod) string {
++	if pod.Spec.NodeName != "" {
++		return pod.Spec.NodeName
++	}
++	if pod.Spec.Affinity == nil || pod.Spec.Affinity.NodeAffinity == nil {
++		return ""
++	}
++	required := pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
++	if required == nil {
++		return ""
++	}
++	for _, term := range required.NodeSelectorTerms {
++		for _, field := range term.MatchFields {
++			if field.Key != "metadata.name" {
++				continue
++			}
++			if field.Operator == corev1.NodeSelectorOpIn && len(field.Values) == 1 {
++				return field.Values[0]
++			}
++		}
++	}
++	return ""
++}
++
+ // applyContainerLimitRange updates recommendation if recommended resources are outside of limits defined in VPA resources policy
+ func applyContainerLimitRange(recommendation corev1.ResourceList,
+ 	containerRequests corev1.ResourceList, containerLimits corev1.ResourceList,
+diff --git a/vertical-pod-autoscaler/pkg/utils/vpa/capping_test.go b/vertical-pod-autoscaler/pkg/utils/vpa/capping_test.go
+index 549e62fe9..5572246a4 100644
+--- a/vertical-pod-autoscaler/pkg/utils/vpa/capping_test.go
++++ b/vertical-pod-autoscaler/pkg/utils/vpa/capping_test.go
+@@ -17,13 +17,17 @@ limitations under the License.
+ package api
+ 
+ import (
++	"context"
+ 	"testing"
+ 
+ 	"github.com/stretchr/testify/assert"
++	autoscalingv1 "k8s.io/api/autoscaling/v1"
+ 	corev1 "k8s.io/api/core/v1"
+ 	"k8s.io/apimachinery/pkg/api/resource"
++	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+ 
+ 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
++	scopeutil "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/scope"
+ 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/test"
+ )
+ 
+@@ -1784,3 +1788,198 @@ func TestCapPodMemoryWithUnderByteSplit(t *testing.T) {
+ 		})
+ 	}
+ }
++
++type fakeNodeGetter struct {
++	nodes map[string]*corev1.Node
++}
++
++func (f *fakeNodeGetter) Get(_ context.Context, name string, _ metav1.GetOptions) (*corev1.Node, error) {
++	if node, found := f.nodes[name]; found {
++		return node, nil
++	}
++	return nil, assert.AnError
++}
++
++func TestApplyScopedRecommendationForDaemonSetByNodeLabelRequiresGroups(t *testing.T) {
++	const containerName = "agent"
++	const scopeKey = "node.kubernetes.io/instance-type"
++	pod := test.Pod().
++		WithName("agent-pod").
++		AddContainer(test.Container().WithName(containerName).Get()).
++		Get()
++	pod.Spec.NodeName = "node-a"
++
++	vpa := test.VerticalPodAutoscaler().
++		WithContainer(containerName).
++		WithTargetRef(&autoscalingv1.CrossVersionObjectReference{
++			Kind:       "DaemonSet",
++			Name:       "agent-ds",
++			APIVersion: "apps/v1",
++		}).
++		Get()
++	vpa.Spec.Scope = vpa_types.VerticalPodAutoscalerScopeType(scopeKey)
++	vpa.Status.Recommendation = &vpa_types.RecommendedPodResources{
++		ContainerRecommendations: []vpa_types.RecommendedContainerResources{
++			{
++				ContainerName: containerName,
++				Target: corev1.ResourceList{
++					corev1.ResourceMemory: resource.MustParse("1Gi"),
++				},
++			},
++		},
++	}
++
++	processor := NewCappingRecommendationProcessorWithNodeGetter(
++		&fakeLimitRangeCalculator{},
++		&fakeNodeGetter{
++			nodes: map[string]*corev1.Node{
++				"node-a": {
++					ObjectMeta: metav1.ObjectMeta{
++						Name: "node-a",
++						Labels: map[string]string{
++							scopeKey: "c3.large",
++						},
++					},
++				},
++			},
++		},
++	)
++
++	res, _, err := processor.Apply(vpa, pod)
++	assert.NoError(t, err)
++	assert.Empty(t, res.ContainerRecommendations)
++}
++
++func TestApplyScopedRecommendationFromCompactGroups(t *testing.T) {
++	const containerName = "agent"
++	const scopeKey = "node.deckhouse.io/group"
++	pod := test.Pod().
++		WithName("agent-pod").
++		AddContainer(test.Container().WithName(containerName).Get()).
++		Get()
++	pod.Spec.NodeName = "node-a"
++
++	vpa := test.VerticalPodAutoscaler().
++		WithContainer(containerName).
++		WithTargetRef(&autoscalingv1.CrossVersionObjectReference{
++			Kind:       "DaemonSet",
++			Name:       "agent-ds",
++			APIVersion: "apps/v1",
++		}).
++		Get()
++	vpa.Spec.Scope = vpa_types.VerticalPodAutoscalerScopeType(scopeKey)
++	vpa.Status.Recommendation = &vpa_types.RecommendedPodResources{
++		ContainerRecommendations: []vpa_types.RecommendedContainerResources{
++			{
++				ContainerName: containerName,
++				Target: corev1.ResourceList{
++					corev1.ResourceMemory: resource.MustParse("1Gi"),
++				},
++			},
++		},
++	}
++	vpa.Status.Groups = []vpa_types.RecommendedPodResourcesGroup{
++		{
++			ScopeValue: scopeutil.AbsentLabelValue,
++			ContainerRecommendations: []vpa_types.RecommendedContainerResources{
++				{
++					ContainerName: containerName,
++					Target: corev1.ResourceList{
++						corev1.ResourceMemory: resource.MustParse("32Mi"),
++					},
++				},
++			},
++		},
++		{
++			ScopeValue: "",
++			ContainerRecommendations: []vpa_types.RecommendedContainerResources{
++				{
++					ContainerName: containerName,
++					Target: corev1.ResourceList{
++						corev1.ResourceMemory: resource.MustParse("50Mi"),
++					},
++				},
++			},
++		},
++		{
++			ScopeValue: "master",
++			ContainerRecommendations: []vpa_types.RecommendedContainerResources{
++				{
++					ContainerName: containerName,
++					Target: corev1.ResourceList{
++						corev1.ResourceMemory: resource.MustParse("50Mi"),
++					},
++				},
++			},
++		},
++		{
++			ScopeValue: "worker",
++			ContainerRecommendations: []vpa_types.RecommendedContainerResources{
++				{
++					ContainerName: containerName,
++					Target: corev1.ResourceList{
++						corev1.ResourceMemory: resource.MustParse("500Mi"),
++					},
++				},
++			},
++		},
++	}
++
++	processor := NewCappingRecommendationProcessorWithNodeGetter(
++		&fakeLimitRangeCalculator{},
++		&fakeNodeGetter{
++			nodes: map[string]*corev1.Node{
++				"node-a": {
++					ObjectMeta: metav1.ObjectMeta{
++						Name: "node-a",
++						Labels: map[string]string{
++							scopeKey: "worker",
++						},
++					},
++				},
++			},
++		},
++	)
++	res, _, err := processor.Apply(vpa, pod)
++	assert.NoError(t, err)
++	if assert.Len(t, res.ContainerRecommendations, 1) {
++		assert.Equal(t, resource.MustParse("500Mi"), res.ContainerRecommendations[0].Target[corev1.ResourceMemory])
++	}
++
++	podEmpty := pod.DeepCopy()
++	podEmpty.Spec.NodeName = "node-empty"
++	podAbsent := pod.DeepCopy()
++	podAbsent.Spec.NodeName = "node-absent"
++
++	processor = NewCappingRecommendationProcessorWithNodeGetter(
++		&fakeLimitRangeCalculator{},
++		&fakeNodeGetter{
++			nodes: map[string]*corev1.Node{
++				"node-empty": {
++					ObjectMeta: metav1.ObjectMeta{
++						Name:   "node-empty",
++						Labels: map[string]string{scopeKey: ""},
++					},
++				},
++				"node-absent": {
++					ObjectMeta: metav1.ObjectMeta{
++						Name:   "node-absent",
++						Labels: map[string]string{"kubernetes.io/hostname": "node-absent"},
++					},
++				},
++			},
++		},
++	)
++
++	resEmpty, _, err := processor.Apply(vpa, podEmpty)
++	assert.NoError(t, err)
++	if assert.Len(t, resEmpty.ContainerRecommendations, 1) {
++		assert.Equal(t, resource.MustParse("50Mi"), resEmpty.ContainerRecommendations[0].Target[corev1.ResourceMemory])
++	}
++
++	resAbsent, _, err := processor.Apply(vpa, podAbsent)
++	assert.NoError(t, err)
++	if assert.Len(t, resAbsent.ContainerRecommendations, 1) {
++		assert.Equal(t, resource.MustParse("32Mi"), resAbsent.ContainerRecommendations[0].Target[corev1.ResourceMemory])
++	}
++}

--- a/modules/302-vertical-pod-autoscaler/images/vertical-pod-autoscaler/werf.inc.yaml
+++ b/modules/302-vertical-pod-autoscaler/images/vertical-pod-autoscaler/werf.inc.yaml
@@ -21,7 +21,7 @@ shell:
     - rm -rf /src/autoscaler /src/vertical-pod-autoscaler/e2e/ /patches /src/autoscaler/.git/
 ---
 image: {{ .ModuleName }}/{{ $.ImageName }}-artifact
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 final: false
 import:
   - image: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact
@@ -35,7 +35,7 @@ secrets:
   value: {{ .GOPROXY }}
 shell:
   install:
-    - export GO_VERSION=${GOLANG_VERSION} CGO_ENABLED=0 GOOS=linux GOARCH=amd64
+    - export CGO_ENABLED=0 GOOS=linux GOARCH=amd64
     - cd /src/vertical-pod-autoscaler/
     - GOPROXY=$(cat /run/secrets/GOPROXY) go mod vendor
 

--- a/modules/302-vertical-pod-autoscaler/oss.yaml
+++ b/modules/302-vertical-pod-autoscaler/oss.yaml
@@ -4,4 +4,4 @@
   logo: /images/logos/kubernetes.svg
   license: Apache License 2.0
   id: autoscaler
-  version: 1.6.0
+  version: 1.7.0


### PR DESCRIPTION
## Description
Upgrades Vertical Pod Autoscaler from v1.6.0 to v1.7.0.

The Deckhouse patch implementing scoped recommendations for DaemonSets has been adapted to the updated upstream APIs and code structure. The build image has also been changed from builder/golang-alpine to builder/golang.

VPA components will restart during the update.

## Why do we need it, and what problem does it solve?
This update brings upstream VPA improvements and security fixes while preserving Deckhouse-specific scoped recommendations for DaemonSets.

The patch and build configuration required updating to remain compatible with VPA v1.7.0.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: vertical-pod-autoscaler
type: feature
summary: Upgrade Vertical Pod Autoscaler to v1.7.0.
impact: Vertical Pod Autoscaler components will be restarted.
impact_level: high
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
