### PR TITLE
[ingress-nginx] fixed build if update base-images

### DIFF
--- a/modules/402-ingress-nginx/images/controller-1-12/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-12/werf.inc.yaml
@@ -942,6 +942,10 @@ import:
   - usr/bin/cp
   - usr/bin/tail
   before: install
+- image: tools/coreutils
+  add: /usr/bin/coreutils
+  to: /apps/rm
+  before: install
 - image: tools/libcap
   add: /usr/sbin/setcap
   to: /apps/setcap
@@ -959,6 +963,7 @@ shell:
   - /apps/setcap -v cap_net_bind_service=+ep /chroot/usr/local/nginx/sbin/nginx
   - /apps/setcap    cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/dumb-init
   - /apps/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/dumb-init
+  - /apps/rm /apps/setcap /apps/rm
 imageSpec:
   config:
     workingDir: /chroot/etc/nginx

--- a/modules/402-ingress-nginx/images/controller-1-12/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-12/werf.inc.yaml
@@ -649,14 +649,7 @@ shell:
 image: {{ $.ModuleName }}/{{ $.ImageName }}-chroot-artifact
 fromImage: builder/alpine-3.21
 final: false
-mount:
-- from: build_dir
-  to: /apps
 import:
-- image: tools/libcap
-  add: /usr/sbin/setcap
-  to: /tools/setcap
-  before: install
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-nginx-artifact
   add: /
   to: /
@@ -870,15 +863,9 @@ shell:
   - mkdir -p /chroot/modules_mount
   - mkdir -p modules_mount
   - ln -s /modules_mount /chroot/modules_mount
-
-  # Utils for final image
-  - cp -a /tools/setcap /apps
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: base/distroless
-mount:
-- from: build_dir
-  to: /apps
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-chroot-artifact
   add: /
@@ -954,6 +941,10 @@ import:
   - usr/bin/cat
   - usr/bin/cp
   - usr/bin/tail
+  before: install
+- image: tools/libcap
+  add: /usr/sbin/setcap
+  to: /apps/setcap
   before: install
 git:
 {{- include "image mount points" $ }}


### PR DESCRIPTION
## Description
The use of /apps/setcap has been reworked to be more reliable.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Updating the base images breaks the build because it can't find /apps/setcap 
```
2026-08-19T21:09:32+03:00 21:09:30 │ ┌ Building stage ingress-nginx/controller-1-12/install
2026-08-19T21:09:32+03:00 21:09:30 │ │ ingress-nginx/controller-1-12/install  /.werf/shell/script.sh: line 4: /apps/setcap: No such file or directory
2026-08-19T21:09:32+03:00 21:09:31 │ ├ Info
2026-08-19T21:09:32+03:00 21:09:31 │ └ Building stage ingress-nginx/controller-1-12/install (1.27 seconds) FAILED
2026-08-19T21:09:32+03:00 21:09:31 └ 🛳️  (890/1293) image ingress-nginx/controller-1-12 (17.98 seconds) FAILED
```
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: fix 
summary:  ingress-nginx  fixed build if update base-images
impact: 
impact_level:  low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
