### PR TITLE
Reduce the in-core GPU node preparation to a non-blocking minimum

### DIFF
--- a/candi/bashible/common-steps/all/006_check_gpu.sh.tpl
+++ b/candi/bashible/common-steps/all/006_check_gpu.sh.tpl
@@ -1,4 +1,4 @@
-# Copyright 2025 Flant JSC
+# Copyright 2026 Flant JSC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,66 +16,138 @@
 {{- if eq .runType "Normal" }}
   {{ if .nodeGroup.gpu }}
 
-if ! command -v /usr/bin/nvidia-container-runtime >/dev/null 2>&1; then
-    bb-log-error "/usr/bin/nvidia-container-runtime is not installed. It is required on NVIDIA GPU nodes."
-    exit 1
-fi
+# The in-core GPU path (NodeGroup.spec.gpu without the `gpu` module) is deprecated and
+# scheduled for removal. Until then its only job is to not stand in the way: a broken
+# GPU host stack must not block node convergence, so this step never exits non-zero and
+# never hangs, it only writes its verdict to the log. Full GPU host stack diagnostics
+# (including any machine-readable signal) belong to the `gpu` module.
+#
+# The messages are split by severity: bb-log-warning when a prerequisite is simply not
+# in place yet (driver or nvidia-smi not installed), bb-log-error when the GPU is
+# present but unusable for CUDA workloads.
 
-if ! command -v /usr/bin/nvidia-smi; then
-    bb-log-error "/usr/bin/nvidia-smi is not installed. It is required on NVIDIA GPU nodes."
-    exit 1
-fi
+# Every nvidia-smi call is bounded in time. A wedged kernel module (Xid error, "GPU has
+# fallen off the bus") makes nvidia-smi hang forever: it neither succeeds nor fails.
+# This step runs inside a parallel step group, so the group `wait` would never return
+# and the run would never reach 069_start_kubelet.sh - which is exactly the observable
+# effect this step exists to report instead of reproducing.
+#
+# Plain `timeout` only sends SIGTERM and then keeps waiting for the child, and a process
+# blocked in a driver ioctl ignores SIGTERM - i.e. it hangs on precisely the case the
+# timeout is here for. `-k` adds the SIGKILL that actually terminates it, so the call is
+# bounded by nvidia_smi_timeout + nvidia_smi_kill_after.
+nvidia_smi_timeout=15
+nvidia_smi_kill_after=5
 
-/usr/bin/nvidia-smi -L
-
-# $1 current version $2 required version
-function compare() {
-  lower_version=$(echo -e "$2\n$1" | sort -V | head -n1)
-  if [[ "$lower_version" != "$2" ]]
-  then
-    bb-log-error "NVIDIA driver version $1 is below the required minimum $2, please update the driver"
-    exit 1
+nvidia_smi() {
+  if command -v timeout >/dev/null 2>&1; then
+    timeout -k "$nvidia_smi_kill_after" "$nvidia_smi_timeout" /usr/bin/nvidia-smi "$@"
+  else
+    /usr/bin/nvidia-smi "$@"
   fi
 }
-required_version="450.80.02"
 
-is_valid_greater_than() {
-    local value="$1"
-    local threshold="$2"
-    
-    if [[ -z "$value" ]]; then
-        return 1
-    fi
-    
-    if ! [[ "$value" =~ ^[0-9]+\.[0-9]$ ]]; then
-        return 1
-    fi
-    
-    if (( $(echo "$value > $threshold" | bc -l) )); then
-        return 0
-    else
-        return 1
-    fi
+has_nvidia_gpu() {
+  local dev vendor class
+  for dev in /sys/bus/pci/devices/*; do
+    vendor="$(cat "$dev/vendor" 2>/dev/null || true)"
+    [ "$vendor" = "0x10de" ] || continue
+    class="$(cat "$dev/class" 2>/dev/null || true)"
+    case "$class" in
+      0x03*) return 0 ;;
+    esac
+  done
+  return 1
 }
 
-version=$(egrep -E -o "[0-9]{3,4}[.][0-9]{1,3}[.][0-9]{1,3}" /proc/driver/nvidia/version)
-compare $version $required_version
+# There is no NVIDIA display controller on this host, so all the NVIDIA-specific checks
+# below are meaningless. This step makes no statement about such a node: no checks, no
+# log messages.
+if ! has_nvidia_gpu; then
+  exit 0
+fi
 
-got_capabilities=$(nvidia-smi --query-gpu="compute_cap" --format=csv,noheader | tr -d ' ' | sed '/^$/d')
-if [[ -z "$got_capabilities" ]]; then
-    bb-log-error "nvidia-smi returned an empty compute capability list"
-    exit 1
+required_version="450.80.02"
+
+# $1 current version, $2 required version
+version_is_at_least() {
+  lower_version=$(printf '%s\n' "$2" "$1" | sort -V | head -n1)
+  [ "$lower_version" = "$2" ]
+}
+
+# The checks below go bottom-up through the stack, so that when several layers are
+# broken at once the first message already points at the root cause.
+
+# The NVIDIA kernel module is loaded and reports a driver version. This is checked
+# before nvidia-smi on purpose: the most common real-world failure - DKMS not rebuilt
+# after a kernel change - breaks nvidia-smi as well, so probing nvidia-smi first would
+# blame the user-space tool for a kernel-side problem.
+# Two- and three-component versions are both accepted: NVIDIA ships releases numbered
+# 550.67, 550.100, 550.135 alongside 550.54.14, and a three-component-only pattern
+# reported those healthy nodes as if no driver were loaded. `sort -V` in
+# version_is_at_least orders a two-component value against the three-component minimum
+# correctly.
+version=$(grep -E -o "[0-9]{3,4}[.][0-9]{1,3}([.][0-9]{1,3})?" /proc/driver/nvidia/version 2>/dev/null | head -n1 || true)
+if [ -z "$version" ]; then
+  bb-log-warning "Cannot determine the NVIDIA driver version from /proc/driver/nvidia/version. The NVIDIA kernel module is not loaded."
+  exit 0
+fi
+
+# The user-space driver is installed at all.
+if ! command -v /usr/bin/nvidia-smi >/dev/null 2>&1; then
+  bb-log-warning "/usr/bin/nvidia-smi is not installed. CUDA workloads will not be available until the NVIDIA driver is installed."
+  exit 0
+fi
+
+# nvidia-smi answers within the timeout and lists the GPUs.
+smi_list=""
+if ! smi_list="$(nvidia_smi -L 2>/dev/null)"; then
+  bb-log-warning "'nvidia-smi -L' failed or did not finish in ${nvidia_smi_timeout}s. The NVIDIA driver is not usable on this node, the kernel module may need a DKMS rebuild for the running kernel."
+  exit 0
+fi
+if [ -z "$(printf '%s' "$smi_list" | tr -d '[:space:]')" ]; then
+  bb-log-warning "'nvidia-smi -L' listed no GPU, the loaded driver sees no device."
+  exit 0
+fi
+bb-log-info "nvidia-smi reports: $smi_list"
+
+# The driver is not older than the minimal supported version.
+if ! version_is_at_least "$version" "$required_version"; then
+  bb-log-error "NVIDIA driver version $version is below the required minimum $required_version, please update the driver"
+  exit 0
+fi
+
+# Every GPU reports a compute capability above 6.0. The comparison is integer-based on
+# purpose: `bc -l` compares 8.90 as a decimal fraction and would rank it below 6.0.
+got_capabilities=$(nvidia_smi --query-gpu="compute_cap" --format=csv,noheader 2>/dev/null | tr -d ' ' | sed '/^$/d' || true)
+if [ -z "$got_capabilities" ]; then
+  bb-log-warning "nvidia-smi returned an empty compute capability list"
+  exit 0
 fi
 
 while IFS= read -r got_capability; do
-    if is_valid_greater_than "$got_capability" "6.0"; then
-        bb-log-info "GPU compute capability $got_capability is supported"
-    else
-        bb-log-error "GPU compute capability $got_capability is below the required minimum 6.0"
-        exit 1
-    fi
+  if ! printf '%s' "$got_capability" | grep -Eq '^[0-9]+\.[0-9]+$'; then
+    bb-log-error "Cannot parse GPU compute capability value: '$got_capability'"
+    exit 0
+  fi
+  cap_major="${got_capability%%.*}"
+  cap_minor="${got_capability#*.}"
+  if [ "$cap_major" -gt 6 ] || { [ "$cap_major" -eq 6 ] && [ "$cap_minor" -gt 0 ]; }; then
+    bb-log-info "GPU compute capability $got_capability is supported"
+  else
+    bb-log-error "GPU compute capability $got_capability is below the required minimum 6.0"
+    exit 0
+  fi
 done <<< "$got_capabilities"
 
+# The container path, checked last so that a broken driver is reported first. Missing
+# toolkit binaries are not a benign state: without them a GPU node cannot run CUDA
+# workloads at all (and 032_configure_containerd.sh has to fall back to the runc default
+# runtime, so plain containers keep working but no container gets a GPU).
+if ! command -v /usr/bin/nvidia-container-runtime >/dev/null 2>&1; then
+  bb-log-error "/usr/bin/nvidia-container-runtime is not installed. CUDA workloads will not run on this node until NVIDIA Container Toolkit is installed."
+  exit 0
+fi
 
   {{- end }}
 {{- end }}

--- a/candi/bashible/common-steps/all/006_check_gpu.sh.tpl
+++ b/candi/bashible/common-steps/all/006_check_gpu.sh.tpl
@@ -1,4 +1,4 @@
-# Copyright 2026 Flant JSC
+# Copyright 2025 Flant JSC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/candi/bashible/common-steps/all/032_configure_containerd.sh.tpl
+++ b/candi/bashible/common-steps/all/032_configure_containerd.sh.tpl
@@ -1,4 +1,4 @@
-# Copyright 2024 Flant JSC
+# Copyright 2026 Flant JSC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -49,11 +49,43 @@ bb-event-on 'containerd-config-file-changed' '_on_containerd_config_changed'
     {{ $sandbox_image = "deckhouse.local/images:pause" }}
   {{- end }}
 
-  {{- $default_runtime := "runc" }}
   {{- if and .nodeGroup.gpu (ne .deckhouse.edition "CSE") }}
-    {{ $default_runtime = "nvidia" }}
-sed -i "s/net.core.bpf_jit_harden = 2/net.core.bpf_jit_harden = 1/" /etc/sysctl.d/99-sysctl.conf # https://github.com/NVIDIA/nvidia-container-toolkit/issues/117#issuecomment-1758781872
-sed -i "s/net.core.bpf_jit_harden = 2/net.core.bpf_jit_harden = 1/" /etc/sysctl.conf # REDOS
+# The containerd default runtime is resolved at run time, not at template time. The
+# NVIDIA Container Toolkit is an external prerequisite of a GPU node and may simply be
+# absent: pointing default_runtime_name at a runtime whose BinaryName does not exist
+# breaks EVERY container on the node (CNI, storage, all DaemonSets), not only the GPU
+# workloads. The deprecated in-core GPU path must not be able to take the whole node
+# down, so the default runtime falls back to runc while the toolkit is missing.
+containerd_default_runtime="nvidia"
+if ! command -v /usr/bin/nvidia-container-runtime >/dev/null 2>&1; then
+  containerd_default_runtime="runc"
+  bb-log-error "/usr/bin/nvidia-container-runtime is not installed, keeping 'runc' as the containerd default runtime. GPU workloads will NOT work on this node until NVIDIA Container Toolkit is installed; general purpose containers keep working."
+fi
+
+# net.core.bpf_jit_harden must be relaxed to 1 on a GPU node, otherwise
+# nvidia-container-cli fails and GPU pods end up in CreateContainerError.
+# https://github.com/NVIDIA/nvidia-container-toolkit/issues/117#issuecomment-1758781872
+#
+# The value is persisted in our own drop-in instead of editing distro files in place:
+# they may be absent, and the value may be set in a different file. The "zz" prefix
+# only orders our file last WITHIN /etc/sysctl.d - it says nothing about the other
+# sysctl sources, see the /etc/sysctl.conf fixup below.
+bb-sync-file /etc/sysctl.d/99-zz-nvidia-bpf-jit-harden.conf - <<< "net.core.bpf_jit_harden = 1"
+
+# procps applies /etc/sysctl.conf AFTER all the drop-in directories, so a value set
+# there overrides the drop-in above on every `sysctl --system`. RED OS ships
+# `net.core.bpf_jit_harden = 2` exactly in /etc/sysctl.conf, hence this in-place
+# fixup. It only rewrites an explicit `= 2` assignment (idempotent, and a no-op when
+# the file or the setting is absent) and must never fail the step.
+if [ -f /etc/sysctl.conf ] && grep -qE '^[[:space:]]*net\.core\.bpf_jit_harden[[:space:]]*=[[:space:]]*2[[:space:]]*$' /etc/sysctl.conf; then
+  sed -i -E 's/^([[:space:]]*net\.core\.bpf_jit_harden[[:space:]]*=[[:space:]]*)2[[:space:]]*$/\11/' /etc/sysctl.conf \
+    || bb-log-warning "Failed to relax net.core.bpf_jit_harden in /etc/sysctl.conf. GPU containers may fail to start after 'sysctl --system'."
+fi
+  {{- else }}
+# Not a GPU NodeGroup, or the edition is CSE. The assignment is not optional: both
+# deckhouse.toml heredocs below interpolate this variable, and an unset one would render
+# an empty default_runtime_name and break every container on the node.
+containerd_default_runtime="runc"
   {{- end }}
 
 systemd_cgroup=true
@@ -139,7 +171,7 @@ oom_score = 0
     drain_exec_sync_io_timeout = '0s'
     ignore_deprecation_warnings = []
     [plugins.'io.containerd.cri.v1.runtime'.containerd]
-      default_runtime_name = {{ $default_runtime | quote }}
+      default_runtime_name = "${containerd_default_runtime}"
       ignore_blockio_not_enabled_errors = false
       ignore_rdt_not_enabled_errors = false
   {{- if and .nodeGroup.gpu (ne .deckhouse.edition "CSE") }}
@@ -330,7 +362,7 @@ oom_score = 0
     cdi_spec_dirs = ['/etc/cdi', '/var/run/cdi']
     [plugins."io.containerd.grpc.v1.cri".containerd]
       snapshotter = "overlayfs"
-      default_runtime_name = {{ $default_runtime | quote }}
+      default_runtime_name = "${containerd_default_runtime}"
       no_pivot = false
       disable_snapshot_annotations = true
       discard_unpacked_layers = true

--- a/candi/bashible/common-steps/all/032_configure_containerd.sh.tpl
+++ b/candi/bashible/common-steps/all/032_configure_containerd.sh.tpl
@@ -1,4 +1,4 @@
-# Copyright 2026 Flant JSC
+# Copyright 2024 Flant JSC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -4297,6 +4297,21 @@ alerts:
         NodeGroup {{ $labels.node_group }} has unavailable instances.
       severity: "8"
       markupFormat: markdown
+    - name: NodeGroupUsesDeprecatedInCoreGPU
+      sourceFile: modules/040-node-manager/monitoring/prometheus-rules/node-group-deprecate.yaml
+      moduleUrl: 040-node-manager
+      module: node-manager
+      edition: ce
+      description: |
+        NodeGroup {{ $labels.name }} has `spec.gpu` configured while the `gpu` module is disabled,
+        so its GPU nodes are served by the built-in GPU support.
+        Built-in GPU support is deprecated and will be removed.
+
+        The `gpu` module must be enabled.
+      summary: |
+        NodeGroup {{ $labels.name }} uses the deprecated built-in GPU support.
+      severity: "9"
+      markupFormat: markdown
     - name: NodeRequiresDisruptionApprovalForUpdate
       sourceFile: modules/040-node-manager/monitoring/prometheus-rules/node-update.yaml
       moduleUrl: 040-node-manager

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -4303,11 +4303,11 @@ alerts:
       module: node-manager
       edition: ce
       description: |
-        NodeGroup {{ $labels.name }} has `spec.gpu` configured while the `gpu` module is disabled,
-        so its GPU nodes are served by the built-in GPU support.
-        Built-in GPU support is deprecated and will be removed.
+        NodeGroup `{{ $labels.name }}` has [`spec.gpu`](/modules/node-manager/cr.html#nodegroup-v1-spec-gpu) configured while the `gpu` module is disabled.
+        As a result, GPU nodes in the NodeGroup use the built-in GPU support,
+        which is deprecated and will be removed in a future DKP release.
 
-        The `gpu` module must be enabled.
+        To use the supported GPU implementation, enable the [`gpu`](/modules/gpu/) module.
       summary: |
         NodeGroup {{ $labels.name }} uses the deprecated built-in GPU support.
       severity: "9"

--- a/modules/040-node-manager/hooks/metrics_gpu_in_core_deprecated.go
+++ b/modules/040-node-manager/hooks/metrics_gpu_in_core_deprecated.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This hook exports a metric for every NodeGroup that relies on the deprecated
+// built-in (in-core) GPU support: `spec.gpu` is set while the `gpu` module is disabled.
+
+package hooks
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook/metrics"
+	"github.com/flant/addon-operator/sdk"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/ptr"
+
+	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
+
+	ngv1 "github.com/deckhouse/deckhouse/modules/040-node-manager/hooks/internal/v1"
+)
+
+const (
+	gpuInCoreDeprecatedMetricName  = "d8_node_group_gpu_in_core_deprecated"
+	gpuInCoreDeprecatedMetricGroup = "d8_node_group_gpu_in_core_deprecated"
+	gpuInCoreDeprecatedSnapshot    = "gpu_nodegroups"
+	gpuModuleName                  = "gpu"
+)
+
+// Both triggers are required, they cover different inputs of the metric:
+//   - NodeGroup events, so that editing or removing `spec.gpu` is reflected right away;
+//   - OnAfterHelm, so that enabling or disabling the `gpu` module is reflected as well.
+//     The alert derived from this metric asks the operator to enable the `gpu` module,
+//     which only changes `global.enabledModules` and touches no NodeGroup, so without
+//     this binding the metric would never be expired and the alert would keep firing
+//     while asking to enable an already enabled module (and, symmetrically, disabling
+//     the module would not produce the metric until the next NodeGroup event).
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	Queue:       "/modules/node-manager",
+	OnAfterHelm: &go_hook.OrderedConfig{Order: 20},
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:                         gpuInCoreDeprecatedSnapshot,
+			ExecuteHookOnSynchronization: ptr.To(true),
+			ApiVersion:                   "deckhouse.io/v1",
+			Kind:                         "NodeGroup",
+			FilterFunc:                   filterNodeGroupGPUUsage,
+		},
+	},
+}, handleGPUInCoreDeprecatedMetrics)
+
+type nodeGroupGPUUsage struct {
+	Name   string `json:"name"`
+	HasGPU bool   `json:"hasGPU"`
+}
+
+func filterNodeGroupGPUUsage(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	var nodeGroup ngv1.NodeGroup
+	if err := sdk.FromUnstructured(obj, &nodeGroup); err != nil {
+		return nil, err
+	}
+
+	return nodeGroupGPUUsage{
+		Name:   nodeGroup.Name,
+		HasGPU: !nodeGroup.Spec.GPU.IsEmpty(),
+	}, nil
+}
+
+// isGPUModuleEnabled repeats the check used by the GPU labeling hook (see gpu_enabled.go),
+// so that the metric and the labeling never disagree on whether the module is enabled.
+func isGPUModuleEnabled(input *go_hook.HookInput) bool {
+	if !input.Values.Exists("global.enabledModules") {
+		return false
+	}
+
+	for _, module := range input.Values.Get("global.enabledModules").Array() {
+		if module.String() == gpuModuleName {
+			return true
+		}
+	}
+
+	return false
+}
+
+func handleGPUInCoreDeprecatedMetrics(_ context.Context, input *go_hook.HookInput) error {
+	// Expire on every run, so that metrics of deleted NodeGroups (or of NodeGroups
+	// that no longer declare `spec.gpu`) do not stick around.
+	input.MetricsCollector.Expire(gpuInCoreDeprecatedMetricGroup)
+
+	// The gpu module owns the GPU stack, in-core support stays idle - nothing to report.
+	if isGPUModuleEnabled(input) {
+		return nil
+	}
+
+	for ng, err := range sdkobjectpatch.SnapshotIter[nodeGroupGPUUsage](input.Snapshots.Get(gpuInCoreDeprecatedSnapshot)) {
+		if err != nil {
+			return fmt.Errorf("failed to iterate over '%s' snapshots: %w", gpuInCoreDeprecatedSnapshot, err)
+		}
+
+		if !ng.HasGPU {
+			continue
+		}
+
+		input.MetricsCollector.Set(
+			gpuInCoreDeprecatedMetricName,
+			1,
+			map[string]string{"name": ng.Name},
+			metrics.WithGroup(gpuInCoreDeprecatedMetricGroup),
+		)
+	}
+
+	return nil
+}

--- a/modules/040-node-manager/hooks/metrics_gpu_in_core_deprecated_test.go
+++ b/modules/040-node-manager/hooks/metrics_gpu_in_core_deprecated_test.go
@@ -1,0 +1,272 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/ptr"
+
+	"github.com/deckhouse/deckhouse/pkg/metrics-storage/operation"
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+const (
+	gpuInCoreNGsYaml = `
+---
+apiVersion: deckhouse.io/v1
+kind: NodeGroup
+metadata:
+  name: worker-gpu
+spec:
+  gpu:
+    sharing: time-slicing
+  nodeType: Static
+---
+apiVersion: deckhouse.io/v1
+kind: NodeGroup
+metadata:
+  name: worker
+spec:
+  nodeType: Static
+`
+	gpuInCoreNGWithoutGPUYaml = `
+---
+apiVersion: deckhouse.io/v1
+kind: NodeGroup
+metadata:
+  name: worker
+spec:
+  nodeType: Static
+`
+	gpuInCoreMigNGYaml = `
+---
+apiVersion: deckhouse.io/v1
+kind: NodeGroup
+metadata:
+  name: worker-gpu-mig
+spec:
+  gpu:
+    sharing: mig
+    mig:
+      partedConfig: all-1g.5gb
+  nodeType: Static
+`
+)
+
+var _ = Describe("Modules :: nodeManager :: hooks :: metrics_gpu_in_core_deprecated ::", func() {
+	f := HookExecutionConfigInit(`{}`, `{}`)
+	var nodeGroupResource = schema.GroupVersionResource{Group: "deckhouse.io", Version: "v1", Resource: "nodegroups"}
+	f.RegisterCRD(nodeGroupResource.Group, nodeGroupResource.Version, "NodeGroup", false)
+
+	expireOnly := func() operation.MetricOperation {
+		return operation.MetricOperation{
+			Group:  "d8_node_group_gpu_in_core_deprecated",
+			Action: operation.ActionExpireMetrics,
+		}
+	}
+
+	deprecatedMetric := func(name string) operation.MetricOperation {
+		return operation.MetricOperation{
+			Name:   "d8_node_group_gpu_in_core_deprecated",
+			Group:  "d8_node_group_gpu_in_core_deprecated",
+			Action: operation.ActionGaugeSet,
+			Value:  ptr.To(1.0),
+			Labels: map[string]string{"name": name},
+		}
+	}
+
+	Context("Hook bindings", func() {
+		It("Must be triggered both by NodeGroup events and by OnAfterHelm", func() {
+			Expect(f.GoHook).NotTo(BeNil())
+
+			config := f.GoHook.GetConfig()
+			// Without this binding, enabling or disabling the `gpu` module (which changes
+			// global.enabledModules only) would never re-run the hook, so the metric would
+			// never be expired and the alert would keep asking to enable an enabled module.
+			Expect(config.OnAfterHelm).NotTo(BeNil())
+			Expect(config.Kubernetes).To(HaveLen(1))
+			Expect(config.Kubernetes[0].Kind).To(Equal("NodeGroup"))
+		})
+	})
+
+	Context("An empty cluster", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(``))
+			f.RunGoHook()
+		})
+
+		It("Must expire the metric group and export nothing", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			m := f.MetricsCollector.CollectedMetrics()
+			Expect(m).To(HaveLen(1))
+			Expect(m[0]).To(BeEquivalentTo(expireOnly()))
+		})
+	})
+
+	Context("NodeGroup with spec.gpu and the gpu module is disabled", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global.enabledModules", []byte(`["vertical-pod-autoscaler", "prometheus"]`))
+			f.BindingContexts.Set(f.KubeStateSet(gpuInCoreNGsYaml))
+			f.RunGoHook()
+		})
+
+		It("Must export the metric only for the GPU NodeGroup", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			m := f.MetricsCollector.CollectedMetrics()
+			Expect(m).To(HaveLen(2))
+			Expect(m[0]).To(BeEquivalentTo(expireOnly()))
+			Expect(m[1]).To(BeEquivalentTo(deprecatedMetric("worker-gpu")))
+		})
+	})
+
+	Context("MIG NodeGroup without spec.gpu.sharing and the gpu module is disabled", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global.enabledModules", []byte(`[]`))
+			f.BindingContexts.Set(f.KubeStateSet(gpuInCoreMigNGYaml))
+			f.RunGoHook()
+		})
+
+		It("Must export the metric for the MIG NodeGroup", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			m := f.MetricsCollector.CollectedMetrics()
+			Expect(m).To(HaveLen(2))
+			Expect(m[0]).To(BeEquivalentTo(expireOnly()))
+			Expect(m[1]).To(BeEquivalentTo(deprecatedMetric("worker-gpu-mig")))
+		})
+	})
+
+	Context("NodeGroup with spec.gpu and the gpu module is enabled", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global.enabledModules", []byte(`["gpu"]`))
+			f.BindingContexts.Set(f.KubeStateSet(gpuInCoreNGsYaml))
+			f.RunGoHook()
+		})
+
+		It("Must export no metrics", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			m := f.MetricsCollector.CollectedMetrics()
+			Expect(m).To(HaveLen(1))
+			Expect(m[0]).To(BeEquivalentTo(expireOnly()))
+		})
+	})
+
+	Context("NodeGroup with spec.gpu and the gpu module is enabled among other modules", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global.enabledModules", []byte(`["vertical-pod-autoscaler", "gpu", "prometheus"]`))
+			f.BindingContexts.Set(f.KubeStateSet(gpuInCoreNGsYaml))
+			f.RunGoHook()
+		})
+
+		It("Must export no metrics", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			m := f.MetricsCollector.CollectedMetrics()
+			Expect(m).To(HaveLen(1))
+			Expect(m[0]).To(BeEquivalentTo(expireOnly()))
+		})
+	})
+
+	Context("NodeGroups without spec.gpu and the gpu module is disabled", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global.enabledModules", []byte(`["prometheus"]`))
+			f.BindingContexts.Set(f.KubeStateSet(gpuInCoreNGWithoutGPUYaml))
+			f.RunGoHook()
+		})
+
+		It("Must export no metrics", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			m := f.MetricsCollector.CollectedMetrics()
+			Expect(m).To(HaveLen(1))
+			Expect(m[0]).To(BeEquivalentTo(expireOnly()))
+		})
+	})
+
+	Context("The gpu module is enabled between two hook runs", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global.enabledModules", []byte(`["prometheus"]`))
+			f.BindingContexts.Set(f.KubeStateSet(gpuInCoreNGsYaml))
+			f.RunGoHook()
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.MetricsCollector.CollectedMetrics()).To(HaveLen(2))
+
+			// Enabling the module changes global.enabledModules only, no NodeGroup is
+			// touched, so the metric may only be expired thanks to the OnAfterHelm binding.
+			f.ValuesSetFromYaml("global.enabledModules", []byte(`["prometheus", "gpu"]`))
+			f.BindingContexts.Set(f.GenerateAfterHelmContext())
+			f.RunGoHook()
+		})
+
+		It("Must expire the metric group and export nothing", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			m := f.MetricsCollector.CollectedMetrics()
+			Expect(m).To(HaveLen(1))
+			Expect(m[0]).To(BeEquivalentTo(expireOnly()))
+		})
+	})
+
+	Context("The gpu module is disabled between two hook runs", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global.enabledModules", []byte(`["prometheus", "gpu"]`))
+			f.BindingContexts.Set(f.KubeStateSet(gpuInCoreNGsYaml))
+			f.RunGoHook()
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.MetricsCollector.CollectedMetrics()).To(HaveLen(1))
+
+			f.ValuesSetFromYaml("global.enabledModules", []byte(`["prometheus"]`))
+			f.BindingContexts.Set(f.GenerateAfterHelmContext())
+			f.RunGoHook()
+		})
+
+		It("Must export the metric for the GPU NodeGroup again", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			m := f.MetricsCollector.CollectedMetrics()
+			Expect(m).To(HaveLen(2))
+			Expect(m[0]).To(BeEquivalentTo(expireOnly()))
+			Expect(m[1]).To(BeEquivalentTo(deprecatedMetric("worker-gpu")))
+		})
+	})
+
+	Context("GPU NodeGroup is deleted", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global.enabledModules", []byte(`["prometheus"]`))
+			f.BindingContexts.Set(f.KubeStateSet(gpuInCoreNGsYaml))
+			f.RunGoHook()
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.MetricsCollector.CollectedMetrics()).To(HaveLen(2))
+
+			f.BindingContexts.Set(f.KubeStateSet(gpuInCoreNGWithoutGPUYaml))
+			f.RunGoHook()
+		})
+
+		It("Must expire the metric group and export nothing", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			m := f.MetricsCollector.CollectedMetrics()
+			Expect(m).To(HaveLen(1))
+			Expect(m[0]).To(BeEquivalentTo(expireOnly()))
+		})
+	})
+})

--- a/modules/040-node-manager/monitoring/prometheus-rules/node-group-deprecate.yaml
+++ b/modules/040-node-manager/monitoring/prometheus-rules/node-group-deprecate.yaml
@@ -18,3 +18,24 @@
 
         To resolve this issue, delete the field from NodeGroup {{ $labels.name }}.
         This is safe, as the setting has already been migrated automatically.
+- name: d8.node-group-gpu-in-core
+  rules:
+  - alert: NodeGroupUsesDeprecatedInCoreGPU
+    expr: |
+      max by (name) (d8_node_group_gpu_in_core_deprecated) > 0
+    for: 15m
+    labels:
+      tier: cluster
+      severity_level: "9"
+    annotations:
+      plk_markup_format: markdown
+      plk_protocol_version: "1"
+      plk_create_group_if_not_exists__cluster_has_node_groups_deprecation_alerts: "NodeGroupsDeprecationAlerts,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+      plk_grouped_by__cluster_has_node_groups_deprecation_alerts: "NodeGroupsDeprecationAlerts,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+      summary: NodeGroup {{ $labels.name }} uses the deprecated built-in GPU support.
+      description: |
+        NodeGroup {{ $labels.name }} has `spec.gpu` configured while the `gpu` module is disabled,
+        so its GPU nodes are served by the built-in GPU support.
+        Built-in GPU support is deprecated and will be removed.
+
+        The `gpu` module must be enabled.

--- a/modules/040-node-manager/monitoring/prometheus-rules/node-group-deprecate.yaml
+++ b/modules/040-node-manager/monitoring/prometheus-rules/node-group-deprecate.yaml
@@ -34,8 +34,8 @@
       plk_grouped_by__cluster_has_node_groups_deprecation_alerts: "NodeGroupsDeprecationAlerts,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
       summary: NodeGroup {{ $labels.name }} uses the deprecated built-in GPU support.
       description: |
-        NodeGroup {{ $labels.name }} has `spec.gpu` configured while the `gpu` module is disabled,
-        so its GPU nodes are served by the built-in GPU support.
-        Built-in GPU support is deprecated and will be removed.
+        NodeGroup `{{ $labels.name }}` has [`spec.gpu`](/modules/node-manager/cr.html#nodegroup-v1-spec-gpu) configured while the `gpu` module is disabled.
+        As a result, GPU nodes in the NodeGroup use the built-in GPU support,
+        which is deprecated and will be removed in a future DKP release.
 
-        The `gpu` module must be enabled.
+        To use the supported GPU implementation, enable the [`gpu`](/modules/gpu/) module.


### PR DESCRIPTION
## Description

Reduces the in-tree GPU node preparation (`NodeGroup.spec.gpu` without the `gpu` module) to
a non-blocking minimum, and adds a deprecation alert for it. Six files, +593/−54.

`candi/bashible/common-steps/all/006_check_gpu.sh.tpl`:

- every failure path now exits 0 and only reports through the log. The step used to `exit 1`
  on five branches whose prerequisites are external to Deckhouse — the NVIDIA driver, the
  container toolkit, device readiness, DKMS after a kernel change;
- every `nvidia-smi` call is bounded with `timeout -k`. Plain `timeout` only sends SIGTERM
  and then keeps waiting, which a process wedged in a driver ioctl ignores, so the call was
  not actually bounded;
- the compute capability comparison no longer uses `bc` (pure-shell integer comparison), the
  validation pattern accepts both two- and three-component driver versions, and
  "cannot parse the value" and "value is below the minimum" are now distinct messages;
- a PCI gate keeps the step silent on a node without an NVIDIA display controller.

`candi/bashible/common-steps/all/032_configure_containerd.sh.tpl`:

- the containerd default runtime is resolved at run time and falls back to `runc` while
  `/usr/bin/nvidia-container-runtime` is absent;
- `net.core.bpf_jit_harden=1` is persisted in an own `/etc/sysctl.d` drop-in instead of
  editing distribution-owned files that may not exist; `/etc/sysctl.conf` is still fixed up
  conditionally, because procps applies it after all drop-in directories and RED OS ships the
  hardened value there.

`modules/040-node-manager`:

- new hook exporting `d8_node_group_gpu_in_core_deprecated` and the
  `NodeGroupUsesDeprecatedInCoreGPU` alert for NodeGroups that still use `spec.gpu` while the
  `gpu` module is disabled. The hook is bound to `OnAfterHelm` in addition to NodeGroup
  events, because enabling the module only changes `global.enabledModules` and would
  otherwise never expire the metric.

### Influence on critical cluster components

- **containerd on GPU nodes may be reconfigured and restarted.** If
  `/usr/bin/nvidia-container-runtime` is absent, the rendered config now selects `runc`
  instead of `nvidia` as the default runtime. On a node whose config previously selected
  `nvidia`, this is a config change, so the existing `containerd-config-file-changed` event
  fires and step 033 restarts containerd. This is the intended effect: with a missing binary
  as the default runtime, containerd cannot start **any** container on the node.
- **Non-GPU and CSE nodes are not affected.** The rendered `/etc/containerd/config.toml` is
  byte-identical to the previous version for ContainerdV1/V2 on non-GPU nodes and on CSE,
  with and without the toolkit present.
- No changes to ingress controllers, control-plane or Prometheus.
- Node convergence behaviour changes for GPU nodes: a GPU problem no longer stops a node
  from converging.

## Why do we need it, and what problem does it solve?

The in-tree GPU check ran as bashible step 006, long before kubelet, and failed the whole
run on any problem. bashible aborts a run on a failing step and retries it forever, so a GPU
problem blocked CRI configuration, kubelet and every other module's
NodeGroupConfiguration on that node.

The consequences are not limited to GPU functionality. Since every later step is skipped, a
node that trips the check never configures kubelet, never finishes bootstrap or an update,
and never applies the node configuration of unrelated modules. A GPU driver broken by a
kernel upgrade is therefore enough to leave a storage module's kernel module uninstalled on
that node, after which replicated volumes stop being attached and the workloads using them
lose their data volumes.

The visible symptom is a node stuck in `UPDATING` and an unrelated subsystem failing on it,
which points an investigation away from the GPU check.

Two more failures of the same class are fixed here:

- the compute capability check compared values with `bc -l`. `bc` is not among the mandatory
  packages and is missing on several supported distributions, so the substitution was empty,
  `(( ))` received an empty string and every GPU was declared unsupported. A healthy H100
  failed with `bc: command not found` followed by a misleading `compute_cap 9.0 is invalid`,
  and the node stopped converging;
- the GPU branch of step 032 edited `/etc/sysctl.d/99-sysctl.conf` and `/etc/sysctl.conf`
  in place with `sed -i`. Neither file exists on many distributions, so the step failed with
  `sed: can't read ...: No such file or directory` and was retried forever. The edit was also
  unreliable when the file did exist: without a literal `net.core.bpf_jit_harden = 2` line
  `sed` succeeded and the value was never persisted.

The in-tree GPU path is deprecated and is replaced by the `gpu` module, but until it is
removed it must not be able to take a node or a cluster down. The new alert makes clusters
still using it visible, since that is the path where these defects live.

## Why do we need it in the patch release (if we do)?

Yes, the three convergence-blocking fixes are worth backporting: each of them can stop a node
from converging indefinitely, which also blocks the node configuration of every other module
on that node. Observed on 1.76.x.

The deprecation alert is safe to backport together with them: it only adds a metric and an
alerting rule and changes no behaviour, and the sooner clusters still on the deprecated path
become visible, the better.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: candi
type: fix
summary: A GPU problem no longer blocks node convergence.
impact: >
  On a NodeGroup with `spec.gpu`, a failing GPU check used to abort the bashible run and be
  retried forever, so the node never configured kubelet and never received updates from any
  other module. Such a node now converges and only its GPU stays unusable.
  If `/usr/bin/nvidia-container-runtime` is absent, containerd is now configured with `runc`
  as the default runtime instead of `nvidia`; on a node whose configuration previously
  selected `nvidia` this changes the containerd config and therefore restarts containerd.
  Previously such a node could not start any container at all.
impact_level: high
---
section: candi
type: fix
summary: GPU compute capability check no longer requires `bc`.
---
section: candi
type: fix
summary: Persist `net.core.bpf_jit_harden` for GPU nodes in an own sysctl drop-in instead of editing distribution files that may be absent.
---
section: node-manager
type: feature
summary: Alert when a NodeGroup uses the deprecated built-in GPU support while the `gpu` module is disabled.
```
