### PR TITLE
[control-plane-manager] Improve etcd join step

### DIFF
--- a/docs/documentation/pages/admin/configuration/backup/BACKUP_AND_RESTORE.md
+++ b/docs/documentation/pages/admin/configuration/backup/BACKUP_AND_RESTORE.md
@@ -392,24 +392,30 @@ To simplify cluster recovery after the master node's IP address changes, use the
 ETCD_SNAPSHOT_PATH="./etcd-backup.snapshot" # Path to the etcd snapshot.
 OLD_IP=10.242.32.34                         # Old master node IP address.
 NEW_IP=10.242.32.21                         # New master node IP address.
+NODE_NAME=master-0                          # Must match --name in the etcd static pod manifest.
 
-mv /etc/kubernetes/manifests/etcd.yaml ~/etcd.yaml 
+mv /etc/kubernetes/manifests/etcd.yaml ~/etcd.yaml
 mkdir ./etcd_old
-mv /var/lib/etcd ~/etcd_old
+mv /var/lib/etcd ./etcd_old
 ETCD_PID=$(crictl inspect $(crictl ps --name etcd -q | head -1) | jq .info.pid)
 ETCDUTL_PATH=/proc/${ETCD_PID}/root/usr/bin/etcdutl
 
-ETCDCTL_API=3 $ETCDUTL_PATH snapshot restore etcd-backup.snapshot --data-dir=/var/lib/etcd 
-
-mv ~/etcd.yaml /etc/kubernetes/manifests/etcd.yaml
+$ETCDUTL_PATH snapshot restore "$ETCD_SNAPSHOT_PATH" \
+  --data-dir=/var/lib/etcd \
+  --name="$NODE_NAME" \
+  --initial-advertise-peer-urls="https://$NEW_IP:2380" \
+  --initial-cluster="$NODE_NAME=https://$NEW_IP:2380"
 
 find /etc/kubernetes/ -type f -exec sed -i "s/$OLD_IP/$NEW_IP/g" {} ';'
 find /etc/systemd/system/kubelet.service.d -type f -exec sed -i "s/$OLD_IP/$NEW_IP/g" {} ';'
-find  /var/lib/bashible/ -type f -exec sed -i "s/$OLD_IP/$NEW_IP/g" {} ';'
+find /var/lib/bashible/ -type f -exec sed -i "s/$OLD_IP/$NEW_IP/g" {} ';'
+sed -i "s/$OLD_IP/$NEW_IP/g" ~/etcd.yaml
 
 cp -r /etc/kubernetes/pki ./pki-backup
 
 d8 tools pki certs renew all --san $NEW_IP
+
+mv ~/etcd.yaml /etc/kubernetes/manifests/etcd.yaml
 
 crictl ps --name 'kube-apiserver' -o json | jq -r '.containers[0].id' | xargs crictl stop
 crictl ps --name 'kubernetes-api-proxy' -o json | jq -r '.containers[0].id' | xargs crictl stop
@@ -444,21 +450,17 @@ If you prefer to manually make changes during cluster recovery after the master 
 
      ```shell
      ETCD_SNAPSHOT_PATH="./etcd-backup.snapshot" # Path to the etcd snapshot.
+     NEW_IP=10.242.32.21                         # New master node IP address.
+     NODE_NAME=master-0                          # Must match --name in the etcd static pod manifest.
      ETCD_PID=$(crictl inspect $(crictl ps --name etcd -q | head -1) | jq .info.pid)
      ETCDUTL_PATH=/proc/${ETCD_PID}/root/usr/bin/etcdutl
 
-     ETCDCTL_API=3 $ETCDUTL_PATH snapshot restore \
-       etcd-backup.snapshot \
-       --data-dir=/var/lib/etcd
+     $ETCDUTL_PATH snapshot restore "$ETCD_SNAPSHOT_PATH" \
+       --data-dir=/var/lib/etcd \
+       --name="$NODE_NAME" \
+       --initial-advertise-peer-urls="https://$NEW_IP:2380" \
+       --initial-cluster="$NODE_NAME=https://$NEW_IP:2380"
      ```
-
-   - Restore the etcd manifest so kubelet starts the etcd pod again:
-
-     ```shell
-     mv ~/etcd.yaml /etc/kubernetes/manifests/etcd.yaml
-     ```
-
-   - Verify etcd is running by checking the pod list using `crictl ps | grep etcd` or reviewing the kubelet logs.
 
 1. Update the IP address in static configuration files. If the old IP address is used in manifests or kubelet services, replace it with the new one:
 
@@ -468,7 +470,8 @@ If you prefer to manually make changes during cluster recovery after the master 
 
     find /etc/kubernetes/ -type f -exec sed -i "s/$OLD_IP/$NEW_IP/g" {} ';'
     find /etc/systemd/system/kubelet.service.d -type f -exec sed -i "s/$OLD_IP/$NEW_IP/g" {} ';'
-    find  /var/lib/bashible/ -type f -exec sed -i "s/$OLD_IP/$NEW_IP/g" {} ';'
+    find /var/lib/bashible/ -type f -exec sed -i "s/$OLD_IP/$NEW_IP/g" {} ';'
+    sed -i "s/$OLD_IP/$NEW_IP/g" ~/etcd.yaml
     ```
 
 1. Back up the current certificates:
@@ -483,9 +486,11 @@ If you prefer to manually make changes during cluster recovery after the master 
    d8 tools pki certs renew all --san <NEW_IP>
    ```
 
-1. Restart all services so that components load the updated certificates and configurations. To immediately stop active containers, run:
+1. Restore the etcd manifest (so kubelet starts the etcd pod again) and restart all services so that components load the updated certificates and configurations. To immediately stop active containers, run:
 
     ```shell
+    mv ~/etcd.yaml /etc/kubernetes/manifests/etcd.yaml
+
     crictl ps --name 'kube-apiserver' -o json | jq -r '.containers[0].id' | xargs crictl stop
     crictl ps --name 'kubernetes-api-proxy' -o json | jq -r '.containers[0].id' | xargs crictl stop
     crictl ps --name 'etcd' -o json | jq -r '.containers[].id' | xargs crictl stop
@@ -493,6 +498,8 @@ If you prefer to manually make changes during cluster recovery after the master 
     systemctl daemon-reload
     systemctl restart kubelet.service
     ```
+
+    Verify etcd is running by checking the pod list using `crictl ps | grep etcd` or reviewing the kubelet logs.
 
 1. Wait for kubelet to regenerate its own certificate. Kubelet will automatically generate a new certificate with the updated IP address:
 

--- a/docs/documentation/pages/admin/configuration/backup/BACKUP_AND_RESTORE_RU.md
+++ b/docs/documentation/pages/admin/configuration/backup/BACKUP_AND_RESTORE_RU.md
@@ -392,24 +392,30 @@ lang: ru
 ETCD_SNAPSHOT_PATH="./etcd-backup.snapshot" # Путь до файла резервной копии etcd.
 OLD_IP=10.242.32.34                         # IP-адрес старого master-узла.
 NEW_IP=10.242.32.21                         # IP-адрес нового master-узла.
+NODE_NAME=master-0                          # Должно совпадать с --name в статическом манифесте etcd.
 
-mv /etc/kubernetes/manifests/etcd.yaml ~/etcd.yaml 
+mv /etc/kubernetes/manifests/etcd.yaml ~/etcd.yaml
 mkdir ./etcd_old
-mv /var/lib/etcd ~/etcd_old
+mv /var/lib/etcd ./etcd_old
 ETCD_PID=$(crictl inspect $(crictl ps --name etcd -q | head -1) | jq .info.pid)
 ETCDUTL_PATH=/proc/${ETCD_PID}/root/usr/bin/etcdutl
 
-ETCDCTL_API=3 $ETCDUTL_PATH snapshot restore etcd-backup.snapshot --data-dir=/var/lib/etcd 
-
-mv ~/etcd.yaml /etc/kubernetes/manifests/etcd.yaml
+$ETCDUTL_PATH snapshot restore "$ETCD_SNAPSHOT_PATH" \
+  --data-dir=/var/lib/etcd \
+  --name="$NODE_NAME" \
+  --initial-advertise-peer-urls="https://$NEW_IP:2380" \
+  --initial-cluster="$NODE_NAME=https://$NEW_IP:2380"
 
 find /etc/kubernetes/ -type f -exec sed -i "s/$OLD_IP/$NEW_IP/g" {} ';'
 find /etc/systemd/system/kubelet.service.d -type f -exec sed -i "s/$OLD_IP/$NEW_IP/g" {} ';'
-find  /var/lib/bashible/ -type f -exec sed -i "s/$OLD_IP/$NEW_IP/g" {} ';'
+find /var/lib/bashible/ -type f -exec sed -i "s/$OLD_IP/$NEW_IP/g" {} ';'
+sed -i "s/$OLD_IP/$NEW_IP/g" ~/etcd.yaml
 
 cp -r /etc/kubernetes/pki ./pki-backup
 
 d8 tools pki certs renew all --san $NEW_IP
+
+mv ~/etcd.yaml /etc/kubernetes/manifests/etcd.yaml
 
 crictl ps --name 'kube-apiserver' -o json | jq -r '.containers[0].id' | xargs crictl stop
 crictl ps --name 'kubernetes-api-proxy' -o json | jq -r '.containers[0].id' | xargs crictl stop
@@ -444,21 +450,17 @@ systemctl restart kubelet.service
 
      ```shell
      ETCD_SNAPSHOT_PATH="./etcd-backup.snapshot" # Путь до файла резервной копии etcd.
+     NEW_IP=10.242.32.21                         # Новый IP-адрес master-узла.
+     NODE_NAME=master-0                          # Должно совпадать с --name в статическом манифесте etcd.
      ETCD_PID=$(crictl inspect $(crictl ps --name etcd -q | head -1) | jq .info.pid)
      ETCDUTL_PATH=/proc/${ETCD_PID}/root/usr/bin/etcdutl
 
-     ETCDCTL_API=3 $ETCDUTL_PATH snapshot restore \
-       etcd-backup.snapshot \
-       --data-dir=/var/lib/etcd
+     $ETCDUTL_PATH snapshot restore "$ETCD_SNAPSHOT_PATH" \
+       --data-dir=/var/lib/etcd \
+       --name="$NODE_NAME" \
+       --initial-advertise-peer-urls="https://$NEW_IP:2380" \
+       --initial-cluster="$NODE_NAME=https://$NEW_IP:2380"
      ```
-
-   - Верните манифест etcd на место, чтобы kubelet снова запустил под:
-
-     ```shell
-     mv ~/etcd.yaml /etc/kubernetes/manifests/etcd.yaml
-     ```
-
-   - Убедитесь, что etcd успешно запустился, проверив список подов с помощью `crictl ps | grep etcd` или просмотрев логи kubelet.
 
 1. Обновите IP-адреса в статичных конфигурационных файлах. Если в манифестах или системных сервисах kubelet прописан старый IP-адрес, замените его на новый:
 
@@ -468,7 +470,8 @@ systemctl restart kubelet.service
 
     find /etc/kubernetes/ -type f -exec sed -i "s/$OLD_IP/$NEW_IP/g" {} ';'
     find /etc/systemd/system/kubelet.service.d -type f -exec sed -i "s/$OLD_IP/$NEW_IP/g" {} ';'
-    find  /var/lib/bashible/ -type f -exec sed -i "s/$OLD_IP/$NEW_IP/g" {} ';'
+    find /var/lib/bashible/ -type f -exec sed -i "s/$OLD_IP/$NEW_IP/g" {} ';'
+    sed -i "s/$OLD_IP/$NEW_IP/g" ~/etcd.yaml
     ```
 
 1. Создайте резервную копию текущих сертификатов:
@@ -483,9 +486,11 @@ systemctl restart kubelet.service
    d8 tools pki certs renew all --san <NEW_IP>
    ```
 
-1. Перезапустите сервисы, чтобы компоненты загрузили обновлённые сертификаты и конфигурации:
+1. Верните манифест etcd на место (чтобы kubelet снова запустил под) и перезапустите сервисы, чтобы компоненты загрузили обновлённые сертификаты и конфигурации:
 
     ```shell
+    mv ~/etcd.yaml /etc/kubernetes/manifests/etcd.yaml
+
     crictl ps --name 'kube-apiserver' -o json | jq -r '.containers[0].id' | xargs crictl stop
     crictl ps --name 'kubernetes-api-proxy' -o json | jq -r '.containers[0].id' | xargs crictl stop
     crictl ps --name 'etcd' -o json | jq -r '.containers[].id' | xargs crictl stop
@@ -493,6 +498,8 @@ systemctl restart kubelet.service
     systemctl daemon-reload
     systemctl restart kubelet.service
     ```
+
+    Убедитесь, что etcd успешно запустился, проверив список подов с помощью `crictl ps | grep etcd` или просмотрев логи kubelet.
 
 1. Дождитесь, пока kubelet обновит собственный сертификат. Kubelet автоматически генерирует и обновляет свой сертификат, в котором будет прописан новый IP-адрес:
   

--- a/go_lib/controlplane/etcd/client/client.go
+++ b/go_lib/controlplane/etcd/client/client.go
@@ -45,6 +45,8 @@ import (
 
 const etcdTimeout = 2 * time.Second
 
+var ErrNoMemberIDForPeerURL = errors.New("no etcd member id found for peer URL")
+
 // Interface describes the etcd client surface used by controlplane code.
 // It allows tests to stub promotion-related flows without a real clientv3 connection.
 type Interface interface {
@@ -53,6 +55,7 @@ type Interface interface {
 	WaitForClusterAvailable(retries int, retryInterval time.Duration) (bool, error)
 	MemberAddAsLearner(ctx context.Context, peerAddrs string) (*clientv3.MemberAddResponse, error)
 	MemberPromote(ctx context.Context, id uint64) (*clientv3.MemberPromoteResponse, error)
+	GetMemberID(ctx context.Context, peerURL string) (uint64, error)
 	CheckClusterHealthy(ctx context.Context, timeout time.Duration) error
 	Defragment(ctx context.Context, endpoint string) error
 	Raw() *clientv3.Client
@@ -164,14 +167,7 @@ func (c *Client) MemberAddAsLearner(ctx context.Context, peerAddrs string) (*cli
 				lastError = err
 				return false, nil
 			}
-			found := false
-			for _, member := range listResp.Members {
-				if member.GetPeerURLs()[0] == peerAddrs {
-					found = true
-					break
-				}
-			}
-			if found {
+			if _, ok := findMemberIDByPeerURL(listResp.Members, peerAddrs); ok {
 				logger.Info("The peer URL for the added etcd member already exists. Skipping etcd member addition", slog.String("peerAddrs", peerAddrs))
 				resp = &clientv3.MemberAddResponse{Members: listResp.Members}
 				return true, nil
@@ -204,6 +200,36 @@ func (c *Client) MemberAddAsLearner(ctx context.Context, peerAddrs string) (*cli
 	}
 
 	return resp, nil
+}
+
+func findMemberIDByPeerURL(members []*etcdserverpb.Member, peerURL string) (uint64, bool) {
+	for _, m := range members {
+		for _, u := range m.GetPeerURLs() {
+			if u == peerURL {
+				return m.GetID(), true
+			}
+		}
+	}
+	return 0, false
+}
+
+// GetMemberID returns the ID of the etcd member that advertises peerURL among any of its peer URLs.
+// It queries the membership API directly instead of relying on a MemberAdd response, so it works on retries when the member already exists.
+func (c *Client) GetMemberID(ctx context.Context, peerURL string) (uint64, error) {
+	cli, err := c.newEtcdClient(c.Endpoints())
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = cli.Close() }()
+
+	resp, err := cli.Raw().MemberList(ctx)
+	if err != nil {
+		return 0, err
+	}
+	if id, ok := findMemberIDByPeerURL(resp.Members, peerURL); ok {
+		return id, nil
+	}
+	return 0, ErrNoMemberIDForPeerURL
 }
 
 // MemberPromote is the extension point for extra promotion logic around clientv3.
@@ -249,7 +275,17 @@ func (c *Client) MemberPromote(ctx context.Context, id uint64) (*clientv3.Member
 	defer func() { _ = cli.Close() }()
 
 	err = wait.PollUntilContextTimeout(ctx, constants.EtcdAPICallRetryInterval, constants.EtcdAPICallTimeout,
-		true, func(_ context.Context) (bool, error) {
+		true, func(pollCtx context.Context) (bool, error) {
+			isLearner, _, err := c.getMemberStatus(pollCtx, id)
+			if err != nil {
+				lastError = err
+				return false, nil
+			}
+			if !isLearner {
+				logger.Info("member already promoted, nothing to do", slog.Any("memberID", learnerIDUint))
+				return true, nil
+			}
+
 			ctx, cancel := context.WithTimeout(context.Background(), etcdTimeout)
 			defer cancel()
 

--- a/go_lib/controlplane/etcd/client/client_test.go
+++ b/go_lib/controlplane/etcd/client/client_test.go
@@ -76,6 +76,10 @@ func (f *fakeClient) MemberPromote(_ context.Context, id uint64) (*clientv3.Memb
 	return &clientv3.MemberPromoteResponse{}, nil
 }
 
+func (f *fakeClient) GetMemberID(_ context.Context, _ string) (uint64, error) {
+	return 0, nil
+}
+
 func (f *fakeClient) CheckClusterHealthy(_ context.Context, _ time.Duration) error {
 	return nil
 }

--- a/go_lib/controlplane/etcd/etcd.go
+++ b/go_lib/controlplane/etcd/etcd.go
@@ -18,6 +18,7 @@ package etcd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -75,13 +76,51 @@ func JoinCluster(podManifest []byte, ip string, nodeName string, options ...opti
 
 	ctx, cancel := context.WithTimeout(context.Background(), constants.KubernetesAPICallTimeout)
 	defer cancel()
-	_, err = etcdClient.MemberPromote(ctx, clusterResponse.Member.ID)
+	id, err := etcdClient.GetMemberID(ctx, etcdPeerAddress)
 	if err != nil {
+		return err
+	}
+	if _, err = etcdClient.MemberPromote(ctx, id); err != nil {
 		return err
 	}
 
 	logger.Info("Waiting for the new etcd member to join the cluster", slog.Duration("timeout", constants.EtcdHealthyCheckInterval*constants.EtcdHealthyCheckRetries))
 	if _, err := etcdClient.WaitForClusterAvailable(constants.EtcdHealthyCheckRetries, constants.EtcdHealthyCheckInterval); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// PromoteMember promotes the etcd member with the given peer IP if it is still a learner.
+// No-op if the member is already a voting member (promotion is idempotent) or not present yet.
+func PromoteMember(peerIP string, options ...option) error {
+	opt := prepareOptions(options...)
+
+	kubeClient, err := client.NewKubernetesClient()
+	if err != nil {
+		return err
+	}
+
+	etcdClient, err := client.New(kubeClient, opt.CertificatesDir)
+	if err != nil {
+		return err
+	}
+	defer etcdClient.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), constants.KubernetesAPICallTimeout)
+	defer cancel()
+
+	id, err := etcdClient.GetMemberID(ctx, GetPeerURL(peerIP))
+	if err != nil {
+		if errors.Is(err, client.ErrNoMemberIDForPeerURL) {
+			return nil
+		}
+		return err
+	}
+
+	logger.Info("ensuring own etcd member is promoted", slog.Uint64("member_id", id), slog.String("peer_ip", peerIP))
+	if _, err := etcdClient.MemberPromote(ctx, id); err != nil {
 		return err
 	}
 

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/classify_etcd_test.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/classify_etcd_test.go
@@ -27,7 +27,7 @@ func TestClassifyEtcd(t *testing.T) {
 		nodeName  = "master-0"
 		ourPeer   = "https://10.0.0.1:2380"
 		otherPeer = "https://10.0.0.2:2380"
-		oldPeer   = "https://10.0.0.9:2380" // same node name, different IP -> conflict
+		oldPeer   = "https://10.0.0.9:2380"
 	)
 
 	tests := []struct {
@@ -95,7 +95,7 @@ func TestClassifyEtcd(t *testing.T) {
 			wantState:      etcdJoined,
 		},
 		{
-			name: "member matched by name when peer URL differs",
+			name: "rare case: member matched by name when peer URL differs",
 			members: []etcdMemberInfo{
 				{Name: nodeName, PeerURLs: []string{oldPeer}},
 			},

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/classify_etcd_test.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/classify_etcd_test.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controlplaneoperation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestClassifyEtcd(t *testing.T) {
+	const (
+		nodeName  = "master-0"
+		ourPeer   = "https://10.0.0.1:2380"
+		otherPeer = "https://10.0.0.2:2380"
+		oldPeer   = "https://10.0.0.9:2380" // same node name, different IP -> conflict
+	)
+
+	tests := []struct {
+		name           string
+		members        []etcdMemberInfo
+		dataDirPresent bool
+		wantState      etcdJoinState
+		wantIsLearner  bool
+	}{
+		{
+			name:           "fresh: no members, no data dir",
+			members:        nil,
+			dataDirPresent: false,
+			wantState:      etcdNeedsJoin,
+		},
+		{
+			name: "fresh: unrelated members, no data dir",
+			members: []etcdMemberInfo{
+				{Name: "master-1", PeerURLs: []string{otherPeer}},
+			},
+			dataDirPresent: false,
+			wantState:      etcdNeedsJoin,
+		},
+		{
+			name: "orphan: our member absent but stale data dir present",
+			members: []etcdMemberInfo{
+				{Name: "master-1", PeerURLs: []string{otherPeer}},
+			},
+			dataDirPresent: true,
+			wantState:      etcdOrphan,
+		},
+		{
+			name: "interrupted join: our learner added but etcd never started (no data dir, empty name)",
+			members: []etcdMemberInfo{
+				{Name: "", PeerURLs: []string{ourPeer}, IsLearner: true},
+			},
+			dataDirPresent: false,
+			wantState:      etcdNeedsJoin,
+			wantIsLearner:  true,
+		},
+		{
+			name: "joined voter: our member present, data dir present, not a learner",
+			members: []etcdMemberInfo{
+				{Name: nodeName, PeerURLs: []string{ourPeer}},
+			},
+			dataDirPresent: true,
+			wantState:      etcdJoined,
+			wantIsLearner:  false,
+		},
+		{
+			name: "joined learner: our member present, data dir present, still a learner",
+			members: []etcdMemberInfo{
+				{Name: nodeName, PeerURLs: []string{ourPeer}, IsLearner: true},
+			},
+			dataDirPresent: true,
+			wantState:      etcdJoined,
+			wantIsLearner:  true,
+		},
+		{
+			name: "peer URL matched in second position",
+			members: []etcdMemberInfo{
+				{Name: nodeName, PeerURLs: []string{otherPeer, ourPeer}},
+			},
+			dataDirPresent: true,
+			wantState:      etcdJoined,
+		},
+		{
+			name: "name conflict: same node name, different peer URL",
+			members: []etcdMemberInfo{
+				{Name: nodeName, PeerURLs: []string{oldPeer}},
+			},
+			dataDirPresent: false,
+			wantState:      etcdNameConflict,
+		},
+		{
+			name: "conflict wins over peer match: new exact-peer learner plus old same-name voter",
+			members: []etcdMemberInfo{
+				{Name: "", PeerURLs: []string{ourPeer}, IsLearner: true},
+				{Name: nodeName, PeerURLs: []string{oldPeer}},
+			},
+			dataDirPresent: true,
+			wantState:      etcdNameConflict,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classifyEtcd(tt.members, tt.dataDirPresent, nodeName, ourPeer)
+			require.Equal(t, tt.wantState, got.state, "state")
+			require.Equal(t, tt.wantIsLearner, got.isLearner, "isLearner")
+		})
+	}
+}

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/classify_etcd_test.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/classify_etcd_test.go
@@ -95,21 +95,22 @@ func TestClassifyEtcd(t *testing.T) {
 			wantState:      etcdJoined,
 		},
 		{
-			name: "name conflict: same node name, different peer URL",
+			name: "member matched by name when peer URL differs",
 			members: []etcdMemberInfo{
 				{Name: nodeName, PeerURLs: []string{oldPeer}},
 			},
 			dataDirPresent: false,
-			wantState:      etcdNameConflict,
+			wantState:      etcdNeedsJoin,
 		},
 		{
-			name: "conflict wins over peer match: new exact-peer learner plus old same-name voter",
+			name: "exact peer match wins over name match",
 			members: []etcdMemberInfo{
 				{Name: "", PeerURLs: []string{ourPeer}, IsLearner: true},
 				{Name: nodeName, PeerURLs: []string{oldPeer}},
 			},
 			dataDirPresent: true,
-			wantState:      etcdNameConflict,
+			wantState:      etcdJoined,
+			wantIsLearner:  true,
 		},
 	}
 

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/controller.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/controller.go
@@ -38,7 +38,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/deckhouse/deckhouse/go_lib/controlplane/etcd"
 	"github.com/deckhouse/deckhouse/pkg/log"
 	metricsstorage "github.com/deckhouse/deckhouse/pkg/metrics-storage"
 
@@ -329,12 +328,15 @@ func (r *Reconciler) diskMatchesDesired(op *controlplanev1alpha1.ControlPlaneOpe
 		if err != nil || !manifestMatches {
 			return manifestMatches, err
 		}
-		peerURL := etcd.GetPeerURL(r.node.AdvertiseIP)
-		memberExists, err := checkEtcdMemberExists(r.node.Name, peerURL, constants.KubernetesPkiPath, r.node.KubeconfigDir)
+		cls, err := classifyEtcdState(r.node, constants.KubernetesPkiPath, r.node.KubeconfigDir)
 		if err != nil {
 			return false, err
 		}
-		return memberExists, nil
+		if cls.state == etcdNameConflict {
+			return false, fmt.Errorf("etcd member %q already registered with a different peer URL (node IP change?): manual member replacement required", r.node.Name)
+		}
+		// The join is committed only when our member is a voting member (not a learner) with a bootstrapped data dir. A learner/interrupted/fresh/orphan state re-runs join+promote.
+		return cls.state == etcdJoined && !cls.isLearner, nil
 	default:
 		return false, nil
 	}

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/controller.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/controller.go
@@ -332,9 +332,6 @@ func (r *Reconciler) diskMatchesDesired(op *controlplanev1alpha1.ControlPlaneOpe
 		if err != nil {
 			return false, err
 		}
-		if cls.state == etcdNameConflict {
-			return false, fmt.Errorf("etcd member %q already registered with a different peer URL (node IP change?): manual member replacement required", r.node.Name)
-		}
 		// The join is committed only when our member is a voting member (not a learner) with a bootstrapped data dir. A learner/interrupted/fresh/orphan state re-runs join+promote.
 		return cls.state == etcdJoined && !cls.isLearner, nil
 	default:

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/etcd.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/etcd.go
@@ -39,75 +39,136 @@ const (
 	etcdMemberListTimeout = 10 * time.Second
 )
 
-// etcdNeedsJoin checks if the etcd member needs to join the cluster:
+type etcdJoinState int
+
+const (
+	// etcdJoined: our member is registered and local etcd has bootstrapped. etcd ignores --initial-cluster on restart, so a plain manifest sync + idempotent promote is safe.
+	etcdJoined etcdJoinState = iota
+	// etcdNeedsJoin: our member must (re)run the idempotent join flow, the only path that writes a manifest with the full --initial-cluster.
+	// Covers both a fresh node and an interrupted join (member added but local etcd never bootstrapped); both lead to the same idempotent JoinCluster.
+	// The data dir is NOT wiped: an interrupted-join etcd may already be starting.
+	etcdNeedsJoin
+	// etcdOrphan: our member is not registered but a stale local data dir exists. Wipe it and rejoin fresh.
+	etcdOrphan
+	// etcdNameConflict: a member carries our node name but none of its peer URLs is ours (e.g. the node was recreated with a new IP).
+	// Joining would add a second member and leave the old, unreachable voter in place (the removal hook keeps it by name), changing quorum requirements.
+	// Fail closed and require an explicit member replacement.
+	etcdNameConflict
+)
+
+type etcdMemberInfo struct {
+	Name      string
+	PeerURLs  []string
+	IsLearner bool
+}
+
+type etcdClassification struct {
+	state     etcdJoinState
+	isLearner bool
+}
+
+// classifyEtcd is the pure decision given the current members, whether the local data dir exists, and this node identity (name + peer URL).
 //
-//	member in cluster (by name or peer URL) -> no join needed
-//	/var/lib/etcd/member does not exist and not in cluster -> fresh node, needs join
-//	data dir exists but not in cluster -> orphan, needs join (cleanup)
+// A member with our node name but none of its peer URLs equal to ours is a distinct, conflicting member (IP change): this takes priority over a successful peer-URL match,
+// because promoting/joining while a stale same-name voter lingers would strand quorum.
+func classifyEtcd(members []etcdMemberInfo, dataDirPresent bool, nodeName, peerURL string) etcdClassification {
+	var ourMember *etcdMemberInfo
+	nameConflict := false
+	for i := range members {
+		m := &members[i]
+		if memberHasPeerURL(m, peerURL) {
+			ourMember = m
+			continue
+		}
+		if nodeName != "" && m.Name == nodeName {
+			nameConflict = true
+		}
+	}
+
+	switch {
+	case nameConflict:
+		return etcdClassification{state: etcdNameConflict}
+	case ourMember != nil && dataDirPresent:
+		return etcdClassification{state: etcdJoined, isLearner: ourMember.IsLearner}
+	case ourMember != nil:
+		return etcdClassification{state: etcdNeedsJoin, isLearner: ourMember.IsLearner} // interrupted join
+	case dataDirPresent:
+		return etcdClassification{state: etcdOrphan}
+	default:
+		return etcdClassification{state: etcdNeedsJoin} // fresh
+	}
+}
+
+func memberHasPeerURL(m *etcdMemberInfo, peerURL string) bool {
+	for _, u := range m.PeerURLs {
+		if u == peerURL {
+			return true
+		}
+	}
+	return false
+}
+
+// classifyEtcdState fetches the membership snapshot and data-dir state, then runs the pure classifier.
 //
 // must ensure admin.conf exists before calling (for ensureAdminKubeconfig).
-func etcdNeedsJoin(node NodeIdentity, pkiDir, kubeconfigDir string) (bool, error) {
-	peerURL := etcd.GetPeerURL(node.AdvertiseIP)
-	exists, err := checkEtcdMemberExists(node.Name, peerURL, pkiDir, kubeconfigDir)
+func classifyEtcdState(node NodeIdentity, pkiDir, kubeconfigDir string) (etcdClassification, error) {
+	members, err := snapshotEtcdMembers(pkiDir, kubeconfigDir)
 	if err != nil {
-		return false, fmt.Errorf("check etcd membership: %w", err)
+		return etcdClassification{}, err
 	}
-	if exists {
-		return false, nil
-	}
-	_, err = os.Stat(etcdDataDir)
-	if os.IsNotExist(err) {
-		return true, nil
-	}
+	dataDirPresent, err := etcdDataDirExists()
 	if err != nil {
-		return false, fmt.Errorf("stat etcd data dir: %w", err)
+		return etcdClassification{}, fmt.Errorf("stat etcd data dir: %w", err)
 	}
-
-	// Data dir exists but member not in cluster - orphan node, needs rejoin
-	return true, nil
+	return classifyEtcd(members, dataDirPresent, node.Name, etcd.GetPeerURL(node.AdvertiseIP)), nil
 }
 
-// cleanupEtcdDataDir removes stale etcd data directory for orphaned nodes.
-func cleanupEtcdDataDir() error {
-	return os.RemoveAll(etcdDataDir)
-}
-
-// checkEtcdMemberExists connects to the etcd cluster and checks by name first, if name is empty (learner not yet started), falls back to peer URL match
-func checkEtcdMemberExists(nodeName, peerURL, pkiDir, kubeconfigDir string) (bool, error) {
+// snapshotEtcdMembers returns the current etcd membership as plain etcdMemberInfo values.
+func snapshotEtcdMembers(pkiDir, kubeconfigDir string) ([]etcdMemberInfo, error) {
 	adminConfPath := filepath.Join(kubeconfigDir, "admin.conf")
 	kubeClient, err := etcdclient.ClientSetFromFile(adminConfPath)
 	if err != nil {
-		return false, fmt.Errorf("create k8s client from admin.conf: %w", err)
+		return nil, fmt.Errorf("create k8s client from admin.conf: %w", err)
 	}
-
 	etcdCli, err := etcdclient.New(kubeClient, pkiDir)
 	if err != nil {
-		return false, fmt.Errorf("create etcd client: %w", err)
+		return nil, fmt.Errorf("create etcd client: %w", err)
 	}
 	defer etcdCli.Close()
 
 	ctx, cancel := context.WithTimeout(context.Background(), etcdMemberListTimeout)
 	defer cancel()
-
 	resp, err := etcdCli.Raw().MemberList(ctx)
 	if err != nil {
-		return false, fmt.Errorf("etcd member list: %w", err)
+		return nil, fmt.Errorf("etcd member list: %w", err)
 	}
 
+	members := make([]etcdMemberInfo, 0, len(resp.Members))
 	for _, m := range resp.Members {
-		if m.Name == nodeName {
-			return true, nil
-		}
-		if peerURL != "" {
-			for _, u := range m.PeerURLs {
-				if u == peerURL {
-					return true, nil
-				}
-			}
-		}
+		members = append(members, etcdMemberInfo{
+			Name:      m.Name,
+			PeerURLs:  m.PeerURLs,
+			IsLearner: m.IsLearner,
+		})
 	}
+	return members, nil
+}
 
-	return false, nil
+// etcdDataDirExists reports whether the local etcd data directory is present, meaning etcd has bootstrapped its storage at least once (and ignores --initial-cluster on restart).
+func etcdDataDirExists() (bool, error) {
+	_, err := os.Stat(etcdDataDir)
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, err
+}
+
+// cleanupEtcdDataDir removes stale etcd data directory for orphaned nodes.
+func cleanupEtcdDataDir() error {
+	return os.RemoveAll(etcdDataDir)
 }
 
 // ensureAdminKubeconfig creates admin.conf if it does not exist.
@@ -139,7 +200,8 @@ func ensureAdminKubeconfig(secretData map[string][]byte, pkiDir, kubeconfigDir, 
 	return err
 }
 
-// reconcileEtcdJoin handles etcd join for a fresh or orphaned node.
+// reconcileEtcdJoin runs the idempotent etcd join flow (etcd.JoinCluster).
+// It does NOT touch the data dir: any stale-data cleanup is the caller's responsibility, done only for the explicitly classified etcdOrphan state (see joinEtcdClusterStep).
 // Precondition: caller must ensure admin.conf exists - see joinEtcdClusterStep.
 func reconcileEtcdJoin(
 	node NodeIdentity,
@@ -148,15 +210,6 @@ func reconcileEtcdJoin(
 	annotations checksumAnnotations,
 	logger *log.Logger,
 ) error {
-	// Cleanup stale etcd data dir if it exists (orphaned node case)
-	if _, err := os.Stat(etcdDataDir); err == nil {
-		logger.Info("etcd join: cleaning up stale etcd data dir")
-		if err := cleanupEtcdDataDir(); err != nil {
-			logger.Error("failed to cleanup etcd data dir", log.Err(err))
-			return fmt.Errorf("cleanup etcd data dir: %w", err)
-		}
-	}
-
 	logger.Info("etcd join: preparing manifest")
 	manifest, err := prepareManifestWithOverrides(component, secretData, annotations, node)
 	if err != nil {

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/etcd.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/etcd.go
@@ -50,10 +50,6 @@ const (
 	etcdNeedsJoin
 	// etcdOrphan: our member is not registered but a stale local data dir exists. Wipe it and rejoin fresh.
 	etcdOrphan
-	// etcdNameConflict: a member carries our node name but none of its peer URLs is ours (e.g. the node was recreated with a new IP).
-	// Joining would add a second member and leave the old, unreachable voter in place (the removal hook keeps it by name), changing quorum requirements.
-	// Fail closed and require an explicit member replacement.
-	etcdNameConflict
 )
 
 type etcdMemberInfo struct {
@@ -68,26 +64,25 @@ type etcdClassification struct {
 }
 
 // classifyEtcd is the pure decision given the current members, whether the local data dir exists, and this node identity (name + peer URL).
-//
-// A member with our node name but none of its peer URLs equal to ours is a distinct, conflicting member (IP change): this takes priority over a successful peer-URL match,
-// because promoting/joining while a stale same-name voter lingers would strand quorum.
+// The peer URL is the strongest identity signal; the node name is a compatibility fallback.
 func classifyEtcd(members []etcdMemberInfo, dataDirPresent bool, nodeName, peerURL string) etcdClassification {
 	var ourMember *etcdMemberInfo
-	nameConflict := false
+	var memberByName *etcdMemberInfo
 	for i := range members {
 		m := &members[i]
 		if memberHasPeerURL(m, peerURL) {
 			ourMember = m
-			continue
+			break
 		}
-		if nodeName != "" && m.Name == nodeName {
-			nameConflict = true
+		if memberByName == nil && nodeName != "" && m.Name == nodeName {
+			memberByName = m
 		}
+	}
+	if ourMember == nil {
+		ourMember = memberByName
 	}
 
 	switch {
-	case nameConflict:
-		return etcdClassification{state: etcdNameConflict}
 	case ourMember != nil && dataDirPresent:
 		return etcdClassification{state: etcdJoined, isLearner: ourMember.IsLearner}
 	case ourMember != nil:

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/steps.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/steps.go
@@ -170,7 +170,7 @@ type joinEtcdClusterStep struct{}
 func (c *joinEtcdClusterStep) Execute(_ context.Context, env *StepEnv, logger *log.Logger) (StepResult, error) {
 	op := env.State.Raw()
 	if op.Spec.Component != controlplanev1alpha1.OperationComponentEtcd {
-		return StepResult{Outcome: OutcomeCompleted}, nil
+		return StepResult{Outcome: OutcomeCompleted, Message: "skipped: component is not etcd"}, nil
 	}
 
 	kubeconfigDir := env.Node.KubeconfigDir
@@ -186,13 +186,8 @@ func (c *joinEtcdClusterStep) Execute(_ context.Context, env *StepEnv, logger *l
 		return StepResult{}, fmt.Errorf("classify etcd state: %w", err)
 	}
 
+	joinMessage := "etcd member joined"
 	switch cls.state {
-	case etcdNameConflict:
-		// Fail closed with a plain error (requeue): a member with our node name is registered under a different peer URL (node IP change?).
-		// Auto-joining would add a duplicate and strand the old voter, changing quorum.
-		// The operation stays visibly stuck with this message until an operator performs an explicit member replacement.
-		return StepResult{}, fmt.Errorf("etcd member %q already registered with a different peer URL (node IP change?): manual member replacement required", env.Node.Name)
-
 	case etcdJoined:
 		// Member registered and local etcd bootstrapped: etcd ignores --initial-cluster on restart, so the self-only manifest from syncFullManifest is safe.
 		// Promote our own member only if it is still a learner (a previous join added it but never promoted it).
@@ -212,23 +207,25 @@ func (c *joinEtcdClusterStep) Execute(_ context.Context, env *StepEnv, logger *l
 				logger.Error("failed to promote own etcd member", log.Err(err))
 				return StepResult{}, fmt.Errorf("promote own etcd member: %w", err)
 			}
+			return StepResult{Outcome: OutcomeCompleted, Message: "etcd learner promoted; manifest synchronized"}, nil
 		}
-		return StepResult{Outcome: OutcomeCompleted}, nil
+		return StepResult{Outcome: OutcomeCompleted, Message: "etcd member already joined; manifest synchronized"}, nil
 
-	case etcdOrphan, etcdNeedsJoin:
+	case etcdOrphan:
 		// Orphan cleanup happens only here, for the explicitly classified state, so a concurrently starting etcd data dir is never deleted.
-		if cls.state == etcdOrphan {
-			logger.Info("etcd orphan: cleaning stale data dir before rejoin")
-			if err := cleanupEtcdDataDir(); err != nil {
-				logger.Error("failed to cleanup etcd data dir", log.Err(err))
-				return StepResult{}, fmt.Errorf("cleanup etcd data dir: %w", err)
-			}
+		logger.Info("etcd orphan: cleaning stale data dir before rejoin")
+		if err := cleanupEtcdDataDir(); err != nil {
+			logger.Error("failed to cleanup etcd data dir", log.Err(err))
+			return StepResult{}, fmt.Errorf("cleanup etcd data dir: %w", err)
 		}
+		joinMessage = "stale etcd data directory removed; member rejoined"
+		fallthrough
+	case etcdNeedsJoin:
 		logger.Info("etcd needs join, executing idempotent join flow")
 		if err := reconcileEtcdJoin(env.Node, op.Spec.Component, env.Secrets.CPMData, checksumAnnotationsFromSpec(op.Spec), logger); err != nil {
 			return StepResult{}, err
 		}
-		return StepResult{Outcome: OutcomeCompleted}, nil
+		return StepResult{Outcome: OutcomeCompleted, Message: joinMessage}, nil
 
 	default:
 		return StepResult{}, fmt.Errorf("unknown etcd join state: %d", cls.state)

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/steps.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/steps.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
+	"github.com/deckhouse/deckhouse/go_lib/controlplane/etcd"
 	"github.com/deckhouse/deckhouse/go_lib/controlplane/pki/signature"
 	"github.com/deckhouse/deckhouse/pkg/log"
 
@@ -180,12 +181,22 @@ func (c *joinEtcdClusterStep) Execute(_ context.Context, env *StepEnv, logger *l
 		return StepResult{}, fmt.Errorf("ensure admin kubeconfig: %w", err)
 	}
 
-	needsJoin, err := etcdNeedsJoin(env.Node, constants.KubernetesPkiPath, kubeconfigDir)
+	cls, err := classifyEtcdState(env.Node, constants.KubernetesPkiPath, kubeconfigDir)
 	if err != nil {
-		return StepResult{}, fmt.Errorf("check etcd join need: %w", err)
+		return StepResult{}, fmt.Errorf("classify etcd state: %w", err)
 	}
-	if !needsJoin {
-		logger.Info("etcd already in cluster, syncing manifest to desired state")
+
+	switch cls.state {
+	case etcdNameConflict:
+		// Fail closed with a plain error (requeue): a member with our node name is registered under a different peer URL (node IP change?).
+		// Auto-joining would add a duplicate and strand the old voter, changing quorum.
+		// The operation stays visibly stuck with this message until an operator performs an explicit member replacement.
+		return StepResult{}, fmt.Errorf("etcd member %q already registered with a different peer URL (node IP change?): manual member replacement required", env.Node.Name)
+
+	case etcdJoined:
+		// Member registered and local etcd bootstrapped: etcd ignores --initial-cluster on restart, so the self-only manifest from syncFullManifest is safe.
+		// Promote our own member only if it is still a learner (a previous join added it but never promoted it).
+		logger.Info("etcd already in cluster, syncing manifest and ensuring promotion")
 		annotations := buildSyncManifestAnnotations(op)
 		results, err := syncFullManifest(op.Spec.Component, env.Secrets.CPMData, annotations, env.Node)
 		if err != nil {
@@ -196,13 +207,32 @@ func (c *joinEtcdClusterStep) Execute(_ context.Context, env *StepEnv, logger *l
 		if !hasChangedFiles(results) {
 			logger.Info("sync manifests no-op: desired content already on disk")
 		}
+		if cls.isLearner {
+			if err := etcd.PromoteMember(env.Node.AdvertiseIP, etcd.WithCertificatesDir(constants.KubernetesPkiPath)); err != nil {
+				logger.Error("failed to promote own etcd member", log.Err(err))
+				return StepResult{}, fmt.Errorf("promote own etcd member: %w", err)
+			}
+		}
 		return StepResult{Outcome: OutcomeCompleted}, nil
+
+	case etcdOrphan, etcdNeedsJoin:
+		// Orphan cleanup happens only here, for the explicitly classified state, so a concurrently starting etcd data dir is never deleted.
+		if cls.state == etcdOrphan {
+			logger.Info("etcd orphan: cleaning stale data dir before rejoin")
+			if err := cleanupEtcdDataDir(); err != nil {
+				logger.Error("failed to cleanup etcd data dir", log.Err(err))
+				return StepResult{}, fmt.Errorf("cleanup etcd data dir: %w", err)
+			}
+		}
+		logger.Info("etcd needs join, executing idempotent join flow")
+		if err := reconcileEtcdJoin(env.Node, op.Spec.Component, env.Secrets.CPMData, checksumAnnotationsFromSpec(op.Spec), logger); err != nil {
+			return StepResult{}, err
+		}
+		return StepResult{Outcome: OutcomeCompleted}, nil
+
+	default:
+		return StepResult{}, fmt.Errorf("unknown etcd join state: %d", cls.state)
 	}
-	logger.Info("etcd needs join, executing join flow")
-	if err := reconcileEtcdJoin(env.Node, op.Spec.Component, env.Secrets.CPMData, checksumAnnotationsFromSpec(op.Spec), logger); err != nil {
-		return StepResult{}, err
-	}
-	return StepResult{Outcome: OutcomeCompleted}, nil
 }
 
 // syncManifestsStep writes the static pod manifest (or patches annotations for PKI-only updates).


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Improves the reliability and idempotency of joining control-plane nodes to an existing etcd cluster.

On every reconciliation, CPM classifies the local member using:

- The current etcd MemberList.
- The node name and advertised peer URL.
- The presence of /var/lib/etcd/member.
- The member's learner status.

Classification and actions:

- Joined — matching peer URL and local data exist. Sync the desired manifest and promote the member if it is still a learner.
- Needs join — local data are absent. Run the idempotent join flow, regardless of whether the member is new or was already added during an interrupted attempt.
- Orphan — local data exist, but no matching member exists in the cluster. Remove stale local data and rejoin.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
An etcd join can be interrupted after adding a learner but before writing its static pod manifest or promoting it. On the next reconciliation, the existing member could previously be treated as fully joined, leaving it permanently unstarted or unpromoted.

Retries could also rely on an empty MemberAdd response when the peer URL already existed.

The new flow derives the required action from the actual etcd membership and local state on every reconciliation. This allows CPM to converge safely after process restarts or partially completed joins without adding duplicate members or deleting active member data.


## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: fix
summary: Improved recovery and convergence of interrupted etcd member joins.
impact: New and recreated control-plane nodes now retry partially completed etcd joins and learner promotion automatically. Existing healthy etcd members are unaffected.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->