### PR TITLE
[istio] Set readOnlyRootFilesystem: true in istio-init

### DIFF
--- a/modules/110-istio/files/v1x27/static/sidecar-injection-template.yaml
+++ b/modules/110-istio/files/v1x27/static/sidecar-injection-template.yaml
@@ -165,7 +165,7 @@ spec:
         drop:
         - ALL
     {{- if not .Values.pilot.cni.enabled }}
-      readOnlyRootFilesystem: false
+      readOnlyRootFilesystem: true
       runAsGroup: 0
       runAsNonRoot: false
       runAsUser: 0

--- a/modules/110-istio/images/common-v1x21x6/patches/005-istio-init-readonly-rootfs.patch
+++ b/modules/110-istio/images/common-v1x21x6/patches/005-istio-init-readonly-rootfs.patch
@@ -1,0 +1,13 @@
+diff --git a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+index f88fec8242..c866d1cde1 100644
+--- a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
++++ b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+@@ -148,7 +148,7 @@ spec:
+         drop:
+         - ALL
+     {{- if not .Values.istio_cni.enabled }}
+-      readOnlyRootFilesystem: false
++      readOnlyRootFilesystem: true
+       runAsGroup: 0
+       runAsNonRoot: false
+       runAsUser: 0

--- a/modules/110-istio/images/common-v1x21x6/patches/README.md
+++ b/modules/110-istio/images/common-v1x21x6/patches/README.md
@@ -27,3 +27,8 @@ Fix use expfmt library in pilot-agent. This library used for format metrics.
 
 Implement graceful transition for remote multicluster secrets. To prevent connectivity gaps during secret rotation, the old secret is no longer dismissed immediately. Instead, it remains active until the new secret is processed and all associated metadata is synced.
 Adopted upstream pr https://github.com/istio/istio/pull/58567.
+
+## 005-istio-init-readonly-rootfs.patch
+
+Set `readOnlyRootFilesystem: true` for the `istio-init` container in the sidecar injection template (`InitContainer` mode).
+Required for clusters that enforce read-only root filesystem via SecurityPolicy/PSS (e.g. CSE). Safe for the standard Deckhouse `proxyv2` image: `iptables-wrapper` selects nft in the pod network namespace, so `/run/xtables.lock` is not required.

--- a/modules/110-istio/images/common-v1x21x6/werf.inc.yaml
+++ b/modules/110-istio/images/common-v1x21x6/werf.inc.yaml
@@ -35,6 +35,7 @@ shell:
   - cd /src/istio/ && git apply --verbose /patches/002-istio-gomod_gosum.patch
   - cd /src/istio/ && git apply --verbose /patches/003-istio-server_fmtText.patch
   - cd /src/istio/ && git apply --verbose /patches/004-istio-multicluster_regenerate_token_timeout.patch
+  - cd /src/istio/ && git apply --verbose /patches/005-istio-init-readonly-rootfs.patch
   - cd /src/kiali/ && git apply --verbose /patches/001-kiali-go-mod.patch
   - cd /src/kiali/ && git apply --verbose /patches/002-kiali-logout.patch
 ---

--- a/modules/110-istio/images/operator-v1x25x2/patches/003-istio-init-readonly-rootfs.patch
+++ b/modules/110-istio/images/operator-v1x25x2/patches/003-istio-init-readonly-rootfs.patch
@@ -1,0 +1,13 @@
+diff --git a/resources/v1.25.2/charts/istiod/files/injection-template.yaml b/resources/v1.25.2/charts/istiod/files/injection-template.yaml
+index 3b3f69cd..0b72b7af 100644
+--- a/resources/v1.25.2/charts/istiod/files/injection-template.yaml
++++ b/resources/v1.25.2/charts/istiod/files/injection-template.yaml
+@@ -155,7 +155,7 @@ spec:
+         drop:
+         - ALL
+     {{- if not .Values.pilot.cni.enabled }}
+-      readOnlyRootFilesystem: false
++      readOnlyRootFilesystem: true
+       runAsGroup: 0
+       runAsNonRoot: false
+       runAsUser: 0

--- a/modules/110-istio/images/operator-v1x25x2/patches/README.md
+++ b/modules/110-istio/images/operator-v1x25x2/patches/README.md
@@ -7,3 +7,9 @@ Fix Istio CVE vulnerabilities
 ## 002-istio-operato-cni_status_restrict.patch
 
 Fix Sails operator check status about CNI
+
+
+## 003-istio-init-readonly-rootfs.patch
+
+Set `readOnlyRootFilesystem: true` for the `istio-init` container in the sidecar injection template (`InitContainer` mode).
+Required for clusters that enforce read-only root filesystem via SecurityPolicy/PSS (e.g. CSE). Safe for the standard Deckhouse `proxyv2` image: `iptables-wrapper` selects nft in the pod network namespace, so `/run/xtables.lock` is not required.

--- a/modules/110-istio/images/operator-v1x25x2/patches/README.md
+++ b/modules/110-istio/images/operator-v1x25x2/patches/README.md
@@ -8,7 +8,6 @@ Fix Istio CVE vulnerabilities
 
 Fix Sails operator check status about CNI
 
-
 ## 003-istio-init-readonly-rootfs.patch
 
 Set `readOnlyRootFilesystem: true` for the `istio-init` container in the sidecar injection template (`InitContainer` mode).

--- a/modules/110-istio/images/operator-v1x25x2/werf.inc.yaml
+++ b/modules/110-istio/images/operator-v1x25x2/werf.inc.yaml
@@ -75,5 +75,6 @@ shell:
   install:
   - cd /src/operator && git apply --verbose /patches/001-istio-go-mod.patch
   - cd /src/operator && git apply --verbose /patches/002-istio-operato-cni_status_restrict.patch
+  - cd /src/operator && git apply --verbose /patches/003-istio-init-readonly-rootfs.patch
 ---
 {{- include "vex mitigation" (list $ (printf "%s/%s" $.ModuleName $.ImageName)) }}

--- a/modules/110-istio/images/proxyv2-v1x21x6/werf.inc.yaml
+++ b/modules/110-istio/images/proxyv2-v1x21x6/werf.inc.yaml
@@ -234,7 +234,7 @@ shell:
   - mkdir -p /relocate/sbin
   - |
     for cmd in iptables iptables-save iptables-restore ip6tables ip6tables-save ip6tables-restore; do
-      ln -f -s /sbin/iptables-wrapper "/relocate/sbin/${cmd}"
+      ln -sf /sbin/xtables-nft-multi "/relocate/sbin/${cmd}"
     done
     # broken symlinks are not imported from the artifact
     touch /sbin/iptables-wrapper

--- a/modules/110-istio/images/proxyv2-v1x21x6/werf.inc.yaml
+++ b/modules/110-istio/images/proxyv2-v1x21x6/werf.inc.yaml
@@ -234,7 +234,7 @@ shell:
   - mkdir -p /relocate/sbin
   - |
     for cmd in iptables iptables-save iptables-restore ip6tables ip6tables-save ip6tables-restore; do
-      ln -sf /sbin/xtables-nft-multi "/relocate/sbin/${cmd}"
+      ln -f -s /sbin/iptables-wrapper "/relocate/sbin/${cmd}"
     done
     # broken symlinks are not imported from the artifact
     touch /sbin/iptables-wrapper

--- a/modules/110-istio/images/proxyv2-v1x25x2/werf.inc.yaml
+++ b/modules/110-istio/images/proxyv2-v1x25x2/werf.inc.yaml
@@ -175,7 +175,7 @@ shell:
   - mkdir -p /relocate/sbin
   - |
     for cmd in iptables iptables-save iptables-restore ip6tables ip6tables-save ip6tables-restore; do
-      ln -f -s /sbin/iptables-wrapper "/relocate/sbin/${cmd}"
+      ln -sf /sbin/xtables-nft-multi "/relocate/sbin/${cmd}"
     done
     # broken symlinks are not imported from the artifact
     touch /sbin/iptables-wrapper

--- a/modules/110-istio/images/proxyv2-v1x25x2/werf.inc.yaml
+++ b/modules/110-istio/images/proxyv2-v1x25x2/werf.inc.yaml
@@ -175,7 +175,7 @@ shell:
   - mkdir -p /relocate/sbin
   - |
     for cmd in iptables iptables-save iptables-restore ip6tables ip6tables-save ip6tables-restore; do
-      ln -sf /sbin/xtables-nft-multi "/relocate/sbin/${cmd}"
+      ln -f -s /sbin/iptables-wrapper "/relocate/sbin/${cmd}"
     done
     # broken symlinks are not imported from the artifact
     touch /sbin/iptables-wrapper

--- a/modules/110-istio/images/proxyv2-v1x27x9/werf.inc.yaml
+++ b/modules/110-istio/images/proxyv2-v1x27x9/werf.inc.yaml
@@ -194,7 +194,7 @@ shell:
   - mkdir -p /relocate/sbin
   - |
     for cmd in iptables iptables-save iptables-restore ip6tables ip6tables-save ip6tables-restore; do
-      ln -f -s /sbin/iptables-wrapper "/relocate/sbin/${cmd}"
+      ln -sf /sbin/xtables-nft-multi "/relocate/sbin/${cmd}"
     done
     # broken symlinks are not imported from the artifact
     touch /sbin/iptables-wrapper

--- a/modules/110-istio/images/proxyv2-v1x27x9/werf.inc.yaml
+++ b/modules/110-istio/images/proxyv2-v1x27x9/werf.inc.yaml
@@ -194,7 +194,7 @@ shell:
   - mkdir -p /relocate/sbin
   - |
     for cmd in iptables iptables-save iptables-restore ip6tables ip6tables-save ip6tables-restore; do
-      ln -sf /sbin/xtables-nft-multi "/relocate/sbin/${cmd}"
+      ln -f -s /sbin/iptables-wrapper "/relocate/sbin/${cmd}"
     done
     # broken symlinks are not imported from the artifact
     touch /sbin/iptables-wrapper


### PR DESCRIPTION
## Description

Set `readOnlyRootFilesystem: true` for the `istio-init` init container in the Istio sidecar injection template (`InitContainer` traffic redirection mode).

Previously the template followed upstream and used `readOnlyRootFilesystem: false` only for `istio-init`, while `istio-validation` (CNI mode) and `istio-proxy` already used `true`. This blocked workloads under Deckhouse `SecurityPolicy` / PSS checks that require a read-only root filesystem for all containers, including init containers.

No cluster control-plane, ingress, or Prometheus restarts are expected. Existing meshed pods keep the old injected spec until recreated; new/recreated pods pick up the updated injection template via ConfigMap `istio-sidecar-injector-<revision>`.

## Why do we need it, and what problem does it solve?

In CSE and other environments with `readOnlyRootFilesystem: true` enforced, sidecar injection in `trafficRedirectionSetupMode: InitContainer` fails admission because `istio-init` is injected with a writable root FS.

Upstream keeps `false` mainly for `iptables-legacy` and `/run/xtables.lock`. Deckhouse `proxyv2` uses [`kubernetes-sigs/iptables-wrappers`](https://github.com/kubernetes-sigs/iptables-wrappers): in a pod network namespace there are no kubelet canary chains, so the wrapper selects **nft**. The nft path does not need `xtables.lock`, so `readOnlyRootFilesystem: true` is safe for the standard Deckhouse Istio data plane.

This aligns `istio-init` with the rest of the injected containers for the read-only root FS policy check.


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: chore
summary: Set readOnlyRootFilesystem to true in the istio-init container.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->