### PR TITLE
[docs] Update architecture docs code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -128,7 +128,7 @@ csi/                                     @AleksZimin @duckhawk @szhem
 deckhouse-controller/                    @ldmonster
 dhctl/                                   @borg-z @090809
 docs/                                    @z9r5
-docs/documentation/pages/architecture/   @voitenkov @z9r5
+docs/documentation/pages/architecture/   @xstayer @z9r5
 helm_lib/                                @ldmonster
 crds/                                    @z9r5
 openapi/                                 @z9r5

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -128,7 +128,7 @@ csi/                                     @AleksZimin @duckhawk @szhem
 deckhouse-controller/                    @ldmonster
 dhctl/                                   @borg-z @090809
 docs/                                    @z9r5
-docs/documentation/pages/architecture/   @xstayer @z9r5
+docs/documentation/pages/architecture/   @voitenkov @xstayer @z9r5
 helm_lib/                                @ldmonster
 crds/                                    @z9r5
 openapi/                                 @z9r5


### PR DESCRIPTION
## Description

Reassign review ownership for the architecture documentation section to a new maintainer

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: ci
type: chore
summary: Update codeowners.
impact_level: low
```
