### PR TITLE
[node-manager] add the missing Russian CRD docs

### DIFF
--- a/modules/040-node-manager/crds/doc-ru-nodebootstrapconfig.yaml
+++ b/modules/040-node-manager/crds/doc-ru-nodebootstrapconfig.yaml
@@ -1,0 +1,30 @@
+spec:
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: |
+            Заявка на первичную загрузку одной машины. MachineSet Cluster API создаёт такую заявку для каждой машины, клонируя её из NodeBootstrapConfigTemplate.
+
+            node-controller рендерит для этой машины конфигурацию узла (NodeConfig) в Secret и сообщает о нём через `status`, которого ждёт контроллер Machine.
+          properties:
+            spec:
+              description: |
+                В версии `v1alpha1` пустой: данные первичной загрузки контроллер рендерит из состояния кластера и в объекте не хранит.
+            status:
+              description: |
+                Состояние заявки.
+              properties:
+                dataSecretName:
+                  description: |
+                    Имя Secret с отрендеренными данными первичной загрузки.
+                initialization:
+                  description: |
+                    Контракт первичной загрузки Cluster API версии `v1beta2`. Контроллер Machine ждёт `dataSecretCreated`, прежде чем прочитать Secret.
+                  properties:
+                    dataSecretCreated:
+                      description: |
+                        Устанавливается в `true`, как только Secret с данными первичной загрузки отрендерен.
+                conditions:
+                  description: |
+                    Условия, объясняющие, доступны ли данные первичной загрузки.

--- a/modules/040-node-manager/crds/doc-ru-nodebootstrapconfigtemplate.yaml
+++ b/modules/040-node-manager/crds/doc-ru-nodebootstrapconfigtemplate.yaml
@@ -1,0 +1,31 @@
+spec:
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: |
+            Шаблон первичной загрузки Cluster API, на который ссылается MachineDeployment группы immutable-узлов.
+
+            Для каждой машины MachineSet клонирует из `spec.template` объект NodeBootstrapConfig, а node-controller рендерит для него данные первичной загрузки.
+          properties:
+            spec:
+              description: |
+                Описание шаблона.
+              properties:
+                template:
+                  description: |
+                    Тело, которое копируется в каждый клонированный NodeBootstrapConfig.
+                  properties:
+                    metadata:
+                      description: |
+                        Лейблы и аннотации, которые Cluster API копирует в каждый клонированный NodeBootstrapConfig.
+                      properties:
+                        labels:
+                          description: |
+                            Лейблы, добавляемые к клону.
+                        annotations:
+                          description: |
+                            Аннотации, добавляемые к клону.
+                    spec:
+                      description: |
+                        Тело клонированного NodeBootstrapConfig. В версии `v1alpha1` намеренно пустое: контроллер рендерит данные первичной загрузки из состояния кластера в момент создания машины, поэтому в шаблон ничего не запекается.


### PR DESCRIPTION
Two CRDs shipped by #21557 have no Russian counterpart, so `Docs Validation (base)` is red on that PR:

```
* modules/040-node-manager/crds/nodebootstrapconfig.yaml ... ERROR: related is absent
* modules/040-node-manager/crds/nodebootstrapconfigtemplate.yaml ... ERROR: related is absent
```

`testing/validate_doc_changes.sh` requires a `doc-ru-<name>.yaml` beside every changed resource. This adds the two missing files and nothing else.

Reproduced and verified locally with the repo's own script against the PR base: red before, `Validation successful.` after.

## Base

Targets `immutable-on-21372` (#21557), not `main` — the two CRDs it documents live there.

## Changelog entries

```changes
section: node-manager
type: chore
summary: Add the Russian documentation for the NodeBootstrapConfig and NodeBootstrapConfigTemplate CRDs.
impact_level: low
```
