### PR TITLE
[cloud-provider-dvp] Add mount points for validation-webhook image

### DIFF
--- a/modules/030-cloud-provider-dvp/images/validation-webhook/mount-points.yaml
+++ b/modules/030-cloud-provider-dvp/images/validation-webhook/mount-points.yaml
@@ -1,0 +1,2 @@
+dirs:
+- /tmp/k8s-webhook-server/serving-certs

--- a/modules/030-cloud-provider-dvp/images/validation-webhook/werf.inc.yaml
+++ b/modules/030-cloud-provider-dvp/images/validation-webhook/werf.inc.yaml
@@ -2,6 +2,7 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/distroless
 import:
+{{- include "image mount points" . }}
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /validation-webhook
   to: /validation-webhook


### PR DESCRIPTION
## Description

Added mount points for the DVP (`cloud-provider-dvp`) validation-webhook image.

The image now declares a mount point for `/tmp/k8s-webhook-server/serving-certs`, which is required by the webhook's controller-runtime framework to serve TLS certificates. Without this directory, the webhook's serving certificates are not properly persisted at runtime, which can lead to TLS handshake failures and rejected admission requests.

## Why do we need it, and what problem does it solve?

The DVP validation-webhook image was missing a `mount-points.yaml` file that declares runtime directories needed by the container. The `/tmp/k8s-webhook-server/serving-certs` directory is used by the controller-runtime framework to store and rotate the webhook's serving TLS certificates. Without an explicit mount point declaration, the directory may not be properly created or persisted, causing certificate availability issues that can break the webhook's admission control.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cloud-provider-dvp
type: fix
summary: Added mount points for the validation-webhook image so serving certificates persist correctly.
impact_level: default
```