### PR TITLE
[multitenancy-manager] Fix jq 1.7-only syntax and the CRD name in Project conversion

### DIFF
--- a/modules/160-multitenancy-manager/webhooks/conversion/projects
+++ b/modules/160-multitenancy-manager/webhooks/conversion/projects
@@ -49,7 +49,7 @@ function __on_conversion::v1alpha1_to_v1alpha2() {
 EOF
   else
     cat <<EOF >"$CONVERSION_RESPONSE_PATH"
-{"failedMessage":"Conversion of deckhouse.io failed"}
+{"failedMessage":"Conversion of projects.deckhouse.io failed"}
 EOF
   fi
 }
@@ -70,7 +70,7 @@ function __on_conversion::v1alpha2_to_v1alpha1() {
 EOF
   else
     cat <<EOF >"$CONVERSION_RESPONSE_PATH"
-{"failedMessage":"Conversion of deckhouse.io.io failed"}
+{"failedMessage":"Conversion of projects.deckhouse.io failed"}
 EOF
   fi
 }

--- a/modules/160-multitenancy-manager/webhooks/conversion/projects
+++ b/modules/160-multitenancy-manager/webhooks/conversion/projects
@@ -37,8 +37,8 @@ function __on_conversion::v1alpha1_to_v1alpha2() {
   if converted=$(context::jq -r '.review.request.objects//[] | map(
      if .apiVersion ==  "deckhouse.io/v1alpha1" then
        .apiVersion = "deckhouse.io/v1alpha2" |
-       if .spec.projectTypeName then .spec.projectTemplateName = .spec.projectTypeName end |
-       if .spec.template then .spec.parameters = .spec.template end |
+       (if .spec.projectTypeName then .spec.projectTemplateName = .spec.projectTypeName else . end) |
+       (if .spec.template then .spec.parameters = .spec.template else . end) |
        del(.spec.projectTypeName) |
        del(.spec.template)
      else . end
@@ -58,8 +58,8 @@ function __on_conversion::v1alpha2_to_v1alpha1() {
   if converted=$(context::jq -r '.review.request.objects//[] | map(
      if .apiVersion ==  "deckhouse.io/v1alpha2" then
        .apiVersion = "deckhouse.io/v1alpha1" |
-       if .spec.projectTemplateName then .spec.projectTypeName = .spec.projectTemplateName end |
-       if .spec.parameters then .spec.template = .spec.parameters end |
+       (if .spec.projectTemplateName then .spec.projectTypeName = .spec.projectTemplateName else . end) |
+       (if .spec.parameters then .spec.template = .spec.parameters else . end) |
        del(.spec.projectTemplateName) |
        del(.spec.parameters)
      else . end


### PR DESCRIPTION
## Description

Two changes to `modules/160-multitenancy-manager/webhooks/conversion/projects`.

**1. The v1alpha1 ↔ v1alpha2 converters use jq syntax that only exists in jq 1.7.**

Both legacy conversion functions contain:

```jq
if .spec.projectTemplateName then .spec.projectTypeName = .spec.projectTemplateName end |
```

An `if ... then ... end` with no `else` branch became legal only in **jq 1.7**. On jq 1.6 the whole program fails to *compile*, so neither direction converts anything:

```
$ jq-1.6 'if true then . end'
jq: error: syntax error, unexpected end (Unix shell quoting issues?)
jq: error: Possibly unterminated 'if' statement
jq: 2 compile errors
```

Both branches are now written out explicitly, matching what the newer v1alpha2 ↔ v1alpha3 converters in the same file already do. Verified by extracting the two programs verbatim from the hook and running them under both jq 1.6 and jq 1.7.1 against a real v1alpha2 Project plus three degenerate inputs (no `spec.parameters`, no `projectTemplateName`, a foreign `apiVersion`):

| input | before (jq 1.6) | before (jq 1.7.1) | after (both) |
|---|---|---|---|
| full object | compile error | → v1alpha1 | → v1alpha1 |
| no `spec.parameters` | compile error | → v1alpha1 | → v1alpha1 |
| no `projectTemplateName` | compile error | → v1alpha1 | → v1alpha1 |
| foreign `apiVersion` | compile error | untouched | untouched |
| v1alpha2→v1alpha1→v1alpha2 | compile error | identical to input | identical to input |

Behaviour on jq 1.7.1 is unchanged; the round trip stays byte-identical. The image has shipped jq 1.7.1 since [#10753](https://github.com/deckhouse/deckhouse/pull/10753) (Dec 2024), so this is latent on anything current — but the reverse converter landed in Nov 2024, one release before that bump, and the construct is a trap for anyone rebuilding the hook against a distro jq.

**2. The failure message named a CRD that does not exist.**

The v1alpha2 → v1alpha1 branch wrote `Conversion of deckhouse.io.io failed` (doubled domain). Both messages now name the CRD the hook is actually registered against, `projects.deckhouse.io`, instead of the bare API group.

### Caveat: that message is unreachable, and it is worth knowing why

While chasing a production report of `Conversion to deckhouse.io/v1alpha1 was not successuful`, it turned out that a hook's `failedMessage` **never reaches anyone**. shell-operator's conversion loop reads only `response.ConvertedObjects` and drops `response.FailedMessage` on the floor ([`operator.go`](https://github.com/flant/shell-operator/blob/v1.8.0/pkg/shell-operator/operator.go#L374-L408) — there is even a commented-out log line that would have printed it), then substitutes its own generic text:

```go
prop := convTask.GetProp("conversionResponse")
response, ok := prop.(*conversion.Response)
...
request.Objects = response.ConvertedObjects          // FailedMessage never read
newSourceVersions := conversion.ExtractAPIVersions(request.Objects)
if len(newSourceVersions) == 1 && newSourceVersions[0] == request.DesiredAPIVersion { done = true; break }
...
return &conversion.Response{
    FailedMessage: fmt.Sprintf("Conversion to %s was not successuful", request.DesiredAPIVersion),
}, nil
```

So the string this PR corrects is only ever read in source. It is still worth correcting — it is what a maintainer greps for when the hook misbehaves — but it fixes nothing an operator can see. Change 1 is the one with teeth. Making shell-operator surface the hook's own message is an upstream fix and is out of scope here.

### Two suspected defects in this hook that do NOT reproduce

Recording these so they do not get re-reported.

**Claim 1: "`spec.projectTemplateName` is dropped during conversion." — Not reproduced.**

The copy to `spec.projectTypeName` happens *before* the `del`, and the mirror runs on the way up. The hook mutates the object in place rather than rebuilding `spec` from a whitelist, so every unmentioned field passes through. Round-tripping a realistic v1alpha2 Project (`description`, `parameters.administrators`, `parameters.resourceQuota.{limits,requests}`, `parameters.networkPolicy`, `parameters.podSecurityProfile`, `parameters.extendedMonitoringEnabled`, `projectTemplateName: default`) through both programs returns an object identical to the input.

**Claim 2: "The `del(...)` calls run unconditionally even when the field is absent." — True but harmless.**

jq's `del` on a missing key is a silent no-op. Inputs with `projectTemplateName`/`parameters` absent, with no `spec` at all, and with `spec: null` all convert cleanly with exit 0 and no spurious keys. Guarding the `del`s would be noise.

### The down-conversion to v1alpha1 is live traffic, not dead code

Worth stating explicitly, because it is counter-intuitive and it is what makes change 1 matter. `v1alpha1` is `served: false` and a direct read really is refused:

```
$ kubectl get --raw '/apis/deckhouse.io/v1alpha1/projects'
Error from server (NotFound): the server could not find the requested resource
```

Yet on a live cluster the apiserver keeps asking the webhook to convert Projects *to* v1alpha1, continuously. Measured over a steady-state 10-minute window on a cluster with 25 Projects and 5 ProjectTemplates (304 conversions in total, **zero failures**):

| CRD | rule | calls |
|---|---|---|
| `projects.deckhouse.io` | v1alpha3 → v1alpha1 | 25 |
| `projects.deckhouse.io` | v1alpha3 → v1alpha2 | 25 |
| `projecttemplates.deckhouse.io` | v1alpha2 → v1alpha1 | 10 |

One full pass over every Project per version every ten minutes, one object per call, median 92 ms per call. So the legacy converter this PR touches is on a hot path that runs continuously — if it ever executes on a jq older than 1.7 it fails closed for every Project in the cluster, which is precisely the failure mode change 1 removes.

The requester is kube-apiserver itself, and it is not reacting to any inbound call. Its own metric attributes the traffic — `apiserver_crd_conversion_webhook_duration_seconds{crd_name="projects.deckhouse.io", from_version="v1alpha3", to_version="v1alpha1"}` stands at 1776 successful conversions against 1770 to v1alpha2 — while `apiserver_request_total` records no request at v1alpha1 at all, not even a 404, and the audit log shows only v1alpha3 traffic from the multitenancy-manager controller.

The same shape repeats on every multi-version Deckhouse CRD in that cluster: nodegroups v1 → v1alpha1 (161) and v1 → v1alpha2 (163), dexauthenticators v1 → v1alpha1 (348) and v1 → v2alpha1 (366), projecttemplates v1alpha2 → v1alpha1 (285). The apiserver converts each object into every non-storage version the CRD declares, in near-equal counts. `served: false` keeps a version out of the REST API; it does not exempt that version from conversion.

One consequence to keep in mind: the conversion never touches `status`, and the v1alpha1 status schema is much smaller than v1alpha2's, so whatever consumes these v1alpha1 objects receives a status pruned down to the v1alpha1 schema. Not changed here.

## Why do we need it, and what problem does it solve?

Change 1 removes a jq-version dependency that silently disables *both* legacy Project conversions rather than degrading. Change 2 stops a maintainer reading this file from chasing a resource name (`deckhouse.io.io`) that matches nothing in the cluster.

## Why do we need it in the patch release (if we do)?

No. Every currently supported release ships jq 1.7.1 in `common/shell-operator`, so change 1 is latent there, and change 2 is not observable at runtime at all.

## Checklist
- [ ] The code is covered by unit tests. — No. There is no test harness for shell-operator hooks in this module. The two jq programs were instead extracted verbatim from the hook and executed under jq 1.6 and jq 1.7.1 across the five cases tabulated above, before and after the change.
- [ ] e2e tests passed. — Not applicable. No behaviour change on the jq version that is actually shipped.
- [ ] Documentation updated according to the changes. — Not applicable. Both are internal to the hook.
- [ ] Changes were tested in the Kubernetes cluster manually. — No. Verified against the extracted jq programs and with `bash -n` on the hook.

## Changelog entries

```changes
section: multitenancy-manager
type: fix
summary: Project v1alpha1<->v1alpha2 conversion no longer depends on jq 1.7-only syntax, which silently disabled both conversions on older jq.
impact_level: low
```



