### PR TITLE
[deckhouse] Run a single package cleanup before the controllers start

### DIFF
--- a/deckhouse-controller/internal/controller/controller.go
+++ b/deckhouse-controller/internal/controller/controller.go
@@ -354,6 +354,12 @@ func (c *Controller) Start(ctx context.Context) error {
 		return fmt.Errorf("sync modules: %w", err)
 	}
 
+	// loadModules below enqueues downloads straight away, so this is the last point at which
+	// dropping stale package state cannot race a deploy. A leak must not stop the tree loading.
+	if err := c.cleanupPackages(ctx, modules); err != nil {
+		c.logger.Warn("failed to cleanup packages", log.Err(err))
+	}
+
 	if err := c.loadModules(ctx, modules); err != nil {
 		return fmt.Errorf("load modules: %w", err)
 	}

--- a/deckhouse-controller/internal/controller/controller.go
+++ b/deckhouse-controller/internal/controller/controller.go
@@ -355,7 +355,8 @@ func (c *Controller) Start(ctx context.Context) error {
 	}
 
 	// loadModules below enqueues downloads straight away, so this is the last point at which
-	// dropping stale package state cannot race a deploy. A leak must not stop the tree loading.
+	// dropping stale package state cannot race a deploy — as long as this manager registers no
+	// reconciler that deploys on its own. A leak must not stop the tree loading.
 	if err := c.cleanupPackages(ctx, modules); err != nil {
 		c.logger.Warn("failed to cleanup packages", log.Err(err))
 	}

--- a/deckhouse-controller/internal/controller/sync.go
+++ b/deckhouse-controller/internal/controller/sync.go
@@ -462,8 +462,9 @@ func (c *Controller) loadModules(ctx context.Context, modules []v1alpha2.Module)
 }
 
 // cleanupPackages hands the runtime every package the cluster still claims, so it drops the rest.
-// A terminating instance is claimed too, unlike in loadModules: reclaiming it belongs to its own
-// teardown, and over-keeping is the safe direction for a pass that deletes.
+// A terminating instance is left out, as in loadModules: the runtime forgets its teardown across a
+// restart and never loads a terminating object, so the remover answers "nothing left to tear down"
+// and this pass is the last owner of its release.
 func (c *Controller) cleanupPackages(ctx context.Context, modules []v1alpha2.Module) error {
 	// this list decides what is deleted, so a lagging watch would read as an application gone
 	applications := new(v1alpha1.ApplicationList)
@@ -474,6 +475,10 @@ func (c *Controller) cleanupPackages(ctx context.Context, modules []v1alpha2.Mod
 	preserveApps := make([]pkgruntime.PreserveApplication, 0, len(applications.Items))
 	for i := range applications.Items {
 		application := &applications.Items[i]
+
+		if !application.DeletionTimestamp.IsZero() {
+			continue
+		}
 
 		preserveApps = append(preserveApps, pkgruntime.PreserveApplication{
 			Namespace:   application.Namespace,
@@ -487,6 +492,10 @@ func (c *Controller) cleanupPackages(ctx context.Context, modules []v1alpha2.Mod
 	preserveModules := make([]pkgruntime.PreserveModule, 0, len(modules))
 	for i := range modules {
 		module := &modules[i]
+
+		if !module.DeletionTimestamp.IsZero() {
+			continue
+		}
 
 		preserveModules = append(preserveModules, pkgruntime.PreserveModule{
 			Name:       module.Name,

--- a/deckhouse-controller/internal/controller/sync.go
+++ b/deckhouse-controller/internal/controller/sync.go
@@ -462,8 +462,8 @@ func (c *Controller) loadModules(ctx context.Context, modules []v1alpha2.Module)
 }
 
 // cleanupPackages hands the runtime every package the cluster still claims, so it drops the rest.
-// The modules are the ones this bootstrap settled on, and the applications are read here, so both
-// lists describe the same moment.
+// A terminating instance is claimed too, unlike in loadModules: reclaiming it belongs to its own
+// teardown, and over-keeping is the safe direction for a pass that deletes.
 func (c *Controller) cleanupPackages(ctx context.Context, modules []v1alpha2.Module) error {
 	// this list decides what is deleted, so a lagging watch would read as an application gone
 	applications := new(v1alpha1.ApplicationList)

--- a/deckhouse-controller/internal/controller/sync.go
+++ b/deckhouse-controller/internal/controller/sync.go
@@ -461,6 +461,44 @@ func (c *Controller) loadModules(ctx context.Context, modules []v1alpha2.Module)
 	return nil
 }
 
+// cleanupPackages hands the runtime every package the cluster still claims, so it drops the rest.
+// The modules are the ones this bootstrap settled on, and the applications are read here, so both
+// lists describe the same moment.
+func (c *Controller) cleanupPackages(ctx context.Context, modules []v1alpha2.Module) error {
+	// this list decides what is deleted, so a lagging watch would read as an application gone
+	applications := new(v1alpha1.ApplicationList)
+	if err := c.ctrl.GetAPIReader().List(ctx, applications); err != nil {
+		return fmt.Errorf("list applications: %w", err)
+	}
+
+	preserveApps := make([]pkgruntime.PreserveApplication, 0, len(applications.Items))
+	for i := range applications.Items {
+		application := &applications.Items[i]
+
+		preserveApps = append(preserveApps, pkgruntime.PreserveApplication{
+			Namespace:   application.Namespace,
+			Name:        application.Name,
+			PackageName: application.Spec.PackageName,
+			Repository:  application.Spec.PackageRepositoryName,
+			Version:     application.Spec.PackageVersion,
+		})
+	}
+
+	preserveModules := make([]pkgruntime.PreserveModule, 0, len(modules))
+	for i := range modules {
+		module := &modules[i]
+
+		preserveModules = append(preserveModules, pkgruntime.PreserveModule{
+			Name:       module.Name,
+			Repository: module.Spec.PackageRepositoryName,
+			Version:    module.Spec.PackageVersion,
+			Embedded:   module.IsEmbedded(),
+		})
+	}
+
+	return c.manager.CleanupV2(ctx, preserveApps, preserveModules)
+}
+
 // runtimeModule is what the runtime needs of a module: its identity, settings and enabled intent.
 func runtimeModule(module *v1alpha2.Module) pkgruntime.Module {
 	return pkgruntime.Module{

--- a/deckhouse-controller/internal/packages/nelm/service.go
+++ b/deckhouse-controller/internal/packages/nelm/service.go
@@ -509,31 +509,27 @@ func (s *Service) GetConversionWebhooks(ctx context.Context, namespace string, p
 
 // Cleanup uninstalls releases owned by this service (carrying the managed-by
 // annotation) whose name is not in keep. keep keys are "<namespace>/<release-name>".
-func (s *Service) Cleanup(ctx context.Context, keep map[string]struct{}, ignoreNamespaces ...string) {
+// One release failing to uninstall does not stop the others; every failure is returned.
+func (s *Service) Cleanup(ctx context.Context, keep map[string]struct{}) error {
 	releases, err := s.client.ListReleases(ctx, nelm.ListOptions{
 		Selector: map[string]string{managedByAnnotation: managedByAnnotationValue},
 	})
 	if err != nil {
-		s.logger.Warn("failed to list releases", log.Err(err))
-		return
+		return fmt.Errorf("list releases: %w", err)
 	}
 
+	var errs error
 	for _, r := range releases {
 		if _, alive := keep[r.Namespace+"/"+r.Name]; alive {
 			continue
 		}
 
-		if slices.Contains(ignoreNamespaces, r.Namespace) {
-			continue
-		}
-
 		if err = s.client.Delete(ctx, r.Namespace, r.Name); err != nil {
-			s.logger.Warn("failed to delete orphan release",
-				slog.String("namespace", r.Namespace),
-				slog.String("release", r.Name),
-				log.Err(err))
+			errs = errors.Join(errs, fmt.Errorf("delete orphan release '%s/%s': %w", r.Namespace, r.Name, err))
 		}
 	}
+
+	return errs
 }
 
 // shouldRunHelmUpgrade determines if a Helm upgrade is needed.

--- a/deckhouse-controller/internal/packages/nelm/service.go
+++ b/deckhouse-controller/internal/packages/nelm/service.go
@@ -510,7 +510,7 @@ func (s *Service) GetConversionWebhooks(ctx context.Context, namespace string, p
 // Cleanup uninstalls releases owned by this service (carrying the managed-by
 // annotation) whose name is not in keep. keep keys are "<namespace>/<release-name>".
 // One release failing to uninstall does not stop the others; every failure is returned.
-func (s *Service) Cleanup(ctx context.Context, keep map[string]struct{}) error {
+func (s *Service) Cleanup(ctx context.Context, keep map[string]struct{}, ignoreNamespaces ...string) error {
 	releases, err := s.client.ListReleases(ctx, nelm.ListOptions{
 		Selector: map[string]string{managedByAnnotation: managedByAnnotationValue},
 	})
@@ -521,6 +521,10 @@ func (s *Service) Cleanup(ctx context.Context, keep map[string]struct{}) error {
 	var errs error
 	for _, r := range releases {
 		if _, alive := keep[r.Namespace+"/"+r.Name]; alive {
+			continue
+		}
+
+		if slices.Contains(ignoreNamespaces, r.Namespace) {
 			continue
 		}
 

--- a/deckhouse-controller/internal/packages/runtime/runtime.go
+++ b/deckhouse-controller/internal/packages/runtime/runtime.go
@@ -747,6 +747,45 @@ func (r *Runtime) Stop() {
 	}
 }
 
+// PreservePackage identifies one installed Package instance to preserve during Cleanup.
+type PreservePackage struct {
+	PackageName string
+	Repository  string
+	Version     string
+
+	ReleaseName      string
+	ReleaseNamespace string
+}
+
+// Cleanup removes downloaded application packages on disk and orphan nelm
+// releases in the cluster that are not in preserves. Runs once during preflight.
+func (r *Runtime) Cleanup(ctx context.Context, preserves []PreservePackage) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	fsPreserve := make([]deployer.PreservePackage, 0, len(preserves))
+	keepReleases := make(map[string]struct{}, len(preserves))
+	for _, preserve := range preserves {
+		fsPreserve = append(fsPreserve, deployer.PreservePackage{
+			Name:       preserve.PackageName,
+			Repository: preserve.Repository,
+			Version:    preserve.Version,
+		})
+
+		keepReleases[preserve.ReleaseNamespace+"/"+preserve.ReleaseName] = struct{}{}
+	}
+
+	if err := r.appDeployer.Cleanup(ctx, fsPreserve); err != nil {
+		r.logger.Warn("cleanup apps failed", log.Err(err))
+		return
+	}
+
+	// do not cleanup modules namespace
+	if err := r.nelmService.Cleanup(ctx, keepReleases, app.NamespaceDeckhouse); err != nil {
+		r.logger.Warn("cleanup releases failed", log.Err(err))
+	}
+}
+
 // PreserveApplication identifies one installed application instance to preserve during CleanupV2.
 type PreserveApplication struct {
 	Namespace string
@@ -795,7 +834,7 @@ func (r *Runtime) CleanupV2(ctx context.Context, preserveApps []PreserveApplicat
 	}
 
 	// every release is kept by name now, so the Deckhouse namespace is no longer exempt
-	if err := r.nelmService.Cleanup(ctx, keepReleases(preserveApps, preserveModules)); err != nil {
+	if err := r.nelmService.Cleanup(ctx, releasePreserveKeys(preserveApps, preserveModules)); err != nil {
 		errs = errors.Join(errs, fmt.Errorf("cleanup releases: %w", err))
 	}
 
@@ -835,9 +874,9 @@ func modulePreservePackages(preserves []PreserveModule) []deployer.PreservePacka
 	return packages
 }
 
-// keepReleases returns the releases to keep, keyed "<namespace>/<release>". An embedded module is
-// kept here, unlike on disk: it owns a release as any other module does.
-func keepReleases(preserveApps []PreserveApplication, preserveModules []PreserveModule) map[string]struct{} {
+// releasePreserveKeys returns the releases to keep, keyed "<namespace>/<release>". An embedded
+// module is kept here, unlike on disk: it owns a release as any other module does.
+func releasePreserveKeys(preserveApps []PreserveApplication, preserveModules []PreserveModule) map[string]struct{} {
 	keep := make(map[string]struct{}, len(preserveApps)+len(preserveModules))
 
 	for _, preserve := range preserveApps {

--- a/deckhouse-controller/internal/packages/runtime/runtime.go
+++ b/deckhouse-controller/internal/packages/runtime/runtime.go
@@ -795,7 +795,9 @@ func (r *Runtime) CleanupV2(ctx context.Context, preserveApps []PreserveApplicat
 	}
 
 	// every release is kept by name now, so the Deckhouse namespace is no longer exempt
-	r.nelmService.Cleanup(ctx, keepReleases(preserveApps, preserveModules))
+	if err := r.nelmService.Cleanup(ctx, keepReleases(preserveApps, preserveModules)); err != nil {
+		errs = errors.Join(errs, fmt.Errorf("cleanup releases: %w", err))
+	}
 
 	return errs
 }

--- a/deckhouse-controller/internal/packages/runtime/runtime.go
+++ b/deckhouse-controller/internal/packages/runtime/runtime.go
@@ -16,6 +16,7 @@ package runtime
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"path/filepath"
@@ -746,41 +747,106 @@ func (r *Runtime) Stop() {
 	}
 }
 
-// PreservePackage identifies one installed Package instance to preserve during Cleanup.
-type PreservePackage struct {
+// PreserveApplication identifies one installed application instance to preserve during CleanupV2.
+type PreserveApplication struct {
+	Namespace string
+	Name      string
+
 	PackageName string
 	Repository  string
 	Version     string
-
-	ReleaseName      string
-	ReleaseNamespace string
 }
 
-// Cleanup removes downloaded application packages on disk and orphan nelm
-// releases in the cluster that are not in preserves. Runs once during preflight.
-func (r *Runtime) Cleanup(ctx context.Context, preserves []PreservePackage) {
+// PreserveModule identifies one installed module to preserve during CleanupV2. A module releases
+// under its own name in the Deckhouse namespace, and an embedded one owns such a release while
+// its package ships in the image, outside the deployer root.
+type PreserveModule struct {
+	Name       string
+	Repository string
+	Version    string
+
+	Embedded bool
+}
+
+// CleanupV2 removes package directories on disk — downloaded and mounted alike — and orphan nelm
+// releases in the cluster that no preserved application or module claims. Applications and modules
+// are passed apart because each deployer is scoped to its own root and a preserved package cannot
+// say which root it belongs to.
+//
+// Both lists are the whole desired state, so this runs once during bootstrap: after that state is
+// settled and before any package is deployed.
+func (r *Runtime) CleanupV2(ctx context.Context, preserveApps []PreserveApplication, preserveModules []PreserveModule) error {
+	// the image always ships modules, so an empty list is a state never read rather than one to act
+	// on — acting on it would drop every module on disk and uninstall every module release
+	if len(preserveModules) == 0 {
+		return errors.New("no module to preserve")
+	}
+
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	fsPreserve := make([]deployer.PreservePackage, 0, len(preserves))
-	keepReleases := make(map[string]struct{}, len(preserves))
+	var errs error
+	if err := r.appDeployer.Cleanup(ctx, appPreservePackages(preserveApps)); err != nil {
+		errs = errors.Join(errs, fmt.Errorf("cleanup application packages: %w", err))
+	}
+
+	if err := r.moduleDeployer.Cleanup(ctx, modulePreservePackages(preserveModules)); err != nil {
+		errs = errors.Join(errs, fmt.Errorf("cleanup module packages: %w", err))
+	}
+
+	// every release is kept by name now, so the Deckhouse namespace is no longer exempt
+	r.nelmService.Cleanup(ctx, keepReleases(preserveApps, preserveModules))
+
+	return errs
+}
+
+// appPreservePackages maps applications onto the packages the application deployer keys on.
+func appPreservePackages(preserves []PreserveApplication) []deployer.PreservePackage {
+	packages := make([]deployer.PreservePackage, 0, len(preserves))
 	for _, preserve := range preserves {
-		fsPreserve = append(fsPreserve, deployer.PreservePackage{
+		packages = append(packages, deployer.PreservePackage{
 			Name:       preserve.PackageName,
 			Repository: preserve.Repository,
 			Version:    preserve.Version,
 		})
-
-		keepReleases[preserve.ReleaseNamespace+"/"+preserve.ReleaseName] = struct{}{}
 	}
 
-	if err := r.appDeployer.Cleanup(ctx, fsPreserve); err != nil {
-		r.logger.Warn("cleanup apps failed", log.Err(err))
-		return
+	return packages
+}
+
+// modulePreservePackages does the same for modules, skipping the embedded ones: their packages sit
+// outside the deployer root, so the module deployer can drop nothing of theirs.
+func modulePreservePackages(preserves []PreserveModule) []deployer.PreservePackage {
+	packages := make([]deployer.PreservePackage, 0, len(preserves))
+	for _, preserve := range preserves {
+		if preserve.Embedded {
+			continue
+		}
+
+		packages = append(packages, deployer.PreservePackage{
+			Name:       preserve.Name,
+			Repository: preserve.Repository,
+			Version:    preserve.Version,
+		})
 	}
 
-	// do not cleanup modules namespace
-	r.nelmService.Cleanup(ctx, keepReleases, app.NamespaceDeckhouse)
+	return packages
+}
+
+// keepReleases returns the releases to keep, keyed "<namespace>/<release>". An embedded module is
+// kept here, unlike on disk: it owns a release as any other module does.
+func keepReleases(preserveApps []PreserveApplication, preserveModules []PreserveModule) map[string]struct{} {
+	keep := make(map[string]struct{}, len(preserveApps)+len(preserveModules))
+
+	for _, preserve := range preserveApps {
+		keep[preserve.Namespace+"/"+apps.BuildName(preserve.Namespace, preserve.Name)] = struct{}{}
+	}
+
+	for _, preserve := range preserveModules {
+		keep[app.NamespaceDeckhouse+"/"+preserve.Name] = struct{}{}
+	}
+
+	return keep
 }
 
 // GetStatus returns package status.

--- a/deckhouse-controller/pkg/controller/packages/application/controller.go
+++ b/deckhouse-controller/pkg/controller/packages/application/controller.go
@@ -75,7 +75,7 @@ func RegisterController(
 
 	r.init.Add(1)
 
-	// add preflight to gate reconciles on the module manager
+	// add preflight to set the cluster UUID
 	if err := runtime.Add(ctrlmanager.RunnableFunc(r.preflight)); err != nil {
 		return fmt.Errorf("add preflight: %w", err)
 	}
@@ -113,9 +113,10 @@ type packageManager interface {
 	RemoveApp(namespace, name string) bool
 	GetStatus(name string) packagestatus.Status
 	GetAppStatusQueue() workqueue.TypedRateLimitingInterface[string]
+	Cleanup(ctx context.Context, preserve []packageruntime.PreservePackage)
 }
 
-// preflight holds reconciles back until the module manager is inited.
+// preflight waits for the module manager and drops runtime state no Application claims.
 func (r *reconciler) preflight(ctx context.Context) error {
 	defer r.init.Done()
 
@@ -126,6 +127,33 @@ func (r *reconciler) preflight(ctx context.Context) error {
 	}); err != nil {
 		return fmt.Errorf("init module manager: %w", err)
 	}
+
+	appsList := new(v1alpha1.ApplicationList)
+	if err := r.client.List(ctx, appsList); err != nil {
+		return fmt.Errorf("list applications: %w", err)
+	}
+
+	preserve := make([]packageruntime.PreservePackage, 0, len(appsList.Items))
+	for _, app := range appsList.Items {
+		// An application already being deleted is not preserved. The runtime forgets its teardown
+		// across a restart, so handleDelete would find nothing left to tear down and release the
+		// finalizer; this cleanup is the last owner of the release, and skipping it here is what
+		// makes that answer true.
+		if !app.DeletionTimestamp.IsZero() {
+			continue
+		}
+
+		preserve = append(preserve, packageruntime.PreservePackage{
+			PackageName: app.Spec.PackageName,
+			Repository:  app.Spec.PackageRepositoryName,
+			Version:     app.Spec.PackageVersion,
+
+			ReleaseName:      apps.BuildName(app.Namespace, app.Name),
+			ReleaseNamespace: app.Namespace,
+		})
+	}
+
+	r.manager.Cleanup(ctx, preserve)
 
 	r.logger.Debug("controller is ready")
 

--- a/deckhouse-controller/pkg/controller/packages/application/controller.go
+++ b/deckhouse-controller/pkg/controller/packages/application/controller.go
@@ -75,7 +75,7 @@ func RegisterController(
 
 	r.init.Add(1)
 
-	// add preflight to set the cluster UUID
+	// add preflight to gate reconciles on the module manager
 	if err := runtime.Add(ctrlmanager.RunnableFunc(r.preflight)); err != nil {
 		return fmt.Errorf("add preflight: %w", err)
 	}
@@ -113,10 +113,9 @@ type packageManager interface {
 	RemoveApp(namespace, name string) bool
 	GetStatus(name string) packagestatus.Status
 	GetAppStatusQueue() workqueue.TypedRateLimitingInterface[string]
-	Cleanup(ctx context.Context, preserve []packageruntime.PreservePackage)
 }
 
-// preflight waits for the module manager and drops runtime state no Application claims.
+// preflight holds reconciles back until the module manager is inited.
 func (r *reconciler) preflight(ctx context.Context) error {
 	defer r.init.Done()
 
@@ -127,33 +126,6 @@ func (r *reconciler) preflight(ctx context.Context) error {
 	}); err != nil {
 		return fmt.Errorf("init module manager: %w", err)
 	}
-
-	appsList := new(v1alpha1.ApplicationList)
-	if err := r.client.List(ctx, appsList); err != nil {
-		return fmt.Errorf("list applications: %w", err)
-	}
-
-	preserve := make([]packageruntime.PreservePackage, 0, len(appsList.Items))
-	for _, app := range appsList.Items {
-		// An application already being deleted is not preserved. The runtime forgets its teardown
-		// across a restart, so handleDelete would find nothing left to tear down and release the
-		// finalizer; this cleanup is the last owner of the release, and skipping it here is what
-		// makes that answer true.
-		if !app.DeletionTimestamp.IsZero() {
-			continue
-		}
-
-		preserve = append(preserve, packageruntime.PreservePackage{
-			PackageName: app.Spec.PackageName,
-			Repository:  app.Spec.PackageRepositoryName,
-			Version:     app.Spec.PackageVersion,
-
-			ReleaseName:      apps.BuildName(app.Namespace, app.Name),
-			ReleaseNamespace: app.Namespace,
-		})
-	}
-
-	r.manager.Cleanup(ctx, preserve)
 
 	r.logger.Debug("controller is ready")
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

The Application controller preflight is the only cleanup today: it drops application package directories and orphan nelm releases, and skips the whole `d8-system` namespace so it will not uninstall module releases its application-only keep list cannot see. Module packages on disk are never dropped — `moduleDeployer.Cleanup` has no caller.

`Runtime.CleanupV2` is added next to it, taking preserved applications and modules as separate lists and dropping downloaded directories, mounted images and orphan nelm releases in one pass. The lists stay separate because each deployer is scoped to its own root and `deployer.PreservePackage` carries no root. Per-release keep keys replace the namespace exclusion. An embedded module is kept by release but not on disk: its package ships in the image. An empty module list is refused — the image always ships modules.

The call sits in the new deckhouse controller's `Start`, after `syncModules` settles the desired state and before `loadModules` enqueues the first download; a failure is logged and the bootstrap continues. The preflight cleanup is left untouched, so nothing calls `CleanupV2` until `internal/controller` gets a caller. `nelm.Service.Cleanup`, shared by both, now returns its failures instead of only logging them. The module deployer root is the path the legacy module symlink directory uses; re-check it before wiring a call site.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

The modulev2 controller needs the same cleanup, and two keep lists computed in two places cannot both be complete — the application-only list is why module releases had to be excluded by namespace.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: chore
summary: Run a single package cleanup before the controllers start
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->


