### PR TITLE
[docs] Add OS image change documentation

### DIFF
--- a/docs/documentation/_faq/admin/CHANGE_OS_IMAGE_CLOUD.md
+++ b/docs/documentation/_faq/admin/CHANGE_OS_IMAGE_CLOUD.md
@@ -1,0 +1,72 @@
+---
+title: How to replace an OS image in a cloud cluster?
+subsystems:
+  - cluster_infrastructure
+lang: en
+---
+
+Replacing an OS image in a cloud cluster works the same way for all providers: change the image reference in the DKP configuration. After that, nodes are reordered by the same mechanism that created them — Terraform, MCM, or CAPI.
+
+Where to change the configuration:
+
+* for [CloudEphemeral](/products/kubernetes-platform/documentation/v1/admin/configuration/platform-scaling/node/cloud-node.html#adding-cloudephemeral-nodes-in-a-cloud-cluster) — in the `<PROVIDER>InstanceClass` resource;
+* for [CloudPermanent](/products/kubernetes-platform/documentation/v1/admin/configuration/platform-scaling/node/cloud-node.html#adding-cloudpermanent-nodes-to-a-cloud-cluster) and master nodes — in `<PROVIDER>ClusterConfiguration`, in the `instanceClass` of the corresponding node group.
+
+If the provider has already been migrated to [ModuleConfig](/products/kubernetes-platform/documentation/v1/faq.html#how-to-migrate-a-cloud-provider-to-moduleconfig-based-configurat)-based configuration (for example, DVP), VM parameters are set via `<PROVIDER>InstanceClass` for both ephemeral and permanent nodes.
+
+The image field name and type depend on the provider and infrastructure and are not unified. For example:
+
+* in VCD it is a `template` string;
+* in DVP it is an `image` object with `kind` and `name`.
+
+See the cloud provider documentation for the field you need.
+
+## Replacement procedure
+
+1. Create a **new** image or template in the cloud. If images are versioned, include the version or date in the name, for example `ubuntu-24-04-20260110` → `ubuntu-24-04-20260204`.
+1. Set the new image in the DKP configuration.
+
+   Example for VMware Cloud Director (`VCDInstanceClass`):
+
+   ```yaml
+   apiVersion: deckhouse.io/v1
+   kind: VCDInstanceClass
+   metadata:
+     name: worker
+   spec:
+     template: Templates/ubuntu-24-04-20260204
+   ```
+
+   Example for DVP (`DVPInstanceClass`):
+
+   ```yaml
+   apiVersion: deckhouse.io/v1
+   kind: DVPInstanceClass
+   metadata:
+     name: worker
+   spec:
+     rootDisk:
+       image:
+         kind: ClusterVirtualImage
+         name: ubuntu-24-04-20260204
+   ```
+
+   For nodes managed via `<PROVIDER>ClusterConfiguration`, change the image field in the `instanceClass` of the required group. You can edit the configuration with:
+
+   ```bash
+   d8 k -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- \
+     deckhouse-controller edit provider-cluster-configuration
+   ```
+
+1. Wait for nodes to be reordered (Terraform / MCM / CAPI). If the new image exists and meets DKP requirements, no further action is needed.
+
+For master nodes, if needed, use the separate instructions: [multi-master](/modules/control-plane-manager/faq.html#how-do-i-switch-to-a-different-os-image-in-a-multi-master-cluster) and [single-master](/modules/control-plane-manager/faq.html#how-do-i-switch-to-a-different-os-image-in-a-single-master-cluster).
+
+## What to watch out for
+
+{% alert level="warning" %}
+If the image is referenced by name, the name in the configuration **must change**. Deleting the old image and creating a new one with the same name does not reorder nodes: DKP reacts to a configuration change, not to the content of the cloud resource.
+{% endalert %}
+
+* The new image must exist in the cloud by the time nodes are reordered.
+* The new image must meet DKP requirements for VM images (including cloud-init support) — the same as when preparing an image initially.

--- a/docs/documentation/_faq/admin/CHANGE_OS_IMAGE_CLOUD_RU.md
+++ b/docs/documentation/_faq/admin/CHANGE_OS_IMAGE_CLOUD_RU.md
@@ -1,0 +1,72 @@
+---
+title: Как заменить образ ОС в облачном кластере?
+subsystems:
+  - cluster_infrastructure
+lang: ru
+---
+
+Замена образа ОС в облачном кластере устроена одинаково для всех провайдеров: нужно изменить ссылку на образ в конфигурации DKP. После этого узлы перезаказываются тем же механизмом, которым они были созданы — Terraform, MCM или CAPI.
+
+Где менять конфигурацию:
+
+* для [CloudEphemeral](/products/kubernetes-platform/documentation/v1/admin/configuration/platform-scaling/node/cloud-node.html#добавление-cloudephemeral-узлов-в-облачном-кластере) — в ресурсе `<PROVIDER>InstanceClass`;
+* для [CloudPermanent](/products/kubernetes-platform/documentation/v1/admin/configuration/platform-scaling/node/cloud-node.html#добавление-cloudpermanent-узлов-в-облачном-кластере) и master-узлов — в `<PROVIDER>ClusterConfiguration` в `instanceClass` соответствующей группы узлов.
+
+Если провайдер уже переведён на конфигурацию через [ModuleConfig](/products/kubernetes-platform/documentation/v1/faq.html#как-мигрировать-облачный-провайдер-на-конфигурацию-через-modulec) (например, DVP), параметры ВМ задаются через `<PROVIDER>InstanceClass` и для эфемерных, и для перманентных узлов.
+
+Имя и тип поля с образом зависят от провайдера и инфраструктуры и не унифицированы. Например:
+
+* в VCD это строка `template`;
+* в DVP — объект `image` с полями `kind` и `name`.
+
+Смотрите описание нужного поля в документации cloud-провайдера.
+
+## Порядок замены
+
+1. Создайте в облаке **новый** образ или шаблон. Если образы версионируются, включайте версию или дату в имя, например `ubuntu-24-04-20260110` → `ubuntu-24-04-20260204`.
+1. Укажите новый образ в конфигурации DKP.
+
+   Пример для VMware Cloud Director (`VCDInstanceClass`):
+
+   ```yaml
+   apiVersion: deckhouse.io/v1
+   kind: VCDInstanceClass
+   metadata:
+     name: worker
+   spec:
+     template: Templates/ubuntu-24-04-20260204
+   ```
+
+   Пример для DVP (`DVPInstanceClass`):
+
+   ```yaml
+   apiVersion: deckhouse.io/v1
+   kind: DVPInstanceClass
+   metadata:
+     name: worker
+   spec:
+     rootDisk:
+       image:
+         kind: ClusterVirtualImage
+         name: ubuntu-24-04-20260204
+   ```
+
+   Для узлов, которые управляются через `<PROVIDER>ClusterConfiguration`, измените поле образа в `instanceClass` нужной группы. Отредактировать конфигурацию можно командой:
+
+   ```bash
+   d8 k -n d8-system exec -ti svc/deckhouse-leader -c deckhouse -- \
+     deckhouse-controller edit provider-cluster-configuration
+   ```
+
+1. Дождитесь перезаказа узлов (Terraform / MCM / CAPI). Если новый образ существует и соответствует требованиям DKP, дополнительных действий не требуется.
+
+Для master-узлов при необходимости используйте отдельные инструкции: [multi-master](/modules/control-plane-manager/faq.html#как-изменить-образ-ос-в-кластере-с-несколькими-master-узлами) и [single-master](/modules/control-plane-manager/faq.html#как-изменить-образ-ос-в-кластере-с-одним-master-узлом).
+
+## На что обратить внимание
+
+{% alert level="warning" %}
+Если образ указывается по имени, при замене имя в конфигурации **должно измениться**. Удаление старого образа и создание нового с тем же именем не приводит к перезаказу узлов: DKP реагирует на изменение конфигурации, а не на содержимое ресурса в облаке.
+{% endalert %}
+
+* Новый образ должен существовать в облаке к моменту перезаказа узлов.
+* Новый образ должен соответствовать требованиям DKP к образам ВМ (в том числе поддержке cloud-init) — так же, как при первичной подготовке образа.

--- a/docs/documentation/pages/admin/configuration/platform-scaling/node/CLOUD_NODE.md
+++ b/docs/documentation/pages/admin/configuration/platform-scaling/node/CLOUD_NODE.md
@@ -12,6 +12,10 @@ In Deckhouse Kubernetes Platform (DKP), cloud nodes can be of the following type
 
 Below are instructions for adding and configuring each type.
 
+{% alert level="info" %}
+To replace an OS image, change its reference in `<PROVIDER>InstanceClass` or `<PROVIDER>ClusterConfiguration`. The name in the configuration must change — updating an image in place with the same name does not reorder nodes. For details, see [How to replace an OS image in a cloud cluster](/products/kubernetes-platform/documentation/v1/faq.html#how-to-replace-an-os-image-in-a-cloud-cluster).
+{% endalert %}
+
 ## Adding CloudEphemeral nodes in a cloud cluster
 
 CloudEphemeral nodes are automatically created and managed within the cluster using the Machine Controller Manager (MCM) or Cluster API (depending on configuration) — both components are part of the [`node-manager`](/modules/node-manager/) module in DKP.

--- a/docs/documentation/pages/admin/configuration/platform-scaling/node/CLOUD_NODE_RU.md
+++ b/docs/documentation/pages/admin/configuration/platform-scaling/node/CLOUD_NODE_RU.md
@@ -12,6 +12,10 @@ lang: ru
 
 Ниже приведены инструкции по добавлению и настройке каждого типа.
 
+{% alert level="info" %}
+Чтобы заменить образ ОС, измените ссылку на него в `<PROVIDER>InstanceClass` или `<PROVIDER>ClusterConfiguration`. Имя в конфигурации должно измениться — обновление образа «на месте» с тем же именем узлы не перезаказывает. Подробнее — в разделе [«Как заменить образ ОС в облачном кластере»](/products/kubernetes-platform/documentation/v1/faq.html#как-заменить-образ-ос-в-облачном-кластере).
+{% endalert %}
+
 ## Добавление CloudEphemeral-узлов в облачном кластере
 
 CloudEphemeral-узлы автоматически создаются и управляются в кластере с помощью Machine Controller Manager (MCM) или Cluster API (в зависимости от конфигурации) — оба компонента входят в состав модуля [`node-manager`](/modules/node-manager/) в DKP.


### PR DESCRIPTION
## Description
Added OS image change documentation.
## Why do we need it, and what problem does it solve?


## Why do we need it in the patch release (if we do)?



## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: docs
type: chore
summary: Added OS image change documentation.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
