### PR TITLE
[deckhouse] Fix RBAC permissions for deckhouse resources

### DIFF
--- a/modules/002-deckhouse/templates/rbacv2/manage/edit.yaml
+++ b/modules/002-deckhouse/templates/rbacv2/manage/edit.yaml
@@ -28,6 +28,9 @@ rules:
   - applicationpackages
   verbs:
   - create
+  - get
+  - list
+  - watch
   - update
   - patch
   - delete

--- a/modules/002-deckhouse/templates/rbacv2/manage/view.yaml
+++ b/modules/002-deckhouse/templates/rbacv2/manage/view.yaml
@@ -21,7 +21,9 @@ rules:
   - modulereleases
   - modules
   - modulesettingsdefinitions
+  - modulesources
   - moduleupdatepolicies
+  - packagerepositories
   - packagerepositoryoperations
   - applicationpackageversions
   - applicationpackages

--- a/modules/002-deckhouse/templates/rbacv2/manage/view.yaml
+++ b/modules/002-deckhouse/templates/rbacv2/manage/view.yaml
@@ -21,9 +21,7 @@ rules:
   - modulereleases
   - modules
   - modulesettingsdefinitions
-  - modulesources
   - moduleupdatepolicies
-  - packagerepositories
   - packagerepositoryoperations
   - applicationpackageversions
   - applicationpackages

--- a/modules/002-deckhouse/templates/user-authz-cluster-roles.yaml
+++ b/modules/002-deckhouse/templates/user-authz-cluster-roles.yaml
@@ -1,8 +1,4 @@
 ---
-# Access level: User.
-# Includes User permissions.
-# Read access: 
-# - applications
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -20,10 +16,6 @@ rules:
   - list
   - watch
 ---
-# Access level: Admin.
-# Includes User, PrivilegedUser, and Editor permissions.
-# Full access: 
-# - applications
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -52,13 +44,6 @@ rules:
   - patch
   - update
 ---
-# Access level: ClusterAdmin.
-# Includes User, PrivilegedUser, Editor, Admin, and ClusterEditor permissions.
-# Full access:
-# - deckhousereleases, moduleconfigs, moduledocumentations, 
-#   modulepulloverrides, modulereleases, modules, modulesources, 
-#   moduleupdatepolicies, packagerepositories, packagerepositoryoperations, 
-#   applicationpackageversions, applicationpackages, applications
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/modules/002-deckhouse/templates/user-authz-cluster-roles.yaml
+++ b/modules/002-deckhouse/templates/user-authz-cluster-roles.yaml
@@ -1,4 +1,11 @@
 ---
+# Access level: User.
+# Includes User permissions.
+# Read access: 
+# deckhousereleases, moduledocumentations, modulepulloverrides, 
+# modulereleases, modules, modulesettingsdefinitions, 
+# moduleupdatepolicies, packagerepositoryoperations, 
+# applicationpackageversions, applicationpackages, applications.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -16,9 +23,7 @@ rules:
   - modulereleases
   - modules
   - modulesettingsdefinitions
-  - modulesources
   - moduleupdatepolicies
-  - packagerepositories
   - packagerepositoryoperations
   - applicationpackageversions
   - applicationpackages
@@ -28,12 +33,47 @@ rules:
   - list
   - watch
 ---
+# Access level: Admin.
+# Includes User, PrivilegedUser, and Editor permissions.
+# Full access: 
+# - applications
+# Read access: 
+# - deckhousereleases, moduledocumentations, modulepulloverrides, 
+#   modulereleases, modules, modulesettingsdefinitions, modulesources, 
+#   moduleupdatepolicies, packagerepositories, packagerepositoryoperations, 
+#   applicationpackageversions, applicationpackages, applications.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   annotations:
     user-authz.deckhouse.io/access-level: Admin
   name: d8:user-authz:deckhouse:admin
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+rules:
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - applications
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+---
+# Access level: ClusterAdmin.
+# Includes User, PrivilegedUser, Editor, Admin, and ClusterEditor permissions.
+# Full access:
+# - deckhousereleases, moduleconfigs, moduledocumentations, 
+#   modulepulloverrides, modulereleases, modules, modulesources, 
+#   moduleupdatepolicies, packagerepositories, packagerepositoryoperations, 
+#   applicationpackageversions, applicationpackages, applications
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    user-authz.deckhouse.io/access-level: ClusterAdmin
+  name: d8:user-authz:deckhouse:cluster-admin
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 rules:
 - apiGroups:
@@ -54,15 +94,10 @@ rules:
   - applications
   verbs:
   - create
-  - delete
-  - deletecollection
-  - patch
-  - update
-- apiGroups:
-  - deckhouse.io
-  resources:
-  - moduleconfigs
-  verbs:
   - get
   - list
   - watch
+  - update
+  - patch
+  - delete
+  - deletecollection

--- a/modules/002-deckhouse/templates/user-authz-cluster-roles.yaml
+++ b/modules/002-deckhouse/templates/user-authz-cluster-roles.yaml
@@ -35,7 +35,6 @@ rules:
 - apiGroups:
   - deckhouse.io
   resources:
-  - packagerepositoryoperations
   - applicationpackageversions
   - applicationpackages
   verbs:

--- a/modules/002-deckhouse/templates/user-authz-cluster-roles.yaml
+++ b/modules/002-deckhouse/templates/user-authz-cluster-roles.yaml
@@ -35,6 +35,16 @@ rules:
 - apiGroups:
   - deckhouse.io
   resources:
+  - packagerepositoryoperations
+  - applicationpackageversions
+  - applicationpackages
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - deckhouse.io
+  resources:
   - applications
   verbs:
   - create

--- a/modules/002-deckhouse/templates/user-authz-cluster-roles.yaml
+++ b/modules/002-deckhouse/templates/user-authz-cluster-roles.yaml
@@ -2,10 +2,7 @@
 # Access level: User.
 # Includes User permissions.
 # Read access: 
-# deckhousereleases, moduledocumentations, modulepulloverrides, 
-# modulereleases, modules, modulesettingsdefinitions, 
-# moduleupdatepolicies, packagerepositoryoperations, 
-# applicationpackageversions, applicationpackages, applications.
+# - applications
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -17,16 +14,6 @@ rules:
 - apiGroups:
   - deckhouse.io
   resources:
-  - deckhousereleases
-  - moduledocumentations
-  - modulepulloverrides
-  - modulereleases
-  - modules
-  - modulesettingsdefinitions
-  - moduleupdatepolicies
-  - packagerepositoryoperations
-  - applicationpackageversions
-  - applicationpackages
   - applications
   verbs:
   - get
@@ -37,11 +24,6 @@ rules:
 # Includes User, PrivilegedUser, and Editor permissions.
 # Full access: 
 # - applications
-# Read access: 
-# - deckhousereleases, moduledocumentations, modulepulloverrides, 
-#   modulereleases, modules, modulesettingsdefinitions, modulesources, 
-#   moduleupdatepolicies, packagerepositories, packagerepositoryoperations, 
-#   applicationpackageversions, applicationpackages, applications.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/modules/140-user-authz/docs/README.md
+++ b/modules/140-user-authz/docs/README.md
@@ -244,12 +244,10 @@ read:
     - deckhouse.io/modulereleases
     - deckhouse.io/modules
     - deckhouse.io/modulesettingsdefinitions
-    - deckhouse.io/modulesources
     - deckhouse.io/moduleupdatepolicies
     - deckhouse.io/nodegroups
     - deckhouse.io/openstackinstanceclasses
     - deckhouse.io/operationpolicies
-    - deckhouse.io/packagerepositories
     - deckhouse.io/packagerepositoryoperations
     - deckhouse.io/projecttemplates
     - deckhouse.io/securitypolicies
@@ -425,21 +423,9 @@ delete,deletecollection:
     - extensions/replicasets
 read-write:
     - deckhouse.io/authorizationrules
-    - deckhouse.io/moduleconfigs
 write:
     - autoscaling.k8s.io/verticalpodautoscalercheckpoints
-    - deckhouse.io/applicationpackages
-    - deckhouse.io/applicationpackageversions
     - deckhouse.io/applications
-    - deckhouse.io/deckhousereleases
-    - deckhouse.io/moduledocumentations
-    - deckhouse.io/modulepulloverrides
-    - deckhouse.io/modulereleases
-    - deckhouse.io/modules
-    - deckhouse.io/modulesources
-    - deckhouse.io/moduleupdatepolicies
-    - deckhouse.io/packagerepositories
-    - deckhouse.io/packagerepositoryoperations
     - deckhouse.io/securitypolicyexceptions
     - extensions.istio.io/wasmplugins
     - rbac.authorization.k8s.io/rolebindings
@@ -472,7 +458,6 @@ read:
     - sailoperator.io/istios
     - sailoperator.io/ztunnels
 read-write:
-    - deckhouse.io/moduleconfigs
     - deckhouse.io/nodegroupconfigurations
     - deckhouse.io/staticinstances
     - multitenancy.deckhouse.io/clusterresourcegrantpolicies
@@ -481,22 +466,11 @@ write:
     - apps/daemonsets
     - autoscaling.k8s.io/verticalpodautoscalercheckpoints
     - cert-manager.io/clusterissuers
-    - deckhouse.io/applicationpackages
-    - deckhouse.io/applicationpackageversions
     - deckhouse.io/applications
-    - deckhouse.io/deckhousereleases
     - deckhouse.io/hubblemonitoringconfigs
     - deckhouse.io/instances
     - deckhouse.io/keepalivedinstances
-    - deckhouse.io/moduledocumentations
-    - deckhouse.io/modulepulloverrides
-    - deckhouse.io/modulereleases
-    - deckhouse.io/modules
-    - deckhouse.io/modulesources
-    - deckhouse.io/moduleupdatepolicies
     - deckhouse.io/nodegroups
-    - deckhouse.io/packagerepositories
-    - deckhouse.io/packagerepositoryoperations
     - deckhouse.io/securitypolicyexceptions
     - extensions.istio.io/wasmplugins
     - extensions/daemonsets
@@ -545,7 +519,10 @@ read-write:
     - deckhouse.io/dexproviderchecks
     - deckhouse.io/dexproviders
     - deckhouse.io/groups
+    - deckhouse.io/moduleconfigs
+    - deckhouse.io/modulesources
     - deckhouse.io/nodeusers
+    - deckhouse.io/packagerepositories
     - deckhouse.io/sshcredentials
     - deckhouse.io/useroperations
     - deckhouse.io/users
@@ -562,9 +539,12 @@ write:
     - config.gatekeeper.sh/configs
     - connection.gatekeeper.sh/connections
     - constraints.gatekeeper.sh/*
+    - deckhouse.io/applicationpackages
+    - deckhouse.io/applicationpackageversions
     - deckhouse.io/awsinstanceclasses
     - deckhouse.io/azureinstanceclasses
     - deckhouse.io/containerdintegritypolicies
+    - deckhouse.io/deckhousereleases
     - deckhouse.io/deschedulers
     - deckhouse.io/dvpinstanceclasses
     - deckhouse.io/dynamixinstanceclasses
@@ -574,8 +554,14 @@ write:
     - deckhouse.io/istiofederations
     - deckhouse.io/istiomulticlusters
     - deckhouse.io/localpathprovisioners
+    - deckhouse.io/moduledocumentations
+    - deckhouse.io/modulepulloverrides
+    - deckhouse.io/modulereleases
+    - deckhouse.io/modules
+    - deckhouse.io/moduleupdatepolicies
     - deckhouse.io/openstackinstanceclasses
     - deckhouse.io/operationpolicies
+    - deckhouse.io/packagerepositoryoperations
     - deckhouse.io/projects
     - deckhouse.io/projecttemplates
     - deckhouse.io/securitypolicies

--- a/modules/140-user-authz/docs/README.md
+++ b/modules/140-user-authz/docs/README.md
@@ -411,6 +411,9 @@ delete,deletecollection:
     - apps/replicasets
     - cert-manager.io/certificaterequests
     - extensions/replicasets
+read:
+    - deckhouse.io/applicationpackages
+    - deckhouse.io/applicationpackageversions
 read-write:
     - deckhouse.io/authorizationrules
 write:
@@ -433,6 +436,8 @@ delete,deletecollection:
 patch,update:
     - nodes
 read:
+    - deckhouse.io/applicationpackages
+    - deckhouse.io/applicationpackageversions
     - deckhouse.io/containerdintegritypolicies
     - deckhouse.io/ingressistiocontrollers
     - deckhouse.io/istiofederations
@@ -505,8 +510,6 @@ read:
     - nfd.k8s-sigs.io/nodefeaturerules
     - nfd.k8s-sigs.io/nodefeatures
 read-write:
-    - deckhouse.io/applicationpackages
-    - deckhouse.io/applicationpackageversions
     - deckhouse.io/clusterauthorizationrules
     - deckhouse.io/deckhousereleases
     - deckhouse.io/dexproviderchecks
@@ -538,6 +541,8 @@ write:
     - config.gatekeeper.sh/configs
     - connection.gatekeeper.sh/connections
     - constraints.gatekeeper.sh/*
+    - deckhouse.io/applicationpackages
+    - deckhouse.io/applicationpackageversions
     - deckhouse.io/awsinstanceclasses
     - deckhouse.io/azureinstanceclasses
     - deckhouse.io/containerdintegritypolicies

--- a/modules/140-user-authz/docs/README.md
+++ b/modules/140-user-authz/docs/README.md
@@ -222,12 +222,9 @@ read:
     - configmaps
     - connection.gatekeeper.sh/connections
     - constraints.gatekeeper.sh/*
-    - deckhouse.io/applicationpackages
-    - deckhouse.io/applicationpackageversions
     - deckhouse.io/applications
     - deckhouse.io/awsinstanceclasses
     - deckhouse.io/azureinstanceclasses
-    - deckhouse.io/deckhousereleases
     - deckhouse.io/deschedulers
     - deckhouse.io/dexauthenticators
     - deckhouse.io/dexclients
@@ -239,16 +236,9 @@ read:
     - deckhouse.io/instances
     - deckhouse.io/keepalivedinstances
     - deckhouse.io/localpathprovisioners
-    - deckhouse.io/moduledocumentations
-    - deckhouse.io/modulepulloverrides
-    - deckhouse.io/modulereleases
-    - deckhouse.io/modules
-    - deckhouse.io/modulesettingsdefinitions
-    - deckhouse.io/moduleupdatepolicies
     - deckhouse.io/nodegroups
     - deckhouse.io/openstackinstanceclasses
     - deckhouse.io/operationpolicies
-    - deckhouse.io/packagerepositoryoperations
     - deckhouse.io/projecttemplates
     - deckhouse.io/securitypolicies
     - deckhouse.io/securitypolicyexceptions
@@ -515,14 +505,23 @@ read:
     - nfd.k8s-sigs.io/nodefeaturerules
     - nfd.k8s-sigs.io/nodefeatures
 read-write:
+    - deckhouse.io/applicationpackages
+    - deckhouse.io/applicationpackageversions
     - deckhouse.io/clusterauthorizationrules
+    - deckhouse.io/deckhousereleases
     - deckhouse.io/dexproviderchecks
     - deckhouse.io/dexproviders
     - deckhouse.io/groups
     - deckhouse.io/moduleconfigs
+    - deckhouse.io/moduledocumentations
+    - deckhouse.io/modulepulloverrides
+    - deckhouse.io/modulereleases
+    - deckhouse.io/modules
     - deckhouse.io/modulesources
+    - deckhouse.io/moduleupdatepolicies
     - deckhouse.io/nodeusers
     - deckhouse.io/packagerepositories
+    - deckhouse.io/packagerepositoryoperations
     - deckhouse.io/sshcredentials
     - deckhouse.io/useroperations
     - deckhouse.io/users
@@ -539,12 +538,9 @@ write:
     - config.gatekeeper.sh/configs
     - connection.gatekeeper.sh/connections
     - constraints.gatekeeper.sh/*
-    - deckhouse.io/applicationpackages
-    - deckhouse.io/applicationpackageversions
     - deckhouse.io/awsinstanceclasses
     - deckhouse.io/azureinstanceclasses
     - deckhouse.io/containerdintegritypolicies
-    - deckhouse.io/deckhousereleases
     - deckhouse.io/deschedulers
     - deckhouse.io/dvpinstanceclasses
     - deckhouse.io/dynamixinstanceclasses
@@ -554,14 +550,8 @@ write:
     - deckhouse.io/istiofederations
     - deckhouse.io/istiomulticlusters
     - deckhouse.io/localpathprovisioners
-    - deckhouse.io/moduledocumentations
-    - deckhouse.io/modulepulloverrides
-    - deckhouse.io/modulereleases
-    - deckhouse.io/modules
-    - deckhouse.io/moduleupdatepolicies
     - deckhouse.io/openstackinstanceclasses
     - deckhouse.io/operationpolicies
-    - deckhouse.io/packagerepositoryoperations
     - deckhouse.io/projects
     - deckhouse.io/projecttemplates
     - deckhouse.io/securitypolicies

--- a/modules/140-user-authz/docs/README_RU.md
+++ b/modules/140-user-authz/docs/README_RU.md
@@ -417,6 +417,9 @@ delete,deletecollection:
     - apps/replicasets
     - cert-manager.io/certificaterequests
     - extensions/replicasets
+read:
+    - deckhouse.io/applicationpackages
+    - deckhouse.io/applicationpackageversions
 read-write:
     - deckhouse.io/authorizationrules
 write:
@@ -439,6 +442,8 @@ delete,deletecollection:
 patch,update:
     - nodes
 read:
+    - deckhouse.io/applicationpackages
+    - deckhouse.io/applicationpackageversions
     - deckhouse.io/containerdintegritypolicies
     - deckhouse.io/ingressistiocontrollers
     - deckhouse.io/istiofederations
@@ -511,8 +516,6 @@ read:
     - nfd.k8s-sigs.io/nodefeaturerules
     - nfd.k8s-sigs.io/nodefeatures
 read-write:
-    - deckhouse.io/applicationpackages
-    - deckhouse.io/applicationpackageversions
     - deckhouse.io/clusterauthorizationrules
     - deckhouse.io/deckhousereleases
     - deckhouse.io/dexproviderchecks
@@ -544,6 +547,8 @@ write:
     - config.gatekeeper.sh/configs
     - connection.gatekeeper.sh/connections
     - constraints.gatekeeper.sh/*
+    - deckhouse.io/applicationpackages
+    - deckhouse.io/applicationpackageversions
     - deckhouse.io/awsinstanceclasses
     - deckhouse.io/azureinstanceclasses
     - deckhouse.io/containerdintegritypolicies

--- a/modules/140-user-authz/docs/README_RU.md
+++ b/modules/140-user-authz/docs/README_RU.md
@@ -250,12 +250,10 @@ read:
     - deckhouse.io/modulereleases
     - deckhouse.io/modules
     - deckhouse.io/modulesettingsdefinitions
-    - deckhouse.io/modulesources
     - deckhouse.io/moduleupdatepolicies
     - deckhouse.io/nodegroups
     - deckhouse.io/openstackinstanceclasses
     - deckhouse.io/operationpolicies
-    - deckhouse.io/packagerepositories
     - deckhouse.io/packagerepositoryoperations
     - deckhouse.io/projecttemplates
     - deckhouse.io/securitypolicies
@@ -431,21 +429,9 @@ delete,deletecollection:
     - extensions/replicasets
 read-write:
     - deckhouse.io/authorizationrules
-    - deckhouse.io/moduleconfigs
 write:
     - autoscaling.k8s.io/verticalpodautoscalercheckpoints
-    - deckhouse.io/applicationpackages
-    - deckhouse.io/applicationpackageversions
     - deckhouse.io/applications
-    - deckhouse.io/deckhousereleases
-    - deckhouse.io/moduledocumentations
-    - deckhouse.io/modulepulloverrides
-    - deckhouse.io/modulereleases
-    - deckhouse.io/modules
-    - deckhouse.io/modulesources
-    - deckhouse.io/moduleupdatepolicies
-    - deckhouse.io/packagerepositories
-    - deckhouse.io/packagerepositoryoperations
     - deckhouse.io/securitypolicyexceptions
     - extensions.istio.io/wasmplugins
     - rbac.authorization.k8s.io/rolebindings
@@ -478,7 +464,6 @@ read:
     - sailoperator.io/istios
     - sailoperator.io/ztunnels
 read-write:
-    - deckhouse.io/moduleconfigs
     - deckhouse.io/nodegroupconfigurations
     - deckhouse.io/staticinstances
     - multitenancy.deckhouse.io/clusterresourcegrantpolicies
@@ -487,22 +472,11 @@ write:
     - apps/daemonsets
     - autoscaling.k8s.io/verticalpodautoscalercheckpoints
     - cert-manager.io/clusterissuers
-    - deckhouse.io/applicationpackages
-    - deckhouse.io/applicationpackageversions
     - deckhouse.io/applications
-    - deckhouse.io/deckhousereleases
     - deckhouse.io/hubblemonitoringconfigs
     - deckhouse.io/instances
     - deckhouse.io/keepalivedinstances
-    - deckhouse.io/moduledocumentations
-    - deckhouse.io/modulepulloverrides
-    - deckhouse.io/modulereleases
-    - deckhouse.io/modules
-    - deckhouse.io/modulesources
-    - deckhouse.io/moduleupdatepolicies
     - deckhouse.io/nodegroups
-    - deckhouse.io/packagerepositories
-    - deckhouse.io/packagerepositoryoperations
     - deckhouse.io/securitypolicyexceptions
     - extensions.istio.io/wasmplugins
     - extensions/daemonsets
@@ -551,7 +525,10 @@ read-write:
     - deckhouse.io/dexproviderchecks
     - deckhouse.io/dexproviders
     - deckhouse.io/groups
+    - deckhouse.io/moduleconfigs
+    - deckhouse.io/modulesources
     - deckhouse.io/nodeusers
+    - deckhouse.io/packagerepositories
     - deckhouse.io/sshcredentials
     - deckhouse.io/useroperations
     - deckhouse.io/users
@@ -568,9 +545,12 @@ write:
     - config.gatekeeper.sh/configs
     - connection.gatekeeper.sh/connections
     - constraints.gatekeeper.sh/*
+    - deckhouse.io/applicationpackages
+    - deckhouse.io/applicationpackageversions
     - deckhouse.io/awsinstanceclasses
     - deckhouse.io/azureinstanceclasses
     - deckhouse.io/containerdintegritypolicies
+    - deckhouse.io/deckhousereleases
     - deckhouse.io/deschedulers
     - deckhouse.io/dvpinstanceclasses
     - deckhouse.io/dynamixinstanceclasses
@@ -580,8 +560,14 @@ write:
     - deckhouse.io/istiofederations
     - deckhouse.io/istiomulticlusters
     - deckhouse.io/localpathprovisioners
+    - deckhouse.io/moduledocumentations
+    - deckhouse.io/modulepulloverrides
+    - deckhouse.io/modulereleases
+    - deckhouse.io/modules
+    - deckhouse.io/moduleupdatepolicies
     - deckhouse.io/openstackinstanceclasses
     - deckhouse.io/operationpolicies
+    - deckhouse.io/packagerepositoryoperations
     - deckhouse.io/projects
     - deckhouse.io/projecttemplates
     - deckhouse.io/securitypolicies

--- a/modules/140-user-authz/docs/README_RU.md
+++ b/modules/140-user-authz/docs/README_RU.md
@@ -228,12 +228,9 @@ read:
     - configmaps
     - connection.gatekeeper.sh/connections
     - constraints.gatekeeper.sh/*
-    - deckhouse.io/applicationpackages
-    - deckhouse.io/applicationpackageversions
     - deckhouse.io/applications
     - deckhouse.io/awsinstanceclasses
     - deckhouse.io/azureinstanceclasses
-    - deckhouse.io/deckhousereleases
     - deckhouse.io/deschedulers
     - deckhouse.io/dexauthenticators
     - deckhouse.io/dexclients
@@ -245,16 +242,9 @@ read:
     - deckhouse.io/instances
     - deckhouse.io/keepalivedinstances
     - deckhouse.io/localpathprovisioners
-    - deckhouse.io/moduledocumentations
-    - deckhouse.io/modulepulloverrides
-    - deckhouse.io/modulereleases
-    - deckhouse.io/modules
-    - deckhouse.io/modulesettingsdefinitions
-    - deckhouse.io/moduleupdatepolicies
     - deckhouse.io/nodegroups
     - deckhouse.io/openstackinstanceclasses
     - deckhouse.io/operationpolicies
-    - deckhouse.io/packagerepositoryoperations
     - deckhouse.io/projecttemplates
     - deckhouse.io/securitypolicies
     - deckhouse.io/securitypolicyexceptions
@@ -521,14 +511,23 @@ read:
     - nfd.k8s-sigs.io/nodefeaturerules
     - nfd.k8s-sigs.io/nodefeatures
 read-write:
+    - deckhouse.io/applicationpackages
+    - deckhouse.io/applicationpackageversions
     - deckhouse.io/clusterauthorizationrules
+    - deckhouse.io/deckhousereleases
     - deckhouse.io/dexproviderchecks
     - deckhouse.io/dexproviders
     - deckhouse.io/groups
     - deckhouse.io/moduleconfigs
+    - deckhouse.io/moduledocumentations
+    - deckhouse.io/modulepulloverrides
+    - deckhouse.io/modulereleases
+    - deckhouse.io/modules
     - deckhouse.io/modulesources
+    - deckhouse.io/moduleupdatepolicies
     - deckhouse.io/nodeusers
     - deckhouse.io/packagerepositories
+    - deckhouse.io/packagerepositoryoperations
     - deckhouse.io/sshcredentials
     - deckhouse.io/useroperations
     - deckhouse.io/users
@@ -545,12 +544,9 @@ write:
     - config.gatekeeper.sh/configs
     - connection.gatekeeper.sh/connections
     - constraints.gatekeeper.sh/*
-    - deckhouse.io/applicationpackages
-    - deckhouse.io/applicationpackageversions
     - deckhouse.io/awsinstanceclasses
     - deckhouse.io/azureinstanceclasses
     - deckhouse.io/containerdintegritypolicies
-    - deckhouse.io/deckhousereleases
     - deckhouse.io/deschedulers
     - deckhouse.io/dvpinstanceclasses
     - deckhouse.io/dynamixinstanceclasses
@@ -560,14 +556,8 @@ write:
     - deckhouse.io/istiofederations
     - deckhouse.io/istiomulticlusters
     - deckhouse.io/localpathprovisioners
-    - deckhouse.io/moduledocumentations
-    - deckhouse.io/modulepulloverrides
-    - deckhouse.io/modulereleases
-    - deckhouse.io/modules
-    - deckhouse.io/moduleupdatepolicies
     - deckhouse.io/openstackinstanceclasses
     - deckhouse.io/operationpolicies
-    - deckhouse.io/packagerepositoryoperations
     - deckhouse.io/projects
     - deckhouse.io/projecttemplates
     - deckhouse.io/securitypolicies


### PR DESCRIPTION
## Description
This PR changes deckhouse resources RBAC to match common role model.

`User` can only view `applications`.  
`Admin` can manage `applications` and view `applicationpackageversions`, `applicationpackages` (To manage `applications` with UI).  
`ClusterAdmin` can manage all resources.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: Fix RBAC permissions for deckhouse user.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
