### PR TITLE
[dhctl] use HTTP for bootstrap RPP and remove Python from reverse tunnel helpers

### DIFF
--- a/candi/bashible/preflight/check_reverse_tunnel_open.sh.tpl
+++ b/candi/bashible/preflight/check_reverse_tunnel_open.sh.tpl
@@ -15,7 +15,15 @@
 # limitations under the License.
 */}}
 
+set -e
+
 target='{{ .url }}'
 target="${target#http://}"
 
-minget "$target" --fail --timeout 5 >/dev/null
+minget_path="$(mktemp /tmp/dhctl-minget.XXXXXX)"
+trap 'rm -f "$minget_path"' EXIT
+
+printf '%s' '{{ .mingetBase64 }}' | base64 -d > "$minget_path"
+chmod 0700 "$minget_path"
+
+"$minget_path" "$target" --fail --timeout 5 >/dev/null

--- a/candi/bashible/preflight/check_reverse_tunnel_open.sh.tpl
+++ b/candi/bashible/preflight/check_reverse_tunnel_open.sh.tpl
@@ -15,29 +15,7 @@
 # limitations under the License.
 */}}
 
-{{- $python_discovery := .Files.Get "deckhouse/candi/bashible/check_python.sh.tpl" }}
-{{- tpl ( $python_discovery ) . | nindent 0 }}
+target='{{ .url }}'
+target="${target#http://}"
 
-check_python
-
-cat - <<EOF | $python_binary
-import ssl
-try:
-    from urllib.request import urlopen, Request
-except ImportError as e:
-    from urllib2 import urlopen, Request
-
-ssl._create_default_https_context = ssl._create_unverified_context
-request = Request('{{.url}}')
-res = False
-try:
-    response = urlopen(request, timeout=5)
-    res = True if response else False
-except Exception as err:
-    res = False
-
-exit(0) if res else exit(1)
-
-EOF
-
-
+minget "$target" --fail --timeout 5 >/dev/null

--- a/candi/bashible/preflight/check_reverse_tunnel_reachable.sh.tpl
+++ b/candi/bashible/preflight/check_reverse_tunnel_reachable.sh.tpl
@@ -15,8 +15,15 @@
 # limitations under the License.
 */}}
 
-target='{{.url}}'
+set -e
+
+target='{{ .url }}'
 target="${target#http://}"
 
-# Any HTTP response proves that the SSH channel is alive end-to-end.
-minget "$target" --timeout 5 >/dev/null
+minget_path="$(mktemp /tmp/dhctl-minget.XXXXXX)"
+trap 'rm -f "$minget_path"' EXIT
+
+printf '%s' '{{ .mingetBase64 }}' | base64 -d > "$minget_path"
+chmod 0700 "$minget_path"
+
+"$minget_path" "$target" --timeout 5 >/dev/null

--- a/candi/bashible/preflight/check_reverse_tunnel_reachable.sh.tpl
+++ b/candi/bashible/preflight/check_reverse_tunnel_reachable.sh.tpl
@@ -15,32 +15,8 @@
 # limitations under the License.
 */}}
 
-{{- $python_discovery := .Files.Get "deckhouse/candi/bashible/check_python.sh.tpl" }}
-{{- tpl ( $python_discovery ) . | nindent 0 }}
+target='{{.url}}'
+target="${target#http://}"
 
-check_python
-
-cat - <<EOF | $python_binary
-import ssl
-try:
-    from urllib.request import urlopen, Request
-    from urllib.error import HTTPError
-except ImportError as e:
-    from urllib2 import urlopen, Request, HTTPError
-
-ssl._create_default_https_context = ssl._create_unverified_context
-request = Request('{{.url}}')
-alive = False
-try:
-    urlopen(request, timeout=5)
-    alive = True
-except HTTPError:
-    # Any HTTP status (e.g. 404 from the rpp-get server) proves the SSH
-    # channel is alive end-to-end, so the reverse tunnel is healthy.
-    alive = True
-except Exception as err:
-    alive = False
-
-exit(0) if alive else exit(1)
-
-EOF
+# Any HTTP response proves that the SSH channel is alive end-to-end.
+minget "$target" --timeout 5 >/dev/null

--- a/candi/bashible/preflight/kill_reverse_tunnel.sh.tpl
+++ b/candi/bashible/preflight/kill_reverse_tunnel.sh.tpl
@@ -15,89 +15,39 @@
 # limitations under the License.
 */}}
 
-{{- $python_discovery := .Files.Get "deckhouse/candi/bashible/check_python.sh.tpl" }}
-{{- tpl ( $python_discovery ) . | nindent 0 }}
+# Kill the process listening on a TCP port by resolving its socket through /proc.
 
-cat - <<EOF | $python_binary
-import pwd
-import os
-import re
-import glob
-import signal
+# Build the little-endian hexadecimal address used in /proc/net/tcp,
+# for example: 1.2.3.4:80 -> 04030201:0050.
+hex_addr="$(awk -v ip='{{.host}}' -v port='{{.port}}' 'BEGIN {
+    split(ip, b, ".")
+    printf "%02X%02X%02X%02X:%04X", b[4], b[3], b[2], b[1], port
+}')"
 
-PROC_TCP = "/proc/net/tcp"
-STATE = {
-        '01':'ESTABLISHED',
-        '02':'SYN_SENT',
-        '03':'SYN_RECV',
-        '04':'FIN_WAIT1',
-        '05':'FIN_WAIT2',
-        '06':'TIME_WAIT',
-        '07':'CLOSE',
-        '08':'CLOSE_WAIT',
-        '09':'LAST_ACK',
-        '0A':'LISTEN',
-        '0B':'CLOSING'
-        }
+# Find the socket inode of the matching LISTEN entry. TCP state 0A means LISTEN.
+inode="$(awk -v address="$hex_addr" '
+    $2 == address && $4 == "0A" {
+        print $10
+        exit
+    }
+' /proc/net/tcp)"
 
-def _load():
-    with open(PROC_TCP,'r') as f:
-        content = f.readlines()
-        content.pop(0)
-    return content
+if [ -z "$inode" ]; then
+    echo "Port not found"
+    exit 0
+fi
 
-def _hex2dec(s):
-    return str(int(s,16))
+# Map the socket inode to a PID through /proc/<pid>/fd and kill the process.
+for fd in /proc/[0-9]*/fd/*; do
+    [ "$(readlink "$fd" 2>/dev/null)" = "socket:[$inode]" ] || continue
 
-def _ip(s):
-    ip = [(_hex2dec(s[6:8])),(_hex2dec(s[4:6])),(_hex2dec(s[2:4])),(_hex2dec(s[0:2]))]
-    return '.'.join(ip)
+    pid="${fd#/proc/}"
+    pid="${pid%%/*}"
 
-def _remove_empty(array):
-    return [x for x in array if x !='']
+    echo "$pid"
+    kill -9 "$pid" 2>/dev/null
+    exit 0
+done
 
-def _convert_ip_port(array):
-    host,port = array.split(':')
-    return _ip(host),_hex2dec(port)
-
-def get_pid_for_listen_port(host, port):
-    content=_load()
-    for line in content:
-        line_array = _remove_empty(line.split(' '))
-        l_host,l_port = _convert_ip_port(line_array[1])
-        if l_host != host or l_port != port:
-            continue
-        state = STATE[line_array[3]]
-        if state != 'LISTEN':
-            continue
-        inode = line_array[9]
-        pid = _get_pid_of_inode(inode)
-
-        return pid
-    return ''
-
-def _get_pid_of_inode(inode):
-    for item in glob.glob('/proc/[0-9]*/fd/[0-9]*'):
-        try:
-            if re.search(inode,os.readlink(item)):
-                return item.split('/')[2]
-        except:
-            pass
-    return ''
-
-if __name__ == '__main__':
-    pid = get_pid_for_listen_port('{{.host}}', '{{.port}}')
-    print(pid)
-    if pid == '':
-        print('No process is listening on the requested port')
-        exit(0)
-    try:
-        os.kill(int(pid), signal.SIGKILL)
-    except Exception as e:
-        print(e)
-
-    exit(0)
-
-EOF
-
-
+echo "Port not found"
+exit 0

--- a/candi/bashible/preflight/kill_reverse_tunnel.sh.tpl
+++ b/candi/bashible/preflight/kill_reverse_tunnel.sh.tpl
@@ -45,7 +45,7 @@ for fd in /proc/[0-9]*/fd/*; do
     pid="${pid%%/*}"
 
     echo "$pid"
-    kill -9 "$pid" 2>/dev/null
+    nohup sh -c "sleep 1; kill -9 '$pid'" >/dev/null 2>&1 &
     exit 0
 done
 

--- a/dhctl/pkg/config/meta.go
+++ b/dhctl/pkg/config/meta.go
@@ -742,7 +742,7 @@ func (m *MetaConfig) ConfigForBashibleBundleTemplate(ctx context.Context, nodeIP
 	clusterMasterEndpoints := m.clusterMasterEndpointsBashibleContext()
 	configForBashibleBundleTemplate["clusterMasterEndpoints"] = clusterMasterEndpoints
 	configForBashibleBundleTemplate["clusterMasterKubeAPIEndpoints"] = clusterMasterEndpointAddresses(clusterMasterEndpoints, "kubeApiPort")
-	configForBashibleBundleTemplate["clusterMasterRPPAddresses"] = clusterMasterEndpointAddresses(clusterMasterEndpoints, "rppServerPort")
+	configForBashibleBundleTemplate["clusterMasterRPPAddresses"] = clusterMasterHTTPAddresses(clusterMasterEndpoints, "rppServerPort")
 	configForBashibleBundleTemplate["clusterMasterRPPBootstrapAddresses"] = clusterMasterEndpointAddresses(clusterMasterEndpoints, "rppBootstrapServerPort")
 
 	mingetBytes, err := minget.Bytes(ctx)
@@ -914,6 +914,16 @@ func clusterMasterEndpointAddresses(endpoints []map[string]any, portName string)
 		}
 
 		addresses = append(addresses, fmt.Sprintf("%s:%d", address, port))
+	}
+
+	return addresses
+}
+
+func clusterMasterHTTPAddresses(endpoints []map[string]any, portName string) []string {
+	addresses := clusterMasterEndpointAddresses(endpoints, portName)
+
+	for i := range addresses {
+		addresses[i] = "http://" + addresses[i]
 	}
 
 	return addresses

--- a/dhctl/pkg/config/meta_test.go
+++ b/dhctl/pkg/config/meta_test.go
@@ -529,7 +529,7 @@ func TestConfigForBashibleBundleTemplateClusterMasterEndpoints(t *testing.T) {
 		"rppBootstrapServerPort": defaultClusterMasterRPPBootstrapServerPort,
 	}, endpoints[0])
 	require.Equal(t, []string{"127.0.0.1:6443"}, data["clusterMasterKubeAPIEndpoints"])
-	require.Equal(t, []string{"127.0.0.1:5444"}, data["clusterMasterRPPAddresses"])
+	require.Equal(t, []string{"http://127.0.0.1:5444"}, data["clusterMasterRPPAddresses"])
 	require.Equal(t, []string{fmt.Sprintf("127.0.0.1:%d", defaultClusterMasterRPPBootstrapServerPort)}, data["clusterMasterRPPBootstrapAddresses"])
 }
 
@@ -552,7 +552,7 @@ func TestConfigForBashibleBundleTemplateDefaultClusterMasterEndpoints(t *testing
 		"rppBootstrapServerPort": defaultClusterMasterRPPBootstrapServerPort,
 	}, endpoints[0])
 	require.Empty(t, data["clusterMasterKubeAPIEndpoints"])
-	require.Equal(t, []string{"127.0.0.1:5444"}, data["clusterMasterRPPAddresses"])
+	require.Equal(t, []string{"http://127.0.0.1:5444"}, data["clusterMasterRPPAddresses"])
 	require.Equal(t, []string{fmt.Sprintf("127.0.0.1:%d", defaultClusterMasterRPPBootstrapServerPort)}, data["clusterMasterRPPBootstrapAddresses"])
 
 	mingetB64, ok := data["mingetB64"].(string)

--- a/dhctl/pkg/operations/bootstrap/rpp/proxy.go
+++ b/dhctl/pkg/operations/bootstrap/rpp/proxy.go
@@ -16,7 +16,6 @@ package rpp
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"log/slog"
 	"net"
@@ -33,7 +32,6 @@ import (
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app/options"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/template"
-	tlsutils "github.com/deckhouse/deckhouse/dhctl/pkg/util/tls"
 )
 
 const (
@@ -69,19 +67,16 @@ const (
 type tunnelCheckKind int
 
 const (
-	// checkHTTPSHealthz expects a real 200 from a TLS /healthz endpoint (5444 proxy).
-	checkHTTPSHealthz tunnelCheckKind = iota
-	// checkReachable treats any HTTP response (incl. 404) as proof the SSH
-	// channel is alive end-to-end (4282 rpp-get server has no /healthz route).
+	// checkHealthz expects a real 200 response from the /healthz endpoint.
+	checkHealthz tunnelCheckKind = iota
+
+	// checkReachable treats any HTTP response, including 404, as proof that
+	// the SSH channel is alive end-to-end. The rpp-get server has no /healthz route.
 	checkReachable
 )
 
-func reverseTunnelCheckURL(kind tunnelCheckKind, host, port string) string {
-	scheme := "https"
-	if kind == checkReachable {
-		scheme = "http"
-	}
-	return fmt.Sprintf("%s://%s/healthz", scheme, net.JoinHostPort(host, port))
+func reverseTunnelCheckURL(host, port string) string {
+	return fmt.Sprintf("http://%s/healthz", net.JoinHostPort(host, port))
 }
 
 func NewRegistryPackagesProxy(clusterDomain string, configGetter registry.ClientConfigGetter, logger *slog.Logger, interactive bool) *RegistryPackagesProxy {
@@ -204,22 +199,8 @@ func (p *RegistryPackagesProxy) startProxy() error {
 
 	p.debug("Cluster domain for registry packages proxy: %s\n", p.clusterDomain)
 
-	const oneDay = 1
-
-	cert, err := tlsutils.GenerateCertificate(
-		"registry-packages-proxy",
-		p.clusterDomain,
-		tlsutils.CertKeyTypeRSA,
-		oneDay,
-	)
-	if err != nil {
-		return fmt.Errorf("failed to generate TLS certificate for registry proxy: %w", err)
-	}
-
 	addr := net.JoinHostPort(localhost, "0")
-	listener, err := tls.Listen("tcp", addr, &tls.Config{
-		Certificates: []tls.Certificate{*cert},
-	})
+	listener, err := net.Listen("tcp", addr)
 	if err != nil {
 		return fmt.Errorf("failed to listen registry proxy socket: %w", err)
 	}
@@ -281,7 +262,7 @@ func (p *RegistryPackagesProxy) startProxy() error {
 func (p *RegistryPackagesProxy) startTunnel(ctx context.Context, sshCl libcon.SSHClient) error {
 	p.debug("Starting registry packages proxy tunnel...")
 
-	tunnel, err := p.upSingleTunnel(ctx, sshCl, p.localPort, p.remotePort, checkHTTPSHealthz)
+	tunnel, err := p.upSingleTunnel(ctx, sshCl, p.localPort, p.remotePort, checkHealthz)
 	if err != nil {
 		return err
 	}
@@ -320,7 +301,7 @@ func (p *RegistryPackagesProxy) upSingleTunnel(ctx context.Context, sshCl libcon
 		return nil, fmt.Errorf("cannot bring up tunnel for registry packages proxy: %w", err)
 	}
 
-	checkURL := reverseTunnelCheckURL(check, listenAddress, remotePort)
+	checkURL := reverseTunnelCheckURL(listenAddress, remotePort)
 	var checkScript string
 	switch check {
 	case checkReachable:

--- a/dhctl/pkg/operations/bootstrap/rpp/proxy_test.go
+++ b/dhctl/pkg/operations/bootstrap/rpp/proxy_test.go
@@ -19,18 +19,32 @@ import "testing"
 func TestReverseTunnelCheckURL(t *testing.T) {
 	cases := []struct {
 		name string
-		kind tunnelCheckKind
 		port string
 		want string
 	}{
-		{"https healthz for tls proxy", checkHTTPSHealthz, "5444", "https://127.0.0.1:5444/healthz"},
-		{"plain http reachable for rpp-get", checkReachable, "4282", "http://127.0.0.1:4282/healthz"},
+		{
+			name: "http healthz for registry packages proxy",
+			port: "5444",
+			want: "http://127.0.0.1:5444/healthz",
+		},
+		{
+			name: "http reachable for rpp-get",
+			port: "4282",
+			want: "http://127.0.0.1:4282/healthz",
+		},
 	}
+
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			got := reverseTunnelCheckURL(c.kind, localhost, c.port)
+			got := reverseTunnelCheckURL(localhost, c.port)
 			if got != c.want {
-				t.Fatalf("reverseTunnelCheckURL(%v, %q, %q) = %q, want %q", c.kind, localhost, c.port, got, c.want)
+				t.Fatalf(
+					"reverseTunnelCheckURL(%q, %q) = %q, want %q",
+					localhost,
+					c.port,
+					got,
+					c.want,
+				)
 			}
 		})
 	}

--- a/dhctl/pkg/template/bashible_test.go
+++ b/dhctl/pkg/template/bashible_test.go
@@ -92,7 +92,7 @@ func TestRenderBashibleTemplateUsesClusterMasterRPPAddressesForBootstrap(t *test
 
 	content := rendered.Content.String()
 	require.Contains(t, content, `unset PACKAGES_PROXY_BOOTSTRAP_CLUSTER_UUID`)
-	require.Contains(t, content, `export PACKAGES_PROXY_ADDRESSES="127.0.0.1:5444"`)
+	require.Contains(t, content, `export PACKAGES_PROXY_ADDRESSES="http://127.0.0.1:5444"`)
 	require.Contains(t, content, `export PACKAGES_PROXY_TOKEN="passthrough"`)
 	require.Contains(t, content, `bb-minget-install`)
 }

--- a/dhctl/pkg/template/bootstrap_test.go
+++ b/dhctl/pkg/template/bootstrap_test.go
@@ -50,5 +50,5 @@ func TestPrepareBootstrapUsesDefaultClusterMasterEndpoints(t *testing.T) {
 	require.Contains(t, content, `PACKAGES_PROXY_BOOTSTRAP_CLUSTER_UUID=""`)
 	require.Contains(t, content, fmt.Sprintf(`export PACKAGES_PROXY_BOOTSTRAP_ADDRESSES="127.0.0.1:%d"`, testRPPBootstrapServerPort))
 	require.NotContains(t, content, "PACKAGES_PROXY_KUBE_APISERVER_ENDPOINTS")
-	require.Contains(t, content, `export PACKAGES_PROXY_ADDRESSES="127.0.0.1:5444"`)
+	require.Contains(t, content, `export PACKAGES_PROXY_ADDRESSES="http://127.0.0.1:5444"`)
 }

--- a/dhctl/pkg/template/preflight.go
+++ b/dhctl/pkg/template/preflight.go
@@ -16,11 +16,14 @@ package template
 
 import (
 	"context"
+	"encoding/base64"
+	"fmt"
 	"path/filepath"
 
 	dhlog "github.com/deckhouse/lib-dhctl/pkg/logger"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app/options"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/minget"
 )
 
 var (
@@ -59,16 +62,31 @@ func RenderAndSavePreflightCheckLocalhostScript(ctx context.Context, globalOptio
 	)
 }
 
-func RenderAndSavePreflightReverseTunnelOpenScript(ctx context.Context, url string, globalOptions *options.GlobalOptions) (string, error) {
+func RenderAndSavePreflightReverseTunnelOpenScript(
+	ctx context.Context,
+	url string,
+	globalOptions *options.GlobalOptions,
+) (string, error) {
 	dhlog.FromContext(ctx).DebugContext(ctx, "Rendering proxy reverse tunnel open script")
-	scriptPath := filepath.Join(globalOptions.CandiDir, "bashible", checkProxyRevTunnelOpenScriptPath)
+
+	encodedMinget, err := mingetBase64(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	scriptPath := filepath.Join(
+		globalOptions.CandiDir,
+		"bashible",
+		checkProxyRevTunnelOpenScriptPath,
+	)
 
 	return RenderAndSaveTemplate(
 		ctx,
 		"check_reverse_tunnel_open.sh",
 		scriptPath,
 		map[string]any{
-			"url": url,
+			"url":          url,
+			"mingetBase64": encodedMinget,
 		},
 	)
 }
@@ -88,16 +106,34 @@ func RenderAndSaveKillReverseTunnelScript(ctx context.Context, host, port string
 	)
 }
 
-func RenderAndSavePreflightReverseTunnelReachableScript(ctx context.Context, url string, globalOptions *options.GlobalOptions) (string, error) {
-	dhlog.FromContext(ctx).DebugContext(ctx, "Start render proxy reverse tunnel reachable script")
-	scriptPath := filepath.Join(globalOptions.CandiDir, "bashible", checkReverseTunnelReachableScriptPath)
+func RenderAndSavePreflightReverseTunnelReachableScript(
+	ctx context.Context,
+	url string,
+	globalOptions *options.GlobalOptions,
+) (string, error) {
+	dhlog.FromContext(ctx).DebugContext(
+		ctx,
+		"Rendering proxy reverse tunnel reachable script",
+	)
+
+	encodedMinget, err := mingetBase64(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	scriptPath := filepath.Join(
+		globalOptions.CandiDir,
+		"bashible",
+		checkReverseTunnelReachableScriptPath,
+	)
 
 	return RenderAndSaveTemplate(
 		ctx,
 		"check_reverse_tunnel_reachable.sh",
 		scriptPath,
-		map[string]interface{}{
-			"url": url,
+		map[string]any{
+			"url":          url,
+			"mingetBase64": encodedMinget,
 		},
 	)
 }
@@ -117,4 +153,13 @@ func RenderAndSavePreflightCheckScript(
 		filepath.Join(path, filename),
 		params,
 	)
+}
+
+func mingetBase64(ctx context.Context) (string, error) {
+	data, err := minget.Bytes(ctx)
+	if err != nil {
+		return "", fmt.Errorf("get minget binary: %w", err)
+	}
+
+	return base64.StdEncoding.EncodeToString(data), nil
 }

--- a/dhctl/pkg/template/preflight_test.go
+++ b/dhctl/pkg/template/preflight_test.go
@@ -45,7 +45,13 @@ func TestRenderAndSavePreflightReverseTunnelReachableScript(t *testing.T) {
 	require.NoError(t, err)
 
 	s := string(content)
-	require.Contains(t, s, "Request('http://127.0.0.1:4282/healthz')")
-	require.Contains(t, s, "except HTTPError:")
-	require.Contains(t, s, "alive = True")
+
+	require.Contains(t, s, `target='http://127.0.0.1:4282/healthz'`)
+	require.Contains(t, s, `target="${target#http://}"`)
+	require.Contains(t, s, `minget "$target" --timeout 5 >/dev/null`)
+
+	require.NotContains(t, s, "check_python")
+	require.NotContains(t, s, "python_binary")
+	require.NotContains(t, s, "urllib")
+	require.NotContains(t, s, `minget "$target" --fail`)
 }

--- a/dhctl/pkg/template/preflight_test.go
+++ b/dhctl/pkg/template/preflight_test.go
@@ -25,14 +25,17 @@ import (
 )
 
 func TestRenderAndSavePreflightReverseTunnelReachableScript(t *testing.T) {
-	// RenderAndSaveTemplate reads the template directly from disk. In the install
-	// container CandiDir resolves to options.DefaultCandiDir (/deckhouse/candi);
-	// when running the unit test we point it at the candi dir of this repo.
 	candiDir := options.DefaultCandiDir
 	if _, err := os.Stat(candiDir); err != nil {
 		candiDir, err = filepath.Abs(filepath.Join("..", "..", "..", "candi"))
 		require.NoError(t, err)
 	}
+
+	// Render uses minget.Bytes. Point it to a small test file instead of
+	// requiring the real embedded minget binary to be prepared.
+	mingetPath := filepath.Join(t.TempDir(), "minget")
+	require.NoError(t, os.WriteFile(mingetPath, []byte("test-minget"), 0o755))
+	t.Setenv("DHCTL_MINGET_PATH", mingetPath)
 
 	path, err := RenderAndSavePreflightReverseTunnelReachableScript(
 		t.Context(),
@@ -48,10 +51,15 @@ func TestRenderAndSavePreflightReverseTunnelReachableScript(t *testing.T) {
 
 	require.Contains(t, s, `target='http://127.0.0.1:4282/healthz'`)
 	require.Contains(t, s, `target="${target#http://}"`)
-	require.Contains(t, s, `minget "$target" --timeout 5 >/dev/null`)
+
+	require.Contains(t, s, `minget_path="$(mktemp /tmp/dhctl-minget.XXXXXX)"`)
+	require.Contains(t, s, `trap 'rm -f "$minget_path"' EXIT`)
+	require.Contains(t, s, `base64 -d > "$minget_path"`)
+	require.Contains(t, s, `chmod 0700 "$minget_path"`)
+	require.Contains(t, s, `"$minget_path" "$target" --timeout 5 >/dev/null`)
 
 	require.NotContains(t, s, "check_python")
 	require.NotContains(t, s, "python_binary")
 	require.NotContains(t, s, "urllib")
-	require.NotContains(t, s, `minget "$target" --fail`)
+	require.NotContains(t, s, `"$minget_path" "$target" --fail`)
 }

--- a/modules/007-registrypackages/images/rpp-get/src/rpp/http.go
+++ b/modules/007-registrypackages/images/rpp-get/src/rpp/http.go
@@ -167,8 +167,12 @@ func buildPackageURL(endpoint, digest, repository, path string) string {
 		values.Set("path", path)
 	}
 
-	endpoint = strings.TrimPrefix(endpoint, "https://")
-	endpoint = strings.TrimPrefix(endpoint, "http://")
+	endpoint = strings.TrimRight(endpoint, "/")
 
-	return "https://" + endpoint + "/package?" + values.Encode()
+	if !strings.HasPrefix(endpoint, "https://") &&
+		!strings.HasPrefix(endpoint, "http://") {
+		endpoint = "https://" + endpoint
+	}
+
+	return endpoint + "/package?" + values.Encode()
 }

--- a/modules/007-registrypackages/images/rpp-get/src/rpp/http_test.go
+++ b/modules/007-registrypackages/images/rpp-get/src/rpp/http_test.go
@@ -78,7 +78,7 @@ func TestBuildPackageURL(t *testing.T) {
 			name:     "endpoint with http scheme",
 			endpoint: "http://1.2.3.4:4219",
 			digest:   "sha256:abc123",
-			wantURL:  "https://1.2.3.4:4219/package?digest=sha256%3Aabc123",
+			wantURL:  "http://1.2.3.4:4219/package?digest=sha256%3Aabc123",
 		},
 		{
 			name:       "with repository",
@@ -94,6 +94,13 @@ func TestBuildPackageURL(t *testing.T) {
 			path:     "/custom/path",
 			wantURL:  "https://1.2.3.4:4219/package?digest=sha256%3Aabc123&path=%2Fcustom%2Fpath",
 		},
+		{
+			name:     "endpoint with trailing slash",
+			endpoint: "http://1.2.3.4:4219/",
+			digest:   "sha256:abc123",
+			wantURL:  "http://1.2.3.4:4219/package?digest=sha256%3Aabc123",
+		},
+
 	}
 
 	for _, tt := range tests {

--- a/modules/007-registrypackages/images/rpp-get/werf.inc.yaml
+++ b/modules/007-registrypackages/images/rpp-get/werf.inc.yaml
@@ -1,5 +1,6 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+final: false
 fromImage: common/src-artifact
 git:
 - add: /{{ $.ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts


### PR DESCRIPTION
## Description

Simplify the bootstrap Registry Packages Proxy and SSH reverse tunnel helpers.

What changed

* The bootstrap Registry Packages Proxy now serves plain HTTP instead of HTTPS.
* Removed the TLS listener and bootstrap certificate generation from the proxy.
* rpp-get now preserves an explicitly specified URL scheme:
    * endpoints without a scheme continue to default to HTTPS;
    * endpoints with http:// or https:// are used as specified.
* The bootstrap bashible context now passes Registry Packages Proxy endpoints with the http:// scheme.
* Reverse tunnel connectivity checks now use minget instead of Python:
    * check_reverse_tunnel_open.sh.tpl succeeds only when the endpoint returns a successful HTTP status;
    * check_reverse_tunnel_reachable.sh.tpl treats any received HTTP response as confirmation that the SSH tunnel is reachable.
* The embedded minget binary is passed to the remote helper script and executed from a temporary file, so it does not need to be installed on the target node.
* kill_reverse_tunnel.sh.tpl was rewritten in Bash and now identifies the process listening on the target port through /proc, without using Python.
* Updated unit tests accordingly.

The changes affect only the bootstrap-time Registry Packages Proxy and reverse tunnel helper scripts. They do not affect the Registry Packages Proxy used by running clusters.

## Why do we need it, and what problem does it solve?

The bootstrap Registry Packages Proxy is accessible only through an SSH reverse tunnel, which already provides transport encryption. Running HTTPS inside this tunnel requires additional certificate generation and TLS handling without providing meaningful additional transport security.

The reverse tunnel helper scripts also depended on Python for basic HTTP connectivity checks and process lookup. This introduced an unnecessary runtime dependency during bootstrap and could prevent installation on minimal operating system images where Python is not available.

This change simplifies the bootstrap path by:

* removing the redundant TLS layer from the bootstrap proxy;
* using explicit HTTP endpoints only for the bootstrap proxy while preserving HTTPS as the default for regular Registry Packages Proxy endpoints;
* replacing Python-based reverse tunnel helpers with embedded minget, Bash, and /proc.

## Why do we need it in the patch release (if we do)?

The change is not required for a patch release. It is a bootstrap-path simplification and dependency reduction rather than a fix for a critical regression.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: dhctl
type: chore
summary:  Simplify the bootstrap Registry Packages Proxy and remove the Python dependency from reverse tunnel helper scripts.
impact_level: low
```
