### PR TITLE
[user-authn] Quote DexProvider-derived values in rendered manifests

### DIFF
--- a/modules/150-user-authn/crds/dex-provider.yaml
+++ b/modules/150-user-authn/crds/dex-provider.yaml
@@ -303,8 +303,11 @@ spec:
                       default: ["openid", "profile", "email", "groups", "offline_access"]
                       description: |
                         List of [additional scopes](https://github.com/dexidp/website/blob/main/content/docs/configuration/custom-scopes-claims-clients.md) to request in token response.
+
+                        A scope is a single token and must not contain whitespace: the OAuth2 protocol passes scopes as a space-delimited list.
                       items:
                         type: string
+                        pattern: '^\S+$'
                     allowedGroups:
                       type: array
                       description: |

--- a/modules/150-user-authn/crds/doc-ru-dex-provider.yaml
+++ b/modules/150-user-authn/crds/doc-ru-dex-provider.yaml
@@ -209,6 +209,8 @@ spec:
                     scopes:
                       description: |
                         Список [полей](https://github.com/dexidp/website/blob/main/content/docs/configuration/custom-scopes-claims-clients.md) для включения в ответ при запросе токена.
+
+                        Scope — это одиночный токен, он не может содержать пробельные символы: протокол OAuth2 передаёт scope'ы списком, разделённым пробелами.
                     promptType:
                       description: |
                         Определяет — должен ли Issuer запрашивать подтверждение и давать подсказки при аутентификации.

--- a/modules/150-user-authn/template_tests/basic_auth_proxy_test.go
+++ b/modules/150-user-authn/template_tests/basic_auth_proxy_test.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template_tests
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/helm"
+)
+
+// multilineValue is a DexProvider field value spanning several lines, indented to match the
+// `args:` block of the proxy container. Unless it is rendered as a quoted scalar, the newline
+// ends the args sequence and the remaining lines become sibling keys of that container.
+const multilineValue = "value\n" +
+	"        image: registry.example.invalid/injected\n" +
+	"        command: [\"/bin/sh\", \"-c\"]\n" +
+	"        args: [\"injected\"]\n" +
+	"        workingDir: /injected"
+
+const basicAuthProxyImage = "registry.example.com@imageHash-userAuthn-basicAuthProxy"
+
+const crowdProvider = `
+- id: crowdID
+  displayName: crowdName
+  type: Crowd
+  crowd:
+    enableBasicAuth: true
+    clientID: clientID
+    clientSecret: secret
+    baseURL: https://example.com
+`
+
+const oidcProvider = `
+- id: oidcID
+  displayName: oidcName
+  type: OIDC
+  oidc:
+    enableBasicAuth: true
+    issuer: https://example.com
+    clientID: clientID
+    clientSecret: secret
+`
+
+const ldapProvider = `
+- id: ldapID
+  displayName: ldapName
+  type: LDAP
+  ldap:
+    enableBasicAuth: true
+    host: ldap.example.com:636
+    userSearch:
+      baseDN: cn=users,dc=example,dc=com
+      username: uid
+      idAttr: uid
+      emailAttr: mail
+`
+
+var _ = Describe("Module :: user-authn :: helm template :: basic auth proxy", func() {
+	hec := SetupHelmConfig("")
+
+	BeforeEach(func() {
+		hec.ValuesSet("global.discovery.kubernetesVersion", "1.29.1")
+		hec.ValuesSet("global.modules.publicDomainTemplate", "%s.example.com")
+		hec.ValuesSet("global.modules.ingressClass", "nginx")
+		hec.ValuesSet("global.modules.https.mode", "CertManager")
+		hec.ValuesSet("global.modules.https.certManager.clusterIssuerName", "letsencrypt")
+		hec.ValuesSet("global.modulesImages.registry.base", "registry.example.com")
+		hec.ValuesSet("global.enabledModules", []string{"cert-manager"})
+		hec.ValuesSet("global.discovery.d8SpecificNodeCountByRole.system", 2)
+		hec.ValuesSet("global.discovery.kubernetesCA", "plainstring")
+
+		hec.ValuesSet("userAuthn.internal.kubernetesDexClientAppSecret", "plainstring")
+		hec.ValuesSet("userAuthn.internal.dexTLS.crt", "plainstring")
+		hec.ValuesSet("userAuthn.internal.dexTLS.key", "plainstring")
+		hec.ValuesSet("userAuthn.internal.dexTLS.ca", "plainstring")
+		hec.ValuesSet("userAuthn.internal.selfSignedCA.cert", "test")
+		hec.ValuesSet("userAuthn.internal.selfSignedCA.key", "test")
+
+		hec.ValuesSet("userAuthn.internal.publishAPI.enabled", true)
+		hec.ValuesSet("userAuthn.internal.publishAPI.addKubeconfigGeneratorEntry", true)
+		hec.ValuesSet("userAuthn.internal.basicAuthProxyCert", "dGVzdA==")
+		hec.ValuesSet("userAuthn.internal.basicAuthProxyKey", "dGVzdA==")
+	})
+
+	injections := []struct {
+		name     string
+		provider string
+		path     string
+		list     bool
+		flag     string
+	}{
+		{"Crowd clientID", crowdProvider, "crowd.clientID", false, "--crowd-application-login"},
+		{"Crowd clientSecret", crowdProvider, "crowd.clientSecret", false, "--crowd-application-password"},
+		{"Crowd baseURL", crowdProvider, "crowd.baseURL", false, "--crowd-base-url"},
+		{"Crowd group", crowdProvider, "crowd.groups", true, "--crowd-allowed-group"},
+		{"OIDC issuer", oidcProvider, "oidc.issuer", false, "--oidc-base-url"},
+		{"OIDC clientID", oidcProvider, "oidc.clientID", false, "--oidc-client-id"},
+		{"OIDC clientSecret", oidcProvider, "oidc.clientSecret", false, "--oidc-client-secret"},
+		{"OIDC scope", oidcProvider, "oidc.scopes", true, "--oidc-scope"},
+		{"LDAP scope", ldapProvider, "ldap.scopes", true, "--ldap-scope"},
+	}
+
+	for _, injection := range injections {
+		Context("With a multiline "+injection.name, func() {
+			BeforeEach(func() {
+				hec.ValuesSetFromYaml("userAuthn.internal.providers", injection.provider)
+
+				path := "userAuthn.internal.providers.0." + injection.path
+				if injection.list {
+					hec.ValuesSet(path, []string{multilineValue})
+				} else {
+					hec.ValuesSet(path, multilineValue)
+				}
+
+				hec.HelmRender()
+			})
+
+			It("Should keep "+injection.flag+" as a single argument of the proxy container", func() {
+				Expect(hec.RenderError).ToNot(HaveOccurred())
+
+				deployment := hec.KubernetesResource("Deployment", "d8-user-authn", "basic-auth-proxy")
+				Expect(deployment.Exists()).To(BeTrue())
+
+				const container = "spec.template.spec.containers.0"
+				Expect(deployment.Field(container + ".image").String()).To(Equal(basicAuthProxyImage))
+				Expect(deployment.Field(container + ".command").Exists()).To(BeFalse())
+				Expect(deployment.Field(container + ".workingDir").Exists()).To(BeFalse())
+
+				args := deployment.Field(container + ".args").AsStringSlice()
+				Expect(args).To(ContainElement("--listen=$(POD_IP):7332"))
+				Expect(args).To(ContainElement(injection.flag + "=" + multilineValue))
+			})
+		})
+	}
+
+	Context("With an OIDC provider", func() {
+		BeforeEach(func() {
+			hec.ValuesSetFromYaml("userAuthn.internal.providers", oidcProvider)
+			hec.HelmRender()
+		})
+
+		It("Should render boolean arguments as unquoted scalars", func() {
+			Expect(hec.RenderError).ToNot(HaveOccurred())
+
+			args := hec.KubernetesResource("Deployment", "d8-user-authn", "basic-auth-proxy").
+				Field("spec.template.spec.containers.0.args").AsStringSlice()
+
+			Expect(args).To(ContainElement("--oidc-get-user-info=false"))
+			Expect(args).To(ContainElement("--oidc-basic-auth-unsupported=false"))
+		})
+	})
+})

--- a/modules/150-user-authn/template_tests/connector_quoting_test.go
+++ b/modules/150-user-authn/template_tests/connector_quoting_test.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template_tests
+
+import (
+	"encoding/base64"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/tidwall/gjson"
+
+	. "github.com/deckhouse/deckhouse/testing/helm"
+)
+
+// ldapBindPWInjection closes its own scalar with a single quote and continues at the
+// indentation of the LDAP connector config, so an unquoted rendering turns the trailing
+// lines into extra keys of that connector.
+const ldapBindPWInjection = "s3cret'\n" +
+	"        insecureNoSSL: true\n" +
+	"        injected: 'yes"
+
+// oidcClaimInjection builds a claim mapping value that ends its own scalar and appends an
+// extra key at the claimMapping indentation level. Each claim gets its own key name so that
+// an unquoted rendering produces distinct keys rather than a duplicate-key parse error.
+func oidcClaimInjection(key string) string {
+	return "claim'\n          " + key + ": injected"
+}
+
+var _ = Describe("Module :: user-authn :: helm template :: connector value quoting", func() {
+	hec := SetupHelmConfig("")
+
+	BeforeEach(func() {
+		hec.ValuesSet("global.discovery.kubernetesVersion", "1.29.1")
+		hec.ValuesSet("global.modules.publicDomainTemplate", "%s.example.com")
+		hec.ValuesSet("global.modules.https.mode", "CertManager")
+		hec.ValuesSet("global.modules.https.certManager.clusterIssuerName", "letsencrypt")
+		hec.ValuesSet("global.modulesImages.registry.base", "registry.example.com")
+		hec.ValuesSet("global.enabledModules", []string{"cert-manager"})
+		hec.ValuesSet("global.discovery.d8SpecificNodeCountByRole.system", 2)
+		hec.ValuesSet("global.discovery.kubernetesCA", "plainstring")
+
+		hec.ValuesSet("userAuthn.internal.kubernetesDexClientAppSecret", "plainstring")
+		hec.ValuesSet("userAuthn.internal.dexTLS.crt", "plainstring")
+		hec.ValuesSet("userAuthn.internal.dexTLS.key", "plainstring")
+		hec.ValuesSet("userAuthn.internal.dexTLS.ca", "plainstring")
+	})
+
+	// dexConnectors decodes the rendered Dex configuration file out of its Secret. Parsing it
+	// back from YAML also proves the rendered configuration is still well-formed.
+	dexConnectors := func() gjson.Result {
+		Expect(hec.RenderError).ToNot(HaveOccurred())
+
+		secret := hec.KubernetesResource("Secret", "d8-user-authn", "dex")
+		Expect(secret.Exists()).To(BeTrue())
+
+		raw, err := base64.StdEncoding.DecodeString(secret.Field("data.config\\.yaml").String())
+		Expect(err).ToNot(HaveOccurred())
+
+		data, err := ConvertYAMLToJSON(raw)
+		Expect(err).ToNot(HaveOccurred(), "rendered Dex config should be valid YAML")
+
+		connectors := gjson.GetBytes(data, "connectors")
+		Expect(connectors.Array()).To(HaveLen(1), "no connector should be injected")
+
+		return connectors.Get("0")
+	}
+
+	Context("With an LDAP provider whose bindPW contains a quote and a line break", func() {
+		BeforeEach(func() {
+			hec.ValuesSetFromYaml("userAuthn.internal.providers", `
+- id: ldapID
+  displayName: ldapName
+  type: LDAP
+  ldap:
+    host: ldap.example.com:636
+    bindDN: uid=serviceaccount,cn=users,dc=example,dc=com
+    userSearch:
+      baseDN: cn=users,dc=example,dc=com
+      username: uid
+      idAttr: uid
+      emailAttr: mail
+`)
+			hec.ValuesSet("userAuthn.internal.providers.0.ldap.bindPW", ldapBindPWInjection)
+			hec.HelmRender()
+		})
+
+		It("Should keep bindPW as a single scalar of the ldap connector", func() {
+			connector := dexConnectors()
+
+			Expect(connector.Get("type").String()).To(Equal("ldap"))
+			Expect(connector.Get("config.bindPW").String()).To(Equal(ldapBindPWInjection))
+			Expect(connector.Get("config.injected").Exists()).To(BeFalse())
+			Expect(connector.Get("config.insecureNoSSL").Exists()).To(BeFalse())
+		})
+	})
+
+	Context("With an OIDC provider whose claim mapping contains quotes and line breaks", func() {
+		BeforeEach(func() {
+			hec.ValuesSetFromYaml("userAuthn.internal.providers", `
+- id: oidcID
+  displayName: oidcName
+  type: OIDC
+  oidc:
+    issuer: https://issuer.example.com
+    clientID: clientID
+    clientSecret: secret
+`)
+			hec.ValuesSet("userAuthn.internal.providers.0.oidc.claimMapping.email", oidcClaimInjection("injectedEmail"))
+			hec.ValuesSet("userAuthn.internal.providers.0.oidc.claimMapping.groups", oidcClaimInjection("injectedGroups"))
+			hec.ValuesSet("userAuthn.internal.providers.0.oidc.claimMapping.preferred_username", oidcClaimInjection("injectedUsername"))
+			hec.HelmRender()
+		})
+
+		It("Should keep every claim mapping as a single scalar of the oidc connector", func() {
+			connector := dexConnectors()
+
+			Expect(connector.Get("type").String()).To(Equal("oidc"))
+
+			claimMapping := connector.Get("config.claimMapping")
+			Expect(claimMapping.Get("email").String()).To(Equal(oidcClaimInjection("injectedEmail")))
+			Expect(claimMapping.Get("groups").String()).To(Equal(oidcClaimInjection("injectedGroups")))
+			Expect(claimMapping.Get("preferred_username").String()).To(Equal(oidcClaimInjection("injectedUsername")))
+
+			for _, key := range []string{"injectedEmail", "injectedGroups", "injectedUsername"} {
+				Expect(claimMapping.Get(key).Exists()).To(BeFalse())
+				Expect(connector.Get("config." + key).Exists()).To(BeFalse())
+			}
+		})
+	})
+})

--- a/modules/150-user-authn/templates/basic-auth-proxy/deployment.yaml
+++ b/modules/150-user-authn/templates/basic-auth-proxy/deployment.yaml
@@ -114,24 +114,24 @@ spec:
         - --cert-path=/etc/certs
         - --api-server-url=https://kubernetes.default
         {{- if eq $type "Crowd" }}
-        - --crowd-application-login={{ $config.clientID }}
-        - --crowd-application-password={{ $config.clientSecret }}
-        - --crowd-base-url={{ $config.baseURL }}
+        - {{ printf "--crowd-application-login=%s" $config.clientID | quote }}
+        - {{ printf "--crowd-application-password=%s" $config.clientSecret | quote }}
+        - {{ printf "--crowd-base-url=%s" $config.baseURL | quote }}
         {{- if $config.groups }}
           {{- range $group := $config.groups }}
-        - --crowd-allowed-group={{ $group }}
+        - {{ printf "--crowd-allowed-group=%s" $group | quote }}
           {{- end }}
         {{- end }}
         {{- end }}
         {{- if eq $type "OIDC" }}
-        - --oidc-base-url={{ $config.issuer }}
-        - --oidc-client-id={{ $config.clientID }}
-        - --oidc-client-secret={{ $config.clientSecret }}
+        - {{ printf "--oidc-base-url=%s" $config.issuer | quote }}
+        - {{ printf "--oidc-client-id=%s" $config.clientID | quote }}
+        - {{ printf "--oidc-client-secret=%s" $config.clientSecret | quote }}
         - --oidc-get-user-info={{ $config.getUserInfo | default false }}
         - --oidc-basic-auth-unsupported={{ $config.basicAuthUnsupported | default false }}
         {{- if $config.scopes }}
           {{- range $scope := $config.scopes }}
-        - --oidc-scope={{ $scope }}
+        - {{ printf "--oidc-scope=%s" $scope | quote }}
           {{- end }}
         {{- else }}
         - --oidc-scope=openid
@@ -150,7 +150,7 @@ spec:
         - --ldap-basic-auth-unsupported={{ $config.basicAuthUnsupported | default false }}
         {{- if $config.scopes }}
           {{- range $scope := $config.scopes }}
-        - --ldap-scope={{ $scope }}
+        - {{ printf "--ldap-scope=%s" $scope | quote }}
           {{- end }}
         {{- else }}
         - --ldap-scope=openid

--- a/modules/150-user-authn/templates/dex/config.yaml
+++ b/modules/150-user-authn/templates/dex/config.yaml
@@ -201,7 +201,7 @@
         bindDN: {{ $provider.ldap.bindDN | quote }}
         {{- end }}
         {{- if $provider.ldap.bindPW  }}
-        bindPW: '{{ $provider.ldap.bindPW }}'
+        bindPW: {{ $provider.ldap.bindPW | quote }}
         {{- end }}
         {{- if $provider.ldap.startTLS }}
         startTLS: true
@@ -251,9 +251,9 @@
         userNameKey: {{ $provider.oidc.userNameKey | default "name" | quote }}
         {{- if $provider.oidc.claimMapping }}
         claimMapping:
-          email: {{ $provider.oidc.claimMapping.email }}
-          groups: {{ $provider.oidc.claimMapping.groups }}
-          preferred_username: {{ $provider.oidc.claimMapping.preferred_username }}
+          email: {{ $provider.oidc.claimMapping.email | quote }}
+          groups: {{ $provider.oidc.claimMapping.groups | quote }}
+          preferred_username: {{ $provider.oidc.claimMapping.preferred_username | quote }}
         {{- end }}
         {{- if $provider.oidc.claimMappingOverride }}
         overrideClaimMapping: true


### PR DESCRIPTION
## Description

Two templates of the `user-authn` module interpolated string fields of the cluster-scoped `DexProvider` resource into rendered YAML without quoting. Every such string-typed interpolation is now rendered as a quoted scalar, reusing the idiom that both files already used for their neighbouring fields.

### 1. `templates/basic-auth-proxy/deployment.yaml`

Values were interpolated into the `args:` list of the `proxy` container. The existing idiom for `--ldap-client-secret` is reused:

```
- {{ printf "--oidc-scope=%s" $scope | quote }}
```

| Argument | Source field |
| --- | --- |
| `--crowd-application-login` | `spec.crowd.clientID` |
| `--crowd-application-password` | `spec.crowd.clientSecret` |
| `--crowd-base-url` | `spec.crowd.baseURL` |
| `--crowd-allowed-group` | `spec.crowd.groups[]` |
| `--oidc-base-url` | `spec.oidc.issuer` |
| `--oidc-client-id` | `spec.oidc.clientID` |
| `--oidc-client-secret` | `spec.oidc.clientSecret` |
| `--oidc-scope` | `spec.oidc.scopes[]` |
| `--ldap-scope` | `spec.ldap.scopes[]` |

### 2. `templates/dex/config.yaml`

Values were interpolated into the connector blocks of the Dex configuration file. The existing idiom for `bindDN`, one line above `bindPW`, is reused:

```
bindDN: {{ $provider.ldap.bindDN | quote }}
```

| Key | Source field | Previous form |
| --- | --- | --- |
| `bindPW` | `spec.ldap.bindPW` | single-quoted |
| `claimMapping.email` | `spec.oidc.claimMapping.email` | unquoted |
| `claimMapping.groups` | `spec.oidc.claimMapping.groups` | unquoted |
| `claimMapping.preferred_username` | `spec.oidc.claimMapping.preferred_username` | unquoted |

A single-quoted YAML scalar is terminated by a `'` in the value, so `bindPW` was affected by a quote as well as by a line break.

### Fields deliberately left alone

A full pass over both templates found no other unsafe interpolation. The following were checked and excluded:

* `--oidc-get-user-info`, `--oidc-basic-auth-unsupported`, `--ldap-basic-auth-unsupported`, `saml.filterGroups`, `saml.insecureSkipSignatureValidation` and the remaining `default false` flags — the corresponding CRD fields are `type: boolean`, so they cannot carry a line break, and quoting them would turn the rendered value into a string that Dex would reject.
* `github.teamNameField` — `type: string`, but constrained by `enum` in the CRD (`['name', 'slug', 'both']` in `v1alpha1`, `['Name', 'Slug', 'Both']` in `v1`), so no other value can be admitted. Left unquoted to keep the existing `| lower` rendering intact.
* `ldap.rootCAData`, `gitlab.rootCAData`, `saml.rootCAData` — piped through `b64enc`, whose output cannot leave the scalar.
* `ldap.userSearch`, `ldap.groupSearch` — rendered with `toYaml`, which quotes as needed.

No behaviour changes for existing configurations: single-line values render exactly as before.

### 3. One schema constraint, and why only one

The templates above close the injection. A third commit additionally constrains `spec.oidc.scopes` items with `pattern: '^\S+$'`, because that constraint follows from the protocol rather than from this defect: OAuth2 passes scopes as a space-delimited list, so a scope containing whitespace cannot work at all, and rejecting it at admission is better than rendering a value that silently breaks authentication. The `oidc` schema is shared between `v1alpha1` and `v1` through the `&oidc` / `*oidc` YAML anchor, so the constraint applies to both served versions and cannot drift apart; that was verified by parsing the CRD.

No other `DexProvider` field gets a schema constraint, and that is a deliberate decision rather than an omission:

* Adding `pattern: '^[^\r\n]*$'` across the roughly sixty unconstrained string fields would **break** `ldap.rootCAData`, `gitlab.rootCAData`, `oidc.rootCAData` and `saml.rootCAData`, whose values are PEM blocks and therefore multi-line by nature.
* The group-shaped lists — `oidc.allowedGroups`, `saml.allowedGroups`, `crowd.groups`, `gitlab.groups`, `bitbucketCloud.teams` — hold group names coming from an external identity provider, which legitimately contain spaces, slashes and non-ASCII characters. A whitespace ban there would reject configurations that work today.
* For everything else the marginal value is low: `DexProvider` is cluster-scoped, so writing it already requires authority over the module's identity configuration, and the rendering path is now quoted regardless of the value.

The same reasoning is why no unit test accompanies the schema change: a test asserting that a declarative `pattern` equals the string it was just set to proves nothing, and the cross-version invariant is guaranteed structurally by the anchor rather than by a hand-maintained duplicate.

## Why do we need it, and what problem does it solve?

Both sinks let a `DexProvider` author inject arbitrary YAML into a rendered manifest.

In the Deployment, a field containing a line break terminated the `args:` block sequence and the remaining lines were parsed as sibling keys of the `proxy` container, allowing `image`, `command`, `args` and `workingDir` of a system container to be replaced. The pod mounts the `basic-auth-cert` secret, so controlling that container matters.

In the Dex configuration the injected YAML lands in Dex's own configuration file, so it can add keys to a connector or append an entire connector — for example enabling `insecureNoSSL` on an LDAP connector, or changing how identities are mapped. Dex mints the identities the kube-apiserver trusts, so silently altering its configuration from a custom resource is worth closing even though it grants nothing beyond what write access to `DexProvider` already implies.

Both paths are covered by template tests that fail against the previous templates and pass with this change:

* `template_tests/basic_auth_proxy_test.go` renders the Deployment with a multi-line value in each of the nine affected fields and asserts the container keeps its own image, gains no `command` or `workingDir`, and that the value stays a single argv element. It also pins the boolean flags to their unquoted form.
* `template_tests/connector_quoting_test.go` decodes the rendered Dex configuration out of its Secret, parses it back as YAML, and asserts that values containing both a quote and a line break round-trip as single scalars, that no extra connector keys appear, and that the connector list stays the expected length.

## Why do we need it in the patch release (if we do)?

This is a hardening fix for a manifest-rendering issue that is reachable from a custom resource, so it should be backported to 1.77 and 1.76.

All three commits cherry-pick onto `release-1.77` and `release-1.76` with no conflicts. `basic-auth-proxy/deployment.yaml` is byte-identical on all three branches; `dex/config.yaml` differs only by lines added elsewhere in the file on `main`, so the change applies by context. For the schema commit, `crds/dex-provider.yaml` and `crds/doc-ru-dex-provider.yaml` diverge from `main` on `release-1.76`, but the `scopes` block and its surrounding context are byte-identical on all three branches and the `&oidc` anchor is present on each, so that hunk applies by context too.

On `release-1.77` the whole `template_tests` suite passes as-is. On `release-1.76` the templates and the new Dex configuration test apply and pass unchanged; only `basic_auth_proxy_test.go` needs `userAuthn.publishAPI.*` instead of `userAuthn.internal.publishAPI.*`, because that value moved between the two releases, and with those two paths adjusted the suite passes there as well. That two-line adaptation is the only reason `release-1.76` needs a dedicated backport pull request rather than a straight pick.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

The `scopes` constraint is described in the CRD `description` in both languages, which is where the reference documentation for this field is generated from. Any further client-facing documentation for this series of changes is handled in a separate documentation pull request, so that the documentation team reviews it in one place.

## Changelog entries

```changes
section: user-authn
type: fix
summary: Quote DexProvider-derived values rendered into the basic-auth-proxy Deployment and the Dex configuration file to prevent YAML injection.
impact_level: default
---
section: user-authn
type: fix
summary: Reject whitespace in DexProvider OIDC scopes, which the OAuth2 protocol cannot represent.
impact: |
  `spec.oidc.scopes` items are now validated against `^\S+$` in both served versions of DexProvider. A scope containing whitespace could never work, because OAuth2 passes scopes as a space-delimited list, but it was previously admitted and silently broke authentication. Stored objects are not invalidated, however a DexProvider holding such a value is rejected on its next write until the value is corrected, which also affects a GitOps flow that reapplies the object unchanged.
impact_level: high
```

