### PR TITLE
[deckhouse] rename the application endpoint Ingress annotation to packages.deckhouse.io/application-endpoint-description

### DIFF
--- a/deckhouse-controller/crds/application.yaml
+++ b/deckhouse-controller/crds/application.yaml
@@ -236,7 +236,7 @@ spec:
               urls:
                 description: |-
                   URLs of application endpoints, collected from Ingress resources of the
-                  application chart annotated with `packages.deckhouse.io/is-application-endpoint`.
+                  application chart annotated with `packages.deckhouse.io/application-endpoint-description`.
                 items:
                   description: |-
                     ApplicationStatusURL is a single application endpoint built from an Ingress
@@ -245,7 +245,7 @@ spec:
                     description:
                       description: |-
                         Description of the endpoint, taken from the value of the
-                        `packages.deckhouse.io/is-application-endpoint` annotation.
+                        `packages.deckhouse.io/application-endpoint-description` annotation.
 
                         Empty when the annotation value is "true".
                       type: string

--- a/deckhouse-controller/crds/doc-ru-application.yaml
+++ b/deckhouse-controller/crds/doc-ru-application.yaml
@@ -116,7 +116,7 @@ spec:
                 urls:
                   description: |
                     URL эндпоинтов приложения, собранные из Ingress-ресурсов
-                    чарта приложения с аннотацией `packages.deckhouse.io/is-application-endpoint`.
+                    чарта приложения с аннотацией `packages.deckhouse.io/application-endpoint-description`.
                   items:
                     description: |
                       Один эндпоинт приложения, построенный на основе Ingress-ресурса чарта приложения.
@@ -124,7 +124,7 @@ spec:
                       description:
                         description: |
                           Описание эндпоинта, взятое из значения аннотации
-                          `packages.deckhouse.io/is-application-endpoint`.
+                          `packages.deckhouse.io/application-endpoint-description`.
 
                           Пустое, если значение аннотации равно `"true"`.
                       url:

--- a/deckhouse-controller/internal/packages/nelm/endpoints.go
+++ b/deckhouse-controller/internal/packages/nelm/endpoints.go
@@ -54,7 +54,7 @@ type endpointIngress struct {
 // extractEndpointURLs collects application endpoints from a rendered
 // multi-document YAML manifest. An endpoint is built for every host/path pair
 // of networking.k8s.io Ingress resources annotated with
-// packages.deckhouse.io/is-application-endpoint (any value except "false").
+// packages.deckhouse.io/application-endpoint-description (any value except "false").
 // The annotation value becomes the endpoint description ("true" means no
 // description). The scheme is https when the host is covered by spec.tls,
 // http otherwise. The result is deduplicated and sorted; undecodable
@@ -78,7 +78,7 @@ func extractEndpointURLs(renderedManifests string) []status.URL {
 			continue
 		}
 
-		value, set := ing.Metadata.Annotations[v1alpha1.ApplicationAnnotationEndpoint]
+		value, set := ing.Metadata.Annotations[v1alpha1.ApplicationAnnotationEndpointDescription]
 		if !set || value == "false" {
 			continue
 		}

--- a/deckhouse-controller/internal/packages/nelm/endpoints_test.go
+++ b/deckhouse-controller/internal/packages/nelm/endpoints_test.go
@@ -41,7 +41,7 @@ kind: Ingress
 metadata:
   name: app
   annotations:
-    packages.deckhouse.io/application-endpoint: "true"
+    packages.deckhouse.io/application-endpoint-description: "true"
 spec:
   tls:
   - hosts:
@@ -65,7 +65,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    packages.deckhouse.io/application-endpoint: "Web UI"
+    packages.deckhouse.io/application-endpoint-description: "Web UI"
 spec:
   tls:
   - hosts:
@@ -87,7 +87,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    packages.deckhouse.io/application-endpoint: "true"
+    packages.deckhouse.io/application-endpoint-description: "true"
 spec:
   rules:
   - host: app.example.com
@@ -104,7 +104,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    packages.deckhouse.io/application-endpoint: "true"
+    packages.deckhouse.io/application-endpoint-description: "true"
 spec:
   tls:
   - hosts:
@@ -137,7 +137,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    packages.deckhouse.io/application-endpoint: "false"
+    packages.deckhouse.io/application-endpoint-description: "false"
 spec:
   rules:
   - host: app.example.com
@@ -151,7 +151,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    packages.deckhouse.io/application-endpoint: "true"
+    packages.deckhouse.io/application-endpoint-description: "true"
 spec:
   rules:
   - http:
@@ -168,7 +168,7 @@ kind: Service
 metadata:
   name: app
   annotations:
-    packages.deckhouse.io/application-endpoint: "true"
+    packages.deckhouse.io/application-endpoint-description: "true"
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -189,7 +189,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    packages.deckhouse.io/application-endpoint: "Dashboard"
+    packages.deckhouse.io/application-endpoint-description: "Dashboard"
 spec:
   tls:
   - hosts:
@@ -225,7 +225,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    packages.deckhouse.io/application-endpoint: "true"
+    packages.deckhouse.io/application-endpoint-description: "true"
 spec:
   rules:
   - host: app.example.com

--- a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/application.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/application.go
@@ -30,9 +30,10 @@ const (
 
 	ApplicationAnnotationRegistrySpecChanged = "packages.deckhouse.io/registry-spec-changed"
 
-	// ApplicationAnnotationEndpoint marks an Ingress in the application chart
-	// as an application endpoint; its hosts and paths are reflected in status.urls.
-	ApplicationAnnotationEndpoint = "packages.deckhouse.io/application-endpoint"
+	// ApplicationAnnotationEndpointDescription marks an Ingress in the application
+	// chart as an application endpoint and holds its description; the hosts and
+	// paths of that Ingress are reflected in status.urls.
+	ApplicationAnnotationEndpointDescription = "packages.deckhouse.io/application-endpoint-description"
 )
 
 var (
@@ -137,7 +138,7 @@ type ApplicationStatus struct {
 	CurrentVersion *ApplicationStatusVersion `json:"currentVersion,omitempty"`
 
 	// URLs of application endpoints, collected from Ingress resources of the
-	// application chart annotated with `packages.deckhouse.io/is-application-endpoint`.
+	// application chart annotated with `packages.deckhouse.io/application-endpoint-description`.
 	// +optional
 	URLs []ApplicationStatusURL `json:"urls,omitempty"`
 
@@ -189,7 +190,7 @@ type ApplicationStatusURL struct {
 	URL string `json:"url"`
 
 	// Description of the endpoint, taken from the value of the
-	// `packages.deckhouse.io/is-application-endpoint` annotation.
+	// `packages.deckhouse.io/application-endpoint-description` annotation.
 	//
 	// Empty when the annotation value is "true".
 	// +optional


### PR DESCRIPTION
## Description
Renames the endpoint Ingress annotation from `packages.deckhouse.io/application-endpoint` to `packages.deckhouse.io/application-endpoint-description`, so the key says what its value is. The CRD descriptions, English and Russian, documented a third key, `packages.deckhouse.io/is-application-endpoint`, that the controller never read — they now point at the real one.

Charts using the previous key have to switch to the new one, otherwise their endpoints stop being reflected in `.status.urls`.

## Why do we need it, and what problem does it solve?
The annotation value is the endpoint description, while its name said nothing about that and the only documentation of it named a key absent from the code. A wrong key fails silently — the Ingress is skipped, `.status.urls` stays empty, and neither the status nor the logs point at the annotation.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: rename the application endpoint Ingress annotation to packages.deckhouse.io/application-endpoint-description
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->

