### PR TITLE
[deckhouse] Skip multiple CNI check during CNI migration

### DIFF
--- a/global-hooks/enable_cni.go
+++ b/global-hooks/enable_cni.go
@@ -130,6 +130,13 @@ func enableCni(_ context.Context, input *go_hook.HookInput) error {
 	}
 
 	if len(explicitlyEnabledCNIs) > 1 {
+		if input.Values.Get("global.internal.cniMigrationEnabled").Bool() {
+			input.Logger.Info(
+				"more than one CNI enabled during CNI migration, skipping check",
+				slog.Any("cni", explicitlyEnabledCNIs.Slice()),
+			)
+			return nil
+		}
 		requirements.SaveValue(cniConfigurationSettledKey, "false")
 		return fmt.Errorf("more than one CNI enabled: %v", explicitlyEnabledCNIs.Slice())
 	} else if len(explicitlyEnabledCNIs) == 1 {

--- a/global-hooks/enable_cni.go
+++ b/global-hooks/enable_cni.go
@@ -132,7 +132,7 @@ func enableCni(_ context.Context, input *go_hook.HookInput) error {
 	if len(explicitlyEnabledCNIs) > 1 {
 		if input.Values.Get("global.internal.cniMigrationEnabled").Bool() {
 			input.Logger.Info(
-				"more than one CNI enabled during CNI migration, skipping check",
+				"more than one CNI is enabled, and the migration process is detected. All CNIs will be running, and there should be no conflicts, as everything is managed by the migration process",
 				slog.Any("cni", explicitlyEnabledCNIs.Slice()),
 			)
 			return nil

--- a/global-hooks/enable_cni_test.go
+++ b/global-hooks/enable_cni_test.go
@@ -173,4 +173,19 @@ spec:
 			Expect(value).To(BeEquivalentTo("false"))
 		})
 	})
+
+	Context("Cluster has a few CNI ModuleConfigs during CNI migration", func() {
+		BeforeEach(func() {
+			requirements.RemoveValue(cniConfigurationSettledKey)
+			f.ValuesSet("global.internal.cniMigrationEnabled", true)
+			f.BindingContexts.Set(f.KubeStateSet(cniConfig("flannel") + cniMC("cni-cilium") + cniMC("cni-flannel")))
+			f.RunHook()
+		})
+
+		It("ExecuteSuccessfully without settling CNI configuration", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			_, exists := requirements.GetValue(cniConfigurationSettledKey)
+			Expect(exists).To(BeFalse())
+		})
+	})
 })


### PR DESCRIPTION
## Description

During a CNI migration the migration controller enables the target CNI module before disabling the current one. In between these two phases both CNI `ModuleConfig` objects have `enabled: true` at the same time.

The `enable_cni` global hook treats "more than one CNI enabled" as a fatal misconfiguration and returns an error. This error is unrelated to the admission webhooks that the migration controller disables (it is an addon-operator hook, not a `Validating`/`Mutating` webhook), so it is not suppressed during migration. If the Deckhouse controller restarts inside this window, the hook runs on synchronization, sees two enabled CNIs, and returns an error, which makes the `main` queue retry indefinitely and get stuck.

This change makes the hook tolerate the transient "two CNIs enabled" state while a CNI migration is in progress: when `global.internal.cniMigrationEnabled` is set, the hook logs an informational message and returns successfully instead of failing. The behavior outside of migration is unchanged.

This change does not restart any critical cluster components.

## Why do we need it, and what problem does it solve?

Without this change, a Deckhouse controller restart during the window between enabling the target CNI and disabling the current one causes the `enable_cni` hook to fail on synchronization. The failure locks the Deckhouse `main` queue on endless retries, blocking `ConvergeModules` and stalling the migration itself.

The fix allows the expected transient state of two simultaneously enabled CNI modules during an active migration, keeping the queue healthy.

## Checklist

- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Skip the multiple CNI check in the enable_cni hook while a CNI migration is in progress to avoid a stuck Deckhouse queue.
impact_level: low
```