### PR TITLE
[deckhouse] fix frozen module release chain and align from-to check 

### DIFF
--- a/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
@@ -503,7 +503,38 @@ func (r *reconciler) processModules(ctx context.Context, source *v1alpha1.Module
 			}
 		}
 
-		if r.needToEnsureRelease(source, module, availableModule, meta, exists, embeddedTargetSource) {
+		if !r.releaseEnsureAllowed(source, module, meta, embeddedTargetSource) {
+			availableModule.Checksum = meta.Checksum
+			availableModule.Version = meta.ModuleVersion
+			availableModules = append(availableModules, availableModule)
+			continue
+		}
+
+		// checksum changed or the target release is missing - ensure as usual.
+		ensure := availableModule.Checksum != meta.Checksum || !exists
+		if !ensure {
+			// The target release already exists and its checksum has not changed, but
+			// the step-by-step chain of ModuleReleases from the deployed release up to
+			// the target may still be incomplete: intermediate minor versions can be
+			// mirrored into the registry after the target release was first created, and
+			// the fetch that created the target could not see them then. The checksum
+			// guard never reopens on its own, so re-run the fetch whenever the chain has
+			// a gap - ensureReleases is idempotent and creates only the missing releases.
+			complete, err := r.releaseChainToTargetComplete(ctx, moduleName, meta.ModuleVersion)
+			if err != nil {
+				logger.Error("failed to check release chain to target, skipping", slog.String("name", moduleName), log.Err(err))
+				availableModule.Error = err.Error()
+				// meta was fetched successfully above, so the channel version is known -
+				// keep it instead of wiping it to "unknown" on this transient check error
+				availableModule.Checksum = meta.Checksum
+				availableModule.Version = meta.ModuleVersion
+				errorsExist = true
+				availableModules = append(availableModules, availableModule)
+				continue
+			}
+			ensure = !complete
+		}
+		if ensure {
 			logger.Debug("ensure release")
 
 			err = ctrlutils.UpdateStatusWithRetry(ctx, r.client, module, func() error {

--- a/deckhouse-controller/pkg/controller/module-controllers/source/controller_test.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/controller_test.go
@@ -199,7 +199,7 @@ func (suite *ControllerTestSuite) SetupSuite() {
 }
 
 func (suite *ControllerTestSuite) BeforeTest(suiteName, testName string) {
-	if suiteName == "ControllerTestSuite" && testName == "TestCreateReconcile" {
+	if suiteName == "ControllerTestSuite" && (testName == "TestCreateReconcile" || testName == "TestFetchMissingIntermediateReleases") {
 		suite.compareGolden = true
 	}
 }
@@ -513,6 +513,27 @@ func (suite *ControllerTestSuite) parseTestdata(filename string) []byte {
 	suite.goldenFile = filepath.Join("./testdata", "golden", filename)
 
 	return data
+}
+
+// TestFetchMissingIntermediateReleases reproduces the frozen-chain bug: the target
+// release already exists and its checksum matches the one recorded on the source (so
+// the plain checksum guard would skip the fetch), yet the step-by-step chain from the
+// deployed release up to the target has a gap because the intermediate versions were
+// mirrored into the registry only after the target release was first created. The
+// reconcile must re-derive the chain and create the missing intermediate releases.
+func (suite *ControllerTestSuite) TestFetchMissingIntermediateReleases() {
+	suite.Run("frozen chain with missing intermediates is re-derived", func() {
+		dc := newMockedContainerWithData(suite.T(),
+			"v1.55.1",
+			[]string{"console"},
+			[]string{"v1.49.1", "v1.50.0", "v1.51.1", "v1.52.0", "v1.53.2", "v1.54.1", "v1.55.1"})
+		suite.setupTestController(string(suite.parseTestdata("frozen-chain-missing-intermediates.yaml")), withDependencyContainer(dc))
+
+		_, err := suite.r.handleModuleSource(context.TODO(), suite.moduleSource(suite.source))
+		require.NoError(suite.T(), err)
+		// the resulting ModuleReleases (including the newly created console-v1.53.2 and
+		// console-v1.54.1) are asserted against the golden snapshot in TearDownSubTest
+	})
 }
 
 func (suite *ControllerTestSuite) TestDeleteReconcile() {

--- a/deckhouse-controller/pkg/controller/module-controllers/source/helpers.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/helpers.go
@@ -22,8 +22,10 @@ import (
 	"fmt"
 	"log/slog"
 	"slices"
+	"sort"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,6 +35,7 @@ import (
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/controller/ctrlutils"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/controller/module-controllers/downloader"
+	moduletypes "github.com/deckhouse/deckhouse/deckhouse-controller/pkg/controller/moduleloader/types"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/controller/module-controllers/utils"
 )
 
@@ -168,14 +171,16 @@ func (r *reconciler) releaseExists(ctx context.Context, sourceName, moduleName, 
 	return true, nil
 }
 
-// needToEnsureRelease checks that the module enabled, the source is the active source,
-// release exists, and checksum not changed.
-func (r *reconciler) needToEnsureRelease(
+// releaseEnsureAllowed reports whether a release for the module may be ensured from
+// the given source at all. It is a pure policy predicate over already-fetched data
+// (no cluster I/O): it does not decide whether there is actually something to fetch -
+// that concrete diff (checksum change, missing target release, incomplete update
+// chain) is evaluated by the caller. It returns false to skip the module entirely for
+// experimental / not-active-source / disabled reasons.
+func (r *reconciler) releaseEnsureAllowed(
 	source *v1alpha1.ModuleSource,
 	module *v1alpha1.Module,
-	sourceModule v1alpha1.AvailableModule,
 	meta *downloader.ModuleDownloadResult,
-	releaseExists bool,
 	embeddedTargetSource string) bool {
 	// skip experimental modules when deckhouse does not allow them
 	if module.IsExperimental() && !r.deckhouseSettings.Get().AllowExperimentalModules {
@@ -225,7 +230,118 @@ func (r *reconciler) needToEnsureRelease(
 		return false
 	}
 
-	return sourceModule.Checksum != meta.Checksum || !releaseExists
+	return true
+}
+
+// releaseChainToTargetComplete reports whether the ModuleReleases already present in
+// the cluster form a continuous update sequence from the deployed release up to (and
+// including) the target version. It returns true (nothing to bridge) when there is no
+// deployed release yet or the target is not ahead of the deployed one - those cases
+// are handled by the regular first-install / no-op flow. A gap yields false,
+// signalling that the step-by-step fetch must run again.
+//
+// The gap rule is shared with the fetcher via isSequentialReleasePair, so this check
+// reports "complete" for exactly the chains the step-by-step fetch would leave
+// untouched (including legitimate non-adjacent jumps allowed by a release's from-to
+// update spec). This equivalence is what keeps the checksum guard from re-opening the
+// fetch on every reconcile for from-to modules.
+func (r *reconciler) releaseChainToTargetComplete(ctx context.Context, moduleName, targetVersion string) (bool, error) {
+	target, err := semver.NewVersion(targetVersion)
+	if err != nil {
+		return false, fmt.Errorf("parse target version %q: %w", targetVersion, err)
+	}
+
+	releaseList := new(v1alpha1.ModuleReleaseList)
+	if err = r.client.List(ctx, releaseList, client.MatchingLabels{v1alpha1.ModuleReleaseLabelModule: moduleName}); err != nil {
+		return false, fmt.Errorf("list module releases: %w", err)
+	}
+
+	// GetVersion (used below and inside isSequentialReleasePair) relies on
+	// semver.MustParse, which panics on a malformed Spec.Version. This check now runs on
+	// the steady-state path (checksum unchanged, target exists) for every installed
+	// module, so validate every release up front: a single corrupt object must surface
+	// as a handled error - the caller keeps the known state and only sets errorsExist,
+	// so no fetch is triggered - instead of panicking the whole reconcile.
+	for i := range releaseList.Items {
+		release := &releaseList.Items[i]
+		if _, err = semver.NewVersion(release.Spec.Version); err != nil {
+			return false, fmt.Errorf("parse release %q version %q: %w", release.Name, release.Spec.Version, err)
+		}
+	}
+
+	// find the highest deployed release; without one the regular first-install flow applies
+	var deployed *v1alpha1.ModuleRelease
+	for i := range releaseList.Items {
+		release := &releaseList.Items[i]
+		if release.GetPhase() != v1alpha1.ModuleReleasePhaseDeployed {
+			continue
+		}
+		if deployed == nil || release.GetVersion().GreaterThan(deployed.GetVersion()) {
+			deployed = release
+		}
+	}
+	if deployed == nil || !target.GreaterThan(deployed.GetVersion()) {
+		return true, nil
+	}
+
+	// collect the deployed release together with the releases in (deployed, target]
+	// and verify they form a continuous update sequence up to the target
+	chain := []*v1alpha1.ModuleRelease{deployed}
+	for i := range releaseList.Items {
+		release := &releaseList.Items[i]
+		if version := release.GetVersion(); version.GreaterThan(deployed.GetVersion()) && !version.GreaterThan(target) {
+			chain = append(chain, release)
+		}
+	}
+	sort.Slice(chain, func(i, j int) bool {
+		return chain[i].GetVersion().LessThan(chain[j].GetVersion())
+	})
+
+	// the target itself must be present as the endpoint of the chain
+	if chain[len(chain)-1].GetVersion().Compare(target) != 0 {
+		return false, nil
+	}
+
+	for i := 1; i < len(chain); i++ {
+		if !isSequentialReleasePair(chain[i-1], chain[i]) {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+// isSequentialReleasePair reports whether an update may proceed directly from the
+// lower release to the higher one, without any release in between: either the versions
+// are naturally adjacent (isUpdatingSequence) or the higher release declares a from-to
+// transition rule (UpdateSpec) that covers the lower version. This is the single rule
+// used both to decide whether the in-cluster chain is complete
+// (releaseChainToTargetComplete) and to pick the starting point of the step-by-step
+// fetch (ensureReleases), so the two never disagree about what counts as a gap.
+func isSequentialReleasePair(lower, higher *v1alpha1.ModuleRelease) bool {
+	if isUpdatingSequence(lower.GetVersion(), higher.GetVersion()) {
+		return true
+	}
+
+	// the from-to rule is declared on the constrained (higher/"to") release
+	spec := higher.GetUpdateSpec()
+	if spec == nil || len(spec.Versions) == 0 {
+		return false
+	}
+
+	return isUpdatingSequenceWithFromTo(lower.GetVersion(), updateConstraintsToVersions(spec.Versions)) == nil
+}
+
+// updateConstraintsToVersions adapts the in-cluster from-to constraints stored on a
+// ModuleRelease to the shape consumed by isUpdatingSequenceWithFromTo, which is also
+// fed the same rules coming from freshly downloaded module definitions in the fetcher.
+func updateConstraintsToVersions(constraints []v1alpha1.UpdateConstraint) []moduletypes.ModuleUpdateVersion {
+	out := make([]moduletypes.ModuleUpdateVersion, len(constraints))
+	for i, c := range constraints {
+		out[i] = moduletypes.ModuleUpdateVersion{From: c.From, To: c.To}
+	}
+
+	return out
 }
 
 // getConfiguredModuleSource returns the source explicitly selected by the operator

--- a/deckhouse-controller/pkg/controller/module-controllers/source/helpers.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/helpers.go
@@ -35,7 +35,6 @@ import (
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/controller/ctrlutils"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/controller/module-controllers/downloader"
-	moduletypes "github.com/deckhouse/deckhouse/deckhouse-controller/pkg/controller/moduleloader/types"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/controller/module-controllers/utils"
 )
 
@@ -314,34 +313,60 @@ func (r *reconciler) releaseChainToTargetComplete(ctx context.Context, moduleNam
 // isSequentialReleasePair reports whether an update may proceed directly from the
 // lower release to the higher one, without any release in between: either the versions
 // are naturally adjacent (isUpdatingSequence) or the higher release declares a from-to
-// transition rule (UpdateSpec) that covers the lower version. This is the single rule
-// used both to decide whether the in-cluster chain is complete
+// transition rule that targets the higher release itself and admits the lower version.
+// This is the single rule used both to decide whether the in-cluster chain is complete
 // (releaseChainToTargetComplete) and to pick the starting point of the step-by-step
 // fetch (ensureReleases), so the two never disagree about what counts as a gap.
+//
+// The from-to rule matches the one the release updater enforces before it deploys a
+// jump (releaseupdater.getFirstCompliantRelease): a constraint bridges the gap only when
+// it points at this very release (its major.minor equals "to") and covers the lower
+// version (lower is within [from, to)). Keeping the two sides identical is what stops
+// the source controller from reporting a chain complete that the updater then refuses to
+// walk - the mismatch that left a module stuck in Pending with a from-to whose "to"
+// overshoots the release's own minor.
 func isSequentialReleasePair(lower, higher *v1alpha1.ModuleRelease) bool {
-	if isUpdatingSequence(lower.GetVersion(), higher.GetVersion()) {
+	lowerVersion, higherVersion := lower.GetVersion(), higher.GetVersion()
+	if isUpdatingSequence(lowerVersion, higherVersion) {
 		return true
 	}
 
 	// the from-to rule is declared on the constrained (higher/"to") release
 	spec := higher.GetUpdateSpec()
-	if spec == nil || len(spec.Versions) == 0 {
+	if spec == nil {
 		return false
 	}
 
-	return isUpdatingSequenceWithFromTo(lower.GetVersion(), updateConstraintsToVersions(spec.Versions)) == nil
-}
-
-// updateConstraintsToVersions adapts the in-cluster from-to constraints stored on a
-// ModuleRelease to the shape consumed by isUpdatingSequenceWithFromTo, which is also
-// fed the same rules coming from freshly downloaded module definitions in the fetcher.
-func updateConstraintsToVersions(constraints []v1alpha1.UpdateConstraint) []moduletypes.ModuleUpdateVersion {
-	out := make([]moduletypes.ModuleUpdateVersion, len(constraints))
-	for i, c := range constraints {
-		out[i] = moduletypes.ModuleUpdateVersion{From: c.From, To: c.To}
+	for _, constraint := range spec.Versions {
+		if fromToBridges(lowerVersion, higherVersion, constraint) {
+			return true
+		}
 	}
 
-	return out
+	return false
+}
+
+// fromToBridges reports whether a single from-to constraint lets an update jump directly
+// onto the higher release from the lower version. It mirrors the release updater: the
+// constraint must target the higher release itself (higher major.minor equals the "to"
+// major.minor) and the lower version must fall in the half-open window [from, to). A
+// constraint that only parses but matches neither - a "to" pointing past the higher
+// release, or a window that does not cover the lower version - does not bridge.
+func fromToBridges(lower, higher *semver.Version, constraint v1alpha1.UpdateConstraint) bool {
+	to, err := semver.NewVersion(constraint.To)
+	if err != nil {
+		return false
+	}
+	if higher.Major() != to.Major() || higher.Minor() != to.Minor() {
+		return false
+	}
+
+	from, err := semver.NewVersion(constraint.From)
+	if err != nil {
+		return false
+	}
+
+	return lower.Compare(from) >= 0 && lower.Compare(to) < 0
 }
 
 // getConfiguredModuleSource returns the source explicitly selected by the operator

--- a/deckhouse-controller/pkg/controller/module-controllers/source/helpers_test.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/helpers_test.go
@@ -15,11 +15,18 @@
 package source
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
+	"github.com/deckhouse/deckhouse/go_lib/project"
+	"github.com/deckhouse/deckhouse/pkg/log"
 )
 
 func TestResolveEmbeddedTargetSource(t *testing.T) {
@@ -102,6 +109,165 @@ func TestResolveEmbeddedTargetSource(t *testing.T) {
 			target, conflict := resolveEmbeddedTargetSource(tt.chosenSource, tt.availableSources)
 			assert.Equal(t, tt.wantTarget, target, "target source")
 			assert.Equal(t, tt.wantConflict, conflict, "conflict")
+		})
+	}
+}
+
+func TestReleaseChainToTargetComplete(t *testing.T) {
+	const moduleName = "console"
+
+	moduleRelease := func(version, phase string) *v1alpha1.ModuleRelease {
+		return &v1alpha1.ModuleRelease{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   moduleName + "-v" + version,
+				Labels: map[string]string{v1alpha1.ModuleReleaseLabelModule: moduleName},
+			},
+			Spec:   v1alpha1.ModuleReleaseSpec{ModuleName: moduleName, Version: version},
+			Status: v1alpha1.ModuleReleaseStatus{Phase: phase},
+		}
+	}
+
+	// moduleReleaseFromTo builds a release that declares a from-to transition rule on
+	// itself (the constrained "to" release), allowing a direct jump from `from`.
+	moduleReleaseFromTo := func(version, phase, from, to string) *v1alpha1.ModuleRelease {
+		release := moduleRelease(version, phase)
+		release.Spec.UpdateSpec = &v1alpha1.UpdateSpec{
+			Versions: []v1alpha1.UpdateConstraint{{From: from, To: to}},
+		}
+		return release
+	}
+
+	tests := []struct {
+		name     string
+		target   string
+		releases []*v1alpha1.ModuleRelease
+		want     bool
+		wantErr  bool
+	}{
+		{
+			// the console case: deployed 1.52.0, target 1.55.1, intermediates missing
+			name:   "gap between deployed and target",
+			target: "v1.55.1",
+			releases: []*v1alpha1.ModuleRelease{
+				moduleRelease("1.52.0", v1alpha1.ModuleReleasePhaseDeployed),
+				moduleRelease("1.55.1", v1alpha1.ModuleReleasePhasePending),
+			},
+			want: false,
+		},
+		{
+			name:   "full continuous chain",
+			target: "v1.55.1",
+			releases: []*v1alpha1.ModuleRelease{
+				moduleRelease("1.52.0", v1alpha1.ModuleReleasePhaseDeployed),
+				moduleRelease("1.53.2", v1alpha1.ModuleReleasePhasePending),
+				moduleRelease("1.54.1", v1alpha1.ModuleReleasePhasePending),
+				moduleRelease("1.55.1", v1alpha1.ModuleReleasePhasePending),
+			},
+			want: true,
+		},
+		{
+			// a from-to rule on the target legitimizes the minor jump: the chain is
+			// complete and the fetch must NOT reopen on every reconcile
+			name:   "gap bridged by target from-to rule",
+			target: "v1.55.1",
+			releases: []*v1alpha1.ModuleRelease{
+				moduleRelease("1.52.0", v1alpha1.ModuleReleasePhaseDeployed),
+				moduleReleaseFromTo("1.55.1", v1alpha1.ModuleReleasePhasePending, "1.52", "1.55"),
+			},
+			want: true,
+		},
+		{
+			// NB: mirrors the fetcher's from-to leniency - a parseable from-to rule on
+			// the higher release bridges the gap even when its [from,to) window does not
+			// actually cover the deployed version (isUpdatingSequenceWithFromTo returns
+			// nil on no-match). Kept consistent on purpose so the guard closes exactly
+			// when the fetch would no-op; see the note in the review.
+			name:   "from-to rule present bridges regardless of window",
+			target: "v1.55.1",
+			releases: []*v1alpha1.ModuleRelease{
+				moduleRelease("1.52.0", v1alpha1.ModuleReleasePhaseDeployed),
+				moduleReleaseFromTo("1.55.1", v1alpha1.ModuleReleasePhasePending, "1.53", "1.55"),
+			},
+			want: true,
+		},
+		{
+			name:   "one intermediate minor missing",
+			target: "v1.55.1",
+			releases: []*v1alpha1.ModuleRelease{
+				moduleRelease("1.52.0", v1alpha1.ModuleReleasePhaseDeployed),
+				moduleRelease("1.53.2", v1alpha1.ModuleReleasePhasePending),
+				moduleRelease("1.55.1", v1alpha1.ModuleReleasePhasePending),
+			},
+			want: false,
+		},
+		{
+			name:   "target release itself missing",
+			target: "v1.55.1",
+			releases: []*v1alpha1.ModuleRelease{
+				moduleRelease("1.52.0", v1alpha1.ModuleReleasePhaseDeployed),
+				moduleRelease("1.53.2", v1alpha1.ModuleReleasePhasePending),
+				moduleRelease("1.54.1", v1alpha1.ModuleReleasePhasePending),
+			},
+			want: false,
+		},
+		{
+			name:     "no deployed release - first install, nothing to bridge",
+			target:   "v1.55.1",
+			releases: []*v1alpha1.ModuleRelease{moduleRelease("1.55.1", v1alpha1.ModuleReleasePhasePending)},
+			want:     true,
+		},
+		{
+			name:   "target not ahead of deployed",
+			target: "v1.52.0",
+			releases: []*v1alpha1.ModuleRelease{
+				moduleRelease("1.52.0", v1alpha1.ModuleReleasePhaseDeployed),
+			},
+			want: true,
+		},
+		{
+			name:   "sequential minor step is complete",
+			target: "v1.53.2",
+			releases: []*v1alpha1.ModuleRelease{
+				moduleRelease("1.52.0", v1alpha1.ModuleReleasePhaseDeployed),
+				moduleRelease("1.53.2", v1alpha1.ModuleReleasePhasePending),
+			},
+			want: true,
+		},
+		{
+			// a corrupt Spec.Version must surface as a handled error, not panic through
+			// GetVersion's semver.MustParse on this steady-state path
+			name:   "malformed release version returns error",
+			target: "v1.55.1",
+			releases: []*v1alpha1.ModuleRelease{
+				moduleRelease("1.52.0", v1alpha1.ModuleReleasePhaseDeployed),
+				moduleRelease("not-a-semver", v1alpha1.ModuleReleasePhasePending),
+			},
+			wantErr: true,
+		},
+	}
+
+	scheme, err := project.Scheme()
+	require.NoError(t, err)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			objects := make([]client.Object, 0, len(tt.releases))
+			for _, rel := range tt.releases {
+				objects = append(objects, rel)
+			}
+
+			r := &reconciler{
+				client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build(),
+				logger: log.NewNop(),
+			}
+
+			got, err := r.releaseChainToTargetComplete(context.Background(), moduleName, tt.target)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/deckhouse-controller/pkg/controller/module-controllers/source/helpers_test.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/helpers_test.go
@@ -177,18 +177,29 @@ func TestReleaseChainToTargetComplete(t *testing.T) {
 			want: true,
 		},
 		{
-			// NB: mirrors the fetcher's from-to leniency - a parseable from-to rule on
-			// the higher release bridges the gap even when its [from,to) window does not
-			// actually cover the deployed version (isUpdatingSequenceWithFromTo returns
-			// nil on no-match). Kept consistent on purpose so the guard closes exactly
-			// when the fetch would no-op; see the note in the review.
-			name:   "from-to rule present bridges regardless of window",
+			// a from-to window that does not cover the deployed version does NOT bridge
+			// the gap: the release updater refuses the jump (deployed < from), so the
+			// chain must be reported incomplete and the intermediate releases fetched
+			name:   "from-to window does not cover deployed - not bridged",
 			target: "v1.55.1",
 			releases: []*v1alpha1.ModuleRelease{
 				moduleRelease("1.52.0", v1alpha1.ModuleReleasePhaseDeployed),
 				moduleReleaseFromTo("1.55.1", v1alpha1.ModuleReleasePhasePending, "1.53", "1.55"),
 			},
-			want: true,
+			want: false,
+		},
+		{
+			// the reported incident: a from-to whose "to" (2.0) overshoots the release's
+			// own minor (1.55). The release updater ignores such a rule (release
+			// major.minor != to), so the source controller must too - report the chain
+			// incomplete and fetch the missing 1.53/1.54 instead of freezing
+			name:   "from-to to overshoots release minor - not bridged",
+			target: "v1.55.1",
+			releases: []*v1alpha1.ModuleRelease{
+				moduleRelease("1.52.0", v1alpha1.ModuleReleasePhaseDeployed),
+				moduleReleaseFromTo("1.55.1", v1alpha1.ModuleReleasePhasePending, "1.40", "2.0"),
+			},
+			want: false,
 		},
 		{
 			name:   "one intermediate minor missing",

--- a/deckhouse-controller/pkg/controller/module-controllers/source/module_release_fetcher.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/module_release_fetcher.go
@@ -283,7 +283,7 @@ func (f *ModuleReleaseFetcher) ensureReleases(
 
 	isSequenceInCluster := true
 	for i := 1; i < len(releasesInCluster); i++ {
-		if !isUpdatingSequence(releasesInCluster[i-1].GetVersion(), releasesInCluster[i].GetVersion()) {
+		if !isSequentialReleasePair(releasesInCluster[i-1], releasesInCluster[i]) {
 			isSequenceInCluster = false
 			break
 		}

--- a/deckhouse-controller/pkg/controller/module-controllers/source/testdata/frozen-chain-missing-intermediates.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/testdata/frozen-chain-missing-intermediates.yaml
@@ -3,7 +3,7 @@ apiVersion: deckhouse.io/v1alpha1
 kind: ModuleSource
 metadata:
   annotations:
-    modules.deckhouse.io/registry-spec-checksum: 912e02634dd8b7222cc42906e35f1e79
+    modules.deckhouse.io/registry-spec-checksum: 90f0955ee984feab5c50611987008def
   name: test-source-1
 spec:
   scanInterval: 6h30m

--- a/deckhouse-controller/pkg/controller/module-controllers/source/testdata/frozen-chain-missing-intermediates.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/testdata/frozen-chain-missing-intermediates.yaml
@@ -1,0 +1,89 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  annotations:
+    modules.deckhouse.io/registry-spec-checksum: 912e02634dd8b7222cc42906e35f1e79
+  name: test-source-1
+spec:
+  scanInterval: 6h30m
+  registry:
+    dockerCfg: YXNiCg==
+    repo: dev-registry.deckhouse.io/deckhouse/modules
+    scheme: HTTPS
+status:
+  message: ""
+  modules:
+    # checksum equals the checksum the mock registry reports for the channel image
+    # ("sha256:"), so the plain checksum guard is satisfied - the update chain must be
+    # re-derived only because it has a gap
+    - name: console
+      checksum: "sha256:"
+---
+apiVersion: deckhouse.io/v1alpha2
+kind: ModuleUpdatePolicy
+metadata:
+  name: test-alpha
+spec:
+  releaseChannel: Alpha
+  update:
+    mode: Manual
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: Module
+metadata:
+  name: console
+properties:
+  version: 1.52.0
+  source: test-source-1
+  updatePolicy: test-alpha
+  availableSources:
+    - test-source-1
+status:
+  phase: Available
+  conditions:
+    - type: EnabledByModuleConfig
+      status: "True"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleRelease
+metadata:
+  labels:
+    module: console
+    modules.deckhouse.io/update-policy: test-alpha
+    release-checksum: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    source: test-source-1
+  name: console-v1.52.0
+spec:
+  moduleName: console
+  version: 1.52.0
+  weight: 900
+status:
+  approved: false
+  message: ""
+  phase: Deployed
+  pullDuration: 0s
+  size: 0
+  transitionTime: "2026-07-01T00:00:00Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleRelease
+metadata:
+  labels:
+    module: console
+    modules.deckhouse.io/update-policy: test-alpha
+    # md5("sha256:") - matches the channel target checksum, so releaseExists() is true
+    release-checksum: 1beb143dffb1b662137094e7faea1e17
+    source: test-source-1
+  name: console-v1.55.1
+spec:
+  moduleName: console
+  version: 1.55.1
+  weight: 900
+status:
+  approved: false
+  message: "minor version is greater than deployed 1.52.0 by one"
+  phase: Pending
+  pullDuration: 0s
+  size: 0
+  transitionTime: "2026-07-01T00:00:00Z"

--- a/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/frozen-chain-missing-intermediates.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/frozen-chain-missing-intermediates.yaml
@@ -1,0 +1,126 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  annotations:
+    modules.deckhouse.io/registry-spec-checksum: 912e02634dd8b7222cc42906e35f1e79
+  finalizers:
+  - modules.deckhouse.io/module-exists
+  name: test-source-1
+  resourceVersion: "1001"
+spec:
+  registry:
+    dockerCfg: YXNiCg==
+    repo: dev-registry.deckhouse.io/deckhouse/modules
+    scheme: HTTPS
+  scanInterval: 6h30m0s
+status:
+  modules:
+  - checksum: 'sha256:'
+    name: console
+    policy: test-alpha
+    version: v1.55.1
+  modulesCount: 1
+  phase: Active
+  syncTime: "2019-10-17T15:33:00Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleRelease
+metadata:
+  labels:
+    module: console
+    modules.deckhouse.io/update-policy: test-alpha
+    release-checksum: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    source: test-source-1
+  name: console-v1.52.0
+  resourceVersion: "999"
+spec:
+  moduleName: console
+  version: 1.52.0
+  weight: 900
+status:
+  approved: false
+  phase: Deployed
+  pullDuration: 0s
+  transitionTime: "2026-07-01T00:00:00Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleRelease
+metadata:
+  annotations:
+    modules.deckhouse.io/change-cause: check release (step-by-step)
+  labels:
+    module: console
+    modules.deckhouse.io/update-policy: test-alpha
+    release-checksum: 1beb143dffb1b662137094e7faea1e17
+    source: test-source-1
+  name: console-v1.53.2
+  ownerReferences:
+  - apiVersion: deckhouse.io/v1alpha1
+    controller: true
+    kind: ModuleSource
+    name: test-source-1
+    uid: ""
+  resourceVersion: "1"
+spec:
+  moduleName: console
+  requirements:
+    kubernetes: '>= 1.27'
+  version: 1.53.2
+  weight: 900
+status:
+  approved: false
+  pullDuration: 0s
+  transitionTime: null
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleRelease
+metadata:
+  annotations:
+    modules.deckhouse.io/change-cause: check release (step-by-step)
+  labels:
+    module: console
+    modules.deckhouse.io/update-policy: test-alpha
+    release-checksum: 1beb143dffb1b662137094e7faea1e17
+    source: test-source-1
+  name: console-v1.54.1
+  ownerReferences:
+  - apiVersion: deckhouse.io/v1alpha1
+    controller: true
+    kind: ModuleSource
+    name: test-source-1
+    uid: ""
+  resourceVersion: "1"
+spec:
+  moduleName: console
+  requirements:
+    kubernetes: '>= 1.27'
+  version: 1.54.1
+  weight: 900
+status:
+  approved: false
+  pullDuration: 0s
+  transitionTime: null
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleRelease
+metadata:
+  annotations:
+    modules.deckhouse.io/change-cause: check release (step-by-step)
+  labels:
+    module: console
+    modules.deckhouse.io/update-policy: test-alpha
+    release-checksum: 1beb143dffb1b662137094e7faea1e17
+    source: test-source-1
+  name: console-v1.55.1
+  resourceVersion: "1000"
+spec:
+  moduleName: console
+  version: 1.55.1
+  weight: 900
+status:
+  approved: false
+  message: minor version is greater than deployed 1.52.0 by one
+  phase: Pending
+  pullDuration: 0s
+  transitionTime: "2026-07-01T00:00:00Z"

--- a/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/frozen-chain-missing-intermediates.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/frozen-chain-missing-intermediates.yaml
@@ -3,18 +3,21 @@ apiVersion: deckhouse.io/v1alpha1
 kind: ModuleSource
 metadata:
   annotations:
-    modules.deckhouse.io/registry-spec-checksum: 912e02634dd8b7222cc42906e35f1e79
+    modules.deckhouse.io/registry-spec-checksum: 90f0955ee984feab5c50611987008def
+  creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/module-exists
   name: test-source-1
   resourceVersion: "1001"
 spec:
   registry:
+    ca: ""
     dockerCfg: YXNiCg==
     repo: dev-registry.deckhouse.io/deckhouse/modules
     scheme: HTTPS
   scanInterval: 6h30m0s
 status:
+  message: ""
   modules:
   - checksum: 'sha256:'
     name: console
@@ -27,6 +30,7 @@ status:
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleRelease
 metadata:
+  creationTimestamp: null
   labels:
     module: console
     modules.deckhouse.io/update-policy: test-alpha
@@ -40,8 +44,10 @@ spec:
   weight: 900
 status:
   approved: false
+  message: ""
   phase: Deployed
   pullDuration: 0s
+  size: 0
   transitionTime: "2026-07-01T00:00:00Z"
 ---
 apiVersion: deckhouse.io/v1alpha1
@@ -49,6 +55,7 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/change-cause: check release (step-by-step)
+  creationTimestamp: null
   labels:
     module: console
     modules.deckhouse.io/update-policy: test-alpha
@@ -70,7 +77,9 @@ spec:
   weight: 900
 status:
   approved: false
+  message: ""
   pullDuration: 0s
+  size: 0
   transitionTime: null
 ---
 apiVersion: deckhouse.io/v1alpha1
@@ -78,6 +87,7 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/change-cause: check release (step-by-step)
+  creationTimestamp: null
   labels:
     module: console
     modules.deckhouse.io/update-policy: test-alpha
@@ -99,7 +109,9 @@ spec:
   weight: 900
 status:
   approved: false
+  message: ""
   pullDuration: 0s
+  size: 0
   transitionTime: null
 ---
 apiVersion: deckhouse.io/v1alpha1
@@ -107,6 +119,7 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/change-cause: check release (step-by-step)
+  creationTimestamp: null
   labels:
     module: console
     modules.deckhouse.io/update-policy: test-alpha
@@ -123,4 +136,5 @@ status:
   message: minor version is greater than deployed 1.52.0 by one
   phase: Pending
   pullDuration: 0s
+  size: 0
   transitionTime: "2026-07-01T00:00:00Z"


### PR DESCRIPTION
## Description

Backport of #21475 to `release-1.76`, together with the follow-up that aligns the source controller's `from-to` check with the release updater.

Fixes a "frozen chain" in the module-source controller: once the target release already existed with a matching checksum, the fetch was skipped forever, so intermediate `ModuleReleases` mirrored into the registry later were never created and the step-by-step update could not proceed.

- Split the fetch decision into `releaseEnsureAllowed` (pure policy over already-fetched data, no cluster I/O) and `releaseChainToTargetComplete`, which reports whether the in-cluster `ModuleReleases` form a continuous chain from the deployed release up to the target and re-runs the idempotent step-by-step fetch on a gap.
- `isSequentialReleasePair` is the single "may we jump directly from release A to release B" rule, shared by the completeness check and the fetcher's starting-point selection. A `from-to` constraint bridges a gap only when it matches what the release updater enforces before it deploys a jump (`releaseupdater.getFirstCompliantRelease`): its `to` equals the higher release's own major.minor and the lower version is within `[from, to)`. This keeps the source controller from reporting a chain complete that the release updater then refuses to walk — a `from-to` whose `to` overshoots the release's own minor previously left the target stuck in Pending.
- `releaseChainToTargetComplete` validates release versions up front, so a malformed `Spec.Version` surfaces as a handled error instead of panicking the reconcile through `GetVersion`'s `semver.MustParse`.

The test fixtures for the frozen-chain golden case were adapted to `release-1.76` (registry-spec checksum and the regenerated golden snapshot).

No impact on critical cluster components (no restarts of ingress-controllers, control-plane, Prometheus, etc.).

## Why do we need it, and what problem does it solve?

A module could not complete its update: intermediate releases mirrored after the target were never created, and a `from-to` whose `to` did not point at the release blocked the step-by-step chain because the source controller and the release updater interpreted the same constraint differently. The frozen state does not self-heal. Backporting brings the fix to clusters on `release-1.76`.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse-controller
type: fix
summary: Re-derive the module release chain and align the from-to gap check with the release updater so intermediate releases are created instead of the chain freezing
impact_level: low
```
