### PR TITLE
[deckhouse] add module v2 validating webhook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -672,9 +672,6 @@ manifests: controller-gen enrich-crds-local ## Generate WebhookConfiguration, Cl
 .PHONY: copy-crds
 copy-crds:
 	@echo "Copying CRDs to deckhouse-controller/crds..."
-	@cp bin/crd/bases/deckhouse.io_modules.yaml deckhouse-controller/crds/module.yaml
-	@cp bin/crd/bases/deckhouse.io_modulepackageversions.yaml deckhouse-controller/crds/modulepackageversion.yaml
-	@cp bin/crd/bases/deckhouse.io_modulepackages.yaml deckhouse-controller/crds/modulepackage.yaml
 	@cp bin/crd/bases/deckhouse.io_applications.yaml deckhouse-controller/crds/application.yaml
 	@cp bin/crd/bases/deckhouse.io_packagerepositoryoperations.yaml deckhouse-controller/crds/packagerepositoryoperation.yaml
 	@cp bin/crd/bases/deckhouse.io_packagerepositories.yaml deckhouse-controller/crds/packagerepository.yaml
@@ -682,6 +679,7 @@ copy-crds:
 	@cp bin/crd/bases/deckhouse.io_applicationpackages.yaml deckhouse-controller/crds/applicationpackage.yaml
 	@cp bin/crd/bases/deckhouse.io_modulepackageversions.yaml deckhouse-controller/crds/modulepackageversion.yaml
 	@cp bin/crd/bases/deckhouse.io_modulepackages.yaml deckhouse-controller/crds/modulepackage.yaml
+	@cp bin/crd/bases/deckhouse.io_modules.yaml deckhouse-controller/crds/module.yaml
 
 .PHONY: generate-crds
 generate-crds: controller-gen

--- a/Makefile
+++ b/Makefile
@@ -714,12 +714,6 @@ enrich-crds-local: generate-crds crd-enricher-local ## Enrich CRDs with the loca
 		dir=$(CURDIR) \
 		$(CRD_ENRICHER_FLAGS)
 
-.PHONY: crds
-crds:
-	make generate-crds
-	make enrich-crds-local
-	make copy-crds
-
 ## Run the crd-enricher module's unit and golden tests. Pass
 ## CRD_ENRICHER_TEST_FLAGS=-golden to regenerate the golden snapshots.
 ##

--- a/Makefile
+++ b/Makefile
@@ -672,6 +672,9 @@ manifests: controller-gen enrich-crds-local ## Generate WebhookConfiguration, Cl
 .PHONY: copy-crds
 copy-crds:
 	@echo "Copying CRDs to deckhouse-controller/crds..."
+	@cp bin/crd/bases/deckhouse.io_modules.yaml deckhouse-controller/crds/module.yaml
+	@cp bin/crd/bases/deckhouse.io_modulepackageversions.yaml deckhouse-controller/crds/modulepackageversion.yaml
+	@cp bin/crd/bases/deckhouse.io_modulepackages.yaml deckhouse-controller/crds/modulepackage.yaml
 	@cp bin/crd/bases/deckhouse.io_applications.yaml deckhouse-controller/crds/application.yaml
 	@cp bin/crd/bases/deckhouse.io_packagerepositoryoperations.yaml deckhouse-controller/crds/packagerepositoryoperation.yaml
 	@cp bin/crd/bases/deckhouse.io_packagerepositories.yaml deckhouse-controller/crds/packagerepository.yaml
@@ -712,6 +715,12 @@ enrich-crds-local: generate-crds crd-enricher-local ## Enrich CRDs with the loca
 		crds=$(CURDIR)/bin/crd/bases \
 		dir=$(CURDIR) \
 		$(CRD_ENRICHER_FLAGS)
+
+.PHONY: crds
+crds:
+	make generate-crds
+	make enrich-crds-local
+	make copy-crds
 
 ## Run the crd-enricher module's unit and golden tests. Pass
 ## CRD_ENRICHER_TEST_FLAGS=-golden to regenerate the golden snapshots.

--- a/deckhouse-controller/crds/doc-ru-module.yaml
+++ b/deckhouse-controller/crds/doc-ru-module.yaml
@@ -61,3 +61,121 @@ spec:
                   properties:
                     editions:
                       description: Настройки работы модуля в редакциях Deckhouse.
+    - name: v1alpha2
+      schema:
+        openAPIV3Schema:
+          description: |
+            Представляет экземпляр модуля, управляемый через систему пакетов.
+          properties:
+            spec:
+              description: |
+                Определяет поведение модуля.
+              properties:
+                packageName:
+                  description: |
+                    Название пакета модуля для установки.
+                packageRepositoryName:
+                  description: |
+                    Название репозитория, где находится пакет.
+                    Если не указано, используется репозиторий по умолчанию.
+                packageVersion:
+                  description: |
+                    Версия пакета модуля для установки.
+                releaseChannel:
+                  description: |
+                    Канал релиза для пакета модуля.
+                settings:
+                  description: |
+                    Настройки конфигурации для модуля.
+            status:
+              description: |
+                Статус модуля.
+              properties:
+                conditions:
+                  description: |
+                    Условия, отражающие последние наблюдения за состоянием модуля.
+                  items:
+                    description: |
+                      Условие, описывающее один аспект текущего состояния модуля.
+                    properties:
+                      lastTransitionTime:
+                        description: |
+                          Последнее время перехода условия из одного статуса в другой.
+                      message:
+                        description: |
+                          Человеко-читаемое сообщение, указывающее детали перехода.
+                      observedGeneration:
+                        description: |
+                          Значение `.metadata.generation`, на котором было установлено условие.
+                          Позволяет определить актуальность условия для текущего состояния ресурса.
+                      reason:
+                        description: |
+                          Программный идентификатор причины последнего перехода условия.
+                      status:
+                        description: |
+                          Статус условия. Может быть `True`, `False` или `Unknown`.
+                      type:
+                        description: |
+                          Тип условия в CamelCase или в формате `foo.example.com/CamelCase`.
+                currentVersion:
+                  description: |
+                    Информация о текущей установленной версии.
+                  properties:
+                    channel:
+                      description: |
+                        Канал релиза, из которого была установлена версия.
+                    version:
+                      description: |
+                        Семантическая версия установленного модуля.
+                internalConditions:
+                  description: |
+                    Внутренние условия модуля.
+                  items:
+                    description: |
+                      Условие, описывающее один аспект текущего состояния модуля.
+                    properties:
+                      lastTransitionTime:
+                        description: |
+                          Последнее время перехода условия из одного статуса в другой.
+                      message:
+                        description: |
+                          Человеко-читаемое сообщение, указывающее детали перехода.
+                      observedGeneration:
+                        description: |
+                          Значение `.metadata.generation`, на котором было установлено условие.
+                          Позволяет определить актуальность условия для текущего состояния ресурса.
+                      reason:
+                        description: |
+                          Программный идентификатор причины последнего перехода условия.
+                      status:
+                        description: |
+                          Статус условия. Может быть `True`, `False` или `Unknown`.
+                      type:
+                        description: |
+                          Тип условия в CamelCase или в формате `foo.example.com/CamelCase`.
+                resourceConditions:
+                  description: |
+                    Условия, связанные с ресурсами модуля.
+                  items:
+                    description: |
+                      Условие, описывающее один аспект текущего состояния модуля.
+                    properties:
+                      lastTransitionTime:
+                        description: |
+                          Последнее время перехода условия из одного статуса в другой.
+                      message:
+                        description: |
+                          Человеко-читаемое сообщение, указывающее детали перехода.
+                      observedGeneration:
+                        description: |
+                          Значение `.metadata.generation`, на котором было установлено условие.
+                          Позволяет определить актуальность условия для текущего состояния ресурса.
+                      reason:
+                        description: |
+                          Программный идентификатор причины последнего перехода условия.
+                      status:
+                        description: |
+                          Статус условия. Может быть `True`, `False` или `Unknown`.
+                      type:
+                        description: |
+                          Тип условия в CamelCase или в формате `foo.example.com/CamelCase`.

--- a/deckhouse-controller/crds/module.yaml
+++ b/deckhouse-controller/crds/module.yaml
@@ -1,207 +1,430 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: modules.deckhouse.io
   labels:
-    heritage: deckhouse
     app.kubernetes.io/name: deckhouse
     app.kubernetes.io/part-of: deckhouse
+    heritage: deckhouse
+  name: modules.deckhouse.io
 spec:
   group: deckhouse.io
-  scope: Cluster
   names:
+    kind: Module
     plural: modules
     singular: module
-    kind: Module
   preserveUnknownFields: false
+  scope: Cluster
   versions:
-    - name: v1alpha1
-      served: true
-      storage: true
-      schema:
-        openAPIV3Schema:
-          type: object
-          description: |
-            Describes the module's status in the cluster. The `Module` object is created automatically after configuring the [ModuleSource](#modulesource) and successfully completing synchronization.
-
+  - additionalPrinterColumns:
+    - description: Module weight
+      jsonPath: .properties.weight
+      name: Weight
+      priority: 1
+      type: integer
+    - description: Module stage
+      jsonPath: .properties.stage
+      name: Stage
+      type: string
+    - description: Release channel of the module.
+      jsonPath: .properties.releaseChannel
+      name: Release channel
+      priority: 1
+      type: string
+    - description: Source of the module it provided by one.
+      jsonPath: .properties.source
+      name: Source
+      type: string
+    - description: Module version.
+      jsonPath: .properties.version
+      name: Version
+      priority: 1
+      type: string
+    - description: Module phase.
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Module`s enabled status.
+      jsonPath: .status.conditions[?(@.type=='EnabledByModuleManager')].status
+      name: Enabled
+      type: string
+    - description: Module`s enabled information.
+      jsonPath: .status.conditions[?(@.type=='EnabledByModuleManager')].message
+      name: Disabled Message
+      priority: 1
+      type: string
+    - description: Module`s ready status.
+      jsonPath: .status.conditions[?(@.type=='IsReady')].status
+      name: Ready
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Describes the module's status in the cluster. The `Module` object
+          is created automatically after configuring the [ModuleSource](#modulesource)
+          and successfully completing synchronization.
+        properties:
           properties:
             properties:
-              type: object
-              properties:
-                availableSources:
-                  type: array
-                  description: Available sources for downloading the module.
-                  items:
+              accessibility:
+                description: Module accessibility settings.
+                properties:
+                  editions:
+                    additionalProperties:
+                      properties:
+                        available:
+                          type: boolean
+                        enabledInBundles:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    description: Module operation settings in Deckhouse editions.
+                    type: object
+                type: object
+              availableSources:
+                description: Available sources for downloading the module.
+                items:
+                  type: string
+                type: array
+              critical:
+                description: Indicates whether the module critical or not.
+                type: boolean
+              disableOptions:
+                description: Parameters of module disable protection.
+                properties:
+                  confirmation:
+                    type: boolean
+                  message:
+                    description: 'Deprecated: use Messages with localized ru/en fields
+                      instead.'
                     type: string
-                weight:
-                  type: integer
-                  description: Module _weight_ (priority).
-                namespace:
-                  type: string
-                  description: Module namespace.
-                subsystems:
-                  type: array
-                  description: Module subsystems.
-                  items:
+                  messages:
+                    description: |-
+                      Warning messages displayed when disabling the module, localized for different languages.
+                      If a message for the selected language is not defined, the value of the `message` field is used instead.
+                    properties:
+                      en:
+                        type: string
+                      ru:
+                        type: string
+                    type: object
+                type: object
+              exclusiveGroup:
+                description: Indicates the group where only one module can be active
+                  at a time.
+                type: string
+              namespace:
+                description: Module namespace.
+                type: string
+              releaseChannel:
+                description: Module release channel.
+                type: string
+              requirements:
+                description: Module dependencies, a set of requirements that must
+                  be met for Deckhouse Kubernetes Platform (DKP) to run the module.
+                properties:
+                  bootstrapped:
+                    description: Required cluster installation status (for built-in
+                      DKP modules only).
                     type: string
-                source:
+                  deckhouse:
+                    description: Required Deckhouse version.
+                    type: string
+                  kubernetes:
+                    description: Required Kubernetes version.
+                    type: string
+                  modules:
+                    additionalProperties:
+                      type: string
+                    description: A list of other enabled modules required for the
+                      module.
+                    type: object
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              source:
+                description: Source the module was downloaded from (otherwise will
+                  be blank).
+                type: string
+              stage:
+                description: Current stage of the module lifecycle.
+                type: string
+              subsystems:
+                description: Module subsystems.
+                items:
                   type: string
-                  description: Source the module was downloaded from (otherwise will be blank).
-                stage:
-                  type: string
-                  description: Current stage of the module lifecycle.
-                critical:
-                  type: boolean
-                  description: Indicates whether the module critical or not.
-                version:
-                  type: string
-                  description: Module version.
-                releaseChannel:
-                  type: string
-                  description: Module release channel.
-                exclusiveGroup:
-                  type: string
-                  description: Indicates the group where only one module can be active at a time.
-                updatePolicy:
-                  type: string
-                  description: Module update policy.
-                disableOptions:
-                  type: object
-                  description: Parameters of module disable protection.
+                type: array
+              updatePolicy:
+                description: Module update policy.
+                type: string
+              version:
+                description: Module version.
+                type: string
+              weight:
+                description: Module _weight_ (priority).
+                type: integer
+            type: object
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            properties:
+              conditions:
+                items:
                   properties:
-                    confirmation:
-                      type: boolean
+                    lastProbeTime:
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
                     message:
                       type: string
-                    messages:
-                      type: object
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  type: object
+                type: array
+                x-kubernetes-patch-merge-key: type
+                x-kubernetes-patch-strategy: merge
+              hooksState:
+                description: Hooks status report.
+                type: string
+              phase:
+                description: Module phase.
+                enum:
+                - Unavailable
+                - Available
+                - Downloading
+                - DownloadingError
+                - Reconciling
+                - Installing
+                - HooksDisabled
+                - WaitSyncTasks
+                - Downloaded
+                - Conflict
+                - Ready
+                - Error
+                type: string
+                x-doc-examples:
+                - Unavailable
+                - Available
+                - Downloading
+                - DownloadingError
+                - Reconciling
+                - Installing
+                - HooksDisabled
+                - WaitSyncTasks
+                - Downloaded
+                - Conflict
+                - Ready
+                - Error
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.packageVersion
+      name: Version
+      type: string
+    - jsonPath: .spec.packageRepositoryName
+      name: Repository
+      priority: 1
+      type: string
+    - jsonPath: .status.summary.state
+      name: State
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Installed')].status
+      name: Installed
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      priority: 1
+      type: string
+    - jsonPath: .status.summary.message
+      name: Message
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: Module represents a module instance managed via the package system.
+        properties:
+          spec:
+            description: Spec defines the behavior of a Module.
+            properties:
+              enabled:
+                description: Enables or disables the module. Unset leaves the decision
+                  to the platform.
+                type: boolean
+              maintenance:
+                description: |-
+                  Defines the module maintenance mode.
+
+                  - `NoResourceReconciliation`: A mode for developing or tweaking the module.
+
+                    In this mode:
+
+                    - Configuration or hook changes are not reconciled, which prevents resources from being updated automatically.
+                    - Resource monitoring is disabled, which prevents deleted resources from being restored.
+                    - All the module's resources are labeled with `maintenance: NoResourceReconciliation`.
+                    - The `ModuleIsInMaintenanceMode` alert is triggered.
+                enum:
+                - NoResourceReconciliation
+                type: string
+              packageRepositoryName:
+                description: |-
+                  Name of the repository where the package is located.
+                  If not specified, the default repository is used.
+                type: string
+                x-doc-examples:
+                - deckhouse
+              packageVersion:
+                description: Version of the module package to install
+                type: string
+                x-doc-examples:
+                - v1.0.0.
+              releaseChannel:
+                description: Release channel for the module package.
+                type: string
+              settings:
+                description: Configuration settings for the module.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              settingsVersion:
+                description: Version of the settings schema. Distinct from packageVersion,
+                  which selects the module package.
+                type: number
+            required:
+            - packageVersion
+            type: object
+          status:
+            description: Status of a Module.
+            properties:
+              conditions:
+                description: Conditions reflecting the latest observations of the
+                  application state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
                       description: |-
-                        Warning messages displayed when disabling the module, localized for different languages.
-                        
-                        If a message for the selected language is not defined, the value of the `message` field is used instead.
-                      properties:
-                        ru:
-                          type: string
-                        en:
-                          type: string
-                requirements:
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
                   type: object
-                  x-kubernetes-preserve-unknown-fields: true
-                  description: Module dependencies, a set of requirements that must be met for Deckhouse Kubernetes Platform (DKP) to run the module.
-                  properties:
-                    deckhouse:
-                      type: string
-                      description: Required Deckhouse version.
-                    kubernetes:
-                      type: string
-                      description: Required Kubernetes version.
-                    bootstrapped:
-                      type: string
-                      description: Required cluster installation status (for built-in DKP modules only).
-                    modules:
-                      type: object
-                      description: A list of other enabled modules required for the module.
-                      additionalProperties:
-                        type: string
-                accessibility:
-                  type: object
-                  description: Module accessibility settings.
-                  properties:
-                    editions:
-                      type: object
-                      description: Module operation settings in Deckhouse editions.
-                      additionalProperties:
-                        type: object
-                        properties:
-                          available:
-                            type: boolean
-                          enabledInBundles:
-                            type: array
-                            items:
-                              type: string
-            status:
-              type: object
-              properties:
-                phase:
-                  type: string
-                  description: Module phase.
-                  enum:
-                    - Unavailable
-                    - Available
-                    - Downloading
-                    - DownloadingError
-                    - Reconciling
-                    - Installing
-                    - HooksDisabled
-                    - WaitSyncTasks
-                    - Downloaded
-                    - Conflict
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              currentVersion:
+                description: Information about the currently installed version.
+                properties:
+                  channel:
+                    description: Release channel from which the version was installed.
+                    type: string
+                  version:
+                    description: Semantic version of the installed module.
+                    type: string
+                type: object
+              lastAppliedConfiguration:
+                description: |-
+                  LastAppliedConfiguration is the effective settings (user configuration merged
+                  with config-schema defaults) that drove the most recent successful apply.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              summary:
+                description: |-
+                  Summary aggregates the high-level user-facing state, message and
+                  resolution hint for the module. The controller always populates it
+                  on reconcile — every module maps to exactly one lifecycle state — so
+                  it is the single source of truth for the UI; clients should not re-derive
+                  these values from the conditions. The pointer leaves it absent only
+                  before the first status computation.
+                properties:
+                  message:
+                    description: Message is a human-readable description of the current
+                      state.
+                    type: string
+                  state:
+                    description: |-
+                      State is the high-level lifecycle state observed for the module.
+                      Always one of: Pending, Failed, Updating, Ready, Degraded, Suspended.
+                    type: string
+                    x-doc-examples:
+                    - Pending
+                    - Failed
+                    - Updating
                     - Ready
-                    - Error
-                hooksState:
-                  type: string
-                  description: Hooks status report.
-                conditions:
-                  x-kubernetes-patch-strategy: merge
-                  x-kubernetes-patch-merge-key: type
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      type:
-                        type: string
-                      status:
-                        type: string
-                      message:
-                        type: string
-                      reason:
-                        type: string
-                      lastTransitionTime:
-                        format: date-time
-                        type: string
-                      lastProbeTime:
-                        format: date-time
-                        type: string
-      subresources:
-        status: {}
-      additionalPrinterColumns:
-        - name: Weight
-          jsonPath: .properties.weight
-          type: integer
-          priority: 1
-          description: Module weight
-        - name: Stage
-          jsonPath: .properties.stage
-          type: string
-          description: Module stage
-        - name: Release channel
-          jsonPath: .properties.releaseChannel
-          description: Release channel of the module.
-          type: string
-          priority: 1
-        - name: Source
-          jsonPath: .properties.source
-          type: string
-          description: Source of the module it provided by one.
-        - name: Version
-          jsonPath: .properties.version
-          type: string
-          description: Module version.
-          priority: 1
-        - name: Phase
-          jsonPath: .status.phase
-          type: string
-          description: Module phase.
-        - name: Enabled
-          jsonPath: .status.conditions[?(@.type=='EnabledByModuleManager')].status
-          description: Module`s enabled status.
-          type: string
-        - name: Disabled Message
-          jsonPath: .status.conditions[?(@.type=='EnabledByModuleManager')].message
-          description: Module`s enabled information.
-          type: string
-          priority: 1
-        - name: Ready
-          jsonPath: .status.conditions[?(@.type=='IsReady')].status
-          description: Module`s ready status.
-          type: string
+                    - Degraded
+                    - Suspended
+                  tip:
+                    description: |-
+                      Tip is a human-readable instruction on how to resolve the current
+                      state. Empty when no action is required.
+                    type: string
+                type: object
+              tracking:
+                description: Nelm tracking.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}

--- a/deckhouse-controller/internal/packages/apps/app.go
+++ b/deckhouse-controller/internal/packages/apps/app.go
@@ -136,9 +136,8 @@ type Config struct {
 	GlobalValuesGetter GlobalValuesGetter
 }
 
-// GlobalValuesGetter returns the platform global values. With withPrefix=false the
-// bare global tree is returned; withPrefix=true wraps it under a "global" key.
-type GlobalValuesGetter func(withPrefix bool) addonutils.Values
+// GlobalValuesGetter returns the platform global values.
+type GlobalValuesGetter func() addonutils.Values
 
 // NewAppByConfig creates a new Application instance with the specified configuration.
 // It initializes hook storage, adds all discovered hooks, and creates values storage.
@@ -262,7 +261,7 @@ func (a *Application) GetRuntimeValues() string {
 	// global.<path> as .Platform.<path>.
 	var global addonutils.Values
 	if a.globalValuesGetter != nil {
-		global = a.globalValuesGetter(false)
+		global = a.globalValuesGetter()
 	}
 	marshalledPlatform, _ := json.Marshal(global)
 

--- a/deckhouse-controller/internal/packages/runtime/apps.go
+++ b/deckhouse-controller/internal/packages/runtime/apps.go
@@ -131,7 +131,7 @@ func (r *Runtime) loadApp(ctx context.Context, repo registry.Remote, packagePath
 	conf.ScheduleManager = r.scheduleManager
 	conf.KubeEventsManager = r.kubeEventsManager
 	conf.GrantResolver = r.grantResolver
-	conf.GlobalValuesGetter = r.addonModuleManager.GetGlobal().GetValues
+	conf.GlobalValuesGetter = r.global.GetValues
 
 	app, err := apps.NewAppByConfig(filepath.Base(packagePath), conf, r.logger)
 	if err != nil {

--- a/deckhouse-controller/internal/packages/runtime/embedded.go
+++ b/deckhouse-controller/internal/packages/runtime/embedded.go
@@ -125,6 +125,11 @@ func (r *Runtime) loadEmbedded(ctx context.Context) error {
 				return fmt.Errorf("load embedded conf: %w", err)
 			}
 
+			// skip node-manager for now
+			if conf.Definition.Name == "node-manager" {
+				return nil
+			}
+
 			conf.Patcher = r.objectPatcher
 			conf.ScheduleManager = r.scheduleManager
 			conf.KubeEventsManager = r.kubeEventsManager
@@ -149,6 +154,10 @@ func (r *Runtime) loadEmbedded(ctx context.Context) error {
 			r.status.SetConditionTrue(module.GetName(), status.ConditionReadyOnFilesystem)
 			r.status.SetConditionTrue(module.GetName(), status.ConditionLoaded)
 			r.status.UpdateVersion(module.GetName(), module.GetVersion().String())
+
+			if err := r.scheduler.AddNode(module); err != nil {
+				return fmt.Errorf("add node: %w", err)
+			}
 
 			return nil
 		})

--- a/deckhouse-controller/internal/packages/runtime/runtime.go
+++ b/deckhouse-controller/internal/packages/runtime/runtime.go
@@ -25,7 +25,6 @@ import (
 	"sync"
 
 	"github.com/Masterminds/semver/v3"
-	addonmodules "github.com/flant/addon-operator/pkg/module_manager/models/modules"
 	addonutils "github.com/flant/addon-operator/pkg/utils"
 	klient "github.com/flant/kube-client/client"
 	objectpatch "github.com/flant/shell-operator/pkg/kube/object_patch"
@@ -33,9 +32,6 @@ import (
 	schedulemanager "github.com/flant/shell-operator/pkg/schedule_manager"
 	"github.com/go-chi/chi/v5"
 	"go.opentelemetry.io/otel"
-	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/client-go/util/retry"
 	"k8s.io/client-go/util/workqueue"
 	runtimecache "sigs.k8s.io/controller-runtime/pkg/cache"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -67,7 +63,6 @@ import (
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/queue"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/registry"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/tools/verity"
-	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/edition"
 	"github.com/deckhouse/deckhouse/go_lib/dependency"
 	"github.com/deckhouse/deckhouse/pkg/log"
@@ -121,8 +116,6 @@ type Runtime struct {
 	apps     map[string]*apps.Application
 	modules  map[string]*modules.Module
 
-	addonModuleManager moduleManagerI
-
 	metricStorage metricsstorage.Storage // Publishes the application maintenance gauge
 
 	logger *log.Logger
@@ -135,15 +128,9 @@ type deployerI interface {
 	Cleanup(ctx context.Context, preserve []deployer.PreservePackage) error
 }
 
-// moduleManagerI provides access to global values for version getters and bootstrap checks.
-type moduleManagerI interface {
-	GetGlobal() *addonmodules.GlobalModule
-	IsModuleEnabled(name string) bool
-}
-
 // Build creates and initializes a Runtime with all subsystems wired together.
 // Blocks until the NELM cache completes its initial sync.
-func Build(cli kclient.Client, edition *edition.Edition, moduleManager moduleManagerI, dc dependency.Container, metricStorage metricsstorage.Storage, logger *log.Logger) (*Runtime, error) {
+func Build(cli kclient.Client, edition *edition.Edition, dc dependency.Container, metricStorage metricsstorage.Storage, logger *log.Logger) (*Runtime, error) {
 	r := new(Runtime)
 
 	r.apps = make(map[string]*apps.Application)
@@ -151,7 +138,6 @@ func Build(cli kclient.Client, edition *edition.Edition, moduleManager moduleMan
 	r.packages = lifecycle.NewStore()
 
 	// Initialize foundational services
-	r.addonModuleManager = moduleManager
 	r.grantResolver = grants.NewResolver(cli)
 	r.metricStorage = metricStorage
 	r.logger = logger.Named("package-runtime")
@@ -199,7 +185,11 @@ func Build(cli kclient.Client, edition *edition.Edition, moduleManager moduleMan
 	}
 
 	// Initialize scheduler with enabling/disabling callbacks
-	r.buildScheduler(cli)
+	r.buildScheduler()
+
+	if err := r.scheduler.AddNode(r.global); err != nil {
+		return nil, fmt.Errorf("add node: %w", err)
+	}
 
 	if err := r.loadEmbedded(context.Background()); err != nil {
 		return nil, fmt.Errorf("load embedded: %w", err)
@@ -497,9 +487,9 @@ func (r *Runtime) buildHealthService() error {
 //   - onDisable: Stops hooks and transitions package back to Loaded state
 //
 // The scheduler starts paused and is resumed after initial package loading completes.
-func (r *Runtime) buildScheduler(cli kclient.Client) {
+func (r *Runtime) buildScheduler() {
 	deckhouseVersionGetter := func() (*semver.Version, error) {
-		value, ok := r.addonModuleManager.GetGlobal().GetValues(false)[deckhouseVersionValue]
+		value, ok := r.global.GetValues()[deckhouseVersionValue]
 		if !ok {
 			return nil, fmt.Errorf("deckhouse version not found in global values")
 		}
@@ -517,7 +507,7 @@ func (r *Runtime) buildScheduler(cli kclient.Client) {
 	}
 
 	kubernetesVersionGetter := func() (*semver.Version, error) {
-		discovery := r.addonModuleManager.GetGlobal().GetValues(false).GetKeySection("discovery")
+		discovery := r.global.GetValues().GetKeySection("discovery")
 		if len(discovery) == 0 {
 			return nil, fmt.Errorf("discovery section not found in global values")
 		}
@@ -537,7 +527,7 @@ func (r *Runtime) buildScheduler(cli kclient.Client) {
 
 	// Bootstrap condition checks if cluster initialization is complete
 	bootstrapCondition := func() bool {
-		value, ok := r.addonModuleManager.GetGlobal().GetValues(false)[bootstrappedGlobalValue]
+		value, ok := r.global.GetValues()[bootstrappedGlobalValue]
 		if !ok {
 			return false
 		}
@@ -550,39 +540,11 @@ func (r *Runtime) buildScheduler(cli kclient.Client) {
 		return bootstrapped
 	}
 
-	// Dependency getter returns the version of enabled module
-	dependencyGetter := func(name string) *semver.Version {
-		if !r.addonModuleManager.IsModuleEnabled(name) {
-			return nil
-		}
-
-		module := new(v1alpha1.Module)
-		err := retry.OnError(retry.DefaultRetry, apierrors.IsServiceUnavailable, func() error {
-			return cli.Get(context.Background(), kclient.ObjectKey{Name: name}, module)
-		})
-		if err != nil {
-			return nil
-		}
-
-		// set a default version for modules overridden by ModulePullOverride (MPOS)
-		if module.IsCondition(v1alpha1.ModuleConditionIsOverridden, corev1.ConditionTrue) {
-			return semver.MustParse("v2.0.0")
-		}
-
-		version, err := semver.NewVersion(module.GetVersion())
-		if err != nil {
-			return nil
-		}
-
-		return version
-	}
-
 	r.scheduler = schedule.NewScheduler(
 		r.logger,
 		schedule.WithDynamicGetter(r.global.IsEnabled),
 		schedule.WithBundleChecker(r.edition.IsEnabled),
 		schedule.WithBootstrapCondition(bootstrapCondition),
-		schedule.WithDependencyGetter(dependencyGetter),
 		schedule.WithDeckhouseVersionGetter(deckhouseVersionGetter),
 		schedule.WithKubeVersionGetter(kubernetesVersionGetter))
 }

--- a/deckhouse-controller/internal/packages/schedule/node.go
+++ b/deckhouse-controller/internal/packages/schedule/node.go
@@ -171,7 +171,10 @@ func (s *Scheduler) addNode(pkg Package) {
 		n.rules = append(n.rules, condition.NewRule(s.bootstrapCondition, reasonRequirementsBootstrap, messageRequirementsBootstrap))
 	}
 
-	if len(constraints.Dependencies) > 0 && s.dependencyGetter != nil {
+	// The dependency gates read the graph itself through s.dependencyVersion, so
+	// they are always built — a package's declared dependencies are never
+	// silently unchecked.
+	if len(constraints.Dependencies) > 0 {
 		deps := make(map[string]dependency.Dependency, len(constraints.Dependencies))
 		for name, dep := range constraints.Dependencies {
 			deps[name] = dependency.Dependency{
@@ -180,15 +183,15 @@ func (s *Scheduler) addNode(pkg Package) {
 			}
 		}
 
-		n.rules = append(n.rules, dependency.NewRule(s.dependencyGetter, deps))
+		n.rules = append(n.rules, dependency.NewRule(s.dependencyVersion, deps))
 	}
 
-	if len(constraints.AnyOf) > 0 && s.dependencyGetter != nil {
-		n.rules = append(n.rules, dependency.NewAnyOfRule(s.dependencyGetter, toAnyOfGroups(constraints.AnyOf)))
+	if len(constraints.AnyOf) > 0 {
+		n.rules = append(n.rules, dependency.NewAnyOfRule(s.dependencyVersion, toAnyOfGroups(constraints.AnyOf)))
 	}
 
-	if len(constraints.NoneOf) > 0 && s.dependencyGetter != nil {
-		n.rules = append(n.rules, dependency.NewNoneOfRule(s.dependencyGetter, toNoneOfGroups(constraints.NoneOf)))
+	if len(constraints.NoneOf) > 0 {
+		n.rules = append(n.rules, dependency.NewNoneOfRule(s.dependencyVersion, toNoneOfGroups(constraints.NoneOf)))
 	}
 
 	// Modules (floor = Static(Disable)) trigger a full-graph reschedule when they

--- a/deckhouse-controller/internal/packages/schedule/rule/dependency/rule.go
+++ b/deckhouse-controller/internal/packages/schedule/rule/dependency/rule.go
@@ -44,7 +44,8 @@ type Dependency struct {
 	Optional bool
 }
 
-// Getter returns the installed version of a module, or nil when it is absent.
+// Getter returns the installed version of a module, or nil when it is absent or
+// not yet usable as a dependency — not enabled, or still being processed.
 type Getter func(module string) *semver.Version
 
 // NewRule constructs a dependency rule resolving versions through the getter.

--- a/deckhouse-controller/internal/packages/schedule/scheduler.go
+++ b/deckhouse-controller/internal/packages/schedule/scheduler.go
@@ -19,6 +19,8 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/Masterminds/semver/v3"
+
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/schedule/rule"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/schedule/rule/bundle"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/schedule/rule/condition"
@@ -64,7 +66,6 @@ type Scheduler struct {
 	eventCh chan Event
 
 	bundleChecker          bundle.BundleChecker
-	dependencyGetter       dependency.Getter
 	kubeVersionGetter      version.Getter      // Gets current Kubernetes version
 	deckhouseVersionGetter version.Getter      // Gets current Deckhouse version
 	bootstrapCondition     condition.Condition // Bootstrap readiness check
@@ -96,13 +97,6 @@ func WithDeckhouseVersionGetter(deckhouseVersionGetter version.Getter) Option {
 func WithBootstrapCondition(cond condition.Condition) Option {
 	return func(s *Scheduler) {
 		s.bootstrapCondition = cond
-	}
-}
-
-// WithDependencyGetter sets the provider for the current dependency version.
-func WithDependencyGetter(getter dependency.Getter) Option {
-	return func(s *Scheduler) {
-		s.dependencyGetter = getter
 	}
 }
 
@@ -189,7 +183,7 @@ func (s *Scheduler) CheckConstraints(name string, constraints Constraints) error
 		rules = append(rules, condition.NewRule(s.bootstrapCondition, reasonRequirementsBootstrap, messageRequirementsBootstrap))
 	}
 
-	if len(constraints.Dependencies) > 0 && s.dependencyGetter != nil {
+	if len(constraints.Dependencies) > 0 {
 		deps := make(map[string]dependency.Dependency, len(constraints.Dependencies))
 		for depName, dep := range constraints.Dependencies {
 			deps[depName] = dependency.Dependency{
@@ -198,15 +192,15 @@ func (s *Scheduler) CheckConstraints(name string, constraints Constraints) error
 			}
 		}
 
-		rules = append(rules, dependency.NewRule(s.dependencyGetter, deps))
+		rules = append(rules, dependency.NewRule(s.dependencyVersion, deps))
 	}
 
-	if len(constraints.AnyOf) > 0 && s.dependencyGetter != nil {
-		rules = append(rules, dependency.NewAnyOfRule(s.dependencyGetter, toAnyOfGroups(constraints.AnyOf)))
+	if len(constraints.AnyOf) > 0 {
+		rules = append(rules, dependency.NewAnyOfRule(s.dependencyVersion, toAnyOfGroups(constraints.AnyOf)))
 	}
 
-	if len(constraints.NoneOf) > 0 && s.dependencyGetter != nil {
-		rules = append(rules, dependency.NewNoneOfRule(s.dependencyGetter, toNoneOfGroups(constraints.NoneOf)))
+	if len(constraints.NoneOf) > 0 {
+		rules = append(rules, dependency.NewNoneOfRule(s.dependencyVersion, toNoneOfGroups(constraints.NoneOf)))
 	}
 
 	if d := rule.Resolve(rules...); d.Kind == rule.Forbid {
@@ -423,14 +417,31 @@ func (s *Scheduler) compute() ([]string, []*node) {
 	return enabled, sorted
 }
 
+// dependencyVersion answers the dependency rules from the graph itself: the
+// installed version of a node that is both enabled and active, nil otherwise.
+// Returning nil for a node that is merely enabled is what orders same-tier
+// dependents behind their dependencies — see canSchedule.
+//
+// Must be called with s.mu held in some mode. Every rule chain is resolved from
+// compute() (write lock) or CheckConstraints (read lock), so it never locks
+// itself: doing so would deadlock on Go's non-reentrant RWMutex.
+func (s *Scheduler) dependencyVersion(name string) *semver.Version {
+	n, ok := s.nodes[name]
+	if !ok || !n.enabled() || n.state != nodeStateActive {
+		return nil
+	}
+
+	return n.version
+}
+
 // canSchedule returns true if a node is eligible to transition from idle to
 // scheduled. Two conditions must hold:
 //  1. The node must be enabled (its rule chain resolved to Enable).
 //  2. All nodes with a strictly lower Order must be active.
 //
 // Dependency-level ordering between same-tier nodes is encoded in the rule
-// chain (the dependency.Getter contract returns versions only for nodes that
-// have reached nodeStateActive).
+// chain (dependencyVersion reports a version only for nodes that have reached
+// nodeStateActive).
 func (s *Scheduler) canSchedule(n *node) bool {
 	if !n.enabled() {
 		return false

--- a/deckhouse-controller/internal/packages/schedule/scheduler_test.go
+++ b/deckhouse-controller/internal/packages/schedule/scheduler_test.go
@@ -82,8 +82,7 @@ func mustVersion(s string) *semver.Version {
 type SchedulerSuite struct {
 	suite.Suite
 
-	versions map[string]*semver.Version
-	sched    *schedule.Scheduler
+	sched *schedule.Scheduler
 }
 
 // TestSchedulerSuite is the testing.T entry point that runs the suite.
@@ -91,17 +90,11 @@ func TestSchedulerSuite(t *testing.T) {
 	suite.Run(t, new(SchedulerSuite))
 }
 
-// SetupTest builds a fresh scheduler and version map for every test so cases
-// remain isolated. The dependency getter reads from s.versions, letting each
-// test simulate module presence/absence by direct map mutation.
+// SetupTest builds a fresh scheduler for every test so cases remain isolated.
+// Dependencies are resolved from the graph itself, so a test simulates module
+// presence with installPackage / uninstallPackage rather than a version map.
 func (s *SchedulerSuite) SetupTest() {
-	s.versions = make(map[string]*semver.Version)
-	s.sched = schedule.NewScheduler(
-		log.NewNop(),
-		schedule.WithDependencyGetter(func(name string) *semver.Version {
-			return s.versions[name]
-		}),
-	)
+	s.sched = schedule.NewScheduler(log.NewNop())
 }
 
 // TearDownTest closes the event channel so a leaked goroutine never wedges
@@ -125,6 +118,29 @@ func (s *SchedulerSuite) activateGlobal() {
 	s.sched.Resume()
 	s.sched.Complete(globalName)
 	s.drainEvents()
+}
+
+// installPackage registers a node and drives it to active, which is what the
+// scheduler's in-graph dependency resolution requires before the node counts as
+// installed for dependents. Order 0 keeps it in the global tier so it never
+// waits behind the package under test. Events are deliberately left buffered:
+// completing a dependency is what re-enables its dependents, and those events
+// are usually what the caller asserts on.
+func (s *SchedulerSuite) installPackage(name, version string) {
+	s.Require().NoError(s.sched.AddNode(&testPackage{
+		name:        name,
+		version:     mustVersion(version),
+		constraints: schedule.Constraints{Order: 0},
+	}))
+
+	s.sched.Complete(name)
+}
+
+// uninstallPackage drops a node from the graph — a package that disappears from
+// the cluster. Like installPackage it leaves events buffered, since the disable
+// cascade it triggers is what callers assert on.
+func (s *SchedulerSuite) uninstallPackage(name string) {
+	s.sched.RemoveNode(name)
 }
 
 // drainEvents non-blockingly empties the scheduler's event channel.
@@ -274,7 +290,7 @@ func (s *SchedulerSuite) TestMandatoryDependency() {
 	// stays out of the scheduled set.
 	s.NotContains(eventNames(s.collectEvents(), schedule.EventSchedule), "consumer")
 
-	s.versions["parent"] = mustVersion("1.0.0")
+	s.installPackage("parent", "1.0.0")
 	s.sched.Schedule()
 
 	s.Contains(eventNames(s.collectEvents(), schedule.EventSchedule), "consumer")
@@ -301,13 +317,102 @@ func (s *SchedulerSuite) TestConditionalDependencyAbsentIsOK() {
 	s.NotContains(eventNames(events, schedule.EventDisable), "consumer")
 }
 
+// TestSameTierDependencyWaitsForActive pins how the scheduler orders dependents
+// within one Order tier, where canSchedule's tier gate does not apply: a
+// dependency that is enabled but still being processed does not count as
+// installed, so its dependent fails the dependency gate and stays off until the
+// consumer calls Complete on the dependency.
+func (s *SchedulerSuite) TestSameTierDependencyWaitsForActive() {
+	s.activateGlobal()
+
+	s.Require().NoError(s.sched.AddNode(&testPackage{
+		name:        "provider",
+		version:     mustVersion("1.0.0"),
+		constraints: schedule.Constraints{Order: schedule.FunctionalOrder},
+	}))
+
+	s.Require().NoError(s.sched.AddNode(&testPackage{
+		name:    "consumer",
+		version: mustVersion("1.0.0"),
+		constraints: schedule.Constraints{
+			Order: schedule.FunctionalOrder,
+			Dependencies: map[string]schedule.Dependency{
+				"provider": {},
+			},
+		},
+	}))
+
+	scheduled := eventNames(s.collectEvents(), schedule.EventSchedule)
+	s.Contains(scheduled, "provider")
+	s.NotContains(scheduled, "consumer",
+		"a scheduled-but-not-active dependency must not satisfy its dependent")
+
+	s.sched.Complete("provider")
+
+	s.Contains(eventNames(s.collectEvents(), schedule.EventSchedule), "consumer",
+		"completing the dependency must release the dependent")
+}
+
+// TestDisabledDependencyDoesNotSatisfy covers a dependency that is present in
+// the graph but turned off: enablement, not mere presence, is what makes a node
+// count as an installed dependency.
+func (s *SchedulerSuite) TestDisabledDependencyDoesNotSatisfy() {
+	s.activateGlobal()
+
+	s.Require().NoError(s.sched.AddNode(&testPackage{
+		name:    "provider",
+		version: mustVersion("1.0.0"),
+		constraints: schedule.Constraints{
+			Order: schedule.FunctionalOrder,
+			Floor: rule.Static(rule.Disable),
+		},
+	}))
+
+	s.Require().NoError(s.sched.AddNode(&testPackage{
+		name:    "consumer",
+		version: mustVersion("1.0.0"),
+		constraints: schedule.Constraints{
+			Order: schedule.FunctionalOrder,
+			Dependencies: map[string]schedule.Dependency{
+				"provider": {},
+			},
+		},
+	}))
+
+	s.NotContains(eventNames(s.collectEvents(), schedule.EventSchedule), "consumer",
+		"a disabled dependency must not satisfy its dependent")
+}
+
+// TestDependencyConstraintCheckedAgainstGraphVersion proves the constraint is
+// evaluated against the dependency node's own version — the version the package
+// reported when it was registered — not against mere presence in the graph.
+func (s *SchedulerSuite) TestDependencyConstraintCheckedAgainstGraphVersion() {
+	s.activateGlobal()
+
+	s.installPackage("provider", "1.0.0")
+
+	s.Require().NoError(s.sched.AddNode(&testPackage{
+		name:    "consumer",
+		version: mustVersion("1.0.0"),
+		constraints: schedule.Constraints{
+			Order: schedule.FunctionalOrder,
+			Dependencies: map[string]schedule.Dependency{
+				"provider": {Constraint: mustConstraint(">=2.0.0")},
+			},
+		},
+	}))
+
+	s.NotContains(eventNames(s.collectEvents(), schedule.EventSchedule), "consumer",
+		"the graph version must be checked against the declared constraint")
+}
+
 // TestEnabledToDisabledFlipEmitsEventDisable verifies that compute() fires
 // EventDisable when a previously-enabled node loses eligibility (e.g. its
 // dependency is removed from the cluster).
 func (s *SchedulerSuite) TestEnabledToDisabledFlipEmitsEventDisable() {
 	s.activateGlobal()
 
-	s.versions["parent"] = mustVersion("1.0.0")
+	s.installPackage("parent", "1.0.0")
 	s.Require().NoError(s.sched.AddNode(&testPackage{
 		name:    "consumer",
 		version: mustVersion("1.0.0"),
@@ -322,7 +427,7 @@ func (s *SchedulerSuite) TestEnabledToDisabledFlipEmitsEventDisable() {
 	s.Contains(eventNames(s.collectEvents(), schedule.EventSchedule), "consumer")
 
 	// Parent disappears — consumer must flip enabled→disabled.
-	delete(s.versions, "parent")
+	s.uninstallPackage("parent")
 	s.sched.Schedule()
 
 	s.Contains(eventNames(s.collectEvents(), schedule.EventDisable), "consumer")
@@ -356,7 +461,7 @@ func (s *SchedulerSuite) TestStatusFlipResetsOnlyAffectedNode() {
 
 	// stable is now active. Flip flapper from disabled → enabled by installing
 	// its dep. compute() must reset flapper to idle but leave stable alone.
-	s.versions["absent"] = mustVersion("1.0.0")
+	s.installPackage("absent", "1.0.0")
 	s.sched.Schedule()
 
 	events := s.collectEvents()
@@ -418,22 +523,24 @@ func (s *SchedulerSuite) TestAddNodeRejectsCyclicAddition() {
 func (s *SchedulerSuite) TestCheckConstraintsRejectsDependencyCycle() {
 	s.activateGlobal()
 
-	// alpha depends on a future beta; no cycle yet (beta isn't in the graph).
+	// alpha depends on a future beta; no cycle yet (beta isn't in the graph). The
+	// edge is optional, and alpha is driven to active, so the proposed beta's dep
+	// on alpha is satisfied — CheckConstraints evaluates the gates before
+	// simulating the cycle, and a gate error is a plain error, not a *CycleError.
+	// Optional changes nothing about the edge: topological order comes from
+	// Dependencies regardless.
 	s.Require().NoError(s.sched.AddNode(&testPackage{
 		name:    "alpha",
 		version: mustVersion("1.0.0"),
 		constraints: schedule.Constraints{
 			Order: 1,
 			Dependencies: map[string]schedule.Dependency{
-				"beta": {},
+				"beta": {Optional: true},
 			},
 		},
 	}))
+	s.sched.Complete("alpha")
 	s.drainEvents()
-
-	// Populate versions so the dep checker chain passes (proposed beta's dep
-	// on alpha is satisfied); cycle simulation is what we want to evaluate.
-	s.versions["alpha"] = mustVersion("1.0.0")
 
 	// Proposed beta depends on alpha. Adding it would create alpha → beta → alpha.
 	err := s.sched.CheckConstraints("beta", schedule.Constraints{
@@ -482,7 +589,7 @@ func mustConstraint(s string) *semver.Constraints {
 func (s *SchedulerSuite) TestAnyOfSatisfiedMemberEnables() {
 	s.activateGlobal()
 
-	s.versions["gcp"] = mustVersion("1.5.0")
+	s.installPackage("gcp", "1.5.0")
 
 	s.Require().NoError(s.sched.AddNode(&testPackage{
 		name:    "consumer",
@@ -533,7 +640,7 @@ func (s *SchedulerSuite) TestAnyOfInstalledButConstraintFailsDisables() {
 	s.activateGlobal()
 
 	// gcp is installed but below the required floor; group is unmet.
-	s.versions["gcp"] = mustVersion("1.4.0")
+	s.installPackage("gcp", "1.4.0")
 
 	s.Require().NoError(s.sched.AddNode(&testPackage{
 		name:    "consumer",
@@ -559,7 +666,7 @@ func (s *SchedulerSuite) TestAnyOfInstalledButConstraintFailsDisables() {
 func (s *SchedulerSuite) TestAnyOfNilConstraintAcceptsAnyVersion() {
 	s.activateGlobal()
 
-	s.versions["gcp"] = mustVersion("0.0.1")
+	s.installPackage("gcp", "0.0.1")
 
 	s.Require().NoError(s.sched.AddNode(&testPackage{
 		name:    "consumer",
@@ -586,7 +693,7 @@ func (s *SchedulerSuite) TestAnyOfMultipleGroupsAllMustPass() {
 	s.activateGlobal()
 
 	// First group satisfied via gcp; second group has no installed members.
-	s.versions["gcp"] = mustVersion("1.5.0")
+	s.installPackage("gcp", "1.5.0")
 
 	s.Require().NoError(s.sched.AddNode(&testPackage{
 		name:    "consumer",
@@ -615,7 +722,7 @@ func (s *SchedulerSuite) TestAnyOfMultipleGroupsAllMustPass() {
 
 	// Installing a member of the second group satisfies all groups; consumer
 	// schedules on the next pass.
-	s.versions["minio"] = mustVersion("2.0.0")
+	s.installPackage("minio", "2.0.0")
 	s.sched.Schedule()
 
 	s.Contains(eventNames(s.collectEvents(), schedule.EventSchedule), "consumer")
@@ -728,7 +835,7 @@ func (s *SchedulerSuite) TestAnyOfMemberInstallTriggersReschedule() {
 
 	s.NotContains(eventNames(s.collectEvents(), schedule.EventSchedule), "consumer")
 
-	s.versions["gcp"] = mustVersion("1.5.0")
+	s.installPackage("gcp", "1.5.0")
 	s.sched.Schedule()
 
 	s.Contains(eventNames(s.collectEvents(), schedule.EventSchedule), "consumer")
@@ -764,7 +871,7 @@ func (s *SchedulerSuite) TestNoneOfInstalledNilConstraintViolated() {
 	s.activateGlobal()
 
 	// Forbidden module is installed at any version — group violated from birth.
-	s.versions["haproxy-legacy"] = mustVersion("0.0.1")
+	s.installPackage("haproxy-legacy", "0.0.1")
 
 	s.Require().NoError(s.sched.AddNode(&testPackage{
 		name:    "consumer",
@@ -790,7 +897,7 @@ func (s *SchedulerSuite) TestNoneOfInstalledInForbiddenRangeViolated() {
 	s.activateGlobal()
 
 	// 1.9.0 matches "<2.0.0" — falls in the forbidden range.
-	s.versions["nginx-ingress-legacy"] = mustVersion("1.9.0")
+	s.installPackage("nginx-ingress-legacy", "1.9.0")
 
 	s.Require().NoError(s.sched.AddNode(&testPackage{
 		name:    "consumer",
@@ -817,7 +924,7 @@ func (s *SchedulerSuite) TestNoneOfInstalledOutsideForbiddenRangeEnables() {
 	s.activateGlobal()
 
 	// 2.0.0 is outside the "<2.0.0" forbidden range — group passes.
-	s.versions["nginx-ingress-legacy"] = mustVersion("2.0.0")
+	s.installPackage("nginx-ingress-legacy", "2.0.0")
 
 	s.Require().NoError(s.sched.AddNode(&testPackage{
 		name:    "consumer",
@@ -843,7 +950,7 @@ func (s *SchedulerSuite) TestNoneOfMultipleGroupsAllMustPass() {
 	s.activateGlobal()
 
 	// Second group violated via deprecated-storage.
-	s.versions["deprecated-storage"] = mustVersion("1.0.0")
+	s.installPackage("deprecated-storage", "1.0.0")
 
 	s.Require().NoError(s.sched.AddNode(&testPackage{
 		name:    "consumer",
@@ -870,7 +977,7 @@ func (s *SchedulerSuite) TestNoneOfMultipleGroupsAllMustPass() {
 	s.NotContains(eventNames(s.collectEvents(), schedule.EventSchedule), "consumer")
 
 	// Removing the violator from the second group enables the consumer.
-	delete(s.versions, "deprecated-storage")
+	s.uninstallPackage("deprecated-storage")
 	s.sched.Schedule()
 
 	s.Contains(eventNames(s.collectEvents(), schedule.EventSchedule), "consumer")
@@ -921,7 +1028,7 @@ func (s *SchedulerSuite) TestNoneOfDoesNotCreateDependencyEdge() {
 func (s *SchedulerSuite) TestCheckConstraintsNoneOfRejectsAtAdmission() {
 	s.activateGlobal()
 
-	s.versions["haproxy-legacy"] = mustVersion("1.0.0")
+	s.installPackage("haproxy-legacy", "1.0.0")
 
 	err := s.sched.CheckConstraints("proposed", schedule.Constraints{
 		Order: schedule.FunctionalOrder,
@@ -961,7 +1068,7 @@ func (s *SchedulerSuite) TestNoneOfMemberInstallTriggersDisable() {
 	s.Contains(eventNames(s.collectEvents(), schedule.EventSchedule), "consumer")
 
 	// Forbidden module appears; consumer must flip enabled→disabled.
-	s.versions["haproxy-legacy"] = mustVersion("1.0.0")
+	s.installPackage("haproxy-legacy", "1.0.0")
 	s.sched.Schedule()
 
 	s.Contains(eventNames(s.collectEvents(), schedule.EventDisable), "consumer")
@@ -1078,9 +1185,6 @@ func (s *SchedulerSuite) useDynamicScheduler() map[string]*bool {
 	s.sched.Stop()
 	s.sched = schedule.NewScheduler(
 		log.NewNop(),
-		schedule.WithDependencyGetter(func(name string) *semver.Version {
-			return s.versions[name]
-		}),
 		schedule.WithDynamicGetter(func(module string) *bool {
 			return enabledState[module]
 		}),
@@ -1142,9 +1246,6 @@ func (s *SchedulerSuite) TestDynamicRuleDisableOverridesBundle() {
 	s.sched.Stop()
 	s.sched = schedule.NewScheduler(
 		log.NewNop(),
-		schedule.WithDependencyGetter(func(name string) *semver.Version {
-			return s.versions[name]
-		}),
 		// Bundle enables every module it is asked about.
 		schedule.WithBundleChecker(func(edition.Licensing) bool { return true }),
 		schedule.WithDynamicGetter(func(module string) *bool {

--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/register.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/register.go
@@ -78,6 +78,7 @@ func RegisterAdmissionHandlers(
 	reg.RegisterHandler("/validate/v1/deckhouse-registry-secret", withInvalidReason(RegistrySecretHandler()))
 	reg.RegisterHandler("/validate/v1alpha1/module-configs", withInvalidReason(moduleConfigValidationHandler(cli, storage, metricStorage, mm, validator, settings, exts.GetModuleDependency(), edition)))
 	reg.RegisterHandler("/validate/v1alpha1/modules", withInvalidReason(moduleValidationHandler()))
+	reg.RegisterHandler("/validate/v1alpha2/modules", withInvalidReason(moduleV1alpha2ValidationHandler(cli)))
 	reg.RegisterHandler("/validate/v1/configuration-secret", withInvalidReason(clusterConfigurationHandler(mm, cli, schemaStore)))
 	reg.RegisterHandler("/validate/v1/provider-configuration-secret", withInvalidReason(providerConfigurationHandler(schemaStore)))
 	reg.RegisterHandler("/validate/v1/static-configuration-secret", withInvalidReason(staticConfigurationHandler(schemaStore)))

--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module.go
@@ -28,10 +28,15 @@ import (
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
 )
 
+// deckhouseServiceAccount is the identity the deckhouse controller talks to the
+// API server with. It owns the Module resource in both served versions, so its
+// own writes are exempt from the manual-change restrictions.
+const deckhouseServiceAccount = "system:serviceaccount:d8-system:deckhouse"
+
 func moduleValidationHandler() http.Handler {
 	vf := kwhvalidating.ValidatorFunc(func(_ context.Context, review *model.AdmissionReview, _ metav1.Object) (*kwhvalidating.ValidatorResult, error) {
 		// UserInfo groups: [system:serviceaccounts system:serviceaccounts:d8-system system:authenticated]
-		if review.UserInfo.Username != "system:serviceaccount:d8-system:deckhouse" {
+		if review.UserInfo.Username != deckhouseServiceAccount {
 			return rejectResult("manual Module change is forbidden")
 		}
 

--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module_test.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module_test.go
@@ -17,7 +17,12 @@ limitations under the License.
 package validation
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,11 +31,13 @@ import (
 	authenticationv1 "k8s.io/api/authentication/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
+	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha2"
 )
-
-const deckhouseServiceAccount = "system:serviceaccount:d8-system:deckhouse"
 
 func newModuleAdmissionReview(operation, username string, module *v1alpha1.Module) *admissionv1.AdmissionReview {
 	review := &admissionv1.AdmissionReview{
@@ -128,4 +135,136 @@ func TestModuleValidationHandler(t *testing.T) {
 			assert.Contains(t, resp.Result.Message, tt.wantMessage)
 		})
 	}
+}
+
+// TestModuleV1alpha2ValidationHandler verifies that a module whose ModuleConfig exists
+// can be neither changed nor deleted by hand, that both are allowed without a config, and
+// that the deckhouse service account is exempt.
+func TestModuleV1alpha2ValidationHandler(t *testing.T) {
+	const moduleName = "test-module"
+
+	module := &v1alpha2.Module{ObjectMeta: metav1.ObjectMeta{Name: moduleName}}
+	moduleConfig := &v1alpha1.ModuleConfig{ObjectMeta: metav1.ObjectMeta{Name: moduleName}}
+
+	tests := []struct {
+		name        string
+		operation   string
+		username    string
+		withConfig  bool
+		wantAllowed bool
+		wantMessage string
+	}{
+		{
+			name:        "editing a module managed by a module config is forbidden",
+			operation:   "UPDATE",
+			username:    "kubernetes-admin",
+			withConfig:  true,
+			wantAllowed: false,
+			wantMessage: "manual Module change is forbidden",
+		},
+		{
+			name:        "editing a module without a module config is allowed",
+			operation:   "UPDATE",
+			username:    "kubernetes-admin",
+			wantAllowed: true,
+		},
+		{
+			name:        "deleting a module managed by a module config is forbidden",
+			operation:   "DELETE",
+			username:    "kubernetes-admin",
+			withConfig:  true,
+			wantAllowed: false,
+			wantMessage: "manual Module deletion is forbidden",
+		},
+		{
+			name:        "deleting a module without a module config is allowed",
+			operation:   "DELETE",
+			username:    "kubernetes-admin",
+			wantAllowed: true,
+		},
+		{
+			name:        "deckhouse service account is exempt",
+			operation:   "UPDATE",
+			username:    deckhouseServiceAccount,
+			withConfig:  true,
+			wantAllowed: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var objs []client.Object
+			if tt.withConfig {
+				objs = append(objs, moduleConfig)
+			}
+
+			handler := moduleV1alpha2ValidationHandler(newFakeClient(t, objs...))
+			resp := callHandler(t, handler, newModuleV1alpha2AdmissionReview(t, tt.operation, tt.username, module))
+
+			if tt.wantAllowed {
+				assert.True(t, resp.Allowed)
+				return
+			}
+
+			require.False(t, resp.Allowed)
+			require.NotNil(t, resp.Result)
+			assert.Contains(t, resp.Result.Message, tt.wantMessage)
+		})
+	}
+}
+
+// TestModuleV1alpha2ValidationHandler_ConfigLookupFails covers the case the webhook's
+// failurePolicy: Fail exists for: when the module config cannot be read, the handler
+// must surface an error rather than mistake it for an absent module config and allow
+// the change.
+func TestModuleV1alpha2ValidationHandler_ConfigLookupFails(t *testing.T) {
+	module := &v1alpha2.Module{ObjectMeta: metav1.ObjectMeta{Name: "test-module"}}
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1alpha1.AddToScheme(scheme))
+	require.NoError(t, v1alpha2.AddToScheme(scheme))
+
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+				return errors.New("connection refused")
+			},
+		}).
+		Build()
+
+	handler := moduleV1alpha2ValidationHandler(cli)
+	review := newModuleV1alpha2AdmissionReview(t, "UPDATE", "kubernetes-admin", module)
+
+	body, err := json.Marshal(review)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/validate", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, req)
+
+	assert.Equal(t, http.StatusInternalServerError, recorder.Code)
+}
+
+func newModuleV1alpha2AdmissionReview(t *testing.T, operation, username string, module *v1alpha2.Module) *admissionv1.AdmissionReview {
+	t.Helper()
+
+	review := newModuleAdmissionReview(operation, username, nil)
+
+	raw, err := json.Marshal(module)
+	require.NoError(t, err)
+
+	// on delete the API server sends the object in oldObject, kubewebhook falls back
+	// to it when object is empty
+	if operation == "DELETE" {
+		review.Request.OldObject = runtime.RawExtension{Raw: raw}
+
+		return review
+	}
+
+	review.Request.Object = runtime.RawExtension{Raw: raw}
+
+	return review
 }

--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module_v1alpha2.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module_v1alpha2.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	kwhhttp "github.com/slok/kubewebhook/v2/pkg/http"
+	"github.com/slok/kubewebhook/v2/pkg/model"
+	kwhvalidating "github.com/slok/kubewebhook/v2/pkg/webhook/validating"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
+	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha2"
+)
+
+// moduleV1alpha2ValidationHandler keeps a module read-only while a module config for it
+// exists: the config owns the module spec and its reconciler syncs it on every reconcile,
+// so a manual change would silently be overwritten. Without a config the module is the
+// user's to manage.
+//
+// Creation is not restricted, so the webhook is registered for updates and deletions only.
+func moduleV1alpha2ValidationHandler(cli client.Client) http.Handler {
+	vf := kwhvalidating.ValidatorFunc(func(ctx context.Context, review *model.AdmissionReview, obj metav1.Object) (*kwhvalidating.ValidatorResult, error) {
+		// the deckhouse controller owns the resource, it reconciles modules and keeps
+		// their spec in sync with the module config
+		if review.UserInfo.Username == deckhouseServiceAccount {
+			return allowResult(nil)
+		}
+
+		module, ok := obj.(*v1alpha2.Module)
+		if !ok {
+			return nil, fmt.Errorf("expect Module as v1alpha2, got %T", obj)
+		}
+
+		// The module config and the module share their name. A lookup failure other than
+		// not found is returned as an error, which the webhook serves as an HTTP 500 so
+		// that the API server applies its failure policy: an unreadable module config
+		// must not pass for an absent one.
+		cfg := new(v1alpha1.ModuleConfig)
+		if err := cli.Get(ctx, client.ObjectKey{Name: module.Name}, cfg); err != nil {
+			if !apierrors.IsNotFound(err) {
+				return nil, fmt.Errorf("get the '%s' module config: %w", module.Name, err)
+			}
+
+			return allowResult(nil)
+		}
+
+		if review.Operation == model.OperationDelete {
+			return rejectResult(fmt.Sprintf("manual Module deletion is forbidden, the '%s' module is managed by its ModuleConfig", module.Name))
+		}
+
+		return rejectResult(fmt.Sprintf("manual Module change is forbidden, the '%s' module is managed by its ModuleConfig, change it there instead", module.Name))
+	})
+
+	// Create webhook.
+	wh, _ := kwhvalidating.NewWebhook(kwhvalidating.WebhookConfig{
+		ID:        "module-v1alpha2-operations",
+		Validator: vf,
+		// logger is nil, because webhook has Info level for reporting about http handler
+		// and we get a log of useless spam here. So we decided to use Noop logger here
+		Logger: nil,
+		Obj:    &v1alpha2.Module{},
+	})
+
+	return kwhhttp.MustHandlerFor(kwhhttp.HandlerConfig{Webhook: wh, Logger: nil})
+}

--- a/deckhouse-controller/pkg/controller/controller.go
+++ b/deckhouse-controller/pkg/controller/controller.go
@@ -304,7 +304,7 @@ func NewDeckhouseController(
 	dc := dependency.NewDependencyContainer()
 	settingsContainer := helpers.NewDeckhouseSettingsContainer(nil, operator.MetricStorage)
 
-	pkgRuntime, err := packageruntime.Build(runtimeManager.GetClient(), edition, operator.ModuleManager, dc, operator.MetricStorage, logger)
+	pkgRuntime, err := packageruntime.Build(runtimeManager.GetClient(), edition, dc, operator.MetricStorage, logger)
 	if err != nil {
 		return nil, fmt.Errorf("create package operator: %w", err)
 	}

--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -280,6 +280,15 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return r.deleteRelease(ctx, release)
 	}
 
+	// Materialize the release in the package system as a draft version (best
+	// effort): promotion is owned by the module-package-version controller, and
+	// a failed attempt retries on the next reconcile of this release.
+	if app.ModulePackagesEnabled() {
+		if err := r.ensureModulePackageVersion(ctx, release); err != nil {
+			r.log.Warn("failed to ensure module package version", slog.String("release", release.GetName()), log.Err(err))
+		}
+	}
+
 	// handle create/update events
 	res, err := r.handleRelease(ctx, release)
 	if err != nil {
@@ -1949,4 +1958,79 @@ func (r *reconciler) isModuleReady(ctx context.Context, moduleName string) bool 
 	}
 
 	return module.Status.Phase == v1alpha1.ModulePhaseReady
+}
+
+// ensureModulePackageVersion materializes the release in the package system as
+// a draft ModulePackageVersion if one does not exist yet. The version carries
+// the legacy label: release images live under the "<module>/release" registry
+// path and describe themselves with module.yaml, which is what the promotion
+// pipeline in the module-package-version controller expects from legacy
+// packages. spec.packageRepositoryName is the release's ModuleSource name — the
+// draft stays unpromoted until a PackageRepository with that name exists.
+func (r *reconciler) ensureModulePackageVersion(ctx context.Context, release *v1alpha1.ModuleRelease) error {
+	logger := r.log.With(slog.String("release", release.GetName()))
+
+	// A release without a source cannot name its repository; there is nothing
+	// to retry until the release gets one.
+	source := release.GetModuleSource()
+	if source == "" {
+		logger.Warn("module release has no module source, skip the package version")
+		return nil
+	}
+
+	// Normalize the version the way the repository scan does ("v" + canonical
+	// semver). Spec.Version is not schema-validated as semver, so a broken
+	// value must not panic the reconciler (the release's GetVersion would).
+	parsed, err := semver.NewVersion(release.Spec.Version)
+	if err != nil {
+		logger.Warn("module release version is not semver, skip the package version",
+			slog.String("version", release.Spec.Version), log.Err(err))
+		return nil
+	}
+	version := "v" + parsed.String()
+
+	name := v1alpha1.MakeModulePackageVersionName(source, release.GetModuleName(), version)
+
+	mpv := new(v1alpha1.ModulePackageVersion)
+	err = r.client.Get(ctx, client.ObjectKey{Name: name}, mpv)
+	if err == nil {
+		return nil
+	}
+	if !apierrors.IsNotFound(err) {
+		return fmt.Errorf("get module package version '%s': %w", name, err)
+	}
+
+	mpv = &v1alpha1.ModulePackageVersion{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1alpha1.ModulePackageVersionGVK.GroupVersion().String(),
+			Kind:       v1alpha1.ModulePackageVersionKind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				"heritage": "deckhouse",
+				v1alpha1.ModulePackageVersionLabelRepository: source,
+				v1alpha1.ModulePackageVersionLabelPackage:    release.GetModuleName(),
+				v1alpha1.ModulePackageVersionLabelDraft:      "true",
+				v1alpha1.ModulePackageVersionLabelLegacy:     "true",
+			},
+		},
+		Spec: v1alpha1.ModulePackageVersionSpec{
+			PackageName:           release.GetModuleName(),
+			PackageVersion:        version,
+			PackageRepositoryName: source,
+		},
+	}
+
+	if err = r.client.Create(ctx, mpv); err != nil {
+		// Another reconcile won the race; the version exists — done.
+		if apierrors.IsAlreadyExists(err) {
+			return nil
+		}
+		return fmt.Errorf("create module package version '%s': %w", name, err)
+	}
+
+	logger.Info("created draft module package version", slog.String("mpv", name))
+
+	return nil
 }

--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -280,15 +280,6 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return r.deleteRelease(ctx, release)
 	}
 
-	// Materialize the release in the package system as a draft version (best
-	// effort): promotion is owned by the module-package-version controller, and
-	// a failed attempt retries on the next reconcile of this release.
-	if app.ModulePackagesEnabled() {
-		if err := r.ensureModulePackageVersion(ctx, release); err != nil {
-			r.log.Warn("failed to ensure module package version", slog.String("release", release.GetName()), log.Err(err))
-		}
-	}
-
 	// handle create/update events
 	res, err := r.handleRelease(ctx, release)
 	if err != nil {
@@ -1958,79 +1949,4 @@ func (r *reconciler) isModuleReady(ctx context.Context, moduleName string) bool 
 	}
 
 	return module.Status.Phase == v1alpha1.ModulePhaseReady
-}
-
-// ensureModulePackageVersion materializes the release in the package system as
-// a draft ModulePackageVersion if one does not exist yet. The version carries
-// the legacy label: release images live under the "<module>/release" registry
-// path and describe themselves with module.yaml, which is what the promotion
-// pipeline in the module-package-version controller expects from legacy
-// packages. spec.packageRepositoryName is the release's ModuleSource name — the
-// draft stays unpromoted until a PackageRepository with that name exists.
-func (r *reconciler) ensureModulePackageVersion(ctx context.Context, release *v1alpha1.ModuleRelease) error {
-	logger := r.log.With(slog.String("release", release.GetName()))
-
-	// A release without a source cannot name its repository; there is nothing
-	// to retry until the release gets one.
-	source := release.GetModuleSource()
-	if source == "" {
-		logger.Warn("module release has no module source, skip the package version")
-		return nil
-	}
-
-	// Normalize the version the way the repository scan does ("v" + canonical
-	// semver). Spec.Version is not schema-validated as semver, so a broken
-	// value must not panic the reconciler (the release's GetVersion would).
-	parsed, err := semver.NewVersion(release.Spec.Version)
-	if err != nil {
-		logger.Warn("module release version is not semver, skip the package version",
-			slog.String("version", release.Spec.Version), log.Err(err))
-		return nil
-	}
-	version := "v" + parsed.String()
-
-	name := v1alpha1.MakeModulePackageVersionName(source, release.GetModuleName(), version)
-
-	mpv := new(v1alpha1.ModulePackageVersion)
-	err = r.client.Get(ctx, client.ObjectKey{Name: name}, mpv)
-	if err == nil {
-		return nil
-	}
-	if !apierrors.IsNotFound(err) {
-		return fmt.Errorf("get module package version '%s': %w", name, err)
-	}
-
-	mpv = &v1alpha1.ModulePackageVersion{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: v1alpha1.ModulePackageVersionGVK.GroupVersion().String(),
-			Kind:       v1alpha1.ModulePackageVersionKind,
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-			Labels: map[string]string{
-				"heritage": "deckhouse",
-				v1alpha1.ModulePackageVersionLabelRepository: source,
-				v1alpha1.ModulePackageVersionLabelPackage:    release.GetModuleName(),
-				v1alpha1.ModulePackageVersionLabelDraft:      "true",
-				v1alpha1.ModulePackageVersionLabelLegacy:     "true",
-			},
-		},
-		Spec: v1alpha1.ModulePackageVersionSpec{
-			PackageName:           release.GetModuleName(),
-			PackageVersion:        version,
-			PackageRepositoryName: source,
-		},
-	}
-
-	if err = r.client.Create(ctx, mpv); err != nil {
-		// Another reconcile won the race; the version exists — done.
-		if apierrors.IsAlreadyExists(err) {
-			return nil
-		}
-		return fmt.Errorf("create module package version '%s': %w", name, err)
-	}
-
-	logger.Info("created draft module package version", slog.String("mpv", name))
-
-	return nil
 }

--- a/modules/002-deckhouse/templates/admission/validation.yaml
+++ b/modules/002-deckhouse/templates/admission/validation.yaml
@@ -40,6 +40,10 @@ webhooks:
         namespace: d8-system
         port: 4223
         path: /validate/v1/deckhouse-registry-secret
+{{/* Modules are served in two versions, each validated by its own webhook below. */}}
+{{/*   matchPolicy must stay Exact on both: with Equivalent the API server converts */}}
+{{/*   a request for one version and delivers it to the other version's webhook too, */}}
+{{/*   so both would fire on every write and the stricter verdict would always win. */}}
   - name: modules.deckhouse-webhook.deckhouse.io
     rules:
       - apiGroups:
@@ -55,7 +59,7 @@ webhooks:
         scope: Cluster
     admissionReviewVersions:
       - v1
-    matchPolicy: Equivalent
+    matchPolicy: Exact
     failurePolicy: Ignore
     sideEffects: None
     clientConfig:
@@ -65,6 +69,32 @@ webhooks:
         namespace: d8-system
         port: 4223
         path: /validate/v1alpha1/modules
+  - name: modules-v1alpha2.deckhouse-webhook.deckhouse.io
+    rules:
+      - apiGroups:
+          - "deckhouse.io"
+        apiVersions:
+          - "v1alpha2"
+        resources:
+          - "modules"
+        operations:
+          - UPDATE
+          - DELETE
+        scope: Cluster
+    admissionReviewVersions:
+      - v1
+    matchPolicy: Exact
+{{/* Fail, unlike the v1alpha1 webhook above: an unreadable module config is served */}}
+{{/*   as an error, and only Fail keeps it from passing for an absent module config. */}}
+    failurePolicy: Fail
+    sideEffects: None
+    clientConfig:
+      caBundle: {{ .Values.deckhouse.internal.admissionWebhookCert.ca | b64enc }}
+      service:
+        name: deckhouse
+        namespace: d8-system
+        port: 4223
+        path: /validate/v1alpha2/modules
   - name: module-configs.deckhouse-webhook.deckhouse.io
     rules:
       - apiGroups:

--- a/modules/002-deckhouse/templates/deployment.yaml
+++ b/modules/002-deckhouse/templates/deployment.yaml
@@ -107,7 +107,7 @@ spec:
         {{- .Values.deckhouse.tolerations | toYaml | nindent 8 }}
         - key: node.deckhouse.io/bashible-uninitialized
           operator: "Exists"
-          effect: "NoSchedule"        
+          effect: "NoSchedule"
         - key: node.deckhouse.io/uninitialized
           operator: "Exists"
           effect: "NoSchedule"
@@ -197,7 +197,7 @@ spec:
             - name: DECKHOUSE_ENABLE_PACKAGE_SYSTEM
               value: "true"
             - name: DECKHOUSE_ENABLE_MODULE_PACKAGES
-              value: "false"
+              value: "true"
             - name: USE_NELM
               value: "true"
             # Adopt fields owned by the legacy "deckhouse-controller" field manager


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Adds a validating webhook for `modules.deckhouse.io/v1alpha2` at `/validate/v1alpha2/modules`.

| Operation | ModuleConfig exists | No ModuleConfig |
|---|---|---|
| `UPDATE` | rejected | allowed |
| `DELETE` | rejected | allowed |

Creation is not restricted, so the rule does not list `CREATE`. The `deckhouse` service account is exempt — it
reconciles Modules and keeps their spec in sync with the ModuleConfig.

A failed ModuleConfig lookup is answered with an error rather than an allow, and the rule uses
`failurePolicy: Fail`, so a Module cannot be changed during a window in which the check could not run.

`matchPolicy` on the existing `modules` webhook changes from `Equivalent` to `Exact`. Both versions of the
resource now have their own webhook, and under `Equivalent` the API server also delivers a request for one
version to the other version's webhook, so both would fire on every write.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
While a ModuleConfig exists it owns the module spec — its reconciler syncs it on every reconcile — so a manual
change is silently overwritten. Admission rejects the change and points at the ModuleConfig instead of leaving
the user to discover that their edit disappeared.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: feature
summary: add module v2 validating webhook
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->



