### PR TITLE
[istio] Fixes to prepare for PSS restricted policies

### DIFF
--- a/ee/modules/110-istio/templates/alliance/healthcheck/deployment.yaml
+++ b/ee/modules/110-istio/templates/alliance/healthcheck/deployment.yaml
@@ -49,6 +49,7 @@ spec:
         app: alliance-healthcheck
         sidecar.istio.io/inject: "true"
         istio.io/rev: default
+        security.deckhouse.io/security-policy-exception.container.istio-init: alliance-healthcheck-istio-init
       annotations:
         istio.deckhouse.io/full-version: "{{ $fullVersion }}"
     spec:

--- a/ee/modules/110-istio/templates/alliance/healthcheck/security-policy-exception.yaml
+++ b/ee/modules/110-istio/templates/alliance/healthcheck/security-policy-exception.yaml
@@ -1,0 +1,36 @@
+{{- if or .Values.istio.federation.enabled .Values.istio.multicluster.enabled }}
+{{- if or (.Values.global.discovery.apiVersions | has "deckhouse.io/v1alpha1/SecurityPolicyException") (.Capabilities.APIVersions.Has "deckhouse.io/v1alpha1/SecurityPolicyException") }}
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: SecurityPolicyException
+metadata:
+  name: alliance-healthcheck-istio-init
+  namespace: d8-{{ .Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "alliance-healthcheck")) | nindent 2 }}
+spec:
+  securityContext:
+    runAsNonRoot:
+      allowedValue: false
+      metadata:
+        description: |
+          Injected istio-init must run as root to set up pod networking via iptables
+          when dataPlane.trafficRedirectionSetupMode is InitContainer.
+    runAsUser:
+      allowedValues:
+        - 0
+      metadata:
+        description: |
+          UID 0 is required for iptables manipulation in the pod network namespace.
+    capabilities:
+      allowedValues:
+        add:
+          - NET_ADMIN
+          - NET_RAW
+        drop:
+          - ALL
+      metadata:
+        description: |
+          NET_ADMIN/NET_RAW are required for istio-init to program iptables redirection
+          rules before the application and istio-proxy containers start.
+{{- end }}
+{{- end }}

--- a/ee/modules/110-istio/templates/alliance/ingressgateway/daemonset.yaml
+++ b/ee/modules/110-istio/templates/alliance/ingressgateway/daemonset.yaml
@@ -179,6 +179,9 @@ spec:
           failureThreshold: 30
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
           runAsGroup: 1337
           runAsNonRoot: true
           runAsUser: 1337

--- a/ee/modules/110-istio/templates/ztunnel/daemonset.yaml
+++ b/ee/modules/110-istio/templates/ztunnel/daemonset.yaml
@@ -25,6 +25,7 @@ spec:
           "app" "ztunnel"
           "sidecar.istio.io/inject" "false"
           "istio.io/dataplane-mode" "none"
+          "security.deckhouse.io/security-policy-exception" "ztunnel"
       )) | nindent 6 }}
       annotations:
         sidecar.istio.io/inject: "false"

--- a/ee/modules/110-istio/templates/ztunnel/security-policy-exception.yaml
+++ b/ee/modules/110-istio/templates/ztunnel/security-policy-exception.yaml
@@ -1,0 +1,58 @@
+{{- if and
+  (include "istioSupportsAmbient" .)
+  (.Values.istio.ambient.enabled)
+}}
+{{- if or (.Values.global.discovery.apiVersions | has "deckhouse.io/v1alpha1/SecurityPolicyException") (.Capabilities.APIVersions.Has "deckhouse.io/v1alpha1/SecurityPolicyException") }}
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: SecurityPolicyException
+metadata:
+  name: ztunnel
+  namespace: d8-{{ .Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "ztunnel")) | nindent 2 }}
+spec:
+  securityContext:
+    allowPrivilegeEscalation:
+      allowedValue: true
+      metadata:
+        description: |
+          ztunnel requires privilege escalation together with SYS_ADMIN to enter pod
+          network namespaces for ambient dataplane redirection.
+    runAsNonRoot:
+      allowedValue: false
+      metadata:
+        description: |
+          ztunnel must run as root to perform TPROXY and setns into pod network namespaces.
+    runAsUser:
+      allowedValues:
+        - 0
+      metadata:
+        description: |
+          UID 0 is required for TPROXY sockets and entering pod network namespaces.
+    capabilities:
+      allowedValues:
+        add:
+          - NET_ADMIN
+          - SYS_ADMIN
+          - NET_RAW
+        drop:
+          - ALL
+      metadata:
+        description: |
+          NET_ADMIN/NET_RAW are required for TPROXY and raw/packet sockets;
+          SYS_ADMIN is required for setns into other network namespaces.
+  volumes:
+    types:
+      allowedValues:
+        - hostPath
+      metadata:
+        description: |
+          hostPath is required to share the ambient dataplane UDS socket with istio-cni.
+    hostPath:
+      allowedValues:
+        - path: /var/run/ztunnel
+          readOnly: false
+          metadata:
+            description: Host directory for the ztunnel UDS socket shared with istio-cni.
+{{- end }}
+{{- end }}

--- a/modules/110-istio/template_tests/module_test.go
+++ b/modules/110-istio/template_tests/module_test.go
@@ -1609,6 +1609,7 @@ MY_VAR: "myvalue"
 			Expect(ingressSvc.Exists()).To(BeTrue())
 
 			Expect(ingressDs.Field("metadata.labels").String()).To(MatchJSON(`{"app":"ingress-gateway-controller","heritage":"deckhouse","instance":"hostport-test","istio":"ingressgateway","istio.deckhouse.io/ingress-gateway-class":"hp","istio.io/dataplane-mode":"none","module":"istio"}`))
+			Expect(ingressDs.Field("spec.template.metadata.labels").String()).To(MatchJSON(`{"app":"ingress-gateway-controller","heritage":"deckhouse","instance":"hostport-test","istio":"ingressgateway","istio.deckhouse.io/ingress-gateway-class":"hp","istio.io/dataplane-mode":"none","module":"istio","security.deckhouse.io/security-policy-exception":"ingress-gateway-controller","sidecar.istio.io/inject":"false"}`))
 			istioProxyContainer := ingressDs.Field("spec.template.spec.containers").Array()
 			Expect(len(istioProxyContainer)).To(Equal(1))
 			Expect((istioProxyContainer[0].Get("ports"))).To(MatchJSON(`[

--- a/modules/110-istio/templates/cni/daemonset.yaml
+++ b/modules/110-istio/templates/cni/daemonset.yaml
@@ -59,6 +59,7 @@ spec:
         app: istio-cni-node
         k8s-app: istio-cni-node
         sidecar.istio.io/inject: "false"
+        security.deckhouse.io/security-policy-exception.container.install-cni: istio-cni-node
         {{- if (semverCompare ">= 1.25.0" $fullVersion) }}
         istio.io/dataplane-mode: none
         {{- end }}

--- a/modules/110-istio/templates/cni/daemonset.yaml
+++ b/modules/110-istio/templates/cni/daemonset.yaml
@@ -59,7 +59,7 @@ spec:
         app: istio-cni-node
         k8s-app: istio-cni-node
         sidecar.istio.io/inject: "false"
-        security.deckhouse.io/security-policy-exception.container.install-cni: istio-cni-node
+        security.deckhouse.io/security-policy-exception: istio-cni-node
         {{- if (semverCompare ">= 1.25.0" $fullVersion) }}
         istio.io/dataplane-mode: none
         {{- end }}

--- a/modules/110-istio/templates/cni/security-policy-exception.yaml
+++ b/modules/110-istio/templates/cni/security-policy-exception.yaml
@@ -49,6 +49,13 @@ spec:
           NET_ADMIN/NET_RAW are required for iptables/ipset and routing;
           SYS_PTRACE/SYS_ADMIN are required to inspect and enter pod network namespaces;
           DAC_OVERRIDE is required to write hostPath mounts owned by non-root.
+  network:
+    hostNetwork:
+      allowedValue: true
+      metadata:
+        description: |
+          Ambient mode requires hostNetwork so install-cni can coordinate with ztunnel
+          and manage pod network namespaces on the node.
   volumes:
     types:
       allowedValues:
@@ -75,5 +82,13 @@ spec:
           readOnly: false
           metadata:
             description: Host network namespaces used by CNI repair to enter pod netns.
+        - path: /proc
+          readOnly: true
+          metadata:
+            description: Host procfs used in ambient mode to inspect and enter pod network namespaces.
+        - path: /var/run/ztunnel
+          readOnly: false
+          metadata:
+            description: Host directory shared with ztunnel for the ambient dataplane UDS socket.
 {{- end }}
 {{- end }}

--- a/modules/110-istio/templates/cni/security-policy-exception.yaml
+++ b/modules/110-istio/templates/cni/security-policy-exception.yaml
@@ -1,0 +1,79 @@
+{{- if eq $.Values.istio.dataPlane.trafficRedirectionSetupMode "CNIPlugin" }}
+{{- if or (.Values.global.discovery.apiVersions | has "deckhouse.io/v1alpha1/SecurityPolicyException") (.Capabilities.APIVersions.Has "deckhouse.io/v1alpha1/SecurityPolicyException") }}
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: SecurityPolicyException
+metadata:
+  name: istio-cni-node
+  namespace: d8-{{ .Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "istio-cni-node")) | nindent 2 }}
+spec:
+  securityContext:
+    allowPrivilegeEscalation:
+      allowedValue: true
+      metadata:
+        description: |
+          install-cni requires privilege escalation together with elevated capabilities
+          to install the CNI plugin and repair pod networking on the node.
+    runAsNonRoot:
+      allowedValue: false
+      metadata:
+        description: |
+          install-cni must run as root to write CNI binaries/config on the host and
+          enter pod network namespaces for repair.
+    runAsUser:
+      allowedValues:
+        - 0
+      metadata:
+        description: |
+          UID 0 is required for hostPath CNI install paths and network-namespace repair.
+    appArmorProfile:
+      allowedValues:
+        - unconfined
+      metadata:
+        description: |
+          Istio CNI (>= 1.25) runs with AppArmor unconfined to perform host mounts and
+          network-namespace operations required by the plugin.
+    capabilities:
+      allowedValues:
+        add:
+          - NET_ADMIN
+          - NET_RAW
+          - SYS_PTRACE
+          - SYS_ADMIN
+          - DAC_OVERRIDE
+        drop:
+          - ALL
+      metadata:
+        description: |
+          NET_ADMIN/NET_RAW are required for iptables/ipset and routing;
+          SYS_PTRACE/SYS_ADMIN are required to inspect and enter pod network namespaces;
+          DAC_OVERRIDE is required to write hostPath mounts owned by non-root.
+  volumes:
+    types:
+      allowedValues:
+        - hostPath
+      metadata:
+        description: |
+          hostPath volumes are required to install the CNI binary/config and share the
+          CNI socket and host network namespaces with the node.
+    hostPath:
+      allowedValues:
+        - path: /opt/cni/bin
+          readOnly: false
+          metadata:
+            description: Host CNI binary directory where install-cni places the plugin.
+        - path: /etc/cni/net.d
+          readOnly: false
+          metadata:
+            description: Host CNI configuration directory where install-cni writes its config.
+        - path: /var/run/istio-cni
+          readOnly: false
+          metadata:
+            description: Host runtime directory for the Istio CNI UDS sockets.
+        - path: /var/run/netns
+          readOnly: false
+          metadata:
+            description: Host network namespaces used by CNI repair to enter pod netns.
+{{- end }}
+{{- end }}

--- a/modules/110-istio/templates/cni/security-policy-exception.yaml
+++ b/modules/110-istio/templates/cni/security-policy-exception.yaml
@@ -56,6 +56,15 @@ spec:
         description: |
           Ambient mode requires hostNetwork so install-cni can coordinate with ztunnel
           and manage pod network namespaces on the node.
+    hostPorts:
+      - port: 15014
+        protocol: TCP
+        metadata:
+          description: Istio CNI metrics endpoint; with hostNetwork it is exposed as a host port.
+      - port: 4286
+        protocol: TCP
+        metadata:
+          description: HTTPS metrics endpoint exposed through kube-rbac-proxy in ambient mode.
   volumes:
     types:
       allowedValues:

--- a/modules/110-istio/templates/ingressistiocontroller/daemonset.yaml
+++ b/modules/110-istio/templates/ingressistiocontroller/daemonset.yaml
@@ -38,14 +38,18 @@ spec:
         proxy.istio.io/config: {{ dict "gatewayTopology" $gatewayTopology | toJson | quote }}
         {{- end }}
         {{- end }}
-      {{- include "helm_lib_module_labels" (list $ (dict
+      {{- $podLabels := dict
           "app" "ingress-gateway-controller"
           "instance" $controller.name
           "istio" "ingressgateway"
           "istio.deckhouse.io/ingress-gateway-class" $controller.spec.ingressGatewayClass
           "istio.io/dataplane-mode" "none"
           "sidecar.istio.io/inject" "false"
-      )) | nindent 6 }}
+      }}
+      {{- if eq $controller.spec.inlet "HostPort" }}
+        {{- $_ := set $podLabels "security.deckhouse.io/security-policy-exception" "ingress-gateway-controller" }}
+      {{- end }}
+      {{- include "helm_lib_module_labels" (list $ $podLabels) | nindent 6 }}
     spec:
       {{- include "helm_lib_priority_class" (tuple $ "system-cluster-critical") | nindent 6 }}
       containers:

--- a/modules/110-istio/templates/ingressistiocontroller/namespace.yaml
+++ b/modules/110-istio/templates/ingressistiocontroller/namespace.yaml
@@ -7,7 +7,7 @@ metadata:
       "extended-monitoring.deckhouse.io/enabled" ""
       "prometheus.deckhouse.io/rules-watcher-enabled" "true"
       "security.deckhouse.io/pod-policy" "restricted"
-      "security.deckhouse.io/pod-policy-action" "warn"
+      "security.deckhouse.io/pod-policy-action" "deny"
       "security.deckhouse.io/enable-security-policy-check" "true"
   )) | nindent 2 }}
 ---

--- a/modules/110-istio/templates/ingressistiocontroller/namespace.yaml
+++ b/modules/110-istio/templates/ingressistiocontroller/namespace.yaml
@@ -6,6 +6,9 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict
       "extended-monitoring.deckhouse.io/enabled" ""
       "prometheus.deckhouse.io/rules-watcher-enabled" "true"
+      "security.deckhouse.io/pod-policy" "restricted"
+      "security.deckhouse.io/pod-policy-action" "warn"
+      "security.deckhouse.io/enable-security-policy-check" "true"
   )) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-ingress-%s" .Chart.Name)) }}

--- a/modules/110-istio/templates/ingressistiocontroller/security-policy-exception.yaml
+++ b/modules/110-istio/templates/ingressistiocontroller/security-policy-exception.yaml
@@ -1,0 +1,40 @@
+{{- $hostPortControllers := list }}
+{{- range $controller := .Values.istio.internal.ingressControllers }}
+  {{- if eq $controller.spec.inlet "HostPort" }}
+    {{- $hostPortControllers = append $hostPortControllers $controller }}
+  {{- end }}
+{{- end }}
+{{- if $hostPortControllers }}
+{{- if or (.Values.global.discovery.apiVersions | has "deckhouse.io/v1alpha1/SecurityPolicyException") (.Capabilities.APIVersions.Has "deckhouse.io/v1alpha1/SecurityPolicyException") }}
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: SecurityPolicyException
+metadata:
+  name: ingress-gateway-controller
+  namespace: d8-ingress-{{ .Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "ingress-gateway-controller")) | nindent 2 }}
+spec:
+  network:
+    hostNetwork:
+      allowedValue: false
+      metadata:
+        description: |
+          Ingress gateway with HostPort inlet publishes listeners on the node without
+          joining the host network namespace.
+    hostPorts:
+    {{- range $controller := $hostPortControllers }}
+      {{- with $controller.spec.hostPort.httpPort }}
+      - port: {{ . }}
+        protocol: TCP
+        metadata:
+          description: HTTP listener hostPort for IngressIstioController {{ $controller.name }}.
+      {{- end }}
+      {{- with $controller.spec.hostPort.httpsPort }}
+      - port: {{ . }}
+        protocol: TCP
+        metadata:
+          description: HTTPS listener hostPort for IngressIstioController {{ $controller.name }}.
+      {{- end }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/modules/110-istio/templates/namespace.yaml
+++ b/modules/110-istio/templates/namespace.yaml
@@ -3,6 +3,12 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict
+    "extended-monitoring.deckhouse.io/enabled" ""
+    "prometheus.deckhouse.io/rules-watcher-enabled" "true"
+    "security.deckhouse.io/pod-policy" "restricted"
+    "security.deckhouse.io/pod-policy-action" "warn"
+    "security.deckhouse.io/enable-security-policy-check" "true"
+  )) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s" .Chart.Name)) }}

--- a/modules/110-istio/templates/namespace.yaml
+++ b/modules/110-istio/templates/namespace.yaml
@@ -7,7 +7,7 @@ metadata:
     "extended-monitoring.deckhouse.io/enabled" ""
     "prometheus.deckhouse.io/rules-watcher-enabled" "true"
     "security.deckhouse.io/pod-policy" "restricted"
-    "security.deckhouse.io/pod-policy-action" "warn"
+    "security.deckhouse.io/pod-policy-action" "deny"
     "security.deckhouse.io/enable-security-policy-check" "true"
   )) | nindent 2 }}
 ---


### PR DESCRIPTION
## Description
Prepare the Istio module for PSS `restricted` (warn) checks: fix `ingressgateway` securityContext and add `SecurityPolicyException`s for legitimate privileged cases (`istio-init` on alliance-healthcheck, `istio-cni-node`, `ztunnel` / ambient).
May restart Istio CNI, ztunnel, alliance ingressgateway, and alliance-healthcheck pods after upgrade.

## Why do we need it, and what problem does it solve?
Deckhouse namespaces are being labeled for PSS checks. Without these fixes/exceptions, Gatekeeper reports warn violations for expected Istio behavior (root/`NET_ADMIN` for CNI and init, ambient `hostNetwork`/hostPorts, ztunnel caps). This pre-fixes the module so it's ready for future PSS policies.



## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: chore
summary: prepared module for PSS restricted checks
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
