### PR TITLE
[node-manager] Fix kubernetes_api_proxy create certs hook

### DIFF
--- a/modules/040-node-manager/hooks/create_rbac_and_certificate_for_kubernetes_api_proxy.go
+++ b/modules/040-node-manager/hooks/create_rbac_and_certificate_for_kubernetes_api_proxy.go
@@ -27,7 +27,9 @@ import (
 	"github.com/pkg/errors"
 	certificatesv1 "k8s.io/api/certificates/v1"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 
@@ -67,6 +69,10 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	},
 }, dependency.WithExternalDependencies(createRBACForKubeAPIServerProxy))
 
+// issueKubeAPIProxyCertificate is a seam over tls_certificate.IssueCertificate so the
+// certificate-generation path can be exercised in unit tests without a CSR signer.
+var issueKubeAPIProxyCertificate = tls_certificate.IssueCertificate
+
 func createRBACForKubeAPIServerProxy(_ context.Context, input *go_hook.HookInput, dc dependency.Container) error {
 	const (
 		roleName             = "node-manager:kubernetes-api-proxy"
@@ -83,25 +89,23 @@ func createRBACForKubeAPIServerProxy(_ context.Context, input *go_hook.HookInput
 		return fmt.Errorf("cannot unmarshal kubernetes-api-proxy-discovery-cert from snapshots: %v", err)
 	}
 
-	var needToGenerate = false
-	if len(certs) == 0 {
-		needToGenerate = true
-	} else {
+	if len(certs) > 0 {
 		cert, err := certificate.ParseCertificate(certs[0].Cert)
 		if err != nil {
 			return fmt.Errorf("cannot parse kubernetes-api-proxy-discovery-cert from snapshots: %v", err)
 		}
 
-		if time.Until(cert.NotAfter) < certOutdatedDuration {
-			needToGenerate = true
+		if time.Until(cert.NotAfter) >= certOutdatedDuration {
+			// The certificate already exists and is still valid. Always republish it into the
+			// module values so apiserverProxyCerts stays present in the bashible context and the
+			// configuration checksum stays stable, then stop.
+			setKubeAPIProxyDiscoveryCertValues(input, certs[0].Cert, certs[0].Key)
+			return nil
 		}
 	}
 
-	if !needToGenerate {
-		return nil
-	}
-
-	cert, err := tls_certificate.IssueCertificate(input, dc, tls_certificate.OrderCertificateRequest{
+	// There is no certificate yet, or the existing one is about to expire: issue a new one.
+	cert, err := issueKubeAPIProxyCertificate(input, dc, tls_certificate.OrderCertificateRequest{
 		CommonName: userName,
 		Groups: []string{
 			roleName,
@@ -115,8 +119,51 @@ func createRBACForKubeAPIServerProxy(_ context.Context, input *go_hook.HookInput
 		return errors.Wrap(err, "failed to issue certificate")
 	}
 
-	input.Values.Set("nodeManager.internal.kubernetesAPIProxyDiscoveryCert.crt", cert.Certificate)
-	input.Values.Set("nodeManager.internal.kubernetesAPIProxyDiscoveryCert.key", cert.Key)
+	setKubeAPIProxyDiscoveryCertValues(input, cert.Certificate, cert.Key)
+
+	// Persist the certificate into a Secret so the next reconcile finds it in the snapshot and
+	// does not regenerate it. Without this the snapshot is always empty, a fresh certificate is
+	// minted on every run, apiserverProxyCerts changes every time, and the bashible configuration
+	// checksum flaps — forcing endless node rollouts.
+	if err := saveKubeAPIProxyDiscoveryCertSecret(input, cert.Certificate, cert.Key); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func setKubeAPIProxyDiscoveryCertValues(input *go_hook.HookInput, crt, key string) {
+	input.Values.Set("nodeManager.internal.kubernetesAPIProxyDiscoveryCert.crt", crt)
+	input.Values.Set("nodeManager.internal.kubernetesAPIProxyDiscoveryCert.key", key)
+}
+
+func saveKubeAPIProxyDiscoveryCertSecret(input *go_hook.HookInput, crt, key string) error {
+	secret := &v1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kubernetes-api-proxy-discovery-cert",
+			Namespace: "kube-system",
+			Labels: map[string]string{
+				"heritage": "deckhouse",
+				"module":   "node-manager",
+			},
+		},
+		Data: map[string][]byte{
+			"crt": []byte(crt),
+			"key": []byte(key),
+		},
+		Type: v1.SecretTypeOpaque,
+	}
+
+	secretUnstructured, err := runtime.DefaultUnstructuredConverter.ToUnstructured(secret)
+	if err != nil {
+		return errors.Wrap(err, "failed to convert kubernetes-api-proxy-discovery-cert secret to unstructured")
+	}
+
+	input.PatchCollector.CreateOrUpdate(secretUnstructured)
 
 	return nil
 }

--- a/modules/040-node-manager/hooks/create_rbac_and_certificate_for_kubernetes_api_proxy_test.go
+++ b/modules/040-node-manager/hooks/create_rbac_and_certificate_for_kubernetes_api_proxy_test.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"time"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/deckhouse/deckhouse/go_lib/certificate"
+	"github.com/deckhouse/deckhouse/go_lib/dependency"
+	"github.com/deckhouse/deckhouse/go_lib/hooks/tls_certificate"
+	"github.com/deckhouse/deckhouse/pkg/log"
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+// The certificate is issued through tls_certificate.IssueCertificate, which creates a
+// CertificateSigningRequest and blocks on csrutil.WaitForCertificate until a signer populates
+// its status — something the hook test fake cluster does not provide. The generation path is
+// therefore exercised by substituting issueKubeAPIProxyCertificate with a deterministic fake,
+// which lets us assert the Secret is created when it is absent while still covering the
+// checksum-stability branch (an already-valid certificate must be republished as-is and not
+// regenerated).
+var _ = Describe("Node Manager hooks :: create_rbac_and_certificate_for_kubernetes_api_proxy ::", func() {
+	f := HookExecutionConfigInit(`{"nodeManager":{"internal":{"kubernetesAPIProxyDiscoveryCert":{}}}}`, "")
+
+	Context("With an existing valid discovery certificate secret", func() {
+		proxyCert, err := genKubeAPIProxyDiscoveryCert()
+		It("Test fixture certificate must be generated", func() {
+			Expect(err).To(BeNil())
+		})
+
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(fmt.Sprintf(`
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: kubernetes-api-proxy-discovery-cert
+  namespace: kube-system
+data:
+  crt: %[1]s
+  key: %[2]s
+`, base64.StdEncoding.EncodeToString([]byte(proxyCert.Cert)),
+				base64.StdEncoding.EncodeToString([]byte(proxyCert.Key)))),
+			)
+			f.RunHook()
+		})
+
+		It("Should republish the existing certificate into values unchanged", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			Expect(f.ValuesGet("nodeManager.internal.kubernetesAPIProxyDiscoveryCert.crt").String()).To(Equal(proxyCert.Cert))
+			Expect(f.ValuesGet("nodeManager.internal.kubernetesAPIProxyDiscoveryCert.key").String()).To(Equal(proxyCert.Key))
+
+			// The published certificate must be the pre-existing one (stable across reconciles),
+			// not a freshly minted one.
+			block, _ := pem.Decode([]byte(f.ValuesGet("nodeManager.internal.kubernetesAPIProxyDiscoveryCert.crt").String()))
+			Expect(block).ShouldNot(BeNil())
+			cert, parseErr := x509.ParseCertificate(block.Bytes)
+			Expect(parseErr).To(BeNil())
+			Expect(cert.Subject.CommonName).To(Equal("kubernetes-api-proxy"))
+		})
+
+		It("Should leave the existing discovery certificate secret untouched", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			secret := f.KubernetesResource("Secret", "kube-system", "kubernetes-api-proxy-discovery-cert")
+			Expect(secret.Exists()).To(BeTrue())
+			Expect(secret.Field("data.crt").String()).To(Equal(base64.StdEncoding.EncodeToString([]byte(proxyCert.Cert))))
+			Expect(secret.Field("data.key").String()).To(Equal(base64.StdEncoding.EncodeToString([]byte(proxyCert.Key))))
+		})
+	})
+
+	Context("Without a discovery certificate secret", func() {
+		proxyCert, err := genKubeAPIProxyDiscoveryCert()
+		It("Test fixture certificate must be generated", func() {
+			Expect(err).To(BeNil())
+		})
+
+		BeforeEach(func() {
+			// Substitute the CSR-based issuer with a deterministic fake so the generation
+			// path runs without a signer in the fake cluster.
+			issueKubeAPIProxyCertificate = func(_ *go_hook.HookInput, _ dependency.Container, _ tls_certificate.OrderCertificateRequest) (*tls_certificate.CertificateInfo, error) {
+				return &tls_certificate.CertificateInfo{Certificate: proxyCert.Cert, Key: proxyCert.Key}, nil
+			}
+			f.BindingContexts.Set(f.KubeStateSet(``))
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+		})
+
+		AfterEach(func() {
+			issueKubeAPIProxyCertificate = tls_certificate.IssueCertificate
+		})
+
+		It("Should create the discovery certificate secret that did not exist before the run", func() {
+			// The secret is absent before the hook runs.
+			Expect(f.KubernetesResource("Secret", "kube-system", "kubernetes-api-proxy-discovery-cert").Exists()).To(BeFalse())
+
+			f.RunHook()
+
+			Expect(f).To(ExecuteSuccessfully())
+
+			// The secret now exists and holds the issued certificate.
+			secret := f.KubernetesResource("Secret", "kube-system", "kubernetes-api-proxy-discovery-cert")
+			Expect(secret.Exists()).To(BeTrue())
+			Expect(secret.Field("data.crt").String()).To(Equal(base64.StdEncoding.EncodeToString([]byte(proxyCert.Cert))))
+			Expect(secret.Field("data.key").String()).To(Equal(base64.StdEncoding.EncodeToString([]byte(proxyCert.Key))))
+
+			// ... and the same certificate is published into the module values.
+			Expect(f.ValuesGet("nodeManager.internal.kubernetesAPIProxyDiscoveryCert.crt").String()).To(Equal(proxyCert.Cert))
+			Expect(f.ValuesGet("nodeManager.internal.kubernetesAPIProxyDiscoveryCert.key").String()).To(Equal(proxyCert.Key))
+		})
+	})
+})
+
+// genKubeAPIProxyDiscoveryCert issues a long-lived (10y) client certificate that mimics the
+// contents of the kube-system/kubernetes-api-proxy-discovery-cert secret.
+func genKubeAPIProxyDiscoveryCert() (*certificate.Certificate, error) {
+	ca, err := certificate.GenerateCA(log.NewNop(), "kubernetes-api-proxy",
+		certificate.WithKeyAlgo("ecdsa"),
+		certificate.WithKeySize(256),
+		certificate.WithCAExpiry("87600h"))
+	if err != nil {
+		return nil, fmt.Errorf("cannot generate CA: %v", err)
+	}
+
+	crt, err := certificate.GenerateSelfSignedCert(log.NewNop(),
+		"kubernetes-api-proxy",
+		ca,
+		certificate.WithKeyAlgo("ecdsa"),
+		certificate.WithKeySize(256),
+		certificate.WithSigningDefaultExpiry((24*time.Hour)*365*10),
+		certificate.WithSigningDefaultUsage([]string{"signing", "key encipherment", "client auth"}),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("cannot generate certificate: %v", err)
+	}
+
+	return &crt, nil
+}


### PR DESCRIPTION
## Description

Fix create_rbac_and_certificate_for_kubernetes_api_proxy hook: save secret if it not exists

## Why do we need it, and what problem does it solve?

If secret with certs doesn't exist, node-manager behave wrong:
- hook create_rbac_and_certificate_for_kubernetes_api_proxy runs, tries to read `kubernetes-api-proxy-discovery-cert` secret, and if it not exists, generate certificates and set it to values, but not to secret it was tried to read; secret still doesn't exist on next run and the hook generates certs and set them to values every tun.
- bashible-apiserver watches the input.yaml changes because of certs canges and regenerate secrets with bashible scripts, each time with a new checksum
- bashible service on each node checks that checksum was changed, and run a full bundle over and over again

To fix it, a secret `kubernetes-api-proxy-discovery-cert` should be saved if it not present

## Why do we need it in the patch release (if we do)?

Deckhouse 1.76 is affected

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: Fix create_rbac_and_certificate_for_kubernetes_api_proxy hook behavior.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
