### PR TITLE
[istio] Fix DMT lint pre CSE 1.77

### DIFF
--- a/ee/modules/110-istio/templates/alliance/ingressgateway/daemonset.yaml
+++ b/ee/modules/110-istio/templates/alliance/ingressgateway/daemonset.yaml
@@ -178,6 +178,7 @@ spec:
           timeoutSeconds: 3
           failureThreshold: 30
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 1337
           runAsNonRoot: true
           runAsUser: 1337

--- a/modules/110-istio/.dmtlint.yaml
+++ b/modules/110-istio/.dmtlint.yaml
@@ -36,6 +36,10 @@ linters-settings:
         - kind: Deployment
           name: metadata-exporter
           container: metadata-discovery
+      no-new-privileges:
+        - kind: DaemonSet
+          name: istio-cni-node
+          container: install-cni
   templates:
     exclude-rules:
       service-port:

--- a/modules/110-istio/module.yaml
+++ b/modules/110-istio/module.yaml
@@ -3,6 +3,8 @@ stage: General Availability
 subsystems:
   - networking
 namespace: d8-istio
+requirements:
+  deckhouse: ">= 1.68.0"
 descriptions:
   en: Implements Service Mesh for centralized management of network traffic in the cluster. Provides mutual TLS, authorization, traffic routing, load balancing, and observability.
   ru: Реализует Service Mesh для централизованного управления сетевым трафиком в кластере. Обеспечивает Mutual TLS, авторизацию, маршрутизацию трафика, балансировку нагрузки и наблюдаемость.

--- a/modules/110-istio/openapi/values.yaml
+++ b/modules/110-istio/openapi/values.yaml
@@ -2,6 +2,12 @@ x-extend:
   schema: config-values.yaml
 type: object
 properties:
+  registry:
+    type: object
+    default: {}
+    properties:
+      dockercfg:
+        type: string
   internal:
     type: object
     default: {}

--- a/modules/110-istio/template_tests/module_test.go
+++ b/modules/110-istio/template_tests/module_test.go
@@ -64,6 +64,7 @@ discovery:
 `
 
 const istioValues = `
+    registry: {}
     internal:
       globalVersion: "1.21.6"
       versionMap:

--- a/modules/110-istio/templates/cni/daemonset.yaml
+++ b/modules/110-istio/templates/cni/daemonset.yaml
@@ -118,6 +118,8 @@ spec:
           securityContext:
             {{- if and $supportsAmbient $.Values.istio.ambient.enabled }}
             privileged: true
+            {{- else }}
+            allowPrivilegeEscalation: false
             {{- end }}
             readOnlyRootFilesystem: true
             runAsNonRoot: false

--- a/modules/110-istio/templates/ingressistiocontroller/registry-secret.yaml
+++ b/modules/110-istio/templates/ingressistiocontroller/registry-secret.yaml
@@ -1,3 +1,4 @@
+{{- if or .Values.global.modulesImages.registry.dockercfg .Values.istio.registry.dockercfg }}
 ---
 apiVersion: v1
 kind: Secret
@@ -7,4 +8,5 @@ metadata:
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 type: kubernetes.io/dockerconfigjson
 data:
-  .dockerconfigjson: {{ .Values.global.modulesImages.registry.dockercfg }}
+  .dockerconfigjson: {{ .Values.istio.registry.dockercfg | default .Values.global.modulesImages.registry.dockercfg }}
+{{- end }}

--- a/modules/110-istio/templates/registry-secret.yaml
+++ b/modules/110-istio/templates/registry-secret.yaml
@@ -1,3 +1,4 @@
+{{- if or .Values.global.modulesImages.registry.dockercfg .Values.istio.registry.dockercfg }}
 ---
 apiVersion: v1
 kind: Secret
@@ -7,7 +8,7 @@ metadata:
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 type: kubernetes.io/dockerconfigjson
 data:
-  .dockerconfigjson: {{ .Values.global.modulesImages.registry.dockercfg }}
+  .dockerconfigjson: {{ .Values.istio.registry.dockercfg | default .Values.global.modulesImages.registry.dockercfg }}
 
 {{- $namespaces := .Values.istio.internal.applicationNamespaces }}
 {{- $istioNamespace := printf "d8-%s" .Chart.Name }}
@@ -27,6 +28,6 @@ metadata:
   {{- include "helm_lib_module_labels" (list $) | nindent 2 }}
 type: kubernetes.io/dockerconfigjson
 data:
-  .dockerconfigjson: {{ $.Values.global.modulesImages.registry.dockercfg }}
+  .dockerconfigjson: {{ $.Values.istio.registry.dockercfg | default $.Values.global.modulesImages.registry.dockercfg }}
 {{- end }}
-
+{{- end }}


### PR DESCRIPTION
## Description
Fixed DMT lint **errors** (not warnings) in the istio module for CSE:
- Registry secrets: use `.Values.istio.registry.dockercfg` per DMT docs
- `module.yaml`: `requirements.deckhouse: ">= 1.68.0"` for `stage`
- CNI DaemonSet: valid securityContext for ambient vs non-ambient (`allowPrivilegeEscalation: false` only when not privileged)
## Why do we need it, and what problem does it solve?
Unblocks DMT lint / CSE patch pipeline pre release-1.77. 


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: chore
summary: Fixed DMT lint errors in the istio module.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
