### PR TITLE
[deckhouse] Remove shortName for Application resource in CRD and update related comments

### DIFF
--- a/deckhouse-controller/crds/application.yaml
+++ b/deckhouse-controller/crds/application.yaml
@@ -11,8 +11,6 @@ spec:
     kind: Application
     listKind: ApplicationList
     plural: applications
-    shortNames:
-    - app
     singular: application
   scope: Namespaced
   versions:

--- a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/application.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/application.go
@@ -54,7 +54,7 @@ var _ runtime.Object = (*Application)(nil)
 // +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:scope=Namespaced,shortName=app
+// +kubebuilder:resource:scope=Namespaced
 // +kubebuilder:printcolumn:name=Package,type=string,JSONPath=.spec.packageName
 // +kubebuilder:printcolumn:name=Version,type=string,JSONPath=.spec.packageVersion
 // +kubebuilder:printcolumn:name=Repository,type=string,JSONPath=.spec.packageRepositoryName,priority=1


### PR DESCRIPTION
## Description
The `Application` custom resource (`applications.deckhouse.io`) no longer
exposes the `app` short name. The short name is removed from the source of
truth (the kubebuilder marker) and from the generated CRD, so it will not be
regenerated back. The resource itself, its API and behavior are unchanged —
only the CLI alias is dropped.

### Before / After

**Before** — the `app` short name collides with Argo CD's
`applications.argoproj.io`, which also registers `app` (and `apps`). In a
cluster with both installed, `kubectl get app` is ambiguous and warns:

```console
$ kubectl get app
Warning: short name "app" could also match lower priority resource applications.deckhouse.io
```

**After** — no collision on `app`. The `Application` resource is used by its
full name:

```console
$ kubectl get applications
```

## Why do we need it, and what problem does it solve?

The `app` short name is not unique: Argo CD's `applications.argoproj.io`
registers the same alias (`["app","apps"]`).

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: chore
summary: Removed the `app` short name from the `Application` resource.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
