### PR TITLE
[cloud-provider-zvirt] Migrate legacy IsDefault key in discovery data before validation

### DIFF
--- a/ee/se-plus/modules/030-cloud-provider-zvirt/hooks/discover.go
+++ b/ee/se-plus/modules/030-cloud-provider-zvirt/hooks/discover.go
@@ -122,7 +122,7 @@ func handleCloudProviderDiscoveryDataSecret(_ context.Context, input *go_hook.Ho
 
 	secret := cloudSecrets[0]
 
-	discoveryDataJSON := secret.Data["discovery-data.json"]
+	discoveryDataJSON := migrateLegacyIsDefaultField(secret.Data["discovery-data.json"])
 
 	if err := validation.ValidateData([]string{"/deckhouse/ee/se-plus/modules/030-cloud-provider-zvirt/candi/openapi", "/deckhouse/candi/cloud-providers/zvirt/openapi"}, &discoveryDataJSON); err != nil {
 		return fmt.Errorf("failed to validate 'discovery-data.json' from 'd8-cloud-provider-discovery-data' secret: %v", err)
@@ -141,6 +141,47 @@ func handleCloudProviderDiscoveryDataSecret(_ context.Context, input *go_hook.Ho
 	}
 
 	return nil
+}
+
+// migrateLegacyIsDefaultField renames the legacy "IsDefault" storage domain property to "isDefault".
+// Discovery data persisted by deckhouse-controller versions prior to the fix in
+// https://github.com/deckhouse/deckhouse/pull/13386 used the wrong JSON key, and strict schema
+// validation permanently rejects such secrets with "storageDomains.IsDefault is a forbidden property"
+// unless the legacy key is normalized first.
+func migrateLegacyIsDefaultField(raw []byte) []byte {
+	var data map[string]any
+	if err := json.Unmarshal(raw, &data); err != nil {
+		return raw
+	}
+
+	domains, ok := data["storageDomains"].([]any)
+	if !ok {
+		return raw
+	}
+
+	changed := false
+	for _, item := range domains {
+		domain, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if v, exists := domain["IsDefault"]; exists {
+			domain["isDefault"] = v
+			delete(domain, "IsDefault")
+			changed = true
+		}
+	}
+
+	if !changed {
+		return raw
+	}
+
+	migrated, err := json.Marshal(data)
+	if err != nil {
+		return raw
+	}
+
+	return migrated
 }
 
 func handleDiscoveryDataVolumeTypes(

--- a/ee/se-plus/modules/030-cloud-provider-zvirt/hooks/discover_test.go
+++ b/ee/se-plus/modules/030-cloud-provider-zvirt/hooks/discover_test.go
@@ -247,4 +247,40 @@ cloudProviderZvirt:
 `))
 		})
 	})
+
+	Context("migrateLegacyIsDefaultField", func() {
+		It("renames legacy 'IsDefault' storage domain key to 'isDefault'", func() {
+			raw := []byte(`{
+  "apiVersion": "deckhouse.io/v1",
+  "kind": "ZvirtCloudProviderDiscoveryData",
+  "storageDomains": [
+    {"name": "D1", "isEnabled": true, "IsDefault": true},
+    {"name": "D2", "isEnabled": false, "isDefault": false}
+  ]
+}`)
+
+			migrated := migrateLegacyIsDefaultField(raw)
+
+			Expect(migrated).To(MatchJSON(`{
+  "apiVersion": "deckhouse.io/v1",
+  "kind": "ZvirtCloudProviderDiscoveryData",
+  "storageDomains": [
+    {"name": "D1", "isEnabled": true, "isDefault": true},
+    {"name": "D2", "isEnabled": false, "isDefault": false}
+  ]
+}`))
+		})
+
+		It("leaves data without the legacy key unchanged", func() {
+			raw := []byte(`{"storageDomains": [{"name": "D1", "isDefault": true}]}`)
+
+			Expect(migrateLegacyIsDefaultField(raw)).To(Equal(raw))
+		})
+
+		It("passes through invalid JSON unchanged", func() {
+			raw := []byte(`not json`)
+
+			Expect(migrateLegacyIsDefaultField(raw)).To(Equal(raw))
+		})
+	})
 })


### PR DESCRIPTION
## Description
Discovery data secrets persisted before [#13386](https://github.com/deckhouse/deckhouse/pull/13386) used a mistagged `IsDefault` (capitalized) JSON key for storage domains, while the module's `cloud_discovery_data.yaml` schema has always required `isDefault` (lowercase). Since the schema's `storageDomains` item objects don't declare `additionalProperties` explicitly, lib-dhctl's validation loader defaults it to `false`, so the stale key is hard-rejected as an unknown property with `storageDomains.IsDefault is a forbidden property`.

This change normalizes the legacy `IsDefault` key to `isDefault` in the raw secret JSON before schema validation runs, so clusters carrying pre-existing discovery data can validate successfully again and the discoverer Pod gets a chance to self-heal the Secret going forward.

This does not affect critical cluster components such as ingress-controllers, control-plane, or Prometheus.

## Why do we need it, and what problem does it solve?
Because the discover hook runs `OnBeforeHelm`, the validation failure blocks the whole `cloud-provider-zvirt` module's Helm sync on every reconcile. This also prevents the `cloud-data-discoverer` Pod (the component that would otherwise rewrite the Secret with the corrected field) from being redeployed, leaving the `deckhouse-controller` queue permanently stuck after upgrading on any zvirt cluster whose discovery data predates the fix in #13386.

Fixes https://github.com/deckhouse/deckhouse/issues/14919

## Why do we need it in the patch release (if we do)?
This fix unblocks the `deckhouse-controller` queue and restores Helm sync for the `cloud-provider-zvirt` module on any affected cluster, so it should be backported to the patch release to avoid clusters remaining stuck until the next minor release.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cloud-provider-zvirt
type: fix
summary: Fix a stuck deckhouse-controller queue caused by legacy `IsDefault` keys in zvirt discovery data failing schema validation.
impact: On zvirt clusters with discovery data persisted before the isDefault key fix in #13386, the cloud-provider-zvirt module's Helm sync was blocked on every reconcile due to a schema validation error, preventing the cloud-data-discoverer Pod from being redeployed. After this update, the legacy key is migrated automatically before validation, unblocking the queue and allowing the discoverer Pod to self-heal the Secret.
impact_level: high
```

---
AI assistance: this change was drafted with Claude Code.

Fixes #14919