### PR TITLE
[docs] Remove Deckhouse Code documentation location from the test environments

### DIFF
--- a/docs/site/.helm/templates/20-ingress.yaml
+++ b/docs/site/.helm/templates/20-ingress.yaml
@@ -232,6 +232,7 @@ spec:
             name: frontend
             port:
               name: http
+{{- if eq $.Values.web.env "web-production" }}
       - path: /products/code/documentation/
         pathType: Prefix
         backend:
@@ -239,6 +240,7 @@ spec:
             name: frontend
             port:
               name: http
+{{- end }}
       - path: /products/virtualization-platform/documentation/
         pathType: Prefix
         backend:


### PR DESCRIPTION
## Description

This pull request adds a conditional ingress path for the documentation site, ensuring the `/products/code/documentation/` route is only exposed in the `web-production` environment.

It is a preparation to moving Deckhouse Code documentation to a separate repository to avoid conflicts.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Remove Deckhouse Code documentation location from the test environments.
impact_level: low
```
