### PR TITLE
[node-manager] Update olcedar to v0.1.2

### DIFF
--- a/modules/040-node-manager/images/olcedar/werf.inc.yaml
+++ b/modules/040-node-manager/images/olcedar/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $version := "04d4baf43d7652dbbf2eb3ccbdc7544dd6379ca4a2a54dff4b090d57-1786519230738"  }}
+{{- $version := "v0.1.2"  }}
 {{- if ne $.Env "CSE" }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}


### PR DESCRIPTION
Bumps the Olcedar OS image to `v0.1.2`, the first build that carries both halves of the rootfs A/B update:

- the agent from `nodelet` main — the `osimage` controller that stages a slot, verifies its signature, switches and judges the trial (merged today, after `v0.1.1` was built);
- the initramfs from `v0.1.2` — the boot-slot chooser and the rollback.

`v0.1.1` carries the new initramfs and an agent without the controller, so a node built from it can pick a slot at boot but nothing can stage or confirm one. Supersedes #22078.

The image is the OS artifact the node pulls: it holds `rootfs.erofs`, `rootfs.verity`, `rootfs.roothash` and `rootfs.roothash.p7s` — exactly the suffixes the agent fetches for a slot.

**Not enough on its own.** Nothing yet tells a node which image to run: the NodeConfig contract still carries `osImage` as a string, while the merged agent and initramfs require an object with a digest. That change rides in #22101.

## Changelog entries

```changes
section: node-manager
type: fix
summary: The Olcedar OS image is updated to v0.1.2, which carries the rootfs A/B update on both the agent and the initramfs side.
impact_level: low
```