### PR TITLE
[dhctl] Derive node group specs after CloudProviderVars is resolved

### DIFF
--- a/dhctl/pkg/config/base_test.go
+++ b/dhctl/pkg/config/base_test.go
@@ -1169,3 +1169,61 @@ func testCreateDeckhouseRegistrySecret(t *testing.T, kubeCl *client.KubernetesCl
 	_, err := kubeCl.CoreV1().Secrets("d8-system").Create(t.Context(), secret, metav1.CreateOptions{})
 	require.NoError(t, err)
 }
+
+// The mc-flow bootstrap path in one piece: NodeGroup documents have no schema,
+// so they land in ResourcesYAML, from where Prepare must derive the typed node
+// group fields. Without them dhctl bootstraps a single master and no workers.
+func TestParseConfigFromDataCloudDerivesNodeGroups(t *testing.T) {
+	config := `
+---
+apiVersion: deckhouse.io/v1
+kind: ClusterConfiguration
+clusterType: Cloud
+cloud:
+  provider: DVP
+  prefix: test
+kubernetesVersion: "Automatic"
+podSubnetCIDR: 10.222.0.0/16
+serviceSubnetCIDR: 10.111.0.0/16
+---
+apiVersion: deckhouse.io/v1
+kind: InitConfiguration
+deckhouse:
+   imagesRepo: test
+   devBranch: test
+   # {"auths": { "test": {}}}
+   registryDockerCfg: eyJhdXRocyI6IHsgInRlc3QiOiB7fX19
+---
+apiVersion: deckhouse.io/v1
+kind: NodeGroup
+metadata:
+  name: master
+spec:
+  nodeType: CloudPermanent
+  cloudInstances:
+    minPerZone: 1
+    classReference:
+      kind: DVPInstanceClass
+      name: master-dvp
+---
+apiVersion: deckhouse.io/v1
+kind: NodeGroup
+metadata:
+  name: worker
+spec:
+  nodeType: CloudPermanent
+  cloudInstances:
+    minPerZone: 1
+    classReference:
+      kind: DVPInstanceClass
+      name: worker-dvp
+`
+
+	metaConfig, err := ParseConfigFromData(t.Context(), config, DummyValidatorProvider(), nil)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, metaConfig.MasterNodeGroupSpec.Replicas)
+	require.Len(t, metaConfig.TerraNodeGroupSpecs, 1)
+	require.Equal(t, "worker", metaConfig.TerraNodeGroupSpecs[0].Name)
+	require.Equal(t, 1, metaConfig.TerraNodeGroupSpecs[0].Replicas)
+}

--- a/dhctl/pkg/config/meta.go
+++ b/dhctl/pkg/config/meta.go
@@ -174,14 +174,23 @@ func (m *MetaConfig) Prepare(ctx context.Context, validatorProvider MetaConfigVa
 		return nil, err
 	}
 
+	// Derive replica counts from the cluster NodeGroups in CloudProviderVars,
+	// the only source of them when PCC carries no nodeGroups (mc-flow). Must
+	// run after CloudProviderVars is resolved above: with it still nil the
+	// typed fields stay zeroed and bootstrap creates neither the additional
+	// masters nor any CloudPermanent node. Re-entrant by the guards inside —
+	// check and converge re-run Prepare on a DeepCopy of a prepared config.
+	applyNodeGroupReplicasFromCloudProviderVars(m)
+
 	return validateProviderConfig(ctx, validatorProvider, m)
 }
 
 // extractProviderClusterFields populates the typed Layout, MasterNodeGroupSpec
-// and TerraNodeGroupSpecs from PCC (legacy flow), falling back to
-// CloudProviderVars.NodeGroups when PCC is empty (mc-flow). For providers that
-// require PCC a missing field fails fast instead of running converge with
-// zeroed typed fields.
+// and TerraNodeGroupSpecs from PCC. For providers that require PCC a missing
+// field fails fast instead of running converge with zeroed typed fields. When
+// PCC carries no nodeGroups (mc-flow) the specs come from
+// applyNodeGroupReplicasFromCloudProviderVars, which Prepare calls once
+// CloudProviderVars is known.
 func (m *MetaConfig) extractProviderClusterFields() error {
 	pccRequired := ProviderRequiresClusterConfig(m.ProviderName)
 	pccPresent := len(m.ProviderClusterConfig) > 0
@@ -213,9 +222,6 @@ func (m *MetaConfig) extractProviderClusterFields() error {
 	// "nodeGroups" is not required even for whitelisted providers: a
 	// master-only cluster is legitimate.
 
-	// mc-flow: derive replica counts from cluster NodeGroups, otherwise the
-	// zeroed typed fields misroute converge into "decrease to 0" logic.
-	applyNodeGroupReplicasFromCloudProviderVars(m)
 	return nil
 }
 

--- a/dhctl/pkg/config/meta_test.go
+++ b/dhctl/pkg/config/meta_test.go
@@ -584,3 +584,134 @@ func TestApplyModuleConfigSettings_TakesFullModuleConfig(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, float64(3), masterPool["replicas"])
 }
+
+// mcFlowResources mirrors a DVP bootstrap config: the CloudPermanent node
+// groups live in the resources documents, not in a ProviderClusterConfiguration.
+const mcFlowResources = `
+apiVersion: deckhouse.io/v1
+kind: NodeGroup
+metadata:
+  name: master
+spec:
+  nodeType: CloudPermanent
+  cloudInstances:
+    minPerZone: 3
+    classReference:
+      kind: DVPInstanceClass
+      name: master-dvp
+---
+apiVersion: deckhouse.io/v1
+kind: NodeGroup
+metadata:
+  name: worker
+spec:
+  nodeType: CloudPermanent
+  cloudInstances:
+    minPerZone: 2
+    classReference:
+      kind: DVPInstanceClass
+      name: worker-dvp
+  nodeTemplate:
+    labels:
+      node-role: worker
+---
+apiVersion: deckhouse.io/v1
+kind: NodeGroup
+metadata:
+  name: system
+spec:
+  nodeType: CloudPermanent
+  cloudInstances:
+    minPerZone: 1
+    classReference:
+      kind: DVPInstanceClass
+      name: worker-dvp
+---
+apiVersion: deckhouse.io/v1
+kind: NodeGroup
+metadata:
+  name: ephemeral
+spec:
+  nodeType: CloudEphemeral
+  cloudInstances:
+    minPerZone: 5
+    maxPerZone: 7
+    classReference:
+      kind: DVPInstanceClass
+      name: worker-dvp
+`
+
+func cloudMetaConfig(resourcesYAML string) *MetaConfig {
+	return &MetaConfig{
+		ClusterConfig: map[string]json.RawMessage{
+			"clusterType":       json.RawMessage(`"Cloud"`),
+			"serviceSubnetCIDR": json.RawMessage(`"10.222.0.0/16"`),
+			"clusterDomain":     json.RawMessage(`"cluster.local"`),
+			"cloud":             json.RawMessage(`{"provider":"DVP","prefix":"test"}`),
+		},
+		ResourcesYAML: resourcesYAML,
+	}
+}
+
+func TestPrepareDerivesNodeGroupsFromResources(t *testing.T) {
+	m, err := cloudMetaConfig(mcFlowResources).Prepare(t.Context(), DummyValidatorProvider())
+	require.NoError(t, err)
+
+	require.Equal(t, 3, m.MasterNodeGroupSpec.Replicas)
+
+	require.Len(t, m.TerraNodeGroupSpecs, 2, "master is not a terra node group, CloudEphemeral is not provisioned by dhctl")
+	require.Equal(t, "system", m.TerraNodeGroupSpecs[0].Name)
+	require.Equal(t, 1, m.TerraNodeGroupSpecs[0].Replicas)
+	require.Equal(t, "worker", m.TerraNodeGroupSpecs[1].Name)
+	require.Equal(t, 2, m.TerraNodeGroupSpecs[1].Replicas)
+	require.Equal(t, map[string]interface{}{"labels": map[string]interface{}{"node-role": "worker"}}, m.TerraNodeGroupSpecs[1].NodeTemplate)
+}
+
+func TestPrepareKeepsProviderClusterConfigNodeGroups(t *testing.T) {
+	m := cloudMetaConfig(mcFlowResources)
+	m.ProviderClusterConfig = map[string]json.RawMessage{
+		"layout":          json.RawMessage(`"Standard"`),
+		"masterNodeGroup": json.RawMessage(`{"replicas":1}`),
+		"nodeGroups":      json.RawMessage(`[{"name":"legacy","replicas":7}]`),
+	}
+
+	m, err := m.Prepare(t.Context(), DummyValidatorProvider())
+	require.NoError(t, err)
+
+	require.Equal(t, 1, m.MasterNodeGroupSpec.Replicas, "provider cluster configuration wins over cluster node groups")
+	require.Len(t, m.TerraNodeGroupSpecs, 1)
+	require.Equal(t, "legacy", m.TerraNodeGroupSpecs[0].Name)
+	require.Equal(t, 7, m.TerraNodeGroupSpecs[0].Replicas)
+}
+
+// An explicitly empty nodeGroups list in the provider cluster configuration is
+// indistinguishable from an absent one, so the cluster node groups are still
+// derived. Documents the current behaviour rather than guaranteeing it.
+func TestPrepareDerivesOnEmptyProviderClusterConfigNodeGroups(t *testing.T) {
+	m := cloudMetaConfig(mcFlowResources)
+	m.ProviderClusterConfig = map[string]json.RawMessage{
+		"layout":          json.RawMessage(`"Standard"`),
+		"masterNodeGroup": json.RawMessage(`{"replicas":1}`),
+		"nodeGroups":      json.RawMessage(`[]`),
+	}
+
+	m, err := m.Prepare(t.Context(), DummyValidatorProvider())
+	require.NoError(t, err)
+
+	require.Len(t, m.TerraNodeGroupSpecs, 2)
+	require.Equal(t, "system", m.TerraNodeGroupSpecs[0].Name)
+	require.Equal(t, "worker", m.TerraNodeGroupSpecs[1].Name)
+}
+
+// check and converge re-run Prepare on a DeepCopy of an already prepared
+// config, so the derivation must not append the same node groups twice.
+func TestPrepareOnDeepCopyIsIdempotent(t *testing.T) {
+	m, err := cloudMetaConfig(mcFlowResources).Prepare(t.Context(), DummyValidatorProvider())
+	require.NoError(t, err)
+
+	again, err := m.DeepCopy().Prepare(t.Context(), DummyValidatorProvider())
+	require.NoError(t, err)
+
+	require.Equal(t, m.MasterNodeGroupSpec.Replicas, again.MasterNodeGroupSpec.Replicas)
+	require.Equal(t, m.TerraNodeGroupSpecs, again.TerraNodeGroupSpecs)
+}

--- a/dhctl/pkg/config/meta_test.go
+++ b/dhctl/pkg/config/meta_test.go
@@ -685,8 +685,10 @@ func TestPrepareKeepsProviderClusterConfigNodeGroups(t *testing.T) {
 }
 
 // An explicitly empty nodeGroups list in the provider cluster configuration is
-// indistinguishable from an absent one, so the cluster node groups are still
-// derived. Documents the current behaviour rather than guaranteeing it.
+// not distinguished from an absent one: the guard in
+// applyNodeGroupReplicasFromCloudProviderVars checks len(), not nil, so the
+// cluster node groups are still derived. That is a choice of the guard, not a
+// property of the data — this documents the behaviour, it does not bless it.
 func TestPrepareDerivesOnEmptyProviderClusterConfigNodeGroups(t *testing.T) {
 	m := cloudMetaConfig(mcFlowResources)
 	m.ProviderClusterConfig = map[string]json.RawMessage{


### PR DESCRIPTION
## Description

`MetaConfig.Prepare` derived `MasterNodeGroupSpec.Replicas` and `TerraNodeGroupSpecs` (`extractProviderClusterFields`, `meta.go:161`) *before* it populated `CloudProviderVars` from `ResourcesYAML` (`meta.go:165`). The derivation reads `CloudProviderVars`, so on the bootstrap-from-file path it always saw `nil` and did nothing.

The derivation is driven by `CloudProviderVars`, not by the provider cluster configuration, so this moves `applyNodeGroupReplicasFromCloudProviderVars` out of `extractProviderClusterFields` into `Prepare`, after every source of `CloudProviderVars` is resolved.

## Why do we need it, and what problem does it solve?

For providers whose node groups live in the resources documents rather than in a `<Provider>ClusterConfiguration` (mc-flow, e.g. DVP), both typed fields stayed zeroed on bootstrap:

* `TerraNodeGroupSpecs` empty → **no CloudPermanent node is created at all**. The bootstrap log shows `Waiting for NodeGroups [master] to become Ready` with the worker NodeGroup missing, even though the `NodeGroup` resource itself is applied to the cluster.
* `MasterNodeGroupSpec.Replicas` at 0 → the additional-master loop in `BootstrapAdditionalMasterNodes` (`steps_nodes.go:70`, `for i := 1; i < Replicas`) never iterates, so **a multi-master cluster comes up with a single master**, silently.

Converge and check were not affected: they parse from the cluster, and `base.go:303` preloads `CloudProviderVars` before `Prepare`. That is why the bug only showed on bootstrap.

It used to work by accident. `validateAndPrepareMetaConfig` re-ran `extractProviderClusterFields` at the very end of `Prepare` so that a provider *preparator* could mutate the provider cluster configuration, and that second pass happened to see a populated `CloudProviderVars`. Removing the preparator mechanism in 2647c34992 removed the second pass with it — nothing went red because no test called `Prepare()`.

Regression range: present in `main` and `release-1.77`, not in `release-1.76`.

## Why do we need it in the patch release (if we do)?

Yes — 1.77 cannot bootstrap a DVP cluster with any CloudPermanent worker, and would bootstrap a 3-master cluster as a 1-master one.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

Tests are added at both levels: `Prepare` (derivation, provider-cluster-configuration precedence, idempotency on the `DeepCopy().Prepare()` re-runs done by check/converge) and `ParseConfigFromData`, which is where the `NodeGroup` documents actually reach `ResourcesYAML`. All of them fail on `main` and pass with this change.

## Changelog entries

```changes
section: dhctl
type: fix
summary: Bootstrap creates the CloudPermanent nodes and the additional masters for providers configured through ModuleConfig.
impact_level: default
```
