### PR TITLE
[cni-simple-bridge] Fixed securityContext and added SecurityPolicyException

### DIFF
--- a/modules/035-cni-simple-bridge/templates/daemonset.yaml
+++ b/modules/035-cni-simple-bridge/templates/daemonset.yaml
@@ -46,12 +46,15 @@ spec:
         {{ include "helm_lib_prevent_ds_eviction_annotation" . | nindent 8 }}
       labels:
         app: simple-bridge
+        security.deckhouse.io/security-policy-exception: simple-bridge
     spec:
       imagePullSecrets:
       - name: deckhouse-registry
       {{- include "helm_lib_priority_class" (tuple . "system-node-critical") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node" "with-uninitialized") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 6 }}
+        seccompProfile:
+          type: RuntimeDefault
       automountServiceAccountToken: true
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
@@ -91,6 +94,8 @@ spec:
             - NET_ADMIN
             drop:
             - ALL
+          seccompProfile:
+            type: RuntimeDefault
         command:
         - /bin/simple-bridge
         env:

--- a/modules/035-cni-simple-bridge/templates/security-policy-exception.yaml
+++ b/modules/035-cni-simple-bridge/templates/security-policy-exception.yaml
@@ -1,0 +1,80 @@
+{{- if (.Values.global.enabledModules | has "admission-policy-engine") }}
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: SecurityPolicyException
+metadata:
+  name: simple-bridge
+  namespace: d8-{{ .Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "simple-bridge")) | nindent 2 }}
+spec:
+  securityContext:
+    allowPrivilegeEscalation:
+      allowedValue: true
+      metadata:
+        description: |
+          simple-bridge runs with allowPrivilegeEscalation=true together with
+          NET_ADMIN/NET_RAW to manage host iptables and routing.
+    runAsNonRoot:
+      allowedValue: false
+      metadata:
+        description: |
+          simple-bridge and iptables-wrapper-init must run as root to manage host
+          networking, CNI config and iptables/nftables rules.
+    runAsUser:
+      allowedValues:
+        - 0
+      metadata:
+        description: |
+          UID 0 is required for host network namespace access and iptables operations.
+    capabilities:
+      allowedValues:
+        add:
+          - NET_ADMIN
+          - NET_RAW
+        drop:
+          - ALL
+      metadata:
+        description: |
+          NET_ADMIN/NET_RAW are required for bridge/routing setup, masquerading and
+          iptables-wrapper configuration on the node.
+    seccompProfile:
+      allowedValues:
+        - RuntimeDefault
+        - runtime/default
+      metadata:
+        description: |
+          RuntimeDefault is used by simple-bridge and iptables-wrapper-init.
+  network:
+    hostNetwork:
+      allowedValue: true
+      metadata:
+        description: |
+          simple-bridge must join the host network namespace to program pod routes
+          and the host bridge datapath.
+  volumes:
+    types:
+      allowedValues:
+        - hostPath
+      metadata:
+        description: |
+          hostPath volumes are required for CNI config, runtime state, network sysfs
+          and the host xtables lock.
+    hostPath:
+      allowedValues:
+        - path: /run
+          readOnly: false
+          metadata:
+            description: Host runtime directory used by simple-bridge for CNI state.
+        - path: /etc/cni/net.d
+          readOnly: false
+          metadata:
+            description: Host CNI configuration directory where simple-bridge installs its config.
+        - path: /run/xtables.lock
+          readOnly: false
+          metadata:
+            description: Host xtables lock used to serialize iptables updates.
+        - path: /sys/class/net
+          readOnly: true
+          metadata:
+            description: Host network interface sysfs used to inspect node NICs.
+{{- end }}


### PR DESCRIPTION
## Description
This PR updates the `securityContext` configuration and adds a `SecurityPolicyException`.

## Why do we need it, and what problem does it solve?
This change aligns the component with the required security policies by correcting the `securityContext` configuration and introducing a `SecurityPolicyException` where elevated permissions are required. This ensures the component can operate correctly while remaining compliant with the platform's security requirements.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: cni-simple-bridge
type: chore
summary: Fixed securityContext and added SecurityPolicyException
impact_level: default
```