### PR TITLE
[candi] bashible: report failing step stderr in Instance message

### DIFF
--- a/candi/bashible/bashible.sh.tpl
+++ b/candi/bashible/bashible.sh.tpl
@@ -546,9 +546,12 @@ function main() {
 
     until /bin/bash --noprofile --norc -"$sx"eEo pipefail -c "export TERM=xterm-256color; unset CDPATH; cd $BOOTSTRAP_DIR; source /var/lib/bashible/bashbooster.sh; source $step" 2> >(tee "$per_step_log" >&2)
     do
+      # Publish the failing step's own stderr: bb-event-error-create and
+      # bb-bashible-ready-steps-failed read $step_log, which otherwise still
+      # holds the last *successful* step's log.
+      cp -f "$per_step_log" "$step_log" 2>/dev/null || true
       attempt=$(( attempt + 1 ))
       if [ -n "${MAX_RETRIES-}" ] && [ "$attempt" -gt "${MAX_RETRIES}" ]; then
-        cp -f "$per_step_log" "$step_log" 2>/dev/null || true
         {{- if ne .runType "ClusterBootstrap" }}
         bb-event-error-create "$step"
         {{- end }}

--- a/candi/bashible/lib.sh.tpl
+++ b/candi/bashible/lib.sh.tpl
@@ -63,7 +63,9 @@ function bb-bashible-ready-steps-failed() {
     local step_log="/var/lib/bashible/step.log"
     if [[ -f "${step_log}" ]]; then
       # Keep only the latest non-empty line to avoid multi-line "wall of text" in condition message.
-      log_excerpt="$(tail -n 100 "${step_log}" | awk 'NF { line=$0 } END { print line }')"
+      # Drop `set -x` trace lines: from the 3rd attempt the step runs with xtrace, so the
+      # last line is bashbooster cleanup (`+ exit 2`), not the error that failed the step.
+      log_excerpt="$(tail -n 100 "${step_log}" | grep -v '^+' | awk 'NF { line=$0 } END { print line }')"
     else
       log_excerpt="bashible step log is not available."
     fi
@@ -193,7 +195,9 @@ function bb-event-error-create() {
   local eventNote
 
   if [[ -f "${eventLog}" ]]; then
-    eventNote="$(tail -c 500 "${eventLog}")"
+    # Same xtrace filter as bb-bashible-ready-steps-failed: without it the note is
+    # 500 bytes of bashbooster cleanup trace instead of the failure.
+    eventNote="$(tail -n 100 "${eventLog}" | grep -v '^+' | tail -c 500)"
   else
     eventNote="bashible step log is not available."
   fi


### PR DESCRIPTION
## Description

`Instance.status.conditions[BashibleReady].message` (reason `StepsFailed`) was supposed to carry "the step and part of its log" (per the Instance statuses ADR), but in practice showed either the bare step name or `+ exit 2`:

1. `bb-run-step` copied the per-step log into `/var/lib/bashible/step.log` only on success and in an unreachable retry-limit branch (`MAX_RETRIES` is never set for steps). During failures, `bb-bashible-ready-steps-failed` / `bb-event-error-create` read a stale `step.log` from the last *successful* step — often empty (`099_reboot.sh`).
2. From the 3rd retry the step runs with `set -x`, so the last non-empty log line is bashbooster cleanup xtrace (`+ exit 2`), not the actual error.

Fix: copy the per-step log into `step.log` at the top of the retry loop, and filter xtrace lines (`^+`) out of both the condition message excerpt and the node event note.

Verified on a live DVP cluster (NGC deliberately broken with `ls -l /bob`): old pipeline yields `+ exit 2`, new pipeline yields `ls: cannot access '/bob': No such file or directory`.

## Why do we need it, and what problem does it solve?

Without the real error in the Instance message, diagnosing a failing bashible step requires SSH to the node. With it, `kubectl get instance -o wide` shows the root cause directly.

## What is the expected result?

`Instance` message for a failing step shows the step name plus the last meaningful stderr line, e.g.:

```
bashible: 100_disable-ntp-on-node.sh: ls: cannot access '/bob': No such file or directory
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: candi
type: fix
summary: bashible now reports the failing step's own stderr in the Instance message, instead of the shell's exit status, so a broken step can be diagnosed without SSH to the node.
impact_level: low
```
