### PR TITLE
[vertical-pod-autoscaler] add vexes

### DIFF
--- a/modules/302-vertical-pod-autoscaler/images/admission-controller/known_vulnerabilities.vex
+++ b/modules/302-vertical-pod-autoscaler/images/admission-controller/known_vulnerabilities.vex
@@ -1,0 +1,37 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "merged-vex-9325a4086a67a79185628f647a2af019abc5eb9c58b8707242fcdc2a732ecc58",
+  "author": "Deckhouse <contact@deckhouse.io>",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-56852"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/text"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость затрагивает итератор golang.org/x/text/unicode/norm.Iter: при обходе входных данных с некорректными UTF-8-последовательностями он может зациклиться. В бинарнике admission-controller пакет unicode/norm присутствует, но его единственный потребитель — golang.org/x/net/idna, который вызывает только API формы нормализации: norm.NFC.String, norm.NFC.Bytes, norm.NFC.QuickSpan и norm.NFC.IsNormalString. Тип norm.Iter не используется ни одним пакетом из графа зависимостей (проверено go list -deps для pkg/admission-controller на vertical-pod-autoscaler-1.7.0 с наложенными патчами модуля), а внутри самого пакета norm он изолирован в iter.go и не вызывается из normalize.go. Воспроизводящий пример из upstream-теста исправления на x/text v0.37.0 зацикливает только norm.Iter, тогда как все перечисленные методы Form возвращаются штатно. Уязвимый код недостижим.",
+      "timestamp": "2026-08-20T14:08:53.472016Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-46600"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "Уязвимость находится в пакете golang.org/x/net/dns/dnsmessage — паника при разборе некорректных SVCB/HTTPS-записей, когда размер значения параметра выходит за границы буфера сообщения. В графе пакетов admission-controller этот пакет отсутствует: из модуля golang.org/x/net v0.55.0 в сборку попадают только idna, http/httpguts, http2, http2/hpack, internal/httpcommon и internal/httpsfv (проверено go list -deps для pkg/admission-controller на vertical-pod-autoscaler-1.7.0 с наложенными патчами модуля). Разбор DNS выполняет штатный резолвер Go через собственную vendored-копию dnsmessage в составе стандартной библиотеки — это отдельный продукт (stdlib), который обновляется бампом Go toolchain в рамках планового апгрейда базовых образов, а не зависимостями данного модуля. Уязвимый код из golang.org/x/net в сборку не входит.",
+      "timestamp": "2026-08-20T14:14:37.6083Z"
+    }
+  ],
+  "timestamp": "2026-08-20T14:15:11Z"
+}

--- a/modules/302-vertical-pod-autoscaler/images/admission-controller/werf.inc.yaml
+++ b/modules/302-vertical-pod-autoscaler/images/admission-controller/werf.inc.yaml
@@ -11,3 +11,5 @@ imageSpec:
   config:
     entrypoint: ["/admission-controller"]
     cmd: ["--v=4", "--stderrthreshold=info"]
+---
+{{- include "vex mitigation" (list $ (printf "%s/%s" $.ModuleName $.ImageName )) }}

--- a/modules/302-vertical-pod-autoscaler/images/recommender/known_vulnerabilities.vex
+++ b/modules/302-vertical-pod-autoscaler/images/recommender/known_vulnerabilities.vex
@@ -1,0 +1,37 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "merged-vex-792528ccdfcb360d6b38ea572339e67fd76ef7c0f1164374dcba3d6e78d58f0f",
+  "author": "Deckhouse <contact@deckhouse.io>",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-56852"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/text"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость затрагивает итератор golang.org/x/text/unicode/norm.Iter: при обходе входных данных с некорректными UTF-8-последовательностями он может зациклиться. В бинарнике recommender пакет unicode/norm присутствует, но его единственный потребитель — golang.org/x/net/idna, который вызывает только API формы нормализации: norm.NFC.String, norm.NFC.Bytes, norm.NFC.QuickSpan и norm.NFC.IsNormalString. Тип norm.Iter не используется ни одним пакетом из графа зависимостей (проверено go list -deps для pkg/recommender на vertical-pod-autoscaler-1.7.0 с наложенными патчами модуля), а внутри самого пакета norm он изолирован в iter.go и не вызывается из normalize.go. Воспроизводящий пример из upstream-теста исправления на x/text v0.37.0 зацикливает только norm.Iter, тогда как все перечисленные методы Form возвращаются штатно. Уязвимый код недостижим.",
+      "timestamp": "2026-08-20T13:42:07.612844Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-46600"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "Уязвимость находится в пакете golang.org/x/net/dns/dnsmessage — паника при разборе некорректных SVCB/HTTPS-записей, когда размер значения параметра выходит за границы буфера сообщения. В графе пакетов recommender этот пакет отсутствует: из модуля golang.org/x/net v0.55.0 в сборку попадают только idna, http/httpguts, http2, http2/hpack, internal/httpcommon и internal/httpsfv (проверено go list -deps для pkg/recommender на vertical-pod-autoscaler-1.7.0 с наложенными патчами модуля). Разбор DNS выполняет штатный резолвер Go через собственную vendored-копию dnsmessage в составе стандартной библиотеки — это отдельный продукт (stdlib), который обновляется бампом Go toolchain в рамках планового апгрейда базовых образов, а не зависимостями данного модуля. Уязвимый код из golang.org/x/net в сборку не входит.",
+      "timestamp": "2026-08-20T13:49:22.30517Z"
+    }
+  ],
+  "timestamp": "2026-08-20T13:50:04Z"
+}

--- a/modules/302-vertical-pod-autoscaler/images/recommender/werf.inc.yaml
+++ b/modules/302-vertical-pod-autoscaler/images/recommender/werf.inc.yaml
@@ -9,3 +9,5 @@ import:
 imageSpec:
   config:
     entrypoint: ["/recommender"]
+---
+{{- include "vex mitigation" (list $ (printf "%s/%s" $.ModuleName $.ImageName )) }}

--- a/modules/302-vertical-pod-autoscaler/images/updater/known_vulnerabilities.vex
+++ b/modules/302-vertical-pod-autoscaler/images/updater/known_vulnerabilities.vex
@@ -1,0 +1,37 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "merged-vex-642feb22aa75cdfead8050beea783a62233df9ea5f46ff497abd7fa75a06a621",
+  "author": "Deckhouse <contact@deckhouse.io>",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-56852"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/text"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость затрагивает итератор golang.org/x/text/unicode/norm.Iter: при обходе входных данных с некорректными UTF-8-последовательностями он может зациклиться. В бинарнике updater пакет unicode/norm присутствует, но его единственный потребитель — golang.org/x/net/idna, который вызывает только API формы нормализации: norm.NFC.String, norm.NFC.Bytes, norm.NFC.QuickSpan и norm.NFC.IsNormalString. Тип norm.Iter не используется ни одним пакетом из графа зависимостей (проверено go list -deps для pkg/updater на vertical-pod-autoscaler-1.7.0 с наложенными патчами модуля), а внутри самого пакета norm он изолирован в iter.go и не вызывается из normalize.go. Воспроизводящий пример из upstream-теста исправления на x/text v0.37.0 зацикливает только norm.Iter, тогда как все перечисленные методы Form возвращаются штатно. Уязвимый код недостижим.",
+      "timestamp": "2026-08-20T13:56:41.128395Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-46600"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "Уязвимость находится в пакете golang.org/x/net/dns/dnsmessage — паника при разборе некорректных SVCB/HTTPS-записей, когда размер значения параметра выходит за границы буфера сообщения. В графе пакетов updater этот пакет отсутствует: из модуля golang.org/x/net v0.55.0 в сборку попадают только idna, http/httpguts, http2, http2/hpack, internal/httpcommon и internal/httpsfv (проверено go list -deps для pkg/updater на vertical-pod-autoscaler-1.7.0 с наложенными патчами модуля). Разбор DNS выполняет штатный резолвер Go через собственную vendored-копию dnsmessage в составе стандартной библиотеки — это отдельный продукт (stdlib), который обновляется бампом Go toolchain в рамках планового апгрейда базовых образов, а не зависимостями данного модуля. Уязвимый код из golang.org/x/net в сборку не входит.",
+      "timestamp": "2026-08-20T14:01:18.94702Z"
+    }
+  ],
+  "timestamp": "2026-08-20T14:02:03Z"
+}

--- a/modules/302-vertical-pod-autoscaler/images/updater/werf.inc.yaml
+++ b/modules/302-vertical-pod-autoscaler/images/updater/werf.inc.yaml
@@ -10,3 +10,5 @@ imageSpec:
   config:
     entrypoint: ["/updater"]
     cmd: ["--v=4", "--stderrthreshold=info"]
+---
+{{- include "vex mitigation" (list $ (printf "%s/%s" $.ModuleName $.ImageName )) }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Adds `known_vulnerabilities.vex` files for the three `vertical-pod-autoscaler`
final images — `recommender`, `updater`, `admission-controller` — with `not_affected` statements
for two High-severity findings reported by Trivy/DefectDojo, and wires the VEX attestation into
the build.


| CVE | Package | Lever | Justification |
|---|---|---|---|
| CVE-2026-56852 | `golang.org/x/text` v0.37.0 | VEX | `vulnerable_code_not_in_execute_path` |
| CVE-2026-46600 | `golang.org/x/net` v0.55.0 | VEX | `vulnerable_code_not_present` |

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: vertical-pod-autoscaler
type: chore
summary: add vex statements for High CVEs in golang.org/x/text and golang.org/x/net
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
