### PR TITLE
[cni-cilium,cilium-hubble] Fixed securityContext and added SecurityPolicyException

### DIFF
--- a/ee/se-plus/modules/021-cni-cilium/templates/egress-gateway-agent/daemonset.yaml
+++ b/ee/se-plus/modules/021-cni-cilium/templates/egress-gateway-agent/daemonset.yaml
@@ -46,6 +46,7 @@ spec:
         {{ include "helm_lib_prevent_ds_eviction_annotation" . | nindent 8 }}
       labels:
         app: egress-gateway-agent
+        security.deckhouse.io/security-policy-exception: egress-gateway-agent
     spec:
       {{- include "helm_lib_priority_class" (tuple . "system-node-critical") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node" "with-uninitialized" "with-cloud-provider-uninitialized" "with-storage-problems") | nindent 6 }}

--- a/ee/se-plus/modules/021-cni-cilium/templates/egress-gateway-agent/security-policy-exception.yaml
+++ b/ee/se-plus/modules/021-cni-cilium/templates/egress-gateway-agent/security-policy-exception.yaml
@@ -1,0 +1,39 @@
+{{- if (.Values.global.enabledModules | has "admission-policy-engine") }}
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: SecurityPolicyException
+metadata:
+  name: egress-gateway-agent
+  namespace: d8-{{ .Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "egress-gateway-agent")) | nindent 2 }}
+spec:
+  securityContext:
+    runAsNonRoot:
+      allowedValue: false
+      metadata:
+        description: |
+          egress-gateway-agent must run as root to announce VirtualIP addresses via ARP/NDP
+          on the host network interfaces.
+    runAsUser:
+      allowedValues:
+        - 0
+      metadata:
+        description: |
+          UID 0 is required for raw network operations used by VirtualIP announcement.
+    capabilities:
+      allowedValues:
+        add:
+          - NET_RAW
+        drop:
+          - ALL
+      metadata:
+        description: |
+          NET_RAW is required to craft ARP/NDP packets for VirtualIP advertisement.
+  network:
+    hostNetwork:
+      allowedValue: true
+      metadata:
+        description: |
+          egress-gateway-agent must join the host network to announce VirtualIP addresses
+          on node interfaces.
+{{- end }}

--- a/modules/021-cni-cilium/templates/_agent-daemonset.tpl
+++ b/modules/021-cni-cilium/templates/_agent-daemonset.tpl
@@ -28,6 +28,7 @@ spec:
       labels:
         app: agent
         module: cni-cilium
+        security.deckhouse.io/security-policy-exception: agent
     spec:
       {{- include "helm_lib_priority_class" (tuple $context "system-node-critical") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple $context "any-node" "with-uninitialized" "with-cloud-provider-uninitialized" "with-storage-problems") | nindent 6 }}

--- a/modules/021-cni-cilium/templates/agent/security-policy-exception.yaml
+++ b/modules/021-cni-cilium/templates/agent/security-policy-exception.yaml
@@ -1,0 +1,146 @@
+{{- if (.Values.global.enabledModules | has "admission-policy-engine") }}
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: SecurityPolicyException
+metadata:
+  name: agent
+  namespace: d8-{{ .Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "agent")) | nindent 2 }}
+spec:
+  securityContext:
+    privileged:
+      allowedValue: true
+      metadata:
+        description: |
+          The mount-bpf-fs init container must run privileged to mount the BPF filesystem
+          at /sys/fs/bpf on the host, which is required for Cilium eBPF datapath operation.
+    allowPrivilegeEscalation:
+      allowedValue: true
+      metadata:
+        description: |
+          Privilege escalation is required together with privileged mode for mount-bpf-fs
+          to perform the host BPF filesystem mount.
+    runAsNonRoot:
+      allowedValue: false
+      metadata:
+        description: |
+          Cilium agent and its init containers must run as root to manage host networking,
+          BPF maps, cgroup mounts and CNI binaries.
+    runAsUser:
+      allowedValues:
+        - 0
+      metadata:
+        description: |
+          UID 0 is required for datapath setup, nsenter into the host namespaces and
+          privileged host filesystem operations.
+    appArmorProfile:
+      allowedValues:
+        - unconfined
+      metadata:
+        description: |
+          Several Cilium init and agent containers need the unconfined AppArmor profile
+          to perform host mounts, sysctl overwrites and CNI binary installation.
+    seLinuxOptions:
+      allowedValues:
+        - level: s0
+          type: spc_t
+      metadata:
+        description: |
+          SELinux type spc_t is required for containers that interact with host namespaces
+          and privileged host resources.
+    capabilities:
+      allowedValues:
+        add:
+          - CHOWN
+          - KILL
+          - NET_ADMIN
+          - NET_RAW
+          - IPC_LOCK
+          - SYS_MODULE
+          - SYS_ADMIN
+          - SYS_RESOURCE
+          - PERFMON
+          - BPF
+          - DAC_OVERRIDE
+          - FOWNER
+          - SETGID
+          - SETUID
+          - SYS_CHROOT
+          - SYS_PTRACE
+        drop:
+          - ALL
+      metadata:
+        description: |
+          Elevated capabilities are required for eBPF datapath, routing/iptables management,
+          cgroup mounts via nsenter, and WireGuard/kernel module checks.
+  network:
+    hostNetwork:
+      allowedValue: true
+      metadata:
+        description: |
+          Cilium agent must run on the host network to program node networking and expose
+          health/metrics endpoints on the node.
+    hostPorts:
+      - port: 4241
+        protocol: TCP
+        metadata:
+          description: HTTPS metrics endpoint exposed through kube-rbac-proxy.
+  volumes:
+    types:
+      allowedValues:
+        - hostPath
+      metadata:
+        description: |
+          hostPath volumes are required to access BPF maps, CNI paths, host procfs and
+          kernel modules on the node.
+    hostPath:
+      allowedValues:
+        - path: /proc/sys/net
+          readOnly: false
+          metadata:
+            description: Host network sysctl tree used by the Cilium agent.
+        - path: /proc/sys/kernel
+          readOnly: false
+          metadata:
+            description: Host kernel sysctl tree used by the Cilium agent.
+        - path: /var/run/cilium
+          readOnly: false
+          metadata:
+            description: Cilium runtime state directory on the host.
+        - path: /var/log/cilium/hubble
+          readOnly: false
+          metadata:
+            description: Hubble log directory on the host.
+        - path: /var/run/netns
+          readOnly: false
+          metadata:
+            description: Host network namespaces used by Cilium socket-LB and health endpoints.
+        - path: /sys/fs/bpf
+          readOnly: false
+          metadata:
+            description: BPF filesystem used for eBPF maps and programs.
+        - path: /proc
+          readOnly: false
+          metadata:
+            description: Host procfs used by nsenter for cgroup and sysctl operations.
+        - path: /run/cilium/cgroupv2
+          readOnly: false
+          metadata:
+            description: Cilium cgroup v2 mount point on the host.
+        - path: /opt/cni/bin
+          readOnly: false
+          metadata:
+            description: Host CNI binary directory where Cilium installs its plugin.
+        - path: /etc/cni/net.d
+          readOnly: false
+          metadata:
+            description: Host CNI configuration directory.
+        - path: /lib/modules
+          readOnly: true
+          metadata:
+            description: Host kernel modules used for iptables and related operations.
+        - path: /run/xtables.lock
+          readOnly: false
+          metadata:
+            description: Host xtables lock used to serialize iptables updates.
+{{- end }}

--- a/modules/021-cni-cilium/templates/operator/deployment.yaml
+++ b/modules/021-cni-cilium/templates/operator/deployment.yaml
@@ -47,6 +47,7 @@ spec:
         configmap-checksum: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum | quote }}
       labels:
         app: operator
+        security.deckhouse.io/security-policy-exception: operator
     spec:
       {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node" "with-uninitialized" "with-cloud-provider-uninitialized") | nindent 6 }}

--- a/modules/021-cni-cilium/templates/operator/security-policy-exception.yaml
+++ b/modules/021-cni-cilium/templates/operator/security-policy-exception.yaml
@@ -1,0 +1,22 @@
+{{- if (.Values.global.enabledModules | has "admission-policy-engine") }}
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: SecurityPolicyException
+metadata:
+  name: operator
+  namespace: d8-{{ .Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "operator")) | nindent 2 }}
+spec:
+  network:
+    hostNetwork:
+      allowedValue: true
+      metadata:
+        description: |
+          Cilium operator runs on the host network to reach the local Kubernetes API
+          proxy on control-plane nodes.
+    hostPorts:
+      - port: 4242
+        protocol: TCP
+        metadata:
+          description: HTTPS metrics endpoint exposed through kube-rbac-proxy.
+{{- end }}

--- a/modules/021-cni-cilium/templates/safe-agent-updater/daemonset.yaml
+++ b/modules/021-cni-cilium/templates/safe-agent-updater/daemonset.yaml
@@ -41,6 +41,7 @@ spec:
         safe-agent-updater-daemonset-generation: {{ include "agent_daemonset_template" (list . "undefined") | sha256sum | quote }}
       labels:
         app: safe-agent-updater
+        security.deckhouse.io/security-policy-exception: safe-agent-updater
     spec:
       {{- include "helm_lib_priority_class" (tuple . "system-node-critical") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node" "with-uninitialized" "with-cloud-provider-uninitialized" "with-storage-problems") | nindent 6 }}
@@ -66,6 +67,7 @@ spec:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
         securityContext:
           readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
           seLinuxOptions:
             level: 's0'
             type: 'spc_t'

--- a/modules/021-cni-cilium/templates/safe-agent-updater/security-policy-exception.yaml
+++ b/modules/021-cni-cilium/templates/safe-agent-updater/security-policy-exception.yaml
@@ -1,0 +1,50 @@
+{{- if (.Values.global.enabledModules | has "admission-policy-engine") }}
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: SecurityPolicyException
+metadata:
+  name: safe-agent-updater
+  namespace: d8-{{ .Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "safe-agent-updater")) | nindent 2 }}
+spec:
+  securityContext:
+    capabilities:
+      allowedValues:
+        add:
+          - NET_ADMIN
+          - NET_RAW
+          - SYS_MODULE
+        drop:
+          - ALL
+      metadata:
+        description: |
+          check-wg-kernel-compat needs NET_ADMIN/NET_RAW/SYS_MODULE to probe WireGuard
+          kernel compatibility on the node.
+    seLinuxOptions:
+      allowedValues:
+        - level: s0
+          type: spc_t
+      metadata:
+        description: |
+          SELinux type spc_t is required for host CNI path access during kernel checks.
+  network:
+    hostNetwork:
+      allowedValue: true
+      metadata:
+        description: |
+          safe-agent-updater runs on the host network to talk to the local Kubernetes
+          API proxy while coordinating Cilium agent updates.
+  volumes:
+    types:
+      allowedValues:
+        - hostPath
+      metadata:
+        description: |
+          hostPath is required to access the host CNI binary directory.
+    hostPath:
+      allowedValues:
+        - path: /opt/cni/bin
+          readOnly: false
+          metadata:
+            description: Host CNI binary directory used during agent image pre-pull and update checks.
+{{- end }}

--- a/modules/500-cilium-hubble/templates/relay/deployment.yaml
+++ b/modules/500-cilium-hubble/templates/relay/deployment.yaml
@@ -53,8 +53,7 @@ spec:
         - name: deckhouse-registry
       containers:
         - name: hubble-relay
-          {{- include "helm_lib_module_container_security_context_not_allow_privilege_escalation" . | nindent 10 }}
-            readOnlyRootFilesystem: true
+          {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all" . | nindent 10 }}
           image: {{ include "helm_lib_module_image" (list . "relay") }}
           command:
             - hubble-relay

--- a/modules/500-cilium-hubble/templates/relay/deployment.yaml
+++ b/modules/500-cilium-hubble/templates/relay/deployment.yaml
@@ -46,6 +46,7 @@ spec:
         cilium.io/hubble-relay-configmap-checksum: {{ include (print $.Template.BasePath "/relay/configmap.yaml") . | sha256sum | quote }}
       labels:
         app: hubble-relay
+        security.deckhouse.io/security-policy-exception: hubble-relay
     spec:
       {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 6 }}
       imagePullSecrets:

--- a/modules/500-cilium-hubble/templates/relay/deployment.yaml
+++ b/modules/500-cilium-hubble/templates/relay/deployment.yaml
@@ -53,10 +53,12 @@ spec:
         - name: deckhouse-registry
       containers:
         - name: hubble-relay
-          {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all" . | nindent 10 }}
+          {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all_and_add" (list . (list "DAC_OVERRIDE")) | nindent 10 }}
+            seccompProfile:
+              type: RuntimeDefault
           image: {{ include "helm_lib_module_image" (list . "relay") }}
           command:
-            - hubble-relay
+            - /usr/local/bin/hubble-relay
           args:
             - serve
           {{- if .Values.ciliumHubble.debugLogging }}

--- a/modules/500-cilium-hubble/templates/relay/security-policy-exception.yaml
+++ b/modules/500-cilium-hubble/templates/relay/security-policy-exception.yaml
@@ -1,0 +1,47 @@
+{{- if (.Values.global.enabledModules | has "admission-policy-engine") }}
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: SecurityPolicyException
+metadata:
+  name: hubble-relay
+  namespace: d8-cni-cilium
+  {{- include "helm_lib_module_labels" (list . (dict "app" "hubble-relay")) | nindent 2 }}
+spec:
+  securityContext:
+    runAsNonRoot:
+      allowedValue: false
+      metadata:
+        description: |
+          hubble-relay must run as root to read TLS material mounted with mode 0400 and
+          to access the Cilium agent UNIX socket on the host.
+    runAsUser:
+      allowedValues:
+        - 0
+      metadata:
+        description: |
+          UID 0 is required for TLS secrets (defaultMode 0400) and the hubble.sock hostPath.
+    capabilities:
+      allowedValues:
+        add:
+          - DAC_OVERRIDE
+        drop:
+          - ALL
+      metadata:
+        description: |
+          DAC_OVERRIDE is required so root can execute the hubble-relay binary which is
+          owned by UID 64535 with mode 0700 after capabilities.drop ALL removes the
+          implicit root DAC bypass.
+  volumes:
+    types:
+      allowedValues:
+        - hostPath
+      metadata:
+        description: |
+          hostPath is required to reach the Cilium agent UNIX socket for Hubble observation data.
+    hostPath:
+      allowedValues:
+        - path: /var/run/cilium
+          readOnly: true
+          metadata:
+            description: Cilium runtime directory containing the Hubble peer socket.
+{{- end }}

--- a/modules/500-cilium-hubble/templates/relay/security-policy-exception.yaml
+++ b/modules/500-cilium-hubble/templates/relay/security-policy-exception.yaml
@@ -14,23 +14,6 @@ spec:
         description: |
           hubble-relay must run as root to read TLS material mounted with mode 0400 and
           to access the Cilium agent UNIX socket on the host.
-    runAsUser:
-      allowedValues:
-        - 0
-      metadata:
-        description: |
-          UID 0 is required for TLS secrets (defaultMode 0400) and the hubble.sock hostPath.
-    capabilities:
-      allowedValues:
-        add:
-          - DAC_OVERRIDE
-        drop:
-          - ALL
-      metadata:
-        description: |
-          DAC_OVERRIDE is required so root can execute the hubble-relay binary which is
-          owned by UID 64535 with mode 0700 after capabilities.drop ALL removes the
-          implicit root DAC bypass.
   volumes:
     types:
       allowedValues:

--- a/modules/500-cilium-hubble/templates/relay/security-policy-exception.yaml
+++ b/modules/500-cilium-hubble/templates/relay/security-policy-exception.yaml
@@ -14,6 +14,21 @@ spec:
         description: |
           hubble-relay must run as root to read TLS material mounted with mode 0400 and
           to access the Cilium agent UNIX socket on the host.
+    runAsUser:
+      allowedValues:
+        - 0
+      metadata:
+        description: |
+          UID 0 is required for TLS secrets (defaultMode 0400) and the hubble.sock hostPath.
+    capabilities:
+      allowedValues:
+        add:
+          - DAC_OVERRIDE
+      metadata:
+        description: |
+          After capabilities.drop ALL, root loses the implicit DAC bypass. DAC_OVERRIDE is
+          required to execute the hubble-relay binary (mode 0700, owner 64535) and to read
+          TLS files mounted with mode 0400.
   volumes:
     types:
       allowedValues:


### PR DESCRIPTION
## Description
This PR updates the `securityContext` configuration and adds a `SecurityPolicyException`.

## Why do we need it, and what problem does it solve?
This change aligns the component with the required security policies by correcting the `securityContext` configuration and introducing a `SecurityPolicyException` where elevated permissions are required. This ensures the component can operate correctly while remaining compliant with the platform's security requirements.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: cni-cilium
type: feature
summary: Fixed securityContext and added a SecurityPolicyException.
impact_level: default
---
section: cilium-hubble
type: feature
summary: Fixed securityContext and added a SecurityPolicyException.
impact_level: default
```
