### PR TITLE
[registry] No init secret deletion (1.76)

### DIFF
--- a/deckhouse-controller/cmd/deckhouse-controller/register-go-hooks.go
+++ b/deckhouse-controller/cmd/deckhouse-controller/register-go-hooks.go
@@ -53,6 +53,7 @@ import (
 	_ "github.com/deckhouse/deckhouse/modules/038-registry/hooks/orchestrator"
 	_ "github.com/deckhouse/deckhouse/modules/038-registry/hooks/orchestrator/bashible"
 	_ "github.com/deckhouse/deckhouse/modules/038-registry/hooks/orchestrator/incluster-proxy"
+	_ "github.com/deckhouse/deckhouse/modules/038-registry/hooks/orchestrator/init-secret"
 	_ "github.com/deckhouse/deckhouse/modules/038-registry/hooks/orchestrator/node-services"
 	_ "github.com/deckhouse/deckhouse/modules/038-registry/hooks/orchestrator/pki"
 	_ "github.com/deckhouse/deckhouse/modules/038-registry/hooks/orchestrator/registry-service"

--- a/dhctl/pkg/config/registry/errors.go
+++ b/dhctl/pkg/config/registry/errors.go
@@ -19,7 +19,6 @@ import (
 )
 
 var (
-	ErrUnknownMode    = errors.New("Unknown registry mode")
-	ErrIsNotReady     = errors.New("Registry is not ready")
-	ErrNotInitialized = errors.New("Registry is not initialized")
+	ErrUnknownMode = errors.New("Unknown registry mode")
+	ErrIsNotReady  = errors.New("Registry is not ready")
 )

--- a/dhctl/pkg/config/registry/pki_test.go
+++ b/dhctl/pkg/config/registry/pki_test.go
@@ -36,7 +36,7 @@ func TestGetPKI(t *testing.T) {
 		ctx := t.Context()
 		kubeClient := client.NewFakeKubernetesClient()
 
-		err := createInitSecret(ctx, kubeClient, false)
+		err := createInitSecret(ctx, kubeClient)
 		require.NoError(t, err)
 
 		pki, err := GetPKI(ctx, kubeClient)

--- a/dhctl/pkg/config/registry/steps.go
+++ b/dhctl/pkg/config/registry/steps.go
@@ -30,16 +30,14 @@ import (
 )
 
 const (
-	secretsNamespace            = "d8-system"
-	stateSecretName             = "registry-state"
-	initSecretName              = "registry-init"
-	initSecretAppliedAnnotation = "registry.deckhouse.io/is-applied"
+	secretsNamespace = "d8-system"
+	stateSecretName  = "registry-state"
+	initSecretName   = "registry-init"
 
 	conditionTypeReady = "Ready"
 )
 
-// WaitForRegistryInitialization waits for the registry to become fully initialized and ready.
-// After successful initialization, the initSecret will be removed.
+// WaitForRegistryReady waits for the registry to become ready.
 // Parameters:
 //   - ctx: context for cancellation and timeouts
 //   - kubeClient: Kubernetes client for API operations
@@ -47,16 +45,15 @@ const (
 //
 // Returns:
 //   - err: error from the operation
-func WaitForRegistryInitialization(ctx context.Context, kubeClient client.KubeClient, config Config) error {
+func WaitForRegistryReady(ctx context.Context, kubeClient client.KubeClient, config Config) error {
 	return retry.
 		NewLoop("Waiting for Registry to become Ready", 100, 20*time.Second).
 		RunContext(ctx, func() error {
-			return checkRegistryInitialization(ctx, kubeClient, config)
+			return isRegistryReady(ctx, kubeClient, config)
 		})
 }
 
-// checkRegistryInitialization performs checks for registry initialization status.
-// After successful initialization, the initSecret will be removed.
+// isRegistryReady checks whether the registry is ready, unless legacy mode is enabled.
 // Parameters:
 //   - ctx: context for cancellation and timeouts
 //   - kubeClient: Kubernetes client for API operations
@@ -64,79 +61,41 @@ func WaitForRegistryInitialization(ctx context.Context, kubeClient client.KubeCl
 //
 // Returns:
 //   - err: error from the operation
-func checkRegistryInitialization(ctx context.Context, kubeClient client.KubeClient, config Config) error {
-	if !config.LegacyMode {
-		if err := checkInit(ctx, kubeClient); err != nil {
-			log.DebugF("Error while checking registry init: %v\n", err)
-			return ErrIsNotReady
-		}
-
-		msg, err := checkReady(ctx, kubeClient)
-		if err != nil {
-			if msg != "" {
-				err := fmt.Errorf("%s\n%s", ErrIsNotReady.Error(), msg)
-				log.DebugF("Error while checking registry ready: %v\n", err)
-				return err
-			}
-
-			log.DebugF("Error while checking registry ready: %v\n", err)
-			return ErrIsNotReady
-		}
+func isRegistryReady(ctx context.Context, kubeClient client.KubeClient, config Config) error {
+	if config.LegacyMode {
+		return nil
 	}
 
-	if err := removeInitSecret(ctx, kubeClient); err != nil {
-		log.DebugF("Error while removing registry init secret: %v\n", err)
+	conditions, err := getConditions(ctx, kubeClient)
+	if err != nil {
+		log.DebugLn(fmt.Sprintf("Error while checking registry ready: %v", err))
 		return ErrIsNotReady
 	}
 
-	return nil
-}
+	if isConditionsReady(conditions) {
+		return nil
+	}
 
-// checkInit verifies if the registry initialization process has started.
-// Parameters:
-//   - ctx: context for cancellation and timeouts
-//   - kubeClient: Kubernetes client for API operations
-//
-// Returns:
-//   - err: error from the operation
-func checkInit(ctx context.Context, kubeClient client.KubeClient) error {
-	exists, applied, err := getInitSecretStatus(ctx, kubeClient)
-	if err != nil {
+	if msg := formatNotReadyMessage(conditions); msg != "" {
+		err := fmt.Errorf("%s\n%s", ErrIsNotReady.Error(), msg)
+		log.DebugLn(ctx, fmt.Sprintf("Error while checking registry ready: %v", err))
 		return err
 	}
 
-	if exists && !applied {
-		return ErrNotInitialized
-	}
-	return nil
+	return ErrIsNotReady
 }
 
-// checkReady verifies if the registry is ready.
-// Parameters:
-//   - ctx: context for cancellation and timeouts
-//   - kubeClient: Kubernetes client for API operations
-//
-// Returns:
-//   - string: readiness status messages
-//   - err: error from the operation
-func checkReady(ctx context.Context, kubeClient client.KubeClient) (string, error) {
-	conditions, err := getStateSecret(ctx, kubeClient)
-	if err != nil {
-		return "", err
-	}
-
+// formatNotReadyMessage builds a human-readable message listing all non-True
+// conditions (excluding the Ready condition itself).
+func formatNotReadyMessage(conditions []metav1.Condition) string {
 	if len(conditions) == 0 {
-		return "", ErrIsNotReady
+		return ""
 	}
 
-	var (
-		msg   strings.Builder
-		ready bool
-	)
+	var msg strings.Builder
 
 	for _, condition := range conditions {
 		if condition.Type == conditionTypeReady {
-			ready = condition.Status == metav1.ConditionTrue
 			continue
 		}
 
@@ -154,14 +113,26 @@ func checkReady(ctx context.Context, kubeClient client.KubeClient) (string, erro
 		)
 	}
 
-	if ready {
-		return "", nil
-	}
-
-	return msg.String(), ErrIsNotReady
+	return msg.String()
 }
 
-// getStateSecret retrieves and parses the registry state conditions.
+// isConditionsReady checks whether the registry is ready based on its conditions.
+// It returns true only if the Ready condition is present and set to True.
+func isConditionsReady(conditions []metav1.Condition) bool {
+	if len(conditions) == 0 {
+		return false
+	}
+
+	for _, condition := range conditions {
+		if condition.Type == conditionTypeReady {
+			return condition.Status == metav1.ConditionTrue
+		}
+	}
+
+	return false
+}
+
+// getConditions retrieves and parses the registry state conditions.
 // Parameters:
 //   - ctx: context for cancellation and timeouts
 //   - kubeClient: Kubernetes client for API operations
@@ -169,72 +140,35 @@ func checkReady(ctx context.Context, kubeClient client.KubeClient) (string, erro
 // Returns:
 //   - []metav1.Condition: registry state conditions
 //   - err: error from the operation
-func getStateSecret(ctx context.Context, kubeClient client.KubeClient) ([]metav1.Condition, error) {
+func getConditions(ctx context.Context, kubeClient client.KubeClient) ([]metav1.Condition, error) {
+	var conditions []metav1.Condition
+
 	secret, err := kubeClient.
 		CoreV1().
 		Secrets(secretsNamespace).
 		Get(ctx, stateSecretName, metav1.GetOptions{})
 
 	if err != nil {
-		return nil, fmt.Errorf("get secret '%s/%s': %w", secretsNamespace, stateSecretName, err)
+		if apierrors.IsNotFound(err) {
+			return conditions, nil
+		}
+		return nil, fmt.Errorf(
+			"get secret '%s/%s': %w",
+			secretsNamespace, stateSecretName, err,
+		)
 	}
 
-	var conditions []metav1.Condition
-
-	conditionRaw, exists := secret.Data["conditions"]
+	rawConditions, exists := secret.Data["conditions"]
 	if !exists {
 		return conditions, nil
 	}
 
-	if err := yaml.Unmarshal(conditionRaw, &conditions); err != nil {
-		return nil, fmt.Errorf("unmarshal secret data: %w", err)
+	if err := yaml.Unmarshal(rawConditions, &conditions); err != nil {
+		return nil, fmt.Errorf(
+			"unmarshal secret '%s/%s' conditions: %w",
+			secretsNamespace, stateSecretName, err,
+		)
 	}
 
 	return conditions, nil
-}
-
-// getInitSecretStatus checks the status of the init secret.
-// Parameters:
-//   - ctx: context for cancellation and timeouts
-//   - kubeClient: Kubernetes client for API operations
-//
-// Returns:
-//   - secretExists: boolean indicating secret presence
-//   - secretApplied: boolean indicating secret application status
-//   - err: error from the operation
-func getInitSecretStatus(ctx context.Context, kubeClient client.KubeClient) (bool, bool, error) {
-	secret, err := kubeClient.
-		CoreV1().
-		Secrets(secretsNamespace).
-		Get(ctx, initSecretName, metav1.GetOptions{})
-
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return false, false, nil
-		}
-		return false, false, fmt.Errorf("get secret '%s/%s': %w", secretsNamespace, initSecretName, err)
-	}
-
-	_, applied := secret.Annotations[initSecretAppliedAnnotation]
-	return true, applied, nil
-}
-
-// removeInitSecret removes the initialization secret.
-// Parameters:
-//   - ctx: context for cancellation and timeouts
-//   - kubeClient: Kubernetes client for API operations
-//
-// Returns:
-//   - err: error from the operation
-func removeInitSecret(ctx context.Context, kubeClient client.KubeClient) error {
-	err := kubeClient.
-		CoreV1().
-		Secrets(secretsNamespace).
-		Delete(ctx, initSecretName, metav1.DeleteOptions{})
-
-	if err != nil && !apierrors.IsNotFound(err) {
-		return fmt.Errorf("remove secret '%s/%s': %w", secretsNamespace, initSecretName, err)
-	}
-
-	return nil
 }

--- a/dhctl/pkg/config/registry/steps_test.go
+++ b/dhctl/pkg/config/registry/steps_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
 )
 
-func createInitSecret(ctx context.Context, kubeClient client.KubeClient, applied bool) error {
+func createInitSecret(ctx context.Context, kubeClient client.KubeClient) error {
 	pki, err := GeneratePKI()
 	if err != nil {
 		return err
@@ -46,12 +46,6 @@ func createInitSecret(ctx context.Context, kubeClient client.KubeClient, applied
 		Data: map[string][]byte{
 			"config": pkiYaml,
 		},
-	}
-
-	if applied {
-		secret.Annotations = map[string]string{
-			initSecretAppliedAnnotation: "",
-		}
 	}
 
 	return createOrUpdateSecret(ctx, kubeClient, secret)
@@ -100,88 +94,53 @@ func createOrUpdateSecret(ctx context.Context, kubeClient client.KubeClient, sec
 	return err
 }
 
-func TestCheckRegistryInitialization(t *testing.T) {
-	t.Run("legacy - should delete init secret", func(t *testing.T) {
+func TestIsRegistryReady(t *testing.T) {
+	t.Run("legacy - returns ready regardless of state secret", func(t *testing.T) {
 		ctx := t.Context()
 		kubeClient := client.NewFakeKubernetesClient()
 		config := ConfigBuilder(
 			WithLegacyMode(),
 		)
 
-		// Setup: create non-applied init secret
-		err := createInitSecret(ctx, kubeClient, false)
+		// Legacy mode skips readiness checks entirely, so the registry is
+		// considered ready no matter what the state secret contains.
+		err := isRegistryReady(ctx, kubeClient, config)
 		require.NoError(t, err)
 
-		isExist, isApplied, err := getInitSecretStatus(ctx, kubeClient)
+		err = createStatusSecret(ctx, kubeClient, false)
 		require.NoError(t, err)
 
-		require.True(t, isExist, "Init secret should exist initially")
-		require.False(t, isApplied, "Init secret should not be applied initially")
-
-		// First run: delete the secret
-		err = checkRegistryInitialization(ctx, kubeClient, config)
+		err = isRegistryReady(ctx, kubeClient, config)
 		require.NoError(t, err)
 
-		isExist, _, err = getInitSecretStatus(ctx, kubeClient)
+		err = createStatusSecret(ctx, kubeClient, true)
 		require.NoError(t, err)
 
-		require.False(t, isExist, "Init secret should be deleted after first run")
-
-		// Second run: verify deletion is idempotent
-		err = checkRegistryInitialization(ctx, kubeClient, config)
+		err = isRegistryReady(ctx, kubeClient, config)
 		require.NoError(t, err)
-
-		isExist, _, err = getInitSecretStatus(ctx, kubeClient)
-		require.NoError(t, err)
-
-		require.False(t, isExist, "Init secret should remain deleted")
 	})
 
-	t.Run("not legacy - should delete init secret after ready", func(t *testing.T) {
+	t.Run("not legacy - readiness flow", func(t *testing.T) {
 		ctx := t.Context()
 		kubeClient := client.NewFakeKubernetesClient()
 		config := ConfigBuilder()
 
-		// Setup initial state with applied init secret
-		err := createInitSecret(ctx, kubeClient, true)
-		require.NoError(t, err)
-
-		isExist, isApplied, err := getInitSecretStatus(ctx, kubeClient)
-		require.NoError(t, err)
-
-		require.True(t, isExist, "Init secret should exist initially")
-		require.True(t, isApplied, "Init secret should be applied initially")
-
-		// First run: preserve secret when module status is unknown
-		err = checkRegistryInitialization(ctx, kubeClient, config)
+		// First run: not ready when module status is unknown
+		err := isRegistryReady(ctx, kubeClient, config)
 		require.EqualError(t, err, ErrIsNotReady.Error())
 
-		isExist, _, err = getInitSecretStatus(ctx, kubeClient)
-		require.NoError(t, err)
-
-		require.True(t, isExist, "Init secret should be preserved when module status is unknown")
-
-		// Second run: preserve secret with unready status
+		// Second run: not ready with unready status
 		err = createStatusSecret(ctx, kubeClient, false)
 		require.NoError(t, err)
 
-		err = checkRegistryInitialization(ctx, kubeClient, config)
+		err = isRegistryReady(ctx, kubeClient, config)
 		require.EqualError(t, err, ErrIsNotReady.Error())
 
-		isExist, _, err = getInitSecretStatus(ctx, kubeClient)
-		require.NoError(t, err)
-
-		require.True(t, isExist, "Init secret should remain preserved with unready status")
-
-		// Third run: delete secret when status becomes ready
+		// Third run: ready when status becomes ready
 		err = createStatusSecret(ctx, kubeClient, true)
 		require.NoError(t, err)
 
-		err = checkRegistryInitialization(ctx, kubeClient, config)
+		err = isRegistryReady(ctx, kubeClient, config)
 		require.NoError(t, err)
-
-		isExist, _, err = getInitSecretStatus(ctx, kubeClient)
-		require.NoError(t, err)
-		require.False(t, isExist, "Init secret should be deleted when module becomes ready")
 	})
 }

--- a/dhctl/pkg/operations/bootstrap/steps.go
+++ b/dhctl/pkg/operations/bootstrap/steps.go
@@ -291,10 +291,7 @@ func InstallDeckhouse(
 			return fmt.Errorf("Deckhouse not ready: %w", err)
 		}
 
-		// Warning! This function must be called at the end of the Deckhouse installation phase.
-		// At the end of this function, the registry-init secret is deleted,
-		// which is used during DeckhouseInstall for certain registry operation modes.
-		err = registry_config.WaitForRegistryInitialization(ctx, kubeCl, config.Registry)
+		err = registry_config.WaitForRegistryReady(ctx, kubeCl, config.Registry)
 		if err != nil {
 			return fmt.Errorf("registry initialization: %v", err)
 		}

--- a/modules/038-registry/hooks/orchestrator/hook.go
+++ b/modules/038-registry/hooks/orchestrator/hook.go
@@ -30,12 +30,12 @@ import (
 
 	registry_const "github.com/deckhouse/deckhouse/go_lib/registry/const"
 	deckhouse_registry "github.com/deckhouse/deckhouse/go_lib/registry/models/deckhouseregistry"
-	init_secret "github.com/deckhouse/deckhouse/go_lib/registry/models/initsecret"
 	registry_pki "github.com/deckhouse/deckhouse/go_lib/registry/pki"
 	"github.com/deckhouse/deckhouse/modules/038-registry/hooks/checker"
 	"github.com/deckhouse/deckhouse/modules/038-registry/hooks/helpers"
 	"github.com/deckhouse/deckhouse/modules/038-registry/hooks/orchestrator/bashible"
 	inclusterproxy "github.com/deckhouse/deckhouse/modules/038-registry/hooks/orchestrator/incluster-proxy"
+	init_secret "github.com/deckhouse/deckhouse/modules/038-registry/hooks/orchestrator/init-secret"
 	nodeservices "github.com/deckhouse/deckhouse/modules/038-registry/hooks/orchestrator/node-services"
 	"github.com/deckhouse/deckhouse/modules/038-registry/hooks/orchestrator/pki"
 	registryservice "github.com/deckhouse/deckhouse/modules/038-registry/hooks/orchestrator/registry-service"
@@ -58,8 +58,6 @@ const (
 	registryServiceSnapName  = "registry-service"
 	bashibleSnapName         = "bashible"
 	registrySwitcherSnapName = "registry-switcher"
-
-	initSecretAppliedAnnotation = "registry.deckhouse.io/is-applied"
 )
 
 func getKubernetesConfigs() []go_hook.KubernetesConfig {
@@ -115,35 +113,6 @@ func getKubernetesConfigs() []go_hook.KubernetesConfig {
 			},
 		},
 		{
-			Name:       initSnapName,
-			ApiVersion: "v1",
-			Kind:       "Secret",
-			NameSelector: &types.NameSelector{
-				MatchNames: []string{"registry-init"},
-			},
-			NamespaceSelector: &types.NamespaceSelector{
-				NameSelector: &types.NameSelector{
-					MatchNames: []string{"d8-system"},
-				},
-			},
-			FilterFunc: func(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
-				var secret v1core.Secret
-
-				err := sdk.FromUnstructured(obj, &secret)
-				if err != nil {
-					return nil, fmt.Errorf("failed to convert init secret to struct: %v", err)
-				}
-
-				_, applied := secret.Annotations[initSecretAppliedAnnotation]
-				ret := InitSecretSnap{
-					IsExist: true,
-					Applied: applied,
-					Config:  secret.Data["config"],
-				}
-				return ret, nil
-			},
-		},
-		{
 			Name:              registrySecretSnapName,
 			ApiVersion:        "v1",
 			Kind:              "Secret",
@@ -166,6 +135,7 @@ func getKubernetesConfigs() []go_hook.KubernetesConfig {
 		registryservice.KubernetsConfig(registryServiceSnapName),
 		inclusterproxy.KubernetesConfig(inClusterProxySnapName),
 		registryswitcher.KubernetesConfig(registrySwitcherSnapName),
+		init_secret.KubernetsConfig(initSnapName),
 	}
 
 	ret = append(ret, nodeservices.KubernetsConfig(nodeServicesSnapName)...)
@@ -187,30 +157,10 @@ func handle(ctx context.Context, input *go_hook.HookInput) error {
 	values := moduleValues.Get()
 
 	var (
-		inputs Inputs
-		err    error
+		noState bool
+		inputs  Inputs
+		err     error
 	)
-
-	initSecret, err := helpers.SnapshotToSingle[InitSecretSnap](input, initSnapName)
-	if err == nil {
-		var config init_secret.Config
-
-		if err = yaml.Unmarshal(initSecret.Config, &config); err != nil {
-			err = fmt.Errorf("cannot unmarhsal init secret YAML: %w", err)
-		} else if err = config.Validate(); err != nil {
-			err = fmt.Errorf("init secret validation error: %w", err)
-		} else {
-			inputs.InitSecret = config
-		}
-	}
-
-	if err != nil && !errors.Is(err, helpers.ErrNoSnapshot) {
-		input.Logger.Warn(
-			"Cannot get init config, the state will be processed without it",
-			"error", err,
-		)
-		initSecret = InitSecretSnap{}
-	}
 
 	if values.State.Mode == "" {
 		input.Logger.Info("State not initialized, trying restore from secret")
@@ -223,6 +173,7 @@ func handle(ctx context.Context, input *go_hook.HookInput) error {
 		}
 
 		if err != nil {
+			noState = true
 			input.Logger.Warn(
 				"Cannot restore state from secret, will initialize new",
 				"error", err,
@@ -250,6 +201,11 @@ func handle(ctx context.Context, input *go_hook.HookInput) error {
 	}
 	if inputs.Params, err = configFromSecret(configSecret); err != nil {
 		return fmt.Errorf("failed to process config from secret %q: %w", configSecret.Name, err)
+	}
+
+	inputs.InitSecret, err = init_secret.InputsFromSnapshot(input, initSnapName)
+	if err != nil {
+		return fmt.Errorf("get InitSecret snapshot error: %w", err)
 	}
 
 	inputs.RegistrySecret, err = helpers.SnapshotToSingle[deckhouse_registry.Config](input, registrySecretSnapName)
@@ -310,8 +266,8 @@ func handle(ctx context.Context, input *go_hook.HookInput) error {
 	// Load checker params
 	values.State.CheckerParams = checker.GetParams(ctx, input)
 
-	// Process the state with init secret
-	if initSecret.IsExist && !initSecret.Applied {
+	// Process the state with init secret if state not exist
+	if noState && inputs.InitSecret.Unapplied {
 		input.Logger.Info("initializing state from init configuration")
 
 		err = values.State.initialize(input.Logger, inputs)
@@ -320,22 +276,22 @@ func handle(ctx context.Context, input *go_hook.HookInput) error {
 		}
 	}
 
-	// Registry parameters are frozen during two critical phases:
+	// Registry parameters are frozen until the cluster has finished bootstrapping.
 	//
-	// 1. Initialization: User input changes are locked to ensure the registry
-	//    configuration can complete without being overwritten. This also prevents
-	//    the Commander agent from inadvertently overriding registry settings
-	//    if Commander itself was misconfigured.
+	// Freezing the parameters here:
+	//   - lets the registry configuration complete without user input changes
+	//     overwriting it (also prevents a misconfigured Commander agent from
+	//     overriding registry settings);
+	//   - avoids port collisions during bootstrap: the registry runs in Direct
+	//     mode on the host network so that Deckhouse (which also uses the host
+	//     network at this stage) can access it directly. If the registry mode
+	//     were changed during bootstrap, the new registry Pod would conflict on
+	//     the same host port already occupied by the existing Direct-mode
+	//     registry, preventing it from starting.
 	//
-	// 2. Cluster Bootstrap: To avoid port collisions. During bootstrap, the registry runs in
-	//    Direct mode on the host network so that Deckhouse (which also uses the host network
-	//    at this stage) can access it directly. If the registry mode were changed during
-	//    bootstrap, the new registry Pod would conflict on the same host port that is already
-	//    occupied by the existing Direct-mode registry, preventing it from starting.
-	//
-	// During these phases, parameters are frozen to prevent external modification.
+	// During this phase, parameters are frozen to prevent external modification.
 	// Any external changes are ignored, and the last saved parameters are used.
-	if initSecret.IsExist || !helpers.ClusterIsBootstrapped(input) {
+	if !helpers.ClusterIsBootstrapped(input) {
 		// Ensure we have frozen params
 		if values.State.InitParams == nil {
 			state := inputs.Params.toState()
@@ -382,18 +338,7 @@ func handle(ctx context.Context, input *go_hook.HookInput) error {
 	}
 
 	// Patch init secret
-	if initSecret.IsExist && !initSecret.Applied {
-		input.Logger.Debug("Marking init secret as applied by setting annotation")
-		patch := map[string]any{
-			"metadata": map[string]any{
-				"annotations": map[string]any{
-					initSecretAppliedAnnotation: "",
-				},
-			},
-		}
-		input.PatchCollector.PatchWithMerge(
-			patch, "v1", "Secret", "d8-system", "registry-init")
-	}
+	init_secret.SetApplied(input, inputs.InitSecret)
 	return nil
 }
 

--- a/modules/038-registry/hooks/orchestrator/init-secret/k8s.go
+++ b/modules/038-registry/hooks/orchestrator/init-secret/k8s.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	 http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package initsecret
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	v1core "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
+
+	init_secret "github.com/deckhouse/deckhouse/go_lib/registry/models/initsecret"
+	"github.com/deckhouse/deckhouse/modules/038-registry/hooks/helpers"
+)
+
+const (
+	secretName        = "registry-init"
+	secretNamespace   = "d8-system"
+	appliedAnnotation = "registry.deckhouse.io/is-applied"
+)
+
+func KubernetsConfig(snapName string) go_hook.KubernetesConfig {
+	return go_hook.KubernetesConfig{
+		Name:       snapName,
+		ApiVersion: "v1",
+		Kind:       "Secret",
+		NameSelector: &types.NameSelector{
+			MatchNames: []string{secretName},
+		},
+		NamespaceSelector: &types.NamespaceSelector{
+			NameSelector: &types.NameSelector{
+				MatchNames: []string{secretNamespace},
+			},
+		},
+		FilterFunc: func(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+			var secret v1core.Secret
+
+			err := sdk.FromUnstructured(obj, &secret)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert init secret to struct: %v", err)
+			}
+
+			_, applied := secret.Annotations[appliedAnnotation]
+			ret := initSecretSnap{
+				Applied:   applied,
+				RawConfig: secret.Data["config"],
+			}
+			return ret, nil
+		},
+	}
+}
+
+func InputsFromSnapshot(input *go_hook.HookInput, snapName string) (Inputs, error) {
+	initSecret, err := helpers.SnapshotToSingle[initSecretSnap](input, snapName)
+	if err != nil {
+		if errors.Is(err, helpers.ErrNoSnapshot) {
+			// No initialization secret found - nothing to process
+			return Inputs{}, nil
+		}
+		// Unexpected error while reading snapshot
+		return Inputs{}, err
+	}
+
+	// Secret already applied in a previous run - skip processing
+	if initSecret.Applied {
+		return Inputs{}, nil
+	}
+
+	// Secret exists and needs to be processed
+	var config init_secret.Config
+	if err = yaml.Unmarshal(initSecret.RawConfig, &config); err != nil {
+		return Inputs{}, fmt.Errorf("cannot unmarshal init secret YAML from snapshot %s: %w", snapName, err)
+	}
+
+	if err = config.Validate(); err != nil {
+		return Inputs{}, fmt.Errorf("init secret validation failed for snapshot %s: %w", snapName, err)
+	}
+
+	return Inputs{
+		Unapplied: true,
+		Config:    config,
+	}, nil
+}
+
+func SetApplied(input *go_hook.HookInput, inputs Inputs) {
+	if inputs.Unapplied {
+		input.Logger.Debug("Marking init secret as applied by setting annotation")
+
+		patch := map[string]any{
+			"metadata": map[string]any{
+				"annotations": map[string]any{
+					appliedAnnotation: "",
+				},
+			},
+		}
+
+		input.PatchCollector.PatchWithMerge(
+			patch, "v1", "Secret", secretNamespace, secretName)
+	}
+}

--- a/modules/038-registry/hooks/orchestrator/init-secret/models.go
+++ b/modules/038-registry/hooks/orchestrator/init-secret/models.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	 http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package initsecret
+
+import (
+	init_secret "github.com/deckhouse/deckhouse/go_lib/registry/models/initsecret"
+)
+
+type initSecretSnap struct {
+	Applied   bool
+	RawConfig []byte
+}
+
+type Inputs struct {
+	Unapplied bool
+	Config    init_secret.Config
+}

--- a/modules/038-registry/hooks/orchestrator/models.go
+++ b/modules/038-registry/hooks/orchestrator/models.go
@@ -24,11 +24,11 @@ import (
 
 	registry_const "github.com/deckhouse/deckhouse/go_lib/registry/const"
 	deckhouse_registry "github.com/deckhouse/deckhouse/go_lib/registry/models/deckhouseregistry"
-	init_secret "github.com/deckhouse/deckhouse/go_lib/registry/models/initsecret"
 	registry_pki "github.com/deckhouse/deckhouse/go_lib/registry/pki"
 	"github.com/deckhouse/deckhouse/modules/038-registry/hooks/checker"
 	"github.com/deckhouse/deckhouse/modules/038-registry/hooks/orchestrator/bashible"
 	inclusterproxy "github.com/deckhouse/deckhouse/modules/038-registry/hooks/orchestrator/incluster-proxy"
+	init_secret "github.com/deckhouse/deckhouse/modules/038-registry/hooks/orchestrator/init-secret"
 	nodeservices "github.com/deckhouse/deckhouse/modules/038-registry/hooks/orchestrator/node-services"
 	"github.com/deckhouse/deckhouse/modules/038-registry/hooks/orchestrator/pki"
 	registryservice "github.com/deckhouse/deckhouse/modules/038-registry/hooks/orchestrator/registry-service"
@@ -106,9 +106,9 @@ func (p ParamsState) toParams() (Params, error) {
 type Inputs struct {
 	Params          Params
 	RegistrySecret  deckhouse_registry.Config
-	InitSecret      init_secret.Config
 	IngressClientCA *x509.Certificate // optional
 
+	InitSecret       init_secret.Inputs
 	PKI              pki.Inputs
 	Secrets          secrets.Inputs
 	Users            users.Inputs
@@ -123,12 +123,6 @@ type Inputs struct {
 type Values struct {
 	Hash  string `json:"hash,omitempty"`
 	State State  `json:"state,omitempty"`
-}
-
-type InitSecretSnap struct {
-	IsExist bool
-	Applied bool
-	Config  []byte
 }
 
 func (p Params) Validate() error {

--- a/modules/038-registry/hooks/orchestrator/state.go
+++ b/modules/038-registry/hooks/orchestrator/state.go
@@ -107,8 +107,8 @@ func (state *State) clearConditions() {
 func (state *State) initialize(log go_hook.Logger, inputs Inputs) error {
 	// Process PKI
 	state.PKI.CA = &pki.CertModel{
-		Cert: inputs.InitSecret.CA.Cert,
-		Key:  inputs.InitSecret.CA.Key,
+		Cert: inputs.InitSecret.Config.CA.Cert,
+		Key:  inputs.InitSecret.Config.CA.Key,
 	}
 
 	pkiResult, err := state.PKI.Process(log)
@@ -117,14 +117,14 @@ func (state *State) initialize(log go_hook.Logger, inputs Inputs) error {
 	}
 
 	// Process Users
-	ro := inputs.InitSecret.ROUser
+	ro := inputs.InitSecret.Config.ROUser
 	state.Users.RO = &users.User{
 		UserName:       ro.Name,
 		HashedPassword: ro.PasswordHash,
 		Password:       ro.Password,
 	}
 
-	rw := inputs.InitSecret.RWUser
+	rw := inputs.InitSecret.Config.RWUser
 	state.Users.RW = &users.User{
 		UserName:       rw.Name,
 		HashedPassword: rw.PasswordHash,


### PR DESCRIPTION
## Description

Fixes the DKP installation retry. The `registry-init` secret is no longer deleted.

Also fixed:
1. Registry startup check is performed only by conditions;
2. init secret handling moved to a separate package in the registry module;
3. Initialization via init config runs only once if the internal state does not exist yet;

## Why do we need it, and what problem does it solve?

Fixes the DKP installation retry. The `registry-init` secret is no longer deleted.

## Why do we need it in the patch release (if we do)?

Fixes the DKP installation retry. The `registry-init` secret is no longer deleted.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: registry
type: fix
summary: Fix DKP bootstrap retry by keeping the `registry-init` secret.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
