### PR TITLE
[node-manager] fix: annotate CAPI MachineDeployments with CPU/memory capacity for scale-from-zero

### DIFF
--- a/modules/040-node-manager/e2e/cluster-autoscaler/tests/ca-scale-from-zero-node-label-dvp/chainsaw-test.yaml
+++ b/modules/040-node-manager/e2e/cluster-autoscaler/tests/ca-scale-from-zero-node-label-dvp/chainsaw-test.yaml
@@ -137,9 +137,9 @@ spec:
           sleep:
             duration: 15s
 
-    - name: verify-machine-deployment-labels-annotation
+    - name: verify-machine-deployment-capacity-annotations
       try:
-        - description: Check that MachineDeployment has node.deckhouse.io/group in capacity labels annotation
+        - description: Check MachineDeployment scale-from-zero labels, CPU, and memory annotations
           script:
             timeout: 300s
             content: |
@@ -149,18 +149,21 @@ spec:
                   -l node-group=e2e-worker-infra --no-headers \
                   -o custom-columns=':metadata.name' 2>/dev/null | head -1)
                 if [ -n "$MD_NAME" ]; then
-                  LABELS_ANN=$(kubectl get machinedeployments.cluster.x-k8s.io -n d8-cloud-instance-manager \
-                    "$MD_NAME" -o jsonpath='{.metadata.annotations.capacity\.cluster-autoscaler\.kubernetes\.io/labels}' 2>/dev/null || echo "")
-                  if echo "$LABELS_ANN" | grep -q "node.deckhouse.io/group=e2e-worker-infra"; then
-                    echo "Found node.deckhouse.io/group=e2e-worker-infra in capacity labels annotation"
+                  MD_JSON=$(kubectl get machinedeployments.cluster.x-k8s.io -n d8-cloud-instance-manager \
+                    "$MD_NAME" -o json 2>/dev/null || echo '{}')
+                  LABELS_ANN=$(echo "$MD_JSON" | jq -r '.metadata.annotations["capacity.cluster-autoscaler.kubernetes.io/labels"] // ""')
+                  CPU_ANN=$(echo "$MD_JSON" | jq -r '.metadata.annotations["capacity.cluster-autoscaler.kubernetes.io/cpu"] // ""')
+                  MEMORY_ANN=$(echo "$MD_JSON" | jq -r '.metadata.annotations["capacity.cluster-autoscaler.kubernetes.io/memory"] // ""')
+                  if echo "$LABELS_ANN" | grep -q "node.deckhouse.io/group=e2e-worker-infra" \
+                    && [ "$CPU_ANN" = "2" ] && [ "$MEMORY_ANN" = "4Gi" ]; then
+                    echo "Found expected labels, CPU, and memory capacity annotations"
                     exit 0
                   fi
-                  echo "Annotation content: $LABELS_ANN"
+                  echo "Annotations: labels=$LABELS_ANN cpu=$CPU_ANN memory=$MEMORY_ANN"
                 fi
                 sleep 10
               done
-              echo "Timed out: node.deckhouse.io/group not found in MachineDeployment capacity labels annotation"
-              echo "This indicates the PR #20174 fix is not applied"
+              echo "Timed out: expected MachineDeployment scale-from-zero capacity annotations were not found"
               exit 1
             check:
               ($error == null): true

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/capi/capi_cloud.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/capi/capi_cloud.go
@@ -41,6 +41,7 @@ import (
 
 type capiMDInput struct {
 	ng                  *deckhousev1.NodeGroup
+	resolved            derived_status.ResolvedNodeGroup
 	mdName              string
 	templateName        string
 	bootstrapSecretName string
@@ -65,6 +66,14 @@ func buildCAPIMachineDeployment(in capiMDInput) *unstructured.Unstructured {
 	}
 	if s := serializeNodeGroupTaints(in.ng); s != "" {
 		annotations["capacity.cluster-autoscaler.kubernetes.io/taints"] = s
+	}
+	if nodeCapacity, _ := in.resolved.NodeCapacity.(map[string]interface{}); nodeCapacity != nil {
+		if cpu := nestedString(nodeCapacity, "cpu"); cpu != "" {
+			annotations["capacity.cluster-autoscaler.kubernetes.io/cpu"] = cpu
+		}
+		if memory := nestedString(nodeCapacity, "memory"); memory != "" {
+			annotations["capacity.cluster-autoscaler.kubernetes.io/memory"] = memory
+		}
 	}
 
 	// Separate instances on purpose: the provider spec patch is deep-merged into spec below,
@@ -397,6 +406,7 @@ func (r *MachineDeploymentReconciler) reconcileCloudMDsRendered(ctx context.Cont
 
 		md := buildCAPIMachineDeployment(capiMDInput{
 			ng:                  ng,
+			resolved:            resolved,
 			mdName:              mdName,
 			templateName:        templateName,
 			bootstrapSecretName: bootstrapSecretName,

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/capi/envtest_md_test.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/capi/envtest_md_test.go
@@ -47,7 +47,13 @@ var _ = Describe("CAPI MachineDeployment rendering", func() {
 		ic.SetAPIVersion("deckhouse.io/v1alpha1")
 		ic.SetKind("DVPInstanceClass")
 		ic.SetName(icName)
-		Expect(unstructured.SetNestedField(ic.Object, "test", "spec", "vmClassName")).To(Succeed())
+		Expect(unstructured.SetNestedMap(ic.Object, map[string]interface{}{
+			"cpu": map[string]interface{}{
+				"cores":        int64(4),
+				"coreFraction": "100%",
+			},
+			"memory": map[string]interface{}{"size": "8Gi"},
+		}, "spec", "virtualMachine")).To(Succeed())
 		return ic
 	}
 
@@ -107,6 +113,26 @@ var _ = Describe("CAPI MachineDeployment rendering", func() {
 			Namespace: common.MachineNamespace, Name: infraRef.Name,
 		}, mt)).To(Succeed())
 		Expect(mt.GetLabels()).To(HaveKeyWithValue("node-group", ng.Name))
+	})
+
+	It("publishes CPU and memory capacity for scale-from-zero", func() {
+		Expect(client.IgnoreAlreadyExists(k8sClient.Create(suiteCtx, newInstanceClass()))).To(Succeed())
+
+		ng := newNodeGroup(testenv.UniqueName("cap-zero"))
+		ng.Spec.CloudInstances.MinPerZone = 0
+		Expect(k8sClient.Create(suiteCtx, ng)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(suiteCtx, ng) })
+
+		Eventually(func(g Gomega) map[string]string {
+			mdList := &capiv1beta2.MachineDeploymentList{}
+			g.Expect(k8sClient.List(suiteCtx, mdList, client.InNamespace(common.MachineNamespace),
+				client.MatchingLabels{"node-group": ng.Name})).To(Succeed())
+			g.Expect(mdList.Items).To(HaveLen(1))
+			return mdList.Items[0].Annotations
+		}, 20*time.Second, 250*time.Millisecond).Should(SatisfyAll(
+			HaveKeyWithValue("capacity.cluster-autoscaler.kubernetes.io/cpu", "4"),
+			HaveKeyWithValue("capacity.cluster-autoscaler.kubernetes.io/memory", "8Gi"),
+		))
 	})
 
 	// Before the migration helm rendered the infrastructure template and pruned it when the

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/capi/machinedeployment_test.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/capi/machinedeployment_test.go
@@ -21,8 +21,10 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	deckhousev1 "github.com/deckhouse/node-controller/api/deckhouse.io/v1"
+	"github.com/deckhouse/node-controller/internal/controller/nodegroup/derived_status"
 )
 
 func ptr[T any](v T) *T { return &v }
@@ -190,6 +192,30 @@ func TestSerializeNodeGroupTaints(t *testing.T) {
 			t.Fatalf("taints not sorted: %q", got)
 		}
 	})
+}
+
+func TestBuildCAPIMachineDeploymentScaleFromZeroCapacity(t *testing.T) {
+	ng := &deckhousev1.NodeGroup{}
+	ng.Name = "worker"
+	resolved := derived_status.ResolvedNodeGroup{
+		NodeCapacity: map[string]interface{}{"cpu": "4", "memory": "8Gi"},
+	}
+
+	md := buildCAPIMachineDeployment(capiMDInput{ng: ng, resolved: resolved})
+	annotations := md.Object["metadata"].(map[string]interface{})["annotations"].(map[string]interface{})
+
+	for key, want := range map[string]string{
+		"capacity.cluster-autoscaler.kubernetes.io/cpu":    "4",
+		"capacity.cluster-autoscaler.kubernetes.io/memory": "8Gi",
+	} {
+		got, ok := annotations[key].(string)
+		if !ok || got != want {
+			t.Fatalf("annotation %q = %v, want %q", key, annotations[key], want)
+		}
+		if _, err := resource.ParseQuantity(got); err != nil {
+			t.Fatalf("annotation %q has invalid Kubernetes quantity %q: %v", key, got, err)
+		}
+	}
 }
 
 func TestApplyMachineDeploymentSpecPatch(t *testing.T) {


### PR DESCRIPTION
## Description
This PR fixes node-manager's CAPI bug: annotate CAPI MachineDeployments with CPU/memory capacity for scale-from-zero.

## Why do we need it, and what problem does it solve?
Without these annotations CA silently drops zero-sized groups from discovery.

## Why do we need it in the patch release (if we do)?
Not necessarily.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: node-manager
type: fix
summary: Annotate CAPI MachineDeployments with CPU/memory capacity for scale-from-zero
impact_level: default
```