### PR TITLE
[multitenancy-manager] Stop granting ProjectTemplate authoring to the module manager

### DIFF
--- a/docs/documentation/_data/rbac/rbac.yaml
+++ b/docs/documentation/_data/rbac/rbac.yaml
@@ -1368,7 +1368,6 @@ modules:
           - deckhouse.io
           resources:
           - projects
-          - projecttemplates
           verbs:
           - create
           - update

--- a/modules/160-multitenancy-manager/templates/rbacv2/manage/edit.yaml
+++ b/modules/160-multitenancy-manager/templates/rbacv2/manage/edit.yaml
@@ -11,11 +11,15 @@ metadata:
     rbac.deckhouse.io/namespace: d8-multitenancy-manager
   name: d8:manage:permission:module:multitenancy-manager:edit
 rules:
+# ProjectTemplate is deliberately free-form: spec.resourcesTemplate is an arbitrary Helm template, and
+# the release it renders into is applied by the module's ServiceAccount, which is bound to cluster-admin.
+# Authoring one is therefore equivalent to holding cluster-admin, and is not granted here — it stays with
+# the legacy ClusterAdmin access level and kubeadm:cluster-admins, both of which can already write RBAC.
+# Reading templates stays in the view role, and creating a Project on an existing template stays here.
 - apiGroups:
   - deckhouse.io
   resources:
   - projects
-  - projecttemplates
   verbs:
   - create
   - update


### PR DESCRIPTION
## Description

`ProjectTemplate.spec.resourcesTemplate` is an arbitrary Helm template, and the release it renders
into is applied by the `multitenancy-manager` ServiceAccount, which is bound to `cluster-admin`.
Nothing on the way inspects that content — the validating webhook
(`internal/webhook/template/hook.go` → `internal/validate/validate.go`) checks the parameter schema
and nothing else, and the post-renderer forces the project namespace onto namespaced objects, which
a cluster-scoped object ignores. Authoring a template is therefore equivalent to holding
`cluster-admin`.

`d8:manage:permission:module:multitenancy-manager:edit` granted exactly that while holding no rights
on `rbac.authorization.k8s.io`. The role aggregates into `d8:manage:deckhouse:manager`, and the
deckhouse subsystem deliberately has no RBAC access — write on `clusterroles`/`clusterrolebindings`
belongs to the security subsystem alone. A subject holding only this role could ship a template
carrying a `ClusterRoleBinding` to `cluster-admin`, create a `Project` on it, and have the module
apply it.

`projecttemplates` is dropped from the write rule of that role:

- reading templates stays in `d8:manage:permission:module:multitenancy-manager:view`;
- creating and editing a `Project` on an existing template stays in the edit role;
- the legacy `ClusterAdmin` access level (`d8:user-authz:multitenancy-manager:cluster-admin`) and
  the `kubeadm:cluster-admins` group (`d8:multitenancy-manager:admin-kubeconfig`) keep the right.
  Both can already write `ClusterRole` and `ClusterRoleBinding`, so for them it is not an escalation.

Filtering the template content instead was considered and is not a boundary: the shipped `default`,
`secure` and `secure-with-dedicated-nodes` templates legitimately render cluster-scoped
`OperationPolicy`, `SecurityPolicy` and `FalcoAuditRules`, so cluster-scoped objects cannot simply be
refused; a deny list of kinds is a race with the API surface; and a template also authors the
project namespace, so it can label it into a pod policy that permits a privileged pod regardless of
what the manifests are filtered for.

`docs/documentation/_data/rbac/rbac.yaml` is updated to match.

## Why do we need it, and what problem does it solve?

A module-level permission granted the rights of a cluster administrator. The role model is built on
the promise that a subsystem manager reaches only its subsystem; this made the deckhouse subsystem
reach RBAC, which belongs to security. Nobody could have safely relied on the removed right, because
it was `cluster-admin` all along.

## Why do we need it in the patch release (if we do)?

Yes. The role is shipped and grantable in every supported release, and the escalation needs nothing
but the role itself.

## Checklist

- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: multitenancy-manager
type: fix
summary: The module manager role no longer grants authoring of project templates.
impact: |
  `d8:manage:permission:module:multitenancy-manager:edit` no longer grants write access to
  `projecttemplates`. A `ProjectTemplate` renders into a release applied by a ServiceAccount bound
  to `cluster-admin`, and its `spec.resourcesTemplate` is arbitrary, so authoring one is equivalent
  to holding `cluster-admin` and is not a module-level permission.

  Reading templates stays in `d8:manage:permission:module:multitenancy-manager:view`, and creating a
  `Project` on an existing template stays in the edit role. The legacy `ClusterAdmin` access level
  and the `kubeadm:cluster-admins` group keep the right. A subject that authored templates through
  the manager role has to be granted one of those instead.
impact_level: high
```
