### PR TITLE
[deckhouse] explain which requirement is unmet when an Application is rejected

### DIFF
--- a/deckhouse-controller/internal/packages/schedule/node.go
+++ b/deckhouse-controller/internal/packages/schedule/node.go
@@ -160,15 +160,15 @@ func (s *Scheduler) addNode(pkg Package) {
 	}
 
 	if constraints.Kubernetes != nil && s.kubeVersionGetter != nil {
-		n.rules = append(n.rules, version.NewRule(s.kubeVersionGetter, constraints.Kubernetes, reasonRequirementsKubernetes))
+		n.rules = append(n.rules, version.NewRule(s.kubeVersionGetter, constraints.Kubernetes, subjectKubernetes, reasonRequirementsKubernetes))
 	}
 
 	if constraints.Deckhouse != nil && s.deckhouseVersionGetter != nil {
-		n.rules = append(n.rules, version.NewRule(s.deckhouseVersionGetter, constraints.Deckhouse, reasonRequirementsDeckhouse))
+		n.rules = append(n.rules, version.NewRule(s.deckhouseVersionGetter, constraints.Deckhouse, subjectDeckhouse, reasonRequirementsDeckhouse))
 	}
 
 	if constraints.Order == FunctionalOrder && s.bootstrapCondition != nil {
-		n.rules = append(n.rules, condition.NewRule(s.bootstrapCondition, reasonRequirementsBootstrap))
+		n.rules = append(n.rules, condition.NewRule(s.bootstrapCondition, reasonRequirementsBootstrap, messageRequirementsBootstrap))
 	}
 
 	if len(constraints.Dependencies) > 0 && s.dependencyGetter != nil {

--- a/deckhouse-controller/internal/packages/schedule/rule/condition/rule.go
+++ b/deckhouse-controller/internal/packages/schedule/rule/condition/rule.go
@@ -31,23 +31,31 @@ type Condition func() bool
 type Rule struct {
 	condition Condition // Function to evaluate
 	reason    string
+	message   string
 }
 
 // NewRule creates a condition rule.
-func NewRule(condition Condition, reason string) *Rule {
+//
+// A condition function returns a bare bool, so it cannot explain itself: message
+// is the caller's description of what an unsatisfied condition means. It is
+// required - on the admission path the reason is dropped and the message is all
+// the user gets, so an empty one denies the request without any explanation.
+func NewRule(condition Condition, reason, message string) *Rule {
 	r := new(Rule)
 
 	r.condition = condition
 	r.reason = reason
+	r.message = message
 
 	return r
 }
 
 // Decide evaluates the condition function: an unmet condition is a hard veto
-// (Forbid) carrying the configured reason; a met condition yields Undefined.
+// (Forbid) carrying the configured reason and message; a met condition yields
+// Undefined.
 func (r *Rule) Decide() rule.Decision {
 	if !r.condition() {
-		return rule.Decision{Kind: rule.Forbid, Reason: r.reason}
+		return rule.Decision{Kind: rule.Forbid, Reason: r.reason, Message: r.message}
 	}
 
 	return rule.Decision{Kind: rule.Undefined}

--- a/deckhouse-controller/internal/packages/schedule/rule/version/rule.go
+++ b/deckhouse-controller/internal/packages/schedule/rule/version/rule.go
@@ -35,6 +35,7 @@ type Getter func() (*semver.Version, error)
 type Rule struct {
 	versionGetter Getter              // Function to get current version
 	constraints   *semver.Constraints // Required version constraint (e.g., ">=1.21, <2.0")
+	subject       string              // What is being versioned, e.g. "Kubernetes" - names the version in failure messages
 	reason        string
 }
 
@@ -45,10 +46,16 @@ type Rule struct {
 //   - ">=1.21, <2.0"     - Range from 1.21 to 2.0
 //   - "~1.21"            - Patch releases of 1.21
 //   - "^1.21"            - Minor releases of 1.x
-func NewRule(getter Getter, constraints *semver.Constraints, reason string) *Rule {
+//
+// subject names what the version belongs to ("Kubernetes", "Deckhouse"). It
+// carries the same information as reason, but in a form fit for a message shown
+// to the user: the reason is a Kubernetes condition reason and is dropped on the
+// admission path, where the message is all the user gets.
+func NewRule(getter Getter, constraints *semver.Constraints, subject, reason string) *Rule {
 	return &Rule{
 		versionGetter: getter,
 		constraints:   constraints,
+		subject:       subject,
 		reason:        reason,
 	}
 }
@@ -65,16 +72,19 @@ func (r *Rule) Decide() rule.Decision {
 		return rule.Decision{
 			Kind:    rule.Forbid,
 			Reason:  "VersionLookupFailed",
-			Message: fmt.Sprintf("get version: %s", err.Error()),
+			Message: fmt.Sprintf("cannot determine the current %s version: %s", r.subject, err.Error()),
 		}
 	}
 
-	// Validate returns (bool, []error) - we only use the errors
-	if _, errs := r.constraints.Validate(version); len(errs) != 0 {
+	// The errors semver returns are discarded on purpose: they render as a bare
+	// comparison of two versions ("1.34.9 is less than v1.35") that names
+	// neither the subject nor the operator of the constraint it came from, so on
+	// the admission path the user cannot tell which requirement was violated.
+	if ok, _ := r.constraints.Validate(version); !ok {
 		return rule.Decision{
 			Kind:    rule.Forbid,
 			Reason:  r.reason,
-			Message: fmt.Errorf("check version error: %w", errs[0]).Error(),
+			Message: fmt.Sprintf("requires %s version '%s', current version is '%s'", r.subject, r.constraints, version),
 		}
 	}
 

--- a/deckhouse-controller/internal/packages/schedule/scheduler.go
+++ b/deckhouse-controller/internal/packages/schedule/scheduler.go
@@ -43,6 +43,14 @@ const (
 	reasonRequirementsKubernetes = "KubernetesRequirementsUnmet"
 	reasonRequirementsDeckhouse  = "DeckhouseRequirementsUnmet"
 	reasonRequirementsBootstrap  = "BootstrapRequirementsUnmet"
+
+	// Subjects and messages spell out for the user what the reason above encodes
+	// for a condition. CheckConstraints surfaces only the decision message, so
+	// whatever is missing there is lost on the admission path.
+	subjectKubernetes = "Kubernetes"
+	subjectDeckhouse  = "Deckhouse"
+
+	messageRequirementsBootstrap = "cluster bootstrap is not finished yet"
 )
 
 // Scheduler manages a dependency graph of packages and their lifecycle.
@@ -170,15 +178,15 @@ func (s *Scheduler) CheckConstraints(name string, constraints Constraints) error
 	var rules []rule.Rule
 
 	if constraints.Kubernetes != nil && s.kubeVersionGetter != nil {
-		rules = append(rules, version.NewRule(s.kubeVersionGetter, constraints.Kubernetes, reasonRequirementsKubernetes))
+		rules = append(rules, version.NewRule(s.kubeVersionGetter, constraints.Kubernetes, subjectKubernetes, reasonRequirementsKubernetes))
 	}
 
 	if constraints.Deckhouse != nil && s.deckhouseVersionGetter != nil {
-		rules = append(rules, version.NewRule(s.deckhouseVersionGetter, constraints.Deckhouse, reasonRequirementsDeckhouse))
+		rules = append(rules, version.NewRule(s.deckhouseVersionGetter, constraints.Deckhouse, subjectDeckhouse, reasonRequirementsDeckhouse))
 	}
 
 	if constraints.Order == FunctionalOrder && s.bootstrapCondition != nil {
-		rules = append(rules, condition.NewRule(s.bootstrapCondition, reasonRequirementsBootstrap))
+		rules = append(rules, condition.NewRule(s.bootstrapCondition, reasonRequirementsBootstrap, messageRequirementsBootstrap))
 	}
 
 	if len(constraints.Dependencies) > 0 && s.dependencyGetter != nil {

--- a/deckhouse-controller/internal/packages/schedule/scheduler_test.go
+++ b/deckhouse-controller/internal/packages/schedule/scheduler_test.go
@@ -682,6 +682,30 @@ func (s *SchedulerSuite) TestCheckConstraintsAnyOfRejectsAtAdmission() {
 	s.Contains(err.Error(), "cloud-provider", "failure message must name the unmet group")
 }
 
+// TestCheckConstraintsVersionRejectionNamesSubject pins the admission-time
+// message content for a version constraint. CheckConstraints surfaces only the
+// decision message and drops the Reason that carries the subject, so the message
+// itself must name what was checked, what was required and what the cluster has
+// — semver's own error ("1.34.9 is less than v1.35") names none of the three.
+//
+// A local scheduler is built because the suite fixture wires no version getter.
+func (s *SchedulerSuite) TestCheckConstraintsVersionRejectionNamesSubject() {
+	sched := schedule.NewScheduler(log.NewNop(), schedule.WithKubeVersionGetter(func() (*semver.Version, error) {
+		return mustVersion("1.34.9"), nil
+	}))
+	defer sched.Stop()
+
+	err := sched.CheckConstraints("proposed", schedule.Constraints{
+		Order:      schedule.FunctionalOrder,
+		Kubernetes: mustConstraint(">= v1.35"),
+	})
+
+	s.Require().Error(err)
+	s.Contains(err.Error(), "Kubernetes", "failure message must name the checked version")
+	s.Contains(err.Error(), ">=v1.35", "failure message must name the violated constraint")
+	s.Contains(err.Error(), "1.34.9", "failure message must name the current version")
+}
+
 // TestAnyOfMemberInstallTriggersReschedule confirms dynamic re-evaluation:
 // a consumer born disabled (no AnyOf member installed) flips to enabled when
 // a member becomes available and the scheduler re-runs.

--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_application.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_application.go
@@ -66,7 +66,12 @@ func applicationValidationHandler(cli client.Client, manager packageManager) htt
 		}
 
 		if err = validateAppAgainstApv(ctx, cli, manager, app); err != nil {
-			return rejectResult(err.Error())
+			// The denial message is the only feedback `kubectl apply` prints, and
+			// it arrives without the object it belongs to: name the Application
+			// and the package version whose requirements were evaluated, so the
+			// rejection is traceable when several manifests are applied at once.
+			return rejectResult(fmt.Sprintf("Application '%s/%s' (package '%s' version '%s'): %s",
+				app.Namespace, app.Name, app.Spec.PackageName, app.Spec.PackageVersion, err))
 		}
 
 		return allowResult(res.Warnings)


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Requirement rejections for `Application` objects now name what was checked, what was required and what the cluster actually has.

- `schedule/rule/version` builds its own message instead of surfacing the raw semver error, and takes a `subject` (`Kubernetes`, `Deckhouse`).
- `schedule/rule/condition` now carries a message. It had none, so an unsatisfied condition denied the request with no text at all.
- The `Application` validating webhook names the object and the package version whose requirements were evaluated.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
`CheckConstraints` surfaces only the decision message and drops the `Reason` that says which subsystem a requirement belongs to, so on the admission path the message is everything the user gets. A rejected `Application` used to read:

```
The request is invalid: : check version error: 1.34.9 is less than v1.35
```

Nothing says the number is a Kubernetes version; the constraint operator is gone, because semver prints only the version part of `>= v1.35`, so a requirement reads as a plain comparison; `check version error` is an internal wrapper leaking into `kubectl` output; and no object is named. An unmet Deckhouse requirement rendered in exactly the same shape, so the two were indistinguishable.

The condition rule was worse. Every `Application` admission evaluates the bootstrap gate, because the webhook always builds constraints with `Order: FunctionalOrder`, and with no message the denial printed bare `The request is invalid` with no explanation whatsoever.

These messages are also what the runtime writes into the `RequirementsMet` condition of a package, so the status path gets the same wording.

### Manual testing

Checked on a cluster running Kubernetes `1.34.9`, with three package versions published to exercise each branch. Package and application names are sanitized; command output is verbatim.

Kubernetes requirement unmet — the case this PR is about (package requires `>= v1.35`):

```
# k apply -f app.yaml
The request is invalid: : Application 'default/example-app-req' (package 'example-app' version 'v0.1.2'): requires Kubernetes version '>=v1.35', current version is '1.34.9'
```

Deckhouse requirement unmet (package requires `>= v3.0.0`) — previously indistinguishable from the Kubernetes rejection, both rendered as `check version error: <x> is less than <y>`:

```
# k apply -f app.yaml
The request is invalid: : Application 'default/example-app-req' (package 'example-app' version 'v0.1.3'): requires Deckhouse version '>=v3.0.0', current version is '2.0.0'
```

Both requirements satisfied — the version rule's pass branch, which this PR also touches:

```
# k apply -f app.yaml
application.deckhouse.io/example-app-req created

# k get app example-app-req
NAME               PACKAGE       VERSION   STATE   MESSAGE   AGE
example-app-req    example-app   v0.1.4                      0s
```

The bootstrap condition message is not covered here: `clusterIsBootstrapped` is held true by a global hook that recreates the backing ConfigMap, so an unsatisfied bootstrap gate cannot be reproduced on a healthy cluster.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: explain which requirement is unmet when an Application is rejected
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->


