### PR TITLE
[user-authn] Gate the allow-access-to-kubernetes annotation on DexClient and DexAuthenticator

### DIFF
--- a/modules/150-user-authn/template_tests/validation_test.go
+++ b/modules/150-user-authn/template_tests/validation_test.go
@@ -1,0 +1,457 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template_tests
+
+import (
+	"context"
+
+	celgo "github.com/google/cel-go/cel"
+	celtypes "github.com/google/cel-go/common/types"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/admission"
+	admissioncel "k8s.io/apiserver/pkg/admission/plugin/cel"
+	celconfig "k8s.io/apiserver/pkg/apis/cel"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/apiserver/pkg/cel/environment"
+	"sigs.k8s.io/yaml"
+
+	. "github.com/deckhouse/deckhouse/testing/helm"
+)
+
+const (
+	validatingAdmissionPolicyAPIVersion        = "admissionregistration.k8s.io/v1/ValidatingAdmissionPolicy"
+	validatingAdmissionPolicyBindingAPIVersion = "admissionregistration.k8s.io/v1/ValidatingAdmissionPolicyBinding"
+
+	allowAccessPolicyName = "dex-allow-access-to-kubernetes.deckhouse.io"
+
+	dexClientAnnotation        = "dexclient.deckhouse.io/allow-access-to-kubernetes"
+	dexAuthenticatorAnnotation = "dexauthenticator.deckhouse.io/allow-access-to-kubernetes"
+
+	deckhouseServiceAccount = "system:serviceaccount:d8-system:deckhouse"
+	namespaceEditor         = "editor@example.com"
+)
+
+var _ = Describe("Module :: user-authn :: helm template :: validation", func() {
+	hec := SetupHelmConfig("")
+
+	BeforeEach(func() {
+		hec.ValuesSet("global.discovery.kubernetesVersion", "1.32.0")
+		hec.ValuesSet("global.modules.publicDomainTemplate", "%s.example.com")
+		hec.ValuesSet("global.modules.https.mode", "CertManager")
+		hec.ValuesSet("global.modules.https.certManager.clusterIssuerName", "letsencrypt")
+		hec.ValuesSet("global.modulesImages.registry.base", "registry.example.com")
+		hec.ValuesSet("global.enabledModules", []string{"cert-manager", "vertical-pod-autoscaler"})
+		hec.ValuesSet("global.discovery.d8SpecificNodeCountByRole.system", 2)
+		hec.ValuesSet("global.discovery.kubernetesCA", "plainstring")
+
+		hec.ValuesSet("userAuthn.internal.kubernetesDexClientAppSecret", "plainstring")
+		hec.ValuesSet("userAuthn.internal.dexTLS.crt", "plainstring")
+		hec.ValuesSet("userAuthn.internal.dexTLS.key", "plainstring")
+		hec.ValuesSet("userAuthn.internal.dexTLS.ca", "plainstring")
+	})
+
+	Context("Without ValidatingAdmissionPolicy support in the cluster", func() {
+		BeforeEach(func() {
+			hec.HelmRender()
+		})
+
+		It("Should not render the policies", func() {
+			Expect(hec.RenderError).ShouldNot(HaveOccurred())
+			Expect(hec.KubernetesGlobalResource("ValidatingAdmissionPolicy", allowAccessPolicyName).Exists()).To(BeFalse())
+			Expect(hec.KubernetesGlobalResource("ValidatingAdmissionPolicyBinding", allowAccessPolicyName).Exists()).To(BeFalse())
+			Expect(hec.KubernetesGlobalResource("ValidatingAdmissionPolicy", "system-users.deckhouse.io").Exists()).To(BeFalse())
+		})
+	})
+
+	Context("With ValidatingAdmissionPolicy support in the cluster", func() {
+		BeforeEach(func() {
+			hec.HelmRender(WithAPIVersions(
+				validatingAdmissionPolicyAPIVersion,
+				validatingAdmissionPolicyBindingAPIVersion,
+			))
+		})
+
+		It("Should render the policy gating the allow-access-to-kubernetes annotation", func() {
+			Expect(hec.RenderError).ShouldNot(HaveOccurred())
+
+			policy := hec.KubernetesGlobalResource("ValidatingAdmissionPolicy", allowAccessPolicyName)
+			Expect(policy.Exists()).To(BeTrue())
+			Expect(policy.Field("apiVersion").String()).To(Equal("admissionregistration.k8s.io/v1"))
+			Expect(policy.Field("metadata.labels.heritage").String()).To(Equal("deckhouse"))
+			Expect(policy.Field("metadata.labels.module").String()).To(Equal("user-authn"))
+			Expect(policy.Field("spec.failurePolicy").String()).To(Equal("Fail"))
+
+			rule := policy.Field("spec.matchConstraints.resourceRules.0")
+			Expect(rule.Get("apiGroups").String()).To(MatchJSON(`["deckhouse.io"]`))
+			Expect(rule.Get("apiVersions").String()).To(MatchJSON(`["*"]`))
+			Expect(rule.Get("operations").String()).To(MatchJSON(`["CREATE","UPDATE"]`))
+			Expect(rule.Get("resources").String()).To(MatchJSON(`["dexclients","dexauthenticators"]`))
+
+			Expect(policy.Field("spec.validations.0.reason").String()).To(Equal("Forbidden"))
+			Expect(policy.Field("spec.validations.0.messageExpression").String()).To(
+				ContainSubstring("grants access to the Kubernetes API"),
+			)
+			Expect(policy.Field("spec.validations.0.messageExpression").String()).To(
+				ContainSubstring("must be applied by a cluster administrator"),
+			)
+
+			binding := hec.KubernetesGlobalResource("ValidatingAdmissionPolicyBinding", allowAccessPolicyName)
+			Expect(binding.Exists()).To(BeTrue())
+			Expect(binding.Field("apiVersion").String()).To(Equal("admissionregistration.k8s.io/v1"))
+			Expect(binding.Field("spec.policyName").String()).To(Equal(allowAccessPolicyName))
+			Expect(binding.Field("spec.validationActions").String()).To(MatchJSON(`["Deny"]`))
+		})
+
+		It("Should keep rendering the pre-existing user validation policy", func() {
+			Expect(hec.KubernetesGlobalResource("ValidatingAdmissionPolicy", "system-users.deckhouse.io").Exists()).To(BeTrue())
+			Expect(hec.KubernetesGlobalResource("ValidatingAdmissionPolicyBinding", "system-users.deckhouse.io").Exists()).To(BeTrue())
+		})
+
+		It("Should evaluate the rendered CEL expressions as intended", func() {
+			policy := compileRenderedPolicy(
+				hec.KubernetesGlobalResource("ValidatingAdmissionPolicy", allowAccessPolicyName).ToYaml(),
+			)
+
+			cases := []struct {
+				name           string
+				resource       string
+				kind           string
+				operation      admission.Operation
+				username       string
+				canManage      bool
+				annotations    map[string]string
+				oldAnnotations map[string]string
+				allowed        bool
+			}{
+				{
+					name:        "unauthorised subject grants access on create",
+					annotations: map[string]string{dexClientAnnotation: "true"},
+					allowed:     false,
+				},
+				{
+					name:        "unauthorised subject creates a client without the annotation",
+					annotations: nil,
+					allowed:     true,
+				},
+				{
+					name:        "annotation explicitly disabled",
+					annotations: map[string]string{dexClientAnnotation: "false"},
+					allowed:     true,
+				},
+				{
+					name:        "annotation value is not a boolean the hooks would honour",
+					annotations: map[string]string{dexClientAnnotation: "yes"},
+					allowed:     true,
+				},
+				{
+					name:        "truthy value in another casing",
+					annotations: map[string]string{dexClientAnnotation: "True"},
+					allowed:     false,
+				},
+				{
+					name:        "truthy value as a single character",
+					annotations: map[string]string{dexClientAnnotation: "t"},
+					allowed:     false,
+				},
+				{
+					name:        "truthy value as a digit",
+					annotations: map[string]string{dexClientAnnotation: "1"},
+					allowed:     false,
+				},
+				{
+					name:        "deckhouse service account grants access",
+					username:    deckhouseServiceAccount,
+					annotations: map[string]string{dexClientAnnotation: "true"},
+					allowed:     true,
+				},
+				{
+					name:        "subject allowed to update the user-authn ModuleConfig grants access",
+					canManage:   true,
+					annotations: map[string]string{dexClientAnnotation: "true"},
+					allowed:     true,
+				},
+				{
+					name:           "existing grant is carried over unchanged",
+					operation:      admission.Update,
+					annotations:    map[string]string{dexClientAnnotation: "true"},
+					oldAnnotations: map[string]string{dexClientAnnotation: "true"},
+					allowed:        true,
+				},
+				{
+					name:           "existing grant is rewritten with an equivalent value",
+					operation:      admission.Update,
+					annotations:    map[string]string{dexClientAnnotation: "1"},
+					oldAnnotations: map[string]string{dexClientAnnotation: "true"},
+					allowed:        true,
+				},
+				{
+					name:           "annotation is added by an update",
+					operation:      admission.Update,
+					annotations:    map[string]string{dexClientAnnotation: "true"},
+					oldAnnotations: nil,
+					allowed:        false,
+				},
+				{
+					name:           "annotation is flipped from false to true",
+					operation:      admission.Update,
+					annotations:    map[string]string{dexClientAnnotation: "true"},
+					oldAnnotations: map[string]string{dexClientAnnotation: "false"},
+					allowed:        false,
+				},
+				{
+					name:           "annotation is flipped from true to false",
+					operation:      admission.Update,
+					annotations:    map[string]string{dexClientAnnotation: "false"},
+					oldAnnotations: map[string]string{dexClientAnnotation: "true"},
+					allowed:        true,
+				},
+				{
+					name:           "annotation is dropped by an update",
+					operation:      admission.Update,
+					annotations:    nil,
+					oldAnnotations: map[string]string{dexClientAnnotation: "true"},
+					allowed:        true,
+				},
+				{
+					name:        "dex authenticator grants access on create",
+					resource:    "dexauthenticators",
+					kind:        "DexAuthenticator",
+					annotations: map[string]string{dexAuthenticatorAnnotation: "true"},
+					allowed:     false,
+				},
+				{
+					name:           "dex authenticator keeps an existing grant",
+					resource:       "dexauthenticators",
+					kind:           "DexAuthenticator",
+					operation:      admission.Update,
+					annotations:    map[string]string{dexAuthenticatorAnnotation: "true"},
+					oldAnnotations: map[string]string{dexAuthenticatorAnnotation: "true"},
+					allowed:        true,
+				},
+				{
+					name:        "annotation of the other kind is not gated",
+					annotations: map[string]string{dexAuthenticatorAnnotation: "true"},
+					allowed:     true,
+				},
+			}
+
+			for _, tc := range cases {
+				By(tc.name)
+
+				resource, kind := tc.resource, tc.kind
+				if resource == "" {
+					resource, kind = "dexclients", "DexClient"
+				}
+				operation := tc.operation
+				if operation == "" {
+					operation = admission.Create
+				}
+				username := tc.username
+				if username == "" {
+					username = namespaceEditor
+				}
+
+				allowed, err := policy.validate(dexAdmissionInput{
+					resource:       resource,
+					kind:           kind,
+					operation:      operation,
+					username:       username,
+					canManage:      tc.canManage,
+					annotations:    tc.annotations,
+					oldAnnotations: tc.oldAnnotations,
+				})
+
+				Expect(err).ToNot(HaveOccurred(), tc.name)
+				Expect(allowed).To(Equal(tc.allowed), tc.name)
+			}
+		})
+	})
+})
+
+// compiledPolicy evaluates the validation expressions of a ValidatingAdmissionPolicy through the
+// same CEL machinery kube-apiserver uses, so the expressions the module ships are under test.
+type compiledPolicy struct {
+	validations admissioncel.ConditionEvaluator
+}
+
+func compileRenderedPolicy(renderedPolicy string) compiledPolicy {
+	// Strict decoding also asserts that the rendered manifest carries no field the API does not know.
+	var policy admissionregistrationv1.ValidatingAdmissionPolicy
+	Expect(yaml.UnmarshalStrict([]byte(renderedPolicy), &policy)).To(Succeed())
+
+	// kube-apiserver declares the authorizer for validations but not for message expressions.
+	validationVars := admissioncel.OptionalVariableDeclarations{HasAuthorizer: true, StrictCost: true}
+	messageVars := admissioncel.OptionalVariableDeclarations{StrictCost: true}
+
+	compiler, err := admissioncel.NewCompositedCompiler(
+		environment.MustBaseEnvSet(environment.DefaultCompatibilityVersion(), true),
+	)
+	Expect(err).ToNot(HaveOccurred())
+
+	// Variables come first: expressions referring to them are type-checked against the types
+	// collected here.
+	for _, variable := range policy.Spec.Variables {
+		result := compiler.CompileAndStoreVariable(
+			namedExpression{name: variable.Name, expression: variable.Expression},
+			validationVars, environment.StoredExpressions,
+		)
+		Expect(result.Error).To(BeNil(), "variable %q should compile", variable.Name)
+	}
+
+	validations := make([]admissioncel.ExpressionAccessor, 0, len(policy.Spec.Validations))
+	for _, validation := range policy.Spec.Validations {
+		condition := boolExpression{expression: validation.Expression}
+		Expect(compiler.CompileCELExpression(condition, validationVars, environment.StoredExpressions).Error).To(BeNil(),
+			"validation %q should compile", validation.Expression)
+
+		message := stringExpression{expression: validation.MessageExpression}
+		Expect(compiler.CompileCELExpression(message, messageVars, environment.StoredExpressions).Error).To(BeNil(),
+			"message expression %q should compile", validation.MessageExpression)
+
+		validations = append(validations, condition)
+	}
+
+	return compiledPolicy{
+		validations: compiler.CompileCondition(validations, validationVars, environment.StoredExpressions),
+	}
+}
+
+type dexAdmissionInput struct {
+	resource       string
+	kind           string
+	operation      admission.Operation
+	username       string
+	canManage      bool
+	annotations    map[string]string
+	oldAnnotations map[string]string
+}
+
+// validate reports whether every validation of the policy admits the request.
+func (p compiledPolicy) validate(input dexAdmissionInput) (bool, error) {
+	const (
+		namespace = "attacker-ns"
+		name      = "app"
+	)
+
+	gvk := schema.GroupVersionKind{Group: "deckhouse.io", Version: "v1", Kind: input.kind}
+	gvr := schema.GroupVersionResource{Group: "deckhouse.io", Version: "v1", Resource: input.resource}
+
+	// The old object has to stay a nil interface on create: a typed nil pointer is treated as
+	// present by the admission machinery.
+	var oldObject runtime.Object
+	if input.operation == admission.Update {
+		oldObject = dexObject(gvk, namespace, name, input.oldAnnotations)
+	}
+
+	attributes := admission.NewAttributesRecord(
+		dexObject(gvk, namespace, name, input.annotations), oldObject,
+		gvk, namespace, name, gvr, "", input.operation, nil, false,
+		&user.DefaultInfo{Name: input.username, Groups: []string{"system:authenticated"}},
+	)
+	versionedAttributes, err := admission.NewVersionedAttributes(attributes, gvk, nil)
+	if err != nil {
+		return false, err
+	}
+
+	results, _, err := p.validations.ForInput(
+		context.Background(), versionedAttributes,
+		admissioncel.CreateAdmissionRequest(attributes, metav1.GroupVersionResource(gvr), metav1.GroupVersionKind(gvk)),
+		admissioncel.OptionalVariableBindings{Authorizer: userAuthnModuleConfigAuthorizer(input.canManage)},
+		nil, celconfig.RuntimeCELCostBudget,
+	)
+	if err != nil {
+		return false, err
+	}
+
+	for _, result := range results {
+		if result.Error != nil {
+			return false, result.Error
+		}
+		if result.EvalResult != celtypes.True {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+func dexObject(gvk schema.GroupVersionKind, namespace, name string, annotations map[string]string) *unstructured.Unstructured {
+	object := &unstructured.Unstructured{}
+	object.SetGroupVersionKind(gvk)
+	object.SetNamespace(namespace)
+	object.SetName(name)
+	object.SetAnnotations(annotations)
+	object.Object["spec"] = map[string]interface{}{
+		"redirectURIs": []interface{}{"https://app.example.com/callback"},
+	}
+
+	return object
+}
+
+// userAuthnModuleConfigAuthorizer mimics RBAC for a subject that either holds or lacks the right to
+// update the user-authn ModuleConfig, and holds nothing else.
+func userAuthnModuleConfigAuthorizer(canManage bool) authorizer.Authorizer {
+	return authorizerFunc(func(attributes authorizer.Attributes) bool {
+		return canManage &&
+			attributes.GetAPIGroup() == "deckhouse.io" &&
+			attributes.GetResource() == "moduleconfigs" &&
+			attributes.GetName() == "user-authn" &&
+			attributes.GetVerb() == "update"
+	})
+}
+
+type authorizerFunc func(authorizer.Attributes) bool
+
+func (f authorizerFunc) Authorize(_ context.Context, attributes authorizer.Attributes) (authorizer.Decision, string, error) {
+	if f(attributes) {
+		return authorizer.DecisionAllow, "", nil
+	}
+
+	return authorizer.DecisionNoOpinion, "", nil
+}
+
+type namedExpression struct {
+	name       string
+	expression string
+}
+
+func (e namedExpression) GetName() string       { return e.name }
+func (e namedExpression) GetExpression() string { return e.expression }
+func (e namedExpression) ReturnTypes() []*celgo.Type {
+	return []*celgo.Type{celgo.AnyType, celgo.DynType}
+}
+
+type boolExpression struct {
+	expression string
+}
+
+func (e boolExpression) GetExpression() string      { return e.expression }
+func (e boolExpression) ReturnTypes() []*celgo.Type { return []*celgo.Type{celgo.BoolType} }
+
+type stringExpression struct {
+	expression string
+}
+
+func (e stringExpression) GetExpression() string      { return e.expression }
+func (e stringExpression) ReturnTypes() []*celgo.Type { return []*celgo.Type{celgo.StringType} }

--- a/modules/150-user-authn/template_tests/validation_test.go
+++ b/modules/150-user-authn/template_tests/validation_test.go
@@ -18,6 +18,11 @@ package template_tests
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
 
 	celgo "github.com/google/cel-go/cel"
 	celtypes "github.com/google/cel-go/common/types"
@@ -28,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/apiserver/pkg/admission"
 	admissioncel "k8s.io/apiserver/pkg/admission/plugin/cel"
 	celconfig "k8s.io/apiserver/pkg/apis/cel"
@@ -110,10 +116,10 @@ var _ = Describe("Module :: user-authn :: helm template :: validation", func() {
 
 			Expect(policy.Field("spec.validations.0.reason").String()).To(Equal("Forbidden"))
 			Expect(policy.Field("spec.validations.0.messageExpression").String()).To(
-				ContainSubstring("grants access to the Kubernetes API"),
+				ContainSubstring("controls access to the Kubernetes API"),
 			)
 			Expect(policy.Field("spec.validations.0.messageExpression").String()).To(
-				ContainSubstring("must be applied by a cluster administrator"),
+				ContainSubstring("may only be introduced or widened by a cluster administrator"),
 			)
 
 			binding := hec.KubernetesGlobalResource("ValidatingAdmissionPolicyBinding", allowAccessPolicyName)
@@ -155,14 +161,19 @@ var _ = Describe("Module :: user-authn :: helm template :: validation", func() {
 					allowed:     true,
 				},
 				{
-					name:        "annotation explicitly disabled",
+					name:        "annotation explicitly disabled on create",
 					annotations: map[string]string{dexClientAnnotation: "false"},
-					allowed:     true,
+					allowed:     false,
 				},
 				{
-					name:        "annotation value is not a boolean the hooks would honour",
+					name:        "annotation value is not a boolean",
 					annotations: map[string]string{dexClientAnnotation: "yes"},
-					allowed:     true,
+					allowed:     false,
+				},
+				{
+					name:        "annotation value is empty",
+					annotations: map[string]string{dexClientAnnotation: ""},
+					allowed:     false,
 				},
 				{
 					name:        "truthy value in another casing",
@@ -220,11 +231,32 @@ var _ = Describe("Module :: user-authn :: helm template :: validation", func() {
 					allowed:        false,
 				},
 				{
+					name:           "annotation is flipped from a value no hook reads as true to true",
+					operation:      admission.Update,
+					annotations:    map[string]string{dexClientAnnotation: "true"},
+					oldAnnotations: map[string]string{dexClientAnnotation: "yes"},
+					allowed:        false,
+				},
+				{
 					name:           "annotation is flipped from true to false",
 					operation:      admission.Update,
 					annotations:    map[string]string{dexClientAnnotation: "false"},
 					oldAnnotations: map[string]string{dexClientAnnotation: "true"},
 					allowed:        true,
+				},
+				{
+					name:           "object that already carries a disabled annotation stays editable",
+					operation:      admission.Update,
+					annotations:    map[string]string{dexClientAnnotation: "false"},
+					oldAnnotations: map[string]string{dexClientAnnotation: "false"},
+					allowed:        true,
+				},
+				{
+					name:           "disabled annotation is added to an object that had none",
+					operation:      admission.Update,
+					annotations:    map[string]string{dexClientAnnotation: "false"},
+					oldAnnotations: nil,
+					allowed:        false,
 				},
 				{
 					name:           "annotation is dropped by an update",
@@ -250,8 +282,15 @@ var _ = Describe("Module :: user-authn :: helm template :: validation", func() {
 					allowed:        true,
 				},
 				{
-					name:        "annotation of the other kind is not gated",
+					name:        "dex client carrying the dex authenticator annotation is not gated",
 					annotations: map[string]string{dexAuthenticatorAnnotation: "true"},
+					allowed:     true,
+				},
+				{
+					name:        "dex authenticator carrying the dex client annotation is not gated",
+					resource:    "dexauthenticators",
+					kind:        "DexAuthenticator",
+					annotations: map[string]string{dexClientAnnotation: "true"},
 					allowed:     true,
 				},
 			}
@@ -286,8 +325,92 @@ var _ = Describe("Module :: user-authn :: helm template :: validation", func() {
 				Expect(allowed).To(Equal(tc.allowed), tc.name)
 			}
 		})
+
+		It("Should deny every annotation value that any hook generation reads as a grant", func() {
+			policy := compileRenderedPolicy(
+				hec.KubernetesGlobalResource("ValidatingAdmissionPolicy", allowAccessPolicyName).ToYaml(),
+			)
+
+			for _, value := range annotationValueCorpus {
+				granting := make([]string, 0, len(hookGenerations))
+				for _, generation := range hookGenerations {
+					if generation.grants(value) {
+						granting = append(granting, generation.name)
+					}
+				}
+
+				if len(granting) == 0 {
+					continue
+				}
+
+				By(fmt.Sprintf("value %q is honoured as a grant by the %v hook", value, granting))
+
+				annotations := map[string]string{dexClientAnnotation: value}
+
+				denied, err := policy.validate(dexAdmissionInput{
+					resource:    "dexclients",
+					kind:        "DexClient",
+					operation:   admission.Create,
+					username:    namespaceEditor,
+					annotations: annotations,
+				})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(denied).To(BeFalse(),
+					"a subject without authority over the user-authn ModuleConfig must not set %q", value)
+
+				// The gate must stop the unauthorised subject only, otherwise the loop above would
+				// pass just as well against a policy that denies everything.
+				granted, err := policy.validate(dexAdmissionInput{
+					resource:    "dexclients",
+					kind:        "DexClient",
+					operation:   admission.Create,
+					username:    namespaceEditor,
+					canManage:   true,
+					annotations: annotations,
+				})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(granted).To(BeTrue(),
+					"a subject with authority over the user-authn ModuleConfig must be able to set %q", value)
+			}
+		})
 	})
 })
+
+// hookGeneration models how a released version of the hooks decides that the annotation grants
+// access to the Kubernetes API. The policy's soundness depends on it denying at least everything
+// the hooks honour, so both sides are derived here instead of being restated in a comment: if a
+// hook is ever widened, this list is the single place that has to change, and the assertions
+// following from it start failing until the policy is widened too.
+type hookGeneration struct {
+	name   string
+	grants func(value string) bool
+}
+
+var hookGenerations = []hookGeneration{
+	{
+		// modules/150-user-authn/hooks/get_dex_client_crds.go and get_dex_authenticator_crds.go
+		// parse the value with strconv.ParseBool and fail closed on anything else.
+		name: "value honouring",
+		grants: func(value string) bool {
+			granted, err := strconv.ParseBool(value)
+
+			return err == nil && granted
+		},
+	},
+	{
+		// Earlier revisions of the same hooks looked the key up and ignored its value entirely.
+		name:   "presence honouring",
+		grants: func(string) bool { return true },
+	},
+}
+
+// annotationValueCorpus covers everything strconv.ParseBool accepts, in both polarities, plus
+// spellings around it that a user could plausibly write.
+var annotationValueCorpus = []string{
+	"1", "t", "T", "TRUE", "true", "True",
+	"0", "f", "F", "FALSE", "false", "False",
+	"", " ", "yes", "no", "on", "off", "enabled", "2", "TrUe", "true ",
+}
 
 // compiledPolicy evaluates the validation expressions of a ValidatingAdmissionPolicy through the
 // same CEL machinery kube-apiserver uses, so the expressions the module ships are under test.
@@ -304,8 +427,16 @@ func compileRenderedPolicy(renderedPolicy string) compiledPolicy {
 	validationVars := admissioncel.OptionalVariableDeclarations{HasAuthorizer: true, StrictCost: true}
 	messageVars := admissioncel.OptionalVariableDeclarations{StrictCost: true}
 
+	// The environment is pinned to the lowest Kubernetes version this branch supports, not to the
+	// compatibility version of the vendored apiserver, which is higher. With failurePolicy: Fail an
+	// expression needing a newer CEL feature would not merely fail to evaluate, it would deny every
+	// DexClient and DexAuthenticator write on the oldest supported cluster.
+	//
+	// The mode has to be NewExpressions for the pin to mean anything: StoredExpressions deliberately
+	// keeps every library available so that policies already persisted in etcd keep evaluating, and
+	// it is NewExpressions that kube-apiserver validates a freshly submitted policy against.
 	compiler, err := admissioncel.NewCompositedCompiler(
-		environment.MustBaseEnvSet(environment.DefaultCompatibilityVersion(), true),
+		environment.MustBaseEnvSet(minimalSupportedKubernetesVersion(), true),
 	)
 	Expect(err).ToNot(HaveOccurred())
 
@@ -314,7 +445,7 @@ func compileRenderedPolicy(renderedPolicy string) compiledPolicy {
 	for _, variable := range policy.Spec.Variables {
 		result := compiler.CompileAndStoreVariable(
 			namedExpression{name: variable.Name, expression: variable.Expression},
-			validationVars, environment.StoredExpressions,
+			validationVars, environment.NewExpressions,
 		)
 		Expect(result.Error).To(BeNil(), "variable %q should compile", variable.Name)
 	}
@@ -322,18 +453,59 @@ func compileRenderedPolicy(renderedPolicy string) compiledPolicy {
 	validations := make([]admissioncel.ExpressionAccessor, 0, len(policy.Spec.Validations))
 	for _, validation := range policy.Spec.Validations {
 		condition := boolExpression{expression: validation.Expression}
-		Expect(compiler.CompileCELExpression(condition, validationVars, environment.StoredExpressions).Error).To(BeNil(),
+		Expect(compiler.CompileCELExpression(condition, validationVars, environment.NewExpressions).Error).To(BeNil(),
 			"validation %q should compile", validation.Expression)
 
 		message := stringExpression{expression: validation.MessageExpression}
-		Expect(compiler.CompileCELExpression(message, messageVars, environment.StoredExpressions).Error).To(BeNil(),
+		Expect(compiler.CompileCELExpression(message, messageVars, environment.NewExpressions).Error).To(BeNil(),
 			"message expression %q should compile", validation.MessageExpression)
 
 		validations = append(validations, condition)
 	}
 
 	return compiledPolicy{
-		validations: compiler.CompileCondition(validations, validationVars, environment.StoredExpressions),
+		validations: compiler.CompileCondition(validations, validationVars, environment.NewExpressions),
+	}
+}
+
+// minimalSupportedKubernetesVersion reads the lowest Kubernetes version listed in
+// candi/version_map.yml, which is the oldest cluster a Deckhouse release from this branch runs on.
+func minimalSupportedKubernetesVersion() *version.Version {
+	raw, err := os.ReadFile(filepath.Join(repositoryRoot(), "candi", "version_map.yml"))
+	Expect(err).ToNot(HaveOccurred())
+
+	var versionMap struct {
+		K8s map[string]json.RawMessage `json:"k8s"`
+	}
+	Expect(yaml.Unmarshal(raw, &versionMap)).To(Succeed())
+	Expect(versionMap.K8s).ToNot(BeEmpty())
+
+	var minimal *version.Version
+	for supported := range versionMap.K8s {
+		parsed, err := version.ParseGeneric(supported)
+		Expect(err).ToNot(HaveOccurred(), "kubernetes version %q should parse", supported)
+
+		if minimal == nil || parsed.LessThan(minimal) {
+			minimal = parsed
+		}
+	}
+
+	return minimal
+}
+
+// repositoryRoot walks up from the package directory to the checkout root.
+func repositoryRoot() string {
+	directory, err := os.Getwd()
+	Expect(err).ToNot(HaveOccurred())
+
+	for {
+		if _, err := os.Stat(filepath.Join(directory, "go.mod")); err == nil {
+			return directory
+		}
+
+		parent := filepath.Dir(directory)
+		Expect(parent).ToNot(Equal(directory), "the repository root should be reachable from %s", directory)
+		directory = parent
 	}
 }
 

--- a/modules/150-user-authn/templates/validation.yaml
+++ b/modules/150-user-authn/templates/validation.yaml
@@ -52,25 +52,33 @@ spec:
       expression: 'object.metadata.?annotations.orValue({})'
     - name: oldAnnotations
       expression: 'oldObject == null ? {} : oldObject.metadata.?annotations.orValue({})'
-    # The truthy set is a superset of what strconv.ParseBool accepts in the hooks, so no value that
-    # the hooks would honour can slip through unchecked.
+    # Presence of the key, not its value, is what the policy gates. Hook generations disagree on how
+    # the value is read: some parse it with strconv.ParseBool and fail closed, older ones grant on
+    # the mere presence of the key. Gating presence keeps the policy sound whichever hook is running
+    # and removes the coupling to the hook's parsing altogether.
+    - name: annotated
+      expression: 'variables.annotation in variables.annotations'
+    - name: annotatedBefore
+      expression: 'variables.annotation in variables.oldAnnotations'
+    # Truthiness is only used to decide whether an update makes an already annotated object more
+    # permissive; it is never what allows the key to appear in the first place.
     - name: grantsAccess
-      expression: 'variables.annotation in variables.annotations
+      expression: 'variables.annotated
         && variables.annotations[variables.annotation].lowerAscii() in ["1", "t", "true"]'
     - name: grantedBefore
-      expression: 'variables.annotation in variables.oldAnnotations
+      expression: 'variables.annotatedBefore
         && variables.oldAnnotations[variables.annotation].lowerAscii() in ["1", "t", "true"]'
   validations:
-    # Only a newly granted access is gated, so objects that already carry the annotation stay editable
-    # by their owners. Authority is proven by the right to update the user-authn ModuleConfig, which
-    # only cluster-wide administrators of this module hold.
+    # Only a newly introduced or newly widened annotation is gated, so objects that already carry it
+    # stay editable by their owners. Authority is proven by the right to update the user-authn
+    # ModuleConfig, which only cluster-wide administrators of this module hold.
     - expression: 'request.userInfo.username == "system:serviceaccount:d8-system:deckhouse"
-        || !variables.grantsAccess
-        || variables.grantedBefore
+        || !variables.annotated
+        || (variables.annotatedBefore && (!variables.grantsAccess || variables.grantedBefore))
         || authorizer.group("deckhouse.io").resource("moduleconfigs").name("user-authn").check("update").allowed()'
       reason: Forbidden
-      messageExpression: '"the " + variables.annotation + " annotation grants access to the Kubernetes API
-        and must be applied by a cluster administrator who is allowed to manage the user-authn module"'
+      messageExpression: '"the " + variables.annotation + " annotation controls access to the Kubernetes API
+        and may only be introduced or widened by a cluster administrator who is allowed to manage the user-authn module"'
 ---
 apiVersion: {{ include "helm_lib_get_api_version_by_kind" (list . "ValidatingAdmissionPolicyBinding") }}
 kind: ValidatingAdmissionPolicyBinding

--- a/modules/150-user-authn/templates/validation.yaml
+++ b/modules/150-user-authn/templates/validation.yaml
@@ -27,6 +27,59 @@ metadata:
 spec:
   policyName: {{ $policyName }}
   validationActions: [Deny]
+{{- $allowAccessPolicyName := "dex-allow-access-to-kubernetes.deckhouse.io" }}
+---
+apiVersion: {{ include "helm_lib_get_api_version_by_kind" (list . "ValidatingAdmissionPolicy") }}
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: {{ $allowAccessPolicyName }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "deckhouse") ) | nindent 2 }}
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups:   ["deckhouse.io"]
+        apiVersions: ["*"]
+        operations:  ["CREATE", "UPDATE"]
+        resources:   ["dexclients", "dexauthenticators"]
+  variables:
+    # The annotation is named after the kind it belongs to, so the key depends on the matched resource.
+    - name: annotation
+      expression: 'request.resource.resource == "dexclients"
+        ? "dexclient.deckhouse.io/allow-access-to-kubernetes"
+        : "dexauthenticator.deckhouse.io/allow-access-to-kubernetes"'
+    - name: annotations
+      expression: 'object.metadata.?annotations.orValue({})'
+    - name: oldAnnotations
+      expression: 'oldObject == null ? {} : oldObject.metadata.?annotations.orValue({})'
+    # The truthy set is a superset of what strconv.ParseBool accepts in the hooks, so no value that
+    # the hooks would honour can slip through unchecked.
+    - name: grantsAccess
+      expression: 'variables.annotation in variables.annotations
+        && variables.annotations[variables.annotation].lowerAscii() in ["1", "t", "true"]'
+    - name: grantedBefore
+      expression: 'variables.annotation in variables.oldAnnotations
+        && variables.oldAnnotations[variables.annotation].lowerAscii() in ["1", "t", "true"]'
+  validations:
+    # Only a newly granted access is gated, so objects that already carry the annotation stay editable
+    # by their owners. Authority is proven by the right to update the user-authn ModuleConfig, which
+    # only cluster-wide administrators of this module hold.
+    - expression: 'request.userInfo.username == "system:serviceaccount:d8-system:deckhouse"
+        || !variables.grantsAccess
+        || variables.grantedBefore
+        || authorizer.group("deckhouse.io").resource("moduleconfigs").name("user-authn").check("update").allowed()'
+      reason: Forbidden
+      messageExpression: '"the " + variables.annotation + " annotation grants access to the Kubernetes API
+        and must be applied by a cluster administrator who is allowed to manage the user-authn module"'
+---
+apiVersion: {{ include "helm_lib_get_api_version_by_kind" (list . "ValidatingAdmissionPolicyBinding") }}
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: {{ $allowAccessPolicyName }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "deckhouse") ) | nindent 2 }}
+spec:
+  policyName: {{ $allowAccessPolicyName }}
+  validationActions: [Deny]
 {{- if .Values.userAuthn.passwordPolicy }}
 {{- $passwordPolicyName := "user-password-immutable.deckhouse.io" }}
 ---


### PR DESCRIPTION
> Based on #22222 (`chore/helm-test-harness-api-versions`), which carries the Helm test harness change this PR's tests need. Merge #22222 first; this PR targets that branch and should be retargeted to `main` once it lands.

## Description

`DexClient` and `DexAuthenticator` are namespaced resources. Two annotations on them act as cluster-level privilege grants:

- `dexclient.deckhouse.io/allow-access-to-kubernetes`
- `dexauthenticator.deckhouse.io/allow-access-to-kubernetes`

The annotation adds the tenant's OAuth2 client to `trustedPeers` of the privileged `kubernetes` OAuth2Client (`modules/150-user-authn/templates/dex/oauth2client.yaml`). Being a trusted peer lets the client ask Dex for cross-client ID tokens with `aud: kubernetes` — tokens the kube-apiserver accepts, mapping `username` from the `email` claim and `groups` from the `groups` claim with an empty prefix (`modules/040-control-plane-manager/templates/_authentication_configuration.tpl`).

Until now nothing constrained who set those annotations. The hooks (`hooks/get_dex_client_crds.go`, `hooks/get_dex_authenticator_crds.go`) only read the annotation off the object; they check neither the subject nor the namespace. The module's only ValidatingAdmissionPolicies target `users`.

This PR adds a `ValidatingAdmissionPolicy` and `ValidatingAdmissionPolicyBinding` named `dex-allow-access-to-kubernetes.deckhouse.io` to `modules/150-user-authn/templates/validation.yaml`, matching `deckhouse.io` `dexclients` and `dexauthenticators` on `CREATE` and `UPDATE`, with `failurePolicy: Fail` and `validationActions: [Deny]`, inside the existing `helm_lib_kind_exists` guard.

### What is gated: presence, not truthiness

The policy gates the **presence** of the annotation key, not the value written into it.

Two hook generations read this annotation differently. Since #21897 (`41ef802ec8` on `main`, `0488dada7b` on `release-1.77`) the hooks parse the value with `strconv.ParseBool` and fail closed on anything else. Before that — and still on `release-1.76`, `hooks/get_dex_client_crds.go:98` and `hooks/get_dex_authenticator_crds.go:78` — the hooks grant on the mere presence of the key, whatever the value is.

A policy that only looked at truthiness would therefore be sound on one branch and bypassable on the other: on the presence-honouring hook a value the policy reads as harmless still switches the grant on. Gating presence removes the dependency on the hook's parsing altogether, so the same policy is correct wherever it is deployed and stays correct if the parsing is ever changed again.

Truthiness is still used, but only in one direction: on `UPDATE` it decides whether the change makes an already annotated object *more* permissive. That keeps objects that already carry the annotation — including ones carrying a non-truthy value — editable by their owners, while still denying a non-truthy value being flipped to a truthy one.

### Authorisation predicate

```
authorizer.group("deckhouse.io").resource("moduleconfigs").name("user-authn").check("update").allowed()
```

The right to update the `user-authn` ModuleConfig is the cluster-wide authority over this module, and it is exactly what the shipped `d8:manage:permission:module:user-authn:edit` role grants (`resourceNames: [user-authn]` on `moduleconfigs`). It is *not* granted by the roles that let a tenant create these objects in the first place: legacy access level `Editor` (`d8:user-authz:user-authn:editor`) and rbacv2 `d8:use:capability:module:user-authn:edit`, which aggregates into `d8:namespace:manager`. A cluster administrator passes; a namespace manager does not. Using the CEL `authorizer` is what makes a policy sufficient here — a webhook would need its own RBAC informer to answer the same question.

The Deckhouse service account is exempted explicitly, the same way `system-users.deckhouse.io` does it in the same file. That covers the DexAuthenticators shipped by modules with the annotation already set (Kiali, Cilium Hubble UI, console), because the Deckhouse controller runs as `system:serviceaccount:d8-system:deckhouse` and applies them itself.

### Backward compatibility

The policy gates the *transition*, not the presence of the annotation on an existing object: `oldObject` is consulted so that an object which already carries the annotation stays fully editable by its owner. Case by case:

| Case | Outcome |
| --- | --- |
| CREATE, no annotation | Allow |
| CREATE, annotation present with any value, unauthorised subject | Deny |
| CREATE, annotation present, subject may update the `user-authn` ModuleConfig | Allow |
| CREATE, annotation present, `system:serviceaccount:d8-system:deckhouse` | Allow |
| UPDATE, annotation present before and after, value unchanged | Allow |
| UPDATE, `"true"` rewritten as `"1"` | Allow |
| UPDATE, `"false"` rewritten as `"false"` | Allow |
| UPDATE, annotation newly added | Deny |
| UPDATE, a value no hook reads as true flipped to `"true"` | Deny |
| UPDATE, `"true"` flipped to `"false"` | Allow |
| UPDATE, annotation removed | Allow |
| `DexClient` carrying the `dexauthenticator.*` key, and the mirror case | Allow (neither hook reads it) |

The one behaviour that changes relative to a truthiness-based gate is that an unauthorised subject can no longer *introduce* the annotation with a non-truthy value such as `"false"`. That value is a grant on the presence-honouring hook, and omitting the annotation expresses the same intent everywhere.

### Operational hazard: delete-and-recreate, and GitOps

Existing objects keep working **only for as long as they are updated in place**. The annotation is evaluated on `CREATE` as a new grant regardless of what existed before, because a deleted object leaves no `oldObject` to compare against. Anything that replaces an object rather than patching it will therefore lose Kubernetes API access:

- ArgoCD or Flux prune-and-recreate, a `replace`-style sync, or recreation triggered by an immutable-field change.
- A tenant re-applying a manifest from scratch after deleting the object.

In each case the `CREATE` carrying the annotation is denied, and if the annotation is stripped to get the object accepted, it comes back **without** access to the Kubernetes API.

Operators managing such objects through GitOps should do one of the following:

- Grant the GitOps controller's service account permission to manage the `user-authn` ModuleConfig (`update` on `moduleconfigs` named `user-authn`), so its `CREATE` requests satisfy the policy — noting this is a genuine cluster-level privilege and should be a deliberate decision.
- Or ensure these objects are updated in place rather than replaced, and have a cluster administrator perform any re-creation.

This tightening is intentional: allowing recreation to restore the grant would leave the problem open to any tenant who can delete and recreate their own object.

### Not included

No hook-side namespace allowlist. It would change behaviour for existing legitimate objects in arbitrary namespaces and therefore need an opt-out ModuleConfig setting, while the admission policy already closes the gap without breaking anything that exists. Worth a follow-up as defence in depth.

No gating of `spec` changes on an object that already carries the grant (`redirectURIs`, `allowedGroups`, `allowedEmails`, `applicationDomain`). Doing that would freeze those fields on every already-granted object, retroactively and with no self-service remedy, which is a wider break than the one this PR makes — the gate here only affects grants being introduced. It is a separate decision and belongs in its own change, most likely behind a ModuleConfig setting.

### Tests

`modules/150-user-authn/template_tests/validation_test.go` asserts that the policy and the binding render when the VAP kinds are available and are skipped when they are not, and evaluates the rendered CEL through the same compiler and evaluator kube-apiserver uses (`k8s.io/apiserver/pkg/admission/plugin/cel`), with a stub authorizer, over all the cases in the table above. The policy is decoded strictly into `admissionregistration.k8s.io/v1`, so a misspelled field fails the test too. Making the VAP kinds visible to the renderer relies on `WithAPIVersions` from #22222.

Two properties are pinned beyond the case table:

- The policy must deny every annotation value that *any* hook generation reads as a grant. Both hook models are expressed as code in the test and the value corpus is run through them, so widening a hook without widening the policy turns into a test failure rather than a silently reopened gap. The same case also asserts that an authorised subject is still allowed to set each of those values, so the assertion cannot be satisfied by a policy that denies everything.
- The CEL environment is pinned to the lowest Kubernetes version listed in `candi/version_map.yml` for the branch under test, and expressions are compiled in `environment.NewExpressions` mode. `environment.StoredExpressions` deliberately exposes every CEL library so persisted policies keep evaluating, so it would accept an expression the oldest supported cluster cannot compile. With `failurePolicy: Fail` that would deny every `DexClient` and `DexAuthenticator` write on such a cluster.

## Why do we need it, and what problem does it solve?

A namespace-scoped subject allowed to create `DexClient`/`DexAuthenticator` could grant itself cluster-level access to the Kubernetes API by adding an annotation to its own namespaced object, with no cluster-level authority involved. Granting Kubernetes API access is a cluster-administration decision, and it now requires cluster-level authority.

## Why do we need it in the patch release (if we do)?

It closes a privilege boundary that a namespace-level role could cross, and it is non-breaking for objects that already carry the annotation and are updated in place.

Because the gate is on the presence of the annotation rather than on its value, it does not depend on the hook parsing introduced by #21897, and therefore needs no prerequisite backport. Verified by cherry-picking #22222's commit, this PR's original commit, and the presence-gating commit into detached worktrees off both release branches and running `go test ./modules/150-user-authn/... -count=1`:

- `release-1.77` — three cherry-picks clean, module suite green; the CEL environment resolves to 1.32 from that branch's `candi/version_map.yml`.
- `release-1.76` — three cherry-picks clean, module suite green; the CEL environment resolves to 1.31, and the policy's expressions compile there.

`ValidatingAdmissionPolicy` is GA since Kubernetes 1.30 and both release branches support 1.31 and newer, so the `helm_lib_kind_exists` guard only matters for clusters where the API is genuinely absent.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes. Handled in #22250, which covers the client documentation for this series; the CI/CD admin guide needs the new privilege requirement and the new troubleshooting case.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authn
type: fix
summary: Adding the allow-access-to-kubernetes annotation to a DexClient or a DexAuthenticator now requires cluster-level authority over the user-authn module.
impact: Only a subject allowed to update the user-authn ModuleConfig, or the Deckhouse service account, may add the `dexclient.deckhouse.io/allow-access-to-kubernetes` or `dexauthenticator.deckhouse.io/allow-access-to-kubernetes` annotation. Objects that already carry it keep working and stay editable by their owners as long as they are updated in place. A GitOps controller that deletes and recreates such an object instead of patching it will have the recreation denied, and the object will come back without access to the Kubernetes API unless the controller's service account is allowed to update the user-authn ModuleConfig.
impact_level: high
```
