### PR TITLE
[docs] Update architecture docs code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -122,7 +122,7 @@ csi/                                     @AleksZimin @duckhawk @szhem
 deckhouse-controller/                    @ldmonster
 dhctl/                                   @borg-z @090809
 docs/                                    @z9r5
-docs/documentation/pages/architecture/   @xstayer @z9r5
+docs/documentation/pages/architecture/   @voitenkov @z9r5
 helm_lib/                                @ldmonster
 crds/                                    @z9r5
 openapi/                                 @z9r5


### PR DESCRIPTION
## Description
Reassign review ownership for the architecture documentation section to a new maintainer

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Update codeowners.
impact_level: low
```
