### PR TITLE
[operator-prometheus] suppress GO-2026-5932 via VEX (1.73)

### DIFF
--- a/modules/200-operator-prometheus/images/prometheus-config-reloader/known_vulnerabilities.vex
+++ b/modules/200-operator-prometheus/images/prometheus-config-reloader/known_vulnerabilities.vex
@@ -3,7 +3,7 @@
   "@id": "merged-vex-operator-prometheus-prometheus-config-reloader",
   "author": "Deckhouse <contact@deckhouse.io>",
   "timestamp": "2026-05-21T15:00:00.000000+03:00",
-  "version": 2,
+  "version": 3,
   "statements": [
     {
       "vulnerability": {
@@ -60,6 +60,20 @@
       "status": "not_affected",
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Уязвимость CVE-2026-44903 (GHSA-fw8g-cg8f-9j28, CWE-79) — Stored XSS в legacy веб-интерфейсе Prometheus при отображении heatmap (histogram bucket label values), активируемый флагом --enable-feature=old-ui. Согласно официальному advisory, уязвимость затрагивает Prometheus < 3.5.3 и < 3.11.3 (фикс в 3.5.3/3.11.3, upstream v0.311.3). Образ prometheus-config-reloader (собирается из prometheus-operator v0.68.0) использует библиотеку github.com/prometheus/prometheus v0.47.0 (Prometheus 2.47.x) только как набор Go-типов для shared конфигурационных структур. Бинарь /bin/prometheus-config-reloader выполняет исключительно sidecar-функции (watch config + trigger reload), не запускает Prometheus-сервер, не открывает legacy web UI Prometheus и не имеет флага --enable-feature=old-ui. Код пакета github.com/prometheus/prometheus/web/ui в /bin/prometheus-config-reloader не импортируется и не компилируется в исполняемый путь. Эксплуатация в рамках данного образа недоступна."
+    },
+    {
+      "vulnerability": {
+        "name": "GO-2026-5932"
+      },
+      "timestamp": "2026-08-18T12:00:00Z",
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/crypto"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "GO-2026-5932: пакет golang.org/x/crypto/openpgp не сопровождается и небезопасен по дизайну, исправленной версии не существует. В образе golang.org/x/crypto уже обновлён до v0.53.0 (патч 004-fix_cve.patch), однако сам пакет openpgp в бинарь /bin/prometheus-config-reloader не импортируется: компонент выполняет исключительно sidecar-функции — отслеживание изменений файлов конфигурации и триггер reload через HTTP-эндпоинт Prometheus — и не выполняет операций OpenPGP. Уязвимый код в образе отсутствует, эксплуатация недоступна."
     }
   ]
 }


### PR DESCRIPTION
## Description

Adds a VEX `not_affected` statement for **GO-2026-5932** (`golang.org/x/crypto`) to the `prometheus-config-reloader` image (`modules/200-operator-prometheus/images/prometheus-config-reloader/known_vulnerabilities.vex`, document version 2 → 3).

No image content changes — VEX only.

## Why do we need it, and what problem does it solve?

The weekly CVE scan reports GO-2026-5932 against `bin/prometheus-config-reloader`.

The advisory covers the `golang.org/x/crypto/openpgp` package, which is unmaintained upstream and **has no fixed version**, so bumping the dependency cannot resolve it. `golang.org/x/crypto` is already pinned to the latest release v0.53.0 by `patches/004-fix_cve.patch`. The `openpgp` package itself is not imported into the binary — the component only watches config files and triggers a reload via the Prometheus HTTP endpoint, and performs no OpenPGP operations.

The same statement already exists for the sibling `prometheus-operator` image (#21763), but VEX attestations are attached per image, so the `prometheus-config-reloader` scan does not see it.

## Why do we need it in the patch release (if we do)?

The finding is reported against the image currently shipped in 1.73.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: operator-prometheus
type: fix
summary: Suppress GO-2026-5932 (golang.org/x/crypto/openpgp) for prometheus-config-reloader via VEX.
impact_level: low
```
