### PR TITLE
[candi] nodeStatusReportFrequency increased to 1m for kubelet

### DIFF
--- a/candi/bashible/common-steps/all/064_configure_kubelet.sh.tpl
+++ b/candi/bashible/common-steps/all/064_configure_kubelet.sh.tpl
@@ -372,6 +372,7 @@ maxOpenFiles: 1000000
   {{- end }}
 {{- end }}
 maxPods: {{ $max_pods }}
+nodeStatusReportFrequency: {{ .nodeStatusReportFrequency | default "1m" }}
 nodeStatusUpdateFrequency: {{ .nodeStatusUpdateFrequency | default "10" }}s
 podsPerCore: 0
 podPidsLimit: -1

--- a/candi/bashible/common-steps/all/064_configure_kubelet.sh.tpl
+++ b/candi/bashible/common-steps/all/064_configure_kubelet.sh.tpl
@@ -372,7 +372,7 @@ maxOpenFiles: 1000000
   {{- end }}
 {{- end }}
 maxPods: {{ $max_pods }}
-nodeStatusReportFrequency: {{ .nodeStatusReportFrequency | default "1m" }}
+nodeStatusReportFrequency: 1m
 nodeStatusUpdateFrequency: {{ .nodeStatusUpdateFrequency | default "10" }}s
 podsPerCore: 0
 podPidsLimit: -1


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Explicitly set `nodeStatusReportFrequency: 1m` in the kubelet config template
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Deckhouse sets `nodeStatusUpdateFrequency` explicitly but leaves `nodeStatusReportFrequency` unset. Per kubelet defaulting, when updateFrequency is set explicitly, reportFrequency inherits it instead of the upstream 5m. As a result the full Node object is re-posted (and rewritten in etcd) every 10s, even when nothing changed.

If node objects are large (13–16 KB, dominated by .status.images), so this is a major source of etcd write churn: ~9 GB/day on a 62-node cluster, ~24 GB/day on a 208-node one - just from unchanged-status keepalives.

This churn may inflate the etcd DB and drives fragmentation (observed 25% -> 75–80% within days), causing etcd/API-server latency spikes and forcing manual defrag every couple of days.

Setting `nodeStatusReportFrequency: 1m` decouples the heavy status write from the fast heartbeat: full Node writes drop ~6×, while liveness (node Lease, renewed every 10s) and immediate posting of real status/label changes are unchanged - so failure detection is not affected.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Explicitly set kubelet nodeStatusReportFrequency to 1m so the full Node object is no longer rewritten in etcd every 10s.
impact: Kubelet config is updated and kubelet is reloaded on all nodes. Node .status fields (capacity, allocatable, images, condition heartbeat timestamps) now refresh once per minute instead of every 10s
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
