### PR TITLE
[network-policy-engine] Fixed securityContext and added SecurityPolicyException

### DIFF
--- a/modules/050-network-policy-engine/templates/daemonset.yaml
+++ b/modules/050-network-policy-engine/templates/daemonset.yaml
@@ -42,6 +42,7 @@ spec:
     metadata:
       labels:
         app: kube-router
+        security.deckhouse.io/security-policy-exception: kube-router
     spec:
       {{- include "helm_lib_priority_class" (tuple . "cluster-medium") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 6 }}
@@ -53,7 +54,7 @@ spec:
       {{ include "helm_lib_module_init_container_iptables_wrapper" . | nindent 6 }}
       containers:
       - name: kube-router
-        {{- include "helm_lib_module_container_security_context_privileged_read_only_root_filesystem" . | nindent 8 }}
+        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all_and_add" (list . (list "NET_ADMIN" "NET_RAW")) | nindent 8 }}
         image: {{ include "helm_lib_module_image" (list . "kubeRouter") }}
         args:
         - --run-router=false

--- a/modules/050-network-policy-engine/templates/security-policy-exception.yaml
+++ b/modules/050-network-policy-engine/templates/security-policy-exception.yaml
@@ -1,0 +1,68 @@
+{{- if (.Values.global.enabledModules | has "admission-policy-engine") }}
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: SecurityPolicyException
+metadata:
+  name: kube-router
+  namespace: d8-system
+  {{- include "helm_lib_module_labels" (list . (dict "app" "kube-router")) | nindent 2 }}
+spec:
+  securityContext:
+    runAsNonRoot:
+      allowedValue: false
+      metadata:
+        description: |
+          kube-router and iptables-wrapper-init must run as root to enforce NetworkPolicy
+          firewall rules on the host network namespace.
+    runAsUser:
+      allowedValues:
+        - 0
+      metadata:
+        description: |
+          UID 0 is required for iptables operations and host network namespace access.
+    capabilities:
+      allowedValues:
+        add:
+          - NET_ADMIN
+          - NET_RAW
+        drop:
+          - ALL
+      metadata:
+        description: |
+          NET_ADMIN/NET_RAW are required to program iptables firewall rules for
+          NetworkPolicies and to set up the iptables-wrapper.
+  network:
+    hostNetwork:
+      allowedValue: true
+      metadata:
+        description: |
+          kube-router must join the host network namespace to apply NetworkPolicy
+          firewall rules to node traffic.
+    hostPorts:
+      - port: 4213
+        protocol: TCP
+        metadata:
+          description: HTTP metrics endpoint exposed by kube-router.
+      - port: 10444
+        protocol: TCP
+        metadata:
+          description: Health check endpoint used by the kube-router liveness probe.
+  volumes:
+    types:
+      allowedValues:
+        - hostPath
+      metadata:
+        description: |
+          hostPath volumes are required to share the host xtables lock and to read
+          kernel modules used by iptables/conntrack.
+    hostPath:
+      allowedValues:
+        - path: /run/xtables.lock
+          readOnly: false
+          metadata:
+            description: Host xtables lock used to serialize iptables updates.
+        - path: /lib/modules
+          readOnly: true
+          metadata:
+            description: Host kernel modules used for iptables/conntrack operations.
+{{- end }}


### PR DESCRIPTION
## Description
This PR updates the `securityContext` configuration and adds a `SecurityPolicyException`.

## Why do we need it, and what problem does it solve?
This change aligns the component with the required security policies by correcting the `securityContext` configuration and introducing a `SecurityPolicyException` where elevated permissions are required. This ensures the component can operate correctly while remaining compliant with the platform's security requirements.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: network-policy-engine
type: chore
summary: Fixed securityContext and added SecurityPolicyException
impact_level: default
```