### PR TITLE
[node-manager] fix GPU memory double-count in dashboards

### DIFF
--- a/ee/modules/040-node-manager/monitoring/grafana-dashboards/nvidia-gpu/gpu_node.json
+++ b/ee/modules/040-node-manager/monitoring/grafana-dashboards/nvidia-gpu/gpu_node.json
@@ -983,24 +983,11 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "100 * sum(max without (exported_namespace, exported_pod, exported_container, container) (DCGM_FI_DEV_FB_USED{Hostname=~\"$node\", gpu=~\"$gpu\"})) by(Hostname, gpu) / clamp_min(sum(max without (exported_namespace, exported_pod, exported_container, container) (DCGM_FI_DEV_FB_USED{Hostname=~\"$node\", gpu=~\"$gpu\"})) by(Hostname, gpu) + sum(max without (exported_namespace, exported_pod, exported_container, container) (DCGM_FI_DEV_FB_FREE{Hostname=~\"$node\", gpu=~\"$gpu\"})) by(Hostname, gpu), 1)",
-          "interval": "",
-          "legendFormat": "GPU {{gpu}}",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${ds_prometheus}"
-          },
-          "editorMode": "code",
-          "exemplar": true,
-          "expr": "100 * max by (Hostname, gpu, GPU_I_PROFILE, GPU_I_ID) (max without (exported_namespace, exported_pod, exported_container, container) (DCGM_FI_DEV_FB_USED{Hostname=~\"$node\", gpu=~\"$gpu\", GPU_I_PROFILE=~\".+\"})) / clamp_min(max by (Hostname, gpu, GPU_I_PROFILE, GPU_I_ID) (max without (exported_namespace, exported_pod, exported_container, container) (DCGM_FI_DEV_FB_USED{Hostname=~\"$node\", gpu=~\"$gpu\", GPU_I_PROFILE=~\".+\"})) + max by (Hostname, gpu, GPU_I_PROFILE, GPU_I_ID) (max without (exported_namespace, exported_pod, exported_container, container) (DCGM_FI_DEV_FB_FREE{Hostname=~\"$node\", gpu=~\"$gpu\", GPU_I_PROFILE=~\".+\"})), 1)",
+          "expr": "100 * sum(max without (exported_namespace, exported_pod, exported_container, container) (DCGM_FI_DEV_FB_USED{Hostname=~\"$node\", gpu=~\"$gpu\"})) by (Hostname, gpu, GPU_I_PROFILE, GPU_I_ID) / clamp_min(sum(max without (exported_namespace, exported_pod, exported_container, container) (DCGM_FI_DEV_FB_USED{Hostname=~\"$node\", gpu=~\"$gpu\"})) by (Hostname, gpu, GPU_I_PROFILE, GPU_I_ID) + sum(max without (exported_namespace, exported_pod, exported_container, container) (DCGM_FI_DEV_FB_FREE{Hostname=~\"$node\", gpu=~\"$gpu\"})) by (Hostname, gpu, GPU_I_PROFILE, GPU_I_ID), 1)",
           "interval": "",
           "legendFormat": "GPU {{gpu}} {{GPU_I_PROFILE}} (ID {{GPU_I_ID}})",
           "range": true,
-          "refId": "B"
+          "refId": "A"
         }
       ],
       "title": "GPU Memory Utilization: ${node}",
@@ -1126,24 +1113,11 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(max without (exported_namespace, exported_pod, exported_container, container) (DCGM_FI_DEV_FB_USED{Hostname=~\"$node\", gpu=~\"$gpu\"})) by(Hostname, gpu)",
-          "interval": "",
-          "legendFormat": "GPU {{gpu}}",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${ds_prometheus}"
-          },
-          "editorMode": "code",
-          "exemplar": true,
-          "expr": "max by (Hostname, gpu, GPU_I_PROFILE, GPU_I_ID) (max without (exported_namespace, exported_pod, exported_container, container) (DCGM_FI_DEV_FB_USED{Hostname=~\"$node\", gpu=~\"$gpu\", GPU_I_PROFILE=~\".+\"}))",
+          "expr": "sum(max without (exported_namespace, exported_pod, exported_container, container) (DCGM_FI_DEV_FB_USED{Hostname=~\"$node\", gpu=~\"$gpu\"})) by (Hostname, gpu, GPU_I_PROFILE, GPU_I_ID)",
           "interval": "",
           "legendFormat": "GPU {{gpu}} {{GPU_I_PROFILE}} (ID {{GPU_I_ID}})",
           "range": true,
-          "refId": "B"
+          "refId": "A"
         }
       ],
       "title": "GPU Framebuffer Memory Used: ${node}",

--- a/ee/modules/040-node-manager/monitoring/grafana-dashboards/nvidia-gpu/gpu_nodes.json
+++ b/ee/modules/040-node-manager/monitoring/grafana-dashboards/nvidia-gpu/gpu_nodes.json
@@ -861,19 +861,6 @@
           "legendFormat": "{{ Hostname }}",
           "range": true,
           "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${ds_prometheus}"
-          },
-          "editorMode": "code",
-          "exemplar": true,
-          "expr": "max by (Hostname, gpu, GPU_I_PROFILE, GPU_I_ID) (max without (exported_namespace, exported_pod, exported_container, container) (DCGM_FI_DEV_FB_USED{Hostname=~\"$node\", GPU_I_PROFILE=~\".+\"}))",
-          "interval": "",
-          "legendFormat": "{{Hostname}} - GPU {{gpu}} {{GPU_I_PROFILE}} (ID {{GPU_I_ID}})",
-          "range": true,
-          "refId": "B"
         }
       ],
       "title": "GPU Framebuffer Memory Used",
@@ -979,19 +966,6 @@
           "legendFormat": "{{Hostname}}",
           "range": true,
           "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${ds_prometheus}"
-          },
-          "editorMode": "code",
-          "exemplar": true,
-          "expr": "100 * max by (Hostname, gpu, GPU_I_PROFILE, GPU_I_ID) (max without (exported_namespace, exported_pod, exported_container, container) (DCGM_FI_DEV_FB_USED{Hostname=~\"$node\", GPU_I_PROFILE=~\".+\"})) / clamp_min(max by (Hostname, gpu, GPU_I_PROFILE, GPU_I_ID) (max without (exported_namespace, exported_pod, exported_container, container) (DCGM_FI_DEV_FB_USED{Hostname=~\"$node\", GPU_I_PROFILE=~\".+\"})) + max by (Hostname, gpu, GPU_I_PROFILE, GPU_I_ID) (max without (exported_namespace, exported_pod, exported_container, container) (DCGM_FI_DEV_FB_FREE{Hostname=~\"$node\", GPU_I_PROFILE=~\".+\"})), 1)",
-          "interval": "",
-          "legendFormat": "{{Hostname}} - GPU {{gpu}} {{GPU_I_PROFILE}} (ID {{GPU_I_ID}})",
-          "range": true,
-          "refId": "B"
         }
       ],
       "title": "GPU Memory Utilization",


### PR DESCRIPTION
## Description
This PR updates metrics representation on dashboards in 
ee/modules/040-node-manager/monitoring/grafana-dashboards/nvidia-gpu/gpu_node.json 
ee/modules/040-node-manager/monitoring/grafana-dashboards/nvidia-gpu/gpu_nodes.json

## Why do we need it, and what problem does it solve?
It fixes double-count in GPU Memory Utilization and removes MIG partition metrics from GPU nodes dashboard representation.

The "GPU Framebuffer Memory Used" and "GPU Memory Utilization" panels had two query targets — a whole-GPU rollup and a per-MIG-instance breakdown. On MIG GPUs the panel's `calculateField` Total (and stacked view) summed both, counting the same memory twice (e.g. 424 MiB rendered as 848 MiB; with sharing the total could exceed physical VRAM).

The panels are now single-query:
- **gpu_nodes** (fleet): usage per node only — grouped by `(Hostname)`; Total = sum across nodes. No device/MIG rows.
- **gpu_node** (drill-down): usage per GPU unit — grouped by `(Hostname, gpu, GPU_I_PROFILE, GPU_I_ID)`, so a MIG instance is its own line with no synthesized parent; Total = true node sum.

A physical GPU is either whole (no `GPU_I_PROFILE`) or MIG-partitioned (per-instance series only, no parent), never both — so one grouped query yields exactly one line per real unit, eliminating the overlap. Dashboard-only change; metrics and the exporter are unaffected.

## Why do we need it in the patch release (if we do)?
Not necessarily

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: node-manager
type: fix
summary: Fix GPU memory double-count and drop MIG partition rows from GPU dashboards.
impact_level: low
```