### PR TITLE
[deckhouse] Add registry availability command to module-not-valid alert

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -3147,7 +3147,19 @@ alerts:
         Possible reasons:
          - The Module image is corrupted.
 
-        To resolve this issue, ensure that {{ $labels.version }} image in the registry '{{ $labels.registry }}' is valid .
+        To resolve this issue, ensure that the {{ $labels.version }} image in the registry '{{ $labels.registry }}' is valid.
+
+        Check which versions of the '{{ $labels.module }}' Module are available in the registry:
+
+        ```bash
+        d8 cr ls {{ $labels.registry }}/{{ $labels.module }}/release
+        ```
+
+        For a private registry, pass the credentials from the corresponding ModuleSource:
+
+        ```bash
+        d8 cr ls -u <USERNAME> -p <PASSWORD> {{ $labels.registry }}/{{ $labels.module }}/release
+        ```
 
         To get the exact error, check Deckhouse logs:
         `d8 k -n d8-system logs deploy/deckhouse | grep "failed to download module"`

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -3119,7 +3119,7 @@ alerts:
       module: deckhouse
       edition: ce
       description: |
-        The '{{ $labels.module }}' Module update has failed.
+        The '{{ $labels.module }}' module update has failed.
 
         Current version: {{ $labels.actualVersion }}.
         Desired version: {{ $labels.version }}.
@@ -3127,9 +3127,9 @@ alerts:
         Attempt to download interim releases failed.
 
         Possible reasons:
-         - The necessary versions of the Module image is not available in the registry.
+         - The necessary versions of the module image is not available in the registry.
 
-        To resolve this issue, ensure that all minor versions of the '{{ $labels.module }}' Module image between {{ $labels.actualVersion }} and {{ $labels.version }} is available in the registry '{{ $labels.registry }}'.
+        To resolve this issue, ensure that all minor versions of the '{{ $labels.module }}' module image between {{ $labels.actualVersion }} and {{ $labels.version }} is available in the registry '{{ $labels.registry }}'.
       summary: |
         Module update has failed. Updating sequence is broken.
       severity: "4"
@@ -3140,16 +3140,16 @@ alerts:
       module: deckhouse
       edition: ce
       description: |
-        The '{{ $labels.module }}' Module update has failed.
+        The '{{ $labels.module }}' module update has failed.
 
         Desired version: {{ $labels.version }}.
 
         Possible reasons:
-         - The Module image is corrupted.
+         - The module image is corrupted.
 
         To resolve this issue, ensure that the {{ $labels.version }} image in the registry '{{ $labels.registry }}' is valid.
 
-        Check which versions of the '{{ $labels.module }}' Module are available in the registry:
+        Check which versions of the '{{ $labels.module }}' module are available in the registry:
 
         ```bash
         d8 cr ls {{ $labels.registry }}/{{ $labels.module }}/release

--- a/modules/002-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
+++ b/modules/002-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
@@ -549,7 +549,19 @@
         Possible reasons:
          - The Module image is corrupted.
 
-        To resolve this issue, ensure that {{ $labels.version }} image in the registry '{{ $labels.registry }}' is valid .
+        To resolve this issue, ensure that the {{ $labels.version }} image in the registry '{{ $labels.registry }}' is valid.
+
+        Check which versions of the '{{ $labels.module }}' Module are available in the registry:
+
+        ```bash
+        d8 cr ls {{ $labels.registry }}/{{ $labels.module }}/release
+        ```
+
+        For a private registry, pass the credentials from the corresponding ModuleSource:
+
+        ```bash
+        d8 cr ls -u <USERNAME> -p <PASSWORD> {{ $labels.registry }}/{{ $labels.module }}/release
+        ```
 
         To get the exact error, check Deckhouse logs:
         `d8 k -n d8-system logs deploy/deckhouse | grep "failed to download module"`

--- a/modules/002-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
+++ b/modules/002-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
@@ -519,7 +519,7 @@
       plk_markup_format: "markdown"
       summary: Module update has failed. Updating sequence is broken.
       description: |
-        The '{{ $labels.module }}' Module update has failed.
+        The '{{ $labels.module }}' module update has failed.
 
         Current version: {{ $labels.actualVersion }}.
         Desired version: {{ $labels.version }}.
@@ -527,9 +527,9 @@
         Attempt to download interim releases failed.
 
         Possible reasons:
-         - The necessary versions of the Module image is not available in the registry.
+         - The necessary versions of the module image is not available in the registry.
 
-        To resolve this issue, ensure that all minor versions of the '{{ $labels.module }}' Module image between {{ $labels.actualVersion }} and {{ $labels.version }} is available in the registry '{{ $labels.registry }}'.
+        To resolve this issue, ensure that all minor versions of the '{{ $labels.module }}' module image between {{ $labels.actualVersion }} and {{ $labels.version }} is available in the registry '{{ $labels.registry }}'.
 
   - alert: DeckhouseModuleUpdatingFailedModuleIsNotValid
     expr: max by(module, registry, version) (d8_module_updating_module_is_not_valid) > 0
@@ -542,16 +542,16 @@
       plk_markup_format: "markdown"
       summary: Module update has failed. Module is not valid.
       description: |
-        The '{{ $labels.module }}' Module update has failed.
+        The '{{ $labels.module }}' module update has failed.
 
         Desired version: {{ $labels.version }}.
 
         Possible reasons:
-         - The Module image is corrupted.
+         - The module image is corrupted.
 
         To resolve this issue, ensure that the {{ $labels.version }} image in the registry '{{ $labels.registry }}' is valid.
 
-        Check which versions of the '{{ $labels.module }}' Module are available in the registry:
+        Check which versions of the '{{ $labels.module }}' module are available in the registry:
 
         ```bash
         d8 cr ls {{ $labels.registry }}/{{ $labels.module }}/release


### PR DESCRIPTION
## Description

The `DeckhouseModuleUpdatingFailedModuleIsNotValid` alert description now embeds a ready-to-run command to check module image availability in the registry:

- `d8 cr ls <registry>/<module>/release` - the path is assembled from the alert labels
- a second variant with `-u`/`-p` for a private registry

Also fixes a cosmetic typo in the existing text (`is valid .` -> `is valid.`).

This is an alert description change only. No restarts or impact on cluster components.

## Why do we need it, and what problem does it solve?

When this alert fires, the on-call engineer needs to check whether the module image is present in the registry. Until now they had to build the full registry path by hand every time.

- The alert already carries the `registry` and `module` labels
- So we can assemble the `d8 cr ls` path and put it straight into the description
- The engineer copies the command and runs it, no manual path building

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: feature
summary: Add a registry image availability command to the DeckhouseModuleUpdatingFailedModuleIsNotValid alert description.
impact_level: low
```
