### PR TITLE
[node-manager] set minReadySeconds=1 on MachineDeployments

### DIFF
--- a/modules/040-node-manager/template_tests/module_test.go
+++ b/modules/040-node-manager/template_tests/module_test.go
@@ -708,6 +708,7 @@ metadata:
 spec:
   clusterName: static
   replicas: 0
+  minReadySeconds: 1
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -2093,6 +2094,8 @@ internal:
 					Expect(md.Field("spec.template.spec.clusterName").String()).To(Equal("app"))
 					Expect(md.Field("spec.template.spec.bootstrap.dataSecretName").String()).To(Equal(d.templateName))
 					Expect(md.Field("spec.template.spec.infrastructureRef.name").String()).To(Equal(d.templateName))
+					// Must stay non-zero: zero is unrepresentable in the v1beta1 MachineSet.
+					Expect(md.Field("spec.minReadySeconds").Int()).To(Equal(int64(1)))
 
 					annotations := md.Field("metadata.annotations").Map()
 					Expect(annotations["cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size"].String()).To(Equal("4"))
@@ -2233,6 +2236,8 @@ internal:
 					Expect(md.Field("spec.template.spec.clusterName").String()).To(Equal("dvp"))
 					Expect(md.Field("spec.template.spec.bootstrap.dataSecretName").String()).To(Equal(d.templateName))
 					Expect(md.Field("spec.template.spec.infrastructureRef.name").String()).To(Equal(d.templateName))
+					// Must stay non-zero: zero is unrepresentable in the v1beta1 MachineSet.
+					Expect(md.Field("spec.minReadySeconds").Int()).To(Equal(int64(1)))
 
 					annotations := md.Field("metadata.annotations").Map()
 					Expect(annotations["cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size"].String()).To(Equal("4"))

--- a/modules/040-node-manager/templates/node-group/_capi_machine_deployment.tpl
+++ b/modules/040-node-manager/templates/node-group/_capi_machine_deployment.tpl
@@ -35,6 +35,10 @@ metadata:
   {{- end }}
 spec:
   clusterName: {{ $context.Values.nodeManager.internal.cloudProvider.capiClusterName | quote }}
+  # Must stay non-zero: in the v1beta1 MachineSet minReadySeconds is int32+omitempty, so zero is
+  # indistinguishable from unset and the v1beta2 apply never converges, spinning MD<->MS forever.
+  # Drop once machinesets.cluster.x-k8s.io is stored as v1beta2.
+  minReadySeconds: 1
   selector: {}
   template:
     metadata:

--- a/modules/040-node-manager/templates/node-group/_static_or_hybrid_machine_deployment.tpl
+++ b/modules/040-node-manager/templates/node-group/_static_or_hybrid_machine_deployment.tpl
@@ -11,6 +11,8 @@ metadata:
 spec:
   clusterName: static
   replicas: {{ $ng.staticInstances.count | default "0" }}
+  # Must stay non-zero, see _capi_machine_deployment.tpl.
+  minReadySeconds: 1
   strategy:
     type: RollingUpdate
     rollingUpdate:


### PR DESCRIPTION
## Description

Render `minReadySeconds: 1` on both MachineDeployment templates (CAPI and static/hybrid) instead of leaving it unset. Covered by template tests.

`minReadySeconds` is how long a Machine must stay Ready before it counts as available; it gates `availableReplicas` and thus the pace of a rolling update. Going from an implicit 0 to 1 delays that by one second per Machine and changes nothing else.

No node rollout: CAPI strips the field before the template comparison and before the hash that names the MachineSet (`mdutil/util.go:429-447`, used at `util.go:382` and `machinedeployment_sync.go:234`). Existing MachineSets are updated in place.

## Why do we need it, and what problem does it solve?

Unset means zero, and zero cannot be stored. In the `v1beta1` MachineSet the field is `int32` + `omitempty`, indistinguishable from unset, and conversion maps it back to `nil` (`api/core/v1beta1/conversion.go:429-433`, `:449`). The MachineDeployment controller copies the zero into its MachineSet on every reconcile, `generation` is computed before down-conversion, so every apply counts as a change and re-triggers the controller.

Result on a live cluster: one MachineSet at `generation: 87157615` after 108 days, ~7 writes/s into etcd with byte-identical content, `kube-apiserver` at 3.4 cores / 4.4 GiB, and a constant

```
failed to patch MachineSet …: timed out waiting for the condition
```

from `patch.Helper` losing all five optimistic-lock retries against the churn. Any non-zero value survives the round-trip and the loop stops.

## Why do we need it in the patch release (if we do)?

Affected clusters burn etcd and apiserver continuously, and the loop does not stop on its own. Only releases that serve `v1beta2` while `machinesets.cluster.x-k8s.io` is still stored as `v1beta1` are affected — 1.69 ships a single-version CRD, `main` already stores `v1beta2`, so this is a release-only fix, not a cherry-pick. The proper fix is migrating the storage version, after which this line should be dropped.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: node-manager
type: fix
summary: Pin MachineDeployment minReadySeconds to 1 so the MachineSet apply converges.
impact_level: low
```
