### PR TITLE
[network-gateway] Fixed user and group in ConfigMap

### DIFF
--- a/ee/modules/450-network-gateway/templates/configmap.yaml
+++ b/ee/modules/450-network-gateway/templates/configmap.yaml
@@ -9,6 +9,8 @@ data:
   config.json: |
     {{- .Values.networkGateway | toJson | nindent 4 }}
   dnsmasq.conf: |
+    user=deckhouse
+    group=deckhouse
     expand-hosts
     localise-queries
     conf-dir=/etc/dnsmasq.conf.d,.rpmnew,.rpmsave,.rpmorig


### PR DESCRIPTION
## Description
This PR fixed user and group in ConfigMap

## Why do we need it, and what problem does it solve?
This PR fixed user and group in ConfigMap for repair error `dnsmasq: unknown user or group: nonroot`

## Why do we need it in the patch release (if we do)?
This fix is required in the patch release because the incorrect configuration prevents `dnsmasq` from starting, which can make the affected functionality unavailable.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: network-gateway
type: fix
summary: Fixed user and group in ConfigMap
impact_level: default
impact: network-gateway pod's will be restarted
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
