### PR TITLE
[deckhouse] Add 'modulesettingsdefinitions' to RBAC rules in user-authz and view templates

### DIFF
--- a/modules/002-deckhouse/templates/rbacv2/manage/view.yaml
+++ b/modules/002-deckhouse/templates/rbacv2/manage/view.yaml
@@ -20,6 +20,7 @@ rules:
   - modulepulloverrides
   - modulereleases
   - modules
+  - modulesettingsdefinitions
   - modulesources
   - moduleupdatepolicies
   - packagerepositories

--- a/modules/002-deckhouse/templates/user-authz-cluster-roles.yaml
+++ b/modules/002-deckhouse/templates/user-authz-cluster-roles.yaml
@@ -15,6 +15,7 @@ rules:
   - modulepulloverrides
   - modulereleases
   - modules
+  - modulesettingsdefinitions
   - modulesources
   - moduleupdatepolicies
   - packagerepositories

--- a/modules/140-user-authz/docs/README.md
+++ b/modules/140-user-authz/docs/README.md
@@ -243,6 +243,7 @@ read:
     - deckhouse.io/modulepulloverrides
     - deckhouse.io/modulereleases
     - deckhouse.io/modules
+    - deckhouse.io/modulesettingsdefinitions
     - deckhouse.io/modulesources
     - deckhouse.io/moduleupdatepolicies
     - deckhouse.io/nodegroups

--- a/modules/140-user-authz/docs/README_RU.md
+++ b/modules/140-user-authz/docs/README_RU.md
@@ -249,6 +249,7 @@ read:
     - deckhouse.io/modulepulloverrides
     - deckhouse.io/modulereleases
     - deckhouse.io/modules
+    - deckhouse.io/modulesettingsdefinitions
     - deckhouse.io/modulesources
     - deckhouse.io/moduleupdatepolicies
     - deckhouse.io/nodegroups


### PR DESCRIPTION
## Description
Fixed an issue where ClusterAdmin (user-authz:cluster-admin) could not view ModuleSettingsDefinitions.
So ModuleSettingsDefinitions added to a RBAC permissions.

Problem:
```yaml
apiVersion: deckhouse.io/v1
kind: User
metadata:
  name: test
spec:
  email: test@deckhouse.io
  password: ""
---
apiVersion: deckhouse.io/v1
kind: ClusterAuthorizationRule
metadata:
  name: test
spec:
  accessLevel: ClusterAdmin
  allowScale: false
  portForwarding: true
  subjects:
  - kind: User
    name: test@deckhouse.io
```
Before:
<img width="752" height="701" alt="image" src="https://github.com/user-attachments/assets/f17b29a6-11ea-4d8a-80eb-6fa2bbcbf08a" />
After:
<img width="622" height="729" alt="image" src="https://github.com/user-attachments/assets/e9bcd6cd-0619-48ad-8d17-5bb2e5c2e687" />


## Why do we need it, and what problem does it solve?
Admin should have access rights to ModuleSettingsDefinitions.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: chore
summary: Allow ClusterAdmin manage ModuleSettingsDefinitions with RBAC.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
