### PR TITLE
[docs] Fix image name at Selectel Getting Started docs

### DIFF
--- a/docs/site/_includes/getting_started/openstack_selectel/partials/config.ru.yml.standard.other.inc
+++ b/docs/site/_includes/getting_started/openstack_selectel/partials/config.ru.yml.standard.other.inc
@@ -187,7 +187,7 @@ masterNodeGroup:
     # [<en>] You might consider changing this.
     # [<ru>] Возможно, захотите изменить.
     # [<en>] Use a cloud image available in your project (check with `openstack image list`). Do not use images provided by Selectel. Instead, use cloud images published by the Linux distribution maintainers.
-    # [<ru>] Используйте образ для облачной среды, доступный в вашем проекте (проверьте командой `openstack image list`). Не используйте образы, предоставленные Selectel. Вместо них используйте образы для облачных сред, опубликованные разработчиками дистрибутива.
+    # [<ru>] Используйте образ для облачной среды, доступный в вашем проекте (проверьте командой `openstack image list`). Не используйте образы, предоставленные Selectel. Вместо них используйте образы для облачных сред, предоставленные разработчиками дистрибутива.
     imageName: Ubuntu 24.04 LTS 64-bit
     # [<en>] Disk size for the root FS.
     # [<ru>] Размер диска для корневой ФС.

--- a/docs/site/_includes/getting_started/openstack_selectel/partials/config.ru.yml.standard.other.inc
+++ b/docs/site/_includes/getting_started/openstack_selectel/partials/config.ru.yml.standard.other.inc
@@ -130,7 +130,7 @@ standard:
     volumeType: fast.ru-3a
     instanceClass:
       flavorName: c2m2-d0
-      imageName: ubuntu-24-04
+      imageName: Ubuntu 24.04 LTS 64-bit
       rootDiskSize: 20
   # [<en>] Network name for external communication. Default is external-network
   # [<ru>] Имя сети для внешнего взаимодействия. Значение по умолчанию: external-network
@@ -186,9 +186,9 @@ masterNodeGroup:
     # [<ru>] Используемый образ виртуальной машины.
     # [<en>] You might consider changing this.
     # [<ru>] Возможно, захотите изменить.
-    # [<en>] Don't use images provided by Selectel. Upload and use cloud images provided, by distribution maintainers.
-    # [<ru>] Не используйте образы, предоставленные Selectel. Загружайте и используйте образы для облачных сред, предоставленные разработчиками дистрибутива.
-    imageName: ubuntu-24.04
+    # [<en>] Use an image available in your project (check with `openstack image list`).
+    # [<ru>] Используйте образ, доступный в вашем проекте (проверьте командой `openstack image list`).
+    imageName: Ubuntu 24.04 LTS 64-bit
     # [<en>] Disk size for the root FS.
     # [<ru>] Размер диска для корневой ФС.
     rootDiskSize: 40
@@ -217,7 +217,7 @@ spec:
   # [<ru>] Используемый образ виртуальной машины.
   # [<en>] You might consider changing this.
   # [<ru>] Возможно, захотите изменить.
-  imageName: ubuntu-24.04
+  imageName: Ubuntu 24.04 LTS 64-bit
 ---
 # [<en>] Section containing the parameters of worker node group.
 # [<en>] https://deckhouse.io/modules/node-manager/cr.html#nodegroup

--- a/docs/site/_includes/getting_started/openstack_selectel/partials/config.ru.yml.standard.other.inc
+++ b/docs/site/_includes/getting_started/openstack_selectel/partials/config.ru.yml.standard.other.inc
@@ -186,8 +186,8 @@ masterNodeGroup:
     # [<ru>] Используемый образ виртуальной машины.
     # [<en>] You might consider changing this.
     # [<ru>] Возможно, захотите изменить.
-    # [<en>] Use an image available in your project (check with `openstack image list`).
-    # [<ru>] Используйте образ, доступный в вашем проекте (проверьте командой `openstack image list`).
+    # [<en>] Use a cloud image available in your project (check with `openstack image list`). Do not use images provided by Selectel. Instead, use cloud images published by the Linux distribution maintainers.
+    # [<ru>] Используйте образ для облачной среды, доступный в вашем проекте (проверьте командой `openstack image list`). Не используйте образы, предоставленные Selectel. Вместо них используйте образы для облачных сред, опубликованные разработчиками дистрибутива.
     imageName: Ubuntu 24.04 LTS 64-bit
     # [<en>] Disk size for the root FS.
     # [<ru>] Размер диска для корневой ФС.

--- a/docs/site/_includes/getting_started/openstack_selectel/partials/config.yml.standard.other.inc
+++ b/docs/site/_includes/getting_started/openstack_selectel/partials/config.yml.standard.other.inc
@@ -130,7 +130,7 @@ standard:
     volumeType: fast.ru-3a
     instanceClass:
       flavorName: c2m2-d0
-      imageName: ubuntu-24-04
+      imageName: Ubuntu 24.04 LTS 64-bit
       rootDiskSize: 20
   # [<en>] Network name for external communication. Default is external-network
   # [<ru>] Имя сети для внешнего взаимодействия. Значение по умолчанию: external-network
@@ -186,9 +186,9 @@ masterNodeGroup:
     # [<ru>] Используемый образ виртуальной машины.
     # [<en>] You might consider changing this.
     # [<ru>] Возможно, захотите изменить.
-    # [<en>] Don't use images provided by Selectel. Upload and use cloud images, provided by distribution maintainers.
-    # [<ru>] Не используйте образы, предоставленные Selectel. Загружайте и используйте образы для облачных сред, предоставленные разработчиками дистрибутива.
-    imageName: ubuntu-24.04
+    # [<en>] Use an image available in your project (check with `openstack image list`).
+    # [<ru>] Используйте образ, доступный в вашем проекте (проверьте командой `openstack image list`).
+    imageName: Ubuntu 24.04 LTS 64-bit
     # [<en>] Disk size for the root FS.
     # [<ru>] Размер диска для корневой ФС.
     rootDiskSize: 40
@@ -217,7 +217,7 @@ spec:
   # [<ru>] Используемый образ виртуальной машины.
   # [<en>] You might consider changing this.
   # [<ru>] Возможно, захотите изменить.
-  imageName: ubuntu-24.04
+  imageName: Ubuntu 24.04 LTS 64-bit
 ---
 # [<en>] Section containing the parameters of worker node group.
 # [<en>] https://deckhouse.io/modules/node-manager/cr.html#nodegroup

--- a/docs/site/_includes/getting_started/openstack_selectel/partials/config.yml.standard.other.inc
+++ b/docs/site/_includes/getting_started/openstack_selectel/partials/config.yml.standard.other.inc
@@ -187,7 +187,7 @@ masterNodeGroup:
     # [<en>] You might consider changing this.
     # [<ru>] Возможно, захотите изменить.
     # [<en>] Use a cloud image available in your project (check with `openstack image list`). Do not use images provided by Selectel. Instead, use cloud images published by the Linux distribution maintainers.
-    # [<ru>] Используйте образ для облачной среды, доступный в вашем проекте (проверьте командой `openstack image list`). Не используйте образы, предоставленные Selectel. Вместо них используйте образы для облачных сред, опубликованные разработчиками дистрибутива.
+    # [<ru>] Используйте образ для облачной среды, доступный в вашем проекте (проверьте командой `openstack image list`). Не используйте образы, предоставленные Selectel. Вместо них используйте образы для облачных сред, предоставленные разработчиками дистрибутива.
     imageName: Ubuntu 24.04 LTS 64-bit
     # [<en>] Disk size for the root FS.
     # [<ru>] Размер диска для корневой ФС.

--- a/docs/site/_includes/getting_started/openstack_selectel/partials/config.yml.standard.other.inc
+++ b/docs/site/_includes/getting_started/openstack_selectel/partials/config.yml.standard.other.inc
@@ -186,8 +186,8 @@ masterNodeGroup:
     # [<ru>] Используемый образ виртуальной машины.
     # [<en>] You might consider changing this.
     # [<ru>] Возможно, захотите изменить.
-    # [<en>] Use an image available in your project (check with `openstack image list`).
-    # [<ru>] Используйте образ, доступный в вашем проекте (проверьте командой `openstack image list`).
+    # [<en>] Use a cloud image available in your project (check with `openstack image list`). Do not use images provided by Selectel. Instead, use cloud images published by the Linux distribution maintainers.
+    # [<ru>] Используйте образ для облачной среды, доступный в вашем проекте (проверьте командой `openstack image list`). Не используйте образы, предоставленные Selectel. Вместо них используйте образы для облачных сред, опубликованные разработчиками дистрибутива.
     imageName: Ubuntu 24.04 LTS 64-bit
     # [<en>] Disk size for the root FS.
     # [<ru>] Размер диска для корневой ФС.


### PR DESCRIPTION
## Description
Fixed image name at Selectel Getting Started docs.

## Why do we need it, and what problem does it solve?

## Why do we need it in the patch release (if we do)?



## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: docs
type: chore
summary: Fixed image name at Selectel Getting Started docs.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
