### PR TITLE
[deckhouse] package admission server

### DIFF
--- a/deckhouse-controller/internal/packages/runtime/admission/server.go
+++ b/deckhouse-controller/internal/packages/runtime/admission/server.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package admission provides the HTTPS server used by package admission handlers.
+// Package admission provides the HTTPS server that serves deckhouse-controller admission handlers.
 package admission
 
 import (
@@ -24,6 +24,8 @@ import (
 	"net"
 	"net/http"
 	"path/filepath"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/deckhouse/deckhouse/pkg/log"
@@ -47,12 +49,18 @@ const (
 	privateKeyFilename = "tls.key"
 )
 
-// Server serves package admission handlers over HTTPS.
+// Server serves admission handlers over HTTPS. A Server may be started only once.
 type Server struct {
 	listenPort string
 	certsDir   string
 
 	mux *http.ServeMux
+
+	started atomic.Bool
+	ready   chan struct{} // closed once the listener is bound and addr is readable
+
+	mu   sync.RWMutex
+	addr net.Addr
 
 	logger *log.Logger
 }
@@ -63,8 +71,22 @@ func NewServer(listenPort, certsDir string, logger *log.Logger) *Server {
 		listenPort: listenPort,
 		certsDir:   certsDir,
 		mux:        http.NewServeMux(),
+		ready:      make(chan struct{}),
 		logger:     logger.Named("admission-server"),
 	}
+}
+
+// Addr returns the bound listener address, or nil before Start binds it.
+func (s *Server) Addr() net.Addr {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.addr
+}
+
+// Ready returns a channel closed once the server is listening; it stays open if Start fails to bind.
+func (s *Server) Ready() <-chan struct{} {
+	return s.ready
 }
 
 // RegisterHandler registers handler for route and reports malformed or conflicting routes as errors.

--- a/deckhouse-controller/internal/packages/runtime/runtime.go
+++ b/deckhouse-controller/internal/packages/runtime/runtime.go
@@ -54,7 +54,6 @@ import (
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/modules"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/modules/global"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/nelm"
-	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/runtime/admission"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/runtime/debug"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/runtime/hookevent"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/runtime/lifecycle"
@@ -102,8 +101,6 @@ type Runtime struct {
 	appDeployer      deployerI          // Deploys and undeploys application package images
 	moduleDeployer   deployerI          // Deploys and undeploys module package images
 	registry         *registry.Service  // Registry service for managing package digests
-
-	admissionServer *admission.Server
 
 	status      *status.Service     // Tracks per-package condition chain
 	scheduler   *schedule.Scheduler // Evaluates enable/disable based on version constraints
@@ -162,11 +159,11 @@ func Build(cli kclient.Client, moduleManager moduleManagerI, dc dependency.Conta
 	r.queueService = queue.NewService(logger)
 	r.status = status.NewService()
 
-	edition, err := edition.Parse(app.Version)
+	edit, err := edition.Parse(app.Version)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse edition: %w", err)
+		return nil, fmt.Errorf("parse edition: %w", err)
 	}
-	r.edition = edition
+	r.edition = edit
 
 	r.registry = registry.NewService(dc, logger)
 	downloadedDir := app.DownloadedModulesDir()

--- a/deckhouse-controller/internal/packages/runtime/runtime.go
+++ b/deckhouse-controller/internal/packages/runtime/runtime.go
@@ -54,6 +54,7 @@ import (
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/modules"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/modules/global"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/nelm"
+	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/runtime/admission"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/runtime/debug"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/runtime/hookevent"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/runtime/lifecycle"
@@ -102,6 +103,8 @@ type Runtime struct {
 	moduleDeployer   deployerI          // Deploys and undeploys module package images
 	registry         *registry.Service  // Registry service for managing package digests
 
+	admissionServer *admission.Server
+
 	status      *status.Service     // Tracks per-package condition chain
 	scheduler   *schedule.Scheduler // Evaluates enable/disable based on version constraints
 	debugServer *debug.Server       // Unix socket debug API
@@ -143,7 +146,7 @@ type moduleManagerI interface {
 
 // Build creates and initializes a Runtime with all subsystems wired together.
 // Blocks until the NELM cache completes its initial sync.
-func Build(cli kclient.Client, edition *edition.Edition, moduleManager moduleManagerI, dc dependency.Container, metricStorage metricsstorage.Storage, logger *log.Logger) (*Runtime, error) {
+func Build(cli kclient.Client, moduleManager moduleManagerI, dc dependency.Container, metricStorage metricsstorage.Storage, logger *log.Logger) (*Runtime, error) {
 	r := new(Runtime)
 
 	r.apps = make(map[string]*apps.Application)
@@ -158,6 +161,11 @@ func Build(cli kclient.Client, edition *edition.Edition, moduleManager moduleMan
 	r.scheduleManager = cron.NewManager(r.logger)
 	r.queueService = queue.NewService(logger)
 	r.status = status.NewService()
+
+	edition, err := edition.Parse(app.Version)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse edition: %w", err)
+	}
 	r.edition = edition
 
 	r.registry = registry.NewService(dc, logger)

--- a/deckhouse-controller/internal/packages/runtime/server/server.go
+++ b/deckhouse-controller/internal/packages/runtime/server/server.go
@@ -1,0 +1,173 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package admission provides the HTTPS server used by package admission handlers.
+package admission
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"path/filepath"
+	"time"
+
+	"github.com/deckhouse/deckhouse/pkg/log"
+)
+
+const (
+	// readHeaderTimeout limits the time spent reading request headers.
+	readHeaderTimeout = 10 * time.Second
+	// readTimeout limits the time spent reading an entire request.
+	readTimeout = 60 * time.Second
+	// writeTimeout limits the time spent writing a response.
+	writeTimeout = 30 * time.Second
+	// idleTimeout limits how long an idle keep-alive connection remains open.
+	idleTimeout = 120 * time.Second
+	// shutdownTimeout limits graceful server shutdown.
+	shutdownTimeout = 5 * time.Second
+
+	// certificateFilename is the TLS certificate filename in certsDir.
+	certificateFilename = "tls.crt"
+	// privateKeyFilename is the TLS private key filename in certsDir.
+	privateKeyFilename = "tls.key"
+)
+
+// Server serves package admission handlers over HTTPS.
+type Server struct {
+	listenPort string
+	certsDir   string
+
+	mux *http.ServeMux
+
+	logger *log.Logger
+}
+
+// NewServer creates an admission server that listens on listenPort and loads TLS files from certsDir.
+func NewServer(listenPort, certsDir string, logger *log.Logger) *Server {
+	return &Server{
+		listenPort: listenPort,
+		certsDir:   certsDir,
+		mux:        http.NewServeMux(),
+		logger:     logger.Named("admission-server"),
+	}
+}
+
+// RegisterHandler registers handler for route and reports malformed or conflicting routes as errors.
+func (s *Server) RegisterHandler(route string, handler http.Handler) error {
+	if handler == nil {
+		return errors.New("handler is required")
+	}
+
+	if err := registerHandler(s.mux, route, handler); err != nil {
+		return err
+	}
+
+	s.logger.Debug("registered admission route", slog.String("route", route))
+
+	return nil
+}
+
+// registerHandler converts the panic-based http.ServeMux registration API into an error.
+func registerHandler(mux *http.ServeMux, route string, handler http.Handler) error {
+	var err error
+
+	func() {
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				err = fmt.Errorf("register admission route %q: %v", route, recovered)
+			}
+		}()
+
+		mux.Handle(route, handler)
+	}()
+
+	return err
+}
+
+// Start runs the admission HTTPS server until ctx is canceled or the server fails.
+// Start blocks so the caller owns the server goroutine and receives lifecycle errors.
+func (s *Server) Start(ctx context.Context) error {
+	certFile := filepath.Join(s.certsDir, certificateFilename)
+	keyFile := filepath.Join(s.certsDir, privateKeyFilename)
+
+	certificate, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return fmt.Errorf("load admission TLS key pair: %w", err)
+	}
+
+	srv := &http.Server{
+		Addr:              net.JoinHostPort("", s.listenPort),
+		Handler:           s.mux,
+		ReadHeaderTimeout: readHeaderTimeout,
+		ReadTimeout:       readTimeout,
+		WriteTimeout:      writeTimeout,
+		IdleTimeout:       idleTimeout,
+		TLSConfig: &tls.Config{
+			Certificates: []tls.Certificate{certificate},
+			MinVersion:   tls.VersionTLS12,
+		},
+	}
+
+	listener, err := net.Listen("tcp", srv.Addr)
+	if err != nil {
+		return fmt.Errorf("listen for admission HTTPS server: %w", err)
+	}
+
+	serveErrCh := make(chan error, 1)
+
+	go func() {
+		serveErrCh <- srv.ServeTLS(listener, "", "")
+	}()
+
+	s.logger.Info("admission server started", slog.String("address", listener.Addr().String()))
+
+	select {
+	case err := <-serveErrCh:
+		if errors.Is(err, http.ErrServerClosed) && ctx.Err() != nil {
+			return nil
+		}
+
+		return fmt.Errorf("serve admission HTTPS server: %w", err)
+	case <-ctx.Done():
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), shutdownTimeout)
+	defer cancel()
+
+	shutdownErr := srv.Shutdown(shutdownCtx)
+	if shutdownErr != nil {
+		shutdownErr = fmt.Errorf("shut down admission HTTPS server: %w", shutdownErr)
+
+		if err := srv.Close(); err != nil {
+			shutdownErr = errors.Join(shutdownErr, fmt.Errorf("close admission HTTPS server: %w", err))
+		}
+	}
+
+	serveErr := <-serveErrCh
+	if !errors.Is(serveErr, http.ErrServerClosed) {
+		shutdownErr = errors.Join(shutdownErr, fmt.Errorf("serve admission HTTPS server: %w", serveErr))
+	}
+
+	if shutdownErr != nil {
+		return shutdownErr
+	}
+
+	s.logger.Info("admission server stopped")
+
+	return nil
+}

--- a/deckhouse-controller/pkg/controller/controller.go
+++ b/deckhouse-controller/pkg/controller/controller.go
@@ -302,7 +302,7 @@ func NewDeckhouseController(
 	dc := dependency.NewDependencyContainer()
 	settingsContainer := helpers.NewDeckhouseSettingsContainer(nil, operator.MetricStorage)
 
-	pkgRuntime, err := packageruntime.Build(runtimeManager.GetClient(), edition, operator.ModuleManager, dc, operator.MetricStorage, logger)
+	pkgRuntime, err := packageruntime.Build(runtimeManager.GetClient(), operator.ModuleManager, dc, operator.MetricStorage, logger)
 	if err != nil {
 		return nil, fmt.Errorf("create package operator: %w", err)
 	}


### PR DESCRIPTION
## Description

Adds the HTTPS transport that package admission handlers will be served from, as a new package
`deckhouse-controller/internal/packages/runtime/admission`. This PR lands the server only — no
handlers are registered and nothing constructs it yet, so runtime behaviour is unchanged.

**`admission.Server`** — three-method surface, no globals, logger injected as the last argument:

- `NewServer(listenPort, certsDir string, logger *log.Logger) *Server` — TLS material is read from
  `certsDir/tls.crt` and `certsDir/tls.key` at start time, not at construction, so the server can be
  built before cert-manager has populated the secret mount.
- `RegisterHandler(route string, handler http.Handler) error` — wraps `http.ServeMux.Handle`, whose
  contract is to **panic** on a duplicate or malformed pattern. Route registration happens during
  controller wiring, where a panic takes down the whole `deckhouse-controller` process; recovering
  and returning an error lets a wiring mistake fail the same way every other `RegisterController`
  failure does. A nil handler is rejected up front.
- `Start(ctx context.Context) error` — **blocking**, so the caller owns the goroutine and receives
  lifecycle errors instead of them disappearing into a fire-and-forget `go srv.ListenAndServe()`.
  Returns `nil` on a clean, context-driven stop.

Shutdown path, in order: on `ctx.Done()` a 5s graceful `Shutdown` runs under
`context.WithoutCancel(ctx)` (the parent is already cancelled, so a derived context would expire
immediately); if it fails, `Close()` force-closes and both errors are joined; the `ServeTLS` result
is then drained and joined unless it is the expected `http.ErrServerClosed`. Both a failed graceful
shutdown and a real serve error stay visible rather than one masking the other.

Hardening defaults: TLS 1.2 minimum, and read-header/read/write/idle timeouts (10s/60s/30s/120s) so
a stalled client cannot pin a connection indefinitely. The bound address is logged after `net.Listen`
succeeds, which also means a port conflict surfaces as an error from `Start` rather than as a
silently dead server.

**Incidental change:** `packageruntime.Build` no longer takes `*edition.Edition` — it calls
`edition.Parse(app.Version)` itself. Single call site (`pkg/controller/controller.go:305`) updated
accordingly. Note this leaves two `edition.Parse` calls in the process: `controller.go` still parses
one for the extenders stack. Happy to revert this hunk and keep passing the edition in if reviewers
prefer one parse.

No CRD, chart, RBAC or values change. Nothing is exposed on the network until the follow-up wires
the server up.

## Why do we need it, and what problem does it solve?

The package runtime needs to validate `Application`, `ApplicationPackage`, `PackageRepository` and
friends at admission time — rejecting a bad spec when it is submitted, instead of accepting it and
surfacing the failure later as a stuck package and a condition on the CR. Serving admission review
requires an HTTPS endpoint with a proper TLS keypair and a graceful lifecycle, and the runtime has
no such server today: `runtime/debug` serves a Unix socket, and the addon-operator side owns its own
listeners.

Landing the transport on its own keeps the follow-up PRs about validation semantics rather than
about `http.Server` plumbing, and keeps this one small enough to review the lifecycle carefully —
shutdown ordering and the panic-to-error boundary are exactly the details that are easy to get
subtly wrong and hard to notice in review when they arrive alongside handler logic.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: chore
summary: Add the admission HTTPS server to package runtime.
impact_level: low
```
