### PR TITLE
[registrypackages] sign the dm-verity roothash of the Olcedar sysext images

### DIFF
--- a/.github/ci_templates/build.yml
+++ b/.github/ci_templates/build.yml
@@ -169,6 +169,11 @@ steps:
       WERF_ANNOTATE_LAYERS_WITH_DM_VERITY_ROOT_HASH: "1"
       WERF_VAULT_AUTH_PATH: "github"
       WERF_ACTIONS_AUDIENCE: "github-access-aud"
+      # Signing of the Olcedar sysext roothashes: which Vault role, and where it is
+      # allowed. The list mirrors that role's bound_claims; elsewhere no token can be
+      # obtained, so signing is skipped rather than failing the build.
+      WERF_OLCEDAR_VAULT_AUTH_ROLE: "deckhouse-olcedar-signer"
+      WERF_OLCEDAR_SYSEXT_SIGN_ENABLED: ${{ contains(fromJSON('["deckhouse/deckhouse", "deckhouse/deckhouse-test-1", "deckhouse/deckhouse-test-2"]'), github.repository) }}
     run: |
       # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
       REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -597,6 +597,11 @@ jobs:
           WERF_ANNOTATE_LAYERS_WITH_DM_VERITY_ROOT_HASH: "1"
           WERF_VAULT_AUTH_PATH: "github"
           WERF_ACTIONS_AUDIENCE: "github-access-aud"
+          # Signing of the Olcedar sysext roothashes: which Vault role, and where it is
+          # allowed. The list mirrors that role's bound_claims; elsewhere no token can be
+          # obtained, so signing is skipped rather than failing the build.
+          WERF_OLCEDAR_VAULT_AUTH_ROLE: "deckhouse-olcedar-signer"
+          WERF_OLCEDAR_SYSEXT_SIGN_ENABLED: ${{ contains(fromJSON('["deckhouse/deckhouse", "deckhouse/deckhouse-test-1", "deckhouse/deckhouse-test-2"]'), github.repository) }}
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
@@ -1336,6 +1341,11 @@ jobs:
           WERF_ANNOTATE_LAYERS_WITH_DM_VERITY_ROOT_HASH: "1"
           WERF_VAULT_AUTH_PATH: "github"
           WERF_ACTIONS_AUDIENCE: "github-access-aud"
+          # Signing of the Olcedar sysext roothashes: which Vault role, and where it is
+          # allowed. The list mirrors that role's bound_claims; elsewhere no token can be
+          # obtained, so signing is skipped rather than failing the build.
+          WERF_OLCEDAR_VAULT_AUTH_ROLE: "deckhouse-olcedar-signer"
+          WERF_OLCEDAR_SYSEXT_SIGN_ENABLED: ${{ contains(fromJSON('["deckhouse/deckhouse", "deckhouse/deckhouse-test-1", "deckhouse/deckhouse-test-2"]'), github.repository) }}
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
@@ -1731,6 +1741,11 @@ jobs:
           WERF_ANNOTATE_LAYERS_WITH_DM_VERITY_ROOT_HASH: "1"
           WERF_VAULT_AUTH_PATH: "github"
           WERF_ACTIONS_AUDIENCE: "github-access-aud"
+          # Signing of the Olcedar sysext roothashes: which Vault role, and where it is
+          # allowed. The list mirrors that role's bound_claims; elsewhere no token can be
+          # obtained, so signing is skipped rather than failing the build.
+          WERF_OLCEDAR_VAULT_AUTH_ROLE: "deckhouse-olcedar-signer"
+          WERF_OLCEDAR_SYSEXT_SIGN_ENABLED: ${{ contains(fromJSON('["deckhouse/deckhouse", "deckhouse/deckhouse-test-1", "deckhouse/deckhouse-test-2"]'), github.repository) }}
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
@@ -2126,6 +2141,11 @@ jobs:
           WERF_ANNOTATE_LAYERS_WITH_DM_VERITY_ROOT_HASH: "1"
           WERF_VAULT_AUTH_PATH: "github"
           WERF_ACTIONS_AUDIENCE: "github-access-aud"
+          # Signing of the Olcedar sysext roothashes: which Vault role, and where it is
+          # allowed. The list mirrors that role's bound_claims; elsewhere no token can be
+          # obtained, so signing is skipped rather than failing the build.
+          WERF_OLCEDAR_VAULT_AUTH_ROLE: "deckhouse-olcedar-signer"
+          WERF_OLCEDAR_SYSEXT_SIGN_ENABLED: ${{ contains(fromJSON('["deckhouse/deckhouse", "deckhouse/deckhouse-test-1", "deckhouse/deckhouse-test-2"]'), github.repository) }}
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
@@ -2521,6 +2541,11 @@ jobs:
           WERF_ANNOTATE_LAYERS_WITH_DM_VERITY_ROOT_HASH: "1"
           WERF_VAULT_AUTH_PATH: "github"
           WERF_ACTIONS_AUDIENCE: "github-access-aud"
+          # Signing of the Olcedar sysext roothashes: which Vault role, and where it is
+          # allowed. The list mirrors that role's bound_claims; elsewhere no token can be
+          # obtained, so signing is skipped rather than failing the build.
+          WERF_OLCEDAR_VAULT_AUTH_ROLE: "deckhouse-olcedar-signer"
+          WERF_OLCEDAR_SYSEXT_SIGN_ENABLED: ${{ contains(fromJSON('["deckhouse/deckhouse", "deckhouse/deckhouse-test-1", "deckhouse/deckhouse-test-2"]'), github.repository) }}
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
@@ -2916,6 +2941,11 @@ jobs:
           WERF_ANNOTATE_LAYERS_WITH_DM_VERITY_ROOT_HASH: "1"
           WERF_VAULT_AUTH_PATH: "github"
           WERF_ACTIONS_AUDIENCE: "github-access-aud"
+          # Signing of the Olcedar sysext roothashes: which Vault role, and where it is
+          # allowed. The list mirrors that role's bound_claims; elsewhere no token can be
+          # obtained, so signing is skipped rather than failing the build.
+          WERF_OLCEDAR_VAULT_AUTH_ROLE: "deckhouse-olcedar-signer"
+          WERF_OLCEDAR_SYSEXT_SIGN_ENABLED: ${{ contains(fromJSON('["deckhouse/deckhouse", "deckhouse/deckhouse-test-1", "deckhouse/deckhouse-test-2"]'), github.repository) }}
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
@@ -3311,6 +3341,11 @@ jobs:
           WERF_ANNOTATE_LAYERS_WITH_DM_VERITY_ROOT_HASH: "1"
           WERF_VAULT_AUTH_PATH: "github"
           WERF_ACTIONS_AUDIENCE: "github-access-aud"
+          # Signing of the Olcedar sysext roothashes: which Vault role, and where it is
+          # allowed. The list mirrors that role's bound_claims; elsewhere no token can be
+          # obtained, so signing is skipped rather than failing the build.
+          WERF_OLCEDAR_VAULT_AUTH_ROLE: "deckhouse-olcedar-signer"
+          WERF_OLCEDAR_SYSEXT_SIGN_ENABLED: ${{ contains(fromJSON('["deckhouse/deckhouse", "deckhouse/deckhouse-test-1", "deckhouse/deckhouse-test-2"]'), github.repository) }}
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}

--- a/.github/workflows/build-and-test_main.yml
+++ b/.github/workflows/build-and-test_main.yml
@@ -359,6 +359,11 @@ jobs:
           WERF_ANNOTATE_LAYERS_WITH_DM_VERITY_ROOT_HASH: "1"
           WERF_VAULT_AUTH_PATH: "github"
           WERF_ACTIONS_AUDIENCE: "github-access-aud"
+          # Signing of the Olcedar sysext roothashes: which Vault role, and where it is
+          # allowed. The list mirrors that role's bound_claims; elsewhere no token can be
+          # obtained, so signing is skipped rather than failing the build.
+          WERF_OLCEDAR_VAULT_AUTH_ROLE: "deckhouse-olcedar-signer"
+          WERF_OLCEDAR_SYSEXT_SIGN_ENABLED: ${{ contains(fromJSON('["deckhouse/deckhouse", "deckhouse/deckhouse-test-1", "deckhouse/deckhouse-test-2"]'), github.repository) }}
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -359,6 +359,11 @@ jobs:
           WERF_ANNOTATE_LAYERS_WITH_DM_VERITY_ROOT_HASH: "1"
           WERF_VAULT_AUTH_PATH: "github"
           WERF_ACTIONS_AUDIENCE: "github-access-aud"
+          # Signing of the Olcedar sysext roothashes: which Vault role, and where it is
+          # allowed. The list mirrors that role's bound_claims; elsewhere no token can be
+          # obtained, so signing is skipped rather than failing the build.
+          WERF_OLCEDAR_VAULT_AUTH_ROLE: "deckhouse-olcedar-signer"
+          WERF_OLCEDAR_SYSEXT_SIGN_ENABLED: ${{ contains(fromJSON('["deckhouse/deckhouse", "deckhouse/deckhouse-test-1", "deckhouse/deckhouse-test-2"]'), github.repository) }}
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
@@ -1075,6 +1080,11 @@ jobs:
           WERF_ANNOTATE_LAYERS_WITH_DM_VERITY_ROOT_HASH: "1"
           WERF_VAULT_AUTH_PATH: "github"
           WERF_ACTIONS_AUDIENCE: "github-access-aud"
+          # Signing of the Olcedar sysext roothashes: which Vault role, and where it is
+          # allowed. The list mirrors that role's bound_claims; elsewhere no token can be
+          # obtained, so signing is skipped rather than failing the build.
+          WERF_OLCEDAR_VAULT_AUTH_ROLE: "deckhouse-olcedar-signer"
+          WERF_OLCEDAR_SYSEXT_SIGN_ENABLED: ${{ contains(fromJSON('["deckhouse/deckhouse", "deckhouse/deckhouse-test-1", "deckhouse/deckhouse-test-2"]'), github.repository) }}
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
@@ -1478,6 +1488,11 @@ jobs:
           WERF_ANNOTATE_LAYERS_WITH_DM_VERITY_ROOT_HASH: "1"
           WERF_VAULT_AUTH_PATH: "github"
           WERF_ACTIONS_AUDIENCE: "github-access-aud"
+          # Signing of the Olcedar sysext roothashes: which Vault role, and where it is
+          # allowed. The list mirrors that role's bound_claims; elsewhere no token can be
+          # obtained, so signing is skipped rather than failing the build.
+          WERF_OLCEDAR_VAULT_AUTH_ROLE: "deckhouse-olcedar-signer"
+          WERF_OLCEDAR_SYSEXT_SIGN_ENABLED: ${{ contains(fromJSON('["deckhouse/deckhouse", "deckhouse/deckhouse-test-1", "deckhouse/deckhouse-test-2"]'), github.repository) }}
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
@@ -1881,6 +1896,11 @@ jobs:
           WERF_ANNOTATE_LAYERS_WITH_DM_VERITY_ROOT_HASH: "1"
           WERF_VAULT_AUTH_PATH: "github"
           WERF_ACTIONS_AUDIENCE: "github-access-aud"
+          # Signing of the Olcedar sysext roothashes: which Vault role, and where it is
+          # allowed. The list mirrors that role's bound_claims; elsewhere no token can be
+          # obtained, so signing is skipped rather than failing the build.
+          WERF_OLCEDAR_VAULT_AUTH_ROLE: "deckhouse-olcedar-signer"
+          WERF_OLCEDAR_SYSEXT_SIGN_ENABLED: ${{ contains(fromJSON('["deckhouse/deckhouse", "deckhouse/deckhouse-test-1", "deckhouse/deckhouse-test-2"]'), github.repository) }}
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
@@ -2284,6 +2304,11 @@ jobs:
           WERF_ANNOTATE_LAYERS_WITH_DM_VERITY_ROOT_HASH: "1"
           WERF_VAULT_AUTH_PATH: "github"
           WERF_ACTIONS_AUDIENCE: "github-access-aud"
+          # Signing of the Olcedar sysext roothashes: which Vault role, and where it is
+          # allowed. The list mirrors that role's bound_claims; elsewhere no token can be
+          # obtained, so signing is skipped rather than failing the build.
+          WERF_OLCEDAR_VAULT_AUTH_ROLE: "deckhouse-olcedar-signer"
+          WERF_OLCEDAR_SYSEXT_SIGN_ENABLED: ${{ contains(fromJSON('["deckhouse/deckhouse", "deckhouse/deckhouse-test-1", "deckhouse/deckhouse-test-2"]'), github.repository) }}
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
@@ -2687,6 +2712,11 @@ jobs:
           WERF_ANNOTATE_LAYERS_WITH_DM_VERITY_ROOT_HASH: "1"
           WERF_VAULT_AUTH_PATH: "github"
           WERF_ACTIONS_AUDIENCE: "github-access-aud"
+          # Signing of the Olcedar sysext roothashes: which Vault role, and where it is
+          # allowed. The list mirrors that role's bound_claims; elsewhere no token can be
+          # obtained, so signing is skipped rather than failing the build.
+          WERF_OLCEDAR_VAULT_AUTH_ROLE: "deckhouse-olcedar-signer"
+          WERF_OLCEDAR_SYSEXT_SIGN_ENABLED: ${{ contains(fromJSON('["deckhouse/deckhouse", "deckhouse/deckhouse-test-1", "deckhouse/deckhouse-test-2"]'), github.repository) }}
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
@@ -3090,6 +3120,11 @@ jobs:
           WERF_ANNOTATE_LAYERS_WITH_DM_VERITY_ROOT_HASH: "1"
           WERF_VAULT_AUTH_PATH: "github"
           WERF_ACTIONS_AUDIENCE: "github-access-aud"
+          # Signing of the Olcedar sysext roothashes: which Vault role, and where it is
+          # allowed. The list mirrors that role's bound_claims; elsewhere no token can be
+          # obtained, so signing is skipped rather than failing the build.
+          WERF_OLCEDAR_VAULT_AUTH_ROLE: "deckhouse-olcedar-signer"
+          WERF_OLCEDAR_SYSEXT_SIGN_ENABLED: ${{ contains(fromJSON('["deckhouse/deckhouse", "deckhouse/deckhouse-test-1", "deckhouse/deckhouse-test-2"]'), github.repository) }}
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -485,6 +485,11 @@ jobs:
           WERF_ANNOTATE_LAYERS_WITH_DM_VERITY_ROOT_HASH: "1"
           WERF_VAULT_AUTH_PATH: "github"
           WERF_ACTIONS_AUDIENCE: "github-access-aud"
+          # Signing of the Olcedar sysext roothashes: which Vault role, and where it is
+          # allowed. The list mirrors that role's bound_claims; elsewhere no token can be
+          # obtained, so signing is skipped rather than failing the build.
+          WERF_OLCEDAR_VAULT_AUTH_ROLE: "deckhouse-olcedar-signer"
+          WERF_OLCEDAR_SYSEXT_SIGN_ENABLED: ${{ contains(fromJSON('["deckhouse/deckhouse", "deckhouse/deckhouse-test-1", "deckhouse/deckhouse-test-2"]'), github.repository) }}
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
@@ -920,6 +925,11 @@ jobs:
           WERF_ANNOTATE_LAYERS_WITH_DM_VERITY_ROOT_HASH: "1"
           WERF_VAULT_AUTH_PATH: "github"
           WERF_ACTIONS_AUDIENCE: "github-access-aud"
+          # Signing of the Olcedar sysext roothashes: which Vault role, and where it is
+          # allowed. The list mirrors that role's bound_claims; elsewhere no token can be
+          # obtained, so signing is skipped rather than failing the build.
+          WERF_OLCEDAR_VAULT_AUTH_ROLE: "deckhouse-olcedar-signer"
+          WERF_OLCEDAR_SYSEXT_SIGN_ENABLED: ${{ contains(fromJSON('["deckhouse/deckhouse", "deckhouse/deckhouse-test-1", "deckhouse/deckhouse-test-2"]'), github.repository) }}
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
@@ -1356,6 +1366,11 @@ jobs:
           WERF_ANNOTATE_LAYERS_WITH_DM_VERITY_ROOT_HASH: "1"
           WERF_VAULT_AUTH_PATH: "github"
           WERF_ACTIONS_AUDIENCE: "github-access-aud"
+          # Signing of the Olcedar sysext roothashes: which Vault role, and where it is
+          # allowed. The list mirrors that role's bound_claims; elsewhere no token can be
+          # obtained, so signing is skipped rather than failing the build.
+          WERF_OLCEDAR_VAULT_AUTH_ROLE: "deckhouse-olcedar-signer"
+          WERF_OLCEDAR_SYSEXT_SIGN_ENABLED: ${{ contains(fromJSON('["deckhouse/deckhouse", "deckhouse/deckhouse-test-1", "deckhouse/deckhouse-test-2"]'), github.repository) }}
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
@@ -1792,6 +1807,11 @@ jobs:
           WERF_ANNOTATE_LAYERS_WITH_DM_VERITY_ROOT_HASH: "1"
           WERF_VAULT_AUTH_PATH: "github"
           WERF_ACTIONS_AUDIENCE: "github-access-aud"
+          # Signing of the Olcedar sysext roothashes: which Vault role, and where it is
+          # allowed. The list mirrors that role's bound_claims; elsewhere no token can be
+          # obtained, so signing is skipped rather than failing the build.
+          WERF_OLCEDAR_VAULT_AUTH_ROLE: "deckhouse-olcedar-signer"
+          WERF_OLCEDAR_SYSEXT_SIGN_ENABLED: ${{ contains(fromJSON('["deckhouse/deckhouse", "deckhouse/deckhouse-test-1", "deckhouse/deckhouse-test-2"]'), github.repository) }}
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
@@ -2228,6 +2248,11 @@ jobs:
           WERF_ANNOTATE_LAYERS_WITH_DM_VERITY_ROOT_HASH: "1"
           WERF_VAULT_AUTH_PATH: "github"
           WERF_ACTIONS_AUDIENCE: "github-access-aud"
+          # Signing of the Olcedar sysext roothashes: which Vault role, and where it is
+          # allowed. The list mirrors that role's bound_claims; elsewhere no token can be
+          # obtained, so signing is skipped rather than failing the build.
+          WERF_OLCEDAR_VAULT_AUTH_ROLE: "deckhouse-olcedar-signer"
+          WERF_OLCEDAR_SYSEXT_SIGN_ENABLED: ${{ contains(fromJSON('["deckhouse/deckhouse", "deckhouse/deckhouse-test-1", "deckhouse/deckhouse-test-2"]'), github.repository) }}
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
@@ -2664,6 +2689,11 @@ jobs:
           WERF_ANNOTATE_LAYERS_WITH_DM_VERITY_ROOT_HASH: "1"
           WERF_VAULT_AUTH_PATH: "github"
           WERF_ACTIONS_AUDIENCE: "github-access-aud"
+          # Signing of the Olcedar sysext roothashes: which Vault role, and where it is
+          # allowed. The list mirrors that role's bound_claims; elsewhere no token can be
+          # obtained, so signing is skipped rather than failing the build.
+          WERF_OLCEDAR_VAULT_AUTH_ROLE: "deckhouse-olcedar-signer"
+          WERF_OLCEDAR_SYSEXT_SIGN_ENABLED: ${{ contains(fromJSON('["deckhouse/deckhouse", "deckhouse/deckhouse-test-1", "deckhouse/deckhouse-test-2"]'), github.repository) }}
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}

--- a/.github/workflows/reproducibility-check.yml
+++ b/.github/workflows/reproducibility-check.yml
@@ -551,6 +551,11 @@ jobs:
           WERF_ANNOTATE_LAYERS_WITH_DM_VERITY_ROOT_HASH: "1"
           WERF_VAULT_AUTH_PATH: "github"
           WERF_ACTIONS_AUDIENCE: "github-access-aud"
+          # Signing of the Olcedar sysext roothashes: which Vault role, and where it is
+          # allowed. The list mirrors that role's bound_claims; elsewhere no token can be
+          # obtained, so signing is skipped rather than failing the build.
+          WERF_OLCEDAR_VAULT_AUTH_ROLE: "deckhouse-olcedar-signer"
+          WERF_OLCEDAR_SYSEXT_SIGN_ENABLED: ${{ contains(fromJSON('["deckhouse/deckhouse", "deckhouse/deckhouse-test-1", "deckhouse/deckhouse-test-2"]'), github.repository) }}
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
@@ -974,6 +979,11 @@ jobs:
           WERF_ANNOTATE_LAYERS_WITH_DM_VERITY_ROOT_HASH: "1"
           WERF_VAULT_AUTH_PATH: "github"
           WERF_ACTIONS_AUDIENCE: "github-access-aud"
+          # Signing of the Olcedar sysext roothashes: which Vault role, and where it is
+          # allowed. The list mirrors that role's bound_claims; elsewhere no token can be
+          # obtained, so signing is skipped rather than failing the build.
+          WERF_OLCEDAR_VAULT_AUTH_ROLE: "deckhouse-olcedar-signer"
+          WERF_OLCEDAR_SYSEXT_SIGN_ENABLED: ${{ contains(fromJSON('["deckhouse/deckhouse", "deckhouse/deckhouse-test-1", "deckhouse/deckhouse-test-2"]'), github.repository) }}
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}

--- a/.github/workflows/svace.yml
+++ b/.github/workflows/svace.yml
@@ -355,6 +355,11 @@ jobs:
           WERF_ANNOTATE_LAYERS_WITH_DM_VERITY_ROOT_HASH: "1"
           WERF_VAULT_AUTH_PATH: "github"
           WERF_ACTIONS_AUDIENCE: "github-access-aud"
+          # Signing of the Olcedar sysext roothashes: which Vault role, and where it is
+          # allowed. The list mirrors that role's bound_claims; elsewhere no token can be
+          # obtained, so signing is skipped rather than failing the build.
+          WERF_OLCEDAR_VAULT_AUTH_ROLE: "deckhouse-olcedar-signer"
+          WERF_OLCEDAR_SYSEXT_SIGN_ENABLED: ${{ contains(fromJSON('["deckhouse/deckhouse", "deckhouse/deckhouse-test-1", "deckhouse/deckhouse-test-2"]'), github.repository) }}
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}

--- a/.werf/defines/olcedar-sysext.tmpl
+++ b/.werf/defines/olcedar-sysext.tmpl
@@ -1,0 +1,86 @@
+# Signing of the dm-verity roothash of an Olcedar sysext image.
+#
+# systemd names the verity sidecars after <name>.raw with the .raw suffix stripped
+# — <name>.verity, <name>.roothash, <name>.roothash.p7s — see
+# build_auxiliary_path() in src/shared/dissect-image.c. The signature is detached,
+# so the kernel supplies the content itself: the hex roothash straight out of the
+# verity table, which is why the file carries no trailing newline.
+#
+# Signing runs only where WERF_OLCEDAR_SYSEXT_SIGN_ENABLED is "true"; the Vault
+# role is bound to deckhouse/deckhouse, so a build elsewhere ships an unsigned
+# image rather than failing.
+
+# d8 talks to Vault. systemd-keyutil builds the PKCS#7 from the signer certificate
+# and the raw signature Vault returns; the package index the builder pins carries
+# systemd 260.3, which does not ship it, so take the two files from 260.4 instead.
+# Drop that part once the index carries 260.4 and `pm install systemd` is enough.
+{{- define "olcedar sysext sign imports" }}
+- image: {{ .ModuleName }}/d8
+  add: /d8
+  to: /usr/bin/d8
+  before: install
+- from: {{ index .Images "systemd-260.4" }}
+  add: /usr/lib/systemd
+  to: /usr/lib/systemd
+  includePaths:
+  - systemd-keyutil
+  - libsystemd-shared-260.so
+  before: install
+{{- end }}
+
+# The OIDC token is minted inside the build rather than passed in: a GitHub
+# Actions JWT is short lived while a build is not, and ACTIONS_ID_TOKEN_REQUEST_*
+# stay valid for the whole job.
+{{- define "olcedar sysext sign secrets" }}
+  {{- if eq (env "WERF_OLCEDAR_SYSEXT_SIGN_ENABLED" "") "true" }}
+secrets:
+- id: VAULT_ADDR
+  env: VAULT_ADDR
+- id: WERF_OLCEDAR_VAULT_AUTH_ROLE
+  env: WERF_OLCEDAR_VAULT_AUTH_ROLE
+- id: ACTIONS_ID_TOKEN_REQUEST_TOKEN
+  env: ACTIONS_ID_TOKEN_REQUEST_TOKEN
+- id: ACTIONS_ID_TOKEN_REQUEST_URL
+  env: ACTIONS_ID_TOKEN_REQUEST_URL
+  {{- end }}
+{{- end }}
+
+{{- define "olcedar sysext sign" }}
+  {{- $name := . }}
+  {{- if eq (env "WERF_OLCEDAR_SYSEXT_SIGN_ENABLED" "") "true" }}
+  - pm install openssl curl jq
+  - |
+    set -eo pipefail
+
+    # The Transit key and its leaf certificate, pinned by serial. They rotate
+    # together: the leaf must match the key, so both lines change at once. The
+    # policy also allows listing olcedar-root-pki/certs to find a new serial.
+    SIGN_KEY_PATH="olcedar-signer/sign/olcedar-2026-july/sha2-256"
+    SIGNER_CERT_PATH="olcedar-root-pki/cert/0f:17:29:75:b0:43:15:cf:56:01:62:10:47:26:ed:79:51:64:fe:96"
+
+    export VAULT_ADDR="$(cat /run/secrets/VAULT_ADDR)"
+    export VAULT_TOKEN="$(d8 stronghold write -field=token auth/github/login role="$(cat /run/secrets/WERF_OLCEDAR_VAULT_AUTH_ROLE)" \
+      jwt="$(curl -fsS -H "Authorization: bearer $(cat /run/secrets/ACTIONS_ID_TOKEN_REQUEST_TOKEN)" "$(cat /run/secrets/ACTIONS_ID_TOKEN_REQUEST_URL)&audience=github-access-aud" | jq -r .value)")"
+
+    d8 stronghold read -field=certificate "${SIGNER_CERT_PATH}" > /tmp/olcedar-signer.pem
+    openssl x509 -in /tmp/olcedar-signer.pem -noout -subject -issuer
+
+    SIGNATURE="$(d8 stronghold write -field=signature "${SIGN_KEY_PATH}" prehashed=true signature_algorithm=pkcs1v15 \
+      input="$(openssl dgst -sha256 -binary /out/{{ $name }}.roothash | base64 | tr -d '\n')")"
+    printf '%s' "${SIGNATURE#vault:v*:}" | base64 -d > /tmp/roothash.sig
+
+    /usr/lib/systemd/systemd-keyutil pkcs7 \
+      --certificate=/tmp/olcedar-signer.pem \
+      --signature=/tmp/roothash.sig \
+      --hash-algorithm=sha256 \
+      --output=/out/{{ $name }}.roothash.p7s
+
+    # Nothing downstream enforces this file yet — systemd-sysext merges an extension
+    # unprotected when verity cannot be set up — so an unchecked signature would go
+    # unnoticed until it matters.
+    openssl smime -verify -inform der -in /out/{{ $name }}.roothash.p7s -content /out/{{ $name }}.roothash -noverify -out /dev/null
+    echo "signed roothash - $(cat /out/{{ $name }}.roothash)"
+  {{- else }}
+  - echo "WERF_OLCEDAR_SYSEXT_SIGN_ENABLED is not true - shipping {{ $name }} without a roothash signature"
+  {{- end }}
+{{- end }}

--- a/candi/alt_base_images.yml
+++ b/candi/alt_base_images.yml
@@ -7,3 +7,4 @@ builder/golang-1.26: "sha256:2ab76902cdeb0034152b4e1c81f1ec08fa26709075a52b25f70
 builder/golang: "sha256:2ab76902cdeb0034152b4e1c81f1ec08fa26709075a52b25f700ce7e3c0f91bb" # from: builder/distroless
 minget-0.1: "sha256:6e37a40153be199ac9d9652072cae7ee4a7a595f9d4de53d04b0ac3b557b658d" # from: builder/scratch
 minget: "sha256:6e37a40153be199ac9d9652072cae7ee4a7a595f9d4de53d04b0ac3b557b658d" # from: builder/scratch
+systemd-260.4: "sha256:e8f1c8b4bc651f9e317568d7380887c7bfafee15edd9a84857be366e36e8abb3" # from: builder/scratch

--- a/modules/007-registrypackages/images/containerd/werf.inc.yaml
+++ b/modules/007-registrypackages/images/containerd/werf.inc.yaml
@@ -268,6 +268,7 @@ import:
   - pidumount
 {{- end }}
   before: install
+{{- include "olcedar sysext sign imports" $ }}
 git:
 - add: /{{ $.ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/sysext
   to: /scripts
@@ -278,6 +279,7 @@ git:
     install:
     - extension-release.containerd
     - sysext-containerd.service
+{{- include "olcedar sysext sign secrets" . }}
 shell:
   beforeInstall:
   - pm install erofs-utils coreutils cryptsetup
@@ -286,11 +288,12 @@ shell:
   - mkdir -p /sysext/usr/lib/extension-release.d /sysext/usr/lib/systemd/system
   - cp -f /scripts/sysext-containerd.service /sysext/usr/lib/systemd/system/containerd.service
   - cp -f /scripts/extension-release.containerd /sysext/usr/lib/extension-release.d/
-  - mkfs.erofs -L _sysext -U 00000000-0000-0000-0000-000000000000 -z lzma,9 containerd.erofs sysext/
-  - veritysetup format containerd.erofs containerd.verity > verity.txt
-  - export ROOTHASH=$(awk '/^Root hash:/ {print $3}' verity.txt)
-  - cat containerd.erofs containerd.verity > /out/containerd.raw
-  - printf '%s\n' "$ROOTHASH" > /out/containerd.raw.roothash
+  - mkfs.erofs -L _sysext -U 00000000-0000-0000-0000-000000000000 -z lzma,9 /out/containerd.raw sysext/
+  # Sidecar files, named the way systemd derives them — see olcedar-sysext.tmpl.
+  - veritysetup format /out/containerd.raw /out/containerd.verity --root-hash-file=roothash.txt
+  - tr -d ' \n' < roothash.txt > /out/containerd.roothash
+  - veritysetup verify /out/containerd.raw /out/containerd.verity "$(cat /out/containerd.roothash)"
+{{- include "olcedar sysext sign" "containerd" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-sysext-{{ $image_version }}
 from: {{ index $.Images "builder/scratch" }}

--- a/modules/007-registrypackages/images/kubelet/werf.inc.yaml
+++ b/modules/007-registrypackages/images/kubelet/werf.inc.yaml
@@ -80,6 +80,7 @@ import:
   add: /kubelet
   to: /sysext/opt/deckhouse/bin/kubelet
   before: install
+{{- include "olcedar sysext sign imports" $ }}
 git:
 - add: /{{ $.ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/sysext
   to: /scripts
@@ -90,6 +91,7 @@ git:
     install:
     - extension-release.kubelet
     - sysext-kubelet.service
+{{- include "olcedar sysext sign secrets" . }}
 shell:
   beforeInstall:
   - pm install erofs-utils coreutils cryptsetup
@@ -98,11 +100,12 @@ shell:
   - mkdir -p /sysext/usr/lib/extension-release.d /sysext/usr/lib/systemd/system
   - cp -f /scripts/sysext-kubelet.service /sysext/usr/lib/systemd/system/kubelet.service
   - cp -f /scripts/extension-release.kubelet /sysext/usr/lib/extension-release.d/
-  - mkfs.erofs -L _sysext -U 00000000-0000-0000-0000-000000000000 -z lzma,9 kubelet.erofs sysext/
-  - veritysetup format kubelet.erofs kubelet.verity > verity.txt
-  - export ROOTHASH=$(awk '/^Root hash:/ {print $3}' verity.txt)
-  - cat kubelet.erofs kubelet.verity > /out/kubelet.raw
-  - printf '%s\n' "$ROOTHASH" > /out/kubelet.raw.roothash
+  - mkfs.erofs -L _sysext -U 00000000-0000-0000-0000-000000000000 -z lzma,9 /out/kubelet.raw sysext/
+  # Sidecar files, named the way systemd derives them — see olcedar-sysext.tmpl.
+  - veritysetup format /out/kubelet.raw /out/kubelet.verity --root-hash-file=roothash.txt
+  - tr -d ' \n' < roothash.txt > /out/kubelet.roothash
+  - veritysetup verify /out/kubelet.raw /out/kubelet.verity "$(cat /out/kubelet.roothash)"
+{{- include "olcedar sysext sign" "kubelet" }}
 ---
 {{- include "vex mitigation" (list $ (printf "%s/%s-sysext-%s" $.ModuleName $.ImageName $image_version)) }}
 {{- end }}

--- a/modules/007-registrypackages/images/kubernetes-cni/werf.inc.yaml
+++ b/modules/007-registrypackages/images/kubernetes-cni/werf.inc.yaml
@@ -151,6 +151,7 @@ import:
   - install
   - uninstall
   before: install
+{{- include "olcedar sysext sign imports" $ }}
 git:
 - add: /{{ $.ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/sysext
   to: /scripts
@@ -161,6 +162,7 @@ git:
     install:
     - extension-release.kubernetes-cni
     - sysext-kubernetes-cni.service
+{{- include "olcedar sysext sign secrets" . }}
 shell:
   beforeInstall:
   - pm install erofs-utils coreutils cryptsetup
@@ -169,8 +171,9 @@ shell:
   - mkdir -p /sysext/usr/lib/extension-release.d /sysext/usr/lib/systemd/system
   - cp -f /scripts/sysext-kubernetes-cni.service /sysext/usr/lib/systemd/system/kubernetes-cni.service
   - cp -f /scripts/extension-release.kubernetes-cni /sysext/usr/lib/extension-release.d/
-  - mkfs.erofs -L _sysext -U 00000000-0000-0000-0000-000000000000 -z lzma,9 kubernetes-cni.erofs sysext/
-  - veritysetup format kubernetes-cni.erofs kubernetes-cni.verity > verity.txt
-  - export ROOTHASH=$(awk '/^Root hash:/ {print $3}' verity.txt)
-  - cat kubernetes-cni.erofs kubernetes-cni.verity > /out/kubernetes-cni.raw
-  - printf '%s\n' "$ROOTHASH" > /out/kubernetes-cni.raw.roothash
+  - mkfs.erofs -L _sysext -U 00000000-0000-0000-0000-000000000000 -z lzma,9 /out/kubernetes-cni.raw sysext/
+  # Sidecar files, named the way systemd derives them — see olcedar-sysext.tmpl.
+  - veritysetup format /out/kubernetes-cni.raw /out/kubernetes-cni.verity --root-hash-file=roothash.txt
+  - tr -d ' \n' < roothash.txt > /out/kubernetes-cni.roothash
+  - veritysetup verify /out/kubernetes-cni.raw /out/kubernetes-cni.verity "$(cat /out/kubernetes-cni.roothash)"
+{{- include "olcedar sysext sign" "kubernetes-cni" }}

--- a/werf-giterminism.yaml
+++ b/werf-giterminism.yaml
@@ -17,6 +17,7 @@ config:
       - ACTIONS_ID_TOKEN_REQUEST_TOKEN
       - VAULT_KEY
       - WERF_SIGN_KEY
+      - WERF_OLCEDAR_SYSEXT_SIGN_ENABLED
     allowUncommittedFiles: ["tools/build_includes/*"]
   secrets:
     allowEnvVariables:
@@ -31,6 +32,7 @@ config:
       - WERF_VAULT_AUTH_ROLE
       - WERF_VAULT_AUTH_JWT
       - WERF_SIGN_KEY
+      - WERF_OLCEDAR_VAULT_AUTH_ROLE
     allowValueIds:
       - SOURCE_REPO
       - GOPROXY


### PR DESCRIPTION
## Description

Ship the verity sidecars of the Olcedar sysext images (`kubelet`, `containerd`, `kubernetes-cni`) under the names systemd looks for, and sign the roothash.

* **Layout.** systemd reads `<name>.verity`, `<name>.roothash` and `<name>.roothash.p7s`, stripping the `.raw` suffix (`build_auxiliary_path()`, `src/shared/dissect-image.c`). We shipped the hash tree concatenated into the image and the roothash as `<name>.raw.roothash`, so verity was never set up and the extension merged unprotected.
* **Signature.** The roothash is signed with the Olcedar Vault Transit key — the key and CA the node kernel already trusts for module signatures. The build verifies the signature before shipping it.
* **CI.** `WERF_OLCEDAR_SYSEXT_SIGN_ENABLED` says whether a build signs. The Vault role (`deckhouse-olcedar-signer`, created in `team/security/seguro-policy!236`) is bound to `deckhouse/deckhouse` and the two test repositories, so a build elsewhere ships an unsigned image rather than failing. `.github/workflows/*` are regenerated with `.github/render-workflows.sh`; only `.github/ci_templates/build.yml` is hand-edited.

`systemd-keyutil` builds the PKCS#7 from the certificate and the raw signature Vault returns. The package index the builder pins carries systemd 260.3, which does not ship it, so it and its library come from the 260.4 base image; that goes away once the index catches up.

Verified on a build in `deckhouse-test-1`: the published image carries exactly the four files, the roothash is 64 bytes with no trailing newline, and the signature validates over those exact bytes and chains to the CA.

```
subject=… CN=olcedar@deckhouse.ru
issuer=…  CN=Olcedar Root CA
Verification successful
```

## Why do we need it, and what problem does it solve?

Olcedar nodes mount sysext images through dm-verity, which the kernel only sets up when the roothash carries a PKCS#7 chaining to the CA built into it. Today neither half works: the sidecars are misnamed and unsigned, so extensions merge without any integrity check.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: registrypackages
type: feature
summary: Sign the dm-verity roothash of the sysext images and name the verity sidecars the way systemd expects.
impact_level: low
```