### PR TITLE
[deckhouse] reserve the d8a- prefix for application objects

### DIFF
--- a/modules/002-deckhouse/templates/validation.yaml
+++ b/modules/002-deckhouse/templates/validation.yaml
@@ -152,6 +152,61 @@ spec:
   - Deny
   - Audit
 
+---
+{{- $policyName := "d8a-prefix.deckhouse.io" }}
+apiVersion: {{ include "helm_lib_get_api_version_by_kind" (list . "ValidatingAdmissionPolicy") }}
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: {{ $policyName }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "deckhouse") ) | nindent 2 }}
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ["*"]
+        apiVersions: ["*"]
+        operations:  ["CREATE", "UPDATE", "DELETE"]
+        resources:   ["*"]
+  matchConditions:
+    - name: 'exclude-groups'
+      expression: '!(["system:nodes", "system:serviceaccounts:kube-system", "system:serviceaccounts:d8-system", "system:serviceaccounts:d8-cni-cilium"].exists(e, (e in request.userInfo.groups)))'
+    - name: 'exclude-users'
+      expression: '!(["system:sudouser", "system:apiserver", "system:kube-controller-manager", "system:kube-scheduler", "system:volume-scheduler", "dhctl"].exists(e, (e == request.userInfo.username)))'
+    # exclude SA from namespaces prefixed with `d8-`
+    # this is required for cert-manager to issue d8a-certificates
+    - name: 'exclude-d8-namespaces'
+      expression: '!(["system:serviceaccount:d8-"].exists(e, (request.userInfo.username.startsWith(e))))'
+    # exclude SA from any namespace which name's starting with `d8a-`
+    - name: 'exclude-application-serviceaccounts'
+      expression: '!(request.userInfo.username.startsWith("system:serviceaccount:") && request.userInfo.username.contains(":d8a-"))'
+    # allow users to delete application pods
+    - name: 'exclude-delete-pods-operations'
+      expression: '!(request.operation == "DELETE" && request.resource.resource == "pods")'
+  validations:
+    # deny all operations with any objects with `d8a-` prefix, except for Pods deletions
+    - expression: |
+        !(
+          (has(object.metadata) && has(object.metadata.name) && object.metadata.name.startsWith("d8a-")) ||
+          (has(oldObject.metadata) && has(oldObject.metadata.name) && oldObject.metadata.name.startsWith("d8a-"))
+        )
+      messageExpression: "'Creating, updating and deleting objects with an application prefix is forbidden'"
+      reason: Forbidden
+  auditAnnotations:
+    - key: 'source-user'
+      valueExpression: "'User: ' + string(request.userInfo.username) + ' tries to change object with an application prefix'"
+
+---
+apiVersion: {{ include "helm_lib_get_api_version_by_kind" (list . "ValidatingAdmissionPolicyBinding") }}
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: {{ $policyName }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "deckhouse") ) | nindent 2 }}
+spec:
+  policyName: {{ $policyName }}
+  validationActions:
+  - Deny
+  - Audit
+
 {{- if ne .Values.global.deckhouseVersion "dev" }}
 
 {{- $policyName := "label-objects.deckhouse.io" }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Add a `ValidatingAdmissionPolicy` and its binding `d8a-prefix.deckhouse.io` to the `deckhouse` module. It denies `CREATE`/`UPDATE`/`DELETE` of any object whose `metadata.name` starts with `d8a-`, for every requester except the platform's own identities. It is a faithful clone of the existing `d8ms-prefix.deckhouse.io` policy in the same file (`modules/002-deckhouse/templates/validation.yaml`), with the reserved prefix changed from `d8ms-` to `d8a-`. It does not touch critical cluster components.

The allow-list is kept identical to the `d8ms-` policy: system groups/users, any ServiceAccount in a `d8-*` namespace (this covers `system:serviceaccount:d8-system:deckhouse`, which renders and applies application resources, and cert-manager issuing `d8a-` secrets), any ServiceAccount in a `d8a-*` namespace, and a carve-out that still lets users delete application pods.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

The `d8a-` prefix is reserved for Kubernetes objects created by Deckhouse Application packages (their rendered resources are named `d8a-<instance>-...`). This policy prevents any non-platform requester from creating, updating or deleting objects under that reserved prefix, so users cannot squat or spoof platform-owned application resources. It is the cluster-side counterpart of the build-time check the `d8 package` linter already enforces on application authors.

### Manual testing

Verified on a cluster running this change, run as the cluster admin (`kubernetes-admin`, a cluster-admin that is not in the policy's exempt list). The only impersonation is the platform ServiceAccount, used to show it is exempt.

```console
# a d8a- object is rejected — even for a cluster-admin
$ k create configmap d8a-verify
error: failed to create configmap: configmaps "d8a-verify" is forbidden: ValidatingAdmissionPolicy 'd8a-prefix.deckhouse.io' with binding 'd8a-prefix.deckhouse.io' denied request: Creating, updating and deleting objects with an application prefix is forbidden

# a plain object is unaffected
$ k create configmap verify-normal
configmap/verify-normal created

# the platform ServiceAccount may create d8a- objects (so application installs are not blocked)
$ k --as=system:serviceaccount:d8-system:deckhouse create configmap d8a-verify
configmap/d8a-verify created

# deleting a d8a- object is rejected too
$ k delete configmap d8a-verify
Error from server (Forbidden): configmaps "d8a-verify" is forbidden: ValidatingAdmissionPolicy 'd8a-prefix.deckhouse.io' with binding 'd8a-prefix.deckhouse.io' denied request: Creating, updating and deleting objects with an application prefix is forbidden

# cleanup (as the exempt platform ServiceAccount)
$ k --as=system:serviceaccount:d8-system:deckhouse delete configmap d8a-verify verify-normal
configmap "d8a-verify" deleted from default namespace
configmap "verify-normal" deleted from default namespace
```

Only platform identities (any ServiceAccount in a `d8-*` namespace) may manage `d8a-` objects, so the deckhouse controller installs applications with `d8a-` names while no other user — up to cluster-admin — can create or squat the prefix.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: feature
summary: Reserved the d8a- prefix for Deckhouse application objects.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->


