### PR TITLE
[deckhouse-controller] fix: ensure embedded module source

### DIFF
--- a/deckhouse-controller/pkg/controller/moduleloader/loader.go
+++ b/deckhouse-controller/pkg/controller/moduleloader/loader.go
@@ -519,8 +519,22 @@ func (l *Loader) ensureModule(ctx context.Context, def *moduletypes.Definition, 
 				// set deckhouse version to embedded modules
 				module.Properties.Version = l.version
 
-				// set embedded source if its unset
-				if len(module.Properties.Source) == 0 {
+				// A physically embedded module must always report Source == "Embedded".
+				// This branch runs for a def parsed from the embedded modules dir, i.e. the
+				// embedded copy is shipped on the filesystem right now, so the module is
+				// served by that copy and its active source cannot be an external one.
+				// The transition off the "Embedded" sentinel is done elsewhere (moduleloader
+				// restore, release deploy) only once the embedded copy is dropped on upgrade,
+				// and both are gated on !IsEmbeddedPresent - so it can never legitimately be
+				// external while we are here.
+				//
+				// Force the sentinel back, do not merely fill it when empty: a stale external
+				// value (e.g. left over from a pre-hardening erroneous flip, or written by a
+				// future regression) would otherwise stick across restarts and could only be
+				// cleared by manually deleting the Module resource. ensureModule runs on every
+				// startup over exactly the set of physically embedded modules, so it is the
+				// authoritative reconciliation point for this invariant.
+				if module.Properties.Source != v1alpha1.ModuleSourceEmbedded {
 					module.Properties.Source = v1alpha1.ModuleSourceEmbedded
 				}
 			}

--- a/deckhouse-controller/pkg/controller/moduleloader/sync_test.go
+++ b/deckhouse-controller/pkg/controller/moduleloader/sync_test.go
@@ -32,6 +32,8 @@ import (
 	installermock "github.com/deckhouse/deckhouse/deckhouse-controller/internal/module/installer/mock"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha2"
+	moduletypes "github.com/deckhouse/deckhouse/deckhouse-controller/pkg/controller/moduleloader/types"
+	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/helpers"
 	"github.com/deckhouse/deckhouse/go_lib/dependency"
 	"github.com/deckhouse/deckhouse/pkg/log"
 )
@@ -404,5 +406,75 @@ func TestDeleteStaleModuleReleases(t *testing.T) {
 
 		err := l.client.Get(context.Background(), client.ObjectKey{Name: "echo-v1.0.0"}, new(v1alpha1.ModuleRelease))
 		assert.NoError(t, err, "embedded module release must be kept")
+	})
+}
+
+// --- ensureModule ----------------------------------------------------------
+
+// newEnsureLoader builds a Loader wired for ensureModule: it needs the embedded
+// update policy (for the release channel) and a version, which newTestLoader
+// leaves unset.
+func newEnsureLoader(t *testing.T, objects ...client.Object) *Loader {
+	t.Helper()
+	l := newTestLoader(t, newRecordingInstaller(new(installerCalls), nil), objects...)
+	l.version = "v1.76.0"
+	l.embeddedPolicy = helpers.NewModuleUpdatePolicySpecContainer(&v1alpha2.ModuleUpdatePolicySpec{
+		ReleaseChannel: "Stable",
+	})
+	return l
+}
+
+// TestEnsureModuleEmbeddedSource verifies that ensureModule keeps the invariant
+// "a physically embedded module always reports Source == Embedded". This is the
+// reconciliation point that heals a stale external source (e.g. deckhouse) left
+// on an embedded module by a pre-hardening erroneous flip after a registry
+// migration - a value that otherwise stuck until the Module was deleted by hand.
+func TestEnsureModuleEmbeddedSource(t *testing.T) {
+	embeddedDef := func() *moduletypes.Definition {
+		return &moduletypes.Definition{
+			Name:   "ingress-nginx",
+			Weight: 380,
+			// parsed from the embedded modules dir - i.e. shipped on the filesystem
+			Path: "/deckhouse/modules/380-ingress-nginx",
+		}
+	}
+
+	t.Run("stale external source on an embedded module is reset to Embedded", func(t *testing.T) {
+		l := newEnsureLoader(t, testModule("ingress-nginx", "deckhouse"))
+
+		require.NoError(t, l.ensureModule(context.Background(), embeddedDef(), true))
+
+		module := getModule(t, l, "ingress-nginx")
+		assert.Equal(t, v1alpha1.ModuleSourceEmbedded, module.Properties.Source,
+			"embedded module must be pinned back to the Embedded source")
+	})
+
+	t.Run("empty source on an embedded module is set to Embedded", func(t *testing.T) {
+		l := newEnsureLoader(t, testModule("ingress-nginx", ""))
+
+		require.NoError(t, l.ensureModule(context.Background(), embeddedDef(), true))
+
+		module := getModule(t, l, "ingress-nginx")
+		assert.Equal(t, v1alpha1.ModuleSourceEmbedded, module.Properties.Source)
+	})
+
+	t.Run("embedded source is left untouched", func(t *testing.T) {
+		l := newEnsureLoader(t, testModule("ingress-nginx", v1alpha1.ModuleSourceEmbedded))
+
+		require.NoError(t, l.ensureModule(context.Background(), embeddedDef(), true))
+
+		module := getModule(t, l, "ingress-nginx")
+		assert.Equal(t, v1alpha1.ModuleSourceEmbedded, module.Properties.Source)
+	})
+
+	t.Run("downloaded (non-embedded) module keeps its external source", func(t *testing.T) {
+		l := newEnsureLoader(t, testModule("echo", "example"))
+		def := &moduletypes.Definition{Name: "echo", Weight: 900, Path: l.downloadedModulesDir + "/modules/echo"}
+
+		require.NoError(t, l.ensureModule(context.Background(), def, false))
+
+		module := getModule(t, l, "echo")
+		assert.Equal(t, "example", module.Properties.Source,
+			"a downloaded module must not be forced to the Embedded source")
 	})
 }


### PR DESCRIPTION
## Description

`ensureModule` runs on every controller startup over the set of physically embedded modules. Previously it only set `Properties.Source = Embedded` when the field was **empty**:

```go
if len(module.Properties.Source) == 0 {
    module.Properties.Source = v1alpha1.ModuleSourceEmbedded
}
```

This means a *stale, non-empty external* source (e.g. `deckhouse`) left on an embedded module would never be corrected. Once set, the wrong value stuck across every restart and could only be cleared by manually deleting the `Module` resource.

This PR changes the check to force the sentinel back whenever it is not already `Embedded`:

```go
if module.Properties.Source != v1alpha1.ModuleSourceEmbedded {
    module.Properties.Source = v1alpha1.ModuleSourceEmbedded
}
```

Because this branch only runs for definitions parsed from the embedded modules dir — i.e. the embedded copy is physically shipped on the filesystem — the module is served by that copy and its active source cannot legitimately be external. The transition off the `Embedded` sentinel (moduleloader restore, release deploy) happens elsewhere and is gated on `!IsEmbeddedPresent`, so it can never be external while `ensureModule` is running. This makes `ensureModule` the authoritative reconciliation point for the invariant "a physically embedded module always reports `Source == Embedded`".

Downloaded (non-embedded) modules are unaffected and keep their external source.

## Why do we need it, and what problem does it solve?

Fixes the invariant that an embedded module must always report `Source == "Embedded"`. A pre-hardening erroneous flip (e.g. after a registry migration) could leave an external source value on an embedded module. With the old empty-only check, that value was never healed and persisted across restarts, with the only workaround being to delete the `Module` resource by hand. This makes startup reconciliation self-healing for that case.

## Why do we need it in the patch release (if we do)?

Clusters that already hit the erroneous flip are stuck with a wrong `Source` on embedded modules until the operator manually deletes the affected `Module` resources. Backporting lets those clusters self-heal on the next controller restart without manual intervention.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse-controller
type: fix
summary: Force embedded modules back to the "Embedded" source on startup, healing a stale external source that previously stuck until the Module resource was deleted manually.
impact_level: default
```
