### PR TITLE
[node-manager] bump cluster-autosclaer to 1.35

### DIFF
--- a/modules/040-node-manager/images/cluster-autoscaler/known_vulnerabilities.vex
+++ b/modules/040-node-manager/images/cluster-autoscaler/known_vulnerabilities.vex
@@ -2,7 +2,7 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "merged-vex-c2167a7b3cc90a41182606ceaec2db0b24311690a9a2f974d6190b35c543bd2e",
   "author": "Deckhouse <contact@deckhouse.io>",
-  "version": 2,
+  "version": 3,
   "statements": [
     {
       "vulnerability": {
@@ -107,8 +107,36 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Уязвимость связана с обходом авторизации на стороне gRPC-сервера через некорректный путь в заголовке :path без ведущего слеша. Cluster-autoscaler не запускает gRPC-сервер и не использует серверные авторизационные интерцепторы gRPC. Библиотека google.golang.org/grpc используется только как транзитивная зависимость для клиентских операций через Kubernetes и etcd библиотеки. Уязвимый серверный код не исполняется.",
       "timestamp": "2026-03-23T09:38:11.040030Z"
+    },
+    {
+      "vulnerability": {
+        "name": "GO-2026-5932"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/crypto"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "GO-2026-5932 относится к пакету golang.org/x/crypto/openpgp, который не поддерживается и признан небезопасным по дизайну. В cluster-autoscaler пакет openpgp не импортируется и не входит в граф зависимостей собираемого бинаря; используются другие подпакеты x/crypto. Уязвимый код отсутствует.",
+      "timestamp": "2026-07-31T12:00:00.000000Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-41579"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/opencontainers/runc"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость CVE-2026-41579 связана с настройкой container rootfs в runc (symlink /dev). Cluster-autoscaler не запускает контейнеры через runc и не выполняет container rootfs setup; runc присутствует только как транзитивная зависимость module graph (через cadvisor) и не исполняется в runtime-сценарии Deckhouse.",
+      "timestamp": "2026-07-31T12:00:00.000000Z"
     }
   ],
   "timestamp": "2026-03-04T14:40:21Z",
-  "last_updated": "2026-04-14T12:00:00Z"
+  "last_updated": "2026-07-31T12:00:00Z"
 }

--- a/modules/040-node-manager/images/cluster-autoscaler/patches/1.35/001-go-mod.patch
+++ b/modules/040-node-manager/images/cluster-autoscaler/patches/1.35/001-go-mod.patch
@@ -1,0 +1,196 @@
+diff --git a/cluster-autoscaler/apis/go.mod b/cluster-autoscaler/apis/go.mod
+index b9c027681..539221049 100644
+--- a/cluster-autoscaler/apis/go.mod
++++ b/cluster-autoscaler/apis/go.mod
+@@ -37,15 +37,15 @@ require (
+ 	github.com/x448/float16 v0.8.4 // indirect
+ 	go.yaml.in/yaml/v2 v2.4.3 // indirect
+ 	go.yaml.in/yaml/v3 v3.0.4 // indirect
+-	golang.org/x/mod v0.29.0 // indirect
+-	golang.org/x/net v0.47.0 // indirect
++	golang.org/x/mod v0.37.0 // indirect
++	golang.org/x/net v0.57.0 // indirect
+ 	golang.org/x/oauth2 v0.30.0 // indirect
+-	golang.org/x/sync v0.18.0 // indirect
+-	golang.org/x/sys v0.38.0 // indirect
+-	golang.org/x/term v0.37.0 // indirect
+-	golang.org/x/text v0.31.0 // indirect
++	golang.org/x/sync v0.22.0 // indirect
++	golang.org/x/sys v0.47.0 // indirect
++	golang.org/x/term v0.45.0 // indirect
++	golang.org/x/text v0.40.0 // indirect
+ 	golang.org/x/time v0.9.0 // indirect
+-	golang.org/x/tools v0.38.0 // indirect
++	golang.org/x/tools v0.47.0 // indirect
+ 	google.golang.org/protobuf v1.36.8 // indirect
+ 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
+ 	gopkg.in/inf.v0 v0.9.1 // indirect
+diff --git a/cluster-autoscaler/apis/go.sum b/cluster-autoscaler/apis/go.sum
+index bc2649611..ef09de02c 100644
+--- a/cluster-autoscaler/apis/go.sum
++++ b/cluster-autoscaler/apis/go.sum
+@@ -102,24 +102,24 @@ go.yaml.in/yaml/v2 v2.4.3 h1:6gvOSjQoTB3vt1l+CU+tSyi/HOjfOjRLJ4YwYZGwRO0=
+ go.yaml.in/yaml/v2 v2.4.3/go.mod h1:zSxWcmIDjOzPXpjlTTbAsKokqkDNAVtZO0WOMiT90s8=
+ go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
+ go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+-golang.org/x/mod v0.29.0 h1:HV8lRxZC4l2cr3Zq1LvtOsi/ThTgWnUk/y64QSs8GwA=
+-golang.org/x/mod v0.29.0/go.mod h1:NyhrlYXJ2H4eJiRy/WDBO6HMqZQ6q9nk4JzS3NuCK+w=
+-golang.org/x/net v0.47.0 h1:Mx+4dIFzqraBXUugkia1OOvlD6LemFo1ALMHjrXDOhY=
+-golang.org/x/net v0.47.0/go.mod h1:/jNxtkgq5yWUGYkaZGqo27cfGZ1c5Nen03aYrrKpVRU=
++golang.org/x/mod v0.37.0 h1:vF1DjpVEshcIqoEaauuHebaLk1O1forxjxBaVn884JQ=
++golang.org/x/mod v0.37.0/go.mod h1:m8S8VeM9r4dzDwjrKO0a1sZP3YjeMamRRlD+fmR2Q/0=
++golang.org/x/net v0.57.0 h1:K5+3DljvIuDG9/Jv9rvyMywYNFCQ9RSUY6OOTTkT+tE=
++golang.org/x/net v0.57.0/go.mod h1:KpXc8iv+r3XplLAG/f7Jsf9RPszJzdR0f58q9vGOuEU=
+ golang.org/x/oauth2 v0.30.0 h1:dnDm7JmhM45NNpd8FDDeLhK6FwqbOf4MLCM9zb1BOHI=
+ golang.org/x/oauth2 v0.30.0/go.mod h1:B++QgG3ZKulg6sRPGD/mqlHQs5rB3Ml9erfeDY7xKlU=
+-golang.org/x/sync v0.18.0 h1:kr88TuHDroi+UVf+0hZnirlk8o8T+4MrK6mr60WkH/I=
+-golang.org/x/sync v0.18.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
+-golang.org/x/sys v0.38.0 h1:3yZWxaJjBmCWXqhN1qh02AkOnCQ1poK6oF+a7xWL6Gc=
+-golang.org/x/sys v0.38.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+-golang.org/x/term v0.37.0 h1:8EGAD0qCmHYZg6J17DvsMy9/wJ7/D/4pV/wfnld5lTU=
+-golang.org/x/term v0.37.0/go.mod h1:5pB4lxRNYYVZuTLmy8oR2BH8dflOR+IbTYFD8fi3254=
+-golang.org/x/text v0.31.0 h1:aC8ghyu4JhP8VojJ2lEHBnochRno1sgL6nEi9WGFGMM=
+-golang.org/x/text v0.31.0/go.mod h1:tKRAlv61yKIjGGHX/4tP1LTbc13YSec1pxVEWXzfoeM=
++golang.org/x/sync v0.22.0 h1:SZjpbeLmrCk4xhRSZFNZW5gFUeCeFgjekvI/+gfScek=
++golang.org/x/sync v0.22.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
++golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
++golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
++golang.org/x/term v0.45.0 h1:NwWyBmoJCbfTHpxrWoZ9C6/VxOf7ic219I8xZZFdrf0=
++golang.org/x/term v0.45.0/go.mod h1:9aqxs0blBcrm/n0L9QW0aRVD+ktan8ssZromtqJC43w=
++golang.org/x/text v0.40.0 h1:Ub2Z6/xjgF1WrYQz2nuITOEegKFtiIy+rieRJ5lHZKs=
++golang.org/x/text v0.40.0/go.mod h1:hpnzDAfGV753zIKo+wk3u1bVKCGPbrnF7+7LBF/UHVY=
+ golang.org/x/time v0.9.0 h1:EsRrnYcQiGH+5FfbgvV4AP7qEZstoyrHB0DzarOQ4ZY=
+ golang.org/x/time v0.9.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
+-golang.org/x/tools v0.38.0 h1:Hx2Xv8hISq8Lm16jvBZ2VQf+RLmbd7wVUsALibYI/IQ=
+-golang.org/x/tools v0.38.0/go.mod h1:yEsQ/d/YK8cjh0L6rZlY8tgtlKiBNTL14pGDJPJpYQs=
++golang.org/x/tools v0.47.0 h1:7Kn5x/d1svx/PzryTsqeoZN4TZwqeH5pGWjefhLi/1Q=
++golang.org/x/tools v0.47.0/go.mod h1:dFHnyTvFWY212G+h7ZY4Vsp/K3U4/7W9TyVaAul8uCA=
+ golang.org/x/tools/go/expect v0.1.1-deprecated h1:jpBZDwmgPhXsKZC6WhL20P4b/wmnpsEAGHaNy0n/rJM=
+ golang.org/x/tools/go/expect v0.1.1-deprecated/go.mod h1:eihoPOH+FgIqa3FpoTwguz/bVUSGBlGQU67vpBeOrBY=
+ golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated h1:1h2MnaIAIXISqTFKdENegdpAgUXz6NrPEsbIeWaBRvM=
+diff --git a/cluster-autoscaler/go.mod b/cluster-autoscaler/go.mod
+index f2c958575..2369acce1 100644
+--- a/cluster-autoscaler/go.mod
++++ b/cluster-autoscaler/go.mod
+@@ -43,10 +43,10 @@ require (
+ 	github.com/stretchr/testify v1.11.1
+ 	github.com/vburenin/ifacemaker v1.2.1
+ 	go.uber.org/mock v0.6.0
+-	golang.org/x/crypto v0.46.0
+-	golang.org/x/net v0.48.0
++	golang.org/x/crypto v0.54.0
++	golang.org/x/net v0.57.0
+ 	golang.org/x/oauth2 v0.30.0
+-	golang.org/x/sys v0.39.0
++	golang.org/x/sys v0.47.0
+ 	google.golang.org/api v0.151.0
+ 	google.golang.org/grpc v1.75.0
+ 	google.golang.org/protobuf v1.36.8
+@@ -221,12 +221,12 @@ require (
+ 	go.yaml.in/yaml/v2 v2.4.3 // indirect
+ 	go.yaml.in/yaml/v3 v3.0.4 // indirect
+ 	golang.org/x/exp v0.0.0-20250819193227-8b4c13bb791b // indirect
+-	golang.org/x/mod v0.30.0 // indirect
+-	golang.org/x/sync v0.19.0 // indirect
+-	golang.org/x/term v0.38.0 // indirect
+-	golang.org/x/text v0.32.0 // indirect
++	golang.org/x/mod v0.37.0 // indirect
++	golang.org/x/sync v0.22.0 // indirect
++	golang.org/x/term v0.45.0 // indirect
++	golang.org/x/text v0.40.0 // indirect
+ 	golang.org/x/time v0.12.0 // indirect
+-	golang.org/x/tools v0.39.0 // indirect
++	golang.org/x/tools v0.47.0 // indirect
+ 	google.golang.org/genproto/googleapis/api v0.0.0-20250826171959-ef028d996bc1 // indirect
+ 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250826171959-ef028d996bc1 // indirect
+ 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
+diff --git a/cluster-autoscaler/go.sum b/cluster-autoscaler/go.sum
+index 11988134e..4bc546c0a 100644
+--- a/cluster-autoscaler/go.sum
++++ b/cluster-autoscaler/go.sum
+@@ -530,8 +530,8 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
+ golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+ golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58=
+ golang.org/x/crypto v0.17.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
+-golang.org/x/crypto v0.46.0 h1:cKRW/pmt1pKAfetfu+RCEvjvZkA9RimPbh7bhFjGVBU=
+-golang.org/x/crypto v0.46.0/go.mod h1:Evb/oLKmMraqjZ2iQTwDwvCtJkczlDuTmdJXoZVzqU0=
++golang.org/x/crypto v0.54.0 h1:YLIA59K4fiNzHzjnZt2tUJQjQtUWfWbeHBqKtk3eScw=
++golang.org/x/crypto v0.54.0/go.mod h1:KWL8ny2AZdGR2cWmzeHrp2azQPGogOv+HeQaVEXC2dk=
+ golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+ golang.org/x/exp v0.0.0-20250819193227-8b4c13bb791b h1:DXr+pvt3nC887026GRP39Ej11UATqWDmWuS99x26cD0=
+ golang.org/x/exp v0.0.0-20250819193227-8b4c13bb791b/go.mod h1:4QTo5u+SEIbbKW1RacMZq1YEfOBqeXa19JeshGi+zc4=
+@@ -543,8 +543,8 @@ golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+ golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+ golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
+ golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
+-golang.org/x/mod v0.30.0 h1:fDEXFVZ/fmCKProc/yAXXUijritrDzahmwwefnjoPFk=
+-golang.org/x/mod v0.30.0/go.mod h1:lAsf5O2EvJeSFMiBxXDki7sCgAxEUcZHXoXMKT4GJKc=
++golang.org/x/mod v0.37.0 h1:vF1DjpVEshcIqoEaauuHebaLk1O1forxjxBaVn884JQ=
++golang.org/x/mod v0.37.0/go.mod h1:m8S8VeM9r4dzDwjrKO0a1sZP3YjeMamRRlD+fmR2Q/0=
+ golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+ golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+ golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+@@ -560,8 +560,8 @@ golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qx
+ golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
+ golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
+ golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
+-golang.org/x/net v0.48.0 h1:zyQRTTrjc33Lhh0fBgT/H3oZq9WuvRR5gPC70xpDiQU=
+-golang.org/x/net v0.48.0/go.mod h1:+ndRgGjkh8FGtu1w1FGbEC31if4VrNVMuKTgcAAnQRY=
++golang.org/x/net v0.57.0 h1:K5+3DljvIuDG9/Jv9rvyMywYNFCQ9RSUY6OOTTkT+tE=
++golang.org/x/net v0.57.0/go.mod h1:KpXc8iv+r3XplLAG/f7Jsf9RPszJzdR0f58q9vGOuEU=
+ golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
+ golang.org/x/oauth2 v0.30.0 h1:dnDm7JmhM45NNpd8FDDeLhK6FwqbOf4MLCM9zb1BOHI=
+ golang.org/x/oauth2 v0.30.0/go.mod h1:B++QgG3ZKulg6sRPGD/mqlHQs5rB3Ml9erfeDY7xKlU=
+@@ -573,8 +573,8 @@ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJ
+ golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+-golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=
+-golang.org/x/sync v0.19.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
++golang.org/x/sync v0.22.0 h1:SZjpbeLmrCk4xhRSZFNZW5gFUeCeFgjekvI/+gfScek=
++golang.org/x/sync v0.22.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+ golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+@@ -591,15 +591,15 @@ golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+-golang.org/x/sys v0.39.0 h1:CvCKL8MeisomCi6qNZ+wbb0DN9E5AATixKsvNtMoMFk=
+-golang.org/x/sys v0.39.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
++golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
++golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+ golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+ golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=
+ golang.org/x/term v0.8.0/go.mod h1:xPskH00ivmX89bAKVGSKKtLOWNx2+17Eiy94tnKShWo=
+ golang.org/x/term v0.15.0/go.mod h1:BDl952bC7+uMoWR75FIrCDx79TPU9oHkTZ9yRbYOrX0=
+-golang.org/x/term v0.38.0 h1:PQ5pkm/rLO6HnxFR7N2lJHOZX6Kez5Y1gDSJla6jo7Q=
+-golang.org/x/term v0.38.0/go.mod h1:bSEAKrOT1W+VSu9TSCMtoGEOUcKxOKgl3LE5QEF/xVg=
++golang.org/x/term v0.45.0 h1:NwWyBmoJCbfTHpxrWoZ9C6/VxOf7ic219I8xZZFdrf0=
++golang.org/x/term v0.45.0/go.mod h1:9aqxs0blBcrm/n0L9QW0aRVD+ktan8ssZromtqJC43w=
+ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+ golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+ golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+@@ -607,8 +607,8 @@ golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+ golang.org/x/text v0.7.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
+ golang.org/x/text v0.9.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=
+ golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
+-golang.org/x/text v0.32.0 h1:ZD01bjUt1FQ9WJ0ClOL5vxgxOI/sVCNgX1YtKwcY0mU=
+-golang.org/x/text v0.32.0/go.mod h1:o/rUWzghvpD5TXrTIBuJU77MTaN0ljMWE47kxGJQ7jY=
++golang.org/x/text v0.40.0 h1:Ub2Z6/xjgF1WrYQz2nuITOEegKFtiIy+rieRJ5lHZKs=
++golang.org/x/text v0.40.0/go.mod h1:hpnzDAfGV753zIKo+wk3u1bVKCGPbrnF7+7LBF/UHVY=
+ golang.org/x/time v0.12.0 h1:ScB/8o8olJvc+CQPWrK3fPZNfh7qgwCrY0zJmoEQLSE=
+ golang.org/x/time v0.12.0/go.mod h1:CDIdPxbZBQxdj6cxyCIdrNogrJKMJ7pr37NYpMcMDSg=
+ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+@@ -622,8 +622,8 @@ golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4f
+ golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+ golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
+ golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
+-golang.org/x/tools v0.39.0 h1:ik4ho21kwuQln40uelmciQPp9SipgNDdrafrYA4TmQQ=
+-golang.org/x/tools v0.39.0/go.mod h1:JnefbkDPyD8UU2kI5fuf8ZX4/yUeh9W877ZeBONxUqQ=
++golang.org/x/tools v0.47.0 h1:7Kn5x/d1svx/PzryTsqeoZN4TZwqeH5pGWjefhLi/1Q=
++golang.org/x/tools v0.47.0/go.mod h1:dFHnyTvFWY212G+h7ZY4Vsp/K3U4/7W9TyVaAul8uCA=
+ golang.org/x/tools/go/expect v0.1.1-deprecated h1:jpBZDwmgPhXsKZC6WhL20P4b/wmnpsEAGHaNy0n/rJM=
+ golang.org/x/tools/go/expect v0.1.1-deprecated/go.mod h1:eihoPOH+FgIqa3FpoTwguz/bVUSGBlGQU67vpBeOrBY=
+ golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated h1:1h2MnaIAIXISqTFKdENegdpAgUXz6NrPEsbIeWaBRvM=

--- a/modules/040-node-manager/images/cluster-autoscaler/patches/1.35/002-kruise-ads.patch
+++ b/modules/040-node-manager/images/cluster-autoscaler/patches/1.35/002-kruise-ads.patch
@@ -1,0 +1,91 @@
+Subject: [PATCH] ++
+---
+Index: cluster-autoscaler/simulator/cluster.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/cluster-autoscaler/simulator/cluster.go b/cluster-autoscaler/simulator/cluster.go
+--- a/cluster-autoscaler/simulator/cluster.go	(revision 669115a6814d33b9d5757aa801402710029cb5b5)
++++ b/cluster-autoscaler/simulator/cluster.go	(date 1745485672011)
+@@ -229,6 +229,14 @@
+
+ 	newpods := make([]*apiv1.Pod, 0, len(pods))
+ 	for _, podptr := range pods {
++		if podptr == nil {
++			klog.Warningf("findPlaceFor: skipping nil pod in list for node %s", removedNode)
++			continue
++		}
++		controllerRef := drain.ControllerRef(podptr)
++		if controllerRef != nil && controllerRef.Kind == "DaemonSet" && controllerRef.APIVersion == "apps.kruise.io/v1alpha1" {
++			continue
++		}
+ 		newpod := *podptr
+ 		newpod.Spec.NodeName = ""
+ 		newpods = append(newpods, &newpod)
+Index: cluster-autoscaler/simulator/drainability/rules/replicated/rule.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/cluster-autoscaler/simulator/drainability/rules/replicated/rule.go b/cluster-autoscaler/simulator/drainability/rules/replicated/rule.go
+--- a/cluster-autoscaler/simulator/drainability/rules/replicated/rule.go	(revision 669115a6814d33b9d5757aa801402710029cb5b5)
++++ b/cluster-autoscaler/simulator/drainability/rules/replicated/rule.go	(date 1745485672003)
+@@ -49,7 +49,7 @@
+
+ 	if r.skipNodesWithCustomControllerPods {
+ 		// TODO(vadasambar): remove this when we get rid of skipNodesWithCustomControllerPods
+-		replicated = replicated && replicatedKind[controllerRef.Kind]
++		replicated = replicated && (replicatedKind[controllerRef.Kind] || (controllerRef.Kind == "DaemonSet" && controllerRef.APIVersion == "apps.kruise.io/v1alpha1"))
+ 	}
+
+ 	if !replicated {
+Index: cluster-autoscaler/simulator/drainability/rules/pdb/rule.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/cluster-autoscaler/simulator/drainability/rules/pdb/rule.go b/cluster-autoscaler/simulator/drainability/rules/pdb/rule.go
+--- a/cluster-autoscaler/simulator/drainability/rules/pdb/rule.go	(revision 669115a6814d33b9d5757aa801402710029cb5b5)
++++ b/cluster-autoscaler/simulator/drainability/rules/pdb/rule.go	(date 1745485990632)
+@@ -40,9 +40,20 @@
+
+ // Drainable decides how to handle pods with pdbs on node drain.
+ func (Rule) Drainable(drainCtx *drainability.DrainContext, pod *apiv1.Pod, _ *framework.NodeInfo) drainability.Status {
++	kruiseAds := false
++	controllerRef := drain.ControllerRef(pod)
++	if controllerRef != nil && controllerRef.APIVersion == "apps.kruise.io/v1alpha1" && controllerRef.Kind == "DaemonSet" {
++		kruiseAds = true
++	}
+ 	for _, pdb := range drainCtx.RemainingPdbTracker.MatchingPdbs(pod) {
+-		if pdb.Status.DisruptionsAllowed < 1 {
+-			return drainability.NewBlockedStatus(drain.NotEnoughPdb, fmt.Errorf("not enough pod disruption budget to move %s/%s", pod.Namespace, pod.Name))
++		if kruiseAds {
++			if pdb.Status.CurrentHealthy <= 1 {
++				return drainability.NewBlockedStatus(drain.NotEnoughPdb, fmt.Errorf("not enough healthy pods to move %s/%s", pod.Namespace, pod.Name))
++			}
++		} else {
++			if pdb.Status.DisruptionsAllowed < 1 {
++				return drainability.NewBlockedStatus(drain.NotEnoughPdb, fmt.Errorf("not enough pod disruption budget to move %s/%s", pod.Namespace, pod.Name))
++			}
+ 		}
+ 	}
+ 	return drainability.NewUndefinedStatus()
+Index: cluster-autoscaler/utils/pod/pod.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/cluster-autoscaler/utils/pod/pod.go b/cluster-autoscaler/utils/pod/pod.go
+--- a/cluster-autoscaler/utils/pod/pod.go	(revision 669115a6814d33b9d5757aa801402710029cb5b5)
++++ b/cluster-autoscaler/utils/pod/pod.go	(date 1745485672019)
+@@ -32,6 +32,9 @@
+ func IsDaemonSetPod(pod *apiv1.Pod) bool {
+ 	controllerRef := metav1.GetControllerOf(pod)
+ 	if controllerRef != nil && controllerRef.Kind == "DaemonSet" {
++		if controllerRef.APIVersion == "apps.kruise.io/v1alpha1" {
++			return false
++		}
+ 		return true
+ 	}
+

--- a/modules/040-node-manager/images/cluster-autoscaler/patches/1.35/003-scale-from-zero.patch
+++ b/modules/040-node-manager/images/cluster-autoscaler/patches/1.35/003-scale-from-zero.patch
@@ -1,0 +1,33 @@
+diff --git a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
+index b6dfeb84d..2f3b18d05 100644
+--- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
++++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
+@@ -836,7 +836,27 @@ func (m *McmManager) GetMachineDeploymentNodeTemplate(machinedeployment *Machine
+ 			return nil, cloudprovider.ErrNotImplemented
+ 		}
+ 	default:
+-		return nil, cloudprovider.ErrNotImplemented
++		scaleFromZero, ok := md.Annotations["cluster-autoscaler.kubernetes.io/scale-from-zero"]
++		if ok && scaleFromZero == "true" {
++			cpu := md.Annotations["cluster-autoscaler.kubernetes.io/node-cpu"]
++			memory := md.Annotations["cluster-autoscaler.kubernetes.io/node-memory"]
++			region = md.Annotations["cluster-autoscaler.kubernetes.io/node-region"]
++			zone = md.Annotations["cluster-autoscaler.kubernetes.io/node-zone"]
++
++			if len(strings.Join([]string{cpu, memory, region, zone}, "")) == 0 {
++				return nil, cloudprovider.ErrNotImplemented
++			}
++
++			instance = instanceType{
++				VCPU:             resource.MustParse(cpu),
++				Memory:           resource.MustParse(memory),
++				GPU:              resource.MustParse("0"),
++				PodCount:         resource.MustParse("110"),
++				EphemeralStorage: resource.MustParse("50378260Ki"),
++			}
++		} else {
++			return nil, cloudprovider.ErrNotImplemented
++		}
+ 	}
+
+ 	labels := make(map[string]string)

--- a/modules/040-node-manager/images/cluster-autoscaler/patches/1.35/004-set-priorities-for-to-de-deleted-machines-and-clean-annotation.patch
+++ b/modules/040-node-manager/images/cluster-autoscaler/patches/1.35/004-set-priorities-for-to-de-deleted-machines-and-clean-annotation.patch
@@ -1,0 +1,172 @@
+Subject: [PATCH] ++
+---
+Index: cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
+--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go	(revision 669115a6814d33b9d5757aa801402710029cb5b5)
++++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go	(date 1747481033457)
+@@ -31,10 +31,10 @@
+ 	"time"
+
+ 	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+-	"k8s.io/apimachinery/pkg/util/sets"
+-	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/eligibility"
+-
+ 	"github.com/gardener/machine-controller-manager/pkg/util/provider/machineutils"
++	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
++	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/eligibility"
++
+ 	apiv1 "k8s.io/api/core/v1"
+ 	"k8s.io/apimachinery/pkg/api/resource"
+ 	"k8s.io/apimachinery/pkg/types"
+@@ -341,26 +341,63 @@
+ 	if len(toBeDeletedMachineNames) == 0 {
+ 		return nil
+ 	}
+-	machinesOfNodeGroup, err := ngImpl.mcmManager.getMachinesForMachineDeployment(ngImpl.Name)
++
++	machines, err := ngImpl.mcmManager.getMachinesForMachineDeployment(ngImpl.Name)
+ 	if err != nil {
+-		klog.Warningf("NodeGroup.Refresh() of %q failed to get machines for MachineDeployment due to: %v", ngImpl.Name, err)
+-		return nil
++		return err
++	}
++
++	machinesSet := make(map[string]*v1alpha1.Machine)
++	for _, machine := range machines {
++		machinesSet[machine.Name] = machine
+ 	}
+-	toBeDeletedMachines := filterMachinesMatchingNames(machinesOfNodeGroup, sets.New(toBeDeletedMachineNames...))
+-	if len(toBeDeletedMachines) == 0 {
+-		klog.Warningf("NodeGroup.Refresh() of %q could not find Machine objects for toBeDeletedMachineNames %q", ngImpl.Name, toBeDeletedMachineNames)
+-		return nil
+-	}
+-	toBeDeletedNodeNames := getNodeNamesFromMachines(toBeDeletedMachines)
+-	if len(toBeDeletedNodeNames) == 0 {
+-		klog.Warningf("NodeGroup.Refresh() of %q could not find toBeDeletedNodeNames for toBeDeletedMachineNames %q of MachineDeployment", ngImpl.Name, toBeDeletedMachineNames)
+-		return nil
++
++	savedInAnnotation := make([]string, 0, len(toBeDeletedMachineNames))
++	for _, deleted := range toBeDeletedMachineNames {
++		if machine, ok := machinesSet[deleted]; ok {
++			if isMachineFailedOrTerminating(machine) {
++				klog.V(4).Infof("Machine %s is marked as failed or terminating. Will be removed from annotation", deleted)
++				continue
++			}
++
++			klog.V(4).Infof("Machine %s was found. Will keep in annotation", deleted)
++			savedInAnnotation = append(savedInAnnotation, deleted)
++		}
++
++		klog.V(4).Infof("Not found machine %s in machineset. Will be removed from annotation", deleted)
+ 	}
+-	err = ngImpl.mcmManager.cordonNodes(toBeDeletedNodeNames)
++
++	klog.V(2).Infof("Next machines will be saved to annotation %v", savedInAnnotation)
++
++	annotationVal := createMachinesTriggeredForDeletionAnnotValue(savedInAnnotation, time.Now().Format(time.RFC3339))
++	mdCopy := mcd.DeepCopy()
++	mdCopy.Annotations[machineutils.TriggerDeletionByMCM] = annotationVal
++	updatedMd, err := ngImpl.mcmManager.machineClient.MachineDeployments(mcd.Namespace).Update(context.TODO(), mdCopy, metav1.UpdateOptions{})
+ 	if err != nil {
+-		// we do not return error since we don't want this to block CA operation. This is best-effort.
+-		klog.Warningf("NodeGroup.Refresh() of %q ran into error cordoning nodes: %v", ngImpl.Name, err)
++		return err
+ 	}
++	klog.V(2).Infof("MachineDeployment %q triggered by mcm annotation cleaned to %q", mcd.Name, updatedMd.Annotations[machineutils.TriggerDeletionByMCM])
++
++	//machinesOfNodeGroup, err := ngImpl.mcmManager.getMachinesForMachineDeployment(ngImpl.Name)
++	//if err != nil {
++	//	klog.Warningf("NodeGroup.Refresh() of %q failed to get machines for MachineDeployment due to: %v", ngImpl.Name, err)
++	//	return nil
++	//}
++	//toBeDeletedMachines := filterMachinesMatchingNames(machinesOfNodeGroup, sets.New(toBeDeletedMachineNames...))
++	//if len(toBeDeletedMachines) == 0 {
++	//	klog.Warningf("NodeGroup.Refresh() of %q could not find Machine objects for toBeDeletedMachineNames %q", ngImpl.Name, toBeDeletedMachineNames)
++	//	return nil
++	//}
++	//toBeDeletedNodeNames := getNodeNamesFromMachines(toBeDeletedMachines)
++	//if len(toBeDeletedNodeNames) == 0 {
++	//	klog.Warningf("NodeGroup.Refresh() of %q could not find toBeDeletedNodeNames for toBeDeletedMachineNames %q of MachineDeployment", ngImpl.Name, toBeDeletedMachineNames)
++	//	return nil
++	//}
++	//err = ngImpl.mcmManager.cordonNodes(toBeDeletedNodeNames)
++	//if err != nil {
++	//	// we do not return error since we don't want this to block CA operation. This is best-effort.
++	//	klog.Warningf("NodeGroup.Refresh() of %q ran into error cordoning nodes: %v", ngImpl.Name, err)
++	//}
+ 	return nil
+ }
+
+@@ -441,6 +478,20 @@
+ 		return fmt.Errorf("MachineDeployment %s is under rolling update , cannot reduce replica count", ngImpl.Name)
+ 	}
+
++	klog.V(2).Infof("Start set priorities for machines %v", toBeDeletedMachineInfos)
++
++	for _, info := range toBeDeletedMachineInfos {
++		err = ngImpl.mcmManager.retry(func(ctx context.Context) (bool, error) {
++
++			klog.V(2).Infof("Set priority for machine %s/%s", info.Key.Namespace, info.Key.Name)
++			return ngImpl.mcmManager.updateAnnotationOnMachine(ctx, info.Key.Name, MachinePriorityMachineAnnotation, priorityValueForDeletionCandidateMachines)
++		}, "Machine", "update", info.Key.Name)
++
++		if err != nil {
++			return err
++		}
++	}
++
+ 	// Trying to update the machineDeployment till the deadline
+ 	err = ngImpl.mcmManager.retry(func(ctx context.Context) (bool, error) {
+ 		return ngImpl.mcmManager.scaleDownMachineDeployment(ctx, ngImpl.Name, toBeDeletedMachineInfos)
+Index: cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
+--- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go	(revision 669115a6814d33b9d5757aa801402710029cb5b5)
++++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go	(date 1747481033495)
+@@ -90,6 +90,7 @@
+ 	defaultPriorityValue = "3"
+ 	// priorityValueForDeletionCandidateMachines is the priority annotation value set on machines that the CA wants to be deleted. Its value is set to 1.
+ 	priorityValueForDeletionCandidateMachines = "1"
++	MachinePriorityMachineAnnotation          = "machinepriority.machine.sapcloud.io"
+ 	minResyncPeriodDefault                    = 1 * time.Hour
+ 	// kindMachineClass is the kind for generic machine class used by the OOT providers
+ 	kindMachineClass = "MachineClass"
+@@ -538,18 +539,19 @@
+ 	}
+ 	klog.V(2).Infof("MachineDeployment %q size decreased from %d to %d, TriggerDeletionByMCM Annotation Value: %q", md.Name, md.Spec.Replicas, updatedMd.Spec.Replicas, updatedMd.Annotations[machineutils.TriggerDeletionByMCM])
+
+-	toBeCordonedNodeNames := make([]string, 0, len(data.RevisedToBeDeletedMachineNames))
+-	for _, mInfo := range toBeDeletedMachineInfos {
+-		if data.RevisedToBeDeletedMachineNames.Has(mInfo.Key.Name) {
+-			toBeCordonedNodeNames = append(toBeCordonedNodeNames, mInfo.NodeName)
+-			klog.V(2).Infof("For MachineDeployment %q, will cordon node: %q corresponding to machine %q", md.Name, mInfo.NodeName, mInfo.Key.Name)
+-		}
+-	}
+-	err = m.cordonNodes(toBeCordonedNodeNames)
+-	if err != nil {
+-		// Do not return error as cordoning is best-effort
+-		klog.Warningf("NodeGroup.deleteMachines() of %q ran into error cordoning nodes: %v", md.Name, err)
+-	}
++	//toBeCordonedNodeNames := make([]string, 0, len(data.RevisedToBeDeletedMachineNames))
++	//for _, mInfo := range toBeDeletedMachineInfos {
++	//	if data.RevisedToBeDeletedMachineNames.Has(mInfo.Key.Name) {
++	//		toBeCordonedNodeNames = append(toBeCordonedNodeNames, mInfo.NodeName)
++	//		klog.V(2).Infof("For MachineDeployment %q, will cordon node: %q corresponding to machine %q", md.Name, mInfo.NodeName, mInfo.Key.Name)
++	//	}
++	//}
++	//err = m.cordonNodes(toBeCordonedNodeNames)
++	//if err != nil {
++	//	// Do not return error as cordoning is best-effort
++	//	klog.Warningf("NodeGroup.deleteMachines() of %q ran into error cordoning nodes: %v", md.Name, err)
++	//}
++
+ 	return false, nil
+ }
+

--- a/modules/040-node-manager/images/cluster-autoscaler/patches/1.35/005-report-all-machine-creation-errors-to-ca.patch
+++ b/modules/040-node-manager/images/cluster-autoscaler/patches/1.35/005-report-all-machine-creation-errors-to-ca.patch
@@ -1,0 +1,28 @@
+diff --git a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
+--- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
++++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
+@@ -641,14 +641,18 @@
+ // generateInstanceStatus returns cloudprovider.InstanceStatus for the machine obj
+ func generateInstanceStatus(machine *v1alpha1.Machine) *cloudprovider.InstanceStatus {
+ 	if machine.Status.LastOperation.Type == v1alpha1.MachineOperationCreate {
+-		if machine.Status.LastOperation.State == v1alpha1.MachineStateFailed && machine.Status.LastOperation.ErrorCode == machinecodes.ResourceExhausted.String() {
++		if machine.Status.LastOperation.State == v1alpha1.MachineStateFailed {
++			errorClass := cloudprovider.OtherErrorClass
++			if machine.Status.LastOperation.ErrorCode == machinecodes.ResourceExhausted.String() {
++				errorClass = cloudprovider.OutOfResourcesErrorClass
++			}
+ 			return &cloudprovider.InstanceStatus{
+ 				State: cloudprovider.InstanceCreating,
+ 				ErrorInfo: &cloudprovider.InstanceErrorInfo{
+-					ErrorClass:   cloudprovider.OutOfResourcesErrorClass,
+-					ErrorCode:    machinecodes.ResourceExhausted.String(),
++					ErrorClass:   errorClass,
++					ErrorCode:    machine.Status.LastOperation.ErrorCode,
+ 					ErrorMessage: machine.Status.LastOperation.Description,
+ 				},
+ 			}
+ 		}
+ 		return &cloudprovider.InstanceStatus{State: cloudprovider.InstanceCreating}
+ 	}
+ 	return nil
+ }

--- a/modules/040-node-manager/images/cluster-autoscaler/patches/1.35/006-fix-upcoming-nodes-deadlock-for-failed-node-groups.patch
+++ b/modules/040-node-manager/images/cluster-autoscaler/patches/1.35/006-fix-upcoming-nodes-deadlock-for-failed-node-groups.patch
@@ -1,0 +1,28 @@
+Subject: [PATCH] Exclude upcoming nodes for groups without active scale-up requests or are backed off in cluster state handling.
+---
+Index: cluster-autoscaler/clusterstate/clusterstate.go
+===================================================================
+diff --git a/cluster-autoscaler/clusterstate/clusterstate.go b/cluster-autoscaler/clusterstate/clusterstate.go
+--- a/cluster-autoscaler/clusterstate/clusterstate.go	(revision e2a2fd389766840e92c96bbd92cd6f392720ce0a)
++++ b/cluster-autoscaler/clusterstate/clusterstate.go	(date 1772437955568)
+@@ -1018,6 +1018,20 @@
+ 			// Negative value is unlikely but theoretically possible.
+ 			continue
+ 		}
++		// Don't count upcoming nodes for node groups that have upcoming nodes but no
++		// active scale-up request (the request was removed after instance creation
++		// failure or timeout) or are backed off. Otherwise, fake upcoming nodes
++		// injected into the cluster snapshot will make unschedulable pods appear
++		// schedulable, preventing ScaleUp from ever being called and considering
++		// alternative node groups.
++		if _, hasScaleUpRequest := csr.scaleUpRequests[id]; !hasScaleUpRequest {
++			klog.V(4).Infof("Skipping %d upcoming nodes for node group %s: no active scale-up request", newNodes, id)
++			continue
++		}
++		if backoffStatus := csr.backoff.BackoffStatus(nodeGroup, csr.nodeInfosForGroups[id], time.Now()); backoffStatus.IsBackedOff {
++			klog.V(4).Infof("Skipping %d upcoming nodes for backed-off node group %s: %s", newNodes, id, backoffStatus.ErrorInfo.ErrorMessage)
++			continue
++		}
+ 		upcomingCounts[id] = newNodes
+ 		// newNodes should include instances that have registered with k8s but aren't ready yet, instances that came up on the cloud provider side
+ 		// but haven't registered with k8s yet, and instances that haven't even come up on the cloud provider side yet (but are reflected in the target

--- a/modules/040-node-manager/images/cluster-autoscaler/patches/1.35/README.md
+++ b/modules/040-node-manager/images/cluster-autoscaler/patches/1.35/README.md
@@ -6,30 +6,29 @@ Bumps Go module dependencies to remediate CVEs reported by Trivy for the
 cluster-autoscaler binary. The vulnerabilities live in indirect/build
 dependencies that are linked into the binary (x/crypto/ssh, x/net, k8s
 staging modules), not in cluster-autoscaler logic, so the fix is a pure
-`go.mod`/`go.sum` bump. The gardener tag stays `v1.34.1`.
+`go.mod`/`go.sum` bump. The gardener tag stays `v1.35.1`.
+
+This patch also covers the k8s 1.36 image: `werf.inc.yaml` clamps
+`$maxVersion = "1.35"`, so that image is built from gardener `v1.35.1`
+with `patches/1.35/`.
 
 Applied to both `cluster-autoscaler/go.mod` and `cluster-autoscaler/apis/go.mod`:
 
-- `go` directive: `1.24.0` -> `1.25.0`
-- `golang.org/x/net`: `v0.38.0` -> `v0.55.0` (HTML parser / HTTP2 / idna CVEs)
-- `golang.org/x/sys`: `v0.31.0` -> `v0.45.0`
-- `golang.org/x/crypto`: `v0.36.0` -> `v0.51.0` (x/crypto/ssh CVEs)
-- `k8s.io/kubernetes`: `v1.34.1` -> `v1.34.2`, and all `k8s.io/*` staging
-  modules (require + replace) synced to `v0.34.2` (kube-controller-manager
-  SSRF, CVE-2025-13281)
+- `golang.org/x/net`: `v0.48.0` -> `v0.57.0` (HTML parser / HTTP2 / idna / dns CVEs)
+- `golang.org/x/sys`: `v0.39.0` -> `v0.47.0`
+- `golang.org/x/crypto`: `v0.46.0` -> `v0.54.0` (x/crypto/ssh CVEs)
+- `golang.org/x/text`: `v0.32.0` -> `v0.40.0` (unicode normalization DoS)
 
 To recreate this patch, check out the clean tag and re-apply the bumps:
 
 ```shell
 git clone <SOURCE_REPO>/gardener/autoscaler.git
-cd autoscaler && git checkout v1.34.1
+cd autoscaler && git checkout v1.35.1
 cd cluster-autoscaler
-go get golang.org/x/crypto@v0.51.0
-go get golang.org/x/net@v0.55.0
-go get golang.org/x/sys@v0.45.0
-go get k8s.io/kubernetes@v1.34.2
-# sync every k8s.io/* require and replace directive to v0.34.2
-cd apis && go get golang.org/x/net@v0.55.0 && cd ..
+go get golang.org/x/crypto@v0.54.0
+go get golang.org/x/net@v0.57.0
+go get golang.org/x/sys@v0.47.0
+cd apis && go get golang.org/x/net@v0.57.0 && go get golang.org/x/sys@v0.47.0 && cd ..
 go mod tidy && (cd apis && go mod tidy)
 cd ..
 git diff -- cluster-autoscaler/go.mod cluster-autoscaler/go.sum \
@@ -59,7 +58,7 @@ drizzling replicas count in machine deployment.
 
 Report all machine creation errors to Cluster Autoscaler, not only ResourceExhausted
 
-Previously, generateInstanceStatus only reported ErrorInfo to the Cluster Autoscaler when a Machine failed with ResourceExhausted error code (quota/stockout). 
+Previously, generateInstanceStatus only reported ErrorInfo to the Cluster Autoscaler when a Machine failed with ResourceExhausted error code (quota/stockout).
 All other creation failures (invalid image, wrong credentials, network errors, etc.) returned InstanceStatus without ErrorInfo, making them invisible to CA's error handling.
 
 ### 006-fix-upcoming-nodes-deadlock-for-failed-node-groups.patch

--- a/modules/040-node-manager/images/cluster-autoscaler/patches/README.md
+++ b/modules/040-node-manager/images/cluster-autoscaler/patches/README.md
@@ -10,17 +10,17 @@ so the fix is a pure `go.mod`/`go.sum` bump — the gardener source tag is not
 changed. The patch touches both `cluster-autoscaler/go.mod` and
 `cluster-autoscaler/apis/go.mod`.
 
-Typical bumps: `golang.org/x/net` -> `v0.55.0`, `golang.org/x/sys` -> `v0.45.0`,
-`golang.org/x/crypto` -> `v0.51.0`, and `k8s.io/kubernetes` (plus all `k8s.io/*`
-require/replace directives) to the latest fix patch of the matching minor
-(for example `v1.32.10` / `v1.33.6` / `v1.34.2`).
+Typical bumps: `golang.org/x/net` -> `v0.57.0`, `golang.org/x/sys` -> `v0.47.0`,
+`golang.org/x/crypto` -> `v0.54.0`, and (for older minors) `k8s.io/kubernetes`
+(plus all `k8s.io/*` require/replace directives) to the latest fix patch of the
+matching minor (for example `v1.32.10` / `v1.33.6` / `v1.34.2`).
 
 Because the patch is generated against a specific gardener tag, it must be
 recreated from a clean checkout of that tag; applying a patch made from a
 different base fails in CI with `patch does not apply`. Per-version target
 versions and the exact recreate commands are documented in each
-`<k8s-minor>/README.md`. Note that the `1.34/` patch is also used for the
-1.35 and 1.36 images (`werf.inc.yaml` clamps `$maxVersion = "1.34"`).
+`<k8s-minor>/README.md`. Note that the `1.35/` patch is also used for the
+1.36 image (`werf.inc.yaml` clamps `$maxVersion = "1.35"`).
 
 ## Scale from zero
 

--- a/modules/040-node-manager/images/cluster-autoscaler/werf.inc.yaml
+++ b/modules/040-node-manager/images/cluster-autoscaler/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $maxVersion := "1.34" -}}
+{{- $maxVersion := "1.35" -}}
 
 {{- range $key, $value := .CandiVersionMap.k8s }}
   {{- $version := toString $key }}

--- a/modules/040-node-manager/templates/cluster-autoscaler/rbac-for-us.yaml
+++ b/modules/040-node-manager/templates/cluster-autoscaler/rbac-for-us.yaml
@@ -168,6 +168,11 @@ rules:
 - apiGroups: ["storage.k8s.io"]
   resources: ["storageclasses", "csinodes", "csistoragecapacities", "csidrivers", "volumeattachments"]
   verbs: ["get", "list", "watch"]
+# Cluster-autoscaler 1.35+ always starts DRA informers and blocks on their cache sync,
+# so these permissions are required even in clusters that do not use DRA.
+- apiGroups: ["resource.k8s.io"]
+  resources: ["resourceclaims", "resourceslices", "deviceclasses"]
+  verbs: ["get", "list", "watch"]
 - apiGroups: [""]
   resources: ["events"]
   verbs: ["create", "update", "patch"]


### PR DESCRIPTION
## Description

Adds native `cluster-autoscaler` 1.35 support for Kubernetes 1.35 (gardener tag `v1.35.1`).

- Introduces `patches/1.35/` with Deckhouse functional patches ported from 1.34 (`002`–`006`); verified to apply cleanly on gardener `v1.35.1`
- Adds `001-go-mod.patch` to bump vulnerable Go dependencies (`golang.org/x/crypto`, `x/net`, `x/sys`, `x/text`)
- Raises `$maxVersion` in `werf.inc.yaml` from `1.34` to `1.35` (Kubernetes 1.36 continues to build from the 1.35 autoscaler image/patches)
- Extends `known_vulnerabilities.vex` for residual findings that do not affect Deckhouse (`GO-2026-5932` / OpenPGP, `CVE-2026-41579` / runc)

Notable changes in 1.35:

- Upstream: Kubernetes libraries updated to 1.35; new `--max-node-startup-time` and `--predicate-parallelism` flags; CSI volume limits considered during scale-up; optimized scaling loop interval by default; fix for scale-down/scale-up oscillation with hard TopologySpreadConstraints
- Gardener/MCM: `TemplateNodeInfo` includes extended resources from MachineClass `Capacity` and `VirtualCapacity`; skip deletion of preserved machines with unregistered nodes; fix cordoned machine after rapid scale-up/scale-down; fix incorrect untaint/uncordon on `ForceDeleteNodes` error

Changelogs:

- Upstream: [cluster-autoscaler-1.35.0](https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.35.0), [cluster-autoscaler-1.35.1](https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.35.1)

- Gardener:  [v1.35.0](https://github.com/gardener/autoscaler/releases/tag/v1.35.0), [v1.35.1](https://github.com/gardener/autoscaler/releases/tag/v1.35.1)

No restarts of ingress-controller, control-plane, or Prometheus are expected from this PR alone; the new image is used when clusters run Kubernetes 1.35+.

## Why do we need it, and what problem does it solve?

Kubernetes 1.35 is already present in `version_map`, but `cluster-autoscaler` was still clamped to gardener 1.34. This PR aligns autoscaler with the cluster Kubernetes minor, keeps Deckhouse MCM-related behavior via the same functional patches, and remediates Trivy-reported CVEs in linked Go modules for the 1.35 binary.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: feature
summary: Add cluster-autoscaler 1.35 support with ported Deckhouse patches and CVE dependency bumps.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
