### PR TITLE
sets image uid and gid, and shrinks the image

### DIFF
--- a/modules/402-ingress-nginx/images/controller-1-10/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-10/werf.inc.yaml
@@ -319,6 +319,9 @@ import:
   add: /chroot
   to: /chroot
   before: setup
+  excludePaths:
+  - usr/lib64/locale
+  - usr/lib/locale
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-chroot-artifact
   add: /usr/bin/mount
   to: /usr/bin/mount
@@ -368,7 +371,7 @@ shell:
   - export LUA_PATH="/usr/local/share/luajit-2.1/?.lua;/usr/local/share/lua/5.1/?.lua;/usr/local/lib/lua/?.lua;;"
   - export LUA_CPATH="/usr/local/lib/lua/?/?.so;/usr/local/lib/lua/?.so;;"
   - cp -R /src/rootfs/etc/* /chroot/etc
-  - cp -a /usr/lib/locale/* /chroot/usr/lib/locale/
+  - mkdir -p /chroot/usr/lib/locale/C.utf8 && cp -alf /usr/lib/locale/C.utf8/. /chroot/usr/lib/locale/C.utf8/
   - rm -rf /src/rootfs/etc/
   - ln -s /usr/local/nginx/sbin/nginx /sbin/nginx
   - groupadd -g {{ $controllerUID }} {{ $controllerUser }}
@@ -422,8 +425,6 @@ shell:
   - rm -rf /chroot/etc/nginx/owasp-modsecurity-crs/renovate.json
   - rm -rf /chroot/etc/nginx/owasp-modsecurity-crs/LICENSE
   - rm -rf /chroot/etc/nginx/owasp-modsecurity-crs/.[^.]*
-# takes ~1GB
-  - rm -rf /chroot/usr/lib64/locale
 imageSpec:
   config:
     workingDir: /
@@ -431,3 +432,4 @@ imageSpec:
     entrypoint: ["/usr/bin/dumb-init", "--"]
     cmd: ["/nginx-ingress-controller"]
     env: { "PATH": "$PATH:/usr/local/luajit/bin:/usr/local/nginx/sbin:/usr/local/nginx/bin", "LUA_PATH": "/usr/local/share/luajit-2.1/?.lua;/usr/local/share/lua/5.1/?.lua;/usr/local/lib/lua/?.lua;;", "LUA_CPATH": "/usr/local/lib/lua/?/?.so;/usr/local/lib/lua/?.so;;" }
+    user: "64535:64535"


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Fixes controller-1-10 image uid/gid and shrinks image size.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Fixes controller-1-10 image uid/gid and shrinks image size.


## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

To comply with security polices.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: fix
summary: Controller 1.10 image uid and gid are set to deckhouse.
impact: All ingress-nginx controller pods of v1.10 will be restarted.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
