### PR TITLE
[deckhouse] Restore admin access to list moduleconfigs

### DIFF
--- a/modules/002-deckhouse/templates/user-authz-cluster-roles.yaml
+++ b/modules/002-deckhouse/templates/user-authz-cluster-roles.yaml
@@ -59,8 +59,6 @@ rules:
   - update
 - apiGroups:
   - deckhouse.io
-  resourceNames:
-  - deckhouse
   resources:
   - moduleconfigs
   verbs:

--- a/modules/140-user-authz/docs/README.md
+++ b/modules/140-user-authz/docs/README.md
@@ -425,17 +425,15 @@ delete,deletecollection:
     - apps/replicasets
     - cert-manager.io/certificaterequests
     - extensions/replicasets
-read:
-    - 'deckhouse.io/moduleconfigs (resourceNames: deckhouse)'
 read-write:
     - deckhouse.io/authorizationrules
+    - deckhouse.io/moduleconfigs
 write:
     - autoscaling.k8s.io/verticalpodautoscalercheckpoints
     - deckhouse.io/applicationpackages
     - deckhouse.io/applicationpackageversions
     - deckhouse.io/applications
     - deckhouse.io/deckhousereleases
-    - deckhouse.io/moduleconfigs
     - deckhouse.io/moduledocumentations
     - deckhouse.io/modulepulloverrides
     - deckhouse.io/modulereleases
@@ -465,7 +463,6 @@ read:
     - deckhouse.io/ingressistiocontrollers
     - deckhouse.io/istiofederations
     - deckhouse.io/istiomulticlusters
-    - 'deckhouse.io/moduleconfigs (resourceNames: deckhouse)'
     - install.istio.io/istiooperators
     - multitenancy.deckhouse.io/grantableclusterresourcedefinitions
     - multitenancy.deckhouse.io/grantableclusterresourcereferences
@@ -477,6 +474,7 @@ read:
     - sailoperator.io/istios
     - sailoperator.io/ztunnels
 read-write:
+    - deckhouse.io/moduleconfigs
     - deckhouse.io/nodegroupconfigurations
     - deckhouse.io/staticinstances
     - multitenancy.deckhouse.io/clusterresourcegrantpolicies
@@ -492,7 +490,6 @@ write:
     - deckhouse.io/hubblemonitoringconfigs
     - deckhouse.io/instances
     - deckhouse.io/keepalivedinstances
-    - deckhouse.io/moduleconfigs
     - deckhouse.io/moduledocumentations
     - deckhouse.io/modulepulloverrides
     - deckhouse.io/modulereleases

--- a/modules/140-user-authz/docs/README_RU.md
+++ b/modules/140-user-authz/docs/README_RU.md
@@ -431,17 +431,15 @@ delete,deletecollection:
     - apps/replicasets
     - cert-manager.io/certificaterequests
     - extensions/replicasets
-read:
-    - 'deckhouse.io/moduleconfigs (resourceNames: deckhouse)'
 read-write:
     - deckhouse.io/authorizationrules
+    - deckhouse.io/moduleconfigs
 write:
     - autoscaling.k8s.io/verticalpodautoscalercheckpoints
     - deckhouse.io/applicationpackages
     - deckhouse.io/applicationpackageversions
     - deckhouse.io/applications
     - deckhouse.io/deckhousereleases
-    - deckhouse.io/moduleconfigs
     - deckhouse.io/moduledocumentations
     - deckhouse.io/modulepulloverrides
     - deckhouse.io/modulereleases
@@ -471,7 +469,6 @@ read:
     - deckhouse.io/ingressistiocontrollers
     - deckhouse.io/istiofederations
     - deckhouse.io/istiomulticlusters
-    - 'deckhouse.io/moduleconfigs (resourceNames: deckhouse)'
     - install.istio.io/istiooperators
     - multitenancy.deckhouse.io/grantableclusterresourcedefinitions
     - multitenancy.deckhouse.io/grantableclusterresourcereferences
@@ -483,6 +480,7 @@ read:
     - sailoperator.io/istios
     - sailoperator.io/ztunnels
 read-write:
+    - deckhouse.io/moduleconfigs
     - deckhouse.io/nodegroupconfigurations
     - deckhouse.io/staticinstances
     - multitenancy.deckhouse.io/clusterresourcegrantpolicies
@@ -498,7 +496,6 @@ write:
     - deckhouse.io/hubblemonitoringconfigs
     - deckhouse.io/instances
     - deckhouse.io/keepalivedinstances
-    - deckhouse.io/moduleconfigs
     - deckhouse.io/moduledocumentations
     - deckhouse.io/modulepulloverrides
     - deckhouse.io/modulereleases


### PR DESCRIPTION
## Description

The `Admin` cluster role scoped `get`/`list`/`watch` on `moduleconfigs` with `resourceNames: [deckhouse]`. RBAC does not match `resourceNames` against nameless collection requests, so `Admin`/`ClusterAdmin` can `get moduleconfig deckhouse` but get `Forbidden` on `kubectl get moduleconfigs`. This drops the `resourceNames` restriction from that rule, restoring ModuleConfig listing. The `User` access level stays restricted.

## Why do we need it, and what problem does it solve?

#19672 revoked ModuleConfig read from the `User` level, but also name-scoped the `Admin` rule and thereby broke `list`/`watch` for `Admin`/`ClusterAdmin`. This restores the pre-#19672 admin behavior while keeping the `User` restriction.

### Manual testing

Verified in a live cluster that the behaviour hinges solely on the `resourceNames` binding: two temporary ClusterRoles differing only by that field, probed via impersonation, then removed. The `Warning: resource 'moduleconfigs' is not namespace scoped` lines are harmless kubectl output.

```console
# 1) role AS PR #19672 made it: get/list/watch scoped to resourceName `deckhouse`
$ k create clusterrole tmp-mc-broken --verb=get,list,watch --resource=moduleconfigs.deckhouse.io --resource-name=deckhouse
clusterrole.rbac.authorization.k8s.io/tmp-mc-broken created
$ k create clusterrolebinding tmp-mc-broken-b --clusterrole=tmp-mc-broken --user=tmp-broken-user
clusterrolebinding.rbac.authorization.k8s.io/tmp-mc-broken-b created
$ k auth can-i list moduleconfigs --as=tmp-broken-user
Warning: resource 'moduleconfigs' is not namespace scoped in group 'deckhouse.io'
no
$ k auth can-i get moduleconfigs/deckhouse --as=tmp-broken-user
Warning: resource 'moduleconfigs' is not namespace scoped in group 'deckhouse.io'
yes

# 2) role AS THIS PR: same verbs, no resourceNames
$ k create clusterrole tmp-mc-fixed --verb=get,list,watch --resource=moduleconfigs.deckhouse.io
clusterrole.rbac.authorization.k8s.io/tmp-mc-fixed created
$ k create clusterrolebinding tmp-mc-fixed-b --clusterrole=tmp-mc-fixed --user=tmp-fixed-user
clusterrolebinding.rbac.authorization.k8s.io/tmp-mc-fixed-b created
$ k auth can-i list moduleconfigs --as=tmp-fixed-user
Warning: resource 'moduleconfigs' is not namespace scoped in group 'deckhouse.io'
yes

# 3) cleanup
$ k delete clusterrolebinding tmp-mc-broken-b tmp-mc-fixed-b
clusterrolebinding.rbac.authorization.k8s.io "tmp-mc-broken-b" deleted
clusterrolebinding.rbac.authorization.k8s.io "tmp-mc-fixed-b" deleted
$ k delete clusterrole tmp-mc-broken tmp-mc-fixed
clusterrole.rbac.authorization.k8s.io "tmp-mc-broken" deleted
clusterrole.rbac.authorization.k8s.io "tmp-mc-fixed" deleted
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: Restore admin access to list moduleconfigs
impact_level: low
```

<!---
`impact_level: low` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->




