### PR TITLE
[control-plane-manager] VCP monitoring modules and improved deckhouse for vcp mode

### DIFF
--- a/deckhouse-controller/cmd/deckhouse-controller/main.go
+++ b/deckhouse-controller/cmd/deckhouse-controller/main.go
@@ -53,59 +53,6 @@ func version() string {
 	return fmt.Sprintf("deckhouse %s (addon-operator %s, shell-operator %s, nelm %s, Golang %s)", DeckhouseVersion, AddonOperatorVersion, ShellOperatorVersion, NelmVersion, runtime.Version())
 }
 
-// propagateKubeconfigEnv exports the kubeconfig path configured via
-// --kube-config/$KUBE_CONFIG into the standard $KUBECONFIG (and the context
-// into $HELM_KUBECONTEXT). The operator's main kube client, the object
-// patcher and the package-system clients receive the path through
-// cfg.Kube.Config directly, but several client paths resolve their config
-// through the default clientcmd loading rules or Helm env settings instead:
-// helm3lib action configs, the `registry` subcommand (ctrl.GetConfigOrDie),
-// the `module enable/disable` debug subcommands and the module-sdk
-// GetK8sClient used by Go hooks (it resolves through ctrl.GetConfig too).
-// Exporting the standard env vars points all of them at the same apiserver
-// instead of silently falling back to the in-cluster config.
-//
-// It does NOT cover the rest of the module-sdk dependency container:
-// GetClientConfig calls rest.InClusterConfig unconditionally, and
-// GetKubeToken/GetHTTPClient read the ServiceAccount token and CA straight
-// from /var/run/secrets/kubernetes.io/serviceaccount. Hooks taking those
-// paths need a real token file at that location.
-func propagateKubeconfigEnv(cfg *app.Config) {
-	if cfg.Kube.Config != "" {
-		os.Setenv("KUBECONFIG", cfg.Kube.Config)
-		materializeDefaultKubeconfig(cfg.Kube.Config)
-	}
-	if cfg.Kube.Context != "" {
-		os.Setenv("HELM_KUBECONTEXT", cfg.Kube.Context)
-	}
-}
-
-// materializeDefaultKubeconfig symlinks $HOME/.kube/config to the configured
-// kubeconfig. The nelm action API (helm backend when USE_NELM=true) does not
-// read $KUBECONFIG: with no explicit paths it defaults to $HOME/.kube/config,
-// so without this link nelm falls back to localhost:8080 when running outside
-// the managed cluster. An already existing $HOME/.kube/config is left as is.
-func materializeDefaultKubeconfig(kubeconfigPath string) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "cannot resolve home dir to link kubeconfig for nelm: %v\n", err)
-		return
-	}
-
-	target := filepath.Join(home, ".kube", "config")
-	if _, err := os.Lstat(target); err == nil {
-		return
-	}
-
-	if err := os.MkdirAll(filepath.Dir(target), 0o700); err != nil {
-		fmt.Fprintf(os.Stderr, "cannot create %s to link kubeconfig for nelm: %v\n", filepath.Dir(target), err)
-		return
-	}
-	if err := os.Symlink(kubeconfigPath, target); err != nil {
-		fmt.Fprintf(os.Stderr, "cannot link kubeconfig for nelm at %s: %v\n", target, err)
-	}
-}
-
 // main is almost a copy from addon-operator. We compile addon-operator to inline
 // Go hooks and set some defaults. Also, helper commands are defined for Shell hooks.
 
@@ -182,8 +129,6 @@ func main() {
 			klogtolog.InitAdapter(cfg.Debug.KubernetesAPI, logger.Named("klog"))
 			stdliblogtolog.InitAdapter(logger)
 
-			propagateKubeconfigEnv(cfg)
-
 			return nil
 		},
 	}
@@ -249,14 +194,6 @@ func main() {
 		dhctlOpts.Global.LoggerType = app.EnvOr(app.EnvLoggerType, "json")
 		dhctlOpts.Render.Editor = app.EnvOr(app.EnvEditor, "vim")
 		dhctlOpts.Kube.InCluster = app.EnvBoolOr(app.EnvKubeConfigInCluster, true)
-		// When a kubeconfig is configured for the operator ($KUBE_CONFIG),
-		// the embedded dhctl edit/config commands must talk to the same
-		// apiserver instead of the in-cluster one.
-		if cfg.Kube.Config != "" {
-			dhctlOpts.Kube.Config = cfg.Kube.Config
-			dhctlOpts.Kube.ConfigContext = cfg.Kube.Context
-			dhctlOpts.Kube.InCluster = false
-		}
 		dhctlOpts.Global.TmpDir = app.EnvOr(app.EnvTmpDir, os.TempDir())
 
 		// Pin the dhctl content directories to the deckhouse image layout

--- a/deckhouse-controller/cmd/deckhouse-controller/main.go
+++ b/deckhouse-controller/cmd/deckhouse-controller/main.go
@@ -60,10 +60,16 @@ func version() string {
 // cfg.Kube.Config directly, but several client paths resolve their config
 // through the default clientcmd loading rules or Helm env settings instead:
 // helm3lib action configs, the `registry` subcommand (ctrl.GetConfigOrDie),
-// the `module enable/disable` debug subcommands and the dependency-container
-// client used by Go hooks. Exporting the standard env vars points all of
-// them at the same apiserver instead of silently falling back to the
-// in-cluster config.
+// the `module enable/disable` debug subcommands and the module-sdk
+// GetK8sClient used by Go hooks (it resolves through ctrl.GetConfig too).
+// Exporting the standard env vars points all of them at the same apiserver
+// instead of silently falling back to the in-cluster config.
+//
+// It does NOT cover the rest of the module-sdk dependency container:
+// GetClientConfig calls rest.InClusterConfig unconditionally, and
+// GetKubeToken/GetHTTPClient read the ServiceAccount token and CA straight
+// from /var/run/secrets/kubernetes.io/serviceaccount. Hooks taking those
+// paths need a real token file at that location.
 func propagateKubeconfigEnv(cfg *app.Config) {
 	if cfg.Kube.Config != "" {
 		os.Setenv("KUBECONFIG", cfg.Kube.Config)

--- a/deckhouse-controller/internal/tools/verity/erofs.go
+++ b/deckhouse-controller/internal/tools/verity/erofs.go
@@ -26,6 +26,8 @@ import (
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/deckhouse/deckhouse/pkg/app"
 )
 
 const (
@@ -120,8 +122,13 @@ func CreateImageByTar(ctx context.Context, rc io.ReadCloser, imagePath string) e
 	return nil
 }
 
-// IsSupported scans /proc/filesystems for erofs type, it returns whether erofs is supported
+// IsSupported scans /proc/filesystems for erofs type, it returns whether erofs is supported.
+// /proc/filesystems describes the node kernel, not what this pod may do with it, so the gate lets a pod without device-mapper access opt out.
 func IsSupported() bool {
+	if app.VerityDisabled() {
+		return false
+	}
+
 	content, err := os.ReadFile("/proc/filesystems")
 	if err != nil {
 		return false

--- a/go_lib/controlplane/kubeconfig/kubeconfig.go
+++ b/go_lib/controlplane/kubeconfig/kubeconfig.go
@@ -179,9 +179,14 @@ func getFileSpec(kind File, opt *options) (*fileSpec, error) {
 		}, nil
 	case Deckhouse:
 		return &fileSpec{
-			ClusterName:         opt.ClusterName,
-			APIServer:           opt.ControlPlaneEndpoint,
-			ClientName:          "deckhouse",
+			ClusterName: opt.ClusterName,
+			APIServer:   opt.ControlPlaneEndpoint,
+			// The ValidatingAdmissionPolicies deckhouse installs into the cluster it
+			// manages (see 002-deckhouse/templates/validation.yaml) only exempt its own
+			// in-cluster ServiceAccount and the "dhctl" user, so an out-of-cluster
+			// deckhouse gets denied on system namespaces and heritage-labelled objects.
+			// TODO: authenticate as the real d8-system:deckhouse ServiceAccount instead.
+			ClientName:          "dhctl",
 			ClientCertNotAfter:  opt.CertProvider.NotAfter(),
 			CACert:              opt.CertProvider.CACert(),
 			CAKey:               opt.CertProvider.CAKey(),

--- a/go_lib/controlplane/kubeconfig/kubeconfig.go
+++ b/go_lib/controlplane/kubeconfig/kubeconfig.go
@@ -177,21 +177,6 @@ func getFileSpec(kind File, opt *options) (*fileSpec, error) {
 			CAKey:               opt.CertProvider.CAKey(),
 			EncryptionAlgorithm: opt.EncryptionAlgorithm,
 		}, nil
-	case Deckhouse:
-		return &fileSpec{
-			ClusterName: opt.ClusterName,
-			APIServer:   opt.ControlPlaneEndpoint,
-			// The ValidatingAdmissionPolicies deckhouse installs into the cluster it
-			// manages (see 002-deckhouse/templates/validation.yaml) only exempt its own
-			// in-cluster ServiceAccount and the "dhctl" user, so an out-of-cluster
-			// deckhouse gets denied on system namespaces and heritage-labelled objects.
-			// TODO: authenticate as the real d8-system:deckhouse ServiceAccount instead.
-			ClientName:          "dhctl",
-			ClientCertNotAfter:  opt.CertProvider.NotAfter(),
-			CACert:              opt.CertProvider.CACert(),
-			CAKey:               opt.CertProvider.CAKey(),
-			EncryptionAlgorithm: opt.EncryptionAlgorithm,
-		}, nil
 	default:
 		return nil, fmt.Errorf("unsupported kind %s", kind)
 	}

--- a/go_lib/controlplane/kubeconfig/types.go
+++ b/go_lib/controlplane/kubeconfig/types.go
@@ -28,5 +28,4 @@ const (
 
 	CiliumOperator     File = "cilium-operator.conf"
 	KonnectivityServer File = "konnectivity-server.conf"
-	Deckhouse          File = "deckhouse.conf"
 )

--- a/go_lib/dependency/k8s/k8s.go
+++ b/go_lib/dependency/k8s/k8s.go
@@ -18,7 +18,6 @@ package k8s
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/flant/kube-client/fake"
 	"k8s.io/client-go/dynamic"
@@ -60,10 +59,6 @@ func NewClient(options ...Option) (Client, error) {
 
 	for _, opt := range options {
 		opt(opts)
-	}
-
-	if opts.kubeconfigPath == "" {
-		opts.kubeconfigPath = os.Getenv("KUBECONFIG")
 	}
 
 	var config *rest.Config

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/constants/constants.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/constants/constants.go
@@ -50,6 +50,7 @@ const (
 	VirtualKubeconfigSecretName               = "d8-kubeconfig-virtual"
 	VirtualAdminKubeconfigSecretName          = "d8-admin-kubeconfig-virtual"
 	VirtualClientsKubeconfigSecretName        = "d8-kubeconfig-virtual-clients"
+	VirtualDeckhouseTokenSecretName           = "d8-deckhouse-token-virtual"
 	VirtualAPIServerServiceName               = "kube-apiserver"
 	VirtualKonnectivityEgressConfigMapName    = "konnectivity-egress"
 	VirtualKonnectivityServerServiceName      = "konnectivity-server"

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/deckhouse/manifests/deployment.yaml
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/deckhouse/manifests/deployment.yaml
@@ -50,8 +50,6 @@ spec:
           command:
             - /usr/bin/deckhouse-controller
             - start
-            - --kube-config
-            - /kubeconfig.yaml
           workingDir: /deckhouse
           securityContext:
             readOnlyRootFilesystem: true
@@ -71,13 +69,8 @@ spec:
             periodSeconds: 5
             failureThreshold: 120
           env:
-            - name: KUBE_CONFIG
-              value: /kubeconfig.yaml
-            - name: KUBECONFIG
-              value: /kubeconfig.yaml
-            # The kubeconfig points at the tenant apiserver; these two make the
-            # in-cluster-config fallback paths land on the same apiserver (the
-            # per-VCP ALB routes :6443 to it) instead of the parent cluster's.
+            # The pod has no kubeconfig: it authenticates as a tenant
+            # ServiceAccount through the mounted token
             - name: KUBERNETES_SERVICE_HOST
               value: "${VCP_API_VIP}"
             - name: KUBERNETES_SERVICE_PORT
@@ -170,9 +163,11 @@ spec:
               mountPath: /root/.kube
             - name: downloaded
               mountPath: /deckhouse/downloaded
-            - name: kubeconfig
-              mountPath: /kubeconfig.yaml
-              subPath: deckhouse.conf
+            # Mounted as a directory on purpose: client-go re-reads the token
+            # through BearerTokenFile, and subPath mounts are never refreshed
+            # by kubelet, so a subPath here would break token rotation.
+            - name: sa-token
+              mountPath: /var/run/secrets/kubernetes.io/serviceaccount
               readOnly: true
       volumes:
         - name: tmp
@@ -184,6 +179,6 @@ spec:
         # Downloadable modules are re-fetched after a pod restart; a PVC is a follow-up.
         - name: downloaded
           emptyDir: {}
-        - name: kubeconfig
+        - name: sa-token
           secret:
-            secretName: d8-kubeconfig-virtual-clients
+            secretName: ${TOKEN_SECRET_NAME}

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/deckhouse/manifests/deployment.yaml
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/deckhouse/manifests/deployment.yaml
@@ -182,3 +182,4 @@ spec:
         - name: sa-token
           secret:
             secretName: ${TOKEN_SECRET_NAME}
+            defaultMode: 0400

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/deckhouse/manifests/deployment.yaml
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/deckhouse/manifests/deployment.yaml
@@ -88,6 +88,11 @@ spec:
               value: "true"
             - name: DECKHOUSE_ENABLE_MODULE_PACKAGES
               value: "false"
+            # This pod has neither /dev nor privileges, so the erofs/dm-verity
+            # installer cannot work here; without the gate it is still picked
+            # whenever the parent node kernel happens to know erofs.
+            - name: DECKHOUSE_DISABLE_VERITY
+              value: "true"
             - name: DECKHOUSE_HA
               value: "false"
             - name: DECKHOUSE_BUNDLE

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/deckhouse/manifests/moduleconfigs.yaml
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/deckhouse/manifests/moduleconfigs.yaml
@@ -40,3 +40,39 @@ spec:
     # TODO: Add cert-manager, ingress/alb modules
     https:
       mode: Disabled
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: monitoring-kubernetes
+  labels:
+    heritage: deckhouse
+spec:
+  enabled: true
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: monitoring-custom
+  labels:
+    heritage: deckhouse
+spec:
+  enabled: true
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: extended-monitoring
+  labels:
+    heritage: deckhouse
+spec:
+  enabled: true
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: monitoring-ping
+  labels:
+    heritage: deckhouse
+spec:
+  enabled: true

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/deckhouse/manifests/moduleconfigs.yaml
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/deckhouse/manifests/moduleconfigs.yaml
@@ -17,3 +17,26 @@ metadata:
     heritage: deckhouse
 spec:
   enabled: true
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: operator-prometheus
+  labels:
+    heritage: deckhouse
+spec:
+  enabled: true
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: prometheus
+  labels:
+    heritage: deckhouse
+spec:
+  enabled: true
+  version: 2
+  settings:
+    # TODO: Add cert-manager, ingress/alb modules
+    https:
+      mode: Disabled

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_deckhouse.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_deckhouse.go
@@ -520,11 +520,7 @@ func reconcileTenantDeckhouseServiceAccount(ctx context.Context, tc client.Clien
 
 	err := tc.Get(ctx, client.ObjectKeyFromObject(target), &corev1.ServiceAccount{})
 	if apierrors.IsNotFound(err) {
-		if err := tc.Create(ctx, target); err != nil && !apierrors.IsAlreadyExists(err) {
-			return err
-		}
-
-		return nil
+		return tc.Create(ctx, target)
 	}
 
 	return err

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_deckhouse.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_deckhouse.go
@@ -53,9 +53,8 @@ const (
 
 	deckhouseServiceAccountName = "deckhouse"
 
-	deckhouseTokenTTL          = 365 * 24 * time.Hour
-	deckhouseTokenIssuedAtKey  = "control-plane.deckhouse.io/token-issued-at"
-	deckhouseTokenExpiresAtKey = "control-plane.deckhouse.io/token-expires-at"
+	deckhouseTokenTTL         = 365 * 24 * time.Hour
+	deckhouseTokenRenewBefore = deckhouseTokenTTL / 2
 
 	deckhouseClusterConfigurationSecretName = "d8-cluster-configuration"
 	deckhouseClusterUUIDConfigMapName       = "d8-cluster-uuid"
@@ -453,8 +452,7 @@ func (r *reconciler) reconcileDeckhouseServiceAccountToken(
 				constants.VirtualControlPlaneScopeLabelKey: vcp.Name,
 			},
 			Annotations: map[string]string{
-				deckhouseTokenIssuedAtKey:  time.Now().UTC().Format(time.RFC3339),
-				deckhouseTokenExpiresAtKey: expiresAt.UTC().Format(time.RFC3339),
+				tokenExpiresAtKey: expiresAt.UTC().Format(time.RFC3339),
 			},
 		},
 		Type: corev1.SecretTypeOpaque,
@@ -482,26 +480,8 @@ func (r *reconciler) reconcileDeckhouseServiceAccountToken(
 }
 
 func isDeckhouseTokenInSync(secret *corev1.Secret, tenantCA []byte) bool {
-	return !deckhouseTokenNeedsRenewal(secret) && bytes.Equal(secret.Data["ca.crt"], tenantCA)
-}
-
-// deckhouseTokenNeedsRenewal reports whether half of the token lifetime has passed.
-func deckhouseTokenNeedsRenewal(secret *corev1.Secret) bool {
-	if secret == nil || len(secret.Data["token"]) == 0 {
-		return true
-	}
-
-	issuedAt, err := time.Parse(time.RFC3339, secret.Annotations[deckhouseTokenIssuedAtKey])
-	if err != nil {
-		return true
-	}
-
-	expiresAt, err := time.Parse(time.RFC3339, secret.Annotations[deckhouseTokenExpiresAtKey])
-	if err != nil {
-		return true
-	}
-
-	return time.Now().After(issuedAt.Add(expiresAt.Sub(issuedAt) / 2))
+	return !tokenNeedsRenewal(secret, deckhouseTokenRenewBefore) &&
+		bytes.Equal(secret.Data["ca.crt"], tenantCA)
 }
 
 func requestTenantDeckhouseToken(ctx context.Context, tcs kubernetes.Interface) (string, time.Time, error) {
@@ -540,7 +520,11 @@ func reconcileTenantDeckhouseServiceAccount(ctx context.Context, tc client.Clien
 
 	err := tc.Get(ctx, client.ObjectKeyFromObject(target), &corev1.ServiceAccount{})
 	if apierrors.IsNotFound(err) {
-		return tc.Create(ctx, target)
+		if err := tc.Create(ctx, target); err != nil && !apierrors.IsAlreadyExists(err) {
+			return err
+		}
+
+		return nil
 	}
 
 	return err

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_deckhouse.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_deckhouse.go
@@ -17,6 +17,7 @@ limitations under the License.
 package virtualcontrolplaneconfiguration
 
 import (
+	"bytes"
 	"context"
 	_ "embed"
 	"errors"
@@ -429,14 +430,12 @@ func (r *reconciler) reconcileDeckhouseServiceAccountToken(
 
 	name := constants.VirtualResourceName(constants.VirtualDeckhouseTokenSecretName, vcp.Name)
 	current, err := r.getSecret(ctx, vcp.Namespace, name)
-	notFound := apierrors.IsNotFound(err)
-	if err != nil && !notFound {
+	switch {
+	case apierrors.IsNotFound(err):
+		current = nil
+	case err != nil:
 		return fmt.Errorf("get token Secret: %w", err)
-	}
-
-	if !notFound &&
-		!deckhouseTokenNeedsRenewal(current) &&
-		equality.Semantic.DeepEqual(current.Data["ca.crt"], tenantCA) {
+	case isDeckhouseTokenInSync(current, tenantCA):
 		return nil
 	}
 
@@ -469,7 +468,7 @@ func (r *reconciler) reconcileDeckhouseServiceAccountToken(
 		return err
 	}
 
-	if notFound {
+	if current == nil {
 		return r.createSecret(ctx, target)
 	}
 
@@ -482,9 +481,13 @@ func (r *reconciler) reconcileDeckhouseServiceAccountToken(
 	return r.patchSecret(ctx, base, current)
 }
 
+func isDeckhouseTokenInSync(secret *corev1.Secret, tenantCA []byte) bool {
+	return !deckhouseTokenNeedsRenewal(secret) && bytes.Equal(secret.Data["ca.crt"], tenantCA)
+}
+
 // deckhouseTokenNeedsRenewal reports whether half of the token lifetime has passed.
 func deckhouseTokenNeedsRenewal(secret *corev1.Secret) bool {
-	if len(secret.Data["token"]) == 0 {
+	if secret == nil || len(secret.Data["token"]) == 0 {
 		return true
 	}
 

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_deckhouse.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_deckhouse.go
@@ -29,12 +29,15 @@ import (
 	"control-plane-manager/internal/constants"
 
 	appsv1 "k8s.io/api/apps/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -46,6 +49,11 @@ const (
 	deckhouseDeploymentName     = "deckhouse"
 	deckhouseContainerName      = "deckhouse"
 	deckhouseRegistrySecretName = "deckhouse-registry"
+
+	deckhouseServiceAccountName = "deckhouse"
+
+	deckhouseTokenTTL          = 30 * 24 * time.Hour
+	deckhouseTokenExpiresAtKey = "control-plane.deckhouse.io/token-expires-at"
 
 	deckhouseClusterConfigurationSecretName = "d8-cluster-configuration"
 	deckhouseClusterUUIDConfigMapName       = "d8-cluster-uuid"
@@ -69,8 +77,9 @@ func (r *reconciler) reconcileDeckhouse(
 	ctx context.Context,
 	vcp *controlplanev1alpha1.VirtualControlPlane,
 	albVIP string,
+	tenantCA []byte,
 ) (reconcile.Result, error) {
-	_, tc, err := r.tenantClients(ctx, vcp)
+	tcs, tc, err := r.tenantClients(ctx, vcp)
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("build tenant clients: %w", err)
 	}
@@ -106,12 +115,17 @@ func (r *reconciler) reconcileDeckhouse(
 		return reconcile.Result{}, fmt.Errorf("reconcile parent registry secret: %w", err)
 	}
 
-	// 7. Parent: the deckhouse Deployment itself.
+	// 7. Tenant ServiceAccount and its token, mounted by the Deployment below.
+	if err := r.reconcileDeckhouseServiceAccountToken(ctx, vcp, tc, tcs, tenantCA); err != nil {
+		return reconcile.Result{}, fmt.Errorf("reconcile deckhouse ServiceAccount token: %w", err)
+	}
+
+	// 8. Parent: the deckhouse Deployment itself.
 	if err := r.reconcileDeckhouseDeployment(ctx, vcp, albVIP); err != nil {
 		return reconcile.Result{}, fmt.Errorf("reconcile deckhouse Deployment: %w", err)
 	}
 
-	// 8. Tenant: ModuleConfigs; requeue until the pod installs the CRD.
+	// 9. Tenant: ModuleConfigs; requeue until the pod installs the CRD.
 	if res, err := reconcileTenantModuleConfigs(ctx, tc); err != nil || !res.IsZero() {
 		return res, err
 	}
@@ -395,6 +409,132 @@ func (r *reconciler) reconcileParentRegistrySecret(ctx context.Context, vcp *con
 	return r.patchSecret(ctx, base, current)
 }
 
+// reconcileDeckhouseServiceAccountToken keeps a mountable copy of a tenant
+// ServiceAccount token in the parent namespace. Deckhouse authenticates to the
+// tenant as system:serviceaccount:d8-system:deckhouse because the admission
+// policies it installs itself (002-deckhouse/templates/validation.yaml) exempt
+// only that identity from touching system namespaces and heritage-labelled
+// objects; a client certificate is denied no matter what RBAC says.
+func (r *reconciler) reconcileDeckhouseServiceAccountToken(
+	ctx context.Context,
+	vcp *controlplanev1alpha1.VirtualControlPlane,
+	tc client.Client,
+	tcs kubernetes.Interface,
+	tenantCA []byte,
+) error {
+	if err := reconcileTenantDeckhouseServiceAccount(ctx, tc); err != nil {
+		return fmt.Errorf("reconcile tenant ServiceAccount: %w", err)
+	}
+
+	name := constants.VirtualResourceName(constants.VirtualDeckhouseTokenSecretName, vcp.Name)
+	current, err := r.getSecret(ctx, vcp.Namespace, name)
+	notFound := apierrors.IsNotFound(err)
+	if err != nil && !notFound {
+		return fmt.Errorf("get token Secret: %w", err)
+	}
+
+	if !notFound &&
+		!deckhouseTokenNeedsRenewal(current) &&
+		equality.Semantic.DeepEqual(current.Data["ca.crt"], tenantCA) {
+		return nil
+	}
+
+	token, expiresAt, err := requestTenantDeckhouseToken(ctx, tcs)
+	if err != nil {
+		return err
+	}
+
+	target := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: vcp.Namespace,
+			Labels: map[string]string{
+				constants.HeritageLabelKey:                 constants.HeritageLabelValue,
+				constants.VirtualControlPlaneScopeLabelKey: vcp.Name,
+			},
+			Annotations: map[string]string{
+				deckhouseTokenExpiresAtKey: expiresAt.UTC().Format(time.RFC3339),
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"token":     []byte(token),
+			"ca.crt":    tenantCA,
+			"namespace": []byte(deckhouseSystemNamespace),
+		},
+	}
+	if err := setVCPControllerReference(vcp, target, r.scheme); err != nil {
+		return err
+	}
+
+	if notFound {
+		return r.createSecret(ctx, target)
+	}
+
+	base := current.DeepCopy()
+	current.Data = target.Data
+	current.Labels = target.Labels
+	current.Annotations = mergeMetadata(current.Annotations, target.Annotations)
+	syncOwnerReferences(current, target)
+
+	return r.patchSecret(ctx, base, current)
+}
+
+func deckhouseTokenNeedsRenewal(secret *corev1.Secret) bool {
+	if len(secret.Data["token"]) == 0 {
+		return true
+	}
+
+	expiresAt, err := time.Parse(time.RFC3339, secret.Annotations[deckhouseTokenExpiresAtKey])
+	if err != nil {
+		return true
+	}
+
+	return time.Now().After(expiresAt.Add(-deckhouseTokenTTL / 2))
+}
+
+func requestTenantDeckhouseToken(ctx context.Context, tcs kubernetes.Interface) (string, time.Time, error) {
+	seconds := int64(deckhouseTokenTTL.Seconds())
+	request := &authenticationv1.TokenRequest{
+		Spec: authenticationv1.TokenRequestSpec{ExpirationSeconds: &seconds},
+	}
+
+	response, err := tcs.CoreV1().
+		ServiceAccounts(deckhouseSystemNamespace).
+		CreateToken(ctx, deckhouseServiceAccountName, request, metav1.CreateOptions{})
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("request token: %w", err)
+	}
+
+	return response.Status.Token, response.Status.ExpirationTimestamp.Time, nil
+}
+
+func reconcileTenantDeckhouseServiceAccount(ctx context.Context, tc client.Client) error {
+	target := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      deckhouseServiceAccountName,
+			Namespace: deckhouseSystemNamespace,
+			Labels: map[string]string{
+				constants.HeritageLabelKey:     constants.HeritageLabelValue,
+				"app.kubernetes.io/managed-by": "Helm",
+			},
+			Annotations: map[string]string{
+				"helm.sh/resource-policy":        "keep",
+				"meta.helm.sh/release-name":      "deckhouse",
+				"meta.helm.sh/release-namespace": deckhouseSystemNamespace,
+			},
+		},
+		AutomountServiceAccountToken: ptr.To(false),
+	}
+
+	err := tc.Get(ctx, client.ObjectKeyFromObject(target), &corev1.ServiceAccount{})
+	if apierrors.IsNotFound(err) {
+		return tc.Create(ctx, target)
+	}
+
+	return err
+}
+
 func (r *reconciler) reconcileDeckhouseDeployment(
 	ctx context.Context,
 	vcp *controlplanev1alpha1.VirtualControlPlane,
@@ -444,6 +584,7 @@ func buildTargetDeckhouseDeployment(
 		"${NAMESPACE}", vcp.Namespace,
 		"${IMAGE_DECKHOUSE}", image,
 		"${VCP_API_VIP}", albVIP,
+		"${TOKEN_SECRET_NAME}", constants.VirtualResourceName(constants.VirtualDeckhouseTokenSecretName, vcp.Name),
 	).Replace(deckhouseDeploymentYAML)
 
 	deployment := &appsv1.Deployment{}
@@ -452,7 +593,6 @@ func buildTargetDeckhouseDeployment(
 	}
 
 	registrySecret := constants.VirtualResourceName(deckhouseRegistrySecretName, vcp.Name)
-	clientsKubeconfigSecret := constants.VirtualResourceName(constants.VirtualClientsKubeconfigSecretName, vcp.Name)
 
 	deployment.Name = constants.VirtualResourceName(deckhouseDeploymentName, vcp.Name)
 	if deployment.Labels == nil {
@@ -476,13 +616,6 @@ func buildTargetDeckhouseDeployment(
 	for i := range deployment.Spec.Template.Spec.ImagePullSecrets {
 		if deployment.Spec.Template.Spec.ImagePullSecrets[i].Name == deckhouseRegistrySecretName {
 			deployment.Spec.Template.Spec.ImagePullSecrets[i].Name = registrySecret
-		}
-	}
-
-	for i := range deployment.Spec.Template.Spec.Volumes {
-		vol := &deployment.Spec.Template.Spec.Volumes[i]
-		if vol.Secret != nil && vol.Secret.SecretName == constants.VirtualClientsKubeconfigSecretName {
-			vol.Secret.SecretName = clientsKubeconfigSecret
 		}
 	}
 

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_deckhouse.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_deckhouse.go
@@ -52,7 +52,8 @@ const (
 
 	deckhouseServiceAccountName = "deckhouse"
 
-	deckhouseTokenTTL          = 30 * 24 * time.Hour
+	deckhouseTokenTTL          = 365 * 24 * time.Hour
+	deckhouseTokenIssuedAtKey  = "control-plane.deckhouse.io/token-issued-at"
 	deckhouseTokenExpiresAtKey = "control-plane.deckhouse.io/token-expires-at"
 
 	deckhouseClusterConfigurationSecretName = "d8-cluster-configuration"
@@ -453,6 +454,7 @@ func (r *reconciler) reconcileDeckhouseServiceAccountToken(
 				constants.VirtualControlPlaneScopeLabelKey: vcp.Name,
 			},
 			Annotations: map[string]string{
+				deckhouseTokenIssuedAtKey:  time.Now().UTC().Format(time.RFC3339),
 				deckhouseTokenExpiresAtKey: expiresAt.UTC().Format(time.RFC3339),
 			},
 		},
@@ -480,8 +482,14 @@ func (r *reconciler) reconcileDeckhouseServiceAccountToken(
 	return r.patchSecret(ctx, base, current)
 }
 
+// deckhouseTokenNeedsRenewal reports whether half of the token lifetime has passed.
 func deckhouseTokenNeedsRenewal(secret *corev1.Secret) bool {
 	if len(secret.Data["token"]) == 0 {
+		return true
+	}
+
+	issuedAt, err := time.Parse(time.RFC3339, secret.Annotations[deckhouseTokenIssuedAtKey])
+	if err != nil {
 		return true
 	}
 
@@ -490,7 +498,7 @@ func deckhouseTokenNeedsRenewal(secret *corev1.Secret) bool {
 		return true
 	}
 
-	return time.Now().After(expiresAt.Add(-deckhouseTokenTTL / 2))
+	return time.Now().After(issuedAt.Add(expiresAt.Sub(issuedAt) / 2))
 }
 
 func requestTenantDeckhouseToken(ctx context.Context, tcs kubernetes.Interface) (string, time.Time, error) {

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_konnectivity_agent_cp.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_konnectivity_agent_cp.go
@@ -38,7 +38,6 @@ const (
 	konnectivityAgentTokenTTL           = 24 * time.Hour
 	konnectivityAgentTokenRegenBelow    = 6 * time.Hour
 	konnectivityAgentCPPlaceholderToken = "placeholder"
-	konnectivityAgentCPTokenExpiresAt   = "control-plane.deckhouse.io/token-expires-at"
 )
 
 func konnectivityAgentCPSecretName(vcpName string) string {
@@ -107,7 +106,7 @@ func (r *reconciler) ensureKonnectivityCPAgentSecretBootstrap(
 		return err
 	}
 
-	target := r.konnectivityCPAgentSecret(vcp, caPEM, string(current.Data["token"]), current.Annotations[konnectivityAgentCPTokenExpiresAt])
+	target := r.konnectivityCPAgentSecret(vcp, caPEM, string(current.Data["token"]), current.Annotations[tokenExpiresAtKey])
 	if err := setVCPControllerReference(vcp, target, r.scheme); err != nil {
 		return err
 	}
@@ -167,14 +166,9 @@ func (r *reconciler) ensureKonnectivityCPAgentToken(
 ) (string, string, error) {
 	if current, err := r.getSecret(ctx, vcp.Namespace, konnectivityAgentCPSecretName(vcp.Name)); err == nil {
 		token := string(current.Data["token"])
-		if token != "" && token != konnectivityAgentCPPlaceholderToken {
-			if expRaw := current.Annotations[konnectivityAgentCPTokenExpiresAt]; expRaw != "" {
-				if exp, err := time.Parse(time.RFC3339, expRaw); err == nil {
-					if time.Until(exp) > konnectivityAgentTokenRegenBelow {
-						return token, expRaw, nil
-					}
-				}
-			}
+		if token != konnectivityAgentCPPlaceholderToken &&
+			!tokenNeedsRenewal(current, konnectivityAgentTokenRegenBelow) {
+			return token, current.Annotations[tokenExpiresAtKey], nil
 		}
 	}
 
@@ -209,7 +203,7 @@ func (r *reconciler) konnectivityCPAgentSecret(
 ) *corev1.Secret {
 	annotations := map[string]string{}
 	if exp != "" {
-		annotations[konnectivityAgentCPTokenExpiresAt] = exp
+		annotations[tokenExpiresAtKey] = exp
 	}
 
 	return &corev1.Secret{

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconciler.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconciler.go
@@ -167,7 +167,7 @@ func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return res, err
 	}
 
-	if res, err := r.reconcileDeckhouse(ctx, vcp, albVIP); err != nil || !res.IsZero() {
+	if res, err := r.reconcileDeckhouse(ctx, vcp, albVIP, pkiSecret.Data["ca.crt"]); err != nil || !res.IsZero() {
 		return res, err
 	}
 
@@ -525,7 +525,6 @@ var adminKubeconfigFiles = []kubeconfig.File{kubeconfig.Admin, kubeconfig.SuperA
 var clientsKubeconfigFiles = []kubeconfig.File{
 	kubeconfig.CiliumOperator,
 	kubeconfig.KonnectivityServer,
-	kubeconfig.Deckhouse,
 	kubeconfig.BashibleApiserver,
 }
 

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/token.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/token.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package virtualcontrolplaneconfiguration
+
+import (
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+const tokenExpiresAtKey = "control-plane.deckhouse.io/token-expires-at"
+
+func tokenNeedsRenewal(secret *corev1.Secret, renewBefore time.Duration) bool {
+	if secret == nil || len(secret.Data["token"]) == 0 {
+		return true
+	}
+
+	expiresAt, err := time.Parse(time.RFC3339, secret.Annotations[tokenExpiresAtKey])
+	if err != nil {
+		return true
+	}
+
+	return time.Until(expiresAt) < renewBefore
+}

--- a/modules/040-control-plane-manager/virtual-control-plane-templates/tenant-rbac.yaml.tpl
+++ b/modules/040-control-plane-manager/virtual-control-plane-templates/tenant-rbac.yaml.tpl
@@ -99,6 +99,8 @@ roleRef:
   kind: ClusterRole
   name: cluster-admin
 subjects:
+# Matches the CN of deckhouse.conf, which deckhouse's own admission policies
+# require to be "dhctl" for an out-of-cluster controller (see go_lib kubeconfig).
 - kind: User
-  name: deckhouse
+  name: dhctl
   apiGroup: rbac.authorization.k8s.io

--- a/modules/040-control-plane-manager/virtual-control-plane-templates/tenant-rbac.yaml.tpl
+++ b/modules/040-control-plane-manager/virtual-control-plane-templates/tenant-rbac.yaml.tpl
@@ -99,8 +99,6 @@ roleRef:
   kind: ClusterRole
   name: cluster-admin
 subjects:
-# Matches the CN of deckhouse.conf, which deckhouse's own admission policies
-# require to be "dhctl" for an out-of-cluster controller (see go_lib kubeconfig).
-- kind: User
-  name: dhctl
-  apiGroup: rbac.authorization.k8s.io
+- kind: ServiceAccount
+  name: deckhouse
+  namespace: d8-system

--- a/pkg/app/features.go
+++ b/pkg/app/features.go
@@ -21,6 +21,7 @@ import "os"
 const (
 	EnvEnablePackageSystem  = "DECKHOUSE_ENABLE_PACKAGE_SYSTEM"
 	EnvEnableModulePackages = "DECKHOUSE_ENABLE_MODULE_PACKAGES"
+	EnvDisableVerity        = "DECKHOUSE_DISABLE_VERITY"
 )
 
 // PackageSystemEnabled reports whether the package-system controllers
@@ -30,3 +31,9 @@ func PackageSystemEnabled() bool { return os.Getenv(EnvEnablePackageSystem) == "
 // ModulePackagesEnabled reports whether the module-package controllers
 // (ModulePackage, ModulePackageVersion, Module v2) are enabled.
 func ModulePackagesEnabled() bool { return os.Getenv(EnvEnableModulePackages) == "true" }
+
+// VerityDisabled reports whether the erofs/dm-verity backend must not be used
+// even when the node kernel supports erofs. Set it where the pod has no access
+// to device-mapper (no /dev, no privileges), so module installation falls back
+// to the symlink backend instead of failing. (Virtual Control Plane)
+func VerityDisabled() bool { return os.Getenv(EnvDisableVerity) == "true" }


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
**Module installation.** `verity.IsSupported()` greps `/proc/filesystems` for `erofs` — a property of the node kernel, not of the pod. The VCP deckhouse pod runs in the parent cluster without `/dev` or privileges, so on a containerd v2 node it picked the dm-verity installer and died with `veritysetup close: exit status 4`; on a containerd v1 node the same pod silently worked through the symlink installer. Adds a `DECKHOUSE_DISABLE_VERITY` gate, applied inside the predicate so all three of its consumers stay consistent.

**Identity.** Deckhouse's own admission policies exempt only `system:serviceaccount:d8-system:deckhouse` and `dhctl`, so a client certificate was denied on every module namespace regardless of RBAC. Separately, Go hooks of downloadable modules read the ServiceAccount token straight from `/var/run/secrets/kubernetes.io/serviceaccount`, which no kubeconfig can cover. The manager now creates the ServiceAccount in the tenant, issues a token via `TokenRequest` and mounts it at the standard path; the kubeconfig and the `KUBECONFIG` propagation added for it are removed as dead code.

**Modules.** Seeds ModuleConfigs for `operator-prometheus`, `prometheus`, `monitoring-kubernetes`, `monitoring-custom`, `extended-monitoring`, `monitoring-ping`. `prometheus` needs `https.mode: Disabled`: the global default is `CertManager`, and a Minimal tenant has neither cert-manager nor an ingress controller.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
