### PR TITLE
[deckhouse] do not inject source registry into a still-embedded module

### DIFF
--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -560,9 +560,17 @@ func (r *reconciler) handleDeployedRelease(ctx context.Context, release *v1alpha
 
 	// check if RegistrySpecChanged annotation is set process it
 	if _, set := release.GetAnnotations()[v1alpha1.ModuleReleaseAnnotationRegistrySpecChanged]; set {
-		// if module is enabled - push runModule task in the main queue
-		r.log.Info("apply new registry settings to module", slog.String("module", release.GetModuleName()))
-		if module := r.moduleManager.GetModule(release.GetModuleName()); module != nil {
+		// While an embedded copy of the module is still shipped it keeps serving the
+		// module and renders images from the platform registry (digests baked into the
+		// Deckhouse image). Injecting the source registry here would make it pull
+		// <sourceRepo>/<name>@<embeddedDigest> - a path that does not exist - and break
+		// the module with ImagePullBackOff. The source registry is applied by the
+		// moduleloader restore once the embedded copy is dropped and the module is activated.
+		if r.installer.IsEmbeddedPresent(release.GetModuleName()) {
+			r.log.Info("module is still embedded, skip new registry settings", slog.String("module", release.GetModuleName()))
+		} else if module := r.moduleManager.GetModule(release.GetModuleName()); module != nil {
+			// if module is enabled - push runModule task in the main queue
+			r.log.Info("apply new registry settings to module", slog.String("module", release.GetModuleName()))
 			module.InjectRegistryValue(utils.BuildRegistryValue(source))
 
 			// run module with new registry value

--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -560,12 +560,7 @@ func (r *reconciler) handleDeployedRelease(ctx context.Context, release *v1alpha
 
 	// check if RegistrySpecChanged annotation is set process it
 	if _, set := release.GetAnnotations()[v1alpha1.ModuleReleaseAnnotationRegistrySpecChanged]; set {
-		// While an embedded copy of the module is still shipped it keeps serving the
-		// module and renders images from the platform registry (digests baked into the
-		// Deckhouse image). Injecting the source registry here would make it pull
-		// <sourceRepo>/<name>@<embeddedDigest> - a path that does not exist - and break
-		// the module with ImagePullBackOff. The source registry is applied by the
-		// moduleloader restore once the embedded copy is dropped and the module is activated.
+		// the embedded copy renders images from the platform registry, so the source registry must not reach its values
 		if r.installer.IsEmbeddedPresent(release.GetModuleName()) {
 			r.log.Info("module is still embedded, skip new registry settings", slog.String("module", release.GetModuleName()))
 		} else if module := r.moduleManager.GetModule(release.GetModuleName()); module != nil {


### PR DESCRIPTION
## Description
Skip applying ModuleSource registry settings to a module whose embedded copy is still on the filesystem. The annotation is still dropped; the source registry is applied by the moduleloader restore once the module is activated.

## Why do we need it, and what problem does it solve?
The `registry-spec-changed` handler injected `registry.base` from the ModuleSource unconditionally. For a module still served by its embedded copy this switches `helm_lib` to `<sourceRepo>/<module>@<digest>`, while its digests come from `global.modulesImages.digests` and exist only in the platform repository - the images fail to pull with `not found` and the module stays in ImagePullBackOff. It fires only when a release is already deployed at the moment the registry spec checksum changes, so bootstrap and updates break intermittently. The moduleloader restore and the module install path already skip still-embedded modules.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Do not inject source registry into a still-embedded module
impact_level: low
```