### PR TITLE
[docs] Update CSE release channel notes in airgapped update guide

### DIFF
--- a/docs/site/pages/guides/AIRGAPPED_UPDATE_RU.md
+++ b/docs/site/pages/guides/AIRGAPPED_UPDATE_RU.md
@@ -345,8 +345,8 @@ Sep 16 12:56:27.087 INFO  ║║ [1 / 1] Pulling registry.deckhouse.ru/deckhouse
 
 ## Особенности при работе с сертифицированной редакцией платформы
 
-Обновление по механизму «каналов обновлений» на текущий момент для CSE редакции не реализовано.
-
 Адрес хранилища образов: `registry-cse.deckhouse.ru/deckhouse/cse`.
 
-Процесс обновления описан на странице [Обновления DKP Certified Security Edition](https://deckhouse.ru/products/kubernetes-platform/certified-security-edition/updates/).
+Начиная с версии 1.73 в редакции CSE поддерживается канал обновлений LTS. После загрузки образов в локальный registry обновление выполняется согласно `spec.settings.update` в ModuleConfig `deckhouse`.
+
+При обновлении с версии ниже 1.73 канал обновлений не используется, следуйте [Руководству по обновлению DKP CSE](https://deckhouse.ru/products/kubernetes-platform/documentation/v1.73-cse/update.html).

--- a/docs/site/pages/guides/AIRGAPPED_UPDATE_RU.md
+++ b/docs/site/pages/guides/AIRGAPPED_UPDATE_RU.md
@@ -345,8 +345,8 @@ Sep 16 12:56:27.087 INFO  ║║ [1 / 1] Pulling registry.deckhouse.ru/deckhouse
 
 ## Особенности при работе с сертифицированной редакцией платформы
 
-Адрес хранилища образов: `registry-cse.deckhouse.ru/deckhouse/cse`.
+При обновлении DKP CSE учитывайте следующие особенности:
 
-Начиная с версии 1.73 в редакции CSE поддерживается канал обновлений LTS. После загрузки образов в локальный registry обновление выполняется согласно `spec.settings.update` в ModuleConfig `deckhouse`.
-
-При обновлении с версии ниже 1.73 канал обновлений не используется, следуйте [Руководству по обновлению DKP CSE](https://deckhouse.ru/products/kubernetes-platform/documentation/v1.73-cse/update.html).
+* Адрес хранилища образов для DKP CSE: `registry-cse.deckhouse.ru/deckhouse/cse`.
+* Начиная с DKP CSE 1.73, платформа поддерживает канал обновлений LTS. После загрузки образов в локальное хранилище образов обновление выполняется согласно настройкам [в блоке `spec.settings.update`](/modules/deckhouse/configuration.html#parameters-update) в ModuleConfig `deckhouse`.
+* При обновлении с версии, предшествующей DKP CSE 1.73, канал обновлений не используется. Выполните обновление, следуя [«Руководству по обновлению DKP CSE»](https://deckhouse.ru/products/kubernetes-platform/documentation/v1.73-cse/update.html).


### PR DESCRIPTION
## Description

Clarified that the LTS release channel is supported for DKP CSE starting from version 1.73.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: fix
summary: Clarified that the LTS release channel is supported for DKP CSE starting from version 1.73.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
