### PR TITLE
[dhctl] feat: adjust preflight system requirements for minimal bundle

### DIFF
--- a/dhctl/pkg/config/deckhouse_config.go
+++ b/dhctl/pkg/config/deckhouse_config.go
@@ -33,6 +33,7 @@ import (
 
 const (
 	DefaultBundle   = "Default"
+	MinimalBundle   = "Minimal"
 	DefaultLogLevel = "Info"
 )
 

--- a/dhctl/pkg/kubernetes/lease/lock.go
+++ b/dhctl/pkg/kubernetes/lease/lock.go
@@ -37,7 +37,10 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/retry"
 )
 
-const lockUserInfoAnnotKey = "dhctl.deckhouse.io/lock-user-info"
+const (
+	acquireErrorPrefix   = "Can't acquire lease lock."
+	lockUserInfoAnnotKey = "dhctl.deckhouse.io/lock-user-info"
+)
 
 type LeaseLockConfig struct {
 	Name      string
@@ -58,6 +61,15 @@ func (c *LeaseLockConfig) RenewRetries() int {
 	d := int64(c.LeaseDurationSeconds) - c.RenewEverySeconds
 	retries := math.Ceil(float64(d) / c.RetryWaitDuration.Seconds())
 	return int(retries)
+}
+
+// AcquireRetries returns the number of attempts required to wait for
+// one configured lease lifetime and make one additional acquisition attempt.
+func (c *LeaseLockConfig) AcquireRetries() int {
+	retries := math.Ceil(
+		float64(c.LeaseDurationSeconds) / c.RetryWaitDuration.Seconds(),
+	)
+	return int(retries) + 1
 }
 
 type LockUserInfo struct {
@@ -205,34 +217,40 @@ func (l *LeaseLock) startAutoRenew(ctx context.Context) {
 func (l *LeaseLock) tryAcquire(ctx context.Context, force bool) (*coordinationv1.Lease, error) {
 	var lease *coordinationv1.Lease
 
-	prefix := "Can't acquire lease lock."
-	cannotRenew := func(err error) bool {
-		return strings.HasPrefix(err.Error(), prefix)
-	}
-
 	kubeClient, err := l.getter.KubeClientCtx(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("could not get kube client: %w", err)
 	}
 
-	acquireRetries := l.config.RenewRetries()
-	err = retry.NewSilentLoop("acquire lease", acquireRetries, l.config.RetryWaitDuration).BreakIf(cannotRenew).RunContext(ctx, func() error {
+	acquireRetries := l.config.AcquireRetries()
+
+	err = retry.NewSilentLoop(
+		"acquire lease",
+		acquireRetries,
+		l.config.RetryWaitDuration,
+	).RunContext(ctx, func() error {
 		var err error
-		lease, err = l.createLease(ctx)
+
+		lease, err = l.createLease(ctx, kubeClient)
 		if err == nil {
 			return nil
 		}
 
-		if errors.IsAlreadyExists(err) {
-			lease, err = kubeClient.CoordinationV1().Leases(l.config.Namespace).Get(ctx, l.config.Name, metav1.GetOptions{})
-			if err != nil {
-				return fmt.Errorf("%s Can't get current lease: %v", prefix, err)
-			}
+		if !errors.IsAlreadyExists(err) {
+			return err
+		}
 
-			lease, err = l.tryRenew(ctx, lease, force)
-			if err != nil {
-				return fmt.Errorf("%s \n%v", prefix, err)
-			}
+		lease, err = kubeClient.
+			CoordinationV1().
+			Leases(l.config.Namespace).
+			Get(ctx, l.config.Name, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("%s Can't get current lease: %v", acquireErrorPrefix, err)
+		}
+
+		lease, err = l.acquireExistingLease(ctx, kubeClient, lease, force)
+		if err != nil {
+			return fmt.Errorf("%s\n%v", acquireErrorPrefix, err)
 		}
 
 		return nil
@@ -241,7 +259,10 @@ func (l *LeaseLock) tryAcquire(ctx context.Context, force bool) (*coordinationv1
 	return lease, err
 }
 
-func (l *LeaseLock) createLease(ctx context.Context) (*coordinationv1.Lease, error) {
+func (l *LeaseLock) createLease(
+	ctx context.Context,
+	kubeClient *client.KubernetesClient,
+) (*coordinationv1.Lease, error) {
 	userInfo := NewLockUserInfo(l.config.AdditionalUserInfo)
 	userInfoStr, err := json.Marshal(userInfo)
 	if err != nil {
@@ -263,12 +284,35 @@ func (l *LeaseLock) createLease(ctx context.Context) (*coordinationv1.Lease, err
 		},
 	}
 
-	kubeClient, err := l.getter.KubeClientCtx(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("could not get kube client: %w", err)
+	return kubeClient.
+		CoordinationV1().
+		Leases(l.config.Namespace).
+		Create(ctx, lease, metav1.CreateOptions{})
+}
+
+func (l *LeaseLock) acquireExistingLease(
+	ctx context.Context,
+	kubeClient *client.KubernetesClient,
+	lease *coordinationv1.Lease,
+	force bool,
+) (*coordinationv1.Lease, error) {
+	if lease == nil {
+		return nil, fmt.Errorf("lease is nil")
 	}
 
-	return kubeClient.CoordinationV1().Leases(l.config.Namespace).Create(ctx, lease, metav1.CreateOptions{})
+	if lease.Spec.HolderIdentity == nil {
+		return nil, fmt.Errorf("lease holder identity is nil")
+	}
+
+	if *lease.Spec.HolderIdentity == l.config.Identity {
+		return l.tryRenew(ctx, lease, force)
+	}
+
+	if l.isStillLocked(lease) {
+		return nil, getCurrentLockerError(lease)
+	}
+
+	return l.takeOverLease(ctx, kubeClient, lease)
 }
 
 func (l *LeaseLock) tryRenew(ctx context.Context, lease *coordinationv1.Lease, force bool) (*coordinationv1.Lease, error) {
@@ -328,14 +372,16 @@ func (l *LeaseLock) isStillLocked(lease *coordinationv1.Lease) bool {
 		return false
 	}
 
-	renewTimeMicro := lease.Spec.RenewTime
-	if renewTimeMicro == nil {
+	if lease.Spec.RenewTime == nil {
 		return true
 	}
 
-	leaseDuration := time.Duration(l.config.LeaseDurationSeconds) * time.Second
-	renewTime := renewTimeMicro.Time
-	endLeaseTime := renewTime.Add(leaseDuration)
+	if lease.Spec.LeaseDurationSeconds == nil {
+		return true
+	}
+
+	leaseDuration := time.Duration(*lease.Spec.LeaseDurationSeconds) * time.Second
+	endLeaseTime := lease.Spec.RenewTime.Time.Add(leaseDuration)
 
 	return time.Now().Before(endLeaseTime)
 }
@@ -361,16 +407,29 @@ func LockInfo(lease *coordinationv1.Lease) (string, *LockUserInfo) {
 	}
 	userInfo := zeroUserInfo
 	if lease != nil {
-		holder = *lease.Spec.HolderIdentity
-		acquireTime = lease.Spec.AcquireTime.Time
-		lastRenew = lease.Spec.RenewTime.Time
-		leaseDurationSec = *lease.Spec.LeaseDurationSeconds
+		if lease.Spec.HolderIdentity != nil {
+			holder = *lease.Spec.HolderIdentity
+		}
 
-		infoJSON, ok := lease.Annotations[lockUserInfoAnnotKey]
-		if ok && infoJSON != "" {
-			err := json.Unmarshal([]byte(infoJSON), &userInfo)
-			if err != nil {
-				userInfo = zeroUserInfo
+		if lease.Spec.AcquireTime != nil {
+			acquireTime = lease.Spec.AcquireTime.Time
+		}
+
+		if lease.Spec.RenewTime != nil {
+			lastRenew = lease.Spec.RenewTime.Time
+		}
+
+		if lease.Spec.LeaseDurationSeconds != nil {
+			leaseDurationSec = *lease.Spec.LeaseDurationSeconds
+		}
+
+		if lease.Annotations != nil {
+			infoJSON, ok := lease.Annotations[lockUserInfoAnnotKey]
+			if ok && infoJSON != "" {
+				err := json.Unmarshal([]byte(infoJSON), &userInfo)
+				if err != nil {
+					userInfo = zeroUserInfo
+				}
 			}
 		}
 	}
@@ -418,4 +477,34 @@ func RemoveLease(ctx context.Context, kubeCl *client.KubernetesClient, config *L
 	})
 
 	return err
+}
+
+func (l *LeaseLock) takeOverLease(
+	ctx context.Context,
+	kubeClient *client.KubernetesClient,
+	lease *coordinationv1.Lease,
+) (*coordinationv1.Lease, error) {
+	userInfo := NewLockUserInfo(l.config.AdditionalUserInfo)
+	userInfoJSON, err := json.Marshal(userInfo)
+	if err != nil {
+		userInfoJSON = nil
+	}
+
+	currentTime := now()
+
+	lease.Spec.HolderIdentity = &l.config.Identity
+	lease.Spec.AcquireTime = currentTime
+	lease.Spec.RenewTime = currentTime
+	lease.Spec.LeaseDurationSeconds = &l.config.LeaseDurationSeconds
+
+	if lease.Annotations == nil {
+		lease.Annotations = make(map[string]string)
+	}
+
+	lease.Annotations[lockUserInfoAnnotKey] = string(userInfoJSON)
+
+	return kubeClient.
+		CoordinationV1().
+		Leases(l.config.Namespace).
+		Update(ctx, lease, metav1.UpdateOptions{})
 }

--- a/dhctl/pkg/kubernetes/lease/lock_test.go
+++ b/dhctl/pkg/kubernetes/lease/lock_test.go
@@ -19,6 +19,10 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	coordinationv1 "k8s.io/api/coordination/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
 )
 
 func TestRenewRetryCount(t *testing.T) {
@@ -33,6 +37,17 @@ func TestRenewRetryCount(t *testing.T) {
 	})
 }
 
+func TestAcquireRetryCount(t *testing.T) {
+	t.Run("Waits one lease lifetime and makes final attempt", func(t *testing.T) {
+		lockConf := &LeaseLockConfig{
+			LeaseDurationSeconds: 300,
+			RetryWaitDuration:    3 * time.Second,
+		}
+
+		require.Equal(t, 101, lockConf.AcquireRetries())
+	})
+}
+
 func TestTryRenewNilLease(t *testing.T) {
 	t.Run("Nil lease should return error, not panic", func(t *testing.T) {
 		lock := &LeaseLock{
@@ -41,13 +56,126 @@ func TestTryRenewNilLease(t *testing.T) {
 			},
 		}
 
-		ctx := t.Context()
-
 		require.NotPanics(t, func() {
-			lease, err := lock.tryRenew(ctx, nil, true)
+			lease, err := lock.tryRenew(t.Context(), nil, true)
+
 			require.Nil(t, lease)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "lease is nil")
 		})
+	})
+}
+
+func TestAcquireExistingLeaseNilHolder(t *testing.T) {
+	t.Run("Lease without holder identity should return error", func(t *testing.T) {
+		lock := &LeaseLock{
+			config: LeaseLockConfig{
+				Identity: "new-holder",
+			},
+		}
+
+		lease, err := lock.acquireExistingLease(
+			t.Context(),
+			nil,
+			&coordinationv1.Lease{},
+			false,
+		)
+
+		require.Nil(t, lease)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "lease holder identity is nil")
+	})
+}
+
+func TestAcquireExistingActiveForeignLease(t *testing.T) {
+	t.Run("Active lease owned by another identity should not be taken over", func(t *testing.T) {
+		holder := "old-holder"
+		duration := int32(300)
+		renewTime := metav1.NewMicroTime(time.Now())
+
+		existingLease := &coordinationv1.Lease{
+			Spec: coordinationv1.LeaseSpec{
+				HolderIdentity:       &holder,
+				RenewTime:            &renewTime,
+				LeaseDurationSeconds: &duration,
+			},
+		}
+
+		lock := &LeaseLock{
+			config: LeaseLockConfig{
+				Identity: "new-holder",
+			},
+		}
+
+		updatedLease, err := lock.acquireExistingLease(
+			t.Context(),
+			nil,
+			existingLease,
+			false,
+		)
+
+		require.Nil(t, updatedLease)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "old-holder")
+		require.Equal(t, "old-holder", *existingLease.Spec.HolderIdentity)
+	})
+}
+
+func TestAcquireExistingExpiredForeignLease(t *testing.T) {
+	t.Run("Expired lease owned by another identity should be taken over", func(t *testing.T) {
+		kubeClient := client.NewFakeKubernetesClient()
+
+		oldHolder := "old-holder"
+		duration := int32(300)
+		acquireTime := metav1.NewMicroTime(time.Now().Add(-20 * time.Minute))
+		renewTime := metav1.NewMicroTime(time.Now().Add(-10 * time.Minute))
+
+		existingLease := &coordinationv1.Lease{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-lock",
+				Namespace: "default",
+			},
+			Spec: coordinationv1.LeaseSpec{
+				HolderIdentity:       &oldHolder,
+				AcquireTime:          &acquireTime,
+				RenewTime:            &renewTime,
+				LeaseDurationSeconds: &duration,
+			},
+		}
+
+		_, err := kubeClient.
+			CoordinationV1().
+			Leases("default").
+			Create(t.Context(), existingLease, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		lock := &LeaseLock{
+			config: LeaseLockConfig{
+				Name:                 "test-lock",
+				Namespace:            "default",
+				Identity:             "new-holder",
+				LeaseDurationSeconds: 300,
+			},
+		}
+
+		updatedLease, err := lock.acquireExistingLease(
+			t.Context(),
+			kubeClient,
+			existingLease,
+			false,
+		)
+
+		require.NoError(t, err)
+		require.NotNil(t, updatedLease)
+		require.NotNil(t, updatedLease.Spec.HolderIdentity)
+		require.Equal(t, "new-holder", *updatedLease.Spec.HolderIdentity)
+
+		storedLease, err := kubeClient.
+			CoordinationV1().
+			Leases("default").
+			Get(t.Context(), "test-lock", metav1.GetOptions{})
+		require.NoError(t, err)
+		require.NotNil(t, storedLease.Spec.HolderIdentity)
+		require.Equal(t, "new-holder", *storedLease.Spec.HolderIdentity)
 	})
 }

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
@@ -462,6 +462,7 @@ func (b *ClusterBootstrapper) bootstrapPreflight(ctx context.Context, bctx *boot
 		staticPreflightSuite, err := suites.NewStaticSuite(suites.StaticDeps{
 			SSHProviderInitializer: b.SSHProviderInitializer,
 			MetaConfig:             bctx.metaConfig,
+			InstallConfig:          bctx.deckhouseInstallConfig,
 			LegacyMode:             b.SSHProviderInitializer.IsLegacyMode(),
 			GlobalOpts:             &b.Options.Global,
 		}, ctx)

--- a/dhctl/pkg/preflight/checks/cloud_system_requirements.go
+++ b/dhctl/pkg/preflight/checks/cloud_system_requirements.go
@@ -26,13 +26,6 @@ import (
 	preflight "github.com/deckhouse/deckhouse/dhctl/pkg/preflight"
 )
 
-const (
-	minimumRequiredCPUCores       = 4
-	minimumRequiredMemoryMB       = 8192 - reservedMemoryThresholdMB
-	minimumRequiredRootDiskSizeGB = 50
-	reservedMemoryThresholdMB     = 512
-)
-
 type CloudSystemRequirementsCheck struct {
 	InstallConfig *config.DeckhouseInstaller
 }
@@ -56,9 +49,12 @@ func (c CloudSystemRequirementsCheck) Run(_ context.Context) error {
 	// input file) the master sizing lives in NodeGroup + InstanceClass resources
 	// resolved by the provider validator, not in PCC. Skip the legacy PCC-based
 	// check — the external validator performs its own checks.
-	if len(c.InstallConfig.ProviderClusterConfig) == 0 {
+	if c.InstallConfig == nil || len(c.InstallConfig.ProviderClusterConfig) == 0 {
 		return nil
 	}
+
+	requirements := systemRequirementsForConfig(c.InstallConfig)
+
 	configObject := make(map[string]any)
 	configKind, err := unmarshalProviderClusterConfiguration(c.InstallConfig.ProviderClusterConfig, configObject)
 	if err != nil {
@@ -110,13 +106,13 @@ func (c CloudSystemRequirementsCheck) Run(_ context.Context) error {
 		return nil
 	}
 
-	if err = validateIntegerPropertyAtPath(configObject, rootDiskPropertyPath, minimumRequiredRootDiskSizeGB, true); err != nil {
+	if err = validateIntegerPropertyAtPath(configObject, rootDiskPropertyPath, requirements.rootDiskSizeGB, true); err != nil {
 		return fmt.Errorf("Root disk capacity: %v", err)
 	}
-	if err = validateIntegerPropertyAtPath(configObject, ramAmountPropertyPath, minimumRequiredMemoryMB, false); err != nil {
+	if err = validateIntegerPropertyAtPath(configObject, ramAmountPropertyPath, requirements.memoryMB, false); err != nil {
 		return fmt.Errorf("RAM amount: %v", err)
 	}
-	if err = validateIntegerPropertyAtPath(configObject, coreCountPropertyPath, minimumRequiredCPUCores, false); err != nil {
+	if err = validateIntegerPropertyAtPath(configObject, coreCountPropertyPath, requirements.cpuCores, false); err != nil {
 		return fmt.Errorf("CPU cores count: %v", err)
 	}
 

--- a/dhctl/pkg/preflight/checks/system_requirements.go
+++ b/dhctl/pkg/preflight/checks/system_requirements.go
@@ -1,0 +1,49 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checks
+
+import "github.com/deckhouse/deckhouse/dhctl/pkg/config"
+
+const (
+	reservedMemoryThresholdMB = 512
+
+	minimumRequiredCPUCores       = 4
+	minimumRequiredMemoryMB       = 8192 - reservedMemoryThresholdMB
+	minimumRequiredRootDiskSizeGB = 50
+
+	minimalBundleRequiredCPUCores = 2
+	minimalBundleRequiredMemoryMB = 4096 - reservedMemoryThresholdMB
+)
+
+type systemRequirements struct {
+	cpuCores       int
+	memoryMB       int
+	rootDiskSizeGB int
+}
+
+func systemRequirementsForConfig(installConfig *config.DeckhouseInstaller) systemRequirements {
+	requirements := systemRequirements{
+		cpuCores:       minimumRequiredCPUCores,
+		memoryMB:       minimumRequiredMemoryMB,
+		rootDiskSizeGB: minimumRequiredRootDiskSizeGB,
+	}
+
+	if installConfig != nil && installConfig.Bundle == config.MinimalBundle {
+		requirements.cpuCores = minimalBundleRequiredCPUCores
+		requirements.memoryMB = minimalBundleRequiredMemoryMB
+	}
+
+	return requirements
+}

--- a/dhctl/pkg/preflight/checks/system_requirements_static.go
+++ b/dhctl/pkg/preflight/checks/system_requirements_static.go
@@ -25,6 +25,7 @@ import (
 
 	libcon "github.com/deckhouse/lib-connection/pkg"
 
+	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
 	preflight "github.com/deckhouse/deckhouse/dhctl/pkg/preflight"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/helper"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/providerinitializer"
@@ -32,6 +33,7 @@ import (
 
 type StaticSystemRequirementsCheck struct {
 	SSHProviderInitializer *providerinitializer.SSHProviderInitializer
+	InstallConfig          *config.DeckhouseInstaller
 }
 
 const StaticSystemRequirementsCheckName preflight.CheckName = "static-system-requirements"
@@ -53,6 +55,7 @@ func (c StaticSystemRequirementsCheck) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
 	ramKb, err := extractRAMCapacityFromNode(ctx, nodeInterface)
 	if err != nil {
 		return err
@@ -63,19 +66,21 @@ func (c StaticSystemRequirementsCheck) Run(ctx context.Context) error {
 		return err
 	}
 
+	requirements := systemRequirementsForConfig(c.InstallConfig)
+
 	var failures []string
-	if coresCount < minimumRequiredCPUCores {
+	if coresCount < requirements.cpuCores {
 		failures = append(failures, fmt.Sprintf(
 			" - System requirements mandate at least %d CPU(s) on the node, but it has %d",
-			minimumRequiredCPUCores,
+			requirements.cpuCores,
 			coresCount,
 		))
 	}
 
-	if ramKb < minimumRequiredMemoryMB*1024 {
+	if ramKb < requirements.memoryMB*1024 {
 		failures = append(failures, fmt.Sprintf(
 			" - System requirements mandate at least %d MiB of RAM on the node, but it has %d MiB",
-			minimumRequiredMemoryMB,
+			requirements.memoryMB,
 			ramKb/1024,
 		))
 	}
@@ -140,8 +145,15 @@ func logicalCoresCountFromCPUInfo(cpuinfo []byte) (int, error) {
 	return len(processors), nil
 }
 
-func StaticSystemRequirements(sshProviderInitializer *providerinitializer.SSHProviderInitializer) preflight.Check {
-	check := StaticSystemRequirementsCheck{SSHProviderInitializer: sshProviderInitializer}
+func StaticSystemRequirements(
+	sshProviderInitializer *providerinitializer.SSHProviderInitializer,
+	installConfig *config.DeckhouseInstaller,
+) preflight.Check {
+	check := StaticSystemRequirementsCheck{
+		SSHProviderInitializer: sshProviderInitializer,
+		InstallConfig:          installConfig,
+	}
+
 	return preflight.Check{
 		Name:        StaticSystemRequirementsCheckName,
 		Description: check.Description(),

--- a/dhctl/pkg/preflight/checks/system_requirements_test.go
+++ b/dhctl/pkg/preflight/checks/system_requirements_test.go
@@ -1,0 +1,321 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checks
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+)
+
+func TestSystemRequirementsForConfig(t *testing.T) {
+	tests := []struct {
+		name          string
+		installConfig *config.DeckhouseInstaller
+		expected      systemRequirements
+	}{
+		{
+			name: "default bundle",
+			installConfig: &config.DeckhouseInstaller{
+				Bundle: config.DefaultBundle,
+			},
+			expected: systemRequirements{
+				cpuCores:       4,
+				memoryMB:       7680,
+				rootDiskSizeGB: 50,
+			},
+		},
+		{
+			name: "minimal bundle",
+			installConfig: &config.DeckhouseInstaller{
+				Bundle: config.MinimalBundle,
+			},
+			expected: systemRequirements{
+				cpuCores:       2,
+				memoryMB:       3584,
+				rootDiskSizeGB: 50,
+			},
+		},
+		{
+			name:          "nil config uses default requirements",
+			installConfig: nil,
+			expected: systemRequirements{
+				cpuCores:       4,
+				memoryMB:       7680,
+				rootDiskSizeGB: 50,
+			},
+		},
+		{
+			name:          "empty bundle uses default requirements",
+			installConfig: &config.DeckhouseInstaller{},
+			expected: systemRequirements{
+				cpuCores:       4,
+				memoryMB:       7680,
+				rootDiskSizeGB: 50,
+			},
+		},
+		{
+			name: "unknown bundle uses default requirements",
+			installConfig: &config.DeckhouseInstaller{
+				Bundle: "Unknown",
+			},
+			expected: systemRequirements{
+				cpuCores:       4,
+				memoryMB:       7680,
+				rootDiskSizeGB: 50,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := systemRequirementsForConfig(tt.installConfig)
+
+			require.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestCloudSystemRequirementsMinimalBundlePassesAtMinimumResources(
+	t *testing.T,
+) {
+	installConfig := &config.DeckhouseInstaller{
+		Bundle: config.MinimalBundle,
+		ProviderClusterConfig: []byte(`
+apiVersion: deckhouse.io/v1
+kind: YandexClusterConfiguration
+layout: Standard
+masterNodeGroup:
+  replicas: 1
+  instanceClass:
+    cores: 2
+    memory: 3584
+`),
+	}
+
+	check := CloudSystemRequirementsCheck{
+		InstallConfig: installConfig,
+	}
+
+	require.NoError(t, check.Run(context.Background()))
+}
+
+func TestCloudSystemRequirementsDefaultBundlePassesAtMinimumResources(
+	t *testing.T,
+) {
+	installConfig := &config.DeckhouseInstaller{
+		Bundle: config.DefaultBundle,
+		ProviderClusterConfig: []byte(`
+apiVersion: deckhouse.io/v1
+kind: YandexClusterConfiguration
+layout: Standard
+masterNodeGroup:
+  replicas: 1
+  instanceClass:
+    cores: 4
+    memory: 7680
+`),
+	}
+
+	check := CloudSystemRequirementsCheck{
+		InstallConfig: installConfig,
+	}
+
+	require.NoError(t, check.Run(context.Background()))
+}
+
+func TestCloudSystemRequirementsDefaultBundleRejectsMinimalMemory(
+	t *testing.T,
+) {
+	installConfig := &config.DeckhouseInstaller{
+		Bundle: config.DefaultBundle,
+		ProviderClusterConfig: []byte(`
+apiVersion: deckhouse.io/v1
+kind: YandexClusterConfiguration
+layout: Standard
+masterNodeGroup:
+  replicas: 1
+  instanceClass:
+    cores: 4
+    memory: 3584
+`),
+	}
+
+	check := CloudSystemRequirementsCheck{
+		InstallConfig: installConfig,
+	}
+
+	err := check.Run(context.Background())
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "RAM amount")
+	require.Contains(
+		t,
+		err.Error(),
+		"expected at least 7680, but 3584 is configured",
+	)
+}
+
+func TestCloudSystemRequirementsDefaultBundleRejectsInsufficientCPU(
+	t *testing.T,
+) {
+	installConfig := &config.DeckhouseInstaller{
+		Bundle: config.DefaultBundle,
+		ProviderClusterConfig: []byte(`
+apiVersion: deckhouse.io/v1
+kind: YandexClusterConfiguration
+layout: Standard
+masterNodeGroup:
+  replicas: 1
+  instanceClass:
+    cores: 3
+    memory: 7680
+`),
+	}
+
+	check := CloudSystemRequirementsCheck{
+		InstallConfig: installConfig,
+	}
+
+	err := check.Run(context.Background())
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "CPU cores count")
+	require.Contains(
+		t,
+		err.Error(),
+		"expected at least 4, but 3 is configured",
+	)
+}
+
+func TestCloudSystemRequirementsMinimalBundleRejectsInsufficientCPU(
+	t *testing.T,
+) {
+	installConfig := &config.DeckhouseInstaller{
+		Bundle: config.MinimalBundle,
+		ProviderClusterConfig: []byte(`
+apiVersion: deckhouse.io/v1
+kind: YandexClusterConfiguration
+layout: Standard
+masterNodeGroup:
+  replicas: 1
+  instanceClass:
+    cores: 1
+    memory: 3584
+`),
+	}
+
+	check := CloudSystemRequirementsCheck{
+		InstallConfig: installConfig,
+	}
+
+	err := check.Run(context.Background())
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "CPU cores count")
+	require.Contains(
+		t,
+		err.Error(),
+		"expected at least 2, but 1 is configured",
+	)
+}
+
+func TestCloudSystemRequirementsMinimalBundleRejectsInsufficientMemory(
+	t *testing.T,
+) {
+	installConfig := &config.DeckhouseInstaller{
+		Bundle: config.MinimalBundle,
+		ProviderClusterConfig: []byte(`
+apiVersion: deckhouse.io/v1
+kind: YandexClusterConfiguration
+layout: Standard
+masterNodeGroup:
+  replicas: 1
+  instanceClass:
+    cores: 2
+    memory: 3583
+`),
+	}
+
+	check := CloudSystemRequirementsCheck{
+		InstallConfig: installConfig,
+	}
+
+	err := check.Run(context.Background())
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "RAM amount")
+	require.Contains(
+		t,
+		err.Error(),
+		"expected at least 3584, but 3583 is configured",
+	)
+}
+
+func TestCloudSystemRequirementsMinimalBundleRejectsSmallExplicitRootDisk(
+	t *testing.T,
+) {
+	installConfig := &config.DeckhouseInstaller{
+		Bundle: config.MinimalBundle,
+		ProviderClusterConfig: []byte(`
+apiVersion: deckhouse.io/v1
+kind: YandexClusterConfiguration
+layout: Standard
+masterNodeGroup:
+  replicas: 1
+  instanceClass:
+    cores: 2
+    memory: 3584
+    diskSizeGB: 49
+`),
+	}
+
+	check := CloudSystemRequirementsCheck{
+		InstallConfig: installConfig,
+	}
+
+	err := check.Run(context.Background())
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Root disk capacity")
+	require.Contains(
+		t,
+		err.Error(),
+		"expected at least 50, but 49 is configured",
+	)
+}
+
+func TestCloudSystemRequirementsNilConfig(t *testing.T) {
+	check := CloudSystemRequirementsCheck{
+		InstallConfig: nil,
+	}
+
+	require.NoError(t, check.Run(context.Background()))
+}
+
+func TestCloudSystemRequirementsWithoutProviderClusterConfig(
+	t *testing.T,
+) {
+	check := CloudSystemRequirementsCheck{
+		InstallConfig: &config.DeckhouseInstaller{
+			Bundle: config.MinimalBundle,
+		},
+	}
+
+	require.NoError(t, check.Run(context.Background()))
+}

--- a/dhctl/pkg/preflight/suites/static.go
+++ b/dhctl/pkg/preflight/suites/static.go
@@ -28,6 +28,8 @@ import (
 type StaticDeps struct {
 	SSHProviderInitializer *providerinitializer.SSHProviderInitializer
 	MetaConfig             *config.MetaConfig
+	InstallConfig          *config.DeckhouseInstaller
+
 	// LegacyMode reflects whether the SSH client uses the legacy clissh
 	// backend. Threaded into RegistryProxy for the SSH tunnel direction.
 	LegacyMode bool
@@ -46,7 +48,7 @@ func NewStaticSuite(deps StaticDeps, ctx context.Context) (preflight.Suite, erro
 		checks.SSHTunnel(deps.SSHProviderInitializer, deps.GlobalOpts),
 		checks.StaticInstancesSSHCredentials(deps.MetaConfig, deps.SSHProviderInitializer),
 		checks.DeckhouseUser(nodeInterface, deps.GlobalOpts),
-		checks.StaticSystemRequirements(deps.SSHProviderInitializer),
+		checks.StaticSystemRequirements(deps.SSHProviderInitializer, deps.InstallConfig),
 		checks.Python(nodeInterface),
 		checks.RegistryProxy(deps.MetaConfig, deps.SSHProviderInitializer, deps.LegacyMode),
 		checks.Ports(deps.SSHProviderInitializer, deps.GlobalOpts),


### PR DESCRIPTION
## Description

Introduced bundle-specific system requirements for dhctl preflight checks.

The minimum CPU and memory requirements are now selected according to the configured Deckhouse bundle:

* Default bundle: 4 CPU, 7680 MiB RAM;
* Minimal bundle: 2 CPU, 3584 MiB RAM.

The requirements are resolved through a shared helper and applied consistently by both cloud and static system requirement checks.

This change affects only preflight validation. It does not modify runtime resource requirements or change any cluster components.

## Why do we need it, and what problem does it solve?

Previously, dhctl always validated the default system requirements regardless of the selected Deckhouse bundle.

As a result, installations using the Minimal bundle could fail preflight validation even though a smaller resource footprint is expected.

This change allows dhctl to validate system requirements according to the configured bundle while keeping a single source of truth for both cloud and static preflight checks.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: dhctl
type: feature
summary: Added bundle-specific system requirements to preflight validation.
impact_level: default
```