### PR TITLE
[deckhouse] chore: update module sdk dependency (#21865)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,8 +62,8 @@ require (
 	github.com/deckhouse/deckhouse/pkg/log v0.2.1
 	github.com/deckhouse/deckhouse/pkg/metrics-storage v0.3.0
 	github.com/deckhouse/deckhouse/pkg/registry v0.0.0-20260525111533-9e5ba68242f7
-	github.com/deckhouse/lib-dhctl v0.21.0
-	github.com/deckhouse/module-sdk v0.12.1
+	github.com/deckhouse/lib-dhctl v0.22.0
+	github.com/deckhouse/module-sdk v0.12.2
 	github.com/ettle/strcase v0.2.0
 	github.com/evanphx/json-patch v5.9.11+incompatible
 	github.com/fsnotify/fsnotify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -161,12 +161,12 @@ github.com/deckhouse/deckhouse/pkg/registry v0.0.0-20260525111533-9e5ba68242f7 h
 github.com/deckhouse/deckhouse/pkg/registry v0.0.0-20260525111533-9e5ba68242f7/go.mod h1:KDf44MqEif8jAKCehKJqOg0k4sJcnetKJKDGd0IFQjI=
 github.com/deckhouse/lib-connection v0.13.0 h1:IQaSb28dnLhvSvathqY/s50D2uc/Z47NIsFUnaPK3mE=
 github.com/deckhouse/lib-connection v0.13.0/go.mod h1:6fNsoXGoxiuSZRMhB1m2NWs1Q70tlmJNdm0MHmjBips=
-github.com/deckhouse/lib-dhctl v0.21.0 h1:6pO9qOj3mdQpX+zD07ZRlorKCtjvn5VEyigmT4k5SBw=
-github.com/deckhouse/lib-dhctl v0.21.0/go.mod h1:hICPf+k3u8V73ndNRNVWUdye/mzo6adLZkXM6vfcmVc=
+github.com/deckhouse/lib-dhctl v0.22.0 h1:TzrizsVjK5IjTUetZ/3lb+21pusV/ldNz8CszFDCrgk=
+github.com/deckhouse/lib-dhctl v0.22.0/go.mod h1:hICPf+k3u8V73ndNRNVWUdye/mzo6adLZkXM6vfcmVc=
 github.com/deckhouse/lib-gossh v0.3.0 h1:FUAlF8+fLnBCII9hXSNx+arZ4PH3H/6fzp5LBlnmlps=
 github.com/deckhouse/lib-gossh v0.3.0/go.mod h1:6bT8jf2fkBPEhYBU35+vMBr5YscliTiS+Vr8v06C+70=
-github.com/deckhouse/module-sdk v0.12.1 h1:kcfvgIKwXUtcDXdK5e7D69lvdyaHctp8ectYKi+BYKw=
-github.com/deckhouse/module-sdk v0.12.1/go.mod h1:v3pnOUIY8hCv7qQ5YaffiAYKj5oH8WBonG614KvRPXw=
+github.com/deckhouse/module-sdk v0.12.2 h1:UXJXjpg6qkPQn0gA294j/2HOJvWuOJKj4c9y8CdfOoY=
+github.com/deckhouse/module-sdk v0.12.2/go.mod h1:v3pnOUIY8hCv7qQ5YaffiAYKj5oH8WBonG614KvRPXw=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/disintegration/imaging v1.6.2 h1:w1LecBlG2Lnp8B3jk5zSuNqd7b4DXhcjwek1ei82L+c=

--- a/modules/000-common/hooks/ensure_crds_test.go
+++ b/modules/000-common/hooks/ensure_crds_test.go
@@ -36,6 +36,7 @@ spec:
   group: deckhouse.io
   names:
     kind: TestCrd
+    listKind: TestCrdList
     plural: testcrds
     singular: testcrd
   preserveUnknownFields: false
@@ -51,10 +52,8 @@ spec:
               a:
                 description: a
                 type: string
-                x-description: a
               b:
                 type: string
-                x-doc-default: b
             type: object
         required:
         - spec
@@ -131,6 +130,7 @@ spec:
   group: deckhouse.io
   names:
     kind: TestCrd
+    listKind: TestCrdList
     plural: testcrds
     singular: testcrd
   preserveUnknownFields: false
@@ -146,10 +146,8 @@ spec:
               a:
                 description: a
                 type: string
-                x-description: a
               b:
                 type: string
-                x-doc-default: b
             type: object
         required:
         - spec

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -53,8 +53,8 @@ require (
 	github.com/deckhouse/deckhouse/go_lib/dependency/vsphere v0.0.0-00010101000000-000000000000 // indirect
 	github.com/deckhouse/deckhouse/pkg/log v0.2.1 // indirect
 	github.com/deckhouse/deckhouse/pkg/metrics-storage v0.3.0 // indirect
-	github.com/deckhouse/lib-dhctl v0.21.0 // indirect
-	github.com/deckhouse/module-sdk v0.12.1 // indirect
+	github.com/deckhouse/lib-dhctl v0.22.0 // indirect
+	github.com/deckhouse/module-sdk v0.12.2 // indirect
 	github.com/denis-tingajkin/go-header v0.4.2 // indirect
 	github.com/docker/cli v29.4.0+incompatible // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -193,10 +193,10 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/deckhouse/deckhouse/pkg/metrics-storage v0.3.0 h1:xZvbKuexrSQGEw6CB4n3UC7XbOb9QNLbm8UhcGZ2R1I=
 github.com/deckhouse/deckhouse/pkg/metrics-storage v0.3.0/go.mod h1:Rz++SzCLkFW03WGgftnn91TimGU2shiKb5S/YuxcBuE=
-github.com/deckhouse/lib-dhctl v0.21.0 h1:6pO9qOj3mdQpX+zD07ZRlorKCtjvn5VEyigmT4k5SBw=
-github.com/deckhouse/lib-dhctl v0.21.0/go.mod h1:hICPf+k3u8V73ndNRNVWUdye/mzo6adLZkXM6vfcmVc=
-github.com/deckhouse/module-sdk v0.12.1 h1:kcfvgIKwXUtcDXdK5e7D69lvdyaHctp8ectYKi+BYKw=
-github.com/deckhouse/module-sdk v0.12.1/go.mod h1:v3pnOUIY8hCv7qQ5YaffiAYKj5oH8WBonG614KvRPXw=
+github.com/deckhouse/lib-dhctl v0.22.0 h1:TzrizsVjK5IjTUetZ/3lb+21pusV/ldNz8CszFDCrgk=
+github.com/deckhouse/lib-dhctl v0.22.0/go.mod h1:hICPf+k3u8V73ndNRNVWUdye/mzo6adLZkXM6vfcmVc=
+github.com/deckhouse/module-sdk v0.12.2 h1:UXJXjpg6qkPQn0gA294j/2HOJvWuOJKj4c9y8CdfOoY=
+github.com/deckhouse/module-sdk v0.12.2/go.mod h1:v3pnOUIY8hCv7qQ5YaffiAYKj5oH8WBonG614KvRPXw=
 github.com/denis-tingajkin/go-header v0.4.2 h1:jEeSF4sdv8/3cT/WY8AgDHUoItNSoEZ7qg9dX7pc218=
 github.com/denis-tingajkin/go-header v0.4.2/go.mod h1:eLRHAVXzE5atsKAnNRDB90WHCFFnBUn4RN0nRcs1LJA=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=


### PR DESCRIPTION
## Description

Bumps `github.com/deckhouse/module-sdk` to `v0.12.2`  and updates the `ensure_crds` golden test to match.

The CRD installer now applies a strict schema contract. Only keys declared as fields of `apiextensionsv1.JSONSchemaProps` are sent to the apiserver, plus `x-kubernetes-sensitive-data`. Everything else is dropped client-side:

* `x-doc-examples`, `x-doc-default`, `x-doc-deprecated`, `x-doc-required`, `x-doc-skip`, `x-examples`, `x-description`
* keys that look official but are not fields — `x-kubernetes-immutable`, `x-kubernetes-patch-strategy`, `x-kubernetes-patch-merge-key`

It also writes the `.spec` values the apiserver fills in itself — `spec.names.listKind`, `spec.names.singular`, and per-version `served`/`storage` — so a manifest that omits them no longer differs from the stored object.

Test change in `modules/000-common/hooks/ensure_crds_test.go`: the goldens lose `x-description` / `x-doc-default` and gain `listKind: TestCrdList`. The manifest `modules/000-common/crds/test-crd.yaml` keeps those two keys, so the test now asserts that they are stripped. This deliberately reverts the assertion added in #21393.

## Why do we need it, and what problem does it solve?

Two bugs, and #21393 traded one for the other.

**Before #21393**, the installer decoded each CRD into `apiextensionsv1.CustomResourceDefinition`. That type declares only seven `x-*` fields, so `x-kubernetes-sensitive-data` was dropped before it ever left the client — the original report, where `kubectl get crd modulesources.deckhouse.io -o yaml | grep sensitive` returned nothing even though the manifest had it.

**After #21393**, the installer applied the file verbatim as `unstructured`. `x-kubernetes-sensitive-data` reached the cluster, but so did every other key, and the apiserver rejects the rest:
                                                                                                                                                                       * 510–765 `Warning: unknown field "spec.versions[0].schema.openAPIV3Ses per Deckhouse pod
* the apiserver *prunes* those keys, so the desired spec could never equal the stored one — the idempotency check never passed and every reconcile issued a full       `Update` of every CRD
                                                                                                                                                                       Dropping the `x-doc-*` keys at install time costs nothing: they are dd-enricher` writes them into the YAML from Go markers, and`docs/documentation/_plugins/render-jsonschema.rb` reads them from files on disk via `@site.data` — never from the apiserver.                                         
`x-kubernetes-sensitive-data` is the one exception, and the reason the contract is an allowlist rather than a rule about prefixes. It is a real field on the Deckhouse apiserver (`010-x-kubernetes-sensitive-data.patch` plus `CRDSensitive upstream, so the stock Go types cannot carry it.

Verified against the CE+EE CRD tree — 68 files, 80 CRDs: the only `x-er are the seven upstream `x-kubernetes-*` fields and all fouroccurrences of `x-kubernetes-sensitive-data`, with no `x-doc-*`. A second install pass performs zero writes.

**Caveat:** on a stock apiserver — managed control plane, dev cluster, `CRDSensitiveData` disabled — `x-kubernetes-sensitive-data` is pruned server-side, so a CRD
carrying it will still be updated on every reconcile there. Accepted:n such a cluster anyway, and detecting it would mean probing theapiserver build on every install.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: chore
summary: Bump module-sdk.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
