### PR TITLE
[cni-cilium] enable bpf trace events for hubble module by default

### DIFF
--- a/modules/021-cni-cilium/templates/configmap.yaml
+++ b/modules/021-cni-cilium/templates/configmap.yaml
@@ -162,11 +162,12 @@ data:
   monitor-aggregation: "medium"
   monitor-aggregation-flags: "all"
 
+  # BPF trace events dominate cilium-agent CPU/memory on dense nodes; disabled
+  # cluster-wide. `drop` and `policy verdict` events are unaffected. To enable
+  # on specific or all nodes, use CiliumNodeConfig (see docs/EXAMPLES.md).
   # Enabled with cilium-hubble; otherwise off (override via CiliumNodeConfig).
-  {{- if has "cilium-hubble" .Values.global.enabledModules }}
-  bpf-events-trace-enabled: "true"
-  {{- else }}
-  bpf-events-trace-enabled: "false"
+  {{- if not (has "cilium-hubble" .Values.global.enabledModules) }}
+bpf-events-trace-enabled: "false"
   {{- end }}
 
   # Local hubble sever section

--- a/modules/021-cni-cilium/templates/configmap.yaml
+++ b/modules/021-cni-cilium/templates/configmap.yaml
@@ -167,7 +167,7 @@ data:
   # on specific or all nodes, use CiliumNodeConfig (see docs/EXAMPLES.md).
   # Enabled with cilium-hubble; otherwise off (override via CiliumNodeConfig).
   {{- if not (has "cilium-hubble" .Values.global.enabledModules) }}
-bpf-events-trace-enabled: "false"
+  bpf-events-trace-enabled: "false"
   {{- end }}
 
   # Local hubble sever section

--- a/modules/021-cni-cilium/templates/configmap.yaml
+++ b/modules/021-cni-cilium/templates/configmap.yaml
@@ -162,10 +162,12 @@ data:
   monitor-aggregation: "medium"
   monitor-aggregation-flags: "all"
 
-  # BPF trace events dominate cilium-agent CPU/memory on dense nodes; disabled
-  # cluster-wide. `drop` and `policy verdict` events are unaffected. To enable
-  # on specific or all nodes, use CiliumNodeConfig (see docs/EXAMPLES.md).
+  # Enabled with cilium-hubble; otherwise off (override via CiliumNodeConfig).
+  {{- if has "cilium-hubble" .Values.global.enabledModules }}
+  bpf-events-trace-enabled: "true"
+  {{- else }}
   bpf-events-trace-enabled: "false"
+  {{- end }}
 
   # Local hubble sever section
   {{- if or (has "cilium-hubble" .Values.global.enabledModules) .Values.cniCilium.internal.hubble.settings.extendedMetrics.enabled .Values.cniCilium.internal.hubble.settings.flowLogs.enabled }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Enable bpf-events-trace-enabled in the cilium-agent ConfigMap when the cilium-hubble module is enabled; keep it disabled otherwise.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

 With BPF traces off, Hubble UI cannot show forwarded flows (only drops/policy verdicts). Enabling traces when cilium-hubble is on restores that visibility without turning them on cluster-wide when Hubble is unused.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cni-cilium
type: chore
summary: Enabled BPF trace events for the Hubble module by default.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->