### PR TITLE
Backport: [deckhouse] Skip ModuleDocumentation for embedded modules

### DIFF
--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -641,7 +641,15 @@ func (r *reconciler) handleDeployedRelease(ctx context.Context, release *v1alpha
 		Controller: ptr.To(true),
 	}
 
-	if !r.installer.IsEmbeddedPresent(release.GetModuleName()) {
+	module := new(v1alpha1.Module)
+	if err = r.client.Get(ctx, client.ObjectKey{Name: release.GetModuleName()}, module); err != nil {
+		r.log.Error("failed to get module", slog.String("module", release.GetModuleName()), log.Err(err))
+
+		return res, fmt.Errorf("get module: %w", err)
+	}
+
+	isEmbedded := module.IsEmbedded() && r.installer.IsEmbeddedPresent(release.GetModuleName())
+	if !isEmbedded {
 		// mpo not found and module is not embedded - update the docs from the module release version
 		if err := utils.EnsureModuleDocumentation(ctx, r.client, release.GetModuleName(), release.GetModuleSource(), moduleChecksum, moduleVersion, modulePath, ownerRef); err != nil {
 			r.log.Error("failed to ensure module documentation", slog.String("module", release.GetModuleName()), log.Err(err))

--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -648,8 +648,7 @@ func (r *reconciler) handleDeployedRelease(ctx context.Context, release *v1alpha
 		return res, fmt.Errorf("get module: %w", err)
 	}
 
-	isEmbedded := module.IsEmbedded() && r.installer.IsEmbeddedPresent(release.GetModuleName())
-	if !isEmbedded {
+	if !r.installer.IsEmbeddedPresent(release.GetModuleName()) {
 		// mpo not found and module is not embedded - update the docs from the module release version
 		if err := utils.EnsureModuleDocumentation(ctx, r.client, release.GetModuleName(), release.GetModuleSource(), moduleChecksum, moduleVersion, modulePath, ownerRef); err != nil {
 			r.log.Error("failed to ensure module documentation", slog.String("module", release.GetModuleName()), log.Err(err))

--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -641,11 +641,13 @@ func (r *reconciler) handleDeployedRelease(ctx context.Context, release *v1alpha
 		Controller: ptr.To(true),
 	}
 
-	// mpo not found - update the docs from the module release version
-	if err = utils.EnsureModuleDocumentation(ctx, r.client, release.GetModuleName(), release.GetModuleSource(), moduleChecksum, moduleVersion, modulePath, ownerRef); err != nil {
-		r.log.Error("failed to ensure module documentation", slog.String("module", release.GetModuleName()), log.Err(err))
+	if !r.installer.IsEmbeddedPresent(release.GetModuleName()) {
+		// mpo not found and module is not embedded - update the docs from the module release version
+		if err := utils.EnsureModuleDocumentation(ctx, r.client, release.GetModuleName(), release.GetModuleSource(), moduleChecksum, moduleVersion, modulePath, ownerRef); err != nil {
+			r.log.Error("failed to ensure module documentation", slog.String("module", release.GetModuleName()), log.Err(err))
 
-		return res, fmt.Errorf("ensure module documentation: %w", err)
+			return res, fmt.Errorf("ensure module documentation: %w", err)
+		}
 	}
 
 	r.log.Debug("delete outdated releases for module", slog.String("module", release.GetModuleName()))

--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -641,13 +641,6 @@ func (r *reconciler) handleDeployedRelease(ctx context.Context, release *v1alpha
 		Controller: ptr.To(true),
 	}
 
-	module := new(v1alpha1.Module)
-	if err = r.client.Get(ctx, client.ObjectKey{Name: release.GetModuleName()}, module); err != nil {
-		r.log.Error("failed to get module", slog.String("module", release.GetModuleName()), log.Err(err))
-
-		return res, fmt.Errorf("get module: %w", err)
-	}
-
 	if !r.installer.IsEmbeddedPresent(release.GetModuleName()) {
 		// mpo not found and module is not embedded - update the docs from the module release version
 		if err := utils.EnsureModuleDocumentation(ctx, r.client, release.GetModuleName(), release.GetModuleSource(), moduleChecksum, moduleVersion, modulePath, ownerRef); err != nil {

--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller_test.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller_test.go
@@ -42,6 +42,7 @@ import (
 	"golang.org/x/text/language"
 	"helm.sh/helm/v3/pkg/releaseutil"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	validationerrors "k8s.io/kube-openapi/pkg/validation/errors"
@@ -176,6 +177,63 @@ func (suite *ReleaseControllerTestSuite) TestCreateReconcile() {
 			_, err = suite.ctr.handleRelease(context.TODO(), mr)
 			require.NoError(suite.T(), err)
 		})
+	})
+
+	// The module is not embedded, so deploying its release also creates the
+	// ModuleDocumentation resource.
+	suite.Run("module documentation created", func() {
+		suite.setupReleaseController(suite.fetchTestFileData("module-documentation-create.yaml"))
+
+		repeatTest(func() {
+			mr := suite.getModuleRelease(suite.testMRName)
+			_, err = suite.ctr.handleRelease(context.TODO(), mr)
+			require.NoError(suite.T(), err)
+		})
+
+		documentation := suite.getModuleDocumentation("parca")
+		assert.Equal(suite.T(), "v1.4.3", documentation.Spec.Version)
+		assert.Equal(suite.T(), "/modules/parca", documentation.Spec.Path)
+		assert.Equal(suite.T(), "98d00f741c99e06e6c6c4d18b763c550", documentation.Spec.Checksum)
+	})
+
+	// A ModuleDocumentation left over from the previous release must be updated
+	// to the version, checksum and path of the newly deployed release.
+	suite.Run("module documentation updated", func() {
+		suite.setupReleaseController(suite.fetchTestFileData("module-documentation-update.yaml"))
+
+		repeatTest(func() {
+			mr := suite.getModuleRelease(suite.testMRName)
+			_, err = suite.ctr.handleRelease(context.TODO(), mr)
+			require.NoError(suite.T(), err)
+		})
+
+		documentation := suite.getModuleDocumentation("parca")
+		assert.Equal(suite.T(), "v1.4.3", documentation.Spec.Version)
+		assert.Equal(suite.T(), "/modules/parca", documentation.Spec.Path)
+		assert.Equal(suite.T(), "98d00f741c99e06e6c6c4d18b763c550", documentation.Spec.Checksum)
+		require.Len(suite.T(), documentation.GetOwnerReferences(), 1)
+		assert.Equal(suite.T(), "parca-v1.4.3", documentation.GetOwnerReferences()[0].Name)
+	})
+
+	// The module is served by its embedded copy (source == Embedded, the copy is
+	// still on disk), so the release is only staged and no ModuleDocumentation is
+	// created for it - documentation for embedded modules is handled elsewhere.
+	suite.Run("module documentation skipped for embedded module", func() {
+		suite.setupReleaseController(
+			suite.fetchTestFileData("module-documentation-embedded.yaml"),
+			withInstaller(&installermock.Installer{
+				IsEmbeddedPresentFunc: func(string) bool { return true },
+			}),
+		)
+
+		repeatTest(func() {
+			mr := suite.getModuleRelease(suite.testMRName)
+			_, err = suite.ctr.handleRelease(context.TODO(), mr)
+			require.NoError(suite.T(), err)
+		})
+
+		err = suite.client.Get(context.TODO(), client.ObjectKey{Name: "parca"}, new(v1alpha1.ModuleDocumentation))
+		assert.True(suite.T(), apierrors.IsNotFound(err), "documentation must not be created for an embedded module")
 	})
 
 	// The module was still embedded but its embedded copy is no longer on disk
@@ -1055,6 +1113,12 @@ func (suite *ReleaseControllerTestSuite) assembleInitObject(strObj string) clien
 		require.NoError(suite.T(), err)
 		obj = module
 
+	case v1alpha1.ModuleDocumentationGVK.Kind:
+		documentation := new(v1alpha1.ModuleDocumentation)
+		err = yaml.Unmarshal(raw, documentation)
+		require.NoError(suite.T(), err)
+		obj = documentation
+
 	case "Secret":
 		secret := new(corev1.Secret)
 		err = yaml.Unmarshal(raw, secret)
@@ -1081,6 +1145,14 @@ func (suite *ReleaseControllerTestSuite) getModuleRelease(name string) *v1alpha1
 	require.NoError(suite.T(), err)
 
 	return release
+}
+
+func (suite *ReleaseControllerTestSuite) getModuleDocumentation(name string) *v1alpha1.ModuleDocumentation {
+	documentation := new(v1alpha1.ModuleDocumentation)
+	err := suite.client.Get(context.TODO(), client.ObjectKey{Name: name}, documentation)
+	require.NoError(suite.T(), err)
+
+	return documentation
 }
 
 func (suite *ReleaseControllerTestSuite) fetchResults() []byte {

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/module-documentation-create.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/module-documentation-create.yaml
@@ -1,0 +1,76 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  annotations:
+    modules.deckhouse.io/registry-spec-checksum: 38557e472e4e2bd8695fc58a255ec3dd
+  creationTimestamp: null
+  finalizers:
+  - modules.deckhouse.io/release-exists
+  name: foxtrot
+  resourceVersion: "999"
+spec:
+  registry:
+    ca: ""
+    dockerCfg: YXNiCg==
+    repo: dev-registry.deckhouse.io/team/foxtrot/modules
+    scheme: HTTPS
+status:
+  message: ""
+  modules:
+  - name: parca
+    policy: foxtrot-alpha
+  modulesCount: 1
+  phase: ""
+  syncTime: "2024-05-03T21:05:05Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleRelease
+metadata:
+  annotations:
+    modules.deckhouse.io/isUpdating: "false"
+    modules.deckhouse.io/notified: "true"
+  creationTimestamp: null
+  finalizers:
+  - modules.deckhouse.io/metrics-registered
+  - modules.deckhouse.io/exist-on-fs
+  labels:
+    module: parca
+    modules.deckhouse.io/update-policy: foxtrot-alpha
+    release-checksum: 98d00f741c99e06e6c6c4d18b763c550
+    source: foxtrot
+    status: deployed
+  name: parca-v1.4.3
+  ownerReferences:
+  - apiVersion: deckhouse.io/v1alpha1
+    controller: true
+    kind: ModuleSource
+    name: foxtrot
+    uid: 71d2300f-700b-452a-896a-6a3805f9cef7
+  resourceVersion: "1003"
+spec:
+  moduleName: parca
+  version: 1.4.3
+  weight: 900
+status:
+  approved: false
+  message: ""
+  phase: Deployed
+  pullDuration: 0s
+  size: 0
+  transitionTime: "2024-05-03T20:55:49Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: Module
+metadata:
+  creationTimestamp: null
+  name: parca
+  resourceVersion: "1000"
+properties: {}
+status:
+  conditions:
+  - lastProbeTime: "2019-10-17T15:33:00Z"
+    lastTransitionTime: "2019-10-17T15:33:00Z"
+    status: "True"
+    type: LastReleaseDeployed
+  phase: Ready

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/module-documentation-embedded.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/module-documentation-embedded.yaml
@@ -1,0 +1,77 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  annotations:
+    modules.deckhouse.io/registry-spec-checksum: 38557e472e4e2bd8695fc58a255ec3dd
+  creationTimestamp: null
+  finalizers:
+  - modules.deckhouse.io/release-exists
+  name: foxtrot
+  resourceVersion: "999"
+spec:
+  registry:
+    ca: ""
+    dockerCfg: YXNiCg==
+    repo: dev-registry.deckhouse.io/team/foxtrot/modules
+    scheme: HTTPS
+status:
+  message: ""
+  modules:
+  - name: parca
+    policy: foxtrot-alpha
+  modulesCount: 1
+  phase: ""
+  syncTime: "2024-05-03T21:05:05Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleRelease
+metadata:
+  annotations:
+    modules.deckhouse.io/isUpdating: "false"
+    modules.deckhouse.io/notified: "true"
+  creationTimestamp: null
+  finalizers:
+  - modules.deckhouse.io/metrics-registered
+  - modules.deckhouse.io/exist-on-fs
+  labels:
+    module: parca
+    modules.deckhouse.io/update-policy: foxtrot-alpha
+    release-checksum: 98d00f741c99e06e6c6c4d18b763c550
+    source: foxtrot
+    status: deployed
+  name: parca-v1.4.3
+  ownerReferences:
+  - apiVersion: deckhouse.io/v1alpha1
+    controller: true
+    kind: ModuleSource
+    name: foxtrot
+    uid: 71d2300f-700b-452a-896a-6a3805f9cef7
+  resourceVersion: "1003"
+spec:
+  moduleName: parca
+  version: 1.4.3
+  weight: 900
+status:
+  approved: false
+  message: ""
+  phase: Deployed
+  pullDuration: 0s
+  size: 0
+  transitionTime: "2024-05-03T20:55:49Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: Module
+metadata:
+  creationTimestamp: null
+  name: parca
+  resourceVersion: "1000"
+properties:
+  source: Embedded
+status:
+  conditions:
+  - lastProbeTime: "2019-10-17T15:33:00Z"
+    lastTransitionTime: "2019-10-17T15:33:00Z"
+    status: "True"
+    type: LastReleaseDeployed
+  phase: Ready

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/module-documentation-update.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/module-documentation-update.yaml
@@ -1,0 +1,76 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  annotations:
+    modules.deckhouse.io/registry-spec-checksum: 38557e472e4e2bd8695fc58a255ec3dd
+  creationTimestamp: null
+  finalizers:
+  - modules.deckhouse.io/release-exists
+  name: foxtrot
+  resourceVersion: "999"
+spec:
+  registry:
+    ca: ""
+    dockerCfg: YXNiCg==
+    repo: dev-registry.deckhouse.io/team/foxtrot/modules
+    scheme: HTTPS
+status:
+  message: ""
+  modules:
+  - name: parca
+    policy: foxtrot-alpha
+  modulesCount: 1
+  phase: ""
+  syncTime: "2024-05-03T21:05:05Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleRelease
+metadata:
+  annotations:
+    modules.deckhouse.io/isUpdating: "false"
+    modules.deckhouse.io/notified: "true"
+  creationTimestamp: null
+  finalizers:
+  - modules.deckhouse.io/metrics-registered
+  - modules.deckhouse.io/exist-on-fs
+  labels:
+    module: parca
+    modules.deckhouse.io/update-policy: foxtrot-alpha
+    release-checksum: 98d00f741c99e06e6c6c4d18b763c550
+    source: foxtrot
+    status: deployed
+  name: parca-v1.4.3
+  ownerReferences:
+  - apiVersion: deckhouse.io/v1alpha1
+    controller: true
+    kind: ModuleSource
+    name: foxtrot
+    uid: 71d2300f-700b-452a-896a-6a3805f9cef7
+  resourceVersion: "1003"
+spec:
+  moduleName: parca
+  version: 1.4.3
+  weight: 900
+status:
+  approved: false
+  message: ""
+  phase: Deployed
+  pullDuration: 0s
+  size: 0
+  transitionTime: "2024-05-03T20:55:49Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: Module
+metadata:
+  creationTimestamp: null
+  name: parca
+  resourceVersion: "1000"
+properties: {}
+status:
+  conditions:
+  - lastProbeTime: "2019-10-17T15:33:00Z"
+    lastTransitionTime: "2019-10-17T15:33:00Z"
+    status: "True"
+    type: LastReleaseDeployed
+  phase: Ready

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/module-documentation-create.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/module-documentation-create.yaml
@@ -1,0 +1,65 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  annotations:
+    modules.deckhouse.io/registry-spec-checksum: 38557e472e4e2bd8695fc58a255ec3dd
+  finalizers:
+    - modules.deckhouse.io/release-exists
+  name: foxtrot
+spec:
+  registry:
+    ca: ""
+    dockerCfg: YXNiCg==
+    repo: dev-registry.deckhouse.io/team/foxtrot/modules
+    scheme: HTTPS
+status:
+  message: ""
+  modules:
+    - name: parca
+      policy: foxtrot-alpha
+  modulesCount: 1
+  syncTime: "2024-05-03T21:05:05Z"
+---
+apiVersion: deckhouse.io/v1alpha2
+kind: ModuleUpdatePolicy
+metadata:
+  name: foxtrot-alpha
+spec:
+  releaseChannel: Alpha
+  update:
+    mode: Auto
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleRelease
+metadata:
+  labels:
+    module: parca
+    modules.deckhouse.io/update-policy: foxtrot-alpha
+    release-checksum: 98d00f741c99e06e6c6c4d18b763c550
+    source: foxtrot
+  name: parca-v1.4.3
+  ownerReferences:
+    - apiVersion: deckhouse.io/v1alpha1
+      controller: true
+      kind: ModuleSource
+      name: foxtrot
+      uid: 71d2300f-700b-452a-896a-6a3805f9cef7
+spec:
+  moduleName: parca
+  version: 1.4.3
+  weight: 900
+status:
+  approved: false
+  message: ""
+  phase: Pending
+  pullDuration: 0s
+  size: 0
+  transitionTime: "2024-05-03T20:55:49Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: Module
+metadata:
+  name: parca
+status:
+  phase: Ready

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/module-documentation-embedded.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/module-documentation-embedded.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  annotations:
+    modules.deckhouse.io/registry-spec-checksum: 38557e472e4e2bd8695fc58a255ec3dd
+  finalizers:
+    - modules.deckhouse.io/release-exists
+  name: foxtrot
+spec:
+  registry:
+    ca: ""
+    dockerCfg: YXNiCg==
+    repo: dev-registry.deckhouse.io/team/foxtrot/modules
+    scheme: HTTPS
+status:
+  message: ""
+  modules:
+    - name: parca
+      policy: foxtrot-alpha
+  modulesCount: 1
+  syncTime: "2024-05-03T21:05:05Z"
+---
+apiVersion: deckhouse.io/v1alpha2
+kind: ModuleUpdatePolicy
+metadata:
+  name: foxtrot-alpha
+spec:
+  releaseChannel: Alpha
+  update:
+    mode: Auto
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleRelease
+metadata:
+  labels:
+    module: parca
+    modules.deckhouse.io/update-policy: foxtrot-alpha
+    release-checksum: 98d00f741c99e06e6c6c4d18b763c550
+    source: foxtrot
+  name: parca-v1.4.3
+  ownerReferences:
+    - apiVersion: deckhouse.io/v1alpha1
+      controller: true
+      kind: ModuleSource
+      name: foxtrot
+      uid: 71d2300f-700b-452a-896a-6a3805f9cef7
+spec:
+  moduleName: parca
+  version: 1.4.3
+  weight: 900
+status:
+  approved: false
+  message: ""
+  phase: Pending
+  pullDuration: 0s
+  size: 0
+  transitionTime: "2024-05-03T20:55:49Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: Module
+metadata:
+  name: parca
+properties:
+  source: Embedded
+status:
+  phase: Ready

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/module-documentation-update.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/module-documentation-update.yaml
@@ -1,0 +1,82 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  annotations:
+    modules.deckhouse.io/registry-spec-checksum: 38557e472e4e2bd8695fc58a255ec3dd
+  finalizers:
+    - modules.deckhouse.io/release-exists
+  name: foxtrot
+spec:
+  registry:
+    ca: ""
+    dockerCfg: YXNiCg==
+    repo: dev-registry.deckhouse.io/team/foxtrot/modules
+    scheme: HTTPS
+status:
+  message: ""
+  modules:
+    - name: parca
+      policy: foxtrot-alpha
+  modulesCount: 1
+  syncTime: "2024-05-03T21:05:05Z"
+---
+apiVersion: deckhouse.io/v1alpha2
+kind: ModuleUpdatePolicy
+metadata:
+  name: foxtrot-alpha
+spec:
+  releaseChannel: Alpha
+  update:
+    mode: Auto
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleRelease
+metadata:
+  labels:
+    module: parca
+    modules.deckhouse.io/update-policy: foxtrot-alpha
+    release-checksum: 98d00f741c99e06e6c6c4d18b763c550
+    source: foxtrot
+  name: parca-v1.4.3
+  ownerReferences:
+    - apiVersion: deckhouse.io/v1alpha1
+      controller: true
+      kind: ModuleSource
+      name: foxtrot
+      uid: 71d2300f-700b-452a-896a-6a3805f9cef7
+spec:
+  moduleName: parca
+  version: 1.4.3
+  weight: 900
+status:
+  approved: false
+  message: ""
+  phase: Pending
+  pullDuration: 0s
+  size: 0
+  transitionTime: "2024-05-03T20:55:49Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: Module
+metadata:
+  name: parca
+status:
+  phase: Ready
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleDocumentation
+metadata:
+  labels:
+    module: parca
+    source: foxtrot
+  name: parca
+  ownerReferences:
+    - apiVersion: deckhouse.io/v1alpha1
+      controller: true
+      kind: ModuleRelease
+      name: parca-v1.4.2
+spec:
+  checksum: 0b95d0f1c9b3d6f2b0e5f5b4a3c2d1e0
+  path: /parca/v1.4.2
+  version: v1.4.2


### PR DESCRIPTION
## Description
This is a backport of #21662
This pull request includes changes to the release controller to avoid creating a ModuleDocumantation for embedded modules that have an external version downloaded.

Before:
```bash
kubectl get moduledocumentations
NAME                  RESULT
commander-agent       Rendered
console               Rendered
observability         Rendered
operator-prometheus   Error
pod-reloader          Rendered
prometheus            Error
prompp                Rendered
snapshot-controller   Rendered
stronghold            Rendered
```

After:
```bash
kubectl get moduledocumentations
NAME                  RESULT
commander-agent       Rendered
console               Rendered
observability         Rendered
pod-reloader          Rendered
prompp                Rendered
snapshot-controller   Rendered
stronghold            Rendered
```

## Why do we need it, and what problem does it solve?
Documentation controller can't render ModuleDocumentation for module that is still embedded, causing errors in logs of deckhouse.


## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: ModuleDocumentation will not be created for embedded modules.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
