### PR TITLE
[deckhouse] mark ModuleConfig as deprecated and add deprecation warning

### DIFF
--- a/deckhouse-controller/crds/module-config.yaml
+++ b/deckhouse-controller/crds/module-config.yaml
@@ -21,6 +21,8 @@ spec:
     - name: v1alpha1
       served: true
       storage: true
+      deprecated: true
+      deprecationWarning: ModuleConfig is deprecated. Use Module instead.
       schema:
         openAPIV3Schema:
           type: object

--- a/deckhouse-controller/internal/metrics/metrics.go
+++ b/deckhouse-controller/internal/metrics/metrics.go
@@ -319,7 +319,7 @@ func RegisterModuleControllerMetrics(metricStorage metricsstorage.Storage) error
 
 	_, err = metricStorage.RegisterGauge(
 		DeprecatedModuleConfigIsUsed,
-		configLabels,
+		[]string{LabelName},
 		options.WithHelp("Gauge indicating deprecated moduleconfigs are used (1.0 = used, 0.0 = not used)"),
 	)
 	if err != nil {

--- a/deckhouse-controller/internal/metrics/metrics.go
+++ b/deckhouse-controller/internal/metrics/metrics.go
@@ -58,6 +58,7 @@ const (
 	D8ModuleConfigObsoleteVersion  = "d8_module_config_obsolete_version"
 	D8ModuleAtConflict             = "d8_module_at_conflict"
 	D8ModuleConfigAllowedToDisable = "d8_moduleconfig_allowed_to_disable"
+	DeprecatedModuleConfigIsUsed   = "d8_deprecated_moduleconfig_is_used"
 
 	// ============================================================================
 	// Module Source Controller Metrics
@@ -314,6 +315,15 @@ func RegisterModuleControllerMetrics(metricStorage metricsstorage.Storage) error
 	)
 	if err != nil {
 		return fmt.Errorf("failed to register %s: %w", D8ModuleConfigObsoleteVersion, err)
+	}
+
+	_, err = metricStorage.RegisterGauge(
+		DeprecatedModuleConfigIsUsed,
+		configLabels,
+		options.WithHelp("Gauge indicating deprecated moduleconfigs are used (1.0 = used, 0.0 = not used)"),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to register %s: %w", DeprecatedModuleConfigIsUsed, err)
 	}
 
 	_, err = metricStorage.RegisterGauge(

--- a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module_config.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module_config.go
@@ -58,6 +58,7 @@ var _ runtime.Object = (*ModuleConfig)(nil)
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster,shortName=mc
+// +kubebuilder:deprecatedversion:warning="ModuleConfig is deprecated. Use Module instead."
 // +kubebuilder:printcolumn:name="Enabled",type="boolean",JSONPath=".spec.enabled",description="Module enabled state"
 // +kubebuilder:printcolumn:name="UpdatePolicy",type="string",JSONPath=".spec.updatePolicy",description="The update policy of the module.",priority=1
 // +kubebuilder:printcolumn:name="Source",type="string",JSONPath=".spec.source",description="The source of the module.",priority=1

--- a/deckhouse-controller/pkg/controller/module-controllers/config/status.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/status.go
@@ -96,6 +96,13 @@ func (r *reconciler) refreshModuleConfig(ctx context.Context, configName string)
 				return fmt.Errorf("update: %w", err)
 			}
 
+			// ModuleConfig is a deprecated resource: any existing config means the
+			// deprecated API is still in use. Reuse the obsolete-version metric group
+			// so the gauge is expired automatically on reconcile and on config deletion.
+			r.metricStorage.Grouped().GaugeSet(metricGroup, metrics.DeprecatedModuleConfigIsUsed, 1.0, map[string]string{
+				"name": moduleConfig.Name,
+			})
+
 			// skip firing alert for global module
 			if moduleConfig.Name != "global" {
 				// update metrics

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -3640,9 +3640,9 @@ alerts:
       module: deckhouse
       edition: ce
       description: |
-        The deprecated ModuleConfig `{{ $labels.module }}` is used. ModuleConfig is deprecated, use the Module resource instead.
+        The deprecated ModuleConfig `{{ $labels.name }}` is used. ModuleConfig is deprecated, use the Module resource instead.
       summary: |
-        Deprecated ModuleConfig {{ $labels.module }} is used.
+        Deprecated ModuleConfig {{ $labels.name }} is used.
       severity: "9"
       markupFormat: markdown
     - name: HelmReleasesHasResourcesWithDeprecatedVersions

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -3634,6 +3634,17 @@ alerts:
         Deckhouse update has failed.
       severity: "4"
       markupFormat: markdown
+    - name: DeprecatedModuleConfigIsUsed
+      sourceFile: modules/002-deckhouse/monitoring/prometheus-rules/alerting.yaml
+      moduleUrl: 002-deckhouse
+      module: deckhouse
+      edition: ce
+      description: |
+        The deprecated ModuleConfig `{{ $labels.module }}` is used. ModuleConfig is deprecated, use the Module resource instead.
+      summary: |
+        Deprecated ModuleConfig {{ $labels.module }} is used.
+      severity: "9"
+      markupFormat: markdown
     - name: HelmReleasesHasResourcesWithDeprecatedVersions
       sourceFile: modules/040-control-plane-manager/monitoring/prometheus-rules/helm/deprecated-versions.yaml
       moduleUrl: 040-control-plane-manager

--- a/modules/002-deckhouse/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/002-deckhouse/monitoring/prometheus-rules/alerting.yaml
@@ -458,3 +458,15 @@
         Module `{{ $labels.module }}` is deprecated.
       description: |
         The module `{{ $labels.module }}` is deprecated and will not receive new updates. The module may be removed in the future, so please disable it in a controlled manner.
+
+  - alert: DeprecatedModuleConfigIsUsed
+    expr: max by (module) (d8_deprecated_moduleconfig_is_used) >= 1
+    labels:
+      severity_level: "9"
+    annotations:
+      plk_markup_format: "markdown"
+      plk_protocol_version: "1"
+      summary: |
+        Deprecated ModuleConfig `{{ $labels.module }}` is used.
+      description: |
+        The deprecated ModuleConfig `{{ $labels.module }}` is used. ModuleConfig is deprecated, use the Module resource instead.

--- a/modules/002-deckhouse/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/002-deckhouse/monitoring/prometheus-rules/alerting.yaml
@@ -460,13 +460,13 @@
         The module `{{ $labels.module }}` is deprecated and will not receive new updates. The module may be removed in the future, so please disable it in a controlled manner.
 
   - alert: DeprecatedModuleConfigIsUsed
-    expr: max by (module) (d8_deprecated_moduleconfig_is_used) >= 1
+    expr: max by (name) (d8_deprecated_moduleconfig_is_used) >= 1
     labels:
       severity_level: "9"
     annotations:
       plk_markup_format: "markdown"
       plk_protocol_version: "1"
       summary: |
-        Deprecated ModuleConfig `{{ $labels.module }}` is used.
+        Deprecated ModuleConfig `{{ $labels.name }}` is used.
       description: |
-        The deprecated ModuleConfig `{{ $labels.module }}` is used. ModuleConfig is deprecated, use the Module resource instead.
+        The deprecated ModuleConfig `{{ $labels.name }}` is used. ModuleConfig is deprecated, use the Module resource instead.


### PR DESCRIPTION
## Description

This change officially deprecates the `ModuleConfig` resource (`v1alpha1`) in favor of the `Module` resource and makes the deprecation observable.

Three things are introduced:

1. **API-level deprecation.** `ModuleConfig` is marked as deprecated, so working with it through the Kubernetes API (e.g. `kubectl`) surfaces a warning: `ModuleConfig is deprecated. Use Module instead.`
2. **Usage metric.** The controller exposes the `d8_deprecated_moduleconfig_is_used` metric that reports whether a `ModuleConfig` is present in the cluster, i.e. whether the deprecated resource is still in use. The metric is emitted per config during reconciliation and is cleared automatically when the config is deleted.
3. **Alert.** A low-severity alert `DeprecatedModuleConfigIsUsed` fires when the deprecated resource is in use, pointing users to the `Module` resource.

`ModuleConfig` keeps working exactly as before — nothing is removed and no behavior changes. The change only signals the deprecation and makes it visible in monitoring.

<img width="646" height="669" alt="image" src="https://github.com/user-attachments/assets/04de8156-19d8-4263-b540-c58289800c33" />


## Why do we need it, and what problem does it solve?

`ModuleConfig` is being superseded by `Module`. Deprecating the resource communicates this direction clearly and warns users before the eventual removal, reducing the risk of a surprising breaking change. The metric and alert give operators visibility into where the deprecated resource is still used, so migration can be planned and tracked instead of discovered late.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: chore
summary: Mark the `ModuleConfig` resource as deprecated.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
