### PR TITLE
[node-manager] Deploy webhook TLS secret in the same stage as the CAPI controller deployment .

### DIFF
--- a/modules/040-node-manager/templates/capi-controller-manager/rbac-for-us.yaml
+++ b/modules/040-node-manager/templates/capi-controller-manager/rbac-for-us.yaml
@@ -6,6 +6,8 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "capi-controller-manager")) | nindent 2 }}
   name: capi-controller-manager
   namespace: d8-cloud-instance-manager
+  annotations:
+    werf.io/deploy-on: pre-install,pre-upgrade,pre-rollback
 automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -14,6 +16,8 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "capi-controller-manager")) | nindent 2 }}
   name: capi-controller-manager:leader-election-role
   namespace: d8-cloud-instance-manager
+  annotations:
+    werf.io/deploy-on: pre-install,pre-upgrade,pre-rollback
 rules:
   - apiGroups:
       - ""
@@ -39,6 +43,8 @@ kind: ClusterRole
 metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "capi-controller-manager")) | nindent 2 }}
   name: d8:node-manager:capi-controller-manager:aggregated-manager-role
+  annotations:
+    werf.io/deploy-on: pre-install,pre-upgrade,pre-rollback
 rules: []
 aggregationRule:
   clusterRoleSelectors:
@@ -50,6 +56,8 @@ kind: ClusterRole
 metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "capi-controller-manager")) | nindent 2 }}
   name: d8:node-manager:capi-controller-manager:manager-role
+  annotations:
+    werf.io/deploy-on: pre-install,pre-upgrade,pre-rollback
 rules:
   ## cluster-api/config/rbac/role.yaml
   - apiGroups:
@@ -331,6 +339,8 @@ metadata:
     {{- include "helm_lib_module_labels" (list . (dict "app" "capi-controller-manager")) | nindent 2 }}
   name: capi-controller-manager:leader-election-rolebinding
   namespace: d8-cloud-instance-manager
+  annotations:
+    werf.io/deploy-on: pre-install,pre-upgrade,pre-rollback
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -345,6 +355,8 @@ kind: ClusterRoleBinding
 metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "capi-controller-manager")) | nindent 2 }}
   name: d8:node-manager:capi-controller-manager:aggregated-manager-rolebinding
+  annotations:
+    werf.io/deploy-on: pre-install,pre-upgrade,pre-rollback
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -359,6 +371,8 @@ kind: ClusterRoleBinding
 metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "capi-controller-manager")) | nindent 2 }}
   name: d8:node-manager:capi-controller-manager:manager-rolebinding
+  annotations:
+    werf.io/deploy-on: pre-install,pre-upgrade,pre-rollback
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/modules/040-node-manager/templates/capi-controller-manager/secret-tls.yaml
+++ b/modules/040-node-manager/templates/capi-controller-manager/secret-tls.yaml
@@ -6,6 +6,8 @@ type: kubernetes.io/tls
 metadata:
   name: capi-webhook-tls
   namespace: d8-cloud-instance-manager
+  annotations:
+    werf.io/deploy-on: pre-install,pre-upgrade,pre-rollback
   {{- include "helm_lib_module_labels" (list . (dict "app" "capi-controller-manager")) | nindent 2 }}
 data:
   ca.crt: {{ .Values.nodeManager.internal.capiControllerManagerWebhookCert.ca | b64enc }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Add the `werf.io/deploy-on: pre-install,pre-upgrade,pre-rollback` annotation to the `capi-webhook-tls` secret so it deploys in the same stage as the capi-controller-manager deployment.  
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Without this, the deployment was created in the pre-upgrade stage while its TLS secret only appeared in the later main stage, so the pod could stay unready for stuck waiting to mount a secret that didn't exist yet.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: deploy webhook tls secret in the same stage as the controller deployment.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
