### PR TITLE
Backport: [user-authn] Remove list access to Dex credential storage from read-only roles

### DIFF
--- a/modules/140-user-authz/docs/README.md
+++ b/modules/140-user-authz/docs/README.md
@@ -493,9 +493,6 @@ delete,deletecollection,get,list,patch,update,watch:
     - machine.sapcloud.io/yandexmachineclasses
 get,list,patch,update,watch:
     - control-plane.deckhouse.io/controlplanenodes
-list:
-    - dex.coreos.com/offlinesessionses
-    - dex.coreos.com/passwords
 patch,update:
     - deckhouse.io/vcdaffinityrules
     - infrastructure.cluster.x-k8s.io/deckhouseclusters

--- a/modules/140-user-authz/docs/README_RU.md
+++ b/modules/140-user-authz/docs/README_RU.md
@@ -499,9 +499,6 @@ delete,deletecollection,get,list,patch,update,watch:
     - machine.sapcloud.io/yandexmachineclasses
 get,list,patch,update,watch:
     - control-plane.deckhouse.io/controlplanenodes
-list:
-    - dex.coreos.com/offlinesessionses
-    - dex.coreos.com/passwords
 patch,update:
     - deckhouse.io/vcdaffinityrules
     - infrastructure.cluster.x-k8s.io/deckhouseclusters

--- a/modules/150-user-authn/template_tests/cluster_roles_test.go
+++ b/modules/150-user-authn/template_tests/cluster_roles_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template_tests
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/helm"
+)
+
+var _ = Describe("Module :: user-authn :: helm template :: cluster roles", func() {
+	hec := SetupHelmConfig("")
+
+	BeforeEach(func() {
+		hec.ValuesSet("global.discovery.kubernetesVersion", "1.15.6")
+		hec.ValuesSet("global.modules.publicDomainTemplate", "%s.example.com")
+		hec.ValuesSet("global.modules.https.mode", "CertManager")
+		hec.ValuesSet("global.modules.https.certManager.clusterIssuerName", "letsencrypt")
+		hec.ValuesSet("global.modulesImages.registry.base", "registry.example.com")
+		hec.ValuesSet("global.enabledModules", []string{"cert-manager"})
+		hec.ValuesSet("global.discovery.d8SpecificNodeCountByRole.system", 2)
+		hec.ValuesSet("global.discovery.kubernetesCA", "plainstring")
+
+		hec.ValuesSet("userAuthn.internal.kubernetesDexClientAppSecret", "plainstring")
+		hec.ValuesSet("userAuthn.internal.dexTLS.crt", "plainstring")
+		hec.ValuesSet("userAuthn.internal.dexTLS.key", "plainstring")
+		hec.ValuesSet("userAuthn.internal.dexTLS.ca", "plainstring")
+
+		hec.HelmRender()
+	})
+
+	Context("By default", func() {
+		// A collection read of the Dex storage CRDs returns whole objects, `hash` and
+		// `previousHashes` included, so no verb on them is safe to hand to a subject that is
+		// not expected to read credentials. Only the dex and user-api service accounts may.
+		It("Should not grant user-facing roles access to the Dex credential storage CRDs", func() {
+			Expect(hec.RenderError).ToNot(HaveOccurred())
+
+			for _, name := range []string{
+				"d8:manage:permission:module:user-authn:view",
+				"d8:manage:permission:module:user-authn:edit",
+				"d8:user-authz:user-authn:cluster-admin",
+			} {
+				clusterRole := hec.KubernetesGlobalResource("ClusterRole", name)
+				Expect(clusterRole.Exists()).To(BeTrue(), name)
+				Expect(clusterRole.Field("rules.#.apiGroups").String()).ToNot(ContainSubstring("dex.coreos.com"), name)
+			}
+		})
+	})
+})

--- a/modules/150-user-authn/templates/rbacv2/manage/view.yaml
+++ b/modules/150-user-authn/templates/rbacv2/manage/view.yaml
@@ -33,14 +33,8 @@ rules:
   - get
   - list
   - watch
-# Read-only audit access to internal Dex storage CRDs (incident response: enumerate active
-# sessions, see which users have stored passwords). list-only — `get` on a single object
-# would expose bcrypt hashes / refresh tokens.
-# NOTE: plural is `offlinesessionses` (matches Dex CRD name).
-- apiGroups:
-  - dex.coreos.com
-  resources:
-  - passwords
-  - offlinesessionses
-  verbs:
-  - list
+# The internal Dex storage CRDs (`passwords`, `offlinesessionses`) are deliberately absent.
+# Restricting them to `list` is not a mitigation: a collection read returns whole objects, so
+# it discloses `hash` and `previousHashes` — the current and historical bcrypt credentials of
+# every local user, administrators included — plus refresh-token material. This role promises
+# read access to configuration only, so use `deckhouse.io` users for the account inventory.

--- a/modules/150-user-authn/templates/user-authz-cluster-roles.yaml
+++ b/modules/150-user-authn/templates/user-authz-cluster-roles.yaml
@@ -63,15 +63,8 @@ rules:
   - deletecollection
   - patch
   - update
-# Read-only audit access to internal Dex storage CRDs. Deliberately list-only:
-# `passwords` contain bcrypt-hashed credentials, `offlinesessionses` carry refresh tokens —
-# `get` on a single object would return the same secret material, so we keep ClusterAdmin
-# at the listing level only (enough to enumerate sessions for incident response).
-# NOTE: plural is `offlinesessionses` (matches Dex CRD name in crds/external/offlinesessionses.yaml).
-- apiGroups:
-  - dex.coreos.com
-  resources:
-  - passwords
-  - offlinesessionses
-  verbs:
-  - list
+# The internal Dex storage CRDs (`passwords`, `offlinesessionses`) are deliberately absent.
+# Withholding `get` is not a mitigation: `list` and `watch` return whole objects, so they
+# disclose `hash` and `previousHashes` — the current and historical bcrypt credentials of every
+# local user — plus refresh-token material. Session and lockout state is available from the
+# `deckhouse.io` resources this role already reads.


### PR DESCRIPTION
> Backport of #22215 to `release-1.77`. The automatic cherry-pick of `c5717dbc07` failed on three files; this is the manual equivalent, and every conflict was the same shape — the branch spells the text being **removed** differently, so git could not match the deletion.
>
> - `modules/150-user-authn/templates/user-authz-cluster-roles.yaml`: the branch carries an older wording of the comment above the grant, and `verbs: [list]` where `main` had `list` and `watch`. Resolved by accepting the deletion: the grant block goes, the new comment explaining why the CRDs are absent stays.
> - `modules/140-user-authz/docs/README.md` and its Russian mirror: the branch groups the two resources under a `list:` key where `main` had `list,watch:`. Resolved by accepting the deletion, which removes the key entirely since those were its only two entries.
>
> `modules/150-user-authn/template_tests/cluster_roles_test.go` and `templates/rbacv2/manage/view.yaml` applied without conflict.
>
> Verified on the branch: the grant is gone from the role, the two resources are gone from both documentation files, and `go test ./modules/150-user-authn/template_tests/ -count=1` passes — including the new spec that asserts no role reads `dex.coreos.com`.

## Description

Two ClusterRoles shipped by `user-authn` granted collection reads on the internal Dex storage CRDs `passwords.dex.coreos.com` and `offlinesessionses.dex.coreos.com`. This PR removes those rules:

- `modules/150-user-authn/templates/rbacv2/manage/view.yaml` — the module read-only role `d8:manage:permission:module:user-authn:view` had a `dex.coreos.com` rule with `list` on `passwords`, `offlinesessionses`.
- `modules/150-user-authn/templates/user-authz-cluster-roles.yaml` — the legacy `d8:user-authz:user-authn:cluster-admin` role had the same rule with `list` + `watch`.

Both rules carried comments claiming the grants were safe because only `get` would expose secret material. Those comments are deleted and replaced with a note stating the correct fact, so the reasoning is not reused to re-add the rules later.

`modules/140-user-authz/docs/README.md` and `README_RU.md` are regenerated (`go run ./helm_generate/ authz-generate-roles`), which drops the `dex.coreos.com/passwords` and `dex.coreos.com/offlinesessionses` entries from the published `ClusterAdmin` rule listing.

A template test asserts that none of `d8:manage:permission:module:user-authn:view`, `:edit`, or `d8:user-authz:user-authn:cluster-admin` grants any verb in the `dex.coreos.com` API group.

No cluster component loses access. The grants that remain on these CRDs belong to `dex` and `user-api` service accounts and to the `d8:user-authn:admin-kubeconfig` role bound to the `kubeadm:cluster-admins` group, which already has unrestricted API access.

## Why do we need it, and what problem does it solve?

The premise behind the grants was wrong: a Kubernetes `list` returns whole objects, not just names. A Dex `Password` object carries `hash` (the current bcrypt hash) and `previousHashes` (the history of prior hashes) alongside `email`, `groups`, and `lockedUntil`; `OfflineSessions` carries refresh-token material. So `list` — and `watch`, which is the same read delivered as a stream — disclosed current and historical credential hashes for every local user, administrators included, to subjects that are only supposed to read configuration. That contradicts the documented contract for the read-only role, which promises access to everything "except Secrets and RBAC resources", and it hands an offline cracking target to any viewer.

The stated purpose of the original grant was incident response: enumerating active sessions and seeing which users have stored passwords. That use case does not depend on reading Dex storage:

- Both roles keep `get`/`list`/`watch` on `deckhouse.io` `users` and `groups`, which is the account inventory.
- `User.status` exposes `groups` and `expireAt`; `UserOperation` covers the administrative actions (force logout, password reset, lock/unlock) that an incident responder actually performs.
- The `UserAccount` projection CRD being introduced in a parallel effort surfaces exactly the operational session data — `email`, `kind`, `connectorID`, `incorrectLoginAttempts`, `locked`, `lockedUntil` — without any hash material, which is the right long-term home for this view.

Known follow-up work, deliberately out of scope here: `User.spec.password` also holds a hash, and both roles still read `deckhouse.io` `users`. Removing that grant is a breaking change to the documented purpose of the role, so it is handled together with the `UserAccount` projection rather than in this PR.

## Why do we need it in the patch release (if we do)?

The `passwords`/`offlinesessionses` grant reached users in `v1.76.1` and is present in 1.76 and 1.77, so it should be backported to `release-1.77` and `release-1.76`. `release-1.75` never had the rule and is not affected.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authn
type: fix
summary: Remove list access to Dex password and offline-session storage from the user-authn read-only and cluster-admin roles.
impact: Subjects holding only the user-authn view role or the legacy ClusterAdmin user-authn role can no longer list `passwords.dex.coreos.com` or `offlinesessionses.dex.coreos.com`. Use `User` objects for user inventory instead.
impact_level: high
```
