### PR TITLE
[user-authn] honour the value of the allow-access-to-kubernetes annotation

### DIFF
--- a/modules/150-user-authn/hooks/get_dex_authenticator_crds.go
+++ b/modules/150-user-authn/hooks/get_dex_authenticator_crds.go
@@ -55,8 +55,8 @@ type DexAuthenticator struct {
 
 	// AllowAccessToKubernetesAnnotation carries the raw annotation value from the filter,
 	// which has no logger, to the hook body, which does. It is nil when the annotation is
-	// absent and is cleared before the authenticator reaches the internal values.
-	AllowAccessToKubernetesAnnotation *string `json:"allowAccessToKubernetesAnnotation,omitempty"`
+	// absent, and json:"-" keeps it out of the internal values the templates read.
+	AllowAccessToKubernetesAnnotation *string `json:"-"`
 }
 
 type Credentials struct {
@@ -197,7 +197,6 @@ func getDexAuthenticator(_ context.Context, input *go_hook.HookInput) error {
 			}
 
 			dexAuthenticator.AllowAccessToKubernetes = allowed
-			dexAuthenticator.AllowAccessToKubernetesAnnotation = nil
 		}
 
 		dexAuthenticator.Credentials = existedCredentials

--- a/modules/150-user-authn/hooks/get_dex_authenticator_crds.go
+++ b/modules/150-user-authn/hooks/get_dex_authenticator_crds.go
@@ -21,7 +21,9 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"log/slog"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
@@ -37,6 +39,10 @@ import (
 	"github.com/deckhouse/deckhouse/go_lib/pwgen"
 )
 
+// dexAuthenticatorAllowAccessToKubernetesAnnotation puts the authenticator into trustedPeers
+// of the kubernetes OAuth2Client, so its tokens are accepted by kube-apiserver.
+const dexAuthenticatorAllowAccessToKubernetesAnnotation = "dexauthenticator.deckhouse.io/allow-access-to-kubernetes"
+
 type DexAuthenticator struct {
 	ID          string                 `json:"uuid"`
 	EncodedName string                 `json:"encodedName"`
@@ -46,6 +52,11 @@ type DexAuthenticator struct {
 
 	AllowAccessToKubernetes bool        `json:"allowAccessToKubernetes"`
 	Credentials             Credentials `json:"credentials"`
+
+	// AllowAccessToKubernetesAnnotation carries the raw annotation value from the filter,
+	// which has no logger, to the hook body, which does. It is nil when the annotation is
+	// absent and is cleared before the authenticator reaches the internal values.
+	AllowAccessToKubernetesAnnotation *string `json:"allowAccessToKubernetesAnnotation,omitempty"`
 }
 
 type Credentials struct {
@@ -75,15 +86,18 @@ func applyDexAuthenticatorFilter(obj *unstructured.Unstructured) (go_hook.Filter
 	id := fmt.Sprintf("%s@%s", name, namespace)
 	encodedName := encoding.ToFnvLikeDex(fmt.Sprintf("%s-%s-dex-authenticator", name, namespace))
 
-	_, allowAccessToKubernetes := obj.GetAnnotations()["dexauthenticator.deckhouse.io/allow-access-to-kubernetes"]
+	var allowAccessAnnotation *string
+	if value, exists := obj.GetAnnotations()[dexAuthenticatorAllowAccessToKubernetesAnnotation]; exists {
+		allowAccessAnnotation = &value
+	}
 
 	return DexAuthenticator{
-		ID:                      id,
-		EncodedName:             encodedName,
-		Name:                    name,
-		Namespace:               namespace,
-		Spec:                    spec,
-		AllowAccessToKubernetes: allowAccessToKubernetes,
+		ID:                                id,
+		EncodedName:                       encodedName,
+		Name:                              name,
+		Namespace:                         namespace,
+		Spec:                              spec,
+		AllowAccessToKubernetesAnnotation: allowAccessAnnotation,
 	}, nil
 }
 
@@ -167,6 +181,23 @@ func getDexAuthenticator(_ context.Context, input *go_hook.HookInput) error {
 		// Migrate all cookie secret from 20 bytes length to 24 bytes
 		if len(existedCredentials.CookieSecret) < 24 {
 			existedCredentials.CookieSecret = pwgen.AlphaNum(24)
+		}
+
+		if raw := dexAuthenticator.AllowAccessToKubernetesAnnotation; raw != nil {
+			allowed, err := strconv.ParseBool(*raw)
+			if err != nil {
+				// Fail closed: a value nobody can read as a boolean must not hand out
+				// tokens the kube-apiserver accepts.
+				allowed = false
+				input.Logger.Warn("Ignoring invalid allow-access-to-kubernetes annotation",
+					slog.String("dexauthenticator", dexAuthenticator.Name),
+					slog.String("namespace", dexAuthenticator.Namespace),
+					slog.String("annotation", dexAuthenticatorAllowAccessToKubernetesAnnotation),
+					slog.String("value", *raw))
+			}
+
+			dexAuthenticator.AllowAccessToKubernetes = allowed
+			dexAuthenticator.AllowAccessToKubernetesAnnotation = nil
 		}
 
 		dexAuthenticator.Credentials = existedCredentials

--- a/modules/150-user-authn/hooks/get_dex_authenticator_crds_test.go
+++ b/modules/150-user-authn/hooks/get_dex_authenticator_crds_test.go
@@ -19,13 +19,22 @@ package hooks
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"strings"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	"k8s.io/utils/ptr"
 
 	. "github.com/deckhouse/deckhouse/testing/hooks"
 )
+
+type inputDexAuthenticatorAllowAccess struct {
+	annotation *string
+	allowed    bool
+	warns      bool
+}
 
 var _ = Describe("User Authn hooks :: get dex authenticator crds ::", func() {
 	f := HookExecutionConfigInit(`{"userAuthn":{"internal": {}}}`, "")
@@ -305,6 +314,71 @@ spec:
 			Expect(namesMap.Get(shortID).Get("ingressNames").Get("0").Get("truncated").Bool()).Should(BeFalse())
 		})
 	})
+
+	DescribeTable("The dexauthenticator.deckhouse.io/allow-access-to-kubernetes annotation",
+		func(in inputDexAuthenticatorAllowAccess) {
+			var annotations string
+			if in.annotation != nil {
+				annotations = fmt.Sprintf("\n  annotations:\n    %s: %q", dexAuthenticatorAllowAccessToKubernetesAnnotation, *in.annotation)
+			}
+
+			f.BindingContexts.Set(f.KubeStateSet(`
+---
+apiVersion: deckhouse.io/v2alpha1
+kind: DexAuthenticator
+metadata:
+  name: test
+  namespace: test` + annotations + `
+spec:
+  applications:
+  - domain: test
+    ingressClassName: "nginx"
+  sendAuthorizationHeader: false
+`))
+			f.RunHook()
+
+			Expect(f).To(ExecuteSuccessfully())
+
+			authenticator := f.ValuesGet("userAuthn.internal.dexAuthenticatorCRDs.0")
+			Expect(authenticator.Get("allowAccessToKubernetes").Bool()).To(Equal(in.allowed))
+			Expect(authenticator.Get("allowAccessToKubernetesAnnotation").Exists()).To(BeFalse())
+
+			logs := string(f.LoggerOutput.Contents())
+			if in.warns {
+				Expect(logs).To(ContainSubstring("Ignoring invalid allow-access-to-kubernetes annotation"))
+				Expect(logs).To(ContainSubstring(dexAuthenticatorAllowAccessToKubernetesAnnotation))
+			} else {
+				Expect(logs).NotTo(ContainSubstring("Ignoring invalid allow-access-to-kubernetes annotation"))
+			}
+		},
+		Entry(`grants access to the Kubernetes API when the value is "true"`,
+			inputDexAuthenticatorAllowAccess{annotation: ptr.To("true"), allowed: true},
+		),
+		Entry(`grants access to the Kubernetes API when the value is "1"`,
+			inputDexAuthenticatorAllowAccess{annotation: ptr.To("1"), allowed: true},
+		),
+		Entry(`grants access to the Kubernetes API when the value is "True"`,
+			inputDexAuthenticatorAllowAccess{annotation: ptr.To("True"), allowed: true},
+		),
+		Entry(`denies access to the Kubernetes API when the value is "false"`,
+			inputDexAuthenticatorAllowAccess{annotation: ptr.To("false")},
+		),
+		Entry(`denies access to the Kubernetes API when the value is "0"`,
+			inputDexAuthenticatorAllowAccess{annotation: ptr.To("0")},
+		),
+		Entry("denies access to the Kubernetes API and warns when the value is empty",
+			inputDexAuthenticatorAllowAccess{annotation: ptr.To(""), warns: true},
+		),
+		Entry(`denies access to the Kubernetes API and warns when the value is "yes"`,
+			inputDexAuthenticatorAllowAccess{annotation: ptr.To("yes"), warns: true},
+		),
+		Entry(`denies access to the Kubernetes API and warns when the value is "enabled"`,
+			inputDexAuthenticatorAllowAccess{annotation: ptr.To("enabled"), warns: true},
+		),
+		Entry("denies access to the Kubernetes API without warning when the annotation is absent",
+			inputDexAuthenticatorAllowAccess{},
+		),
+	)
 })
 
 var _ = Describe("safeDNS1123Name", func() {

--- a/modules/150-user-authn/hooks/get_dex_client_crds.go
+++ b/modules/150-user-authn/hooks/get_dex_client_crds.go
@@ -60,8 +60,8 @@ type DexClient struct {
 
 	// AllowAccessToKubernetesAnnotation carries the raw annotation value from the filter,
 	// which has no logger, to the hook body, which does. It is nil when the annotation is
-	// absent and is cleared before the client reaches the internal values.
-	AllowAccessToKubernetesAnnotation *string `json:"allowAccessToKubernetesAnnotation,omitempty"`
+	// absent, and json:"-" keeps it out of the internal values the templates read.
+	AllowAccessToKubernetesAnnotation *string `json:"-"`
 }
 
 type DexClientSecret struct {
@@ -203,7 +203,6 @@ func getDexClient(_ context.Context, input *go_hook.HookInput) error {
 			}
 
 			dexClient.AllowAccessToKubernetes = allowed
-			dexClient.AllowAccessToKubernetesAnnotation = nil
 		}
 
 		dexClient.Secret = existedSecret

--- a/modules/150-user-authn/hooks/get_dex_client_crds.go
+++ b/modules/150-user-authn/hooks/get_dex_client_crds.go
@@ -19,6 +19,8 @@ package hooks
 import (
 	"context"
 	"fmt"
+	"log/slog"
+	"strconv"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
@@ -31,6 +33,10 @@ import (
 	"github.com/deckhouse/deckhouse/go_lib/encoding"
 	"github.com/deckhouse/deckhouse/go_lib/pwgen"
 )
+
+// dexClientAllowAccessToKubernetesAnnotation puts the client into trustedPeers of the
+// kubernetes OAuth2Client, so its tokens are accepted by kube-apiserver.
+const dexClientAllowAccessToKubernetesAnnotation = "dexclient.deckhouse.io/allow-access-to-kubernetes"
 
 type DexClient struct {
 	ID        string `json:"id"`
@@ -51,6 +57,11 @@ type DexClient struct {
 	Annotations map[string]string `json:"annotations"`
 
 	AllowAccessToKubernetes bool `json:"allowAccessToKubernetes"`
+
+	// AllowAccessToKubernetesAnnotation carries the raw annotation value from the filter,
+	// which has no logger, to the hook body, which does. It is nil when the annotation is
+	// absent and is cleared before the client reaches the internal values.
+	AllowAccessToKubernetesAnnotation *string `json:"allowAccessToKubernetesAnnotation,omitempty"`
 }
 
 type DexClientSecret struct {
@@ -91,23 +102,23 @@ func applyDexClientFilter(obj *unstructured.Unstructured) (go_hook.FilterResult,
 		annotations = make(map[string]string)
 	}
 
-	if value, exists := obj.GetAnnotations()["dexclient.deckhouse.io/allow-access-to-kubernetes"]; exists {
-		annotations["dexclient.deckhouse.io/allow-access-to-kubernetes"] = value
+	var allowAccessAnnotation *string
+	if value, exists := obj.GetAnnotations()[dexClientAllowAccessToKubernetesAnnotation]; exists {
+		annotations[dexClientAllowAccessToKubernetesAnnotation] = value
+		allowAccessAnnotation = &value
 	}
 
-	_, allowAccessToKubernetes := obj.GetAnnotations()["dexclient.deckhouse.io/allow-access-to-kubernetes"]
-
 	return DexClient{
-		ID:                      id,
-		LegacyID:                legacyID,
-		EncodedID:               encoding.ToFnvLikeDex(id),
-		LegacyEncodedID:         encoding.ToFnvLikeDex(legacyID),
-		Name:                    name,
-		Namespace:               namespace,
-		Spec:                    spec,
-		Labels:                  labels,
-		Annotations:             annotations,
-		AllowAccessToKubernetes: allowAccessToKubernetes,
+		ID:                                id,
+		LegacyID:                          legacyID,
+		EncodedID:                         encoding.ToFnvLikeDex(id),
+		LegacyEncodedID:                   encoding.ToFnvLikeDex(legacyID),
+		Name:                              name,
+		Namespace:                         namespace,
+		Spec:                              spec,
+		Labels:                            labels,
+		Annotations:                       annotations,
+		AllowAccessToKubernetesAnnotation: allowAccessAnnotation,
 	}, nil
 }
 
@@ -176,6 +187,23 @@ func getDexClient(_ context.Context, input *go_hook.HookInput) error {
 		existedSecret, ok := credentialsByID[dexClient.ID]
 		if !ok {
 			existedSecret = pwgen.AlphaNum(20)
+		}
+
+		if raw := dexClient.AllowAccessToKubernetesAnnotation; raw != nil {
+			allowed, err := strconv.ParseBool(*raw)
+			if err != nil {
+				// Fail closed: a value nobody can read as a boolean must not hand out
+				// tokens the kube-apiserver accepts.
+				allowed = false
+				input.Logger.Warn("Ignoring invalid allow-access-to-kubernetes annotation",
+					slog.String("dexclient", dexClient.Name),
+					slog.String("namespace", dexClient.Namespace),
+					slog.String("annotation", dexClientAllowAccessToKubernetesAnnotation),
+					slog.String("value", *raw))
+			}
+
+			dexClient.AllowAccessToKubernetes = allowed
+			dexClient.AllowAccessToKubernetesAnnotation = nil
 		}
 
 		dexClient.Secret = existedSecret

--- a/modules/150-user-authn/hooks/get_dex_client_crds_test.go
+++ b/modules/150-user-authn/hooks/get_dex_client_crds_test.go
@@ -17,12 +17,22 @@ limitations under the License.
 package hooks
 
 import (
+	"fmt"
+
 	. "github.com/benjamintf1/unmarshalledmatchers"
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	"k8s.io/utils/ptr"
 
 	. "github.com/deckhouse/deckhouse/testing/hooks"
 )
+
+type inputDexClientAllowAccess struct {
+	annotation *string
+	allowed    bool
+	warns      bool
+}
 
 var _ = Describe("User Authn hooks :: get dex client crds ::", func() {
 	f := HookExecutionConfigInit(`{"userAuthn":{"internal": {}}}`, "")
@@ -368,4 +378,82 @@ spec:
 }]`))
 		})
 	})
+
+	DescribeTable("The dexclient.deckhouse.io/allow-access-to-kubernetes annotation",
+		func(in inputDexClientAllowAccess) {
+			var annotations string
+			if in.annotation != nil {
+				annotations = fmt.Sprintf("\n  annotations:\n    %s: %q", dexClientAllowAccessToKubernetesAnnotation, *in.annotation)
+			}
+
+			f.BindingContexts.Set(f.KubeStateSet(`
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dex-client-opendistro
+  namespace: test
+  labels:
+    app: dex-client
+    name: credentials
+data:
+  clientSecret: dGVzdA==
+---
+apiVersion: deckhouse.io/v1
+kind: DexClient
+metadata:
+  name: opendistro
+  namespace: test` + annotations + `
+spec:
+  redirectURIs:
+  - https://opendistro.example.com/callback
+`))
+			f.RunHook()
+
+			Expect(f).To(ExecuteSuccessfully())
+
+			client := f.ValuesGet("userAuthn.internal.dexClientCRDs.0")
+			Expect(client.Get("allowAccessToKubernetes").Bool()).To(Equal(in.allowed))
+			Expect(client.Get("allowAccessToKubernetesAnnotation").Exists()).To(BeFalse())
+
+			if in.annotation != nil {
+				Expect(client.Get("annotations").String()).To(MatchJSON(fmt.Sprintf(`{%q: %q}`, dexClientAllowAccessToKubernetesAnnotation, *in.annotation)))
+			}
+
+			logs := string(f.LoggerOutput.Contents())
+			if in.warns {
+				Expect(logs).To(ContainSubstring("Ignoring invalid allow-access-to-kubernetes annotation"))
+				Expect(logs).To(ContainSubstring(dexClientAllowAccessToKubernetesAnnotation))
+			} else {
+				Expect(logs).NotTo(ContainSubstring("Ignoring invalid allow-access-to-kubernetes annotation"))
+			}
+		},
+		Entry(`grants access to the Kubernetes API when the value is "true"`,
+			inputDexClientAllowAccess{annotation: ptr.To("true"), allowed: true},
+		),
+		Entry(`grants access to the Kubernetes API when the value is "1"`,
+			inputDexClientAllowAccess{annotation: ptr.To("1"), allowed: true},
+		),
+		Entry(`grants access to the Kubernetes API when the value is "True"`,
+			inputDexClientAllowAccess{annotation: ptr.To("True"), allowed: true},
+		),
+		Entry(`denies access to the Kubernetes API when the value is "false"`,
+			inputDexClientAllowAccess{annotation: ptr.To("false")},
+		),
+		Entry(`denies access to the Kubernetes API when the value is "0"`,
+			inputDexClientAllowAccess{annotation: ptr.To("0")},
+		),
+		Entry("denies access to the Kubernetes API and warns when the value is empty",
+			inputDexClientAllowAccess{annotation: ptr.To(""), warns: true},
+		),
+		Entry(`denies access to the Kubernetes API and warns when the value is "yes"`,
+			inputDexClientAllowAccess{annotation: ptr.To("yes"), warns: true},
+		),
+		Entry(`denies access to the Kubernetes API and warns when the value is "enabled"`,
+			inputDexClientAllowAccess{annotation: ptr.To("enabled"), warns: true},
+		),
+		Entry("denies access to the Kubernetes API without warning when the annotation is absent",
+			inputDexClientAllowAccess{},
+		),
+	)
 })


### PR DESCRIPTION
## Description

`modules/150-user-authn` decided whether a DexClient or a DexAuthenticator may obtain tokens with `aud=kubernetes` by checking that the annotation key existed, never looking at its value:

```go
_, allowAccessToKubernetes := obj.GetAnnotations()["dexclient.deckhouse.io/allow-access-to-kubernetes"]
```

In `get_dex_client_crds.go` the value was even read into a variable two lines earlier and then discarded.

The value is now parsed with `strconv.ParseBool`, in both `get_dex_client_crds.go` and `get_dex_authenticator_crds.go`. Only `1`, `t`, `T`, `TRUE`, `true` and `True` grant the capability.

A value that does not parse (`yes`, `enabled`, an empty string, a typo) is treated as **disabled**. Fail-closed is the only defensible reading: this flag hands out credentials the kube-apiserver accepts, and that must never be the by-product of a string nobody can interpret. It is not swallowed silently, though — silence is exactly what kept the original defect invisible — so the hook emits a warning naming the object, its namespace and the offending value:

```
Ignoring invalid allow-access-to-kubernetes annotation dexclient=opendistro namespace=test value=yes
```

The filter functions (`applyDexClientFilter`, `applyDexAuthenticatorFilter`) receive only an `*unstructured.Unstructured` and have no logger, so the parse happens in the hook body, which does. This mirrors how `get_dex_user_crds.go` already handles a malformed `spec.ttl`: the filter carries the raw value, the hook body parses it and calls `input.Logger.Warn`. Each filter now carries the raw annotation in an `*string` field that the hook body clears before the object reaches the internal values, so the rendered values are byte-identical to before.

Nothing else changed: no templates, no CRDs, no RBAC.

## Why do we need it, and what problem does it solve?

The annotation puts the client into `trustedPeers` of the `kubernetes` OAuth2Client (`templates/dex/oauth2client.yaml:29-35`), and that client's tokens are accepted by kube-apiserver. Combined with `skipApprovalScreen: true`, which the module renders by default, this is a direct path to cluster credentials.

An administrator who wrote:

```yaml
annotations:
  dexclient.deckhouse.io/allow-access-to-kubernetes: "false"
```

to switch the capability **off** got the exact opposite, silently. Every example in the repository and in the documentation writes `"true"`, and `docs/documentation/pages/admin/configuration/access/authorization/CI_CD.md` describes the annotation as though its value carried meaning — so the wrong belief was easy to hold and impossible to detect from the cluster.

## Why do we need it in the patch release (if we do)?

**Recommendation: no backport to `release-1.77`.** The affected files are byte-identical on `main` and `release-1.77`, so a cherry-pick would be clean if we decide otherwise — the argument is about desirability, not feasibility.

Against backporting: this fix *removes* access, it never grants it. Leaving 1.77 unfixed does not open a hole that is not already open; it preserves an over-permissive state that the affected administrator can correct today by deleting the annotation. There is no remote exploitation path — reaching the broken state requires someone with write access to DexClient or DexAuthenticator objects to have written a false-y value themselves. Meanwhile the fix is a `impact_level: high` behaviour change: a cluster that unknowingly relies on the broken semantics loses `aud=kubernetes` the moment it lands. Patch releases flow automatically within a release channel, so that breakage would arrive without the "Know Before Update" prompt that a minor release gives operators. Trading a silent loss of API access for an already-contained mis-grant is a bad deal in a patch.

For it, if we disagree: the current behaviour makes an explicit `"false"` do the opposite of what it says, and some would argue that is severe enough to correct everywhere at once. If a specific customer is found to be affected, cherry-picking is a one-liner and I am happy to open the backport.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes. (No change needed: the docs already describe the annotation as value-carrying — the code is what disagreed with them.)
- [ ] Changes were tested in the Kubernetes cluster manually.

### Tests

`modules/150-user-authn/hooks/{get_dex_client_crds_test.go,get_dex_authenticator_crds_test.go}` gain a `DescribeTable` each, following the Ginkgo/Gomega setup already used in this package (`HookExecutionConfigInit`, `f.KubeStateSet`, `f.RunHook`, and `f.LoggerOutput` for the warning). Nine cases per hook: `"true"`, `"1"` and `"True"` grant; `"false"` and `"0"` deny; `""`, `"yes"` and `"enabled"` deny and warn; an absent annotation denies without warning. Each case also asserts that the raw-value carrier field never leaks into the internal values.

```
$ go build ./...
$ go test ./modules/150-user-authn/hooks/
ok  	github.com/deckhouse/deckhouse/modules/150-user-authn/hooks	37.946s   (146 specs, 0 failures)
$ golangci-lint run ./modules/150-user-authn/hooks/...
0 issues.
```

`modules/150-user-authn/template_tests` cannot run outside the build container (`charts/helm_lib` is an absolute symlink into `/deckhouse`); this is pre-existing and unrelated, and no template was touched.

### Map-key-presence sweep

The original report asked for a sweep of `modules/150-user-authn/hooks/` and `modules/150-user-authn/images/` for `_, x := m[key]` decisions where the value carries meaning.

| Location | Verdict |
| --- | --- |
| `hooks/get_dex_client_crds.go:98` | **Defect — fixed here.** |
| `hooks/get_dex_authenticator_crds.go:78` | **Defect — fixed here.** |
| `hooks/get_dex_user_crds.go:347,351` (`deckhouse.io/locked-by-administrator`) | Not a defect. Deliberate presence marker, and deliberately so: the module writes it itself with `""` in `get_dex_user_operation_crds.go:544` and with `"true"` in `get_dex_user_operation_crds.go:801`, where the comment states that presence is what matters and the value only keeps the Console path uniform. Users do not author it. Left alone. |
| `hooks/get_dex_user_crds.go:422` (`expectedPasswordNames`) | Not a defect. Set membership; the map value is `struct{}`-like bookkeeping. |
| `hooks/get_dex_user_crds.go:613` (`seen`) | Not a defect. Deduplication set. |
| `hooks/expire_dex_user_crds.go:136` (`expiredUsers`) | Not a defect. Set membership. |
| `hooks/generate_kubeconfig_encoded_names.go:115` (`legacyReserved`) | Not a defect. Set of reserved client IDs. |
| `images/basic-auth-proxy/.../crowd.go:160` (`allowedGroups`) | Not a defect. Set membership for group authorisation. |
| `images/user-api/src/pkg/k8s/password_cache.go:120` (`localUsers`) | Not a defect. Existence probe; the value is fetched separately. |
| `hooks/get_dex_user_operation_crds.go:609`, `images/user-api/.../handlers.go:166` (`bcrypt.Cost`) | Not map lookups; discarded return value of a validation call. |

No third genuine instance, so nothing beyond the two annotations was touched.

### Follow-up, not fixed here

The original report also claimed that a DexClient's `redirectURIs` are appended into the `kubernetes` OAuth2Client's `redirectURIs`. **That claim is wrong.** The block at `templates/dex/oauth2client.yaml:58-64` iterates `dexAuthenticatorCRDs`, not `dexClientCRDs`, and emits a derived URL `https://{{ $crd.spec.applicationDomain }}/dex-authenticator/callback` whose domain is pattern-constrained in the CRD (`crds/dex-authenticator.yaml:79`, `^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`). A DexClient cannot inject a redirect URI into the `kubernetes` client.

What does hold up is narrower: a DexClient's *own* `redirectURIs` are unvalidated. `crds/dex-client.yaml:54-58` declares them as a bare `array of string` with no `pattern` and no `format`, and there is no validating webhook for `dexclients` — `webhooks/validating/` contains only `user.py`, `group.py` and `dex_authenticator/`. Worth addressing, but it is a separate change with its own compatibility surface (existing clients may hold URIs that a new pattern would reject), so it is deliberately out of scope here.

## Changelog entries

```changes
section: user-authn
type: fix
summary: DexClient and DexAuthenticator now honour the value of the allow-access-to-kubernetes annotation instead of merely its presence.
impact: |
  The `dexclient.deckhouse.io/allow-access-to-kubernetes` and
  `dexauthenticator.deckhouse.io/allow-access-to-kubernetes` annotations were previously
  evaluated by key presence, so any value — including "false" — granted the client the
  right to obtain tokens with `aud=kubernetes` and placed it into `trustedPeers` of the
  `kubernetes` OAuth2Client, whose tokens kube-apiserver accepts.

  The value is now parsed as a boolean. Only 1, t, T, TRUE, true and True grant the
  capability. Any other value, including "false", "0", "yes", "enabled" and an empty
  string, disables it; unparseable values are rejected with a warning in the
  deckhouse Pod log naming the object and the offending value.

  Affected: clusters with a DexClient or DexAuthenticator that carries the annotation
  with a value other than a boolean true. Those objects lose access to the Kubernetes
  API on update, which for most of them is the behaviour their author intended.

  Before updating, run
  `kubectl get dexclient,dexauthenticator -A -o json | jq -r '.items[] | select(.metadata.annotations | to_entries[]? | select(.key | endswith("deckhouse.io/allow-access-to-kubernetes")) | .value | ascii_downcase | IN("1","t","true") | not) | "\(.kind)/\(.metadata.namespace)/\(.metadata.name)"'`
  and, for every object listed, either set the annotation to "true" if it genuinely needs
  Kubernetes API access, or remove the annotation to confirm it does not.
impact_level: high
```