### PR TITLE
[deckhouse] dev module processing

### DIFF
--- a/deckhouse-controller/internal/packages/runtime/modules.go
+++ b/deckhouse-controller/internal/packages/runtime/modules.go
@@ -363,6 +363,13 @@ func (r *Runtime) cleanupModule(name string) func() {
 	}
 }
 
+// GetModuleDigest resolves the digest the tag currently points at. It is what a caller
+// pinning a module to a mutable dev tag compares against, because the runtime's own change
+// detection is blind to a repush under an unchanged tag.
+func (r *Runtime) GetModuleDigest(ctx context.Context, remote registry.Remote, name, tag string) (string, error) {
+	return r.registry.GetImageDigest(ctx, remote, name, tag)
+}
+
 // ValidateModuleExclusiveGroup returns an error if there is an enabled module with the same exclusive group.
 func (r *Runtime) ValidateModuleExclusiveGroup(group string) error {
 	r.mu.RLock()

--- a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha2/module.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha2/module.go
@@ -35,6 +35,9 @@ const (
 	// ModuleAnnotationDev marks a module restored from a development pull override.
 	ModuleAnnotationDev = "modules.deckhouse.io/dev"
 
+	// ModuleAnnotationHash holds the digest a dev module was last handed to the runtime on.
+	ModuleAnnotationHash = "modules.deckhouse.io/hash"
+
 	// ModuleAnnotationEmbedded marks a module that is embedded in the Deckhouse image.
 	ModuleAnnotationEmbedded = "modules.deckhouse.io/embedded"
 )

--- a/deckhouse-controller/pkg/controller/packages/module/controller.go
+++ b/deckhouse-controller/pkg/controller/packages/module/controller.go
@@ -54,6 +54,9 @@ const (
 	// defaultRequeueAfter is the retry delay for states that need an external change to
 	// make progress, such as a missing package or a version still in draft.
 	defaultRequeueAfter = 30 * time.Second
+	// devRequeueAfter is how often a dev module's tag is re-resolved. A repush moves nothing
+	// in the API server, so the digest behind the tag is only ever seen by looking again.
+	devRequeueAfter = 15 * time.Second
 )
 
 // RegisterController registers the Module controller with the manager.
@@ -101,6 +104,7 @@ type reconciler struct {
 type packageManager interface {
 	UpdateModulesSettings(name string, settingsVersion int, settings addonutils.Values, maintenance string, enabled *bool)
 	UpdateModule(repo registry.Remote, module packageruntime.Module, force bool)
+	GetModuleDigest(ctx context.Context, repo registry.Remote, name, tag string) (string, error)
 	UpdateEmbeddedModule(module packageruntime.Module)
 	RemoveModule(name string)
 	RemoveEmbeddedModule(name string)
@@ -142,6 +146,12 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{RequeueAfter: defaultRequeueAfter}, nil
 	}
 
+	// A dev module follows a mutable tag, and a repush under it changes nothing the informer
+	// watches, so the only way to notice one is to resolve the tag again on a timer.
+	if module.IsDev() && !module.IsEmbedded() {
+		return ctrl.Result{RequeueAfter: devRequeueAfter}, nil
+	}
+
 	return ctrl.Result{}, nil
 }
 
@@ -173,6 +183,12 @@ func (r *reconciler) handleCreateOrUpdate(ctx context.Context, module *v1alpha2.
 	// resolve — the annotation is read before any of them, the way the bootstrap and the runtime do.
 	if module.IsEmbedded() {
 		return r.handleEmbedded(ctx, module, original)
+	}
+
+	// A dev module is pinned to a mutable tag, which the repository scan publishes no version
+	// for, so it is routed before the package and the version are looked up — as embedded is.
+	if module.IsDev() {
+		return r.handleDev(ctx, module, original)
 	}
 
 	pkg := new(v1alpha1.ModulePackage)
@@ -266,6 +282,75 @@ func (r *reconciler) handleEmbedded(ctx context.Context, module, original *v1alp
 	// A reference left behind would block its owner's deletion for ever, and an embedded module owns
 	// neither a package nor a version. The registry annotation goes with them: nothing is pulled.
 	ctrlutils.DropOwnerReferences(module, v1alpha1.ModulePackageVersionKind, v1alpha1.ModulePackageKind)
+	delete(module.Annotations, v1alpha2.ModuleAnnotationRegistrySpecChanged)
+
+	if err := r.client.Patch(ctx, module, client.MergeFrom(original)); err != nil {
+		logger.Error("failed to patch the module", log.Err(err))
+		return fmt.Errorf("patch module '%s': %w", module.Name, err)
+	}
+
+	return nil
+}
+
+// handleDev hands a module pinned to a mutable dev image tag to the package runtime, the way
+// the override controller drives the addon-operator path.
+//
+// No ModulePackageVersion is published for such a tag, so the digest behind it takes the place of
+// a version as the change signal: it is compared with the one the module was last handed over on,
+// and a move forces the runtime past change detection that only ever sees the same tag. The digest
+// is recorded after the handover, so a failure before it re-forces rather than skips.
+func (r *reconciler) handleDev(ctx context.Context, module, original *v1alpha2.Module) error {
+	logger := r.logger.With(slog.String("name", module.Name))
+
+	logger.Debug("handle dev module")
+
+	if module.Spec.PackageRepositoryName == "" {
+		logger.Debug("dev module has no package repository")
+
+		return fmt.Errorf("dev module '%s' has no package repository", module.Name)
+	}
+
+	repo := new(v1alpha1.PackageRepository)
+	if err := r.client.Get(ctx, client.ObjectKey{Name: module.Spec.PackageRepositoryName}, repo); err != nil {
+		logger.Error("failed to get the package repository", log.Err(err))
+		return fmt.Errorf("get package repository '%s': %w", module.Spec.PackageRepositoryName, err)
+	}
+
+	remote := registry.BuildRemote(repo)
+
+	digest, err := r.manager.GetModuleDigest(ctx, remote, module.Name, module.Spec.PackageVersion)
+	if err != nil {
+		logger.Error("failed to resolve the dev image digest", log.Err(err))
+		return fmt.Errorf("get digest of the module '%s': %w", module.Name, err)
+	}
+
+	// Only the digest tells a repushed image from an untouched one, and force is what carries that
+	// verdict past change detection, which sees the same tag either way.
+	forced := module.Annotations[v1alpha2.ModuleAnnotationHash] != digest
+
+	// A version the repository scan produced cannot back a dev tag, and the reference to it would
+	// block its owner's deletion for ever — the module arrives with one when it was released before.
+	if name := ctrlutils.OwnerRefName(module, v1alpha1.ModulePackageVersionKind); name != "" {
+		if err := r.detachVersion(ctx, name); err != nil {
+			logger.Error("failed to detach the module package version", slog.String("mpv", name), log.Err(err))
+			return fmt.Errorf("detach module package version '%s': %w", name, err)
+		}
+	}
+
+	r.manager.UpdateModule(remote, packageruntime.Module{
+		Name: module.Name,
+		Definition: modules.Definition{
+			Name:    module.Name,
+			Version: module.Spec.PackageVersion,
+		},
+		Settings:        module.Spec.Settings.GetMap(),
+		SettingsVersion: module.Spec.SettingsVersion,
+		Maintenance:     module.Spec.Maintenance,
+		Enabled:         module.Spec.Enabled,
+	}, forced)
+
+	ctrlutils.DropOwnerReferences(module, v1alpha1.ModulePackageVersionKind, v1alpha1.ModulePackageKind)
+	module.Annotations[v1alpha2.ModuleAnnotationHash] = digest
 	delete(module.Annotations, v1alpha2.ModuleAnnotationRegistrySpecChanged)
 
 	if err := r.client.Patch(ctx, module, client.MergeFrom(original)); err != nil {


### PR DESCRIPTION
## Description

Teaches the Module controller to process dev modules — the ones a `ModulePullOverride` pins to a mutable image tag instead of a released version — by repeating what the override controller does on the addon-operator path.

A dev module is a `Module` carrying `modules.deckhouse.io/dev` whose `spec.packageVersion` is an image tag (`main`, `pr1234`), not a version. A repository scan publishes a `ModulePackageVersion` only for versions it actually found, so no version ever backs such a tag: the controller went for the `ModulePackage`, got `NotFound` and requeued every 30s forever. A dev module moved the CR but never reached the runtime.

**Module controller**

* `handleCreateOrUpdate` branches on `IsDev()` right after the embedded branch, before the package, the version and the draft check are looked up — the same bypass, for the same reason. The repository is still resolved, because a dev module does have one.
* What replaces the version as the change signal is the **digest**. `handleDev` resolves the one behind the tag, compares it with `modules.deckhouse.io/hash` — the digest the module was last handed over on — and passes the verdict straight into `UpdateModule`'s `force`, which is the only thing that gets a repush past change detection blind to mutable tags. `force` also makes the Deploy task discard its cached copy of the tag. This mirrors `ModulePullOverride`, where `status.imageDigest` plays the part of the annotation.
* The annotation is written **after** the handover, in the same patch as the owner references, so a pass that fails before it re-forces on the next reconcile rather than skipping the repush. Forcing twice only costs a redeploy; skipping once leaves the cluster on a stale image.
* On the way through, the release path's bookkeeping is unwound for a module that was released before the override arrived: the `ModulePackageVersion` is released (`status.used = false`) and the package and version owner references are dropped, since a leftover non-controller reference blocks its owner's deletion for ever.
* `Reconcile` requeues a dev module every 15s — the same default `ModulePullOverride.spec.scanInterval` carries. Nothing in the API server moves when an image is repushed, so the tag is only ever re-resolved by looking again.

**Package runtime**

* `GetModuleDigest` exposes the registry lookup the comparison needs. The runtime resolves the digest but never compares it: what the tag points at now is a registry fact, whether that counts as a change is the caller's.

## Why do we need it, and what problem does it solve?

Dev modules were unusable under the package runtime. A developer pinning a module to a dev tag saw the `Module` resource move onto that tag and nothing else happen — no download, no deploy, no hooks — and a repush under the same tag was invisible even in principle, because the runtime's change detection compares versions and a dev tag never changes. This closes the last gap between the override flow and the package runtime, so the develop-and-repush loop works on the new runtime as it does on addon-operator.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: chore
summary: Processes dev modules.
impact_level: low
```
