### PR TITLE
[node-manager] Expand cluster role permissions to include scaling for MachineSets and MachinePools.

### DIFF
--- a/modules/040-node-manager/templates/user-authz-cluster-roles.yaml
+++ b/modules/040-node-manager/templates/user-authz-cluster-roles.yaml
@@ -119,6 +119,8 @@ rules:
   - machinehealthchecks
   - clusters
   - machinedeployments/scale
+  - machinesets/scale
+  - machinepools/scale
   verbs:
   - create
   - update

--- a/modules/140-user-authz/docs/README.md
+++ b/modules/140-user-authz/docs/README.md
@@ -586,6 +586,8 @@ write:
     - cilium.io/ciliumclusterwidenetworkpolicies
     - cilium.io/ciliumnetworkpolicies
     - cluster.x-k8s.io/machinedeployments/scale
+    - cluster.x-k8s.io/machinepools/scale
+    - cluster.x-k8s.io/machinesets/scale
     - config.gatekeeper.sh/configs
     - connection.gatekeeper.sh/connections
     - constraints.gatekeeper.sh/*

--- a/modules/140-user-authz/docs/README_RU.md
+++ b/modules/140-user-authz/docs/README_RU.md
@@ -592,6 +592,8 @@ write:
     - cilium.io/ciliumclusterwidenetworkpolicies
     - cilium.io/ciliumnetworkpolicies
     - cluster.x-k8s.io/machinedeployments/scale
+    - cluster.x-k8s.io/machinepools/scale
+    - cluster.x-k8s.io/machinesets/scale
     - config.gatekeeper.sh/configs
     - connection.gatekeeper.sh/connections
     - constraints.gatekeeper.sh/*


### PR DESCRIPTION
## Description
Extend the `d8:user-authz:node-manager:cluster-admin` ClusterRole with write access to the `machinesets/scale` and `machinepools/scale` subresources in the `cluster.x-k8s.io` API group. Follow-up to #19677, which added `machinedeployments/scale` to the same rule but left the two sibling scale subresources uncovered.

No workloads or controllers are restarted by this change — it only updates a static ClusterRole manifest rendered by the node-manager Helm chart.

Scope of the change is intentionally limited to cluster.x-k8s.io. The MCM MachineSet / MachineDeployment CRDs (machine.sapcloud.io) declare only the status subresource; adding machinesets/scale there would be a no-op against the API server.

## Why do we need it, and what problem does it solve?

After #19677 a ClusterAdmin operator could kubectl scale a MachineDeployment in the cluster.x-k8s.io group, but the same operation on a MachineSet or MachinePool would fail with forbidden and require escalating to SuperAdmin. That is inconsistent with ClusterAdmin already having full CRUD on the MachineSet / MachinePool parent resources.

Practical scenarios unblocked by this change:

- symmetric coverage of all three CAPI scalable resources for ClusterAdmin;
- ability to use kubectl scale machineset/… and kubectl scale machinepool/… without escalating.

In Deckhouse's default setup cluster-autoscaler scales only MachineDeployments and MachineSets owned by them are reconciled back by the MachineDeployment controller, so the primary consumer of this permission is a human operator, not an automated component.
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: feature
summary: Extend `ClusterAdmin` RBAC with `machinesets/scale` and `machinepools/scale` in `cluster.x-k8s.io`, for symmetry with the existing `machinedeployments/scale` permission.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
