### PR TITLE
[user-authz] Reject identities that collide with authorization rule subjects

### DIFF
--- a/modules/140-user-authz/webhooks/validating/identity_collision.py
+++ b/modules/140-user-authz/webhooks/validating/identity_collision.py
@@ -1,0 +1,227 @@
+#!/usr/bin/python3
+
+# Copyright 2026 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# This hook guards the authorization rules owned by this module against a local identity silently
+# landing in one of them.
+#
+# A local identity name reaches the token Dex issues verbatim, and kube-apiserver maps it to a
+# Kubernetes identity with an empty prefix, so there is no namespacing between locally managed
+# identities and identities asserted by an external identity provider:
+#
+# - Group.spec.name becomes the group name in the "groups" claim.
+# - User.spec.email becomes the username. The AuthorizationRule and ClusterAuthorizationRule CRDs
+#   say so themselves: "Use the user's `email` as the username to grant privileges to the specific
+#   user".
+#
+# Creating such an object with a name that an existing rule already lists as a subject therefore
+# grants that rule's privileges to it, with nothing in either object recording that it happened.
+#
+# The check lives in this module rather than in user-authn on purpose. It needs the authorization
+# rules, which this module owns, and it only needs the incoming object from the admission request.
+# A hook in user-authn would have to open informers on the CRDs of this module, and a missing CRD
+# makes informer creation fail (shell-operator, pkg/kube_events_manager/resource_informer.go), which
+# would take the whole hook down in a cluster where user-authz is disabled. Here the dependency is
+# the other way round and is harmless: the validating rules below name resources owned by
+# user-authn, and if that module is disabled its CRDs are absent, the rules simply never match.
+
+from typing import Optional
+
+from deckhouse import hook
+from dotmap import DotMap
+
+CLUSTER_RULES_SNAPSHOT_NAME = "d8-user-authz-collision-cluster-authorization-rules"
+NAMESPACED_RULES_SNAPSHOT_NAME = "d8-user-authz-collision-authorization-rules"
+
+CONFIG = f"""
+configVersion: v1
+kubernetesValidating:
+- name: d8-user-authz-group-authorization-rule-collision.deckhouse.io
+  includeSnapshotsFrom: ["{CLUSTER_RULES_SNAPSHOT_NAME}", "{NAMESPACED_RULES_SNAPSHOT_NAME}"]
+  rules:
+  - apiGroups:   ["deckhouse.io"]
+    apiVersions: ["*"]
+    operations:  ["CREATE", "UPDATE"]
+    resources:   ["groups"]
+    scope:       "Cluster"
+- name: d8-user-authz-user-authorization-rule-collision.deckhouse.io
+  includeSnapshotsFrom: ["{CLUSTER_RULES_SNAPSHOT_NAME}", "{NAMESPACED_RULES_SNAPSHOT_NAME}"]
+  rules:
+  - apiGroups:   ["deckhouse.io"]
+    apiVersions: ["*"]
+    operations:  ["CREATE", "UPDATE", "DELETE"]
+    resources:   ["users"]
+    scope:       "Cluster"
+kubernetes:
+- name: {CLUSTER_RULES_SNAPSHOT_NAME}
+  apiVersion: deckhouse.io/v1alpha1
+  kind: ClusterAuthorizationRule
+  executeHookOnEvent: []
+  executeHookOnSynchronization: false
+  keepFullObjectsInMemory: false
+  jqFilter: |
+    {{
+      "name": .metadata.name,
+      "groupSubjects": [.spec.subjects[]? | select(.kind == "Group") | .name],
+      "userSubjects": [.spec.subjects[]? | select(.kind == "User") | .name]
+    }}
+- name: {NAMESPACED_RULES_SNAPSHOT_NAME}
+  apiVersion: deckhouse.io/v1alpha1
+  kind: AuthorizationRule
+  executeHookOnEvent: []
+  executeHookOnSynchronization: false
+  keepFullObjectsInMemory: false
+  jqFilter: |
+    {{
+      "name": .metadata.name,
+      "namespace": .metadata.namespace,
+      "groupSubjects": [.spec.subjects[]? | select(.kind == "Group") | .name],
+      "userSubjects": [.spec.subjects[]? | select(.kind == "User") | .name]
+    }}
+"""
+
+# Acknowledges that a collision with an authorization rule is intentional. The prefix is
+# user-authz because the constraint and its enforcement belong to this module: with user-authz
+# disabled there are no rules and the annotation means nothing.
+COLLISION_ANNOTATION = "user-authz.deckhouse.io/allow-authorization-rule-collision"
+
+
+def main(ctx: hook.Context):
+    try:
+        # DotMap is a dict with dot notation
+        binding_context = DotMap(ctx.binding_context)
+        errmsg, warnings = validate(binding_context)
+        if errmsg is None:
+            ctx.output.validations.allow(*warnings)
+        else:
+            ctx.output.validations.deny(errmsg)
+    except Exception as e:
+        ctx.output.validations.error(str(e))
+
+
+def validate(ctx: DotMap) -> tuple[Optional[str], list[str]]:
+    req = ctx.review.request
+    kind = req.kind.kind.lower()
+
+    if kind == "group":
+        return validate_identity(ctx, resource="groups.deckhouse.io", field=".spec.name",
+                                 subjects_key="groupSubjects",
+                                 name=spec_value(req.object, "name"),
+                                 old_name=spec_value(req.oldObject, "name"))
+    if kind == "user":
+        if req.operation == "DELETE":
+            return warn_rule_outlives_user(ctx, spec_value(req.oldObject, "email"))
+        return validate_identity(ctx, resource="users.deckhouse.io", field=".spec.email",
+                                 subjects_key="userSubjects",
+                                 name=spec_value(req.object, "email"),
+                                 old_name=spec_value(req.oldObject, "email"))
+
+    return None, []
+
+
+def spec_value(obj: Optional[DotMap], field: str):
+    """
+    Read a spec field of an admission review object.
+
+    `object` is null on DELETE and `oldObject` is null on CREATE, so both have to be treated as
+    absent rather than dereferenced.
+    """
+    if not obj:
+        return None
+
+    return obj.spec[field]
+
+
+def validate_identity(ctx: DotMap, resource: str, field: str, subjects_key: str,
+                      name, old_name) -> tuple[Optional[str], list[str]]:
+    warnings = []
+
+    if not isinstance(name, str) or not name:
+        # The field is required by both CRDs, so an absent value is not something this hook has an
+        # opinion about — the owning module's own schema and webhooks reject it.
+        return None, warnings
+
+    granting_rule = granting_rule_for(ctx, subjects_key, name)
+    if granting_rule is None:
+        return None, warnings
+
+    collision = f"{resource} \"{field}\" \"{name}\" is already granted privileges by {granting_rule}"
+
+    # An already existing collision is only reported: the privileges are effective anyway, and
+    # denying updates would lock such an object out of any further modification. An UPDATE whose
+    # oldObject is missing counts as new, so an unreadable previous value fails closed.
+    name_is_new = ctx.review.request.operation == "CREATE" or old_name != name
+    if name_is_new and not is_collision_acknowledged(ctx.review.request.object):
+        return (
+            f"{collision}; use a different value or set the "
+            f"\"{COLLISION_ANNOTATION}: true\" annotation to confirm the collision"
+        ), warnings
+
+    warnings.append(f"{collision}; it inherits the privileges granted by that rule")
+    return None, warnings
+
+
+def warn_rule_outlives_user(ctx: DotMap, email) -> tuple[Optional[str], list[str]]:
+    """
+    Report that deleting the User does not revoke the rule.
+
+    The email stays granted, so recreating a User with the same email restores the privileges, and
+    until then the email is free for anyone allowed to create a User.
+    """
+    if not isinstance(email, str) or not email:
+        return None, []
+
+    granting_rule = granting_rule_for(ctx, "userSubjects", email)
+    if granting_rule is None:
+        return None, []
+
+    return None, [f"{granting_rule} still grants privileges to \".spec.email\" \"{email}\""]
+
+
+def granting_rule_for(ctx: DotMap, subjects_key: str, name: str) -> Optional[str]:
+    """
+    Find an authorization rule that already grants privileges to the given identity name.
+
+    The comparison is exact. Dex lowercases the email before putting it into the token, so a rule
+    subject written in another case never matches an issued token and reporting it would be a false
+    positive.
+
+    Returns:
+        Optional[str]: description of the rule granting the privileges, or None when there is none.
+                       The first rule found for a name wins, so the reported rule is stable.
+    """
+    privileged = {}
+
+    for rule in ctx.snapshots.get(CLUSTER_RULES_SNAPSHOT_NAME, []):
+        rule_name = f"clusterauthorizationrules.deckhouse.io \"{rule.filterResult.name}\""
+        for subject in rule.filterResult[subjects_key]:
+            privileged.setdefault(subject, rule_name)
+
+    for rule in ctx.snapshots.get(NAMESPACED_RULES_SNAPSHOT_NAME, []):
+        rule_name = (f"authorizationrules.deckhouse.io "
+                     f"\"{rule.filterResult.namespace}/{rule.filterResult.name}\"")
+        for subject in rule.filterResult[subjects_key]:
+            privileged.setdefault(subject, rule_name)
+
+    return privileged.get(name)
+
+
+def is_collision_acknowledged(obj: DotMap) -> bool:
+    return obj.metadata.annotations.get(COLLISION_ANNOTATION, "").lower() == "true"
+
+
+if __name__ == "__main__":
+    hook.run(main, config=CONFIG)

--- a/modules/140-user-authz/webhooks/validating/identity_collision.py
+++ b/modules/140-user-authz/webhooks/validating/identity_collision.py
@@ -18,14 +18,14 @@
 # This hook guards the authorization rules owned by this module against a local identity silently
 # landing in one of them.
 #
-# A local identity name reaches the token Dex issues verbatim, and kube-apiserver maps it to a
-# Kubernetes identity with an empty prefix, so there is no namespacing between locally managed
-# identities and identities asserted by an external identity provider:
+# A local identity name reaches the token Dex issues, and kube-apiserver maps it to a Kubernetes
+# identity with an empty prefix, so there is no namespacing between locally managed identities and
+# identities asserted by an external identity provider:
 #
-# - Group.spec.name becomes the group name in the "groups" claim.
-# - User.spec.email becomes the username. The AuthorizationRule and ClusterAuthorizationRule CRDs
-#   say so themselves: "Use the user's `email` as the username to grant privileges to the specific
-#   user".
+# - Group.spec.name becomes the group name in the "groups" claim, byte for byte.
+# - User.spec.email becomes the username, lowercased on the way. The AuthorizationRule and
+#   ClusterAuthorizationRule CRDs say so themselves: "Use the user's `email` as the username to
+#   grant privileges to the specific user".
 #
 # Creating such an object with a name that an existing rule already lists as a subject therefore
 # grants that rule's privileges to it, with nothing in either object recording that it happened.
@@ -38,7 +38,7 @@
 # the other way round and is harmless: the validating rules below name resources owned by
 # user-authn, and if that module is disabled its CRDs are absent, the rules simply never match.
 
-from typing import Optional
+from typing import Callable, NamedTuple, Optional
 
 from deckhouse import hook
 from dotmap import DotMap
@@ -54,7 +54,7 @@ kubernetesValidating:
   rules:
   - apiGroups:   ["deckhouse.io"]
     apiVersions: ["*"]
-    operations:  ["CREATE", "UPDATE"]
+    operations:  ["CREATE", "UPDATE", "DELETE"]
     resources:   ["groups"]
     scope:       "Cluster"
 - name: d8-user-authz-user-authorization-rule-collision.deckhouse.io
@@ -99,6 +99,42 @@ kubernetes:
 COLLISION_ANNOTATION = "user-authz.deckhouse.io/allow-authorization-rule-collision"
 
 
+class IdentityKind(NamedTuple):
+    """
+    Everything this hook needs to know about one of the two validated kinds.
+
+    Attributes:
+        resource: the resource name used in the messages.
+        spec_field: the name of the spec field holding the identity.
+        subjects_key: the jqFilter output key holding the matching rule subjects.
+        token_identity: maps the spec field value to the identity that actually reaches the
+                        token, which is what an authorization rule subject is matched against.
+    """
+    resource: str
+    spec_field: str
+    subjects_key: str
+    token_identity: Callable[[str], str]
+
+    @property
+    def field_path(self) -> str:
+        return f".spec.{self.spec_field}"
+
+
+# Group.spec.name reaches the "groups" claim byte for byte: nothing between the Group object and
+# the Password object Dex serves normalises it (modules/150-user-authn/hooks/get_dex_user_crds.go,
+# makeUserGroupsMap and newPasswordObject), so the comparison is exact in both directions.
+#
+# User.spec.email does not: Deckhouse lowercases it before it reaches the Password object
+# (modules/150-user-authn/hooks/get_dex_user_crds.go:276), so the username in the token is
+# unconditionally spec.email.lower().
+IDENTITY_KINDS = {
+    "group": IdentityKind(resource="groups.deckhouse.io", spec_field="name",
+                          subjects_key="groupSubjects", token_identity=lambda name: name),
+    "user": IdentityKind(resource="users.deckhouse.io", spec_field="email",
+                         subjects_key="userSubjects", token_identity=str.lower),
+}
+
+
 def main(ctx: hook.Context):
     try:
         # DotMap is a dict with dot notation
@@ -114,22 +150,17 @@ def main(ctx: hook.Context):
 
 def validate(ctx: DotMap) -> tuple[Optional[str], list[str]]:
     req = ctx.review.request
-    kind = req.kind.kind.lower()
+    identity = IDENTITY_KINDS.get(req.kind.kind.lower())
+    if identity is None:
+        return None, []
 
-    if kind == "group":
-        return validate_identity(ctx, resource="groups.deckhouse.io", field=".spec.name",
-                                 subjects_key="groupSubjects",
-                                 name=spec_value(req.object, "name"),
-                                 old_name=spec_value(req.oldObject, "name"))
-    if kind == "user":
-        if req.operation == "DELETE":
-            return warn_rule_outlives_user(ctx, spec_value(req.oldObject, "email"))
-        return validate_identity(ctx, resource="users.deckhouse.io", field=".spec.email",
-                                 subjects_key="userSubjects",
-                                 name=spec_value(req.object, "email"),
-                                 old_name=spec_value(req.oldObject, "email"))
+    if req.operation == "DELETE":
+        return warn_rule_outlives_identity(ctx, identity,
+                                           spec_value(req.oldObject, identity.spec_field))
 
-    return None, []
+    return validate_identity(ctx, identity,
+                             name=spec_value(req.object, identity.spec_field),
+                             old_name=spec_value(req.oldObject, identity.spec_field))
 
 
 def spec_value(obj: Optional[DotMap], field: str):
@@ -145,7 +176,7 @@ def spec_value(obj: Optional[DotMap], field: str):
     return obj.spec[field]
 
 
-def validate_identity(ctx: DotMap, resource: str, field: str, subjects_key: str,
+def validate_identity(ctx: DotMap, identity: IdentityKind,
                       name, old_name) -> tuple[Optional[str], list[str]]:
     warnings = []
 
@@ -154,16 +185,21 @@ def validate_identity(ctx: DotMap, resource: str, field: str, subjects_key: str,
         # opinion about — the owning module's own schema and webhooks reject it.
         return None, warnings
 
-    granting_rule = granting_rule_for(ctx, subjects_key, name)
+    granting_rule = granting_rule_for(ctx, identity, name)
     if granting_rule is None:
         return None, warnings
 
-    collision = f"{resource} \"{field}\" \"{name}\" is already granted privileges by {granting_rule}"
+    collision = (f"{identity.resource} \"{identity.field_path}\" \"{name}\" "
+                 f"is already granted privileges by {granting_rule}")
 
     # An already existing collision is only reported: the privileges are effective anyway, and
-    # denying updates would lock such an object out of any further modification. An UPDATE whose
-    # oldObject is missing counts as new, so an unreadable previous value fails closed.
-    name_is_new = ctx.review.request.operation == "CREATE" or old_name != name
+    # denying updates would lock such an object out of any further modification. The comparison is
+    # on the token identity, so rewriting an already colliding email in a different case does not
+    # count as introducing it. An UPDATE whose oldObject is missing counts as new, so an unreadable
+    # previous value fails closed.
+    name_is_new = (ctx.review.request.operation == "CREATE"
+                   or not isinstance(old_name, str)
+                   or identity.token_identity(old_name) != identity.token_identity(name))
     if name_is_new and not is_collision_acknowledged(ctx.review.request.object):
         return (
             f"{collision}; use a different value or set the "
@@ -174,30 +210,45 @@ def validate_identity(ctx: DotMap, resource: str, field: str, subjects_key: str,
     return None, warnings
 
 
-def warn_rule_outlives_user(ctx: DotMap, email) -> tuple[Optional[str], list[str]]:
+def warn_rule_outlives_identity(ctx: DotMap, identity: IdentityKind,
+                                name) -> tuple[Optional[str], list[str]]:
     """
-    Report that deleting the User does not revoke the rule.
+    Report that deleting the object does not revoke the rule.
 
-    The email stays granted, so recreating a User with the same email restores the privileges, and
-    until then the email is free for anyone allowed to create a User.
+    The name stays granted, so recreating a Group or a User with the same name restores the
+    privileges, and until then the name is free for anyone allowed to create one.
     """
-    if not isinstance(email, str) or not email:
+    if not isinstance(name, str) or not name:
         return None, []
 
-    granting_rule = granting_rule_for(ctx, "userSubjects", email)
+    granting_rule = granting_rule_for(ctx, identity, name)
     if granting_rule is None:
         return None, []
 
-    return None, [f"{granting_rule} still grants privileges to \".spec.email\" \"{email}\""]
+    return None, [f"{granting_rule} still grants privileges to "
+                  f"\"{identity.field_path}\" \"{name}\""]
 
 
-def granting_rule_for(ctx: DotMap, subjects_key: str, name: str) -> Optional[str]:
+def granting_rule_for(ctx: DotMap, identity: IdentityKind, name: str) -> Optional[str]:
     """
     Find an authorization rule that already grants privileges to the given identity name.
 
-    The comparison is exact. Dex lowercases the email before putting it into the token, so a rule
-    subject written in another case never matches an issued token and reporting it would be a false
-    positive.
+    A rule subject is matched against the identity that ends up in the token, not against the spec
+    field verbatim, and the two differ for User.spec.email. The asymmetry is deliberate and both
+    directions matter:
+
+    - A mixed-case *incoming* email is a real collision. The username the API server sees is
+      unconditionally spec.email.lower(), so "Privileged@Example.com" inherits everything a rule
+      grants to "privileged@example.com". Comparing verbatim would miss it and make the check
+      bypassable by case alone.
+    - A mixed-case *rule subject* is not a collision. Subjects reach the RoleBinding verbatim
+      (modules/140-user-authz/templates/cluster-role-bindings.yaml:38,
+      modules/140-user-authz/hooks/handle_manage_bindings.go:256) and RBAC matches them exactly, so
+      a subject that is not already lowercase can never match an issued token, and reporting it
+      would be a false positive.
+
+    Group.spec.name has no such normalisation anywhere on its way to the "groups" claim, so both
+    sides are compared verbatim for groups.
 
     Returns:
         Optional[str]: description of the rule granting the privileges, or None when there is none.
@@ -207,16 +258,16 @@ def granting_rule_for(ctx: DotMap, subjects_key: str, name: str) -> Optional[str
 
     for rule in ctx.snapshots.get(CLUSTER_RULES_SNAPSHOT_NAME, []):
         rule_name = f"clusterauthorizationrules.deckhouse.io \"{rule.filterResult.name}\""
-        for subject in rule.filterResult[subjects_key]:
+        for subject in rule.filterResult[identity.subjects_key]:
             privileged.setdefault(subject, rule_name)
 
     for rule in ctx.snapshots.get(NAMESPACED_RULES_SNAPSHOT_NAME, []):
         rule_name = (f"authorizationrules.deckhouse.io "
                      f"\"{rule.filterResult.namespace}/{rule.filterResult.name}\"")
-        for subject in rule.filterResult[subjects_key]:
+        for subject in rule.filterResult[identity.subjects_key]:
             privileged.setdefault(subject, rule_name)
 
-    return privileged.get(name)
+    return privileged.get(identity.token_identity(name))
 
 
 def is_collision_acknowledged(obj: DotMap) -> bool:

--- a/modules/140-user-authz/webhooks/validating/identity_collision_test.py
+++ b/modules/140-user-authz/webhooks/validating/identity_collision_test.py
@@ -14,11 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
 import json
+import shutil
+import subprocess
+import unittest
 
 import identity_collision
 import identity_collision_test_factories as factories
+import yaml
 from identity_collision import COLLISION_ANNOTATION
 from deckhouse import hook, tests
 from dotmap import DotMap
@@ -28,6 +31,15 @@ class TestIdentityCollisionWithAuthorizationRules(unittest.TestCase):
 
     def run_hook(self, context_json: str):
         return hook.testrun(identity_collision.main, [DotMap(json.loads(context_json))])
+
+    def assert_allowed_without_warnings(self, out):
+        """
+        tests.assert_validation_allowed(..., None) returns early without looking at the warnings,
+        so a test that must observe silence has to check it itself.
+        """
+        self.assertEqual(len(out.validations.data), 1)
+        self.assertTrue(out.validations.data[0]["allowed"])
+        self.assertNotIn("warnings", out.validations.data[0])
 
     def deny_message(self, resource: str, field: str, value: str, rule: str) -> str:
         return (f'{resource} "{field}" "{value}" is already granted privileges by {rule}; '
@@ -54,12 +66,12 @@ class TestIdentityCollisionWithAuthorizationRules(unittest.TestCase):
 
     def test_group_allowed_when_name_is_not_a_rule_subject(self):
         out = self.run_hook(factories.prepare_group_binding_context("harmless-group"))
-        tests.assert_validation_allowed(self, out, None)
+        self.assert_allowed_without_warnings(out)
 
     def test_group_allowed_when_no_rules_exist(self):
         out = self.run_hook(factories.prepare_group_binding_context(
             factories.CLUSTER_RULE_GROUP_SUBJECT, with_rules=False))
-        tests.assert_validation_allowed(self, out, None)
+        self.assert_allowed_without_warnings(out)
 
     def test_group_allowed_with_warning_when_collision_is_acknowledged(self):
         group_name = factories.CLUSTER_RULE_GROUP_SUBJECT
@@ -81,6 +93,29 @@ class TestIdentityCollisionWithAuthorizationRules(unittest.TestCase):
         tests.assert_validation_allowed(self, out, self.warn_message(
             "groups.deckhouse.io", ".spec.name", group_name, factories.CLUSTER_RULE_DESCRIPTION))
 
+    def test_group_denied_when_the_old_object_cannot_be_read(self):
+        """An UPDATE with an unreadable oldObject counts as introducing the name: fail closed."""
+        group_name = factories.CLUSTER_RULE_GROUP_SUBJECT
+        out = self.run_hook(factories.prepare_group_binding_context(
+            group_name, operation="UPDATE", with_old_object=False))
+        tests.assert_validation_deny(self, out, self.deny_message(
+            "groups.deckhouse.io", ".spec.name", group_name, factories.CLUSTER_RULE_DESCRIPTION))
+
+    # Group.spec.name is not normalised anywhere between the Group object and the "groups" claim
+    # (modules/150-user-authn/hooks/get_dex_user_crds.go, makeUserGroupsMap builds the claim from
+    # group.Spec.Name verbatim), so a case-only difference is a genuinely different group and
+    # reporting it either way round would be a false positive.
+    def test_group_allowed_when_name_differs_from_the_subject_only_by_case(self):
+        out = self.run_hook(factories.prepare_group_binding_context(
+            factories.CLUSTER_RULE_GROUP_SUBJECT.upper()))
+        self.assert_allowed_without_warnings(out)
+
+    def test_group_allowed_when_the_rule_subject_differs_only_by_case(self):
+        out = self.run_hook(factories.prepare_group_binding_context(
+            factories.MIXED_CASE_RULE_GROUP_SUBJECT.lower(),
+            cluster_rule_group_subjects=[factories.MIXED_CASE_RULE_GROUP_SUBJECT]))
+        self.assert_allowed_without_warnings(out)
+
     # User
 
     def test_user_denied_when_email_is_a_rule_user_subject(self):
@@ -97,7 +132,7 @@ class TestIdentityCollisionWithAuthorizationRules(unittest.TestCase):
 
     def test_user_allowed_when_email_is_not_a_rule_subject(self):
         out = self.run_hook(factories.prepare_user_binding_context("harmless@example.com"))
-        tests.assert_validation_allowed(self, out, None)
+        self.assert_allowed_without_warnings(out)
 
     def test_user_allowed_with_warning_when_collision_is_acknowledged(self):
         email = factories.CLUSTER_RULE_USER_SUBJECT
@@ -119,12 +154,53 @@ class TestIdentityCollisionWithAuthorizationRules(unittest.TestCase):
         tests.assert_validation_allowed(self, out, self.warn_message(
             "users.deckhouse.io", ".spec.email", email, factories.CLUSTER_RULE_DESCRIPTION))
 
-    # A rule subject written in another case never matches the token Dex issues, because Dex
-    # lowercases the email, so reporting it would be a false positive.
-    def test_user_allowed_when_email_differs_only_by_case(self):
+    def test_user_denied_when_the_old_object_cannot_be_read(self):
+        """An UPDATE with an unreadable oldObject counts as introducing the email: fail closed."""
+        email = factories.CLUSTER_RULE_USER_SUBJECT
         out = self.run_hook(factories.prepare_user_binding_context(
-            factories.CLUSTER_RULE_USER_SUBJECT.upper()))
-        tests.assert_validation_allowed(self, out, None)
+            email, operation="UPDATE", with_old_object=False))
+        tests.assert_validation_deny(self, out, self.deny_message(
+            "users.deckhouse.io", ".spec.email", email, factories.CLUSTER_RULE_DESCRIPTION))
+
+    # Email case. Deckhouse lowercases spec.email before it reaches the Password object
+    # (modules/150-user-authn/hooks/get_dex_user_crds.go:276), and the username claim the API
+    # server consumes is that email (modules/040-control-plane-manager/templates/
+    # _authentication_configuration.tpl:18-20). The two directions are therefore not symmetric.
+
+    def test_user_denied_when_email_reaches_the_subject_only_after_lowercasing(self):
+        """
+        The incoming email is mixed case and the rule subject is lowercase.
+
+        The issued token carries the lowercased email, so the rule grants it. Comparing verbatim
+        would let an uppercase spelling walk past the check.
+        """
+        email = factories.CLUSTER_RULE_USER_SUBJECT.upper()
+        out = self.run_hook(factories.prepare_user_binding_context(email))
+        tests.assert_validation_deny(self, out, self.deny_message(
+            "users.deckhouse.io", ".spec.email", email, factories.CLUSTER_RULE_DESCRIPTION))
+
+    def test_user_allowed_with_warning_when_a_colliding_email_only_changes_case(self):
+        """
+        Both spellings lowercase to the same rule subject, so the collision is not being
+        introduced by this UPDATE and the object must stay modifiable.
+        """
+        email = factories.CLUSTER_RULE_USER_SUBJECT.upper()
+        out = self.run_hook(factories.prepare_user_binding_context(
+            email, operation="UPDATE", old_email=factories.CLUSTER_RULE_USER_SUBJECT.capitalize()))
+        tests.assert_validation_allowed(self, out, self.warn_message(
+            "users.deckhouse.io", ".spec.email", email, factories.CLUSTER_RULE_DESCRIPTION))
+
+    def test_user_allowed_when_the_rule_subject_itself_is_mixed_case(self):
+        """
+        The rule subject is mixed case and the incoming email is already lowercase.
+
+        Subjects reach the RoleBinding verbatim and RBAC matches them exactly, so such a subject
+        can never match an issued token and reporting it would be a false positive.
+        """
+        out = self.run_hook(factories.prepare_user_binding_context(
+            factories.MIXED_CASE_RULE_USER_SUBJECT.lower(),
+            cluster_rule_user_subjects=[factories.MIXED_CASE_RULE_USER_SUBJECT]))
+        self.assert_allowed_without_warnings(out)
 
     # Delete
 
@@ -135,10 +211,112 @@ class TestIdentityCollisionWithAuthorizationRules(unittest.TestCase):
             f'{factories.CLUSTER_RULE_DESCRIPTION} still grants privileges to '
             f'".spec.email" "{email}"'))
 
+    def test_user_deletion_warns_for_a_mixed_case_email(self):
+        email = factories.CLUSTER_RULE_USER_SUBJECT.upper()
+        out = self.run_hook(factories.prepare_user_binding_context(email, operation="DELETE"))
+        tests.assert_validation_allowed(self, out, (
+            f'{factories.CLUSTER_RULE_DESCRIPTION} still grants privileges to '
+            f'".spec.email" "{email}"'))
+
     def test_user_deletion_is_silent_when_no_rule_grants_the_email(self):
         out = self.run_hook(factories.prepare_user_binding_context(
             "harmless@example.com", operation="DELETE"))
-        tests.assert_validation_allowed(self, out, None)
+        self.assert_allowed_without_warnings(out)
+
+    def test_group_deletion_warns_that_the_rule_survives_it(self):
+        group_name = factories.CLUSTER_RULE_GROUP_SUBJECT
+        out = self.run_hook(factories.prepare_group_binding_context(
+            group_name, operation="DELETE"))
+        tests.assert_validation_allowed(self, out, (
+            f'{factories.CLUSTER_RULE_DESCRIPTION} still grants privileges to '
+            f'".spec.name" "{group_name}"'))
+
+    def test_group_deletion_is_silent_when_no_rule_grants_the_name(self):
+        out = self.run_hook(factories.prepare_group_binding_context(
+            "harmless-group", operation="DELETE"))
+        self.assert_allowed_without_warnings(out)
+
+
+@unittest.skipUnless(shutil.which("jq"), "jq is required to execute the hook's jqFilter programs")
+class TestSnapshotJQFilters(unittest.TestCase):
+    """
+    Run the jqFilter programs from CONFIG the way shell-operator would.
+
+    The binding contexts above carry a hand-built filterResult, so without this the filters
+    themselves are never executed and a change to either of them would go unnoticed.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        config = yaml.safe_load(identity_collision.CONFIG)
+        cls.filters = {b["name"]: b["jqFilter"] for b in config["kubernetes"]}
+
+    def run_filter(self, snapshot_name: str, obj: dict) -> dict:
+        result = subprocess.run(
+            ["jq", "-c", self.filters[snapshot_name]],
+            input=json.dumps(obj), capture_output=True, text=True, check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        return json.loads(result.stdout)
+
+    def test_config_declares_both_snapshots(self):
+        self.assertEqual(
+            sorted(self.filters),
+            sorted([identity_collision.CLUSTER_RULES_SNAPSHOT_NAME,
+                    identity_collision.NAMESPACED_RULES_SNAPSHOT_NAME]))
+
+    def test_cluster_rule_filter_keeps_only_group_and_user_subjects(self):
+        out = self.run_filter(
+            identity_collision.CLUSTER_RULES_SNAPSHOT_NAME,
+            factories.prepare_cluster_authorization_rule(factories.MIXED_KIND_SUBJECTS))
+        self.assertEqual(out, {
+            "name": "admin-rule",
+            "groupSubjects": [factories.CLUSTER_RULE_GROUP_SUBJECT],
+            "userSubjects": [factories.CLUSTER_RULE_USER_SUBJECT],
+        })
+
+    def test_namespaced_rule_filter_keeps_only_group_and_user_subjects(self):
+        out = self.run_filter(
+            identity_collision.NAMESPACED_RULES_SNAPSHOT_NAME,
+            factories.prepare_authorization_rule(factories.MIXED_KIND_SUBJECTS))
+        self.assertEqual(out, {
+            "name": "team-rule",
+            "namespace": "team-a",
+            "groupSubjects": [factories.CLUSTER_RULE_GROUP_SUBJECT],
+            "userSubjects": [factories.CLUSTER_RULE_USER_SUBJECT],
+        })
+
+    def test_filters_tolerate_a_rule_without_subjects(self):
+        """The `[]?` guard: `.spec.subjects[]` on a missing key would abort the whole filter."""
+        for snapshot_name, rule in [
+            (identity_collision.CLUSTER_RULES_SNAPSHOT_NAME,
+             factories.prepare_cluster_authorization_rule(None)),
+            (identity_collision.NAMESPACED_RULES_SNAPSHOT_NAME,
+             factories.prepare_authorization_rule(None)),
+        ]:
+            with self.subTest(snapshot_name):
+                out = self.run_filter(snapshot_name, rule)
+                self.assertEqual(out["groupSubjects"], [])
+                self.assertEqual(out["userSubjects"], [])
+
+    def test_filter_output_feeds_the_lookup(self):
+        """The filter output is what granting_rule_for indexes, so wire the two together."""
+        filter_result = self.run_filter(
+            identity_collision.CLUSTER_RULES_SNAPSHOT_NAME,
+            factories.prepare_cluster_authorization_rule(factories.MIXED_KIND_SUBJECTS))
+        ctx = DotMap({"snapshots": {
+            identity_collision.CLUSTER_RULES_SNAPSHOT_NAME: [{"filterResult": filter_result}],
+            identity_collision.NAMESPACED_RULES_SNAPSHOT_NAME: [],
+        }})
+
+        self.assertEqual(
+            identity_collision.granting_rule_for(
+                ctx, identity_collision.IDENTITY_KINDS["user"],
+                factories.CLUSTER_RULE_USER_SUBJECT.upper()),
+            factories.CLUSTER_RULE_DESCRIPTION)
+        self.assertIsNone(
+            identity_collision.granting_rule_for(
+                ctx, identity_collision.IDENTITY_KINDS["user"], "builder"))
 
 
 if __name__ == '__main__':

--- a/modules/140-user-authz/webhooks/validating/identity_collision_test.py
+++ b/modules/140-user-authz/webhooks/validating/identity_collision_test.py
@@ -1,0 +1,145 @@
+#!/usr/bin/python3
+
+# Copyright 2026 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import json
+
+import identity_collision
+import identity_collision_test_factories as factories
+from identity_collision import COLLISION_ANNOTATION
+from deckhouse import hook, tests
+from dotmap import DotMap
+
+
+class TestIdentityCollisionWithAuthorizationRules(unittest.TestCase):
+
+    def run_hook(self, context_json: str):
+        return hook.testrun(identity_collision.main, [DotMap(json.loads(context_json))])
+
+    def deny_message(self, resource: str, field: str, value: str, rule: str) -> str:
+        return (f'{resource} "{field}" "{value}" is already granted privileges by {rule}; '
+                f'use a different value or set the "{COLLISION_ANNOTATION}: true" annotation '
+                f'to confirm the collision')
+
+    def warn_message(self, resource: str, field: str, value: str, rule: str) -> str:
+        return (f'{resource} "{field}" "{value}" is already granted privileges by {rule}; '
+                f'it inherits the privileges granted by that rule')
+
+    # Group
+
+    def test_group_denied_when_name_is_a_rule_group_subject(self):
+        for scenario, group_name, rule in [
+            ['ClusterAuthorizationRule subject',
+             factories.CLUSTER_RULE_GROUP_SUBJECT, factories.CLUSTER_RULE_DESCRIPTION],
+            ['AuthorizationRule subject',
+             factories.NAMESPACED_RULE_GROUP_SUBJECT, factories.NAMESPACED_RULE_DESCRIPTION],
+        ]:
+            with self.subTest(scenario):
+                out = self.run_hook(factories.prepare_group_binding_context(group_name))
+                tests.assert_validation_deny(self, out, self.deny_message(
+                    "groups.deckhouse.io", ".spec.name", group_name, rule))
+
+    def test_group_allowed_when_name_is_not_a_rule_subject(self):
+        out = self.run_hook(factories.prepare_group_binding_context("harmless-group"))
+        tests.assert_validation_allowed(self, out, None)
+
+    def test_group_allowed_when_no_rules_exist(self):
+        out = self.run_hook(factories.prepare_group_binding_context(
+            factories.CLUSTER_RULE_GROUP_SUBJECT, with_rules=False))
+        tests.assert_validation_allowed(self, out, None)
+
+    def test_group_allowed_with_warning_when_collision_is_acknowledged(self):
+        group_name = factories.CLUSTER_RULE_GROUP_SUBJECT
+        out = self.run_hook(factories.prepare_group_binding_context(group_name, acknowledged=True))
+        tests.assert_validation_allowed(self, out, self.warn_message(
+            "groups.deckhouse.io", ".spec.name", group_name, factories.CLUSTER_RULE_DESCRIPTION))
+
+    def test_group_denied_when_renamed_into_a_collision(self):
+        group_name = factories.CLUSTER_RULE_GROUP_SUBJECT
+        out = self.run_hook(factories.prepare_group_binding_context(
+            group_name, operation="UPDATE", old_group_name="harmless-group"))
+        tests.assert_validation_deny(self, out, self.deny_message(
+            "groups.deckhouse.io", ".spec.name", group_name, factories.CLUSTER_RULE_DESCRIPTION))
+
+    def test_group_allowed_with_warning_when_collision_already_existed(self):
+        group_name = factories.CLUSTER_RULE_GROUP_SUBJECT
+        out = self.run_hook(factories.prepare_group_binding_context(
+            group_name, operation="UPDATE", old_group_name=group_name))
+        tests.assert_validation_allowed(self, out, self.warn_message(
+            "groups.deckhouse.io", ".spec.name", group_name, factories.CLUSTER_RULE_DESCRIPTION))
+
+    # User
+
+    def test_user_denied_when_email_is_a_rule_user_subject(self):
+        for scenario, email, rule in [
+            ['ClusterAuthorizationRule subject',
+             factories.CLUSTER_RULE_USER_SUBJECT, factories.CLUSTER_RULE_DESCRIPTION],
+            ['AuthorizationRule subject',
+             factories.NAMESPACED_RULE_USER_SUBJECT, factories.NAMESPACED_RULE_DESCRIPTION],
+        ]:
+            with self.subTest(scenario):
+                out = self.run_hook(factories.prepare_user_binding_context(email))
+                tests.assert_validation_deny(self, out, self.deny_message(
+                    "users.deckhouse.io", ".spec.email", email, rule))
+
+    def test_user_allowed_when_email_is_not_a_rule_subject(self):
+        out = self.run_hook(factories.prepare_user_binding_context("harmless@example.com"))
+        tests.assert_validation_allowed(self, out, None)
+
+    def test_user_allowed_with_warning_when_collision_is_acknowledged(self):
+        email = factories.CLUSTER_RULE_USER_SUBJECT
+        out = self.run_hook(factories.prepare_user_binding_context(email, acknowledged=True))
+        tests.assert_validation_allowed(self, out, self.warn_message(
+            "users.deckhouse.io", ".spec.email", email, factories.CLUSTER_RULE_DESCRIPTION))
+
+    def test_user_denied_when_email_changed_into_a_collision(self):
+        email = factories.CLUSTER_RULE_USER_SUBJECT
+        out = self.run_hook(factories.prepare_user_binding_context(
+            email, operation="UPDATE", old_email="harmless@example.com"))
+        tests.assert_validation_deny(self, out, self.deny_message(
+            "users.deckhouse.io", ".spec.email", email, factories.CLUSTER_RULE_DESCRIPTION))
+
+    def test_user_allowed_with_warning_when_collision_already_existed(self):
+        email = factories.CLUSTER_RULE_USER_SUBJECT
+        out = self.run_hook(factories.prepare_user_binding_context(
+            email, operation="UPDATE", old_email=email))
+        tests.assert_validation_allowed(self, out, self.warn_message(
+            "users.deckhouse.io", ".spec.email", email, factories.CLUSTER_RULE_DESCRIPTION))
+
+    # A rule subject written in another case never matches the token Dex issues, because Dex
+    # lowercases the email, so reporting it would be a false positive.
+    def test_user_allowed_when_email_differs_only_by_case(self):
+        out = self.run_hook(factories.prepare_user_binding_context(
+            factories.CLUSTER_RULE_USER_SUBJECT.upper()))
+        tests.assert_validation_allowed(self, out, None)
+
+    # Delete
+
+    def test_user_deletion_warns_that_the_rule_survives_it(self):
+        email = factories.CLUSTER_RULE_USER_SUBJECT
+        out = self.run_hook(factories.prepare_user_binding_context(email, operation="DELETE"))
+        tests.assert_validation_allowed(self, out, (
+            f'{factories.CLUSTER_RULE_DESCRIPTION} still grants privileges to '
+            f'".spec.email" "{email}"'))
+
+    def test_user_deletion_is_silent_when_no_rule_grants_the_email(self):
+        out = self.run_hook(factories.prepare_user_binding_context(
+            "harmless@example.com", operation="DELETE"))
+        tests.assert_validation_allowed(self, out, None)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/modules/140-user-authz/webhooks/validating/identity_collision_test_factories.py
+++ b/modules/140-user-authz/webhooks/validating/identity_collision_test_factories.py
@@ -1,0 +1,137 @@
+#!/usr/bin/python3
+
+# Copyright 2026 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import typing
+
+from identity_collision import (
+    CLUSTER_RULES_SNAPSHOT_NAME,
+    NAMESPACED_RULES_SNAPSHOT_NAME,
+    COLLISION_ANNOTATION,
+)
+
+# The rules every scenario is validated against. "privileged" identities are subjects of a
+# ClusterAuthorizationRule, "team-*" ones of a namespaced AuthorizationRule.
+CLUSTER_RULE_GROUP_SUBJECT = "privileged-group"
+CLUSTER_RULE_USER_SUBJECT = "privileged@example.com"
+NAMESPACED_RULE_GROUP_SUBJECT = "team-devs"
+NAMESPACED_RULE_USER_SUBJECT = "team-lead@example.com"
+
+CLUSTER_RULE_DESCRIPTION = 'clusterauthorizationrules.deckhouse.io "admin-rule"'
+NAMESPACED_RULE_DESCRIPTION = 'authorizationrules.deckhouse.io "team-a/team-rule"'
+
+
+def _snapshots(with_rules: bool = True) -> dict:
+    if not with_rules:
+        return {CLUSTER_RULES_SNAPSHOT_NAME: [], NAMESPACED_RULES_SNAPSHOT_NAME: []}
+
+    return {
+        CLUSTER_RULES_SNAPSHOT_NAME: [
+            {
+                "filterResult": {
+                    "name": "admin-rule",
+                    "groupSubjects": [CLUSTER_RULE_GROUP_SUBJECT],
+                    "userSubjects": [CLUSTER_RULE_USER_SUBJECT],
+                }
+            }
+        ],
+        NAMESPACED_RULES_SNAPSHOT_NAME: [
+            {
+                "filterResult": {
+                    "name": "team-rule",
+                    "namespace": "team-a",
+                    "groupSubjects": [NAMESPACED_RULE_GROUP_SUBJECT],
+                    "userSubjects": [NAMESPACED_RULE_USER_SUBJECT],
+                }
+            }
+        ],
+    }
+
+
+def _binding_context(kind: str, resource: str, webhook: str, operation: str,
+                     spec: typing.Optional[dict], old_spec: typing.Optional[dict],
+                     acknowledged: bool, with_rules: bool) -> str:
+    metadata = {"name": "test-object"}
+    if acknowledged:
+        metadata["annotations"] = {COLLISION_ANNOTATION: "true"}
+
+    obj = None if spec is None else {
+        "apiVersion": "deckhouse.io/v1",
+        "kind": kind,
+        "metadata": metadata,
+        "spec": spec,
+    }
+    old_obj = None if old_spec is None else {
+        "apiVersion": "deckhouse.io/v1",
+        "kind": kind,
+        "metadata": metadata,
+        "spec": old_spec,
+    }
+
+    return json.dumps({
+        "binding": webhook,
+        "review": {
+            "request": {
+                "uid": "b4e3d1c0-0000-0000-0000-000000000000",
+                "kind": {"group": "deckhouse.io", "version": "v1", "kind": kind},
+                "resource": {"group": "deckhouse.io", "version": "v1", "resource": resource},
+                "name": "test-object",
+                "operation": operation,
+                "userInfo": {"username": "kubernetes-admin", "groups": ["system:masters"]},
+                "object": obj,
+                "oldObject": old_obj,
+                "dryRun": False,
+            }
+        },
+        "snapshots": _snapshots(with_rules),
+        "type": "Validating",
+    })
+
+
+def prepare_group_binding_context(group_name: str, operation: str = "CREATE",
+                                  old_group_name: typing.Optional[str] = None,
+                                  acknowledged: bool = False,
+                                  with_rules: bool = True) -> str:
+    old_spec = None if operation == "CREATE" else {"name": old_group_name, "members": []}
+    return _binding_context(
+        kind="Group", resource="groups",
+        webhook="d8-user-authz-group-authorization-rule-collision.deckhouse.io",
+        operation=operation,
+        spec={"name": group_name, "members": []},
+        old_spec=old_spec,
+        acknowledged=acknowledged, with_rules=with_rules,
+    )
+
+
+def prepare_user_binding_context(email: str, operation: str = "CREATE",
+                                 old_email: typing.Optional[str] = None,
+                                 acknowledged: bool = False,
+                                 with_rules: bool = True) -> str:
+    if operation == "DELETE":
+        return _binding_context(
+            kind="User", resource="users",
+            webhook="d8-user-authz-user-authorization-rule-collision.deckhouse.io",
+            operation=operation, spec=None, old_spec={"email": email},
+            acknowledged=acknowledged, with_rules=with_rules,
+        )
+
+    old_spec = None if operation == "CREATE" else {"email": old_email}
+    return _binding_context(
+        kind="User", resource="users",
+        webhook="d8-user-authz-user-authorization-rule-collision.deckhouse.io",
+        operation=operation, spec={"email": email}, old_spec=old_spec,
+        acknowledged=acknowledged, with_rules=with_rules,
+    )

--- a/modules/140-user-authz/webhooks/validating/identity_collision_test_factories.py
+++ b/modules/140-user-authz/webhooks/validating/identity_collision_test_factories.py
@@ -33,18 +33,30 @@ NAMESPACED_RULE_USER_SUBJECT = "team-lead@example.com"
 CLUSTER_RULE_DESCRIPTION = 'clusterauthorizationrules.deckhouse.io "admin-rule"'
 NAMESPACED_RULE_DESCRIPTION = 'authorizationrules.deckhouse.io "team-a/team-rule"'
 
+# A subject an administrator wrote in mixed case. It reaches the RoleBinding verbatim and RBAC
+# matches subjects exactly, so it can never match an issued token and must not be reported.
+MIXED_CASE_RULE_USER_SUBJECT = "Legacy@Example.com"
+MIXED_CASE_RULE_GROUP_SUBJECT = "Legacy-Group"
 
-def _snapshots(with_rules: bool = True) -> dict:
+
+def _snapshots(with_rules: bool = True,
+               cluster_rule_group_subjects: typing.Optional[list] = None,
+               cluster_rule_user_subjects: typing.Optional[list] = None) -> dict:
     if not with_rules:
         return {CLUSTER_RULES_SNAPSHOT_NAME: [], NAMESPACED_RULES_SNAPSHOT_NAME: []}
+
+    if cluster_rule_group_subjects is None:
+        cluster_rule_group_subjects = [CLUSTER_RULE_GROUP_SUBJECT]
+    if cluster_rule_user_subjects is None:
+        cluster_rule_user_subjects = [CLUSTER_RULE_USER_SUBJECT]
 
     return {
         CLUSTER_RULES_SNAPSHOT_NAME: [
             {
                 "filterResult": {
                     "name": "admin-rule",
-                    "groupSubjects": [CLUSTER_RULE_GROUP_SUBJECT],
-                    "userSubjects": [CLUSTER_RULE_USER_SUBJECT],
+                    "groupSubjects": cluster_rule_group_subjects,
+                    "userSubjects": cluster_rule_user_subjects,
                 }
             }
         ],
@@ -63,7 +75,9 @@ def _snapshots(with_rules: bool = True) -> dict:
 
 def _binding_context(kind: str, resource: str, webhook: str, operation: str,
                      spec: typing.Optional[dict], old_spec: typing.Optional[dict],
-                     acknowledged: bool, with_rules: bool) -> str:
+                     acknowledged: bool, with_rules: bool,
+                     cluster_rule_group_subjects: typing.Optional[list] = None,
+                     cluster_rule_user_subjects: typing.Optional[list] = None) -> str:
     metadata = {"name": "test-object"}
     if acknowledged:
         metadata["annotations"] = {COLLISION_ANNOTATION: "true"}
@@ -96,7 +110,8 @@ def _binding_context(kind: str, resource: str, webhook: str, operation: str,
                 "dryRun": False,
             }
         },
-        "snapshots": _snapshots(with_rules),
+        "snapshots": _snapshots(with_rules, cluster_rule_group_subjects,
+                                cluster_rule_user_subjects),
         "type": "Validating",
     })
 
@@ -104,8 +119,21 @@ def _binding_context(kind: str, resource: str, webhook: str, operation: str,
 def prepare_group_binding_context(group_name: str, operation: str = "CREATE",
                                   old_group_name: typing.Optional[str] = None,
                                   acknowledged: bool = False,
-                                  with_rules: bool = True) -> str:
-    old_spec = None if operation == "CREATE" else {"name": old_group_name, "members": []}
+                                  with_rules: bool = True,
+                                  with_old_object: bool = True,
+                                  cluster_rule_group_subjects: typing.Optional[list] = None) -> str:
+    if operation == "DELETE":
+        return _binding_context(
+            kind="Group", resource="groups",
+            webhook="d8-user-authz-group-authorization-rule-collision.deckhouse.io",
+            operation=operation, spec=None, old_spec={"name": group_name, "members": []},
+            acknowledged=acknowledged, with_rules=with_rules,
+            cluster_rule_group_subjects=cluster_rule_group_subjects,
+        )
+
+    # with_old_object=False models an UPDATE whose oldObject the hook cannot read.
+    old_spec = None if operation == "CREATE" or not with_old_object else {
+        "name": old_group_name, "members": []}
     return _binding_context(
         kind="Group", resource="groups",
         webhook="d8-user-authz-group-authorization-rule-collision.deckhouse.io",
@@ -113,25 +141,64 @@ def prepare_group_binding_context(group_name: str, operation: str = "CREATE",
         spec={"name": group_name, "members": []},
         old_spec=old_spec,
         acknowledged=acknowledged, with_rules=with_rules,
+        cluster_rule_group_subjects=cluster_rule_group_subjects,
     )
 
 
 def prepare_user_binding_context(email: str, operation: str = "CREATE",
                                  old_email: typing.Optional[str] = None,
                                  acknowledged: bool = False,
-                                 with_rules: bool = True) -> str:
+                                 with_rules: bool = True,
+                                 with_old_object: bool = True,
+                                 cluster_rule_user_subjects: typing.Optional[list] = None) -> str:
     if operation == "DELETE":
         return _binding_context(
             kind="User", resource="users",
             webhook="d8-user-authz-user-authorization-rule-collision.deckhouse.io",
             operation=operation, spec=None, old_spec={"email": email},
             acknowledged=acknowledged, with_rules=with_rules,
+            cluster_rule_user_subjects=cluster_rule_user_subjects,
         )
 
-    old_spec = None if operation == "CREATE" else {"email": old_email}
+    old_spec = None if operation == "CREATE" or not with_old_object else {"email": old_email}
     return _binding_context(
         kind="User", resource="users",
         webhook="d8-user-authz-user-authorization-rule-collision.deckhouse.io",
         operation=operation, spec={"email": email}, old_spec=old_spec,
         acknowledged=acknowledged, with_rules=with_rules,
+        cluster_rule_user_subjects=cluster_rule_user_subjects,
     )
+
+
+def prepare_cluster_authorization_rule(subjects: typing.Optional[list]) -> dict:
+    """
+    A ClusterAuthorizationRule object as the API server stores it, to feed a jqFilter.
+
+    subjects=None omits `spec.subjects` entirely, which is what the `[]?` guard in both filters
+    exists for.
+    """
+    spec = {"accessLevel": "Editor"}
+    if subjects is not None:
+        spec["subjects"] = subjects
+
+    return {
+        "apiVersion": "deckhouse.io/v1alpha1",
+        "kind": "ClusterAuthorizationRule",
+        "metadata": {"name": "admin-rule"},
+        "spec": spec,
+    }
+
+
+def prepare_authorization_rule(subjects: typing.Optional[list]) -> dict:
+    """A namespaced AuthorizationRule object, to feed a jqFilter."""
+    rule = prepare_cluster_authorization_rule(subjects)
+    rule["kind"] = "AuthorizationRule"
+    rule["metadata"] = {"name": "team-rule", "namespace": "team-a"}
+    return rule
+
+
+MIXED_KIND_SUBJECTS = [
+    {"kind": "Group", "name": CLUSTER_RULE_GROUP_SUBJECT},
+    {"kind": "ServiceAccount", "name": "builder", "namespace": "ci"},
+    {"kind": "User", "name": CLUSTER_RULE_USER_SUBJECT},
+]

--- a/testing/webhooks/test.sh
+++ b/testing/webhooks/test.sh
@@ -20,7 +20,8 @@ echo "Proxy: $DISTRO_PACKAGES_PROXY"
 if [ -n "${DISTRO_PACKAGES_PROXY}" ]; then
     sed -iE "s|https://dl-cdn.alpinelinux.org|http://$DISTRO_PACKAGES_PROXY/repository|g" /etc/apk/repositories
 fi
-apk update && apk add --no-cache python3 py3-pip findutils grep
+# jq is needed by tests that execute a hook's jqFilter the way shell-operator would.
+apk update && apk add --no-cache python3 py3-pip findutils grep jq
 
 pip3 install --break-system-packages -r /requirements.txt
 


### PR DESCRIPTION
## Description

A local identity name reaches the token Dex issues, and kube-apiserver maps it to a Kubernetes identity with an **empty prefix** (`modules/040-control-plane-manager/templates/_authentication_configuration.tpl:17-23` — `claimMappings.username.claim: "email"`, `claimMappings.groups.claim: "groups"`, both with `prefix: ""`). There is therefore no namespacing between locally managed identities and identities asserted by an external identity provider, in either direction:

- `Group.spec.name` (`deckhouse.io/v1alpha1`) becomes the group name in the `groups` claim.
- `User.spec.email` (`deckhouse.io/v1`) becomes the username. The `AuthorizationRule` and `ClusterAuthorizationRule` CRDs say so themselves: "Use the user's `email` as the username to grant privileges to the specific user".

Creating such an object with a name that an existing rule already lists as a subject grants that rule's privileges to it, and nothing in either object records that it happened. Nothing validated that.

This PR adds a validating webhook, `modules/140-user-authz/webhooks/validating/identity_collision.py`, that refuses to introduce such a name and reports the rule responsible.

### Why the check lives in `user-authz` and not in `user-authn`

The obvious placement is the existing `user-authn` hooks that already validate these objects, and the first version of this PR did that. It was wrong, and the reason is worth stating because it is a trap anyone extending an admission hook can fall into.

Those hooks would need `kubernetes` bindings on `AuthorizationRule` and `ClusterAuthorizationRule`, which `user-authz` owns. Module CRDs are installed per module (`deckhouse-controller/internal/packages/runtime/tasks/ensurecrd/task.go`), so in a cluster where `user-authz` is disabled those CRDs do not exist. A binding on an absent CRD is not a no-op: `createSharedInformer` fails with "Cannot get GroupVersionResource info … Possibly CRD is not created before informers are started" (`shell-operator/pkg/kube_events_manager/resource_informer.go:120`) and the error propagates out of `CreateInformers`, taking down the whole hook — including the checks it performed before this change. `allowFailure` does not help; it governs hook execution, not informer creation.

Putting the check in `user-authz` inverts the dependency into a harmless one. The hook subscribes only to the two CRDs its own module ships, so they are present whenever the hook is loaded at all. What it needs from `user-authn` is only the incoming object, which arrives in the admission request. Its `kubernetesValidating` rules name `groups` and `users`, and if `user-authn` is disabled those CRDs are absent and the rules simply never match — the API server does not require a rule's target resource to exist.

This is also the established shape in this module rather than a new invention: `webhooks/validating/system_roles` validates `clusterroles` and `webhooks/validating/role_binding` validates `clusterrolebindings`, both resources this module does not own. `webhooks/validating/multitenancy.py` is the closest structural precedent — one Python hook validating two kinds, dispatching on `request.kind.kind`, with `includeSnapshotsFrom` attaching snapshots to individual rules — and this hook follows it.

The symmetry is deliberate and complete in the direction that matters. The other direction is not covered: adding a subject to a rule when a matching local `Group` or `User` already exists produces no warning. Covering it would require informers on the `user-authn` CRDs, reintroducing exactly the fragility described above, and it is the less important direction — whoever edits an authorization rule is the privileged party making a deliberate grant.

### Behaviour

**Snapshots.** Two `kubernetes` bindings with `executeHookOnEvent: []`, `executeHookOnSynchronization: false`, `keepFullObjectsInMemory: false`, and a `jqFilter` projecting only the rule identity and its `Group` and `User` subjects, so the snapshots stay small. They carry no `group` and no `queue` — nothing has to be coordinated with another binding, and `includeSnapshotsFrom` names both snapshots on each validating rule explicitly. `ServiceAccount` subjects are filtered out; they are not affected by this class of collision. No RBAC change is needed: the webhook handler already holds `get`/`list`/`watch` on `deckhouse.io` `*` (`modules/002-deckhouse/templates/webhook-handler/rbac-for-us.yaml`).

**Deny vs warn.** The collision is denied, with two deliberate scope limits and one escape hatch:

1. **Denied only when the colliding identity is being introduced** — on `CREATE`, or on `UPDATE` when the identity actually changes into a colliding value. An object that already carries a colliding name keeps working and only produces a warning. Denying unconditionally would lock existing legitimate setups out of any further modification, such as adding a group member, and the privileges are already effective for such an object anyway, so a hard error would not take them away. An `UPDATE` whose `oldObject` cannot be read counts as new, so an unreadable previous value fails closed.
2. **Escape hatch** — the `user-authz.deckhouse.io/allow-authorization-rule-collision: "true"` annotation on the `Group` or `User` acknowledges the collision and downgrades the denial to a warning. This keeps the legitimate workflow of writing a rule in advance and then creating the local object that populates it. The prefix is `user-authz` because the constraint and its enforcement belong to this module: with `user-authz` disabled there are no rules and the annotation means nothing.
3. **No silent allow** — every path either denies or emits a warning naming the rule that grants the privileges.

The alternative of denying only when the requester is not permitted to manage the colliding rule was rejected: without `SubjectAccessReview` it can only be approximated from `request.userInfo`, which is guessing rather than authorization, and adding an API call on the write path trades a correctness problem for an availability one. The chosen design is honest about what it protects. It deterministically stops the *accidental* silent privilege grant, and it turns the *deliberate* one into an explicit, greppable, audit-visible annotation instead of an invisible name match. It does not by itself stop someone who can already create these objects, since they can also set the annotation; closing that needs `SubjectAccessReview` and is worth a major release.

**Deletion warns that the rule survives it.** Deleting a `Group` or a `User` does not touch the rule, so the name stays granted: recreating an object with the same name restores the privileges, and until then the name is free for anyone allowed to create one. Both kinds warn and neither blocks the deletion.

### The email comparison is case-insensitive on one side only

Rule subjects are matched against the identity that ends up in the token, not against the spec field verbatim, and for `User.spec.email` the two differ. The two directions are not symmetric and both matter:

- **A mixed-case incoming email is a real collision and is denied.** Deckhouse lowercases the email before it reaches the `Password` object — `email := strings.ToLower(dexUser.Spec.Email)` at `modules/150-user-authn/hooks/get_dex_user_crds.go:276`, and that variable is what populates `Password.email` (`:496`, `:540`, `:593`). The username claim the API server consumes is that email, so the username is unconditionally `spec.email.lower()`. Comparing verbatim made the check bypassable by case alone: a `User` with `Privileged@Example.com` matched no subject, and the issued token still carried `privileged@example.com`, which the rule grants. The hook now compares `spec.email.lower()`.
- **A mixed-case rule subject is not a collision and is not reported.** Subjects reach the RoleBinding verbatim (`modules/140-user-authz/templates/cluster-role-bindings.yaml:38`, `modules/140-user-authz/hooks/handle_manage_bindings.go:256`) and RBAC matches subjects by exact string, so a subject that is not already lowercase can never match an issued token. Normalising that side too would report a collision that does not exist, so subjects stay indexed verbatim.

Consistently with the same rule, the "is the identity being introduced" comparison for `UPDATE` is on the token identity as well: rewriting an already colliding email in a different case does not count as introducing it and only warns, so a legacy object stays modifiable.

**`Group.spec.name` is compared verbatim in both directions**, and deliberately not the same way. Nothing normalises a group name on its way to the `groups` claim: `makeUserGroupsMap` accumulates `group.Spec.Name` byte for byte (`modules/150-user-authn/hooks/get_dex_user_crds.go:697,706`), the result is written to `Password.groups` unchanged (`:503`, `:563`, `:596`), and there is no `strings.ToLower` on any group path in either module — the only one in `user-authz` is on an annotation value used for naming, not on a subject (`modules/140-user-authz/hooks/handle_dict_bindings.go:167`). A case-only difference in a group name is therefore a genuinely different group, and treating it as a collision would be a false positive. Two tests pin this down so that the email fix cannot later be copied onto groups by reflex.

This hook does not rely on `modules/150-user-authn/webhooks/validating/user.py` rejecting uppercase emails on `CREATE`: that check has a legacy path that allows an `UPDATE` between two uppercase values (`user.py:117` only fires when the old email was lowercase, `user.py:122-125` then allows and returns), and it belongs to a different module that may be disabled.

`object` is null on `DELETE` and `oldObject` is null on `CREATE`, so both are treated as absent rather than dereferenced.

### Tests

`identity_collision_test.py` with an `identity_collision_test_factories.py` context factory, following the structure of `multitenancy_test.py` and `multitenancy_test_factories.py` in the same directory. 28 tests cover, for both `Group` and `User`: denial against a `ClusterAuthorizationRule` subject and against a namespaced `AuthorizationRule` subject; a non-colliding name; no rules at all; the acknowledging annotation; renaming into a collision; a pre-existing collision producing a warning instead of a denial; an `UPDATE` whose `oldObject` is unreadable failing closed; both deletion outcomes; and both directions of the email case question plus both directions of the group case question.

The `jqFilter` programs are no longer assumed. `TestSnapshotJQFilters` parses `CONFIG` as YAML and runs each filter through `jq` against real rule objects, checking that `ServiceAccount` subjects are dropped, that the `[]?` guard survives a rule with no `spec.subjects`, and that the filter output feeds `granting_rule_for` unchanged. `jq` was added to `testing/webhooks/test.sh` so the CI container has it; the class is skipped rather than failing if it is absent.

Every guard was checked by mutation — each of the following makes the suite fail, and reverting it makes it pass again:

| mutation | failing tests |
| --- | --- |
| compare `spec.email` verbatim | `test_user_denied_when_email_reaches_the_subject_only_after_lowercasing`, `test_user_deletion_warns_for_a_mixed_case_email`, `test_filter_output_feeds_the_lookup` |
| index rule subjects lowercased | `test_user_allowed_when_the_rule_subject_itself_is_mixed_case` |
| lowercase group names too | `test_group_allowed_when_name_differs_from_the_subject_only_by_case` |
| handle `DELETE` for `User` only | `test_group_deletion_warns_that_the_rule_survives_it` |
| drop the fail-closed `oldObject` guard | `test_user_denied_when_the_old_object_cannot_be_read` |
| compare old and new identity verbatim | `test_user_allowed_with_warning_when_a_colliding_email_only_changes_case` |
| drop `select(.kind == "Group")` from the filters | both `*_filter_keeps_only_group_and_user_subjects` tests |
| drop the `?` from `.spec.subjects[]?` | `test_filters_tolerate_a_rule_without_subjects` (both subtests) |

## Why do we need it, and what problem does it solve?

Picking a name that is already a subject in an authorization rule silently grants that rule's privileges, with no indication anywhere that it happened. It is reachable by accident by an administrator who simply chooses a name already present in a rule. It is also the mechanism by which someone who may create `Group` or `User` objects but has no authority over `user-authz` can inherit privileges intended for an external identity — for a `Group` by adding themselves as a member, for a `User` by taking over an email a rule already trusts — and then re-authenticating.

## Why do we need it in the patch release (if we do)?

Yes. It closes an unintended privilege escalation path that needs no special conditions to hit, and the change is one new validating hook that adds no new failure mode to any existing one. The check is deliberately scoped so that it cannot break already existing objects: they stay updatable and only produce a warning.

Backporting is nearly trivial. Three of the four touched files are new and their paths do not exist on either release branch; the fourth is a one-line `apk add` in `testing/webhooks/test.sh`. Both commits were cherry-picked with `-x` into throwaway detached worktrees and the whole webhook test directory was run there:

- **`release-1.77`** (at `89786b5386`): both picks clean, no conflict. `identity_collision_test.py` 28 tests OK, `multitenancy_test.py` 12 tests OK.
- **`release-1.76`** (at `d9659de1fc`): the first pick is clean; the second conflicts on `testing/webhooks/test.sh`, because that branch does not yet carry the `DISTRO_PACKAGES_PROXY` block. The resolution is to keep the branch's own version of the file and append `jq` to its `apk add` line — one line, no logic. After it: `identity_collision_test.py` 28 tests OK, `multitenancy_test.py` 8 tests OK.

The runtime prerequisites were verified on both branches: both `AuthorizationRule` and `ClusterAuthorizationRule` CRDs with their `subjects` schema, `Group.spec.name`, the webhook handler's per-enabled-module hook copying (`images/webhook-handler/src/entrypoint.sh`), the same `deckhouse==0.4.11`, `dotmap==1.3.30` and `PyYAML==6.0.2` webhook dependencies, and the same `deckhouse.io` RBAC. The premise of the email fix holds on both: `release-1.77` lowercases the email in the hook exactly as `main` does, and `release-1.76` does it in the Helm template that renders the `Password` object instead (`modules/150-user-authn/templates/dex/passwords.yaml:14` — `email: {{ $crd.spec.email | lower | quote }}`), while the groups on the same object are rendered verbatim (`:21`).

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

Client-facing documentation for this change is handled in a separate documentation PR, together with the docs for the other changes in this series, so that the documentation team reviews them in one place.

## Changelog entries

```changes
section: user-authz
type: fix
summary: Reject local Group names and User emails that collide with a subject already granted privileges by an authorization rule.
impact: |
  Creating a `Group` or a `User`, or renaming an existing one, so that `Group.spec.name` matches a group subject or `User.spec.email` matches a user subject of an existing AuthorizationRule or ClusterAuthorizationRule is now rejected, preventing an unintended privilege grant. The email is compared after lowercasing, since that is the form that reaches the token. Set the `user-authz.deckhouse.io/allow-authorization-rule-collision` annotation to `"true"` on the object if the collision is intentional. Already existing objects keep working and only produce a warning. Any declarative flow that manages both the rule and the identity is affected, not only one that deletes and recreates the identity: a first-time apply denies the `Group` or `User` whenever the rule happens to be applied first, and nothing guarantees the order. Add the annotation to such objects before upgrading. Deleting a `Group` or a `User` whose name is still a subject of a rule now produces a warning, since the rule keeps granting that name.
impact_level: high
---
section: testing
type: chore
summary: Install jq in the python webhook test container so hooks can test their own jqFilter programs.
impact_level: low
```
