### PR TITLE
[istio] Fix istiod affinity in 1.25

### DIFF
--- a/modules/110-istio/template_tests/module_test.go
+++ b/modules/110-istio/template_tests/module_test.go
@@ -567,6 +567,15 @@ var _ = Describe("Module :: istio :: helm template :: main", func() {
 			Expect(istioV25.Field("metadata.name").String()).To(Equal(`v1x25x2`))
 			Expect(istioV25.Field("spec.values.meshConfig.rootNamespace").String()).To(Equal(`d8-istio`))
 			Expect(istioV25.Field("spec.values.global.proxy.image").String()).To(Equal(`registry.example.com@imageHash-istio-proxyv2V1x25x2`))
+			Expect(istioV25.Field("spec.values.pilot.affinity").String()).To(MatchYAML(`
+podAntiAffinity:
+  requiredDuringSchedulingIgnoredDuringExecution:
+  - labelSelector:
+      matchLabels:
+        app: istiod
+        istio.io/rev: v1x25x2
+    topologyKey: kubernetes.io/hostname
+`))
 
 			Expect(iopV21.Field("spec.revision").String()).To(Equal(`v1x21x6`))
 			Expect(iopV21.Field("spec.meshConfig.rootNamespace").String()).To(Equal(`d8-istio`))

--- a/modules/110-istio/templates/control-plane/iop/istios.yaml
+++ b/modules/110-istio/templates/control-plane/iop/istios.yaml
@@ -205,6 +205,7 @@ spec:
       autoscaleEnabled: false
       taint:
         enabled: false
+{{- include "helm_lib_pod_anti_affinity_for_ha" (list $ (dict "app" "istiod" "istio.io/rev" $revision)) | nindent 6 }}
       podAnnotations:
         istio-mtls-ca-bundle-checksum: {{ include "istioCABundleChecksum" $ }}
   {{- if eq $.Values.istio.controlPlane.replicasManagement.mode "Standard" }}


### PR DESCRIPTION
## Description

Add the Deckhouse high-availability pod anti-affinity configuration to `spec.values.pilot.affinity` in the Sail Operator `Istio` resource used for Istio 1.25. The rule prevents Istiod replicas of the same revision from being scheduled on the same node.

## Why do we need it, and what problem does it solve?

The legacy `IstioOperator` resource includes Deckhouse's standard HA pod anti-affinity, but the Sail Operator `Istio` resource introduced for Istio 1.25 did not pass that configuration through `spec.values.pilot.affinity`.

As a result, multiple Istiod replicas could be scheduled on the same node in an HA cluster, reducing control-plane fault tolerance. This change restores the expected behavior by requiring replicas of the same Istio revision to run on different nodes.

## Why do we need it in the patch release (if we do)?

The missing anti-affinity is an availability regression for Istio 1.25. Backporting the fix restores the HA scheduling guarantees that earlier Istio versions already receive.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: fix
summary: Restore Istiod pod anti-affinity for Istio 1.25 installations managed by the Sail Operator.
impact_level: default
```