### PR TITLE
[candi] Add exception for Oracle Linux UEK kernels for fix CVE-2025-37999 for 1.76

### DIFF
--- a/candi/bashible/common-steps/all/000_check_containerd_v2_support.sh.tpl
+++ b/candi/bashible/common-steps/all/000_check_containerd_v2_support.sh.tpl
@@ -66,6 +66,14 @@ is_kernel_erofs_cve_vulnerable() {
     (( build >= 1010 )) && return 1
   fi
 
+  # Exception for Oracle Linux UEK8 kernels (el9uek/el10uek) only: base version stays 6.12.0 while the fix is backported.
+  # CVE fixed starting kernel-uek 6.12.0-101.33.4.3 (ELSA-2025-20480 https://linux.oracle.com/errata/ELSA-2025-20480.html).
+  # Anchoring on 6.12.0 keeps 5.15-based UEK7 (el9uek) out of this branch.
+  if [[ "$full_kv" =~ ^6\.12\.0-([0-9.]+)\.el(9|10)uek ]]; then
+    version_ge "6.12.0.${BASH_REMATCH[1]}" "6.12.0.101.33.4.3" && return 1
+    return 0
+  fi
+
   local kv=$(echo "$full_kv" | cut -d- -f1)
   if version_ge "$kv" "6.12.0" && ! version_ge "$kv" "6.12.29"; then
     return 0


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Add exception for Oracle Linux UEK kernels for fix CVE-2025-37999 according to https://linux.oracle.com/errata/ELSA-2025-20480.html
RHCK kernel - Out of support scope https://access.redhat.com/security/cve/cve-2025-37999

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?
Deckhouse bootstrap on Oracle Linux UEK kernels is blocked although the vulnerability has been fixed
<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Add exception for Oracle Linux UEK kernels for fix CVE-2025-37999 on bashible
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
