### PR TITLE
[registry-packages-proxy] Resolve CLI artifacts at the registry root above the edition

### DIFF
--- a/go_lib/registry-packages-proxy/proxy/cli_handler_test.go
+++ b/go_lib/registry-packages-proxy/proxy/cli_handler_test.go
@@ -125,6 +125,8 @@ type fakeCLIRegistryClient struct {
 	layerDigest         string
 	// rawManifests maps "path:ref" -> raw manifest bytes for GetRawManifest.
 	rawManifests map[string]string
+	// repos records cfg.Repository of every call, in order.
+	repos []string
 
 	getPackageCalls int32
 	listTagsCalls   int32
@@ -137,7 +139,23 @@ type fakeCLIRegistryClient struct {
 	manifestErr   error
 }
 
-func (f *fakeCLIRegistryClient) ListTags(_ context.Context, _ pkgLog.Logger, _ *registry.ClientConfig, path string) ([]string, error) {
+func (f *fakeCLIRegistryClient) recordRepo(cfg *registry.ClientConfig) {
+	if cfg == nil {
+		return
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.repos = append(f.repos, cfg.Repository)
+}
+
+func (f *fakeCLIRegistryClient) seenRepos() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.repos...)
+}
+
+func (f *fakeCLIRegistryClient) ListTags(_ context.Context, _ pkgLog.Logger, cfg *registry.ClientConfig, path string) ([]string, error) {
+	f.recordRepo(cfg)
 	atomic.AddInt32(&f.listTagsCalls, 1)
 	if f.listTagsErr != nil {
 		return nil, f.listTagsErr
@@ -151,7 +169,8 @@ func (f *fakeCLIRegistryClient) ListTags(_ context.Context, _ pkgLog.Logger, _ *
 	return tags, nil
 }
 
-func (f *fakeCLIRegistryClient) ResolveTag(_ context.Context, _ pkgLog.Logger, _ *registry.ClientConfig, path, tag string, platform *v1.Platform) (string, error) {
+func (f *fakeCLIRegistryClient) ResolveTag(_ context.Context, _ pkgLog.Logger, cfg *registry.ClientConfig, path, tag string, platform *v1.Platform) (string, error) {
+	f.recordRepo(cfg)
 	atomic.AddInt32(&f.resolveTagCalls, 1)
 	if f.resolveTagErr != nil {
 		return "", f.resolveTagErr
@@ -171,7 +190,8 @@ func (f *fakeCLIRegistryClient) ResolveTag(_ context.Context, _ pkgLog.Logger, _
 	return d, nil
 }
 
-func (f *fakeCLIRegistryClient) GetPackage(_ context.Context, _ pkgLog.Logger, _ *registry.ClientConfig, _ string, _ string) (int64, string, io.ReadCloser, error) {
+func (f *fakeCLIRegistryClient) GetPackage(_ context.Context, _ pkgLog.Logger, cfg *registry.ClientConfig, _ string, _ string) (int64, string, io.ReadCloser, error) {
+	f.recordRepo(cfg)
 	atomic.AddInt32(&f.getPackageCalls, 1)
 	if f.getPackageErr != nil {
 		return 0, "", nil, f.getPackageErr
@@ -179,7 +199,8 @@ func (f *fakeCLIRegistryClient) GetPackage(_ context.Context, _ pkgLog.Logger, _
 	return int64(len(f.packageBody)), f.layerDigest, io.NopCloser(bytes.NewReader(f.packageBody)), nil
 }
 
-func (f *fakeCLIRegistryClient) GetRawManifest(_ context.Context, _ pkgLog.Logger, _ *registry.ClientConfig, path, ref string) ([]byte, string, error) {
+func (f *fakeCLIRegistryClient) GetRawManifest(_ context.Context, _ pkgLog.Logger, cfg *registry.ClientConfig, path, ref string) ([]byte, string, error) {
+	f.recordRepo(cfg)
 	atomic.AddInt32(&f.manifestCalls, 1)
 	if f.manifestErr != nil {
 		return nil, "", f.manifestErr
@@ -553,4 +574,114 @@ func TestCLIHandler_GetManifest_NotFound(t *testing.T) {
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+func TestCLIRegistryRepository(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]string{
+		// Edition repositories collapse to the shared root.
+		"registry.deckhouse.io/deckhouse/ee":            "registry.deckhouse.io/deckhouse",
+		"registry.deckhouse.io/deckhouse/ce":            "registry.deckhouse.io/deckhouse",
+		"registry.deckhouse.io/deckhouse/be":            "registry.deckhouse.io/deckhouse",
+		"registry.deckhouse.io/deckhouse/se":            "registry.deckhouse.io/deckhouse",
+		"registry.deckhouse.io/deckhouse/se-plus":       "registry.deckhouse.io/deckhouse",
+		"registry.deckhouse.io/deckhouse/fe/":           "registry.deckhouse.io/deckhouse",
+		"registry-cse.deckhouse.ru/deckhouse/cse":       "registry-cse.deckhouse.ru/deckhouse",
+		"registry.company.com:5000/mirror/deckhouse/ee": "registry.company.com:5000/mirror/deckhouse",
+		// Repositories without an edition segment are the root already.
+		"dev-registry.deckhouse.io/sys/deckhouse-oss": "dev-registry.deckhouse.io/sys/deckhouse-oss",
+		"registry.company.com/deckhouse":              "registry.company.com/deckhouse",
+		"registry.company.com/ee-mirror":              "registry.company.com/ee-mirror",
+		"registry.company.com/deckhouse/EE":           "registry.company.com/deckhouse/EE",
+		"registry.local:5000":                         "registry.local:5000",
+	}
+
+	for in, want := range cases {
+		in, want := in, want
+		t.Run(in, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, want, cliRegistryRepository(in))
+		})
+	}
+}
+
+// TestCLIHandler_ResolvesArtifactsAtRegistryRoot: every /v1/images/* route
+// reads from the registry root above the cluster's edition repository, for
+// both deckhouse-cli and its plugins.
+func TestCLIHandler_ResolvesArtifactsAtRegistryRoot(t *testing.T) {
+	fake := &fakeCLIRegistryClient{
+		tags: map[string][]string{
+			"deckhouse-cli":             {"v1.0.0"},
+			"deckhouse-cli/plugins/foo": {"v0.1.0"},
+		},
+		tagToManifestDigest: map[string]string{
+			"deckhouse-cli/plugins/foo:v0.1.0": "sha256:feedface",
+		},
+		rawManifests: map[string]string{
+			"deckhouse-cli/plugins/foo:v0.1.0": `{"schemaVersion":2}`,
+		},
+		packageBody: []byte("plugin-binary"),
+		layerDigest: "abc123",
+	}
+	getter := &fakeCLIGetter{cfg: &registry.ClientConfig{
+		Repository: "registry.deckhouse.io/deckhouse/ee",
+		Scheme:     "https",
+		Auth:       "bGljZW5zZS10b2tlbjpzZWNyZXQ=",
+	}}
+	p := newTestProxy(t, fake, getter, nil)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(cliImagesPathPrefix, p.CLIHandler())
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	for _, urlPath := range []string{
+		"/v1/images/deckhouse-cli/tags",
+		"/v1/images/deckhouse-cli/plugins/foo/tags",
+		"/v1/images/deckhouse-cli/plugins/foo/manifests/v0.1.0",
+		"/v1/images/deckhouse-cli/plugins/foo/images/v0.1.0",
+	} {
+		resp, err := http.Get(srv.URL + urlPath)
+		require.NoError(t, err, urlPath)
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode, urlPath)
+	}
+
+	repos := fake.seenRepos()
+	// tags, tags, manifest, resolve + pull: five registry calls.
+	require.Len(t, repos, 5)
+	for _, repo := range repos {
+		assert.Equal(t, "registry.deckhouse.io/deckhouse", repo, "edition segment must be dropped for CLI artifacts")
+	}
+	// The rest of the registry config travels unchanged.
+	cfg, err := getter.Get(registry.DefaultRepository)
+	require.NoError(t, err)
+	assert.Equal(t, "registry.deckhouse.io/deckhouse/ee", cfg.Repository, "the getter-owned config must not be mutated")
+}
+
+// TestCLIHandler_KeepsRepositoryWithoutEdition: a cluster repository with no
+// edition segment (dev registries, air-gapped mirrors) is used as is.
+func TestCLIHandler_KeepsRepositoryWithoutEdition(t *testing.T) {
+	fake := &fakeCLIRegistryClient{
+		tags: map[string][]string{"deckhouse-cli/plugins/foo": {"v0.1.0"}},
+	}
+	getter := &fakeCLIGetter{cfg: &registry.ClientConfig{
+		Repository: "dev-registry.deckhouse.io/sys/deckhouse-oss",
+		Scheme:     "https",
+	}}
+	p := newTestProxy(t, fake, getter, nil)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(cliImagesPathPrefix, p.CLIHandler())
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/v1/images/deckhouse-cli/plugins/foo/tags")
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	assert.Equal(t, []string{"dev-registry.deckhouse.io/sys/deckhouse-oss"}, fake.seenRepos())
 }

--- a/go_lib/registry-packages-proxy/proxy/cli_handler_test.go
+++ b/go_lib/registry-packages-proxy/proxy/cli_handler_test.go
@@ -587,7 +587,6 @@ func TestCLIRegistryRepository(t *testing.T) {
 		"registry.deckhouse.io/deckhouse/se":            "registry.deckhouse.io/deckhouse",
 		"registry.deckhouse.io/deckhouse/se-plus":       "registry.deckhouse.io/deckhouse",
 		"registry.deckhouse.io/deckhouse/fe/":           "registry.deckhouse.io/deckhouse",
-		"registry-cse.deckhouse.ru/deckhouse/cse":       "registry-cse.deckhouse.ru/deckhouse",
 		"registry.company.com:5000/mirror/deckhouse/ee": "registry.company.com:5000/mirror/deckhouse",
 		// Repositories without an edition segment are the root already.
 		"dev-registry.deckhouse.io/sys/deckhouse-oss": "dev-registry.deckhouse.io/sys/deckhouse-oss",
@@ -595,6 +594,15 @@ func TestCLIRegistryRepository(t *testing.T) {
 		"registry.company.com/ee-mirror":              "registry.company.com/ee-mirror",
 		"registry.company.com/deckhouse/EE":           "registry.company.com/deckhouse/EE",
 		"registry.local:5000":                         "registry.local:5000",
+		// CSE keeps its editionless artifacts (the installer) under
+		// deckhouse/cse, so that path is a root of its own.
+		"registry-cse.deckhouse.ru/deckhouse/cse": "registry-cse.deckhouse.ru/deckhouse/cse",
+		// Stripping never eats the last path segment and leaves a bare host,
+		// nor empties the repository outright.
+		"registry.example.com/ee": "registry.example.com/ee",
+		"registry.local/se":       "registry.local/se",
+		"/ee":                     "/ee",
+		"//ee":                    "//ee",
 	}
 
 	for in, want := range cases {

--- a/go_lib/registry-packages-proxy/proxy/proxy.go
+++ b/go_lib/registry-packages-proxy/proxy/proxy.go
@@ -592,7 +592,8 @@ func (h *cliHandler) serveHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 // cliClientConfig resolves the default registry config and returns a private
-// copy with SignCheck stamped in. Callers must NOT mutate the value returned
+// copy pointed at the CLI artifacts repository (see cliRegistryRepository)
+// with SignCheck stamped in. Callers must NOT mutate the value returned
 // directly by the getter: the watcher rewrites those entries under a write
 // lock while readers still hold a pointer to them.
 func (h *cliHandler) cliClientConfig(w http.ResponseWriter, logger log.Logger) (*registry.ClientConfig, bool) {
@@ -607,8 +608,46 @@ func (h *cliHandler) cliClientConfig(w http.ResponseWriter, logger log.Logger) (
 		return nil, false
 	}
 	local := *cfg
+	local.Repository = cliRegistryRepository(cfg.Repository)
 	local.SignCheck = h.proxy.config.SignCheck
 	return &local, true
+}
+
+// editionSegments are the per-edition segments that end a Deckhouse registry
+// repository, e.g. the "ee" of registry.deckhouse.io/deckhouse/ee. The list
+// follows editions.yaml at the repository root.
+var editionSegments = map[string]struct{}{
+	"ce":      {},
+	"be":      {},
+	"se":      {},
+	"se-plus": {},
+	"ee":      {},
+	"fe":      {},
+	"cse":     {},
+}
+
+// cliRegistryRepository returns the repository holding the Deckhouse CLI
+// artifacts: deckhouse-cli and deckhouse-cli/plugins/<name>. They are
+// published once for all editions at the registry root, one level above the
+// cluster's edition repository:
+//
+//	registry.deckhouse.io/deckhouse/ee  ->  registry.deckhouse.io/deckhouse
+//
+// A repository that does not end with an edition segment (dev registries,
+// air-gapped mirrors pushed to a plain path) is that root already.
+func cliRegistryRepository(clusterRepository string) string {
+	repo := strings.TrimRight(clusterRepository, "/")
+
+	idx := strings.LastIndex(repo, "/")
+	if idx < 0 {
+		return repo
+	}
+
+	if _, isEdition := editionSegments[repo[idx+1:]]; !isEdition {
+		return repo
+	}
+
+	return repo[:idx]
 }
 
 func (h *cliHandler) handleListTags(w http.ResponseWriter, r *http.Request, imagePath string) {

--- a/go_lib/registry-packages-proxy/proxy/proxy.go
+++ b/go_lib/registry-packages-proxy/proxy/proxy.go
@@ -614,8 +614,15 @@ func (h *cliHandler) cliClientConfig(w http.ResponseWriter, logger log.Logger) (
 }
 
 // editionSegments are the per-edition segments that end a Deckhouse registry
-// repository, e.g. the "ee" of registry.deckhouse.io/deckhouse/ee. The list
-// follows editions.yaml at the repository root.
+// repository, e.g. the "ee" of registry.deckhouse.io/deckhouse/ee.
+//
+// The list matches Edition.IsValid in the deckhouse-cli client, which decides
+// where `d8 mirror pull` reads the CLI artifacts from and where `d8 mirror
+// push` writes them. Both sides must agree, so keep them in sync.
+//
+// "cse" is absent on purpose: the CSE registry keeps the editionless
+// artifacts (the installer) under deckhouse/cse, so deckhouse/cse is a root
+// of its own, not an edition sub-path.
 var editionSegments = map[string]struct{}{
 	"ce":      {},
 	"be":      {},
@@ -623,7 +630,6 @@ var editionSegments = map[string]struct{}{
 	"se-plus": {},
 	"ee":      {},
 	"fe":      {},
-	"cse":     {},
 }
 
 // cliRegistryRepository returns the repository holding the Deckhouse CLI
@@ -647,7 +653,31 @@ func cliRegistryRepository(clusterRepository string) string {
 		return repo
 	}
 
-	return repo[:idx]
+	root := repo[:idx]
+
+	// The root keeps the host and at least one path segment. A repository
+	// like "registry.example.com/ee" names a project that happens to be
+	// called "ee", not an edition of a Deckhouse repository, and its CLI
+	// artifacts stay where they are.
+	if countPathSegments(root) < 2 {
+		return repo
+	}
+
+	return root
+}
+
+// countPathSegments counts the non-empty slash-separated parts of repo, the
+// host included.
+func countPathSegments(repo string) int {
+	count := 0
+
+	for _, segment := range strings.Split(repo, "/") {
+		if segment != "" {
+			count++
+		}
+	}
+
+	return count
 }
 
 func (h *cliHandler) handleListTags(w http.ResponseWriter, r *http.Request, imagePath string) {

--- a/modules/039-registry-packages-proxy/docs/README.md
+++ b/modules/039-registry-packages-proxy/docs/README.md
@@ -100,6 +100,8 @@ Allowed `<IMAGE>` values:
 - `deckhouse-cli`
 - `deckhouse-cli/plugins/<PLUGIN>`, where `<PLUGIN>` is a single path segment
 
+Deckhouse CLI artifacts are published once for all editions, at the registry root one level above the cluster's edition repository. The proxy takes the repository from the `d8-system/deckhouse-registry` secret and drops the trailing edition segment (`ce`, `be`, `se`, `se-plus`, `ee`, `fe`, `cse`). For example, a cluster with the `registry.deckhouse.io/deckhouse/ee` repository reads the images from `registry.deckhouse.io/deckhouse/deckhouse-cli` and `registry.deckhouse.io/deckhouse/deckhouse-cli/plugins/<PLUGIN>`. A repository without an edition segment is used as is. The credentials come from the same secret in both cases.
+
 The `/v1/images/<IMAGE>/images/<VERSION>` endpoint accepts an optional `platform=<OS>-<ARCH>` query parameter and picks the matching child manifest from a multi-platform index. If the parameter isn't set, the `linux/amd64` platform is used.
 
 The following is an example of a query for a list of Deckhouse CLI tags:

--- a/modules/039-registry-packages-proxy/docs/README_RU.md
+++ b/modules/039-registry-packages-proxy/docs/README_RU.md
@@ -100,6 +100,8 @@ Content-Disposition: attachment; filename="<ИМЯ-ПАКЕТА>.svg"
 - `deckhouse-cli`;
 - `deckhouse-cli/plugins/<PLUGIN>`, где `<PLUGIN>` — один сегмент пути.
 
+Артефакты Deckhouse CLI публикуются один раз для всех редакций: в корне реестра, на уровень выше репозитория редакции кластера. Прокси берёт репозиторий из секрета `d8-system/deckhouse-registry` и отбрасывает завершающий сегмент редакции (`ce`, `be`, `se`, `se-plus`, `ee`, `fe`, `cse`). Например, для кластера с репозиторием `registry.deckhouse.io/deckhouse/ee` образы читаются из `registry.deckhouse.io/deckhouse/deckhouse-cli` и `registry.deckhouse.io/deckhouse/deckhouse-cli/plugins/<PLUGIN>`. Репозиторий без сегмента редакции используется как есть. Учётные данные в обоих случаях берутся из того же секрета.
+
 Эндпоинт `/v1/images/<IMAGE>/images/<VERSION>` принимает необязательный параметр запроса `platform=<OS>-<ARCH>` и выбирает соответствующий дочерний манифест из мультиплатформенного индекса. Если параметр не указан, используется платформа `linux/amd64`.
 
 Пример запроса списка тегов Deckhouse CLI:


### PR DESCRIPTION
## Description

The `/v1/images/*` routes (`deckhouse-cli` and `deckhouse-cli/plugins/<name>`) now read from the registry root one level above the cluster's edition repository:

- `registry.deckhouse.io/deckhouse/ee` -> `registry.deckhouse.io/deckhouse`
- the trailing edition segment is dropped: `ce`, `be`, `se`, `se-plus`, `ee`, `fe`, `cse` (the list follows `editions.yaml`)
- a repository without an edition segment (`dev-registry.deckhouse.io/sys/deckhouse-oss`, an air-gapped mirror pushed to `registry.company.com/deckhouse`) is used unchanged
- credentials, scheme and CA still come from the `d8-system/deckhouse-registry` secret, only the path changes

Only the CLI routes are affected. `/package`, `/v1/packages/*` and node bootstrap are untouched. No component restarts beyond the usual module image update.

## Why do we need it, and what problem does it solve?

Deckhouse CLI and its plugins are published once for all editions, at the registry root: `registry.deckhouse.io/deckhouse/deckhouse-cli` and `registry.deckhouse.io/deckhouse/deckhouse-cli/plugins/<name>`.

The proxy joined the cluster repository with the image path as is:

- a production cluster on `registry.deckhouse.io/deckhouse/ee` looked for `deckhouse/ee/deckhouse-cli/plugins/<name>`, where nothing is published
- so `d8 plugins install` and `d8 dist update` through the proxy could not work against the production registry
- it worked on dev clusters only because their repository has no edition segment

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: registry-packages-proxy
type: fix
summary: The proxy serves `deckhouse-cli` and `deckhouse-cli/plugins/<name>` images from the registry root above the cluster's edition repository.
impact_level: default
```
