### PR TITLE
[deckhouse-controller] fix: use effective module enabled state

### DIFF
--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -632,7 +632,7 @@ func (r *reconciler) handleDeployedRelease(ctx context.Context, release *v1alpha
 		Controller: ptr.To(true),
 	}
 
-	// do not (re)create documentation for a module disabled by config
+	// do not (re)create documentation for a disabled module
 	module := new(v1alpha1.Module)
 	if err = r.client.Get(ctx, client.ObjectKey{Name: release.GetModuleName()}, module); err != nil {
 		r.log.Error("failed to get module", slog.String("module", release.GetModuleName()), log.Err(err))
@@ -640,8 +640,11 @@ func (r *reconciler) handleDeployedRelease(ctx context.Context, release *v1alpha
 		return res, fmt.Errorf("get module: %w", err)
 	}
 
-	// ensure documentation only for a module enabled by config
-	if module.IsCondition(v1alpha1.ModuleConditionEnabledByModuleConfig, corev1.ConditionTrue) {
+	// ensure documentation for any enabled module, regardless of how it is enabled
+	// (by module config, by bundle or by an enabled script) - EnabledByModuleManager
+	// reflects the effective enabled state, unlike EnabledByModuleConfig which is only
+	// set for modules enabled explicitly via a ModuleConfig
+	if module.IsCondition(v1alpha1.ModuleConditionEnabledByModuleManager, corev1.ConditionTrue) {
 		if err = utils.EnsureModuleDocumentationForRelease(ctx, r.client, release); err != nil {
 			r.log.Error("failed to ensure module documentation", slog.String("module", release.GetModuleName()), log.Err(err))
 


### PR DESCRIPTION
## Description

The release controller gated `ModuleDocumentation` creation on the module being enabled specifically through a `ModuleConfig`:

```go
if module.IsCondition(v1alpha1.ModuleConditionEnabledByModuleConfig, corev1.ConditionTrue) {
    utils.EnsureModuleDocumentationForRelease(...)
}
```

`EnabledByModuleConfig` is only set to `True` when a module is enabled explicitly via a `ModuleConfig` with `spec.enabled: true`. Modules enabled by the bundle default or by an `enabled` script do not have this condition set to `True`, even though they are effectively running.

This PR switches the guard to `EnabledByModuleManager`, which reflects the *effective* enabled state of the module regardless of how it was enabled (ModuleConfig, bundle, or `enabled` script). This aligns the release controller with the override controller, which already accounts for bundle-based enablement.

No other paths are changed: the config controller (ModuleConfig-driven creation) and the override controller (ModulePullOverride) keep their existing behavior.



## Why do we need it, and what problem does it solve?

In-cluster documentation was silently missing for a whole class of modules: any external module enabled by the bundle default or an `enabled` script, but without an explicit `enabled: true` ModuleConfig. For such modules the `ModuleRelease` reached `Deployed`, the module ran normally (`ENABLED=True`), yet no `ModuleDocumentation` object was ever created, so `docs-builder` never received their docs.

The failure was confusing to diagnose because:

- The `ENABLED` column in `kubectl get modules` maps to `EnabledByModuleManager`, not to `EnabledByModuleConfig` — so the module looked enabled while docs were gated on a different, unset condition.
- The skip is silent: the guard is a plain `if` with no log line, so nothing appeared in the Deckhouse logs.
- Documentation creation is reactive and effectively one-shot (on release deploy), so it never self-healed for modules that were already `Deployed`.

As a result, whether a module had docs depended on whether someone happened to enable it via a ModuleConfig, which varied cluster to cluster.

After this change, documentation is ensured for every enabled module, matching user expectation ("the module is enabled, so its docs should be available").


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: Fix missing in-cluster documentation for modules enabled by bundle or an `enabled` script by gating `ModuleDocumentation` creation on `EnabledByModuleManager` instead of `EnabledByModuleConfig`.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
