### PR TITLE
[dhctl] fix(dhctl-for-commander): trim grpc check response, increase grpc message size

### DIFF
--- a/dhctl/Makefile
+++ b/dhctl/Makefile
@@ -40,9 +40,9 @@ DHCTL_TESTS_OPENSSH_IMAGE=lscr.io/linuxserver/openssh-server:10.0_p1-r9-ls209
 OS_NAME := $(shell uname)
 PLATFORM_NAME := $(shell uname -m)
 ifndef OS
-	ifeq ($(UNAME), Linux)
+	ifeq ($(OS_NAME), Linux)
 		OS = linux
-	else ifeq ($(UNAME), Darwin)
+	else ifeq ($(OS_NAME), Darwin)
 		OS = darwin
 	endif
 endif

--- a/dhctl/pkg/infrastructure/plan/trim.go
+++ b/dhctl/pkg/infrastructure/plan/trim.go
@@ -1,0 +1,130 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plan
+
+import "encoding/json"
+
+// Trim returns a copy of the plan keeping only what describes the change
+// itself: resource_changes cut down to type, name, actions and a few
+// identity fields of before/after, and prior_state cut down to each
+// resource's name, type and tags.Name. Everything else a raw OpenTofu plan
+// carries (format_version, terraform_version, variables, planned_values,
+// output_changes, configuration, resource_changes' "after_unknown", and the
+// rest of prior_state/before/after) is static context rather than a change,
+// and is dropped.
+func (p Plan) Trim() Plan {
+	trimmed := Plan{}
+
+	if resourceChanges, ok := trimResourceChanges(p["resource_changes"]); ok {
+		trimmed["resource_changes"] = resourceChanges
+	}
+
+	if priorState, ok := trimPriorState(p["prior_state"]); ok {
+		trimmed["prior_state"] = priorState
+	}
+
+	return trimmed
+}
+
+type trimmedPriorState struct {
+	Values struct {
+		RootModule struct {
+			Resources []trimmedResource `json:"resources"`
+		} `json:"root_module"`
+	} `json:"values"`
+}
+
+type trimmedResource struct {
+	Name   string `json:"name"`
+	Type   string `json:"type"`
+	Values struct {
+		Tags struct {
+			Name string `json:"Name,omitempty"`
+		} `json:"tags"`
+	} `json:"values"`
+}
+
+func trimPriorState(raw any) (trimmedPriorState, bool) {
+	if raw == nil {
+		return trimmedPriorState{}, false
+	}
+
+	data, err := json.Marshal(raw)
+	if err != nil {
+		return trimmedPriorState{}, false
+	}
+
+	var trimmed trimmedPriorState
+
+	// json.Unmarshal is best-effort: a type mismatch on one field (e.g. a
+	// provider whose "tags" is a list, not a map) only zeroes that field,
+	// not the rest of the resource or array. Ignoring the error is deliberate.
+	_ = json.Unmarshal(data, &trimmed)
+
+	return trimmed, true
+}
+
+// trimmedResourceChange keeps only what identifies a resource and describes
+// its change: type, name, actions, and a few identity fields of before and
+// after. Their full attributes and after_unknown duplicate most of a
+// resource's own state for every unchanged (no-op) resource too, making
+// them the largest part of a plan on a big cluster — dropped entirely
+// rather than trimmed further.
+type trimmedResourceChange struct {
+	Type   string          `json:"type"`
+	Name   string          `json:"name"`
+	Change trimmedChangeOp `json:"change"`
+}
+
+type trimmedChangeOp struct {
+	Actions []string             `json:"actions"`
+	Before  *trimmedChangeValues `json:"before,omitempty"`
+	After   *trimmedChangeValues `json:"after,omitempty"`
+}
+
+type trimmedChangeValues struct {
+	Name     string                `json:"name,omitempty"`
+	Manifest *trimmedManifest      `json:"manifest,omitempty"`
+	Metadata []trimmedMetadataName `json:"metadata,omitempty"`
+}
+
+type trimmedManifest struct {
+	Kind     string               `json:"kind,omitempty"`
+	Metadata *trimmedMetadataName `json:"metadata,omitempty"`
+}
+
+type trimmedMetadataName struct {
+	Name string `json:"name,omitempty"`
+}
+
+func trimResourceChanges(raw any) ([]trimmedResourceChange, bool) {
+	if raw == nil {
+		return nil, false
+	}
+
+	data, err := json.Marshal(raw)
+	if err != nil {
+		return nil, false
+	}
+
+	var trimmed []trimmedResourceChange
+
+	// Same best-effort decode as trimPriorState: a shape mismatch on one
+	// resource_change's "before" (provider-specific attributes) only zeroes
+	// that one field of that one element, not the whole array.
+	_ = json.Unmarshal(data, &trimmed)
+
+	return trimmed, true
+}

--- a/dhctl/pkg/infrastructure/plan/trim_test.go
+++ b/dhctl/pkg/infrastructure/plan/trim_test.go
@@ -1,0 +1,506 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plan_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/infrastructure/plan"
+)
+
+func TestPlan_Trim(t *testing.T) {
+	tests := map[string]struct {
+		plan     plan.Plan
+		expected plan.Plan
+	}{
+		"trims resource_changes to identity fields and prior_state to name/type/tags.Name": {
+			plan: plan.Plan{
+				"format_version":    "1.0",
+				"terraform_version": "1.6.0",
+				"variables":         map[string]any{"foo": "bar"},
+				"planned_values":    map[string]any{"root_module": map[string]any{}},
+				"output_changes":    map[string]any{},
+				"configuration":     map[string]any{"root_module": map[string]any{}},
+				"resource_changes": []any{
+					map[string]any{
+						"address":       "yandex_compute_instance.master",
+						"mode":          "managed",
+						"type":          "yandex_compute_instance",
+						"name":          "master",
+						"provider_name": "registry.opentofu.org/yandex-cloud/yandex",
+						"change": map[string]any{
+							"actions": []any{"delete", "create"},
+							"before": map[string]any{
+								"name":      "master",
+								"zone":      "ru-central1-a",
+								"boot_disk": []any{map[string]any{"disk_id": "abc"}},
+							},
+							"after": map[string]any{
+								"name": "master",
+								"zone": "ru-central1-a",
+							},
+							"after_unknown": map[string]any{"id": true},
+						},
+					},
+				},
+				"prior_state": map[string]any{
+					"format_version":    "1.0",
+					"terraform_version": "1.6.0",
+					"values": map[string]any{
+						"outputs": map[string]any{
+							"master_ip_address_for_ssh": map[string]any{"value": "1.2.3.4"},
+						},
+						"root_module": map[string]any{
+							"resources": []any{
+								map[string]any{
+									"name": "master",
+									"type": "yandex_compute_instance",
+									"values": map[string]any{
+										"tags":        map[string]any{"Name": "master-0"},
+										"boot_disk":   []any{map[string]any{"disk_id": "abc"}},
+										"description": "a large unrelated blob of attributes",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: plan.Plan{
+				"resource_changes": []any{
+					map[string]any{
+						"type": "yandex_compute_instance",
+						"name": "master",
+						"change": map[string]any{
+							"actions": []any{"delete", "create"},
+							"before":  map[string]any{"name": "master"},
+							"after":   map[string]any{"name": "master"},
+						},
+					},
+				},
+				"prior_state": map[string]any{
+					"values": map[string]any{
+						"root_module": map[string]any{
+							"resources": []any{
+								map[string]any{
+									"name":   "master",
+									"type":   "yandex_compute_instance",
+									"values": map[string]any{"tags": map[string]any{"Name": "master-0"}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"before is omitted for a create-only change, not turned into an empty object": {
+			plan: plan.Plan{
+				"resource_changes": []any{
+					map[string]any{
+						"type": "yandex_compute_instance",
+						"name": "worker-1",
+						"change": map[string]any{
+							"actions": []any{"create"},
+						},
+					},
+				},
+			},
+			expected: plan.Plan{
+				"resource_changes": []any{
+					map[string]any{
+						"type":   "yandex_compute_instance",
+						"name":   "worker-1",
+						"change": map[string]any{"actions": []any{"create"}},
+					},
+				},
+			},
+		},
+		"after is omitted for a delete-only change, not turned into an empty object": {
+			plan: plan.Plan{
+				"resource_changes": []any{
+					map[string]any{
+						"type": "yandex_compute_instance",
+						"name": "worker-1",
+						"change": map[string]any{
+							"actions": []any{"delete"},
+							"before":  map[string]any{"name": "worker-1-name"},
+						},
+					},
+				},
+			},
+			expected: plan.Plan{
+				"resource_changes": []any{
+					map[string]any{
+						"type": "yandex_compute_instance",
+						"name": "worker-1",
+						"change": map[string]any{
+							"actions": []any{"delete"},
+							"before":  map[string]any{"name": "worker-1-name"},
+						},
+					},
+				},
+			},
+		},
+		"before without a name attribute (e.g. aws_instance) omits the name key rather than an empty string": {
+			// aws_instance names instances via a tag, not a "name" attribute -
+			// the key must be absent here, not present-and-empty.
+			plan: plan.Plan{
+				"resource_changes": []any{
+					map[string]any{
+						"type": "aws_instance",
+						"name": "master",
+						"change": map[string]any{
+							"actions": []any{"delete", "create"},
+							"before": map[string]any{
+								"tags":          map[string]any{"Name": "master-0"},
+								"instance_type": "m5.large",
+							},
+						},
+					},
+				},
+			},
+			expected: plan.Plan{
+				"resource_changes": []any{
+					map[string]any{
+						"type": "aws_instance",
+						"name": "master",
+						"change": map[string]any{
+							"actions": []any{"delete", "create"},
+							"before":  map[string]any{},
+						},
+					},
+				},
+			},
+		},
+		"before name falls back through manifest.metadata.name and metadata[].name shapes": {
+			plan: plan.Plan{
+				"resource_changes": []any{
+					map[string]any{
+						"type": "kubernetes_manifest",
+						"name": "some_manifest",
+						"change": map[string]any{
+							"actions": []any{"delete"},
+							"before": map[string]any{
+								"manifest": map[string]any{
+									"kind":     "Deployment",
+									"metadata": map[string]any{"name": "my-deployment", "namespace": "default"},
+									"spec":     map[string]any{"replicas": 3},
+								},
+								"metadata": []any{
+									map[string]any{"name": "meta-entry", "uid": "abc-123"},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: plan.Plan{
+				"resource_changes": []any{
+					map[string]any{
+						"type": "kubernetes_manifest",
+						"name": "some_manifest",
+						"change": map[string]any{
+							"actions": []any{"delete"},
+							"before": map[string]any{
+								"manifest": map[string]any{
+									"kind":     "Deployment",
+									"metadata": map[string]any{"name": "my-deployment"},
+								},
+								"metadata": []any{
+									map[string]any{"name": "meta-entry"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"one resource_change with a malformed before shape does not drop the rest of the array": {
+			plan: plan.Plan{
+				"resource_changes": []any{
+					map[string]any{
+						"type": "weird_provider_resource",
+						"name": "quirky",
+						"change": map[string]any{
+							"actions": []any{"update"},
+							"before": map[string]any{
+								"name":     "quirky-actual-name",
+								"metadata": map[string]any{"unexpected": "object-instead-of-array"},
+							},
+						},
+					},
+					map[string]any{
+						"type": "yandex_compute_instance",
+						"name": "worker-0",
+						"change": map[string]any{
+							"actions": []any{"update"},
+							"before":  map[string]any{"name": "worker-0-name"},
+						},
+					},
+				},
+			},
+			expected: plan.Plan{
+				"resource_changes": []any{
+					map[string]any{
+						"type": "weird_provider_resource",
+						"name": "quirky",
+						"change": map[string]any{
+							"actions": []any{"update"},
+							"before":  map[string]any{"name": "quirky-actual-name"},
+						},
+					},
+					map[string]any{
+						"type": "yandex_compute_instance",
+						"name": "worker-0",
+						"change": map[string]any{
+							"actions": []any{"update"},
+							"before":  map[string]any{"name": "worker-0-name"},
+						},
+					},
+				},
+			},
+		},
+		"missing resource_changes is omitted, prior_state is still trimmed": {
+			plan: plan.Plan{
+				"prior_state": map[string]any{
+					"values": map[string]any{
+						"root_module": map[string]any{
+							"resources": []any{
+								map[string]any{"name": "master", "type": "yandex_compute_instance", "values": map[string]any{}},
+							},
+						},
+					},
+				},
+			},
+			expected: plan.Plan{
+				"prior_state": map[string]any{
+					"values": map[string]any{
+						"root_module": map[string]any{
+							"resources": []any{
+								map[string]any{"name": "master", "type": "yandex_compute_instance", "values": map[string]any{"tags": map[string]any{}}},
+							},
+						},
+					},
+				},
+			},
+		},
+		"resource without tags keeps an empty values object": {
+			plan: plan.Plan{
+				"prior_state": map[string]any{
+					"values": map[string]any{
+						"root_module": map[string]any{
+							"resources": []any{
+								map[string]any{
+									"name":   "worker",
+									"type":   "aws_ebs_volume",
+									"values": map[string]any{"size": 100},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: plan.Plan{
+				"prior_state": map[string]any{
+					"values": map[string]any{
+						"root_module": map[string]any{
+							"resources": []any{
+								map[string]any{
+									"name":   "worker",
+									"type":   "aws_ebs_volume",
+									"values": map[string]any{"tags": map[string]any{}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"resource with tags but no Name keeps an empty tags object": {
+			plan: plan.Plan{
+				"prior_state": map[string]any{
+					"values": map[string]any{
+						"root_module": map[string]any{
+							"resources": []any{
+								map[string]any{
+									"name":   "master",
+									"type":   "aws_instance",
+									"values": map[string]any{"tags": map[string]any{"Environment": "prod"}},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: plan.Plan{
+				"prior_state": map[string]any{
+					"values": map[string]any{
+						"root_module": map[string]any{
+							"resources": []any{
+								map[string]any{
+									"name":   "master",
+									"type":   "aws_instance",
+									"values": map[string]any{"tags": map[string]any{}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"resource with tags explicitly null keeps an empty tags object": {
+			plan: plan.Plan{
+				"prior_state": map[string]any{
+					"values": map[string]any{
+						"root_module": map[string]any{
+							"resources": []any{
+								map[string]any{
+									"name":   "worker",
+									"type":   "aws_ebs_volume",
+									"values": map[string]any{"tags": nil},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: plan.Plan{
+				"prior_state": map[string]any{
+					"values": map[string]any{
+						"root_module": map[string]any{
+							"resources": []any{
+								map[string]any{
+									"name":   "worker",
+									"type":   "aws_ebs_volume",
+									"values": map[string]any{"tags": map[string]any{}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"missing prior_state is omitted; resource_changes is still trimmed": {
+			plan: plan.Plan{
+				"resource_changes": []any{
+					map[string]any{
+						"type": "yandex_compute_instance",
+						"name": "worker-0",
+						"change": map[string]any{
+							"actions": []any{"no-op"},
+							"before":  map[string]any{"name": "worker-0-name"},
+							"after":   map[string]any{"name": "worker-0-name"},
+						},
+					},
+				},
+			},
+			expected: plan.Plan{
+				"resource_changes": []any{
+					map[string]any{
+						"type": "yandex_compute_instance",
+						"name": "worker-0",
+						"change": map[string]any{
+							"actions": []any{"no-op"},
+							"before":  map[string]any{"name": "worker-0-name"},
+							"after":   map[string]any{"name": "worker-0-name"},
+						},
+					},
+				},
+			},
+		},
+		"malformed prior_state shape yields an empty scaffold, not an error": {
+			plan: plan.Plan{
+				"prior_state": "not-an-object",
+			},
+			expected: plan.Plan{
+				"prior_state": map[string]any{
+					"values": map[string]any{
+						"root_module": map[string]any{
+							"resources": nil,
+						},
+					},
+				},
+			},
+		},
+		"one resource with a malformed field does not drop the rest of the array": {
+			plan: plan.Plan{
+				"prior_state": map[string]any{
+					"values": map[string]any{
+						"root_module": map[string]any{
+							"resources": []any{
+								map[string]any{
+									"name": "master",
+									"type": "google_compute_instance",
+									"values": map[string]any{
+										"tags": []any{"master", "kube"},
+									},
+								},
+								map[string]any{
+									"name": "worker-0",
+									"type": "yandex_compute_instance",
+									"values": map[string]any{
+										"tags": map[string]any{"Name": "worker-0-name"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: plan.Plan{
+				"prior_state": map[string]any{
+					"values": map[string]any{
+						"root_module": map[string]any{
+							"resources": []any{
+								map[string]any{
+									"name":   "master",
+									"type":   "google_compute_instance",
+									"values": map[string]any{"tags": map[string]any{}},
+								},
+								map[string]any{
+									"name":   "worker-0",
+									"type":   "yandex_compute_instance",
+									"values": map[string]any{"tags": map[string]any{"Name": "worker-0-name"}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"empty plan returns empty": {
+			plan:     plan.Plan{},
+			expected: plan.Plan{},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, err := json.Marshal(tt.plan.Trim())
+			require.NoError(t, err)
+
+			expected, err := json.Marshal(tt.expected)
+			require.NoError(t, err)
+
+			assert.JSONEq(t, string(expected), string(actual))
+		})
+	}
+}

--- a/dhctl/pkg/operations/check/check.go
+++ b/dhctl/pkg/operations/check/check.go
@@ -116,6 +116,24 @@ func (s Statistics) Format(outputFormat string) ([]byte, error) {
 	return data, nil
 }
 
+// Trim returns a copy of the statistics with each infrastructure
+// plan reduced to what actually changed.
+// Unlike Format, which hides the plan entirely, this keeps the change itself
+// and drops only its surrounding static context.
+func (s Statistics) Trim() (Statistics, error) {
+	copied, err := copystructure.Copy(s)
+	if err != nil {
+		return Statistics{}, fmt.Errorf("unable to copy check statistics")
+	}
+
+	trimmedStatistics := copied.(Statistics)
+	for i, p := range trimmedStatistics.InfrastructurePlan {
+		trimmedStatistics.InfrastructurePlan[i] = p.Trim()
+	}
+
+	return trimmedStatistics, nil
+}
+
 type ClusterStateCheckResult struct {
 	Change             int
 	Plan               plan.Plan

--- a/dhctl/pkg/operations/check/check_test.go
+++ b/dhctl/pkg/operations/check/check_test.go
@@ -15,8 +15,10 @@
 package check
 
 import (
+	"encoding/json"
 	"testing"
 
+	"github.com/mitchellh/copystructure"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/yaml"
@@ -37,6 +39,88 @@ func TestStatistics_Format(t *testing.T) {
 
 	assert.EqualValues(t, expectedStatistics, statistics)
 	assert.Equal(t, statisticsYAMLPrintable, string(formattedStatistics))
+}
+
+func TestStatistics_Trim(t *testing.T) {
+	resourceChanges := []any{
+		map[string]any{
+			"type": "yandex_compute_instance",
+			"name": "master",
+			"change": map[string]any{
+				"actions": []any{"update"},
+				"before":  map[string]any{"name": "master"},
+				"after":   map[string]any{"name": "master"},
+			},
+		},
+	}
+	originalPlan := plan.Plan{
+		"format_version":   "0.1",
+		"configuration":    map[string]any{"root_module": map[string]any{}},
+		"resource_changes": resourceChanges,
+		"prior_state": map[string]any{
+			"values": map[string]any{
+				"root_module": map[string]any{
+					"resources": []any{
+						map[string]any{
+							"name": "master",
+							"type": "yandex_compute_instance",
+							"values": map[string]any{
+								"tags":      map[string]any{"Name": "master-0"},
+								"boot_disk": []any{"large blob"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	statistics := Statistics{
+		Cluster:            ClusterCheckResult{Status: "ok"},
+		InfrastructurePlan: []plan.Plan{originalPlan},
+	}
+
+	copied, err := copystructure.Copy(originalPlan)
+	require.NoError(t, err)
+
+	trimmed, err := statistics.Trim()
+	require.NoError(t, err)
+
+	require.Len(t, trimmed.InfrastructurePlan, 1)
+
+	actualPlan, err := json.Marshal(trimmed.InfrastructurePlan[0])
+	require.NoError(t, err)
+	expectedPlan, err := json.Marshal(plan.Plan{
+		"resource_changes": []any{
+			map[string]any{
+				"type": "yandex_compute_instance",
+				"name": "master",
+				"change": map[string]any{
+					"actions": []any{"update"},
+					"before":  map[string]any{"name": "master"},
+					"after":   map[string]any{"name": "master"},
+				},
+			},
+		},
+		"prior_state": map[string]any{
+			"values": map[string]any{
+				"root_module": map[string]any{
+					"resources": []any{
+						map[string]any{
+							"name":   "master",
+							"type":   "yandex_compute_instance",
+							"values": map[string]any{"tags": map[string]any{"Name": "master-0"}},
+						},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	assert.JSONEq(t, string(expectedPlan), string(actualPlan))
+
+	// Trim must not mutate the receiver: callers may still need the
+	// untrimmed statistics after calling it.
+	assert.Equal(t, copied.(plan.Plan), statistics.InfrastructurePlan[0])
 }
 
 const (

--- a/dhctl/pkg/server/rpc/dhctl/check.go
+++ b/dhctl/pkg/server/rpc/dhctl/check.go
@@ -280,10 +280,11 @@ func (s *Service) check(ctx context.Context, p *checkParams) *pb.CheckResult {
 		}
 	}()
 
-	resultData, marshalErr := json.Marshal(result)
+	trimmedResult, trimErr := trimCheckResult(result)
+	resultData, marshalErr := json.Marshal(trimmedResult)
 	state, stateErr := extractLastState(ctx)
 
-	err = errors.Join(checkErr, marshalErr, stateErr)
+	err = errors.Join(checkErr, trimErr, marshalErr, stateErr)
 
 	if result != nil {
 		// todo: move onCheckResult call to check.Check() func (as in converge)
@@ -305,4 +306,20 @@ func (s *Service) checkServerTransitions() []fsm.Transition {
 			Destination: "running",
 		},
 	}
+}
+
+func trimCheckResult(result *check.CheckResult) (*check.CheckResult, error) {
+	if result == nil {
+		return nil, nil
+	}
+
+	trimmedStatistics, err := result.StatusDetails.Statistics.Trim()
+	if err != nil {
+		return nil, fmt.Errorf("trimming check result: %w", err)
+	}
+
+	trimmedResult := *result
+	trimmedResult.StatusDetails.Statistics = trimmedStatistics
+
+	return &trimmedResult, nil
 }

--- a/dhctl/pkg/server/rpc/dhctl/commander_attach.go
+++ b/dhctl/pkg/server/rpc/dhctl/commander_attach.go
@@ -230,10 +230,16 @@ func (s *Service) commanderAttach(ctx context.Context, p *attachParams) *pb.Comm
 	})
 
 	result, attachErr := attacher.Attach(ctx)
+
+	var trimErr error
+	if result != nil {
+		result.CheckResult, trimErr = trimCheckResult(result.CheckResult)
+	}
+
 	resultData, marshalResultErr := json.Marshal(result)
 	state, stateErr := extractLastState(ctx)
 
-	err = errors.Join(attachErr, stateErr, marshalResultErr)
+	err = errors.Join(attachErr, trimErr, stateErr, marshalResultErr)
 
 	return &pb.CommanderAttachResult{State: string(state), Result: string(resultData), Err: util.ErrToString(err)}
 }
@@ -260,6 +266,12 @@ func (s *Service) commanderAttachServerTransitions() []fsm.Transition {
 
 //nolint:musttag
 func (s *Service) attachSwitchPhaseData(onPhaseData phases.OnPhaseFuncData[attach.PhaseData]) (*pb.CommanderAttachResponse, error) {
+	var err error
+	onPhaseData.CompletedPhaseData.CheckResult, err = trimCheckResult(onPhaseData.CompletedPhaseData.CheckResult)
+	if err != nil {
+		return nil, err
+	}
+
 	phaseDataBytes, err := json.Marshal(onPhaseData.CompletedPhaseData)
 	if err != nil {
 		return nil, err

--- a/dhctl/pkg/server/rpc/dhctl/converge.go
+++ b/dhctl/pkg/server/rpc/dhctl/converge.go
@@ -336,10 +336,16 @@ func (s *Service) converge(ctx context.Context, p *convergeParams) *pb.ConvergeR
 	converger := converge.NewConverger(convergeParams)
 
 	result, convergeErr := converger.Converge(ctx)
+
+	var trimErr error
+	if result != nil {
+		result.CheckResult, trimErr = trimCheckResult(result.CheckResult)
+	}
+
 	resultData, marshalResultErr := json.Marshal(result)
 	state, stateErr := extractLastState(ctx)
 
-	err = errors.Join(convergeErr, stateErr, marshalResultErr)
+	err = errors.Join(convergeErr, trimErr, stateErr, marshalResultErr)
 
 	if err != nil {
 		span.SetStatus(otcodes.Error, err.Error())

--- a/dhctl/pkg/server/server/proxy.go
+++ b/dhctl/pkg/server/server/proxy.go
@@ -203,6 +203,10 @@ func createDHCTLServerConn(ctx context.Context, address string) (*grpc.ClientCon
 	conn, err := grpc.NewClient(
 		"unix://"+address,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(MaxMessageSize),
+			grpc.MaxCallSendMsgSize(MaxMessageSize),
+		),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("creating client connection: %w", err)

--- a/dhctl/pkg/server/server/server.go
+++ b/dhctl/pkg/server/server/server.go
@@ -40,6 +40,11 @@ import (
 
 const SinglethreadedMethodsPrefix = "/dhctl.DHCTL" // full method example: /dhctl.DHCTL/Check
 
+// MaxMessageSize is 2x gRPC's default 4MB message limit: a check on an
+// out-of-sync cluster with many changed nodes can still get close to the
+// default limit even after dhctl trims what it sends.
+const MaxMessageSize = 8 * 1024 * 1024
+
 // Serve starts GRPC server
 func Serve(ctx context.Context, params settings.ServerParams) error {
 	if err := params.Validate(); err != nil {
@@ -96,6 +101,8 @@ func Serve(ctx context.Context, params settings.ServerParams) error {
 			interceptors.StreamRequestsCounter(requestsCounter),
 		),
 		grpc.UnknownServiceHandler(proxy.TransparentHandler(dhctlProxy.Director())),
+		grpc.MaxRecvMsgSize(MaxMessageSize),
+		grpc.MaxSendMsgSize(MaxMessageSize),
 	)
 
 	// https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-grpc-liveness-probe

--- a/dhctl/pkg/server/server/singlethreaded/server.go
+++ b/dhctl/pkg/server/server/singlethreaded/server.go
@@ -91,6 +91,8 @@ func Serve(ctx context.Context, params settings.ServerSingleshotParams) error {
 			recovery.StreamServerInterceptor(recovery.WithRecoveryHandlerContext(interceptors.PanicRecoveryHandler())),
 			interceptors.StreamParallelTasksLimiter(sem, server.SinglethreadedMethodsPrefix),
 		),
+		grpc.MaxRecvMsgSize(server.MaxMessageSize),
+		grpc.MaxSendMsgSize(server.MaxMessageSize),
 	)
 
 	// https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-grpc-liveness-probe


### PR DESCRIPTION
## Description

- Fixed `make bin/protoc` download failure: `Makefile` compared an undefined `$(UNAME)` instead of `$(OS_NAME)`, so `PROTOC_PLATFORM` was always empty and the download URL was malformed (404). Fixed the variable name; no functional change to build logic otherwise.

- Trimmed `terraform_plan` inside every `check.CheckResult` that crosses the gRPC boundary — not just standalone `Check`: `Converge` (when a destructive change needs approval) and `CommanderAttach` (both its final result and its check-phase completion data) embed the same `CheckResult` in their response. On an `OutOfSync` cluster with many changed/managed nodes, the raw OpenTofu `terraform_plan` inside it could be large enough to exceed gRPC's 4MB message limit, failing on `Recv()`.

-  Added `plan.Plan.Trim()` (`pkg/infrastructure/plan/trim.go`): reduces `prior_state` to just `name`/`type`/`values.tags.Name` per resource — enough to identify a resource, not its full attribute state. Drops `configuration`, `planned_values`, `variables`, `output_changes`, and the rest of `prior_state`, which are never read by any consumer.
- Also cuts `resource_changes` down to `type`/`name`/`change.actions` plus a handful of `before`/`after` identity fields (`name`, `manifest.kind`, `manifest.metadata.name`, `metadata[].name`) used to render a human-readable resource label

- Raised the gRPC max message size from the default 4MB to 8MB as additional headroom, applied symmetrically across the whole transport chain.


Verified end-to-end on the review environment: triggered a destructive change and confirmed the confirmation panel in Commander correctly renders the full list of resources to be deleted/recreated (VirtualMachine, VirtualDisk, VirtualMachineIPAddress, etc.) from the trimmed Check response — nothing missing or broken on the UI side.

<img width="1294" height="686" alt="Screenshot 2026-07-31 at 17 36 14" src="https://github.com/user-attachments/assets/d7664944-492b-400f-a17b-5d7ed8f08136" />


## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: trim grpc check response, increase grpc message size
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
