### PR TITLE
Istio add missing jwks configmap template

### DIFF
--- a/modules/110-istio/template_tests/module_test.go
+++ b/modules/110-istio/template_tests/module_test.go
@@ -369,17 +369,23 @@ var _ = Describe("Module :: istio :: helm template :: main", func() {
 			f.HelmRender()
 		})
 
-		It("passes the certificate to pilot configuration for supported Istio versions", func() {
+		It("passes the certificate to pilot configuration and creates ConfigMaps for installed Istio versions", func() {
 			Expect(f.RenderError).ShouldNot(HaveOccurred())
 
-			istioV25 := f.KubernetesResource("Istio", "d8-istio", "v1x25x2")
 			iopV21 := f.KubernetesResource("IstioOperator", "d8-istio", "v1x21x6")
+			istioV25 := f.KubernetesResource("Istio", "d8-istio", "v1x25x2")
+			jwksExtraRootCAV21 := f.KubernetesResource("ConfigMap", "d8-istio", "pilot-jwks-extra-cacerts-v1x21x6")
+			jwksExtraRootCAV25 := f.KubernetesResource("ConfigMap", "d8-istio", "pilot-jwks-extra-cacerts-v1x25x2")
 
-			Expect(istioV25.Exists()).To(BeTrue())
 			Expect(iopV21.Exists()).To(BeTrue())
+			Expect(istioV25.Exists()).To(BeTrue())
+			Expect(jwksExtraRootCAV21.Exists()).To(BeTrue())
+			Expect(jwksExtraRootCAV25.Exists()).To(BeTrue())
 
-			Expect(istioV25.Field("spec.values.pilot.jwksResolverExtraRootCA").String()).To(Equal(jwksResolverAdditionalRootCA))
 			Expect(iopV21.Field("spec.values.pilot.jwksResolverExtraRootCA").String()).To(Equal(jwksResolverAdditionalRootCA))
+			Expect(istioV25.Field("spec.values.pilot.jwksResolverExtraRootCA").String()).To(Equal(jwksResolverAdditionalRootCA))
+			Expect(jwksExtraRootCAV21.Field("data.extra\\.pem").String()).To(Equal(jwksResolverAdditionalRootCA))
+			Expect(jwksExtraRootCAV25.Field("data.extra\\.pem").String()).To(Equal(jwksResolverAdditionalRootCA))
 		})
 	})
 

--- a/modules/110-istio/templates/control-plane/jwks-extra-root-ca.yaml
+++ b/modules/110-istio/templates/control-plane/jwks-extra-root-ca.yaml
@@ -1,0 +1,16 @@
+{{- with $.Values.istio.jwksResolverAdditionalRootCA }}
+  {{- $jwksResolverAdditionalRootCA := . }}
+  {{- range $version := $.Values.istio.internal.versionsToInstall }}
+    {{- $versionInfo := get $.Values.istio.internal.versionMap $version }}
+    {{- $revision := get $versionInfo "revision" }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pilot-jwks-extra-cacerts-{{ $revision }}
+  namespace: d8-{{ $.Chart.Name }}
+  {{- include "helm_lib_module_labels" (list $ (dict "app" "istiod" "istio.io/rev" $revision "operator.istio.io/component" "Pilot")) | nindent 2 }}
+data:
+  extra.pem: {{ $jwksResolverAdditionalRootCA | quote }}
+  {{- end }}
+{{- end }}


### PR DESCRIPTION
## Description

Adds the missing Istio Helm template that creates a `pilot-jwks-extra-cacerts-<revision>` ConfigMap for every installed Istio version when `jwksResolverAdditionalRootCA` is configured.

## Why do we need it, and what problem does it solve?

The Istio control-plane configuration already passes `jwksResolverAdditionalRootCA` to Pilot, which makes `istiod` expect a revision-specific `pilot-jwks-extra-cacerts-<revision>` ConfigMap. However, no component currently creates that ConfigMap. As a result, configuring an additional root CA for JWKS HTTPS endpoints does not work as intended.

## Why do we need it in the patch release (if we do)?

This fixes a bug in an existing Istio configuration option. Without the fix, clusters that configure an additional JWKS root CA do not get the required ConfigMap, so `istiod` pods cannot start at all.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: fix
summary: Create the ConfigMaps required for additional JWKS root CA certificates.
impact_level: default
```
