### PR TITLE
[cloud-provider-dvp] skip foreign nodes in cloud controller manager

### DIFF
--- a/modules/030-cloud-provider-dvp/images/cloud-controller-manager/src/pkg/cloudprovider/dvp/instance.go
+++ b/modules/030-cloud-provider-dvp/images/cloud-controller-manager/src/pkg/cloudprovider/dvp/instance.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	"dvp-common/api"
 
@@ -53,6 +52,13 @@ func (c *Cloud) NodeAddressesByProviderID(ctx context.Context, providerID string
 func (c *Cloud) InstanceID(ctx context.Context, nodeName types.NodeName) (string, error) {
 	vm, err := c.getVMByNodeName(ctx, nodeName)
 	if err != nil {
+		if errors.Is(err, cloudprovider.InstanceNotFound) {
+			// A node without a providerID cannot be attributed to DVP by its
+			// name alone. Returning InstanceNotFound here makes the cloud node
+			// lifecycle controller delete it before another provider can claim it.
+			return "", fmt.Errorf("DVP virtual machine for node %q was not found", nodeName)
+		}
+
 		return "", err
 	}
 
@@ -79,7 +85,7 @@ func (c *Cloud) InstanceExistsByProviderID(ctx context.Context, providerID strin
 	// Nodes managed by another cloud provider are outside DVP's responsibility.
 	// Report them as existing so that the cloud node lifecycle controller does
 	// not delete them, and avoid making a lookup against the DVP API.
-	if !strings.HasPrefix(providerID, providerName+"://") {
+	if !IsManagedProviderID(providerID) {
 		return true, nil
 	}
 
@@ -96,6 +102,10 @@ func (c *Cloud) InstanceExistsByProviderID(ctx context.Context, providerID strin
 }
 
 func (c *Cloud) InstanceShutdownByProviderID(ctx context.Context, providerID string) (bool, error) {
+	if !IsManagedProviderID(providerID) {
+		return false, nil
+	}
+
 	vm, err := c.getVMByProviderID(ctx, providerID)
 	if err != nil {
 		return false, err

--- a/modules/030-cloud-provider-dvp/images/cloud-controller-manager/src/pkg/cloudprovider/dvp/instance.go
+++ b/modules/030-cloud-provider-dvp/images/cloud-controller-manager/src/pkg/cloudprovider/dvp/instance.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"dvp-common/api"
 
@@ -75,6 +76,13 @@ func (c *Cloud) CurrentNodeName(ctx context.Context, hostname string) (types.Nod
 }
 
 func (c *Cloud) InstanceExistsByProviderID(ctx context.Context, providerID string) (bool, error) {
+	// Nodes managed by another cloud provider are outside DVP's responsibility.
+	// Report them as existing so that the cloud node lifecycle controller does
+	// not delete them, and avoid making a lookup against the DVP API.
+	if !strings.HasPrefix(providerID, providerName+"://") {
+		return true, nil
+	}
+
 	_, err := c.getVMByProviderID(ctx, providerID)
 	if err != nil {
 		if errors.Is(err, cloudprovider.InstanceNotFound) {

--- a/modules/030-cloud-provider-dvp/images/cloud-controller-manager/src/pkg/cloudprovider/dvp/instance_test.go
+++ b/modules/030-cloud-provider-dvp/images/cloud-controller-manager/src/pkg/cloudprovider/dvp/instance_test.go
@@ -22,13 +22,33 @@ import (
 )
 
 func TestInstanceExistsByProviderIDSkipsForeignProvider(t *testing.T) {
+	// A nil dvpService is intentional: foreign provider IDs must return before
+	// any request to the DVP API is attempted.
 	cloud := &Cloud{}
 
-	exists, err := cloud.InstanceExistsByProviderID(context.Background(), "other://instance")
-	if err != nil {
-		t.Fatalf("InstanceExistsByProviderID() returned an unexpected error: %v", err)
+	for _, providerID := range []string{"other://instance", "", "dvp://"} {
+		t.Run(providerID, func(t *testing.T) {
+			exists, err := cloud.InstanceExistsByProviderID(context.Background(), providerID)
+			if err != nil {
+				t.Fatalf("InstanceExistsByProviderID() returned an unexpected error: %v", err)
+			}
+			if !exists {
+				t.Fatal("InstanceExistsByProviderID() returned false for an unmanaged provider ID")
+			}
+		})
 	}
-	if !exists {
-		t.Fatal("InstanceExistsByProviderID() returned false for a foreign provider")
+}
+
+func TestInstanceShutdownByProviderIDSkipsForeignProvider(t *testing.T) {
+	// A nil dvpService is intentional: foreign provider IDs must return before
+	// any request to the DVP API is attempted.
+	cloud := &Cloud{}
+
+	shutdown, err := cloud.InstanceShutdownByProviderID(context.Background(), "other://instance")
+	if err != nil {
+		t.Fatalf("InstanceShutdownByProviderID() returned an unexpected error: %v", err)
+	}
+	if shutdown {
+		t.Fatal("InstanceShutdownByProviderID() returned true for a foreign provider")
 	}
 }

--- a/modules/030-cloud-provider-dvp/images/cloud-controller-manager/src/pkg/cloudprovider/dvp/instance_test.go
+++ b/modules/030-cloud-provider-dvp/images/cloud-controller-manager/src/pkg/cloudprovider/dvp/instance_test.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dvp
+
+import (
+	"context"
+	"testing"
+)
+
+func TestInstanceExistsByProviderIDSkipsForeignProvider(t *testing.T) {
+	cloud := &Cloud{}
+
+	exists, err := cloud.InstanceExistsByProviderID(context.Background(), "other://instance")
+	if err != nil {
+		t.Fatalf("InstanceExistsByProviderID() returned an unexpected error: %v", err)
+	}
+	if !exists {
+		t.Fatal("InstanceExistsByProviderID() returned false for a foreign provider")
+	}
+}

--- a/modules/030-cloud-provider-dvp/images/cloud-controller-manager/src/pkg/cloudprovider/dvp/util.go
+++ b/modules/030-cloud-provider-dvp/images/cloud-controller-manager/src/pkg/cloudprovider/dvp/util.go
@@ -29,6 +29,11 @@ func MapNodeNameToVMName(nodeName types.NodeName) string {
 	return string(nodeName)
 }
 
+// IsManagedProviderID reports whether providerID identifies a DVP instance.
+func IsManagedProviderID(providerID string) bool {
+	return regExpProviderID.MatchString(providerID)
+}
+
 func ParseProviderID(providerID string) (string, error) {
 	matches := regExpProviderID.FindStringSubmatch(providerID)
 	if len(matches) == 2 {

--- a/modules/030-cloud-provider-dvp/images/cloud-controller-manager/src/pkg/cloudprovider/dvp/util_test.go
+++ b/modules/030-cloud-provider-dvp/images/cloud-controller-manager/src/pkg/cloudprovider/dvp/util_test.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dvp
+
+import "testing"
+
+func TestIsManagedProviderID(t *testing.T) {
+	tests := []struct {
+		name       string
+		providerID string
+		want       bool
+	}{
+		{name: "DVP instance", providerID: "dvp://vm", want: true},
+		{name: "foreign instance", providerID: "other://vm", want: false},
+		{name: "empty provider ID", providerID: "", want: false},
+		{name: "empty DVP instance name", providerID: "dvp://", want: false},
+		{name: "case-sensitive scheme", providerID: "DVP://vm", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsManagedProviderID(tt.providerID); got != tt.want {
+				t.Fatalf("IsManagedProviderID(%q) = %v, want %v", tt.providerID, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
Make DVP CCM skip nodes whose `providerID` is empty or does not start with `dvp://`.

## Why do we need it, and what problem does it solve?
DVP CCM may incorrectly process and delete nodes managed by other cloud providers. Foreign nodes are now treated as existing and no DVP API lookup is performed for them.

## Why do we need it in the patch release (if we do)?
This prevents unintended node deletion in clusters containing nodes managed by multiple cloud providers. It is a backward-compatible bug fix with limited scope.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-dvp
type: fix
summary: skip foreign nodes in cloud controller manager
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
