### PR TITLE
[node-manager] Block release update on containerd v1 nodes

### DIFF
--- a/modules/040-node-manager/hooks/containerd_v1_nodes_present.go
+++ b/modules/040-node-manager/hooks/containerd_v1_nodes_present.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency/requirements"
+)
+
+const (
+	containerdV1NodesPresentValuesKey = "nodeManager:containerdV1NodesPresent"
+	containerdRuntimePrefix           = "containerd://"
+)
+
+// set nodeManager:containerdV1NodesPresent=true if at least one node is running containerd v1.x
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	Queue: "/modules/node-manager",
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:       "containerd_v1_nodes",
+			ApiVersion: "v1",
+			Kind:       "Node",
+			FilterFunc: filterNodeContainerRuntimeVersion,
+		},
+	},
+}, handleContainerdV1NodesPresent)
+
+func filterNodeContainerRuntimeVersion(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	var node corev1.Node
+	if err := sdk.FromUnstructured(obj, &node); err != nil {
+		return nil, err
+	}
+
+	return node.Status.NodeInfo.ContainerRuntimeVersion, nil
+}
+
+func handleContainerdV1NodesPresent(_ context.Context, input *go_hook.HookInput) error {
+	snaps := input.Snapshots.Get("containerd_v1_nodes")
+
+	hasContainerdV1Nodes := false
+	for runtimeVersion, err := range sdkobjectpatch.SnapshotIter[string](snaps) {
+		if err != nil {
+			return fmt.Errorf("failed to iterate over 'containerd_v1_nodes' snapshot: %w", err)
+		}
+
+		if isContainerdV1(runtimeVersion) {
+			hasContainerdV1Nodes = true
+			break
+		}
+	}
+
+	requirements.SaveValue(containerdV1NodesPresentValuesKey, hasContainerdV1Nodes)
+
+	return nil
+}
+
+// isContainerdV1 reports whether the node's container runtime is containerd v1.x,
+// e.g. "containerd://1.7.13" (true) vs "containerd://2.0.1" (false).
+func isContainerdV1(runtimeVersion string) bool {
+	version, ok := strings.CutPrefix(runtimeVersion, containerdRuntimePrefix)
+	if !ok {
+		return false
+	}
+
+	major, _, _ := strings.Cut(version, ".")
+
+	return major == "1"
+}

--- a/modules/040-node-manager/hooks/containerd_v1_nodes_present_test.go
+++ b/modules/040-node-manager/hooks/containerd_v1_nodes_present_test.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency/requirements"
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("Modules :: node-manager :: hooks :: containerd_v1_nodes_present ::", func() {
+	const (
+		noNodes = ``
+
+		containerdV2Node = `
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: node-v2
+status:
+  nodeInfo:
+    containerRuntimeVersion: containerd://2.0.1
+`
+
+		containerdV1Node = `
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: node-v1
+status:
+  nodeInfo:
+    containerRuntimeVersion: containerd://1.7.13
+`
+
+		mixedNodes = `
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: node-v2
+status:
+  nodeInfo:
+    containerRuntimeVersion: containerd://2.0.1
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: node-v1
+status:
+  nodeInfo:
+    containerRuntimeVersion: containerd://1.7.13
+`
+	)
+
+	f := HookExecutionConfigInit(`{"global":{"discovery":{"kubernetesVersion": "1.16.15", "kubernetesVersions":["1.16.15"], "clusterUUID":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"}},"nodeManager":{"internal": {}}}`, `{}`)
+
+	Context("No nodes", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(noNodes))
+			f.RunHook()
+		})
+
+		It("Hook must not fail, value should be false", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			value, exists := requirements.GetValue(containerdV1NodesPresentValuesKey)
+			Expect(exists).To(BeTrue())
+			Expect(value).To(BeFalse())
+		})
+	})
+
+	Context("Only containerd v2 nodes", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(containerdV2Node))
+			f.RunHook()
+		})
+
+		It("Hook must not fail, value should be false", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			value, exists := requirements.GetValue(containerdV1NodesPresentValuesKey)
+			Expect(exists).To(BeTrue())
+			Expect(value).To(BeFalse())
+		})
+	})
+
+	Context("Only containerd v1 nodes", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(containerdV1Node))
+			f.RunHook()
+		})
+
+		It("Hook must not fail, value should be true", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			value, exists := requirements.GetValue(containerdV1NodesPresentValuesKey)
+			Expect(exists).To(BeTrue())
+			Expect(value).To(BeTrue())
+		})
+	})
+
+	Context("Mixed containerd v1 and v2 nodes", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(mixedNodes))
+			f.RunHook()
+		})
+
+		It("Hook must not fail, value should be true", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			value, exists := requirements.GetValue(containerdV1NodesPresentValuesKey)
+			Expect(exists).To(BeTrue())
+			Expect(value).To(BeTrue())
+		})
+	})
+})

--- a/modules/040-node-manager/requirements/check.go
+++ b/modules/040-node-manager/requirements/check.go
@@ -27,12 +27,14 @@ import (
 )
 
 const (
-	minUbuntuVersionValuesKey           = "nodeManager:nodesMinimalOSVersionUbuntu"
-	minDebianVersionValuesKey           = "nodeManager:nodesMinimalOSVersionDebian"
-	requirementsUbuntuKey               = "nodesMinimalOSVersionUbuntu"
-	requirementsDebianKey               = "nodesMinimalOSVersionDebian"
-	unmetCloudConditionsKey             = "nodeManager:unmetCloudConditions"
-	unmetCloudConditionsRequirementsKey = "unmetCloudConditions"
+	minUbuntuVersionValuesKey               = "nodeManager:nodesMinimalOSVersionUbuntu"
+	minDebianVersionValuesKey               = "nodeManager:nodesMinimalOSVersionDebian"
+	requirementsUbuntuKey                   = "nodesMinimalOSVersionUbuntu"
+	requirementsDebianKey                   = "nodesMinimalOSVersionDebian"
+	unmetCloudConditionsKey                 = "nodeManager:unmetCloudConditions"
+	unmetCloudConditionsRequirementsKey     = "unmetCloudConditions"
+	containerdV1NodesPresentValuesKey       = "nodeManager:containerdV1NodesPresent"
+	containerdV1NodesPresentRequirementsKey = "checkContainerdV1NodesPresent"
 )
 
 // normalizeUbuntuVersionForSemver converts Ubuntu version format to semver format: 20.04.3 -> 20.4.3, 20.04 -> 20.4.0
@@ -93,9 +95,33 @@ func init() {
 		return true, nil
 	}
 
+	checkContainerdV1NodesPresentFunc := func(requirementValue string, getter requirements.ValueGetter) (bool, error) {
+		requirementValue = strings.TrimSpace(requirementValue)
+		if requirementValue == "false" || requirementValue == "" {
+			return true, nil
+		}
+
+		containerdV1NodesPresent, exists := getter.Get(containerdV1NodesPresentValuesKey)
+		if !exists {
+			return true, nil
+		}
+
+		hasContainerdV1Nodes, ok := containerdV1NodesPresent.(bool)
+		if !ok {
+			return false, fmt.Errorf("invalid containerdV1NodesPresent value type")
+		}
+
+		if requirementValue == "true" && hasContainerdV1Nodes {
+			return false, errors.New("has nodes running containerd v1.x")
+		}
+
+		return true, nil
+	}
+
 	requirements.RegisterCheck(unmetCloudConditionsRequirementsKey, checkUnmetCloudConditionsFunc)
 	requirements.RegisterCheck(requirementsUbuntuKey, checkRequirementUbuntuFunc)
 	requirements.RegisterCheck(requirementsDebianKey, checkRequirementDebianFunc)
+	requirements.RegisterCheck(containerdV1NodesPresentRequirementsKey, checkContainerdV1NodesPresentFunc)
 }
 
 func baseFuncMinVerOS(requirementValue string, getter requirements.ValueGetter, osImage string) (bool, error) {

--- a/modules/040-node-manager/requirements/check_test.go
+++ b/modules/040-node-manager/requirements/check_test.go
@@ -73,3 +73,28 @@ func TestUnmetCloudConditionsRequirement(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+func TestContainerdV1NodesPresentRequirement(t *testing.T) {
+	requirements.RemoveValue(containerdV1NodesPresentValuesKey)
+
+	t.Run("requirement is not set", func(t *testing.T) {
+		requirements.SaveValue(containerdV1NodesPresentValuesKey, true)
+		ok, err := requirements.CheckRequirement(containerdV1NodesPresentRequirementsKey, "")
+		assert.True(t, ok)
+		require.NoError(t, err)
+	})
+
+	t.Run("no containerd v1 nodes", func(t *testing.T) {
+		requirements.SaveValue(containerdV1NodesPresentValuesKey, false)
+		ok, err := requirements.CheckRequirement(containerdV1NodesPresentRequirementsKey, "true")
+		assert.True(t, ok)
+		require.NoError(t, err)
+	})
+
+	t.Run("has containerd v1 nodes", func(t *testing.T) {
+		requirements.SaveValue(containerdV1NodesPresentValuesKey, true)
+		ok, err := requirements.CheckRequirement(containerdV1NodesPresentRequirementsKey, "true")
+		assert.False(t, ok)
+		require.Error(t, err)
+	})
+}

--- a/release.yaml
+++ b/release.yaml
@@ -36,6 +36,7 @@ requirements:
   "metallbHasStandardConfiguration": "true" # ee/se/modules/380-metallb/requirements/check.go
   "unmetCloudConditions": "true" # modules/040-node-manager/requirements/check.go
   "nodesMinimalLinuxKernelVersion": "5.8.0" # modules/021-cni-cilium/requirements/check.go
+  # "checkContainerdV1NodesPresent": "true" # modules/040-node-manager/requirements/check.go
 
 # map of disruptions, associated with a specific release. You have to register check functions before specified release
 disruptions:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Failed cherry pick of https://github.com/deckhouse/deckhouse/pull/21994

Adds a new node-manager hook (`containerd_v1_nodes_present.go`) that watches `status.nodeInfo.containerRuntimeVersion` on Node objects and reports whether any node is running containerd v1.x. This is wired into a new release requirement, `checkContainerdV1NodesPresent` (`modules/040-node-manager/requirements/check.go`)

The new flag stays commented out in `release.yaml` - there is no active behavior change for users yet. No critical cluster components are restarted or reconfigured.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
The new check reads the node's real containerRuntimeVersion and, once enabled, can block a release update while containerd v1 nodes are still present in the cluster.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: feature
summary: Added a release requirement that can block updates while nodes are still running containerd v1.x.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
