### PR TITLE
[ci] Fix incorrect image promote order

### DIFF
--- a/.github/ci_templates/promote_image.yml
+++ b/.github/ci_templates/promote_image.yml
@@ -16,48 +16,6 @@
 
 {!{ define "promote_image_edition_steps" }!}
 {!{- $edition := index . 0 -}!}
-- name: Copy attestations ({!{$edition}!})
-  env:
-    WERF_ENV: {!{$edition}!}
-    STAGE_REGISTRY_HOST: ${{ steps.secrets.outputs.DECKHOUSE_REGISTRY_STAGE_HOST }}
-    DECKHOUSE_REGISTRY_HOST: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
-  run: |
-    set -euo pipefail
-    function regctl_copy() {
-      local attempt
-      for attempt in $(seq 1 5); do
-        regctl image copy "$@" && return 0
-        [[ $attempt -eq 5 ]] && return 1
-        echo "⚠️ [$(date -u)] regctl copy failed (attempt ${attempt}/5), retrying in 5s..."
-        sleep 5
-      done
-    }
-
-    REGISTRY_SUFFIX=$(echo "${WERF_ENV}" | tr '[:upper:]' '[:lower:]')
-    IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-    STAGE_PATH="${STAGE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}"
-    PROD_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}"
-
-    DIGESTS_JSON="images_digests-att.json"
-
-    if ! regctl image get-file "${STAGE_PATH}/install:${IMAGE_TAG}" /deckhouse/candi/images_digests.json > "${DIGESTS_JSON}" 2>/dev/null; then
-      echo "⚠️ [$(date -u)] Could not read /deckhouse/candi/images_digests.json from '${STAGE_PATH}/install:${IMAGE_TAG}', skipping digest attestations copy"
-      exit 1
-    fi
-
-    while IFS= read -r IMG_DIGEST; do
-      [[ -z "${IMG_DIGEST}" ]] && continue
-      D_HEX="${IMG_DIGEST#sha256:}"
-      SRC_ATT="${STAGE_PATH}:sha256-${D_HEX}.att"
-      DST_ATT="${PROD_PATH}:sha256-${D_HEX}.att"
-      if regctl image manifest "${SRC_ATT}" >/dev/null 2>&1; then
-        echo "⚓️ 💫 [$(date -u)] Copying attestation '${SRC_ATT}' -> '${DST_ATT}'"
-        regctl_copy "${SRC_ATT}" "${DST_ATT}"
-      fi
-    done < <(jq -r '[.. | strings | select(test("^sha256:[a-f0-9]{64}$"))] | unique | .[]' "${DIGESTS_JSON}")
-
-    rm -rf ${DIGESTS_JSON}
-
 - name: Promote images from stage to prod ({!{$edition}!})
   env:
     WERF_ENV: {!{$edition}!}
@@ -108,11 +66,6 @@
       fi
     }
 
-    promote_with_att ""
-    promote_with_att "install"
-    promote_with_att "install-standalone"
-    promote_with_att "release-channel"
-
     DIGESTS_JSON="images_digests-promote.json"
 
     # Promote from images_digests.json
@@ -131,6 +84,53 @@
       echo "⚠️ [$(date -u)] Could not read /deckhouse/candi/images_digests.json from '${STAGE_PATH}/install:${IMAGE_TAG}'"
       exit 1
     fi
+
+    promote_with_att ""
+    promote_with_att "install"
+    promote_with_att "install-standalone"
+    promote_with_att "release-channel"
+
+- name: Copy attestations ({!{$edition}!})
+  env:
+    WERF_ENV: {!{$edition}!}
+    STAGE_REGISTRY_HOST: ${{ steps.secrets.outputs.DECKHOUSE_REGISTRY_STAGE_HOST }}
+    DECKHOUSE_REGISTRY_HOST: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
+  run: |
+    set -euo pipefail
+    function regctl_copy() {
+      local attempt
+      for attempt in $(seq 1 5); do
+        regctl image copy "$@" && return 0
+        [[ $attempt -eq 5 ]] && return 1
+        echo "⚠️ [$(date -u)] regctl copy failed (attempt ${attempt}/5), retrying in 5s..."
+        sleep 5
+      done
+    }
+
+    REGISTRY_SUFFIX=$(echo "${WERF_ENV}" | tr '[:upper:]' '[:lower:]')
+    IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+    STAGE_PATH="${STAGE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}"
+    PROD_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}"
+
+    DIGESTS_JSON="images_digests-att.json"
+
+    if ! regctl image get-file "${STAGE_PATH}/install:${IMAGE_TAG}" /deckhouse/candi/images_digests.json > "${DIGESTS_JSON}" 2>/dev/null; then
+      echo "⚠️ [$(date -u)] Could not read /deckhouse/candi/images_digests.json from '${STAGE_PATH}/install:${IMAGE_TAG}', skipping digest attestations copy"
+      exit 1
+    fi
+
+    while IFS= read -r IMG_DIGEST; do
+      [[ -z "${IMG_DIGEST}" ]] && continue
+      D_HEX="${IMG_DIGEST#sha256:}"
+      SRC_ATT="${STAGE_PATH}:sha256-${D_HEX}.att"
+      DST_ATT="${PROD_PATH}:sha256-${D_HEX}.att"
+      if regctl image manifest "${SRC_ATT}" >/dev/null 2>&1; then
+        echo "⚓️ 💫 [$(date -u)] Copying attestation '${SRC_ATT}' -> '${DST_ATT}'"
+        regctl_copy "${SRC_ATT}" "${DST_ATT}"
+      fi
+    done < <(jq -r '[.. | strings | select(test("^sha256:[a-f0-9]{64}$"))] | unique | .[]' "${DIGESTS_JSON}")
+
+    rm -rf ${DIGESTS_JSON}
 
 - name: Check DKP images manifests in public registry ({!{$edition}!})
   env:

--- a/.github/workflows/promote_image.yml
+++ b/.github/workflows/promote_image.yml
@@ -210,48 +210,6 @@ jobs:
       # </template: login_rw_registry_step>
     # </template: promote_image_setup_steps>
 
-      - name: Copy attestations (CE)
-        env:
-          WERF_ENV: CE
-          STAGE_REGISTRY_HOST: ${{ steps.secrets.outputs.DECKHOUSE_REGISTRY_STAGE_HOST }}
-          DECKHOUSE_REGISTRY_HOST: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
-        run: |
-          set -euo pipefail
-          function regctl_copy() {
-            local attempt
-            for attempt in $(seq 1 5); do
-              regctl image copy "$@" && return 0
-              [[ $attempt -eq 5 ]] && return 1
-              echo "⚠️ [$(date -u)] regctl copy failed (attempt ${attempt}/5), retrying in 5s..."
-              sleep 5
-            done
-          }
-
-          REGISTRY_SUFFIX=$(echo "${WERF_ENV}" | tr '[:upper:]' '[:lower:]')
-          IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-          STAGE_PATH="${STAGE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}"
-          PROD_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}"
-
-          DIGESTS_JSON="images_digests-att.json"
-
-          if ! regctl image get-file "${STAGE_PATH}/install:${IMAGE_TAG}" /deckhouse/candi/images_digests.json > "${DIGESTS_JSON}" 2>/dev/null; then
-            echo "⚠️ [$(date -u)] Could not read /deckhouse/candi/images_digests.json from '${STAGE_PATH}/install:${IMAGE_TAG}', skipping digest attestations copy"
-            exit 1
-          fi
-
-          while IFS= read -r IMG_DIGEST; do
-            [[ -z "${IMG_DIGEST}" ]] && continue
-            D_HEX="${IMG_DIGEST#sha256:}"
-            SRC_ATT="${STAGE_PATH}:sha256-${D_HEX}.att"
-            DST_ATT="${PROD_PATH}:sha256-${D_HEX}.att"
-            if regctl image manifest "${SRC_ATT}" >/dev/null 2>&1; then
-              echo "⚓️ 💫 [$(date -u)] Copying attestation '${SRC_ATT}' -> '${DST_ATT}'"
-              regctl_copy "${SRC_ATT}" "${DST_ATT}"
-            fi
-          done < <(jq -r '[.. | strings | select(test("^sha256:[a-f0-9]{64}$"))] | unique | .[]' "${DIGESTS_JSON}")
-
-          rm -rf ${DIGESTS_JSON}
-
       - name: Promote images from stage to prod (CE)
         env:
           WERF_ENV: CE
@@ -302,11 +260,6 @@ jobs:
             fi
           }
 
-          promote_with_att ""
-          promote_with_att "install"
-          promote_with_att "install-standalone"
-          promote_with_att "release-channel"
-
           DIGESTS_JSON="images_digests-promote.json"
 
           # Promote from images_digests.json
@@ -325,6 +278,53 @@ jobs:
             echo "⚠️ [$(date -u)] Could not read /deckhouse/candi/images_digests.json from '${STAGE_PATH}/install:${IMAGE_TAG}'"
             exit 1
           fi
+
+          promote_with_att ""
+          promote_with_att "install"
+          promote_with_att "install-standalone"
+          promote_with_att "release-channel"
+
+      - name: Copy attestations (CE)
+        env:
+          WERF_ENV: CE
+          STAGE_REGISTRY_HOST: ${{ steps.secrets.outputs.DECKHOUSE_REGISTRY_STAGE_HOST }}
+          DECKHOUSE_REGISTRY_HOST: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
+        run: |
+          set -euo pipefail
+          function regctl_copy() {
+            local attempt
+            for attempt in $(seq 1 5); do
+              regctl image copy "$@" && return 0
+              [[ $attempt -eq 5 ]] && return 1
+              echo "⚠️ [$(date -u)] regctl copy failed (attempt ${attempt}/5), retrying in 5s..."
+              sleep 5
+            done
+          }
+
+          REGISTRY_SUFFIX=$(echo "${WERF_ENV}" | tr '[:upper:]' '[:lower:]')
+          IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+          STAGE_PATH="${STAGE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}"
+          PROD_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}"
+
+          DIGESTS_JSON="images_digests-att.json"
+
+          if ! regctl image get-file "${STAGE_PATH}/install:${IMAGE_TAG}" /deckhouse/candi/images_digests.json > "${DIGESTS_JSON}" 2>/dev/null; then
+            echo "⚠️ [$(date -u)] Could not read /deckhouse/candi/images_digests.json from '${STAGE_PATH}/install:${IMAGE_TAG}', skipping digest attestations copy"
+            exit 1
+          fi
+
+          while IFS= read -r IMG_DIGEST; do
+            [[ -z "${IMG_DIGEST}" ]] && continue
+            D_HEX="${IMG_DIGEST#sha256:}"
+            SRC_ATT="${STAGE_PATH}:sha256-${D_HEX}.att"
+            DST_ATT="${PROD_PATH}:sha256-${D_HEX}.att"
+            if regctl image manifest "${SRC_ATT}" >/dev/null 2>&1; then
+              echo "⚓️ 💫 [$(date -u)] Copying attestation '${SRC_ATT}' -> '${DST_ATT}'"
+              regctl_copy "${SRC_ATT}" "${DST_ATT}"
+            fi
+          done < <(jq -r '[.. | strings | select(test("^sha256:[a-f0-9]{64}$"))] | unique | .[]' "${DIGESTS_JSON}")
+
+          rm -rf ${DIGESTS_JSON}
 
       - name: Check DKP images manifests in public registry (CE)
         env:
@@ -451,48 +451,6 @@ jobs:
       # </template: login_rw_registry_step>
     # </template: promote_image_setup_steps>
 
-      - name: Copy attestations (EE)
-        env:
-          WERF_ENV: EE
-          STAGE_REGISTRY_HOST: ${{ steps.secrets.outputs.DECKHOUSE_REGISTRY_STAGE_HOST }}
-          DECKHOUSE_REGISTRY_HOST: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
-        run: |
-          set -euo pipefail
-          function regctl_copy() {
-            local attempt
-            for attempt in $(seq 1 5); do
-              regctl image copy "$@" && return 0
-              [[ $attempt -eq 5 ]] && return 1
-              echo "⚠️ [$(date -u)] regctl copy failed (attempt ${attempt}/5), retrying in 5s..."
-              sleep 5
-            done
-          }
-
-          REGISTRY_SUFFIX=$(echo "${WERF_ENV}" | tr '[:upper:]' '[:lower:]')
-          IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-          STAGE_PATH="${STAGE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}"
-          PROD_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}"
-
-          DIGESTS_JSON="images_digests-att.json"
-
-          if ! regctl image get-file "${STAGE_PATH}/install:${IMAGE_TAG}" /deckhouse/candi/images_digests.json > "${DIGESTS_JSON}" 2>/dev/null; then
-            echo "⚠️ [$(date -u)] Could not read /deckhouse/candi/images_digests.json from '${STAGE_PATH}/install:${IMAGE_TAG}', skipping digest attestations copy"
-            exit 1
-          fi
-
-          while IFS= read -r IMG_DIGEST; do
-            [[ -z "${IMG_DIGEST}" ]] && continue
-            D_HEX="${IMG_DIGEST#sha256:}"
-            SRC_ATT="${STAGE_PATH}:sha256-${D_HEX}.att"
-            DST_ATT="${PROD_PATH}:sha256-${D_HEX}.att"
-            if regctl image manifest "${SRC_ATT}" >/dev/null 2>&1; then
-              echo "⚓️ 💫 [$(date -u)] Copying attestation '${SRC_ATT}' -> '${DST_ATT}'"
-              regctl_copy "${SRC_ATT}" "${DST_ATT}"
-            fi
-          done < <(jq -r '[.. | strings | select(test("^sha256:[a-f0-9]{64}$"))] | unique | .[]' "${DIGESTS_JSON}")
-
-          rm -rf ${DIGESTS_JSON}
-
       - name: Promote images from stage to prod (EE)
         env:
           WERF_ENV: EE
@@ -543,11 +501,6 @@ jobs:
             fi
           }
 
-          promote_with_att ""
-          promote_with_att "install"
-          promote_with_att "install-standalone"
-          promote_with_att "release-channel"
-
           DIGESTS_JSON="images_digests-promote.json"
 
           # Promote from images_digests.json
@@ -566,6 +519,53 @@ jobs:
             echo "⚠️ [$(date -u)] Could not read /deckhouse/candi/images_digests.json from '${STAGE_PATH}/install:${IMAGE_TAG}'"
             exit 1
           fi
+
+          promote_with_att ""
+          promote_with_att "install"
+          promote_with_att "install-standalone"
+          promote_with_att "release-channel"
+
+      - name: Copy attestations (EE)
+        env:
+          WERF_ENV: EE
+          STAGE_REGISTRY_HOST: ${{ steps.secrets.outputs.DECKHOUSE_REGISTRY_STAGE_HOST }}
+          DECKHOUSE_REGISTRY_HOST: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
+        run: |
+          set -euo pipefail
+          function regctl_copy() {
+            local attempt
+            for attempt in $(seq 1 5); do
+              regctl image copy "$@" && return 0
+              [[ $attempt -eq 5 ]] && return 1
+              echo "⚠️ [$(date -u)] regctl copy failed (attempt ${attempt}/5), retrying in 5s..."
+              sleep 5
+            done
+          }
+
+          REGISTRY_SUFFIX=$(echo "${WERF_ENV}" | tr '[:upper:]' '[:lower:]')
+          IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+          STAGE_PATH="${STAGE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}"
+          PROD_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}"
+
+          DIGESTS_JSON="images_digests-att.json"
+
+          if ! regctl image get-file "${STAGE_PATH}/install:${IMAGE_TAG}" /deckhouse/candi/images_digests.json > "${DIGESTS_JSON}" 2>/dev/null; then
+            echo "⚠️ [$(date -u)] Could not read /deckhouse/candi/images_digests.json from '${STAGE_PATH}/install:${IMAGE_TAG}', skipping digest attestations copy"
+            exit 1
+          fi
+
+          while IFS= read -r IMG_DIGEST; do
+            [[ -z "${IMG_DIGEST}" ]] && continue
+            D_HEX="${IMG_DIGEST#sha256:}"
+            SRC_ATT="${STAGE_PATH}:sha256-${D_HEX}.att"
+            DST_ATT="${PROD_PATH}:sha256-${D_HEX}.att"
+            if regctl image manifest "${SRC_ATT}" >/dev/null 2>&1; then
+              echo "⚓️ 💫 [$(date -u)] Copying attestation '${SRC_ATT}' -> '${DST_ATT}'"
+              regctl_copy "${SRC_ATT}" "${DST_ATT}"
+            fi
+          done < <(jq -r '[.. | strings | select(test("^sha256:[a-f0-9]{64}$"))] | unique | .[]' "${DIGESTS_JSON}")
+
+          rm -rf ${DIGESTS_JSON}
 
       - name: Check DKP images manifests in public registry (EE)
         env:
@@ -692,48 +692,6 @@ jobs:
       # </template: login_rw_registry_step>
     # </template: promote_image_setup_steps>
 
-      - name: Copy attestations (FE)
-        env:
-          WERF_ENV: FE
-          STAGE_REGISTRY_HOST: ${{ steps.secrets.outputs.DECKHOUSE_REGISTRY_STAGE_HOST }}
-          DECKHOUSE_REGISTRY_HOST: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
-        run: |
-          set -euo pipefail
-          function regctl_copy() {
-            local attempt
-            for attempt in $(seq 1 5); do
-              regctl image copy "$@" && return 0
-              [[ $attempt -eq 5 ]] && return 1
-              echo "⚠️ [$(date -u)] regctl copy failed (attempt ${attempt}/5), retrying in 5s..."
-              sleep 5
-            done
-          }
-
-          REGISTRY_SUFFIX=$(echo "${WERF_ENV}" | tr '[:upper:]' '[:lower:]')
-          IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-          STAGE_PATH="${STAGE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}"
-          PROD_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}"
-
-          DIGESTS_JSON="images_digests-att.json"
-
-          if ! regctl image get-file "${STAGE_PATH}/install:${IMAGE_TAG}" /deckhouse/candi/images_digests.json > "${DIGESTS_JSON}" 2>/dev/null; then
-            echo "⚠️ [$(date -u)] Could not read /deckhouse/candi/images_digests.json from '${STAGE_PATH}/install:${IMAGE_TAG}', skipping digest attestations copy"
-            exit 1
-          fi
-
-          while IFS= read -r IMG_DIGEST; do
-            [[ -z "${IMG_DIGEST}" ]] && continue
-            D_HEX="${IMG_DIGEST#sha256:}"
-            SRC_ATT="${STAGE_PATH}:sha256-${D_HEX}.att"
-            DST_ATT="${PROD_PATH}:sha256-${D_HEX}.att"
-            if regctl image manifest "${SRC_ATT}" >/dev/null 2>&1; then
-              echo "⚓️ 💫 [$(date -u)] Copying attestation '${SRC_ATT}' -> '${DST_ATT}'"
-              regctl_copy "${SRC_ATT}" "${DST_ATT}"
-            fi
-          done < <(jq -r '[.. | strings | select(test("^sha256:[a-f0-9]{64}$"))] | unique | .[]' "${DIGESTS_JSON}")
-
-          rm -rf ${DIGESTS_JSON}
-
       - name: Promote images from stage to prod (FE)
         env:
           WERF_ENV: FE
@@ -784,11 +742,6 @@ jobs:
             fi
           }
 
-          promote_with_att ""
-          promote_with_att "install"
-          promote_with_att "install-standalone"
-          promote_with_att "release-channel"
-
           DIGESTS_JSON="images_digests-promote.json"
 
           # Promote from images_digests.json
@@ -807,6 +760,53 @@ jobs:
             echo "⚠️ [$(date -u)] Could not read /deckhouse/candi/images_digests.json from '${STAGE_PATH}/install:${IMAGE_TAG}'"
             exit 1
           fi
+
+          promote_with_att ""
+          promote_with_att "install"
+          promote_with_att "install-standalone"
+          promote_with_att "release-channel"
+
+      - name: Copy attestations (FE)
+        env:
+          WERF_ENV: FE
+          STAGE_REGISTRY_HOST: ${{ steps.secrets.outputs.DECKHOUSE_REGISTRY_STAGE_HOST }}
+          DECKHOUSE_REGISTRY_HOST: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
+        run: |
+          set -euo pipefail
+          function regctl_copy() {
+            local attempt
+            for attempt in $(seq 1 5); do
+              regctl image copy "$@" && return 0
+              [[ $attempt -eq 5 ]] && return 1
+              echo "⚠️ [$(date -u)] regctl copy failed (attempt ${attempt}/5), retrying in 5s..."
+              sleep 5
+            done
+          }
+
+          REGISTRY_SUFFIX=$(echo "${WERF_ENV}" | tr '[:upper:]' '[:lower:]')
+          IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+          STAGE_PATH="${STAGE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}"
+          PROD_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}"
+
+          DIGESTS_JSON="images_digests-att.json"
+
+          if ! regctl image get-file "${STAGE_PATH}/install:${IMAGE_TAG}" /deckhouse/candi/images_digests.json > "${DIGESTS_JSON}" 2>/dev/null; then
+            echo "⚠️ [$(date -u)] Could not read /deckhouse/candi/images_digests.json from '${STAGE_PATH}/install:${IMAGE_TAG}', skipping digest attestations copy"
+            exit 1
+          fi
+
+          while IFS= read -r IMG_DIGEST; do
+            [[ -z "${IMG_DIGEST}" ]] && continue
+            D_HEX="${IMG_DIGEST#sha256:}"
+            SRC_ATT="${STAGE_PATH}:sha256-${D_HEX}.att"
+            DST_ATT="${PROD_PATH}:sha256-${D_HEX}.att"
+            if regctl image manifest "${SRC_ATT}" >/dev/null 2>&1; then
+              echo "⚓️ 💫 [$(date -u)] Copying attestation '${SRC_ATT}' -> '${DST_ATT}'"
+              regctl_copy "${SRC_ATT}" "${DST_ATT}"
+            fi
+          done < <(jq -r '[.. | strings | select(test("^sha256:[a-f0-9]{64}$"))] | unique | .[]' "${DIGESTS_JSON}")
+
+          rm -rf ${DIGESTS_JSON}
 
       - name: Check DKP images manifests in public registry (FE)
         env:
@@ -933,48 +933,6 @@ jobs:
       # </template: login_rw_registry_step>
     # </template: promote_image_setup_steps>
 
-      - name: Copy attestations (BE)
-        env:
-          WERF_ENV: BE
-          STAGE_REGISTRY_HOST: ${{ steps.secrets.outputs.DECKHOUSE_REGISTRY_STAGE_HOST }}
-          DECKHOUSE_REGISTRY_HOST: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
-        run: |
-          set -euo pipefail
-          function regctl_copy() {
-            local attempt
-            for attempt in $(seq 1 5); do
-              regctl image copy "$@" && return 0
-              [[ $attempt -eq 5 ]] && return 1
-              echo "⚠️ [$(date -u)] regctl copy failed (attempt ${attempt}/5), retrying in 5s..."
-              sleep 5
-            done
-          }
-
-          REGISTRY_SUFFIX=$(echo "${WERF_ENV}" | tr '[:upper:]' '[:lower:]')
-          IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-          STAGE_PATH="${STAGE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}"
-          PROD_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}"
-
-          DIGESTS_JSON="images_digests-att.json"
-
-          if ! regctl image get-file "${STAGE_PATH}/install:${IMAGE_TAG}" /deckhouse/candi/images_digests.json > "${DIGESTS_JSON}" 2>/dev/null; then
-            echo "⚠️ [$(date -u)] Could not read /deckhouse/candi/images_digests.json from '${STAGE_PATH}/install:${IMAGE_TAG}', skipping digest attestations copy"
-            exit 1
-          fi
-
-          while IFS= read -r IMG_DIGEST; do
-            [[ -z "${IMG_DIGEST}" ]] && continue
-            D_HEX="${IMG_DIGEST#sha256:}"
-            SRC_ATT="${STAGE_PATH}:sha256-${D_HEX}.att"
-            DST_ATT="${PROD_PATH}:sha256-${D_HEX}.att"
-            if regctl image manifest "${SRC_ATT}" >/dev/null 2>&1; then
-              echo "⚓️ 💫 [$(date -u)] Copying attestation '${SRC_ATT}' -> '${DST_ATT}'"
-              regctl_copy "${SRC_ATT}" "${DST_ATT}"
-            fi
-          done < <(jq -r '[.. | strings | select(test("^sha256:[a-f0-9]{64}$"))] | unique | .[]' "${DIGESTS_JSON}")
-
-          rm -rf ${DIGESTS_JSON}
-
       - name: Promote images from stage to prod (BE)
         env:
           WERF_ENV: BE
@@ -1025,11 +983,6 @@ jobs:
             fi
           }
 
-          promote_with_att ""
-          promote_with_att "install"
-          promote_with_att "install-standalone"
-          promote_with_att "release-channel"
-
           DIGESTS_JSON="images_digests-promote.json"
 
           # Promote from images_digests.json
@@ -1048,6 +1001,53 @@ jobs:
             echo "⚠️ [$(date -u)] Could not read /deckhouse/candi/images_digests.json from '${STAGE_PATH}/install:${IMAGE_TAG}'"
             exit 1
           fi
+
+          promote_with_att ""
+          promote_with_att "install"
+          promote_with_att "install-standalone"
+          promote_with_att "release-channel"
+
+      - name: Copy attestations (BE)
+        env:
+          WERF_ENV: BE
+          STAGE_REGISTRY_HOST: ${{ steps.secrets.outputs.DECKHOUSE_REGISTRY_STAGE_HOST }}
+          DECKHOUSE_REGISTRY_HOST: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
+        run: |
+          set -euo pipefail
+          function regctl_copy() {
+            local attempt
+            for attempt in $(seq 1 5); do
+              regctl image copy "$@" && return 0
+              [[ $attempt -eq 5 ]] && return 1
+              echo "⚠️ [$(date -u)] regctl copy failed (attempt ${attempt}/5), retrying in 5s..."
+              sleep 5
+            done
+          }
+
+          REGISTRY_SUFFIX=$(echo "${WERF_ENV}" | tr '[:upper:]' '[:lower:]')
+          IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+          STAGE_PATH="${STAGE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}"
+          PROD_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}"
+
+          DIGESTS_JSON="images_digests-att.json"
+
+          if ! regctl image get-file "${STAGE_PATH}/install:${IMAGE_TAG}" /deckhouse/candi/images_digests.json > "${DIGESTS_JSON}" 2>/dev/null; then
+            echo "⚠️ [$(date -u)] Could not read /deckhouse/candi/images_digests.json from '${STAGE_PATH}/install:${IMAGE_TAG}', skipping digest attestations copy"
+            exit 1
+          fi
+
+          while IFS= read -r IMG_DIGEST; do
+            [[ -z "${IMG_DIGEST}" ]] && continue
+            D_HEX="${IMG_DIGEST#sha256:}"
+            SRC_ATT="${STAGE_PATH}:sha256-${D_HEX}.att"
+            DST_ATT="${PROD_PATH}:sha256-${D_HEX}.att"
+            if regctl image manifest "${SRC_ATT}" >/dev/null 2>&1; then
+              echo "⚓️ 💫 [$(date -u)] Copying attestation '${SRC_ATT}' -> '${DST_ATT}'"
+              regctl_copy "${SRC_ATT}" "${DST_ATT}"
+            fi
+          done < <(jq -r '[.. | strings | select(test("^sha256:[a-f0-9]{64}$"))] | unique | .[]' "${DIGESTS_JSON}")
+
+          rm -rf ${DIGESTS_JSON}
 
       - name: Check DKP images manifests in public registry (BE)
         env:
@@ -1174,48 +1174,6 @@ jobs:
       # </template: login_rw_registry_step>
     # </template: promote_image_setup_steps>
 
-      - name: Copy attestations (SE)
-        env:
-          WERF_ENV: SE
-          STAGE_REGISTRY_HOST: ${{ steps.secrets.outputs.DECKHOUSE_REGISTRY_STAGE_HOST }}
-          DECKHOUSE_REGISTRY_HOST: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
-        run: |
-          set -euo pipefail
-          function regctl_copy() {
-            local attempt
-            for attempt in $(seq 1 5); do
-              regctl image copy "$@" && return 0
-              [[ $attempt -eq 5 ]] && return 1
-              echo "⚠️ [$(date -u)] regctl copy failed (attempt ${attempt}/5), retrying in 5s..."
-              sleep 5
-            done
-          }
-
-          REGISTRY_SUFFIX=$(echo "${WERF_ENV}" | tr '[:upper:]' '[:lower:]')
-          IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-          STAGE_PATH="${STAGE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}"
-          PROD_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}"
-
-          DIGESTS_JSON="images_digests-att.json"
-
-          if ! regctl image get-file "${STAGE_PATH}/install:${IMAGE_TAG}" /deckhouse/candi/images_digests.json > "${DIGESTS_JSON}" 2>/dev/null; then
-            echo "⚠️ [$(date -u)] Could not read /deckhouse/candi/images_digests.json from '${STAGE_PATH}/install:${IMAGE_TAG}', skipping digest attestations copy"
-            exit 1
-          fi
-
-          while IFS= read -r IMG_DIGEST; do
-            [[ -z "${IMG_DIGEST}" ]] && continue
-            D_HEX="${IMG_DIGEST#sha256:}"
-            SRC_ATT="${STAGE_PATH}:sha256-${D_HEX}.att"
-            DST_ATT="${PROD_PATH}:sha256-${D_HEX}.att"
-            if regctl image manifest "${SRC_ATT}" >/dev/null 2>&1; then
-              echo "⚓️ 💫 [$(date -u)] Copying attestation '${SRC_ATT}' -> '${DST_ATT}'"
-              regctl_copy "${SRC_ATT}" "${DST_ATT}"
-            fi
-          done < <(jq -r '[.. | strings | select(test("^sha256:[a-f0-9]{64}$"))] | unique | .[]' "${DIGESTS_JSON}")
-
-          rm -rf ${DIGESTS_JSON}
-
       - name: Promote images from stage to prod (SE)
         env:
           WERF_ENV: SE
@@ -1266,11 +1224,6 @@ jobs:
             fi
           }
 
-          promote_with_att ""
-          promote_with_att "install"
-          promote_with_att "install-standalone"
-          promote_with_att "release-channel"
-
           DIGESTS_JSON="images_digests-promote.json"
 
           # Promote from images_digests.json
@@ -1289,6 +1242,53 @@ jobs:
             echo "⚠️ [$(date -u)] Could not read /deckhouse/candi/images_digests.json from '${STAGE_PATH}/install:${IMAGE_TAG}'"
             exit 1
           fi
+
+          promote_with_att ""
+          promote_with_att "install"
+          promote_with_att "install-standalone"
+          promote_with_att "release-channel"
+
+      - name: Copy attestations (SE)
+        env:
+          WERF_ENV: SE
+          STAGE_REGISTRY_HOST: ${{ steps.secrets.outputs.DECKHOUSE_REGISTRY_STAGE_HOST }}
+          DECKHOUSE_REGISTRY_HOST: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
+        run: |
+          set -euo pipefail
+          function regctl_copy() {
+            local attempt
+            for attempt in $(seq 1 5); do
+              regctl image copy "$@" && return 0
+              [[ $attempt -eq 5 ]] && return 1
+              echo "⚠️ [$(date -u)] regctl copy failed (attempt ${attempt}/5), retrying in 5s..."
+              sleep 5
+            done
+          }
+
+          REGISTRY_SUFFIX=$(echo "${WERF_ENV}" | tr '[:upper:]' '[:lower:]')
+          IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+          STAGE_PATH="${STAGE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}"
+          PROD_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}"
+
+          DIGESTS_JSON="images_digests-att.json"
+
+          if ! regctl image get-file "${STAGE_PATH}/install:${IMAGE_TAG}" /deckhouse/candi/images_digests.json > "${DIGESTS_JSON}" 2>/dev/null; then
+            echo "⚠️ [$(date -u)] Could not read /deckhouse/candi/images_digests.json from '${STAGE_PATH}/install:${IMAGE_TAG}', skipping digest attestations copy"
+            exit 1
+          fi
+
+          while IFS= read -r IMG_DIGEST; do
+            [[ -z "${IMG_DIGEST}" ]] && continue
+            D_HEX="${IMG_DIGEST#sha256:}"
+            SRC_ATT="${STAGE_PATH}:sha256-${D_HEX}.att"
+            DST_ATT="${PROD_PATH}:sha256-${D_HEX}.att"
+            if regctl image manifest "${SRC_ATT}" >/dev/null 2>&1; then
+              echo "⚓️ 💫 [$(date -u)] Copying attestation '${SRC_ATT}' -> '${DST_ATT}'"
+              regctl_copy "${SRC_ATT}" "${DST_ATT}"
+            fi
+          done < <(jq -r '[.. | strings | select(test("^sha256:[a-f0-9]{64}$"))] | unique | .[]' "${DIGESTS_JSON}")
+
+          rm -rf ${DIGESTS_JSON}
 
       - name: Check DKP images manifests in public registry (SE)
         env:
@@ -1415,48 +1415,6 @@ jobs:
       # </template: login_rw_registry_step>
     # </template: promote_image_setup_steps>
 
-      - name: Copy attestations (SE-plus)
-        env:
-          WERF_ENV: SE-plus
-          STAGE_REGISTRY_HOST: ${{ steps.secrets.outputs.DECKHOUSE_REGISTRY_STAGE_HOST }}
-          DECKHOUSE_REGISTRY_HOST: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
-        run: |
-          set -euo pipefail
-          function regctl_copy() {
-            local attempt
-            for attempt in $(seq 1 5); do
-              regctl image copy "$@" && return 0
-              [[ $attempt -eq 5 ]] && return 1
-              echo "⚠️ [$(date -u)] regctl copy failed (attempt ${attempt}/5), retrying in 5s..."
-              sleep 5
-            done
-          }
-
-          REGISTRY_SUFFIX=$(echo "${WERF_ENV}" | tr '[:upper:]' '[:lower:]')
-          IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-          STAGE_PATH="${STAGE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}"
-          PROD_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}"
-
-          DIGESTS_JSON="images_digests-att.json"
-
-          if ! regctl image get-file "${STAGE_PATH}/install:${IMAGE_TAG}" /deckhouse/candi/images_digests.json > "${DIGESTS_JSON}" 2>/dev/null; then
-            echo "⚠️ [$(date -u)] Could not read /deckhouse/candi/images_digests.json from '${STAGE_PATH}/install:${IMAGE_TAG}', skipping digest attestations copy"
-            exit 1
-          fi
-
-          while IFS= read -r IMG_DIGEST; do
-            [[ -z "${IMG_DIGEST}" ]] && continue
-            D_HEX="${IMG_DIGEST#sha256:}"
-            SRC_ATT="${STAGE_PATH}:sha256-${D_HEX}.att"
-            DST_ATT="${PROD_PATH}:sha256-${D_HEX}.att"
-            if regctl image manifest "${SRC_ATT}" >/dev/null 2>&1; then
-              echo "⚓️ 💫 [$(date -u)] Copying attestation '${SRC_ATT}' -> '${DST_ATT}'"
-              regctl_copy "${SRC_ATT}" "${DST_ATT}"
-            fi
-          done < <(jq -r '[.. | strings | select(test("^sha256:[a-f0-9]{64}$"))] | unique | .[]' "${DIGESTS_JSON}")
-
-          rm -rf ${DIGESTS_JSON}
-
       - name: Promote images from stage to prod (SE-plus)
         env:
           WERF_ENV: SE-plus
@@ -1507,11 +1465,6 @@ jobs:
             fi
           }
 
-          promote_with_att ""
-          promote_with_att "install"
-          promote_with_att "install-standalone"
-          promote_with_att "release-channel"
-
           DIGESTS_JSON="images_digests-promote.json"
 
           # Promote from images_digests.json
@@ -1530,6 +1483,53 @@ jobs:
             echo "⚠️ [$(date -u)] Could not read /deckhouse/candi/images_digests.json from '${STAGE_PATH}/install:${IMAGE_TAG}'"
             exit 1
           fi
+
+          promote_with_att ""
+          promote_with_att "install"
+          promote_with_att "install-standalone"
+          promote_with_att "release-channel"
+
+      - name: Copy attestations (SE-plus)
+        env:
+          WERF_ENV: SE-plus
+          STAGE_REGISTRY_HOST: ${{ steps.secrets.outputs.DECKHOUSE_REGISTRY_STAGE_HOST }}
+          DECKHOUSE_REGISTRY_HOST: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
+        run: |
+          set -euo pipefail
+          function regctl_copy() {
+            local attempt
+            for attempt in $(seq 1 5); do
+              regctl image copy "$@" && return 0
+              [[ $attempt -eq 5 ]] && return 1
+              echo "⚠️ [$(date -u)] regctl copy failed (attempt ${attempt}/5), retrying in 5s..."
+              sleep 5
+            done
+          }
+
+          REGISTRY_SUFFIX=$(echo "${WERF_ENV}" | tr '[:upper:]' '[:lower:]')
+          IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+          STAGE_PATH="${STAGE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}"
+          PROD_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}"
+
+          DIGESTS_JSON="images_digests-att.json"
+
+          if ! regctl image get-file "${STAGE_PATH}/install:${IMAGE_TAG}" /deckhouse/candi/images_digests.json > "${DIGESTS_JSON}" 2>/dev/null; then
+            echo "⚠️ [$(date -u)] Could not read /deckhouse/candi/images_digests.json from '${STAGE_PATH}/install:${IMAGE_TAG}', skipping digest attestations copy"
+            exit 1
+          fi
+
+          while IFS= read -r IMG_DIGEST; do
+            [[ -z "${IMG_DIGEST}" ]] && continue
+            D_HEX="${IMG_DIGEST#sha256:}"
+            SRC_ATT="${STAGE_PATH}:sha256-${D_HEX}.att"
+            DST_ATT="${PROD_PATH}:sha256-${D_HEX}.att"
+            if regctl image manifest "${SRC_ATT}" >/dev/null 2>&1; then
+              echo "⚓️ 💫 [$(date -u)] Copying attestation '${SRC_ATT}' -> '${DST_ATT}'"
+              regctl_copy "${SRC_ATT}" "${DST_ATT}"
+            fi
+          done < <(jq -r '[.. | strings | select(test("^sha256:[a-f0-9]{64}$"))] | unique | .[]' "${DIGESTS_JSON}")
+
+          rm -rf ${DIGESTS_JSON}
 
       - name: Check DKP images manifests in public registry (SE-plus)
         env:


### PR DESCRIPTION
## Description
Fix incorrect image promote order.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: fix
summary: Fix incorrect image promote order.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
