### PR TITLE
[cloud-provider-dvp] fix rbacv2 

### DIFF
--- a/modules/030-cloud-provider-dvp/templates/rbacv2/manage/edit.yaml
+++ b/modules/030-cloud-provider-dvp/templates/rbacv2/manage/edit.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    heritage: deckhouse
+    module: cloud-provider-dvp
+    rbac.deckhouse.io/aggregate-to-infrastructure-as: manager
+    rbac.deckhouse.io/kind: manage
+    rbac.deckhouse.io/level: module
+    rbac.deckhouse.io/namespace: d8-cloud-provider-dvp
+  name: d8:manage:permission:module:cloud-provider-dvp:edit
+rules:
+- apiGroups:
+  - deckhouse.io
+  resourceNames:
+  - cloud-provider-dvp
+  resources:
+  - moduleconfigs
+  verbs:
+  - create
+  - update
+  - patch
+  - delete

--- a/modules/030-cloud-provider-dvp/templates/rbacv2/manage/view.yaml
+++ b/modules/030-cloud-provider-dvp/templates/rbacv2/manage/view.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    heritage: deckhouse
+    module: cloud-provider-dvp
+    rbac.deckhouse.io/aggregate-to-infrastructure-as: viewer
+    rbac.deckhouse.io/kind: manage
+    rbac.deckhouse.io/level: module
+    rbac.deckhouse.io/namespace: d8-cloud-provider-dvp
+  name: d8:manage:permission:module:cloud-provider-dvp:view
+rules:
+- apiGroups:
+  - deckhouse.io
+  resourceNames:
+  - cloud-provider-dvp
+  resources:
+  - moduleconfigs
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Added `templates/rbacv2/manage/view.yaml` and `templates/rbacv2/manage/edit.yaml` to `cloud-provider-dvp`. Creates ClusterRoles `d8:manage:permission:module:cloud-provider-dvp:view` and `d8:manage:permission:module:cloud-provider-dvp:edit` that aggregate into `d8:manage:infrastructure:viewer` and
  `d8:manage:infrastructure:manager` respectively.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

  Users with rbacv2 `d8:manage:infrastructure:viewer` or `d8:manage:infrastructure:manager` roles could not read or modify the `cloud-provider-dvp` ModuleConfig. All other 10 cloud-provider modules publish these ClusterRoles; DVP was missing them.


## Why do we need it in the patch release (if we do)?

We don't

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-dvp
type: fix
summary: "Fixed ModuleConfig access for users with the d8:manage:infrastructure:viewer and d8:manage:infrastructure:manager roles."
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
