### PR TITLE
[node-manager] Support cloud-provider Bashible steps secrets

### DIFF
--- a/modules/040-node-manager/images/bashible-apiserver/src/pkg/template/cloud_provider_steps.go
+++ b/modules/040-node-manager/images/bashible-apiserver/src/pkg/template/cloud_provider_steps.go
@@ -1,0 +1,182 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+)
+
+const (
+	cloudProviderNameLabel            = "cloud-provider.deckhouse.io/name"
+	cloudProviderBashibleLabel        = "cloud-provider.deckhouse.io/bashible"
+	cloudProviderStepsLabelSelector   = cloudProviderBashibleLabel + "=steps," + cloudProviderNameLabel
+	cloudProviderStepsSecretNamespace = "kube-system"
+)
+
+type cloudProviderStepsSecret struct {
+	provider string
+	data     map[string][]byte
+}
+
+func (s *StepsStorage) subscribeOnCloudProviderSteps(
+	ctx context.Context,
+	factory informers.SharedInformerFactory,
+) {
+	if factory == nil {
+		return
+	}
+
+	informer := factory.Core().V1().Secrets().Informer()
+	_ = informer.SetWatchErrorHandler(cache.DefaultWatchErrorHandler)
+
+	_, _ = informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			secret, ok := obj.(*corev1.Secret)
+			if !ok {
+				return
+			}
+			s.upsertCloudProviderStepsSecret(secret)
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			oldSecret, oldOK := oldObj.(*corev1.Secret)
+			newSecret, newOK := newObj.(*corev1.Secret)
+			if !oldOK || !newOK {
+				return
+			}
+			if oldSecret.ResourceVersion == newSecret.ResourceVersion {
+				return
+			}
+			s.upsertCloudProviderStepsSecret(newSecret)
+		},
+		DeleteFunc: func(obj interface{}) {
+			secret, ok := deletedSecret(obj)
+			if !ok {
+				return
+			}
+			s.deleteCloudProviderStepsSecret(secret.Name)
+		},
+	})
+
+	go informer.Run(ctx.Done())
+
+	if !cache.WaitForCacheSync(ctx.Done(), informer.HasSynced) {
+		klog.Errorf("unable to sync cloud-provider steps Secrets informer: %v", ctx.Err())
+	}
+}
+
+func (s *StepsStorage) upsertCloudProviderStepsSecret(secret *corev1.Secret) {
+	provider := secret.Labels[cloudProviderNameLabel]
+	if provider == "" {
+		klog.Warningf("Ignoring cloud-provider steps Secret %q without %q label", secret.Name, cloudProviderNameLabel)
+		return
+	}
+
+	scripts := make(map[string][]byte)
+	for name, content := range secret.Data {
+		if !strings.HasSuffix(name, ".sh.tpl") {
+			continue
+		}
+		scripts[name] = append([]byte(nil), content...)
+	}
+
+	s.m.Lock()
+	s.cloudProviderStepSecrets[secret.Name] = cloudProviderStepsSecret{
+		provider: provider,
+		data:     scripts,
+	}
+	s.m.Unlock()
+
+	s.notifyCloudProviderStepsChanged()
+}
+
+func (s *StepsStorage) deleteCloudProviderStepsSecret(name string) {
+	s.m.Lock()
+	_, exists := s.cloudProviderStepSecrets[name]
+	if exists {
+		delete(s.cloudProviderStepSecrets, name)
+	}
+	s.m.Unlock()
+
+	if exists {
+		s.notifyCloudProviderStepsChanged()
+	}
+}
+
+func (s *StepsStorage) notifyCloudProviderStepsChanged() {
+	select {
+	case s.cloudProviderStepsChanged <- struct{}{}:
+	default:
+	}
+}
+
+func (s *StepsStorage) OnCloudProviderStepsChanged() <-chan struct{} {
+	return s.cloudProviderStepsChanged
+}
+
+func deletedSecret(obj interface{}) (*corev1.Secret, bool) {
+	if secret, ok := obj.(*corev1.Secret); ok {
+		return secret, true
+	}
+
+	tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+	if !ok {
+		return nil, false
+	}
+
+	secret, ok := tombstone.Obj.(*corev1.Secret)
+	return secret, ok
+}
+
+func (s *StepsStorage) cloudProviderStepsFor(provider string) (map[string][]byte, bool, error) {
+	s.m.RLock()
+	defer s.m.RUnlock()
+
+	scripts := make(map[string][]byte)
+	owners := make(map[string]string)
+	found := false
+
+	for secretName, secret := range s.cloudProviderStepSecrets {
+		if secret.provider != provider {
+			continue
+		}
+
+		found = true
+
+		for scriptName, content := range secret.data {
+			if owner, exists := owners[scriptName]; exists {
+				return nil, true, fmt.Errorf(
+					"cloud-provider steps Secrets %q and %q contain the same script %q",
+					owner,
+					secretName,
+					scriptName,
+				)
+			}
+
+			owners[scriptName] = secretName
+			scripts[scriptName] = append([]byte(nil), content...)
+		}
+	}
+
+	return scripts, found, nil
+}

--- a/modules/040-node-manager/images/bashible-apiserver/src/pkg/template/cloud_provider_steps_test.go
+++ b/modules/040-node-manager/images/bashible-apiserver/src/pkg/template/cloud_provider_steps_test.go
@@ -1,0 +1,402 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestCloudProviderStepsFor(t *testing.T) {
+	tests := []struct {
+		name            string
+		secrets         map[string]cloudProviderStepsSecret
+		provider        string
+		expectedScripts map[string][]byte
+		expectedFound   bool
+		expectedError   bool
+	}{
+		{
+			name:     "provider Secret is absent",
+			secrets:  map[string]cloudProviderStepsSecret{},
+			provider: "aws",
+
+			expectedScripts: map[string][]byte{},
+			expectedFound:   false,
+		},
+		{
+			name: "empty provider Secret exists",
+			secrets: map[string]cloudProviderStepsSecret{
+				"aws-steps": {
+					provider: "aws",
+					data:     map[string][]byte{},
+				},
+			},
+			provider: "aws",
+
+			expectedScripts: map[string][]byte{},
+			expectedFound:   true,
+		},
+		{
+			name: "returns scripts only for requested provider",
+			secrets: map[string]cloudProviderStepsSecret{
+				"aws-steps": {
+					provider: "aws",
+					data: map[string][]byte{
+						"001_aws.sh.tpl": []byte("aws"),
+					},
+				},
+				"azure-steps": {
+					provider: "azure",
+					data: map[string][]byte{
+						"001_azure.sh.tpl": []byte("azure"),
+					},
+				},
+			},
+			provider: "aws",
+
+			expectedScripts: map[string][]byte{
+				"001_aws.sh.tpl": []byte("aws"),
+			},
+			expectedFound: true,
+		},
+		{
+			name: "combines multiple Secrets of one provider",
+			secrets: map[string]cloudProviderStepsSecret{
+				"aws-first": {
+					provider: "aws",
+					data: map[string][]byte{
+						"001_first.sh.tpl": []byte("first"),
+					},
+				},
+				"aws-second": {
+					provider: "aws",
+					data: map[string][]byte{
+						"002_second.sh.tpl": []byte("second"),
+					},
+				},
+			},
+			provider: "aws",
+
+			expectedScripts: map[string][]byte{
+				"001_first.sh.tpl":  []byte("first"),
+				"002_second.sh.tpl": []byte("second"),
+			},
+			expectedFound: true,
+		},
+		{
+			name: "rejects duplicate script names",
+			secrets: map[string]cloudProviderStepsSecret{
+				"aws-first": {
+					provider: "aws",
+					data: map[string][]byte{
+						"001_same.sh.tpl": []byte("first"),
+					},
+				},
+				"aws-second": {
+					provider: "aws",
+					data: map[string][]byte{
+						"001_same.sh.tpl": []byte("second"),
+					},
+				},
+			},
+			provider:      "aws",
+			expectedFound: true,
+			expectedError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			storage := &StepsStorage{
+				cloudProviderStepSecrets: tt.secrets,
+			}
+
+			scripts, found, err := storage.cloudProviderStepsFor(tt.provider)
+
+			if tt.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expectedScripts, scripts)
+			}
+
+			require.Equal(t, tt.expectedFound, found)
+		})
+	}
+}
+
+func TestUpsertCloudProviderStepsSecret(t *testing.T) {
+	storage := &StepsStorage{
+		cloudProviderStepSecrets:  make(map[string]cloudProviderStepsSecret),
+		cloudProviderStepsChanged: make(chan struct{}, 1),
+	}
+
+	originalContent := []byte("original")
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "aws-steps",
+			Labels: map[string]string{
+				cloudProviderBashibleLabel: "steps",
+				cloudProviderNameLabel:     "aws",
+			},
+		},
+		Data: map[string][]byte{
+			"001_step.sh.tpl": originalContent,
+			"ignored.txt":     []byte("must not be included"),
+		},
+	}
+
+	storage.upsertCloudProviderStepsSecret(secret)
+
+	stored, exists := storage.cloudProviderStepSecrets["aws-steps"]
+	require.True(t, exists)
+	require.Equal(t, "aws", stored.provider)
+	require.Equal(t, []byte("original"), stored.data["001_step.sh.tpl"])
+	require.NotContains(t, stored.data, "ignored.txt")
+
+	select {
+	case <-storage.cloudProviderStepsChanged:
+	default:
+		t.Fatal("expected cloud-provider steps change notification")
+	}
+
+	// The storage must own a copy and not reference informer-managed data.
+	originalContent[0] = 'X'
+	require.Equal(t, []byte("original"), stored.data["001_step.sh.tpl"])
+
+	// Upsert replaces the complete contents of the Secret rather than merging it
+	// with the previous version.
+	secret.Data = map[string][]byte{
+		"002_new_step.sh.tpl": []byte("new"),
+	}
+	storage.upsertCloudProviderStepsSecret(secret)
+
+	stored = storage.cloudProviderStepSecrets["aws-steps"]
+	require.NotContains(t, stored.data, "001_step.sh.tpl")
+	require.Equal(t, []byte("new"), stored.data["002_new_step.sh.tpl"])
+}
+
+func TestUpsertCloudProviderStepsSecretWithoutProviderLabel(t *testing.T) {
+	storage := &StepsStorage{
+		cloudProviderStepSecrets:  make(map[string]cloudProviderStepsSecret),
+		cloudProviderStepsChanged: make(chan struct{}, 1),
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "invalid-steps",
+			Labels: map[string]string{
+				cloudProviderBashibleLabel: "steps",
+			},
+		},
+		Data: map[string][]byte{
+			"001_step.sh.tpl": []byte("step"),
+		},
+	}
+
+	storage.upsertCloudProviderStepsSecret(secret)
+
+	require.Empty(t, storage.cloudProviderStepSecrets)
+
+	select {
+	case <-storage.cloudProviderStepsChanged:
+		t.Fatal("unexpected change notification")
+	default:
+	}
+}
+
+func TestDeleteCloudProviderStepsSecret(t *testing.T) {
+	storage := &StepsStorage{
+		cloudProviderStepSecrets: map[string]cloudProviderStepsSecret{
+			"aws-steps": {
+				provider: "aws",
+				data: map[string][]byte{
+					"001_step.sh.tpl": []byte("step"),
+				},
+			},
+		},
+		cloudProviderStepsChanged: make(chan struct{}, 1),
+	}
+
+	storage.deleteCloudProviderStepsSecret("aws-steps")
+
+	require.NotContains(t, storage.cloudProviderStepSecrets, "aws-steps")
+
+	select {
+	case <-storage.cloudProviderStepsChanged:
+	default:
+		t.Fatal("expected cloud-provider steps change notification")
+	}
+
+	// Repeated deletion changes nothing and must not trigger an update.
+	storage.deleteCloudProviderStepsSecret("aws-steps")
+
+	select {
+	case <-storage.cloudProviderStepsChanged:
+		t.Fatal("unexpected change notification")
+	default:
+	}
+}
+
+func TestDeletedSecret(t *testing.T) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "aws-steps",
+		},
+	}
+
+	t.Run("direct Secret", func(t *testing.T) {
+		result, ok := deletedSecret(secret)
+
+		require.True(t, ok)
+		require.Same(t, secret, result)
+	})
+
+	t.Run("tombstone", func(t *testing.T) {
+		result, ok := deletedSecret(cache.DeletedFinalStateUnknown{
+			Key: "kube-system/aws-steps",
+			Obj: secret,
+		})
+
+		require.True(t, ok)
+		require.Same(t, secret, result)
+	})
+
+	t.Run("unexpected object", func(t *testing.T) {
+		result, ok := deletedSecret("not a Secret")
+
+		require.False(t, ok)
+		require.Nil(t, result)
+	})
+}
+
+func TestSubscribeOnCloudProviderSteps(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	matchingSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "aws-steps",
+			Namespace:       cloudProviderStepsSecretNamespace,
+			ResourceVersion: "1",
+			Labels: map[string]string{
+				cloudProviderBashibleLabel: "steps",
+				cloudProviderNameLabel:     "aws",
+			},
+		},
+		Data: map[string][]byte{
+			"001_aws.sh.tpl": []byte("initial"),
+		},
+	}
+
+	ignoredSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "azure-bootstrap",
+			Namespace: cloudProviderStepsSecretNamespace,
+			Labels: map[string]string{
+				cloudProviderBashibleLabel: "bootstrap",
+				cloudProviderNameLabel:     "azure",
+			},
+		},
+		Data: map[string][]byte{
+			"001_azure.sh.tpl": []byte("must be ignored"),
+		},
+	}
+
+	kubeClient := fake.NewSimpleClientset(
+		matchingSecret,
+		ignoredSecret,
+	)
+
+	factory := informers.NewSharedInformerFactoryWithOptions(
+		kubeClient,
+		0,
+		informers.WithNamespace(cloudProviderStepsSecretNamespace),
+		informers.WithTweakListOptions(func(options *metav1.ListOptions) {
+			options.LabelSelector = cloudProviderStepsLabelSelector
+		}),
+	)
+
+	storage := &StepsStorage{
+		cloudProviderStepSecrets:  make(map[string]cloudProviderStepsSecret),
+		cloudProviderStepsChanged: make(chan struct{}, 1),
+	}
+
+	storage.subscribeOnCloudProviderSteps(ctx, factory)
+
+	t.Run("loads matching Secret during initial list", func(t *testing.T) {
+		scripts, found, err := storage.cloudProviderStepsFor("aws")
+
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Equal(t, []byte("initial"), scripts["001_aws.sh.tpl"])
+	})
+
+	t.Run("ignores Secret outside selector", func(t *testing.T) {
+		scripts, found, err := storage.cloudProviderStepsFor("azure")
+
+		require.NoError(t, err)
+		require.False(t, found)
+		require.Empty(t, scripts)
+	})
+
+	t.Run("receives Secret update through watch", func(t *testing.T) {
+		updatedSecret := matchingSecret.DeepCopy()
+		updatedSecret.ResourceVersion = "2"
+		updatedSecret.Data = map[string][]byte{
+			"002_aws.sh.tpl": []byte("updated"),
+		}
+
+		_, err := kubeClient.CoreV1().
+			Secrets(cloudProviderStepsSecretNamespace).
+			Update(ctx, updatedSecret, metav1.UpdateOptions{})
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			scripts, found, err := storage.cloudProviderStepsFor("aws")
+			if err != nil || !found {
+				return false
+			}
+
+			_, oldExists := scripts["001_aws.sh.tpl"]
+			return !oldExists &&
+				string(scripts["002_aws.sh.tpl"]) == "updated"
+		}, time.Second, 10*time.Millisecond)
+	})
+
+	t.Run("receives Secret deletion through watch", func(t *testing.T) {
+		err := kubeClient.CoreV1().
+			Secrets(cloudProviderStepsSecretNamespace).
+			Delete(ctx, matchingSecret.Name, metav1.DeleteOptions{})
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			_, found, err := storage.cloudProviderStepsFor("aws")
+			return err == nil && !found
+		}, time.Second, 10*time.Millisecond)
+	})
+}

--- a/modules/040-node-manager/images/bashible-apiserver/src/pkg/template/context.go
+++ b/modules/040-node-manager/images/bashible-apiserver/src/pkg/template/context.go
@@ -142,6 +142,7 @@ func NewContext(ctx context.Context, stepsStorage *StepsStorage, kubeClient clie
 	contextSecretFactory := newBashibleInformerFactory(kubeClient, resyncTimeout, "d8-cloud-instance-manager", "app=bashible-apiserver")
 	nodeUserCRDFactory := newNodeUserInformerFactory(kubeClient, resyncTimeout)
 	moduleSourcesFactory := newModuleSourcesInformerFactory(kubeClient, resyncTimeout, "app!=deckhouse,heritage!=deckhouse,module!=deckhouse")
+	cloudProviderStepsFactory := newBashibleInformerFactory(kubeClient, resyncTimeout, cloudProviderStepsSecretNamespace, cloudProviderStepsLabelSelector)
 
 	contextSecretUpdates := c.subscribe(ctx, contextSecretFactory, contextSecretName)
 
@@ -150,6 +151,7 @@ func NewContext(ctx context.Context, stepsStorage *StepsStorage, kubeClient clie
 
 	c.subscribeOnNodeUserCRD(ctx, nodeUserCRDFactory)
 	c.subscribeOnModuleSource(ctx, moduleSourcesFactory)
+	c.stepsStorage.subscribeOnCloudProviderSteps(ctx, cloudProviderStepsFactory)
 
 	go c.onSecretsUpdate(ctx, contextSecretUpdates, registryDataCh)
 
@@ -341,6 +343,9 @@ func (c *BashibleContext) onSecretsUpdate(ctx context.Context, contextSecretC ch
 
 		case <-c.OnModuleSourceChanged():
 			c.update("ModuleSourceConfiguration")
+
+		case <-c.stepsStorage.OnCloudProviderStepsChanged():
+			c.update("cloud provider Bashible steps")
 
 		case <-ctx.Done():
 			return

--- a/modules/040-node-manager/images/bashible-apiserver/src/pkg/template/steps_storage.go
+++ b/modules/040-node-manager/images/bashible-apiserver/src/pkg/template/steps_storage.go
@@ -48,6 +48,9 @@ type StepsStorage struct {
 
 	configurationsChanged chan struct{}
 	emitter               changesEmitter
+
+	cloudProviderStepSecrets  map[string]cloudProviderStepsSecret
+	cloudProviderStepsChanged chan struct{}
 }
 
 type nodeConfigurationQueueAction struct {
@@ -70,6 +73,8 @@ func NewStepsStorage(ctx context.Context, rootDir string, ngConfigFactory dynami
 		nodeGroupConfigurations:      make(map[string][]*nodeConfigurationScript),
 		nodeGroupConfigurationsQueue: make(chan nodeConfigurationQueueAction, 100),
 		configurationsChanged:        make(chan struct{}, 1),
+		cloudProviderStepSecrets:     make(map[string]cloudProviderStepsSecret),
+		cloudProviderStepsChanged:    make(chan struct{}, 1),
 	}
 
 	ss.subscribeOnCRD(ctx, ngConfigFactory)
@@ -154,17 +159,53 @@ func (s *StepsStorage) subscribeOnCRD(ctx context.Context, ngConfigFactory dynam
 }
 
 func (s *StepsStorage) renderSystemScripts(target, provider string, templateContext map[string]interface{}) (map[string]string, error) {
-	key := fmt.Sprintf(keyPattern, target, provider)
+	var (
+		providerTemplates      map[string][]byte
+		hasProviderStepsSecret bool
+		err                    error
+	)
+
+	if target == "all" {
+		providerTemplates, hasProviderStepsSecret, err = s.cloudProviderStepsFor(provider)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	filesystemProvider := provider
+	if hasProviderStepsSecret {
+		// Read only common Deckhouse steps from the image.
+		// Provider-specific steps will be taken from the Secret.
+		filesystemProvider = ""
+	}
+
+	key := fmt.Sprintf(keyPattern, target, filesystemProvider)
 
 	s.m.RLock()
 	templates, ok := s.systemScripts[key]
 	s.m.RUnlock()
+
 	if !ok {
-		var err error
-		templates, err = s.loadTemplates(target, provider)
+		templates, err = s.loadTemplates(target, filesystemProvider)
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	if hasProviderStepsSecret {
+		combinedTemplates := make(
+			map[string][]byte,
+			len(templates)+len(providerTemplates),
+		)
+
+		for name, content := range templates {
+			combinedTemplates[name] = content
+		}
+		for name, content := range providerTemplates {
+			combinedTemplates[name] = content
+		}
+
+		templates = combinedTemplates
 	}
 
 	steps := make(map[string]string)

--- a/modules/040-node-manager/images/bashible-apiserver/src/pkg/template/steps_storage_test.go
+++ b/modules/040-node-manager/images/bashible-apiserver/src/pkg/template/steps_storage_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderSystemScriptsWithCloudProviderSecret(t *testing.T) {
+	tests := []struct {
+		name            string
+		secrets         map[string]cloudProviderStepsSecret
+		expectedScripts map[string]string
+	}{
+		{
+			name:    "uses legacy provider steps when Secret is absent",
+			secrets: map[string]cloudProviderStepsSecret{},
+			expectedScripts: map[string]string{
+				"001_common.sh": "common",
+				"002_legacy.sh": "legacy",
+			},
+		},
+		{
+			name: "uses Secret instead of legacy provider steps",
+			secrets: map[string]cloudProviderStepsSecret{
+				"aws-steps": {
+					provider: "aws",
+					data: map[string][]byte{
+						"003_external.sh.tpl": []byte("external"),
+					},
+				},
+			},
+			expectedScripts: map[string]string{
+				"001_common.sh":   "common",
+				"003_external.sh": "external",
+			},
+		},
+		{
+			name: "empty Secret disables legacy provider steps",
+			secrets: map[string]cloudProviderStepsSecret{
+				"aws-steps": {
+					provider: "aws",
+					data:     map[string][]byte{},
+				},
+			},
+			expectedScripts: map[string]string{
+				"001_common.sh": "common",
+			},
+		},
+		{
+			name: "Secret step overrides common step",
+			secrets: map[string]cloudProviderStepsSecret{
+				"aws-steps": {
+					provider: "aws",
+					data: map[string][]byte{
+						"001_common.sh.tpl": []byte("external replacement"),
+					},
+				},
+			},
+			expectedScripts: map[string]string{
+				"001_common.sh": "external replacement",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			storage := &StepsStorage{
+				// "all:" represents common Deckhouse steps.
+				// "all:aws" represents the old combined common + provider cache.
+				systemScripts: map[string]map[string][]byte{
+					"all:": {
+						"001_common.sh.tpl": []byte("common"),
+					},
+					"all:aws": {
+						"001_common.sh.tpl": []byte("common"),
+						"002_legacy.sh.tpl": []byte("legacy"),
+					},
+				},
+				cloudProviderStepSecrets: tt.secrets,
+			}
+
+			steps, err := storage.renderSystemScripts(
+				"all",
+				"aws",
+				map[string]interface{}{},
+			)
+
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedScripts, steps)
+
+			// Combining Secret steps must not modify the cached common templates.
+			require.Equal(
+				t,
+				"common",
+				string(storage.systemScripts["all:"]["001_common.sh.tpl"]),
+			)
+		})
+	}
+}

--- a/modules/040-node-manager/templates/bashible-apiserver/rbac-for-us.yaml
+++ b/modules/040-node-manager/templates/bashible-apiserver/rbac-for-us.yaml
@@ -172,3 +172,30 @@ subjects:
   - kind: ServiceAccount
     name: bashible-apiserver
     namespace: d8-cloud-instance-manager
+---
+# To read cloud-provider Bashible steps secrets in kube-system
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: d8:node-manager:bashible-apiserver:cloud-provider-steps
+  namespace: kube-system
+  {{- include "helm_lib_module_labels" (list . (dict "app" "bashible-apiserver")) | nindent 2 }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: d8:node-manager:bashible-apiserver:cloud-provider-steps
+  namespace: kube-system
+  {{- include "helm_lib_module_labels" (list . (dict "app" "bashible-apiserver")) | nindent 2 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: d8:node-manager:bashible-apiserver:cloud-provider-steps
+subjects:
+  - kind: ServiceAccount
+    name: bashible-apiserver
+    namespace: d8-cloud-instance-manager


### PR DESCRIPTION
## Description

Adds support for cloud-provider-specific Bashible lifecycle steps stored in Kubernetes Secrets.

bashible-apiserver now watches Secrets in kube-system with the following labels:

```
cloud-provider.deckhouse.io/bashible: steps
cloud-provider.deckhouse.io/name: <PROVIDER_ID>
```

Scripts stored under *.sh.tpl keys are included in the Bashible node group bundle for the corresponding provider.

When a matching Secret exists, it becomes the source of provider-specific steps, while common Deckhouse steps continue to be loaded from the bashible-apiserver image. If no matching Secret exists, the existing image-based provider steps are used for backward compatibility. An empty Secret is supported and represents a provider without additional lifecycle steps.

The change also adds the RBAC permissions required for bashible-apiserver to watch these Secrets.

Bootstrap scripts are not covered by this change.

Tests added for:

- Secret discovery, updates, and deletion through the Kubernetes informer;
- filtering Secret data by the .sh.tpl suffix;
- provider selection and multiple Secrets;
- empty Secrets and legacy fallback;
- script conflicts and overrides;
- concurrent access using the Go race detector.

The node-manager template test suite passes: 23/23 specs.

## Why do we need it, and what problem does it solve?

External cloud-provider modules keep their provider-specific Bashible scripts in Kubernetes Secrets instead of embedding them into the bashible-apiserver image.

Previously, bashible-apiserver did not read Secrets labeled with cloud-provider.deckhouse.io/bashible=steps. Therefore, lifecycle steps supplied by an external cloud-provider module could not be included in node Bashible bundles.

This change enables node-manager to consume those scripts dynamically, allowing an external cloud-provider module to deliver and update its node lifecycle steps independently of the Deckhouse core release cycle.

The implementation follows the external cloud-provider module ADR.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: node-manager
type: feature 
summary: Add support for cloud-provider-specific Bashible lifecycle steps stored in Kubernetes Secrets.
impact_level: default 
```