### PR TITLE
[deckhouse] show the allow-disabling annotation hint when disabling a confirmation-required module

### DIFF
--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module_config.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module_config.go
@@ -203,7 +203,7 @@ func moduleConfigValidationHandler(
 				// we can disable unknown module without any further check
 				if module, err := moduleStorage.GetModuleByName(obj.GetName()); err == nil {
 					if reason, needConfirm := module.GetConfirmationDisableReason(); needConfirm {
-						return rejectResult(reason)
+						return rejectResult(confirmationDisableWarning(reason))
 					}
 				}
 			}
@@ -305,7 +305,7 @@ func confirmationDisableWarning(reason string) string {
 	if !strings.HasSuffix(reason, ".") {
 		reason += "."
 	}
-	return reason + disableReasonSuffix
+	return reason + " " + disableReasonSuffix
 }
 
 func allowResult(warnMsgs []string) (*kwhvalidating.ValidatorResult, error) {


### PR DESCRIPTION
## Description

`d8 p module disable <name>` sets the ModuleConfig to `spec.enabled: false` (an admission `UPDATE`). For a confirmation-required module the webhook rejects it, but on `release-1.75` that message dropped the hint on how to proceed. This appends the `modules.deckhouse.io/allow-disabling=true` hint via the existing `confirmationDisableWarning` helper (plus the missing space), matching `release-1.76`. Targeted backport of the user-facing part of #20542 / #20544.

## Why do we need it, and what problem does it solve?

Without the hint, users see only `…back them up if you want to restore a cluster backup.` and think the platform is broken. `release-1.76` already shows the hint; this restores parity on `1.75`.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: show the allow-disabling annotation hint when disabling a confirmation-required module
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
