### PR TITLE
[metallb] Fixed securityContext and added SecurityPolicyException

### DIFF
--- a/ee/modules/380-metallb/templates/speaker/daemonset.yaml
+++ b/ee/modules/380-metallb/templates/speaker/daemonset.yaml
@@ -47,6 +47,7 @@ spec:
       labels:
         app: speaker
         metallb-role: speaker
+        security.deckhouse.io/security-policy-exception: speaker
     spec:
       {{- include "helm_lib_priority_class" (tuple . "system-node-critical") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 6 }}

--- a/ee/modules/380-metallb/templates/speaker/security-policy-exception.yaml
+++ b/ee/modules/380-metallb/templates/speaker/security-policy-exception.yaml
@@ -5,7 +5,7 @@ kind: SecurityPolicyException
 metadata:
   name: speaker
   namespace: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "app" "l2lb-speaker")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "speaker")) | nindent 2 }}
 spec:
   securityContext:
     runAsNonRoot:
@@ -37,4 +37,17 @@ spec:
         description: |
           The speaker must join the host network namespace to advertise service IPs
           via ARP/NDP on the node interfaces and to participate in memberlist gossip.
+    hostPorts:
+      - port: 4218
+        protocol: TCP
+        metadata:
+          description: MetalLB memberlist TCP gossip port used by speaker.
+      - port: 4218
+        protocol: UDP
+        metadata:
+          description: MetalLB memberlist UDP gossip port used by speaker.
+      - port: 4220
+        protocol: TCP
+        metadata:
+          description: HTTPS metrics endpoint exposed through kube-rbac-proxy.
 {{- end }}

--- a/ee/modules/380-metallb/templates/speaker/security-policy-exception.yaml
+++ b/ee/modules/380-metallb/templates/speaker/security-policy-exception.yaml
@@ -1,0 +1,40 @@
+{{- if (.Values.global.enabledModules | has "admission-policy-engine") }}
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: SecurityPolicyException
+metadata:
+  name: speaker
+  namespace: d8-{{ .Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "l2lb-speaker")) | nindent 2 }}
+spec:
+  securityContext:
+    runAsNonRoot:
+      allowedValue: false
+      metadata:
+        description: |
+          MetalLB speaker must run as root to send gratuitous ARP/NDP announcements
+          on the host network interfaces.
+    runAsUser:
+      allowedValues:
+        - 0
+      metadata:
+        description: |
+          UID 0 is required for raw network operations used by L2 service advertisement.
+    capabilities:
+      allowedValues:
+        add:
+          - NET_RAW
+        drop:
+          - ALL
+      metadata:
+        description: |
+          NET_RAW is required to craft ARP/NDP packets that announce LoadBalancer IPs
+          on the local network segment.
+  network:
+    hostNetwork:
+      allowedValue: true
+      metadata:
+        description: |
+          The speaker must join the host network namespace to advertise service IPs
+          via ARP/NDP on the node interfaces and to participate in memberlist gossip.
+{{- end }}

--- a/ee/se/modules/380-metallb/templates/l2lb/speaker/daemonset.yaml
+++ b/ee/se/modules/380-metallb/templates/l2lb/speaker/daemonset.yaml
@@ -45,6 +45,7 @@ spec:
       labels:
         app: l2lb-speaker
         metallb-role: speaker
+        security.deckhouse.io/security-policy-exception: l2lb-speaker
     spec:
       {{- include "helm_lib_priority_class" (tuple . "system-node-critical") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 6 }}

--- a/ee/se/modules/380-metallb/templates/l2lb/speaker/security-policy-exception.yaml
+++ b/ee/se/modules/380-metallb/templates/l2lb/speaker/security-policy-exception.yaml
@@ -37,4 +37,17 @@ spec:
         description: |
           The L2 speaker must join the host network namespace to advertise service IPs
           via ARP/NDP on the node interfaces and to participate in memberlist gossip.
+    hostPorts:
+      - port: 4225
+        protocol: TCP
+        metadata:
+          description: MetalLB memberlist TCP gossip port used by l2lb-speaker.
+      - port: 4225
+        protocol: UDP
+        metadata:
+          description: MetalLB memberlist UDP gossip port used by l2lb-speaker.
+      - port: 4226
+        protocol: TCP
+        metadata:
+          description: HTTPS metrics endpoint exposed through kube-rbac-proxy.
 {{- end }}

--- a/ee/se/modules/380-metallb/templates/l2lb/speaker/security-policy-exception.yaml
+++ b/ee/se/modules/380-metallb/templates/l2lb/speaker/security-policy-exception.yaml
@@ -1,0 +1,40 @@
+{{- if (.Values.global.enabledModules | has "admission-policy-engine") }}
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: SecurityPolicyException
+metadata:
+  name: l2lb-speaker
+  namespace: d8-{{ .Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "l2lb-speaker")) | nindent 2 }}
+spec:
+  securityContext:
+    runAsNonRoot:
+      allowedValue: false
+      metadata:
+        description: |
+          MetalLB L2 speaker must run as root to send gratuitous ARP/NDP announcements
+          on the host network interfaces.
+    runAsUser:
+      allowedValues:
+        - 0
+      metadata:
+        description: |
+          UID 0 is required for raw network operations used by L2 service advertisement.
+    capabilities:
+      allowedValues:
+        add:
+          - NET_RAW
+        drop:
+          - ALL
+      metadata:
+        description: |
+          NET_RAW is required to craft ARP/NDP packets that announce LoadBalancer IPs
+          on the local network segment.
+  network:
+    hostNetwork:
+      allowedValue: true
+      metadata:
+        description: |
+          The L2 speaker must join the host network namespace to advertise service IPs
+          via ARP/NDP on the node interfaces and to participate in memberlist gossip.
+{{- end }}


### PR DESCRIPTION
## Description
This PR updates the `securityContext` configuration and adds a `SecurityPolicyException`.

## Why do we need it, and what problem does it solve?
This change aligns the component with the required security policies by correcting the `securityContext` configuration and introducing a `SecurityPolicyException` where elevated permissions are required. This ensures the component can operate correctly while remaining compliant with the platform's security requirements.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: metallb
type: chore
summary: Fixed securityContext and added a SecurityPolicyException.
impact_level: default
```
