### PR TITLE
[deckhouse] fix values validation failing on the injected registry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/cloudflare/cfssl v1.6.5
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/fatih/color v1.18.0 // indirect
-	github.com/flant/addon-operator v1.21.29-0.20260814124557-f1a273e87046
+	github.com/flant/addon-operator v1.21.29
 	github.com/flant/kube-client v1.7.0
 	github.com/flant/shell-operator v1.17.7
 	github.com/go-openapi/spec v0.22.1

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/cloudflare/cfssl v1.6.5
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/fatih/color v1.18.0 // indirect
-	github.com/flant/addon-operator v1.21.28
+	github.com/flant/addon-operator v1.21.29-0.20260814124557-f1a273e87046
 	github.com/flant/kube-client v1.7.0
 	github.com/flant/shell-operator v1.17.7
 	github.com/go-openapi/spec v0.22.1

--- a/go.sum
+++ b/go.sum
@@ -204,6 +204,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/flant/addon-operator v1.21.28 h1:sVqvvsHZ7fdS9USpHghlS4+UsSGV+H6GK3v5Zz5668Y=
 github.com/flant/addon-operator v1.21.28/go.mod h1:F8Qvz7cwJkQ+JqcyYXQvg20B+0cS6wQU4zQe//m06t4=
+github.com/flant/addon-operator v1.21.29-0.20260814124557-f1a273e87046 h1:a7oanSVCdWepnaKloj9NKc9yGvcDZeRRCEXuyiVdo38=
+github.com/flant/addon-operator v1.21.29-0.20260814124557-f1a273e87046/go.mod h1:F8Qvz7cwJkQ+JqcyYXQvg20B+0cS6wQU4zQe//m06t4=
 github.com/flant/kube-client v1.7.0 h1:+B0yZfQuVKnsyf51+pQckxeKA7SR9YOdhyR3GeQi57s=
 github.com/flant/kube-client v1.7.0/go.mod h1:16bcsXO8C7i0rtKmrpbgmJpnQgqlUzfIOZs521WmKcE=
 github.com/flant/shell-operator v1.17.7 h1:yhYGXasvd/p/gzaYPw47CeGL8n9QZQRZQjQcPiSfRsk=

--- a/go.sum
+++ b/go.sum
@@ -206,6 +206,8 @@ github.com/flant/addon-operator v1.21.28 h1:sVqvvsHZ7fdS9USpHghlS4+UsSGV+H6GK3v5
 github.com/flant/addon-operator v1.21.28/go.mod h1:F8Qvz7cwJkQ+JqcyYXQvg20B+0cS6wQU4zQe//m06t4=
 github.com/flant/addon-operator v1.21.29-0.20260814124557-f1a273e87046 h1:a7oanSVCdWepnaKloj9NKc9yGvcDZeRRCEXuyiVdo38=
 github.com/flant/addon-operator v1.21.29-0.20260814124557-f1a273e87046/go.mod h1:F8Qvz7cwJkQ+JqcyYXQvg20B+0cS6wQU4zQe//m06t4=
+github.com/flant/addon-operator v1.21.29 h1:P9iGRVPC7ysW596AvijAIBmvonsQJ4yupmI9Jp2uUto=
+github.com/flant/addon-operator v1.21.29/go.mod h1:F8Qvz7cwJkQ+JqcyYXQvg20B+0cS6wQU4zQe//m06t4=
 github.com/flant/kube-client v1.7.0 h1:+B0yZfQuVKnsyf51+pQckxeKA7SR9YOdhyR3GeQi57s=
 github.com/flant/kube-client v1.7.0/go.mod h1:16bcsXO8C7i0rtKmrpbgmJpnQgqlUzfIOZs521WmKcE=
 github.com/flant/shell-operator v1.17.7 h1:yhYGXasvd/p/gzaYPw47CeGL8n9QZQRZQjQcPiSfRsk=


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Bumps `flant/addon-operator` to the `release-1.21` backport of the registry values fix, where `InjectRegistryValue` wrote a `*Registry` struct into the module values tree instead of a plain map.

No packages-side change here: `internal/packages/values` on this branch does not inject a registry yet, so the `*structpb.Struct` variant of the same defect does not exist in 1.76.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

CEL validation of `x-deckhouse-validations` converts values with `structpb`, which accepts only maps, slices and scalars, so a Go struct in the values tree fails the whole validation with `proto: invalid type`. Every hook values patch of any module that has a root-level validation rule and a registry injected from a `ModuleSource` failed, and the module never converged.

### Notes

Cherry-picked in flant/addon-operator#821; verified in a cluster on the main-line PR #22165, not on a build of this branch.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Fix values validation failing on the injected registry
impact_level: low
```