### PR TITLE
chore: check verity support more strictly

### DIFF
--- a/deckhouse-controller/internal/tools/verity/erofs.go
+++ b/deckhouse-controller/internal/tools/verity/erofs.go
@@ -22,7 +22,10 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
+	"sync"
+	"time"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -120,12 +123,58 @@ func CreateImageByTar(ctx context.Context, rc io.ReadCloser, imagePath string) e
 	return nil
 }
 
-// IsSupported scans /proc/filesystems for erofs type, it returns whether erofs is supported
+// IsSupported reports whether the erofs+dm-verity module backend can be
+// used. The result is computed once per process (memoized) via a real
+// self-test rather than passive inspection.
 func IsSupported() bool {
+	return isSupported()
+}
+
+var isSupported = sync.OnceValue(func() bool {
 	content, err := os.ReadFile("/proc/filesystems")
+	if err != nil || !strings.Contains(string(content), erofsType) {
+		return false
+	}
+
+	return selfTestDMVerity()
+})
+
+// selfTestDMVerity actually attempts to open a dm-verity mapping for a tiny
+// scratch file, and reports whether that succeeded.
+//
+// This can't be answered by passively inspecting /proc or /sys: the kernel
+// only autoloads the "verity" device-mapper target on a real table-load
+// attempt (which is exactly what CreateMapper below does), not when merely
+// listing already-loaded targets (e.g. via "dmsetup targets"). A kernel
+// where dm-verity is a not-yet-loaded module would look unsupported to any
+// such passive check, even though the real operation would succeed - the
+// self-test avoids that false negative by doing the real thing.
+func selfTestDMVerity() bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	dir, err := os.MkdirTemp("", "verity-selftest-")
+	if err != nil {
+		return false
+	}
+	defer os.RemoveAll(dir)
+
+	imagePath := filepath.Join(dir, "test.img")
+	if err := os.WriteFile(imagePath, make([]byte, 4096), 0o600); err != nil {
+		return false
+	}
+
+	hash, err := CreateImageHash(ctx, imagePath)
 	if err != nil {
 		return false
 	}
 
-	return strings.Contains(string(content), erofsType)
+	name := fmt.Sprintf("verity-selftest-%d", os.Getpid())
+	if err := CreateMapper(ctx, name, imagePath, hash); err != nil {
+		return false
+	}
+
+	_ = CloseMapper(ctx, name)
+
+	return true
 }

--- a/deckhouse-controller/internal/tools/verity/erofs_test.go
+++ b/deckhouse-controller/internal/tools/verity/erofs_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package verity
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestSelfTestDMVerityDoesNotHang guards against the self-test regressing
+// into an unbounded wait: on a host without dm-verity support (or without
+// the veritysetup/mkfs.erofs binaries at all, as in this CI/dev environment)
+// it must return false quickly, not hang for the full previous 15-30 minute
+// install timeout the original bug caused downstream.
+func TestSelfTestDMVerityDoesNotHang(t *testing.T) {
+	start := time.Now()
+	got := selfTestDMVerity()
+	elapsed := time.Since(start)
+
+	if elapsed > 10*time.Second {
+		t.Fatalf("selfTestDMVerity took %s, want it bounded well under the 5s self-test timeout", elapsed)
+	}
+
+	t.Logf("selfTestDMVerity() = %v, took %s", got, elapsed)
+}
+
+// TestSelfTestDMVerityCleansUpTempFiles ensures the self-test never leaks its
+// scratch directory, whether it succeeds or fails.
+func TestSelfTestDMVerityCleansUpTempFiles(t *testing.T) {
+	before := countSelftestTempDirs(t)
+
+	selfTestDMVerity()
+
+	after := countSelftestTempDirs(t)
+	if after != before {
+		t.Fatalf("selfTestDMVerity leaked a temp dir: before=%d after=%d", before, after)
+	}
+}
+
+// TestIsSupportedIsMemoized calls IsSupported twice and expects the second
+// call to be effectively free (sync.OnceValue), and both calls to agree.
+func TestIsSupportedIsMemoized(t *testing.T) {
+	first := IsSupported()
+
+	start := time.Now()
+	second := IsSupported()
+	elapsed := time.Since(start)
+
+	if first != second {
+		t.Fatalf("IsSupported() is not stable across calls: first=%v second=%v", first, second)
+	}
+
+	if elapsed > 100*time.Millisecond {
+		t.Fatalf("second IsSupported() call took %s, want it memoized (near-instant)", elapsed)
+	}
+}
+
+func countSelftestTempDirs(t *testing.T) int {
+	t.Helper()
+
+	entries, err := os.ReadDir(os.TempDir())
+	if err != nil {
+		t.Fatalf("read temp dir: %v", err)
+	}
+
+	count := 0
+	for _, e := range entries {
+		if e.IsDir() && strings.HasPrefix(filepath.Base(e.Name()), "verity-selftest-") {
+			count++
+		}
+	}
+
+	return count
+}


### PR DESCRIPTION
## Description

Fixes `verity.IsSupported()` in `deckhouse-controller` (`internal/tools/verity/erofs.go`), which decides whether the erofs+dm-verity module installer backend can be used, or whether to fall back to the plain symlink installer.

Previously it only checked whether the `erofs` filesystem was listed in `/proc/filesystems`. That is not sufficient: a kernel can support the `erofs` filesystem while lacking the `verity` device-mapper target (`CONFIG_DM_VERITY`) entirely — e.g. Docker Desktop for Mac's LinuxKit kernel. In that case `IsSupported()` incorrectly returned `true`, the erofs+dm-verity backend was selected, and every non-embedded module install (`ingress-nginx`, `prometheus`, `operator-prometheus`, `monitoring-kubernetes`, etc. — anything not baked into the deckhouse binary) got stuck in an infinite retry loop failing on `veritysetup open: ... Kernel does not support dm-verity mapping`, never falling back to the already-existing, working symlink installer.

The fix replaces the passive `/proc/filesystems` check with a real, one-time self-test: it creates a tiny scratch file, computes its dm-verity hash, and actually attempts to open a verity mapping for it (reusing the already-present `CreateImageHash`/`CreateMapper`/`CloseMapper` helpers). This is intentionally not a passive kernel-module/sysfs check — the kernel only autoloads the `verity` device-mapper target on a real table-load attempt, not when merely listing already-loaded targets, so a passive check could produce false negatives on kernels where dm-verity is a valid but not-yet-loaded module. The result is memoized per-process (`sync.OnceValue`), so the self-test only runs once.

This does not affect module installation timing, module content, or behavior on hosts where dm-verity is genuinely supported (the overwhelming majority of production kernels) — `IsSupported()` still correctly returns `true` there, with one extra self-test at controller startup (a few milliseconds).

## Why do we need it, and what problem does it solve?

Without this fix, installing Deckhouse on any host whose kernel doesn't support `dm-verity` (encountered while testing on `kind` + Docker Desktop for Mac) permanently fails to install any non-embedded module. `create-resources`/module installation hangs until the configured timeout with no way to recover, because the code silently picked the wrong installer backend instead of falling back to the working one that already exists in the codebase.

## Why do we need it in the patch release (if we do)?

Not necessarily — this affects hosts whose kernel lacks `dm-verity` support, most commonly local/dev/test clusters (e.g. `kind` on Docker Desktop for Mac). It's a genuine correctness bug though (affected hosts can't install modules at all today), so worth considering for backport if any patch-release users are known to be on such kernels.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse-controller
type: fix
summary: Fix incorrect detection of dm-verity kernel support during module installation.
impact: |
  Hosts whose kernel doesn't support dm-verity (e.g. some kind/Docker Desktop setups)
  previously got stuck forever trying to install any non-embedded module
  (ingress-nginx, prometheus, etc.), since support detection only checked for the
  erofs filesystem and not the actual dm-verity device-mapper target. Such hosts now
  correctly fall back to the existing plain installer instead of hanging.
impact_level: default