### PR TITLE
[dhctl] install deckhouse: reformat installing resources view

### DIFF
--- a/dhctl/pkg/kubernetes/actions/resources/resources.go
+++ b/dhctl/pkg/kubernetes/actions/resources/resources.go
@@ -325,14 +325,22 @@ func CreateResourcesLoop(
 
 	waiter := NewWaiter(checkers)
 
-	gvks := make(map[string]struct{})
-	resourcesToCreate := make([]string, 0, len(resourceCreator.resources))
-	for _, resource := range resourceCreator.resources {
-		key := resource.DetailedGVKString()
-		if _, ok := gvks[key]; !ok {
-			gvks[key] = struct{}{}
-			resourcesToCreate = append(resourcesToCreate, key)
+	// List each object on its own line so operators see which resources are actually
+	// applied. The old output deduplicated by GVK, hiding distinct instances (a single
+	// "Kind=ModuleConfig" line stood in for 15 different ModuleConfigs). Labels are padded
+	// to a common width so the instance names line up in a column.
+	labels := make([]string, len(resourceCreator.resources))
+	names := make([]string, len(resourceCreator.resources))
+	maxLabel := 0
+	for i, resource := range resourceCreator.resources {
+		labels[i], names[i] = resourceListParts(resource)
+		if len(labels[i]) > maxLabel {
+			maxLabel = len(labels[i])
 		}
+	}
+	resourcesToCreate := make([]string, len(resourceCreator.resources))
+	for i := range resourcesToCreate {
+		resourcesToCreate[i] = fmt.Sprintf("%-*s %s", maxLabel, labels[i], names[i])
 	}
 
 	_ = dhlog.RunProcess(ctx, dhlog.FromContext(ctx), "Resources to create", func(ctx context.Context) error {
@@ -458,6 +466,25 @@ func getUnstructuredName(obj *unstructured.Unstructured) string {
 		return fmt.Sprintf("%s %s", obj.GetKind(), obj.GetName())
 	}
 	return fmt.Sprintf("%s %s/%s", obj.GetKind(), obj.GetNamespace(), obj.GetName())
+}
+
+// resourceListParts splits one object into its type label and instance name for the
+// "Resources to create" listing. The label is "Kind[ (group/version)]:"; the group/version
+// is shown only for non-core groups, since core resources (Namespace, ServiceAccount, …)
+// are self-evident, but a custom resource's version can matter (e.g. across module API
+// migrations). The name is "[namespace/]name", namespaced only for namespaced objects.
+func resourceListParts(r *template.Resource) (label, name string) {
+	label = r.GVK.Kind
+	if r.GVK.Group != "" {
+		label += " (" + r.GVK.Group + "/" + r.GVK.Version + ")"
+	}
+	label += ":"
+
+	name = r.Object.GetName()
+	if ns := r.Object.GetNamespace(); ns != "" {
+		name = ns + "/" + name
+	}
+	return label, name
 }
 
 func DeleteResourcesLoop(ctx context.Context, kubeCl *client.KubernetesClient, resources template.Resources) error {

--- a/dhctl/pkg/kubernetes/actions/resources/resources.go
+++ b/dhctl/pkg/kubernetes/actions/resources/resources.go
@@ -473,14 +473,14 @@ func getUnstructuredName(obj *unstructured.Unstructured) string {
 // is shown only for non-core groups, since core resources (Namespace, ServiceAccount, …)
 // are self-evident, but a custom resource's version can matter (e.g. across module API
 // migrations). The name is "[namespace/]name", namespaced only for namespaced objects.
-func resourceListParts(r *template.Resource) (label, name string) {
-	label = r.GVK.Kind
+func resourceListParts(r *template.Resource) (string, string) {
+	label := r.GVK.Kind
 	if r.GVK.Group != "" {
 		label += " (" + r.GVK.Group + "/" + r.GVK.Version + ")"
 	}
 	label += ":"
 
-	name = r.Object.GetName()
+	name := r.Object.GetName()
 	if ns := r.Object.GetNamespace(); ns != "" {
 		name = ns + "/" + name
 	}


### PR DESCRIPTION
## Description

Before:

```
  │ ┌ Resources to create                                                                                                                                                                                                                  
  │ │ ApiVersion=v1, Kind=Namespace                                                                                                                                                                                                        
  │ │ ApiVersion=v1, Kind=ServiceAccount                                                                                                                                                                                                   
  │ │ ApiVersion=v1, Kind=Secret                                                                                                                                                                                                           
  │ │ ApiVersion=v1, Kind=ConfigMap                                                                                                                                                                                                        
  │ │ Group=deckhouse.io, ApiVersion=v1alpha1, Kind=LocalPathProvisioner                                                                                                                                                                   
  │ │ Group=deckhouse.io, ApiVersion=v1alpha1, Kind=ModuleConfig                                                                                                                                                                           
  │ └ Resources to create (0.00 seconds)  
```

After:

```
│ ┌ Resources to create
│ │ Namespace:                                    d8-local-path-provisioner
│ │ ServiceAccount:                               d8-local-path-provisioner/local-path-provisioner
│ │ Secret:                                       d8-local-path-provisioner/deckhouse-registry
│ │ ConfigMap:                                    d8-local-path-provisioner/local-path-provisioner
│ │ LocalPathProvisioner (deckhouse.io/v1alpha1): local-path-storage
│ │ ModuleConfig (deckhouse.io/v1alpha1):         deckhouse
│ │ ModuleConfig (deckhouse.io/v1alpha1):         cni-cilium
│ │ ModuleConfig (deckhouse.io/v1alpha1):         global
│ └ Resources to create (0.00 seconds)  
```

This is a logging-only change in `dhctl/pkg/kubernetes/actions/resources/resources.go`. No change to what gets applied or in what order. **No impact on running components.**

## Why do we need it, and what problem does it solve?

The bootstrap output was uninformative: the deduplicated GVK list hid the actual objects, so operators reading the log could not verify which resources (and how many) were being created. Listing each object restores that visibility.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: dhctl
type: chore
summary: List each object individually in the "Resources to create" bootstrap output instead of a deduplicated GVK list.
impact_level: low
```
