### PR TITLE
docs: Update crd render (x-doc-examples) for internal modules

### DIFF
--- a/docs/documentation/_plugins/render-jsonschema.rb
+++ b/docs/documentation/_plugins/render-jsonschema.rb
@@ -267,9 +267,47 @@ module JSONSchemaRenderer
         merged
     end
 
-    def format_examples(name, attributes)
+    # Renders a single x-doc-examples array item.
+    # Supports the x-example / x-name / x-description format (with optional i18n overlay).
+    def format_x_doc_example_item(name, value, langExample = nil)
+        if value.is_a?(Hash) && value.has_key?('x-example') && !value['x-example'].nil?
+            content = value['x-example']
+            x_name = value['x-name']
+            x_description = value['x-description']
+            if langExample.is_a?(Hash)
+                x_name = langExample['x-name'] if langExample['x-name']
+                x_description = langExample['x-description'] if langExample['x-description']
+            end
+
+            parts = []
+            parts << %Q(<p class="resources__attrs"><i><strong>#{CGI.escapeHTML(x_name.to_s)}</strong></i></p>) if x_name && !x_name.to_s.empty?
+            if x_description && !x_description.to_s.empty?
+                parts << %Q(<div class="resources__prop_description">#{escape_chars(convert(x_description.to_s))}</div>)
+            end
+
+            yaml_markdown = if content.is_a?(String) && content =~ /\`\`\`|\n/
+                content
+            elsif content.is_a?(Hash)
+                %Q(```yaml\n#{content.to_yaml.sub(/^---(\n| ){1}/,'')}```)
+            else
+                %Q(```yaml\n#{(name ? {name => content} : content).to_yaml.sub(/^---(\n| ){1}/,'')}```)
+            end
+            parts << escape_chars(convert(yaml_markdown)).delete_prefix('<p>').sub(/<\/p>[\s]*$/,"")
+            return parts.join("\n")
+        end
+
+        yaml_markdown = if value.is_a?(String) && value =~ /\`\`\`|\n/
+            value
+        else
+            %Q(```yaml\n#{(name ? {name => value} : value).to_yaml.sub(/^---(\n| ){1}/,'')}```)
+        end
+        escape_chars(convert(yaml_markdown)).delete_prefix('<p>').sub(/<\/p>[\s]*$/,"")
+    end
+
+    def format_examples(name, attributes, primaryLanguage = nil)
         result = Array.new()
         exampleObject = nil
+        exampleKeyToUse = nil
 
         begin
           if attributes.has_key?('x-doc-examples')
@@ -311,6 +349,24 @@ module JSONSchemaRenderer
             end
 
             example =  %Q(<p class="resources__attrs"><span class="resources__attrs_name">#{exampleTitle}:</span>)
+
+            # x-doc-examples: support x-example / x-name / x-description (+ i18n overlays)
+            if exampleKeyToUse == 'x-doc-examples' && exampleObjectIsArrayOfExamples
+                langExamples = nil
+                if primaryLanguage.is_a?(Hash) && primaryLanguage.has_key?('x-doc-examples')
+                    langExamples = primaryLanguage['x-doc-examples']
+                end
+
+                parts = []
+                exampleObject.each_with_index do |value, index|
+                    next if value.nil?
+                    langExample = (langExamples.is_a?(Array) && index < langExamples.length) ? langExamples[index] : nil
+                    parts << format_x_doc_example_item(name, value, langExample)
+                end
+                result.push(%Q(#{example}</p>#{parts.join("\n")}))
+                return result
+            end
+
             exampleContent = ""
                         if exampleObject.is_a?(Hash) && exampleObject.has_key?('oneOf')
                             exampleContent = %Q(```yaml\n#{(if name then {name => exampleObject['oneOf']} else exampleObject['oneOf'] end).to_yaml.sub(/^---(\n| ){1}/,'')}```)
@@ -324,7 +380,7 @@ module JSONSchemaRenderer
                             end
                         elsif exampleObjectIsArrayOfExamples and (exampleObject.length > 1)
                             exampleObject.each do | value |
-                                if value == nil then continue end
+                                next if value.nil?
                                 if exampleContent.length > 0 then exampleContent = exampleContent + "\n" end
                                 exampleContent = %Q(#{exampleContent}\n```yaml\n#{(if name then {name => value} else value end).to_yaml.sub(/^---(\n| ){1}/,'')}```)
                             end
@@ -515,7 +571,7 @@ module JSONSchemaRenderer
             end
         end
 
-        result.push(format_examples(name, attributes))
+        result.push(format_examples(name, attributes, primaryLanguage))
 
         result
     end
@@ -1078,8 +1134,16 @@ module JSONSchemaRenderer
                     if item["schema"]["openAPIV3Schema"].has_key?('x-doc-examples') or item["schema"]["openAPIV3Schema"].has_key?('x-doc-example') or
                        item["schema"]["openAPIV3Schema"].has_key?('example') or item["schema"]["openAPIV3Schema"].has_key?('x-examples')
                     then
+                        _langSchema = nil
+                        if input['i18n'][@lang] and
+                           get_hash_value(input['i18n'][@lang],"spec","versions") and
+                           input['i18n'][@lang]["spec"]["versions"].select {|i| i['name'].to_s == item['name'].to_s; }[0]
+                        then
+                            _langVersion = input['i18n'][@lang]["spec"]["versions"].select {|i| i['name'].to_s == item['name'].to_s; }[0]
+                            _langSchema = get_hash_value(_langVersion, 'schema', 'openAPIV3Schema')
+                        end
                         result.push('<div markdown="0">')
-                        result.push(format_examples(nil, item["schema"]["openAPIV3Schema"]))
+                        result.push(format_examples(nil, item["schema"]["openAPIV3Schema"], _langSchema))
                         result.push('</div>')
                     end
 
@@ -1213,7 +1277,7 @@ module JSONSchemaRenderer
            input.has_key?('example') or input.has_key?('x-examples')
         then
             result.push('<div markdown="0">')
-            result.push(format_examples(nil, input))
+            result.push(format_examples(nil, input, get_hash_value(input, 'i18n', @lang)))
             result.push('</div>')
         end
 

--- a/docs/site/_plugins/render-jsonschema.rb
+++ b/docs/site/_plugins/render-jsonschema.rb
@@ -251,9 +251,47 @@ module JSONSchemaRenderer
         merged
     end
 
-    def format_examples(name, attributes)
+    # Renders a single x-doc-examples array item.
+    # Supports the x-example / x-name / x-description format (with optional i18n overlay).
+    def format_x_doc_example_item(name, value, langExample = nil)
+        if value.is_a?(Hash) && value.has_key?('x-example') && !value['x-example'].nil?
+            content = value['x-example']
+            x_name = value['x-name']
+            x_description = value['x-description']
+            if langExample.is_a?(Hash)
+                x_name = langExample['x-name'] if langExample['x-name']
+                x_description = langExample['x-description'] if langExample['x-description']
+            end
+
+            parts = []
+            parts << %Q(<p class="resources__attrs"><i><strong>#{CGI.escapeHTML(x_name.to_s)}</strong></i></p>) if x_name && !x_name.to_s.empty?
+            if x_description && !x_description.to_s.empty?
+                parts << %Q(<div class="resources__prop_description">#{escape_chars(convert(x_description.to_s))}</div>)
+            end
+
+            yaml_markdown = if content.is_a?(String) && content =~ /\`\`\`|\n/
+                content
+            elsif content.is_a?(Hash)
+                %Q(```yaml\n#{content.to_yaml.sub(/^---(\n| ){1}/,'')}```)
+            else
+                %Q(```yaml\n#{(name ? {name => content} : content).to_yaml.sub(/^---(\n| ){1}/,'')}```)
+            end
+            parts << escape_chars(convert(yaml_markdown)).delete_prefix('<p>').sub(/<\/p>[\s]*$/,"")
+            return parts.join("\n")
+        end
+
+        yaml_markdown = if value.is_a?(String) && value =~ /\`\`\`|\n/
+            value
+        else
+            %Q(```yaml\n#{(name ? {name => value} : value).to_yaml.sub(/^---(\n| ){1}/,'')}```)
+        end
+        escape_chars(convert(yaml_markdown)).delete_prefix('<p>').sub(/<\/p>[\s]*$/,"")
+    end
+
+    def format_examples(name, attributes, primaryLanguage = nil)
         result = Array.new()
         exampleObject = nil
+        exampleKeyToUse = nil
 
         begin
           if attributes.has_key?('x-doc-examples')
@@ -295,6 +333,24 @@ module JSONSchemaRenderer
             end
 
             example =  %Q(<p class="resources__attrs"><span class="resources__attrs_name">#{exampleTitle}:</span>)
+
+            # x-doc-examples: support x-example / x-name / x-description (+ i18n overlays)
+            if exampleKeyToUse == 'x-doc-examples' && exampleObjectIsArrayOfExamples
+                langExamples = nil
+                if primaryLanguage.is_a?(Hash) && primaryLanguage.has_key?('x-doc-examples')
+                    langExamples = primaryLanguage['x-doc-examples']
+                end
+
+                parts = []
+                exampleObject.each_with_index do |value, index|
+                    next if value.nil?
+                    langExample = (langExamples.is_a?(Array) && index < langExamples.length) ? langExamples[index] : nil
+                    parts << format_x_doc_example_item(name, value, langExample)
+                end
+                result.push(%Q(#{example}</p>#{parts.join("\n")}))
+                return result
+            end
+
             exampleContent = ""
                         if exampleObject.is_a?(Hash) && exampleObject.has_key?('oneOf')
                             exampleContent = %Q(```yaml\n#{(if name then {name => exampleObject['oneOf']} else exampleObject['oneOf'] end).to_yaml.sub(/^---(\n| ){1}/,'')}```)
@@ -308,7 +364,7 @@ module JSONSchemaRenderer
                             end
                         elsif exampleObjectIsArrayOfExamples and (exampleObject.length > 1)
                             exampleObject.each do | value |
-                                if value == nil then continue end
+                                next if value.nil?
                                 if exampleContent.length > 0 then exampleContent = exampleContent + "\n" end
                                 exampleContent = %Q(#{exampleContent}\n```yaml\n#{(if name then {name => value} else value end).to_yaml.sub(/^---(\n| ){1}/,'')}```)
                             end
@@ -451,7 +507,7 @@ module JSONSchemaRenderer
             end
         end
 
-        result.push(format_examples(name, attributes))
+        result.push(format_examples(name, attributes, primaryLanguage))
 
         result
     end
@@ -996,8 +1052,16 @@ module JSONSchemaRenderer
                     if item["schema"]["openAPIV3Schema"].has_key?('x-doc-examples') or item["schema"]["openAPIV3Schema"].has_key?('x-doc-example') or
                        item["schema"]["openAPIV3Schema"].has_key?('example') or item["schema"]["openAPIV3Schema"].has_key?('x-examples')
                     then
+                        _langSchema = nil
+                        if input['i18n'][@lang] and
+                           get_hash_value(input['i18n'][@lang],"spec","versions") and
+                           input['i18n'][@lang]["spec"]["versions"].select {|i| i['name'].to_s == item['name'].to_s; }[0]
+                        then
+                            _langVersion = input['i18n'][@lang]["spec"]["versions"].select {|i| i['name'].to_s == item['name'].to_s; }[0]
+                            _langSchema = get_hash_value(_langVersion, 'schema', 'openAPIV3Schema')
+                        end
                         result.push('<div markdown="0">')
-                        result.push(format_examples(nil, item["schema"]["openAPIV3Schema"]))
+                        result.push(format_examples(nil, item["schema"]["openAPIV3Schema"], _langSchema))
                         result.push('</div>')
                     end
 
@@ -1110,7 +1174,7 @@ module JSONSchemaRenderer
            input.has_key?('example') or input.has_key?('x-examples')
         then
             result.push('<div markdown="0">')
-            result.push(format_examples(nil, input))
+            result.push(format_examples(nil, input, get_hash_value(input, 'i18n', @lang)))
             result.push('</div>')
         end
 


### PR DESCRIPTION
## Description

Ref: https://github.com/deckhouse/deckhouse/pull/21636

This pull request enhances how OpenAPI example are rendered in the documentation for internal modules. The main changes improve the handling and display of `x-doc-examples` by adding a way to specify localized example title and description.

### New `x-doc-examples` structure

`x-doc-examples` is still an array of examples. **Legacy behavior is unchanged**: each array item can be a scalar or a plain structure, and it is rendered as a YAML example as before.

Use the **new object format** when an example needs a title and/or description.  
**Detection rule:** if an array item is an object and has `x-example` at the **root** of that item, it is treated as the new format. Otherwise the whole item is rendered with the legacy logic.

| Field | Required (new format) | Purpose |
|------|------------------------|---------|
| `x-example` | yes (format marker) | Example value |
| `x-name` | no | Example title in docs |
| `x-description` | no | Example description (markdown) |

#### Legacy (unchanged)

```yaml
# ...
chaos:
  type: object
  description: |
    Chaos monkey settings.
  x-doc-examples:
    - mode: DrainAndDelete
      period: 24h
  properties:
    mode:
      type: string
      enum:
        - Disabled
        - DrainAndDelete
    period:
      type: string
# ...
```

Each item is a value/structure and is rendered as a YAML example. No title/description.

#### New format (title + description)

```yaml
# ...
chaos:
  type: object
  description: |
    Chaos monkey settings.
  x-doc-examples:
    - x-name: Drain and delete daily
      x-description: |
        Periodically drain and delete a node from this NodeGroup
        to verify cluster resiliency.
      x-example:
        mode: DrainAndDelete
        period: 24h
    - x-name: Disabled
      x-description: |
        Leave this NodeGroup intact; chaos monkey does nothing.
      x-example:
        mode: Disabled
        period: 6h
  properties:
    mode:
      type: string
      enum:
        - Disabled
        - DrainAndDelete
    period:
      type: string
# ...
```

`x-name` and `x-description` are optional; `x-example` alone is enough to switch to the new format.

#### Mixed array

Items with and without root-level `x-example` can coexist in one `x-doc-examples` list: items with `x-example` use the new renderer; the rest keep legacy rendering.

#### i18n

In `doc-ru-*.yaml`, override `x-name` / `x-description` by item index; `x-example` comes from the main spec:

The main spec part:
```yaml
x-doc-examples:
  - x-name: Drain and delete daily
    x-description: Periodically drain and delete a node.
    x-example:
      mode: DrainAndDelete
      period: 24h
```

The part in doc-ru-*.yaml:
```yaml
x-doc-examples:
  - x-name: Удаление узла раз в сутки
    x-description: Раз в сутки узлу будет выполняться drain, затем удаление..
```

#### Rendering example

Example:

```yaml
x-doc-examples:
- x-example:
    field: a
    fieldTwo: b
    fieldThree:
      some: thing
  x-description: the first example
  x-name: First
- x-example:
    field: b
  x-description: the second example
  x-name: Second
```

This will be rendered in the documentation as:

<img width="989" height="595" alt="render_example" src="https://github.com/user-attachments/assets/689d30d8-723b-420d-8e84-f4bf504819d6" />

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Added ability to to specify localized title and description in OpenAPI example to render them in the documentation.
impact_level: low
```
