### PR TITLE
[deckhouse] Stop deleting publish API TLS secret on deckhouse restart

### DIFF
--- a/modules/040-control-plane-manager/hooks/discover_publish_api_cert.go
+++ b/modules/040-control-plane-manager/hooks/discover_publish_api_cert.go
@@ -68,11 +68,11 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			NameSelector: &types.NameSelector{
 				MatchNames: possiblePublishAPISecretNames,
 			},
-			// Run only in BeforeHelm: publish_api_from_cm (Order 5) writes the real
-			// publishAPI mode there. On other runs the mode may still be the schema
-			// default, and getCert would delete the active mode's secret.
+			// Skip the Synchronization run: at that point the real publishAPI mode
+			// may not be in values yet, and getCert would treat the active mode's
+			// secret as leftover. Event runs happen after the first BeforeHelm and
+			// keep the published CA fresh when the active secret changes.
 			ExecuteHookOnSynchronization: ptr.To(false),
-			ExecuteHookOnEvents:          ptr.To(false),
 			FilterFunc:                   applyPublishAPICertFilter,
 		},
 	},

--- a/modules/040-control-plane-manager/hooks/discover_publish_api_cert.go
+++ b/modules/040-control-plane-manager/hooks/discover_publish_api_cert.go
@@ -86,15 +86,6 @@ func discoverPublishAPICA(_ context.Context, input *go_hook.HookInput) error {
 		kubeCAPath     = "global.discovery.kubernetesCA"
 	)
 
-	caCertificates := make(map[string][]byte)
-	for publishCert, err := range sdkobjectpatch.SnapshotIter[PublishAPICert](input.Snapshots.Get("secret")) {
-		if err != nil {
-			return fmt.Errorf("failed to iterate over 'secret' snapshot: %w", err)
-		}
-
-		caCertificates[publishCert.Name] = publishCert.Data
-	}
-
 	var cert string
 	var err error
 	switch input.Values.Get(modePath).String() {

--- a/modules/040-control-plane-manager/hooks/discover_publish_api_cert.go
+++ b/modules/040-control-plane-manager/hooks/discover_publish_api_cert.go
@@ -25,6 +25,7 @@ import (
 	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/ptr"
 
 	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 
@@ -67,7 +68,12 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			NameSelector: &types.NameSelector{
 				MatchNames: possiblePublishAPISecretNames,
 			},
-			FilterFunc: applyPublishAPICertFilter,
+			// Run only in BeforeHelm: publish_api_from_cm (Order 5) writes the real
+			// publishAPI mode there. On other runs the mode may still be the schema
+			// default, and getCert would delete the active mode's secret.
+			ExecuteHookOnSynchronization: ptr.To(false),
+			ExecuteHookOnEvents:          ptr.To(false),
+			FilterFunc:                   applyPublishAPICertFilter,
 		},
 	},
 }, discoverPublishAPICA)

--- a/modules/040-control-plane-manager/hooks/discover_publish_api_cert_test.go
+++ b/modules/040-control-plane-manager/hooks/discover_publish_api_cert_test.go
@@ -73,6 +73,16 @@ metadata:
 data:
   ca.crt: a3ViZXJuZXRlcy10bHM=
 `
+	certManagerCertSecretRotated := `
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kubernetes-tls
+  namespace: kube-system
+data:
+  ca.crt: a3ViZXJuZXRlcy10bHMtcm90YXRlZA==
+`
 	customCertSecret := `
 ---
 apiVersion: v1
@@ -232,6 +242,23 @@ data:
 			Expect(f.KubernetesResource("Secret", "kube-system", "kubernetes-tls").Exists()).To(BeTrue())
 			Expect(f.KubernetesResource("Secret", "kube-system", "kubernetes-tls-selfsigned").Exists()).To(BeFalse())
 			Expect(f.KubernetesResource("Secret", "kube-system", "kubernetes-tls-customcertificate").Exists()).To(BeFalse())
+		})
+	})
+
+	Context("Global mode with CertManager, kubernetes-tls changes after BeforeHelm", func() {
+		BeforeEach(func() {
+			f.ValuesSet("controlPlaneManager.apiserver.publishAPI.ingress.https.mode", "Global")
+			f.ValuesSet("global.modules.https.mode", "CertManager")
+			f.KubeStateSet(certManagerCertSecret)
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.RunHook()
+			f.BindingContexts.Set(f.KubeStateSet(certManagerCertSecretRotated))
+			f.RunHook()
+		})
+
+		It("Should publish the new CA on the secret event", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("controlPlaneManager.internal.authn.publishedAPIKubeconfigGeneratorMasterCA").String()).To(Equal("kubernetes-tls-rotated"))
 		})
 	})
 

--- a/modules/040-control-plane-manager/hooks/discover_publish_api_cert_test.go
+++ b/modules/040-control-plane-manager/hooks/discover_publish_api_cert_test.go
@@ -217,6 +217,24 @@ data:
 		})
 	})
 
+	Context("Global mode with CertManager and all secrets in cluster", func() {
+		BeforeEach(func() {
+			f.ValuesSet("controlPlaneManager.apiserver.publishAPI.ingress.https.mode", "Global")
+			f.ValuesSet("global.modules.https.mode", "CertManager")
+			f.KubeStateSet(selfSignedCertSecret + certManagerCertSecret + customCertSecret)
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.RunHook()
+		})
+
+		It("Should keep kubernetes-tls and delete not matching secrets", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("controlPlaneManager.internal.authn.publishedAPIKubeconfigGeneratorMasterCA").String()).To(Equal("kubernetes-tls"))
+			Expect(f.KubernetesResource("Secret", "kube-system", "kubernetes-tls").Exists()).To(BeTrue())
+			Expect(f.KubernetesResource("Secret", "kube-system", "kubernetes-tls-selfsigned").Exists()).To(BeFalse())
+			Expect(f.KubernetesResource("Secret", "kube-system", "kubernetes-tls-customcertificate").Exists()).To(BeFalse())
+		})
+	})
+
 	Context("Global mode with kubeconfigGeneratorMasterCA set and all secrets in cluster", func() {
 		BeforeEach(func() {
 			f.ValuesSet("controlPlaneManager.apiserver.publishAPI.ingress.https.mode", "Global")

--- a/modules/040-control-plane-manager/hooks/discover_publish_api_cert_test.go
+++ b/modules/040-control-plane-manager/hooks/discover_publish_api_cert_test.go
@@ -86,7 +86,8 @@ data:
 
 	DescribeTable("publishAPI discovery cert",
 		func(in inputPublishAPICACert, out string) {
-			f.BindingContexts.Set(f.KubeStateSet(in.manifests))
+			f.KubeStateSet(in.manifests)
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
 			f.ValuesSet("controlPlaneManager.apiserver.publishAPI.ingress.https.mode", in.publishAPIMode)
 			f.ValuesSet("global.modules.https.mode", in.httpsMode)
 
@@ -204,7 +205,8 @@ data:
 		BeforeEach(func() {
 			f.ValuesSet("controlPlaneManager.apiserver.publishAPI.ingress.https.mode", "SelfSigned")
 			f.ValuesSet("global.modules.https.mode", "CertManager")
-			f.BindingContexts.Set(f.KubeStateSet(selfSignedCertSecret + certManagerCertSecret + customCertSecret))
+			f.KubeStateSet(selfSignedCertSecret + certManagerCertSecret + customCertSecret)
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
 			f.RunHook()
 		})
 
@@ -212,6 +214,24 @@ data:
 			Expect(f.KubernetesResource("Secret", "kube-system", "kubernetes-tls-selfsigned").Exists()).To(BeTrue())
 			Expect(f.KubernetesResource("Secret", "kube-system", "kubernetes-tls").Exists()).To(BeFalse())
 			Expect(f.KubernetesResource("Secret", "kube-system", "kubernetes-tls-customcertificate").Exists()).To(BeFalse())
+		})
+	})
+
+	Context("Global mode with kubeconfigGeneratorMasterCA set and all secrets in cluster", func() {
+		BeforeEach(func() {
+			f.ValuesSet("controlPlaneManager.apiserver.publishAPI.ingress.https.mode", "Global")
+			f.ValuesSet("global.modules.https.mode", "CertManager")
+			f.ValuesSet("controlPlaneManager.apiserver.publishAPI.ingress.https.global.kubeconfigGeneratorMasterCA", "")
+			f.KubeStateSet(selfSignedCertSecret + certManagerCertSecret + customCertSecret)
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.RunHook()
+		})
+
+		It("Should keep every secret", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.KubernetesResource("Secret", "kube-system", "kubernetes-tls").Exists()).To(BeTrue())
+			Expect(f.KubernetesResource("Secret", "kube-system", "kubernetes-tls-selfsigned").Exists()).To(BeTrue())
+			Expect(f.KubernetesResource("Secret", "kube-system", "kubernetes-tls-customcertificate").Exists()).To(BeTrue())
 		})
 	})
 })

--- a/modules/150-user-authn/hooks/discover_publish_api_cert.go
+++ b/modules/150-user-authn/hooks/discover_publish_api_cert.go
@@ -25,6 +25,7 @@ import (
 	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/ptr"
 
 	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 
@@ -77,7 +78,12 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			NameSelector: &types.NameSelector{
 				MatchNames: possiblePublishAPISecretNames,
 			},
-			FilterFunc: applyPublishAPISecretCertFilter,
+			// Run only in BeforeHelm: keeping or deleting secrets depends on the CPM
+			// export in the secret_cpm snapshot, which may be empty on Synchronization
+			// and event runs of this binding.
+			ExecuteHookOnSynchronization: ptr.To(false),
+			ExecuteHookOnEvents:          ptr.To(false),
+			FilterFunc:                   applyPublishAPISecretCertFilter,
 		},
 		{
 			Name:       "secret_cpm",
@@ -91,7 +97,10 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			NameSelector: &types.NameSelector{
 				MatchNames: []string{"d8-publish-api-config"},
 			},
-			FilterFunc: applyPublishAPICertFilterCPM,
+			// No Synchronization run for the same reason; events stay on so the
+			// mirrored CA value refreshes when the CPM export changes.
+			ExecuteHookOnSynchronization: ptr.To(false),
+			FilterFunc:                   applyPublishAPICertFilterCPM,
 		},
 	},
 }, discoverPublishAPICA)

--- a/modules/150-user-authn/hooks/discover_publish_api_cert.go
+++ b/modules/150-user-authn/hooks/discover_publish_api_cert.go
@@ -121,15 +121,6 @@ func discoverPublishAPICA(_ context.Context, input *go_hook.HookInput) error {
 		return nil
 	}
 
-	caCertificatesBytes := make(map[string][]byte)
-	for publishCert, err := range sdkobjectpatch.SnapshotIter[PublishAPICert](input.Snapshots.Get("secret")) {
-		if err != nil {
-			return fmt.Errorf("failed to iterate over 'secret' snapshot: %w", err)
-		}
-
-		caCertificatesBytes[publishCert.Name] = publishCert.Data
-	}
-
 	var cert string
 	var err error
 	switch input.Values.Get(modePath).String() {

--- a/modules/150-user-authn/hooks/discover_publish_api_cert_test.go
+++ b/modules/150-user-authn/hooks/discover_publish_api_cert_test.go
@@ -94,7 +94,8 @@ data:
 `
 	DescribeTable("publishAPI discovery cert",
 		func(in inputPublishAPICACert, out string) {
-			f.BindingContexts.Set(f.KubeStateSet(in.manifests))
+			f.KubeStateSet(in.manifests)
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
 			f.ValuesSet("userAuthn.publishAPI.https.mode", in.publishAPIMode)
 			f.ValuesSet("userAuthn.https.mode", in.httpMode)
 
@@ -220,7 +221,8 @@ data:
 		BeforeEach(func() {
 			f.ValuesSet("userAuthn.publishAPI.https.mode", "SelfSigned")
 			f.ValuesSet("userAuthn.https.mode", "CertManager")
-			f.BindingContexts.Set(f.KubeStateSet(selfSignedCertSecret + certManagerCertSecret + customCertSecret))
+			f.KubeStateSet(selfSignedCertSecret + certManagerCertSecret + customCertSecret)
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
 			f.RunHook()
 		})
 
@@ -228,6 +230,23 @@ data:
 			Expect(f.KubernetesResource("Secret", "d8-user-authn", "kubernetes-tls-selfsigned").Exists()).To(BeTrue())
 			Expect(f.KubernetesResource("Secret", "d8-user-authn", "kubernetes-tls").Exists()).To(BeFalse())
 			Expect(f.KubernetesResource("Secret", "d8-user-authn", "kubernetes-tls-customcertificate").Exists()).To(BeFalse())
+		})
+	})
+
+	Context("With all secrets and the control-plane-manager export in cluster", func() {
+		BeforeEach(func() {
+			f.ValuesSet("userAuthn.publishAPI.https.mode", "SelfSigned")
+			f.ValuesSet("userAuthn.https.mode", "CertManager")
+			f.KubeStateSet(selfSignedCertSecret + certManagerCertSecret + customCertSecret + cpmConfigSecret)
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.RunHook()
+		})
+
+		It("Should keep every secret", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.KubernetesResource("Secret", "d8-user-authn", "kubernetes-tls").Exists()).To(BeTrue())
+			Expect(f.KubernetesResource("Secret", "d8-user-authn", "kubernetes-tls-selfsigned").Exists()).To(BeTrue())
+			Expect(f.KubernetesResource("Secret", "d8-user-authn", "kubernetes-tls-customcertificate").Exists()).To(BeTrue())
 		})
 	})
 })


### PR DESCRIPTION
## Description

The `discover_publish_api_cert` hook in `control-plane-manager` no longer runs on Synchronization. 
Its `secret` binding gets `ExecuteHookOnSynchronization: false`; event runs and BeforeHelm stay. 

The binding still tracks the secrets, so the snapshot stays fresh. 

Why skipping only Synchronization is enough: 
- On clusters with publishAPI settings still in the `user-authn` ModuleConfig, `publish_api_from_cm` writes the real `publishAPI.ingress.https.mode` into values. It runs in its own module queue: on Synchronization of its migration ConfigMap binding and in BeforeHelm (Order 5). 
- Before this change this hook also ran on Synchronization at deckhouse startup, in a queue not ordered against `publish_api_from_cm`, and in practice it ran first. At that moment the mode in values is still the schema default `SelfSigned`. With the wrong mode `getCert` deleted the active secret `kube-system/kubernetes-tls` on every restart (see the next section). 
- Inside BeforeHelm hooks run strictly by Order, so this hook (Order 10) always runs after `publish_api_from_cm` (Order 5) and sees the real mode. 
- Event runs are safe too: events of a binding unlock only after its Synchronization task, and event tasks queue in `main` behind the startup ModuleRun, so an event run always happens after the first BeforeHelm, when the real mode is already in values. 
- Event runs stay on because they keep the published CA fresh: in SelfSigned and CustomCertificate modes the CA comes from the secret's `ca.crt`, and the secret appears or rotates after BeforeHelm has already run.

**_The cleanup logic itself is unchanged._**

How a deckhouse restart goes after this change:

```mermaid
---
title: "After the fix: the hook skips the Synchronization run"
---
flowchart TB
    Restart(["deckhouse restart"])

    %% ═══════ Phases ═══════
    subgraph Sync["Synchronization (always runs first)"]
        NoRun["discover_publish_api_cert<br>does not run<br>(ExecuteHookOnSynchronization:<br>false). Its secret snapshot<br>is filled anyway"]:::skip
    end

    subgraph Helm["BeforeHelm (hooks run strictly by Order)"]
        WriteMode["publish_api_from_cm<br>(Order 5) writes the<br>real mode: Global"]
        HookHelm["discover_publish_api_cert<br>(Order 10) reads Global"]
        RightActive["Active secret:<br>kubernetes-tls<br>Delete only -selfsigned<br>and -customcertificate<br>(leftovers of an old mode)"]
    end

    %% ═══════ Flow ═══════
    Restart --> NoRun
    NoRun --> WriteMode
    WriteMode --> HookHelm
    HookHelm --> RightActive
    RightActive --> Intact["kubernetes-tls stays intact,<br>cert-manager has<br>nothing to reissue"]:::ok
    Intact --> Valid(["api.#60;domain#62; serves the<br>valid Let's Encrypt cert"]):::ok

    %% ═══════ Styles ═══════
    classDef ok fill:#4caf50,stroke:#2e7d32,color:#fff
    classDef skip fill:#9e9e9e,stroke:#616161,color:#fff
```

The legacy hook in `user-authn` gets `ExecuteHookOnSynchronization: false` and `ExecuteHookOnEvents: false` on its `secret` binding. It deletes secrets with the same names in `d8-user-authn` and had the same flaw; event freshness is not needed there, since those legacy secrets are leftovers that nothing recreates since #18628. Its `secret_cpm` binding keeps event runs on purpose: it is the only path that carries a changed CA into the kubeconfig-generator config. One case remains: deleting the `d8-publish-api-config` export triggers a single legacy-cleanup run outside BeforeHelm. That run can only remove leftover secrets in `d8-user-authn`, and nothing recreates them since #18628.

Both hooks also lose a small dead block: a name-to-CA map built from the secret snapshot and never read (`getCert` builds its own).

No cluster components are restarted by this change - only hook scheduling metadata.

Tests:

- Both test suites run the hook via `GenerateBeforeHelmContext` (Synchronization contexts no longer trigger it).
- New case in control-plane-manager: `Global` mode with `kubeconfigGeneratorMasterCA` set deletes nothing.
- New case in control-plane-manager: `Global` + `CertManager` without the override keeps `kubernetes-tls` and deletes `kubernetes-tls-selfsigned` and `kubernetes-tls-customcertificate` (the branch that runs `getCert("kubernetes-tls")`).
- New case in control-plane-manager: after BeforeHelm, a changed `kubernetes-tls` triggers an event run that publishes the new CA.
- New case in user-authn: with a live control-plane-manager export, the legacy hook deletes nothing.
- The old case "Should delete not matching secrets" passes unchanged.

## Why do we need it, and what problem does it solve?

Regression from #18628, which moved publishAPI settings from `user-authn` to `control-plane-manager`.

Background. publishAPI exposes kube-apiserver at `api.<domain>` through ingress. The TLS certificate for that host lives in one of three secrets in `kube-system`: `kubernetes-tls`, `kubernetes-tls-selfsigned`, `kubernetes-tls-customcertificate`. Which one is active depends on `publishAPI.ingress.https.mode`. The `discover_publish_api_cert` hook publishes the CA of the active secret into values and deletes the other two as leftovers of a previous mode. So the hook is safe only while it sees the real mode.

On clusters where publishAPI settings still live in the `user-authn` ModuleConfig, the real mode does not come from ModuleConfig directly. A global hook copies the settings into a migration ConfigMap, and `publish_api_from_cm` writes them into values: on Synchronization of its ConfigMap binding (module queue `/modules/control-plane-manager`) and in BeforeHelm (Order 5). Until it has run, `publishAPI.ingress.https.mode` in values is the schema default `SelfSigned`.

Synchronization always runs before the first BeforeHelm. So on every deckhouse restart:

1. The hook runs on Synchronization in a queue that is not ordered against the module queue of `publish_api_from_cm`. In practice it runs first, before `publish_api_from_cm` has written anything.
2. It reads the default `SelfSigned` mode, treats `kubernetes-tls-selfsigned` as active and deletes `kube-system/kubernetes-tls` - the Let's Encrypt certificate for `api.<domain>`.
3. One second later `publish_api_from_cm` writes the real mode `Global`. The secret is already gone.
4. cert-manager notices the missing secret and reissues the certificate.

One restart is one extra reissue. After 5 reissues in a week Let's Encrypt returns 429 and refuses to issue for up to seven days. `api.<domain>` falls back to the fake ingress certificate, and kubectl and d8 of every user with a kubeconfig-generator config stop working until the rate limit window passes.

The same restart, step by step, before this change:

```mermaid
---
title: "Before the fix: every deckhouse restart deletes kubernetes-tls"
---
flowchart TB
    Restart(["deckhouse restart"])

    %% ═══════ Phases ═══════
    subgraph Sync["Synchronization (always runs first)"]
        HookSync["discover_publish_api_cert<br>runs"]
        ReadDefault["Read the mode from values:<br>publishAPI.ingress.https.mode<br>publish_api_from_cm has<br>not run yet, so it is the<br>schema default: SelfSigned"]
        WrongActive["Active secret:<br>kubernetes-tls-selfsigned"]
        DeleteLive["Delete kubernetes-tls<br>in kube-system<br>(the live Let's Encrypt cert)"]:::err
    end

    subgraph Helm["BeforeHelm (runs after Synchronization)"]
        WriteMode["publish_api_from_cm<br>(Order 5) writes the<br>real mode: Global"]
        HookHelm["discover_publish_api_cert<br>(Order 10) sees Global,<br>but the secret is gone"]
    end

    %% ═══════ Flow ═══════
    Restart --> HookSync
    HookSync --> ReadDefault
    ReadDefault --> WrongActive
    WrongActive --> DeleteLive
    DeleteLive --> WriteMode
    WriteMode --> HookHelm
    HookHelm --> Reissue["cert-manager notices the<br>missing secret and<br>reissues the certificate"]
    Reissue --> Limit{"5 reissues<br>within 168h?"}
    Limit -- "yes" --> RateLimited["Let's Encrypt:<br>429 rateLimited"]:::err
    RateLimited --> Fake(["api.#60;domain#62; serves the<br>fake ingress.local cert,<br>kubectl fails: x509 error"]):::err
    Limit -- "no, next restart" --> Restart

    %% ═══════ Styles ═══════
    classDef err fill:#f44336,stroke:#c62828,color:#fff
```

Confirmed on a dev cluster: the kube-audit log shows `system:serviceaccount:d8-system:deckhouse` deleting `kubernetes-tls` at 15:03:23.79, and the deckhouse log shows `publish_api_from_cm` writing the real mode at 15:03:24 - one second too late, on every restart.

Verified on the same cluster with the PR image on 2026-08-17 (with a stand-in `kubernetes-tls` secret, since Let's Encrypt was still rate limited). The startup timeline is unchanged: the `discover_publish_api_cert` Synchronization task at 05:26:21, `publish_api_from_cm` writes the real mode at 05:26:22, BeforeHelm runs Order 5 then Order 10 at 05:26:24. But the hook is skipped on Synchronization now: `kubernetes-tls` keeps its UID across the restart, the audit log has no delete of it, and the hook metrics show no execution for `binding="kubernetes"`. Two hours earlier the same restart on the `main` image deleted the secret 66 seconds after the pod started (audit log, 02:05:39).

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: control-plane-manager
type: fix
summary: The publish API certificate hook no longer deletes the active TLS secret (kube-system/kubernetes-tls) on deckhouse restart.
```

```changes
section: user-authn
type: fix
summary: The legacy publish API certificate hook no longer deletes TLS secrets in d8-user-authn on deckhouse restart.
```


