### PR TITLE
Backport: [user-authn] Issue a dedicated OAuth2 client secret per DexAuthenticator

### DIFF
--- a/modules/150-user-authn/hooks/generate_kubernetes_dex_client_app_secret.go
+++ b/modules/150-user-authn/hooks/generate_kubernetes_dex_client_app_secret.go
@@ -29,6 +29,16 @@ import (
 	"github.com/deckhouse/deckhouse/go_lib/pwgen"
 )
 
+const (
+	// kubernetesDexClientAppSecretPath holds the secret of the privileged kubernetes OAuth2Client.
+	// It is shared by every consumer of the kubernetes client and must never be handed out to
+	// per-application clients.
+	kubernetesDexClientAppSecretPath = "userAuthn.internal.kubernetesDexClientAppSecret"
+
+	kubernetesDexClientAppSecretNamespace = "d8-user-authn"
+	kubernetesDexClientAppSecretName      = "kubernetes-dex-client-app-secret"
+)
+
 type KubernetesSecret []byte
 
 func applyKubernetesSecretFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
@@ -49,11 +59,11 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			Kind:       "Secret",
 			NamespaceSelector: &types.NamespaceSelector{
 				NameSelector: &types.NameSelector{
-					MatchNames: []string{"d8-user-authn"},
+					MatchNames: []string{kubernetesDexClientAppSecretNamespace},
 				},
 			},
 			NameSelector: &types.NameSelector{
-				MatchNames: []string{"kubernetes-dex-client-app-secret"},
+				MatchNames: []string{kubernetesDexClientAppSecretName},
 			},
 			FilterFunc: applyKubernetesSecretFilter,
 		},
@@ -61,8 +71,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 }, kubernetesDexClientAppSecret)
 
 func kubernetesDexClientAppSecret(_ context.Context, input *go_hook.HookInput) error {
-	secretPath := "userAuthn.internal.kubernetesDexClientAppSecret"
-	if input.Values.Exists(secretPath) && input.Values.Get(secretPath).String() != "" {
+	if input.Values.Exists(kubernetesDexClientAppSecretPath) && input.Values.Get(kubernetesDexClientAppSecretPath).String() != "" {
 		return nil
 	}
 
@@ -76,14 +85,14 @@ func kubernetesDexClientAppSecret(_ context.Context, input *go_hook.HookInput) e
 
 		// if secret field was removed, generate a new one
 		if len(secretContent) == 0 {
-			input.Values.Set(secretPath, pwgen.AlphaNum(20))
+			input.Values.Set(kubernetesDexClientAppSecretPath, pwgen.AlphaNum(20))
 			return nil
 		}
 
-		input.Values.Set(secretPath, string(secretContent))
+		input.Values.Set(kubernetesDexClientAppSecretPath, string(secretContent))
 		return nil
 	}
 
-	input.Values.Set(secretPath, pwgen.AlphaNum(20))
+	input.Values.Set(kubernetesDexClientAppSecretPath, pwgen.AlphaNum(20))
 	return nil
 }

--- a/modules/150-user-authn/hooks/get_dex_authenticator_crds.go
+++ b/modules/150-user-authn/hooks/get_dex_authenticator_crds.go
@@ -21,11 +21,13 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"log/slog"
 	"regexp"
 	"strings"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -130,8 +132,47 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			},
 			FilterFunc: applyDexAuthenticatorSecretFilter,
 		},
+		{
+			Name:       "kubernetesClientSecret",
+			ApiVersion: "v1",
+			Kind:       "Secret",
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{kubernetesDexClientAppSecretNamespace},
+				},
+			},
+			NameSelector: &types.NameSelector{
+				MatchNames: []string{kubernetesDexClientAppSecretName},
+			},
+			FilterFunc: applyKubernetesSecretFilter,
+		},
 	},
 }, getDexAuthenticator)
+
+// sharedKubernetesClientSecret returns the secret of the privileged kubernetes OAuth2Client as it
+// exists in the cluster.
+//
+// It deliberately reads this hook's own snapshot instead of kubernetesDexClientAppSecretPath: that
+// values path is written by kubernetesDexClientAppSecret, which runs in the "main" queue while this
+// hook runs in "/modules/user-authn", so nothing orders the two and the value may still be absent
+// here on a cold start. The cluster Secret is also the authoritative source, since it is the object
+// whose content was copied into the application namespaces.
+//
+// An empty result means the shared secret does not exist in the cluster, so no authenticator can be
+// carrying it and there is nothing to migrate.
+func sharedKubernetesClientSecret(input *go_hook.HookInput) (string, error) {
+	snapshots := input.Snapshots.Get("kubernetesClientSecret")
+	if len(snapshots) == 0 {
+		return "", nil
+	}
+
+	var secretContent []byte
+	if err := snapshots[0].UnmarshalTo(&secretContent); err != nil {
+		return "", fmt.Errorf("cannot convert kubernetes client secret to bytes: failed to unmarshal 'kubernetesClientSecret' snapshot: %w", err)
+	}
+
+	return string(secretContent), nil
+}
 
 func getDexAuthenticator(_ context.Context, input *go_hook.HookInput) error {
 	authenticators := input.Snapshots.Get("authenticators")
@@ -145,6 +186,16 @@ func getDexAuthenticator(_ context.Context, input *go_hook.HookInput) error {
 		}
 
 		credentialsByID[dexSecret.ID] = dexSecret.Credentials
+	}
+
+	// Authenticators created before the templates stopped copying the kubernetes OAuth2Client
+	// secret into the application namespace carry that shared secret in their credentials
+	// Secret, and the "credentials" snapshot above reads it straight back into appDexSecret.
+	// Keep it to detect and rotate those, otherwise the shared secret would never leave the
+	// application namespace.
+	sharedClientSecret, err := sharedKubernetesClientSecret(input)
+	if err != nil {
+		return err
 	}
 
 	dexAuthenticators := make([]DexAuthenticator, 0, len(authenticators))
@@ -167,6 +218,18 @@ func getDexAuthenticator(_ context.Context, input *go_hook.HookInput) error {
 		// Migrate all cookie secret from 20 bytes length to 24 bytes
 		if len(existedCredentials.CookieSecret) < 24 {
 			existedCredentials.CookieSecret = pwgen.AlphaNum(24)
+		}
+
+		// Migrate authenticators that reuse the shared kubernetes client secret to their own one.
+		// The non-empty guard keeps an authenticator whose credentials Secret carries no
+		// client-secret from being rotated against an absent shared secret.
+		if sharedClientSecret != "" && existedCredentials.AppDexSecret == sharedClientSecret {
+			existedCredentials.AppDexSecret = pwgen.AlphaNum(20)
+			// Rotating logs every user of this authenticator out and rolls its pods, so make the
+			// upgrade traceable in the Deckhouse log.
+			input.Logger.Warn("Rotating DexAuthenticator client secret that reused the shared kubernetes client secret",
+				slog.String("dexauthenticator", dexAuthenticator.Name),
+				slog.String("namespace", dexAuthenticator.Namespace))
 		}
 
 		dexAuthenticator.Credentials = existedCredentials

--- a/modules/150-user-authn/hooks/get_dex_authenticator_crds_test.go
+++ b/modules/150-user-authn/hooks/get_dex_authenticator_crds_test.go
@@ -18,14 +18,33 @@ package hooks
 
 import (
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"strings"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
 	. "github.com/deckhouse/deckhouse/testing/hooks"
 )
+
+type inputDexAuthenticatorClientSecret struct {
+	// existing is the client-secret stored in the authenticator credentials Secret.
+	existing string
+	// omitExisting drops the client-secret key altogether, as a Secret written by an older
+	// template revision that never carried it would look.
+	omitExisting bool
+	// inCluster is data.secret of d8-user-authn/kubernetes-dex-client-app-secret; empty means
+	// the Secret is absent from the cluster.
+	inCluster string
+	// inValues is userAuthn.internal.kubernetesDexClientAppSecret; empty means the sibling hook
+	// has not populated it yet.
+	inValues string
+	rotated  bool
+}
+
+const testSharedKubernetesClientSecret = "sharedKubernetesSecret"
 
 var _ = Describe("User Authn hooks :: get dex authenticator crds ::", func() {
 	f := HookExecutionConfigInit(`{"userAuthn":{"internal": {}}}`, "")
@@ -305,6 +324,109 @@ spec:
 			Expect(namesMap.Get(shortID).Get("ingressNames").Get("0").Get("truncated").Bool()).Should(BeFalse())
 		})
 	})
+
+	DescribeTable("The client secret of an existing DexAuthenticator",
+		func(in inputDexAuthenticatorClientSecret) {
+			const cookieSecret = "testNexttestNexttestNext"
+
+			clientSecretData := ""
+			if !in.omitExisting {
+				clientSecretData = "\n  client-secret: " + base64.StdEncoding.EncodeToString([]byte(in.existing))
+			}
+
+			sharedSecret := ""
+			if in.inCluster != "" {
+				sharedSecret = `
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ` + kubernetesDexClientAppSecretName + `
+  namespace: ` + kubernetesDexClientAppSecretNamespace + `
+data:
+  secret: ` + base64.StdEncoding.EncodeToString([]byte(in.inCluster)) + "\n"
+			}
+
+			if in.inValues == "" {
+				f.ValuesDelete(kubernetesDexClientAppSecretPath)
+			} else {
+				f.ValuesSet(kubernetesDexClientAppSecretPath, in.inValues)
+			}
+
+			f.BindingContexts.Set(f.KubeStateSet(`
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dex-authenticator-test
+  namespace: test
+  labels:
+    app: dex-authenticator
+    name: credentials
+data:` + clientSecretData + `
+  cookie-secret: ` + base64.StdEncoding.EncodeToString([]byte(cookieSecret)) + `
+---
+apiVersion: deckhouse.io/v2alpha1
+kind: DexAuthenticator
+metadata:
+  name: test
+  namespace: test
+  annotations:
+    dexauthenticator.deckhouse.io/allow-access-to-kubernetes: "true"
+spec:
+  applications:
+  - domain: test
+    ingressClassName: "nginx"
+` + sharedSecret))
+			f.RunHook()
+
+			Expect(f).To(ExecuteSuccessfully())
+
+			appDexSecret := f.ValuesGet("userAuthn.internal.dexAuthenticatorCRDs.0.credentials.appDexSecret").String()
+			logs := string(f.LoggerOutput.Contents())
+			if in.rotated {
+				Expect(appDexSecret).NotTo(Equal(testSharedKubernetesClientSecret))
+				Expect(appDexSecret).To(HaveLen(20))
+				Expect(logs).To(ContainSubstring("Rotating DexAuthenticator client secret that reused the shared kubernetes client secret"))
+			} else {
+				Expect(appDexSecret).To(Equal(in.existing))
+				Expect(logs).NotTo(ContainSubstring("Rotating DexAuthenticator client secret that reused the shared kubernetes client secret"))
+			}
+		},
+		Entry("is regenerated when it equals the shared kubernetes client secret",
+			inputDexAuthenticatorClientSecret{
+				existing:  testSharedKubernetesClientSecret,
+				inCluster: testSharedKubernetesClientSecret,
+				inValues:  testSharedKubernetesClientSecret,
+				rotated:   true,
+			},
+		),
+		Entry("is preserved when it is unrelated to the shared kubernetes client secret",
+			inputDexAuthenticatorClientSecret{
+				existing:  "perAuthenticatorSecret",
+				inCluster: testSharedKubernetesClientSecret,
+				inValues:  testSharedKubernetesClientSecret,
+			},
+		),
+		// The values path is written by kubernetesDexClientAppSecret, which runs in the "main"
+		// queue while this hook runs in "/modules/user-authn", so it may still be empty here.
+		// The migration must not depend on it.
+		Entry("is regenerated from the cluster Secret when the values path is not populated yet",
+			inputDexAuthenticatorClientSecret{
+				existing:  testSharedKubernetesClientSecret,
+				inCluster: testSharedKubernetesClientSecret,
+				rotated:   true,
+			},
+		),
+		Entry("is preserved when the shared kubernetes client secret does not exist in the cluster",
+			inputDexAuthenticatorClientSecret{existing: "perAuthenticatorSecret"},
+		),
+		// Both sides of the comparison are empty here, so without the non-empty guard every
+		// authenticator whose credentials Secret has no client-secret would be rotated.
+		Entry("is left empty when neither the credentials Secret nor the shared secret carries one",
+			inputDexAuthenticatorClientSecret{omitExisting: true},
+		),
+	)
 })
 
 var _ = Describe("safeDNS1123Name", func() {

--- a/modules/150-user-authn/template_tests/authenticator_test.go
+++ b/modules/150-user-authn/template_tests/authenticator_test.go
@@ -177,6 +177,14 @@ var _ = Describe("Module :: user-authn :: helm template :: dex authenticator", f
 			Expect(secret.Field("data.client-secret").String()).To(Equal("ZGV4U2VjcmV0"))
 			Expect(secret.Field("data.cookie-secret").String()).To(Equal("Y29va2llU2VjcmV0"))
 
+			// Even with access to the Kubernetes API the authenticator gets its own client
+			// secret, never the shared secret of the kubernetes OAuth2Client ("plainstring").
+			secretWithAccess := hec.KubernetesResource("Secret", "d8-test", "dex-authenticator-test-2")
+			Expect(secretWithAccess.Exists()).To(BeTrue())
+			Expect(secretWithAccess.Field("data.client-secret").String()).To(Equal("ZGV4U2VjcmV0"))
+			Expect(secretWithAccess.Field("data.client-secret").String()).NotTo(Equal("cGxhaW5zdHJpbmc="))
+			Expect(secretWithAccess.Field("data.cookie-secret").String()).To(Equal("Y29va2llU2VjcmV0"))
+
 			oauth2clientTest := hec.KubernetesResource("OAuth2Client", "d8-user-authn", "justForTest")
 			Expect(oauth2clientTest.Exists()).To(BeTrue())
 			Expect(oauth2clientTest.Field("redirectURIs").String()).To(MatchJSON(`["https://authenticator.example.com/dex-authenticator/callback","https://authenticator-two.example.com/dex-authenticator/callback"]`))

--- a/modules/150-user-authn/template_tests/kubernetes_oauth2client_test.go
+++ b/modules/150-user-authn/template_tests/kubernetes_oauth2client_test.go
@@ -64,8 +64,10 @@ var _ = Describe("Module :: user-authn :: helm template :: kubernetes oauth2clie
     appDexSecret: dexSecret
     cookieSecret: cookieSecret
   spec:
-    applicationDomain: authenticator.example.com
-    applicationIngressCertificateSecretName: test
+    applications:
+    - domain: authenticator.example.com
+      ingressClassName: nginx
+      ingressSecretName: test
 `)
 			hec.ValuesSetFromYaml("userAuthn.internal.dexAuthenticatorNames", `
 "test@d8-test":
@@ -75,13 +77,31 @@ var _ = Describe("Module :: user-authn :: helm template :: kubernetes oauth2clie
   secretName: "dex-authenticator-test"
   secretTruncated: false
   secretHash: ""
-  ingressNames: {}
+  ingressNames:
+    "0":
+      name: "test-dex-authenticator"
+      truncated: false
+      hash: ""
 `)
 			hec.HelmRender()
 		})
-		It("Should deploy kubernetes OAuth2Client", func() {
+		It("Should deploy kubernetes OAuth2Client without redirect URIs", func() {
 			Expect(hec.RenderError).ShouldNot(HaveOccurred())
-			Expect(hec.KubernetesResource("OAuth2Client", "d8-user-authn", "nn2wezlsnzsxizltzpzjzzeeeirsk").Exists()).To(BeTrue())
+
+			oauth2Client := hec.KubernetesResource("OAuth2Client", "d8-user-authn", "nn2wezlsnzsxizltzpzjzzeeeirsk")
+			Expect(oauth2Client.Exists()).To(BeTrue())
+
+			redirectURIs := oauth2Client.Field("redirectURIs")
+			Expect(redirectURIs.IsArray()).To(BeTrue(), "redirectURIs must render as a list, not a bare key parsed as null")
+			Expect(redirectURIs.Array()).To(BeEmpty())
+
+			// The authenticator still reaches the privileged client through trustedPeers, so the
+			// empty redirectURIs above is not just an empty render.
+			peers := []string{}
+			for _, p := range oauth2Client.Field("trustedPeers").Array() {
+				peers = append(peers, p.String())
+			}
+			Expect(peers).To(ConsistOf("test-d8-test-dex-authenticator"))
 		})
 	})
 
@@ -95,8 +115,10 @@ var _ = Describe("Module :: user-authn :: helm template :: kubernetes oauth2clie
     appDexSecret: dexSecret
     cookieSecret: cookieSecret
   spec:
-    applicationDomain: authenticator.example.com
-    applicationIngressCertificateSecretName: test
+    applications:
+    - domain: authenticator.example.com
+      ingressClassName: nginx
+      ingressSecretName: test
 `)
 			hec.ValuesSetFromYaml("userAuthn.internal.dexAuthenticatorNames", `
 "test@d8-test":
@@ -106,7 +128,11 @@ var _ = Describe("Module :: user-authn :: helm template :: kubernetes oauth2clie
   secretName: "dex-authenticator-test"
   secretTruncated: false
   secretHash: ""
-  ingressNames: {}
+  ingressNames:
+    "0":
+      name: "test-dex-authenticator"
+      truncated: false
+      hash: ""
 `)
 			hec.HelmRender()
 		})

--- a/modules/150-user-authn/templates/dex-authenticator/secret.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/secret.yaml
@@ -19,11 +19,7 @@ metadata:
   {{- end }}
   {{- include "helm_lib_module_labels" (list $context $labels) | nindent 2 }}
 data:
-  {{- if $crd.allowAccessToKubernetes }}
-  client-secret: {{ $context.Values.userAuthn.internal.kubernetesDexClientAppSecret | b64enc }}
-  {{- else }}
   client-secret: {{ $crd.credentials.appDexSecret | b64enc }}
-  {{- end }}
   cookie-secret: {{ $crd.credentials.cookieSecret | b64enc }}
   {{- $namespaces := (get $context "namespaces") | default (list) }}
   {{- if not (has $crd.namespace $namespaces) }}

--- a/modules/150-user-authn/templates/dex/oauth2client.yaml
+++ b/modules/150-user-authn/templates/dex/oauth2client.yaml
@@ -41,6 +41,7 @@ trustedPeers:
 - kubeconfig-generator-{{ $index }}
   {{- end }}
 {{- end }}
+{{- if or $context.Values.userAuthn.kubeconfigGenerator $context.Values.userAuthn.publishAPI.enabled }}
 redirectURIs:
   {{- if $context.Values.userAuthn.kubeconfigGenerator }}
     {{- range $index, $cluster := $context.Values.userAuthn.kubeconfigGenerator }}
@@ -50,11 +51,10 @@ redirectURIs:
   {{- if $context.Values.userAuthn.publishAPI.enabled }}
 - https://{{ include "helm_lib_module_public_domain" (list $context "kubeconfig") }}/callback/
   {{- end }}
-  {{- if $context.Values.userAuthn.internal.dexAuthenticatorCRDs }}
-    {{- range $crd := $context.Values.userAuthn.internal.dexAuthenticatorCRDs }}
-      {{- if $crd.allowAccessToKubernetes }}
-- https://{{ $crd.spec.applicationDomain }}/dex-authenticator/callback
-      {{- end }}
-    {{- end }}
-  {{- end }}
+{{- else }}
+# The client exists only to hold trustedPeers of authenticators, which redirect to their own
+# OAuth2Client, so it needs no redirect URI of its own. Emit an empty list rather than a bare key,
+# which would parse as null.
+redirectURIs: []
+{{- end }}
 {{- end }}


### PR DESCRIPTION
> Backport of #22216 to `release-1.76`. The automatic cherry-pick could not be used: three files conflict, and a fourth applies cleanly while silently breaking the render.
>
> **Conflicts, all the same shape** — the branch does not carry the `allow-access-to-kubernetes` annotation parsing that `main` keeps next to this change:
>
> - `hooks/get_dex_authenticator_crds.go`: kept the migration block, dropped the annotation parsing. Added the `log/slog` import, which reached `main` together with the parsing this branch does not have.
> - `hooks/get_dex_authenticator_crds_test.go`: kept `inputDexAuthenticatorClientSecret`, `testSharedKubernetesClientSecret` and the `The client secret of an existing DexAuthenticator` table; dropped the annotation table and its input type. Added `. "github.com/onsi/ginkgo/extensions/table"`, the import this branch uses for `DescribeTable`, for the same reason.
> - `template_tests/kubernetes_oauth2client_test.go`: dropped the `Full scenario` context. It reads `userAuthn.internal.kubeconfigClientEncodedNames` and `kubeconfigPublishAPIEncodedName`, neither of which exists here. The fixture updates and the renamed `without redirect URIs` spec applied outside the conflict and are kept.
>
> **The change that conflicts with nothing and matters most.** The guard this PR adds in `templates/dex/oauth2client.yaml` reads `userAuthn.internal.publishAPI.enabled`. That path exists from 1.77 onwards; here the setting lives at `userAuthn.publishAPI`. Git applies the line without complaint and the whole chart stops rendering. Rewritten to the path this branch serves, and the fix is load-bearing: putting the original line back turns `modules/150-user-authn/template_tests` red.
>
> **Verified on the branch.** `go test ./modules/150-user-authn/... -count=1`: `hooks` and `openapi/conversions` pass. `template_tests` currently reports ten failures in the `basic auth proxy` context, which are not from this change — they are the fixture that arrived with the backport of #22214 and are fixed in #22366. With that fix applied locally the package passes, so this PR is green once #22366 lands.

## Description

Two internal-only changes in `modules/150-user-authn`. No CRD/API change.

**1. Stop copying the shared `kubernetes` client secret into application namespaces.**

`templates/dex-authenticator/secret.yaml` rendered `client-secret` from
`userAuthn.internal.kubernetesDexClientAppSecret` whenever the authenticator carried the
`dexauthenticator.deckhouse.io/allow-access-to-kubernetes` annotation. That value is the single secret of the
privileged `kubernetes` OAuth2 client, also used by `templates/dex/secret.yaml`,
`templates/kubeconfig-generator/oauth2client.yaml`, `templates/dex/kubeconfig-oauth2clients.yaml`,
`templates/dex/kubernetes-dex-client-configuration.yaml` and `templates/basic-auth-proxy/deployment.yaml`.
The Secret is created in `{{ $crd.namespace }}`, so anyone able to read Secrets in an application namespace
obtained a cluster-level credential. The template now always renders the per-authenticator
`credentials.appDexSecret`.

Because `hooks/get_dex_authenticator_crds.go` reads `client-secret` back out of that same Secret into
`credentials.appDexSecret` (`applyDexAuthenticatorSecretFilter`), on clusters where the annotation was already
in use `appDexSecret` *is* the shared secret, and dropping the template branch alone would not rotate anything.
The hook therefore regenerates `appDexSecret` once when it equals the current secret of the `kubernetes`
client, reusing the existing `go_lib/pwgen` generator (`pwgen.AlphaNum(20)`) already used for `appDexSecret`
and `cookieSecret`.

The comparison value is read from the hook's own `kubernetesClientSecret` snapshot of
`d8-user-authn/kubernetes-dex-client-app-secret`, reusing `applyKubernetesSecretFilter` from
`hooks/generate_kubernetes_dex_client_app_secret.go`. It is deliberately not read from
`userAuthn.internal.kubernetesDexClientAppSecret`: that values path is written by
`kubernetesDexClientAppSecret`, which runs in the `main` queue, while this hook declares
`Queue: "/modules/user-authn"`, and `ModuleRun` queues the Synchronization tasks of the two queues
independently, so nothing orders them on a cold start. The cluster Secret is also the authoritative source,
being the object whose content was copied out. An absent Secret now means the shared secret does not exist, so
nothing can be carrying it. Every rotation is logged with `input.Logger.Warn`, since it rolls the
authenticator's pods.

**2. Remove dead tenant-controlled input from the privileged client.**

`templates/dex/oauth2client.yaml` appended `https://{{ $crd.spec.applicationDomain }}/dex-authenticator/callback`
to the `redirectURIs` of the `kubernetes` client itself. The hook watches `deckhouse.io/v2alpha1`, whose schema
has `spec.applications[].domain` and no `spec.applicationDomain` (`crds/dex-authenticator.yaml`), so the entry
always rendered as the broken literal `https:///dex-authenticator/callback`. The block is removed, and the
`redirectURIs` key now renders as `[]` instead of a bare key when the client exists only to hold the
`trustedPeers` of annotated authenticators.

### Verification that matching client secrets are not required

Cross-client audience issuance in Dex depends only on `trustedPeers` membership, never on a matching client
secret. In dex v2.44.0 (the version pinned in `modules/150-user-authn/oss.yaml`),
`server/oauth2.go:634-652` `validateCrossClientTrust` loads the peer client and returns true purely on
`peer.TrustedPeers` containing the requesting `clientID`; `server/oauth2.go:321-342` `getAudience` then adds the
peer to the audience. The three call sites (`server/oauth2.go:426`, `server/oauth2.go:541`,
`server/handlers.go:1150`) pass only client IDs. `templates/dex/oauth2client.yaml` already lists
`<name>-<namespace>-dex-authenticator` in `trustedPeers`, and `templates/dex-authenticator/oauth2client.yaml:12`
already registers the authenticator's own client under `secret: {{ $crd.credentials.appDexSecret }}` — which is
exactly what `OAUTH2_PROXY_CLIENT_SECRET` in `templates/dex-authenticator/deployment.yaml:240-244` consumes,
paired with `--client-id={{ $crd.name }}-{{ $crd.namespace }}-dex-authenticator`. So the authenticator
authenticates as itself and the shared secret was never needed.

### Verification that the removed redirect URI breaks nothing

oauth2-proxy authenticates under its own `client_id` (see above), and Dex validates `redirect_uri` against the
client resolved from the request's `client_id` (`server/oauth2.go:481-492`: `GetClient(ctx, clientID)` followed
by `validateRedirectURI(client, redirectURI)`), i.e. against
`templates/dex-authenticator/oauth2client.yaml:25-28`, where the genuine callback lives. The removed entry was
never a valid URI anyway.

### Operational consequence

Regenerating `appDexSecret` changes the `checksum/config` annotation on the authenticator Deployment
(`templates/dex-authenticator/deployment.yaml:150`), so authenticator pods roll once and users of those
applications may have to authenticate again. The `cookieSecret` is not touched.

### Follow-up work

Admission control over who may set the `dexclient.deckhouse.io/allow-access-to-kubernetes` /
`dexauthenticator.deckhouse.io/allow-access-to-kubernetes` annotations, and a namespace allowlist for them, are
deliberately out of scope here — they are behaviour-breaking and handled separately.

## Why do we need it, and what problem does it solve?

It removes an over-shared credential: a cluster-level OAuth2 client secret was being distributed into
tenant-readable namespaces with no user interaction required to obtain it. It also removes the single place
where tenant-controlled input reached the privileged client's `redirectURIs` — harmless today only because the
field name is wrong, and a real defect the moment someone "repairs" it.

## Why do we need it in the patch release (if we do)?

The over-sharing exists on any cluster that uses the annotation outside system namespaces, so it is worth
backporting to 1.77 and 1.76.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authn
type: fix
summary: Issue a dedicated OAuth2 client secret per DexAuthenticator instead of reusing the shared cluster client secret.
impact: |
  On upgrade, every DexAuthenticator that carries the
  `dexauthenticator.deckhouse.io/allow-access-to-kubernetes` annotation gets a freshly generated client
  secret, because it previously received the client secret of the privileged `kubernetes` OAuth2 client
  instead. Its pods roll once and users of those applications may have to sign in again. Each rotation is
  written to the Deckhouse log as `Rotating DexAuthenticator client secret that reused the shared kubernetes
  client secret`, with the authenticator name and namespace.

  If that annotation was ever used outside the `d8-*` and `kube-*` namespaces, the shared secret must be
  considered disclosed to anyone who could read Secrets in those namespaces, and has to be rotated by hand.
  Deleting the Secret alone does not rotate it: while the value is non-empty in memory the owning hook
  re-renders the same one. Rotate it as follows.

  1. If a GitOps tool syncs the `d8-user-authn` namespace, exclude
     `Secret/kubernetes-dex-client-app-secret` from that sync first, otherwise it is restored to the old
     value.
  2. Blank the stored value:
     `kubectl -n d8-user-authn patch secret kubernetes-dex-client-app-secret --type merge -p '{"data":{"secret":""}}'`
  3. Drop the in-memory copy: `kubectl -n d8-system rollout restart deployment/deckhouse`
  4. Check that `kubectl -n d8-user-authn get secret kubernetes-dex-client-app-secret -o jsonpath='{.data.secret}'`
     now differs from the previous value. If it does not, the module re-rendered the old value before the
     restart took effect; repeat steps 2 and 3.

  The blast radius of that rotation is wider than the `kubernetes` client alone. The same value is the client
  secret of the `kubeconfig-generator`, `kubeconfig-publish-api` and every `kubeconfig-<slug>` OAuth2 client,
  and it is passed to basic-auth-proxy as `--ldap-client-secret`. In-cluster consumers are re-rendered and
  their pods roll automatically, but kubeconfig files already downloaded from the kubeconfig generator carry
  the old client secret and can no longer refresh their tokens, so their users must download a new
  kubeconfig. Already issued ID tokens keep working until they expire, at most `settings.idTokenTTL`.

  Deleting and recreating a DexAuthenticator is always a safe way to force a fresh per-authenticator secret:
  the credentials Secret is regenerated with the resource. Its content is owned by Deckhouse, so no GitOps
  change is needed for the per-authenticator rotation itself.
impact_level: high
---
section: user-authn
type: fix
summary: Drop the dead per-DexAuthenticator redirect URI from the privileged kubernetes OAuth2 client.
```

