### PR TITLE
[descheduler] Rename dashboard to Workload Happiness

### DIFF
--- a/modules/400-descheduler/monitoring/grafana-dashboards/descheduler/workload-happiness.json
+++ b/modules/400-descheduler/monitoring/grafana-dashboards/descheduler/workload-happiness.json
@@ -1,6 +1,6 @@
 {
-  "title": "Descheduler / DRS-Lens",
-  "uid": "descheduler-drs-lens",
+  "title": "Descheduler / Workload Happiness",
+  "uid": "descheduler-workload-happiness",
   "schemaVersion": 39,
   "editable": false,
   "graphTooltip": 1,

--- a/modules/400-descheduler/monitoring/prometheus-rules/workload-happiness.yaml
+++ b/modules/400-descheduler/monitoring/prometheus-rules/workload-happiness.yaml
@@ -1,4 +1,4 @@
-- name: descheduler.drs-lens.happiness
+- name: descheduler.workload-happiness.happiness
   rules:
   - record: descheduler:replicaset_workload
     expr: |
@@ -241,7 +241,7 @@
     labels: { bucket: unhappy }
     expr: descheduler:workload_happiness_score < 60
 
-- name: descheduler.drs-lens.balance
+- name: descheduler.workload-happiness.balance
   rules:
   - record: descheduler:node_pod_allocation_ratio
     expr: |


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Rename dashboard to Workload Happiness
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: descheduler
type: chore
summary: Renamed the dashboard to Workload Happiness.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
