### PR TITLE
Changelog v1.76.8

### DIFF
--- a/CHANGELOG/CHANGELOG-v1.76.8.yml
+++ b/CHANGELOG/CHANGELOG-v1.76.8.yml
@@ -2,6 +2,11 @@ cloud-provider-dvp:
   fixes:
     - summary: skip foreign nodes in cloud controller manager
       pull_request: https://github.com/deckhouse/deckhouse/pull/21779
+cni-cilium:
+  fixes:
+    - summary: Bump Go dependencies in the egress-gateway-agent image to fix known CVEs.
+      pull_request: https://github.com/deckhouse/deckhouse/pull/21608
+      impact: The egress-gateway-agent component will restart after the update.
 deckhouse:
   fixes:
     - summary: >-

--- a/CHANGELOG/CHANGELOG-v1.76.md
+++ b/CHANGELOG/CHANGELOG-v1.76.md
@@ -20,6 +20,7 @@
  - The cilium-hubble components (hubble-ui, hubble-relay) will restart after the update.
  - The cni-cilium components (cilium agent, operator) will restart after the update.
  - The coredns and kube-dns components will restart after the update.
+ - The egress-gateway-agent component will restart after the update.
  - The metallb components (controller, speaker, l2lb) will restart after the update.
  - The node-local-dns components will restart after the update.
  - The service-with-healthchecks components (controller, agent) will restart after the update.
@@ -247,6 +248,8 @@
  - **[cloud-provider-zvirt]** fix CVEs in cloud-provider-zvirt [#18257](https://github.com/deckhouse/deckhouse/pull/18257)
  - **[cni-cilium]** Bump Go dependencies and backport upstream cilium security patches to fix known CVEs. [#21507](https://github.com/deckhouse/deckhouse/pull/21507)
     The cni-cilium components (cilium agent, operator) will restart after the update.
+ - **[cni-cilium]** Bump Go dependencies in the egress-gateway-agent image to fix known CVEs. [#21608](https://github.com/deckhouse/deckhouse/pull/21608)
+    The egress-gateway-agent component will restart after the update.
  - **[cni-cilium]** Fixed CVE-2026-33186, CVE-2026-27142, and CVE-2026-27139 by updating grpc dependency and Go version, and resolved build compatibility issues. [#18553](https://github.com/deckhouse/deckhouse/pull/18553)
  - **[cni-cilium]** Fixed CVE-2026-41520 for cilium-bugtool util [#20240](https://github.com/deckhouse/deckhouse/pull/20240)
  - **[cni-cilium]** Fixed constant `invalid sysctl parameter: "net.ipv4.conf..rp_filter"` errors in cilium-agent logs when using Egress Gateway with a Virtual IP. [#18952](https://github.com/deckhouse/deckhouse/pull/18952)


### PR DESCRIPTION
# Changelog v1.76.8

## Know before update


 - The coredns and kube-dns components will restart after the update.
 - The egress-gateway-agent component will restart after the update.
 - The node-local-dns components will restart after the update.
 - The service-with-healthchecks components (controller, agent) will restart after the update.

## Fixes


 - **[cloud-provider-dvp]** skip foreign nodes in cloud controller manager [#21779](https://github.com/deckhouse/deckhouse/pull/21779)
 - **[cni-cilium]** Bump Go dependencies in the egress-gateway-agent image to fix known CVEs. [#21608](https://github.com/deckhouse/deckhouse/pull/21608)
    The egress-gateway-agent component will restart after the update.
 - **[deckhouse-controller]** ModuleDocumentation will not be created for embedded modules. [#21652](https://github.com/deckhouse/deckhouse/pull/21652)
 - **[ingress-nginx]** Nginx version is updated to 1.30.4. [#21666](https://github.com/deckhouse/deckhouse/pull/21666)
    All Ingress-nginx controller pods will be restarted.
 - **[kube-dns]** Bump Go dependencies in the sts-pods-hosts-appender-webhook and coredns images to fix known CVEs. [#21627](https://github.com/deckhouse/deckhouse/pull/21627)
    The coredns and kube-dns components will restart after the update.
 - **[node-local-dns]** Bump Go dependencies in the safe-updater and stale-dns-connections-cleaner images to fix known CVEs. [#21627](https://github.com/deckhouse/deckhouse/pull/21627)
    The node-local-dns components will restart after the update.
 - **[service-with-healthchecks]** Bump Go dependencies in the service-with-healthchecks image to fix known CVEs. [#21592](https://github.com/deckhouse/deckhouse/pull/21592)
    The service-with-healthchecks components (controller, agent) will restart after the update.
 - **[user-authn]** Fix Dex token refresh with upstream providers that rotate refresh tokens (GitLab), which logged users out every `idTokenTTL`. [#21687](https://github.com/deckhouse/deckhouse/pull/21687)

## Chore


 - **[deckhouse]** Allow ClusterAdmin manage ModuleSettingsDefinitions with RBAC. [#21753](https://github.com/deckhouse/deckhouse/pull/21753)

For more information, see the [changelog](https://github.com/deckhouse/deckhouse/blob/main/CHANGELOG/CHANGELOG-v1.76.md) and minor version [release changes](https://github.com/deckhouse/deckhouse/releases/tag/v1.76.0).