### PR TITLE
[user-authn] let ClusterAdmin watch the Dex storage CRDs

### DIFF
--- a/modules/140-user-authz/docs/README.md
+++ b/modules/140-user-authz/docs/README.md
@@ -525,7 +525,7 @@ delete,deletecollection,get,list,patch,update,watch:
     - machine.sapcloud.io/yandexmachineclasses
 get,list,patch,update,watch:
     - control-plane.deckhouse.io/controlplanenodes
-list:
+list,watch:
     - dex.coreos.com/offlinesessionses
     - dex.coreos.com/passwords
 patch,update:

--- a/modules/140-user-authz/docs/README_RU.md
+++ b/modules/140-user-authz/docs/README_RU.md
@@ -531,7 +531,7 @@ delete,deletecollection,get,list,patch,update,watch:
     - machine.sapcloud.io/yandexmachineclasses
 get,list,patch,update,watch:
     - control-plane.deckhouse.io/controlplanenodes
-list:
+list,watch:
     - dex.coreos.com/offlinesessionses
     - dex.coreos.com/passwords
 patch,update:

--- a/modules/150-user-authn/templates/user-authz-cluster-roles.yaml
+++ b/modules/150-user-authn/templates/user-authz-cluster-roles.yaml
@@ -62,10 +62,12 @@ rules:
   - deletecollection
   - patch
   - update
-# Read-only audit access to internal Dex storage CRDs. Deliberately list-only:
+# Read-only audit access to internal Dex storage CRDs. Deliberately without `get`:
 # `passwords` contain bcrypt-hashed credentials, `offlinesessionses` carry refresh tokens —
-# `get` on a single object would return the same secret material, so we keep ClusterAdmin
-# at the listing level only (enough to enumerate sessions for incident response).
+# a named read would return the same secret material, so ClusterAdmin stays at the
+# collection level (enough to enumerate sessions for incident response).
+# `watch` is the same collection read delivered as a stream, so it discloses nothing `list`
+# does not; without it every client — kubectl -w, any informer — has to poll instead.
 # NOTE: plural is `offlinesessionses` (matches Dex CRD name in crds/external/offlinesessionses.yaml).
 - apiGroups:
   - dex.coreos.com
@@ -74,3 +76,4 @@ rules:
   - offlinesessionses
   verbs:
   - list
+  - watch


### PR DESCRIPTION
## Description

`ClusterAdmin` could `list` the internal Dex storage CRDs (`dex.coreos.com/passwords`, `dex.coreos.com/offlinesessionses`) but not `watch` them, so every client following those objects had to poll.

A watch returns the same collection a list already returns, delivered as a stream, so it discloses nothing new. The named read (`get`) stays out for the reason it always was: `passwords` hold bcrypt-hashed credentials and `offlinesessionses` hold refresh tokens.

## Why do we need it, and what problem does it solve?

Without `watch`, `kubectl get -w` and any informer over these resources fail for a cluster administrator, which makes following active sessions during an incident a polling loop.

## Why do we need it in the patch release (if we do)?

Yes — it is a two-verb RBAC addition with no behaviour change for anything else, and the missing verb is felt exactly when someone is investigating an incident.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authn
type: fix
summary: ClusterAdmin can watch the Dex storage CRDs (passwords, offlinesessionses), not only list them.
impact_level: low
```
