### PR TITLE
test: rollout gate and self-updating agent trial stand

### DIFF
--- a/modules/007-registrypackages/images/nodelet/werf.inc.yaml
+++ b/modules/007-registrypackages/images/nodelet/werf.inc.yaml
@@ -15,7 +15,7 @@
          up agent changes. Currently the tip of selfupdate-on-main, which adds the
          trial-and-demote self-update on top of the self-restart and the rootfs
          A/B controller. Trial artifact, not for merge. */ -}}
-  {{- $nodeletCommit := "c8eef5606bb5d3d9ebb8b477e4c1cf8167d76f39" }}
+  {{- $nodeletCommit := "20642623cec83f71dac035b5c76b6647bc1008f5" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false

--- a/modules/007-registrypackages/images/nodelet/werf.inc.yaml
+++ b/modules/007-registrypackages/images/nodelet/werf.inc.yaml
@@ -12,10 +12,10 @@
   {{- /* The agent has no releases yet, so it is pinned by commit: werf keys a
          shell-cloned source on the rendered instructions alone, and a moving
          branch would be built once and cached forever. Bump this line to pick
-         up agent changes. Currently main, which carries both the self-restart and the
-         rootfs A/B controller: an older agent restarts its own unit mid-pass,
-         and one without os-image cannot update the root at all. */ -}}
-  {{- $nodeletCommit := "42f770a2fe94ff24e69faf2a372ea54cd319c761" }}
+         up agent changes. Currently the tip of selfupdate-on-main, which adds the
+         trial-and-demote self-update on top of the self-restart and the rootfs
+         A/B controller. Trial artifact, not for merge. */ -}}
+  {{- $nodeletCommit := "fbe7a1fbffb380596c99fdc8db2e7c0e7a0b1f5f" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false

--- a/modules/007-registrypackages/images/nodelet/werf.inc.yaml
+++ b/modules/007-registrypackages/images/nodelet/werf.inc.yaml
@@ -15,7 +15,7 @@
          up agent changes. Currently the tip of selfupdate-on-main, which adds the
          trial-and-demote self-update on top of the self-restart and the rootfs
          A/B controller. Trial artifact, not for merge. */ -}}
-  {{- $nodeletCommit := "fbe7a1fbffb380596c99fdc8db2e7c0e7a0b1f5f" }}
+  {{- $nodeletCommit := "c8eef5606bb5d3d9ebb8b477e4c1cf8167d76f39" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/nodeconfig/controller.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/nodeconfig/controller.go
@@ -22,6 +22,7 @@ package nodeconfig
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -136,6 +137,12 @@ func (r *Reconciler) reconcileAllNodes(ctx context.Context, logger logr.Logger) 
 		return ctrl.Result{}, fmt.Errorf("list nodes: %w", err)
 	}
 
+	// Unhealthy nodes first, the way bashible hands its approvals out: with one
+	// slot free, repairing what is broken beats touching what works.
+	sort.SliceStable(nodes.Items, func(i, j int) bool {
+		return !nodeIsReady(&nodes.Items[i]) && nodeIsReady(&nodes.Items[j])
+	})
+
 	var firstErr error
 	failed := 0
 	p := newPass()
@@ -162,6 +169,18 @@ func (r *Reconciler) reconcileAllNodes(ctx context.Context, logger logr.Logger) 
 	}
 
 	return ctrl.Result{}, firstErr
+}
+
+// nodeIsReady reports the kubelet's own verdict, which is what "broken" means
+// here — not whether the configuration converged.
+func nodeIsReady(node *corev1.Node) bool {
+	for i := range node.Status.Conditions {
+		c := &node.Status.Conditions[i]
+		if c.Type == corev1.NodeReady {
+			return c.Status == corev1.ConditionTrue
+		}
+	}
+	return false
 }
 
 // reconcileNode brings one node's NodeConfig in line with its NodeGroup. A node

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/nodeconfig/controller.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/nodeconfig/controller.go
@@ -292,7 +292,9 @@ func (r *Reconciler) apply(ctx context.Context, ng *v1.NodeGroup, node *corev1.N
 		return nil, err
 	}
 	if !budget.hasSlot(desired.Name) {
-		logger.Info("holding the NodeConfig back until the group has a free rollout slot", "node", desired.Name, "nodeGroup", ng.Name)
+		logger.Info("holding the NodeConfig back until the group has a free rollout slot",
+			"node", desired.Name, "nodeGroup", ng.Name,
+			"waitingFor", budget.holders(), "concurrency", budget.concurrency)
 		return existing, nil
 	}
 

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/nodeconfig/e2e_test.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/nodeconfig/e2e_test.go
@@ -39,6 +39,7 @@ import (
 	v1alpha1 "github.com/deckhouse/node-controller/api/deckhouse.io/v1alpha1"
 	internalv1alpha1 "github.com/deckhouse/node-controller/api/internal.deckhouse.io/v1alpha1"
 	nodecommon "github.com/deckhouse/node-controller/internal/common"
+	"github.com/deckhouse/node-controller/internal/controller/nodegroup/derived_status"
 	"github.com/deckhouse/node-controller/internal/testenv"
 )
 
@@ -432,9 +433,12 @@ var _ = Describe("NodeConfig controller", func() {
 	})
 
 	// User story: As an operator whose immutable nodes have gone quiet, I want a
-	// NodeGroup edit to reach none of them rather than all, so a fleet with down
-	// agents does not take a change together and interrupt itself together later.
-	It("gives no node a slot while more of the group is silent than it may update", func(ctx context.Context) {
+	// NodeGroup edit to reach them one at a time rather than all together, so a
+	// fleet with down agents does not take a change together and interrupt itself
+	// together later. Silence on a spec nobody publishes any more does not hold a
+	// slot — the group would never get the edit that fixes it — but the node that
+	// takes the edit does, so the gate never opens wider than one node.
+	It("hands a silent group its change one node at a time", func(ctx context.Context) {
 		ngName := testenv.UniqueName("workers-silent")
 		createImmutableNodeGroup(ctx, ngName, func(ng *deckhousev1.NodeGroup) {
 			ng.Spec.Kubelet = &deckhousev1.KubeletSpec{MaxPods: ptr.To[int32](110)}
@@ -463,20 +467,30 @@ var _ = Describe("NodeConfig controller", func() {
 		ng.Spec.Kubelet.MaxPods = ptr.To[int32](200)
 		Expect(k8sClient.Patch(ctx, ng, patch)).To(Succeed())
 
-		// Three nodes mid-update and one update allowed: the change waits for the
-		// group to come back rather than being handed to all three at once.
-		Consistently(func(g Gomega) {
-			g.Expect(updatedNodes(ctx, g, nodes...)).To(Equal(0))
-		}, testenv.NegativeCheckDuration, testenv.EventuallyPoll).Should(Succeed())
-
-		By("the agents reporting the config they were given")
-		for _, name := range nodes {
-			reportApplied(ctx, name)
-		}
-
+		// One update allowed: the node that takes it holds the only slot, however
+		// silent the other two are.
 		Eventually(func(g Gomega) {
 			g.Expect(updatedNodes(ctx, g, nodes...)).To(Equal(1))
 		}, testenv.EventuallyTimeout, testenv.EventuallyPoll).Should(Succeed())
+		Consistently(func(g Gomega) {
+			g.Expect(updatedNodes(ctx, g, nodes...)).To(Equal(1))
+		}, testenv.NegativeCheckDuration, testenv.EventuallyPoll).Should(Succeed())
+
+		By("the node that took it reporting the config it was given")
+		for _, name := range nodes {
+			if getNodeConfig(ctx, Default, name).Spec.Kubelet.MaxPods == 200 {
+				reportApplied(ctx, name)
+			}
+		}
+
+		// The next node takes it and holds the slot in its turn: the change walks
+		// the group, one proof at a time, instead of arriving everywhere at once.
+		Eventually(func(g Gomega) {
+			g.Expect(updatedNodes(ctx, g, nodes...)).To(Equal(2))
+		}, testenv.EventuallyTimeout, testenv.EventuallyPoll).Should(Succeed())
+		Consistently(func(g Gomega) {
+			g.Expect(updatedNodes(ctx, g, nodes...)).To(Equal(2))
+		}, testenv.NegativeCheckDuration, testenv.EventuallyPoll).Should(Succeed())
 	})
 
 	// User story: As an operator, I want a release that ships a rebuilt system
@@ -596,30 +610,47 @@ var _ = Describe("NodeConfig controller", func() {
 		// updating.
 		stale := staleGroupSnapshot(ctx, ngName)
 
-		By("handing the first node a new spec")
-		nc := getNodeConfig(ctx, Default, first)
-		patch := client.MergeFrom(nc.DeepCopy())
-		nc.Spec.Kubelet.MaxPods = 199
-		Expect(k8sClient.Patch(ctx, nc, patch)).To(Succeed())
-
+		By("raising maxPods, which the controller hands to one of the two")
 		ng := &deckhousev1.NodeGroup{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: ngName}, ng)).To(Succeed())
+		patch := client.MergeFrom(ng.DeepCopy())
+		ng.Spec.Kubelet.MaxPods = ptr.To[int32](200)
+		Expect(k8sClient.Patch(ctx, ng, patch)).To(Succeed())
+
+		var moved, waiting string
+		Eventually(func(g Gomega) {
+			moved, waiting = "", ""
+			for _, name := range []string{first, second} {
+				if getNodeConfig(ctx, g, name).Spec.Kubelet.MaxPods == 200 {
+					moved = name
+					continue
+				}
+				waiting = name
+			}
+			g.Expect(moved).NotTo(BeEmpty())
+			g.Expect(waiting).NotTo(BeEmpty())
+		}, testenv.EventuallyTimeout, testenv.EventuallyPoll).Should(Succeed())
+
+		// The gate renders against the group as it now stands, so the node that
+		// took the change reads as carrying the published spec unproven.
 		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: ngName}, ng)).To(Succeed())
 		gate := &Reconciler{}
 		gate.Client = stale
 		gate.sources = &sourceReader{Client: stale, Reader: apiReader}
+		gate.derived = &derived_status.Service{Client: k8sClient}
 
-		// One node is mid-update and maxConcurrent defaults to one: the second
-		// node must wait, however applied the cache believes the group to be.
+		// One node is mid-update and maxConcurrent defaults to one: the other node
+		// must wait, however applied the cache believes the group to be.
 		// Each check reads the budget afresh — a budget is per pass.
 		Eventually(func(g Gomega) {
-			g.Expect(rolloutSlotFor(ctx, g, gate, ng, second)).To(BeFalse())
+			g.Expect(rolloutSlotFor(ctx, g, gate, ng, waiting)).To(BeFalse())
 		}, testenv.EventuallyTimeout, testenv.EventuallyPoll).Should(Succeed())
 
-		By("the first node reporting the spec it was given")
-		reportApplied(ctx, first)
+		By("the node that took it reporting the spec it was given")
+		reportApplied(ctx, moved)
 
 		Eventually(func(g Gomega) {
-			g.Expect(rolloutSlotFor(ctx, g, gate, ng, second)).To(BeTrue())
+			g.Expect(rolloutSlotFor(ctx, g, gate, ng, waiting)).To(BeTrue())
 		}, testenv.EventuallyTimeout, testenv.EventuallyPoll).Should(Succeed())
 	})
 

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/nodeconfig/e2e_test.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/nodeconfig/e2e_test.go
@@ -493,6 +493,57 @@ var _ = Describe("NodeConfig controller", func() {
 		}, testenv.NegativeCheckDuration, testenv.EventuallyPoll).Should(Succeed())
 	})
 
+	// User story: as an operator whose whole group broke on a bad release, I want
+	// the fix to reach it. Measured twice on zykov-ab-57a656c4: two workers on
+	// generation 1 while the master was on 5, and only raising maxConcurrent moved
+	// them.
+	It("delivers a new spec to a group where no node has converged", func(ctx context.Context) {
+		ngName := testenv.UniqueName("workers-wedged")
+		createImmutableNodeGroup(ctx, ngName, nil)
+
+		first := testenv.UniqueName("node")
+		second := testenv.UniqueName("node")
+		createNode(ctx, first, ngName)
+		createNode(ctx, second, ngName)
+
+		// Both nodes report the published spec as not applied — a bad release, a
+		// registry outage, anything that lands on the whole group at once.
+		for _, name := range []string{first, second} {
+			Eventually(func(g Gomega) {
+				nc := getNodeConfig(ctx, g, name)
+				meta.SetStatusCondition(&nc.Status.Conditions, metav1.Condition{
+					Type: configurationAppliedCondition, Status: metav1.ConditionFalse,
+					Reason: "RollbackFailed", Message: "the previous configuration could not be restored",
+				})
+				nc.Status.AppliedGeneration = 0
+				g.Expect(k8sClient.Status().Update(ctx, nc)).To(Succeed())
+			}, testenv.EventuallyTimeout, testenv.EventuallyPoll).Should(Succeed())
+		}
+
+		By("the release publishing the cure")
+		setContainerdDigest(ctx, testContainerdRebuiltDigest)
+
+		curedNodes := func(g Gomega) int {
+			cured := 0
+			for _, name := range []string{first, second} {
+				if digestOf(getNodeConfig(ctx, g, name), containerdExtension) == testContainerdRebuiltDigest {
+					cured++
+				}
+			}
+			return cured
+		}
+
+		Eventually(func(g Gomega) {
+			g.Expect(curedNodes(g)).To(Equal(1),
+				"exactly one node of a wedged group must get the cure: none means the group is locked, both means the gate is gone")
+		}, testenv.EventuallyTimeout, testenv.EventuallyPoll).Should(Succeed())
+		// The cure is still a change under test: the node that took it holds the
+		// slot until it proves it, so the second node waits its turn.
+		Consistently(func(g Gomega) {
+			g.Expect(curedNodes(g)).To(Equal(1))
+		}, testenv.NegativeCheckDuration, testenv.EventuallyPoll).Should(Succeed())
+	})
+
 	// User story: As an operator, I want a release that ships a rebuilt system
 	// extension to reach the fleet on its own. The digests ConfigMap used to be
 	// read but not watched, so the new digest sat unnoticed until some unrelated

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/nodeconfig/e2e_test.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/nodeconfig/e2e_test.go
@@ -544,6 +544,57 @@ var _ = Describe("NodeConfig controller", func() {
 		}, testenv.NegativeCheckDuration, testenv.EventuallyPoll).Should(Succeed())
 	})
 
+	// bashible gives the approval to unhealthy nodes first: fixing what is broken
+	// beats touching what works. Ported here for the same reason. The healthy node
+	// is created first, so without the ordering it takes the only slot, never
+	// reports back, and the broken one waits for a change that never arrives.
+	It("gives the free slot to the unhealthy node first", func(ctx context.Context) {
+		ngName := testenv.UniqueName("workers-priority")
+		createImmutableNodeGroup(ctx, ngName, nil)
+
+		healthy := testenv.UniqueName("node")
+		broken := testenv.UniqueName("node")
+		createNode(ctx, healthy, ngName)
+		createNode(ctx, broken, ngName)
+		heartbeat(ctx, healthy)
+
+		Eventually(func(g Gomega) {
+			node := &corev1.Node{}
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: broken}, node)).To(Succeed())
+			patch := client.MergeFrom(node.DeepCopy())
+			node.Status.Conditions = []corev1.NodeCondition{{
+				Type:              corev1.NodeReady,
+				Status:            corev1.ConditionFalse,
+				Reason:            "KubeletNotReady",
+				Message:           "kubelet stopped posting node status",
+				LastHeartbeatTime: metav1.Now(),
+			}}
+			g.Expect(k8sClient.Status().Patch(ctx, node, patch)).To(Succeed())
+		}, testenv.EventuallyTimeout, testenv.EventuallyPoll).Should(Succeed())
+
+		// Both configured and settled first: a node that has just joined is given
+		// its config without passing the gate at all, so publishing the change
+		// before that has happened would test nothing.
+		Eventually(func(g Gomega) {
+			g.Expect(digestOf(getNodeConfig(ctx, g, healthy), containerdExtension)).To(Equal(testContainerdDigest))
+			g.Expect(digestOf(getNodeConfig(ctx, g, broken), containerdExtension)).To(Equal(testContainerdDigest))
+		}, testenv.EventuallyTimeout, testenv.EventuallyPoll).Should(Succeed())
+
+		By("the release publishing a change")
+		setContainerdDigest(ctx, testContainerdRebuiltDigest)
+
+		Eventually(func(g Gomega) {
+			g.Expect(digestOf(getNodeConfig(ctx, g, broken), containerdExtension)).
+				To(Equal(testContainerdRebuiltDigest), "the unhealthy node must be served first")
+		}, testenv.EventuallyTimeout, testenv.EventuallyPoll).Should(Succeed())
+		// The broken node never reports back, so it holds the only slot: the
+		// healthy one is left alone, which is the other half of serving the
+		// broken one first.
+		Consistently(func(g Gomega) {
+			g.Expect(digestOf(getNodeConfig(ctx, g, healthy), containerdExtension)).To(Equal(testContainerdDigest))
+		}, testenv.NegativeCheckDuration, testenv.EventuallyPoll).Should(Succeed())
+	})
+
 	// User story: As an operator, I want a release that ships a rebuilt system
 	// extension to reach the fleet on its own. The digests ConfigMap used to be
 	// read but not watched, so the new digest sat unnoticed until some unrelated

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/nodeconfig/rollout.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/nodeconfig/rollout.go
@@ -106,6 +106,12 @@ func (b *rolloutBudget) hasSlot(nodeName string) bool {
 	return len(b.updating) < b.concurrency
 }
 
+// holders names the nodes occupying the slots, sorted, for the one log line an
+// operator reads when a rollout is not moving.
+func (b *rolloutBudget) holders() []string {
+	return slices.Sorted(maps.Keys(b.updating))
+}
+
 // spend records that a node was handed a new spec, so the nodes rendered after
 // it in the same pass are judged against a group where it is updating.
 func (b *rolloutBudget) spend(nodeName string) {

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/nodeconfig/rollout.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/nodeconfig/rollout.go
@@ -90,9 +90,9 @@ func conditionEqual(before, after []metav1.Condition, name string) bool {
 // broken on a spec nobody publishes any more is not mid-rollout.
 type rolloutBudget struct {
 	concurrency int
-	// updating holds the nodes of the group that are mid-update: those that had
-	// not applied their config when the group was read, plus the ones this pass
-	// has handed a new spec to since.
+	// updating holds the nodes of the group that are mid-update: those carrying
+	// the published spec unproven when the group was read, plus the ones this
+	// pass has handed a new spec to since.
 	updating map[string]struct{}
 }
 

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/nodeconfig/rollout.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/nodeconfig/rollout.go
@@ -163,7 +163,6 @@ func (r *Reconciler) rolloutBudget(ctx context.Context, ng *v1.NodeGroup, p *pas
 // desired spec has no live Node and is about to be deleted.
 func membersOfUpdating(configs []internalv1alpha1.NodeConfig,
 	desired map[string]internalv1alpha1.NodeSpec) map[string]struct{} {
-
 	updating := make(map[string]struct{})
 	for i := range configs {
 		nc := &configs[i]

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/nodeconfig/rollout.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/nodeconfig/rollout.go
@@ -22,6 +22,8 @@ import (
 	"maps"
 	"slices"
 
+	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -83,9 +85,9 @@ func conditionEqual(before, after []metav1.Condition, name string) bool {
 		oldCondition.ObservedGeneration == newCondition.ObservedGeneration
 }
 
-// rolloutBudget is how many more nodes of one group may be handed a new spec —
-// the same guarantee bashible nodes get from update-approval annotations,
-// except this controller simply withholds the change.
+// rolloutBudget is how many more nodes of one group may be handed a new spec.
+// Like bashible's update-approval, it counts grants and not health: a node
+// broken on a spec nobody publishes any more is not mid-rollout.
 type rolloutBudget struct {
 	concurrency int
 	// updating holds the nodes of the group that are mid-update: those that had
@@ -123,17 +125,59 @@ func (r *Reconciler) rolloutBudget(ctx context.Context, ng *v1.NodeGroup, p *pas
 		return nil, fmt.Errorf("list NodeConfigs of %s: %w", ng.Name, err)
 	}
 
+	nodes := &corev1.NodeList{}
+	if err := r.sources.Reader.List(ctx, nodes, client.MatchingLabels{nodecommon.NodeGroupLabel: ng.Name}); err != nil {
+		return nil, fmt.Errorf("list Nodes of %s: %w", ng.Name, err)
+	}
+	// The same render apply() gives the node, so a node that already carries what
+	// the cluster publishes is not mistaken for one left behind. Read once for
+	// the group: renderSpec is pure and the inputs are memoised in the pass.
+	in, err := r.clusterInputs(ctx, ng, p)
+	if err != nil {
+		return nil, err
+	}
+	desired := make(map[string]internalv1alpha1.NodeSpec, len(nodes.Items))
+	for i := range nodes.Items {
+		desired[nodes.Items[i].Name] = renderSpec(ng, &nodes.Items[i], in)
+	}
+
 	budget := &rolloutBudget{
 		concurrency: ua.CalculateConcurrency(maxConcurrent(ng), len(configs.Items)),
-		updating:    make(map[string]struct{}),
-	}
-	for i := range configs.Items {
-		if !applied(&configs.Items[i]) {
-			budget.updating[configs.Items[i].Name] = struct{}{}
-		}
+		updating:    membersOfUpdating(configs.Items, desired),
 	}
 	p.rollouts[ng.Name] = budget
 	return budget, nil
+}
+
+// membersOfUpdating names the nodes that occupy a rollout slot: those carrying
+// the spec the cluster publishes now, and not yet proven.
+//
+// A node stuck on an older spec is not mid-rollout, it is broken, and counting
+// it locks the cure out of a group that is already broken. A NodeConfig with no
+// desired spec has no live Node and is about to be deleted.
+func membersOfUpdating(configs []internalv1alpha1.NodeConfig,
+	desired map[string]internalv1alpha1.NodeSpec) map[string]struct{} {
+
+	updating := make(map[string]struct{})
+	for i := range configs {
+		nc := &configs[i]
+		want, ok := desired[nc.Name]
+		if !ok {
+			continue
+		}
+		if applied(nc) {
+			continue
+		}
+		// The carry-over apply() performs, with no reported address: a node
+		// keeping what it booted with is not drift, and reading it as drift
+		// would free a slot the node is genuinely holding.
+		keepBootstrapOnlyFields(&want, &nc.Spec, nil)
+		if !apiequality.Semantic.DeepEqual(nc.Spec, want) {
+			continue
+		}
+		updating[nc.Name] = struct{}{}
+	}
+	return updating
 }
 
 // applied reports whether the node has finished reconciling the spec it was

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/nodeconfig/rollout_test.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/nodeconfig/rollout_test.go
@@ -117,6 +117,88 @@ func TestRolloutBudget(t *testing.T) {
 	})
 }
 
+// testOldOSImageDigest is a spec nobody publishes any more: what a node left
+// behind by a bad release is still carrying.
+const testOldOSImageDigest = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+
+func notApplied(name string, spec internalv1alpha1.NodeSpec) internalv1alpha1.NodeConfig {
+	nc := internalv1alpha1.NodeConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Generation: 2},
+		Spec:       spec,
+	}
+	nc.Status.AppliedGeneration = 1
+	return nc
+}
+
+func appliedConfig(name string, spec internalv1alpha1.NodeSpec) internalv1alpha1.NodeConfig {
+	nc := internalv1alpha1.NodeConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Generation: 2},
+		Spec:       spec,
+	}
+	nc.Status.AppliedGeneration = 2
+	meta.SetStatusCondition(&nc.Status.Conditions, metav1.Condition{
+		Type: configurationAppliedCondition, Status: metav1.ConditionTrue,
+		Reason: "ReconcileSucceeded", Message: "applied", ObservedGeneration: nc.Generation,
+	})
+	return nc
+}
+
+// The gate must hold "no more than N nodes carry an unproven current spec", not
+// "no more than N nodes are unhealthy" — the latter it cannot control, and
+// trying to hold it locks the cure out of a group that is already broken.
+func TestBudgetIgnoresNodesStuckOnAnOlderSpec(t *testing.T) {
+	desired := internalv1alpha1.NodeSpec{NodeName: "n1", OSImage: internalv1alpha1.OSImage{Digest: testOSImageDigest}}
+	stale := internalv1alpha1.NodeSpec{NodeName: "n1", OSImage: internalv1alpha1.OSImage{Digest: testOldOSImageDigest}}
+
+	configs := []internalv1alpha1.NodeConfig{
+		notApplied("n1", stale),   // broken on a spec nobody publishes any more
+		notApplied("n2", desired), // genuinely mid-rollout
+		appliedConfig("n3", desired),
+	}
+
+	updating := membersOfUpdating(configs, map[string]internalv1alpha1.NodeSpec{
+		"n1": desired, "n2": desired, "n3": desired,
+	})
+
+	if _, ok := updating["n1"]; ok {
+		t.Fatal("a node stuck on an older spec occupies a rollout slot it does not use")
+	}
+	if _, ok := updating["n2"]; !ok {
+		t.Fatal("a node carrying the current spec without proving it must hold its slot")
+	}
+	if _, ok := updating["n3"]; ok {
+		t.Fatal("a converged node holds a slot")
+	}
+}
+
+// A NodeConfig whose Node is gone is about to be deleted; it must not hold the
+// group hostage in the meantime.
+func TestBudgetIgnoresOrphans(t *testing.T) {
+	desired := internalv1alpha1.NodeSpec{NodeName: "gone", OSImage: internalv1alpha1.OSImage{Digest: testOSImageDigest}}
+	configs := []internalv1alpha1.NodeConfig{notApplied("gone", desired)}
+
+	if updating := membersOfUpdating(configs, map[string]internalv1alpha1.NodeSpec{}); len(updating) != 0 {
+		t.Fatalf("membersOfUpdating() = %v, want empty: an orphan holds no slot", updating)
+	}
+}
+
+// The bootstrap-only fields the render cannot reproduce must not read as drift:
+// a node keeping the address it booted with is not stuck on an older spec.
+func TestBudgetIgnoresBootstrapOnlyFields(t *testing.T) {
+	desired := internalv1alpha1.NodeSpec{NodeName: "n1", OSImage: internalv1alpha1.OSImage{Digest: testOSImageDigest}}
+	bootstrapped := desired
+	bootstrapped.Kubelet.NodeIP = "10.0.0.5"
+
+	updating := membersOfUpdating(
+		[]internalv1alpha1.NodeConfig{notApplied("n1", bootstrapped)},
+		map[string]internalv1alpha1.NodeSpec{"n1": desired},
+	)
+
+	if _, ok := updating["n1"]; !ok {
+		t.Fatal("a node carrying the current spec plus its bootstrapped address must hold its slot")
+	}
+}
+
 func nodeConfigAt(generation, observed, applied int64, phase string) *internalv1alpha1.NodeConfig {
 	nc := &internalv1alpha1.NodeConfig{}
 	nc.Generation = generation

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/nodeconfig/rollout_test.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/nodeconfig/rollout_test.go
@@ -117,6 +117,18 @@ func TestRolloutBudget(t *testing.T) {
 	})
 }
 
+// The held node's log line names who it is waiting for, so the order has to be
+// the group's and not the map's — an operator comparing two lines must not see
+// the same group reshuffled.
+func TestBudgetHoldersAreSorted(t *testing.T) {
+	budget := &rolloutBudget{concurrency: 1, updating: map[string]struct{}{
+		"node-c": {}, "node-a": {}, "node-b": {},
+	}}
+
+	require.Equal(t, []string{"node-a", "node-b", "node-c"}, budget.holders())
+	require.Empty(t, (&rolloutBudget{updating: map[string]struct{}{}}).holders())
+}
+
 // testOldOSImageDigest is a spec nobody publishes any more: what a node left
 // behind by a bad release is still carrying.
 const testOldOSImageDigest = "sha256:1111111111111111111111111111111111111111111111111111111111111111"

--- a/modules/040-node-manager/images/olcedar/werf.inc.yaml
+++ b/modules/040-node-manager/images/olcedar/werf.inc.yaml
@@ -1,4 +1,6 @@
-{{- $version := "v0.1.3"  }}
+{{- /* Trial build from the protected agent-restart-limit branch: initramfs that
+       identifies the system disk, plus the agent restart limit. Not for merge. */ -}}
+{{- $version := "e18e8becdc4c9a85e4badc34f635092555995f4796d328aa99e1c077-1786707571684"  }}
 {{- if ne $.Env "CSE" }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact


### PR DESCRIPTION
Test stand only — never merge.

Builds two images for the live trials on the immutable stand:

- `node-controller` with the rollout-gate membership fix (a slot is held only by a node carrying the current, unproven spec; unhealthy nodes are served first).
- `nodelet` sysext pinned to the tip of `selfupdate-on-main` (trial-and-demote self-update).

Base is `nodelet-sysext` (#22101), so the diff shows only the gate commits plus the pin.

The real gate change will come as its own PR from `rollout-gate-membership`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0146tQC21Qc8YED924aALToL