### PR TITLE
[registry, registry-package-proxy, control-plane-manager, cert-manager, istio, user-authn, cilium-hubble, openvpn, deckhouse-tools, documentation] update certificates and add letsencrypt staging for gateway api

### DIFF
--- a/modules/038-registry/templates/ingress/certmanager-certificate.yaml
+++ b/modules/038-registry/templates/ingress/certmanager-certificate.yaml
@@ -30,6 +30,10 @@ spec:
 {{- $moduleGateway := dict }}
 {{- include "helm_lib_module_gateway" (list . $moduleGateway) }}
 {{- if and $moduleGateway (eq (include "helm_lib_module_https_mode" .) "CertManager") }}
+{{- $issuerName := include "helm_lib_module_https_cert_manager_cluster_issuer_name" . }}
+{{- if or (eq $issuerName "letsencrypt") (eq $issuerName "letsencrypt-staging") }}
+  {{- $issuerName = printf "%s-gateway-%s" $issuerName $moduleGateway.name }}
+{{- end }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -44,7 +48,7 @@ spec:
   dnsNames:
   - {{ include "helm_lib_module_public_domain" (list . "registry") }}
   issuerRef:
-    name: {{ printf "letsencrypt-gateway-%s" $moduleGateway.name }}
+    name: {{ $issuerName }}
     kind: ClusterIssuer
 {{- end }}
 {{- end }}

--- a/modules/039-registry-packages-proxy/templates/httproute.yaml
+++ b/modules/039-registry-packages-proxy/templates/httproute.yaml
@@ -114,6 +114,10 @@ spec:
         value: /
 {{- end }}
 {{- if and $moduleGateway (eq (include "helm_lib_module_https_mode" .) "CertManager") }}
+{{- $issuerName := include "helm_lib_module_https_cert_manager_cluster_issuer_name" . }}
+{{- if or (eq $issuerName "letsencrypt") (eq $issuerName "letsencrypt-staging") }}
+  {{- $issuerName = printf "%s-gateway-%s" $issuerName $moduleGateway.name }}
+{{- end }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -128,7 +132,7 @@ spec:
   dnsNames:
   - {{ include "helm_lib_module_public_domain" (list . "registry-packages-proxy") }}
   issuerRef:
-    name: {{ printf "letsencrypt-gateway-%s" $moduleGateway.name }}
+    name: {{ $issuerName }}
     kind: ClusterIssuer
 {{- end }}
 {{- end }}

--- a/modules/040-control-plane-manager/templates/kubernetes-api/certificate.yaml
+++ b/modules/040-control-plane-manager/templates/kubernetes-api/certificate.yaml
@@ -30,6 +30,10 @@ spec:
 {{- end }}
 {{- end }}
 {{- if and $moduleGateway .Values.controlPlaneManager.apiserver.publishAPI.ingress.enabled (eq .Values.controlPlaneManager.apiserver.publishAPI.ingress.https.mode "Global") (eq (include "helm_lib_module_https_mode" .) "CertManager") }}
+{{- $issuerName := include "helm_lib_module_https_cert_manager_cluster_issuer_name" . }}
+{{- if or (eq $issuerName "letsencrypt") (eq $issuerName "letsencrypt-staging") }}
+  {{- $issuerName = printf "%s-gateway-%s" $issuerName $moduleGateway.name }}
+{{- end }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -44,6 +48,6 @@ spec:
   dnsNames:
   - {{ include "helm_lib_module_public_domain" (list . "api") }}
   issuerRef:
-    name: {{ printf "letsencrypt-gateway-%s" $moduleGateway.name }}
+    name: {{ $issuerName }}
     kind: ClusterIssuer
 {{- end }}

--- a/modules/040-control-plane-manager/templates/kubernetes-api/httproute.yaml
+++ b/modules/040-control-plane-manager/templates/kubernetes-api/httproute.yaml
@@ -91,7 +91,36 @@ spec:
     namespace: kube-system
     sectionName: api
   rules:
-  # /healthz, /livez and /readyz are intentionally not published until HTTPRoute can return a direct 403.
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /healthz
+    filters:
+    - type: ExtensionRef
+      extensionRef:
+        group: network.deckhouse.io
+        kind: HTTPRouteFilter
+        name: return-403
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /livez
+    filters:
+    - type: ExtensionRef
+      extensionRef:
+        group: network.deckhouse.io
+        kind: HTTPRouteFilter
+        name: return-403
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /readyz
+    filters:
+    - type: ExtensionRef
+      extensionRef:
+        group: network.deckhouse.io
+        kind: HTTPRouteFilter
+        name: return-403
   - backendRefs:
     - group: ""
       kind: Service

--- a/modules/101-cert-manager/templates/cert-manager/clusterissuer-letsencrypt-staging-gateway.yaml
+++ b/modules/101-cert-manager/templates/cert-manager/clusterissuer-letsencrypt-staging-gateway.yaml
@@ -1,0 +1,29 @@
+{{- if not .Values.certManager.disableLetsencrypt }}
+{{- $moduleGateway := dict }}
+{{- include "helm_lib_module_gateway" (list . $moduleGateway) }}
+  {{- if and $moduleGateway (include "helm_lib_kind_exists" (list . "Gateway")) (include "helm_lib_kind_exists" (list . "HTTPRoute")) }}
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: {{ printf "letsencrypt-staging-gateway-%s" $moduleGateway.name }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "cert-manager")) | nindent 2 }}
+spec:
+  acme:
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+  {{- if .Values.certManager.internal.email }}
+    email: "{{ .Values.certManager.internal.email }}"
+  {{- end }}
+    privateKeySecretRef:
+      name: cert-manager-letsencrypt-private-key
+    solvers:
+    - http01:
+        gatewayHTTPRoute:
+          parentRefs:
+          - group: gateway.networking.k8s.io
+            kind: Gateway
+            name: {{ $moduleGateway.name }}
+            namespace: {{ $moduleGateway.namespace }}
+            sectionName: d8-http-default
+  {{- end }}
+{{- end }}

--- a/modules/110-istio/templates/certificate.yaml
+++ b/modules/110-istio/templates/certificate.yaml
@@ -22,6 +22,10 @@ spec:
     kind: ClusterIssuer
 {{- end }}
 {{- if and $moduleGateway (eq (include "helm_lib_module_https_mode" .) "CertManager") }}
+{{- $issuerName := include "helm_lib_module_https_cert_manager_cluster_issuer_name" . }}
+{{- if or (eq $issuerName "letsencrypt") (eq $issuerName "letsencrypt-staging") }}
+  {{- $issuerName = printf "%s-gateway-%s" $issuerName $moduleGateway.name }}
+{{- end }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -39,7 +43,7 @@ spec:
   - {{ include "helm_lib_module_public_domain" (list . "istio") }}
   - {{ include "helm_lib_module_public_domain" (list . "istio-metadata") }}
   issuerRef:
-    name: {{ printf "letsencrypt-gateway-%s" $moduleGateway.name }}
+    name: {{ $issuerName }}
     kind: ClusterIssuer
   {{- if .Values.istio.multicluster.enabled }}
 ---
@@ -58,7 +62,7 @@ spec:
   dnsNames:
   - {{ include "helm_lib_module_public_domain" (list . "istio-api-proxy") }}
   issuerRef:
-    name: {{ printf "letsencrypt-gateway-%s" $moduleGateway.name }}
+    name: {{ $issuerName }}
     kind: ClusterIssuer
   {{- end }}
 {{- end }}

--- a/modules/150-user-authn/templates/dex/certificate.yaml
+++ b/modules/150-user-authn/templates/dex/certificate.yaml
@@ -20,6 +20,10 @@ spec:
     kind: ClusterIssuer
   {{- end }}
   {{- if and $moduleGateway (eq (include "helm_lib_module_https_mode" .) "CertManager") }}
+  {{- $issuerName := include "helm_lib_module_https_cert_manager_cluster_issuer_name" . }}
+  {{- if or (eq $issuerName "letsencrypt") (eq $issuerName "letsencrypt-staging") }}
+    {{- $issuerName = printf "%s-gateway-%s" $issuerName $moduleGateway.name }}
+  {{- end }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -34,7 +38,7 @@ spec:
   dnsNames:
   - {{ include "helm_lib_module_public_domain" (list . "dex") }}
   issuerRef:
-    name: {{ printf "letsencrypt-gateway-%s" $moduleGateway.name }}
+    name: {{ $issuerName }}
     kind: ClusterIssuer
   {{- end }}
 {{- end }}

--- a/modules/150-user-authn/templates/kubeconfig-generator/certificate.yaml
+++ b/modules/150-user-authn/templates/kubeconfig-generator/certificate.yaml
@@ -20,6 +20,10 @@ spec:
     kind: ClusterIssuer
   {{- end }}
   {{- if and $moduleGateway (eq (include "helm_lib_module_https_mode" .) "CertManager") }}
+  {{- $issuerName := include "helm_lib_module_https_cert_manager_cluster_issuer_name" . }}
+  {{- if or (eq $issuerName "letsencrypt") (eq $issuerName "letsencrypt-staging") }}
+    {{- $issuerName = printf "%s-gateway-%s" $issuerName $moduleGateway.name }}
+  {{- end }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -34,7 +38,7 @@ spec:
   dnsNames:
   - {{ include "helm_lib_module_public_domain" (list . "kubeconfig") }}
   issuerRef:
-    name: {{ printf "letsencrypt-gateway-%s" $moduleGateway.name }}
+    name: {{ $issuerName }}
     kind: ClusterIssuer
   {{- end }}
 {{- end }}

--- a/modules/500-cilium-hubble/templates/ui/ingress.yaml
+++ b/modules/500-cilium-hubble/templates/ui/ingress.yaml
@@ -70,6 +70,10 @@ spec:
     kind: ClusterIssuer
 {{- end }}
 {{- if and $moduleGateway (eq (include "helm_lib_module_https_mode" .) "CertManager") }}
+{{- $issuerName := include "helm_lib_module_https_cert_manager_cluster_issuer_name" . }}
+{{- if or (eq $issuerName "letsencrypt") (eq $issuerName "letsencrypt-staging") }}
+  {{- $issuerName = printf "%s-gateway-%s" $issuerName $moduleGateway.name }}
+{{- end }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -84,7 +88,7 @@ spec:
   dnsNames:
     - {{ include "helm_lib_module_public_domain" (list . "hubble") }}
   issuerRef:
-    name: {{ printf "letsencrypt-gateway-%s" $moduleGateway.name }}
+    name: {{ $issuerName }}
     kind: ClusterIssuer
 {{- end }}
 {{- end }}

--- a/modules/500-openvpn/templates/openvpn/ingress.yaml
+++ b/modules/500-openvpn/templates/openvpn/ingress.yaml
@@ -67,6 +67,10 @@ spec:
     kind: ClusterIssuer
   {{- end }}
   {{- if and $moduleGateway (eq (include "helm_lib_module_https_mode" .) "CertManager") }}
+  {{- $issuerName := include "helm_lib_module_https_cert_manager_cluster_issuer_name" . }}
+  {{- if or (eq $issuerName "letsencrypt") (eq $issuerName "letsencrypt-staging") }}
+    {{- $issuerName = printf "%s-gateway-%s" $issuerName $moduleGateway.name }}
+  {{- end }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -81,7 +85,7 @@ spec:
   dnsNames:
   - {{ include "helm_lib_module_public_domain" (list . "openvpn-admin") }}
   issuerRef:
-    name: {{ printf "letsencrypt-gateway-%s" $moduleGateway.name }}
+    name: {{ $issuerName }}
     kind: ClusterIssuer
   {{- end }}
 {{- end }}

--- a/modules/800-deckhouse-tools/templates/ingress.yaml
+++ b/modules/800-deckhouse-tools/templates/ingress.yaml
@@ -68,6 +68,10 @@ spec:
 {{- $moduleGateway := dict }}
 {{- include "helm_lib_module_gateway" (list . $moduleGateway) }}
 {{- if and $moduleGateway (eq (include "helm_lib_module_https_mode" .) "CertManager") }}
+{{- $issuerName := include "helm_lib_module_https_cert_manager_cluster_issuer_name" . }}
+{{- if or (eq $issuerName "letsencrypt") (eq $issuerName "letsencrypt-staging") }}
+  {{- $issuerName = printf "%s-gateway-%s" $issuerName $moduleGateway.name }}
+{{- end }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -82,7 +86,7 @@ spec:
   dnsNames:
   - {{ include "helm_lib_module_public_domain" (list . "tools") }}
   issuerRef:
-    name: {{ printf "letsencrypt-gateway-%s" $moduleGateway.name }}
+    name: {{ $issuerName }}
     kind: ClusterIssuer
 {{- end }}
 ---

--- a/modules/810-documentation/templates/ingress.yaml
+++ b/modules/810-documentation/templates/ingress.yaml
@@ -124,6 +124,10 @@ spec:
 {{- $moduleGateway := dict }}
 {{- include "helm_lib_module_gateway" (list . $moduleGateway) }}
 {{- if and $moduleGateway (eq (include "helm_lib_module_https_mode" .) "CertManager") }}
+{{- $issuerName := include "helm_lib_module_https_cert_manager_cluster_issuer_name" . }}
+{{- if or (eq $issuerName "letsencrypt") (eq $issuerName "letsencrypt-staging") }}
+  {{- $issuerName = printf "%s-gateway-%s" $issuerName $moduleGateway.name }}
+{{- end }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -138,7 +142,7 @@ spec:
   dnsNames:
   - {{ include "helm_lib_module_public_domain" (list . "documentation") }}
   issuerRef:
-    name: {{ printf "letsencrypt-gateway-%s" $moduleGateway.name }}
+    name: {{ $issuerName }}
     kind: ClusterIssuer
 {{- end }}
 ---


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
This pr adds an additional letsencrypt-staging cluster issuer if the ALB module is enabled and default DKP gateway is set.
Also, it updates the way a cluster issuers is selected for each certificate created for the default DKP gateway so that it's possible to use cluster issuer presented in the cluster.
One more thing it does is update the kubernetes api HTTPRoute so that /livez|readyz|healthz handles return 403, replicating the related Ingress configuration, instead of 404.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

It extends Gateway API support in terms of using cluster issuers.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: registry
type: fix
summary: Gateway API certificate manifest is updated to support any cluster issuer.
impact_level: low
---
section: registry-packages-proxy
type: fix
summary: Gateway API certificate manifest is updated to support any cluster issuer.
impact_level: low
---
section: istio
type: fix
summary: Gateway API certificate manifest is updated to support any cluster issuer.
impact_level: low
---
section: cert-manager
type: fix
summary: Additional letsencrypt-staging cluster issuer for Gateway API is provided.
impact_level: low
---
section: user-authn
type: fix
summary: Gateway API certificate manifest is updated to support any cluster issuer.
impact_level: low
---
section: control-plane-manager
type: fix
summary: Kubernetes API HTTProute was updated to return 403 instead of 404.
impact_level: low
---
section: cilium-hubble
type: fix
summary: Gateway API certificate manifest is updated to support any cluster issuer.
impact_level: low
---
section: openvpn
type: fix
summary: Gateway API certificate manifest is updated to support any cluster issuer.
impact_level: low
---
section: deckhouse-tools
type: fix
summary: Gateway API certificate manifest is updated to support any cluster issuer.
impact_level: low
---
section: documentation
type: fix
summary: Gateway API certificate manifest is updated to support any cluster issuer.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
