### PR TITLE
[control-plane-manager] Fix kubectl exec via Gateway API

### DIFF
--- a/modules/040-control-plane-manager/templates/kubernetes-api/basic-auth-proxy.yaml
+++ b/modules/040-control-plane-manager/templates/kubernetes-api/basic-auth-proxy.yaml
@@ -67,7 +67,7 @@ metadata:
   name: basic-auth-proxy
   namespace: kube-system
   annotations:
-    alb.network.deckhouse.io/buffer-max-request-bytes: "10485760"
+    alb.network.deckhouse.io/request-body-buffer-limit: "10485760"
   {{- if .Values.controlPlaneManager.apiserver.publishAPI.ingress.whitelistSourceRanges }}
     alb.network.deckhouse.io/whitelist-source-range: {{ .Values.controlPlaneManager.apiserver.publishAPI.ingress.whitelistSourceRanges | join "," }}
   {{- end }}

--- a/modules/040-control-plane-manager/templates/kubernetes-api/httproute.yaml
+++ b/modules/040-control-plane-manager/templates/kubernetes-api/httproute.yaml
@@ -10,7 +10,7 @@ metadata:
   namespace: kube-system
   annotations:
     alb.network.deckhouse.io/backend-tls-settings: '{"mode": "SIMPLE", "insecureSkipVerify": true}'
-    alb.network.deckhouse.io/buffer-max-request-bytes: "10485760"
+    alb.network.deckhouse.io/request-body-buffer-limit: "10485760"
   {{- if .Values.controlPlaneManager.apiserver.publishAPI.ingress.whitelistSourceRanges }}
     alb.network.deckhouse.io/whitelist-source-range: {{ .Values.controlPlaneManager.apiserver.publishAPI.ingress.whitelistSourceRanges | join "," }}
   {{- end }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Replaced the Envoy request buffer filter configuration with a per-route request body limit for the published Kubernetes API HTTPRoutes.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

`alb.network.deckhouse.io/buffer-max-request-bytes` enables the Envoy buffer filter. The filter blocks WebSocket Upgrade requests, causing `kubectl exec` to hang when Kubernetes API is published through Gateway API.

`request-body-buffer-limit` preserves the existing 10 MiB request-body limit without enabling the buffer filter, so WebSocket-based `kubectl exec` works.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

The issue prevents `kubectl exec` through a published Kubernetes API with Gateway API enabled.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: fix
summary: Fix kubectl exec through Kubernetes API published with Gateway API.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
