### PR TITLE
[deckhouse] fix: guard embedded package registration

### DIFF
--- a/deckhouse-controller/internal/packages/runtime/embedded.go
+++ b/deckhouse-controller/internal/packages/runtime/embedded.go
@@ -137,17 +137,19 @@ func (r *Runtime) loadEmbedded(ctx context.Context) error {
 				return fmt.Errorf("new module by config: %w", err)
 			}
 
+			// lifecycle.Store is not thread-safe, so guard it (and the module map)
+			// with r.mu; status.Service is internally synchronized.
 			r.mu.Lock()
 			r.modules[module.GetName()] = module
+			r.packages.Update(module.GetName(), module.GetVersion().String(), 0, make(addonutils.Values), "")
 			r.mu.Unlock()
 
-			// register package in status and packages stores
+			// register package in status store
 			r.status.NewStatus(module.GetName())
 			r.status.SetConditionTrue(module.GetName(), status.ConditionRequirementsMet)
 			r.status.SetConditionTrue(module.GetName(), status.ConditionReadyOnFilesystem)
 			r.status.SetConditionTrue(module.GetName(), status.ConditionLoaded)
 			r.status.UpdateVersion(module.GetName(), module.GetVersion().String())
-			r.packages.Update(module.GetName(), module.GetVersion().String(), 0, make(addonutils.Values), "")
 
 			return nil
 		})


### PR DESCRIPTION
## Description
`loadEmbedded` loads embedded modules concurrently (`errgroup`, 8 workers — introduced in #20903). Each worker registered its module by calling `r.packages.Update(...)`, but that call was left **outside** the `r.mu` critical section — the lock only wrapped the `r.modules` map write.

`r.packages` is a `lifecycle.Store`, which is explicitly **not thread-safe** ("callers must hold `Runtime.mu` before calling any method"): `Store.Update` does a raw `s.packages[name] = ...` map write. With several workers reaching that line at once, Go's runtime detects the concurrent map access and aborts the whole process with `fatal error: concurrent map writes`.

The fix moves `r.packages.Update` inside the existing `r.mu.Lock()`/`Unlock()` tated under the same lock every other call site (`scheduleGlobal`,`schedulePackage`, `disablePackage`) already holds. `r.status.*` is left as-is — `status.Service` has its own internal mutex. 
                                                   
## Why do we need it, and what problem does it solve?                                                                                                                                 
It fixes a startup crash of the Deckhouse controller. The bug is a data race, so it fires non-deterministically depending on goroutine timing and the number of enabled modules — the controller may crash on one restart and come up fine on the next, landing the pand taking the whole operator down until it happens to win the race.

Because `fatal error` cannot be caught with `recover()`, there is no graceful docess dies. The more embedded modules a bundle enables, the higher the odds ofhitting it on any given start.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Fix concurrent map write crash on controller startup during parallel embedded module load.
impact_level: low
```
