### PR TITLE
[istio] Fix dmt lint for CSE 1.73

### DIFF
--- a/ee/modules/110-istio/templates/alliance/ingressgateway/daemonset.yaml
+++ b/ee/modules/110-istio/templates/alliance/ingressgateway/daemonset.yaml
@@ -175,10 +175,11 @@ spec:
           timeoutSeconds: 3
           failureThreshold: 30
         securityContext:
-          runAsGroup: 1337
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 1337
-          readOnlyRootFilesystem: true
+          runAsGroup: 1337
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 10 | nindent 12 }}

--- a/ee/modules/110-istio/templates/alliance/ingressgateway/daemonset.yaml
+++ b/ee/modules/110-istio/templates/alliance/ingressgateway/daemonset.yaml
@@ -176,10 +176,10 @@ spec:
           failureThreshold: 30
         securityContext:
           allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
+          runAsGroup: 1337
           runAsNonRoot: true
           runAsUser: 1337
-          runAsGroup: 1337
+          readOnlyRootFilesystem: true
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 10 | nindent 12 }}

--- a/modules/110-istio/.dmtlint.yaml
+++ b/modules/110-istio/.dmtlint.yaml
@@ -30,6 +30,10 @@ linters-settings:
         - kind: Deployment
           name: metadata-exporter
           container: metadata-discovery
+      no-new-privileges:
+        - kind: DaemonSet
+          name: istio-cni-node
+          container: install-cni
   templates:
     exclude-rules:
       service-port:

--- a/modules/110-istio/module.yaml
+++ b/modules/110-istio/module.yaml
@@ -4,6 +4,8 @@ subsystems:
   - infrastructure
   - networking
 namespace: d8-istio
+requirements:
+  deckhouse: ">= 1.68.0"
 descriptions:
   en: Implements Service Mesh for centralized management of network traffic in the cluster. Provides mutual TLS, authorization, traffic routing, load balancing, and observability.
   ru: Реализует Service Mesh для централизованного управления сетевым трафиком в кластере. Обеспечивает mutual TLS, авторизацию, маршрутизацию трафика, балансировку нагрузки и наблюдаемость.

--- a/modules/110-istio/monitoring/grafana-dashboards/istio/extension.json
+++ b/modules/110-istio/monitoring/grafana-dashboards/istio/extension.json
@@ -117,7 +117,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "type": "graph",
+      "type": "timeseries",
       "xaxis": {
         "buckets": null,
         "mode": "time",
@@ -219,7 +219,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "type": "graph",
+      "type": "timeseries",
       "xaxis": {
         "buckets": null,
         "mode": "time",
@@ -330,7 +330,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "type": "graph",
+      "type": "timeseries",
       "xaxis": {
         "buckets": null,
         "mode": "time",
@@ -437,7 +437,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "type": "graph",
+      "type": "timeseries",
       "xaxis": {
         "buckets": null,
         "mode": "time",
@@ -539,7 +539,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "type": "graph",
+      "type": "timeseries",
       "xaxis": {
         "buckets": null,
         "mode": "time",
@@ -654,7 +654,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "type": "graph",
+      "type": "timeseries",
       "xaxis": {
         "buckets": null,
         "mode": "time",
@@ -755,7 +755,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "type": "graph",
+      "type": "timeseries",
       "xaxis": {
         "buckets": null,
         "mode": "time",
@@ -803,9 +803,9 @@
         },
         "hide": 0,
         "includeAll": false,
-        "label": null,
+        "label": "Prometheus",
         "multi": false,
-        "name": "datasource",
+        "name": "ds_prometheus",
         "options": [],
         "query": "prometheus",
         "queryValue": "",

--- a/modules/110-istio/monitoring/grafana-dashboards/istio/mesh.json
+++ b/modules/110-istio/monitoring/grafana-dashboards/istio/mesh.json
@@ -1636,7 +1636,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "type": "graph",
+      "type": "timeseries",
       "xaxis": {
         "buckets": null,
         "mode": "time",
@@ -1682,9 +1682,9 @@
         },
         "hide": 0,
         "includeAll": false,
-        "label": null,
+        "label": "Prometheus",
         "multi": false,
-        "name": "datasource",
+        "name": "ds_prometheus",
         "options": [],
         "query": "prometheus",
         "queryValue": "",

--- a/modules/110-istio/monitoring/grafana-dashboards/istio/service.json
+++ b/modules/110-istio/monitoring/grafana-dashboards/istio/service.json
@@ -337,7 +337,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -752,7 +752,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -998,7 +998,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -1107,7 +1107,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -1271,7 +1271,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -1433,7 +1433,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -1595,7 +1595,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -1699,7 +1699,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -1802,7 +1802,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -1947,7 +1947,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -2056,7 +2056,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -2220,7 +2220,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -2382,7 +2382,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -2544,7 +2544,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -2648,7 +2648,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -2751,7 +2751,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -2801,9 +2801,9 @@
         },
         "hide": 0,
         "includeAll": false,
-        "label": null,
+        "label": "Prometheus",
         "multi": false,
-        "name": "datasource",
+        "name": "ds_prometheus",
         "options": [],
         "query": "prometheus",
         "queryValue": "",

--- a/modules/110-istio/monitoring/grafana-dashboards/istio/workload.json
+++ b/modules/110-istio/monitoring/grafana-dashboards/istio/workload.json
@@ -337,7 +337,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -684,7 +684,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -793,7 +793,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -957,7 +957,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -1119,7 +1119,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -1281,7 +1281,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -1385,7 +1385,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -1488,7 +1488,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -1633,7 +1633,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -1742,7 +1742,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -1906,7 +1906,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -2068,7 +2068,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -2230,7 +2230,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -2333,7 +2333,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -2436,7 +2436,7 @@
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -2486,9 +2486,9 @@
         },
         "hide": 0,
         "includeAll": false,
-        "label": null,
+        "label": "Prometheus",
         "multi": false,
-        "name": "datasource",
+        "name": "ds_prometheus",
         "options": [],
         "query": "prometheus",
         "queryValue": "",

--- a/modules/110-istio/openapi/values.yaml
+++ b/modules/110-istio/openapi/values.yaml
@@ -2,6 +2,12 @@ x-extend:
   schema: config-values.yaml
 type: object
 properties:
+  registry:
+    type: object
+    default: {}
+    properties:
+      dockercfg:
+        type: string
   internal:
     type: object
     default: {}

--- a/modules/110-istio/template_tests/module_test.go
+++ b/modules/110-istio/template_tests/module_test.go
@@ -66,6 +66,7 @@ discovery:
 `
 
 const istioValues = `
+    registry: {}
     internal:
       applicationNamespaces: []
       globalVersion: "1.21.6"

--- a/modules/110-istio/templates/cni/daemonset.yaml
+++ b/modules/110-istio/templates/cni/daemonset.yaml
@@ -85,6 +85,7 @@ spec:
             - install-cni
           {{- if not $.Values.istio.internal.enableAmbientMode }}
           securityContext:
+            allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             runAsNonRoot: false
             runAsUser: 0

--- a/modules/110-istio/templates/cni/daemonset.yaml
+++ b/modules/110-istio/templates/cni/daemonset.yaml
@@ -91,10 +91,7 @@ spec:
             runAsUser: 0
             runAsGroup: 0
           {{- else }}
-          securityContext:
-            allowPrivilegeEscalation: false
-            privileged: true
-            readOnlyRootFilesystem: true
+          {{- include "helm_lib_module_container_security_context_privileged_read_only_root_filesystem" . | nindent 10 }}
           {{- end }}
           env:
             {{- if ($.Values.istio.internal.enableAmbientMode) }}

--- a/modules/110-istio/templates/cni/daemonset.yaml
+++ b/modules/110-istio/templates/cni/daemonset.yaml
@@ -91,7 +91,10 @@ spec:
             runAsUser: 0
             runAsGroup: 0
           {{- else }}
-          {{- include "helm_lib_module_container_security_context_privileged_read_only_root_filesystem" . | nindent 10 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: true
+            readOnlyRootFilesystem: true
           {{- end }}
           env:
             {{- if ($.Values.istio.internal.enableAmbientMode) }}

--- a/modules/110-istio/templates/ingress-gateway-controller/registry-secret.yaml
+++ b/modules/110-istio/templates/ingress-gateway-controller/registry-secret.yaml
@@ -1,3 +1,8 @@
+{{- $dockercfg := .Values.global.modulesImages.registry.dockercfg }}
+{{- if .Values.istio.registry }}
+  {{- $dockercfg = .Values.istio.registry.dockercfg | default $dockercfg }}
+{{- end }}
+{{- if $dockercfg }}
 ---
 apiVersion: v1
 kind: Secret
@@ -7,4 +12,5 @@ metadata:
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 type: kubernetes.io/dockerconfigjson
 data:
-  .dockerconfigjson: {{ .Values.istio.registry.dockercfg | default .Values.global.modulesImages.registry.dockercfg }}
+  .dockerconfigjson: {{ $dockercfg }}
+{{- end }}

--- a/modules/110-istio/templates/ingress-gateway-controller/registry-secret.yaml
+++ b/modules/110-istio/templates/ingress-gateway-controller/registry-secret.yaml
@@ -7,5 +7,4 @@ metadata:
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 type: kubernetes.io/dockerconfigjson
 data:
-  .dockerconfigjson: {{ .Values.global.modulesImages.registry.dockercfg }}
-
+  .dockerconfigjson: {{ .Values.istio.registry.dockercfg | default .Values.global.modulesImages.registry.dockercfg }}

--- a/modules/110-istio/templates/ingress-gateway-controller/registry-secret.yaml
+++ b/modules/110-istio/templates/ingress-gateway-controller/registry-secret.yaml
@@ -1,8 +1,3 @@
-{{- $dockercfg := .Values.global.modulesImages.registry.dockercfg }}
-{{- if .Values.istio.registry }}
-  {{- $dockercfg = .Values.istio.registry.dockercfg | default $dockercfg }}
-{{- end }}
-{{- if $dockercfg }}
 ---
 apiVersion: v1
 kind: Secret
@@ -12,5 +7,4 @@ metadata:
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 type: kubernetes.io/dockerconfigjson
 data:
-  .dockerconfigjson: {{ $dockercfg }}
-{{- end }}
+  .dockerconfigjson: {{ .Values.istio.registry.dockercfg | default .Values.global.modulesImages.registry.dockercfg }}

--- a/modules/110-istio/templates/ingress-gateway-controller/registry-secret.yaml
+++ b/modules/110-istio/templates/ingress-gateway-controller/registry-secret.yaml
@@ -1,3 +1,4 @@
+{{- if or .Values.global.modulesImages.registry.dockercfg .Values.istio.registry.dockercfg }}
 ---
 apiVersion: v1
 kind: Secret
@@ -8,3 +9,4 @@ metadata:
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ .Values.istio.registry.dockercfg | default .Values.global.modulesImages.registry.dockercfg }}
+{{- end }}

--- a/modules/110-istio/templates/registry-secret.yaml
+++ b/modules/110-istio/templates/registry-secret.yaml
@@ -1,3 +1,8 @@
+{{- $dockercfg := .Values.global.modulesImages.registry.dockercfg }}
+{{- if .Values.istio.registry }}
+  {{- $dockercfg = .Values.istio.registry.dockercfg | default $dockercfg }}
+{{- end }}
+{{- if $dockercfg }}
 ---
 apiVersion: v1
 kind: Secret
@@ -7,7 +12,7 @@ metadata:
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 type: kubernetes.io/dockerconfigjson
 data:
-  .dockerconfigjson: {{ .Values.istio.registry.dockercfg | default .Values.global.modulesImages.registry.dockercfg }}
+  .dockerconfigjson: {{ $dockercfg }}
 
 {{- $namespaces := .Values.istio.internal.applicationNamespaces }}
 {{- $namespaces = append $namespaces (printf "d8-%s" .Chart.Name) }} # d8-istio
@@ -21,5 +26,6 @@ metadata:
   {{- include "helm_lib_module_labels" (list $) | nindent 2 }}
 type: kubernetes.io/dockerconfigjson
 data:
-  .dockerconfigjson: {{ $.Values.istio.registry.dockercfg | default $.Values.global.modulesImages.registry.dockercfg }}
+  .dockerconfigjson: {{ $dockercfg }}
+{{- end }}
 {{- end }}

--- a/modules/110-istio/templates/registry-secret.yaml
+++ b/modules/110-istio/templates/registry-secret.yaml
@@ -1,3 +1,4 @@
+{{- if or .Values.global.modulesImages.registry.dockercfg .Values.istio.registry.dockercfg }}
 ---
 apiVersion: v1
 kind: Secret
@@ -22,4 +23,5 @@ metadata:
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ $.Values.istio.registry.dockercfg | default $.Values.global.modulesImages.registry.dockercfg }}
+{{- end }}
 {{- end }}

--- a/modules/110-istio/templates/registry-secret.yaml
+++ b/modules/110-istio/templates/registry-secret.yaml
@@ -1,8 +1,3 @@
-{{- $dockercfg := .Values.global.modulesImages.registry.dockercfg }}
-{{- if .Values.istio.registry }}
-  {{- $dockercfg = .Values.istio.registry.dockercfg | default $dockercfg }}
-{{- end }}
-{{- if $dockercfg }}
 ---
 apiVersion: v1
 kind: Secret
@@ -12,7 +7,7 @@ metadata:
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 type: kubernetes.io/dockerconfigjson
 data:
-  .dockerconfigjson: {{ $dockercfg }}
+  .dockerconfigjson: {{ .Values.istio.registry.dockercfg | default .Values.global.modulesImages.registry.dockercfg }}
 
 {{- $namespaces := .Values.istio.internal.applicationNamespaces }}
 {{- $namespaces = append $namespaces (printf "d8-%s" .Chart.Name) }} # d8-istio
@@ -26,6 +21,5 @@ metadata:
   {{- include "helm_lib_module_labels" (list $) | nindent 2 }}
 type: kubernetes.io/dockerconfigjson
 data:
-  .dockerconfigjson: {{ $dockercfg }}
-{{- end }}
+  .dockerconfigjson: {{ $.Values.istio.registry.dockercfg | default $.Values.global.modulesImages.registry.dockercfg }}
 {{- end }}

--- a/modules/110-istio/templates/registry-secret.yaml
+++ b/modules/110-istio/templates/registry-secret.yaml
@@ -7,7 +7,7 @@ metadata:
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 type: kubernetes.io/dockerconfigjson
 data:
-  .dockerconfigjson: {{ .Values.global.modulesImages.registry.dockercfg }}
+  .dockerconfigjson: {{ .Values.istio.registry.dockercfg | default .Values.global.modulesImages.registry.dockercfg }}
 
 {{- $namespaces := .Values.istio.internal.applicationNamespaces }}
 {{- $namespaces = append $namespaces (printf "d8-%s" .Chart.Name) }} # d8-istio
@@ -21,6 +21,5 @@ metadata:
   {{- include "helm_lib_module_labels" (list $) | nindent 2 }}
 type: kubernetes.io/dockerconfigjson
 data:
-  .dockerconfigjson: {{ $.Values.global.modulesImages.registry.dockercfg }}
+  .dockerconfigjson: {{ $.Values.istio.registry.dockercfg | default $.Values.global.modulesImages.registry.dockercfg }}
 {{- end }}
-


### PR DESCRIPTION
## Description
Fixed DMT lint **errors** (not warnings) in the istio module for CSE:
- Grafana dashboards: `ds_prometheus`, `graph` → `timeseries`
- Registry secrets: use `.Values.istio.registry.dockercfg` per DMT docs
- `module.yaml`: `requirements.deckhouse: ">= 1.68.0"` for `stage`
- CNI DaemonSet: valid securityContext for ambient vs non-ambient (`allowPrivilegeEscalation: false` only when not privileged)
## Why do we need it, and what problem does it solve?
Unblocks DMT lint / CSE patch pipeline. 

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: chore
summary: fixes for dmt lint↓
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
