### PR TITLE
[1.77] Remove containerd v1 from the CSE edition

### DIFF
--- a/.werf/werf-release-channel.yaml
+++ b/.werf/werf-release-channel.yaml
@@ -26,6 +26,7 @@ shell:
     {{- if eq $.Env "CSE" }}
     yq eval '.requirements.migratedModules = .requirements.migratedModules + ",commander,commander-agent,console,csi-ceph,csi-nfs,csi-scsi-generic,csi-yadro-tatlin-unified,observability,prompp,sds-local-volume,sds-node-configurator,secrets-store-integration,snapshot-controller,storage-volume-data-manager,virtualization"' -i /deckhouse/release.yaml
     yq eval '.requirements.disabledModules = .requirements.disabledModules + ",gost-integrity-controller"' -i /deckhouse/release.yaml
+    yq eval '.requirements.checkContainerdV1NodesPresent = "true"' -i /deckhouse/release.yaml
     {{- end }}
     yq eval '.version = env(version)' -i /deckhouse/release.yaml
     yq eval -j /deckhouse/release.yaml > version.json

--- a/ee/cse/candi/openapi/cluster_configuration.yaml
+++ b/ee/cse/candi/openapi/cluster_configuration.yaml
@@ -115,21 +115,19 @@ apiVersions:
         type: string
         description: |
           The container runtime type that used on cluster nodes (NodeGroups) by default.
-
           If the value `NotManaged` is used, then Deckhouse does not manage the container runtime (and doesn't install it).
           In this case, it is necessary to use images for NodeGroups on which the container runtime is already installed.
 
-          If `ContainerdV2` is set, `CgroupsV2` will be used (providing improved security and resource management). To use `ContainerdV2` as the container runtime, cluster nodes must meet the following requirements:
+          Containerd v1 is not available in this edition. `ContainerdV2` uses `CgroupsV2`, providing improved security and resource management, and requires cluster nodes to meet the following requirements:
 
           - Support for `CgroupsV2`.
           - Linux kernel version 5.8 or newer, except for the ranges 6.12.0–6.12.28 or 6.14.0–6.14.6 (these versions are affected by CVE-2025-37999 in EROFS).
           - Systemd version `244` or newer.
           - Support for `erofs` kernel module.
         enum:
-        - "Containerd"
         - "ContainerdV2"
         - "NotManaged"
-        default: "Containerd"
+        default: "ContainerdV2"
       kubernetesVersion:
         type: string
         description: |

--- a/global-hooks/check_switch_edition.go
+++ b/global-hooks/check_switch_edition.go
@@ -59,6 +59,7 @@ type switchEditionChecker func(context.Context, *go_hook.HookInput, dependency.C
 
 var switchEditionCheckers = []switchEditionChecker{
 	controlPlaneSwitchEditionChecker,
+	containerdV1SwitchEditionChecker,
 }
 
 func checkSwitchDeckhouseEdition(ctx context.Context, input *go_hook.HookInput, dc dependency.Container) error {
@@ -128,7 +129,7 @@ func checkSwitchDeckhouseEdition(ctx context.Context, input *go_hook.HookInput, 
 
 	resErr := errors[0]
 	for _, nextErr := range errors[1:] {
-		resErr = fmt.Errorf("\n%w", nextErr)
+		resErr = fmt.Errorf("%w\n%w", resErr, nextErr)
 	}
 
 	return fmt.Errorf(

--- a/global-hooks/check_switch_edition_containerd.go
+++ b/global-hooks/check_switch_edition_containerd.go
@@ -1,0 +1,158 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hooks
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sort"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/yaml"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency"
+	"github.com/deckhouse/deckhouse/go_lib/dependency/k8s"
+)
+
+const (
+	cseEditionName      = "CSE"
+	criTypeContainerdV1 = "Containerd"
+)
+
+var nodeGroupGVRForCRICheck = schema.GroupVersionResource{
+	Group:    "deckhouse.io",
+	Version:  "v1",
+	Resource: "nodegroups",
+}
+
+// containerdV1SwitchEditionChecker blocks a switch to CSE while the cluster still asks for containerd v1 (EE to CSE).
+func containerdV1SwitchEditionChecker(
+	ctx context.Context,
+	input *go_hook.HookInput,
+	dc dependency.Container,
+	p *switchEditionCheckerParams,
+) error {
+	allowSwitch := func(cause string, args ...any) error {
+		input.Logger.Info(
+			"Allow switch edition by containerd checker",
+			slog.String("cause", fmt.Sprintf(cause, args...)),
+		)
+		return nil
+	}
+
+	if p.currentEdition != cseEditionName {
+		return allowSwitch("current edition %s is not CSE", p.currentEdition)
+	}
+
+	client, err := dc.GetK8sClient()
+	if err != nil {
+		return fmt.Errorf("cannot get k8s client for containerd check: %w", err)
+	}
+
+	defaultCRI, found, err := clusterDefaultCRI(ctx, client)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return allowSwitch("kube-system/d8-cluster-configuration secret not found")
+	}
+
+	if defaultCRI == criTypeContainerdV1 {
+		return fmt.Errorf(
+			"defaultCRI is %s in the kube-system/d8-cluster-configuration secret, but CSE does not ship "+
+				"containerd v1. Set defaultCRI to ContainerdV2 and migrate the nodes first",
+			criTypeContainerdV1,
+		)
+	}
+
+	blocked, err := nodeGroupsRequestingContainerdV1(ctx, client, defaultCRI)
+	if err != nil {
+		return err
+	}
+	if len(blocked) > 0 {
+		return fmt.Errorf(
+			"NodeGroups %v resolve to CRI %s, but CSE does not ship containerd v1. "+
+				"Set spec.cri.type to ContainerdV2 and migrate their nodes first",
+			blocked, criTypeContainerdV1,
+		)
+	}
+
+	return allowSwitch("no NodeGroup requests containerd v1")
+}
+
+// clusterDefaultCRI reads defaultCRI from the ClusterConfiguration secret.
+func clusterDefaultCRI(ctx context.Context, client k8s.Client) (string, bool, error) {
+	secret, err := client.CoreV1().Secrets("kube-system").Get(ctx, "d8-cluster-configuration", metav1.GetOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("cannot get kube-system/d8-cluster-configuration: %w", err)
+	}
+
+	raw, ok := secret.Data["cluster-configuration.yaml"]
+	if !ok {
+		return "", false, nil
+	}
+
+	var clusterConfig struct {
+		DefaultCRI string `json:"defaultCRI"`
+	}
+	if err := yaml.Unmarshal(raw, &clusterConfig); err != nil {
+		return "", false, fmt.Errorf("cannot parse cluster-configuration.yaml: %w", err)
+	}
+
+	return clusterConfig.DefaultCRI, true, nil
+}
+
+func nodeGroupsRequestingContainerdV1(ctx context.Context, client k8s.Client, defaultCRI string) ([]string, error) {
+	nodeGroups, err := client.Dynamic().Resource(nodeGroupGVRForCRICheck).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("cannot list NodeGroups: %w", err)
+	}
+
+	var blocked []string
+	for _, item := range nodeGroups.Items {
+		criType, _, err := unstructured.NestedString(item.Object, "spec", "cri", "type")
+		if err != nil {
+			return nil, fmt.Errorf("cannot read spec.cri.type of NodeGroup %s: %w", item.GetName(), err)
+		}
+
+		if effectiveCRIType(criType, defaultCRI) == criTypeContainerdV1 {
+			blocked = append(blocked, item.GetName())
+		}
+	}
+
+	sort.Strings(blocked)
+
+	return blocked, nil
+}
+
+// effectiveCRIType resolves the CRI type for a NodeGroup: the NodeGroup wins, then defaultCRI, then containerd v1.
+func effectiveCRIType(nodeGroupCRI, defaultCRI string) string {
+	if nodeGroupCRI != "" {
+		return nodeGroupCRI
+	}
+	if defaultCRI != "" {
+		return defaultCRI
+	}
+
+	return criTypeContainerdV1
+}

--- a/modules/007-registrypackages/images/containerd/werf.inc.yaml
+++ b/modules/007-registrypackages/images/containerd/werf.inc.yaml
@@ -1,7 +1,10 @@
 {{- $containerd_v1_version := "1.7.34" }}
 {{- $containerd_v2_version := "2.2.7" }}
 {{- $runc_version := "1.3.6" }}
-{{- $containerd_versions := list $containerd_v1_version $containerd_v2_version }}
+{{- $containerd_versions := list $containerd_v2_version }}
+{{- if ne $.Env "CSE" }}
+  {{- $containerd_versions = list $containerd_v1_version $containerd_v2_version }}
+{{- end }}
 {{- $runc_versions := list $runc_version }}
 {{- $containerd2runc := dict $containerd_v1_version $runc_version $containerd_v2_version $runc_version }}
 {{- $containerd_integrity_patches_version := .IntegrityPatchesVersion | default "0" }} # may be redefine in CSE

--- a/modules/040-node-manager/crds/doc-ru-node_group.yaml
+++ b/modules/040-node-manager/crds/doc-ru-node_group.yaml
@@ -738,6 +738,8 @@ spec:
                         Если не указан, используется значение параметра `defaultCRI` ClusterConfiguration.
 
                         > **Внимание.** Поддержка Docker считается устаревшей.
+
+                        > **Внимание.** В редакции CSE доступен только containerd v2.
                     containerd:
                       description: |
                         Параметры работы containerd.

--- a/modules/040-node-manager/crds/node_group.yaml
+++ b/modules/040-node-manager/crds/node_group.yaml
@@ -1560,6 +1560,8 @@ spec:
                         If not specified, the `defaultCRI` parameter value of ClusterConfiguration is used.
 
                         > **Note.** Docker support is deprecated.
+
+                        > **Note.** The CSE edition supports containerd v2 only.
                       enum:
                         - Docker
                         - Containerd

--- a/modules/040-node-manager/hooks/get_crds.go
+++ b/modules/040-node-manager/hooks/get_crds.go
@@ -49,6 +49,7 @@ import (
 const (
 	CRITypeDocker           = "Docker"
 	CRITypeContainerd       = "Containerd"
+	CRITypeContainerdV2     = "ContainerdV2"
 	NodeGroupDefaultCRIType = CRITypeContainerd
 
 	errorStatusField       = "error"
@@ -492,6 +493,10 @@ func getCRDsHandler(_ context.Context, input *go_hook.HookInput) error {
 		// Detect CRI type. Default CRI type is 'Docker' for Kubernetes version less than 1.19.
 		v1_19_0, _ := semver.NewVersion("1.19.0")
 		defaultCRIType := NodeGroupDefaultCRIType
+		// CSE builds no containerd v1 package, so its implicit default cannot be v1.
+		if input.Values.Get("global.deckhouseEdition").String() == "CSE" {
+			defaultCRIType = CRITypeContainerdV2
+		}
 		if effectiveKubeVer.LessThan(v1_19_0) {
 			defaultCRIType = CRITypeDocker
 		}

--- a/modules/040-node-manager/images/node-controller/src/internal/common/edition.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/common/edition.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import "os"
+
+const DeckhouseEditionEnv = "DECKHOUSE_EDITION"
+
+const cseEdition = "CSE"
+
+func IsCSEEdition() bool {
+	return os.Getenv(DeckhouseEditionEnv) == cseEdition
+}

--- a/modules/040-node-manager/images/node-controller/src/internal/webhook/nodegroup_webhook.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/webhook/nodegroup_webhook.go
@@ -54,6 +54,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	v1 "github.com/deckhouse/node-controller/api/deckhouse.io/v1"
+	nodecommon "github.com/deckhouse/node-controller/internal/common"
 )
 
 var webhookLog = logf.Log.WithName("nodegroup-webhook")
@@ -173,6 +174,10 @@ func (w *NodeGroupValidator) Handle(ctx context.Context, req admission.Request) 
 
 	if ng.Spec.CRI != nil && ng.Spec.CRI.Type == v1.CRITypeDocker {
 		return admission.Denied("it is forbidden to set cri type to Docker")
+	}
+
+	if nodecommon.IsCSEEdition() && ng.Spec.CRI != nil && ng.Spec.CRI.Type == v1.CRITypeContainerd {
+		return admission.Denied("CRI Containerd (containerd v1) is not supported in the CSE edition, use ContainerdV2")
 	}
 
 	if ng.Spec.CRI != nil {
@@ -437,7 +442,11 @@ func getCRIType(ng *v1.NodeGroup, defaultCRI string) string {
 	if defaultCRI != "" {
 		return defaultCRI
 	}
-	return "Containerd"
+	// CSE builds no containerd v1 package, so its implicit default cannot be v1.
+	if nodecommon.IsCSEEdition() {
+		return string(v1.CRITypeContainerdV2)
+	}
+	return string(v1.CRITypeContainerd)
 }
 
 // ClusterConfig holds relevant fields from d8-cluster-configuration Secret

--- a/modules/040-node-manager/templates/node-controller/deployment.yaml
+++ b/modules/040-node-manager/templates/node-controller/deployment.yaml
@@ -119,6 +119,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+  {{- if eq .Values.global.deckhouseEdition "CSE" }}
+        - name: DECKHOUSE_EDITION
+          value: {{ .Values.global.deckhouseEdition | quote }}
+  {{- end }}
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 4290

--- a/release.yaml
+++ b/release.yaml
@@ -34,7 +34,7 @@ requirements:
   "istioMinimalVersion": "1.21" # modules/110-istio/requirements/check.go
   "unmetCloudConditions": "true" # modules/040-node-manager/requirements/check.go
   "nodesMinimalLinuxKernelVersion": "5.8.0" # modules/021-cni-cilium/requirements/check.go
-  # "checkContainerdV1NodesPresent": "true" # modules/040-node-manager/requirements/check.go
+  # "checkContainerdV1NodesPresent": "false" # modules/040-node-manager/requirements/check.go; injected with 'true' only for CSE via .werf/werf-release-channel.yaml (CSE drops containerd v1)
 
 # map of disruptions, associated with a specific release. You have to register check functions before specified release
 disruptions:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Manual backport PR https://github.com/deckhouse/deckhouse/pull/22085

Removes containerd v1 from the CSE edition. Other editions are unchanged.

- **candi/registrypackages:** the `containerd 1.7.34` package is no longer built for CSE (`werf.inc.yaml` gates the version list on `$.Env`).
- **CSE schema:** `defaultCRI` in `ClusterConfiguration` drops `Containerd` from the enum and defaults to `ContainerdV2`. This also covers dhctl, which reads schemas from the edition-specific candi baked into the installer image — no dhctl code change needed.
- **node-manager hook (`get_crds.go`):** the effective default CRI for a NodeGroup without an explicit `spec.cri.type` becomes `ContainerdV2` in the CSE edition. The hook reads the edition from `global.deckhouseEdition` values (it runs inside deckhouse, so no env is needed).
- **node-controller webhook:** denies `spec.cri.type: Containerd` in CSE and defaults the empty CRI fallback to `ContainerdV2`. The controller is a separate binary without values access, so it reads the edition from the `DECKHOUSE_EDITION` env injected into its Deployment only in CSE.
- **release requirement:** `checkContainerdV1NodesPresent` stays commented out in `release.yaml` (absent ≡ no-op in every edition) and is injected with `"true"` only for CSE via the existing per-edition block in `.werf/werf-release-channel.yaml`. It blocks the upgrade while containerd v1 is still used by any node, NodeGroup or `defaultCRI` (the check hook already merged in #22048).
- **global-hooks:** a new switch-edition checker (`check_switch_edition_containerd.go`) blocks EE->CSE while the cluster still uses containerd v1 (via `defaultCRI` or a NodeGroup) — this path does not go through DeckhouseRelease, so release requirements never run for it. Also fixes a pre-existing bug in `check_switch_edition.go` where the multi-checker error aggregation overwrote its accumulator and reported only the last failure.
- **docs:** the v1 `NodeGroup` CRD description notes that the CSE edition supports containerd v2 only (EN + doc-ru).

Also fix:
- the switch-edition error aggregator overwrote its accumulator, reporting only one of several failed checks.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: chore
summary: Containerd v1 is removed from the CSE edition
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
