### PR TITLE
[base_images] update to v2.1.3 (ms 1.78)

### DIFF
--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -3935,7 +3935,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:4084498cbdb681577f79312814fb0b07d55c243401e6c301557c4b3b880cbf5f"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:08071b109453731fe526a9325ee2e14262646f14906e2397ea3a33d819de6571"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'
@@ -4050,7 +4050,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run node-controller tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:4084498cbdb681577f79312814fb0b07d55c243401e6c301557c4b3b880cbf5f"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:08071b109453731fe526a9325ee2e14262646f14906e2397ea3a33d819de6571"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/.github/workflows/build-and-test_main.yml
+++ b/.github/workflows/build-and-test_main.yml
@@ -1281,7 +1281,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:4084498cbdb681577f79312814fb0b07d55c243401e6c301557c4b3b880cbf5f"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:08071b109453731fe526a9325ee2e14262646f14906e2397ea3a33d819de6571"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -3563,7 +3563,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:4084498cbdb681577f79312814fb0b07d55c243401e6c301557c4b3b880cbf5f"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:08071b109453731fe526a9325ee2e14262646f14906e2397ea3a33d819de6571"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/candi/alt_base_images.yml
+++ b/candi/alt_base_images.yml
@@ -1,9 +1,9 @@
-# version=v2.1.2
+# version=v2.1.3
 REGISTRY_PATH: registry.deckhouse.io/container-factory
-base/distroless-fin: "sha256:68145e490a5fb7f475543836cd50f2a156c1c08f233f2e056ba54ee4aa3260b1" # from: base/scratch
-builder/distroless: "sha256:8981f522c3b254c393f9920ef152c2aca8c43fca2aeaf873de43b8f12381964d" # from: base/scratch
-builder/golang-1.25: "sha256:538638a6f02876d2aec950a62ee1ddcc36db5e505df81baecb13cb11e0b85ff9" # from: builder/distroless
-builder/golang-1.26: "sha256:4084498cbdb681577f79312814fb0b07d55c243401e6c301557c4b3b880cbf5f" # from: builder/distroless
-builder/golang: "sha256:4084498cbdb681577f79312814fb0b07d55c243401e6c301557c4b3b880cbf5f" # from: builder/distroless
+base/distroless-fin: "sha256:e24c06e0beeabf36e8d2f60c7edda31a5f2047c2fa6ae9d648d7fd6f7e5c0310" # from: scratch
+builder/distroless: "sha256:86ca0311d9335650bc5207bbe653b59475e39dd3a93a073ddfdc21180dd06e3b" # from: base/scratch
+builder/golang-1.25: "sha256:a5c0f098213eafce434dfb18533da45f192b72b8010e3e146ea73f037059ea9a" # from: builder/distroless
+builder/golang-1.26: "sha256:08071b109453731fe526a9325ee2e14262646f14906e2397ea3a33d819de6571" # from: builder/distroless
+builder/golang: "sha256:08071b109453731fe526a9325ee2e14262646f14906e2397ea3a33d819de6571" # from: builder/distroless
 minget-0.1: "sha256:2c4c67ddccd25bdf01ee0bc5ac77ca5eb0b8f826484250cc416fb7b0c47e4283" # from: base/scratch
 minget: "sha256:2c4c67ddccd25bdf01ee0bc5ac77ca5eb0b8f826484250cc416fb7b0c47e4283" # from: base/scratch


### PR DESCRIPTION
## Description
Update base images

## Why do we need it, and what problem does it solve?
Fix base/distroless image

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: chore
summary: [base_images] fix base/distroless final image
impact: low
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
