### PR TITLE
[deckhouse] package release controller

### DIFF
--- a/deckhouse-controller/internal/controller/modules/config/controller.go
+++ b/deckhouse-controller/internal/controller/modules/config/controller.go
@@ -56,9 +56,9 @@ const (
 	maxConcurrentReconciles = 3
 	// cacheSyncTimeout bounds the initial informer cache sync.
 	cacheSyncTimeout = 3 * time.Minute
-	// moduleNotFoundInterval is the retry delay for a config whose module does not exist
+	// defaultRequeueAfter is the retry delay for a config whose module does not exist
 	// yet, a state only an external change can resolve.
-	moduleNotFoundInterval = 3 * time.Minute
+	defaultRequeueAfter = 3 * time.Minute
 
 	// moduleDeckhouse and moduleGlobal name the system modules, whose source and update
 	// policy are not driven by their config.
@@ -189,7 +189,7 @@ func (r *reconciler) handleCreateOrUpdate(ctx context.Context, mc *v1alpha1.Modu
 			return ctrl.Result{}, err
 		}
 
-		return ctrl.Result{RequeueAfter: moduleNotFoundInterval}, nil
+		return ctrl.Result{RequeueAfter: defaultRequeueAfter}, nil
 	}
 
 	return r.processModule(ctx, mc, module)

--- a/deckhouse-controller/internal/controller/modules/override/controller.go
+++ b/deckhouse-controller/internal/controller/modules/override/controller.go
@@ -123,7 +123,7 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		}
 
 		r.logger.Error("failed to get module pull override", slog.String("name", req.Name), log.Err(err))
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{}, fmt.Errorf("get: %w", err)
 	}
 
 	// handle delete event

--- a/deckhouse-controller/internal/controller/modules/release/controller.go
+++ b/deckhouse-controller/internal/controller/modules/release/controller.go
@@ -1,0 +1,444 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package release
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	ctrlmanager "sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/metrics"
+	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/runtime"
+	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/schedule"
+	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/registry"
+	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
+	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/controller/ctrlutils"
+	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/controller/module-controllers/utils"
+	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/helpers"
+	releaseUpdater "github.com/deckhouse/deckhouse/deckhouse-controller/pkg/releaseupdater"
+	"github.com/deckhouse/deckhouse/pkg/log"
+	metricsstorage "github.com/deckhouse/deckhouse/pkg/metrics-storage"
+)
+
+const (
+	// controllerName is the name the controller is registered under in the manager.
+	controllerName = "d8-module-release-controller"
+
+	// maxConcurrentReconciles allows a few releases to be reconciled at once.
+	maxConcurrentReconciles = 3
+	// cacheSyncTimeout bounds the initial informer cache sync.
+	cacheSyncTimeout = 3 * time.Minute
+
+	// defaultRequeueAfter is the retry delay for a release that cannot advance yet, such as
+	// one waiting on a window, an approval or a module that is not ready.
+	defaultRequeueAfter = 15 * time.Second
+	// disabledByIgnorePolicy is the status message of a release its policy refuses to update.
+	disabledByIgnorePolicy = `Update disabled by 'Ignore' update policy`
+
+	// outdatedReleasesKeepCount is how many superseded, suspended or skipped releases per
+	// module survive cleanup, so an operator can still see recent history.
+	outdatedReleasesKeepCount = 3
+)
+
+// MetricsUpdater reports the blocked-release metric for a single release.
+type MetricsUpdater interface {
+	UpdateReleaseMetric(string, releaseUpdater.MetricLabels)
+	PurgeReleaseMetric(string)
+}
+
+// packageManager hands a module version to the package runtime, which owns the download, the
+// on-disk placement and the reload that follow, and answers whether a release's requirements
+// hold against the live cluster.
+type packageManager interface {
+	UpdateModule(repo registry.Remote, module runtime.Module, force bool)
+	RemoveModule(name string)
+	CheckConstraints(name string, constraints schedule.Constraints) error
+}
+
+// RegisterController registers the ModuleRelease controller with the manager. The preflight wait
+// group is owned by the caller and gates reconciliation until the startup sync has finished.
+func RegisterController(
+	ctrlManager ctrlmanager.Manager,
+	manager packageManager,
+	preflight *sync.WaitGroup,
+	embeddedPolicy *helpers.ModuleUpdatePolicySpecContainer,
+	ms metricsstorage.Storage,
+	logger *log.Logger,
+) error {
+	r := &reconciler{
+		init:           preflight,
+		client:         ctrlManager.GetClient(),
+		manager:        manager,
+		embeddedPolicy: embeddedPolicy,
+		metricStorage:  ms,
+		metricsUpdater: releaseUpdater.NewMetricsUpdater(ms, releaseUpdater.ModuleReleaseBlockedMetricName),
+		logger:         logger.Named(controllerName),
+	}
+
+	if err := ctrlManager.Add(ctrlmanager.RunnableFunc(r.seedReleaseMetrics)); err != nil {
+		return fmt.Errorf("add seed release metrics: %w", err)
+	}
+
+	if err := ctrl.NewControllerManagedBy(ctrlManager).
+		Named(controllerName).
+		For(&v1alpha1.ModuleRelease{}).
+		// for reconcile documentation if accidentally removed
+		Owns(&v1alpha1.ModuleDocumentation{}).
+		WithEventFilter(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.AnnotationChangedPredicate{})).
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: maxConcurrentReconciles,
+			CacheSyncTimeout:        cacheSyncTimeout,
+			NeedLeaderElection:      new(false),
+		}).
+		Complete(r); err != nil {
+		return fmt.Errorf("complete: %w", err)
+	}
+
+	return nil
+}
+
+// reconciler reconciles ModuleRelease objects.
+type reconciler struct {
+	init   *sync.WaitGroup
+	client client.Client
+
+	manager packageManager
+
+	embeddedPolicy *helpers.ModuleUpdatePolicySpecContainer
+	metricStorage  metricsstorage.Storage
+	metricsUpdater MetricsUpdater
+
+	logger *log.Logger
+}
+
+// seedReleaseMetrics publishes the pull gauges for the releases that already exist, so the
+// metrics are not blank until each release happens to reconcile.
+func (r *reconciler) seedReleaseMetrics(ctx context.Context) error {
+	releases := new(v1alpha1.ModuleReleaseList)
+	if err := r.client.List(ctx, releases); err != nil {
+		return fmt.Errorf("list module releases: %w", err)
+	}
+
+	for _, mr := range releases.Items {
+		labels := map[string]string{
+			metrics.LabelVersion: mr.GetVersion().String(),
+			metrics.LabelModule:  mr.GetModuleName(),
+		}
+
+		r.metricStorage.GaugeSet(metrics.ModulePullSecondsTotal, mr.Status.PullDuration.Seconds(), labels)
+		r.metricStorage.GaugeSet(metrics.ModuleSizeBytesTotal, float64(mr.Status.Size), labels)
+	}
+
+	r.logger.Debug("controller is ready")
+
+	return nil
+}
+
+// Reconcile dispatches the release to the delete or the create/update handler.
+func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	// wait for init
+	r.init.Wait()
+
+	r.logger.Debug("reconcile module release", slog.String("release", req.Name))
+	mr := new(v1alpha1.ModuleRelease)
+	if err := r.client.Get(ctx, client.ObjectKey{Name: req.Name}, mr); err != nil {
+		if apierrors.IsNotFound(err) {
+			r.logger.Warn("module release is not found", slog.String("release", req.Name))
+			return ctrl.Result{}, nil
+		}
+
+		r.logger.Error("failed to get module release", slog.String("release", req.Name), log.Err(err))
+		return ctrl.Result{}, fmt.Errorf("get: %w", err)
+	}
+
+	r.metricsUpdater.PurgeReleaseMetric(mr.GetName())
+
+	// handle delete event
+	if !mr.DeletionTimestamp.IsZero() {
+		return r.handleDelete(ctx, mr)
+	}
+
+	// handle create/update events
+	res, err := r.handleCreateOrUpdate(ctx, mr)
+	if err != nil {
+		r.logger.Warn("handle release", log.Err(err))
+	}
+
+	return res, err
+}
+
+// handleRelease routes the release by phase. Terminal phases only need their status label
+// resynced; a pending release is skipped entirely while a pull override holds the module.
+func (r *reconciler) handleCreateOrUpdate(ctx context.Context, mr *v1alpha1.ModuleRelease) (ctrl.Result, error) {
+	ctx, span := otel.Tracer(controllerName).Start(ctx, "handleRelease")
+	defer span.End()
+
+	span.SetAttributes(attribute.String("release", mr.GetName()))
+	span.SetAttributes(attribute.String("module", mr.GetModuleName()))
+	span.SetAttributes(attribute.String("source", mr.GetModuleSource()))
+	span.SetAttributes(attribute.String("phase", mr.GetPhase()))
+
+	res, err := r.preHandleCheck(ctx, mr)
+	if err != nil {
+		r.logger.Error("failed to update module release before handling", slog.String("release", mr.GetName()), log.Err(err))
+
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	if !res.IsZero() {
+		return res, nil
+	}
+
+	// add finalizer for metrics reset on deletion (so the release resource will be deleted only after metrics are reset)
+	if !controllerutil.ContainsFinalizer(mr, v1alpha1.ModuleReleaseFinalizerMetricsRegistered) {
+		controllerutil.AddFinalizer(mr, v1alpha1.ModuleReleaseFinalizerMetricsRegistered)
+		if err := r.client.Update(ctx, mr); err != nil {
+			r.logger.Error("failed to add metrics finalizer to module release", slog.String("release", mr.GetName()), log.Err(err))
+			return ctrl.Result{Requeue: true}, nil
+		}
+
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	switch mr.GetPhase() {
+	case "":
+		mr.Status.Phase = v1alpha1.ModuleReleasePhasePending
+		mr.Status.TransitionTime = metav1.NewTime(time.Now().UTC())
+		if err = r.client.Status().Update(ctx, mr); err != nil {
+			r.logger.Error("failed to update module release status", slog.String("release", mr.GetName()), log.Err(err))
+			return ctrl.Result{Requeue: true}, nil
+		}
+
+		// process to the next phase
+		return ctrl.Result{Requeue: true}, nil
+
+	case v1alpha1.ModuleReleasePhaseSuperseded, v1alpha1.ModuleReleasePhaseSuspended, v1alpha1.ModuleReleasePhaseSkipped:
+		if err = r.syncStatusLabel(ctx, mr, strings.ToLower(mr.GetPhase())); err != nil {
+			r.logger.Error("failed to update module release status", slog.String("release", mr.GetName()), log.Err(err))
+			return ctrl.Result{Requeue: true}, nil
+		}
+
+		return ctrl.Result{}, nil
+
+	case v1alpha1.ModuleReleasePhaseDeployed:
+		res, err = r.handleDeployedRelease(ctx, mr)
+		if err != nil {
+			r.releaseLogger(mr).Debug("result of handle deployed release", log.Err(err))
+
+			return res, err
+		}
+
+		return res, nil
+	}
+
+	// if module pull override exists, don't process pending release, to avoid fs override
+	exists, err := utils.ModulePullOverrideExists(ctx, r.client, mr.GetModuleName())
+	if err != nil {
+		r.logger.Error("failed to get module pull override", slog.String("module", mr.GetModuleName()), log.Err(err))
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	if exists {
+		r.logger.Info("module is overridden, skip release processing", slog.String("module", mr.GetModuleName()))
+		return ctrl.Result{RequeueAfter: defaultRequeueAfter}, nil
+	}
+
+	// process only pending releases
+	res, err = r.handlePendingRelease(ctx, mr)
+	if err != nil {
+		r.releaseLogger(mr).Debug("result of handle pending release", log.Err(err))
+
+		return res, err
+	}
+
+	return res, nil
+}
+
+// preHandleCheck backfills the module label every later lookup selects on, requeueing so the
+// rest of the flow sees the labelled object.
+func (r *reconciler) preHandleCheck(ctx context.Context, mr *v1alpha1.ModuleRelease) (ctrl.Result, error) {
+	if _, ok := mr.Labels[v1alpha1.ModuleReleaseLabelModule]; ok {
+		return ctrl.Result{}, nil
+	}
+
+	err := ctrlutils.UpdateWithRetry(ctx, r.client, mr, func() error {
+		if len(mr.ObjectMeta.Labels) == 0 {
+			mr.ObjectMeta.Labels = make(map[string]string, 1)
+		}
+
+		mr.ObjectMeta.Labels[v1alpha1.ModuleReleaseLabelModule] = mr.GetModuleName()
+
+		return nil
+	})
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("update with retry: %w", err)
+	}
+
+	return ctrl.Result{Requeue: true}, nil
+}
+
+// syncStatusLabel keeps the status label in step with the phase, so release lists can select
+// on it. It is a no-op when the label already matches.
+func (r *reconciler) syncStatusLabel(ctx context.Context, mr *v1alpha1.ModuleRelease, status string) error {
+	if mr.Labels[v1alpha1.ModuleReleaseLabelStatus] == status {
+		return nil
+	}
+
+	if len(mr.Labels) == 0 {
+		mr.Labels = make(map[string]string, 1)
+	}
+
+	mr.Labels[v1alpha1.ModuleReleaseLabelStatus] = status
+
+	if err := r.client.Update(ctx, mr); err != nil {
+		return fmt.Errorf("update: %w", err)
+	}
+
+	return nil
+}
+
+// releaseLogger tags a logger with the release's identity, the triple every release path logs.
+// The source key is module_source because sloglint reserves source.
+func (r *reconciler) releaseLogger(mr *v1alpha1.ModuleRelease) *log.Logger {
+	return r.logger.With(
+		slog.String("module_name", mr.GetModuleName()),
+		slog.String("release_name", mr.GetName()),
+		slog.String("module_source", mr.GetModuleSource()),
+	)
+}
+
+// retryBackoff is the conflict backoff for release writes. Releases are touched from several
+// paths at once, so conflicts are frequent and the default backoff waits far too long.
+func retryBackoff() *wait.Backoff {
+	return &wait.Backoff{
+		Steps: 6,
+		// magic number
+		Duration: 20 * time.Millisecond,
+		Factor:   1.0,
+		Jitter:   0.1,
+	}
+}
+
+// newModuleReleaseWithName returns a release stub carrying only a name, enough for the client
+// to address an object the caller does not need to read first.
+func newModuleReleaseWithName(name string) *v1alpha1.ModuleRelease {
+	return &v1alpha1.ModuleRelease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+}
+
+// isModuleReady reports whether the module is in the Ready phase. A module that cannot be read
+// counts as not ready, which holds the release back rather than deploying onto unknown state.
+func (r *reconciler) isModuleReady(ctx context.Context, moduleName string) bool {
+	module := new(v1alpha1.Module)
+	if err := r.client.Get(ctx, types.NamespacedName{Name: moduleName}, module); err != nil {
+		r.logger.Warn("cannot find module", slog.String("module_name", moduleName), log.Err(err))
+
+		return false
+	}
+
+	return module.Status.Phase == v1alpha1.ModulePhaseReady
+}
+
+// updateReleaseStatus writes the release's phase and message, stamping the transition time only
+// when the phase actually changes. Reaching a terminal phase purges the blocked-release metric,
+// which would otherwise keep alerting on a release that can no longer move.
+func (r *reconciler) updateReleaseStatus(ctx context.Context, mr *v1alpha1.ModuleRelease, status *v1alpha1.ModuleReleaseStatus) error {
+	r.logger.Debug("refresh release status", slog.String("release", mr.GetName()))
+
+	switch status.Phase {
+	case v1alpha1.ModuleReleasePhaseSuperseded, v1alpha1.ModuleReleasePhaseSuspended, v1alpha1.ModuleReleasePhaseSkipped, v1alpha1.ModuleReleasePhaseTerminating:
+		r.metricsUpdater.PurgeReleaseMetric(mr.GetName())
+	}
+
+	err := ctrlutils.UpdateStatusWithRetry(ctx, r.client, mr, func() error {
+		if mr.GetPhase() != status.Phase {
+			mr.Status.TransitionTime = metav1.NewTime(time.Now().UTC())
+		}
+
+		mr.Status.Phase = status.Phase
+		mr.Status.Message = status.Message
+
+		return nil
+	}, ctrlutils.WithRetryOnConflictBackoff(retryBackoff()))
+	if err != nil {
+		return fmt.Errorf("update status with retry: %w", err)
+	}
+
+	return nil
+}
+
+// updateModuleLastReleaseDeployedStatus records on the module whether its newest release made
+// it. A failure points at the release, since that is where the detail lives.
+func (r *reconciler) updateModuleLastReleaseDeployedStatus(ctx context.Context, mr *v1alpha1.ModuleRelease, msg, reason string, deployed bool) error {
+	module := new(v1alpha1.Module)
+	if err := r.client.Get(ctx, client.ObjectKey{Name: mr.GetModuleName()}, module); err != nil {
+		return fmt.Errorf("get module: %w", err)
+	}
+
+	r.logger.With(slog.String("module", mr.GetModuleName())).Debug("refresh module status")
+
+	err := ctrlutils.UpdateStatusWithRetry(ctx, r.client, module, func() error {
+		if deployed {
+			module.SetConditionTrue(v1alpha1.ModuleConditionLastReleaseDeployed, v1alpha1.WithTimer(time.Now))
+
+			return nil
+		}
+
+		condMessage := fmt.Sprintf("%s: see details in the module release v%s", msg, mr.GetVersion().String())
+		module.SetConditionFalse(v1alpha1.ModuleConditionLastReleaseDeployed, reason, condMessage, v1alpha1.WithTimer(time.Now))
+
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("update status with retry: %w", err)
+	}
+
+	return nil
+}
+
+// updateReleaseStatusMessage sets the release's status message, skipping the write when it is
+// already set so a steady state does not churn status.
+func (r *reconciler) updateReleaseStatusMessage(ctx context.Context, mr *v1alpha1.ModuleRelease, message string) error {
+	if mr.GetMessage() == message {
+		return nil
+	}
+
+	mr.Status.Message = message
+
+	if err := r.client.Status().Update(ctx, mr); err != nil {
+		return fmt.Errorf("update the '%s' module release status: %w", mr.GetName(), err)
+	}
+
+	return nil
+}

--- a/deckhouse-controller/internal/controller/modules/release/deploy.go
+++ b/deckhouse-controller/internal/controller/modules/release/deploy.go
@@ -1,0 +1,213 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package release
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/modules"
+	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/runtime"
+	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/registry"
+	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
+	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/controller/ctrlutils"
+	releaseUpdater "github.com/deckhouse/deckhouse/deckhouse-controller/pkg/releaseupdater"
+	"github.com/deckhouse/deckhouse/pkg/log"
+)
+
+// dryRunTimeout bounds the detached dry-run pass, whose parent context may already be gone.
+const dryRunTimeout = time.Minute
+
+// applyRelease deploys the release. A nil task means there is no release to supersede.
+func (r *reconciler) applyRelease(ctx context.Context, mr *v1alpha1.ModuleRelease, task *releaseUpdater.Task) error {
+	ctx, span := otel.Tracer(controllerName).Start(ctx, "applyRelease")
+	defer span.End()
+
+	var deployedReleaseInfo *releaseUpdater.ReleaseInfo
+	if task != nil {
+		deployedReleaseInfo = task.DeployedReleaseInfo
+	}
+
+	if err := r.runReleaseDeploy(ctx, mr, deployedReleaseInfo); err != nil {
+		return fmt.Errorf("run release deploy: %w", err)
+	}
+
+	return nil
+}
+
+// runReleaseDeploy hands the version to the runtime, supersedes the release it replaces and
+// marks this one Deployed. Metadata and status are written separately, each with its own
+// conflict retry.
+func (r *reconciler) runReleaseDeploy(ctx context.Context, mr *v1alpha1.ModuleRelease, deployedReleaseInfo *releaseUpdater.ReleaseInfo) error {
+	ctx, span := otel.Tracer(controllerName).Start(ctx, "runReleaseDeploy")
+	defer span.End()
+
+	r.logger.Info("applying release", slog.String("release", mr.GetName()))
+
+	if err := r.deployModule(ctx, mr); err != nil {
+		return fmt.Errorf("deploy module: %w", err)
+	}
+
+	if deployedReleaseInfo != nil {
+		err := r.updateReleaseStatus(ctx, newModuleReleaseWithName(deployedReleaseInfo.Name), &v1alpha1.ModuleReleaseStatus{
+			Phase:   v1alpha1.ModuleReleasePhaseSuperseded,
+			Message: "",
+		})
+		if err != nil {
+			r.logger.Error("update status", slog.String("release", deployedReleaseInfo.Name), log.Err(err))
+		}
+	}
+
+	err := ctrlutils.UpdateWithRetry(ctx, r.client, mr, func() error {
+		if len(mr.Annotations) == 0 {
+			mr.Annotations = make(map[string]string, 2)
+		}
+
+		mr.Annotations[v1alpha1.ModuleReleaseAnnotationIsUpdating] = "true"
+		mr.Annotations[v1alpha1.ModuleReleaseAnnotationNotified] = "true"
+
+		if len(mr.ObjectMeta.Labels) == 0 {
+			mr.ObjectMeta.Labels = make(map[string]string, 1)
+		}
+
+		mr.ObjectMeta.Labels[v1alpha1.ModuleReleaseLabelStatus] = v1alpha1.ModuleReleaseLabelDeployed
+
+		// the one-shot annotations that asked for this deploy are spent
+		if mr.GetApplyNow() {
+			delete(mr.Annotations, v1alpha1.ModuleReleaseAnnotationApplyNow)
+		}
+
+		if mr.GetForce() {
+			delete(mr.Annotations, v1alpha1.ModuleReleaseAnnotationForce)
+		}
+
+		if mr.GetReinstall() {
+			delete(mr.Annotations, v1alpha1.ModuleReleaseAnnotationReinstall)
+		}
+
+		controllerutil.AddFinalizer(mr, v1alpha1.ModuleReleaseFinalizerExistOnFs)
+
+		return nil
+	}, ctrlutils.WithRetryOnConflictBackoff(retryBackoff()))
+	if err != nil {
+		return fmt.Errorf("update with retry: %w", err)
+	}
+
+	err = ctrlutils.UpdateStatusWithRetry(ctx, r.client, mr, func() error {
+		mr.Status.Phase = v1alpha1.ModuleReleasePhaseDeployed
+		mr.Status.Message = ""
+
+		return nil
+	}, ctrlutils.WithRetryOnConflictBackoff(retryBackoff()))
+	if err != nil {
+		return fmt.Errorf("update status with retry: %w", err)
+	}
+
+	return nil
+}
+
+// deployModule hands the release's version to the package runtime, which pulls the image, places
+// it on disk, parses the definition and reloads the module. Settings are not passed: they belong
+// to the module config controller, which pushes them separately.
+func (r *reconciler) deployModule(ctx context.Context, mr *v1alpha1.ModuleRelease) error {
+	ctx, span := otel.Tracer(controllerName).Start(ctx, "deployModule")
+	defer span.End()
+
+	// dryrun for testing purpose
+	if mr.GetDryRun() {
+		go r.runDryRunDeploy(mr)
+
+		return nil
+	}
+
+	source := new(v1alpha1.ModuleSource)
+	if err := r.client.Get(ctx, client.ObjectKey{Name: mr.GetModuleSource()}, source); err != nil {
+		return fmt.Errorf("get the '%s' module source: %w", mr.GetModuleSource(), err)
+	}
+
+	// Not forced: a release pins an immutable version tag, so a copy the runtime already has of
+	// that version is the right one.
+	r.updateModule(source, mr, false)
+
+	return nil
+}
+
+// updateModule registers the release's version with the runtime. force makes the runtime redeploy
+// a version it already tracks, which is needed when only the registry behind it changed.
+func (r *reconciler) updateModule(source *v1alpha1.ModuleSource, mr *v1alpha1.ModuleRelease, force bool) {
+	r.logger.Debug("update module in the package runtime",
+		slog.String("module", mr.GetModuleName()),
+		slog.String("version", mr.GetModuleVersion()),
+		slog.Bool("force", force))
+
+	r.manager.UpdateModule(registry.BuildRemote(source), runtime.Module{
+		Name: mr.GetModuleName(),
+		Definition: modules.Definition{
+			Version: mr.GetModuleVersion(),
+		},
+	}, force)
+}
+
+// runDryRunDeploy nudges the module's other pending releases so they requeue and observe the
+// dry-run outcome. It runs detached from the reconcile, on its own bounded context.
+func (r *reconciler) runDryRunDeploy(mr *v1alpha1.ModuleRelease) {
+	r.logger.Debug("dryrun start soon...")
+
+	time.Sleep(3 * time.Second)
+
+	r.logger.Debug("dryrun started")
+
+	ctx, cancel := context.WithTimeout(context.Background(), dryRunTimeout)
+	defer cancel()
+
+	releases := new(v1alpha1.ModuleReleaseList)
+	if err := r.client.List(ctx, releases, client.MatchingLabels{v1alpha1.ModuleReleaseLabelModule: mr.GetModuleName()}); err != nil {
+		r.logger.Error("dryrun list module releases", slog.String("module_name", mr.GetModuleName()), log.Err(err))
+
+		return
+	}
+
+	for i := range releases.Items {
+		pending := &releases.Items[i]
+
+		if pending.GetName() == mr.GetName() || pending.Status.Phase != v1alpha1.ModuleReleasePhasePending {
+			continue
+		}
+
+		// update releases to trigger their requeue
+		err := ctrlutils.UpdateWithRetry(ctx, r.client, pending, func() error {
+			if len(pending.Annotations) == 0 {
+				pending.Annotations = make(map[string]string, 1)
+			}
+
+			pending.Annotations[v1alpha1.ModuleReleaseAnnotationTriggeredByDryrun] = mr.GetName()
+
+			return nil
+		})
+		if err != nil {
+			r.logger.Error("dryrun update release to requeue", log.Err(err))
+
+			continue
+		}
+
+		r.logger.Debug("dryrun release successfully updated", slog.String("release", pending.Name))
+	}
+}

--- a/deckhouse-controller/internal/controller/modules/release/deployed.go
+++ b/deckhouse-controller/internal/controller/modules/release/deployed.go
@@ -1,0 +1,368 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package release
+
+import (
+	"context"
+	"crypto/md5"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+	"go.opentelemetry.io/otel"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
+	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/controller/module-controllers/utils"
+	"github.com/deckhouse/deckhouse/pkg/log"
+)
+
+// handleDeployedRelease keeps an already deployed release consistent: it refreshes the
+// module's last-release-deployed condition, serves a pending reinstall or registry change,
+// ensures finalizers, labels, documentation and settings ownership, and prunes outdated
+// releases. A module held by a pull override is left alone.
+func (r *reconciler) handleDeployedRelease(ctx context.Context, mr *v1alpha1.ModuleRelease) (ctrl.Result, error) {
+	ctx, span := otel.Tracer(controllerName).Start(ctx, "handleDeployedRelease")
+	defer span.End()
+
+	res := ctrl.Result{}
+
+	pendingReleaseFound, err := r.hasOlderPendingRelease(ctx, mr)
+	if err != nil {
+		return res, err
+	}
+
+	// an older pending release will be skipped later in the cycle, but until it is the module
+	// cannot be called fully deployed
+	if !pendingReleaseFound {
+		if err = r.updateModuleLastReleaseDeployedStatus(ctx, mr, "", "", true); err != nil {
+			return res, fmt.Errorf("update module last release deployed status: %w", err)
+		}
+	}
+
+	if mr.GetReinstall() {
+		if err = r.applyRelease(ctx, mr, nil); err != nil {
+			return res, fmt.Errorf("run release deploy: %w", err)
+		}
+
+		r.logger.Info("module release reloaded", slog.String("release", mr.GetName()))
+
+		return res, nil
+	}
+
+	if len(mr.Annotations) == 0 {
+		mr.Annotations = make(map[string]string, 1)
+	}
+
+	var needsUpdate bool
+
+	if mr.GetIsUpdating() {
+		needsUpdate = true
+
+		if r.isModuleReady(ctx, mr.GetModuleName()) {
+			mr.Annotations[v1alpha1.ModuleReleaseAnnotationIsUpdating] = "false"
+		}
+	}
+
+	// at least one release for module source is deployed, add finalizer to prevent module source deletion
+	source := new(v1alpha1.ModuleSource)
+	if err = r.client.Get(ctx, client.ObjectKey{Name: mr.GetModuleSource()}, source); err != nil {
+		r.logger.Error("failed to get module source", slog.String("module_source", mr.GetModuleSource()), log.Err(err))
+
+		return res, fmt.Errorf("get module source: %w", err)
+	}
+
+	// check if RegistrySpecChanged annotation is set process it
+	if _, set := mr.GetAnnotations()[v1alpha1.ModuleReleaseAnnotationRegistrySpecChanged]; set {
+		// the version is unchanged, so the runtime would skip an unforced update
+		r.logger.Info("apply new registry settings to module", slog.String("module", mr.GetModuleName()))
+		r.updateModule(source, mr, true)
+
+		// delete annotation and requeue
+		delete(mr.ObjectMeta.Annotations, v1alpha1.ModuleReleaseAnnotationRegistrySpecChanged)
+		needsUpdate = true
+	}
+
+	// add finalizer
+	if !controllerutil.ContainsFinalizer(mr, v1alpha1.ModuleReleaseFinalizerExistOnFs) {
+		controllerutil.AddFinalizer(mr, v1alpha1.ModuleReleaseFinalizerExistOnFs)
+		needsUpdate = true
+	}
+
+	if mr.Labels[v1alpha1.ModuleReleaseLabelStatus] != v1alpha1.ModuleReleaseLabelDeployed {
+		if len(mr.ObjectMeta.Labels) == 0 {
+			mr.ObjectMeta.Labels = make(map[string]string, 1)
+		}
+
+		mr.ObjectMeta.Labels[v1alpha1.ModuleReleaseLabelStatus] = v1alpha1.ModuleReleaseLabelDeployed
+		needsUpdate = true
+	}
+
+	if needsUpdate {
+		if err = r.client.Update(ctx, mr); err != nil {
+			r.logger.Error("failed to update module release", slog.String("release", mr.GetName()), log.Err(err))
+
+			return res, fmt.Errorf("update module release: %w", err)
+		}
+
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	if !controllerutil.ContainsFinalizer(source, v1alpha1.ModuleSourceFinalizerReleaseExists) {
+		controllerutil.AddFinalizer(source, v1alpha1.ModuleSourceFinalizerReleaseExists)
+		if err = r.client.Update(ctx, source); err != nil {
+			r.logger.Error("failed to add finalizer to module source", slog.String("module_source", mr.GetModuleSource()), log.Err(err))
+
+			return res, fmt.Errorf("add finalizer to module source: %w", err)
+		}
+	}
+
+	// checks if the module release is overridden by modulepulloverride
+	exists, err := utils.ModulePullOverrideExists(ctx, r.client, mr.GetModuleName())
+	if err != nil {
+		r.logger.Error("failed to get module pull override", slog.String("module", mr.GetModuleName()), log.Err(err))
+
+		return res, fmt.Errorf("module pull override exists: %w", err)
+	}
+
+	if exists {
+		r.logger.Debug("module is overridden, skip it", slog.String("module", mr.GetModuleName()))
+
+		return res, nil
+	}
+
+	if err = r.ensureDocumentation(ctx, mr); err != nil {
+		return res, err
+	}
+
+	r.logger.Debug("delete outdated releases for module", slog.String("module", mr.GetModuleName()))
+	if err = r.deleteOutdatedModuleReleases(ctx, mr.GetModuleSource(), mr.GetModuleName()); err != nil {
+		r.logger.Error("failed to delete outdated module releases", slog.String("module", mr.GetModuleName()), log.Err(err))
+
+		return res, fmt.Errorf("delete outdated module releases: %w", err)
+	}
+
+	return res, r.ownModuleSettings(ctx, mr)
+}
+
+// hasOlderPendingRelease reports whether the module has a pending release older than the
+// deployed one, which reconcile will skip but which still blocks a clean deployed verdict.
+func (r *reconciler) hasOlderPendingRelease(ctx context.Context, mr *v1alpha1.ModuleRelease) (bool, error) {
+	releases := new(v1alpha1.ModuleReleaseList)
+	labelSelector := client.MatchingLabels{
+		v1alpha1.ModuleReleaseLabelSource: mr.GetModuleSource(),
+		v1alpha1.ModuleReleaseLabelModule: mr.GetModuleName(),
+	}
+
+	if err := r.client.List(ctx, releases, labelSelector); err != nil {
+		return false, fmt.Errorf("list module releases: %w", err)
+	}
+
+	for i := range releases.Items {
+		if releases.Items[i].Status.Phase == v1alpha1.ModuleReleasePhasePending && mr.GetVersion().GreaterThan(releases.Items[i].GetVersion()) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// ensureDocumentation republishes the module's documentation from this release. It skips a
+// disabled module and a module whose embedded copy is still shipped, since neither serves docs
+// from the downloaded release.
+func (r *reconciler) ensureDocumentation(ctx context.Context, mr *v1alpha1.ModuleRelease) error {
+	module := new(v1alpha1.Module)
+	if err := r.client.Get(ctx, client.ObjectKey{Name: mr.GetModuleName()}, module); err != nil {
+		r.logger.Error("failed to get module", slog.String("module", mr.GetModuleName()), log.Err(err))
+
+		return fmt.Errorf("get module: %w", err)
+	}
+
+	// ensure documentation for any enabled module, regardless of how it is enabled
+	// (by module config, by bundle or by an enabled script) - EnabledByModuleManager
+	// reflects the effective enabled state, unlike EnabledByModuleConfig which is only
+	// set for modules enabled explicitly via a ModuleConfig
+	if !module.IsCondition(v1alpha1.ModuleConditionEnabledByModuleManager, corev1.ConditionTrue) || module.IsEmbedded() {
+		return nil
+	}
+
+	// Use mount point path: /modules/<module> (modules are mounted at /deckhouse/downloaded/modules/deployed/<module>)
+	modulePath := filepath.Join("/modules/deployed", mr.GetModuleName())
+	moduleVersion := "v" + mr.GetVersion().String()
+
+	// the checksum identifies the built docs; without a label to read it from, derive one that at
+	// least changes with the version
+	moduleChecksum := mr.Labels[v1alpha1.ModuleReleaseLabelReleaseChecksum]
+	if moduleChecksum == "" {
+		moduleChecksum = fmt.Sprintf("%x", md5.Sum([]byte(moduleVersion)))
+	}
+
+	ownerRef := metav1.OwnerReference{
+		APIVersion: v1alpha1.ModuleReleaseGVK.GroupVersion().String(),
+		Kind:       v1alpha1.ModuleReleaseGVK.Kind,
+		Name:       mr.GetName(),
+		UID:        mr.GetUID(),
+		Controller: new(true),
+	}
+
+	if err := utils.EnsureModuleDocumentation(ctx, r.client, mr.GetModuleName(), module.Properties.Source, moduleChecksum, moduleVersion, modulePath, ownerRef); err != nil {
+		r.logger.Error("failed to ensure module documentation", slog.String("module", mr.GetModuleName()), log.Err(err))
+
+		return fmt.Errorf("ensure module documentation: %w", err)
+	}
+
+	return nil
+}
+
+// ownModuleSettings points the module's settings definition at this release, so the settings
+// are garbage collected with it. A module without a settings definition is not an error.
+func (r *reconciler) ownModuleSettings(ctx context.Context, mr *v1alpha1.ModuleRelease) error {
+	settings := new(v1alpha1.ModuleSettingsDefinition)
+	if err := r.client.Get(ctx, client.ObjectKey{Name: mr.GetModuleName()}, settings); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("get module settings: %w", err)
+		}
+
+		r.logger.Warn("module settings not found", slog.String("module", mr.GetModuleName()))
+
+		return nil
+	}
+
+	settings.OwnerReferences = []metav1.OwnerReference{{
+		APIVersion: v1alpha1.ModuleReleaseGVK.GroupVersion().String(),
+		Kind:       v1alpha1.ModuleReleaseGVK.Kind,
+		Name:       mr.GetName(),
+		UID:        mr.GetUID(),
+		Controller: new(true),
+	}}
+
+	if err := r.client.Update(ctx, settings); err != nil {
+		r.logger.Warn("failed to update module settings", slog.String("module", mr.GetModuleName()), log.Err(err))
+
+		return fmt.Errorf("update: %w", err)
+	}
+
+	return nil
+}
+
+// deleteRelease removes the module from the filesystem and releases the release's finalizers.
+// It first parks the release in Terminating and requeues, so the phase is durable before
+// anything is uninstalled.
+func (r *reconciler) handleDelete(ctx context.Context, mr *v1alpha1.ModuleRelease) (ctrl.Result, error) {
+	if mr.GetPhase() != v1alpha1.ModuleReleasePhaseTerminating {
+		mr.Status.Phase = v1alpha1.ModuleReleasePhaseTerminating
+		if err := r.client.Status().Update(ctx, mr); err != nil {
+			r.logger.Warn("failed to set terminating to the release", slog.String("release", mr.GetName()), log.Err(err))
+
+			return ctrl.Result{}, fmt.Errorf("update: %w", err)
+		}
+
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	// The metric is already reset in the handleRelease function, so we can release the finalizer
+	if controllerutil.ContainsFinalizer(mr, v1alpha1.ModuleReleaseFinalizerMetricsRegistered) {
+		controllerutil.RemoveFinalizer(mr, v1alpha1.ModuleReleaseFinalizerMetricsRegistered)
+		if err := r.client.Update(ctx, mr); err != nil {
+			r.logger.Error("failed to remove metrics finalizer from module release", slog.String("release", mr.GetName()), log.Err(err))
+			return ctrl.Result{}, err
+		}
+	}
+
+	// the runtime disables the module and unmounts it, so nothing is left running off the
+	// filesystem once RemoveModule's Disable -> Undeploy pair drains
+	if mr.GetLabels()[v1alpha1.ModuleReleaseLabelStatus] == strings.ToLower(v1alpha1.ModuleReleasePhaseDeployed) {
+		r.logger.Info("remove module from the package runtime", slog.String("module", mr.GetModuleName()))
+
+		r.manager.RemoveModule(mr.GetModuleName())
+	}
+
+	if controllerutil.ContainsFinalizer(mr, v1alpha1.ModuleReleaseFinalizerExistOnFs) {
+		controllerutil.RemoveFinalizer(mr, v1alpha1.ModuleReleaseFinalizerExistOnFs)
+		if err := r.client.Update(ctx, mr); err != nil {
+			r.logger.Error("failed to update module release", slog.String("release", mr.GetName()), log.Err(err))
+			return ctrl.Result{}, fmt.Errorf("update: %w", err)
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// deleteOutdatedModuleReleases finds and deletes all outdated releases of the module in
+// Suspend, Skipped or Superseded phases, except for outdatedReleasesKeepCount most recent ones.
+func (r *reconciler) deleteOutdatedModuleReleases(ctx context.Context, moduleSource, module string) error {
+	releases := new(v1alpha1.ModuleReleaseList)
+	labelSelector := client.MatchingLabels{
+		v1alpha1.ModuleReleaseLabelSource: moduleSource,
+		v1alpha1.ModuleReleaseLabelModule: module,
+	}
+
+	if err := r.client.List(ctx, releases, labelSelector); err != nil {
+		r.logger.Error("failed to list all module releases", log.Err(err))
+
+		return fmt.Errorf("list releases: %w", err)
+	}
+
+	type outdatedRelease struct {
+		name    string
+		version *semver.Version
+	}
+
+	// the selector already pins one module, but a source may serve several, so group by name
+	outdatedReleases := make(map[string][]outdatedRelease)
+
+	for _, mr := range releases.Items {
+		switch mr.GetPhase() {
+		case v1alpha1.ModuleReleasePhaseSuperseded, v1alpha1.ModuleReleasePhaseSuspended, v1alpha1.ModuleReleasePhaseSkipped:
+			outdatedReleases[mr.Spec.ModuleName] = append(outdatedReleases[mr.Spec.ModuleName], outdatedRelease{
+				name:    mr.GetName(),
+				version: mr.GetVersion(),
+			})
+		}
+	}
+
+	for moduleName, outdated := range outdatedReleases {
+		r.logger.Debug("found the following outdated releases for module", slog.String("name", moduleName), slog.Any("releases_list", outdated))
+
+		if len(outdated) <= outdatedReleasesKeepCount {
+			continue
+		}
+
+		// newest first, so the tail past the keep count is what goes
+		slices.SortFunc(outdated, func(a, b outdatedRelease) int {
+			return b.version.Compare(a.version)
+		})
+
+		for _, release := range outdated[outdatedReleasesKeepCount:] {
+			if err := r.client.Delete(ctx, newModuleReleaseWithName(release.name)); err != nil && !apierrors.IsNotFound(err) {
+				r.logger.Error("failed to delete outdated release", slog.String("outdated_release", release.name), log.Err(err))
+
+				return fmt.Errorf("delete outdated release: %w", err)
+			}
+
+			r.logger.Info("cleaned up outdated release", slog.String("outdated_release", release.name), slog.String("module_name", moduleName))
+		}
+	}
+
+	return nil
+}

--- a/deckhouse-controller/internal/controller/modules/release/pending.go
+++ b/deckhouse-controller/internal/controller/modules/release/pending.go
@@ -1,0 +1,578 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package release
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Masterminds/semver/v3"
+	"go.opentelemetry.io/otel"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/metrics"
+	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/schedule"
+	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
+	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha2"
+	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/controller/ctrlutils"
+	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/controller/module-controllers/utils"
+	releaseUpdater "github.com/deckhouse/deckhouse/deckhouse-controller/pkg/releaseupdater"
+	"github.com/deckhouse/deckhouse/pkg/log"
+)
+
+// handlePendingRelease decides whether a pending release may deploy now: it resolves the
+// update policy, asks the task calculator for a verdict, then gates on module readiness,
+// requirements and the deploy-time checks before applying. A forced release skips every gate.
+func (r *reconciler) handlePendingRelease(ctx context.Context, mr *v1alpha1.ModuleRelease) (ctrl.Result, error) {
+	ctx, span := otel.Tracer(controllerName).Start(ctx, "handlePendingRelease")
+	defer span.End()
+
+	var res ctrl.Result
+
+	logger := r.releaseLogger(mr)
+	logger.Debug("handle pending release")
+
+	policy, policyRes, err := r.resolvePolicy(ctx, mr, logger)
+	if err != nil {
+		return res, err
+	}
+
+	if policyRes != nil {
+		return *policyRes, nil
+	}
+
+	// parse notification config from the deckhouse-discovery secret
+	config, err := utils.GetNotificationConfig(ctx, r.client)
+	if err != nil {
+		logger.Error("failed to parse the notification config", log.Err(err))
+
+		return res, fmt.Errorf("get notification config: %w", err)
+	}
+
+	us := &releaseUpdater.Settings{
+		NotificationConfig: config,
+		Mode:               v1alpha2.ParseUpdateMode(policy.Spec.Update.Mode),
+		Windows:            policy.Spec.Update.Windows,
+		Subject:            releaseUpdater.SubjectModule,
+	}
+
+	if err = r.patchManualRelease(ctx, mr, us); err != nil {
+		return res, err
+	}
+
+	taskCalculator := releaseUpdater.NewModuleReleaseTaskCalculator(r.client, policy.Spec.ReleaseChannel, logger)
+
+	task, err := taskCalculator.CalculatePendingReleaseTask(ctx, mr)
+	if err != nil {
+		return res, fmt.Errorf("calculate pending release task: %w", err)
+	}
+
+	if mr.GetForce() {
+		logger.Warn("forced release found")
+
+		// deploy forced release without any checks (windows, requirements, approvals and so on)
+		if err = r.applyRelease(ctx, mr, task); err != nil {
+			logger.Error("apply forced release", log.Err(err))
+
+			return res, fmt.Errorf("apply forced release: %w", err)
+		}
+
+		r.logger.Info("a new module release deployed", slog.String("module", mr.GetModuleName()))
+
+		return ctrl.Result{}, nil
+	}
+
+	switch task.TaskType {
+	case releaseUpdater.Process:
+		// pass
+	case releaseUpdater.Skip:
+		logger.Debug("skip pending release")
+
+		err = r.updateReleaseStatus(ctx, mr, &v1alpha1.ModuleReleaseStatus{
+			Phase:   v1alpha1.ModuleReleasePhaseSkipped,
+			Message: task.Message,
+		})
+		if err != nil {
+			logger.Warn("skip order status update ", slog.String("release", mr.GetName()), log.Err(err))
+			return ctrl.Result{RequeueAfter: defaultRequeueAfter}, nil
+		}
+
+		return res, nil
+	case releaseUpdater.Await:
+		logger.Debug("await pending release")
+
+		err = r.updateReleaseStatus(ctx, mr, &v1alpha1.ModuleReleaseStatus{
+			Phase:   v1alpha1.ModuleReleasePhasePending,
+			Message: task.Message,
+		})
+		if err != nil {
+			logger.Warn("await order status update ", log.Err(err))
+		}
+
+		return ctrl.Result{RequeueAfter: defaultRequeueAfter}, nil
+	}
+
+	// a single or patch release is safe to lay down onto a module that is not settled yet,
+	// anything larger waits for the currently deployed version to become ready
+	if !task.IsSingle && !task.IsPatch && !r.isModuleReady(ctx, mr.GetModuleName()) {
+		logger.Debug("module is not ready, waiting")
+
+		message := "awaiting for module to be ready"
+		if task.DeployedReleaseInfo != nil {
+			message = fmt.Sprintf("awaiting for module v%s to be ready", task.DeployedReleaseInfo.Version.String())
+		}
+
+		if updateErr := r.updateReleaseStatus(ctx, mr, &v1alpha1.ModuleReleaseStatus{
+			Phase:   v1alpha1.ModuleReleasePhasePending,
+			Message: message,
+		}); updateErr != nil {
+			logger.Warn("module release status update failed", log.Err(updateErr))
+		}
+
+		err = r.updateModuleLastReleaseDeployedStatus(ctx, mr, "ModuleRelease could not be applied, awaiting for deployed release be ready", "ReleaseDeployedIsNotReady", false)
+		if err != nil {
+			return res, fmt.Errorf("update module last release deployed status: %w", err)
+		}
+
+		return ctrl.Result{RequeueAfter: defaultRequeueAfter}, nil
+	}
+
+	logger.Debug("process pending release")
+
+	metricLabels := releaseUpdater.NewReleaseMetricLabels(mr)
+	defer func() {
+		metricLabels[metrics.LabelMajorReleaseDepth] = strconv.Itoa(task.QueueDepth.GetMajorReleaseDepth())
+		if task.IsMajor {
+			metricLabels[metrics.LabelMajorReleaseName] = mr.GetName()
+		}
+
+		if task.IsFromTo {
+			metricLabels[metrics.LabelFromToName] = mr.GetName()
+		}
+
+		if metricLabels[metrics.LabelManualApprovalRequired] == "true" {
+			metricLabels[metrics.LabelReleaseQueueDepth] = strconv.Itoa(task.QueueDepth.GetReleaseQueueDepth())
+		}
+
+		r.metricsUpdater.UpdateReleaseMetric(mr.GetName(), metricLabels)
+	}()
+
+	// handling error inside function
+	if err = r.checkRequirements(ctx, mr, metricLabels, logger); err != nil {
+		// ignore this err, just requeue because of check failed
+		return ctrl.Result{RequeueAfter: defaultRequeueAfter}, nil
+	}
+
+	logger.Debug("requirements checks passed")
+
+	// handling error inside function
+	if err = r.preApplyReleaseCheck(ctx, mr, task, us, metricLabels); err != nil {
+		// ignore this err, just requeue because of check failed
+		return ctrl.Result{RequeueAfter: defaultRequeueAfter}, nil
+	}
+
+	logger.Debug("pre apply checks passed")
+
+	if err = r.applyRelease(ctx, mr, task); err != nil {
+		return res, fmt.Errorf("apply predicted release: %w", err)
+	}
+
+	// no deckhouse restart if dryrun
+	if mr.GetDryRun() {
+		return ctrl.Result{}, nil
+	}
+
+	r.logger.Info("a new module release deployed", slog.String("module", mr.GetModuleName()))
+
+	logger.Debug("module release deployed")
+
+	return ctrl.Result{RequeueAfter: defaultRequeueAfter}, nil
+}
+
+// resolvePolicy returns the update policy governing the release. A non-nil result means the
+// caller should return it instead of continuing: the policy is missing, or it ignores updates.
+func (r *reconciler) resolvePolicy(ctx context.Context, mr *v1alpha1.ModuleRelease, logger *log.Logger) (*v1alpha2.ModuleUpdatePolicy, *ctrl.Result, error) {
+	// if the release has associated update policy and it's not empty - just get it
+	// otherwise, try to get it from the module
+	policyName, found := mr.GetObjectMeta().GetLabels()[v1alpha1.ModuleReleaseLabelUpdatePolicy]
+	if !found || policyName == "" {
+		return r.updatePolicy(ctx, mr)
+	}
+
+	policy, err := r.getUpdatePolicy(ctx, policyName)
+	if err != nil {
+		r.metricStorage.CounterAdd(metrics.ModuleUpdatePolicyNotFound, 1.0, map[string]string{
+			metrics.LabelVersion:       mr.GetReleaseVersion(),
+			metrics.LabelModuleRelease: mr.GetName(),
+			metrics.LabelModule:        mr.GetModuleName(),
+		})
+
+		if uerr := r.updateReleaseStatusMessage(ctx, mr, fmt.Sprintf("Update policy %s not found", policyName)); uerr != nil {
+			logger.Error("failed to update release status", log.Err(uerr))
+
+			return nil, nil, uerr
+		}
+
+		logger.Error("failed to get update policy", slog.String("policy", policyName), log.Err(err))
+
+		return nil, &ctrl.Result{RequeueAfter: defaultRequeueAfter}, nil
+	}
+
+	// TODO(ipaqsa): remove it
+	if policy.Spec.Update.Mode == v1alpha2.ModuleUpdatePolicyModeIgnore {
+		if uerr := r.updateReleaseStatusMessage(ctx, mr, disabledByIgnorePolicy); uerr != nil {
+			logger.Error("failed to update release status", slog.String("release", mr.GetName()), log.Err(uerr))
+
+			return nil, nil, uerr
+		}
+
+		return nil, &ctrl.Result{RequeueAfter: defaultRequeueAfter * 4}, nil
+	}
+
+	return policy, nil, nil
+}
+
+// getUpdatePolicy reads the named policy, falling back to the embedded one when the name is
+// empty.
+func (r *reconciler) getUpdatePolicy(ctx context.Context, name string) (*v1alpha2.ModuleUpdatePolicy, error) {
+	if name == "" {
+		return &v1alpha2.ModuleUpdatePolicy{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       v1alpha2.ModuleUpdatePolicyGVK.Kind,
+				APIVersion: v1alpha2.ModuleUpdatePolicyGVK.GroupVersion().String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "",
+			},
+			Spec: *r.embeddedPolicy.Get(),
+		}, nil
+	}
+
+	policy := new(v1alpha2.ModuleUpdatePolicy)
+	if err := r.client.Get(ctx, client.ObjectKey{Name: name}, policy); err != nil {
+		return nil, fmt.Errorf("get update policy: %w", err)
+	}
+
+	return policy, nil
+}
+
+// updatePolicy discovers the policy that matches the module and stamps its name onto the
+// release, so later reconciles resolve it by label instead of rediscovering it.
+func (r *reconciler) updatePolicy(ctx context.Context, mr *v1alpha1.ModuleRelease) (*v1alpha2.ModuleUpdatePolicy, *ctrl.Result, error) {
+	policy, err := utils.GetUpdatePolicyByModule(ctx, r.client, r.embeddedPolicy, mr.GetModuleName())
+	if err != nil {
+		r.logger.Error("failed to get update policy", slog.String("release", mr.GetName()), log.Err(err))
+
+		if uerr := r.updateReleaseStatusMessage(ctx, mr, "Update policy not set. Create a suitable ModuleUpdatePolicy object"); uerr != nil {
+			r.logger.Error("failed to update release status", slog.String("release", mr.GetName()), log.Err(uerr))
+
+			return nil, nil, uerr
+		}
+
+		return nil, &ctrl.Result{RequeueAfter: defaultRequeueAfter}, nil
+	}
+
+	marshalledPatch, _ := json.Marshal(map[string]any{
+		"metadata": map[string]any{
+			"labels": map[string]any{
+				v1alpha1.ModuleReleaseLabelUpdatePolicy: policy.GetName(),
+			},
+		},
+		"status": map[string]string{
+			"message": "",
+		},
+	})
+
+	patch := client.RawPatch(types.MergePatchType, marshalledPatch)
+	if err = r.client.Patch(ctx, mr, patch); err != nil {
+		r.logger.Error("failed to patch module release", slog.String("release", mr.GetName()), log.Err(err))
+
+		return nil, &ctrl.Result{RequeueAfter: defaultRequeueAfter}, nil
+	}
+
+	// also patch status field
+	if err = r.client.Status().Patch(ctx, mr, patch); err != nil {
+		r.logger.Error("failed to patch module release status", slog.String("release", mr.GetName()), log.Err(err))
+
+		return nil, &ctrl.Result{RequeueAfter: defaultRequeueAfter}, nil
+	}
+
+	return policy, nil, nil
+}
+
+// patchManualRelease mirrors the release's manual approval into its status, so the task
+// calculator sees the approval an operator granted through the annotation.
+func (r *reconciler) patchManualRelease(ctx context.Context, mr *v1alpha1.ModuleRelease, us *releaseUpdater.Settings) error {
+	if us.Mode.String() != v1alpha2.UpdateModeManual.String() {
+		return nil
+	}
+
+	patch := client.MergeFrom(mr.DeepCopy())
+
+	mr.SetApprovedStatus(mr.GetManuallyApproved())
+
+	if err := r.client.Status().Patch(ctx, mr, patch); err != nil {
+		return fmt.Errorf("patch approved status: %w", err)
+	}
+
+	return nil
+}
+
+// errRequirementsNotMet reports that a release may not deploy yet. It is a control signal, not a
+// failure: the caller requeues on it rather than surfacing it.
+var errRequirementsNotMet = errors.New("release requirements are not met")
+
+// checkRequirements asks the scheduler whether the release's declared requirements hold against
+// the live cluster, and records the verdict on both the release and its module. It returns
+// errRequirementsNotMet when the release has to wait.
+func (r *reconciler) checkRequirements(ctx context.Context, mr *v1alpha1.ModuleRelease, metricLabels releaseUpdater.MetricLabels, logger *log.Logger) error {
+	constraints, err := releaseConstraints(mr)
+	if err != nil {
+		// requirements that cannot be parsed will not start parsing on a retry, but the release
+		// still has to report why it is stuck
+		logger.Error("failed to parse release requirements", log.Err(err))
+
+		return r.reportRequirementsNotMet(ctx, mr, metricLabels, err, logger)
+	}
+
+	if err = r.manager.CheckConstraints(mr.GetModuleName(), constraints); err != nil {
+		logger.Debug("release requirements are not met", log.Err(err))
+
+		return r.reportRequirementsNotMet(ctx, mr, metricLabels, err, logger)
+	}
+
+	return nil
+}
+
+// reportRequirementsNotMet parks the release in Pending with the reason and marks the module's
+// last-release-deployed condition false.
+func (r *reconciler) reportRequirementsNotMet(ctx context.Context, mr *v1alpha1.ModuleRelease, metricLabels releaseUpdater.MetricLabels, reason error, logger *log.Logger) error {
+	metricLabels.SetTrue(metrics.LabelRequirementsNotMet)
+
+	if err := r.updateReleaseStatus(ctx, mr, &v1alpha1.ModuleReleaseStatus{
+		Phase:   v1alpha1.ModuleReleasePhasePending,
+		Message: reason.Error(),
+	}); err != nil {
+		logger.Warn("met requirements status update ", log.Err(err))
+	}
+
+	if err := r.updateModuleLastReleaseDeployedStatus(ctx, mr, "ModuleRelease could not be applied, not met requirements", "ReleaseRequirementsCheck", false); err != nil {
+		return fmt.Errorf("update module last release deployed status: %w", err)
+	}
+
+	return errRequirementsNotMet
+}
+
+// releaseConstraints maps the release's declared requirements onto the scheduler's constraint
+// shape. Licensing, subscriptions and the enablement floor stay unset: admission evaluates only
+// the gate rules, and the floor is intent rather than a requirement.
+func releaseConstraints(mr *v1alpha1.ModuleRelease) (schedule.Constraints, error) {
+	// Order decides whether the bootstrap gate applies, so it has to match what
+	// modules.Definition builds for the same module or admission checks a different set of rules
+	// than the scheduler will.
+	order := schedule.Order(mr.GetWeight())
+	if order == 0 {
+		order = schedule.FunctionalOrder
+	}
+
+	constraints := schedule.Constraints{Order: order}
+
+	requirements := mr.GetModuleReleaseRequirements()
+	if requirements == nil {
+		return constraints, nil
+	}
+
+	kubernetes, err := parseConstraint(requirements.Kubernetes)
+	if err != nil {
+		return constraints, fmt.Errorf("parse kubernetes requirement: %w", err)
+	}
+
+	deckhouse, err := parseConstraint(requirements.Deckhouse)
+	if err != nil {
+		return constraints, fmt.Errorf("parse deckhouse requirement: %w", err)
+	}
+
+	constraints.Kubernetes = kubernetes
+	constraints.Deckhouse = deckhouse
+
+	if len(requirements.ParentModules) == 0 {
+		return constraints, nil
+	}
+
+	// parent modules are mandatory: the release declares them so they are enabled, so none of
+	// them is Optional
+	dependencies := make(map[string]schedule.Dependency, len(requirements.ParentModules))
+	for name, raw := range requirements.ParentModules {
+		constraint, cerr := parseConstraint(raw)
+		if cerr != nil {
+			return constraints, fmt.Errorf("parse the '%s' module requirement: %w", name, cerr)
+		}
+
+		dependencies[name] = schedule.Dependency{Constraint: constraint}
+	}
+
+	constraints.Dependencies = dependencies
+
+	return constraints, nil
+}
+
+// parseConstraint parses a semver constraint, reading an empty string as "no constraint".
+func parseConstraint(raw string) (*semver.Constraints, error) {
+	if raw == "" {
+		return nil, nil
+	}
+
+	return semver.NewConstraint(raw)
+}
+
+// msgReleaseIsBlockedByNotification is the status message of a release held back because its
+// notification could not be delivered.
+const msgReleaseIsBlockedByNotification = "Release is blocked, failed to send release notification"
+
+// errPreApplyCheckFailed reports that a release may not deploy yet. It is a control signal, not
+// a failure: the caller requeues on it rather than surfacing it.
+var errPreApplyCheckFailed = errors.New("pre apply check is failed")
+
+// timeResult is a deploy verdict plus whether the operator has already been notified about it.
+type timeResult struct {
+	*releaseUpdater.ProcessedDeployTimeResult
+	Notified bool
+}
+
+// preApplyReleaseCheck reports whether the release may deploy now. It returns nil when it may,
+// and errPreApplyCheckFailed after recording the reason and rescheduling the release.
+func (r *reconciler) preApplyReleaseCheck(ctx context.Context, mr *v1alpha1.ModuleRelease, task *releaseUpdater.Task, us *releaseUpdater.Settings, metricLabels releaseUpdater.MetricLabels) error {
+	ctx, span := otel.Tracer(controllerName).Start(ctx, "preApplyReleaseCheck")
+	defer span.End()
+
+	result := r.deployTimeCalculate(ctx, mr, task, us, metricLabels)
+	if result == nil {
+		return nil
+	}
+
+	err := r.updateReleaseStatus(ctx, mr, &v1alpha1.ModuleReleaseStatus{
+		Phase:   v1alpha1.ModuleReleasePhasePending,
+		Message: result.Message,
+	})
+	if err != nil {
+		r.logger.Warn("met release conditions status update ", slog.String("release", mr.GetName()), log.Err(err))
+	}
+
+	err = r.updateModuleLastReleaseDeployedStatus(ctx, mr, "ModuleRelease could not be applied, release postponed", "ReleaseDeployTimeCheck", false)
+	if err != nil {
+		return fmt.Errorf("update module last release deployed status: %w", err)
+	}
+
+	err = ctrlutils.UpdateWithRetry(ctx, r.client, mr, func() error {
+		if len(mr.Annotations) == 0 {
+			mr.Annotations = make(map[string]string, 2)
+		}
+
+		mr.Annotations[v1alpha1.ModuleReleaseAnnotationIsUpdating] = "false"
+		mr.Annotations[v1alpha1.ModuleReleaseAnnotationNotified] = strconv.FormatBool(result.Notified)
+
+		// a shifted apply time is the notification's promise to the operator, so record that the
+		// release now waits on a time it did not originally carry
+		if !result.ReleaseApplyAfterTime.IsZero() {
+			mr.Spec.ApplyAfter = &metav1.Time{Time: result.ReleaseApplyAfterTime.UTC()}
+
+			mr.Annotations[v1alpha1.ModuleReleaseAnnotationNotificationTimeShift] = "true"
+		}
+
+		return nil
+	}, ctrlutils.WithRetryOnConflictBackoff(retryBackoff()))
+	if err != nil {
+		r.logger.Warn("met release conditions resource update ", slog.String("release", mr.GetName()), log.Err(err))
+	}
+
+	return errPreApplyCheckFailed
+}
+
+// deployTimeCalculate reports why a release may not deploy yet, or nil when it may. A patch
+// release only weighs canary, notification and windows; anything larger additionally needs
+// disruption approval. A notification that cannot be delivered blocks the deploy.
+func (r *reconciler) deployTimeCalculate(ctx context.Context, mr v1alpha1.Release, task *releaseUpdater.Task, us *releaseUpdater.Settings, metricLabels releaseUpdater.MetricLabels) *timeResult {
+	releaseNotifier := releaseUpdater.NewReleaseNotifier(us)
+	timeChecker := releaseUpdater.NewDeployTimeServiceAt(time.Now().UTC(), us, r.logger)
+
+	if task.IsPatch {
+		deployTime := timeChecker.CalculatePatchDeployTime(mr, metricLabels)
+
+		if err := releaseNotifier.SendPatchReleaseNotification(ctx, mr, deployTime.ReleaseApplyTime, metricLabels); err != nil {
+			r.logger.Warn("send [patch] release notification", log.Err(err))
+
+			return blockedByNotification(deployTime)
+		}
+
+		processed := timeChecker.ProcessPatchReleaseDeployTime(mr, deployTime)
+		if processed == nil {
+			return nil
+		}
+
+		return &timeResult{ProcessedDeployTimeResult: processed, Notified: true}
+	}
+
+	// for minor release we must check additional conditions
+	checker := releaseUpdater.NewPreApplyChecker(us, r.logger)
+	if reasons := checker.MetRequirements(ctx, &mr); len(reasons) > 0 {
+		metricLabels.SetTrue(metrics.LabelDisruptionApprovalRequired)
+
+		msgs := make([]string, 0, len(reasons))
+		for _, reason := range reasons {
+			msgs = append(msgs, reason.Message)
+		}
+
+		return &timeResult{
+			ProcessedDeployTimeResult: &releaseUpdater.ProcessedDeployTimeResult{
+				Message: fmt.Sprintf("release blocked, disruption approval required: %s", strings.Join(msgs, ", ")),
+			},
+		}
+	}
+
+	deployTime := timeChecker.CalculateMinorDeployTime(mr, metricLabels)
+
+	if err := releaseNotifier.SendMinorReleaseNotification(ctx, mr, deployTime.ReleaseApplyTime, metricLabels); err != nil {
+		r.logger.Warn("send minor release notification", log.Err(err))
+
+		return blockedByNotification(deployTime)
+	}
+
+	processed := timeChecker.ProcessMinorReleaseDeployTime(mr, deployTime)
+	if processed == nil {
+		return nil
+	}
+
+	return &timeResult{ProcessedDeployTimeResult: processed, Notified: true}
+}
+
+// blockedByNotification builds the verdict for a release whose notification failed, carrying
+// the apply time forward so the release is retried rather than deployed unannounced.
+func blockedByNotification(deployTime *releaseUpdater.DeployTimeResult) *timeResult {
+	return &timeResult{
+		ProcessedDeployTimeResult: &releaseUpdater.ProcessedDeployTimeResult{
+			Message:               msgReleaseIsBlockedByNotification,
+			ReleaseApplyAfterTime: deployTime.ReleaseApplyAfterTime,
+		},
+	}
+}

--- a/deckhouse-controller/pkg/releaseupdater/deploy_time_checker.go
+++ b/deckhouse-controller/pkg/releaseupdater/deploy_time_checker.go
@@ -38,12 +38,18 @@ type DeployTimeService struct {
 }
 
 func NewDeployTimeService(dc dependency.Container, settings *Settings, logger *log.Logger) *DeployTimeService {
+	return NewDeployTimeServiceAt(dc.GetClock().Now().UTC(), settings, logger)
+}
+
+// NewDeployTimeServiceAt builds the service against an explicit now, for callers that carry no
+// dependency container. The service pins now once, so every check in one pass sees one instant.
+func NewDeployTimeServiceAt(now time.Time, settings *Settings, logger *log.Logger) *DeployTimeService {
 	return &DeployTimeService{
 		releaseNotifier: NewReleaseNotifier(settings),
 
 		settings: settings,
 
-		now: dc.GetClock().Now().UTC(),
+		now: now,
 
 		logger: logger,
 	}


### PR DESCRIPTION
> **Stacked PR.** Base branch is `chore/package-config-controller` (#21842), not `main`.
> Review that one first; this diff is only the release controller on top of it.

## Description

Ports the `ModuleRelease` controller into the AddonOperator-free tree at
`deckhouse-controller/internal/controller/modules/release/` and rewires it onto the package
runtime. It is the third module controller to move across, after `override` and `config`.

The controller's job shrinks to one decision: **which version of this module should be running.**
Everything downstream — pulling the image, placing it on disk, parsing the definition, applying
values, restarting hooks — is now the runtime's. `internal/controller/sync.go:153`
(`restoreReleases`) already performed this mapping at startup and was the model.

### Ownership after this change

| Concern | Owner |
| --- | --- |
| Which version runs | this controller → `UpdateModule` |
| Download, mount, load, hooks | runtime `Deploy`/`Load` tasks |
| Settings + enabled intent | config controller → `UpdateModulesSettings` |
| Schema validation, conversions | runtime values layer |

Note the split with the config controller: `UpdateModule` is called with `Name` and
`Definition.Version` only. Settings deliberately do **not** travel with the version.

### Dependencies dropped

- **addon-operator** — the `moduleManager` interface (`DisableModuleHooks`, `GetModule`,
  `IsModuleEnabled`, `PushRunModuleTask`, `AreModulesInited`) is gone. Reconciliation now gates on
  a caller-owned `preflight *sync.WaitGroup`, as in `config` and `override`.
- **`Installer`** — `Download`/`Stage`/`Install`/`Uninstall`/`IsEmbeddedPresent` all disappear.
  `deployModule` collapses from ~170 lines to reading a `ModuleSource` and calling `UpdateModule`;
  deleting a deployed release calls `RemoveModule`.
- **`dependency.Container`** — the four `dc.GetClock().Now()` calls become `time.Now()`.
  `pkg/releaseupdater` gains `NewDeployTimeServiceAt(now time.Time, …)` and the existing
  `NewDeployTimeService(dc, …)` delegates to it, so the DeckhouseRelease controller is untouched.
- **`extenders.IExtendersStack`** — replaced, see below.

`RegisterController` goes from eight parameters to six, behind one consumer-defined
`packageManager` interface (`UpdateModule` / `RemoveModule` / `CheckConstraints`).

### Requirements gating moves to the scheduler

`NewModuleReleaseRequirementsChecker(exts, …)` is replaced by the runtime's own
`Runtime.CheckConstraints`, which the Application validation webhook already uses
(`validate_application.go:297`). `releaseConstraints` maps `ModuleRelease.Spec.Requirements` onto
`schedule.Constraints`: `Kubernetes`/`Deckhouse` become semver constraints, `ParentModules`
become mandatory `Dependencies`.

`Order` is resolved the same way `modules/definition.go:122` does — `Order(Weight)`, falling back
to `FunctionalOrder` when the weight is 0. That matters: `CheckConstraints` only applies the
bootstrap gate when `Order == FunctionalOrder`, and `FunctionalOrder` is **999, not 0**, so a
zero-valued `Constraints` would silently check a weaker rule set than the module actually faces.

Two behaviour deltas worth knowing:

- **Cycle detection is new** — `CheckConstraints` also runs `simulateCycle`, so a release whose
  dependencies would form a cycle is now rejected at admission instead of at `AddNode`.
- **One reason at a time** — the old checker joined all unmet reasons with `;`; `CheckConstraints`
  returns the first `Forbid`.
- `anyOf`/`noneOf` are still not checked here: `ModuleReleaseRequirements` has no field for them.

### Deckhouse no longer restarts to pick up a module

`restartLoop`, the `SIGUSR2`-to-pid-1 `shutdownFunc`, `restartCheckTicker` and the three atomics
(`activeApplyCount`, `releaseWasProcessed`, `readyForRestart`) are all deleted. `UpdateModule`
enqueues `Disable → Deploy → Load` and the runtime reloads the module in place.

### Module documentation

`ensureDocumentation` now calls `utils.EnsureModuleDocumentation` with the same arguments the
config and override controllers build, instead of `utils.EnsureModuleDocumentationForRelease`.
This is not only cosmetic: the two helpers disagree on the mount path
(`/modules/<module>` vs `/modules/deployed/<module>`), and `deployed` is the correct one — modules
are mounted at `/deckhouse/downloaded/modules/deployed/<module>`. All three controllers now hand
docs-builder the same path. The old helper's last remaining caller is the pre-migration
`pkg/controller/module-controllers/release`.

### Restyle and alignment

The moved file was 1952 lines in one file, including ~260 lines of "Processing Pipeline / Example
Scenarios" doc comment. It is now **four files, 1603 lines**, split by reconcile path:
`controller.go` (wiring, dispatch, status writers), `pending.go` (may it deploy?), `deploy.go`
(the runtime handoff), `deployed.go` (maintenance + delete).

Conventions are now identical across `config`, `override` and `release`:

| | before | after |
| --- | --- | --- |
| CR variable | `release` (shadowed `package release`) | `mr`, matching `mc` / `mpo` |
| entry points | `handleRelease` / `deleteRelease` | `handleCreateOrUpdate` / `handleDelete` |
| requeue const | `defaultCheckInterval` / `moduleNotFoundInterval` | `defaultRequeueAfter` |
| logger | `logger` | `logger.Named(controllerName)` |
| Get failure | `ctrl.Result{Requeue: true}, nil` | `ctrl.Result{}, fmt.Errorf("get: %w", err)` |

The last one has teeth: `Requeue: true, nil` requeues *without* the rate limiter's exponential
backoff and drops the error from the controller's error metrics. `config` already returned the
error; `override` and `release` now match it (hence the small diffs in the other two files).

The `mr` rename was done with `gopls rename`, not a regex, so log messages and slog keys
containing the word "release" are untouched.

Three defects found and fixed while reading the moved code:

1. Two `logger.Warn(…, log.Err(err))` calls logged the outer `err` (nil at that point) instead of
   the `updateErr` just checked, silently swallowing the real failure.
2. `r.dependencyContainer.GetClock().Now()` — a statement whose result was discarded.
3. `downloadedModulesDir` and `symlinksDir` — struct fields assigned but never read (dead in the
   original too; its test only assigned them as well).

## Why do we need it, and what problem does it solve?

Modules still run on addon-operator while applications run on the package runtime; moving modules
across is the current migration. The `ModuleRelease` controller has to exist in the new tree
without an `AddonOperator` handle before module packages can be switched on behind
`DECKHOUSE_ENABLE_MODULE_PACKAGES`.

## Deliberately not in this PR

- **Not wired.** `RegisterController` has no caller yet, same as `config` and `override`;
  `internal/controller/controller.go` still has the runtime construction commented out. Compile
  and review only — `*runtime.Runtime` was verified to satisfy `packageManager` with a temporary
  compile-time assertion.
- **No tests.** The package has none, and neither do its two siblings. A black-box `testify` suite
  against a fake `packageManager` is the natural follow-up.
- **`ModuleConfigurationError` metric and the `ReleaseConfigValidationCheck` condition** are no
  longer set — the validation that raised them needed the module on disk. `resetConfigurationErrorMetric`
  was deleted rather than left clearing a metric nothing sets. Alerts keyed on it go quiet until
  the runtime reports schema failures through its own status path.
- **Embedded-module handover.** The `Properties.Source` flip off the `ModuleSourceEmbedded`
  sentinel went with the Install/Stage branch. The runtime loads embedded modules itself
  (`internal/packages/runtime/embedded.go`), so it should own that transition — needs confirming.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: chore
summary: Package release controller.
impact_level: low
```
