### PR TITLE
Backport: [deckhouse-controller] fix: ensure embedded module source

### DIFF
--- a/deckhouse-controller/pkg/controller/moduleloader/loader.go
+++ b/deckhouse-controller/pkg/controller/moduleloader/loader.go
@@ -496,8 +496,18 @@ func (l *Loader) ensureModule(ctx context.Context, def *moduletypes.Definition, 
 				// set deckhouse version to embedded modules
 				module.Properties.Version = l.version
 
-				// set embedded source if its unset
-				if len(module.Properties.Source) == 0 {
+				// A physically embedded module must always report Source == "Embedded".
+				// This branch runs for a def parsed from the embedded modules dir, which
+				// takes precedence over the downloaded one, so the module is served by the
+				// embedded copy and its active source cannot be an external one.
+				//
+				// Force the sentinel back, do not merely fill it when empty: a stale
+				// external value (e.g. left over from an erroneous flip after a registry
+				// migration) would otherwise stick across restarts and could only be
+				// cleared by manually deleting the Module resource. ensureModule runs on
+				// every startup over exactly the set of physically embedded modules, so it
+				// is the authoritative reconciliation point for this invariant.
+				if module.Properties.Source != v1alpha1.ModuleSourceEmbedded {
 					module.Properties.Source = v1alpha1.ModuleSourceEmbedded
 				}
 			}

--- a/deckhouse-controller/pkg/controller/moduleloader/loader_test.go
+++ b/deckhouse-controller/pkg/controller/moduleloader/loader_test.go
@@ -1,0 +1,127 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package moduleloader
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
+	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha2"
+	moduletypes "github.com/deckhouse/deckhouse/deckhouse-controller/pkg/controller/moduleloader/types"
+	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/helpers"
+	"github.com/deckhouse/deckhouse/pkg/log"
+)
+
+// newEnsureLoader builds a Loader with everything ensureModule reads: a fake
+// client, the embedded update policy (for the release channel) and a version.
+func newEnsureLoader(t *testing.T, objects ...client.Object) *Loader {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1alpha1.SchemeBuilder.AddToScheme(scheme))
+	require.NoError(t, v1alpha2.SchemeBuilder.AddToScheme(scheme))
+
+	return &Loader{
+		client:  fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build(),
+		logger:  log.NewNop(),
+		version: "v1.73.0",
+		embeddedPolicy: helpers.NewModuleUpdatePolicySpecContainer(&v1alpha2.ModuleUpdatePolicySpec{
+			ReleaseChannel: "Stable",
+		}),
+	}
+}
+
+func ensureTestModule(name, source string) *v1alpha1.Module {
+	return &v1alpha1.Module{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       v1alpha1.ModuleGVK.Kind,
+			APIVersion: v1alpha1.ModuleGVK.GroupVersion().String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Properties: v1alpha1.ModuleProperties{Source: source},
+	}
+}
+
+func getEnsuredModule(t *testing.T, l *Loader, name string) *v1alpha1.Module {
+	t.Helper()
+
+	module := new(v1alpha1.Module)
+	require.NoError(t, l.client.Get(context.Background(), client.ObjectKey{Name: name}, module))
+
+	return module
+}
+
+// TestEnsureModuleEmbeddedSource verifies that ensureModule keeps the invariant
+// "a physically embedded module always reports Source == Embedded". This is the
+// reconciliation point that heals a stale external source (e.g. deckhouse) left
+// on an embedded module by an erroneous flip after a registry migration - a
+// value that otherwise stuck until the Module was deleted by hand.
+func TestEnsureModuleEmbeddedSource(t *testing.T) {
+	embeddedDef := func() *moduletypes.Definition {
+		return &moduletypes.Definition{
+			Name:   "ingress-nginx",
+			Weight: 380,
+			// parsed from the embedded modules dir - i.e. shipped on the filesystem
+			Path: embeddedModulesDir + "/380-ingress-nginx",
+		}
+	}
+
+	t.Run("stale external source on an embedded module is reset to Embedded", func(t *testing.T) {
+		l := newEnsureLoader(t, ensureTestModule("ingress-nginx", "deckhouse"))
+
+		require.NoError(t, l.ensureModule(context.Background(), embeddedDef(), true))
+
+		module := getEnsuredModule(t, l, "ingress-nginx")
+		assert.Equal(t, v1alpha1.ModuleSourceEmbedded, module.Properties.Source,
+			"embedded module must be pinned back to the Embedded source")
+	})
+
+	t.Run("empty source on an embedded module is set to Embedded", func(t *testing.T) {
+		l := newEnsureLoader(t, ensureTestModule("ingress-nginx", ""))
+
+		require.NoError(t, l.ensureModule(context.Background(), embeddedDef(), true))
+
+		module := getEnsuredModule(t, l, "ingress-nginx")
+		assert.Equal(t, v1alpha1.ModuleSourceEmbedded, module.Properties.Source)
+	})
+
+	t.Run("embedded source is left untouched", func(t *testing.T) {
+		l := newEnsureLoader(t, ensureTestModule("ingress-nginx", v1alpha1.ModuleSourceEmbedded))
+
+		require.NoError(t, l.ensureModule(context.Background(), embeddedDef(), true))
+
+		module := getEnsuredModule(t, l, "ingress-nginx")
+		assert.Equal(t, v1alpha1.ModuleSourceEmbedded, module.Properties.Source)
+	})
+
+	t.Run("downloaded (non-embedded) module keeps its external source", func(t *testing.T) {
+		l := newEnsureLoader(t, ensureTestModule("echo", "example"))
+		def := &moduletypes.Definition{Name: "echo", Weight: 900, Path: "/deckhouse/downloaded/modules/echo"}
+
+		require.NoError(t, l.ensureModule(context.Background(), def, false))
+
+		module := getEnsuredModule(t, l, "echo")
+		assert.Equal(t, "example", module.Properties.Source,
+			"a downloaded module must not be forced to the Embedded source")
+	})
+}


### PR DESCRIPTION
> [!NOTE]
> **Backport of #21473 to `release-1.73`.**
> Cherry-pick of commit `cdd0343cd0eb133638950db9d519d3d5d2df163d`.
>
> The fix in `loader.go` is applied as is. Two adjustments were needed for this branch:
> - The unit test could not be cherry-picked: `sync_test.go` here is still the old testify suite and has none of the helpers the original test uses. The same four cases were rewritten as a self-contained `loader_test.go`.
> - The comment referred to `IsEmbeddedPresent` and to guards that do not exist in this branch. It now states only what holds here: the embedded modules dir precedes the downloaded one in `MODULES_DIR`, so a physically embedded module is always served by its embedded copy.
>
> Note that 1.73 does not have the companion hardening from #21129 / #21131 ("forbid create mr if embedded module enabled"), which added the `isEmbeddedModule` guard to `needToEnsureRelease` in the module source controller. Without it the source controller can still flip the source of an embedded module at runtime. This backport heals the value on every controller start, but a full fix for 1.73 also needs that hardening.

## Description

`ensureModule` runs on every controller startup over the set of physically embedded modules. Previously it only set `Properties.Source = Embedded` when the field was **empty**:

```go
if len(module.Properties.Source) == 0 {
    module.Properties.Source = v1alpha1.ModuleSourceEmbedded
}
```

This means a *stale, non-empty external* source (e.g. `deckhouse`) left on an embedded module would never be corrected. Once set, the wrong value stuck across every restart and could only be cleared by manually deleting the `Module` resource.

This PR changes the check to force the sentinel back whenever it is not already `Embedded`:

```go
if module.Properties.Source != v1alpha1.ModuleSourceEmbedded {
    module.Properties.Source = v1alpha1.ModuleSourceEmbedded
}
```

Because this branch only runs for definitions parsed from the embedded modules dir — i.e. the embedded copy is physically shipped on the filesystem — the module is served by that copy and its active source cannot legitimately be external. The transition off the `Embedded` sentinel (moduleloader restore, release deploy) happens elsewhere and is gated on `!IsEmbeddedPresent`, so it can never be external while `ensureModule` is running. This makes `ensureModule` the authoritative reconciliation point for the invariant "a physically embedded module always reports `Source == Embedded`".

Downloaded (non-embedded) modules are unaffected and keep their external source.

## Why do we need it, and what problem does it solve?

Fixes the invariant that an embedded module must always report `Source == "Embedded"`. A pre-hardening erroneous flip (e.g. after a registry migration) could leave an external source value on an embedded module. With the old empty-only check, that value was never healed and persisted across restarts, with the only workaround being to delete the `Module` resource by hand. This makes startup reconciliation self-healing for that case.

## Why do we need it in the patch release (if we do)?

Clusters that already hit the erroneous flip are stuck with a wrong `Source` on embedded modules until the operator manually deletes the affected `Module` resources. Backporting lets those clusters self-heal on the next controller restart without manual intervention.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse-controller
type: fix
summary: Force embedded modules back to the "Embedded" source on startup, healing a stale external source that previously stuck until the Module resource was deleted manually.
impact_level: default
```

