### PR TITLE
[docs] Change installer version channel to stable

### DIFF
--- a/docs/site/.helm/templates/10-cm.yaml
+++ b/docs/site/.helm/templates/10-cm.yaml
@@ -55,7 +55,7 @@ data:
         --retry-connrefused \
         --connect-timeout 10 \
         --max-time 30 \
-        "https://deckhouse.ru/downloads/deckhouse-installer-trdl/targets/channels/1/ea")
+        "https://deckhouse.ru/downloads/deckhouse-installer-trdl/targets/channels/1/stable")
 
     if [ -z "$VERSION" ]; then
       echo "Failed to retrieve version."


### PR DESCRIPTION
## Description
- Switch the version retrieval endpoint from the early-access channel to the stable channel for the Deckhouse Installer download configuration on the site.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Switch the version retrieval endpoint from the early-access channel to the stable channel for the Deckhouse Installer download configuration on the site.
impact_level: low
```
