### PR TITLE
[istio] Change runAsUser to DH for module non-dataplane containers

### DIFF
--- a/ee/modules/110-istio/images/config-analyzer-v1x25x2/werf.inc.yaml
+++ b/ee/modules/110-istio/images/config-analyzer-v1x25x2/werf.inc.yaml
@@ -14,7 +14,6 @@ import:
   before: install
 imageSpec:
   config:
-    user: "64535:64535"
     entrypoint: ["/istio-config-analyzer"]
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact

--- a/ee/modules/110-istio/images/config-analyzer-v1x27x9/werf.inc.yaml
+++ b/ee/modules/110-istio/images/config-analyzer-v1x27x9/werf.inc.yaml
@@ -14,7 +14,6 @@ import:
   before: install
 imageSpec:
   config:
-    user: "64535:64535"
     entrypoint: ["/istio-config-analyzer"]
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact

--- a/ee/modules/110-istio/images/config-analyzer-v1x29x6/werf.inc.yaml
+++ b/ee/modules/110-istio/images/config-analyzer-v1x29x6/werf.inc.yaml
@@ -14,7 +14,6 @@ import:
   before: install
 imageSpec:
   config:
-    user: "64535:64535"
     entrypoint: ["/istio-config-analyzer"]
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact

--- a/ee/modules/110-istio/images/ztunnel-v1x25x2/werf.inc.yaml
+++ b/ee/modules/110-istio/images/ztunnel-v1x25x2/werf.inc.yaml
@@ -31,7 +31,6 @@ import:
     before: install
 imageSpec:
   config:
-    user: "1337:1337"
     env:  
       ISTIO_META_ISTIO_VERSION: {{ $istioVersion }}
     entrypoint: ["/usr/local/bin/ztunnel"]

--- a/ee/modules/110-istio/images/ztunnel-v1x27x9/werf.inc.yaml
+++ b/ee/modules/110-istio/images/ztunnel-v1x27x9/werf.inc.yaml
@@ -32,7 +32,6 @@ import:
     before: install
 imageSpec:
   config:
-    user: "1337:1337"
     env:  
       ISTIO_META_ISTIO_VERSION: {{ $istioVersion }}
     entrypoint: ["/usr/local/bin/ztunnel"]

--- a/ee/modules/110-istio/images/ztunnel-v1x29x6/werf.inc.yaml
+++ b/ee/modules/110-istio/images/ztunnel-v1x29x6/werf.inc.yaml
@@ -32,7 +32,6 @@ import:
     before: install
 imageSpec:
   config:
-    user: "1337:1337"
     env:  
       ISTIO_META_ISTIO_VERSION: {{ $istioVersion }}
     entrypoint: ["/usr/local/bin/ztunnel"]

--- a/ee/modules/110-istio/monitoring/prometheus-rules/config-analysis.yaml
+++ b/ee/modules/110-istio/monitoring/prometheus-rules/config-analysis.yaml
@@ -252,8 +252,9 @@
         d8 k -n d8-istio logs -l app=istio-config-analyzer,istio.io/rev={{$labels.revision}} --tail=100
         ```
   # InvalidApplicationUID (IST0144) is intentionally muted: Deckhouse Istio
-  # components (operator/pilot/…) run as UID 1337 by design, and application
-  # misuse of UID 1337 is already covered by IstioApplicationsUsingReservedUID.
+  # dataplane components (istio-proxy sidecar / ingressgateway) still run as UID
+  # 1337 by design, and application misuse of UID 1337 is already covered by
+  # IstioApplicationsUsingReservedUID.
   - alert: D8IstioConfigAnalysisWarning
     expr: |
       sum by (revision, type, namespace, resource, code) (

--- a/ee/modules/110-istio/templates/config-analyzer/deployment.yaml
+++ b/ee/modules/110-istio/templates/config-analyzer/deployment.yaml
@@ -66,7 +66,7 @@ spec:
       containers:
       - name: istio-config-analyzer
         image: {{ include "helm_lib_module_image" (list $ (printf "configAnalyzer%s" $imageSuffix)) }}
-        {{- include "helm_lib_module_container_security_context_pss_restricted_flexible" (dict "uid" 64535) | nindent 8 }}
+        {{- include "helm_lib_module_container_security_context_pss_restricted_flexible" dict | nindent 8 }}
         imagePullPolicy: IfNotPresent
         args:
         - "--istio-namespace=d8-{{ $.Chart.Name }}"

--- a/modules/110-istio/images/cni-v1x25x2/werf.inc.yaml
+++ b/modules/110-istio/images/cni-v1x25x2/werf.inc.yaml
@@ -11,14 +11,14 @@ import:
 - image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /src/istio/out/istio-cni
   to: /opt/cni/bin/istio-cni
-  owner: 1337
-  group: 1337
+  owner: 64535
+  group: 64535
   after: setup
 - image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /src/istio/out/install-cni
   to: /usr/local/bin/install-cni
-  owner: 1337
-  group: 1337
+  owner: 64535
+  group: 64535
   after: setup
 - image: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
   add: /relocate
@@ -40,7 +40,6 @@ imageSpec:
   config:
     env: {"PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/cni/bin"}
     workingDir: "/opt/cni/bin"
-    user: "1337:1337"
     entrypoint: ["/usr/local/bin/install-cni"]
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
@@ -82,7 +81,7 @@ shell:
   - strip /src/istio/out/install-cni
   - strip /src/istio/out/istio-cni
   - chmod 0700 /src/istio/out/install-cni /src/istio/out/istio-cni
-  - chown 1337:1337 /src/istio/out/istio-cni
+  - chown 64535:64535 /src/istio/out/istio-cni
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
 from: {{ index $.Images "builder/distroless" }}

--- a/modules/110-istio/images/cni-v1x27x9/werf.inc.yaml
+++ b/modules/110-istio/images/cni-v1x27x9/werf.inc.yaml
@@ -12,14 +12,14 @@ import:
 - image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /src/istio/out/istio-cni
   to: /opt/cni/bin/istio-cni
-  owner: 1337
-  group: 1337
+  owner: 64535
+  group: 64535
   after: setup
 - image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /src/istio/out/install-cni
   to: /usr/local/bin/install-cni
-  owner: 1337
-  group: 1337
+  owner: 64535
+  group: 64535
   after: setup
 - image: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
   add: /relocate
@@ -42,7 +42,6 @@ imageSpec:
     env:
       PATH: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/cni/bin"
     workingDir: "/opt/cni/bin"
-    user: "1337:1337"
     entrypoint: ["/usr/local/bin/install-cni"]
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
@@ -84,7 +83,7 @@ shell:
   - strip /src/istio/out/install-cni
   - strip /src/istio/out/istio-cni
   - chmod 0700 /src/istio/out/install-cni /src/istio/out/istio-cni
-  - chown 1337:1337 /src/istio/out/istio-cni
+  - chown 64535:64535 /src/istio/out/istio-cni
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
 from: {{ index $.Images "builder/distroless" }}

--- a/modules/110-istio/images/cni-v1x29x6/werf.inc.yaml
+++ b/modules/110-istio/images/cni-v1x29x6/werf.inc.yaml
@@ -12,14 +12,14 @@ import:
 - image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /src/istio/out/istio-cni
   to: /opt/cni/bin/istio-cni
-  owner: 1337
-  group: 1337
+  owner: 64535
+  group: 64535
   after: setup
 - image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /src/istio/out/install-cni
   to: /usr/local/bin/install-cni
-  owner: 1337
-  group: 1337
+  owner: 64535
+  group: 64535
   after: setup
 - image: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
   add: /relocate
@@ -42,7 +42,6 @@ imageSpec:
     env:
       PATH: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/cni/bin"
     workingDir: "/opt/cni/bin"
-    user: "1337:1337"
     entrypoint: ["/usr/local/bin/install-cni"]
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
@@ -84,7 +83,7 @@ shell:
   - strip /src/istio/out/install-cni
   - strip /src/istio/out/istio-cni
   - chmod 0700 /src/istio/out/install-cni /src/istio/out/istio-cni
-  - chown 1337:1337 /src/istio/out/istio-cni
+  - chown 64535:64535 /src/istio/out/istio-cni
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
 from: {{ index $.Images "builder/distroless" }}

--- a/modules/110-istio/images/kiali-v1x25x2/werf.inc.yaml
+++ b/modules/110-istio/images/kiali-v1x25x2/werf.inc.yaml
@@ -10,15 +10,18 @@ import:
 - image: {{ .ModuleName }}/{{ .ImageName }}-backend-build-artifact
   add: /src/kiali/out/kiali
   to: /opt/kiali/kiali
+  owner: 64535
+  group: 64535
   before: install
 - image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-kiali-frontend-build-artifact
   add: /src/kial-frontend-assets/static
   to: /opt/kiali/console
+  owner: 64535
+  group: 64535
   before: install
 {{- include "image mount points" . }}
 imageSpec:
   config:
-    user: "1000"
     workingDir: "/opt/kiali"
     entrypoint: ["/opt/kiali/kiali"]
 ---

--- a/modules/110-istio/images/kiali-v1x27x9/werf.inc.yaml
+++ b/modules/110-istio/images/kiali-v1x27x9/werf.inc.yaml
@@ -17,7 +17,6 @@ import:
 {{- include "image mount points" . }}
 imageSpec:
   config:
-    user: "64535:64535"
     workingDir: "/opt/kiali"
     entrypoint: ["/opt/kiali/kiali"]
 ---

--- a/modules/110-istio/images/kiali-v1x29x6/werf.inc.yaml
+++ b/modules/110-istio/images/kiali-v1x29x6/werf.inc.yaml
@@ -17,7 +17,6 @@ import:
 {{- include "image mount points" . }}
 imageSpec:
   config:
-    user: "64535:64535"
     workingDir: "/opt/kiali"
     entrypoint: ["/opt/kiali/kiali"]
 ---

--- a/modules/110-istio/images/operator-v1x21x6/werf.inc.yaml
+++ b/modules/110-istio/images/operator-v1x21x6/werf.inc.yaml
@@ -9,8 +9,8 @@ import:
 - image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /src/istio/out/operator
   to: /usr/local/bin/operator
-  owner: 1337
-  group: 1337
+  owner: 64535
+  group: 64535
   after: setup
 - image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /src/istio/manifests
@@ -18,7 +18,6 @@ import:
   after: setup
 imageSpec:
   config:
-    user: "1337:1337"
     entrypoint: ["/usr/local/bin/operator"]
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
@@ -65,5 +64,6 @@ shell:
   - common/scripts/gobuild.sh /src/istio/out/ -tags=agent,disable_pgv /src/istio/operator/cmd/operator/
   - strip /src/istio/out/operator
   - chmod 0700 /src/istio/out/operator
+  - chown 64535:64535 /src/istio/out/operator
 ---
 {{- include "vex mitigation" (list $ (printf "%s/%s" $.ModuleName $.ImageName)) }}

--- a/modules/110-istio/images/operator-v1x25x2/werf.inc.yaml
+++ b/modules/110-istio/images/operator-v1x25x2/werf.inc.yaml
@@ -9,8 +9,8 @@ import:
 - image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /src/operator/out/operator
   to: /usr/local/bin/operator
-  owner: 1337
-  group: 1337
+  owner: 64535
+  group: 64535
   after: setup
 - image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
   add: /src/istio/manifests
@@ -23,7 +23,6 @@ import:
 {{- include "image mount points" . }}
 imageSpec:
   config:
-    user: "1337:1337"
     workingDir: "/"
     entrypoint: ["/usr/local/bin/operator"]
 ---
@@ -53,7 +52,7 @@ shell:
   - strip /src/operator/out/main
   - mv /src/operator/out/main /src/operator/out/operator
   - chmod 0700 /src/operator/out/operator
-  - chown 1337:1337 /src/operator/out/operator
+  - chown 64535:64535 /src/operator/out/operator
 #=====================================================================================================
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact

--- a/modules/110-istio/images/pilot-v1x25x2/werf.inc.yaml
+++ b/modules/110-istio/images/pilot-v1x25x2/werf.inc.yaml
@@ -9,19 +9,18 @@ import:
 - image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /src/istio/out/pilot-discovery
   to: /usr/local/bin/pilot-discovery
-  owner: 1337
-  group: 1337
+  owner: 64535
+  group: 64535
   after: setup
 - image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
   add: /src/istio/tools/packaging/common/envoy_bootstrap.json
   to: /var/lib/istio/envoy/envoy_bootstrap_tmpl.json
-  owner: 1337
-  group: 1337
+  owner: 64535
+  group: 64535
   after: setup
 {{- include "image mount points" . }}
 imageSpec:
   config:
-    user: "1337:1337"
     entrypoint: ["/usr/local/bin/pilot-discovery"]
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
@@ -61,6 +60,6 @@ shell:
   - common/scripts/gobuild.sh /src/istio/out/ -tags=disable_pgv /src/istio/pilot/cmd/pilot-discovery/
   - strip /src/istio/out/pilot-discovery
   - chmod 0700 /src/istio/out/pilot-discovery
-  - chown 1337:1337 /src/istio/out/pilot-discovery
+  - chown 64535:64535 /src/istio/out/pilot-discovery
 ---
 {{- include "vex mitigation" (list $ (printf "%s/%s" $.ModuleName $.ImageName)) }}

--- a/modules/110-istio/images/pilot-v1x27x9/werf.inc.yaml
+++ b/modules/110-istio/images/pilot-v1x27x9/werf.inc.yaml
@@ -10,19 +10,18 @@ import:
 - image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /src/istio/out/pilot-discovery
   to: /usr/local/bin/pilot-discovery
-  owner: 1337
-  group: 1337
+  owner: 64535
+  group: 64535
   after: setup
 - image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
   add: /src/istio/tools/packaging/common/envoy_bootstrap.json
   to: /var/lib/istio/envoy/envoy_bootstrap_tmpl.json
-  owner: 1337
-  group: 1337
+  owner: 64535
+  group: 64535
   after: setup
 {{- include "image mount points" . }}
 imageSpec:
   config:
-    user: "1337:1337"
     entrypoint: ["/usr/local/bin/pilot-discovery"]
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
@@ -62,7 +61,7 @@ shell:
   - common/scripts/gobuild.sh /src/istio/out/ -tags=disable_pgv /src/istio/pilot/cmd/pilot-discovery/
   - strip /src/istio/out/pilot-discovery
   - chmod 0700 /src/istio/out/pilot-discovery
-  - chown 1337:1337 /src/istio/out/pilot-discovery
+  - chown 64535:64535 /src/istio/out/pilot-discovery
 ---
 {{- include "vex mitigation" (list $ (printf "%s/%s" $.ModuleName $.ImageName)) }}
 {{- end }}

--- a/modules/110-istio/images/pilot-v1x29x6/werf.inc.yaml
+++ b/modules/110-istio/images/pilot-v1x29x6/werf.inc.yaml
@@ -10,19 +10,18 @@ import:
 - image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /src/istio/out/pilot-discovery
   to: /usr/local/bin/pilot-discovery
-  owner: 1337
-  group: 1337
+  owner: 64535
+  group: 64535
   after: setup
 - image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
   add: /src/istio/tools/packaging/common/envoy_bootstrap.json
   to: /var/lib/istio/envoy/envoy_bootstrap_tmpl.json
-  owner: 1337
-  group: 1337
+  owner: 64535
+  group: 64535
   after: setup
 {{- include "image mount points" . }}
 imageSpec:
   config:
-    user: "1337:1337"
     entrypoint: ["/usr/local/bin/pilot-discovery"]
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
@@ -62,7 +61,7 @@ shell:
   - common/scripts/gobuild.sh /src/istio/out/ -tags=disable_pgv /src/istio/pilot/cmd/pilot-discovery/
   - strip /src/istio/out/pilot-discovery
   - chmod 0700 /src/istio/out/pilot-discovery
-  - chown 1337:1337 /src/istio/out/pilot-discovery
+  - chown 64535:64535 /src/istio/out/pilot-discovery
 ---
 {{- include "vex mitigation" (list $ (printf "%s/%s" $.ModuleName $.ImageName)) }}
 {{- end }}

--- a/modules/110-istio/images/proxyv2-v1x25x2/werf.inc.yaml
+++ b/modules/110-istio/images/proxyv2-v1x25x2/werf.inc.yaml
@@ -67,7 +67,6 @@ import:
 {{- include "image mount points" . }}
 imageSpec:
   config:
-    user: "1337:1337"
     env: 
       ISTIO_META_ISTIO_PROXY_SHA: "istio-proxy:78bd2d9b284978e170a49cd13decd5f952544489"
       ISTIO_META_ISTIO_VERSION: {{ $istioVersion }}

--- a/modules/110-istio/images/proxyv2-v1x27x9/werf.inc.yaml
+++ b/modules/110-istio/images/proxyv2-v1x27x9/werf.inc.yaml
@@ -71,7 +71,6 @@ import:
 {{- include "image mount points" . }}
 imageSpec:
   config:
-    user: "1337:1337"
     env: 
       ISTIO_META_ISTIO_PROXY_SHA: "istio-proxy:78bd2d9b284978e170a49cd13decd5f952544489"
       ISTIO_META_ISTIO_VERSION: {{ $istioVersion }}

--- a/modules/110-istio/images/proxyv2-v1x29x6/werf.inc.yaml
+++ b/modules/110-istio/images/proxyv2-v1x29x6/werf.inc.yaml
@@ -87,7 +87,6 @@ import:
 {{- include "image mount points" . }}
 imageSpec:
   config:
-    user: "1337:1337"
     env: 
       ISTIO_META_ISTIO_PROXY_SHA: "istio-proxy:8f4f69324c5c9271faad34c13e2e20a558669121"
       ISTIO_META_ISTIO_VERSION: {{ $istioVersion }}

--- a/modules/110-istio/templates/control-plane/deployment.yaml
+++ b/modules/110-istio/templates/control-plane/deployment.yaml
@@ -172,13 +172,7 @@ spec:
         {{- end }}
         resources:
         {{- include "helm_lib_resources_management_pod_resources" (list $.Values.istio.controlPlane.resourcesManagement) | nindent 10 }}
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          capabilities:
-            drop:
-            - ALL
+        {{- include "helm_lib_module_container_security_context_pss_restricted_flexible" dict | nindent 8 }}
         volumeMounts:
         - name: istio-token
           mountPath: /var/run/secrets/tokens

--- a/modules/110-istio/templates/control-plane/iop/iop.yaml
+++ b/modules/110-istio/templates/control-plane/iop/iop.yaml
@@ -239,15 +239,6 @@ spec:
       rollingMaxUnavailable: {{ include "helm_lib_is_ha_to_value" (list $ 1 0) }}
       image: {{ include "helm_lib_module_image" (list $ (printf "pilot%s" $imageSuffix )) }}
       configNamespace: d8-{{ $.Chart.Name }}
-      securityContext:
-        allowPrivilegeEscalation: false
-        readOnlyRootFilesystem: true
-        runAsNonRoot: true
-        runAsUser: 64535
-        runAsGroup: 64535
-        capabilities:
-          drop:
-          - ALL
       resources:
 {{ include "helm_lib_resources_management_pod_resources" (list $.Values.istio.controlPlane.resourcesManagement) | nindent 8 }}
   {{- if $.Values.istio.controlPlane.nodeSelector }}

--- a/modules/110-istio/templates/control-plane/iop/iop.yaml
+++ b/modules/110-istio/templates/control-plane/iop/iop.yaml
@@ -239,6 +239,15 @@ spec:
       rollingMaxUnavailable: {{ include "helm_lib_is_ha_to_value" (list $ 1 0) }}
       image: {{ include "helm_lib_module_image" (list $ (printf "pilot%s" $imageSuffix )) }}
       configNamespace: d8-{{ $.Chart.Name }}
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        runAsUser: 64535
+        runAsGroup: 64535
+        capabilities:
+          drop:
+          - ALL
       resources:
 {{ include "helm_lib_resources_management_pod_resources" (list $.Values.istio.controlPlane.resourcesManagement) | nindent 8 }}
   {{- if $.Values.istio.controlPlane.nodeSelector }}

--- a/modules/110-istio/templates/control-plane/iop/istios.yaml
+++ b/modules/110-istio/templates/control-plane/iop/istios.yaml
@@ -215,6 +215,15 @@ spec:
   # if ne $.Values.istio.controlPlane.replicasManagement.mode "HPA", do not declare the replicaCount in spec.
       rollingMaxUnavailable: {{ include "helm_lib_is_ha_to_value" (list $ 1 0) }}
       image: {{ include "helm_lib_module_image" (list $ (printf "pilot%s" $imageSuffix )) }}
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        runAsUser: 64535
+        runAsGroup: 64535
+        capabilities:
+          drop:
+          - ALL
       resources:
 {{ include "helm_lib_resources_management_pod_resources" (list $.Values.istio.controlPlane.resourcesManagement) | nindent 8 }}
   {{- if $.Values.istio.controlPlane.nodeSelector }}

--- a/modules/110-istio/templates/control-plane/iop/istios.yaml
+++ b/modules/110-istio/templates/control-plane/iop/istios.yaml
@@ -215,15 +215,6 @@ spec:
   # if ne $.Values.istio.controlPlane.replicasManagement.mode "HPA", do not declare the replicaCount in spec.
       rollingMaxUnavailable: {{ include "helm_lib_is_ha_to_value" (list $ 1 0) }}
       image: {{ include "helm_lib_module_image" (list $ (printf "pilot%s" $imageSuffix )) }}
-      securityContext:
-        allowPrivilegeEscalation: false
-        readOnlyRootFilesystem: true
-        runAsNonRoot: true
-        runAsUser: 64535
-        runAsGroup: 64535
-        capabilities:
-          drop:
-          - ALL
       resources:
 {{ include "helm_lib_resources_management_pod_resources" (list $.Values.istio.controlPlane.resourcesManagement) | nindent 8 }}
   {{- if $.Values.istio.controlPlane.nodeSelector }}

--- a/modules/110-istio/templates/kiali/deployment.yaml
+++ b/modules/110-istio/templates/kiali/deployment.yaml
@@ -54,7 +54,7 @@ spec:
       {{- include "helm_lib_tolerations" (tuple . "system") | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple . "cluster-low") | nindent 6 }}
       {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "kiali")) | nindent 6 }}
-      {{- include "helm_lib_module_pod_security_context_run_as_user_custom" (list . 1000 1000) | nindent 6 }}
+      {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
       automountServiceAccountToken: true
       serviceAccountName: kiali
       imagePullSecrets:
@@ -62,7 +62,7 @@ spec:
       containers:
       - name: kiali
         image: {{ include "helm_lib_module_image" (list $ (printf "kiali%s" $imageSuffix)) }}
-        {{- include "helm_lib_module_container_security_context_pss_restricted_flexible" (dict "uid" 1000 ) | nindent 8 }}
+        {{- include "helm_lib_module_container_security_context_run_as_user_deckhouse_pss_restricted" . | nindent 8 }}
         imagePullPolicy: IfNotPresent
         command:
         - "/opt/kiali/kiali"

--- a/modules/110-istio/templates/operator/deployment.yaml
+++ b/modules/110-istio/templates/operator/deployment.yaml
@@ -74,7 +74,7 @@ spec:
       {{- include "helm_lib_node_selector" (tuple $ "system") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple $ "system") | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple $ "cluster-low") | nindent 6 }}
-      {{- include "helm_lib_module_pod_security_context_run_as_user_nobody" $ | nindent 6 }}
+      {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" $ | nindent 6 }}
       automountServiceAccountToken: true
       serviceAccountName: operator-{{ $revision }}
       imagePullSecrets:
@@ -85,16 +85,7 @@ spec:
         command:
         - operator
         - server
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          privileged: false
-          readOnlyRootFilesystem: true
-          runAsGroup: 1337
-          runAsUser: 1337
-          runAsNonRoot: true
+        {{- include "helm_lib_module_container_security_context_pss_restricted_flexible" dict | nindent 8 }}
         imagePullPolicy: IfNotPresent
         {{- if (hasPrefix "1.25" $fullVersion) }}
         volumeMounts:


### PR DESCRIPTION
## Description
Align Istio module images and workloads with Deckhouse conventions for the deckhouse user (`64535`):

- Remove `imageSpec.config.user` from werf image specs (DMT: parameter must be empty).
- For non-dataplane components (pilot/istiod, operator, CNI, Kiali, config-analyzer): set file ownership to `64535:64535` and run pods/containers via `helm_lib` security-context helpers with the deckhouse UID.
- For dataplane images (`proxyv2`, `ztunnel`): only drop `imageSpec.config.user`; runtime UID stays driven by pod/injection `securityContext` (still `1337` where applicable).
- Switch operator / control-plane / Kiali / config-analyzer templates from hardcoded `1337`/`1000`/`nobody` contexts to deckhouse / PSS-restricted helpers.
- Adjust the muted `InvalidApplicationUID` (IST0144) comment so it refers only to dataplane UID `1337`.


## Why do we need it, and what problem does it solve?
DMT reports `imageSpec.config.user:` must be empty, while several Istio images still bake in `1337:1337` (or other UIDs). Non-dataplane module components should run as the standard Deckhouse user (`64535`) with UID set in Kubernetes `securityContext`, not in the image config. That clears the DMT warning, aligns Istio with other modules, and keeps reserved UID `1337` meaningful for dataplane / sidecar traffic bypass rather than for control-plane workloads.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: chore
summary: Run non-dataplane Istio components as the deckhouse user and clear imageSpec.config.user
impact: Restarts istiod, istio-operator, Kiali, istio-cni, and config-analyzer.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
