### PR TITLE
[node-manager] Preserve existing node taints on first template application when no template taints are configured

### DIFF
--- a/modules/040-node-manager/images/node-controller/src/internal/controller/nodetemplate/coverage_test.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/nodetemplate/coverage_test.go
@@ -537,10 +537,21 @@ func TestTaintSliceEqual(t *testing.T) {
 // --- applyTemplateTaints: removal + nil/nil branches ---
 
 func TestApplyTemplateTaints(t *testing.T) {
-	t.Run("nil template and lastApplied returns empty changed", func(t *testing.T) {
+	t.Run("nil actual, template and lastApplied returns empty changed", func(t *testing.T) {
 		got, changed := applyTemplateTaints(nil, nil, nil)
-		if !changed || len(got) != 0 {
+		if changed || len(got) != 0 {
 			t.Fatalf("expected empty+changed, got %+v changed=%v", got, changed)
+		}
+	})
+
+	t.Run("nil template and lastApplied preserves actual", func(t *testing.T) {
+		actual := []corev1.Taint{{Key: "dedicated", Effect: corev1.TaintEffectNoSchedule}}
+		got, changed := applyTemplateTaints(actual, nil, nil)
+		if changed {
+			t.Fatalf("expected no change when no template, got changed=true")
+		}
+		if len(got) != 1 || got[0].Key != "dedicated" {
+			t.Fatalf("expected actual preserved, got %+v", got)
 		}
 	})
 

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/nodetemplate/taints.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/nodetemplate/taints.go
@@ -136,7 +136,7 @@ func taintToString(t corev1.Taint) string {
 
 func applyTemplateTaints(actual, template, lastApplied []corev1.Taint) ([]corev1.Taint, bool) {
 	if template == nil && lastApplied == nil {
-		return []corev1.Taint{}, true
+		return actual, false
 	}
 
 	changed := false


### PR DESCRIPTION
## Description

Fixed `applyTemplateTaints` in the node-controller: the early return for `template == nil && lastApplied == nil` now preserves the node's existing taints instead of clearing them.

This is the case of the first template application — when there is no template taints configured, and no last-applied annotation exists yet on the node.

## Why do we need it, and what problem does it solve?

On multi-master Yandex Cloud clusters, CloudPermanent nodes (frontend node group) were observed with empty `spec.providerID`, while master and CloudEphemeral nodes had it set correctly. This caused CCM load balancer target group sync failures. On single-master clusters and after node group scale-up, the problem did not reproduce.

Diagnosis:
1. The CCM cloud-node-controller sets `providerID` only for nodes that have the `node.cloudprovider.kubernetes.io/uninitialized` taint — the standard K8s signal for external cloud provider initialization.
2. On the affected frontend node, this taint was absent, while `node.deckhouse.io/uninitialized` was also absent — meaning node-template reconciliation had already run.
3. CloudEphemeral nodes (system) were unaffected because they use `fixCloudNodeTaints()`, which preserves existing taints via `mergeTaints`.
4. CloudPermanent nodes go through `applyNodeTemplate()` which calls `applyTemplateTaints`. On the first application, `applyTemplateTaints(actual, nil, nil)` returned an empty list, clearing all taints — including the CCM one.
5. This is a race condition: on multi-master the CCM starts slower (3 pods, leader election) and loses to the node-controller. On single-master and scale-up, the CCM starts first and sets providerID before the taints are cleared.

The fix preserves all existing taints when there is no template to apply. The caller (`applyNodeTemplate`) still removes the managed `node.deckhouse.io/uninitialized` taint separately.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: node-manager
type: fix
summary: Preserve existing node taints on first template application when no template taints are configured.
impact_level: default
```