### PR TITLE
[deckhouse] expose module CRD GVKs as Platform.capabilities

### DIFF
--- a/deckhouse-controller/internal/packages/modules/global/module.go
+++ b/deckhouse-controller/internal/packages/modules/global/module.go
@@ -479,7 +479,8 @@ func (m *Module) SetEnabledModules(enabledModules []string) {
 	}
 }
 
-// SetCapabilities injects GVK values, discovered during executing ModuleEnsureCRDs tasks, into .global.discovery.apiVersions values
+// SetCapabilities injects GVK values, discovered during executing ModuleEnsureCRDs tasks,
+// into the .Capabilities global value, exposed to charts as .Platform.Capabilities
 func (m *Module) SetCapabilities(apiVersions []string) {
 	if len(apiVersions) == 0 {
 		return
@@ -489,9 +490,14 @@ func (m *Module) SetCapabilities(apiVersions []string) {
 	sort.Strings(apiVersions)
 	data, _ := json.Marshal(apiVersions)
 
-	// backward compatibility: set apiVersions to .global.discovery.apiVersions
-	// TODO(ipaqsa): get rid of it further and add Capabilities field
 	patch := addonutils.ValuesPatch{Operations: []*sdkutils.ValuesPatchOperation{
+		{
+			Op:    "add",
+			Path:  "/Capabilities",
+			Value: data,
+		},
+		// backward compatibility: set apiVersions to .global.discovery.apiVersions
+		// TODO(ipaqsa): get rid of it further
 		{
 			Op:    "add",
 			Path:  "/discovery/apiVersions",
@@ -500,7 +506,7 @@ func (m *Module) SetCapabilities(apiVersions []string) {
 	}}
 
 	if err := m.values.ApplyValuesPatch(patch); err != nil {
-		m.logger.Error(fmt.Sprintf("failed to set enabled modules to global: %v", err.Error()))
+		m.logger.Error(fmt.Sprintf("failed to set capabilities to global: %v", err.Error()))
 	}
 }
 

--- a/deckhouse-controller/internal/packages/modules/global/module.go
+++ b/deckhouse-controller/internal/packages/modules/global/module.go
@@ -457,7 +457,6 @@ func filterEnabledFromValuesPatch(valuesPatch *addonutils.ValuesPatch) map[strin
 
 // SetEnabledModules inject enabledModules to the global values
 // enabledModules are injected as a patch, to recalculate on every global values change
-// EnabledModules is an alias of the same list, exposed to charts as .Platform.EnabledModules
 func (m *Module) SetEnabledModules(enabledModules []string) {
 	if len(enabledModules) == 0 {
 		return
@@ -471,11 +470,6 @@ func (m *Module) SetEnabledModules(enabledModules []string) {
 		{
 			Op:    "add",
 			Path:  "/enabledModules",
-			Value: data,
-		},
-		{
-			Op:    "add",
-			Path:  "/EnabledModules",
 			Value: data,
 		},
 	}}

--- a/deckhouse-controller/internal/packages/modules/global/module.go
+++ b/deckhouse-controller/internal/packages/modules/global/module.go
@@ -457,6 +457,7 @@ func filterEnabledFromValuesPatch(valuesPatch *addonutils.ValuesPatch) map[strin
 
 // SetEnabledModules inject enabledModules to the global values
 // enabledModules are injected as a patch, to recalculate on every global values change
+// EnabledModules is an alias of the same list, exposed to charts as .Platform.EnabledModules
 func (m *Module) SetEnabledModules(enabledModules []string) {
 	if len(enabledModules) == 0 {
 		return
@@ -470,6 +471,11 @@ func (m *Module) SetEnabledModules(enabledModules []string) {
 		{
 			Op:    "add",
 			Path:  "/enabledModules",
+			Value: data,
+		},
+		{
+			Op:    "add",
+			Path:  "/EnabledModules",
 			Value: data,
 		},
 	}}

--- a/deckhouse-controller/internal/packages/modules/global/module.go
+++ b/deckhouse-controller/internal/packages/modules/global/module.go
@@ -480,7 +480,7 @@ func (m *Module) SetEnabledModules(enabledModules []string) {
 }
 
 // SetCapabilities injects GVK values, discovered during executing ModuleEnsureCRDs tasks,
-// into the .Capabilities global value, exposed to charts as .Platform.Capabilities
+// into the .capabilities global value, exposed to charts as .Platform.capabilities
 func (m *Module) SetCapabilities(apiVersions []string) {
 	if len(apiVersions) == 0 {
 		return
@@ -493,7 +493,7 @@ func (m *Module) SetCapabilities(apiVersions []string) {
 	patch := addonutils.ValuesPatch{Operations: []*sdkutils.ValuesPatchOperation{
 		{
 			Op:    "add",
-			Path:  "/Capabilities",
+			Path:  "/capabilities",
 			Value: data,
 		},
 		// backward compatibility: set apiVersions to .global.discovery.apiVersions

--- a/global-hooks/openapi/values.yaml
+++ b/global-hooks/openapi/values.yaml
@@ -54,14 +54,6 @@ properties:
     # fake *-crd modules are required for backward compatibility with lib_helm library TODO: remove fake crd modules
     - [ "cert-manager", "vertical-pod-autoscaler", "vertical-pod-autoscaler-crd", "prometheus", "prometheus-crd", "operator-prometheus", "operator-prometheus" ]
     - [ "cert-manager", "prometheus" ]
-  EnabledModules:
-    type: array
-    items:
-      type: string
-    description: |
-      Alias of enabledModules, exposed to package charts as .Platform.EnabledModules.
-    x-examples:
-    - [ "cert-manager", "prometheus" ]
   capabilities:
     type: array
     items:

--- a/global-hooks/openapi/values.yaml
+++ b/global-hooks/openapi/values.yaml
@@ -54,13 +54,13 @@ properties:
     # fake *-crd modules are required for backward compatibility with lib_helm library TODO: remove fake crd modules
     - [ "cert-manager", "vertical-pod-autoscaler", "vertical-pod-autoscaler-crd", "prometheus", "prometheus-crd", "operator-prometheus", "operator-prometheus" ]
     - [ "cert-manager", "prometheus" ]
-  Capabilities:
+  capabilities:
     type: array
     items:
       type: string
     description: |
       List of GVKs installed from the modules' crds directories.
-      Exposed to package charts as .Platform.Capabilities.
+      Exposed to package charts as .Platform.capabilities.
     x-examples:
     - [ "deckhouse.io/v1alpha1/NodeGroup", "deckhouse.io/v1beta1/NodeGroup", "monitoring.coreos.com/v1/PrometheusRule" ]
   discovery:

--- a/global-hooks/openapi/values.yaml
+++ b/global-hooks/openapi/values.yaml
@@ -54,6 +54,14 @@ properties:
     # fake *-crd modules are required for backward compatibility with lib_helm library TODO: remove fake crd modules
     - [ "cert-manager", "vertical-pod-autoscaler", "vertical-pod-autoscaler-crd", "prometheus", "prometheus-crd", "operator-prometheus", "operator-prometheus" ]
     - [ "cert-manager", "prometheus" ]
+  EnabledModules:
+    type: array
+    items:
+      type: string
+    description: |
+      Alias of enabledModules, exposed to package charts as .Platform.EnabledModules.
+    x-examples:
+    - [ "cert-manager", "prometheus" ]
   capabilities:
     type: array
     items:

--- a/global-hooks/openapi/values.yaml
+++ b/global-hooks/openapi/values.yaml
@@ -54,6 +54,15 @@ properties:
     # fake *-crd modules are required for backward compatibility with lib_helm library TODO: remove fake crd modules
     - [ "cert-manager", "vertical-pod-autoscaler", "vertical-pod-autoscaler-crd", "prometheus", "prometheus-crd", "operator-prometheus", "operator-prometheus" ]
     - [ "cert-manager", "prometheus" ]
+  Capabilities:
+    type: array
+    items:
+      type: string
+    description: |
+      List of GVKs installed from the modules' crds directories.
+      Exposed to package charts as .Platform.Capabilities.
+    x-examples:
+    - [ "deckhouse.io/v1alpha1/NodeGroup", "deckhouse.io/v1beta1/NodeGroup", "monitoring.coreos.com/v1/PrometheusRule" ]
   discovery:
     additionalProperties: true
     type: object


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

The GVKs of CRDs applied while enabling modules (collected by the `EnsureCRDs` tasks) are published to a new top-level global value `capabilities`, so package charts can read them as `.Platform.capabilities`:

```
{{- if .Platform.capabilities | has "monitoring.coreos.com/v1/PodMonitor" }}
```

It is the same sorted `<group>/<version>/<Kind>` list that already goes to `.global.discovery.apiVersions`; both paths are written in one values patch. The legacy path is kept for backward compatibility.

`global-hooks/openapi/values.yaml` declares the new key: global values are patched in strict mode against a schema root with `additionalProperties: false`, so an undeclared key fails the whole patch.

`.Platform` for module packages is built from the packages-runtime global values, the store this patch writes to. Application packages take `.Platform` from the addon-operator global module and are unaffected.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Helm's built-in `.Capabilities.APIVersions` is a discovery snapshot and misses CRDs applied in the same converge round, which is why in-tree charts OR it with `.Values.global.discovery.apiVersions`. That value is authoritative — `globalrun` ensures the CRDs of every enabled module behind the global barrier, before any module renders — but it is a legacy addon-operator path that `.Platform` is meant to replace. Naming it in the new contract lets the legacy path be dropped later.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: feature
summary: expose module CRD GVKs as Platform.capabilities
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->



