### PR TITLE
[bashible] Containerd v2 integrity migration fix for cse

### DIFF
--- a/candi/bashible/common-steps/all/031_install_containerd.sh.tpl
+++ b/candi/bashible/common-steps/all/031_install_containerd.sh.tpl
@@ -62,6 +62,20 @@ cntrd_version_change_check() {
 
 command -v containerd &>/dev/null && cntrd_version_change_check
 
+{{- $integrityEditions := list "CSE" }}
+{{- if and (eq .cri "ContainerdV2") (has .deckhouse.edition $integrityEditions) }}
+cntrd_integrity_migration_check() {
+  if containerd --help 2>/dev/null | grep -q -- '--integrity-check-interval'; then
+    return 0
+  fi
+  bb-log-info "Switching to containerd with integrity checks, containerd state wipe is required"
+  bb-flag-set cntrd-integrity-migration-required
+  bb-deckhouse-get-disruptive-update-approval
+}
+
+command -v containerd &>/dev/null && cntrd_integrity_migration_check
+{{- end }}
+
 if bb-is-distro-like? "rhel"; then
   if bb-dnf-package? "selinux-policy"; then
     if ! bb-dnf-package? "container-selinux"; then

--- a/candi/bashible/common-steps/all/031_install_containerd.sh.tpl
+++ b/candi/bashible/common-steps/all/031_install_containerd.sh.tpl
@@ -77,6 +77,9 @@ command -v containerd &>/dev/null && cntrd_integrity_migration_check
 
 if bb-flag? cntrd-integrity-migration-required; then
   bb-log-info "Pre-installing local image packages before containerd state wipe"
+  if ! bb-flag? cntrd-major-version-changed; then
+    bb-flag-set cntrd-integrity-restore-kubelet
+  fi
   bb-package-install "pause:{{ $.images.registrypackages.pause }}"
   bb-package-install "kubernetes-api-proxy:{{ $.images.registrypackages.kubernetesApiProxy }}"
   bb-package-install "registry-proxy:{{ $.images.registrypackages.registryProxy }}"

--- a/candi/bashible/common-steps/all/031_install_containerd.sh.tpl
+++ b/candi/bashible/common-steps/all/031_install_containerd.sh.tpl
@@ -74,6 +74,13 @@ cntrd_integrity_migration_check() {
 }
 
 command -v containerd &>/dev/null && cntrd_integrity_migration_check
+
+if bb-flag? cntrd-integrity-migration-required; then
+  bb-log-info "Pre-installing local image packages before containerd state wipe"
+  bb-package-install "pause:{{ $.images.registrypackages.pause }}"
+  bb-package-install "kubernetes-api-proxy:{{ $.images.registrypackages.kubernetesApiProxy }}"
+  bb-package-install "registry-proxy:{{ $.images.registrypackages.registryProxy }}"
+fi
 {{- end }}
 
 if bb-is-distro-like? "rhel"; then

--- a/candi/bashible/common-steps/all/032_configure_containerd.sh.tpl
+++ b/candi/bashible/common-steps/all/032_configure_containerd.sh.tpl
@@ -33,6 +33,7 @@ migrate() {
   bb-flag-set need-local-images-import
   bb-flag-set reboot
   bb-flag-unset cntrd-major-version-changed
+  bb-flag-unset cntrd-integrity-migration-required
   bb-flag-unset disruption
   bb-log-info "Finished containerd migration"
 }
@@ -499,7 +500,7 @@ EOF
 {{- end }}
 
 {{- if or ( eq .cri "Containerd") ( eq .cri "ContainerdV2") }}
-if bb-flag? cntrd-major-version-changed; then
+if bb-flag? cntrd-major-version-changed || bb-flag? cntrd-integrity-migration-required; then
   migrate
 fi
 {{- end }}

--- a/candi/bashible/common-steps/all/033_restart_containerd_if_needed.sh.tpl
+++ b/candi/bashible/common-steps/all/033_restart_containerd_if_needed.sh.tpl
@@ -23,5 +23,11 @@ if bb-flag? containerd-need-restart; then
   fi
   bb-flag-set kubelet-need-restart
   bb-flag-unset containerd-need-restart
+
+  if bb-flag? cntrd-integrity-restore-kubelet; then
+    bb-log-info "Containerd state was wiped, starting kubelet to restore apiserver access"
+    systemctl start kubelet.service
+    bb-flag-unset cntrd-integrity-restore-kubelet
+  fi
 fi
 {{- end }}

--- a/docs/documentation/pages/admin/configuration/update/SWITCHING_EDITIONS_RU.md
+++ b/docs/documentation/pages/admin/configuration/update/SWITCHING_EDITIONS_RU.md
@@ -653,6 +653,13 @@ deckhouse=registry-cse.deckhouse.ru/deckhouse/cse:$DECKHOUSE_VERSION
 
 {% tab "На DKP CSE" %}
 1. При переключении на DKP CSE возможна временная недоступность компонентов кластера.
+1. Каждый узел кластера будет поочерёдно перезагружен с очисткой кэша образов containerd. Чтобы управлять моментом перезагрузки, заранее переведите все NodeGroup, включая `master`, в ручной режим подтверждения простоя:
+
+   ```shell
+   d8 k patch ng <ИМЯ_NODEGROUP> --type=merge -p '{"spec":{"disruptions":{"approvalMode":"Manual"}}}'
+   ```
+
+   Исходное значение верните после завершения переключения.
 1. Переключение на DKP CSE возможно только с DKP EE (Enterprise Edition). Переключение поддерживается только **между одинаковыми минорными версиями** DKP. Например, с DKP EE 1.67.x на DKP CSE 1.67.x.
 
    При необходимости, выполните обновление DKP EE до соответствующей минорной версии и последней патч-версии.
@@ -868,6 +875,10 @@ deckhouse=registry-cse.deckhouse.ru/deckhouse/cse:$DECKHOUSE_VERSION
 1. Проверьте поды с образами из хранилища образов контейнеров для старой редакции:
 
    {{ check_old_pods | regex_replace: "^", "   " }}
+
+1. **Только для DKP CSE** — подтвердите перезагрузку узлов:
+
+   {{ cse_containerd_migration | regex_replace: "^", "   " }}
 
 1. **Только для DKP CSE** — установите `releaseChannel` в moduleConfig `deckhouse`:
 
@@ -1116,6 +1127,10 @@ deckhouse=registry-cse.deckhouse.ru/deckhouse/cse:$DECKHOUSE_VERSION
       | regex_replace: "<!/?REMOVE_FOR_CSE_1_58>\n?", ""
       | regex_replace: "^", "   "
    }}
+
+1. Подтвердите перезагрузку узлов:
+
+   {{ cse_containerd_migration | regex_replace: "^", "   " }}
 
 1. Дождитесь готовности DKP:
 

--- a/docs/documentation/pages/admin/configuration/update/SWITCHING_EDITIONS_RU.md
+++ b/docs/documentation/pages/admin/configuration/update/SWITCHING_EDITIONS_RU.md
@@ -218,6 +218,33 @@ d8 k get pods -A -o json | jq -r '.items[] | select(.spec.containers[] | select(
 
 {% endcapture %}
 
+{% capture cse_containerd_migration %}
+Каждый узел один раз перезагрузится с очисткой кэша образов containerd. После перезагрузки узел заново скачает все образы из хранилища образов контейнеров.
+
+Подтверждайте узлы по одному, дожидаясь возвращения каждого в состояние `Ready`.
+
+В ручном режиме подтверждения простоя DKP не вытесняет поды с узла — аннотация подтверждения сразу разрешает очистку состояния containerd. Вытесните нагрузку самостоятельно:
+
+```shell
+d8 k drain <ИМЯ_УЗЛА> --ignore-daemonsets --delete-emptydir-data
+```
+
+Не подтверждайте узел, пока манифесты control plane на master-узлах не начнут ссылаться на образы DKP CSE: команда `grep image: /etc/kubernetes/manifests/*` не должна возвращать строк с `deckhouse/ee`. Если такие строки ещё есть, дождитесь, пока control-plane-manager перепишет манифесты. До подтверждения узел работает штатно, но не переходит в состояние `UPTODATE`.
+
+Подтвердите обновление узла:
+
+```shell
+d8 k annotate node <ИМЯ_УЗЛА> update.node.deckhouse.io/disruption-approved=
+```
+
+После возвращения узла в состояние `Ready` верните его в планирование:
+
+```shell
+d8 k uncordon <ИМЯ_УЗЛА>
+```
+
+{% endcapture %}
+
 {% capture change_registry_mc_deckhouse_unmanaged %}
 
 ```yaml

--- a/docs/documentation/pages/admin/configuration/update/SWITCHING_EDITIONS_RU.md
+++ b/docs/documentation/pages/admin/configuration/update/SWITCHING_EDITIONS_RU.md
@@ -219,6 +219,19 @@ d8 k get pods -A -o json | jq -r '.items[] | select(.spec.containers[] | select(
 
 {% endcapture %}
 
+{% capture cse_containerd_migration %}
+Каждый узел один раз перезагрузится с очисткой кэша образов containerd. После перезагрузки узел заново скачает все образы из хранилища образов контейнеров.
+
+Подтверждайте узлы по одному, дожидаясь возвращения каждого в состояние `Ready`:
+
+```shell
+d8 k annotate node <ИМЯ_УЗЛА> update.node.deckhouse.io/disruption-approved=
+```
+
+До подтверждения узел работает штатно, но не переходит в состояние `UPTODATE`.
+
+{% endcapture %}
+
 {% capture enable_chrony_cse %}
 
 ```shell
@@ -586,6 +599,13 @@ d8 k delete ngc containerdv2-$NEW_EDITION-config.sh
 
 {% tab "На DKP CSE" %}
 1. При переключении на DKP CSE возможна временная недоступность компонентов кластера.
+1. Каждый узел кластера будет поочерёдно перезагружен с очисткой кэша образов containerd. Чтобы управлять моментом перезагрузки, заранее переведите все NodeGroup, включая `master`, в ручной режим подтверждения простоя:
+
+   ```shell
+   d8 k patch ng <ИМЯ_NODEGROUP> --type=merge -p '{"spec":{"disruptions":{"approvalMode":"Manual"}}}'
+   ```
+
+   Исходное значение верните после завершения переключения.
 1. Переключение на DKP CSE возможно только с DKP EE (Enterprise Edition). Переключение поддерживается только **между одинаковыми минорными версиями** DKP. Например, с DKP EE 1.67.x на DKP CSE 1.67.x.
 
    При необходимости, выполните обновление DKP EE до соответствующей минорной версии и последней патч-версии.
@@ -891,6 +911,10 @@ d8 k delete ngc containerdv2-$NEW_EDITION-config.sh
 
    {{ check_old_pods | regex_replace: "^", "   " }}
 
+1. **Только для DKP CSE** — подтвердите перезагрузку узлов:
+
+   {{ cse_containerd_migration | regex_replace: "^", "   " }}
+
 1. **Только для DKP CSE** — установите `releaseChannel` в moduleConfig `deckhouse`:
 
    {{ enable_release_channel_cse | regex_replace: "^", "   " }}
@@ -1107,6 +1131,10 @@ d8 k delete ngc containerdv2-$NEW_EDITION-config.sh
    }}
 
    {{ take_care_deckhuse_imagepullbackoff }}
+
+1. Подтвердите перезагрузку узлов:
+
+   {{ cse_containerd_migration | regex_replace: "^", "   " }}
 
 1. Дождитесь готовности DKP:
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Describe containerd state migration for ContainerdV2 nodes when switching from EE to CSE

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: fix
summary: Describe containerd state migration for ContainerdV2 nodes when switching from EE to CSE
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
