### PR TITLE
[docs] Add new instance prefix configuration and deprecate legacy examples at documentation

### DIFF
--- a/docs/documentation/pages/admin/configuration/integrations/public/amazon/STORAGE.md
+++ b/docs/documentation/pages/admin/configuration/integrations/public/amazon/STORAGE.md
@@ -137,6 +137,12 @@ kubectl -n kube-system get cm d8-cluster-uuid -o json | jq -r '.data."cluster-uu
 To get the `prefix`, use the following command:
 
 ```shell
-kubectl -n kube-system get secret d8-cluster-configuration -o json | \
+d8 k get mc global -o jsonpath='{.spec.settings.prefix}{"\n"}'
+```
+
+If the value is empty, use the deprecated command:
+
+```shell
+d8 k -n kube-system get secret d8-cluster-configuration -o json | \
   jq -r '.data."cluster-configuration.yaml"' | base64 -d | grep prefix
 ```

--- a/docs/documentation/pages/admin/configuration/integrations/public/amazon/STORAGE.md
+++ b/docs/documentation/pages/admin/configuration/integrations/public/amazon/STORAGE.md
@@ -140,7 +140,7 @@ To get the `prefix`, use the following command:
 d8 k get mc global -o jsonpath='{.spec.settings.prefix}{"\n"}'
 ```
 
-If the value is empty, use the deprecated command:
+If the value is empty, get it from the deprecated [`cloud.prefix`](/products/kubernetes-platform/documentation/v1/reference/api/cr.html#clusterconfiguration-cloud-prefix) parameter of ClusterConfiguration (the prefix has moved to the ModuleConfig `global`):
 
 ```shell
 d8 k -n kube-system get secret d8-cluster-configuration -o json | \

--- a/docs/documentation/pages/admin/configuration/integrations/public/amazon/STORAGE_RU.md
+++ b/docs/documentation/pages/admin/configuration/integrations/public/amazon/STORAGE_RU.md
@@ -126,6 +126,12 @@ d8 k -n kube-system get cm d8-cluster-uuid -o json | jq -r '.data."cluster-uuid"
 Узнать `prefix` можно с помощью команды:
 
 ```shell
+d8 k get mc global -o jsonpath='{.spec.settings.prefix}{"\n"}'
+```
+
+Если значение пустое, используйте устаревший способ:
+
+```shell
 d8 k -n kube-system get secret d8-cluster-configuration -o json | \
   jq -r '.data."cluster-configuration.yaml"' | base64 -d | grep prefix
 ```

--- a/docs/documentation/pages/admin/configuration/integrations/public/amazon/STORAGE_RU.md
+++ b/docs/documentation/pages/admin/configuration/integrations/public/amazon/STORAGE_RU.md
@@ -129,7 +129,7 @@ d8 k -n kube-system get cm d8-cluster-uuid -o json | jq -r '.data."cluster-uuid"
 d8 k get mc global -o jsonpath='{.spec.settings.prefix}{"\n"}'
 ```
 
-Если значение пустое, используйте устаревший способ:
+Если значение пустое, возьмите его из устаревшего параметра [`cloud.prefix`](/products/kubernetes-platform/documentation/v1/reference/api/cr.html#clusterconfiguration-cloud-prefix) ресурса ClusterConfiguration (префикс перенесён в ModuleConfig `global`):
 
 ```shell
 d8 k -n kube-system get secret d8-cluster-configuration -o json | \

--- a/docs/documentation/pages/admin/configuration/integrations/public/gcp/CONFIGURATION_AND_LAYOUT.md
+++ b/docs/documentation/pages/admin/configuration/integrations/public/gcp/CONFIGURATION_AND_LAYOUT.md
@@ -288,6 +288,12 @@ To add manually created virtual machines to the cluster as nodes, add a `Network
 You can find the cluster prefix by running the following command:
 
 ```shell
-kubectl -n kube-system get secret d8-cluster-configuration -o json | jq -r '.data."cluster-configuration.yaml"' \
+d8 k get mc global -o jsonpath='{.spec.settings.prefix}{"\n"}'
+```
+
+If the value is empty, use the deprecated command:
+
+```shell
+d8 k -n kube-system get secret d8-cluster-configuration -o json | jq -r '.data."cluster-configuration.yaml"' \
   | base64 -d | grep prefix
 ```

--- a/docs/documentation/pages/admin/configuration/integrations/public/gcp/CONFIGURATION_AND_LAYOUT.md
+++ b/docs/documentation/pages/admin/configuration/integrations/public/gcp/CONFIGURATION_AND_LAYOUT.md
@@ -291,7 +291,7 @@ You can find the cluster prefix by running the following command:
 d8 k get mc global -o jsonpath='{.spec.settings.prefix}{"\n"}'
 ```
 
-If the value is empty, use the deprecated command:
+If the value is empty, get it from the deprecated [`cloud.prefix`](/products/kubernetes-platform/documentation/v1/reference/api/cr.html#clusterconfiguration-cloud-prefix) parameter of ClusterConfiguration (the prefix has moved to the ModuleConfig `global`):
 
 ```shell
 d8 k -n kube-system get secret d8-cluster-configuration -o json | jq -r '.data."cluster-configuration.yaml"' \

--- a/docs/documentation/pages/admin/configuration/integrations/public/gcp/CONFIGURATION_AND_LAYOUT_RU.md
+++ b/docs/documentation/pages/admin/configuration/integrations/public/gcp/CONFIGURATION_AND_LAYOUT_RU.md
@@ -280,7 +280,7 @@ spec:
 d8 k get mc global -o jsonpath='{.spec.settings.prefix}{"\n"}'
 ```
 
-Если значение пустое, используйте устаревший способ:
+Если значение пустое, возьмите его из устаревшего параметра [`cloud.prefix`](/products/kubernetes-platform/documentation/v1/reference/api/cr.html#clusterconfiguration-cloud-prefix) ресурса ClusterConfiguration (префикс перенесён в ModuleConfig `global`):
 
 ```shell
 d8 k -n kube-system get secret d8-cluster-configuration -o json | jq -r '.data."cluster-configuration.yaml"' \

--- a/docs/documentation/pages/admin/configuration/integrations/public/gcp/CONFIGURATION_AND_LAYOUT_RU.md
+++ b/docs/documentation/pages/admin/configuration/integrations/public/gcp/CONFIGURATION_AND_LAYOUT_RU.md
@@ -274,7 +274,13 @@ spec:
 
 К виртуальным машинам, которые вы хотите добавить к кластеру в качестве узлов, добавьте `Network Tag`, аналогичный префиксу кластера.
 
-Префикс кластера можно узнать, воспользовавшись следующей командой:
+Префикс кластера можно узнать с помощью команды:
+
+```shell
+d8 k get mc global -o jsonpath='{.spec.settings.prefix}{"\n"}'
+```
+
+Если значение пустое, используйте устаревший способ:
 
 ```shell
 d8 k -n kube-system get secret d8-cluster-configuration -o json | jq -r '.data."cluster-configuration.yaml"' \

--- a/docs/documentation/pages/admin/configuration/integrations/public/yandex/CONFIGURATION_AND_LAYOUT.md
+++ b/docs/documentation/pages/admin/configuration/integrations/public/yandex/CONFIGURATION_AND_LAYOUT.md
@@ -507,7 +507,7 @@ Read through the [security group specifics in Yandex Cloud](https://yandex.cloud
    d8 k get mc global -o jsonpath='{.spec.settings.prefix}{"\n"}'
    ```
 
-   If the value is empty, use the deprecated command:
+   If the value is empty, get it from the deprecated [`cloud.prefix`](/products/kubernetes-platform/documentation/v1/reference/api/cr.html#clusterconfiguration-cloud-prefix) parameter of ClusterConfiguration (the prefix has moved to the ModuleConfig `global`):
 
    ```bash
    d8 k get secrets -n kube-system d8-cluster-configuration -ojson | \

--- a/docs/documentation/pages/admin/configuration/integrations/public/yandex/CONFIGURATION_AND_LAYOUT.md
+++ b/docs/documentation/pages/admin/configuration/integrations/public/yandex/CONFIGURATION_AND_LAYOUT.md
@@ -500,11 +500,17 @@ Read through the [security group specifics in Yandex Cloud](https://yandex.cloud
 
 1. Identify the cloud network used by the DKP cluster.
 
-   The network name matches the `prefix` field in the [ClusterConfiguration](/products/kubernetes-platform/documentation/v1/reference/api/cr.html#clusterconfiguration) resource.
+   The network name matches the [`prefix`](/products/kubernetes-platform/documentation/v1/reference/api/global.html#parameters-prefix) parameter of the ModuleConfig `global`.
    You can retrieve it using the following command:
 
    ```bash
-   kubectl get secrets -n kube-system d8-cluster-configuration -ojson | \
+   d8 k get mc global -o jsonpath='{.spec.settings.prefix}{"\n"}'
+   ```
+
+   If the value is empty, use the deprecated command:
+
+   ```bash
+   d8 k get secrets -n kube-system d8-cluster-configuration -ojson | \
      jq -r '.data."cluster-configuration.yaml"' | base64 -d | grep prefix | cut -d: -f2
    ```
 

--- a/docs/documentation/pages/admin/configuration/integrations/public/yandex/CONFIGURATION_AND_LAYOUT_RU.md
+++ b/docs/documentation/pages/admin/configuration/integrations/public/yandex/CONFIGURATION_AND_LAYOUT_RU.md
@@ -468,7 +468,7 @@ spec:
    d8 k get mc global -o jsonpath='{.spec.settings.prefix}{"\n"}'
    ```
 
-   Если значение пустое, используйте устаревший способ:
+   Если значение пустое, возьмите его из устаревшего параметра [`cloud.prefix`](/products/kubernetes-platform/documentation/v1/reference/api/cr.html#clusterconfiguration-cloud-prefix) ресурса ClusterConfiguration (префикс перенесён в ModuleConfig `global`):
 
    ```bash
    d8 k get secrets -n kube-system d8-cluster-configuration -ojson | \

--- a/docs/documentation/pages/admin/configuration/integrations/public/yandex/CONFIGURATION_AND_LAYOUT_RU.md
+++ b/docs/documentation/pages/admin/configuration/integrations/public/yandex/CONFIGURATION_AND_LAYOUT_RU.md
@@ -461,7 +461,14 @@ spec:
 
 1. Определите облачную сеть, в которой работает кластер Deckhouse Kubernetes Platform.
 
-   Название сети совпадает с полем `prefix` ресурса [ClusterConfiguration](/products/kubernetes-platform/documentation/v1/reference/api/cr.html#clusterconfiguration). Его можно узнать с помощью команды:
+   Название сети совпадает с параметром [`prefix`](/products/kubernetes-platform/documentation/v1/reference/api/global.html#parameters-prefix) ModuleConfig `global`.
+   Его можно узнать с помощью команды:
+
+   ```bash
+   d8 k get mc global -o jsonpath='{.spec.settings.prefix}{"\n"}'
+   ```
+
+   Если значение пустое, используйте устаревший способ:
 
    ```bash
    d8 k get secrets -n kube-system d8-cluster-configuration -ojson | \

--- a/ee/modules/030-cloud-provider-openstack/candi/docs/LAYOUTS.md
+++ b/ee/modules/030-cloud-provider-openstack/candi/docs/LAYOUTS.md
@@ -73,7 +73,7 @@ nodeGroups:
     # is no dhcp in network that is used as default gateway.
     configDrive: false
     # Required, the gateway of the network will be used as the default gateway.
-    # Matches the cloud.prefix in the ClusterConfiguration resource.
+    # Matches the prefix parameter in the global ModuleConfig.
     mainNetwork: kube
     additionalNetworks:                         # Optional.
     - office
@@ -158,7 +158,7 @@ nodeGroups:
     # gateway.
     configDrive: false
     # Required, the gateway of the network will be used as the default gateway.
-    # Matches the cloud.prefix in the ClusterConfiguration resource.
+    # Matches the prefix parameter in the global ModuleConfig.
     mainNetwork: kube
     additionalNetworks:                          # Optional.
     - office

--- a/ee/modules/030-cloud-provider-openstack/candi/docs/LAYOUTS_RU.md
+++ b/ee/modules/030-cloud-provider-openstack/candi/docs/LAYOUTS_RU.md
@@ -75,7 +75,7 @@ nodeGroups:
     # качестве шлюза по умолчанию.
     configDrive: false
     # Обязательный параметр, шлюз этой сети будет использован как шлюз по умолчанию.
-    # Совпадает с cloud.prefix в ресурсе ClusterConfiguration.
+    # Совпадает с параметром prefix в ModuleConfig global.
     mainNetwork: kube
     additionalNetworks:                         # Необязательный параметр.
     - office
@@ -166,7 +166,7 @@ nodeGroups:
     # качестве шлюза по умолчанию.
     configDrive: false
     # Обязательный параметр, шлюз этой сети будет использован как шлюз по умолчанию.
-    # Совпадает с cloud.prefix в ресурсе ClusterConfiguration.
+    # Совпадает с параметром prefix в ModuleConfig global.
     mainNetwork: kube
     additionalNetworks:                           # Необязательный параметр.
     - office

--- a/modules/030-cloud-provider-aws/candi/openapi/cluster_configuration.yaml
+++ b/modules/030-cloud-provider-aws/candi/openapi/cluster_configuration.yaml
@@ -481,7 +481,7 @@ apiVersions:
         description: |
           The name of the IAM role that will be attached to all AWS instances of the cluster nodes.
 
-          DKP always creates and assigns a special IAM role named `<PREFIX>-node` to each AWS instance of the cluster nodes (`<PREFIX>` is the value of the parameter [cloud.prefix](/products/kubernetes-platform/documentation/v1/reference/api/cr.html#clusterconfiguration-cloud-prefix) in the common cluster parameters). You can specify your IAM-role with greater permissions in the `iamNodeRole` parameter, but it is important that it includes the IAM policies of the role created by DKP (the `<PREFIX>-node` role).
+          DKP always creates and assigns a special IAM role named `<PREFIX>-node` to each AWS instance of the cluster nodes (`<PREFIX>` is the value of the [`prefix`](/products/kubernetes-platform/documentation/v1/reference/api/global.html#parameters-prefix) parameter in the ModuleConfig `global`). You can specify your IAM-role with greater permissions in the `iamNodeRole` parameter, but it is important that it includes the IAM policies of the role created by DKP (the `<PREFIX>-node` role).
 
           More details about IAM roles for AWS EC2 can be found in the [AWS documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html).
     allOf:

--- a/modules/030-cloud-provider-aws/candi/openapi/doc-ru-cluster_configuration.yaml
+++ b/modules/030-cloud-provider-aws/candi/openapi/doc-ru-cluster_configuration.yaml
@@ -274,6 +274,6 @@ apiVersions:
         description: |
           Имя IAM-роли, которая будет привязана ко всем AWS-инстансам узлов кластера.
 
-          DKP всегда создает и привязывает к каждому AWS-инстансу узла кластера специальную IAM-роль с именем `<PREFIX>-node`, где `<PREFIX>` — значение параметра [`prefix`](/products/kubernetes-platform/documentation/v1/reference/api/global.html#parameters-prefix) ModuleConfig `global`. Вы можете указать в параметре `iamNodeRole` свою IAM-роль с бОльшими правами, но, важно чтобы она включала в себя политики IAM-роли, создаваемой DKP (роль `<PREFIX>-node`).
+          DKP всегда создает и привязывает к каждому AWS-инстансу узла кластера специальную IAM-роль с именем `<PREFIX>-node`, где `<PREFIX>` — значение параметра [`prefix`](/products/kubernetes-platform/documentation/v1/reference/api/global.html#parameters-prefix) ModuleConfig `global`. В параметре `iamNodeRole` можно указать собственную IAM-роль с расширенным набором прав. При этом она должна включать все политики IAM-роли `<PREFIX>-node`, создаваемой DKP.
 
           Подробнее о IAM-ролях для AWS EC2 можно прочитать в [документации AWS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html).

--- a/modules/030-cloud-provider-aws/candi/openapi/doc-ru-cluster_configuration.yaml
+++ b/modules/030-cloud-provider-aws/candi/openapi/doc-ru-cluster_configuration.yaml
@@ -274,6 +274,6 @@ apiVersions:
         description: |
           Имя IAM-роли, которая будет привязана ко всем AWS-инстансам узлов кластера.
 
-          DKP всегда создает и привязывает к каждому AWS-инстансу узла кластера специальную IAM-роль с именем `<PREFIX>-node`, где `<PREFIX>` — значение параметра [cloud.prefix](/products/kubernetes-platform/documentation/v1/reference/api/cr.html#clusterconfiguration-cloud-prefix) общих параметров кластера. Вы можете указать в параметре `iamNodeRole` свою IAM-роль с бОльшими правами, но, важно чтобы она включала в себя политики IAM-роли, создаваемой DKP (роль `<PREFIX>-node`).
+          DKP всегда создает и привязывает к каждому AWS-инстансу узла кластера специальную IAM-роль с именем `<PREFIX>-node`, где `<PREFIX>` — значение параметра [`prefix`](/products/kubernetes-platform/documentation/v1/reference/api/global.html#parameters-prefix) ModuleConfig `global`. Вы можете указать в параметре `iamNodeRole` свою IAM-роль с бОльшими правами, но, важно чтобы она включала в себя политики IAM-роли, создаваемой DKP (роль `<PREFIX>-node`).
 
           Подробнее о IAM-ролях для AWS EC2 можно прочитать в [документации AWS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html).

--- a/modules/030-cloud-provider-aws/docs/FAQ.md
+++ b/modules/030-cloud-provider-aws/docs/FAQ.md
@@ -86,6 +86,12 @@ To add a pre-created VM as a node to a cluster, follow these steps:
    * You can find out `prefix` using the command:
 
      ```shell
+     d8 k get mc global -o jsonpath='{.spec.settings.prefix}{"\n"}'
+     ```
+
+     If the value is empty, use the deprecated command:
+
+     ```shell
      d8 k -n kube-system get secret d8-cluster-configuration -o json | jq -r '.data."cluster-configuration.yaml"' \
        | base64 -d | grep prefix
      ```

--- a/modules/030-cloud-provider-aws/docs/FAQ.md
+++ b/modules/030-cloud-provider-aws/docs/FAQ.md
@@ -89,7 +89,7 @@ To add a pre-created VM as a node to a cluster, follow these steps:
      d8 k get mc global -o jsonpath='{.spec.settings.prefix}{"\n"}'
      ```
 
-     If the value is empty, use the deprecated command:
+     If the value is empty, get it from the deprecated [`cloud.prefix`](/products/kubernetes-platform/documentation/v1/reference/api/cr.html#clusterconfiguration-cloud-prefix) parameter of ClusterConfiguration (the prefix has moved to the ModuleConfig `global`):
 
      ```shell
      d8 k -n kube-system get secret d8-cluster-configuration -o json | jq -r '.data."cluster-configuration.yaml"' \

--- a/modules/030-cloud-provider-aws/docs/FAQ_RU.md
+++ b/modules/030-cloud-provider-aws/docs/FAQ_RU.md
@@ -87,6 +87,12 @@ title: "Cloud provider — AWS: FAQ"
    * Узнать `prefix` можно с помощью команды:
 
      ```shell
+     d8 k get mc global -o jsonpath='{.spec.settings.prefix}{"\n"}'
+     ```
+
+     Если значение пустое, используйте устаревший способ:
+
+     ```shell
      d8 k -n kube-system get secret d8-cluster-configuration -o json | jq -r '.data."cluster-configuration.yaml"' \
        | base64 -d | grep prefix
      ```

--- a/modules/030-cloud-provider-aws/docs/FAQ_RU.md
+++ b/modules/030-cloud-provider-aws/docs/FAQ_RU.md
@@ -90,7 +90,7 @@ title: "Cloud provider — AWS: FAQ"
      d8 k get mc global -o jsonpath='{.spec.settings.prefix}{"\n"}'
      ```
 
-     Если значение пустое, используйте устаревший способ:
+     Если значение пустое, возьмите его из устаревшего параметра [`cloud.prefix`](/products/kubernetes-platform/documentation/v1/reference/api/cr.html#clusterconfiguration-cloud-prefix) ресурса ClusterConfiguration (префикс перенесён в ModuleConfig `global`):
 
      ```shell
      d8 k -n kube-system get secret d8-cluster-configuration -o json | jq -r '.data."cluster-configuration.yaml"' \

--- a/modules/030-cloud-provider-gcp/docs/FAQ.md
+++ b/modules/030-cloud-provider-gcp/docs/FAQ.md
@@ -19,7 +19,7 @@ You can find out `prefix` using the command:
 d8 k get mc global -o jsonpath='{.spec.settings.prefix}{"\n"}'
 ```
 
-If the value is empty, use the deprecated command:
+If the value is empty, get it from the deprecated [`cloud.prefix`](/products/kubernetes-platform/documentation/v1/reference/api/cr.html#clusterconfiguration-cloud-prefix) parameter of ClusterConfiguration (the prefix has moved to the ModuleConfig `global`):
 
 ```shell
 d8 k -n kube-system get secret d8-cluster-configuration -o json | jq -r '.data."cluster-configuration.yaml"' \

--- a/modules/030-cloud-provider-gcp/docs/FAQ.md
+++ b/modules/030-cloud-provider-gcp/docs/FAQ.md
@@ -16,6 +16,12 @@ For the VMs, you want to add to a cluster as nodes, add a `Network Tag` similar 
 You can find out `prefix` using the command:
 
 ```shell
+d8 k get mc global -o jsonpath='{.spec.settings.prefix}{"\n"}'
+```
+
+If the value is empty, use the deprecated command:
+
+```shell
 d8 k -n kube-system get secret d8-cluster-configuration -o json | jq -r '.data."cluster-configuration.yaml"' \
   | base64 -d | grep prefix
 ```

--- a/modules/030-cloud-provider-gcp/docs/FAQ_RU.md
+++ b/modules/030-cloud-provider-gcp/docs/FAQ_RU.md
@@ -13,7 +13,13 @@ title: "Cloud provider — GCP: FAQ"
 
 К виртуальным машинам, которые вы хотите добавить к кластеру в качестве узлов, добавьте `Network Tag`, аналогичный префиксу кластера.
 
-Префикс кластера можно узнать, воспользовавшись следующей командой:
+Префикс кластера можно узнать с помощью команды:
+
+```shell
+d8 k get mc global -o jsonpath='{.spec.settings.prefix}{"\n"}'
+```
+
+Если значение пустое, используйте устаревший способ:
 
 ```shell
 d8 k -n kube-system get secret d8-cluster-configuration -o json | jq -r '.data."cluster-configuration.yaml"' \

--- a/modules/030-cloud-provider-gcp/docs/FAQ_RU.md
+++ b/modules/030-cloud-provider-gcp/docs/FAQ_RU.md
@@ -19,7 +19,7 @@ title: "Cloud provider — GCP: FAQ"
 d8 k get mc global -o jsonpath='{.spec.settings.prefix}{"\n"}'
 ```
 
-Если значение пустое, используйте устаревший способ:
+Если значение пустое, возьмите его из устаревшего параметра [`cloud.prefix`](/products/kubernetes-platform/documentation/v1/reference/api/cr.html#clusterconfiguration-cloud-prefix) ресурса ClusterConfiguration (префикс перенесён в ModuleConfig `global`):
 
 ```shell
 d8 k -n kube-system get secret d8-cluster-configuration -o json | jq -r '.data."cluster-configuration.yaml"' \

--- a/modules/030-cloud-provider-yandex/candi/docs/ENVIRONMENT.md
+++ b/modules/030-cloud-provider-yandex/candi/docs/ENVIRONMENT.md
@@ -79,7 +79,14 @@ If the cluster uses `cilium` in VXLAN mode, make sure security groups allow inte
 
 1. Find out in which cloud network the Deckhouse Kubernetes Platform cluster is running.
 
-   The network name matches the `prefix` field of [the ClusterConfiguration](/products/kubernetes-platform/documentation/v1/reference/api/cr.html#clusterconfiguration) resource. It can be retrieved using the following command:
+   The network name matches the [`prefix`](/products/kubernetes-platform/documentation/v1/reference/api/global.html#parameters-prefix) parameter of the ModuleConfig `global`.
+   You can retrieve it using the following command:
+
+   ```bash
+   d8 k get mc global -o jsonpath='{.spec.settings.prefix}{"\n"}'
+   ```
+
+   If the value is empty, use the deprecated command:
 
    ```bash
    d8 k get secrets -n kube-system d8-cluster-configuration -ojson | \

--- a/modules/030-cloud-provider-yandex/candi/docs/ENVIRONMENT.md
+++ b/modules/030-cloud-provider-yandex/candi/docs/ENVIRONMENT.md
@@ -86,7 +86,7 @@ If the cluster uses `cilium` in VXLAN mode, make sure security groups allow inte
    d8 k get mc global -o jsonpath='{.spec.settings.prefix}{"\n"}'
    ```
 
-   If the value is empty, use the deprecated command:
+   If the value is empty, get it from the deprecated [`cloud.prefix`](/products/kubernetes-platform/documentation/v1/reference/api/cr.html#clusterconfiguration-cloud-prefix) parameter of ClusterConfiguration (the prefix has moved to the ModuleConfig `global`):
 
    ```bash
    d8 k get secrets -n kube-system d8-cluster-configuration -ojson | \

--- a/modules/030-cloud-provider-yandex/candi/docs/ENVIRONMENT_RU.md
+++ b/modules/030-cloud-provider-yandex/candi/docs/ENVIRONMENT_RU.md
@@ -81,7 +81,14 @@ description: "Настройка Yandex Cloud для работы облачно
 
 1. Определите облачную сеть, в которой работает кластер Deckhouse Kubernetes Platform.
 
-   Название сети совпадает с полем `prefix` ресурса [ClusterConfiguration](/products/kubernetes-platform/documentation/v1/reference/api/cr.html#clusterconfiguration). Его можно узнать с помощью команды:
+   Название сети совпадает с параметром [`prefix`](/products/kubernetes-platform/documentation/v1/reference/api/global.html#parameters-prefix) ModuleConfig `global`.
+   Его можно узнать с помощью команды:
+
+   ```bash
+   d8 k get mc global -o jsonpath='{.spec.settings.prefix}{"\n"}'
+   ```
+
+   Если значение пустое, используйте устаревший способ:
 
    ```bash
    d8 k get secrets -n kube-system d8-cluster-configuration -ojson | \

--- a/modules/030-cloud-provider-yandex/candi/docs/ENVIRONMENT_RU.md
+++ b/modules/030-cloud-provider-yandex/candi/docs/ENVIRONMENT_RU.md
@@ -88,7 +88,7 @@ description: "Настройка Yandex Cloud для работы облачно
    d8 k get mc global -o jsonpath='{.spec.settings.prefix}{"\n"}'
    ```
 
-   Если значение пустое, используйте устаревший способ:
+   Если значение пустое, возьмите его из устаревшего параметра [`cloud.prefix`](/products/kubernetes-platform/documentation/v1/reference/api/cr.html#clusterconfiguration-cloud-prefix) ресурса ClusterConfiguration (префикс перенесён в ModuleConfig `global`):
 
    ```bash
    d8 k get secrets -n kube-system d8-cluster-configuration -ojson | \


### PR DESCRIPTION
## Description
Added new instance prefix configuration and deprecate legacy examples at documentation.
Based on [PR 21533](https://github.com/deckhouse/deckhouse/pull/21533).
## Why do we need it, and what problem does it solve?

## Why do we need it in the patch release (if we do)?


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: docs
type: chore
summary: Add new instance prefix configuration and deprecate legacy examples at documentation.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
