### PR TITLE
[istio] Istioctl default namespace patch refactor

### DIFF
--- a/modules/110-istio/images/istioctl-v1x21x6/patches/001-deckhouse-default-istio-namespace.patch
+++ b/modules/110-istio/images/istioctl-v1x21x6/patches/001-deckhouse-default-istio-namespace.patch
@@ -1,21 +1,12 @@
-diff --git a/istioctl/cmd/root.go b/istioctl/cmd/root.go
-index 14628cb58e..ee84d9eeef 100644
---- a/istioctl/cmd/root.go
-+++ b/istioctl/cmd/root.go
-@@ -45,7 +45,6 @@ import (
- 	"istio.io/istio/operator/cmd/mesh"
- 	"istio.io/istio/pkg/cmd"
- 	"istio.io/istio/pkg/collateral"
--	"istio.io/istio/pkg/config/constants"
- 	"istio.io/istio/pkg/log"
- 	"istio.io/istio/tools/bug-report/pkg/bugreport"
- )
-@@ -88,7 +87,7 @@ func ConfigAndEnvProcessing() error {
- }
+diff --git a/pkg/config/constants/constants.go b/pkg/config/constants/constants.go
+--- a/pkg/config/constants/constants.go
++++ b/pkg/config/constants/constants.go
+@@ -85,7 +85,7 @@ const (
+ 	IstioIngressLabelValue = "ingressgateway"
  
- func init() {
--	viper.SetDefault("istioNamespace", constants.IstioSystemNamespace)
-+	viper.SetDefault("istioNamespace", "d8-istio")
- 	viper.SetDefault("xds-port", 15012)
- }
+ 	// IstioSystemNamespace is the namespace where Istio's components are deployed
+-	IstioSystemNamespace = "istio-system"
++	IstioSystemNamespace = "d8-istio"
  
+ 	// DefaultAuthenticationPolicyName is the name of the cluster-scoped authentication policy. Only
+ 	// policy with this name in the cluster-scoped will be considered.

--- a/modules/110-istio/images/istioctl-v1x21x6/patches/README.md
+++ b/modules/110-istio/images/istioctl-v1x21x6/patches/README.md
@@ -2,4 +2,4 @@
 
 ## 001-deckhouse-default-istio-namespace.patch
 
-Fix default Istio namespace to Deckhouse Istio namespace
+Set `constants.IstioSystemNamespace` to the Deckhouse Istio namespace (`d8-istio`).

--- a/modules/110-istio/images/istioctl-v1x25x2/patches/001-deckhouse-default-istio-namespace.patch
+++ b/modules/110-istio/images/istioctl-v1x25x2/patches/001-deckhouse-default-istio-namespace.patch
@@ -1,20 +1,12 @@
-diff --git a/istioctl/cmd/root.go b/istioctl/cmd/root.go
---- a/istioctl/cmd/root.go
-+++ b/istioctl/cmd/root.go
-@@ -45,7 +45,6 @@ import (
- 	"istio.io/istio/operator/cmd/mesh"
- 	"istio.io/istio/pkg/cmd"
- 	"istio.io/istio/pkg/collateral"
--	"istio.io/istio/pkg/config/constants"
- 	"istio.io/istio/pkg/log"
- 	"istio.io/istio/tools/bug-report/pkg/bugreport"
- )
-@@ -88,7 +87,7 @@ func ConfigAndEnvProcessing() error {
- }
+diff --git a/pkg/config/constants/constants.go b/pkg/config/constants/constants.go
+--- a/pkg/config/constants/constants.go
++++ b/pkg/config/constants/constants.go
+@@ -74,7 +74,7 @@ const (
+ 	IstioIngressLabelValue = "ingressgateway"
  
- func init() {
--	viper.SetDefault("istioNamespace", constants.IstioSystemNamespace)
-+	viper.SetDefault("istioNamespace", "d8-istio")
- 	viper.SetDefault("xds-port", 15012)
- }
+ 	// IstioSystemNamespace is the namespace where Istio's components are deployed
+-	IstioSystemNamespace = "istio-system"
++	IstioSystemNamespace = "d8-istio"
  
+ 	// DefaultAuthenticationPolicyName is the name of the cluster-scoped authentication policy. Only
+ 	// policy with this name in the cluster-scoped will be considered.

--- a/modules/110-istio/images/istioctl-v1x25x2/patches/README.md
+++ b/modules/110-istio/images/istioctl-v1x25x2/patches/README.md
@@ -2,4 +2,4 @@
 
 ## 001-deckhouse-default-istio-namespace.patch
 
-Fix default Istio namespace to Deckhouse Istio namespace.
+Set `constants.IstioSystemNamespace` to the Deckhouse Istio namespace (`d8-istio`).

--- a/modules/110-istio/images/istioctl-v1x27x9/patches/001-deckhouse-default-istio-namespace.patch
+++ b/modules/110-istio/images/istioctl-v1x27x9/patches/001-deckhouse-default-istio-namespace.patch
@@ -1,20 +1,12 @@
-diff --git a/istioctl/cmd/root.go b/istioctl/cmd/root.go
---- a/istioctl/cmd/root.go
-+++ b/istioctl/cmd/root.go
-@@ -45,7 +45,6 @@ import (
- 	"istio.io/istio/operator/cmd/mesh"
- 	"istio.io/istio/pkg/cmd"
- 	"istio.io/istio/pkg/collateral"
--	"istio.io/istio/pkg/config/constants"
- 	"istio.io/istio/pkg/log"
- 	"istio.io/istio/tools/bug-report/pkg/bugreport"
- )
-@@ -88,7 +87,7 @@ func ConfigAndEnvProcessing() error {
- }
+diff --git a/pkg/config/constants/constants.go b/pkg/config/constants/constants.go
+--- a/pkg/config/constants/constants.go
++++ b/pkg/config/constants/constants.go
+@@ -74,7 +74,7 @@ const (
+ 	IstioIngressLabelValue = "ingressgateway"
  
- func init() {
--	viper.SetDefault("istioNamespace", constants.IstioSystemNamespace)
-+	viper.SetDefault("istioNamespace", "d8-istio")
- 	viper.SetDefault("xds-port", 15012)
- }
+ 	// IstioSystemNamespace is the namespace where Istio's components are deployed
+-	IstioSystemNamespace = "istio-system"
++	IstioSystemNamespace = "d8-istio"
  
+ 	// DefaultAuthenticationPolicyName is the name of the cluster-scoped authentication policy. Only
+ 	// policy with this name in the cluster-scoped will be considered.

--- a/modules/110-istio/images/istioctl-v1x27x9/patches/README.md
+++ b/modules/110-istio/images/istioctl-v1x27x9/patches/README.md
@@ -2,4 +2,4 @@
 
 ## 001-deckhouse-default-istio-namespace.patch
 
-Fix default Istio namespace to Deckhouse Istio namespace.
+Set `constants.IstioSystemNamespace` to the Deckhouse Istio namespace (`d8-istio`).

--- a/modules/110-istio/images/istioctl-v1x29x6/patches/001-deckhouse-default-istio-namespace.patch
+++ b/modules/110-istio/images/istioctl-v1x29x6/patches/001-deckhouse-default-istio-namespace.patch
@@ -1,20 +1,12 @@
-diff --git a/istioctl/cmd/root.go b/istioctl/cmd/root.go
---- a/istioctl/cmd/root.go
-+++ b/istioctl/cmd/root.go
-@@ -45,7 +45,6 @@ import (
- 	"istio.io/istio/operator/cmd/mesh"
- 	"istio.io/istio/pkg/cmd"
- 	"istio.io/istio/pkg/collateral"
--	"istio.io/istio/pkg/config/constants"
- 	"istio.io/istio/pkg/log"
- 	"istio.io/istio/tools/bug-report/pkg/bugreport"
- )
-@@ -88,7 +87,7 @@ func ConfigAndEnvProcessing() error {
- }
+diff --git a/pkg/config/constants/constants.go b/pkg/config/constants/constants.go
+--- a/pkg/config/constants/constants.go
++++ b/pkg/config/constants/constants.go
+@@ -74,7 +74,7 @@ const (
+ 	IstioIngressLabelValue = "ingressgateway"
  
- func init() {
--	viper.SetDefault("istioNamespace", constants.IstioSystemNamespace)
-+	viper.SetDefault("istioNamespace", "d8-istio")
- 	viper.SetDefault("xds-port", 15012)
- }
+ 	// IstioSystemNamespace is the namespace where Istio's components are deployed
+-	IstioSystemNamespace = "istio-system"
++	IstioSystemNamespace = "d8-istio"
  
+ 	// DefaultAuthenticationPolicyName is the name of the cluster-scoped authentication policy. Only
+ 	// policy with this name in the cluster-scoped will be considered.

--- a/modules/110-istio/images/istioctl-v1x29x6/patches/README.md
+++ b/modules/110-istio/images/istioctl-v1x29x6/patches/README.md
@@ -2,4 +2,4 @@
 
 ## 001-deckhouse-default-istio-namespace.patch
 
-Fix default Istio namespace to Deckhouse Istio namespace.
+Set `constants.IstioSystemNamespace` to the Deckhouse Istio namespace (`d8-istio`).


### PR DESCRIPTION
## Description

Refactors the `istioctl` default-namespace patch: instead of hardcoding `"d8-istio"` in `viper.SetDefault`, it changes `constants.IstioSystemNamespace` (`istio-system` → `d8-istio`).

Applies to all `istioctl` image revisions (`1.21`, `1.25`, `1.27`, `1.29`).

No restarts of control-plane, ingress, or other cluster components.

## Why do we need it, and what problem does it solve?

`istioctl` defaults to `istio-system`, while Deckhouse deploys Istio into `d8-istio`. The previous patch overrode only one call site, so other uses of `IstioSystemNamespace` still pointed at `istio-system`. Setting the constant covers all of them.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: chore
summary: refactor istioctl default namespace patch 
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
