### PR TITLE
[cloud-provider-zvirt] Don't crashloop capz-controller-manager on zVirt tag init

### DIFF
--- a/ee/se-plus/modules/030-cloud-provider-zvirt/images/capz-controller-manager/src/cmd/main.go
+++ b/ee/se-plus/modules/030-cloud-provider-zvirt/images/capz-controller-manager/src/cmd/main.go
@@ -27,6 +27,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
@@ -134,21 +135,36 @@ func main() {
 		tlsProvider.CACertsFromSystem()
 	}
 
-	zvirtClient, err := ovsdk.New(
+	// The connection is not verified here: this runs before mgr.Start, i.e. before the health
+	// probes are served, so a call to an unavailable zVirt engine could only end in a pod
+	// killed by the liveness probe and restarted forever, with the error nowhere to be seen.
+	zvirtClient, err := ovsdk.NewWithVerify(
 		zvirtCredentials.URL,
 		zvirtCredentials.User,
 		zvirtCredentials.Password,
 		tlsProvider,
 		ovirt_logger.NewKLogr(),
+		nil,
 		nil)
 	if err != nil {
-		setupLog.Error(err, "zVirt connection cannot be established")
+		setupLog.Error(err, "zVirt client cannot be created")
 		os.Exit(1)
 	}
 
 	tg := tagger.NewTagger(zvirtClient)
-	if err = tg.InitTags(context.Background(), strings.Fields(os.Getenv("ZVIRT_VM_TAGS"))); err != nil {
-		setupLog.Error(err, "zVirt tags cannot be initialized")
+
+	// Creating the tags is the first call to the zVirt engine and it runs once the manager
+	// is up, so that a failure is reported by a pod that stays alive instead of killing it
+	// before it can say anything. The error is logged and not returned, as the manager
+	// stops on a runnable error.
+	if err = mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
+		if err := tg.InitTags(ctx, strings.Fields(os.Getenv("ZVIRT_VM_TAGS"))); err != nil {
+			setupLog.Error(err, "zVirt tags cannot be initialized")
+		}
+
+		return nil
+	})); err != nil {
+		setupLog.Error(err, "unable to add tag initialization to manager")
 		os.Exit(1)
 	}
 

--- a/ee/se-plus/modules/030-cloud-provider-zvirt/images/capz-controller-manager/src/internal/ovirt_logger/logger.go
+++ b/ee/se-plus/modules/030-cloud-provider-zvirt/images/capz-controller-manager/src/internal/ovirt_logger/logger.go
@@ -64,8 +64,10 @@ func NewKLogr(names ...string) *KLogr {
 	}
 
 	return &KLogr{
-		logger:   logger,
-		VDebug:   5,
+		logger: logger,
+		// go-ovirt-client reports failed API attempts via Debugf, and textlogger runs at
+		// verbosity 0, so at V(5) a call retrying for minutes was silent in the log.
+		VDebug:   0,
 		VInfo:    0,
 		VWarning: 0,
 	}

--- a/ee/se-plus/modules/030-cloud-provider-zvirt/images/capz-controller-manager/src/internal/tagger/tagger.go
+++ b/ee/se-plus/modules/030-cloud-provider-zvirt/images/capz-controller-manager/src/internal/tagger/tagger.go
@@ -8,12 +8,17 @@ package tagger
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	ovirt "github.com/ovirt/go-ovirt-client/v3"
 )
 
 type TaggerImpl struct {
-	cl     ovirt.Client
+	cl ovirt.Client
+
+	// lock guards tagIDs. The tags are initialized by a runnable of the manager, which runs
+	// concurrently with the reconcile loops that tag the VMs.
+	lock   sync.Mutex
 	tagIDs []ovirt.TagID
 }
 
@@ -25,12 +30,14 @@ func NewTagger(client ovirt.Client) *TaggerImpl {
 }
 
 func (t *TaggerImpl) InitTags(ctx context.Context, tags []string) error {
+	cl := t.cl.WithContext(ctx)
+
 	tagsToCreate := make(map[string]struct{})
 	for _, tag := range tags {
 		tagsToCreate[tag] = struct{}{}
 	}
 
-	existingTags, err := t.cl.ListTags()
+	existingTags, err := cl.ListTags()
 	if err != nil {
 		return fmt.Errorf("Read existing tags from zVirt: %w", err)
 	}
@@ -41,19 +48,29 @@ func (t *TaggerImpl) InitTags(ctx context.Context, tags []string) error {
 
 	ctp := ovirt.NewCreateTagParams().MustWithDescription("Tag created by cluster-api-provider-zvirt, do not delete")
 	for tagName := range tagsToCreate {
-		tag, err := t.cl.WithContext(ctx).CreateTag(tagName, ctp)
+		tag, err := cl.CreateTag(tagName, ctp)
 		if err != nil {
 			return fmt.Errorf("Create %s tag: %w", tagName, err)
 		}
+
+		// Published one by one, so that the tags that could be created are applied to the
+		// VMs even when a later one fails.
+		t.lock.Lock()
 		t.tagIDs = append(t.tagIDs, tag.ID())
+		t.lock.Unlock()
 	}
 
 	return nil
 }
 
 func (t *TaggerImpl) TagVM(ctx context.Context, vmID ovirt.VMID) error {
+	t.lock.Lock()
+	// InitTags only appends, so the elements up to this length are never rewritten.
+	tagIDs := t.tagIDs
+	t.lock.Unlock()
+
 	cl := t.cl.WithContext(ctx)
-	for _, tagID := range t.tagIDs {
+	for _, tagID := range tagIDs {
 		if err := cl.AddTagToVM(vmID, tagID); err != nil {
 			return fmt.Errorf("Tag VM[id = %s] with Tag[id = %s]: %w", vmID, tagID, err)
 		}


### PR DESCRIPTION
## Description

`capz-controller-manager` created the zVirt tags before `mgr.Start()`, i.e. before `:8081` started serving `/healthz` and `/readyz`. Any problem with the credentials at that point means an empty log and a container killed by the liveness probe: go-ovirt-client retries the failed call for about 8.5 minutes, the probe kills the container after 60 seconds, and the reason is never logged. The pod stays in `CrashLoopBackOff` even after the zVirt side is fixed.

Three files change:

- `cmd/main.go` — no zVirt call happens before the manager starts. The client is built with `NewWithVerify(..., nil)` instead of `New(...)`, so the connection is not verified there, and `os.Exit(1)` is left only for invalid configuration (malformed URL, username without `@`, unusable CA bundle). Creating the tags moved into a manager `Runnable`, which runs once the probes are up; its error is logged and not returned, since returning an error from a `Runnable` stops the manager.
- `internal/tagger` — `tagIDs` is guarded by a lock. A plain `RunnableFunc` implements neither `LeaderElectionRunnable` nor `warmupRunnable`, so `runnables.Add` puts it in the same group as the controllers and every member of that group is started in its own goroutine: `InitTags` now writes `tagIDs` while the reconcile loops read it in `TagVM`. Before the move `InitTags` had completed before `mgr.Start` and nothing was shared. The IDs are appended under the lock, and `TagVM` copies the slice header while holding it — since `InitTags` only appends, the elements up to that length are never rewritten. Verified with the race detector on a concurrent `InitTags`/`TagVM` pair. `ListTags` also goes through the `WithContext` client now, so it no longer keeps retrying for its own five minutes after the manager has been asked to stop.
- `internal/ovirt_logger` — `Debugf` is logged at `V(0)` instead of `V(5)`. go-ovirt-client reports failed API attempts from its retry loop via `Debugf`, and textlogger runs at verbosity 0, so a call retrying for minutes was completely silent.

The lock does not order the two, so a VM created before the initialization finishes is tagged with whatever is known at that moment, and a tag that could not be created stays missing until the pod is restarted. Nothing in Deckhouse reads these tags — they are only written by this controller, and master nodes created by terraform never get them — so this is a marker missing in the zVirt UI, and the reason for it is in the log.

No changes to the manifests, RBAC or CRDs.

## Why do we need it, and what problem does it solve?

Found on an e2e cluster where the pod had 34 restarts: the zVirt account could list tags but not create one, so `POST /ovirt-engine/api/tags` returned access denied. The log showed nothing but reconnect attempts, and the container was killed 60 seconds after every start.

After the fix the pod stays Ready and the log says why the tags could not be created.

## Why do we need it in the patch release (if we do)?

A zVirt account without tag management permissions, or an engine unavailable at the wrong moment, permanently breaks the CAPI provider with no diagnostics, and it does not recover once the zVirt side is fixed.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cloud-provider-zvirt
type: fix
summary: Prevent capz-controller-manager from crashlooping without diagnostics when zVirt tags cannot be created.
impact_level: default
```
