### PR TITLE
[cloud-provider-vcd] Fix dependencies graph

### DIFF
--- a/ee/modules/030-cloud-provider-vcd/candi/layouts/with-nat/base-infrastructure/main.tf
+++ b/ee/modules/030-cloud-provider-vcd/candi/layouts/with-nat/base-infrastructure/main.tf
@@ -72,6 +72,8 @@ module "snat" {
   external_network_type = local.external_network_type
   external_address      = var.providerClusterConfiguration.edgeGateway.externalIP
   external_port         = var.providerClusterConfiguration.edgeGateway.externalPort
+
+  depends_on = [module.network]
 }
 
 module "dnat_bastion" {
@@ -87,6 +89,8 @@ module "dnat_bastion" {
   external_port         = local.dnat_bastion_external_port
   external_network_name = local.external_network_name
   external_network_type = local.external_network_type
+
+  depends_on = [module.network]
 }
 
 
@@ -99,4 +103,6 @@ module "firewall" {
   edge_gateway_type     = var.providerClusterConfiguration.edgeGateway.type
   internal_network_name = var.providerClusterConfiguration.mainNetwork
   internal_network_cidr = var.providerClusterConfiguration.internalNetworkCIDR
+
+  depends_on = [module.network]
 }


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Added `depends_on = [module.network]` to the `snat`, `dnat_bastion`, and `firewall` module blocks in `ee/modules/030-cloud-provider-vcd/candi/layouts/with-nat/base-infrastructure/main.tf`. This forces Terraform to tear down NAT and firewall configuration on the edge gateway before deleting the routed network during
  cluster destroy.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

  In the WithNAT placement strategy, the `snat`, `dnat_bastion`, and `firewall` modules referenced `providerClusterConfiguration.mainNetwork` as a plain string instead of the network module's output, so Terraform's dependency graph had no edge between the routed network and the NAT/firewall resources bound to it on the
  edge gateway. During `terraform destroy`, this let Terraform delete the network concurrently with (or before) the NAT/firewall teardown, and vCloud Director's backend intermittently rejected the network deletion with "network still in use," causing cluster deletion to fail with a race condition.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-vcd
type: fix
summary: Fixes an intermittent "network still in use" error during cluster deletion with the WithNAT placement strategy.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
