### PR TITLE
assign pabateman and alexey-su as owners of caps and candi everywhere

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -72,6 +72,7 @@
 **/040-node-manager/templates/cluster-autoscaler                 @yalosev @ergoz
 **/040-node-manager/templates/integrity-containerd-configurator  @sprait
 **/040-node-manager/templates/integrity-controller               @sprait
+**/040-node-manager/templates/caps-controller-manager            @aleksey-su @pabateman
 **/040-node-manager/monitoring/grafana-dashboards/nvidia-gpu     @serg-su
 **/040-node-manager/templates/nvidia-gpu                         @serg-su
 **/040-node-manager/hooks/fencing**                              @yalosev @ergoz

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -44,6 +44,7 @@
 021-cni-cilium/                                                  @AndreyPavlovFlant @apolovov
 025-static-routing-manager/                                      @AndreyPavlovFlant @apolovov
 030-cloud-provider-*/                                            @aleksey-su @pabateman
+**/030-cloud-provider-*/candi/                                   @aleksey-su @pabateman
 031-local-path-provisioner/                                      @AleksZimin @duckhawk @szhem
 035-cni-flannel/                                                 @AndreyPavlovFlant @apolovov
 035-cni-simple-bridge/                                           @AndreyPavlovFlant @apolovov
@@ -66,6 +67,7 @@
 **/040-node-manager/images/bashible-apiserver                    @borg-z @090809 @sprait
 **/040-node-manager/images/integrity-containerd-configurator     @sprait
 **/040-node-manager/images/integrity-controller                  @sprait
+**/040-node-manager/images/caps-controller-manager               @aleksey-su @pabateman
 **/040-node-manager/templates/fencing-agent                      @yalosev @ergoz
 **/040-node-manager/templates/cluster-autoscaler                 @yalosev @ergoz
 **/040-node-manager/templates/integrity-containerd-configurator  @sprait


### PR DESCRIPTION
## Description
Added `**/030-cloud-provider-*/candi/` entry to CODEOWNERS, explicitly assigning `@aleksey-su @pabateman` as owners of `candi/` directories in all cloud-provider modules.

## Why do we need it, and what problem does it solve?
Without this entry, `candi/` paths inside `030-cloud-provider-*` modules matched the broader `/ee/**/candi/` and `**/candi/` rules (owners: `@borg-z @090809`) rather than the cloud-provider owners. CODEOWNERS uses last-match-wins, so the more specific rule added here overrides the generic `candi/` rules for cloud
  providers.

## Why do we need it in the patch release (if we do)?
We don't

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Assign cloud-provider module candi directories to @aleksey-su and @pabateman in CODEOWNERS
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
