### PR TITLE
[deckhouse-controller] delete module documentation when module is disable

### DIFF
--- a/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
@@ -319,6 +319,12 @@ func (r *reconciler) processModule(ctx context.Context, moduleConfig *v1alpha1.M
 			r.logger.Error("failed to enable the module", slog.String("module", module.Name), log.Err(err))
 			return ctrl.Result{}, err
 		}
+
+		// restore documentation for the re-enabled module from its deployed release
+		if err := r.ensureModuleDocumentation(ctx, module); err != nil {
+			r.logger.Error("failed to ensure module documentation", slog.String("module", module.Name), log.Err(err))
+			return ctrl.Result{}, err
+		}
 	}
 
 	if module.IsExperimental() {
@@ -523,6 +529,12 @@ func (r *reconciler) removeFinalizer(ctx context.Context, config *v1alpha1.Modul
 
 func (r *reconciler) disableModule(ctx context.Context, module *v1alpha1.Module) error {
 	r.logger.Debug("disable the module", slog.String("module", module.Name))
+
+	// remove module documentation immediately on disable so docs-builder drops it
+	if err := utils.DeleteModuleDocumentation(ctx, r.client, module.Name); err != nil {
+		return fmt.Errorf("delete module documentation: %w", err)
+	}
+
 	return utils.UpdateStatus[*v1alpha1.Module](ctx, r.client, module, func(module *v1alpha1.Module) bool {
 		if module.IsCondition(v1alpha1.ModuleConditionEnabledByModuleConfig, corev1.ConditionFalse) {
 			return false
@@ -560,4 +572,22 @@ func (r *reconciler) enableModule(ctx context.Context, module *v1alpha1.Module) 
 
 		return true
 	})
+}
+
+func (r *reconciler) ensureModuleDocumentation(ctx context.Context, module *v1alpha1.Module) error {
+	releases := new(v1alpha1.ModuleReleaseList)
+	if err := r.client.List(ctx, releases, client.MatchingLabels{
+		v1alpha1.ModuleReleaseLabelModule: module.Name,
+		v1alpha1.ModuleReleaseLabelStatus: v1alpha1.ModuleReleaseLabelDeployed,
+	}); err != nil {
+		return fmt.Errorf("list module releases: %w", err)
+	}
+
+	for i := range releases.Items {
+		if err := utils.EnsureModuleDocumentationForRelease(ctx, r.client, &releases.Items[i]); err != nil {
+			return fmt.Errorf("ensure module documentation: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -16,7 +16,6 @@ package release
 
 import (
 	"context"
-	"crypto/md5"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -36,6 +35,7 @@ import (
 	addonutils "github.com/flant/addon-operator/pkg/utils"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -627,15 +627,6 @@ func (r *reconciler) handleDeployedRelease(ctx context.Context, release *v1alpha
 		return res, nil
 	}
 
-	// Use mount point path: /modules/<module> (modules are mounted at /deckhouse/downloaded/modules/<module>)
-	modulePath := fmt.Sprintf("/modules/%s", release.GetModuleName())
-	moduleVersion := "v" + release.GetVersion().String()
-
-	moduleChecksum := release.Labels[v1alpha1.ModuleReleaseLabelReleaseChecksum]
-	if moduleChecksum == "" {
-		moduleChecksum = fmt.Sprintf("%x", md5.Sum([]byte(moduleVersion)))
-	}
-
 	ownerRef := metav1.OwnerReference{
 		APIVersion: v1alpha1.ModuleReleaseGVK.GroupVersion().String(),
 		Kind:       v1alpha1.ModuleReleaseGVK.Kind,
@@ -644,9 +635,17 @@ func (r *reconciler) handleDeployedRelease(ctx context.Context, release *v1alpha
 		Controller: ptr.To(true),
 	}
 
-	if !r.installer.IsEmbeddedPresent(release.GetModuleName()) {
-		// mpo not found and module is not embedded - update the docs from the module release version
-		if err := utils.EnsureModuleDocumentation(ctx, r.client, release.GetModuleName(), release.GetModuleSource(), moduleChecksum, moduleVersion, modulePath, ownerRef); err != nil {
+	// do not (re)create documentation for a module disabled by config
+	module := new(v1alpha1.Module)
+	if err = r.client.Get(ctx, client.ObjectKey{Name: release.GetModuleName()}, module); err != nil {
+		r.log.Error("failed to get module", slog.String("module", release.GetModuleName()), log.Err(err))
+
+		return res, fmt.Errorf("get module: %w", err)
+	}
+
+	// ensure documentation only for a module enabled by config and not served by an embedded copy
+	if module.IsCondition(v1alpha1.ModuleConditionEnabledByModuleConfig, corev1.ConditionTrue) && !r.installer.IsEmbeddedPresent(release.GetModuleName()) {
+		if err = utils.EnsureModuleDocumentationForRelease(ctx, r.client, release); err != nil {
 			r.log.Error("failed to ensure module documentation", slog.String("module", release.GetModuleName()), log.Err(err))
 
 			return res, fmt.Errorf("ensure module documentation: %w", err)

--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -635,7 +635,7 @@ func (r *reconciler) handleDeployedRelease(ctx context.Context, release *v1alpha
 		Controller: ptr.To(true),
 	}
 
-	// do not (re)create documentation for a module disabled by config
+	// do not (re)create documentation for a disabled module
 	module := new(v1alpha1.Module)
 	if err = r.client.Get(ctx, client.ObjectKey{Name: release.GetModuleName()}, module); err != nil {
 		r.log.Error("failed to get module", slog.String("module", release.GetModuleName()), log.Err(err))
@@ -643,8 +643,12 @@ func (r *reconciler) handleDeployedRelease(ctx context.Context, release *v1alpha
 		return res, fmt.Errorf("get module: %w", err)
 	}
 
-	// ensure documentation only for a module enabled by config and not served by an embedded copy
-	if module.IsCondition(v1alpha1.ModuleConditionEnabledByModuleConfig, corev1.ConditionTrue) && !r.installer.IsEmbeddedPresent(release.GetModuleName()) {
+	// ensure documentation for any enabled module, regardless of how it is enabled
+	// (by module config, by bundle or by an enabled script) - EnabledByModuleManager
+	// reflects the effective enabled state, unlike EnabledByModuleConfig which is only
+	// set for modules enabled explicitly via a ModuleConfig; a module still served by
+	// its embedded copy is skipped, its documentation ships with the Deckhouse image
+	if module.IsCondition(v1alpha1.ModuleConditionEnabledByModuleManager, corev1.ConditionTrue) && !r.installer.IsEmbeddedPresent(release.GetModuleName()) {
 		if err = utils.EnsureModuleDocumentationForRelease(ctx, r.client, release); err != nil {
 			r.log.Error("failed to ensure module documentation", slog.String("module", release.GetModuleName()), log.Err(err))
 

--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -646,10 +646,22 @@ func (r *reconciler) handleDeployedRelease(ctx context.Context, release *v1alpha
 	// ensure documentation for any enabled module, regardless of how it is enabled
 	// (by module config, by bundle or by an enabled script) - EnabledByModuleManager
 	// reflects the effective enabled state, unlike EnabledByModuleConfig which is only
-	// set for modules enabled explicitly via a ModuleConfig; a module still served by
-	// its embedded copy is skipped, its documentation ships with the Deckhouse image
-	if module.IsCondition(v1alpha1.ModuleConditionEnabledByModuleManager, corev1.ConditionTrue) && !r.installer.IsEmbeddedPresent(release.GetModuleName()) {
-		if err = utils.EnsureModuleDocumentationForRelease(ctx, r.client, release); err != nil {
+	// set for modules enabled explicitly via a ModuleConfig
+	if module.IsCondition(v1alpha1.ModuleConditionEnabledByModuleManager, corev1.ConditionTrue) {
+		if r.installer.IsEmbeddedPresent(release.GetModuleName()) {
+			// The embedded copy serves the module, so the release is only staged and the
+			// /modules/<name> mount a ModuleDocumentation points at is never created, while
+			// the docs of the running (embedded) version ship with the documentation image.
+			// A ModuleDocumentation left over from a Deckhouse that predates this guard makes
+			// the docbuilder stat a path that cannot appear until the embedded copy is dropped
+			// on upgrade, and retry it forever, so delete it. The branch below recreates it
+			// once the module is activated.
+			if err = utils.DeleteModuleDocumentation(ctx, r.client, release.GetModuleName()); err != nil {
+				r.log.Error("failed to delete stale module documentation", slog.String("module", release.GetModuleName()), log.Err(err))
+
+				return res, fmt.Errorf("delete stale module documentation: %w", err)
+			}
+		} else if err = utils.EnsureModuleDocumentationForRelease(ctx, r.client, release); err != nil {
 			r.log.Error("failed to ensure module documentation", slog.String("module", release.GetModuleName()), log.Err(err))
 
 			return res, fmt.Errorf("ensure module documentation: %w", err)

--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller_test.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller_test.go
@@ -236,6 +236,28 @@ func (suite *ReleaseControllerTestSuite) TestCreateReconcile() {
 		assert.True(suite.T(), apierrors.IsNotFound(err), "documentation must not be created for an embedded module")
 	})
 
+	// The module is served by its embedded copy, but a ModuleDocumentation created by
+	// an older Deckhouse (before documentation was skipped for embedded modules) is
+	// still around. It points at a mount that is never created for a staged release,
+	// so the docbuilder would retry it forever - it must be deleted.
+	suite.Run("stale module documentation deleted for embedded module", func() {
+		suite.setupReleaseController(
+			suite.fetchTestFileData("module-documentation-stale-embedded.yaml"),
+			withInstaller(&installermock.Installer{
+				IsEmbeddedPresentFunc: func(string) bool { return true },
+			}),
+		)
+
+		repeatTest(func() {
+			mr := suite.getModuleRelease(suite.testMRName)
+			_, err = suite.ctr.handleRelease(context.TODO(), mr)
+			require.NoError(suite.T(), err)
+		})
+
+		err = suite.client.Get(context.TODO(), client.ObjectKey{Name: "parca"}, new(v1alpha1.ModuleDocumentation))
+		assert.True(suite.T(), apierrors.IsNotFound(err), "stale documentation must be deleted for an embedded module")
+	})
+
 	// The module was still embedded but its embedded copy is no longer on disk
 	// (IsEmbeddedPresent == false), so the release is activated (Install) and the
 	// active source is switched off the "Embedded" sentinel to the real source.

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/module-documentation-create.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/module-documentation-create.yaml
@@ -69,6 +69,14 @@ metadata:
 properties: {}
 status:
   conditions:
+  - lastProbeTime: null
+    lastTransitionTime: null
+    status: "True"
+    type: EnabledByModuleConfig
+  - lastProbeTime: null
+    lastTransitionTime: null
+    status: "True"
+    type: EnabledByModuleManager
   - lastProbeTime: "2019-10-17T15:33:00Z"
     lastTransitionTime: "2019-10-17T15:33:00Z"
     status: "True"

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/module-documentation-embedded.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/module-documentation-embedded.yaml
@@ -70,6 +70,14 @@ properties:
   source: Embedded
 status:
   conditions:
+  - lastProbeTime: null
+    lastTransitionTime: null
+    status: "True"
+    type: EnabledByModuleConfig
+  - lastProbeTime: null
+    lastTransitionTime: null
+    status: "True"
+    type: EnabledByModuleManager
   - lastProbeTime: "2019-10-17T15:33:00Z"
     lastTransitionTime: "2019-10-17T15:33:00Z"
     status: "True"

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/module-documentation-stale-embedded.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/module-documentation-stale-embedded.yaml
@@ -1,0 +1,77 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  annotations:
+    modules.deckhouse.io/registry-spec-checksum: 38557e472e4e2bd8695fc58a255ec3dd
+  finalizers:
+  - modules.deckhouse.io/release-exists
+  name: foxtrot
+  resourceVersion: "999"
+spec:
+  registry:
+    dockerCfg: YXNiCg==
+    repo: dev-registry.deckhouse.io/team/foxtrot/modules
+    scheme: HTTPS
+status:
+  modules:
+  - name: parca
+    policy: foxtrot-alpha
+  modulesCount: 1
+  syncTime: "2024-05-03T21:05:05Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleRelease
+metadata:
+  annotations:
+    modules.deckhouse.io/isUpdating: "false"
+    modules.deckhouse.io/notified: "true"
+  finalizers:
+  - modules.deckhouse.io/metrics-registered
+  - modules.deckhouse.io/exist-on-fs
+  labels:
+    module: parca
+    modules.deckhouse.io/update-policy: foxtrot-alpha
+    release-checksum: 98d00f741c99e06e6c6c4d18b763c550
+    source: foxtrot
+    status: deployed
+  name: parca-v1.4.3
+  ownerReferences:
+  - apiVersion: deckhouse.io/v1alpha1
+    controller: true
+    kind: ModuleSource
+    name: foxtrot
+    uid: 71d2300f-700b-452a-896a-6a3805f9cef7
+  resourceVersion: "1003"
+spec:
+  moduleName: parca
+  version: 1.4.3
+  weight: 900
+status:
+  approved: false
+  phase: Deployed
+  pullDuration: 0s
+  transitionTime: "2024-05-03T20:55:49Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: Module
+metadata:
+  name: parca
+  resourceVersion: "1000"
+properties:
+  source: Embedded
+status:
+  conditions:
+  - lastProbeTime: null
+    lastTransitionTime: null
+    status: "True"
+    type: EnabledByModuleConfig
+  - lastProbeTime: null
+    lastTransitionTime: null
+    status: "True"
+    type: EnabledByModuleManager
+  - lastProbeTime: "2019-10-17T15:33:00Z"
+    lastTransitionTime: "2019-10-17T15:33:00Z"
+    status: "True"
+    type: LastReleaseDeployed
+  phase: Ready

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/module-documentation-stale-embedded.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/module-documentation-stale-embedded.yaml
@@ -4,20 +4,24 @@ kind: ModuleSource
 metadata:
   annotations:
     modules.deckhouse.io/registry-spec-checksum: 38557e472e4e2bd8695fc58a255ec3dd
+  creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/release-exists
   name: foxtrot
   resourceVersion: "999"
 spec:
   registry:
+    ca: ""
     dockerCfg: YXNiCg==
     repo: dev-registry.deckhouse.io/team/foxtrot/modules
     scheme: HTTPS
 status:
+  message: ""
   modules:
   - name: parca
     policy: foxtrot-alpha
   modulesCount: 1
+  phase: ""
   syncTime: "2024-05-03T21:05:05Z"
 ---
 apiVersion: deckhouse.io/v1alpha1
@@ -26,6 +30,7 @@ metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "false"
     modules.deckhouse.io/notified: "true"
+  creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/metrics-registered
   - modules.deckhouse.io/exist-on-fs
@@ -49,13 +54,16 @@ spec:
   weight: 900
 status:
   approved: false
+  message: ""
   phase: Deployed
   pullDuration: 0s
+  size: 0
   transitionTime: "2024-05-03T20:55:49Z"
 ---
 apiVersion: deckhouse.io/v1alpha1
 kind: Module
 metadata:
+  creationTimestamp: null
   name: parca
   resourceVersion: "1000"
 properties:

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/module-documentation-update.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/module-documentation-update.yaml
@@ -69,6 +69,14 @@ metadata:
 properties: {}
 status:
   conditions:
+  - lastProbeTime: null
+    lastTransitionTime: null
+    status: "True"
+    type: EnabledByModuleConfig
+  - lastProbeTime: null
+    lastTransitionTime: null
+    status: "True"
+    type: EnabledByModuleManager
   - lastProbeTime: "2019-10-17T15:33:00Z"
     lastTransitionTime: "2019-10-17T15:33:00Z"
     status: "True"

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/module-documentation-create.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/module-documentation-create.yaml
@@ -63,3 +63,8 @@ metadata:
   name: parca
 status:
   phase: Ready
+  conditions:
+    - type: EnabledByModuleConfig
+      status: "True"
+    - type: EnabledByModuleManager
+      status: "True"

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/module-documentation-embedded.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/module-documentation-embedded.yaml
@@ -65,3 +65,8 @@ properties:
   source: Embedded
 status:
   phase: Ready
+  conditions:
+    - type: EnabledByModuleConfig
+      status: "True"
+    - type: EnabledByModuleManager
+      status: "True"

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/module-documentation-stale-embedded.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/module-documentation-stale-embedded.yaml
@@ -1,0 +1,89 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  annotations:
+    modules.deckhouse.io/registry-spec-checksum: 38557e472e4e2bd8695fc58a255ec3dd
+  finalizers:
+    - modules.deckhouse.io/release-exists
+  name: foxtrot
+spec:
+  registry:
+    ca: ""
+    dockerCfg: YXNiCg==
+    repo: dev-registry.deckhouse.io/team/foxtrot/modules
+    scheme: HTTPS
+status:
+  message: ""
+  modules:
+    - name: parca
+      policy: foxtrot-alpha
+  modulesCount: 1
+  syncTime: "2024-05-03T21:05:05Z"
+---
+apiVersion: deckhouse.io/v1alpha2
+kind: ModuleUpdatePolicy
+metadata:
+  name: foxtrot-alpha
+spec:
+  releaseChannel: Alpha
+  update:
+    mode: Auto
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleRelease
+metadata:
+  labels:
+    module: parca
+    modules.deckhouse.io/update-policy: foxtrot-alpha
+    release-checksum: 98d00f741c99e06e6c6c4d18b763c550
+    source: foxtrot
+  name: parca-v1.4.3
+  ownerReferences:
+    - apiVersion: deckhouse.io/v1alpha1
+      controller: true
+      kind: ModuleSource
+      name: foxtrot
+      uid: 71d2300f-700b-452a-896a-6a3805f9cef7
+spec:
+  moduleName: parca
+  version: 1.4.3
+  weight: 900
+status:
+  approved: false
+  message: ""
+  phase: Pending
+  pullDuration: 0s
+  size: 0
+  transitionTime: "2024-05-03T20:55:49Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: Module
+metadata:
+  name: parca
+properties:
+  source: Embedded
+status:
+  phase: Ready
+  conditions:
+    - type: EnabledByModuleConfig
+      status: "True"
+    - type: EnabledByModuleManager
+      status: "True"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleDocumentation
+metadata:
+  labels:
+    module: parca
+    source: foxtrot
+  name: parca
+  ownerReferences:
+    - apiVersion: deckhouse.io/v1alpha1
+      controller: true
+      kind: ModuleRelease
+      name: parca-v1.4.2
+spec:
+  checksum: 0b95d0f1c9b3d6f2b0e5f5b4a3c2d1e0
+  path: /modules/parca
+  version: v1.4.2

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/module-documentation-update.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/module-documentation-update.yaml
@@ -62,6 +62,11 @@ kind: Module
 metadata:
   name: parca
 status:
+  conditions:
+    - type: EnabledByModuleConfig
+      status: "True"
+    - type: EnabledByModuleManager
+      status: "True"
   phase: Ready
 ---
 apiVersion: deckhouse.io/v1alpha1

--- a/deckhouse-controller/pkg/controller/module-controllers/utils/utils.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/utils/utils.go
@@ -16,6 +16,7 @@ package utils //nolint:revive
 
 import (
 	"context"
+	"crypto/md5"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -29,6 +30,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
@@ -316,6 +318,43 @@ func EnsureModuleDocumentation(
 	}
 
 	return nil
+}
+
+// DeleteModuleDocumentation deletes module documentation, ignoring NotFound
+func DeleteModuleDocumentation(ctx context.Context, cli client.Client, moduleName string) error {
+	md := &v1alpha1.ModuleDocumentation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: moduleName,
+		},
+	}
+
+	if err := cli.Delete(ctx, md); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("delete the '%s' module documentation: %w", moduleName, err)
+	}
+
+	return nil
+}
+
+// EnsureModuleDocumentationForRelease ensures module documentation from a deployed release
+func EnsureModuleDocumentationForRelease(ctx context.Context, cli client.Client, release *v1alpha1.ModuleRelease) error {
+	// mount point path: /modules/<module>
+	modulePath := fmt.Sprintf("/modules/%s", release.GetModuleName())
+	moduleVersion := "v" + release.GetVersion().String()
+
+	moduleChecksum := release.Labels[v1alpha1.ModuleReleaseLabelReleaseChecksum]
+	if moduleChecksum == "" {
+		moduleChecksum = fmt.Sprintf("%x", md5.Sum([]byte(moduleVersion)))
+	}
+
+	ownerRef := metav1.OwnerReference{
+		APIVersion: v1alpha1.ModuleReleaseGVK.GroupVersion().String(),
+		Kind:       v1alpha1.ModuleReleaseGVK.Kind,
+		Name:       release.GetName(),
+		UID:        release.GetUID(),
+		Controller: ptr.To(true),
+	}
+
+	return EnsureModuleDocumentation(ctx, cli, release.GetModuleName(), release.GetModuleSource(), moduleChecksum, moduleVersion, modulePath, ownerRef)
 }
 
 // GetNotificationConfig gets config from discovery secret


### PR DESCRIPTION
## Description

Fixes a bug where a module's documentation was **not removed when the module was disabled**: the `ModuleDocumentation` resource (and the docs served by docs-builder, visible in the web UI) stayed in the cluster and even survived controller restarts, although the module was off.

Root cause: nothing deleted the documentation on disable, and the release controller actively brought it back — it `Owns` `ModuleDocumentation`, so removing the resource instantly triggered an owner reconcile that recreated it. The "check" that should have prevented this was missing.

Fix, all in `deckhouse-controller`:
- **config controller** — deletes the module's `ModuleDocumentation` on disable (docs-builder then drops the rendered docs via its finalizer);
- **release controller** — no longer recreates `ModuleDocumentation` for a module disabled by config (the missing check: ensure docs only for an enabled module);
- **config controller** — restores `ModuleDocumentation` on re-enable, so disable/enable round-trips correctly.


## Why do we need it, and what problem does it solve?

A disabled module kept its documentation published in the cluster (web UI) and it persisted across controller restarts — misleading, since a disabled module shouldn't keep serving docs. The fix makes documentation follow the module's enabled state: removed on disable, back on enable.


### Manual test (cluster) — `console` module

```console
# disable → documentation deleted
$ dcmd console
Module console disabled
$ k get moduledocumentation console
Error from server (NotFound): moduledocumentations.deckhouse.io "console" not found

# restart while disabled → still gone
$ restartdc && k -n d8-system rollout status deployment deckhouse
deployment "deckhouse" successfully rolled out
$ k get moduledocumentation console
Error from server (NotFound): moduledocumentations.deckhouse.io "console" not found

# re-enable → restored (already back before the module finishes installing)
$ dcme console
Module console enabled
$ k get module console
NAME      STAGE                  SOURCE      PHASE        ENABLED   READY
console   General Availability   deckhouse   Downloaded   False     False
$ k get moduledocumentation console
NAME      RESULT
console   Rendered
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix 
summary: Deleted module documentation when a module is disabled.
impact_level: default
```

