### PR TITLE
[candi] update main for skipping rpp-get-install in general loop

### DIFF
--- a/candi/bashible/bashible.sh.tpl
+++ b/candi/bashible/bashible.sh.tpl
@@ -370,7 +370,14 @@ function main() {
     source "/var/lib/bashible/telemetry.env"
   fi
 
-  if [ -z "${is_local-}" ]; then
+  {{- /*
+    Only the child pass (BASHIBLE_SKIP_UPDATE=yes) runs the steps that need these
+    binaries. The self-update pass must not depend on them: the rpp-get digest is
+    baked into the bashible.sh already on disk, so it is the first thing to rot out
+    of the registry, and failing here pins the node to an outdated bashible.sh with
+    no way to ever fetch a newer one.
+  */}}
+  if [ -z "${is_local-}" ] && [ -n "${BASHIBLE_SKIP_UPDATE-}" ]; then
 {{- if ne .runType "Normal" }}
     bb-minget-install
 {{- end }}


### PR DESCRIPTION
## Description

`main()` in `candi/bashible/bashible.sh.tpl` runs twice per bashible tick:

1. the **self-update pass** — fetches `bashibles.bashible.deckhouse.io/<nodegroup>`
   from bashible-apiserver, writes `bashible-new.sh`, re-executes it with
   `BASHIBLE_SKIP_UPDATE=yes`, and promotes it over `bashible.sh` on success;
2. the **child pass** (`BASHIBLE_SKIP_UPDATE=yes`) — the one that actually runs
   the bundle steps.

`bb-rpp-get-install` (and `bb-minget-install` for non-`Normal` run types) was
executed in **both** passes. Under `set -Eeo pipefail` its failure aborts the run
at that line, which sits *before* the self-update block — so a node that cannot
install `rpp-get` never even attempts to fetch a newer `bashible.sh`.

This PR gates that call on `BASHIBLE_SKIP_UPDATE`, so only the child pass installs
those binaries. The self-update pass does not use `rpp-get` at all: it reaches the
API over `d8-curl` with the kubelet client certificate.

No impact on running components: no restarts of ingress-controllers, control-plane
or Prometheus, no node drain or reboot, no change to the bundle steps themselves or
to the configuration checksum. Rollback behaviour is unchanged — the child pass still
has to succeed before `bashible-new.sh` is promoted, so a broken new version cannot
replace a working one.

## Why do we need it, and what problem does it solve?

The `rpp-get` digest is rendered into the `bashible.sh` that lives on the node, and
that file can stay on disk arbitrarily long. If the digest it references disappears
from the registry, every run dies at `bb-rpp-get-install` — before the self-update
block — so the node can never pick up a newer `bashible.sh` whose digest is still
available. The node is then pinned to an outdated bashible, stops applying any
configuration changes, and recovery requires manual work on each affected node
(replacing `/var/lib/bashible/bashible.sh` by hand with the current one from the
bashible-apiserver API).

Scope is narrow in practice: on customer clusters registry tags are not deleted, so
this is effectively a development- and CI-cluster problem, where images get pruned
and long-lived nodes end up referencing digests that no longer exist. That is where
it was hit and where it costs time — a node that silently stops updating, with no
status condition explaining why, and no way to recover other than by hand.

The steps themselves are not exposed to this: they are re-rendered from
`nodegroupbundles` on every run and always carry current digests. Only the runner's
own baked-in digest can go stale, and this change stops that from being able to block
the update path.

## Why do we need it in the patch release (if we do)?

Not necessarily. 

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: candi
type: fix
summary: A missing rpp-get package no longer prevents bashible from updating itself on a node.
impact_level: low
```
