### PR TITLE
[deckhouse] fix values validation failing on the injected registry

### DIFF
--- a/deckhouse-controller/internal/packages/values/storage.go
+++ b/deckhouse-controller/internal/packages/values/storage.go
@@ -24,7 +24,6 @@ import (
 	addonutils "github.com/flant/addon-operator/pkg/utils"
 	"github.com/go-openapi/spec"
 	"github.com/go-openapi/swag/conv"
-	"google.golang.org/protobuf/types/known/structpb"
 
 	sdkutils "github.com/deckhouse/module-sdk/pkg/utils"
 
@@ -358,13 +357,13 @@ func (s *Storage) InjectRegistryValue(registry registry.Remote) {
 		s.staticValues = addonutils.Values{}
 	}
 
-	s.staticValues["registry"] = &structpb.Struct{
-		Fields: map[string]*structpb.Value{
-			"base":      {Kind: &structpb.Value_StringValue{StringValue: registry.Repository}},
-			"dockercfg": {Kind: &structpb.Value_StringValue{StringValue: registry.DockerConfig}},
-			"scheme":    {Kind: &structpb.Value_StringValue{StringValue: registry.Scheme}},
-			"ca":        {Kind: &structpb.Value_StringValue{StringValue: registry.CA}},
-		},
+	// plain JSON types only: values are walked natively by CEL (structpb) and OpenAPI
+	// validation, both fail on anything but maps, slices and scalars
+	s.staticValues["registry"] = map[string]any{
+		"base":      registry.Repository,
+		"dockercfg": registry.DockerConfig,
+		"scheme":    registry.Scheme,
+		"ca":        registry.CA,
 	}
 
 	_ = s.calculateResultValues()

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/cloudflare/cfssl v1.6.5
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/fatih/color v1.18.0 // indirect
-	github.com/flant/addon-operator v1.24.10-0.20260814103130-8773981166a4
+	github.com/flant/addon-operator v1.24.10
 	github.com/flant/kube-client v1.9.1
 	github.com/flant/shell-operator v1.20.2
 	github.com/go-openapi/spec v0.22.1

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/cloudflare/cfssl v1.6.5
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/fatih/color v1.18.0 // indirect
-	github.com/flant/addon-operator v1.24.9
+	github.com/flant/addon-operator v1.24.10-0.20260814103130-8773981166a4
 	github.com/flant/kube-client v1.9.1
 	github.com/flant/shell-operator v1.20.2
 	github.com/go-openapi/spec v0.22.1

--- a/go.sum
+++ b/go.sum
@@ -220,6 +220,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/flant/addon-operator v1.24.9 h1:sMvrYcfseTOKWvnDcocPxcr25QI/vxfOOobRHWiDYUs=
 github.com/flant/addon-operator v1.24.9/go.mod h1:X6GklVOyxf6SciOR3XexUFv+lbmXUL+hvcpcsjoVDCc=
+github.com/flant/addon-operator v1.24.10-0.20260814103130-8773981166a4 h1:+p19B5nieXMMb84JgUjdWp/87g3BSZ3oA70BBekEIYg=
+github.com/flant/addon-operator v1.24.10-0.20260814103130-8773981166a4/go.mod h1:X6GklVOyxf6SciOR3XexUFv+lbmXUL+hvcpcsjoVDCc=
 github.com/flant/kube-client v1.9.1 h1:B5Sa++5arl3N/KBdL1KNMlUBtzQXKz1o2FIiFb4X+VA=
 github.com/flant/kube-client v1.9.1/go.mod h1:jAQ01+f5Q8UJJ4RYZlk5xqoA+OOalpr/QJ3e3Q/saqw=
 github.com/flant/shell-operator v1.20.2 h1:rI2lIkhZxIfMVR0NFMSZ5xyXMvtBj+Wai2MPopb/Yp0=

--- a/go.sum
+++ b/go.sum
@@ -222,6 +222,8 @@ github.com/flant/addon-operator v1.24.9 h1:sMvrYcfseTOKWvnDcocPxcr25QI/vxfOOobRH
 github.com/flant/addon-operator v1.24.9/go.mod h1:X6GklVOyxf6SciOR3XexUFv+lbmXUL+hvcpcsjoVDCc=
 github.com/flant/addon-operator v1.24.10-0.20260814103130-8773981166a4 h1:+p19B5nieXMMb84JgUjdWp/87g3BSZ3oA70BBekEIYg=
 github.com/flant/addon-operator v1.24.10-0.20260814103130-8773981166a4/go.mod h1:X6GklVOyxf6SciOR3XexUFv+lbmXUL+hvcpcsjoVDCc=
+github.com/flant/addon-operator v1.24.10 h1:PyZEKyNpYsIT+8w16DtTtTQCpfiEaXyIAMXTl14Pr5w=
+github.com/flant/addon-operator v1.24.10/go.mod h1:X6GklVOyxf6SciOR3XexUFv+lbmXUL+hvcpcsjoVDCc=
 github.com/flant/kube-client v1.9.1 h1:B5Sa++5arl3N/KBdL1KNMlUBtzQXKz1o2FIiFb4X+VA=
 github.com/flant/kube-client v1.9.1/go.mod h1:jAQ01+f5Q8UJJ4RYZlk5xqoA+OOalpr/QJ3e3Q/saqw=
 github.com/flant/shell-operator v1.20.2 h1:rI2lIkhZxIfMVR0NFMSZ5xyXMvtBj+Wai2MPopb/Yp0=

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -66,7 +66,7 @@ require (
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/fatih/structtag v1.2.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/flant/addon-operator v1.24.10-0.20260814103130-8773981166a4 // indirect
+	github.com/flant/addon-operator v1.24.10 // indirect
 	github.com/flant/kube-client v1.9.1 // indirect
 	github.com/flant/shell-operator v1.20.2 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -66,7 +66,7 @@ require (
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/fatih/structtag v1.2.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/flant/addon-operator v1.24.9 // indirect
+	github.com/flant/addon-operator v1.24.10-0.20260814103130-8773981166a4 // indirect
 	github.com/flant/kube-client v1.9.1 // indirect
 	github.com/flant/shell-operator v1.20.2 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -241,6 +241,8 @@ github.com/flant/addon-operator v1.24.9 h1:sMvrYcfseTOKWvnDcocPxcr25QI/vxfOOobRH
 github.com/flant/addon-operator v1.24.9/go.mod h1:X6GklVOyxf6SciOR3XexUFv+lbmXUL+hvcpcsjoVDCc=
 github.com/flant/addon-operator v1.24.10-0.20260814103130-8773981166a4 h1:+p19B5nieXMMb84JgUjdWp/87g3BSZ3oA70BBekEIYg=
 github.com/flant/addon-operator v1.24.10-0.20260814103130-8773981166a4/go.mod h1:X6GklVOyxf6SciOR3XexUFv+lbmXUL+hvcpcsjoVDCc=
+github.com/flant/addon-operator v1.24.10 h1:PyZEKyNpYsIT+8w16DtTtTQCpfiEaXyIAMXTl14Pr5w=
+github.com/flant/addon-operator v1.24.10/go.mod h1:X6GklVOyxf6SciOR3XexUFv+lbmXUL+hvcpcsjoVDCc=
 github.com/flant/kube-client v1.9.1 h1:B5Sa++5arl3N/KBdL1KNMlUBtzQXKz1o2FIiFb4X+VA=
 github.com/flant/kube-client v1.9.1/go.mod h1:jAQ01+f5Q8UJJ4RYZlk5xqoA+OOalpr/QJ3e3Q/saqw=
 github.com/flant/shell-operator v1.20.2 h1:rI2lIkhZxIfMVR0NFMSZ5xyXMvtBj+Wai2MPopb/Yp0=

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -239,6 +239,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/flant/addon-operator v1.24.9 h1:sMvrYcfseTOKWvnDcocPxcr25QI/vxfOOobRHWiDYUs=
 github.com/flant/addon-operator v1.24.9/go.mod h1:X6GklVOyxf6SciOR3XexUFv+lbmXUL+hvcpcsjoVDCc=
+github.com/flant/addon-operator v1.24.10-0.20260814103130-8773981166a4 h1:+p19B5nieXMMb84JgUjdWp/87g3BSZ3oA70BBekEIYg=
+github.com/flant/addon-operator v1.24.10-0.20260814103130-8773981166a4/go.mod h1:X6GklVOyxf6SciOR3XexUFv+lbmXUL+hvcpcsjoVDCc=
 github.com/flant/kube-client v1.9.1 h1:B5Sa++5arl3N/KBdL1KNMlUBtzQXKz1o2FIiFb4X+VA=
 github.com/flant/kube-client v1.9.1/go.mod h1:jAQ01+f5Q8UJJ4RYZlk5xqoA+OOalpr/QJ3e3Q/saqw=
 github.com/flant/shell-operator v1.20.2 h1:rI2lIkhZxIfMVR0NFMSZ5xyXMvtBj+Wai2MPopb/Yp0=


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

`InjectRegistryValue` wrote a `*structpb.Struct` into the package values tree; it now writes a plain `map[string]any` with the same keys. The `flant/addon-operator` bump carries the same fix for the module path, where the injected value was a `*modules.Registry` struct.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

CEL validation of `x-deckhouse-validations` converts values with `structpb`, which accepts only maps, slices and scalars, so a Go struct anywhere in the values tree fails the whole validation with `proto: invalid type`. On the module path this broke every hook values patch of any module that has a root-level validation rule and a registry injected from a `ModuleSource`, and the module never converged; on the package path the same failure was waiting for the first package with a root-level rule.

### Notes

Pinned to `addon-operator v1.24.10`, the release carrying flant/addon-operator#820.

### Manual testing

Converged the same external module twice in one cluster — with `addon-operator v1.24.9` and with the pin from this PR. The module carries a root-level `x-deckhouse-validations` rule and an onStartup hook that patches module values, which is the combination that triggers the defect. Module name sanitized to `<module>`, stacktrace elided.

Before, every retry of the hook's values patch failed:

```
k -n d8-system logs deployment/deckhouse | grep "invalid type"
{"level":"error","logger":"addon-operator.module-run","msg":"ModuleRun failed. Requeue task to retry after delay.","binding":"ConvergeModules","count":8,"error":"2 errors occurred:\n\t* cannot apply values patch for module values\n\t* convert values to struct: proto: invalid type: *modules.Registry\n\n","event.type":"OperatorStartup","module":"<module>","phase":"Startup","queue":"main","task.id":"<task-id>","stacktrace":[...]}

k get module <module> -o jsonpath='{.status.phase}'
Error
```

After, same module and same rule:

```
k -n d8-system logs deployment/deckhouse | grep -c "invalid type"
0

k get module <module> -o jsonpath='{.status.phase}'
Ready
```

The rule is evaluated rather than silently skipped — admission rejects a value it forbids and accepts one it allows:

```
k patch mc <module> --type=merge -p '{"spec":{"version":1,"settings":{"replicas":5}}}' --dry-run=server
The request is invalid: : spec.settings are not valid (version 1):  validate config values: replicas must not exceed 3

k patch mc <module> --type=merge -p '{"spec":{"version":1,"settings":{"replicas":2}}}' --dry-run=server
moduleconfig.deckhouse.io/<module> patched
```

Not covered in the cluster: the packages path in `internal/packages/values`, which had the same defect with a `*structpb.Struct` and is fixed by the same change.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: fix values validation failing on the injected registry
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->


