### PR TITLE
[cni-cilium] Fix agent-wide deadlock and crash in ipcache/policy under identity churn.

### DIFF
--- a/modules/021-cni-cilium/images/bin-cilium/patches/019-ipcache-no-deadlock-on-label-injection.patch
+++ b/modules/021-cni-cilium/images/bin-cilium/patches/019-ipcache-no-deadlock-on-label-injection.patch
@@ -1,0 +1,64 @@
+diff --git a/pkg/ipcache/metadata.go b/pkg/ipcache/metadata.go
+index 1f41ae64..d8be860f 100644
+--- a/pkg/ipcache/metadata.go
++++ b/pkg/ipcache/metadata.go
+@@ -34,6 +34,9 @@ var (
+
+ 	LabelInjectorName = "ipcache-inject-labels"
+
++	// policyMapUpdateTimeout bounds the wait in UpdatePolicyMaps().
++	policyMapUpdateTimeout = 3 * time.Minute
++
+ 	injectLabelsControllerGroup = controller.NewGroup("ipcache-inject-labels")
+ )
+
+@@ -546,7 +549,6 @@ func (ipc *IPCache) doInjectLabels(ctx context.Context, modifiedPrefixes []netip
+ 	}
+
+ 	ipc.mutex.Lock()
+-	defer ipc.mutex.Unlock()
+ 	for p, entry := range entriesToReplace {
+ 		prefix := p.String()
+ 		meta := ipc.getK8sMetadata(prefix)
+@@ -613,14 +615,17 @@ func (ipc *IPCache) doInjectLabels(ctx context.Context, modifiedPrefixes []netip
+ 			}
+ 		}
+ 	}
++	for prefix, id := range entriesToDelete {
++		ipc.deleteLocked(prefix.String(), id.Source)
++	}
++	// Don't hold lock while calling UpdatePolicyMaps, as it will otherwise run into a deadlock
++	ipc.mutex.Unlock()
++
+ 	if len(idsToDelete) > 0 {
+ 		if ipc.UpdatePolicyMaps(ctx, nil, idsToDelete) {
+ 			mutated = true
+ 		}
+ 	}
+-	for prefix, id := range entriesToDelete {
+-		ipc.deleteLocked(prefix.String(), id.Source)
+-	}
+
+ 	return remainingPrefixes, mutated, err
+ }
+@@ -650,7 +655,19 @@ func (ipc *IPCache) UpdatePolicyMaps(ctx context.Context, addedIdentities, delet
+ 	}
+
+ 	policyImplementedWG := ipc.DatapathHandler.UpdatePolicyMaps(ctx, &wg)
+-	policyImplementedWG.Wait()
++
++	implemented := make(chan struct{})
++	go func() {
++		policyImplementedWG.Wait()
++		close(implemented)
++	}()
++	select {
++	case <-implemented:
++	case <-ctx.Done():
++	case <-time.After(policyMapUpdateTimeout):
++		log.WithField(logfields.Duration, policyMapUpdateTimeout).
++			Warning("Timed out waiting for policy map updates to be applied to all endpoints")
++	}
+
+ 	return mutated
+ }

--- a/modules/021-cni-cilium/images/bin-cilium/patches/020-policy-nil-safe-selector-policy-detach.patch
+++ b/modules/021-cni-cilium/images/bin-cilium/patches/020-policy-nil-safe-selector-policy-detach.patch
@@ -1,0 +1,17 @@
+diff --git a/pkg/policy/distillery.go b/pkg/policy/distillery.go
+index f6f38c96..39a7d1da 100644
+--- a/pkg/policy/distillery.go
++++ b/pkg/policy/distillery.go
+@@ -58,7 +58,11 @@ func (cache *policyCache) delete(identity *identityPkg.Identity) bool {
+ 	cip, ok := cache.policies[identity.ID]
+ 	if ok {
+ 		delete(cache.policies, identity.ID)
+-		cip.getPolicy().detach(true, 0)
++		// The policy is nil while another goroutine is still resolving it in
++		// updateSelectorPolicy(), which does not hold the cache lock.
++		if selPolicy := cip.getPolicy(); selPolicy != nil {
++			selPolicy.detach(true, 0)
++		}
+ 	}
+ 	return ok
+ }

--- a/modules/021-cni-cilium/images/bin-cilium/patches/README.md
+++ b/modules/021-cni-cilium/images/bin-cilium/patches/README.md
@@ -95,4 +95,20 @@ An ICMP echo reply feature has been added to reply on LoadBalancer's service IP
 
 ## 018-fix-svacer.patch
 
-Fixed svacer DEREF_OF_NULL error in pkg/policy/api/icmp.go 
+Fixed svacer DEREF_OF_NULL error in pkg/policy/api/icmp.go
+
+## 019-ipcache-no-deadlock-on-label-injection.patch
+
+Backport for Cilium 1.17.x fixing an agent-wide deadlock in ipcache label injection:
+`doInjectLabels()` holds `ipc.mutex` while `UpdatePolicyMaps()` waits for all endpoints,
+yet endpoint regeneration acquires the same mutex (`GetDNSRules` → `LookupByIdentity`),
+so under identity churn regeneration stops node-wide, CNI requests pile up, the
+`endpoint-create` limiter returns `429 putEndpointIdTooManyRequests` and liveness stays
+green. The patch moves the delete-path `UpdatePolicyMaps()` call out of the critical
+section, as the add path above it already does, and bounds the previously unbounded wait
+with `ctx` and a 3-minute timeout.
+
+**Remove this patch when upgrading to Cilium 1.18 or newer**, where upstream fixed the
+same deadlock (`cilium#39970`, commit `47ace2de6`) by removing
+`IPCache.UpdatePolicyMaps()` altogether, so the patch is both unnecessary and will fail
+to apply.

--- a/modules/021-cni-cilium/images/bin-cilium/patches/README.md
+++ b/modules/021-cni-cilium/images/bin-cilium/patches/README.md
@@ -112,3 +112,16 @@ with `ctx` and a 3-minute timeout.
 same deadlock (`cilium#39970`, commit `47ace2de6`) by removing
 `IPCache.UpdatePolicyMaps()` altogether, so the patch is both unnecessary and will fail
 to apply.
+
+## 020-policy-nil-safe-selector-policy-detach.patch
+
+Fixes an agent crash (`SIGSEGV` in `selectorPolicy.detach`) that shows up once endpoint
+regeneration runs at full speed under heavy identity churn. `policyCache.delete()`
+dereferences `cip.getPolicy()` unconditionally, but a cache entry created by
+`lookupOrCreate()` has a nil policy until `updateSelectorPolicy()` finishes resolving it,
+and that resolution does not hold the cache lock — so an endpoint whose identity changes
+mid-regeneration can have its old identity removed while its policy is still being
+resolved. The patch adds the nil check, matching `pkg/policy/distillery.go` in 1.18.
+
+**Remove this patch when upgrading to Cilium 1.18 or newer**, where the same nil check is
+already present (it was never backported to 1.17.x, up to and including v1.17.18).


### PR DESCRIPTION
## Description

Adds two backport patches for the Cilium 1.17.x agent used in the cni-cilium module:

- `019-ipcache-no-deadlock-on-label-injection.patch` — moves the delete-path UpdatePolicyMaps() call in doInjectLabels() out of the ipc.mutex critical section (matching the add path above it) and bounds the previously unbounded wait with ctx and a 3-minute timeout.
- `020-policy-nil-safe-selector-policy-detach.patch` — adds a nil check in policyCache.delete() before calling selectorPolicy.detach(), so a cache entry whose policy is still being resolved by updateSelectorPolicy() (without holding the cache lock) is not dereferenced.
Both patches document the exact upstream fix and are marked for removal on upgrade to Cilium 1.18+.

Fixes https://github.com/deckhouse/deckhouse/issues/21647

## Why do we need it, and what problem does it solve?

Under identity churn the Cilium agent could deadlock: doInjectLabels() held ipc.mutex while UpdatePolicyMaps() waited for all endpoints to regenerate, but endpoint regeneration acquires the same mutex (GetDNSRules → LookupByIdentity). As a result endpoint regeneration stopped node-wide, CNI requests piled up, the endpoint-create limiter started returning 429 putEndpointIdTooManyRequests, and pods failed to get networking — while agent liveness stayed green, so the agent was not restarted automatically.

Once regeneration ran at full speed, a second latent bug surfaced: policyCache.delete() dereferenced a nil SelectorPolicy for an endpoint whose identity changed mid-regeneration, crashing the agent with a SIGSEGV in selectorPolicy.detach.

Together these caused node-wide loss of pod networking and agent crashes on clusters with high identity churn.

## Why do we need it in the patch release (if we do)?

Both are production-impacting stability bugs (node-wide connectivity outage and agent crash) that affect existing clusters running the current Cilium 1.17.x. The fixes are self-contained backports and should be delivered to affected clusters without waiting for the Cilium upgrade, where both are fixed upstream.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cni-cilium
type: fix
summary: Fix agent-wide deadlock in ipcache label injection and a nil-pointer crash in policy cache under identity churn.
impact: Cilium agent pods are restarted to apply the fixes.
impact_level: high
```
