### PR TITLE
[operator-prometheus] suppress GO-2026-5932 in prometheus-config-reloader via VEX

### DIFF
--- a/modules/200-operator-prometheus/images/prometheus-config-reloader/known_vulnerabilities.vex
+++ b/modules/200-operator-prometheus/images/prometheus-config-reloader/known_vulnerabilities.vex
@@ -3,7 +3,7 @@
   "@id": "merged-vex-operator-prometheus-prometheus-config-reloader",
   "author": "Deckhouse <contact@deckhouse.io>",
   "timestamp": "2026-05-21T15:00:00.000000+03:00",
-  "version": 2,
+  "version": 3,
   "statements": [
     {
       "vulnerability": {
@@ -60,6 +60,20 @@
       "status": "not_affected",
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Уязвимость CVE-2026-44903 (GHSA-fw8g-cg8f-9j28, CWE-79) — Stored XSS в legacy веб-интерфейсе Prometheus при отображении heatmap (histogram bucket label values), активируемый флагом --enable-feature=old-ui. Согласно официальному advisory, уязвимость затрагивает Prometheus < 3.5.3 и < 3.11.3 (фикс в 3.5.3/3.11.3, upstream v0.311.3). Образ prometheus-config-reloader (собирается из prometheus-operator v0.68.0) использует библиотеку github.com/prometheus/prometheus v0.47.0 (Prometheus 2.47.x) только как набор Go-типов для shared конфигурационных структур. Бинарь /bin/prometheus-config-reloader выполняет исключительно sidecar-функции (watch config + trigger reload), не запускает Prometheus-сервер, не открывает legacy web UI Prometheus и не имеет флага --enable-feature=old-ui. Код пакета github.com/prometheus/prometheus/web/ui в /bin/prometheus-config-reloader не импортируется и не компилируется в исполняемый путь. Эксплуатация в рамках данного образа недоступна."
+    },
+    {
+      "vulnerability": {
+        "name": "GO-2026-5932"
+      },
+      "timestamp": "2026-08-13T12:00:00.000000+03:00",
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/crypto@v0.53.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "GO-2026-5932 относится к пакету golang.org/x/crypto/openpgp, который объявлен неподдерживаемым (deprecated) и небезопасным по своей архитектуре; исправленной версии модуля golang.org/x/crypto не существует и не будет выпущено — upstream рекомендует переход на github.com/ProtonMail/go-crypto. Образ prometheus-config-reloader собирается из prometheus-operator v0.68.0 с golang.org/x/crypto v0.53.0, однако сканер сообщает об уязвимости на уровне модуля, а не пакета. Проверка полного графа зависимостей сборки (go list -deps ./cmd/prometheus-config-reloader, CGO_ENABLED=0 GOOS=linux GOARCH=amd64) показывает, что из модуля golang.org/x/crypto в бинарь /bin/prometheus-config-reloader компилируются только пакеты golang.org/x/crypto/pkcs12 и golang.org/x/crypto/pkcs12/internal/rc2; пакеты golang.org/x/crypto/openpgp и его подпакеты отсутствуют в графе полностью. Бинарь выполняет исключительно sidecar-функции — отслеживание изменений файлов конфигурации и триггер reload через HTTP-эндпоинт основного Prometheus — и не выполняет никаких операций OpenPGP (проверка подписей, шифрование, разбор keyring). Уязвимый код не присутствует в образе, эксплуатация недоступна."
     }
   ]
 }


### PR DESCRIPTION
## Description

Suppresses `GO-2026-5932` (`golang.org/x/crypto` v0.53.0) reported by Trivy against `bin/prometheus-config-reloader` in the `operator-prometheus/prometheus-config-reloader` image.

**There is no fixed version.** The advisory states that `golang.org/x/crypto/openpgp` is unmaintained and unsafe by design; upstream deprecated the package and will not ship a fixed release (the recommended path is migrating to `github.com/ProtonMail/go-crypto`). Bumping `golang.org/x/crypto` cannot clear it — the module is already at `v0.53.0` via `patches/004-fix_cve.patch`. Per the fallback rule for advisories with no fix, this is handled with a VEX statement.

## Why `not_affected` / `vulnerable_code_not_present`

The scanner flags `gobinary` findings at **module** granularity, so `golang.org/x/crypto` is reported regardless of which of its packages are actually linked in.

Resolving the real build graph of the binary (prometheus-operator `v0.68.0` with the Deckhouse patches applied, same flags as the werf build) shows `openpgp` is absent entirely:

```console
$ CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go list -deps ./cmd/prometheus-config-reloader | grep openpgp
$ CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go list -deps ./cmd/prometheus-config-reloader | grep '^golang.org/x/crypto'
golang.org/x/crypto/pkcs12/internal/rc2
golang.org/x/crypto/pkcs12
```

Only `pkcs12` (and its internal `rc2` helper) are compiled into `/bin/prometheus-config-reloader` — zero `openpgp` packages out of 989 resolved dependencies. The binary is a sidecar that watches config files and triggers a reload over the main Prometheus HTTP endpoint; it performs no OpenPGP operations (signature verification, encryption, keyring parsing).

This mirrors the statement already carried by the sibling `prometheus-operator` image, added in #21763, which covers both `/bin/operator` and `/bin/prometheus-config-reloader` — this PR adds the corresponding statement to the config-reloader image's own VEX document so the attestation attached to that image is complete.

## Changes

- `modules/200-operator-prometheus/images/prometheus-config-reloader/known_vulnerabilities.vex`: add the `GO-2026-5932` statement, bump document `version` 2 → 3.

No changelog entry: VEX-only change with no user-facing behavior difference, consistent with the precedent CVE-suppression commits for this module.

## Note for reviewers

The `Pull Request Changes validation` job may report a failure unrelated to this change — it checks out `main` rather than the PR base, and `operator-prometheus` no longer exists on `main`. It is not merge-blocking (see #21649, #21763).

🤖 Generated with [Claude Code](https://claude.com/claude-code)