### PR TITLE
Backport: [registrypackages] Build olcedar sysext images only for non-CSE editions

### DIFF
--- a/modules/007-registrypackages/images/containerd/werf.inc.yaml
+++ b/modules/007-registrypackages/images/containerd/werf.inc.yaml
@@ -247,6 +247,7 @@ shell:
 {{- include "vex mitigation" (list $ (printf "%s/%s-%s" $.ModuleName $.ImageName $image_version)) }}
 {{- end }}
 
+{{- if ne $.Env "CSE" }}
 # containerd sysext (built for containerd v2 only)
 
 {{- $image_version := $containerd_v2_version | replace "." "-" }}
@@ -264,9 +265,6 @@ import:
   - containerd-shim-runc-v2
   - ctr
   - runc
-{{- if and (eq $.Env "CSE") }}
-  - pidumount
-{{- end }}
   before: install
 git:
 - add: /{{ $.ModulePath }}modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/sysext
@@ -310,3 +308,4 @@ imageSpec:
     clearEntrypoint: true
     removeEnv: ["/.*/"]
 {{- include "vex mitigation" (list $ (printf "%s/%s-sysext-%s" $.ModuleName $.ImageName $image_version)) }}
+{{- end }}

--- a/modules/007-registrypackages/images/kubelet/werf.inc.yaml
+++ b/modules/007-registrypackages/images/kubelet/werf.inc.yaml
@@ -46,6 +46,7 @@ shell:
 {{- end }}
 
 
+{{- if ne $.Env "CSE" }}
 # kubelet sysext
 
 
@@ -105,4 +106,5 @@ shell:
   - printf '%s\n' "$ROOTHASH" > /out/kubelet.raw.roothash
 ---
 {{- include "vex mitigation" (list $ (printf "%s/%s-sysext-%s" $.ModuleName $.ImageName $image_version)) }}
+{{- end }}
 {{- end }}

--- a/modules/007-registrypackages/images/kubernetes-cni/werf.inc.yaml
+++ b/modules/007-registrypackages/images/kubernetes-cni/werf.inc.yaml
@@ -98,6 +98,7 @@ shell:
     - make build_linux
     - mv /src/scripts/* /
     - cp -f /src/cni-plugin/dist/flannel-amd64 /flannel
+{{- if ne $.Env "CSE" }}
 ---
 
 # kubernetes-cni sysext
@@ -174,3 +175,4 @@ shell:
   - export ROOTHASH=$(awk '/^Root hash:/ {print $3}' verity.txt)
   - cat kubernetes-cni.erofs kubernetes-cni.verity > /out/kubernetes-cni.raw
   - printf '%s\n' "$ROOTHASH" > /out/kubernetes-cni.raw.roothash
+{{- end }}


### PR DESCRIPTION
## Description

Wrap the olcedar sysext image definitions (`containerd`, `kubelet`, `kubernetes-cni`) in `{{- if ne $.Env "CSE" }}`, so they are only built for non-CSE editions. Drops the now-unreachable CSE-only `pidumount` import from the containerd sysext.

`WERF_ENV=CSE werf config list` renders no `*-sysext-*` images; EE still renders all of them.

## Why do we need it, and what problem does it solve?

The immutable (olcedar) OS is not shipped in CSE, so the sysext images are dead weight there: extra build time and an extra attack surface in an edition that has to be certified.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: registrypackages
type: chore
summary: Build olcedar sysext images only for non-CSE editions.
impact_level: low
```
