### PR TITLE
[docbuilder] Enhance documentation fetching logic to include downloaded directory

### DIFF
--- a/deckhouse-controller/pkg/controller/module-controllers/docbuilder/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/docbuilder/controller.go
@@ -264,6 +264,7 @@ func (r *reconciler) createOrUpdateReconcile(ctx context.Context, md *v1alpha1.M
 		}
 
 		if fetchModuleErr != nil {
+			r.logger.Error("Failed to fetch documentation from module directory", slog.String("module_name", moduleName), slog.String("address", addr), slog.String("path", md.Spec.Path), log.Err(fetchModuleErr))
 			cond.Type = v1alpha1.TypeError
 			cond.Message = fmt.Sprintf("Error occurred while fetching the documentation: %s. Please fix the module's docs or restart the Deckhouse to restore the module", fetchModuleErr)
 			mdCopy.Status.Conditions = append(mdCopy.Status.Conditions, cond)

--- a/deckhouse-controller/pkg/controller/module-controllers/docbuilder/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/docbuilder/controller.go
@@ -234,7 +234,7 @@ func (r *reconciler) createOrUpdateReconcile(ctx context.Context, md *v1alpha1.M
 	b := new(bytes.Buffer)
 
 	r.logger.Debug("Getting module's documentation locally", slog.String("module_name", moduleName))
-	fetchModuleErr := r.getDocumentationFromModuleDir(md.Spec.Path, b)
+	fetchModuleErr := r.getDocumentationFromModuleOrDownloadedDir(md.Spec.Path, b)
 
 	var rendered int
 	now := metav1.NewTime(r.dc.GetClock().Now().UTC())
@@ -264,7 +264,6 @@ func (r *reconciler) createOrUpdateReconcile(ctx context.Context, md *v1alpha1.M
 		}
 
 		if fetchModuleErr != nil {
-			r.logger.Error("Failed to fetch documentation from module directory", slog.String("module_name", moduleName), slog.String("address", addr), slog.String("path", md.Spec.Path), log.Err(fetchModuleErr))
 			cond.Type = v1alpha1.TypeError
 			cond.Message = fmt.Sprintf("Error occurred while fetching the documentation: %s. Please fix the module's docs or restart the Deckhouse to restore the module", fetchModuleErr)
 			mdCopy.Status.Conditions = append(mdCopy.Status.Conditions, cond)
@@ -344,12 +343,34 @@ func (r *reconciler) getDocsBuilderAddresses(ctx context.Context) ([]string, err
 	return addresses, nil
 }
 
+// If the documentation is not present in the module directory, try to get it from the downloaded directory.
+func (r *reconciler) getDocumentationFromModuleOrDownloadedDir(modulePath string, buf *bytes.Buffer) error {
+	err := r.getDocumentationFromModuleDir(modulePath, buf)
+	if err != nil && errors.Is(err, os.ErrNotExist) {
+		return r.getDocumentationFromDownloadedDir(modulePath, buf)
+	}
+	return err
+}
+
 func (r *reconciler) getDocumentationFromModuleDir(modulePath string, buf *bytes.Buffer) error {
 	// modulePath is now in format "/modules/<module>" (e.g., "/modules/stronghold")
 	// Remove leading slash and join with downloadedModulesDir to get full path
 	cleanPath := strings.TrimPrefix(modulePath, "/")
 	moduleDir := filepath.Join(r.downloadedModulesDir, cleanPath)
 
+	return r.getDocumentationFromDir(moduleDir, buf)
+}
+
+func (r *reconciler) getDocumentationFromDownloadedDir(modulePath string, buf *bytes.Buffer) error {
+	// modulePath is now in format "/<module>" (e.g., "/stronghold")
+	// Remove leading slash and join with downloadedModulesDir to get full path
+	cleanPath := strings.TrimPrefix(modulePath, "/")
+	moduleDir := filepath.Join(r.downloadedModulesDir, cleanPath)
+
+	return r.getDocumentationFromDir(moduleDir, buf)
+}
+
+func (r *reconciler) getDocumentationFromDir(moduleDir string, buf *bytes.Buffer) error {
 	dir, err := os.Stat(moduleDir)
 	if err != nil {
 		return fmt.Errorf("stat: %w", err)

--- a/deckhouse-controller/pkg/controller/module-controllers/docbuilder/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/docbuilder/controller.go
@@ -365,6 +365,7 @@ func (r *reconciler) getDocumentationFromDownloadedDir(modulePath string, versio
 	// modulePath is now in format "/<module>/<version>" (e.g., "/stronghold/v1.0.0")
 	// Remove leading slash and join with downloadedModulesDir to get full path
 	cleanPath := strings.TrimPrefix(modulePath, "/")
+	cleanPath = strings.TrimPrefix(cleanPath, "modules/")
 	moduleDir := filepath.Join(r.downloadedModulesDir, cleanPath, version)
 
 	return r.getDocumentationFromDir(moduleDir, buf)

--- a/deckhouse-controller/pkg/controller/module-controllers/docbuilder/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/docbuilder/controller.go
@@ -233,8 +233,8 @@ func (r *reconciler) createOrUpdateReconcile(ctx context.Context, md *v1alpha1.M
 
 	b := new(bytes.Buffer)
 
-	r.logger.Debug("Getting module's documentation locally", slog.String("module_name", moduleName))
-	fetchModuleErr := r.getDocumentationFromModuleOrDownloadedDir(md.Spec.Path, b)
+	r.logger.Debug("Getting module's documentation locally", slog.String("module_name", moduleName), slog.String("version", md.Spec.Version))
+	fetchModuleErr := r.getDocumentationFromModuleOrDownloadedDir(md.Spec.Path, md.Spec.Version, b)
 
 	var rendered int
 	now := metav1.NewTime(r.dc.GetClock().Now().UTC())
@@ -344,10 +344,10 @@ func (r *reconciler) getDocsBuilderAddresses(ctx context.Context) ([]string, err
 }
 
 // If the documentation is not present in the module directory, try to get it from the downloaded directory.
-func (r *reconciler) getDocumentationFromModuleOrDownloadedDir(modulePath string, buf *bytes.Buffer) error {
+func (r *reconciler) getDocumentationFromModuleOrDownloadedDir(modulePath string, version string, buf *bytes.Buffer) error {
 	err := r.getDocumentationFromModuleDir(modulePath, buf)
 	if err != nil && errors.Is(err, os.ErrNotExist) {
-		return r.getDocumentationFromDownloadedDir(modulePath, buf)
+		return r.getDocumentationFromDownloadedDir(modulePath, version, buf)
 	}
 	return err
 }
@@ -361,11 +361,11 @@ func (r *reconciler) getDocumentationFromModuleDir(modulePath string, buf *bytes
 	return r.getDocumentationFromDir(moduleDir, buf)
 }
 
-func (r *reconciler) getDocumentationFromDownloadedDir(modulePath string, buf *bytes.Buffer) error {
-	// modulePath is now in format "/<module>" (e.g., "/stronghold")
+func (r *reconciler) getDocumentationFromDownloadedDir(modulePath string, version string, buf *bytes.Buffer) error {
+	// modulePath is now in format "/<module>/<version>" (e.g., "/stronghold/v1.0.0")
 	// Remove leading slash and join with downloadedModulesDir to get full path
 	cleanPath := strings.TrimPrefix(modulePath, "/")
-	moduleDir := filepath.Join(r.downloadedModulesDir, cleanPath)
+	moduleDir := filepath.Join(r.downloadedModulesDir, cleanPath, version)
 
 	return r.getDocumentationFromDir(moduleDir, buf)
 }

--- a/deckhouse-controller/pkg/controller/module-controllers/docbuilder/controller_test.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/docbuilder/controller_test.go
@@ -196,6 +196,19 @@ func (suite *ControllerTestSuite) TestCreateReconcile() {
 		require.NoError(suite.T(), err)
 	})
 
+	suite.Run("module dir is absent, docs are in the downloaded dir", func() {
+		require.NoError(suite.T(), os.RemoveAll(filepath.Join(suite.tmpDir, "modules", "testmodule")))
+		suite.prepareDownloadedModuleOpenAPI("testmodule", "v1.0.0")
+		dependency.TestDC.HTTPClient.DoMock.Set(docBuildResponder("/api/v1/doc/testmodule/v1.0.0"))
+
+		suite.setupController("downloaded-dir.yaml")
+
+		md := suite.getModuleDocumentation("testmodule")
+		res, err := suite.ctr.createOrUpdateReconcile(context.TODO(), md)
+		assert.False(suite.T(), res.Requeue)
+		require.NoError(suite.T(), err)
+	})
+
 	suite.Run("with empty dir", func() {
 		suite.setupController("empty-dir.yaml")
 
@@ -210,6 +223,15 @@ func (suite *ControllerTestSuite) TestCreateReconcile() {
 // has something to read.
 func (suite *ControllerTestSuite) prepareModuleOpenAPI(module string) {
 	openapiDir := filepath.Join(suite.tmpDir, "modules", module, "openapi")
+	_ = os.MkdirAll(openapiDir, 0o777)
+	_ = os.WriteFile(filepath.Join(openapiDir, "config-values.yaml"), []byte("{}"), 0o666)
+}
+
+// prepareDownloadedModuleOpenAPI lays the openapi config down into the module's
+// downloaded dir <module>/<version>, the one the module is unpacked into before
+// being mounted at modules/<module>.
+func (suite *ControllerTestSuite) prepareDownloadedModuleOpenAPI(module, version string) {
+	openapiDir := filepath.Join(suite.tmpDir, module, version, "openapi")
 	_ = os.MkdirAll(openapiDir, 0o777)
 	_ = os.WriteFile(filepath.Join(openapiDir, "config-values.yaml"), []byte("{}"), 0o666)
 }

--- a/deckhouse-controller/pkg/controller/module-controllers/docbuilder/testdata/downloaded-dir.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/docbuilder/testdata/downloaded-dir.yaml
@@ -1,0 +1,21 @@
+# Module isn't mounted at modules/testmodule, docs are only in testmodule/v1.0.0
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleDocumentation
+metadata:
+  name: testmodule
+spec:
+  version: v1.0.0
+  checksum: abc
+  path: /modules/testmodule
+---
+apiVersion: coordination.k8s.io/v1
+kind: Lease
+metadata:
+  labels:
+    deckhouse.io/documentation-builder-sync: ""
+  name: module-docs-builder-ldq7x
+  namespace: d8-system
+spec:
+  holderIdentity: 10-111-111-11.d8-system.pod.cluster.local:8081
+  leaseDurationSeconds: 35
+  renewTime: "2024-05-08T12:11:04.160683Z"

--- a/deckhouse-controller/pkg/controller/module-controllers/docbuilder/testdata/golden/downloaded-dir.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/docbuilder/testdata/golden/downloaded-dir.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleDocumentation
+metadata:
+  finalizers:
+  - modules.deckhouse.io/documentation-exists
+  name: testmodule
+  resourceVersion: "1001"
+spec:
+  checksum: abc
+  path: /modules/testmodule
+  version: v1.0.0
+status:
+  conditions:
+  - address: http://10-111-111-11.d8-system.pod.cluster.local:8081
+    checksum: abc
+    lastTransitionTime: "2019-10-17T16:33:00Z"
+    type: Rendered
+    version: v1.0.0
+  result: Rendered

--- a/deckhouse-controller/pkg/controller/module-controllers/docbuilder/testdata/golden/empty-dir.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/docbuilder/testdata/golden/empty-dir.yaml
@@ -13,7 +13,7 @@ status:
   - address: http://10-222-222-22.d8-system.pod.cluster.local:8081
     checksum: abc
     lastTransitionTime: "2019-10-17T16:33:00Z"
-    message: 'Error occurred while fetching the documentation: stat: stat /testdir/modules/absentmodule:
+    message: 'Error occurred while fetching the documentation: stat: stat /testdir/absentmodule/v1.0.0:
       no such file or directory. Please fix the module''s docs or restart the Deckhouse
       to restore the module'
     type: Error


### PR DESCRIPTION
## Description
When module is embedded, but have a ModuleRelease (can be downloaded as external) it can't process the ModuleDocumentation. Controller trying to find module files are not linked to `/downloaded/modules/<module>` in this case. Module files still located in `/downloaded/<module>/<version>`
This PR adds support for search documentation to render in additional path.

Before:
```yaml
apiVersion: deckhouse.io/v1alpha1
kind: ModuleDocumentation
metadata:
  labels:
    module: monitoring-kubernetes
    source: deckhouse
  name: monitoring-kubernetes
spec:
  path: /modules/monitoring-kubernetes
  version: v1.0.2
status:
  conditions:
  - message: 'Error occurred while fetching the documentation: stat: stat /deckhouse/downloaded/modules/monitoring-kubernetes/v1.0.2:
      no such file or directory. Please fix the module''s docs or restart the Deckhouse
      to restore the module'
    type: Error
    version: v1.0.2
  result: Error
```

After:
```yaml
apiVersion: deckhouse.io/v1alpha1
kind: ModuleDocumentation
metadata:
  labels:
    module: monitoring-kubernetes
    source: deckhouse
  name: monitoring-kubernetes
spec:
  path: /modules/monitoring-kubernetes
  version: v1.0.2
status:
  conditions:
  - type: Rendered
    version: v1.0.0
  result: Rendered
```

## Why do we need it, and what problem does it solve?
Documentation for downloaded modules can't be pre-rendered until embedded module not external.


## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs-builder
type: fix
summary:  Documentation can now be builded for embedded modules, that have external version.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
