### PR TITLE
[docs] limit the impact of a failed documentation build

### DIFF
--- a/deckhouse-controller/pkg/controller/module-controllers/docbuilder/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/docbuilder/controller.go
@@ -52,11 +52,7 @@ import (
 	"github.com/deckhouse/deckhouse/pkg/log"
 )
 
-const (
-	controllerName = "module-documentation"
-
-	defaultDocumentationCheckInterval = 10 * time.Second
-)
+const controllerName = "module-documentation"
 
 type reconciler struct {
 	client               client.Client
@@ -305,8 +301,11 @@ func (r *reconciler) createOrUpdateReconcile(ctx context.Context, md *v1alpha1.M
 		return result, fmt.Errorf("patch: %w", err)
 	}
 
+	// Returning an error hands the retry to the workqueue rate limiter, which backs off
+	// exponentially. Every retry re-uploads the documentation and triggers a full site rebuild,
+	// so a fixed interval turns a persistent render failure into an endless rebuild loop.
 	if mdCopy.Status.RenderResult != v1alpha1.ResultRendered {
-		return ctrl.Result{RequeueAfter: defaultDocumentationCheckInterval}, nil
+		return result, fmt.Errorf("render documentation: %s", mdCopy.Status.RenderResult)
 	}
 
 	if !controllerutil.ContainsFinalizer(mdCopy, documentationExistsFinalizer) {

--- a/deckhouse-controller/pkg/controller/module-controllers/docbuilder/controller_test.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/docbuilder/controller_test.go
@@ -144,8 +144,8 @@ func (suite *ControllerTestSuite) TestCreateReconcile() {
 
 		md := suite.getModuleDocumentation("testmodule")
 		res, err := suite.ctr.createOrUpdateReconcile(context.TODO(), md)
-		assert.Equal(suite.T(), res.RequeueAfter, defaultDocumentationCheckInterval)
-		require.NoError(suite.T(), err)
+		assert.Empty(suite.T(), res.RequeueAfter)
+		require.Error(suite.T(), err)
 	})
 
 	suite.Run("render new version", func() {
@@ -201,8 +201,8 @@ func (suite *ControllerTestSuite) TestCreateReconcile() {
 
 		md := suite.getModuleDocumentation("absentmodule")
 		res, err := suite.ctr.createOrUpdateReconcile(context.TODO(), md)
-		assert.Equal(suite.T(), res.RequeueAfter, defaultDocumentationCheckInterval)
-		require.NoError(suite.T(), err)
+		assert.Empty(suite.T(), res.RequeueAfter)
+		require.Error(suite.T(), err)
 	})
 }
 

--- a/modules/810-documentation/templates/deployment.yaml
+++ b/modules/810-documentation/templates/deployment.yaml
@@ -44,9 +44,7 @@ spec:
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 10 | nindent 12 }}
-  {{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler") }}
             {{- include "web_resources" . | nindent 12 }}
-  {{- end }}
           limits:
             cpu: 200m
             memory: 100Mi
@@ -119,9 +117,7 @@ spec:
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 10 | nindent 12 }}
-  {{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler") }}
             {{- include "builder_resources" . | nindent 12 }}
-  {{- end }}
           limits:
             cpu: 200m
             memory: 2Gi


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Backport of #21968. Cherry-picked cleanly, no conflicts.

- **Requests.** The memory limit was set unconditionally but the request only without VPA, and Kubernetes defaults a request to the limit, so the builder reserved 2Gi. The request now stays regardless of VPA, which still overrides it.
- **Retry.** A render failure was requeued every 10s, and each retry triggers another full site rebuild. It is now returned as an error, so the rate limiter backs off exponentially.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
The builder reserved 2Gi on the system node while using a fraction of it, so a small node was left with almost no allocatable memory and pods created afterwards stayed Pending with `Insufficient memory`. And whenever a render failed, it was retried every 10 seconds, each retry triggering another full rebuild of the site, so the builder never got a pause.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: limit the impact of a failed documentation build
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
