### PR TITLE
[candi] remove Python dependency from reverse tunnel scripts

### DIFF
--- a/candi/bashible/preflight/check_reverse_tunnel_open.sh.tpl
+++ b/candi/bashible/preflight/check_reverse_tunnel_open.sh.tpl
@@ -15,29 +15,7 @@
 # limitations under the License.
 */}}
 
-{{- $python_discovery := .Files.Get "deckhouse/candi/bashible/check_python.sh.tpl" }}
-{{- tpl ( $python_discovery ) . | nindent 0 }}
+target='{{ .url }}'
+target="${target#http://}"
 
-check_python
-
-cat - <<EOF | $python_binary
-import ssl
-try:
-    from urllib.request import urlopen, Request
-except ImportError as e:
-    from urllib2 import urlopen, Request
-
-ssl._create_default_https_context = ssl._create_unverified_context
-request = Request('{{.url}}')
-res = False
-try:
-    response = urlopen(request, timeout=5)
-    res = True if response else False
-except Exception as err:
-    res = False
-
-exit(0) if res else exit(1)
-
-EOF
-
-
+minget "$target" --fail --timeout 5 >/dev/null

--- a/candi/bashible/preflight/check_reverse_tunnel_reachable.sh.tpl
+++ b/candi/bashible/preflight/check_reverse_tunnel_reachable.sh.tpl
@@ -15,32 +15,8 @@
 # limitations under the License.
 */}}
 
-{{- $python_discovery := .Files.Get "deckhouse/candi/bashible/check_python.sh.tpl" }}
-{{- tpl ( $python_discovery ) . | nindent 0 }}
+target='{{.url}}'
+target="${target#http://}"
 
-check_python
-
-cat - <<EOF | $python_binary
-import ssl
-try:
-    from urllib.request import urlopen, Request
-    from urllib.error import HTTPError
-except ImportError as e:
-    from urllib2 import urlopen, Request, HTTPError
-
-ssl._create_default_https_context = ssl._create_unverified_context
-request = Request('{{.url}}')
-alive = False
-try:
-    urlopen(request, timeout=5)
-    alive = True
-except HTTPError:
-    # Any HTTP status (e.g. 404 from the rpp-get server) proves the SSH
-    # channel is alive end-to-end, so the reverse tunnel is healthy.
-    alive = True
-except Exception as err:
-    alive = False
-
-exit(0) if alive else exit(1)
-
-EOF
+# Any HTTP response proves that the SSH channel is alive end-to-end.
+minget "$target" --timeout 5 >/dev/null

--- a/candi/bashible/preflight/kill_reverse_tunnel.sh.tpl
+++ b/candi/bashible/preflight/kill_reverse_tunnel.sh.tpl
@@ -15,89 +15,39 @@
 # limitations under the License.
 */}}
 
-{{- $python_discovery := .Files.Get "deckhouse/candi/bashible/check_python.sh.tpl" }}
-{{- tpl ( $python_discovery ) . | nindent 0 }}
+# Kill the process listening on a TCP port by resolving its socket through /proc.
 
-cat - <<EOF | $python_binary
-import pwd
-import os
-import re
-import glob
-import signal
+# Build the little-endian hexadecimal address used in /proc/net/tcp,
+# for example: 1.2.3.4:80 -> 04030201:0050.
+hex_addr="$(awk -v ip='{{.host}}' -v port='{{.port}}' 'BEGIN {
+    split(ip, b, ".")
+    printf "%02X%02X%02X%02X:%04X", b[4], b[3], b[2], b[1], port
+}')"
 
-PROC_TCP = "/proc/net/tcp"
-STATE = {
-        '01':'ESTABLISHED',
-        '02':'SYN_SENT',
-        '03':'SYN_RECV',
-        '04':'FIN_WAIT1',
-        '05':'FIN_WAIT2',
-        '06':'TIME_WAIT',
-        '07':'CLOSE',
-        '08':'CLOSE_WAIT',
-        '09':'LAST_ACK',
-        '0A':'LISTEN',
-        '0B':'CLOSING'
-        }
+# Find the socket inode of the matching LISTEN entry. TCP state 0A means LISTEN.
+inode="$(awk -v address="$hex_addr" '
+    $2 == address && $4 == "0A" {
+        print $10
+        exit
+    }
+' /proc/net/tcp)"
 
-def _load():
-    with open(PROC_TCP,'r') as f:
-        content = f.readlines()
-        content.pop(0)
-    return content
+if [ -z "$inode" ]; then
+    echo "Port not found"
+    exit 0
+fi
 
-def _hex2dec(s):
-    return str(int(s,16))
+# Map the socket inode to a PID through /proc/<pid>/fd and kill the process.
+for fd in /proc/[0-9]*/fd/*; do
+    [ "$(readlink "$fd" 2>/dev/null)" = "socket:[$inode]" ] || continue
 
-def _ip(s):
-    ip = [(_hex2dec(s[6:8])),(_hex2dec(s[4:6])),(_hex2dec(s[2:4])),(_hex2dec(s[0:2]))]
-    return '.'.join(ip)
+    pid="${fd#/proc/}"
+    pid="${pid%%/*}"
 
-def _remove_empty(array):
-    return [x for x in array if x !='']
+    echo "$pid"
+    kill -9 "$pid" 2>/dev/null
+    exit 0
+done
 
-def _convert_ip_port(array):
-    host,port = array.split(':')
-    return _ip(host),_hex2dec(port)
-
-def get_pid_for_listen_port(host, port):
-    content=_load()
-    for line in content:
-        line_array = _remove_empty(line.split(' '))
-        l_host,l_port = _convert_ip_port(line_array[1])
-        if l_host != host or l_port != port:
-            continue
-        state = STATE[line_array[3]]
-        if state != 'LISTEN':
-            continue
-        inode = line_array[9]
-        pid = _get_pid_of_inode(inode)
-
-        return pid
-    return ''
-
-def _get_pid_of_inode(inode):
-    for item in glob.glob('/proc/[0-9]*/fd/[0-9]*'):
-        try:
-            if re.search(inode,os.readlink(item)):
-                return item.split('/')[2]
-        except:
-            pass
-    return ''
-
-if __name__ == '__main__':
-    pid = get_pid_for_listen_port('{{.host}}', '{{.port}}')
-    print(pid)
-    if pid == '':
-        print('No process is listening on the requested port')
-        exit(0)
-    try:
-        os.kill(int(pid), signal.SIGKILL)
-    except Exception as e:
-        print(e)
-
-    exit(0)
-
-EOF
-
-
+echo "Port not found"
+exit 0

--- a/dhctl/pkg/template/preflight_test.go
+++ b/dhctl/pkg/template/preflight_test.go
@@ -45,7 +45,13 @@ func TestRenderAndSavePreflightReverseTunnelReachableScript(t *testing.T) {
 	require.NoError(t, err)
 
 	s := string(content)
-	require.Contains(t, s, "Request('http://127.0.0.1:4282/healthz')")
-	require.Contains(t, s, "except HTTPError:")
-	require.Contains(t, s, "alive = True")
+
+	require.Contains(t, s, `target='http://127.0.0.1:4282/healthz'`)
+	require.Contains(t, s, `target="${target#http://}"`)
+	require.Contains(t, s, `minget "$target" --timeout 5 >/dev/null`)
+
+	require.NotContains(t, s, "check_python")
+	require.NotContains(t, s, "python_binary")
+	require.NotContains(t, s, "urllib")
+	require.NotContains(t, s, `minget "$target" --fail`)
 }


### PR DESCRIPTION
## Description

Replaced Python-based reverse tunnel bootstrap helper scripts with implementations that do not require Python.

What changed:

* check_reverse_tunnel_open.sh.tpl now uses minget to verify that the service exposed through the SSH reverse tunnel returns a successful HTTP response.
* check_reverse_tunnel_reachable.sh.tpl now uses minget to verify end-to-end reverse tunnel connectivity.
* kill_reverse_tunnel.sh.tpl now uses Bash and /proc to locate and terminate the process listening on the tunnel port.
* Updated the corresponding unit tests.

The change does not restart or affect running cluster components. It only changes helper scripts used during bootstrap.

## Why do we need it, and what problem does it solve?

The reverse tunnel bootstrap helper scripts required Python to be installed on the target node.

The connectivity checks can be performed with minget, while the listening process can be located directly through /proc. Removing the Python dependency makes bootstrap compatible with more minimal operating system installations and avoids requiring an interpreter for these simple operations.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: candi
type: chore
summary: Remove Python dependency from reverse tunnel bootstrap helper scripts.
impact_level: low
```