### PR TITLE
[multitenancy-manager][docs] fix grantedResource.apiGroup in GrantableClusterResourceDefinition examples

### DIFF
--- a/docs/documentation/pages/admin/configuration/multitenancy/USAGE.md
+++ b/docs/documentation/pages/admin/configuration/multitenancy/USAGE.md
@@ -323,7 +323,7 @@ metadata:
   name: storageclasses
 spec:
   grantedResource:
-    apiVersion: storage.k8s.io/v1
+    apiGroup: storage.k8s.io
     kind: StorageClass
   enforcement: Managed
   defaultAvailability: All

--- a/docs/documentation/pages/admin/configuration/multitenancy/USAGE_RU.md
+++ b/docs/documentation/pages/admin/configuration/multitenancy/USAGE_RU.md
@@ -322,7 +322,7 @@ metadata:
   name: storageclasses
 spec:
   grantedResource:
-    apiVersion: storage.k8s.io/v1
+    apiGroup: storage.k8s.io
     kind: StorageClass
   enforcement: Managed
   defaultAvailability: All

--- a/docs/site/pages/virtualization-platform/documentation/admin/platform-management/access-control/PROJECTS.md
+++ b/docs/site/pages/virtualization-platform/documentation/admin/platform-management/access-control/PROJECTS.md
@@ -340,7 +340,7 @@ metadata:
   name: storageclasses
 spec:
   grantedResource:
-    apiVersion: storage.k8s.io/v1
+    apiGroup: storage.k8s.io
     kind: StorageClass
   enforcement: Managed
   defaultAvailability: All

--- a/docs/site/pages/virtualization-platform/documentation/admin/platform-management/access-control/PROJECTS_RU.md
+++ b/docs/site/pages/virtualization-platform/documentation/admin/platform-management/access-control/PROJECTS_RU.md
@@ -341,7 +341,7 @@ metadata:
   name: storageclasses
 spec:
   grantedResource:
-    apiVersion: storage.k8s.io/v1
+    apiGroup: storage.k8s.io
     kind: StorageClass
   enforcement: Managed
   defaultAvailability: All

--- a/modules/160-multitenancy-manager/docs/USAGE.md
+++ b/modules/160-multitenancy-manager/docs/USAGE.md
@@ -338,7 +338,7 @@ metadata:
   name: storageclasses
 spec:
   grantedResource:
-    apiVersion: storage.k8s.io/v1
+    apiGroup: storage.k8s.io
     kind: StorageClass
   enforcement: Managed
   defaultAvailability: All

--- a/modules/160-multitenancy-manager/docs/USAGE_RU.md
+++ b/modules/160-multitenancy-manager/docs/USAGE_RU.md
@@ -341,7 +341,7 @@ metadata:
   name: storageclasses
 spec:
   grantedResource:
-    apiVersion: storage.k8s.io/v1
+    apiGroup: storage.k8s.io
     kind: StorageClass
   enforcement: Managed
   defaultAvailability: All


### PR DESCRIPTION
## Description

Fixed `GrantableClusterResourceDefinition` examples: replaced invalid `spec.grantedResource.apiVersion` with the correct `apiGroup`.

## Why do we need it, and what problem does it solve?

Documentation examples used `apiVersion: storage.k8s.io/v1` instead of `apiGroup: storage.k8s.io`. Per the CRD, the field is `apiGroup`; the version is resolved via discovery. The typo could lead users to copy an invalid manifest.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: multitenancy-manager
type: fix
summary: Fix GrantableClusterResourceDefinition docs — use grantedResource.apiGroup instead of apiVersion.
impact_level: low