### PR TITLE
[cloud-provider-aws] enable PPS and add SPE

### DIFF
--- a/ee/modules/030-cloud-provider-dynamix/templates/namespace.yaml
+++ b/ee/modules/030-cloud-provider-dynamix/templates/namespace.yaml
@@ -10,7 +10,7 @@ security.deckhouse.io/enable-security-policy-check: "true"
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: d8-cloud-provider-dynamix
+  name: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (fromYaml (include "labels" .))) | nindent 2 }}
 ---
-{{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . "d8-cloud-provider-dynamix") }}
+{{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s" .Chart.Name)) }}

--- a/ee/modules/030-cloud-provider-huaweicloud/templates/namespace.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/templates/namespace.yaml
@@ -9,7 +9,7 @@ security.deckhouse.io/enable-security-policy-check: "true"
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: d8-cloud-provider-huaweicloud
+  name: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (fromYaml (include "labels" .))) | nindent 2 }}
 ---
-{{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . "d8-cloud-provider-huaweicloud") }}
+{{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s" .Chart.Name)) }}

--- a/ee/modules/030-cloud-provider-openstack/templates/namespace.yaml
+++ b/ee/modules/030-cloud-provider-openstack/templates/namespace.yaml
@@ -10,7 +10,7 @@ security.deckhouse.io/enable-security-policy-check: "true"
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: d8-cloud-provider-openstack
+  name: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (fromYaml (include "labels" .))) | nindent 2 }}
 ---
-{{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . "d8-cloud-provider-openstack") }}
+{{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s" .Chart.Name)) }}

--- a/ee/modules/030-cloud-provider-vcd/templates/namespace.yaml
+++ b/ee/modules/030-cloud-provider-vcd/templates/namespace.yaml
@@ -10,7 +10,7 @@ security.deckhouse.io/enable-security-policy-check: "true"
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: d8-cloud-provider-vcd
+  name: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (fromYaml (include "labels" .))) | nindent 2 }}
 ---
-{{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . "d8-cloud-provider-vcd") }}
+{{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s" .Chart.Name)) }}

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/templates/namespace.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/templates/namespace.yaml
@@ -2,13 +2,15 @@
 prometheus.deckhouse.io/rules-watcher-enabled: "true"
 extended-monitoring.deckhouse.io/enabled: ""
 security.deckhouse.io/pod-policy: "restricted"
+{{- if .Values.global.enabledModules | has "admission-policy-engine-crd" }}
 security.deckhouse.io/enable-security-policy-check: "true"
+{{- end }}
 {{- end }}
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: d8-cloud-provider-vsphere
+  name: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (fromYaml (include "labels" .))) | nindent 2 }}
 ---
-{{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . "d8-cloud-provider-vsphere") }}
+{{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s" .Chart.Name)) }}

--- a/ee/se-plus/modules/030-cloud-provider-zvirt/templates/namespace.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-zvirt/templates/namespace.yaml
@@ -2,14 +2,15 @@
 prometheus.deckhouse.io/rules-watcher-enabled: "true"
 extended-monitoring.deckhouse.io/enabled: ""
 security.deckhouse.io/pod-policy: "restricted"
+{{- if .Values.global.enabledModules | has "admission-policy-engine-crd" }}
 security.deckhouse.io/enable-security-policy-check: "true"
+{{- end }}
 {{- end }}
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: d8-cloud-provider-zvirt
+  name: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (fromYaml (include "labels" .))) | nindent 2 }}
 ---
-{{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . "d8-cloud-provider-zvirt") }}
-
+{{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s" .Chart.Name)) }}

--- a/modules/030-cloud-provider-aws/template_tests/module_test.go
+++ b/modules/030-cloud-provider-aws/template_tests/module_test.go
@@ -515,7 +515,7 @@ storageclass.kubernetes.io/is-default-class: "true"
 			BeforeEach(func() {
 				f.ValuesSetFromYaml("global", globalValues)
 				f.ValuesSet("global.modulesImages", GetModulesImages())
-				f.ValuesSetFromYaml("global.enabledModules", `["vertical-pod-autoscaler"]`)
+				f.ValuesSetFromYaml("global.enabledModules", `["vertical-pod-autoscaler-crd"]`)
 				f.ValuesSetFromYaml("cloudProviderAws", moduleValues)
 				f.HelmRender()
 			})

--- a/modules/030-cloud-provider-aws/template_tests/module_test.go
+++ b/modules/030-cloud-provider-aws/template_tests/module_test.go
@@ -49,7 +49,7 @@ const bashibleLabelKey = "cloud-provider\\.deckhouse\\.io/bashible"
 
 const globalValues = `
   clusterIsBootstrapped: true
-  enabledModules: ["vertical-pod-autoscaler"]
+  enabledModules: ["vertical-pod-autoscaler", "vertical-pod-autoscaler-crd"]
   clusterConfiguration:
     apiVersion: deckhouse.io/v1
     cloud:
@@ -163,6 +163,7 @@ var _ = Describe("Module :: cloud-provider-aws :: helm template ::", func() {
 			ccmClusterRole := f.KubernetesGlobalResource("ClusterRole", "d8:cloud-provider-aws:cloud-controller-manager")
 			ccmClusterRoleBinding := f.KubernetesGlobalResource("ClusterRoleBinding", "d8:cloud-provider-aws:cloud-controller-manager")
 			ccmSecret := f.KubernetesResource("Secret", moduleNamespace, "cloud-controller-manager")
+			ccmVPA := f.KubernetesResource("VerticalPodAutoscaler", moduleNamespace, "cloud-controller-manager")
 
 			ebsControllerPluginDeployment := f.KubernetesResource("Deployment", moduleNamespace, "csi-controller")
 			ebsCSIDriver := f.KubernetesGlobalResource("CSIDriver", "ebs.csi.aws.com")
@@ -281,6 +282,7 @@ var _ = Describe("Module :: cloud-provider-aws :: helm template ::", func() {
 
 			// user story #2
 			Expect(ccmDeployment.Exists()).To(BeTrue())
+			Expect(ccmVPA.Exists()).To(BeTrue())
 			Expect(ccmServiceAccount.Exists()).To(BeTrue())
 			Expect(ccmClusterRole.Exists()).To(BeTrue())
 			Expect(ccmClusterRoleBinding.Exists()).To(BeTrue())
@@ -404,7 +406,7 @@ storageclass.kubernetes.io/is-default-class: "true"
 			BeforeEach(func() {
 				f.ValuesSetFromYaml("global", globalValues)
 				f.ValuesSet("global.modulesImages", GetModulesImages())
-				f.ValuesSetFromYaml("global.enabledModules", `["vertical-pod-autoscaler"]`)
+				f.ValuesSetFromYaml("global.enabledModules", `["vertical-pod-autoscaler", "vertical-pod-autoscaler-crd"]`)
 				f.ValuesSetFromYaml("cloudProviderAws", moduleValues)
 				f.HelmRender()
 			})
@@ -435,17 +437,126 @@ storageclass.kubernetes.io/is-default-class: "true"
 		})
 	})
 
+	Context("SecurityPolicyException resources", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", globalValues)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYaml("global.enabledModules", `["vertical-pod-autoscaler", "vertical-pod-autoscaler-crd", "admission-policy-engine-crd"]`)
+			f.ValuesSetFromYaml("cloudProviderAws", moduleValues)
+			f.HelmRender()
+		})
+
+		It("Should render SecurityPolicyException for CCM", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			spe := f.KubernetesResource("SecurityPolicyException", moduleNamespace, "cloud-controller-manager")
+			Expect(spe.Exists()).To(BeTrue())
+		})
+
+		It("Should render SecurityPolicyException for CSI controller", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			spe := f.KubernetesResource("SecurityPolicyException", moduleNamespace, "csi-controller")
+			Expect(spe.Exists()).To(BeTrue())
+		})
+
+		It("Should render SecurityPolicyException for CSI node", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			spe := f.KubernetesResource("SecurityPolicyException", moduleNamespace, "csi-node")
+			Expect(spe.Exists()).To(BeTrue())
+		})
+
+		It("Should NOT render SecurityPolicyException when admission-policy-engine-crd is absent", func() {
+			f.ValuesSetFromYaml("global.enabledModules", `["vertical-pod-autoscaler", "vertical-pod-autoscaler-crd"]`)
+			f.HelmRender()
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			ccmSpe := f.KubernetesResource("SecurityPolicyException", moduleNamespace, "cloud-controller-manager")
+			Expect(ccmSpe.Exists()).To(BeFalse())
+
+			csiControllerSpe := f.KubernetesResource("SecurityPolicyException", moduleNamespace, "csi-controller")
+			Expect(csiControllerSpe.Exists()).To(BeFalse())
+
+			csiNodeSpe := f.KubernetesResource("SecurityPolicyException", moduleNamespace, "csi-node")
+			Expect(csiNodeSpe.Exists()).To(BeFalse())
+		})
+	})
+
+	Context("Node termination handler", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", globalValues)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYaml("cloudProviderAws", moduleValues)
+			f.HelmRender()
+		})
+
+		It("Should render node-termination-handler DaemonSet", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			ds := f.KubernetesResource("DaemonSet", moduleNamespace, "node-termination-handler")
+			Expect(ds.Exists()).To(BeTrue())
+		})
+
+		It("Should render node-termination-handler RBAC resources", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			sa := f.KubernetesResource("ServiceAccount", moduleNamespace, "node-termination-handler")
+			Expect(sa.Exists()).To(BeTrue())
+
+			cr := f.KubernetesGlobalResource("ClusterRole", "d8:cloud-provider-aws:node-termination-handler")
+			Expect(cr.Exists()).To(BeTrue())
+
+			crb := f.KubernetesGlobalResource("ClusterRoleBinding", "d8:cloud-provider-aws:node-termination-handler")
+			Expect(crb.Exists()).To(BeTrue())
+		})
+
+		Context("VPA enabled", func() {
+			BeforeEach(func() {
+				f.ValuesSetFromYaml("global", globalValues)
+				f.ValuesSet("global.modulesImages", GetModulesImages())
+				f.ValuesSetFromYaml("global.enabledModules", `["vertical-pod-autoscaler"]`)
+				f.ValuesSetFromYaml("cloudProviderAws", moduleValues)
+				f.HelmRender()
+			})
+
+			It("Should render VPA for node-termination-handler", func() {
+				Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+				vpa := f.KubernetesResource("VerticalPodAutoscaler", moduleNamespace, "node-termination-handler")
+				Expect(vpa.Exists()).To(BeTrue())
+			})
+		})
+
+		Context("VPA disabled", func() {
+			BeforeEach(func() {
+				f.ValuesSetFromYaml("global", globalValues)
+				f.ValuesSet("global.modulesImages", GetModulesImages())
+				f.ValuesSetFromYaml("global.enabledModules", `[]`)
+				f.ValuesSetFromYaml("cloudProviderAws", moduleValues)
+				f.HelmRender()
+			})
+
+			It("Should not render VPA for node-termination-handler", func() {
+				Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+				vpa := f.KubernetesResource("VerticalPodAutoscaler", moduleNamespace, "node-termination-handler")
+				Expect(vpa.Exists()).To(BeFalse())
+			})
+		})
+	})
+
 	Context("AWS with existing CNI secret data", func() {
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global", globalValues)
 			f.ValuesSet("global.modulesImages", GetModulesImages())
 			f.ValuesSetFromYaml("cloudProviderAws", moduleValues)
-			f.ValuesSet("cloudProviderAws.internal.cniSecretData", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`cni: %s
+			f.ValuesSet("cloudProviderAws.internal.cniSecretData", base64.StdEncoding.EncodeToString(fmt.Appendf(nil, `cni: %s
 flannel: %s
 `,
 				base64.StdEncoding.EncodeToString([]byte("flannel")),
 				base64.StdEncoding.EncodeToString([]byte(`{"podNetworkMode":"host-gw"}`)),
-			))))
+			)))
 			f.HelmRender()
 		})
 

--- a/modules/030-cloud-provider-aws/templates/cloud-controller-manager/deployment.yaml
+++ b/modules/030-cloud-provider-aws/templates/cloud-controller-manager/deployment.yaml
@@ -1,153 +1,33 @@
-{{- define "aws_cloud_controller_manager_resources" }}
-cpu: 25m
-memory: 50Mi
-{{- end }}
-
 {{- $kubernetesSemVer := semver .Values.global.discovery.kubernetesVersion }}
 {{- $ccmImageName := join "" (list "cloudControllerManager" $kubernetesSemVer.Major $kubernetesSemVer.Minor ) }}
 {{- $ccmImage := include "helm_lib_module_image_no_fail" (list . $ccmImageName) }}
 {{- if $ccmImage }}
-  {{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler") }}
----
-apiVersion: autoscaling.k8s.io/v1
-kind: VerticalPodAutoscaler
-metadata:
-  name: cloud-controller-manager
-  namespace: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "app" "cloud-controller-manager")) | nindent 2 }}
-spec:
-  targetRef:
-    apiVersion: "apps/v1"
-    kind: Deployment
-    name: cloud-controller-manager
-  updatePolicy:
-    updateMode: "InPlaceOrRecreate"
-  resourcePolicy:
-    containerPolicies:
-    - containerName: "aws-cloud-controller-manager"
-      minAllowed:
-        {{- include "aws_cloud_controller_manager_resources" . | nindent 8 }}
-      maxAllowed:
-        cpu: 50m
-        memory: 50Mi
-  {{- end }}
----
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: cloud-controller-manager
-  namespace: d8-cloud-provider-aws
-  {{- include "helm_lib_module_labels" (list . (dict "app" "cloud-controller-manager")) | nindent 2 }}
-spec:
-  maxUnavailable: 1
-  selector:
-    matchLabels:
-      app: cloud-controller-manager
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: cloud-controller-manager
-  namespace: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "app" "cloud-controller-manager")) | nindent 2 }}
-spec:
-  {{- include "helm_lib_deployment_on_master_strategy_and_replicas_for_ha" . | nindent 2 }}
-  revisionHistoryLimit: 2
-  selector:
-    matchLabels:
-      app: cloud-controller-manager
-  template:
-    metadata:
-      labels:
-        app: cloud-controller-manager
-      annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/cloud-controller-manager/secret.yaml") . | sha256sum }}
-    spec:
-      imagePullSecrets:
-      - name: deckhouse-registry
-      {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
-      {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "cloud-controller-manager")) | nindent 6 }}
-      {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
-      {{- include "helm_lib_tolerations" (tuple . "wildcard") | nindent 6 }}
-      {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
-      automountServiceAccountToken: true
-      hostNetwork: true
-      dnsPolicy: Default
-      serviceAccountName: cloud-controller-manager
-      containers:
-        - name: aws-cloud-controller-manager
-          {{- include "helm_lib_module_container_security_context_pss_restricted_flexible" dict | nindent 10 }}
-          image: {{ $ccmImage }}
-          args:
-          - --leader-elect=true
-          - --cluster-cidr={{ .Values.global.discovery.podSubnet }}
-          - --allocate-node-cidrs=true
-          - --configure-cloud-routes=true
-          - --cloud-config=/etc/cloud-contoller-manager-config/cloud-config
-          - --cloud-provider=aws
-          - --bind-address=127.0.0.1
-          - --secure-port=10471
-          - --v=2
-          env:
-      # KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT are needed on the bootstrap phase to make CCM work without kube-proxy
-      {{- if not .Values.global.clusterIsBootstrapped }}
-          - name: KUBERNETES_SERVICE_HOST
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: status.hostIP
-          - name: KUBERNETES_SERVICE_PORT
-            value: "6443"
-      {{- end }}
-          - name: HOST_IP
-            valueFrom:
-              fieldRef:
-                fieldPath: status.hostIP
-          - name: AWS_ACCESS_KEY_ID
-            valueFrom:
-              secretKeyRef:
-                name: cloud-controller-manager
-                key: aws-access-key-id
-          - name: AWS_SECRET_ACCESS_KEY
-            valueFrom:
-              secretKeyRef:
-                name: cloud-controller-manager
-                key: aws-secret-access-key
-          {{- include "helm_lib_envs_for_proxy" . | nindent 10 }}
-          livenessProbe:
-            httpGet:
-              path: /healthz
-              port: 10471
-              host: 127.0.0.1
-              scheme: HTTPS
-          readinessProbe:
-            httpGet:
-              path: /healthz
-              port: 10471
-              host: 127.0.0.1
-              scheme: HTTPS
-          volumeMounts:
-          - mountPath: /etc/kubernetes/pki
-            name: k8s-certs
-            readOnly: true
-          - mountPath: /etc/cloud-contoller-manager-config
-            name: config
-            readOnly: true
-          resources:
-            requests:
-              {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 10 | nindent 14 }}
-  {{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler") }}
-              {{- include "aws_cloud_controller_manager_resources" . | nindent 14 }}
-  {{- end }}
-      volumes:
-      - hostPath:
-          path: /etc/kubernetes/pki
-          type: DirectoryOrCreate
-        name: k8s-certs
-      - name: config
-        secret:
-          secretName: cloud-controller-manager
-          items:
-          - key: cloud-config
-            path: cloud-config
+
+{{- $ccmConfig := dict }}
+{{- $_ := set $ccmConfig "image" $ccmImage }}
+{{- $_ := set $ccmConfig "additionalArgs" (list
+  (printf "--cluster-cidr=%s" .Values.global.discovery.podSubnet)
+  "--allocate-node-cidrs=true"
+  "--configure-cloud-routes=true"
+  "--cloud-config=/etc/cloud-contoller-manager-config/cloud-config"
+  "--cloud-provider=aws"
+  "--v=2"
+) }}
+{{- $_ := set $ccmConfig "additionalEnvs" (list
+  (dict "name" "AWS_ACCESS_KEY_ID" "valueFrom" (dict "secretKeyRef" (dict "name" "cloud-controller-manager" "key" "aws-access-key-id")))
+  (dict "name" "AWS_SECRET_ACCESS_KEY" "valueFrom" (dict "secretKeyRef" (dict "name" "cloud-controller-manager" "key" "aws-secret-access-key")))
+) }}
+{{- $_ := set $ccmConfig "additionalPodAnnotations" (dict "checksum/config" (include (print $.Template.BasePath "/cloud-controller-manager/secret.yaml") . | sha256sum)) }}
+{{- $_ := set $ccmConfig "additionalVolumeMounts" (list
+  (dict "mountPath" "/etc/kubernetes/pki" "name" "k8s-certs" "readOnly" true)
+  (dict "mountPath" "/etc/cloud-contoller-manager-config" "name" "config" "readOnly" true)
+) }}
+{{- $_ := set $ccmConfig "additionalVolumes" (list
+  (dict "hostPath" (dict "path" "/etc/kubernetes/pki" "type" "DirectoryOrCreate") "name" "k8s-certs")
+  (dict "name" "config" "secret" (dict "secretName" "cloud-controller-manager" "items" (list (dict "key" "cloud-config" "path" "cloud-config"))))
+) }}
+{{- $_ := set $ccmConfig "vpaEnabled" true }}
+{{- $_ := set $ccmConfig "securityPolicyExceptionEnabled" true }}
+
+{{- include "helm_lib_cloud_controller_manager_manifests" (list . $ccmConfig) }}
 {{- end }}

--- a/modules/030-cloud-provider-aws/templates/cloud-data-discoverer/deployment.yaml
+++ b/modules/030-cloud-provider-aws/templates/cloud-data-discoverer/deployment.yaml
@@ -1,159 +1,27 @@
-{{- define "aws_cloud_data_discoverer_resources" }}
-cpu: 25m
-memory: 50Mi
-{{- end }}
+{{- define "aws_cdd_envs" -}}
+- name: AWS_ACCESS_KEY_ID
+  valueFrom:
+    secretKeyRef:
+      name: cloud-controller-manager
+      key: aws-access-key-id
+- name: AWS_SECRET_ACCESS_KEY
+  valueFrom:
+    secretKeyRef:
+      name: cloud-controller-manager
+      key: aws-secret-access-key
+- name: AWS_REGION
+  value: {{ .Values.cloudProviderAws.internal.region }}
+{{- end -}}
 
-{{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler") }}
----
-apiVersion: autoscaling.k8s.io/v1
-kind: VerticalPodAutoscaler
-metadata:
-  name: cloud-data-discoverer
-  namespace: d8-cloud-provider-aws
-  {{- include "helm_lib_module_labels" (list . (dict "app" "cloud-data-discoverer")) | nindent 2 }}
-spec:
-  targetRef:
-    apiVersion: "apps/v1"
-    kind: Deployment
-    name: cloud-data-discoverer
-  updatePolicy:
-    updateMode: "Initial"
-  resourcePolicy:
-    containerPolicies:
-    - containerName: "cloud-data-discoverer"
-      minAllowed:
-        {{- include "aws_cloud_data_discoverer_resources" . | nindent 8 }}
-      maxAllowed:
-        cpu: 50m
-        memory: 50Mi
-    {{- include "helm_lib_vpa_kube_rbac_proxy_resources" . | nindent 4 }}
-{{- end }}
----
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: cloud-data-discoverer
-  namespace: d8-cloud-provider-aws
-  {{- include "helm_lib_module_labels" (list . (dict "app" "cloud-data-discoverer")) | nindent 2 }}
-spec:
-  maxUnavailable: 1
-  selector:
-    matchLabels:
-      app: cloud-data-discoverer
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: cloud-data-discoverer
-  namespace: d8-cloud-provider-aws
-  {{- include "helm_lib_module_labels" (list . (dict "app" "cloud-data-discoverer")) | nindent 2 }}
-spec:
-  replicas: 1
-  revisionHistoryLimit: 2
-  strategy:
-    type: Recreate
-  selector:
-    matchLabels:
-      app: cloud-data-discoverer
-  template:
-    metadata:
-      labels:
-        app: cloud-data-discoverer
-      annotations:
-        kubectl.kubernetes.io/default-exec-container: cloud-data-discoverer
-        kubectl.kubernetes.io/default-logs-container: cloud-data-discoverer
-        checksum/config: {{ include (print $.Template.BasePath "/cloud-controller-manager/secret.yaml") . | sha256sum }}
-    spec:
-      imagePullSecrets:
-      - name: deckhouse-registry
-      {{- include "helm_lib_priority_class" (tuple . "cluster-low") | nindent 6 }}
-      {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
-      {{- include "helm_lib_tolerations" (tuple . "any-node" "with-uninitialized") | nindent 6 }}
-      {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
-      dnsPolicy: {{ include "helm_lib_dns_policy_bootstraping_state" (list . "Default" "ClusterFirstWithHostNet") }}
-      automountServiceAccountToken: true
-      serviceAccountName: cloud-data-discoverer
-      containers:
-      - name: cloud-data-discoverer
-        {{- include "helm_lib_module_container_security_context_pss_restricted_flexible" dict | nindent 8 }}
-        image: {{ include "helm_lib_module_image" (list . "cloudDataDiscoverer") }}
-        args:
-        - --discovery-period=1h
-        - --listen-address=127.0.0.1:8081
-        env:
-        - name: AWS_ACCESS_KEY_ID
-          valueFrom:
-            secretKeyRef:
-              name: cloud-controller-manager
-              key: aws-access-key-id
-        - name: AWS_SECRET_ACCESS_KEY
-          valueFrom:
-            secretKeyRef:
-              name: cloud-controller-manager
-              key: aws-secret-access-key
-        - name: AWS_REGION
-          value: {{.Values.cloudProviderAws.internal.region }}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 8080
-            scheme: HTTPS
-        readinessProbe:
-          httpGet:
-            path: /healthz
-            port: 8080
-            scheme: HTTPS
-        resources:
-          requests:
-            {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
-          {{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler") }}
-            {{- include "aws_cloud_data_discoverer_resources" . | nindent 12 }}
-          {{- end }}
-      - name: kube-rbac-proxy
-        {{- include "helm_lib_module_container_security_context_pss_restricted_flexible" dict | nindent 8 }}
-        image: {{ include "helm_lib_module_common_image" (list . "kubeRbacProxy") }}
-        args:
-          - "--secure-listen-address=$(KUBE_RBAC_PROXY_LISTEN_ADDRESS):8080"
-          - "--v=2"
-          - "--logtostderr=true"
-          - "--stale-cache-interval=1h30m"
-          - "--livez-path=/livez"
-        ports:
-          - containerPort: 8080
-            name: https-metrics
-        env:
-          - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
-            valueFrom:
-              fieldRef:
-                fieldPath: status.podIP
-          - name: KUBE_RBAC_PROXY_CONFIG
-            value: |
-              excludePaths:
-              - /healthz
-              upstreams:
-              - upstream: http://127.0.0.1:8081/
-                path: /
-                authorization:
-                  resourceAttributes:
-                    namespace: d8-cloud-provider-aws
-                    apiGroup: apps
-                    apiVersion: v1
-                    resource: deployments
-                    subresource: prometheus-metrics
-                    name: cloud-data-discoverer
-        livenessProbe:
-          httpGet:
-            path: /livez
-            port: 8080
-            scheme: HTTPS
-        readinessProbe:
-          httpGet:
-            path: /livez
-            port: 8080
-            scheme: HTTPS
-        resources:
-          requests:
-            {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
-          {{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler") }}
-            {{- include "helm_lib_container_kube_rbac_proxy_resources" . | nindent 12 }}
-          {{- end }}
+{{- define "aws_cdd_pod_annotations" -}}
+checksum/config: {{ include (print $.Template.BasePath "/cloud-controller-manager/secret.yaml") . | sha256sum }}
+{{- end -}}
+
+{{- $cddConfig := dict -}}
+{{- $_ := set $cddConfig "fullname" "cloud-data-discoverer" -}}
+{{- $_ := set $cddConfig "image" (include "helm_lib_module_image" (list . "cloudDataDiscoverer")) -}}
+{{- $_ := set $cddConfig "additionalEnv" (include "aws_cdd_envs" . | fromYamlArray) -}}
+{{- $_ := set $cddConfig "additionalPodAnnotations" (include "aws_cdd_pod_annotations" . | fromYaml) -}}
+{{- $_ := set $cddConfig "vpaEnabled" true -}}
+
+{{- include "helm_lib_cloud_data_discoverer_manifests" (list . $cddConfig) }}

--- a/modules/030-cloud-provider-aws/templates/cloud-data-discoverer/pod-monitor.yaml
+++ b/modules/030-cloud-provider-aws/templates/cloud-data-discoverer/pod-monitor.yaml
@@ -1,40 +1,4 @@
-{{- if (.Values.global.enabledModules | has "operator-prometheus") }}
----
-apiVersion: monitoring.coreos.com/v1
-kind: PodMonitor
-metadata:
-  name: cloud-data-discoverer-metrics
-  namespace: d8-monitoring
-  {{- include "helm_lib_module_labels" (list . (dict "prometheus" "main" "app" "cloud-data-discoverer")) | nindent 2 }}
-spec:
-  jobLabel: app
-  podMetricsEndpoints:
-    - port: https-metrics
-      path: /metrics
-      scheme: https
-      bearerTokenSecret:
-        name: "prometheus-token"
-        key: "token"
-      tlsConfig:
-        insecureSkipVerify: true
-      honorLabels: true
-      scrapeTimeout: {{ include "helm_lib_prometheus_target_scrape_timeout_seconds" (list . 25) }}
-      relabelings:
-      - regex: endpoint|pod|container
-        action: labeldrop
-      - targetLabel: job
-        replacement: cloud-data-discoverer
-      - sourceLabels: [__meta_kubernetes_pod_node_name]
-        targetLabel: node
-      - targetLabel: tier
-        replacement: cluster
-      - sourceLabels: [__meta_kubernetes_pod_ready]
-        regex: "true"
-        action: keep
-  selector:
-    matchLabels:
-      app: cloud-data-discoverer
-  namespaceSelector:
-    matchNames:
-      - d8-cloud-provider-aws
-{{- end }}
+{{- $podMonitorConfig := dict -}}
+{{- $_ := set $podMonitorConfig "targetNamespace" "d8-cloud-provider-aws" -}}
+
+{{- include "helm_lib_cloud_data_discoverer_pod_monitor" (list . $podMonitorConfig) }}

--- a/modules/030-cloud-provider-aws/templates/csi/controller.yaml
+++ b/modules/030-cloud-provider-aws/templates/csi/controller.yaml
@@ -38,6 +38,7 @@
   {{- $_ := set $csiControllerConfig "additionalControllerArgs" (include "csi_controller_args" . | fromYamlArray) }}
   {{- $_ := set $csiControllerConfig "additionalControllerEnvs" (include "csi_controller_envs" . | fromYamlArray) }}
   {{- $_ := set $csiControllerConfig "dnsPolicy" (include "helm_lib_dns_policy_bootstraping_state" (list . "Default" "ClusterFirstWithHostNet")) }}
+  {{- $_ := set $csiControllerConfig "securityPolicyExceptionEnabled" true }}
 
   {{- include "helm_lib_csi_controller_manifests" (list . $csiControllerConfig) }}
 
@@ -47,6 +48,7 @@
   {{- $_ := set $csiNodeConfig "driverFQDN" "ebs.csi.aws.com" }}
   {{- $_ := set $csiNodeConfig "additionalNodeEnvs" (include "csi_node_envs" . | fromYamlArray) }}
   {{- $_ := set $csiNodeConfig "dnsPolicy" (include "helm_lib_dns_policy_bootstraping_state" (list . "Default" "ClusterFirstWithHostNet")) }}
+  {{- $_ := set $csiNodeConfig "securityPolicyExceptionEnabled" true }}
 
   {{- include "helm_lib_csi_node_manifests" (list . $csiNodeConfig) }}
 {{- end }}

--- a/modules/030-cloud-provider-aws/templates/namespace.yaml
+++ b/modules/030-cloud-provider-aws/templates/namespace.yaml
@@ -1,7 +1,16 @@
+{{- define "labels" }}
+prometheus.deckhouse.io/rules-watcher-enabled: "true"
+extended-monitoring.deckhouse.io/enabled: ""
+security.deckhouse.io/pod-policy: "restricted"
+{{- if .Values.global.enabledModules | has "admission-policy-engine-crd" }}
+security.deckhouse.io/enable-security-policy-check: "true"
+{{- end }}
+{{- end }}
+---
 apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (fromYaml (include "labels" .))) | nindent 2 }}
 ---
-{{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s"  .Chart.Name)) }}
+{{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s" .Chart.Name)) }}

--- a/modules/030-cloud-provider-aws/templates/node-termination-handler/daemonset.yaml
+++ b/modules/030-cloud-provider-aws/templates/node-termination-handler/daemonset.yaml
@@ -3,7 +3,7 @@ cpu: 25m
 memory: 25Mi
 {{- end }}
 
-{{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler") }}
+{{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
@@ -83,7 +83,7 @@ spec:
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
-{{- if not (.Values.global.enabledModules | has "vertical-pod-autoscaler") }}
+{{- if not (.Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
             {{- include "node_termination_handler_resources" . | nindent 12 }}
 {{- end }}
 

--- a/modules/030-cloud-provider-aws/templates/node-termination-handler/daemonset.yaml
+++ b/modules/030-cloud-provider-aws/templates/node-termination-handler/daemonset.yaml
@@ -44,6 +44,9 @@ spec:
         {{ include "helm_lib_prevent_ds_eviction_annotation" . | nindent 8 }}
       labels:
         app: node-termination-handler
+        {{- if .Values.global.enabledModules | has "admission-policy-engine-crd" }}
+        security.deckhouse.io/security-policy-exception: node-termination-handler
+        {{- end }}
     spec:
       affinity:
         nodeAffinity:

--- a/modules/030-cloud-provider-aws/templates/node-termination-handler/security-policy-exception.yaml
+++ b/modules/030-cloud-provider-aws/templates/node-termination-handler/security-policy-exception.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.global.enabledModules | has "admission-policy-engine-crd" }}
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: SecurityPolicyException
+metadata:
+  name: node-termination-handler
+  namespace: d8-{{ .Chart.Name }}
+spec:
+  network:
+    hostNetwork:
+      allowedValue: true
+      metadata:
+        description: |
+          Allow host network access for node-termination-handler.
+          Requires host network to reach the EC2 instance metadata service at 169.254.169.254, which is accessible only from the host network namespace. Used to detect spot interruption notices, rebalance recommendations, and scheduled maintenance events.
+{{- end }}

--- a/modules/030-cloud-provider-azure/templates/namespace.yaml
+++ b/modules/030-cloud-provider-azure/templates/namespace.yaml
@@ -1,12 +1,16 @@
+{{- define "labels" }}
+prometheus.deckhouse.io/rules-watcher-enabled: "true"
+extended-monitoring.deckhouse.io/enabled: ""
+security.deckhouse.io/pod-policy: "restricted"
+{{- if .Values.global.enabledModules | has "admission-policy-engine-crd" }}
+security.deckhouse.io/enable-security-policy-check: "true"
+{{- end }}
+{{- end }}
+---
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: d8-cloud-provider-azure
-  {{- include "helm_lib_module_labels" (list . (dict
-    "extended-monitoring.deckhouse.io/enabled" ""
-    "prometheus.deckhouse.io/rules-watcher-enabled" "true"
-    "security.deckhouse.io/pod-policy" "restricted"
-    "security.deckhouse.io/enable-security-policy-check" "true"
-    )) | nindent 2 }}
+  name: d8-{{ .Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (fromYaml (include "labels" .))) | nindent 2 }}
 ---
-{{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . "d8-cloud-provider-azure") }}
+{{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s" .Chart.Name)) }}

--- a/modules/030-cloud-provider-dvp/templates/namespace.yaml
+++ b/modules/030-cloud-provider-dvp/templates/namespace.yaml
@@ -2,13 +2,15 @@
 prometheus.deckhouse.io/rules-watcher-enabled: "true"
 extended-monitoring.deckhouse.io/enabled: ""
 security.deckhouse.io/pod-policy: "restricted"
+{{- if .Values.global.enabledModules | has "admission-policy-engine-crd" }}
 security.deckhouse.io/enable-security-policy-check: "true"
+{{- end }}
 {{- end }}
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: d8-cloud-provider-dvp
+  name: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (fromYaml (include "labels" .))) | nindent 2 }}
 ---
-{{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . "d8-cloud-provider-dvp") }}
+{{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s" .Chart.Name)) }}

--- a/modules/030-cloud-provider-gcp/templates/namespace.yaml
+++ b/modules/030-cloud-provider-gcp/templates/namespace.yaml
@@ -1,6 +1,6 @@
 {{- define "labels" }}
-extended-monitoring.deckhouse.io/enabled: ""
 prometheus.deckhouse.io/rules-watcher-enabled: "true"
+extended-monitoring.deckhouse.io/enabled: ""
 security.deckhouse.io/pod-policy: "restricted"
 {{- if .Values.global.enabledModules | has "admission-policy-engine-crd" }}
 security.deckhouse.io/enable-security-policy-check: "true"
@@ -10,7 +10,7 @@ security.deckhouse.io/enable-security-policy-check: "true"
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: d8-cloud-provider-gcp
+  name: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (fromYaml (include "labels" .))) | nindent 2 }}
 ---
-{{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s"  .Chart.Name)) }}
+{{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s" .Chart.Name)) }}

--- a/modules/030-cloud-provider-yandex/templates/namespace.yaml
+++ b/modules/030-cloud-provider-yandex/templates/namespace.yaml
@@ -1,15 +1,17 @@
 {{- define "labels" }}
-prometheus.deckhouse.io/monitor-watcher-enabled: "true"
 prometheus.deckhouse.io/rules-watcher-enabled: "true"
+prometheus.deckhouse.io/monitor-watcher-enabled: "true"
 extended-monitoring.deckhouse.io/enabled: ""
 security.deckhouse.io/pod-policy: "restricted"
+{{- if .Values.global.enabledModules | has "admission-policy-engine-crd" }}
 security.deckhouse.io/enable-security-policy-check: "true"
+{{- end }}
 {{- end }}
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: d8-cloud-provider-yandex
+  name: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (fromYaml (include "labels" .))) | nindent 2 }}
 ---
-{{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . "d8-cloud-provider-yandex") }}
+{{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s" .Chart.Name)) }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

  - `modules/030-cloud-provider-aws/templates/cloud-controller-manager/deployment.yaml` — replaced 154-line hand-written VPA+PDB+Deployment with `helm_lib_cloud_controller_manager_manifests`; added `securityPolicyExceptionEnabled: true`
  - `modules/030-cloud-provider-aws/templates/csi/controller.yaml` — added `securityPolicyExceptionEnabled: true` to both `$csiControllerConfig` and `$csiNodeConfig`
  - `modules/030-cloud-provider-aws/templates/cloud-data-discoverer/deployment.yaml` — replaced 160-line hand-written manifest with `helm_lib_cloud_data_discoverer_manifests`
  - `modules/030-cloud-provider-aws/templates/cloud-data-discoverer/pod-monitor.yaml` — replaced hand-written PodMonitor with `helm_lib_cloud_data_discoverer_pod_monitor`
  - `modules/030-cloud-provider-aws/template_tests/module_test.go` — added `vertical-pod-autoscaler-crd` to `enabledModules`; added CCM VPA assertion; added SecurityPolicyException tests (CCM, CSI controller, CSI node — present/absent); added node-termination-handler tests (DaemonSet, RBAC, VPA on/off); fixed CDD VPA
  context to use `vertical-pod-autoscaler-crd`
  - All 11 `030-cloud-provider-*/templates/namespace.yaml` files — unified to VCD reference pattern: named `"labels"` template + `fromYaml`, three unconditional labels (`prometheus.deckhouse.io/rules-watcher-enabled`, `extended-monitoring.deckhouse.io/enabled`, `security.deckhouse.io/pod-policy: restricted`),
  `security.deckhouse.io/enable-security-policy-check` conditional on `admission-policy-engine-crd`, namespace name via `d8-{{ .Chart.Name }}`, `helm_lib_kube_rbac_proxy_ca_certificate` arg via `printf "d8-%s" .Chart.Name`
  - Additional per-module namespace fixes: azure converted from inline `dict` to named template; gcp hardcoded rbac cert arg replaced with `.Chart.Name`; yandex/dvp/vsphere/zvirt got APE-CRD guard on `enable-security-policy-check`

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

  `cloud-provider-aws` was the only `030-cloud-provider-*` module with no `SecurityPolicyException` coverage despite its CCM running with `hostNetwork: true` and a `hostPath` volume at `/etc/kubernetes/pki`. Three bugs in hand-written templates used wrong module guards: `vertical-pod-autoscaler` instead of
  `vertical-pod-autoscaler-crd` (VPA) and `operator-prometheus` instead of `operator-prometheus-crd` (PodMonitor), causing those resources to render or not based on incorrect module checks. Namespace templates were inconsistent across modules — missing security labels, unconditional APE-CRD labels, hardcoded namespace
  name strings, and differing structural styles.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

We don't

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-aws
type: fix
summary: Adds SecurityPolicyException for CCM and CSI components, fixes VPA and PodMonitor module guards, migrates hand-written templates to helm_lib helpers.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
