### PR TITLE
[deckhouse] Make packages nelm operation timeout configurable

### DIFF
--- a/deckhouse-controller/internal/packages/nelm/service.go
+++ b/deckhouse-controller/internal/packages/nelm/service.go
@@ -109,12 +109,6 @@ type Service struct {
 
 // NewService creates a new nelm service for managing Helm releases.
 func NewService(cache runtimecache.Cache, callback drift.AbsentCallback, status *status.Service, logger *log.Logger) *Service {
-	timeout, err := timeoutFromEnv()
-	if err != nil {
-		logger.Warn("invalid PACKAGE_NELM_TIMEOUT, using default",
-			slog.Duration("default", defaultPackageNelmTimeout), log.Err(err))
-	}
-
 	nelmClient := nelm.New(logger,
 		nelm.WithResourcesLabels(map[string]string{
 			"heritage": "deckhouse",
@@ -122,7 +116,7 @@ func NewService(cache runtimecache.Cache, callback drift.AbsentCallback, status 
 		nelm.WithReleaseAnnotations(map[string]string{
 			managedByAnnotation: managedByAnnotationValue,
 		}),
-		nelm.WithTimeout(timeout),
+		nelm.WithTimeout(resolveTimeout()),
 	)
 
 	return &Service{
@@ -547,17 +541,13 @@ func (s *Service) isHelmChart(path string) (bool, error) {
 	return false, nil
 }
 
-// timeoutFromEnv reads PACKAGE_NELM_TIMEOUT (a Go duration such as "30m"). An empty
-// value yields defaultPackageNelmTimeout; a malformed value yields the same default
-// together with the parse error so the caller can report it.
-func timeoutFromEnv() (time.Duration, error) {
-	raw, ok := os.LookupEnv(envPackageNelmTimeout)
-	if !ok || raw == "" {
-		return defaultPackageNelmTimeout, nil
+// resolveTimeout returns the nelm release-operation timeout: the PACKAGE_NELM_TIMEOUT
+// value (a Go duration such as "30m") when it is set and valid, otherwise
+// defaultPackageNelmTimeout.
+func resolveTimeout() time.Duration {
+	if d, err := time.ParseDuration(os.Getenv(envPackageNelmTimeout)); err == nil {
+		return d
 	}
-	timeout, err := time.ParseDuration(raw)
-	if err != nil {
-		return defaultPackageNelmTimeout, err
-	}
-	return timeout, nil
+
+	return defaultPackageNelmTimeout
 }

--- a/deckhouse-controller/internal/packages/nelm/service.go
+++ b/deckhouse-controller/internal/packages/nelm/service.go
@@ -24,6 +24,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 
 	addonutils "github.com/flant/addon-operator/pkg/utils"
 	"github.com/google/uuid"
@@ -48,6 +49,15 @@ const (
 	// managedByAnnotation marks a release as owned by this service.
 	managedByAnnotation      = "packages.deckhouse.io/managed-by"
 	managedByAnnotationValue = "deckhouse"
+)
+
+const (
+	// envPackageNelmTimeout sets the timeout for every nelm release operation on the
+	// packages path. Its value is a Go duration (for example "30m") and is set on the
+	// Deckhouse deployment.
+	envPackageNelmTimeout = "PACKAGE_NELM_TIMEOUT"
+	// defaultPackageNelmTimeout applies when PACKAGE_NELM_TIMEOUT is unset or malformed.
+	defaultPackageNelmTimeout = 30 * time.Minute
 )
 
 const (
@@ -106,6 +116,7 @@ func NewService(cache runtimecache.Cache, callback drift.AbsentCallback, status 
 		nelm.WithReleaseAnnotations(map[string]string{
 			managedByAnnotation: managedByAnnotationValue,
 		}),
+		nelm.WithTimeout(packageNelmTimeout(logger)),
 	)
 
 	return &Service{
@@ -115,6 +126,29 @@ func NewService(cache runtimecache.Cache, callback drift.AbsentCallback, status 
 		monitorManager: drift.New(cache, nelmClient, callback, logger),
 		logger:         logger.Named(nelmServiceTracer),
 	}
+}
+
+// packageNelmTimeout returns the timeout for every nelm release operation on the
+// packages path. It reads PACKAGE_NELM_TIMEOUT (a Go duration such as "30m") set on
+// the Deckhouse deployment; an unset or malformed value falls back to
+// defaultPackageNelmTimeout.
+func packageNelmTimeout(logger *log.Logger) time.Duration {
+	raw := os.Getenv(envPackageNelmTimeout)
+	if raw == "" {
+		return defaultPackageNelmTimeout
+	}
+
+	timeout, err := time.ParseDuration(raw)
+	if err != nil {
+		logger.Warn("invalid PACKAGE_NELM_TIMEOUT, using default",
+			slog.String("value", raw),
+			slog.Duration("default_timeout", defaultPackageNelmTimeout),
+			log.Err(err))
+
+		return defaultPackageNelmTimeout
+	}
+
+	return timeout
 }
 
 // HasMonitor checks if a release monitor exists for the given name.

--- a/deckhouse-controller/internal/packages/nelm/service.go
+++ b/deckhouse-controller/internal/packages/nelm/service.go
@@ -52,11 +52,11 @@ const (
 )
 
 const (
-	// envPackageNelmTimeout sets the timeout for every nelm release operation on the
-	// packages path. Its value is a Go duration (for example "30m") and is set on the
-	// Deckhouse deployment.
+	// envPackageNelmTimeout is the env var (set on the Deckhouse deployment) that
+	// bounds each nelm release operation on the packages path. Its value is a Go
+	// duration, e.g. "30m".
 	envPackageNelmTimeout = "PACKAGE_NELM_TIMEOUT"
-	// defaultPackageNelmTimeout applies when PACKAGE_NELM_TIMEOUT is unset or malformed.
+	// defaultPackageNelmTimeout applies when envPackageNelmTimeout is unset or malformed.
 	defaultPackageNelmTimeout = 30 * time.Minute
 )
 
@@ -109,6 +109,12 @@ type Service struct {
 
 // NewService creates a new nelm service for managing Helm releases.
 func NewService(cache runtimecache.Cache, callback drift.AbsentCallback, status *status.Service, logger *log.Logger) *Service {
+	timeout, err := releaseTimeout()
+	if err != nil {
+		logger.Warn("invalid PACKAGE_NELM_TIMEOUT, using default",
+			slog.Duration("default", defaultPackageNelmTimeout), log.Err(err))
+	}
+
 	nelmClient := nelm.New(logger,
 		nelm.WithResourcesLabels(map[string]string{
 			"heritage": "deckhouse",
@@ -116,7 +122,7 @@ func NewService(cache runtimecache.Cache, callback drift.AbsentCallback, status 
 		nelm.WithReleaseAnnotations(map[string]string{
 			managedByAnnotation: managedByAnnotationValue,
 		}),
-		nelm.WithTimeout(packageNelmTimeout(logger)),
+		nelm.WithTimeout(timeout),
 	)
 
 	return &Service{
@@ -128,27 +134,19 @@ func NewService(cache runtimecache.Cache, callback drift.AbsentCallback, status 
 	}
 }
 
-// packageNelmTimeout returns the timeout for every nelm release operation on the
-// packages path. It reads PACKAGE_NELM_TIMEOUT (a Go duration such as "30m") set on
-// the Deckhouse deployment; an unset or malformed value falls back to
-// defaultPackageNelmTimeout.
-func packageNelmTimeout(logger *log.Logger) time.Duration {
-	raw := os.Getenv(envPackageNelmTimeout)
-	if raw == "" {
-		return defaultPackageNelmTimeout
+// releaseTimeout reads PACKAGE_NELM_TIMEOUT (a Go duration such as "30m"). An empty
+// value yields defaultPackageNelmTimeout; a malformed value yields the same default
+// together with the parse error so the caller can report it.
+func releaseTimeout() (time.Duration, error) {
+	v, ok := os.LookupEnv(envPackageNelmTimeout)
+	if !ok || v == "" {
+		return defaultPackageNelmTimeout, nil
 	}
-
-	timeout, err := time.ParseDuration(raw)
+	timeout, err := time.ParseDuration(v)
 	if err != nil {
-		logger.Warn("invalid PACKAGE_NELM_TIMEOUT, using default",
-			slog.String("value", raw),
-			slog.Duration("default_timeout", defaultPackageNelmTimeout),
-			log.Err(err))
-
-		return defaultPackageNelmTimeout
+		return defaultPackageNelmTimeout, err
 	}
-
-	return timeout
+	return timeout, nil
 }
 
 // HasMonitor checks if a release monitor exists for the given name.

--- a/deckhouse-controller/internal/packages/nelm/service.go
+++ b/deckhouse-controller/internal/packages/nelm/service.go
@@ -109,7 +109,7 @@ type Service struct {
 
 // NewService creates a new nelm service for managing Helm releases.
 func NewService(cache runtimecache.Cache, callback drift.AbsentCallback, status *status.Service, logger *log.Logger) *Service {
-	timeout, err := releaseTimeout()
+	timeout, err := timeoutFromEnv()
 	if err != nil {
 		logger.Warn("invalid PACKAGE_NELM_TIMEOUT, using default",
 			slog.Duration("default", defaultPackageNelmTimeout), log.Err(err))
@@ -132,21 +132,6 @@ func NewService(cache runtimecache.Cache, callback drift.AbsentCallback, status 
 		monitorManager: drift.New(cache, nelmClient, callback, logger),
 		logger:         logger.Named(nelmServiceTracer),
 	}
-}
-
-// releaseTimeout reads PACKAGE_NELM_TIMEOUT (a Go duration such as "30m"). An empty
-// value yields defaultPackageNelmTimeout; a malformed value yields the same default
-// together with the parse error so the caller can report it.
-func releaseTimeout() (time.Duration, error) {
-	v, ok := os.LookupEnv(envPackageNelmTimeout)
-	if !ok || v == "" {
-		return defaultPackageNelmTimeout, nil
-	}
-	timeout, err := time.ParseDuration(v)
-	if err != nil {
-		return defaultPackageNelmTimeout, err
-	}
-	return timeout, nil
 }
 
 // HasMonitor checks if a release monitor exists for the given name.
@@ -560,4 +545,19 @@ func (s *Service) isHelmChart(path string) (bool, error) {
 	s.logger.Warn("no helm chart found in path", slog.String("path", path))
 
 	return false, nil
+}
+
+// timeoutFromEnv reads PACKAGE_NELM_TIMEOUT (a Go duration such as "30m"). An empty
+// value yields defaultPackageNelmTimeout; a malformed value yields the same default
+// together with the parse error so the caller can report it.
+func timeoutFromEnv() (time.Duration, error) {
+	raw, ok := os.LookupEnv(envPackageNelmTimeout)
+	if !ok || raw == "" {
+		return defaultPackageNelmTimeout, nil
+	}
+	timeout, err := time.ParseDuration(raw)
+	if err != nil {
+		return defaultPackageNelmTimeout, err
+	}
+	return timeout, nil
 }

--- a/modules/002-deckhouse/templates/deployment.yaml
+++ b/modules/002-deckhouse/templates/deployment.yaml
@@ -187,6 +187,8 @@ spec:
               value: "false"
             - name: USE_NELM
               value: "true"
+            - name: PACKAGE_NELM_TIMEOUT
+              value: "30m"
             - name: LOG_TYPE
               value: "json"
             - name: DECKHOUSE_HA


### PR DESCRIPTION
## Description
Package (Application) installs and uninstalls ran every nelm release operation under a hardcoded 3-minute timeout — the default in the in-process nelm client wrapper (`deckhouse-controller/internal/nelm/client.go`). Installs whose resources legitimately take longer were aborted.

This exposes the timeout as the `PACKAGE_NELM_TIMEOUT` environment variable on the Deckhouse deployment and raises the effective default to 30 minutes. The value is a Go duration (e.g. `30m`); an unset or malformed value falls back to 30 minutes. Only the packages path is affected — it is the sole consumer of this client. Module Helm releases go through a different client and were never bound by this timeout.

## Why do we need it, and what problem does it solve?
Application installs whose resources take longer than 3 minutes to converge were failing prematurely on the nelm timeout. 30 minutes is a safer default for real workloads, and exposing it as an environment variable lets the timeout be tuned per deployment without a rebuild.

### Manual testing
Verified on a dev cluster: the controller re-rendered its own Deployment with the new variable set to 30m.

```
$ kubectl -n d8-system get deploy deckhouse -o jsonpath='{range .spec.template.spec.containers[?(@.name=="deckhouse")].env[*]}{.name}={.value}{"\n"}{end}' | grep -E 'PACKAGE_NELM_TIMEOUT|USE_NELM|DECKHOUSE_ENABLE_PACKAGE_SYSTEM'
DECKHOUSE_ENABLE_PACKAGE_SYSTEM=true
USE_NELM=true
PACKAGE_NELM_TIMEOUT=30m
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: feature
summary: Make packages nelm operation timeout configurable
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->



