### PR TITLE
[dhctl] add network overlap preflight for static clusters

### DIFF
--- a/dhctl/pkg/app/options/preflight_known_checks.gen.go
+++ b/dhctl/pkg/app/options/preflight_known_checks.gen.go
@@ -10,6 +10,7 @@ var generatedPreflightChecks = []string{
 	"cloud-prefix",
 	"deckhouse-user",
 	"dhctl-edition",
+	"host-network-cidr-intersection",
 	"instance-class-provider",
 	"ports-availability",
 	"public-domain-template",

--- a/dhctl/pkg/preflight/checks/host_network_cidr_intersection.go
+++ b/dhctl/pkg/preflight/checks/host_network_cidr_intersection.go
@@ -1,0 +1,509 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checks
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/netip"
+	"strings"
+
+	libcon "github.com/deckhouse/lib-connection/pkg"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+	preflight "github.com/deckhouse/deckhouse/dhctl/pkg/preflight"
+)
+
+type HostNetworkCIDRIntersectionCheck struct {
+	MetaConfig    *config.MetaConfig
+	NodeInterface libcon.Interface
+}
+
+const HostNetworkCIDRIntersectionCheckName preflight.CheckName = "host-network-cidr-intersection"
+
+type detectedNetwork struct {
+	CIDR   string
+	Source string
+}
+
+type detectedAddress struct {
+	Address string
+	Source  string
+}
+
+type hostNetworkState struct {
+	Networks  []detectedNetwork
+	Addresses []detectedAddress
+}
+
+type ipAddressEntry struct {
+	InterfaceName string          `json:"ifname"`
+	Addresses     []ipAddressInfo `json:"addr_info"`
+}
+
+type ipAddressInfo struct {
+	Family       string `json:"family"`
+	LocalAddress string `json:"local"`
+	PrefixLength int    `json:"prefixlen"`
+}
+
+type ipRouteEntry struct {
+	Destination string `json:"dst"`
+	Gateway     string `json:"gateway"`
+	Device      string `json:"dev"`
+}
+
+func (HostNetworkCIDRIntersectionCheck) Description() string {
+	return "cluster CIDRs do not intersect with host networks"
+}
+
+func (HostNetworkCIDRIntersectionCheck) Phase() preflight.Phase {
+	return preflight.PhasePostInfra
+}
+
+func (HostNetworkCIDRIntersectionCheck) RetryPolicy() preflight.RetryPolicy {
+	return preflight.DefaultRetryPolicy
+}
+
+func (c HostNetworkCIDRIntersectionCheck) Run(ctx context.Context) error {
+	if c.MetaConfig == nil {
+		return fmt.Errorf("metaConfig is required")
+	}
+	if c.NodeInterface == nil {
+		return fmt.Errorf("node interface is required")
+	}
+
+	podCIDR, serviceCIDR, err := getCIDRs(c.MetaConfig)
+	if err != nil {
+		return err
+	}
+
+	host, err := collectHostNetworkState(ctx, c.NodeInterface)
+	if err != nil {
+		return err
+	}
+
+	return checkClusterCIDRsAgainstHost(
+		podCIDR,
+		serviceCIDR,
+		host,
+	)
+}
+
+func collectHostNetworkState(
+	ctx context.Context,
+	nodeInterface libcon.Interface,
+) (hostNetworkState, error) {
+	var state hostNetworkState
+
+	addressOutput, err := hostCommandOutput(
+		ctx,
+		nodeInterface,
+		"ip",
+		"-j",
+		"address",
+		"show",
+	)
+	if err != nil {
+		return hostNetworkState{}, err
+	}
+
+	networks, err := parseIPAddresses(addressOutput)
+	if err != nil {
+		return hostNetworkState{}, err
+	}
+	state.Networks = append(state.Networks, networks...)
+
+	for _, family := range []string{"-4", "-6"} {
+		routeOutput, err := hostCommandOutput(
+			ctx,
+			nodeInterface,
+			"ip",
+			"-j",
+			family,
+			"route",
+			"show",
+			"table",
+			"all",
+		)
+		if err != nil {
+			return hostNetworkState{}, err
+		}
+
+		routeState, err := parseIPRoutes(routeOutput)
+		if err != nil {
+			return hostNetworkState{}, err
+		}
+
+		state.Networks = append(
+			state.Networks,
+			routeState.Networks...,
+		)
+		state.Addresses = append(
+			state.Addresses,
+			routeState.Addresses...,
+		)
+	}
+
+	resolvConfOutput, err := hostCommandOutput(
+		ctx,
+		nodeInterface,
+		"cat",
+		"/etc/resolv.conf",
+	)
+	if err != nil {
+		return hostNetworkState{}, err
+	}
+
+	nameservers, err := parseResolvConf(resolvConfOutput)
+	if err != nil {
+		return hostNetworkState{}, err
+	}
+	state.Addresses = append(state.Addresses, nameservers...)
+
+	return state, nil
+}
+
+func hostCommandOutput(
+	ctx context.Context,
+	nodeInterface libcon.Interface,
+	name string,
+	args ...string,
+) ([]byte, error) {
+	command := nodeInterface.Command(name, args...)
+
+	stdout, stderr, err := command.Output(ctx)
+	if err == nil {
+		return stdout, nil
+	}
+
+	stderrMessage := strings.TrimSpace(string(stderr))
+	if stderrMessage == "" {
+		return nil, fmt.Errorf(
+			"execute host command %s: %w",
+			name,
+			err,
+		)
+	}
+
+	return nil, fmt.Errorf(
+		"execute host command %s: %w: %s",
+		name,
+		err,
+		stderrMessage,
+	)
+}
+
+func checkClusterCIDRsAgainstHost(
+	podCIDR string,
+	serviceCIDR string,
+	host hostNetworkState,
+) error {
+	clusterNetworks := []struct {
+		name string
+		cidr string
+	}{
+		{
+			name: "podSubnetCIDR",
+			cidr: podCIDR,
+		},
+		{
+			name: "serviceSubnetCIDR",
+			cidr: serviceCIDR,
+		},
+	}
+
+	for _, clusterNetwork := range clusterNetworks {
+		clusterPrefix, err := netip.ParsePrefix(clusterNetwork.cidr)
+		if err != nil {
+			return fmt.Errorf(
+				"invalid %s %q: %w",
+				clusterNetwork.name,
+				clusterNetwork.cidr,
+				err,
+			)
+		}
+		clusterPrefix = clusterPrefix.Masked()
+
+		for _, detected := range host.Networks {
+			detectedPrefix, err := netip.ParsePrefix(detected.CIDR)
+			if err != nil {
+				return fmt.Errorf(
+					"invalid CIDR %q discovered from %s: %w",
+					detected.CIDR,
+					detected.Source,
+					err,
+				)
+			}
+
+			if clusterPrefix.Overlaps(detectedPrefix.Masked()) {
+				return fmt.Errorf(
+					"%s %s intersects with %s %s",
+					clusterNetwork.name,
+					clusterNetwork.cidr,
+					detected.Source,
+					detected.CIDR,
+				)
+			}
+		}
+
+		for _, detected := range host.Addresses {
+			detectedAddress, err := netip.ParseAddr(detected.Address)
+			if err != nil {
+				return fmt.Errorf(
+					"invalid IP address %q discovered from %s: %w",
+					detected.Address,
+					detected.Source,
+					err,
+				)
+			}
+
+			if clusterPrefix.Contains(detectedAddress) {
+				return fmt.Errorf(
+					"%s %s contains %s %s",
+					clusterNetwork.name,
+					clusterNetwork.cidr,
+					detected.Source,
+					detected.Address,
+				)
+			}
+		}
+	}
+
+	return nil
+}
+
+func parseIPAddresses(output []byte) ([]detectedNetwork, error) {
+	var entries []ipAddressEntry
+	if err := json.Unmarshal(output, &entries); err != nil {
+		return nil, fmt.Errorf("parse ip address output: %w", err)
+	}
+
+	var networks []detectedNetwork
+
+	for _, entry := range entries {
+		for _, addressInfo := range entry.Addresses {
+			if addressInfo.Family != "inet" &&
+				addressInfo.Family != "inet6" {
+				continue
+			}
+
+			address, err := netip.ParseAddr(addressInfo.LocalAddress)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"parse address %q on interface %s: %w",
+					addressInfo.LocalAddress,
+					entry.InterfaceName,
+					err,
+				)
+			}
+
+			if addressInfo.PrefixLength < 0 ||
+				addressInfo.PrefixLength > address.BitLen() {
+				return nil, fmt.Errorf(
+					"invalid prefix length %d for address %s on interface %s",
+					addressInfo.PrefixLength,
+					addressInfo.LocalAddress,
+					entry.InterfaceName,
+				)
+			}
+
+			prefix := netip.PrefixFrom(
+				address,
+				addressInfo.PrefixLength,
+			).Masked()
+
+			networks = append(networks, detectedNetwork{
+				CIDR:   prefix.String(),
+				Source: "interface " + entry.InterfaceName,
+			})
+		}
+	}
+
+	return networks, nil
+}
+
+func parseIPRoutes(output []byte) (hostNetworkState, error) {
+	var routes []ipRouteEntry
+	if err := json.Unmarshal(output, &routes); err != nil {
+		return hostNetworkState{}, fmt.Errorf(
+			"parse ip route output: %w",
+			err,
+		)
+	}
+
+	var state hostNetworkState
+
+	for _, route := range routes {
+		if route.Destination == "default" {
+			if err := addDefaultGateway(&state, route); err != nil {
+				return hostNetworkState{}, err
+			}
+			continue
+		}
+
+		if route.Destination == "" {
+			continue
+		}
+
+		prefix, err := parseRouteDestination(route.Destination)
+		if err != nil {
+			return hostNetworkState{}, err
+		}
+
+		// Some ip versions may represent the default route
+		// as 0.0.0.0/0 or ::/0.
+		if prefix.Bits() == 0 {
+			if err := addDefaultGateway(&state, route); err != nil {
+				return hostNetworkState{}, err
+			}
+			continue
+		}
+
+		source := "route"
+		if route.Device != "" {
+			source += " via " + route.Device
+		}
+
+		state.Networks = append(state.Networks, detectedNetwork{
+			CIDR:   prefix.Masked().String(),
+			Source: source,
+		})
+	}
+
+	return state, nil
+}
+
+func addDefaultGateway(
+	state *hostNetworkState,
+	route ipRouteEntry,
+) error {
+	if route.Gateway == "" {
+		return nil
+	}
+
+	gateway, err := netip.ParseAddr(route.Gateway)
+	if err != nil {
+		return fmt.Errorf(
+			"parse default gateway %q: %w",
+			route.Gateway,
+			err,
+		)
+	}
+
+	source := "default gateway"
+	if route.Device != "" {
+		source += " via " + route.Device
+	}
+
+	state.Addresses = append(
+		state.Addresses,
+		detectedAddress{
+			Address: gateway.String(),
+			Source:  source,
+		},
+	)
+
+	return nil
+}
+
+func parseRouteDestination(destination string) (netip.Prefix, error) {
+	if prefix, err := netip.ParsePrefix(destination); err == nil {
+		return prefix.Masked(), nil
+	}
+
+	// Host routes may be returned without /32 or /128.
+	address, err := netip.ParseAddr(destination)
+	if err != nil {
+		return netip.Prefix{}, fmt.Errorf(
+			"parse route destination %q: %w",
+			destination,
+			err,
+		)
+	}
+
+	return netip.PrefixFrom(address, address.BitLen()), nil
+}
+
+func parseResolvConf(output []byte) ([]detectedAddress, error) {
+	scanner := bufio.NewScanner(bytes.NewReader(output))
+
+	var addresses []detectedAddress
+	lineNumber := 0
+
+	for scanner.Scan() {
+		lineNumber++
+
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" ||
+			strings.HasPrefix(line, "#") ||
+			strings.HasPrefix(line, ";") {
+			continue
+		}
+
+		fields := strings.Fields(line)
+		if len(fields) < 2 || fields[0] != "nameserver" {
+			continue
+		}
+
+		address, err := netip.ParseAddr(fields[1])
+		if err != nil {
+			return nil, fmt.Errorf(
+				"parse nameserver %q on line %d: %w",
+				fields[1],
+				lineNumber,
+				err,
+			)
+		}
+
+		// A scoped IPv6 address may contain an interface zone,
+		// but cluster CIDRs do not have zones.
+		if address.Zone() != "" {
+			address = address.WithZone("")
+		}
+
+		addresses = append(addresses, detectedAddress{
+			Address: address.String(),
+			Source:  "DNS server",
+		})
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan resolv.conf: %w", err)
+	}
+
+	return addresses, nil
+}
+
+func HostNetworkCIDRIntersection(
+	metaConfig *config.MetaConfig,
+	nodeInterface libcon.Interface,
+) preflight.Check {
+	check := HostNetworkCIDRIntersectionCheck{
+		MetaConfig:    metaConfig,
+		NodeInterface: nodeInterface,
+	}
+
+	return preflight.Check{
+		Name:        HostNetworkCIDRIntersectionCheckName,
+		Description: check.Description(),
+		Phase:       check.Phase(),
+		Retry:       check.RetryPolicy(),
+		Run:         check.Run,
+	}
+}

--- a/dhctl/pkg/preflight/checks/host_network_cidr_intersection_test.go
+++ b/dhctl/pkg/preflight/checks/host_network_cidr_intersection_test.go
@@ -1,0 +1,433 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checks
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/preflight/checks/mocks"
+)
+
+func TestCheckClusterCIDRsAgainstHost(t *testing.T) {
+	tests := []struct {
+		name              string
+		podCIDR           string
+		serviceCIDR       string
+		host              hostNetworkState
+		wantError         string
+		wantErrorContains string
+	}{
+		{
+			name:        "no intersections",
+			podCIDR:     "10.111.0.0/16",
+			serviceCIDR: "10.222.0.0/16",
+			host: hostNetworkState{
+				Networks: []detectedNetwork{
+					{
+						CIDR:   "192.168.1.0/24",
+						Source: "interface eth0",
+					},
+				},
+			},
+		},
+		{
+			name:        "service CIDR contains DNS server",
+			podCIDR:     "10.111.0.0/16",
+			serviceCIDR: "10.222.0.0/16",
+			host: hostNetworkState{
+				Addresses: []detectedAddress{
+					{
+						Address: "10.222.0.10",
+						Source:  "DNS server",
+					},
+				},
+			},
+			wantError: "serviceSubnetCIDR 10.222.0.0/16 contains DNS server 10.222.0.10",
+		},
+		{
+			name:        "pod CIDR intersects interface network",
+			podCIDR:     "10.111.0.0/16",
+			serviceCIDR: "10.222.0.0/16",
+			host: hostNetworkState{
+				Networks: []detectedNetwork{
+					{
+						CIDR:   "10.111.10.0/24",
+						Source: "interface eth0",
+					},
+				},
+			},
+			wantError: "podSubnetCIDR 10.111.0.0/16 intersects with interface eth0 10.111.10.0/24",
+		},
+		{
+			name:        "service CIDR intersects route",
+			podCIDR:     "10.111.0.0/16",
+			serviceCIDR: "10.222.0.0/16",
+			host: hostNetworkState{
+				Networks: []detectedNetwork{
+					{
+						CIDR:   "10.222.128.0/24",
+						Source: "route via eth1",
+					},
+				},
+			},
+			wantError: "serviceSubnetCIDR 10.222.0.0/16 intersects with route via eth1 10.222.128.0/24",
+		},
+		{
+			name:        "pod CIDR contains default gateway",
+			podCIDR:     "10.111.0.0/16",
+			serviceCIDR: "10.222.0.0/16",
+			host: hostNetworkState{
+				Addresses: []detectedAddress{
+					{
+						Address: "10.111.0.1",
+						Source:  "default gateway",
+					},
+				},
+			},
+			wantError: "podSubnetCIDR 10.111.0.0/16 contains default gateway 10.111.0.1",
+		},
+		{
+			name:        "IPv6 networks intersect",
+			podCIDR:     "fd00:111::/64",
+			serviceCIDR: "fd00:222::/112",
+			host: hostNetworkState{
+				Networks: []detectedNetwork{
+					{
+						CIDR:   "fd00:111::1000/120",
+						Source: "interface eth0",
+					},
+				},
+			},
+			wantError: "podSubnetCIDR fd00:111::/64 intersects with interface eth0 fd00:111::1000/120",
+		},
+		{
+			name:        "invalid discovered network",
+			podCIDR:     "10.111.0.0/16",
+			serviceCIDR: "10.222.0.0/16",
+			host: hostNetworkState{
+				Networks: []detectedNetwork{
+					{
+						CIDR:   "not-a-cidr",
+						Source: "interface eth0",
+					},
+				},
+			},
+			wantErrorContains: `invalid CIDR "not-a-cidr" discovered from interface eth0`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := checkClusterCIDRsAgainstHost(
+				tt.podCIDR,
+				tt.serviceCIDR,
+				tt.host,
+			)
+
+			switch {
+			case tt.wantError != "":
+				assert.EqualError(t, err, tt.wantError)
+			case tt.wantErrorContains != "":
+				assert.ErrorContains(t, err, tt.wantErrorContains)
+			default:
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestParseIPAddresses(t *testing.T) {
+	output := []byte(`[
+		{
+			"ifname": "eth0",
+			"addr_info": [
+				{
+					"family": "inet",
+					"local": "192.168.10.15",
+					"prefixlen": 24
+				},
+				{
+					"family": "inet6",
+					"local": "fd00:10::15",
+					"prefixlen": 64
+				}
+			]
+		},
+		{
+			"ifname": "eth1",
+			"addr_info": [
+				{
+					"family": "inet",
+					"local": "172.16.5.10",
+					"prefixlen": 16
+				}
+			]
+		}
+	]`)
+
+	networks, err := parseIPAddresses(output)
+
+	assert.NoError(t, err)
+	assert.Equal(t, []detectedNetwork{
+		{
+			CIDR:   "192.168.10.0/24",
+			Source: "interface eth0",
+		},
+		{
+			CIDR:   "fd00:10::/64",
+			Source: "interface eth0",
+		},
+		{
+			CIDR:   "172.16.0.0/16",
+			Source: "interface eth1",
+		},
+	}, networks)
+}
+
+func TestParseIPRoutes(t *testing.T) {
+	output := []byte(`[
+		{
+			"dst": "default",
+			"gateway": "192.168.10.1",
+			"dev": "eth0"
+		},
+		{
+			"dst": "10.50.0.0/16",
+			"gateway": "192.168.10.2",
+			"dev": "eth0"
+		},
+		{
+			"dst": "203.0.113.42",
+			"dev": "eth1"
+		},
+		{
+			"dst": "fd00:50::/64",
+			"dev": "eth2"
+		}
+	]`)
+
+	state, err := parseIPRoutes(output)
+
+	assert.NoError(t, err)
+	assert.Equal(t, []detectedNetwork{
+		{
+			CIDR:   "10.50.0.0/16",
+			Source: "route via eth0",
+		},
+		{
+			CIDR:   "203.0.113.42/32",
+			Source: "route via eth1",
+		},
+		{
+			CIDR:   "fd00:50::/64",
+			Source: "route via eth2",
+		},
+	}, state.Networks)
+
+	assert.Equal(t, []detectedAddress{
+		{
+			Address: "192.168.10.1",
+			Source:  "default gateway via eth0",
+		},
+	}, state.Addresses)
+}
+
+func TestParseResolvConf(t *testing.T) {
+	output := []byte(`
+# Generated by systemd-resolved
+search example.internal
+nameserver 10.222.0.10
+nameserver 1.1.1.1 # public DNS
+nameserver fd00:53::1
+options edns0 trust-ad
+`)
+
+	addresses, err := parseResolvConf(output)
+
+	assert.NoError(t, err)
+	assert.Equal(t, []detectedAddress{
+		{
+			Address: "10.222.0.10",
+			Source:  "DNS server",
+		},
+		{
+			Address: "1.1.1.1",
+			Source:  "DNS server",
+		},
+		{
+			Address: "fd00:53::1",
+			Source:  "DNS server",
+		},
+	}, addresses)
+}
+
+func TestHostNetworkCIDRIntersectionCheck_Run(t *testing.T) {
+	nodeInterface := &mocks.MockNodeInterface{}
+
+	commands := []*mocks.MockCommand{
+		expectHostCommand(
+			nodeInterface,
+			"ip",
+			[]string{"-j", "address", "show"},
+			`[
+				{
+					"ifname": "eth0",
+					"addr_info": [
+						{
+							"family": "inet",
+							"local": "192.168.10.15",
+							"prefixlen": 24
+						}
+					]
+				}
+			]`,
+		),
+		expectHostCommand(
+			nodeInterface,
+			"ip",
+			[]string{
+				"-j",
+				"-4",
+				"route",
+				"show",
+				"table",
+				"all",
+			},
+			`[
+				{
+					"dst": "default",
+					"gateway": "192.168.10.1",
+					"dev": "eth0"
+				},
+				{
+					"dst": "192.168.10.0/24",
+					"dev": "eth0"
+				}
+			]`,
+		),
+		expectHostCommand(
+			nodeInterface,
+			"ip",
+			[]string{
+				"-j",
+				"-6",
+				"route",
+				"show",
+				"table",
+				"all",
+			},
+			`[]`,
+		),
+		expectHostCommand(
+			nodeInterface,
+			"cat",
+			[]string{"/etc/resolv.conf"},
+			`
+				search parent-cluster.local
+				nameserver 10.222.0.10
+			`,
+		),
+	}
+
+	check := HostNetworkCIDRIntersectionCheck{
+		MetaConfig: &config.MetaConfig{
+			ClusterConfig: map[string]json.RawMessage{
+				"podSubnetCIDR":     []byte(`"10.111.0.0/16"`),
+				"serviceSubnetCIDR": []byte(`"10.222.0.0/16"`),
+			},
+		},
+		NodeInterface: nodeInterface,
+	}
+
+	err := check.Run(t.Context())
+
+	assert.EqualError(
+		t,
+		err,
+		"serviceSubnetCIDR 10.222.0.0/16 contains DNS server 10.222.0.10",
+	)
+
+	nodeInterface.AssertExpectations(t)
+	for _, command := range commands {
+		command.AssertExpectations(t)
+	}
+}
+
+func expectHostCommand(
+	nodeInterface *mocks.MockNodeInterface,
+	name string,
+	args []string,
+	stdout string,
+) *mocks.MockCommand {
+	command := &mocks.MockCommand{}
+
+	nodeInterface.
+		On("Command", name, args).
+		Return(command).
+		Once()
+
+	command.
+		On("Output", mock.Anything).
+		Return([]byte(stdout), []byte{}, nil).
+		Once()
+
+	return command
+}
+
+func TestHostCommandOutputReturnsCommandError(t *testing.T) {
+	nodeInterface := &mocks.MockNodeInterface{}
+	command := &mocks.MockCommand{}
+
+	nodeInterface.
+		On(
+			"Command",
+			"ip",
+			[]string{"-j", "address", "show"},
+		).
+		Return(command).
+		Once()
+
+	command.
+		On("Output", mock.Anything).
+		Return(
+			[]byte{},
+			[]byte("ip: command not found"),
+			errors.New("exit status 127"),
+		).
+		Once()
+
+	output, err := hostCommandOutput(
+		t.Context(),
+		nodeInterface,
+		"ip",
+		"-j",
+		"address",
+		"show",
+	)
+
+	assert.Nil(t, output)
+	assert.ErrorContains(t, err, "execute host command ip")
+	assert.ErrorContains(t, err, "exit status 127")
+	assert.ErrorContains(t, err, "ip: command not found")
+
+	nodeInterface.AssertExpectations(t)
+	command.AssertExpectations(t)
+}

--- a/dhctl/pkg/preflight/suites/static.go
+++ b/dhctl/pkg/preflight/suites/static.go
@@ -48,6 +48,7 @@ func NewStaticSuite(deps StaticDeps, ctx context.Context) (preflight.Suite, erro
 		checks.SudoAllowed(nodeInterface),
 		checks.SSHTunnel(deps.SSHProviderInitializer, deps.GlobalOpts),
 		checks.StaticInstancesSSHAccess(deps.MetaConfig, deps.SSHProviderInitializer),
+		checks.HostNetworkCIDRIntersection(deps.MetaConfig, nodeInterface),
 		checks.DeckhouseUser(nodeInterface, deps.GlobalOpts),
 		checks.StaticSystemRequirements(deps.SSHProviderInitializer, deps.InstallConfig),
 		checks.Python(nodeInterface),


### PR DESCRIPTION
## Description

Adds a post-infra preflight check for static cluster bootstrap that detects overlaps between the configured cluster networks and the existing network environment of the target host.

The check collects the following information from the target host:

- IPv4 and IPv6 networks configured on network interfaces;
- IPv4 and IPv6 routes;
- default gateway addresses;
- DNS server addresses from /etc/resolv.conf.

It compares the discovered networks and addresses with podSubnetCIDR and serviceSubnetCIDR. If an overlap is found, dhctl stops the bootstrap and reports the conflicting CIDR, address, and its source.

The check runs only for static clusters after SSH access to the target host is available. It does not contain DVP-specific logic and can be used for static machines running in any infrastructure.

This change does not restart or otherwise affect any components of existing clusters. It only changes validation during a new static cluster bootstrap.

Parent cluster discovery, clusterDomain validation, and cloud-cluster integration are outside the scope of this change.

## Why do we need it, and what problem does it solve?

When a static machine is created inside an existing DVP cluster or another user-managed infrastructure, the configured pod or service CIDRs of the new cluster may overlap with networks and infrastructure addresses already used by that machine.

For example, the machine may use 10.222.0.10 as its DNS server while the new cluster is configured with serviceSubnetCIDR: 10.222.0.0/16. After the service network is configured, traffic to the existing DNS server may be intercepted as traffic to a Service of the new cluster. DNS resolution then stops working, images cannot be pulled, and the bootstrap fails later with non-obvious errors such as ImagePullBackOff.

Previously, dhctl could only compare cluster CIDRs with networks explicitly specified in the static configuration. It did not inspect the actual network environment of the target host.

The new preflight check detects such conflicts before the cluster network is configured and reports the original cause directly to the user.

## Why do we need it in the patch release (if we do)?

Not necessarily. This is preventive validation for new static cluster installations and does not fix the runtime behavior of existing clusters.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: dhctl
type: feature 
summary: Added a preflight check that prevents static cluster bootstrap when pod or service CIDRs overlap with the target host network.
impact_level: default 
```
