### PR TITLE
[istio] Set --revision flag always to use binary revision

### DIFF
--- a/modules/110-istio/images/istioctl-v1x21x6/patches/002-deckhouse-default-istio-revision.patch
+++ b/modules/110-istio/images/istioctl-v1x21x6/patches/002-deckhouse-default-istio-revision.patch
@@ -1,0 +1,32 @@
+diff --git a/istioctl/pkg/cli/context.go b/istioctl/pkg/cli/context.go
+index bafcc0d..f4e0c15 100644
+--- a/istioctl/pkg/cli/context.go
++++ b/istioctl/pkg/cli/context.go
+@@ -76,6 +76,7 @@ func NewCLIContext(rootFlags *RootFlags) Context {
+ }
+ 
+ func (i *instance) CLIClientWithRevision(rev string) (kube.CLIClient, error) {
++	rev = "v1x21"
+ 	if i.clients == nil {
+ 		i.clients = make(map[string]kube.CLIClient)
+ 	}
+diff --git a/istioctl/pkg/clioptions/control_plane.go b/istioctl/pkg/clioptions/control_plane.go
+index 0ca06f2..ed8883c 100644
+--- a/istioctl/pkg/clioptions/control_plane.go
++++ b/istioctl/pkg/clioptions/control_plane.go
+@@ -25,6 +25,14 @@ type ControlPlaneOptions struct {
+ // AttachControlPlaneFlags attaches control-plane flags to a Cobra command.
+ // (Currently just --revision)
+ func (o *ControlPlaneOptions) AttachControlPlaneFlags(cmd *cobra.Command) {
+-	cmd.PersistentFlags().StringVarP(&o.Revision, "revision", "r", "",
++	cmd.PersistentFlags().StringVarP(&o.Revision, "revision", "r", "v1x21",
+ 		"Control plane revision")
++	prevPreRun := cmd.PersistentPreRunE
++	cmd.PersistentPreRunE = func(c *cobra.Command, args []string) error {
++		o.Revision = "v1x21"
++		if prevPreRun != nil {
++			return prevPreRun(c, args)
++		}
++		return nil
++	}
+ }

--- a/modules/110-istio/images/istioctl-v1x21x6/patches/README.md
+++ b/modules/110-istio/images/istioctl-v1x21x6/patches/README.md
@@ -3,3 +3,11 @@
 ## 001-deckhouse-default-istio-namespace.patch
 
 Set `constants.IstioSystemNamespace` to the Deckhouse Istio namespace (`d8-istio`).
+
+## 002-deckhouse-default-istio-revision.patch
+
+Force the Deckhouse control-plane revision of this image (`v1x21`) for istioctl commands that talk to the control plane:
+
+- default value of `--revision` / `-r`;
+- user-provided `--revision` is overridden in `PersistentPreRunE`;
+- `CLIClientWithRevision` always uses `v1x21`.

--- a/modules/110-istio/images/istioctl-v1x21x6/werf.inc.yaml
+++ b/modules/110-istio/images/istioctl-v1x21x6/werf.inc.yaml
@@ -28,6 +28,7 @@ shell:
   install:
   - cd /src/istio/
   - git apply --verbose /patches/001-deckhouse-default-istio-namespace.patch
+  - git apply --verbose /patches/002-deckhouse-default-istio-revision.patch
   - echo {{ $istioVersion }} > version
   - export VERSION={{ $istioVersion }}
   - export BUILDINFO=$(mktemp)

--- a/modules/110-istio/images/istioctl-v1x25x2/patches/002-deckhouse-default-istio-revision.patch
+++ b/modules/110-istio/images/istioctl-v1x25x2/patches/002-deckhouse-default-istio-revision.patch
@@ -1,0 +1,32 @@
+diff --git a/istioctl/pkg/cli/context.go b/istioctl/pkg/cli/context.go
+index aaedf8a..cbeb615 100644
+--- a/istioctl/pkg/cli/context.go
++++ b/istioctl/pkg/cli/context.go
+@@ -100,6 +100,7 @@ func (i *instance) getImpersonateConfig() rest.ImpersonationConfig {
+ }
+ 
+ func (i *instance) CLIClientWithRevision(rev string) (kube.CLIClient, error) {
++	rev = "v1x25"
+ 	if i.clients == nil {
+ 		i.clients = make(map[string]kube.CLIClient)
+ 	}
+diff --git a/istioctl/pkg/clioptions/control_plane.go b/istioctl/pkg/clioptions/control_plane.go
+index 0ca06f2..c10e691 100644
+--- a/istioctl/pkg/clioptions/control_plane.go
++++ b/istioctl/pkg/clioptions/control_plane.go
+@@ -25,6 +25,14 @@ type ControlPlaneOptions struct {
+ // AttachControlPlaneFlags attaches control-plane flags to a Cobra command.
+ // (Currently just --revision)
+ func (o *ControlPlaneOptions) AttachControlPlaneFlags(cmd *cobra.Command) {
+-	cmd.PersistentFlags().StringVarP(&o.Revision, "revision", "r", "",
++	cmd.PersistentFlags().StringVarP(&o.Revision, "revision", "r", "v1x25",
+ 		"Control plane revision")
++	prevPreRun := cmd.PersistentPreRunE
++	cmd.PersistentPreRunE = func(c *cobra.Command, args []string) error {
++		o.Revision = "v1x25"
++		if prevPreRun != nil {
++			return prevPreRun(c, args)
++		}
++		return nil
++	}
+ }

--- a/modules/110-istio/images/istioctl-v1x25x2/patches/README.md
+++ b/modules/110-istio/images/istioctl-v1x25x2/patches/README.md
@@ -3,3 +3,11 @@
 ## 001-deckhouse-default-istio-namespace.patch
 
 Set `constants.IstioSystemNamespace` to the Deckhouse Istio namespace (`d8-istio`).
+
+## 002-deckhouse-default-istio-revision.patch
+
+Force the Deckhouse control-plane revision of this image (`v1x25`) for istioctl commands that talk to the control plane:
+
+- default value of `--revision` / `-r`;
+- user-provided `--revision` is overridden in `PersistentPreRunE`;
+- `CLIClientWithRevision` always uses `v1x25`.

--- a/modules/110-istio/images/istioctl-v1x25x2/werf.inc.yaml
+++ b/modules/110-istio/images/istioctl-v1x25x2/werf.inc.yaml
@@ -28,6 +28,7 @@ shell:
   install:
   - cd /src/istio/
   - git apply --verbose /patches/001-deckhouse-default-istio-namespace.patch
+  - git apply --verbose /patches/002-deckhouse-default-istio-revision.patch
   - echo {{ $istioVersion }} > version
   - export VERSION={{ $istioVersion }}
   - export BUILDINFO=$(mktemp)

--- a/modules/110-istio/images/istioctl-v1x27x9/patches/002-deckhouse-default-istio-revision.patch
+++ b/modules/110-istio/images/istioctl-v1x27x9/patches/002-deckhouse-default-istio-revision.patch
@@ -1,0 +1,32 @@
+diff --git a/istioctl/pkg/cli/context.go b/istioctl/pkg/cli/context.go
+index 2572e3a..5e5d910 100644
+--- a/istioctl/pkg/cli/context.go
++++ b/istioctl/pkg/cli/context.go
+@@ -113,6 +113,7 @@ func (i *instance) getImpersonateConfig() rest.ImpersonationConfig {
+ }
+ 
+ func (i *instance) CLIClientWithRevision(rev string) (kube.CLIClient, error) {
++	rev = "v1x27"
+ 	if i.clients == nil {
+ 		i.clients = make(map[string]kube.CLIClient)
+ 	}
+diff --git a/istioctl/pkg/clioptions/control_plane.go b/istioctl/pkg/clioptions/control_plane.go
+index 0ca06f2..c18d791 100644
+--- a/istioctl/pkg/clioptions/control_plane.go
++++ b/istioctl/pkg/clioptions/control_plane.go
+@@ -25,6 +25,14 @@ type ControlPlaneOptions struct {
+ // AttachControlPlaneFlags attaches control-plane flags to a Cobra command.
+ // (Currently just --revision)
+ func (o *ControlPlaneOptions) AttachControlPlaneFlags(cmd *cobra.Command) {
+-	cmd.PersistentFlags().StringVarP(&o.Revision, "revision", "r", "",
++	cmd.PersistentFlags().StringVarP(&o.Revision, "revision", "r", "v1x27",
+ 		"Control plane revision")
++	prevPreRun := cmd.PersistentPreRunE
++	cmd.PersistentPreRunE = func(c *cobra.Command, args []string) error {
++		o.Revision = "v1x27"
++		if prevPreRun != nil {
++			return prevPreRun(c, args)
++		}
++		return nil
++	}
+ }

--- a/modules/110-istio/images/istioctl-v1x27x9/patches/README.md
+++ b/modules/110-istio/images/istioctl-v1x27x9/patches/README.md
@@ -3,3 +3,11 @@
 ## 001-deckhouse-default-istio-namespace.patch
 
 Set `constants.IstioSystemNamespace` to the Deckhouse Istio namespace (`d8-istio`).
+
+## 002-deckhouse-default-istio-revision.patch
+
+Force the Deckhouse control-plane revision of this image (`v1x27`) for istioctl commands that talk to the control plane:
+
+- default value of `--revision` / `-r`;
+- user-provided `--revision` is overridden in `PersistentPreRunE`;
+- `CLIClientWithRevision` always uses `v1x27`.

--- a/modules/110-istio/images/istioctl-v1x27x9/werf.inc.yaml
+++ b/modules/110-istio/images/istioctl-v1x27x9/werf.inc.yaml
@@ -29,6 +29,7 @@ shell:
   install:
   - cd /src/istio/
   - git apply --verbose /patches/001-deckhouse-default-istio-namespace.patch
+  - git apply --verbose /patches/002-deckhouse-default-istio-revision.patch
   - echo {{ $istioVersion }} > version
   - export VERSION={{ $istioVersion }}
   - export BUILDINFO=$(mktemp)

--- a/modules/110-istio/images/istioctl-v1x29x6/patches/002-deckhouse-default-istio-revision.patch
+++ b/modules/110-istio/images/istioctl-v1x29x6/patches/002-deckhouse-default-istio-revision.patch
@@ -1,8 +1,16 @@
 diff --git a/istioctl/pkg/cli/context.go b/istioctl/pkg/cli/context.go
-index 709b88e..a760318 100644
+index 709b88e..6b2a996 100644
 --- a/istioctl/pkg/cli/context.go
 +++ b/istioctl/pkg/cli/context.go
-@@ -119,6 +119,7 @@ func (i *instance) getImpersonateConfig() rest.ImpersonationConfig {
+@@ -26,7 +26,6 @@ import (
+ 	"istio.io/istio/istioctl/pkg/util/handlers"
+ 	"istio.io/istio/pkg/cluster"
+ 	"istio.io/istio/pkg/kube"
+-	"istio.io/istio/pkg/log"
+ 	"istio.io/istio/pkg/maps"
+ 	"istio.io/istio/pkg/ptr"
+ 	"istio.io/istio/pkg/revisions"
+@@ -119,6 +118,7 @@ func (i *instance) getImpersonateConfig() rest.ImpersonationConfig {
  }
  
  func (i *instance) CLIClientWithRevision(rev string) (kube.CLIClient, error) {
@@ -10,7 +18,7 @@ index 709b88e..a760318 100644
  	if i.clients == nil {
  		i.clients = make(map[string]kube.CLIClient)
  	}
-@@ -210,33 +211,7 @@ func handleNamespace(ns, defaultNamespace string) string {
+@@ -210,33 +210,7 @@ func handleNamespace(ns, defaultNamespace string) string {
  }
  
  func (i *instance) RevisionOrDefault(rev string) string {

--- a/modules/110-istio/images/istioctl-v1x29x6/patches/002-deckhouse-default-istio-revision.patch
+++ b/modules/110-istio/images/istioctl-v1x29x6/patches/002-deckhouse-default-istio-revision.patch
@@ -1,0 +1,67 @@
+diff --git a/istioctl/pkg/cli/context.go b/istioctl/pkg/cli/context.go
+index 709b88e..a760318 100644
+--- a/istioctl/pkg/cli/context.go
++++ b/istioctl/pkg/cli/context.go
+@@ -119,6 +119,7 @@ func (i *instance) getImpersonateConfig() rest.ImpersonationConfig {
+ }
+ 
+ func (i *instance) CLIClientWithRevision(rev string) (kube.CLIClient, error) {
++	rev = "v1x29"
+ 	if i.clients == nil {
+ 		i.clients = make(map[string]kube.CLIClient)
+ 	}
+@@ -210,33 +211,7 @@ func handleNamespace(ns, defaultNamespace string) string {
+ }
+ 
+ func (i *instance) RevisionOrDefault(rev string) string {
+-	if rev != "" {
+-		return rev
+-	}
+-
+-	// Try to get the default revision from the default watcher
+-	// We create a simple approach that doesn't cause circular dependencies
+-
+-	stop := make(chan struct{})
+-	defer close(stop)
+-	if i.defaultWatcher == nil {
+-		// Try to initialize the default watcher using a basic client
+-		if basicClient := i.getBasicClientForDefaultWatcher(); basicClient != nil {
+-			i.defaultWatcher = revisions.NewDefaultWatcher(basicClient, "")
+-			basicClient.RunAndWait(stop)
+-			go i.defaultWatcher.Run(stop)
+-			kube.WaitForCacheSync("default revision watcher", stop, i.defaultWatcher.HasSynced)
+-		}
+-	}
+-
+-	if i.defaultWatcher != nil {
+-		if defaultRev := i.defaultWatcher.GetDefault(); defaultRev != "" {
+-			return defaultRev
+-		}
+-		log.Debug("default revision watcher not synced, falling back to \"default\"")
+-	}
+-
+-	return "default"
++	return "v1x29"
+ }
+ 
+ // getBasicClientForDefaultWatcher creates a basic kube client just for watching default revisions
+diff --git a/istioctl/pkg/clioptions/control_plane.go b/istioctl/pkg/clioptions/control_plane.go
+index 0ca06f2..0b3c12f 100644
+--- a/istioctl/pkg/clioptions/control_plane.go
++++ b/istioctl/pkg/clioptions/control_plane.go
+@@ -25,6 +25,14 @@ type ControlPlaneOptions struct {
+ // AttachControlPlaneFlags attaches control-plane flags to a Cobra command.
+ // (Currently just --revision)
+ func (o *ControlPlaneOptions) AttachControlPlaneFlags(cmd *cobra.Command) {
+-	cmd.PersistentFlags().StringVarP(&o.Revision, "revision", "r", "",
++	cmd.PersistentFlags().StringVarP(&o.Revision, "revision", "r", "v1x29",
+ 		"Control plane revision")
++	prevPreRun := cmd.PersistentPreRunE
++	cmd.PersistentPreRunE = func(c *cobra.Command, args []string) error {
++		o.Revision = "v1x29"
++		if prevPreRun != nil {
++			return prevPreRun(c, args)
++		}
++		return nil
++	}
+ }

--- a/modules/110-istio/images/istioctl-v1x29x6/patches/README.md
+++ b/modules/110-istio/images/istioctl-v1x29x6/patches/README.md
@@ -3,3 +3,12 @@
 ## 001-deckhouse-default-istio-namespace.patch
 
 Set `constants.IstioSystemNamespace` to the Deckhouse Istio namespace (`d8-istio`).
+
+## 002-deckhouse-default-istio-revision.patch
+
+Force the Deckhouse control-plane revision of this image (`v1x29`) for istioctl commands that talk to the control plane:
+
+- default value of `--revision` / `-r`;
+- user-provided `--revision` is overridden in `PersistentPreRunE`;
+- `CLIClientWithRevision` always uses `v1x29`;
+- `RevisionOrDefault` always returns `v1x29` (ignores revision tags and user input).

--- a/modules/110-istio/images/istioctl-v1x29x6/werf.inc.yaml
+++ b/modules/110-istio/images/istioctl-v1x29x6/werf.inc.yaml
@@ -29,6 +29,7 @@ shell:
   install:
   - cd /src/istio/
   - git apply --verbose /patches/001-deckhouse-default-istio-namespace.patch
+  - git apply --verbose /patches/002-deckhouse-default-istio-revision.patch
   - echo {{ $istioVersion }} > version
   - export VERSION={{ $istioVersion }}
   - export BUILDINFO=$(mktemp)


### PR DESCRIPTION
## Description

Patched Deckhouse `istioctl` to force Deckhouse-specific defaults for control plane revision. For control plane lookup commands, `istioctl` now uses the image revision even if the user passes a different `--revision`.

**Examples**
```bash
# all of these behave the same for istioctl-1.29 and work like --revision was always set v1x29:
istioctl-1.29 version
istioctl-1.29 version --revision v1x21
istioctl-1.29 version --revision default
```
```
# proxy-status also uses only the binary revision
istioctl-1.21 proxy-status   # looks at v1x21 only
istioctl-1.29 proxy-status   # looks at v1x29 only
```

List of affected commands:
```
version / x version
proxy-status (ps)
remote-clusters
admin log
dashboard controlz
dashboard istiod-debug
x internal-debug
kube-inject
precheck
x workload entry configure
``` 

## Why do we need it, and what problem does it solve?

It fixes failures in commands like `version` and `proxy-status` without requiring users to manually pick the correct revision.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: chore
summary: istioctl now always uses the revision associated with the binary
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
