### PR TITLE
[dhctl] Pull provider bundle from upstream registry when out of cluster

### DIFF
--- a/dhctl/cmd/dhctl/main.go
+++ b/dhctl/cmd/dhctl/main.go
@@ -309,6 +309,14 @@ func main() {
 	kpApp.HelpFlag.Short('h')
 	app.GlobalFlags(kpApp, &opts.Global)
 
+	// Runs after flags are parsed, before any command action: mirror the
+	// in-cluster kube flag into GlobalOptions so config parsing can pick the
+	// reachable registry (in-cluster mirror vs upstream) accordingly.
+	kpApp.PreAction(func(_ *kingpin.ParseContext) error {
+		opts.Global.KubeInCluster = opts.Kube.InCluster
+		return nil
+	})
+
 	kpApp.Command("version", "Show version.").Action(func(c *kingpin.ParseContext) error {
 		fmt.Printf("%s %s", app.AppName, opts.BuildInfo.AppVersion)
 		return nil

--- a/dhctl/pkg/app/options/global.go
+++ b/dhctl/pkg/app/options/global.go
@@ -67,6 +67,12 @@ type GlobalOptions struct {
 
 	// EnsureCandiAvailable: the install tree is missing and must be downloaded.
 	EnsureCandiAvailable bool
+
+	// KubeInCluster mirrors KubeOptions.InCluster: dhctl runs inside the target
+	// cluster (auto-converger, exporter), so the in-cluster registry mirror is
+	// reachable. When false (manual dhctl over SSH, commander) the upstream
+	// registry from registry-config is used instead.
+	KubeInCluster bool
 }
 
 func (o GlobalOptions) ToSpanAttributes() []otattribute.KeyValue {

--- a/dhctl/pkg/config/base.go
+++ b/dhctl/pkg/config/base.go
@@ -228,7 +228,10 @@ func parseConfigFromCluster(ctx context.Context, kubeCl *client.KubernetesClient
 	// plugins are pulled lazily and read DeckhouseConfig.RegistryDockerCfg.
 	needRegistryData := globalOptions.EnsureCandiAvailable || needProviderCandi || clusterConfig.Type == CloudClusterType
 	if needRegistryData {
-		conf, b64dc, err := registrydata.GetRegistryData(ctx, kubeCl)
+		// Out of the cluster (manual dhctl over SSH) the deckhouse-registry mirror
+		// registry.d8-system.svc is unresolvable, so prefer the upstream registry
+		// for the candi/provider-bundle download; in-cluster callers keep the mirror.
+		conf, b64dc, err := registrydata.GetRegistryDataPreferUpstream(ctx, kubeCl, globalOptions.KubeInCluster)
 		if err != nil {
 			return nil, err
 		}

--- a/dhctl/pkg/config/base.go
+++ b/dhctl/pkg/config/base.go
@@ -1044,7 +1044,7 @@ func PrepareCandiDir(ctx context.Context, kubeCl *client.KubernetesClient, globa
 		return nil
 	}
 
-	conf, _, err := registrydata.GetRegistryData(ctx, kubeCl)
+	conf, _, err := registrydata.GetRegistryDataPreferUpstream(ctx, kubeCl, globalOptions.KubeInCluster)
 	if err != nil {
 		return err
 	}

--- a/dhctl/pkg/kubernetes/actions/registrydata/registrydata.go
+++ b/dhctl/pkg/kubernetes/actions/registrydata/registrydata.go
@@ -17,6 +17,7 @@ package registrydata
 import (
 	"context"
 	"encoding/base64"
+	"fmt"
 	"strings"
 	"time"
 
@@ -24,10 +25,36 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/deckhouse/deckhouse/go_lib/registry/helpers"
+
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/image"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/retry"
 )
+
+// GetRegistryDataPreferUpstream resolves the registry to pull images from. Out
+// of the cluster (inCluster=false: manual dhctl over SSH, commander) it prefers
+// the upstream registry from registry-config, which is reachable from anywhere,
+// because the deckhouse-registry mirror (registry.d8-system.svc) only resolves
+// inside the cluster. In the cluster (auto-converger, exporter) the mirror is
+// the fast local path, so it is used directly. Falls back to the mirror when no
+// upstream is configured (older clusters that expose the reachable registry in
+// deckhouse-registry directly).
+func GetRegistryDataPreferUpstream(ctx context.Context, kubeCl *client.KubernetesClient, inCluster bool) (*image.RegistryConfig, string, error) {
+	if inCluster {
+		return GetRegistryData(ctx, kubeCl)
+	}
+
+	conf, dockerCfg, found, err := getUpstreamRegistryData(ctx, kubeCl)
+	if err != nil {
+		return nil, "", err
+	}
+	if found {
+		return conf, dockerCfg, nil
+	}
+
+	return GetRegistryData(ctx, kubeCl)
+}
 
 var (
 	d8RppSecretName      = "deckhouse-registry"
@@ -80,6 +107,15 @@ func GetRegistryData(ctx context.Context, kubeCl *client.KubernetesClient) (*ima
 // clusters without the registry module) or carries no imagesRepo (Local mode),
 // so the caller can fall back to GetRegistryData.
 func GetUpstreamRegistryData(ctx context.Context, kubeCl *client.KubernetesClient) (*image.RegistryConfig, bool, error) {
+	conf, _, found, err := getUpstreamRegistryData(ctx, kubeCl)
+	return conf, found, err
+}
+
+// getUpstreamRegistryData additionally builds the registryDockerCfg (base64
+// docker config json) from the upstream credentials, so a caller that also
+// needs the dockercfg for lazy image pulls does not fall back to the
+// in-cluster mirror's credentials.
+func getUpstreamRegistryData(ctx context.Context, kubeCl *client.KubernetesClient) (*image.RegistryConfig, string, bool, error) {
 	var secret *corev1.Secret
 	err := retry.NewLoop("Get upstream registry data from cluster", 225, 1*time.Second).
 		BreakIf(apierrors.IsNotFound).
@@ -94,30 +130,33 @@ func GetUpstreamRegistryData(ctx context.Context, kubeCl *client.KubernetesClien
 			return nil
 		})
 	if apierrors.IsNotFound(err) {
-		return nil, false, nil
+		return nil, "", false, nil
 	}
 	if err != nil {
-		return nil, false, err
+		return nil, "", false, err
 	}
 
 	imagesRepo := string(secret.Data["imagesRepo"])
 	if imagesRepo == "" {
-		return nil, false, nil
+		return nil, "", false, nil
 	}
 
 	scheme := strings.ToUpper(string(secret.Data["scheme"]))
 	if scheme == "" {
 		scheme = "HTTPS"
 	}
-	conf, err := image.NewRegistryConfig(
-		scheme,
-		imagesRepo,
-		string(secret.Data["username"]),
-		string(secret.Data["password"]),
-		string(secret.Data["ca"]),
-	)
+	username := string(secret.Data["username"])
+	password := string(secret.Data["password"])
+	conf, err := image.NewRegistryConfig(scheme, imagesRepo, username, password, string(secret.Data["ca"]))
 	if err != nil {
-		return nil, false, err
+		return nil, "", false, err
 	}
-	return conf, true, nil
+
+	address, _ := helpers.SplitAddressAndPath(imagesRepo)
+	dockerCfg, err := helpers.DockerCfgFromCreds(username, password, address)
+	if err != nil {
+		return nil, "", false, fmt.Errorf("build upstream registry dockercfg: %w", err)
+	}
+
+	return conf, base64.StdEncoding.EncodeToString(dockerCfg), true, nil
 }

--- a/dhctl/pkg/kubernetes/actions/registrydata/registrydata.go
+++ b/dhctl/pkg/kubernetes/actions/registrydata/registrydata.go
@@ -149,7 +149,7 @@ func getUpstreamRegistryData(ctx context.Context, kubeCl *client.KubernetesClien
 	password := string(secret.Data["password"])
 	conf, err := image.NewRegistryConfig(scheme, imagesRepo, username, password, string(secret.Data["ca"]))
 	if err != nil {
-		return nil, "", false, err
+		return nil, "", false, fmt.Errorf("build upstream registry config: %w", err)
 	}
 
 	address, _ := helpers.SplitAddressAndPath(imagesRepo)

--- a/dhctl/pkg/kubernetes/actions/registrydata/registrydata_test.go
+++ b/dhctl/pkg/kubernetes/actions/registrydata/registrydata_test.go
@@ -15,6 +15,7 @@
 package registrydata
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -63,5 +64,61 @@ func TestGetUpstreamRegistryData(t *testing.T) {
 		_, found, err := GetUpstreamRegistryData(t.Context(), kubeCl)
 		require.NoError(t, err)
 		require.False(t, found)
+	})
+}
+
+func createDeckhouseRegistrySecret(t *testing.T, kubeCl *client.KubernetesClient, imagesRegistry string) {
+	t.Helper()
+	host, _, _ := strings.Cut(imagesRegistry, "/")
+	_, err := kubeCl.CoreV1().Secrets(d8RppSecretNamespace).Create(t.Context(), &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: d8RppSecretName, Namespace: d8RppSecretNamespace},
+		Data: map[string][]byte{
+			".dockerconfigjson": []byte(`{"auths":{"` + host + `":{"auth":"dXNlcjpwYXNz"}}}`),
+			"imagesRegistry":    []byte(imagesRegistry),
+			"scheme":            []byte("HTTPS"),
+		},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+}
+
+func TestGetRegistryDataPreferUpstream(t *testing.T) {
+	const (
+		upstream = "dev-registry.deckhouse.io/sys/deckhouse-oss"
+		mirror   = "registry.d8-system.svc:5001/system/deckhouse"
+	)
+
+	t.Run("out of cluster prefers the upstream registry with a dockercfg", func(t *testing.T) {
+		kubeCl := client.NewFakeKubernetesClient()
+		createRegistryConfigSecret(t, kubeCl, map[string][]byte{
+			"mode": []byte("Direct"), "imagesRepo": []byte(upstream),
+			"scheme": []byte("HTTPS"), "username": []byte("u"), "password": []byte("p"),
+		})
+		createDeckhouseRegistrySecret(t, kubeCl, mirror)
+
+		conf, b64dc, err := GetRegistryDataPreferUpstream(t.Context(), kubeCl, false)
+		require.NoError(t, err)
+		require.Equal(t, upstream, conf.GetRegistry())
+		require.NotEmpty(t, b64dc, "upstream path must build a registryDockerCfg")
+	})
+
+	t.Run("in cluster uses the mirror", func(t *testing.T) {
+		kubeCl := client.NewFakeKubernetesClient()
+		createRegistryConfigSecret(t, kubeCl, map[string][]byte{
+			"mode": []byte("Direct"), "imagesRepo": []byte(upstream), "scheme": []byte("HTTPS"),
+		})
+		createDeckhouseRegistrySecret(t, kubeCl, mirror)
+
+		conf, _, err := GetRegistryDataPreferUpstream(t.Context(), kubeCl, true)
+		require.NoError(t, err)
+		require.Equal(t, mirror, conf.GetRegistry())
+	})
+
+	t.Run("out of cluster falls back to the mirror when no upstream is configured", func(t *testing.T) {
+		kubeCl := client.NewFakeKubernetesClient()
+		createDeckhouseRegistrySecret(t, kubeCl, mirror)
+
+		conf, _, err := GetRegistryDataPreferUpstream(t.Context(), kubeCl, false)
+		require.NoError(t, err)
+		require.Equal(t, mirror, conf.GetRegistry())
 	})
 }

--- a/dhctl/pkg/kubernetes/actions/registrydata/registrydata_test.go
+++ b/dhctl/pkg/kubernetes/actions/registrydata/registrydata_test.go
@@ -23,6 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/util/image"
 )
 
 func createRegistryConfigSecret(t *testing.T, kubeCl *client.KubernetesClient, data map[string][]byte) {
@@ -98,7 +99,15 @@ func TestGetRegistryDataPreferUpstream(t *testing.T) {
 		conf, b64dc, err := GetRegistryDataPreferUpstream(t.Context(), kubeCl, false)
 		require.NoError(t, err)
 		require.Equal(t, upstream, conf.GetRegistry())
-		require.NotEmpty(t, b64dc, "upstream path must build a registryDockerCfg")
+
+		// The dockercfg must key on the same host that RegistryConfigFromDockerConfig
+		// looks up, otherwise lazy image pulls out of the cluster find no credentials.
+		dockerCfg, err := image.DecodeDockerConfig(b64dc)
+		require.NoError(t, err)
+		registryConf, err := image.RegistryConfigFromDockerConfig(dockerCfg, "HTTPS", upstream)
+		require.NoError(t, err)
+		require.Equal(t, "u", registryConf.GetUsername())
+		require.Equal(t, "p", registryConf.GetPassword())
 	})
 
 	t.Run("in cluster uses the mirror", func(t *testing.T) {
@@ -120,5 +129,18 @@ func TestGetRegistryDataPreferUpstream(t *testing.T) {
 		conf, _, err := GetRegistryDataPreferUpstream(t.Context(), kubeCl, false)
 		require.NoError(t, err)
 		require.Equal(t, mirror, conf.GetRegistry())
+	})
+
+	t.Run("out of cluster surfaces an invalid upstream instead of falling back", func(t *testing.T) {
+		kubeCl := client.NewFakeKubernetesClient()
+		createRegistryConfigSecret(t, kubeCl, map[string][]byte{
+			"mode": []byte("Direct"), "imagesRepo": []byte(upstream), "scheme": []byte("invalid"),
+		})
+		createDeckhouseRegistrySecret(t, kubeCl, mirror)
+
+		conf, b64dc, err := GetRegistryDataPreferUpstream(t.Context(), kubeCl, false)
+		require.ErrorContains(t, err, "scheme must be HTTP or HTTPS")
+		require.Nil(t, conf)
+		require.Empty(t, b64dc)
 	})
 }


### PR DESCRIPTION
## Description

A manual `dhctl converge` (over SSH, from the install container) on a cluster with an external
provider fails while downloading the provider bundle:

```
prepare provider bundle: download provider bundle registry.d8-system.svc:5001/system/deckhouse@sha256:...:
Get "https://registry.d8-system.svc:5001/v2/": dial tcp: lookup registry.d8-system.svc ... no such host
```

`parseConfigFromCluster` always read the registry from the `deckhouse-registry` secret, which on
clusters with an in-cluster registry points at the `registry.d8-system.svc` mirror. That mirror
only resolves inside the cluster, so an out-of-cluster dhctl times out on it.

Commander already reads the **upstream** registry (`registry-config`) for this reason. This change
does the same for the config-parse path, gated by whether dhctl runs in the cluster:

- **out of the cluster** (manual dhctl over SSH, commander): prefer the upstream registry from
  `registry-config` (reachable from anywhere), fall back to `deckhouse-registry`;
- **in the cluster** (auto-converger, exporter — `--kube-client-from-cluster`): keep the local
  mirror.

`opts.Kube.InCluster` is mirrored into `GlobalOptions.KubeInCluster` in a root `PreAction`, so the
config parser can pick the reachable registry. `GetUpstreamRegistryData` now also builds the
`registryDockerCfg` from the upstream credentials, so lazy image pulls out of the cluster use the
upstream registry too.

## Why do we need it, and what problem does it solve?

Fixes manual `converge`/`destroy` on clusters created via commander (or any cluster with an
in-cluster registry): the operation could not download the external provider bundle because it
looked it up in the cluster-internal registry mirror.

## Why do we need it in the patch release (if we do)?

Yes — it unblocks manual converge/destroy on affected clusters.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: dhctl
type: fix
summary: Pull the external provider bundle from the upstream registry when dhctl runs outside the cluster, so manual converge/destroy no longer fails on the unreachable in-cluster registry mirror.
```
