### PR TITLE
[deckhouse-controller] Fix minor release misclassified as a patch

### DIFF
--- a/deckhouse-controller/pkg/releaseupdater/task_calculator.go
+++ b/deckhouse-controller/pkg/releaseupdater/task_calculator.go
@@ -466,16 +466,33 @@ func (p *TaskCalculator) CalculatePendingReleaseTask(ctx context.Context, releas
 	}
 
 	if releaseIdx > 0 {
-		// Classify patch vs minor from the immediate lower-versioned neighbour
-		// (any phase) plus the deployed release, independently of the
-		// Pending/Deployed predecessor scan below. Otherwise, when every lower
-		// release is Superseded/Skipped/Suspended and no Deployed release object
-		// exists, a minor bump keeps the isPatch=true default and is routed
-		// through the patch path, which skips the minor approval gate — so the
-		// minor gets applied without confirmation in every mode except Manual.
-		immediatePrevRelease := releases[releaseIdx-1]
-		if !isPatchRelease(immediatePrevRelease.GetVersion(), release.GetVersion()) ||
-			(deployedReleaseInfo != nil && !isPatchRelease(deployedReleaseInfo.Version, release.GetVersion())) {
+		// Patch or minor is measured against the version that is actually running,
+		// independently of the Pending/Deployed predecessor scan below. Otherwise a
+		// minor bump keeps the isPatch=true default and is routed through the patch
+		// path, which skips the minor approval gate — the minor then gets applied
+		// without confirmation in every mode except Manual.
+		//
+		// Only Deployed and Superseded prove that a version ever ran, so only they
+		// can serve as the reference. A Skipped or Suspended neighbour never ran and
+		// must not make a minor bump look like a patch.
+		//
+		// Known gap: if the Deployed object is removed by hand it leaves no
+		// Superseded trace, so the reference falls back to an older minor and a
+		// genuine patch asks for confirmation until checkDeckhouseRelease recreates
+		// the object. An interrupted deploy does leave the trace (the old release is
+		// marked Superseded before the new one is marked Deployed), so it is
+		// classified correctly.
+		referenceVersion := releases[releaseIdx-1].GetVersion()
+
+		if deployedReleaseInfo != nil {
+			referenceVersion = deployedReleaseInfo.Version
+		} else if lastRunRelease := getLatestReleaseInfoByPhase(releases[:releaseIdx], v1alpha1.DeckhouseReleasePhaseSuperseded); lastRunRelease != nil {
+			referenceVersion = lastRunRelease.Version
+		}
+
+		if !isPatchRelease(referenceVersion, release.GetVersion()) {
+			logger.Debug("current release is not a patch", slog.String("reference_version", referenceVersion.Original()))
+
 			isPatch = false
 		}
 
@@ -505,10 +522,7 @@ func (p *TaskCalculator) CalculatePendingReleaseTask(ctx context.Context, releas
 			// if release version is greater in major or minor version than previous release
 			if !isPatchRelease(prevRelease.GetVersion(), release.GetVersion()) ||
 				(deployedReleaseInfo != nil && !isPatchRelease(deployedReleaseInfo.Version, release.GetVersion())) {
-				logger.Debug("current release is not a patch")
-
-				// isPatch is already set above; classification does not depend on
-				// the Pending/Deployed predecessor scan.
+				logger.Debug("previous release is not a patch predecessor")
 
 				// it must await if previous release has Pending state (unless it's forced)
 				// truncate all not deployed phase releases
@@ -828,6 +842,25 @@ func getFirstReleaseInfoByPhase(releases []v1alpha1.Release, phase string) *rele
 		Name:               filteredDR.GetName(),
 		Version:            filteredDR.GetVersion(),
 	}
+}
+
+// getLatestReleaseInfoByPhase returns the highest-versioned release in the given phase.
+// Unlike getFirstReleaseInfoByPhase, which returns the lowest match.
+// releases slice must be sorted asc
+func getLatestReleaseInfoByPhase(releases []v1alpha1.Release, phase string) *releaseInfo {
+	for idx, release := range slices.Backward(releases) {
+		if release.GetPhase() != phase {
+			continue
+		}
+
+		return &releaseInfo{
+			IndexInReleaseList: idx,
+			Name:               release.GetName(),
+			Version:            release.GetVersion(),
+		}
+	}
+
+	return nil
 }
 
 // getLatestForcedReleaseInfo

--- a/deckhouse-controller/pkg/releaseupdater/task_calculator.go
+++ b/deckhouse-controller/pkg/releaseupdater/task_calculator.go
@@ -465,9 +465,22 @@ func (p *TaskCalculator) CalculatePendingReleaseTask(ctx context.Context, releas
 		}
 	}
 
-	// check previous release
-	// only for awaiting purpose
 	if releaseIdx > 0 {
+		// Classify patch vs minor from the immediate lower-versioned neighbour
+		// (any phase) plus the deployed release, independently of the
+		// Pending/Deployed predecessor scan below. Otherwise, when every lower
+		// release is Superseded/Skipped/Suspended and no Deployed release object
+		// exists, a minor bump keeps the isPatch=true default and is routed
+		// through the patch path, which skips the minor approval gate — so the
+		// minor gets applied without confirmation in every mode except Manual.
+		immediatePrevRelease := releases[releaseIdx-1]
+		if !isPatchRelease(immediatePrevRelease.GetVersion(), release.GetVersion()) ||
+			(deployedReleaseInfo != nil && !isPatchRelease(deployedReleaseInfo.Version, release.GetVersion())) {
+			isPatch = false
+		}
+
+		// check previous release
+		// only for awaiting purpose
 		logger.Debug("checking previous release for awaiting logic")
 
 		// Find the previous release that is Pending or Deployed (skip Suspended, Superseded, Skipped)
@@ -494,7 +507,8 @@ func (p *TaskCalculator) CalculatePendingReleaseTask(ctx context.Context, releas
 				(deployedReleaseInfo != nil && !isPatchRelease(deployedReleaseInfo.Version, release.GetVersion())) {
 				logger.Debug("current release is not a patch")
 
-				isPatch = false
+				// isPatch is already set above; classification does not depend on
+				// the Pending/Deployed predecessor scan.
 
 				// it must await if previous release has Pending state (unless it's forced)
 				// truncate all not deployed phase releases

--- a/deckhouse-controller/pkg/releaseupdater/task_calculator_test.go
+++ b/deckhouse-controller/pkg/releaseupdater/task_calculator_test.go
@@ -620,8 +620,8 @@ func TestTaskCalculator_CalculatePendingReleaseTask(t *testing.T) {
 			},
 		},
 		{
-			// The immediate neighbour of any non-Pending/Deployed phase (here
-			// Skipped) still drives minor classification.
+			// Last-resort fallback: no Deployed and no Superseded release at all,
+			// so the immediate neighbour is the only reference available.
 			name:           "minor bump is minor when previous is skipped and none deployed",
 			releaseChannel: "stable",
 			releases: []v1alpha1.Release{
@@ -634,6 +634,71 @@ func TestTaskCalculator_CalculatePendingReleaseTask(t *testing.T) {
 				IsPatch:    false,
 				IsLatest:   true,
 				QueueDepth: &ReleaseQueueDepthDelta{},
+			},
+		},
+		{
+			// A Skipped sibling in the target minor must not make the bump look like
+			// a patch: v1.76.7 never ran, it was skipped when v1.76.8 appeared. The
+			// last version known to have run is the highest Superseded one, v1.75.13,
+			// so this is a minor bump and needs approval.
+			name:           "minor bump is minor when the neighbour is a skipped release of the target minor",
+			releaseChannel: "stable",
+			releases: []v1alpha1.Release{
+				&mockRelease{name: "v1.75.13", version: "1.75.13", phase: v1alpha1.DeckhouseReleasePhaseSuperseded},
+				&mockRelease{name: "v1.76.7", version: "1.76.7", phase: v1alpha1.DeckhouseReleasePhaseSkipped},
+				&mockRelease{name: "v1.76.8", version: "1.76.8", phase: v1alpha1.DeckhouseReleasePhasePending},
+			},
+			pendingRelease: &mockRelease{name: "v1.76.8", version: "1.76.8", phase: v1alpha1.DeckhouseReleasePhasePending},
+			expectedTask: &Task{
+				TaskType:   Process,
+				IsPatch:    false,
+				IsLatest:   true,
+				QueueDepth: &ReleaseQueueDepthDelta{},
+			},
+		},
+		{
+			// Interrupted deploy: v1.76.5 was marked Superseded before the new
+			// release could be marked Deployed. The Superseded trace shows the
+			// cluster already ran v1.76.5, so v1.76.8 is a genuine patch and must
+			// keep deploying automatically despite the older v1.75.14 below it.
+			name:           "patch stays patch when the highest superseded is in the same minor and none deployed",
+			releaseChannel: "stable",
+			releases: []v1alpha1.Release{
+				&mockRelease{name: "v1.75.14", version: "1.75.14", phase: v1alpha1.DeckhouseReleasePhaseSuperseded},
+				&mockRelease{name: "v1.76.5", version: "1.76.5", phase: v1alpha1.DeckhouseReleasePhaseSuperseded},
+				&mockRelease{name: "v1.76.7", version: "1.76.7", phase: v1alpha1.DeckhouseReleasePhaseSkipped},
+				&mockRelease{name: "v1.76.8", version: "1.76.8", phase: v1alpha1.DeckhouseReleasePhasePending},
+			},
+			pendingRelease: &mockRelease{name: "v1.76.8", version: "1.76.8", phase: v1alpha1.DeckhouseReleasePhasePending},
+			expectedTask: &Task{
+				TaskType:   Process,
+				IsPatch:    true,
+				IsLatest:   true,
+				QueueDepth: &ReleaseQueueDepthDelta{},
+			},
+		},
+		{
+			// The Deployed release wins over an older Superseded one: the cluster
+			// runs v1.76.7, so v1.76.8 is a patch even though the highest Superseded
+			// release, v1.75.14, is a minor behind. This is the steady state right
+			// after any minor upgrade.
+			name:           "patch stays patch when deployed is in the target minor and superseded is a minor behind",
+			releaseChannel: "stable",
+			releases: []v1alpha1.Release{
+				&mockRelease{name: "v1.75.14", version: "1.75.14", phase: v1alpha1.DeckhouseReleasePhaseSuperseded},
+				&mockRelease{name: "v1.76.7", version: "1.76.7", phase: v1alpha1.DeckhouseReleasePhaseDeployed},
+				&mockRelease{name: "v1.76.8", version: "1.76.8", phase: v1alpha1.DeckhouseReleasePhasePending},
+			},
+			pendingRelease: &mockRelease{name: "v1.76.8", version: "1.76.8", phase: v1alpha1.DeckhouseReleasePhasePending},
+			expectedTask: &Task{
+				TaskType: Process,
+				IsPatch:  true,
+				IsLatest: true,
+				DeployedReleaseInfo: &ReleaseInfo{
+					Name:    "v1.76.7",
+					Version: semver.MustParse("1.76.7"),
+				},
+				QueueDepth: &ReleaseQueueDepthDelta{Major: 0, Minor: 0, Patch: 1},
 			},
 		},
 	}

--- a/deckhouse-controller/pkg/releaseupdater/task_calculator_test.go
+++ b/deckhouse-controller/pkg/releaseupdater/task_calculator_test.go
@@ -581,6 +581,61 @@ func TestTaskCalculator_CalculatePendingReleaseTask(t *testing.T) {
 				QueueDepth: &ReleaseQueueDepthDelta{Major: 0, Minor: 2, Patch: 0},
 			},
 		},
+		{
+			// Regression guard: every lower release is Superseded and no Deployed
+			// release object exists at calculation time. Before the fix, isPatch
+			// kept its true default and the minor bump v1.75.* -> v1.76.* was
+			// routed through the patch path and auto-applied without approval.
+			name:           "minor bump is minor when all lower releases superseded and none deployed",
+			releaseChannel: "stable",
+			releases: []v1alpha1.Release{
+				&mockRelease{name: "v1.75.9", version: "1.75.9", phase: v1alpha1.DeckhouseReleasePhaseSuperseded},
+				&mockRelease{name: "v1.75.14", version: "1.75.14", phase: v1alpha1.DeckhouseReleasePhaseSuperseded},
+				&mockRelease{name: "v1.76.8", version: "1.76.8", phase: v1alpha1.DeckhouseReleasePhasePending},
+			},
+			pendingRelease: &mockRelease{name: "v1.76.8", version: "1.76.8", phase: v1alpha1.DeckhouseReleasePhasePending},
+			expectedTask: &Task{
+				TaskType:   Process,
+				IsPatch:    false,
+				IsLatest:   true,
+				QueueDepth: &ReleaseQueueDepthDelta{},
+			},
+		},
+		{
+			// Guard the opposite direction: a genuine patch must still be a patch
+			// when the lower releases are Superseded and no Deployed object exists.
+			name:           "patch stays patch when lower releases superseded and none deployed",
+			releaseChannel: "stable",
+			releases: []v1alpha1.Release{
+				&mockRelease{name: "v1.75.13", version: "1.75.13", phase: v1alpha1.DeckhouseReleasePhaseSuperseded},
+				&mockRelease{name: "v1.75.14", version: "1.75.14", phase: v1alpha1.DeckhouseReleasePhaseSuperseded},
+				&mockRelease{name: "v1.75.15", version: "1.75.15", phase: v1alpha1.DeckhouseReleasePhasePending},
+			},
+			pendingRelease: &mockRelease{name: "v1.75.15", version: "1.75.15", phase: v1alpha1.DeckhouseReleasePhasePending},
+			expectedTask: &Task{
+				TaskType:   Process,
+				IsPatch:    true,
+				IsLatest:   true,
+				QueueDepth: &ReleaseQueueDepthDelta{},
+			},
+		},
+		{
+			// The immediate neighbour of any non-Pending/Deployed phase (here
+			// Skipped) still drives minor classification.
+			name:           "minor bump is minor when previous is skipped and none deployed",
+			releaseChannel: "stable",
+			releases: []v1alpha1.Release{
+				&mockRelease{name: "v1.75.14", version: "1.75.14", phase: v1alpha1.DeckhouseReleasePhaseSkipped},
+				&mockRelease{name: "v1.76.0", version: "1.76.0", phase: v1alpha1.DeckhouseReleasePhasePending},
+			},
+			pendingRelease: &mockRelease{name: "v1.76.0", version: "1.76.0", phase: v1alpha1.DeckhouseReleasePhasePending},
+			expectedTask: &Task{
+				TaskType:   Process,
+				IsPatch:    false,
+				IsLatest:   true,
+				QueueDepth: &ReleaseQueueDepthDelta{},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Description

Fixes a patch/minor misclassification in `CalculatePendingReleaseTask` (`deckhouse-controller/pkg/releaseupdater/task_calculator.go`). A minor release could be classified as a patch — and therefore auto-applied without approval — when the DeckhouseRelease list contains no object in the `Deployed` phase and every lower-versioned release is `Superseded`/`Skipped`/`Suspended`.

The fix separates patch/minor classification from the awaiting-logic scan: classification now uses the immediate lower-versioned neighbour (any phase) plus the deployed release, before and independently of the Pending/Deployed predecessor scan. The awaiting logic keeps skipping Suspended/Superseded/Skipped as before.

Added regression tests in `task_calculator_test.go` covering: a minor bump with all lower releases Superseded and no Deployed release (now `IsPatch=false`), the opposite guard (a genuine patch stays `IsPatch=true` under the same conditions), and a minor bump whose only lower release is `Skipped`.

This is one of two independent defects found while investigating an unexpected minor auto-update (v1.75.14 → v1.76.8); the other — an update-mode default mismatch — is addressed separately.

## Why do we need it, and what problem does it solve?

`isPatch` defaults to `true` and is only reset to `false` inside the `if prevReleaseFound` branch, whose scan accepts only `Pending`/`Deployed` predecessors. When no Deployed release object is present (e.g. after an interrupted deploy between "mark old Superseded" and "mark new Deployed", or after a restore) and all lower releases are `Superseded`/`Skipped`/`Suspended`, the scan finds nothing, the branch is skipped, and a genuine minor bump keeps `isPatch=true`.

A minor misclassified as a patch is routed through `CalculatePatchDeployTime`, which requires manual approval only in `Manual` mode — so in `AutoPatch` (and `Auto`) the minor is deployed with no confirmation, bypassing the minor approval gate and the pod-readiness wait.

This is a regression from #16096 ("fix update suspend skip"), which merged patch/minor classification and the awaiting logic under the same predecessor scan. Because releases are sorted ascending, classifying from the immediate neighbour is equivalent to the old condition whenever a Pending/Deployed predecessor is found, and correct when none exists.

Observed in the field: a cluster with all `v1.75.*` releases `Superseded` and no `Deployed` release object auto-upgraded `v1.75.14` → `v1.76.8`, with `release.deckhouse.io/update-info` showing `taskCalculation.isPatch: true`.

## Why do we need it in the patch release (if we do)?

Recommended. This is a silent safety bug present in released versions: in an off-nominal but reachable state, a minor update is applied without confirmation regardless of `AutoPatch`. Backporting restores the approval gate for existing clusters. It changes update behavior in that state, hence `impact_level: high`.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Fix a minor Deckhouse release being auto-applied as a patch when no Deployed release object is present.
impact_level: default
```