### PR TITLE
[dhctl] Refactor SSH key handling to use `os.MkdirTemp` instead of hardcoded TMPDIR logic

### DIFF
--- a/dhctl/pkg/preflight/checks/static_instances_ssh_access.go
+++ b/dhctl/pkg/preflight/checks/static_instances_ssh_access.go
@@ -18,12 +18,10 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
-	"time"
 
 	"gopkg.in/yaml.v3"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -243,21 +241,16 @@ func checkSSHAccess(ctx context.Context, sshProviderInitializer *providerinitial
 		}
 	}
 
-	tmpDir := filepath.Join(os.Getenv("TMPDIR"), "preflight")
-
-	err = os.MkdirAll(tmpDir, 0o755)
-	if err != nil {
-		return fmt.Errorf("failed to create tmp directory: %w", err)
-	}
-
-	privateKeyPrefixPathWithoutSuffix := filepath.Join(tmpDir, "id_rsa_preflight.key")
-
-	n := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
-	privateKeyPath := fmt.Sprintf("%s.%d", privateKeyPrefixPathWithoutSuffix, n)
-
 	if cred.PrivateSSHKey != "" {
-		err = os.WriteFile(privateKeyPath, []byte(cred.PrivateSSHKey), 0o600)
+		// The dhctl pod sets no TMPDIR and mounts / read-only; only /tmp is writable.
+		tmpDir, err := os.MkdirTemp("", "preflight")
 		if err != nil {
+			return fmt.Errorf("failed to create tmp directory: %w", err)
+		}
+		defer os.RemoveAll(tmpDir)
+
+		privateKeyPath := filepath.Join(tmpDir, "id_rsa_preflight.key")
+		if err := os.WriteFile(privateKeyPath, []byte(cred.PrivateSSHKey), 0o600); err != nil {
 			return fmt.Errorf("Failed to write private key: %w", err)
 		}
 


### PR DESCRIPTION
## Description

The `static-instances-ssh-access` preflight check built its temp directory from `TMPDIR`:

```go
tmpDir := filepath.Join(os.Getenv("TMPDIR"), "preflight")
```

`TMPDIR` is not set in the dhctl-server pod, so this collapsed to the relative path `preflight`,
resolved against the container's read-only `/`. Replaced with `os.MkdirTemp("", "preflight")`, which
falls back to `/tmp` — the writable mount dhctl already uses for its state cache.

Also: the temp dir is now removed on return, so StaticInstance private keys no longer accumulate on
the pod's filesystem; the `math/rand` filename suffix is dropped since `MkdirTemp` already guarantees
unique names.

No impact on running components — installer-side only.

## Why do we need it, and what problem does it solve?

Bootstrap of any cluster with `StaticInstances` fails 100% of the time when the installer runs in a
pod (Commander / dhctl-server):

```
FAILED Infra preflights
reason: SSH access check failed for test-system-0 (10.66.10.2:22): failed to create tmp directory: mkdir preflight: read-only file system
```

Running `dhctl` from a shell hides it, since `TMPDIR` is normally set there.

Introduced by #19063.

## Why do we need it in the patch release (if we do)?

Yes — blocks bootstrap outright, no user-side workaround (`TMPDIR` is not theirs to set in the
installer pod). Reproduced on `release-1-77`.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: dhctl
type: fix
summary: Fix the static-instances-ssh-access preflight check failing with "read-only file system" when the installer runs in a pod.
impact_level: default
```
