### PR TITLE
[dhctl] Implement per-step bashible state

### DIFF
--- a/candi/bashible/bashible.sh.tpl
+++ b/candi/bashible/bashible.sh.tpl
@@ -343,6 +343,7 @@ function main() {
   export BOOTSTRAP_DIR="/var/lib/bashible"
   export BUNDLE_STEPS_DIR="$BOOTSTRAP_DIR/bundle_steps"
   export BUNDLE_STEPS_STATUS_DIR="$BOOTSTRAP_DIR/bundle_steps_status"
+  export BUNDLE_STEPS_CONFLICT_FILE="$BOOTSTRAP_DIR/bundle_steps_conflict"
   export CONFIGURATION_CHECKSUM_FILE="$BOOTSTRAP_DIR/configuration_checksum"
   export UPTIME_FILE="$BOOTSTRAP_DIR/uptime"
   export CONFIGURATION_CHECKSUM="{{ .configurationChecksum | default "" }}"
@@ -572,6 +573,11 @@ function main() {
         >&2 echo "ERROR: Recorded checksum: ${step_recorded_checksum}, current checksum: ${step_checksum}."
         >&2 echo "ERROR: Resuming would re-run it against a node that may already reflect its old version, which is unsafe."
         >&2 echo "ERROR: Please run 'dhctl bootstrap-phase abort' to clean up, then start a fresh bootstrap."
+        # dhctl reads this back over SSH to tell apart this fatal, unresolvable
+        # condition from an ordinary transient failure, so it can stop
+        # retrying the whole bundle immediately instead of burning through
+        # its retry budget on a mismatch that will never fix itself.
+        printf '%s\n' "$step_base" >> "$BUNDLE_STEPS_CONFLICT_FILE"
         bb-bashible-ready-steps-failed "$step_base"
         return 1
       fi

--- a/candi/bashible/bashible.sh.tpl
+++ b/candi/bashible/bashible.sh.tpl
@@ -342,6 +342,7 @@ function main() {
   export HOME="/var/lib/bashible"
   export BOOTSTRAP_DIR="/var/lib/bashible"
   export BUNDLE_STEPS_DIR="$BOOTSTRAP_DIR/bundle_steps"
+  export BUNDLE_STEPS_STATUS_DIR="$BOOTSTRAP_DIR/bundle_steps_status"
   export CONFIGURATION_CHECKSUM_FILE="$BOOTSTRAP_DIR/configuration_checksum"
   export UPTIME_FILE="$BOOTSTRAP_DIR/uptime"
   export CONFIGURATION_CHECKSUM="{{ .configurationChecksum | default "" }}"
@@ -531,6 +532,43 @@ function main() {
     # parsed by dhctl-side measurement tooling to map where bashible time goes.
     local start_ts
     start_ts=$(date +%s.%N)
+
+{{- if eq .runType "ClusterBootstrap" }}
+    # Bootstrap-only resume support: a step is skipped if it already succeeded
+    # with identical content in a previous bashible.sh run on this node (dhctl
+    # re-seeds this directory from its own state before re-executing the
+    # bundle, so this also survives the node being re-provisioned between
+    # bootstrap attempts).
+    #
+    # If a marker exists but its checksum does NOT match (the step ran before
+    # with different content, e.g. cluster config or dhctl version changed
+    # between bootstrap attempts), it is unsafe to just silently re-run it:
+    # the node may already reflect the OLD version of this step, and later
+    # steps may depend on that. Fail loudly instead of retrying blindly.
+    local step_status_file="$BUNDLE_STEPS_STATUS_DIR/$step_base"
+    local step_checksum=""
+    if [ -f "$step" ]; then
+      step_checksum="$(sha256sum "$step" | awk '{print $1}')"
+    fi
+    if [ -n "$step_checksum" ] && [ -f "$step_status_file" ]; then
+      local step_recorded_checksum
+      step_recorded_checksum="$(cat "$step_status_file")"
+      if [ "$step_recorded_checksum" == "$step_checksum" ]; then
+        echo ===
+        echo "=== Step: $step (already completed, skipping)"
+        echo ===
+        return 0
+      else
+        >&2 echo "ERROR: Step ${step_base} already completed in a previous bootstrap attempt with different content."
+        >&2 echo "ERROR: Recorded checksum: ${step_recorded_checksum}, current checksum: ${step_checksum}."
+        >&2 echo "ERROR: Resuming would re-run it against a node that may already reflect its old version, which is unsafe."
+        >&2 echo "ERROR: Please run 'dhctl bootstrap-phase abort' to clean up, then start a fresh bootstrap."
+        bb-bashible-ready-steps-failed "$step_base"
+        return 1
+      fi
+    fi
+{{- end }}
+
     echo ===
     echo === Step: $step
     echo ===
@@ -566,6 +604,13 @@ function main() {
       bb-bashible-ready-steps-failed "$step_base"
     done
     cp -f "$per_step_log" "$step_log" 2>/dev/null || true
+
+{{- if eq .runType "ClusterBootstrap" }}
+    if [ -n "$step_checksum" ]; then
+      mkdir -p "$BUNDLE_STEPS_STATUS_DIR"
+      printf '%s' "$step_checksum" > "$step_status_file"
+    fi
+{{- end }}
 
     bb-telemetry-end-span "$span_ctx" "$step_base"
 

--- a/candi/bashible/bashible.sh.tpl
+++ b/candi/bashible/bashible.sh.tpl
@@ -559,6 +559,15 @@ function main() {
         echo ===
         return 0
       else
+        # dhctl attributes all subsequent output to whichever step last
+        # printed an "=== Step: ..." header (see bashibleStepsHeaderRegexp in
+        # lib-connection), which otherwise would still be the PREVIOUS
+        # (skipped) step here since this branch fails without ever running
+        # the step. Emit our own header first so this failure is correctly
+        # attributed to this step, not the last one that happened to skip.
+        echo ===
+        echo "=== Step: $step"
+        echo ===
         >&2 echo "ERROR: Step ${step_base} already completed in a previous bootstrap attempt with different content."
         >&2 echo "ERROR: Recorded checksum: ${step_recorded_checksum}, current checksum: ${step_checksum}."
         >&2 echo "ERROR: Resuming would re-run it against a node that may already reflect its old version, which is unsafe."

--- a/dhctl/cmd/dhctl/commands/config.go
+++ b/dhctl/cmd/dhctl/commands/config.go
@@ -67,7 +67,7 @@ func DefineRenderBashibleBundle(cmd *kingpin.CmdClause, opts *options.Options) *
 			return err
 		}
 
-		templateData, err := metaConfig.ConfigForBashibleBundleTemplate(ctx, "$MY_IP")
+		templateData, err := metaConfig.ConfigForBashibleBundleTemplate(ctx, "$MY_IP", nil)
 		if err != nil {
 			return err
 		}
@@ -128,7 +128,7 @@ func DefineRenderMasterBootstrap(cmd *kingpin.CmdClause, opts *options.Options) 
 		templateController := template.NewTemplateController(opts.Render.BashibleBundleDir)
 		l.Info(fmt.Sprintf("Bundle Dir: %q", templateController.TmpDir))
 
-		return template.PrepareBootstrap(ctx, templateController, "127.0.0.1", metaConfig, &opts.Global)
+		return template.PrepareBootstrap(ctx, templateController, "127.0.0.1", metaConfig, &opts.Global, nil)
 	}
 
 	return cmd.Action(func(c *kingpin.ParseContext) error {

--- a/dhctl/pkg/config/meta.go
+++ b/dhctl/pkg/config/meta.go
@@ -731,7 +731,16 @@ func (m *MetaConfig) ClusterConfigMap() (map[string]interface{}, error) {
 	return out, nil
 }
 
-func (m *MetaConfig) ConfigForBashibleBundleTemplate(ctx context.Context, nodeIP string) (map[string]interface{}, error) {
+// ConfigForBashibleBundleTemplate builds the template data map for rendering
+// bashible bundle steps. pkiProvider supplies the registry CA/user PKI; pass
+// nil to generate a fresh one each call (e.g. one-off preview/debug
+// rendering). Callers that need PKI stable across repeated calls (resumed
+// bootstrap attempts) should pass a provider that caches its result.
+func (m *MetaConfig) ConfigForBashibleBundleTemplate(ctx context.Context, nodeIP string, pkiProvider registry.PKIProvider) (map[string]interface{}, error) {
+	if pkiProvider == nil {
+		pkiProvider = registry.GeneratePKI
+	}
+
 	data := make(map[string]interface{}, len(m.ClusterConfig))
 
 	for key, value := range m.ClusterConfig {
@@ -798,7 +807,7 @@ func (m *MetaConfig) ConfigForBashibleBundleTemplate(ctx context.Context, nodeIP
 	// Registry
 	registryContext, err := m.Registry.
 		Manifest().
-		BashibleContext(registry.GeneratePKI)
+		BashibleContext(pkiProvider)
 	if err != nil {
 		return nil, fmt.Errorf("create registry bashible context: %s", err)
 	}

--- a/dhctl/pkg/config/meta_test.go
+++ b/dhctl/pkg/config/meta_test.go
@@ -379,7 +379,7 @@ func TestConfigForBashibleBundleTemplateClusterMasterEndpoints(t *testing.T) {
 		},
 	}
 
-	data, err := cfg.ConfigForBashibleBundleTemplate(t.Context(), "10.0.0.2")
+	data, err := cfg.ConfigForBashibleBundleTemplate(t.Context(), "10.0.0.2", nil)
 	require.NoError(t, err)
 
 	endpoints, ok := data["clusterMasterEndpoints"].([]map[string]any)
@@ -403,7 +403,7 @@ func TestConfigForBashibleBundleTemplateDefaultClusterMasterEndpoints(t *testing
 	require.NoError(t, os.WriteFile(mingetPath, expectedMingetBytes, 0o600))
 	t.Setenv("DHCTL_MINGET_PATH", mingetPath)
 
-	data, err := cfg.ConfigForBashibleBundleTemplate(t.Context(), "10.0.0.2")
+	data, err := cfg.ConfigForBashibleBundleTemplate(t.Context(), "10.0.0.2", nil)
 	require.NoError(t, err)
 
 	endpoints, ok := data["clusterMasterEndpoints"].([]map[string]any)

--- a/dhctl/pkg/operations/bootstrap/bashible/runner.go
+++ b/dhctl/pkg/operations/bootstrap/bashible/runner.go
@@ -42,6 +42,9 @@ const (
 	// bundleStepsStatusDir must match STEPS_STATUS_DIR set up in bashible.sh.tpl.
 	bundleStepsStatusDir = "/var/lib/bashible/bundle_steps_status"
 
+	// bundleStepsDir must match BUNDLE_STEPS_DIR set up in bashible.sh.tpl.
+	bundleStepsDir = "/var/lib/bashible/bundle_steps"
+
 	stepsStatusPollInterval = 15 * time.Second
 )
 
@@ -334,6 +337,17 @@ func (r *Runner) attemptExecuteBundle(
 	stopStepsStatusPolling := r.startStepsStatusPolling(ctx, params.OnStepsStatus)
 	defer stopStepsStatusPolling()
 
+	// The uploaded tar is only ever extracted on top of whatever is already
+	// on the node ("tar x" adds/overwrites, it never deletes) and bashible.sh
+	// itself only clears this directory on the non-local (converge) path.
+	// Without this, a step removed from the current build (e.g. renamed,
+	// deleted, or reordered) keeps lingering in bundle_steps and keeps
+	// getting executed on every future attempt, forever out of sync with
+	// what dhctl actually built.
+	if err := r.clearBundleStepsDir(ctx); err != nil {
+		return err
+	}
+
 	bundleCmd := r.nodeInterface.UploadScript("bashible.sh", "--local")
 	bundleCmd.WithCleanupAfterExec(false)
 	bundleCmd.Sudo()
@@ -351,6 +365,21 @@ func (r *Runner) attemptExecuteBundle(
 
 		return fmt.Errorf("bundle '%s' error: %w", bundleDir, err)
 	}
+	return nil
+}
+
+// clearBundleStepsDir removes any step files left over from a previous
+// bundle upload, so the directory ends up containing exactly what the
+// current build produced once the fresh tar is extracted on top of it.
+func (r *Runner) clearBundleStepsDir(ctx context.Context) error {
+	cmd := r.nodeInterface.Command("rm", "-rf", bundleStepsDir)
+	cmd.Sudo(ctx)
+	cmd.WithTimeout(10 * time.Second)
+
+	if err := cmd.Run(ctx); err != nil {
+		return fmt.Errorf("clear bundle steps dir: %w", err)
+	}
+
 	return nil
 }
 

--- a/dhctl/pkg/operations/bootstrap/bashible/runner.go
+++ b/dhctl/pkg/operations/bootstrap/bashible/runner.go
@@ -45,6 +45,10 @@ const (
 	// bundleStepsDir must match BUNDLE_STEPS_DIR set up in bashible.sh.tpl.
 	bundleStepsDir = "/var/lib/bashible/bundle_steps"
 
+	// bundleStepsConflictFile must match BUNDLE_STEPS_CONFLICT_FILE set up in
+	// bashible.sh.tpl.
+	bundleStepsConflictFile = "/var/lib/bashible/bundle_steps_conflict"
+
 	stepsStatusPollInterval = 15 * time.Second
 )
 
@@ -52,6 +56,29 @@ var (
 	stepsStatusNameRe     = regexp.MustCompile(`^[A-Za-z0-9_.-]+$`)
 	stepsStatusChecksumRe = regexp.MustCompile(`^[a-f0-9]{64}$`)
 )
+
+// ErrBashibleStepsConflict marks a bundle execution failure as caused by a
+// step whose content changed since it last completed successfully on this
+// node (see bb-run-step's checksum check in bashible.sh.tpl). Retrying the
+// whole bundle again would just hit the exact same mismatch every time, so
+// callers should stop instead of exhausting their retry budget on it.
+var ErrBashibleStepsConflict = errors.New("bashible bundle steps changed since a previous bootstrap attempt")
+
+func newStepsConflictError(steps []string) error {
+	return fmt.Errorf(
+		"%w: %s already completed on this node in a previous bootstrap attempt with different content.\n"+
+			"Resuming would re-run it against a node that already applied its old version, which is unsafe.\n"+
+			"Please run \"dhctl bootstrap-phase abort\" to clean up, then start a fresh bootstrap.",
+		ErrBashibleStepsConflict, strings.Join(steps, ", "),
+	)
+}
+
+// stepsConflictBreakPredicate stops the bundle-execution retry loop as soon
+// as it hits ErrBashibleStepsConflict: every other attempt would just fail
+// with the exact same unresolvable mismatch, so retrying is pure waste.
+func stepsConflictBreakPredicate(err error) bool {
+	return errors.Is(err, ErrBashibleStepsConflict)
+}
 
 var (
 	alreadyRunDefaultOpts      = retry.AttemptsWithWaitOpts(300, 1*time.Second)
@@ -307,6 +334,7 @@ func (r *Runner) ExecuteBundle(ctx context.Context, params ExecuteBundleParams) 
 	}
 
 	return retry.NewLoopWithParams(loopParams).
+		BreakIf(stepsConflictBreakPredicate).
 		RunContext(ctx, func() error {
 			// we do not need to restart tunnel because we have HealthMonitor
 			logger := r.logger
@@ -359,6 +387,10 @@ func (r *Runner) attemptExecuteBundle(
 	r.reportStepsStatus(ctx, params.OnStepsStatus)
 
 	if err != nil {
+		if conflictedSteps, cErr := r.checkStepsConflict(ctx); cErr == nil && len(conflictedSteps) > 0 {
+			return newStepsConflictError(conflictedSteps)
+		}
+
 		if ee, ok := errors.AsType[*exec.ExitError](err); ok {
 			return fmt.Errorf("bundle '%s' error: %w\nstderr: %s", bundleDir, err, string(ee.Stderr))
 		}
@@ -370,9 +402,11 @@ func (r *Runner) attemptExecuteBundle(
 
 // clearBundleStepsDir removes any step files left over from a previous
 // bundle upload, so the directory ends up containing exactly what the
-// current build produced once the fresh tar is extracted on top of it.
+// current build produced once the fresh tar is extracted on top of it. It
+// also clears any leftover steps-conflict marker, so a conflict resolved
+// since the last attempt (e.g. a fresh node) isn't reported again.
 func (r *Runner) clearBundleStepsDir(ctx context.Context) error {
-	cmd := r.nodeInterface.Command("rm", "-rf", bundleStepsDir)
+	cmd := r.nodeInterface.Command("rm", "-rf", bundleStepsDir, bundleStepsConflictFile)
 	cmd.Sudo(ctx)
 	cmd.WithTimeout(10 * time.Second)
 
@@ -381,6 +415,31 @@ func (r *Runner) clearBundleStepsDir(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// checkStepsConflict reads the marker bb-run-step writes when it detects a
+// step's content changed since it last completed successfully on this node
+// (a checksum mismatch against bundle_steps_status). A missing/empty marker
+// is not an error, it just means no conflict was hit.
+func (r *Runner) checkStepsConflict(ctx context.Context) ([]string, error) {
+	cmd := r.nodeInterface.Command("sh", "-c", fmt.Sprintf("cat %s 2>/dev/null || true", bundleStepsConflictFile))
+	cmd.Sudo(ctx)
+	cmd.WithTimeout(10 * time.Second)
+
+	stdout, _, err := cmd.Output(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("check bashible bundle steps conflict: %w", err)
+	}
+
+	var steps []string
+	for _, line := range strings.Split(string(stdout), "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			steps = append(steps, line)
+		}
+	}
+
+	return steps, nil
 }
 
 // startStepsStatusPolling periodically reports the node's current steps

--- a/dhctl/pkg/operations/bootstrap/bashible/runner.go
+++ b/dhctl/pkg/operations/bootstrap/bashible/runner.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os/exec"
+	"regexp"
 	"strings"
 	"time"
 
@@ -37,6 +38,16 @@ import (
 
 const (
 	endPipelineFileMark = app.NodeDeckhouseDirectoryPath + "/first-control-plane-bashible-ran"
+
+	// bundleStepsStatusDir must match STEPS_STATUS_DIR set up in bashible.sh.tpl.
+	bundleStepsStatusDir = "/var/lib/bashible/bundle_steps_status"
+
+	stepsStatusPollInterval = 15 * time.Second
+)
+
+var (
+	stepsStatusNameRe     = regexp.MustCompile(`^[A-Za-z0-9_.-]+$`)
+	stepsStatusChecksumRe = regexp.MustCompile(`^[a-f0-9]{64}$`)
 )
 
 var (
@@ -173,6 +184,84 @@ type ExecuteBundleParams struct {
 	BundleDir     string
 	CommanderMode bool
 	GlobalOpts    *options.GlobalOptions
+
+	// OnStepsStatus, if set, is called with the currently known set of
+	// completed bashible bundle steps (name -> content checksum), both
+	// periodically while the bundle is executing and right after each
+	// execution attempt. It lets the caller persist progress so a later
+	// dhctl run can resume instead of re-running already-completed steps.
+	OnStepsStatus func(ctx context.Context, statuses map[string]string)
+}
+
+// FetchStepsStatus reads the bootstrap-only per-step completion markers
+// (name -> content checksum) that bb-run-step writes into bundleStepsStatusDir
+// on the node. Missing/empty directory is not an error, it just yields an
+// empty map.
+func (r *Runner) FetchStepsStatus(ctx context.Context) (map[string]string, error) {
+	cmd := r.nodeInterface.Command("sh", "-c", fmt.Sprintf(
+		`for f in %s/*; do [ -f "$f" ] && printf '%%s %%s\n' "$(basename "$f")" "$(cat "$f")"; done`,
+		bundleStepsStatusDir,
+	))
+	cmd.Sudo(ctx)
+	cmd.WithTimeout(10 * time.Second)
+
+	stdout, _, err := cmd.Output(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("fetch bashible bundle steps status: %w", err)
+	}
+
+	return parseStepsStatus(string(stdout)), nil
+}
+
+func parseStepsStatus(output string) map[string]string {
+	statuses := make(map[string]string)
+
+	for _, line := range strings.Split(output, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			continue
+		}
+
+		name, checksum := fields[0], fields[1]
+		if !stepsStatusNameRe.MatchString(name) || !stepsStatusChecksumRe.MatchString(checksum) {
+			continue
+		}
+
+		statuses[name] = checksum
+	}
+
+	return statuses
+}
+
+// PushStepsStatus seeds bundleStepsStatusDir on the node with previously
+// remembered (name -> content checksum) markers before bashible.sh runs, so a
+// resumed bootstrap can skip steps that already succeeded with identical
+// content, even if the node was recreated since the markers were recorded.
+func (r *Runner) PushStepsStatus(ctx context.Context, statuses map[string]string) error {
+	if len(statuses) == 0 {
+		return nil
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "mkdir -p %s", bundleStepsStatusDir)
+
+	for name, checksum := range statuses {
+		if !stepsStatusNameRe.MatchString(name) || !stepsStatusChecksumRe.MatchString(checksum) {
+			return fmt.Errorf("invalid bashible step status entry: name=%q checksum=%q", name, checksum)
+		}
+
+		fmt.Fprintf(&b, " && printf '%%s' '%s' > '%s/%s'", checksum, bundleStepsStatusDir, name)
+	}
+
+	cmd := r.nodeInterface.Command("sh", "-c", b.String())
+	cmd.Sudo(ctx)
+	cmd.WithTimeout(30 * time.Second)
+
+	if err := cmd.Run(ctx); err != nil {
+		return fmt.Errorf("push bashible bundle steps status: %w", err)
+	}
+
+	return nil
 }
 
 func (r *Runner) ExecuteBundle(ctx context.Context, params ExecuteBundleParams) error {
@@ -242,6 +331,9 @@ func (r *Runner) attemptExecuteBundle(
 	// we need this, due to not create relay in every attempt, but we need to correct hook data from bashible
 	spanUpdater(span)
 
+	stopStepsStatusPolling := r.startStepsStatusPolling(ctx, params.OnStepsStatus)
+	defer stopStepsStatusPolling()
+
 	bundleCmd := r.nodeInterface.UploadScript("bashible.sh", "--local")
 	bundleCmd.WithCleanupAfterExec(false)
 	bundleCmd.Sudo()
@@ -249,6 +341,9 @@ func (r *Runner) attemptExecuteBundle(
 	bundleDir := "bashible"
 
 	_, err := bundleCmd.ExecuteBundle(ctx, parentDir, bundleDir)
+
+	r.reportStepsStatus(ctx, params.OnStepsStatus)
+
 	if err != nil {
 		if ee, ok := errors.AsType[*exec.ExitError](err); ok {
 			return fmt.Errorf("bundle '%s' error: %w\nstderr: %s", bundleDir, err, string(ee.Stderr))
@@ -257,6 +352,57 @@ func (r *Runner) attemptExecuteBundle(
 		return fmt.Errorf("bundle '%s' error: %w", bundleDir, err)
 	}
 	return nil
+}
+
+// startStepsStatusPolling periodically reports the node's current steps
+// status while a (potentially very long, since a single step retries
+// indefinitely without MAX_RETRIES) bundle execution attempt is in flight, so
+// progress isn't lost if dhctl is interrupted mid-attempt. The returned func
+// stops the polling and must be called once the attempt finishes.
+func (r *Runner) startStepsStatusPolling(ctx context.Context, onStatus func(context.Context, map[string]string)) func() {
+	if onStatus == nil {
+		return func() {}
+	}
+
+	done := make(chan struct{})
+
+	go func() {
+		ticker := time.NewTicker(stepsStatusPollInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-done:
+				return
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				r.reportStepsStatus(ctx, onStatus)
+			}
+		}
+	}()
+
+	return func() {
+		close(done)
+	}
+}
+
+func (r *Runner) reportStepsStatus(ctx context.Context, onStatus func(context.Context, map[string]string)) {
+	if onStatus == nil {
+		return
+	}
+
+	statuses, err := r.FetchStepsStatus(ctx)
+	if err != nil {
+		r.logger.DebugContext(ctx, fmt.Sprintf("failed to fetch bashible bundle steps status: %v", err))
+		return
+	}
+
+	if len(statuses) == 0 {
+		return
+	}
+
+	onStatus(ctx, statuses)
 }
 
 func (r *Runner) cleanupPreviousBashibleIfNeed(ctx context.Context) error {

--- a/dhctl/pkg/operations/bootstrap/bashible/runner_test.go
+++ b/dhctl/pkg/operations/bootstrap/bashible/runner_test.go
@@ -142,3 +142,14 @@ func TestRunner_PushStepsStatus_Success(t *testing.T) {
 	require.Contains(t, captured[0], validChecksum)
 	require.Contains(t, captured[0], "000_step_one")
 }
+
+func TestRunner_ClearBundleStepsDir(t *testing.T) {
+	var captured []string
+	node := newTestNode(t, nil, nil, &captured)
+
+	r := NewRunner(node, slog.Default())
+
+	require.NoError(t, r.clearBundleStepsDir(t.Context()))
+	require.Len(t, captured, 1)
+	require.Equal(t, "rm -rf "+bundleStepsDir, captured[0])
+}

--- a/dhctl/pkg/operations/bootstrap/bashible/runner_test.go
+++ b/dhctl/pkg/operations/bootstrap/bashible/runner_test.go
@@ -1,0 +1,144 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bashible
+
+import (
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	libcon "github.com/deckhouse/lib-connection/pkg"
+	"github.com/deckhouse/lib-connection/pkg/ssh/session"
+	"github.com/deckhouse/lib-connection/pkg/ssh/testssh"
+)
+
+const validChecksum = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+func newTestNode(t *testing.T, commandStdout []byte, commandErr error, captured *[]string) libcon.Interface {
+	t.Helper()
+
+	host := "127.0.0.1"
+	cl := testssh.NewClient(session.NewSession(session.Input{
+		AvailableHosts: []session.Host{{Host: host, Name: "localhost"}},
+	}), nil)
+
+	cl.AddCommandProvider(host, func(_ testssh.Bastion, name string, args ...string) *testssh.Command {
+		if captured != nil {
+			*captured = append(*captured, strings.Join(append([]string{name}, args...), " "))
+		}
+		return testssh.NewCommand(commandStdout).WithErr(commandErr)
+	})
+
+	require.NoError(t, cl.Start(t.Context()))
+
+	return cl
+}
+
+func TestParseStepsStatus(t *testing.T) {
+	cases := []struct {
+		name   string
+		output string
+		want   map[string]string
+	}{
+		{
+			name:   "empty output",
+			output: "",
+			want:   map[string]string{},
+		},
+		{
+			name:   "single entry",
+			output: "000_step_one " + validChecksum + "\n",
+			want:   map[string]string{"000_step_one": validChecksum},
+		},
+		{
+			name: "multiple entries",
+			output: "000_step_one " + validChecksum + "\n" +
+				"001_step_two " + strings.Repeat("b", 64) + "\n",
+			want: map[string]string{
+				"000_step_one": validChecksum,
+				"001_step_two": strings.Repeat("b", 64),
+			},
+		},
+		{
+			name:   "malformed line is skipped",
+			output: "not-enough-fields\n000_step_one " + validChecksum + "\n",
+			want:   map[string]string{"000_step_one": validChecksum},
+		},
+		{
+			name:   "invalid checksum is skipped",
+			output: "000_step_one not-a-checksum\n",
+			want:   map[string]string{},
+		},
+		{
+			name:   "invalid name is skipped",
+			output: "../etc/passwd " + validChecksum + "\n",
+			want:   map[string]string{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, parseStepsStatus(tc.output))
+		})
+	}
+}
+
+func TestRunner_FetchStepsStatus(t *testing.T) {
+	stdout := []byte("000_step_one " + validChecksum + "\n")
+	node := newTestNode(t, stdout, nil, nil)
+
+	r := NewRunner(node, slog.Default())
+
+	statuses, err := r.FetchStepsStatus(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{"000_step_one": validChecksum}, statuses)
+}
+
+func TestRunner_PushStepsStatus_Empty(t *testing.T) {
+	var captured []string
+	node := newTestNode(t, nil, nil, &captured)
+
+	r := NewRunner(node, slog.Default())
+
+	require.NoError(t, r.PushStepsStatus(t.Context(), nil))
+	require.Empty(t, captured, "no command should be issued for an empty statuses map")
+}
+
+func TestRunner_PushStepsStatus_InvalidEntry(t *testing.T) {
+	var captured []string
+	node := newTestNode(t, nil, nil, &captured)
+
+	r := NewRunner(node, slog.Default())
+
+	err := r.PushStepsStatus(t.Context(), map[string]string{"000_step_one": "not-a-checksum"})
+	require.Error(t, err)
+	require.Empty(t, captured, "no command should be issued when an entry fails validation")
+}
+
+func TestRunner_PushStepsStatus_Success(t *testing.T) {
+	var captured []string
+	node := newTestNode(t, nil, nil, &captured)
+
+	r := NewRunner(node, slog.Default())
+
+	err := r.PushStepsStatus(t.Context(), map[string]string{"000_step_one": validChecksum})
+	require.NoError(t, err)
+	require.Len(t, captured, 1)
+	require.Contains(t, captured[0], bundleStepsStatusDir)
+	require.Contains(t, captured[0], validChecksum)
+	require.Contains(t, captured[0], "000_step_one")
+}

--- a/dhctl/pkg/operations/bootstrap/bashible/runner_test.go
+++ b/dhctl/pkg/operations/bootstrap/bashible/runner_test.go
@@ -15,6 +15,7 @@
 package bashible
 
 import (
+	"errors"
 	"log/slog"
 	"strings"
 	"testing"
@@ -151,5 +152,30 @@ func TestRunner_ClearBundleStepsDir(t *testing.T) {
 
 	require.NoError(t, r.clearBundleStepsDir(t.Context()))
 	require.Len(t, captured, 1)
-	require.Equal(t, "rm -rf "+bundleStepsDir, captured[0])
+	require.Equal(t, "rm -rf "+bundleStepsDir+" "+bundleStepsConflictFile, captured[0])
+}
+
+func TestRunner_CheckStepsConflict_None(t *testing.T) {
+	node := newTestNode(t, nil, nil, nil)
+
+	r := NewRunner(node, slog.Default())
+
+	steps, err := r.checkStepsConflict(t.Context())
+	require.NoError(t, err)
+	require.Empty(t, steps)
+}
+
+func TestRunner_CheckStepsConflict_Found(t *testing.T) {
+	node := newTestNode(t, []byte("075_add_failure.sh\n"), nil, nil)
+
+	r := NewRunner(node, slog.Default())
+
+	steps, err := r.checkStepsConflict(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, []string{"075_add_failure.sh"}, steps)
+}
+
+func TestStepsConflictBreakPredicate(t *testing.T) {
+	require.True(t, stepsConflictBreakPredicate(newStepsConflictError([]string{"075_add_failure.sh"})))
+	require.False(t, stepsConflictBreakPredicate(errors.New("some transient error")))
 }

--- a/dhctl/pkg/operations/bootstrap/bashible/steps_status.go
+++ b/dhctl/pkg/operations/bootstrap/bashible/steps_status.go
@@ -1,0 +1,79 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bashible
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// localBundleStepsDir mirrors stepsDir in dhctl/pkg/template/bundle.go
+// ("/var/lib/bashible/bundle_steps"), relative to a rendered bundle's root
+// (templateController.TmpDir).
+const localBundleStepsDir = "var/lib/bashible/bundle_steps"
+
+// VerifyStepsStatus compares previously recorded bashible bundle step
+// checksums (name -> sha256, as saved by dhctl from an earlier bootstrap
+// attempt) against the freshly rendered local bundle in bundleDir. It
+// returns an error naming any step whose content changed since it last
+// completed successfully.
+//
+// A mismatch means the cluster config or dhctl/candi version changed between
+// bootstrap attempts. Silently re-running such a step would apply it against
+// a node that may already reflect its OLD version and later steps may depend
+// on that — unsafe to do automatically, so bootstrap should stop rather than
+// resume.
+func VerifyStepsStatus(bundleDir string, saved map[string]string) error {
+	names := make([]string, 0, len(saved))
+	for name := range saved {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var changed []string
+
+	for _, name := range names {
+		path := filepath.Join(bundleDir, localBundleStepsDir, name)
+
+		content, err := os.ReadFile(path)
+		if err != nil {
+			changed = append(changed, fmt.Sprintf("%s (%v)", name, err))
+			continue
+		}
+
+		sum := sha256.Sum256(content)
+		checksum := hex.EncodeToString(sum[:])
+		if checksum != saved[name] {
+			changed = append(changed, name)
+		}
+	}
+
+	if len(changed) == 0 {
+		return nil
+	}
+
+	return fmt.Errorf(stepsChangedErrorTemplate, strings.Join(changed, ", "))
+}
+
+const stepsChangedErrorTemplate = `Bootstrap cannot safely resume: the following bashible bundle steps already completed in a previous bootstrap attempt, but their content has changed since then: %s.
+
+Resuming would re-run them against a node that already applied their old version, which is unsafe.
+
+Please run "dhctl bootstrap-phase abort" to clean up, then start a fresh bootstrap.`

--- a/dhctl/pkg/operations/bootstrap/bashible/steps_status_test.go
+++ b/dhctl/pkg/operations/bootstrap/bashible/steps_status_test.go
@@ -1,0 +1,71 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bashible
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func writeLocalStep(t *testing.T, bundleDir, name, content string) string {
+	t.Helper()
+
+	path := filepath.Join(bundleDir, localBundleStepsDir, name)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+	return checksumOf(content)
+}
+
+func checksumOf(content string) string {
+	sum := sha256.Sum256([]byte(content))
+	return hex.EncodeToString(sum[:])
+}
+
+func TestVerifyStepsStatus_NoSavedEntries(t *testing.T) {
+	bundleDir := t.TempDir()
+	require.NoError(t, VerifyStepsStatus(bundleDir, nil))
+}
+
+func TestVerifyStepsStatus_UnchangedStepsMatch(t *testing.T) {
+	bundleDir := t.TempDir()
+	checksum := writeLocalStep(t, bundleDir, "000_step_one", "echo hello\n")
+
+	err := VerifyStepsStatus(bundleDir, map[string]string{"000_step_one": checksum})
+	require.NoError(t, err)
+}
+
+func TestVerifyStepsStatus_ChangedContentIsRejected(t *testing.T) {
+	bundleDir := t.TempDir()
+	writeLocalStep(t, bundleDir, "000_step_one", "echo hello\n")
+
+	err := VerifyStepsStatus(bundleDir, map[string]string{"000_step_one": checksumOf("echo something-else\n")})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "000_step_one")
+	require.Contains(t, err.Error(), "bootstrap-phase abort")
+}
+
+func TestVerifyStepsStatus_MissingStepIsRejected(t *testing.T) {
+	bundleDir := t.TempDir()
+
+	err := VerifyStepsStatus(bundleDir, map[string]string{"000_step_one": checksumOf("echo hello\n")})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "000_step_one")
+}

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
@@ -686,6 +686,7 @@ func (b *ClusterBootstrapper) bootstrapKubernetes(ctx context.Context, bctx *boo
 		CommanderMode:          b.CommanderMode,
 		GlobalOpts:             &b.Options.Global,
 		PhasedExecutionContext: b.PhasedExecutionContext,
+		BootstrapState:         bctx.bootstrapState,
 	})
 
 	if err != nil {

--- a/dhctl/pkg/operations/bootstrap/state.go
+++ b/dhctl/pkg/operations/bootstrap/state.go
@@ -19,6 +19,7 @@ package bootstrap
 import (
 	"context"
 
+	"github.com/deckhouse/deckhouse/dhctl/pkg/config/registry"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/state"
 )
 
@@ -26,6 +27,7 @@ const (
 	PostBootstrapResultCacheKey      = "post-bootstrap-result"
 	ManifestCreatedInClusterCacheKey = "tf-state-and-manifests-in-cluster"
 	BashibleStepsStatusCacheKey      = "bashible-bundle-steps-status"
+	RegistryPKICacheKey              = "registry-pki"
 )
 
 type State struct {
@@ -74,6 +76,32 @@ func (s *State) BashibleStepsStatus(ctx context.Context) (map[string]string, err
 	}
 
 	return statuses, nil
+}
+
+// SaveRegistryPKI persists the generated registry CA/user PKI so subsequent
+// bootstrap attempts for the same cluster reuse it instead of generating a
+// new one every process invocation (which would push different credentials
+// than an earlier, possibly interrupted, attempt already used).
+func (s *State) SaveRegistryPKI(ctx context.Context, pki registry.PKI) error {
+	return s.cache.SaveStruct(ctx, RegistryPKICacheKey, pki)
+}
+
+// RegistryPKI loads the previously saved registry PKI. ok is false, with no
+// error, if nothing has been saved yet.
+func (s *State) RegistryPKI(ctx context.Context) (pki registry.PKI, ok bool, err error) {
+	inCache, err := s.cache.InCache(ctx, RegistryPKICacheKey)
+	if err != nil {
+		return registry.PKI{}, false, err
+	}
+	if !inCache {
+		return registry.PKI{}, false, nil
+	}
+
+	if err := s.cache.LoadStruct(ctx, RegistryPKICacheKey, &pki); err != nil {
+		return registry.PKI{}, false, err
+	}
+
+	return pki, true, nil
 }
 
 func (s *State) PostBootstrapScriptResult(ctx context.Context) ([]byte, error) {

--- a/dhctl/pkg/operations/bootstrap/state.go
+++ b/dhctl/pkg/operations/bootstrap/state.go
@@ -88,7 +88,7 @@ func (s *State) SaveRegistryPKI(ctx context.Context, pki registry.PKI) error {
 
 // RegistryPKI loads the previously saved registry PKI. ok is false, with no
 // error, if nothing has been saved yet.
-func (s *State) RegistryPKI(ctx context.Context) (pki registry.PKI, ok bool, err error) {
+func (s *State) RegistryPKI(ctx context.Context) (registry.PKI, bool, error) {
 	inCache, err := s.cache.InCache(ctx, RegistryPKICacheKey)
 	if err != nil {
 		return registry.PKI{}, false, err
@@ -97,6 +97,7 @@ func (s *State) RegistryPKI(ctx context.Context) (pki registry.PKI, ok bool, err
 		return registry.PKI{}, false, nil
 	}
 
+	var pki registry.PKI
 	if err := s.cache.LoadStruct(ctx, RegistryPKICacheKey, &pki); err != nil {
 		return registry.PKI{}, false, err
 	}

--- a/dhctl/pkg/operations/bootstrap/state.go
+++ b/dhctl/pkg/operations/bootstrap/state.go
@@ -25,6 +25,7 @@ import (
 const (
 	PostBootstrapResultCacheKey      = "post-bootstrap-result"
 	ManifestCreatedInClusterCacheKey = "tf-state-and-manifests-in-cluster"
+	BashibleStepsStatusCacheKey      = "bashible-bundle-steps-status"
 )
 
 type State struct {
@@ -47,6 +48,32 @@ func (s *State) SaveManifestsCreated(ctx context.Context) error {
 
 func (s *State) IsManifestsCreated(ctx context.Context) (bool, error) {
 	return s.cache.InCache(ctx, ManifestCreatedInClusterCacheKey)
+}
+
+// SaveBashibleStepsStatus persists the set of bashible bundle steps that have
+// already completed successfully (name -> content checksum), so a later
+// dhctl run can resume the bootstrap bashible pipeline without re-running them.
+func (s *State) SaveBashibleStepsStatus(ctx context.Context, statuses map[string]string) error {
+	return s.cache.SaveStruct(ctx, BashibleStepsStatusCacheKey, statuses)
+}
+
+// BashibleStepsStatus loads the previously saved bashible bundle steps status.
+// It returns an empty map, not an error, if nothing has been saved yet.
+func (s *State) BashibleStepsStatus(ctx context.Context) (map[string]string, error) {
+	inCache, err := s.cache.InCache(ctx, BashibleStepsStatusCacheKey)
+	if err != nil {
+		return nil, err
+	}
+	if !inCache {
+		return map[string]string{}, nil
+	}
+
+	statuses := make(map[string]string)
+	if err := s.cache.LoadStruct(ctx, BashibleStepsStatusCacheKey, &statuses); err != nil {
+		return nil, err
+	}
+
+	return statuses, nil
 }
 
 func (s *State) PostBootstrapScriptResult(ctx context.Context) ([]byte, error) {

--- a/dhctl/pkg/operations/bootstrap/state_test.go
+++ b/dhctl/pkg/operations/bootstrap/state_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/deckhouse/deckhouse/dhctl/pkg/config/registry"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/cache"
 )
 
@@ -42,5 +43,35 @@ func TestState_BashibleStepsStatus_RoundTrip(t *testing.T) {
 
 	got, err := s.BashibleStepsStatus(t.Context())
 	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+func TestState_RegistryPKI_NotFoundWhenNothingSaved(t *testing.T) {
+	s := NewBootstrapState(cache.NewTestCache())
+
+	pki, ok, err := s.RegistryPKI(t.Context())
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Equal(t, registry.PKI{}, pki)
+}
+
+func TestState_RegistryPKI_RoundTrip(t *testing.T) {
+	s := NewBootstrapState(cache.NewTestCache())
+
+	want := registry.PKI{
+		CA: registry.PKICertKey{Cert: "cert-data", Key: "key-data"},
+		ROUser: registry.PKIUser{
+			Name: "ro", Password: "ro-pass", PasswordHash: "ro-hash",
+		},
+		RWUser: registry.PKIUser{
+			Name: "rw", Password: "rw-pass", PasswordHash: "rw-hash",
+		},
+	}
+
+	require.NoError(t, s.SaveRegistryPKI(t.Context(), want))
+
+	got, ok, err := s.RegistryPKI(t.Context())
+	require.NoError(t, err)
+	require.True(t, ok)
 	require.Equal(t, want, got)
 }

--- a/dhctl/pkg/operations/bootstrap/state_test.go
+++ b/dhctl/pkg/operations/bootstrap/state_test.go
@@ -1,0 +1,46 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bootstrap
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/util/cache"
+)
+
+func TestState_BashibleStepsStatus_EmptyWhenNothingSaved(t *testing.T) {
+	s := NewBootstrapState(cache.NewTestCache())
+
+	statuses, err := s.BashibleStepsStatus(t.Context())
+	require.NoError(t, err)
+	require.Empty(t, statuses)
+}
+
+func TestState_BashibleStepsStatus_RoundTrip(t *testing.T) {
+	s := NewBootstrapState(cache.NewTestCache())
+
+	want := map[string]string{
+		"000_step_one": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		"001_step_two": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+	}
+
+	require.NoError(t, s.SaveBashibleStepsStatus(t.Context(), want))
+
+	got, err := s.BashibleStepsStatus(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}

--- a/dhctl/pkg/operations/bootstrap/steps_bashible.go
+++ b/dhctl/pkg/operations/bootstrap/steps_bashible.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app/options"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+	configregistry "github.com/deckhouse/deckhouse/dhctl/pkg/config/registry"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/module/controlplane"
 	dhbashible "github.com/deckhouse/deckhouse/dhctl/pkg/operations/bootstrap/bashible"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/bootstrap/deps"
@@ -108,10 +109,38 @@ func RunBashiblePipeline(ctx context.Context, params *BashiblePipelineParams) er
 	templateController := template.NewTemplateController("")
 	bashible := dhbashible.NewRunner(nodeInterface, logger)
 
+	// The registry CA/user PKI is otherwise regenerated fresh on every call,
+	// which would make bashible bundle steps that embed it (e.g.
+	// 073_init_registry_secrets.sh) differ across bootstrap attempts of the
+	// same cluster. Persist it in dhctl's own state so resumed attempts push
+	// the SAME credentials a partially-bootstrapped node may already have.
+	pkiProvider := configregistry.PKIProvider(func() (configregistry.PKI, error) {
+		if params.BootstrapState != nil {
+			if pki, ok, err := params.BootstrapState.RegistryPKI(ctx); err != nil {
+				return configregistry.PKI{}, err
+			} else if ok {
+				return pki, nil
+			}
+		}
+
+		pki, err := configregistry.GeneratePKI()
+		if err != nil {
+			return configregistry.PKI{}, err
+		}
+
+		if params.BootstrapState != nil {
+			if err := params.BootstrapState.SaveRegistryPKI(ctx, pki); err != nil {
+				logger.WarnContext(ctx, fmt.Sprintf("failed to save registry PKI: %v", err))
+			}
+		}
+
+		return pki, nil
+	})
+
 	err := dhlog.RunProcess(ctx, dhlog.FromContext(ctx), "Preparing bootstrap", func(ctx context.Context) error {
 		dhlog.FromContext(ctx).DebugContext(ctx, fmt.Sprintf("Rendered templates directory %s", templateController.TmpDir))
 
-		if err := template.PrepareBootstrap(ctx, templateController, nodeIP, cfg, globalOpts); err != nil {
+		if err := template.PrepareBootstrap(ctx, templateController, nodeIP, cfg, globalOpts, pkiProvider); err != nil {
 			return fmt.Errorf("prepare bootstrap: %v", err)
 		}
 
@@ -162,7 +191,7 @@ func RunBashiblePipeline(ctx context.Context, params *BashiblePipelineParams) er
 	defer registryPackagesProxyCleanup()
 	params.PhasedExecutionContext.CompleteSubPhase(ctx, phases.InstallKubernetesSubPhaseRegistryPackagesProxy)
 
-	if err = PrepareBashibleBundle(ctx, nodeIP, devicePath, cfg, templateController, globalOpts); err != nil {
+	if err = PrepareBashibleBundle(ctx, nodeIP, devicePath, cfg, templateController, globalOpts, pkiProvider); err != nil {
 		return err
 	}
 	tomb.RegisterOnShutdown("Delete templates temporary directory", func() {
@@ -329,9 +358,10 @@ func PrepareBashibleBundle(
 	metaConfig *config.MetaConfig,
 	controller *template.Controller,
 	globalOpts *options.GlobalOptions,
+	pkiProvider configregistry.PKIProvider,
 ) error {
 	return dhlog.RunProcess(ctx, dhlog.FromContext(ctx), "Prepare Bashible", func(ctx context.Context) error {
-		return template.PrepareBundle(ctx, controller, nodeIP, devicePath, metaConfig, globalOpts)
+		return template.PrepareBundle(ctx, controller, nodeIP, devicePath, metaConfig, globalOpts, pkiProvider)
 	})
 }
 

--- a/dhctl/pkg/operations/bootstrap/steps_bashible.go
+++ b/dhctl/pkg/operations/bootstrap/steps_bashible.go
@@ -57,6 +57,7 @@ type BashiblePipelineParams struct {
 	IsDebug                bool
 	PhasedExecutionContext phases.DefaultPhasedExecutionContext
 	GlobalOpts             *options.GlobalOptions
+	BootstrapState         *State
 }
 
 func (p *BashiblePipelineParams) Validate() error {
@@ -206,10 +207,33 @@ func RunBashiblePipeline(ctx context.Context, params *BashiblePipelineParams) er
 
 	params.PhasedExecutionContext.CompleteSubPhase(ctx, phases.InstallKubernetesSubPhaseModulesPreparation)
 
+	if params.BootstrapState != nil {
+		savedStepsStatus, err := params.BootstrapState.BashibleStepsStatus(ctx)
+		if err != nil {
+			logger.WarnContext(ctx, fmt.Sprintf("failed to load saved bashible bundle steps status: %v", err))
+		} else if len(savedStepsStatus) > 0 {
+			if err := dhbashible.VerifyStepsStatus(templateController.TmpDir, savedStepsStatus); err != nil {
+				return err
+			}
+
+			if err := bashible.PushStepsStatus(ctx, savedStepsStatus); err != nil {
+				logger.WarnContext(ctx, fmt.Sprintf("failed to push saved bashible bundle steps status: %v", err))
+			}
+		}
+	}
+
 	if err := bashible.ExecuteBundle(ctx, dhbashible.ExecuteBundleParams{
 		BundleDir:     templateController.TmpDir,
 		CommanderMode: params.CommanderMode,
 		GlobalOpts:    params.GlobalOpts,
+		OnStepsStatus: func(ctx context.Context, statuses map[string]string) {
+			if params.BootstrapState == nil {
+				return
+			}
+			if err := params.BootstrapState.SaveBashibleStepsStatus(ctx, statuses); err != nil {
+				logger.WarnContext(ctx, fmt.Sprintf("failed to save bashible bundle steps status: %v", err))
+			}
+		},
 	}); err != nil {
 		return err
 	}

--- a/dhctl/pkg/template/bashbooster_test.go
+++ b/dhctl/pkg/template/bashbooster_test.go
@@ -58,7 +58,7 @@ func TestRenderBashBooster(t *testing.T) {
 	}
 	t.Setenv("DHCTL_MINGET_PATH", mingetPath)
 
-	bashibleData, err := metaConfig.ConfigForBashibleBundleTemplate(t.Context(), "10.0.0.2")
+	bashibleData, err := metaConfig.ConfigForBashibleBundleTemplate(t.Context(), "10.0.0.2", nil)
 	if err != nil {
 		t.Fatalf("ConfigForBashibleBundleTemplate error: %v", err)
 	}

--- a/dhctl/pkg/template/bashible_test.go
+++ b/dhctl/pkg/template/bashible_test.go
@@ -81,7 +81,7 @@ func TestRenderBashibleTemplateUsesClusterMasterRPPAddressesForBootstrap(t *test
 	require.NoError(t, os.WriteFile(mingetPath, []byte("test-minget"), 0o600))
 	t.Setenv("DHCTL_MINGET_PATH", mingetPath)
 
-	data, err := metaConfig.ConfigForBashibleBundleTemplate(t.Context(), "10.0.0.2")
+	data, err := metaConfig.ConfigForBashibleBundleTemplate(t.Context(), "10.0.0.2", nil)
 	require.NoError(t, err)
 
 	tplContent, err := os.ReadFile("/deckhouse/candi/bashible/bashible.sh.tpl")

--- a/dhctl/pkg/template/bootstrap.go
+++ b/dhctl/pkg/template/bootstrap.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app/options"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/config/registry"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/telemetry"
 )
 
@@ -34,11 +35,12 @@ func PrepareBootstrap(
 	nodeIP string,
 	metaConfig *config.MetaConfig,
 	globalOptions *options.GlobalOptions,
+	pkiProvider registry.PKIProvider,
 ) error {
 	ctx, span := telemetry.StartSpan(ctx, "PrepareBootstrap")
 	defer span.End()
 
-	bashibleData, err := metaConfig.ConfigForBashibleBundleTemplate(ctx, nodeIP)
+	bashibleData, err := metaConfig.ConfigForBashibleBundleTemplate(ctx, nodeIP, pkiProvider)
 	if err != nil {
 		return err
 	}

--- a/dhctl/pkg/template/bootstrap_test.go
+++ b/dhctl/pkg/template/bootstrap_test.go
@@ -37,7 +37,7 @@ func TestPrepareBootstrapUsesDefaultClusterMasterEndpoints(t *testing.T) {
 	templateController := NewTemplateController("")
 	defer templateController.Close()
 
-	err = PrepareBootstrap(t.Context(), templateController, "127.0.0.1", metaConfig, &options.GlobalOptions{CandiDir: options.DefaultCandiDir})
+	err = PrepareBootstrap(t.Context(), templateController, "127.0.0.1", metaConfig, &options.GlobalOptions{CandiDir: options.DefaultCandiDir}, nil)
 	require.NoError(t, err)
 
 	renderedBootstrap, err := os.ReadFile(filepath.Join(templateController.TmpDir, "bootstrap", "01-bootstrap-prerequisites.sh"))

--- a/dhctl/pkg/template/bundle.go
+++ b/dhctl/pkg/template/bundle.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app/options"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/config/registry"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/module/controlplane"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/telemetry"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/fs"
@@ -71,11 +72,12 @@ func PrepareBundle(
 	devicePath string,
 	metaConfig *config.MetaConfig,
 	globalOptions *options.GlobalOptions,
+	pkiProvider registry.PKIProvider,
 ) error {
 	ctx, span := telemetry.StartSpan(ctx, "PrepareBundle")
 	defer span.End()
 
-	bashibleData, err := metaConfig.ConfigForBashibleBundleTemplate(ctx, nodeIP)
+	bashibleData, err := metaConfig.ConfigForBashibleBundleTemplate(ctx, nodeIP, pkiProvider)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

This PR adds per-step tracking instead:

- Each bundle step, on success, records a checksum of its own rendered content in `/var/lib/bashible/bundle_steps_status/<step>` on the node.
- Before running a step, `bashible.sh` checks this marker: if the checksum matches, the step is skipped.
- dhctl also mirrors this per-step status into its own local state cache (`dhctl/pkg/operations/bootstrap/state.go`), and re-seeds the node from it before each execution attempt — so resume works even if the node's own bundle_steps_status was lost, not just within a single dhctl process.
- If a step's content has *changed* since it last succeeded (recorded checksum ≠ current checksum — e.g. cluster config or dhctl/candi version changed between attempts), dhctl does **not** silently re-run it: silently re-running could apply a different version of that step against a node that already reflects the old one. Instead it aborts immediately (both a cheap local pre-check in Go and an authoritative on-node check in bash) with a clear message telling the operator to run `dhctl bootstrap-phase abort` and start fresh, rather than retrying a condition that can never resolve itself.
- The `bundle_steps` directory on the node is now cleared before every bundle upload, so it always exactly mirrors what dhctl actually built (previously, a step removed from the current build — e.g. renamed/deleted — would linger on the node forever and keep executing on every future attempt, since `tar x` only adds/overwrites and never deletes).
- The registry CA/user PKI (previously regenerated fresh on every dhctl process invocation) is now generated once and persisted in dhctl's state cache, reused on subsequent bootstrap attempts for the same cluster. This was needed to make steps that embed it (e.g. `073_init_registry_secrets.sh`) checksum-stable across resumes, and independently fixes a pre-existing risk of pushing different registry credentials than an earlier, possibly-interrupted attempt already used.
- The bundle-execution retry loop now recognizes the "steps changed, unsafe to resume" condition as fatal and stops immediately instead of burning through its retry budget (up to 100 attempts) hitting the exact same unresolvable mismatch every time.

This does not affect converge or normal node bootstrap — all the new skip/conflict logic in `bashible.sh.tpl` is gated to `runType == "ClusterBootstrap"`, which is only ever set for the `dhctl bootstrap` flow.


## Why do we need it, and what problem does it solve?

Bootstrapping a cluster can take a long time and fail or get interrupted partway through for reasons unrelated to the bootstrap logic itself (flaky network, a transient cloud API error, an operator's Ctrl-C, a dhctl pod restart). Today, resuming after any of these means redoing the entire bashible run from step zero — including PKI generation, package installs, and other slow steps — which is wasteful and, in some cases (e.g. a step that behaves differently once earlier steps have already partially configured the node), can even fail in ways a from-scratch bootstrap wouldn't. This PR lets `dhctl bootstrap` pick up where it left off instead of always starting over, while explicitly refusing to guess when it's unsafe to do so (content changed) rather than silently risking an inconsistent node.


## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: feature
summary: Implement seamless bashible resume and per-step state
impact_level: default
```

```changes
section: candi
type: feature
summary: Implement seamless bashible resume and per-step state
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
