### PR TITLE
[cloud-provider-dvp] Add migration pending metric for D8CloudProviderDVPMigrationPending alert

### DIFF
--- a/modules/030-cloud-provider-dvp/hooks/migration_pending_metric.go
+++ b/modules/030-cloud-provider-dvp/hooks/migration_pending_metric.go
@@ -1,0 +1,193 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook/metrics"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/ptr"
+)
+
+// The D8CloudProviderDVPMigrationPending alert must not fire in clusters managed by
+// Deckhouse Commander until Commander learns to apply the new-format migration
+// resources: the admin cannot act on the alert in that case. Commander management is
+// detected by the kube-system/d8-commander-uuid ConfigMap (created by dhctl in commander
+// mode). Whether Commander already supports the new format is read from the
+// d8-commander-agent/commander-info ConfigMap: flags.cloudProviderNoPCCInputFormatSupported
+// ("1" means supported). The migration marker ConfigMap alone cannot express this, and the
+// support flag lives inside a JSON blob (data.json) that PromQL cannot read, so this hook
+// computes a single metric that the alert consumes directly.
+const (
+	migrationPendingMetricName  = "d8_cloud_provider_dvp_migration_pending"
+	migrationPendingMetricGroup = "D8CloudProviderDVPMigration"
+
+	commanderUUIDNamespace     = "kube-system"
+	commanderUUIDConfigMapName = "d8-commander-uuid"
+
+	commanderInfoNamespace     = "d8-commander-agent"
+	commanderInfoConfigMapName = "commander-info"
+	commanderInfoDataKey       = "data.json"
+	commanderPCCSupportFlag    = "cloudProviderNoPCCInputFormatSupported"
+)
+
+// commanderInfoResult carries the parsed support flag from the commander-info ConfigMap.
+type commanderInfoResult struct {
+	Supported bool `json:"supported"`
+}
+
+// commanderInfoData mirrors the relevant part of commander-info data.json. Flag values are
+// strings ("1"/"0"), not booleans.
+type commanderInfoData struct {
+	Flags map[string]string `json:"flags"`
+}
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	OnAfterHelm: &go_hook.OrderedConfig{Order: 20},
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:       "module_migration_marker",
+			ApiVersion: "v1",
+			Kind:       "ConfigMap",
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{dvpNamespace},
+				},
+			},
+			NameSelector: &types.NameSelector{
+				MatchNames: []string{dvpMigrationConfigMapName},
+			},
+			ExecuteHookOnEvents:          ptr.To(true),
+			ExecuteHookOnSynchronization: ptr.To(true),
+			FilterFunc:                   filterMigrationMarkerConfigMap,
+		},
+		{
+			Name:       "commander_uuid",
+			ApiVersion: "v1",
+			Kind:       "ConfigMap",
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{commanderUUIDNamespace},
+				},
+			},
+			NameSelector: &types.NameSelector{
+				MatchNames: []string{commanderUUIDConfigMapName},
+			},
+			ExecuteHookOnEvents:          ptr.To(true),
+			ExecuteHookOnSynchronization: ptr.To(true),
+			FilterFunc:                   filterCommanderUUIDConfigMap,
+		},
+		{
+			Name:       "commander_info",
+			ApiVersion: "v1",
+			Kind:       "ConfigMap",
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{commanderInfoNamespace},
+				},
+			},
+			NameSelector: &types.NameSelector{
+				MatchNames: []string{commanderInfoConfigMapName},
+			},
+			ExecuteHookOnEvents:          ptr.To(true),
+			ExecuteHookOnSynchronization: ptr.To(true),
+			FilterFunc:                   filterCommanderInfoConfigMap,
+		},
+	},
+}, handleMigrationPendingMetric)
+
+// filterMigrationMarkerConfigMap reports the presence of the migration marker ConfigMap.
+func filterMigrationMarkerConfigMap(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	if obj.GetName() != dvpMigrationConfigMapName {
+		return nil, nil
+	}
+	return obj.GetName(), nil
+}
+
+// filterCommanderUUIDConfigMap reports the presence of the commander-uuid ConfigMap.
+func filterCommanderUUIDConfigMap(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	if obj.GetName() != commanderUUIDConfigMapName {
+		return nil, nil
+	}
+	return obj.GetName(), nil
+}
+
+// filterCommanderInfoConfigMap extracts the cloudProviderNoPCCInputFormatSupported flag from
+// the commander-info ConfigMap. A missing/empty/invalid data.json or flag is treated as "not supported"
+func filterCommanderInfoConfigMap(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	if obj.GetName() != commanderInfoConfigMapName {
+		return nil, nil
+	}
+
+	cm := &corev1.ConfigMap{}
+	if err := sdk.FromUnstructured(obj, cm); err != nil {
+		return nil, err
+	}
+
+	result := commanderInfoResult{Supported: false}
+
+	raw, ok := cm.Data[commanderInfoDataKey]
+	if !ok || raw == "" {
+		return result, nil
+	}
+
+	var data commanderInfoData
+	if err := json.Unmarshal([]byte(raw), &data); err != nil {
+		// fail-closed: unparsable data.json means we cannot confirm support.
+		return result, nil
+	}
+
+	result.Supported = data.Flags[commanderPCCSupportFlag] == "1"
+	return result, nil
+}
+
+func handleMigrationPendingMetric(_ context.Context, input *go_hook.HookInput) error {
+	input.MetricsCollector.Expire(migrationPendingMetricGroup)
+
+	migrationPresent := len(input.Snapshots.Get("module_migration_marker")) > 0
+	if !migrationPresent {
+		return nil
+	}
+
+	commanderManaged := len(input.Snapshots.Get("commander_uuid")) > 0
+
+	commanderNoPCCSupported := false
+	if infoSnaps := input.Snapshots.Get("commander_info"); len(infoSnaps) > 0 {
+		var info commanderInfoResult
+		if err := infoSnaps[0].UnmarshalTo(&info); err != nil {
+			return err
+		}
+		commanderNoPCCSupported = info.Supported
+	}
+
+	if !commanderManaged || commanderNoPCCSupported {
+		input.MetricsCollector.Set(
+			migrationPendingMetricName,
+			1,
+			nil,
+			metrics.WithGroup(migrationPendingMetricGroup),
+		)
+	}
+
+	return nil
+}

--- a/modules/030-cloud-provider-dvp/hooks/migration_pending_metric_test.go
+++ b/modules/030-cloud-provider-dvp/hooks/migration_pending_metric_test.go
@@ -1,0 +1,202 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/utils/ptr"
+
+	"github.com/deckhouse/deckhouse/pkg/metrics-storage/operation"
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("Modules :: cloud-provider-dvp :: hooks :: migration_pending_metric ::", func() {
+	const (
+		migrationMarkerCM = `
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: d8-module-is-migrating
+  namespace: d8-cloud-provider-dvp
+`
+		commanderUUIDCM = `
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: d8-commander-uuid
+  namespace: kube-system
+data:
+  commander-uuid: "00000000-0000-0000-0000-000000000000"
+`
+		commanderInfoSupportedCM = `
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: commander-info
+  namespace: d8-commander-agent
+data:
+  "data.json": |
+    {"flags": {"cloudProviderNoPCCInputFormatSupported": "1"}}
+`
+		commanderInfoNotSupportedCM = `
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: commander-info
+  namespace: d8-commander-agent
+data:
+  "data.json": |
+    {"flags": {"cloudProviderNoPCCInputFormatSupported": "0"}}
+`
+		commanderInfoNoFlagCM = `
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: commander-info
+  namespace: d8-commander-agent
+data:
+  "data.json": |
+    {"flags": {"commanderHAEnabled": "0"}}
+`
+		commanderInfoInvalidCM = `
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: commander-info
+  namespace: d8-commander-agent
+data:
+  "data.json": "not-a-json"
+`
+	)
+
+	f := HookExecutionConfigInit(`{"cloudProviderDvp":{"internal":{}}}`, `{}`)
+
+	assertMetricSet := func(f *HookExecutionConfig) {
+		m := f.MetricsCollector.CollectedMetrics()
+		Expect(m).To(HaveLen(2))
+		Expect(m[0]).To(BeEquivalentTo(operation.MetricOperation{
+			Group:  migrationPendingMetricGroup,
+			Action: operation.ActionExpireMetrics,
+		}))
+		Expect(m[1]).To(BeEquivalentTo(operation.MetricOperation{
+			Name:   migrationPendingMetricName,
+			Value:  ptr.To(1.0),
+			Action: operation.ActionGaugeSet,
+			Group:  migrationPendingMetricGroup,
+		}))
+	}
+
+	assertMetricNotSet := func(f *HookExecutionConfig) {
+		m := f.MetricsCollector.CollectedMetrics()
+		Expect(m).To(HaveLen(1))
+		Expect(m[0]).To(BeEquivalentTo(operation.MetricOperation{
+			Group:  migrationPendingMetricGroup,
+			Action: operation.ActionExpireMetrics,
+		}))
+	}
+
+	Context("No migration marker ConfigMap", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(commanderUUIDCM))
+			f.RunHook()
+		})
+
+		It("does not set the metric", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			assertMetricNotSet(f)
+		})
+	})
+
+	Context("Migration marker present, no Commander (regular cluster)", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(migrationMarkerCM))
+			f.RunHook()
+		})
+
+		It("sets the metric (alert fires)", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			assertMetricSet(f)
+		})
+	})
+
+	Context("Migration marker present, Commander-managed, no commander-info", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(migrationMarkerCM + commanderUUIDCM))
+			f.RunHook()
+		})
+
+		It("does not set the metric (alert suppressed)", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			assertMetricNotSet(f)
+		})
+	})
+
+	Context("Migration marker present, Commander-managed, support flag = 1", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(migrationMarkerCM + commanderUUIDCM + commanderInfoSupportedCM))
+			f.RunHook()
+		})
+
+		It("sets the metric (Commander supports the new format)", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			assertMetricSet(f)
+		})
+	})
+
+	Context("Migration marker present, Commander-managed, support flag = 0", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(migrationMarkerCM + commanderUUIDCM + commanderInfoNotSupportedCM))
+			f.RunHook()
+		})
+
+		It("does not set the metric (alert suppressed)", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			assertMetricNotSet(f)
+		})
+	})
+
+	Context("Migration marker present, Commander-managed, support flag absent", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(migrationMarkerCM + commanderUUIDCM + commanderInfoNoFlagCM))
+			f.RunHook()
+		})
+
+		It("does not set the metric (fail-closed)", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			assertMetricNotSet(f)
+		})
+	})
+
+	Context("Migration marker present, Commander-managed, invalid data.json", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(migrationMarkerCM + commanderUUIDCM + commanderInfoInvalidCM))
+			f.RunHook()
+		})
+
+		It("does not set the metric and does not fail (fail-closed)", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			assertMetricNotSet(f)
+		})
+	})
+})

--- a/modules/030-cloud-provider-dvp/monitoring/prometheus-rules/migration.yaml
+++ b/modules/030-cloud-provider-dvp/monitoring/prometheus-rules/migration.yaml
@@ -2,7 +2,7 @@
   rules:
     - alert: D8CloudProviderDVPMigrationPending
       expr: |
-        max(kube_configmap_info{namespace="d8-cloud-provider-dvp", configmap="d8-module-is-migrating"}) > 0
+        max(d8_cloud_provider_dvp_migration_pending) > 0
       for: 1m
       labels:
         severity_level: "6"


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Added the 'D8CloudProviderDVPMigration/d8_cloud_provider_dvp_migration_pending' metric, which generates the 'D8CloudProviderDVPMigrationPending' alert.

The metric is created in the hook based on the presence of the `d8-cloud-provider-dvp/d8-module-is-migrating` and `kube-system/d8-commander-uuid` ConfigMaps and the content in the `d8-commander-agent/commander-info` ConfigMap; The `cloudProviderNoPCCInputFormatSupported` flag must be activated to indicate that Commander supports the new DVP configuration format from the cloud provider.

After the changes, the need for ConfigMap `d8-cloud-provider-dvp/d8-module-is-migrating` has not disappeared. ConfigMap is used in a validation webhook to understand the state of migration. This has several advantages:

+ Webhook becomes easier: without ConfigMap, you would have to read legacy PCC secret, ModuleConfig, CredentialSecrets, NodeGroups, InstanceClasses — all for each webhook request to understand the migration status
+ Racing. ConfigMap is an atomic sign. IsNewResourcesComplete switches as resources are created one by one. In the window between "ModuleConfig created" and "last InstanceClass created", the status will be unstable

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

The Commander does not currently have support for the new cloud-provider DVP configuration format. The following situation arises: the clusters managed by the commander will not be able to migrate and they will have a `D8CloudProviderDVPMigrationPending` alert that the user will not be able to do anything about until support for new configs is available

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

Not necessarily

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-dvp
type: fix
summary: Added the d8_cloud_provider_dvp_migration_pending metric for the D8CloudProviderDVPMigrationPending alert.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
