### PR TITLE
fix

### DIFF
--- a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module.go
@@ -272,13 +272,15 @@ func (m *Module) IsEnabledByBundle(editionName, bundleName string) bool {
 		return false
 	}
 
-	// an explicit edition entry is authoritative: it fully defines the enabled
-	// bundles for the edition and does not fall back to the default settings
-	if edition, ok := access.Editions[editionName]; ok {
+	// an edition entry is authoritative only when it declares its own bundles;
+	// an availability-only entry (no enabledInBundles) inherits the default
+	// settings, so marking a module available in an edition does not silently
+	// drop the _default bundle enablement
+	if edition, ok := access.Editions[editionName]; ok && len(edition.EnabledInBundles) > 0 {
 		return isEnabledInBundle(edition.EnabledInBundles, bundleName)
 	}
 
-	// no edition entry — fall back to the default settings
+	// no edition entry (or an availability-only one) — fall back to the default settings
 	defaultSettings, ok := access.Editions["_default"]
 	if !ok {
 		return false

--- a/deckhouse-controller/pkg/controller/moduleloader/types/definition.go
+++ b/deckhouse-controller/pkg/controller/moduleloader/types/definition.go
@@ -141,13 +141,15 @@ func (a *ModuleAccessibility) IsEnabled(editionName, bundleName string) bool {
 		return false
 	}
 
-	// an explicit edition entry is authoritative: it fully defines the enabled
-	// bundles for the edition and does not fall back to the default settings
-	if edition, ok := a.Editions[editionName]; ok {
+	// an edition entry is authoritative only when it declares its own bundles;
+	// an availability-only entry (no enabledInBundles) inherits the default
+	// settings, so marking a module available in an edition does not silently
+	// drop the _default bundle enablement
+	if edition, ok := a.Editions[editionName]; ok && len(edition.EnabledInBundles) > 0 {
 		return isEnabledInBundle(edition.EnabledInBundles, bundleName)
 	}
 
-	// no edition entry — fall back to the default settings
+	// no edition entry (or an availability-only one) — fall back to the default settings
 	defaultSettings, ok := a.Editions["_default"]
 	if !ok {
 		return false

--- a/deckhouse-controller/pkg/controller/moduleloader/types/definition_test.go
+++ b/deckhouse-controller/pkg/controller/moduleloader/types/definition_test.go
@@ -75,3 +75,41 @@ accessibility:
 	// check mapping to v1alpha1
 	assert.NotEmpty(t, m.Accessibility.ToV1Alpha1())
 }
+
+func TestModuleAccessibilityIsEnabled(t *testing.T) {
+	// Regression from #20958: an availability-only edition entry (no enabledInBundles)
+	// must inherit the _default bundle enablement instead of silently disabling the module.
+	availabilityOnly := &ModuleAccessibility{
+		Editions: map[string]ModuleEdition{
+			"_default": {Available: true, EnabledInBundles: []string{"Default", "Managed"}},
+			"cse":      {Available: true}, // no enabledInBundles -> inherit _default
+		},
+	}
+	assert.True(t, availabilityOnly.IsEnabled("cse", "Default"), "availability-only cse entry must inherit _default bundles")
+	assert.True(t, availabilityOnly.IsEnabled("cse", "Managed"))
+	assert.False(t, availabilityOnly.IsEnabled("cse", "Minimal"), "Minimal is not in _default bundles")
+	assert.True(t, availabilityOnly.IsAvailable("cse"))
+
+	// An edition entry that declares its own bundles stays authoritative: it does NOT
+	// merge with _default, so a bundle only present in _default is not enabled for it.
+	authoritative := &ModuleAccessibility{
+		Editions: map[string]ModuleEdition{
+			"_default": {Available: true, EnabledInBundles: []string{"Default"}},
+			"ee":       {Available: true, EnabledInBundles: []string{"Minimal"}},
+		},
+	}
+	assert.True(t, authoritative.IsEnabled("ee", "Minimal"))
+	assert.False(t, authoritative.IsEnabled("ee", "Default"), "ee declares its own bundles and must not inherit _default's Default")
+	// an edition without its own entry falls back to _default
+	assert.True(t, authoritative.IsEnabled("ce", "Default"))
+	assert.False(t, authoritative.IsEnabled("ce", "Minimal"))
+
+	// no _default and no matching edition entry -> not enabled
+	noDefault := &ModuleAccessibility{
+		Editions: map[string]ModuleEdition{
+			"ee": {Available: true, EnabledInBundles: []string{"Default"}},
+		},
+	}
+	assert.False(t, noDefault.IsEnabled("cse", "Default"))
+	assert.True(t, noDefault.IsEnabled("ee", "Default"))
+}


### PR DESCRIPTION
## Description

Since #20958 (*"set accessibility for embedded modules"*), `ModuleAccessibility.IsEnabled` — and its copy `Module.IsEnabledByBundle` — treats **any** explicit edition entry as fully authoritative for bundle enablement and no longer falls back to the `_default` entry. That same PR also added `accessibility` blocks to ~47 embedded modules (previously `nil`, so they were not gated by the edition extenders at all — `AddConstraints` registers a module in the `editionAvailable`/`editionEnabled` extenders only when its accessibility is non-nil).

Combined effect: a module that declares an **availability-only edition entry** — e.g. `cse: { available: true }` with no `enabledInBundles`, added only to mark availability in that edition — together with a `_default: { enabledInBundles: [...] }` used for bundle enablement, becomes *available but never enabled by any bundle*. The `_default` bundles are shadowed by the bundle-less edition entry, so the module turns on only via an explicit `ModuleConfig`. The same gate applies to external modules during release-ensure (`source/helpers.go`) and in `ModuleConfig` validation, using the running `edition.Name` / bundle.

**Fix:** an edition entry is authoritative only when it declares its own `enabledInBundles`; an availability-only entry (no bundles) inherits `_default`. Edition entries that *do* declare bundles keep the authoritative, non-merging behavior introduced in #20958, so per-edition bundle overrides still work.

Applied to both copies of the logic:
- `ModuleAccessibility.IsEnabled` — `deckhouse-controller/pkg/controller/moduleloader/types/definition.go` (used by the `editionEnabled` extender, ModuleSource release-ensure, MC validation);
- `Module.IsEnabledByBundle` — `deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module.go`.

Intentionally **not** changed (flagged for a separate decision): the package-model equivalent `edition.Edition.IsEnabled` in `pkg/edition/license.go`, which documents the opposite (*"authoritative even when empty"*) for the newer package/licensing model — a distinct subsystem.

## Why do we need it, and what problem does it solve?

Regression fix. Modules declared *available-in-edition + enabled-via-`_default`* silently stopped auto-enabling and had to be enabled by hand in `ModuleConfig` — most visible in CSE and for external modules. The #20958 semantics change is not covered by a distinguishing unit test (existing `TestUnmarshal` has no `_default`) and has no changelog entry.

## Why do we need it in the patch release (if we do)?

Worth backporting to any patch line that already shipped #20958 — it silently disables modules that should be enabled by default.

## Checklist
- [x] The code is covered by unit tests. *(new `TestModuleAccessibilityIsEnabled`; existing `TestUnmarshal` and MC-validation tests pass; touched packages build)*
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse-controller
type: fix
summary: Module accessibility — an availability-only edition entry inherits `_default` bundle enablement instead of disabling the module.
impact_level: default
```
