### PR TITLE
[docs][documentation] Add nil-safety guards for OpenAPI extraction to prevent panics

### DIFF
--- a/docs/site/backends/docs-builder-template/layouts/_partials/openapi/extract-configuration-search-params.json
+++ b/docs/site/backends/docs-builder-template/layouts/_partials/openapi/extract-configuration-search-params.json
@@ -14,7 +14,7 @@
     {{- range $paramName, $paramData := $data.properties }}
       {{- if reflect.IsMap $paramData }}
         {{- $paramLangData := "" }}
-        {{- if and (reflect.IsMap $langData) $langData.properties }}
+        {{- if and (reflect.IsMap $langData) (reflect.IsMap $langData.properties) }}
           {{- $paramLangData = index $langData.properties $paramName }}
         {{- end }}
         {{- $currentAncestors := $ancestors | append $paramName }}

--- a/docs/site/backends/docs-builder-template/layouts/_partials/openapi/extract-configuration-search-params.json
+++ b/docs/site/backends/docs-builder-template/layouts/_partials/openapi/extract-configuration-search-params.json
@@ -12,48 +12,54 @@
 {{- if reflect.IsMap $data }}
   {{- if $data.properties }}
     {{- range $paramName, $paramData := $data.properties }}
-      {{- $paramLangData := index $langData.properties $paramName }}
-      {{- $currentAncestors := $ancestors | append $paramName }}
-      {{- $paramPath := delimit $currentAncestors "." }}
+      {{- if reflect.IsMap $paramData }}
+        {{- $paramLangData := "" }}
+        {{- if and (reflect.IsMap $langData) $langData.properties }}
+          {{- $paramLangData = index $langData.properties $paramName }}
+        {{- end }}
+        {{- $currentAncestors := $ancestors | append $paramName }}
+        {{- $paramPath := delimit $currentAncestors "." }}
 
-      {{- $description := "" }}
-      {{- if $paramLangData.description }}
-        {{- $description = $paramLangData.description | plainify }}
-      {{- else if $paramData.description }}
-        {{- $description = $paramData.description | plainify }}
-      {{- end }}
+        {{- $description := "" }}
+        {{- if and (reflect.IsMap $paramLangData) $paramLangData.description }}
+          {{- $description = $paramLangData.description | plainify }}
+        {{- else if $paramData.description }}
+          {{- $description = $paramData.description | plainify }}
+        {{- end }}
 
+        {{- $searchParam := dict
+          "name" $paramName
+          "module" $moduleName
+          "moduletype" "source"
+          "url" (printf "/modules/%s/%s/configuration.html#parameters-%s" $moduleName $moduleChannel (delimit $currentAncestors "-" | lower))
+          "path" $paramPath
+          "content" $description }}
 
-      {{- $searchParam := dict
-        "name" $paramName
-        "module" $moduleName
-        "moduletype" "source"
-        "url" (printf "/modules/%s/%s/configuration.html#parameters-%s" $moduleName $moduleChannel (delimit $currentAncestors "-" | lower))
-        "path" $paramPath
-        "content" $description }}
+        {{- if $resourceName }}
+          {{- $searchParam = merge $searchParam (dict "resName" $resourceName) }}
+        {{- end }}
 
-      {{- if $resourceName }}
-        {{- $searchParam = merge $searchParam (dict "resName" $resourceName) }}
-      {{- end }}
+        {{- if $apiVersion }}
+          {{- $searchParam = merge $searchParam (dict "apiVersion" $apiVersion) }}
+        {{- end }}
 
-      {{- if $apiVersion }}
-        {{- $searchParam = merge $searchParam (dict "apiVersion" $apiVersion) }}
-      {{- end }}
+        {{- $searchParams = $searchParams | append $searchParam }}
 
+        {{- /* Recursively process nested properties */}}
+        {{- if $paramData.properties }}
+          {{- $nestedParams := partial "openapi/extract-configuration-search-params.json" (dict "data" $paramData "langData" $paramLangData "moduleName" $moduleName "moduleChannel" $moduleChannel "ancestors" $currentAncestors "resourceName" $resourceName "apiVersion" $apiVersion) }}
+          {{- $searchParams = $searchParams | append $nestedParams }}
+        {{- end }}
 
-
-      {{- $searchParams = $searchParams | append $searchParam }}
-
-      {{- /* Recursively process nested properties */}}
-      {{- if $paramData.properties }}
-        {{- $nestedParams := partial "openapi/extract-configuration-search-params.json" (dict "data" $paramData "langData" $paramLangData "moduleName" $moduleName "moduleChannel" $moduleChannel "ancestors" $currentAncestors "resourceName" $resourceName "apiVersion" $apiVersion) }}
-        {{- $searchParams = $searchParams | append $nestedParams }}
-      {{- end }}
-
-      {{- /* Process array items if they have properties */}}
-      {{- if and $paramData.items $paramData.items.properties }}
-        {{- $nestedParams := partial "openapi/extract-configuration-search-params.json" (dict "data" $paramData.items "langData" $paramLangData.items "moduleName" $moduleName "moduleChannel" $moduleChannel "ancestors" $currentAncestors "resourceName" $resourceName "apiVersion" $apiVersion) }}
-        {{- $searchParams = $searchParams | append $nestedParams }}
+        {{- /* Process array items if they have properties */}}
+        {{- if and (reflect.IsMap $paramData.items) $paramData.items.properties }}
+          {{- $langItems := "" }}
+          {{- if reflect.IsMap $paramLangData }}
+            {{- $langItems = $paramLangData.items }}
+          {{- end }}
+          {{- $nestedParams := partial "openapi/extract-configuration-search-params.json" (dict "data" $paramData.items "langData" $langItems "moduleName" $moduleName "moduleChannel" $moduleChannel "ancestors" $currentAncestors "resourceName" $resourceName "apiVersion" $apiVersion) }}
+          {{- $searchParams = $searchParams | append $nestedParams }}
+        {{- end }}
       {{- end }}
     {{- end }}
   {{- end }}

--- a/docs/site/backends/docs-builder-template/layouts/_partials/openapi/extract-crd-properties-recursive.json
+++ b/docs/site/backends/docs-builder-template/layouts/_partials/openapi/extract-crd-properties-recursive.json
@@ -11,38 +11,47 @@
 {{- if reflect.IsMap $data }}
   {{- if $data.properties }}
     {{- range $paramName, $paramData := $data.properties }}
-      {{- $paramLangData := index $langData.properties $paramName }}
-      {{- $currentAncestors := $ancestors | append $paramName }}
-      {{- $paramPath := delimit $currentAncestors "." }}
+      {{- if reflect.IsMap $paramData }}
+        {{- $paramLangData := "" }}
+        {{- if and (reflect.IsMap $langData) $langData.properties }}
+          {{- $paramLangData = index $langData.properties $paramName }}
+        {{- end }}
+        {{- $currentAncestors := $ancestors | append $paramName }}
+        {{- $paramPath := delimit $currentAncestors "." }}
 
-      {{- $description := "" }}
-      {{- if $paramLangData.description }}
-        {{- $description = $paramLangData.description | plainify }}
-      {{- else if $paramData.description }}
-        {{- $description = $paramData.description | plainify }}
-      {{- end }}
+        {{- $description := "" }}
+        {{- if and (reflect.IsMap $paramLangData) $paramLangData.description }}
+          {{- $description = $paramLangData.description | plainify }}
+        {{- else if $paramData.description }}
+          {{- $description = $paramData.description | plainify }}
+        {{- end }}
 
-      {{- $searchParam := dict
-        "name" $paramName
-        "module" $moduleName
-        "moduletype" "source"
-        "url" (printf "/modules/%s/%s/cr.html#%s-%s-%s" $moduleName $moduleChannel ($kind | lower) ($versionName | lower) (delimit $currentAncestors "-" | lower))
-        "path" (printf "%s-%s-%s" ($kind | lower) $versionName $paramPath)
-        "content" $description
-        "resName" $kind }}
+        {{- $searchParam := dict
+          "name" $paramName
+          "module" $moduleName
+          "moduletype" "source"
+          "url" (printf "/modules/%s/%s/cr.html#%s-%s-%s" $moduleName $moduleChannel ($kind | lower) ($versionName | lower) (delimit $currentAncestors "-" | lower))
+          "path" (printf "%s-%s-%s" ($kind | lower) $versionName $paramPath)
+          "content" $description
+          "resName" $kind }}
 
-      {{- $searchParams = $searchParams | append $searchParam }}
+        {{- $searchParams = $searchParams | append $searchParam }}
 
-      {{- /* Recursively process nested properties */}}
-      {{- if $paramData.properties }}
-        {{- $nestedParams := partial "openapi/extract-crd-properties-recursive" (dict "data" $paramData "langData" $paramLangData "moduleName" $moduleName "moduleChannel" $moduleChannel "ancestors" $currentAncestors "kind" $kind "versionName" $versionName) }}
-        {{- $searchParams = $searchParams | append $nestedParams }}
-      {{- end }}
+        {{- /* Recursively process nested properties */}}
+        {{- if $paramData.properties }}
+          {{- $nestedParams := partial "openapi/extract-crd-properties-recursive" (dict "data" $paramData "langData" $paramLangData "moduleName" $moduleName "moduleChannel" $moduleChannel "ancestors" $currentAncestors "kind" $kind "versionName" $versionName) }}
+          {{- $searchParams = $searchParams | append $nestedParams }}
+        {{- end }}
 
-      {{- /* Process array items if they have properties */}}
-      {{- if and $paramData.items $paramData.items.properties }}
-        {{- $arrayParams := partial "openapi/extract-crd-properties-recursive" (dict "data" $paramData.items "langData" $paramLangData.items "moduleName" $moduleName "moduleChannel" $moduleChannel "ancestors" $currentAncestors "kind" $kind "versionName" $versionName) }}
-        {{- $searchParams = $searchParams | append $arrayParams }}
+        {{- /* Process array items if they have properties */}}
+        {{- if and (reflect.IsMap $paramData.items) $paramData.items.properties }}
+          {{- $langItems := "" }}
+          {{- if reflect.IsMap $paramLangData }}
+            {{- $langItems = $paramLangData.items }}
+          {{- end }}
+          {{- $arrayParams := partial "openapi/extract-crd-properties-recursive" (dict "data" $paramData.items "langData" $langItems "moduleName" $moduleName "moduleChannel" $moduleChannel "ancestors" $currentAncestors "kind" $kind "versionName" $versionName) }}
+          {{- $searchParams = $searchParams | append $arrayParams }}
+        {{- end }}
       {{- end }}
     {{- end }}
   {{- end }}

--- a/docs/site/backends/docs-builder-template/layouts/_partials/openapi/extract-crd-properties-recursive.json
+++ b/docs/site/backends/docs-builder-template/layouts/_partials/openapi/extract-crd-properties-recursive.json
@@ -13,7 +13,7 @@
     {{- range $paramName, $paramData := $data.properties }}
       {{- if reflect.IsMap $paramData }}
         {{- $paramLangData := "" }}
-        {{- if and (reflect.IsMap $langData) $langData.properties }}
+        {{- if and (reflect.IsMap $langData) (reflect.IsMap $langData.properties) }}
           {{- $paramLangData = index $langData.properties $paramName }}
         {{- end }}
         {{- $currentAncestors := $ancestors | append $paramName }}

--- a/docs/site/backends/docs-builder-template/layouts/_partials/openapi/extract-crd-search-params.html
+++ b/docs/site/backends/docs-builder-template/layouts/_partials/openapi/extract-crd-search-params.html
@@ -70,12 +70,16 @@
   {{- $versionSchema := $stablestVersion.schema.openAPIV3Schema }}
   {{- $langVersionData := dict }}
 
-  {{- if $langData.spec.versions }}
-    {{- $langVersionData = index (where $langData.spec.versions "name" "eq" $versionName) 0 }}
+  {{- /* Language schema may be missing entirely (no doc-<lang>-<crd> key) — guard every dereference against nil */}}
+  {{- if and (reflect.IsMap $langData) $langData.spec $langData.spec.versions }}
+    {{- $matchedLangVersions := where $langData.spec.versions "name" "eq" $versionName }}
+    {{- if gt (len $matchedLangVersions) 0 }}
+      {{- $langVersionData = index $matchedLangVersions 0 }}
+    {{- end }}
   {{- end }}
 
   {{- $description := $versionSchema.description }}
-  {{- if $langVersionData.schema.openAPIV3Schema.description }}
+  {{- if and (reflect.IsMap $langVersionData) $langVersionData.schema $langVersionData.schema.openAPIV3Schema $langVersionData.schema.openAPIV3Schema.description }}
     {{- $description = $langVersionData.schema.openAPIV3Schema.description }}
   {{- end }}
 
@@ -94,7 +98,11 @@
 
   {{- /* Extract properties from the CRD schema using recursive partial */}}
   {{- if $versionSchema.properties }}
-    {{- $crdProperties := partial "openapi/extract-crd-properties-recursive" (dict "data" $versionSchema "langData" $langVersionData.schema.openAPIV3Schema "moduleName" $moduleName "moduleChannel" $moduleChannel "ancestors" slice "kind" $kind "versionName" $versionName) }}
+    {{- $langSchema := "" }}
+    {{- if and (reflect.IsMap $langVersionData) $langVersionData.schema $langVersionData.schema.openAPIV3Schema }}
+      {{- $langSchema = $langVersionData.schema.openAPIV3Schema }}
+    {{- end }}
+    {{- $crdProperties := partial "openapi/extract-crd-properties-recursive" (dict "data" $versionSchema "langData" $langSchema "moduleName" $moduleName "moduleChannel" $moduleChannel "ancestors" slice "kind" $kind "versionName" $versionName) }}
     {{- $searchParams = $searchParams | append $crdProperties }}
   {{- end }}
 {{- end }}

--- a/docs/site/backends/docs-builder-template/layouts/_partials/openapi/format-attributes.html
+++ b/docs/site/backends/docs-builder-template/layouts/_partials/openapi/format-attributes.html
@@ -7,7 +7,7 @@
 {{- $linkAnchor := .linkAnchor }}
 
 {{- $description :=  "" }}
-{{- if $langData.description }}
+{{- if and (reflect.IsMap $langData) $langData.description }}
   {{- $description = $langData.description }}
 {{- else }}
   {{- $description =  $attributes.description }}

--- a/docs/site/backends/docs-builder-template/layouts/_partials/openapi/format-configuration.html
+++ b/docs/site/backends/docs-builder-template/layouts/_partials/openapi/format-configuration.html
@@ -118,7 +118,7 @@ Context:
       {{- end }}
 
       {{- $propertyLangData := "" }}
-      {{- if and (reflect.IsMap $langData) $langData.properties }}
+      {{- if and (reflect.IsMap $langData) (reflect.IsMap $langData.properties) }}
         {{- $propertyLangData = index $langData.properties $property }}
       {{- end }}
       {{- partial "openapi/format-schema" ( dict "name" $property "data" $propertyData "langData" $propertyLangData "resourceName" "parameters" "type" "module_configuration") }}

--- a/docs/site/backends/docs-builder-template/layouts/_partials/openapi/format-configuration.html
+++ b/docs/site/backends/docs-builder-template/layouts/_partials/openapi/format-configuration.html
@@ -117,7 +117,10 @@ Context:
         {{- end }}
       {{- end }}
 
-      {{- $propertyLangData := index $langData.properties $property }}
+      {{- $propertyLangData := "" }}
+      {{- if and (reflect.IsMap $langData) $langData.properties }}
+        {{- $propertyLangData = index $langData.properties $property }}
+      {{- end }}
       {{- partial "openapi/format-schema" ( dict "name" $property "data" $propertyData "langData" $propertyLangData "resourceName" "parameters" "type" "module_configuration") }}
     {{- end }}
     </ul>

--- a/docs/site/backends/docs-builder-template/layouts/_partials/openapi/format-crd.html
+++ b/docs/site/backends/docs-builder-template/layouts/_partials/openapi/format-crd.html
@@ -76,7 +76,7 @@
         {{- end }}
         
         {{- $propertyLangData := "" }}
-        {{- if and (reflect.IsMap $langVersionData) $langVersionData.schema $langVersionData.schema.openAPIV3Schema $langVersionData.schema.openAPIV3Schema.properties }}
+        {{- if and (reflect.IsMap $langVersionData) (reflect.IsMap $langVersionData.schema) (reflect.IsMap $langVersionData.schema.openAPIV3Schema) (reflect.IsMap $langVersionData.schema.openAPIV3Schema.properties) }}
           {{- $propertyLangData = index $langVersionData.schema.openAPIV3Schema.properties $property }}
         {{- end }}
 

--- a/docs/site/backends/docs-builder-template/layouts/_partials/openapi/format-crd.html
+++ b/docs/site/backends/docs-builder-template/layouts/_partials/openapi/format-crd.html
@@ -44,9 +44,12 @@
 
     {{- $description :=  $versionSchema.description }}
     {{- $langVersionData := dict }}
-    {{- if $langData.spec.versions }}
-      {{- $langVersionData =  index (where $langData.spec.versions "name" "eq" $versionName) 0 }}
-      {{- if $langVersionData.schema.openAPIV3Schema.description }}{{ $description = $langVersionData.schema.openAPIV3Schema.description }}{{ end }}
+    {{- if and (reflect.IsMap $langData) $langData.spec $langData.spec.versions }}
+      {{- $matchedLangVersions := where $langData.spec.versions "name" "eq" $versionName }}
+      {{- if gt (len $matchedLangVersions) 0 }}
+        {{- $langVersionData = index $matchedLangVersions 0 }}
+      {{- end }}
+      {{- if and (reflect.IsMap $langVersionData) $langVersionData.schema $langVersionData.schema.openAPIV3Schema $langVersionData.schema.openAPIV3Schema.description }}{{ $description = $langVersionData.schema.openAPIV3Schema.description }}{{ end }}
     {{- end }}
 
     <div class="resources__prop_description">{{ partial "openapi/format-description" $description }}</div>
@@ -72,7 +75,10 @@
           {{- end }}
         {{- end }}
         
-        {{- $propertyLangData := index $langVersionData.schema.openAPIV3Schema.properties $property }}
+        {{- $propertyLangData := "" }}
+        {{- if and (reflect.IsMap $langVersionData) $langVersionData.schema $langVersionData.schema.openAPIV3Schema $langVersionData.schema.openAPIV3Schema.properties }}
+          {{- $propertyLangData = index $langVersionData.schema.openAPIV3Schema.properties $property }}
+        {{- end }}
 
         {{- $liClass := "" }}
         {{- if eq $property "spec" }}

--- a/docs/site/backends/docs-builder-template/layouts/_partials/openapi/format-schema.html
+++ b/docs/site/backends/docs-builder-template/layouts/_partials/openapi/format-schema.html
@@ -108,7 +108,7 @@
   <ul>
   {{- range $subParameterName, $subParameterAttributes := $data.properties }}
     {{- $subParameterLangData := "" }}
-    {{- if and (reflect.IsMap $langData) $langData.properties }}
+    {{- if and (reflect.IsMap $langData) (reflect.IsMap $langData.properties) }}
       {{- $subParameterLangData = index $langData.properties $subParameterName }}
     {{- end }}
 
@@ -130,7 +130,7 @@
     <ul>
     {{- range $subParameterName, $subParameterAttributes := $data.items.properties }}
       {{- $subParameterLangData := "" }}
-      {{- if and (reflect.IsMap $langData) (reflect.IsMap $langData.items) $langData.items.properties }}
+      {{- if and (reflect.IsMap $langData) (reflect.IsMap $langData.items) (reflect.IsMap $langData.items.properties) }}
         {{- $subParameterLangData = index $langData.items.properties $subParameterName }}
       {{- end }}
 
@@ -173,7 +173,10 @@
       {{- $additionalPropsData := $data.additionalProperties }}
       {{- $additionalPropsLangData := "" }}
       {{- if reflect.IsMap $langData }}
-        {{- $additionalPropsLangData = index $langData "additionalProperties" }}
+        {{- $indexedAdditionalPropsLangData := index $langData "additionalProperties" }}
+        {{- if reflect.IsMap $indexedAdditionalPropsLangData }}
+          {{- $additionalPropsLangData = $indexedAdditionalPropsLangData }}
+        {{- end }}
       {{- end }}
       {{- $additionalPropsRequired := $additionalPropsData.required }}
 
@@ -258,7 +261,7 @@
   {{- range $pattern, $patternSchema := $data.patternProperties }}
     {{- if reflect.IsMap $patternSchema }}
       {{- $patternLangData := dict }}
-      {{- if and (reflect.IsMap $langData) $langData.patternProperties }}
+      {{- if and (reflect.IsMap $langData) (reflect.IsMap $langData.patternProperties) }}
         {{- $indexedLangData := index $langData.patternProperties $pattern }}
         {{- if reflect.IsMap $indexedLangData }}
           {{- $patternLangData = $indexedLangData }}

--- a/docs/site/backends/docs-builder-template/layouts/_partials/openapi/format-schema.html
+++ b/docs/site/backends/docs-builder-template/layouts/_partials/openapi/format-schema.html
@@ -107,7 +107,10 @@
   {{- $requiredParameters := $data.required }}
   <ul>
   {{- range $subParameterName, $subParameterAttributes := $data.properties }}
-    {{- $subParameterLangData := index $langData.properties $subParameterName }}
+    {{- $subParameterLangData := "" }}
+    {{- if and (reflect.IsMap $langData) $langData.properties }}
+      {{- $subParameterLangData = index $langData.properties $subParameterName }}
+    {{- end }}
 
     {{/* Checking for x-doc-skip into child properties */}}
     {{- if reflect.IsMap $subParameterAttributes }}
@@ -126,7 +129,10 @@
     {{/* Array of objects */}}
     <ul>
     {{- range $subParameterName, $subParameterAttributes := $data.items.properties }}
-      {{- $subParameterLangData := index $langData.items.properties $subParameterName }}
+      {{- $subParameterLangData := "" }}
+      {{- if and (reflect.IsMap $langData) (reflect.IsMap $langData.items) $langData.items.properties }}
+        {{- $subParameterLangData = index $langData.items.properties $subParameterName }}
+      {{- end }}
 
       {{/* Checking for x-doc-skip for array items */}}
       {{- if reflect.IsMap $subParameterAttributes }}
@@ -148,8 +154,12 @@
     {{- range $key, $val := $data.items }}{{ if in $keysToShow $key }}{{ $keysToShowIsExist = true }}{{ end }}{{ end }}
 
     {{- if $keysToShowIsExist }}
+      {{- $itemsLangData := "" }}
+      {{- if reflect.IsMap $langData }}
+        {{- $itemsLangData = $langData.items }}
+      {{- end }}
       <ul>
-      {{- partial "openapi/format-schema" ( dict "name" "" "data" $data.items "langData" $langData.items "parent" $data "ancestors" $fullPath "apiVersion"  $apiVersion "resourceName" $resourceName "type" $type) }}
+      {{- partial "openapi/format-schema" ( dict "name" "" "data" $data.items "langData" $itemsLangData "parent" $data "ancestors" $fullPath "apiVersion"  $apiVersion "resourceName" $resourceName "type" $type) }}
       </ul>
     {{- end }}
 
@@ -161,7 +171,10 @@
 
     {{- if and (reflect.IsMap $data.additionalProperties) (not $data.properties) ($data.additionalProperties.properties) (or (not $data.additionalProperties.type) (eq $data.additionalProperties.type "object")) }} {{/* Render if additionalProperties is a schema object with properties (not primitive type) AND parent has no properties */}}
       {{- $additionalPropsData := $data.additionalProperties }}
-      {{- $additionalPropsLangData := index $langData "additionalProperties" }}
+      {{- $additionalPropsLangData := "" }}
+      {{- if reflect.IsMap $langData }}
+        {{- $additionalPropsLangData = index $langData "additionalProperties" }}
+      {{- end }}
       {{- $additionalPropsRequired := $additionalPropsData.required }}
 
       {{/* Checking for x-doc-skip for additionalProperties */}}
@@ -191,7 +204,7 @@
 
           {{- /* Get existing description if any */}}
           {{- $existingDescription := "" }}
-          {{- if $additionalPropsLangData.description }}
+          {{- if and (reflect.IsMap $additionalPropsLangData) $additionalPropsLangData.description }}
             {{- $existingDescription = $additionalPropsLangData.description }}
           {{- else if $additionalPropsData.description }}
             {{- $existingDescription = $additionalPropsData.description }}
@@ -219,7 +232,10 @@
       {{- end }}
     {{- else if and (reflect.IsMap $data.additionalProperties) ($data.additionalProperties.properties) }} {{/* Only render if additionalProperties is a schema object AND has properties (normal case when parent has properties) */}}
       {{- $additionalPropsData := $data.additionalProperties }}
-      {{- $additionalPropsLangData := index $langData "additionalProperties" }}
+      {{- $additionalPropsLangData := "" }}
+      {{- if reflect.IsMap $langData }}
+        {{- $additionalPropsLangData = index $langData "additionalProperties" }}
+      {{- end }}
       {{- $additionalPropsRequired := $additionalPropsData.required }}
 
       {{/* Checking for x-doc-skip for additionalProperties */}}


### PR DESCRIPTION
## Description

This pull request improves the robustness of the OpenAPI and CRD documentation extraction templates by adding additional type checks and nil-guards. These changes ensure that the templates handle missing or malformed language data gracefully, preventing runtime errors and improving compatibility with incomplete schemas.

## Why do we need it, and what problem does it solve?
Fix a bug when building OpenAPI schemas for modules documentation.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: fix
summary: Add nil-safety guards for OpenAPI extraction to prevent panics.
impact_level: low
```
