### PR TITLE
[vertical-pod-autoscaler] Fix cve in 1.73

### DIFF
--- a/modules/302-vertical-pod-autoscaler/images/admission-controller/known_vulnerabilities.vex
+++ b/modules/302-vertical-pod-autoscaler/images/admission-controller/known_vulnerabilities.vex
@@ -1,0 +1,206 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-68ba11ffab091d021f89629d40842cca204154d6bd7b58407e9744faea2c5826",
+  "author": "Deckhouse <contact@deckhouse.io>",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-25681"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость XSS в golang.org/x/net/html: разбор произвольного HTML с последующим Render может давать неожиданное дерево HTML. Компонент VPA admission-controller не разбирает и не рендерит HTML и не отдаёт контент в браузер — пакет golang.org/x/net/html не входит в путь исполнения компонента.",
+      "timestamp": "2026-07-24T04:45:02.000000Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-27136"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость XSS в golang.org/x/net/html: обход санитизации при разборе и повторном рендеринге HTML. Компонент VPA admission-controller не работает с HTML и не имеет веб-интерфейса — уязвимый код golang.org/x/net/html не достигается ни в одном пути выполнения.",
+      "timestamp": "2026-07-24T04:45:02.000000Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-33814"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "Уязвимость DoS в HTTP/2-транспорте golang.org/x/net: при получении SETTINGS-фрейма со значением SETTINGS_MAX_FRAME_SIZE=0 транспорт входит в бесконечный цикл записи CONTINUATION-фреймов. Хотя HTTP/2-клиент используется (client-go), вредоносный SETTINGS-фрейм может прийти только от сервера, к которому подключается admission-controller, — а это исключительно доверенный in-cluster kube-apiserver. Сетевой атакующий не может внедрить такой фрейм, поэтому уязвимый код не контролируется злоумышленником.",
+      "timestamp": "2026-07-24T04:45:02.000000Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39821"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость в golang.org/x/net/idna: функции ToASCII/ToUnicode некорректно принимают Punycode-метки, декодируемые в ASCII-only имя, что может привести к повышению привилегий в программах, выполняющих проверки прав по имени хоста. Компонент VPA admission-controller не выполняет авторизацию или проверки привилегий по именам хостов и подключается только к доверенному in-cluster kube-apiserver — уязвимый путь idna не задействован.",
+      "timestamp": "2026-07-24T04:45:02.000000Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39822"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/stdlib@v1.26.4"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость CWE-61 (переход по символьной ссылке, symlink following) в Go stdlib v1.26.4 (API os.Root): при открытии файла внутри os.Root финальная символьная ссылка с путём, оканчивающимся на «/», может вести за пределы корня. Компонент VPA admission-controller не использует sandbox-API os.Root и не обрабатывает произвольные пути файловой системы от недоверенных пользователей — уязвимый код не достигается. Бамп Go toolchain будет выполнен в рамках планового апгрейда базовых образов.",
+      "timestamp": "2026-07-24T04:45:02.000000Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-47911"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость DoS в golang.org/x/net/html: квадратичная сложность html.Parse на специально сформированном HTML. Компонент VPA admission-controller не разбирает и не рендерит HTML — пакет golang.org/x/net/html не входит в путь исполнения компонента.",
+      "timestamp": "2026-07-24T04:45:02.000000Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-58190"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость DoS в golang.org/x/net/html: бесконечный цикл разбора в html.Parse на определённом вводе. Компонент VPA admission-controller не разбирает и не рендерит HTML — уязвимый код golang.org/x/net/html не достигается ни в одном пути выполнения.",
+      "timestamp": "2026-07-24T04:45:02.000000Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-25680"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость DoS в golang.org/x/net/html: разбор произвольного HTML может потреблять чрезмерное время CPU. Компонент VPA admission-controller не разбирает и не рендерит HTML — уязвимый код не достигается ни в одном пути выполнения.",
+      "timestamp": "2026-07-24T04:45:02.000000Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-42502"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость XSS в golang.org/x/net/html: разбор произвольного HTML с последующим Render может давать неожиданное дерево HTML. Компонент VPA admission-controller не разбирает и не рендерит HTML — уязвимый код не входит в путь исполнения компонента.",
+      "timestamp": "2026-07-24T04:45:02.000000Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-42506"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость XSS в golang.org/x/net/html: обход санитизации при разборе и повторном рендеринге HTML. Компонент VPA admission-controller не работает с HTML и не имеет веб-интерфейса — уязвимый код не достигается ни в одном пути выполнения.",
+      "timestamp": "2026-07-24T04:45:02.000000Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-42505"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/stdlib@v1.26.4"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость раскрытия информации CWE-201 в Go stdlib v1.26.4 (crypto/tls, Encrypted Client Hello): при использовании ECH идентификаторы pre-shared key раскрываются в незашифрованном ClientHello, что позволяет пассивному наблюдателю деанонимизировать рукопожатие. Компонент VPA admission-controller и client-go не включают ECH (требуется явная настройка EncryptedClientHelloConfigList, по умолчанию выключена), а TLS-соединения устанавливаются только к доверенному in-cluster kube-apiserver — уязвимый путь ECH не задействован. Бамп Go toolchain будет выполнен в рамках планового апгрейда базовых образов.",
+      "timestamp": "2026-07-24T04:45:02.000000Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-46600"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость в golang.org/x/net/dns/dnsmessage: разбор некорректной SVCB- или HTTPS-записи ресурса может вызвать панику из-за переполнения буфера сообщения. Компонент VPA admission-controller не использует golang.org/x/net/dns/dnsmessage: разрешение имён выполняется штатным резолвером Go/ОС, DNS-сообщения компонент не разбирает — уязвимый код не достигается ни в одном пути выполнения.",
+      "timestamp": "2026-07-24T04:45:02.000000Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39824"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/sys"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "Уязвимость в golang.org/x/sys/windows: функция NewNTUnicodeString не проверяет переполнение длины строки и возвращает усечённую строку. Компонент VPA admission-controller собирается с GOOS=linux; файлы golang.org/x/sys/windows исключены ограничениями сборки (//go:build windows) и не компилируются в linux-бинарник — уязвимый код в артефакте отсутствует.",
+      "timestamp": "2026-07-24T04:45:02.000000Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-56852"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/text"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "Уязвимость DoS в golang.org/x/text: norm.Iter может войти в бесконечный цикл при обработке ввода с некорректными байтами UTF-8. В компоненте VPA admission-controller пакет golang.org/x/text/unicode/norm задействуется лишь косвенно через golang.org/x/net/idna при нормализации имени хоста во время исходящего TLS-подключения — а это исключительно доверенный in-cluster kube-apiserver с валидным ASCII-именем. Недоверенные данные (имена и метки объектов из API) через нормализацию не проходят, поэтому уязвимый код не контролируется злоумышленником.",
+      "timestamp": "2026-07-24T04:45:02.000000Z"
+    }
+  ],
+  "timestamp": "2026-07-24T04:45:02Z",
+  "last_updated": "2026-07-24T04:45:02Z"
+}

--- a/modules/302-vertical-pod-autoscaler/images/admission-controller/werf.inc.yaml
+++ b/modules/302-vertical-pod-autoscaler/images/admission-controller/werf.inc.yaml
@@ -12,3 +12,5 @@ imageSpec:
   config:
     entrypoint: ["/admission-controller"]
     cmd: ["--v=4", "--stderrthreshold=info"]
+---
+{{- include "vex mitigation" (list $ (printf "%s/%s" $.ModuleName $.ImageName)) }}

--- a/modules/302-vertical-pod-autoscaler/images/recommender/known_vulnerabilities.vex
+++ b/modules/302-vertical-pod-autoscaler/images/recommender/known_vulnerabilities.vex
@@ -1,0 +1,206 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-e6fedb7843f73eccb89ecc213e3e4b27fbe597ba3f26ee8ea8f34c9b3ccc5efb",
+  "author": "Deckhouse <contact@deckhouse.io>",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-25681"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость XSS в golang.org/x/net/html: разбор произвольного HTML с последующим Render может давать неожиданное дерево HTML. Компонент VPA recommender не разбирает и не рендерит HTML и не отдаёт контент в браузер — пакет golang.org/x/net/html не входит в путь исполнения компонента.",
+      "timestamp": "2026-07-24T04:45:02.000000Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-27136"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость XSS в golang.org/x/net/html: обход санитизации при разборе и повторном рендеринге HTML. Компонент VPA recommender не работает с HTML и не имеет веб-интерфейса — уязвимый код golang.org/x/net/html не достигается ни в одном пути выполнения.",
+      "timestamp": "2026-07-24T04:45:02.000000Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-33814"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "Уязвимость DoS в HTTP/2-транспорте golang.org/x/net: при получении SETTINGS-фрейма со значением SETTINGS_MAX_FRAME_SIZE=0 транспорт входит в бесконечный цикл записи CONTINUATION-фреймов. Хотя HTTP/2-клиент используется (client-go), вредоносный SETTINGS-фрейм может прийти только от сервера, к которому подключается recommender, — а это доверенный in-cluster kube-apiserver и доверенный in-cluster aggregating-proxy (Prometheus). Сетевой атакующий не может внедрить такой фрейм, поэтому уязвимый код не контролируется злоумышленником.",
+      "timestamp": "2026-07-24T04:45:02.000000Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39821"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость в golang.org/x/net/idna: функции ToASCII/ToUnicode некорректно принимают Punycode-метки, декодируемые в ASCII-only имя, что может привести к повышению привилегий в программах, выполняющих проверки прав по имени хоста. Компонент VPA recommender не выполняет авторизацию или проверки привилегий по именам хостов и подключается только к доверенным in-cluster endpoints (kube-apiserver и aggregating-proxy) — уязвимый путь idna не задействован.",
+      "timestamp": "2026-07-24T04:45:02.000000Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39822"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/stdlib@v1.26.4"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость CWE-61 (переход по символьной ссылке, symlink following) в Go stdlib v1.26.4 (API os.Root): при открытии файла внутри os.Root финальная символьная ссылка с путём, оканчивающимся на «/», может вести за пределы корня. Компонент VPA recommender не использует sandbox-API os.Root и не обрабатывает произвольные пути файловой системы от недоверенных пользователей — уязвимый код не достигается. Бамп Go toolchain будет выполнен в рамках планового апгрейда базовых образов.",
+      "timestamp": "2026-07-24T04:45:02.000000Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-47911"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость DoS в golang.org/x/net/html: квадратичная сложность html.Parse на специально сформированном HTML. Компонент VPA recommender не разбирает и не рендерит HTML — пакет golang.org/x/net/html не входит в путь исполнения компонента.",
+      "timestamp": "2026-07-24T04:45:02.000000Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-58190"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость DoS в golang.org/x/net/html: бесконечный цикл разбора в html.Parse на определённом вводе. Компонент VPA recommender не разбирает и не рендерит HTML — уязвимый код golang.org/x/net/html не достигается ни в одном пути выполнения.",
+      "timestamp": "2026-07-24T04:45:02.000000Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-25680"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость DoS в golang.org/x/net/html: разбор произвольного HTML может потреблять чрезмерное время CPU. Компонент VPA recommender не разбирает и не рендерит HTML — уязвимый код не достигается ни в одном пути выполнения.",
+      "timestamp": "2026-07-24T04:45:02.000000Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-42502"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость XSS в golang.org/x/net/html: разбор произвольного HTML с последующим Render может давать неожиданное дерево HTML. Компонент VPA recommender не разбирает и не рендерит HTML — уязвимый код не входит в путь исполнения компонента.",
+      "timestamp": "2026-07-24T04:45:02.000000Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-42506"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость XSS в golang.org/x/net/html: обход санитизации при разборе и повторном рендеринге HTML. Компонент VPA recommender не работает с HTML и не имеет веб-интерфейса — уязвимый код не достигается ни в одном пути выполнения.",
+      "timestamp": "2026-07-24T04:45:02.000000Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-42505"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/stdlib@v1.26.4"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость раскрытия информации CWE-201 в Go stdlib v1.26.4 (crypto/tls, Encrypted Client Hello): при использовании ECH идентификаторы pre-shared key раскрываются в незашифрованном ClientHello, что позволяет пассивному наблюдателю деанонимизировать рукопожатие. Компонент VPA recommender и client-go не включают ECH (требуется явная настройка EncryptedClientHelloConfigList, по умолчанию выключена), а TLS-соединения устанавливаются только к доверенным in-cluster endpoints (kube-apiserver и aggregating-proxy) — уязвимый путь ECH не задействован. Бамп Go toolchain будет выполнен в рамках планового апгрейда базовых образов.",
+      "timestamp": "2026-07-24T04:45:02.000000Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-46600"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость в golang.org/x/net/dns/dnsmessage: разбор некорректной SVCB- или HTTPS-записи ресурса может вызвать панику из-за переполнения буфера сообщения. Компонент VPA recommender не использует golang.org/x/net/dns/dnsmessage: разрешение имён выполняется штатным резолвером Go/ОС, DNS-сообщения компонент не разбирает — уязвимый код не достигается ни в одном пути выполнения.",
+      "timestamp": "2026-07-24T04:45:02.000000Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39824"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/sys"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "Уязвимость в golang.org/x/sys/windows: функция NewNTUnicodeString не проверяет переполнение длины строки и возвращает усечённую строку. Компонент VPA recommender собирается с GOOS=linux; файлы golang.org/x/sys/windows исключены ограничениями сборки (//go:build windows) и не компилируются в linux-бинарник — уязвимый код в артефакте отсутствует.",
+      "timestamp": "2026-07-24T04:45:02.000000Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-56852"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/text"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "Уязвимость DoS в golang.org/x/text: norm.Iter может войти в бесконечный цикл при обработке ввода с некорректными байтами UTF-8. В компоненте VPA recommender пакет golang.org/x/text/unicode/norm задействуется лишь косвенно через golang.org/x/net/idna при нормализации имени хоста во время исходящего TLS-подключения — а это исключительно доверенные in-cluster endpoints (kube-apiserver и aggregating-proxy) с валидными ASCII-именами. Недоверенные данные (имена и метки объектов из API) через нормализацию не проходят, поэтому уязвимый код не контролируется злоумышленником.",
+      "timestamp": "2026-07-24T04:45:02.000000Z"
+    }
+  ],
+  "timestamp": "2026-07-24T04:45:02Z",
+  "last_updated": "2026-07-24T04:45:02Z"
+}

--- a/modules/302-vertical-pod-autoscaler/images/recommender/werf.inc.yaml
+++ b/modules/302-vertical-pod-autoscaler/images/recommender/werf.inc.yaml
@@ -9,3 +9,5 @@ import:
 imageSpec:
   config:
     entrypoint: ["/recommender"]
+---
+{{- include "vex mitigation" (list $ (printf "%s/%s" $.ModuleName $.ImageName)) }}

--- a/modules/302-vertical-pod-autoscaler/images/updater/known_vulnerabilities.vex
+++ b/modules/302-vertical-pod-autoscaler/images/updater/known_vulnerabilities.vex
@@ -1,0 +1,206 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-b2c9684837488baf55ff30d83e5ca5b0c331dfa469194e5c76d754a8932a6013",
+  "author": "Deckhouse <contact@deckhouse.io>",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-25681"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость XSS в golang.org/x/net/html: разбор произвольного HTML с последующим Render может давать неожиданное дерево HTML. Компонент VPA updater не разбирает и не рендерит HTML и не отдаёт контент в браузер — пакет golang.org/x/net/html не входит в путь исполнения компонента.",
+      "timestamp": "2026-07-24T04:45:02.000000Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-27136"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость XSS в golang.org/x/net/html: обход санитизации при разборе и повторном рендеринге HTML. Компонент VPA updater не работает с HTML и не имеет веб-интерфейса — уязвимый код golang.org/x/net/html не достигается ни в одном пути выполнения.",
+      "timestamp": "2026-07-24T04:45:02.000000Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-33814"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "Уязвимость DoS в HTTP/2-транспорте golang.org/x/net: при получении SETTINGS-фрейма со значением SETTINGS_MAX_FRAME_SIZE=0 транспорт входит в бесконечный цикл записи CONTINUATION-фреймов. Хотя HTTP/2-клиент используется (client-go), вредоносный SETTINGS-фрейм может прийти только от сервера, к которому подключается updater, — а это исключительно доверенный in-cluster kube-apiserver. Сетевой атакующий не может внедрить такой фрейм, поэтому уязвимый код не контролируется злоумышленником.",
+      "timestamp": "2026-07-24T04:45:02.000000Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39821"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость в golang.org/x/net/idna: функции ToASCII/ToUnicode некорректно принимают Punycode-метки, декодируемые в ASCII-only имя, что может привести к повышению привилегий в программах, выполняющих проверки прав по имени хоста. Компонент VPA updater не выполняет авторизацию или проверки привилегий по именам хостов и подключается только к доверенному in-cluster kube-apiserver — уязвимый путь idna не задействован.",
+      "timestamp": "2026-07-24T04:45:02.000000Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39822"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/stdlib@v1.26.4"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость CWE-61 (переход по символьной ссылке, symlink following) в Go stdlib v1.26.4 (API os.Root): при открытии файла внутри os.Root финальная символьная ссылка с путём, оканчивающимся на «/», может вести за пределы корня. Компонент VPA updater не использует sandbox-API os.Root и не обрабатывает произвольные пути файловой системы от недоверенных пользователей — уязвимый код не достигается. Бамп Go toolchain будет выполнен в рамках планового апгрейда базовых образов.",
+      "timestamp": "2026-07-24T04:45:02.000000Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-47911"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость DoS в golang.org/x/net/html: квадратичная сложность html.Parse на специально сформированном HTML. Компонент VPA updater не разбирает и не рендерит HTML — пакет golang.org/x/net/html не входит в путь исполнения компонента.",
+      "timestamp": "2026-07-24T04:45:02.000000Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-58190"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость DoS в golang.org/x/net/html: бесконечный цикл разбора в html.Parse на определённом вводе. Компонент VPA updater не разбирает и не рендерит HTML — уязвимый код golang.org/x/net/html не достигается ни в одном пути выполнения.",
+      "timestamp": "2026-07-24T04:45:02.000000Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-25680"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость DoS в golang.org/x/net/html: разбор произвольного HTML может потреблять чрезмерное время CPU. Компонент VPA updater не разбирает и не рендерит HTML — уязвимый код не достигается ни в одном пути выполнения.",
+      "timestamp": "2026-07-24T04:45:02.000000Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-42502"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость XSS в golang.org/x/net/html: разбор произвольного HTML с последующим Render может давать неожиданное дерево HTML. Компонент VPA updater не разбирает и не рендерит HTML — уязвимый код не входит в путь исполнения компонента.",
+      "timestamp": "2026-07-24T04:45:02.000000Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-42506"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость XSS в golang.org/x/net/html: обход санитизации при разборе и повторном рендеринге HTML. Компонент VPA updater не работает с HTML и не имеет веб-интерфейса — уязвимый код не достигается ни в одном пути выполнения.",
+      "timestamp": "2026-07-24T04:45:02.000000Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-42505"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/stdlib@v1.26.4"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость раскрытия информации CWE-201 в Go stdlib v1.26.4 (crypto/tls, Encrypted Client Hello): при использовании ECH идентификаторы pre-shared key раскрываются в незашифрованном ClientHello, что позволяет пассивному наблюдателю деанонимизировать рукопожатие. Компонент VPA updater и client-go не включают ECH (требуется явная настройка EncryptedClientHelloConfigList, по умолчанию выключена), а TLS-соединения устанавливаются только к доверенному in-cluster kube-apiserver — уязвимый путь ECH не задействован. Бамп Go toolchain будет выполнен в рамках планового апгрейда базовых образов.",
+      "timestamp": "2026-07-24T04:45:02.000000Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-46600"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость в golang.org/x/net/dns/dnsmessage: разбор некорректной SVCB- или HTTPS-записи ресурса может вызвать панику из-за переполнения буфера сообщения. Компонент VPA updater не использует golang.org/x/net/dns/dnsmessage: разрешение имён выполняется штатным резолвером Go/ОС, DNS-сообщения компонент не разбирает — уязвимый код не достигается ни в одном пути выполнения.",
+      "timestamp": "2026-07-24T04:45:02.000000Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39824"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/sys"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "Уязвимость в golang.org/x/sys/windows: функция NewNTUnicodeString не проверяет переполнение длины строки и возвращает усечённую строку. Компонент VPA updater собирается с GOOS=linux; файлы golang.org/x/sys/windows исключены ограничениями сборки (//go:build windows) и не компилируются в linux-бинарник — уязвимый код в артефакте отсутствует.",
+      "timestamp": "2026-07-24T04:45:02.000000Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-56852"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/text"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "Уязвимость DoS в golang.org/x/text: norm.Iter может войти в бесконечный цикл при обработке ввода с некорректными байтами UTF-8. В компоненте VPA updater пакет golang.org/x/text/unicode/norm задействуется лишь косвенно через golang.org/x/net/idna при нормализации имени хоста во время исходящего TLS-подключения — а это исключительно доверенный in-cluster kube-apiserver с валидным ASCII-именем. Недоверенные данные (имена и метки объектов из API) через нормализацию не проходят, поэтому уязвимый код не контролируется злоумышленником.",
+      "timestamp": "2026-07-24T04:45:02.000000Z"
+    }
+  ],
+  "timestamp": "2026-07-24T04:45:02Z",
+  "last_updated": "2026-07-24T04:45:02Z"
+}

--- a/modules/302-vertical-pod-autoscaler/images/updater/werf.inc.yaml
+++ b/modules/302-vertical-pod-autoscaler/images/updater/werf.inc.yaml
@@ -10,3 +10,5 @@ imageSpec:
   config:
     entrypoint: ["/updater"]
     cmd: ["--v=4", "--stderrthreshold=info"]
+---
+{{- include "vex mitigation" (list $ (printf "%s/%s" $.ModuleName $.ImageName)) }}

--- a/testing/library/images_tags_generated.go
+++ b/testing/library/images_tags_generated.go
@@ -644,8 +644,11 @@ var DefaultImagesDigests = map[string]interface{}{
 		"webhook": "imageHash-userAuthz-webhook",
 	},
 	"verticalPodAutoscaler": map[string]interface{}{
-		"admissionController": "imageHash-verticalPodAutoscaler-admissionController",
-		"recommender":         "imageHash-verticalPodAutoscaler-recommender",
-		"updater":             "imageHash-verticalPodAutoscaler-updater",
+		"admissionController":            "imageHash-verticalPodAutoscaler-admissionController",
+		"admissionControllerVexArtifact": "imageHash-verticalPodAutoscaler-admissionControllerVexArtifact",
+		"recommender":                    "imageHash-verticalPodAutoscaler-recommender",
+		"recommenderVexArtifact":         "imageHash-verticalPodAutoscaler-recommenderVexArtifact",
+		"updater":                        "imageHash-verticalPodAutoscaler-updater",
+		"updaterVexArtifact":             "imageHash-verticalPodAutoscaler-updaterVexArtifact",
 	},
 }


### PR DESCRIPTION
## Description

Add VEX `not_affected` statements for CVEs reported by the Trivy scan against Vertical Pod Autoscaler images (`admission-controller`, `recommender`, `updater`) 
Affected packages are present only as transitive dependencies (or are unreachable / not compiled into the Linux binary). VPA  do not use SSH, HTML parsing, Windows-specific APIs, OpenPGP, `os.Root` sandboxing, or runc container runtime paths in their execution flow. HTTP/2 client connections go only to trusted in-cluster endpoints (kube-apiserver, monitoring aggregating-proxy for recommender) and configured cloud-provider APIs.

### Closed vulnerabilities (VEX `not_affected`)

#### Vertical Pod Autoscaler (`admission-controller`, `recommender`, `updater`)

##### `golang.org/x/net` (html / idna / http2 / dns)

- CVE-2025-47911
- CVE-2025-58190
- CVE-2026-25680
- CVE-2026-25681
- CVE-2026-27136
- CVE-2026-33814
- CVE-2026-39821
- CVE-2026-42502
- CVE-2026-42506
- CVE-2026-46600

##### Go stdlib `v1.26.4`

- CVE-2026-39822 (`os.Root` symlink following)
- CVE-2026-42505 (`crypto/tls` ECH information disclosure)

##### Other

- CVE-2026-39824 (`golang.org/x/sys/windows` — not present in Linux build)
- CVE-2026-56852 (`golang.org/x/text` unicode normalization DoS)

Status: `not_affected` (mainly `vulnerable_code_not_in_execute_path`, plus `vulnerable_code_not_present` / `vulnerable_code_cannot_be_controlled_by_adversary` where applicable).

## Why do we need it, and what problem does it solve?

Trivy reports High/Medium/Info findings in transitive Go dependencies of VPA images. These findings are not exploitable in the runtime context of these components, so VEX statements suppress false positives in security scans without changing application code.

## Why do we need it in the patch release (if we do)?

Needed for the patch release to clear known false-positive CVEs from security reports for VPA images in 1.73.x.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: vertical-pod-autoscaler
type: chore
summary: add vex statements for CVEs in x/net, x/sys, x/text and stdlib
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
