### PR TITLE
[descheduler] fix vex

### DIFF
--- a/modules/400-descheduler/images/descheduler/known_vulnerabilities.vex
+++ b/modules/400-descheduler/images/descheduler/known_vulnerabilities.vex
@@ -1,0 +1,51 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-cf67c1d15ba9b2b3a76640921b70d3ec428d80b094749baab315f0035d5a1fc0",
+  "author": "Deckhouse <contact@deckhouse.io>",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "GHSA-hrxh-6v49-42gf"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/google.golang.org/grpc"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость объединяет три проблемы grpc-go: обход авторизации и панику в движке xDS RBAC (google.golang.org/grpc/internal/xds/rbac) и обход защиты от HTTP/2 Rapid Reset в серверном транспорте (internal/transport, http2_server.go). Descheduler использует google.golang.org/grpc только в клиентском режиме: для экспорта трассировок через otlptracegrpc и как транзитивную зависимость клиентских библиотек Kubernetes. gRPC-сервер не создаётся и не запускается, вызов grpc.NewServer в коде компонента отсутствует, а метрики и healthz отдаются обычным HTTP-сервером. Пакеты google.golang.org/grpc/xds и google.golang.org/grpc/internal/xds/rbac не входят в граф зависимостей собираемого бинарного файла. Изменения клиентского транспорта в исправляющем коммите носят характер рефакторинга типов и не связаны с эксплуатацией. Уязвимый код не исполняется.",
+      "timestamp": "2026-08-20T14:12:35.847213Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-56852"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/text"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "Уязвимость представляет собой зацикливание norm.Iter и смежных функций пакета golang.org/x/text/unicode/norm при обработке некорректных последовательностей UTF-8. В бинарном файле descheduler пакет norm достижим только двумя путями: через golang.org/x/net/idna при формировании заголовков исходящих HTTP/2-запросов (httpcommon.EncodeHeaders -> httpguts.PunycodeHostPort) и через golang.org/x/text/cases в OpenAPI-инсталляторе k8s.io/apiserver. В первом случае обрабатывается имя хоста, которое берётся из in-cluster-конфигурации Kubernetes API, адреса OTLP-коллектора и параметров DeschedulerPolicy, то есть задаётся администратором кластера, а не атакующим; для ASCII-имён вызов idna пропускается по быстрому пути. Во втором случае на вход подаются константные строки. Серверный путь обработки входящих HTTP/2-запросов (httpcommon.NewServerRequest) idna и norm не вызывает, поэтому клиент не может передать некорректный UTF-8 в уязвимый код.",
+      "timestamp": "2026-08-20T14:26:09.512874Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-46600"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "Уязвимость находится в пакете golang.org/x/net/dns/dnsmessage и проявляется при разборе некорректных ресурсных записей SVCB и HTTPS (Parser.SVCBResource, Parser.HTTPSResource, Message.Unpack). Пакет dns/dnsmessage не входит в граф зависимостей собираемого бинарного файла descheduler: из модуля golang.org/x/net используются только подпакеты idna, http2, http/httpguts, http/httpproxy, websocket и trace. Разрешение имён выполняется штатным резолвером Go, функция net.LookupCNAME, к которой относится одноимённая проблема во вендоренной копии пакета в стандартной библиотеке, компонентом не вызывается, а сборка выполняется с CGO_ENABLED=0. Уязвимый код в образе отсутствует.",
+      "timestamp": "2026-08-20T14:38:52.09164Z"
+    }
+  ],
+  "timestamp": "2026-08-20T14:41:03Z"
+}

--- a/modules/400-descheduler/images/descheduler/known_vulnerabilities.vex
+++ b/modules/400-descheduler/images/descheduler/known_vulnerabilities.vex
@@ -15,7 +15,7 @@
       ],
       "status": "not_affected",
       "justification": "vulnerable_code_not_in_execute_path",
-      "impact_statement": "Уязвимость объединяет три проблемы grpc-go: обход авторизации и панику в движке xDS RBAC (google.golang.org/grpc/internal/xds/rbac) и обход защиты от HTTP/2 Rapid Reset в серверном транспорте (internal/transport, http2_server.go). Descheduler использует google.golang.org/grpc только в клиентском режиме: для экспорта трассировок через otlptracegrpc и как транзитивную зависимость клиентских библиотек Kubernetes. gRPC-сервер не создаётся и не запускается, вызов grpc.NewServer в коде компонента отсутствует, а метрики и healthz отдаются обычным HTTP-сервером. Пакеты google.golang.org/grpc/xds и google.golang.org/grpc/internal/xds/rbac не входят в граф зависимостей собираемого бинарного файла. Изменения клиентского транспорта в исправляющем коммите носят характер рефакторинга типов и не связаны с эксплуатацией. Уязвимый код не исполняется.",
+      "impact_statement": "Descheduler использует google.golang.org/grpc только в клиентском режиме: для экспорта трассировок через otlptracegrpc и как транзитивную зависимость клиентских библиотек Kubernetes. gRPC-сервер не создаётся и не запускается, вызов grpc.NewServer в коде компонента отсутствует, а метрики и healthz отдаются обычным HTTP-сервером. Пакеты google.golang.org/grpc/xds и google.golang.org/grpc/internal/xds/rbac не входят в граф зависимостей собираемого бинарного файла. Изменения клиентского транспорта в исправляющем коммите носят характер рефакторинга типов и не связаны с эксплуатацией. Уязвимый код не исполняется.",
       "timestamp": "2026-08-20T14:12:35.847213Z"
     },
     {


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

| Vulnerability | Component | Justification |
|---|---|---|
| `GHSA-hrxh-6v49-42gf` | `google.golang.org/grpc` v1.81.1 | `vulnerable_code_not_in_execute_path` |
| `CVE-2026-56852` | `golang.org/x/text` v0.37.0 | `vulnerable_code_cannot_be_controlled_by_adversary` |
| `CVE-2026-46600` | `golang.org/x/net` v0.55.0 | `vulnerable_code_not_present` |

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: descheduler
type: chore
summary: add vex statements for High CVEs in grpc, x/text and x/net
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
