### PR TITLE
[chrony] revert chrony_exporter to 0.11.0, close CVEs by go.mod bump

### DIFF
--- a/modules/470-chrony/images/chrony-exporter/patches/chrony_exporter/001-go-mod.patch
+++ b/modules/470-chrony/images/chrony-exporter/patches/chrony_exporter/001-go-mod.patch
@@ -1,0 +1,66 @@
+diff --git a/go.mod b/go.mod
+index 334541f..fa425de 100644
+--- a/go.mod
++++ b/go.mod
+@@ -1,6 +1,6 @@
+ module github.com/superq/chrony_exporter
+ 
+-go 1.22
++go 1.25.0
+ 
+ require (
+ 	github.com/alecthomas/kingpin/v2 v2.4.0
+@@ -24,12 +24,12 @@ require (
+ 	github.com/prometheus/client_model v0.6.1 // indirect
+ 	github.com/prometheus/procfs v0.15.1 // indirect
+ 	github.com/xhit/go-str2duration/v2 v2.1.0 // indirect
+-	golang.org/x/crypto v0.27.0 // indirect
+-	golang.org/x/net v0.29.0 // indirect
+-	golang.org/x/oauth2 v0.23.0 // indirect
+-	golang.org/x/sync v0.8.0 // indirect
+-	golang.org/x/sys v0.25.0 // indirect
+-	golang.org/x/text v0.18.0 // indirect
++	golang.org/x/crypto v0.53.0 // indirect
++	golang.org/x/net v0.56.0 // indirect
++	golang.org/x/oauth2 v0.27.0 // indirect
++	golang.org/x/sync v0.21.0 // indirect
++	golang.org/x/sys v0.46.0 // indirect
++	golang.org/x/text v0.39.0 // indirect
+ 	google.golang.org/protobuf v1.34.2 // indirect
+ 	gopkg.in/yaml.v2 v2.4.0 // indirect
+ )
+diff --git a/go.sum b/go.sum
+index 596a73d..17cc8e3 100644
+--- a/go.sum
++++ b/go.sum
+@@ -54,18 +54,18 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
+ github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+ github.com/xhit/go-str2duration/v2 v2.1.0 h1:lxklc02Drh6ynqX+DdPyp5pCKLUQpRT8bp8Ydu2Bstc=
+ github.com/xhit/go-str2duration/v2 v2.1.0/go.mod h1:ohY8p+0f07DiV6Em5LKB0s2YpLtXVyJfNt1+BlmyAsU=
+-golang.org/x/crypto v0.27.0 h1:GXm2NjJrPaiv/h1tb2UH8QfgC/hOf/+z0p6PT8o1w7A=
+-golang.org/x/crypto v0.27.0/go.mod h1:1Xngt8kV6Dvbssa53Ziq6Eqn0HqbZi5Z6R0ZpwQzt70=
+-golang.org/x/net v0.29.0 h1:5ORfpBpCs4HzDYoodCDBbwHzdR5UrLBZ3sOnUJmFoHo=
+-golang.org/x/net v0.29.0/go.mod h1:gLkgy8jTGERgjzMic6DS9+SP0ajcu6Xu3Orq/SpETg0=
+-golang.org/x/oauth2 v0.23.0 h1:PbgcYx2W7i4LvjJWEbf0ngHV6qJYr86PkAV3bXdLEbs=
+-golang.org/x/oauth2 v0.23.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
+-golang.org/x/sync v0.8.0 h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=
+-golang.org/x/sync v0.8.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+-golang.org/x/sys v0.25.0 h1:r+8e+loiHxRqhXVl6ML1nO3l1+oFoWbnlu2Ehimmi34=
+-golang.org/x/sys v0.25.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+-golang.org/x/text v0.18.0 h1:XvMDiNzPAl0jr17s6W9lcaIhGUfUORdGCNsuLmPG224=
+-golang.org/x/text v0.18.0/go.mod h1:BuEKDfySbSR4drPmRPG/7iBdf8hvFMuRexcpahXilzY=
++golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=
++golang.org/x/crypto v0.53.0/go.mod h1:DNLU434OwVakk9PzuwV8w62mAJpRJL3vsgcfp4Qnsio=
++golang.org/x/net v0.56.0 h1:Rw8j/hFzGvJUZwNBXnAtf5sVDVt+65SK2C7IxCxZt5o=
++golang.org/x/net v0.56.0/go.mod h1:D3Ku6r+V6JROoZK144D2XfMHFcMq/0zSfLelVTCFKec=
++golang.org/x/oauth2 v0.27.0 h1:da9Vo7/tDv5RH/7nZDz1eMGS/q1Vv1N/7FCrBhI9I3M=
++golang.org/x/oauth2 v0.27.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT8=
++golang.org/x/sync v0.21.0 h1:HLII4xRRTtCRkxYp4HNFF0Js/Og6q2i++KXbg0gHCwM=
++golang.org/x/sync v0.21.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
++golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
++golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
++golang.org/x/text v0.39.0 h1:UbZz4pLOvn600D6Oh6GGEI6VAmndrEBLv8/6BEXzyus=
++golang.org/x/text v0.39.0/go.mod h1:3UwRclnC2g0TU9x8PZiyfOajCd1zaUNHF9cvqcQZ+ZM=
+ google.golang.org/protobuf v1.34.2 h1:6xV6lTsCfpGD21XK49h7MhtcApnLqkfYgPcdHftf6hg=
+ google.golang.org/protobuf v1.34.2/go.mod h1:qYOHts0dSfpeUzUFpOMr/WGzszTmLH+DiWniOlNbLDw=
+ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/modules/470-chrony/images/chrony-exporter/patches/chrony_exporter/README.md
+++ b/modules/470-chrony/images/chrony-exporter/patches/chrony_exporter/README.md
@@ -1,0 +1,10 @@
+## patches
+
+### 001-go-mod.patch
+
+Bumps golang.org/x/net and golang.org/x/text (carrying x/crypto and x/sys) to
+clear the CVEs reported against the chrony_exporter binary, including
+CVE-2025-58181. Keeps github.com/prometheus/exporter-toolkit at v0.13.0 on
+purpose: from v0.14.0 its landing page answers 404 on any path but the route
+prefix, and the DaemonSet's liveness/readiness probes hit /healthz, which this
+exporter never serves.

--- a/modules/470-chrony/images/chrony-exporter/werf.inc.yaml
+++ b/modules/470-chrony/images/chrony-exporter/werf.inc.yaml
@@ -1,8 +1,16 @@
-{{- $chronyExproterVersion := "0.14.0"}}
+{{- $chronyExproterVersion := "0.11.0"}}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
 fromImage: common/src-artifact
 final: false
+git:
+- add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/patches
+  to: /patches
+  includePaths:
+  - '**/*.patch'
+  stageDependencies:
+    install:
+    - '**/*.patch'
 secrets:
 - id: SOURCE_REPO
   value: {{ .SOURCE_REPO }}
@@ -10,6 +18,8 @@ shell:
   install:
   - cd /src
   - git clone --depth 1 --branch v{{$chronyExproterVersion}} $(cat /run/secrets/SOURCE_REPO)/SuperQ/chrony_exporter.git chrony_exporter
+  - cd /src/chrony_exporter
+  - git apply /patches/chrony_exporter/*.patch --verbose
   - rm -rf /src/chrony_exporter/.git
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact


### PR DESCRIPTION
## Description

Reverts `chrony_exporter` from 0.14.0 back to 0.11.0 (#22115) and closes the same
CVEs with a dependency bump instead.

`001-go-mod.patch` is regenerated against v0.11.0 and now raises
`golang.org/x/net` to v0.56.0 — which carries `golang.org/x/crypto` v0.53.0 and
`golang.org/x/sys` v0.46.0 — and `golang.org/x/text` to v0.39.0.
`002-go-mod.patch` is folded into it: the same bump covers the CVE-2025-58181
mitigation it used to carry, so one patch file is left instead of two.

`github.com/prometheus/exporter-toolkit` deliberately stays at v0.13.0.

## Why do we need it, and what problem does it solve?

On 0.14.0 the `chrony-exporter` container goes into `CrashLoopBackOff`. Its
liveness and readiness probes hit `/healthz` and get a 404, so the kubelet keeps
killing it:

```
Warning  Unhealthy  Readiness probe failed: HTTP probe failed with statuscode: 404
Warning  Unhealthy  Liveness probe failed: HTTP probe failed with statuscode: 404
Normal   Killing    Container chrony-exporter failed liveness probe, will be restarted
```

**The exporter has never served `/healthz`.** `main.go` registers only
`*metricsPath` and the landing page on `/`. Up to `exporter-toolkit` v0.13.0 —
which 0.11.0 pins — the landing page answered *any* path:

```go
func (h *LandingPageHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
	w.Header().Add("Content-Type", "text/html; charset=UTF-8")
	w.Write(h.landingPage)
}
```

so the probes got a 200 by accident. v0.17.1, which 0.14.0 pulls in, added a path
check:

```go
	if r.URL.Path != h.routePrefix {
		http.NotFound(w, r)
		return
	}
```

Reproduced against both builds directly, with the same flags the DaemonSet passes:

| build | `GET /healthz` | `GET /` |
| --- | --- | --- |
| 0.11.0 + this patch (toolkit v0.13.0) | **200** | 200 |
| 0.14.0 (toolkit v0.17.1) | **404** | 200 |

So the probes in `modules/470-chrony/templates/daemonset.yaml` have been
fictitiously green all along, and the minor bump only exposed it. Moving to a
newer `chrony_exporter` therefore needs the probes pointed at an endpoint that
actually exists — that is a separate task, not something to bundle into a CVE fix.

### Verification

- `001-go-mod.patch` applies cleanly on a fresh `v0.11.0` checkout.
- The module builds for `linux/amd64`. The bump raises the `go` directive from
  1.24.0 to 1.25.0, which `builder/golang-alpine` (pinned to Go 1.25 in
  `candi/base_images.yml`) supports.
- `trivy fs` before vs after: all 23 targeted CVEs gone, no new CVE introduced —
  the `golang.org/x/crypto/ssh` family (CVE-2026-39827 … CVE-2026-39835,
  CVE-2026-42508, CVE-2026-46595, CVE-2026-46597, CVE-2026-46598),
  `golang.org/x/net` (CVE-2026-25680, CVE-2026-25681, CVE-2026-27136,
  CVE-2026-33814, CVE-2026-39821, CVE-2026-42502, CVE-2026-42506, CVE-2026-46600)
  and `golang.org/x/text` CVE-2026-56852.

Unchanged from #22115: the scanner also reports CVE-2026-27145, CVE-2026-39822,
CVE-2026-42504, CVE-2026-42505 and CVE-2026-42507 on this binary. Those are Go
**stdlib** CVEs and are fixed by bumping the Go builder images repo-wide.

## Why do we need it in the patch release (if we do)?

Yes — #22115 is already on `main`, and any build carrying it has a crash-looping
`chrony-exporter` container on every node.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: chrony
type: fix
summary: revert chrony_exporter to 0.11.0 to stop the exporter crash-looping on failed probes, keeping the CVE fix as a dependency bump
impact_level: high
impact: On builds carrying #22115 the chrony-exporter container crash-loops, because its probes hit /healthz and chrony_exporter 0.14.0 answers 404 on any path but the route prefix. This reverts to 0.11.0, where the probes are answered, and closes the CVEs with a go.mod bump instead.
```
