### PR TITLE
[registry-packages-proxy] access unmasked dockerCfg field

### DIFF
--- a/modules/039-registry-packages-proxy/templates/rbac-for-us.yaml
+++ b/modules/039-registry-packages-proxy/templates/rbac-for-us.yaml
@@ -31,6 +31,16 @@ rules:
       - get
       - list
       - watch
+  # Allow getting unmasked sensitive data in spec.registry (dockerCfg, login, password).
+  # Needed to authenticate to a private registry when serving package icons.
+  - apiGroups:
+      - "deckhouse.io"
+    resources:
+      - packagerepositories/sensitive
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - authentication.k8s.io
     resources:

--- a/modules/039-registry-packages-proxy/templates/rbac-for-us.yaml
+++ b/modules/039-registry-packages-proxy/templates/rbac-for-us.yaml
@@ -22,6 +22,15 @@ rules:
       - get
       - list
       - watch
+  # Allow getting unmasked sensitive data in spec.registry.dockerCFG.
+  - apiGroups:
+      - "deckhouse.io"
+    resources:
+      - modulesources/sensitive
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - authentication.k8s.io
     resources:


### PR DESCRIPTION
## Description

`spec.registry.dockerCfg` (and the `PackageRepository` `spec.registry` `login`/`password`) are now marked as `x-kubernetes-sensitive-data`. The apiserver masks such fields on normal `get`/`list`, and returns the raw unmasked value only through the `<resource>/sensitive` subresource, which requires an explicit RBAC grant.

This PR adds those grants to the `registry-packages-proxy` ClusterRole in [rbac-for-us.yaml](modules/039-registry-packages-proxy/templates/rbac-for-us.yaml):
- `modulesources/sensitive` — so the proxy can read the unmasked `dockerCfg` used to pull modules from a private registry.
- `packagerepositories/sensitive` — so it can read the unmasked `dockerCfg`/`login`/`password` used to authenticate when serving package icons.

Both grant `get`/`list`/`watch`, mirroring the existing rule on the base resources.

## Why do we need it, and what problem does it solve?

Without the `/sensitive` RBAC, the apiserver strips the credential fields before `registry-packages-proxy` sees them, so authentication to a private registry fails. This surfaced as:

- Errors in the controller log when processing module source events:
  ```
  {"level":"error","msg":"Process module source event: %v","!BADKEY":"illegal base64 data at input byte 0", ...}
  ```
  (the masked `dockerCfg` is not valid base64)

- Failures in bashible:
  ```
  [rpp-get] [serviceScripts] attempt 1 failed: access to ... returned HTTP 500:
  registry client config for repository 'dev-registry.deckhouse.io/sys/deckhouse-oss/modules' not found
  ```

Granting access to the `/sensitive` subresource lets the proxy read the real credentials again and restores registry authentication for both the module download flow and the package-icon flow.

## Why do we need it in the patch release (if we do)?

Yes — this fixes a regression introduced together with the `x-kubernetes-sensitive-data` marking: on affected versions `registry-packages-proxy` can no longer authenticate to a private registry, breaking module downloads and package icons. The RBAC grant should be backported wherever the sensitive-data marking is present.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: registry-packages-proxy
type: fix
summary: Grant registry-packages-proxy RBAC to read unmasked registry credentials (modulesources/sensitive, packagerepositories/sensitive), restoring authentication to private registries.
impact_level: default
```
