### PR TITLE
[user-authn] reject reserved system: identities in basic-auth-proxy

### DIFF
--- a/modules/150-user-authn/images/basic-auth-proxy/app/pkg/proxy/proxy.go
+++ b/modules/150-user-authn/images/basic-auth-proxy/app/pkg/proxy/proxy.go
@@ -415,6 +415,11 @@ func (h *Handler) validateCredentials(ctx context.Context, login, password strin
 
 	h.cache.SetWithTTL(key, cacheEntry{groups: groups}, h.GroupsCacheTTL)
 	h.logger.Printf("received groups for %s: %s", login, groups)
+	for _, group := range groups {
+		if isReservedIdentity(group) {
+			h.logger.Warningf("group %q of user %s will not be forwarded: the %q prefix is reserved by kube-apiserver", group, login, reservedIdentityPrefix)
+		}
+	}
 	return groups, nil
 }
 
@@ -441,12 +446,13 @@ func isReservedIdentity(name string) bool {
 	return strings.HasPrefix(name, reservedIdentityPrefix)
 }
 
-// filterReservedGroups drops directory groups that claim a reserved name.
-func (h *Handler) filterReservedGroups(login string, groups []string) []string {
+// filterReservedGroups drops directory groups that claim a reserved name. It is
+// silent by design: it runs on every proxied request, while validateCredentials
+// reports the same groups once per cache fill.
+func filterReservedGroups(groups []string) []string {
 	filtered := make([]string, 0, len(groups))
 	for _, group := range groups {
 		if isReservedIdentity(group) {
-			h.logger.Warningf("dropping group %q of user %s: the %q prefix is reserved by kube-apiserver", group, login, reservedIdentityPrefix)
 			continue
 		}
 		filtered = append(filtered, group)
@@ -463,7 +469,7 @@ func (h *Handler) modifyRequest(w http.ResponseWriter, r *http.Request, login st
 
 	stripIdentityHeaders(r.Header)
 	r.Header.Set("X-Remote-User", login)
-	for _, group := range h.filterReservedGroups(login, groups) {
+	for _, group := range filterReservedGroups(groups) {
 		r.Header.Add("X-Remote-Group", group)
 	}
 

--- a/modules/150-user-authn/images/basic-auth-proxy/app/pkg/proxy/proxy.go
+++ b/modules/150-user-authn/images/basic-auth-proxy/app/pkg/proxy/proxy.go
@@ -56,6 +56,11 @@ const (
 	// extraHeaderPrefix is the prefix kube-apiserver maps to user.Info.Extra
 	// (see --requestheader-extra-headers-prefix); must be stripped on ingress.
 	extraHeaderPrefix = "X-Remote-Extra-"
+
+	// reservedIdentityPrefix marks the identity namespace kube-apiserver keeps
+	// for itself, mirroring the userValidationRules the OIDC path enforces via
+	// AuthenticationConfiguration.
+	reservedIdentityPrefix = "system:"
 )
 
 var _ http.Handler = &Handler{}
@@ -427,10 +432,38 @@ func stripIdentityHeaders(h http.Header) {
 	}
 }
 
+// isReservedIdentity reports whether name lies in the identity namespace
+// kube-apiserver reserves for itself. An external directory holds no authority
+// over that namespace: system:masters is bound to cluster-admin by a default
+// ClusterRoleBinding, and the rest of the prefix carries kube-apiserver's own
+// synthetic groups such as system:authenticated.
+func isReservedIdentity(name string) bool {
+	return strings.HasPrefix(name, reservedIdentityPrefix)
+}
+
+// filterReservedGroups drops directory groups that claim a reserved name.
+func (h *Handler) filterReservedGroups(login string, groups []string) []string {
+	filtered := make([]string, 0, len(groups))
+	for _, group := range groups {
+		if isReservedIdentity(group) {
+			h.logger.Warningf("dropping group %q of user %s: the %q prefix is reserved by kube-apiserver", group, login, reservedIdentityPrefix)
+			continue
+		}
+		filtered = append(filtered, group)
+	}
+	return filtered
+}
+
 func (h *Handler) modifyRequest(w http.ResponseWriter, r *http.Request, login string, groups []string) {
+	if isReservedIdentity(login) {
+		h.logger.Errorf("403 Forbidden, user %s claims the reserved %q prefix", login, reservedIdentityPrefix)
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
+	}
+
 	stripIdentityHeaders(r.Header)
 	r.Header.Set("X-Remote-User", login)
-	for _, group := range groups {
+	for _, group := range h.filterReservedGroups(login, groups) {
 		r.Header.Add("X-Remote-Group", group)
 	}
 

--- a/modules/150-user-authn/images/basic-auth-proxy/app/pkg/proxy/proxy_test.go
+++ b/modules/150-user-authn/images/basic-auth-proxy/app/pkg/proxy/proxy_test.go
@@ -232,9 +232,9 @@ func TestHandler_CacheKey_DomainSeparation(t *testing.T) {
 	h := newTestHandler(t, &fakeProvider{}, 10*time.Second, 2*time.Minute)
 
 	tests := []struct {
-		name             string
-		loginA, passwdA  string
-		loginB, passwdB  string
+		name            string
+		loginA, passwdA string
+		loginB, passwdB string
 	}{
 		{"plain concat collision", "ab", "cd", "a", "bcd"},
 		{"nul-byte collision", "attacker\x00", "X", "attacker", "\x00X"},
@@ -401,6 +401,279 @@ func TestHandler_ServeHTTP(t *testing.T) {
 					t.Fatal("expected upstream to be called at least once")
 				}
 				tt.assertLastRequest(t, *obs)
+			}
+		})
+	}
+}
+
+// TestHandler_ReservedIdentitiesFromDirectory is the e2e regression for the
+// privilege escalation available to a directory administrator: a group named
+// system:masters in LDAP/OIDC/Crowd used to reach kube-apiserver verbatim.
+// Assertions are on the headers observed by the upstream, so they pin the
+// behaviour through modifyRequest rather than through the helper alone.
+func TestHandler_ReservedIdentitiesFromDirectory(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		login      string
+		provGroups []string
+		wantStatus int
+		wantHits   int64
+		wantUser   string
+		wantGroups []string
+	}{
+		{
+			name:       "an ordinary directory group reaches the upstream unchanged",
+			login:      "alice",
+			provGroups: []string{"devs"},
+			wantStatus: http.StatusOK,
+			wantHits:   1,
+			wantUser:   "alice",
+			wantGroups: []string{"devs"},
+		},
+		{
+			name:       "a directory group named system:masters is dropped",
+			login:      "alice",
+			provGroups: []string{"devs", "system:masters"},
+			wantStatus: http.StatusOK,
+			wantHits:   1,
+			wantUser:   "alice",
+			wantGroups: []string{"devs"},
+		},
+		{
+			name:       "a directory group named system:authenticated is dropped",
+			login:      "alice",
+			provGroups: []string{"system:authenticated", "devs"},
+			wantStatus: http.StatusOK,
+			wantHits:   1,
+			wantUser:   "alice",
+			wantGroups: []string{"devs"},
+		},
+		{
+			name:       "a group that merely contains system: is kept",
+			login:      "alice",
+			provGroups: []string{"acme:system:masters", "not-system:masters", "systems"},
+			wantStatus: http.StatusOK,
+			wantHits:   1,
+			wantUser:   "alice",
+			wantGroups: []string{"acme:system:masters", "not-system:masters", "systems"},
+		},
+		{
+			name:       "a user with no directory groups authenticates without group headers",
+			login:      "alice",
+			provGroups: nil,
+			wantStatus: http.StatusOK,
+			wantHits:   1,
+			wantUser:   "alice",
+			wantGroups: nil,
+		},
+		{
+			name:       "a user whose every group is reserved still authenticates, with no group headers",
+			login:      "alice",
+			provGroups: []string{"system:masters", "system:authenticated"},
+			wantStatus: http.StatusOK,
+			wantHits:   1,
+			wantUser:   "alice",
+			wantGroups: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var (
+				upstreamHits atomic.Int64
+				lastHeaders  atomic.Pointer[http.Header]
+			)
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				upstreamHits.Add(1)
+				headers := r.Header.Clone()
+				lastHeaders.Store(&headers)
+				w.WriteHeader(http.StatusOK)
+			}))
+			t.Cleanup(upstream.Close)
+
+			u, err := url.Parse(upstream.URL)
+			if err != nil {
+				t.Fatalf("parse upstream url: %v", err)
+			}
+
+			h := newTestHandler(t, &fakeProvider{groups: tt.provGroups}, 10*time.Second, 2*time.Minute)
+			h.reverseProxy = httputil.NewSingleHostReverseProxy(u)
+
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/namespaces", nil)
+			req.SetBasicAuth(tt.login, "ok")
+
+			h.ServeHTTP(rec, req)
+
+			if rec.Code != tt.wantStatus {
+				t.Fatalf("status: got %d, want %d", rec.Code, tt.wantStatus)
+			}
+			if got := upstreamHits.Load(); got != tt.wantHits {
+				t.Fatalf("upstream hits: got %d, want %d", got, tt.wantHits)
+			}
+			if tt.wantHits == 0 {
+				return
+			}
+
+			headers := lastHeaders.Load()
+			if headers == nil {
+				t.Fatal("expected the upstream to observe a request")
+			}
+			if got := headers.Get("X-Remote-User"); got != tt.wantUser {
+				t.Fatalf("X-Remote-User: got %q, want %q", got, tt.wantUser)
+			}
+			if got := headers.Values("X-Remote-Group"); !slices.Equal(got, tt.wantGroups) {
+				t.Fatalf("X-Remote-Group: got %v, want %v", got, tt.wantGroups)
+			}
+		})
+	}
+}
+
+// TestHandler_ReservedUsernameIsRefused drives modifyRequest directly rather
+// than ServeHTTP: RFC 7617 gives the first colon to the user-id/password
+// separator, so basic auth cannot carry a "system:"-prefixed login at all
+// (SetBasicAuth("system:masters", "pw") is read back as user "system"). The
+// guard is defence in depth at the choke point, for any caller that does not
+// source the login from r.BasicAuth.
+func TestHandler_ReservedUsernameIsRefused(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		login      string
+		wantStatus int
+		wantHits   int64
+	}{
+		{
+			name:       "a user named system:masters is refused with the credentials failure",
+			login:      "system:masters",
+			wantStatus: http.StatusForbidden,
+			wantHits:   0,
+		},
+		{
+			name:       "a user named system:kube-controller-manager is refused",
+			login:      "system:kube-controller-manager",
+			wantStatus: http.StatusForbidden,
+			wantHits:   0,
+		},
+		{
+			name:       "a login that merely contains system: is proxied",
+			login:      "acme:system:bob",
+			wantStatus: http.StatusOK,
+			wantHits:   1,
+		},
+		{
+			name:       "an ordinary login is proxied",
+			login:      "alice",
+			wantStatus: http.StatusOK,
+			wantHits:   1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var (
+				upstreamHits atomic.Int64
+				lastHeaders  atomic.Pointer[http.Header]
+			)
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				upstreamHits.Add(1)
+				headers := r.Header.Clone()
+				lastHeaders.Store(&headers)
+				w.WriteHeader(http.StatusOK)
+			}))
+			t.Cleanup(upstream.Close)
+
+			u, err := url.Parse(upstream.URL)
+			if err != nil {
+				t.Fatalf("parse upstream url: %v", err)
+			}
+
+			h := newTestHandler(t, &fakeProvider{}, 10*time.Second, 2*time.Minute)
+			h.reverseProxy = httputil.NewSingleHostReverseProxy(u)
+
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/namespaces", nil)
+
+			h.modifyRequest(rec, req, tt.login, []string{"devs"})
+
+			if rec.Code != tt.wantStatus {
+				t.Fatalf("status: got %d, want %d", rec.Code, tt.wantStatus)
+			}
+			if got := upstreamHits.Load(); got != tt.wantHits {
+				t.Fatalf("upstream hits: got %d, want %d", got, tt.wantHits)
+			}
+			if tt.wantHits == 0 {
+				if got := req.Header.Get("X-Remote-User"); got != "" {
+					t.Fatalf("X-Remote-User must not be set on a refused request, got %q", got)
+				}
+				return
+			}
+
+			headers := lastHeaders.Load()
+			if headers == nil {
+				t.Fatal("expected the upstream to observe a request")
+			}
+			if got := headers.Get("X-Remote-User"); got != tt.login {
+				t.Fatalf("X-Remote-User: got %q, want %q", got, tt.login)
+			}
+		})
+	}
+}
+
+// TestHandler_BasicAuthCannotCarryAReservedUsername pins the RFC 7617 parsing
+// that keeps the reserved-username case unreachable from the network: the
+// login is truncated at the first colon, so it can never bear the prefix.
+func TestHandler_BasicAuthCannotCarryAReservedUsername(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/namespaces", nil)
+	req.SetBasicAuth("system:masters", "pw")
+
+	login, password, ok := req.BasicAuth()
+	if !ok {
+		t.Fatal("expected basic auth credentials to parse")
+	}
+	if login != "system" {
+		t.Fatalf("login: got %q, want %q", login, "system")
+	}
+	if password != "masters:pw" {
+		t.Fatalf("password: got %q, want %q", password, "masters:pw")
+	}
+	if isReservedIdentity(login) {
+		t.Fatalf("login %q must not be reserved after basic-auth parsing", login)
+	}
+}
+
+// TestIsReservedIdentity is a focused unit test for the predicate.
+func TestIsReservedIdentity(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"system:masters is reserved", "system:masters", true},
+		{"system:authenticated is reserved", "system:authenticated", true},
+		{"the bare prefix is reserved", "system:", true},
+		{"a plain group is not reserved", "devs", false},
+		{"an embedded prefix is not reserved", "acme:system:masters", false},
+		{"a prefix without the colon is not reserved", "systems", false},
+		{"the empty string is not reserved", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isReservedIdentity(tt.in); got != tt.want {
+				t.Fatalf("isReservedIdentity(%q): got %v, want %v", tt.in, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Description

`basic-auth-proxy` copied directory group names into `X-Remote-Group` verbatim. This change rejects identities in the reserved `system:` namespace at the point where the identity headers are written:

- Groups whose name begins with `system:` are dropped, and each drop is logged with the user and the group so an operator can see why a group vanished.
- A `system:`-prefixed username cannot be dropped, because it *is* the identity, so it is refused with the same `403 Forbidden` the proxy already returns for bad credentials. That keeps the response uniform and does not leak which usernames exist. It is logged distinctly.

The filtering lives in `modifyRequest` and nowhere else. That is the single point where `X-Remote-User` and `X-Remote-Group` are written and every provider path funnels through it, so no provider can bypass it. Filtering earlier, where provider groups enter the cache, would have to be repeated in each of the three provider implementations and a fourth provider added later could omit it. It would also turn the Crowd-specific "no allowed groups" check in `ServeHTTP` into a rejection for a user whose groups all happen to be reserved, whereas the intended behaviour is to authenticate that user with no groups at all.

No cluster component restarts beyond the `basic-auth-proxy` Deployment itself, which only exists when the feature is enabled.

The commit also realigns a struct in `proxy_test.go` that already failed `gofmt` on `main`, in a test this change does not otherwise touch.

### Scope notes

**`X-Remote-Extra-*` is already safe and is not changed.** The original report asked about it. `stripIdentityHeaders` deletes every header carrying the `X-Remote-Extra-` prefix on ingress, and the proxy never re-adds an extra of its own, so no directory-sourced value can reach `user.Info.Extra`. There is an existing regression test for this.

**A `system:`-prefixed username is not reachable over basic auth today.** RFC 7617 gives the first colon to the user-id/password separator, so `SetBasicAuth("system:masters", "pw")` is read back by `r.BasicAuth()` as user `system` with password `masters:pw`. The username guard is therefore defence in depth at the choke point for any future caller that does not source the login from `r.BasicAuth`, and it mirrors the rule the OIDC path already enforces. A test pins that parsing behaviour so the claim does not silently rot.

**Follow-up, not implemented here:** an `allowedGroups` allow-list exists for the Crowd provider only (`provider/crowd.go`), configured from `DexProvider.spec.crowd.groups`. `provider/oidc.go` and `provider/ldap.go` return `claims.Groups` with no equivalent. To be accurate about what it does: it is a general allow-list, not a `system:` filter, and it is inert when unconfigured — `GetGroups` only intersects when `len(allowedGroups) > 0` and otherwise appends every group. So it would **not** have prevented this defect on its own: an operator who never set `groups`, or who set it and also had a `system:masters` entry in it, was still exposed, and OIDC and LDAP users were exposed unconditionally. Extending an allow-list to the other two providers is reasonable work but is a different change with a different user-facing contract.

## Why do we need it, and what problem does it solve?

The proxy authenticates a user against an external directory and forwards their identity to kube-apiserver using request-header authentication. It presents a client certificate whose CN is `front-proxy-client` (`hooks/generate_basic_auth_proxy_cert.go:177`), which is exactly the identity in `--requestheader-allowed-names` (`candi/control-plane/kube-apiserver.yaml.tpl:137`). kube-apiserver therefore trusts `X-Remote-User` and `X-Remote-Group` from this proxy without further checks.

Group names came from the directory and were copied into `X-Remote-Group` with no filtering, so a user who belonged to a directory group literally named `system:masters` became a member of that Kubernetes group and picked up the `cluster-admin` binding that ships with it. The group name is chosen by the directory administrator, not by Kubernetes, and the directory may be shared with systems where `system:masters` is an unremarkable name.

Two things make this worth fixing rather than documenting:

The code twelve lines above the defect already named this exact escalation. The comment on `stripIdentityHeaders` explains that kube-apiserver trusts these headers and that leaving a client-supplied one through "would let any client become cluster-admin via `X-Remote-Group: system:masters`". But it describes a different attacker: the HTTP client spoofing the header on the way in, which is why the function deletes every client-supplied `X-Remote-*` value. The threat model did not cover the same value arriving from the trusted side, out of the directory, after authentication had already succeeded.

The project had already decided that `system:`-prefixed identities from an external IdP are unacceptable, and enforces it on the OIDC path: `modules/040-control-plane-manager/templates/_authentication_configuration.tpl:31-35` carries `userValidationRules` rejecting both a `system:` username and any `system:` group. Those rules sit inside the `jwt:` list item (and inside `{{- if .apiserver.oidcIssuerURL }}`), so they constrain JWT authenticators only and do not apply to the request-header path at all. This change makes the two paths agree.

### Severity, honestly bounded

This is not remotely reachable in a default installation. The code path only exists when `publishAPI` is enabled **and** a provider has `enableBasicAuth` set:

- `publishAPI.enabled` defaults to `false` in `openapi/config-values.yaml`.
- `enableBasicAuth` is an unset boolean with no default in the `DexProvider` CRD, so it is off unless an operator opts in.
- `templates/_helpers.tpl` (`is_basic_auth_enabled`) requires both. Note it accepts `Crowd`, `OIDC` **and** `LDAP`, so the exposure is slightly wider than a Crowd-only reading suggests, though `enableBasicAuth` requires exactly one such provider.

Exploiting it also requires the ability to create or join a group with a specific name in the external directory, which is normally an administrative action. The realistic scenario is not a determined attacker so much as a shared or pre-existing directory that already contains a group named `system:masters` for unrelated reasons, silently granting cluster-admin to everyone in it.

## Why do we need it in the patch release (if we do)?

**Recommendation: yes, backport to `release-1.77`.**

The cherry-pick is clean. `proxy.go` and `proxy_test.go` are byte-identical on `main` and `release-1.77` (blob `c442acd3d5` and `6f3d7b7659` on both), so the commit applies without conflict.

Weighing it: the non-default configuration required to reach the path argues against urgency, and on its own would justify waiting for the next minor. What tips it the other way is that the failure is silent and the fix is small. An affected cluster shows no symptom — a directory group grants cluster-admin and nothing logs it — so operators cannot self-assess without being told to go and audit their directory. The change is a prefix check on a path that is off by default, so the regression risk to unaffected clusters is close to nil: a cluster not using basic auth cannot notice, and a cluster using it only notices if it was relying on the broken behaviour, which is the behaviour being removed.

The one genuine behaviour change to flag for a patch release is that a user who *is* currently getting privileges through a `system:`-prefixed group will lose them on update. That is the point of the fix, but it can look like a regression to an operator who does not know why, which is why the dropped group is logged and why the changelog impact is marked `high`.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

Documentation is not affected: no user-facing parameter is added or changed, and the constraint enforced here is the one the OIDC path already documents.

## Changelog entries

```changes
section: user-authn
type: fix
summary: basic-auth-proxy no longer forwards reserved `system:` groups and usernames from the external directory to kube-apiserver.
impact: |
  Affects clusters where `publishAPI` is enabled together with `enableBasicAuth` on a
  Crowd, OIDC or LDAP `DexProvider`. Both are disabled by default, so a default
  installation is not affected.

  Previously the proxy copied directory group names into the `X-Remote-Group` header
  verbatim. Because kube-apiserver trusts that header from this proxy, a user in a
  directory group literally named `system:masters` was granted cluster-admin. Group
  names are chosen by the directory administrator, not by Kubernetes.

  After updating, any group whose name begins with `system:` is dropped before the
  request reaches kube-apiserver, and each drop is logged by the basic-auth-proxy pod
  with the user and the group name. A user authenticating with a `system:`-prefixed
  username is refused with `403 Forbidden`. This matches the `userValidationRules`
  already enforced on the OIDC/JWT path.

  Before updating, audit your directory for groups whose name begins with `system:`
  and check whether anyone currently relies on one to reach the Kubernetes API through
  basic auth. Such users will lose those privileges on update and must be granted
  access through a normal group bound by RBAC instead. Check the basic-auth-proxy logs
  after updating for `dropping group` messages.
impact_level: high
```