### PR TITLE
[istio] Fix go mod tidy broken by config-analyzer image sources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -398,3 +398,8 @@ replace github.com/docker/docker => github.com/docker/docker v28.3.3+incompatibl
 replace github.com/docker/cli => github.com/docker/cli v28.3.3+incompatible
 
 replace github.com/deckhouse/deckhouse/go_lib/controlplane => ./go_lib/controlplane
+
+// Image sources under this tree are built inside third-party source trees
+// (see werf.inc.yaml) and are hidden from build/lint by build tags. go mod
+// tidy inspects imports under all build tags, so ignore the tree entirely.
+ignore ./ee/modules/110-istio/images


### PR DESCRIPTION
## Description

Adds an `ignore` directive (Go 1.25+) to the root `go.mod`:

```
ignore ./ee/modules/110-istio/images
```

Go tooling stops treating Istio image sources as packages of the root module. Image builds are not affected: these sources are compiled inside the Istio source tree by werf (see `werf.inc.yaml` of the images). No cluster components are affected.

## Why do we need it, and what problem does it solve?

After #21349 plain `go mod tidy` fails at the repo root:

```
k8s.io/api/autoscaling/v2beta2: module k8s.io/api@latest found (v0.36.3), but does not contain package k8s.io/api/autoscaling/v2beta2
```

`ee/modules/110-istio/images/config-analyzer-*/src/*.go` import `istio.io/istio` and have no `go.mod` of their own. 

The `deckhouse_external` build tag hides them from build and lint, but `go mod tidy` inspects imports under all build tags - the only exceptions are the `ignore` tag and the `ignore` directive. 

So tidy pulls `istio.io/istio`, which bumps `k8s.io/api` to v0.36, where the `autoscaling/v2beta2` package needed by `fluxcd/flagger` (a nelm dependency) no longer exists. 

The requirements become unsolvable, and tidy is broken for every developer working in the repo. 
CI stays green only because no PR job runs tidy.

Bisect-verified: tidy works at `9e400d834f~1` and fails starting exactly at `9e400d834f`. With this fix tidy works again (verified locally).

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: chore
summary: Restore `go mod tidy` at the repo root by ignoring Istio image sources in go.mod.
impact_level: low
```
