### PR TITLE
[cloud-provider-openstack] Make openstack CCM work in VK cloud 

### DIFF
--- a/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/patches/1.34/005-fallback-octavia-version-discovery.patch
+++ b/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/patches/1.34/005-fallback-octavia-version-discovery.patch
@@ -1,0 +1,91 @@
+diff --git a/pkg/client/service.go b/pkg/client/service.go
+index e5c47d7..f3bccd0 100644
+--- a/pkg/client/service.go
++++ b/pkg/client/service.go
+@@ -18,9 +18,12 @@ package client
+ 
+ import (
+ 	"fmt"
++	"strings"
+ 
+ 	"github.com/gophercloud/gophercloud/v2"
+ 	"github.com/gophercloud/gophercloud/v2/openstack"
++	tokens2 "github.com/gophercloud/gophercloud/v2/openstack/identity/v2/tokens"
++	tokens3 "github.com/gophercloud/gophercloud/v2/openstack/identity/v3/tokens"
+ )
+ 
+ // NewNetworkV2 creates a ServiceClient that may be used with the neutron v2 API
+@@ -56,11 +59,73 @@ func NewLoadBalancerV2(provider *gophercloud.ProviderClient, eo *gophercloud.End
+ 	var err error
+ 	lb, err = openstack.NewLoadBalancerV2(provider, *eo)
+ 	if err != nil {
++		if strings.Contains(err.Error(), "invalid format") {
++			lb, fallbackErr := newLoadBalancerV2FromCatalog(provider, *eo)
++			if fallbackErr == nil {
++				return lb, nil
++			}
++			return nil, fmt.Errorf("failed to find load-balancer v2 %s endpoint for region %s: %v (fallback from service catalog failed: %v)", eo.Availability, eo.Region, err, fallbackErr)
++		}
+ 		return nil, fmt.Errorf("failed to find load-balancer v2 %s endpoint for region %s: %v", eo.Availability, eo.Region, err)
+ 	}
+ 	return lb, nil
+ }
+ 
++func newLoadBalancerV2FromCatalog(provider *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
++	eo.ApplyDefaults("load-balancer")
++	if eo.Version != 0 && eo.Version != 2 {
++		return nil, fmt.Errorf("conflict between requested service major version and manually set version")
++	}
++	eo.Version = 2
++
++	authResult := provider.GetAuthResult()
++	if authResult == nil {
++		return nil, fmt.Errorf("no auth result available")
++	}
++
++	var endpoint string
++	var err error
++	switch result := authResult.(type) {
++	case tokens2.CreateResult:
++		catalog, catalogErr := result.ExtractServiceCatalog()
++		if catalogErr != nil {
++			return nil, catalogErr
++		}
++		endpoint, err = openstack.V2EndpointURL(catalog, eo)
++	case tokens3.CreateResult:
++		catalog, catalogErr := result.ExtractServiceCatalog()
++		if catalogErr != nil {
++			return nil, catalogErr
++		}
++		endpoint, err = openstack.V3EndpointURL(catalog, eo)
++	case tokens3.GetResult:
++		catalog, catalogErr := result.ExtractServiceCatalog()
++		if catalogErr != nil {
++			return nil, catalogErr
++		}
++		endpoint, err = openstack.V3EndpointURL(catalog, eo)
++	default:
++		return nil, fmt.Errorf("unsupported auth result type %T", authResult)
++	}
++	if err != nil {
++		return nil, err
++	}
++
++	// The OpenStack Octavia API paths used by gophercloud are rooted at /v2.0/.
++	// VK Cloud may publish patch-level discovery versions like v2.14.1, which
++	// gophercloud v2.8.0 cannot parse, so this fallback intentionally skips
++	// version discovery and uses the catalog endpoint directly.
++	endpoint = gophercloud.NormalizeURL(endpoint)
++	resourceBase := strings.Replace(endpoint, "v2.0/", "", -1) + "v2.0/"
++
++	return &gophercloud.ServiceClient{
++		ProviderClient: provider,
++		Endpoint:       endpoint,
++		ResourceBase:   resourceBase,
++		Type:           "load-balancer",
++	}, nil
++}
++
+ // NewKeyManagerV1 creates a ServiceClient that can be used with KeyManager v1 API
+ func NewKeyManagerV1(provider *gophercloud.ProviderClient, eo *gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
+ 	secret, err := openstack.NewKeyManagerV1(provider, *eo)


### PR DESCRIPTION
+

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
