### PR TITLE
[local-path-provisioner] Fix CVEs in Go dependencies

### DIFF
--- a/modules/031-local-path-provisioner/images/local-path-provisioner/patches/004-fix-cve.patch
+++ b/modules/031-local-path-provisioner/images/local-path-provisioner/patches/004-fix-cve.patch
@@ -1,0 +1,107 @@
+diff --git a/go.mod b/go.mod
+index e7edc9d..c279b3d 100644
+--- a/go.mod
++++ b/go.mod
+@@ -35,7 +35,7 @@ require (
+ 	github.com/google/uuid v1.6.0 // indirect
+ 	github.com/josharian/intern v1.0.0 // indirect
+ 	github.com/json-iterator/go v1.1.12 // indirect
+-	github.com/klauspost/compress v1.17.11 // indirect
++	github.com/klauspost/compress v1.18.7 // indirect
+ 	github.com/mailru/easyjson v0.9.0 // indirect
+ 	github.com/miekg/dns v1.1.62 // indirect
+ 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+@@ -49,15 +49,15 @@ require (
+ 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+ 	github.com/spf13/pflag v1.0.5 // indirect
+ 	github.com/x448/float16 v0.8.4 // indirect
+-	golang.org/x/mod v0.22.0 // indirect
+-	golang.org/x/net v0.38.0 // indirect
++	golang.org/x/mod v0.37.0 // indirect
++	golang.org/x/net v0.56.0 // indirect
+ 	golang.org/x/oauth2 v0.27.0 // indirect
+-	golang.org/x/sync v0.12.0 // indirect
+-	golang.org/x/sys v0.31.0 // indirect
+-	golang.org/x/term v0.30.0 // indirect
+-	golang.org/x/text v0.23.0 // indirect
++	golang.org/x/sync v0.21.0 // indirect
++	golang.org/x/sys v0.46.0 // indirect
++	golang.org/x/term v0.44.0 // indirect
++	golang.org/x/text v0.39.0 // indirect
+ 	golang.org/x/time v0.9.0 // indirect
+-	golang.org/x/tools v0.29.0 // indirect
++	golang.org/x/tools v0.47.0 // indirect
+ 	google.golang.org/protobuf v1.36.5 // indirect
+ 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
+ 	gopkg.in/inf.v0 v0.9.1 // indirect
+diff --git a/go.sum b/go.sum
+index 69989e8..98bd111 100644
+--- a/go.sum
++++ b/go.sum
+@@ -43,8 +43,8 @@ github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dv
+ github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
+ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
+ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+-github.com/klauspost/compress v1.17.11 h1:In6xLpyWOi1+C7tXUUWv2ot1QvBjxevKAaI6IXrJmUc=
+-github.com/klauspost/compress v1.17.11/go.mod h1:pMDklpSncoRMuLFrf1W9Ss9KT+0rH90U12bZKk7uwG0=
++github.com/klauspost/compress v1.18.7 h1:aUyZsS4kH3QTKurYhAOwAHxllVPnOthb3vPfnF1Ehjw=
++github.com/klauspost/compress v1.18.7/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
+ github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+ github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
+ github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+@@ -116,41 +116,41 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
+ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+ golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+ golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+-golang.org/x/mod v0.22.0 h1:D4nJWe9zXqHOmWqj4VMOJhvzj7bEZg4wEYa759z1pH4=
+-golang.org/x/mod v0.22.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
++golang.org/x/mod v0.37.0 h1:vF1DjpVEshcIqoEaauuHebaLk1O1forxjxBaVn884JQ=
++golang.org/x/mod v0.37.0/go.mod h1:m8S8VeM9r4dzDwjrKO0a1sZP3YjeMamRRlD+fmR2Q/0=
+ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+ golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+-golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
+-golang.org/x/net v0.38.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
++golang.org/x/net v0.56.0 h1:Rw8j/hFzGvJUZwNBXnAtf5sVDVt+65SK2C7IxCxZt5o=
++golang.org/x/net v0.56.0/go.mod h1:D3Ku6r+V6JROoZK144D2XfMHFcMq/0zSfLelVTCFKec=
+ golang.org/x/oauth2 v0.27.0 h1:da9Vo7/tDv5RH/7nZDz1eMGS/q1Vv1N/7FCrBhI9I3M=
+ golang.org/x/oauth2 v0.27.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT8=
+ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+-golang.org/x/sync v0.12.0 h1:MHc5BpPuC30uJk597Ri8TV3CNZcTLu6B6z4lJy+g6Jw=
+-golang.org/x/sync v0.12.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
++golang.org/x/sync v0.21.0 h1:HLII4xRRTtCRkxYp4HNFF0Js/Og6q2i++KXbg0gHCwM=
++golang.org/x/sync v0.21.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+ golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
+-golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+-golang.org/x/term v0.30.0 h1:PQ39fJZ+mfadBm0y5WlL4vlM7Sx1Hgf13sMIY2+QS9Y=
+-golang.org/x/term v0.30.0/go.mod h1:NYYFdzHoI5wRh/h5tDMdMqCqPJZEuNqVR5xJLd/n67g=
++golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
++golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
++golang.org/x/term v0.44.0 h1:0rLvDRCtNj0gZkyIXhCyOb2OAzEhLVqc4B+hrsBhrmc=
++golang.org/x/term v0.44.0/go.mod h1:7ze4MdzUzLXpSAoFP1H0bOI9aXDqveSvatT5vKcFh2Y=
+ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+ golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+-golang.org/x/text v0.23.0 h1:D71I7dUrlY+VX0gQShAThNGHFxZ13dGLBHQLVl1mJlY=
+-golang.org/x/text v0.23.0/go.mod h1:/BLNzu4aZCJ1+kcD0DNRotWKage4q2rGVAg4o22unh4=
++golang.org/x/text v0.39.0 h1:UbZz4pLOvn600D6Oh6GGEI6VAmndrEBLv8/6BEXzyus=
++golang.org/x/text v0.39.0/go.mod h1:3UwRclnC2g0TU9x8PZiyfOajCd1zaUNHF9cvqcQZ+ZM=
+ golang.org/x/time v0.9.0 h1:EsRrnYcQiGH+5FfbgvV4AP7qEZstoyrHB0DzarOQ4ZY=
+ golang.org/x/time v0.9.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
+ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+ golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+ golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+-golang.org/x/tools v0.29.0 h1:Xx0h3TtM9rzQpQuR4dKLrdglAmCEN5Oi+P74JdhdzXE=
+-golang.org/x/tools v0.29.0/go.mod h1:KMQVMRsVxU6nHCFXrBPhDB8XncLNLM0lIy/F14RP588=
++golang.org/x/tools v0.47.0 h1:7Kn5x/d1svx/PzryTsqeoZN4TZwqeH5pGWjefhLi/1Q=
++golang.org/x/tools v0.47.0/go.mod h1:dFHnyTvFWY212G+h7ZY4Vsp/K3U4/7W9TyVaAul8uCA=
+ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+ golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/modules/031-local-path-provisioner/images/local-path-provisioner/patches/README.md
+++ b/modules/031-local-path-provisioner/images/local-path-provisioner/patches/README.md
@@ -38,3 +38,29 @@ manages host-path directories that were originally created by root and
 therefore must run as root itself.
 
 The patch touches `util.go`.
+
+### 004-fix-cve.patch
+
+Bumps vulnerable transitive Go dependencies of `v0.0.36` (`go.mod`, `go.sum`):
+
+* `github.com/klauspost/compress` `v1.17.11` → `v1.18.7`
+* `golang.org/x/net` `v0.38.0` → `v0.56.0`
+* `golang.org/x/sys` `v0.31.0` → `v0.46.0`
+* `golang.org/x/text` `v0.23.0` → `v0.39.0`
+* `golang.org/x/mod`, `golang.org/x/sync`, `golang.org/x/term`, `golang.org/x/tools` — bumped to satisfy the module graph
+
+#### Fix CVEs
+
+- CVE-2025-47911
+- CVE-2025-58190
+- CVE-2026-25680
+- CVE-2026-25681
+- CVE-2026-27136
+- CVE-2026-33814
+- CVE-2026-39821
+- CVE-2026-39824
+- CVE-2026-42502
+- CVE-2026-42506
+- CVE-2026-46600
+- CVE-2026-56852
+- GHSA-259r-337f-4rfw


### PR DESCRIPTION
## Description

Adds `004-fix-cve.patch` to the `local-path-provisioner` image. The patch touches only `go.mod`/`go.sum` of the upstream `rancher/local-path-provisioner` v0.0.36 sources and bumps the vulnerable transitive Go dependencies:

| Module | Before | After |
|---|---|---|
| `github.com/klauspost/compress` | v1.17.11 | v1.18.7 |
| `golang.org/x/net` | v0.38.0 | v0.56.0 |
| `golang.org/x/sys` | v0.31.0 | v0.46.0 |
| `golang.org/x/text` | v0.23.0 | v0.39.0 |

`golang.org/x/mod`, `golang.org/x/sync`, `golang.org/x/term` and `golang.org/x/tools` are bumped as required by the module graph.

`patches/README.md` documents the patch and the list of fixed CVEs.

No changes to the module templates, RBAC or configuration — the binary is rebuilt from the same upstream tag, so the only effect is a restart of the `local-path-provisioner` Deployment on update.

## Why do we need it, and what problem does it solve?

`local-path-provisioner` v0.0.36 ships dependencies with known vulnerabilities. Two of them are reachable from the provisioner code path (verified with `govulncheck -mode=source`):

- `CVE-2026-33814` — infinite loop in the HTTP/2 transport of `golang.org/x/net` on a bad `SETTINGS_MAX_FRAME_SIZE` frame; reachable through the Kubernetes client used to read the module ConfigMap.
- `CVE-2026-39821` — `golang.org/x/net/idna` fails to reject ASCII-only Punycode-encoded labels.

The rest are not reachable from the called code but are still reported by the image scanners:

- `golang.org/x/net`: `CVE-2025-47911`, `CVE-2025-58190`, `CVE-2026-25680`, `CVE-2026-25681`, `CVE-2026-27136`, `CVE-2026-42502`, `CVE-2026-42506`, `CVE-2026-46600`
- `golang.org/x/text`: `CVE-2026-56852`
- `golang.org/x/sys`: `CVE-2026-39824`
- `github.com/klauspost/compress`: `GHSA-259r-337f-4rfw`

After the patch `govulncheck` reports no vulnerabilities in third-party modules for this image. The remaining findings are Go standard library ones, fixed by the `builder/golang` base image and out of scope for this repository.

## Why do we need it in the patch release (if we do)?

Yes — the image is affected by publicly known vulnerabilities, one of which (`CVE-2026-33814`, DoS) is reachable at runtime. The change is limited to dependency versions of an already shipped upstream tag, so the backport risk is minimal.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

Verified locally on a clean checkout of upstream `v0.0.36`: all four patches (`001`–`004`) apply with `git apply` without conflicts, the binary builds with the same command werf uses, and `govulncheck -mode=source` no longer reports vulnerable third-party modules.

Note: upstream's `TestLoadHelperPodFile/pod_securityContext_runAsUser_0_is_rejected` and `..._runAsGroup_0_is_rejected` fail on the patched tree. This is the pre-existing, intentional deviation introduced by `003-allow-root-helperpod.patch` and is unrelated to this change.

## Changelog entries

```changes
section: local-path-provisioner
type: fix
summary: Fix CVEs in the Go dependencies of the `local-path-provisioner` image.
impact: The `local-path-provisioner` Deployment will be restarted.
impact_level: low
```
