### PR TITLE
[candi] Add fg DRADeviceTaints

### DIFF
--- a/candi/bashible/common-steps/all/064_configure_kubelet.sh.tpl
+++ b/candi/bashible/common-steps/all/064_configure_kubelet.sh.tpl
@@ -343,7 +343,6 @@ featureGates:
   DRADeviceBindingConditions: true
   DRAConsumableCapacity: true
   DRAExtendedResource: true
-  DRADeviceTaints: true
 {{- end }}
 {{- range .allowedKubeletFeatureGates }}
   {{ . }}: true

--- a/candi/bashible/common-steps/all/064_configure_kubelet.sh.tpl
+++ b/candi/bashible/common-steps/all/064_configure_kubelet.sh.tpl
@@ -343,6 +343,7 @@ featureGates:
   DRADeviceBindingConditions: true
   DRAConsumableCapacity: true
   DRAExtendedResource: true
+  DRADeviceTaints: true
 {{- end }}
 {{- range .allowedKubeletFeatureGates }}
   {{ . }}: true

--- a/candi/control-plane/kube-apiserver.yaml.tpl
+++ b/candi/control-plane/kube-apiserver.yaml.tpl
@@ -9,6 +9,7 @@
   {{- $baseFeatureGates = append $baseFeatureGates "DRADeviceBindingConditions=true" -}}
   {{- $baseFeatureGates = append $baseFeatureGates "DRAConsumableCapacity=true" -}}
   {{- $baseFeatureGates = append $baseFeatureGates "DRAExtendedResource=true" -}}
+  {{- $baseFeatureGates = append $baseFeatureGates "DRADeviceTaints=true" -}}
 {{- end }}
 {{- if semverCompare ">=1.33" .clusterConfiguration.kubernetesVersion }}
   {{- $baseFeatureGates = append $baseFeatureGates "DRAPartitionableDevices=true" -}}

--- a/candi/control-plane/kube-apiserver.yaml.tpl
+++ b/candi/control-plane/kube-apiserver.yaml.tpl
@@ -10,7 +10,6 @@
   {{- $baseFeatureGates = append $baseFeatureGates "DRAConsumableCapacity=true" -}}
   {{- $baseFeatureGates = append $baseFeatureGates "DRAExtendedResource=true" -}}
 {{- end }}
-{{- /* DRADeviceTaints: Alpha default=false in 1.33-1.35, Beta default=true since 1.36 */ -}}
 {{- if semverCompare ">=1.33 <1.36" .clusterConfiguration.kubernetesVersion }}
   {{- $baseFeatureGates = append $baseFeatureGates "DRADeviceTaints=true" -}}
 {{- end }}

--- a/candi/control-plane/kube-apiserver.yaml.tpl
+++ b/candi/control-plane/kube-apiserver.yaml.tpl
@@ -9,6 +9,9 @@
   {{- $baseFeatureGates = append $baseFeatureGates "DRADeviceBindingConditions=true" -}}
   {{- $baseFeatureGates = append $baseFeatureGates "DRAConsumableCapacity=true" -}}
   {{- $baseFeatureGates = append $baseFeatureGates "DRAExtendedResource=true" -}}
+{{- end }}
+{{- /* DRADeviceTaints: Alpha default=false in 1.33-1.35, Beta default=true since 1.36 */ -}}
+{{- if semverCompare ">=1.33 <1.36" .clusterConfiguration.kubernetesVersion }}
   {{- $baseFeatureGates = append $baseFeatureGates "DRADeviceTaints=true" -}}
 {{- end }}
 {{- if semverCompare ">=1.33" .clusterConfiguration.kubernetesVersion }}

--- a/candi/control-plane/kube-controller-manager.yaml.tpl
+++ b/candi/control-plane/kube-controller-manager.yaml.tpl
@@ -21,7 +21,8 @@
 {{- if semverCompare ">=1.32 <1.34" .clusterConfiguration.kubernetesVersion }}
   {{- $baseFeatureGates = append $baseFeatureGates "DynamicResourceAllocation=true" -}}
 {{- end }}
-{{- if semverCompare ">=1.34" .clusterConfiguration.kubernetesVersion }}
+{{- /* DRADeviceTaints: Alpha default=false in 1.33-1.35, Beta default=true since 1.36 */ -}}
+{{- if semverCompare ">=1.33 <1.36" .clusterConfiguration.kubernetesVersion }}
   {{- $baseFeatureGates = append $baseFeatureGates "DRADeviceTaints=true" -}}
 {{- end }}
 {{- if semverCompare "<=1.32" .clusterConfiguration.kubernetesVersion }}

--- a/candi/control-plane/kube-controller-manager.yaml.tpl
+++ b/candi/control-plane/kube-controller-manager.yaml.tpl
@@ -21,7 +21,6 @@
 {{- if semverCompare ">=1.32 <1.34" .clusterConfiguration.kubernetesVersion }}
   {{- $baseFeatureGates = append $baseFeatureGates "DynamicResourceAllocation=true" -}}
 {{- end }}
-{{- /* DRADeviceTaints: Alpha default=false in 1.33-1.35, Beta default=true since 1.36 */ -}}
 {{- if semverCompare ">=1.33 <1.36" .clusterConfiguration.kubernetesVersion }}
   {{- $baseFeatureGates = append $baseFeatureGates "DRADeviceTaints=true" -}}
 {{- end }}

--- a/candi/control-plane/kube-controller-manager.yaml.tpl
+++ b/candi/control-plane/kube-controller-manager.yaml.tpl
@@ -21,6 +21,9 @@
 {{- if semverCompare ">=1.32 <1.34" .clusterConfiguration.kubernetesVersion }}
   {{- $baseFeatureGates = append $baseFeatureGates "DynamicResourceAllocation=true" -}}
 {{- end }}
+{{- if semverCompare ">=1.34" .clusterConfiguration.kubernetesVersion }}
+  {{- $baseFeatureGates = append $baseFeatureGates "DRADeviceTaints=true" -}}
+{{- end }}
 {{- if semverCompare "<=1.32" .clusterConfiguration.kubernetesVersion }}
   {{- $baseFeatureGates = append $baseFeatureGates "InPlacePodVerticalScaling=true" -}}
 {{- end }}

--- a/candi/control-plane/kube-scheduler.yaml.tpl
+++ b/candi/control-plane/kube-scheduler.yaml.tpl
@@ -10,6 +10,9 @@
   {{- $baseFeatureGates = append $baseFeatureGates "DRADeviceBindingConditions=true" -}}
   {{- $baseFeatureGates = append $baseFeatureGates "DRAConsumableCapacity=true" -}}
   {{- $baseFeatureGates = append $baseFeatureGates "DRAExtendedResource=true" -}}
+{{- end }}
+{{- /* DRADeviceTaints: Alpha default=false in 1.33-1.35, Beta default=true since 1.36 */ -}}
+{{- if semverCompare ">=1.33 <1.36" .clusterConfiguration.kubernetesVersion }}
   {{- $baseFeatureGates = append $baseFeatureGates "DRADeviceTaints=true" -}}
 {{- end }}
 {{- if semverCompare ">=1.33" .clusterConfiguration.kubernetesVersion }}

--- a/candi/control-plane/kube-scheduler.yaml.tpl
+++ b/candi/control-plane/kube-scheduler.yaml.tpl
@@ -10,6 +10,7 @@
   {{- $baseFeatureGates = append $baseFeatureGates "DRADeviceBindingConditions=true" -}}
   {{- $baseFeatureGates = append $baseFeatureGates "DRAConsumableCapacity=true" -}}
   {{- $baseFeatureGates = append $baseFeatureGates "DRAExtendedResource=true" -}}
+  {{- $baseFeatureGates = append $baseFeatureGates "DRADeviceTaints=true" -}}
 {{- end }}
 {{- if semverCompare ">=1.33" .clusterConfiguration.kubernetesVersion }}
   {{- $baseFeatureGates = append $baseFeatureGates "DRAPartitionableDevices=true" -}}

--- a/candi/control-plane/kube-scheduler.yaml.tpl
+++ b/candi/control-plane/kube-scheduler.yaml.tpl
@@ -11,7 +11,6 @@
   {{- $baseFeatureGates = append $baseFeatureGates "DRAConsumableCapacity=true" -}}
   {{- $baseFeatureGates = append $baseFeatureGates "DRAExtendedResource=true" -}}
 {{- end }}
-{{- /* DRADeviceTaints: Alpha default=false in 1.33-1.35, Beta default=true since 1.36 */ -}}
 {{- if semverCompare ">=1.33 <1.36" .clusterConfiguration.kubernetesVersion }}
   {{- $baseFeatureGates = append $baseFeatureGates "DRADeviceTaints=true" -}}
 {{- end }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Enable the `DRADeviceTaints` (KEP-5055) Kubernetes feature gate by default on `kube-apiserver`, `kube-scheduler`, and `kube-controller-manager` for clusters running Kubernetes 1.34 and above.

This restarts `kube-apiserver`, `kube-controller-manager`, and `kube-scheduler` on clusters with Kubernetes >= 1.34.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Requested for the `gpu` module, to replace an existing custom implementation of similar device-taint logic with native Kubernetes support.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: chore
summary: Enable the `DRADeviceTaints` feature gate by default for Kubernetes 1.34+.
impact: kube-apiserver, kube-scheduler, and kube-controller-manager will restart on clusters running Kubernetes 1.34 or newer.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
