### PR TITLE
test: sysext update workflow (do not merge)

### DIFF
--- a/modules/007-registrypackages/images/containerd/werf.inc.yaml
+++ b/modules/007-registrypackages/images/containerd/werf.inc.yaml
@@ -286,6 +286,10 @@ shell:
   - mkdir -p /sysext/usr/lib/extension-release.d /sysext/usr/lib/systemd/system
   - cp -f /scripts/sysext-containerd.service /sysext/usr/lib/systemd/system/containerd.service
   - cp -f /scripts/extension-release.containerd /sysext/usr/lib/extension-release.d/
+  # TEST MARKER (branch sysext-update-test, do not merge): changes the image
+  # content so the sysext gets a new digest, and lands a file the node can be
+  # checked for to prove the new image is what actually got merged.
+  - printf 'sysext-update-test rev1\n' > /sysext/usr/lib/nodelet-sysext-test-containerd
   - mkfs.erofs -L _sysext -U 00000000-0000-0000-0000-000000000000 -z lzma,9 containerd.erofs sysext/
   - veritysetup format containerd.erofs containerd.verity > verity.txt
   - export ROOTHASH=$(awk '/^Root hash:/ {print $3}' verity.txt)

--- a/modules/007-registrypackages/images/kubelet/werf.inc.yaml
+++ b/modules/007-registrypackages/images/kubelet/werf.inc.yaml
@@ -98,6 +98,10 @@ shell:
   - mkdir -p /sysext/usr/lib/extension-release.d /sysext/usr/lib/systemd/system
   - cp -f /scripts/sysext-kubelet.service /sysext/usr/lib/systemd/system/kubelet.service
   - cp -f /scripts/extension-release.kubelet /sysext/usr/lib/extension-release.d/
+  # TEST MARKER (branch sysext-update-test, do not merge): changes the image
+  # content so the sysext gets a new digest, and lands a file the node can be
+  # checked for to prove the new image is what actually got merged.
+  - printf 'sysext-update-test rev1\n' > /sysext/usr/lib/nodelet-sysext-test-kubelet
   - mkfs.erofs -L _sysext -U 00000000-0000-0000-0000-000000000000 -z lzma,9 kubelet.erofs sysext/
   - veritysetup format kubelet.erofs kubelet.verity > verity.txt
   - export ROOTHASH=$(awk '/^Root hash:/ {print $3}' verity.txt)


### PR DESCRIPTION
Throwaway branch used to exercise the node extension update path end to end on the olcedar stand.

Adds a marker file to the containerd and kubelet sysext images so both get a new digest. That is what drives the update: new digest in the images-digests ConfigMap -> node-controller renders it into NodeConfig -> generation bumps -> nodelet reports DisruptionRequired -> the cluster drains and approves -> nodelet downloads, installs, merges and restarts the units.

The marker lands at /usr/lib/nodelet-sysext-test-{containerd,kubelet} on the node, so the merged overlay can be verified directly.

Not for merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)