### PR TITLE
[ci] Simplify werf/ddk install script

### DIFF
--- a/.github/ci_templates/steps.yml
+++ b/.github/ci_templates/steps.yml
@@ -210,25 +210,13 @@
       echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
       exit 1
     fi
-    MINIMAL_DDK_VERSION="v2.62.1"
-    if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-      minimal_ddk_major=${BASH_REMATCH[1]}
-      minimal_ddk_minor=${BASH_REMATCH[2]}
-      minimal_ddk_patch=${BASH_REMATCH[3]}
-    fi
-    if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-      werf_current_major=${BASH_REMATCH[1]}
-      werf_current_minor=${BASH_REMATCH[2]}
-      werf_current_patch=${BASH_REMATCH[3]}
-    fi
-    if (( werf_current_major > minimal_ddk_major )); then
+    if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
       werf_fallback=false
-    elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-      werf_fallback=false
-    elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-      werf_fallback=false
-    else
+    elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
       werf_fallback=true
+    else
+      echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+      exit 1
     fi
     WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
     echo "$WERF_PATH" >> "$GITHUB_PATH"

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -485,25 +485,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
@@ -911,25 +899,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
@@ -1102,25 +1078,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
@@ -1270,25 +1234,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
@@ -1681,25 +1633,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
@@ -2092,25 +2032,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
@@ -2503,25 +2431,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
@@ -2914,25 +2830,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
@@ -3325,25 +3229,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
@@ -3720,25 +3612,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
@@ -3872,25 +3752,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"

--- a/.github/workflows/build-and-test_main.yml
+++ b/.github/workflows/build-and-test_main.yml
@@ -248,25 +248,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
@@ -655,25 +643,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
@@ -844,25 +820,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
@@ -945,25 +909,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
@@ -1125,25 +1077,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
@@ -2010,25 +1950,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
@@ -2328,25 +2256,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
@@ -2482,25 +2398,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -248,25 +248,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
@@ -655,25 +643,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
@@ -844,25 +820,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
@@ -1010,25 +974,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
@@ -1429,25 +1381,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
@@ -1848,25 +1788,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
@@ -2267,25 +2195,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
@@ -2686,25 +2602,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
@@ -3105,25 +3009,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
@@ -3460,25 +3352,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
@@ -4504,25 +4384,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
@@ -4642,25 +4510,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
@@ -4835,25 +4691,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -369,25 +369,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
@@ -820,25 +808,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
@@ -1272,25 +1248,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
@@ -1724,25 +1688,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
@@ -2176,25 +2128,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
@@ -2628,25 +2568,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"

--- a/.github/workflows/deploy-alpha.yml
+++ b/.github/workflows/deploy-alpha.yml
@@ -1410,25 +1410,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
@@ -1546,25 +1534,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -1410,25 +1410,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
@@ -1546,25 +1534,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"

--- a/.github/workflows/deploy-early-access.yml
+++ b/.github/workflows/deploy-early-access.yml
@@ -1410,25 +1410,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
@@ -1546,25 +1534,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"

--- a/.github/workflows/deploy-rock-solid.yml
+++ b/.github/workflows/deploy-rock-solid.yml
@@ -1410,25 +1410,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
@@ -1546,25 +1534,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"

--- a/.github/workflows/deploy-stable.yml
+++ b/.github/workflows/deploy-stable.yml
@@ -1410,25 +1410,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
@@ -1546,25 +1534,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"

--- a/.github/workflows/deploy-web-stage.yml
+++ b/.github/workflows/deploy-web-stage.yml
@@ -229,25 +229,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"

--- a/.github/workflows/deploy-web-test.yml
+++ b/.github/workflows/deploy-web-test.yml
@@ -229,25 +229,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"

--- a/.github/workflows/deploy-web-test10.yml
+++ b/.github/workflows/deploy-web-test10.yml
@@ -229,25 +229,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"

--- a/.github/workflows/deploy-web-test2.yml
+++ b/.github/workflows/deploy-web-test2.yml
@@ -229,25 +229,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"

--- a/.github/workflows/deploy-web-test3.yml
+++ b/.github/workflows/deploy-web-test3.yml
@@ -229,25 +229,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"

--- a/.github/workflows/deploy-web-test4.yml
+++ b/.github/workflows/deploy-web-test4.yml
@@ -229,25 +229,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"

--- a/.github/workflows/deploy-web-test5.yml
+++ b/.github/workflows/deploy-web-test5.yml
@@ -229,25 +229,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"

--- a/.github/workflows/deploy-web-test6.yml
+++ b/.github/workflows/deploy-web-test6.yml
@@ -229,25 +229,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"

--- a/.github/workflows/deploy-web-test7.yml
+++ b/.github/workflows/deploy-web-test7.yml
@@ -229,25 +229,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"

--- a/.github/workflows/deploy-web-test8.yml
+++ b/.github/workflows/deploy-web-test8.yml
@@ -229,25 +229,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"

--- a/.github/workflows/deploy-web-test9.yml
+++ b/.github/workflows/deploy-web-test9.yml
@@ -229,25 +229,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"

--- a/.github/workflows/docs-pdf-daily.yml
+++ b/.github/workflows/docs-pdf-daily.yml
@@ -170,25 +170,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"

--- a/.github/workflows/k8s-autoupdate.yml
+++ b/.github/workflows/k8s-autoupdate.yml
@@ -70,25 +70,13 @@ jobs:
           echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
           exit 1
         fi
-        MINIMAL_DDK_VERSION="v2.62.1"
-        if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-          minimal_ddk_major=${BASH_REMATCH[1]}
-          minimal_ddk_minor=${BASH_REMATCH[2]}
-          minimal_ddk_patch=${BASH_REMATCH[3]}
-        fi
-        if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-          werf_current_major=${BASH_REMATCH[1]}
-          werf_current_minor=${BASH_REMATCH[2]}
-          werf_current_patch=${BASH_REMATCH[3]}
-        fi
-        if (( werf_current_major > minimal_ddk_major )); then
+        if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
           werf_fallback=false
-        elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-          werf_fallback=false
-        elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-          werf_fallback=false
-        else
+        elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
           werf_fallback=true
+        else
+          echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+          exit 1
         fi
         WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
         echo "$WERF_PATH" >> "$GITHUB_PATH"

--- a/.github/workflows/reproducibility-check.yml
+++ b/.github/workflows/reproducibility-check.yml
@@ -440,25 +440,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
@@ -878,25 +866,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"

--- a/.github/workflows/stage_registry_clean.yml
+++ b/.github/workflows/stage_registry_clean.yml
@@ -120,25 +120,13 @@ jobs:
           echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
           exit 1
         fi
-        MINIMAL_DDK_VERSION="v2.62.1"
-        if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-          minimal_ddk_major=${BASH_REMATCH[1]}
-          minimal_ddk_minor=${BASH_REMATCH[2]}
-          minimal_ddk_patch=${BASH_REMATCH[3]}
-        fi
-        if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-          werf_current_major=${BASH_REMATCH[1]}
-          werf_current_minor=${BASH_REMATCH[2]}
-          werf_current_patch=${BASH_REMATCH[3]}
-        fi
-        if (( werf_current_major > minimal_ddk_major )); then
+        if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
           werf_fallback=false
-        elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-          werf_fallback=false
-        elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-          werf_fallback=false
-        else
+        elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
           werf_fallback=true
+        else
+          echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+          exit 1
         fi
         WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
         echo "$WERF_PATH" >> "$GITHUB_PATH"

--- a/.github/workflows/svace.yml
+++ b/.github/workflows/svace.yml
@@ -244,25 +244,13 @@ jobs:
             echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
             exit 1
           fi
-          MINIMAL_DDK_VERSION="v2.62.1"
-          if [[ ${MINIMAL_DDK_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            minimal_ddk_major=${BASH_REMATCH[1]}
-            minimal_ddk_minor=${BASH_REMATCH[2]}
-            minimal_ddk_patch=${BASH_REMATCH[3]}
-          fi
-          if [[ ${WERF_VERSION} =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            werf_current_major=${BASH_REMATCH[1]}
-            werf_current_minor=${BASH_REMATCH[2]}
-            werf_current_patch=${BASH_REMATCH[3]}
-          fi
-          if (( werf_current_major > minimal_ddk_major )); then
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
             werf_fallback=false
-          elif (( werf_current_minor > minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          elif (( werf_current_patch >= minimal_ddk_patch && werf_current_minor == minimal_ddk_minor && werf_current_major == minimal_ddk_major )); then
-            werf_fallback=false
-          else
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
           fi
           WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
           echo "$WERF_PATH" >> "$GITHUB_PATH"


### PR DESCRIPTION
## Description
Simplify werf/ddk install script to account for different versioning of both.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: ci
type: chore
summary: Simplify werf/ddk install script to account for different versioning.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
