### PR TITLE
[deckhouse] Build hook and controller Kubernetes clients from the configured kubeconfig

### DIFF
--- a/deckhouse-controller/cmd/deckhouse-controller/start.go
+++ b/deckhouse-controller/cmd/deckhouse-controller/start.go
@@ -52,6 +52,7 @@ import (
 	d8Apis "github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/controller"
 	debugserver "github.com/deckhouse/deckhouse/deckhouse-controller/pkg/debug-server"
+	"github.com/deckhouse/deckhouse/go_lib/dependency/k8s"
 	"github.com/deckhouse/deckhouse/pkg/app"
 	"github.com/deckhouse/deckhouse/pkg/log"
 	metricsstorage "github.com/deckhouse/deckhouse/pkg/metrics-storage"
@@ -82,6 +83,13 @@ func (r *reaperMutex) Release() {
 
 func start(logger *log.Logger, cfg *app.Config) func(cmd *cobra.Command, args []string) error {
 	return func(_ *cobra.Command, _ []string) error {
+		// Point the Kubernetes clients built by go_lib/dependency (used by Go
+		// hooks and controllers) at the same kubeconfig the operator's own client
+		// uses. Empty in the normal in-cluster case, which keeps the in-cluster
+		// service-account behavior; set to --kube-config when deckhouse-controller
+		// drives a remote cluster. Must run before the operator and any hook start.
+		k8s.SetDefaultKubeConfig(cfg.Kube.Config, cfg.Kube.Context)
+
 		if os.Getenv(app.EnvSkipEntrypoint) != "true" {
 			if err := entrypoint(logger); err != nil {
 				logger.Error("entrypoint run", log.Err(err))

--- a/deckhouse-controller/cmd/deckhouse-controller/start.go
+++ b/deckhouse-controller/cmd/deckhouse-controller/start.go
@@ -139,11 +139,16 @@ func start(logger *log.Logger, cfg *app.Config) func(cmd *cobra.Command, args []
 			version = strings.TrimSuffix(string(content), "\n")
 		}
 
-		if version == "dev" && !app.EnabledHA() {
+		// A remote managed cluster (--kube-config) or a single-replica dev run does
+		// not use in-cluster leader election: the lease belongs to the cluster the
+		// pod lives in, not the managed one, and a dev run has a single replica.
+		if cfg.Kube.Config != "" || (version == "dev" && !app.EnabledHA()) {
 			if err := run(ctx, operator, logger); err != nil {
 				logger.Error("run", log.Err(err))
 				os.Exit(1)
 			}
+
+			return nil
 		}
 
 		logger.Info("Deckhouse starts in HA mode")

--- a/global-hooks/check_switch_edition.go
+++ b/global-hooks/check_switch_edition.go
@@ -74,6 +74,14 @@ func checkSwitchDeckhouseEdition(ctx context.Context, input *go_hook.HookInput, 
 
 	d8Deployment, err := client.AppsV1().Deployments("d8-system").Get(ctx, "deckhouse", metav1.GetOptions{})
 	if err != nil {
+		// No deckhouse Deployment in the managed cluster: deckhouse runs outside
+		// it (or the cluster is being installed), so there is no previous edition
+		// to compare against. Nothing to check.
+		if k8serrors.IsNotFound(err) {
+			input.Logger.Warn("deckhouse deployment not found, probably running outside the managed cluster. Skip")
+			return nil
+		}
+
 		return fmt.Errorf("cannot get deckhouse deployment: %v", err)
 	}
 

--- a/global-hooks/discovery/apiserver_ca.go
+++ b/global-hooks/discovery/apiserver_ca.go
@@ -19,24 +19,30 @@ package hooks
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency"
 )
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	OnStartup: &go_hook.OrderedConfig{Order: 5},
-}, discoverApiserverCA)
+}, dependency.WithExternalDependencies(discoverApiserverCA))
 
-func discoverApiserverCA(_ context.Context, input *go_hook.HookInput) error {
-	caPath := "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
-
-	content, err := os.ReadFile(caPath)
+func discoverApiserverCA(_ context.Context, input *go_hook.HookInput, dc dependency.Container) error {
+	// Take the CA from the cluster the hooks actually talk to — the managed
+	// cluster when a kubeconfig is configured, the in-cluster service account
+	// otherwise — instead of always reading the pod's own service-account CA.
+	config, err := dc.GetClientConfig()
 	if err != nil {
-		return fmt.Errorf("cannot find kubernetes ca: %v, (not in pod?)", err)
+		return fmt.Errorf("get client config: %w", err)
 	}
 
-	input.Values.Set("global.discovery.kubernetesCA", string(content))
+	if len(config.CAData) == 0 {
+		return fmt.Errorf("kubernetes CA is empty")
+	}
+
+	input.Values.Set("global.discovery.kubernetesCA", string(config.CAData))
 	return nil
 }

--- a/global-hooks/discovery/kubernetes_version.go
+++ b/global-hooks/discovery/kubernetes_version.go
@@ -34,10 +34,12 @@ import (
 	v1meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	apimachineryversion "k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/rest"
 
 	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 
 	d8http "github.com/deckhouse/deckhouse/go_lib/dependency/http"
+	"github.com/deckhouse/deckhouse/go_lib/dependency/k8s"
 	"github.com/deckhouse/deckhouse/go_lib/dependency/requirements"
 	"github.com/deckhouse/deckhouse/go_lib/module"
 )
@@ -56,6 +58,7 @@ const apiServerNs = "kube-system"
 // versionHTTPClient is used to validate that tls certificate DNS name contains kubernetes service cluster ip
 var (
 	versionHTTPClient d8http.Client
+	versionHTTPErr    error
 	once              sync.Once
 )
 
@@ -195,10 +198,6 @@ func getKubeVersionForServer(endpoint string, cl d8http.Client) (*semver.Version
 	if err != nil {
 		return nil, fmt.Errorf("new request: %w", err)
 	}
-	err = d8http.SetKubeAuthToken(req)
-	if err != nil {
-		return nil, fmt.Errorf("set kube auth token: %w", err)
-	}
 
 	res, err := cl.Do(req)
 	if err != nil {
@@ -320,13 +319,29 @@ func k8sVersions(ctx context.Context, input *go_hook.HookInput) error {
 		if versionHTTPClient != nil {
 			return
 		}
-		contentCA, _ := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
 
-		versionHTTPClient = d8http.NewClient(
-			d8http.WithTLSServerName("kubernetes.default.svc"),
-			d8http.WithAdditionalCACerts([][]byte{contentCA}),
-		)
+		// Build the version-check client from the same connection config the hooks
+		// use (managed cluster via kubeconfig, or in-cluster), so it trusts the
+		// right CA and authenticates with the right credentials. Certificates are
+		// issued for the kubernetes service name / cluster IP, but each apiserver
+		// endpoint is queried by address, so pin the expected TLS server name.
+		config, err := k8s.RESTConfig()
+		if err != nil {
+			versionHTTPErr = fmt.Errorf("rest config: %w", err)
+			return
+		}
+		config.TLSClientConfig.ServerName = "kubernetes.default.svc"
+
+		client, err := rest.HTTPClientFor(config)
+		if err != nil {
+			versionHTTPErr = fmt.Errorf("http client: %w", err)
+			return
+		}
+		versionHTTPClient = client
 	})
+	if versionHTTPClient == nil {
+		return fmt.Errorf("version http client: %w", versionHTTPErr)
+	}
 
 	versions := make([]string, 0)
 	var minVer *semver.Version

--- a/go_lib/dependency/dependency.go
+++ b/go_lib/dependency/dependency.go
@@ -29,7 +29,6 @@ import (
 	"github.com/flant/kube-client/fake"
 	"github.com/gojuno/minimock/v3"
 	"github.com/jonboulle/clockwork"
-	"github.com/pkg/errors"
 	"k8s.io/client-go/rest"
 
 	"github.com/deckhouse/deckhouse/go_lib/dependency/cr"
@@ -187,17 +186,21 @@ func (dc *dependencyContainer) GetClientConfig() (*rest.Config, error) {
 		return TestDC.GetClientConfig()
 	}
 
-	config, err := rest.InClusterConfig()
+	config, err := k8s.RESTConfig()
 	if err != nil {
-		return nil, fmt.Errorf("in cluster config: %w", err)
+		return nil, fmt.Errorf("rest config: %w", err)
 	}
 
-	caCert, err := os.ReadFile(config.TLSClientConfig.CAFile)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to read CA file")
-	}
+	// InClusterConfig reports the CA via a file path; callers expect the bytes
+	// inline, so read the file when the kubeconfig did not already provide CAData.
+	if len(config.CAData) == 0 && config.TLSClientConfig.CAFile != "" {
+		caCert, err := os.ReadFile(config.TLSClientConfig.CAFile)
+		if err != nil {
+			return nil, fmt.Errorf("read CA file: %w", err)
+		}
 
-	config.CAData = caCert
+		config.CAData = caCert
+	}
 
 	return config, nil
 }

--- a/go_lib/dependency/k8s/k8s.go
+++ b/go_lib/dependency/k8s/k8s.go
@@ -54,22 +54,59 @@ type k8sClient struct {
 	dynamicClient dynamic.Interface
 }
 
-func NewClient(options ...Option) (Client, error) {
-	opts := &k8sOptions{}
+// defaultKubeConfigPath and defaultKubeContext point the clients built by this
+// package at an explicit kubeconfig instead of the in-cluster service account.
+// They are set once at startup via SetDefaultKubeConfig and read-only afterwards.
+var (
+	defaultKubeConfigPath string
+	defaultKubeContext    string
+)
+
+// SetDefaultKubeConfig makes NewClient and RESTConfig build their rest.Config
+// from the given kubeconfig instead of the in-cluster service account token. An
+// empty path keeps the in-cluster behavior. It must be called once during
+// startup, before any client is created, so deckhouse-controller can drive a
+// remote cluster through the same --kube-config the operator's own client uses.
+func SetDefaultKubeConfig(path, context string) {
+	defaultKubeConfigPath = path
+	defaultKubeContext = context
+}
+
+// RESTConfig resolves a *rest.Config honoring the kubeconfig set by
+// SetDefaultKubeConfig (or overridden per call via WithKubeConfig/WithKubeContext),
+// and falls back to the in-cluster config when no kubeconfig is configured.
+func RESTConfig(options ...Option) (*rest.Config, error) {
+	opts := &k8sOptions{
+		kubeconfigPath: defaultKubeConfigPath,
+		kubeContext:    defaultKubeContext,
+	}
 
 	for _, opt := range options {
 		opt(opts)
 	}
 
-	var config *rest.Config
-	var err error
-	if opts.kubeconfigPath != "" {
-		config, err = clientcmd.BuildConfigFromFlags("", opts.kubeconfigPath)
-	} else {
-		config, err = rest.InClusterConfig()
+	if opts.kubeconfigPath == "" {
+		return rest.InClusterConfig()
 	}
+
+	loadingRules := &clientcmd.ClientConfigLoadingRules{ExplicitPath: opts.kubeconfigPath}
+	overrides := &clientcmd.ConfigOverrides{}
+	if opts.kubeContext != "" {
+		overrides.CurrentContext = opts.kubeContext
+	}
+
+	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, overrides).ClientConfig()
 	if err != nil {
-		return nil, fmt.Errorf("in cluster config: %w", err)
+		return nil, fmt.Errorf("load kubeconfig %q: %w", opts.kubeconfigPath, err)
+	}
+
+	return config, nil
+}
+
+func NewClient(options ...Option) (Client, error) {
+	config, err := RESTConfig(options...)
+	if err != nil {
+		return nil, fmt.Errorf("rest config: %w", err)
 	}
 
 	clientset, err := kubernetes.NewForConfig(config)
@@ -91,6 +128,7 @@ func (k k8sClient) Dynamic() dynamic.Interface {
 
 type k8sOptions struct {
 	kubeconfigPath string
+	kubeContext    string
 }
 
 type Option func(options *k8sOptions)
@@ -99,5 +137,13 @@ type Option func(options *k8sOptions)
 func WithKubeConfig(kubeConfigPath string) Option {
 	return func(options *k8sOptions) {
 		options.kubeconfigPath = kubeConfigPath
+	}
+}
+
+// WithKubeContext selects a context from the kubeconfig passed via WithKubeConfig
+// or SetDefaultKubeConfig. It is ignored when no kubeconfig is configured.
+func WithKubeContext(kubeContext string) Option {
+	return func(options *k8sOptions) {
+		options.kubeContext = kubeContext
 	}
 }

--- a/go_lib/dependency/k8s/k8s_test.go
+++ b/go_lib/dependency/k8s/k8s_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8s
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testKubeConfig = `apiVersion: v1
+kind: Config
+current-context: ctx-a
+clusters:
+- name: cluster-a
+  cluster:
+    server: https://a.example:6443
+    insecure-skip-tls-verify: true
+- name: cluster-b
+  cluster:
+    server: https://b.example:6443
+    insecure-skip-tls-verify: true
+contexts:
+- name: ctx-a
+  context:
+    cluster: cluster-a
+    user: user-a
+- name: ctx-b
+  context:
+    cluster: cluster-b
+    user: user-b
+users:
+- name: user-a
+  user:
+    token: token-a
+- name: user-b
+  user:
+    token: token-b
+`
+
+func writeTestKubeConfig(t *testing.T) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "kubeconfig.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(testKubeConfig), 0o600))
+
+	return path
+}
+
+func TestRESTConfigFromKubeConfig(t *testing.T) {
+	path := writeTestKubeConfig(t)
+
+	tests := []struct {
+		give     string // context name, empty means current-context
+		wantHost string
+	}{
+		{give: "", wantHost: "https://a.example:6443"},
+		{give: "ctx-b", wantHost: "https://b.example:6443"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.give, func(t *testing.T) {
+			config, err := RESTConfig(WithKubeConfig(path), WithKubeContext(tt.give))
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantHost, config.Host)
+		})
+	}
+}
+
+func TestSetDefaultKubeConfig(t *testing.T) {
+	path := writeTestKubeConfig(t)
+
+	// SetDefaultKubeConfig mutates package-level defaults, so restore them.
+	t.Cleanup(func() { SetDefaultKubeConfig("", "") })
+
+	SetDefaultKubeConfig(path, "ctx-b")
+
+	config, err := RESTConfig()
+	require.NoError(t, err)
+	assert.Equal(t, "https://b.example:6443", config.Host)
+}

--- a/modules/002-deckhouse/hooks/set_module_image_value.go
+++ b/modules/002-deckhouse/hooks/set_module_image_value.go
@@ -73,8 +73,15 @@ func parseDeckhouseImage(_ context.Context, input *go_hook.HookInput) error {
 		return fmt.Errorf("failed to unmarshal deckhouse snapshot: %w", err)
 	}
 
-	if len(deckhouseImages) != 1 {
-		return fmt.Errorf("deckhouse was not able to find an image of itself")
+	if len(deckhouseImages) == 0 {
+		// No deckhouse Deployment in the cluster: deckhouse runs outside the
+		// managed cluster, so there is no image of itself to track. Leave
+		// currentReleaseImageName unset; templates gate the self-Deployment on it.
+		input.Logger.Info("no deckhouse deployment in the cluster, skip setting the release image")
+		return nil
+	}
+	if len(deckhouseImages) > 1 {
+		return fmt.Errorf("deckhouse found more than one image of itself")
 	}
 	image := deckhouseImages[0]
 

--- a/modules/002-deckhouse/hooks/set_module_image_value_test.go
+++ b/modules/002-deckhouse/hooks/set_module_image_value_test.go
@@ -129,4 +129,17 @@ spec:
 			})
 		})
 	})
+
+	Context("Without Deckhouse pod (running outside the managed cluster)", func() {
+		BeforeEach(func() {
+			f.KubeStateSet(``)
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.RunHook()
+		})
+
+		It("Should run and leave the release image unset", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("deckhouse.internal.currentReleaseImageName").Exists()).To(BeFalse())
+		})
+	})
 })

--- a/modules/002-deckhouse/openapi/values.yaml
+++ b/modules/002-deckhouse/openapi/values.yaml
@@ -5,8 +5,6 @@ properties:
   internal:
     type: object
     default: {}
-    x-required-for-helm:
-    - currentReleaseImageName
     properties:
       namespaces:
         type: array

--- a/modules/002-deckhouse/templates/admission/validation.yaml
+++ b/modules/002-deckhouse/templates/admission/validation.yaml
@@ -1,6 +1,8 @@
 {{/* KubeDNS is not installed on the bootstrap phase and kube-apiserver will fail on a DNS resolution request */}}
 {{/*   because it doesn't know `deckhouse.d8-system.svc` address yet.*/}}
-{{- if .Values.global.clusterIsBootstrapped }}
+{{/* The webhook points at the in-cluster deckhouse Service; skip it when deckhouse */}}
+{{/*   manages a remote cluster (no self-Deployment, so currentReleaseImageName is unset). */}}
+{{- if and .Values.global.clusterIsBootstrapped (hasKey .Values.deckhouse.internal "currentReleaseImageName") }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:

--- a/modules/002-deckhouse/templates/deployment.yaml
+++ b/modules/002-deckhouse/templates/deployment.yaml
@@ -3,6 +3,13 @@ cpu: 150m
 memory: 500Mi
 {{- end }}
 
+{{- /*
+  Render deckhouse's own workload only when it runs in this cluster (self-hosted).
+  currentReleaseImageName is set by the set_module_image_value hook from the
+  in-cluster deckhouse Deployment; when deckhouse manages a remote cluster it is
+  unset, so nothing here is rendered into that cluster.
+*/}}
+{{- if (hasKey .Values.deckhouse.internal "currentReleaseImageName") }}
 {{- if or (.Values.global.discovery.apiVersions | has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
 ---
 apiVersion: autoscaling.k8s.io/v1
@@ -415,3 +422,4 @@ spec:
         hostPath:
           path: /var/lib/deckhouse/downloaded
           type: DirectoryOrCreate
+{{- end }}


### PR DESCRIPTION
## Description


## Why do we need it, and what problem does it solve?

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: Build hook and controller Kubernetes clients from the configured kubeconfig
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
