### PR TITLE
[go-lib] Fix validation for optional module not found

### DIFF
--- a/go_lib/dependency/extenders/moduledependency/moduledependency.go
+++ b/go_lib/dependency/extenders/moduledependency/moduledependency.go
@@ -224,6 +224,11 @@ func (e *Extender) ValidateRelease(moduleName, moduleRelease string, version *se
 	// check if the new requirements are satisfied
 	for _, parentModule := range req.matcher.GetConstraintsNames() {
 		parentVersion, err := e.modulesVersionHelper(parentModule)
+		_, isOptional := req.optional[parentModule]
+		// if the parent module is optional and not found, skip it
+		if err != nil && apierrors.IsNotFound(err) && isOptional {
+			continue
+		}
 		if err != nil {
 			validateErr = multierror.Append(validateErr, fmt.Errorf("could not get the '%s' module version: %s", parentModule, err.Error()))
 			if apierrors.IsNotFound(err) {
@@ -234,7 +239,7 @@ func (e *Extender) ValidateRelease(moduleName, moduleRelease string, version *se
 		// check if the parent module is disabled/absent
 		if parentVersion == "" || !slices.Contains(enabledModules, parentModule) {
 			// if parent req is optional and disabled just skip it
-			if _, ok := req.optional[parentModule]; ok {
+			if isOptional {
 				e.logger.Debug("module`s requirements not met, but its optional",
 					slog.String("module", moduleName), slog.String("required", parentModule))
 				continue

--- a/go_lib/dependency/extenders/moduledependency/moduledependency_blackbox_test.go
+++ b/go_lib/dependency/extenders/moduledependency/moduledependency_blackbox_test.go
@@ -220,6 +220,24 @@ func TestValidateReleaseWithMissingDependency(t *testing.T) {
 	assert.Contains(t, err.Error(), "could not get", "Error should mention the get failure")
 }
 
+// TestValidateReleaseWithOptionalMissingDependency tests that an optional dependency
+// resolves without error when its Module resource does not exist (NotFound)
+func TestValidateReleaseWithOptionalMissingDependency(t *testing.T) {
+	extender := moduledependency.Instance()
+
+	// Set up version helper that returns not found error, simulating an absent Module resource
+	extender.SetModulesVersionHelper(func(moduleName string) (string, error) {
+		return "", apierrors.NewNotFound(schema.GroupResource{Group: "modules", Resource: "module"}, moduleName)
+	})
+
+	version, _ := semver.NewVersion("1.0.0")
+	err := extender.ValidateRelease("moduleWithOptionalMissingDep", "v1.0.0", version, map[string]string{
+		"missingOptionalDep": ">= 1.0.0 !optional",
+	})
+
+	assert.NoError(t, err, "ValidateRelease should not fail on optional missing dependency")
+}
+
 // TestValidateReleaseWithUnparsableVersion tests validation with an unparsable parent version
 func TestValidateReleaseWithUnparsableVersion(t *testing.T) {
 	extender := moduledependency.Instance()


### PR DESCRIPTION
## Description
Fixes module release validation so that an `!optional` dependency on a module is correctly skipped when the required module does not exist at all (its `Module` resource is missing), not just when it exists but is disabled.

## Why do we need it, and what problem does it solve?
The purpose of marking a dependency `!optional` is to allow a module release to pass validation even when that dependency isn't present/enabled. The "not found" case was not covered by this check, so module releases with optional dependencies on modules that aren't installed at all were incorrectly rejected.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: tools
type: fix
summary: Fixed module release validation incorrectly failing for `!optional` dependencies when the required module doesn't exist in the cluster.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
