### PR TITLE
[user-authn] Stop copying the platform registry credential into DexAuthenticator namespaces

### DIFF
--- a/modules/150-user-authn/template_tests/authenticator_test.go
+++ b/modules/150-user-authn/template_tests/authenticator_test.go
@@ -115,6 +115,17 @@ var _ = Describe("Module :: user-authn :: helm template :: dex authenticator", f
   allowAccessToKubernetes: true
   spec:
     keepUsersLoggedInFor: "2h20m4s"
+- name: test-tenant
+  encodedName: justForTestTenant
+  namespace: my-app
+  credentials:
+    appDexSecret: dexSecret
+    cookieSecret: cookieSecret
+  spec:
+    applications:
+    - domain: tenant.example.com
+      ingressClassName: test
+      ingressSecretName: test
 `)
 			hec.ValuesSet("userAuthn.idTokenTTL", "2h20m4s")
 
@@ -166,6 +177,18 @@ var _ = Describe("Module :: user-authn :: helm template :: dex authenticator", f
       name: "test-05f0e90e-dex-authenticator"
       truncated: false
       hash: ""
+"test-tenant@my-app":
+  name: "test-tenant-dex-authenticator"
+  truncated: false
+  hash: ""
+  secretName: "dex-authenticator-test-tenant"
+  secretTruncated: false
+  secretHash: ""
+  ingressNames:
+    "0":
+      name: "test-tenant-dex-authenticator"
+      truncated: false
+      hash: ""
 `)
 			hec.HelmRender()
 		})
@@ -178,6 +201,7 @@ var _ = Describe("Module :: user-authn :: helm template :: dex authenticator", f
 			Expect(hec.KubernetesResource("PodDisruptionBudget", "d8-test", "test-dex-authenticator").Exists()).To(BeTrue())
 			Expect(hec.KubernetesResource("VerticalPodAutoscaler", "d8-test", "test-dex-authenticator").Exists()).To(BeTrue())
 			Expect(hec.KubernetesResource("Secret", "d8-test", "registry-dex-authenticator").Exists()).To(BeFalse())
+			Expect(hec.KubernetesResource("Secret", "my-app", "registry-dex-authenticator").Exists()).To(BeFalse())
 
 			secret := hec.KubernetesResource("Secret", "d8-test", "dex-authenticator-test")
 			Expect(secret.Exists()).To(BeTrue())
@@ -218,7 +242,7 @@ var _ = Describe("Module :: user-authn :: helm template :: dex authenticator", f
 
 			deploymentTest := hec.KubernetesResource("Deployment", "d8-test", "test-dex-authenticator")
 			Expect(deploymentTest.Exists()).To(BeTrue())
-			Expect(deploymentTest.Field("spec.template.spec.imagePullSecrets").Exists()).To(BeFalse())
+			Expect(deploymentTest.Field("spec.template.spec.imagePullSecrets").String()).To(MatchJSON(`[{"name":"deckhouse-registry"}]`))
 			Expect(deploymentTest.Field("spec.template.spec.nodeSelector").String()).To(MatchJSON(`{"testnode": ""}`))
 			Expect(deploymentTest.Field("spec.template.spec.tolerations").String()).To(MatchYAML(`
 - key: foo
@@ -275,7 +299,7 @@ var _ = Describe("Module :: user-authn :: helm template :: dex authenticator", f
 
 			deploymentTest2 := hec.KubernetesResource("Deployment", "d8-test", "test-2-dex-authenticator")
 			Expect(deploymentTest2.Exists()).To(BeTrue())
-			Expect(deploymentTest2.Field("spec.template.spec.imagePullSecrets").Exists()).To(BeFalse())
+			Expect(deploymentTest2.Field("spec.template.spec.imagePullSecrets").String()).To(MatchJSON(`[{"name":"deckhouse-registry"}]`))
 			Expect(deploymentTest2.Field("spec.template.spec.nodeSelector").String()).To(MatchJSON(`{"node-role.deckhouse.io/system": ""}`))
 			Expect(deploymentTest2.Field("spec.template.spec.tolerations").Exists()).To(BeTrue()) // default taints
 
@@ -311,6 +335,11 @@ var _ = Describe("Module :: user-authn :: helm template :: dex authenticator", f
 			}
 			Expect(oauth2proxyArgTest4).Should(ContainElement("--cookie-expire=2h20m5s"))
 			Expect(oauth2proxyArgTest4).Should(ContainElement("--cookie-refresh=2h20m4s"))
+
+			Expect(hec.KubernetesResource("Secret", "my-app", "dex-authenticator-test-tenant").Exists()).To(BeTrue())
+			deploymentTenant := hec.KubernetesResource("Deployment", "my-app", "test-tenant-dex-authenticator")
+			Expect(deploymentTenant.Exists()).To(BeTrue())
+			Expect(deploymentTenant.Field("spec.template.spec.imagePullSecrets").Exists()).To(BeFalse())
 		})
 	})
 

--- a/modules/150-user-authn/template_tests/authenticator_test.go
+++ b/modules/150-user-authn/template_tests/authenticator_test.go
@@ -177,7 +177,7 @@ var _ = Describe("Module :: user-authn :: helm template :: dex authenticator", f
 
 			Expect(hec.KubernetesResource("PodDisruptionBudget", "d8-test", "test-dex-authenticator").Exists()).To(BeTrue())
 			Expect(hec.KubernetesResource("VerticalPodAutoscaler", "d8-test", "test-dex-authenticator").Exists()).To(BeTrue())
-			Expect(hec.KubernetesResource("Secret", "d8-test", "registry-dex-authenticator").Exists()).To(BeTrue())
+			Expect(hec.KubernetesResource("Secret", "d8-test", "registry-dex-authenticator").Exists()).To(BeFalse())
 
 			secret := hec.KubernetesResource("Secret", "d8-test", "dex-authenticator-test")
 			Expect(secret.Exists()).To(BeTrue())
@@ -218,6 +218,7 @@ var _ = Describe("Module :: user-authn :: helm template :: dex authenticator", f
 
 			deploymentTest := hec.KubernetesResource("Deployment", "d8-test", "test-dex-authenticator")
 			Expect(deploymentTest.Exists()).To(BeTrue())
+			Expect(deploymentTest.Field("spec.template.spec.imagePullSecrets").Exists()).To(BeFalse())
 			Expect(deploymentTest.Field("spec.template.spec.nodeSelector").String()).To(MatchJSON(`{"testnode": ""}`))
 			Expect(deploymentTest.Field("spec.template.spec.tolerations").String()).To(MatchYAML(`
 - key: foo
@@ -274,6 +275,7 @@ var _ = Describe("Module :: user-authn :: helm template :: dex authenticator", f
 
 			deploymentTest2 := hec.KubernetesResource("Deployment", "d8-test", "test-2-dex-authenticator")
 			Expect(deploymentTest2.Exists()).To(BeTrue())
+			Expect(deploymentTest2.Field("spec.template.spec.imagePullSecrets").Exists()).To(BeFalse())
 			Expect(deploymentTest2.Field("spec.template.spec.nodeSelector").String()).To(MatchJSON(`{"node-role.deckhouse.io/system": ""}`))
 			Expect(deploymentTest2.Field("spec.template.spec.tolerations").Exists()).To(BeTrue()) // default taints
 

--- a/modules/150-user-authn/template_tests/authenticator_test.go
+++ b/modules/150-user-authn/template_tests/authenticator_test.go
@@ -126,6 +126,17 @@ var _ = Describe("Module :: user-authn :: helm template :: dex authenticator", f
     - domain: tenant.example.com
       ingressClassName: test
       ingressSecretName: test
+- name: test-kube
+  encodedName: justForTestKube
+  namespace: kube-test
+  credentials:
+    appDexSecret: dexSecret
+    cookieSecret: cookieSecret
+  spec:
+    applications:
+    - domain: kube.example.com
+      ingressClassName: test
+      ingressSecretName: test
 `)
 			hec.ValuesSet("userAuthn.idTokenTTL", "2h20m4s")
 
@@ -189,6 +200,18 @@ var _ = Describe("Module :: user-authn :: helm template :: dex authenticator", f
       name: "test-tenant-dex-authenticator"
       truncated: false
       hash: ""
+"test-kube@kube-test":
+  name: "test-kube-dex-authenticator"
+  truncated: false
+  hash: ""
+  secretName: "dex-authenticator-test-kube"
+  secretTruncated: false
+  secretHash: ""
+  ingressNames:
+    "0":
+      name: "test-kube-dex-authenticator"
+      truncated: false
+      hash: ""
 `)
 			hec.HelmRender()
 		})
@@ -202,6 +225,7 @@ var _ = Describe("Module :: user-authn :: helm template :: dex authenticator", f
 			Expect(hec.KubernetesResource("VerticalPodAutoscaler", "d8-test", "test-dex-authenticator").Exists()).To(BeTrue())
 			Expect(hec.KubernetesResource("Secret", "d8-test", "registry-dex-authenticator").Exists()).To(BeFalse())
 			Expect(hec.KubernetesResource("Secret", "my-app", "registry-dex-authenticator").Exists()).To(BeFalse())
+			Expect(hec.KubernetesResource("Secret", "kube-test", "registry-dex-authenticator").Exists()).To(BeFalse())
 
 			secret := hec.KubernetesResource("Secret", "d8-test", "dex-authenticator-test")
 			Expect(secret.Exists()).To(BeTrue())
@@ -340,6 +364,11 @@ var _ = Describe("Module :: user-authn :: helm template :: dex authenticator", f
 			deploymentTenant := hec.KubernetesResource("Deployment", "my-app", "test-tenant-dex-authenticator")
 			Expect(deploymentTenant.Exists()).To(BeTrue())
 			Expect(deploymentTenant.Field("spec.template.spec.imagePullSecrets").Exists()).To(BeFalse())
+
+			Expect(hec.KubernetesResource("Secret", "kube-test", "dex-authenticator-test-kube").Exists()).To(BeTrue())
+			deploymentKube := hec.KubernetesResource("Deployment", "kube-test", "test-kube-dex-authenticator")
+			Expect(deploymentKube.Exists()).To(BeTrue())
+			Expect(deploymentKube.Field("spec.template.spec.imagePullSecrets").String()).To(MatchJSON(`[{"name":"deckhouse-registry"}]`))
 		})
 	})
 

--- a/modules/150-user-authn/templates/dex-authenticator/deployment.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/deployment.yaml
@@ -165,6 +165,10 @@ spec:
       {{- include "helm_lib_priority_class" (tuple $context "cluster-low") | nindent 6 }}
       {{- include "helm_lib_pod_anti_affinity_for_ha" (list $context (dict "app" "dex-authenticator" "name" $crd.name) (dict "revisionScoped" true)) | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+{{- if or (hasPrefix "d8-" $crd.namespace) (hasPrefix "kube-" $crd.namespace) }}
+      imagePullSecrets:
+      - name: deckhouse-registry
+{{- end }}
       volumes:
       - name: tls
         emptyDir: {}

--- a/modules/150-user-authn/templates/dex-authenticator/deployment.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/deployment.yaml
@@ -165,8 +165,6 @@ spec:
       {{- include "helm_lib_priority_class" (tuple $context "cluster-low") | nindent 6 }}
       {{- include "helm_lib_pod_anti_affinity_for_ha" (list $context (dict "app" "dex-authenticator" "name" $crd.name) (dict "revisionScoped" true)) | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
-      imagePullSecrets:
-      - name: registry-dex-authenticator
       volumes:
       - name: tls
         emptyDir: {}

--- a/modules/150-user-authn/templates/dex-authenticator/secret.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/secret.yaml
@@ -21,18 +21,4 @@ metadata:
 data:
   client-secret: {{ $crd.credentials.appDexSecret | b64enc }}
   cookie-secret: {{ $crd.credentials.cookieSecret | b64enc }}
-  {{- $namespaces := (get $context "namespaces") | default (list) }}
-  {{- if not (has $crd.namespace $namespaces) }}
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: registry-dex-authenticator
-  namespace: {{ $crd.namespace | quote }}
-  {{- include "helm_lib_module_labels" (list $context (dict "app" "dex-authenticator")) | nindent 2 }}
-type: kubernetes.io/dockerconfigjson
-data:
-  .dockerconfigjson: {{ $context.Values.global.modulesImages.registry.dockercfg }}
-  {{- $_ := set $context "namespaces" (append $namespaces $crd.namespace) }}
-  {{- end }}
 {{- end }}


### PR DESCRIPTION
## Description

Stacked on #22216 because that PR already rewrites `templates/dex-authenticator/secret.yaml`. This change is only the extra `Secret/registry-dex-authenticator` document and the matching `imagePullSecrets` on the authenticator Deployment. Retarget to `main` after #22216 merges.

`templates/dex-authenticator/secret.yaml` copied `global.modulesImages.registry.dockercfg` into a `kubernetes.io/dockerconfigjson` Secret named `registry-dex-authenticator` in every namespace that hosts a `DexAuthenticator`. The authenticator Deployment then referenced that Secret as `imagePullSecrets`. The Secret lives in `{{ $crd.namespace }}`, so anyone who can `get`/`list` Secrets there obtained the platform registry credential.

The copy is removed. The cookie/client-secret Secret is unchanged.

Pull path after this change:

- A DexAuthenticator in a `d8-*` / `kube-*` namespace gets `imagePullSecrets: [{name: deckhouse-registry}]` instead of `registry-dex-authenticator`. That Secret already exists in those namespaces — the same credential path as other module workloads. The name change is a pod-template change, so those Deployments roll once.
- A DexAuthenticator in a tenant namespace has no `imagePullSecrets`. On `defaultCRI: Containerd` / `ContainerdV2` the node CRI already has registry auth (`hosts.toml`). On `defaultCRI: NotManaged` Deckhouse does not write node registry auth: CE anonymous pull still works; EE/FE/SE and private registries will fail a cold pull of a tenant authenticator. Dropping `imagePullSecrets` is also a pod-template change, so those Deployments roll once as well.

Every DexAuthenticator in the cluster therefore rolls once: platform authenticators on the ingress auth path (kiali, hubble-ui, openvpn, deckhouse-tools, documentation) and every tenant authenticator.

This PR only stops the **user-authn** copy. Istio still renders `Secret/d8-istio-sidecar-registry` with the same dockercfg into every mesh-enrolled namespace; that is out of scope here.

Do not mix this with #22219: that PR is about who may set `allow-access-to-kubernetes`, not about registry credentials.

## Why do we need it, and what problem does it solve?

It stops user-authn from distributing a cluster-level registry pull credential into tenant-readable namespaces. Creating any `DexAuthenticator` was enough; no extra annotation or cluster-admin right was required.

Leaving the Secret in place whenever `spec.nodeSelector` is not the system selector does not close the leak: that field is tenant-controlled. Moving the pods into `d8-user-authn` would break the documented in-cluster `auth-url` of the form `https://<svc>.<tenant-ns>.svc`.

## Why do we need it in the patch release (if we do)?

The copy is created on any cluster that has a `DexAuthenticator` outside `d8-*` / `kube-*`, so it is worth backporting to 1.77 and 1.76 together with #22216.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authn
type: fix
summary: Stop copying the platform registry credential into DexAuthenticator namespaces.
impact: |
  On upgrade Helm deletes Secret/registry-dex-authenticator from every namespace that hosts a DexAuthenticator. Every DexAuthenticator Deployment changes imagePullSecrets — d8-* / kube-* switch the name from registry-dex-authenticator to deckhouse-registry (that Secret already exists there); tenant Deployments drop imagePullSecrets — so every authenticator rolls once. That includes platform authenticators on the ingress auth path (kiali, hubble-ui, openvpn, deckhouse-tools, documentation) and every tenant authenticator.

  Tenant pods then pull with the node's CRI registry credentials when defaultCRI is Containerd or ContainerdV2. That node path is not configured when defaultCRI is NotManaged; CE anonymous pull is unaffected, EE/FE/SE and private registries can fail a cold pull of a tenant DexAuthenticator. The Secret that holds cookie-secret and client-secret is unchanged.

  If a DexAuthenticator already existed in a namespace where non-platform identities can read Secrets, the platform registry credential that was copied there must be treated as disclosed. Rotating that credential (the in-cluster deckhouse-registry Secret and the matching CRI config on nodes) is a separate operator action; this change only stops further copies from user-authn and removes the per-namespace ones.
impact_level: high
```