### PR TITLE
[candi] update base images to v2.1.0

### DIFF
--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -3935,7 +3935,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:2ab76902cdeb0034152b4e1c81f1ec08fa26709075a52b25f700ce7e3c0f91bb"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:4a7df18cd80f2974858278a2fdc907a006867650052aa58c8fc67f500f7e1bae"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'
@@ -4050,7 +4050,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run node-controller tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:2ab76902cdeb0034152b4e1c81f1ec08fa26709075a52b25f700ce7e3c0f91bb"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:4a7df18cd80f2974858278a2fdc907a006867650052aa58c8fc67f500f7e1bae"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -3935,7 +3935,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:4a7df18cd80f2974858278a2fdc907a006867650052aa58c8fc67f500f7e1bae"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:f816c1b296cb31935296365802fb788d113a5ea33141c8c50ad5ac2ccba69a23"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'
@@ -4050,7 +4050,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run node-controller tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:4a7df18cd80f2974858278a2fdc907a006867650052aa58c8fc67f500f7e1bae"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:f816c1b296cb31935296365802fb788d113a5ea33141c8c50ad5ac2ccba69a23"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/.github/workflows/build-and-test_main.yml
+++ b/.github/workflows/build-and-test_main.yml
@@ -1281,7 +1281,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:2ab76902cdeb0034152b4e1c81f1ec08fa26709075a52b25f700ce7e3c0f91bb"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:4a7df18cd80f2974858278a2fdc907a006867650052aa58c8fc67f500f7e1bae"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/.github/workflows/build-and-test_main.yml
+++ b/.github/workflows/build-and-test_main.yml
@@ -1281,7 +1281,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:4a7df18cd80f2974858278a2fdc907a006867650052aa58c8fc67f500f7e1bae"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:f816c1b296cb31935296365802fb788d113a5ea33141c8c50ad5ac2ccba69a23"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -3563,7 +3563,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:2ab76902cdeb0034152b4e1c81f1ec08fa26709075a52b25f700ce7e3c0f91bb"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:4a7df18cd80f2974858278a2fdc907a006867650052aa58c8fc67f500f7e1bae"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -3563,7 +3563,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:4a7df18cd80f2974858278a2fdc907a006867650052aa58c8fc67f500f7e1bae"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:f816c1b296cb31935296365802fb788d113a5ea33141c8c50ad5ac2ccba69a23"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/.werf/defines/olcedar-sysext.tmpl
+++ b/.werf/defines/olcedar-sysext.tmpl
@@ -19,13 +19,6 @@
   add: /d8
   to: /usr/bin/d8
   before: install
-- from: {{ index .Images "systemd-260.4" }}
-  add: /usr/lib/systemd
-  to: /usr/lib/systemd
-  includePaths:
-  - systemd-keyutil
-  - libsystemd-shared-260.so
-  before: install
 {{- end }}
 
 # The OIDC token is minted inside the build rather than passed in: a GitHub

--- a/candi/alt_base_images.yml
+++ b/candi/alt_base_images.yml
@@ -1,10 +1,9 @@
-# version=v1.3.22
+# version=v2.0.2
 REGISTRY_PATH: registry.deckhouse.io/container-factory
-base/distroless-fin: "sha256:014bf210c5e13d1e2ea968979a9cc5527d60a6d10ecedd51f97b6dd0dc7d554b" # from: builder/scratch
-builder/distroless: "sha256:cbbacd9cc6b4b49e900bf525f9f21c07d4fc04ce6c6b8705ec6d79bf2aa821ea" # from: builder/scratch
-builder/golang-1.25: "sha256:9d5909a5ba1d022d0157816ce59af74e607aed4496981cf5046b29cca56c867e" # from: builder/distroless
-builder/golang-1.26: "sha256:2ab76902cdeb0034152b4e1c81f1ec08fa26709075a52b25f700ce7e3c0f91bb" # from: builder/distroless
-builder/golang: "sha256:2ab76902cdeb0034152b4e1c81f1ec08fa26709075a52b25f700ce7e3c0f91bb" # from: builder/distroless
-minget-0.1: "sha256:6e37a40153be199ac9d9652072cae7ee4a7a595f9d4de53d04b0ac3b557b658d" # from: builder/scratch
-minget: "sha256:6e37a40153be199ac9d9652072cae7ee4a7a595f9d4de53d04b0ac3b557b658d" # from: builder/scratch
-systemd-260.4: "sha256:e8f1c8b4bc651f9e317568d7380887c7bfafee15edd9a84857be366e36e8abb3" # from: builder/scratch
+base/distroless-fin: "sha256:4ad8cec42020ee1fafce1b73672f91d43487d753b826ae19dfcd37b7582d9339" # from: base/scratch
+builder/distroless: "sha256:55f867c1fdc3df868f2954f1e294c1ed2d4d3048d772b4a3d312b6f94e95d739" # from: base/scratch
+builder/golang-1.25: "sha256:4a7df18cd80f2974858278a2fdc907a006867650052aa58c8fc67f500f7e1bae" # from: builder/distroless
+builder/golang-1.26: "sha256:4a7df18cd80f2974858278a2fdc907a006867650052aa58c8fc67f500f7e1bae" # from: builder/distroless
+builder/golang: "sha256:4a7df18cd80f2974858278a2fdc907a006867650052aa58c8fc67f500f7e1bae" # from: builder/distroless
+minget-0.1: "sha256:6e37a40153be199ac9d9652072cae7ee4a7a595f9d4de53d04b0ac3b557b658d" # from: base/scratch
+minget: "sha256:6e37a40153be199ac9d9652072cae7ee4a7a595f9d4de53d04b0ac3b557b658d" # from: base/scratch

--- a/candi/alt_base_images.yml
+++ b/candi/alt_base_images.yml
@@ -1,9 +1,9 @@
-# version=v2.0.2
+# version=v2.1.0
 REGISTRY_PATH: registry.deckhouse.io/container-factory
-base/distroless-fin: "sha256:4ad8cec42020ee1fafce1b73672f91d43487d753b826ae19dfcd37b7582d9339" # from: base/scratch
-builder/distroless: "sha256:55f867c1fdc3df868f2954f1e294c1ed2d4d3048d772b4a3d312b6f94e95d739" # from: base/scratch
-builder/golang-1.25: "sha256:4a7df18cd80f2974858278a2fdc907a006867650052aa58c8fc67f500f7e1bae" # from: builder/distroless
-builder/golang-1.26: "sha256:4a7df18cd80f2974858278a2fdc907a006867650052aa58c8fc67f500f7e1bae" # from: builder/distroless
-builder/golang: "sha256:4a7df18cd80f2974858278a2fdc907a006867650052aa58c8fc67f500f7e1bae" # from: builder/distroless
-minget-0.1: "sha256:6e37a40153be199ac9d9652072cae7ee4a7a595f9d4de53d04b0ac3b557b658d" # from: base/scratch
-minget: "sha256:6e37a40153be199ac9d9652072cae7ee4a7a595f9d4de53d04b0ac3b557b658d" # from: base/scratch
+base/distroless-fin: "sha256:b87c25e94e1acceb36335d55954b8c9990f75520068d36b625d8474790fe4afd" # from: base/scratch
+builder/distroless: "sha256:059ef42b81381593c99500462901927e4ad8c592180e39cd783161f5e90412c4" # from: base/scratch
+builder/golang-1.25: "sha256:f816c1b296cb31935296365802fb788d113a5ea33141c8c50ad5ac2ccba69a23" # from: builder/distroless
+builder/golang-1.26: "sha256:f816c1b296cb31935296365802fb788d113a5ea33141c8c50ad5ac2ccba69a23" # from: builder/distroless
+builder/golang: "sha256:f816c1b296cb31935296365802fb788d113a5ea33141c8c50ad5ac2ccba69a23" # from: builder/distroless
+minget-0.1: "sha256:2c4c67ddccd25bdf01ee0bc5ac77ca5eb0b8f826484250cc416fb7b0c47e4283" # from: base/scratch
+minget: "sha256:2c4c67ddccd25bdf01ee0bc5ac77ca5eb0b8f826484250cc416fb7b0c47e4283" # from: base/scratch

--- a/modules/007-registrypackages/images/containerd/werf.inc.yaml
+++ b/modules/007-registrypackages/images/containerd/werf.inc.yaml
@@ -282,7 +282,7 @@ git:
 {{- include "olcedar sysext sign secrets" . }}
 shell:
   beforeInstall:
-  - pm install erofs-utils coreutils cryptsetup
+  - pm install erofs-utils coreutils cryptsetup systemd@260.4
   - mkdir -p /out
   install:
   - mkdir -p /sysext/usr/lib/extension-release.d /sysext/usr/lib/systemd/system

--- a/modules/007-registrypackages/images/kubelet/werf.inc.yaml
+++ b/modules/007-registrypackages/images/kubelet/werf.inc.yaml
@@ -94,7 +94,7 @@ git:
 {{- include "olcedar sysext sign secrets" . }}
 shell:
   beforeInstall:
-  - pm install erofs-utils coreutils cryptsetup
+  - pm install erofs-utils coreutils cryptsetup systemd@260.4
   - mkdir -p /out
   install:
   - mkdir -p /sysext/usr/lib/extension-release.d /sysext/usr/lib/systemd/system

--- a/modules/007-registrypackages/images/kubernetes-cni/werf.inc.yaml
+++ b/modules/007-registrypackages/images/kubernetes-cni/werf.inc.yaml
@@ -165,7 +165,7 @@ git:
 {{- include "olcedar sysext sign secrets" . }}
 shell:
   beforeInstall:
-  - pm install erofs-utils coreutils cryptsetup
+  - pm install erofs-utils coreutils cryptsetup systemd@260.4
   - mkdir -p /out
   install:
   - mkdir -p /sysext/usr/lib/extension-release.d /sysext/usr/lib/systemd/system


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Upgrade base images to v2.1.0
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Enable SBOM for base images, add new packages and other features
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: chore
summary: SBOM enabled for building base images
impact: New process for building base images. Some base platforms, such as base/{gotest/redis/nginx/etc}, are now available as packages for installation via the package manager (PM). Add own cc-wrapper to build flow. Fix qemu arch problems
impact_level: high
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
