### PR TITLE
[network-gateway] Fix DHCP (dnsmasq) and SNAT images after distroless base/build update

### DIFF
--- a/ee/modules/450-network-gateway/images/dnsmasq/src/prepare-config.py
+++ b/ee/modules/450-network-gateway/images/dnsmasq/src/prepare-config.py
@@ -12,6 +12,7 @@ try:
     import pysqlite3
     sys.modules['sqlite3'] = pysqlite3
 except ImportError as e:
+    print(e)
     sys.exit(1)
 
 from pyroute2 import IPRoute

--- a/ee/modules/450-network-gateway/images/dnsmasq/werf.inc.yaml
+++ b/ee/modules/450-network-gateway/images/dnsmasq/werf.inc.yaml
@@ -4,25 +4,45 @@ final: false
 from: {{ index $.Images "builder/distroless" }}
 shell:
   beforeInstall:
-  - pm install dnsmasq python@3.12 libc python-wheel -d /out
+  - pm install dnsmasq -d /out
+---
+image: {{ $.ModuleName }}/{{ $.ImageName }}-wheel-artifact
+from: {{ index $.Images "builder/distroless" }}
+final: false
+git:
+- add: /{{ $.ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ $.ImageName }}/src/requirements.txt
+  to: /requirements.txt
+  stageDependencies:
+    install:
+    - '**/*'
+shell:
+  beforeInstall:
+  - pm install python@3.12 libc python-wheel
+  install:
+  - pip3 install -f file:///wheels --no-index --upgrade pip
+  - pip3 install -f file:///wheels --no-index -r /requirements.txt
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
 from: {{ index $.Images "base/distroless-fin" }}
 git:
 - add: /{{ $.ModulePath }}modules/450-{{ $.ModuleName }}/images/{{ $.ImageName }}/src/prepare-config.py
   to: /prepare-config.py
-- add: /{{ $.ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/src/requirements.txt
-  to: /requirements.txt
-  stageDependencies:
-    install:
-    - '**/*'
 import:
 - image: {{ .ModuleName }}/{{ .ImageName }}-artifact
   add: /out
   to: /
   before: install
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-wheel-artifact
+  add: /
+  to: /
+  before: install
+  includePaths:
+  - usr/bin/python3*
+  - usr/lib/python3*
+  - usr/lib/lib*.so*
+  - usr/lib/ld-linux-x86-64.so.2
+  - lib64
+  excludePaths:
+  - usr/lib/python*/site-packages/pip-25.3*
+  - usr/lib/python*/test
 {{- include "image mount points" $ }}
-shell:
-  install:
-  - pip3 install -f file:///wheels --no-index --upgrade pip
-  - pip3 install -f file:///wheels --no-index -r /requirements.txt

--- a/ee/modules/450-network-gateway/images/snat/werf.inc.yaml
+++ b/ee/modules/450-network-gateway/images/snat/werf.inc.yaml
@@ -18,6 +18,6 @@ import:
   before: setup
 {{- include "image mount points" $ }}
 shell:
-  install:
+  setup:
   # prevent mounting to /usr/bin due to /sbin is a symlink to /usr/bin in a container
   - /usr/bin/unlink /sbin

--- a/ee/modules/450-network-gateway/images/snat/werf.inc.yaml
+++ b/ee/modules/450-network-gateway/images/snat/werf.inc.yaml
@@ -17,3 +17,7 @@ import:
   to: /
   before: setup
 {{- include "image mount points" $ }}
+shell:
+  install:
+  # prevent mounting to /usr/bin due to /sbin is a symlink to /usr/bin in a container
+  - unlink /sbin

--- a/ee/modules/450-network-gateway/images/snat/werf.inc.yaml
+++ b/ee/modules/450-network-gateway/images/snat/werf.inc.yaml
@@ -20,4 +20,4 @@ import:
 shell:
   install:
   # prevent mounting to /usr/bin due to /sbin is a symlink to /usr/bin in a container
-  - unlink /sbin
+  - /usr/binunlink /sbin

--- a/ee/modules/450-network-gateway/images/snat/werf.inc.yaml
+++ b/ee/modules/450-network-gateway/images/snat/werf.inc.yaml
@@ -20,4 +20,4 @@ import:
 shell:
   install:
   # prevent mounting to /usr/bin due to /sbin is a symlink to /usr/bin in a container
-  - /usr/binunlink /sbin
+  - /usr/bin/unlink /sbin

--- a/ee/modules/450-network-gateway/templates/configmap.yaml
+++ b/ee/modules/450-network-gateway/templates/configmap.yaml
@@ -8,3 +8,7 @@ metadata:
 data:
   config.json: |
     {{- .Values.networkGateway | toJson | nindent 4 }}
+  dnsmasq.conf: |
+    expand-hosts
+    localise-queries
+    conf-dir=/etc/dnsmasq.conf.d,.rpmnew,.rpmsave,.rpmorig

--- a/ee/modules/450-network-gateway/templates/dhcp-statefulset.yaml
+++ b/ee/modules/450-network-gateway/templates/dhcp-statefulset.yaml
@@ -88,6 +88,9 @@ spec:
         image: {{ include "helm_lib_module_image" (list . "dnsmasq") }}
         command: ['dnsmasq', '-dK', '--dhcp-leasefile=/var/lib/dnsmasq/dhcp.leases']
         volumeMounts:
+        - name: network-gateway-config
+          mountPath: /etc/dnsmasq.conf
+          subPath: dnsmasq.conf
         - name: dhcp-config
           mountPath: /etc/dnsmasq.conf.d
         - name: dhcp-data


### PR DESCRIPTION
## Description

After the base distroless images and the image build approach were updated, the network-gateway module broke.

The changes introduced in this pull request aim to neutralize the modifications in the new builds and restore the functionality of the modules.

## Why do we need it, and what problem does it solve?

The network-gateway module is currently non-functional: the `dhcp` (dnsmasq) and `snat` pods crash-loops, and their features are unavailable for the managed subnet.

## Why do we need it in the patch release (if we do)?

The affected releases ship a broken network-gateway module (DHCP is down, `dhcp`/`snat` pods fail). Users need the fix without waiting for the next minor release.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: network-gateway
type: fix
summary: Fix dnsmasq (DHCP) and snat containers crash-loop.
```