### PR TITLE
[node-manager] keep MachineDeployment replicas owned by deckhouse-hook

### DIFF
--- a/modules/040-node-manager/hooks/force_machine_deployment_replicas_ownership.go
+++ b/modules/040-node-manager/hooks/force_machine_deployment_replicas_ownership.go
@@ -31,15 +31,24 @@ limitations under the License.
 // The FilterFunc keeps only MachineDeployments whose spec.replicas is still owned
 // by the legacy field manager (everything else is dropped from the snapshot by
 // returning a nil result), so the handler's snapshots contain exactly the objects
-// that must be fixed. For each of them it force-claims the field for
-// "deckhouse-hook" via server-side apply, re-applying the current value so the
-// count is unchanged. It runs OnBeforeHelm, right before nelm applies the
-// node-manager release, so ownership is migrated BEFORE the apply that would
-// otherwise prune it — that is what prevents the scale-to-zero instead of only
-// healing it afterwards. WaitForSynchronization is left at its default (true) so
-// the snapshots are populated before beforeHelm runs; both CRDs ship in
-// node-manager/crds and node-manager is critical, so they are always present and
-// the synchronization cannot stall.
+// that must be fixed. For each of them it migrates ownership to "deckhouse-hook"
+// by rewriting metadata.managedFields directly (the client-go CSA->SSA upgrade
+// primitive), which drops the legacy manager WITHOUT touching spec.replicas.
+//
+// A server-side apply cannot do this: SSA conflict detection is value-based
+// (structured-merge-diff computes conflicts as ownedFields ∩ (Modified ∪ Added)),
+// so re-applying spec.replicas at its current value adds a "deckhouse-hook" Apply
+// co-owner but never strips the legacy "deckhouse-controller" owner — nelm's
+// adopt gate then still adopts and prunes the field. Only an explicit
+// managedFields rewrite transfers ownership of an unchanged value.
+//
+// It runs OnBeforeHelm, right before nelm applies the node-manager release, so
+// ownership is migrated BEFORE the apply that would otherwise prune it — that is
+// what prevents the scale-to-zero instead of only healing it afterwards.
+// WaitForSynchronization is left at its default (true) so the snapshots are
+// populated before beforeHelm runs; both CRDs ship in node-manager/crds and
+// node-manager is critical, so they are always present and the synchronization
+// cannot stall.
 
 package hooks
 
@@ -55,7 +64,9 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	apitypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/util/csaupgrade"
 	"k8s.io/utils/ptr"
 
 	"github.com/deckhouse/deckhouse/go_lib/dependency"
@@ -121,14 +132,13 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	},
 }, dependency.WithExternalDependencies(handleForceMachineDeploymentReplicasOwnership))
 
-// machineDeploymentReplicas is the snapshot entry for a MachineDeployment that
-// still needs its spec.replicas ownership migrated. MachineDeployments that are
-// already off the legacy manager never reach the snapshot (see the filters).
-type machineDeploymentReplicas struct {
+// machineDeploymentRef is the snapshot entry for a MachineDeployment that still
+// needs its spec.replicas ownership migrated. MachineDeployments that are already
+// off the legacy manager never reach the snapshot (see the filters). Only the
+// name is carried: the migration rewrites managedFields and never reads or writes
+// the replica value.
+type machineDeploymentRef struct {
 	Name string
-	// Replicas is the current value, re-applied verbatim so claiming ownership
-	// never changes the count.
-	Replicas int32
 }
 
 func machineDeploymentReplicasOwnershipFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
@@ -144,7 +154,7 @@ func machineDeploymentReplicasOwnershipFilter(obj *unstructured.Unstructured) (g
 		return nil, err
 	}
 
-	return machineDeploymentReplicas{Name: md.Name, Replicas: md.Spec.Replicas}, nil
+	return machineDeploymentRef{Name: md.Name}, nil
 }
 
 func capiMachineDeploymentReplicasOwnershipFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
@@ -157,12 +167,7 @@ func capiMachineDeploymentReplicasOwnershipFilter(obj *unstructured.Unstructured
 		return nil, err
 	}
 
-	var replicas int32
-	if md.Spec.Replicas != nil {
-		replicas = *md.Spec.Replicas
-	}
-
-	return machineDeploymentReplicas{Name: md.Name, Replicas: replicas}, nil
+	return machineDeploymentRef{Name: md.Name}, nil
 }
 
 func handleForceMachineDeploymentReplicasOwnership(ctx context.Context, input *go_hook.HookInput, dc dependency.Container) error {
@@ -180,7 +185,7 @@ func handleForceMachineDeploymentReplicasOwnership(ctx context.Context, input *g
 }
 
 func forceReplicasOwnership(ctx context.Context, input *go_hook.HookInput, dyn dynamic.Interface, snaps []pkg.Snapshot, gvr schema.GroupVersionResource) {
-	for md, err := range sdkobjectpatch.SnapshotIter[machineDeploymentReplicas](snaps) {
+	for md, err := range sdkobjectpatch.SnapshotIter[machineDeploymentRef](snaps) {
 		if err != nil {
 			input.Logger.Warn("force replicas ownership: iterate snapshot",
 				slog.String("gvr", gvr.String()), slog.Any("error", err))
@@ -189,8 +194,8 @@ func forceReplicasOwnership(ctx context.Context, input *go_hook.HookInput, dyn d
 
 		// The snapshot only contains MachineDeployments whose spec.replicas is still
 		// legacy-owned (the filter drops the rest), so every entry needs the claim.
-		if err := claimReplicasOwnership(ctx, dyn, gvr, md.Name, md.Replicas); err != nil {
-			input.Logger.Warn("force replicas ownership: claim spec.replicas",
+		if err := claimReplicasOwnership(ctx, dyn, gvr, md.Name); err != nil {
+			input.Logger.Warn("force replicas ownership: migrate spec.replicas owner",
 				slog.String("machinedeployment", md.Name), slog.Any("error", err))
 		}
 	}
@@ -228,32 +233,37 @@ func replicasOwnedByLegacyManager(managedFields []metav1.ManagedFieldsEntry) boo
 	return false
 }
 
-// claimReplicasOwnership takes over ownership of spec.replicas for the
-// hookFieldManager via a forced server-side apply, re-applying the current value
-// so the count is unchanged. A forced apply is the only operation that transfers
-// ownership without changing the value; it moves the field off the legacy manager
-// so nelm's adopt-deckhouse-controller-fields gate no longer prunes it.
-func claimReplicasOwnership(ctx context.Context, dyn dynamic.Interface, gvr schema.GroupVersionResource, name string, replicas int32) error {
-	applyObj := map[string]any{
-		"apiVersion": gvr.GroupVersion().String(),
-		"kind":       "MachineDeployment",
-		"metadata": map[string]any{
-			"name":      name,
-			"namespace": machineDeploymentNamespace,
-		},
-		"spec": map[string]any{
-			"replicas": replicas,
-		},
-	}
-
-	data, err := json.Marshal(applyObj)
+// claimReplicasOwnership migrates ownership of every field still tracked by the
+// legacy "deckhouse-controller" Update manager (spec.replicas in particular) to
+// the "deckhouse-hook" Apply manager, without changing any field value, so nelm's
+// adopt-deckhouse-controller-fields gate no longer prunes them.
+//
+// It rewrites metadata.managedFields directly via the client-go CSA->SSA upgrade
+// primitive rather than a server-side apply, because a forced apply that
+// re-applies spec.replicas at its current value does NOT strip the legacy owner:
+// SSA conflict detection only fires for fields an operation adds or modifies, so
+// an unchanged value keeps its existing owner (see the package comment). The
+// upgrade patch pins metadata.resourceVersion, so a concurrent write makes the
+// patch fail with a conflict rather than clobber it; the next converge retries.
+func claimReplicasOwnership(ctx context.Context, dyn dynamic.Interface, gvr schema.GroupVersionResource, name string) error {
+	live, err := dyn.Resource(gvr).Namespace(machineDeploymentNamespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
 
+	patch, err := csaupgrade.UpgradeManagedFieldsPatch(live, sets.New(legacyFieldManager), hookFieldManager)
+	if err != nil {
+		return err
+	}
+	if patch == nil {
+		// Ownership is already off the legacy manager (e.g. a concurrent run or a
+		// prior converge migrated it) — nothing to do.
+		return nil
+	}
+
 	_, err = dyn.Resource(gvr).Namespace(machineDeploymentNamespace).Patch(
-		ctx, name, apitypes.ApplyPatchType, data,
-		metav1.PatchOptions{FieldManager: hookFieldManager, Force: ptr.To(true)},
+		ctx, name, apitypes.JSONPatchType, patch,
+		metav1.PatchOptions{FieldManager: hookFieldManager},
 	)
 
 	return err

--- a/modules/040-node-manager/hooks/force_machine_deployment_replicas_ownership.go
+++ b/modules/040-node-manager/hooks/force_machine_deployment_replicas_ownership.go
@@ -1,0 +1,260 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This hook keeps MachineDeployment.spec.replicas owned by the "deckhouse-hook"
+// field manager so nelm's adopt-deckhouse-controller-fields gate never prunes it
+// (which would scale the MachineDeployment to zero — the template does not render
+// spec.replicas, the replica count is maintained out-of-band by
+// set_replicas_on_machine_deployment.go and by cluster-autoscaler).
+//
+// Every hook write already uses the "deckhouse-hook" field manager
+// (shapp.KubeClientFieldManager, set in
+// deckhouse-controller/cmd/deckhouse-controller/start.go). Before the Dec 2025
+// rename that manager was "deckhouse-controller" — the same name the pre-nelm
+// Helm 3 engine used — so fields written by hooks before the rename and never
+// changed since (a merge patch only transfers ownership of fields whose value it
+// changes) are still owned by the legacy manager and become pruning targets.
+//
+// The FilterFunc keeps only MachineDeployments whose spec.replicas is still owned
+// by the legacy field manager (everything else is dropped from the snapshot by
+// returning a nil result), so the handler's snapshots contain exactly the objects
+// that must be fixed. For each of them it force-claims the field for
+// "deckhouse-hook" via server-side apply, re-applying the current value so the
+// count is unchanged. It runs OnBeforeHelm, right before nelm applies the
+// node-manager release, so ownership is migrated BEFORE the apply that would
+// otherwise prune it — that is what prevents the scale-to-zero instead of only
+// healing it afterwards. WaitForSynchronization is left at its default (true) so
+// the snapshots are populated before beforeHelm runs; both CRDs ship in
+// node-manager/crds and node-manager is critical, so they are always present and
+// the synchronization cannot stall.
+
+package hooks
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	apitypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/utils/ptr"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency"
+	"github.com/deckhouse/module-sdk/pkg"
+	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
+
+	"github.com/deckhouse/deckhouse/modules/040-node-manager/hooks/internal/capi/v1beta1"
+	"github.com/deckhouse/deckhouse/modules/040-node-manager/hooks/internal/mcm/v1alpha1"
+)
+
+const (
+	machineDeploymentNamespace = "d8-cloud-instance-manager"
+
+	// hookFieldManager must match shapp.KubeClientFieldManager set in
+	// deckhouse-controller/cmd/deckhouse-controller/start.go. Fields owned by it
+	// are NOT subsumed by nelm's adopt-deckhouse-controller-fields gate.
+	hookFieldManager = "deckhouse-hook"
+
+	// legacyFieldManager is the field manager used by the pre-nelm Helm 3 engine
+	// and, before the Dec 2025 rename to hookFieldManager, by hook patches too.
+	// nelm's adopt-deckhouse-controller-fields gate reclaims fields owned by it.
+	legacyFieldManager = "deckhouse-controller"
+)
+
+var (
+	mcmMachineDeploymentGVR  = schema.GroupVersionResource{Group: "machine.sapcloud.io", Version: "v1alpha1", Resource: "machinedeployments"}
+	capiMachineDeploymentGVR = schema.GroupVersionResource{Group: "cluster.x-k8s.io", Version: "v1beta1", Resource: "machinedeployments"}
+)
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	// Run before the node-manager release is applied, so ownership is migrated
+	// before the adopting apply can prune spec.replicas.
+	OnBeforeHelm: &go_hook.OrderedConfig{Order: 10},
+	Queue:        "/modules/node-manager/force_machine_deployment_replicas_ownership",
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:       "mds",
+			ApiVersion: "machine.sapcloud.io/v1alpha1",
+			Kind:       "MachineDeployment",
+			// beforeHelm needs the snapshot populated, so wait for synchronization.
+			// The CRD always exists (node-manager/crds, critical module), so the wait
+			// cannot stall the converge.
+			WaitForSynchronization: ptr.To(true),
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{machineDeploymentNamespace},
+				},
+			},
+			FilterFunc: machineDeploymentReplicasOwnershipFilter,
+		},
+		{
+			Name:                   "capi_mds",
+			ApiVersion:             "cluster.x-k8s.io/v1beta1",
+			Kind:                   "MachineDeployment",
+			WaitForSynchronization: ptr.To(true),
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{machineDeploymentNamespace},
+				},
+			},
+			FilterFunc: capiMachineDeploymentReplicasOwnershipFilter,
+		},
+	},
+}, dependency.WithExternalDependencies(handleForceMachineDeploymentReplicasOwnership))
+
+// machineDeploymentReplicas is the snapshot entry for a MachineDeployment that
+// still needs its spec.replicas ownership migrated. MachineDeployments that are
+// already off the legacy manager never reach the snapshot (see the filters).
+type machineDeploymentReplicas struct {
+	Name string
+	// Replicas is the current value, re-applied verbatim so claiming ownership
+	// never changes the count.
+	Replicas int32
+}
+
+func machineDeploymentReplicasOwnershipFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	// Keep only MachineDeployments whose spec.replicas is still owned by the legacy
+	// field manager — the ones nelm's adoption gate would prune. A nil result drops
+	// the object from the snapshot, so the handler only ever sees what it must fix.
+	if !replicasOwnedByLegacyManager(obj.GetManagedFields()) {
+		return nil, nil
+	}
+
+	var md v1alpha1.MachineDeployment
+	if err := sdk.FromUnstructured(obj, &md); err != nil {
+		return nil, err
+	}
+
+	return machineDeploymentReplicas{Name: md.Name, Replicas: md.Spec.Replicas}, nil
+}
+
+func capiMachineDeploymentReplicasOwnershipFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	if !replicasOwnedByLegacyManager(obj.GetManagedFields()) {
+		return nil, nil
+	}
+
+	var md v1beta1.MachineDeployment
+	if err := sdk.FromUnstructured(obj, &md); err != nil {
+		return nil, err
+	}
+
+	var replicas int32
+	if md.Spec.Replicas != nil {
+		replicas = *md.Spec.Replicas
+	}
+
+	return machineDeploymentReplicas{Name: md.Name, Replicas: replicas}, nil
+}
+
+func handleForceMachineDeploymentReplicasOwnership(ctx context.Context, input *go_hook.HookInput, dc dependency.Container) error {
+	client, err := dc.GetK8sClient()
+	if err != nil {
+		// Best-effort: never block the node-manager release on ownership upkeep.
+		input.Logger.Warn("force replicas ownership: get k8s client", slog.Any("error", err))
+		return nil
+	}
+
+	forceReplicasOwnership(ctx, input, client.Dynamic(), input.Snapshots.Get("mds"), mcmMachineDeploymentGVR)
+	forceReplicasOwnership(ctx, input, client.Dynamic(), input.Snapshots.Get("capi_mds"), capiMachineDeploymentGVR)
+
+	return nil
+}
+
+func forceReplicasOwnership(ctx context.Context, input *go_hook.HookInput, dyn dynamic.Interface, snaps []pkg.Snapshot, gvr schema.GroupVersionResource) {
+	for md, err := range sdkobjectpatch.SnapshotIter[machineDeploymentReplicas](snaps) {
+		if err != nil {
+			input.Logger.Warn("force replicas ownership: iterate snapshot",
+				slog.String("gvr", gvr.String()), slog.Any("error", err))
+			continue
+		}
+
+		// The snapshot only contains MachineDeployments whose spec.replicas is still
+		// legacy-owned (the filter drops the rest), so every entry needs the claim.
+		if err := claimReplicasOwnership(ctx, dyn, gvr, md.Name, md.Replicas); err != nil {
+			input.Logger.Warn("force replicas ownership: claim spec.replicas",
+				slog.String("machinedeployment", md.Name), slog.Any("error", err))
+		}
+	}
+}
+
+// replicasOwnedByLegacyManager reports whether spec.replicas is currently owned
+// by the legacy "deckhouse-controller" field manager on the main resource
+// (subresources are ignored).
+func replicasOwnedByLegacyManager(managedFields []metav1.ManagedFieldsEntry) bool {
+	for _, entry := range managedFields {
+		if entry.Manager != legacyFieldManager || entry.Subresource != "" || entry.FieldsV1 == nil {
+			continue
+		}
+
+		var fields map[string]json.RawMessage
+		if err := json.Unmarshal(entry.FieldsV1.Raw, &fields); err != nil {
+			continue
+		}
+
+		specRaw, ok := fields["f:spec"]
+		if !ok {
+			continue
+		}
+
+		var spec map[string]json.RawMessage
+		if err := json.Unmarshal(specRaw, &spec); err != nil {
+			continue
+		}
+
+		if _, ok := spec["f:replicas"]; ok {
+			return true
+		}
+	}
+
+	return false
+}
+
+// claimReplicasOwnership takes over ownership of spec.replicas for the
+// hookFieldManager via a forced server-side apply, re-applying the current value
+// so the count is unchanged. A forced apply is the only operation that transfers
+// ownership without changing the value; it moves the field off the legacy manager
+// so nelm's adopt-deckhouse-controller-fields gate no longer prunes it.
+func claimReplicasOwnership(ctx context.Context, dyn dynamic.Interface, gvr schema.GroupVersionResource, name string, replicas int32) error {
+	applyObj := map[string]any{
+		"apiVersion": gvr.GroupVersion().String(),
+		"kind":       "MachineDeployment",
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": machineDeploymentNamespace,
+		},
+		"spec": map[string]any{
+			"replicas": replicas,
+		},
+	}
+
+	data, err := json.Marshal(applyObj)
+	if err != nil {
+		return err
+	}
+
+	_, err = dyn.Resource(gvr).Namespace(machineDeploymentNamespace).Patch(
+		ctx, name, apitypes.ApplyPatchType, data,
+		metav1.PatchOptions{FieldManager: hookFieldManager, Force: ptr.To(true)},
+	)
+
+	return err
+}

--- a/modules/040-node-manager/hooks/force_machine_deployment_replicas_ownership.go
+++ b/modules/040-node-manager/hooks/force_machine_deployment_replicas_ownership.go
@@ -31,9 +31,10 @@ limitations under the License.
 // The FilterFunc keeps only MachineDeployments whose spec.replicas is still owned
 // by the legacy field manager (everything else is dropped from the snapshot by
 // returning a nil result), so the handler's snapshots contain exactly the objects
-// that must be fixed. For each of them it migrates ownership to "deckhouse-hook"
-// by rewriting metadata.managedFields directly (the client-go CSA->SSA upgrade
-// primitive), which drops the legacy manager WITHOUT touching spec.replicas.
+// that must be fixed. For each of them it moves spec.replicas ownership to
+// "deckhouse-hook" by editing metadata.managedFields directly — dropping only that
+// one field from the legacy manager and leaving the replica value and every other
+// field the legacy manager owns untouched.
 //
 // A server-side apply cannot do this: SSA conflict detection is value-based
 // (structured-merge-diff computes conflicts as ownedFields ∩ (Modified ∪ Added)),
@@ -64,9 +65,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	apitypes "k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/util/csaupgrade"
 	"k8s.io/utils/ptr"
 
 	"github.com/deckhouse/deckhouse/go_lib/dependency"
@@ -233,32 +232,45 @@ func replicasOwnedByLegacyManager(managedFields []metav1.ManagedFieldsEntry) boo
 	return false
 }
 
-// claimReplicasOwnership migrates ownership of every field still tracked by the
-// legacy "deckhouse-controller" Update manager (spec.replicas in particular) to
-// the "deckhouse-hook" Apply manager, without changing any field value, so nelm's
-// adopt-deckhouse-controller-fields gate no longer prunes them.
+// claimReplicasOwnership moves ownership of spec.replicas — and only
+// spec.replicas — off the legacy "deckhouse-controller" field manager onto
+// "deckhouse-hook", without changing the replica value, so nelm's
+// adopt-deckhouse-controller-fields gate no longer prunes it. Any other field the
+// legacy manager happens to own is left untouched.
 //
-// It rewrites metadata.managedFields directly via the client-go CSA->SSA upgrade
-// primitive rather than a server-side apply, because a forced apply that
-// re-applies spec.replicas at its current value does NOT strip the legacy owner:
-// SSA conflict detection only fires for fields an operation adds or modifies, so
-// an unchanged value keeps its existing owner (see the package comment). The
-// upgrade patch pins metadata.resourceVersion, so a concurrent write makes the
-// patch fail with a conflict rather than clobber it; the next converge retries.
+// This is done by rewriting metadata.managedFields directly rather than with a
+// server-side apply, because a forced apply that re-applies spec.replicas at its
+// current value does NOT strip the legacy owner: SSA conflict detection only fires
+// for fields an operation adds or modifies, so re-applying an unchanged value adds
+// a "deckhouse-hook" co-owner but keeps the legacy owner in place (see the package
+// comment). The patch pins metadata.resourceVersion, so a concurrent write makes
+// it fail with a conflict rather than clobber that write; the next converge
+// retries.
 func claimReplicasOwnership(ctx context.Context, dyn dynamic.Interface, gvr schema.GroupVersionResource, name string) error {
 	live, err := dyn.Resource(gvr).Namespace(machineDeploymentNamespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
 
-	patch, err := csaupgrade.UpgradeManagedFieldsPatch(live, sets.New(legacyFieldManager), hookFieldManager)
+	newManagedFields, changed, err := migrateReplicasOwnerToHook(live.GetManagedFields(), gvr.GroupVersion().String())
 	if err != nil {
 		return err
 	}
-	if patch == nil {
-		// Ownership is already off the legacy manager (e.g. a concurrent run or a
+	if !changed {
+		// spec.replicas is already off the legacy manager (a concurrent run or a
 		// prior converge migrated it) — nothing to do.
 		return nil
+	}
+
+	// Replace the whole managedFields array and pin resourceVersion. resourceVersion
+	// is a "replace" (not "test") so a stale object is rejected by etcd with a 409
+	// conflict instead of by the apiserver with an invalid-request error.
+	patch, err := json.Marshal([]map[string]any{
+		{"op": "replace", "path": "/metadata/managedFields", "value": newManagedFields},
+		{"op": "replace", "path": "/metadata/resourceVersion", "value": live.GetResourceVersion()},
+	})
+	if err != nil {
+		return err
 	}
 
 	_, err = dyn.Resource(gvr).Namespace(machineDeploymentNamespace).Patch(
@@ -267,4 +279,156 @@ func claimReplicasOwnership(ctx context.Context, dyn dynamic.Interface, gvr sche
 	)
 
 	return err
+}
+
+// migrateReplicasOwnerToHook returns a copy of managedFields with spec.replicas
+// removed from the legacy "deckhouse-controller" manager (dropping any entry that
+// is left owning nothing) and owned by "deckhouse-hook" instead. Every other field
+// and manager is preserved verbatim. The bool reports whether anything changed; if
+// not, the original slice is returned and no patch is needed. Only entries on the
+// main resource (empty subresource) are considered.
+func migrateReplicasOwnerToHook(entries []metav1.ManagedFieldsEntry, apiVersion string) ([]metav1.ManagedFieldsEntry, bool, error) {
+	out := make([]metav1.ManagedFieldsEntry, 0, len(entries))
+	changed := false
+
+	for _, entry := range entries {
+		if entry.Manager == legacyFieldManager && entry.Subresource == "" && entry.FieldsV1 != nil {
+			removed, newRaw, err := removeReplicasFromFields(entry.FieldsV1.Raw)
+			if err != nil {
+				return nil, false, err
+			}
+			if removed {
+				changed = true
+				if len(newRaw) == 0 {
+					// The legacy entry owned nothing but spec.replicas — drop it.
+					continue
+				}
+				// entry is a copy from range; repointing FieldsV1 does not mutate the
+				// caller's slice (the raw bytes are never modified in place).
+				entry.FieldsV1 = &metav1.FieldsV1{Raw: newRaw}
+			}
+		}
+		out = append(out, entry)
+	}
+
+	if !changed {
+		return entries, false, nil
+	}
+
+	if err := ensureHookOwnsReplicas(&out, apiVersion); err != nil {
+		return nil, false, err
+	}
+
+	return out, true, nil
+}
+
+// removeReplicasFromFields removes the f:spec/f:replicas path from a FieldsV1 blob.
+// It returns whether the path was present, and the re-encoded blob with empty
+// parents pruned (nil when the whole blob is left empty).
+func removeReplicasFromFields(raw []byte) (bool, []byte, error) {
+	top := map[string]json.RawMessage{}
+	if err := json.Unmarshal(raw, &top); err != nil {
+		return false, nil, err
+	}
+
+	specRaw, ok := top["f:spec"]
+	if !ok {
+		return false, raw, nil
+	}
+
+	spec := map[string]json.RawMessage{}
+	if err := json.Unmarshal(specRaw, &spec); err != nil {
+		return false, nil, err
+	}
+	if _, ok := spec["f:replicas"]; !ok {
+		return false, raw, nil
+	}
+
+	delete(spec, "f:replicas")
+	if len(spec) == 0 {
+		delete(top, "f:spec")
+	} else {
+		newSpec, err := json.Marshal(spec)
+		if err != nil {
+			return false, nil, err
+		}
+		top["f:spec"] = newSpec
+	}
+
+	if len(top) == 0 {
+		return true, nil, nil
+	}
+
+	newRaw, err := json.Marshal(top)
+	if err != nil {
+		return false, nil, err
+	}
+
+	return true, newRaw, nil
+}
+
+// ensureHookOwnsReplicas makes the "deckhouse-hook" manager own f:spec/f:replicas:
+// it adds the path to the first existing deckhouse-hook entry on the main resource,
+// or appends a new Update entry when there is none. Update mirrors the entry that
+// set_replicas_on_machine_deployment.go produces and that nelm already leaves
+// alone.
+func ensureHookOwnsReplicas(entries *[]metav1.ManagedFieldsEntry, apiVersion string) error {
+	for i := range *entries {
+		entry := &(*entries)[i]
+		if entry.Manager != hookFieldManager || entry.Subresource != "" || entry.FieldsV1 == nil {
+			continue
+		}
+
+		added, newRaw, err := addReplicasToFields(entry.FieldsV1.Raw)
+		if err != nil {
+			return err
+		}
+		if added {
+			entry.FieldsV1 = &metav1.FieldsV1{Raw: newRaw}
+		}
+		return nil
+	}
+
+	*entries = append(*entries, metav1.ManagedFieldsEntry{
+		Manager:    hookFieldManager,
+		Operation:  metav1.ManagedFieldsOperationUpdate,
+		APIVersion: apiVersion,
+		FieldsType: "FieldsV1",
+		FieldsV1:   &metav1.FieldsV1{Raw: []byte(`{"f:spec":{"f:replicas":{}}}`)},
+	})
+
+	return nil
+}
+
+// addReplicasToFields adds the f:spec/f:replicas path to a FieldsV1 blob, reporting
+// whether it had to change anything (it is a no-op when the path is already there).
+func addReplicasToFields(raw []byte) (bool, []byte, error) {
+	top := map[string]json.RawMessage{}
+	if err := json.Unmarshal(raw, &top); err != nil {
+		return false, nil, err
+	}
+
+	spec := map[string]json.RawMessage{}
+	if specRaw, ok := top["f:spec"]; ok {
+		if err := json.Unmarshal(specRaw, &spec); err != nil {
+			return false, nil, err
+		}
+	}
+	if _, ok := spec["f:replicas"]; ok {
+		return false, raw, nil
+	}
+
+	spec["f:replicas"] = json.RawMessage(`{}`)
+	newSpec, err := json.Marshal(spec)
+	if err != nil {
+		return false, nil, err
+	}
+	top["f:spec"] = newSpec
+
+	newRaw, err := json.Marshal(top)
+	if err != nil {
+		return false, nil, err
+	}
+
+	return true, newRaw, nil
 }

--- a/modules/040-node-manager/hooks/force_machine_deployment_replicas_ownership_test.go
+++ b/modules/040-node-manager/hooks/force_machine_deployment_replicas_ownership_test.go
@@ -17,10 +17,152 @@ limitations under the License.
 package hooks
 
 import (
+	"sync"
 	"testing"
 
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	apitypes "k8s.io/apimachinery/pkg/types"
+	k8sdynamicfake "k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
 )
+
+var _ = Describe("Modules :: node-manager :: hooks :: force_machine_deployment_replicas_ownership ::", func() {
+	const state = `
+---
+apiVersion: machine.sapcloud.io/v1alpha1
+kind: MachineDeployment
+metadata:
+  name: md-mcm-legacy
+  namespace: d8-cloud-instance-manager
+  labels:
+    node-group: worker
+  managedFields:
+  - manager: deckhouse-controller
+    operation: Update
+    apiVersion: machine.sapcloud.io/v1alpha1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:spec:
+        f:replicas: {}
+spec:
+  replicas: 2
+---
+apiVersion: machine.sapcloud.io/v1alpha1
+kind: MachineDeployment
+metadata:
+  name: md-mcm-hook
+  namespace: d8-cloud-instance-manager
+  labels:
+    node-group: worker
+  managedFields:
+  - manager: deckhouse-hook
+    operation: Update
+    apiVersion: machine.sapcloud.io/v1alpha1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:spec:
+        f:replicas: {}
+spec:
+  replicas: 3
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: md-capi-legacy
+  namespace: d8-cloud-instance-manager
+  labels:
+    node-group: static
+  managedFields:
+  - manager: deckhouse-controller
+    operation: Update
+    apiVersion: cluster.x-k8s.io/v1beta1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:spec:
+        f:replicas: {}
+spec:
+  replicas: 1
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: md-capi-other
+  namespace: d8-cloud-instance-manager
+  labels:
+    node-group: static
+  managedFields:
+  - manager: machine-controller-manager
+    operation: Update
+    apiVersion: cluster.x-k8s.io/v1beta1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:spec:
+        f:replicas: {}
+spec:
+  replicas: 4
+`
+
+	f := HookExecutionConfigInit(`{"nodeManager":{"internal":{}}}`, `{}`)
+	f.RegisterCRD("machine.sapcloud.io", "v1alpha1", "MachineDeployment", true)
+	f.RegisterCRD("cluster.x-k8s.io", "v1beta1", "MachineDeployment", true)
+
+	// appliedPatches records the names of MachineDeployments that received a
+	// server-side apply (the ownership claim). A single reactor is installed once
+	// the fake client exists; the slice is reset before every run.
+	var (
+		appliedPatches []string
+		spyOnce        sync.Once
+	)
+
+	installApplySpy := func() {
+		spyOnce.Do(func() {
+			fakeDynamic := f.KubeClient().Dynamic().(*k8sdynamicfake.FakeDynamicClient)
+			fakeDynamic.PrependReactor("patch", "machinedeployments", func(action k8stesting.Action) (bool, k8sruntime.Object, error) {
+				patch := action.(k8stesting.PatchAction)
+				if patch.GetPatchType() == apitypes.ApplyPatchType {
+					appliedPatches = append(appliedPatches, patch.GetName())
+				}
+				// Short-circuit: record the claim and skip the default apply, whose
+				// server-side-apply emulation is not needed for this assertion.
+				return true, &unstructured.Unstructured{}, nil
+			})
+		})
+	}
+
+	Context("MachineDeployments with mixed spec.replicas ownership", func() {
+		BeforeEach(func() {
+			appliedPatches = nil
+			f.BindingContexts.Set(f.KubeStateSet(state))
+			installApplySpy()
+			f.RunHook()
+		})
+
+		It("claims ownership only for the legacy-owned MachineDeployments", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(appliedPatches).To(ConsistOf("md-mcm-legacy", "md-capi-legacy"))
+		})
+	})
+
+	Context("no MachineDeployments", func() {
+		BeforeEach(func() {
+			appliedPatches = nil
+			f.BindingContexts.Set(f.KubeStateSet(``))
+			installApplySpy()
+			f.RunHook()
+		})
+
+		It("does nothing and does not fail", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(appliedPatches).To(BeEmpty())
+		})
+	})
+})
 
 func ownerManagedField(manager, subresource, fieldsV1 string) metav1.ManagedFieldsEntry {
 	return metav1.ManagedFieldsEntry{

--- a/modules/040-node-manager/hooks/force_machine_deployment_replicas_ownership_test.go
+++ b/modules/040-node-manager/hooks/force_machine_deployment_replicas_ownership_test.go
@@ -112,9 +112,10 @@ spec:
 	f.RegisterCRD("machine.sapcloud.io", "v1alpha1", "MachineDeployment", true)
 	f.RegisterCRD("cluster.x-k8s.io", "v1beta1", "MachineDeployment", true)
 
-	// appliedPatches records the names of MachineDeployments that received a
-	// server-side apply (the ownership claim). A single reactor is installed once
-	// the fake client exists; the slice is reset before every run.
+	// appliedPatches records the names of MachineDeployments that received the
+	// managedFields ownership-migration patch (a JSON patch, not a server-side
+	// apply). A single reactor is installed once the fake client exists; the slice
+	// is reset before every run.
 	var (
 		appliedPatches []string
 		spyOnce        sync.Once
@@ -125,11 +126,11 @@ spec:
 			fakeDynamic := f.KubeClient().Dynamic().(*k8sdynamicfake.FakeDynamicClient)
 			fakeDynamic.PrependReactor("patch", "machinedeployments", func(action k8stesting.Action) (bool, k8sruntime.Object, error) {
 				patch := action.(k8stesting.PatchAction)
-				if patch.GetPatchType() == apitypes.ApplyPatchType {
+				if patch.GetPatchType() == apitypes.JSONPatchType {
 					appliedPatches = append(appliedPatches, patch.GetName())
 				}
-				// Short-circuit: record the claim and skip the default apply, whose
-				// server-side-apply emulation is not needed for this assertion.
+				// Short-circuit: record the migration and skip applying the JSON patch,
+				// whose managedFields rewrite is not needed for this assertion.
 				return true, &unstructured.Unstructured{}, nil
 			})
 		})

--- a/modules/040-node-manager/hooks/force_machine_deployment_replicas_ownership_test.go
+++ b/modules/040-node-manager/hooks/force_machine_deployment_replicas_ownership_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package hooks
 
 import (
+	"encoding/json"
 	"sync"
 	"testing"
 
@@ -234,4 +235,151 @@ func TestReplicasOwnedByLegacyManager(t *testing.T) {
 			}
 		})
 	}
+}
+
+// specFieldOwned reports whether the (manager, subresource) entry owns
+// f:spec/<field> in its managed fields.
+func specFieldOwned(entries []metav1.ManagedFieldsEntry, manager, subresource, field string) bool {
+	for _, e := range entries {
+		if e.Manager != manager || e.Subresource != subresource || e.FieldsV1 == nil {
+			continue
+		}
+		var top map[string]json.RawMessage
+		if json.Unmarshal(e.FieldsV1.Raw, &top) != nil {
+			continue
+		}
+		specRaw, ok := top["f:spec"]
+		if !ok {
+			continue
+		}
+		var spec map[string]json.RawMessage
+		if json.Unmarshal(specRaw, &spec) != nil {
+			continue
+		}
+		if _, ok := spec[field]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// managerEntries counts the entries owned by the (manager, subresource) pair.
+func managerEntries(entries []metav1.ManagedFieldsEntry, manager, subresource string) int {
+	n := 0
+	for _, e := range entries {
+		if e.Manager == manager && e.Subresource == subresource {
+			n++
+		}
+	}
+	return n
+}
+
+func TestMigrateReplicasOwnerToHook(t *testing.T) {
+	const apiVersion = "machine.sapcloud.io/v1alpha1"
+
+	t.Run("legacy owns only spec.replicas, no hook entry", func(t *testing.T) {
+		in := []metav1.ManagedFieldsEntry{
+			ownerManagedField(legacyFieldManager, "", `{"f:spec":{"f:replicas":{}}}`),
+		}
+
+		out, changed, err := migrateReplicasOwnerToHook(in, apiVersion)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !changed {
+			t.Fatal("expected changed=true")
+		}
+		if managerEntries(out, legacyFieldManager, "") != 0 {
+			t.Errorf("legacy entry must be dropped when it owned only spec.replicas, got %d", managerEntries(out, legacyFieldManager, ""))
+		}
+		if !specFieldOwned(out, hookFieldManager, "", "f:replicas") {
+			t.Error("hook manager must own spec.replicas")
+		}
+		// The fabricated hook entry must be a well-formed Update entry.
+		for _, e := range out {
+			if e.Manager == hookFieldManager {
+				if e.Operation != metav1.ManagedFieldsOperationUpdate {
+					t.Errorf("hook entry operation = %v, want Update", e.Operation)
+				}
+				if e.APIVersion != apiVersion {
+					t.Errorf("hook entry apiVersion = %q, want %q", e.APIVersion, apiVersion)
+				}
+			}
+		}
+	})
+
+	t.Run("legacy owns other spec fields too, only replicas is moved", func(t *testing.T) {
+		in := []metav1.ManagedFieldsEntry{
+			ownerManagedField(legacyFieldManager, "", `{"f:spec":{"f:minReadySeconds":{},"f:replicas":{}}}`),
+		}
+
+		out, changed, err := migrateReplicasOwnerToHook(in, apiVersion)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !changed {
+			t.Fatal("expected changed=true")
+		}
+		if specFieldOwned(out, legacyFieldManager, "", "f:replicas") {
+			t.Error("legacy manager must no longer own spec.replicas")
+		}
+		if !specFieldOwned(out, legacyFieldManager, "", "f:minReadySeconds") {
+			t.Error("legacy manager must keep spec.minReadySeconds")
+		}
+		if !specFieldOwned(out, hookFieldManager, "", "f:replicas") {
+			t.Error("hook manager must own spec.replicas")
+		}
+	})
+
+	t.Run("existing hook entry gains replicas, legacy entry dropped", func(t *testing.T) {
+		in := []metav1.ManagedFieldsEntry{
+			ownerManagedField(hookFieldManager, "", `{"f:spec":{"f:minReadySeconds":{}}}`),
+			ownerManagedField(legacyFieldManager, "", `{"f:spec":{"f:replicas":{}}}`),
+		}
+
+		out, changed, err := migrateReplicasOwnerToHook(in, apiVersion)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !changed {
+			t.Fatal("expected changed=true")
+		}
+		if managerEntries(out, hookFieldManager, "") != 1 {
+			t.Errorf("expected replicas merged into the existing hook entry, got %d hook entries", managerEntries(out, hookFieldManager, ""))
+		}
+		if managerEntries(out, legacyFieldManager, "") != 0 {
+			t.Error("legacy entry must be dropped")
+		}
+		if !specFieldOwned(out, hookFieldManager, "", "f:replicas") || !specFieldOwned(out, hookFieldManager, "", "f:minReadySeconds") {
+			t.Error("hook manager must own both spec.replicas and spec.minReadySeconds")
+		}
+	})
+
+	t.Run("already migrated is a no-op", func(t *testing.T) {
+		in := []metav1.ManagedFieldsEntry{
+			ownerManagedField(hookFieldManager, "", `{"f:spec":{"f:replicas":{}}}`),
+		}
+
+		_, changed, err := migrateReplicasOwnerToHook(in, apiVersion)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if changed {
+			t.Error("expected changed=false when the legacy manager does not own spec.replicas")
+		}
+	})
+
+	t.Run("legacy owns replicas only on the status subresource is untouched", func(t *testing.T) {
+		in := []metav1.ManagedFieldsEntry{
+			ownerManagedField(legacyFieldManager, "status", `{"f:status":{"f:replicas":{}}}`),
+		}
+
+		_, changed, err := migrateReplicasOwnerToHook(in, apiVersion)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if changed {
+			t.Error("expected changed=false for a status-subresource entry")
+		}
+	})
 }

--- a/modules/040-node-manager/hooks/force_machine_deployment_replicas_ownership_test.go
+++ b/modules/040-node-manager/hooks/force_machine_deployment_replicas_ownership_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func ownerManagedField(manager, subresource, fieldsV1 string) metav1.ManagedFieldsEntry {
+	return metav1.ManagedFieldsEntry{
+		Manager:     manager,
+		Operation:   metav1.ManagedFieldsOperationUpdate,
+		Subresource: subresource,
+		FieldsType:  "FieldsV1",
+		FieldsV1:    &metav1.FieldsV1{Raw: []byte(fieldsV1)},
+	}
+}
+
+func TestReplicasOwnedByLegacyManager(t *testing.T) {
+	tests := []struct {
+		name          string
+		managedFields []metav1.ManagedFieldsEntry
+		want          bool
+	}{
+		{
+			name:          "no managed fields",
+			managedFields: nil,
+			want:          false,
+		},
+		{
+			name:          "legacy manager owns spec.replicas",
+			managedFields: []metav1.ManagedFieldsEntry{ownerManagedField(legacyFieldManager, "", `{"f:spec":{"f:replicas":{}}}`)},
+			want:          true,
+		},
+		{
+			name:          "legacy manager owns spec.replicas alongside other fields",
+			managedFields: []metav1.ManagedFieldsEntry{ownerManagedField(legacyFieldManager, "", `{"f:spec":{".":{},"f:minReadySeconds":{},"f:replicas":{}}}`)},
+			want:          true,
+		},
+		{
+			name:          "legacy manager owns spec but not replicas",
+			managedFields: []metav1.ManagedFieldsEntry{ownerManagedField(legacyFieldManager, "", `{"f:spec":{"f:minReadySeconds":{}}}`)},
+			want:          false,
+		},
+		{
+			name:          "spec.replicas owned by the hook manager, not legacy",
+			managedFields: []metav1.ManagedFieldsEntry{ownerManagedField(hookFieldManager, "", `{"f:spec":{"f:replicas":{}}}`)},
+			want:          false,
+		},
+		{
+			name:          "legacy manager owns replicas only on the status subresource",
+			managedFields: []metav1.ManagedFieldsEntry{ownerManagedField(legacyFieldManager, "status", `{"f:status":{"f:replicas":{}}}`)},
+			want:          false,
+		},
+		{
+			name: "mixed managers, legacy owns replicas",
+			managedFields: []metav1.ManagedFieldsEntry{
+				ownerManagedField("machine-controller-manager", "status", `{"f:status":{"f:replicas":{}}}`),
+				ownerManagedField(hookFieldManager, "", `{"f:spec":{"f:minReadySeconds":{}}}`),
+				ownerManagedField(legacyFieldManager, "", `{"f:spec":{"f:replicas":{}}}`),
+			},
+			want: true,
+		},
+		{
+			name:          "legacy manager with nil FieldsV1",
+			managedFields: []metav1.ManagedFieldsEntry{{Manager: legacyFieldManager, Operation: metav1.ManagedFieldsOperationUpdate}},
+			want:          false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := replicasOwnedByLegacyManager(tt.managedFields); got != tt.want {
+				t.Errorf("replicasOwnedByLegacyManager() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Adds a hook: `force_machine_deployment_replicas_ownership`. It runs `OnBeforeHelm`, right before the node-manager release is applied.

What it does:

- looks at MCM and CAPI MachineDeployments in `d8-cloud-instance-manager`;
- picks only those where `spec.replicas` is still owned by the old `deckhouse-controller` field manager;
- moves ownership of that field to `deckhouse-hook` by rewriting `metadata.managedFields` (JSON patch, `resourceVersion` pinned).

The replica count is not changed. Other fields of the old manager are kept. Errors are only logged and never block the release.

Server-side apply does not work here. SSA reports a conflict only for values an apply changes, so applying the same replica count adds a second owner but keeps the old one.

Nothing restarts, no nodes roll.

## Why do we need it, and what problem does it solve?

1.76.9 turns on `NELM_FEAT_ADOPT_DECKHOUSE_CONTROLLER_FIELDS` (#21831). nelm takes over fields owned by `deckhouse-controller` and drops the ones that are not in the manifest.

`MachineDeployment.spec.replicas` is not in the template. It is set by `set_replicas_on_machine_deployment.go` and by cluster-autoscaler. That hook patches only when the value changes, so for NodeGroups with a stable replica count the field is still owned by `deckhouse-controller` (the hook manager was renamed to `deckhouse-hook` in Dec 2025).

So on upgrade nelm takes the field and deletes it. MCM reads a missing `spec.replicas` as 0, scales the MachineSet to zero, and every CloudEphemeral node is deleted and created again.

This happened in production on a 1.76.8 -> 1.76.9 upgrade: all cloud nodes were recreated at once.

The hook runs before the apply, so it prevents the scale to zero instead of fixing it afterwards.

## Why do we need it in the patch release (if we do)?

Any cluster with MCM or CAPI nodes that upgrades to 1.76.9 or later can hit this, and it recreates all cloud nodes at once.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: node-manager
type: fix
summary: MachineDeployment `spec.replicas` is no longer dropped on upgrade, so cloud nodes are not recreated.
impact_level: high
impact: |
  Fixes recreation of all CloudEphemeral nodes on upgrade to 1.76.9. The MachineDeployment
  replica count was dropped and the MachineDeployment was scaled to zero.
```
