### PR TITLE
[deckhouse] fix: preserve crd vendor extensions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	github.com/deckhouse/deckhouse/pkg/metrics-storage v0.3.0
 	github.com/deckhouse/deckhouse/pkg/registry v0.0.0-20260525111533-9e5ba68242f7
 	github.com/deckhouse/lib-dhctl v0.21.0
-	github.com/deckhouse/module-sdk v0.12.1-0.20260716150856-69f81b203c3c
+	github.com/deckhouse/module-sdk v0.12.1-0.20260720012432-54a05551f06a
 	github.com/ettle/strcase v0.2.0
 	github.com/evanphx/json-patch v5.9.11+incompatible
 	github.com/fsnotify/fsnotify v1.9.0

--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	github.com/deckhouse/deckhouse/pkg/metrics-storage v0.3.0
 	github.com/deckhouse/deckhouse/pkg/registry v0.0.0-20260525111533-9e5ba68242f7
 	github.com/deckhouse/lib-dhctl v0.21.0
-	github.com/deckhouse/module-sdk v0.12.0
+	github.com/deckhouse/module-sdk v0.12.1-0.20260716150856-69f81b203c3c
 	github.com/ettle/strcase v0.2.0
 	github.com/evanphx/json-patch v5.9.11+incompatible
 	github.com/fsnotify/fsnotify v1.9.0

--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	github.com/deckhouse/deckhouse/pkg/metrics-storage v0.3.0
 	github.com/deckhouse/deckhouse/pkg/registry v0.0.0-20260525111533-9e5ba68242f7
 	github.com/deckhouse/lib-dhctl v0.21.0
-	github.com/deckhouse/module-sdk v0.12.1-0.20260720012432-54a05551f06a
+	github.com/deckhouse/module-sdk v0.12.1
 	github.com/ettle/strcase v0.2.0
 	github.com/evanphx/json-patch v5.9.11+incompatible
 	github.com/fsnotify/fsnotify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -165,8 +165,8 @@ github.com/deckhouse/lib-dhctl v0.21.0 h1:6pO9qOj3mdQpX+zD07ZRlorKCtjvn5VEyigmT4
 github.com/deckhouse/lib-dhctl v0.21.0/go.mod h1:hICPf+k3u8V73ndNRNVWUdye/mzo6adLZkXM6vfcmVc=
 github.com/deckhouse/lib-gossh v0.3.0 h1:FUAlF8+fLnBCII9hXSNx+arZ4PH3H/6fzp5LBlnmlps=
 github.com/deckhouse/lib-gossh v0.3.0/go.mod h1:6bT8jf2fkBPEhYBU35+vMBr5YscliTiS+Vr8v06C+70=
-github.com/deckhouse/module-sdk v0.12.1-0.20260716150856-69f81b203c3c h1:MjE6pzklp7tDx8UkCO0zuaW7ouwnLDqxeJaFZ7K2WfQ=
-github.com/deckhouse/module-sdk v0.12.1-0.20260716150856-69f81b203c3c/go.mod h1:v3pnOUIY8hCv7qQ5YaffiAYKj5oH8WBonG614KvRPXw=
+github.com/deckhouse/module-sdk v0.12.1-0.20260720012432-54a05551f06a h1:NuIaIsKzkq3bS+k2+tE6HW6UEweFhqISFYa6EDaZ/wA=
+github.com/deckhouse/module-sdk v0.12.1-0.20260720012432-54a05551f06a/go.mod h1:v3pnOUIY8hCv7qQ5YaffiAYKj5oH8WBonG614KvRPXw=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/disintegration/imaging v1.6.2 h1:w1LecBlG2Lnp8B3jk5zSuNqd7b4DXhcjwek1ei82L+c=

--- a/go.sum
+++ b/go.sum
@@ -167,6 +167,8 @@ github.com/deckhouse/lib-gossh v0.3.0 h1:FUAlF8+fLnBCII9hXSNx+arZ4PH3H/6fzp5LBln
 github.com/deckhouse/lib-gossh v0.3.0/go.mod h1:6bT8jf2fkBPEhYBU35+vMBr5YscliTiS+Vr8v06C+70=
 github.com/deckhouse/module-sdk v0.12.1-0.20260720012432-54a05551f06a h1:NuIaIsKzkq3bS+k2+tE6HW6UEweFhqISFYa6EDaZ/wA=
 github.com/deckhouse/module-sdk v0.12.1-0.20260720012432-54a05551f06a/go.mod h1:v3pnOUIY8hCv7qQ5YaffiAYKj5oH8WBonG614KvRPXw=
+github.com/deckhouse/module-sdk v0.12.1 h1:kcfvgIKwXUtcDXdK5e7D69lvdyaHctp8ectYKi+BYKw=
+github.com/deckhouse/module-sdk v0.12.1/go.mod h1:v3pnOUIY8hCv7qQ5YaffiAYKj5oH8WBonG614KvRPXw=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/disintegration/imaging v1.6.2 h1:w1LecBlG2Lnp8B3jk5zSuNqd7b4DXhcjwek1ei82L+c=

--- a/go.sum
+++ b/go.sum
@@ -165,8 +165,8 @@ github.com/deckhouse/lib-dhctl v0.21.0 h1:6pO9qOj3mdQpX+zD07ZRlorKCtjvn5VEyigmT4
 github.com/deckhouse/lib-dhctl v0.21.0/go.mod h1:hICPf+k3u8V73ndNRNVWUdye/mzo6adLZkXM6vfcmVc=
 github.com/deckhouse/lib-gossh v0.3.0 h1:FUAlF8+fLnBCII9hXSNx+arZ4PH3H/6fzp5LBlnmlps=
 github.com/deckhouse/lib-gossh v0.3.0/go.mod h1:6bT8jf2fkBPEhYBU35+vMBr5YscliTiS+Vr8v06C+70=
-github.com/deckhouse/module-sdk v0.12.0 h1:kQe0RmhHz3+A2VoxG56/8Dd4WeVSbwc38Ocg3Can16g=
-github.com/deckhouse/module-sdk v0.12.0/go.mod h1:v3pnOUIY8hCv7qQ5YaffiAYKj5oH8WBonG614KvRPXw=
+github.com/deckhouse/module-sdk v0.12.1-0.20260716150856-69f81b203c3c h1:MjE6pzklp7tDx8UkCO0zuaW7ouwnLDqxeJaFZ7K2WfQ=
+github.com/deckhouse/module-sdk v0.12.1-0.20260716150856-69f81b203c3c/go.mod h1:v3pnOUIY8hCv7qQ5YaffiAYKj5oH8WBonG614KvRPXw=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/disintegration/imaging v1.6.2 h1:w1LecBlG2Lnp8B3jk5zSuNqd7b4DXhcjwek1ei82L+c=

--- a/modules/000-common/hooks/ensure_crds_test.go
+++ b/modules/000-common/hooks/ensure_crds_test.go
@@ -38,6 +38,7 @@ spec:
     kind: TestCrd
     plural: testcrds
     singular: testcrd
+  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1alpha1
@@ -50,20 +51,16 @@ spec:
               a:
                 description: a
                 type: string
+                x-description: a
               b:
                 type: string
+                x-doc-default: b
             type: object
         required:
         - spec
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null
 `
 		existInClusterCRD = `
 apiVersion: apiextensions.k8s.io/v1
@@ -136,6 +133,7 @@ spec:
     kind: TestCrd
     plural: testcrds
     singular: testcrd
+  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1alpha1
@@ -148,20 +146,16 @@ spec:
               a:
                 description: a
                 type: string
+                x-description: a
               b:
                 type: string
+                x-doc-default: b
             type: object
         required:
         - spec
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null
 `
 	)
 

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/deckhouse/deckhouse/pkg/log v0.2.1 // indirect
 	github.com/deckhouse/deckhouse/pkg/metrics-storage v0.3.0 // indirect
 	github.com/deckhouse/lib-dhctl v0.21.0 // indirect
-	github.com/deckhouse/module-sdk v0.12.1-0.20260716150856-69f81b203c3c // indirect
+	github.com/deckhouse/module-sdk v0.12.1-0.20260720012432-54a05551f06a // indirect
 	github.com/denis-tingajkin/go-header v0.4.2 // indirect
 	github.com/docker/cli v29.4.0+incompatible // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/deckhouse/deckhouse/pkg/log v0.2.1 // indirect
 	github.com/deckhouse/deckhouse/pkg/metrics-storage v0.3.0 // indirect
 	github.com/deckhouse/lib-dhctl v0.21.0 // indirect
-	github.com/deckhouse/module-sdk v0.12.0 // indirect
+	github.com/deckhouse/module-sdk v0.12.1-0.20260716150856-69f81b203c3c // indirect
 	github.com/denis-tingajkin/go-header v0.4.2 // indirect
 	github.com/docker/cli v29.4.0+incompatible // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/deckhouse/deckhouse/pkg/log v0.2.1 // indirect
 	github.com/deckhouse/deckhouse/pkg/metrics-storage v0.3.0 // indirect
 	github.com/deckhouse/lib-dhctl v0.21.0 // indirect
-	github.com/deckhouse/module-sdk v0.12.1-0.20260720012432-54a05551f06a // indirect
+	github.com/deckhouse/module-sdk v0.12.1 // indirect
 	github.com/denis-tingajkin/go-header v0.4.2 // indirect
 	github.com/docker/cli v29.4.0+incompatible // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -195,8 +195,8 @@ github.com/deckhouse/deckhouse/pkg/metrics-storage v0.3.0 h1:xZvbKuexrSQGEw6CB4n
 github.com/deckhouse/deckhouse/pkg/metrics-storage v0.3.0/go.mod h1:Rz++SzCLkFW03WGgftnn91TimGU2shiKb5S/YuxcBuE=
 github.com/deckhouse/lib-dhctl v0.21.0 h1:6pO9qOj3mdQpX+zD07ZRlorKCtjvn5VEyigmT4k5SBw=
 github.com/deckhouse/lib-dhctl v0.21.0/go.mod h1:hICPf+k3u8V73ndNRNVWUdye/mzo6adLZkXM6vfcmVc=
-github.com/deckhouse/module-sdk v0.12.0 h1:kQe0RmhHz3+A2VoxG56/8Dd4WeVSbwc38Ocg3Can16g=
-github.com/deckhouse/module-sdk v0.12.0/go.mod h1:v3pnOUIY8hCv7qQ5YaffiAYKj5oH8WBonG614KvRPXw=
+github.com/deckhouse/module-sdk v0.12.1-0.20260716150856-69f81b203c3c h1:MjE6pzklp7tDx8UkCO0zuaW7ouwnLDqxeJaFZ7K2WfQ=
+github.com/deckhouse/module-sdk v0.12.1-0.20260716150856-69f81b203c3c/go.mod h1:v3pnOUIY8hCv7qQ5YaffiAYKj5oH8WBonG614KvRPXw=
 github.com/denis-tingajkin/go-header v0.4.2 h1:jEeSF4sdv8/3cT/WY8AgDHUoItNSoEZ7qg9dX7pc218=
 github.com/denis-tingajkin/go-header v0.4.2/go.mod h1:eLRHAVXzE5atsKAnNRDB90WHCFFnBUn4RN0nRcs1LJA=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -195,8 +195,8 @@ github.com/deckhouse/deckhouse/pkg/metrics-storage v0.3.0 h1:xZvbKuexrSQGEw6CB4n
 github.com/deckhouse/deckhouse/pkg/metrics-storage v0.3.0/go.mod h1:Rz++SzCLkFW03WGgftnn91TimGU2shiKb5S/YuxcBuE=
 github.com/deckhouse/lib-dhctl v0.21.0 h1:6pO9qOj3mdQpX+zD07ZRlorKCtjvn5VEyigmT4k5SBw=
 github.com/deckhouse/lib-dhctl v0.21.0/go.mod h1:hICPf+k3u8V73ndNRNVWUdye/mzo6adLZkXM6vfcmVc=
-github.com/deckhouse/module-sdk v0.12.1-0.20260720012432-54a05551f06a h1:NuIaIsKzkq3bS+k2+tE6HW6UEweFhqISFYa6EDaZ/wA=
-github.com/deckhouse/module-sdk v0.12.1-0.20260720012432-54a05551f06a/go.mod h1:v3pnOUIY8hCv7qQ5YaffiAYKj5oH8WBonG614KvRPXw=
+github.com/deckhouse/module-sdk v0.12.1 h1:kcfvgIKwXUtcDXdK5e7D69lvdyaHctp8ectYKi+BYKw=
+github.com/deckhouse/module-sdk v0.12.1/go.mod h1:v3pnOUIY8hCv7qQ5YaffiAYKj5oH8WBonG614KvRPXw=
 github.com/denis-tingajkin/go-header v0.4.2 h1:jEeSF4sdv8/3cT/WY8AgDHUoItNSoEZ7qg9dX7pc218=
 github.com/denis-tingajkin/go-header v0.4.2/go.mod h1:eLRHAVXzE5atsKAnNRDB90WHCFFnBUn4RN0nRcs1LJA=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -195,8 +195,8 @@ github.com/deckhouse/deckhouse/pkg/metrics-storage v0.3.0 h1:xZvbKuexrSQGEw6CB4n
 github.com/deckhouse/deckhouse/pkg/metrics-storage v0.3.0/go.mod h1:Rz++SzCLkFW03WGgftnn91TimGU2shiKb5S/YuxcBuE=
 github.com/deckhouse/lib-dhctl v0.21.0 h1:6pO9qOj3mdQpX+zD07ZRlorKCtjvn5VEyigmT4k5SBw=
 github.com/deckhouse/lib-dhctl v0.21.0/go.mod h1:hICPf+k3u8V73ndNRNVWUdye/mzo6adLZkXM6vfcmVc=
-github.com/deckhouse/module-sdk v0.12.1-0.20260716150856-69f81b203c3c h1:MjE6pzklp7tDx8UkCO0zuaW7ouwnLDqxeJaFZ7K2WfQ=
-github.com/deckhouse/module-sdk v0.12.1-0.20260716150856-69f81b203c3c/go.mod h1:v3pnOUIY8hCv7qQ5YaffiAYKj5oH8WBonG614KvRPXw=
+github.com/deckhouse/module-sdk v0.12.1-0.20260720012432-54a05551f06a h1:NuIaIsKzkq3bS+k2+tE6HW6UEweFhqISFYa6EDaZ/wA=
+github.com/deckhouse/module-sdk v0.12.1-0.20260720012432-54a05551f06a/go.mod h1:v3pnOUIY8hCv7qQ5YaffiAYKj5oH8WBonG614KvRPXw=
 github.com/denis-tingajkin/go-header v0.4.2 h1:jEeSF4sdv8/3cT/WY8AgDHUoItNSoEZ7qg9dX7pc218=
 github.com/denis-tingajkin/go-header v0.4.2/go.mod h1:eLRHAVXzE5atsKAnNRDB90WHCFFnBUn4RN0nRcs1LJA=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=


### PR DESCRIPTION
## Description

Bump `github.com/deckhouse/module-sdk` to the version that applies CRDs to the
cluster verbatim, preserving custom vendor extensions in the OpenAPI schema
(`x-*`). See deckhouse/module-sdk#122.

The only deckhouse-side change is updating the `000-common` `ensure_crds` golden
test to match the corrected installer output:

- `x-*` vendor extensions (`x-description`, `x-doc-default`) are now preserved;
- `preserveUnknownFields: false` is kept verbatim;
- the spurious empty `status:` block (an artifact of the previous typed
  round-trip) is no longer emitted.

## Why do we need it, and what problem does it solve?

The CRD installer used to decode CRDs into the typed
`apiextensionsv1.CustomResourceDefinition` before applying them.
`JSONSchemaProps` has typed fields only for the known upstream `x-kubernetes-*`
keys and no catch-all, so any non-standard `x-*` extension was silently dropped:
`x-kubernetes-sensitive-data`, `x-ui-*`, `x-kubernetes-patch-strategy`,
`x-kubernetes-patch-merge-key`, etc.

The loss was silent and sticky: the trimmed CRD stayed valid, so `apply`
succeeded without error, and because the read-back path was also typed, the diff
compared two equally-trimmed specs and never triggered an update — so a re-run
didn't self-heal. In particular `x-kubernetes-sensitive-data: true` never reached
the cluster CRD, so consumers reading the CRD from the API server couldn't tell
which fields must be redacted.

The fix itself lives in module-sdk (deckhouse/module-sdk#122); the installer now
acts as a transport and lets the API server own schema validation. The
`ensure_crds` golden test previously encoded the old lossy output, so it is
updated here to reflect the correct behavior — the test is catching up to the
fix, not the code breaking the test.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: Apply CRDs as unstructured so custom OpenAPI vendor extensions (`x-*`) are no longer silently dropped on install.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
