### PR TITLE
[deckhouse] Detach leader election from addon-operator

### DIFF
--- a/deckhouse-controller/cmd/deckhouse-controller/start.go
+++ b/deckhouse-controller/cmd/deckhouse-controller/start.go
@@ -220,7 +220,7 @@ func runWithLeaderElection(ctx context.Context, operator *addonoperator.AddonOpe
 		identity = fmt.Sprintf("%s.%s.%s.pod.%s", podName, strings.ReplaceAll(podIP, ".", "-"), podNs, clusterDomain)
 	}
 
-	err := operator.WithLeaderElector(&leaderelection.LeaderElectionConfig{
+	elector, err := leaderelection.NewLeaderElector(leaderelection.LeaderElectionConfig{
 		// Create a leaderElectionConfig for leader election
 		Lock: &resourcelock.LeaseLock{
 			LeaseMeta: v1.ObjectMeta{
@@ -252,8 +252,13 @@ func runWithLeaderElection(ctx context.Context, operator *addonoperator.AddonOpe
 		ReleaseOnCancel: true,
 	})
 	if err != nil {
-		operator.Logger.Error("run with leader elector", log.Err(err))
+		logger.Fatal("create leader elector", log.Err(err))
 	}
+
+	// addon-operator does not run the election, it only reads the leader state in its
+	// /readyz handler: a non-leader replica reports readiness by proxying to the leader
+	// instead of to its own converge, which never runs there.
+	operator.LeaderElector = elector
 
 	go func() {
 		<-ctx.Done()
@@ -263,7 +268,7 @@ func runWithLeaderElection(ctx context.Context, operator *addonoperator.AddonOpe
 		}
 	}()
 
-	operator.LeaderElector.Run(ctx)
+	elector.Run(ctx)
 }
 
 func run(ctx context.Context, operator *addonoperator.AddonOperator, logger *log.Logger) error {


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
`deckhouse-controller` builds and runs its own `leaderelection.LeaderElector` instead of calling `AddonOperator.WithLeaderElector`, a thin wrapper storing the result in an exported field. A failing constructor now stops startup instead of being logged and followed by a call on a nil elector.

The elector is still assigned to `operator.LeaderElector`, which addon-operator reads in its `/readyz` handler to let a non-leader replica proxy readiness to the leader; without it non-leader replicas stay NotReady.

Unchanged: lease name, timings, identity format, callbacks.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Leader election is the controller's own HA concern, not part of the addon-operator module runtime.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: chore
summary: Detach leader election from addon-operator
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->

