### PR TITLE
[user-authz] Remove outdated (EE Only) from multitenancy webhook error message

### DIFF
--- a/modules/140-user-authz/webhooks/validating/multitenancy.py
+++ b/modules/140-user-authz/webhooks/validating/multitenancy.py
@@ -135,7 +135,7 @@ def validate_car_multitenancy_related_fields(obj: DotMap) -> tuple[list[str], li
         if field in obj.spec:
             errors.append(
                 f"You must enable userAuthz.enableMultiTenancy to use the {description} "
-                f"in ClusterAuthorizationRule '{resource_name}' (EE Only)"
+                f"in ClusterAuthorizationRule '{resource_name}'"
             )
 
     return errors, []

--- a/modules/140-user-authz/webhooks/validating/multitenancy_test.py
+++ b/modules/140-user-authz/webhooks/validating/multitenancy_test.py
@@ -41,9 +41,9 @@ class TestMultiTenancyValidationForCarsAndModuleConfig(unittest.TestCase):
         ]:
             with self.subTest(title=scenario):
                 tests.assert_validation_deny(self, self.run_hook(ctx_json), '; '.join([
-                    "You must enable userAuthz.enableMultiTenancy to use the allowAccessToSystemNamespaces flag in ClusterAuthorizationRule 'user1' (EE Only)",
-                    "You must enable userAuthz.enableMultiTenancy to use the namespaceSelector option in ClusterAuthorizationRule 'user1' (EE Only)",
-                    "You must enable userAuthz.enableMultiTenancy to use the limitNamespaces option in ClusterAuthorizationRule 'user1' (EE Only)",
+                    "You must enable userAuthz.enableMultiTenancy to use the allowAccessToSystemNamespaces flag in ClusterAuthorizationRule 'user1'",
+                    "You must enable userAuthz.enableMultiTenancy to use the namespaceSelector option in ClusterAuthorizationRule 'user1'",
+                    "You must enable userAuthz.enableMultiTenancy to use the limitNamespaces option in ClusterAuthorizationRule 'user1'",
                 ]))
 
     def test_car_allowed_when_multitenancy_disabled_and_no_multitenancy_related_fields(self):
@@ -93,12 +93,12 @@ class TestMultiTenancyValidationForCarsAndModuleConfig(unittest.TestCase):
         ]:
              with self.subTest(scenario):
                 tests.assert_validation_deny(self, self.run_hook(ctx_json), "; ".join([
-                    "You must enable userAuthz.enableMultiTenancy to use the allowAccessToSystemNamespaces flag in ClusterAuthorizationRule 'user1' (EE Only)",
-                    "You must enable userAuthz.enableMultiTenancy to use the namespaceSelector option in ClusterAuthorizationRule 'user1' (EE Only)",
-                    "You must enable userAuthz.enableMultiTenancy to use the limitNamespaces option in ClusterAuthorizationRule 'user1' (EE Only)",
-                    "You must enable userAuthz.enableMultiTenancy to use the allowAccessToSystemNamespaces flag in ClusterAuthorizationRule 'user3' (EE Only)",
-                    "You must enable userAuthz.enableMultiTenancy to use the namespaceSelector option in ClusterAuthorizationRule 'user3' (EE Only)",
-                    "You must enable userAuthz.enableMultiTenancy to use the limitNamespaces option in ClusterAuthorizationRule 'user3' (EE Only)",
+                    "You must enable userAuthz.enableMultiTenancy to use the allowAccessToSystemNamespaces flag in ClusterAuthorizationRule 'user1'",
+                    "You must enable userAuthz.enableMultiTenancy to use the namespaceSelector option in ClusterAuthorizationRule 'user1'",
+                    "You must enable userAuthz.enableMultiTenancy to use the limitNamespaces option in ClusterAuthorizationRule 'user1'",
+                    "You must enable userAuthz.enableMultiTenancy to use the allowAccessToSystemNamespaces flag in ClusterAuthorizationRule 'user3'",
+                    "You must enable userAuthz.enableMultiTenancy to use the namespaceSelector option in ClusterAuthorizationRule 'user3'",
+                    "You must enable userAuthz.enableMultiTenancy to use the limitNamespaces option in ClusterAuthorizationRule 'user3'",
                 ]))
 
     def test_module_config_allowed_when_multitenancy_disabled_and_no_cars_have_multitenancy_related_fields(self):


### PR DESCRIPTION
## Description
Remove the outdated `(EE Only)` suffix from the `d8-user-authz-car-multitenancy-related-options` validating webhook error message.

## Why do we need it, and what problem does it solve?
The webhook error incorrectly claimed that multitenancy-related options (`namespaceSelector`, `limitNamespaces`, `allowAccessToSystemNamespaces`) are EE-only.

## Why do we need it in the patch release (if we do)?
Not necessarily.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authz
type: fix
summary: Remove outdated "(EE Only)" from the multitenancy validating webhook error message.
impact_level: low