### PR TITLE
[kube-proxy] Fixed securityContext

### DIFF
--- a/modules/036-kube-proxy/templates/daemonset.yaml
+++ b/modules/036-kube-proxy/templates/daemonset.yaml
@@ -98,7 +98,7 @@ spec:
             {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 10 | nindent 12 }}
       containers:
       - name: kube-proxy
-        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all_and_add" (list . (list "NET_ADMIN" "NET_RAW")) | nindent 8 }}
+        {{- include "helm_lib_module_container_security_context_privileged_read_only_root_filesystem" . | nindent 8 }}
         image: {{ include "helm_lib_module_image" (list . (list "kubeProxy" $kubeVersion.Major $kubeVersion.Minor | join "" )) }}
         command:
         - /usr/local/bin/kube-proxy

--- a/modules/036-kube-proxy/templates/security-policy-exception.yaml
+++ b/modules/036-kube-proxy/templates/security-policy-exception.yaml
@@ -8,6 +8,13 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "d8-kube-proxy")) | nindent 2 }}
 spec:
   securityContext:
+    privileged:
+      allowedValue: true
+      metadata:
+        description: |
+          kube-proxy must run privileged to write host network sysctls under /proc/sys
+          (conntrack timeouts, route_localnet) and to manage iptables/nftables rules
+          for ClusterIP/NodePort services.
     runAsNonRoot:
       allowedValue: false
       metadata:
@@ -29,8 +36,8 @@ spec:
           - ALL
       metadata:
         description: |
-          NET_ADMIN/NET_RAW are required to program service NAT and filtering rules
-          via iptables (kube-proxy mode=iptables) and to set up the iptables-wrapper.
+          NET_ADMIN/NET_RAW are required by iptables-wrapper-init to set up the iptables
+          wrapper used by kube-proxy (mode=iptables).
   network:
     hostNetwork:
       allowedValue: true


### PR DESCRIPTION
## Description
This PR updates the `securityContext` configuration and adds a `SecurityPolicyException`.

## Why do we need it, and what problem does it solve?
This change aligns the component with the required security policies by correcting the `securityContext` configuration and introducing a `SecurityPolicyException` where elevated permissions are required. This ensures the component can operate correctly while remaining compliant with the platform's security requirements.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: kube-proxy
type: chore
summary: Fixed securityContext and added SecurityPolicyException
impact_level: default
```