### PR TITLE
[deckhouse] atomically install modules and re-download incomplete versions

### DIFF
--- a/deckhouse-controller/internal/module/installer/symlink/installer.go
+++ b/deckhouse-controller/internal/module/installer/symlink/installer.go
@@ -95,15 +95,10 @@ func (i *Installer) Install(ctx context.Context, module, version, tempModulePath
 	// /deckhouse/downloaded/<module>/<version>
 	versionPath := filepath.Join(modulePath, version)
 
-	// Remove old version if exists (for atomic update)
-	if _, err := os.Stat(versionPath); err == nil {
-		if err = os.RemoveAll(versionPath); err != nil {
-			return fmt.Errorf("delete old version '%s': %w", versionPath, err)
-		}
-	}
-
-	// Copy module files to permanent location
-	if err := cp.Copy(tempModulePath, versionPath); err != nil {
+	// Copy module files to permanent location atomically, so an interrupted copy
+	// never leaves a partial version directory that a later restore would trust as
+	// complete and expose through the module symlink.
+	if err := atomicCopyDir(tempModulePath, versionPath); err != nil {
 		span.SetStatus(codes.Error, err.Error())
 		return fmt.Errorf("copy module '%s': %w", modulePath, err)
 	}
@@ -155,15 +150,10 @@ func (i *Installer) Stage(ctx context.Context, module, version, tempModulePath s
 	// /deckhouse/downloaded/<module>/<version>
 	versionPath := filepath.Join(modulePath, version)
 
-	// Remove old version if exists (for atomic update)
-	if _, err := os.Stat(versionPath); err == nil {
-		if err = os.RemoveAll(versionPath); err != nil {
-			return fmt.Errorf("delete old version '%s': %w", versionPath, err)
-		}
-	}
-
-	// Copy module files to permanent location, but do NOT create the symlink.
-	if err := cp.Copy(tempModulePath, versionPath); err != nil {
+	// Copy module files to permanent location atomically and without creating the
+	// symlink, so an interrupted copy never leaves a partial version directory that
+	// a later restore would trust as complete.
+	if err := atomicCopyDir(tempModulePath, versionPath); err != nil {
 		span.SetStatus(codes.Error, err.Error())
 		return fmt.Errorf("copy module '%s': %w", modulePath, err)
 	}
@@ -194,9 +184,11 @@ func (i *Installer) StageFromRegistry(ctx context.Context, ms *v1alpha1.ModuleSo
 	// /deckhouse/downloaded/<module>/<version>
 	versionPath := filepath.Join(modulePath, version)
 
-	// Download module only if it is not present on the filesystem yet.
-	if _, err := os.Stat(versionPath); err != nil {
-		if err = i.registry.Download(ctx, registry.BuildRemote(ms), versionPath, module, version); err != nil {
+	// Re-download when the version is missing or incomplete (e.g. an empty directory
+	// left by an interrupted download), instead of trusting bare existence, which
+	// would keep a broken module in place across restarts.
+	if !moduleComplete(versionPath) {
+		if err := i.registry.Download(ctx, registry.BuildRemote(ms), versionPath, module, version); err != nil {
 			span.SetStatus(codes.Error, err.Error())
 			return fmt.Errorf("download module '%s': %w", module, err)
 		}
@@ -297,9 +289,11 @@ func (i *Installer) Restore(ctx context.Context, ms *v1alpha1.ModuleSource, modu
 	// This allows multiple versions to coexist before symlink switch
 	versionPath := filepath.Join(modulePath, version)
 
-	// Check if module version already exists
-	if _, err := os.Stat(versionPath); err != nil {
-		if err = i.registry.Download(ctx, registry.BuildRemote(ms), versionPath, module, version); err != nil {
+	// Re-download when the version is missing or incomplete (e.g. an empty directory
+	// left by an interrupted download), instead of trusting bare existence, which
+	// would keep a broken module in place across restarts.
+	if !moduleComplete(versionPath) {
+		if err := i.registry.Download(ctx, registry.BuildRemote(ms), versionPath, module, version); err != nil {
 			span.SetStatus(codes.Error, err.Error())
 			return fmt.Errorf("download module '%s': %w", module, err) // Propagate download error
 		}
@@ -312,4 +306,43 @@ func (i *Installer) Restore(ctx context.Context, ms *v1alpha1.ModuleSource, modu
 	}
 
 	return nil
+}
+
+// atomicCopyDir copies the contents of src into a temporary sibling of dst on the
+// same filesystem and then renames it onto dst. Because the rename is the only
+// operation that publishes dst, an interrupted copy leaves dst either untouched or
+// absent, never a partially written directory.
+func atomicCopyDir(src, dst string) error {
+	scratch, err := os.MkdirTemp(filepath.Dir(dst), "."+filepath.Base(dst)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create scratch dir: %w", err)
+	}
+	defer os.RemoveAll(scratch)
+
+	if err = cp.Copy(src, scratch); err != nil {
+		return fmt.Errorf("copy '%s': %w", src, err)
+	}
+
+	// os.Rename needs an empty or absent target, so drop any stale directory first.
+	if err = os.RemoveAll(dst); err != nil {
+		return fmt.Errorf("remove stale '%s': %w", dst, err)
+	}
+	if err = os.Rename(scratch, dst); err != nil {
+		return fmt.Errorf("rename '%s' to '%s': %w", scratch, dst, err)
+	}
+
+	return nil
+}
+
+// moduleComplete reports whether the module version directory holds a materialized
+// module. An interrupted download leaves an empty directory; a bare existence check
+// treats that as present and keeps the broken module in place, so an empty or
+// unreadable directory is reported as incomplete and re-downloaded.
+func moduleComplete(versionPath string) bool {
+	entries, err := os.ReadDir(versionPath)
+	if err != nil {
+		return false
+	}
+
+	return len(entries) > 0
 }

--- a/deckhouse-controller/internal/module/installer/symlink/installer_test.go
+++ b/deckhouse-controller/internal/module/installer/symlink/installer_test.go
@@ -1,0 +1,133 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package symlink
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/deckhouse/deckhouse/pkg/log"
+)
+
+// TestModuleComplete pins the recovery gate: an empty version directory (what an
+// interrupted download leaves behind) must be reported as incomplete so Restore
+// re-downloads it instead of trusting bare existence.
+func TestModuleComplete(t *testing.T) {
+	t.Run("empty directory is incomplete", func(t *testing.T) {
+		assert.False(t, moduleComplete(t.TempDir()))
+	})
+
+	t.Run("populated directory is complete", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "module.yaml"), []byte("x"), 0o600))
+		assert.True(t, moduleComplete(dir))
+	})
+
+	t.Run("missing directory is incomplete", func(t *testing.T) {
+		assert.False(t, moduleComplete(filepath.Join(t.TempDir(), "absent")))
+	})
+}
+
+func TestAtomicCopyDir(t *testing.T) {
+	t.Run("copies contents and leaves no scratch", func(t *testing.T) {
+		src := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(src, "a.txt"), []byte("a"), 0o600))
+		require.NoError(t, os.MkdirAll(filepath.Join(src, "sub"), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(src, "sub", "b.txt"), []byte("b"), 0o600))
+
+		parent := t.TempDir()
+		dst := filepath.Join(parent, "v1.0.0")
+		require.NoError(t, atomicCopyDir(src, dst))
+
+		assertFileContent(t, filepath.Join(dst, "a.txt"), "a")
+		assertFileContent(t, filepath.Join(dst, "sub", "b.txt"), "b")
+		assertNoScratch(t, parent)
+	})
+
+	t.Run("replaces an existing directory atomically", func(t *testing.T) {
+		src := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(src, "new.txt"), []byte("new"), 0o600))
+
+		parent := t.TempDir()
+		dst := filepath.Join(parent, "v1.0.0")
+		require.NoError(t, os.MkdirAll(dst, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(dst, "stale.txt"), []byte("stale"), 0o600))
+
+		require.NoError(t, atomicCopyDir(src, dst))
+
+		assertFileContent(t, filepath.Join(dst, "new.txt"), "new")
+		assert.NoFileExists(t, filepath.Join(dst, "stale.txt"))
+		assertNoScratch(t, parent)
+	})
+}
+
+func TestInstall(t *testing.T) {
+	downloaded := t.TempDir()
+	inst := &Installer{
+		downloaded: downloaded,
+		symlinkDir: filepath.Join(downloaded, "modules"),
+		logger:     log.NewNop(),
+	}
+	require.NoError(t, os.MkdirAll(inst.symlinkDir, 0o755))
+
+	src := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(src, "module.yaml"), []byte("name: mod\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "images_digests.json"), []byte("{}"), 0o600))
+
+	require.NoError(t, inst.Install(context.Background(), "mod", "v1.0.0", src))
+
+	versionPath := filepath.Join(downloaded, "mod", "v1.0.0")
+	assertFileContent(t, filepath.Join(versionPath, "module.yaml"), "name: mod\n")
+	assertFileContent(t, filepath.Join(versionPath, "images_digests.json"), "{}")
+
+	// the module symlink resolves to the freshly materialized version
+	resolved, err := filepath.EvalSymlinks(filepath.Join(inst.symlinkDir, "mod"))
+	require.NoError(t, err)
+	want, err := filepath.EvalSymlinks(versionPath)
+	require.NoError(t, err)
+	assert.Equal(t, want, resolved)
+
+	// re-installing the same version replaces its contents wholesale, not merges
+	src2 := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(src2, "module.yaml"), []byte("name: mod2\n"), 0o600))
+	require.NoError(t, inst.Install(context.Background(), "mod", "v1.0.0", src2))
+
+	assertFileContent(t, filepath.Join(versionPath, "module.yaml"), "name: mod2\n")
+	assert.NoFileExists(t, filepath.Join(versionPath, "images_digests.json"))
+	assertNoScratch(t, filepath.Join(downloaded, "mod"))
+}
+
+func assertFileContent(t *testing.T, path, want string) {
+	t.Helper()
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, want, string(got))
+}
+
+// assertNoScratch fails if a temporary scratch directory from atomicCopyDir was
+// left behind in dir (the rename must consume it on success).
+func assertNoScratch(t *testing.T, dir string) {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	for _, entry := range entries {
+		assert.NotContains(t, entry.Name(), ".tmp-", "leftover scratch dir")
+	}
+}

--- a/deckhouse-controller/internal/registry/service.go
+++ b/deckhouse-controller/internal/registry/service.go
@@ -219,7 +219,10 @@ func (s *Service) Download(ctx context.Context, remote Remote, out, packageName,
 	return s.download(ctx, img, out)
 }
 
-// download copies tar to path
+// download extracts the image tar onto output atomically: the tar is unpacked into
+// a temporary sibling directory on the same filesystem and then renamed onto
+// output, so an interrupted extract can never leave a partial directory at the
+// final path that a later restore would mistake for a complete module.
 func (s *Service) download(_ context.Context, img crv1.Image, output string) error {
 	rc, err := cr.Extract(img)
 	if err != nil {
@@ -227,9 +230,15 @@ func (s *Service) download(_ context.Context, img crv1.Image, output string) err
 	}
 	defer rc.Close()
 
-	if err := os.MkdirAll(output, 0o700); err != nil {
-		return fmt.Errorf("create output path: %w", err)
+	if err := os.MkdirAll(filepath.Dir(output), 0o700); err != nil {
+		return fmt.Errorf("create output parent path: %w", err)
 	}
+
+	scratch, err := os.MkdirTemp(filepath.Dir(output), "."+filepath.Base(output)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create scratch dir: %w", err)
+	}
+	defer os.RemoveAll(scratch)
 
 	tr := tar.NewReader(rc)
 	for {
@@ -247,7 +256,7 @@ func (s *Service) download(_ context.Context, img crv1.Image, output string) err
 			return fmt.Errorf("path traversal detected in the package archive: malicious path %v", hdr.Name)
 		}
 
-		target := filepath.Join(output, hdr.Name)
+		target := filepath.Join(scratch, hdr.Name)
 		switch hdr.Typeflag {
 		case tar.TypeDir:
 			if err = os.MkdirAll(target, os.FileMode(hdr.Mode)); err != nil {
@@ -279,10 +288,19 @@ func (s *Service) download(_ context.Context, img crv1.Image, output string) err
 			}
 
 		case tar.TypeLink:
-			if err = os.Link(path.Join(output, hdr.Linkname), target); err != nil {
+			if err = os.Link(path.Join(scratch, hdr.Linkname), target); err != nil {
 				return fmt.Errorf("create hardlink: %w", err)
 			}
 		}
+	}
+
+	// os.Rename needs an empty or absent target, so drop any stale directory first,
+	// then publish the fully unpacked tree with a single atomic rename.
+	if err := os.RemoveAll(output); err != nil {
+		return fmt.Errorf("remove stale output '%s': %w", output, err)
+	}
+	if err := os.Rename(scratch, output); err != nil {
+		return fmt.Errorf("rename scratch to output '%s': %w", output, err)
 	}
 
 	return nil


### PR DESCRIPTION
## Description
An interrupted module download (a registry connection drop or a leader-pod restart mid-pull) could leave an empty `<downloaded>/<module>/<version>` directory. The symlink installer then trusted it forever — `Restore` skipped the re-download on a bare existence check and symlinked the module to the empty directory — so the module stayed broken across restarts.

This hardens the symlink backend:
- `registry.download`, `Install` and `Stage` materialize the version directory atomically (unpack/copy into a temporary sibling, then rename), so an interrupted write never publishes a partial directory.
- `Restore` and `StageFromRegistry` re-download when the directory is missing or empty instead of trusting bare existence, healing a broken directory on the next reconcile.

## Why do we need it, and what problem does it solve?
A single registry disconnect or leader-pod restart during a module pull could leave an external module permanently broken (an empty version directory behind a live symlink) with no self-healing — until the directory was removed by hand. This makes recovery automatic.

### Manual testing

Reproduced the incident and verified the self-heal on a cluster running this change. An external module's version directory was emptied (simulating a download interrupted by a registry disconnect or a leader-pod restart), keeping the symlink, then Deckhouse was restarted.

```
# 1. break: empty the version dir, keep the symlink -> incident state
$ d8 k -n d8-system exec deploy/deckhouse -c deckhouse -- \
    sh -c 'find /deckhouse/downloaded/a-k-test/v0.0.13 -mindepth 1 -delete; \
           ls -la /deckhouse/downloaded/a-k-test/v0.0.13/; readlink /deckhouse/downloaded/modules/a-k-test'
total 8
drwx------ 2 deckhouse root 4096 .
drwxr-xr-x 8 deckhouse root 4096 ..
/deckhouse/downloaded/a-k-test/v0.0.13          # symlink still points at the empty dir

# 2. restart Deckhouse -> startup Restore runs
$ d8 k -n d8-system rollout restart deploy/deckhouse

# 3. after restart the version dir re-downloaded itself, without any manual recovery
$ d8 k -n d8-system exec deploy/deckhouse -c deckhouse -- ls /deckhouse/downloaded/a-k-test/v0.0.13/
changelog.yaml  charts  crds  hooks  images_digests.json  module.yaml  openapi  templates

# module loaded from the full dir again (weight read from module.yaml, not the dir-name fallback)
$ d8 k get module a-k-test -o wide
NAME       WEIGHT   RELEASE CHANNEL   SOURCE   VERSION   PHASE   ENABLED   READY
a-k-test   900      Stable            test     v0.0.13   Ready   True      True

# the "images_digests.json: no such file" warning never fired (re-download ran first)
$ d8 k -n d8-system logs deploy/deckhouse -c deckhouse | grep -c 'a-k-test/v0.0.13/images_digests.json: no such file'
0

# recovery path proof: module re-fetched, then rendered from the restored dir
... module-source-controller.downloader  msg="fetching module release metadata"  path="<registry>/.../a-k-test/release"  release_channel="Stable"
... helm-module.nelm  msg="Render nelm templates for chart was successful"  chart="/deckhouse/downloaded/a-k-test/v0.0.13"  module="a-k-test"

# no leftover scratch dirs from the atomic write
$ d8 k -n d8-system exec deploy/deckhouse -c deckhouse -- find /deckhouse/downloaded -maxdepth 2 -name '.*.tmp-*'
(no output)
```

Without this change the same steps left the directory empty: the module weight fell 900 -> 100 (it was loaded from the empty dir), the warning recurred on every restart, and the module stayed broken until the directory was removed by hand.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: Made module installation atomic and re-download incomplete versions.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->


