### PR TITLE
[node-manager] fix checker containerd v1 node present

### DIFF
--- a/modules/040-node-manager/hooks/containerd_v1_nodes_present.go
+++ b/modules/040-node-manager/hooks/containerd_v1_nodes_present.go
@@ -29,14 +29,18 @@ import (
 	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 
 	"github.com/deckhouse/deckhouse/go_lib/dependency/requirements"
+	ngv1 "github.com/deckhouse/deckhouse/modules/040-node-manager/hooks/internal/v1"
 )
 
 const (
 	containerdV1NodesPresentValuesKey = "nodeManager:containerdV1NodesPresent"
 	containerdRuntimePrefix           = "containerd://"
+	// defaultCRIValuesPath is filled by the global discovery hook from the d8-cluster-configuration secret.
+	defaultCRIValuesPath = "global.clusterConfiguration.defaultCRI"
 )
 
-// set nodeManager:containerdV1NodesPresent=true if at least one node is running containerd v1.x
+// set nodeManager:containerdV1NodesPresent=true if containerd v1.x is used anywhere in the cluster:
+// at least one node runs it, a NodeGroup requests it explicitly or it is the cluster-wide default CRI
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	Queue: "/modules/node-manager",
 	Kubernetes: []go_hook.KubernetesConfig{
@@ -45,6 +49,12 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			ApiVersion: "v1",
 			Kind:       "Node",
 			FilterFunc: filterNodeContainerRuntimeVersion,
+		},
+		{
+			Name:       "containerd_v1_node_groups",
+			ApiVersion: "deckhouse.io/v1",
+			Kind:       "NodeGroup",
+			FilterFunc: filterNodeGroupCRIType,
 		},
 	},
 }, handleContainerdV1NodesPresent)
@@ -58,11 +68,19 @@ func filterNodeContainerRuntimeVersion(obj *unstructured.Unstructured) (go_hook.
 	return node.Status.NodeInfo.ContainerRuntimeVersion, nil
 }
 
-func handleContainerdV1NodesPresent(_ context.Context, input *go_hook.HookInput) error {
-	snaps := input.Snapshots.Get("containerd_v1_nodes")
+func filterNodeGroupCRIType(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	var nodeGroup ngv1.NodeGroup
+	if err := sdk.FromUnstructured(obj, &nodeGroup); err != nil {
+		return nil, err
+	}
 
+	return nodeGroup.Spec.CRI.Type, nil
+}
+
+func handleContainerdV1NodesPresent(_ context.Context, input *go_hook.HookInput) error {
 	hasContainerdV1Nodes := false
-	for runtimeVersion, err := range sdkobjectpatch.SnapshotIter[string](snaps) {
+
+	for runtimeVersion, err := range sdkobjectpatch.SnapshotIter[string](input.Snapshots.Get("containerd_v1_nodes")) {
 		if err != nil {
 			return fmt.Errorf("failed to iterate over 'containerd_v1_nodes' snapshot: %w", err)
 		}
@@ -70,6 +88,26 @@ func handleContainerdV1NodesPresent(_ context.Context, input *go_hook.HookInput)
 		if isContainerdV1(runtimeVersion) {
 			hasContainerdV1Nodes = true
 			break
+		}
+	}
+
+	if !hasContainerdV1Nodes {
+		for criType, err := range sdkobjectpatch.SnapshotIter[string](input.Snapshots.Get("containerd_v1_node_groups")) {
+			if err != nil {
+				return fmt.Errorf("failed to iterate over 'containerd_v1_node_groups' snapshot: %w", err)
+			}
+
+			// CRITypeContainerd is containerd v1.x, containerd v2.x has its own 'ContainerdV2' CRI type.
+			if criType == CRITypeContainerd {
+				hasContainerdV1Nodes = true
+				break
+			}
+		}
+	}
+
+	if !hasContainerdV1Nodes {
+		if defaultCRI, ok := input.Values.GetOk(defaultCRIValuesPath); ok && defaultCRI.String() == CRITypeContainerd {
+			hasContainerdV1Nodes = true
 		}
 	}
 

--- a/modules/040-node-manager/hooks/containerd_v1_nodes_present_test.go
+++ b/modules/040-node-manager/hooks/containerd_v1_nodes_present_test.go
@@ -17,12 +17,30 @@ limitations under the License.
 package hooks
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
 	"github.com/deckhouse/deckhouse/go_lib/dependency/requirements"
 	. "github.com/deckhouse/deckhouse/testing/hooks"
 )
+
+// setClusterConfigurationWithDefaultCRI emulates the d8-cluster-configuration secret
+// discovered into global values with the given defaultCRI.
+func setClusterConfigurationWithDefaultCRI(f *HookExecutionConfig, defaultCRI string) {
+	f.ValuesSetFromYaml("global.clusterConfiguration", []byte(fmt.Sprintf(`
+apiVersion: deckhouse.io/v1
+kind: ClusterConfiguration
+clusterDomain: cluster.local
+clusterType: Static
+defaultCRI: %s
+kubernetesVersion: "1.30"
+podSubnetCIDR: 10.111.0.0/16
+podSubnetNodeCIDRPrefix: "24"
+serviceSubnetCIDR: 10.222.0.0/16
+`, defaultCRI)))
+}
 
 var _ = Describe("Modules :: node-manager :: hooks :: containerd_v1_nodes_present ::", func() {
 	const (
@@ -68,9 +86,34 @@ status:
   nodeInfo:
     containerRuntimeVersion: containerd://1.7.13
 `
+
+		containerdV1NodeGroup = `
+---
+apiVersion: deckhouse.io/v1
+kind: NodeGroup
+metadata:
+  name: ng-v1
+spec:
+  nodeType: Static
+  cri:
+    type: Containerd
+`
+
+		containerdV2NodeGroup = `
+---
+apiVersion: deckhouse.io/v1
+kind: NodeGroup
+metadata:
+  name: ng-v2
+spec:
+  nodeType: Static
+  cri:
+    type: ContainerdV2
+`
 	)
 
 	f := HookExecutionConfigInit(`{"global":{"discovery":{"kubernetesVersion": "1.16.15", "kubernetesVersions":["1.16.15"], "clusterUUID":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"}},"nodeManager":{"internal": {}}}`, `{}`)
+	f.RegisterCRD("deckhouse.io", "v1", "NodeGroup", false)
 
 	Context("No nodes", func() {
 		BeforeEach(func() {
@@ -125,6 +168,64 @@ status:
 			value, exists := requirements.GetValue(containerdV1NodesPresentValuesKey)
 			Expect(exists).To(BeTrue())
 			Expect(value).To(BeTrue())
+		})
+	})
+
+	Context("NodeGroup with cri.type Containerd and no nodes", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(containerdV1NodeGroup))
+			f.RunHook()
+		})
+
+		It("Hook must not fail, value should be true", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			value, exists := requirements.GetValue(containerdV1NodesPresentValuesKey)
+			Expect(exists).To(BeTrue())
+			Expect(value).To(BeTrue())
+		})
+	})
+
+	Context("NodeGroup with cri.type ContainerdV2 and containerd v2 node", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(containerdV2NodeGroup + containerdV2Node))
+			f.RunHook()
+		})
+
+		It("Hook must not fail, value should be false", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			value, exists := requirements.GetValue(containerdV1NodesPresentValuesKey)
+			Expect(exists).To(BeTrue())
+			Expect(value).To(BeFalse())
+		})
+	})
+
+	Context("defaultCRI is Containerd and no nodes", func() {
+		BeforeEach(func() {
+			setClusterConfigurationWithDefaultCRI(f, "Containerd")
+			f.BindingContexts.Set(f.KubeStateSet(noNodes))
+			f.RunHook()
+		})
+
+		It("Hook must not fail, value should be true", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			value, exists := requirements.GetValue(containerdV1NodesPresentValuesKey)
+			Expect(exists).To(BeTrue())
+			Expect(value).To(BeTrue())
+		})
+	})
+
+	Context("defaultCRI is ContainerdV2 and no nodes", func() {
+		BeforeEach(func() {
+			setClusterConfigurationWithDefaultCRI(f, "ContainerdV2")
+			f.BindingContexts.Set(f.KubeStateSet(noNodes))
+			f.RunHook()
+		})
+
+		It("Hook must not fail, value should be false", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			value, exists := requirements.GetValue(containerdV1NodesPresentValuesKey)
+			Expect(exists).To(BeTrue())
+			Expect(value).To(BeFalse())
 		})
 	})
 })

--- a/modules/040-node-manager/requirements/check.go
+++ b/modules/040-node-manager/requirements/check.go
@@ -112,7 +112,7 @@ func init() {
 		}
 
 		if requirementValue == "true" && hasContainerdV1Nodes {
-			return false, errors.New("has nodes running containerd v1.x")
+			return false, errors.New("containerd v1.x is still in use by nodes, NodeGroups or defaultCRI")
 		}
 
 		return true, nil


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Related to: https://github.com/deckhouse/deckhouse/pull/21994
Make check 'containerd_v1_nodes_present.go'  more comprehensive, include NG.spec and defaultCRI parameters.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Make check 'containerd_v1_nodes_present.go'  more comprehensive.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: chore
summary: Make the hook’s check for containerd v1 more comprehensive.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
