### PR TITLE
[istio] Fix VEX files

### DIFF
--- a/ee/modules/110-istio/images/config-analyzer-v1x21x6/known_vulnerabilities.vex
+++ b/ee/modules/110-istio/images/config-analyzer-v1x21x6/known_vulnerabilities.vex
@@ -1,0 +1,79 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "merged-vex-c08326a5ed591dda3a60eecf94812fdf8ff2fe5fcfe197a97c104868f6dc66b5",
+  "author": "Deckhouse <contact@deckhouse.io>",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "GO-2026-5932"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/crypto@v0.53.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "GO-2026-5932 concerns golang.org/x/crypto/openpgp, which is unmaintained and unsafe by design. This component does not import or execute the openpgp package; golang.org/x/crypto is pulled in transitively for other subpackages. Exploitation of openpgp via this binary is not available.",
+      "timestamp": "2026-08-10T08:37:33.000000000Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-40179"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/prometheus/prometheus@v0.48.1"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Stored XSS in the Prometheus 3.x web UI (CVE-2026-40179). The istio-config-analyzer binary does not run the Prometheus server or expose that UI; github.com/prometheus/prometheus v0.48.1 is a library dependency only.",
+      "timestamp": "2026-08-10T08:47:21.000000000Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-42151"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/prometheus/prometheus@v0.48.1"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Azure OAuth client_secret disclosure via Prometheus /-/config API (CVE-2026-42151). The istio-config-analyzer binary does not run the Prometheus server or expose that endpoint; github.com/prometheus/prometheus v0.48.1 is library-only.",
+      "timestamp": "2026-08-10T08:47:21.000000000Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-42154"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/prometheus/prometheus@v0.48.1"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "DoS via snappy payload on Prometheus remote-read /api/v1/read (CVE-2026-42154). The istio-config-analyzer binary does not run the Prometheus server or handle that endpoint; github.com/prometheus/prometheus v0.48.1 is library-only.",
+      "timestamp": "2026-08-10T08:47:21.000000000Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-44903"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/prometheus/prometheus@v0.48.1"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Stored XSS in the legacy Prometheus UI heatmap (CVE-2026-44903). The istio-config-analyzer binary does not run the Prometheus server or expose that UI; github.com/prometheus/prometheus v0.48.1 is library-only.",
+      "timestamp": "2026-08-10T08:47:21.000000000Z"
+    }
+  ],
+  "timestamp": "2026-08-10T08:47:21Z"
+}

--- a/ee/modules/110-istio/images/config-analyzer-v1x25x2/known_vulnerabilities.vex
+++ b/ee/modules/110-istio/images/config-analyzer-v1x25x2/known_vulnerabilities.vex
@@ -1,6 +1,6 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
-  "@id": "merged-vex-a215ac0e5b7ebabf62399fda80008ccc3f4877d8b0c09adada7b27e489ce60ed",
+  "@id": "merged-vex-cf1ef4435e187633710e8124251aa489b055dd1c84d1201e6e326c77e0cac6b5",
   "author": "Deckhouse <contact@deckhouse.io>",
   "version": 1,
   "statements": [
@@ -10,7 +10,7 @@
       },
       "products": [
         {
-          "@id": "pkg:golang/golang.org/x/crypto@v0.54.0"
+          "@id": "pkg:golang/golang.org/x/crypto@v0.53.0"
         }
       ],
       "status": "not_affected",

--- a/ee/modules/110-istio/images/config-analyzer-v1x27x9/known_vulnerabilities.vex
+++ b/ee/modules/110-istio/images/config-analyzer-v1x27x9/known_vulnerabilities.vex
@@ -1,6 +1,6 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
-  "@id": "merged-vex-a215ac0e5b7ebabf62399fda80008ccc3f4877d8b0c09adada7b27e489ce60ed",
+  "@id": "merged-vex-e519eff7c1c0119fa8870bc3e96b413db1118ad11bed2120f503ae56c3526df4",
   "author": "Deckhouse <contact@deckhouse.io>",
   "version": 1,
   "statements": [
@@ -10,7 +10,7 @@
       },
       "products": [
         {
-          "@id": "pkg:golang/golang.org/x/crypto@v0.54.0"
+          "@id": "pkg:golang/golang.org/x/crypto@v0.53.0"
         }
       ],
       "status": "not_affected",

--- a/modules/110-istio/images/cni-v1x29x6/known_vulnerabilities.vex
+++ b/modules/110-istio/images/cni-v1x29x6/known_vulnerabilities.vex
@@ -10,14 +10,14 @@
       },
       "products": [
         {
-          "@id": "pkg:golang/golang.org/x/crypto@v0.53.0"
+          "@id": "pkg:golang/golang.org/x/crypto@v0.54.0"
         }
       ],
       "status": "not_affected",
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "GO-2026-5932 concerns golang.org/x/crypto/openpgp, which is unmaintained and unsafe by design. This component does not import or execute the openpgp package; golang.org/x/crypto is pulled in transitively for other subpackages. Exploitation of openpgp via this binary is not available.",
-      "timestamp": "2026-08-05T15:10:49.000000000Z"
+      "timestamp": "2026-08-10T08:37:33.000000000Z"
     }
   ],
-  "timestamp": "2026-08-05T15:10:49Z"
+  "timestamp": "2026-08-10T08:37:33Z"
 }

--- a/modules/110-istio/images/proxyv2-v1x29x6/known_vulnerabilities.vex
+++ b/modules/110-istio/images/proxyv2-v1x29x6/known_vulnerabilities.vex
@@ -10,14 +10,14 @@
       },
       "products": [
         {
-          "@id": "pkg:golang/golang.org/x/crypto@v0.53.0"
+          "@id": "pkg:golang/golang.org/x/crypto@v0.54.0"
         }
       ],
       "status": "not_affected",
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "GO-2026-5932 concerns golang.org/x/crypto/openpgp, which is unmaintained and unsafe by design. This component does not import or execute the openpgp package; golang.org/x/crypto is pulled in transitively for other subpackages. Exploitation of openpgp via this binary is not available.",
-      "timestamp": "2026-08-05T15:10:49.000000000Z"
+      "timestamp": "2026-08-10T08:37:33.000000000Z"
     }
   ],
-  "timestamp": "2026-08-05T15:10:49Z"
+  "timestamp": "2026-08-10T08:37:33Z"
 }


### PR DESCRIPTION
## Description

Add and fix OpenVEX statements for Istio images:

- config-analyzer **1-21 / 1-25 / 1-27 / 1-29** (`GO-2026-5932` on `golang.org/x/crypto`; Prometheus CVEs on 1-21)
- correct `x/crypto` product version **0.53 → 0.54** in **cni / pilot / proxyv2 1-29**

## Why do we need it, and what problem does it solve?

Scanners flag transitive `x/crypto` / Prometheus findings in binaries that do not run the vulnerable code paths (`openpgp`, Prometheus server/UI). VEX marks them `not_affected` so CI/security reports stay accurate without unnecessary image bumps.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: chore
summary: Fix and extend module known_vulnerabilities.vex for config-analyzer and 1.29 images. 
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
