### PR TITLE
[ci] add gitlab weekly-cve-scan

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,7 +7,10 @@ stages:
   - .post
 
 include:
-- .gitlab/**.yml
+  - .gitlab/**.yml
+
+variables:
+  CI_IMAGES_TAG: "v4"
 
 default:
   tags:

--- a/.gitlab/notify-failure.yml
+++ b/.gitlab/notify-failure.yml
@@ -1,0 +1,22 @@
+.notify-failure-base:
+  image:
+    name: ${CI_REGISTRY}/deckhouse/ssdlc/ci-images/tools/notify:${CI_IMAGES_TAG}
+  variables:
+    GIT_STRATEGY: none
+    GIT_SUBMODULE_STRATEGY: none
+    VAULT_AUTH_PATH: fox
+    VAULT_AUTH_ROLE: deckhouse
+    JOB_NAME: $CI_JOB_NAME
+    WORKFLOW_NAME: $CI_PIPELINE_SCHEDULE_DESCRIPTION
+    WORKFLOW_URL: $CI_PIPELINE_URL
+  id_tokens:
+    VAULT_ID_TOKEN:
+      aud: gitlab-access-aud
+  secrets:
+    LOOP_SERVICE_NOTIFICATIONS:
+      token: $VAULT_ID_TOKEN
+      file: false
+      vault: 6db2f1ee-9b6f-4f4f-8381-2fb43060478a/team-ssdlc/loop/webhook_url@projects
+  when: on_failure
+  script:
+    - send-report.sh --webhook "ci_fail"

--- a/.gitlab/rules.yml
+++ b/.gitlab/rules.yml
@@ -32,3 +32,7 @@ workflow:
 .rules:on_release_branch:
   rules:
     - if: $CI_COMMIT_BRANCH =~ /^release-\d+\.\d+$/
+
+.rules:on_schedule_cve_scans:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule" && $DKP_CVE_SCANS_ENABLE == "true"

--- a/.gitlab/weekly-cve-scans.yml
+++ b/.gitlab/weekly-cve-scans.yml
@@ -1,0 +1,148 @@
+# Weekly CVE scan jobs.
+include:
+  - '.gitlab/notify-failure.yml'
+
+.weekly-cve-common:
+  stage: validate
+  timeout: 4h
+  resource_group: weekly-cve-scan
+  interruptible: true
+  cache: []
+  dependencies: []
+  id_tokens:
+    VAULT_ID_TOKEN:
+      aud: gitlab-access-aud
+  variables:
+    VAULT_AUTH_PATH: fox
+    VAULT_AUTH_ROLE: deckhouse
+    GIT_STRATEGY: clone
+    GIT_DEPTH: "1"
+    GIT_SUBMODULE_STRATEGY: none
+
+.cve-scan-variables:
+  variables:
+    CS_TRIVY_BIN_VERSION: "v0.67.2"
+    CS_TRIVY_REPO_ID: "2181"
+
+    CS_TRIVY_PROD_REGISTRY: "${PROD_READ_REGISTRY}"
+    CS_TRIVY_DB_URL: "${PROD_READ_REGISTRY}/deckhouse/ee/security/trivy-db:2"
+    CS_TRIVY_JAVA_DB_URL: "${PROD_READ_REGISTRY}/deckhouse/ee/security/trivy-java-db:1"
+    CS_TRIVY_POLICY_URL: "${PROD_READ_REGISTRY}/deckhouse/ee/security/trivy-bdu:1"
+    CS_TRIVY_REPORTS_LOG_OUTPUT: "1" # Trivy log output level (0=off, 1=CVE report, 2=license report)
+
+    CS_PROD_REGISTRY: "${PROD_READ_REGISTRY}"
+    CS_PROD_REGISTRY_USER: "${PROD_READ_REGISTRY_USER}"
+    CS_PROD_REGISTRY_PASSWORD: "${PROD_READ_REGISTRY_PASSWORD}"
+
+    CS_DEV_REGISTRY: "${DECKHOUSE_DEV_REGISTRY_HOST}"
+    CS_DEV_REGISTRY_USER: "${DECKHOUSE_DEV_REGISTRY_USER}"
+    CS_DEV_REGISTRY_PASSWORD: "${DECKHOUSE_DEV_REGISTRY_PASSWORD}"
+
+    CS_SOURCE_TAG: "main"
+    CS_CASE: "deckhouse"
+
+    CS_RELEASE_IN_DEV: "False" # If true, release tag will be searched in dev registry instead of prod
+    CS_SCAN_SEVERAL_LATEST_RELEASES: "False" # Scan multiple latest releases (True/False)
+    CS_SCAN_USERS: "False" # Enable user validation scan for CSE (True/False)
+    CS_LATEST_RELEASES_AMOUNT: 3
+
+    CS_EXTERNAL_MODULE_NAME: "" # External module name (required when case=External Modules)
+    CS_MODULE_PROD_REGISTRY_CUSTOM_PATH: "deckhouse/fe/modules" # Custom path for external modules in production registry
+    CS_MODULE_DEV_REGISTRY_CUSTOM_PATH: "sys/deckhouse-oss/modules" # Custom path for external modules in development registry
+
+    CS_DD_URL: "${DD_URL}"
+    CS_DD_TOKEN: "${DD_TOKEN}"
+
+    CS_DIGEST_FROM_WERF: "images_tags_werf" # Prefix of Werf image digest files (for CSE external modules)
+
+    CS_CODEOWNERS_REPO_TOKEN: "${CODEOWNERS_REPO_TOKEN}"
+    CS_DECKHOUSE_PRIVATE_REPO: "${DECKHOUSE_PRIVATE_REPO}"
+    CS_CONFIGMAP_PROJECT_ID: "4352"
+
+    CS_WORKDIR: "${CI_PROJECT_DIR}/cve-scan" # Working directory for temporary files
+
+weekly-cve-scan:
+  extends:
+    - .weekly-cve-common
+    - .cve-scan-variables
+    - .rules:on_schedule_cve_scans
+  id_tokens:
+    VAULT_ID_TOKEN:
+      aud: gitlab-access-aud
+  secrets:
+    DECKHOUSE_DEV_REGISTRY_HOST:
+      token: $VAULT_ID_TOKEN
+      file: false
+      vault: 6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/registry_host/DECKHOUSE_DEV_REGISTRY_HOST@projects
+    DECKHOUSE_DEV_REGISTRY_USER:
+      token: $VAULT_ID_TOKEN
+      file: false
+      vault: 101ceaca-97cd-462f-aed5-070d9b9de175/dev-registry/writetoken/login@projects
+    DECKHOUSE_DEV_REGISTRY_PASSWORD:
+      token: $VAULT_ID_TOKEN
+      file: false
+      vault: 101ceaca-97cd-462f-aed5-070d9b9de175/dev-registry/writetoken/password@projects
+    PROD_READ_REGISTRY:
+      token: $VAULT_ID_TOKEN
+      file: false
+      vault: 101ceaca-97cd-462f-aed5-070d9b9de175/registry_host/DECKHOUSE_READ_REGISTRY_HOST@projects
+    PROD_READ_REGISTRY_USER:
+      token: $VAULT_ID_TOKEN
+      file: false
+      vault: 6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/registry_read_token/login@projects
+    PROD_READ_REGISTRY_PASSWORD:
+      token: $VAULT_ID_TOKEN
+      file: false
+      vault: 6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/registry_read_token/password@projects
+    DD_TOKEN:
+      token: $VAULT_ID_TOKEN
+      file: false
+      vault: 24cb1d7c-717a-4f92-8547-26f632916a7a/Trivy_CVE_Scan_CI_Secrets/DD_TOKEN@projects
+    DD_URL:
+      token: $VAULT_ID_TOKEN
+      file: false
+      vault: 24cb1d7c-717a-4f92-8547-26f632916a7a/Trivy_CVE_Scan_CI_Secrets/DD_URL@projects
+    CVE_TEST_SSH_PRIVATE_KEY:
+      token: $VAULT_ID_TOKEN
+      file: false
+      vault: 24cb1d7c-717a-4f92-8547-26f632916a7a/Trivy_CVE_Scan_CI_Secrets/CVE_TEST_SSH_PRIVATE_KEY@projects
+    CVE_TEST_REPO_GIT:
+      token: $VAULT_ID_TOKEN
+      file: false
+      vault: 24cb1d7c-717a-4f92-8547-26f632916a7a/Trivy_CVE_Scan_CI_Secrets/CVE_TEST_REPO_GIT@projects
+    DECKHOUSE_PRIVATE_REPO:
+      token: $VAULT_ID_TOKEN
+      file: false
+      vault: 24cb1d7c-717a-4f92-8547-26f632916a7a/Trivy_CVE_Scan_CI_Secrets/DECKHOUSE_PRIVATE_REPO@projects
+    CODEOWNERS_REPO_TOKEN:
+      token: $VAULT_ID_TOKEN
+      file: false
+      vault: b050f3bd-733f-4746-9640-9df80d484074/CODEOWNERS_REPO_TOKEN/CODEOWNERS_REPO_TOKEN@projects
+
+  before_script:
+    - set -euo pipefail
+    - mkdir -p "${CI_PROJECT_DIR}/.ssh"
+    - HOST="$(echo "${CVE_TEST_REPO_GIT}" | sed -E 's/.*@([^:]+).*/\1/')"
+    - ssh-keyscan -t ed25519 -H "${HOST}" >> "${CI_PROJECT_DIR}/.ssh/known_hosts"
+    - echo "${CVE_TEST_SSH_PRIVATE_KEY}" | tr -d '\r' > "${CI_PROJECT_DIR}/.ssh/id_rsa" # else error in libcrypto
+    - chmod 600 "${CI_PROJECT_DIR}/.ssh/id_rsa"
+
+  script:
+    - GIT_SSH_COMMAND="ssh -i ${CI_PROJECT_DIR}/.ssh/id_rsa -o UserKnownHostsFile=${CI_PROJECT_DIR}/.ssh/known_hosts" git clone --depth 1 "${CVE_TEST_REPO_GIT}" {CI_PROJECT_DIR}/tmp/cve-scripts
+    - cp {CI_PROJECT_DIR}/tmp/cve-scripts/*.sh {CI_PROJECT_DIR}/tmp/cve-scripts/*.py ./
+    - chmod +x ./*.sh ./*.py
+    - bash ./cve_scan.sh
+
+  after_script:
+    - rm -rf "${CI_PROJECT_DIR}/.ssh"
+
+  tags:
+    - vm-intteam-cloud-d8-ssdlc-runner
+
+weekly-cve-scan-failure-notify:
+  extends:
+    - .weekly-cve-common
+    - .notify-failure-base
+  needs:
+    - job: weekly-cve-scan
+      optional: true


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Add transformed in gitlab-ci weekly cve scans pipeline

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
It needed in migrating CI process
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Add transformed weekly cve scans for gitlab ci
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
