### PR TITLE
[istio] Add omitted module_tests over 1.29

### DIFF
--- a/modules/110-istio/template_tests/module_test.go
+++ b/modules/110-istio/template_tests/module_test.go
@@ -2001,6 +2001,66 @@ MY_VAR: "myvalue"
 			Expect(clusterRole.Exists()).To(BeTrue())
 			Expect(clusterRole.Field("rules").String()).To(ContainSubstring("backendtlspolicies"))
 		})
+
+		It("renders istiod ClusterRole with 1.29 gateway API BackendTLSPolicy permissions", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			istiodClusterRole := f.KubernetesGlobalResource("ClusterRole", "d8:istio:control-plane:iop:istiod-v1x29")
+			Expect(istiodClusterRole.Exists()).To(BeTrue())
+			Expect(istiodClusterRole.Field("rules").String()).To(ContainSubstring("backendtlspolicies"))
+			Expect(istiodClusterRole.Field("rules").String()).To(ContainSubstring("backendtlspolicies/status"))
+		})
+	})
+
+	Context("joint install of operator-backed 1.25 and operator-free 1.29", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", globalValues)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYamlWithOpenAPIDefaults("istio", istioValues)
+			f.ValuesSetFromYaml("istio.internal.versionMap", `
+"1.25":
+  revision: "v1x25"
+  fullVersion: "1.25.2"
+  imageSuffix: "V1x25x2"
+  supportsAmbient: true
+  supportsOperator: true
+"1.29":
+  revision: "v1x29"
+  fullVersion: "1.29.6"
+  imageSuffix: "V1x29x6"
+  supportsAmbient: true
+  supportsOperator: false
+`)
+			// Canary upgrade path: keep 1.25 as global, install 1.29 as additional revision.
+			f.ValuesSetFromYaml("istio.internal.versionsToInstall", `["1.25","1.29"]`)
+			f.ValuesSetFromYaml("istio.internal.operatorVersionsToInstall", `["1.25"]`)
+			f.ValuesSet("istio.internal.globalVersion", "1.25")
+			f.HelmRender()
+		})
+
+		It("renders Sail operator control plane for 1.25 and helm istiod for 1.29", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			istioV25 := f.KubernetesResource("Istio", "d8-istio", "v1x25")
+			Expect(istioV25.Exists()).To(BeTrue())
+			Expect(f.KubernetesResource("Deployment", "d8-istio", "operator-v1x25").Exists()).To(BeTrue())
+			Expect(f.KubernetesResource("Deployment", "d8-istio", "istiod-v1x25").Exists()).To(BeFalse())
+
+			Expect(f.KubernetesResource("Deployment", "d8-istio", "istiod-v1x29").Exists()).To(BeTrue())
+			Expect(f.KubernetesResource("Service", "d8-istio", "istiod-v1x29").Exists()).To(BeTrue())
+			Expect(f.KubernetesResource("ConfigMap", "d8-istio", "istio-v1x29").Exists()).To(BeTrue())
+			Expect(f.KubernetesResource("IstioOperator", "d8-istio", "v1x29").Exists()).To(BeFalse())
+			Expect(f.KubernetesResource("Istio", "d8-istio", "v1x29").Exists()).To(BeFalse())
+			Expect(f.KubernetesResource("Deployment", "d8-istio", "operator-v1x29").Exists()).To(BeFalse())
+
+			istiodClusterRoleV29 := f.KubernetesGlobalResource("ClusterRole", "d8:istio:control-plane:iop:istiod-v1x29")
+			Expect(istiodClusterRoleV29.Exists()).To(BeTrue())
+			Expect(istiodClusterRoleV29.Field("rules").String()).To(ContainSubstring("backendtlspolicies"))
+
+			istiodClusterRoleV25 := f.KubernetesGlobalResource("ClusterRole", "d8:istio:control-plane:iop:istiod-v1x25")
+			Expect(istiodClusterRoleV25.Exists()).To(BeTrue())
+			Expect(istiodClusterRoleV25.Field("rules").String()).NotTo(ContainSubstring("backendtlspolicies"))
+		})
 	})
 
 	Context("operator-free sidecar with custom static resourcesManagement configuration", func() {


### PR DESCRIPTION
## Description

Adds omitted Istio module template tests for version 1.29:

- Asserts that the istiod ClusterRole for revision `v1x29` includes Gateway API `backendtlspolicies` / `backendtlspolicies/status` permissions.
- Covers the canary upgrade render path: joint install of operator-backed 1.25 (Sail `Istio` CR + operator) and operator-free 1.29 (helm `istiod` Deployment/Service/ConfigMap, without operator/IOP/Sail CR), including the RBAC difference between the two revisions.

## Why do we need it, and what problem does it solve?

Istio 1.29 uses operator-free control-plane rendering and has 1.29-specific istiod RBAC (`BackendTLSPolicy`). Existing template coverage checked a standalone 1.29 control plane and the config-analyzer role, but did not lock in:

- the istiod ClusterRole rules that differ from older revisions;
- the documented canary layout (`globalVersion=1.25` + additional `1.29`), where Sail/operator and helm istiod must coexist correctly.

These tests close that gap so regressions in 1.29 RBAC or mixed-version rendering are caught in CI.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: chore
summary: Add template tests for Istio 1.29 RBAC and canary joint install with 1.25
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
