### PR TITLE
[ci] Add gitlab secret scan and update notify-failure include

### DIFF
--- a/.gitlab/notify-failure.yml
+++ b/.gitlab/notify-failure.yml
@@ -1,14 +1,16 @@
-.notify-failure-base:
-  image:
-    name: ${CI_REGISTRY}/deckhouse/ssdlc/ci-images/tools/notify:${CI_IMAGES_TAG}
+.after_scripts:
+  notify_cmd: |
+    if [ ${CI_JOB_STATUS} == "failed" ]; then
+      message="🛑 Workflow: **${CI_PIPELINE_SCHEDULE_DESCRIPTION:-CI_PIPELINE_SOURCE}** Job: **${CI_JOB_NAME}** failed! 🛑\n[URL](${CI_PIPELINE_URL})"
+      curl -f -L -X POST "${LOOP_SERVICE_NOTIFICATIONS}" \
+        -H "Content-Type: application/json" \
+        --data "{\"type\": \"ci_fail\",\"message\":\"${message}\"}"
+    fi
+
+.notify:
   variables:
-    GIT_STRATEGY: none
-    GIT_SUBMODULE_STRATEGY: none
     VAULT_AUTH_PATH: fox
     VAULT_AUTH_ROLE: deckhouse
-    JOB_NAME: $CI_JOB_NAME
-    WORKFLOW_NAME: $CI_PIPELINE_SCHEDULE_DESCRIPTION
-    WORKFLOW_URL: $CI_PIPELINE_URL
   id_tokens:
     VAULT_ID_TOKEN:
       aud: gitlab-access-aud
@@ -17,6 +19,5 @@
       token: $VAULT_ID_TOKEN
       file: false
       vault: 6db2f1ee-9b6f-4f4f-8381-2fb43060478a/team-ssdlc/loop/webhook_url@projects
-  when: on_failure
-  script:
-    - send-report.sh --webhook "ci_fail"
+  after_script:
+    - !reference [.after_scripts, notify_cmd]

--- a/.gitlab/rules.yml
+++ b/.gitlab/rules.yml
@@ -23,7 +23,7 @@ workflow:
 
 .rules:on_main:
   rules:
-    - if: $CI_COMMIT_BRANCH == "main"
+    - if: $CI_COMMIT_BRANCH == "main" && $CI_PIPELINE_SOURCE != "schedule"
 
 .rules:on_merge_request:
   rules:
@@ -44,7 +44,7 @@ workflow:
 # Manual edition builds (MR / main). Release-branch editions are automatic.
 .rules:on_main_manual:
   rules:
-    - if: $CI_COMMIT_BRANCH == "main"
+    - if: $CI_COMMIT_BRANCH == "main" && $CI_PIPELINE_SOURCE != "schedule"
       when: manual
 
 .rules:on_merge_request_manual:
@@ -57,14 +57,14 @@ workflow:
 # PR + main + release-x.xx (validate, unit/lint, tests, doc_web).
 .rules:on_validate:
   rules:
-    - if: $CI_COMMIT_BRANCH == "main"
+    - if: $CI_COMMIT_BRANCH == "main" && $CI_PIPELINE_SOURCE != "schedule"
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
     - if: $CI_COMMIT_BRANCH =~ /^release-\d+\.\d+$/
 
 # PR + main only (security_scan, main_web_build).
 .rules:on_pr_main:
   rules:
-    - if: $CI_COMMIT_BRANCH == "main"
+    - if: $CI_COMMIT_BRANCH == "main" && $CI_PIPELINE_SOURCE != "schedule"
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
 
 # --- path-filtered (MR only) --------------------------------------------------

--- a/.gitlab/rules.yml
+++ b/.gitlab/rules.yml
@@ -37,6 +37,10 @@ workflow:
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule" && $DKP_CVE_SCANS_ENABLE == "true"
 
+.rules:on_schedule_secrets_scan:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule" && $DKP_SECRETS_SCAN_ENABLE == "true"
+
 # Manual edition builds (MR / main). Release-branch editions are automatic.
 .rules:on_main_manual:
   rules:

--- a/.gitlab/security.yml
+++ b/.gitlab/security.yml
@@ -1,43 +1,76 @@
 # Source security scan (GitHub security-scan-src.yml subset). PR-only.
-# Diff mode; base config from internal modules-gitlab-ci repo.
+# Diff mode; diff_cmd; base config from internal modules-gitlab-ci repo.
+# Full mode; full_cmd
+
+# Secrets Scan job.
+include:
+  - '.gitlab/notify-failure.yml'
+
+.scripts:
+  gitleaks_config: |
+    curl -sSfL \
+      --header "JOB-TOKEN: ${CI_JOB_TOKEN}" \
+      -o gitleaks.base.toml \
+      "${CI_API_V4_URL}/projects/${GITLEAKS_CONFIG_PROJECT}/repository/files/${GITLEAKS_CONFIG_FILE}/raw?ref=${GITLEAKS_CONFIG_REF}"
+
+  gitleaks_diff_cmd: |
+    if [[ -n "${CI_MERGE_REQUEST_DIFF_BASE_SHA:-}" ]]; then
+      LOG_OPTS="${CI_MERGE_REQUEST_DIFF_BASE_SHA}..${CI_COMMIT_SHA}"
+    elif [[ -n "${CI_COMMIT_BEFORE_SHA:-}" && "${CI_COMMIT_BEFORE_SHA}" != "0000000000000000000000000000000000000000" ]]; then
+      LOG_OPTS="${CI_COMMIT_BEFORE_SHA}..${CI_COMMIT_SHA}"
+    else
+      LOG_OPTS="${CI_COMMIT_SHA}^..${CI_COMMIT_SHA}"
+    fi
+    echo "gitleaks diff range: ${LOG_OPTS}"
+    gitleaks detect \
+      --source "${CI_PROJECT_DIR}" \
+      --config "${CI_PROJECT_DIR}/.gitleaks.toml" \
+      --log-opts "${LOG_OPTS}" \
+      --no-banner \
+      --redact \
+      --report-format json \
+      --report-path gitleaks.json \
+      --exit-code 1
+
+  gitleaks_full_cmd: |
+    set -euo pipefail
+    gitleaks detect --no-banner --redact --log-level debug \
+      --report-format json --report-path gitleaks.json \
+      --config "${CI_PROJECT_DIR}/.gitleaks.toml" \
+      --platform gitlab
+      --source .
+
+
+.gitleaks-base-common:
+  image: ${CI_REGISTRY}/deckhouse/ssdlc/ci-images/tools/gitleaks:${CI_IMAGES_TAG}
+  variables:
+    GIT_STRATEGY: clone
+    GIT_DEPTH: "0" # Search all commits
+    GITLEAKS_CONFIG_REF: "v15.0"
+    GITLEAKS_CONFIG_PROJECT: "deckhouse%2F3p%2Fdeckhouse%2Fmodules-gitlab-ci"
+    GITLEAKS_CONFIG_FILE: "gitleaks%2Fconfig%2Fgitleaks.base.toml"
+  before_script:
+    - !reference [.scripts, gitleaks_config]
+  artifacts:
+    when: always
+    expire_in: 1 week
+    paths:
+      - gitleaks.json
+
+secrets-scan:
+  stage: validate
+  extends:
+    - .rules:on_schedule_secrets_scan
+    - .gitleaks-base-common
+    - .notify
+  script:
+    - !reference [.scripts, gitleaks_full_cmd]
 
 gitleaks_scan:
   stage: validate
   needs: []
   extends:
     - .rules:on_merge_request
-  variables:
-    GIT_DEPTH: "0"
-    GITLEAKS_CONFIG_REF: "v15.0"
-    GITLEAKS_CONFIG_PROJECT: "deckhouse%2F3p%2Fdeckhouse%2Fmodules-gitlab-ci"
-    GITLEAKS_CONFIG_FILE: "gitleaks%2Fconfig%2Fgitleaks.base.toml"
-  image: ${CI_REGISTRY}/deckhouse/ssdlc/ci-images/tools/gitleaks:${CI_IMAGES_TAG}
+    - .gitleaks-base-common
   script:
-    - |
-      curl -sSfL \
-        --header "JOB-TOKEN: ${CI_JOB_TOKEN}" \
-        -o gitleaks.base.toml \
-        "${CI_API_V4_URL}/projects/${GITLEAKS_CONFIG_PROJECT}/repository/files/${GITLEAKS_CONFIG_FILE}/raw?ref=${GITLEAKS_CONFIG_REF}"
-    - |
-      if [[ -n "${CI_MERGE_REQUEST_DIFF_BASE_SHA:-}" ]]; then
-        LOG_OPTS="${CI_MERGE_REQUEST_DIFF_BASE_SHA}..${CI_COMMIT_SHA}"
-      elif [[ -n "${CI_COMMIT_BEFORE_SHA:-}" && "${CI_COMMIT_BEFORE_SHA}" != "0000000000000000000000000000000000000000" ]]; then
-        LOG_OPTS="${CI_COMMIT_BEFORE_SHA}..${CI_COMMIT_SHA}"
-      else
-        LOG_OPTS="${CI_COMMIT_SHA}^..${CI_COMMIT_SHA}"
-      fi
-      echo "gitleaks diff range: ${LOG_OPTS}"
-      gitleaks detect \
-        --source "${CI_PROJECT_DIR}" \
-        --config "${CI_PROJECT_DIR}/.gitleaks.toml" \
-        --log-opts "${LOG_OPTS}" \
-        --no-banner \
-        --redact \
-        --report-format json \
-        --report-path gitleaks.json \
-        --exit-code 1
-  artifacts:
-    when: always
-    expire_in: 1 week
-    paths:
-      - gitleaks.json
+    - !reference [.scripts, gitleaks_diff_cmd]

--- a/.gitlab/weekly-cve-scans.yml
+++ b/.gitlab/weekly-cve-scans.yml
@@ -66,6 +66,7 @@ weekly-cve-scan:
     - .weekly-cve-common
     - .cve-scan-variables
     - .rules:on_schedule_cve_scans
+    - .notify
   id_tokens:
     VAULT_ID_TOKEN:
       aud: gitlab-access-aud
@@ -135,14 +136,7 @@ weekly-cve-scan:
 
   after_script:
     - rm -rf "${CI_PROJECT_DIR}/.ssh"
+    - !reference [.after_scripts, notify_cmd]
 
   tags:
     - vm-intteam-cloud-d8-ssdlc-runner
-
-weekly-cve-scan-failure-notify:
-  extends:
-    - .weekly-cve-common
-    - .notify-failure-base
-  needs:
-    - job: weekly-cve-scan
-      optional: true


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Adding pipelines for using scheduling secret scan in gitlab.
Updating notify include logic and scheme.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
We need to transfer by adding secret scan job aka gitleaks full mode detect.
We do not need separate notify jobs. That's why we change it to include by after_script block and script reference
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
Not related to release
## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: feature
summary: Add secret scan job and update notify include
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
