### PR TITLE
[deckhouse] update modulev2 settings

### DIFF
--- a/deckhouse-controller/internal/packages/runtime/apps.go
+++ b/deckhouse-controller/internal/packages/runtime/apps.go
@@ -16,6 +16,7 @@ package runtime
 
 import (
 	"context"
+	"log/slog"
 	"path/filepath"
 	"slices"
 
@@ -67,6 +68,8 @@ type App struct {
 func (r *Runtime) UpdateApp(repo registry.Remote, app App) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+
+	r.logger.Debug("update app", slog.String("name", app.Name))
 
 	if len(app.Namespace) == 0 {
 		app.Namespace = defaultNamespace
@@ -164,6 +167,8 @@ func (r *Runtime) loadApp(ctx context.Context, repo registry.Remote, packagePath
 func (r *Runtime) RemoveApp(namespace, instance string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+
+	r.logger.Debug("remove app", slog.String("namespace", namespace), slog.String("instance", instance))
 
 	name := apps.BuildName(namespace, instance)
 	r.scheduler.RemoveNode(name)

--- a/deckhouse-controller/internal/packages/runtime/embedded.go
+++ b/deckhouse-controller/internal/packages/runtime/embedded.go
@@ -137,10 +137,6 @@ func (r *Runtime) loadEmbedded(ctx context.Context) error {
 				return fmt.Errorf("new module by config: %w", err)
 			}
 
-			if module.GetName() == "node-manager" {
-				return nil
-			}
-
 			// lifecycle.Store is not thread-safe, so guard it (and the module map)
 			// with r.mu; status.Service is internally synchronized.
 			r.mu.Lock()
@@ -154,10 +150,6 @@ func (r *Runtime) loadEmbedded(ctx context.Context) error {
 			r.status.SetConditionTrue(module.GetName(), status.ConditionReadyOnFilesystem)
 			r.status.SetConditionTrue(module.GetName(), status.ConditionLoaded)
 			r.status.UpdateVersion(module.GetName(), module.GetVersion().String())
-
-			if err := r.scheduler.AddNode(module); err != nil {
-				return fmt.Errorf("add node to scheduler: %w", err)
-			}
 
 			return nil
 		})

--- a/deckhouse-controller/internal/packages/runtime/embedded.go
+++ b/deckhouse-controller/internal/packages/runtime/embedded.go
@@ -137,6 +137,10 @@ func (r *Runtime) loadEmbedded(ctx context.Context) error {
 				return fmt.Errorf("new module by config: %w", err)
 			}
 
+			if module.GetName() == "node-manager" {
+				return nil
+			}
+
 			// lifecycle.Store is not thread-safe, so guard it (and the module map)
 			// with r.mu; status.Service is internally synchronized.
 			r.mu.Lock()
@@ -150,6 +154,10 @@ func (r *Runtime) loadEmbedded(ctx context.Context) error {
 			r.status.SetConditionTrue(module.GetName(), status.ConditionReadyOnFilesystem)
 			r.status.SetConditionTrue(module.GetName(), status.ConditionLoaded)
 			r.status.UpdateVersion(module.GetName(), module.GetVersion().String())
+
+			if err := r.scheduler.AddNode(module); err != nil {
+				return fmt.Errorf("add node to scheduler: %w", err)
+			}
 
 			return nil
 		})

--- a/deckhouse-controller/internal/packages/runtime/lifecycle/store.go
+++ b/deckhouse-controller/internal/packages/runtime/lifecycle/store.go
@@ -129,7 +129,7 @@ func (s *Store) Update(name, version string, settingsVersion int, settings addon
 // load tasks are left running. It is the settings-only counterpart to Update,
 // used when settings change independently of a version change. The ModuleConfig
 // enabled intent is tracked separately by the global module, not here.
-func (s *Store) UpdateSettings(name string, settingsVersion int, settings addonutils.Values) bool {
+func (s *Store) UpdateSettings(name string, settingsVersion int, settings addonutils.Values, maintenance string) bool {
 	pkg, ok := s.packages[name]
 	if !ok {
 		return false
@@ -146,6 +146,7 @@ func (s *Store) UpdateSettings(name string, settingsVersion int, settings addonu
 		pkg.settings = settings
 	}
 	pkg.settingsVersion = settingsVersion
+	pkg.maintenance = maintenance
 
 	return true
 }

--- a/deckhouse-controller/internal/packages/runtime/modules.go
+++ b/deckhouse-controller/internal/packages/runtime/modules.go
@@ -16,6 +16,7 @@ package runtime
 
 import (
 	"context"
+	"log/slog"
 	"slices"
 
 	addonutils "github.com/flant/addon-operator/pkg/utils"
@@ -71,6 +72,8 @@ func (r *Runtime) UpdateModulesSettings(name string, settingsVersion int, settin
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	r.logger.Debug("update module settings", slog.String("name", name))
+
 	// Settings live in the per-package store; the ModuleConfig enabled intent
 	// lives in the global module (thread-safe for the scheduler's enabled getter).
 	// Reschedule if either actually changed.
@@ -91,6 +94,8 @@ func (r *Runtime) UpdateModulesSettings(name string, settingsVersion int, settin
 func (r *Runtime) UpdateModule(repo registry.Remote, module Module) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+
+	r.logger.Debug("update module", slog.String("name", module.Name))
 
 	if len(module.Settings) == 0 {
 		module.Settings = make(addonutils.Values)

--- a/deckhouse-controller/internal/packages/runtime/modules.go
+++ b/deckhouse-controller/internal/packages/runtime/modules.go
@@ -68,7 +68,7 @@ type Module struct {
 // dropped — there is no per-package store to stash them in yet; the eventual
 // UpdateModule registers the package and supplies its settings. Either way, an
 // untracked package has no node to reschedule, so no Reschedule happens here.
-func (r *Runtime) UpdateModulesSettings(name string, settingsVersion int, settings addonutils.Values, enabled *bool) {
+func (r *Runtime) UpdateModulesSettings(name string, settingsVersion int, settings addonutils.Values, maintenance string, enabled *bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -77,7 +77,7 @@ func (r *Runtime) UpdateModulesSettings(name string, settingsVersion int, settin
 	// Settings live in the per-package store; the ModuleConfig enabled intent
 	// lives in the global module (thread-safe for the scheduler's enabled getter).
 	// Reschedule if either actually changed.
-	settingsChanged := r.packages.UpdateSettings(name, settingsVersion, settings)
+	settingsChanged := r.packages.UpdateSettings(name, settingsVersion, settings, maintenance)
 	enabledChanged := r.global.SetConfigEnabled(name, enabled)
 
 	if settingsChanged || enabledChanged {

--- a/deckhouse-controller/internal/packages/runtime/runtime.go
+++ b/deckhouse-controller/internal/packages/runtime/runtime.go
@@ -200,6 +200,10 @@ func New(cli kclient.Client, edition *edition.Edition, moduleManager moduleManag
 	// Initialize scheduler with enabling/disabling callbacks
 	r.buildScheduler(cli)
 
+	if err := r.scheduler.AddNode(r.global); err != nil {
+		return nil, fmt.Errorf("add node to scheduler: %w", err)
+	}
+
 	if err := r.loadEmbedded(context.Background()); err != nil {
 		return nil, fmt.Errorf("load embedded: %w", err)
 	}

--- a/deckhouse-controller/internal/packages/runtime/runtime.go
+++ b/deckhouse-controller/internal/packages/runtime/runtime.go
@@ -140,9 +140,9 @@ type moduleManagerI interface {
 	IsModuleEnabled(name string) bool
 }
 
-// New creates and initializes a Runtime with all subsystems wired together.
+// Build creates and initializes a Runtime with all subsystems wired together.
 // Blocks until the NELM cache completes its initial sync.
-func New(cli kclient.Client, edition *edition.Edition, moduleManager moduleManagerI, dc dependency.Container, metricStorage metricsstorage.Storage, logger *log.Logger) (*Runtime, error) {
+func Build(cli kclient.Client, edition *edition.Edition, moduleManager moduleManagerI, dc dependency.Container, metricStorage metricsstorage.Storage, logger *log.Logger) (*Runtime, error) {
 	r := new(Runtime)
 
 	r.apps = make(map[string]*apps.Application)
@@ -199,10 +199,6 @@ func New(cli kclient.Client, edition *edition.Edition, moduleManager moduleManag
 
 	// Initialize scheduler with enabling/disabling callbacks
 	r.buildScheduler(cli)
-
-	if err := r.scheduler.AddNode(r.global); err != nil {
-		return nil, fmt.Errorf("add node to scheduler: %w", err)
-	}
 
 	if err := r.loadEmbedded(context.Background()); err != nil {
 		return nil, fmt.Errorf("load embedded: %w", err)

--- a/deckhouse-controller/pkg/controller/controller.go
+++ b/deckhouse-controller/pkg/controller/controller.go
@@ -303,6 +303,11 @@ func NewDeckhouseController(
 	dc := dependency.NewDependencyContainer()
 	settingsContainer := helpers.NewDeckhouseSettingsContainer(nil, operator.MetricStorage)
 
+	pkgRuntime, err := packageruntime.New(runtimeManager.GetClient(), edition, operator.ModuleManager, dc, operator.MetricStorage, logger)
+	if err != nil {
+		return nil, fmt.Errorf("create package operator: %w", err)
+	}
+
 	// do not start operator until controllers preflight checks done
 	preflightCountDown := new(sync.WaitGroup)
 
@@ -314,7 +319,7 @@ func NewDeckhouseController(
 		return nil, fmt.Errorf("create deckhouse release controller: %w", err)
 	}
 
-	err = moduleconfig.RegisterController(runtimeManager, operator.ModuleManager, conversionsStore, edition, configHandler, operator.MetricStorage, exts, logger.Named("module-config-controller"))
+	err = moduleconfig.RegisterController(runtimeManager, operator.ModuleManager, pkgRuntime, conversionsStore, edition, configHandler, operator.MetricStorage, exts, logger.Named("module-config-controller"))
 	if err != nil {
 		return nil, fmt.Errorf("register module config controller: %w", err)
 	}
@@ -342,11 +347,6 @@ func NewDeckhouseController(
 	err = objectkeeper.RegisterController(runtimeManager, dc, logger.Named("objectkeeper-controller"))
 	if err != nil {
 		return nil, fmt.Errorf("register objectkeeper controller: %w", err)
-	}
-
-	pkgRuntime, err := packageruntime.New(runtimeManager.GetClient(), edition, operator.ModuleManager, dc, operator.MetricStorage, logger)
-	if err != nil {
-		return nil, fmt.Errorf("create package operator: %w", err)
 	}
 
 	// package should not run before converge done

--- a/deckhouse-controller/pkg/controller/controller.go
+++ b/deckhouse-controller/pkg/controller/controller.go
@@ -303,7 +303,7 @@ func NewDeckhouseController(
 	dc := dependency.NewDependencyContainer()
 	settingsContainer := helpers.NewDeckhouseSettingsContainer(nil, operator.MetricStorage)
 
-	pkgRuntime, err := packageruntime.New(runtimeManager.GetClient(), edition, operator.ModuleManager, dc, operator.MetricStorage, logger)
+	pkgRuntime, err := packageruntime.Build(runtimeManager.GetClient(), edition, operator.ModuleManager, dc, operator.MetricStorage, logger)
 	if err != nil {
 		return nil, fmt.Errorf("create package operator: %w", err)
 	}

--- a/deckhouse-controller/pkg/controller/controller.go
+++ b/deckhouse-controller/pkg/controller/controller.go
@@ -490,7 +490,7 @@ func (c *DeckhouseController) loadInitialConfiguration(ctx context.Context) erro
 			continue
 		}
 
-		c.packageRuntime.UpdateModulesSettings(conf.Name, conf.Spec.Version, conf.Spec.Settings.GetMap(), conf.Spec.Enabled)
+		c.packageRuntime.UpdateModulesSettings(conf.Name, conf.Spec.Version, conf.Spec.Settings.GetMap(), conf.Spec.Maintenance, conf.Spec.Enabled)
 	}
 
 	return nil

--- a/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
@@ -211,7 +211,7 @@ func (r *reconciler) handleModuleConfig(ctx context.Context, moduleConfig *v1alp
 	basicModule := r.moduleManager.GetModule(moduleConfig.Name)
 	if moduleConfig.Name == moduleGlobal || basicModule != nil {
 		r.logger.Debug("send event to operator", slog.String("name", moduleConfig.Name), slog.Bool("enabled", moduleConfig.IsEnabled()))
-		// r.handler.HandleEvent(moduleConfig, config.EventUpdate)
+		r.handler.HandleEvent(moduleConfig, config.EventUpdate)
 	}
 
 	if !app.ModulePackagesEnabled() {

--- a/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
@@ -49,7 +49,6 @@ import (
 	"github.com/deckhouse/deckhouse/go_lib/configtools/conversion"
 	"github.com/deckhouse/deckhouse/go_lib/dependency/extenders"
 	"github.com/deckhouse/deckhouse/go_lib/telemetry"
-	"github.com/deckhouse/deckhouse/pkg/app"
 	"github.com/deckhouse/deckhouse/pkg/log"
 	metricsstorage "github.com/deckhouse/deckhouse/pkg/metrics-storage"
 )
@@ -150,7 +149,7 @@ type moduleManager interface {
 }
 
 type packageManager interface {
-	UpdateModulesSettings(name string, settingsVersion int, settings addonutils.Values, enabled *bool)
+	UpdateModulesSettings(name string, settingsVersion int, settings addonutils.Values, maintenance string, enabled *bool)
 }
 
 func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -214,14 +213,13 @@ func (r *reconciler) handleModuleConfig(ctx context.Context, moduleConfig *v1alp
 		r.handler.HandleEvent(moduleConfig, config.EventUpdate)
 	}
 
-	if app.ModulePackagesEnabled() {
-		// update modules settings in the package manager
-		r.packageManager.UpdateModulesSettings(
-			moduleConfig.Name,
-			moduleConfig.Spec.Version,
-			moduleConfig.Spec.Settings.GetMap(),
-			moduleConfig.Spec.Enabled)
-	}
+	// update modules settings in the package manager
+	r.packageManager.UpdateModulesSettings(
+		moduleConfig.Name,
+		moduleConfig.Spec.Version,
+		moduleConfig.Spec.Settings.GetMap(),
+		moduleConfig.Spec.Maintenance,
+		moduleConfig.Spec.Enabled)
 
 	if err := r.refreshModuleConfig(ctx, moduleConfig.Name); err != nil {
 		return ctrl.Result{Requeue: true}, nil

--- a/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
@@ -24,6 +24,7 @@ import (
 	"github.com/flant/addon-operator/pkg/kube_config_manager/config"
 	"github.com/flant/addon-operator/pkg/module_manager/models/modules"
 	"github.com/flant/addon-operator/pkg/module_manager/models/modules/events"
+	addonutils "github.com/flant/addon-operator/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -66,6 +67,7 @@ const (
 func RegisterController(
 	runtimeManager manager.Manager,
 	mm moduleManager,
+	pm packageManager,
 	conversionsStore *conversion.ConversionsStore,
 	edition *d8edition.Edition,
 	handler *confighandler.Handler,
@@ -80,6 +82,7 @@ func RegisterController(
 		handler:          handler,
 		conversionsStore: conversionsStore,
 		moduleManager:    mm,
+		packageManager:   pm,
 		edition:          edition,
 		metricStorage:    ms,
 		configValidator:  configtools.NewValidator(mm, conversionsStore),
@@ -128,6 +131,7 @@ type reconciler struct {
 	edition          *d8edition.Edition
 	handler          *confighandler.Handler
 	moduleManager    moduleManager
+	packageManager   packageManager
 	metricStorage    metricsstorage.Storage
 	configValidator  *configtools.Validator
 	exts             extenders.IExtendersStack
@@ -142,6 +146,10 @@ type moduleManager interface {
 	GetGlobal() *modules.GlobalModule
 	GetUpdatedByExtender(name string) (string, error)
 	GetModuleEventsChannel() chan events.ModuleEvent
+}
+
+type packageManager interface {
+	UpdateModulesSettings(name string, settingsVersion int, settings addonutils.Values, enabled *bool)
 }
 
 func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -198,23 +206,19 @@ func (r *reconciler) runModuleEventLoop(ctx context.Context) error {
 }
 
 func (r *reconciler) handleModuleConfig(ctx context.Context, moduleConfig *v1alpha1.ModuleConfig) (ctrl.Result, error) {
-	// TODO: remove after 1.73+
-	if controllerutil.ContainsFinalizer(moduleConfig, v1alpha1.ModuleConfigFinalizerOld) {
-		patch := client.MergeFrom(moduleConfig.DeepCopy())
-		controllerutil.RemoveFinalizer(moduleConfig, v1alpha1.ModuleConfigFinalizerOld)
-
-		if err := r.client.Patch(ctx, moduleConfig, patch); err != nil {
-			r.logger.Error("failed to remove old finalizer", slog.String("name", moduleConfig.Name), log.Err(err))
-			return ctrl.Result{}, fmt.Errorf("patch: %w", err)
-		}
-	}
-
 	// send an event to addon-operator only if the module exists, or it is the global one
 	basicModule := r.moduleManager.GetModule(moduleConfig.Name)
 	if moduleConfig.Name == moduleGlobal || basicModule != nil {
 		r.logger.Debug("send event to operator", slog.String("name", moduleConfig.Name), slog.Bool("enabled", moduleConfig.IsEnabled()))
-		r.handler.HandleEvent(moduleConfig, config.EventUpdate)
+		// r.handler.HandleEvent(moduleConfig, config.EventUpdate)
 	}
+
+	// update modules settings in the package manager
+	r.packageManager.UpdateModulesSettings(
+		moduleConfig.Name,
+		moduleConfig.Spec.Version,
+		moduleConfig.Spec.Settings.GetMap(),
+		moduleConfig.Spec.Enabled)
 
 	if err := r.refreshModuleConfig(ctx, moduleConfig.Name); err != nil {
 		return ctrl.Result{Requeue: true}, nil

--- a/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
@@ -49,6 +49,7 @@ import (
 	"github.com/deckhouse/deckhouse/go_lib/configtools/conversion"
 	"github.com/deckhouse/deckhouse/go_lib/dependency/extenders"
 	"github.com/deckhouse/deckhouse/go_lib/telemetry"
+	"github.com/deckhouse/deckhouse/pkg/app"
 	"github.com/deckhouse/deckhouse/pkg/log"
 	metricsstorage "github.com/deckhouse/deckhouse/pkg/metrics-storage"
 )
@@ -213,12 +214,14 @@ func (r *reconciler) handleModuleConfig(ctx context.Context, moduleConfig *v1alp
 		// r.handler.HandleEvent(moduleConfig, config.EventUpdate)
 	}
 
-	// update modules settings in the package manager
-	r.packageManager.UpdateModulesSettings(
-		moduleConfig.Name,
-		moduleConfig.Spec.Version,
-		moduleConfig.Spec.Settings.GetMap(),
-		moduleConfig.Spec.Enabled)
+	if !app.ModulePackagesEnabled() {
+		// update modules settings in the package manager
+		r.packageManager.UpdateModulesSettings(
+			moduleConfig.Name,
+			moduleConfig.Spec.Version,
+			moduleConfig.Spec.Settings.GetMap(),
+			moduleConfig.Spec.Enabled)
+	}
 
 	if err := r.refreshModuleConfig(ctx, moduleConfig.Name); err != nil {
 		return ctrl.Result{Requeue: true}, nil

--- a/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
@@ -214,7 +214,7 @@ func (r *reconciler) handleModuleConfig(ctx context.Context, moduleConfig *v1alp
 		r.handler.HandleEvent(moduleConfig, config.EventUpdate)
 	}
 
-	if !app.ModulePackagesEnabled() {
+	if app.ModulePackagesEnabled() {
 		// update modules settings in the package manager
 		r.packageManager.UpdateModulesSettings(
 			moduleConfig.Name,

--- a/deckhouse-controller/pkg/controller/module-controllers/config/controller_test.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/controller_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/flant/addon-operator/pkg/module_manager/models/modules"
 	"github.com/flant/addon-operator/pkg/module_manager/models/modules/events"
 	"github.com/flant/addon-operator/pkg/utils"
+	addonutils "github.com/flant/addon-operator/pkg/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -106,6 +107,7 @@ func (suite *ControllerTestSuite) buildReconciler() {
 		handler:          newMockHandler(),
 		conversionsStore: conversionsStore,
 		moduleManager:    newMockModuleManager(),
+		packageManager:   &stubPackageManager{},
 		edition:          &d8edition.Edition{Name: "fe", Bundle: "Default"},
 		metricStorage:    metricstorage.NewMetricStorage(metricstorage.WithNewRegistry(), metricstorage.WithLogger(log.NewNop())),
 		configValidator:  nil, // Disable validation in tests to avoid schema issues
@@ -262,4 +264,10 @@ func newMockHandler() *confighandler.Handler {
 	handler.StartInformer(context.Background(), configEventCh)
 
 	return handler
+}
+
+type stubPackageManager struct{}
+
+func (s *stubPackageManager) UpdateModulesSettings(_ string, _ int, _ addonutils.Values, _ string, _ *bool) {
+	// no-op
 }


### PR DESCRIPTION
## Description

Rebased onto `main` now that #21049 (`pilot/wire-runtime`) has merged.

Wires `ModuleConfig` state through to the modulev2 package runtime. Until now a
`ModuleConfig` change only reached addon-operator, so the package scheduler never
saw user settings, the enabled intent, or maintenance mode.

**Settings propagation**

- The `moduleconfig` reconciler takes a new `packageManager` dependency — a
  one-method interface declared at the consumer — and calls
  `UpdateModulesSettings` for every handled `ModuleConfig`, passing
  `spec.version`, `spec.settings`, `spec.maintenance` and `spec.enabled`.
- `NewDeckhouseController` now builds the package runtime **before** registering
  the module-config controller, since the runtime is a constructor argument of
  that controller. Ordering only — the runtime is still started after converge,
  not at construction.
- Renamed `packageruntime.New` → `packageruntime.Build`: it assembles and wires
  every subsystem and blocks on the initial NELM cache sync, so `New` understated
  what a caller is paying for.

**Maintenance mode on the settings-only path**

`lifecycle.Store` already treated maintenance as first-class — `NeedUpdate`
compares it and `Update` persists it — but `UpdateSettings`, the settings-only
counterpart used when no version change is involved, had no maintenance
parameter at all. It is now threaded through both that path and
`Runtime.UpdateModulesSettings`, so a `ModuleConfig` that changes maintenance
mode without a version bump reaches the store.

**Observability**

- Debug logs on the runtime mutation entry points (`UpdateApp`, `RemoveApp`,
  `UpdateModule`, `UpdateModulesSettings`) so the event flow is traceable.

**Cleanup**

- Dropped the `ModuleConfigFinalizerOld` migration patch from
  `handleModuleConfig` (`TODO: remove after 1.73+`). Current-generation
  finalizer handling is untouched; this removes one write per reconcile on every
  `ModuleConfig`.

## Why do we need it, and what problem does it solve?

Under modulev2 the package runtime owns the module lifecycle, but nothing fed it
user configuration. Module settings, the enabled intent and maintenance mode
never reached the scheduler, so packages were scheduled against stale or empty
values. This closes that gap end to end, including the settings-only path where
maintenance changes were previously dropped.

Note that `UpdateModulesSettings` is called unconditionally rather than behind
`app.ModulePackagesEnabled()`. For an untracked package it records only the
enabled intent and performs no scheduling, so it is inert when module packages
are not in use.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: feature
summary: Propagate ModuleConfig settings, enabled intent and maintenance mode to the modulev2 package runtime.
impact_level: low
```
