### PR TITLE
[docs] Fix yellow highlight for internalNetworkCIDRs in virtualization comments

### DIFF
--- a/docs/site/_assets/js/getting-started.js
+++ b/docs/site/_assets/js/getting-started.js
@@ -24,6 +24,8 @@ function config_highlight() {
   let matchMustChange = '!CHANGE_';
   let matchMightChangeEN = /# [Yy]ou might consider changing this\.?/;
   let matchMightChangeRU = /# [Вв]озможно, захотите изменить\.?/;
+  let matchExceptionEN = /Specify, if the cluster nodes have more than one network interface|If only one interface is used on the nodes of the cluster/i;
+  let matchExceptionRU = /Укажите, если используете модуль virtualization|Если на узлах кластера используется только один интерфейс/i;
 
   function nextCodeSpan($el) {
     let n = $el.next();
@@ -38,8 +40,20 @@ function config_highlight() {
   }
 
   $('code span.c1').filter(function () {
-    return (matchMightChangeEN.test(this.innerText)) || (matchMightChangeRU.test(this.innerText));
+    // Новые проверки через ИЛИ
+    return (matchMightChangeEN.test(this.innerText)) || 
+           (matchMightChangeRU.test(this.innerText)) ||
+           (matchExceptionEN.test(this.innerText)) || 
+           (matchExceptionRU.test(this.innerText));
   }).each(function (index) {
+    const commentText = $(this).text();
+    const shouldSkipChildren = commentText.includes('virtualization') || commentText.includes('StaticClusterConfiguration');
+    
+    if (shouldSkipChildren) {
+      $(this).addClass('mightChange');
+      return; // Выходим, не обрабатывая дочерние элементы
+    }
+    
     let $third = nextCodeSpan(nextCodeSpan(nextCodeSpan($(this))));
     let $colon = $third.length && nextCodeSpan($third).length && nextCodeSpan($third).text().trim() === ':' ? nextCodeSpan($third) : null;
     try {

--- a/docs/site/_assets/js/getting-started.js
+++ b/docs/site/_assets/js/getting-started.js
@@ -24,8 +24,8 @@ function config_highlight() {
   let matchMustChange = '!CHANGE_';
   let matchMightChangeEN = /# [Yy]ou might consider changing this\.?/;
   let matchMightChangeRU = /# [Вв]озможно, захотите изменить\.?/;
-  let matchExceptionEN = /Specify, if the cluster nodes have more than one network interface|If only one interface is used on the nodes of the cluster/i;
-  let matchExceptionRU = /Укажите, если используете модуль virtualization|Если на узлах кластера используется только один интерфейс/i;
+  let matchExceptionEN = /# [Ss]pecify, if the cluster nodes have more than one network interface|# [Ii]f only one interface is used on the nodes of the cluster/;
+  let matchExceptionRU = /# [Уу]кажите, если используете модуль virtualization|# [Ее]сли на узлах кластера используется только один интерфейс/;
 
   function nextCodeSpan($el) {
     let n = $el.next();
@@ -40,20 +40,19 @@ function config_highlight() {
   }
 
   $('code span.c1').filter(function () {
-    // Новые проверки через ИЛИ
-    return (matchMightChangeEN.test(this.innerText)) || 
+    return (matchMightChangeEN.test(this.innerText)) ||
            (matchMightChangeRU.test(this.innerText)) ||
-           (matchExceptionEN.test(this.innerText)) || 
+           (matchExceptionEN.test(this.innerText)) ||
            (matchExceptionRU.test(this.innerText));
   }).each(function (index) {
     const commentText = $(this).text();
     const shouldSkipChildren = commentText.includes('virtualization') || commentText.includes('StaticClusterConfiguration');
-    
+
     if (shouldSkipChildren) {
       $(this).addClass('mightChange');
-      return; // Выходим, не обрабатывая дочерние элементы
+      return; // Skip following spans; highlight only the comment
     }
-    
+
     let $third = nextCodeSpan(nextCodeSpan(nextCodeSpan($(this))));
     let $colon = $third.length && nextCodeSpan($third).length && nextCodeSpan($third).text().trim() === ':' ? nextCodeSpan($third) : null;
     try {


### PR DESCRIPTION
## Description

Fixed incorrect yellow highlighting in documentation for internalNetworkCIDRs configuration block. The issue occurred when comments mentioned the virtualization module or StaticClusterConfiguration resource - the highlighter was incorrectly applying "might change" styling to the YAML elements (internalNetworkCIDRs:, -, *) instead of only highlighting the comment itself.

## Why do we need it, and what problem does it solve?

Fixes the highlighting issue for !CHANGE_internalNetworkCIDRs after a comment is highlighted in yellow.

## Why do we need it in the patch release (if we do)?

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: fix
summary: Fixed incorrect yellow highlighting for internalNetworkCIDRs in virtualization comments to only highlight the comment text, not the following elements.
impact_level: low
```

