### PR TITLE
[istio] Fix hold-proxy-termination hook template

### DIFF
--- a/modules/110-istio/templates/control-plane/iop.yaml
+++ b/modules/110-istio/templates/control-plane/iop.yaml
@@ -262,7 +262,7 @@ spec:
               lifecycle:
                 preStop:
                   exec:
-                    command: ["/bin/sh", "-c", "curl -X POST localhost:15000/drain_listeners?inboundonly; while [ $(ss -Htlp state all | grep -vE '(envoy|pilot-agent|TIME-WAIT)' | wc -l | xargs ) -ne 0 ]; do sleep 1; done"]
+                    command: ["/bin/sh", "-c", "curl -X POST 'localhost:15000/drain_listeners?inboundonly&graceful&skip_exit'; while [ $(ss -Htlp state all | grep -vE '(envoy|pilot-agent|TIME-WAIT)' | wc -l | xargs ) -ne 0 ]; do sleep 1; done"]
       neverInjectSelector:
       - matchExpressions:
         - key: job-name

--- a/modules/110-istio/templates/control-plane/istios.yaml
+++ b/modules/110-istio/templates/control-plane/istios.yaml
@@ -242,7 +242,7 @@ spec:
               lifecycle:
                 preStop:
                   exec:
-                    command: ["/bin/sh", "-c", "curl -X POST localhost:15000/drain_listeners?inboundonly; while [ $(ss -Htlp state all | grep -vE '(envoy|pilot-agent|TIME-WAIT)' | wc -l | xargs ) -ne 0 ]; do sleep 1; done"]
+                    command: ["/bin/sh", "-c", "curl -X POST 'localhost:15000/drain_listeners?inboundonly&graceful&skip_exit'; while [ $(ss -Htlp state all | grep -vE '(envoy|pilot-agent|TIME-WAIT)' | wc -l | xargs ) -ne 0 ]; do sleep 1; done"]
       neverInjectSelector:
       - matchExpressions:
         - key: job-name


### PR DESCRIPTION
Backport of https://github.com/deckhouse/deckhouse/pull/22068

## Description

Update the `d8-hold-istio-proxy-termination-until-application-stops` sidecar injection template to request graceful inbound listener draining:

```text
/drain_listeners?inboundonly&graceful&skip_exit
```

## Why do we need it, and what problem does it solve?

The previous hook called `/drain_listeners?inboundonly`, which immediately stopped inbound listeners without gracefully retiring established HTTP connections. In a multicluster setup, existing connections through an east-west gateway could therefore continue carrying requests to a terminating pod even after its application stopped. The destination sidecar would then fail to connect to the application port and return transient HTTP 503 responses during rollouts.

Adding `graceful` makes Envoy retire established HTTP connections using protocol-aware draining (`Connection: close` for HTTP/1.1 and GOAWAY for HTTP/2). `skip_exit` keeps the sidecar available for outbound calls while the application finishes its shutdown.

## Why do we need it in the patch release (if we do)?

This fixes client-visible HTTP 503 errors during normal application rollouts for workloads using the hold-proxy-termination template. The change is limited to correcting the existing shutdown hook behavior.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: fix
summary: Fix graceful draining of established HTTP connections when application pods terminate.
impact_level: default
```