### PR TITLE
[CI] Fix nginx static artifact

### DIFF
--- a/modules/402-ingress-nginx/images/proxy-failover/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/proxy-failover/werf.inc.yaml
@@ -37,6 +37,7 @@ shell:
 ---
 image: {{ .ModuleName }}/nginx-static-artifact
 fromImage: common/nginx-static
+final: false
 git:
 - add: /{{ $.ModulePath }}modules/402-{{ $.ModuleName }}/images/{{ $.ImageName }}/conf/
   to: /opt/nginx-static/conf

--- a/testing/library/images_tags_generated.go
+++ b/testing/library/images_tags_generated.go
@@ -313,7 +313,6 @@ var DefaultImagesDigests = map[string]interface{}{
 		"kubeRbacProxy":            "imageHash-ingressNginx-kubeRbacProxy",
 		"kubeRbacProxyVexArtifact": "imageHash-ingressNginx-kubeRbacProxyVexArtifact",
 		"nginxExporter":            "imageHash-ingressNginx-nginxExporter",
-		"nginxStaticArtifact":      "imageHash-ingressNginx-nginxStaticArtifact",
 		"protobufExporter":         "imageHash-ingressNginx-protobufExporter",
 		"proxyFailover":            "imageHash-ingressNginx-proxyFailover",
 		"proxyFailoverIptables":    "imageHash-ingressNginx-proxyFailoverIptables",


### PR DESCRIPTION
## Description

Mark `ingress-nginx/nginx-static-artifact` as a non-final Werf image.

No impact on cluster components or runtime images.

## Why do we need it, and what problem does it solve?

`nginx-static-artifact` is an intermediate image imported into `proxy-failover`, but was reported by Werf as final. The CI changed-images check then tried to find its digest in `images_digests.json` and failed, blocking builds.

## Why do we need it in the patch release (if we do)?

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: ci
type: chore
summary: Fix CI handling of the ingress-nginx intermediate build image.
impact_level: low