### PR TITLE
chore: update lib-helm to 1.72.14

### DIFF
--- a/helm_lib/Chart.lock
+++ b/helm_lib/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: deckhouse_lib_helm
   repository: https://deckhouse.github.io/lib-helm
-  version: 1.72.12
-digest: sha256:703211b51d8eb0871c4a82cd9223cdda5b30b524430fc6f6b6591d683f99503c
-generated: "2026-07-29T14:48:37.601394+04:00"
+  version: 1.72.14
+digest: sha256:797db50685dd232d3125d740cdccb477ce5d23ea835fd8aefe3be5ddd12dc66c
+generated: "2026-08-10T17:29:32.276732+03:00"

--- a/helm_lib/Chart.yaml
+++ b/helm_lib/Chart.yaml
@@ -5,5 +5,5 @@ version: 0.1.0
 description: Helm helpers
 dependencies:
   - name: deckhouse_lib_helm
-    version: "1.72.12"
+    version: "1.72.14"
     repository: https://deckhouse.github.io/lib-helm

--- a/helm_lib/charts/deckhouse_lib_helm/Chart.yaml
+++ b/helm_lib/charts/deckhouse_lib_helm/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: Helm utils template definitions for Deckhouse modules.
 name: deckhouse_lib_helm
 type: library
-version: 1.72.12
+version: 1.72.14

--- a/helm_lib/charts/deckhouse_lib_helm/README.md
+++ b/helm_lib/charts/deckhouse_lib_helm/README.md
@@ -8,6 +8,7 @@
 | [helm_lib_admission_webhook_client_ca_certificate](#helm_lib_admission_webhook_client_ca_certificate) |
 | **Api Version And Kind** |
 | [helm_lib_kind_exists](#helm_lib_kind_exists) |
+| [helm_lib_api_version_exists](#helm_lib_api_version_exists) |
 | [helm_lib_get_api_version_by_kind](#helm_lib_get_api_version_by_kind) |
 | **Application Image** |
 | [helm_lib_application_image](#helm_lib_application_image) |
@@ -195,6 +196,21 @@ list:
 list:
 -  Template context with .Values, .Chart, etc 
 -  Kind name portion 
+
+
+### helm_lib_api_version_exists
+
+ returns "true" if the GVK is available: installed from modules' crds (global.discovery.apiVersions) or present in cluster discovery (Capabilities) 
+
+#### Usage
+
+`{{ if (include "helm_lib_api_version_exists" (list . "<group>/<version>/<Kind>")) }} `
+
+#### Arguments
+
+list:
+-  Template context with .Values, .Chart, etc 
+-  Group/version/kind string, e.g. "snapshot.storage.k8s.io/v1/VolumeSnapshotClass" 
 
 
 ### helm_lib_get_api_version_by_kind
@@ -1842,13 +1858,14 @@ list:
 
 #### Usage
 
-`{{ include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "test")) }} `
+`{{ include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "test") (dict "revisionScoped" true)) }} `
 
 #### Arguments
 
 list:
 -  Template context with .Values, .Chart, etc 
 -  Match labels for podAntiAffinity label selector 
+-  Whether to scope podAntiAffinity to pods from the same Deployment revision 
 
 
 ### helm_lib_pod_affinity

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_api_version_and_kind.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_api_version_and_kind.tpl
@@ -14,6 +14,16 @@
   {{- end }}
 {{- end -}}
 
+{{- /* Usage: {{ if (include "helm_lib_api_version_exists" (list . "<group>/<version>/<Kind>")) }} */ -}}
+{{- /* returns "true" if the GVK is available: installed from modules' crds (global.discovery.apiVersions) or present in cluster discovery (Capabilities) */ -}}
+{{- define "helm_lib_api_version_exists" -}}
+  {{- $context := index . 0 -}} {{- /* Template context with .Values, .Chart, etc */ -}}
+  {{- $crdAPIVer := index . 1 -}} {{- /* Group/version/kind string, e.g. "snapshot.storage.k8s.io/v1/VolumeSnapshotClass" */ -}}
+  {{- if or ($context.Values.global.discovery.apiVersions | has $crdAPIVer) ($context.Capabilities.APIVersions.Has $crdAPIVer) -}}
+true
+  {{- end -}}
+{{- end -}}
+
 {{- /* Usage: {{ include "helm_lib_get_api_version_by_kind" (list . "<kind-name>") }} */ -}}
 {{- /* returns current apiVersion string, based on available helm capabilities, for the provided kind (not all kinds are supported) */ -}}
 {{- define "helm_lib_get_api_version_by_kind" }}

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_csi_controller.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_csi_controller.tpl
@@ -730,6 +730,22 @@ rules:
 - apiGroups: ["storage.k8s.io"]
   resources: ["volumeattachments"]
   verbs: ["get", "list", "watch"]
+{{- if (include "helm_lib_api_version_exists" (list . "storage-foundation.deckhouse.io/v1alpha1/VolumeRestoreRequest")) }}
+# When storage-foundation is enabled, the stock external-provisioner is replaced with its fork
+# (see helm_lib_csi_image_with_common_fallback), which additionally runs the VolumeRestoreRequest
+# executor: a cluster-wide informer on volumerestorerequests that provisions the target volume and
+# creates the PV/PVC pair for it. The sidecar is deployed by the driver module, so its
+# provisioner SA needs these permissions in every module that uses this define.
+# volumerestorerequests/status is intentionally NOT granted: the status is owned by the
+# storage-foundation controller, which derives it from the target PVC; the sidecar only executes.
+- apiGroups: ["storage-foundation.deckhouse.io"]
+  resources: ["volumerestorerequests"]
+  verbs: ["get", "list", "watch"]
+# Complements the stock persistentvolumeclaims rule above (get/list/watch/update).
+- apiGroups: [""]
+  resources: ["persistentvolumeclaims"]
+  verbs: ["create", "patch"]
+{{- end }}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_module_image.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_module_image.tpl
@@ -4,65 +4,53 @@
   {{- $context := index . 0 }} {{- /* Template context with .Values, .Chart, etc */ -}}
   {{- $containerName := index . 1 | trimAll "\"" }} {{- /* Container name */ -}}
 
-  {{- if and (lt (len .) 3) $context.Module $context.Module.Package }}
-    {{- /* New approach: the current module's own image from its package digests. */}}
+  {{- /* New approach: use module package values */}} 
+  {{- if and $context.Module $context.Module.Package }}
+    {{- $registryBase := $context.Module.Package.Registry.repository }}
+    {{- if not $registryBase }}
+      {{- fail "Registry base is not set" }}
+    {{- end }}
+
+    {{- $packageName := $context.Module.Package.Name }}
+    {{- if not $packageName }}
+      {{- fail "Package name is not set" }}
+    {{- end }}
+
     {{- $imageDigest := index $context.Module.Package.Digests $containerName }}
     {{- if not $imageDigest }}
       {{- fail (printf "Image %s has no digest" $containerName) }}
     {{- end }}
 
-    {{- $registryBase := $context.Module.Package.Registry.repository }}
-    {{- if $registryBase }}
-      {{- /* Module carries its own registry (external module): <repo>/<package>@<digest> */}}
-      {{- $packageName := $context.Module.Package.Name }}
-      {{- if not $packageName }}
-        {{- fail "Package name is not set" }}
-      {{- end }}
-      {{- printf "%s/%s@%s" $registryBase $packageName $imageDigest }}
-    {{- else }}
-      {{- /* Embedded module: no own registry, image lives in the platform registry addressed by digest */}}
-      {{- $registryBase = $context.Values.global.modulesImages.registry.base }}
-      {{- if not $registryBase }}
-        {{- fail "Registry base is not set" }}
-      {{- end }}
-      {{- printf "%s@%s" $registryBase $imageDigest }}
-    {{- end }}
+    {{- printf "%s/%s@%s" $registryBase $packageName $imageDigest }}
 
+  {{- /* Legacy fallback: use global modulesImages values */}}
   {{- else }}
-    {{- /* Global map: legacy (by chart name) or an explicit source module (e.g. "common"). */}}
-    {{- $moduleName := $context.Chart.Name }}
+    {{- $rawModuleName := $context.Chart.Name }}
     {{- if ge (len .) 3 }}
-      {{- $moduleName = (index . 2) }}
+      {{- $rawModuleName = (index . 2) }} {{- /* Optional module name */ -}}
     {{- end }}
-    {{- include "helm_lib_module_image_from_global" (list $context $containerName $moduleName) }}
-  {{- end }}
-{{- end }}
+    {{- $moduleName := (include "helm_lib_module_camelcase_name" $rawModuleName) }}
 
-{{- /* Resolve an image from the global modulesImages digest map by module name. */}}
-{{- /* Usage: {{ include "helm_lib_module_image_from_global" (list $context "<container-name>" "<raw-module-name>") }} */ -}}
-{{- define "helm_lib_module_image_from_global" }}
-  {{- $context := index . 0 }}
-  {{- $containerName := index . 1 | trimAll "\"" }}
-  {{- $rawModuleName := index . 2 }}
-  {{- $moduleName := (include "helm_lib_module_camelcase_name" $rawModuleName) }}
+    {{- $imageDigest := index $context.Values.global.modulesImages.digests $moduleName $containerName }}
+    {{- if not $imageDigest }}
+      {{- $error := (printf "Image %s.%s has no digest" $moduleName $containerName ) }}
+      {{- fail $error }}
+    {{- end }}
 
-  {{- $imageDigest := index $context.Values.global.modulesImages.digests $moduleName $containerName }}
-  {{- if not $imageDigest }}
-    {{- fail (printf "Image %s.%s has no digest" $moduleName $containerName) }}
-  {{- end }}
-
-  {{- $registryBase := $context.Values.global.modulesImages.registry.base }}
-  {{- /* handle external modules registry */}}
-  {{- if index $context.Values $moduleName }}
-    {{- if index $context.Values $moduleName "registry" }}
-      {{- if index $context.Values $moduleName "registry" "base" }}
-        {{- $host := trimAll "/" (index $context.Values $moduleName "registry" "base") }}
-        {{- $path := trimAll "/" (include "helm_lib_module_kebabcase_name" $rawModuleName) }}
-        {{- $registryBase = join "/" (list $host $path) }}
+    {{- $registryBase := $context.Values.global.modulesImages.registry.base }}
+  {{- /*  handle external modules registry */}}
+    {{- if index $context.Values $moduleName }}
+      {{- if index $context.Values $moduleName "registry" }}
+        {{- if index $context.Values $moduleName "registry" "base" }}
+          {{- $host := trimAll "/" (index $context.Values $moduleName "registry" "base") }}
+          {{- $path := trimAll "/" (include "helm_lib_module_kebabcase_name" $rawModuleName) }}
+          {{- $registryBase = join "/" (list $host $path) }}
+        {{- end }}
       {{- end }}
     {{- end }}
+  {{- /* end of external module handling block */}}
+    {{- printf "%s@%s" $registryBase $imageDigest }}
   {{- end }}
-  {{- printf "%s@%s" $registryBase $imageDigest }}
 {{- end }}
 
 {{- /* Usage: {{ include "helm_lib_module_image_no_fail" (list . "<container-name>") }} */ -}}

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_spec_for_high_availability.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_spec_for_high_availability.tpl
@@ -1,8 +1,15 @@
-{{- /* Usage: {{ include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "test")) }} */ -}}
+{{- /* Usage: {{ include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "test") (dict "revisionScoped" true)) }} */ -}}
 {{- /* returns pod affinity spec */ -}}
 {{- define "helm_lib_pod_anti_affinity_for_ha" }}
 {{- $context := index . 0 -}} {{- /* Template context with .Values, .Chart, etc */ -}}
-{{- $labels := index . 1 }} {{- /* Match labels for podAntiAffinity label selector */ -}}
+{{- $labels := index . 1 -}} {{- /* Match labels for podAntiAffinity label selector */ -}}
+{{- $revisionScoped := false -}} {{- /* Whether to scope podAntiAffinity to pods from the same Deployment revision */ -}}
+{{- if ge (len .) 3 -}}
+  {{- $options := index . 2 -}}
+  {{- if hasKey $options "revisionScoped" -}}
+    {{- $revisionScoped = $options.revisionScoped -}}
+  {{- end -}}
+{{- end -}}
   {{- if (include "helm_lib_ha_enabled" $context) }}
 affinity:
   podAntiAffinity:
@@ -11,6 +18,10 @@ affinity:
         matchLabels:
     {{- range $key, $value := $labels }}
           {{ $key }}: {{ $value | quote }}
+    {{- end }}
+    {{- if $revisionScoped }}
+      matchLabelKeys:
+      - pod-template-hash
     {{- end }}
       topologyKey: kubernetes.io/hostname
   {{- end }}


### PR DESCRIPTION
## Description

Updated `lib-helm` from `1.72.12` to `1.72.14`.

## Why do we need it, and what problem does it solve?

The new version adds optional revision-scoped HA pod anti-affinity and includes the other fixes released since `1.72.12`.

## Why do we need it in the patch release (if we do)?

Required to use revision-scoped anti-affinity in Deckhouse.

## Checklist

- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: common
type: chore
summary: Updated lib-helm to version 1.72.14.
impact_level: low
```