### PR TITLE
[control-plane] VCP: clustered to namespaced

### DIFF
--- a/modules/040-control-plane-manager/crds/doc-ru-virtual_control_plane.yaml
+++ b/modules/040-control-plane-manager/crds/doc-ru-virtual_control_plane.yaml
@@ -6,7 +6,7 @@ spec:
         description: |
           Описывает tenant control plane Kubernetes, которым управляет модуль `control-plane-manager`.
 
-          Ресурс является cluster-scoped. Каждый объект VirtualControlPlane представляет один control plane тенанта и
+          Каждый объект VirtualControlPlane представляет один control plane тенанта и
           используется как источник желаемого состояния для ресурсов, необходимых для его запуска в управляющем кластере.
         properties:
           spec:

--- a/modules/040-control-plane-manager/crds/virtual_control_plane.yaml
+++ b/modules/040-control-plane-manager/crds/virtual_control_plane.yaml
@@ -15,7 +15,7 @@ spec:
     - vcp
     singular: virtualcontrolplane
   preserveUnknownFields: false
-  scope: Cluster
+  scope: Namespaced
   versions:
   - additionalPrinterColumns:
     - description: Desired Kubernetes version.
@@ -44,7 +44,7 @@ spec:
         description: |-
           VirtualControlPlane describes a tenant Kubernetes control plane managed by the control-plane-manager module.
 
-          The resource is cluster-scoped. Each VirtualControlPlane represents one tenant control plane and is used as
+          Each VirtualControlPlane represents one tenant control plane and is used as
           the desired-state source for the resources required to run it in the management cluster.
         properties:
           apiVersion:

--- a/modules/040-control-plane-manager/hooks/handle_virtual_control_plane_test.go
+++ b/modules/040-control-plane-manager/hooks/handle_virtual_control_plane_test.go
@@ -32,14 +32,15 @@ var _ = Describe("Modules :: control-plane-manager :: hooks :: handle_virtual_co
 		Version:  "v1alpha1",
 		Resource: "virtualcontrolplanes",
 	}
-	f.RegisterCRD(virtualControlPlaneResource.Group, virtualControlPlaneResource.Version, "VirtualControlPlane", false)
+	f.RegisterCRD(virtualControlPlaneResource.Group, virtualControlPlaneResource.Version, "VirtualControlPlane", true)
 
 	const virtualControlPlane = `
 ---
 apiVersion: control-plane.deckhouse.io/v1alpha1
 kind: VirtualControlPlane
 metadata:
-  name: tenant-a
+  name: main
+  namespace: tenant-a
 spec:
   kubernetesVersion: "1.31"
 `

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/api/v1alpha1/virtualcontrolplane_types.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/api/v1alpha1/virtualcontrolplane_types.go
@@ -80,7 +80,7 @@ type VirtualControlPlaneStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:scope=Cluster,shortName=vcp
+// +kubebuilder:resource:scope=Namespaced,shortName=vcp
 // +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".spec.kubernetesVersion",description="Desired Kubernetes version"
 // +kubebuilder:printcolumn:name="Replicas",type="integer",JSONPath=".spec.replicas",description="Desired number of control plane replicas"
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status",description="Virtual control plane readiness"

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/config/crd/bases/control-plane.deckhouse.io_virtualcontrolplanes.yaml
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/config/crd/bases/control-plane.deckhouse.io_virtualcontrolplanes.yaml
@@ -14,7 +14,7 @@ spec:
     shortNames:
     - vcp
     singular: virtualcontrolplane
-  scope: Cluster
+  scope: Namespaced
   versions:
   - additionalPrinterColumns:
     - description: Desired Kubernetes version

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/constants/constants.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/constants/constants.go
@@ -17,6 +17,7 @@ limitations under the License.
 package constants
 
 import (
+	"fmt"
 	"strings"
 	"time"
 )
@@ -48,6 +49,12 @@ const (
 	VirtualPKISecretName                      = "d8-pki-virtual"
 	VirtualKubeconfigSecretName               = "d8-kubeconfig-virtual"
 	VirtualAdminKubeconfigSecretName          = "d8-admin-kubeconfig-virtual"
+	VirtualAPIServerServiceName               = "kube-apiserver"
+	VirtualKonnectivityEgressConfigMapName    = "konnectivity-egress"
+	VirtualKonnectivityServerServiceName      = "konnectivity-server"
+	VirtualKonnectivityAgentCPSecretName      = "konnectivity-agent-cp"
+	VirtualDatastoreName                      = "d8-datastore-virtual"
+	VirtualDatastoreCredsSecretName           = "d8-datastore-creds-virtual"
 	VirtualControlPlaneNodeOrdinalLabelKey    = "control-plane.deckhouse.io/virtual-control-plane-node-ordinal"
 	VirtualControlPlaneScopeLabelKey          = "control-plane.deckhouse.io/virtual-control-plane"
 	VirtualJoinScriptSecretName               = "d8-vcp-join-script"
@@ -147,4 +154,13 @@ func SignatureEnabled() bool {
 // ToRelativePath returns path without leading slash for using in tmp directory sync
 func ToRelativePath(absolutePath string) string {
 	return strings.TrimPrefix(absolutePath, "/")
+}
+
+// VirtualResourceName returns a per-VCP unique object name so multiple VirtualControlPlanes
+// can coexist in one Namespace without colliding on hardcoded resource names.
+func VirtualResourceName(base, vcpName string) string {
+	if vcpName == "" {
+		return base
+	}
+	return fmt.Sprintf("%s-%s", base, vcpName)
 }

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/constants/constants.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/constants/constants.go
@@ -43,7 +43,6 @@ const (
 	VirtualConfigurationController            = "virtual-control-plane-configuration-controller"
 	VirtualControlPlaneNodeController         = "virtual-control-plane-node-controller"
 	VirtualControlPlaneApproverControllerName = "virtual_control_plane_approver_controller"
-	VirtualControlPlaneNamespacePrefix        = "vcp-"
 	VirtualControlPlaneConfigSecretName       = "d8-virtual-control-plane-config"
 	VirtualRenderedConfigSecretName           = "d8-vcp-config-virtual"
 	VirtualPKISecretName                      = "d8-pki-virtual"
@@ -58,8 +57,8 @@ const (
 	// DefaultTenantPodSubnetCIDR must stay in sync with cluster-pool-ipv4-cidr in cilium-vcp.yaml.tpl.
 	DefaultTenantPodSubnetCIDR = "10.244.0.0/16"
 	// DefaultTenantClusterDNS is the 10th address of DefaultTenantServiceSubnetCIDR.
-	DefaultTenantClusterDNS = "10.96.0.10"
-	VirtualExposeDomainSuffix                 = "vcp.local"
+	DefaultTenantClusterDNS   = "10.96.0.10"
+	VirtualExposeDomainSuffix = "vcp.local"
 
 	RegistryPackagesProxyPort          int32 = 4219
 	RegistryPackagesProxyBootstrapPort int32 = 4282

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-approver/controller.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-approver/controller.go
@@ -45,7 +45,7 @@ const (
 
 func rateLimiter() workqueue.TypedRateLimiter[reconcile.Request] {
 	return workqueue.NewTypedMaxOfRateLimiter(
-		workqueue.NewTypedItemExponentialFailureRateLimiter[reconcile.Request](100*time.Millisecond, 3*time.Second),
+		workqueue.NewTypedItemExponentialFailureRateLimiter[reconcile.Request](5*time.Second, 3*time.Minute),
 		&workqueue.TypedBucketRateLimiter[reconcile.Request]{
 			Limiter: rate.NewLimiter(rate.Limit(maxConcurrentReconciles), maxConcurrentReconciles),
 		},
@@ -56,7 +56,7 @@ func mapToNamespace(_ context.Context, obj client.Object) []reconcile.Request {
 	return []reconcile.Request{{
 		NamespacedName: types.NamespacedName{
 			Namespace: obj.GetNamespace(),
-			Name:      approverRequestName,
+			Name:      obj.GetLabels()[constants.VirtualControlPlaneScopeLabelKey],
 		},
 	}}
 }

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-approver/reconciler.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-approver/reconciler.go
@@ -49,7 +49,14 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	log.FromContext(ctx).Info("Reconcile started")
 
 	nodeList := &controlplanev1alpha1.ControlPlaneNodeList{}
-	if err := r.client.List(ctx, nodeList, client.InNamespace(request.Namespace)); err != nil {
+	if err := r.client.List(
+		ctx,
+		nodeList,
+		client.InNamespace(request.Namespace),
+		client.MatchingLabels{
+			constants.VirtualControlPlaneScopeLabelKey: request.Name,
+		},
+	); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -60,7 +67,14 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	operations := &controlplanev1alpha1.ControlPlaneOperationList{}
-	if err := r.client.List(ctx, operations, client.InNamespace(request.Namespace)); err != nil {
+	if err := r.client.List(
+		ctx,
+		operations,
+		client.InNamespace(request.Namespace),
+		client.MatchingLabels{
+			constants.VirtualControlPlaneScopeLabelKey: request.Name,
+		},
+	); err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to list virtual control plane operations: %w", err)
 	}
 	if len(operations.Items) == 0 {

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/manifest_render.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/manifest_render.go
@@ -153,5 +153,16 @@ func buildManifestReplacer(
 		"${VCP_API_HOST}", apiExposeHost(vcp),
 		"${VCP_KONN_HOST}", konnExposeHost(vcp),
 		"${VCP_PKG_HOST}", packagesExposeHost(vcp),
+		"${PKI_SECRET_NAME}", constants.VirtualResourceName(constants.VirtualPKISecretName, vcp.Name),
+		"${KUBE_APISERVER_SERVICE_NAME}", constants.VirtualResourceName(constants.VirtualAPIServerServiceName, vcp.Name),
+		"${KONNECTIVITY_EGRESS_CM_NAME}", constants.VirtualResourceName(constants.VirtualKonnectivityEgressConfigMapName, vcp.Name),
+		"${KONNECTIVITY_SERVER_SERVICE_NAME}", constants.VirtualResourceName(constants.VirtualKonnectivityServerServiceName, vcp.Name),
+		"${KONNECTIVITY_AGENT_CP_SECRET_NAME}", constants.VirtualResourceName(constants.VirtualKonnectivityAgentCPSecretName, vcp.Name),
+		"${ADMIN_KUBECONFIG_SECRET_NAME}", constants.VirtualResourceName(constants.VirtualAdminKubeconfigSecretName, vcp.Name),
+		"${KUBECONFIG_SECRET_NAME}", constants.VirtualResourceName(constants.VirtualKubeconfigSecretName, vcp.Name),
+		"${DATASTORE_NAME}", constants.VirtualResourceName(constants.VirtualDatastoreName, vcp.Name),
+		"${DATASTORE_CREDS_SECRET_NAME}", constants.VirtualResourceName(constants.VirtualDatastoreCredsSecretName, vcp.Name),
+		"${CILIUM_CONFIG_NAME}", constants.VirtualResourceName("cilium-config", vcp.Name),
+		"${CILIUM_OPERATOR_NAME}", constants.VirtualResourceName("cilium-operator", vcp.Name),
 	)
 }

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/manifest_render.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/manifest_render.go
@@ -133,8 +133,6 @@ func buildManifestReplacer(
 	apiAdvertiseAddress string,
 	clusterUUID string,
 ) *strings.Replacer {
-	namespace := vcpNamespace(vcp)
-
 	return strings.NewReplacer(
 		"${VCP_API_VIP}", apiAdvertiseAddress,
 		"${VCP_CLUSTER_UUID}", clusterUUID,
@@ -147,7 +145,7 @@ func buildManifestReplacer(
 		"${IMAGE_CILIUM}", fixed.Cilium,
 		"${IMAGE_CILIUM_OPERATOR}", fixed.CiliumOperator,
 		"${VCP_NAME}", vcp.Name,
-		"${NAMESPACE}", namespace,
+		"${NAMESPACE}", vcp.Namespace,
 		"${VCP_KONNECTIVITY_SERVER_COUNT}", fmt.Sprintf("%d", vcp.Spec.Replicas),
 		"${CLUSTER_DOMAIN}", constants.DefaultTenantClusterDomain,
 		"${SERVICE_SUBNET_CIDR}", constants.DefaultTenantServiceSubnetCIDR,

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/owner.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/owner.go
@@ -7,7 +7,7 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
-    10|Unless required by applicable law or agreed to in writing, software
+Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/owner.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/owner.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    10|Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package virtualcontrolplaneconfiguration
+
+import (
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func setVCPControllerReference(vcp metav1.Object, obj client.Object, scheme *runtime.Scheme) error {
+	return ctrl.SetControllerReference(vcp, obj, scheme)
+}
+
+func ownerReferencesDiffer(current, target client.Object) bool {
+	return !equality.Semantic.DeepEqual(current.GetOwnerReferences(), target.GetOwnerReferences())
+}
+
+func syncOwnerReferences(current, target client.Object) {
+	current.SetOwnerReferences(target.GetOwnerReferences())
+}
+
+// patchSpecDataAndOwnerRefs reconciles spec/data and heals OwnerReferences without touching status.
+func patchSpecDataAndOwnerRefs(current, target *unstructured.Unstructured) (client.Object, bool) {
+	changed := false
+
+	if !equality.Semantic.DeepEqual(current.Object["spec"], target.Object["spec"]) ||
+		!equality.Semantic.DeepEqual(current.Object["data"], target.Object["data"]) {
+		if spec, ok := target.Object["spec"]; ok {
+			current.Object["spec"] = spec
+		}
+		if data, ok := target.Object["data"]; ok {
+			current.Object["data"] = data
+		}
+		changed = true
+	}
+
+	if ownerReferencesDiffer(current, target) {
+		syncOwnerReferences(current, target)
+		changed = true
+	}
+
+	if !changed {
+		return nil, false
+	}
+	return current, true
+}

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/predicates.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/predicates.go
@@ -53,7 +53,7 @@ func (r *reconciler) mapConfigSecretToVirtualControlPlanes(ctx context.Context, 
 	for i := range vcpList.Items {
 		vcp := &vcpList.Items[i]
 		requests = append(requests, reconcile.Request{
-			NamespacedName: client.ObjectKey{Name: vcp.Name},
+			NamespacedName: client.ObjectKey{Namespace: vcp.Namespace, Name: vcp.Name},
 		})
 	}
 

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_alb.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_alb.go
@@ -65,7 +65,17 @@ func (r *reconciler) reconcileALB(ctx context.Context, vcp *controlplanev1alpha1
 	}
 
 	for _, target := range objects {
-		if err := applyObject(ctx, r.client, target, patchSpecData); err != nil {
+		// Cross-namespace objects (e.g. ReferenceGrant in d8-cloud-instance-manager) cannot be
+		// owned by a namespaced VirtualControlPlane; apply without controller ownerRef.
+		sameNS := target.GetNamespace() == "" || target.GetNamespace() == vcp.Namespace
+		mutate := patchSpecData
+		if sameNS {
+			if err := setVCPControllerReference(vcp, target, r.scheme); err != nil {
+				return reconcile.Result{}, err
+			}
+			mutate = patchSpecDataAndOwnerRefs
+		}
+		if err := applyObject(ctx, r.client, target, mutate); err != nil {
 			return reconcile.Result{}, err
 		}
 	}

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_alb.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_alb.go
@@ -59,7 +59,7 @@ func (r *reconciler) reconcileALB(ctx context.Context, vcp *controlplanev1alpha1
 		return reconcile.Result{}, fmt.Errorf("config Secret missing %q", albManifestKey)
 	}
 
-	objects, err := parseManifestDocs(raw, constants.VirtualControlPlaneNamespacePrefix+vcp.Name)
+	objects, err := parseManifestDocs(raw, vcp.Namespace)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -94,12 +94,10 @@ func patchSpecData(current, target *unstructured.Unstructured) (client.Object, b
 // The externally-reachable address is read straight off the "d8-alb-<gw>-loadbalancer"
 // Service the ALB module provisions alongside the Gateway for that inlet type.
 func (r *reconciler) albVIP(ctx context.Context, vcp *controlplanev1alpha1.VirtualControlPlane) (string, error) {
-	namespace := vcpNamespace(vcp)
-
 	albi := &unstructured.Unstructured{}
 	albi.SetAPIVersion("network.deckhouse.io/v1alpha1")
 	albi.SetKind("ALBInstance")
-	if err := r.client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: vcp.Name}, albi); err != nil {
+	if err := r.client.Get(ctx, client.ObjectKey{Namespace: vcp.Namespace, Name: vcp.Name}, albi); err != nil {
 		if apierrors.IsNotFound(err) {
 			return "", nil
 		}
@@ -111,7 +109,7 @@ func (r *reconciler) albVIP(ctx context.Context, vcp *controlplanev1alpha1.Virtu
 		gatewayName = vcp.Name // spec.gatewayName
 	}
 
-	lbService, err := r.getService(ctx, namespace, fmt.Sprintf("d8-alb-%s-loadbalancer", gatewayName))
+	lbService, err := r.getService(ctx, vcp.Namespace, fmt.Sprintf("d8-alb-%s-loadbalancer", gatewayName))
 	if apierrors.IsNotFound(err) {
 		return "", nil
 	}

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_bashible-apiserver.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_bashible-apiserver.go
@@ -515,7 +515,7 @@ func (r *reconciler) reconcileBashibleTLSSecret(
 	vcp *controlplanev1alpha1.VirtualControlPlane,
 	pkiSecret *corev1.Secret,
 ) (*corev1.Secret, reconcile.Result, error) {
-	target := buildTargetBashibleTLSSecret(vcp)
+	target := buildTargetBashibleTLSSecret(vcp.Namespace)
 
 	current, err := r.getSecret(ctx, target.Namespace, target.Name)
 	if apierrors.IsNotFound(err) {
@@ -538,9 +538,7 @@ func (r *reconciler) reconcileBashibleTLSSecret(
 	return current, reconcile.Result{}, nil
 }
 
-func buildTargetBashibleTLSSecret(vcp *controlplanev1alpha1.VirtualControlPlane) *corev1.Secret {
-	namespace := vcpNamespace(vcp)
-
+func buildTargetBashibleTLSSecret(namespace string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      bashibleTLSSecretName,
@@ -584,8 +582,6 @@ func buildBashibleTLSSecretData(pkiSecret *corev1.Secret) (map[string][]byte, er
 var bashibleVersionMap string
 
 func (r *reconciler) reconcileBashibleFilesConfigMap(ctx context.Context, vcp *controlplanev1alpha1.VirtualControlPlane) (reconcile.Result, error) {
-	namespace := vcpNamespace(vcp)
-
 	versionMap, imagesDigestsJSON, err := r.getBashibleFiles(ctx)
 	if err != nil {
 		return reconcile.Result{}, err
@@ -594,7 +590,7 @@ func (r *reconciler) reconcileBashibleFilesConfigMap(ctx context.Context, vcp *c
 	target := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      bashibleFilesConfigMapName,
-			Namespace: namespace,
+			Namespace: vcp.Namespace,
 		},
 		Data: map[string]string{
 			"version_map.yml":     versionMap,
@@ -602,7 +598,7 @@ func (r *reconciler) reconcileBashibleFilesConfigMap(ctx context.Context, vcp *c
 		},
 	}
 
-	current, err := r.getConfigMap(ctx, namespace, bashibleFilesConfigMapName)
+	current, err := r.getConfigMap(ctx, vcp.Namespace, bashibleFilesConfigMapName)
 	if apierrors.IsNotFound(err) {
 		if err := ctrl.SetControllerReference(vcp, target, r.scheme); err != nil {
 			return reconcile.Result{}, err
@@ -647,7 +643,7 @@ func (r *reconciler) reconcileBashibleService(
 	ctx context.Context,
 	vcp *controlplanev1alpha1.VirtualControlPlane,
 ) (*corev1.Service, reconcile.Result, error) {
-	target := buildTargetBashibleService(vcp)
+	target := buildTargetBashibleService(vcp.Namespace)
 
 	current, err := r.getService(ctx, target.Namespace, target.Name)
 	if apierrors.IsNotFound(err) {
@@ -677,9 +673,7 @@ func (r *reconciler) reconcileBashibleService(
 	return current, reconcile.Result{}, nil
 }
 
-func buildTargetBashibleService(vcp *controlplanev1alpha1.VirtualControlPlane) *corev1.Service {
-	namespace := vcpNamespace(vcp)
-
+func buildTargetBashibleService(namespace string) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      bashibleServiceName,
@@ -739,7 +733,7 @@ func (r *reconciler) reconcileBashibleDeployment(
 		return reconcile.Result{}, fmt.Errorf("get bashible apiserver image: %w", err)
 	}
 
-	target, err := buildTargetBashibleDeployment(vcp, image)
+	target, err := buildTargetBashibleDeployment(vcp.Namespace, image)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -776,9 +770,7 @@ func (r *reconciler) getBashibleApiserverImage(ctx context.Context) (string, err
 //go:embed bashible-apiserver/manifests/deployment.yaml
 var bashibleDeploymentYAML string
 
-func buildTargetBashibleDeployment(vcp *controlplanev1alpha1.VirtualControlPlane, image string) (*appsv1.Deployment, error) {
-	namespace := vcpNamespace(vcp)
-
+func buildTargetBashibleDeployment(namespace string, image string) (*appsv1.Deployment, error) {
 	rendered := strings.NewReplacer(
 		"${NAMESPACE}", namespace,
 		"${IMAGE_BASHIBLE_APISERVER}", image,

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_bashible-apiserver.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_bashible-apiserver.go
@@ -43,7 +43,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	certutil "k8s.io/client-go/util/cert"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -173,7 +172,7 @@ func (r *reconciler) reconcileBashibleKubeconfigSecret(
 		vcp,
 		apiserverService,
 		pkiSecret,
-		bashibleKubeconfigSecretName,
+		constants.VirtualResourceName(bashibleKubeconfigSecretName, vcp.Name),
 		[]kubeconfig.File{kubeconfig.BashibleApiserver},
 		apiServerHTTPSURL(apiserverService.Spec.ClusterIP),
 	)
@@ -515,7 +514,10 @@ func (r *reconciler) reconcileBashibleTLSSecret(
 	vcp *controlplanev1alpha1.VirtualControlPlane,
 	pkiSecret *corev1.Secret,
 ) (*corev1.Secret, reconcile.Result, error) {
-	target := buildTargetBashibleTLSSecret(vcp.Namespace)
+	target := buildTargetBashibleTLSSecret(vcp)
+	if err := setVCPControllerReference(vcp, target, r.scheme); err != nil {
+		return nil, reconcile.Result{}, err
+	}
 
 	current, err := r.getSecret(ctx, target.Namespace, target.Name)
 	if apierrors.IsNotFound(err) {
@@ -525,24 +527,33 @@ func (r *reconciler) reconcileBashibleTLSSecret(
 		}
 		target.Data = data
 
-		if err := ctrl.SetControllerReference(vcp, target, r.scheme); err != nil {
-			return nil, reconcile.Result{}, err
-		}
-
 		return target, reconcile.Result{}, r.createSecret(ctx, target)
 	}
 	if err != nil {
 		return nil, reconcile.Result{}, fmt.Errorf("get bashible-apiserver TLS Secret: %w", err)
 	}
 
-	return current, reconcile.Result{}, nil
+	if !ownerReferencesDiffer(current, target) &&
+		equality.Semantic.DeepEqual(current.Labels, target.Labels) {
+		return current, reconcile.Result{}, nil
+	}
+
+	base := current.DeepCopy()
+	current.Labels = target.Labels
+	syncOwnerReferences(current, target)
+
+	return current, reconcile.Result{}, r.patchSecret(ctx, base, current)
 }
 
-func buildTargetBashibleTLSSecret(namespace string) *corev1.Secret {
+func buildTargetBashibleTLSSecret(vcp *controlplanev1alpha1.VirtualControlPlane) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      bashibleTLSSecretName,
-			Namespace: namespace,
+			Name:      constants.VirtualResourceName(bashibleTLSSecretName, vcp.Name),
+			Namespace: vcp.Namespace,
+			Labels: map[string]string{
+				constants.HeritageLabelKey:                 constants.HeritageLabelValue,
+				constants.VirtualControlPlaneScopeLabelKey: vcp.Name,
+			},
 		},
 		Type: corev1.SecretTypeOpaque,
 	}
@@ -589,20 +600,24 @@ func (r *reconciler) reconcileBashibleFilesConfigMap(ctx context.Context, vcp *c
 
 	target := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      bashibleFilesConfigMapName,
+			Name:      constants.VirtualResourceName(bashibleFilesConfigMapName, vcp.Name),
 			Namespace: vcp.Namespace,
+			Labels: map[string]string{
+				constants.HeritageLabelKey:                 constants.HeritageLabelValue,
+				constants.VirtualControlPlaneScopeLabelKey: vcp.Name,
+			},
 		},
 		Data: map[string]string{
 			"version_map.yml":     versionMap,
 			"images_digests.json": imagesDigestsJSON,
 		},
 	}
+	if err := setVCPControllerReference(vcp, target, r.scheme); err != nil {
+		return reconcile.Result{}, err
+	}
 
-	current, err := r.getConfigMap(ctx, vcp.Namespace, bashibleFilesConfigMapName)
+	current, err := r.getConfigMap(ctx, target.Namespace, target.Name)
 	if apierrors.IsNotFound(err) {
-		if err := ctrl.SetControllerReference(vcp, target, r.scheme); err != nil {
-			return reconcile.Result{}, err
-		}
 		return reconcile.Result{}, r.createConfigMap(ctx, target)
 	}
 
@@ -610,12 +625,16 @@ func (r *reconciler) reconcileBashibleFilesConfigMap(ctx context.Context, vcp *c
 		return reconcile.Result{}, err
 	}
 
-	if equality.Semantic.DeepEqual(current.Data, target.Data) {
+	if equality.Semantic.DeepEqual(current.Data, target.Data) &&
+		equality.Semantic.DeepEqual(current.Labels, target.Labels) &&
+		!ownerReferencesDiffer(current, target) {
 		return reconcile.Result{}, nil
 	}
 
 	base := current.DeepCopy()
 	current.Data = target.Data
+	current.Labels = target.Labels
+	syncOwnerReferences(current, target)
 	return reconcile.Result{}, r.patchConfigMap(ctx, base, current)
 }
 
@@ -643,13 +662,13 @@ func (r *reconciler) reconcileBashibleService(
 	ctx context.Context,
 	vcp *controlplanev1alpha1.VirtualControlPlane,
 ) (*corev1.Service, reconcile.Result, error) {
-	target := buildTargetBashibleService(vcp.Namespace)
+	target := buildTargetBashibleService(vcp)
+	if err := setVCPControllerReference(vcp, target, r.scheme); err != nil {
+		return nil, reconcile.Result{}, err
+	}
 
 	current, err := r.getService(ctx, target.Namespace, target.Name)
 	if apierrors.IsNotFound(err) {
-		if err := ctrl.SetControllerReference(vcp, target, r.scheme); err != nil {
-			return nil, reconcile.Result{}, err
-		}
 		if err := r.createService(ctx, target); err != nil {
 			return nil, reconcile.Result{}, fmt.Errorf("create bashible Service: %w", err)
 		}
@@ -673,20 +692,22 @@ func (r *reconciler) reconcileBashibleService(
 	return current, reconcile.Result{}, nil
 }
 
-func buildTargetBashibleService(namespace string) *corev1.Service {
+func buildTargetBashibleService(vcp *controlplanev1alpha1.VirtualControlPlane) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      bashibleServiceName,
-			Namespace: namespace,
+			Name:      constants.VirtualResourceName(bashibleServiceName, vcp.Name),
+			Namespace: vcp.Namespace,
 			Labels: map[string]string{
-				"app":                      bashibleAppLabel,
-				constants.HeritageLabelKey: constants.HeritageLabelValue,
+				"app":                                      bashibleAppLabel,
+				constants.HeritageLabelKey:                 constants.HeritageLabelValue,
+				constants.VirtualControlPlaneScopeLabelKey: vcp.Name,
 			},
 		},
 		Spec: corev1.ServiceSpec{
 			Type: corev1.ServiceTypeClusterIP,
 			Selector: map[string]string{
-				"app": bashibleAppLabel,
+				"app":                                      bashibleAppLabel,
+				constants.VirtualControlPlaneScopeLabelKey: vcp.Name,
 			},
 			Ports: []corev1.ServicePort{
 				{
@@ -709,7 +730,8 @@ func isBashibleServiceInSync(current, target *corev1.Service) bool {
 
 	return current.Spec.Type == target.Spec.Type &&
 		equality.Semantic.DeepEqual(current.Spec.Selector, target.Spec.Selector) &&
-		equality.Semantic.DeepEqual(current.Spec.Ports, target.Spec.Ports)
+		equality.Semantic.DeepEqual(current.Spec.Ports, target.Spec.Ports) &&
+		equality.Semantic.DeepEqual(current.OwnerReferences, target.OwnerReferences)
 }
 
 func applyBashibleServiceTarget(current, target *corev1.Service) {
@@ -722,6 +744,7 @@ func applyBashibleServiceTarget(current, target *corev1.Service) {
 	current.Spec.Type = target.Spec.Type
 	current.Spec.Selector = target.Spec.Selector
 	current.Spec.Ports = target.Spec.Ports
+	current.OwnerReferences = target.OwnerReferences
 }
 
 func (r *reconciler) reconcileBashibleDeployment(
@@ -733,16 +756,16 @@ func (r *reconciler) reconcileBashibleDeployment(
 		return reconcile.Result{}, fmt.Errorf("get bashible apiserver image: %w", err)
 	}
 
-	target, err := buildTargetBashibleDeployment(vcp.Namespace, image)
+	target, err := buildTargetBashibleDeployment(vcp, image)
 	if err != nil {
+		return reconcile.Result{}, err
+	}
+	if err := setVCPControllerReference(vcp, target, r.scheme); err != nil {
 		return reconcile.Result{}, err
 	}
 
 	current, err := r.getDeployment(ctx, target.Namespace, target.Name)
 	if apierrors.IsNotFound(err) {
-		if err := ctrl.SetControllerReference(vcp, target, r.scheme); err != nil {
-			return reconcile.Result{}, err
-		}
 		return reconcile.Result{}, r.createDeployment(ctx, target)
 	}
 	if err != nil {
@@ -770,15 +793,60 @@ func (r *reconciler) getBashibleApiserverImage(ctx context.Context) (string, err
 //go:embed bashible-apiserver/manifests/deployment.yaml
 var bashibleDeploymentYAML string
 
-func buildTargetBashibleDeployment(namespace string, image string) (*appsv1.Deployment, error) {
+func buildTargetBashibleDeployment(vcp *controlplanev1alpha1.VirtualControlPlane, image string) (*appsv1.Deployment, error) {
 	rendered := strings.NewReplacer(
-		"${NAMESPACE}", namespace,
+		"${NAMESPACE}", vcp.Namespace,
 		"${IMAGE_BASHIBLE_APISERVER}", image,
 	).Replace(bashibleDeploymentYAML)
 
 	deployment := &appsv1.Deployment{}
 	if err := yaml.Unmarshal([]byte(rendered), deployment); err != nil {
 		return nil, fmt.Errorf("unmarshal bashible Deployment: %w", err)
+	}
+
+	tlsSecret := constants.VirtualResourceName(bashibleTLSSecretName, vcp.Name)
+	filesCM := constants.VirtualResourceName(bashibleFilesConfigMapName, vcp.Name)
+	kubeconfigSecret := constants.VirtualResourceName(bashibleKubeconfigSecretName, vcp.Name)
+	registrySecret := constants.VirtualResourceName(bashibleRegistrySecretName, vcp.Name)
+
+	deployment.Name = constants.VirtualResourceName(bashibleDeploymentName, vcp.Name)
+	if deployment.Labels == nil {
+		deployment.Labels = map[string]string{}
+	}
+	deployment.Labels[constants.VirtualControlPlaneScopeLabelKey] = vcp.Name
+
+	if deployment.Spec.Selector == nil {
+		deployment.Spec.Selector = &metav1.LabelSelector{}
+	}
+	if deployment.Spec.Selector.MatchLabels == nil {
+		deployment.Spec.Selector.MatchLabels = map[string]string{}
+	}
+	deployment.Spec.Selector.MatchLabels[constants.VirtualControlPlaneScopeLabelKey] = vcp.Name
+
+	if deployment.Spec.Template.Labels == nil {
+		deployment.Spec.Template.Labels = map[string]string{}
+	}
+	deployment.Spec.Template.Labels[constants.VirtualControlPlaneScopeLabelKey] = vcp.Name
+
+	for i := range deployment.Spec.Template.Spec.ImagePullSecrets {
+		if deployment.Spec.Template.Spec.ImagePullSecrets[i].Name == bashibleRegistrySecretName {
+			deployment.Spec.Template.Spec.ImagePullSecrets[i].Name = registrySecret
+		}
+	}
+
+	for i := range deployment.Spec.Template.Spec.Volumes {
+		vol := &deployment.Spec.Template.Spec.Volumes[i]
+		if vol.Secret != nil {
+			switch vol.Secret.SecretName {
+			case bashibleTLSSecretName:
+				vol.Secret.SecretName = tlsSecret
+			case bashibleKubeconfigSecretName:
+				vol.Secret.SecretName = kubeconfigSecret
+			}
+		}
+		if vol.ConfigMap != nil && vol.ConfigMap.Name == bashibleFilesConfigMapName {
+			vol.ConfigMap.Name = filesCM
+		}
 	}
 
 	return deployment, nil
@@ -792,7 +860,8 @@ func isBashibleDeploymentInSync(current, target *appsv1.Deployment) bool {
 	}
 	return equality.Semantic.DeepEqual(current.Spec.Replicas, target.Spec.Replicas) &&
 		equality.Semantic.DeepEqual(current.Spec.Selector, target.Spec.Selector) &&
-		equality.Semantic.DeepDerivative(target.Spec.Template, current.Spec.Template)
+		equality.Semantic.DeepDerivative(target.Spec.Template, current.Spec.Template) &&
+		equality.Semantic.DeepEqual(current.OwnerReferences, target.OwnerReferences)
 }
 
 func applyBashibleDeploymentTarget(current, target *appsv1.Deployment) {
@@ -803,6 +872,7 @@ func applyBashibleDeploymentTarget(current, target *appsv1.Deployment) {
 	current.Spec.Replicas = target.Spec.Replicas
 	current.Spec.Selector = target.Spec.Selector
 	current.Spec.Template = target.Spec.Template
+	current.OwnerReferences = target.OwnerReferences
 }
 
 func (r *reconciler) reconcileBashibleAPIService(

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_deckhouse.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_deckhouse.go
@@ -365,7 +365,7 @@ func (r *reconciler) reconcileParentRegistrySecret(ctx context.Context, vcp *con
 		return fmt.Errorf("get parent registry secret: %w", err)
 	}
 
-	target := buildTargetRegistrySecret(parent, constants.VirtualControlPlaneNamespacePrefix+vcp.Name)
+	target := buildTargetRegistrySecret(parent, vcp.Namespace)
 
 	current, err := r.getSecret(ctx, target.Namespace, target.Name)
 	if apierrors.IsNotFound(err) {
@@ -399,7 +399,7 @@ func (r *reconciler) reconcileDeckhouseDeployment(
 		return fmt.Errorf("get parent deckhouse image: %w", err)
 	}
 
-	target, err := buildTargetDeckhouseDeployment(vcp, image, albVIP)
+	target, err := buildTargetDeckhouseDeployment(vcp.Namespace, image, albVIP)
 	if err != nil {
 		return err
 	}
@@ -426,12 +426,10 @@ func (r *reconciler) reconcileDeckhouseDeployment(
 }
 
 func buildTargetDeckhouseDeployment(
-	vcp *controlplanev1alpha1.VirtualControlPlane,
+	namespace string,
 	image string,
 	albVIP string,
 ) (*appsv1.Deployment, error) {
-	namespace := vcpNamespace(vcp)
-
 	rendered := strings.NewReplacer(
 		"${NAMESPACE}", namespace,
 		"${IMAGE_DECKHOUSE}", image,

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_deckhouse.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_deckhouse.go
@@ -35,7 +35,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -155,7 +154,7 @@ func (r *reconciler) reconcileTenantRegistrySecret(ctx context.Context, tc clien
 		return fmt.Errorf("get parent registry secret: %w", err)
 	}
 
-	target := buildTargetRegistrySecret(parent, deckhouseSystemNamespace)
+	target := buildTargetRegistrySecret(parent, deckhouseSystemNamespace, deckhouseRegistrySecretName)
 	// The deckhouse module's chart renders this secret too; without helm
 	// adoption metadata the release install fails with "invalid ownership
 	// metadata" (same pattern as dhctl's DeckhouseRegistrySecret).
@@ -200,11 +199,11 @@ func isMetadataSubset(target, current map[string]string) bool {
 }
 
 // buildTargetRegistrySecret builds a copy of the parent cluster's
-// deckhouse-registry Secret for the given namespace.
-func buildTargetRegistrySecret(parent *corev1.Secret, namespace string) *corev1.Secret {
+// deckhouse-registry Secret for the given namespace and name.
+func buildTargetRegistrySecret(parent *corev1.Secret, namespace, name string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      deckhouseRegistrySecretName,
+			Name:      name,
 			Namespace: namespace,
 			Labels: map[string]string{
 				constants.HeritageLabelKey: constants.HeritageLabelValue,
@@ -365,26 +364,34 @@ func (r *reconciler) reconcileParentRegistrySecret(ctx context.Context, vcp *con
 		return fmt.Errorf("get parent registry secret: %w", err)
 	}
 
-	target := buildTargetRegistrySecret(parent, vcp.Namespace)
+	target := buildTargetRegistrySecret(
+		parent,
+		vcp.Namespace,
+		constants.VirtualResourceName(deckhouseRegistrySecretName, vcp.Name),
+	)
+	target.Labels[constants.VirtualControlPlaneScopeLabelKey] = vcp.Name
+	if err := setVCPControllerReference(vcp, target, r.scheme); err != nil {
+		return err
+	}
 
 	current, err := r.getSecret(ctx, target.Namespace, target.Name)
 	if apierrors.IsNotFound(err) {
-		if err := ctrl.SetControllerReference(vcp, target, r.scheme); err != nil {
-			return err
-		}
-
 		return r.createSecret(ctx, target)
 	}
 	if err != nil {
 		return err
 	}
 
-	if equality.Semantic.DeepEqual(current.Data, target.Data) {
+	if equality.Semantic.DeepEqual(current.Data, target.Data) &&
+		equality.Semantic.DeepEqual(current.Labels, target.Labels) &&
+		!ownerReferencesDiffer(current, target) {
 		return nil
 	}
 
 	base := current.DeepCopy()
 	current.Data = target.Data
+	current.Labels = target.Labels
+	syncOwnerReferences(current, target)
 
 	return r.patchSecret(ctx, base, current)
 }
@@ -399,11 +406,11 @@ func (r *reconciler) reconcileDeckhouseDeployment(
 		return fmt.Errorf("get parent deckhouse image: %w", err)
 	}
 
-	target, err := buildTargetDeckhouseDeployment(vcp.Namespace, image, albVIP)
+	target, err := buildTargetDeckhouseDeployment(vcp, image, albVIP)
 	if err != nil {
 		return err
 	}
-	if err := ctrl.SetControllerReference(vcp, target, r.scheme); err != nil {
+	if err := setVCPControllerReference(vcp, target, r.scheme); err != nil {
 		return err
 	}
 
@@ -415,23 +422,27 @@ func (r *reconciler) reconcileDeckhouseDeployment(
 		return err
 	}
 
-	if equality.Semantic.DeepEqual(current.Spec, target.Spec) {
+	if equality.Semantic.DeepEqual(current.Spec, target.Spec) &&
+		equality.Semantic.DeepEqual(current.Labels, target.Labels) &&
+		!ownerReferencesDiffer(current, target) {
 		return nil
 	}
 
 	base := current.DeepCopy()
 	current.Spec = target.Spec
+	current.Labels = target.Labels
+	syncOwnerReferences(current, target)
 
 	return r.patchDeployment(ctx, base, current)
 }
 
 func buildTargetDeckhouseDeployment(
-	namespace string,
+	vcp *controlplanev1alpha1.VirtualControlPlane,
 	image string,
 	albVIP string,
 ) (*appsv1.Deployment, error) {
 	rendered := strings.NewReplacer(
-		"${NAMESPACE}", namespace,
+		"${NAMESPACE}", vcp.Namespace,
 		"${IMAGE_DECKHOUSE}", image,
 		"${VCP_API_VIP}", albVIP,
 	).Replace(deckhouseDeploymentYAML)
@@ -439,6 +450,41 @@ func buildTargetDeckhouseDeployment(
 	deployment := &appsv1.Deployment{}
 	if err := yaml.Unmarshal([]byte(rendered), deployment); err != nil {
 		return nil, fmt.Errorf("unmarshal deckhouse Deployment: %w", err)
+	}
+
+	registrySecret := constants.VirtualResourceName(deckhouseRegistrySecretName, vcp.Name)
+	adminKubeconfigSecret := constants.VirtualResourceName(constants.VirtualAdminKubeconfigSecretName, vcp.Name)
+
+	deployment.Name = constants.VirtualResourceName(deckhouseDeploymentName, vcp.Name)
+	if deployment.Labels == nil {
+		deployment.Labels = map[string]string{}
+	}
+	deployment.Labels[constants.VirtualControlPlaneScopeLabelKey] = vcp.Name
+
+	if deployment.Spec.Selector == nil {
+		deployment.Spec.Selector = &metav1.LabelSelector{}
+	}
+	if deployment.Spec.Selector.MatchLabels == nil {
+		deployment.Spec.Selector.MatchLabels = map[string]string{}
+	}
+	deployment.Spec.Selector.MatchLabels[constants.VirtualControlPlaneScopeLabelKey] = vcp.Name
+
+	if deployment.Spec.Template.Labels == nil {
+		deployment.Spec.Template.Labels = map[string]string{}
+	}
+	deployment.Spec.Template.Labels[constants.VirtualControlPlaneScopeLabelKey] = vcp.Name
+
+	for i := range deployment.Spec.Template.Spec.ImagePullSecrets {
+		if deployment.Spec.Template.Spec.ImagePullSecrets[i].Name == deckhouseRegistrySecretName {
+			deployment.Spec.Template.Spec.ImagePullSecrets[i].Name = registrySecret
+		}
+	}
+
+	for i := range deployment.Spec.Template.Spec.Volumes {
+		vol := &deployment.Spec.Template.Spec.Volumes[i]
+		if vol.Secret != nil && vol.Secret.SecretName == constants.VirtualAdminKubeconfigSecretName {
+			vol.Secret.SecretName = adminKubeconfigSecret
+		}
 	}
 
 	return deployment, nil

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_finalizer.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_finalizer.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package virtualcontrolplaneconfiguration
 
 import (

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_finalizer.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_finalizer.go
@@ -1,0 +1,92 @@
+package virtualcontrolplaneconfiguration
+
+import (
+	"context"
+	controlplanev1alpha1 "control-plane-manager/api/v1alpha1"
+	"control-plane-manager/internal/constants"
+	"fmt"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	finalizerName = "virtualcontrolplanes.control-plane.deckhouse.io/finalizer"
+
+	postgresGoneAwaitingRequeueInterval = 10 * time.Second
+	postgresSecretPrefix                = "d8ms-pg"
+)
+
+func (r *reconciler) reconcileFinalizer(ctx context.Context, vcp *controlplanev1alpha1.VirtualControlPlane) (reconcile.Result, error) {
+	if vcp.DeletionTimestamp.IsZero() {
+		if controllerutil.ContainsFinalizer(vcp, finalizerName) {
+			return reconcile.Result{}, nil
+		}
+
+		base := vcp.DeepCopy()
+		controllerutil.AddFinalizer(vcp, finalizerName)
+		return reconcile.Result{}, r.client.Patch(ctx, vcp, client.MergeFrom(base))
+	}
+
+	if !controllerutil.ContainsFinalizer(vcp, finalizerName) {
+		return reconcile.Result{}, nil
+	}
+
+	res, err := r.finalize(ctx, vcp)
+	if err != nil || !res.IsZero() {
+		return res, err
+	}
+
+	base := vcp.DeepCopy()
+	controllerutil.RemoveFinalizer(vcp, finalizerName)
+	return reconcile.Result{}, r.client.Patch(ctx, vcp, client.MergeFrom(base))
+}
+
+func (r *reconciler) finalize(ctx context.Context, vcp *controlplanev1alpha1.VirtualControlPlane) (reconcile.Result, error) {
+	return r.deletePostgresArtifacts(ctx, vcp)
+}
+
+func (r *reconciler) deletePostgresArtifacts(ctx context.Context, vcp *controlplanev1alpha1.VirtualControlPlane) (reconcile.Result, error) {
+	postgresDeleted, err := r.ensurePostgresDeleted(ctx, vcp)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	if !postgresDeleted {
+		return reconcile.Result{RequeueAfter: postgresGoneAwaitingRequeueInterval}, nil
+	}
+
+	postgresName := constants.VirtualResourceName(constants.VirtualDatastoreName, vcp.Name)
+	for _, suffix := range []string{"repl-cert", "server-cert"} {
+		name := fmt.Sprintf("%s-%s-%s", postgresSecretPrefix, postgresName, suffix)
+		if err := r.deleteSecret(ctx, vcp.Namespace, name); err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (r *reconciler) ensurePostgresDeleted(ctx context.Context, vcp *controlplanev1alpha1.VirtualControlPlane) (bool, error) {
+	obj := postgres()
+	obj.SetNamespace(vcp.Namespace)
+	obj.SetName(constants.VirtualResourceName(constants.VirtualDatastoreName, vcp.Name))
+
+	err := r.client.Get(ctx, client.ObjectKeyFromObject(obj), obj)
+	if apierrors.IsNotFound(err) {
+		return true, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("get Postgres: %w", err)
+	}
+
+	if obj.GetDeletionTimestamp().IsZero() {
+		if err := client.IgnoreNotFound(r.client.Delete(ctx, obj)); err != nil {
+			return false, fmt.Errorf("delete Postgres: %w", err)
+		}
+	}
+
+	return false, nil
+}

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_joinscript.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_joinscript.go
@@ -74,18 +74,17 @@ func (r *reconciler) reconcileJoinScript(
 	)
 	rendered := replacer.Replace(string(tpl))
 
-	ns := vcpNamespace(vcp)
 	target := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      constants.VirtualJoinScriptSecretName,
-			Namespace: ns,
+			Namespace: vcp.Namespace,
 			Labels:    map[string]string{constants.HeritageLabelKey: constants.HeritageLabelValue},
 		},
 		Type: corev1.SecretTypeOpaque,
 		Data: map[string][]byte{"bootstrap.sh": []byte(rendered)},
 	}
 
-	current, err := r.getSecret(ctx, ns, target.Name)
+	current, err := r.getSecret(ctx, vcp.Namespace, target.Name)
 	if apierrors.IsNotFound(err) {
 		if err := ctrl.SetControllerReference(vcp, target, r.scheme); err != nil {
 			return reconcile.Result{}, err

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_joinscript.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_joinscript.go
@@ -28,7 +28,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -76,19 +75,22 @@ func (r *reconciler) reconcileJoinScript(
 
 	target := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      constants.VirtualJoinScriptSecretName,
+			Name:      constants.VirtualResourceName(constants.VirtualJoinScriptSecretName, vcp.Name),
 			Namespace: vcp.Namespace,
-			Labels:    map[string]string{constants.HeritageLabelKey: constants.HeritageLabelValue},
+			Labels: map[string]string{
+				constants.HeritageLabelKey:                 constants.HeritageLabelValue,
+				constants.VirtualControlPlaneScopeLabelKey: vcp.Name,
+			},
 		},
 		Type: corev1.SecretTypeOpaque,
 		Data: map[string][]byte{"bootstrap.sh": []byte(rendered)},
 	}
+	if err := setVCPControllerReference(vcp, target, r.scheme); err != nil {
+		return reconcile.Result{}, err
+	}
 
 	current, err := r.getSecret(ctx, vcp.Namespace, target.Name)
 	if apierrors.IsNotFound(err) {
-		if err := ctrl.SetControllerReference(vcp, target, r.scheme); err != nil {
-			return reconcile.Result{}, err
-		}
 		return reconcile.Result{}, r.createSecret(ctx, target)
 	}
 	if err != nil {
@@ -96,6 +98,7 @@ func (r *reconciler) reconcileJoinScript(
 	}
 	base := current.DeepCopy()
 	current.Data = target.Data
+	syncOwnerReferences(current, target)
 	return reconcile.Result{}, r.patchSecret(ctx, base, current)
 }
 

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_konnectivity_agent_cp.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_konnectivity_agent_cp.go
@@ -28,12 +28,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 const (
-	konnectivityAgentCPSecretName       = "konnectivity-agent-cp"
 	konnectivityAgentNamespace          = "kube-system"
 	konnectivityAgentSAName             = "konnectivity-agent"
 	konnectivityAudience                = "system:konnectivity-server"
@@ -42,6 +40,10 @@ const (
 	konnectivityAgentCPPlaceholderToken = "placeholder"
 	konnectivityAgentCPTokenExpiresAt   = "control-plane.deckhouse.io/token-expires-at"
 )
+
+func konnectivityAgentCPSecretName(vcpName string) string {
+	return constants.VirtualResourceName(constants.VirtualKonnectivityAgentCPSecretName, vcpName)
+}
 
 // reconcileKonnectivityCPAgentSecret upgrades the parent secret with a real nested TokenRequest
 // token once the nested API and konnectivity-agent SA are available.
@@ -64,7 +66,10 @@ func (r *reconciler) reconcileKonnectivityCPAgentSecret(
 	}
 
 	target := r.konnectivityCPAgentSecret(vcp, pkiSecret.Data["ca.crt"], token, exp)
-	current, err := r.getSecret(ctx, vcp.Namespace, konnectivityAgentCPSecretName)
+	if err := setVCPControllerReference(vcp, target, r.scheme); err != nil {
+		return reconcile.Result{}, err
+	}
+	current, err := r.getSecret(ctx, vcp.Namespace, konnectivityAgentCPSecretName(vcp.Name))
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -73,6 +78,7 @@ func (r *reconciler) reconcileKonnectivityCPAgentSecret(
 	current.Data = target.Data
 	current.Labels = target.Labels
 	current.Annotations = target.Annotations
+	syncOwnerReferences(current, target)
 	return reconcile.Result{}, r.patchSecret(ctx, base, current)
 }
 
@@ -83,7 +89,8 @@ func (r *reconciler) ensureKonnectivityCPAgentSecretBootstrap(
 	vcp *controlplanev1alpha1.VirtualControlPlane,
 	caPEM []byte,
 ) error {
-	current, err := r.getSecret(ctx, vcp.Namespace, konnectivityAgentCPSecretName)
+	secretName := konnectivityAgentCPSecretName(vcp.Name)
+	current, err := r.getSecret(ctx, vcp.Namespace, secretName)
 	if apierrors.IsNotFound(err) {
 		target := r.konnectivityCPAgentSecret(
 			vcp,
@@ -91,7 +98,7 @@ func (r *reconciler) ensureKonnectivityCPAgentSecretBootstrap(
 			konnectivityAgentCPPlaceholderToken,
 			"",
 		)
-		if err := ctrl.SetControllerReference(vcp, target, r.scheme); err != nil {
+		if err := setVCPControllerReference(vcp, target, r.scheme); err != nil {
 			return err
 		}
 		return r.createSecret(ctx, target)
@@ -100,7 +107,12 @@ func (r *reconciler) ensureKonnectivityCPAgentSecretBootstrap(
 		return err
 	}
 
-	if string(current.Data["ca.crt"]) == string(caPEM) {
+	target := r.konnectivityCPAgentSecret(vcp, caPEM, string(current.Data["token"]), current.Annotations[konnectivityAgentCPTokenExpiresAt])
+	if err := setVCPControllerReference(vcp, target, r.scheme); err != nil {
+		return err
+	}
+
+	if string(current.Data["ca.crt"]) == string(caPEM) && !ownerReferencesDiffer(current, target) {
 		return nil
 	}
 	base := current.DeepCopy()
@@ -108,6 +120,7 @@ func (r *reconciler) ensureKonnectivityCPAgentSecretBootstrap(
 		current.Data = map[string][]byte{}
 	}
 	current.Data["ca.crt"] = caPEM
+	syncOwnerReferences(current, target)
 	return r.patchSecret(ctx, base, current)
 }
 
@@ -152,7 +165,7 @@ func (r *reconciler) ensureKonnectivityCPAgentToken(
 	ctx context.Context,
 	vcp *controlplanev1alpha1.VirtualControlPlane,
 ) (string, string, error) {
-	if current, err := r.getSecret(ctx, vcp.Namespace, konnectivityAgentCPSecretName); err == nil {
+	if current, err := r.getSecret(ctx, vcp.Namespace, konnectivityAgentCPSecretName(vcp.Name)); err == nil {
 		token := string(current.Data["token"])
 		if token != "" && token != konnectivityAgentCPPlaceholderToken {
 			if expRaw := current.Annotations[konnectivityAgentCPTokenExpiresAt]; expRaw != "" {
@@ -201,7 +214,7 @@ func (r *reconciler) konnectivityCPAgentSecret(
 
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        konnectivityAgentCPSecretName,
+			Name:        konnectivityAgentCPSecretName(vcp.Name),
 			Namespace:   vcp.Namespace,
 			Annotations: annotations,
 			Labels: map[string]string{

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_konnectivity_agent_cp.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_konnectivity_agent_cp.go
@@ -50,8 +50,6 @@ func (r *reconciler) reconcileKonnectivityCPAgentSecret(
 	vcp *controlplanev1alpha1.VirtualControlPlane,
 	pkiSecret *corev1.Secret,
 ) (reconcile.Result, error) {
-	ns := vcpNamespace(vcp)
-
 	if err := r.ensureKonnectivityCPAgentSecretBootstrap(ctx, vcp, pkiSecret.Data["ca.crt"]); err != nil {
 		return reconcile.Result{}, err
 	}
@@ -66,7 +64,7 @@ func (r *reconciler) reconcileKonnectivityCPAgentSecret(
 	}
 
 	target := r.konnectivityCPAgentSecret(vcp, pkiSecret.Data["ca.crt"], token, exp)
-	current, err := r.getSecret(ctx, ns, konnectivityAgentCPSecretName)
+	current, err := r.getSecret(ctx, vcp.Namespace, konnectivityAgentCPSecretName)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -85,9 +83,7 @@ func (r *reconciler) ensureKonnectivityCPAgentSecretBootstrap(
 	vcp *controlplanev1alpha1.VirtualControlPlane,
 	caPEM []byte,
 ) error {
-	ns := vcpNamespace(vcp)
-
-	current, err := r.getSecret(ctx, ns, konnectivityAgentCPSecretName)
+	current, err := r.getSecret(ctx, vcp.Namespace, konnectivityAgentCPSecretName)
 	if apierrors.IsNotFound(err) {
 		target := r.konnectivityCPAgentSecret(
 			vcp,
@@ -156,9 +152,7 @@ func (r *reconciler) ensureKonnectivityCPAgentToken(
 	ctx context.Context,
 	vcp *controlplanev1alpha1.VirtualControlPlane,
 ) (string, string, error) {
-	ns := vcpNamespace(vcp)
-
-	if current, err := r.getSecret(ctx, ns, konnectivityAgentCPSecretName); err == nil {
+	if current, err := r.getSecret(ctx, vcp.Namespace, konnectivityAgentCPSecretName); err == nil {
 		token := string(current.Data["token"])
 		if token != "" && token != konnectivityAgentCPPlaceholderToken {
 			if expRaw := current.Annotations[konnectivityAgentCPTokenExpiresAt]; expRaw != "" {
@@ -200,7 +194,6 @@ func (r *reconciler) konnectivityCPAgentSecret(
 	caPEM []byte,
 	token, exp string,
 ) *corev1.Secret {
-	ns := vcpNamespace(vcp)
 	annotations := map[string]string{}
 	if exp != "" {
 		annotations[konnectivityAgentCPTokenExpiresAt] = exp
@@ -209,7 +202,7 @@ func (r *reconciler) konnectivityCPAgentSecret(
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        konnectivityAgentCPSecretName,
-			Namespace:   ns,
+			Namespace:   vcp.Namespace,
 			Annotations: annotations,
 			Labels: map[string]string{
 				constants.HeritageLabelKey:                 constants.HeritageLabelValue,

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_postgres.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_postgres.go
@@ -26,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/yaml"
@@ -37,7 +38,7 @@ const (
 )
 
 func (r *reconciler) reconcilePostgres(ctx context.Context, vcp *controlplanev1alpha1.VirtualControlPlane, configSecret *corev1.Secret) (reconcile.Result, error) {
-	target, err := buildTargetPostgres(configSecret, vcp)
+	target, err := buildTargetPostgres(configSecret, vcp.Namespace)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -45,6 +46,9 @@ func (r *reconciler) reconcilePostgres(ctx context.Context, vcp *controlplanev1a
 	current := postgres()
 	err = r.client.Get(ctx, client.ObjectKeyFromObject(target), current)
 	if apierrors.IsNotFound(err) {
+		if err := ctrl.SetControllerReference(vcp, target, r.scheme); err != nil {
+			return reconcile.Result{}, err
+		}
 		if err := r.client.Create(ctx, target); err != nil {
 			return reconcile.Result{}, fmt.Errorf("create Postgres: %w", err)
 		}
@@ -68,7 +72,7 @@ func postgres() *unstructured.Unstructured {
 	return obj
 }
 
-func buildTargetPostgres(configSecret *corev1.Secret, vcp *controlplanev1alpha1.VirtualControlPlane) (*unstructured.Unstructured, error) {
+func buildTargetPostgres(configSecret *corev1.Secret, namespace string) (*unstructured.Unstructured, error) {
 	raw, ok := configSecret.Data[datastoreManifestKey]
 	if !ok {
 		return nil, fmt.Errorf("config Secret missing %q", datastoreManifestKey)
@@ -78,7 +82,7 @@ func buildTargetPostgres(configSecret *corev1.Secret, vcp *controlplanev1alpha1.
 	if err := yaml.Unmarshal(raw, obj); err != nil {
 		return nil, fmt.Errorf("decode datastore manifest: %w", err)
 	}
-	obj.SetNamespace(vcpNamespace(vcp))
+	obj.SetNamespace(namespace)
 
 	return obj, nil
 }

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_postgres.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_postgres.go
@@ -26,7 +26,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/yaml"
@@ -42,13 +41,13 @@ func (r *reconciler) reconcilePostgres(ctx context.Context, vcp *controlplanev1a
 	if err != nil {
 		return reconcile.Result{}, err
 	}
+	if err := setVCPControllerReference(vcp, target, r.scheme); err != nil {
+		return reconcile.Result{}, err
+	}
 
 	current := postgres()
 	err = r.client.Get(ctx, client.ObjectKeyFromObject(target), current)
 	if apierrors.IsNotFound(err) {
-		if err := ctrl.SetControllerReference(vcp, target, r.scheme); err != nil {
-			return reconcile.Result{}, err
-		}
 		if err := r.client.Create(ctx, target); err != nil {
 			return reconcile.Result{}, fmt.Errorf("create Postgres: %w", err)
 		}
@@ -56,6 +55,14 @@ func (r *reconciler) reconcilePostgres(ctx context.Context, vcp *controlplanev1a
 	}
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("get Postgres: %w", err)
+	}
+
+	if ownerReferencesDiffer(current, target) {
+		base := current.DeepCopy()
+		syncOwnerReferences(current, target)
+		if err := r.client.Patch(ctx, current, client.MergeFrom(base)); err != nil {
+			return reconcile.Result{}, fmt.Errorf("patch Postgres ownerRefs: %w", err)
+		}
 	}
 
 	if !isPostgresAvailable(current) {

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconciler.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconciler.go
@@ -208,7 +208,7 @@ func buildTargetAPIServerService(vcp *controlplanev1alpha1.VirtualControlPlane) 
 			// Always ClusterIP: external exposure is handled by the per-VCP ALB (TLSRoute backend), not the Service.
 			Type: corev1.ServiceTypeClusterIP,
 			Selector: map[string]string{
-				"app":                                      "kube-apiserver",
+				"app": "kube-apiserver",
 				constants.VirtualControlPlaneScopeLabelKey: vcp.Name,
 			},
 			Ports: []corev1.ServicePort{
@@ -633,6 +633,12 @@ func (r *reconciler) reconcileControlPlaneNodes(
 		return reconcile.Result{}, err
 	}
 
+	for _, target := range targets {
+		if err := setVCPControllerReference(vcp, target, r.scheme); err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+
 	targetNames := make(map[string]struct{}, len(targets))
 	for _, target := range targets {
 		targetNames[target.Name] = struct{}{}
@@ -755,7 +761,7 @@ func buildTargetControlPlaneNode(
 }
 
 func computeControlPlaneNodeName(vcp *controlplanev1alpha1.VirtualControlPlane, ordinal int32) string {
-	return fmt.Sprintf("%s-%d", vcp.Name, ordinal)
+	return fmt.Sprintf("%s-master-%d", vcp.Name, ordinal)
 }
 
 func isControlPlaneNodeInSync(current, target *controlplanev1alpha1.ControlPlaneNode) bool {

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconciler.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconciler.go
@@ -43,7 +43,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -164,13 +163,13 @@ func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 }
 
 func (r *reconciler) reconcileAPIServerService(ctx context.Context, vcp *controlplanev1alpha1.VirtualControlPlane) (*corev1.Service, reconcile.Result, error) {
-	target := buildTargetAPIServerService(vcp.Namespace)
+	target := buildTargetAPIServerService(vcp)
+	if err := setVCPControllerReference(vcp, target, r.scheme); err != nil {
+		return nil, reconcile.Result{}, err
+	}
 
 	current, err := r.getService(ctx, target.Namespace, target.Name)
 	if apierrors.IsNotFound(err) {
-		if err := ctrl.SetControllerReference(vcp, target, r.scheme); err != nil {
-			return nil, reconcile.Result{}, err
-		}
 		if err := r.createService(ctx, target); err != nil {
 			return nil, reconcile.Result{}, err
 		}
@@ -195,20 +194,22 @@ func (r *reconciler) reconcileAPIServerService(ctx context.Context, vcp *control
 	return current, reconcile.Result{}, r.patchService(ctx, base, current)
 }
 
-func buildTargetAPIServerService(namespace string) *corev1.Service {
+func buildTargetAPIServerService(vcp *controlplanev1alpha1.VirtualControlPlane) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kube-apiserver",
-			Namespace: namespace,
+			Name:      constants.VirtualResourceName(constants.VirtualAPIServerServiceName, vcp.Name),
+			Namespace: vcp.Namespace,
 			Labels: map[string]string{
-				constants.HeritageLabelKey: constants.HeritageLabelValue,
+				constants.HeritageLabelKey:                 constants.HeritageLabelValue,
+				constants.VirtualControlPlaneScopeLabelKey: vcp.Name,
 			},
 		},
 		Spec: corev1.ServiceSpec{
 			// Always ClusterIP: external exposure is handled by the per-VCP ALB (TLSRoute backend), not the Service.
 			Type: corev1.ServiceTypeClusterIP,
 			Selector: map[string]string{
-				"app": "kube-apiserver",
+				"app":                                      "kube-apiserver",
+				constants.VirtualControlPlaneScopeLabelKey: vcp.Name,
 			},
 			Ports: []corev1.ServicePort{
 				{
@@ -231,7 +232,8 @@ func isAPIServerServiceInSync(current, target *corev1.Service) bool {
 
 	return current.Spec.Type == target.Spec.Type &&
 		equality.Semantic.DeepEqual(current.Spec.Selector, target.Spec.Selector) &&
-		equality.Semantic.DeepEqual(current.Spec.Ports, target.Spec.Ports)
+		equality.Semantic.DeepEqual(current.Spec.Ports, target.Spec.Ports) &&
+		equality.Semantic.DeepEqual(current.OwnerReferences, target.OwnerReferences)
 }
 
 func applyAPIServerServiceTarget(current, target *corev1.Service) {
@@ -244,6 +246,7 @@ func applyAPIServerServiceTarget(current, target *corev1.Service) {
 	current.Spec.Type = target.Spec.Type
 	current.Spec.Selector = target.Spec.Selector
 	current.Spec.Ports = target.Spec.Ports
+	current.OwnerReferences = target.OwnerReferences
 }
 
 // virtualAPIServerPort is the secure port the tenant kube-apiserver listens on.
@@ -269,7 +272,10 @@ func apiServerCertExtraSANs(vcp *controlplanev1alpha1.VirtualControlPlane) []str
 }
 
 func (r *reconciler) reconcilePKISecret(ctx context.Context, vcp *controlplanev1alpha1.VirtualControlPlane, apiserverService *corev1.Service, albVIP string) (*corev1.Secret, reconcile.Result, error) {
-	target := buildTargetPKISecret(vcp.Namespace)
+	target := buildTargetPKISecret(vcp)
+	if err := setVCPControllerReference(vcp, target, r.scheme); err != nil {
+		return nil, reconcile.Result{}, err
+	}
 
 	extraSANs := apiServerCertExtraSANs(vcp)
 	if albVIP != "" {
@@ -284,9 +290,6 @@ func (r *reconciler) reconcilePKISecret(ctx context.Context, vcp *controlplanev1
 		}
 		target.Data = data
 
-		if err := ctrl.SetControllerReference(vcp, target, r.scheme); err != nil {
-			return nil, reconcile.Result{}, err
-		}
 		if err := r.createSecret(ctx, target); err != nil {
 			return nil, reconcile.Result{}, err
 		}
@@ -303,25 +306,25 @@ func (r *reconciler) reconcilePKISecret(ctx context.Context, vcp *controlplanev1
 	}
 	target.Data = data
 
-	if equality.Semantic.DeepEqual(current.Data, target.Data) {
+	if equality.Semantic.DeepEqual(current.Data, target.Data) && !ownerReferencesDiffer(current, target) {
 		return current, reconcile.Result{}, nil
 	}
 
 	base := current.DeepCopy()
 	current.Data = target.Data
+	syncOwnerReferences(current, target)
 
 	return current, reconcile.Result{}, r.patchSecret(ctx, base, current)
 }
 
-func buildTargetPKISecret(namespace string) *corev1.Secret {
-	name := constants.VirtualPKISecretName
-
+func buildTargetPKISecret(vcp *controlplanev1alpha1.VirtualControlPlane) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
+			Name:      constants.VirtualResourceName(constants.VirtualPKISecretName, vcp.Name),
+			Namespace: vcp.Namespace,
 			Labels: map[string]string{
-				constants.HeritageLabelKey: constants.HeritageLabelValue,
+				constants.HeritageLabelKey:                 constants.HeritageLabelValue,
+				constants.VirtualControlPlaneScopeLabelKey: vcp.Name,
 			},
 		},
 		Type: corev1.SecretTypeOpaque,
@@ -401,7 +404,8 @@ func (r *reconciler) reconcileKubeconfigSecret(
 	pkiSecret *corev1.Secret,
 ) (*corev1.Secret, reconcile.Result, error) {
 	endpoint := apiServerHTTPSURL(apiserverService.Spec.ClusterIP)
-	return r.reconcileKubeconfigSecretFiles(ctx, vcp, apiserverService, pkiSecret, constants.VirtualKubeconfigSecretName, componentKubeconfigFiles, endpoint)
+	name := constants.VirtualResourceName(constants.VirtualKubeconfigSecretName, vcp.Name)
+	return r.reconcileKubeconfigSecretFiles(ctx, vcp, apiserverService, pkiSecret, name, componentKubeconfigFiles, endpoint)
 }
 
 func (r *reconciler) reconcileAdminKubeconfigSecret(
@@ -411,7 +415,8 @@ func (r *reconciler) reconcileAdminKubeconfigSecret(
 	pkiSecret *corev1.Secret,
 	endpoint string,
 ) (*corev1.Secret, reconcile.Result, error) {
-	return r.reconcileKubeconfigSecretFiles(ctx, vcp, apiserverService, pkiSecret, constants.VirtualAdminKubeconfigSecretName, adminKubeconfigFiles, endpoint)
+	name := constants.VirtualResourceName(constants.VirtualAdminKubeconfigSecretName, vcp.Name)
+	return r.reconcileKubeconfigSecretFiles(ctx, vcp, apiserverService, pkiSecret, name, adminKubeconfigFiles, endpoint)
 }
 
 func (r *reconciler) reconcileKubeconfigSecretFiles(
@@ -423,7 +428,10 @@ func (r *reconciler) reconcileKubeconfigSecretFiles(
 	files []kubeconfig.File,
 	endpoint string,
 ) (*corev1.Secret, reconcile.Result, error) {
-	target := buildTargetKubeconfigSecret(vcp.Namespace, name)
+	target := buildTargetKubeconfigSecret(vcp, name)
+	if err := setVCPControllerReference(vcp, target, r.scheme); err != nil {
+		return nil, reconcile.Result{}, err
+	}
 
 	data, err := buildTargetKubeconfigSecretData(apiserverService, pkiSecret, files, endpoint)
 	if err != nil {
@@ -433,21 +441,19 @@ func (r *reconciler) reconcileKubeconfigSecretFiles(
 
 	current, err := r.getSecret(ctx, target.Namespace, target.Name)
 	if apierrors.IsNotFound(err) {
-		if err := ctrl.SetControllerReference(vcp, target, r.scheme); err != nil {
-			return nil, reconcile.Result{}, err
-		}
 		return target, reconcile.Result{}, r.createSecret(ctx, target)
 	}
 	if err != nil {
 		return nil, reconcile.Result{}, fmt.Errorf("get kubeconfig Secret %s: %w", name, err)
 	}
 
-	if equality.Semantic.DeepEqual(current.Data, target.Data) {
+	if equality.Semantic.DeepEqual(current.Data, target.Data) && !ownerReferencesDiffer(current, target) {
 		return current, reconcile.Result{}, nil
 	}
 
 	base := current.DeepCopy()
 	current.Data = target.Data
+	syncOwnerReferences(current, target)
 
 	return current, reconcile.Result{}, r.patchSecret(ctx, base, current)
 }
@@ -455,7 +461,7 @@ func (r *reconciler) reconcileKubeconfigSecretFiles(
 func (r *reconciler) reconcileStatus(ctx context.Context, vcp *controlplanev1alpha1.VirtualControlPlane, endpoint string) error {
 	ref := &controlplanev1alpha1.VirtualControlPlaneKubeconfigSecretRef{
 		Namespace: vcp.Namespace,
-		Name:      constants.VirtualAdminKubeconfigSecretName,
+		Name:      constants.VirtualResourceName(constants.VirtualAdminKubeconfigSecretName, vcp.Name),
 	}
 
 	if vcp.Status.Endpoint == endpoint &&
@@ -471,13 +477,14 @@ func (r *reconciler) reconcileStatus(ctx context.Context, vcp *controlplanev1alp
 	return r.client.Status().Patch(ctx, vcp, client.MergeFrom(base))
 }
 
-func buildTargetKubeconfigSecret(namespace string, name string) *corev1.Secret {
+func buildTargetKubeconfigSecret(vcp *controlplanev1alpha1.VirtualControlPlane, name string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: namespace,
+			Namespace: vcp.Namespace,
 			Labels: map[string]string{
-				constants.HeritageLabelKey: constants.HeritageLabelValue,
+				constants.HeritageLabelKey:                 constants.HeritageLabelValue,
+				constants.VirtualControlPlaneScopeLabelKey: vcp.Name,
 			},
 		},
 		Type: corev1.SecretTypeOpaque,
@@ -573,14 +580,14 @@ func (r *reconciler) reconcileConfigSecret(ctx context.Context, vcp *controlplan
 		return nil, reconcile.Result{}, fmt.Errorf("render manifests: %w", err)
 	}
 
-	target := buildTargetConfigSecret(vcp.Namespace)
+	target := buildTargetConfigSecret(vcp)
 	target.Data = data
+	if err := setVCPControllerReference(vcp, target, r.scheme); err != nil {
+		return nil, reconcile.Result{}, err
+	}
 
 	current, err := r.getSecret(ctx, target.Namespace, target.Name)
 	if apierrors.IsNotFound(err) {
-		if err := ctrl.SetControllerReference(vcp, target, r.scheme); err != nil {
-			return nil, reconcile.Result{}, err
-		}
 		if err := r.createSecret(ctx, target); err != nil {
 			return nil, reconcile.Result{}, err
 		}
@@ -590,23 +597,25 @@ func (r *reconciler) reconcileConfigSecret(ctx context.Context, vcp *controlplan
 		return nil, reconcile.Result{}, fmt.Errorf("get rendered config Secret: %w", err)
 	}
 
-	if equality.Semantic.DeepEqual(current.Data, target.Data) {
+	if equality.Semantic.DeepEqual(current.Data, target.Data) && !ownerReferencesDiffer(current, target) {
 		return current, reconcile.Result{}, nil
 	}
 
 	base := current.DeepCopy()
 	current.Data = target.Data
+	syncOwnerReferences(current, target)
 
 	return current, reconcile.Result{}, r.patchSecret(ctx, base, current)
 }
 
-func buildTargetConfigSecret(namespace string) *corev1.Secret {
+func buildTargetConfigSecret(vcp *controlplanev1alpha1.VirtualControlPlane) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      constants.VirtualRenderedConfigSecretName,
-			Namespace: namespace,
+			Name:      constants.VirtualResourceName(constants.VirtualRenderedConfigSecretName, vcp.Name),
+			Namespace: vcp.Namespace,
 			Labels: map[string]string{
-				constants.HeritageLabelKey: constants.HeritageLabelValue,
+				constants.HeritageLabelKey:                 constants.HeritageLabelValue,
+				constants.VirtualControlPlaneScopeLabelKey: vcp.Name,
 			},
 		},
 		Type: corev1.SecretTypeOpaque,
@@ -628,12 +637,12 @@ func (r *reconciler) reconcileControlPlaneNodes(
 	for _, target := range targets {
 		targetNames[target.Name] = struct{}{}
 
+		if err := setVCPControllerReference(vcp, target, r.scheme); err != nil {
+			return reconcile.Result{}, err
+		}
+
 		current, err := r.getControlPlaneNode(ctx, target.Namespace, target.Name)
 		if apierrors.IsNotFound(err) {
-			if err := ctrl.SetControllerReference(vcp, target, r.scheme); err != nil {
-				return reconcile.Result{}, err
-			}
-
 			if err := r.createControlPlaneNode(ctx, target); err != nil {
 				return reconcile.Result{}, err
 			}
@@ -751,11 +760,13 @@ func computeControlPlaneNodeName(vcp *controlplanev1alpha1.VirtualControlPlane, 
 
 func isControlPlaneNodeInSync(current, target *controlplanev1alpha1.ControlPlaneNode) bool {
 	return equality.Semantic.DeepEqual(current.Labels, target.Labels) &&
+		equality.Semantic.DeepEqual(current.OwnerReferences, target.OwnerReferences) &&
 		equality.Semantic.DeepEqual(current.Spec, target.Spec)
 }
 
 func applyControlPlaneNodeTarget(current, target *controlplanev1alpha1.ControlPlaneNode) {
 	current.Labels = target.Labels
+	current.OwnerReferences = target.OwnerReferences
 	current.Spec = target.Spec
 }
 

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconciler.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconciler.go
@@ -633,12 +633,6 @@ func (r *reconciler) reconcileControlPlaneNodes(
 		return reconcile.Result{}, err
 	}
 
-	for _, target := range targets {
-		if err := setVCPControllerReference(vcp, target, r.scheme); err != nil {
-			return reconcile.Result{}, err
-		}
-	}
-
 	targetNames := make(map[string]struct{}, len(targets))
 	for _, target := range targets {
 		targetNames[target.Name] = struct{}{}

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconciler.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconciler.go
@@ -67,17 +67,13 @@ type reconciler struct {
 func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	log.FromContext(ctx).Info("Reconcile started")
 
-	vcp, err := r.getVirtualControlPlane(ctx, req.Name)
+	vcp, err := r.getVirtualControlPlane(ctx, req.NamespacedName)
 	if apierrors.IsNotFound(err) {
-		r.forgetTenantClients(req.Name)
+		r.forgetTenantClients(req.Namespace, req.Name)
 		return reconcile.Result{}, nil
 	}
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("get VirtualControlPlane: %w", err)
-	}
-
-	if res, err := r.reconcileNamespace(ctx, vcp); err != nil || !res.IsZero() {
-		return res, err
 	}
 
 	albVIP, err := r.albVIP(ctx, vcp)
@@ -167,61 +163,8 @@ func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	return reconcile.Result{RequeueAfter: requeueInterval}, nil
 }
 
-func (r *reconciler) reconcileNamespace(ctx context.Context, vcp *controlplanev1alpha1.VirtualControlPlane) (reconcile.Result, error) {
-	target := buildTargetNamespace(vcp)
-
-	current, err := r.getNamespace(ctx, target.Name)
-	if apierrors.IsNotFound(err) {
-		if err := ctrl.SetControllerReference(vcp, target, r.scheme); err != nil {
-			return reconcile.Result{}, err
-		}
-
-		return reconcile.Result{}, r.createNamespace(ctx, target)
-	}
-	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("get Namespace: %w", err)
-	}
-
-	if isNamespaceInSync(current, target) {
-		return reconcile.Result{}, nil
-	}
-
-	base := current.DeepCopy()
-	applyNamespaceTarget(current, target)
-
-	return reconcile.Result{}, r.patchNamespace(ctx, base, current)
-}
-
-func buildTargetNamespace(vcp *controlplanev1alpha1.VirtualControlPlane) *corev1.Namespace {
-	return &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: vcpNamespace(vcp),
-			Labels: map[string]string{
-				constants.HeritageLabelKey: constants.HeritageLabelValue,
-			},
-		},
-	}
-}
-
-func isNamespaceInSync(current, target *corev1.Namespace) bool {
-	for key, value := range target.Labels {
-		if current.Labels[key] != value {
-			return false
-		}
-	}
-	return true
-}
-
-func applyNamespaceTarget(current, target *corev1.Namespace) {
-	if current.Labels == nil {
-		current.Labels = map[string]string{}
-	}
-
-	maps.Copy(current.Labels, target.Labels)
-}
-
 func (r *reconciler) reconcileAPIServerService(ctx context.Context, vcp *controlplanev1alpha1.VirtualControlPlane) (*corev1.Service, reconcile.Result, error) {
-	target := buildTargetAPIServerService(vcp)
+	target := buildTargetAPIServerService(vcp.Namespace)
 
 	current, err := r.getService(ctx, target.Namespace, target.Name)
 	if apierrors.IsNotFound(err) {
@@ -252,9 +195,7 @@ func (r *reconciler) reconcileAPIServerService(ctx context.Context, vcp *control
 	return current, reconcile.Result{}, r.patchService(ctx, base, current)
 }
 
-func buildTargetAPIServerService(vcp *controlplanev1alpha1.VirtualControlPlane) *corev1.Service {
-	namespace := vcpNamespace(vcp)
-
+func buildTargetAPIServerService(namespace string) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kube-apiserver",
@@ -298,18 +239,11 @@ func applyAPIServerServiceTarget(current, target *corev1.Service) {
 		current.Labels = map[string]string{}
 	}
 
-	for key, value := range target.Labels {
-		current.Labels[key] = value
-	}
+	maps.Copy(current.Labels, target.Labels)
 
 	current.Spec.Type = target.Spec.Type
 	current.Spec.Selector = target.Spec.Selector
 	current.Spec.Ports = target.Spec.Ports
-}
-
-// vcpNamespace is the parent-cluster namespace that holds a VCP's control-plane objects.
-func vcpNamespace(vcp *controlplanev1alpha1.VirtualControlPlane) string {
-	return constants.VirtualControlPlaneNamespacePrefix + vcp.Name
 }
 
 // virtualAPIServerPort is the secure port the tenant kube-apiserver listens on.
@@ -335,7 +269,7 @@ func apiServerCertExtraSANs(vcp *controlplanev1alpha1.VirtualControlPlane) []str
 }
 
 func (r *reconciler) reconcilePKISecret(ctx context.Context, vcp *controlplanev1alpha1.VirtualControlPlane, apiserverService *corev1.Service, albVIP string) (*corev1.Secret, reconcile.Result, error) {
-	target := buildTargetPKISecret(vcp)
+	target := buildTargetPKISecret(vcp.Namespace)
 
 	extraSANs := apiServerCertExtraSANs(vcp)
 	if albVIP != "" {
@@ -379,9 +313,8 @@ func (r *reconciler) reconcilePKISecret(ctx context.Context, vcp *controlplanev1
 	return current, reconcile.Result{}, r.patchSecret(ctx, base, current)
 }
 
-func buildTargetPKISecret(vcp *controlplanev1alpha1.VirtualControlPlane) *corev1.Secret {
+func buildTargetPKISecret(namespace string) *corev1.Secret {
 	name := constants.VirtualPKISecretName
-	namespace := vcpNamespace(vcp)
 
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -413,9 +346,8 @@ func buildTargetPKISecretData(vcp *controlplanev1alpha1.VirtualControlPlane, api
 		}
 	}
 
-	nodeName := vcpNamespace(vcp)
 	if _, err := pki.CreatePKIBundle(
-		nodeName,
+		vcp.Namespace,
 		constants.DefaultTenantClusterDomain,
 		advertiseAddress,
 		constants.DefaultTenantServiceSubnetCIDR,
@@ -491,7 +423,7 @@ func (r *reconciler) reconcileKubeconfigSecretFiles(
 	files []kubeconfig.File,
 	endpoint string,
 ) (*corev1.Secret, reconcile.Result, error) {
-	target := buildTargetKubeconfigSecret(vcp, name)
+	target := buildTargetKubeconfigSecret(vcp.Namespace, name)
 
 	data, err := buildTargetKubeconfigSecretData(apiserverService, pkiSecret, files, endpoint)
 	if err != nil {
@@ -522,7 +454,7 @@ func (r *reconciler) reconcileKubeconfigSecretFiles(
 
 func (r *reconciler) reconcileStatus(ctx context.Context, vcp *controlplanev1alpha1.VirtualControlPlane, endpoint string) error {
 	ref := &controlplanev1alpha1.VirtualControlPlaneKubeconfigSecretRef{
-		Namespace: vcpNamespace(vcp),
+		Namespace: vcp.Namespace,
 		Name:      constants.VirtualAdminKubeconfigSecretName,
 	}
 
@@ -539,9 +471,7 @@ func (r *reconciler) reconcileStatus(ctx context.Context, vcp *controlplanev1alp
 	return r.client.Status().Patch(ctx, vcp, client.MergeFrom(base))
 }
 
-func buildTargetKubeconfigSecret(vcp *controlplanev1alpha1.VirtualControlPlane, name string) *corev1.Secret {
-	namespace := vcpNamespace(vcp)
-
+func buildTargetKubeconfigSecret(namespace string, name string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -643,7 +573,7 @@ func (r *reconciler) reconcileConfigSecret(ctx context.Context, vcp *controlplan
 		return nil, reconcile.Result{}, fmt.Errorf("render manifests: %w", err)
 	}
 
-	target := buildTargetConfigSecret(vcp)
+	target := buildTargetConfigSecret(vcp.Namespace)
 	target.Data = data
 
 	current, err := r.getSecret(ctx, target.Namespace, target.Name)
@@ -670,9 +600,7 @@ func (r *reconciler) reconcileConfigSecret(ctx context.Context, vcp *controlplan
 	return current, reconcile.Result{}, r.patchSecret(ctx, base, current)
 }
 
-func buildTargetConfigSecret(vcp *controlplanev1alpha1.VirtualControlPlane) *corev1.Secret {
-	namespace := vcpNamespace(vcp)
-
+func buildTargetConfigSecret(namespace string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      constants.VirtualRenderedConfigSecretName,
@@ -702,6 +630,10 @@ func (r *reconciler) reconcileControlPlaneNodes(
 
 		current, err := r.getControlPlaneNode(ctx, target.Namespace, target.Name)
 		if apierrors.IsNotFound(err) {
+			if err := ctrl.SetControllerReference(vcp, target, r.scheme); err != nil {
+				return reconcile.Result{}, err
+			}
+
 			if err := r.createControlPlaneNode(ctx, target); err != nil {
 				return reconcile.Result{}, err
 			}
@@ -801,10 +733,11 @@ func buildTargetControlPlaneNode(
 	return &controlplanev1alpha1.ControlPlaneNode{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      computeControlPlaneNodeName(vcp, ordinal),
-			Namespace: vcpNamespace(vcp),
+			Namespace: vcp.Namespace,
 			Labels: map[string]string{
 				constants.HeritageLabelKey:                       constants.HeritageLabelValue,
 				constants.ControlPlaneTypeLabelKey:               string(constants.ControlPlaneTypeVirtual),
+				constants.VirtualControlPlaneScopeLabelKey:       vcp.Name,
 				constants.VirtualControlPlaneNodeOrdinalLabelKey: fmt.Sprintf("%d", ordinal),
 			},
 		},
@@ -813,18 +746,16 @@ func buildTargetControlPlaneNode(
 }
 
 func computeControlPlaneNodeName(vcp *controlplanev1alpha1.VirtualControlPlane, ordinal int32) string {
-	return fmt.Sprintf("%s%s-%d", constants.VirtualControlPlaneNamespacePrefix, vcp.Name, ordinal)
+	return fmt.Sprintf("%s-%d", vcp.Name, ordinal)
 }
 
 func isControlPlaneNodeInSync(current, target *controlplanev1alpha1.ControlPlaneNode) bool {
 	return equality.Semantic.DeepEqual(current.Labels, target.Labels) &&
-		equality.Semantic.DeepEqual(current.OwnerReferences, target.OwnerReferences) &&
 		equality.Semantic.DeepEqual(current.Spec, target.Spec)
 }
 
 func applyControlPlaneNodeTarget(current, target *controlplanev1alpha1.ControlPlaneNode) {
 	current.Labels = target.Labels
-	current.OwnerReferences = target.OwnerReferences
 	current.Spec = target.Spec
 }
 
@@ -865,25 +796,10 @@ func controlPlaneNodeOrdinal(cpn *controlplanev1alpha1.ControlPlaneNode) int32 {
 
 // Kubernetes I/O helpers.
 // VirtualControlPlane
-func (r *reconciler) getVirtualControlPlane(ctx context.Context, name string) (*controlplanev1alpha1.VirtualControlPlane, error) {
+func (r *reconciler) getVirtualControlPlane(ctx context.Context, key client.ObjectKey) (*controlplanev1alpha1.VirtualControlPlane, error) {
 	vcp := &controlplanev1alpha1.VirtualControlPlane{}
-	err := r.client.Get(ctx, client.ObjectKey{Name: name}, vcp)
+	err := r.client.Get(ctx, key, vcp)
 	return vcp, err
-}
-
-// Namespace
-func (r *reconciler) getNamespace(ctx context.Context, name string) (*corev1.Namespace, error) {
-	ns := &corev1.Namespace{}
-	err := r.client.Get(ctx, client.ObjectKey{Name: name}, ns)
-	return ns, err
-}
-
-func (r *reconciler) createNamespace(ctx context.Context, ns *corev1.Namespace) error {
-	return r.client.Create(ctx, ns)
-}
-
-func (r *reconciler) patchNamespace(ctx context.Context, base, ns *corev1.Namespace) error {
-	return r.client.Patch(ctx, ns, client.MergeFrom(base))
 }
 
 // Secret
@@ -946,7 +862,10 @@ func (r *reconciler) getControlPlaneNodesByVirtualControlPlane(
 	err := r.client.List(
 		ctx,
 		cpnList,
-		client.InNamespace(constants.VirtualControlPlaneNamespacePrefix+vcp.Name),
+		client.InNamespace(vcp.Namespace),
+		client.MatchingLabels{
+			constants.VirtualControlPlaneScopeLabelKey: vcp.Name,
+		},
 	)
 	if err != nil {
 		return nil, err

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconciler.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconciler.go
@@ -75,6 +75,14 @@ func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return reconcile.Result{}, fmt.Errorf("get VirtualControlPlane: %w", err)
 	}
 
+	res, err := r.reconcileFinalizer(ctx, vcp)
+	if err != nil || !res.IsZero() {
+		return res, err
+	}
+	if !vcp.DeletionTimestamp.IsZero() {
+		return reconcile.Result{}, nil
+	}
+
 	albVIP, err := r.albVIP(ctx, vcp)
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("resolve ALB VIP: %w", err)
@@ -826,6 +834,11 @@ func (r *reconciler) createSecret(ctx context.Context, secret *corev1.Secret) er
 
 func (r *reconciler) patchSecret(ctx context.Context, base, secret *corev1.Secret) error {
 	return r.client.Patch(ctx, secret, client.MergeFrom(base))
+}
+
+func (r *reconciler) deleteSecret(ctx context.Context, namespace, name string) error {
+	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name}}
+	return client.IgnoreNotFound(r.client.Delete(ctx, secret))
 }
 
 // ConfigMap

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/tenantclient.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/tenantclient.go
@@ -45,9 +45,8 @@ type tenantClientSet struct {
 	client         client.Client
 }
 
-func (r *reconciler) tenantKubeconfigRaw(ctx context.Context, vcp *controlplanev1alpha1.VirtualControlPlane) ([]byte, error) {
-	ns := vcpNamespace(vcp)
-	sec, err := r.getSecret(ctx, ns, constants.VirtualAdminKubeconfigSecretName)
+func (r *reconciler) tenantKubeconfigRaw(ctx context.Context, namespace string) ([]byte, error) {
+	sec, err := r.getSecret(ctx, namespace, constants.VirtualAdminKubeconfigSecretName)
 	if err != nil {
 		return nil, fmt.Errorf("get admin kubeconfig secret: %w", err)
 	}
@@ -65,13 +64,13 @@ func (r *reconciler) tenantKubeconfigRaw(ctx context.Context, vcp *controlplanev
 // Building client.New triggers discovery against the tenant API server, so cached
 // entries are reused until the admin kubeconfig content changes (e.g. cert rotation).
 func (r *reconciler) tenantClients(ctx context.Context, vcp *controlplanev1alpha1.VirtualControlPlane) (kubernetes.Interface, client.Client, error) {
-	raw, err := r.tenantKubeconfigRaw(ctx, vcp)
+	raw, err := r.tenantKubeconfigRaw(ctx, vcp.Namespace)
 	if err != nil {
 		return nil, nil, err
 	}
 	hash := sha256.Sum256(raw)
 
-	if v, ok := r.tenantClientSets.Load(vcp.Name); ok {
+	if v, ok := r.tenantClientSets.Load(tenantClientCacheKey(vcp.Namespace, vcp.Name)); ok {
 		if cached := v.(*tenantClientSet); cached.kubeconfigHash == hash {
 			return cached.clientset, cached.client, nil
 		}
@@ -95,7 +94,7 @@ func (r *reconciler) tenantClients(ctx context.Context, vcp *controlplanev1alpha
 		return nil, nil, fmt.Errorf("build tenant client: %w", err)
 	}
 
-	r.tenantClientSets.Store(vcp.Name, &tenantClientSet{
+	r.tenantClientSets.Store(tenantClientCacheKey(vcp.Namespace, vcp.Name), &tenantClientSet{
 		kubeconfigHash: hash,
 		clientset:      cs,
 		client:         c,
@@ -104,6 +103,10 @@ func (r *reconciler) tenantClients(ctx context.Context, vcp *controlplanev1alpha
 }
 
 // forgetTenantClients drops cached tenant clients for a deleted VirtualControlPlane.
-func (r *reconciler) forgetTenantClients(vcpName string) {
-	r.tenantClientSets.Delete(vcpName)
+func (r *reconciler) forgetTenantClients(namespace, name string) {
+	r.tenantClientSets.Delete(tenantClientCacheKey(namespace, name))
+}
+
+func tenantClientCacheKey(namespace, name string) string {
+	return namespace + "/" + name
 }

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/tenantclient.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/tenantclient.go
@@ -45,8 +45,10 @@ type tenantClientSet struct {
 	client         client.Client
 }
 
-func (r *reconciler) tenantKubeconfigRaw(ctx context.Context, namespace string) ([]byte, error) {
-	sec, err := r.getSecret(ctx, namespace, constants.VirtualAdminKubeconfigSecretName)
+func (r *reconciler) tenantKubeconfigRaw(ctx context.Context, vcp *controlplanev1alpha1.VirtualControlPlane) ([]byte, error) {
+	ns := vcp.Namespace
+	name := constants.VirtualResourceName(constants.VirtualAdminKubeconfigSecretName, vcp.Name)
+	sec, err := r.getSecret(ctx, ns, name)
 	if err != nil {
 		return nil, fmt.Errorf("get admin kubeconfig secret: %w", err)
 	}
@@ -64,7 +66,7 @@ func (r *reconciler) tenantKubeconfigRaw(ctx context.Context, namespace string) 
 // Building client.New triggers discovery against the tenant API server, so cached
 // entries are reused until the admin kubeconfig content changes (e.g. cert rotation).
 func (r *reconciler) tenantClients(ctx context.Context, vcp *controlplanev1alpha1.VirtualControlPlane) (kubernetes.Interface, client.Client, error) {
-	raw, err := r.tenantKubeconfigRaw(ctx, vcp.Namespace)
+	raw, err := r.tenantKubeconfigRaw(ctx, vcp)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-operation/reconciler.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-operation/reconciler.go
@@ -319,10 +319,15 @@ func (r *reconciler) patchOperationStatus(ctx context.Context, operation, base *
 }
 
 func (r *reconciler) getSecrets(ctx context.Context, operation *controlplanev1alpha1.ControlPlaneOperation) (*corev1.Secret, *corev1.Secret, *corev1.Secret, error) {
+	vcpName := operation.Labels[constants.VirtualControlPlaneScopeLabelKey]
+	if vcpName == "" {
+		return nil, nil, nil, fmt.Errorf("operation %s/%s missing label %s", operation.Namespace, operation.Name, constants.VirtualControlPlaneScopeLabelKey)
+	}
+
 	configSecret := &corev1.Secret{}
 	if err := r.client.Get(ctx, client.ObjectKey{
 		Namespace: operation.Namespace,
-		Name:      constants.VirtualRenderedConfigSecretName,
+		Name:      constants.VirtualResourceName(constants.VirtualRenderedConfigSecretName, vcpName),
 	}, configSecret); err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to get config secret: %v", err)
 	}
@@ -330,7 +335,7 @@ func (r *reconciler) getSecrets(ctx context.Context, operation *controlplanev1al
 	pkiSecret := &corev1.Secret{}
 	if err := r.client.Get(ctx, client.ObjectKey{
 		Namespace: operation.Namespace,
-		Name:      constants.VirtualPKISecretName,
+		Name:      constants.VirtualResourceName(constants.VirtualPKISecretName, vcpName),
 	}, pkiSecret); err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to get pki secret: %v", err)
 	}
@@ -338,7 +343,7 @@ func (r *reconciler) getSecrets(ctx context.Context, operation *controlplanev1al
 	kubeconfigSecret := &corev1.Secret{}
 	if err := r.client.Get(ctx, client.ObjectKey{
 		Namespace: operation.Namespace,
-		Name:      constants.VirtualKubeconfigSecretName,
+		Name:      constants.VirtualResourceName(constants.VirtualKubeconfigSecretName, vcpName),
 	}, kubeconfigSecret); err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to get kubeconfig secret: %v", err)
 	}

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/cpn/cpnplanner/plan.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/cpn/cpnplanner/plan.go
@@ -88,5 +88,6 @@ func nodeRef(cpn *controlplanev1alpha1.ControlPlaneNode) operations.NodeRef {
 		Name:      cpn.Name,
 		Type:      cpn.Labels[constants.ControlPlaneTypeLabelKey],
 		UID:       cpn.UID,
+		VCPName:   cpn.Labels[constants.VirtualControlPlaneScopeLabelKey],
 	}
 }

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/operations/ephemeral/identity.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/operations/ephemeral/identity.go
@@ -7,7 +7,7 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
-    10|Unless required by applicable law or agreed to in writing, software
+Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/operations/ephemeral/identity.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/operations/ephemeral/identity.go
@@ -7,7 +7,7 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
+    10|Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
@@ -18,14 +18,29 @@ package ephemeral
 
 import (
 	controlplanev1alpha1 "control-plane-manager/api/v1alpha1"
+	"control-plane-manager/internal/constants"
 )
 
 type tenantIdentity struct {
 	Namespace string
+	VCPName   string
 }
 
 func tenantIdentityFromOperation(operation *controlplanev1alpha1.ControlPlaneOperation) tenantIdentity {
 	return tenantIdentity{
 		Namespace: operation.Namespace,
+		VCPName:   operation.Labels[constants.VirtualControlPlaneScopeLabelKey],
 	}
+}
+
+func (t tenantIdentity) pkiSecretName() string {
+	return constants.VirtualResourceName(constants.VirtualPKISecretName, t.VCPName)
+}
+
+func (t tenantIdentity) configSecretName() string {
+	return constants.VirtualResourceName(constants.VirtualRenderedConfigSecretName, t.VCPName)
+}
+
+func (t tenantIdentity) apiServerServiceName() string {
+	return constants.VirtualResourceName(constants.VirtualAPIServerServiceName, t.VCPName)
 }

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/operations/ephemeral/identity.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/operations/ephemeral/identity.go
@@ -18,18 +18,14 @@ package ephemeral
 
 import (
 	controlplanev1alpha1 "control-plane-manager/api/v1alpha1"
-	"control-plane-manager/internal/constants"
-	"strings"
 )
 
 type tenantIdentity struct {
-	Name      string
 	Namespace string
 }
 
 func tenantIdentityFromOperation(operation *controlplanev1alpha1.ControlPlaneOperation) tenantIdentity {
 	return tenantIdentity{
-		Name:      strings.TrimPrefix(operation.Namespace, constants.VirtualControlPlaneNamespacePrefix),
 		Namespace: operation.Namespace,
 	}
 }

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/operations/ephemeral/identity.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/operations/ephemeral/identity.go
@@ -41,6 +41,10 @@ func (t tenantIdentity) configSecretName() string {
 	return constants.VirtualResourceName(constants.VirtualRenderedConfigSecretName, t.VCPName)
 }
 
+func (t tenantIdentity) kubeconfigSecretName() string {
+	return constants.VirtualResourceName(constants.VirtualKubeconfigSecretName, t.VCPName)
+}
+
 func (t tenantIdentity) apiServerServiceName() string {
 	return constants.VirtualResourceName(constants.VirtualAPIServerServiceName, t.VCPName)
 }

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/operations/ephemeral/step_cert_observe.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/operations/ephemeral/step_cert_observe.go
@@ -19,7 +19,6 @@ package ephemeral
 import (
 	"context"
 	controlplanev1alpha1 "control-plane-manager/api/v1alpha1"
-	"control-plane-manager/internal/constants"
 	"control-plane-manager/internal/operations"
 	"fmt"
 	"strings"
@@ -100,7 +99,7 @@ func (e *StepExecutor) observeKubeconfigExpirations(ctx context.Context, out map
 	secret := &corev1.Secret{}
 	key := client.ObjectKey{
 		Namespace: e.tenantIdentity.Namespace,
-		Name:      constants.VirtualKubeconfigSecretName,
+		Name:      e.tenantIdentity.kubeconfigSecretName(),
 	}
 	if err := e.client.Get(ctx, key, secret); err != nil {
 		return fmt.Errorf("get kubeconfig secret %s: %w", key.Name, err)

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/operations/ephemeral/step_renew_pki_certs.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/operations/ephemeral/step_renew_pki_certs.go
@@ -127,7 +127,7 @@ func (e *StepExecutor) loadTenantPKIConfig(ctx context.Context) (tenantPKIConfig
 	secret := &corev1.Secret{}
 	key := client.ObjectKey{
 		Namespace: e.tenantIdentity.Namespace,
-		Name:      constants.VirtualRenderedConfigSecretName,
+		Name:      e.tenantIdentity.configSecretName(),
 	}
 	err := e.client.Get(ctx, key, secret)
 	if apierrors.IsNotFound(err) {
@@ -172,7 +172,7 @@ func createComponentPKIBundle(
 
 func (e *StepExecutor) apiserverClusterIP(ctx context.Context) (net.IP, error) {
 	svc := &corev1.Service{}
-	key := client.ObjectKey{Namespace: e.tenantIdentity.Namespace, Name: "kube-apiserver"}
+	key := client.ObjectKey{Namespace: e.tenantIdentity.Namespace, Name: e.tenantIdentity.apiServerServiceName()}
 	if err := e.client.Get(ctx, key, svc); err != nil {
 		return nil, fmt.Errorf("get apiserver service: %w", err)
 	}
@@ -187,7 +187,7 @@ func (e *StepExecutor) getPKISecret(ctx context.Context) (*corev1.Secret, error)
 	secret := &corev1.Secret{}
 	key := client.ObjectKey{
 		Namespace: e.tenantIdentity.Namespace,
-		Name:      constants.VirtualPKISecretName,
+		Name:      e.tenantIdentity.pkiSecretName(),
 	}
 	if err := e.client.Get(ctx, key, secret); err != nil {
 		return nil, fmt.Errorf("get pki secret %s: %w", key.Name, err)

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/operations/ephemeral/step_sync_manifests.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/operations/ephemeral/step_sync_manifests.go
@@ -86,7 +86,7 @@ func (e *StepExecutor) buildTargetStatefulSet(ctx context.Context) (*appsv1.Stat
 	pkiSecret := &corev1.Secret{}
 	if err := e.client.Get(
 		ctx,
-		client.ObjectKey{Namespace: e.tenantIdentity.Namespace, Name: constants.VirtualPKISecretName},
+		client.ObjectKey{Namespace: e.tenantIdentity.Namespace, Name: e.tenantIdentity.pkiSecretName()},
 		pkiSecret,
 	); err != nil {
 		return nil, fmt.Errorf("get pki secret: %w", err)
@@ -106,7 +106,7 @@ func (e *StepExecutor) loadTargetStatefulSet(ctx context.Context) (*appsv1.State
 	secret := &corev1.Secret{}
 	if err := e.client.Get(
 		ctx,
-		client.ObjectKey{Namespace: e.tenantIdentity.Namespace, Name: constants.VirtualRenderedConfigSecretName},
+		client.ObjectKey{Namespace: e.tenantIdentity.Namespace, Name: e.tenantIdentity.configSecretName()},
 		secret,
 	); err != nil {
 		return nil, fmt.Errorf("get vcp config secret: %w", err)

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/operations/ephemeral/step_sync_manifests.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/operations/ephemeral/step_sync_manifests.go
@@ -83,6 +83,10 @@ func (e *StepExecutor) buildTargetStatefulSet(ctx context.Context) (*appsv1.Stat
 		return nil, fmt.Errorf("get target statefulset: %w", err)
 	}
 
+	if err := e.setCPNControllerOwner(sts); err != nil {
+		return nil, err
+	}
+
 	pkiSecret := &corev1.Secret{}
 	if err := e.client.Get(
 		ctx,
@@ -100,6 +104,17 @@ func (e *StepExecutor) buildTargetStatefulSet(ctx context.Context) (*appsv1.Stat
 	e.applyDesiredChecksums(sts, certsChecksum)
 
 	return sts, nil
+}
+
+// setCPNControllerOwner makes the StatefulSet a dependent of the ControlPlaneNode that owns
+// this operation, so VCP → CPN deletion garbage-collects component StatefulSets in a shared Namespace.
+func (e *StepExecutor) setCPNControllerOwner(sts *appsv1.StatefulSet) error {
+	owner := metav1.GetControllerOf(e.operation)
+	if owner == nil {
+		return fmt.Errorf("operation %s/%s has no controller owner (expected ControlPlaneNode)", e.operation.Namespace, e.operation.Name)
+	}
+	sts.SetOwnerReferences([]metav1.OwnerReference{*owner})
+	return nil
 }
 
 func (e *StepExecutor) loadTargetStatefulSet(ctx context.Context) (*appsv1.StatefulSet, error) {

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/operations/operation.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/operations/operation.go
@@ -34,6 +34,7 @@ type NodeRef struct {
 	Name      string
 	Type      string // control-plane.deckhouse.io/type label value
 	UID       types.UID
+	VCPName   string // control-plane.deckhouse.io/virtual-control-plane label (virtual only)
 }
 
 func NewOperation(node NodeRef, c controlplanev1alpha1.OperationComponent, steps []controlplanev1alpha1.StepName, intended controlplanev1alpha1.Checksums) *controlplanev1alpha1.ControlPlaneOperation {
@@ -53,15 +54,19 @@ func NewApprovedOperation(node NodeRef, c controlplanev1alpha1.OperationComponen
 }
 
 func baseOperation(node NodeRef, component controlplanev1alpha1.OperationComponent, steps []controlplanev1alpha1.StepName) *controlplanev1alpha1.ControlPlaneOperation {
+	labels := map[string]string{
+		constants.ControlPlaneNodeNameLabelKey:  node.Name,
+		constants.ControlPlaneComponentLabelKey: component.LabelValue(),
+		constants.ControlPlaneTypeLabelKey:      node.Type,
+		constants.HeritageLabelKey:              constants.HeritageLabelValue,
+	}
+	if node.VCPName != "" {
+		labels[constants.VirtualControlPlaneScopeLabelKey] = node.VCPName
+	}
 	return &controlplanev1alpha1.ControlPlaneOperation{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: node.Namespace,
-			Labels: map[string]string{
-				constants.ControlPlaneNodeNameLabelKey:  node.Name,
-				constants.ControlPlaneComponentLabelKey: component.LabelValue(),
-				constants.ControlPlaneTypeLabelKey:      node.Type,
-				constants.HeritageLabelKey:              constants.HeritageLabelValue,
-			},
+			Labels:    labels,
 		},
 		Spec: controlplanev1alpha1.ControlPlaneOperationSpec{
 			NodeName:  node.Name,

--- a/modules/040-control-plane-manager/templates/validation.yaml
+++ b/modules/040-control-plane-manager/templates/validation.yaml
@@ -100,7 +100,8 @@ spec:
         && (
           request.userInfo.username == "system:serviceaccount:kube-system:namespace-controller"
           || (
-            request.resource.resource == "controlplaneoperations"
+            (request.resource.resource == "controlplaneoperations"
+              || request.resource.resource == "controlplanenodes")
             && (
               request.userInfo.username == "system:kube-controller-manager"
               || request.userInfo.username == "system:serviceaccount:kube-system:generic-garbage-collector"

--- a/modules/040-control-plane-manager/templates/virtual-control-plane.yaml
+++ b/modules/040-control-plane-manager/templates/virtual-control-plane.yaml
@@ -114,7 +114,7 @@ rules:
   verbs: ["get", "list", "watch", "create", "update", "patch"]
 - apiGroups: [""]
   resources: ["secrets"]
-  verbs: ["get", "list", "watch", "create", "update", "patch"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 - apiGroups: [""]
   resources: ["configmaps"]
   verbs: ["get", "list", "watch", "create", "update", "patch"]

--- a/modules/040-control-plane-manager/templates/virtual-control-plane.yaml
+++ b/modules/040-control-plane-manager/templates/virtual-control-plane.yaml
@@ -147,7 +147,7 @@ rules:
   verbs: ["get", "list", "watch", "create", "update", "patch"]
 - apiGroups: ["control-plane.deckhouse.io"]
   resources: ["virtualcontrolplanes"]
-  verbs: ["get", "list", "watch"]
+  verbs: ["get", "list", "watch", "patch"]
 - apiGroups: ["control-plane.deckhouse.io"]
   resources: ["virtualcontrolplanes/status"]
   verbs: ["get", "update", "patch"]

--- a/modules/040-control-plane-manager/virtual-control-plane-templates/alb.yaml.tpl
+++ b/modules/040-control-plane-manager/virtual-control-plane-templates/alb.yaml.tpl
@@ -187,7 +187,7 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: ReferenceGrant
 metadata:
-  name: vcp-${VCP_NAME}-packages
+  name: vcp-${NAMESPACE}-${VCP_NAME}-packages
   namespace: d8-cloud-instance-manager
   labels:
     heritage: deckhouse

--- a/modules/040-control-plane-manager/virtual-control-plane-templates/alb.yaml.tpl
+++ b/modules/040-control-plane-manager/virtual-control-plane-templates/alb.yaml.tpl
@@ -5,7 +5,7 @@ metadata:
   namespace: ${NAMESPACE}
   labels:
     heritage: deckhouse
-    control-plane.deckhouse.io/vcp: ${VCP_NAME}
+    control-plane.deckhouse.io/virtual-control-plane: ${VCP_NAME}
 spec:
   gatewayName: ${VCP_NAME}
   inlet:
@@ -20,11 +20,11 @@ spec:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: konnectivity-egress
+  name: ${KONNECTIVITY_EGRESS_CM_NAME}
   namespace: ${NAMESPACE}
   labels:
     heritage: deckhouse
-    control-plane.deckhouse.io/vcp: ${VCP_NAME}
+    control-plane.deckhouse.io/virtual-control-plane: ${VCP_NAME}
 data:
   egress-selector-configuration.yaml: |
     apiVersion: apiserver.k8s.io/v1beta1
@@ -47,15 +47,16 @@ data:
 apiVersion: v1
 kind: Service
 metadata:
-  name: konnectivity-server
+  name: ${KONNECTIVITY_SERVER_SERVICE_NAME}
   namespace: ${NAMESPACE}
   labels:
     heritage: deckhouse
-    control-plane.deckhouse.io/vcp: ${VCP_NAME}
+    control-plane.deckhouse.io/virtual-control-plane: ${VCP_NAME}
 spec:
   type: ClusterIP
   selector:
     app: kube-apiserver
+    control-plane.deckhouse.io/virtual-control-plane: ${VCP_NAME}
   ports:
   - name: agent
     port: 8132
@@ -69,7 +70,7 @@ metadata:
   namespace: ${NAMESPACE}
   labels:
     heritage: deckhouse
-    control-plane.deckhouse.io/vcp: ${VCP_NAME}
+    control-plane.deckhouse.io/virtual-control-plane: ${VCP_NAME}
 spec:
   parentRef:
     name: ${VCP_NAME}
@@ -97,7 +98,7 @@ metadata:
   namespace: ${NAMESPACE}
   labels:
     heritage: deckhouse
-    control-plane.deckhouse.io/vcp: ${VCP_NAME}
+    control-plane.deckhouse.io/virtual-control-plane: ${VCP_NAME}
 spec:
   parentRefs:
   - name: ${VCP_NAME}
@@ -106,7 +107,7 @@ spec:
     port: 6443
   rules:
   - backendRefs:
-    - name: kube-apiserver
+    - name: ${KUBE_APISERVER_SERVICE_NAME}
       port: 6443
 ---
 apiVersion: gateway.networking.k8s.io/v1
@@ -116,7 +117,7 @@ metadata:
   namespace: ${NAMESPACE}
   labels:
     heritage: deckhouse
-    control-plane.deckhouse.io/vcp: ${VCP_NAME}
+    control-plane.deckhouse.io/virtual-control-plane: ${VCP_NAME}
 spec:
   parentRefs:
   - name: ${VCP_NAME}
@@ -128,7 +129,7 @@ spec:
   - ${VCP_KONN_HOST}
   rules:
   - backendRefs:
-    - name: konnectivity-server
+    - name: ${KONNECTIVITY_SERVER_SERVICE_NAME}
       port: 8132
 ---
 # SNI passthrough to RPP:443 (kube-rbac-proxy, token-gated). The token is the gate.
@@ -139,7 +140,7 @@ metadata:
   namespace: ${NAMESPACE}
   labels:
     heritage: deckhouse
-    control-plane.deckhouse.io/vcp: ${VCP_NAME}
+    control-plane.deckhouse.io/virtual-control-plane: ${VCP_NAME}
 spec:
   parentRefs:
   - name: ${VCP_NAME}
@@ -164,7 +165,7 @@ metadata:
   namespace: ${NAMESPACE}
   labels:
     heritage: deckhouse
-    control-plane.deckhouse.io/vcp: ${VCP_NAME}
+    control-plane.deckhouse.io/virtual-control-plane: ${VCP_NAME}
 spec:
   parentRefs:
   - name: ${VCP_NAME}
@@ -190,7 +191,7 @@ metadata:
   namespace: d8-cloud-instance-manager
   labels:
     heritage: deckhouse
-    control-plane.deckhouse.io/vcp: ${VCP_NAME}
+    control-plane.deckhouse.io/virtual-control-plane: ${VCP_NAME}
 spec:
   from:
   - group: gateway.networking.k8s.io

--- a/modules/040-control-plane-manager/virtual-control-plane-templates/cilium-operator.yaml.tpl
+++ b/modules/040-control-plane-manager/virtual-control-plane-templates/cilium-operator.yaml.tpl
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cilium-config
+  name: ${CILIUM_CONFIG_NAME}
   namespace: ${NAMESPACE}
 data:
 
@@ -261,7 +261,7 @@ data:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: cilium-operator
+  name: ${CILIUM_OPERATOR_NAME}
   namespace: ${NAMESPACE}
 automountServiceAccountToken: false
 ---
@@ -269,11 +269,11 @@ automountServiceAccountToken: false
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: cilium-operator
+  name: ${CILIUM_OPERATOR_NAME}
   namespace: ${NAMESPACE}
   labels:
     io.cilium/app: operator
-    name: cilium-operator
+    name: ${CILIUM_OPERATOR_NAME}
     app.kubernetes.io/part-of: cilium
     app.kubernetes.io/name: cilium-operator
 spec:
@@ -283,7 +283,7 @@ spec:
   selector:
     matchLabels:
       io.cilium/app: operator
-      name: cilium-operator
+      name: ${CILIUM_OPERATOR_NAME}
   # ensure operator update on single node k8s clusters, by using rolling update with maxUnavailable=100% in case
   # of one replica and no user configured Recreate strategy.
   # otherwise an update might get stuck due to the default maxUnavailable=50% in combination with the
@@ -300,7 +300,7 @@ spec:
         prometheus.io/scrape: "true"
       labels:
         io.cilium/app: operator
-        name: cilium-operator
+        name: ${CILIUM_OPERATOR_NAME}
         app.kubernetes.io/part-of: cilium
         app.kubernetes.io/name: cilium-operator
     spec:
@@ -333,7 +333,7 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: debug
-              name: cilium-config
+              name: ${CILIUM_CONFIG_NAME}
               optional: true
         ports:
         - name: health
@@ -376,7 +376,7 @@ spec:
         terminationMessagePolicy: FallbackToLogsOnError
       restartPolicy: Always
       priorityClassName: system-cluster-critical
-      serviceAccountName: "cilium-operator"
+      serviceAccountName: "${CILIUM_OPERATOR_NAME}"
       automountServiceAccountToken: false
       # In HA mode, cilium-operator pods must not be scheduled on the same
       # node as they will clash with each other.
@@ -405,10 +405,10 @@ spec:
         # To read the configuration from the config map
       - name: cilium-config-path
         configMap:
-          name: cilium-config
+          name: ${CILIUM_CONFIG_NAME}
       - name: nested-kubeconfig
         secret:
-          secretName: d8-admin-kubeconfig-virtual
+          secretName: ${ADMIN_KUBECONFIG_SECRET_NAME}
           items:
           - key: super-admin.conf
             path: kubeconfig

--- a/modules/040-control-plane-manager/virtual-control-plane-templates/datastore.yaml.tpl
+++ b/modules/040-control-plane-manager/virtual-control-plane-templates/datastore.yaml.tpl
@@ -1,18 +1,18 @@
 apiVersion: managed-services.deckhouse.io/v1alpha1
 kind: Postgres
 metadata:
-  name: d8-datastore-virtual
+  name: ${DATASTORE_NAME}
   namespace: ${NAMESPACE}
   labels:
     heritage: deckhouse
-    control-plane.deckhouse.io/vcp: ${VCP_NAME}
+    control-plane.deckhouse.io/virtual-control-plane: ${VCP_NAME}
 spec:
   postgresClassName: default
   type: Standalone
   users:
   - name: kine
     role: rw
-    storeCredsToSecret: d8-datastore-creds-virtual
+    storeCredsToSecret: ${DATASTORE_CREDS_SECRET_NAME}
   databases:
   - name: kine
   instance:

--- a/modules/040-control-plane-manager/virtual-control-plane-templates/kube-apiserver.yaml.tpl
+++ b/modules/040-control-plane-manager/virtual-control-plane-templates/kube-apiserver.yaml.tpl
@@ -5,6 +5,7 @@ metadata:
   namespace: ${NAMESPACE}
   labels:
     app: kube-apiserver
+    control-plane.deckhouse.io/virtual-control-plane: ${VCP_NAME}
     control-plane.deckhouse.io/vcp: ${VCP_NAME}
     control-plane.deckhouse.io/cpn: ${CPN_NAME}
 spec:
@@ -13,11 +14,13 @@ spec:
   selector:
     matchLabels:
       app: kube-apiserver
+      control-plane.deckhouse.io/virtual-control-plane: ${VCP_NAME}
       control-plane.deckhouse.io/cpn: ${CPN_NAME}
   template:
     metadata:
       labels:
         app: kube-apiserver
+        control-plane.deckhouse.io/virtual-control-plane: ${VCP_NAME}
         control-plane.deckhouse.io/vcp: ${VCP_NAME}
         control-plane.deckhouse.io/cpn: ${CPN_NAME}
     spec:
@@ -91,9 +94,9 @@ spec:
       - name: kine
         image: ${IMAGE_KINE}
         env:
-        - {name: PGHOST, valueFrom: {secretKeyRef: {name: d8-datastore-creds-virtual, key: host}}}
-        - {name: PGUSER, valueFrom: {secretKeyRef: {name: d8-datastore-creds-virtual, key: username}}}
-        - {name: PGPASSWORD, valueFrom: {secretKeyRef: {name: d8-datastore-creds-virtual, key: password}}}
+        - {name: PGHOST, valueFrom: {secretKeyRef: {name: ${DATASTORE_CREDS_SECRET_NAME}, key: host}}}
+        - {name: PGUSER, valueFrom: {secretKeyRef: {name: ${DATASTORE_CREDS_SECRET_NAME}, key: username}}}
+        - {name: PGPASSWORD, valueFrom: {secretKeyRef: {name: ${DATASTORE_CREDS_SECRET_NAME}, key: password}}}
         command:
         - kine
         - --endpoint=postgres://$(PGUSER)@$(PGHOST):5432/kine?sslmode=require
@@ -183,16 +186,16 @@ spec:
       volumes:
       - name: pki
         secret:
-          secretName: d8-pki-virtual
+          secretName: ${PKI_SECRET_NAME}
       - name: konnectivity-uds
         emptyDir: {}
       - name: konnectivity-egress
         configMap:
-          name: konnectivity-egress
+          name: ${KONNECTIVITY_EGRESS_CM_NAME}
       - name: konnectivity-kubeconfig
         secret:
-          secretName: d8-admin-kubeconfig-virtual
+          secretName: ${ADMIN_KUBECONFIG_SECRET_NAME}
       - name: konnectivity-agent-cp
         secret:
-          secretName: konnectivity-agent-cp
+          secretName: ${KONNECTIVITY_AGENT_CP_SECRET_NAME}
           optional: true

--- a/modules/040-control-plane-manager/virtual-control-plane-templates/kube-controller-manager.yaml.tpl
+++ b/modules/040-control-plane-manager/virtual-control-plane-templates/kube-controller-manager.yaml.tpl
@@ -49,7 +49,7 @@ spec:
       volumes:
       - name: pki
         secret:
-          secretName: d8-pki-virtual
+          secretName: ${PKI_SECRET_NAME}
       - name: kubeconfig
         secret:
-          secretName: d8-kubeconfig-virtual
+          secretName: ${KUBECONFIG_SECRET_NAME}

--- a/modules/040-control-plane-manager/virtual-control-plane-templates/kube-scheduler.yaml.tpl
+++ b/modules/040-control-plane-manager/virtual-control-plane-templates/kube-scheduler.yaml.tpl
@@ -41,7 +41,7 @@ spec:
       volumes:
       - name: pki
         secret:
-          secretName: d8-pki-virtual
+          secretName: ${PKI_SECRET_NAME}
       - name: kubeconfig
         secret:
-          secretName: d8-kubeconfig-virtual
+          secretName: ${KUBECONFIG_SECRET_NAME}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
