### PR TITLE
Remove changed-images steps for non FE editions

### DIFF
--- a/.github/ci_templates/build.yml
+++ b/.github/ci_templates/build.yml
@@ -36,7 +36,7 @@ runs-on: [self-hosted, large]
 {!{- end }!}
 outputs:
   tests_image_name: ${{ steps.build.outputs.tests_image_name }}
-{!{- if eq $buildType "dev" }!}
+{!{- if and (eq $buildType "dev") (eq $werfEnv "FE") }!}
   changed_count:    ${{ steps.diff.outputs.changed_count }}
   matrix:           ${{ steps.diff.outputs.matrix }}
   changed_compact:  ${{ steps.diff.outputs.changed_compact }}
@@ -368,7 +368,7 @@ steps:
     with:
       name: build_report_${{ env.WERF_ENV }}
       path: images_tags_werf.json
-{!{- if eq $buildType "dev" }!}
+{!{- if and (eq $buildType "dev") (eq $werfEnv "FE") }!}
   - name: Extract images_digests.json
     env:
       DEV_REGISTRY: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_HOST }}

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -1164,9 +1164,6 @@ jobs:
     runs-on: [self-hosted, large]
     outputs:
       tests_image_name: ${{ steps.build.outputs.tests_image_name }}
-      changed_count:    ${{ steps.diff.outputs.changed_count }}
-      matrix:           ${{ steps.diff.outputs.matrix }}
-      changed_compact:  ${{ steps.diff.outputs.changed_compact }}
       tags: ${{ steps.set-pr-tag.outputs.tags }}
     steps:
 
@@ -1555,32 +1552,6 @@ jobs:
         with:
           name: build_report_${{ env.WERF_ENV }}
           path: images_tags_werf.json
-      - name: Extract images_digests.json
-        env:
-          DEV_REGISTRY: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_HOST }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          set -euo pipefail
-          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
-          if [[ ${REPO_SUFFIX} == ${GITHUB_REPOSITORY} ]] ; then
-            IMAGE_TAG="pr${PR_NUMBER}"
-          else
-            IMAGE_TAG="pr${PR_NUMBER}-${REPO_SUFFIX}"
-          fi
-          regctl image get-file "${DEV_REGISTRY}/sys/deckhouse-oss:${IMAGE_TAG}" \
-            /deckhouse/modules/images_digests.json > images_digests.json
-          modules=$(jq 'keys | length' images_digests.json)
-          images=$(jq '[.[] | to_entries[]] | length' images_digests.json)
-          echo "images_digests.json: ${modules} modules, ${images} module images."
-      - name: Compute changed images
-        id: diff
-        env:
-          BUILD_REPORT_PATH:   ./images_tags_werf.json
-          IMAGES_DIGESTS_PATH: ./images_digests.json
-          OUTPUT_CHANGED:      ./changed_images.json
-        run: |
-          python3 .github/scripts/python/changed_images.py
-
       - name: Cleanup workdir
         if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
         run: |
@@ -1604,9 +1575,6 @@ jobs:
     runs-on: [self-hosted, large]
     outputs:
       tests_image_name: ${{ steps.build.outputs.tests_image_name }}
-      changed_count:    ${{ steps.diff.outputs.changed_count }}
-      matrix:           ${{ steps.diff.outputs.matrix }}
-      changed_compact:  ${{ steps.diff.outputs.changed_compact }}
       tags: ${{ steps.set-pr-tag.outputs.tags }}
     steps:
 
@@ -1995,32 +1963,6 @@ jobs:
         with:
           name: build_report_${{ env.WERF_ENV }}
           path: images_tags_werf.json
-      - name: Extract images_digests.json
-        env:
-          DEV_REGISTRY: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_HOST }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          set -euo pipefail
-          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
-          if [[ ${REPO_SUFFIX} == ${GITHUB_REPOSITORY} ]] ; then
-            IMAGE_TAG="pr${PR_NUMBER}"
-          else
-            IMAGE_TAG="pr${PR_NUMBER}-${REPO_SUFFIX}"
-          fi
-          regctl image get-file "${DEV_REGISTRY}/sys/deckhouse-oss:${IMAGE_TAG}" \
-            /deckhouse/modules/images_digests.json > images_digests.json
-          modules=$(jq 'keys | length' images_digests.json)
-          images=$(jq '[.[] | to_entries[]] | length' images_digests.json)
-          echo "images_digests.json: ${modules} modules, ${images} module images."
-      - name: Compute changed images
-        id: diff
-        env:
-          BUILD_REPORT_PATH:   ./images_tags_werf.json
-          IMAGES_DIGESTS_PATH: ./images_digests.json
-          OUTPUT_CHANGED:      ./changed_images.json
-        run: |
-          python3 .github/scripts/python/changed_images.py
-
       - name: Cleanup workdir
         if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
         run: |
@@ -2044,9 +1986,6 @@ jobs:
     runs-on: [self-hosted, large]
     outputs:
       tests_image_name: ${{ steps.build.outputs.tests_image_name }}
-      changed_count:    ${{ steps.diff.outputs.changed_count }}
-      matrix:           ${{ steps.diff.outputs.matrix }}
-      changed_compact:  ${{ steps.diff.outputs.changed_compact }}
       tags: ${{ steps.set-pr-tag.outputs.tags }}
     steps:
 
@@ -2435,32 +2374,6 @@ jobs:
         with:
           name: build_report_${{ env.WERF_ENV }}
           path: images_tags_werf.json
-      - name: Extract images_digests.json
-        env:
-          DEV_REGISTRY: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_HOST }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          set -euo pipefail
-          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
-          if [[ ${REPO_SUFFIX} == ${GITHUB_REPOSITORY} ]] ; then
-            IMAGE_TAG="pr${PR_NUMBER}"
-          else
-            IMAGE_TAG="pr${PR_NUMBER}-${REPO_SUFFIX}"
-          fi
-          regctl image get-file "${DEV_REGISTRY}/sys/deckhouse-oss:${IMAGE_TAG}" \
-            /deckhouse/modules/images_digests.json > images_digests.json
-          modules=$(jq 'keys | length' images_digests.json)
-          images=$(jq '[.[] | to_entries[]] | length' images_digests.json)
-          echo "images_digests.json: ${modules} modules, ${images} module images."
-      - name: Compute changed images
-        id: diff
-        env:
-          BUILD_REPORT_PATH:   ./images_tags_werf.json
-          IMAGES_DIGESTS_PATH: ./images_digests.json
-          OUTPUT_CHANGED:      ./changed_images.json
-        run: |
-          python3 .github/scripts/python/changed_images.py
-
       - name: Cleanup workdir
         if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
         run: |
@@ -2484,9 +2397,6 @@ jobs:
     runs-on: [self-hosted, large]
     outputs:
       tests_image_name: ${{ steps.build.outputs.tests_image_name }}
-      changed_count:    ${{ steps.diff.outputs.changed_count }}
-      matrix:           ${{ steps.diff.outputs.matrix }}
-      changed_compact:  ${{ steps.diff.outputs.changed_compact }}
       tags: ${{ steps.set-pr-tag.outputs.tags }}
     steps:
 
@@ -2875,32 +2785,6 @@ jobs:
         with:
           name: build_report_${{ env.WERF_ENV }}
           path: images_tags_werf.json
-      - name: Extract images_digests.json
-        env:
-          DEV_REGISTRY: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_HOST }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          set -euo pipefail
-          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
-          if [[ ${REPO_SUFFIX} == ${GITHUB_REPOSITORY} ]] ; then
-            IMAGE_TAG="pr${PR_NUMBER}"
-          else
-            IMAGE_TAG="pr${PR_NUMBER}-${REPO_SUFFIX}"
-          fi
-          regctl image get-file "${DEV_REGISTRY}/sys/deckhouse-oss:${IMAGE_TAG}" \
-            /deckhouse/modules/images_digests.json > images_digests.json
-          modules=$(jq 'keys | length' images_digests.json)
-          images=$(jq '[.[] | to_entries[]] | length' images_digests.json)
-          echo "images_digests.json: ${modules} modules, ${images} module images."
-      - name: Compute changed images
-        id: diff
-        env:
-          BUILD_REPORT_PATH:   ./images_tags_werf.json
-          IMAGES_DIGESTS_PATH: ./images_digests.json
-          OUTPUT_CHANGED:      ./changed_images.json
-        run: |
-          python3 .github/scripts/python/changed_images.py
-
       - name: Cleanup workdir
         if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
         run: |
@@ -2924,9 +2808,6 @@ jobs:
     runs-on: [self-hosted, large]
     outputs:
       tests_image_name: ${{ steps.build.outputs.tests_image_name }}
-      changed_count:    ${{ steps.diff.outputs.changed_count }}
-      matrix:           ${{ steps.diff.outputs.matrix }}
-      changed_compact:  ${{ steps.diff.outputs.changed_compact }}
       tags: ${{ steps.set-pr-tag.outputs.tags }}
     steps:
 
@@ -3315,32 +3196,6 @@ jobs:
         with:
           name: build_report_${{ env.WERF_ENV }}
           path: images_tags_werf.json
-      - name: Extract images_digests.json
-        env:
-          DEV_REGISTRY: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_HOST }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          set -euo pipefail
-          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
-          if [[ ${REPO_SUFFIX} == ${GITHUB_REPOSITORY} ]] ; then
-            IMAGE_TAG="pr${PR_NUMBER}"
-          else
-            IMAGE_TAG="pr${PR_NUMBER}-${REPO_SUFFIX}"
-          fi
-          regctl image get-file "${DEV_REGISTRY}/sys/deckhouse-oss:${IMAGE_TAG}" \
-            /deckhouse/modules/images_digests.json > images_digests.json
-          modules=$(jq 'keys | length' images_digests.json)
-          images=$(jq '[.[] | to_entries[]] | length' images_digests.json)
-          echo "images_digests.json: ${modules} modules, ${images} module images."
-      - name: Compute changed images
-        id: diff
-        env:
-          BUILD_REPORT_PATH:   ./images_tags_werf.json
-          IMAGES_DIGESTS_PATH: ./images_digests.json
-          OUTPUT_CHANGED:      ./changed_images.json
-        run: |
-          python3 .github/scripts/python/changed_images.py
-
       - name: Cleanup workdir
         if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
         run: |
@@ -3364,9 +3219,6 @@ jobs:
     runs-on: [self-hosted, large]
     outputs:
       tests_image_name: ${{ steps.build.outputs.tests_image_name }}
-      changed_count:    ${{ steps.diff.outputs.changed_count }}
-      matrix:           ${{ steps.diff.outputs.matrix }}
-      changed_compact:  ${{ steps.diff.outputs.changed_compact }}
       tags: ${{ steps.set-pr-tag.outputs.tags }}
     steps:
 
@@ -3754,32 +3606,6 @@ jobs:
         with:
           name: build_report_${{ env.WERF_ENV }}
           path: images_tags_werf.json
-      - name: Extract images_digests.json
-        env:
-          DEV_REGISTRY: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_HOST }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          set -euo pipefail
-          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
-          if [[ ${REPO_SUFFIX} == ${GITHUB_REPOSITORY} ]] ; then
-            IMAGE_TAG="pr${PR_NUMBER}"
-          else
-            IMAGE_TAG="pr${PR_NUMBER}-${REPO_SUFFIX}"
-          fi
-          regctl image get-file "${DEV_REGISTRY}/sys/deckhouse-oss:${IMAGE_TAG}" \
-            /deckhouse/modules/images_digests.json > images_digests.json
-          modules=$(jq 'keys | length' images_digests.json)
-          images=$(jq '[.[] | to_entries[]] | length' images_digests.json)
-          echo "images_digests.json: ${modules} modules, ${images} module images."
-      - name: Compute changed images
-        id: diff
-        env:
-          BUILD_REPORT_PATH:   ./images_tags_werf.json
-          IMAGES_DIGESTS_PATH: ./images_digests.json
-          OUTPUT_CHANGED:      ./changed_images.json
-        run: |
-          python3 .github/scripts/python/changed_images.py
-
       - name: Cleanup workdir
         if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
         run: |


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Remove changed-images steps for non FE editions

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Remove changed-images steps for non FE editions
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
