### PR TITLE
[docs] Migrate defaultCRI from ClusterConfiguration to node-manager mc

### DIFF
--- a/docs/site/pages/guides/PRIVATE_ENVIRONMENT.md
+++ b/docs/site/pages/guides/PRIVATE_ENVIRONMENT.md
@@ -1215,13 +1215,24 @@ serviceSubnetCIDR: 10.222.0.0/16
 kubernetesVersion: "Automatic"
 # Cluster domain.
 clusterDomain: "cluster.local"
-# The default container runtime type used on cluster nodes (in NodeGroups).
-defaultCRI: "ContainerdV2"
 # Proxy server settings.
 proxy:
   httpProxy: http://proxy.local:3128
   httpsProxy: https://proxy.local:3128
   noProxy: ["harbor.example", "proxy.local", "10.128.0.8", "10.128.0.32", "10.128.0.18"]
+---
+# node-manager module settings.
+# https://deckhouse.io/modules/node-manager/configuration.html
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: node-manager
+spec:
+  version: 3
+  enabled: true
+  settings:
+    # The default container runtime type used on cluster nodes (in NodeGroups).
+    defaultCRI: "ContainerdV2"
 ---
 # deckhouse module settings.
 # https://deckhouse.io/modules/deckhouse/configuration.html

--- a/docs/site/pages/guides/PRIVATE_ENVIRONMENT_RU.md
+++ b/docs/site/pages/guides/PRIVATE_ENVIRONMENT_RU.md
@@ -1258,13 +1258,24 @@ serviceSubnetCIDR: 10.222.0.0/16
 kubernetesVersion: "Automatic"
 # Домен кластера.
 clusterDomain: "cluster.local"
-# Тип container runtime, используемый на узлах кластера (в NodeGroup’ах) по умолчанию.
-defaultCRI: "ContainerdV2"
 # Настройки proxy-сервера.
 proxy:
   httpProxy: http://proxy.local:3128
   httpsProxy: https://proxy.local:3128
   noProxy: ["harbor.example", "proxy.local", "10.128.0.8", "10.128.0.32", "10.128.0.18"]
+---
+# Настройки модуля node-manager.
+# https://deckhouse.ru/modules/node-manager/configuration.html
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: node-manager
+spec:
+  version: 3
+  enabled: true
+  settings:
+    # Тип container runtime, используемый на узлах кластера (в NodeGroup’ах) по умолчанию.
+    defaultCRI: "ContainerdV2"
 ---
 # Настройки модуля deckhouse.
 # https://deckhouse.ru/modules/deckhouse/configuration.html

--- a/docs/site/pages/virtualization-platform/documentation/admin/platform-management/platform-scaling/control-plane/UPDATING_AND_VERSIONING.md
+++ b/docs/site/pages/virtualization-platform/documentation/admin/platform-management/platform-scaling/control-plane/UPDATING_AND_VERSIONING.md
@@ -30,7 +30,6 @@ The control plane update process in DVP is fully automated.
      provider: Yandex
    clusterDomain: cloud.education
    clusterType: Cloud
-   defaultCRI: Containerd
    kubernetesVersion: "1.30"
    podSubnetCIDR: 10.111.0.0/16
    podSubnetNodeCIDRPrefix: "24"

--- a/docs/site/pages/virtualization-platform/documentation/admin/platform-management/platform-scaling/control-plane/UPDATING_AND_VERSIONING_RU.md
+++ b/docs/site/pages/virtualization-platform/documentation/admin/platform-management/platform-scaling/control-plane/UPDATING_AND_VERSIONING_RU.md
@@ -31,7 +31,6 @@ lang: ru
      provider: Yandex
    clusterDomain: cloud.education
    clusterType: Cloud
-   defaultCRI: Containerd
    kubernetesVersion: "1.30"
    podSubnetCIDR: 10.111.0.0/16
    podSubnetNodeCIDRPrefix: "24"

--- a/docs/site/pages/virtualization-platform/documentation/admin/platform-management/platform-scaling/node/MIGRATING.md
+++ b/docs/site/pages/virtualization-platform/documentation/admin/platform-management/platform-scaling/node/MIGRATING.md
@@ -43,15 +43,19 @@ Also note that this is a [disruptive update](./node-management.html#disruptive-u
 
 You can enable containerd v2 in two ways:
 
-1. **For the entire cluster**. Set the value `ContainerdV2` for the [`defaultCRI`](/products/kubernetes-platform/documentation/v1/reference/api/cr.html#clusterconfiguration-defaultcri) parameter in the `ClusterConfiguration` resource. This value will apply to all [NodeGroup](/modules/node-manager/cr.html#nodegroup) objects where [`spec.cri.type`](/modules/node-manager/cr.html#nodegroup-v1-spec-cri-type) is not explicitly defined.
+1. **For the entire cluster**. Set the value `ContainerdV2` for the [`defaultCRI`](/modules/node-manager/configuration.html#parameters-defaultcri) parameter in the `node-manager` ModuleConfig. This value will apply to all [NodeGroup](/modules/node-manager/cr.html#nodegroup) objects where [`spec.cri.type`](/modules/node-manager/cr.html#nodegroup-v1-spec-cri-type) is not explicitly defined.
 
    Example:
 
    ```yaml
-   apiVersion: deckhouse.io/v1
-   kind: ClusterConfiguration
-   ...
-   defaultCRI: ContainerdV2
+   apiVersion: deckhouse.io/v1alpha1
+   kind: ModuleConfig
+   metadata:
+     name: node-manager
+   spec:
+     version: 3
+     settings:
+       defaultCRI: ContainerdV2
    ```
 
 1. **For a specific node group**. Set `ContainerdV2` in the [`spec.cri.type`](/modules/node-manager/cr.html#nodegroup-v1-spec-cri-type) parameter of the [NodeGroup](/modules/node-manager/cr.html#nodegroup) object.

--- a/docs/site/pages/virtualization-platform/documentation/admin/platform-management/platform-scaling/node/MIGRATING_RU.md
+++ b/docs/site/pages/virtualization-platform/documentation/admin/platform-management/platform-scaling/node/MIGRATING_RU.md
@@ -43,15 +43,19 @@ ls -l /etc/containerd/conf.d
 
 Включение containerd v2 возможно двумя способами:
 
-1. **Для всего кластера**. Укажите значение `ContainerdV2` в параметре [`defaultCRI`](/products/kubernetes-platform/documentation/v1/reference/api/cr.html#clusterconfiguration-defaultcri) ресурса ClusterConfiguration. Это значение будет применяться ко всем [NodeGroup](/modules/node-manager/cr.html#nodegroup), в которых явно не указан [`spec.cri.type`](/modules/node-manager/cr.html#nodegroup-v1-spec-cri-type).
+1. **Для всего кластера**. Укажите значение `ContainerdV2` в параметре [`defaultCRI`](/modules/node-manager/configuration.html#parameters-defaultcri) ModuleConfig `node-manager`. Это значение будет применяться ко всем [NodeGroup](/modules/node-manager/cr.html#nodegroup), в которых явно не указан [`spec.cri.type`](/modules/node-manager/cr.html#nodegroup-v1-spec-cri-type).
 
    Пример:
 
    ```yaml
-   apiVersion: deckhouse.io/v1
-   kind: ClusterConfiguration
-   ...
-   defaultCRI: ContainerdV2
+   apiVersion: deckhouse.io/v1alpha1
+   kind: ModuleConfig
+   metadata:
+     name: node-manager
+   spec:
+     version: 3
+     settings:
+       defaultCRI: ContainerdV2
    ```
 
 1. **Для конкретной группы узлов**. Укажите `ContainerdV2` в параметре [`spec.cri.type`](/modules/node-manager/cr.html#nodegroup-v1-spec-cri-type) в объекте [NodeGroup](/modules/node-manager/cr.html#nodegroup).

--- a/docs/site/pages/virtualization-platform/documentation/user/resource-managment/USB_DEVICES.md
+++ b/docs/site/pages/virtualization-platform/documentation/user/resource-managment/USB_DEVICES.md
@@ -11,7 +11,7 @@ DVP supports USB device passthrough to virtual machines using DRA (Dynamic Resou
 
 USB device passthrough requires:
 
-- `containerd v2`: Detailed requirements for cluster nodes are described in the [`defaultCRI`](/products/kubernetes-platform/documentation/v1/reference/api/cr.html#clusterconfiguration-defaultcri) parameter.
+- `containerd v2`: Detailed requirements for cluster nodes are described in the [`defaultCRI`](/modules/node-manager/configuration.html#parameters-defaultcri) parameter.
 - [Kubernetes](/products/kubernetes-platform/documentation/v1/reference/supported_versions.html#kubernetes) version 1.34 or higher.
 - [Deckhouse Kubernetes Platform (DKP)](https://releases.deckhouse.io/) version 1.75 or higher.
 

--- a/docs/site/pages/virtualization-platform/documentation/user/resource-managment/USB_DEVICES_RU.md
+++ b/docs/site/pages/virtualization-platform/documentation/user/resource-managment/USB_DEVICES_RU.md
@@ -12,7 +12,7 @@ DVP поддерживает проброс USB-устройств в вирту
 
 Для проброса USB требуются:
 
-- `containerd v2` — подробные требования к узлам кластера описаны в параметре [`defaultCRI`](/products/kubernetes-platform/documentation/v1/reference/api/cr.html#clusterconfiguration-defaultcri);
+- `containerd v2` — подробные требования к узлам кластера описаны в параметре [`defaultCRI`](/modules/node-manager/configuration.html#parameters-defaultcri);
 - [Kubernetes](/products/kubernetes-platform/documentation/v1/reference/supported_versions.html#kubernetes) версии не ниже 1.34;
 - [Deckhouse Kubernetes Platform (DKP)](https://releases.deckhouse.ru/) версии не ниже 1.75.
 


### PR DESCRIPTION
## Description

Docs from https://github.com/deckhouse/deckhouse/pull/21482

DO NOT MERGE BEFORE 1.79

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: feature
summary: Docs for migration defaultCRI from ClusterConfiguration to node-manager ModuleConfig.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
