### PR TITLE
Backport: [registry] bump docker-distribution to v2.8.3-deckhouse.5 to fix 14 CVEs

### DIFF
--- a/modules/038-registry/images/docker-distribution/werf.inc.yaml
+++ b/modules/038-registry/images/docker-distribution/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $version := "v2.8.3-deckhouse.4"}}
+{{- $version := "v2.8.3-deckhouse.5"}}
 ---
 image: "{{ $.ModuleName }}/{{ $.ImageName }}-src-artifact"
 fromImage: common/src-artifact


### PR DESCRIPTION
## Description

Backport of #22119 to `release-1.77`. Bumps the pinned `docker-distribution`
source tag from `v2.8.3-deckhouse.4` to `v2.8.3-deckhouse.5`.

The tag carries a dependency bump only
([deckhouse/3p-distribution#4](https://github.com/deckhouse/3p-distribution/pull/4)):
`golang.org/x/crypto` v0.45.0 → v0.53.0 and `golang.org/x/sys` v0.38.0 → v0.46.0,
plus the re-vendored tree. No source changes. The tag is already in the mirror —
the same bump is on `main`.

## Why do we need it, and what problem does it solve?

Clears 14 CVEs reported against the `registry` binary — the
`golang.org/x/crypto/ssh` family: CVE-2026-39827, CVE-2026-39828, CVE-2026-39829,
CVE-2026-39830, CVE-2026-39831, CVE-2026-39832, CVE-2026-39833, CVE-2026-39834,
CVE-2026-39835, CVE-2026-42508, CVE-2026-46595, CVE-2026-46597, CVE-2026-46598,
CVE-2024-45337.

### Verification

`trivy fs` on the upstream checkout, `-deckhouse.4` vs `-deckhouse.5`: all 14
targeted CVEs gone, no new CVE introduced.

The bump raises the module's `go` directive from 1.24.0 to 1.25.0. The image
builds with `builder/golang`, pinned to `golang:1.25.10-bookworm` in
`candi/base_images.yml`, so the toolchain covers it.

## Why do we need it in the patch release (if we do)?

This is the patch-release backport of a CVE fix already on `main`.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: registry
type: fix
summary: bump docker-distribution to v2.8.3-deckhouse.5 to clear 14 CVEs
impact_level: low
```
