### PR TITLE
ci: add Vault role for signing Olcedar sysext roothashes

### DIFF
--- a/.github/ci_templates/build.yml
+++ b/.github/ci_templates/build.yml
@@ -169,6 +169,13 @@ steps:
       WERF_ANNOTATE_LAYERS_WITH_DM_VERITY_ROOT_HASH: "1"
       WERF_VAULT_AUTH_PATH: "github"
       WERF_ACTIONS_AUDIENCE: "github-access-aud"
+      # Whether the sysext images of the Olcedar node get their dm-verity roothash
+      # signed. It is signed with the Olcedar key the node kernel trusts, not with the
+      # Deckhouse key WERF_SIGN_KEY above, so the build logs in with its own Vault role
+      # (deckhouse-olcedar-signer) right before signing — a token there lives 180s.
+      # The list below mirrors the repositories that role is bound to; a build
+      # anywhere else cannot obtain a token and skips signing instead of failing.
+      WERF_OLCEDAR_SYSEXT_SIGN_ENABLED: ${{ contains(fromJSON('["deckhouse/deckhouse", "deckhouse/deckhouse-test-1", "deckhouse/deckhouse-test-2"]'), github.repository) }}
     run: |
       # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
       REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -597,6 +597,13 @@ jobs:
           WERF_ANNOTATE_LAYERS_WITH_DM_VERITY_ROOT_HASH: "1"
           WERF_VAULT_AUTH_PATH: "github"
           WERF_ACTIONS_AUDIENCE: "github-access-aud"
+          # Whether the sysext images of the Olcedar node get their dm-verity roothash
+          # signed. It is signed with the Olcedar key the node kernel trusts, not with the
+          # Deckhouse key WERF_SIGN_KEY above, so the build logs in with its own Vault role
+          # (deckhouse-olcedar-signer) right before signing — a token there lives 180s.
+          # The list below mirrors the repositories that role is bound to; a build
+          # anywhere else cannot obtain a token and skips signing instead of failing.
+          WERF_OLCEDAR_SYSEXT_SIGN_ENABLED: ${{ contains(fromJSON('["deckhouse/deckhouse", "deckhouse/deckhouse-test-1", "deckhouse/deckhouse-test-2"]'), github.repository) }}
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
@@ -1336,6 +1343,13 @@ jobs:
           WERF_ANNOTATE_LAYERS_WITH_DM_VERITY_ROOT_HASH: "1"
           WERF_VAULT_AUTH_PATH: "github"
           WERF_ACTIONS_AUDIENCE: "github-access-aud"
+          # Whether the sysext images of the Olcedar node get their dm-verity roothash
+          # signed. It is signed with the Olcedar key the node kernel trusts, not with the
+          # Deckhouse key WERF_SIGN_KEY above, so the build logs in with its own Vault role
+          # (deckhouse-olcedar-signer) right before signing — a token there lives 180s.
+          # The list below mirrors the repositories that role is bound to; a build
+          # anywhere else cannot obtain a token and skips signing instead of failing.
+          WERF_OLCEDAR_SYSEXT_SIGN_ENABLED: ${{ contains(fromJSON('["deckhouse/deckhouse", "deckhouse/deckhouse-test-1", "deckhouse/deckhouse-test-2"]'), github.repository) }}
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
@@ -1731,6 +1745,13 @@ jobs:
           WERF_ANNOTATE_LAYERS_WITH_DM_VERITY_ROOT_HASH: "1"
           WERF_VAULT_AUTH_PATH: "github"
           WERF_ACTIONS_AUDIENCE: "github-access-aud"
+          # Whether the sysext images of the Olcedar node get their dm-verity roothash
+          # signed. It is signed with the Olcedar key the node kernel trusts, not with the
+          # Deckhouse key WERF_SIGN_KEY above, so the build logs in with its own Vault role
+          # (deckhouse-olcedar-signer) right before signing — a token there lives 180s.
+          # The list below mirrors the repositories that role is bound to; a build
+          # anywhere else cannot obtain a token and skips signing instead of failing.
+          WERF_OLCEDAR_SYSEXT_SIGN_ENABLED: ${{ contains(fromJSON('["deckhouse/deckhouse", "deckhouse/deckhouse-test-1", "deckhouse/deckhouse-test-2"]'), github.repository) }}
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
@@ -2126,6 +2147,13 @@ jobs:
           WERF_ANNOTATE_LAYERS_WITH_DM_VERITY_ROOT_HASH: "1"
           WERF_VAULT_AUTH_PATH: "github"
           WERF_ACTIONS_AUDIENCE: "github-access-aud"
+          # Whether the sysext images of the Olcedar node get their dm-verity roothash
+          # signed. It is signed with the Olcedar key the node kernel trusts, not with the
+          # Deckhouse key WERF_SIGN_KEY above, so the build logs in with its own Vault role
+          # (deckhouse-olcedar-signer) right before signing — a token there lives 180s.
+          # The list below mirrors the repositories that role is bound to; a build
+          # anywhere else cannot obtain a token and skips signing instead of failing.
+          WERF_OLCEDAR_SYSEXT_SIGN_ENABLED: ${{ contains(fromJSON('["deckhouse/deckhouse", "deckhouse/deckhouse-test-1", "deckhouse/deckhouse-test-2"]'), github.repository) }}
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
@@ -2521,6 +2549,13 @@ jobs:
           WERF_ANNOTATE_LAYERS_WITH_DM_VERITY_ROOT_HASH: "1"
           WERF_VAULT_AUTH_PATH: "github"
           WERF_ACTIONS_AUDIENCE: "github-access-aud"
+          # Whether the sysext images of the Olcedar node get their dm-verity roothash
+          # signed. It is signed with the Olcedar key the node kernel trusts, not with the
+          # Deckhouse key WERF_SIGN_KEY above, so the build logs in with its own Vault role
+          # (deckhouse-olcedar-signer) right before signing — a token there lives 180s.
+          # The list below mirrors the repositories that role is bound to; a build
+          # anywhere else cannot obtain a token and skips signing instead of failing.
+          WERF_OLCEDAR_SYSEXT_SIGN_ENABLED: ${{ contains(fromJSON('["deckhouse/deckhouse", "deckhouse/deckhouse-test-1", "deckhouse/deckhouse-test-2"]'), github.repository) }}
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
@@ -2916,6 +2951,13 @@ jobs:
           WERF_ANNOTATE_LAYERS_WITH_DM_VERITY_ROOT_HASH: "1"
           WERF_VAULT_AUTH_PATH: "github"
           WERF_ACTIONS_AUDIENCE: "github-access-aud"
+          # Whether the sysext images of the Olcedar node get their dm-verity roothash
+          # signed. It is signed with the Olcedar key the node kernel trusts, not with the
+          # Deckhouse key WERF_SIGN_KEY above, so the build logs in with its own Vault role
+          # (deckhouse-olcedar-signer) right before signing — a token there lives 180s.
+          # The list below mirrors the repositories that role is bound to; a build
+          # anywhere else cannot obtain a token and skips signing instead of failing.
+          WERF_OLCEDAR_SYSEXT_SIGN_ENABLED: ${{ contains(fromJSON('["deckhouse/deckhouse", "deckhouse/deckhouse-test-1", "deckhouse/deckhouse-test-2"]'), github.repository) }}
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
@@ -3311,6 +3353,13 @@ jobs:
           WERF_ANNOTATE_LAYERS_WITH_DM_VERITY_ROOT_HASH: "1"
           WERF_VAULT_AUTH_PATH: "github"
           WERF_ACTIONS_AUDIENCE: "github-access-aud"
+          # Whether the sysext images of the Olcedar node get their dm-verity roothash
+          # signed. It is signed with the Olcedar key the node kernel trusts, not with the
+          # Deckhouse key WERF_SIGN_KEY above, so the build logs in with its own Vault role
+          # (deckhouse-olcedar-signer) right before signing — a token there lives 180s.
+          # The list below mirrors the repositories that role is bound to; a build
+          # anywhere else cannot obtain a token and skips signing instead of failing.
+          WERF_OLCEDAR_SYSEXT_SIGN_ENABLED: ${{ contains(fromJSON('["deckhouse/deckhouse", "deckhouse/deckhouse-test-1", "deckhouse/deckhouse-test-2"]'), github.repository) }}
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}

--- a/.github/workflows/build-and-test_main.yml
+++ b/.github/workflows/build-and-test_main.yml
@@ -359,6 +359,13 @@ jobs:
           WERF_ANNOTATE_LAYERS_WITH_DM_VERITY_ROOT_HASH: "1"
           WERF_VAULT_AUTH_PATH: "github"
           WERF_ACTIONS_AUDIENCE: "github-access-aud"
+          # Whether the sysext images of the Olcedar node get their dm-verity roothash
+          # signed. It is signed with the Olcedar key the node kernel trusts, not with the
+          # Deckhouse key WERF_SIGN_KEY above, so the build logs in with its own Vault role
+          # (deckhouse-olcedar-signer) right before signing — a token there lives 180s.
+          # The list below mirrors the repositories that role is bound to; a build
+          # anywhere else cannot obtain a token and skips signing instead of failing.
+          WERF_OLCEDAR_SYSEXT_SIGN_ENABLED: ${{ contains(fromJSON('["deckhouse/deckhouse", "deckhouse/deckhouse-test-1", "deckhouse/deckhouse-test-2"]'), github.repository) }}
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -359,6 +359,13 @@ jobs:
           WERF_ANNOTATE_LAYERS_WITH_DM_VERITY_ROOT_HASH: "1"
           WERF_VAULT_AUTH_PATH: "github"
           WERF_ACTIONS_AUDIENCE: "github-access-aud"
+          # Whether the sysext images of the Olcedar node get their dm-verity roothash
+          # signed. It is signed with the Olcedar key the node kernel trusts, not with the
+          # Deckhouse key WERF_SIGN_KEY above, so the build logs in with its own Vault role
+          # (deckhouse-olcedar-signer) right before signing — a token there lives 180s.
+          # The list below mirrors the repositories that role is bound to; a build
+          # anywhere else cannot obtain a token and skips signing instead of failing.
+          WERF_OLCEDAR_SYSEXT_SIGN_ENABLED: ${{ contains(fromJSON('["deckhouse/deckhouse", "deckhouse/deckhouse-test-1", "deckhouse/deckhouse-test-2"]'), github.repository) }}
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
@@ -1075,6 +1082,13 @@ jobs:
           WERF_ANNOTATE_LAYERS_WITH_DM_VERITY_ROOT_HASH: "1"
           WERF_VAULT_AUTH_PATH: "github"
           WERF_ACTIONS_AUDIENCE: "github-access-aud"
+          # Whether the sysext images of the Olcedar node get their dm-verity roothash
+          # signed. It is signed with the Olcedar key the node kernel trusts, not with the
+          # Deckhouse key WERF_SIGN_KEY above, so the build logs in with its own Vault role
+          # (deckhouse-olcedar-signer) right before signing — a token there lives 180s.
+          # The list below mirrors the repositories that role is bound to; a build
+          # anywhere else cannot obtain a token and skips signing instead of failing.
+          WERF_OLCEDAR_SYSEXT_SIGN_ENABLED: ${{ contains(fromJSON('["deckhouse/deckhouse", "deckhouse/deckhouse-test-1", "deckhouse/deckhouse-test-2"]'), github.repository) }}
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
@@ -1478,6 +1492,13 @@ jobs:
           WERF_ANNOTATE_LAYERS_WITH_DM_VERITY_ROOT_HASH: "1"
           WERF_VAULT_AUTH_PATH: "github"
           WERF_ACTIONS_AUDIENCE: "github-access-aud"
+          # Whether the sysext images of the Olcedar node get their dm-verity roothash
+          # signed. It is signed with the Olcedar key the node kernel trusts, not with the
+          # Deckhouse key WERF_SIGN_KEY above, so the build logs in with its own Vault role
+          # (deckhouse-olcedar-signer) right before signing — a token there lives 180s.
+          # The list below mirrors the repositories that role is bound to; a build
+          # anywhere else cannot obtain a token and skips signing instead of failing.
+          WERF_OLCEDAR_SYSEXT_SIGN_ENABLED: ${{ contains(fromJSON('["deckhouse/deckhouse", "deckhouse/deckhouse-test-1", "deckhouse/deckhouse-test-2"]'), github.repository) }}
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
@@ -1881,6 +1902,13 @@ jobs:
           WERF_ANNOTATE_LAYERS_WITH_DM_VERITY_ROOT_HASH: "1"
           WERF_VAULT_AUTH_PATH: "github"
           WERF_ACTIONS_AUDIENCE: "github-access-aud"
+          # Whether the sysext images of the Olcedar node get their dm-verity roothash
+          # signed. It is signed with the Olcedar key the node kernel trusts, not with the
+          # Deckhouse key WERF_SIGN_KEY above, so the build logs in with its own Vault role
+          # (deckhouse-olcedar-signer) right before signing — a token there lives 180s.
+          # The list below mirrors the repositories that role is bound to; a build
+          # anywhere else cannot obtain a token and skips signing instead of failing.
+          WERF_OLCEDAR_SYSEXT_SIGN_ENABLED: ${{ contains(fromJSON('["deckhouse/deckhouse", "deckhouse/deckhouse-test-1", "deckhouse/deckhouse-test-2"]'), github.repository) }}
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
@@ -2284,6 +2312,13 @@ jobs:
           WERF_ANNOTATE_LAYERS_WITH_DM_VERITY_ROOT_HASH: "1"
           WERF_VAULT_AUTH_PATH: "github"
           WERF_ACTIONS_AUDIENCE: "github-access-aud"
+          # Whether the sysext images of the Olcedar node get their dm-verity roothash
+          # signed. It is signed with the Olcedar key the node kernel trusts, not with the
+          # Deckhouse key WERF_SIGN_KEY above, so the build logs in with its own Vault role
+          # (deckhouse-olcedar-signer) right before signing — a token there lives 180s.
+          # The list below mirrors the repositories that role is bound to; a build
+          # anywhere else cannot obtain a token and skips signing instead of failing.
+          WERF_OLCEDAR_SYSEXT_SIGN_ENABLED: ${{ contains(fromJSON('["deckhouse/deckhouse", "deckhouse/deckhouse-test-1", "deckhouse/deckhouse-test-2"]'), github.repository) }}
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
@@ -2687,6 +2722,13 @@ jobs:
           WERF_ANNOTATE_LAYERS_WITH_DM_VERITY_ROOT_HASH: "1"
           WERF_VAULT_AUTH_PATH: "github"
           WERF_ACTIONS_AUDIENCE: "github-access-aud"
+          # Whether the sysext images of the Olcedar node get their dm-verity roothash
+          # signed. It is signed with the Olcedar key the node kernel trusts, not with the
+          # Deckhouse key WERF_SIGN_KEY above, so the build logs in with its own Vault role
+          # (deckhouse-olcedar-signer) right before signing — a token there lives 180s.
+          # The list below mirrors the repositories that role is bound to; a build
+          # anywhere else cannot obtain a token and skips signing instead of failing.
+          WERF_OLCEDAR_SYSEXT_SIGN_ENABLED: ${{ contains(fromJSON('["deckhouse/deckhouse", "deckhouse/deckhouse-test-1", "deckhouse/deckhouse-test-2"]'), github.repository) }}
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
@@ -3090,6 +3132,13 @@ jobs:
           WERF_ANNOTATE_LAYERS_WITH_DM_VERITY_ROOT_HASH: "1"
           WERF_VAULT_AUTH_PATH: "github"
           WERF_ACTIONS_AUDIENCE: "github-access-aud"
+          # Whether the sysext images of the Olcedar node get their dm-verity roothash
+          # signed. It is signed with the Olcedar key the node kernel trusts, not with the
+          # Deckhouse key WERF_SIGN_KEY above, so the build logs in with its own Vault role
+          # (deckhouse-olcedar-signer) right before signing — a token there lives 180s.
+          # The list below mirrors the repositories that role is bound to; a build
+          # anywhere else cannot obtain a token and skips signing instead of failing.
+          WERF_OLCEDAR_SYSEXT_SIGN_ENABLED: ${{ contains(fromJSON('["deckhouse/deckhouse", "deckhouse/deckhouse-test-1", "deckhouse/deckhouse-test-2"]'), github.repository) }}
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -485,6 +485,13 @@ jobs:
           WERF_ANNOTATE_LAYERS_WITH_DM_VERITY_ROOT_HASH: "1"
           WERF_VAULT_AUTH_PATH: "github"
           WERF_ACTIONS_AUDIENCE: "github-access-aud"
+          # Whether the sysext images of the Olcedar node get their dm-verity roothash
+          # signed. It is signed with the Olcedar key the node kernel trusts, not with the
+          # Deckhouse key WERF_SIGN_KEY above, so the build logs in with its own Vault role
+          # (deckhouse-olcedar-signer) right before signing — a token there lives 180s.
+          # The list below mirrors the repositories that role is bound to; a build
+          # anywhere else cannot obtain a token and skips signing instead of failing.
+          WERF_OLCEDAR_SYSEXT_SIGN_ENABLED: ${{ contains(fromJSON('["deckhouse/deckhouse", "deckhouse/deckhouse-test-1", "deckhouse/deckhouse-test-2"]'), github.repository) }}
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
@@ -920,6 +927,13 @@ jobs:
           WERF_ANNOTATE_LAYERS_WITH_DM_VERITY_ROOT_HASH: "1"
           WERF_VAULT_AUTH_PATH: "github"
           WERF_ACTIONS_AUDIENCE: "github-access-aud"
+          # Whether the sysext images of the Olcedar node get their dm-verity roothash
+          # signed. It is signed with the Olcedar key the node kernel trusts, not with the
+          # Deckhouse key WERF_SIGN_KEY above, so the build logs in with its own Vault role
+          # (deckhouse-olcedar-signer) right before signing — a token there lives 180s.
+          # The list below mirrors the repositories that role is bound to; a build
+          # anywhere else cannot obtain a token and skips signing instead of failing.
+          WERF_OLCEDAR_SYSEXT_SIGN_ENABLED: ${{ contains(fromJSON('["deckhouse/deckhouse", "deckhouse/deckhouse-test-1", "deckhouse/deckhouse-test-2"]'), github.repository) }}
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
@@ -1356,6 +1370,13 @@ jobs:
           WERF_ANNOTATE_LAYERS_WITH_DM_VERITY_ROOT_HASH: "1"
           WERF_VAULT_AUTH_PATH: "github"
           WERF_ACTIONS_AUDIENCE: "github-access-aud"
+          # Whether the sysext images of the Olcedar node get their dm-verity roothash
+          # signed. It is signed with the Olcedar key the node kernel trusts, not with the
+          # Deckhouse key WERF_SIGN_KEY above, so the build logs in with its own Vault role
+          # (deckhouse-olcedar-signer) right before signing — a token there lives 180s.
+          # The list below mirrors the repositories that role is bound to; a build
+          # anywhere else cannot obtain a token and skips signing instead of failing.
+          WERF_OLCEDAR_SYSEXT_SIGN_ENABLED: ${{ contains(fromJSON('["deckhouse/deckhouse", "deckhouse/deckhouse-test-1", "deckhouse/deckhouse-test-2"]'), github.repository) }}
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
@@ -1792,6 +1813,13 @@ jobs:
           WERF_ANNOTATE_LAYERS_WITH_DM_VERITY_ROOT_HASH: "1"
           WERF_VAULT_AUTH_PATH: "github"
           WERF_ACTIONS_AUDIENCE: "github-access-aud"
+          # Whether the sysext images of the Olcedar node get their dm-verity roothash
+          # signed. It is signed with the Olcedar key the node kernel trusts, not with the
+          # Deckhouse key WERF_SIGN_KEY above, so the build logs in with its own Vault role
+          # (deckhouse-olcedar-signer) right before signing — a token there lives 180s.
+          # The list below mirrors the repositories that role is bound to; a build
+          # anywhere else cannot obtain a token and skips signing instead of failing.
+          WERF_OLCEDAR_SYSEXT_SIGN_ENABLED: ${{ contains(fromJSON('["deckhouse/deckhouse", "deckhouse/deckhouse-test-1", "deckhouse/deckhouse-test-2"]'), github.repository) }}
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
@@ -2228,6 +2256,13 @@ jobs:
           WERF_ANNOTATE_LAYERS_WITH_DM_VERITY_ROOT_HASH: "1"
           WERF_VAULT_AUTH_PATH: "github"
           WERF_ACTIONS_AUDIENCE: "github-access-aud"
+          # Whether the sysext images of the Olcedar node get their dm-verity roothash
+          # signed. It is signed with the Olcedar key the node kernel trusts, not with the
+          # Deckhouse key WERF_SIGN_KEY above, so the build logs in with its own Vault role
+          # (deckhouse-olcedar-signer) right before signing — a token there lives 180s.
+          # The list below mirrors the repositories that role is bound to; a build
+          # anywhere else cannot obtain a token and skips signing instead of failing.
+          WERF_OLCEDAR_SYSEXT_SIGN_ENABLED: ${{ contains(fromJSON('["deckhouse/deckhouse", "deckhouse/deckhouse-test-1", "deckhouse/deckhouse-test-2"]'), github.repository) }}
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
@@ -2664,6 +2699,13 @@ jobs:
           WERF_ANNOTATE_LAYERS_WITH_DM_VERITY_ROOT_HASH: "1"
           WERF_VAULT_AUTH_PATH: "github"
           WERF_ACTIONS_AUDIENCE: "github-access-aud"
+          # Whether the sysext images of the Olcedar node get their dm-verity roothash
+          # signed. It is signed with the Olcedar key the node kernel trusts, not with the
+          # Deckhouse key WERF_SIGN_KEY above, so the build logs in with its own Vault role
+          # (deckhouse-olcedar-signer) right before signing — a token there lives 180s.
+          # The list below mirrors the repositories that role is bound to; a build
+          # anywhere else cannot obtain a token and skips signing instead of failing.
+          WERF_OLCEDAR_SYSEXT_SIGN_ENABLED: ${{ contains(fromJSON('["deckhouse/deckhouse", "deckhouse/deckhouse-test-1", "deckhouse/deckhouse-test-2"]'), github.repository) }}
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}

--- a/.github/workflows/reproducibility-check.yml
+++ b/.github/workflows/reproducibility-check.yml
@@ -551,6 +551,13 @@ jobs:
           WERF_ANNOTATE_LAYERS_WITH_DM_VERITY_ROOT_HASH: "1"
           WERF_VAULT_AUTH_PATH: "github"
           WERF_ACTIONS_AUDIENCE: "github-access-aud"
+          # Whether the sysext images of the Olcedar node get their dm-verity roothash
+          # signed. It is signed with the Olcedar key the node kernel trusts, not with the
+          # Deckhouse key WERF_SIGN_KEY above, so the build logs in with its own Vault role
+          # (deckhouse-olcedar-signer) right before signing — a token there lives 180s.
+          # The list below mirrors the repositories that role is bound to; a build
+          # anywhere else cannot obtain a token and skips signing instead of failing.
+          WERF_OLCEDAR_SYSEXT_SIGN_ENABLED: ${{ contains(fromJSON('["deckhouse/deckhouse", "deckhouse/deckhouse-test-1", "deckhouse/deckhouse-test-2"]'), github.repository) }}
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
@@ -974,6 +981,13 @@ jobs:
           WERF_ANNOTATE_LAYERS_WITH_DM_VERITY_ROOT_HASH: "1"
           WERF_VAULT_AUTH_PATH: "github"
           WERF_ACTIONS_AUDIENCE: "github-access-aud"
+          # Whether the sysext images of the Olcedar node get their dm-verity roothash
+          # signed. It is signed with the Olcedar key the node kernel trusts, not with the
+          # Deckhouse key WERF_SIGN_KEY above, so the build logs in with its own Vault role
+          # (deckhouse-olcedar-signer) right before signing — a token there lives 180s.
+          # The list below mirrors the repositories that role is bound to; a build
+          # anywhere else cannot obtain a token and skips signing instead of failing.
+          WERF_OLCEDAR_SYSEXT_SIGN_ENABLED: ${{ contains(fromJSON('["deckhouse/deckhouse", "deckhouse/deckhouse-test-1", "deckhouse/deckhouse-test-2"]'), github.repository) }}
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}

--- a/.github/workflows/svace.yml
+++ b/.github/workflows/svace.yml
@@ -355,6 +355,13 @@ jobs:
           WERF_ANNOTATE_LAYERS_WITH_DM_VERITY_ROOT_HASH: "1"
           WERF_VAULT_AUTH_PATH: "github"
           WERF_ACTIONS_AUDIENCE: "github-access-aud"
+          # Whether the sysext images of the Olcedar node get their dm-verity roothash
+          # signed. It is signed with the Olcedar key the node kernel trusts, not with the
+          # Deckhouse key WERF_SIGN_KEY above, so the build logs in with its own Vault role
+          # (deckhouse-olcedar-signer) right before signing — a token there lives 180s.
+          # The list below mirrors the repositories that role is bound to; a build
+          # anywhere else cannot obtain a token and skips signing instead of failing.
+          WERF_OLCEDAR_SYSEXT_SIGN_ENABLED: ${{ contains(fromJSON('["deckhouse/deckhouse", "deckhouse/deckhouse-test-1", "deckhouse/deckhouse-test-2"]'), github.repository) }}
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}

--- a/werf-giterminism.yaml
+++ b/werf-giterminism.yaml
@@ -17,6 +17,7 @@ config:
       - ACTIONS_ID_TOKEN_REQUEST_TOKEN
       - VAULT_KEY
       - WERF_SIGN_KEY
+      - WERF_OLCEDAR_SYSEXT_SIGN_ENABLED
     allowUncommittedFiles: ["tools/build_includes/*"]
   secrets:
     allowEnvVariables:


### PR DESCRIPTION
Lets the build sign the dm-verity roothash of the Olcedar sysext images (`modules/007-registrypackages/images/{kubelet,containerd,kubernetes-cni}`). **Nothing signs anything yet** — the signing step lands in #21914.

`WERF_OLCEDAR_SYSEXT_SIGN_ENABLED` says whether a build signs. The signature is made with the Olcedar key the node kernel trusts, not the Deckhouse key `WERF_SIGN_KEY`, so the build logs in with its own Vault role (`deckhouse-olcedar-signer`, created in `team/security/seguro-policy!236`). That role is bound to `repository: deckhouse/deckhouse`, so builds elsewhere cannot get a token and must skip signing rather than fail.

Only `.github/ci_templates/build.yml` and `werf-giterminism.yaml` are hand-edited; `.github/workflows/*` are regenerated with `.github/render-workflows.sh`.

## Why do we need it, and what problem does it solve?

Olcedar nodes mount sysext images through dm-verity. The kernel verifies one only if the roothash carries a detached PKCS#7 chaining to the CA built into it. Today those images ship a plaintext roothash and no signature.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Changelog entries

```changes
section: ci
type: feature
summary: Let the build sign the dm-verity roothash of the Olcedar sysext images.
impact_level: low
```