### PR TITLE
[deckhouse] fix verity verbosity and remove damaged hash

### DIFF
--- a/deckhouse-controller/internal/tools/verity/dmverity.go
+++ b/deckhouse-controller/internal/tools/verity/dmverity.go
@@ -173,19 +173,30 @@ func CreateImageHash(ctx context.Context, imagePath string) (string, error) {
 	defer file.Close()
 
 	if err = file.Truncate(hashSize); err != nil {
-		return "", fmt.Errorf("truncate hash image: %w", err)
+		return "", removeHashImage(hashPath, fmt.Errorf("truncate hash image: %w", err))
 	}
 
+	// veritysetup fills the hash tree in place, so every failure below leaves a
+	// truncated file behind, which breaks verification on the next start
 	hash, err := veritySetupFormat(ctx, imagePath, hashPath)
 	if err != nil {
-		return "", err
+		return "", removeHashImage(hashPath, err)
 	}
 
 	if len(hash) == 0 {
-		return "", ErrEmptyHash
+		return "", removeHashImage(hashPath, ErrEmptyHash)
 	}
 
 	return hash, nil
+}
+
+// removeHashImage drops a partially written hash tree and keeps the original cause
+func removeHashImage(hashPath string, cause error) error {
+	if err := os.Remove(hashPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return errors.Join(cause, fmt.Errorf("remove partial hash image '%s': %w", hashPath, err))
+	}
+
+	return cause
 }
 
 // VerifyImage performs verification of the erofs image against its hash tree using veritysetup.
@@ -235,10 +246,23 @@ func veritySetupFormat(ctx context.Context, imagePath, hashPath string) (string,
 		hashPath,
 	}
 
+	started := time.Now()
+
 	// veritysetup format --data-block-size=4096 --hash-block-size=4096 --salt=<salt> <imagePath> <hashPath>
 	cmd := exec.CommandContext(ctx, verityCommand, args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
+		// CommandContext kills the child with SIGKILL once the context is done, which is
+		// reported as 'signal: killed' - the same as an OOM kill, hence the explicit check
+		elapsed := time.Since(started).Truncate(time.Millisecond)
+
+		switch {
+		case errors.Is(ctx.Err(), context.DeadlineExceeded):
+			return "", fmt.Errorf("veritysetup format timed out after %s: %w (output: %s)", elapsed, ctx.Err(), string(output))
+		case errors.Is(ctx.Err(), context.Canceled):
+			return "", fmt.Errorf("veritysetup format canceled after %s: %w (output: %s)", elapsed, ctx.Err(), string(output))
+		}
+
 		return "", fmt.Errorf("veritysetup format: %w (output: %s)", err, string(output))
 	}
 


### PR DESCRIPTION
## Description

Two changes in `deckhouse-controller/internal/tools/verity/dmverity.go`:

1. **`veritysetup format` failures now say why the child died.** `CreateImageHash` bounds the
   command with a one-minute context (`imageHashTimeout`), and `exec.CommandContext` kills the
   child with SIGKILL when that context is done. Go reports this as `signal: killed` — the exact
   string an OOM kill produces — so a self-inflicted timeout was indistinguishable from the
   kernel killing the process. `veritySetupFormat` now inspects `ctx.Err()` and reports the
   elapsed time:

   | Cause | Error |
   |---|---|
   | Deadline fired | `veritysetup format timed out after 1m0.003s: context deadline exceeded (output: )` |
   | Root context canceled (pod SIGTERM, lost leadership) | `veritysetup format canceled after 4.117s: context canceled (output: )` |
   | External SIGKILL (OOM) or non-zero exit | `veritysetup format: signal: killed (output: )` (unchanged) |

   The elapsed duration is measured rather than taken from `imageHashTimeout`, because the
   deadline may also come from a parent context — the real number tells whether the command hit
   the minute or died after four seconds.

2. **A killed `format` no longer leaves a corrupted hash tree on disk.** `CreateImageHash`
   creates and truncates `<version>.erofs.verity` *before* running `veritysetup format`, which
   then fills it in place. Any failure left a partially written file behind. All three failure
   paths (`Truncate`, `format`, empty root hash) now drop it via `removeHashImage`, which joins a
   removal error onto the original cause instead of replacing or swallowing it.

## Why do we need it, and what problem does it solve?

A cluster hit this on Deckhouse startup:

```
{"level":"error","msg":"run","error":"start deckhouse controller: init module loader: restore modules by overrides: restore the module 'prometheus-metrics-adapter': create image hash: veritysetup format: signal: killed (output: )"}
```

The message is a dead end: `signal: killed` with empty output covers both "our own one-minute
deadline fired" and "the kernel OOM-killed the process", and the two have completely different
remedies. Deciding between them required reproducing the failure by hand inside the pod. After
this change the log answers the question on its own, and `signal: killed` becomes a reliable
signal of an actual external kill.

The leftover `.verity` file is the second half of the problem: the restore failure aborts
`DeckhouseController.Start`, the pod goes into CrashLoopBackOff, and every subsequent start
retries the same module — previously with a truncated hash tree already sitting on disk.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Add verbosity to veritysetup format and delete damaged hash. 
```
