### PR TITLE
[deckhouse] improve package settings validation

### DIFF
--- a/deckhouse-controller/internal/packages/apps/app.go
+++ b/deckhouse-controller/internal/packages/apps/app.go
@@ -340,7 +340,7 @@ func (a *Application) GetSettingsChecksum() string {
 
 // ValidateSettings validates settings against openAPI and call setting check if exists
 func (a *Application) ValidateSettings(ctx context.Context, _ int, settings addonutils.Values) (settingscheck.Result, error) {
-	if err := a.values.ValidateSettings(settings); err != nil {
+	if err := a.values.ValidateSettings(0, settings); err != nil {
 		return settingscheck.Result{}, err
 	}
 
@@ -380,7 +380,7 @@ func (a *Application) ApplySettings(_ int, settings addonutils.Values) error {
 		return err
 	}
 
-	return a.values.ApplySettings(settings)
+	return a.values.ApplySettings(0, settings)
 }
 
 // resolveGrantDefaults resolves the per-project default for every

--- a/deckhouse-controller/internal/packages/modules/global/module.go
+++ b/deckhouse-controller/internal/packages/modules/global/module.go
@@ -234,12 +234,12 @@ func (m *Module) ValidateSettings(_ context.Context, settingsVersion int, settin
 	// Convert to latest schema version before validation
 	if m.converter != nil && settingsVersion > 0 {
 		var err error
-		_, settings, err = m.converter.ConvertToLatest(settingsVersion, settings)
+		settingsVersion, settings, err = m.converter.ConvertToLatest(settingsVersion, settings)
 		if err != nil {
 			return settingscheck.Result{}, fmt.Errorf("convert settings: %w", err)
 		}
 	}
-	if err := m.values.ValidateSettings(settings); err != nil {
+	if err := m.values.ValidateSettings(settingsVersion, settings); err != nil {
 		return settingscheck.Result{}, err
 	}
 
@@ -262,12 +262,12 @@ func (m *Module) ApplySettings(settingsVersion int, settings addonutils.Values) 
 	// Convert to latest schema version before applying
 	if m.converter != nil && settingsVersion > 0 {
 		var err error
-		_, settings, err = m.converter.ConvertToLatest(settingsVersion, settings)
+		settingsVersion, settings, err = m.converter.ConvertToLatest(settingsVersion, settings)
 		if err != nil {
 			return fmt.Errorf("convert settings: %w", err)
 		}
 	}
-	return m.values.ApplySettings(settings)
+	return m.values.ApplySettings(settingsVersion, settings)
 }
 
 // GetSettings returns the effective settings: user config merged with

--- a/deckhouse-controller/internal/packages/modules/module.go
+++ b/deckhouse-controller/internal/packages/modules/module.go
@@ -313,12 +313,12 @@ func (m *Module) ValidateSettings(ctx context.Context, settingsVersion int, sett
 	// Convert to latest schema version before validation
 	if m.converter != nil && settingsVersion > 0 {
 		var err error
-		_, settings, err = m.converter.ConvertToLatest(settingsVersion, settings)
+		settingsVersion, settings, err = m.converter.ConvertToLatest(settingsVersion, settings)
 		if err != nil {
 			return settingscheck.Result{}, fmt.Errorf("convert settings: %w", err)
 		}
 	}
-	if err := m.values.ValidateSettings(settings); err != nil {
+	if err := m.values.ValidateSettings(settingsVersion, settings); err != nil {
 		return settingscheck.Result{}, err
 	}
 
@@ -360,12 +360,12 @@ func (m *Module) ApplySettings(settingsVersion int, settings addonutils.Values) 
 	// Convert to latest schema version before applying
 	if m.converter != nil && settingsVersion > 0 {
 		var err error
-		_, settings, err = m.converter.ConvertToLatest(settingsVersion, settings)
+		settingsVersion, settings, err = m.converter.ConvertToLatest(settingsVersion, settings)
 		if err != nil {
 			return fmt.Errorf("convert settings: %w", err)
 		}
 	}
-	return m.values.ApplySettings(settings)
+	return m.values.ApplySettings(settingsVersion, settings)
 }
 
 // GetSettings returns the effective settings: user config merged with

--- a/deckhouse-controller/internal/packages/values/storage.go
+++ b/deckhouse-controller/internal/packages/values/storage.go
@@ -52,7 +52,8 @@ type Storage struct {
 
 	// settings are user-defined values from package settings
 	// These are stored separately before merging with static and openapi values
-	settings addonutils.Values
+	settings        addonutils.Values
+	settingsVersion int // schema version used to produce settings
 
 	// grantDefaults are runtime-resolved defaults for fields tagged with
 	// x-deckhouse-grantable-resource. They are injected by the grantDefaultsTransformer
@@ -171,8 +172,9 @@ func (s *Storage) ApplySettingsDefaults(settings addonutils.Values) addonutils.V
 }
 
 // ValidateSettings validates values against the config OpenAPI schema.
-// Does not modify the stored values - use ApplySettings to persist.
-func (s *Storage) ValidateSettings(settings addonutils.Values) error {
+// Stored settings are exposed to CEL as oldSelf only when their schema version matches.
+// This method does not modify stored values; use ApplySettings to persist them.
+func (s *Storage) ValidateSettings(settingsVersion int, settings addonutils.Values) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -180,16 +182,16 @@ func (s *Storage) ValidateSettings(settings addonutils.Values) error {
 		settings = addonutils.Values{}
 	}
 
-	if err := s.validateSettings(settings); err != nil {
+	if err := s.validateSettings(settingsVersion, settings); err != nil {
 		return fmt.Errorf("validate config values: %w", err)
 	}
 
 	return nil
 }
 
-// ApplySettings validates and saves user-defined config values.
+// ApplySettings validates and saves versioned user-defined config values.
 // After saving, recalculates the result values with all layers merged.
-func (s *Storage) ApplySettings(settings addonutils.Values) error {
+func (s *Storage) ApplySettings(settingsVersion int, settings addonutils.Values) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -197,11 +199,12 @@ func (s *Storage) ApplySettings(settings addonutils.Values) error {
 		settings = addonutils.Values{}
 	}
 
-	if err := s.validateSettings(settings); err != nil {
+	if err := s.validateSettings(settingsVersion, settings); err != nil {
 		return fmt.Errorf("validate config values: %w", err)
 	}
 
 	s.settings = settings
+	s.settingsVersion = settingsVersion
 
 	return s.calculateResultValues()
 }
@@ -328,7 +331,8 @@ func (s *Storage) validateValues(values addonutils.Values) error {
 // Previously stored user settings are passed as the old state so that
 // x-deckhouse-validations transition rules (rules referencing oldSelf) can
 // implement immutability and other update-time invariants on ModuleConfig.
-func (s *Storage) validateSettings(values addonutils.Values) error {
+// Settings from a different schema version are not comparable and are omitted.
+func (s *Storage) validateSettings(settingsVersion int, values addonutils.Values) error {
 	validatableValues := addonutils.Values{s.name: values}
 
 	if s.schemaStorage.GetSchema(schema.TypeSettings) == nil && len(values) > 0 {
@@ -336,7 +340,7 @@ func (s *Storage) validateSettings(values addonutils.Values) error {
 	}
 
 	var oldValidatable addonutils.Values
-	if s.settings != nil {
+	if s.settings != nil && s.settingsVersion == settingsVersion {
 		oldValidatable = addonutils.Values{s.name: s.settings}
 	}
 


### PR DESCRIPTION
## Description

Track the schema version associated with stored package settings and expose those settings to CEL as `oldSelf` only when the stored and incoming versions match.

ModuleV2 and global module settings now retain the version returned by conversion to the latest schema before validation and persistence. Applications use their reserved settings version `0`.

This change does not restart ingress controllers, control-plane components, Prometheus, or other critical cluster components.

## Why do we need it, and what problem does it solve?

Package settings validation previously retained the old settings value but not the schema version that produced it. As a result, CEL transition rules could compare `self` with an `oldSelf` from a different settings schema version. Such values are not necessarily structurally or semantically comparable and could cause valid settings migrations to be rejected.

The values store now scopes `oldSelf` to a matching schema version. Regular OpenAPI and CEL validation still runs for the incoming settings; only transition rules that require an incompatible old value are skipped.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist

- [ ] The code is covered by unit tests. Tests were not requested for this change.
- [ ] e2e tests passed. Not run.
- [ ] Documentation updated according to the changes. No user-facing documentation change is required.
- [ ] Changes were tested in the Kubernetes cluster manually. Not run.

## Changelog entries

```changes
section: deckhouse-controller
type: fix
summary: Prevent package settings CEL transition rules from comparing values from different schema versions.
impact_level: low
```
