### PR TITLE
[candi] Add a bashible step to detect whether apparmor and selinux are enabled

### DIFF
--- a/candi/bashible/common-steps/all/093_set_mac_security_labels.sh.tpl
+++ b/candi/bashible/common-steps/all/093_set_mac_security_labels.sh.tpl
@@ -1,0 +1,74 @@
+# Copyright 2026 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# bashible: parallel-group=light-labels
+
+{{- if eq .runType "Normal" }}
+# If there is no kubelet.conf than node is not bootstrapped and there is nothing to do
+kubeconfig="/etc/kubernetes/kubelet.conf"
+if [ ! -f "$kubeconfig" ]; then
+  exit 0
+fi
+
+if [[ "${FIRST_BASHIBLE_RUN}" == "yes" ]]; then
+  exit 0
+fi
+
+# if reboot flag set due to disruption update we pass this step.
+if bb-flag? disruption && bb-flag? reboot; then
+  exit 0
+fi
+
+node=$(bb-d8-node-name)
+
+# Detect SELinux status:
+#   enforcing  - SELinux is enabled and enforcing policies
+#   permissive - SELinux is enabled but only logging denials
+#   disabled   - SELinux kernel module is loaded but disabled
+#   absent     - SELinux is not installed on this OS (e.g. Ubuntu family without policycoreutils)
+if command -v getenforce >/dev/null 2>&1; then
+  selinux="$(getenforce | tr '[:upper:]' '[:lower:]')"
+else
+  selinux="absent"
+fi
+
+# Detect AppArmor status:
+#   enabled  - AppArmor is active and enforcing profiles
+#   disabled - AppArmor is installed but not active
+#   absent   - AppArmor is not installed on this OS (e.g. RHEL/AlmaLinux family)
+if command -v aa-status >/dev/null 2>&1; then
+  if aa-status --enabled 2>/dev/null; then
+    apparmor="enabled"
+  else
+    apparmor="disabled"
+  fi
+else
+  apparmor="absent"
+fi
+
+max_attempts=5
+
+for kv in "node.deckhouse.io/selinux=${selinux}" "node.deckhouse.io/apparmor=${apparmor}"; do
+  attempt=0
+  until bb-curl-helper-patch-node-metadata "$node" "labels" "$kv"; do
+    attempt=$(( attempt + 1 ))
+    if [ "$attempt" -gt "$max_attempts" ]; then
+      bb-log-error "Failed to set $kv label on node $node after $max_attempts attempts"
+      exit 1
+    fi
+    echo "Retrying to set $kv label on node $node (attempt $attempt of $max_attempts)"
+    sleep 5
+  done
+done
+{{- end  }}


### PR DESCRIPTION
## Description

A new bashible step [`093_set_mac_security_labels.sh.tpl`](candi/bashible/common-steps/all/093_set_mac_security_labels.sh.tpl) detects SELinux and AppArmor status on each node during convergence and exposes it as two Node labels:

- `node.deckhouse.io/selinux=enforcing|permissive|disabled|absent`
- `node.deckhouse.io/apparmor=enabled|disabled|absent`

The step follows the existing pattern of [`092_set_cgroup_type.sh.tpl`](candi/bashible/common-steps/all/092_set_cgroup_type.sh.tpl): runs only after the kubelet is registered, skips the first bashible run and the disruption-reboot window, writes labels via `bb-curl-helper-patch-node-metadata` with retry, and runs in the `light-labels` parallel group. Detection uses `getenforce` for SELinux and `aa-status --enabled` for AppArmor; `absent` means the package is not installed on this OS family. The step is purely informational — it does not restart any services or modify the node.

## Why do we need it, and what problem does it solve?

Deckhouse had no way to expose the MAC (SELinux/AppArmor) state of a node to modules, Go hooks, or the scheduler. SELinux status was checked locally only in [`005_install_mandatory_selinux_policies.sh.tpl`](candi/bashible/common-steps/all/005_install_mandatory_selinux_policies.sh.tpl) but never stored as a node fact; AppArmor was not detected at all. This closes the gap consistently with the existing node-fact labels (`cgroup`, `cri-type`, `virtualization`, `dvp-nesting-level`), making the MAC state available to informers, `nodeSelector`, and Go hooks (e.g. `admission-policy-engine` could allow `apparmor:unconfined` only on nodes with `node.deckhouse.io/apparmor=absent`).

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: feature
summary: Detect SELinux and AppArmor status on cluster nodes and expose it as the `node.deckhouse.io/selinux` and `node.deckhouse.io/apparmor` Node labels.
impact_level: low
```