### PR TITLE
[deckhouse] stop false drift detection reinstalling packages with helm hooks (1.76)

### DIFF
--- a/deckhouse-controller/internal/nelm/client.go
+++ b/deckhouse-controller/internal/nelm/client.go
@@ -411,6 +411,15 @@ func (c *Client) Render(ctx context.Context, namespace, releaseName string, opts
 	// Combine all resources into a single YAML document with separators
 	var result strings.Builder
 	for _, resource := range res.Resources {
+		// Keep only regular release resources. Helm hooks live in the cluster just
+		// for the duration of a hook, and standalone crds/ CRDs are never applied at
+		// all because Install passes NoInstallStandaloneCRDs. Both are legitimately
+		// absent from the cluster, so they must not reach the release checksum and
+		// the absent-resources monitor.
+		if resource.StoreAs != common.StoreAsRegular {
+			continue
+		}
+
 		marshalled, err := yaml.Marshal(resource.Unstruct)
 		if err != nil {
 			span.SetStatus(codes.Error, err.Error())


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Backport of #21836 to release-1.76.

`Client.Render` keeps only regular release resources — helm hooks and standalone `crds/` CRDs are
dropped. Same fix as flant/addon-operator#815 on the modules path.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

The rendered manifests feed the release checksum and the absent-resources monitor, but
`action.ChartRender` also returns hooks and standalone CRDs. A hook object exists only while its hook
runs, and `crds/` objects are never applied because `Install` passes `NoInstallStandaloneCRDs`, so the
monitor found them missing on every scan and rescheduled the package — any package whose chart has helm
hooks was reinstalled roughly every five minutes, burning release revisions. An unchanged checksum did
not help, because `shouldRunHelmUpgrade` runs the same absent check.

### Notes for the reviewer

- Packages with hooks or a `crds/` directory get one new revision after this change.
- A hook-only chart change no longer triggers an upgrade, matching helm3 `rs.Manifest` semantics.
- `deckhouse-controller packages render` no longer prints hooks and standalone CRDs.
- This branch pins `flant/addon-operator v1.21.26`; the modules-path fix landed in v1.21.27, so
  covering it here needs a separate bump.
- Still open: the monitor looks every resource up in the release namespace, so cluster-scoped and
  cross-namespace resources are reported missing.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: stop false drift detection reinstalling packages with helm hooks
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
