### PR TITLE
[deckhouse-controller] add x-deckhouse-ui-validation-message to package settings schemas

### DIFF
--- a/deckhouse-controller/pkg/apis/deckhouse.io/openapi/types.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/openapi/types.go
@@ -101,9 +101,9 @@ type OpenAPIV3Schema struct {
 	// +optional
 	XUIOrder *int64 `json:"x-deckhouse-ui-order,omitempty"`
 
-	// x-deckhouse-ui-validation-description overrides the validation error.
+	// x-deckhouse-ui-validation-message overrides the validation error.
 	// +optional
-	XUIValidationDescription string `json:"x-deckhouse-ui-validation-description,omitempty"`
+	XUIValidationMessage string `json:"x-deckhouse-ui-validation-message,omitempty"`
 }
 
 // OpenAPIV3SchemaOrArray represents a value that can either be an OpenAPIV3Schema

--- a/deckhouse-controller/pkg/apis/deckhouse.io/openapi/types.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/openapi/types.go
@@ -100,6 +100,10 @@ type OpenAPIV3Schema struct {
 	// web console UI: fields with lower values are shown first.
 	// +optional
 	XUIOrder *int64 `json:"x-deckhouse-ui-order,omitempty"`
+
+	// x-deckhouse-ui-validation-description overrides the validation error.
+	// +optional
+	XUIValidationDescription string `json:"x-deckhouse-ui-validation-description,omitempty"`
 }
 
 // OpenAPIV3SchemaOrArray represents a value that can either be an OpenAPIV3Schema

--- a/deckhouse-controller/pkg/apis/deckhouse.io/openapi/types_test.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/openapi/types_test.go
@@ -172,10 +172,10 @@ func TestMarshalRoundtrip_xDeckhouseExtensions(t *testing.T) {
 		Type: "object",
 		Properties: map[string]OpenAPIV3Schema{
 			"storageClass": {
-				Type:                     "string",
-				XGrant:                   "storageclasses",
-				XUIOrder:                 int64Ptr(0),
-				XUIValidationDescription: "must reference an existing StorageClass",
+				Type:                 "string",
+				XGrant:               "storageclasses",
+				XUIOrder:             int64Ptr(0),
+				XUIValidationMessage: "must reference an existing StorageClass",
 			},
 			"replicas": {
 				Type:        "integer",
@@ -209,8 +209,8 @@ func TestMarshalRoundtrip_xDeckhouseExtensions(t *testing.T) {
 	if sc.XUIOrder == nil || *sc.XUIOrder != 0 {
 		t.Errorf("x-deckhouse-ui-order: explicit 0 not preserved")
 	}
-	if sc.XUIValidationDescription != "must reference an existing StorageClass" {
-		t.Errorf("x-deckhouse-ui-validation-description: got %q", sc.XUIValidationDescription)
+	if sc.XUIValidationMessage != "must reference an existing StorageClass" {
+		t.Errorf("x-deckhouse-ui-validation-message: got %q", sc.XUIValidationMessage)
 	}
 
 	rep, ok := restored.Properties["replicas"]
@@ -493,10 +493,10 @@ func realModuleSchema() *OpenAPIV3Schema {
 				},
 			},
 			"logLevel": {
-				Type:                     "string",
-				Pattern:                  "^(debug|info|warn|error)$",
-				Default:                  jsonPtr(`"info"`),
-				XUIValidationDescription: "log level must be one of: debug, info, warn, error",
+				Type:                 "string",
+				Pattern:              "^(debug|info|warn|error)$",
+				Default:              jsonPtr(`"info"`),
+				XUIValidationMessage: "log level must be one of: debug, info, warn, error",
 			},
 		},
 		XValidations: []ValidationRule{
@@ -576,8 +576,8 @@ func TestRealModuleSchema_roundtrip(t *testing.T) {
 	}
 
 	logLevel, ok := restored.Properties["logLevel"]
-	if !ok || logLevel.XUIValidationDescription != "log level must be one of: debug, info, warn, error" {
-		t.Errorf("logLevel ui-validation-description lost")
+	if !ok || logLevel.XUIValidationMessage != "log level must be one of: debug, info, warn, error" {
+		t.Errorf("logLevel ui-validation-message lost")
 	}
 
 	if len(restored.XValidations) != 1 {

--- a/deckhouse-controller/pkg/apis/deckhouse.io/openapi/types_test.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/openapi/types_test.go
@@ -172,9 +172,10 @@ func TestMarshalRoundtrip_xDeckhouseExtensions(t *testing.T) {
 		Type: "object",
 		Properties: map[string]OpenAPIV3Schema{
 			"storageClass": {
-				Type:     "string",
-				XGrant:   "storageclasses",
-				XUIOrder: int64Ptr(0),
+				Type:                     "string",
+				XGrant:                   "storageclasses",
+				XUIOrder:                 int64Ptr(0),
+				XUIValidationDescription: "must reference an existing StorageClass",
 			},
 			"replicas": {
 				Type:        "integer",
@@ -207,6 +208,9 @@ func TestMarshalRoundtrip_xDeckhouseExtensions(t *testing.T) {
 	}
 	if sc.XUIOrder == nil || *sc.XUIOrder != 0 {
 		t.Errorf("x-deckhouse-ui-order: explicit 0 not preserved")
+	}
+	if sc.XUIValidationDescription != "must reference an existing StorageClass" {
+		t.Errorf("x-deckhouse-ui-validation-description: got %q", sc.XUIValidationDescription)
 	}
 
 	rep, ok := restored.Properties["replicas"]
@@ -489,9 +493,10 @@ func realModuleSchema() *OpenAPIV3Schema {
 				},
 			},
 			"logLevel": {
-				Type:    "string",
-				Pattern: "^(debug|info|warn|error)$",
-				Default: jsonPtr(`"info"`),
+				Type:                     "string",
+				Pattern:                  "^(debug|info|warn|error)$",
+				Default:                  jsonPtr(`"info"`),
+				XUIValidationDescription: "log level must be one of: debug, info, warn, error",
 			},
 		},
 		XValidations: []ValidationRule{
@@ -568,6 +573,11 @@ func TestRealModuleSchema_roundtrip(t *testing.T) {
 	env, ok := restored.Properties["env"]
 	if !ok || env.Items == nil || len(env.Items.JSONSchemas) != 1 {
 		t.Errorf("env items (multi schema) lost")
+	}
+
+	logLevel, ok := restored.Properties["logLevel"]
+	if !ok || logLevel.XUIValidationDescription != "log level must be one of: debug, info, warn, error" {
+		t.Errorf("logLevel ui-validation-description lost")
 	}
 
 	if len(restored.XValidations) != 1 {


### PR DESCRIPTION
## Description
Application package settings schemas (`openapi/settings.yaml`, parsed into the typed `openapi.OpenAPIV3Schema` struct and published to `ApplicationPackageVersion.status.packageSchemas.settingsSchema`) carry `x-deckhouse-*` extensions as typed fields. This PR adds a new extension, `x-deckhouse-ui-validation-message`:

- `OpenAPIV3Schema` gains a typed `XUIValidationDescription string` field (`x-deckhouse-ui-validation-message`) that overrides the validation error message shown under a settings field in the web console UI when the entered value fails schema validation, so package authors can replace machine-oriented output such as a raw regex pattern with a human-readable hint.

## Why do we need it, and what problem does it solve?
When a value entered in the web console fails schema validation, the error shown under the field is machine-oriented — for example, a raw regex pattern from the schema. The new `x-deckhouse-ui-validation-message` extension lets a package author provide a human-readable message for such errors in the package's `settings.yaml`; the value is delivered to the web console via `ApplicationPackageVersion.status.packageSchemas`.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: feature
summary: Added the x-deckhouse-ui-validation-description extension to application package settings schemas.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->