### PR TITLE
[deckhouse] validate dmt#438 (actualized nelm render) over all modules

### DIFF
--- a/tools/dmt-lint.sh
+++ b/tools/dmt-lint.sh
@@ -16,45 +16,13 @@
 
 set -euo pipefail
 
-DMT_VERSION=0.1.95
+# VALIDATION ONLY (deckhouse/dmt#438): build dmt from the PR commit instead of a
+# released binary, to run the actualized nelm renderer (public action.ChartRender)
+# over all modules. Revert to `DMT_VERSION=<release>` + the curl install before merge.
+DMT_REF=97a4944663b412c51dcc7e35a4df3ba2d668c2fc
 
 function install_dmt() {
-  platform_name=$(uname -m)
-  os_name=$(uname)
-
-  case "$os_name" in
-    Linux)
-      local platform="linux"
-      ;;
-    Darwin)
-      local platform="darwin"
-      ;;
-    *)
-      echo "Unsupported OS: $os_name"
-      return 1
-      ;;
-  esac
-
-  case "$platform_name" in
-    x86_64)
-      local arch="amd64"
-      ;;
-    arm64)
-      local arch="arm64"
-      ;;
-    aarch64)
-      local arch="arm64"
-      ;;
-    *)
-      echo "Unsupported architecture: $platform_name"
-      return 1
-      ;;
-  esac
-
-  curl -sSfL https://github.com/deckhouse/dmt/releases/download/v${DMT_VERSION}/dmt-${DMT_VERSION}-"${platform}"-${arch}.tar.gz | tar -zx --strip-components 1 -C /tmp
-  mv /tmp/dmt /usr/local/bin/dmt
-  chmod +x /usr/local/bin/dmt
-
+  GOBIN=/usr/local/bin go install "github.com/deckhouse/dmt/cmd/dmt@${DMT_REF}"
 }
 
 function structure_prepare {

--- a/tools/dmt-lint.sh
+++ b/tools/dmt-lint.sh
@@ -16,13 +16,45 @@
 
 set -euo pipefail
 
-# VALIDATION ONLY (deckhouse/dmt#438): build dmt from the PR commit instead of a
-# released binary, to run the actualized nelm renderer (public action.ChartRender)
-# over all modules. Revert to `DMT_VERSION=<release>` + the curl install before merge.
-DMT_REF=97a4944663b412c51dcc7e35a4df3ba2d668c2fc
+DMT_VERSION=0.1.96-rc0
 
 function install_dmt() {
-  GOBIN=/usr/local/bin go install "github.com/deckhouse/dmt/cmd/dmt@${DMT_REF}"
+  platform_name=$(uname -m)
+  os_name=$(uname)
+
+  case "$os_name" in
+    Linux)
+      local platform="linux"
+      ;;
+    Darwin)
+      local platform="darwin"
+      ;;
+    *)
+      echo "Unsupported OS: $os_name"
+      return 1
+      ;;
+  esac
+
+  case "$platform_name" in
+    x86_64)
+      local arch="amd64"
+      ;;
+    arm64)
+      local arch="arm64"
+      ;;
+    aarch64)
+      local arch="arm64"
+      ;;
+    *)
+      echo "Unsupported architecture: $platform_name"
+      return 1
+      ;;
+  esac
+
+  curl -sSfL https://github.com/deckhouse/dmt/releases/download/v${DMT_VERSION}/dmt-${DMT_VERSION}-"${platform}"-${arch}.tar.gz | tar -zx --strip-components 1 -C /tmp
+  mv /tmp/dmt /usr/local/bin/dmt
+  chmod +x /usr/local/bin/dmt
+
 }
 
 function structure_prepare {


### PR DESCRIPTION
## Description

Temporary validation PR — **not for merge**. It points the `Tests DMT lint` CI job at [deckhouse/dmt#438](https://github.com/deckhouse/dmt/pull/438), released as the pre-release `v0.1.96-rc0`, so the actualized nelm renderer runs over every in-tree module. `tools/dmt-lint.sh` bumps `DMT_VERSION` to `0.1.96-rc0`; revert to the current release before merge.

## Why do we need it, and what problem does it solve?

dmt#438 (on top of #437) reworks how dmt renders modules for linting: it drops the vendored low-level Helm engine and renders via nelm's public `action.ChartRender` — the same entrypoint deckhouse-controller and d8-package-plugin use — strictly, with values-driven image/`global` stubs instead of in-memory helm_lib overrides.

Because that changes rendering behavior (camelCase image-digest keys, common-image and `.Values.global.*` stub completeness, strict render), it must be validated against the full module corpus before merging dmt. This PR's `Tests DMT lint` run surfaces any module that fails to render under the new engine.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: tools
type: chore
summary: validate the actualized dmt nelm renderer (dmt#438) over all modules
impact_level: low
```