### PR TITLE
[docs] Remove the duplicate components table from the OpenStack documentation

### DIFF
--- a/docs/documentation/_includes/admin/integrations/openstack-based-configuration-ru.md
+++ b/docs/documentation/_includes/admin/integrations/openstack-based-configuration-ru.md
@@ -445,24 +445,6 @@ spec:
       owner: default
 ```
 
-### Список необходимых сервисов
-
-Список сервисов {{ site.data.admin.cloud-types.types[page.cloud_type].name }}, необходимых для работы Deckhouse Kubernetes Platform в {{ site.data.admin.cloud-types.types[page.cloud_type].name }}:
-
-| Сервис                           | Версия API |
-|:---------------------------------|:----------:|
-| Identity (Keystone)              | v3         |
-| Compute (Nova)                   | v2         |
-| Network (Neutron)                | v2         |
-| Block Storage (Cinder)           | v3         |
-| Load Balancing (Octavia) *       | v2         |
-
-\* Если нужно заказывать Load Balancer.
-
-{% if page.cloud_type == 'vk-private' or page.cloud_type == 'vk' %}
-Адреса и порты API можно узнать [в официальной документации](https://cloud.vk.com/docs/tools-for-using-services/api/rest-api/endpoints).
-{% endif %}
-
 ### Настройка LoadBalancer
 
 {% alert level="warning" %}

--- a/docs/documentation/_includes/admin/integrations/openstack-based-configuration.md
+++ b/docs/documentation/_includes/admin/integrations/openstack-based-configuration.md
@@ -457,24 +457,6 @@ spec:
       owner: default
 ```
 
-### List of required services
-
-Below is the list of {{ site.data.admin.cloud-types.types[page.cloud_type].name }} services required for DKP to operate in {{ site.data.admin.cloud-types.types[page.cloud_type].name }}:
-
-| Service                           | API version |
-|:---------------------------------|:----------:|
-| Identity (Keystone)              | v3         |
-| Compute (Nova)                   | v2         |
-| Network (Neutron)                | v2         |
-| Block Storage (Cinder)           | v3         |
-| Load Balancing (Octavia) *       | v2         |
-
-\* If you need to provision a LoadBalancer.
-
-{% if page.cloud_type == 'vk-private' or page.cloud_type == 'vk' %}
-For the API endpoints and ports, refer to the [official documentation](https://cloud.vk.com/docs/en/tools-for-using-services/api/rest-api/endpoints).
-{% endif %}
-
 ### LoadBalancer configuration
 
 {% alert level="warning" %}


### PR DESCRIPTION
## Description
Removed the duplicate components table from the OpenStack documentation.

Fixes https://github.com/deckhouse/deckhouse/pull/21410

## Why do we need it, and what problem does it solve?


## Why do we need it in the patch release (if we do)?


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: docs
type: chore
summary: Removed the duplicate components table from the OpenStack documentation.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
