### PR TITLE
[control-plane-manager] Fix ValidatingAdmissionPolicy for moduleConfig

### DIFF
--- a/modules/040-control-plane-manager/templates/validation.yaml
+++ b/modules/040-control-plane-manager/templates/validation.yaml
@@ -180,34 +180,22 @@ spec:
     resourceRules:
     - apiGroups:   ["deckhouse.io"]
       apiVersions: ["v1alpha1"]
-      operations:  ["CREATE", "UPDATE"]
+      operations:  ["UPDATE"]
       resources:   ["moduleconfigs"]
   matchConditions:
     - name: {{ $policyName }}
-      expression: 'object.metadata.name == "control-plane-manager"'      
+      expression: 'object.metadata.name == "control-plane-manager"'
   validations:
     - expression: |
         !(
-          (
-            has(oldObject.spec.settings) && has(oldObject.spec.settings.apiserver) && has(oldObject.spec.settings.apiserver.signature) ?
-            oldObject.spec.settings.apiserver.signature : 'Rollback'
-          ) == 'Enforce' && 
-          (
-            has(object.spec.settings) && has(object.spec.settings.apiserver) && has(object.spec.settings.apiserver.signature) ?
-            object.spec.settings.apiserver.signature : 'Rollback'
-          ) == 'Rollback'
+          oldObject.?spec.?settings.?apiserver.?signature.orValue('Rollback') == 'Enforce' &&
+          object.?spec.?settings.?apiserver.?signature.orValue('Rollback') == 'Rollback'
         )
       message: "Change from 'Enforce' to 'Rollback' is forbidden. You should set the 'Migrate' option, wait for the migration to complete (DKP queue to clear), and then change it to 'Enforce'"
     - expression: |
         !(
-          (
-            has(oldObject.spec.settings) && has(oldObject.spec.settings.apiserver) && has(oldObject.spec.settings.apiserver.signature) ?
-            oldObject.spec.settings.apiserver.signature : 'Rollback'
-          ) == 'Rollback' && 
-          (
-            has(object.spec.settings) && has(object.spec.settings.apiserver) && has(object.spec.settings.apiserver.signature) ?
-            object.spec.settings.apiserver.signature : 'Rollback'
-          ) == 'Enforce'
+          oldObject.?spec.?settings.?apiserver.?signature.orValue('Rollback') == 'Rollback' &&
+          object.?spec.?settings.?apiserver.?signature.orValue('Rollback') == 'Enforce'
         )
       message: "Change from 'Rollback' to 'Enforce' is forbidden. You should set the 'Migrate' option, migrate all data to new format (see documentation), and then change it to 'Enforce'"
 ---


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix the `mc-control-plane-manager` validating admission policy (CSE only)
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
`dhctl bootstrap` hangs and fails at `Create Manifests` on a CSE cluster whose `ModuleConfig/control-plane-manager` has `apiserver.signature: Enforce`:

```
Manifest for ModuleConfig "control-plane-manager"   (x600, one per second)
Create Manifests FAILED (457.01 seconds)

moduleconfigs.deckhouse.io "control-plane-manager" is forbidden:
ValidatingAdmissionPolicy 'mc-control-plane-manager' ... resulted in error: no such key: spec
```
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: fix
summary: Fix dhctl bootstrap failing on CSE clusters with 'apiserver.signature Enforce' on control-plane-manager moduleConfig
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
