### PR TITLE
[istio] Add annotation full-version to alliance-healthcheck

### DIFF
--- a/ee/modules/110-istio/templates/alliance/healthcheck/deployment.yaml
+++ b/ee/modules/110-istio/templates/alliance/healthcheck/deployment.yaml
@@ -5,7 +5,7 @@ memory: 25Mi
 
 {{- if or .Values.istio.federation.enabled .Values.istio.multicluster.enabled }}
   {{- $versionInfo := get .Values.istio.internal.versionMap .Values.istio.internal.globalVersion }}
-  {{- $revision := get $versionInfo "revision" }}
+  {{- $fullVersion := get $versionInfo "fullVersion" }}
   {{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler") }}
 ---
 apiVersion: autoscaling.k8s.io/v1
@@ -49,6 +49,8 @@ spec:
         app: alliance-healthcheck
         sidecar.istio.io/inject: "true"
         istio.io/rev: default
+      annotations:
+        istio.deckhouse.io/full-version: "{{ $fullVersion }}"
     spec:
       {{- include "helm_lib_node_selector" (tuple . "system") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "system") | nindent 6 }}


### PR DESCRIPTION
## Description

- Added annotation `istio.deckhouse.io/full-version` to alliance-healthcheck deployment
- Removed unused $revision var from alliance-healthcheck deployment.

## Why do we need it, and what problem does it solve?
Adding of `istio.deckhouse.io/full-version` allows alliance-healthcheck to "follow" istio MC globalVersion changes to always run on actual globalVersion.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: chore
summary: Alliance-healthcheck now auto-restarts when globalVersion has been changed
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
