### PR TITLE
[user-authz] Fix validating webhooks

### DIFF
--- a/modules/140-user-authz/webhooks/validating/multitenancy.py
+++ b/modules/140-user-authz/webhooks/validating/multitenancy.py
@@ -17,6 +17,14 @@
 
 # This hook checks the MultiTenancy flag for the user-authz module.
 #
+# The effective value of enableMultiTenancy is read from the Module CR
+# (deckhouse.io/v1alpha2) status.lastAppliedConfiguration, which contains
+# the user configuration merged with config-schema defaults. This is
+# necessary because in some editions (e.g. CSE) enableMultiTenancy defaults
+# to true, and when the user has not explicitly set it in the ModuleConfig,
+# the field is absent from spec.settings — but the effective value is still
+# true.
+#
 # - If the flag is enabled — we just exit.
 #
 # - If the flag is disabled — we check the ClusterAuthorizationRule (CAR) resource being created or updated
@@ -36,13 +44,13 @@ from deckhouse import hook
 from dotmap import DotMap
 
 SEPARATOR = "; "
-MODULE_CONFIG_SNAPSHOT_NAME = "d8-user-authz-moduleconfig" 
+MODULE_SNAPSHOT_NAME = "d8-user-authz-module"
 CLUSTER_AUTH_RULES_SNAPSHOT_NAME = "d8-user-authz-cars"
 CONFIG = f"""
 configVersion: v1
 kubernetesValidating:
 - name: d8-user-authz-car-multitenancy-related-options.deckhouse.io
-  includeSnapshotsFrom: ["{MODULE_CONFIG_SNAPSHOT_NAME}"]
+  includeSnapshotsFrom: ["{MODULE_SNAPSHOT_NAME}"]
   rules:
   - apiGroups:   ["deckhouse.io"]
     apiVersions: ["*"]
@@ -59,15 +67,19 @@ kubernetesValidating:
     apiVersions: ["*"]
     resources: ["moduleconfigs"]
     operations: ["CREATE", "UPDATE"]
-    scope: "Cluster"
+    scope:       "Cluster"
 
 kubernetes:
-- name: {MODULE_CONFIG_SNAPSHOT_NAME}
-  apiVersion: deckhouse.io/v1alpha1
-  kind: ModuleConfig
+- name: {MODULE_SNAPSHOT_NAME}
+  apiVersion: deckhouse.io/v1alpha2
+  kind: Module
   executeHookOnEvent: []
   executeHookOnSynchronization: true
-  keepFullObjectsInMemory: true
+  keepFullObjectsInMemory: false
+  jqFilter: |
+    {{
+      "enableMultiTenancy": .status.lastAppliedConfiguration.enableMultiTenancy
+    }}
   nameSelector:
     matchNames:
     - user-authz
@@ -98,8 +110,8 @@ def validate(ctx: DotMap) -> tuple[list[str], list[str]]:
 
     if kind == "clusterauthorizationrule":
         # don't check ClusterAuthorizationRule if user-authz MultiTenancy option is enabled
-        moduleconfig_snapshot = ctx.snapshots[MODULE_CONFIG_SNAPSHOT_NAME]
-        if len(moduleconfig_snapshot) != 0 and moduleconfig_snapshot[0].object.spec.settings.enableMultiTenancy is True:
+        module_snapshot = ctx.snapshots[MODULE_SNAPSHOT_NAME]
+        if len(module_snapshot) != 0 and module_snapshot[0].filterResult.enableMultiTenancy is True:
             return [], []
 
         return validate_car_multitenancy_related_fields(req.object)
@@ -135,7 +147,7 @@ def validate_car_multitenancy_related_fields(obj: DotMap) -> tuple[list[str], li
         if field in obj.spec:
             errors.append(
                 f"You must enable userAuthz.enableMultiTenancy to use the {description} "
-                f"in ClusterAuthorizationRule '{resource_name}' (EE Only)"
+                f"in ClusterAuthorizationRule '{resource_name}'"
             )
 
     return errors, []

--- a/modules/140-user-authz/webhooks/validating/multitenancy_test.py
+++ b/modules/140-user-authz/webhooks/validating/multitenancy_test.py
@@ -41,9 +41,9 @@ class TestMultiTenancyValidationForCarsAndModuleConfig(unittest.TestCase):
         ]:
             with self.subTest(title=scenario):
                 tests.assert_validation_deny(self, self.run_hook(ctx_json), '; '.join([
-                    "You must enable userAuthz.enableMultiTenancy to use the allowAccessToSystemNamespaces flag in ClusterAuthorizationRule 'user1' (EE Only)",
-                    "You must enable userAuthz.enableMultiTenancy to use the namespaceSelector option in ClusterAuthorizationRule 'user1' (EE Only)",
-                    "You must enable userAuthz.enableMultiTenancy to use the limitNamespaces option in ClusterAuthorizationRule 'user1' (EE Only)",
+                    "You must enable userAuthz.enableMultiTenancy to use the allowAccessToSystemNamespaces flag in ClusterAuthorizationRule 'user1'",
+                    "You must enable userAuthz.enableMultiTenancy to use the namespaceSelector option in ClusterAuthorizationRule 'user1'",
+                    "You must enable userAuthz.enableMultiTenancy to use the limitNamespaces option in ClusterAuthorizationRule 'user1'",
                 ]))
 
     def test_car_allowed_when_multitenancy_disabled_and_no_multitenancy_related_fields(self):
@@ -63,6 +63,14 @@ class TestMultiTenancyValidationForCarsAndModuleConfig(unittest.TestCase):
     def test_car_allowed_when_multitenancy_enabled_and_multitenancy_related_fields_used(self):
         for scenario, ctx_json in [
             ['enableMultiTenancy is True',
+             factories.prepare_car_binding_context(
+                car_restricted_multitenancy_fields=True, module_enable_multitenancy_field=True)
+            ],
+            # CSE edition: enableMultiTenancy defaults to true in the schema.
+            # The ModuleConfig has no explicit enableMultiTenancy field, but
+            # the Module CR status.lastAppliedConfiguration reflects the
+            # effective value (true) after merging with schema defaults.
+            ['enableMultiTenancy is True via schema default (CSE edition)',
              factories.prepare_car_binding_context(
                 car_restricted_multitenancy_fields=True, module_enable_multitenancy_field=True)
             ],
@@ -93,12 +101,12 @@ class TestMultiTenancyValidationForCarsAndModuleConfig(unittest.TestCase):
         ]:
              with self.subTest(scenario):
                 tests.assert_validation_deny(self, self.run_hook(ctx_json), "; ".join([
-                    "You must enable userAuthz.enableMultiTenancy to use the allowAccessToSystemNamespaces flag in ClusterAuthorizationRule 'user1' (EE Only)",
-                    "You must enable userAuthz.enableMultiTenancy to use the namespaceSelector option in ClusterAuthorizationRule 'user1' (EE Only)",
-                    "You must enable userAuthz.enableMultiTenancy to use the limitNamespaces option in ClusterAuthorizationRule 'user1' (EE Only)",
-                    "You must enable userAuthz.enableMultiTenancy to use the allowAccessToSystemNamespaces flag in ClusterAuthorizationRule 'user3' (EE Only)",
-                    "You must enable userAuthz.enableMultiTenancy to use the namespaceSelector option in ClusterAuthorizationRule 'user3' (EE Only)",
-                    "You must enable userAuthz.enableMultiTenancy to use the limitNamespaces option in ClusterAuthorizationRule 'user3' (EE Only)",
+                    "You must enable userAuthz.enableMultiTenancy to use the allowAccessToSystemNamespaces flag in ClusterAuthorizationRule 'user1'",
+                    "You must enable userAuthz.enableMultiTenancy to use the namespaceSelector option in ClusterAuthorizationRule 'user1'",
+                    "You must enable userAuthz.enableMultiTenancy to use the limitNamespaces option in ClusterAuthorizationRule 'user1'",
+                    "You must enable userAuthz.enableMultiTenancy to use the allowAccessToSystemNamespaces flag in ClusterAuthorizationRule 'user3'",
+                    "You must enable userAuthz.enableMultiTenancy to use the namespaceSelector option in ClusterAuthorizationRule 'user3'",
+                    "You must enable userAuthz.enableMultiTenancy to use the limitNamespaces option in ClusterAuthorizationRule 'user3'",
                 ]))
 
     def test_module_config_allowed_when_multitenancy_disabled_and_no_cars_have_multitenancy_related_fields(self):

--- a/modules/140-user-authz/webhooks/validating/multitenancy_test.py
+++ b/modules/140-user-authz/webhooks/validating/multitenancy_test.py
@@ -158,4 +158,3 @@ class TestMultiTenancyValidationForCarsAndModuleConfig(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-

--- a/modules/140-user-authz/webhooks/validating/multitenancy_test.py
+++ b/modules/140-user-authz/webhooks/validating/multitenancy_test.py
@@ -158,3 +158,4 @@ class TestMultiTenancyValidationForCarsAndModuleConfig(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+

--- a/modules/140-user-authz/webhooks/validating/multitenancy_test_factories.py
+++ b/modules/140-user-authz/webhooks/validating/multitenancy_test_factories.py
@@ -161,92 +161,10 @@ def prepare_car_binding_context(
         }}
       }},
       "snapshots": {{
-        "d8-user-authz-moduleconfig": [
+        "d8-user-authz-module": [
           {{
-            "object": {{
-              "apiVersion": "deckhouse.io/v1alpha1",
-              "kind": "ModuleConfig",
-              "metadata": {{
-                "creationTimestamp": "2025-07-29T02:01:51Z",
-                "finalizers": [
-                  "modules.deckhouse.io/module-registered"
-                ],
-                "generation": 19,
-                "managedFields": [
-                  {{
-                    "apiVersion": "deckhouse.io/v1alpha1",
-                    "fieldsType": "FieldsV1",
-                    "fieldsV1": {{
-                      "f:spec": {{
-                        ".": {{}},
-                        "f:enabled": {{}},
-                        "f:version": {{}}
-                      }}
-                    }},
-                    "manager": "dhctl",
-                    "operation": "Update",
-                    "time": "2025-07-29T02:01:51Z"
-                  }},
-                  {{
-                    "apiVersion": "deckhouse.io/v1alpha1",
-                    "fieldsType": "FieldsV1",
-                    "fieldsV1": {{
-                      "f:metadata": {{
-                        "f:finalizers": {{
-                          ".": {{}}
-                        }}
-                      }}
-                    }},
-                    "manager": "deckhouse-controller",
-                    "operation": "Update",
-                    "time": "2025-07-29T02:02:28Z"
-                  }},
-                  {{
-                    "apiVersion": "deckhouse.io/v1alpha1",
-                    "fieldsType": "FieldsV1",
-                    "fieldsV1": {{
-                      "f:status": {{
-                        ".": {{}},
-                        "f:message": {{}},
-                        "f:version": {{}}
-                      }}
-                    }},
-                    "manager": "deckhouse-controller",
-                    "operation": "Update",
-                    "subresource": "status",
-                    "time": "2025-07-29T02:02:28Z"
-                  }},
-                  {{
-                    "apiVersion": "deckhouse.io/v1alpha1",
-                    "fieldsType": "FieldsV1",
-                    "fieldsV1": {{
-                      "f:spec": {{
-                        "f:settings": {{
-                          ".": {{}},
-                          "f:enableMultiTenancy": {{}}
-                        }}
-                      }}
-                    }},
-                    "manager": "kubectl-edit",
-                    "operation": "Update",
-                    "time": "2025-07-29T23:27:00Z"
-                  }}
-                ],
-                "name": "user-authz",
-                "resourceVersion": "663947",
-                "uid": "71324cad-b74b-45ce-b122-1040558471ee"
-              }},
-              "spec": {{
-                "enabled": true,
-                "settings": {{
-                  {'' if module_enable_multitenancy_field is None else ('"enableMultiTenancy": true' if module_enable_multitenancy_field else '"enableMultiTenancy": false')}
-                }},
-                "version": 1
-              }},
-              "status": {{
-                "message": "",
-                "version": "1"
-              }}
+            "filterResult": {{
+              {'' if module_enable_multitenancy_field is None else ('"enableMultiTenancy": true' if module_enable_multitenancy_field else '"enableMultiTenancy": false')}
             }}
           }}
         ]


### PR DESCRIPTION
## Description
Refactored the multitenancy validating webhook to read `enableMultiTenancy` from the Module `v1alpha2` CR (`status.lastAppliedConfiguration`) instead of `ModuleConfig.spec.settings`.
Also removed the incorrect "(EE Only)" suffix from error messages.

## Why do we need it, and what problem does it solve?

In some editions (e.g. CSE), `enableMultiTenancy` defaults to `true` in the OpenAPI schema. When a user has not explicitly set this parameter in the ModuleConfig, the field is absent from `spec.settings` — but the effective value is still `true`. The webhook was reading from `ModuleConfig.spec.settings`, causing it to treat multitenancy as disabled when it was actually enabled by default.

The fix uses the `Module` v1alpha2 CR's `status.lastAppliedConfiguration`, which contains the user config merged with schema defaults — the effective runtime configuration.

Additionally, the "(EE Only)" label was inaccurate since multitenancy is available in multiple editions (BE, SE, SE+, EE, CSE-lite, CSE-pro), not just EE.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authz
type: fix
summary: Fix multitenancy validatiing webhook to read effective enableMultiTenancy from the Module `v1alpha2` CR 
impact_level: default
```