### PR TITLE
[deckhouse] Add PackageRepository configuration for deckhouse-modules

### DIFF
--- a/modules/002-deckhouse/templates/default-package-repository.yaml
+++ b/modules/002-deckhouse/templates/default-package-repository.yaml
@@ -13,3 +13,18 @@ spec:
     repo: {{ printf "%s/packages" $.Values.global.modulesImages.registry.base }}
     scheme: {{ $.Values.global.modulesImages.registry.scheme | upper }}
   scanInterval: 3m
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: PackageRepository
+metadata:
+  name: deckhouse-modules
+  {{- include "helm_lib_module_labels" (list . (dict "app" "deckhouse")) | nindent 2 }}
+spec:
+  registry:
+    {{- if $.Values.global.modulesImages.registry.CA }}
+    ca: | {{ $.Values.global.modulesImages.registry.CA | nindent 6 }}
+    {{- end }}
+    dockerCfg: {{ $.Values.global.modulesImages.registry.dockercfg }}
+    repo: {{ printf "%s/modules" $.Values.global.modulesImages.registry.base }}
+    scheme: {{ $.Values.global.modulesImages.registry.scheme | upper }}
+  scanInterval: 3m


### PR DESCRIPTION
## Description
Added deckhouse-modules PackageRepository, created by default.

## Why do we need it, and what problem does it solve?
For v2 modules to work correctly, a PackageRepository is required with the module path specified, as in the old ModuleSource resources.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: chore
summary: Added deckhouse-modules PackageRepository configuration.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
