### PR TITLE
[ci] Add werf install to documentation rollout

### DIFF
--- a/.github/workflow_templates/build-and-test_pre-release.yml
+++ b/.github/workflow_templates/build-and-test_pre-release.yml
@@ -160,7 +160,7 @@ jobs:
     steps:
 {!{ tmpl.Exec "started_at_output" . | strings.Indent 6 }!}
 {!{ tmpl.Exec "checkout_full_step" $ctx | strings.Indent 6}!}
-{!{ tmpl.Exec "read_werf_version_step" $ctx | strings.Indent 6 }!}
+{!{ tmpl.Exec "werf_setup_steps" $ctx | strings.Indent 6 }!}
 {!{- $secrets := slice -}!}
 {!{- $secrets = append ( slice "projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/registry_host" "DECKHOUSE_DEV_REGISTRY_HOST" "DECKHOUSE_DEV_REGISTRY_HOST" ) $secrets -}!}
 {!{- $secrets = append ( slice "projects/data/101ceaca-97cd-462f-aed5-070d9b9de175/dev-registry/writetoken" "login" "DECKHOUSE_DEV_REGISTRY_USER" ) $secrets -}!}
@@ -183,7 +183,7 @@ jobs:
     steps:
 {!{ tmpl.Exec "started_at_output" . | strings.Indent 6 }!}
 {!{ tmpl.Exec "checkout_full_step" $ctx | strings.Indent 6}!}
-{!{ tmpl.Exec "read_werf_version_step" $ctx | strings.Indent 6 }!}
+{!{ tmpl.Exec "werf_setup_steps" $ctx | strings.Indent 6 }!}
 {!{- $secrets := slice -}!}
 {!{- $secrets = append ( slice "projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/registry_host" "DECKHOUSE_DEV_REGISTRY_HOST" "DECKHOUSE_DEV_REGISTRY_HOST" ) $secrets -}!}
 {!{- $secrets = append ( slice "projects/data/101ceaca-97cd-462f-aed5-070d9b9de175/dev-registry/writetoken" "login" "DECKHOUSE_DEV_REGISTRY_USER" ) $secrets -}!}

--- a/.github/workflow_templates/k8s-autoupdate.yml
+++ b/.github/workflow_templates/k8s-autoupdate.yml
@@ -34,8 +34,7 @@ jobs:
     - skip_tests_repos
     steps:
 {!{ tmpl.Exec "checkout_step" . | strings.Indent 4 }!}
-{!{ tmpl.Exec "read_werf_version_step" . | strings.Indent 4 }!}
-{!{ tmpl.Exec "werf_install_step" . | strings.Indent 4 }!}
+{!{ tmpl.Exec "werf_setup_steps" . | strings.Indent 4 }!}
 {!{- $secrets := slice -}!}
 {!{- $secrets = append ( slice "projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/team-ssdlc/loop" "webhook_url" "LOOP_SERVICE_NOTIFICATIONS" ) $secrets -}!}
 {!{ tmpl.Exec "import_secrets" $secrets | strings.Indent 4 }!}

--- a/.github/workflow_templates/stage_registry_clean.yml
+++ b/.github/workflow_templates/stage_registry_clean.yml
@@ -51,8 +51,7 @@ jobs:
       {!{ tmpl.Exec "import_secrets" $secrets | strings.Indent 4 }!}
 
       {!{ tmpl.Exec "checkout_step" $ctx | strings.Indent 4 }!}
-      {!{ tmpl.Exec "read_werf_version_step" $ctx | strings.Indent 4 }!}
-      {!{ tmpl.Exec "werf_install_step" $ctx | strings.Indent 4 }!}
+      {!{ tmpl.Exec "werf_setup_steps" $ctx | strings.Indent 4 }!}
       {!{ tmpl.Exec "login_stage_registry_step" $ctx | strings.Indent 4 }!}
 
     - name: RM Deckhouse image

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -4614,6 +4614,7 @@ jobs:
           fetch-depth: 0
       # </template: checkout_full_step>
 
+
       # <template: read_werf_version_step>
       - name: Read werf version from werf_envs.yml
         id: read_werf_version
@@ -4633,6 +4634,51 @@ jobs:
           echo "WERF_VERSION=${WERF_VERSION}" >> "$GITHUB_ENV"
           echo "werf_version=${WERF_VERSION}" >> "$GITHUB_OUTPUT"
       # </template: read_werf_version_step>
+
+      # <template: werf_install_step>
+      - name: Install werf-dk CLI
+        run: |
+          if [[ -z "${WERF_VERSION:-}" ]]; then
+            echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
+            exit 1
+          fi
+          MINIMAL_DDK_VERSION="v2.62.1"
+          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            minimal_ddk_major=${BASH_REMATCH[1]}
+            minimal_ddk_minor=${BASH_REMATCH[2]}
+            minimal_ddk_patch=${BASH_REMATCH[3]}
+          fi
+          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            werf_current_major=${BASH_REMATCH[1]}
+            werf_current_minor=${BASH_REMATCH[2]}
+            werf_current_patch=${BASH_REMATCH[3]}
+          fi
+          if (( werf_current_major > minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          else
+            werf_fallback=true
+          fi
+          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
+          echo "$WERF_PATH" >> "$GITHUB_PATH"
+          CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
+          if [[ "${WERF_VERSION}" != "$CACHED_VERSION" && $werf_fallback == "false" ]]; then
+            echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}";
+            mkdir -p "$WERF_PATH"
+            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}/werf
+            chmod +x "$WERF_PATH/werf"
+          elif [[ "${WERF_VERSION}" != "$CACHED_VERSION" && $werf_fallback == "true" ]]; then
+            echo "Current werf is $CACHED_VERSION, fallback to ${WERF_VERSION}";
+            mkdir -p "$WERF_PATH"
+            curl -Lsfo "$WERF_PATH/werf" https://tuf.werf.io/targets/releases/${WERF_VERSION#v}/linux-amd64/bin/werf
+            chmod +x "$WERF_PATH/werf"
+          else
+            echo "Current werf is $CACHED_VERSION, skipping download"
+          fi
+      # </template: werf_install_step>
       # <template: import_secrets>
       - name: Split repository name
         id: split
@@ -4761,6 +4807,7 @@ jobs:
           fetch-depth: 0
       # </template: checkout_full_step>
 
+
       # <template: read_werf_version_step>
       - name: Read werf version from werf_envs.yml
         id: read_werf_version
@@ -4780,6 +4827,51 @@ jobs:
           echo "WERF_VERSION=${WERF_VERSION}" >> "$GITHUB_ENV"
           echo "werf_version=${WERF_VERSION}" >> "$GITHUB_OUTPUT"
       # </template: read_werf_version_step>
+
+      # <template: werf_install_step>
+      - name: Install werf-dk CLI
+        run: |
+          if [[ -z "${WERF_VERSION:-}" ]]; then
+            echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
+            exit 1
+          fi
+          MINIMAL_DDK_VERSION="v2.62.1"
+          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            minimal_ddk_major=${BASH_REMATCH[1]}
+            minimal_ddk_minor=${BASH_REMATCH[2]}
+            minimal_ddk_patch=${BASH_REMATCH[3]}
+          fi
+          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            werf_current_major=${BASH_REMATCH[1]}
+            werf_current_minor=${BASH_REMATCH[2]}
+            werf_current_patch=${BASH_REMATCH[3]}
+          fi
+          if (( werf_current_major > minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
+            werf_fallback=false
+          else
+            werf_fallback=true
+          fi
+          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
+          echo "$WERF_PATH" >> "$GITHUB_PATH"
+          CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
+          if [[ "${WERF_VERSION}" != "$CACHED_VERSION" && $werf_fallback == "false" ]]; then
+            echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}";
+            mkdir -p "$WERF_PATH"
+            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}/werf
+            chmod +x "$WERF_PATH/werf"
+          elif [[ "${WERF_VERSION}" != "$CACHED_VERSION" && $werf_fallback == "true" ]]; then
+            echo "Current werf is $CACHED_VERSION, fallback to ${WERF_VERSION}";
+            mkdir -p "$WERF_PATH"
+            curl -Lsfo "$WERF_PATH/werf" https://tuf.werf.io/targets/releases/${WERF_VERSION#v}/linux-amd64/bin/werf
+            chmod +x "$WERF_PATH/werf"
+          else
+            echo "Current werf is $CACHED_VERSION, skipping download"
+          fi
+      # </template: werf_install_step>
       # <template: import_secrets>
       - name: Split repository name
         id: split

--- a/.github/workflows/k8s-autoupdate.yml
+++ b/.github/workflows/k8s-autoupdate.yml
@@ -42,6 +42,7 @@ jobs:
 
     # </template: checkout_step>
 
+
     # <template: read_werf_version_step>
     - name: Read werf version from werf_envs.yml
       id: read_werf_version

--- a/.github/workflows/stage_registry_clean.yml
+++ b/.github/workflows/stage_registry_clean.yml
@@ -92,6 +92,7 @@ jobs:
 
     # </template: checkout_step>
 
+
     # <template: read_werf_version_step>
     - name: Read werf version from werf_envs.yml
       id: read_werf_version


### PR DESCRIPTION
## Description
Add werf install step to documentation rollout job for release branches.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: fix
summary: Add werf install to documentation rollout.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
