### PR TITLE
[network-policy-engine] Fixed securityContext

### DIFF
--- a/modules/050-network-policy-engine/templates/daemonset.yaml
+++ b/modules/050-network-policy-engine/templates/daemonset.yaml
@@ -54,7 +54,7 @@ spec:
       {{ include "helm_lib_module_init_container_iptables_wrapper" . | nindent 6 }}
       containers:
       - name: kube-router
-        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all_and_add" (list . (list "NET_ADMIN" "NET_RAW")) | nindent 8 }}
+        {{- include "helm_lib_module_container_security_context_privileged_read_only_root_filesystem" . | nindent 8 }}
         image: {{ include "helm_lib_module_image" (list . "kubeRouter") }}
         args:
         - --run-router=false

--- a/modules/050-network-policy-engine/templates/security-policy-exception.yaml
+++ b/modules/050-network-policy-engine/templates/security-policy-exception.yaml
@@ -8,6 +8,12 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "kube-router")) | nindent 2 }}
 spec:
   securityContext:
+    privileged:
+      allowedValue: true
+      metadata:
+        description: |
+          kube-router must run privileged to enforce NetworkPolicy firewall rules
+          via iptables on the host network namespace.
     runAsNonRoot:
       allowedValue: false
       metadata:
@@ -29,8 +35,8 @@ spec:
           - ALL
       metadata:
         description: |
-          NET_ADMIN/NET_RAW are required to program iptables firewall rules for
-          NetworkPolicies and to set up the iptables-wrapper.
+          NET_ADMIN/NET_RAW are required by iptables-wrapper-init to set up
+          the iptables binaries used by kube-router.
   network:
     hostNetwork:
       allowedValue: true


### PR DESCRIPTION
## Description
This PR updates the `securityContext` configuration and adds a `SecurityPolicyException`.

## Why do we need it, and what problem does it solve?
This change aligns the component with the required security policies by correcting the `securityContext` configuration and introducing a `SecurityPolicyException` where elevated permissions are required. This ensures the component can operate correctly while remaining compliant with the platform's security requirements.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: network-policy-engine
type: chore
summary: Fixed securityContext and added SecurityPolicyException
impact_level: default
```