### PR TITLE
candi: fix duplicated TOML table in rendered containerd config.toml

### DIFF
--- a/candi/bashible/common-steps/all/032_configure_containerd.sh.tpl
+++ b/candi/bashible/common-steps/all/032_configure_containerd.sh.tpl
@@ -390,13 +390,14 @@ oom_score = 0
           {{- else }}
           auth = {{ (($mirror).auth).auth | default "" | quote }}
           {{- end }}
-      {{- if $mirror.ca }}
+      {{- if or $mirror.ca (eq $mirror.scheme "http") }}
         [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ $mirror.host }}".tls]
+      {{- if $mirror.ca }}
           ca_file = "/opt/deckhouse/share/ca-certificates/registry-{{ $mirror.host | lower }}-ca.crt"
       {{- end }}
       {{- if eq $mirror.scheme "http" }}
-        [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ $mirror.host }}".tls]
           insecure_skip_verify = true
+      {{- end }}
       {{- end }}
     {{- end }}
   {{- end }}

--- a/dhctl/pkg/template/bashible_test.go
+++ b/dhctl/pkg/template/bashible_test.go
@@ -17,8 +17,10 @@ package template
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/BurntSushi/toml"
 	"github.com/stretchr/testify/require"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app/options"
@@ -95,4 +97,57 @@ func TestRenderBashibleTemplateUsesClusterMasterRPPAddressesForBootstrap(t *test
 	require.Contains(t, content, `export PACKAGES_PROXY_ADDRESSES="http://127.0.0.1:5444"`)
 	require.Contains(t, content, `export PACKAGES_PROXY_TOKEN="passthrough"`)
 	require.Contains(t, content, `bb-minget-install`)
+}
+
+// A mirror that carries both a CA (set via --ca-file) and an "http" scheme (left over
+// from a previous "change-registry" run without --ca-file) must still render as valid
+// TOML: https://github.com/deckhouse/deckhouse/issues/13934
+func TestRenderBashibleContainerdConfigDoesNotDuplicateTLSTable(t *testing.T) {
+	tplContent, err := os.ReadFile("../../../candi/bashible/common-steps/all/032_configure_containerd.sh.tpl")
+	require.NoError(t, err)
+
+	data := map[string]any{
+		"cri": "Containerd",
+		"nodeGroup": map[string]any{
+			"cri": map[string]any{},
+			"gpu": false,
+		},
+		"images":    map[string]any{},
+		"deckhouse": map[string]any{"edition": "EE"},
+		"runType":   "Normal",
+		"normal":    map[string]any{"moduleSourcesCA": map[string]any{}},
+		"registry": map[string]any{
+			"registryModuleEnable": false,
+			"hosts": map[string]any{
+				"harbor.example.com": map[string]any{
+					"mirrors": []any{
+						map[string]any{
+							"host":   "harbor.example.com",
+							"scheme": "http",
+							"ca":     "FAKE-CA-CONTENT",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	rendered, err := RenderTemplate("032_configure_containerd.sh.tpl", tplContent, data)
+	require.NoError(t, err)
+
+	content := rendered.Content.String()
+
+	const marker = "bb-sync-file /etc/containerd/deckhouse.toml - << EOF\n"
+	start := strings.Index(content, marker)
+	require.NotEqual(t, -1, start, "generated config.toml heredoc not found")
+	start += len(marker)
+	end := strings.Index(content[start:], "\nEOF\n")
+	require.NotEqual(t, -1, end, "end of generated config.toml heredoc not found")
+	// The heredoc is expanded by bash at runtime; substitute the one shell variable it
+	// references so the captured body parses the same way the shell-rendered file would.
+	tomlBody := strings.ReplaceAll(content[start:start+end], "${systemd_cgroup}", "true")
+
+	var parsed map[string]any
+	_, err = toml.Decode(tomlBody, &parsed)
+	require.NoError(t, err, "generated containerd config.toml must be valid TOML")
 }


### PR DESCRIPTION
## Description
This change fixes bashible's containerd config template (`032_configure_containerd.sh.tpl`, used for the "Containerd" v1 CRI) so it no longer emits the `[plugins."io.containerd.grpc.v1.cri".registry.configs."<host>".tls]` TOML table twice for the same mirror host. Previously, when a mirror had both a CA file and an `http` scheme configured at the same time, the template opened that table once to set `ca_file` and again to set `insecure_skip_verify`, producing invalid TOML (duplicate table definitions) that containerd refused to load. Both conditional blocks are now merged into a single `[...tls]` table, with `ca_file` and `insecure_skip_verify` each still independently conditional on the underlying mirror fields, so at most one table header is emitted per host. The `ContainerdV2` branch of the template is unaffected, since it always uses `config_path` and never generates per-mirror `[...configs."<host>".tls]` blocks. This does not affect control-plane, ingress-controller, or Prometheus restarts.

## Why do we need it, and what problem does it solve?
This is reachable via `deckhouse-controller helper change-registry`: running it first without `--ca-file` and then again with `--ca-file` for the same host can leave a mirror record with the `http` scheme from the first run and the CA from the second run, producing exactly this invalid config. As a result, bashible fails with the error `containerd: failed to load TOML: ... duplicated tables`, breaking containerd config regeneration on affected nodes.

Fixes https://github.com/deckhouse/deckhouse/issues/13934

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: candi
type: fix
summary: Fix duplicated TOML table in rendered containerd config.toml when a registry mirror has both a CA file and an "http" scheme configured.
impact: Nodes whose registry mirror config had both a CA file and an "http" scheme set (e.g. after running `deckhouse-controller helper change-registry` twice with different flags for the same host) could fail to regenerate containerd's config.toml with a "duplicated tables" TOML error. After this fix, the generated config is valid and containerd loads it correctly.
impact_level: high
```

---
AI assistance: this change was drafted with Claude Code.

Fixes #13934