### PR TITLE
[deckhouse] split module and app status queue

### DIFF
--- a/deckhouse-controller/internal/packages/runtime/runtime.go
+++ b/deckhouse-controller/internal/packages/runtime/runtime.go
@@ -844,9 +844,14 @@ func (r *Runtime) GetStatus(name string) status.Status {
 	return r.status.GetStatus(name)
 }
 
-// GetStatusQueue returns the status queue for external access
-func (r *Runtime) GetStatusQueue() workqueue.TypedRateLimitingInterface[string] {
-	return r.status.Queue()
+// GetAppStatusQueue returns the application status queue for external access
+func (r *Runtime) GetAppStatusQueue() workqueue.TypedRateLimitingInterface[string] {
+	return r.status.AppQueue()
+}
+
+// GetModuleStatusQueue returns the module status queue for external access
+func (r *Runtime) GetModuleStatusQueue() workqueue.TypedRateLimitingInterface[string] {
+	return r.status.ModuleQueue()
 }
 
 // PauseScheduler suspends the scheduler so it stops firing enable/disable callbacks.

--- a/deckhouse-controller/internal/packages/status/service.go
+++ b/deckhouse-controller/internal/packages/status/service.go
@@ -17,6 +17,7 @@ package status
 import (
 	"errors"
 	"slices"
+	"strings"
 	"sync"
 
 	addonutils "github.com/flant/addon-operator/pkg/utils"
@@ -50,8 +51,14 @@ const (
 	// ConditionReasonApplyingManifests indicates that nelm is applying manifests to the cluster
 	ConditionReasonApplyingManifests ConditionReason = "ApplyingManifests"
 
-	// queueName labels the notification workqueue for metrics.
-	queueName = "package-status"
+	// appQueueName labels the application notification workqueue for metrics.
+	appQueueName = "application-status"
+	// moduleQueueName labels the module notification workqueue for metrics.
+	moduleQueueName = "module-status"
+
+	// appNameParts is the number of dot-separated parts in an application
+	// name ("namespace.name", see apps.BuildName). Module names carry no dot.
+	appNameParts = 2
 )
 
 // Error wraps an error with associated status conditions
@@ -88,12 +95,15 @@ type Service struct {
 	// name drains the entry, so a startup-race event is not lost.
 	pendingHealth map[string]health.Event
 
-	// queue carries names of packages whose status changed. It coalesces
+	// appQueue carries names of packages whose status changed. It coalesces
 	// repeated notifications for the same package into a single item, so a
 	// flood of updates (e.g. nelm progress) cannot outgrow the number of
 	// packages. Notifications are enqueued outside s.mu, so a slow consumer
 	// can never block a producer that holds the lock.
-	queue workqueue.TypedRateLimitingInterface[string]
+	appQueue workqueue.TypedRateLimitingInterface[string]
+
+	// moduleQueue carries names of modules whose status changed.
+	moduleQueue workqueue.TypedRateLimitingInterface[string]
 }
 
 // Status represents the current state of a package
@@ -129,24 +139,48 @@ type Condition struct {
 
 func NewService() *Service {
 	return &Service{
-		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
+		appQueue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: queueName},
+			workqueue.TypedRateLimitingQueueConfig[string]{Name: appQueueName},
+		),
+		moduleQueue: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[string](),
+			workqueue.TypedRateLimitingQueueConfig[string]{Name: moduleQueueName},
 		),
 		statuses:      make(map[string]*Status),
 		pendingHealth: make(map[string]health.Event),
 	}
 }
 
-// Queue returns the notification queue. Consumers pull changed package names
-// via Get/Done and requeue transient failures via AddRateLimited.
-func (s *Service) Queue() workqueue.TypedRateLimitingInterface[string] {
-	return s.queue
+// AppQueue returns the application notification queue. Consumers pull changed
+// application names ("namespace.name") via Get/Done and requeue transient
+// failures via AddRateLimited.
+func (s *Service) AppQueue() workqueue.TypedRateLimitingInterface[string] {
+	return s.appQueue
+}
+
+// ModuleQueue returns the module notification queue. Consumers pull changed
+// module names via Get/Done and requeue transient failures via AddRateLimited.
+func (s *Service) ModuleQueue() workqueue.TypedRateLimitingInterface[string] {
+	return s.moduleQueue
+}
+
+// queueFor returns the notification queue that owns the given package name.
+// Application names are built as "namespace.name" (see apps.BuildName), so a
+// name that splits into exactly two dot-separated parts belongs to an
+// application; anything else is a module name.
+func (s *Service) queueFor(name string) workqueue.TypedRateLimitingInterface[string] {
+	if len(strings.Split(name, ".")) == appNameParts {
+		return s.appQueue
+	}
+
+	return s.moduleQueue
 }
 
 // Shutdown stops the notification queue; the consumer loop exits on the next Get.
 func (s *Service) Shutdown() {
-	s.queue.ShutDown()
+	s.appQueue.ShutDown()
+	s.moduleQueue.ShutDown()
 }
 
 // GetStatus retrieves a copy of the current status for a package by name ("namespace.name")
@@ -216,7 +250,7 @@ func (s *Service) SetConditionTrue(name string, condition ConditionType) {
 	s.mu.Unlock()
 
 	if notify {
-		s.queue.Add(name)
+		s.queueFor(name).Add(name)
 	}
 }
 
@@ -239,7 +273,7 @@ func (s *Service) SetConditionFalse(name string, condition ConditionType, reason
 	s.mu.Unlock()
 
 	if notify {
-		s.queue.Add(name)
+		s.queueFor(name).Add(name)
 	}
 }
 
@@ -257,7 +291,7 @@ func (s *Service) UpdateVersion(name string, version string) {
 	status.setCondition(Condition{Type: ConditionPending, Status: metav1.ConditionTrue, Message: "waiting for processing"})
 	s.mu.Unlock()
 
-	s.queue.Add(name)
+	s.queueFor(name).Add(name)
 }
 
 // UpdateTracking updates the nelm progress report for a package and notifies listeners.
@@ -297,7 +331,7 @@ func (s *Service) UpdateTracking(name string, report progrep.ProgressReport) {
 	}
 	s.mu.Unlock()
 
-	s.queue.Add(name)
+	s.queueFor(name).Add(name)
 }
 
 // UpdateURLs stores application endpoint URLs collected from the rendered
@@ -318,7 +352,7 @@ func (s *Service) UpdateURLs(name string, urls []URL) {
 	s.mu.Unlock()
 
 	if notify {
-		s.queue.Add(name)
+		s.queueFor(name).Add(name)
 	}
 }
 
@@ -361,7 +395,7 @@ func (s *Service) UpdateHealth(name string, event health.Event) {
 	s.mu.Unlock()
 
 	if notify {
-		s.queue.Add(name)
+		s.queueFor(name).Add(name)
 	}
 }
 
@@ -408,7 +442,7 @@ func (s *Service) HandleError(name string, cond ConditionType, err error) {
 	s.mu.Unlock()
 
 	if notify {
-		s.queue.Add(name)
+		s.queueFor(name).Add(name)
 	}
 }
 
@@ -492,6 +526,6 @@ func (s *Service) NewStatus(name string) {
 	s.mu.Unlock()
 
 	if notify {
-		s.queue.Add(name)
+		s.queueFor(name).Add(name)
 	}
 }

--- a/deckhouse-controller/internal/packages/status/service.go
+++ b/deckhouse-controller/internal/packages/status/service.go
@@ -170,7 +170,7 @@ func (s *Service) ModuleQueue() workqueue.TypedRateLimitingInterface[string] {
 // name that splits into exactly two dot-separated parts belongs to an
 // application; anything else is a module name.
 func (s *Service) queueFor(name string) workqueue.TypedRateLimitingInterface[string] {
-	if len(strings.Split(name, ".")) == appNameParts {
+	if strings.Count(name, ".")+1 >= appNameParts {
 		return s.appQueue
 	}
 

--- a/deckhouse-controller/pkg/controller/module-controllers/config/controller_test.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/controller_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/flant/addon-operator/pkg/kube_config_manager/config"
 	"github.com/flant/addon-operator/pkg/module_manager/models/modules"
 	"github.com/flant/addon-operator/pkg/module_manager/models/modules/events"
-	"github.com/flant/addon-operator/pkg/utils"
 	addonutils "github.com/flant/addon-operator/pkg/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -257,7 +256,7 @@ func (m *mockModuleManager) GetModuleEventsChannel() chan events.ModuleEvent {
 
 func newMockHandler() *confighandler.Handler {
 	// minimal handler for tests with dummy channels
-	deckhouseConfigCh := make(chan utils.Values, 10)
+	deckhouseConfigCh := make(chan addonutils.Values, 10)
 	configEventCh := make(chan config.Event, 10)
 
 	handler := confighandler.New(nil, conversionsStore, deckhouseConfigCh)

--- a/deckhouse-controller/pkg/controller/packages/application/controller.go
+++ b/deckhouse-controller/pkg/controller/packages/application/controller.go
@@ -73,7 +73,7 @@ type packageRuntime interface {
 	UpdateApp(repo registry.Remote, inst packageruntime.App)
 	RemoveApp(namespace, name string)
 	GetStatus(name string) packagestatus.Status
-	GetStatusQueue() workqueue.TypedRateLimitingInterface[string]
+	GetAppStatusQueue() workqueue.TypedRateLimitingInterface[string]
 	Cleanup(ctx context.Context, preserve []packageruntime.PreservePackage)
 }
 
@@ -101,7 +101,7 @@ func RegisterController(
 	}
 
 	r.status = status.NewService(r.client, packageRuntime.GetStatus, r.logger)
-	r.status.Start(context.Background(), packageRuntime.GetStatusQueue())
+	r.status.Start(context.Background(), packageRuntime.GetAppStatusQueue())
 
 	return ctrl.NewControllerManagedBy(runtimeManager).
 		Named(controllerName).

--- a/deckhouse-controller/pkg/controller/packages/application/controller_test.go
+++ b/deckhouse-controller/pkg/controller/packages/application/controller_test.go
@@ -270,8 +270,8 @@ func (o *operatorStub) GetStatus(name string) packagestatus.Status {
 	return packagestatus.NewService().GetStatus(name)
 }
 
-func (o *operatorStub) GetStatusQueue() workqueue.TypedRateLimitingInterface[string] {
-	return packagestatus.NewService().Queue()
+func (o *operatorStub) GetAppStatusQueue() workqueue.TypedRateLimitingInterface[string] {
+	return packagestatus.NewService().AppQueue()
 }
 
 func (o *operatorStub) Cleanup(_ context.Context, _ []packageoperator.PreservePackage) {}


### PR DESCRIPTION
> [!NOTE]
> This PR is based on `feat/modulev2-settings`, not `main`. Please review/merge it after the base branch.

## Description

Splits the single package-status notification workqueue in `internal/packages/status` into two independent queues — one for applications, one for modules — and wires the application controller to consume only the application queue.

* `status.Service` now owns `appQueue` and `moduleQueue`, exposed via `AppQueue()` and `ModuleQueue()`. `Shutdown()` closes both.
* Added the `queueFor(name)` router: package names are split by `.`, and a name with exactly two parts is an application (`namespace.name`, as built by `apps.BuildName`) — anything else is a module. Every notification site (`SetConditionTrue`, `SetConditionFalse`, `UpdateVersion`, `UpdateTracking`, `UpdateURLs`, `UpdateHealth`, `HandleError`, `NewStatus`) enqueues through it, so routing follows the same key the `statuses` map is already keyed by.
* Each queue gets its own metrics name (`application-status` / `module-status`) instead of sharing `package-status`, so their depth/adds/retries are observable separately rather than collapsing into one series.
* `Runtime.GetStatusQueue()` is replaced by `GetAppStatusQueue()` and `GetModuleStatusQueue()`. The `packageRuntime` interface in the application controller declares only `GetAppStatusQueue()`, so the app status reconciler cannot observe module events even by accident.

No behavioural change for applications: the same names reach the same consumer, just over a dedicated queue.

## Why do we need it, and what problem does it solve?

Applications and modules shared one queue while having different consumers and lifecycles. That coupling has three costs:

1. **Head-of-line blocking** — a slow or backed-off module status update delays application status updates (and vice versa), because rate limiting and retries are per-queue.
2. **Consumer over-reach** — the application status reconciler received every module name as well and had to ignore it; a dedicated queue makes the contract explicit at the interface level instead of relying on filtering.
3. **Unusable metrics** — one queue name meant app and module backlogs were indistinguishable in workqueue metrics.

Separating them is also a prerequisite for a module-side status consumer: `ModuleQueue()` / `GetModuleStatusQueue()` are in place so it can be wired without touching the notification path again.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: chore
summary: Split module and app status queue.
impact_level: low
```
