### PR TITLE
[keepalived][network-gateway] Fixed bug with Python

### DIFF
--- a/ee/modules/450-keepalived/images/keepalived/src/prepare-config.py
+++ b/ee/modules/450-keepalived/images/keepalived/src/prepare-config.py
@@ -6,6 +6,13 @@
 import json
 import os, sys
 import socket
+
+try:
+    import pysqlite3
+    sys.modules['sqlite3'] = pysqlite3
+except ImportError as e:
+    sys.exit(1)
+
 from pyroute2 import IPRoute
 
 KEEPALIVED_CONFIG_TEMPLATE = """

--- a/ee/modules/450-keepalived/images/keepalived/src/requirements.txt
+++ b/ee/modules/450-keepalived/images/keepalived/src/requirements.txt
@@ -1,2 +1,2 @@
 pyroute2==0.8.1
-
+pysqlite3-binary==0.5.4.post2

--- a/ee/modules/450-keepalived/images/keepalived/werf.inc.yaml
+++ b/ee/modules/450-keepalived/images/keepalived/werf.inc.yaml
@@ -43,14 +43,9 @@ git:
   stageDependencies:
     install:
     - '**/*'
-import:
-- image: common/wheel-artifact
-  add: /wheels
-  to: /wheels
-  before: install
 shell:
   beforeInstall:
-  - pm install python@3.12 gnu-glibc python-wheel
+  - pm install python@3.12 libc python-wheel
   install:
   - pip3 install -f file:///wheels --no-index --upgrade pip
   - pip3 install -f file:///wheels --no-index -r /requirements.txt

--- a/ee/modules/450-keepalived/images/keepalived/werf.inc.yaml
+++ b/ee/modules/450-keepalived/images/keepalived/werf.inc.yaml
@@ -37,20 +37,32 @@ shell:
 image: {{ $.ModuleName }}/{{ $.ImageName }}-python-artifact
 from: {{ index $.Images "builder/distroless" }}
 final: false
+git:
+- add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/src/requirements.txt
+  to: /requirements.txt
+  stageDependencies:
+    install:
+    - '**/*'
+import:
+- image: common/wheel-artifact
+  add: /wheels
+  to: /wheels
+  before: install
 shell:
   beforeInstall:
-  - pm install python@3.12 gnu-glibc python-wheel -d /out
+  - pm install python@3.12 gnu-glibc python-wheel coreutils -d /out
+  install:
+  - export PATH="/out/usr/bin:${PATH}"
+  - export LD_LIBRARY_PATH="/out/lib64:/out/usr/lib64:/out/lib:/out/usr/lib:${LD_LIBRARY_PATH}"
+  - pip3 install -f file:///wheels --no-index --upgrade pip --prefix=/out/usr
+  - pip3 install -f file:///wheels --no-index -r /requirements.txt --prefix=/out/usr
+  - rm -rf /out/usr/lib/python*/site-packages/pip-25.3* /out/usr/lib64/python*/site-packages/pip-25.3*
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
 from: {{ index $.Images "base/distroless-fin" }}
 git:
 - add: /{{ $.ModulePath }}modules/450-{{ $.ModuleName }}/images/{{ $.ImageName }}/src/prepare-config.py
   to: /prepare-config.py
-- add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/src/requirements.txt
-  to: /requirements.txt
-  stageDependencies:
-    install:
-    - '**/*'
 import:
 - image: {{ $.ModuleName }}/build-keepalived
   add: /opt/keepalived-static/usr/sbin/keepalived
@@ -64,13 +76,4 @@ import:
   add: /out
   to: /
   before: install
-- image: common/wheel-artifact
-  add: /wheels
-  to: /wheels
-  before: install
 {{- include "image mount points" . }}
-shell:
-  install:
-  - pip3 install -f file:///wheels --no-index --upgrade pip
-  - pip3 install -f file:///wheels --no-index -r /requirements.txt
-  - rm -rf /usr/lib/python*/site-packages/pip-25.3* /usr/lib64/python*/site-packages/pip-25.3* /wheels

--- a/ee/modules/450-keepalived/images/keepalived/werf.inc.yaml
+++ b/ee/modules/450-keepalived/images/keepalived/werf.inc.yaml
@@ -74,13 +74,11 @@ import:
   to: /
   before: install
   includePaths:
-  - lib64/ld-linux-x86-64.so.2
-  - lib64/lib*.so*
   - usr/bin/python3*
-  - usr/lib64/python3*
   - usr/lib/python3*
-  - usr/lib64/lib*.so*
   - usr/lib/lib*.so*
+  - usr/lib/ld-linux-x86-64.so.2
+  - lib64
   excludePaths:
   - usr/lib/python*/site-packages/pip-25.3*
   - usr/lib64/python*/site-packages/pip-25.3*

--- a/ee/modules/450-keepalived/images/keepalived/werf.inc.yaml
+++ b/ee/modules/450-keepalived/images/keepalived/werf.inc.yaml
@@ -34,7 +34,7 @@ shell:
   - chmod 0700 /opt/keepalived-static/usr/sbin/keepalived
   - chmod 0700 /opt/keepalived-static/usr/bin/genhash
 ---
-image: {{ $.ModuleName }}/{{ $.ImageName }}-python-artifact
+image: {{ $.ModuleName }}/{{ $.ImageName }}-wheel-artifact
 from: {{ index $.Images "builder/distroless" }}
 final: false
 git:
@@ -50,16 +50,13 @@ import:
   before: install
 shell:
   beforeInstall:
-  - pm install python@3.12 gnu-glibc python-wheel coreutils -d /out
+  - pm install python@3.12 gnu-glibc python-wheel
   install:
-  - export PATH="/out/usr/bin:${PATH}"
-  - export LD_LIBRARY_PATH="/out/lib64:/out/usr/lib64:/out/lib:/out/usr/lib:${LD_LIBRARY_PATH}"
-  - pip3 install -f file:///wheels --no-index --upgrade pip --prefix=/out/usr
-  - pip3 install -f file:///wheels --no-index -r /requirements.txt --prefix=/out/usr
-  - rm -rf /out/usr/lib/python*/site-packages/pip-25.3* /out/usr/lib64/python*/site-packages/pip-25.3*
+  - pip3 install -f file:///wheels --no-index --upgrade pip
+  - pip3 install -f file:///wheels --no-index -r /requirements.txt
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-from: {{ index $.Images "base/distroless-fin" }}
+fromImage: common/distroless
 git:
 - add: /{{ $.ModulePath }}modules/450-{{ $.ModuleName }}/images/{{ $.ImageName }}/src/prepare-config.py
   to: /prepare-config.py
@@ -72,8 +69,21 @@ import:
   add: /opt/keepalived-static/usr/bin/genhash
   to: /usr/bin/genhash
   before: install
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-python-artifact
-  add: /out
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-wheel-artifact
+  add: /
   to: /
   before: install
+  includePaths:
+  - lib64/ld-linux-x86-64.so.2
+  - lib64/lib*.so*
+  - usr/bin/python3*
+  - usr/lib64/python3*
+  - usr/lib/python3*
+  - usr/lib64/lib*.so*
+  - usr/lib/lib*.so*
+  excludePaths:
+  - usr/lib/python*/site-packages/pip-25.3*
+  - usr/lib64/python*/site-packages/pip-25.3*
+  - usr/lib/python*/test
+  - usr/lib64/python*/test
 {{- include "image mount points" . }}

--- a/ee/modules/450-keepalived/images/keepalived/werf.inc.yaml
+++ b/ee/modules/450-keepalived/images/keepalived/werf.inc.yaml
@@ -76,7 +76,5 @@ import:
   - lib64
   excludePaths:
   - usr/lib/python*/site-packages/pip-25.3*
-  - usr/lib64/python*/site-packages/pip-25.3*
   - usr/lib/python*/test
-  - usr/lib64/python*/test
 {{- include "image mount points" . }}

--- a/ee/modules/450-keepalived/images/keepalived/werf.inc.yaml
+++ b/ee/modules/450-keepalived/images/keepalived/werf.inc.yaml
@@ -34,32 +34,23 @@ shell:
   - chmod 0700 /opt/keepalived-static/usr/sbin/keepalived
   - chmod 0700 /opt/keepalived-static/usr/bin/genhash
 ---
-image: {{ $.ModuleName }}/{{ $.ImageName }}-wheel-artifact
+image: {{ $.ModuleName }}/{{ $.ImageName }}-python-artifact
 from: {{ index $.Images "builder/distroless" }}
 final: false
+shell:
+  beforeInstall:
+  - pm install python@3.12 gnu-glibc python-wheel -d /out
+---
+image: {{ .ModuleName }}/{{ .ImageName }}
+from: {{ index $.Images "base/distroless-fin" }}
 git:
+- add: /{{ $.ModulePath }}modules/450-{{ $.ModuleName }}/images/{{ $.ImageName }}/src/prepare-config.py
+  to: /prepare-config.py
 - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/src/requirements.txt
   to: /requirements.txt
   stageDependencies:
     install:
     - '**/*'
-import:
-- image: common/wheel-artifact
-  add: /wheels
-  to: /wheels
-  before: install
-shell:
-  beforeInstall:
-  - pm install python@3.12 gnu-glibc python-wheel
-  install:
-  - pip3 install -f file:///wheels --no-index --upgrade pip
-  - pip3 install -f file:///wheels --no-index -r /requirements.txt
----
-image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
-git:
-- add: /{{ $.ModulePath }}modules/450-{{ $.ModuleName }}/images/{{ $.ImageName }}/src/prepare-config.py
-  to: /prepare-config.py
 import:
 - image: {{ $.ModuleName }}/build-keepalived
   add: /opt/keepalived-static/usr/sbin/keepalived
@@ -69,17 +60,17 @@ import:
   add: /opt/keepalived-static/usr/bin/genhash
   to: /usr/bin/genhash
   before: install
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-wheel-artifact
-  add: /
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-python-artifact
+  add: /out
   to: /
   before: install
-  includePaths:
-  - lib64/ld-linux-x86-64.so.2
-  - usr/bin/python3*
-  - usr/lib64/python3*
-  - usr/lib/python3*
-  - usr/lib64/lib*.so*
-  excludePaths:
-  - usr/lib/python*/site-packages/pip-25.3*
-  - usr/lib/python*/test
+- image: common/wheel-artifact
+  add: /wheels
+  to: /wheels
+  before: install
 {{- include "image mount points" . }}
+shell:
+  install:
+  - pip3 install -f file:///wheels --no-index --upgrade pip
+  - pip3 install -f file:///wheels --no-index -r /requirements.txt
+  - rm -rf /usr/lib/python*/site-packages/pip-25.3* /usr/lib64/python*/site-packages/pip-25.3* /wheels

--- a/ee/modules/450-network-gateway/images/dnsmasq/src/prepare-config.py
+++ b/ee/modules/450-network-gateway/images/dnsmasq/src/prepare-config.py
@@ -7,6 +7,13 @@ import json
 import os, sys
 import socket
 import ipcalc
+
+try:
+    import pysqlite3
+    sys.modules['sqlite3'] = pysqlite3
+except ImportError as e:
+    sys.exit(1)
+
 from pyroute2 import IPRoute
 
 class dnsmasqConfig:

--- a/ee/modules/450-network-gateway/images/dnsmasq/src/requirements.txt
+++ b/ee/modules/450-network-gateway/images/dnsmasq/src/requirements.txt
@@ -1,3 +1,4 @@
 pyroute2==0.8.1
 six==1.17.0
 ipcalc==1.99.0
+pysqlite3-binary==0.5.4.post2

--- a/ee/modules/450-network-gateway/images/dnsmasq/werf.inc.yaml
+++ b/ee/modules/450-network-gateway/images/dnsmasq/werf.inc.yaml
@@ -4,7 +4,7 @@ final: false
 from: {{ index $.Images "builder/distroless" }}
 shell:
   beforeInstall:
-  - pm install dnsmasq sqlite python@3.12 gnu-glibc python-wheel -d /out
+  - pm install dnsmasq python@3.12 libc python-wheel -d /out
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
 from: {{ index $.Images "base/distroless-fin" }}


### PR DESCRIPTION
## Description
This PR fixes Python in the `450-keepalived` and `450-network-gateway` modules image.

## Why do we need it, and what problem does it solve?
After migrating to the new image build process in PR #20540, Python stopped working due to incorrect linking of the C standard library. This PR fixes the linking issue and restores Python functionality in the module image.

## Why do we need it in the patch release (if we do)?
This issue breaks Python in the released module image, which can affect runtime behavior and maintenance tasks. The fix restores the expected functionality and should therefore be included in a patch release.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: network-gateway
type: fix
summary: Fixed Python linking in the network-gateway module image.
impact_level: low
---
section: keepalived
type: fix
summary: Fixed Python linking in the keepalived module image.
impact_level: low
```
