### PR TITLE
[dhctl] apply CloudPermanent NodeGroups and instance classes before building nodes

### DIFF
--- a/dhctl/pkg/config/meta.go
+++ b/dhctl/pkg/config/meta.go
@@ -286,7 +286,9 @@ func requireNodeGroupReplicas(ng map[string]interface{}, name string) error {
 	if !ok {
 		return fmt.Errorf(
 			"NodeGroup %q is CloudPermanent but has no spec.cloudInstances.minPerZone: "+
-				"dhctl cannot tell how many nodes it must keep", name)
+				"dhctl cannot tell how many nodes it must keep. Set spec.cloudInstances.classReference "+
+				"and spec.cloudInstances.minPerZone on it, or re-apply the NodeGroup from your "+
+				"configuration; dhctl destroy does not need them and still works", name)
 	}
 	if replicas < 0 {
 		return fmt.Errorf(

--- a/dhctl/pkg/config/meta.go
+++ b/dhctl/pkg/config/meta.go
@@ -30,10 +30,10 @@ import (
 	"github.com/iancoleman/strcase"
 	"sigs.k8s.io/yaml"
 
+	proto "github.com/deckhouse/deckhouse/go_lib/dhctl-provider-protocol"
 	registry_const "github.com/deckhouse/deckhouse/go_lib/registry/const"
 	"github.com/deckhouse/deckhouse/go_lib/registry/models/initconfig"
 	"github.com/deckhouse/deckhouse/go_lib/registry/models/moduleconfig"
-	proto "github.com/deckhouse/deckhouse/go_lib/dhctl-provider-protocol"
 	dhlog "github.com/deckhouse/lib-dhctl/pkg/logger"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config/digests"

--- a/dhctl/pkg/config/meta.go
+++ b/dhctl/pkg/config/meta.go
@@ -28,7 +28,6 @@ import (
 	"strings"
 
 	"github.com/iancoleman/strcase"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/yaml"
 
 	registry_const "github.com/deckhouse/deckhouse/go_lib/registry/const"
@@ -598,73 +597,23 @@ func (m *MetaConfig) NodeGroupManifest(terraNodeGroup TerraNodeGroupSpec) map[st
 	if terraNodeGroup.NodeTemplate == nil {
 		terraNodeGroup.NodeTemplate = make(map[string]any)
 	}
-	spec := map[string]any{
-		"nodeType": "CloudPermanent",
-		"disruptions": map[string]any{
-			"approvalMode": "Manual",
-		},
-		"nodeTemplate": terraNodeGroup.NodeTemplate,
-	}
-	addCloudInstances(spec, m.cloudInstances(terraNodeGroup.Name))
-
+	// spec.cloudInstances is deliberately absent: in the mc-flow the NodeGroup
+	// from the user's resources is applied before this runs, and a JSON merge
+	// patch leaves keys it does not carry alone.
 	return map[string]any{
 		"apiVersion": "deckhouse.io/v1",
 		"kind":       "NodeGroup",
 		"metadata": map[string]any{
 			"name": terraNodeGroup.Name,
 		},
-		"spec": spec,
-	}
-}
-
-// MasterNodeGroupManifest prepares the control-plane NodeGroup custom resource.
-// Deckhouse's node-manager creates the same object if it is missing, but only
-// as bare metadata — see modules/040-node-manager/hooks/create_master_node_group.go.
-// dhctl writes it too so the mc-flow's cloudInstances is there from the start.
-func (m *MetaConfig) MasterNodeGroupManifest() map[string]any {
-	spec := map[string]any{
-		"nodeType": "CloudPermanent",
-		"disruptions": map[string]any{
-			"approvalMode": "Manual",
+		"spec": map[string]any{
+			"nodeType": "CloudPermanent",
+			"disruptions": map[string]any{
+				"approvalMode": "Manual",
+			},
+			"nodeTemplate": terraNodeGroup.NodeTemplate,
 		},
 	}
-	addCloudInstances(spec, m.cloudInstances(masterNodeGroupName))
-
-	return map[string]any{
-		"apiVersion": "deckhouse.io/v1",
-		"kind":       "NodeGroup",
-		"metadata": map[string]any{
-			"name": masterNodeGroupName,
-		},
-		"spec": spec,
-	}
-}
-
-func addCloudInstances(spec map[string]any, cloudInstances map[string]any) {
-	if len(cloudInstances) > 0 {
-		spec["cloudInstances"] = cloudInstances
-	}
-}
-
-// cloudInstances returns a deep copy of spec.cloudInstances of the named
-// CloudPermanent NodeGroup. It is the replica count and the instance class of
-// that group, and in the mc-flow the cluster object is the only place they are
-// kept — see applyNodeGroupReplicasFromCloudProviderVars, which reads them back
-// on every converge. Nil in the legacy ProviderClusterConfiguration flow, whose
-// NodeGroups never reach CloudProviderVars.
-func (m *MetaConfig) cloudInstances(nodeGroupName string) map[string]any {
-	if m.CloudProviderVars == nil {
-		return nil
-	}
-	ng, ok := m.CloudProviderVars.NodeGroups[nodeGroupName]
-	if !ok {
-		return nil
-	}
-	cloudInstances, found, err := unstructured.NestedMap(ng, "spec", "cloudInstances")
-	if err != nil || !found {
-		return nil
-	}
-	return cloudInstances
 }
 
 func (m *MetaConfig) MarshalFullConfig() []byte {

--- a/dhctl/pkg/config/meta.go
+++ b/dhctl/pkg/config/meta.go
@@ -236,15 +236,16 @@ func applyNodeGroupReplicasFromCloudProviderVars(m *MetaConfig) error {
 		return nil
 	}
 	// Only the mc-flow derives replicas from NodeGroups; the legacy flow reads
-	// them from its ProviderClusterConfiguration and its NodeGroups legitimately
-	// carry no cloudInstances at all.
-	mcFlow := len(m.ProviderClusterConfig) == 0
+	// them from its ProviderClusterConfiguration.
+	enforceReplicas := !m.HasLegacyProviderConfig()
 
-	if _, hasMaster := m.CloudProviderVars.NodeGroups[masterNodeGroupName]; hasMaster && m.MasterNodeGroupSpec.Replicas == 0 {
-		if err := requireCloudInstances(m.CloudProviderVars.NodeGroups, masterNodeGroupName, mcFlow); err != nil {
-			return err
+	if masterNg, hasMaster := m.CloudProviderVars.NodeGroups[masterNodeGroupName]; hasMaster && m.MasterNodeGroupSpec.Replicas == 0 {
+		if enforceReplicas {
+			if err := requireNodeGroupReplicas(masterNg, masterNodeGroupName); err != nil {
+				return err
+			}
 		}
-		if r := nodeGroupReplicas(m.CloudProviderVars.NodeGroups, masterNodeGroupName); r > 0 {
+		if r, ok := nodeGroupMinPerZone(masterNg); ok && r > 0 {
 			m.MasterNodeGroupSpec.Replicas = r
 		}
 	}
@@ -252,19 +253,17 @@ func applyNodeGroupReplicasFromCloudProviderVars(m *MetaConfig) error {
 		// Iterate over sorted names so the order of TerraNodeGroupSpecs
 		// is reproducible. Map iteration is randomised by the Go runtime;
 		// downstream state-hash comparisons see spurious drift otherwise.
-		//
-		// All non-master CloudPermanent NodeGroups (already filtered by
-		// IsCloudPermanentNodeGroup before reaching here) are emitted as
-		// TerraNodeGroupSpecs so converge keeps managing them.
 		for _, name := range sortedKeys(m.CloudProviderVars.NodeGroups) {
 			if name == masterNodeGroupName {
 				continue
 			}
-			if err := requireCloudInstances(m.CloudProviderVars.NodeGroups, name, mcFlow); err != nil {
-				return err
-			}
 			ng := m.CloudProviderVars.NodeGroups[name]
-			r := nodeGroupReplicas(m.CloudProviderVars.NodeGroups, name)
+			if enforceReplicas {
+				if err := requireNodeGroupReplicas(ng, name); err != nil {
+					return err
+				}
+			}
+			r, _ := nodeGroupMinPerZone(ng)
 			nodeTemplate, _ := nestedMap(ng, "spec", "nodeTemplate")
 			m.TerraNodeGroupSpecs = append(m.TerraNodeGroupSpecs, TerraNodeGroupSpec{
 				Name:         name,
@@ -277,40 +276,41 @@ func applyNodeGroupReplicasFromCloudProviderVars(m *MetaConfig) error {
 	return nil
 }
 
-// requireCloudInstances rejects a CloudPermanent NodeGroup that carries no
-// cloudInstances section. In the mc-flow that section is the only record of the
-// group's replica count, and a missing count reads back as zero, which converge
-// acts on by deleting every node of the group — the control plane included.
-func requireCloudInstances(ngs map[string]map[string]interface{}, name string, mcFlow bool) error {
-	if !mcFlow {
-		return nil
+// requireNodeGroupReplicas rejects a CloudPermanent NodeGroup no keepable node
+// count can be read from. Converge acts on a zero by deleting every node of the
+// group, so an unreadable count must stop it rather than be read as zero.
+func requireNodeGroupReplicas(ng map[string]interface{}, name string) error {
+	replicas, ok := nodeGroupMinPerZone(ng)
+	if !ok {
+		return fmt.Errorf(
+			"NodeGroup %q is CloudPermanent but has no spec.cloudInstances.minPerZone: "+
+				"dhctl cannot tell how many nodes it must keep", name)
 	}
-	if _, ok := nestedMap(ngs[name], "spec", "cloudInstances"); ok {
-		return nil
+	if name == masterNodeGroupName && replicas < 1 {
+		return fmt.Errorf(
+			"NodeGroup %q has spec.cloudInstances.minPerZone: %d: the control plane cannot be scaled to zero",
+			name, replicas)
 	}
-	return fmt.Errorf(
-		"NodeGroup %q is CloudPermanent but has no spec.cloudInstances: dhctl cannot tell how many nodes it must keep. "+
-			"Restore spec.cloudInstances.classReference and spec.cloudInstances.minPerZone on it before converging",
-		name)
+	return nil
 }
 
-// nodeGroupReplicas derives the replica count for a CloudPermanent NodeGroup
-// from spec.cloudInstances.minPerZone, which CloudPermanent NGs always set
-// (they are the only kind that reaches here — see IsCloudPermanentNodeGroup).
-// Returning zero is interpreted by MasterNodeGroupController as "scale to
-// zero", so the caller must explicitly guard the master NG against that
-// outcome.
-func nodeGroupReplicas(ngs map[string]map[string]interface{}, name string) int {
-	ng, ok := ngs[name]
+// nodeGroupMinPerZone reports the node count of a CloudPermanent NodeGroup and
+// whether it is set at all; an explicit zero and an absent value mean different
+// things to the caller.
+func nodeGroupMinPerZone(ng map[string]interface{}) (int, bool) {
+	cloudInstances, ok := nestedMap(ng, "spec", "cloudInstances")
 	if !ok {
-		return 0
+		return 0, false
 	}
-	if ci, ok := nestedMap(ng, "spec", "cloudInstances"); ok {
-		if r := toPositiveInt(ci["minPerZone"]); r > 0 {
-			return r
-		}
+	switch n := cloudInstances["minPerZone"].(type) {
+	case float64:
+		return int(n), true
+	case int64:
+		return int(n), true
+	case int:
+		return n, true
 	}
-	return 0
+	return 0, false
 }
 
 func sortedKeys(m map[string]map[string]interface{}) []string {
@@ -320,24 +320,6 @@ func sortedKeys(m map[string]map[string]interface{}) []string {
 	}
 	sort.Strings(keys)
 	return keys
-}
-
-func toPositiveInt(v interface{}) int {
-	switch n := v.(type) {
-	case float64:
-		if n > 0 {
-			return int(n)
-		}
-	case int64:
-		if n > 0 {
-			return int(n)
-		}
-	case int:
-		if n > 0 {
-			return n
-		}
-	}
-	return 0
 }
 
 func nestedMap(obj map[string]interface{}, path ...string) (map[string]interface{}, bool) {

--- a/dhctl/pkg/config/meta.go
+++ b/dhctl/pkg/config/meta.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 
 	"github.com/iancoleman/strcase"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/yaml"
 
 	registry_const "github.com/deckhouse/deckhouse/go_lib/registry/const"
@@ -180,7 +181,9 @@ func (m *MetaConfig) Prepare(ctx context.Context, validatorProvider MetaConfigVa
 	// typed fields stay zeroed and bootstrap creates neither the additional
 	// masters nor any CloudPermanent node. Re-entrant by the guards inside —
 	// check and converge re-run Prepare on a DeepCopy of a prepared config.
-	applyNodeGroupReplicasFromCloudProviderVars(m)
+	if err := applyNodeGroupReplicasFromCloudProviderVars(m); err != nil {
+		return nil, err
+	}
 
 	return validateProviderConfig(ctx, validatorProvider, m)
 }
@@ -229,11 +232,19 @@ func (m *MetaConfig) extractProviderClusterFields() error {
 // it is not supported in Deckhouse.
 const masterNodeGroupName = "master"
 
-func applyNodeGroupReplicasFromCloudProviderVars(m *MetaConfig) {
+func applyNodeGroupReplicasFromCloudProviderVars(m *MetaConfig) error {
 	if m.CloudProviderVars == nil {
-		return
+		return nil
 	}
+	// Only the mc-flow derives replicas from NodeGroups; the legacy flow reads
+	// them from its ProviderClusterConfiguration and its NodeGroups legitimately
+	// carry no cloudInstances at all.
+	mcFlow := len(m.ProviderClusterConfig) == 0
+
 	if _, hasMaster := m.CloudProviderVars.NodeGroups[masterNodeGroupName]; hasMaster && m.MasterNodeGroupSpec.Replicas == 0 {
+		if err := requireCloudInstances(m.CloudProviderVars.NodeGroups, masterNodeGroupName, mcFlow); err != nil {
+			return err
+		}
 		if r := nodeGroupReplicas(m.CloudProviderVars.NodeGroups, masterNodeGroupName); r > 0 {
 			m.MasterNodeGroupSpec.Replicas = r
 		}
@@ -250,6 +261,9 @@ func applyNodeGroupReplicasFromCloudProviderVars(m *MetaConfig) {
 			if name == masterNodeGroupName {
 				continue
 			}
+			if err := requireCloudInstances(m.CloudProviderVars.NodeGroups, name, mcFlow); err != nil {
+				return err
+			}
 			ng := m.CloudProviderVars.NodeGroups[name]
 			r := nodeGroupReplicas(m.CloudProviderVars.NodeGroups, name)
 			nodeTemplate, _ := nestedMap(ng, "spec", "nodeTemplate")
@@ -260,6 +274,25 @@ func applyNodeGroupReplicasFromCloudProviderVars(m *MetaConfig) {
 			})
 		}
 	}
+
+	return nil
+}
+
+// requireCloudInstances rejects a CloudPermanent NodeGroup that carries no
+// cloudInstances section. In the mc-flow that section is the only record of the
+// group's replica count, and a missing count reads back as zero, which converge
+// acts on by deleting every node of the group — the control plane included.
+func requireCloudInstances(ngs map[string]map[string]interface{}, name string, mcFlow bool) error {
+	if !mcFlow {
+		return nil
+	}
+	if _, ok := nestedMap(ngs[name], "spec", "cloudInstances"); ok {
+		return nil
+	}
+	return fmt.Errorf(
+		"NodeGroup %q is CloudPermanent but has no spec.cloudInstances: dhctl cannot tell how many nodes it must keep. "+
+			"Restore spec.cloudInstances.classReference and spec.cloudInstances.minPerZone on it before converging",
+		name)
 }
 
 // nodeGroupReplicas derives the replica count for a CloudPermanent NodeGroup
@@ -565,20 +598,73 @@ func (m *MetaConfig) NodeGroupManifest(terraNodeGroup TerraNodeGroupSpec) map[st
 	if terraNodeGroup.NodeTemplate == nil {
 		terraNodeGroup.NodeTemplate = make(map[string]any)
 	}
+	spec := map[string]any{
+		"nodeType": "CloudPermanent",
+		"disruptions": map[string]any{
+			"approvalMode": "Manual",
+		},
+		"nodeTemplate": terraNodeGroup.NodeTemplate,
+	}
+	addCloudInstances(spec, m.cloudInstances(terraNodeGroup.Name))
+
 	return map[string]any{
 		"apiVersion": "deckhouse.io/v1",
 		"kind":       "NodeGroup",
 		"metadata": map[string]any{
 			"name": terraNodeGroup.Name,
 		},
-		"spec": map[string]any{
-			"nodeType": "CloudPermanent",
-			"disruptions": map[string]any{
-				"approvalMode": "Manual",
-			},
-			"nodeTemplate": terraNodeGroup.NodeTemplate,
+		"spec": spec,
+	}
+}
+
+// MasterNodeGroupManifest prepares the control-plane NodeGroup custom resource.
+// Deckhouse's node-manager creates the same object if it is missing, but only
+// as bare metadata — see modules/040-node-manager/hooks/create_master_node_group.go.
+// dhctl writes it too so the mc-flow's cloudInstances is there from the start.
+func (m *MetaConfig) MasterNodeGroupManifest() map[string]any {
+	spec := map[string]any{
+		"nodeType": "CloudPermanent",
+		"disruptions": map[string]any{
+			"approvalMode": "Manual",
 		},
 	}
+	addCloudInstances(spec, m.cloudInstances(masterNodeGroupName))
+
+	return map[string]any{
+		"apiVersion": "deckhouse.io/v1",
+		"kind":       "NodeGroup",
+		"metadata": map[string]any{
+			"name": masterNodeGroupName,
+		},
+		"spec": spec,
+	}
+}
+
+func addCloudInstances(spec map[string]any, cloudInstances map[string]any) {
+	if len(cloudInstances) > 0 {
+		spec["cloudInstances"] = cloudInstances
+	}
+}
+
+// cloudInstances returns a deep copy of spec.cloudInstances of the named
+// CloudPermanent NodeGroup. It is the replica count and the instance class of
+// that group, and in the mc-flow the cluster object is the only place they are
+// kept — see applyNodeGroupReplicasFromCloudProviderVars, which reads them back
+// on every converge. Nil in the legacy ProviderClusterConfiguration flow, whose
+// NodeGroups never reach CloudProviderVars.
+func (m *MetaConfig) cloudInstances(nodeGroupName string) map[string]any {
+	if m.CloudProviderVars == nil {
+		return nil
+	}
+	ng, ok := m.CloudProviderVars.NodeGroups[nodeGroupName]
+	if !ok {
+		return nil
+	}
+	cloudInstances, found, err := unstructured.NestedMap(ng, "spec", "cloudInstances")
+	if err != nil || !found {
+		return nil
+	}
+	return cloudInstances
 }
 
 func (m *MetaConfig) MarshalFullConfig() []byte {

--- a/dhctl/pkg/config/meta.go
+++ b/dhctl/pkg/config/meta.go
@@ -287,8 +287,7 @@ func requireNodeGroupReplicas(ng map[string]interface{}, name string) error {
 		return fmt.Errorf(
 			"NodeGroup %q is CloudPermanent but has no spec.cloudInstances.minPerZone: "+
 				"dhctl cannot tell how many nodes it must keep. Set spec.cloudInstances.classReference "+
-				"and spec.cloudInstances.minPerZone on it, or re-apply the NodeGroup from your "+
-				"configuration; dhctl destroy does not need them and still works", name)
+				"and spec.cloudInstances.minPerZone on it, or re-apply the NodeGroup from your configuration", name)
 	}
 	if replicas < 0 {
 		return fmt.Errorf(

--- a/dhctl/pkg/config/meta.go
+++ b/dhctl/pkg/config/meta.go
@@ -33,6 +33,7 @@ import (
 	registry_const "github.com/deckhouse/deckhouse/go_lib/registry/const"
 	"github.com/deckhouse/deckhouse/go_lib/registry/models/initconfig"
 	"github.com/deckhouse/deckhouse/go_lib/registry/models/moduleconfig"
+	proto "github.com/deckhouse/deckhouse/go_lib/dhctl-provider-protocol"
 	dhlog "github.com/deckhouse/lib-dhctl/pkg/logger"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config/digests"
@@ -235,9 +236,10 @@ func applyNodeGroupReplicasFromCloudProviderVars(m *MetaConfig) error {
 	if m.CloudProviderVars == nil {
 		return nil
 	}
-	// Only the mc-flow derives replicas from NodeGroups; the legacy flow reads
-	// them from its ProviderClusterConfiguration.
-	enforceReplicas := !m.HasLegacyProviderConfig()
+	// Only the mc-flow derives replicas from NodeGroups, and only an operation
+	// that acts on the count needs them: destroy removes the nodes anyway, and
+	// must stay possible on a cluster whose count is unreadable.
+	enforceReplicas := !m.HasLegacyProviderConfig() && m.Operation != proto.OperationDestroy
 
 	if masterNg, hasMaster := m.CloudProviderVars.NodeGroups[masterNodeGroupName]; hasMaster && m.MasterNodeGroupSpec.Replicas == 0 {
 		if enforceReplicas {

--- a/dhctl/pkg/config/meta.go
+++ b/dhctl/pkg/config/meta.go
@@ -592,28 +592,42 @@ func (m *MetaConfig) ExtractMasterNodeGroupStaticSettings(ctx context.Context) m
 	return static
 }
 
-// NodeGroupManifest prepares NodeGroup custom resource for static nodes, which were ordered by infrastructure utility
+// NodeGroupManifest prepares NodeGroup custom resource for static nodes, which were ordered by infrastructure utility.
+// Applied as a merge patch over the user's NodeGroup, so it carries neither
+// cloudInstances nor an approvalMode the user already chose.
 func (m *MetaConfig) NodeGroupManifest(terraNodeGroup TerraNodeGroupSpec) map[string]any {
 	if terraNodeGroup.NodeTemplate == nil {
 		terraNodeGroup.NodeTemplate = make(map[string]any)
 	}
-	// spec.cloudInstances is deliberately absent: in the mc-flow the NodeGroup
-	// from the user's resources is applied before this runs, and a JSON merge
-	// patch leaves keys it does not carry alone.
+
+	spec := map[string]any{
+		"nodeType":     "CloudPermanent",
+		"nodeTemplate": terraNodeGroup.NodeTemplate,
+	}
+	if !m.nodeGroupSetsApprovalMode(terraNodeGroup.Name) {
+		spec["disruptions"] = map[string]any{"approvalMode": "Manual"}
+	}
+
 	return map[string]any{
 		"apiVersion": "deckhouse.io/v1",
 		"kind":       "NodeGroup",
 		"metadata": map[string]any{
 			"name": terraNodeGroup.Name,
 		},
-		"spec": map[string]any{
-			"nodeType": "CloudPermanent",
-			"disruptions": map[string]any{
-				"approvalMode": "Manual",
-			},
-			"nodeTemplate": terraNodeGroup.NodeTemplate,
-		},
+		"spec": spec,
 	}
+}
+
+func (m *MetaConfig) nodeGroupSetsApprovalMode(nodeGroupName string) bool {
+	if m.CloudProviderVars == nil {
+		return false
+	}
+	disruptions, ok := nestedMap(m.CloudProviderVars.NodeGroups[nodeGroupName], "spec", "disruptions")
+	if !ok {
+		return false
+	}
+	mode, _ := disruptions["approvalMode"].(string)
+	return mode != ""
 }
 
 func (m *MetaConfig) MarshalFullConfig() []byte {

--- a/dhctl/pkg/config/meta.go
+++ b/dhctl/pkg/config/meta.go
@@ -286,6 +286,11 @@ func requireNodeGroupReplicas(ng map[string]interface{}, name string) error {
 			"NodeGroup %q is CloudPermanent but has no spec.cloudInstances.minPerZone: "+
 				"dhctl cannot tell how many nodes it must keep", name)
 	}
+	if replicas < 0 {
+		return fmt.Errorf(
+			"NodeGroup %q has spec.cloudInstances.minPerZone: %d: it cannot be negative",
+			name, replicas)
+	}
 	if name == masterNodeGroupName && replicas < 1 {
 		return fmt.Errorf(
 			"NodeGroup %q has spec.cloudInstances.minPerZone: %d: the control plane cannot be scaled to zero",

--- a/dhctl/pkg/config/meta.go
+++ b/dhctl/pkg/config/meta.go
@@ -236,13 +236,13 @@ func applyNodeGroupReplicasFromCloudProviderVars(m *MetaConfig) error {
 	if m.CloudProviderVars == nil {
 		return nil
 	}
-	// Only the mc-flow derives replicas from NodeGroups, and only an operation
-	// that acts on the count needs them: destroy removes the nodes anyway, and
-	// must stay possible on a cluster whose count is unreadable.
-	enforceReplicas := !m.HasLegacyProviderConfig() && m.Operation != proto.OperationDestroy
+	// Only a flow that reads the count from the NodeGroups needs it known, and only
+	// an operation that acts on it: legacy takes it from ProviderClusterConfiguration,
+	// destroy removes the nodes regardless and must stay possible.
+	mustKnowNodeCount := !m.HasLegacyProviderConfig() && m.Operation != proto.OperationDestroy
 
 	if masterNg, hasMaster := m.CloudProviderVars.NodeGroups[masterNodeGroupName]; hasMaster && m.MasterNodeGroupSpec.Replicas == 0 {
-		if enforceReplicas {
+		if mustKnowNodeCount {
 			if err := requireNodeGroupReplicas(masterNg, masterNodeGroupName); err != nil {
 				return err
 			}
@@ -260,7 +260,7 @@ func applyNodeGroupReplicasFromCloudProviderVars(m *MetaConfig) error {
 				continue
 			}
 			ng := m.CloudProviderVars.NodeGroups[name]
-			if enforceReplicas {
+			if mustKnowNodeCount {
 				if err := requireNodeGroupReplicas(ng, name); err != nil {
 					return err
 				}

--- a/dhctl/pkg/config/meta_test.go
+++ b/dhctl/pkg/config/meta_test.go
@@ -875,3 +875,15 @@ func TestPrepareGuardIsOffForDestroy(t *testing.T) {
 	_, err := m.Prepare(t.Context(), DummyValidatorProvider())
 	require.NoError(t, err)
 }
+
+// The guard blocks converge and check, so its message has to carry the way out.
+func TestPrepareGuardErrorNamesTheRemedy(t *testing.T) {
+	m := cloudMetaConfig("")
+	m.CloudProviderVars = &CloudProviderVars{NodeGroups: map[string]map[string]interface{}{
+		masterNodeGroupName: clusterNodeGroup(map[string]interface{}{"nodeType": "CloudPermanent"}),
+	}}
+
+	_, err := m.Prepare(t.Context(), DummyValidatorProvider())
+	require.ErrorContains(t, err, "spec.cloudInstances.classReference")
+	require.ErrorContains(t, err, "dhctl destroy")
+}

--- a/dhctl/pkg/config/meta_test.go
+++ b/dhctl/pkg/config/meta_test.go
@@ -28,8 +28,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	registry_const "github.com/deckhouse/deckhouse/go_lib/registry/const"
 	proto "github.com/deckhouse/deckhouse/go_lib/dhctl-provider-protocol"
+	registry_const "github.com/deckhouse/deckhouse/go_lib/registry/const"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app/options"
 )

--- a/dhctl/pkg/config/meta_test.go
+++ b/dhctl/pkg/config/meta_test.go
@@ -718,18 +718,48 @@ func TestPrepareOnDeepCopyIsIdempotent(t *testing.T) {
 	require.Equal(t, m.TerraNodeGroupSpecs, again.TerraNodeGroupSpecs)
 }
 
-// NodeGroupManifest is applied as a JSON merge patch over the NodeGroup the
-// user's resources already put in the cluster, so it must not carry a
-// cloudInstances of its own — an empty one would overwrite the real section,
-// and converge reads the replica count back from exactly there.
-func TestNodeGroupManifestLeavesCloudInstancesAlone(t *testing.T) {
-	m, err := cloudMetaConfig(mcFlowResources).Prepare(t.Context(), DummyValidatorProvider())
-	require.NoError(t, err)
+// The manifest is a JSON merge patch applied over the NodeGroup the user's
+// resources already put in the cluster, so it must carry dhctl's Manual default
+// only where the user expressed no choice.
+func TestNodeGroupManifestDefersToUserApprovalMode(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		disruptions map[string]interface{}
+		wantPatched bool
+	}{
+		{name: "no disruptions at all", disruptions: nil, wantPatched: true},
+		{name: "explicit approvalMode", disruptions: map[string]interface{}{"approvalMode": "Automatic"}, wantPatched: false},
+		{name: "disruptions without approvalMode", disruptions: map[string]interface{}{
+			"automatic": map[string]interface{}{"drainBeforeApproval": true},
+		}, wantPatched: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ngSpec := map[string]interface{}{
+				"nodeType": "CloudPermanent",
+				"cloudInstances": map[string]interface{}{
+					"minPerZone":     float64(2),
+					"classReference": map[string]interface{}{"kind": "DVPInstanceClass", "name": "worker-dvp"},
+				},
+			}
+			if tc.disruptions != nil {
+				ngSpec["disruptions"] = tc.disruptions
+			}
 
-	for _, terraNg := range m.TerraNodeGroupSpecs {
-		spec, ok := nestedMap(m.NodeGroupManifest(terraNg), "spec")
-		require.True(t, ok)
-		require.NotContains(t, spec, "cloudInstances", "node group %q", terraNg.Name)
+			m := cloudMetaConfig("")
+			m.CloudProviderVars = &CloudProviderVars{NodeGroups: map[string]map[string]interface{}{
+				"worker": {"spec": ngSpec},
+			}}
+
+			spec, ok := nestedMap(m.NodeGroupManifest(TerraNodeGroupSpec{Name: "worker", Replicas: 2}), "spec")
+			require.True(t, ok)
+			require.NotContains(t, spec, "cloudInstances", "the patch must never carry the replica count")
+
+			disruptions, patched := nestedMap(spec, "disruptions")
+			require.Equal(t, tc.wantPatched, patched)
+			if tc.wantPatched {
+				require.Equal(t, "Manual", disruptions["approvalMode"])
+			}
+		})
 	}
 }
 

--- a/dhctl/pkg/config/meta_test.go
+++ b/dhctl/pkg/config/meta_test.go
@@ -763,21 +763,89 @@ func TestNodeGroupManifestDefersToUserApprovalMode(t *testing.T) {
 	}
 }
 
-// A CloudPermanent NodeGroup in the cluster with no cloudInstances carries no
-// replica count at all. Silently reading it as zero is what deletes nodes, so
-// the mc-flow refuses to converge on it instead.
-func TestPrepareRejectsClusterNodeGroupWithoutCloudInstances(t *testing.T) {
+func clusterNodeGroup(spec map[string]interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"apiVersion": "deckhouse.io/v1",
+		"kind":       "NodeGroup",
+		"spec":       spec,
+	}
+}
+
+func cloudPermanentSpec(minPerZone any) map[string]interface{} {
+	cloudInstances := map[string]interface{}{
+		"classReference": map[string]interface{}{"kind": "DVPInstanceClass", "name": "any"},
+	}
+	if minPerZone != nil {
+		cloudInstances["minPerZone"] = minPerZone
+	}
+	return map[string]interface{}{"nodeType": "CloudPermanent", "cloudInstances": cloudInstances}
+}
+
+// Zero replicas is what converge acts on by deleting the group's nodes, so the
+// mc-flow refuses anything it cannot read a keepable count from.
+func TestPrepareRejectsUnusableReplicaCount(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		nodeGroups map[string]map[string]interface{}
+		wantErr    string
+	}{
+		{
+			name:       "master without cloudInstances",
+			nodeGroups: map[string]map[string]interface{}{"master": clusterNodeGroup(map[string]interface{}{"nodeType": "CloudPermanent"})},
+			wantErr:    "minPerZone",
+		},
+		{
+			name:       "master scaled to zero",
+			nodeGroups: map[string]map[string]interface{}{"master": clusterNodeGroup(cloudPermanentSpec(float64(0)))},
+			wantErr:    "control plane",
+		},
+		{
+			name: "worker without cloudInstances",
+			nodeGroups: map[string]map[string]interface{}{
+				"master": clusterNodeGroup(cloudPermanentSpec(float64(1))),
+				"worker": clusterNodeGroup(map[string]interface{}{"nodeType": "CloudPermanent"}),
+			},
+			wantErr: "minPerZone",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := cloudMetaConfig("")
+			m.CloudProviderVars = &CloudProviderVars{NodeGroups: tc.nodeGroups}
+
+			_, err := m.Prepare(t.Context(), DummyValidatorProvider())
+			require.ErrorContains(t, err, tc.wantErr)
+		})
+	}
+}
+
+// A non-master group scaled to zero is a deliberate choice, not a broken object.
+func TestPrepareAllowsZeroReplicasOnNonMaster(t *testing.T) {
 	m := cloudMetaConfig("")
 	m.CloudProviderVars = &CloudProviderVars{NodeGroups: map[string]map[string]interface{}{
-		masterNodeGroupName: {
-			"apiVersion": "deckhouse.io/v1",
-			"kind":       "NodeGroup",
-			"metadata":   map[string]interface{}{"name": masterNodeGroupName},
-			"spec":       map[string]interface{}{"nodeType": "CloudPermanent"},
-		},
+		"master": clusterNodeGroup(cloudPermanentSpec(float64(1))),
+		"worker": clusterNodeGroup(cloudPermanentSpec(float64(0))),
+	}}
+
+	m, err := m.Prepare(t.Context(), DummyValidatorProvider())
+	require.NoError(t, err)
+	require.Equal(t, 1, m.MasterNodeGroupSpec.Replicas)
+	require.Len(t, m.TerraNodeGroupSpecs, 1)
+	require.Equal(t, 0, m.TerraNodeGroupSpecs[0].Replicas)
+}
+
+// The legacy flow reads replicas from its ProviderClusterConfiguration, and its
+// NodeGroups carry no cloudInstances by design.
+func TestPrepareGuardIsOffForLegacyProviderConfig(t *testing.T) {
+	m := cloudMetaConfig("")
+	m.ProviderClusterConfig = map[string]json.RawMessage{
+		"layout":          json.RawMessage(`"Standard"`),
+		"masterNodeGroup": json.RawMessage(`{"replicas":1}`),
+		"nodeGroups":      json.RawMessage(`[{"name":"legacy","replicas":2}]`),
+	}
+	m.CloudProviderVars = &CloudProviderVars{NodeGroups: map[string]map[string]interface{}{
+		"master": clusterNodeGroup(map[string]interface{}{"nodeType": "CloudPermanent"}),
 	}}
 
 	_, err := m.Prepare(t.Context(), DummyValidatorProvider())
-	require.ErrorContains(t, err, "cloudInstances")
-	require.ErrorContains(t, err, masterNodeGroupName)
+	require.NoError(t, err)
 }

--- a/dhctl/pkg/config/meta_test.go
+++ b/dhctl/pkg/config/meta_test.go
@@ -807,6 +807,19 @@ func TestPrepareRejectsUnusableReplicaCount(t *testing.T) {
 			},
 			wantErr: "minPerZone",
 		},
+		{
+			name: "worker with negative minPerZone",
+			nodeGroups: map[string]map[string]interface{}{
+				"master": clusterNodeGroup(cloudPermanentSpec(float64(1))),
+				"worker": clusterNodeGroup(cloudPermanentSpec(float64(-1))),
+			},
+			wantErr: "negative",
+		},
+		{
+			name:       "master with negative minPerZone",
+			nodeGroups: map[string]map[string]interface{}{"master": clusterNodeGroup(cloudPermanentSpec(float64(-1)))},
+			wantErr:    "negative",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			m := cloudMetaConfig("")

--- a/dhctl/pkg/config/meta_test.go
+++ b/dhctl/pkg/config/meta_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	registry_const "github.com/deckhouse/deckhouse/go_lib/registry/const"
+	proto "github.com/deckhouse/deckhouse/go_lib/dhctl-provider-protocol"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app/options"
 )
@@ -855,6 +856,18 @@ func TestPrepareGuardIsOffForLegacyProviderConfig(t *testing.T) {
 		"masterNodeGroup": json.RawMessage(`{"replicas":1}`),
 		"nodeGroups":      json.RawMessage(`[{"name":"legacy","replicas":2}]`),
 	}
+	m.CloudProviderVars = &CloudProviderVars{NodeGroups: map[string]map[string]interface{}{
+		"master": clusterNodeGroup(map[string]interface{}{"nodeType": "CloudPermanent"}),
+	}}
+
+	_, err := m.Prepare(t.Context(), DummyValidatorProvider())
+	require.NoError(t, err)
+}
+
+// A cluster whose NodeGroups lost their replica count must still be destroyable.
+func TestPrepareGuardIsOffForDestroy(t *testing.T) {
+	m := cloudMetaConfig("")
+	m.Operation = proto.OperationDestroy
 	m.CloudProviderVars = &CloudProviderVars{NodeGroups: map[string]map[string]interface{}{
 		"master": clusterNodeGroup(map[string]interface{}{"nodeType": "CloudPermanent"}),
 	}}

--- a/dhctl/pkg/config/meta_test.go
+++ b/dhctl/pkg/config/meta_test.go
@@ -718,69 +718,18 @@ func TestPrepareOnDeepCopyIsIdempotent(t *testing.T) {
 	require.Equal(t, m.TerraNodeGroupSpecs, again.TerraNodeGroupSpecs)
 }
 
-// clusterNodeGroupsFromManifests mirrors what a converge run reads back: the
-// NodeGroup objects dhctl itself wrote to the cluster during bootstrap, keyed
-// by name the way fetchCloudPermanentNodeGroupsFromCluster keys them.
-func clusterNodeGroupsFromManifests(m *MetaConfig) map[string]map[string]interface{} {
-	ngs := map[string]map[string]interface{}{
-		masterNodeGroupName: m.MasterNodeGroupManifest(),
-	}
-	for _, terraNg := range m.TerraNodeGroupSpecs {
-		ngs[terraNg.Name] = m.NodeGroupManifest(terraNg)
-	}
-	return ngs
-}
-
-func TestNodeGroupManifestKeepsCloudInstances(t *testing.T) {
+// NodeGroupManifest is applied as a JSON merge patch over the NodeGroup the
+// user's resources already put in the cluster, so it must not carry a
+// cloudInstances of its own — an empty one would overwrite the real section,
+// and converge reads the replica count back from exactly there.
+func TestNodeGroupManifestLeavesCloudInstancesAlone(t *testing.T) {
 	m, err := cloudMetaConfig(mcFlowResources).Prepare(t.Context(), DummyValidatorProvider())
 	require.NoError(t, err)
 
 	for _, terraNg := range m.TerraNodeGroupSpecs {
-		manifest := m.NodeGroupManifest(terraNg)
-
-		cloudInstances, ok := nestedMap(manifest, "spec", "cloudInstances")
-		require.Truef(t, ok, "node group %q written to the cluster without spec.cloudInstances", terraNg.Name)
-		require.Equal(t, float64(terraNg.Replicas), cloudInstances["minPerZone"])
-
-		classRef, ok := nestedMap(cloudInstances, "classReference")
-		require.Truef(t, ok, "node group %q written without spec.cloudInstances.classReference", terraNg.Name)
-		require.Equal(t, "DVPInstanceClass", classRef["kind"])
-	}
-}
-
-func TestMasterNodeGroupManifestKeepsCloudInstances(t *testing.T) {
-	m, err := cloudMetaConfig(mcFlowResources).Prepare(t.Context(), DummyValidatorProvider())
-	require.NoError(t, err)
-
-	manifest := m.MasterNodeGroupManifest()
-	require.Equal(t, masterNodeGroupName, manifest["metadata"].(map[string]any)["name"])
-
-	cloudInstances, ok := nestedMap(manifest, "spec", "cloudInstances")
-	require.True(t, ok, "master node group written to the cluster without spec.cloudInstances")
-	require.Equal(t, float64(3), cloudInstances["minPerZone"])
-}
-
-// The mc-flow has no ProviderClusterConfiguration, so converge recovers the
-// replica counts from the NodeGroups in the cluster. Those NodeGroups are the
-// ones dhctl wrote during bootstrap, which makes this a closed loop: whatever
-// the write drops, the next converge cannot see. Dropping cloudInstances makes
-// every replica count read back as zero, and zero means "scale to zero".
-func TestClusterNodeGroupsRoundTripPreservesReplicas(t *testing.T) {
-	fromFile, err := cloudMetaConfig(mcFlowResources).Prepare(t.Context(), DummyValidatorProvider())
-	require.NoError(t, err)
-
-	fromCluster := cloudMetaConfig("")
-	fromCluster.CloudProviderVars = &CloudProviderVars{NodeGroups: clusterNodeGroupsFromManifests(fromFile)}
-
-	fromCluster, err = fromCluster.Prepare(t.Context(), DummyValidatorProvider())
-	require.NoError(t, err)
-
-	require.Equal(t, fromFile.MasterNodeGroupSpec.Replicas, fromCluster.MasterNodeGroupSpec.Replicas)
-
-	require.Len(t, fromCluster.TerraNodeGroupSpecs, len(fromFile.TerraNodeGroupSpecs))
-	for i, want := range fromFile.TerraNodeGroupSpecs {
-		require.Equal(t, want.Name, fromCluster.TerraNodeGroupSpecs[i].Name)
-		require.Equal(t, want.Replicas, fromCluster.TerraNodeGroupSpecs[i].Replicas)
+		spec, ok := nestedMap(m.NodeGroupManifest(terraNg), "spec")
+		require.True(t, ok)
+		require.NotContains(t, spec, "cloudInstances", "node group %q", terraNg.Name)
 	}
 }
 

--- a/dhctl/pkg/config/meta_test.go
+++ b/dhctl/pkg/config/meta_test.go
@@ -885,5 +885,5 @@ func TestPrepareGuardErrorNamesTheRemedy(t *testing.T) {
 
 	_, err := m.Prepare(t.Context(), DummyValidatorProvider())
 	require.ErrorContains(t, err, "spec.cloudInstances.classReference")
-	require.ErrorContains(t, err, "dhctl destroy")
+	require.ErrorContains(t, err, "spec.cloudInstances.minPerZone")
 }

--- a/dhctl/pkg/config/meta_test.go
+++ b/dhctl/pkg/config/meta_test.go
@@ -717,3 +717,88 @@ func TestPrepareOnDeepCopyIsIdempotent(t *testing.T) {
 	require.Equal(t, m.MasterNodeGroupSpec.Replicas, again.MasterNodeGroupSpec.Replicas)
 	require.Equal(t, m.TerraNodeGroupSpecs, again.TerraNodeGroupSpecs)
 }
+
+// clusterNodeGroupsFromManifests mirrors what a converge run reads back: the
+// NodeGroup objects dhctl itself wrote to the cluster during bootstrap, keyed
+// by name the way fetchCloudPermanentNodeGroupsFromCluster keys them.
+func clusterNodeGroupsFromManifests(m *MetaConfig) map[string]map[string]interface{} {
+	ngs := map[string]map[string]interface{}{
+		masterNodeGroupName: m.MasterNodeGroupManifest(),
+	}
+	for _, terraNg := range m.TerraNodeGroupSpecs {
+		ngs[terraNg.Name] = m.NodeGroupManifest(terraNg)
+	}
+	return ngs
+}
+
+func TestNodeGroupManifestKeepsCloudInstances(t *testing.T) {
+	m, err := cloudMetaConfig(mcFlowResources).Prepare(t.Context(), DummyValidatorProvider())
+	require.NoError(t, err)
+
+	for _, terraNg := range m.TerraNodeGroupSpecs {
+		manifest := m.NodeGroupManifest(terraNg)
+
+		cloudInstances, ok := nestedMap(manifest, "spec", "cloudInstances")
+		require.Truef(t, ok, "node group %q written to the cluster without spec.cloudInstances", terraNg.Name)
+		require.Equal(t, float64(terraNg.Replicas), cloudInstances["minPerZone"])
+
+		classRef, ok := nestedMap(cloudInstances, "classReference")
+		require.Truef(t, ok, "node group %q written without spec.cloudInstances.classReference", terraNg.Name)
+		require.Equal(t, "DVPInstanceClass", classRef["kind"])
+	}
+}
+
+func TestMasterNodeGroupManifestKeepsCloudInstances(t *testing.T) {
+	m, err := cloudMetaConfig(mcFlowResources).Prepare(t.Context(), DummyValidatorProvider())
+	require.NoError(t, err)
+
+	manifest := m.MasterNodeGroupManifest()
+	require.Equal(t, masterNodeGroupName, manifest["metadata"].(map[string]any)["name"])
+
+	cloudInstances, ok := nestedMap(manifest, "spec", "cloudInstances")
+	require.True(t, ok, "master node group written to the cluster without spec.cloudInstances")
+	require.Equal(t, float64(3), cloudInstances["minPerZone"])
+}
+
+// The mc-flow has no ProviderClusterConfiguration, so converge recovers the
+// replica counts from the NodeGroups in the cluster. Those NodeGroups are the
+// ones dhctl wrote during bootstrap, which makes this a closed loop: whatever
+// the write drops, the next converge cannot see. Dropping cloudInstances makes
+// every replica count read back as zero, and zero means "scale to zero".
+func TestClusterNodeGroupsRoundTripPreservesReplicas(t *testing.T) {
+	fromFile, err := cloudMetaConfig(mcFlowResources).Prepare(t.Context(), DummyValidatorProvider())
+	require.NoError(t, err)
+
+	fromCluster := cloudMetaConfig("")
+	fromCluster.CloudProviderVars = &CloudProviderVars{NodeGroups: clusterNodeGroupsFromManifests(fromFile)}
+
+	fromCluster, err = fromCluster.Prepare(t.Context(), DummyValidatorProvider())
+	require.NoError(t, err)
+
+	require.Equal(t, fromFile.MasterNodeGroupSpec.Replicas, fromCluster.MasterNodeGroupSpec.Replicas)
+
+	require.Len(t, fromCluster.TerraNodeGroupSpecs, len(fromFile.TerraNodeGroupSpecs))
+	for i, want := range fromFile.TerraNodeGroupSpecs {
+		require.Equal(t, want.Name, fromCluster.TerraNodeGroupSpecs[i].Name)
+		require.Equal(t, want.Replicas, fromCluster.TerraNodeGroupSpecs[i].Replicas)
+	}
+}
+
+// A CloudPermanent NodeGroup in the cluster with no cloudInstances carries no
+// replica count at all. Silently reading it as zero is what deletes nodes, so
+// the mc-flow refuses to converge on it instead.
+func TestPrepareRejectsClusterNodeGroupWithoutCloudInstances(t *testing.T) {
+	m := cloudMetaConfig("")
+	m.CloudProviderVars = &CloudProviderVars{NodeGroups: map[string]map[string]interface{}{
+		masterNodeGroupName: {
+			"apiVersion": "deckhouse.io/v1",
+			"kind":       "NodeGroup",
+			"metadata":   map[string]interface{}{"name": masterNodeGroupName},
+			"spec":       map[string]interface{}{"nodeType": "CloudPermanent"},
+		},
+	}}
+
+	_, err := m.Prepare(t.Context(), DummyValidatorProvider())
+	require.ErrorContains(t, err, "cloudInstances")
+	require.ErrorContains(t, err, masterNodeGroupName)
+}

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
@@ -1073,9 +1073,8 @@ func isProviderNodeResource(resource *template.Resource) bool {
 }
 
 // applyMasterNodeGroupDefaults fills in the control-plane defaults that
-// node-manager's create_master_node_group hook supplies with CreateIfNotExists —
-// it never corrects an object dhctl wrote first. Absent keys only: what the user
-// set stays.
+// node-manager's CreateIfNotExists hook never corrects once dhctl has already
+// written the object. Absent keys only: what the user set stays.
 func applyMasterNodeGroupDefaults(resources template.Resources) {
 	for _, resource := range resources {
 		if resource.GVK.Kind != "NodeGroup" || resource.GVK.Group != "deckhouse.io" {
@@ -1089,16 +1088,19 @@ func applyMasterNodeGroupDefaults(resources template.Resources) {
 			_ = unstructured.SetNestedField(resource.Object.Object, "Manual", "spec", "disruptions", "approvalMode")
 		}
 
-		labels, _, _ := unstructured.NestedStringMap(resource.Object.Object, "spec", "nodeTemplate", "labels")
-		if labels == nil {
-			labels = map[string]string{}
-		}
-		for _, key := range []string{"node-role.kubernetes.io/control-plane", "node-role.kubernetes.io/master"} {
-			if _, ok := labels[key]; !ok {
-				labels[key] = ""
+		// NestedMap preserves non-string label values instead of NestedStringMap's
+		// all-or-nothing error, so a stray non-string label doesn't get wiped below.
+		if labels, _, err := unstructured.NestedMap(resource.Object.Object, "spec", "nodeTemplate", "labels"); err == nil {
+			if labels == nil {
+				labels = map[string]interface{}{}
 			}
+			for _, key := range []string{"node-role.kubernetes.io/control-plane", "node-role.kubernetes.io/master"} {
+				if _, ok := labels[key]; !ok {
+					labels[key] = ""
+				}
+			}
+			_ = unstructured.SetNestedMap(resource.Object.Object, labels, "spec", "nodeTemplate", "labels")
 		}
-		_ = unstructured.SetNestedStringMap(resource.Object.Object, labels, "spec", "nodeTemplate", "labels")
 
 		if _, found, _ := unstructured.NestedFieldNoCopy(resource.Object.Object, "spec", "nodeTemplate", "taints"); !found {
 			_ = unstructured.SetNestedSlice(resource.Object.Object, []any{map[string]any{

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
@@ -640,7 +640,7 @@ func (b *ClusterBootstrapper) bootstrapPostInfraPreflights(ctx context.Context, 
 			return err
 		}
 
-		before, provider, after := splitResourcesOnPreAndPostDeckhouseInstall(ctx, parsedResources)
+		before, provider, after := splitResourcesOnPreAndPostDeckhouseInstall(ctx, parsedResources, bctx.metaConfig.ClusterType == config.CloudClusterType)
 
 		bctx.resourcesToCreateBefore = before
 		bctx.resourcesToCreateProvider = provider
@@ -1029,7 +1029,7 @@ func bootstrapAdditionalNodesForCloudCluster(
 	})
 }
 
-func splitResourcesOnPreAndPostDeckhouseInstall(ctx context.Context, resourcesToCreate template.Resources) (template.Resources, template.Resources, template.Resources) {
+func splitResourcesOnPreAndPostDeckhouseInstall(ctx context.Context, resourcesToCreate template.Resources, isCloudCluster bool) (template.Resources, template.Resources, template.Resources) {
 	before := make(template.Resources, 0, len(resourcesToCreate))
 	provider := make(template.Resources, 0, len(resourcesToCreate))
 	after := make(template.Resources, 0, len(resourcesToCreate))
@@ -1039,18 +1039,18 @@ func splitResourcesOnPreAndPostDeckhouseInstall(ctx context.Context, resourcesTo
 		hasBeforeAnnotation := annotations != nil && annotations["dhctl.deckhouse.io/bootstrap-resource-place"] == "before-deckhouse"
 
 		if hasBeforeAnnotation || isCloudProviderCredentialSecret(resource) {
-			dhlog.FromContext(ctx).DebugContext(ctx, fmt.Sprintf("Add resource %s - %s to after queue", resource.String(), resource.Object.GetName()))
+			dhlog.FromContext(ctx).DebugContext(ctx, fmt.Sprintf("Add resource %s - %s to before queue", resource.String(), resource.Object.GetName()))
 			before = append(before, resource)
 			continue
 		}
 
-		if isProviderNodeResource(resource) {
+		if isCloudCluster && isProviderNodeResource(resource) {
 			dhlog.FromContext(ctx).DebugContext(ctx, fmt.Sprintf("Add resource %s - %s to provider queue", resource.String(), resource.Object.GetName()))
 			provider = append(provider, resource)
 			continue
 		}
 
-		dhlog.FromContext(ctx).DebugContext(ctx, fmt.Sprintf("Add resource %s - %s to before queue", resource.String(), resource.Object.GetName()))
+		dhlog.FromContext(ctx).DebugContext(ctx, fmt.Sprintf("Add resource %s - %s to after queue", resource.String(), resource.Object.GetName()))
 		after = append(after, resource)
 	}
 
@@ -1059,10 +1059,9 @@ func splitResourcesOnPreAndPostDeckhouseInstall(ctx context.Context, resourcesTo
 	return before, provider, after
 }
 
-// isProviderNodeResource reports the objects dhctl provisions cloud nodes from:
-// the CloudPermanent NodeGroups and the instance classes they reference. They
-// describe what is about to be built, so they have to reach the cluster before
-// the build, not with the rest of the user's resources once it is over.
+// isProviderNodeResource reports the objects dhctl builds cloud nodes from. They
+// describe what is about to be built, so they reach the cluster before the build
+// rather than with the rest of the user's resources once it is over.
 func isProviderNodeResource(resource *template.Resource) bool {
 	if resource.GVK.Group != "deckhouse.io" {
 		return false

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -36,7 +37,6 @@ import (
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app/options"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/global"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/infrastructure"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/infrastructureprovider"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/infrastructureprovider/cloud"
@@ -172,21 +172,22 @@ func (b *ClusterBootstrapper) getCleanupFunc(ctx context.Context, metaConfig *co
 }
 
 type bootstrapContext struct {
-	masterAddressesForSSH   map[string]string
-	metaConfig              *config.MetaConfig
-	stateCache              state.Cache
-	configHash              string
-	deckhouseInstallConfig  *config.DeckhouseInstaller
-	bootstrapState          *State
-	nodeIP                  string
-	devicePath              string
-	resourcesTemplateData   map[string]any
-	resourcesToCreateBefore template.Resources
-	resourcesToCreateAfter  template.Resources
-	installDeckhouseResult  *InstallDeckhouseResult
-	cleanup                 func()
-	finishProgress          func()
-	preflightRunner         *preflight.Preflight
+	masterAddressesForSSH     map[string]string
+	metaConfig                *config.MetaConfig
+	stateCache                state.Cache
+	configHash                string
+	deckhouseInstallConfig    *config.DeckhouseInstaller
+	bootstrapState            *State
+	nodeIP                    string
+	devicePath                string
+	resourcesTemplateData     map[string]any
+	resourcesToCreateBefore   template.Resources
+	resourcesToCreateProvider template.Resources
+	resourcesToCreateAfter    template.Resources
+	installDeckhouseResult    *InstallDeckhouseResult
+	cleanup                   func()
+	finishProgress            func()
+	preflightRunner           *preflight.Preflight
 }
 
 func (b *ClusterBootstrapper) Bootstrap(ctx context.Context) error {
@@ -639,9 +640,10 @@ func (b *ClusterBootstrapper) bootstrapPostInfraPreflights(ctx context.Context, 
 			return err
 		}
 
-		before, after := splitResourcesOnPreAndPostDeckhouseInstall(ctx, parsedResources)
+		before, provider, after := splitResourcesOnPreAndPostDeckhouseInstall(ctx, parsedResources)
 
 		bctx.resourcesToCreateBefore = before
+		bctx.resourcesToCreateProvider = provider
 		bctx.resourcesToCreateAfter = after
 	}
 
@@ -760,6 +762,22 @@ func (b *ClusterBootstrapper) bootstrapAdditionalNodes(ctx context.Context, bctx
 
 		kubeCl, err := b.KubeProvider.Client(ctx)
 		if err != nil {
+			return err
+		}
+
+		// The CloudPermanent NodeGroups and their instance classes describe the nodes
+		// the steps below are about to build, and in the mc-flow the cluster objects
+		// are the only record converge later reads them back from. Applied here, right
+		// after Deckhouse installed their CRDs, rather than with the rest of the user's
+		// resources once the nodes already exist.
+		if err := createResources(
+			ctx,
+			&client.KubernetesClient{KubeClient: kubeCl},
+			bctx.resourcesToCreateProvider,
+			nil,
+			true,
+			b.Options.Bootstrap.ResourcesTimeout,
+		); err != nil {
 			return err
 		}
 
@@ -975,10 +993,6 @@ func bootstrapAdditionalNodesForCloudCluster(
 	ctx, span := telemetry.StartSpan(ctx, "ClusterBootstrapper.Bootstrap.AdditionalNodesForCloudCluster")
 	defer span.End()
 
-	if err := ensureMasterNodeGroup(ctx, kubeCl, metaConfig); err != nil {
-		return err
-	}
-
 	if err := BootstrapAdditionalMasterNodes(ctx, kubeCl, metaConfig, masterAddressesForSSH, infrastructureContext, cache.Global(), globalOptions); err != nil {
 		return err
 	}
@@ -1015,29 +1029,9 @@ func bootstrapAdditionalNodesForCloudCluster(
 	})
 }
 
-// ensureMasterNodeGroup writes the control-plane NodeGroup in the mc-flow, where
-// its spec.cloudInstances is the only record of the master replica count and of
-// the instance class, and converge reads it back from the cluster on every run.
-// Deckhouse's node-manager creates the same object without that section and gets
-// there first, so leaving it to the create-resources phase — the last one — means
-// an interrupted bootstrap leaves a master NodeGroup that converge then reads as
-// "zero replicas". No-op in the legacy ProviderClusterConfiguration flow, whose
-// NodeGroups carry no cloudInstances by design.
-func ensureMasterNodeGroup(ctx context.Context, kubeCl *client.KubernetesClient, metaConfig *config.MetaConfig) error {
-	if metaConfig.CloudProviderVars == nil {
-		return nil
-	}
-	if _, ok := metaConfig.CloudProviderVars.NodeGroups[global.MasterNodeGroupName]; !ok {
-		return nil
-	}
-
-	return dhlog.RunProcess(ctx, dhlog.FromContext(ctx), "Create master NodeGroup", func(ctx context.Context) error {
-		return entity.CreateNodeGroup(ctx, kubeCl, global.MasterNodeGroupName, metaConfig.MasterNodeGroupManifest())
-	})
-}
-
-func splitResourcesOnPreAndPostDeckhouseInstall(ctx context.Context, resourcesToCreate template.Resources) (template.Resources, template.Resources) {
+func splitResourcesOnPreAndPostDeckhouseInstall(ctx context.Context, resourcesToCreate template.Resources) (template.Resources, template.Resources, template.Resources) {
 	before := make(template.Resources, 0, len(resourcesToCreate))
+	provider := make(template.Resources, 0, len(resourcesToCreate))
 	after := make(template.Resources, 0, len(resourcesToCreate))
 
 	for _, resource := range resourcesToCreate {
@@ -1050,13 +1044,33 @@ func splitResourcesOnPreAndPostDeckhouseInstall(ctx context.Context, resourcesTo
 			continue
 		}
 
+		if isProviderNodeResource(resource) {
+			dhlog.FromContext(ctx).DebugContext(ctx, fmt.Sprintf("Add resource %s - %s to provider queue", resource.String(), resource.Object.GetName()))
+			provider = append(provider, resource)
+			continue
+		}
+
 		dhlog.FromContext(ctx).DebugContext(ctx, fmt.Sprintf("Add resource %s - %s to before queue", resource.String(), resource.Object.GetName()))
 		after = append(after, resource)
 	}
 
 	before = prependMissingNamespaces(before)
 
-	return before, after
+	return before, provider, after
+}
+
+// isProviderNodeResource reports the objects dhctl provisions cloud nodes from:
+// the CloudPermanent NodeGroups and the instance classes they reference. They
+// describe what is about to be built, so they have to reach the cluster before
+// the build, not with the rest of the user's resources once it is over.
+func isProviderNodeResource(resource *template.Resource) bool {
+	if resource.GVK.Group != "deckhouse.io" {
+		return false
+	}
+	if strings.HasSuffix(resource.GVK.Kind, "InstanceClass") {
+		return true
+	}
+	return resource.GVK.Kind == "NodeGroup" && config.IsCloudPermanentNodeGroup(resource.Object.Object)
 }
 
 // isCloudProviderCredentialSecret returns true for Secret resources carrying

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
@@ -641,7 +641,7 @@ func (b *ClusterBootstrapper) bootstrapPostInfraPreflights(ctx context.Context, 
 			return err
 		}
 
-		before, provider, after := splitResourcesOnPreAndPostDeckhouseInstall(ctx, parsedResources, bctx.metaConfig.ClusterType == config.CloudClusterType)
+		before, provider, after := splitResourcesOnPreAndPostDeckhouseInstall(ctx, parsedResources, nodesComeFromResources(bctx.metaConfig))
 
 		applyMasterNodeGroupDefaults(provider)
 
@@ -1029,7 +1029,14 @@ func bootstrapAdditionalNodesForCloudCluster(
 	})
 }
 
-func splitResourcesOnPreAndPostDeckhouseInstall(ctx context.Context, resourcesToCreate template.Resources, isCloudCluster bool) (template.Resources, template.Resources, template.Resources) {
+// nodesComeFromResources reports whether dhctl builds this cluster's cloud nodes
+// from the user's resources. Only the ModuleConfig flow does: a static cluster
+// builds no cloud nodes, a legacy one builds them from ProviderClusterConfiguration.
+func nodesComeFromResources(metaConfig *config.MetaConfig) bool {
+	return metaConfig.ClusterType == config.CloudClusterType && !metaConfig.HasLegacyProviderConfig()
+}
+
+func splitResourcesOnPreAndPostDeckhouseInstall(ctx context.Context, resourcesToCreate template.Resources, nodesFromResources bool) (template.Resources, template.Resources, template.Resources) {
 	before := make(template.Resources, 0, len(resourcesToCreate))
 	provider := make(template.Resources, 0, len(resourcesToCreate))
 	after := make(template.Resources, 0, len(resourcesToCreate))
@@ -1044,7 +1051,7 @@ func splitResourcesOnPreAndPostDeckhouseInstall(ctx context.Context, resourcesTo
 			continue
 		}
 
-		if isCloudCluster && isProviderNodeResource(resource) {
+		if nodesFromResources && isProviderNodeResource(resource) {
 			dhlog.FromContext(ctx).DebugContext(ctx, fmt.Sprintf("Add resource %s - %s to provider queue", resource.String(), resource.Object.GetName()))
 			provider = append(provider, resource)
 			continue

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
@@ -1199,9 +1199,11 @@ func createResources(
 					retry.WithWhitelist(actions.ErrManifestTaskTransient),
 				)
 
-				return retry.NewLoopWithParams(loopParams).RunContext(ctx, func() error {
+				if err := retry.NewLoopWithParams(loopParams).RunContext(ctx, func() error {
 					return task.Do(kubeCl)
-				})
+				}); err != nil {
+					return err
+				}
 			}
 
 			return nil

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
@@ -37,6 +37,7 @@ import (
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app/options"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/global"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/infrastructure"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/infrastructureprovider"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/infrastructureprovider/cloud"
@@ -642,6 +643,8 @@ func (b *ClusterBootstrapper) bootstrapPostInfraPreflights(ctx context.Context, 
 
 		before, provider, after := splitResourcesOnPreAndPostDeckhouseInstall(ctx, parsedResources, bctx.metaConfig.ClusterType == config.CloudClusterType)
 
+		applyMasterNodeGroupDefaults(provider)
+
 		bctx.resourcesToCreateBefore = before
 		bctx.resourcesToCreateProvider = provider
 		bctx.resourcesToCreateAfter = after
@@ -1067,6 +1070,43 @@ func isProviderNodeResource(resource *template.Resource) bool {
 		return true
 	}
 	return resource.GVK.Kind == "NodeGroup" && config.IsCloudPermanentNodeGroup(resource.Object.Object)
+}
+
+// applyMasterNodeGroupDefaults fills in the control-plane defaults that
+// node-manager's create_master_node_group hook supplies with CreateIfNotExists —
+// it never corrects an object dhctl wrote first. Absent keys only: what the user
+// set stays.
+func applyMasterNodeGroupDefaults(resources template.Resources) {
+	for _, resource := range resources {
+		if resource.GVK.Kind != "NodeGroup" || resource.GVK.Group != "deckhouse.io" {
+			continue
+		}
+		if resource.Object.GetName() != global.MasterNodeGroupName {
+			continue
+		}
+
+		if _, found, _ := unstructured.NestedString(resource.Object.Object, "spec", "disruptions", "approvalMode"); !found {
+			_ = unstructured.SetNestedField(resource.Object.Object, "Manual", "spec", "disruptions", "approvalMode")
+		}
+
+		labels, _, _ := unstructured.NestedStringMap(resource.Object.Object, "spec", "nodeTemplate", "labels")
+		if labels == nil {
+			labels = map[string]string{}
+		}
+		for _, key := range []string{"node-role.kubernetes.io/control-plane", "node-role.kubernetes.io/master"} {
+			if _, ok := labels[key]; !ok {
+				labels[key] = ""
+			}
+		}
+		_ = unstructured.SetNestedStringMap(resource.Object.Object, labels, "spec", "nodeTemplate", "labels")
+
+		if _, found, _ := unstructured.NestedFieldNoCopy(resource.Object.Object, "spec", "nodeTemplate", "taints"); !found {
+			_ = unstructured.SetNestedSlice(resource.Object.Object, []any{map[string]any{
+				"key":    "node-role.kubernetes.io/control-plane",
+				"effect": "NoSchedule",
+			}}, "spec", "nodeTemplate", "taints")
+		}
+	}
 }
 
 // isCloudProviderCredentialSecret returns true for Secret resources carrying

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
@@ -768,7 +768,11 @@ func (b *ClusterBootstrapper) bootstrapAdditionalNodes(ctx context.Context, bctx
 			return err
 		}
 
-		localBootstraper := func(action func() error) error {
+		if err := b.createProviderResources(ctx, bctx, &client.KubernetesClient{KubeClient: kubeCl}); err != nil {
+			return err
+		}
+
+		inClusterLock := func(action func() error) error {
 			if b.CommanderMode {
 				return action()
 			}
@@ -781,20 +785,7 @@ func (b *ClusterBootstrapper) bootstrapAdditionalNodes(ctx context.Context, bctx
 			).Run(ctx, action)
 		}
 
-		err = localBootstraper(func() error {
-			// The CloudPermanent NodeGroups and their instance classes describe the
-			// nodes the call below is about to build, so they reach the cluster first.
-			if err := createResources(
-				ctx,
-				&client.KubernetesClient{KubeClient: kubeCl},
-				bctx.resourcesToCreateProvider,
-				nil,
-				true,
-				b.Options.Bootstrap.ResourcesTimeout,
-			); err != nil {
-				return err
-			}
-
+		err = inClusterLock(func() error {
 			return bootstrapAdditionalNodesForCloudCluster(
 				ctx,
 				&client.KubernetesClient{KubeClient: kubeCl},
@@ -823,6 +814,20 @@ func (b *ClusterBootstrapper) bootstrapAdditionalNodes(ctx context.Context, bctx
 	b.PhasedExecutionContext.CompleteSubPhase(ctx, phases.InstallAdditionalMastersAndStaticNodesSubPhaseWait)
 
 	return nil
+}
+
+// createProviderResources puts the CloudPermanent NodeGroups and the instance
+// classes they reference in the cluster before dhctl builds any node from them.
+// Converge later reads the node count back from those same objects.
+func (b *ClusterBootstrapper) createProviderResources(ctx context.Context, bctx *bootstrapContext, kubeCl *client.KubernetesClient) error {
+	return createResources(
+		ctx,
+		kubeCl,
+		bctx.resourcesToCreateProvider,
+		nil,
+		true,
+		b.Options.Bootstrap.ResourcesTimeout,
+	)
 }
 
 func (b *ClusterBootstrapper) bootstrapCreateResources(ctx context.Context, bctx *bootstrapContext) error {

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
@@ -765,22 +765,6 @@ func (b *ClusterBootstrapper) bootstrapAdditionalNodes(ctx context.Context, bctx
 			return err
 		}
 
-		// The CloudPermanent NodeGroups and their instance classes describe the nodes
-		// the steps below are about to build, and in the mc-flow the cluster objects
-		// are the only record converge later reads them back from. Applied here, right
-		// after Deckhouse installed their CRDs, rather than with the rest of the user's
-		// resources once the nodes already exist.
-		if err := createResources(
-			ctx,
-			&client.KubernetesClient{KubeClient: kubeCl},
-			bctx.resourcesToCreateProvider,
-			nil,
-			true,
-			b.Options.Bootstrap.ResourcesTimeout,
-		); err != nil {
-			return err
-		}
-
 		localBootstraper := func(action func() error) error {
 			if b.CommanderMode {
 				return action()
@@ -795,6 +779,19 @@ func (b *ClusterBootstrapper) bootstrapAdditionalNodes(ctx context.Context, bctx
 		}
 
 		err = localBootstraper(func() error {
+			// The CloudPermanent NodeGroups and their instance classes describe the
+			// nodes the call below is about to build, so they reach the cluster first.
+			if err := createResources(
+				ctx,
+				&client.KubernetesClient{KubeClient: kubeCl},
+				bctx.resourcesToCreateProvider,
+				nil,
+				true,
+				b.Options.Bootstrap.ResourcesTimeout,
+			); err != nil {
+				return err
+			}
+
 			return bootstrapAdditionalNodesForCloudCluster(
 				ctx,
 				&client.KubernetesClient{KubeClient: kubeCl},

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app/options"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/global"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/infrastructure"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/infrastructureprovider"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/infrastructureprovider/cloud"
@@ -974,6 +975,10 @@ func bootstrapAdditionalNodesForCloudCluster(
 	ctx, span := telemetry.StartSpan(ctx, "ClusterBootstrapper.Bootstrap.AdditionalNodesForCloudCluster")
 	defer span.End()
 
+	if err := ensureMasterNodeGroup(ctx, kubeCl, metaConfig); err != nil {
+		return err
+	}
+
 	if err := BootstrapAdditionalMasterNodes(ctx, kubeCl, metaConfig, masterAddressesForSSH, infrastructureContext, cache.Global(), globalOptions); err != nil {
 		return err
 	}
@@ -1007,6 +1012,27 @@ func bootstrapAdditionalNodesForCloudCluster(
 		pec.CompleteSubPhase(ctx, phases.InstallAdditionalMastersAndStaticNodeSubPhaseStaticNodes)
 
 		return nil
+	})
+}
+
+// ensureMasterNodeGroup writes the control-plane NodeGroup in the mc-flow, where
+// its spec.cloudInstances is the only record of the master replica count and of
+// the instance class, and converge reads it back from the cluster on every run.
+// Deckhouse's node-manager creates the same object without that section and gets
+// there first, so leaving it to the create-resources phase — the last one — means
+// an interrupted bootstrap leaves a master NodeGroup that converge then reads as
+// "zero replicas". No-op in the legacy ProviderClusterConfiguration flow, whose
+// NodeGroups carry no cloudInstances by design.
+func ensureMasterNodeGroup(ctx context.Context, kubeCl *client.KubernetesClient, metaConfig *config.MetaConfig) error {
+	if metaConfig.CloudProviderVars == nil {
+		return nil
+	}
+	if _, ok := metaConfig.CloudProviderVars.NodeGroups[global.MasterNodeGroupName]; !ok {
+		return nil
+	}
+
+	return dhlog.RunProcess(ctx, dhlog.FromContext(ctx), "Create master NodeGroup", func(ctx context.Context) error {
+		return entity.CreateNodeGroup(ctx, kubeCl, global.MasterNodeGroupName, metaConfig.MasterNodeGroupManifest())
 	})
 }
 

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper_test.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper_test.go
@@ -49,7 +49,7 @@ func TestSplitResources_CredentialSecretGoesToBefore(t *testing.T) {
 	})
 	regularResource := newResource(t, "deckhouse.io/v1alpha1", "ModuleConfig", "user-authn", "", nil)
 
-	before, after := splitResourcesOnPreAndPostDeckhouseInstall(context.TODO(), template.Resources{credSecret, regularResource})
+	before, _, after := splitResourcesOnPreAndPostDeckhouseInstall(context.TODO(), template.Resources{credSecret, regularResource})
 
 	// before queue must contain the credential Secret AND a namespace stub for d8-cloud-provider-dvp.
 	require.Len(t, before, 2)
@@ -67,7 +67,7 @@ func TestSplitResources_NonCredentialSecretGoesToAfter(t *testing.T) {
 		"type": "Opaque",
 	})
 
-	before, after := splitResourcesOnPreAndPostDeckhouseInstall(context.TODO(), template.Resources{plainSecret})
+	before, _, after := splitResourcesOnPreAndPostDeckhouseInstall(context.TODO(), template.Resources{plainSecret})
 
 	require.Empty(t, before)
 	require.Len(t, after, 1)
@@ -80,7 +80,7 @@ func TestSplitResources_BeforeAnnotationStillRespected(t *testing.T) {
 		"dhctl.deckhouse.io/bootstrap-resource-place": "before-deckhouse",
 	})
 
-	before, after := splitResourcesOnPreAndPostDeckhouseInstall(context.TODO(), template.Resources{annotated})
+	before, _, after := splitResourcesOnPreAndPostDeckhouseInstall(context.TODO(), template.Resources{annotated})
 
 	require.Empty(t, after)
 	// Namespace stub for kube-system is added even though kube-system always exists; harmless.
@@ -98,7 +98,7 @@ func TestSplitResources_ExplicitNamespaceNotDuplicated(t *testing.T) {
 		"dhctl.deckhouse.io/bootstrap-resource-place": "before-deckhouse",
 	})
 
-	before, _ := splitResourcesOnPreAndPostDeckhouseInstall(context.TODO(), template.Resources{credSecret, explicitNS})
+	before, _, _ := splitResourcesOnPreAndPostDeckhouseInstall(context.TODO(), template.Resources{credSecret, explicitNS})
 
 	// Only one Namespace entry — the user-provided one, no auto-stub.
 	nsCount := 0
@@ -108,4 +108,30 @@ func TestSplitResources_ExplicitNamespaceNotDuplicated(t *testing.T) {
 		}
 	}
 	require.Equal(t, 1, nsCount)
+}
+
+// dhctl builds the CloudPermanent nodes from these objects, so they go to the
+// cluster before the build; everything else waits for the final phase.
+func TestSplitResources_ProviderNodeResourcesGoToProviderQueue(t *testing.T) {
+	masterNg := newResource(t, "deckhouse.io/v1", "NodeGroup", "master", "", map[string]any{
+		"spec": map[string]any{"nodeType": "CloudPermanent"},
+	})
+	ephemeralNg := newResource(t, "deckhouse.io/v1", "NodeGroup", "ubuntu", "", map[string]any{
+		"spec": map[string]any{"nodeType": "CloudEphemeral"},
+	})
+	instanceClass := newResource(t, "deckhouse.io/v1alpha1", "DVPInstanceClass", "master-dvp", "", nil)
+	moduleConfig := newResource(t, "deckhouse.io/v1alpha1", "ModuleConfig", "user-authn", "", nil)
+
+	before, provider, after := splitResourcesOnPreAndPostDeckhouseInstall(
+		context.TODO(), template.Resources{masterNg, ephemeralNg, instanceClass, moduleConfig})
+
+	require.Empty(t, before)
+
+	require.Len(t, provider, 2)
+	require.Equal(t, "master", provider[0].Object.GetName())
+	require.Equal(t, "master-dvp", provider[1].Object.GetName())
+
+	require.Len(t, after, 2)
+	require.Equal(t, "ubuntu", after[0].Object.GetName(), "CloudEphemeral node groups must not provision before the cluster is built")
+	require.Equal(t, "user-authn", after[1].Object.GetName())
 }

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper_test.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper_test.go
@@ -217,6 +217,29 @@ func TestApplyMasterNodeGroupDefaults_KeepsWhatTheUserChose(t *testing.T) {
 	require.Empty(t, taints, "an explicitly empty taint list is the user's choice")
 }
 
+// A non-string label value (an unquoted YAML scalar decodes as bool/float64,
+// not string) must not make the merge drop every other label.
+func TestApplyMasterNodeGroupDefaults_PreservesNonStringLabelValues(t *testing.T) {
+	masterNg := newResource(t, "deckhouse.io/v1", "NodeGroup", "master", "", map[string]any{
+		"spec": map[string]any{
+			"nodeType": "CloudPermanent",
+			"nodeTemplate": map[string]any{
+				"labels": map[string]any{"team": "infra", "enabled": true},
+			},
+		},
+	})
+
+	applyMasterNodeGroupDefaults(template.Resources{masterNg})
+
+	labels, found, err := unstructured.NestedMap(masterNg.Object.Object, "spec", "nodeTemplate", "labels")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, true, labels["enabled"])
+	require.Equal(t, "infra", labels["team"])
+	require.Equal(t, "", labels["node-role.kubernetes.io/control-plane"])
+	require.Equal(t, "", labels["node-role.kubernetes.io/master"])
+}
+
 // Only the master group gets these; every other NodeGroup is left alone.
 func TestApplyMasterNodeGroupDefaults_IgnoresOtherNodeGroups(t *testing.T) {
 	workerNg := newResource(t, "deckhouse.io/v1", "NodeGroup", "worker", "", map[string]any{

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper_test.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper_test.go
@@ -16,14 +16,30 @@ package bootstrap
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/template"
 )
+
+func TestNodesComeFromResources(t *testing.T) {
+	mcFlow := &config.MetaConfig{ClusterType: config.CloudClusterType}
+	require.True(t, nodesComeFromResources(mcFlow))
+
+	legacy := &config.MetaConfig{
+		ClusterType:           config.CloudClusterType,
+		ProviderClusterConfig: map[string]json.RawMessage{"layout": json.RawMessage(`"Standard"`)},
+	}
+	require.False(t, nodesComeFromResources(legacy), "a legacy cloud cluster builds its nodes from ProviderClusterConfiguration")
+
+	static := &config.MetaConfig{ClusterType: config.StaticClusterType}
+	require.False(t, nodesComeFromResources(static), "a static cluster builds no cloud nodes")
+}
 
 func newResource(t *testing.T, apiVersion, kind, name, namespace string, fields map[string]any) *template.Resource {
 	t.Helper()

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper_test.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper_test.go
@@ -153,3 +153,81 @@ func TestSplitResources_StaticClusterKeepsProviderResourcesInAfter(t *testing.T)
 	require.Equal(t, "worker-dvp", after[0].Object.GetName())
 	require.Equal(t, "ubuntu", after[1].Object.GetName())
 }
+
+// node-manager's create_master_node_group hook supplies these defaults with
+// CreateIfNotExists, so it never corrects an object dhctl wrote first.
+func TestApplyMasterNodeGroupDefaults_FillsWhatTheUserOmitted(t *testing.T) {
+	masterNg := newResource(t, "deckhouse.io/v1", "NodeGroup", "master", "", map[string]any{
+		"spec": map[string]any{
+			"nodeType": "CloudPermanent",
+			"nodeTemplate": map[string]any{
+				"labels": map[string]any{"team": "infra"},
+			},
+		},
+	})
+
+	applyMasterNodeGroupDefaults(template.Resources{masterNg})
+
+	approvalMode, found, err := unstructured.NestedString(masterNg.Object.Object, "spec", "disruptions", "approvalMode")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, "Manual", approvalMode)
+
+	labels, found, err := unstructured.NestedStringMap(masterNg.Object.Object, "spec", "nodeTemplate", "labels")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, map[string]string{
+		"team":                                  "infra",
+		"node-role.kubernetes.io/control-plane": "",
+		"node-role.kubernetes.io/master":        "",
+	}, labels)
+
+	taints, found, err := unstructured.NestedSlice(masterNg.Object.Object, "spec", "nodeTemplate", "taints")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, []any{map[string]any{
+		"key":    "node-role.kubernetes.io/control-plane",
+		"effect": "NoSchedule",
+	}}, taints)
+}
+
+func TestApplyMasterNodeGroupDefaults_KeepsWhatTheUserChose(t *testing.T) {
+	masterNg := newResource(t, "deckhouse.io/v1", "NodeGroup", "master", "", map[string]any{
+		"spec": map[string]any{
+			"nodeType":    "CloudPermanent",
+			"disruptions": map[string]any{"approvalMode": "Automatic"},
+			"nodeTemplate": map[string]any{
+				"labels": map[string]any{"node-role.kubernetes.io/master": "custom"},
+				"taints": []any{},
+			},
+		},
+	})
+
+	applyMasterNodeGroupDefaults(template.Resources{masterNg})
+
+	approvalMode, _, _ := unstructured.NestedString(masterNg.Object.Object, "spec", "disruptions", "approvalMode")
+	require.Equal(t, "Automatic", approvalMode)
+
+	labels, _, _ := unstructured.NestedStringMap(masterNg.Object.Object, "spec", "nodeTemplate", "labels")
+	require.Equal(t, "custom", labels["node-role.kubernetes.io/master"])
+	require.Equal(t, "", labels["node-role.kubernetes.io/control-plane"])
+
+	taints, found, _ := unstructured.NestedSlice(masterNg.Object.Object, "spec", "nodeTemplate", "taints")
+	require.True(t, found)
+	require.Empty(t, taints, "an explicitly empty taint list is the user's choice")
+}
+
+// Only the master group gets these; every other NodeGroup is left alone.
+func TestApplyMasterNodeGroupDefaults_IgnoresOtherNodeGroups(t *testing.T) {
+	workerNg := newResource(t, "deckhouse.io/v1", "NodeGroup", "worker", "", map[string]any{
+		"spec": map[string]any{"nodeType": "CloudPermanent"},
+	})
+	instanceClass := newResource(t, "deckhouse.io/v1alpha1", "DVPInstanceClass", "master", "", nil)
+
+	applyMasterNodeGroupDefaults(template.Resources{workerNg, instanceClass})
+
+	_, found, _ := unstructured.NestedMap(workerNg.Object.Object, "spec", "disruptions")
+	require.False(t, found)
+	_, found, _ = unstructured.NestedMap(instanceClass.Object.Object, "spec")
+	require.False(t, found, "an InstanceClass named master must not be mistaken for the NodeGroup")
+}

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper_test.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper_test.go
@@ -49,7 +49,7 @@ func TestSplitResources_CredentialSecretGoesToBefore(t *testing.T) {
 	})
 	regularResource := newResource(t, "deckhouse.io/v1alpha1", "ModuleConfig", "user-authn", "", nil)
 
-	before, _, after := splitResourcesOnPreAndPostDeckhouseInstall(context.TODO(), template.Resources{credSecret, regularResource})
+	before, _, after := splitResourcesOnPreAndPostDeckhouseInstall(context.TODO(), template.Resources{credSecret, regularResource}, true)
 
 	// before queue must contain the credential Secret AND a namespace stub for d8-cloud-provider-dvp.
 	require.Len(t, before, 2)
@@ -67,7 +67,7 @@ func TestSplitResources_NonCredentialSecretGoesToAfter(t *testing.T) {
 		"type": "Opaque",
 	})
 
-	before, _, after := splitResourcesOnPreAndPostDeckhouseInstall(context.TODO(), template.Resources{plainSecret})
+	before, _, after := splitResourcesOnPreAndPostDeckhouseInstall(context.TODO(), template.Resources{plainSecret}, true)
 
 	require.Empty(t, before)
 	require.Len(t, after, 1)
@@ -80,7 +80,7 @@ func TestSplitResources_BeforeAnnotationStillRespected(t *testing.T) {
 		"dhctl.deckhouse.io/bootstrap-resource-place": "before-deckhouse",
 	})
 
-	before, _, after := splitResourcesOnPreAndPostDeckhouseInstall(context.TODO(), template.Resources{annotated})
+	before, _, after := splitResourcesOnPreAndPostDeckhouseInstall(context.TODO(), template.Resources{annotated}, true)
 
 	require.Empty(t, after)
 	// Namespace stub for kube-system is added even though kube-system always exists; harmless.
@@ -98,7 +98,7 @@ func TestSplitResources_ExplicitNamespaceNotDuplicated(t *testing.T) {
 		"dhctl.deckhouse.io/bootstrap-resource-place": "before-deckhouse",
 	})
 
-	before, _, _ := splitResourcesOnPreAndPostDeckhouseInstall(context.TODO(), template.Resources{credSecret, explicitNS})
+	before, _, _ := splitResourcesOnPreAndPostDeckhouseInstall(context.TODO(), template.Resources{credSecret, explicitNS}, true)
 
 	// Only one Namespace entry — the user-provided one, no auto-stub.
 	nsCount := 0
@@ -123,7 +123,7 @@ func TestSplitResources_ProviderNodeResourcesGoToProviderQueue(t *testing.T) {
 	moduleConfig := newResource(t, "deckhouse.io/v1alpha1", "ModuleConfig", "user-authn", "", nil)
 
 	before, provider, after := splitResourcesOnPreAndPostDeckhouseInstall(
-		context.TODO(), template.Resources{masterNg, ephemeralNg, instanceClass, moduleConfig})
+		context.TODO(), template.Resources{masterNg, ephemeralNg, instanceClass, moduleConfig}, true)
 
 	require.Empty(t, before)
 
@@ -134,4 +134,22 @@ func TestSplitResources_ProviderNodeResourcesGoToProviderQueue(t *testing.T) {
 	require.Len(t, after, 2)
 	require.Equal(t, "ubuntu", after[0].Object.GetName(), "CloudEphemeral node groups must not provision before the cluster is built")
 	require.Equal(t, "user-authn", after[1].Object.GetName())
+}
+
+// A Static cluster builds no cloud nodes, so nothing may be diverted out of the
+// queue that actually gets applied for it.
+func TestSplitResources_StaticClusterKeepsProviderResourcesInAfter(t *testing.T) {
+	instanceClass := newResource(t, "deckhouse.io/v1alpha1", "DVPInstanceClass", "worker-dvp", "", nil)
+	ephemeralNg := newResource(t, "deckhouse.io/v1", "NodeGroup", "ubuntu", "", map[string]any{
+		"spec": map[string]any{"nodeType": "CloudEphemeral"},
+	})
+
+	before, provider, after := splitResourcesOnPreAndPostDeckhouseInstall(
+		context.TODO(), template.Resources{instanceClass, ephemeralNg}, false)
+
+	require.Empty(t, before)
+	require.Empty(t, provider, "a Static cluster never applies the provider queue")
+	require.Len(t, after, 2)
+	require.Equal(t, "worker-dvp", after[0].Object.GetName())
+	require.Equal(t, "ubuntu", after[1].Object.GetName())
 }


### PR DESCRIPTION
## Description

In the ModuleConfig flow (no `ProviderClusterConfiguration`, e.g. DVP), the CloudPermanent NodeGroups and the instance classes they reference are now applied right after Deckhouse is ready, before dhctl builds any node from them, instead of travelling with the rest of the user's resources in the last bootstrap phase.

- `splitResourcesOnPreAndPostDeckhouseInstall` gained a `provider` bucket, filled only when dhctl builds the cluster's cloud nodes from those resources (`nodesComeFromResources`). Static and legacy cloud clusters keep everything in the late bucket, exactly as before. CloudEphemeral NodeGroups stay there too: applied early they would provision nodes before the cluster is built.
- `applyMasterNodeGroupDefaults` fills the control-plane defaults for the `master` NodeGroup — `approvalMode: Manual`, the two labels, the `NoSchedule` taint — because node-manager's hook uses `CreateIfNotExists` and never corrects an object dhctl wrote first. Absent keys only.
- `NodeGroupManifest`, which merge-patches the group afterwards, no longer carries an `approvalMode` the user already chose.
- `applyNodeGroupReplicasFromCloudProviderVars` refuses a CloudPermanent NodeGroup it cannot read a keepable node count from, instead of reading it as zero. Off for the legacy flow and for `destroy`, so a broken cluster stays destroyable.

No restart of cluster components.

## Why do we need it, and what problem does it solve?

`spec.cloudInstances` on the cluster NodeGroup is the only record of the replica count in this flow, and converge reads it back from the cluster: `parseConfigFromCluster` → `CloudProviderVarsFromCluster` → `applyNodeGroupReplicasFromCloudProviderVars`.

Nothing put those objects in the cluster until the last bootstrap phase. Until then the NodeGroups described no replicas — the `master` one came from node-manager's hook as bare metadata, the others from `NodeGroupManifest` — and the instance classes did not exist at all while the VMs referencing them were being built.

A bootstrap interrupted in that window left the cluster that way, and the next converge read every count as zero. Zero means scale to zero: it deletes the group's nodes, the control plane included. A user hit exactly this — a `master` NodeGroup with `generation: 1` whose spec is byte-for-byte the hook's output, and no instance class in the cluster.

## Why do we need it in the patch release (if we do)?

Yes — an interrupted bootstrap leaves a cluster whose next converge deletes its own nodes.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

Two DVP bootstraps with the same config, snapshot at the same point — CloudPermanent NodeGroups created, nodes not built yet:

| | `main` | this branch |
|---|---|---|
| `master` | `gen 1`, classReference `<none>`, minPerZone `<none>` | `gen 2`, `master-dvp`, `1`, `Manual` + `NoSchedule` taint |
| `worker` | `gen 1`, classReference `<none>`, minPerZone `<none>` | `gen 2`, `worker-dvp`, `1`, `Manual` |
| `dvpinstanceclasses` | empty | `master-dvp`, `worker-dvp`, `ubuntu` |

The `main` run reproduces the reported state exactly. Bootstrap end to end `status: ok`, all nodes Ready.

Unit tests cover the bucketing (cloud, static, legacy), the guard's rejections and its two exemptions, the `approvalMode` deference and the master defaults. Not covered: the static and legacy paths are unit-tested only, and the module-config task loop needs a live API server.

## Changelog entries

```changes
section: dhctl
type: fix
summary: Apply CloudPermanent NodeGroups and their instance classes before building the nodes.
impact: In the ModuleConfig flow (no ProviderClusterConfiguration, e.g. DVP) these objects reached the cluster only in the last phase of bootstrap, so until then the CloudPermanent NodeGroups described no replicas. A bootstrap interrupted before that phase left them that way, and the next converge read every replica count as zero and deleted the nodes of those groups, the control plane included.
impact_level: default
```
