### PR TITLE
[deckhouse] Render documentation PodMonitor only when its CRD is present

### DIFF
--- a/modules/810-documentation/templates/podmonitor.yaml
+++ b/modules/810-documentation/templates/podmonitor.yaml
@@ -1,3 +1,4 @@
+{{- if (.Values.global.discovery.apiVersions | has "monitoring.coreos.com/v1/PodMonitor") }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
@@ -32,3 +33,4 @@ spec:
     matchLabels:
       app: documentation
       app.kubernetes.io/part-of: deckhouse-docs
+{{- end }}


### PR DESCRIPTION
## Description
`modules/810-documentation/templates/podmonitor.yaml` was rendered unconditionally. After `operator-prometheus`, `prometheus` and `loki` were removed from the embedded modules, the `monitoring.coreos.com` CRDs are no longer installed when those modules are absent, so the module's Helm release fails with `no matches for kind "PodMonitor"`, stays in `Error`, and blocks Deckhouse convergence.

This guards the `PodMonitor` on CRD presence (`.Values.global.discovery.apiVersions | has "monitoring.coreos.com/v1/PodMonitor"`), matching modules like `vertical-pod-autoscaler`: it renders when Prometheus is present and is skipped when the CRD is absent.

## Why do we need it, and what problem does it solve?
Without Prometheus the `documentation` module can't install and the cluster never becomes Ready. This is what breaks the `e2e-eks` job on `main` — `dhctl` times out waiting for Deckhouse readiness.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: documentation
type: fix
summary: Render documentation PodMonitor only when its CRD is present
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->

