### PR TITLE
[deckhouse-controller] Default unset update.mode to AutoPatch

### DIFF
--- a/deckhouse-controller/pkg/controller/controller.go
+++ b/deckhouse-controller/pkg/controller/controller.go
@@ -289,7 +289,9 @@ func NewDeckhouseController(
 	// create a default policy, it'll be filled in with relevant settings from the deckhouse moduleConfig
 	embeddedPolicy := helpers.NewModuleUpdatePolicySpecContainer(&v1alpha2.ModuleUpdatePolicySpec{
 		Update: v1alpha2.ModuleUpdatePolicySpecUpdate{
-			Mode: "Auto",
+			// Match the documented AutoPatch default; syncDeckhouseSettings
+			// overwrites this from the deckhouse ModuleConfig on the first sync.
+			Mode: v1alpha2.UpdateModeAutoPatch.String(),
 		},
 		ReleaseChannel: defaultReleaseChannel,
 	})

--- a/deckhouse-controller/pkg/helpers/deckhouse_settings.go
+++ b/deckhouse-controller/pkg/helpers/deckhouse_settings.go
@@ -48,7 +48,15 @@ func DefaultDeckhouseSettings() *DeckhouseSettings {
 		ReleaseChannel:           "",
 		AllowExperimentalModules: false,
 	}
-	settings.Update.Mode = "Auto"
+	// The documented OpenAPI default for settings.update.mode is AutoPatch
+	// (modules/002-deckhouse/openapi/config-values.yaml). This seed is applied
+	// before the deckhouse ModuleConfig is unmarshalled over it in
+	// syncDeckhouseSettings, and json.Unmarshal leaves an unset update.mode
+	// untouched — so this default is what an unset mode resolves to. It must
+	// match the OpenAPI default (and ParseUpdateMode's fallback), otherwise a
+	// cluster without an explicit update.mode silently runs in Auto and
+	// auto-applies minor releases without approval.
+	settings.Update.Mode = v1alpha2.UpdateModeAutoPatch.String()
 	settings.Update.DisruptionApprovalMode = "Auto"
 	settings.Update.BlockOnAlerts.Enabled = false
 	settings.Update.BlockOnAlerts.Severity = 4

--- a/deckhouse-controller/pkg/helpers/deckhouse_settings_test.go
+++ b/deckhouse-controller/pkg/helpers/deckhouse_settings_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helpers
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha2"
+)
+
+// The documented OpenAPI default for settings.update.mode is AutoPatch
+// (modules/002-deckhouse/openapi/config-values.yaml). An unset update.mode must
+// resolve to AutoPatch, not Auto — otherwise minor releases auto-apply without
+// approval on clusters that never set the mode explicitly.
+func TestDefaultDeckhouseSettingsUpdateMode(t *testing.T) {
+	require.Equal(t, v1alpha2.UpdateModeAutoPatch.String(), DefaultDeckhouseSettings().Update.Mode)
+}
+
+// syncDeckhouseSettings seeds DefaultDeckhouseSettings() and then unmarshals the
+// deckhouse ModuleConfig over it. A config that does not set update.mode must
+// keep the AutoPatch default rather than silently falling back to Auto.
+func TestUnsetUpdateModeStaysAutoPatchAfterConfigOverlay(t *testing.T) {
+	settings := DefaultDeckhouseSettings()
+
+	require.NoError(t, json.Unmarshal([]byte(`{"releaseChannel":"Stable"}`), settings))
+
+	require.Equal(t, v1alpha2.UpdateModeAutoPatch.String(), settings.Update.Mode)
+}
+
+// An explicitly configured update.mode must still win over the default.
+func TestExplicitUpdateModeOverridesDefault(t *testing.T) {
+	settings := DefaultDeckhouseSettings()
+
+	require.NoError(t, json.Unmarshal([]byte(`{"update":{"mode":"Auto"}}`), settings))
+
+	require.Equal(t, v1alpha2.UpdateModeAuto.String(), settings.Update.Mode)
+}


### PR DESCRIPTION
## Description

Fixes a defaulting mismatch: when `settings.update.mode` is not set in the `deckhouse` ModuleConfig, the release controller effectively ran in `Auto` mode instead of the documented `AutoPatch` default.

Two internal seeds are aligned with the documented `AutoPatch` default via the existing `v1alpha2.UpdateModeAutoPatch` constant:
- `DefaultDeckhouseSettings()` — `deckhouse-controller/pkg/helpers/deckhouse_settings.go`
- the initial `embeddedPolicy` value — `deckhouse-controller/pkg/controller/controller.go`

Added regression tests in `deckhouse-controller/pkg/helpers/deckhouse_settings_test.go`.

**User-visible effect:** clusters that never set `update.mode` explicitly will now require manual approval for minor updates — both Deckhouse core and, via the embedded module update policy, module releases. Patch updates continue to apply automatically. This aligns runtime behavior with the already-documented default, so no docs change is required. Set `update.mode: Auto` explicitly to keep the previous behavior.

> Note: this fix came out of an investigation into an unexpected minor auto-update (v1.75.14 → v1.76.8). A second, independent defect — minor/patch misclassification in `task_calculator.go` when no `Deployed` release object is present — is handled in a separate PR.

## Why do we need it, and what problem does it solve?

The OpenAPI default for `settings.update.mode` is `AutoPatch` (`modules/002-deckhouse/openapi/config-values.yaml`), which requires manual confirmation for minor version changes. But that default is only applied by addon-operator when computing merged module values for hooks/templates. The release controller reads settings via a different path that bypasses OpenAPI defaulting:

1. `confighandler.valuesByModuleConfig` → `moduleConfig.Spec.Settings.GetMap()` returns the raw settings; an unset `update.mode` is simply absent.
2. `syncDeckhouseSettings` seeds `helpers.DefaultDeckhouseSettings()` (which set `Mode = "Auto"`) and `json.Unmarshal`s the config over it; `Unmarshal` does not touch the absent key, so `"Auto"` survives.
3. `ParseUpdateMode("Auto")` returns `UpdateModeAuto`.

As a result, a cluster with no explicit `update.mode` auto-applied minor releases with no approval — the opposite of the documented `AutoPatch` contract. Observed in the field: a cluster silently upgraded `v1.75.14` → `v1.76.8`, with the deployed `DeckhouseRelease` carrying `release.deckhouse.io/update-info` showing `updatePolicy.mode: "Auto"`.

`ParseUpdateMode` already treats `AutoPatch` as its fallback, so the seed defaults were the sole source of the mismatch. This PR aligns them.

## Why do we need it in the patch release (if we do)?

Recommended. This is a silent behavioral bug present in released versions: any cluster without an explicit `update.mode` applies minor updates without confirmation, contrary to documentation. Backporting restores the documented safety for existing clusters. Because it changes update behavior, it is marked `impact_level: high` so it lands in "Know Before Update".

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: An unset `settings.update.mode` now defaults to `AutoPatch` instead of silently running as `Auto`.
impact_level: default
```