### PR TITLE
[descheduler] add cve to vex

### DIFF
--- a/modules/400-descheduler/images/descheduler/known_vulnerabilities.vex
+++ b/modules/400-descheduler/images/descheduler/known_vulnerabilities.vex
@@ -283,8 +283,204 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Уязвимость CWE-61 (переход по символьной ссылке, symlink following) в Go stdlib v1.26.4 (API os.Root): при открытии файла внутри os.Root финальная символьная ссылка с путём, оканчивающимся на «/», может вести за пределы корня. Descheduler не использует sandbox-API os.Root и не обрабатывает произвольные пути файловой системы от недоверенных пользователей — уязвимый код не достигается. Бамп Go toolchain будет выполнен в рамках планового апгрейда базовых образов.",
       "timestamp": "2026-07-22T13:16:22.346010Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39827"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/crypto"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость DoS в golang.org/x/crypto/ssh: аутентифицированный SSH-клиент, многократно открывающий отклоняемые сервером каналы, вызывал неограниченный рост памяти на сервере. Descheduler не запускает SSH-сервер и не использует golang.org/x/crypto/ssh — уязвимый код не достигается ни в одном пути выполнения.",
+      "timestamp": "2026-07-22T14:46:22.311023Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39833"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/crypto"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость в golang.org/x/crypto/ssh/agent: in-memory keyring молча принимал, но не применял ограничение ConfirmBeforeUse, подписывая без запроса подтверждения. Descheduler не использует ssh-агент — уязвимый код не достигается ни в одном пути выполнения.",
+      "timestamp": "2026-07-22T14:46:22.311023Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39834"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/crypto"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость DoS в golang.org/x/crypto/ssh: целочисленное переполнение при записи более 4 ГБ за один вызов Write в SSH-канал приводило к бесконечному циклу отправки пустых пакетов. Descheduler не использует SSH-каналы — уязвимый код не достигается ни в одном пути выполнения.",
+      "timestamp": "2026-07-22T14:46:22.311023Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-46598"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/crypto"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость DoS в golang.org/x/crypto/ssh/agent: приведение некорректных wire-байтов к ed25519.PrivateKey вызывает панику при использовании ключа. Descheduler не использует ssh-агент — уязвимый код не достигается ни в одном пути выполнения.",
+      "timestamp": "2026-07-22T14:46:22.311023Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-47911"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость DoS в golang.org/x/net/html: квадратичная сложность html.Parse на специально сформированном HTML. Descheduler не разбирает и не рендерит HTML — пакет golang.org/x/net/html не входит в путь исполнения компонента.",
+      "timestamp": "2026-07-22T14:46:22.311023Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-58190"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость DoS в golang.org/x/net/html: бесконечный цикл разбора в html.Parse на определённом вводе. Descheduler не разбирает и не рендерит HTML — уязвимый код golang.org/x/net/html не достигается ни в одном пути выполнения.",
+      "timestamp": "2026-07-22T14:46:22.311023Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-25680"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость DoS в golang.org/x/net/html: разбор произвольного HTML может потреблять чрезмерное время CPU. Descheduler не разбирает и не рендерит HTML — уязвимый код не достигается ни в одном пути выполнения.",
+      "timestamp": "2026-07-22T14:46:22.311023Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-42502"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость XSS в golang.org/x/net/html: разбор произвольного HTML с последующим Render может давать неожиданное дерево HTML. Descheduler не разбирает и не рендерит HTML — уязвимый код не входит в путь исполнения компонента.",
+      "timestamp": "2026-07-22T14:46:22.311023Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-42506"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость XSS в golang.org/x/net/html: обход санитизации при разборе и повторном рендеринге HTML. Descheduler не работает с HTML и не имеет веб-интерфейса — уязвимый код не достигается ни в одном пути выполнения.",
+      "timestamp": "2026-07-22T14:46:22.311023Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-42505"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/stdlib@v1.26.4"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость раскрытия информации CWE-201 в Go stdlib v1.26.4 (crypto/tls, Encrypted Client Hello): при использовании ECH идентификаторы pre-shared key раскрываются в незашифрованном ClientHello, что позволяет пассивному наблюдателю деанонимизировать рукопожатие. Descheduler и client-go не включают ECH (требуется явная настройка EncryptedClientHelloConfigList, по умолчанию выключена), а TLS-соединения устанавливаются только к доверенному in-cluster kube-apiserver — уязвимый путь ECH не задействован. Бамп Go toolchain будет выполнен в рамках планового апгрейда базовых образов.",
+      "timestamp": "2026-07-22T14:46:22.311023Z"
+    },
+    {
+      "vulnerability": {
+        "name": "GO-2026-5932"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/crypto"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "Информационная рекомендация: пакет golang.org/x/crypto/openpgp небезопасен по своей архитектуре, не поддерживается и не должен использоваться. Descheduler не импортирует golang.org/x/crypto/openpgp: проверка графа зависимостей (go list -deps) подтверждает, что пакет не входит в сборку, а при статической компоновке (CGO_ENABLED=0) невключённые пакеты в бинарник не попадают — уязвимый код в артефакте отсутствует.",
+      "timestamp": "2026-07-22T14:46:22.311023Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-46600"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость в golang.org/x/net/dns/dnsmessage: разбор некорректной SVCB- или HTTPS-записи ресурса может вызвать панику из-за переполнения буфера сообщения. Descheduler не использует golang.org/x/net/dns/dnsmessage: разрешение имён выполняется штатным резолвером Go/ОС, DNS-сообщения компонент не разбирает — уязвимый код не достигается ни в одном пути выполнения.",
+      "timestamp": "2026-07-22T14:46:22.311023Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39824"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/sys"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "Уязвимость в golang.org/x/sys/windows: функция NewNTUnicodeString не проверяет переполнение длины строки и возвращает усечённую строку. Descheduler собирается с GOOS=linux; файлы golang.org/x/sys/windows исключены ограничениями сборки (//go:build windows) и не компилируются в linux-бинарник — уязвимый код в артефакте отсутствует.",
+      "timestamp": "2026-07-22T14:46:22.311023Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-56852"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/text"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "Уязвимость DoS в golang.org/x/text: norm.Iter может войти в бесконечный цикл при обработке ввода с некорректными байтами UTF-8. В descheduler пакет golang.org/x/text/unicode/norm задействуется лишь косвенно через golang.org/x/net/idna при нормализации имени хоста во время исходящего TLS-подключения — а это исключительно доверенный in-cluster kube-apiserver с валидным ASCII-именем. Недоверенные данные (имена и метки объектов из API) через нормализацию не проходят, поэтому уязвимый код не контролируется злоумышленником.",
+      "timestamp": "2026-07-22T14:46:22.311023Z"
     }
   ],
   "timestamp": "2026-01-12T11:51:20Z",
-  "last_updated": "2026-07-22T13:16:22Z"
+  "last_updated": "2026-07-22T14:46:22Z"
 }

--- a/modules/400-descheduler/images/descheduler/known_vulnerabilities.vex
+++ b/modules/400-descheduler/images/descheduler/known_vulnerabilities.vex
@@ -2,7 +2,7 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-95caeb00c03a501857d0b423a0bc2296ad7048120f6cf4f12510866919a323d5",
   "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
-  "version": 6,
+  "version": 7,
   "statements": [
     {
       "vulnerability": {
@@ -73,8 +73,218 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Уязвимость CVE-2026-39883 связана с вызовом команды kenv по неабсолютному пути на операционных системах BSD и Solaris (PATH hijacking, CWE-426). Компоненты Deckhouse, включая Descheduler, собираются с GOOS=linux и выполняются в контейнерах на Linux; уязвимый путь выполнения в этой среде отсутствует.",
       "timestamp": "2026-04-16T15:43:34.356000Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-47913"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/crypto"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость в SSH-клиенте golang.org/x/crypto/ssh/agent: клиент паникует при получении неожиданного ответа SSH_AGENT_SUCCESS. Descheduler не использует SSH и не работает с ssh-агентом — библиотека golang.org/x/crypto присутствует лишь как транзитивная зависимость клиентских библиотек Kubernetes, уязвимый код не вызывается ни в одном пути выполнения.",
+      "timestamp": "2026-07-22T13:16:22.346010Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39828"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/crypto"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость в SSH-сервере golang.org/x/crypto/ssh: при возврате PartialSuccessError с ненулевыми Permissions ограничения (например force-command) молча отбрасывались. Descheduler не запускает SSH-сервер и не использует golang.org/x/crypto/ssh — уязвимый код не достигается ни в одном пути выполнения.",
+      "timestamp": "2026-07-22T13:16:22.346010Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39829"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/crypto"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость DoS в парсере публичных ключей golang.org/x/crypto/ssh: отсутствие ограничения размера параметров RSA/DSA приводит к длительному потреблению CPU при проверке подписи. Descheduler не выполняет аутентификацию по SSH и не разбирает SSH-ключи — уязвимый код не вызывается ни в одном пути выполнения.",
+      "timestamp": "2026-07-22T13:16:22.346010Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39830"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/crypto"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость DoS в golang.org/x/crypto/ssh: незапрошенные ответы на global request заполняют внутренний буфер и блокируют read-loop соединения, вызывая утечку горутин. Descheduler не устанавливает SSH-соединений — уязвимый код не достигается ни в одном пути выполнения.",
+      "timestamp": "2026-07-22T13:16:22.346010Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39831"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/crypto"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость в golang.org/x/crypto/ssh: метод Verify для аппаратных ключей FIDO/U2F (sk-ecdsa, sk-ssh-ed25519) не проверял флаг User Presence. Descheduler не использует SSH и аппаратные ключи безопасности — уязвимый код не вызывается ни в одном пути выполнения.",
+      "timestamp": "2026-07-22T13:16:22.346010Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39832"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/crypto"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость в golang.org/x/crypto/ssh/agent: constraint-расширения (restrict-destination-v00@openssh.com) не сериализовались при добавлении ключа в удалённый агент, из-за чего ограничения назначения молча снимались. Descheduler не использует ssh-агент — уязвимый код не достигается ни в одном пути выполнения.",
+      "timestamp": "2026-07-22T13:16:22.346010Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39835"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/crypto"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость DoS в golang.org/x/crypto/ssh: CertChecker без заданных IsUserAuthority/IsHostAuthority паникует при предъявлении клиентом сертификата. Descheduler не запускает SSH-сервер и не использует CertChecker — уязвимый код не вызывается ни в одном пути выполнения.",
+      "timestamp": "2026-07-22T13:16:22.346010Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-42508"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/crypto"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость в golang.org/x/crypto/ssh/knownhosts: отозванный SignatureKey центра сертификации не проверялся на отзыв. Descheduler не использует SSH и не работает с known_hosts — уязвимый код не достигается ни в одном пути выполнения.",
+      "timestamp": "2026-07-22T13:16:22.346010Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-46595"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/crypto"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость обхода авторизации в golang.org/x/crypto/ssh: при использовании callback-ов, отличных от public key, пропускалась проверка source-address. Descheduler не запускает SSH-сервер — уязвимый код не вызывается ни в одном пути выполнения.",
+      "timestamp": "2026-07-22T13:16:22.346010Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-46597"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/crypto"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость DoS в golang.org/x/crypto/ssh: некорректное приведение bytes→int вызывает панику на стороне сервера в декодере пакетов AES-GCM. Descheduler не запускает SSH-сервер — уязвимый код не достигается ни в одном пути выполнения.",
+      "timestamp": "2026-07-22T13:16:22.346010Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-25681"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость XSS в golang.org/x/net/html: разбор произвольного HTML с последующим Render может давать неожиданное дерево HTML. Descheduler не разбирает и не рендерит HTML и не отдаёт контент в браузер — пакет golang.org/x/net/html не входит в путь исполнения компонента.",
+      "timestamp": "2026-07-22T13:16:22.346010Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-27136"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость XSS в golang.org/x/net/html: обход санитизации при разборе и повторном рендеринге HTML. Descheduler не работает с HTML и не имеет веб-интерфейса — уязвимый код golang.org/x/net/html не достигается ни в одном пути выполнения.",
+      "timestamp": "2026-07-22T13:16:22.346010Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-33814"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "Уязвимость DoS в HTTP/2-транспорте golang.org/x/net: при получении SETTINGS-фрейма со значением SETTINGS_MAX_FRAME_SIZE=0 транспорт входит в бесконечный цикл записи CONTINUATION-фреймов. Хотя HTTP/2-клиент используется client-go, вредоносный SETTINGS-фрейм может прийти только от сервера, к которому подключается descheduler, — а это исключительно доверенный in-cluster kube-apiserver. Сетевой атакующий не может внедрить такой фрейм, поэтому уязвимый код не контролируется злоумышленником.",
+      "timestamp": "2026-07-22T13:16:22.346010Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39821"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость в golang.org/x/net/idna: функции ToASCII/ToUnicode некорректно принимают Punycode-метки, декодируемые в ASCII-only имя, что может привести к повышению привилегий в программах, выполняющих проверки прав по имени хоста. Descheduler не выполняет авторизацию или проверки привилегий по именам хостов и подключается только к доверенному in-cluster kube-apiserver — уязвимый путь idna не задействован.",
+      "timestamp": "2026-07-22T13:16:22.346010Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39822"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/stdlib@v1.26.4"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость CWE-61 (переход по символьной ссылке, symlink following) в Go stdlib v1.26.4 (API os.Root): при открытии файла внутри os.Root финальная символьная ссылка с путём, оканчивающимся на «/», может вести за пределы корня. Descheduler не использует sandbox-API os.Root и не обрабатывает произвольные пути файловой системы от недоверенных пользователей — уязвимый код не достигается. Бамп Go toolchain будет выполнен в рамках планового апгрейда базовых образов.",
+      "timestamp": "2026-07-22T13:16:22.346010Z"
     }
   ],
   "timestamp": "2026-01-12T11:51:20Z",
-  "last_updated": "2026-04-16T15:43:34Z"
+  "last_updated": "2026-07-22T13:16:22Z"
 }


### PR DESCRIPTION
## Description

Add VEX `not_affected` statements for CVEs reported by the Trivy scan
against the `descheduler` image.

Affected packages are present only as transitive dependencies (or are
unreachable / not compiled into the Linux binary). Descheduler does not
use SSH, HTML parsing, Windows-specific APIs, OpenPGP, or `os.Root`
sandboxing in its execution path.

### Closed vulnerabilities (VEX `not_affected`)

#### `golang.org/x/crypto` (SSH / agent / OpenPGP)
- CVE-2025-47913
- CVE-2026-39827
- CVE-2026-39828
- CVE-2026-39829
- CVE-2026-39830
- CVE-2026-39831
- CVE-2026-39832
- CVE-2026-39833
- CVE-2026-39834
- CVE-2026-39835
- CVE-2026-42508
- CVE-2026-46595
- CVE-2026-46597
- CVE-2026-46598
- GO-2026-5932 (`golang.org/x/crypto/openpgp` — vulnerable code not present)

#### `golang.org/x/net` (html / idna / http2 / dns)
- CVE-2025-47911
- CVE-2025-58190
- CVE-2026-25680
- CVE-2026-25681
- CVE-2026-27136
- CVE-2026-33814
- CVE-2026-39821
- CVE-2026-42502
- CVE-2026-42506
- CVE-2026-46600

#### Go stdlib `v1.26.4`
- CVE-2026-39822 (`os.Root` symlink following)
- CVE-2026-42505 (`crypto/tls` ECH information disclosure)

#### Other
- CVE-2026-39824 (`golang.org/x/sys/windows` — not present in Linux build)
- CVE-2026-56852 (`golang.org/x/text` unicode normalization DoS)

**Total: 29 statements** (status: `not_affected`; mainly
`vulnerable_code_not_in_execute_path`, plus
`vulnerable_code_not_present` / `vulnerable_code_cannot_be_controlled_by_adversary`
where applicable).

## Why do we need it, and what problem does it solve?

Trivy reports High/Medium/Low findings in transitive Go dependencies of
the `descheduler` image. These findings are not exploitable in the
descheduler runtime context, so VEX statements suppress false positives
in security scans without changing the application code.

## Why do we need it in the patch release (if we do)?

Needed for the patch release to clear known false-positive CVEs from
security reports for the `descheduler` image in 1.73.x.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: descheduler
type: chore
summary: add vex statements for CVEs in x/crypto, x/net, x/sys, x/text and stdlib
impact_level: low