### PR TITLE
[deckhouse] stop false drift detection reinstalling packages with helm hooks

### DIFF
--- a/deckhouse-controller/internal/nelm/client.go
+++ b/deckhouse-controller/internal/nelm/client.go
@@ -447,6 +447,15 @@ func (c *Client) Render(ctx context.Context, namespace, releaseName string, opts
 	// Combine all resources into a single YAML document with separators
 	var result strings.Builder
 	for _, resource := range res.Resources {
+		// Keep only regular release resources. Helm hooks live in the cluster just
+		// for the duration of a hook, and standalone crds/ CRDs are never applied at
+		// all because Install passes NoInstallStandaloneCRDs. Both are legitimately
+		// absent from the cluster, so they must not reach the release checksum and
+		// the absent-resources monitor.
+		if resource.StoreAs != common.StoreAsRegular {
+			continue
+		}
+
 		marshalled, err := yaml.Marshal(resource.Unstruct)
 		if err != nil {
 			span.SetStatus(codes.Error, err.Error())


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

`Client.Render` keeps only regular release resources — helm hooks and standalone `crds/` CRDs are
dropped. Same fix as flant/addon-operator#815 on the modules path.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

The rendered manifests feed the release checksum and the absent-resources monitor, but
`action.ChartRender` also returns hooks and standalone CRDs. A hook object exists only while its hook
runs, and `crds/` objects are never applied because `Install` passes `NoInstallStandaloneCRDs`, so the
monitor found them missing on every scan and rescheduled the package — any package whose chart has helm
hooks was reinstalled roughly every five minutes, burning release revisions. An unchanged checksum did
not help, because `shouldRunHelmUpgrade` runs the same absent check.

### Notes for the reviewer

- Packages with hooks or a `crds/` directory get one new revision after this change.
- A hook-only chart change no longer triggers an upgrade, matching helm3 `rs.Manifest` semantics.
- `deckhouse-controller packages render` no longer prints hooks and standalone CRDs.
- Still open: the monitor looks every resource up in the release namespace, so cluster-scoped and
  cross-namespace resources are reported missing.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: Stop false drift detection reinstalling packages with helm hooks
impact_level: low
```
