### PR TITLE
[deckhouse] fix: delete stale documentation for embedded modules

### DIFF
--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -647,8 +647,21 @@ func (r *reconciler) handleDeployedRelease(ctx context.Context, release *v1alpha
 	// (by module config, by bundle or by an enabled script) - EnabledByModuleManager
 	// reflects the effective enabled state, unlike EnabledByModuleConfig which is only
 	// set for modules enabled explicitly via a ModuleConfig
-	if module.IsCondition(v1alpha1.ModuleConditionEnabledByModuleManager, corev1.ConditionTrue) && !r.installer.IsEmbeddedPresent(release.GetModuleName()) {
-		if err = utils.EnsureModuleDocumentationForRelease(ctx, r.client, release); err != nil {
+	if module.IsCondition(v1alpha1.ModuleConditionEnabledByModuleManager, corev1.ConditionTrue) {
+		if r.installer.IsEmbeddedPresent(release.GetModuleName()) {
+			// The embedded copy serves the module, so the release is only staged and the
+			// /modules/<name> mount a ModuleDocumentation points at is never created, while
+			// the docs of the running (embedded) version ship with the documentation image.
+			// A ModuleDocumentation left over from a Deckhouse that predates this guard makes
+			// the docbuilder stat a path that cannot appear until the embedded copy is dropped
+			// on upgrade, and retry it forever, so delete it. The branch below recreates it
+			// once the module is activated.
+			if err = utils.DeleteModuleDocumentation(ctx, r.client, release.GetModuleName()); err != nil {
+				r.log.Error("failed to delete stale module documentation", slog.String("module", release.GetModuleName()), log.Err(err))
+
+				return res, fmt.Errorf("delete stale module documentation: %w", err)
+			}
+		} else if err = utils.EnsureModuleDocumentationForRelease(ctx, r.client, release); err != nil {
 			r.log.Error("failed to ensure module documentation", slog.String("module", release.GetModuleName()), log.Err(err))
 
 			return res, fmt.Errorf("ensure module documentation: %w", err)

--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller_test.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller_test.go
@@ -39,6 +39,7 @@ import (
 	"golang.org/x/text/language"
 	"helm.sh/helm/v3/pkg/releaseutil"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -194,6 +195,28 @@ func (suite *ReleaseControllerTestSuite) TestCreateReconcile() {
 			_, err = suite.ctr.handleRelease(context.TODO(), mr)
 			require.NoError(suite.T(), err)
 		})
+	})
+
+	// The module is served by its embedded copy, but a ModuleDocumentation created by
+	// an older Deckhouse (before documentation was skipped for embedded modules) is
+	// still around. It points at a mount that is never created for a staged release,
+	// so the docbuilder would retry it forever - it must be deleted.
+	suite.Run("stale module documentation deleted for embedded module", func() {
+		suite.setupReleaseController(
+			suite.fetchTestFileData("module-documentation-stale-embedded.yaml"),
+			withInstaller(&installermock.Installer{
+				IsEmbeddedPresentFunc: func(string) bool { return true },
+			}),
+		)
+
+		repeatTest(func() {
+			mr := suite.getModuleRelease(suite.testMRName)
+			_, err = suite.ctr.handleRelease(context.TODO(), mr)
+			require.NoError(suite.T(), err)
+		})
+
+		err = suite.client.Get(context.TODO(), client.ObjectKey{Name: "parca"}, new(v1alpha1.ModuleDocumentation))
+		assert.True(suite.T(), apierrors.IsNotFound(err), "stale documentation must be deleted for an embedded module")
 	})
 
 	// The module was still embedded but its embedded copy is no longer on disk

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/module-documentation-stale-embedded.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/module-documentation-stale-embedded.yaml
@@ -1,0 +1,77 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  annotations:
+    modules.deckhouse.io/registry-spec-checksum: 38557e472e4e2bd8695fc58a255ec3dd
+  finalizers:
+  - modules.deckhouse.io/release-exists
+  name: foxtrot
+  resourceVersion: "999"
+spec:
+  registry:
+    dockerCfg: YXNiCg==
+    repo: dev-registry.deckhouse.io/team/foxtrot/modules
+    scheme: HTTPS
+status:
+  modules:
+  - name: parca
+    policy: foxtrot-alpha
+  modulesCount: 1
+  syncTime: "2024-05-03T21:05:05Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleRelease
+metadata:
+  annotations:
+    modules.deckhouse.io/isUpdating: "false"
+    modules.deckhouse.io/notified: "true"
+  finalizers:
+  - modules.deckhouse.io/metrics-registered
+  - modules.deckhouse.io/exist-on-fs
+  labels:
+    module: parca
+    modules.deckhouse.io/update-policy: foxtrot-alpha
+    release-checksum: 98d00f741c99e06e6c6c4d18b763c550
+    source: foxtrot
+    status: deployed
+  name: parca-v1.4.3
+  ownerReferences:
+  - apiVersion: deckhouse.io/v1alpha1
+    controller: true
+    kind: ModuleSource
+    name: foxtrot
+    uid: 71d2300f-700b-452a-896a-6a3805f9cef7
+  resourceVersion: "1003"
+spec:
+  moduleName: parca
+  version: 1.4.3
+  weight: 900
+status:
+  approved: false
+  phase: Deployed
+  pullDuration: 0s
+  transitionTime: "2024-05-03T20:55:49Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: Module
+metadata:
+  name: parca
+  resourceVersion: "1000"
+properties:
+  source: Embedded
+status:
+  conditions:
+  - lastProbeTime: null
+    lastTransitionTime: null
+    status: "True"
+    type: EnabledByModuleConfig
+  - lastProbeTime: null
+    lastTransitionTime: null
+    status: "True"
+    type: EnabledByModuleManager
+  - lastProbeTime: "2019-10-17T15:33:00Z"
+    lastTransitionTime: "2019-10-17T15:33:00Z"
+    status: "True"
+    type: LastReleaseDeployed
+  phase: Ready

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/module-documentation-stale-embedded.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/module-documentation-stale-embedded.yaml
@@ -1,0 +1,89 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  annotations:
+    modules.deckhouse.io/registry-spec-checksum: 38557e472e4e2bd8695fc58a255ec3dd
+  finalizers:
+    - modules.deckhouse.io/release-exists
+  name: foxtrot
+spec:
+  registry:
+    ca: ""
+    dockerCfg: YXNiCg==
+    repo: dev-registry.deckhouse.io/team/foxtrot/modules
+    scheme: HTTPS
+status:
+  message: ""
+  modules:
+    - name: parca
+      policy: foxtrot-alpha
+  modulesCount: 1
+  syncTime: "2024-05-03T21:05:05Z"
+---
+apiVersion: deckhouse.io/v1alpha2
+kind: ModuleUpdatePolicy
+metadata:
+  name: foxtrot-alpha
+spec:
+  releaseChannel: Alpha
+  update:
+    mode: Auto
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleRelease
+metadata:
+  labels:
+    module: parca
+    modules.deckhouse.io/update-policy: foxtrot-alpha
+    release-checksum: 98d00f741c99e06e6c6c4d18b763c550
+    source: foxtrot
+  name: parca-v1.4.3
+  ownerReferences:
+    - apiVersion: deckhouse.io/v1alpha1
+      controller: true
+      kind: ModuleSource
+      name: foxtrot
+      uid: 71d2300f-700b-452a-896a-6a3805f9cef7
+spec:
+  moduleName: parca
+  version: 1.4.3
+  weight: 900
+status:
+  approved: false
+  message: ""
+  phase: Pending
+  pullDuration: 0s
+  size: 0
+  transitionTime: "2024-05-03T20:55:49Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: Module
+metadata:
+  name: parca
+properties:
+  source: Embedded
+status:
+  phase: Ready
+  conditions:
+    - type: EnabledByModuleConfig
+      status: "True"
+    - type: EnabledByModuleManager
+      status: "True"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleDocumentation
+metadata:
+  labels:
+    module: parca
+    source: foxtrot
+  name: parca
+  ownerReferences:
+    - apiVersion: deckhouse.io/v1alpha1
+      controller: true
+      kind: ModuleRelease
+      name: parca-v1.4.2
+spec:
+  checksum: 0b95d0f1c9b3d6f2b0e5f5b4a3c2d1e0
+  path: /modules/parca
+  version: v1.4.2


### PR DESCRIPTION
## Description
Deletes a stale `ModuleDocumentation` instead of merely skipping it when the module is still served by its embedded copy.

`handleDeployedRelease` already skipped documentation for a module whose embedded copy is present on the filesystem (#21662), but only for newly created resources: a `ModuleDocumentation` created by an older Deckhouse stayed in the cluster forever. Now that branch removes it via `utils.DeleteModuleDocumentation`, and the existing branch recreates it once the module is activated.

Covered by a new unit test (`stale module documentation deleted for embedded module`) with a fixture reproducing an upgraded cluster: an embedded module, a deployed `ModuleRelease` and a leftover `ModuleDocumentation`.

No changes to cluster components, no restarts.

## Why do we need it, and what problem does it solve?

While a module is migrating from embedded to external, both copies coexist: the release is only staged (`Stage`, not `Install`), so the `/modules/<name>` mount that `ModuleDocumentation.spec.path` points at is never created — the embedded copy keeps serving the module and wins the module search path.

A `ModuleDocumentation` left over from before #21662 makes the docbuilder controller stat a path that cannot appear until the embedded copy is dropped on upgrade:

```
{"level":"error","logger":"deckhouse-controller.module-documentation-controller",
 "msg":"Failed to fetch documentation from module directory",
 "error":"stat: stat /deckhouse/downloaded/modules/ingress-nginx: no such file or directory",
 "module_name":"ingress-nginx"}
```

The error is unrecoverable, and since #21968 the reconciler returns it so the workqueue can back off — so it repeats forever, with a full goroutine stack attached to every `Error` record (`pkg/log` adds one). Real clusters see this for every migrating module (`ingress-nginx`, `monitoring-custom`), several screens of log per retry.

Nothing is lost by the deletion: the documentation of the running (embedded) version ships with the `documentation` image in `/app/embedded-modules` and is served independently of docs-builder. The uploaded copy being dropped is the one that fails to render anyway.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix 
summary: Delete stale documentation for embedded modules.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
