### PR TITLE
[deckhouse] chore: add pod policy labels to d8-system namespace

### DIFF
--- a/modules/002-deckhouse/hooks/ensure_system_namespace_labels.go
+++ b/modules/002-deckhouse/hooks/ensure_system_namespace_labels.go
@@ -43,8 +43,11 @@ func enableExtendedMonitoring(_ context.Context, input *go_hook.HookInput) error
 		"metadata": map[string]interface{}{
 			"labels": map[string]string{
 				"heritage": "deckhouse",
-				"extended-monitoring.deckhouse.io/enabled":      "",
-				"prometheus.deckhouse.io/rules-watcher-enabled": "true",
+				"extended-monitoring.deckhouse.io/enabled":           "",
+				"prometheus.deckhouse.io/rules-watcher-enabled":      "true",
+				"security.deckhouse.io/pod-policy":                   "restricted",
+				"security.deckhouse.io/pod-policy-action":            "warn",
+				"security.deckhouse.io/enable-security-policy-check": "true",
 			},
 		},
 	}

--- a/modules/002-deckhouse/hooks/ensure_system_namespace_labels_test.go
+++ b/modules/002-deckhouse/hooks/ensure_system_namespace_labels_test.go
@@ -89,6 +89,28 @@ metadata:
 			Expect(label.String()).To(Equal("true"))
 		})
 
+		It("Pod policy labels should be present on d8-system namespace", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			ns := f.KubernetesGlobalResource("Namespace", "d8-system")
+			for name, value := range map[string]string{
+				`security\.deckhouse\.io/pod-policy`:                   "restricted",
+				`security\.deckhouse\.io/pod-policy-action`:            "warn",
+				`security\.deckhouse\.io/enable-security-policy-check`: "true",
+			} {
+				label := ns.Field("metadata.labels." + name)
+				Expect(label.Exists()).To(BeTrue())
+				Expect(label.String()).To(Equal(value))
+			}
+		})
+
+		It("Pod policy labels should not be present on kube-system namespace", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			ns := f.KubernetesGlobalResource("Namespace", "kube-system")
+			Expect(ns.Field(`metadata.labels.security\.deckhouse\.io/pod-policy`).Exists()).To(BeFalse())
+		})
+
 		It("Rules watcher label should not be present on kube-system namespace", func() {
 			Expect(f).To(ExecuteSuccessfully())
 

--- a/modules/002-deckhouse/template_tests/module_test.go
+++ b/modules/002-deckhouse/template_tests/module_test.go
@@ -259,4 +259,56 @@ var _ = Describe("Module :: deckhouse :: helm template ::", func() {
 			Expect(servicePort).To(Equal("6443"))
 		})
 	})
+
+	Context("SecurityPolicyException for the deckhouse pod", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", globalValues)
+			f.ValuesSetFromYaml("global.discovery.apiVersions", `["deckhouse.io/v1alpha1/SecurityPolicyException"]`)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYaml("deckhouse", moduleValuesForMasterNode)
+			f.HelmRender()
+		})
+
+		nsName := "d8-system"
+		chartName := "deckhouse"
+
+		It("Pod label must point to an existing exception", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			dp := f.KubernetesResource("Deployment", nsName, chartName)
+			speName := dp.Field(`spec.template.metadata.labels.security\.deckhouse\.io/security-policy-exception`).String()
+			Expect(speName).NotTo(BeEmpty())
+			Expect(f.KubernetesResource("SecurityPolicyException", nsName, speName).Exists()).To(BeTrue())
+		})
+
+		It("Every container must drop capabilities, otherwise the exception cannot cover it", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			dp := f.KubernetesResource("Deployment", nsName, chartName)
+			for _, path := range []string{"spec.template.spec.containers", "spec.template.spec.initContainers"} {
+				for _, container := range dp.Field(path).Array() {
+					Expect(container.Get("securityContext.capabilities.drop").Array()).
+						NotTo(BeEmpty(), "container %s", container.Get("name").String())
+				}
+			}
+		})
+
+		It("Every container port must be listed in the exception, the pod runs in the host network", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			dp := f.KubernetesResource("Deployment", nsName, chartName)
+			Expect(dp.Field("spec.template.spec.hostNetwork").Bool()).To(BeTrue())
+
+			spe := f.KubernetesResource("SecurityPolicyException", nsName, chartName)
+			allowedPorts := make(map[int64]bool)
+			for _, port := range spe.Field("spec.network.hostPorts").Array() {
+				allowedPorts[port.Get("port").Int()] = true
+			}
+			for _, container := range dp.Field("spec.template.spec.containers").Array() {
+				for _, port := range container.Get("ports").Array() {
+					Expect(allowedPorts).To(HaveKey(port.Get("containerPort").Int()))
+				}
+			}
+		})
+	})
 })

--- a/modules/002-deckhouse/templates/cni-migration/agent.yaml
+++ b/modules/002-deckhouse/templates/cni-migration/agent.yaml
@@ -14,6 +14,7 @@ spec:
     metadata:
       labels:
         app: cni-migration-agent
+        security.deckhouse.io/security-policy-exception: cni-migration-agent
     spec:
       serviceAccountName: cni-migration-agent
       hostNetwork: true
@@ -57,6 +58,9 @@ spec:
           privileged: true
           runAsUser: 0
           runAsGroup: 0
+          capabilities:
+            drop:
+            - all
         volumeMounts:
         - name: tmp
           mountPath: /tmp

--- a/modules/002-deckhouse/templates/cni-migration/manager.yaml
+++ b/modules/002-deckhouse/templates/cni-migration/manager.yaml
@@ -17,10 +17,12 @@ spec:
     metadata:
       labels:
         app: cni-migration-manager
+        security.deckhouse.io/security-policy-exception: cni-migration-manager
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       priorityClassName: system-cluster-critical
+      {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
       nodeSelector:
         node-role.kubernetes.io/control-plane: ""
       tolerations:
@@ -28,6 +30,7 @@ spec:
       serviceAccountName: cni-migration-manager
       containers:
       - name: manager
+        {{- include "helm_lib_module_container_security_context_pss_restricted_flexible" dict | nindent 8 }}
         image: {{ include "helm_lib_module_common_image" (list . "cniMigrationController") }}
         args:
         - "--mode=manager"

--- a/modules/002-deckhouse/templates/cni-migration/security-policy-exception.yaml
+++ b/modules/002-deckhouse/templates/cni-migration/security-policy-exception.yaml
@@ -1,0 +1,149 @@
+{{- if .Values.global.internal.cniMigrationEnabled }}
+{{- if or (.Values.global.discovery.apiVersions | has "deckhouse.io/v1alpha1/SecurityPolicyException") (.Capabilities.APIVersions.Has "deckhouse.io/v1alpha1/SecurityPolicyException") }}
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: SecurityPolicyException
+metadata:
+  name: cni-migration-agent
+  namespace: d8-system
+  {{- include "helm_lib_module_labels" (list . (dict "app" "cni-migration-agent")) | nindent 2 }}
+spec:
+  securityContext:
+    privileged:
+      allowedValue: true
+      metadata:
+        description: |
+          The agent switches the CNI plugin on the node: it rewrites the host CNI
+          configuration and binaries, flushes iptables rules and cleans up the datapath
+          state of the CNI being replaced.
+    allowPrivilegeEscalation:
+      allowedValue: true
+      metadata:
+        description: |
+          Kubernetes rejects allowPrivilegeEscalation=false on a privileged container,
+          so it is implied by the privileged mode the agent requires.
+    runAsNonRoot:
+      allowedValue: false
+      metadata:
+        description: |
+          Rewriting host CNI configuration and binaries and managing the node datapath
+          require root on the node.
+    runAsUser:
+      allowedValues:
+        - 0
+      metadata:
+        description: |
+          UID 0 is required to enter host namespaces and to write to root-owned host
+          paths such as /etc/cni/net.d and /opt/cni/bin.
+    capabilities:
+      allowedValues:
+        drop:
+          - all
+      metadata:
+        description: |
+          The agent adds no capabilities explicitly; it relies on the privileged mode
+          required for host networking operations.
+    seccompProfile:
+      allowedValues:
+        - ""
+        - undefined
+      metadata:
+        description: |
+          The agent container runs privileged, so the container runtime applies no
+          seccomp profile to it.
+  network:
+    hostNetwork:
+      allowedValue: true
+      metadata:
+        description: |
+          The agent reconfigures node networking and reaches the API server through the
+          node-local kubernetes-api-proxy on 127.0.0.1, which stays available while the
+          cluster network is being switched over.
+    hostPID:
+      allowedValue: true
+      metadata:
+        description: |
+          The host PID namespace is required to enter the network namespaces of running
+          pods and to inspect processes of the CNI being replaced.
+    hostIPC:
+      allowedValue: true
+      metadata:
+        description: |
+          The host IPC namespace is required to reach the runtime sockets of the CNI
+          being replaced.
+  volumes:
+    types:
+      allowedValues:
+        - hostPath
+      metadata:
+        description: |
+          CNI configuration, binaries and datapath state live on the node, so they
+          cannot be provided through pod-local storage.
+    hostPath:
+      allowedValues:
+        - path: /proc
+          readOnly: true
+          metadata:
+            description: Host procfs used to look up network namespaces of running pods.
+        - path: /sys
+          readOnly: true
+          metadata:
+            description: Host sysfs used to inspect network interfaces and BPF state.
+        - path: /etc/cni/net.d
+          readOnly: false
+          metadata:
+            description: Host CNI configuration directory rewritten during the migration.
+        - path: /opt/cni/bin
+          readOnly: false
+          metadata:
+            description: Host CNI binary directory rewritten during the migration.
+        - path: /run
+          readOnly: false
+          metadata:
+            description: Host runtime directory with CNI and container runtime sockets.
+        - path: /sys/fs/bpf
+          readOnly: false
+          metadata:
+            description: BPF filesystem holding eBPF maps of the CNI being replaced.
+        - path: /lib/modules
+          readOnly: true
+          metadata:
+            description: Host kernel modules used for iptables operations.
+        - path: /var/lib/cni
+          readOnly: false
+          metadata:
+            description: Host CNI state directory cleaned up during the migration.
+        - path: /var/lib/cilium
+          readOnly: false
+          metadata:
+            description: Cilium state directory cleaned up during the migration.
+        - path: /var/log/cilium/hubble
+          readOnly: false
+          metadata:
+            description: Hubble log directory cleaned up during the migration.
+        - path: /var/run/cilium
+          readOnly: false
+          metadata:
+            description: Cilium runtime directory with the agent socket.
+        - path: /var/run/netns
+          readOnly: false
+          metadata:
+            description: Host network namespaces of running pods.
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: SecurityPolicyException
+metadata:
+  name: cni-migration-manager
+  namespace: d8-system
+  {{- include "helm_lib_module_labels" (list . (dict "app" "cni-migration-manager")) | nindent 2 }}
+spec:
+  network:
+    hostNetwork:
+      allowedValue: true
+      metadata:
+        description: |
+          The manager reaches the API server through the node-local kubernetes-api-proxy
+          on 127.0.0.1, which stays available while the cluster network is being
+          switched over.
+{{- end }}
+{{- end }}

--- a/modules/002-deckhouse/templates/deployment.yaml
+++ b/modules/002-deckhouse/templates/deployment.yaml
@@ -73,6 +73,7 @@ spec:
     metadata:
       labels:
         app: deckhouse
+        security.deckhouse.io/security-policy-exception: deckhouse
       annotations:
         checksum/registry: {{ include (print $.Template.BasePath "/registry-secret.yaml") . | sha256sum }}
         checksum/registry-version: {{ .Values.global.modulesImages.registry.hash | default "" | quote }}
@@ -123,6 +124,18 @@ spec:
             runAsUser: 0
             runAsNonRoot: false
             readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - all
+              # chown/chmod the downloaded modules directory to the deckhouse user and
+              # traverse it on subsequent runs, when it is already owned by 64535 and 0700.
+              add:
+              - CHOWN
+              - FOWNER
+              - DAC_OVERRIDE
+            seccompProfile:
+              type: RuntimeDefault
           resources:
             requests:
               {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 100 | nindent 14 }}
@@ -132,10 +145,10 @@ spec:
       containers:
         - name: deckhouse
           {{- include "helm_lib_module_container_security_context_privileged_read_only_root_filesystem" . | nindent 10 }}
-{{- if .Values.deckhouse.internal.chrootMode }}
             capabilities:
               drop:
               - all
+{{- if .Values.deckhouse.internal.chrootMode }}
               add:
               - SYS_ADMIN
   {{- if semverCompare ">= 1.30" .Values.global.discovery.kubernetesVersion }}

--- a/modules/002-deckhouse/templates/security-policy-exception.yaml
+++ b/modules/002-deckhouse/templates/security-policy-exception.yaml
@@ -1,0 +1,109 @@
+{{- if or (.Values.global.discovery.apiVersions | has "deckhouse.io/v1alpha1/SecurityPolicyException") (.Capabilities.APIVersions.Has "deckhouse.io/v1alpha1/SecurityPolicyException") }}
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: SecurityPolicyException
+metadata:
+  name: deckhouse
+  namespace: d8-system
+  {{- include "helm_lib_module_labels" (list . (dict "app" "deckhouse")) | nindent 2 }}
+spec:
+  securityContext:
+    privileged:
+      allowedValue: true
+      metadata:
+        description: |
+          The Deckhouse controller runs module hooks that manage the node: it enters the
+          host filesystem in chroot mode, reads host devices and operates on host paths
+          on behalf of the modules it installs.
+    allowPrivilegeEscalation:
+      allowedValue: true
+      metadata:
+        description: |
+          Kubernetes rejects allowPrivilegeEscalation=false on a privileged container,
+          so it is implied by the privileged mode the controller requires.
+    runAsNonRoot:
+      allowedValue: false
+      metadata:
+        description: |
+          Module hooks operate on root-owned host paths under /var/lib/deckhouse and on
+          host devices, and the init container prepares the downloaded modules directory.
+    runAsUser:
+      allowedValues:
+        - 0
+      metadata:
+        description: |
+          UID 0 is required for the host filesystem operations performed by module hooks
+          and by the init container that prepares /var/lib/deckhouse/downloaded.
+    capabilities:
+      allowedValues:
+        add:
+          - SYS_ADMIN
+          - CHOWN
+          - FOWNER
+          - DAC_OVERRIDE
+        drop:
+          - all
+      metadata:
+        description: |
+          SYS_ADMIN is required by the controller in chroot mode to enter the node
+          filesystem namespace. CHOWN, FOWNER and DAC_OVERRIDE are required by the init
+          container to hand the downloaded modules directory over to the deckhouse user.
+    appArmorProfile:
+      allowedValues:
+        - unconfined
+      metadata:
+        description: |
+          The default AppArmor profile denies the mount and chroot operations the
+          controller performs in chroot mode.
+    seccompProfile:
+      allowedValues:
+        - ""
+        - undefined
+      metadata:
+        description: |
+          The controller container runs privileged, so the container runtime applies no
+          seccomp profile to it, and the syscalls used by shell module hooks are not
+          covered by RuntimeDefault.
+  network:
+    hostNetwork:
+      allowedValue: true
+      metadata:
+        description: |
+          Deckhouse reaches the API server through the node-local kubernetes-api-proxy on
+          127.0.0.1, which keeps it working while the cluster network is being configured.
+    hostPorts:
+      - port: 4222
+        protocol: TCP
+        metadata:
+          description: Addon-operator metrics and readiness endpoint.
+      - port: 4223
+        protocol: TCP
+        metadata:
+          description: Addon-operator admission (validating and conversion) webhook server.
+      - port: 4204
+        protocol: TCP
+        metadata:
+          description: Debug HTTP server exposed through kube-rbac-proxy.
+  volumes:
+    types:
+      allowedValues:
+        - hostPath
+      metadata:
+        description: |
+          Deckhouse keeps downloaded module sources on the node and needs access to host
+          devices, so these volumes cannot be replaced with pod-local storage.
+    hostPath:
+      allowedValues:
+        - path: /dev
+          readOnly: false
+          metadata:
+            description: Host devices used by module hooks running in chroot mode.
+        - path: /var/lib/deckhouse
+          readOnly: false
+          metadata:
+            description: Node-local state directory prepared by the init container.
+        - path: /var/lib/deckhouse/downloaded
+          readOnly: false
+          metadata:
+            description: Node-local storage for downloaded module sources.
+{{- end }}


### PR DESCRIPTION
## Description

Migrates the `d8-system` namespace to Pod Security Standards `restricted` plus SecurityPolicy checks, and formalizes every legitimate deviation of this module's workloads as an explicit `SecurityPolicyException` (SPE).

**Namespace labels.** The `ensure_system_namespace_labels` hook now also sets on `d8-system`:

- `security.deckhouse.io/pod-policy=restricted`
- `security.deckhouse.io/pod-policy-action=warn`
- `security.deckhouse.io/enable-security-policy-check=true`

The action is `warn`, so nothing is blocked — violations are only reported via admission warnings and the `d8_gatekeeper_exporter_constraint_violations` metric.

**Exceptions.** Three new `SecurityPolicyException` resources: `deckhouse`, `cni-migration-agent` and `cni-migration-manager`. Each allowance carries an English `metadata.description` explaining why it is required, since these descr documentation and CSE certification evidence. Pod templates referencetheir exception through the `security.deckhouse.io/security-policy-exception` label. Both files render only when the `deckhouse.io/v1alpha1/SecurityPolicyException` API
is available, so clusters without `admission-policy-engine` are unaffec

**Manifests tightened where no exception is needed** — the goal is the  not the minimum diff:

- `deckhouse` container now drops all capabilities unconditionally; prest existed only in chroot mode. `SYS_ADMIN` is still added only inchroot mode.
- `init-downloaded-modules` init container gets `allowPrivilegeEscalatie: RuntimeDefault`, and drops all capabilities while adding only`CHOWN`, `FOWNER` and `DAC_OVERRIDE`, which it needs to hand `/var/lib/deckhouse/downloaded` over to the `deckhouse` user.
- `cni-migration-manager` moved to `helm_lib_module_pod_security_contexnd `helm_lib_module_container_security_context_pss_restricted_flexible`. It now runs as non-root with a read-only root filesystem, so `hostNetwork` is its only remaining exception.
- `cni-migration-agent` explicitly drops all capabilities on top of thees.

**Impact on critical components.** The `deckhouse` Deployment pod templouse` pod is rolling-restarted on update. The `cni-migration` workloadsare only rendered while a CNI migration is in progress. No other component is affected.


## Why do we need it, and what problem does it solve?

Deckhouse system namespaces are labelled `heritage: deckhouse` and are currently excluded from the very security policies the platform enforces on customer workloads. This is a real gap: elevated privileges in platform components are implicit defaults that nobody reviews, and there is no machine-readable record of which component needs `privileged`, root, `hostPath` or extra capabilities, or why.

Switching `d8-system` to `restricted` plus SecurityPolicy checks converts those implicit holes into explicit, reviewable `SecurityPolicyException` resources with a documented justification for each allowance. That gives three concrete benefits: deviations become visible in review and in metrics, anything that was privileged only by accident gets tightened (as several containers in this PR were), and the exception descriptions provide the audit trail required for CSE certification.

### How it was tested

Unit tests:

- `go test ./modules/002-deckhouse/...` — green. Note that the template suite needs the CI container (`charts/helm_lib` is a symlink to `/deckhouse/...`).
- New hook test asserts the three labels land on `d8-system` and are not applied to `kube-system`.
- Three new template tests assert that the pod label points at an exception that actually exists, that every container drops capabilities, and that every `containerPort` is listed in the exception's `network.hostPorts`. The last one matters because with `hostNetwork: true` the exception's port list fully replaces the policy's port ranges, so an incomplete list would silently produce violations.

Manual verification on a dev stand:

- Confirmed the policies actually reach the namespace: a deliberately non-compliant pod is rejected by both `d8-pod-security-restricted-deny-d8-default` and a temporary SecurityPolicy stricter than the real manifests.
- With `pod-policy-action=deny` and that strict SecurityPolicy applied, every pod living in `d8-system` was re-submitted through admission via `--dry-run=server`. All passed: `deckhouse`, `webhook-handler`, `documentation`, `deckhouse-tools`, both dex-authenticators, and the cert-manager ACME HTTP-01 solver.
- Gatekeeper audit reports zero violations for `d8-system`, and audit timestamps were confirmed to advance, so the zero is a real result rather than a stale one.


## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: chore
summary: Add pod policy labels to d8-system namespace.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
