### PR TITLE
[docs] Add the Short Names CRD rendering on the reference pages

### DIFF
--- a/docs/documentation/_plugins/render-jsonschema.rb
+++ b/docs/documentation/_plugins/render-jsonschema.rb
@@ -178,6 +178,13 @@ module JSONSchemaRenderer
         input ? input.dig(*keys) : nil
     end
 
+    def format_crd_short_names(input)
+        shortNames = get_hash_value(input, 'spec', 'names', 'shortNames')
+        return '' if shortNames.nil? || shortNames.empty?
+
+        '<p><font size="-1"><strong>Short names: ' + Array(shortNames).join(', ') + '</strong></font></p>'
+    end
+
     def get_search_keywords(primaryLanguage, fallbackLanguage = nil)
       return '' if !primaryLanguage
       if get_hash_value(primaryLanguage, "x-doc-search") then
@@ -989,6 +996,7 @@ module JSONSchemaRenderer
                 resourceGroup = get_hash_value(input,'metadata','name')
                 fullPath = [sprintf(%q(v1beta1-%s), input["spec"]["names"]["kind"])]
                 result.push("<h2>#{resourceName}</h2>")
+                result.push(format_crd_short_names(input))
                 result.push('<p><font size="-1">Scope: ' + input["spec"]["scope"])
                 if input["spec"].has_key?("version") then
                    result.push('<br/>Version: ' + input["spec"]["version"] + '</font></p>')
@@ -1053,6 +1061,7 @@ module JSONSchemaRenderer
                  result.push("<h2>#{resourceName}</h2>")
 
                  if  input["spec"]["versions"].length > 1 then
+                     result.push(format_crd_short_names(input))
                      result.push('<p><font size="-1">Scope: ' + input["spec"]["scope"] + '</font></p>')
                      result.push('<div class="tabs-block">')
                      result.push('<ul class="tabs__container tabs__container--title">')
@@ -1076,6 +1085,7 @@ module JSONSchemaRenderer
                     versionAPI = item['name']
 
                     if input["spec"]["versions"].length == 1 then
+                        result.push(format_crd_short_names(input))
                         result.push('<p><font size="-1">Scope: ' + input["spec"]["scope"])
                         result.push('<br/>Version: ' + item['name'] + '</font></p>')
                     else

--- a/docs/site/_plugins/render-jsonschema.rb
+++ b/docs/site/_plugins/render-jsonschema.rb
@@ -162,6 +162,13 @@ module JSONSchemaRenderer
         input ? input.dig(*keys) : nil
     end
 
+    def format_crd_short_names(input)
+        shortNames = get_hash_value(input, 'spec', 'names', 'shortNames')
+        return '' if shortNames.nil? || shortNames.empty?
+
+        '<p><font size="-1"><strong>Short names: ' + Array(shortNames).join(', ') + '</strong></font></p>'
+    end
+
     def get_search_keywords(primaryLanguage, fallbackLanguage = nil)
       return '' if !primaryLanguage
       if get_hash_value(primaryLanguage, "x-doc-search") then
@@ -909,6 +916,7 @@ module JSONSchemaRenderer
                 resourceName = input["spec"]["names"]["kind"]
                 fullPath = [sprintf(%q(v1beta1-%s), input["spec"]["names"]["kind"])]
                 result.push(convert("## " + input["spec"]["names"]["kind"]))
+                result.push(format_crd_short_names(input))
                 result.push('<p><font size="-1">Scope: ' + input["spec"]["scope"])
                 if input["spec"].has_key?("version") then
                    result.push('<br/>Version: ' + input["spec"]["version"] + '</font></p>')
@@ -971,6 +979,7 @@ module JSONSchemaRenderer
                  result.push(%Q(<h2>#{input["spec"]["names"]["kind"]}</h2>))
 
                  if  input["spec"]["versions"].length > 1 then
+                     result.push(format_crd_short_names(input))
                      result.push('<p><font size="-1">Scope: ' + input["spec"]["scope"] + '</font></p>')
                      result.push('<div class="tabs-block">')
                      result.push('<ul class="tabs__container tabs__container--title">')
@@ -994,6 +1003,7 @@ module JSONSchemaRenderer
                     versionAPI = item['name']
 
                     if input["spec"]["versions"].length == 1 then
+                        result.push(format_crd_short_names(input))
                         result.push('<p><font size="-1">Scope: ' + input["spec"]["scope"])
                         result.push('<br/>Version: ' + item['name'] + '</font></p>')
                     else

--- a/docs/site/backends/docs-builder-template/layouts/_partials/openapi/extract-crd-search-params.html
+++ b/docs/site/backends/docs-builder-template/layouts/_partials/openapi/extract-crd-search-params.html
@@ -7,6 +7,10 @@
 {{- $searchParams := slice }}
 
 {{- $kind := $crdData.spec.names.kind }}
+{{- $shortNames := slice }}
+{{- if $crdData.spec.names.shortNames }}
+  {{- $shortNames = $crdData.spec.names.shortNames }}
+{{- end }}
 
 {{- if $crdData.spec.versions }}
   {{- /* Find the stablest API version according to Kubernetes rules */}}
@@ -78,6 +82,10 @@
   {{- if $langVersionData.schema.openAPIV3Schema.description }}
     {{- $description = $langVersionData.schema.openAPIV3Schema.description }}
   {{- end }}
+  {{- $content := default "" $description }}
+  {{- if gt (len $shortNames) 0 }}
+    {{- $content = printf "%s\nShort names: %s" $content (delimit $shortNames ", ") }}
+  {{- end }}
 
   {{- /* Add CRD resource itself as a searchable item */}}
   {{- $crdParam := dict
@@ -86,7 +94,7 @@
     "moduletype" "source"
     "url" (printf "/modules/%s/%s/cr.html#%s" $moduleName $moduleChannel ( $kind | lower))
     "path" (printf "%s-%s" ($kind | lower) $versionName)
-    "content" $description
+    "content" $content
     "resName" $kind
     "isResource" "true" }}
 

--- a/docs/site/backends/docs-builder-template/layouts/_partials/openapi/format-crd.html
+++ b/docs/site/backends/docs-builder-template/layouts/_partials/openapi/format-crd.html
@@ -1,9 +1,17 @@
-{{/* Renders a CRD. */}}
+  {{/* Renders a CRD. */}}
 
 {{- $data := .data }}
 {{- $langData := .langData }}
 {{- $kind := .data.spec.names.kind }}
 {{- $kindDowncase := .data.spec.names.kind | lower }}
+{{- $shortNames := slice }}
+{{- if $data.spec.names.shortNames }}
+  {{- $shortNames = $data.spec.names.shortNames }}
+{{- end }}
+{{- $shortNamesLine := "" }}
+{{- if gt ( $shortNames | len ) 0 }}
+  {{- $shortNamesLine = printf "<p><font size=\"-1\"><strong>Short names: %s</strong></font></p>" ( delimit $shortNames ", " ) }}
+{{- end }}
 
 <h2>{{ $kind }}</h2>
 
@@ -16,6 +24,7 @@
 
 {{- if and $data.spec.versions (gt ( $data.spec.versions | len ) 0) }}
   {{- if gt ( $data.spec.versions | len ) 1 }}
+    {{- $shortNamesLine | safeHTML }}
     <p><font size="-1">Scope: {{ $data.spec.scope }}</font></p>
     <div class="tabs-block">
     <ul class="tabs__container tabs__container--title">
@@ -33,6 +42,7 @@
     {{- $versionSchema := ( index (where $data.spec.versions "name" .) 0 ).schema.openAPIV3Schema }}
 
     {{- if eq ( $data.spec.versions | len ) 1 }}
+      {{- $shortNamesLine | safeHTML }}
       <p><font size="-1">Scope: {{ $data.spec.scope }}
       <br/>Version: {{ $versionName }}</font></p>
     {{- end }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Added rendering of `spec.names.shortNames` in CRD documentation.

CRDs that define the `shortNames` array now show a `Short names` line next to `Scope` and `Version`, for example `mc` for `ModuleConfig` and `ng` for `NodeGroup`.

The change was added to both CRD renderers: the Jekyll/Ruby renderer for the current documentation pages and the Hugo docs-builder renderer for module CRDs. Short names were also added to the Hugo search index so resources can be found by their abbreviations.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Add short names render.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
