### PR TITLE
[dhctl] refactor resource ready/not-ready view, like "resources to create" #21563

### DIFF
--- a/dhctl/pkg/kubernetes/actions/resources/resources.go
+++ b/dhctl/pkg/kubernetes/actions/resources/resources.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"slices"
 	"strings"
 	"time"
 
@@ -341,21 +340,15 @@ func CreateResourcesLoop(
 
 	// List each object on its own line so operators see which resources are actually
 	// applied. The old output deduplicated by GVK, hiding distinct instances (a single
-	// "Kind=ModuleConfig" line stood in for 15 different ModuleConfigs). Labels are padded
-	// to a common width so the instance names line up in a column.
+	// "Kind=ModuleConfig" line stood in for 15 different ModuleConfigs).
 	labels := make([]string, len(resourceCreator.resources))
 	names := make([]string, len(resourceCreator.resources))
-	maxLabel := 0
+
 	for i, resource := range resourceCreator.resources {
 		labels[i], names[i] = resourceListParts(resource)
-		if len(labels[i]) > maxLabel {
-			maxLabel = len(labels[i])
-		}
 	}
-	resourcesToCreate := make([]string, len(resourceCreator.resources))
-	for i := range resourcesToCreate {
-		resourcesToCreate[i] = fmt.Sprintf("%-*s %s", maxLabel, labels[i], names[i])
-	}
+
+	resourcesToCreate := alignedLines(labels, names)
 
 	_ = dhlog.RunProcess(ctx, dhlog.FromContext(ctx), "Resources to create", func(ctx context.Context) error {
 		dhlog.FromContext(ctx).InfoContext(ctx, strings.Join(resourcesToCreate, "\n"))
@@ -363,7 +356,8 @@ func CreateResourcesLoop(
 	})
 
 	attempt := 0
-	createdResources := make([]string, 0, len(resourceCreator.resources))
+	createdCheckers := make([]Checker, 0, len(checkers))
+
 	for {
 		iterCtx, iterSpan := telemetry.StartSpan(ctx, "createResources.iteration")
 		iterSpan.SetAttributes(otattribute.Int("attempt", attempt))
@@ -380,29 +374,22 @@ func CreateResourcesLoop(
 			return err
 		}
 
-		ready, res, remained, errWaiter := waiter.ReadyAllWithRes(iterCtx)
+		ready, readyNow, remained, errWaiter := waiter.ReadyAllWithRes(iterCtx)
 		if errWaiter != nil {
 			iterSpan.End()
 			return errWaiter
 		}
 
-		if len(res) > 0 {
-			createdResources = append(createdResources, res...)
-		}
+		createdCheckers = append(createdCheckers, readyNow...)
 
 		iterSpan.SetAttributes(
 			otattribute.Int("pending_count", len(remained)),
-			otattribute.Int("created_count", len(createdResources)),
+			otattribute.Int("created_count", len(createdCheckers)),
 			otattribute.Bool("all_ready", ready),
 		)
 
 		if len(remained) > 0 && attempt%10 == 0 {
-			msg := make(map[string][]string)
-			msg["remained"] = remained
-			if len(createdResources) > 0 {
-				msg["created"] = createdResources
-			}
-			logResources(iterCtx, msg)
+			logResources(iterCtx, remained, createdCheckers)
 		}
 		iterSpan.End()
 		if ready && err == nil {
@@ -423,7 +410,7 @@ func CreateResourcesLoop(
 							"This is usually caused by the absence of worker nodes in the cluster. "+
 							"Add at least one worker node or remove the taints from the master node "+
 							"(in the case of a single-node installation).",
-						timeout, strings.Join(remained, "\n")))
+						timeout, strings.Join(checkerLines(remained), "\n")))
 					return nil
 				})
 
@@ -442,36 +429,42 @@ func CreateResourcesLoop(
 	}
 }
 
-func logResources(ctx context.Context, res map[string][]string) {
+func logResources(ctx context.Context, remained, created []Checker) {
+	remained, created = objectChecks(remained), objectChecks(created)
+	if len(remained) == 0 && len(created) == 0 {
+		return
+	}
+
 	_ = dhlog.RunProcess(ctx, dhlog.FromContext(ctx), "Resource readiness check", func(ctx context.Context) error {
-		remained, ok := res["remained"]
-		if ok {
-			for i, s := range remained {
-				if strings.Contains(s, "cluster") {
-					remained = slices.Delete(remained, i, i+1)
-				}
-			}
-			_ = dhlog.RunProcess(ctx, dhlog.FromContext(ctx), "Resource not ready", func(ctx context.Context) error {
-				dhlog.FromContext(ctx).InfoContext(ctx, strings.Join(remained, "\n"))
-				return nil
-			})
-		}
-
-		created, ok := res["created"]
-		if ok {
-			for i, s := range created {
-				if strings.Contains(s, "cluster") {
-					created = slices.Delete(created, i, i+1)
-				}
-			}
-			_ = dhlog.RunProcess(ctx, dhlog.FromContext(ctx), "Resource ready", func(ctx context.Context) error {
-				dhlog.FromContext(ctx).InfoContext(ctx, strings.Join(created, "\n"))
-				return nil
-			})
-		}
-
+		logCheckerList(ctx, "Resource not ready", remained)
+		logCheckerList(ctx, "Resource ready", created)
 		return nil
 	})
+}
+
+func logCheckerList(ctx context.Context, title string, checkers []Checker) {
+	if len(checkers) == 0 {
+		return
+	}
+
+	_ = dhlog.RunProcess(ctx, dhlog.FromContext(ctx), title, func(ctx context.Context) error {
+		dhlog.FromContext(ctx).InfoContext(ctx, strings.Join(checkerLines(checkers), "\n"))
+		return nil
+	})
+}
+
+// The readiness listings answer "how far along are my resources", so they drop the checks that
+// stand for no applied object. Returning a fresh slice is required: the caller's slices are owned
+// by CreateResourcesLoop and live across its iterations.
+func objectChecks(checkers []Checker) []Checker {
+	listed := make([]Checker, 0, len(checkers))
+	for _, c := range checkers {
+		if _, ok := c.(*resourceReadinessChecker); ok {
+			listed = append(listed, c)
+		}
+	}
+
+	return listed
 }
 
 func getUnstructuredName(obj *unstructured.Unstructured) string {
@@ -499,6 +492,38 @@ func resourceListParts(r *template.Resource) (string, string) {
 		name = ns + "/" + name
 	}
 	return label, name
+}
+
+func checkerLines(checkers []Checker) []string {
+	labels := make([]string, len(checkers))
+	names := make([]string, len(checkers))
+
+	for i, c := range checkers {
+		switch check := c.(type) {
+		case *resourceReadinessChecker:
+			labels[i], names[i] = resourceListParts(check.resource)
+		case *clusterIsBootstrapCheck:
+			// Waits for the d8-cluster-is-bootstraped ConfigMap, which Deckhouse creates once the
+			// first Ready non-master node has joined (global-hooks/cluster_is_bootstrapped.go).
+			labels[i], names[i] = "Cluster bootstrap:", "waiting for a Ready worker node"
+		}
+	}
+
+	return alignedLines(labels, names)
+}
+
+func alignedLines(labels, names []string) []string {
+	width := 0
+	for _, label := range labels {
+		width = max(width, len(label))
+	}
+
+	lines := make([]string, len(labels))
+	for i := range labels {
+		lines[i] = fmt.Sprintf("%-*s %s", width, labels[i], names[i])
+	}
+
+	return lines
 }
 
 func DeleteResourcesLoop(ctx context.Context, kubeCl *client.KubernetesClient, resources template.Resources) error {

--- a/dhctl/pkg/kubernetes/actions/resources/resources_test.go
+++ b/dhctl/pkg/kubernetes/actions/resources/resources_test.go
@@ -1,0 +1,123 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	dhlog "github.com/deckhouse/lib-dhctl/pkg/logger"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/template"
+)
+
+func TestReadinessListing(t *testing.T) {
+	const content = `
+---
+apiVersion: deckhouse.io/v1
+kind: ClusterAuthorizationRule
+metadata:
+  name: admin
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-config
+  namespace: d8-system
+---
+apiVersion: deckhouse.io/v1
+kind: NodeGroup
+metadata:
+  name: cluster-x
+spec:
+  nodeType: Static
+---
+`
+
+	resources, err := template.ParseResourcesContent(t.Context(), content, nil)
+	require.NoError(t, err)
+
+	// Replicas turn on the cluster bootstrap check, which is not backed by an object.
+	cnf := &config.MetaConfig{
+		TerraNodeGroupSpecs: []config.TerraNodeGroupSpec{{Replicas: 1, Name: "terra"}},
+	}
+
+	checkers, err := GetCheckers(t.Context(), nil, resources, cnf)
+	require.NoError(t, err)
+	require.Len(t, checkers, 4)
+	require.Equal(t, "cluster", checkers[0].Name())
+
+	for _, tc := range []struct {
+		name     string
+		checkers []Checker
+		want     []string
+	}{
+		{
+			name:     "no checks",
+			checkers: nil,
+			want:     []string{},
+		},
+		{
+			name:     "timeout listing keeps the cluster check",
+			checkers: checkers,
+			want: []string{
+				"Cluster bootstrap:                          waiting for a Ready worker node",
+				"ConfigMap:                                  d8-system/cluster-config",
+				"ClusterAuthorizationRule (deckhouse.io/v1): admin",
+				"NodeGroup (deckhouse.io/v1):                cluster-x",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, checkerLines(tc.checkers))
+		})
+	}
+
+	t.Run("each listing holds what it was given", func(t *testing.T) {
+		var buf bytes.Buffer
+		ctx := dhlog.ToContext(t.Context(), slog.New(slog.NewTextHandler(&buf, nil)))
+
+		logResources(ctx, checkers[:2], checkers[2:])
+
+		notReady, ready, split := strings.Cut(buf.String(), `"Starting: Resource ready"`)
+		require.True(t, split, "both listings are printed")
+
+		// The handler escapes the joined lines, so the listing arrives as one \n-separated message.
+		require.Contains(t, notReady, `"Starting: Resource not ready"`)
+		require.Contains(t, notReady, strings.Join(checkerLines(checkers[1:2]), `\n`))
+		require.Contains(t, ready, strings.Join(checkerLines(checkers[2:]), `\n`))
+
+		require.NotContains(t, buf.String(), "Cluster bootstrap:", "the cluster check is dropped")
+		require.Contains(t, buf.String(), "cluster-x", "a resource named like the cluster check is not")
+
+		// CreateResourcesLoop reuses both slices on every iteration.
+		require.Len(t, checkers, 4)
+		require.Equal(t, "cluster", checkers[0].Name())
+	})
+
+	t.Run("nothing but the cluster check", func(t *testing.T) {
+		var buf bytes.Buffer
+		ctx := dhlog.ToContext(t.Context(), slog.New(slog.NewTextHandler(&buf, nil)))
+
+		logResources(ctx, checkers[:1], nil)
+
+		require.Empty(t, buf.String(), "no empty framed block")
+	})
+}

--- a/dhctl/pkg/kubernetes/actions/resources/waiter.go
+++ b/dhctl/pkg/kubernetes/actions/resources/waiter.go
@@ -120,26 +120,26 @@ func (w *Waiter) ReadyAll(ctx context.Context) (bool, error) {
 	return len(w.checkers) == 0, nil
 }
 
-func (w *Waiter) ReadyAllWithRes(ctx context.Context) (bool, []string, []string, error) {
-	checkersToStay := make([]Checker, 0)
-	readyResources := make([]string, 0)
-	remainedResources := make([]string, 0)
+// The returned pending slice is the waiter's own list of remaining checks - read it, do not
+// append to or reorder it.
+func (w *Waiter) ReadyAllWithRes(ctx context.Context) (bool, []Checker, []Checker, error) {
+	readyCheckers := make([]Checker, 0)
+	remainedCheckers := make([]Checker, 0)
 
 	for _, c := range w.checkers {
 		ready, err := c.IsReady(ctx)
 		if err != nil {
-			return false, readyResources, remainedResources, err
+			return false, readyCheckers, remainedCheckers, err
 		}
 
 		if !ready {
-			checkersToStay = append(checkersToStay, c)
-			remainedResources = append(remainedResources, c.Name())
+			remainedCheckers = append(remainedCheckers, c)
 		} else {
-			readyResources = append(readyResources, c.Name())
+			readyCheckers = append(readyCheckers, c)
 		}
 	}
 
-	w.checkers = checkersToStay
+	w.checkers = remainedCheckers
 
-	return len(w.checkers) == 0, readyResources, remainedResources, nil
+	return len(w.checkers) == 0, readyCheckers, remainedCheckers, nil
 }


### PR DESCRIPTION
## Description

PR #21563 reformatted the "Resources to create" listing, but the readiness listings printed by
the same loop — "Resource not ready", "Resource ready" and the "Resources failed to become ready"
timeout warning — were left as they were: raw `Checker.Name()` strings.

Before:

```
  │ ┌ Resource readiness check
  │ │ ┌ Resource not ready
  │ │ │ /v1, Kind=ConfigMap 'd8-system/deckhouse-registry'
  │ │ │ deckhouse.io/v1, Kind=NodeGroup 'worker'
  │ │ │ deckhouse.io/v1alpha1, Kind=ModuleConfig 'cni-cilium'
  │ │ └ Resource not ready
  │ │ ┌ Resource ready
  │ │ │ /v1, Kind=Namespace 'd8-system'
  │ │ └ Resource ready
  │ └ Resource readiness check
```

After — the same shape as "Resources to create", so the two listings can be read line by line:

```
  │ ┌ Resource readiness check
  │ │ ┌ Resource not ready
  │ │ │ ConfigMap:                            d8-system/deckhouse-registry
  │ │ │ NodeGroup (deckhouse.io/v1):          worker
  │ │ │ ModuleConfig (deckhouse.io/v1alpha1): cni-cilium
  │ │ └ Resource not ready
  │ │ ┌ Resource ready
  │ │ │ Namespace: d8-system
  │ │ └ Resource ready
  │ └ Resource readiness check
```

The timeout warning is aligned the same way. The cluster bootstrap check stays in that listing —
"no worker nodes" is exactly the case this message is written for, and that check is then usually
the last pending one — but it no longer prints as a bare `cluster` token next to `Kind: name`
siblings:

```
  Installation finished with an error: creating resources timed out after 30m0s.
  The resources below did not become ready and were not fully created:
  Cluster bootstrap:                    waiting for a Ready worker node
  NodeGroup (deckhouse.io/v1):          worker
  ModuleConfig (deckhouse.io/v1alpha1): cni-cilium
```

To do this, `Waiter.ReadyAllWithRes` now returns the checks themselves (`[]Checker`) instead of
pre-rendered names: `Name()` carries neither the GVK nor the namespace that a listing needs, and
it also serves as the dedup key for single checks, so it should not double as the display form.
With the checks in hand, the listing code reaches the `*template.Resource` and calls the same
`resourceListParts` helper that "Resources to create" uses — the format lives in one place
(`alignedLines`).

`checkerLines` switches over the two `Checker` implementations that exist, both in this package.
A third one would have to be added there; the alternative — a display method on the `Checker`
interface — buys nothing today and is the upgrade path if a third implementation appears.

Two bugs in `logResources` die with the rewrite:

1. The cluster bootstrap check was excluded from the listings with `strings.Contains(s, "cluster")`
   against the rendered line. That also swallowed real resources whose own name contains
   "cluster" — a `NodeGroup` named `cluster-a`, a `ClusterAuthorizationRule`, a ConfigMap named
   `cluster-config` — hiding them from the operator entirely. The check is now selected by its
   type (`objectChecks`), not by a substring of its output.
2. The exclusion ran as `for i, s := range x { if … { x = slices.Delete(x, i, i+1) } }`: deleting
   while ranging by index skips the next element, and `slices.Delete` shifts the backing array in
   place. The "created" slice is owned by `CreateResourcesLoop` and lives across iterations, so
   the delete corrupted it — the caller kept its old length over shifted contents and grew a
   duplicated trailing entry that reappeared on every later log. Filtering now writes into a fresh
   slice and never touches the caller's.

Also: a readiness block that would contain nothing (only the cluster check pending, early in
bootstrap) is skipped instead of rendering an empty framed box.

Covered by `TestReadinessListing`: it pins the rendered lines for both listings, that each listing
holds what it was given, and that the caller's slices survive the call. Both fixed bugs were
verified to fail it before the change.

This is a logging-only change. No change to which resources are applied, in what order, or to how
readiness is decided; telemetry counters still count every check, cluster one included. **No impact
on running components.**

## Why do we need it, and what problem does it solve?

While waiting for resources, the bootstrap output prints the pending and ready lists every tenth
attempt — this is the only place an operator can see where an installation is stuck. It printed a
different, noisier format than the "Resources to create" list right above it (`/v1, Kind=ConfigMap
'd8-system/deckhouse-registry'`), so the two could not be compared at a glance.

Worse, the `strings.Contains(s, "cluster")` filter silently dropped any resource whose name
contains "cluster" from both listings, and the in-place delete corrupted the accumulated "ready"
list. So the one diagnostic view of a stalled install could omit real resources and show duplicated
entries — precisely when it is being read to find out what went wrong.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: dhctl
type: fix
summary: The bootstrap readiness listings no longer hide resources whose name contains "cluster", and print each object in the same format as "Resources to create".
impact_level: low
```
