### PR TITLE
[ci] Update image build templates to Werf3

### DIFF
--- a/.werf/defines/base.tmpl
+++ b/.werf/defines/base.tmpl
@@ -10,7 +10,7 @@
   before: setup
   {{- range $k8s := $context.k8sVersions }}
     {{- $image_version := printf "%s.%d" $k8s.kubectl (index $context.CandiVersionMap "k8s" $k8s.kubectl "patch") | replace "." "-" }}
-- image: common/kubernetes-artifact-{{ $image_version }}
+- from: common/kubernetes-artifact-{{ $image_version }}
   add: /src/_output/bin/kubectl
   to: /usr/bin/kubectl-{{ $k8s.kubectl }}
   before: setup
@@ -70,7 +70,7 @@ image: common-base-python-artifact
 final: false
 from: {{ index $.Images "base/python-3.12" }}
 import:
-- image: common/wheel-artifact
+- from: common/wheel-artifact
   add: /wheels
   to: /wheels
   before: install
@@ -82,7 +82,7 @@ shell:
 image: common-base
 from: {{ index $.Images "base/distroless" }}
 import:
-- image: common-base-python-artifact
+- from: common-base-python-artifact
   add: /
   to: /
   before: setup
@@ -95,7 +95,7 @@ import:
   - usr/lib/python*/site-packages/pip-25.3*
   - usr/lib/python*/test
 {{ include "base components imports" (dict "Images" $context.Images "k8sVersions" $context.k8sVersions "CandiVersionMap" $context.CandiVersionMap ) }}
-- image: registrypackages/d8-curl-artifact-8-9-1
+- from: registrypackages/d8-curl-artifact-8-9-1
   add: /d8-curl
   to: /usr/bin/curl
   before: install

--- a/.werf/defines/candi.tmpl
+++ b/.werf/defines/candi.tmpl
@@ -4,11 +4,11 @@
 {{- define "candi_generic_imports" }}
 {{- $context := . -}}
 
-- image: dev/candi
+- from: dev/candi
   add: /deckhouse
   to: /deckhouse
   before: setup
-- image: dev-prebuild
+- from: dev-prebuild
   add: /deckhouse
   to: /deckhouse
   includePaths:
@@ -16,7 +16,7 @@
   - global-hooks/openapi/config-values.yaml
   - candi/terraform_versions.yml
   after: setup
-- image: version-map-artifact
+- from: version-map-artifact
   add: /version_map_{{ $context.Env }}.yml
   to: /deckhouse/candi/version_map.yml
   before: setup

--- a/.werf/defines/dev-prebuild.tmpl
+++ b/.werf/defines/dev-prebuild.tmpl
@@ -25,7 +25,7 @@
 {{- define "dev_prebuild_images_imports" }}
 {{- $context := . -}}
 
-- image: deckhouse-controller-artifact
+- from: deckhouse-controller-artifact
   add: /out
   to: /usr/bin
   after: install
@@ -48,7 +48,7 @@
   add: /usr/sbin/veritysetup
   to: /usr/sbin/veritysetup
   after: setup
-- image: version-map-artifact
+- from: version-map-artifact
   add: /version_map_{{ $context.Env }}.yml
   to: /deckhouse/candi/version_map.yml
   after: setup
@@ -87,13 +87,13 @@ imageSpec:
 # render deckhouse controller image
 {{- define "dev_image" }}
 image: dev
-fromImage: dev-prebuild
+from: dev-prebuild
 import:
-- image: images-digests
+- from: images-digests
   add: /images_digests.json
   to: /deckhouse/modules/images_digests.json
   after: setup
-- image: images-digests
+- from: images-digests
   add: /images_digests.json
   to: /deckhouse/modules/040-node-manager/images_digests.json
   after: setup

--- a/.werf/defines/dhctl.tmpl
+++ b/.werf/defines/dhctl.tmpl
@@ -7,7 +7,7 @@
 
 image: dhctl-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: {{ printf "%s/dhctl" $prefix }}
   to: /src/dhctl
@@ -49,14 +49,14 @@ image: dhctl
 image: dhctl-base
 {{- end }}
 final: false
-fromImage: base-for-go
+from: base-for-go
 import:
-- image: dhctl-src-artifact
+- from: dhctl-src-artifact
   add: /src
   to: /
   before: install
 {{- if $context.includeImagesDigests }}
-- image: images-digests
+- from: images-digests
   add: /images_digests.json
   to: /images_digests.json
   before: install
@@ -80,9 +80,9 @@ shell:
   - cp /minget pkg/minget/embed/minget
   - GOPROXY=$(cat /run/secrets/GOPROXY) go mod download
   - export RPP_SIGN_CHECK={{ $rppSignCheck }}
-  - export D8_VERSION={{ $context.CI_COMMIT_TAG }} 
-  - export DEFAULT_KUBERNETES_VERSION={{ $context.DEFAULT_KUBERNETES_VERSION }} 
-  - export EDITION={{ $context.Env }} 
-  - export EE_EDITIONS={{ include "ee_editions_list_string" $context | trim }} 
+  - export D8_VERSION={{ $context.CI_COMMIT_TAG }}
+  - export DEFAULT_KUBERNETES_VERSION={{ $context.DEFAULT_KUBERNETES_VERSION }}
+  - export EDITION={{ $context.Env }}
+  - export EE_EDITIONS={{ include "ee_editions_list_string" $context | trim }}
   - make build
 {{- end }}

--- a/.werf/defines/image-mountpoints.tmpl
+++ b/.werf/defines/image-mountpoints.tmpl
@@ -3,13 +3,13 @@
 {{- define "image mount points" }}
   {{- $mountPoints := ($.Files.Get (printf "%smodules/%s-%s/images/%s/mount-points.yaml" $.ModulePath $.ModulePriority $.ModuleName $.ImageName) | fromYaml) }}
   {{- range $v := $mountPoints.dirs }}
-- image: werf-mountpoints
+- from: werf-mountpoints
   add: /tools/mounts/mountdir
   to: {{ trimSuffix "/" $v }}
   before: install
   {{- end }}
   {{- range $v := $mountPoints.files }}
-- image: werf-mountpoints
+- from: werf-mountpoints
   add: /tools/mounts/mountfile
   to: {{ $v }}
   before: install

--- a/.werf/defines/installer.tmpl
+++ b/.werf/defines/installer.tmpl
@@ -3,11 +3,11 @@
 #   Env - werf env
 {{- define "installer_and_installer_standalone_generic_imports" }}
 {{- $context := . -}}
-- image: dhctl
+- from: dhctl
   add: /dhctl/bin/dhctl
   to: /dhctl
   before: setup
-- image: dev-prebuild
+- from: dev-prebuild
   add: /deckhouse
   to: /deckhouse
   includePaths:
@@ -15,15 +15,15 @@
   - modules/*/openapi/conversions/*.yaml
   - global-hooks/openapi/config-values.yaml
   after: setup
-- image: dev-prebuild
+- from: dev-prebuild
   add: /deckhouse/deckhouse-controller/crds/module-config.yaml
   to: /deckhouse/crds/module-config.yaml
   after: setup
-- image: images-digests
+- from: images-digests
   add: /images_digests.json
   to: /deckhouse/candi/images_digests.json
   before: setup
-- image: version-map-artifact
+- from: version-map-artifact
   add: /version_map_{{ $context.Env }}.yml
   to: /deckhouse/candi/version_map.yml
   before: setup
@@ -31,7 +31,7 @@
   add: /usr/share/terminfo
   to: /usr/share/terminfo
   before: install
-- image: ssh-static
+- from: ssh-static
   add: /ssh/bin
   to: /bin
   before: setup
@@ -237,7 +237,7 @@
     {{- break -}}
   {{- end }}
 {{- end }}
-- image: opentofu # from modules/040-terraform-manager/images/terraform-manager-base/werf.inc.yaml
+- from: opentofu # from modules/040-terraform-manager/images/terraform-manager-base/werf.inc.yaml
   add: /opentofu/opentofu
   to: /bin/opentofu
   before: setup
@@ -261,13 +261,13 @@
 
         {{- if $tf.versions }}
           {{- range $version := $tf.versions }}
-- image: {{ $tf.artifact }} # from modules/040-terraform-manager/images/terraform-manager-{PROVIDER}/werf.inc.yaml
+- from: {{ $tf.artifact }} # from modules/040-terraform-manager/images/terraform-manager-{PROVIDER}/werf.inc.yaml
   add: /{{ $tf.artifactBinary }}-v{{ $version }}
   to: /plugins/registry.opentofu.org/{{ $tf.namespace }}/{{ $tf.type }}/{{ $version }}/linux_amd64/{{ $tf.destinationBinary }}
   before: setup
           {{- end }}
         {{- else }}
-- image: {{ $tf.artifact }} # from modules/040-terraform-manager/images/terraform-manager-{PROVIDER}/werf.inc.yaml
+- from: {{ $tf.artifact }} # from modules/040-terraform-manager/images/terraform-manager-{PROVIDER}/werf.inc.yaml
   add: /{{ $tf.artifactBinary }}
   to: /plugins/registry.opentofu.org/{{ $tf.namespace }}/{{ $tf.type }}/{{ $tf.version }}/linux_amd64/{{ $tf.destinationBinary }}
   before: setup
@@ -303,7 +303,7 @@
   {{- end }}
 {{- end }}
 {{- if ne $.Env "CSE" }}
-- image: terraform # from modules/040-terraform-manager/images/terraform-manager-base/werf.inc.yaml
+- from: terraform # from modules/040-terraform-manager/images/terraform-manager-base/werf.inc.yaml
   add: /terraform/terraform
   to: /bin/terraform
   before: setup
@@ -323,13 +323,13 @@
 
         {{- if $tf.versions }}
           {{- range $version := $tf.versions }}
-- image: {{ $tf.artifact }} # from modules/040-terraform-manager/images/terraform-manager-{PROVIDER}/werf.inc.yaml
+- from: {{ $tf.artifact }} # from modules/040-terraform-manager/images/terraform-manager-{PROVIDER}/werf.inc.yaml
   add: /{{ $tf.artifactBinary }}-v{{ $version }}
   to: /plugins/registry.terraform.io/{{ $tf.namespace }}/{{ $tf.type }}/{{ $version }}/linux_amd64/{{ $tf.destinationBinary }}
   before: setup
           {{- end }}
         {{- else }}
-- image: {{ $tf.artifact }} # from modules/040-terraform-manager/images/terraform-manager-{PROVIDER}/werf.inc.yaml
+- from: {{ $tf.artifact }} # from modules/040-terraform-manager/images/terraform-manager-{PROVIDER}/werf.inc.yaml
   add: /{{ $tf.artifactBinary }}
   to: /plugins/registry.terraform.io/{{ $tf.namespace }}/{{ $tf.type }}/{{ $tf.version }}/linux_amd64/{{ $tf.destinationBinary }}
   before: setup
@@ -486,7 +486,7 @@ shell:
 image: dev/install-standalone
 from: {{ index $.Images "builder/scratch" }}
 import:
-- image: install-standalone-builder
+- from: install-standalone-builder
   add: /dhctl-{{- $context.CI_COMMIT_TAG }}.x86_64.tar.gz
   to: /
   before: setup

--- a/.werf/defines/ssh-static.tmpl
+++ b/.werf/defines/ssh-static.tmpl
@@ -8,7 +8,7 @@
 ---
 image: ssh-static-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 secrets:
 - id: SOURCE_REPO
   value: {{ .SOURCE_REPO }}
@@ -21,7 +21,7 @@ image: ssh-static
 final: false
 from: {{ index $.Images "builder/alpine-3.21" }}
 import:
-- image: ssh-static-src-artifact
+- from: ssh-static-src-artifact
   add: /src
   to: /src
   before: install

--- a/.werf/defines/trivyignore.tmpl
+++ b/.werf/defines/trivyignore.tmpl
@@ -33,7 +33,7 @@
   {{- if $trivyIgnoreFile }}
 ---
 image: {{ $imageName }}-trivy-ignore-artifact
-fromImage: base/vex
+from: base/vex
 final: true
 secrets:
 - id: REGISTRY_USER

--- a/.werf/defines/vex.tmpl
+++ b/.werf/defines/vex.tmpl
@@ -33,7 +33,7 @@
   {{- if $vexFile }}
 ---
 image: {{ $imageName }}-vex-artifact
-fromImage: base/vex
+from: base/vex
 final: true
 secrets:
 - id: REGISTRY_USER

--- a/.werf/werf-deckhouse-controller.yaml
+++ b/.werf/werf-deckhouse-controller.yaml
@@ -27,9 +27,9 @@ shell:
 ---
 image: deckhouse-controller-artifact
 final: false
-fromImage: base-for-go
+from: base-for-go
 import:
-- image: deckhouse-controller-src-artifact
+- from: deckhouse-controller-src-artifact
   add: /deckhouse
   to: /deckhouse
   before: install

--- a/.werf/werf-dev-install-standalone.yaml
+++ b/.werf/werf-dev-install-standalone.yaml
@@ -21,7 +21,7 @@ image: install-standalone-builder
 final: false
 from: {{ index $.Images "builder/alpine" }}
 import:
-- image: install-standalone-builder-content
+- from: install-standalone-builder-content
   add: /
   to: /image
   before: setup

--- a/.werf/werf-dev.yaml
+++ b/.werf/werf-dev.yaml
@@ -1,6 +1,6 @@
 ---
 image: dev-prebuild
-fromImage: common-base
+from: common-base
 git:
 - add: /
   to: /deckhouse

--- a/.werf/werf-e2e-opentofu-eks.yaml
+++ b/.werf/werf-e2e-opentofu-eks.yaml
@@ -3,38 +3,38 @@
 image: e2e-opentofu-eks
 # we use artifact with ubuntu because alpine can not unzip with `unzip` and `tar` command
 # current openstack zip-archive with error: "unzip: zip flag 8 (streaming) is not supported"
-fromImage: common/alt-p11-artifact
+from: common/alt-p11-artifact
 import:
   {{- $k8sVersion := index (index .k8sVersions 0) "kubectl" }}
   {{- $image_version := printf "%s.%d" $k8sVersion (index $.CandiVersionMap "k8s" $k8sVersion "patch") | replace "." "-" }}
-  - image: common/kubernetes-artifact-{{ $image_version }}
+  - from: common/kubernetes-artifact-{{ $image_version }}
     add: /src/_output/bin/kubectl
     to: /usr/local/bin/kubectl
     before: setup
-  - image: opentofu # from modules/040-terraform-manager/images/terraform-manager-base/werf.inc.yaml
+  - from: opentofu # from modules/040-terraform-manager/images/terraform-manager-base/werf.inc.yaml
     add: /opentofu/opentofu
     to: /image/bin/opentofu
     before: setup
   {{- if ne $.Env "CSE" }}
   {{- $tf := index $.TF "aws" }}
-  - image: {{ $tf.artifact }} # from modules/040-terraform-manager/images/terraform-manager-aws/werf.inc.yaml
+  - from: {{ $tf.artifact }} # from modules/040-terraform-manager/images/terraform-manager-aws/werf.inc.yaml
     add: /{{ $tf.artifactBinary }}
     to: /usr/local/share/opentofu/plugins/registry.opentofu.org/{{ $tf.namespace }}/{{ $tf.type }}/{{ $tf.version }}//linux_amd64/{{ $tf.destinationBinary }}
     before: setup
   {{- end }}
-  - image: e2e-eks-terraform-plugins
+  - from: e2e-eks-terraform-plugins
     add: /terraform-provider-random
     to: /usr/local/share/opentofu/plugins/registry.opentofu.org/hashicorp/random/3.4.3/linux_amd64/terraform-provider-random_v3.4.3_x5
     before: setup
-  - image: e2e-eks-terraform-plugins
+  - from: e2e-eks-terraform-plugins
     add: /terraform-provider-tls
     to: /usr/local/share/opentofu/plugins/registry.opentofu.org/hashicorp/tls/4.0.5/linux_amd64/terraform-provider-tls_v4.0.5_x5
     before: setup
-  - image: e2e-eks-terraform-plugins
+  - from: e2e-eks-terraform-plugins
     add: /terraform-provider-cloudinit
     to: /usr/local/share/opentofu/plugins/registry.opentofu.org/hashicorp/cloudinit/2.2.0/linux_amd64/terraform-provider-cloudinit_v2.2.0_x5
     before: setup
-  - image: e2e-eks-terraform-plugins
+  - from: e2e-eks-terraform-plugins
     add: /terraform-provider-kubernetes
     to: /usr/local/share/opentofu/plugins/registry.opentofu.org/hashicorp/kubernetes/2.31.0/linux_amd64/terraform-provider-kubernetes_v2.31.0_x5
     before: setup
@@ -58,7 +58,7 @@ shell:
 ---
 image: e2e-eks-terraform-plugins-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 secrets:
 - id: SOURCE_REPO
   value: {{ .SOURCE_REPO }}
@@ -73,7 +73,7 @@ image: e2e-eks-terraform-plugins
 final: false
 from: {{ index $.Images "builder/golang-alpine" }}
 import:
-- image: e2e-eks-terraform-plugins-src-artifact
+- from: e2e-eks-terraform-plugins-src-artifact
   add: /src
   to: /src
   before: install

--- a/.werf/werf-release-channel.yaml
+++ b/.werf/werf-release-channel.yaml
@@ -51,7 +51,7 @@ git:
 image: release-channel-version
 from: {{ index $.Images "builder/scratch" }}
 import:
-- image: release-channel-version-prebuild
+- from: release-channel-version-prebuild
   add: /
   to: /
   after: install

--- a/.werf/werf-test.yaml
+++ b/.werf/werf-test.yaml
@@ -1,7 +1,7 @@
 {{- if eq $.Env "FE" }}
 ---
 image: tests-prebuild
-fromImage: base-for-go
+from: base-for-go
 git:
 - add: /
   to: /deckhouse
@@ -49,11 +49,11 @@ import:
   add: /usr/bin/jq
   to: /usr/bin/jq
   after: setup
-- image: version-map-artifact
+- from: version-map-artifact
   add: /version_map_{{ $.Env }}.yml
   to: /deckhouse/candi/version_map.yml
   after: setup
-- image: golangci-lint-artifact
+- from: golangci-lint-artifact
   add: /usr/local/bin/golangci-lint
   to: /usr/local/bin/golangci-lint
   before: install
@@ -78,21 +78,21 @@ imageSpec:
     env: { "ADDON_OPERATOR_NAMESPACE": "tests", "DECKHOUSE_POD": "tests", "MODULES_DIR": "/deckhouse/modules", "GLOBAL_HOOKS_DIR": "/deckhouse/global-hooks", "PATH": "${PATH}:/go/bin:/usr/local/go/bin:/root/go/bin" }
 ---
 image: tests
-fromImage: tests-prebuild
+from: tests-prebuild
 import:
-- image: terraform # from modules/040-terraform-manager/images/terraform-manager-base/werf.inc.yaml
+- from: terraform # from modules/040-terraform-manager/images/terraform-manager-base/werf.inc.yaml
   add: /terraform/terraform
   to: /dhctl-tests/bin/terraform
   before: setup
-- image: opentofu # from modules/040-terraform-manager/images/terraform-manager-base/werf.inc.yaml
+- from: opentofu # from modules/040-terraform-manager/images/terraform-manager-base/werf.inc.yaml
   add: /opentofu/opentofu
   to: /dhctl-tests/bin/opentofu
   before: setup
-- image: {{ .TF.yandex.artifact }} # from modules/040-terraform-manager/images/terraform-manager-{PROVIDER}/werf.inc.yaml
+- from: {{ .TF.yandex.artifact }} # from modules/040-terraform-manager/images/terraform-manager-{PROVIDER}/werf.inc.yaml
   add: /{{ .TF.yandex.artifactBinary }}
   to: /dhctl-tests/plugins/registry.opentofu.org/{{ .TF.yandex.namespace }}/{{ .TF.yandex.type }}/{{ $.TF.yandex.version }}/linux_amd64/{{ .TF.yandex.destinationBinary }}
   before: setup
-- image: {{ .TF.gcp.artifact }} # from modules/040-terraform-manager/images/terraform-manager-{PROVIDER}/werf.inc.yaml
+- from: {{ .TF.gcp.artifact }} # from modules/040-terraform-manager/images/terraform-manager-{PROVIDER}/werf.inc.yaml
   add: /{{ .TF.gcp.artifactBinary }}
   to: /dhctl-tests/plugins/registry.terraform.io/{{ .TF.gcp.namespace }}/{{ .TF.gcp.type }}/{{ $.TF.gcp.version }}/linux_amd64/{{ .TF.gcp.destinationBinary }}
   before: setup
@@ -102,7 +102,7 @@ import:
 # images_digests.json, testing/library/utils.go falls back to the dummy
 # DefaultImagesDigests (tools/images_tags) — the path designed for
 # template/matrix tests.
-- image: werf-mountpoints
+- from: werf-mountpoints
   add: /tools/mounts/mountfile
   to: /root/.ack-ginkgo-rc
   before: setup

--- a/docs/documentation/werf-s3-loader.inc.yaml
+++ b/docs/documentation/werf-s3-loader.inc.yaml
@@ -8,19 +8,19 @@ git:
   to: /patch-modules-list.sh
 import:
 # Static files of embedded modules
-- image: {{ .ModuleName }}/modules-embedded/static-artifact
+- from: {{ .ModuleName }}/modules-embedded/static-artifact
   add: /app/_site/
   to: /embedded-modules
   before: setup
   includePaths:
   - en
   - ru
-- image: {{ .ModuleName }}/modules-embedded/static-artifact
+- from: {{ .ModuleName }}/modules-embedded/static-artifact
   add: /srv/jekyll-data/documentation/_data/modules/embedded_modules_list.json
   to: /embedded-modules/embedded_modules_list.json
   before: setup
 # Static files of documentation
-- image: {{ .ModuleName }}/{{ .ImageName }}/static
+- from: {{ .ModuleName }}/{{ .ImageName }}/static
   add: /app/_site
   to: /documentation
   before: setup

--- a/docs/site/werf-debug.yaml
+++ b/docs/site/werf-debug.yaml
@@ -80,7 +80,7 @@ git:
       install: 'go.mod'
       setup: '**/*'
 import:
-  - image: web-static
+  - from: web-static
     add: /app/_site
     to: /app/root
     before: setup
@@ -97,7 +97,7 @@ shell:
       {{- .Files.Get ".werf/nginx.conf" | nindent 6 }}
       EOD
 import:
-- image: web-static
+- from: web-static
   add: /app/_site
   to: /app
   before: setup

--- a/docs/site/werf-docs-builder.inc.yaml
+++ b/docs/site/werf-docs-builder.inc.yaml
@@ -1,16 +1,16 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
 {{ if eq .ModuleName "documentation" }}
-fromImage: common/distroless
+from: common/distroless
 {{ else }}
 from: {{ index $.Images "builder/scratch" }}
 {{ end }}
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-artifact
   add: /src/docs-builder
   to: /app/server
   before: setup
-- image: d8-docs-artifacts
+- from: d8-docs-artifacts
   add: /export
   to: /app/hugo-init/data/dkp
   includePaths:
@@ -138,7 +138,7 @@ mount:
 {{ include "mount points for golang builds" . }}
 {{ if ne .ModuleName "website-docs" }}
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src
   to: /src
   before: install
@@ -157,7 +157,7 @@ shell:
 {{ if ne .ModuleName "website-docs" }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 shell:
   install:

--- a/docs/site/werf-modules-watcher.inc.yaml
+++ b/docs/site/werf-modules-watcher.inc.yaml
@@ -21,7 +21,7 @@ imageSpec:
   config:
     workingDir: "/app"
 import:
-  - image: registry-modules-watcher-artifact
+  - from: registry-modules-watcher-artifact
     add: /go/src/app/registry-modules-watcher
     to: /app/registry-modules-watcher
     before: setup

--- a/docs/site/werf-web-frontend.inc.yaml
+++ b/docs/site/werf-web-frontend.inc.yaml
@@ -131,19 +131,19 @@ git:
     setup: ['**/*']
 {{- if and (ne $.Env "development") (ne $.Env "module") (ne $.Env "local") }}
 import:
-  - image: site-external-artifacts
+  - from: site-external-artifacts
     add: /data/topnav.json
     to: /srv/jekyll-data/site/_data/topnav.json
     before: setup
-  - image: site-external-artifacts
+  - from: site-external-artifacts
     add: /data/topnav-l2-products.json
     to: /srv/jekyll-data/site/_data/topnav-l2-products.json
     before: setup
-  - image: site-external-artifacts
+  - from: site-external-artifacts
     add: /data/footer.json
     to: /srv/jekyll-data/site/_data/footer.json
     before: setup
-  - image: site-external-artifacts
+  - from: site-external-artifacts
     add: /data/copyright.json
     to: /srv/jekyll-data/site/_data/copyright.json
     before: setup
@@ -185,7 +185,7 @@ git:
   to: /scripts/channels-convert.sh
 {{- end }}
 import:
-- image: web-frontend-artifact
+- from: web-frontend-artifact
   add: /app/_site
   to: /app
   before: setup
@@ -201,14 +201,14 @@ import:
   add: /usr/bin/yq
   to: /usr/bin/yq
   before: setup
-- image: {{ .ModuleName }}/modules-embedded/static-artifact
+- from: {{ .ModuleName }}/modules-embedded/static-artifact
   add: /app/_site/
   to: /app/embedded-modules
   before: setup
   includePaths:
   - en
   - ru
-- image: {{ .ModuleName }}/{{ .ImageName }}/static
+- from: {{ .ModuleName }}/{{ .ImageName }}/static
   add: /app/_site
   to: /app/dkp-docs
   before: setup

--- a/docs/site/werf-web-router.inc.yaml
+++ b/docs/site/werf-web-router.inc.yaml
@@ -30,11 +30,11 @@ import:
     add: /usr/bin/jq
     to: /usr/bin/jq
     before: setup
-  - image: web-router-artifact
+  - from: web-router-artifact
     add: /go/src/app/server
     to: /app/server
     before: setup
-  - image: web-frontend-artifact
+  - from: web-frontend-artifact
     add: /app/_site
     to: /app/root
     before: setup

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/werf.inc.yaml
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/src
@@ -22,7 +22,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src
   to: /src
   before: install
@@ -41,9 +41,9 @@ shell:
   - chmod 0700 permission-browser-apiserver
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /src/permission-browser-apiserver
   to: /permission-browser-apiserver
   before: setup

--- a/ee/be/modules/140-user-authz/images/webhook/werf.inc.yaml
+++ b/ee/be/modules/140-user-authz/images/webhook/werf.inc.yaml
@@ -1,12 +1,12 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-user-authz-webhook-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-user-authz-webhook-artifact
   add: /src/webhook
   to: /webhook
   before: setup
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-user-authz-webhook-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-user-authz-webhook-artifact
   add: /src/healthcheck
   to: /healthcheck
   before: setup
@@ -16,7 +16,7 @@ imageSpec:
     entrypoint: [ "/webhook" ]
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-user-authz-webhook-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
   - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/src
@@ -38,7 +38,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-user-authz-webhook-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-  - image: {{ $.ModuleName }}/{{ $.ImageName }}-user-authz-webhook-src-artifact
+  - from: {{ $.ModuleName }}/{{ $.ImageName }}-user-authz-webhook-src-artifact
     add: /src
     to: /src
     before: install

--- a/ee/be/modules/350-node-local-dns/images/coredns/werf.inc.yaml
+++ b/ee/be/modules/350-node-local-dns/images/coredns/werf.inc.yaml
@@ -1,8 +1,8 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/coredns
+from: common/coredns
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /coredns-helper
   to: /coredns-helper
   before: setup
@@ -12,7 +12,7 @@ imageSpec:
     entrypoint: [ "/coredns" ]
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/src
@@ -28,7 +28,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/ee/be/modules/350-node-local-dns/images/iptables-loop/werf.inc.yaml
+++ b/ee/be/modules/350-node-local-dns/images/iptables-loop/werf.inc.yaml
@@ -1,9 +1,9 @@
 {{- if ne $.Env "CSE" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /iptables-loop
   to: /iptables-loop
   before: setup
@@ -13,7 +13,7 @@ imageSpec:
     entrypoint: [ "/iptables-loop" ]
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/src
@@ -29,7 +29,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/ee/be/modules/350-node-local-dns/images/iptables-wrapper-init/werf.inc.yaml
+++ b/ee/be/modules/350-node-local-dns/images/iptables-wrapper-init/werf.inc.yaml
@@ -2,7 +2,7 @@
 {{- $iptables_image_version := $iptables_version | replace "." "-" }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
 - from: {{ index $.Images "tools/coreutils" }}
   add: /
@@ -15,25 +15,25 @@ import:
   add: /usr/bin/bash
   to: /bin/bash
   before: setup
-- image: common/iptables-wrapper
+- from: common/iptables-wrapper
   add: /iptables-wrapper
   to: /iptables-wrapper
   before: setup
-- image: registrypackages/iptables-artifact-{{ $iptables_image_version }}
+- from: registrypackages/iptables-artifact-{{ $iptables_image_version }}
   add: /
   to: /_sbin
   includePaths:
   - xtables-legacy-multi
   - xtables-nft-multi
   before: setup
-- image: {{ .ModuleName }}/iptables-wrapper-init-binaries-artifact
+- from: {{ .ModuleName }}/iptables-wrapper-init-binaries-artifact
   add: /relocate
   to: /relocate
   before: setup
 {{- include "image mount points" . }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
-fromImage: common/relocate-artifact
+from: common/relocate-artifact
 final: false
 shell:
   install:

--- a/ee/be/modules/350-node-local-dns/images/safe-updater/werf.inc.yaml
+++ b/ee/be/modules/350-node-local-dns/images/safe-updater/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
   - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/src
@@ -15,7 +15,7 @@ shell:
 image: {{ .ModuleName }}/{{ .ImageName }}
 from: {{ index $.Images "base/distroless" }}
 import:
-- image: {{ .ModuleName }}/{{ $.ImageName }}-build-artifact
+- from: {{ .ModuleName }}/{{ $.ImageName }}-build-artifact
   add: /safe-updater
   to: /safe-updater
   before: install
@@ -27,7 +27,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/ee/be/modules/350-node-local-dns/images/stale-dns-connections-cleaner/werf.inc.yaml
+++ b/ee/be/modules/350-node-local-dns/images/stale-dns-connections-cleaner/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}
@@ -21,7 +21,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-build-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install
@@ -43,9 +43,9 @@ shell:
   - chmod 0700 /src/stale-dns-connections-cleaner
 ---
 image: {{ $.ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-build-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-build-artifact
   add: /src/stale-dns-connections-cleaner
   to: /stale-dns-connections-cleaner
   before: install

--- a/ee/cse/modules/007-registrypackages/images/cosign/werf.inc.yaml
+++ b/ee/cse/modules/007-registrypackages/images/cosign/werf.inc.yaml
@@ -3,7 +3,7 @@
 image: {{ .ModuleName }}/{{ .ImageName }}
 from: {{ index $.Images "builder/scratch" }}
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-artifact
   add: /
   to: /
   includePaths:
@@ -27,7 +27,7 @@ git:
 - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/scripts
   to: /
 import:
-- image: {{ index $.Images "tools/cosign" }} 
+- from: {{ index $.Images "tools/cosign" }}
   add: /usr/bin/cosign
   to: /cosign
   before: install

--- a/ee/cse/modules/007-registrypackages/images/d8-bcheck/werf.inc.yaml
+++ b/ee/cse/modules/007-registrypackages/images/d8-bcheck/werf.inc.yaml
@@ -3,7 +3,7 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact-{{ $image_version }}
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/scripts
   to: /src/scripts
@@ -13,7 +13,7 @@ git:
 image: {{ .ModuleName }}/{{ .ImageName }}-{{ $image_version }}
 from: {{ index .Images "builder/scratch" }}
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-artifact-{{ $image_version }}
+- from: {{ .ModuleName }}/{{ .ImageName }}-artifact-{{ $image_version }}
   add: /
   to: /
   includePaths:
@@ -36,11 +36,11 @@ from: {{ index .Images "builder/golang" }}
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact-{{ $image_version }}
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact-{{ $image_version }}
   add: /src
   to: /src
   before: install
-- image: {{ index .Images "libs/musl" }}
+- from: {{ index .Images "libs/musl" }}
   add: /
   to: /
   before: install
@@ -50,7 +50,7 @@ import:
     - usr/lib
     - usr/lib64
     - usr/include
-- image: {{ index .Images "libs/zstd" }}
+- from: {{ index .Images "libs/zstd" }}
   add: /
   to: /libs/zstd
   before: install
@@ -61,7 +61,7 @@ import:
     - usr/bin
     - usr/sbin
     - usr/share
-- image: {{ index .Images "libs/libuv" }}
+- from: {{ index .Images "libs/libuv" }}
   add: /
   to: /libs/libuv
   before: install
@@ -72,7 +72,7 @@ import:
     - usr/bin
     - usr/sbin
     - usr/share
-- image: {{ index .Images "libs/zlib" }}
+- from: {{ index .Images "libs/zlib" }}
   add: /
   to: /libs/zlib
   before: install
@@ -83,7 +83,7 @@ import:
     - usr/bin
     - usr/sbin
     - usr/share
-- image: {{ index .Images "tools/openssl" }}
+- from: {{ index .Images "tools/openssl" }}
   add: /
   to: /tools/openssl
   before: install
@@ -94,7 +94,7 @@ import:
     - usr/bin
     - usr/sbin
     - usr/share
-- image: {{ index .Images "tools/elfutils" }}
+- from: {{ index .Images "tools/elfutils" }}
   add: /
   to: /tools/elfutils
   before: install

--- a/ee/cse/modules/007-registrypackages/images/logpipe/werf.inc.yaml
+++ b/ee/cse/modules/007-registrypackages/images/logpipe/werf.inc.yaml
@@ -3,7 +3,7 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact-{{ $image_version }}
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ .ModulePath }}/modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/scripts
   to: /src/scripts
@@ -13,7 +13,7 @@ git:
 image: {{ .ModuleName }}/{{ .ImageName }}-{{ $image_version }}
 from: {{ index .Images "builder/scratch" }}
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-artifact-{{ $image_version }}
+- from: {{ .ModuleName }}/{{ .ImageName }}-artifact-{{ $image_version }}
   add: /
   to: /
   includePaths:
@@ -36,7 +36,7 @@ from: {{ index .Images "builder/golang" }}
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact-{{ $image_version }}
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact-{{ $image_version }}
   add: /src
   to: /src
   before: install

--- a/ee/cse/modules/040-node-manager/images/integrity-containerd-configurator/werf.inc.yaml
+++ b/ee/cse/modules/040-node-manager/images/integrity-containerd-configurator/werf.inc.yaml
@@ -1,18 +1,18 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 imageSpec:
   config:
     entrypoint: ["/integrity-containerd-configurator"]
 import:
-- image: {{ .ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ .ModuleName }}/{{ $.ImageName }}-artifact
   add: /integrity-containerd-configurator
   to: /integrity-containerd-configurator
   before: setup
 {{- include "image mount points" . }}
 ---
 image: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ $.ModulePath }}modules/040-{{ .ModuleName }}/images/{{ .ImageName }}/src
@@ -60,11 +60,11 @@ image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-- image: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install
-- image: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /go_lib/controlplane
   to: /go_lib/controlplane
   before: install

--- a/ee/cse/modules/040-node-manager/images/integrity-controller/werf.inc.yaml
+++ b/ee/cse/modules/040-node-manager/images/integrity-controller/werf.inc.yaml
@@ -1,17 +1,17 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 imageSpec:
   config:
     entrypoint: ["/integrity-controller"]
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-artifact
   add: /integrity-controller
   to: /integrity-controller
   before: setup
 ---
 image: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ $.ModulePath }}modules/040-{{ .ModuleName }}/images/{{ .ImageName }}/src
@@ -33,7 +33,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-- image: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/ee/fe/modules/500-basic-auth/images/nginx/werf.inc.yaml
+++ b/ee/fe/modules/500-basic-auth/images/nginx/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/nginx-static
+from: common/nginx-static
 imageSpec:
   config:
     entrypoint: ["/opt/nginx-static/sbin/nginx", "-g", "daemon off;"]

--- a/ee/modules/030-cloud-provider-dynamix/images/capd-controller-manager/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-dynamix/images/capd-controller-manager/werf.inc.yaml
@@ -2,19 +2,19 @@
 {{- $version_common := "v0.5.0" }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 imageSpec:
   config:
     entrypoint: ["/capd-controller-manager"]
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-artifact
   add: /capd-controller-manager
   to: /capd-controller-manager
   before: setup
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 fromCacheVersion: "2025-02-14.1"
 secrets:
 - id: CLOUD_PROVIDERS_SOURCE_REPO
@@ -36,7 +36,7 @@ fromCacheVersion: "2025-02-14.2"
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/ee/modules/030-cloud-provider-dynamix/images/cloud-controller-manager/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-dynamix/images/cloud-controller-manager/werf.inc.yaml
@@ -2,9 +2,9 @@
 {{- $version_common := "v0.5.0" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /dynamix-cloud-controller-manager
   to: /dynamix-cloud-controller-manager
   before: setup
@@ -14,7 +14,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 secrets:
 - id: CLOUD_PROVIDERS_SOURCE_REPO
   value: {{ .CLOUD_PROVIDERS_SOURCE_REPO }}
@@ -34,7 +34,7 @@ from: {{ index $.Images "builder/golang" }}
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/ee/modules/030-cloud-provider-dynamix/images/cloud-data-discoverer/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-dynamix/images/cloud-data-discoverer/werf.inc.yaml
@@ -2,9 +2,9 @@
 {{- $version_common := "v0.5.0" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /discoverer
   to: /discoverer
   before: setup
@@ -14,7 +14,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /go_lib/cloud-data
   to: /deckhouse/go_lib/cloud-data
@@ -57,7 +57,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/ee/modules/030-cloud-provider-dynamix/images/dynamix-csi-driver/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-dynamix/images/dynamix-csi-driver/werf.inc.yaml
@@ -2,25 +2,25 @@
 {{- $version_common := "v0.5.0" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /dynamix-csi-driver
   to: /dynamix-csi-driver
   before: setup
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /relocate
   to: /
   before: install
   includePaths:
   - '**/*'
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /lib64
   to: /lib64
   before: install
   includePaths:
   - 'libresolv*'
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /lib/udev/scsi_id
   to: /lib/udev/scsi_id
   before: setup
@@ -34,7 +34,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 fromCacheVersion: "2025-02-14.1"
 secrets:
 - id: CLOUD_PROVIDERS_SOURCE_REPO
@@ -55,7 +55,7 @@ from: {{ index $.Images "builder/golang" }}
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install
@@ -74,7 +74,7 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
 final: false
-fromImage: common/relocate-artifact
+from: common/relocate-artifact
 shell:
   beforeInstall:
   - apt-get update -y

--- a/ee/modules/030-cloud-provider-dynamix/images/terraform-manager/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-dynamix/images/terraform-manager/werf.inc.yaml
@@ -16,7 +16,7 @@ git:
     install:
     - '**/*'
 import:
-  - image: terraform-provider-decort
+  - from: terraform-provider-decort
     add: /terraform-provider-decort
     to: /terraform-manager/terraform-provider-decort
     before: setup
@@ -27,7 +27,7 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ $.ModulePath }}modules/030-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
   to: /patches
@@ -50,7 +50,7 @@ from: {{ index $.Images "builder/golang" }}
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/ee/modules/030-cloud-provider-huaweicloud/images/caphc-controller-manager/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/images/caphc-controller-manager/werf.inc.yaml
@@ -2,9 +2,9 @@
 {{- $version_common := "v0.8.1" }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-artifact
   add: /caphc-controller-manager
   to: /caphc-controller-manager
   before: setup
@@ -14,7 +14,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 secrets:
 - id: CLOUD_PROVIDERS_SOURCE_REPO
   value: {{ .CLOUD_PROVIDERS_SOURCE_REPO }}
@@ -32,7 +32,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/ee/modules/030-cloud-provider-huaweicloud/images/cloud-controller-manager/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/images/cloud-controller-manager/werf.inc.yaml
@@ -1,9 +1,9 @@
 {{- $version := include "get_oss_version_by_id" (list "ccm-huaweicloud" $) }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /huaweicloud-cloud-controller-manager
   to: /huaweicloud-cloud-controller-manager
   before: setup
@@ -13,7 +13,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
   to: /patches
@@ -34,7 +34,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-  - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+  - from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
     add: /src
     to: /src
     before: install

--- a/ee/modules/030-cloud-provider-huaweicloud/images/cloud-data-discoverer/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/images/cloud-data-discoverer/werf.inc.yaml
@@ -2,9 +2,9 @@
 {{- $version_common := "v0.8.1" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /discoverer
   to: /discoverer
   before: setup
@@ -14,7 +14,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /go_lib/cloud-data
   to: /deckhouse/go_lib/cloud-data
@@ -57,7 +57,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/ee/modules/030-cloud-provider-huaweicloud/images/huaweicloud-csi-driver/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/images/huaweicloud-csi-driver/werf.inc.yaml
@@ -1,29 +1,29 @@
 {{- $version := include "get_oss_version_by_id" (list "csi-huaweicloud" $) }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /evs-csi-plugin
   to: /evs-csi-plugin
   before: setup
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /sfs-csi-plugin
   to: /sfs-csi-plugin
   before: setup
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /relocate
   to: /
   before: install
   includePaths:
   - '**/*'
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /lib64
   to: /lib64
   before: install
   includePaths:
   - 'libresolv*'
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /lib/udev/scsi_id
   to: /lib/udev/scsi_id
   before: setup
@@ -33,7 +33,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
   to: /patches
@@ -54,7 +54,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install
@@ -75,7 +75,7 @@ shell:
 {{- $csiBinaries := "/bin/chmod /bin/mount /bin/mkdir /bin/rmdir /bin/umount /bin/findmnt /bin/lsblk /sbin/badblocks /sbin/blockdev /sbin/blk* /sbin/btrfs* /sbin/dumpe2fs /sbin/e2* /sbin/findfs /sbin/fsck* /sbin/fsfreeze /sbin/fstrim /sbin/mke2fs /sbin/mkfs* /sbin/resize2fs /sbin/xfs_repair /usr/sbin/nvme /usr/sbin/parted /usr/sbin/xfs*" }}
 image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
 final: false
-fromImage: common/relocate-artifact
+from: common/relocate-artifact
 shell:
   beforeInstall:
   - apt-get update -y

--- a/ee/modules/030-cloud-provider-huaweicloud/images/terraform-manager/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/images/terraform-manager/werf.inc.yaml
@@ -16,7 +16,7 @@ git:
     install:
     - '**/*'
 import:
-  - image: terraform-provider-huaweicloud
+  - from: terraform-provider-huaweicloud
     add: /terraform-provider-huaweicloud
     to: /terraform-manager/terraform-provider-huaweicloud
     before: setup
@@ -27,7 +27,7 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ $.ModulePath }}modules/030-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
   to: /patches
@@ -51,7 +51,7 @@ from: {{ index $.Images "builder/golang" }}
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/ee/modules/030-cloud-provider-openstack/images/capo-controller-manager/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-openstack/images/capo-controller-manager/werf.inc.yaml
@@ -1,9 +1,9 @@
 {{- $version := include "get_oss_version_by_id" (list "capo-openstack" $) }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-artifact
   add: /capo-controller-manager
   to: /capo-controller-manager
   before: setup
@@ -13,7 +13,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/patches
   to: /patches
@@ -34,7 +34,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/ee/modules/030-cloud-provider-openstack/images/cinder-csi-plugin/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-openstack/images/cinder-csi-plugin/werf.inc.yaml
@@ -11,13 +11,13 @@
     {{- end }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
   add: /src/cinder-csi-plugin
   to: /bin/cinder-csi-plugin
   before: setup
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /relocate
   to: /
   before: install
@@ -29,7 +29,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 {{- if $patch }}
 git:
 - add: {{ $patches }}/patches/{{ $k8s_version }}
@@ -54,7 +54,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
   add: /src
   to: /src
   before: install
@@ -77,7 +77,7 @@ shell:
 {{- $csiBinaries := "/bin/chmod /bin/mount /bin/mkdir /bin/rmdir /bin/umount /bin/findmnt /bin/lsblk /sbin/badblocks /sbin/blockdev /sbin/blk* /sbin/btrfs* /sbin/dumpe2fs /sbin/e2* /sbin/findfs /sbin/fsck* /sbin/fsfreeze /sbin/fstrim /sbin/mke2fs /sbin/mkfs* /sbin/resize2fs /usr/sbin/parted /usr/sbin/xfs*" }}
 image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
 final: false
-fromImage: common/relocate-artifact
+from: common/relocate-artifact
 shell:
   beforeInstall:
   - apt-get update -y

--- a/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/werf.inc.yaml
@@ -11,9 +11,9 @@
     {{- end }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
   add: /src/openstack-cloud-controller-manager
   to: /bin/openstack-cloud-controller-manager
   before: setup
@@ -23,7 +23,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 {{- if $patch }}
 git:
 - add: {{ $patches }}/patches/{{ $k8s_version }}
@@ -48,7 +48,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
   add: /src
   to: /src
   before: install

--- a/ee/modules/030-cloud-provider-openstack/images/cloud-data-discoverer/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-openstack/images/cloud-data-discoverer/werf.inc.yaml
@@ -1,8 +1,8 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /discoverer
   to: /discoverer
   before: setup
@@ -12,7 +12,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/src
   to:  /src
@@ -54,7 +54,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/ee/modules/030-cloud-provider-openstack/images/terraform-manager/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-openstack/images/terraform-manager/werf.inc.yaml
@@ -16,7 +16,7 @@ git:
     install:
     - '**/*'
 import:
-- image: terraform-provider-openstack
+- from: terraform-provider-openstack
   add: /terraform-provider-openstack
   to: /terraform-manager/terraform-provider-openstack
   before: setup
@@ -27,7 +27,7 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ $.ModulePath }}modules/030-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
   to: /patches
@@ -50,7 +50,7 @@ from: {{ index $.Images "builder/golang" }}
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/ee/modules/030-cloud-provider-vcd/images/capcd-controller-manager-legacy/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-vcd/images/capcd-controller-manager-legacy/werf.inc.yaml
@@ -1,9 +1,9 @@
 {{- $version := include "get_oss_version_by_id_and_condition" (list "capi-vcd" (dict "mode" "legacy") $) }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /cluster-api-provider-cloud-director
   to: /cluster-api-provider-cloud-director
   before: setup
@@ -13,10 +13,10 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 
 import:
-- image: {{$.ModuleName}}/cloud-controller-manager-legacy-src-artifact
+- from: {{$.ModuleName}}/cloud-controller-manager-legacy-src-artifact
   add: /src
   to: /src/ccm
   after: install
@@ -41,7 +41,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/ee/modules/030-cloud-provider-vcd/images/capcd-controller-manager/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-vcd/images/capcd-controller-manager/werf.inc.yaml
@@ -1,9 +1,9 @@
 {{- $version := include "get_oss_version_by_id_and_condition" (list "capi-vcd" (dict "mode" "new") $) }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /cluster-api-provider-cloud-director
   to: /cluster-api-provider-cloud-director
   before: setup
@@ -13,9 +13,9 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 import:
-- image: {{$.ModuleName}}/cloud-controller-manager-src-artifact
+- from: {{$.ModuleName}}/cloud-controller-manager-src-artifact
   add: /src
   to: /src/ccm
   after: install
@@ -40,7 +40,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/ee/modules/030-cloud-provider-vcd/images/cloud-controller-manager-legacy/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-vcd/images/cloud-controller-manager-legacy/werf.inc.yaml
@@ -1,9 +1,9 @@
 {{- $version := include "get_oss_version_by_id_and_condition" (list "ccm-vcd" (dict "mode" "legacy") $) }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /src/bin/cloud-provider-for-cloud-director
   to: /cloud-provider-for-cloud-director
   before: setup
@@ -13,7 +13,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
   to: /patches
@@ -34,7 +34,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-  - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+  - from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
     add: /src
     to: /src
     before: install

--- a/ee/modules/030-cloud-provider-vcd/images/cloud-controller-manager/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-vcd/images/cloud-controller-manager/werf.inc.yaml
@@ -1,9 +1,9 @@
 {{- $version := include "get_oss_version_by_id_and_condition" (list "ccm-vcd" (dict "mode" "new") $) }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /src/bin/cloud-provider-for-cloud-director
   to: /cloud-provider-for-cloud-director
   before: setup
@@ -13,7 +13,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
   to: /patches
@@ -34,7 +34,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-  - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+  - from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
     add: /src
     to: /src
     before: install

--- a/ee/modules/030-cloud-provider-vcd/images/cloud-data-discoverer-legacy/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-vcd/images/cloud-data-discoverer-legacy/werf.inc.yaml
@@ -1,8 +1,8 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /discoverer
   to: /discoverer
   before: setup
@@ -12,7 +12,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
   - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/cloud-data-discoverer/src
     to: /src
@@ -58,7 +58,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/ee/modules/030-cloud-provider-vcd/images/cloud-data-discoverer/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-vcd/images/cloud-data-discoverer/werf.inc.yaml
@@ -1,8 +1,8 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /discoverer
   to: /discoverer
   before: setup
@@ -12,7 +12,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
   - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/src
     to:  /src
@@ -54,7 +54,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/ee/modules/030-cloud-provider-vcd/images/infra-controller-manager-legacy/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-vcd/images/infra-controller-manager-legacy/werf.inc.yaml
@@ -1,8 +1,8 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /infra-controller-manager
   to: /infra-controller-manager
   before: setup
@@ -12,7 +12,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
   - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/infra-controller-manager/src
     to: /src
@@ -49,7 +49,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/ee/modules/030-cloud-provider-vcd/images/infra-controller-manager/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-vcd/images/infra-controller-manager/werf.inc.yaml
@@ -1,8 +1,8 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /infra-controller-manager
   to: /infra-controller-manager
   before: setup
@@ -12,7 +12,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
   - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/src
     to:  /src
@@ -45,7 +45,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/ee/modules/030-cloud-provider-vcd/images/terraform-manager/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-vcd/images/terraform-manager/werf.inc.yaml
@@ -17,7 +17,7 @@ git:
     - '**/*'
 import:
 {{- range $_, $version := $version_map }}
-- image: terraform-provider-vcd-artifact
+- from: terraform-provider-vcd-artifact
   add: /terraform-provider-vcd-v{{ $version }}
   to: /terraform-manager/terraform-provider-vcd-v{{ $version }}
   before: setup
@@ -29,7 +29,7 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ $.ModulePath }}modules/030-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
   to: /patches
@@ -54,7 +54,7 @@ from: {{ index $.Images "builder/golang" }}
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/ee/modules/030-cloud-provider-vcd/images/vcd-csi-plugin-legacy/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-vcd/images/vcd-csi-plugin-legacy/werf.inc.yaml
@@ -1,25 +1,25 @@
 {{- $version := include "get_oss_version_by_id_and_condition" (list "csi-vcd" (dict "mode" "legacy") $) }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /src/bin/cloud-director-named-disk-csi-driver
   to: /cloud-director-named-disk-csi-driver
   before: setup
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /relocate
   to: /
   before: install
   includePaths:
   - '**/*'
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /lib64
   to: /lib64
   before: install
   includePaths:
   - 'libresolv*'
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /lib/udev/scsi_id
   to: /lib/udev/scsi_id
   before: setup
@@ -29,7 +29,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
   to: /patches
@@ -50,7 +50,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install
@@ -72,7 +72,7 @@ shell:
 {{- $csiBinaries := "/bin/chmod /bin/mount /bin/mkdir /bin/rmdir /bin/umount /bin/findmnt /bin/lsblk /sbin/badblocks /sbin/blockdev /sbin/blk* /sbin/btrfs* /sbin/dumpe2fs /sbin/e2* /sbin/findfs /sbin/fsck* /sbin/fsfreeze /sbin/fstrim /sbin/mke2fs /sbin/mkfs* /sbin/resize2fs /sbin/xfs_repair /usr/sbin/nvme /usr/sbin/parted /usr/sbin/xfs*" }}
 image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
 final: false
-fromImage: common/relocate-artifact
+from: common/relocate-artifact
 shell:
   beforeInstall:
   - apt-get update -y

--- a/ee/modules/030-cloud-provider-vcd/images/vcd-csi-plugin/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-vcd/images/vcd-csi-plugin/werf.inc.yaml
@@ -1,25 +1,25 @@
 {{- $version := include "get_oss_version_by_id_and_condition" (list "csi-vcd" (dict "mode" "new") $) }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /src/bin/cloud-director-named-disk-csi-driver
   to: /cloud-director-named-disk-csi-driver
   before: setup
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /relocate
   to: /
   before: install
   includePaths:
   - '**/*'
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /lib64
   to: /lib64
   before: install
   includePaths:
   - 'libresolv*'
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /lib/udev/scsi_id
   to: /lib/udev/scsi_id
   before: setup
@@ -29,7 +29,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
   to: /patches
@@ -50,7 +50,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install
@@ -72,7 +72,7 @@ shell:
 {{- $csiBinaries := "/bin/chmod /bin/mount /bin/mkdir /bin/rmdir /bin/umount /bin/findmnt /bin/lsblk /sbin/badblocks /sbin/blockdev /sbin/blk* /sbin/btrfs* /sbin/dumpe2fs /sbin/e2* /sbin/findfs /sbin/fsck* /sbin/fsfreeze /sbin/fstrim /sbin/mke2fs /sbin/mkfs* /sbin/resize2fs /sbin/xfs_repair /usr/sbin/nvme /usr/sbin/parted /usr/sbin/xfs*" }}
 image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
 final: false
-fromImage: common/relocate-artifact
+from: common/relocate-artifact
 shell:
   beforeInstall:
   - apt-get update -y

--- a/ee/modules/040-node-manager/images/d8-shutdown-inhibitor/werf.inc.yaml
+++ b/ee/modules/040-node-manager/images/d8-shutdown-inhibitor/werf.inc.yaml
@@ -1,7 +1,7 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
   to: /src/scripts
@@ -20,7 +20,7 @@ shell:
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 from: {{ index $.Images "base/scratch" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /
   to: /
   includePaths:
@@ -42,7 +42,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/ee/modules/040-node-manager/images/node-feature-discovery/werf.inc.yaml
+++ b/ee/modules/040-node-manager/images/node-feature-discovery/werf.inc.yaml
@@ -2,7 +2,7 @@
 {{- if ne $.Env "CSE" }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
@@ -24,7 +24,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install
@@ -43,9 +43,9 @@ shell:
   - chmod 0700 /nfd-master /nfd-worker /nfd-gc
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /
   includePaths:
   - nfd-master

--- a/ee/modules/040-node-manager/images/nvidia-container-toolkit/werf.inc.yaml
+++ b/ee/modules/040-node-manager/images/nvidia-container-toolkit/werf.inc.yaml
@@ -2,7 +2,7 @@
 {{- if ne $.Env "CSE" }}
 ---
 image: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 secrets:
 - id: SOURCE_REPO
@@ -15,9 +15,9 @@ shell:
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
 final: false
-fromImage: {{ .ModuleName }}/builder-cuda
+from: {{ .ModuleName }}/builder-cuda
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   before: install
 mount:

--- a/ee/modules/040-node-manager/images/nvidia-dcgm-exporter/werf.inc.yaml
+++ b/ee/modules/040-node-manager/images/nvidia-dcgm-exporter/werf.inc.yaml
@@ -2,7 +2,7 @@
 {{- if ne $.Env "CSE" }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
@@ -23,12 +23,12 @@ shell:
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
 final: false
-fromImage: {{ .ModuleName }}/builder-cuda
+from: {{ .ModuleName }}/builder-cuda
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src
   before: install
-- image: {{ .ModuleName }}/nvidia-dcgm-build-artifact
+- from: {{ .ModuleName }}/nvidia-dcgm-build-artifact
   add: /out
   to: /
   includePaths:
@@ -68,52 +68,52 @@ shell:
     cd /out/lib/x86_64-linux-gnu && for f in libcap.so.2.*; do ln -sf "$f" libcap.so.2; done
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /ldconf
   to: /etc
   includePaths:
   - ld.so.conf
   before: setup
-- image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /ldconf/ld.so.conf.d
   to: /etc/ld.so.conf.d
   includePaths:
   - x86_64-linux-gnu.conf
   before: setup
-- image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /
   to: /usr/bin
   includePaths:
   - dcgm-exporter
   - dcgm-exporter-entrypoint.sh
   before: setup
-- image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /sbin
   to: /sbin
   includePaths:
   - getcap
   - setcap
   before: setup
-- image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /out/lib/x86_64-linux-gnu
   to: /usr/lib/x86_64-linux-gnu
   includePaths:
   - libcap.so.2*
   before: setup
-- image: {{ .ModuleName }}/nvidia-dcgm-build-artifact
+- from: {{ .ModuleName }}/nvidia-dcgm-build-artifact
   add: /out/
   to: /
   includePaths:
   - usr/*
   - lib
   before: setup
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src/etc/*
   to: /etc/dcgm-exporter
   before: setup
-- image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /
   includePaths:
     - lib64

--- a/ee/modules/040-node-manager/images/nvidia-dcgm/werf.inc.yaml
+++ b/ee/modules/040-node-manager/images/nvidia-dcgm/werf.inc.yaml
@@ -4,7 +4,7 @@
 {{- if ne $.Env "CSE" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
@@ -53,14 +53,14 @@ image: {{ .ModuleName }}/{{ .ImageName }}-crosstool-ng-artifact
 final: false
 from: {{ index $.Images "builder/golang-bookworm" }}
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src
   before: install
-- image: {{ .ModuleName }}/{{ .ImageName }}-deps-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-deps-artifact
   add: /deps/crosstool-ng
   to: /deps/crosstool-ng
   before: install
-- image: {{ .ModuleName }}/{{ .ImageName }}-deps-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-deps-artifact
   add: /deps/crosstool-ng-src
   to: /deps/crosstool-ng-src
   before: install
@@ -100,14 +100,14 @@ image: {{ .ModuleName }}/{{ .ImageName }}-chs-artifact
 final: false
 from: {{ index $.Images "builder/golang-bookworm" }}
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src
   before: install
-- image: {{ .ModuleName }}/{{ .ImageName }}-crosstool-ng-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-crosstool-ng-artifact
   add: /opt/cross
   to: /opt/cross
   before: install
-- image: {{ .ModuleName }}/{{ .ImageName }}-deps-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-deps-artifact
   add: /deps/host
   to: /deps/host
   before: install
@@ -137,16 +137,16 @@ shell:
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-build-image-deps-artifact
 final: false
-fromImage: {{ .ModuleName }}/{{ .ImageName }}-chs-artifact
+from: {{ .ModuleName }}/{{ .ImageName }}-chs-artifact
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src
   before: install
-- image: {{ .ModuleName }}/{{ .ImageName }}-deps-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-deps-artifact
   add: /deps/target
   to: /deps/target
   before: install
-- image: {{ .ModuleName }}/{{ .ImageName }}-deps-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-deps-artifact
   add: /deps/nvidia
   to: /deps/nvidia
   before: install
@@ -189,12 +189,12 @@ shell:
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
 final: false
-fromImage: {{ .ModuleName }}/{{ .ImageName }}-chs-artifact
+from: {{ .ModuleName }}/{{ .ImageName }}-chs-artifact
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src
   before: install
-- image: {{ .ModuleName }}/{{ .ImageName }}-build-image-deps-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-build-image-deps-artifact
   add: /tmp/x86_64-linux-gnu
   before: install
 - from: {{ index $.Images "libs/glibc" }}
@@ -204,7 +204,7 @@ import:
   - usr/*
   - lib64/*
   before: install
-- image: {{ .ModuleName }}/{{ .ImageName }}-deps-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-deps-artifact
   add: /deps/nvidia
   to: /deps/nvidia
   before: install
@@ -258,9 +258,9 @@ shell:
     ln -s /usr/lib /out/lib
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /out/
   to: /
   includePaths:

--- a/ee/modules/040-node-manager/images/nvidia-device-plugin/werf.inc.yaml
+++ b/ee/modules/040-node-manager/images/nvidia-device-plugin/werf.inc.yaml
@@ -2,7 +2,7 @@
 {{- if ne $.Env "CSE" }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
@@ -23,9 +23,9 @@ shell:
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
 final: false
-fromImage: {{ .ModuleName }}/builder-cuda
+from: {{ .ModuleName }}/builder-cuda
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   before: install
 mount:
@@ -45,21 +45,21 @@ shell:
   - chmod 0700 /config-manager /gpu-feature-discovery /nvidia-device-plugin
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /
   includePaths:
     - config-manager
     - gpu-feature-discovery
     - nvidia-device-plugin
   before: setup
-- image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /usr/lib64
   includePaths:
     - ld-linux-x86-64.so.2
   before: setup
-- image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /usr/lib/x86_64-linux-gnu
   includePaths:
     - ld-linux-x86-64.so.2
@@ -70,7 +70,7 @@ import:
     - libdl.so.2
     - libm.so.6
   before: setup
-- image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /
   includePaths:
     - lib64

--- a/ee/modules/040-node-manager/images/nvidia-mig-manager/werf.inc.yaml
+++ b/ee/modules/040-node-manager/images/nvidia-mig-manager/werf.inc.yaml
@@ -7,20 +7,20 @@
   {{- $kubectl_version  := printf "%s.%s" $version $patch | replace "." "-" }}
 ---
 image: {{ $.ModuleName }}/nvidia-mig-manager-{{ $image_version }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-build-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-build-artifact-{{ $image_version }}
   add: /usr/bin
   includePaths:
     - nvidia-mig-parted
     - nvidia-mig-manager
   before: setup
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-build-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-build-artifact-{{ $image_version }}
   add: /usr/lib64
   includePaths:
     - ld-linux-x86-64.so.2
   before: setup
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-build-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-build-artifact-{{ $image_version }}
   add: /usr/lib/x86_64-linux-gnu
   includePaths:
     - ld-linux-x86-64.so.2
@@ -31,13 +31,13 @@ import:
     - libdl.so.2
     - libm.so.6
   before: setup
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-build-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-build-artifact-{{ $image_version }}
   add: /
   includePaths:
     - lib64
     - lib
   before: setup
-- image: {{ $.ModuleName }}/nvidia-container-toolkit-build-artifact
+- from: {{ $.ModuleName }}/nvidia-container-toolkit-build-artifact
   add: /usr/bin/nvidia-ctk
   to: /usr/bin/nvidia-ctk
   before: setup
@@ -51,7 +51,7 @@ import:
   includePaths:
   - usr/bin/*
   before: setup
-- image: common/kubernetes-artifact-{{ $kubectl_version }}
+- from: common/kubernetes-artifact-{{ $kubectl_version }}
   add: /src/_output/bin/kubectl
   to: /usr/bin/kubectl
   before: setup
@@ -61,7 +61,7 @@ import:
   after: setup
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 secrets:
 - id: SOURCE_REPO
@@ -74,9 +74,9 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-build-artifact-{{ $image_version }}
 final: false
-fromImage: {{ $.ModuleName }}/builder-cuda
+from: {{ $.ModuleName }}/builder-cuda
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
   add: /src
   before: install
 mount:

--- a/ee/modules/040-terraform-manager/images/terraform-manager-dynamix/werf.inc.yaml
+++ b/ee/modules/040-terraform-manager/images/terraform-manager-dynamix/werf.inc.yaml
@@ -1,11 +1,11 @@
 {{- if not (and (index . "HasAvailableModules") (not (hasKey (index . "AvailableModulesDict") "cloud-provider-dynamix"))) }}
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: '{{- include "infrastructure_manager_base_image" (dict "TF" .TF "providerName" "decort") -}}'
+from: '{{- include "infrastructure_manager_base_image" (dict "TF" .TF "providerName" "decort") -}}'
 git:
   - add: /{{ .ModulePath }}modules/030-cloud-provider-dynamix/candi
     to: /deckhouse/candi/cloud-providers/dynamix
 import:
-  - image: cloud-provider-dynamix/terraform-manager
+  - from: cloud-provider-dynamix/terraform-manager
     add: /terraform-manager/terraform-provider-decort
     to: /plugins/{{ include "infrastructure_manager_plugin_dir" (dict "TF" .TF "providerName" "decort") }}/{{ .TF.decort.namespace }}/{{ .TF.decort.type }}/{{ .TF.decort.version }}/linux_amd64/terraform-provider-decort
     before: setup

--- a/ee/modules/040-terraform-manager/images/terraform-manager-huaweicloud/werf.inc.yaml
+++ b/ee/modules/040-terraform-manager/images/terraform-manager-huaweicloud/werf.inc.yaml
@@ -1,11 +1,11 @@
 {{- if not (and (index . "HasAvailableModules") (not (hasKey (index . "AvailableModulesDict") "cloud-provider-huaweicloud"))) }}
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: '{{- include "infrastructure_manager_base_image" (dict "TF" .TF "providerName" "huaweicloud") }}'
+from: '{{- include "infrastructure_manager_base_image" (dict "TF" .TF "providerName" "huaweicloud") }}'
 git:
   - add: /{{ .ModulePath }}modules/030-cloud-provider-huaweicloud/candi
     to: /deckhouse/candi/cloud-providers/huaweicloud
 import:
-  - image: cloud-provider-huaweicloud/terraform-manager
+  - from: cloud-provider-huaweicloud/terraform-manager
     add: /terraform-manager/terraform-provider-huaweicloud
     to: /plugins/{{ include "infrastructure_manager_plugin_dir" (dict "TF" .TF "providerName" "huaweicloud") }}/{{ .TF.huaweicloud.namespace }}/{{ .TF.huaweicloud.type }}/{{ .TF.huaweicloud.version }}/linux_amd64/terraform-provider-huaweicloud
     before: setup

--- a/ee/modules/040-terraform-manager/images/terraform-manager-openstack/werf.inc.yaml
+++ b/ee/modules/040-terraform-manager/images/terraform-manager-openstack/werf.inc.yaml
@@ -1,11 +1,11 @@
 {{- if not (and (index . "HasAvailableModules") (not (hasKey (index . "AvailableModulesDict") "cloud-provider-openstack"))) }}
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: '{{- include "infrastructure_manager_base_image" (dict "TF" .TF "providerName" "openstack") }}'
+from: '{{- include "infrastructure_manager_base_image" (dict "TF" .TF "providerName" "openstack") }}'
 git:
 - add: /{{ .ModulePath }}modules/030-cloud-provider-openstack/candi
   to: /deckhouse/candi/cloud-providers/openstack
 import:
-- image: cloud-provider-openstack/terraform-manager
+- from: cloud-provider-openstack/terraform-manager
   add: /terraform-manager/terraform-provider-openstack
   to: /plugins/{{ include "infrastructure_manager_plugin_dir" (dict "TF" .TF "providerName" "openstack") }}/{{ .TF.openstack.namespace }}/{{ .TF.openstack.type }}/{{ .TF.openstack.version }}/linux_amd64/terraform-provider-openstack
   before: setup

--- a/ee/modules/040-terraform-manager/images/terraform-manager-vcd/werf.inc.yaml
+++ b/ee/modules/040-terraform-manager/images/terraform-manager-vcd/werf.inc.yaml
@@ -1,13 +1,13 @@
 ---
 {{- if not (and (index . "HasAvailableModules") (not (hasKey (index . "AvailableModulesDict") "cloud-provider-vcd"))) }}
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: '{{- include "infrastructure_manager_base_image" (dict "TF" .TF "providerName" "vcd") }}'
+from: '{{- include "infrastructure_manager_base_image" (dict "TF" .TF "providerName" "vcd") }}'
 git:
 - add: /{{ .ModulePath }}modules/030-cloud-provider-vcd/candi
   to: /deckhouse/candi/cloud-providers/vcd
 import:
 {{- range $version := .TF.vcd.versions }}
-- image: cloud-provider-vcd/terraform-manager
+- from: cloud-provider-vcd/terraform-manager
   add: /terraform-manager/terraform-provider-vcd-v{{ $version }}
   to: /plugins/{{ include "infrastructure_manager_plugin_dir" (dict "TF" $.TF "providerName" "vcd") }}/{{ $.TF.vcd.namespace }}/{{ $.TF.vcd.type }}/{{ $version }}/linux_amd64/terraform-provider-vcd
   before: setup

--- a/ee/modules/110-istio/images/alliance-healthcheck/werf.inc.yaml
+++ b/ee/modules/110-istio/images/alliance-healthcheck/werf.inc.yaml
@@ -1,8 +1,8 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /src/alliance-healthcheck
   to: /alliance-healthcheck
   owner: "64535"
@@ -16,7 +16,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src
   to: /src
   before: install
@@ -39,7 +39,7 @@ shell:
   - chown -R 64535:64535 /src/alliance-healthcheck
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/src

--- a/ee/modules/110-istio/images/api-proxy/werf.inc.yaml
+++ b/ee/modules/110-istio/images/api-proxy/werf.inc.yaml
@@ -1,8 +1,8 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /src/api-proxy
   to: /api-proxy
   owner: "64535"
@@ -17,7 +17,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src
   to: /src
   before: install
@@ -40,7 +40,7 @@ shell:
   - chown -R 64535:64535 /src/api-proxy
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/src

--- a/ee/modules/110-istio/images/config-analyzer-v1x21x6/werf.inc.yaml
+++ b/ee/modules/110-istio/images/config-analyzer-v1x21x6/werf.inc.yaml
@@ -4,9 +4,9 @@
 {{- $istioImageVersion := (printf "v%s" (replace "." "x" $istioVersion)) }} {{- /* 1.21.6 -> v1x21x6 */}}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /src/istio/out/istio-config-analyzer
   to: /istio-config-analyzer
   owner: 64535
@@ -29,7 +29,7 @@ git:
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-- image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
+- from: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
   add: /src/istio
   to: /src/istio
   before: install

--- a/ee/modules/110-istio/images/config-analyzer-v1x25x2/werf.inc.yaml
+++ b/ee/modules/110-istio/images/config-analyzer-v1x25x2/werf.inc.yaml
@@ -4,9 +4,9 @@
 {{- $istioImageVersion := (printf "v%s" (replace "." "x" $istioVersion)) }} {{- /* 1.25.2 -> v1x25x2 */}}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /src/istio/out/istio-config-analyzer
   to: /istio-config-analyzer
   owner: 64535
@@ -29,7 +29,7 @@ git:
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-- image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
+- from: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
   add: /src/istio
   to: /src/istio
   before: install

--- a/ee/modules/110-istio/images/config-analyzer-v1x27x9/werf.inc.yaml
+++ b/ee/modules/110-istio/images/config-analyzer-v1x27x9/werf.inc.yaml
@@ -4,9 +4,9 @@
 {{- $istioImageVersion := (printf "v%s" (replace "." "x" $istioVersion)) }} {{- /* 1.27.9 -> v1x27x9 */}}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /src/istio/out/istio-config-analyzer
   to: /istio-config-analyzer
   owner: 64535
@@ -29,7 +29,7 @@ git:
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-- image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
+- from: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
   add: /src/istio
   to: /src/istio
   before: install

--- a/ee/modules/110-istio/images/metadata-exporter/werf.inc.yaml
+++ b/ee/modules/110-istio/images/metadata-exporter/werf.inc.yaml
@@ -1,8 +1,8 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /src/metadata-exporter
   to: /metadata-exporter
   owner: "64535"
@@ -22,7 +22,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src
   to: /src
   before: install
@@ -45,7 +45,7 @@ shell:
   - chown -R 64535:64535 /src/metadata-exporter
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/src

--- a/ee/modules/110-istio/images/metrics-exporter/werf.inc.yaml
+++ b/ee/modules/110-istio/images/metrics-exporter/werf.inc.yaml
@@ -1,8 +1,8 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /src/monitor
   to: /monitor
   after: setup
@@ -14,7 +14,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src
   to: /src
   before: install
@@ -37,7 +37,7 @@ shell:
   - chown -R 64535:64535 /src/monitor
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/src

--- a/ee/modules/110-istio/images/waypoint-controller/werf.inc.yaml
+++ b/ee/modules/110-istio/images/waypoint-controller/werf.inc.yaml
@@ -2,7 +2,7 @@
 image: {{ .ModuleName }}/{{ .ImageName }}
 from: {{ index $.Images "base/distroless" }}
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /waypoint-controller
   to: /waypoint-controller
   before: install

--- a/ee/modules/110-istio/images/ztunnel-v1x25x2/werf.inc.yaml
+++ b/ee/modules/110-istio/images/ztunnel-v1x25x2/werf.inc.yaml
@@ -1,9 +1,9 @@
 {{- $istioVersion := "1.25.2" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-  - image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+  - from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
     add: /src/ztunnel/bin/ztunnel
     to: /usr/local/bin/ztunnel
     owner: 1337
@@ -32,15 +32,15 @@ import:
 imageSpec:
   config:
     user: "1337:1337"
-    env:  
+    env:
       ISTIO_META_ISTIO_VERSION: {{ $istioVersion }}
     entrypoint: ["/usr/local/bin/ztunnel"]
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
-fromImage: common/alt-p11-artifact
+from: common/alt-p11-artifact
 final: false
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src/ztunnel
   to: /src/ztunnel
   before: install
@@ -68,14 +68,14 @@ shell:
   - echo "StrictHostKeyChecking accept-new" > ~/.ssh/config
   - |
     cargo build \
-    --release 
+    --release
   - strip /src/ztunnel/out/rust/release/ztunnel
   - mkdir -p /src/ztunnel/bin
   - mv /src/ztunnel/out/rust/release/ztunnel /src/ztunnel/bin/ztunnel
 #=====================================================================================================
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - url: {{ .SOURCE_REPO }}/istio/ztunnel

--- a/ee/modules/110-istio/images/ztunnel-v1x27x9/werf.inc.yaml
+++ b/ee/modules/110-istio/images/ztunnel-v1x27x9/werf.inc.yaml
@@ -2,9 +2,9 @@
 {{- $istioVersion := "1.27.9" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-  - image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+  - from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
     add: /src/ztunnel/bin/ztunnel
     to: /usr/local/bin/ztunnel
     owner: 1337
@@ -33,15 +33,15 @@ import:
 imageSpec:
   config:
     user: "1337:1337"
-    env:  
+    env:
       ISTIO_META_ISTIO_VERSION: {{ $istioVersion }}
     entrypoint: ["/usr/local/bin/ztunnel"]
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
-fromImage: common/alt-p11-artifact
+from: common/alt-p11-artifact
 final: false
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src/ztunnel
   to: /src/ztunnel
   before: install
@@ -69,14 +69,14 @@ shell:
   - echo "StrictHostKeyChecking accept-new" > ~/.ssh/config
   - |
     cargo build \
-    --release 
+    --release
   - strip /src/ztunnel/out/rust/release/ztunnel
   - mkdir -p /src/ztunnel/bin
   - mv /src/ztunnel/out/rust/release/ztunnel /src/ztunnel/bin/ztunnel
 #=====================================================================================================
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - url: {{ .SOURCE_REPO }}/istio/ztunnel

--- a/ee/modules/380-metallb/images/metallb/werf.inc.yaml
+++ b/ee/modules/380-metallb/images/metallb/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ .ModulePath }}modules/380-{{ .ModuleName }}/images/{{ .ImageName }}/patches
@@ -23,7 +23,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src
   to: /src
   before: install
@@ -47,9 +47,9 @@ shell:
   - chmod 0755 /speaker
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-controller
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-artifact
   add: /controller
   to: /controller
   before: setup
@@ -58,9 +58,9 @@ imageSpec:
     entrypoint: ["/controller"]
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-speaker
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-artifact
   add: /speaker
   to: /speaker
   before: setup

--- a/ee/modules/450-keepalived/images/keepalived/werf.inc.yaml
+++ b/ee/modules/450-keepalived/images/keepalived/werf.inc.yaml
@@ -1,7 +1,7 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 secrets:
 - id: SOURCE_REPO
   value: {{ .SOURCE_REPO }}
@@ -14,7 +14,7 @@ image: {{ .ModuleName }}/build-keepalived
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install
@@ -51,20 +51,20 @@ shell:
   - pip3 install -f file:///wheels --no-index -r /requirements.txt
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 git:
 - add: /{{ $.ModulePath }}modules/450-{{ $.ModuleName }}/images/{{ $.ImageName }}/src/prepare-config.py
   to: /prepare-config.py
 import:
-- image: {{ $.ModuleName }}/build-keepalived
+- from: {{ $.ModuleName }}/build-keepalived
   add: /opt/keepalived-static/usr/sbin/keepalived
   to: /usr/sbin/keepalived
   before: install
-- image: {{ $.ModuleName }}/build-keepalived
+- from: {{ $.ModuleName }}/build-keepalived
   add: /opt/keepalived-static/usr/bin/genhash
   to: /usr/bin/genhash
   before: install
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-wheel-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-wheel-artifact
   add: /
   to: /
   before: install

--- a/ee/modules/450-network-gateway/images/dnsmasq/werf.inc.yaml
+++ b/ee/modules/450-network-gateway/images/dnsmasq/werf.inc.yaml
@@ -17,7 +17,7 @@ git:
     install:
     - '**/*'
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-artifact
   add: /out
   to: /
   before: install

--- a/ee/modules/450-network-gateway/images/iptables-wrapper-init/werf.inc.yaml
+++ b/ee/modules/450-network-gateway/images/iptables-wrapper-init/werf.inc.yaml
@@ -2,7 +2,7 @@
 {{- $iptables_image_version := $iptables_version | replace "." "-" }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
 - from: {{ index $.Images "tools/coreutils" }}
   add: /
@@ -15,18 +15,18 @@ import:
   add: /usr/bin/bash
   to: /bin/bash
   before: setup
-- image: common/iptables-wrapper
+- from: common/iptables-wrapper
   add: /iptables-wrapper
   to: /iptables-wrapper
   before: setup
-- image: registrypackages/iptables-artifact-{{ $iptables_image_version }}
+- from: registrypackages/iptables-artifact-{{ $iptables_image_version }}
   add: /
   to: /_sbin
   includePaths:
   - xtables-legacy-multi
   - xtables-nft-multi
   before: setup
-- image: {{ .ModuleName }}/{{ .ImageName }}-relocate-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-relocate-artifact
   add: /relocate
   to: /relocate
   before: setup

--- a/ee/modules/450-network-gateway/images/snat/werf.inc.yaml
+++ b/ee/modules/450-network-gateway/images/snat/werf.inc.yaml
@@ -12,7 +12,7 @@ git:
 - add: /{{ $.ModulePath }}modules/450-{{ $.ModuleName }}/images/{{ $.ImageName }}/src/iptables-loop.py
   to: /iptables-loop.py
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-artifact
   add: /out
   to: /
   before: setup

--- a/ee/modules/610-service-with-healthchecks/images/agent/werf.inc.yaml
+++ b/ee/modules/610-service-with-healthchecks/images/agent/werf.inc.yaml
@@ -1,8 +1,8 @@
 ---
 image: {{ $.ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-  - image: {{ $.ModuleName }}/service-with-healthchecks-build-artifact
+  - from: {{ $.ModuleName }}/service-with-healthchecks-build-artifact
     add: /agent
     to: /agent
     before: install

--- a/ee/modules/610-service-with-healthchecks/images/artifact/werf.inc.yaml
+++ b/ee/modules/610-service-with-healthchecks/images/artifact/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ .ModuleName }}/service-with-healthchecks-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
   - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}
@@ -23,7 +23,7 @@ from: {{ index $.Images "builder/golang" }}
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-  - image: {{ .ModuleName }}/service-with-healthchecks-src-artifact
+  - from: {{ .ModuleName }}/service-with-healthchecks-src-artifact
     add: /src
     to: /src
     before: install

--- a/ee/modules/610-service-with-healthchecks/images/controller/werf.inc.yaml
+++ b/ee/modules/610-service-with-healthchecks/images/controller/werf.inc.yaml
@@ -1,8 +1,8 @@
 ---
 image: {{ $.ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-  - image: {{ $.ModuleName }}/service-with-healthchecks-build-artifact
+  - from: {{ $.ModuleName }}/service-with-healthchecks-build-artifact
     add: /controller
     to: /controller
     before: install

--- a/ee/se-plus/modules/015-admission-policy-engine/images/ratify/werf.inc.yaml
+++ b/ee/se-plus/modules/015-admission-policy-engine/images/ratify/werf.inc.yaml
@@ -1,9 +1,9 @@
 {{ $ratifyVersion := include "get_oss_version_by_id" (list "ratify" $ ) }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /ratify
   to: /ratify
   before: setup
@@ -13,7 +13,7 @@ imageSpec:
     entrypoint: [ "/ratify" ]
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ $.ModulePath }}modules/015-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
@@ -27,7 +27,7 @@ git:
     install:
     - '**/*'
   includePaths:
-  - ratify/*.yaml    
+  - ratify/*.yaml
 secrets:
 - id: SOURCE_REPO
   value: {{ .SOURCE_REPO }}
@@ -38,15 +38,15 @@ shell:
   - git apply /patches/*.patch --verbose --allow-empty
   - rm -rf .git
   # check if module crds/ratify are the same as ratify crds
-  - | 
+  - |
     echo "Checking if module crds/ratify are the same as ratify crds"
-    diff -qr "/src/config/crd/bases" "/module_crds/ratify"   
+    diff -qr "/src/config/crd/bases" "/module_crds/ratify"
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 from: {{ index $.Images "builder/golang-1.26" }}
 final: false
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/ee/se-plus/modules/021-cni-cilium/images/egress-gateway-agent/werf.inc.yaml
+++ b/ee/se-plus/modules/021-cni-cilium/images/egress-gateway-agent/werf.inc.yaml
@@ -1,7 +1,7 @@
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-  - image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+  - from: {{ .ModuleName }}/{{ .ImageName }}-artifact
     add: /egress-gateway-agent
     to: /egress-gateway-agent
     before: setup
@@ -10,7 +10,7 @@ imageSpec:
     entrypoint: ["/egress-gateway-agent"]
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/src
@@ -27,7 +27,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/images/cloud-controller-manager/werf.inc.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/images/cloud-controller-manager/werf.inc.yaml
@@ -11,9 +11,9 @@
     {{- end }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
   add: /vsphere-cloud-controller-manager
   to: /bin/vsphere-cloud-controller-manager
   before: setup
@@ -22,7 +22,7 @@ imageSpec:
     entrypoint: ["/bin/vsphere-cloud-controller-manager"]
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 {{- if $patch }}
 git:
@@ -48,7 +48,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
   add: /src
   to: /src
   before: install

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/images/cloud-data-discoverer/werf.inc.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/images/cloud-data-discoverer/werf.inc.yaml
@@ -1,8 +1,8 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /discoverer
   to: /discoverer
   before: setup
@@ -12,7 +12,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/src
   to:  /src
@@ -65,7 +65,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/images/csi-vsphere-syncer/werf.inc.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/images/csi-vsphere-syncer/werf.inc.yaml
@@ -11,9 +11,9 @@
       {{- if ne $.Env "CSE" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
   add: /src/vsphere-syncer
   to: /bin/vsphere-syncer
   before: setup
@@ -22,7 +22,7 @@ imageSpec:
     entrypoint: ["/bin/vsphere-syncer"]
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
     {{- if $patch }}
 git:
@@ -50,7 +50,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
   add: /src
   to: /src
   before: install

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/images/terraform-manager/werf.inc.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/images/terraform-manager/werf.inc.yaml
@@ -16,7 +16,7 @@ git:
     install:
     - '**/*'
 import:
-- image: terraform-provider-vsphere
+- from: terraform-provider-vsphere
   add: /terraform-provider-vsphere
   to: /terraform-manager/terraform-provider-vsphere
   before: setup
@@ -27,7 +27,7 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 fromCacheVersion: "2025-02-05.03"
 git:
 - add: /{{ $.ModulePath }}modules/030-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
@@ -52,7 +52,7 @@ from: {{ index $.Images "builder/golang" }}
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/images/vsphere-csi-plugin-legacy/werf.inc.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/images/vsphere-csi-plugin-legacy/werf.inc.yaml
@@ -2,13 +2,13 @@
 {{- $csi_commit := "6189afc2522d83a96d3857110c61478710110347" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-csi-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-csi-artifact
   add: /src/vsphere-csi
   to: /bin/vsphere-csi
   before: setup
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /relocate
   to: /
   before: install
@@ -20,7 +20,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ $.ModulePath }}modules/030-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
   to: /patches
@@ -46,7 +46,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-csi-artifact
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install
@@ -67,7 +67,7 @@ shell:
 {{- $csiBinaries := "/bin/chmod /bin/mount /bin/mkdir /bin/rmdir /bin/umount /bin/findmnt /bin/lsblk /sbin/badblocks /sbin/blockdev /sbin/blk* /sbin/btrfs* /sbin/dumpe2fs /sbin/e2* /sbin/findfs /sbin/fsck* /sbin/fsfreeze /sbin/fstrim /sbin/mke2fs /sbin/mkfs* /sbin/resize2fs /usr/sbin/parted /usr/sbin/xfs* /sbin/mount.nfs* /sbin/umount.nfs*" }}
 image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
 final: false
-fromImage: common/relocate-artifact
+from: common/relocate-artifact
 shell:
   beforeInstall:
   - apt-get update -y

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/images/vsphere-csi-plugin/werf.inc.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/images/vsphere-csi-plugin/werf.inc.yaml
@@ -11,13 +11,13 @@
     {{- end }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
   add: /src/vsphere-csi
   to: /bin/vsphere-csi
   before: setup
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /relocate
   to: /
   before: install
@@ -28,7 +28,7 @@ imageSpec:
     entrypoint: ["/bin/vsphere-csi"]
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 {{- if $patch }}
 git:
@@ -56,7 +56,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
   add: /src
   to: /src
   before: install
@@ -80,7 +80,7 @@ shell:
 {{- $csiBinaries := "/bin/chmod /bin/mount /bin/mkdir /bin/rmdir /bin/umount /bin/findmnt /bin/lsblk /sbin/badblocks /sbin/blockdev /sbin/blk* /sbin/btrfs* /sbin/dumpe2fs /sbin/e2* /sbin/findfs /sbin/fsck* /sbin/fsfreeze /sbin/fstrim /sbin/mke2fs /sbin/mkfs* /sbin/resize2fs /usr/sbin/parted /usr/sbin/xfs* /sbin/mount.nfs* /sbin/umount.nfs*" }}
 image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
 final: false
-fromImage: common/relocate-artifact
+from: common/relocate-artifact
 shell:
   beforeInstall:
   - apt-get update -y

--- a/ee/se-plus/modules/030-cloud-provider-zvirt/images/capz-controller-manager/werf.inc.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-zvirt/images/capz-controller-manager/werf.inc.yaml
@@ -1,19 +1,19 @@
 {{- $version := "v0.0.1-flant" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/distroless
+from: common/distroless
 imageSpec:
   config:
     entrypoint: ["/capz-controller-manager"]
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /capz-controller-manager
   to: /capz-controller-manager
   before: setup
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/src
   to:  /src
@@ -35,7 +35,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/ee/se-plus/modules/030-cloud-provider-zvirt/images/cloud-controller-manager/werf.inc.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-zvirt/images/cloud-controller-manager/werf.inc.yaml
@@ -1,9 +1,9 @@
 {{- $version := "v0.0.1-flant" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-  - image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+  - from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
     add: /zvirt-cloud-controller-manager
     to: /zvirt-cloud-controller-manager
     before: setup
@@ -13,7 +13,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
   - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/src
     to:  /src
@@ -38,7 +38,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-  - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+  - from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
     add: /src
     to: /src
     before: install

--- a/ee/se-plus/modules/030-cloud-provider-zvirt/images/cloud-data-discoverer/werf.inc.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-zvirt/images/cloud-data-discoverer/werf.inc.yaml
@@ -1,9 +1,9 @@
 {{- $version := "v0.0.1-flant" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /discoverer
   to: /discoverer
   before: setup
@@ -13,7 +13,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/src
   to:  /src
@@ -63,7 +63,7 @@ secrets:
 - id: GOPROXY
   value: {{ .GOPROXY }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/ee/se-plus/modules/030-cloud-provider-zvirt/images/terraform-manager/werf.inc.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-zvirt/images/terraform-manager/werf.inc.yaml
@@ -16,7 +16,7 @@ git:
     install:
     - '**/*'
 import:
-  - image: terraform-provider-ovirt
+  - from: terraform-provider-ovirt
     add: /terraform-provider-ovirt
     to: /terraform-manager/terraform-provider-ovirt
     before: setup
@@ -27,7 +27,7 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ $.ModulePath }}modules/030-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
   to: /patches
@@ -50,7 +50,7 @@ from: {{ index $.Images "builder/golang" }}
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/ee/se-plus/modules/030-cloud-provider-zvirt/images/zvirt-csi-driver/werf.inc.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-zvirt/images/zvirt-csi-driver/werf.inc.yaml
@@ -3,25 +3,25 @@
 {{- $go_ovirt_client_version := "v3.2.0-flant-1" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /ovirt-csi-driver
   to: /ovirt-csi-driver
   before: setup
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /relocate
   to: /
   before: install
   includePaths:
   - '**/*'
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /lib64
   to: /lib64
   before: install
   includePaths:
   - 'libresolv*'
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /lib/udev/scsi_id
   to: /lib/udev/scsi_id
   before: setup
@@ -36,7 +36,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
   to: /patches
@@ -63,7 +63,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-  - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+  - from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
     add: /src
     to: /src
     before: install
@@ -83,7 +83,7 @@ shell:
 {{- $csiBinaries := "/bin/chmod /bin/mount /bin/mkdir /bin/rmdir /bin/umount /bin/findmnt /sbin/badblocks /sbin/blockdev /sbin/blk* /sbin/btrfs* /sbin/dumpe2fs /sbin/e2* /sbin/findfs /sbin/fsck* /sbin/fsfreeze /sbin/fstrim /sbin/mke2fs /sbin/mkfs* /sbin/resize2fs /sbin/xfs_repair /usr/sbin/nvme /usr/sbin/parted /usr/sbin/xfs*" }}
 image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
 final: false
-fromImage: common/relocate-artifact
+from: common/relocate-artifact
 shell:
   beforeInstall:
   {{- include "alt packages proxy" . | nindent 2 }}

--- a/ee/se-plus/modules/040-terraform-manager/images/terraform-manager-vsphere/werf.inc.yaml
+++ b/ee/se-plus/modules/040-terraform-manager/images/terraform-manager-vsphere/werf.inc.yaml
@@ -1,11 +1,11 @@
 {{- if not (and (index . "HasAvailableModules") (not (hasKey (index . "AvailableModulesDict") "cloud-provider-vsphere"))) }}
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: '{{- include "infrastructure_manager_base_image" (dict "TF" .TF "providerName" "vsphere") }}'
+from: '{{- include "infrastructure_manager_base_image" (dict "TF" .TF "providerName" "vsphere") }}'
 git:
 - add: /{{ .ModulePath }}modules/030-cloud-provider-vsphere/candi
   to: /deckhouse/candi/cloud-providers/vsphere
 import:
-- image: cloud-provider-vsphere/terraform-manager
+- from: cloud-provider-vsphere/terraform-manager
   add: /terraform-manager/terraform-provider-vsphere
   to: /plugins/{{ include "infrastructure_manager_plugin_dir" (dict "TF" .TF "providerName" "vsphere") }}/{{ .TF.vsphere.namespace }}/{{ .TF.vsphere.type }}/{{ .TF.vsphere.version }}/linux_amd64/terraform-provider-vsphere
   before: setup

--- a/ee/se-plus/modules/040-terraform-manager/images/terraform-manager-zvirt/werf.inc.yaml
+++ b/ee/se-plus/modules/040-terraform-manager/images/terraform-manager-zvirt/werf.inc.yaml
@@ -1,11 +1,11 @@
 {{- if not (and (index . "HasAvailableModules") (not (hasKey (index . "AvailableModulesDict") "cloud-provider-zvirt"))) }}
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: '{{- include "infrastructure_manager_base_image" (dict "TF" .TF "providerName" "ovirt") }}'
+from: '{{- include "infrastructure_manager_base_image" (dict "TF" .TF "providerName" "ovirt") }}'
 git:
   - add: /{{ .ModulePath }}modules/030-cloud-provider-zvirt/candi
     to: /deckhouse/candi/cloud-providers/zvirt
 import:
-  - image: cloud-provider-zvirt/terraform-manager
+  - from: cloud-provider-zvirt/terraform-manager
     add: /terraform-manager/terraform-provider-ovirt
     to: /plugins/{{ include "infrastructure_manager_plugin_dir" (dict "TF" .TF "providerName" "ovirt") }}/{{ .TF.ovirt.namespace }}/{{ .TF.ovirt.type }}/{{ .TF.ovirt.version }}/linux_amd64/terraform-provider-ovirt
     before: setup

--- a/ee/se/modules/380-metallb/images/l2lb/werf.inc.yaml
+++ b/ee/se/modules/380-metallb/images/l2lb/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ .ModulePath }}modules/380-{{ .ModuleName }}/images/{{ .ImageName }}/patches
@@ -28,7 +28,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src
   to: /src
   before: install
@@ -52,9 +52,9 @@ shell:
   - chmod 0755 /speaker
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-controller
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-artifact
   add: /controller
   to: /controller
   before: setup
@@ -63,13 +63,13 @@ imageSpec:
     entrypoint: ["/controller"]
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-speaker
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-artifact
   add: /speaker
   to: /speaker
   before: setup
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /configs/excludel2.yaml
   to: /etc/metallb/excludel2.yaml
   before: setup

--- a/modules/000-common/images/check-kernel-version/werf.inc.yaml
+++ b/modules/000-common/images/check-kernel-version/werf.inc.yaml
@@ -1,8 +1,8 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /src/check-kernel-version
   to: /check-kernel-version
   before: setup
@@ -11,7 +11,7 @@ imageSpec:
     entrypoint: [ "/check-kernel-version" ]
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/src
@@ -27,7 +27,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/modules/000-common/images/cni-migration-controller/werf.inc.yaml
+++ b/modules/000-common/images/cni-migration-controller/werf.inc.yaml
@@ -18,18 +18,18 @@ image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-  - image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+  - from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
     add: /src
     to: /src
     before: install
-  - image: registrypackages/iptables-artifact-{{ $iptables_image_version }}
+  - from: registrypackages/iptables-artifact-{{ $iptables_image_version }}
     add: /
     to: /relocate/sbin
     includePaths:
       - xtables-legacy-multi
       - xtables-nft-multi
     before: install
-  - image: common/iptables-wrapper
+  - from: common/iptables-wrapper
     add: /iptables-wrapper
     to: /relocate/sbin/iptables-wrapper
     before: install
@@ -67,15 +67,15 @@ shell:
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 from: {{ index $.Images "base/distroless" }}
 import:
-  - image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+  - from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
     add: /cni-migration-controller
     to: /cni-migration-controller
     before: setup
-  - image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+  - from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
     add: /relocate/sbin
     to: /sbin
     before: setup
-  - image: cni-cilium/agent-distroless
+  - from: cni-cilium/agent-distroless
     add: /usr/bin/cilium-dbg
     to: /sbin/cilium-dbg
     before: setup

--- a/modules/000-common/images/cni-migration-init-checker/werf.inc.yaml
+++ b/modules/000-common/images/cni-migration-init-checker/werf.inc.yaml
@@ -16,7 +16,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-  - image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+  - from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
     add: /src
     to: /src
     before: install
@@ -39,7 +39,7 @@ shell:
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 from: {{ index $.Images "base/distroless" }}
 import:
-  - image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+  - from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
     add: /cni-migration-init-checker
     to: /cni-migration-init-checker
     before: setup

--- a/modules/000-common/images/coredns/werf.inc.yaml
+++ b/modules/000-common/images/coredns/werf.inc.yaml
@@ -2,7 +2,7 @@
 {{- $kubeforward_version := "0.3.0" }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ $.ModulePath }}modules/{{ .ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
@@ -28,7 +28,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-  - image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+  - from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
     add: /src
     to: /src
     before: install
@@ -49,9 +49,9 @@ shell:
     - chmod 0700 /coredns
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-artifact
   add: /coredns
   to: /coredns
   before: setup

--- a/modules/000-common/images/crane/werf.inc.yaml
+++ b/modules/000-common/images/crane/werf.inc.yaml
@@ -3,7 +3,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}
 from: {{ index $.Images "builder/scratch" }}
 final: false
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-artifact
   add: /crane
   to: /crane
   before: install

--- a/modules/000-common/images/csi-external-attacher/werf.inc.yaml
+++ b/modules/000-common/images/csi-external-attacher/werf.inc.yaml
@@ -12,9 +12,9 @@
     {{- end }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $version | replace "." "-" }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
   add: /csi-attacher
   to: /csi-attacher
   before: setup
@@ -24,7 +24,7 @@ imageSpec:
     entrypoint: ["/csi-attacher"]
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $version | replace "." "-" }}
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
     {{- if $patch }}
 git:
@@ -53,7 +53,7 @@ final: false
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $version | replace "." "-" }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $version | replace "." "-" }}
   add: /src
   to: /src
   before: install

--- a/modules/000-common/images/csi-external-provisioner/werf.inc.yaml
+++ b/modules/000-common/images/csi-external-provisioner/werf.inc.yaml
@@ -12,9 +12,9 @@
     {{- end }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $version | replace "." "-" }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
   add: /csi-provisioner
   to: /csi-provisioner
   before: setup
@@ -24,7 +24,7 @@ imageSpec:
     entrypoint: ["/csi-provisioner"]
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $version | replace "." "-" }}
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
     {{- if $patch }}
 git:
@@ -53,7 +53,7 @@ final: false
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $version | replace "." "-" }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $version | replace "." "-" }}
   add: /src
   to: /src
   before: install

--- a/modules/000-common/images/csi-external-resizer/werf.inc.yaml
+++ b/modules/000-common/images/csi-external-resizer/werf.inc.yaml
@@ -12,9 +12,9 @@
     {{- end }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $version | replace "." "-" }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
   add: /csi-resizer
   to: /csi-resizer
   before: setup
@@ -24,7 +24,7 @@ imageSpec:
     entrypoint: ["/csi-resizer"]
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $version | replace "." "-" }}
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
     {{- if $patch }}
 git:
@@ -53,7 +53,7 @@ mount:
 {{ include "mount points for golang builds" . }}
 final: false
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $version | replace "." "-" }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $version | replace "." "-" }}
   add: /src
   to: /src
   before: install

--- a/modules/000-common/images/csi-external-snapshotter/werf.inc.yaml
+++ b/modules/000-common/images/csi-external-snapshotter/werf.inc.yaml
@@ -12,9 +12,9 @@
     {{- end }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $version | replace "." "-" }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
   add: /csi-snapshotter
   to: /csi-snapshotter
   before: setup
@@ -24,7 +24,7 @@ imageSpec:
     entrypoint: ["/csi-snapshotter"]
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $version | replace "." "-" }}
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
     {{- if $patch }}
 git:
@@ -53,7 +53,7 @@ final: false
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $version | replace "." "-" }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $version | replace "." "-" }}
   add: /src
   to: /src
   before: install

--- a/modules/000-common/images/csi-livenessprobe/werf.inc.yaml
+++ b/modules/000-common/images/csi-livenessprobe/werf.inc.yaml
@@ -12,9 +12,9 @@
     {{- end }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $version | replace "." "-" }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
   add: /livenessprobe
   to: /livenessprobe
   before: setup
@@ -24,7 +24,7 @@ imageSpec:
     entrypoint: ["/livenessprobe"]
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $version | replace "." "-" }}
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
     {{- if $patch }}
 git:
@@ -53,7 +53,7 @@ final: false
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $version | replace "." "-" }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $version | replace "." "-" }}
   add: /src
   to: /src
   before: install

--- a/modules/000-common/images/csi-node-driver-registrar/werf.inc.yaml
+++ b/modules/000-common/images/csi-node-driver-registrar/werf.inc.yaml
@@ -12,9 +12,9 @@
     {{- end }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $version | replace "." "-" }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
   add: /csi-node-driver-registrar
   to: /csi-node-driver-registrar
   before: setup
@@ -24,7 +24,7 @@ imageSpec:
     entrypoint: ["/csi-node-driver-registrar"]
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $version | replace "." "-" }}
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
     {{- if $patch }}
 git:
@@ -52,7 +52,7 @@ final: false
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $version | replace "." "-" }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $version | replace "." "-" }}
   add: /src
   to: /src
   before: install

--- a/modules/000-common/images/debug-container/werf.inc.yaml
+++ b/modules/000-common/images/debug-container/werf.inc.yaml
@@ -5,7 +5,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
 from: {{ index $.Images "builder/alpine" }}
 final: false
 import:
-- image: registrypackages/iptables-artifact-{{ $iptables_image_version }}
+- from: registrypackages/iptables-artifact-{{ $iptables_image_version }}
   add: /
   to: /usr/bin
   includePaths:
@@ -42,32 +42,32 @@ shell:
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 from: {{ index $.Images "base/distroless-fin" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /out
   to: /
   before: install
-- image: control-plane-manager/etcd
+- from: control-plane-manager/etcd
   add: /usr/bin
   to: /usr/bin
   includePaths:
   - etcdctl
   - etcdutl
   before: install
-- image: istio/istioctl-v1x21x6-build-artifact
+- from: istio/istioctl-v1x21x6-build-artifact
   add: /src/istio/out/istioctl
   to: /usr/bin/istioctl-1.21
   before: install
-- image: istio/istioctl-v1x25x2-build-artifact
+- from: istio/istioctl-v1x25x2-build-artifact
   add: /src/istio/out/istioctl
   to: /usr/bin/istioctl-1.25
   before: install
 {{- if ne $.Env "CSE" }}
-- image: istio/istioctl-v1x27x9-build-artifact
+- from: istio/istioctl-v1x27x9-build-artifact
   add: /src/istio/out/istioctl
   to: /usr/bin/istioctl-1.27
   before: install
 {{- end }}
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /usr/bin
   to: /usr/bin
   includePaths:

--- a/modules/000-common/images/distroless/werf.inc.yaml
+++ b/modules/000-common/images/distroless/werf.inc.yaml
@@ -3,7 +3,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}
 from: {{ index $.Images "builder/scratch" }}
 final: false
 import:
-  - image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+  - from: {{ .ModuleName }}/{{ .ImageName }}-artifact
     add: /relocate
     to: /
     before: setup

--- a/modules/000-common/images/init/werf.inc.yaml
+++ b/modules/000-common/images/init/werf.inc.yaml
@@ -1,16 +1,16 @@
 {{- $binaries := "/bin/sh /bin/chown /bin/chmod /bin/ls /bin/cp /bin/rm /bin/mkdir /bin/nc /bin/sleep /bin/true" }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-artifact
   add: /relocate
   to: /
   before: setup
 {{- include "image mount points" . }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
-fromImage: common/relocate-artifact
+from: common/relocate-artifact
 final: false
 shell:
   beforeInstall:

--- a/modules/000-common/images/iptables-wrapper/werf.inc.yaml
+++ b/modules/000-common/images/iptables-wrapper/werf.inc.yaml
@@ -1,15 +1,15 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 final: false
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /src/iptables-wrapper
   to: /iptables-wrapper
   before: setup
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 secrets:
 - id: SOURCE_REPO
@@ -25,7 +25,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/modules/000-common/images/kube-rbac-proxy/werf.inc.yaml
+++ b/modules/000-common/images/kube-rbac-proxy/werf.inc.yaml
@@ -1,8 +1,8 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /kube-rbac-proxy
   to: /kube-rbac-proxy
   before: setup
@@ -13,7 +13,7 @@ imageSpec:
     expose: ["8080"]
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ $.ModulePath }}modules/{{ .ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
@@ -35,7 +35,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/modules/000-common/images/kubernetes/werf.inc.yaml
+++ b/modules/000-common/images/kubernetes/werf.inc.yaml
@@ -33,7 +33,7 @@
   {{- end }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $full_version | replace "." "-" }}
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 
 {{- if $hasPatches }}
@@ -92,7 +92,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $full_version | replace 
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $full_version | replace "." "-" }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $full_version | replace "." "-" }}
   add: /src
   to: /src
   before: install

--- a/modules/000-common/images/nginx-static/werf.inc.yaml
+++ b/modules/000-common/images/nginx-static/werf.inc.yaml
@@ -2,7 +2,7 @@
 {{- $OpenSSLVersion := "3.3.2" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 secrets:
 - id: SOURCE_REPO
@@ -17,7 +17,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 from: {{ index $.Images "builder/alpine-3.21" }}
 final: false
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install
@@ -41,10 +41,10 @@ shell:
   - chmod 0700 /opt/nginx-static/sbin/nginx
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/distroless
+from: common/distroless
 final: false
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /opt/nginx-static
   to: /opt/nginx-static
   before: setup

--- a/modules/000-common/images/pause/werf.inc.yaml
+++ b/modules/000-common/images/pause/werf.inc.yaml
@@ -1,8 +1,8 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /pause-linux-amd64
   to: /pause
   before: setup
@@ -11,7 +11,7 @@ imageSpec:
     entrypoint: ["/pause"]
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ $.ModulePath }}modules/{{ .ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/src
@@ -27,7 +27,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 from: {{ index $.Images "builder/alpine" }}
 final: false
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/modules/000-common/images/promtool/werf.inc.yaml
+++ b/modules/000-common/images/promtool/werf.inc.yaml
@@ -1,7 +1,7 @@
 {{- $prometheusVersion := "v2.55.1" }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/patches
@@ -25,11 +25,11 @@ image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 from: {{ index $.Images "builder/golang-1.25" }}
 final: false
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src/prometheus
   to: /src
   before: install
-- image: common/promu-artifact
+- from: common/promu-artifact
   add: /src/promu
   to: /bin/promu
   before: install

--- a/modules/000-common/images/promu/werf.inc.yaml
+++ b/modules/000-common/images/promu/werf.inc.yaml
@@ -1,7 +1,7 @@
 {{- $promuVersion := "0.17.0" }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/patches
@@ -25,7 +25,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 from: {{ index $.Images "builder/golang-1.25" }}
 final: false
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src/promu
   to: /src
   before: install

--- a/modules/000-common/images/redis-static/werf.inc.yaml
+++ b/modules/000-common/images/redis-static/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 secrets:
 - id: SOURCE_REPO
@@ -15,7 +15,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 from: {{ index $.Images "builder/alpine" }}
 final: false
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install
@@ -36,9 +36,9 @@ shell:
   - chmod 0700 /src/src/redis-server
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ .ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ .ImageName }}-artifact
   add: /src/src/redis-server
   to: /redis-server
   before: setup

--- a/modules/000-common/images/shell-operator/werf.inc.yaml
+++ b/modules/000-common/images/shell-operator/werf.inc.yaml
@@ -4,21 +4,21 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}
 final: false
 from: {{ index $.Images "base/distroless" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /shell-operator/shell-operator
   to: /shell-operator
   before: setup
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /shell-operator/shell_lib.sh
   to: /shell_lib.sh
   before: setup
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /shell-operator/frameworks
   to: /frameworks
   before: setup
 {{- $k8sVersion := index (index .k8sVersions 0) "kubectl" }}
 {{- $image_version := printf "%s.%d" $k8sVersion (index $.CandiVersionMap "k8s" $k8sVersion "patch") | replace "." "-" }}
-- image: common/kubernetes-artifact-{{ $image_version }}
+- from: common/kubernetes-artifact-{{ $image_version }}
   add: /src/_output/bin/kubectl
   to: /usr/bin/kubectl
   before: setup
@@ -29,7 +29,7 @@ import:
   add: /usr/bin/bash
   to: /bin/bash
   before: setup
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /shell-operator/sh
   to: /bin/sh
   before: setup
@@ -184,7 +184,7 @@ final: false
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/modules/000-common/images/src-artifact/werf.inc.yaml
+++ b/modules/000-common/images/src-artifact/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/alt-p11-artifact
+from: common/alt-p11-artifact
 final: false
 shell:
   beforeInstall:

--- a/modules/000-common/images/task/werf.inc.yaml
+++ b/modules/000-common/images/task/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 secrets:
 - id: SOURCE_REPO
@@ -17,7 +17,7 @@ final: false
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/modules/000-common/images/vxlan-offloading-fixer/werf.inc.yaml
+++ b/modules/000-common/images/vxlan-offloading-fixer/werf.inc.yaml
@@ -1,7 +1,7 @@
 {{- $version := "6.11" }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/src
@@ -24,7 +24,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-ethtool-artifact
 from: {{ index $.Images "builder/distroless" }}
 final: false
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src
   to: /src
   before: install
@@ -58,7 +58,7 @@ final: false
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src/vxlan-offloading-fixer
   to: /src
   before: install
@@ -73,17 +73,17 @@ shell:
   - chmod 0755 /tmp/vxlan-offloading-fixer
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-ethtool-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-ethtool-artifact
   add: /ethtool
   to: /ethtool
   before: setup
-- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-artifact
   add: /tmp/vxlan-offloading-fixer
   to: /vxlan-offloading-fixer
   before: setup
-- image: common/pause
+- from: common/pause
   add: /pause
   to: /pause
   before: install

--- a/modules/000-common/images/wheel-artifact/werf.inc.yaml
+++ b/modules/000-common/images/wheel-artifact/werf.inc.yaml
@@ -2,7 +2,7 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 secrets:
 - id: SOURCE_REPO
   value: {{ .SOURCE_REPO }}

--- a/modules/002-deckhouse/images/init/werf.inc.yaml
+++ b/modules/002-deckhouse/images/init/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/init
+from: common/init
 import:
 {{- include "image mount points" . }}
 ---

--- a/modules/002-deckhouse/images/webhook-handler/werf.inc.yaml
+++ b/modules/002-deckhouse/images/webhook-handler/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/shell-operator
+from: common/shell-operator
 import:
 - from: {{ index $.Images "tools/yq" }}
   add: /usr/bin/yq
@@ -10,19 +10,19 @@ import:
   add: /usr/bin/semver
   to: /usr/bin/semver
   before: setup
-- image: common/promtool-artifact
+- from: common/promtool-artifact
   add: /promtool
   to: /usr/local/bin/promtool
   before: setup
-- image: {{ $.ModuleName }}/{{ .ImageName }}-label-converter-artifact
+- from: {{ $.ModuleName }}/{{ .ImageName }}-label-converter-artifact
   add: /label-converter
   to: /usr/local/bin/label-converter
   before: setup
-- image: {{ $.ModuleName }}/{{ .ImageName }}-webhook-operator-artifact
+- from: {{ $.ModuleName }}/{{ .ImageName }}-webhook-operator-artifact
   add: /webhook-operator
   to: /
   before: setup
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-wheel-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-wheel-artifact
   add: /
   to: /
   before: install
@@ -78,7 +78,7 @@ imageSpec:
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-label-converter-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/src/label-converter
   to: /src
@@ -101,7 +101,7 @@ from: {{ index $.Images "builder/golang" }}
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-label-converter-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-label-converter-src-artifact
   add: /src
   to: /src
   before: install
@@ -126,7 +126,7 @@ git:
     install:
     - '**/*'
 import:
-- image: common/wheel-artifact
+- from: common/wheel-artifact
   add: /wheels
   to: /wheels
   before: install
@@ -141,7 +141,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-webhook-operator-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-  - image: {{ $.ModuleName }}/{{ $.ImageName }}-webhook-operator-src-artifact
+  - from: {{ $.ModuleName }}/{{ $.ImageName }}-webhook-operator-src-artifact
     add: /src
     to: /operator
     before: install
@@ -160,7 +160,7 @@ shell:
     - chmod 0700 /webhook-operator
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-webhook-operator-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 shell:
   install:

--- a/modules/007-registrypackages/images/amazon-ec2-utils/werf.inc.yaml
+++ b/modules/007-registrypackages/images/amazon-ec2-utils/werf.inc.yaml
@@ -4,7 +4,7 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ $.ModulePath }}/modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
   to: /src/scripts
@@ -23,11 +23,11 @@ shell:
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
 from: {{ index $.Images "builder/scratch" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src/amazon-ec2-utils/ebsnvme-id
   to: /ebsnvme-id
   before: setup
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src/scripts
   to: /
   before: setup

--- a/modules/007-registrypackages/images/cfssl/werf.inc.yaml
+++ b/modules/007-registrypackages/images/cfssl/werf.inc.yaml
@@ -2,7 +2,7 @@
 {{- $image_version := $version | replace "." "-" }}
 ---
 image: "{{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}"
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
   - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
@@ -25,7 +25,7 @@ image: "{{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}"
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-  - image: "{{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}"
+  - from: "{{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}"
     add: /src/cfssl
     before: install
 mount:
@@ -45,16 +45,16 @@ shell:
     - mv ./bin/* /
 ---
 image: "{{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}"
-fromImage: common/distroless
+from: common/distroless
 import:
-  - image: "{{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}"
+  - from: "{{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}"
     add: /src/scripts
     to: /
     includePaths:
     - install
     - uninstall
     before: setup
-  - image: "{{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}"
+  - from: "{{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}"
     add: /
     to: /
     includePaths:

--- a/modules/007-registrypackages/images/containerd/werf.inc.yaml
+++ b/modules/007-registrypackages/images/containerd/werf.inc.yaml
@@ -40,7 +40,7 @@ INTEGRITY_NAMESPACES="{{ $namespaces }}"
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-runc-src-artifact-{{ $runc_version }}
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 {{- if $runcHasPatch }}
 git:
 - add: /{{ $.ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches/runc
@@ -66,7 +66,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-runc-artifact-{{ $runc_version }}
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-runc-src-artifact-{{ $runc_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-runc-src-artifact-{{ $runc_version }}
   add: /src
   to: /src
   before: install
@@ -104,7 +104,7 @@ shell:
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
 from: {{ index $.Images "builder/scratch" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
   add: /out
   to: /
   includePaths:
@@ -118,11 +118,11 @@ import:
   - containerd.service
   before: setup
 {{- if and (eq $.Env "CSE") $is_v2 }}
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-pidumount-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-pidumount-artifact
   add: /pidumount
   before: setup
 {{- end }}
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-runc-artifact-{{ $runc_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-runc-artifact-{{ $runc_version }}
   add: /out/runc
   to: /runc
   before: setup
@@ -137,7 +137,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ $.ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
   to: /src/scripts
@@ -176,7 +176,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
   add: /src
   to: /src
   before: install
@@ -215,7 +215,7 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-pidumount-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ $.ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/pidumount/src
   to: /src
@@ -224,7 +224,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-pidumount-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-pidumount-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-pidumount-src-artifact
   add: /src
   before: install
 secrets:
@@ -255,7 +255,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-sysext-artifact-{{ $image_version }}
 from: {{ index $.Images "builder/distroless" }}
 final: false
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
   add: /
   to: /sysext/opt/deckhouse/bin
   includePaths:
@@ -295,7 +295,7 @@ shell:
 image: {{ $.ModuleName }}/{{ $.ImageName }}-sysext-{{ $image_version }}
 from: {{ index $.Images "builder/scratch" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-sysext-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-sysext-artifact-{{ $image_version }}
   add: /out
   to: /
   includePaths:

--- a/modules/007-registrypackages/images/crictl/werf.inc.yaml
+++ b/modules/007-registrypackages/images/crictl/werf.inc.yaml
@@ -13,7 +13,7 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
   to: /src/scripts
@@ -42,7 +42,7 @@ shell:
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
 from: {{ index $.Images "builder/scratch" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
   add: /
   to: /
   includePaths:
@@ -63,7 +63,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
   add: /src
   to: /src
   before: install

--- a/modules/007-registrypackages/images/cryptsetup/werf.inc.yaml
+++ b/modules/007-registrypackages/images/cryptsetup/werf.inc.yaml
@@ -2,7 +2,7 @@
 image: {{ .ModuleName }}/{{ .ImageName }}
 from: {{ index $.Images "builder/scratch" }}
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-artifact
   add: /
   to: /
   includePaths:

--- a/modules/007-registrypackages/images/d8-ca-updater/werf.inc.yaml
+++ b/modules/007-registrypackages/images/d8-ca-updater/werf.inc.yaml
@@ -4,7 +4,7 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
 from: {{ index $.Images "builder/scratch" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
   add: /
   to: /
   includePaths:

--- a/modules/007-registrypackages/images/d8-curl/werf.inc.yaml
+++ b/modules/007-registrypackages/images/d8-curl/werf.inc.yaml
@@ -3,7 +3,7 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ $.ModulePath }}/modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
   to: /src/scripts
@@ -21,7 +21,7 @@ shell:
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
 from: {{ index $.Images "builder/scratch" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
   add: /
   to: /
   includePaths:
@@ -42,7 +42,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 final: false
 from: {{ index $.Images "builder/alpine" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
   add: /src
   to: /src
   before: setup

--- a/modules/007-registrypackages/images/d8/werf.inc.yaml
+++ b/modules/007-registrypackages/images/d8/werf.inc.yaml
@@ -1,7 +1,7 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ $.ModulePath }}/modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
   to: /src/scripts
@@ -19,7 +19,7 @@ shell:
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 from: {{ index $.Images "builder/scratch" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /
   to: /
   includePaths:
@@ -42,11 +42,11 @@ from: {{ index $.Images "builder/golang-bookworm" }}
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install
-- image: common/task-artifact
+- from: common/task-artifact
   add: /task
   to: /usr/local/bin/task
   before: install

--- a/modules/007-registrypackages/images/docker-registry/werf.inc.yaml
+++ b/modules/007-registrypackages/images/docker-registry/werf.inc.yaml
@@ -5,7 +5,7 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact-{{ $image_version }}
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ .ModulePath }}/modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/scripts
   to: /src/scripts
@@ -32,7 +32,7 @@ shell:
 image: {{ .ModuleName }}/{{ .ImageName }}-{{ $image_version }}
 from: {{ index $.Images "builder/scratch" }}
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-artifact-{{ $image_version }}
+- from: {{ .ModuleName }}/{{ .ImageName }}-artifact-{{ $image_version }}
   add: /
   to: /
   includePaths:
@@ -54,7 +54,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-artifact-{{ $image_version }}
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact-{{ $image_version }}
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact-{{ $image_version }}
   add: /src
   to: /src
   before: install

--- a/modules/007-registrypackages/images/e2fsprogs/werf.inc.yaml
+++ b/modules/007-registrypackages/images/e2fsprogs/werf.inc.yaml
@@ -3,7 +3,7 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ .ModulePath }}/modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/scripts
   to: /src/scripts
@@ -21,14 +21,14 @@ shell:
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
 from: {{ index $.Images "builder/scratch" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
   add: /src/scripts
   to: /
   includePaths:
   - install
   - uninstall
   before: setup
-- image: {{ .ModuleName }}/{{ .ImageName }}-artifact-{{ $image_version }}
+- from: {{ .ModuleName }}/{{ .ImageName }}-artifact-{{ $image_version }}
   add: /relocate/sbin
   to: /
   includePaths:
@@ -49,7 +49,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 final: false
 from: {{ index $.Images "builder/alpine" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
   add: /src
   to: /src
   before: install

--- a/modules/007-registrypackages/images/ec2-describe-tags/werf.inc.yaml
+++ b/modules/007-registrypackages/images/ec2-describe-tags/werf.inc.yaml
@@ -4,7 +4,7 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ $.ModulePath }}/modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
   to: /src/scripts
@@ -22,7 +22,7 @@ shell:
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
 from: {{ index $.Images "builder/scratch" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
   add: /
   to: /
   includePaths:
@@ -43,7 +43,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact-{{ $image_version }}
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact-{{ $image_version }}
   add: /src
   to: /src
   before: install

--- a/modules/007-registrypackages/images/ecr-credential-provider/werf.inc.yaml
+++ b/modules/007-registrypackages/images/ecr-credential-provider/werf.inc.yaml
@@ -13,7 +13,7 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
   to: /src/scripts
@@ -43,7 +43,7 @@ shell:
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
 from: {{ index $.Images "builder/scratch" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
   add: /
   to: /
   includePaths:
@@ -64,7 +64,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
   add: /src
   to: /src
   before: install

--- a/modules/007-registrypackages/images/erofs/werf.inc.yaml
+++ b/modules/007-registrypackages/images/erofs/werf.inc.yaml
@@ -2,7 +2,7 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 from: {{ index $.Images "builder/scratch" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /
   to: /
   includePaths:

--- a/modules/007-registrypackages/images/growpart/werf.inc.yaml
+++ b/modules/007-registrypackages/images/growpart/werf.inc.yaml
@@ -4,7 +4,7 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact-{{ $image_version }}
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ $.ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
   to: /src/scripts
@@ -24,7 +24,7 @@ shell:
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
 from: {{ index $.Images "builder/scratch" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
   add: /
   to: /
   includePaths:
@@ -32,7 +32,7 @@ import:
   - install
   - uninstall
   before: setup
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-fdisk-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-fdisk-{{ $image_version }}
   add: /
   to: /
   includePaths:
@@ -52,7 +52,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-fdisk-{{ $image_version }}
 final: false
 from: {{ index $.Images "builder/golang-alpine" }}
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact-{{ $image_version }}
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact-{{ $image_version }}
   add: /src
   to: /src
   before: install
@@ -73,7 +73,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 final: false
 from: {{ index $.Images "builder/alpine" }}
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact-{{ $image_version }}
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact-{{ $image_version }}
   add: /src
   to: /src
   before: install

--- a/modules/007-registrypackages/images/iptables/werf.inc.yaml
+++ b/modules/007-registrypackages/images/iptables/werf.inc.yaml
@@ -6,7 +6,7 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ $.ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
   to: /src/scripts
@@ -28,7 +28,7 @@ shell:
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
 from: {{ index $.Images "builder/scratch" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
   add: /
   to: /
   includePaths:
@@ -50,7 +50,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 final: false
 from: {{ index $.Images "builder/alpine" }}
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact-{{ $image_version }}
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact-{{ $image_version }}
   add: /src
   to: /src
   before: install

--- a/modules/007-registrypackages/images/jq/werf.inc.yaml
+++ b/modules/007-registrypackages/images/jq/werf.inc.yaml
@@ -4,7 +4,7 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
 from: {{ index $.Images "builder/scratch" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
   add: /
   to: /
   includePaths:

--- a/modules/007-registrypackages/images/kubectl/werf.inc.yaml
+++ b/modules/007-registrypackages/images/kubectl/werf.inc.yaml
@@ -6,7 +6,7 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
 from: {{ index $.Images "builder/scratch" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
   add: /
   to: /
   includePaths:
@@ -33,7 +33,7 @@ git:
     setup:
     - '**/*'
 import:
-- image: common/kubernetes-artifact-{{ $image_version }}
+- from: common/kubernetes-artifact-{{ $image_version }}
   add: /src/_output/bin/kubectl
   to: /kubectl
   before: setup

--- a/modules/007-registrypackages/images/kubelet/werf.inc.yaml
+++ b/modules/007-registrypackages/images/kubelet/werf.inc.yaml
@@ -6,7 +6,7 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
 from: {{ index $.Images "builder/scratch" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
   add: /
   to: /
   includePaths:
@@ -34,7 +34,7 @@ git:
     setup:
     - '**/*'
 import:
-- image: common/kubernetes-artifact-{{ $image_version }}
+- from: common/kubernetes-artifact-{{ $image_version }}
   add: /src/_output/bin/kubelet
   to: /kubelet
   before: setup
@@ -57,7 +57,7 @@ shell:
 image: {{ $.ModuleName }}/{{ $.ImageName }}-sysext-{{ $image_version }}
 from: {{ index $.Images "builder/scratch" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-sysext-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-sysext-artifact-{{ $image_version }}
   add: /out
   to: /
   includePaths:
@@ -76,7 +76,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-sysext-artifact-{{ $image_version }}
 final: false
 from: {{ index $.Images "builder/distroless" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
   add: /kubelet
   to: /sysext/opt/deckhouse/bin/kubelet
   before: install

--- a/modules/007-registrypackages/images/kubernetes-api-proxy/werf.inc.yaml
+++ b/modules/007-registrypackages/images/kubernetes-api-proxy/werf.inc.yaml
@@ -3,7 +3,7 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 from: {{ index $.Images "builder/scratch" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /
   to: /
   includePaths:
@@ -25,7 +25,7 @@ git:
     setup:
     - '**/*'
 import:
-- image: common/crane
+- from: common/crane
   add: /crane
   to: /crane
   before: setup

--- a/modules/007-registrypackages/images/kubernetes-cni/werf.inc.yaml
+++ b/modules/007-registrypackages/images/kubernetes-cni/werf.inc.yaml
@@ -7,7 +7,7 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ $.ModulePath }}/modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
   to: /patches
@@ -36,7 +36,7 @@ shell:
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
 from: {{ index $.Images "builder/scratch" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
   add: /
   to: /
   includePaths:
@@ -77,7 +77,7 @@ from: {{ index $.Images "builder/golang" }}
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
   add: /src
   to: /src
   before: install
@@ -106,7 +106,7 @@ shell:
 image: {{ $.ModuleName }}/{{ $.ImageName }}-sysext-{{ $image_version }}
 from: {{ index $.Images "builder/scratch" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-sysext-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-sysext-artifact-{{ $image_version }}
   add: /out
   to: /
   includePaths:
@@ -125,7 +125,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-sysext-artifact-{{ $image_version }}
 final: false
 from: {{ index $.Images "builder/distroless" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
   add: /
   to: /sysext/opt/deckhouse/bin
   includePaths:

--- a/modules/007-registrypackages/images/lsblk/werf.inc.yaml
+++ b/modules/007-registrypackages/images/lsblk/werf.inc.yaml
@@ -4,7 +4,7 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
 from: {{ index $.Images "builder/scratch" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
   add: /
   to: /
   includePaths:
@@ -23,7 +23,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ $.ModulePath }}/modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
   to: /src/scripts
@@ -44,7 +44,7 @@ final: false
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
   add: /src
   to: /src
   before: setup

--- a/modules/007-registrypackages/images/netcat/werf.inc.yaml
+++ b/modules/007-registrypackages/images/netcat/werf.inc.yaml
@@ -3,7 +3,7 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ $.ModulePath }}/modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
   to: /src/scripts
@@ -21,7 +21,7 @@ shell:
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
 from: {{ index $.Images "builder/scratch" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
   add: /
   to: /
   includePaths:
@@ -42,7 +42,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 final: false
 from: {{ index $.Images "builder/alpine" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
   add: /src
   to: /src
   before: install

--- a/modules/007-registrypackages/images/nfs-mount/werf.inc.yaml
+++ b/modules/007-registrypackages/images/nfs-mount/werf.inc.yaml
@@ -5,7 +5,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
 from: {{ index $.Images "builder/scratch" }}
 fromCacheVersion: "2025-06-24 13:00"
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
   add: /
   to: /
   includePaths:

--- a/modules/007-registrypackages/images/nvme-cli/werf.inc.yaml
+++ b/modules/007-registrypackages/images/nvme-cli/werf.inc.yaml
@@ -4,7 +4,7 @@
 image: {{ .ModuleName }}/{{ .ImageName }}-{{ $image_version }}
 from: {{ index $.Images "builder/scratch" }}
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-artifact-{{ $image_version }}
+- from: {{ .ModuleName }}/{{ .ImageName }}-artifact-{{ $image_version }}
   add: /relocate
   to: /
   includePaths:
@@ -23,7 +23,7 @@ imageSpec:
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact-{{ $image_version }}
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ .ModulePath }}/modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/scripts
   to: /src/scripts
@@ -44,7 +44,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-artifact-{{ $image_version }}
 final: false
 from: {{ index $.Images "builder/alt" }}
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact-{{ $image_version }}
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact-{{ $image_version }}
   add: /src
   to: /src
   before: install

--- a/modules/007-registrypackages/images/pause/werf.inc.yaml
+++ b/modules/007-registrypackages/images/pause/werf.inc.yaml
@@ -3,7 +3,7 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 from: {{ index $.Images "builder/scratch" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /
   to: /
   includePaths:
@@ -25,7 +25,7 @@ git:
     setup:
     - '**/*'
 import:
-- image: common/crane
+- from: common/crane
   add: /crane
   to: /crane
   before: setup

--- a/modules/007-registrypackages/images/registry-proxy/werf.inc.yaml
+++ b/modules/007-registrypackages/images/registry-proxy/werf.inc.yaml
@@ -3,7 +3,7 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 from: {{ index $.Images "builder/scratch" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /
   to: /
   includePaths:
@@ -25,7 +25,7 @@ git:
     setup:
     - '**/*'
 import:
-- image: common/crane
+- from: common/crane
   add: /crane
   to: /crane
   before: setup

--- a/modules/007-registrypackages/images/rpp-get/werf.inc.yaml
+++ b/modules/007-registrypackages/images/rpp-get/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ $.ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
   to: /src/scripts
@@ -19,7 +19,7 @@ shell:
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 from: {{ index $.Images "builder/scratch" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /
   to: /
   includePaths:
@@ -42,7 +42,7 @@ from: {{ index $.Images "builder/golang" }}
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/modules/007-registrypackages/images/socat/werf.inc.yaml
+++ b/modules/007-registrypackages/images/socat/werf.inc.yaml
@@ -3,7 +3,7 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ $.ModulePath }}/modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
   to: /src/scripts
@@ -21,7 +21,7 @@ shell:
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
 from: {{ index $.Images "builder/scratch" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
   add: /
   to: /
   includePaths:
@@ -40,9 +40,9 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 final: false
-fromImage: common/alt-p11-artifact
+from: common/alt-p11-artifact
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
   add: /src
   to: /src
   before: install

--- a/modules/007-registrypackages/images/systemctl-power-commands-wrapper/werf.inc.yaml
+++ b/modules/007-registrypackages/images/systemctl-power-commands-wrapper/werf.inc.yaml
@@ -3,7 +3,7 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ $.ModulePath }}/modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
   to: /src/scripts
@@ -33,7 +33,7 @@ from: {{ index $.Images "builder/golang" }}
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
   add: /src
   to: /src
   before: install
@@ -52,7 +52,7 @@ shell:
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
 from: {{ index $.Images "builder/scratch" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
   add: /
   to: /
   includePaths:

--- a/modules/007-registrypackages/images/tail-log/werf.inc.yaml
+++ b/modules/007-registrypackages/images/tail-log/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ $.ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
   to: /src/scripts
@@ -19,7 +19,7 @@ shell:
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 from: {{ index $.Images "builder/scratch" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /
   to: /
   includePaths:
@@ -42,7 +42,7 @@ from: {{ index $.Images "builder/golang" }}
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/modules/007-registrypackages/images/toml-merge/werf.inc.yaml
+++ b/modules/007-registrypackages/images/toml-merge/werf.inc.yaml
@@ -3,7 +3,7 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ $.ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
   to: /src/scripts
@@ -22,7 +22,7 @@ shell:
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
 from: {{ index $.Images "builder/scratch" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
   add: /
   to: /
   includePaths:
@@ -45,7 +45,7 @@ from: {{ index $.Images "builder/golang" }}
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
   add: /src
   to: /src
   before: install

--- a/modules/007-registrypackages/images/virt-what/werf.inc.yaml
+++ b/modules/007-registrypackages/images/virt-what/werf.inc.yaml
@@ -3,7 +3,7 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ $.ModulePath }}/modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
   to: /src/scripts
@@ -21,7 +21,7 @@ shell:
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
 from: {{ index $.Images "builder/scratch" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
   add: /
   to: /
   includePaths:
@@ -43,7 +43,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 final: false
 from: {{ index $.Images "builder/alpine" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
   add: /src
   to: /src
   before: install

--- a/modules/007-registrypackages/images/which/werf.inc.yaml
+++ b/modules/007-registrypackages/images/which/werf.inc.yaml
@@ -4,7 +4,7 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
 from: {{ index $.Images "builder/scratch" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
   add: /
   to: /
   includePaths:
@@ -23,7 +23,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ $.ModulePath }}/modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
   to: /src/scripts
@@ -44,7 +44,7 @@ final: false
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
   add: /src
   to: /src
   before: setup

--- a/modules/007-registrypackages/images/xfsprogs/werf.inc.yaml
+++ b/modules/007-registrypackages/images/xfsprogs/werf.inc.yaml
@@ -4,7 +4,7 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
 from: {{ index $.Images "builder/scratch" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
   add: /out
   to: /
   before: setup

--- a/modules/007-registrypackages/images/yq/werf.inc.yaml
+++ b/modules/007-registrypackages/images/yq/werf.inc.yaml
@@ -4,7 +4,7 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
 from: {{ index $.Images "builder/scratch" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
   add: /
   to: /
   includePaths:

--- a/modules/015-admission-policy-engine/images/constraint-exporter/werf.inc.yaml
+++ b/modules/015-admission-policy-engine/images/constraint-exporter/werf.inc.yaml
@@ -1,8 +1,8 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-  - image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+  - from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
     add: /constraint_exporter
     to: /constraint_exporter
     before: setup
@@ -11,7 +11,7 @@ imageSpec:
     entrypoint: [ "/constraint_exporter" ]
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ $.ModulePath }}modules/015-{{ $.ModuleName }}/images/{{ $.ImageName }}/src
@@ -27,7 +27,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/modules/015-admission-policy-engine/images/gatekeeper/werf.inc.yaml
+++ b/modules/015-admission-policy-engine/images/gatekeeper/werf.inc.yaml
@@ -1,9 +1,9 @@
 {{ $gatekeeperVersion := include "get_oss_version_by_id" (list "gatekeeper" $ ) }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /gatekeeper
   to: /bin/gatekeeper
   before: setup
@@ -13,7 +13,7 @@ imageSpec:
     entrypoint: [ "/bin/gatekeeper" ]
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ $.ModulePath }}modules/015-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
@@ -27,7 +27,7 @@ git:
   - gatekeeper/*.yaml
   stageDependencies:
     install:
-    - '**/*'    
+    - '**/*'
 secrets:
 - id: SOURCE_REPO
   value: {{ .SOURCE_REPO }}
@@ -39,15 +39,15 @@ shell:
   - rm -rf website
   - rm -rf .git
   # check if module crds/gatekeeper are the same as gatekeeper crds
-  - | 
+  - |
     echo "Checking if module crds/gatekeeper are the same as gatekeeper crds"
-    diff -qr "/src/charts/gatekeeper/crds" "/module_crds/gatekeeper" 
+    diff -qr "/src/charts/gatekeeper/crds" "/module_crds/gatekeeper"
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/modules/021-cni-cilium/images/agent/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/agent/werf.inc.yaml
@@ -94,7 +94,7 @@
 # #####################################################################
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}
@@ -110,29 +110,29 @@ shell:
   - cd /src
 ---
 image: {{ .ModuleName }}/agent-binaries-artifact
-fromImage: {{ .ModuleName }}/base-cilium-dev
+from: {{ .ModuleName }}/base-cilium-dev
 final: false
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src/check-n-cleaning-iptables.sh
   to: /check-n-cleaning-iptables.sh
   before: install
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src/binary_replace.sh
   to: /binary_replace.sh
   before: install
-- image: registrypackages/iptables-artifact-{{ $iptables_image_version }}
+- from: registrypackages/iptables-artifact-{{ $iptables_image_version }}
   add: /
   to: /sbin
   includePaths:
   - xtables-legacy-multi
   - xtables-nft-multi
   before: install
-- image: common/iptables-wrapper
+- from: common/iptables-wrapper
   add: /iptables-wrapper
   to: /usr/sbin/iptables-wrapper
   before: install
-- image: {{ .ModuleName }}/cilium-artifact
+- from: {{ .ModuleName }}/cilium-artifact
   add: /tmp/install
   to: /
   before: install
@@ -147,19 +147,19 @@ import:
   - var/lib/cilium/bpf
   - usr/bin/hubble
   - etc/bash_completion.d/hubble
-- image: {{ .ModuleName }}/bpftool-artifact
+- from: {{ .ModuleName }}/bpftool-artifact
   add: /usr/local/bin/bpftool
   to: /usr/local/bin/bpftool
   before: install
-- image: {{ .ModuleName }}/gops-artifact
+- from: {{ .ModuleName }}/gops-artifact
   add: /out/linux/amd64/bin/gops
   to: /bin/gops
   before: install
-- image: {{ .ModuleName }}/cni-plugins-artifact
+- from: {{ .ModuleName }}/cni-plugins-artifact
   add: /out/linux/amd64/bin/loopback
   to: /cni/loopback
   before: install
-- image: {{ .ModuleName }}/cilium-envoy-artifact
+- from: {{ .ModuleName }}/cilium-envoy-artifact
   add: /tmp/install/usr
   to: /usr
   before: install
@@ -167,18 +167,18 @@ import:
   - bin/cilium-envoy
   - bin/cilium-envoy-starter
   - lib/libcilium.so
-- image: {{ .ModuleName }}/llvm-artifact
+- from: {{ .ModuleName }}/llvm-artifact
   add: /usr/local/bin/
   to: /usr/local/bin
   before: install
   includePaths:
   - clang
   - llc
-- image: {{ .ModuleName }}/llvm-artifact
+- from: {{ .ModuleName }}/llvm-artifact
   add: /usr/lib/llvm-19.1/lib64/libLLVM.so.19.1
   to: /usr/lib/llvm-19.1/lib64/libLLVM.so.19.1
   before: install
-- image: common/distroless
+- from: common/distroless
   add: /etc/group
   to: /from_common_distroless/group
   before: install
@@ -211,7 +211,7 @@ import:
   before: setup
   add: /usr/bin/true
   to: /usr/bin/true
-- image: registrypackages/d8-curl-artifact-8-9-1
+- from: registrypackages/d8-curl-artifact-8-9-1
   before: setup
   add: /d8-curl
   to: /usr/bin/curl
@@ -324,7 +324,7 @@ import:
   before: install
 - from: {{ .ModuleName }}/glibc-artifact
   add: /out/usr/lib/libtinfo*
-  to: /usr/lib64/
+  to: /usr/lib64
   before: install
 - from: {{ index $.Images "tools/elfutils-elfutils-0.193" }}
   add: /usr/lib
@@ -335,7 +335,7 @@ import:
   - libelf.so
   - libelf.so.1
   - libelf-0.193.so
-- image: common/pause
+- from: common/pause
   add: /pause
   to: /pause
   before: setup
@@ -568,9 +568,9 @@ shell:
 # New Main Agent Image (Distroless)
 ---
 image: {{ .ModuleName }}/agent-distroless
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/agent-binaries-artifact
+- from: {{ .ModuleName }}/agent-binaries-artifact
   add: /relocate
   to: /
   before: install

--- a/modules/021-cni-cilium/images/base-cilium-dev/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/base-cilium-dev/werf.inc.yaml
@@ -34,12 +34,12 @@ mount:
 - from: tmp_dir
   to: /root/.cache/bazel
 import:
-- image: {{ .ModuleName }}/golang-artifact
+- from: {{ .ModuleName }}/golang-artifact
   add: /usr/local/go
   to: /usr/local/go
   before: install
 {{- if eq $.SVACE_ENABLED "true" }}
-- image: {{ .ModuleName }}/golang-artifact
+- from: {{ .ModuleName }}/golang-artifact
   add: /
   to: /
   includePaths:

--- a/modules/021-cni-cilium/images/bin-bpftool/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/bin-bpftool/werf.inc.yaml
@@ -15,7 +15,7 @@
 # #####################################################################
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 secrets:
 - id: SOURCE_REPO
@@ -30,10 +30,10 @@ shell:
   - rm -rf /src/linux/.git
 ---
 image: {{ .ModuleName }}/bpftool-artifact
-fromImage: {{ .ModuleName }}/base-cilium-dev
+from: {{ .ModuleName }}/base-cilium-dev
 final: false
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/modules/021-cni-cilium/images/bin-cilium-envoy/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/bin-cilium-envoy/werf.inc.yaml
@@ -18,7 +18,7 @@
 # #####################################################################
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/patches
@@ -53,10 +53,10 @@ shell:
   - pm install libatomic@15.2 libc@2.43 ncurses -d /out
 ---
 image: {{ .ModuleName }}/cilium-envoy-artifact
-fromImage: {{ .ModuleName }}/base-cilium-dev
+from: {{ .ModuleName }}/base-cilium-dev
 final: false
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src
   to: /src
   before: install
@@ -90,7 +90,7 @@ import:
   before: install
 - from: {{ .ModuleName }}/glibc-artifact
   add: /out/usr/lib/libtinfo*
-  to: /usr/lib64/
+  to: /usr/lib64
   before: install
 mount:
 {{ include "mount points for golang builds" . }}

--- a/modules/021-cni-cilium/images/bin-cilium/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/bin-cilium/werf.inc.yaml
@@ -3,7 +3,7 @@
 # Based on https://github.com/cilium/cilium/blob/v1.17.4/images/cilium/Dockerfile (builder stage)
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/patches
@@ -23,14 +23,14 @@ shell:
   - rm -rf /src/cilium/.git
 ---
 image: {{ .ModuleName }}/cilium-artifact
-fromImage: {{ .ModuleName }}/base-cilium-dev
+from: {{ .ModuleName }}/base-cilium-dev
 final: false
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src
   to: /src
   before: install
-- image: {{ .ModuleName }}/llvm-artifact
+- from: {{ .ModuleName }}/llvm-artifact
   add: /usr/local/bin/
   to: /usr/local/bin
   before: install
@@ -38,15 +38,15 @@ import:
   - clang
   - llc
   - llvm-objcopy
-- image: {{ .ModuleName }}/bpftool-artifact
+- from: {{ .ModuleName }}/bpftool-artifact
   add: /usr/local/bin/bpftool
   to: /usr/local/bin/bpftool
   before: install
-- image: {{ .ModuleName }}/cni-plugins-artifact
+- from: {{ .ModuleName }}/cni-plugins-artifact
   add: /out/linux/amd64/bin/loopback
   to: /cni/loopback
   before: install
-- image: {{ .ModuleName }}/gops-artifact
+- from: {{ .ModuleName }}/gops-artifact
   add: /out/linux/amd64/bin/gops
   to: /bin/gops
   before: install

--- a/modules/021-cni-cilium/images/bin-cni-plugins/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/bin-cni-plugins/werf.inc.yaml
@@ -8,7 +8,7 @@
 # #####################################################################
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/patches
@@ -30,7 +30,7 @@ image: {{ .ModuleName }}/cni-plugins-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/modules/021-cni-cilium/images/bin-gops/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/bin-gops/werf.inc.yaml
@@ -5,7 +5,7 @@
 # #####################################################################
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/patches
@@ -27,7 +27,7 @@ image: {{ .ModuleName }}/gops-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/modules/021-cni-cilium/images/bin-llvm/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/bin-llvm/werf.inc.yaml
@@ -16,7 +16,7 @@
 # #####################################################################
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 secrets:
 - id: SOURCE_REPO
@@ -33,10 +33,10 @@ shell:
   - rm -rf /src/llvm/.git
 ---
 image: {{ .ModuleName }}/llvm-artifact
-fromImage: {{ .ModuleName }}/base-cilium-dev
+from: {{ .ModuleName }}/base-cilium-dev
 final: false
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/modules/021-cni-cilium/images/check-kernel-version/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/check-kernel-version/werf.inc.yaml
@@ -1,16 +1,16 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: common/check-kernel-version
+- from: common/check-kernel-version
   add: /check-kernel-version
   to: /check-kernel-version
   before: setup
-- image: {{ .ModuleName }}/{{ .ImageName }}-relocate-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-relocate-artifact
   add: /relocate/bin/true
   to: /bin/true
   before: setup
-- image: common/pause
+- from: common/pause
   add: /pause
   to: /pause
   before: install
@@ -21,7 +21,7 @@ imageSpec:
 {{- $binaries := "/bin/true" }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-relocate-artifact
-fromImage: common/relocate-artifact
+from: common/relocate-artifact
 final: false
 shell:
  setup:

--- a/modules/021-cni-cilium/images/check-wg-kernel-compat/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/check-wg-kernel-compat/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/src
@@ -16,7 +16,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src
   to: /src
   before: install
@@ -42,9 +42,9 @@ shell:
   - chmod 0755 /src/check-wg-kernel-compat
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /src/check-wg-kernel-compat
   to: /check-wg-kernel-compat
   before: install

--- a/modules/021-cni-cilium/images/kube-rbac-proxy/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/kube-rbac-proxy/werf.inc.yaml
@@ -1,12 +1,12 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/kube-rbac-proxy
+from: common/kube-rbac-proxy
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-relocate-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-relocate-artifact
   add: /relocate/bin/true
   to: /bin/true
   before: setup
-- image: common/pause
+- from: common/pause
   add: /pause
   to: /pause
   before: install
@@ -18,7 +18,7 @@ imageSpec:
 {{- $binaries := "/bin/true" }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-relocate-artifact
-fromImage: common/relocate-artifact
+from: common/relocate-artifact
 final: false
 shell:
  setup:

--- a/modules/021-cni-cilium/images/operator/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/operator/werf.inc.yaml
@@ -6,7 +6,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-- image: {{ .ModuleName }}/bin-cilium-src-artifact
+- from: {{ .ModuleName }}/bin-cilium-src-artifact
   add: /src
   to: /src
   before: install
@@ -38,9 +38,9 @@ shell:
   - rm -rf /src/cilium/vendor
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /out/linux/amd64/usr/bin/cilium-operator
   to: /usr/bin/cilium-operator
   before: install

--- a/modules/021-cni-cilium/images/safe-agent-updater/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/safe-agent-updater/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/src
@@ -17,7 +17,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src
   to: /src
   before: install
@@ -43,9 +43,9 @@ shell:
   - chmod 0700 /src/safe-agent-updater
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /src/safe-agent-updater
   to: /safe-agent-updater
   before: install

--- a/modules/030-cloud-provider-aws/images/cloud-controller-manager/werf.inc.yaml
+++ b/modules/030-cloud-provider-aws/images/cloud-controller-manager/werf.inc.yaml
@@ -11,9 +11,9 @@
     {{- end }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
   add: /src/aws-cloud-controller-manager
   to: /usr/local/bin/aws-cloud-controller-manager
   before: setup
@@ -23,7 +23,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 {{- if $patch }}
 git:
   - add: {{ $patches }}/patches/{{ $k8s_version }}
@@ -48,7 +48,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-  - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
+  - from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
     add: /src
     to: /src
     before: install

--- a/modules/030-cloud-provider-aws/images/cloud-data-discoverer/werf.inc.yaml
+++ b/modules/030-cloud-provider-aws/images/cloud-data-discoverer/werf.inc.yaml
@@ -1,8 +1,8 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /discoverer
   to: /discoverer
   before: setup
@@ -12,7 +12,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/src
   to:  /src
@@ -54,7 +54,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/modules/030-cloud-provider-aws/images/ebs-csi-plugin/werf.inc.yaml
+++ b/modules/030-cloud-provider-aws/images/ebs-csi-plugin/werf.inc.yaml
@@ -10,13 +10,13 @@
     {{- end }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
   add: /aws-ebs-csi-driver
   to: /bin/aws-ebs-csi-driver
   before: setup
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /relocate
   to: /
   before: install
@@ -28,7 +28,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 {{- if $patch }}
 git:
 - add: {{ $patches }}/patches/{{ $version }}
@@ -53,7 +53,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-  - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
+  - from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
     add: /src
     to: /src
     before: install
@@ -78,7 +78,7 @@ shell:
 {{- $csiBinaries := "/bin/chmod /bin/mount /bin/mkdir /bin/rmdir /bin/umount /bin/findmnt /bin/lsblk /sbin/badblocks /sbin/blockdev /sbin/blk* /sbin/dumpe2fs /sbin/e2* /sbin/findfs /sbin/fsck* /sbin/fstrim /sbin/mke2fs /sbin/mkfs* /sbin/resize2fs /usr/sbin/parted /usr/sbin/xfs*" }}
 image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
 final: false
-fromImage: common/relocate-artifact
+from: common/relocate-artifact
 shell:
   beforeInstall:
     - apt-get update -y

--- a/modules/030-cloud-provider-aws/images/node-termination-handler/werf.inc.yaml
+++ b/modules/030-cloud-provider-aws/images/node-termination-handler/werf.inc.yaml
@@ -1,9 +1,9 @@
 {{- $version := include "get_oss_version_by_id" (list "node-termination-handler-aws" $) }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-  - image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+  - from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
     add: /node-termination-handler
     to: /node-termination-handler
     before: setup
@@ -13,7 +13,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
   to: /patches
@@ -36,7 +36,7 @@ from: {{ index $.Images "builder/golang" }}
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/modules/030-cloud-provider-aws/images/terraform-manager/werf.inc.yaml
+++ b/modules/030-cloud-provider-aws/images/terraform-manager/werf.inc.yaml
@@ -16,7 +16,7 @@ git:
     install:
     - '**/*'
 import:
-- image: terraform-provider-aws
+- from: terraform-provider-aws
   add: /terraform-provider-aws
   to: /terraform-manager/terraform-provider-aws
   before: setup
@@ -27,7 +27,7 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ $.ModulePath }}modules/030-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
   to: /patches
@@ -50,7 +50,7 @@ from: {{ index $.Images "builder/golang" }}
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/modules/030-cloud-provider-azure/images/azuredisk-csi/werf.inc.yaml
+++ b/modules/030-cloud-provider-azure/images/azuredisk-csi/werf.inc.yaml
@@ -11,13 +11,13 @@
     {{- end }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
   add: /src/_output/amd64/azurediskplugin
   to: /azurediskplugin
   before: setup
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /relocate
   to: /
   before: install
@@ -29,7 +29,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 {{- if $patch }}
 git:
 - add: {{ $patches }}/patches/{{ $k8s_version }}
@@ -54,7 +54,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
   add: /src
   to: /src
   before: install
@@ -78,7 +78,7 @@ shell:
 {{- $csiBinaries := "/bin/chmod /bin/mount /bin/mkdir /bin/rmdir /bin/umount /bin/findmnt /bin/lsblk /sbin/badblocks /sbin/blockdev /sbin/blk* /sbin/btrfs* /sbin/dumpe2fs /sbin/e2* /sbin/findfs /sbin/fsck* /sbin/fsfreeze /sbin/fstrim /sbin/mke2fs /sbin/mkfs* /sbin/resize2fs /usr/sbin/parted /usr/sbin/xfs*" }}
 image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
 final: false
-fromImage: common/relocate-artifact
+from: common/relocate-artifact
 shell:
   beforeInstall:
   - apt-get update -y

--- a/modules/030-cloud-provider-azure/images/cloud-controller-manager/werf.inc.yaml
+++ b/modules/030-cloud-provider-azure/images/cloud-controller-manager/werf.inc.yaml
@@ -11,10 +11,10 @@
     {{- end }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
-fromImage: common/distroless
+from: common/distroless
 fromCacheVersion: "patch-refresh-1"
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
   add: /src/bin/azure-cloud-controller-manager
   to: /usr/local/bin/azure-cloud-controller-manager
   before: setup
@@ -24,7 +24,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 {{- if $patch }}
 git:
 - add: {{ $patches }}/patches/{{ $k8s_version }}
@@ -49,7 +49,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
   add: /src
   to: /src
   before: install

--- a/modules/030-cloud-provider-azure/images/cloud-data-discoverer/werf.inc.yaml
+++ b/modules/030-cloud-provider-azure/images/cloud-data-discoverer/werf.inc.yaml
@@ -1,8 +1,8 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /discoverer
   to: /discoverer
   before: setup
@@ -12,7 +12,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/src
   to:  /src
@@ -54,7 +54,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/modules/030-cloud-provider-azure/images/terraform-manager/werf.inc.yaml
+++ b/modules/030-cloud-provider-azure/images/terraform-manager/werf.inc.yaml
@@ -16,7 +16,7 @@ git:
     install:
     - '**/*'
 import:
-- image: terraform-provider-azure
+- from: terraform-provider-azure
   add: /terraform-provider-azurerm
   to: /terraform-manager/terraform-provider-azurerm
   before: setup
@@ -27,7 +27,7 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ $.ModulePath }}modules/030-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
   to: /patches
@@ -52,7 +52,7 @@ from: {{ index $.Images "builder/golang" }}
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/werf.inc.yaml
+++ b/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/werf.inc.yaml
@@ -1,8 +1,8 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-  - image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+  - from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
     add: /capdvp-controller-manager
     to: /capdvp-controller-manager
     before: setup
@@ -12,7 +12,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
   - add: /{{ $.ModulePath }}modules/030-{{ $.ModuleName }}/images/{{ $.ImageName }}/src
     to:  /src
@@ -40,7 +40,7 @@ mount:
   - fromPath: ~/go-pkg-cache
     to: /go/pkg
 import:
-  - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+  - from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
     add: /src
     to: /src
     before: install

--- a/modules/030-cloud-provider-dvp/images/cloud-controller-manager/werf.inc.yaml
+++ b/modules/030-cloud-provider-dvp/images/cloud-controller-manager/werf.inc.yaml
@@ -1,8 +1,8 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-  - image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+  - from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
     add: /dvp-cloud-controller-manager
     to: /dvp-cloud-controller-manager
     before: setup
@@ -12,7 +12,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ $.ModulePath }}modules/030-{{ $.ModuleName }}/images/{{ $.ImageName }}/src
   to:  /src
@@ -40,7 +40,7 @@ mount:
   - fromPath: ~/go-pkg-cache
     to: /go/pkg
 import:
-  - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+  - from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
     add: /src
     to: /src
     before: install

--- a/modules/030-cloud-provider-dvp/images/cloud-data-discoverer/werf.inc.yaml
+++ b/modules/030-cloud-provider-dvp/images/cloud-data-discoverer/werf.inc.yaml
@@ -1,8 +1,8 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /discoverer
   to: /discoverer
   before: setup
@@ -12,7 +12,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 fromCacheVersion: 2025-03-04.01
 git:
 - add: {{ .gitPrefix }}/go_lib/cloud-data
@@ -52,7 +52,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/modules/030-cloud-provider-dvp/images/dvp-csi-driver/werf.inc.yaml
+++ b/modules/030-cloud-provider-dvp/images/dvp-csi-driver/werf.inc.yaml
@@ -1,25 +1,25 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
 {{- include "image mount points" . }}
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /dvp-csi-driver
   to: /dvp-csi-driver
   before: setup
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /relocate
   to: /
   before: install
   includePaths:
   - '**/*'
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /lib64
   to: /lib64
   before: install
   includePaths:
   - 'libresolv*'
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /lib/udev/scsi_id
   to: /lib/udev/scsi_id
   before: setup
@@ -33,7 +33,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/src
   to:  /src
@@ -67,7 +67,7 @@ mount:
 - fromPath: ~/go-pkg-cache
   to: /go/pkg
 import:
-  - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+  - from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
     add: /src
     to: /src
     before: install
@@ -84,7 +84,7 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
 final: false
-fromImage: common/relocate-artifact
+from: common/relocate-artifact
 shell:
   beforeInstall:
   - apt-get update -y

--- a/modules/030-cloud-provider-dvp/images/terraform-manager/werf.inc.yaml
+++ b/modules/030-cloud-provider-dvp/images/terraform-manager/werf.inc.yaml
@@ -8,31 +8,22 @@ git:
   excludePaths:
   - '**/terraform_versions.yml'
   - '**/plan_rules.yml'
-  stageDependencies:
-    install:
-    - '**/*'
 - add: /{{ $.ModulePath }}modules/030-{{ $.ModuleName }}/candi/terraform_versions.yml
   to: /terraform-manager/terraform_versions.yml
-  stageDependencies:
-    install:
-    - '**/*'
 # plan_rules.yml must sit next to terraform_versions.yml: dhctl reads the pair
 # straight from the unpacked bundle, and the rules describe that versions file.
 - add: /{{ $.ModulePath }}modules/030-{{ $.ModuleName }}/candi/plan_rules.yml
   to: /terraform-manager/plan_rules.yml
-  stageDependencies:
-    install:
-    - '**/*'
 - add: /{{ $.ModulePath }}modules/030-{{ $.ModuleName }}/openapi/
   to: /candi/module-openapi
 - add: /{{ $.ModulePath }}modules/030-{{ $.ModuleName }}/crds/instance_class.yaml
   to: /crd/instance_class.yaml
 import:
-- image: terraform-provider-kubernetes
+- from: terraform-provider-kubernetes
   add: /terraform-provider-kubernetes
   to: /terraform-manager/terraform-provider-kubernetes
   before: setup
-- image: {{ $.ModuleName }}/validator
+- from: {{ $.ModuleName }}/validator
   add: /dhctl-provider-dvp
   to: /validator
   before: setup
@@ -40,7 +31,7 @@ import:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ $.ModulePath }}modules/030-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
   to: /patches
@@ -66,7 +57,7 @@ mount:
 - fromPath: ~/go-pkg-cache
   to: /go/pkg
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/modules/030-cloud-provider-dvp/images/validation-webhook/werf.inc.yaml
+++ b/modules/030-cloud-provider-dvp/images/validation-webhook/werf.inc.yaml
@@ -1,9 +1,9 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
 {{- include "image mount points" . }}
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /validation-webhook
   to: /validation-webhook
   before: setup
@@ -13,7 +13,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ $.ModulePath }}modules/030-{{ $.ModuleName }}/images/{{ $.ImageName }}/src
   to: /src/validation-webhook/src
@@ -82,7 +82,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/modules/030-cloud-provider-dvp/images/validator/werf.inc.yaml
+++ b/modules/030-cloud-provider-dvp/images/validator/werf.inc.yaml
@@ -2,14 +2,14 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /dhctl-provider-dvp
   to: /dhctl-provider-dvp
   before: setup
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ $.ModulePath }}modules/030-{{ $.ModuleName }}/images/{{ $.ImageName }}/src
   to: /src/validator/src
@@ -78,7 +78,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/modules/030-cloud-provider-gcp/images/cloud-controller-manager/werf.inc.yaml
+++ b/modules/030-cloud-provider-gcp/images/cloud-controller-manager/werf.inc.yaml
@@ -12,9 +12,9 @@
     {{- end }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
   add: /src/gcp-cloud-controller-manager
   to: /usr/local/bin/cloud-controller-manager
   before: setup
@@ -24,7 +24,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 {{- if $patch }}
 git:
   - add: {{ $patches }}/patches/{{ $src_version }}
@@ -49,7 +49,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
   add: /src
   to: /src
   before: install

--- a/modules/030-cloud-provider-gcp/images/cloud-data-discoverer/werf.inc.yaml
+++ b/modules/030-cloud-provider-gcp/images/cloud-data-discoverer/werf.inc.yaml
@@ -1,8 +1,8 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /discoverer
   to: /discoverer
   before: setup
@@ -12,7 +12,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/src
   to:  /src
@@ -54,7 +54,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/modules/030-cloud-provider-gcp/images/pd-csi-plugin/werf.inc.yaml
+++ b/modules/030-cloud-provider-gcp/images/pd-csi-plugin/werf.inc.yaml
@@ -10,29 +10,29 @@
     {{- end }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
   add: /src/bin/gce-pd-csi-driver
   to: /gce-pd-csi-driver
   before: setup
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /relocate
   to: /
   before: install
   includePaths:
   - '**/*'
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /lib64
   to: /lib64
   before: install
   includePaths:
   - 'libresolv*'
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /lib/udev/scsi_id
   to: /lib/udev_containerized/scsi_id
   before: setup
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
   add: /src/deploy/kubernetes/udev/google_nvme_id
   to: /lib/udev_containerized/google_nvme_id
   before: setup
@@ -42,7 +42,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 {{- if $patch }}
 git:
   - add: {{ $patches }}/patches/{{ $version }}
@@ -67,7 +67,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
   add: /src
   to: /src
   before: install
@@ -92,7 +92,7 @@ shell:
 {{- $csiBinaries := "/bin/chmod /bin/mount /bin/mkdir /bin/rmdir /bin/umount /bin/findmnt /bin/lsblk /sbin/badblocks /sbin/blockdev /sbin/blk* /sbin/btrfs* /sbin/dumpe2fs /sbin/e2* /sbin/findfs /sbin/fsck* /sbin/fsfreeze /sbin/fstrim /sbin/mke2fs /sbin/mkfs* /sbin/resize2fs /sbin/xfs_repair /usr/sbin/nvme /usr/sbin/parted /usr/sbin/xfs*" }}
 image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
 final: false
-fromImage: common/relocate-artifact
+from: common/relocate-artifact
 shell:
   beforeInstall:
   - apt-get update -y

--- a/modules/030-cloud-provider-gcp/images/terraform-manager/werf.inc.yaml
+++ b/modules/030-cloud-provider-gcp/images/terraform-manager/werf.inc.yaml
@@ -16,7 +16,7 @@ git:
     install:
     - '**/*'
 import:
-- image: terraform-provider-gcp
+- from: terraform-provider-gcp
   add: /terraform-provider-gcp
   to: /terraform-manager/terraform-provider-gcp
   before: setup
@@ -27,7 +27,7 @@ shell:
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
   to: /patches
@@ -50,7 +50,7 @@ from: {{ index $.Images "builder/golang" }}
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/modules/030-cloud-provider-yandex/images/capy-controller-manager/werf.inc.yaml
+++ b/modules/030-cloud-provider-yandex/images/capy-controller-manager/werf.inc.yaml
@@ -6,9 +6,9 @@
 {{- end }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /src/manager
   to: /capy-controller-manager
   before: setup
@@ -18,7 +18,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 {{- if $patch }}
 git:
   - add: {{ $patches }}/patches
@@ -43,7 +43,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/modules/030-cloud-provider-yandex/images/cloud-controller-manager/werf.inc.yaml
+++ b/modules/030-cloud-provider-yandex/images/cloud-controller-manager/werf.inc.yaml
@@ -1,9 +1,9 @@
 {{- $version := include "get_oss_version_by_id" (list "ccm-yandex" $) }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /src/yandex-cloud-controller-manager
   to: /usr/local/bin/cloud-controller-manager
   before: setup
@@ -13,7 +13,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 secrets:
 - id: SOURCE_REPO
   value: {{ .SOURCE_REPO }}
@@ -27,7 +27,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-  - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+  - from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
     add: /src
     to: /src
     before: install

--- a/modules/030-cloud-provider-yandex/images/cloud-data-discoverer/werf.inc.yaml
+++ b/modules/030-cloud-provider-yandex/images/cloud-data-discoverer/werf.inc.yaml
@@ -1,8 +1,8 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /discoverer
   to: /discoverer
   before: setup
@@ -12,7 +12,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/src
   to:  /src
@@ -54,7 +54,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/modules/030-cloud-provider-yandex/images/cloud-metrics-exporter/werf.inc.yaml
+++ b/modules/030-cloud-provider-yandex/images/cloud-metrics-exporter/werf.inc.yaml
@@ -1,8 +1,8 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-artifact
   add: /src/exporter
   to: /exporter
   after: setup
@@ -12,7 +12,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
   - add: /{{ .ModulePath }}modules/030-{{ .ModuleName }}/images/{{ .ImageName }}
     to: /src
@@ -34,7 +34,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-  - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+  - from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
     add: /src
     to: /src
     before: install

--- a/modules/030-cloud-provider-yandex/images/cloud-migrator/werf.inc.yaml
+++ b/modules/030-cloud-provider-yandex/images/cloud-migrator/werf.inc.yaml
@@ -1,8 +1,8 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /migrator
   to: /migrator
   before: setup
@@ -12,7 +12,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
   - add: /{{ .ModulePath }}modules/030-{{ .ModuleName }}/images/{{ .ImageName }}/src
     to: /src
@@ -34,7 +34,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-  - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+  - from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
     add: /src
     to: /src
     before: install

--- a/modules/030-cloud-provider-yandex/images/terraform-manager/werf.inc.yaml
+++ b/modules/030-cloud-provider-yandex/images/terraform-manager/werf.inc.yaml
@@ -16,7 +16,7 @@ git:
     install:
     - '**/*'
 import:
-- image: terraform-provider-yandex
+- from: terraform-provider-yandex
   add: /terraform-provider-yandex
   to: /terraform-manager/terraform-provider-yandex
   before: setup
@@ -27,7 +27,7 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ $.ModulePath }}modules/030-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
   to: /patches
@@ -50,7 +50,7 @@ from: {{ index $.Images "builder/golang" }}
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/modules/030-cloud-provider-yandex/images/yandex-csi-plugin/werf.inc.yaml
+++ b/modules/030-cloud-provider-yandex/images/yandex-csi-plugin/werf.inc.yaml
@@ -1,13 +1,13 @@
 {{- $version := include "get_oss_version_by_id" (list "csi-yandex" $) }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /go/bin/yandex-csi-driver
   to: /bin/yandex-csi-driver
   before: setup
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /relocate
   to: /
   before: install
@@ -19,7 +19,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 secrets:
 - id: SOURCE_REPO
   value: {{ .SOURCE_REPO }}
@@ -33,7 +33,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-  - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+  - from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
     add: /go/src/app
     to: /go/src/app
     before: install
@@ -59,7 +59,7 @@ shell:
 {{- $csiBinaries := "/bin/chmod /bin/mount /bin/mkdir /bin/rmdir /bin/umount /bin/findmnt /bin/lsblk /sbin/badblocks /sbin/blockdev /sbin/blk* /sbin/dumpe2fs /sbin/e2* /sbin/findfs /sbin/fsck* /sbin/fstrim /sbin/mke2fs /sbin/mkfs* /sbin/resize2fs /usr/sbin/parted /usr/sbin/xfs*" }}
 image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
 final: false
-fromImage: common/relocate-artifact
+from: common/relocate-artifact
 shell:
   beforeInstall:
     - apt-get update -y

--- a/modules/031-local-path-provisioner/images/helper/werf.inc.yaml
+++ b/modules/031-local-path-provisioner/images/helper/werf.inc.yaml
@@ -5,7 +5,7 @@ from: {{ index $.Images "builder/golang" }}
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src
   to: /src
   before: install
@@ -19,9 +19,9 @@ shell:
   - chmod 0777 /manager
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-dir-manager
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-dir-manager
   add: /manager
   to: /manager
   after: install
@@ -29,7 +29,7 @@ import:
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/src
   to: /src

--- a/modules/031-local-path-provisioner/images/local-path-provisioner/werf.inc.yaml
+++ b/modules/031-local-path-provisioner/images/local-path-provisioner/werf.inc.yaml
@@ -1,9 +1,9 @@
 {{- $localPathProvisionerVersion := "0.0.36"}}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /local-path-provisioner
   to: /usr/bin/local-path-provisioner
   after: install
@@ -14,7 +14,7 @@ imageSpec:
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/patches
   to: /patches
@@ -37,7 +37,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/modules/035-cni-flannel/images/flanneld/werf.inc.yaml
+++ b/modules/035-cni-flannel/images/flanneld/werf.inc.yaml
@@ -3,7 +3,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-entrypoint-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src/entrypoint
   to: /src
   before: install
@@ -22,7 +22,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src/flannel
   to: /src
   before: install
@@ -41,7 +41,7 @@ shell:
   - make dist/flanneld
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ .ModulePath }}modules/035-{{ .ModuleName }}/images/flanneld/entrypoint
@@ -65,13 +65,13 @@ shell:
   - git apply /patches/*.patch --verbose
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-artifact
   add: /src/dist/flanneld
   to: /opt/bin/flanneld
   before: setup
-- image: {{ .ModuleName }}/{{ .ImageName }}-entrypoint-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-entrypoint-artifact
   add: /entrypoint
   to: /entrypoint
   before: setup

--- a/modules/035-cni-flannel/images/iptables-wrapper-init/werf.inc.yaml
+++ b/modules/035-cni-flannel/images/iptables-wrapper-init/werf.inc.yaml
@@ -2,7 +2,7 @@
 {{- $iptables_image_version := $iptables_version | replace "." "-" }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
 - from: {{ index $.Images "tools/coreutils" }}
   add: /
@@ -15,18 +15,18 @@ import:
   add: /usr/bin/bash
   to: /bin/bash
   before: setup
-- image: common/iptables-wrapper
+- from: common/iptables-wrapper
   add: /iptables-wrapper
   to: /iptables-wrapper
   before: setup
-- image: registrypackages/iptables-artifact-{{ $iptables_image_version }}
+- from: registrypackages/iptables-artifact-{{ $iptables_image_version }}
   add: /
   to: /_sbin
   includePaths:
   - xtables-legacy-multi
   - xtables-nft-multi
   before: setup
-- image: {{ .ModuleName }}/{{ .ImageName }}-relocate-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-relocate-artifact
   add: /relocate
   to: /relocate
   before: setup

--- a/modules/035-cni-simple-bridge/images/iptables-wrapper-init/werf.inc.yaml
+++ b/modules/035-cni-simple-bridge/images/iptables-wrapper-init/werf.inc.yaml
@@ -2,7 +2,7 @@
 {{- $iptables_image_version := $iptables_version | replace "." "-" }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
 - from: {{ index $.Images "tools/coreutils" }}
   add: /
@@ -15,18 +15,18 @@ import:
   add: /usr/bin/bash
   to: /bin/bash
   before: setup
-- image: common/iptables-wrapper
+- from: common/iptables-wrapper
   add: /iptables-wrapper
   to: /iptables-wrapper
   before: setup
-- image: registrypackages/iptables-artifact-{{ $iptables_image_version }}
+- from: registrypackages/iptables-artifact-{{ $iptables_image_version }}
   add: /
   to: /_sbin
   includePaths:
   - xtables-legacy-multi
   - xtables-nft-multi
   before: setup
-- image: {{ .ModuleName }}/{{ .ImageName }}-relocate-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-relocate-artifact
   add: /relocate
   to: /relocate
   before: setup

--- a/modules/035-cni-simple-bridge/images/simple-bridge/werf.inc.yaml
+++ b/modules/035-cni-simple-bridge/images/simple-bridge/werf.inc.yaml
@@ -12,7 +12,7 @@ shell:
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 from: {{ index $.Images "base/distroless-fin" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /out
   to: /
   before: install

--- a/modules/036-kube-proxy/images/init-container/werf.inc.yaml
+++ b/modules/036-kube-proxy/images/init-container/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
   - add: /{{ $.ModulePath }}/modules/036-{{ $.ModuleName }}/images/{{ $.ImageName }}/src
@@ -18,7 +18,7 @@ final: false
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-  - image: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact
+  - from: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact
     add: /src
     to: /src
     before: install
@@ -32,9 +32,9 @@ shell:
     - go build -ldflags="-s -w" -o entrypoint main.go
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ .ModuleName }}/{{ $.ImageName }}-artifact
   add: /src/entrypoint
   to: /entrypoint
   before: setup

--- a/modules/036-kube-proxy/images/iptables-wrapper-init/werf.inc.yaml
+++ b/modules/036-kube-proxy/images/iptables-wrapper-init/werf.inc.yaml
@@ -2,7 +2,7 @@
 {{- $iptables_image_version := $iptables_version | replace "." "-" }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
 - from: {{ index $.Images "tools/coreutils" }}
   add: /
@@ -15,18 +15,18 @@ import:
   add: /usr/bin/bash
   to: /bin/bash
   before: setup
-- image: common/iptables-wrapper
+- from: common/iptables-wrapper
   add: /iptables-wrapper
   to: /iptables-wrapper
   before: setup
-- image: registrypackages/iptables-artifact-{{ $iptables_image_version }}
+- from: registrypackages/iptables-artifact-{{ $iptables_image_version }}
   add: /
   to: /_sbin
   includePaths:
   - xtables-legacy-multi
   - xtables-nft-multi
   before: setup
-- image: {{ .ModuleName }}/{{ .ImageName }}-relocate-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-relocate-artifact
   add: /relocate
   to: /relocate
   before: setup

--- a/modules/036-kube-proxy/images/kube-proxy/werf.inc.yaml
+++ b/modules/036-kube-proxy/images/kube-proxy/werf.inc.yaml
@@ -13,13 +13,13 @@ shell:
   {{- $image_version := printf "%s.%s" $version $patch | replace "." "-" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $version | replace "." "-" }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /relocate
   to: /
   before: setup
-- image: common/kubernetes-artifact-{{ $image_version }}
+- from: common/kubernetes-artifact-{{ $image_version }}
   add: /src/_output/bin/kube-proxy
   to: /usr/local/bin/kube-proxy
   before: setup

--- a/modules/038-registry/images/docker-auth/werf.inc.yaml
+++ b/modules/038-registry/images/docker-auth/werf.inc.yaml
@@ -1,7 +1,7 @@
 {{- $version := "v1.14.0-deckhouse.7"}}
 ---
 image: "{{ $.ModuleName }}/{{ $.ImageName }}-src-artifact"
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
   - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
@@ -24,7 +24,7 @@ image: "{{ $.ModuleName }}/{{ $.ImageName }}-artifact"
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-  - image: "{{ $.ModuleName }}/{{ $.ImageName }}-src-artifact"
+  - from: "{{ $.ModuleName }}/{{ $.ImageName }}-src-artifact"
     add: /src/docker_auth
     before: install
 mount:
@@ -44,24 +44,24 @@ shell:
     - mv ./auth_server /auth_server
 ---
 image: "{{ $.ModuleName }}/{{ $.ImageName }}"
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: "{{ $.ModuleName }}/{{ $.ImageName }}-src-artifact"
+- from: "{{ $.ModuleName }}/{{ $.ImageName }}-src-artifact"
   add: /src/scripts
   to: /
   includePaths:
   - install
   - uninstall
   before: setup
-- image: "{{ $.ModuleName }}/{{ $.ImageName }}-src-artifact"
+- from: "{{ $.ModuleName }}/{{ $.ImageName }}-src-artifact"
   add: /src/tmp
   to: /tmp
   before: setup
-- image: "{{ $.ModuleName }}/{{ $.ImageName }}-artifact"
+- from: "{{ $.ModuleName }}/{{ $.ImageName }}-artifact"
   add: /auth_server
   to: /auth_server
   before: setup
-- image: common/pause
+- from: common/pause
   add: /pause
   to: /pause
   before: setup

--- a/modules/038-registry/images/docker-distribution/werf.inc.yaml
+++ b/modules/038-registry/images/docker-distribution/werf.inc.yaml
@@ -1,7 +1,7 @@
 {{- $version := "v2.8.3-deckhouse.4"}}
 ---
 image: "{{ $.ModuleName }}/{{ $.ImageName }}-src-artifact"
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
   - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
@@ -24,7 +24,7 @@ image: "{{ $.ModuleName }}/{{ $.ImageName }}-artifact"
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-  - image: "{{ $.ModuleName }}/{{ $.ImageName }}-src-artifact"
+  - from: "{{ $.ModuleName }}/{{ $.ImageName }}-src-artifact"
     add: /src/distribution
     before: install
 mount:
@@ -45,24 +45,24 @@ shell:
     - mv ./bin/registry /registry
 ---
 image: "{{ $.ModuleName }}/{{ $.ImageName }}"
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: "{{ $.ModuleName }}/{{ $.ImageName }}-src-artifact"
+- from: "{{ $.ModuleName }}/{{ $.ImageName }}-src-artifact"
   add: /src/scripts
   to: /
   includePaths:
   - install
   - uninstall
   before: setup
-- image: "{{ $.ModuleName }}/{{ $.ImageName }}-src-artifact"
+- from: "{{ $.ModuleName }}/{{ $.ImageName }}-src-artifact"
   add: /src/tmp
   to: /tmp
   before: setup
-- image: "{{ $.ModuleName }}/{{ $.ImageName }}-artifact"
+- from: "{{ $.ModuleName }}/{{ $.ImageName }}-artifact"
   add: /registry
   to: /registry
   before: setup
-- image: common/pause
+- from: common/pause
   add: /pause
   to: /pause
   before: setup

--- a/modules/038-registry/images/mirrorer/werf.inc.yaml
+++ b/modules/038-registry/images/mirrorer/werf.inc.yaml
@@ -2,7 +2,7 @@
 {{ $appAbsPath := printf "/deckhouse/modules/038-%s/images/%s/app" $.ModuleName $.ImageName }}
 ---
 image: "{{ $.ModuleName }}/{{ $.ImageName }}-src-artifact"
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
   - add: {{ $appRelPath }}
@@ -18,7 +18,7 @@ image: "{{ $.ModuleName }}/{{ $.ImageName }}-artifact"
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-  - image: "{{ $.ModuleName }}/{{ $.ImageName }}-src-artifact"
+  - from: "{{ $.ModuleName }}/{{ $.ImageName }}-src-artifact"
     add: /src/deckhouse
     to: /deckhouse
     before: install
@@ -37,17 +37,17 @@ shell:
     - chmod 0755 /mirrorer
 ---
 image: "{{ $.ModuleName }}/{{ $.ImageName }}"
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: "{{ $.ModuleName }}/{{ $.ImageName }}-src-artifact"
+- from: "{{ $.ModuleName }}/{{ $.ImageName }}-src-artifact"
   add: /src/tmp
   to: /tmp
   before: setup
-- image: "{{ $.ModuleName }}/{{ $.ImageName }}-artifact"
+- from: "{{ $.ModuleName }}/{{ $.ImageName }}-artifact"
   add: /mirrorer
   to: /mirrorer
   before: setup
-- image: common/pause
+- from: common/pause
   add: /pause
   to: /pause
   before: setup

--- a/modules/038-registry/images/nodeservices-manager/werf.inc.yaml
+++ b/modules/038-registry/images/nodeservices-manager/werf.inc.yaml
@@ -2,7 +2,7 @@
 {{ $appAbsPath := printf "/deckhouse/modules/038-%s/images/%s/app" $.ModuleName $.ImageName }}
 ---
 image: "{{ $.ModuleName }}/{{ $.ImageName }}-src-artifact"
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
   - add: {{ $appRelPath }}
@@ -23,7 +23,7 @@ image: "{{ $.ModuleName }}/{{ $.ImageName }}-artifact"
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-  - image: "{{ $.ModuleName }}/{{ $.ImageName }}-src-artifact"
+  - from: "{{ $.ModuleName }}/{{ $.ImageName }}-src-artifact"
     add: /src/deckhouse
     to: /deckhouse
     before: install
@@ -42,13 +42,13 @@ shell:
     - chmod 0755 /manager
 ---
 image: "{{ $.ModuleName }}/{{ $.ImageName }}"
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: "{{ $.ModuleName }}/{{ $.ImageName }}-artifact"
+- from: "{{ $.ModuleName }}/{{ $.ImageName }}-artifact"
   add: /manager
   to: /manager
   before: setup
-- image: common/pause
+- from: common/pause
   add: /pause
   to: /pause
   before: setup

--- a/modules/038-registry/images/registry-proxy/werf.inc.yaml
+++ b/modules/038-registry/images/registry-proxy/werf.inc.yaml
@@ -1,8 +1,8 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/nginx-static
+from: common/nginx-static
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /src/registry-proxy-reloader
   to: /registry-proxy-reloader
   before: install
@@ -15,7 +15,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-  - image: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact
+  - from: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact
     add: /src
     to: /src
     before: install
@@ -32,7 +32,7 @@ shell:
     - chmod 0700 registry-proxy-reloader
 ---
 image: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
   - add: /{{ $.ModulePath }}modules/038-{{ $.ModuleName }}/images/{{ $.ImageName }}/reloader

--- a/modules/038-registry/images/syncer/werf.inc.yaml
+++ b/modules/038-registry/images/syncer/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: "{{ $.ModuleName }}/{{ $.ImageName }}-src-artifact"
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
   - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
@@ -21,7 +21,7 @@ image: "{{ $.ModuleName }}/{{ $.ImageName }}-artifact"
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-  - image: "{{ $.ModuleName }}/{{ $.ImageName }}-src-artifact"
+  - from: "{{ $.ModuleName }}/{{ $.ImageName }}-src-artifact"
     add: /src/app
     to: /app
     before: install
@@ -40,16 +40,16 @@ shell:
     - chmod 0755 /syncer
 ---
 image: "{{ $.ModuleName }}/{{ $.ImageName }}"
-fromImage: common/distroless
+from: common/distroless
 import:
-  - image: "{{ $.ModuleName }}/{{ $.ImageName }}-src-artifact"
+  - from: "{{ $.ModuleName }}/{{ $.ImageName }}-src-artifact"
     add: /src/scripts
     to: /
     includePaths:
     - install
     - uninstall
     before: setup
-  - image: "{{ $.ModuleName }}/{{ $.ImageName }}-artifact"
+  - from: "{{ $.ModuleName }}/{{ $.ImageName }}-artifact"
     add: /syncer
     to: /syncer
     before: setup

--- a/modules/039-registry-packages-proxy/images/registry-packages-proxy/werf.inc.yaml
+++ b/modules/039-registry-packages-proxy/images/registry-packages-proxy/werf.inc.yaml
@@ -2,10 +2,10 @@
 image: {{ .ModuleName }}/{{ .ImageName }}
 from: {{ index $.Images "base/distroless" }}
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-artifact
   add: /registry-packages-proxy
-  before: setup 
-{{- include "image mount points" . }}  
+  before: setup
+{{- include "image mount points" . }}
 imageSpec:
   config:
     entrypoint: ["/registry-packages-proxy"]
@@ -45,11 +45,11 @@ image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src
   to: /src
   before: install
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /go_lib/registry-packages-proxy
   to: /go_lib/registry-packages-proxy
   before: install

--- a/modules/040-control-plane-manager/images/control-plane-manager/werf.inc.yaml
+++ b/modules/040-control-plane-manager/images/control-plane-manager/werf.inc.yaml
@@ -1,8 +1,8 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /control-plane-manager
   to: /control-plane-manager
   before: install
@@ -17,11 +17,11 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /go_lib/controlplane
   to: /go_lib/controlplane
   before: install
@@ -41,7 +41,7 @@ shell:
     - GOPROXY=$(cat /run/secrets/GOPROXY) GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build $BUILD_TAGS -ldflags="-s -w $ETCD_SIGN_ENABLED" -o /control-plane-manager .
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ $.ModulePath }}modules/040-{{ $.ModuleName }}/images/{{ $.ImageName }}/src

--- a/modules/040-control-plane-manager/images/etcd-backup/werf.inc.yaml
+++ b/modules/040-control-plane-manager/images/etcd-backup/werf.inc.yaml
@@ -1,7 +1,7 @@
 {{- $binaries := "/bin/sh /bin/mv /bin/df /bin/du /bin/tail /bin/awk /bin/tar /bin/gzip /bin/chmod" }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 git:
 - add: /{{ $.ModulePath }}/modules/040-{{ $.ModuleName }}/images/{{ $.ImageName }}/entrypoint.sh
   to: /entrypoint.sh
@@ -10,14 +10,14 @@ git:
     - '**/*'
 import:
 {{- include "image mount points" . }}
-- image: {{ .ModuleName }}/etcd-artifact
+- from: {{ .ModuleName }}/etcd-artifact
   add: /etcdctl
   to: /bin/etcdctl
   before: setup
-- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-artifact
   add: /usr/lib/locale/C.utf8
   before: setup
-- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-artifact
   add: /relocate
   to: /
   before: setup
@@ -29,7 +29,7 @@ imageSpec:
     entrypoint: ["/entrypoint.sh"]
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
-fromImage: common/relocate-artifact
+from: common/relocate-artifact
 final: false
 shell:
   install:

--- a/modules/040-control-plane-manager/images/etcd/werf.inc.yaml
+++ b/modules/040-control-plane-manager/images/etcd/werf.inc.yaml
@@ -3,7 +3,7 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ .ModulePath }}/modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/patches
   to: /patches
@@ -22,13 +22,13 @@ shell:
   - rm -rf .git
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: common/pause
+- from: common/pause
   add: /pause
   to: /pause
   before: setup
-- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-artifact
   add: /
   to: /usr/bin
   includePaths:
@@ -47,7 +47,7 @@ final: false
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/modules/040-control-plane-manager/images/kube-apiserver/werf.inc.yaml
+++ b/modules/040-control-plane-manager/images/kube-apiserver/werf.inc.yaml
@@ -4,13 +4,13 @@
   {{- $image_version := printf "%s.%s" $version $patch | replace "." "-" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $version | replace "." "-" }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: common/pause
+- from: common/pause
   add: /pause
   to: /pause
   before: setup
-- image: common/kubernetes-artifact-{{ $image_version }}
+- from: common/kubernetes-artifact-{{ $image_version }}
   add: /src/_output/bin/kube-apiserver
   to: /usr/bin/kube-apiserver
   before: setup

--- a/modules/040-control-plane-manager/images/kube-controller-manager/werf.inc.yaml
+++ b/modules/040-control-plane-manager/images/kube-controller-manager/werf.inc.yaml
@@ -9,13 +9,13 @@ that we include for now to support in-tree Ceph Volume Provisioner
   {{- $image_version := printf "%s.%s" $version $patch | replace "." "-" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $version | replace "." "-" }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: common/pause
+- from: common/pause
   add: /pause
   to: /pause
   before: setup
-- image: common/kubernetes-artifact-{{ $image_version }}
+- from: common/kubernetes-artifact-{{ $image_version }}
   add: /src/_output/bin/kube-controller-manager
   to: /usr/bin/kube-controller-manager
   before: setup

--- a/modules/040-control-plane-manager/images/kube-scheduler/werf.inc.yaml
+++ b/modules/040-control-plane-manager/images/kube-scheduler/werf.inc.yaml
@@ -4,13 +4,13 @@
   {{- $image_version := printf "%s.%s" $version $patch | replace "." "-" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $version | replace "." "-" }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: common/pause
+- from: common/pause
   add: /pause
   to: /pause
   before: setup
-- image: common/kubernetes-artifact-{{ $image_version }}
+- from: common/kubernetes-artifact-{{ $image_version }}
   add: /src/_output/bin/kube-scheduler
   to: /usr/bin/kube-scheduler
   before: setup

--- a/modules/040-node-manager/images/bashible-apiserver/werf.inc.yaml
+++ b/modules/040-node-manager/images/bashible-apiserver/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ $.ModulePath }}modules/040-{{ $.ModuleName }}/images/{{ $.ImageName }}/src
@@ -33,11 +33,11 @@ image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src
   to: /src
   before: install
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /go_lib/registry
   to: /go_lib/registry
   before: install
@@ -55,9 +55,9 @@ shell:
   - chmod 0700 bashible-apiserver
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-artifact
   add: /src/bashible-apiserver
   to: /bashible-apiserver
   before: setup

--- a/modules/040-node-manager/images/capi-controller-manager/werf.inc.yaml
+++ b/modules/040-node-manager/images/capi-controller-manager/werf.inc.yaml
@@ -1,16 +1,16 @@
 {{- $version := include "get_oss_version_by_id" (list "cluster-api" $ )  -}}
 ---
 image: {{ .ModuleName }}/capi-controller-manager
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /capi-controller-manager
   to: /capi-controller-manager
   before: setup
 {{- include "image mount points" . }}
 ---
 image: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/patches
@@ -32,7 +32,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-- image: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/modules/040-node-manager/images/caps-controller-manager/werf.inc.yaml
+++ b/modules/040-node-manager/images/caps-controller-manager/werf.inc.yaml
@@ -1,15 +1,15 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 imageSpec:
   config:
     entrypoint: ["/caps-controller-manager"]
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-artifact
   add: /caps-controller-manager
   to: /caps-controller-manager
   before: setup
-- image: ssh-static
+- from: ssh-static
   add: /ssh/bin
   to: /bin
   before: setup
@@ -18,7 +18,7 @@ import:
 {{- include "image mount points" . }}
 ---
 image: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ $.ModulePath }}modules/040-{{ .ModuleName }}/images/{{ .ImageName }}/src
@@ -40,7 +40,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-- image: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/modules/040-node-manager/images/cluster-autoscaler/werf.inc.yaml
+++ b/modules/040-node-manager/images/cluster-autoscaler/werf.inc.yaml
@@ -18,7 +18,7 @@
 
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
     {{- if $patch }}
 git:
@@ -48,7 +48,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}-src-artifact
   add: /src
   to: /src
   before: install
@@ -66,9 +66,9 @@ shell:
   - echo "{{ $clusterAutoscalerVersion }}.{{ $value.clusterAutoscalerPatch }}-flant" > VERSION
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
   add: /src
   to: /
   includePaths:

--- a/modules/040-node-manager/images/fencing-agent/werf.inc.yaml
+++ b/modules/040-node-manager/images/fencing-agent/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ $.ModulePath }}modules/040-node-manager/images/fencing-agent/src
@@ -16,7 +16,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-- image: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install
@@ -36,9 +36,9 @@ shell:
   - chmod 0700 /src/fencing-agent
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-artifact
   add: /src/fencing-agent
   to: /fencing-agent
   before: setup

--- a/modules/040-node-manager/images/kubernetes-api-proxy/werf.inc.yaml
+++ b/modules/040-node-manager/images/kubernetes-api-proxy/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ $.ModulePath }}modules/040-node-manager/images/kubernetes-api-proxy/src
@@ -16,7 +16,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-- image: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install
@@ -36,9 +36,9 @@ shell:
   - chmod 0700 /src/kubernetes-api-proxy
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-artifact
   add: /src/kubernetes-api-proxy
   to: /kubernetes-api-proxy
   before: setup

--- a/modules/040-node-manager/images/machine-controller-manager/werf.inc.yaml
+++ b/modules/040-node-manager/images/machine-controller-manager/werf.inc.yaml
@@ -2,21 +2,21 @@
 {{- if ne $.Env "CSE" }}
 
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 fromCacheVersion: "2025.04.29.4"
 imageSpec:
   config:
     env: { "WORKDIR": "/" }
     entrypoint: ["/machine-controller-manager"]
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-artifact
   add: /src/machine-controller-manager
   to: /machine-controller-manager
   before: setup
 ---
 image: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact
 fromCacheVersion: "2025.04.29.1"
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 secrets:
 - id: SOURCE_REPO
@@ -30,7 +30,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-- image: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/modules/040-node-manager/images/node-controller/werf.inc.yaml
+++ b/modules/040-node-manager/images/node-controller/werf.inc.yaml
@@ -1,22 +1,22 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 imageSpec:
   config:
     entrypoint: ["/node-controller"]
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-artifact
   add: /node-controller
   to: /node-controller
   before: setup
-- image: {{ .ModuleName }}/{{ .ImageName }}-crds-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-crds-artifact
   add: /crds
   to: /crds
   before: setup
 {{- include "image mount points" . }}
 ---
 image: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ $.ModulePath }}modules/040-{{ .ModuleName }}/images/{{ .ImageName }}/src
@@ -49,11 +49,11 @@ image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-- image: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install
-- image: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /go_lib/dependency/k8s/drain
   to: /go_lib/dependency/k8s/drain
   before: install
@@ -71,13 +71,10 @@ shell:
   - chmod 0700 /node-controller
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-crds-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ $.ModulePath }}modules/040-{{ .ModuleName }}/images/{{ .ImageName }}/crds
   to: /crds
   includePaths:
   - "*.yaml"
-  stageDependencies:
-    install:
-    - "*.yaml"

--- a/modules/040-node-manager/images/node-group-exporter/werf.inc.yaml
+++ b/modules/040-node-manager/images/node-group-exporter/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ $.ModulePath }}modules/040-{{ $.ModuleName }}/images/{{ $.ImageName }}/src
@@ -16,7 +16,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-- image: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
   to: /src
   before: install
@@ -36,9 +36,9 @@ shell:
   - chmod 0700 /src/node-group-exporter
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-artifact
   add: /src/node-group-exporter
   to: /node-group-exporter
   before: setup

--- a/modules/040-terraform-manager/images/base-opentofu/werf.inc.yaml
+++ b/modules/040-terraform-manager/images/base-opentofu/werf.inc.yaml
@@ -2,7 +2,7 @@
 image: {{ .ModuleName }}/{{ .ImageName }}
 from: {{ index $.Images "base/scratch" }}
 import:
-- image: opentofu
+- from: opentofu
   add: /opentofu/opentofu
   to: /opentofu
   before: setup

--- a/modules/040-terraform-manager/images/base-terraform-manager/werf.inc.yaml
+++ b/modules/040-terraform-manager/images/base-terraform-manager/werf.inc.yaml
@@ -2,13 +2,13 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
 final: false
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: dhctl-base # from main werf.yaml
+- from: dhctl-base # from main werf.yaml
   add: /dhctl/bin/dhctl
   to: /dhctl
   before: setup
-- image: terraform
+- from: terraform
   add: /terraform/terraform
   to: /bin/terraform
   before: setup
@@ -22,13 +22,13 @@ git:
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-opentofu
 final: false
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: dhctl-base # from main werf.yaml
+- from: dhctl-base # from main werf.yaml
   add: /dhctl/bin/dhctl
   to: /dhctl
   before: setup
-- image: opentofu
+- from: opentofu
   add: /opentofu/opentofu
   to: /bin/opentofu
   before: setup
@@ -42,7 +42,7 @@ git:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-terraform-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ $.ModulePath }}modules/040-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches/terraform
   to: /patches
@@ -62,7 +62,7 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-opentofu-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ $.ModulePath }}modules/040-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches/opentofu
   to: /patches
@@ -85,7 +85,7 @@ image: terraform
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-terraform-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-terraform-src-artifact
   add: /src
   to: /src
   before: install
@@ -107,7 +107,7 @@ image: opentofu
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-opentofu-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-opentofu-src-artifact
   add: /src
   to: /src
   before: install

--- a/modules/040-terraform-manager/images/base-terraform/werf.inc.yaml
+++ b/modules/040-terraform-manager/images/base-terraform/werf.inc.yaml
@@ -3,7 +3,7 @@
 image: {{ .ModuleName }}/{{ .ImageName }}
 from: {{ index $.Images "base/scratch" }}
 import:
-- image: terraform
+- from: terraform
   add: /terraform/terraform
   to: /terraform
   before: setup

--- a/modules/040-terraform-manager/images/terraform-manager-aws/werf.inc.yaml
+++ b/modules/040-terraform-manager/images/terraform-manager-aws/werf.inc.yaml
@@ -1,11 +1,11 @@
 {{- if not (and (index . "HasAvailableModules") (not (hasKey (index . "AvailableModulesDict") "cloud-provider-aws"))) }}
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: '{{- include "infrastructure_manager_base_image" (dict "TF" .TF "providerName" "aws") }}'
+from: '{{- include "infrastructure_manager_base_image" (dict "TF" .TF "providerName" "aws") }}'
 git:
 - add: /{{ .ModulePath }}modules/030-cloud-provider-aws/candi
   to: /deckhouse/candi/cloud-providers/aws
 import:
-- image: cloud-provider-aws/terraform-manager
+- from: cloud-provider-aws/terraform-manager
   add: /terraform-manager/terraform-provider-aws
   to: /plugins/{{ include "infrastructure_manager_plugin_dir" (dict "TF" .TF "providerName" "aws") }}/{{ .TF.aws.namespace }}/{{ .TF.aws.type }}/{{ .TF.aws.version }}/linux_amd64/terraform-provider-aws
   before: setup

--- a/modules/040-terraform-manager/images/terraform-manager-azure/werf.inc.yaml
+++ b/modules/040-terraform-manager/images/terraform-manager-azure/werf.inc.yaml
@@ -1,11 +1,11 @@
 {{- if not (and (index . "HasAvailableModules") (not (hasKey (index . "AvailableModulesDict") "cloud-provider-azure"))) }}
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: '{{ include "infrastructure_manager_base_image" (dict "TF" .TF "providerName" "azure") }}'
+from: '{{ include "infrastructure_manager_base_image" (dict "TF" .TF "providerName" "azure") }}'
 git:
 - add: /{{ .ModulePath }}modules/030-cloud-provider-azure/candi
   to: /deckhouse/candi/cloud-providers/azure
 import:
-- image: cloud-provider-azure/terraform-manager
+- from: cloud-provider-azure/terraform-manager
   add: /terraform-manager/terraform-provider-azurerm
   to: /plugins/{{ include "infrastructure_manager_plugin_dir" (dict "TF" .TF "providerName" "azure") }}/{{ .TF.azure.namespace }}/{{ .TF.azure.type }}/{{ .TF.azure.version }}/linux_amd64/terraform-provider-azurerm
   before: setup

--- a/modules/040-terraform-manager/images/terraform-manager-dvp/werf.inc.yaml
+++ b/modules/040-terraform-manager/images/terraform-manager-dvp/werf.inc.yaml
@@ -7,7 +7,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}
 # The base is pinned directly instead of being looked up in candi's
 # terraform_versions.yml: DVP's settings (useOpentofu included) live in its own
 # bundle, so candi carries no dvp entry to look up.
-fromImage: terraform-manager/base-terraform-manager-opentofu
+from: terraform-manager/base-terraform-manager-opentofu
 
 {{ include "image_spec_for_infrastructure_manager" . }}
 {{- end }}

--- a/modules/040-terraform-manager/images/terraform-manager-gcp/werf.inc.yaml
+++ b/modules/040-terraform-manager/images/terraform-manager-gcp/werf.inc.yaml
@@ -1,12 +1,12 @@
 ---
 {{- if not (and (index . "HasAvailableModules") (not (hasKey (index . "AvailableModulesDict") "cloud-provider-gcp"))) }}
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: '{{- include "infrastructure_manager_base_image" (dict "TF" .TF "providerName" "gcp") }}'
+from: '{{- include "infrastructure_manager_base_image" (dict "TF" .TF "providerName" "gcp") }}'
 git:
 - add: /{{ .ModulePath }}modules/030-cloud-provider-gcp/candi
   to: /deckhouse/candi/cloud-providers/gcp
 import:
-- image: cloud-provider-gcp/terraform-manager
+- from: cloud-provider-gcp/terraform-manager
   add: /terraform-manager/terraform-provider-gcp
   to: /plugins/{{ include "infrastructure_manager_plugin_dir" (dict "TF" .TF "providerName" "gcp") }}/{{ .TF.gcp.namespace }}/{{ .TF.gcp.type }}/{{ .TF.gcp.version }}/linux_amd64/terraform-provider-google
   before: setup

--- a/modules/040-terraform-manager/images/terraform-manager-yandex/werf.inc.yaml
+++ b/modules/040-terraform-manager/images/terraform-manager-yandex/werf.inc.yaml
@@ -1,11 +1,11 @@
 {{- if not (and (index . "HasAvailableModules") (not (hasKey (index . "AvailableModulesDict") "cloud-provider-yandex"))) }}
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: '{{- include "infrastructure_manager_base_image" (dict "TF" .TF "providerName" "yandex") }}'
+from: '{{- include "infrastructure_manager_base_image" (dict "TF" .TF "providerName" "yandex") }}'
 git:
 - add: /{{ .ModulePath }}modules/030-cloud-provider-yandex/candi
   to: /deckhouse/candi/cloud-providers/yandex
 import:
-- image: cloud-provider-yandex/terraform-manager
+- from: cloud-provider-yandex/terraform-manager
   add: /terraform-manager/terraform-provider-yandex
   to: /plugins/{{ include "infrastructure_manager_plugin_dir" (dict "TF" .TF "providerName" "yandex") }}/{{ .TF.yandex.namespace }}/{{ .TF.yandex.type }}/{{ .TF.yandex.version }}/linux_amd64/terraform-provider-yandex
   before: setup

--- a/modules/042-kube-dns/images/sts-pods-hosts-appender-init-container/werf.inc.yaml
+++ b/modules/042-kube-dns/images/sts-pods-hosts-appender-init-container/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ $.ModulePath }}modules/042-{{ $.ModuleName }}/images/{{ $.ImageName }}/src
@@ -18,7 +18,7 @@ final: false
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-  - image: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact
+  - from: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact
     add: /src
     to: /src
     before: install
@@ -36,9 +36,9 @@ shell:
       {{- include "image-build.build" $buildContext | indent 6 }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-  - image: {{ .ModuleName }}/{{ $.ImageName }}-artifact
+  - from: {{ .ModuleName }}/{{ $.ImageName }}-artifact
     add: /src/render-etc-hosts-with-cluster-domain-aliases
     to: /render-etc-hosts-with-cluster-domain-aliases
     before: setup

--- a/modules/042-kube-dns/images/sts-pods-hosts-appender-webhook/werf.inc.yaml
+++ b/modules/042-kube-dns/images/sts-pods-hosts-appender-webhook/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ $.ModulePath }}/modules/042-{{ $.ModuleName }}/images/{{ $.ImageName }}/src
@@ -18,7 +18,7 @@ final: false
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-  - image: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact
+  - from: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact
     add: /src
     to: /src
     before: install
@@ -36,9 +36,9 @@ shell:
       {{- include "image-build.build" $buildContext | indent 6 }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ .ModuleName }}/{{ $.ImageName }}-artifact
   add: /src/sts-pods-hosts-appender-webhook
   to: /sts-pods-hosts-appender-webhook
   before: setup

--- a/modules/050-network-policy-engine/images/iptables-wrapper-init/werf.inc.yaml
+++ b/modules/050-network-policy-engine/images/iptables-wrapper-init/werf.inc.yaml
@@ -2,7 +2,7 @@
 {{- $iptables_image_version := $iptables_version | replace "." "-" }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 fromCacheVersion: "2025-09-10-2"
 import:
 - from: {{ index $.Images "tools/coreutils" }}
@@ -16,18 +16,18 @@ import:
   add: /usr/bin/bash
   to: /bin/bash
   before: setup
-- image: common/iptables-wrapper
+- from: common/iptables-wrapper
   add: /iptables-wrapper
   to: /iptables-wrapper
   before: setup
-- image: registrypackages/iptables-artifact-{{ $iptables_image_version }}
+- from: registrypackages/iptables-artifact-{{ $iptables_image_version }}
   add: /
   to: /_sbin
   includePaths:
   - xtables-legacy-multi
   - xtables-nft-multi
   before: setup
-- image: {{ .ModuleName }}/{{ .ImageName }}-relocate-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-relocate-artifact
   add: /relocate
   to: /relocate
   before: setup
@@ -36,7 +36,7 @@ import:
 image: {{ .ModuleName }}/{{ .ImageName }}-relocate-artifact
 final: false
 fromCacheVersion: "2025-09-10-2"
-fromImage: common/relocate-artifact
+from: common/relocate-artifact
 shell:
   install:
   - mkdir -p /relocate/sbin

--- a/modules/050-network-policy-engine/images/kube-router/werf.inc.yaml
+++ b/modules/050-network-policy-engine/images/kube-router/werf.inc.yaml
@@ -3,7 +3,7 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
 final: false
-fromImage: common/relocate-artifact
+from: common/relocate-artifact
 shell:
   beforeInstall:
   - apt-get install -y ipset conntrack-tools
@@ -12,7 +12,7 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 secrets:
 - id: SOURCE_REPO
   value: {{ .SOURCE_REPO }}
@@ -33,7 +33,7 @@ shell:
 image: {{ .ModuleName }}/kube-router-artifact
 final: false
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src
   to: /src
   before: install
@@ -50,13 +50,13 @@ shell:
   - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "-X github.com/cloudnativelabs/kube-router/v2/pkg/version.Version=${GIT_COMMIT} -X github.com/cloudnativelabs/kube-router/v2/pkg/version.BuildDate=${BUILD_DATE}" -o kube-router cmd/kube-router/kube-router.go
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /relocate
   to: /
   before: setup
-- image: {{ .ModuleName }}/kube-router-artifact
+- from: {{ .ModuleName }}/kube-router-artifact
   add: /src/kube-router
   to: /opt/bin/kube-router
   before: setup

--- a/modules/101-cert-manager/images/cert-manager-acme-solver/werf.inc.yaml
+++ b/modules/101-cert-manager/images/cert-manager-acme-solver/werf.inc.yaml
@@ -1,7 +1,7 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/cert-manager-controller-artifact
+- from: {{ $.ModuleName }}/cert-manager-controller-artifact
   add: /acmesolver-linux-amd64
   to: /bin/acmesolver
   before: setup

--- a/modules/101-cert-manager/images/cert-manager-cainjector/werf.inc.yaml
+++ b/modules/101-cert-manager/images/cert-manager-cainjector/werf.inc.yaml
@@ -1,7 +1,7 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/cert-manager-controller-artifact
+- from: {{ $.ModuleName }}/cert-manager-controller-artifact
   add: /cainjector-linux-amd64
   to: /bin/cainjector
   before: setup

--- a/modules/101-cert-manager/images/cert-manager-controller/werf.inc.yaml
+++ b/modules/101-cert-manager/images/cert-manager-controller/werf.inc.yaml
@@ -1,8 +1,8 @@
 {{- $version := include "get_oss_version_by_id" (list "cert-manager" $ )  -}} # see in oss.yaml
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /controller-linux-amd64
   to: /bin/cert-manager-controller
   before: setup
@@ -11,7 +11,7 @@ imageSpec:
     entrypoint: ["/bin/cert-manager-controller"]
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $version | replace "." "-" }}
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ $.ModulePath }}modules/101-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
@@ -20,7 +20,7 @@ git:
     install:
     - '**/*'
 - add: /{{ $.ModulePath }}modules/101-{{ $.ModuleName }}/crds
-  to: /module_crds    
+  to: /module_crds
 secrets:
 - id: SOURCE_REPO
   value: {{ .SOURCE_REPO }}
@@ -36,15 +36,15 @@ shell:
   - rm -rf /src/.git
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-ci-validator
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ $.ModulePath }}modules/101-{{ $.ModuleName }}/crds
   to: /module_crds
 - add: /{{ $.ModulePath }}modules/101-{{ $.ModuleName }}/docs
-  to: /docs  
+  to: /docs
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact-{{ $version | replace "." "-" }}
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact-{{ $version | replace "." "-" }}
   add: /src/deploy/crds
   to: /src/deploy/crds
   before: install
@@ -54,7 +54,7 @@ import:
   before: install
 shell:
   install:
-  - | 
+  - |
     echo "Checking if module crds are the same as cert-manager crds"
     DOWNLOAD=false CRD_FILE_PATH=/src/deploy/crds MODULE_VERSION=v{{ $version }} /module_crds/cert-manager/update.sh
 
@@ -63,7 +63,7 @@ shell:
     for f in $dir1/*.yaml; do
       base=$(basename "$f")
         diff <(yq -P 'sort_keys(..)' $dir1/$base) <(yq -P 'sort_keys(..)' $dir2/$base)
-    done  
+    done
 
   - |
     echo "Checking cert-manager version in documentation"
@@ -74,7 +74,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 from: {{ index $.Images ( eq $.SVACE_ENABLED "false" | ternary "builder/golang-bookworm" "builder/golang-bookworm-svace" ) }}
 final: false
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact-{{ $version | replace "." "-" }}
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact-{{ $version | replace "." "-" }}
   add: /src
   to: /src
   before: install

--- a/modules/101-cert-manager/images/cert-manager-webhook/werf.inc.yaml
+++ b/modules/101-cert-manager/images/cert-manager-webhook/werf.inc.yaml
@@ -1,7 +1,7 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/cert-manager-controller-artifact
+- from: {{ $.ModuleName }}/cert-manager-controller-artifact
   add: /webhook-linux-amd64
   to: /bin/webhook
   before: setup

--- a/modules/110-istio/images/cni-v1x21x6/werf.inc.yaml
+++ b/modules/110-istio/images/cni-v1x21x6/werf.inc.yaml
@@ -6,32 +6,32 @@
 ---
 # Based on https://github.com/istio/istio/blob/1.21.6/cni/deployments/kubernetes/Dockerfile.install-cni
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /src/istio/out/istio-cni
   to: /opt/cni/bin/istio-cni
   owner: 1337
   group: 1337
   after: setup
-- image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /src/istio/out/install-cni
   to: /usr/local/bin/install-cni
   owner: 1337
   group: 1337
   after: setup
-- image: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
   add: /relocate
   to: /
   before: setup
-- image: registrypackages/iptables-artifact-{{ $iptables_image_version }}
+- from: registrypackages/iptables-artifact-{{ $iptables_image_version }}
   add: /
   to: /sbin
   includePaths:
   - xtables-legacy-multi
   - xtables-nft-multi
   before: setup
-- image: common/iptables-wrapper
+- from: common/iptables-wrapper
   add: /iptables-wrapper
   to: /sbin/iptables-wrapper
   before: setup
@@ -47,7 +47,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-- image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
+- from: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
   add: /src/istio
   to: /src/istio
   before: install

--- a/modules/110-istio/images/cni-v1x25x2/werf.inc.yaml
+++ b/modules/110-istio/images/cni-v1x25x2/werf.inc.yaml
@@ -6,32 +6,32 @@
 ---
 # Based on https://github.com/istio/istio/blob/1.25.2/cni/deployments/kubernetes/Dockerfile.install-cni
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /src/istio/out/istio-cni
   to: /opt/cni/bin/istio-cni
   owner: 1337
   group: 1337
   after: setup
-- image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /src/istio/out/install-cni
   to: /usr/local/bin/install-cni
   owner: 1337
   group: 1337
   after: setup
-- image: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
   add: /relocate
   to: /
   before: setup
-- image: registrypackages/iptables-artifact-{{ $iptables_image_version }}
+- from: registrypackages/iptables-artifact-{{ $iptables_image_version }}
   add: /
   to: /sbin
   includePaths:
   - xtables-legacy-multi
   - xtables-nft-multi
   before: setup
-- image: common/iptables-wrapper
+- from: common/iptables-wrapper
   add: /iptables-wrapper
   to: /sbin/iptables-wrapper
   before: setup
@@ -47,7 +47,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-- image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
+- from: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
   add: /src/istio
   to: /src/istio
   before: install

--- a/modules/110-istio/images/cni-v1x27x9/werf.inc.yaml
+++ b/modules/110-istio/images/cni-v1x27x9/werf.inc.yaml
@@ -7,32 +7,32 @@
 ---
 # Based on https://github.com/istio/istio/blob/1.27.9/cni/deployments/kubernetes/Dockerfile.install-cni
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /src/istio/out/istio-cni
   to: /opt/cni/bin/istio-cni
   owner: 1337
   group: 1337
   after: setup
-- image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /src/istio/out/install-cni
   to: /usr/local/bin/install-cni
   owner: 1337
   group: 1337
   after: setup
-- image: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
   add: /relocate
   to: /
   before: setup
-- image: registrypackages/iptables-artifact-{{ $iptables_image_version }}
+- from: registrypackages/iptables-artifact-{{ $iptables_image_version }}
   add: /
   to: /sbin
   includePaths:
   - xtables-legacy-multi
   - xtables-nft-multi
   before: setup
-- image: common/iptables-wrapper
+- from: common/iptables-wrapper
   add: /iptables-wrapper
   to: /sbin/iptables-wrapper
   before: setup
@@ -49,7 +49,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-- image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
+- from: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
   add: /src/istio
   to: /src/istio
   before: install

--- a/modules/110-istio/images/common-v1x21x6/werf.inc.yaml
+++ b/modules/110-istio/images/common-v1x21x6/werf.inc.yaml
@@ -3,7 +3,7 @@
 {{- $kialiVersion := printf "v%s" (include "get_oss_version_by_id" (list "kiali-for-istio-1-21" $ )) }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/patches
@@ -43,7 +43,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-kiali-frontend-build-artifact
 from: {{ index $.Images "builder/node-alpine-22.16" }}
 final: false
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src/kiali/frontend
   to: /src/kiali/frontend
   before: install

--- a/modules/110-istio/images/common-v1x25x2/werf.inc.yaml
+++ b/modules/110-istio/images/common-v1x25x2/werf.inc.yaml
@@ -3,7 +3,7 @@
 {{- $kialiVersion := printf "v%s" (include "get_oss_version_by_id" (list "kiali-for-istio-1-25" $ )) }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/patches
@@ -38,7 +38,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-kiali-frontend-build-artifact
 from: {{ index $.Images "builder/node-alpine-22.16" }}
 final: false
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src/kiali/frontend
   to: /src/kiali/frontend
   before: install

--- a/modules/110-istio/images/common-v1x27x9/werf.inc.yaml
+++ b/modules/110-istio/images/common-v1x27x9/werf.inc.yaml
@@ -4,7 +4,7 @@
 {{- $kialiVersion := printf "v%s" (include "get_oss_version_by_id" (list "kiali-for-istio-1-27" $ )) }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/patches
@@ -37,7 +37,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-kiali-frontend-build-artifact
 from: {{ index $.Images "builder/node-alpine-22.16" }}
 final: false
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src/kiali/frontend
   to: /src/kiali/frontend
   before: install

--- a/modules/110-istio/images/istioctl-v1x21x6/werf.inc.yaml
+++ b/modules/110-istio/images/istioctl-v1x21x6/werf.inc.yaml
@@ -15,7 +15,7 @@ git:
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-- image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
+- from: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
   add: /src/istio
   to: /src/istio
   before: install

--- a/modules/110-istio/images/istioctl-v1x25x2/werf.inc.yaml
+++ b/modules/110-istio/images/istioctl-v1x25x2/werf.inc.yaml
@@ -15,7 +15,7 @@ git:
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-- image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
+- from: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
   add: /src/istio
   to: /src/istio
   before: install

--- a/modules/110-istio/images/istioctl-v1x27x9/werf.inc.yaml
+++ b/modules/110-istio/images/istioctl-v1x27x9/werf.inc.yaml
@@ -16,7 +16,7 @@ git:
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-- image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
+- from: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
   add: /src/istio
   to: /src/istio
   before: install

--- a/modules/110-istio/images/kiali-v1x21x6/werf.inc.yaml
+++ b/modules/110-istio/images/kiali-v1x21x6/werf.inc.yaml
@@ -5,13 +5,13 @@
 ---
 # Based on https://github.com/kiali/kiali/blob/v1.81.0/deploy/docker/Dockerfile-distroless
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-backend-build-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-backend-build-artifact
   add: /src/kiali/out/kiali
   to: /opt/kiali/kiali
   before: install
-- image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-kiali-frontend-build-artifact
+- from: {{ .ModuleName }}/common-{{ $istioImageVersion }}-kiali-frontend-build-artifact
   add: /src/kial-frontend-assets/static
   to: /opt/kiali/console
   before: install
@@ -28,7 +28,7 @@ from: {{ index $.Images "builder/golang" }}
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-- image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
+- from: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
   add: /src/kiali
   to: /src/kiali
   before: setup

--- a/modules/110-istio/images/kiali-v1x25x2/werf.inc.yaml
+++ b/modules/110-istio/images/kiali-v1x25x2/werf.inc.yaml
@@ -5,13 +5,13 @@
 ---
 # Based on https://github.com/kiali/kiali/blob/v2.7.1/deploy/docker/Dockerfile-distroless
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-backend-build-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-backend-build-artifact
   add: /src/kiali/out/kiali
   to: /opt/kiali/kiali
   before: install
-- image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-kiali-frontend-build-artifact
+- from: {{ .ModuleName }}/common-{{ $istioImageVersion }}-kiali-frontend-build-artifact
   add: /src/kial-frontend-assets/static
   to: /opt/kiali/console
   before: install
@@ -28,7 +28,7 @@ from: {{ index $.Images "builder/golang" }}
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-- image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
+- from: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
   add: /src/kiali
   to: /src/kiali
   before: setup

--- a/modules/110-istio/images/kiali-v1x27x9/werf.inc.yaml
+++ b/modules/110-istio/images/kiali-v1x27x9/werf.inc.yaml
@@ -6,9 +6,9 @@
 ---
 # Based on https://github.com/kiali/kiali/blob/v2.12.0/deploy/docker/Dockerfile-distroless
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-backend-build-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-backend-build-artifact
   add: /src/kiali/out/kiali
   to: /opt/kiali/kiali
   owner: 64535
@@ -27,11 +27,11 @@ from: {{ index $.Images "builder/golang" }}
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-- image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
+- from: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
   add: /src/kiali
   to: /src/kiali
   before: install
-- image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-kiali-frontend-build-artifact
+- from: {{ .ModuleName }}/common-{{ $istioImageVersion }}-kiali-frontend-build-artifact
   add: /src/kiali/frontend/build
   to: /src/kiali/frontend/build
   before: install

--- a/modules/110-istio/images/operator-v1x21x6/werf.inc.yaml
+++ b/modules/110-istio/images/operator-v1x21x6/werf.inc.yaml
@@ -4,15 +4,15 @@
 ---
 # Based on https://github.com/istio/istio/blob/1.21.6/operator/docker/Dockerfile.operator
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /src/istio/out/operator
   to: /usr/local/bin/operator
   owner: 1337
   group: 1337
   after: setup
-- image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /src/istio/manifests
   to: /var/lib/istio/manifests
   after: setup
@@ -31,7 +31,7 @@ git:
     install:
     - '**/*'
 import:
-- image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
+- from: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
   add: /src/istio
   to: /src/istio
   before: install

--- a/modules/110-istio/images/operator-v1x25x2/werf.inc.yaml
+++ b/modules/110-istio/images/operator-v1x25x2/werf.inc.yaml
@@ -4,19 +4,19 @@
 ---
 # Based on https://github.com/istio/istio/blob/1.21.6/operator/docker/Dockerfile.operator
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /src/operator/out/operator
   to: /usr/local/bin/operator
   owner: 1337
   group: 1337
   after: setup
-- image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
+- from: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
   add: /src/istio/manifests
   to: /var/lib/istio/manifests
   after: setup
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src/operator/resources
   to: /var/lib/sail-operator/resources
   after: setup
@@ -31,7 +31,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src/operator
   to: /src/operator
   before: install
@@ -57,7 +57,7 @@ shell:
 #=====================================================================================================
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/patches

--- a/modules/110-istio/images/pilot-v1x21x6/werf.inc.yaml
+++ b/modules/110-istio/images/pilot-v1x21x6/werf.inc.yaml
@@ -4,21 +4,21 @@
 ---
 # Based on https://github.com/istio/istio/blob/1.21.6/pilot/docker/Dockerfile.pilot
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /src/istio/out/pilot-discovery
   to: /usr/local/bin/pilot-discovery
   owner: 1337
   group: 1337
   after: setup
-- image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
+- from: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
   add: /src/istio/tools/packaging/common/envoy_bootstrap.json
   to: /var/lib/istio/envoy/envoy_bootstrap_tmpl.json
   owner: 1337
   group: 1337
   after: setup
-- image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
+- from: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
   add: /src/istio/tools/packaging/common/gcp_envoy_bootstrap.json
   to: /var/lib/istio/envoy/gcp_envoy_bootstrap_tmpl.json
   owner: 1337
@@ -36,7 +36,7 @@ from: {{ index $.Images "builder/golang" }}
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-- image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
+- from: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
   add: /src/istio
   to: /src/istio
   before: setup

--- a/modules/110-istio/images/pilot-v1x25x2/werf.inc.yaml
+++ b/modules/110-istio/images/pilot-v1x25x2/werf.inc.yaml
@@ -4,15 +4,15 @@
 ---
 # Based on https://github.com/istio/istio/blob/1.25.2/pilot/docker/Dockerfile.pilot
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /src/istio/out/pilot-discovery
   to: /usr/local/bin/pilot-discovery
   owner: 1337
   group: 1337
   after: setup
-- image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
+- from: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
   add: /src/istio/tools/packaging/common/envoy_bootstrap.json
   to: /var/lib/istio/envoy/envoy_bootstrap_tmpl.json
   owner: 1337
@@ -30,7 +30,7 @@ from: {{ index $.Images "builder/golang" }}
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-- image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
+- from: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
   add: /src/istio
   to: /src/istio
   before: setup

--- a/modules/110-istio/images/pilot-v1x27x9/werf.inc.yaml
+++ b/modules/110-istio/images/pilot-v1x27x9/werf.inc.yaml
@@ -5,15 +5,15 @@
 ---
 # Based on https://github.com/istio/istio/blob/1.27.9/pilot/docker/Dockerfile.pilot
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /src/istio/out/pilot-discovery
   to: /usr/local/bin/pilot-discovery
   owner: 1337
   group: 1337
   after: setup
-- image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
+- from: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
   add: /src/istio/tools/packaging/common/envoy_bootstrap.json
   to: /var/lib/istio/envoy/envoy_bootstrap_tmpl.json
   owner: 1337
@@ -31,7 +31,7 @@ from: {{ index $.Images "builder/golang" }}
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-- image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
+- from: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
   add: /src/istio
   to: /src/istio
   before: setup

--- a/modules/110-istio/images/proxyv2-v1x21x6/werf.inc.yaml
+++ b/modules/110-istio/images/proxyv2-v1x21x6/werf.inc.yaml
@@ -13,27 +13,27 @@
 # Based on https://github.com/istio/istio/blob/1.21.6/docker/Dockerfile.base
 #      and https://github.com/istio/istio/blob/1.21.6/pilot/docker/Dockerfile.proxyv2
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
+- from: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
   add: /src/istio/tools/packaging/common/envoy_bootstrap.json
   to: /var/lib/istio/envoy/envoy_bootstrap_tmpl.json
   owner: 1337
   group: 1337
   after: setup
-- image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
+- from: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
   add: /src/istio/tools/packaging/common/gcp_envoy_bootstrap.json
   to: /var/lib/istio/envoy/gcp_envoy_bootstrap_tmpl.json
   owner: 1337
   group: 1337
   after: setup
-- image: {{ .ModuleName }}/{{ .ImageName }}-agent-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-agent-artifact
   add: /src/istio/out/pilot-agent
   to: /usr/local/bin/pilot-agent
   owner: 1337
   group: 1337
   after: setup
-- image: {{ .ModuleName }}/{{ .ImageName }}-build-envoy-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-build-envoy-artifact
   add: /src/proxy/bin/envoy
   to: /usr/local/bin/envoy
   owner: 1337
@@ -51,22 +51,22 @@ import:
   add: /lib64/ld-linux-x86-64.so.2
   to: /lib64/ld-linux-x86-64.so.2
   after: setup
-- image: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
   add: /relocate
   to: /
   before: setup
-- image: registrypackages/iptables-artifact-{{ $iptables_image_version }}
+- from: registrypackages/iptables-artifact-{{ $iptables_image_version }}
   add: /
   to: /sbin
   includePaths:
   - xtables-legacy-multi
   - xtables-nft-multi
   before: setup
-- image: common/iptables-wrapper
+- from: common/iptables-wrapper
   add: /iptables-wrapper
   to: /sbin/iptables-wrapper
   before: setup
-- image: registrypackages/d8-curl-artifact-8-9-1
+- from: registrypackages/d8-curl-artifact-8-9-1
   add: /d8-curl
   to: /usr/bin/curl
   before: setup
@@ -84,7 +84,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-agent-artifact
 from: {{ index $.Images "builder/golang-alpine" }}
 final: false
 import:
-- image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
+- from: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
   add: /src/istio
   to: /src/istio
   before: install
@@ -123,14 +123,14 @@ shell:
   - chown 1337:1337 /src/istio/out/pilot-agent
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-build-envoy-artifact
-fromImage: {{ $.ModuleName }}/{{ .ImageName }}-build-image-artifact
+from: {{ $.ModuleName }}/{{ .ImageName }}-build-image-artifact
 final: false
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src/proxy
   to: /src/proxy
   before: install
-- image: {{ .ModuleName }}/{{ .ImageName }}-build-libcxx-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-build-libcxx-artifact
   add: /opt/libcxx
   to: /opt/libcxx
   before: install
@@ -184,10 +184,10 @@ shell:
   - mv /src/proxy/bazel-bin/envoy /src/proxy/bin/
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-build-libcxx-artifact
-fromImage: {{ $.ModuleName }}/{{ .ImageName }}-build-image-artifact
+from: {{ $.ModuleName }}/{{ .ImageName }}-build-image-artifact
 final: false
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src/llvm
   to: /src/llvm
   before: install
@@ -222,7 +222,7 @@ shell:
   - rm -rf /opt/libcxx/include
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
-fromImage: common/relocate-artifact
+from: common/relocate-artifact
 final: false
 shell:
   beforeInstall:
@@ -261,7 +261,7 @@ mount:
 - from: tmp_dir
   to: /root/.cache/bazel
 import:
-- image: {{ .ModuleName }}/golang-artifact
+- from: {{ .ModuleName }}/golang-artifact
   add: /usr/local/go
   to: /usr/local/go
   before: install
@@ -338,7 +338,7 @@ imageSpec:
 #=====================================================================================================
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/patches

--- a/modules/110-istio/images/proxyv2-v1x25x2/werf.inc.yaml
+++ b/modules/110-istio/images/proxyv2-v1x25x2/werf.inc.yaml
@@ -13,21 +13,21 @@
 # Based on https://github.com/istio/istio/blob/1.25.2/docker/Dockerfile.base
 #      and https://github.com/istio/istio/blob/1.25.2/pilot/docker/Dockerfile.proxyv2
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
+- from: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
   add: /src/istio/tools/packaging/common/envoy_bootstrap.json
   to: /var/lib/istio/envoy/envoy_bootstrap_tmpl.json
   owner: 1337
   group: 1337
   after: setup
-- image: {{ .ModuleName }}/{{ .ImageName }}-agent-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-agent-artifact
   add: /src/istio/out/pilot-agent
   to: /usr/local/bin/pilot-agent
   owner: 1337
   group: 1337
   after: setup
-- image: {{ .ModuleName }}/{{ .ImageName }}-build-envoy-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-build-envoy-artifact
   add: /src/proxy/bin/envoy
   to: /usr/local/bin/envoy
   owner: 1337
@@ -45,22 +45,22 @@ import:
   add: /lib64/ld-linux-x86-64.so.2
   to: /lib64/ld-linux-x86-64.so.2
   before: install
-- image: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
   add: /relocate
   to: /
   before: setup
-- image: registrypackages/iptables-artifact-{{ $iptables_image_version }}
+- from: registrypackages/iptables-artifact-{{ $iptables_image_version }}
   add: /
   to: /sbin
   includePaths:
   - xtables-legacy-multi
   - xtables-nft-multi
   before: setup
-- image: common/iptables-wrapper
+- from: common/iptables-wrapper
   add: /iptables-wrapper
   to: /sbin/iptables-wrapper
   before: setup
-- image: registrypackages/d8-curl-artifact-8-9-1
+- from: registrypackages/d8-curl-artifact-8-9-1
   add: /d8-curl
   to: /usr/bin/curl
   before: setup
@@ -68,7 +68,7 @@ import:
 imageSpec:
   config:
     user: "1337:1337"
-    env: 
+    env:
       ISTIO_META_ISTIO_PROXY_SHA: "istio-proxy:78bd2d9b284978e170a49cd13decd5f952544489"
       ISTIO_META_ISTIO_VERSION: {{ $istioVersion }}
     workingDir: "/"
@@ -80,7 +80,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-agent-artifact
 from: {{ index $.Images "builder/golang-alpine" }}
 final: false
 import:
-- image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
+- from: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
   add: /src/istio
   to: /src/istio
   before: install
@@ -119,10 +119,10 @@ shell:
   - chown 1337:1337 /src/istio/out/pilot-agent
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-build-envoy-artifact
-fromImage: {{ $.ModuleName }}/{{ .ImageName }}-build-image-artifact
+from: {{ $.ModuleName }}/{{ .ImageName }}-build-image-artifact
 final: false
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src/proxy
   to: /src/proxy
   before: install
@@ -163,7 +163,7 @@ shell:
   - rm -rf /tmp/bazel-cache
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
-fromImage: common/relocate-artifact
+from: common/relocate-artifact
 final: false
 shell:
   beforeInstall:
@@ -200,11 +200,11 @@ final: false
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-golang-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-golang-artifact
   add: /usr/local/go
   to: /usr/local/go
   before: install
-- image: common/alt-p11-artifact
+- from: common/alt-p11-artifact
   add: /root/.ssh
   to: /root/.ssh
   before: install
@@ -266,7 +266,7 @@ imageSpec:
 #=====================================================================================================
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 secrets:
 - id: SOURCE_REPO

--- a/modules/110-istio/images/proxyv2-v1x27x9/werf.inc.yaml
+++ b/modules/110-istio/images/proxyv2-v1x27x9/werf.inc.yaml
@@ -17,21 +17,21 @@
 # Based on https://github.com/istio/istio/blob/1.27.9/docker/Dockerfile.base
 #      and https://github.com/istio/istio/blob/1.27.9/pilot/docker/Dockerfile.proxyv2
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
+- from: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
   add: /src/istio/tools/packaging/common/envoy_bootstrap.json
   to: /var/lib/istio/envoy/envoy_bootstrap_tmpl.json
   owner: 1337
   group: 1337
   after: setup
-- image: {{ .ModuleName }}/{{ .ImageName }}-agent-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-agent-artifact
   add: /src/istio/out/pilot-agent
   to: /usr/local/bin/pilot-agent
   owner: 1337
   group: 1337
   after: setup
-- image: {{ .ModuleName }}/{{ .ImageName }}-build-envoy-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-build-envoy-artifact
   add: /src/proxy/bin/envoy
   to: /usr/local/bin/envoy
   owner: 1337
@@ -49,22 +49,22 @@ import:
   add: /lib64/ld-linux-x86-64.so.2
   to: /lib64/ld-linux-x86-64.so.2
   before: install
-- image: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
   add: /relocate
   to: /
   before: setup
-- image: registrypackages/iptables-artifact-{{ $iptables_image_version }}
+- from: registrypackages/iptables-artifact-{{ $iptables_image_version }}
   add: /
   to: /sbin
   includePaths:
   - xtables-legacy-multi
   - xtables-nft-multi
   before: setup
-- image: common/iptables-wrapper
+- from: common/iptables-wrapper
   add: /iptables-wrapper
   to: /sbin/iptables-wrapper
   before: setup
-- image: registrypackages/d8-curl-artifact-8-9-1
+- from: registrypackages/d8-curl-artifact-8-9-1
   add: /d8-curl
   to: /usr/bin/curl
   before: setup
@@ -72,7 +72,7 @@ import:
 imageSpec:
   config:
     user: "1337:1337"
-    env: 
+    env:
       ISTIO_META_ISTIO_PROXY_SHA: "istio-proxy:78bd2d9b284978e170a49cd13decd5f952544489"
       ISTIO_META_ISTIO_VERSION: {{ $istioVersion }}
     workingDir: "/"
@@ -84,7 +84,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-agent-artifact
 from: {{ index $.Images "builder/golang-alpine" }}
 final: false
 import:
-- image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
+- from: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
   add: /src/istio
   to: /src/istio
   before: install
@@ -123,10 +123,10 @@ shell:
   - chown 1337:1337 /src/istio/out/pilot-agent
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-build-envoy-artifact
-fromImage: {{ $.ModuleName }}/{{ .ImageName }}-build-image-artifact
+from: {{ $.ModuleName }}/{{ .ImageName }}-build-image-artifact
 final: false
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src/proxy
   to: /src/proxy
   before: install
@@ -182,7 +182,7 @@ shell:
   - rm -rf /src/proxy/bazel-bin/envoy
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
-fromImage: common/relocate-artifact
+from: common/relocate-artifact
 final: false
 shell:
   beforeInstall:
@@ -219,11 +219,11 @@ final: false
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-golang-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-golang-artifact
   add: /usr/local/go
   to: /usr/local/go
   before: install
-- image: common/alt-p11-artifact
+- from: common/alt-p11-artifact
   add: /root/.ssh
   to: /root/.ssh
   before: install
@@ -323,7 +323,7 @@ imageSpec:
     env: {"GOROOT": "/usr/local/go", "GOPATH": "/go", "PATH": "${PATH}:${GOROOT}/bin:${GOPATH}/bin", "GOOS": "linux", "GOARCH": "amd64"}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 secrets:
 - id: SOURCE_REPO

--- a/modules/150-user-authn/images/basic-auth-proxy/werf.inc.yaml
+++ b/modules/150-user-authn/images/basic-auth-proxy/werf.inc.yaml
@@ -1,9 +1,9 @@
 {{- if ne $.Env "CSE" }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-  - image: {{ $.ModuleName }}/{{ $.ImageName }}-basic-auth-proxy-artifact
+  - from: {{ $.ModuleName }}/{{ $.ImageName }}-basic-auth-proxy-artifact
     add: /src/basic-auth-proxy
     to: /basic-auth-proxy
     before: setup
@@ -12,7 +12,7 @@ imageSpec:
     entrypoint: [ "/basic-auth-proxy" ]
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-basic-auth-proxy-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/app
@@ -34,7 +34,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-basic-auth-proxy-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-basic-auth-proxy-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-basic-auth-proxy-src-artifact
   add: /src
   to: /src
   before: install

--- a/modules/150-user-authn/images/dex-authenticator/werf.inc.yaml
+++ b/modules/150-user-authn/images/dex-authenticator/werf.inc.yaml
@@ -1,12 +1,12 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-oauth2-proxy-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-oauth2-proxy-artifact
   add: /src/oauth2-proxy
   to: /bin/oauth2_proxy
   before: setup
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-url-exec-prober-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-url-exec-prober-artifact
   add: /src/url-exec-prober
   to: /usr/local/bin/url-exec-prober
   before: setup
@@ -17,7 +17,7 @@ imageSpec:
     cmd: [ "--upstream=http://0.0.0.0:8080/", "--http-address=0.0.0.0:4180" ]
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
   - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches/
@@ -54,7 +54,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-oauth2-proxy-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-  - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+  - from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
     add: /src
     to: /src
     before: install
@@ -77,7 +77,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-url-exec-prober-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src/url-exec-prober
   to: /src
   before: install

--- a/modules/150-user-authn/images/dex/werf.inc.yaml
+++ b/modules/150-user-authn/images/dex/werf.inc.yaml
@@ -1,13 +1,13 @@
 {{- $dexVersion := include "get_oss_version_by_id" (list "dex" $ ) }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-dex-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-dex-artifact
   add: /src/dex
   to: /usr/local/bin/dex
   before: setup
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-dex-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-dex-src-artifact
   add: /web
   to: /web
   before: setup
@@ -17,7 +17,7 @@ imageSpec:
     entrypoint: ["/usr/local/bin/dex", "serve", "/etc/dex/config.docker.yaml"]
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-dex-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 fromCacheVersion: "2025-02-18.01"
 final: false
 git:
@@ -58,7 +58,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-dex-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-  - image: {{ $.ModuleName }}/{{ $.ImageName }}-dex-src-artifact
+  - from: {{ $.ModuleName }}/{{ $.ImageName }}-dex-src-artifact
     add: /src
     to: /src
     before: install

--- a/modules/150-user-authn/images/kubeconfig-generator/werf.inc.yaml
+++ b/modules/150-user-authn/images/kubeconfig-generator/werf.inc.yaml
@@ -1,20 +1,20 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /src/dex-k8s-authenticator
   to: /app/bin/dex-k8s-authenticator
   before: setup
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /etc/nsswitch.conf
   to: /etc/nsswitch.conf
   before: setup
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /src/html
   to: /app/html
   before: setup
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /src/templates
   to: /app/templates
   before: setup
@@ -25,7 +25,7 @@ imageSpec:
     workingDir: "/app"
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
   - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
@@ -50,7 +50,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-  - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+  - from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
     add: /src
     to: /src
     before: install

--- a/modules/150-user-authn/images/self-signed-generator/werf.inc.yaml
+++ b/modules/150-user-authn/images/self-signed-generator/werf.inc.yaml
@@ -1,8 +1,8 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /src/self-signed-generator
   to: /self-signed-generator
   before: setup
@@ -12,7 +12,7 @@ imageSpec:
     entrypoint: [ "/self-signed-generator" ]
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
   - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/src
@@ -22,7 +22,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-  - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+  - from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
     add: /src
     to: /src
     before: install

--- a/modules/150-user-authn/images/user-api/werf.inc.yaml
+++ b/modules/150-user-authn/images/user-api/werf.inc.yaml
@@ -1,8 +1,8 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /src/user-api
   to: /user-api
   before: setup
@@ -12,7 +12,7 @@ imageSpec:
     entrypoint: [ "/user-api" ]
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
   - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/src
@@ -22,7 +22,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-  - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+  - from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
     add: /src
     to: /src
     before: install

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/werf.inc.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/werf.inc.yaml
@@ -1,16 +1,16 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
   add: /src/multitenancy-manager
   to: /multitenancy-manager
   before: setup
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src/templates
   to: /templates
   before: setup
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src/helmlib
   to: /helmlib
   before: setup
@@ -20,7 +20,7 @@ imageSpec:
     entrypoint: [ "/multitenancy-manager" ]
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
   - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/src
@@ -48,7 +48,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-  - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+  - from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
     add: /src
     to: /src
     before: install

--- a/modules/302-vertical-pod-autoscaler/images/admission-controller/werf.inc.yaml
+++ b/modules/302-vertical-pod-autoscaler/images/admission-controller/werf.inc.yaml
@@ -1,12 +1,12 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/vertical-pod-autoscaler-artifact
+- from: {{ .ModuleName }}/vertical-pod-autoscaler-artifact
   add: /admission-controller
   to: /admission-controller
   before: setup
-{{- include "image mount points" . }}  
+{{- include "image mount points" . }}
 imageSpec:
   config:
     entrypoint: ["/admission-controller"]

--- a/modules/302-vertical-pod-autoscaler/images/recommender/werf.inc.yaml
+++ b/modules/302-vertical-pod-autoscaler/images/recommender/werf.inc.yaml
@@ -1,8 +1,8 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/vertical-pod-autoscaler-artifact
+- from: {{ .ModuleName }}/vertical-pod-autoscaler-artifact
   add: /recommender
   to: /recommender
   before: setup

--- a/modules/302-vertical-pod-autoscaler/images/updater/werf.inc.yaml
+++ b/modules/302-vertical-pod-autoscaler/images/updater/werf.inc.yaml
@@ -1,8 +1,8 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/vertical-pod-autoscaler-artifact
+- from: {{ .ModuleName }}/vertical-pod-autoscaler-artifact
   add: /updater
   to: /updater
   before: setup

--- a/modules/302-vertical-pod-autoscaler/images/vertical-pod-autoscaler/werf.inc.yaml
+++ b/modules/302-vertical-pod-autoscaler/images/vertical-pod-autoscaler/werf.inc.yaml
@@ -1,7 +1,7 @@
 {{- $vpaVersion := include "get_oss_version_by_id" (list "autoscaler" $ )  -}}
 ---
 image: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ $.ModulePath }}/modules/302-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
@@ -24,7 +24,7 @@ image: {{ .ModuleName }}/{{ $.ImageName }}-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-  - image: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact
+  - from: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact
     add: /src
     to: /src
     before: install

--- a/modules/400-descheduler/images/descheduler/werf.inc.yaml
+++ b/modules/400-descheduler/images/descheduler/werf.inc.yaml
@@ -2,7 +2,7 @@
 {{- $version = printf "v%s" $version }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ $.ModulePath }}modules/400-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
@@ -25,7 +25,7 @@ image: {{ .ModuleName }}/build-artifact
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src
   to: /src
   before: install
@@ -46,7 +46,7 @@ shell:
 image: {{ .ModuleName }}/{{ .ImageName }}
 from: {{ index $.Images "base/distroless" }}
 import:
-- image: {{ .ModuleName }}/build-artifact
+- from: {{ .ModuleName }}/build-artifact
   add: /descheduler
   to: /descheduler
   before: setup

--- a/modules/470-chrony/images/chrony-exporter/werf.inc.yaml
+++ b/modules/470-chrony/images/chrony-exporter/werf.inc.yaml
@@ -1,7 +1,7 @@
 {{- $chronyExproterVersion := "0.11.0"}}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/patches
@@ -28,11 +28,11 @@ final: false
 mount:
 {{ include "mount points for golang builds" . }}
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src/chrony_exporter
   to: /chrony_exporter
   before: install
-- image: common/promu-artifact
+- from: common/promu-artifact
   add: /src/promu
   to: /bin/promu
   before: install
@@ -46,9 +46,9 @@ shell:
   - promu build
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-artifact
   add: /chrony_exporter/chrony_exporter
   to: /bin/chrony_exporter
   before: install

--- a/modules/470-chrony/images/chrony/werf.inc.yaml
+++ b/modules/470-chrony/images/chrony/werf.inc.yaml
@@ -1,7 +1,7 @@
 {{- $version := "4.6.1" }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ $.ModulePath }}modules/470-{{ $.ModuleName }}/images/{{ $.ImageName }}/src
@@ -27,7 +27,7 @@ image: {{ .ModuleName }}/build-chrony-static-artifact
 from: {{ index $.Images "builder/distroless" }}
 final: false
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src/chrony
   to: /src
   before: install
@@ -48,7 +48,7 @@ image: {{ .ModuleName }}/build-entrypoint-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src/entrypoint
   to: /src
   before: install
@@ -65,16 +65,16 @@ shell:
   - chmod +x /entrypoint
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/build-chrony-static-artifact
+- from: {{ .ModuleName }}/build-chrony-static-artifact
   add: /opt/chrony-static
   before: setup
 - from: {{ index $.Images "tools/tini" }}
   add: /usr/bin/tini
   to: /tini
   before: setup
-- image: {{ .ModuleName }}/build-entrypoint-artifact
+- from: {{ .ModuleName }}/build-entrypoint-artifact
   add: /entrypoint
   to: /entrypoint
   before: setup

--- a/modules/500-cilium-hubble/images/relay/werf.inc.yaml
+++ b/modules/500-cilium-hubble/images/relay/werf.inc.yaml
@@ -5,7 +5,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-build-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-- image: cni-cilium/bin-cilium-src-artifact
+- from: cni-cilium/bin-cilium-src-artifact
   add: /src/cilium
   to: /src/cilium
   before: install
@@ -30,13 +30,13 @@ shell:
 # Distroless Main Image
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-build-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-build-artifact
   add: /out/linux/amd64/usr/bin/hubble-relay
   to: /usr/local/bin/hubble-relay
   before: install
-- image: cni-cilium/gops-artifact
+- from: cni-cilium/gops-artifact
   add: /out/linux/amd64/bin/gops
   to: /bin/gops
   before: install

--- a/modules/500-cilium-hubble/images/ui/werf.inc.yaml
+++ b/modules/500-cilium-hubble/images/ui/werf.inc.yaml
@@ -7,7 +7,7 @@
 # and on https://github.com/cilium/hubble-ui/blob/v0.13.5/backend/Dockerfile
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
-fromImage: common/src-artifact
+from: common/src-artifact
 final: false
 git:
 - add: /{{ $.ModulePath }}modules/500-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
@@ -38,7 +38,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-backend-build-artifact
 from: {{ index $.Images "builder/golang" }}
 final: false
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src/hubble-ui
   to: /src/hubble-ui
   before: install
@@ -62,7 +62,7 @@ shell:
 image: {{ $.ModuleName }}/{{ $.ImageName }}-frontend
 from: {{ index $.Images "base/nginx" }}
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src/server/public
   to: /app
   before: install
@@ -72,9 +72,9 @@ imageSpec:
     entrypoint: [ "/usr/sbin/nginx", "-g", "daemon off;" ]
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-backend
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-backend-build-artifact
+- from: {{ $.ModuleName }}/{{ $.ImageName }}-backend-build-artifact
   add: /src/hubble-ui/backend/backend
   to: /usr/local/bin/hubble-ui-backend
   before: install

--- a/modules/500-openvpn/images/easyrsa-migrator/werf.inc.yaml
+++ b/modules/500-openvpn/images/easyrsa-migrator/werf.inc.yaml
@@ -1,8 +1,8 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-artifact
   add: /src/easyrsa-migrator
   to: /bin/easyrsa-migrator
   before: setup
@@ -13,7 +13,7 @@ imageSpec:
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/src
   to: /src
@@ -34,7 +34,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/modules/500-openvpn/images/iptables-wrapper-init/werf.inc.yaml
+++ b/modules/500-openvpn/images/iptables-wrapper-init/werf.inc.yaml
@@ -2,7 +2,7 @@
 {{- $iptables_image_version := $iptables_version | replace "." "-" }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 fromCacheVersion: "2025-09-16"
 import:
 - from: {{ index $.Images "tools/coreutils" }}
@@ -16,18 +16,18 @@ import:
   add: /usr/bin/bash
   to: /bin/bash
   before: setup
-- image: common/iptables-wrapper
+- from: common/iptables-wrapper
   add: /iptables-wrapper
   to: /iptables-wrapper
   before: setup
-- image: registrypackages/iptables-artifact-{{ $iptables_image_version }}
+- from: registrypackages/iptables-artifact-{{ $iptables_image_version }}
   add: /
   to: /_sbin
   includePaths:
   - xtables-legacy-multi
   - xtables-nft-multi
   before: setup
-- image: {{ .ModuleName }}/{{ .ImageName }}-relocate-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-relocate-artifact
   add: /relocate
   to: /relocate
   before: setup
@@ -35,7 +35,7 @@ import:
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-relocate-artifact
 final: false
-fromImage: common/relocate-artifact
+from: common/relocate-artifact
 shell:
   install:
   - mkdir -p /relocate/sbin

--- a/modules/500-openvpn/images/openvpn/werf.inc.yaml
+++ b/modules/500-openvpn/images/openvpn/werf.inc.yaml
@@ -1,17 +1,17 @@
 {{- $binaries := "/usr/sbin/conntrack /usr/lib64/libnetfilter_conntrack.so* /bin/mknod" }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-artifact
   add: /src/openvpn/src/openvpn/openvpn
   to: /usr/sbin/openvpn
   before: setup
-- image: {{ .ModuleName }}/{{ .ImageName }}-entrypoint-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-entrypoint-artifact
   add: /src/entrypoint
   to: /entrypoint
   before: setup
-- image: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
   add: /relocate
   to: /
   before: setup
@@ -19,7 +19,7 @@ import:
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/entrypoint
   to: /src/entrypoint
@@ -45,7 +45,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-entrypoint-artifact
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src/entrypoint
   to: /src
   before: install
@@ -67,7 +67,7 @@ image: {{ .ModuleName }}/openssl-artifact
 final: false
 from: {{ index $.Images "builder/alpine" }}
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src/openssl
   to: /src
   before: install
@@ -85,11 +85,11 @@ image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 final: false
 from: {{ index $.Images "builder/alpine" }}
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src
   to: /src
   before: install
-- image: {{ .ModuleName }}/openssl-artifact
+- from: {{ .ModuleName }}/openssl-artifact
   add: /openssl
   to: /
   before: install
@@ -110,7 +110,7 @@ shell:
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
 final: false
-fromImage: common/relocate-artifact
+from: common/relocate-artifact
 shell:
   beforeInstall:
   {{- include "alt packages proxy" . | nindent 2 }}

--- a/modules/500-openvpn/images/ovpn-admin/werf.inc.yaml
+++ b/modules/500-openvpn/images/ovpn-admin/werf.inc.yaml
@@ -2,7 +2,7 @@
 {{- $binaries := "/bin/bash" }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 git:
 - add: /{{ .ModulePath }}/modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/templates
   to: /app/templates
@@ -11,23 +11,23 @@ git:
       - '**/*'
 import:
 {{- include "image mount points" . }}
-- image: {{ .ModuleName }}/{{ .ImageName }}-backend-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-backend-artifact
   add: /src/ovpn-admin
   to: /app/ovpn-admin
   before: setup
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src/version
   to: /app/version
   before: setup
-- image: {{ .ModuleName }}/openvpn-artifact
+- from: {{ .ModuleName }}/openvpn-artifact
   add: /src/openvpn/src/openvpn/openvpn
   to: /usr/sbin/openvpn
   before: setup
-- image: {{ .ModuleName }}/{{ .ImageName }}-frontend-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-frontend-artifact
   add: /src/frontend/static
   to: /app/frontend/static
   before: setup
-- image: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
   add: /relocate
   to: /
   before: setup
@@ -40,7 +40,7 @@ imageSpec:
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/patches
   to: /patches
@@ -65,7 +65,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-backend-artifact
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src
   to: /src
   before: install
@@ -87,7 +87,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-frontend-artifact
 final: false
 from: {{ .Images.BASE_NODE_16_ALPINE }}
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src
   to: /src
   before: install
@@ -100,9 +100,9 @@ shell:
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
 final: false
-fromImage: common/relocate-artifact
+from: common/relocate-artifact
 import:
-- image: {{ .ModuleName }}/openssl-artifact
+- from: {{ .ModuleName }}/openssl-artifact
   add: /openssl
   to: /openssl
   before: install

--- a/modules/500-openvpn/images/pmacct/werf.inc.yaml
+++ b/modules/500-openvpn/images/pmacct/werf.inc.yaml
@@ -1,8 +1,8 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: common/distroless
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-artifact
   add: /relocate
   to: /
   before: setup
@@ -12,7 +12,7 @@ imageSpec:
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 secrets:
 - id: SOURCE_REPO
   value: {{ .SOURCE_REPO }}
@@ -31,9 +31,9 @@ shell:
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 final: false
-fromImage: common/relocate-artifact
+from: common/relocate-artifact
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src
   to: /src
   before: install

--- a/modules/800-deckhouse-tools/images/web/werf.inc.yaml
+++ b/modules/800-deckhouse-tools/images/web/werf.inc.yaml
@@ -1,5 +1,5 @@
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/nginx-static
+from: common/nginx-static
 git:
 - add: /{{ $.ModulePath }}modules/800-{{ $.ModuleName }}/images/{{ $.ImageName }}/nginx.conf
   to: /opt/nginx-static/conf/nginx.conf
@@ -7,7 +7,7 @@ git:
     setup:
     - '**/*'
 import:
-  - image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+  - from: {{ .ModuleName }}/{{ .ImageName }}-artifact
     add: /app
     to: /app
     before: setup
@@ -20,7 +20,7 @@ imageSpec:
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
 final: false
-fromImage: common/src-artifact
+from: common/src-artifact
 git:
 - add: /{{ $.ModulePath }}modules/800-{{ $.ModuleName }}/images/{{ $.ImageName }}/src
   to: /src/src
@@ -47,19 +47,19 @@ image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 final: false
 from: {{ index $.Images "builder/golang" }}
 import:
-  - image: {{ .ModuleName }}/{{ .ImageName }}-frontend-artifact
+  - from: {{ .ModuleName }}/{{ .ImageName }}-frontend-artifact
     add: /app/dist
     to: /app
     before: install
-  - image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+  - from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
     add: /src/static
     to: /static
     before: install
-  - image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+  - from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
     add: /src/deckhouse-cli
     to: /src
     before: install
-  - image: common/task-artifact
+  - from: common/task-artifact
     add: /task
     to: /usr/local/bin/task
     before: install
@@ -99,7 +99,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-frontend-artifact
 final: false
 from: {{ .Images.BASE_NODE_20_ALPINE }}
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+- from: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src/src
   to: /app
   before: setup

--- a/modules/810-documentation/images/web/werf.inc.yaml
+++ b/modules/810-documentation/images/web/werf.inc.yaml
@@ -14,10 +14,10 @@
 # Nginx for serving documentation static files
 # Image documentation/web (for website)
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/nginx-static
+from: common/nginx-static
 import:
 {{- include "image mount points" . }}
-- image: {{ .ModuleName }}/{{ .ImageName }}/static
+- from: {{ .ModuleName }}/{{ .ImageName }}/static
   add: /app/_site/documentation
   to: /app/docs-dkp
   before: setup
@@ -27,7 +27,7 @@ import:
   - search-index.json
   - '*/sitemap*.xml'
   - '*/robots.txt'
-- image: {{ .ModuleName }}/modules-embedded/static-artifact
+- from: {{ .ModuleName }}/modules-embedded/static-artifact
   add: /app/_site/
   to: /app/embedded-modules
   before: setup


### PR DESCRIPTION
## Description
This PR updates image build templates to the syntax expected by the upcoming Werf3 (delivery-kit) release. 

- Replaces the deprecated directives `fromImage` and `image` in `import` blocks with `from`.
- Fixes a number of minor template errors that would cause the Werf3 build to fail.

This is a build-time-only refactoring: it does not touch runtime manifests, hooks, or Go code, and does not restart any cluster components. The resulting images are functionally identical.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: ci
type: chore
summary: Update image build templates to Werf3.
impact_level: low
```