### PR TITLE
[istio] Add missing tools to proxyv2 images

### DIFF
--- a/modules/110-istio/images/proxyv2-v1x21x6/werf.inc.yaml
+++ b/modules/110-istio/images/proxyv2-v1x21x6/werf.inc.yaml
@@ -66,6 +66,33 @@ import:
   add: /iptables-wrapper
   to: /sbin/iptables-wrapper
   before: setup
+- from: {{ index $.Images "tools/bash" }}
+  add: /usr/bin
+  to: /bin
+  includePaths:
+  - bash
+  - sh
+  before: setup
+- from: {{ index $.Images "tools/iproute2" }}
+  add: /sbin/ss
+  to: /usr/sbin/ss
+  before: setup
+- from: {{ index $.Images "tools/coreutils" }}
+  add: /usr/bin
+  to: /usr/bin
+  includePaths:
+  - echo
+  - sleep
+  - wc
+  before: setup
+- from: {{ index $.Images "tools/grep" }}
+  add: /usr/bin/grep
+  to: /usr/bin/grep
+  before: setup
+- from: {{ index $.Images "tools/findutils" }}
+  add: /usr/bin/xargs
+  to: /usr/bin/xargs
+  before: setup
 - image: registrypackages/d8-curl-artifact-8-9-1
   add: /d8-curl
   to: /usr/bin/curl

--- a/modules/110-istio/images/proxyv2-v1x25x2/werf.inc.yaml
+++ b/modules/110-istio/images/proxyv2-v1x25x2/werf.inc.yaml
@@ -60,6 +60,33 @@ import:
   add: /iptables-wrapper
   to: /sbin/iptables-wrapper
   before: setup
+- from: {{ index $.Images "tools/bash" }}
+  add: /usr/bin
+  to: /bin
+  includePaths:
+  - bash
+  - sh
+  before: setup
+- from: {{ index $.Images "tools/iproute2" }}
+  add: /sbin/ss
+  to: /usr/sbin/ss
+  before: setup
+- from: {{ index $.Images "tools/coreutils" }}
+  add: /usr/bin
+  to: /usr/bin
+  includePaths:
+  - echo
+  - sleep
+  - wc
+  before: setup
+- from: {{ index $.Images "tools/grep" }}
+  add: /usr/bin/grep
+  to: /usr/bin/grep
+  before: setup
+- from: {{ index $.Images "tools/findutils" }}
+  add: /usr/bin/xargs
+  to: /usr/bin/xargs
+  before: setup
 - image: registrypackages/d8-curl-artifact-8-9-1
   add: /d8-curl
   to: /usr/bin/curl


### PR DESCRIPTION
## Description

Adds the shell utilities required by the Istio proxy termination `preStop` hook to supported proxyv2 images:

- `bash` and `sh`
- `ss` from iproute2
- `echo`, `sleep`, and `wc` from coreutils
- `grep`
- `xargs` from findutils

## Why do we need it, and what problem does it solve?

The `d8-hold-istio-proxy-termination-until-application-stops` injection template configures a `preStop` hook that drains inbound Envoy listeners and waits for the application ports to close. The hook invokes `/bin/sh`, `ss`, `grep`, `wc`, `xargs`, and `sleep`, but these tools were missing from the proxyv2 images. As a result, the hook failed instead of holding the Istio proxy until the application stopped.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: fix
summary: Add missing tools to proxyv2 images so the application-aware proxy termination hook works correctly.
impact_level: default
```