### PR TITLE
[istio] Fix operator 1.25 startup with containerd v2 and RO rootfs

### DIFF
--- a/modules/110-istio/images/operator-v1x25x2/mount-points.yaml
+++ b/modules/110-istio/images/operator-v1x25x2/mount-points.yaml
@@ -1,0 +1,2 @@
+dirs:
+- /etc/sail-operator

--- a/modules/110-istio/images/operator-v1x25x2/werf.inc.yaml
+++ b/modules/110-istio/images/operator-v1x25x2/werf.inc.yaml
@@ -20,6 +20,7 @@ import:
   add: /src/operator/resources
   to: /var/lib/sail-operator/resources
   after: setup
+{{- include "image mount points" . }}
 imageSpec:
   config:
     user: "1337:1337"


### PR DESCRIPTION
## Description

Pre-create the `/etc/sail-operator` directory in the Istio `operator-v1x25x2` image via `mount-points.yaml` and include `image mount points` in the image build.

This does not restart critical cluster components by itself. After the image is rebuilt and rolled out, the Sail Operator deployment for Istio 1.25 will restart to pick up the new image.

## Why do we need it, and what problem does it solve?

When upgrading Istio from 1.21 to 1.25, the Sail Operator pod fails to start with:
```
    error mounting ".../operator-config" to rootfs at "/etc/sail-operator":
    create mountpoint for /etc/sail-operator mount: mkdirat .../rootfs/etc/sail-operator: read-only file system
```
The operator container runs with `readOnlyRootFilesystem: true` and mounts a downwardAPI volume at `/etc/sail-operator`. That path was missing from the image, so containerd/runc tried to create the mount point on a read-only rootfs and failed. This is the same class of issue as other Deckhouse images that need explicit mount points under containerd v2 + RO rootfs.

Without this fix, control-plane upgrade to Istio 1.25 is blocked because the operator cannot start.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: fix
summary: Fix operator 1.25 startup with containerd v2 and RO rootfs
impact_level: default
```
