### PR TITLE
[node-local-dns] Fix known CVEs in coredns helper image

### DIFF
--- a/ee/be/modules/350-node-local-dns/images/coredns/src/go.mod
+++ b/ee/be/modules/350-node-local-dns/images/coredns/src/go.mod
@@ -1,6 +1,6 @@
 module coredns-helper
 
-go 1.25
+go 1.25.0
 
 require (
 	github.com/coreos/go-iptables v0.8.0
@@ -11,8 +11,8 @@ require (
 require (
 	github.com/vishvananda/netns v0.0.5 // indirect
 	golang.org/x/mod v0.29.0 // indirect
-	golang.org/x/net v0.46.0 // indirect
+	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/sync v0.17.0 // indirect
-	golang.org/x/sys v0.37.0 // indirect
+	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/tools v0.38.0 // indirect
 )

--- a/ee/be/modules/350-node-local-dns/images/coredns/src/go.sum
+++ b/ee/be/modules/350-node-local-dns/images/coredns/src/go.sum
@@ -10,13 +10,13 @@ github.com/vishvananda/netns v0.0.5 h1:DfiHV+j8bA32MFM7bfEunvT8IAqQ/NzSJHtcmW5zd
 github.com/vishvananda/netns v0.0.5/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
 golang.org/x/mod v0.29.0 h1:HV8lRxZC4l2cr3Zq1LvtOsi/ThTgWnUk/y64QSs8GwA=
 golang.org/x/mod v0.29.0/go.mod h1:NyhrlYXJ2H4eJiRy/WDBO6HMqZQ6q9nk4JzS3NuCK+w=
-golang.org/x/net v0.46.0 h1:giFlY12I07fugqwPuWJi68oOnpfqFnJIJzaIIm2JVV4=
-golang.org/x/net v0.46.0/go.mod h1:Q9BGdFy1y4nkUwiLvT5qtyhAnEHgnQ/zd8PfU6nc210=
+golang.org/x/net v0.56.0 h1:Rw8j/hFzGvJUZwNBXnAtf5sVDVt+65SK2C7IxCxZt5o=
+golang.org/x/net v0.56.0/go.mod h1:D3Ku6r+V6JROoZK144D2XfMHFcMq/0zSfLelVTCFKec=
 golang.org/x/sync v0.17.0 h1:l60nONMj9l5drqw6jlhIELNv9I0A4OFgRsG9k2oT9Ug=
 golang.org/x/sync v0.17.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.37.0 h1:fdNQudmxPjkdUTPnLn5mdQv7Zwvbvpaxqs831goi9kQ=
-golang.org/x/sys v0.37.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
+golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/tools v0.38.0 h1:Hx2Xv8hISq8Lm16jvBZ2VQf+RLmbd7wVUsALibYI/IQ=
 golang.org/x/tools v0.38.0/go.mod h1:yEsQ/d/YK8cjh0L6rZlY8tgtlKiBNTL14pGDJPJpYQs=


### PR DESCRIPTION
## Description

Remediate known CVEs in the `coredns` image of the `node-local-dns` module by bumping its Go dependencies in `images/coredns/src`:

- `golang.org/x/net` to `v0.56.0`.
- `golang.org/x/sys` to `v0.46.0`.
- Normalize the Go directive to `1.25.0`.

These changes rebuild the `coredns` image. Expect a restart of the `node-local-dns` DaemonSet pods on every node after the update.

## Why do we need it, and what problem does it solve?

The `coredns` helper image shipped with vulnerable versions of `golang.org/x/net` and `golang.org/x/sys`. The remediated issues include multiple HIGH-severity XSS and privilege-escalation findings in `golang.org/x/net/html` and `golang.org/x/net/idna` (CVE-2026-25681, CVE-2026-27136, CVE-2026-39821, CVE-2026-42502, CVE-2026-42506), HTTP/2 and HTML-parsing denial-of-service issues (CVE-2026-33814, CVE-2026-25680, CVE-2026-27141, CVE-2026-46600), and an integer overflow in `golang.org/x/sys/windows` (CVE-2026-39824). Bumping the dependencies removes these vulnerabilities from the delivered binary.

## Why do we need it in the patch release (if we do)?

The fixes eliminate HIGH-severity vulnerabilities from an image that ships in every cluster running the `node-local-dns` module. Backporting to the patch release delivers the security fixes to users on current releases without waiting for the next major release.

## Checklist

- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: node-local-dns
type: fix
summary: Bump Go dependencies in the coredns helper image to fix known CVEs.
impact: The node-local-dns DaemonSet pods will restart after the update.
impact_level: high
```