### PR TITLE
[docs-builder] add hugo react to context and timeouts

### DIFF
--- a/deckhouse-controller/internal/app/env.go
+++ b/deckhouse-controller/internal/app/env.go
@@ -17,6 +17,7 @@ package app
 import (
 	"os"
 	"strconv"
+	"time"
 )
 
 // Environment variable names the deckhouse controller reads at runtime. They are
@@ -66,6 +67,13 @@ const (
 	EnvEditor              = "DECKHOUSE_EDITOR"
 	EnvKubeConfigInCluster = "DECKHOUSE_KUBE_CONFIG_IN_CLUSTER"
 	EnvTmpDir              = "DECKHOUSE_TMP_DIR"
+
+	// EnvDocumentationBuildTimeout caps a single upload+build round-trip from the
+	// module-documentation controller to a docs-builder. Every build triggers a
+	// full-site Hugo rebuild serialized across all modules, so this must exceed the
+	// worst-case build time; too low a value cancels healthy builds and churns the
+	// builder. A Go duration string (e.g. "120s", "2m").
+	EnvDocumentationBuildTimeout = "DOCUMENTATION_BUILD_TIMEOUT"
 )
 
 // EnvOr returns the value of the env var name, or defaultValue when it is unset or empty.
@@ -84,6 +92,20 @@ func EnvBoolOr(name string, defaultValue bool) bool {
 		return defaultValue
 	}
 	parsed, err := strconv.ParseBool(v)
+	if err != nil {
+		return defaultValue
+	}
+	return parsed
+}
+
+// EnvDurationOr parses the env var as a Go duration (per time.ParseDuration), or
+// returns defaultValue when unset, empty, or unparseable.
+func EnvDurationOr(name string, defaultValue time.Duration) time.Duration {
+	v, ok := os.LookupEnv(name)
+	if !ok || v == "" {
+		return defaultValue
+	}
+	parsed, err := time.ParseDuration(v)
 	if err != nil {
 		return defaultValue
 	}
@@ -121,3 +143,10 @@ func TracingOTLPInsecure() bool { return os.Getenv(EnvTracingOTLPInsecure) == "t
 
 // TracingOTLPTLSSkipVerify reports whether OTLP exporter TLS verification is skipped.
 func TracingOTLPTLSSkipVerify() bool { return os.Getenv(EnvTracingOTLPTLSSkipVerify) == "true" }
+
+// DocumentationBuildTimeout is the per-request timeout the module-documentation
+// controller applies to docs-builder upload/build calls. Defaults to 120s when
+// DOCUMENTATION_BUILD_TIMEOUT is unset or unparseable.
+func DocumentationBuildTimeout() time.Duration {
+	return EnvDurationOr(EnvDocumentationBuildTimeout, 120*time.Second)
+}

--- a/deckhouse-controller/pkg/controller/module-controllers/docbuilder/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/docbuilder/controller.go
@@ -47,6 +47,7 @@ import (
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/app"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
 	"github.com/deckhouse/deckhouse/go_lib/dependency"
+	d8http "github.com/deckhouse/deckhouse/go_lib/dependency/http"
 	"github.com/deckhouse/deckhouse/go_lib/module"
 	docsbuilder "github.com/deckhouse/deckhouse/go_lib/module/docs-builder"
 	"github.com/deckhouse/deckhouse/pkg/log"
@@ -69,8 +70,13 @@ func RegisterController(mgr manager.Manager, dc dependency.Container, logger *lo
 		client:               mgr.GetClient(),
 		downloadedModulesDir: app.DownloadedModulesDir(),
 		dc:                   dependency.NewDependencyContainer(),
-		docsBuilder:          docsbuilder.NewClient(dc.GetHTTPClient()),
-		logger:               logger,
+		// Every build triggers a full-site rebuild on the docs-builder; give the
+		// call room to finish (configurable via DOCUMENTATION_BUILD_TIMEOUT)
+		// instead of the default 10s HTTP client timeout, which cancels healthy
+		// builds under load. Safe to raise because the builder now honors the
+		// request context and aborts abandoned builds.
+		docsBuilder: docsbuilder.NewClient(dc.GetHTTPClient(d8http.WithTimeout(app.DocumentationBuildTimeout()))),
+		logger:      logger,
 	}
 
 	err := ctrl.NewControllerManagedBy(mgr).

--- a/docs/site/backends/docs-builder/internal/docs/build.go
+++ b/docs/site/backends/docs-builder/internal/docs/build.go
@@ -15,6 +15,7 @@
 package docs
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
@@ -30,9 +31,17 @@ import (
 	"github.com/flant/docs-builder/pkg/hugo"
 )
 
-func (svc *Service) Build() error {
-	svc.buildMu.Lock()
-	defer svc.buildMu.Unlock()
+func (svc *Service) Build(ctx context.Context) error {
+	// Acquire the build slot. Selecting on ctx means a caller whose request
+	// was already canceled — e.g. the client hit its timeout while an earlier
+	// build still held the slot — drops out here instead of queuing up yet
+	// another redundant full-site rebuild behind it.
+	select {
+	case svc.buildSem <- struct{}{}:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	defer func() { <-svc.buildSem }()
 
 	start := time.Now()
 	status := "ok"
@@ -42,8 +51,22 @@ func (svc *Service) Build() error {
 		svc.metrics.HistogramObserve(metrics.DocsBuilderBuildDurationSeconds, dur, map[string]string{"status": status}, nil)
 	}()
 
-	err := svc.buildHugo()
+	// The request may have been canceled while we waited for the slot; skip
+	// the build rather than start work nobody is waiting for.
+	if err := ctx.Err(); err != nil {
+		status = "canceled"
+		return err
+	}
+
+	err := svc.buildHugo(ctx)
 	if err != nil {
+		// A canceled build is not a broken site: leave the last good render
+		// (and isReady) in place and don't count it as a failure.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			status = "canceled"
+			return ctxErr
+		}
+
 		svc.isReady.Store(false)
 		status = "fail"
 
@@ -89,7 +112,7 @@ func (svc *Service) Build() error {
 	return nil
 }
 
-func (svc *Service) buildHugo() error {
+func (svc *Service) buildHugo(ctx context.Context) error {
 	flags := &hugo.Flags{
 		LogLevel: "debug",
 		Source:   svc.baseDir,
@@ -99,7 +122,16 @@ func (svc *Service) buildHugo() error {
 	svc.metrics.Grouped().ExpireGroupMetricByName(metrics.DocsBuilderModuleRenderErrorGroup, metrics.DocsBuilderModuleRenderError)
 
 	for {
-		buildErr := hugo.Build(flags, svc.logger)
+		// A single hugo pass runs to completion once started, but this
+		// self-heal loop can rerun it once per broken module it strips —
+		// several full-site builds in one call. Bail between passes so a
+		// canceled request stops multiplying rebuilds instead of holding the
+		// build slot for every remaining broken module.
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		buildErr := hugo.Build(ctx, flags, svc.logger)
 		if buildErr == nil {
 			return nil
 		}

--- a/docs/site/backends/docs-builder/internal/docs/service.go
+++ b/docs/site/backends/docs-builder/internal/docs/service.go
@@ -18,7 +18,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -49,11 +48,14 @@ type Service struct {
 	isReady              atomic.Bool
 	channelMappingEditor *channelMappingEditor
 
-	// buildMu serializes Build() calls: baseDir is a shared, on-disk Hugo
-	// working tree, and hugo.Build() gives every call its own in-memory
-	// site model, so concurrent builds both corrupt each other's output
-	// files and multiply memory use per concurrent call.
-	buildMu sync.Mutex
+	// buildSem serializes Build() calls (capacity 1): baseDir is a shared,
+	// on-disk Hugo working tree, and hugo.Build() gives every call its own
+	// in-memory site model, so concurrent builds both corrupt each other's
+	// output files and multiply memory use per concurrent call. It is a
+	// channel rather than a sync.Mutex so a caller whose triggering request
+	// was already canceled can drop out while waiting instead of queuing up
+	// yet another now-pointless full-site rebuild.
+	buildSem chan struct{}
 
 	logger  *log.Logger
 	metrics *metricsstorage.MetricStorage
@@ -64,6 +66,7 @@ func NewService(baseDir, destDir string, highAvailability bool, logger *log.Logg
 		baseDir:              baseDir,
 		destDir:              destDir,
 		channelMappingEditor: newChannelMappingEditor(baseDir),
+		buildSem:             make(chan struct{}, 1),
 		logger:               logger,
 		metrics:              ms,
 	}

--- a/docs/site/backends/docs-builder/internal/http/v1/handler.go
+++ b/docs/site/backends/docs-builder/internal/http/v1/handler.go
@@ -15,7 +15,9 @@
 package v1
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
@@ -122,9 +124,18 @@ func (h *DocsBuilderHandler) handleUpload(w http.ResponseWriter, r *http.Request
 	w.WriteHeader(http.StatusCreated)
 }
 
-func (h *DocsBuilderHandler) handleBuild(w http.ResponseWriter, _ *http.Request) {
-	err := h.docsService.Build()
+func (h *DocsBuilderHandler) handleBuild(w http.ResponseWriter, r *http.Request) {
+	err := h.docsService.Build(r.Context())
 	if err != nil {
+		// The client went away (its request timeout fired) or the server is
+		// shutting down: the build was intentionally abandoned, not broken.
+		// Under load this is the common path, so keep it out of the error log
+		// and don't dirty the response — the caller is no longer listening.
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			h.logger.Debug("build canceled", log.Err(err))
+			return
+		}
+
 		h.logger.Error("build", log.Err(err))
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return

--- a/docs/site/backends/docs-builder/pkg/hugo/commandeer.go
+++ b/docs/site/backends/docs-builder/pkg/hugo/commandeer.go
@@ -15,6 +15,7 @@
 package hugo
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -45,7 +46,7 @@ import (
 	"github.com/deckhouse/deckhouse/pkg/log"
 )
 
-func (c *command) Run() error {
+func (c *command) Run(ctx context.Context) error {
 	// Close the HugoSites when the build is done. Each HugoSites owns a
 	// dynacache whose background goroutine keeps the whole site model
 	// reachable; without Close() that graph never becomes eligible for GC
@@ -59,7 +60,7 @@ func (c *command) Run() error {
 		return fmt.Errorf("load config: %w", err)
 	}
 
-	err = b.build()
+	err = b.build(ctx)
 	if err != nil {
 		return fmt.Errorf("build: %w", err)
 	}
@@ -114,7 +115,7 @@ func (c *command) PreRun() error {
 	return nil
 }
 
-func Build(flags *Flags, logger *log.Logger) error {
+func Build(ctx context.Context, flags *Flags, logger *log.Logger) error {
 	cmd := &command{flags: flags, logger: logger}
 
 	err := cmd.PreRun()
@@ -122,7 +123,7 @@ func Build(flags *Flags, logger *log.Logger) error {
 		return fmt.Errorf("pre run: %w", err)
 	}
 
-	err = cmd.Run()
+	err = cmd.Run(ctx)
 	if err != nil {
 		return fmt.Errorf("run: %w", err)
 	}

--- a/docs/site/backends/docs-builder/pkg/hugo/hugobuilder.go
+++ b/docs/site/backends/docs-builder/pkg/hugo/hugobuilder.go
@@ -15,6 +15,7 @@
 package hugo
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -72,8 +73,8 @@ func (b *hugoBuilder) withConf(fn func(conf *commonConfig)) {
 	fn(b.conf)
 }
 
-func (b *hugoBuilder) build() error {
-	err := b.fullBuild()
+func (b *hugoBuilder) build(ctx context.Context) error {
+	err := b.fullBuild(ctx)
 	if err != nil {
 		return fmt.Errorf("full build: %w", err)
 	}
@@ -101,7 +102,7 @@ func (b *hugoBuilder) build() error {
 	return nil
 }
 
-func (b *hugoBuilder) buildSites() error {
+func (b *hugoBuilder) buildSites(ctx context.Context) error {
 	h, err := b.hugo()
 	if err != nil {
 		return fmt.Errorf("hugo: %w", err)
@@ -109,6 +110,14 @@ func (b *hugoBuilder) buildSites() error {
 
 	mu.Lock()
 	defer mu.Unlock()
+
+	// Last cancellation checkpoint before the heavy render. hugo's
+	// HugoSites.Build takes no context (v0.163.3 builds under an internal
+	// context.Background), so once this call starts it runs to completion;
+	// guarding here keeps a canceled request from kicking off a fresh pass.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 
 	// NoBuildLock is true to prevent hugo creating lock file
 	// we use mutex to lock the entire hugo build
@@ -214,7 +223,7 @@ func (b *hugoBuilder) doWithPublishDirs(f func(sourceFs *filesystems.SourceFiles
 	return langCount, nil
 }
 
-func (b *hugoBuilder) fullBuild() error {
+func (b *hugoBuilder) fullBuild(ctx context.Context) error {
 	var (
 		g         errgroup.Group
 		langCount map[string]uint64
@@ -224,6 +233,9 @@ func (b *hugoBuilder) fullBuild() error {
 	b.logger.Info(hugo.BuildVersionString())
 
 	copyStaticFunc := func() error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		cnt, err := b.copyStatic()
 		if err != nil {
 			return fmt.Errorf("error copying static files: %w", err)
@@ -232,7 +244,7 @@ func (b *hugoBuilder) fullBuild() error {
 		return nil
 	}
 	buildSitesFunc := func() error {
-		if err := b.buildSites(); err != nil {
+		if err := b.buildSites(ctx); err != nil {
 			return fmt.Errorf("error building site: %w", err)
 		}
 		return nil

--- a/modules/002-deckhouse/templates/deployment.yaml
+++ b/modules/002-deckhouse/templates/deployment.yaml
@@ -206,6 +206,12 @@ spec:
               value: "true"
             - name: PACKAGE_NELM_TIMEOUT
               value: "30m"
+            # Per-request timeout for module-documentation -> docs-builder upload/build
+            # calls. Each build is a full-site Hugo rebuild, so 10s (the default HTTP
+            # client timeout) cancels healthy builds under load; raise here if a large
+            # docs site still times out.
+            - name: DOCUMENTATION_BUILD_TIMEOUT
+              value: "120s"
             - name: LOG_TYPE
               value: "json"
             - name: DECKHOUSE_HA


### PR DESCRIPTION
## Description

`ModuleDocumentation` resources intermittently stay in `RenderResult: Error`, with a status condition like:

```
build documentation: POST "http://<pod>.d8-system.pod.cluster.local:8081/api/v1/build":
do request: ... net/http: request canceled (Client.Timeout exceeded while awaiting headers)
```

even though the individual module content renders fine in the docs-builder logs — the aggregate build step is what times out. On a cluster with many modules this typically shows up as a handful of modules `Rendered` and most stuck in `Error`.

### Root cause

Every `POST /api/v1/build` triggers a **full-site Hugo rebuild** of all modules (content + the aggregated search index), serialized on the builder. The `module-documentation` controller reconciles modules one at a time (`MaxConcurrentReconciles: 1`) and, for each not-yet-rendered module, uploads its docs and triggers one such full rebuild. Three properties turn a slow build into a self-sustaining congestion collapse:

- The controller's HTTP client used a fixed **10s** timeout (the `go_lib/dependency/http` default). A full-site build that legitimately takes longer is canceled client-side; the module is marked `Error` and retried, which re-uploads and re-triggers another full rebuild.
- `docs-builder`'s build handler **ignored the request context** and `Service.Build` held a plain `sync.Mutex`, so a build whose client had already given up kept running to completion, holding the build lock, while every queued reconcile stacked up behind it and timed out in turn.
- The self-heal loop in `buildHugo` reruns the whole Hugo build once per broken module it strips, multiplying the work inside a single request.

Modules that happened to finish a build under 10s were cached by `version`+`checksum` and stayed `Rendered`; the rest churned in `Error`, keeping the builder saturated — which matches the observed split.

### Fix

**docs-builder — make a build cancelable, so abandoned work stops instead of piling up:**

- Thread the request context from the `/api/v1/build` handler through `Service.Build` → `buildHugo` → the Hugo wrapper (`Build` → `Run` → `build` → `fullBuild` → `buildSites`).
- Replace the build mutex with a context-aware semaphore: a caller whose request was already canceled drops out of the queue instead of running a now-redundant full rebuild.
- Check the context between self-heal passes and immediately before each Hugo pass.
- Treat a canceled build as *not a failure*: readiness and the last good render are preserved, and it is recorded as `status="canceled"` rather than `fail`.

**deckhouse-controller — give the build a longer, configurable timeout (now safe because builds are cancelable):**

- The build request timeout is configurable via the `DOCUMENTATION_BUILD_TIMEOUT` environment variable (default `120s`, wired in the `deckhouse` Deployment), scoped to the build call so that upload and health checks keep their tight failure detection against an unreachable builder.

### Known limitation

A single in-flight Hugo render pass cannot be aborted mid-pass: Hugo `v0.163.3`'s `HugoSites.Build` takes no context and builds under an internal `context.Background()`. Cancellation therefore happens at boundaries (slot wait, self-heal loop, before each pass) — enough to stop the pile-up and free the build slot promptly, but one already-started pass runs to completion.

## Why do we need it, and what problem does it solve?

On clusters with many modules, module documentation could get permanently stuck in `Error` and the documentation site would stop updating, because the controller and the builder drove each other into a full-rebuild congestion collapse. This change restores reliable documentation rendering and makes the build timeout tunable for large docs sites without rebuilding the image.

Operational note: before raising the timeout, check the `docs_builder_build_duration_seconds` metric. If a clean single build already fits well under the previous 10s, the cancellation fix alone removes the pile-up; the larger timeout is the safety margin for genuinely long builds.

## Why do we need it in the patch release (if we do)?

Yes. This is a production issue — documentation rendering wedges under load with no real workaround other than reducing the module count or restarting the controller — and the fix is self-contained, so it should be backported.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: fix
summary: Module documentation no longer gets stuck in Error under load; docs-builder builds are cancelable and no longer pile up redundant full-site rebuilds behind requests whose clients already timed out.
impact_level: low
```
```changes
section: deckhouse-controller
type: fix
summary: The module-documentation build request timeout to docs-builder is configurable via DOCUMENTATION_BUILD_TIMEOUT (default 120s) instead of a fixed 10s that canceled healthy full-site builds.
impact_level: low
```