### PR TITLE
[deckhouse] Restore admin access to list moduleconfigs

### DIFF
--- a/modules/002-deckhouse/templates/user-authz-cluster-roles.yaml
+++ b/modules/002-deckhouse/templates/user-authz-cluster-roles.yaml
@@ -59,8 +59,6 @@ rules:
   - update
 - apiGroups:
   - deckhouse.io
-  resourceNames:
-  - deckhouse
   resources:
   - moduleconfigs
   verbs:


### PR DESCRIPTION
## Description

Backport of #21499 to `release-1.76`. Removes the `resourceNames: [deckhouse]` restriction from the `Admin` cluster role rule for `moduleconfigs` (`get`/`list`/`watch`), so `Admin`/`ClusterAdmin` can list ModuleConfigs again. The `User` access level stays unable to read them.

On `release-1.76` this is a single role change — the user-authz access docs do not render this matrix (unlike `main`), so no generated docs change here. That mismatch is why the automatic backport cherry-pick conflicted.

## Why do we need it, and what problem does it solve?

Since the restriction landed in 1.76, the `Admin` rule for `moduleconfigs` was scoped to `resourceNames: [deckhouse]`. RBAC does not match `resourceNames` against nameless collection requests, so `kubectl get moduleconfigs` returns `Forbidden` for `Admin`/`ClusterAdmin`, while `get moduleconfig deckhouse` by name still works. This restores listing while keeping the intended `User` restriction. Behaviour verified on a live cluster in #21499.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: Restore admin access to list moduleconfigs
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
