### PR TITLE
[docs] Fix ModuleUpdatePolicy example in release channel FAQ

### DIFF
--- a/docs/documentation/_faq/admin/CHANGE_MODULE_RELEASE_CHANNEL.md
+++ b/docs/documentation/_faq/admin/CHANGE_MODULE_RELEASE_CHANNEL.md
@@ -26,11 +26,11 @@ To change the release channel for a module from a source, follow these steps:
      name: my-module-policy
    spec:
      releaseChannel: Alpha
-     # If necessary, specify the update mode and update windows.
-     # update:
-     #   mode: AutoPatch
-     #   windows: []
+     update:
+       mode: Auto
    ```
+
+   If necessary, change the [update mode](./reference/api/cr.html#moduleupdatepolicy-v1alpha2-spec-update-mode) and configure [update windows](./reference/api/cr.html#moduleupdatepolicy-v1alpha2-spec-update-windows).
 
    Ensure that the policy has been created:
 

--- a/docs/documentation/_faq/admin/CHANGE_MODULE_RELEASE_CHANNEL_RU.md
+++ b/docs/documentation/_faq/admin/CHANGE_MODULE_RELEASE_CHANNEL_RU.md
@@ -29,7 +29,7 @@ lang: ru
      update:
        mode: Auto
    ```
-   
+
    При необходимости измените [режим обновления](./reference/api/cr.html#moduleupdatepolicy-v1alpha2-spec-update-mode) и настройте [окна обновлений](./reference/api/cr.html#moduleupdatepolicy-v1alpha2-spec-update-windows).
 
    Убедитесь, что политика создана:

--- a/docs/documentation/_faq/admin/CHANGE_MODULE_RELEASE_CHANNEL_RU.md
+++ b/docs/documentation/_faq/admin/CHANGE_MODULE_RELEASE_CHANNEL_RU.md
@@ -26,11 +26,11 @@ lang: ru
      name: my-module-policy
    spec:
      releaseChannel: Alpha
-     # При необходимости, укажите режим обновления и окна обновления.
-     # update:
-     #   mode: AutoPatch
-     #   windows: []
+     update:
+       mode: Auto
    ```
+   
+   При необходимости измените [режим обновления](./reference/api/cr.html#moduleupdatepolicy-v1alpha2-spec-update-mode) и настройте [окна обновлений](./reference/api/cr.html#moduleupdatepolicy-v1alpha2-spec-update-windows).
 
    Убедитесь, что политика создана:
 


### PR DESCRIPTION
## Description

- Updated the ModuleUpdatePolicy example in the FAQ on changing a module release channel: used `update.mode: Auto` instead of commented-out `AutoPatch`
- Added links to the update mode and update windows reference for both EN and RU docs

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: fix
summary: Fixed ModuleUpdatePolicy example in release channel FAQ.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
