### PR TITLE
[candi] Set PDPL level for d8-dhctl-converger on Astra Linux

### DIFF
--- a/candi/bashible/common-steps/all/000_add_node_users.sh.tpl
+++ b/candi/bashible/common-steps/all/000_add_node_users.sh.tpl
@@ -317,6 +317,22 @@ function main() {
         nodeuser_add_error "${user_name}" "${error_message}"
         continue
       fi
+
+      # d8-dhctl-converger is also used to destroy static masters, on Astra Linux it needs
+      # an elevated PDPL level to be able to perform privileged operations.
+      if [[ "$user_name" == "d8-dhctl-converger" ]] && [[ $(bb-is-bundle) == "astra" ]]; then
+        if type pdpl-user >/dev/null 2>&1; then
+          error_message=$(pdpl-user -i 63 d8-dhctl-converger 2>&1)
+          if bb-error?
+          then
+            bb-log-error "Error setting PDPL level for user '$user_name': ${error_message}"
+            nodeuser_add_error "${user_name}" "${error_message}"
+            continue
+          fi
+        else
+          bb-log-warning "pdpl-user command not found, skipping PDPL level setup for user '$user_name'"
+        fi
+      fi
     fi
     nodeuser_clear_error "${user_name}"
   done


### PR DESCRIPTION
## Description

Backport to `main` of #20552 (merged into `release-1.73`).

Run `pdpl-user -i 63 d8-dhctl-converger` after the user is created when the node bundle is `astra`. Required so the converger user can destroy static master nodes on Astra Linux. If `pdpl-user` is not available, the step is skipped with a warning.

## Why do we need it, and what problem does it solve?

Required so the converger user can destroy static master nodes on Astra Linux.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: candi
type: fix
summary: Set PDPL level for d8-dhctl-converger on Astra Linux
impact:
impact_level: low
```
