### PR TITLE
[docs] Add Kubernetes conformance test results page

### DIFF
--- a/docs/documentation/_data/sidebars/main.yml
+++ b/docs/documentation/_data/sidebars/main.yml
@@ -1767,6 +1767,10 @@ entries:
             ru: Поддерживаемые версии K8s и ОС
           url: /reference/supported_versions.html
         - title:
+            en: Kubernetes conformance test results
+            ru: Результаты Kubernetes conformance-тестов
+          url: /reference/kubernetes-conformance.html
+        - title:
             en: Revision comparison
             ru: Сравнение редакций
           url: /reference/revision-comparison.html

--- a/docs/documentation/_plugins/kubernetes_conformance_generator.rb
+++ b/docs/documentation/_plugins/kubernetes_conformance_generator.rb
@@ -1,0 +1,63 @@
+module KubernetesConformance
+  class Generator < Jekyll::Generator
+    safe true
+    priority :high
+
+    def generate(site)
+      conformance_dir = File.join(site.source, 'assets', 'conformance')
+
+      site.data['kubernetes_conformance'] = {
+        'results' => conformance_results(conformance_dir),
+        'readme' => {
+          'en' => conformance_readme(conformance_dir, 'README.md'),
+          'ru' => conformance_readme(conformance_dir, 'README_RU.md')
+        }
+      }
+    end
+
+    private
+
+    def conformance_results(conformance_dir)
+      return [] unless Dir.exist?(conformance_dir)
+
+      Dir.children(conformance_dir).each_with_object([]) do |version, results|
+        next unless version.match?(/\A\d+\.\d+\z/)
+
+        xml_path = File.join(conformance_dir, version, 'junit_01.xml')
+        next unless File.file?(xml_path)
+
+        results << {
+          'version' => version,
+          'xml_path' => "/assets/conformance/#{version}/junit_01.xml"
+        }
+      end.sort_by { |result| result['version'].split('.').map(&:to_i) }.reverse
+    end
+
+    def conformance_readme(conformance_dir, filename)
+      readme_path = File.join(conformance_dir, filename)
+      return '' unless File.file?(readme_path)
+
+      demote_markdown_headings(File.read(readme_path))
+    end
+
+    def demote_markdown_headings(markdown)
+      fence_character = nil
+
+      markdown.each_line.map do |line|
+        fence = line.match(/\A\s*(`{3,}|~{3,})/)
+
+        if fence_character
+          fence_character = nil if line.match?(/\A\s*#{Regexp.escape(fence_character)}{3,}\s*\z/)
+          line
+        elsif fence
+          fence_character = fence[1][0]
+          line
+        elsif line.match?(/\A\#{1,5}\s/)
+          "##{line}"
+        else
+          line
+        end
+      end.join
+    end
+  end
+end

--- a/docs/documentation/pages/reference/KUBERNETES_CONFORMANCE.md
+++ b/docs/documentation/pages/reference/KUBERNETES_CONFORMANCE.md
@@ -5,7 +5,7 @@ description: "CNCF Kubernetes conformance e2e test results for Kubernetes versio
 search: kubernetes conformance, cncf conformance, sonobuoy, e2e tests, junit
 ---
 
-Deckhouse Kubernetes Platform is tested against the CNCF Kubernetes conformance suite. The tests are run with Sonobuoy in `certified-conformance` mode for each Kubernetes minor version listed below.
+Deckhouse Kubernetes Platform is tested against the Kubernetes conformance suite of the CNCF Certified Kubernetes Conformance Program. The tests are run with Sonobuoy in `certified-conformance` mode for each Kubernetes minor version listed below.
 
 ## Test results
 

--- a/docs/documentation/pages/reference/KUBERNETES_CONFORMANCE.md
+++ b/docs/documentation/pages/reference/KUBERNETES_CONFORMANCE.md
@@ -1,0 +1,29 @@
+---
+title: Kubernetes conformance test results
+permalink: en/reference/kubernetes-conformance.html
+description: "CNCF Kubernetes conformance e2e test results for Kubernetes versions supported by Deckhouse Kubernetes Platform"
+search: kubernetes conformance, cncf conformance, sonobuoy, e2e tests, junit
+---
+
+Deckhouse Kubernetes Platform is tested against the CNCF Kubernetes conformance suite. The tests are run with Sonobuoy in `certified-conformance` mode for each Kubernetes minor version listed below.
+
+## Test results
+
+{% assign conformance_results = site.data.kubernetes_conformance.results %}
+{% if conformance_results.size > 0 %}
+{% for result in conformance_results %}
+- Kubernetes **{{ result.version }}** — <a href="{{ site.canonical_url_prefix_documentation }}{{ result.xml_path }}" download>Download JUnit XML report</a>
+{% endfor %}
+{% else %}
+No conformance test results are available.
+{% endif %}
+
+{% assign conformance_readme = site.data.kubernetes_conformance.readme[page.lang] %}
+{% if conformance_readme != empty %}
+{{ conformance_readme | markdownify }}
+{% else %}
+
+## Running the tests
+
+The conformance test instructions are currently unavailable.
+{% endif %}

--- a/docs/documentation/pages/reference/KUBERNETES_CONFORMANCE_RU.md
+++ b/docs/documentation/pages/reference/KUBERNETES_CONFORMANCE_RU.md
@@ -1,0 +1,30 @@
+---
+title: Результаты Kubernetes conformance-тестов
+permalink: ru/reference/kubernetes-conformance.html
+description: "Результаты e2e-тестов CNCF Kubernetes conformance для версий Kubernetes, поддерживаемых Deckhouse Kubernetes Platform"
+lang: ru
+search: kubernetes conformance, cncf conformance, sonobuoy, e2e-тесты, junit, тесты на совместимость
+---
+
+Deckhouse Kubernetes Platform тестируется на соответствие требованиям CNCF Kubernetes conformance. Для каждой указанной ниже минорной версии Kubernetes тесты запускаются с помощью Sonobuoy в режиме `certified-conformance`.
+
+## Результаты тестирования
+
+{% assign conformance_results = site.data.kubernetes_conformance.results %}
+{% if conformance_results.size > 0 %}
+{% for result in conformance_results %}
+- Kubernetes **{{ result.version }}** — <a href="{{ site.canonical_url_prefix_documentation }}{{ result.xml_path }}" download>Скачать отчёт JUnit в формате XML</a>
+{% endfor %}
+{% else %}
+Результаты conformance-тестов пока недоступны.
+{% endif %}
+
+{% assign conformance_readme = site.data.kubernetes_conformance.readme[page.lang] %}
+{% if conformance_readme != empty %}
+{{ conformance_readme | markdownify }}
+{% else %}
+
+## Запуск тестов
+
+Инструкция по запуску conformance-тестов пока недоступна.
+{% endif %}

--- a/docs/documentation/pages/reference/KUBERNETES_CONFORMANCE_RU.md
+++ b/docs/documentation/pages/reference/KUBERNETES_CONFORMANCE_RU.md
@@ -6,7 +6,7 @@ lang: ru
 search: kubernetes conformance, cncf conformance, sonobuoy, e2e-тесты, junit, тесты на совместимость
 ---
 
-Deckhouse Kubernetes Platform тестируется на соответствие требованиям CNCF Kubernetes conformance. Для каждой указанной ниже минорной версии Kubernetes тесты запускаются с помощью Sonobuoy в режиме `certified-conformance`.
+Deckhouse Kubernetes Platform тестируется на соответствие набору Kubernetes conformance-тестов программы CNCF Certified Kubernetes Conformance Program. Для каждой указанной ниже минорной версии Kubernetes тесты запускаются с помощью Sonobuoy в режиме `certified-conformance`.
 
 ## Результаты тестирования
 

--- a/docs/documentation/werf-git-section.inc.yaml
+++ b/docs/documentation/werf-git-section.inc.yaml
@@ -5,6 +5,12 @@
   group: jekyll
   stageDependencies:
     setup: ['**/*']
+- add: /modules/000-common/images/kubernetes/conformance
+  to: /srv/jekyll-data/documentation/assets/conformance
+  owner: jekyll
+  group: jekyll
+  stageDependencies:
+    setup: ['**/*']
 - add: /editions.yaml
   to: /srv/jekyll-data/documentation/_data/editions-repo-data.yaml
   owner: jekyll

--- a/modules/000-common/images/kubernetes/conformance/README.md
+++ b/modules/000-common/images/kubernetes/conformance/README.md
@@ -79,28 +79,3 @@ You will get:
 `plugins/e2e/results/global/junit_01.xml`
 
 Optional: remove the tarball when done (`rm -f sb.tar.gz`).
-
----
-
-## 6. Add files to this module
-
-Place both files under the minor version directory that matches your cluster, for example:
-
-```text
-modules/000-common/images/kubernetes/conformance/<version>/e2e.log
-modules/000-common/images/kubernetes/conformance/<version>/junit_01.xml
-```
-
-Example: for Kubernetes **1.33** → use directory `1.33/`.
-
-Commit the changes and open a PR.
-
----
-
-## 7. PR labels (automation)
-
-After the workflow that validates conformance results is present on the **default branch**, add label:
-
-`tests/conformance/<version>`
-
-(for example `tests/conformance/1.33`). Automation reads `junit_01.xml` from this PR branch and, depending on the suite outcome, sets follow-up labels (`passed` / `failed`) and removes the trigger label so you can run the check again.

--- a/modules/000-common/images/kubernetes/conformance/README_RU.md
+++ b/modules/000-common/images/kubernetes/conformance/README_RU.md
@@ -1,0 +1,81 @@
+# Соответствие требованиям CNCF Kubernetes (Sonobuoy)
+
+В этом каталоге для каждой минорной версии Kubernetes хранятся артефакты **сертификационного тестирования на соответствие требованиям**: `e2e.log` и `junit_01.xml`, созданные [Sonobuoy](https://github.com/vmware-tanzu/sonobuoy) в режиме `certified-conformance`.
+
+Используйте эту инструкцию, когда необходимо обновить сохранённые результаты после обновления или проверки поддерживаемой линейки версий Kubernetes.
+
+---
+
+## 1. Подготовка кластера и Deckhouse
+
+Разверните кластер с Deckhouse на целевой версии Kubernetes и убедитесь, что `kubectl` настроен для работы с ним.
+
+---
+
+## 2. Настройка RBAC и admission-контроля (необходимо для корректного запуска)
+
+Pod Security Standards могут блокировать рабочие нагрузки, необходимые набору e2e-тестов. На время запуска ослабьте настройки **Admission Policy Engine** по умолчанию, чтобы ограничения безопасности не мешали выполнению тестов.
+
+Примените следующую конфигурацию один раз (проверьте её перед применением в production-кластере):
+
+```bash
+kubectl apply -f - <<'EOF'
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: admission-policy-engine
+spec:
+  enabled: true
+  settings:
+    podSecurityStandards:
+      defaultPolicy: Privileged
+  version: 1
+EOF
+```
+
+---
+
+## 3. Установка CLI Sonobuoy
+
+Скачайте нужную версию со [страницы релизов Sonobuoy](https://github.com/vmware-tanzu/sonobuoy/releases), распакуйте бинарный файл и добавьте его в `PATH` либо запускайте из каталога распаковки.
+
+Пример для Linux `amd64` (замените версию на необходимую):
+
+```bash
+curl -sL -o sonobuoy.tgz \
+  'https://github.com/vmware-tanzu/sonobuoy/releases/download/v0.57.3/sonobuoy_0.57.3_linux_amd64.tar.gz'
+tar -xzf sonobuoy.tgz sonobuoy
+chmod +x sonobuoy
+```
+
+---
+
+## 4. Запуск conformance-тестов
+
+```bash
+./sonobuoy run --mode=certified-conformance --kubeconfig=/etc/kubernetes/super-admin.conf
+```
+
+Дождитесь, пока команда `./sonobuoy status` сообщит о состоянии **completed**. Для наблюдения за ходом выполнения проверяйте создание и удаление пространств имён: тесты запускаются в изолированных пространствах имён.
+
+Обычно выполнение занимает около **2 часов**.
+
+---
+
+## 5. Получение только `e2e.log` и `junit_01.xml`
+
+На машине, где запускается CLI, выполните:
+
+```bash
+./sonobuoy retrieve . -f sb.tar.gz
+tar -xzf sb.tar.gz \
+  plugins/e2e/results/global/e2e.log \
+  plugins/e2e/results/global/junit_01.xml
+```
+
+В результате будут получены файлы:
+
+`plugins/e2e/results/global/e2e.log`  
+`plugins/e2e/results/global/junit_01.xml`
+
+После завершения архив можно удалить: `rm -f sb.tar.gz`.


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Adds localized Kubernetes conformance test result pages to the Reference section.

- Automatically discovers available Kubernetes versions.
- Publishes JUnit XML reports as documentation assets.
- Renders the source README on the English page.
- Shows a translation notice on the Russian page.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: feature
summary: Added Kubernetes conformance test results page.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
