### PR TITLE
[keepalived][network-gateway] Fixed bug with Python

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -418,6 +418,7 @@ update-base-images-versions:
 	$(MAKE) render-workflow
 
 BASE_LIMIT_KEYS := REGISTRY_PATH \
+                base/distroless \
                 builder/distroless \
                 builder/golang-1.25 \
                 builder/golang-1.26 \
@@ -441,6 +442,9 @@ update-container-factory: ## Download container-factory digests and update candi
 	  echo "# version=$$ver"; \
 	  for key in $(BASE_LIMIT_KEYS); do \
 	    line=$$(grep -F "$${key}:" .alt_base_images.full.yml | head -n1); \
+	    case "$$key" in \
+	      base/distroless) line=$$(printf '%s\n' "$$line" | sed 's#^base/distroless:#base/distroless-fin:#');; \
+	    esac; \
 	    echo "$$line"; \
 	  done; \
 	} > alt_base_images.yml; \

--- a/candi/alt_base_images.yml
+++ b/candi/alt_base_images.yml
@@ -1,5 +1,6 @@
 # version=v1.0.39
 REGISTRY_PATH: registry.deckhouse.io/container-factory
+base/distroless-fin: "sha256:422360b71845014cb7827ef52cb5e06dd0a0ac659a52c475bbdc59ed37958ae4" # from: builder/scratch
 builder/distroless: "sha256:8dda129ecf0e61f67fa897ea6f8edaa0b710ca51dc6c19f28e3842caa91931c9" # from: builder/scratch
 builder/golang-1.25: "sha256:9f3119c4027d1e8aafc7fe6288677d25adcf61c57d741280deb1755015a78f5a" # from: builder/distroless
 builder/golang-1.26: "sha256:a48a8c688cf1514300381f49f8a402c571596198dcb84219363125a04e7076ce" # from: builder/distroless

--- a/ee/modules/450-keepalived/images/keepalived/src/prepare-config.py
+++ b/ee/modules/450-keepalived/images/keepalived/src/prepare-config.py
@@ -6,6 +6,13 @@
 import json
 import os, sys
 import socket
+
+try:
+    import pysqlite3
+    sys.modules['sqlite3'] = pysqlite3
+except ImportError as e:
+    sys.exit(1)
+
 from pyroute2 import IPRoute
 
 KEEPALIVED_CONFIG_TEMPLATE = """

--- a/ee/modules/450-keepalived/images/keepalived/src/requirements.txt
+++ b/ee/modules/450-keepalived/images/keepalived/src/requirements.txt
@@ -1,2 +1,2 @@
 pyroute2==0.8.1
-
+pysqlite3-binary==0.5.4.post2

--- a/ee/modules/450-keepalived/images/keepalived/werf.inc.yaml
+++ b/ee/modules/450-keepalived/images/keepalived/werf.inc.yaml
@@ -12,7 +12,7 @@ shell:
 ---
 image: {{ .ModuleName }}/build-keepalived
 final: false
-from: {{ index $.Images "builder/alpine-3.21" }}
+from: {{ index $.Images "builder/golang" }}
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src
@@ -20,20 +20,22 @@ import:
   before: install
 shell:
   beforeInstall:
-  {{- include "alpine packages proxy" . | nindent 2 }}
-  - apk add --no-cache make autoconf automake build-base linux-headers openssl-dev openssl-libs-static pcre-dev pcre2-dev net-snmp-dev
+  - pm -V v1.3.22 install m4 automake autoconf net-snmp-devel binutils linux-headers openssl-devel pcre-devel pcre2-devel pkgconf perl gnu-glibc-devel
   install:
   - cd /src
   - ./autogen.sh
-  - CFLAGS='-static -s' LDFLAGS=-static ./configure --disable-dynamic-linking --prefix=/usr --exec-prefix=/usr --bindir=/usr/bin --sbindir=/usr/sbin --sysconfdir=/etc --datadir=/usr/share --localstatedir=/var --mandir=/usr/share/man --enable-bfd --enable-snmp --enable-snmp-rfc --enable-nftables --enable-regex --enable-json --enable-vrrp # --enable-libnl-dynamic
-  - make
-  - DESTDIR=/opt/keepalived-static make install
+  - export PKG_CONFIG=pkg-config
+  - export PERL_CORE=$(perl -MConfig -e 'print $Config{archlib}')/CORE
+  - export KA_LIBS="-L/usr/lib -lpcre2-8 -Wl,--start-group -lnetsnmpmibs -lnetsnmpagent -lnetsnmp -lssl -lcrypto -L$PERL_CORE -lperl -Wl,--end-group -ldl -pthread -lcrypt -lm"
+  - CFLAGS='-static -s' LDFLAGS='-static -L/usr/lib' ac_cv_lib_ssl_SSL_CTX_new=yes ac_cv_func_netsnmp_enable_subagent=yes ./configure --disable-dynamic-linking --prefix=/usr --exec-prefix=/usr --bindir=/usr/bin --sbindir=/usr/sbin --sysconfdir=/etc --datadir=/usr/share --localstatedir=/var --mandir=/usr/share/man --enable-bfd --enable-snmp --enable-snmp-rfc --enable-nftables --enable-regex --enable-json --enable-vrrp
+  - make -j"$(nproc)" KA_LIBS="${KA_LIBS}"
+  - DESTDIR=/opt/keepalived-static make install KA_LIBS="${KA_LIBS}"
   - chown -R 64535:64535 /opt/keepalived-static
   - chmod 0700 /opt/keepalived-static/usr/sbin/keepalived
   - chmod 0700 /opt/keepalived-static/usr/bin/genhash
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-wheel-artifact
-from: {{ index $.Images "base/python-3.12" }}
+from: {{ index $.Images "builder/distroless" }}
 final: false
 git:
 - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/src/requirements.txt
@@ -41,12 +43,9 @@ git:
   stageDependencies:
     install:
     - '**/*'
-import:
-- image: common/wheel-artifact
-  add: /wheels
-  to: /wheels
-  before: install
 shell:
+  beforeInstall:
+  - pm -V v1.3.22 install python@3.12 libc python-wheel
   install:
   - pip3 install -f file:///wheels --no-index --upgrade pip
   - pip3 install -f file:///wheels --no-index -r /requirements.txt
@@ -71,10 +70,11 @@ import:
   to: /
   before: install
   includePaths:
-  - lib/ld-musl-x86_64*
   - usr/bin/python3*
   - usr/lib/python3*
   - usr/lib/lib*.so*
+  - usr/lib/ld-linux-x86-64.so.2
+  - lib64
   excludePaths:
   - usr/lib/python*/site-packages/pip-25.3*
   - usr/lib/python*/test

--- a/ee/modules/450-network-gateway/images/dnsmasq/src/prepare-config.py
+++ b/ee/modules/450-network-gateway/images/dnsmasq/src/prepare-config.py
@@ -12,6 +12,7 @@ try:
     import pysqlite3
     sys.modules['sqlite3'] = pysqlite3
 except ImportError as e:
+    print(e)
     sys.exit(1)
 
 from pyroute2 import IPRoute

--- a/ee/modules/450-network-gateway/images/dnsmasq/src/prepare-config.py
+++ b/ee/modules/450-network-gateway/images/dnsmasq/src/prepare-config.py
@@ -7,6 +7,13 @@ import json
 import os, sys
 import socket
 import ipcalc
+
+try:
+    import pysqlite3
+    sys.modules['sqlite3'] = pysqlite3
+except ImportError as e:
+    sys.exit(1)
+
 from pyroute2 import IPRoute
 
 class dnsmasqConfig:

--- a/ee/modules/450-network-gateway/images/dnsmasq/src/requirements.txt
+++ b/ee/modules/450-network-gateway/images/dnsmasq/src/requirements.txt
@@ -1,3 +1,4 @@
 pyroute2==0.8.1
 six==1.17.0
 ipcalc==1.99.0
+pysqlite3-binary==0.5.4.post2

--- a/ee/modules/450-network-gateway/images/dnsmasq/werf.inc.yaml
+++ b/ee/modules/450-network-gateway/images/dnsmasq/werf.inc.yaml
@@ -4,8 +4,7 @@ final: false
 from: {{ index $.Images "builder/distroless" }}
 shell:
   beforeInstall:
-  - pm install dnsmasq python@3.12 libc -d /out
-  - pm -V v1.3.3 install python-wheel -d /out
+  - pm -V v1.3.3 install dnsmasq python@3.12 libc python-wheel -d /out
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
 from: {{ index $.Images "base/distroless-fin" }}

--- a/ee/modules/450-network-gateway/images/dnsmasq/werf.inc.yaml
+++ b/ee/modules/450-network-gateway/images/dnsmasq/werf.inc.yaml
@@ -1,69 +1,29 @@
-{{- define "alt change repos" }}
-{{- $new_date := "2026/05/17" }}
-- sed -i "s|/archive/p11/date/[^/]*/[^/]*/[^/]*/|/archive/p11/date/{{ $new_date }}/|g" /etc/apt/sources.list.d/alt.list
-{{- end }}
-
-{{- $binaries := "/usr/lib64/libsqlite3.so* /usr/sbin/dnsmasq /lib64/libnss_*" }}
 ---
-image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
-fromImage: common/relocate-artifact
+image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 final: false
+from: {{ index $.Images "builder/distroless" }}
 shell:
   beforeInstall:
-  {{- include "alt change repos" . | nindent 2 }}
-  {{- include "alt packages proxy" . | nindent 2 }}
-  {{- include "alt dist upgrade" . | nindent 2 }}
-  - apt-get update
-  - apt-get install -y dnsmasq libsqlite3
-  install:
-  - /binary_replace.sh -i "{{ $binaries }}" -o /relocate
+  - pm install dnsmasq python@3.12 libc -d /out
+  - pm -V v1.3.3 install python-wheel -d /out
 ---
-image: {{ $.ModuleName }}/{{ $.ImageName }}-wheel-artifact
-from: {{ index $.Images "base/python-3.12" }}
-final: false
+image: {{ .ModuleName }}/{{ .ImageName }}
+from: {{ index $.Images "base/distroless-fin" }}
 git:
-- add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/src/requirements.txt
+- add: /{{ $.ModulePath }}modules/450-{{ $.ModuleName }}/images/{{ $.ImageName }}/src/prepare-config.py
+  to: /prepare-config.py
+- add: /{{ $.ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/src/requirements.txt
   to: /requirements.txt
   stageDependencies:
     install:
     - '**/*'
+{{- include "image mount points" $ }}
 import:
-- image: common/wheel-artifact
-  add: /wheels
-  to: /wheels
+- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+  add: /out
+  to: /
   before: install
 shell:
   install:
   - pip3 install -f file:///wheels --no-index --upgrade pip
   - pip3 install -f file:///wheels --no-index -r /requirements.txt
----
-image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
-git:
-- add: /{{ $.ModulePath }}modules/450-{{ $.ModuleName }}/images/{{ $.ImageName }}/src/prepare-config.py
-  to: /prepare-config.py
-{{- include "image mount points" $ }}
-import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
-  add: /relocate
-  to: /
-  before: install
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
-  add: /
-  to: /
-  before: install
-  includePaths:
-  - etc/dnsmasq.conf
-  - etc/dnsmasq.conf.d
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-wheel-artifact
-  add: /
-  to: /
-  before: install
-  includePaths:
-  - lib/ld-musl-x86_64*
-  - usr/bin/python3*
-  - usr/lib/python3*
-  - usr/lib/lib*.so*
-  excludePaths:
-  - usr/lib/python*/site-packages/pip-25.3*
-  - usr/lib/python*/test

--- a/ee/modules/450-network-gateway/images/dnsmasq/werf.inc.yaml
+++ b/ee/modules/450-network-gateway/images/dnsmasq/werf.inc.yaml
@@ -4,25 +4,45 @@ final: false
 from: {{ index $.Images "builder/distroless" }}
 shell:
   beforeInstall:
-  - pm -V v1.3.3 install dnsmasq python@3.12 libc python-wheel -d /out
+  - pm -V v1.3.3 install dnsmasq -d /out
+---
+image: {{ $.ModuleName }}/{{ $.ImageName }}-wheel-artifact
+from: {{ index $.Images "builder/distroless" }}
+final: false
+git:
+- add: /{{ $.ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ $.ImageName }}/src/requirements.txt
+  to: /requirements.txt
+  stageDependencies:
+    install:
+    - '**/*'
+shell:
+  beforeInstall:
+  - pm -V v1.3.3 install python@3.12 libc python-wheel
+  install:
+  - pip3 install -f file:///wheels --no-index --upgrade pip
+  - pip3 install -f file:///wheels --no-index -r /requirements.txt
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
 from: {{ index $.Images "base/distroless-fin" }}
 git:
 - add: /{{ $.ModulePath }}modules/450-{{ $.ModuleName }}/images/{{ $.ImageName }}/src/prepare-config.py
   to: /prepare-config.py
-- add: /{{ $.ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/src/requirements.txt
-  to: /requirements.txt
-  stageDependencies:
-    install:
-    - '**/*'
 {{- include "image mount points" $ }}
 import:
 - image: {{ .ModuleName }}/{{ .ImageName }}-artifact
   add: /out
   to: /
   before: install
-shell:
-  install:
-  - pip3 install -f file:///wheels --no-index --upgrade pip
-  - pip3 install -f file:///wheels --no-index -r /requirements.txt
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-wheel-artifact
+  add: /
+  to: /
+  before: install
+  includePaths:
+  - usr/bin/python3*
+  - usr/lib/python3*
+  - usr/lib/lib*.so*
+  - usr/lib/ld-linux-x86-64.so.2
+  - lib64
+  excludePaths:
+  - usr/lib/python*/site-packages/pip-25.3*
+  - usr/lib/python*/test

--- a/ee/modules/450-network-gateway/templates/configmap.yaml
+++ b/ee/modules/450-network-gateway/templates/configmap.yaml
@@ -8,3 +8,7 @@ metadata:
 data:
   config.json: |
     {{- .Values.networkGateway | toJson | nindent 4 }}
+  dnsmasq.conf: |
+    expand-hosts
+    localise-queries
+    conf-dir=/etc/dnsmasq.conf.d,.rpmnew,.rpmsave,.rpmorig

--- a/ee/modules/450-network-gateway/templates/dhcp-statefulset.yaml
+++ b/ee/modules/450-network-gateway/templates/dhcp-statefulset.yaml
@@ -87,6 +87,9 @@ spec:
         image: {{ include "helm_lib_module_image" (list . "dnsmasq") }}
         command: ['dnsmasq', '-dK', '--dhcp-leasefile=/var/lib/dnsmasq/dhcp.leases']
         volumeMounts:
+        - name: network-gateway-config
+          mountPath: /etc/dnsmasq.conf
+          subPath: dnsmasq.conf
         - name: dhcp-config
           mountPath: /etc/dnsmasq.conf.d
         - name: dhcp-data


### PR DESCRIPTION
## Description
This PR fixes Python in the `450-keepalived` and `450-network-gateway` modules image.

## Why do we need it, and what problem does it solve?
After migrating to the new image build process in PR #20914, Python stopped working due to incorrect linking of the C standard library. This PR fixes the linking issue and restores Python functionality in the module image.

## Why do we need it in the patch release (if we do)?
This issue breaks Python in the released module image, which can affect runtime behavior and maintenance tasks. The fix restores the expected functionality and should therefore be included in a patch release.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: network-gateway
type: fix
summary: Fixed Python linking in the network-gateway module image.
---
section: keepalived
type: fix
summary: Fixed Python linking in the keepalived module image.
```
