### PR TITLE
[candi] Final migration go-build artifacts to native builder/golang

### DIFF
--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -4074,7 +4074,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:5f08b1ad99579ad9a602f78f565b85651bd3256cd4373068b73f9d3c906cec8b"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:b341355bc9d4f164891f1e77b44c2569290b18218e6c7a2976d931d1fc571b39"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'
@@ -4189,7 +4189,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run node-controller tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:5f08b1ad99579ad9a602f78f565b85651bd3256cd4373068b73f9d3c906cec8b"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:b341355bc9d4f164891f1e77b44c2569290b18218e6c7a2976d931d1fc571b39"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -4074,7 +4074,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:50cc08c2e61e6ecd8e6586ab4e91f47f3eefadebf9a26a126b99a082362c0769"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:5f08b1ad99579ad9a602f78f565b85651bd3256cd4373068b73f9d3c906cec8b"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'
@@ -4189,7 +4189,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run node-controller tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:50cc08c2e61e6ecd8e6586ab4e91f47f3eefadebf9a26a126b99a082362c0769"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:5f08b1ad99579ad9a602f78f565b85651bd3256cd4373068b73f9d3c906cec8b"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -4074,7 +4074,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:b341355bc9d4f164891f1e77b44c2569290b18218e6c7a2976d931d1fc571b39"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:266bb6f1223a85a03e9a91c4debd7cc3be46ee2a845bde9c6feae7a310b984e7"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'
@@ -4189,7 +4189,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run node-controller tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:b341355bc9d4f164891f1e77b44c2569290b18218e6c7a2976d931d1fc571b39"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:266bb6f1223a85a03e9a91c4debd7cc3be46ee2a845bde9c6feae7a310b984e7"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/.github/workflows/build-and-test_main.yml
+++ b/.github/workflows/build-and-test_main.yml
@@ -1354,7 +1354,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:50cc08c2e61e6ecd8e6586ab4e91f47f3eefadebf9a26a126b99a082362c0769"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:5f08b1ad99579ad9a602f78f565b85651bd3256cd4373068b73f9d3c906cec8b"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/.github/workflows/build-and-test_main.yml
+++ b/.github/workflows/build-and-test_main.yml
@@ -1354,7 +1354,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:5f08b1ad99579ad9a602f78f565b85651bd3256cd4373068b73f9d3c906cec8b"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:b341355bc9d4f164891f1e77b44c2569290b18218e6c7a2976d931d1fc571b39"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/.github/workflows/build-and-test_main.yml
+++ b/.github/workflows/build-and-test_main.yml
@@ -1354,7 +1354,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:b341355bc9d4f164891f1e77b44c2569290b18218e6c7a2976d931d1fc571b39"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:266bb6f1223a85a03e9a91c4debd7cc3be46ee2a845bde9c6feae7a310b984e7"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -3686,7 +3686,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:50cc08c2e61e6ecd8e6586ab4e91f47f3eefadebf9a26a126b99a082362c0769"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:5f08b1ad99579ad9a602f78f565b85651bd3256cd4373068b73f9d3c906cec8b"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -3686,7 +3686,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:b341355bc9d4f164891f1e77b44c2569290b18218e6c7a2976d931d1fc571b39"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:266bb6f1223a85a03e9a91c4debd7cc3be46ee2a845bde9c6feae7a310b984e7"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -3686,7 +3686,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:5f08b1ad99579ad9a602f78f565b85651bd3256cd4373068b73f9d3c906cec8b"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:b341355bc9d4f164891f1e77b44c2569290b18218e6c7a2976d931d1fc571b39"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/candi/alt_base_images.yml
+++ b/candi/alt_base_images.yml
@@ -1,9 +1,9 @@
-# version=v1.3.9
+# version=v1.3.18
 REGISTRY_PATH: registry.deckhouse.io/container-factory
 base/distroless-fin: "sha256:014bf210c5e13d1e2ea968979a9cc5527d60a6d10ecedd51f97b6dd0dc7d554b" # from: builder/scratch
-builder/distroless: "sha256:4a8c6e8084386e5afa35c2074429942d55cb20a7efb2a28090bc51451fe60c5e" # from: builder/scratch
-builder/golang-1.25: "sha256:917fae1374278f88b120713d7c078ac2c0ed3f654613d9cf4584c61536df18c7" # from: builder/distroless
-builder/golang-1.26: "sha256:50cc08c2e61e6ecd8e6586ab4e91f47f3eefadebf9a26a126b99a082362c0769" # from: builder/distroless
-builder/golang: "sha256:50cc08c2e61e6ecd8e6586ab4e91f47f3eefadebf9a26a126b99a082362c0769" # from: builder/distroless
+builder/distroless: "sha256:0f2cb1696929a387d43a7ed1489d9536be101ac5509611571063cd3045aa3096" # from: builder/scratch
+builder/golang-1.25: "sha256:3dd7bab46856cc9de2847d27777a8a32663c70c9f6f7b245c44f0651c6402d36" # from: builder/distroless
+builder/golang-1.26: "sha256:5f08b1ad99579ad9a602f78f565b85651bd3256cd4373068b73f9d3c906cec8b" # from: builder/distroless
+builder/golang: "sha256:5f08b1ad99579ad9a602f78f565b85651bd3256cd4373068b73f9d3c906cec8b" # from: builder/distroless
 minget-0.1: "sha256:eb53006583279ce86d498004cc308dfa90993ab3e9d4928f8f400d2ef2b19f9e" # from: builder/scratch
 minget: "sha256:eb53006583279ce86d498004cc308dfa90993ab3e9d4928f8f400d2ef2b19f9e" # from: builder/scratch

--- a/candi/alt_base_images.yml
+++ b/candi/alt_base_images.yml
@@ -1,9 +1,9 @@
-# version=v1.3.19
+# version=v1.3.20
 REGISTRY_PATH: registry.deckhouse.io/container-factory
 base/distroless-fin: "sha256:014bf210c5e13d1e2ea968979a9cc5527d60a6d10ecedd51f97b6dd0dc7d554b" # from: builder/scratch
-builder/distroless: "sha256:670825389836b475179ab8a65a985e037a0c1ab898cc355473275dc92f1315f5" # from: builder/scratch
-builder/golang-1.25: "sha256:cc26cb60e744522d112011f0dcbdee69b40cfe6fe9c88ee7e375623a45f3df26" # from: builder/distroless
-builder/golang-1.26: "sha256:b341355bc9d4f164891f1e77b44c2569290b18218e6c7a2976d931d1fc571b39" # from: builder/distroless
-builder/golang: "sha256:b341355bc9d4f164891f1e77b44c2569290b18218e6c7a2976d931d1fc571b39" # from: builder/distroless
-minget-0.1: "sha256:eb53006583279ce86d498004cc308dfa90993ab3e9d4928f8f400d2ef2b19f9e" # from: builder/scratch
-minget: "sha256:eb53006583279ce86d498004cc308dfa90993ab3e9d4928f8f400d2ef2b19f9e" # from: builder/scratch
+builder/distroless: "sha256:16d4bd4716f516e38cf892bfd83b7d0800e96df3e360fa07741dc986cf373f99" # from: builder/scratch
+builder/golang-1.25: "sha256:b44d90af91e2b67ccbc05f290d628aafefef04590d11689c499d5755d2ecbadc" # from: builder/distroless
+builder/golang-1.26: "sha256:266bb6f1223a85a03e9a91c4debd7cc3be46ee2a845bde9c6feae7a310b984e7" # from: builder/distroless
+builder/golang: "sha256:266bb6f1223a85a03e9a91c4debd7cc3be46ee2a845bde9c6feae7a310b984e7" # from: builder/distroless
+minget-0.1: "sha256:6e37a40153be199ac9d9652072cae7ee4a7a595f9d4de53d04b0ac3b557b658d" # from: builder/scratch
+minget: "sha256:6e37a40153be199ac9d9652072cae7ee4a7a595f9d4de53d04b0ac3b557b658d" # from: builder/scratch

--- a/candi/alt_base_images.yml
+++ b/candi/alt_base_images.yml
@@ -1,9 +1,9 @@
-# version=v1.3.18
+# version=v1.3.19
 REGISTRY_PATH: registry.deckhouse.io/container-factory
 base/distroless-fin: "sha256:014bf210c5e13d1e2ea968979a9cc5527d60a6d10ecedd51f97b6dd0dc7d554b" # from: builder/scratch
-builder/distroless: "sha256:0f2cb1696929a387d43a7ed1489d9536be101ac5509611571063cd3045aa3096" # from: builder/scratch
-builder/golang-1.25: "sha256:3dd7bab46856cc9de2847d27777a8a32663c70c9f6f7b245c44f0651c6402d36" # from: builder/distroless
-builder/golang-1.26: "sha256:5f08b1ad99579ad9a602f78f565b85651bd3256cd4373068b73f9d3c906cec8b" # from: builder/distroless
-builder/golang: "sha256:5f08b1ad99579ad9a602f78f565b85651bd3256cd4373068b73f9d3c906cec8b" # from: builder/distroless
+builder/distroless: "sha256:670825389836b475179ab8a65a985e037a0c1ab898cc355473275dc92f1315f5" # from: builder/scratch
+builder/golang-1.25: "sha256:cc26cb60e744522d112011f0dcbdee69b40cfe6fe9c88ee7e375623a45f3df26" # from: builder/distroless
+builder/golang-1.26: "sha256:b341355bc9d4f164891f1e77b44c2569290b18218e6c7a2976d931d1fc571b39" # from: builder/distroless
+builder/golang: "sha256:b341355bc9d4f164891f1e77b44c2569290b18218e6c7a2976d931d1fc571b39" # from: builder/distroless
 minget-0.1: "sha256:eb53006583279ce86d498004cc308dfa90993ab3e9d4928f8f400d2ef2b19f9e" # from: builder/scratch
 minget: "sha256:eb53006583279ce86d498004cc308dfa90993ab3e9d4928f8f400d2ef2b19f9e" # from: builder/scratch

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/werf.inc.yaml
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/werf.inc.yaml
@@ -19,7 +19,7 @@ shell:
     - cd /src
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
-from: {{ index $.Images ( eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alt-svace" ) }}
+from: {{ index $.Images "builder/golang" }}
 final: false
 import:
 - image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact

--- a/ee/be/modules/140-user-authz/images/webhook/werf.inc.yaml
+++ b/ee/be/modules/140-user-authz/images/webhook/werf.inc.yaml
@@ -35,7 +35,7 @@ shell:
     - cd /src
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-user-authz-webhook-artifact
-from: {{ index $.Images ( eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alt-svace" ) }}
+from: {{ index $.Images "builder/golang" }}
 final: false
 import:
   - image: {{ $.ModuleName }}/{{ $.ImageName }}-user-authz-webhook-src-artifact

--- a/ee/be/modules/350-node-local-dns/images/coredns/werf.inc.yaml
+++ b/ee/be/modules/350-node-local-dns/images/coredns/werf.inc.yaml
@@ -25,7 +25,7 @@ shell:
   - cd /src
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 final: false
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact

--- a/ee/be/modules/350-node-local-dns/images/iptables-loop/werf.inc.yaml
+++ b/ee/be/modules/350-node-local-dns/images/iptables-loop/werf.inc.yaml
@@ -26,7 +26,7 @@ shell:
   - cd /src
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 final: false
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact

--- a/ee/cse/modules/007-registrypackages/images/d8-bcheck/werf.inc.yaml
+++ b/ee/cse/modules/007-registrypackages/images/d8-bcheck/werf.inc.yaml
@@ -32,7 +32,7 @@ imageSpec:
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact-{{ $image_version }}
 final: false
-from: {{ index .Images "builder/golang-alpine" }}
+from: {{ index .Images "builder/golang" }}
 mount:
 {{ include "mount points for golang builds" . }}
 import:
@@ -110,8 +110,7 @@ secrets:
   value: {{ .GOPROXY }}
 shell:
   beforeInstall:
-  {{- include "alpine packages proxy" . | nindent 2 }}
-  - apk add --no-cache build-base rsync
+  - pm install build-base rsync
   install:
   - |
     if [[ -d /libs ]]; then

--- a/ee/modules/040-node-manager/images/d8-shutdown-inhibitor/werf.inc.yaml
+++ b/ee/modules/040-node-manager/images/d8-shutdown-inhibitor/werf.inc.yaml
@@ -40,7 +40,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src

--- a/ee/modules/040-node-manager/images/node-feature-discovery/werf.inc.yaml
+++ b/ee/modules/040-node-manager/images/node-feature-discovery/werf.inc.yaml
@@ -22,7 +22,7 @@ shell:
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src

--- a/ee/modules/110-istio/images/alliance-healthcheck/werf.inc.yaml
+++ b/ee/modules/110-istio/images/alliance-healthcheck/werf.inc.yaml
@@ -13,7 +13,7 @@ imageSpec:
     entrypoint: ["/alliance-healthcheck"]
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 final: false
 import:
 - image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
@@ -27,8 +27,7 @@ secrets:
   value: {{ .GOPROXY }}
 shell:
   beforeInstall:
-  {{- include "alpine packages proxy" . | nindent 2 }}
-  - apk add --no-cache bash git binutils
+  - pm install bash git binutils
   install:
   - cd /src
   - GOPROXY=$(cat /run/secrets/GOPROXY) go mod download

--- a/ee/modules/110-istio/images/waypoint-controller/werf.inc.yaml
+++ b/ee/modules/110-istio/images/waypoint-controller/werf.inc.yaml
@@ -12,7 +12,7 @@ imageSpec:
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 git:
   - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/src
     to: /src

--- a/modules/000-common/images/vxlan-offloading-fixer/werf.inc.yaml
+++ b/modules/000-common/images/vxlan-offloading-fixer/werf.inc.yaml
@@ -35,8 +35,7 @@ mount:
 {{ include "mount points for golang builds" . }}
 shell:
   beforeInstall:
-  {{- include "alpine packages proxy" . | nindent 2 }}
-  - pm install autoconf automake libtool build-base linux-headers pkgconf
+  - pm install autoconf m4 automake libtool build-base linux-headers pkgconf
   setup:
   - export PKG_CONFIG_PATH=/opt/deckhouse/bin/.libs/pkgconfig
   - cd /src/libmnl

--- a/modules/000-common/images/vxlan-offloading-fixer/werf.inc.yaml
+++ b/modules/000-common/images/vxlan-offloading-fixer/werf.inc.yaml
@@ -21,7 +21,7 @@ shell:
   - rm -r ethtool/.git
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-ethtool-artifact
-from: {{ index $.Images "builder/alpine" }}
+from: {{ index $.Images "builder/distroless" }}
 final: false
 import:
 - image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
@@ -36,7 +36,7 @@ mount:
 shell:
   beforeInstall:
   {{- include "alpine packages proxy" . | nindent 2 }}
-  - apk add --no-cache autoconf automake make libtool g++ linux-headers pkgconfig
+  - pm install autoconf automake libtool build-base linux-headers pkgconf
   setup:
   - export PKG_CONFIG_PATH=/opt/deckhouse/bin/.libs/pkgconfig
   - cd /src/libmnl

--- a/modules/015-admission-policy-engine/images/constraint-exporter/werf.inc.yaml
+++ b/modules/015-admission-policy-engine/images/constraint-exporter/werf.inc.yaml
@@ -24,7 +24,7 @@ shell:
     - cd /src
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
-from: {{ index $.Images ( eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alt-svace" ) }}
+from: {{ index $.Images "builder/golang" }}
 final: false
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact

--- a/modules/015-admission-policy-engine/images/gatekeeper/werf.inc.yaml
+++ b/modules/015-admission-policy-engine/images/gatekeeper/werf.inc.yaml
@@ -44,7 +44,7 @@ shell:
     diff -qr "/src/charts/gatekeeper/crds" "/module_crds/gatekeeper" 
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
-from: {{ index $.Images ( eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alt-svace" ) }}
+from: {{ index $.Images "builder/golang" }}
 final: false
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact

--- a/modules/040-terraform-manager/images/base-terraform-manager/werf.inc.yaml
+++ b/modules/040-terraform-manager/images/base-terraform-manager/werf.inc.yaml
@@ -83,7 +83,7 @@ shell:
 # use artifact for one place import for base and install images
 image: terraform
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-terraform-src-artifact
   add: /src

--- a/modules/050-network-policy-engine/images/kube-router/werf.inc.yaml
+++ b/modules/050-network-policy-engine/images/kube-router/werf.inc.yaml
@@ -37,7 +37,7 @@ import:
   add: /src
   to: /src
   before: install
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 secrets:
 - id: GOPROXY
   value: {{ .GOPROXY }}

--- a/modules/150-user-authn/images/basic-auth-proxy/werf.inc.yaml
+++ b/modules/150-user-authn/images/basic-auth-proxy/werf.inc.yaml
@@ -31,7 +31,7 @@ shell:
     - cd /src
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-basic-auth-proxy-artifact
-from: {{ index $.Images ( eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alt-svace" ) }}
+from: {{ index $.Images "builder/golang" }}
 final: false
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-basic-auth-proxy-src-artifact

--- a/modules/150-user-authn/images/dex-authenticator/werf.inc.yaml
+++ b/modules/150-user-authn/images/dex-authenticator/werf.inc.yaml
@@ -51,7 +51,7 @@ shell:
     - rm -rf .git docs
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-oauth2-proxy-artifact
-from: {{ index $.Images ( eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alt-svace" ) }}
+from: {{ index $.Images "builder/golang" }}
 final: false
 import:
   - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
@@ -74,7 +74,7 @@ shell:
     - chmod 0700 oauth2-proxy
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-url-exec-prober-artifact
-from: {{ index $.Images ( eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alpine-svace" ) }}
+from: {{ index $.Images "builder/golang" }}
 final: false
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact

--- a/modules/150-user-authn/images/dex/werf.inc.yaml
+++ b/modules/150-user-authn/images/dex/werf.inc.yaml
@@ -55,7 +55,7 @@ shell:
     - rm -rf examples
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-dex-artifact
-from: {{ index $.Images ( eq $.SVACE_ENABLED "false" | ternary "builder/golang-bookworm" "builder/golang-alt-svace" ) }}
+from: {{ index $.Images "builder/golang" }}
 final: false
 import:
   - image: {{ $.ModuleName }}/{{ $.ImageName }}-dex-src-artifact

--- a/modules/150-user-authn/images/kubeconfig-generator/werf.inc.yaml
+++ b/modules/150-user-authn/images/kubeconfig-generator/werf.inc.yaml
@@ -47,7 +47,7 @@ shell:
     - git apply --whitespace=fix -v /patches/*.patch
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
-from: {{ index $.Images ( eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alpine-svace" ) }}
+from: {{ index $.Images "builder/golang" }}
 final: false
 import:
   - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact

--- a/modules/150-user-authn/images/self-signed-generator/werf.inc.yaml
+++ b/modules/150-user-authn/images/self-signed-generator/werf.inc.yaml
@@ -19,7 +19,7 @@ git:
     to: /src
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
-from: {{ index $.Images ( eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alpine-svace" ) }}
+from: {{ index $.Images "builder/golang" }}
 final: false
 import:
   - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact

--- a/modules/150-user-authn/images/user-api/werf.inc.yaml
+++ b/modules/150-user-authn/images/user-api/werf.inc.yaml
@@ -19,7 +19,7 @@ git:
     to: /src
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
-from: {{ index $.Images ( eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alpine-svace" ) }}
+from: {{ index $.Images "builder/golang" }}
 final: false
 import:
   - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/werf.inc.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/werf.inc.yaml
@@ -45,7 +45,7 @@ shell:
   - cd /src
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
-from: {{ index $.Images ( eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alpine-svace" ) }}
+from: {{ index $.Images "builder/golang" }}
 final: false
 import:
   - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact

--- a/modules/470-chrony/images/chrony/werf.inc.yaml
+++ b/modules/470-chrony/images/chrony/werf.inc.yaml
@@ -24,7 +24,7 @@ shell:
   - git clone --depth 1 --branch {{ $version }} $(cat /run/secrets/SOURCE_REPO)/chrony/chrony /src/chrony && rm -rf /src/chrony/.git
 ---
 image: {{ .ModuleName }}/build-chrony-static-artifact
-from: {{ index $.Images "builder/alpine" }}
+from: {{ index $.Images "builder/distroless" }}
 final: false
 import:
 - image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
@@ -33,8 +33,7 @@ import:
   before: install
 shell:
   beforeInstall:
-  {{- include "alpine packages proxy" . | nindent 2 }}
-  - apk add --no-cache automake autoconf libtool build-base bison asciidoctor libcap-dev libcap-static
+  - pm install automake autoconf libtool build-base bison asciidoctor libcap-devel libucontext
   install:
   - cd /src
   - echo "{{ $version }}" > version.txt
@@ -46,7 +45,7 @@ shell:
   - chmod +x /opt/chrony-static/sbin/chronyd
 ---
 image: {{ .ModuleName }}/build-entrypoint-artifact
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 final: false
 import:
 - image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact

--- a/modules/470-chrony/images/chrony/werf.inc.yaml
+++ b/modules/470-chrony/images/chrony/werf.inc.yaml
@@ -33,13 +33,13 @@ import:
   before: install
 shell:
   beforeInstall:
-  - pm install automake autoconf libtool build-base bison asciidoctor libcap-devel libucontext
+  - pm install automake autoconf libtool build-base bison asciidoctor libcap-devel libucontext linux-headers
   install:
   - cd /src
   - echo "{{ $version }}" > version.txt
   - CFLAGS="-static" LDFLAGS="-static" ./configure --prefix=/opt/chrony-static
-  - make -j1
-  - make -j1 install
+  - make -j$(nproc)
+  - make install
   - chown -R 64535:64535 /opt/chrony-static
   - chmod +x /opt/chrony-static/bin/chronyc
   - chmod +x /opt/chrony-static/sbin/chronyd

--- a/modules/500-openvpn/images/easyrsa-migrator/werf.inc.yaml
+++ b/modules/500-openvpn/images/easyrsa-migrator/werf.inc.yaml
@@ -32,7 +32,7 @@ shell:
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 import:
 - image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src

--- a/modules/500-openvpn/images/openvpn/werf.inc.yaml
+++ b/modules/500-openvpn/images/openvpn/werf.inc.yaml
@@ -43,7 +43,7 @@ shell:
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-entrypoint-artifact
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 import:
 - image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src/entrypoint

--- a/modules/500-openvpn/images/ovpn-admin/werf.inc.yaml
+++ b/modules/500-openvpn/images/ovpn-admin/werf.inc.yaml
@@ -63,7 +63,7 @@ shell:
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-backend-artifact
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 import:
 - image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src


### PR DESCRIPTION
## Description
Migrate remaining module image stages with `go build` from `builder/golang-alpine`/`bookworm` to `builder/golang`. Replace `apk add` with `pm install` where needed; build chronyd on `builder/distroless` + `pm`.

## Why do we need it, and what problem does it solve?
Unify Go/native image builds on candi builders (`builder/golang`, `builder/distroless`) and the `pm` package manager instead of Alpine/`apk`.

## Why do we need it in the patch release (if we do)?
## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
## Changelog entries

```changes
section: common
type: chore
summary: Switch leftover Go image builds to builder/golang and pm instead of Alpine/apk
impact_level: default
```
