### PR TITLE
[docs] Add info about LB annotation at OpenStack documentation

### DIFF
--- a/docs/documentation/_includes/admin/integrations/openstack-based-configuration-ru.md
+++ b/docs/documentation/_includes/admin/integrations/openstack-based-configuration-ru.md
@@ -451,9 +451,15 @@ spec:
 Для корректного определения клиентского IP-адреса необходимо использовать LoadBalancer с поддержкой Proxy Protocol.
 {% endalert %}
 
+Рекомендуется ограничивать список узлов, добавляемых в пул балансировщика, с помощью аннотации [`loadbalancer.openstack.org/node-selector`](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md#load-balancer).
+
+Без ограничения по `node-selector` cloud-controller-manager может использовать в качестве таргетов балансировщика все подходящие узлы кластера. В результате добавление или удаление узлов, не связанных с обслуживаемой балансировщиком нагрузкой, может приводить к обновлению состава пула балансировщика. В крупных или часто изменяющихся кластерах такие обновления могут происходить регулярно, а в некоторых конфигурациях сопровождаться кратковременными нарушениями существующих соединений.
+
+С помощью `loadbalancer.openstack.org/node-selector` рекомендуется выбирать только те узлы, которые должны использоваться в качестве таргетов данного LoadBalancer.
+
 #### Пример IngressNginxController
 
-Ниже представлен простой пример конфигурации [IngressNginxController](/modules/ingress-nginx/cr.html#ingressnginxcontroller):
+В примере поды ingress-контроллера размещаются на frontend-узлах, а аннотация `loadbalancer.openstack.org/node-selector` ограничивает пул балансировщика этими же узлами:
 
 ```yaml
 apiVersion: deckhouse.io/v1
@@ -465,6 +471,7 @@ spec:
   inlet: LoadBalancerWithProxyProtocol
   loadBalancerWithProxyProtocol:
     annotations:
+      loadbalancer.openstack.org/node-selector: "node-role.deckhouse.io/frontend"
       loadbalancer.openstack.org/proxy-protocol: "true"
       loadbalancer.openstack.org/timeout-member-connect: "2000"
   nodeSelector:

--- a/docs/documentation/_includes/admin/integrations/openstack-based-configuration-ru.md
+++ b/docs/documentation/_includes/admin/integrations/openstack-based-configuration-ru.md
@@ -471,7 +471,7 @@ spec:
   inlet: LoadBalancerWithProxyProtocol
   loadBalancerWithProxyProtocol:
     annotations:
-      loadbalancer.openstack.org/node-selector: "node-role.deckhouse.io/frontend"
+      loadbalancer.openstack.org/node-selector: "node-role.deckhouse.io/frontend="
       loadbalancer.openstack.org/proxy-protocol: "true"
       loadbalancer.openstack.org/timeout-member-connect: "2000"
   nodeSelector:

--- a/docs/documentation/_includes/admin/integrations/openstack-based-configuration-ru.md
+++ b/docs/documentation/_includes/admin/integrations/openstack-based-configuration-ru.md
@@ -459,7 +459,7 @@ spec:
 
 #### Пример IngressNginxController
 
-В примере поды ingress-контроллера размещаются на frontend-узлах, а аннотация `loadbalancer.openstack.org/node-selector` ограничивает пул балансировщика этими же узлами:
+В примере поды Ingress-контроллера размещаются на frontend-узлах, а аннотация `loadbalancer.openstack.org/node-selector` ограничивает пул балансировщика этими же узлами:
 
 ```yaml
 apiVersion: deckhouse.io/v1

--- a/docs/documentation/_includes/admin/integrations/openstack-based-configuration.md
+++ b/docs/documentation/_includes/admin/integrations/openstack-based-configuration.md
@@ -483,7 +483,7 @@ spec:
   inlet: LoadBalancerWithProxyProtocol
   loadBalancerWithProxyProtocol:
     annotations:
-      loadbalancer.openstack.org/node-selector: "node-role.deckhouse.io/frontend"
+      loadbalancer.openstack.org/node-selector: "node-role.deckhouse.io/frontend="
       loadbalancer.openstack.org/proxy-protocol: "true"
       loadbalancer.openstack.org/timeout-member-connect: "2000"
   nodeSelector:

--- a/docs/documentation/_includes/admin/integrations/openstack-based-configuration.md
+++ b/docs/documentation/_includes/admin/integrations/openstack-based-configuration.md
@@ -460,12 +460,18 @@ For the API endpoints and ports, refer to the [official documentation](https://c
 ### LoadBalancer configuration
 
 {% alert level="warning" %}
-To correctly detect client IP addresses, you must use a LoadBalancer that supports Proxy Protocol.
+To correctly determine the client IP address, use a LoadBalancer with Proxy Protocol support.
 {% endalert %}
 
-#### Example: IngressNginxController
+It is recommended to limit the list of nodes added to the load balancer pool using the [`loadbalancer.openstack.org/node-selector`](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md#load-balancer) annotation.
 
-The following is a simple configuration example for an [IngressNginxController](/modules/ingress-nginx/cr.html#ingressnginxcontroller):
+Without a `node-selector` restriction, cloud-controller-manager may use all suitable cluster nodes as load balancer targets. As a result, adding or removing nodes that are not related to the workload served by the load balancer may trigger an update of the load balancer pool membership. In large or frequently changing clusters, such updates may occur regularly and, in some configurations, may cause brief disruptions to existing connections.
+
+It is recommended to use `loadbalancer.openstack.org/node-selector` to select only the nodes that should be used as targets for the corresponding LoadBalancer.
+
+#### IngressNginxController example
+
+In this example, the ingress controller pods are scheduled on frontend nodes, while the `loadbalancer.openstack.org/node-selector` annotation limits the load balancer pool to the same nodes:
 
 ```yaml
 apiVersion: deckhouse.io/v1
@@ -477,6 +483,7 @@ spec:
   inlet: LoadBalancerWithProxyProtocol
   loadBalancerWithProxyProtocol:
     annotations:
+      loadbalancer.openstack.org/node-selector: "node-role.deckhouse.io/frontend"
       loadbalancer.openstack.org/proxy-protocol: "true"
       loadbalancer.openstack.org/timeout-member-connect: "2000"
   nodeSelector:

--- a/docs/documentation/_includes/admin/integrations/openstack-based-configuration.md
+++ b/docs/documentation/_includes/admin/integrations/openstack-based-configuration.md
@@ -471,7 +471,7 @@ It is recommended to use `loadbalancer.openstack.org/node-selector` to select on
 
 #### IngressNginxController example
 
-In this example, the ingress controller pods are scheduled on frontend nodes, while the `loadbalancer.openstack.org/node-selector` annotation limits the load balancer pool to the same nodes:
+In this example, the Ingress controller pods are scheduled on frontend nodes, while the `loadbalancer.openstack.org/node-selector` annotation limits the load balancer pool to the same nodes:
 
 ```yaml
 apiVersion: deckhouse.io/v1

--- a/ee/modules/030-cloud-provider-openstack/docs/FAQ.md
+++ b/ee/modules/030-cloud-provider-openstack/docs/FAQ.md
@@ -44,9 +44,9 @@ spec:
 
 There may be many reasons why you may need to restrict or expand incoming/outgoing traffic on cluster VMs in OpenStack:
 
-* Allow VMs on a different subnet to connect to cluster nodes.
-* Allow connecting to the ports of the static node so that the application can work.
-* Restrict access to external resources or other VMs in the cloud for security reasons.
+- Allow VMs on a different subnet to connect to cluster nodes.
+- Allow connecting to the ports of the static node so that the application can work.
+- Restrict access to external resources or other VMs in the cloud for security reasons.
 
 For all this, additional security groups should be used. You can only use security groups that are created in the cloud tentatively.
 
@@ -54,8 +54,8 @@ For all this, additional security groups should be used. You can only use securi
 
 This parameter can be set either in an existing cluster or when creating one. In both cases, additional security groups are declared in the `OpenStackClusterConfiguration`:
 
-* for master nodes, in the `additionalSecurityGroups` of the `masterNodeGroup` section;
-* for static nodes, in the `additionalSecurityGroups` field of the `nodeGroups` subsection that corresponds to the target nodeGroup.
+- for master nodes, in the `additionalSecurityGroups` of the `masterNodeGroup` section;
+- for static nodes, in the `additionalSecurityGroups` field of the `nodeGroups` subsection that corresponds to the target nodeGroup.
 
 The `additionalSecurityGroups` field contains an array of strings with security group names.
 
@@ -222,8 +222,8 @@ username = {{ nova_service_user_name }}
 
 The node disk can be local or network. A local disk in OpenStack, is an ephemeral disk, and a network disk is a persistent disk (cinder storage). Nodes with local disks cannot migrate between hypervisors.
 
-* A network disk is preferred for the master node so that the node can migrate between hypervisors.
-* A local disk is preffered for the ephemeral node to save on cost. Not all cloud providers support the use of local disks. If local disks are not supported, you have to use network disks for ephemeral nodes.
+- A network disk is preferred for the master node so that the node can migrate between hypervisors.
+- A local disk is preffered for the ephemeral node to save on cost. Not all cloud providers support the use of local disks. If local disks are not supported, you have to use network disks for ephemeral nodes.
 
 | Local disk (ephemeral)        | Network disk (persistent)                    |
 | ----------------------------- | -------------------------------------------- |
@@ -243,15 +243,15 @@ The `OpenStackInstanceClass` has a `rootDiskSize` parameter, and OpenStack flavo
 
 #### Network disk is recommended for master nodes and bastion host
 
-* Use flavor with a zero disk size.
-* Set the `rootDiskSize` in the `OpenStackInstanceClass`.
-* Check the disk type. The disk type will be taken from the OS image if it is [set](#how-to-override-a-default-volume-type-of-cloud-provider). If it is not set, the disk type will be taken from [volumeTypeMap](cluster_configuration.html#openstackclusterconfiguration-masternodegroup-volumetypemap).
+- Use flavor with a zero disk size.
+- Set the `rootDiskSize` in the `OpenStackInstanceClass`.
+- Check the disk type. The disk type will be taken from the OS image if it is [set](#how-to-override-a-default-volume-type-of-cloud-provider). If it is not set, the disk type will be taken from [volumeTypeMap](cluster_configuration.html#openstackclusterconfiguration-masternodegroup-volumetypemap).
 
 #### Local disk is recommended for ephemeral nodes
 
-* Use flavor with the specified disk size.
-* Do not use the `rootDiskSize` parameter in the `OpenStackInstanceClass`.
-* Check the disk type. The disk type will be taken from the OS image if it is [set](#how-to-override-a-default-volume-type-of-cloud-provider). If it is not set, the default disk type of the cloud provider will be used.
+- Use flavor with the specified disk size.
+- Do not use the `rootDiskSize` parameter in the `OpenStackInstanceClass`.
+- Check the disk type. The disk type will be taken from the OS image if it is [set](#how-to-override-a-default-volume-type-of-cloud-provider). If it is not set, the default disk type of the cloud provider will be used.
 
 ### How do I check the disk volume in a flavor?
 

--- a/ee/modules/030-cloud-provider-openstack/docs/FAQ.md
+++ b/ee/modules/030-cloud-provider-openstack/docs/FAQ.md
@@ -236,7 +236,7 @@ The `OpenStackInstanceClass` has a `rootDiskSize` parameter, and OpenStack flavo
 
 |                                     | flavor disk size = 0                 | flavor disk size > 0                              |
 | ----------------------------------- | ------------------------------------ | ------------------------------------------------- |
-| **`rootDiskSize` is not specified** | ❗️*You need to set the size*. Without specifying the size, there will be an error creating a VM. | Local disk with size according to the flavor    |
+| **`rootDiskSize` is not specified** | ❗*You need to set the size*. Without specifying the size, there will be an error creating a VM. | Local disk with size according to the flavor    |
 | **`rootDiskSize` is specified**     | Network disk with the `rootDiskSize` size                                         | ❗ Network disk (rootDiskSize) and local disk (according to the flavor). Avoid using this option, as the cloud provider will charge for both disks. |
 
 > Please note, that to create a node with the `CloudEphemeral` type in a zone other than zone A, you must first create a flavor with a disk of the required size. The [rootDiskSize](/modules/cloud-provider-openstack/cr.html#openstackinstanceclass-v1-spec-rootdisksize) parameter does not need to be specified.

--- a/ee/modules/030-cloud-provider-openstack/docs/FAQ.md
+++ b/ee/modules/030-cloud-provider-openstack/docs/FAQ.md
@@ -28,7 +28,7 @@ spec:
   inlet: LoadBalancerWithProxyProtocol
   loadBalancerWithProxyProtocol:
     annotations:
-      loadbalancer.openstack.org/node-selector: "node-role.deckhouse.io/frontend"
+      loadbalancer.openstack.org/node-selector: "node-role.deckhouse.io/frontend="
       loadbalancer.openstack.org/proxy-protocol: "true"
       loadbalancer.openstack.org/timeout-member-connect: "2000"
   nodeSelector:

--- a/ee/modules/030-cloud-provider-openstack/docs/FAQ.md
+++ b/ee/modules/030-cloud-provider-openstack/docs/FAQ.md
@@ -4,11 +4,19 @@ title: "Cloud provider — OpenStack: FAQ"
 
 ## How do I set up LoadBalancer?
 
-> **Note!** Load Balancer must support Proxy Protocol to determine the client IP correctly.
+{% alert level="warning" %}
+To correctly determine the client IP address, use a LoadBalancer with Proxy Protocol support.
+{% endalert %}
 
-### An example of IngressNginxController
+It is recommended to limit the list of nodes added to the load balancer pool using the [`loadbalancer.openstack.org/node-selector`](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md#load-balancer) annotation.
 
-Below is a simple example of the `IngressNginxController' configuration:
+Without a `node-selector` restriction, cloud-controller-manager may use all suitable cluster nodes as load balancer targets. As a result, adding or removing nodes that are not related to the workload served by the load balancer may trigger an update of the load balancer pool membership. In large or frequently changing clusters, such updates may occur regularly and, in some configurations, may cause brief disruptions to existing connections.
+
+It is recommended to use `loadbalancer.openstack.org/node-selector` to select only the nodes that should be used as targets for the corresponding LoadBalancer.
+
+### IngressNginxController example
+
+In this example, the ingress controller pods are scheduled on frontend nodes, while the `loadbalancer.openstack.org/node-selector` annotation limits the load balancer pool to the same nodes:
 
 ```yaml
 apiVersion: deckhouse.io/v1
@@ -20,6 +28,7 @@ spec:
   inlet: LoadBalancerWithProxyProtocol
   loadBalancerWithProxyProtocol:
     annotations:
+      loadbalancer.openstack.org/node-selector: "node-role.deckhouse.io/frontend"
       loadbalancer.openstack.org/proxy-protocol: "true"
       loadbalancer.openstack.org/timeout-member-connect: "2000"
   nodeSelector:

--- a/ee/modules/030-cloud-provider-openstack/docs/FAQ.md
+++ b/ee/modules/030-cloud-provider-openstack/docs/FAQ.md
@@ -16,7 +16,7 @@ It is recommended to use `loadbalancer.openstack.org/node-selector` to select on
 
 ### IngressNginxController example
 
-In this example, the ingress controller pods are scheduled on frontend nodes, while the `loadbalancer.openstack.org/node-selector` annotation limits the load balancer pool to the same nodes:
+In this example, the Ingress controller pods are scheduled on frontend nodes, while the `loadbalancer.openstack.org/node-selector` annotation limits the load balancer pool to the same nodes:
 
 ```yaml
 apiVersion: deckhouse.io/v1

--- a/ee/modules/030-cloud-provider-openstack/docs/FAQ_RU.md
+++ b/ee/modules/030-cloud-provider-openstack/docs/FAQ_RU.md
@@ -4,11 +4,19 @@ title: "Cloud provider — OpenStack: FAQ"
 
 ## Как настроить LoadBalancer?
 
-> **Внимание.** Для корректного определения клиентского IP-адреса необходимо использовать LoadBalancer с поддержкой Proxy Protocol.
+{% alert level="warning" %}
+Для корректного определения клиентского IP-адреса необходимо использовать LoadBalancer с поддержкой Proxy Protocol.
+{% endalert %}
+
+Рекомендуется ограничивать список узлов, добавляемых в пул балансировщика, с помощью аннотации [`loadbalancer.openstack.org/node-selector`](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md#load-balancer).
+
+Без ограничения по `node-selector` cloud-controller-manager может использовать в качестве таргетов балансировщика все подходящие узлы кластера. В результате добавление или удаление узлов, не связанных с обслуживаемой балансировщиком нагрузкой, может приводить к обновлению состава пула балансировщика. В крупных или часто изменяющихся кластерах такие обновления могут происходить регулярно, а в некоторых конфигурациях сопровождаться кратковременными нарушениями существующих соединений.
+
+С помощью `loadbalancer.openstack.org/node-selector` рекомендуется выбирать только те узлы, которые должны использоваться в качестве таргетов данного LoadBalancer.
 
 ### Пример IngressNginxController
 
-Ниже представлен простой пример конфигурации `IngressNginxController`:
+В примере поды ingress-контроллера размещаются на frontend-узлах, а аннотация `loadbalancer.openstack.org/node-selector` ограничивает пул балансировщика этими же узлами:
 
 ```yaml
 apiVersion: deckhouse.io/v1
@@ -20,6 +28,7 @@ spec:
   inlet: LoadBalancerWithProxyProtocol
   loadBalancerWithProxyProtocol:
     annotations:
+      loadbalancer.openstack.org/node-selector: "node-role.deckhouse.io/frontend"
       loadbalancer.openstack.org/proxy-protocol: "true"
       loadbalancer.openstack.org/timeout-member-connect: "2000"
   nodeSelector:

--- a/ee/modules/030-cloud-provider-openstack/docs/FAQ_RU.md
+++ b/ee/modules/030-cloud-provider-openstack/docs/FAQ_RU.md
@@ -28,7 +28,7 @@ spec:
   inlet: LoadBalancerWithProxyProtocol
   loadBalancerWithProxyProtocol:
     annotations:
-      loadbalancer.openstack.org/node-selector: "node-role.deckhouse.io/frontend"
+      loadbalancer.openstack.org/node-selector: "node-role.deckhouse.io/frontend="
       loadbalancer.openstack.org/proxy-protocol: "true"
       loadbalancer.openstack.org/timeout-member-connect: "2000"
   nodeSelector:

--- a/ee/modules/030-cloud-provider-openstack/docs/FAQ_RU.md
+++ b/ee/modules/030-cloud-provider-openstack/docs/FAQ_RU.md
@@ -16,7 +16,7 @@ title: "Cloud provider — OpenStack: FAQ"
 
 ### Пример IngressNginxController
 
-В примере поды ingress-контроллера размещаются на frontend-узлах, а аннотация `loadbalancer.openstack.org/node-selector` ограничивает пул балансировщика этими же узлами:
+В примере поды Ingress-контроллера размещаются на frontend-узлах, а аннотация `loadbalancer.openstack.org/node-selector` ограничивает пул балансировщика этими же узлами:
 
 ```yaml
 apiVersion: deckhouse.io/v1


### PR DESCRIPTION
## Description
Added info about LB annotation at OpenStack documentation.

## Why do we need it, and what problem does it solve?


## Why do we need it in the patch release (if we do)?



## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: docs
type: chore
summary: Added info about LB annotation at OpenStack documentation.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
