### PR TITLE
[cloud-provider-dvp][cloud-provider-dynamix] fix  rbacv1 instanceclass

### DIFF
--- a/ee/modules/030-cloud-provider-dynamix/templates/user-authz-cluster-roles.yaml
+++ b/ee/modules/030-cloud-provider-dynamix/templates/user-authz-cluster-roles.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    user-authz.deckhouse.io/access-level: User
+  name: d8:user-authz:cloud-provider-dynamix:user
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+rules:
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - dynamixinstanceclasses
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    user-authz.deckhouse.io/access-level: ClusterAdmin
+  name: d8:user-authz:cloud-provider-dynamix:cluster-admin
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+rules:
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - dynamixinstanceclasses
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update

--- a/modules/030-cloud-provider-dvp/templates/user-authz-cluster-roles.yaml
+++ b/modules/030-cloud-provider-dvp/templates/user-authz-cluster-roles.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    user-authz.deckhouse.io/access-level: User
+  name: d8:user-authz:cloud-provider-dvp:user
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+rules:
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - dvpinstanceclasses
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    user-authz.deckhouse.io/access-level: ClusterAdmin
+  name: d8:user-authz:cloud-provider-dvp:cluster-admin
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+rules:
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - dvpinstanceclasses
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Added `templates/user-authz-cluster-roles.yaml` to `cloud-provider-dvp` and `cloud-provider-dynamix` modules. Each file creates two ClusterRoles — `d8:user-authz:<provider>:user` (access-level: User, grants `get/list/watch`) and `d8:user-authz:<provider>:cluster-admin` (access-level: ClusterAdmin, grants write verbs)
   — for the corresponding `*InstanceClass` CRD.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

 Users with `ClusterAuthorizationRule.spec.accessLevel: ClusterAdmin` (role `user-authz:cluster-admin`) had no access to `DVPInstanceClass` and `DynamixInstanceClass`. The `user-authz` module discovers provider-specific CRD permissions via the `user-authz.deckhouse.io/access-level` annotation on ClusterRoles. Both
  modules were missing the required template file, so no such ClusterRoles existed in the cluster and the node-manager UI and CLI workflows that read `*InstanceClass` objects were broken for non-`system:masters` users.

## Why do we need it in the patch release (if we do)?

Regression affects all clusters in release-1.76 with DVP or Dynamix cloud provider. Users cannot read or manage `DVPInstanceClass`/`DynamixInstanceClass` objects. No workaround without granting raw `cluster-admin`.

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-dvp
type: fix
summary: Fix DVPInstanceClass access for users with user-authz ClusterAdmin role
impact_level: high
impact: Users with accessLevel ClusterAdmin in ClusterAuthorizationRule gain read and write access to DVPInstanceClass objects; previously all access was denied.
---
section: cloud-provider-dynamix
type: fix
summary: Fix DynamixInstanceClass access for users with user-authz ClusterAdmin role
impact_level: high
impact: Users with accessLevel ClusterAdmin in ClusterAuthorizationRule gain read and write access to DynamixInstanceClass objects; previously all access was denied.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
