### PR TITLE
docs: Add processing x-example in x-doc-examples for crd render

### DIFF
--- a/docs/site/backends/docs-builder-template/layouts/_partials/openapi/format-attributes.html
+++ b/docs/site/backends/docs-builder-template/layouts/_partials/openapi/format-attributes.html
@@ -64,7 +64,7 @@
 {{- end }}
 
 {{- if or (isset $attributes "x-doc-examples") (isset $attributes "x-doc-example") (isset $attributes "example") (isset $attributes "x-examples") }}
-  {{- template "format-example" ( dict "attributes" $attributes "linkAnchor" $linkAnchor "name" .name ) }}
+  {{- template "format-example" ( dict "attributes" $attributes "langData" $langData "linkAnchor" $linkAnchor "name" .name ) }}
 {{- end }}
 
 {{- define "format-default" }}
@@ -119,25 +119,58 @@
 {{- define "format-example" }}
   {{- $name := .name }}
   {{- $attributes := .attributes }}
+  {{- $langData := .langData }}
   {{- $linkAnchor := printf "%sL" .linkAnchor }}
   {{- $isArray := false }}
-  {{- $keyToUse := "" }}
+  {{- $example := "" }}
   {{- $title := T "example" | humanize }}
   {{- $hl_opts := dict "lineNos" "false" "anchorLineNos" "true" "lineAnchors" $linkAnchor "guessSyntax" "true" "style" "native" }}
 
   {{- if isset $attributes "x-doc-examples" }}
-    {{- $keyToUse = "x-doc-examples" }}
     {{- $isArray = true }}
+    {{- $rawExamples := index $attributes "x-doc-examples" }}
+    {{- $langExamples := slice }}
+    {{- if and (reflect.IsMap $langData) (isset $langData "x-doc-examples") }}
+      {{- $langExamples = index $langData "x-doc-examples" }}
+    {{- end }}
+    {{- $normalizedExamples := slice }}
+    {{- range $index, $raw := $rawExamples }}
+      {{- if reflect.IsMap $raw }}
+        {{/* Normalize map keys via JSON round-trip so index works reliably. */}}
+        {{- $item := $raw | jsonify | unmarshal }}
+        {{- $xExample := index $item "x-example" }}
+        {{- if $xExample }}
+          {{- $xName := index $item "x-name" }}
+          {{- $xDescription := index $item "x-description" }}
+          {{- if and $langExamples (lt $index (len $langExamples)) }}
+            {{- $langRaw := index $langExamples $index }}
+            {{- if reflect.IsMap $langRaw }}
+              {{- $langItem := $langRaw | jsonify | unmarshal }}
+              {{- if index $langItem "x-name" }}
+                {{- $xName = index $langItem "x-name" }}
+              {{- end }}
+              {{- if index $langItem "x-description" }}
+                {{- $xDescription = index $langItem "x-description" }}
+              {{- end }}
+            {{- end }}
+          {{- end }}
+          {{- $normalizedExamples = $normalizedExamples | append (dict "_xDocExample" true "content" $xExample "name" $xName "description" $xDescription) }}
+        {{- else }}
+          {{- $normalizedExamples = $normalizedExamples | append $item }}
+        {{- end }}
+      {{- else }}
+        {{- $normalizedExamples = $normalizedExamples | append $raw }}
+      {{- end }}
+    {{- end }}
+    {{- $example = $normalizedExamples }}
   {{- else if isset $attributes "x-doc-example" }}
-    {{- $keyToUse = "x-doc-example" }}
+    {{- $example = index $attributes "x-doc-example" }}
   {{- else if isset $attributes "example" }}
-    {{- $keyToUse = "example" }}
+    {{- $example = index $attributes "example" }}
   {{- else if isset $attributes "x-examples" }}
-    {{- $keyToUse = "x-examples" }}
     {{- $isArray = true }}
+    {{- $example = index $attributes "x-examples" }}
   {{- end }}
-
-  {{- $example := index $attributes $keyToUse }}
 
   <!-- $example ({{ reflect.IsMap $example }})- {{ $example }} -->
 
@@ -148,9 +181,28 @@
 <p class="resources__attrs"><span class="resources__attrs_name">{{ $title }}:</span>
   <div class="language-yaml highlighter-rouge">
 
-  {{- if and $isArray }}<br>
+  {{- if and $isArray }}
     {{- range $example }}
-      {{- if reflect.IsMap . }}
+      {{- if and (reflect.IsMap .) (index . "_xDocExample") }}
+          {{- with index . "name" }}
+            <p><i><strong>{{ . }}</strong></i></p>
+          {{- end }}
+          {{- with index . "description" }}
+            <div class="resources__prop_description">{{ partial "openapi/format-description" . }}</div>
+          {{- end }}
+          {{- $content := index . "content" }}
+          {{- if reflect.IsMap $content }}
+            {{- transform.Highlight ( transform.Remarshal "yaml" ( $content | jsonify ) ) "yaml" $hl_opts }}
+          {{- else if reflect.IsSlice $content }}
+            {{- transform.Highlight ( transform.Remarshal "yaml" (dict $name $content ) ) "yaml" $hl_opts }}
+          {{- else }}
+            {{- if hasPrefix $content "```" }}
+              {{- $content | markdownify }}
+            {{- else }}
+              {{- transform.Highlight ( transform.Remarshal "yaml" (dict $name $content ) ) "yaml" $hl_opts }}
+            {{- end }}
+          {{- end }}
+      {{- else if reflect.IsMap . }}
           {{- transform.Highlight ( transform.Remarshal "yaml" ( . | jsonify ) ) "yaml" $hl_opts }}
       {{- else if reflect.IsSlice . }}
           {{- transform.Highlight ( transform.Remarshal "yaml" (dict $name . ) ) "yaml" $hl_opts }}

--- a/docs/site/backends/docs-builder-template/layouts/_partials/openapi/format-configuration.html
+++ b/docs/site/backends/docs-builder-template/layouts/_partials/openapi/format-configuration.html
@@ -95,7 +95,7 @@ Context:
 <p><font size="-1">{{ T "version_of_schema" }}: {{ $configVersion }}</font></p>
 
 {{- if or (isset $data "x-doc-examples") (isset $data "x-doc-example") (isset $data "example") (isset $data "x-examples") }}
-  {{- template "format-example" ( dict "attributes" $data "linkAnchor" "parameters-settings" "name" "" ) }}
+  {{- template "format-example" ( dict "attributes" $data "langData" $langData "linkAnchor" "parameters-settings" "name" "" ) }}
 {{- end }}
 
 <ul class="resources">

--- a/docs/site/backends/docs-builder-template/layouts/_partials/openapi/format-crd.html
+++ b/docs/site/backends/docs-builder-template/layouts/_partials/openapi/format-crd.html
@@ -53,7 +53,11 @@
 
     {{- if or (isset $versionSchema "x-doc-examples") (isset $versionSchema "x-doc-example") (isset $versionSchema "example") (isset $versionSchema "x-examples") }}
       {{- $linkAnchor := printf "%s-%s" $kindDowncase $versionName }}
-      {{- template "format-example" ( dict "attributes" $versionSchema "linkAnchor" $linkAnchor "name" "" ) }}
+      {{- $langSchema := dict }}
+      {{- if and $langVersionData.schema $langVersionData.schema.openAPIV3Schema }}
+        {{- $langSchema = $langVersionData.schema.openAPIV3Schema }}
+      {{- end }}
+      {{- template "format-example" ( dict "attributes" $versionSchema "langData" $langSchema "linkAnchor" $linkAnchor "name" "" ) }}
     {{- end }}
 
     <ul class="resources">


### PR DESCRIPTION
## Description

This pull request enhances how OpenAPI example are rendered in the documentation for external modules. The main changes improve the handling and display of `x-doc-examples` by adding a way to specify localized example title and description.

### New `x-doc-examples` structure

`x-doc-examples` is still an array of examples. **Legacy behavior is unchanged**: each array item can be a scalar or a plain structure, and it is rendered as a YAML example as before.

Use the **new object format** when an example needs a title and/or description.  
**Detection rule:** if an array item is an object and has `x-example` at the **root** of that item, it is treated as the new format. Otherwise the whole item is rendered with the legacy logic.

| Field | Required (new format) | Purpose |
|------|------------------------|---------|
| `x-example` | yes (format marker) | Example value |
| `x-name` | no | Example title in docs |
| `x-description` | no | Example description (markdown) |

#### Legacy (unchanged)

```yaml
# ...
chaos:
  type: object
  description: |
    Chaos monkey settings.
  x-doc-examples:
    - mode: DrainAndDelete
      period: 24h
  properties:
    mode:
      type: string
      enum:
        - Disabled
        - DrainAndDelete
    period:
      type: string
# ...
```

Each item is a value/structure and is rendered as a YAML example. No title/description.

#### New format (title + description)

```yaml
# ...
chaos:
  type: object
  description: |
    Chaos monkey settings.
  x-doc-examples:
    - x-name: Drain and delete daily
      x-description: |
        Periodically drain and delete a node from this NodeGroup
        to verify cluster resiliency.
      x-example:
        mode: DrainAndDelete
        period: 24h
    - x-name: Disabled
      x-description: |
        Leave this NodeGroup intact; chaos monkey does nothing.
      x-example:
        mode: Disabled
        period: 6h
  properties:
    mode:
      type: string
      enum:
        - Disabled
        - DrainAndDelete
    period:
      type: string
# ...
```

`x-name` and `x-description` are optional; `x-example` alone is enough to switch to the new format.

#### Mixed array

Items with and without root-level `x-example` can coexist in one `x-doc-examples` list: items with `x-example` use the new renderer; the rest keep legacy rendering.

#### i18n

In `doc-ru-*.yaml`, override `x-name` / `x-description` by item index; `x-example` comes from the main spec:

The main spec part:
```yaml
x-doc-examples:
  - x-name: Drain and delete daily
    x-description: Periodically drain and delete a node.
    x-example:
      mode: DrainAndDelete
      period: 24h
```

The part in doc-ru-*.yaml:
```yaml
x-doc-examples:
  - x-name: Удаление узла раз в сутки
    x-description: Раз в сутки узлу будет выполняться drain, затем удаление..
```

#### Rendering example

Example:

```yaml
x-doc-examples:
- x-example:
    field: a
    fieldTwo: b
    fieldThree:
      some: thing
  x-description: the first example
  x-name: First
- x-example:
    field: b
  x-description: the second example
  x-name: Second
```

This will be rendered in the documentation as:

<img width="989" height="595" alt="render_example" src="https://github.com/user-attachments/assets/689d30d8-723b-420d-8e84-f4bf504819d6" />

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Added ability to to specify localized title and description in OpenAPI example to render them in the documentation.
impact_level: default
```
