### PR TITLE
[user-authn] Issue a dedicated OAuth2 client secret per DexAuthenticator

### DIFF
--- a/modules/150-user-authn/hooks/generate_kubernetes_dex_client_app_secret.go
+++ b/modules/150-user-authn/hooks/generate_kubernetes_dex_client_app_secret.go
@@ -29,6 +29,11 @@ import (
 	"github.com/deckhouse/deckhouse/go_lib/pwgen"
 )
 
+// kubernetesDexClientAppSecretPath holds the secret of the privileged kubernetes OAuth2Client.
+// It is shared by every consumer of the kubernetes client and must never be handed out to
+// per-application clients.
+const kubernetesDexClientAppSecretPath = "userAuthn.internal.kubernetesDexClientAppSecret"
+
 type KubernetesSecret []byte
 
 func applyKubernetesSecretFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
@@ -61,7 +66,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 }, kubernetesDexClientAppSecret)
 
 func kubernetesDexClientAppSecret(_ context.Context, input *go_hook.HookInput) error {
-	secretPath := "userAuthn.internal.kubernetesDexClientAppSecret"
+	secretPath := kubernetesDexClientAppSecretPath
 	if input.Values.Exists(secretPath) && input.Values.Get(secretPath).String() != "" {
 		return nil
 	}

--- a/modules/150-user-authn/hooks/generate_kubernetes_dex_client_app_secret.go
+++ b/modules/150-user-authn/hooks/generate_kubernetes_dex_client_app_secret.go
@@ -29,10 +29,15 @@ import (
 	"github.com/deckhouse/deckhouse/go_lib/pwgen"
 )
 
-// kubernetesDexClientAppSecretPath holds the secret of the privileged kubernetes OAuth2Client.
-// It is shared by every consumer of the kubernetes client and must never be handed out to
-// per-application clients.
-const kubernetesDexClientAppSecretPath = "userAuthn.internal.kubernetesDexClientAppSecret"
+const (
+	// kubernetesDexClientAppSecretPath holds the secret of the privileged kubernetes OAuth2Client.
+	// It is shared by every consumer of the kubernetes client and must never be handed out to
+	// per-application clients.
+	kubernetesDexClientAppSecretPath = "userAuthn.internal.kubernetesDexClientAppSecret"
+
+	kubernetesDexClientAppSecretNamespace = "d8-user-authn"
+	kubernetesDexClientAppSecretName      = "kubernetes-dex-client-app-secret"
+)
 
 type KubernetesSecret []byte
 
@@ -54,11 +59,11 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			Kind:       "Secret",
 			NamespaceSelector: &types.NamespaceSelector{
 				NameSelector: &types.NameSelector{
-					MatchNames: []string{"d8-user-authn"},
+					MatchNames: []string{kubernetesDexClientAppSecretNamespace},
 				},
 			},
 			NameSelector: &types.NameSelector{
-				MatchNames: []string{"kubernetes-dex-client-app-secret"},
+				MatchNames: []string{kubernetesDexClientAppSecretName},
 			},
 			FilterFunc: applyKubernetesSecretFilter,
 		},
@@ -66,8 +71,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 }, kubernetesDexClientAppSecret)
 
 func kubernetesDexClientAppSecret(_ context.Context, input *go_hook.HookInput) error {
-	secretPath := kubernetesDexClientAppSecretPath
-	if input.Values.Exists(secretPath) && input.Values.Get(secretPath).String() != "" {
+	if input.Values.Exists(kubernetesDexClientAppSecretPath) && input.Values.Get(kubernetesDexClientAppSecretPath).String() != "" {
 		return nil
 	}
 
@@ -81,14 +85,14 @@ func kubernetesDexClientAppSecret(_ context.Context, input *go_hook.HookInput) e
 
 		// if secret field was removed, generate a new one
 		if len(secretContent) == 0 {
-			input.Values.Set(secretPath, pwgen.AlphaNum(20))
+			input.Values.Set(kubernetesDexClientAppSecretPath, pwgen.AlphaNum(20))
 			return nil
 		}
 
-		input.Values.Set(secretPath, string(secretContent))
+		input.Values.Set(kubernetesDexClientAppSecretPath, string(secretContent))
 		return nil
 	}
 
-	input.Values.Set(secretPath, pwgen.AlphaNum(20))
+	input.Values.Set(kubernetesDexClientAppSecretPath, pwgen.AlphaNum(20))
 	return nil
 }

--- a/modules/150-user-authn/hooks/get_dex_authenticator_crds.go
+++ b/modules/150-user-authn/hooks/get_dex_authenticator_crds.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -144,8 +145,47 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			},
 			FilterFunc: applyDexAuthenticatorSecretFilter,
 		},
+		{
+			Name:       "kubernetesClientSecret",
+			ApiVersion: "v1",
+			Kind:       "Secret",
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{kubernetesDexClientAppSecretNamespace},
+				},
+			},
+			NameSelector: &types.NameSelector{
+				MatchNames: []string{kubernetesDexClientAppSecretName},
+			},
+			FilterFunc: applyKubernetesSecretFilter,
+		},
 	},
 }, getDexAuthenticator)
+
+// sharedKubernetesClientSecret returns the secret of the privileged kubernetes OAuth2Client as it
+// exists in the cluster.
+//
+// It deliberately reads this hook's own snapshot instead of kubernetesDexClientAppSecretPath: that
+// values path is written by kubernetesDexClientAppSecret, which runs in the "main" queue while this
+// hook runs in "/modules/user-authn", so nothing orders the two and the value may still be absent
+// here on a cold start. The cluster Secret is also the authoritative source, since it is the object
+// whose content was copied into the application namespaces.
+//
+// An empty result means the shared secret does not exist in the cluster, so no authenticator can be
+// carrying it and there is nothing to migrate.
+func sharedKubernetesClientSecret(input *go_hook.HookInput) (string, error) {
+	snapshots := input.Snapshots.Get("kubernetesClientSecret")
+	if len(snapshots) == 0 {
+		return "", nil
+	}
+
+	var secretContent []byte
+	if err := snapshots[0].UnmarshalTo(&secretContent); err != nil {
+		return "", fmt.Errorf("cannot convert kubernetes client secret to bytes: failed to unmarshal 'kubernetesClientSecret' snapshot: %w", err)
+	}
+
+	return string(secretContent), nil
+}
 
 func getDexAuthenticator(_ context.Context, input *go_hook.HookInput) error {
 	authenticators := input.Snapshots.Get("authenticators")
@@ -166,7 +206,10 @@ func getDexAuthenticator(_ context.Context, input *go_hook.HookInput) error {
 	// Secret, and the "credentials" snapshot above reads it straight back into appDexSecret.
 	// Keep it to detect and rotate those, otherwise the shared secret would never leave the
 	// application namespace.
-	sharedClientSecret := input.Values.Get(kubernetesDexClientAppSecretPath).String()
+	sharedClientSecret, err := sharedKubernetesClientSecret(input)
+	if err != nil {
+		return err
+	}
 
 	dexAuthenticators := make([]DexAuthenticator, 0, len(authenticators))
 	// Build computed names map: key "<name>@<namespace>" => {name, truncated, hash}
@@ -190,9 +233,16 @@ func getDexAuthenticator(_ context.Context, input *go_hook.HookInput) error {
 			existedCredentials.CookieSecret = pwgen.AlphaNum(24)
 		}
 
-		// Migrate authenticators that reuse the shared kubernetes client secret to their own one
+		// Migrate authenticators that reuse the shared kubernetes client secret to their own one.
+		// The non-empty guard keeps an authenticator whose credentials Secret carries no
+		// client-secret from being rotated against an absent shared secret.
 		if sharedClientSecret != "" && existedCredentials.AppDexSecret == sharedClientSecret {
 			existedCredentials.AppDexSecret = pwgen.AlphaNum(20)
+			// Rotating logs every user of this authenticator out and rolls its pods, so make the
+			// upgrade traceable in the Deckhouse log.
+			input.Logger.Warn("Rotating DexAuthenticator client secret that reused the shared kubernetes client secret",
+				slog.String("dexauthenticator", dexAuthenticator.Name),
+				slog.String("namespace", dexAuthenticator.Namespace))
 		}
 
 		if raw := dexAuthenticator.AllowAccessToKubernetesAnnotation; raw != nil {

--- a/modules/150-user-authn/hooks/get_dex_authenticator_crds.go
+++ b/modules/150-user-authn/hooks/get_dex_authenticator_crds.go
@@ -161,6 +161,13 @@ func getDexAuthenticator(_ context.Context, input *go_hook.HookInput) error {
 		credentialsByID[dexSecret.ID] = dexSecret.Credentials
 	}
 
+	// Authenticators created before the templates stopped copying the kubernetes OAuth2Client
+	// secret into the application namespace carry that shared secret in their credentials
+	// Secret, and the "credentials" snapshot above reads it straight back into appDexSecret.
+	// Keep it to detect and rotate those, otherwise the shared secret would never leave the
+	// application namespace.
+	sharedClientSecret := input.Values.Get(kubernetesDexClientAppSecretPath).String()
+
 	dexAuthenticators := make([]DexAuthenticator, 0, len(authenticators))
 	// Build computed names map: key "<name>@<namespace>" => {name, truncated, hash}
 	namesMap := make(map[string]interface{})
@@ -181,6 +188,11 @@ func getDexAuthenticator(_ context.Context, input *go_hook.HookInput) error {
 		// Migrate all cookie secret from 20 bytes length to 24 bytes
 		if len(existedCredentials.CookieSecret) < 24 {
 			existedCredentials.CookieSecret = pwgen.AlphaNum(24)
+		}
+
+		// Migrate authenticators that reuse the shared kubernetes client secret to their own one
+		if sharedClientSecret != "" && existedCredentials.AppDexSecret == sharedClientSecret {
+			existedCredentials.AppDexSecret = pwgen.AlphaNum(20)
 		}
 
 		if raw := dexAuthenticator.AllowAccessToKubernetesAnnotation; raw != nil {

--- a/modules/150-user-authn/hooks/get_dex_authenticator_crds_test.go
+++ b/modules/150-user-authn/hooks/get_dex_authenticator_crds_test.go
@@ -18,6 +18,7 @@ package hooks
 
 import (
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"fmt"
 	"strings"
@@ -35,6 +36,13 @@ type inputDexAuthenticatorAllowAccess struct {
 	allowed    bool
 	warns      bool
 }
+
+type inputDexAuthenticatorClientSecret struct {
+	existing string
+	rotated  bool
+}
+
+const sharedKubernetesClientSecret = "sharedKubernetesSecret"
 
 var _ = Describe("User Authn hooks :: get dex authenticator crds ::", func() {
 	f := HookExecutionConfigInit(`{"userAuthn":{"internal": {}}}`, "")
@@ -377,6 +385,57 @@ spec:
 		),
 		Entry("denies access to the Kubernetes API without warning when the annotation is absent",
 			inputDexAuthenticatorAllowAccess{},
+		),
+	)
+
+	DescribeTable("The client secret of an existing DexAuthenticator",
+		func(in inputDexAuthenticatorClientSecret) {
+			const cookieSecret = "testNexttestNexttestNext"
+
+			f.ValuesSet("userAuthn.internal.kubernetesDexClientAppSecret", sharedKubernetesClientSecret)
+			f.BindingContexts.Set(f.KubeStateSet(`
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dex-authenticator-test
+  namespace: test
+  labels:
+    app: dex-authenticator
+    name: credentials
+data:
+  client-secret: ` + base64.StdEncoding.EncodeToString([]byte(in.existing)) + `
+  cookie-secret: ` + base64.StdEncoding.EncodeToString([]byte(cookieSecret)) + `
+---
+apiVersion: deckhouse.io/v2alpha1
+kind: DexAuthenticator
+metadata:
+  name: test
+  namespace: test
+  annotations:
+    dexauthenticator.deckhouse.io/allow-access-to-kubernetes: "true"
+spec:
+  applications:
+  - domain: test
+    ingressClassName: "nginx"
+`))
+			f.RunHook()
+
+			Expect(f).To(ExecuteSuccessfully())
+
+			appDexSecret := f.ValuesGet("userAuthn.internal.dexAuthenticatorCRDs.0.credentials.appDexSecret").String()
+			if in.rotated {
+				Expect(appDexSecret).NotTo(Equal(sharedKubernetesClientSecret))
+				Expect(appDexSecret).To(HaveLen(20))
+			} else {
+				Expect(appDexSecret).To(Equal(in.existing))
+			}
+		},
+		Entry("is regenerated when it equals the shared kubernetes client secret",
+			inputDexAuthenticatorClientSecret{existing: sharedKubernetesClientSecret, rotated: true},
+		),
+		Entry("is preserved when it is unrelated to the shared kubernetes client secret",
+			inputDexAuthenticatorClientSecret{existing: "perAuthenticatorSecret"},
 		),
 	)
 })

--- a/modules/150-user-authn/hooks/get_dex_authenticator_crds_test.go
+++ b/modules/150-user-authn/hooks/get_dex_authenticator_crds_test.go
@@ -38,11 +38,21 @@ type inputDexAuthenticatorAllowAccess struct {
 }
 
 type inputDexAuthenticatorClientSecret struct {
+	// existing is the client-secret stored in the authenticator credentials Secret.
 	existing string
+	// omitExisting drops the client-secret key altogether, as a Secret written by an older
+	// template revision that never carried it would look.
+	omitExisting bool
+	// inCluster is data.secret of d8-user-authn/kubernetes-dex-client-app-secret; empty means
+	// the Secret is absent from the cluster.
+	inCluster string
+	// inValues is userAuthn.internal.kubernetesDexClientAppSecret; empty means the sibling hook
+	// has not populated it yet.
+	inValues string
 	rotated  bool
 }
 
-const sharedKubernetesClientSecret = "sharedKubernetesSecret"
+const testSharedKubernetesClientSecret = "sharedKubernetesSecret"
 
 var _ = Describe("User Authn hooks :: get dex authenticator crds ::", func() {
 	f := HookExecutionConfigInit(`{"userAuthn":{"internal": {}}}`, "")
@@ -392,7 +402,30 @@ spec:
 		func(in inputDexAuthenticatorClientSecret) {
 			const cookieSecret = "testNexttestNexttestNext"
 
-			f.ValuesSet("userAuthn.internal.kubernetesDexClientAppSecret", sharedKubernetesClientSecret)
+			clientSecretData := ""
+			if !in.omitExisting {
+				clientSecretData = "\n  client-secret: " + base64.StdEncoding.EncodeToString([]byte(in.existing))
+			}
+
+			sharedSecret := ""
+			if in.inCluster != "" {
+				sharedSecret = `
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ` + kubernetesDexClientAppSecretName + `
+  namespace: ` + kubernetesDexClientAppSecretNamespace + `
+data:
+  secret: ` + base64.StdEncoding.EncodeToString([]byte(in.inCluster)) + "\n"
+			}
+
+			if in.inValues == "" {
+				f.ValuesDelete(kubernetesDexClientAppSecretPath)
+			} else {
+				f.ValuesSet(kubernetesDexClientAppSecretPath, in.inValues)
+			}
+
 			f.BindingContexts.Set(f.KubeStateSet(`
 ---
 apiVersion: v1
@@ -403,8 +436,7 @@ metadata:
   labels:
     app: dex-authenticator
     name: credentials
-data:
-  client-secret: ` + base64.StdEncoding.EncodeToString([]byte(in.existing)) + `
+data:` + clientSecretData + `
   cookie-secret: ` + base64.StdEncoding.EncodeToString([]byte(cookieSecret)) + `
 ---
 apiVersion: deckhouse.io/v2alpha1
@@ -418,24 +450,54 @@ spec:
   applications:
   - domain: test
     ingressClassName: "nginx"
-`))
+` + sharedSecret))
 			f.RunHook()
 
 			Expect(f).To(ExecuteSuccessfully())
 
 			appDexSecret := f.ValuesGet("userAuthn.internal.dexAuthenticatorCRDs.0.credentials.appDexSecret").String()
+			logs := string(f.LoggerOutput.Contents())
 			if in.rotated {
-				Expect(appDexSecret).NotTo(Equal(sharedKubernetesClientSecret))
+				Expect(appDexSecret).NotTo(Equal(testSharedKubernetesClientSecret))
 				Expect(appDexSecret).To(HaveLen(20))
+				Expect(logs).To(ContainSubstring("Rotating DexAuthenticator client secret that reused the shared kubernetes client secret"))
 			} else {
 				Expect(appDexSecret).To(Equal(in.existing))
+				Expect(logs).NotTo(ContainSubstring("Rotating DexAuthenticator client secret that reused the shared kubernetes client secret"))
 			}
 		},
 		Entry("is regenerated when it equals the shared kubernetes client secret",
-			inputDexAuthenticatorClientSecret{existing: sharedKubernetesClientSecret, rotated: true},
+			inputDexAuthenticatorClientSecret{
+				existing:  testSharedKubernetesClientSecret,
+				inCluster: testSharedKubernetesClientSecret,
+				inValues:  testSharedKubernetesClientSecret,
+				rotated:   true,
+			},
 		),
 		Entry("is preserved when it is unrelated to the shared kubernetes client secret",
+			inputDexAuthenticatorClientSecret{
+				existing:  "perAuthenticatorSecret",
+				inCluster: testSharedKubernetesClientSecret,
+				inValues:  testSharedKubernetesClientSecret,
+			},
+		),
+		// The values path is written by kubernetesDexClientAppSecret, which runs in the "main"
+		// queue while this hook runs in "/modules/user-authn", so it may still be empty here.
+		// The migration must not depend on it.
+		Entry("is regenerated from the cluster Secret when the values path is not populated yet",
+			inputDexAuthenticatorClientSecret{
+				existing:  testSharedKubernetesClientSecret,
+				inCluster: testSharedKubernetesClientSecret,
+				rotated:   true,
+			},
+		),
+		Entry("is preserved when the shared kubernetes client secret does not exist in the cluster",
 			inputDexAuthenticatorClientSecret{existing: "perAuthenticatorSecret"},
+		),
+		// Both sides of the comparison are empty here, so without the non-empty guard every
+		// authenticator whose credentials Secret has no client-secret would be rotated.
+		Entry("is left empty when neither the credentials Secret nor the shared secret carries one",
+			inputDexAuthenticatorClientSecret{omitExisting: true},
 		),
 	)
 })

--- a/modules/150-user-authn/template_tests/authenticator_test.go
+++ b/modules/150-user-authn/template_tests/authenticator_test.go
@@ -184,6 +184,14 @@ var _ = Describe("Module :: user-authn :: helm template :: dex authenticator", f
 			Expect(secret.Field("data.client-secret").String()).To(Equal("ZGV4U2VjcmV0"))
 			Expect(secret.Field("data.cookie-secret").String()).To(Equal("Y29va2llU2VjcmV0"))
 
+			// Even with access to the Kubernetes API the authenticator gets its own client
+			// secret, never the shared secret of the kubernetes OAuth2Client ("plainstring").
+			secretWithAccess := hec.KubernetesResource("Secret", "d8-test", "dex-authenticator-test-2")
+			Expect(secretWithAccess.Exists()).To(BeTrue())
+			Expect(secretWithAccess.Field("data.client-secret").String()).To(Equal("ZGV4U2VjcmV0"))
+			Expect(secretWithAccess.Field("data.client-secret").String()).NotTo(Equal("cGxhaW5zdHJpbmc="))
+			Expect(secretWithAccess.Field("data.cookie-secret").String()).To(Equal("Y29va2llU2VjcmV0"))
+
 			oauth2clientTest := hec.KubernetesResource("OAuth2Client", "d8-user-authn", "justForTest")
 			Expect(oauth2clientTest.Exists()).To(BeTrue())
 			Expect(oauth2clientTest.Field("redirectURIs").String()).To(MatchJSON(`["https://authenticator.example.com/dex-authenticator/callback","https://authenticator-two.example.com/dex-authenticator/callback"]`))

--- a/modules/150-user-authn/template_tests/kubernetes_oauth2client_test.go
+++ b/modules/150-user-authn/template_tests/kubernetes_oauth2client_test.go
@@ -80,9 +80,12 @@ var _ = Describe("Module :: user-authn :: helm template :: kubernetes oauth2clie
 `)
 			hec.HelmRender()
 		})
-		It("Should deploy kubernetes OAuth2Client", func() {
+		It("Should deploy kubernetes OAuth2Client without redirect URIs", func() {
 			Expect(hec.RenderError).ShouldNot(HaveOccurred())
-			Expect(hec.KubernetesResource("OAuth2Client", "d8-user-authn", "nn2wezlsnzsxizltzpzjzzeeeirsk").Exists()).To(BeTrue())
+
+			oauth2Client := hec.KubernetesResource("OAuth2Client", "d8-user-authn", "nn2wezlsnzsxizltzpzjzzeeeirsk")
+			Expect(oauth2Client.Exists()).To(BeTrue())
+			Expect(oauth2Client.Field("redirectURIs").Array()).To(BeEmpty())
 		})
 	})
 
@@ -249,8 +252,10 @@ var _ = Describe("Module :: user-authn :: helm template :: kubernetes oauth2clie
 				"https://kubeconfig.example.com/callback/0",
 				"https://kubeconfig.example.com/callback/1",
 				"https://kubeconfig.example.com/callback/",
-				"https://with-access.example.com/dex-authenticator/callback",
 			))
+			// Authenticators redirect to their own OAuth2Client, so no tenant-controlled
+			// domain may reach the redirect URIs of the privileged kubernetes client.
+			Expect(uris).NotTo(ContainElement(ContainSubstring("/dex-authenticator/callback")))
 		})
 
 		It("Should render a separate OAuth2Client for each slug-based clientID and for publishAPI", func() {

--- a/modules/150-user-authn/template_tests/kubernetes_oauth2client_test.go
+++ b/modules/150-user-authn/template_tests/kubernetes_oauth2client_test.go
@@ -65,8 +65,10 @@ var _ = Describe("Module :: user-authn :: helm template :: kubernetes oauth2clie
     appDexSecret: dexSecret
     cookieSecret: cookieSecret
   spec:
-    applicationDomain: authenticator.example.com
-    applicationIngressCertificateSecretName: test
+    applications:
+    - domain: authenticator.example.com
+      ingressClassName: nginx
+      ingressSecretName: test
 `)
 			hec.ValuesSetFromYaml("userAuthn.internal.dexAuthenticatorNames", `
 "test@d8-test":
@@ -76,7 +78,11 @@ var _ = Describe("Module :: user-authn :: helm template :: kubernetes oauth2clie
   secretName: "dex-authenticator-test"
   secretTruncated: false
   secretHash: ""
-  ingressNames: {}
+  ingressNames:
+    "0":
+      name: "test-dex-authenticator"
+      truncated: false
+      hash: ""
 `)
 			hec.HelmRender()
 		})
@@ -85,7 +91,18 @@ var _ = Describe("Module :: user-authn :: helm template :: kubernetes oauth2clie
 
 			oauth2Client := hec.KubernetesResource("OAuth2Client", "d8-user-authn", "nn2wezlsnzsxizltzpzjzzeeeirsk")
 			Expect(oauth2Client.Exists()).To(BeTrue())
-			Expect(oauth2Client.Field("redirectURIs").Array()).To(BeEmpty())
+
+			redirectURIs := oauth2Client.Field("redirectURIs")
+			Expect(redirectURIs.IsArray()).To(BeTrue(), "redirectURIs must render as a list, not a bare key parsed as null")
+			Expect(redirectURIs.Array()).To(BeEmpty())
+
+			// The authenticator still reaches the privileged client through trustedPeers, so the
+			// empty redirectURIs above is not just an empty render.
+			peers := []string{}
+			for _, p := range oauth2Client.Field("trustedPeers").Array() {
+				peers = append(peers, p.String())
+			}
+			Expect(peers).To(ConsistOf("test-d8-test-dex-authenticator"))
 		})
 	})
 
@@ -99,8 +116,10 @@ var _ = Describe("Module :: user-authn :: helm template :: kubernetes oauth2clie
     appDexSecret: dexSecret
     cookieSecret: cookieSecret
   spec:
-    applicationDomain: authenticator.example.com
-    applicationIngressCertificateSecretName: test
+    applications:
+    - domain: authenticator.example.com
+      ingressClassName: nginx
+      ingressSecretName: test
 `)
 			hec.ValuesSetFromYaml("userAuthn.internal.dexAuthenticatorNames", `
 "test@d8-test":
@@ -110,7 +129,11 @@ var _ = Describe("Module :: user-authn :: helm template :: kubernetes oauth2clie
   secretName: "dex-authenticator-test"
   secretTruncated: false
   secretHash: ""
-  ingressNames: {}
+  ingressNames:
+    "0":
+      name: "test-dex-authenticator"
+      truncated: false
+      hash: ""
 `)
 			hec.HelmRender()
 		})
@@ -131,8 +154,10 @@ var _ = Describe("Module :: user-authn :: helm template :: kubernetes oauth2clie
     appDexSecret: s1
     cookieSecret: c1
   spec:
-    applicationDomain: with-access.example.com
-    applicationIngressCertificateSecretName: cert-1
+    applications:
+    - domain: with-access.example.com
+      ingressClassName: nginx
+      ingressSecretName: cert-1
 - name: no-access
   encodedName: encNoAccess
   namespace: d8-no-access
@@ -140,8 +165,10 @@ var _ = Describe("Module :: user-authn :: helm template :: kubernetes oauth2clie
     appDexSecret: s2
     cookieSecret: c2
   spec:
-    applicationDomain: no-access.example.com
-    applicationIngressCertificateSecretName: cert-2
+    applications:
+    - domain: no-access.example.com
+      ingressClassName: nginx
+      ingressSecretName: cert-2
 `)
 			hec.ValuesSetFromYaml("userAuthn.internal.dexAuthenticatorNames", `
 "with-access@d8-with-access":
@@ -151,7 +178,11 @@ var _ = Describe("Module :: user-authn :: helm template :: kubernetes oauth2clie
   secretName: "dex-authenticator-with-access"
   secretTruncated: false
   secretHash: ""
-  ingressNames: {}
+  ingressNames:
+    "0":
+      name: "with-access-dex-authenticator"
+      truncated: false
+      hash: ""
 "no-access@d8-no-access":
   name: "no-access-dex-authenticator"
   truncated: false
@@ -159,7 +190,11 @@ var _ = Describe("Module :: user-authn :: helm template :: kubernetes oauth2clie
   secretName: "dex-authenticator-no-access"
   secretTruncated: false
   secretHash: ""
-  ingressNames: {}
+  ingressNames:
+    "0":
+      name: "no-access-dex-authenticator"
+      truncated: false
+      hash: ""
 `)
 			hec.ValuesSetFromYaml("userAuthn.internal.dexClientCRDs", `
 - id: my-app@d8-test

--- a/modules/150-user-authn/templates/dex-authenticator/secret.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/secret.yaml
@@ -19,11 +19,7 @@ metadata:
   {{- end }}
   {{- include "helm_lib_module_labels" (list $context $labels) | nindent 2 }}
 data:
-  {{- if $crd.allowAccessToKubernetes }}
-  client-secret: {{ $context.Values.userAuthn.internal.kubernetesDexClientAppSecret | b64enc }}
-  {{- else }}
   client-secret: {{ $crd.credentials.appDexSecret | b64enc }}
-  {{- end }}
   cookie-secret: {{ $crd.credentials.cookieSecret | b64enc }}
   {{- $namespaces := (get $context "namespaces") | default (list) }}
   {{- if not (has $crd.namespace $namespaces) }}

--- a/modules/150-user-authn/templates/dex/oauth2client.yaml
+++ b/modules/150-user-authn/templates/dex/oauth2client.yaml
@@ -46,6 +46,7 @@ trustedPeers:
 - kubeconfig-{{ $slug }}
   {{- end }}
 {{- end }}
+{{- if or $context.Values.userAuthn.kubeconfigGenerator $context.Values.userAuthn.internal.publishAPI.enabled }}
 redirectURIs:
   {{- if $context.Values.userAuthn.kubeconfigGenerator }}
     {{- range $index, $cluster := $context.Values.userAuthn.kubeconfigGenerator }}
@@ -55,4 +56,10 @@ redirectURIs:
   {{- if $context.Values.userAuthn.internal.publishAPI.enabled }}
 - https://{{ include "helm_lib_module_public_domain" (list $context "kubeconfig") }}/callback/
   {{- end }}
+{{- else }}
+# The client exists only to hold trustedPeers of authenticators, which redirect to their own
+# OAuth2Client, so it needs no redirect URI of its own. Emit an empty list rather than a bare key,
+# which would parse as null.
+redirectURIs: []
+{{- end }}
 {{- end }}

--- a/modules/150-user-authn/templates/dex/oauth2client.yaml
+++ b/modules/150-user-authn/templates/dex/oauth2client.yaml
@@ -55,11 +55,4 @@ redirectURIs:
   {{- if $context.Values.userAuthn.internal.publishAPI.enabled }}
 - https://{{ include "helm_lib_module_public_domain" (list $context "kubeconfig") }}/callback/
   {{- end }}
-  {{- if $context.Values.userAuthn.internal.dexAuthenticatorCRDs }}
-    {{- range $crd := $context.Values.userAuthn.internal.dexAuthenticatorCRDs }}
-      {{- if $crd.allowAccessToKubernetes }}
-- https://{{ $crd.spec.applicationDomain }}/dex-authenticator/callback
-      {{- end }}
-    {{- end }}
-  {{- end }}
 {{- end }}


### PR DESCRIPTION
## Description

Two internal-only changes in `modules/150-user-authn`. No CRD/API change.

**1. Stop copying the shared `kubernetes` client secret into application namespaces.**

`templates/dex-authenticator/secret.yaml` rendered `client-secret` from
`userAuthn.internal.kubernetesDexClientAppSecret` whenever the authenticator carried the
`dexauthenticator.deckhouse.io/allow-access-to-kubernetes` annotation. That value is the single secret of the
privileged `kubernetes` OAuth2 client, also used by `templates/dex/secret.yaml`,
`templates/kubeconfig-generator/oauth2client.yaml`, `templates/dex/kubeconfig-oauth2clients.yaml`,
`templates/dex/kubernetes-dex-client-configuration.yaml` and `templates/basic-auth-proxy/deployment.yaml`.
The Secret is created in `{{ $crd.namespace }}`, so anyone able to read Secrets in an application namespace
obtained a cluster-level credential. The template now always renders the per-authenticator
`credentials.appDexSecret`.

Because `hooks/get_dex_authenticator_crds.go` reads `client-secret` back out of that same Secret into
`credentials.appDexSecret` (`applyDexAuthenticatorSecretFilter`), on clusters where the annotation was already
in use `appDexSecret` *is* the shared secret, and dropping the template branch alone would not rotate anything.
The hook therefore regenerates `appDexSecret` once when it equals the current secret of the `kubernetes`
client, reusing the existing `go_lib/pwgen` generator (`pwgen.AlphaNum(20)`) already used for `appDexSecret`
and `cookieSecret`.

The comparison value is read from the hook's own `kubernetesClientSecret` snapshot of
`d8-user-authn/kubernetes-dex-client-app-secret`, reusing `applyKubernetesSecretFilter` from
`hooks/generate_kubernetes_dex_client_app_secret.go`. It is deliberately not read from
`userAuthn.internal.kubernetesDexClientAppSecret`: that values path is written by
`kubernetesDexClientAppSecret`, which runs in the `main` queue, while this hook declares
`Queue: "/modules/user-authn"`, and `ModuleRun` queues the Synchronization tasks of the two queues
independently, so nothing orders them on a cold start. The cluster Secret is also the authoritative source,
being the object whose content was copied out. An absent Secret now means the shared secret does not exist, so
nothing can be carrying it. Every rotation is logged with `input.Logger.Warn`, since it rolls the
authenticator's pods.

**2. Remove dead tenant-controlled input from the privileged client.**

`templates/dex/oauth2client.yaml` appended `https://{{ $crd.spec.applicationDomain }}/dex-authenticator/callback`
to the `redirectURIs` of the `kubernetes` client itself. The hook watches `deckhouse.io/v2alpha1`, whose schema
has `spec.applications[].domain` and no `spec.applicationDomain` (`crds/dex-authenticator.yaml`), so the entry
always rendered as the broken literal `https:///dex-authenticator/callback`. The block is removed, and the
`redirectURIs` key now renders as `[]` instead of a bare key when the client exists only to hold the
`trustedPeers` of annotated authenticators.

### Verification that matching client secrets are not required

Cross-client audience issuance in Dex depends only on `trustedPeers` membership, never on a matching client
secret. In dex v2.44.0 (the version pinned in `modules/150-user-authn/oss.yaml`),
`server/oauth2.go:634-652` `validateCrossClientTrust` loads the peer client and returns true purely on
`peer.TrustedPeers` containing the requesting `clientID`; `server/oauth2.go:321-342` `getAudience` then adds the
peer to the audience. The three call sites (`server/oauth2.go:426`, `server/oauth2.go:541`,
`server/handlers.go:1150`) pass only client IDs. `templates/dex/oauth2client.yaml` already lists
`<name>-<namespace>-dex-authenticator` in `trustedPeers`, and `templates/dex-authenticator/oauth2client.yaml:12`
already registers the authenticator's own client under `secret: {{ $crd.credentials.appDexSecret }}` — which is
exactly what `OAUTH2_PROXY_CLIENT_SECRET` in `templates/dex-authenticator/deployment.yaml:240-244` consumes,
paired with `--client-id={{ $crd.name }}-{{ $crd.namespace }}-dex-authenticator`. So the authenticator
authenticates as itself and the shared secret was never needed.

### Verification that the removed redirect URI breaks nothing

oauth2-proxy authenticates under its own `client_id` (see above), and Dex validates `redirect_uri` against the
client resolved from the request's `client_id` (`server/oauth2.go:481-492`: `GetClient(ctx, clientID)` followed
by `validateRedirectURI(client, redirectURI)`), i.e. against
`templates/dex-authenticator/oauth2client.yaml:25-28`, where the genuine callback lives. The removed entry was
never a valid URI anyway.

### Operational consequence

Regenerating `appDexSecret` changes the `checksum/config` annotation on the authenticator Deployment
(`templates/dex-authenticator/deployment.yaml:150`), so authenticator pods roll once and users of those
applications may have to authenticate again. The `cookieSecret` is not touched.

### Follow-up work

Admission control over who may set the `dexclient.deckhouse.io/allow-access-to-kubernetes` /
`dexauthenticator.deckhouse.io/allow-access-to-kubernetes` annotations, and a namespace allowlist for them, are
deliberately out of scope here — they are behaviour-breaking and handled separately.

## Why do we need it, and what problem does it solve?

It removes an over-shared credential: a cluster-level OAuth2 client secret was being distributed into
tenant-readable namespaces with no user interaction required to obtain it. It also removes the single place
where tenant-controlled input reached the privileged client's `redirectURIs` — harmless today only because the
field name is wrong, and a real defect the moment someone "repairs" it.

## Why do we need it in the patch release (if we do)?

The over-sharing exists on any cluster that uses the annotation outside system namespaces, so it is worth
backporting to 1.77 and 1.76.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authn
type: fix
summary: Issue a dedicated OAuth2 client secret per DexAuthenticator instead of reusing the shared cluster client secret.
impact: |
  On upgrade, every DexAuthenticator that carries the
  `dexauthenticator.deckhouse.io/allow-access-to-kubernetes` annotation gets a freshly generated client
  secret, because it previously received the client secret of the privileged `kubernetes` OAuth2 client
  instead. Its pods roll once and users of those applications may have to sign in again. Each rotation is
  written to the Deckhouse log as `Rotating DexAuthenticator client secret that reused the shared kubernetes
  client secret`, with the authenticator name and namespace.

  If that annotation was ever used outside the `d8-*` and `kube-*` namespaces, the shared secret must be
  considered disclosed to anyone who could read Secrets in those namespaces, and has to be rotated by hand.
  Deleting the Secret alone does not rotate it: while the value is non-empty in memory the owning hook
  re-renders the same one. Rotate it as follows.

  1. If a GitOps tool syncs the `d8-user-authn` namespace, exclude
     `Secret/kubernetes-dex-client-app-secret` from that sync first, otherwise it is restored to the old
     value.
  2. Blank the stored value:
     `kubectl -n d8-user-authn patch secret kubernetes-dex-client-app-secret --type merge -p '{"data":{"secret":""}}'`
  3. Drop the in-memory copy: `kubectl -n d8-system rollout restart deployment/deckhouse`
  4. Check that `kubectl -n d8-user-authn get secret kubernetes-dex-client-app-secret -o jsonpath='{.data.secret}'`
     now differs from the previous value. If it does not, the module re-rendered the old value before the
     restart took effect; repeat steps 2 and 3.

  The blast radius of that rotation is wider than the `kubernetes` client alone. The same value is the client
  secret of the `kubeconfig-generator`, `kubeconfig-publish-api` and every `kubeconfig-<slug>` OAuth2 client,
  and it is passed to basic-auth-proxy as `--ldap-client-secret`. In-cluster consumers are re-rendered and
  their pods roll automatically, but kubeconfig files already downloaded from the kubeconfig generator carry
  the old client secret and can no longer refresh their tokens, so their users must download a new
  kubeconfig. Already issued ID tokens keep working until they expire, at most `settings.idTokenTTL`.

  Deleting and recreating a DexAuthenticator is always a safe way to force a fresh per-authenticator secret:
  the credentials Secret is regenerated with the resource. Its content is owned by Deckhouse, so no GitOps
  change is needed for the per-authenticator rotation itself.
impact_level: high
---
section: user-authn
type: fix
summary: Drop the dead per-DexAuthenticator redirect URI from the privileged kubernetes OAuth2 client.
```
