### PR TITLE
[registry] bump docker-auth to v1.14.0-deckhouse.10 to fix 23 CVEs

### DIFF
--- a/modules/038-registry/images/docker-auth/werf.inc.yaml
+++ b/modules/038-registry/images/docker-auth/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $version := "v1.14.0-deckhouse.7"}}
+{{- $version := "v1.14.0-deckhouse.10"}}
 ---
 image: "{{ $.ModuleName }}/{{ $.ImageName }}-src-artifact"
 fromImage: common/src-artifact


### PR DESCRIPTION
## Description

Bumps the pinned `docker-auth` source tag from `v1.14.0-deckhouse.7` to
`v1.14.0-deckhouse.10`.

The new tag contains one commit — a dependency bump in
[deckhouse/3p-docker_auth#8](https://github.com/deckhouse/3p-docker_auth/pull/8):

| dependency | from | to |
| --- | --- | --- |
| `golang.org/x/net` | v0.52.0 | v0.56.0 |
| `golang.org/x/crypto` | v0.49.0 | v0.53.0 |
| `golang.org/x/sys` | v0.42.0 | v0.46.0 |
| `golang.org/x/text` | v0.35.0 | v0.39.0 |
| `google.golang.org/grpc` | v1.79.3 | v1.82.1 |

No source changes. The tag is branched off the `deckhouse` branch head and
deliberately does not include the audit-subject commit that `-deckhouse.8`/`.9`
carry on an unmerged branch.

> Depends on `v1.14.0-deckhouse.10` being present in the mirror the build clones
> from (`SOURCE_REPO`). Merge after the 3p repo sync.

## Why do we need it, and what problem does it solve?

Clears 23 CVEs reported against the `auth_server` binary of this image:

- `golang.org/x/crypto/ssh` — CVE-2026-39827 … CVE-2026-39835, CVE-2026-42508,
  CVE-2026-46595, CVE-2026-46597, CVE-2026-46598
- `golang.org/x/net` — CVE-2026-25680, CVE-2026-25681, CVE-2026-27136,
  CVE-2026-33814, CVE-2026-39821, CVE-2026-42502, CVE-2026-42506, CVE-2026-46600
- `golang.org/x/text` — CVE-2026-56852

### Verification

`trivy fs` on the shipped `auth_server` module, `-deckhouse.7` vs
`-deckhouse.10`: all 23 targeted CVEs gone, no new CVE introduced. Both the
`auth_server` module and the `.build/genversion` build helper build for
`linux/amd64`.

The only entry left in the post-fix scan of the shipped module is `GO-2026-5932`,
an informational `UNKNOWN` advisory that `golang.org/x/crypto/openpgp` is
unmaintained. It has no fixed version and predates this change.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: registry
type: fix
summary: bump docker-auth to v1.14.0-deckhouse.10 to clear 23 CVEs
impact_level: low
```
