### PR TITLE
[cni-flannel] Fixed securityContext and added SecurityPolicyException

### DIFF
--- a/modules/035-cni-flannel/templates/daemonset.yaml
+++ b/modules/035-cni-flannel/templates/daemonset.yaml
@@ -45,6 +45,7 @@ spec:
       labels:
         tier: node
         app: flannel
+        security.deckhouse.io/security-policy-exception: flannel
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{ include "helm_lib_prevent_ds_eviction_annotation" . | nindent 8 }}

--- a/modules/035-cni-flannel/templates/security-policy-exception.yaml
+++ b/modules/035-cni-flannel/templates/security-policy-exception.yaml
@@ -1,0 +1,63 @@
+{{- if (.Values.global.enabledModules | has "admission-policy-engine") }}
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: SecurityPolicyException
+metadata:
+  name: flannel
+  namespace: d8-{{ .Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "flannel")) | nindent 2 }}
+spec:
+  securityContext:
+    runAsNonRoot:
+      allowedValue: false
+      metadata:
+        description: |
+          kube-flannel and iptables-wrapper-init must run as root to manage host
+          networking, CNI config and iptables/nftables rules.
+    runAsUser:
+      allowedValues:
+        - 0
+      metadata:
+        description: |
+          UID 0 is required for host network namespace access and iptables operations.
+    capabilities:
+      allowedValues:
+        add:
+          - NET_ADMIN
+          - NET_RAW
+        drop:
+          - ALL
+      metadata:
+        description: |
+          NET_ADMIN/NET_RAW are required for flannel routing/masquerading, VXLAN offload
+          fixes and iptables-wrapper setup on the node.
+  network:
+    hostNetwork:
+      allowedValue: true
+      metadata:
+        description: |
+          Flannel must join the host network namespace to program pod routes and
+          VXLAN/host-gw datapath on the node.
+  volumes:
+    types:
+      allowedValues:
+        - hostPath
+      metadata:
+        description: |
+          hostPath volumes are required for CNI config, flannel runtime state and
+          the host xtables lock.
+    hostPath:
+      allowedValues:
+        - path: /etc/cni/net.d
+          readOnly: false
+          metadata:
+            description: Host CNI configuration directory where Flannel installs its config.
+        - path: /run/flannel
+          readOnly: false
+          metadata:
+            description: Flannel runtime state directory on the host.
+        - path: /run/xtables.lock
+          readOnly: false
+          metadata:
+            description: Host xtables lock used to serialize iptables updates.
+{{- end }}


### PR DESCRIPTION
## Description
This PR updates the `securityContext` configuration and adds a `SecurityPolicyException`.

## Why do we need it, and what problem does it solve?
This change aligns the component with the required security policies by correcting the `securityContext` configuration and introducing a `SecurityPolicyException` where elevated permissions are required. This ensures the component can operate correctly while remaining compliant with the platform's security requirements.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: cni-flannel
type: chore
summary: Fixed securityContext and added SecurityPolicyException
impact_level: default
```