### PR TITLE
Backport: [node-manager] fix: annotate CAPI MachineDeployments with CPU/memory capacity for scale-from-zero

### DIFF
--- a/modules/040-node-manager/e2e/cluster-autoscaler/tests/ca-scale-from-zero-node-label-dvp/chainsaw-test.yaml
+++ b/modules/040-node-manager/e2e/cluster-autoscaler/tests/ca-scale-from-zero-node-label-dvp/chainsaw-test.yaml
@@ -137,9 +137,9 @@ spec:
           sleep:
             duration: 15s
 
-    - name: verify-machine-deployment-labels-annotation
+    - name: verify-machine-deployment-capacity-annotations
       try:
-        - description: Check that MachineDeployment has node.deckhouse.io/group in capacity labels annotation
+        - description: Check MachineDeployment scale-from-zero labels, CPU, and memory annotations
           script:
             timeout: 300s
             content: |
@@ -149,18 +149,21 @@ spec:
                   -l node-group=e2e-worker-infra --no-headers \
                   -o custom-columns=':metadata.name' 2>/dev/null | head -1)
                 if [ -n "$MD_NAME" ]; then
-                  LABELS_ANN=$(kubectl get machinedeployments.cluster.x-k8s.io -n d8-cloud-instance-manager \
-                    "$MD_NAME" -o jsonpath='{.metadata.annotations.capacity\.cluster-autoscaler\.kubernetes\.io/labels}' 2>/dev/null || echo "")
-                  if echo "$LABELS_ANN" | grep -q "node.deckhouse.io/group=e2e-worker-infra"; then
-                    echo "Found node.deckhouse.io/group=e2e-worker-infra in capacity labels annotation"
+                  MD_JSON=$(kubectl get machinedeployments.cluster.x-k8s.io -n d8-cloud-instance-manager \
+                    "$MD_NAME" -o json 2>/dev/null || echo '{}')
+                  LABELS_ANN=$(echo "$MD_JSON" | jq -r '.metadata.annotations["capacity.cluster-autoscaler.kubernetes.io/labels"] // ""')
+                  CPU_ANN=$(echo "$MD_JSON" | jq -r '.metadata.annotations["capacity.cluster-autoscaler.kubernetes.io/cpu"] // ""')
+                  MEMORY_ANN=$(echo "$MD_JSON" | jq -r '.metadata.annotations["capacity.cluster-autoscaler.kubernetes.io/memory"] // ""')
+                  if echo "$LABELS_ANN" | grep -q "node.deckhouse.io/group=e2e-worker-infra" \
+                    && [ "$CPU_ANN" = "2" ] && [ "$MEMORY_ANN" = "4Gi" ]; then
+                    echo "Found expected labels, CPU, and memory capacity annotations"
                     exit 0
                   fi
-                  echo "Annotation content: $LABELS_ANN"
+                  echo "Annotations: labels=$LABELS_ANN cpu=$CPU_ANN memory=$MEMORY_ANN"
                 fi
                 sleep 10
               done
-              echo "Timed out: node.deckhouse.io/group not found in MachineDeployment capacity labels annotation"
-              echo "This indicates the PR #20174 fix is not applied"
+              echo "Timed out: expected MachineDeployment scale-from-zero capacity annotations were not found"
               exit 1
             check:
               ($error == null): true
@@ -171,6 +174,7 @@ spec:
             content: |
               kubectl get machinedeployments.cluster.x-k8s.io -n d8-cloud-instance-manager \
                 -l node-group=e2e-worker-infra -o yaml 2>/dev/null || true
+              kubectl get configmap d8-node-manager-capi-node-capacity -n d8-cloud-instance-manager -o yaml 2>/dev/null || true
 
     - name: apply-deployment
       try:

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/capi/common.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/capi/common.go
@@ -33,6 +33,9 @@ const (
 	clusterConfigSecretNamespace = "kube-system"
 	clusterUUIDConfigMapName     = "d8-cluster-uuid"
 	clusterUUIDConfigMapNS       = "kube-system"
+	// nodeCapacityConfigMapName is rendered by helm from get_crds nodeCapacity values
+	// so CAPI MachineDeployments can advertise CPU/memory for scale-from-zero.
+	nodeCapacityConfigMapName = "d8-node-manager-capi-node-capacity"
 )
 
 type BaseWithReader struct {

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/capi/machinedeployment.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/capi/machinedeployment.go
@@ -260,6 +260,8 @@ func (r *MachineDeploymentReconciler) reconcileCloudMDs(ctx context.Context, ng 
 		infraAPIGroup = infraAPIGroup[:idx]
 	}
 
+	capacityCPU, capacityMemory := r.readNodeCapacity(ctx, ng.Name)
+
 	for _, zone := range zones {
 		mdHash := sha256Hash(clusterUUID + zone)
 		mdSuffix := fmt.Sprintf("%s-%s", ng.Name, mdHash)
@@ -285,6 +287,7 @@ func (r *MachineDeploymentReconciler) reconcileCloudMDs(ctx context.Context, ng 
 		if serializedTaints != "" {
 			annotations["capacity.cluster-autoscaler.kubernetes.io/taints"] = serializedTaints
 		}
+		setScaleFromZeroCapacityAnnotations(annotations, capacityCPU, capacityMemory)
 
 		commonLabels := map[string]interface{}{
 			"heritage":   "deckhouse",
@@ -609,6 +612,41 @@ func applyMachineDeploymentSpecPatch(spec map[string]interface{}, rawPatch strin
 
 	deepMergeMaps(spec, patch)
 	return nil
+}
+
+type nodeCapacityValues struct {
+	CPU    string `json:"cpu" yaml:"cpu"`
+	Memory string `json:"memory" yaml:"memory"`
+}
+
+// readNodeCapacity loads CPU/memory previously calculated by get_crds and published
+// via the d8-node-manager-capi-node-capacity ConfigMap for scale-from-zero.
+func (r *MachineDeploymentReconciler) readNodeCapacity(ctx context.Context, ngName string) (cpu, memory string) {
+	cm := &corev1.ConfigMap{}
+	if err := r.APIReader.Get(ctx, types.NamespacedName{
+		Name: nodeCapacityConfigMapName, Namespace: common.MachineNamespace,
+	}, cm); err != nil {
+		return "", ""
+	}
+	raw, ok := cm.Data[ngName]
+	if !ok || strings.TrimSpace(raw) == "" {
+		return "", ""
+	}
+	var capacity nodeCapacityValues
+	if err := sigsyaml.Unmarshal([]byte(raw), &capacity); err != nil {
+		log.FromContext(ctx).Error(err, "failed to unmarshal node capacity", "nodeGroup", ngName)
+		return "", ""
+	}
+	return capacity.CPU, capacity.Memory
+}
+
+func setScaleFromZeroCapacityAnnotations(annotations map[string]interface{}, cpu, memory string) {
+	if cpu != "" {
+		annotations["capacity.cluster-autoscaler.kubernetes.io/cpu"] = cpu
+	}
+	if memory != "" {
+		annotations["capacity.cluster-autoscaler.kubernetes.io/memory"] = memory
+	}
 }
 
 func substitutePatchVariables(raw string, vars map[string]string) string {

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/capi/machinedeployment_test.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/capi/machinedeployment_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	deckhousev1 "github.com/deckhouse/node-controller/api/deckhouse.io/v1"
 )
@@ -186,6 +187,29 @@ func TestSerializeNodeGroupTaints(t *testing.T) {
 			t.Fatalf("taints not sorted: %q", got)
 		}
 	})
+}
+
+func TestSetScaleFromZeroCapacityAnnotations(t *testing.T) {
+	annotations := map[string]interface{}{}
+	setScaleFromZeroCapacityAnnotations(annotations, "4", "8Gi")
+
+	for key, want := range map[string]string{
+		"capacity.cluster-autoscaler.kubernetes.io/cpu":    "4",
+		"capacity.cluster-autoscaler.kubernetes.io/memory": "8Gi",
+	} {
+		got, ok := annotations[key].(string)
+		if !ok || got != want {
+			t.Fatalf("annotation %q = %v, want %q", key, annotations[key], want)
+		}
+		if _, err := resource.ParseQuantity(got); err != nil {
+			t.Fatalf("annotation %q has invalid Kubernetes quantity %q: %v", key, got, err)
+		}
+	}
+
+	setScaleFromZeroCapacityAnnotations(annotations, "", "")
+	if got := annotations["capacity.cluster-autoscaler.kubernetes.io/cpu"]; got != "4" {
+		t.Fatalf("empty cpu overwrote existing annotation: %v", got)
+	}
 }
 
 func TestApplyMachineDeploymentSpecPatch(t *testing.T) {

--- a/modules/040-node-manager/templates/node-controller/capi-node-capacity.yaml
+++ b/modules/040-node-manager/templates/node-controller/capi-node-capacity.yaml
@@ -1,0 +1,27 @@
+{{- /*
+  Bridge get_crds-computed nodeCapacity into node-controller.
+
+  Before #20682 the helm template _capi_machine_deployment.tpl wrote
+  capacity.cluster-autoscaler.kubernetes.io/{cpu,memory} from $ng.nodeCapacity.
+  CAPI MachineDeployments are now rendered by node-controller, which does not
+  see module values, so publish the already-calculated capacities here.
+*/ -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: d8-node-manager-capi-node-capacity
+  namespace: d8-cloud-instance-manager
+  {{- include "helm_lib_module_labels" (list . (dict "app" "node-controller")) | nindent 2 }}
+data:
+  {{- $capacityPublished := false }}
+  {{- range $ng := .Values.nodeManager.internal.nodeGroups | default list }}
+    {{- if $ng.nodeCapacity }}
+      {{- $capacityPublished = true }}
+  {{ $ng.name }}: |
+    cpu: {{ $ng.nodeCapacity.cpu | quote }}
+    memory: {{ $ng.nodeCapacity.memory | quote }}
+    {{- end }}
+  {{- end }}
+  {{- if not $capacityPublished }}
+  _placeholder: ""
+  {{- end }}


### PR DESCRIPTION
## Description
Backport of https://github.com/deckhouse/deckhouse/pull/21820 to `release-1.77`.

Restores CAPI MachineDeployment annotations:
- `capacity.cluster-autoscaler.kubernetes.io/cpu`
- `capacity.cluster-autoscaler.kubernetes.io/memory`

In 1.77 capacity is still calculated by `get_crds` into module values. This PR publishes those values via ConfigMap `d8-node-manager-capi-node-capacity`, and node-controller reads them when rendering CAPI MachineDeployments.

## Why do we need it, and what problem does it solve?
Regression from https://github.com/deckhouse/deckhouse/pull/20682 (`v1.77.0`): after moving CAPI MD rendering into node-controller, CPU/memory capacity annotations were dropped. Without them Cluster Autoscaler silently excludes zero-sized CAPI node groups (`!CanScaleFromZero()`), so scale-from-zero does not work.

## Why do we need it in the patch release (if we do)?
Yes. The bug exists on `release-1.77` (introduced by #20682). Main/#21820 alone does not fix 1.77.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: node-manager
type: fix
summary: Annotate CAPI MachineDeployments with CPU/memory capacity for scale-from-zero
impact_level: default
```