### PR TITLE
[deckhouse] enable PSS restricted security policy checks on d8-monitoring

### DIFF
--- a/modules/002-deckhouse/template_tests/module_test.go
+++ b/modules/002-deckhouse/template_tests/module_test.go
@@ -353,4 +353,34 @@ var _ = Describe("Module :: deckhouse :: helm template ::", func() {
 			Expect(f.KubernetesResource("PodMonitor", "d8-monitoring", "webhook-handler").Exists()).To(BeFalse())
 		})
 	})
+
+	Context("Security policy labels on the d8-monitoring namespace", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", globalValues)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYaml("deckhouse", moduleValuesForMasterNode)
+			f.HelmRender()
+		})
+
+		It("Must be evaluated against the restricted standard in warn mode", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			ns := f.KubernetesGlobalResource("Namespace", "d8-monitoring")
+			Expect(ns.Exists()).To(BeTrue())
+			Expect(ns.Field(`metadata.labels.security\.deckhouse\.io/pod-policy`).String()).To(Equal("restricted"))
+			Expect(ns.Field(`metadata.labels.security\.deckhouse\.io/pod-policy-action`).String()).To(Equal("warn"))
+			Expect(ns.Field(`metadata.labels.security\.deckhouse\.io/enable-security-policy-check`).String()).To(Equal("true"))
+		})
+
+		It("Must keep the labels it already had", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			ns := f.KubernetesGlobalResource("Namespace", "d8-monitoring")
+			Expect(ns.Field(`metadata.labels.prometheus\.deckhouse\.io/monitor-watcher-enabled`).String()).To(Equal("true"))
+			Expect(ns.Field(`metadata.labels.prometheus\.deckhouse\.io/rules-watcher-enabled`).String()).To(Equal("true"))
+			Expect(ns.Field(`metadata.labels.prometheus\.deckhouse\.io/scrape-configs-watcher-enabled`).String()).To(Equal("true"))
+			Expect(ns.Field(`metadata.labels.extended-monitoring\.deckhouse\.io/enabled`).Exists()).To(BeTrue())
+			Expect(ns.Field("metadata.labels.heritage").String()).To(Equal("deckhouse"))
+		})
+	})
 })

--- a/modules/002-deckhouse/templates/namespace.yaml
+++ b/modules/002-deckhouse/templates/namespace.yaml
@@ -5,7 +5,15 @@ metadata:
   name: d8-monitoring
   annotations:
     helm.sh/resource-policy: keep
-  {{- include "helm_lib_module_labels" (list . (dict "prometheus.deckhouse.io/monitor-watcher-enabled" "true" "extended-monitoring.deckhouse.io/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true" "prometheus.deckhouse.io/scrape-configs-watcher-enabled" "true")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict
+    "prometheus.deckhouse.io/monitor-watcher-enabled" "true"
+    "extended-monitoring.deckhouse.io/enabled" ""
+    "prometheus.deckhouse.io/rules-watcher-enabled" "true"
+    "prometheus.deckhouse.io/scrape-configs-watcher-enabled" "true"
+    "security.deckhouse.io/pod-policy" "restricted"
+    "security.deckhouse.io/pod-policy-action" "warn"
+    "security.deckhouse.io/enable-security-policy-check" "true"
+  )) | nindent 2 }}
 ---
 apiVersion: v1
 kind: Namespace


### PR DESCRIPTION
## Description

### Why do we need it, and what problem does it solve?

Part of the migration of system namespaces to PSS `restricted` + SecurityPolicy checks ([ADR](https://fox.flant.com/deckhouse/docs/architecture-decision-records/-/blob/main/platform-security/2025-11-06-security-policy-exception.md)).

`modules/002-deckhouse/templates/namespace.yaml` — three labels added to `d8-monitoring` (existing labels preserved):

```yaml
security.deckhouse.io/pod-policy: "restricted"
security.deckhouse.io/pod-policy-action: "warn"
security.deckhouse.io/enable-security-policy-check: "true"
```

Plus two template tests in `modules/002-deckhouse/template_tests/module_test.go` covering the new labels and the preserved ones.

`d8-monitoring` is created here but hosts workloads owned by other repositories — the external observability modules, plus `monitoring-kubernetes` and `extended-monitoring`. They cannot label it themselves (two Helm releases cannot own the same Namespace), so the labels have to live in this template. Without them the `SecurityPolicyException` resources shipped in those modules are inert: `modules/015-admission-policy-engine/templates/_helpers.tpl` selects pods via a `namespaceSelector` on these labels and excludes `heritage: deckhouse` namespaces from the default constraint set.

`pod-policy-action: warn` matches how `d8-system` and `d8-cloud-instance-manager` are labelled today; it is for the 1.78 warn stage and will be dropped before 1.79.

## Verification

Verified on the `kilo` dev stand running this PR's build (`dev-registry.../deckhouse-oss:pr22024`) with every module that deploys into `d8-monitoring` pinned to its corresponding MR build.

- the labels land on `d8-monitoring` as intended, `heritage: deckhouse` preserved, and the `-d8` gatekeeper constraints activate for the namespace
- **deny pass**: with `pod-policy-action` removed — i.e. under real `deny` enforcement rather than `warn` — **all 22 pods in `d8-monitoring` are admitted, zero denials**
- every DaemonSet/Deployment in the namespace was additionally deleted and recreated while still under `deny`, and all came back `Running`
- gatekeeper audit afterwards: **zero violations**

Coverage of everything that puts a pod in `d8-monitoring`:

| Owner module | Workloads | Result |
|---|---|---|
| `prometheus` | prometheus-main, grafana-v10, trickster, memcached, aggregating-proxy, alerts-receiver | allowed |
| `monitoring-kubernetes` | node-exporter, kube-state-metrics, oom-kills-exporter | allowed, **needs exception** |
| `monitoring-ping` | monitoring-ping | allowed, **needs exception** |
| `extended-monitoring` | extended-monitoring-exporter, image-availability-exporter, events-exporter, x509-certificate-exporter | allowed, no change needed |
| `prometheus-metrics-adapter` | prometheus-metrics-adapter | allowed, no change needed |
| `user-authn` | grafana-dex-authenticator | allowed, no change needed |

`monitoring-deckhouse`, `monitoring-applications` and `monitoring-custom` ship no workload templates at all (rules and dashboards only), so they cannot be affected.

## ⚠️ Merge ordering

**This PR must not merge before monitoring-kubernetes and monitoring-ping external modules introduce their exceptions.** Both were denied under `deny` enforcement before their MRs; with the MRs applied they pass. Labelling `d8-monitoring` first would put `node-exporter`, `oom-kills-exporter` and `monitoring-ping` into a warning state in the field, and into a hard-failure state once `pod-policy-action: warn` is dropped for 1.79.

### Why do we need it in the patch release (if we do)?

No.

## Checklist

- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: feature
summary: Enable Pod Security Standards restricted checks in warn mode on the d8-monitoring namespace.
impact_level: default
```
