### PR TITLE
add source label to system metrics

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -3870,56 +3870,6 @@ alerts:
       module: node-manager
       edition: ce
       description: |
-        This probably means that `machine-controller-manager` is unable to create Machines using the cloud provider module.
-
-        Possible causes:
-
-        1. Cloud provider resource limits.
-        2. No access to the cloud provider API.
-        3. Misconfiguration of the cloud provider or instance class.
-        4. Problems with bootstrapping the Machine.
-
-        Recommended actions:
-
-        1. Check the status of the NodeGroup:
-
-           ```shell
-           d8 k get ng {{ $labels.node_group }} -o yaml
-           ```
-
-           Look for errors in the `.status.lastMachineFailures` field.
-
-        2. If no Instances stay in the Pending state for more than a couple of minutes, it likely means that Instances are being continuously created and deleted due to an error:
-
-           ```shell
-           d8 k get instances
-           ```
-
-        3. If logs don’t show errors, and an Instance continues to be Pending, check its bootstrap status:
-
-           ```shell
-           d8 k get instances <INSTANCE_NAME> -o yaml | grep 'bootstrapStatus' -B0 -A2
-           ```
-
-        4. If the output looks like the example below, use the `logsEndpoint` (or the command in `description`) to examine bootstrap logs:
-
-           ```text
-           bootstrapStatus:
-             description: Use 'curl -N http://192.168.199.158:8000' to get bootstrap logs.
-             logsEndpoint: http://192.168.199.158:8000
-           ```
-
-        5. If there's no bootstrap log endpoint, `cloudInit` may not be working correctly. This could indicate a misconfigured instance class in the cloud provider.
-      summary: |
-        NodeGroup {{ $labels.node_group }} has no available instances.
-      severity: "7"
-      markupFormat: markdown
-    - name: NodeGroupReplicasUnavailable
-      sourceFile: modules/040-node-manager/monitoring/prometheus-rules/node-group.tpl
-      moduleUrl: 040-node-manager
-      module: node-manager
-      edition: ce
-      description: |
         The number of simultaneously unavailable instances in the {{ $labels.node_group }} NodeGroup exceeds the allowed threshold.
         This may indicate that the autoscaler has provisioned too many nodes at once. Check the state of the Machine in the cluster.
         This probably means that `machine-controller-manager` is unable to create Machines using the cloud provider module.
@@ -3964,7 +3914,57 @@ alerts:
         5. If there's no bootstrap log endpoint, `cloudInit` may not be working correctly. This could indicate a misconfigured instance class in the cloud provider.
       summary: |
         Too many unavailable instances in the {{ $labels.node_group }} NodeGroup.
-      severity: "8"
+      severity: "6"
+      markupFormat: markdown
+    - name: NodeGroupReplicasUnavailable
+      sourceFile: modules/040-node-manager/monitoring/prometheus-rules/node-group.tpl
+      moduleUrl: 040-node-manager
+      module: node-manager
+      edition: ce
+      description: |
+        This probably means that `machine-controller-manager` is unable to create Machines using the cloud provider module.
+
+        Possible causes:
+
+        1. Cloud provider resource limits.
+        2. No access to the cloud provider API.
+        3. Misconfiguration of the cloud provider or instance class.
+        4. Problems with bootstrapping the Machine.
+
+        Recommended actions:
+
+        1. Check the status of the NodeGroup:
+
+           ```shell
+           d8 k get ng {{ $labels.node_group }} -o yaml
+           ```
+
+           Look for errors in the `.status.lastMachineFailures` field.
+
+        2. If no Instances stay in the Pending state for more than a couple of minutes, it likely means that Instances are being continuously created and deleted due to an error:
+
+           ```shell
+           d8 k get instances
+           ```
+
+        3. If logs don’t show errors, and an Instance continues to be Pending, check its bootstrap status:
+
+           ```shell
+           d8 k get instances <INSTANCE_NAME> -o yaml | grep 'bootstrapStatus' -B0 -A2
+           ```
+
+        4. If the output looks like the example below, use the `logsEndpoint` (or the command in `description`) to examine bootstrap logs:
+
+           ```text
+           bootstrapStatus:
+             description: Use 'curl -N http://192.168.199.158:8000' to get bootstrap logs.
+             logsEndpoint: http://192.168.199.158:8000
+           ```
+
+        5. If there's no bootstrap log endpoint, `cloudInit` may not be working correctly. This could indicate a misconfigured instance class in the cloud provider.
+      summary: |
+        NodeGroup {{ $labels.node_group }} has no available instances.
+      severity: "7"
       markupFormat: markdown
     - name: NodeGroupReplicasUnavailable
       sourceFile: modules/040-node-manager/monitoring/prometheus-rules/node-group.tpl

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -4392,56 +4392,6 @@ alerts:
       module: node-manager
       edition: ce
       description: |
-        This probably means that `machine-controller-manager` is unable to create Machines using the cloud provider module.
-
-        Possible causes:
-
-        1. Cloud provider resource limits.
-        2. No access to the cloud provider API.
-        3. Misconfiguration of the cloud provider or instance class.
-        4. Problems with bootstrapping the Machine.
-
-        Recommended actions:
-
-        1. Check the status of the NodeGroup:
-
-           ```shell
-           d8 k get ng {{ $labels.node_group }} -o yaml
-           ```
-
-           Look for errors in the `.status.lastMachineFailures` field.
-
-        2. If no Instances stay in the Pending state for more than a couple of minutes, it likely means that Instances are being continuously created and deleted due to an error:
-
-           ```shell
-           d8 k get instances
-           ```
-
-        3. If logs don’t show errors, and an Instance continues to be Pending, check its bootstrap status:
-
-           ```shell
-           d8 k get instances <INSTANCE_NAME> -o yaml | grep 'bootstrapStatus' -B0 -A2
-           ```
-
-        4. If the output looks like the example below, use the `logsEndpoint` (or the command in `description`) to examine bootstrap logs:
-
-           ```text
-           bootstrapStatus:
-             description: Use 'curl -N http://192.168.199.158:8000' to get bootstrap logs.
-             logsEndpoint: http://192.168.199.158:8000
-           ```
-
-        5. If there's no bootstrap log endpoint, `cloudInit` may not be working correctly. This could indicate a misconfigured instance class in the cloud provider.
-      summary: |
-        NodeGroup {{ $labels.node_group }} has no available instances.
-      severity: "7"
-      markupFormat: markdown
-    - name: NodeGroupReplicasUnavailable
-      sourceFile: modules/040-node-manager/monitoring/prometheus-rules/node-group.tpl
-      moduleUrl: 040-node-manager
-      module: node-manager
-      edition: ce
-      description: |
         The number of simultaneously unavailable instances in the {{ $labels.node_group }} NodeGroup exceeds the allowed threshold.
         This may indicate that the autoscaler has provisioned too many nodes at once. Check the state of the Machine in the cluster.
         This probably means that `machine-controller-manager` is unable to create Machines using the cloud provider module.
@@ -4486,7 +4436,57 @@ alerts:
         5. If there's no bootstrap log endpoint, `cloudInit` may not be working correctly. This could indicate a misconfigured instance class in the cloud provider.
       summary: |
         Too many unavailable instances in the {{ $labels.node_group }} NodeGroup.
-      severity: "8"
+      severity: "6"
+      markupFormat: markdown
+    - name: NodeGroupReplicasUnavailable
+      sourceFile: modules/040-node-manager/monitoring/prometheus-rules/node-group.tpl
+      moduleUrl: 040-node-manager
+      module: node-manager
+      edition: ce
+      description: |
+        This probably means that `machine-controller-manager` is unable to create Machines using the cloud provider module.
+
+        Possible causes:
+
+        1. Cloud provider resource limits.
+        2. No access to the cloud provider API.
+        3. Misconfiguration of the cloud provider or instance class.
+        4. Problems with bootstrapping the Machine.
+
+        Recommended actions:
+
+        1. Check the status of the NodeGroup:
+
+           ```shell
+           d8 k get ng {{ $labels.node_group }} -o yaml
+           ```
+
+           Look for errors in the `.status.lastMachineFailures` field.
+
+        2. If no Instances stay in the Pending state for more than a couple of minutes, it likely means that Instances are being continuously created and deleted due to an error:
+
+           ```shell
+           d8 k get instances
+           ```
+
+        3. If logs don’t show errors, and an Instance continues to be Pending, check its bootstrap status:
+
+           ```shell
+           d8 k get instances <INSTANCE_NAME> -o yaml | grep 'bootstrapStatus' -B0 -A2
+           ```
+
+        4. If the output looks like the example below, use the `logsEndpoint` (or the command in `description`) to examine bootstrap logs:
+
+           ```text
+           bootstrapStatus:
+             description: Use 'curl -N http://192.168.199.158:8000' to get bootstrap logs.
+             logsEndpoint: http://192.168.199.158:8000
+           ```
+
+        5. If there's no bootstrap log endpoint, `cloudInit` may not be working correctly. This could indicate a misconfigured instance class in the cloud provider.
+      summary: |
+        NodeGroup {{ $labels.node_group }} has no available instances.
+      severity: "7"
       markupFormat: markdown
     - name: NodeGroupReplicasUnavailable
       sourceFile: modules/040-node-manager/monitoring/prometheus-rules/node-group.tpl

--- a/ee/be/modules/350-node-local-dns/templates/podmonitor.yaml
+++ b/ee/be/modules/350-node-local-dns/templates/podmonitor.yaml
@@ -32,4 +32,6 @@ spec:
     - sourceLabels: [__meta_kubernetes_pod_ready]
       regex: "true"
       action: keep
+    - targetLabel: source
+      replacement: deckhouse
 {{- end }}

--- a/ee/be/modules/350-node-local-dns/templates/podmonitor.yaml
+++ b/ee/be/modules/350-node-local-dns/templates/podmonitor.yaml
@@ -32,6 +32,6 @@ spec:
     - sourceLabels: [__meta_kubernetes_pod_ready]
       regex: "true"
       action: keep
-    - targetLabel: source
-      replacement: deckhouse
+    - targetLabel: d8_source
+      replacement: dkp
 {{- end }}

--- a/ee/modules/030-cloud-provider-dynamix/templates/cloud-data-discoverer/pod-monitor.yaml
+++ b/ee/modules/030-cloud-provider-dynamix/templates/cloud-data-discoverer/pod-monitor.yaml
@@ -30,6 +30,8 @@ spec:
       - sourceLabels: [__meta_kubernetes_pod_ready]
         regex: "true"
         action: keep
+      - targetLabel: source
+        replacement: deckhouse
   selector:
     matchLabels:
       app: cloud-data-discoverer

--- a/ee/modules/030-cloud-provider-dynamix/templates/cloud-data-discoverer/pod-monitor.yaml
+++ b/ee/modules/030-cloud-provider-dynamix/templates/cloud-data-discoverer/pod-monitor.yaml
@@ -30,8 +30,8 @@ spec:
       - sourceLabels: [__meta_kubernetes_pod_ready]
         regex: "true"
         action: keep
-      - targetLabel: source
-        replacement: deckhouse
+      - targetLabel: d8_source
+        replacement: dkp
   selector:
     matchLabels:
       app: cloud-data-discoverer

--- a/ee/modules/030-cloud-provider-huaweicloud/templates/caphc-controller-manager/pod-monitor.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/templates/caphc-controller-manager/pod-monitor.yaml
@@ -20,6 +20,8 @@ spec:
           replacement: caphc-controller-manager
         - targetLabel: tier
           replacement: cluster
+        - targetLabel: source
+          replacement: deckhouse
   selector:
     matchLabels:
       app: caphc-controller-manager

--- a/ee/modules/030-cloud-provider-huaweicloud/templates/caphc-controller-manager/pod-monitor.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/templates/caphc-controller-manager/pod-monitor.yaml
@@ -20,8 +20,8 @@ spec:
           replacement: caphc-controller-manager
         - targetLabel: tier
           replacement: cluster
-        - targetLabel: source
-          replacement: deckhouse
+        - targetLabel: d8_source
+          replacement: dkp
   selector:
     matchLabels:
       app: caphc-controller-manager

--- a/ee/modules/030-cloud-provider-openstack/templates/cloud-data-discoverer/pod-monitor.yaml
+++ b/ee/modules/030-cloud-provider-openstack/templates/cloud-data-discoverer/pod-monitor.yaml
@@ -30,6 +30,8 @@ spec:
       - sourceLabels: [__meta_kubernetes_pod_ready]
         regex: "true"
         action: keep
+      - targetLabel: source
+        replacement: deckhouse
   selector:
     matchLabels:
       app: cloud-data-discoverer

--- a/ee/modules/030-cloud-provider-openstack/templates/cloud-data-discoverer/pod-monitor.yaml
+++ b/ee/modules/030-cloud-provider-openstack/templates/cloud-data-discoverer/pod-monitor.yaml
@@ -30,8 +30,8 @@ spec:
       - sourceLabels: [__meta_kubernetes_pod_ready]
         regex: "true"
         action: keep
-      - targetLabel: source
-        replacement: deckhouse
+      - targetLabel: d8_source
+        replacement: dkp
   selector:
     matchLabels:
       app: cloud-data-discoverer

--- a/ee/modules/040-node-manager/templates/podmonitor.yaml
+++ b/ee/modules/040-node-manager/templates/podmonitor.yaml
@@ -36,6 +36,8 @@ spec:
     - sourceLabels: [__meta_kubernetes_pod_ready]
       regex: "true"
       action: keep
+    - targetLabel: source
+      replacement: deckhouse
   {{- end }}
 {{- end }}
 {{- end }}

--- a/ee/modules/040-node-manager/templates/podmonitor.yaml
+++ b/ee/modules/040-node-manager/templates/podmonitor.yaml
@@ -36,8 +36,8 @@ spec:
     - sourceLabels: [__meta_kubernetes_pod_ready]
       regex: "true"
       action: keep
-    - targetLabel: source
-      replacement: deckhouse
+    - targetLabel: d8_source
+      replacement: dkp
   {{- end }}
 {{- end }}
 {{- end }}

--- a/ee/modules/110-istio/templates/alliance/healthcheck/pod-monitor.yaml
+++ b/ee/modules/110-istio/templates/alliance/healthcheck/pod-monitor.yaml
@@ -27,4 +27,6 @@ spec:
         - sourceLabels: [__meta_kubernetes_pod_ready]
           regex: "true"
           action: keep
+        - targetLabel: source
+          replacement: deckhouse
 {{- end }}

--- a/ee/modules/110-istio/templates/alliance/healthcheck/pod-monitor.yaml
+++ b/ee/modules/110-istio/templates/alliance/healthcheck/pod-monitor.yaml
@@ -27,6 +27,6 @@ spec:
         - sourceLabels: [__meta_kubernetes_pod_ready]
           regex: "true"
           action: keep
-        - targetLabel: source
-          replacement: deckhouse
+        - targetLabel: d8_source
+          replacement: dkp
 {{- end }}

--- a/ee/modules/110-istio/templates/alliance/ingressgateway/podmonitor.yaml
+++ b/ee/modules/110-istio/templates/alliance/ingressgateway/podmonitor.yaml
@@ -43,6 +43,8 @@ spec:
           sourceLabels:
             - __meta_kubernetes_namespace
           targetLabel: namespace
+        - targetLabel: source
+          replacement: deckhouse
       scheme: http
   selector:
     matchExpressions:

--- a/ee/modules/110-istio/templates/alliance/ingressgateway/podmonitor.yaml
+++ b/ee/modules/110-istio/templates/alliance/ingressgateway/podmonitor.yaml
@@ -43,8 +43,8 @@ spec:
           sourceLabels:
             - __meta_kubernetes_namespace
           targetLabel: namespace
-        - targetLabel: source
-          replacement: deckhouse
+        - targetLabel: d8_source
+          replacement: dkp
       scheme: http
   selector:
     matchExpressions:

--- a/ee/modules/110-istio/templates/alliance/metadata-exporter/pod-monitor.yaml
+++ b/ee/modules/110-istio/templates/alliance/metadata-exporter/pod-monitor.yaml
@@ -33,5 +33,7 @@ spec:
         - sourceLabels: [__meta_kubernetes_pod_ready]
           regex: "true"
           action: keep
+        - targetLabel: source
+          replacement: deckhouse
 {{- end }}
 {{- end }}

--- a/ee/modules/110-istio/templates/alliance/metadata-exporter/pod-monitor.yaml
+++ b/ee/modules/110-istio/templates/alliance/metadata-exporter/pod-monitor.yaml
@@ -33,7 +33,7 @@ spec:
         - sourceLabels: [__meta_kubernetes_pod_ready]
           regex: "true"
           action: keep
-        - targetLabel: source
-          replacement: deckhouse
+        - targetLabel: d8_source
+          replacement: dkp
 {{- end }}
 {{- end }}

--- a/ee/modules/110-istio/templates/config-analyzer/podmonitor.yaml
+++ b/ee/modules/110-istio/templates/config-analyzer/podmonitor.yaml
@@ -44,6 +44,8 @@ spec:
     - sourceLabels: [__meta_kubernetes_pod_ready]
       regex: "true"
       action: keep
+    - targetLabel: source
+      replacement: deckhouse
     {{- end }}
   {{- end }}
 {{- end }}

--- a/ee/modules/110-istio/templates/config-analyzer/podmonitor.yaml
+++ b/ee/modules/110-istio/templates/config-analyzer/podmonitor.yaml
@@ -44,8 +44,8 @@ spec:
     - sourceLabels: [__meta_kubernetes_pod_ready]
       regex: "true"
       action: keep
-    - targetLabel: source
-      replacement: deckhouse
+    - targetLabel: d8_source
+      replacement: dkp
     {{- end }}
   {{- end }}
 {{- end }}

--- a/ee/modules/110-istio/templates/multicluster/metrics-exporter/pod-monitor.yaml
+++ b/ee/modules/110-istio/templates/multicluster/metrics-exporter/pod-monitor.yaml
@@ -32,4 +32,6 @@ spec:
         - sourceLabels: [__meta_kubernetes_pod_ready]
           regex: "true"
           action: keep
+        - targetLabel: source
+          replacement: deckhouse
   {{- end }}

--- a/ee/modules/110-istio/templates/multicluster/metrics-exporter/pod-monitor.yaml
+++ b/ee/modules/110-istio/templates/multicluster/metrics-exporter/pod-monitor.yaml
@@ -32,6 +32,6 @@ spec:
         - sourceLabels: [__meta_kubernetes_pod_ready]
           regex: "true"
           action: keep
-        - targetLabel: source
-          replacement: deckhouse
+        - targetLabel: d8_source
+          replacement: dkp
   {{- end }}

--- a/ee/modules/110-istio/templates/ztunnel/podmonitor.yaml
+++ b/ee/modules/110-istio/templates/ztunnel/podmonitor.yaml
@@ -26,6 +26,8 @@ spec:
     - action: replace
       replacement: ztunnel
       targetLabel: job
+    - targetLabel: source
+      replacement: deckhouse
   selector:
     matchLabels:
       app: ztunnel

--- a/ee/modules/110-istio/templates/ztunnel/podmonitor.yaml
+++ b/ee/modules/110-istio/templates/ztunnel/podmonitor.yaml
@@ -26,8 +26,8 @@ spec:
     - action: replace
       replacement: ztunnel
       targetLabel: job
-    - targetLabel: source
-      replacement: deckhouse
+    - targetLabel: d8_source
+      replacement: dkp
   selector:
     matchLabels:
       app: ztunnel

--- a/ee/modules/380-metallb/templates/controller/podmonitor.yaml
+++ b/ee/modules/380-metallb/templates/controller/podmonitor.yaml
@@ -25,6 +25,8 @@ spec:
         - sourceLabels: [__meta_kubernetes_pod_ready]
           regex: "true"
           action: keep
+        - targetLabel: source
+          replacement: deckhouse
   selector:
     matchLabels:
       app: controller

--- a/ee/modules/380-metallb/templates/controller/podmonitor.yaml
+++ b/ee/modules/380-metallb/templates/controller/podmonitor.yaml
@@ -25,8 +25,8 @@ spec:
         - sourceLabels: [__meta_kubernetes_pod_ready]
           regex: "true"
           action: keep
-        - targetLabel: source
-          replacement: deckhouse
+        - targetLabel: d8_source
+          replacement: dkp
   selector:
     matchLabels:
       app: controller

--- a/ee/modules/380-metallb/templates/speaker/podmonitor.yaml
+++ b/ee/modules/380-metallb/templates/speaker/podmonitor.yaml
@@ -25,6 +25,8 @@ spec:
         - sourceLabels: [__meta_kubernetes_pod_ready]
           regex: "true"
           action: keep
+        - targetLabel: source
+          replacement: deckhouse
   selector:
     matchLabels:
       app: speaker

--- a/ee/modules/380-metallb/templates/speaker/podmonitor.yaml
+++ b/ee/modules/380-metallb/templates/speaker/podmonitor.yaml
@@ -25,8 +25,8 @@ spec:
         - sourceLabels: [__meta_kubernetes_pod_ready]
           regex: "true"
           action: keep
-        - targetLabel: source
-          replacement: deckhouse
+        - targetLabel: d8_source
+          replacement: dkp
   selector:
     matchLabels:
       app: speaker

--- a/ee/se-plus/modules/030-csi-vsphere/templates/cloud-data-discoverer/pod-monitor.yaml
+++ b/ee/se-plus/modules/030-csi-vsphere/templates/cloud-data-discoverer/pod-monitor.yaml
@@ -30,6 +30,8 @@ spec:
       - sourceLabels: [__meta_kubernetes_pod_ready]
         regex: "true"
         action: keep
+      - targetLabel: source
+        replacement: deckhouse
   selector:
     matchLabels:
       app: cloud-data-discoverer

--- a/ee/se-plus/modules/030-csi-vsphere/templates/cloud-data-discoverer/pod-monitor.yaml
+++ b/ee/se-plus/modules/030-csi-vsphere/templates/cloud-data-discoverer/pod-monitor.yaml
@@ -30,8 +30,8 @@ spec:
       - sourceLabels: [__meta_kubernetes_pod_ready]
         regex: "true"
         action: keep
-      - targetLabel: source
-        replacement: deckhouse
+      - targetLabel: d8_source
+        replacement: dkp
   selector:
     matchLabels:
       app: cloud-data-discoverer

--- a/ee/se/modules/380-metallb/templates/l2lb/controller/podmonitor.yaml
+++ b/ee/se/modules/380-metallb/templates/l2lb/controller/podmonitor.yaml
@@ -25,6 +25,8 @@ spec:
         - sourceLabels: [__meta_kubernetes_pod_ready]
           regex: "true"
           action: keep
+        - targetLabel: source
+          replacement: deckhouse
   selector:
     matchLabels:
       app: l2lb-controller

--- a/ee/se/modules/380-metallb/templates/l2lb/controller/podmonitor.yaml
+++ b/ee/se/modules/380-metallb/templates/l2lb/controller/podmonitor.yaml
@@ -25,8 +25,8 @@ spec:
         - sourceLabels: [__meta_kubernetes_pod_ready]
           regex: "true"
           action: keep
-        - targetLabel: source
-          replacement: deckhouse
+        - targetLabel: d8_source
+          replacement: dkp
   selector:
     matchLabels:
       app: l2lb-controller

--- a/ee/se/modules/380-metallb/templates/l2lb/speaker/podmonitor.yaml
+++ b/ee/se/modules/380-metallb/templates/l2lb/speaker/podmonitor.yaml
@@ -25,6 +25,8 @@ spec:
         - sourceLabels: [__meta_kubernetes_pod_ready]
           regex: "true"
           action: keep
+        - targetLabel: source
+          replacement: deckhouse
   selector:
     matchLabels:
       app: l2lb-speaker

--- a/ee/se/modules/380-metallb/templates/l2lb/speaker/podmonitor.yaml
+++ b/ee/se/modules/380-metallb/templates/l2lb/speaker/podmonitor.yaml
@@ -25,8 +25,8 @@ spec:
         - sourceLabels: [__meta_kubernetes_pod_ready]
           regex: "true"
           action: keep
-        - targetLabel: source
-          replacement: deckhouse
+        - targetLabel: d8_source
+          replacement: dkp
   selector:
     matchLabels:
       app: l2lb-speaker

--- a/global-hooks/openapi/values.yaml
+++ b/global-hooks/openapi/values.yaml
@@ -52,7 +52,7 @@ properties:
       type: string
     x-examples:
     # fake *-crd modules are required for backward compatibility with lib_helm library TODO: remove fake crd modules
-    - [ "cert-manager", "vertical-pod-autoscaler", "vertical-pod-autoscaler-crd", "prometheus", "prometheus-crd", "operator-prometheus", "operator-prometheus" ]
+    - [ "cert-manager", "vertical-pod-autoscaler", "vertical-pod-autoscaler-crd", "prometheus", "prometheus-crd", "operator-prometheus", "operator-prometheus-crd" ]
     - [ "cert-manager", "prometheus" ]
   discovery:
     additionalProperties: true

--- a/global-hooks/openapi/values.yaml
+++ b/global-hooks/openapi/values.yaml
@@ -52,7 +52,7 @@ properties:
       type: string
     x-examples:
     # fake *-crd modules are required for backward compatibility with lib_helm library TODO: remove fake crd modules
-    - [ "cert-manager", "vertical-pod-autoscaler", "vertical-pod-autoscaler-crd", "prometheus", "prometheus-crd", "operator-prometheus", "operator-prometheus" ]
+    - [ "cert-manager", "vertical-pod-autoscaler", "vertical-pod-autoscaler-crd", "prometheus", "prometheus-crd", "operator-prometheus", "operator-prometheus-crd" ]
     - [ "cert-manager", "prometheus" ]
   capabilities:
     type: array

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_cloud_data_discoverer.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_cloud_data_discoverer.tpl
@@ -297,6 +297,8 @@ spec:
       - sourceLabels: [__meta_kubernetes_pod_ready]
         regex: "true"
         action: keep
+      - targetLabel: source
+        replacement: deckhouse
     {{- with $additionalRelabelings }}
       {{- toYaml . | nindent 6 }}
     {{- end }}

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_cloud_data_discoverer.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_cloud_data_discoverer.tpl
@@ -297,8 +297,8 @@ spec:
       - sourceLabels: [__meta_kubernetes_pod_ready]
         regex: "true"
         action: keep
-      - targetLabel: source
-        replacement: deckhouse
+      - targetLabel: d8_source
+        replacement: dkp
     {{- with $additionalRelabelings }}
       {{- toYaml . | nindent 6 }}
     {{- end }}

--- a/modules/002-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
+++ b/modules/002-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
@@ -166,6 +166,8 @@
         This alert often indicates that the Deckhouse Pod is experiencing connectivity issues with the Internet.
 
   - record: d8:deckhouse_queue_is_hung:with_head
+    labels:
+      source: deckhouse
     expr: |
       (max by (pod, instance, queue) (
         min_over_time(deckhouse_tasks_queue_length{queue!~"main-subqueue-kubernetes-.*|/modules/upmeter/update_selector.*|/modules/secret-copier|/modules/deckhouse/update_deckhouse_image"}[__SCRAPE_INTERVAL_X_3__])

--- a/modules/002-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
+++ b/modules/002-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
@@ -167,7 +167,7 @@
 
   - record: d8:deckhouse_queue_is_hung:with_head
     labels:
-      source: deckhouse
+      d8_source: dkp
     expr: |
       (max by (pod, instance, queue) (
         min_over_time(deckhouse_tasks_queue_length{queue!~"main-subqueue-kubernetes-.*|/modules/upmeter/update_selector.*|/modules/secret-copier|/modules/deckhouse/update_deckhouse_image"}[__SCRAPE_INTERVAL_X_3__])

--- a/modules/002-deckhouse/templates/podmonitor.yaml
+++ b/modules/002-deckhouse/templates/podmonitor.yaml
@@ -21,6 +21,8 @@ spec:
       replacement: cluster
     - targetLabel: scrape_source
       replacement: self
+    - targetLabel: source
+      replacement: deckhouse
     metricRelabelings:
     # Drop all buckets
     - sourceLabels: [__name__]
@@ -36,6 +38,8 @@ spec:
       replacement: cluster
     - targetLabel: scrape_source
       replacement: hooks
+    - targetLabel: source
+      replacement: deckhouse
   selector:
     matchLabels:
       app: deckhouse

--- a/modules/002-deckhouse/templates/podmonitor.yaml
+++ b/modules/002-deckhouse/templates/podmonitor.yaml
@@ -11,7 +11,6 @@ spec:
   podMetricsEndpoints:
   - port: self
     path: "/metrics"
-    honorLabels: true
     relabelings:
     - sourceLabels: [__meta_kubernetes_pod_container_port_number]
       regex: "4222"

--- a/modules/002-deckhouse/templates/podmonitor.yaml
+++ b/modules/002-deckhouse/templates/podmonitor.yaml
@@ -22,8 +22,8 @@ spec:
       replacement: cluster
     - targetLabel: scrape_source
       replacement: self
-    - targetLabel: source
-      replacement: deckhouse
+    - targetLabel: d8_source
+      replacement: dkp
     metricRelabelings:
     # Drop all buckets
     - sourceLabels: [__name__]
@@ -39,8 +39,8 @@ spec:
       replacement: cluster
     - targetLabel: scrape_source
       replacement: hooks
-    - targetLabel: source
-      replacement: deckhouse
+    - targetLabel: d8_source
+      replacement: dkp
   selector:
     matchLabels:
       app: deckhouse

--- a/modules/002-deckhouse/templates/podmonitor.yaml
+++ b/modules/002-deckhouse/templates/podmonitor.yaml
@@ -11,6 +11,7 @@ spec:
   podMetricsEndpoints:
   - port: self
     path: "/metrics"
+    honorLabels: true
     relabelings:
     - sourceLabels: [__meta_kubernetes_pod_container_port_number]
       regex: "4222"

--- a/modules/002-deckhouse/templates/webhook-handler/podmonitor.yaml
+++ b/modules/002-deckhouse/templates/webhook-handler/podmonitor.yaml
@@ -21,6 +21,8 @@ spec:
       replacement: cluster
     - targetLabel: scrape_source
       replacement: self
+    - targetLabel: source
+      replacement: deckhouse
     metricRelabelings:
     - sourceLabels: [__name__]
       regex: 'webhook_handler_hook_run_seconds_bucket|webhook_handler_kube_jq_filter_duration_seconds_bucket|webhook_handler_kube_event_duration_seconds_bucket|webhook_handler_hook_run_user_cpu_seconds_bucket|webhook_handler_hook_run_sys_cpu_seconds_bucket|webhook_handler_tasks_queue_action_duration_seconds_bucket'
@@ -35,6 +37,8 @@ spec:
       replacement: cluster
     - targetLabel: scrape_source
       replacement: hooks
+    - targetLabel: source
+      replacement: deckhouse
   selector:
     matchLabels:
       app: webhook-handler

--- a/modules/002-deckhouse/templates/webhook-handler/podmonitor.yaml
+++ b/modules/002-deckhouse/templates/webhook-handler/podmonitor.yaml
@@ -21,8 +21,8 @@ spec:
       replacement: cluster
     - targetLabel: scrape_source
       replacement: self
-    - targetLabel: source
-      replacement: deckhouse
+    - targetLabel: d8_source
+      replacement: dkp
     metricRelabelings:
     - sourceLabels: [__name__]
       regex: 'webhook_handler_hook_run_seconds_bucket|webhook_handler_kube_jq_filter_duration_seconds_bucket|webhook_handler_kube_event_duration_seconds_bucket|webhook_handler_hook_run_user_cpu_seconds_bucket|webhook_handler_hook_run_sys_cpu_seconds_bucket|webhook_handler_tasks_queue_action_duration_seconds_bucket'
@@ -37,8 +37,8 @@ spec:
       replacement: cluster
     - targetLabel: scrape_source
       replacement: hooks
-    - targetLabel: source
-      replacement: deckhouse
+    - targetLabel: d8_source
+      replacement: dkp
   selector:
     matchLabels:
       app: webhook-handler

--- a/modules/015-admission-policy-engine/templates/podmonitor.yaml
+++ b/modules/015-admission-policy-engine/templates/podmonitor.yaml
@@ -20,6 +20,8 @@ spec:
     relabelings:
     - targetLabel: tier
       replacement: cluster
+    - targetLabel: source
+      replacement: deckhouse
   selector:
     matchLabels:
       app: gatekeeper
@@ -48,6 +50,8 @@ spec:
       relabelings:
         - targetLabel: tier
           replacement: cluster
+        - targetLabel: source
+          replacement: deckhouse
     - port: https-metrics
       scheme: https
       path: /exporter-metrics
@@ -60,6 +64,8 @@ spec:
       relabelings:
         - targetLabel: tier
           replacement: cluster
+        - targetLabel: source
+          replacement: deckhouse
   selector:
     matchLabels:
       app: gatekeeper

--- a/modules/015-admission-policy-engine/templates/podmonitor.yaml
+++ b/modules/015-admission-policy-engine/templates/podmonitor.yaml
@@ -20,8 +20,8 @@ spec:
     relabelings:
     - targetLabel: tier
       replacement: cluster
-    - targetLabel: source
-      replacement: deckhouse
+    - targetLabel: d8_source
+      replacement: dkp
   selector:
     matchLabels:
       app: gatekeeper
@@ -50,8 +50,8 @@ spec:
       relabelings:
         - targetLabel: tier
           replacement: cluster
-        - targetLabel: source
-          replacement: deckhouse
+        - targetLabel: d8_source
+          replacement: dkp
     - port: https-metrics
       scheme: https
       path: /exporter-metrics
@@ -64,8 +64,8 @@ spec:
       relabelings:
         - targetLabel: tier
           replacement: cluster
-        - targetLabel: source
-          replacement: deckhouse
+        - targetLabel: d8_source
+          replacement: dkp
   selector:
     matchLabels:
       app: gatekeeper

--- a/modules/021-cni-cilium/templates/agent/podmonitor.yaml
+++ b/modules/021-cni-cilium/templates/agent/podmonitor.yaml
@@ -22,6 +22,8 @@ spec:
       replacement: cluster
     - targetLabel: job
       replacement: "cilium-agent"
+    - targetLabel: source
+      replacement: deckhouse
   {{- if .Values.cniCilium.internal.hubble.settings.extendedMetrics.enabled }}
   - port: https-metrics
     scheme: https
@@ -37,6 +39,8 @@ spec:
         replacement: cluster
       - targetLabel: job
         replacement: "cilium-agent-extended-metrics"
+      - targetLabel: source
+        replacement: deckhouse
   {{- end }}
   selector:
     matchLabels:

--- a/modules/021-cni-cilium/templates/agent/podmonitor.yaml
+++ b/modules/021-cni-cilium/templates/agent/podmonitor.yaml
@@ -22,8 +22,8 @@ spec:
       replacement: cluster
     - targetLabel: job
       replacement: "cilium-agent"
-    - targetLabel: source
-      replacement: deckhouse
+    - targetLabel: d8_source
+      replacement: dkp
   {{- if .Values.cniCilium.internal.hubble.settings.extendedMetrics.enabled }}
   - port: https-metrics
     scheme: https
@@ -39,8 +39,8 @@ spec:
         replacement: cluster
       - targetLabel: job
         replacement: "cilium-agent-extended-metrics"
-      - targetLabel: source
-        replacement: deckhouse
+      - targetLabel: d8_source
+        replacement: dkp
   {{- end }}
   selector:
     matchLabels:

--- a/modules/021-cni-cilium/templates/operator/podmonitor.yaml
+++ b/modules/021-cni-cilium/templates/operator/podmonitor.yaml
@@ -22,6 +22,8 @@ spec:
       replacement: cluster
     - targetLabel: job
       replacement: "cilium-operator"
+    - targetLabel: source
+      replacement: deckhouse
   selector:
     matchLabels:
       app: operator

--- a/modules/021-cni-cilium/templates/operator/podmonitor.yaml
+++ b/modules/021-cni-cilium/templates/operator/podmonitor.yaml
@@ -22,8 +22,8 @@ spec:
       replacement: cluster
     - targetLabel: job
       replacement: "cilium-operator"
-    - targetLabel: source
-      replacement: deckhouse
+    - targetLabel: d8_source
+      replacement: dkp
   selector:
     matchLabels:
       app: operator

--- a/modules/030-cloud-provider-gcp/templates/cloud-data-discoverer/pod-monitor.yaml
+++ b/modules/030-cloud-provider-gcp/templates/cloud-data-discoverer/pod-monitor.yaml
@@ -31,6 +31,8 @@ spec:
       - sourceLabels: [__meta_kubernetes_pod_ready]
         regex: "true"
         action: keep
+      - targetLabel: source
+        replacement: deckhouse
   selector:
     matchLabels:
       app: cloud-data-discoverer

--- a/modules/030-cloud-provider-gcp/templates/cloud-data-discoverer/pod-monitor.yaml
+++ b/modules/030-cloud-provider-gcp/templates/cloud-data-discoverer/pod-monitor.yaml
@@ -31,8 +31,8 @@ spec:
       - sourceLabels: [__meta_kubernetes_pod_ready]
         regex: "true"
         action: keep
-      - targetLabel: source
-        replacement: deckhouse
+      - targetLabel: d8_source
+        replacement: dkp
   selector:
     matchLabels:
       app: cloud-data-discoverer

--- a/modules/030-cloud-provider-yandex/monitoring/grafana-dashboards/nat-instance/kubernetes-cluster/nat-instance.json
+++ b/modules/030-cloud-provider-yandex/monitoring/grafana-dashboards/nat-instance/kubernetes-cluster/nat-instance.json
@@ -817,7 +817,26 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "default",
+          "value": "default"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Prometheus",
+        "multi": false,
+        "name": "ds_prometheus",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
   },
   "time": {
     "from": "now-3h",

--- a/modules/030-cloud-provider-yandex/templates/cloud-metrics-exporter/pod-monitor.yaml
+++ b/modules/030-cloud-provider-yandex/templates/cloud-metrics-exporter/pod-monitor.yaml
@@ -31,6 +31,8 @@ spec:
         - sourceLabels: [ __meta_kubernetes_pod_ready ]
           regex: "true"
           action: keep
+        - targetLabel: source
+          replacement: deckhouse
   selector:
     matchLabels:
       app: cloud-metrics-exporter

--- a/modules/030-cloud-provider-yandex/templates/cloud-metrics-exporter/pod-monitor.yaml
+++ b/modules/030-cloud-provider-yandex/templates/cloud-metrics-exporter/pod-monitor.yaml
@@ -31,8 +31,8 @@ spec:
         - sourceLabels: [ __meta_kubernetes_pod_ready ]
           regex: "true"
           action: keep
-        - targetLabel: source
-          replacement: deckhouse
+        - targetLabel: d8_source
+          replacement: dkp
   selector:
     matchLabels:
       app: cloud-metrics-exporter

--- a/modules/036-kube-proxy/templates/podmonitor.yaml
+++ b/modules/036-kube-proxy/templates/podmonitor.yaml
@@ -32,4 +32,6 @@ spec:
     - sourceLabels: [__meta_kubernetes_pod_ready]
       regex: "true"
       action: keep
+    - targetLabel: source
+      replacement: deckhouse
 {{- end }}

--- a/modules/036-kube-proxy/templates/podmonitor.yaml
+++ b/modules/036-kube-proxy/templates/podmonitor.yaml
@@ -32,6 +32,6 @@ spec:
     - sourceLabels: [__meta_kubernetes_pod_ready]
       regex: "true"
       action: keep
-    - targetLabel: source
-      replacement: deckhouse
+    - targetLabel: d8_source
+      replacement: dkp
 {{- end }}

--- a/modules/039-registry-packages-proxy/templates/pod-monitor.yaml
+++ b/modules/039-registry-packages-proxy/templates/pod-monitor.yaml
@@ -32,6 +32,8 @@ spec:
     - sourceLabels: [__meta_kubernetes_pod_ready]
       regex: "true"
       action: keep
+    - targetLabel: source
+      replacement: deckhouse
     metricRelabelings:
     # Vector has a problem with internal metrics registry grows unbounded.
     # Drop metrics with high cardinality labels here to avoid overloading Prometheus instances.

--- a/modules/039-registry-packages-proxy/templates/pod-monitor.yaml
+++ b/modules/039-registry-packages-proxy/templates/pod-monitor.yaml
@@ -32,8 +32,8 @@ spec:
     - sourceLabels: [__meta_kubernetes_pod_ready]
       regex: "true"
       action: keep
-    - targetLabel: source
-      replacement: deckhouse
+    - targetLabel: d8_source
+      replacement: dkp
     metricRelabelings:
     # Vector has a problem with internal metrics registry grows unbounded.
     # Drop metrics with high cardinality labels here to avoid overloading Prometheus instances.

--- a/modules/040-control-plane-manager/monitoring/prometheus-rules/etcd-maintenance.yaml
+++ b/modules/040-control-plane-manager/monitoring/prometheus-rules/etcd-maintenance.yaml
@@ -35,6 +35,8 @@
 - name: d8.etcd-maintenance.quota-backend-bytes
   rules:
     - record: etcd_latency:etcd_request_duration_seconds:p99
+      labels:
+        source: deckhouse
       expr: |
         histogram_quantile(0.99,
           sum by (instance, le) (

--- a/modules/040-control-plane-manager/monitoring/prometheus-rules/etcd-maintenance.yaml
+++ b/modules/040-control-plane-manager/monitoring/prometheus-rules/etcd-maintenance.yaml
@@ -36,7 +36,7 @@
   rules:
     - record: etcd_latency:etcd_request_duration_seconds:p99
       labels:
-        source: deckhouse
+        d8_source: dkp
       expr: |
         histogram_quantile(0.99,
           sum by (instance, le) (

--- a/modules/040-control-plane-manager/monitoring/prometheus-rules/kubernetes.tpl
+++ b/modules/040-control-plane-manager/monitoring/prometheus-rules/kubernetes.tpl
@@ -48,44 +48,67 @@ Consider enabling the `control-plane-manager` module for advanced debugging.
   - record: pod:container_memory_usage_bytes:sum
     expr: sum(container_memory_usage_bytes{container!="POD",pod!=""}) BY
       (pod)
+    labels:
+      source: deckhouse
   - record: pod:container_spec_cpu_shares:sum
     expr: sum(container_spec_cpu_shares{container!="POD",pod!=""}) BY (pod)
+    labels:
+      source: deckhouse
   - record: pod:container_cpu_usage:sum
     expr: sum(rate(container_cpu_usage_seconds_total{container!="POD",pod!=""}[5m]))
       BY (pod)
+    labels:
+      source: deckhouse
   - record: pod:container_fs_usage_bytes:sum
     expr: sum(container_fs_usage_bytes{container!="POD",pod!=""}) BY (pod)
+    labels:
+      source: deckhouse
   - record: namespace:container_memory_usage_bytes:sum
     expr: sum(container_memory_usage_bytes{container!=""}) BY (namespace)
+    labels:
+      source: deckhouse
   - record: namespace:container_spec_cpu_shares:sum
     expr: sum(container_spec_cpu_shares{container!=""}) BY (namespace)
+    labels:
+      source: deckhouse
   - record: namespace:container_cpu_usage:sum
     expr: sum(rate(container_cpu_usage_seconds_total{container!="POD"}[5m]))
       BY (namespace)
+    labels:
+      source: deckhouse
   - record: cluster:memory_usage:ratio
     expr: sum(container_memory_usage_bytes{container!="POD",pod!=""}) BY
       (cluster) / sum(machine_memory_bytes) BY (cluster)
+    labels:
+      source: deckhouse
   - record: cluster:container_spec_cpu_shares:ratio
     expr: sum(container_spec_cpu_shares{container!="POD",pod!=""}) / 1000
       / sum(machine_cpu_cores)
+    labels:
+      source: deckhouse
   - record: cluster:container_cpu_usage:ratio
     expr: sum(rate(container_cpu_usage_seconds_total{container!="POD",pod!=""}[5m]))
       / sum(machine_cpu_cores)
+    labels:
+      source: deckhouse
   - record: apiserver_latency_seconds:quantile
     expr: histogram_quantile(0.99, rate(apiserver_request_latencies_bucket[5m])) /
       1e+06
     labels:
       quantile: "0.99"
+      source: deckhouse
   - record: apiserver_latency:quantile_seconds
     expr: histogram_quantile(0.9, rate(apiserver_request_latencies_bucket[5m])) /
       1e+06
     labels:
       quantile: "0.9"
+      source: deckhouse
   - record: apiserver_latency_seconds:quantile
     expr: histogram_quantile(0.5, rate(apiserver_request_latencies_bucket[5m])) /
       1e+06
     labels:
       quantile: "0.5"
+      source: deckhouse
   - alert: K8SApiserverDown
     expr: absent(up{job="kube-apiserver"} == 1)
     for: 20m

--- a/modules/040-control-plane-manager/monitoring/prometheus-rules/kubernetes.tpl
+++ b/modules/040-control-plane-manager/monitoring/prometheus-rules/kubernetes.tpl
@@ -49,66 +49,66 @@ Consider enabling the `control-plane-manager` module for advanced debugging.
     expr: sum(container_memory_usage_bytes{container!="POD",pod!=""}) BY
       (pod)
     labels:
-      source: deckhouse
+      d8_source: dkp
   - record: pod:container_spec_cpu_shares:sum
     expr: sum(container_spec_cpu_shares{container!="POD",pod!=""}) BY (pod)
     labels:
-      source: deckhouse
+      d8_source: dkp
   - record: pod:container_cpu_usage:sum
     expr: sum(rate(container_cpu_usage_seconds_total{container!="POD",pod!=""}[5m]))
       BY (pod)
     labels:
-      source: deckhouse
+      d8_source: dkp
   - record: pod:container_fs_usage_bytes:sum
     expr: sum(container_fs_usage_bytes{container!="POD",pod!=""}) BY (pod)
     labels:
-      source: deckhouse
+      d8_source: dkp
   - record: namespace:container_memory_usage_bytes:sum
     expr: sum(container_memory_usage_bytes{container!=""}) BY (namespace)
     labels:
-      source: deckhouse
+      d8_source: dkp
   - record: namespace:container_spec_cpu_shares:sum
     expr: sum(container_spec_cpu_shares{container!=""}) BY (namespace)
     labels:
-      source: deckhouse
+      d8_source: dkp
   - record: namespace:container_cpu_usage:sum
     expr: sum(rate(container_cpu_usage_seconds_total{container!="POD"}[5m]))
       BY (namespace)
     labels:
-      source: deckhouse
+      d8_source: dkp
   - record: cluster:memory_usage:ratio
     expr: sum(container_memory_usage_bytes{container!="POD",pod!=""}) BY
       (cluster) / sum(machine_memory_bytes) BY (cluster)
     labels:
-      source: deckhouse
+      d8_source: dkp
   - record: cluster:container_spec_cpu_shares:ratio
     expr: sum(container_spec_cpu_shares{container!="POD",pod!=""}) / 1000
       / sum(machine_cpu_cores)
     labels:
-      source: deckhouse
+      d8_source: dkp
   - record: cluster:container_cpu_usage:ratio
     expr: sum(rate(container_cpu_usage_seconds_total{container!="POD",pod!=""}[5m]))
       / sum(machine_cpu_cores)
     labels:
-      source: deckhouse
+      d8_source: dkp
   - record: apiserver_latency_seconds:quantile
     expr: histogram_quantile(0.99, rate(apiserver_request_latencies_bucket[5m])) /
       1e+06
     labels:
       quantile: "0.99"
-      source: deckhouse
+      d8_source: dkp
   - record: apiserver_latency:quantile_seconds
     expr: histogram_quantile(0.9, rate(apiserver_request_latencies_bucket[5m])) /
       1e+06
     labels:
       quantile: "0.9"
-      source: deckhouse
+      d8_source: dkp
   - record: apiserver_latency_seconds:quantile
     expr: histogram_quantile(0.5, rate(apiserver_request_latencies_bucket[5m])) /
       1e+06
     labels:
       quantile: "0.5"
-      source: deckhouse
+      d8_source: dkp
   - alert: K8SApiserverDown
     expr: absent(up{job="kube-apiserver"} == 1)
     for: 20m

--- a/modules/040-control-plane-manager/templates/control-plane-proxy-service-monitor.yaml
+++ b/modules/040-control-plane-manager/templates/control-plane-proxy-service-monitor.yaml
@@ -45,6 +45,8 @@ spec:
     - sourceLabels: [__meta_kubernetes_endpointslice_endpoint_conditions_ready]
       regex: "true"
       action: keep
+    - targetLabel: source
+      replacement: deckhouse
   {{- if eq $profile "main" }}
   - scheme: https
     port: https-metrics
@@ -64,6 +66,8 @@ spec:
     - sourceLabels: [__meta_kubernetes_endpointslice_endpoint_conditions_ready]
       regex: "true"
       action: keep
+    - targetLabel: source
+      replacement: deckhouse
   - scheme: https
     port: https-metrics
     path: /controller-manager/metrics
@@ -83,6 +87,8 @@ spec:
     - sourceLabels: [__meta_kubernetes_endpointslice_endpoint_conditions_ready]
       regex: "true"
       action: keep
+    - targetLabel: source
+      replacement: deckhouse
   {{- end }}
 {{- end }}
 {{- end }}

--- a/modules/040-control-plane-manager/templates/control-plane-proxy-service-monitor.yaml
+++ b/modules/040-control-plane-manager/templates/control-plane-proxy-service-monitor.yaml
@@ -45,8 +45,8 @@ spec:
     - sourceLabels: [__meta_kubernetes_endpointslice_endpoint_conditions_ready]
       regex: "true"
       action: keep
-    - targetLabel: source
-      replacement: deckhouse
+    - targetLabel: d8_source
+      replacement: dkp
   {{- if eq $profile "main" }}
   - scheme: https
     port: https-metrics
@@ -66,8 +66,8 @@ spec:
     - sourceLabels: [__meta_kubernetes_endpointslice_endpoint_conditions_ready]
       regex: "true"
       action: keep
-    - targetLabel: source
-      replacement: deckhouse
+    - targetLabel: d8_source
+      replacement: dkp
   - scheme: https
     port: https-metrics
     path: /controller-manager/metrics
@@ -87,8 +87,8 @@ spec:
     - sourceLabels: [__meta_kubernetes_endpointslice_endpoint_conditions_ready]
       regex: "true"
       action: keep
-    - targetLabel: source
-      replacement: deckhouse
+    - targetLabel: d8_source
+      replacement: dkp
   {{- end }}
 {{- end }}
 {{- end }}

--- a/modules/040-control-plane-manager/templates/kube-apiserver-service-monitor.yaml
+++ b/modules/040-control-plane-manager/templates/kube-apiserver-service-monitor.yaml
@@ -33,6 +33,8 @@ spec:
     - sourceLabels: [__meta_kubernetes_endpointslice_endpoint_conditions_ready]
       regex: "true"
       action: keep
+    - targetLabel: source
+      replacement: deckhouse
     metricRelabelings:
     # Drop some buckets to reduce cardinality, default precision is too high
     - sourceLabels: [__name__, le]

--- a/modules/040-control-plane-manager/templates/kube-apiserver-service-monitor.yaml
+++ b/modules/040-control-plane-manager/templates/kube-apiserver-service-monitor.yaml
@@ -33,8 +33,8 @@ spec:
     - sourceLabels: [__meta_kubernetes_endpointslice_endpoint_conditions_ready]
       regex: "true"
       action: keep
-    - targetLabel: source
-      replacement: deckhouse
+    - targetLabel: d8_source
+      replacement: dkp
     metricRelabelings:
     # Drop some buckets to reduce cardinality, default precision is too high
     - sourceLabels: [__name__, le]

--- a/modules/040-control-plane-manager/templates/podmonitor.yaml
+++ b/modules/040-control-plane-manager/templates/podmonitor.yaml
@@ -24,6 +24,8 @@ spec:
     - sourceLabels: [__meta_kubernetes_pod_ready]
       regex: "true"
       action: keep
+    - targetLabel: source
+      replacement: deckhouse
   selector:
     matchLabels:
       component: control-plane-manager

--- a/modules/040-control-plane-manager/templates/podmonitor.yaml
+++ b/modules/040-control-plane-manager/templates/podmonitor.yaml
@@ -24,8 +24,8 @@ spec:
     - sourceLabels: [__meta_kubernetes_pod_ready]
       regex: "true"
       action: keep
-    - targetLabel: source
-      replacement: deckhouse
+    - targetLabel: d8_source
+      replacement: dkp
   selector:
     matchLabels:
       component: control-plane-manager

--- a/modules/040-node-manager/monitoring/prometheus-rules/node-group.tpl
+++ b/modules/040-node-manager/monitoring/prometheus-rules/node-group.tpl
@@ -86,7 +86,7 @@
       * on(name) group_left(node_group) machine_deployment_node_group_info
     for: 20m
     labels:
-      severity_level: "8"
+      severity_level: "6"
       tier: cluster
     annotations:
       plk_protocol_version: "1"

--- a/modules/040-node-manager/templates/capi-controller-manager/pod-monitor.yaml
+++ b/modules/040-node-manager/templates/capi-controller-manager/pod-monitor.yaml
@@ -25,6 +25,8 @@ spec:
     - sourceLabels: [__meta_kubernetes_pod_ready]
       regex: "true"
       action: keep
+    - targetLabel: source
+      replacement: deckhouse
   selector:
     matchLabels:
       app: capi-controller-manager

--- a/modules/040-node-manager/templates/capi-controller-manager/pod-monitor.yaml
+++ b/modules/040-node-manager/templates/capi-controller-manager/pod-monitor.yaml
@@ -25,8 +25,8 @@ spec:
     - sourceLabels: [__meta_kubernetes_pod_ready]
       regex: "true"
       action: keep
-    - targetLabel: source
-      replacement: deckhouse
+    - targetLabel: d8_source
+      replacement: dkp
   selector:
     matchLabels:
       app: capi-controller-manager

--- a/modules/040-node-manager/templates/cluster-autoscaler/pod-monitor.yaml
+++ b/modules/040-node-manager/templates/cluster-autoscaler/pod-monitor.yaml
@@ -26,6 +26,8 @@ spec:
     - sourceLabels: [__meta_kubernetes_pod_ready]
       regex: "true"
       action: keep
+    - targetLabel: source
+      replacement: deckhouse
   selector:
     matchLabels:
       app: {{ $name }}

--- a/modules/040-node-manager/templates/cluster-autoscaler/pod-monitor.yaml
+++ b/modules/040-node-manager/templates/cluster-autoscaler/pod-monitor.yaml
@@ -26,8 +26,8 @@ spec:
     - sourceLabels: [__meta_kubernetes_pod_ready]
       regex: "true"
       action: keep
-    - targetLabel: source
-      replacement: deckhouse
+    - targetLabel: d8_source
+      replacement: dkp
   selector:
     matchLabels:
       app: {{ $name }}

--- a/modules/040-node-manager/templates/machine-controller-manager/pod-monitor.yaml
+++ b/modules/040-node-manager/templates/machine-controller-manager/pod-monitor.yaml
@@ -25,6 +25,8 @@ spec:
     - sourceLabels: [__meta_kubernetes_pod_ready]
       regex: "true"
       action: keep
+    - targetLabel: source
+      replacement: deckhouse
   selector:
     matchLabels:
       app: machine-controller-manager

--- a/modules/040-node-manager/templates/machine-controller-manager/pod-monitor.yaml
+++ b/modules/040-node-manager/templates/machine-controller-manager/pod-monitor.yaml
@@ -25,8 +25,8 @@ spec:
     - sourceLabels: [__meta_kubernetes_pod_ready]
       regex: "true"
       action: keep
-    - targetLabel: source
-      replacement: deckhouse
+    - targetLabel: d8_source
+      replacement: dkp
   selector:
     matchLabels:
       app: machine-controller-manager

--- a/modules/040-node-manager/templates/node-controller/pod-monitor.yaml
+++ b/modules/040-node-manager/templates/node-controller/pod-monitor.yaml
@@ -24,6 +24,8 @@ spec:
     - sourceLabels: [__meta_kubernetes_pod_ready]
       regex: "true"
       action: keep
+    - targetLabel: source
+      replacement: deckhouse
   selector:
     matchLabels:
       app: node-controller

--- a/modules/040-node-manager/templates/node-controller/pod-monitor.yaml
+++ b/modules/040-node-manager/templates/node-controller/pod-monitor.yaml
@@ -24,8 +24,8 @@ spec:
     - sourceLabels: [__meta_kubernetes_pod_ready]
       regex: "true"
       action: keep
-    - targetLabel: source
-      replacement: deckhouse
+    - targetLabel: d8_source
+      replacement: dkp
   selector:
     matchLabels:
       app: node-controller

--- a/modules/040-node-manager/templates/node-group-exporter/pod-monitor.yaml
+++ b/modules/040-node-manager/templates/node-group-exporter/pod-monitor.yaml
@@ -25,6 +25,8 @@ spec:
     - sourceLabels: [__meta_kubernetes_pod_ready]
       regex: "true"
       action: keep
+    - targetLabel: source
+      replacement: deckhouse
   selector:
     matchLabels:
       app: node-group-exporter

--- a/modules/040-node-manager/templates/node-group-exporter/pod-monitor.yaml
+++ b/modules/040-node-manager/templates/node-group-exporter/pod-monitor.yaml
@@ -25,8 +25,8 @@ spec:
     - sourceLabels: [__meta_kubernetes_pod_ready]
       regex: "true"
       action: keep
-    - targetLabel: source
-      replacement: deckhouse
+    - targetLabel: d8_source
+      replacement: dkp
   selector:
     matchLabels:
       app: node-group-exporter

--- a/modules/040-terraform-manager/templates/terraform-auto-converger/podmonitor.yaml
+++ b/modules/040-terraform-manager/templates/terraform-auto-converger/podmonitor.yaml
@@ -24,6 +24,8 @@ spec:
       action: keep
     - regex: endpoint
       action: labeldrop
+    - targetLabel: source
+      replacement: deckhouse
   selector:
     matchLabels:
       app: terraform-auto-converger

--- a/modules/040-terraform-manager/templates/terraform-auto-converger/podmonitor.yaml
+++ b/modules/040-terraform-manager/templates/terraform-auto-converger/podmonitor.yaml
@@ -24,8 +24,8 @@ spec:
       action: keep
     - regex: endpoint
       action: labeldrop
-    - targetLabel: source
-      replacement: deckhouse
+    - targetLabel: d8_source
+      replacement: dkp
   selector:
     matchLabels:
       app: terraform-auto-converger

--- a/modules/040-terraform-manager/templates/terraform-state-exporter/podmonitor.yaml
+++ b/modules/040-terraform-manager/templates/terraform-state-exporter/podmonitor.yaml
@@ -24,6 +24,8 @@ spec:
       action: keep
     - regex: endpoint
       action: labeldrop
+    - targetLabel: source
+      replacement: deckhouse
   selector:
     matchLabels:
       app: terraform-state-exporter

--- a/modules/040-terraform-manager/templates/terraform-state-exporter/podmonitor.yaml
+++ b/modules/040-terraform-manager/templates/terraform-state-exporter/podmonitor.yaml
@@ -24,8 +24,8 @@ spec:
       action: keep
     - regex: endpoint
       action: labeldrop
-    - targetLabel: source
-      replacement: deckhouse
+    - targetLabel: d8_source
+      replacement: dkp
   selector:
     matchLabels:
       app: terraform-state-exporter

--- a/modules/042-kube-dns/templates/podmonitor.yaml
+++ b/modules/042-kube-dns/templates/podmonitor.yaml
@@ -32,4 +32,6 @@ spec:
     - sourceLabels: [__meta_kubernetes_pod_ready]
       regex: "true"
       action: keep
+    - targetLabel: source
+      replacement: deckhouse
 {{- end }}

--- a/modules/042-kube-dns/templates/podmonitor.yaml
+++ b/modules/042-kube-dns/templates/podmonitor.yaml
@@ -32,6 +32,6 @@ spec:
     - sourceLabels: [__meta_kubernetes_pod_ready]
       regex: "true"
       action: keep
-    - targetLabel: source
-      replacement: deckhouse
+    - targetLabel: d8_source
+      replacement: dkp
 {{- end }}

--- a/modules/050-network-policy-engine/templates/podmonitor.yaml
+++ b/modules/050-network-policy-engine/templates/podmonitor.yaml
@@ -18,6 +18,8 @@ spec:
     - sourceLabels: [__meta_kubernetes_pod_ready]
       regex: "true"
       action: keep
+    - targetLabel: source
+      replacement: deckhouse
   selector:
     matchLabels:
       app: kube-router

--- a/modules/050-network-policy-engine/templates/podmonitor.yaml
+++ b/modules/050-network-policy-engine/templates/podmonitor.yaml
@@ -18,8 +18,8 @@ spec:
     - sourceLabels: [__meta_kubernetes_pod_ready]
       regex: "true"
       action: keep
-    - targetLabel: source
-      replacement: deckhouse
+    - targetLabel: d8_source
+      replacement: dkp
   selector:
     matchLabels:
       app: kube-router

--- a/modules/101-cert-manager/templates/cert-manager/podmonitor.yaml
+++ b/modules/101-cert-manager/templates/cert-manager/podmonitor.yaml
@@ -24,6 +24,8 @@ spec:
     - sourceLabels: [__meta_kubernetes_pod_ready]
       regex: "true"
       action: keep
+    - targetLabel: source
+      replacement: deckhouse
   selector:
     matchLabels:
       app: cert-manager

--- a/modules/101-cert-manager/templates/cert-manager/podmonitor.yaml
+++ b/modules/101-cert-manager/templates/cert-manager/podmonitor.yaml
@@ -24,8 +24,8 @@ spec:
     - sourceLabels: [__meta_kubernetes_pod_ready]
       regex: "true"
       action: keep
-    - targetLabel: source
-      replacement: deckhouse
+    - targetLabel: d8_source
+      replacement: dkp
   selector:
     matchLabels:
       app: cert-manager

--- a/modules/110-istio/templates/cni/podmonitor.yaml
+++ b/modules/110-istio/templates/cni/podmonitor.yaml
@@ -23,6 +23,8 @@ spec:
           replacement: cluster
         - targetLabel: job
           replacement: "istio-cni"
+        - targetLabel: source
+          replacement: deckhouse
   selector:
     matchLabels:
       app: istio-cni-node

--- a/modules/110-istio/templates/cni/podmonitor.yaml
+++ b/modules/110-istio/templates/cni/podmonitor.yaml
@@ -23,8 +23,8 @@ spec:
           replacement: cluster
         - targetLabel: job
           replacement: "istio-cni"
-        - targetLabel: source
-          replacement: deckhouse
+        - targetLabel: d8_source
+          replacement: dkp
   selector:
     matchLabels:
       app: istio-cni-node

--- a/modules/110-istio/templates/control-plane/servicemonitor.yaml
+++ b/modules/110-istio/templates/control-plane/servicemonitor.yaml
@@ -42,5 +42,7 @@ spec:
     - sourceLabels: [__meta_kubernetes_endpointslice_endpoint_conditions_ready]
       regex: "true"
       action: keep
+    - targetLabel: source
+      replacement: deckhouse
   {{- end }}
 {{- end }}

--- a/modules/110-istio/templates/control-plane/servicemonitor.yaml
+++ b/modules/110-istio/templates/control-plane/servicemonitor.yaml
@@ -42,7 +42,7 @@ spec:
     - sourceLabels: [__meta_kubernetes_endpointslice_endpoint_conditions_ready]
       regex: "true"
       action: keep
-    - targetLabel: source
-      replacement: deckhouse
+    - targetLabel: d8_source
+      replacement: dkp
   {{- end }}
 {{- end }}

--- a/modules/110-istio/templates/ingressistiocontroller/podmonitor.yaml
+++ b/modules/110-istio/templates/ingressistiocontroller/podmonitor.yaml
@@ -43,6 +43,9 @@ spec:
       sourceLabels:
       - __meta_kubernetes_namespace
       targetLabel: namespace
+    - action: replace
+      replacement: deckhouse
+      targetLabel: source
     scheme: http
   selector:
     matchExpressions:

--- a/modules/110-istio/templates/ingressistiocontroller/podmonitor.yaml
+++ b/modules/110-istio/templates/ingressistiocontroller/podmonitor.yaml
@@ -44,8 +44,8 @@ spec:
       - __meta_kubernetes_namespace
       targetLabel: namespace
     - action: replace
-      replacement: deckhouse
-      targetLabel: source
+      replacement: dkp
+      targetLabel: d8_source
     scheme: http
   selector:
     matchExpressions:

--- a/modules/110-istio/templates/operator/podmonitor.yaml
+++ b/modules/110-istio/templates/operator/podmonitor.yaml
@@ -43,6 +43,8 @@ spec:
     - sourceLabels: [__meta_kubernetes_pod_ready]
       regex: "true"
       action: keep
+    - targetLabel: source
+      replacement: deckhouse
     {{- end }}
   {{- end }}
 {{- end }}

--- a/modules/110-istio/templates/operator/podmonitor.yaml
+++ b/modules/110-istio/templates/operator/podmonitor.yaml
@@ -43,8 +43,8 @@ spec:
     - sourceLabels: [__meta_kubernetes_pod_ready]
       regex: "true"
       action: keep
-    - targetLabel: source
-      replacement: deckhouse
+    - targetLabel: d8_source
+      replacement: dkp
     {{- end }}
   {{- end }}
 {{- end }}

--- a/modules/110-istio/templates/podmonitor.yaml
+++ b/modules/110-istio/templates/podmonitor.yaml
@@ -43,6 +43,8 @@ spec:
       sourceLabels:
       - __meta_kubernetes_namespace
       targetLabel: namespace
+    - targetLabel: source
+      replacement: deckhouse
   selector:
     matchExpressions:
     - key: service.istio.io/canonical-name

--- a/modules/110-istio/templates/podmonitor.yaml
+++ b/modules/110-istio/templates/podmonitor.yaml
@@ -43,8 +43,8 @@ spec:
       sourceLabels:
       - __meta_kubernetes_namespace
       targetLabel: namespace
-    - targetLabel: source
-      replacement: deckhouse
+    - targetLabel: d8_source
+      replacement: dkp
   selector:
     matchExpressions:
     - key: service.istio.io/canonical-name

--- a/modules/150-user-authn/templates/controller/podmonitor.yaml
+++ b/modules/150-user-authn/templates/controller/podmonitor.yaml
@@ -22,6 +22,6 @@ spec:
     - sourceLabels: [__meta_kubernetes_pod_ready]
       regex: "true"
       action: keep
-    - targetLabel: source
-      replacement: deckhouse
+    - targetLabel: d8_source
+      replacement: dkp
 {{- end }}

--- a/modules/150-user-authn/templates/controller/podmonitor.yaml
+++ b/modules/150-user-authn/templates/controller/podmonitor.yaml
@@ -22,4 +22,6 @@ spec:
     - sourceLabels: [__meta_kubernetes_pod_ready]
       regex: "true"
       action: keep
+    - targetLabel: source
+      replacement: deckhouse
 {{- end }}

--- a/modules/150-user-authn/templates/dex/podmonitor.yaml
+++ b/modules/150-user-authn/templates/dex/podmonitor.yaml
@@ -28,4 +28,6 @@ spec:
     - sourceLabels: [__meta_kubernetes_pod_ready]
       regex: "true"
       action: keep
+    - targetLabel: source
+      replacement: deckhouse
 {{- end }}

--- a/modules/150-user-authn/templates/dex/podmonitor.yaml
+++ b/modules/150-user-authn/templates/dex/podmonitor.yaml
@@ -28,6 +28,6 @@ spec:
     - sourceLabels: [__meta_kubernetes_pod_ready]
       regex: "true"
       action: keep
-    - targetLabel: source
-      replacement: deckhouse
+    - targetLabel: d8_source
+      replacement: dkp
 {{- end }}

--- a/modules/302-vertical-pod-autoscaler/templates/podmonitor.yaml
+++ b/modules/302-vertical-pod-autoscaler/templates/podmonitor.yaml
@@ -27,6 +27,8 @@ spec:
         action: labeldrop
       - targetLabel: tier
         replacement: cluster
+      - targetLabel: source
+        replacement: deckhouse
 {{/*    metricRelabelings:*/}}
 {{/*    # Vector has a problem with internal metrics registry grows unbounded.*/}}
 {{/*    # Drop metrics with high cardinality labels here to avoid overloading Prometheus instances.*/}}

--- a/modules/302-vertical-pod-autoscaler/templates/podmonitor.yaml
+++ b/modules/302-vertical-pod-autoscaler/templates/podmonitor.yaml
@@ -27,8 +27,8 @@ spec:
         action: labeldrop
       - targetLabel: tier
         replacement: cluster
-      - targetLabel: source
-        replacement: deckhouse
+      - targetLabel: d8_source
+        replacement: dkp
 {{/*    metricRelabelings:*/}}
 {{/*    # Vector has a problem with internal metrics registry grows unbounded.*/}}
 {{/*    # Drop metrics with high cardinality labels here to avoid overloading Prometheus instances.*/}}

--- a/modules/400-descheduler/monitoring/prometheus-rules/drs-lens.yaml
+++ b/modules/400-descheduler/monitoring/prometheus-rules/drs-lens.yaml
@@ -1,6 +1,8 @@
 - name: descheduler.drs-lens.happiness
   rules:
   - record: descheduler:replicaset_workload
+    labels:
+      source: deckhouse
     expr: |
       max by (namespace, replicaset, workload_kind, workload_name) (
         label_replace(label_replace(
@@ -10,6 +12,8 @@
       )
 
   - record: descheduler:pod_workload
+    labels:
+      source: deckhouse
     expr: |
       max by (namespace, pod, node, workload_kind, workload_name) (
         (
@@ -44,9 +48,13 @@
         (kube_pod_status_phase{job="kube-state-metrics", phase="Succeeded"} == 1)
 
   - record: descheduler:workload_replicas
+    labels:
+      source: deckhouse
     expr: count by (namespace, workload_kind, workload_name) (descheduler:pod_workload)
 
   - record: descheduler:pod_restarts_15m
+    labels:
+      source: deckhouse
     expr: |
       round(sum by (namespace, pod) (
         increase(kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace!~"d8-.*|kube-system"}[15m])
@@ -54,6 +62,8 @@
 
   # Primary source klog_pod_oomkill; fallback last_terminated_reason gated by a recent restart.
   - record: descheduler:pod_oom_15m
+    labels:
+      source: deckhouse
     expr: |
       max by (namespace, pod) (
         label_replace(
@@ -71,6 +81,8 @@
 
   # State penalties are share-weighted: sum of per-pod weight over the anchor / replicas.
   - record: descheduler:workload_phase_penalty
+    labels:
+      source: deckhouse
     expr: |
       sum by (namespace, workload_kind, workload_name) (
         (
@@ -85,6 +97,8 @@
 
   # Container-level readiness penalty is absorbed here: pod Ready=False already covers it.
   - record: descheduler:workload_readiness_penalty
+    labels:
+      source: deckhouse
     expr: |
       30 * sum by (namespace, workload_kind, workload_name) (
         (kube_pod_status_ready{job="kube-state-metrics", condition="false"} == 1)
@@ -94,6 +108,8 @@
       / descheduler:workload_replicas
 
   - record: descheduler:workload_restart_penalty
+    labels:
+      source: deckhouse
     expr: |
       sum by (namespace, workload_kind, workload_name) (
         (
@@ -106,6 +122,8 @@
       / descheduler:workload_replicas
 
   - record: descheduler:workload_oom_penalty
+    labels:
+      source: deckhouse
     expr: |
       35 * sum by (namespace, workload_kind, workload_name) (
         (descheduler:pod_oom_15m > bool 0)
@@ -115,6 +133,8 @@
       / descheduler:workload_replicas
 
   - record: descheduler:workload_cpu_request_cores
+    labels:
+      source: deckhouse
     expr: |
       sum by (namespace, workload_kind, workload_name) (
         kube_pod_container_resource_requests{job="kube-state-metrics", resource="cpu", unit="core"}
@@ -123,6 +143,8 @@
       )
 
   - record: descheduler:workload_cpu_usage_cores
+    labels:
+      source: deckhouse
     expr: |
       sum by (namespace, workload_kind, workload_name) (
         rate(container_cpu_usage_seconds_total{job="kubelet", container!~"|POD"}[5m])
@@ -131,6 +153,8 @@
       )
 
   - record: descheduler:workload_memory_request_bytes
+    labels:
+      source: deckhouse
     expr: |
       sum by (namespace, workload_kind, workload_name) (
         kube_pod_container_resource_requests{job="kube-state-metrics", resource="memory", unit="byte"}
@@ -139,6 +163,8 @@
       )
 
   - record: descheduler:workload_memory_usage_bytes
+    labels:
+      source: deckhouse
     expr: |
       sum by (namespace, workload_kind, workload_name) (
         container_memory_working_set_bytes{job="kubelet", container!~"|POD"}
@@ -148,13 +174,19 @@
 
   # The `> 0` guard drops zero/absent denominators so the ratio yields no series (not +Inf/NaN).
   - record: descheduler:workload_cpu_usage_ratio
+    labels:
+      source: deckhouse
     expr: descheduler:workload_cpu_usage_cores / (descheduler:workload_cpu_request_cores > 0)
 
   - record: descheduler:workload_memory_request_usage_ratio
+    labels:
+      source: deckhouse
     expr: descheduler:workload_memory_usage_bytes / (descheduler:workload_memory_request_bytes > 0)
 
   # MAX over pods: OOM proximity is per-pod physics.
   - record: descheduler:workload_memory_limit_usage_ratio
+    labels:
+      source: deckhouse
     expr: |
       max by (namespace, workload_kind, workload_name) (
         (
@@ -170,6 +202,8 @@
 
   # "no request" = workload has no aggregate request series at all (detected via `unless`).
   - record: descheduler:workload_cpu_penalty
+    labels:
+      source: deckhouse
     expr: |
       clamp_max(
           ((descheduler:workload_replicas unless descheduler:workload_cpu_request_cores) > bool 0) * 10
@@ -182,6 +216,8 @@
 
   # Terms are additive; each falls back to 0 via `or replicas*0`, so a limit-only workload still scores the limit rungs.
   - record: descheduler:workload_memory_penalty
+    labels:
+      source: deckhouse
     expr: |
       clamp_max(
           (((descheduler:workload_replicas unless descheduler:workload_memory_request_bytes) > bool 0) * 10
@@ -195,6 +231,8 @@
         35)
 
   - record: descheduler:workload_node_penalty
+    labels:
+      source: deckhouse
     expr: |
       sum by (namespace, workload_kind, workload_name) (
         descheduler:pod_workload
@@ -210,6 +248,8 @@
       / descheduler:workload_replicas
 
   - record: descheduler:workload_eviction_penalty
+    labels:
+      source: deckhouse
     expr: |
       max by (namespace, workload_kind, workload_name) (
           (increase(descheduler_pod_evictions_total{job="descheduler", result="success"}[15m]) > bool 0) * 10
@@ -218,6 +258,8 @@
       )
 
   - record: descheduler:workload_happiness_score
+    labels:
+      source: deckhouse
     expr: |
       clamp_min(clamp_max(
         100
@@ -232,27 +274,33 @@
       , 100), 0)
 
   - record: descheduler:workload_happiness_bucket
-    labels: { bucket: happy }
+    labels: { bucket: happy, source: deckhouse }
     expr: descheduler:workload_happiness_score >= 80
   - record: descheduler:workload_happiness_bucket
-    labels: { bucket: warning }
+    labels: { bucket: warning, source: deckhouse }
     expr: (descheduler:workload_happiness_score >= 60) and (descheduler:workload_happiness_score < 80)
   - record: descheduler:workload_happiness_bucket
-    labels: { bucket: unhappy }
+    labels: { bucket: unhappy, source: deckhouse }
     expr: descheduler:workload_happiness_score < 60
 
 - name: descheduler.drs-lens.balance
   rules:
   - record: descheduler:node_pod_allocation_ratio
+    labels:
+      source: deckhouse
     expr: |
       count by (node) (kube_pod_info{job="kube-state-metrics"})
         / on (node) group_left ()
         max by (node) (kube_node_status_allocatable{job="kube-state-metrics", resource="pods", unit="integer"})
 
   - record: descheduler:node_cpu_usage_ratio
+    labels:
+      source: deckhouse
     expr: 1 - avg by (node) (rate(node_cpu_seconds_total{job="node-exporter", mode="idle"}[5m]))
 
   - record: descheduler:node_memory_usage_ratio
+    labels:
+      source: deckhouse
     expr: |
       1 - (
         max by (node) (node_memory_MemAvailable_bytes{job="node-exporter"})
@@ -260,33 +308,37 @@
       )
 
   - record: descheduler:node_cpu_request_ratio
+    labels:
+      source: deckhouse
     expr: |
       sum by (node) (kube_pod_container_resource_requests{job="kube-state-metrics", resource="cpu", unit="core"})
         / on (node) group_left ()
         max by (node) (kube_node_status_allocatable{job="kube-state-metrics", resource="cpu", unit="core"})
 
   - record: descheduler:node_memory_request_ratio
+    labels:
+      source: deckhouse
     expr: |
       sum by (node) (kube_pod_container_resource_requests{job="kube-state-metrics", resource="memory", unit="byte"})
         / on (node) group_left ()
         max by (node) (kube_node_status_allocatable{job="kube-state-metrics", resource="memory", unit="byte"})
 
   - record: descheduler:cluster_imbalance_score
-    labels: { resource: pods }
+    labels: { resource: pods, source: deckhouse }
     expr: max(descheduler:node_pod_allocation_ratio) - min(descheduler:node_pod_allocation_ratio)
   - record: descheduler:cluster_imbalance_score
-    labels: { resource: cpu }
+    labels: { resource: cpu, source: deckhouse }
     expr: max(descheduler:node_cpu_usage_ratio) - min(descheduler:node_cpu_usage_ratio)
   - record: descheduler:cluster_imbalance_score
-    labels: { resource: memory }
+    labels: { resource: memory, source: deckhouse }
     expr: max(descheduler:node_memory_usage_ratio) - min(descheduler:node_memory_usage_ratio)
 
   - record: descheduler:cluster_imbalance_stddev
-    labels: { resource: pods }
+    labels: { resource: pods, source: deckhouse }
     expr: stddev(descheduler:node_pod_allocation_ratio)
   - record: descheduler:cluster_imbalance_stddev
-    labels: { resource: cpu }
+    labels: { resource: cpu, source: deckhouse }
     expr: stddev(descheduler:node_cpu_usage_ratio)
   - record: descheduler:cluster_imbalance_stddev
-    labels: { resource: memory }
+    labels: { resource: memory, source: deckhouse }
     expr: stddev(descheduler:node_memory_usage_ratio)

--- a/modules/400-descheduler/monitoring/prometheus-rules/workload-happiness.yaml
+++ b/modules/400-descheduler/monitoring/prometheus-rules/workload-happiness.yaml
@@ -1,6 +1,8 @@
 - name: descheduler.workload-happiness.happiness
   rules:
   - record: descheduler:replicaset_workload
+    labels:
+      source: deckhouse
     expr: |
       max by (namespace, replicaset, workload_kind, workload_name) (
         label_replace(label_replace(
@@ -10,6 +12,8 @@
       )
 
   - record: descheduler:pod_workload
+    labels:
+      source: deckhouse
     expr: |
       max by (namespace, pod, node, workload_kind, workload_name) (
         (
@@ -44,9 +48,13 @@
         (kube_pod_status_phase{job="kube-state-metrics", phase="Succeeded"} == 1)
 
   - record: descheduler:workload_replicas
+    labels:
+      source: deckhouse
     expr: count by (namespace, workload_kind, workload_name) (descheduler:pod_workload)
 
   - record: descheduler:pod_restarts_15m
+    labels:
+      source: deckhouse
     expr: |
       round(sum by (namespace, pod) (
         increase(kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace!~"d8-.*|kube-system"}[15m])
@@ -54,6 +62,8 @@
 
   # Primary source klog_pod_oomkill; fallback last_terminated_reason gated by a recent restart.
   - record: descheduler:pod_oom_15m
+    labels:
+      source: deckhouse
     expr: |
       max by (namespace, pod) (
         label_replace(
@@ -71,6 +81,8 @@
 
   # State penalties are share-weighted: sum of per-pod weight over the anchor / replicas.
   - record: descheduler:workload_phase_penalty
+    labels:
+      source: deckhouse
     expr: |
       sum by (namespace, workload_kind, workload_name) (
         (
@@ -85,6 +97,8 @@
 
   # Container-level readiness penalty is absorbed here: pod Ready=False already covers it.
   - record: descheduler:workload_readiness_penalty
+    labels:
+      source: deckhouse
     expr: |
       30 * sum by (namespace, workload_kind, workload_name) (
         (kube_pod_status_ready{job="kube-state-metrics", condition="false"} == 1)
@@ -94,6 +108,8 @@
       / descheduler:workload_replicas
 
   - record: descheduler:workload_restart_penalty
+    labels:
+      source: deckhouse
     expr: |
       sum by (namespace, workload_kind, workload_name) (
         (
@@ -106,6 +122,8 @@
       / descheduler:workload_replicas
 
   - record: descheduler:workload_oom_penalty
+    labels:
+      source: deckhouse
     expr: |
       35 * sum by (namespace, workload_kind, workload_name) (
         (descheduler:pod_oom_15m > bool 0)
@@ -115,6 +133,8 @@
       / descheduler:workload_replicas
 
   - record: descheduler:workload_cpu_request_cores
+    labels:
+      source: deckhouse
     expr: |
       sum by (namespace, workload_kind, workload_name) (
         kube_pod_container_resource_requests{job="kube-state-metrics", resource="cpu", unit="core"}
@@ -123,6 +143,8 @@
       )
 
   - record: descheduler:workload_cpu_usage_cores
+    labels:
+      source: deckhouse
     expr: |
       sum by (namespace, workload_kind, workload_name) (
         rate(container_cpu_usage_seconds_total{job="kubelet", container!~"|POD"}[5m])
@@ -131,6 +153,8 @@
       )
 
   - record: descheduler:workload_memory_request_bytes
+    labels:
+      source: deckhouse
     expr: |
       sum by (namespace, workload_kind, workload_name) (
         kube_pod_container_resource_requests{job="kube-state-metrics", resource="memory", unit="byte"}
@@ -139,6 +163,8 @@
       )
 
   - record: descheduler:workload_memory_usage_bytes
+    labels:
+      source: deckhouse
     expr: |
       sum by (namespace, workload_kind, workload_name) (
         container_memory_working_set_bytes{job="kubelet", container!~"|POD"}
@@ -148,13 +174,19 @@
 
   # The `> 0` guard drops zero/absent denominators so the ratio yields no series (not +Inf/NaN).
   - record: descheduler:workload_cpu_usage_ratio
+    labels:
+      source: deckhouse
     expr: descheduler:workload_cpu_usage_cores / (descheduler:workload_cpu_request_cores > 0)
 
   - record: descheduler:workload_memory_request_usage_ratio
+    labels:
+      source: deckhouse
     expr: descheduler:workload_memory_usage_bytes / (descheduler:workload_memory_request_bytes > 0)
 
   # MAX over pods: OOM proximity is per-pod physics.
   - record: descheduler:workload_memory_limit_usage_ratio
+    labels:
+      source: deckhouse
     expr: |
       max by (namespace, workload_kind, workload_name) (
         (
@@ -170,6 +202,8 @@
 
   # "no request" = workload has no aggregate request series at all (detected via `unless`).
   - record: descheduler:workload_cpu_penalty
+    labels:
+      source: deckhouse
     expr: |
       clamp_max(
           ((descheduler:workload_replicas unless descheduler:workload_cpu_request_cores) > bool 0) * 10
@@ -182,6 +216,8 @@
 
   # Terms are additive; each falls back to 0 via `or replicas*0`, so a limit-only workload still scores the limit rungs.
   - record: descheduler:workload_memory_penalty
+    labels:
+      source: deckhouse
     expr: |
       clamp_max(
           (((descheduler:workload_replicas unless descheduler:workload_memory_request_bytes) > bool 0) * 10
@@ -195,6 +231,8 @@
         35)
 
   - record: descheduler:workload_node_penalty
+    labels:
+      source: deckhouse
     expr: |
       sum by (namespace, workload_kind, workload_name) (
         descheduler:pod_workload
@@ -210,6 +248,8 @@
       / descheduler:workload_replicas
 
   - record: descheduler:workload_eviction_penalty
+    labels:
+      source: deckhouse
     expr: |
       max by (namespace, workload_kind, workload_name) (
           (increase(descheduler_pod_evictions_total{job="descheduler", result="success"}[15m]) > bool 0) * 10
@@ -218,6 +258,8 @@
       )
 
   - record: descheduler:workload_happiness_score
+    labels:
+      source: deckhouse
     expr: |
       clamp_min(clamp_max(
         100
@@ -232,27 +274,33 @@
       , 100), 0)
 
   - record: descheduler:workload_happiness_bucket
-    labels: { bucket: happy }
+    labels: { bucket: happy, source: deckhouse }
     expr: descheduler:workload_happiness_score >= 80
   - record: descheduler:workload_happiness_bucket
-    labels: { bucket: warning }
+    labels: { bucket: warning, source: deckhouse }
     expr: (descheduler:workload_happiness_score >= 60) and (descheduler:workload_happiness_score < 80)
   - record: descheduler:workload_happiness_bucket
-    labels: { bucket: unhappy }
+    labels: { bucket: unhappy, source: deckhouse }
     expr: descheduler:workload_happiness_score < 60
 
 - name: descheduler.workload-happiness.balance
   rules:
   - record: descheduler:node_pod_allocation_ratio
+    labels:
+      source: deckhouse
     expr: |
       count by (node) (kube_pod_info{job="kube-state-metrics"})
         / on (node) group_left ()
         max by (node) (kube_node_status_allocatable{job="kube-state-metrics", resource="pods", unit="integer"})
 
   - record: descheduler:node_cpu_usage_ratio
+    labels:
+      source: deckhouse
     expr: 1 - avg by (node) (rate(node_cpu_seconds_total{job="node-exporter", mode="idle"}[5m]))
 
   - record: descheduler:node_memory_usage_ratio
+    labels:
+      source: deckhouse
     expr: |
       1 - (
         max by (node) (node_memory_MemAvailable_bytes{job="node-exporter"})
@@ -260,33 +308,37 @@
       )
 
   - record: descheduler:node_cpu_request_ratio
+    labels:
+      source: deckhouse
     expr: |
       sum by (node) (kube_pod_container_resource_requests{job="kube-state-metrics", resource="cpu", unit="core"})
         / on (node) group_left ()
         max by (node) (kube_node_status_allocatable{job="kube-state-metrics", resource="cpu", unit="core"})
 
   - record: descheduler:node_memory_request_ratio
+    labels:
+      source: deckhouse
     expr: |
       sum by (node) (kube_pod_container_resource_requests{job="kube-state-metrics", resource="memory", unit="byte"})
         / on (node) group_left ()
         max by (node) (kube_node_status_allocatable{job="kube-state-metrics", resource="memory", unit="byte"})
 
   - record: descheduler:cluster_imbalance_score
-    labels: { resource: pods }
+    labels: { resource: pods, source: deckhouse }
     expr: max(descheduler:node_pod_allocation_ratio) - min(descheduler:node_pod_allocation_ratio)
   - record: descheduler:cluster_imbalance_score
-    labels: { resource: cpu }
+    labels: { resource: cpu, source: deckhouse }
     expr: max(descheduler:node_cpu_usage_ratio) - min(descheduler:node_cpu_usage_ratio)
   - record: descheduler:cluster_imbalance_score
-    labels: { resource: memory }
+    labels: { resource: memory, source: deckhouse }
     expr: max(descheduler:node_memory_usage_ratio) - min(descheduler:node_memory_usage_ratio)
 
   - record: descheduler:cluster_imbalance_stddev
-    labels: { resource: pods }
+    labels: { resource: pods, source: deckhouse }
     expr: stddev(descheduler:node_pod_allocation_ratio)
   - record: descheduler:cluster_imbalance_stddev
-    labels: { resource: cpu }
+    labels: { resource: cpu, source: deckhouse }
     expr: stddev(descheduler:node_cpu_usage_ratio)
   - record: descheduler:cluster_imbalance_stddev
-    labels: { resource: memory }
+    labels: { resource: memory, source: deckhouse }
     expr: stddev(descheduler:node_memory_usage_ratio)

--- a/modules/400-descheduler/monitoring/prometheus-rules/workload-happiness.yaml
+++ b/modules/400-descheduler/monitoring/prometheus-rules/workload-happiness.yaml
@@ -2,7 +2,7 @@
   rules:
   - record: descheduler:replicaset_workload
     labels:
-      source: deckhouse
+      d8_source: dkp
     expr: |
       max by (namespace, replicaset, workload_kind, workload_name) (
         label_replace(label_replace(
@@ -13,7 +13,7 @@
 
   - record: descheduler:pod_workload
     labels:
-      source: deckhouse
+      d8_source: dkp
     expr: |
       max by (namespace, pod, node, workload_kind, workload_name) (
         (
@@ -49,12 +49,12 @@
 
   - record: descheduler:workload_replicas
     labels:
-      source: deckhouse
+      d8_source: dkp
     expr: count by (namespace, workload_kind, workload_name) (descheduler:pod_workload)
 
   - record: descheduler:pod_restarts_15m
     labels:
-      source: deckhouse
+      d8_source: dkp
     expr: |
       round(sum by (namespace, pod) (
         increase(kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace!~"d8-.*|kube-system"}[15m])
@@ -63,7 +63,7 @@
   # Primary source klog_pod_oomkill; fallback last_terminated_reason gated by a recent restart.
   - record: descheduler:pod_oom_15m
     labels:
-      source: deckhouse
+      d8_source: dkp
     expr: |
       max by (namespace, pod) (
         label_replace(
@@ -82,7 +82,7 @@
   # State penalties are share-weighted: sum of per-pod weight over the anchor / replicas.
   - record: descheduler:workload_phase_penalty
     labels:
-      source: deckhouse
+      d8_source: dkp
     expr: |
       sum by (namespace, workload_kind, workload_name) (
         (
@@ -98,7 +98,7 @@
   # Container-level readiness penalty is absorbed here: pod Ready=False already covers it.
   - record: descheduler:workload_readiness_penalty
     labels:
-      source: deckhouse
+      d8_source: dkp
     expr: |
       30 * sum by (namespace, workload_kind, workload_name) (
         (kube_pod_status_ready{job="kube-state-metrics", condition="false"} == 1)
@@ -109,7 +109,7 @@
 
   - record: descheduler:workload_restart_penalty
     labels:
-      source: deckhouse
+      d8_source: dkp
     expr: |
       sum by (namespace, workload_kind, workload_name) (
         (
@@ -123,7 +123,7 @@
 
   - record: descheduler:workload_oom_penalty
     labels:
-      source: deckhouse
+      d8_source: dkp
     expr: |
       35 * sum by (namespace, workload_kind, workload_name) (
         (descheduler:pod_oom_15m > bool 0)
@@ -134,7 +134,7 @@
 
   - record: descheduler:workload_cpu_request_cores
     labels:
-      source: deckhouse
+      d8_source: dkp
     expr: |
       sum by (namespace, workload_kind, workload_name) (
         kube_pod_container_resource_requests{job="kube-state-metrics", resource="cpu", unit="core"}
@@ -144,7 +144,7 @@
 
   - record: descheduler:workload_cpu_usage_cores
     labels:
-      source: deckhouse
+      d8_source: dkp
     expr: |
       sum by (namespace, workload_kind, workload_name) (
         rate(container_cpu_usage_seconds_total{job="kubelet", container!~"|POD"}[5m])
@@ -154,7 +154,7 @@
 
   - record: descheduler:workload_memory_request_bytes
     labels:
-      source: deckhouse
+      d8_source: dkp
     expr: |
       sum by (namespace, workload_kind, workload_name) (
         kube_pod_container_resource_requests{job="kube-state-metrics", resource="memory", unit="byte"}
@@ -164,7 +164,7 @@
 
   - record: descheduler:workload_memory_usage_bytes
     labels:
-      source: deckhouse
+      d8_source: dkp
     expr: |
       sum by (namespace, workload_kind, workload_name) (
         container_memory_working_set_bytes{job="kubelet", container!~"|POD"}
@@ -175,18 +175,18 @@
   # The `> 0` guard drops zero/absent denominators so the ratio yields no series (not +Inf/NaN).
   - record: descheduler:workload_cpu_usage_ratio
     labels:
-      source: deckhouse
+      d8_source: dkp
     expr: descheduler:workload_cpu_usage_cores / (descheduler:workload_cpu_request_cores > 0)
 
   - record: descheduler:workload_memory_request_usage_ratio
     labels:
-      source: deckhouse
+      d8_source: dkp
     expr: descheduler:workload_memory_usage_bytes / (descheduler:workload_memory_request_bytes > 0)
 
   # MAX over pods: OOM proximity is per-pod physics.
   - record: descheduler:workload_memory_limit_usage_ratio
     labels:
-      source: deckhouse
+      d8_source: dkp
     expr: |
       max by (namespace, workload_kind, workload_name) (
         (
@@ -203,7 +203,7 @@
   # "no request" = workload has no aggregate request series at all (detected via `unless`).
   - record: descheduler:workload_cpu_penalty
     labels:
-      source: deckhouse
+      d8_source: dkp
     expr: |
       clamp_max(
           ((descheduler:workload_replicas unless descheduler:workload_cpu_request_cores) > bool 0) * 10
@@ -217,7 +217,7 @@
   # Terms are additive; each falls back to 0 via `or replicas*0`, so a limit-only workload still scores the limit rungs.
   - record: descheduler:workload_memory_penalty
     labels:
-      source: deckhouse
+      d8_source: dkp
     expr: |
       clamp_max(
           (((descheduler:workload_replicas unless descheduler:workload_memory_request_bytes) > bool 0) * 10
@@ -232,7 +232,7 @@
 
   - record: descheduler:workload_node_penalty
     labels:
-      source: deckhouse
+      d8_source: dkp
     expr: |
       sum by (namespace, workload_kind, workload_name) (
         descheduler:pod_workload
@@ -249,7 +249,7 @@
 
   - record: descheduler:workload_eviction_penalty
     labels:
-      source: deckhouse
+      d8_source: dkp
     expr: |
       max by (namespace, workload_kind, workload_name) (
           (increase(descheduler_pod_evictions_total{job="descheduler", result="success"}[15m]) > bool 0) * 10
@@ -259,7 +259,7 @@
 
   - record: descheduler:workload_happiness_score
     labels:
-      source: deckhouse
+      d8_source: dkp
     expr: |
       clamp_min(clamp_max(
         100
@@ -274,20 +274,20 @@
       , 100), 0)
 
   - record: descheduler:workload_happiness_bucket
-    labels: { bucket: happy, source: deckhouse }
+    labels: { bucket: happy, d8_source: dkp }
     expr: descheduler:workload_happiness_score >= 80
   - record: descheduler:workload_happiness_bucket
-    labels: { bucket: warning, source: deckhouse }
+    labels: { bucket: warning, d8_source: dkp }
     expr: (descheduler:workload_happiness_score >= 60) and (descheduler:workload_happiness_score < 80)
   - record: descheduler:workload_happiness_bucket
-    labels: { bucket: unhappy, source: deckhouse }
+    labels: { bucket: unhappy, d8_source: dkp }
     expr: descheduler:workload_happiness_score < 60
 
 - name: descheduler.workload-happiness.balance
   rules:
   - record: descheduler:node_pod_allocation_ratio
     labels:
-      source: deckhouse
+      d8_source: dkp
     expr: |
       count by (node) (kube_pod_info{job="kube-state-metrics"})
         / on (node) group_left ()
@@ -295,12 +295,12 @@
 
   - record: descheduler:node_cpu_usage_ratio
     labels:
-      source: deckhouse
+      d8_source: dkp
     expr: 1 - avg by (node) (rate(node_cpu_seconds_total{job="node-exporter", mode="idle"}[5m]))
 
   - record: descheduler:node_memory_usage_ratio
     labels:
-      source: deckhouse
+      d8_source: dkp
     expr: |
       1 - (
         max by (node) (node_memory_MemAvailable_bytes{job="node-exporter"})
@@ -309,7 +309,7 @@
 
   - record: descheduler:node_cpu_request_ratio
     labels:
-      source: deckhouse
+      d8_source: dkp
     expr: |
       sum by (node) (kube_pod_container_resource_requests{job="kube-state-metrics", resource="cpu", unit="core"})
         / on (node) group_left ()
@@ -317,28 +317,28 @@
 
   - record: descheduler:node_memory_request_ratio
     labels:
-      source: deckhouse
+      d8_source: dkp
     expr: |
       sum by (node) (kube_pod_container_resource_requests{job="kube-state-metrics", resource="memory", unit="byte"})
         / on (node) group_left ()
         max by (node) (kube_node_status_allocatable{job="kube-state-metrics", resource="memory", unit="byte"})
 
   - record: descheduler:cluster_imbalance_score
-    labels: { resource: pods, source: deckhouse }
+    labels: { resource: pods, d8_source: dkp }
     expr: max(descheduler:node_pod_allocation_ratio) - min(descheduler:node_pod_allocation_ratio)
   - record: descheduler:cluster_imbalance_score
-    labels: { resource: cpu, source: deckhouse }
+    labels: { resource: cpu, d8_source: dkp }
     expr: max(descheduler:node_cpu_usage_ratio) - min(descheduler:node_cpu_usage_ratio)
   - record: descheduler:cluster_imbalance_score
-    labels: { resource: memory, source: deckhouse }
+    labels: { resource: memory, d8_source: dkp }
     expr: max(descheduler:node_memory_usage_ratio) - min(descheduler:node_memory_usage_ratio)
 
   - record: descheduler:cluster_imbalance_stddev
-    labels: { resource: pods, source: deckhouse }
+    labels: { resource: pods, d8_source: dkp }
     expr: stddev(descheduler:node_pod_allocation_ratio)
   - record: descheduler:cluster_imbalance_stddev
-    labels: { resource: cpu, source: deckhouse }
+    labels: { resource: cpu, d8_source: dkp }
     expr: stddev(descheduler:node_cpu_usage_ratio)
   - record: descheduler:cluster_imbalance_stddev
-    labels: { resource: memory, source: deckhouse }
+    labels: { resource: memory, d8_source: dkp }
     expr: stddev(descheduler:node_memory_usage_ratio)

--- a/modules/400-descheduler/templates/podmonitor.yaml
+++ b/modules/400-descheduler/templates/podmonitor.yaml
@@ -34,6 +34,8 @@ spec:
     - sourceLabels: [__meta_kubernetes_pod_ready]
       regex: "true"
       action: keep
+    - targetLabel: source
+      replacement: deckhouse
     metricRelabelings:
     # Vector has a problem with internal metrics registry grows unbounded.
     # Drop metrics with high cardinality labels here to avoid overloading Prometheus instances.

--- a/modules/400-descheduler/templates/podmonitor.yaml
+++ b/modules/400-descheduler/templates/podmonitor.yaml
@@ -34,8 +34,8 @@ spec:
     - sourceLabels: [__meta_kubernetes_pod_ready]
       regex: "true"
       action: keep
-    - targetLabel: source
-      replacement: deckhouse
+    - targetLabel: d8_source
+      replacement: dkp
     metricRelabelings:
     # Vector has a problem with internal metrics registry grows unbounded.
     # Drop metrics with high cardinality labels here to avoid overloading Prometheus instances.

--- a/modules/470-chrony/monitoring/prometheus-rules/chrony.yaml
+++ b/modules/470-chrony/monitoring/prometheus-rules/chrony.yaml
@@ -2,8 +2,12 @@
   rules:
   - record: chrony_tracking_last_offset_seconds:abs
     expr: abs(chrony_tracking_last_offset_seconds)
+    labels:
+      source: deckhouse
   - record: chrony_rtt_seconds
     expr: chrony_tracking_last_offset_seconds - chrony_serverstats_ntp_timestamps_held
+    labels:
+      source: deckhouse
 
   - alert: NTPDaemonOnNodeDoesNotSynchronizeTime
     expr: (min by (node) (node_timex_sync_status{job="node-exporter"})) == 0

--- a/modules/470-chrony/monitoring/prometheus-rules/chrony.yaml
+++ b/modules/470-chrony/monitoring/prometheus-rules/chrony.yaml
@@ -3,11 +3,11 @@
   - record: chrony_tracking_last_offset_seconds:abs
     expr: abs(chrony_tracking_last_offset_seconds)
     labels:
-      source: deckhouse
+      d8_source: dkp
   - record: chrony_rtt_seconds
     expr: chrony_tracking_last_offset_seconds - chrony_serverstats_ntp_timestamps_held
     labels:
-      source: deckhouse
+      d8_source: dkp
 
   - alert: NTPDaemonOnNodeDoesNotSynchronizeTime
     expr: (min by (node) (node_timex_sync_status{job="node-exporter"})) == 0

--- a/modules/470-chrony/templates/podmonitor.yaml
+++ b/modules/470-chrony/templates/podmonitor.yaml
@@ -34,4 +34,6 @@ spec:
       targetLabel: node
     - targetLabel: tier
       replacement: cluster
+    - targetLabel: source
+      replacement: deckhouse
 {{- end }}

--- a/modules/470-chrony/templates/podmonitor.yaml
+++ b/modules/470-chrony/templates/podmonitor.yaml
@@ -34,6 +34,6 @@ spec:
       targetLabel: node
     - targetLabel: tier
       replacement: cluster
-    - targetLabel: source
-      replacement: deckhouse
+    - targetLabel: d8_source
+      replacement: dkp
 {{- end }}

--- a/modules/500-openvpn/templates/openvpn/podmonitor.yaml
+++ b/modules/500-openvpn/templates/openvpn/podmonitor.yaml
@@ -25,6 +25,8 @@ spec:
         - sourceLabels: [__meta_kubernetes_pod_ready]
           regex: "true"
           action: keep
+        - targetLabel: source
+          replacement: deckhouse
   selector:
     matchLabels:
       app: openvpn

--- a/modules/500-openvpn/templates/openvpn/podmonitor.yaml
+++ b/modules/500-openvpn/templates/openvpn/podmonitor.yaml
@@ -25,8 +25,8 @@ spec:
         - sourceLabels: [__meta_kubernetes_pod_ready]
           regex: "true"
           action: keep
-        - targetLabel: source
-          replacement: deckhouse
+        - targetLabel: d8_source
+          replacement: dkp
   selector:
     matchLabels:
       app: openvpn

--- a/modules/810-documentation/templates/podmonitor.yaml
+++ b/modules/810-documentation/templates/podmonitor.yaml
@@ -29,6 +29,8 @@ spec:
       replacement: cluster
     - targetLabel: job
       replacement: "documentation"
+    - targetLabel: source
+      replacement: deckhouse
   selector:
     matchLabels:
       app: documentation

--- a/modules/810-documentation/templates/podmonitor.yaml
+++ b/modules/810-documentation/templates/podmonitor.yaml
@@ -29,8 +29,8 @@ spec:
       replacement: cluster
     - targetLabel: job
       replacement: "documentation"
-    - targetLabel: source
-      replacement: deckhouse
+    - targetLabel: d8_source
+      replacement: dkp
   selector:
     matchLabels:
       app: documentation


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Add d8_source=dkp label to all system metrics


## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

When a user deploys an exporter with the same metric names as system ones, Prometheus gets duplicate time series. This causes errors in rules and triggers PrometheusRuleEvaluationFailing alerts.
This PR adds a d8_source="dkp" label to all metrics scraped by Deckhouse-managed monitors, so they are no longer affected by user-exported metrics with the same names.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

No need

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->
```changes
section: deckhouse
type: fix 
summary: add d8_source="dkp" label to all system metrics
impact_level: default 
```