### PR TITLE
[docs] Fix encoding for conformance file reads

### DIFF
--- a/docs/documentation/_plugins/kubernetes_conformance_generator.rb
+++ b/docs/documentation/_plugins/kubernetes_conformance_generator.rb
@@ -37,7 +37,7 @@ module KubernetesConformance
       readme_path = File.join(conformance_dir, filename)
       return '' unless File.file?(readme_path)
 
-      demote_markdown_headings(File.read(readme_path))
+      demote_markdown_headings(File.read(readme_path, encoding: 'UTF-8'))
     end
 
     def demote_markdown_headings(markdown)


### PR DESCRIPTION
## Description

This pull request makes a small improvement to file reading in the Kubernetes conformance documentation generator by explicitly specifying UTF-8 encoding when reading files. This ensures correct handling of non-ASCII characters in documentation files.

* Updated `conformance_readme` in `kubernetes_conformance_generator.rb` to read files with UTF-8 encoding, improving support for international characters.

Fixes: https://github.com/deckhouse/deckhouse/pull/21845

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: fix
summary: Fix encoding for conformance file reads.
impact_level: low
```
