### PR TITLE
[test] Broken OS image for unhappy-path testing

### DIFF
--- a/modules/040-node-manager/images/olcedar/werf.inc.yaml
+++ b/modules/040-node-manager/images/olcedar/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $version := "v0.1.3"  }}
+{{- $version := "fda11c0e6006f7dec8d89926ee1699d62d200879115040f95953c261-1786618361192"  }}
 {{- if ne $.Env "CSE" }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact


### PR DESCRIPTION
Throwaway branch: republishes the deliberately broken Olcedar image (`v0.1.3-broken`, an agent that never converges) into the release so a node can pull it by digest. The digest is the only deliverable.

Do not merge.