### PR TITLE
[deckhouse] wait until nelm deletes resources

### DIFF
--- a/deckhouse-controller/internal/packages/runtime/apps.go
+++ b/deckhouse-controller/internal/packages/runtime/apps.go
@@ -164,7 +164,13 @@ func (r *Runtime) loadApp(ctx context.Context, repo registry.Remote, packagePath
 	return app.GetVersion().String(), nil
 }
 
-// RemoveApp removes an application and cancels all its running operations.
+// RemoveApp removes an application, cancels all its running operations and reports whether the
+// teardown has finished. The caller polls it and holds the Application's finalizer until it
+// returns true, so the CR outlives the Helm release it owns.
+//
+// It is idempotent by contract: a call made while the teardown runs must not re-issue
+// EventRemove, because that cancels the whole context tree (lifecycle.Package.newContext) and
+// would restart the very uninstall the caller is waiting for.
 //
 // After the undeploy task succeeds, a cleanup goroutine removes the
 // Store entry and stops the queue. The goroutine is necessary because
@@ -172,14 +178,27 @@ func (r *Runtime) loadApp(ctx context.Context, repo registry.Remote, packagePath
 // within the queue's own processing loop would deadlock on WaitGroup.
 //
 // Store.Delete has a state guard: if UpdateApp re-created the package
-// between undeploy and cleanup, Delete is a no-op (version != "").
-func (r *Runtime) RemoveApp(namespace, instance string) {
+// between undeploy and cleanup, Delete is a no-op (version != "") and the removal reports
+// unfinished again, now for the re-created generation.
+func (r *Runtime) RemoveApp(namespace, instance string) bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	name := apps.BuildName(namespace, instance)
+
+	switch r.packages.RemovalState(name) {
+	case lifecycle.RemovalDone:
+		// nothing is tracked under the name: the teardown finished, or never had to run
+		return true
+
+	case lifecycle.RemovalInFlight:
+		r.logger.Debug("app removal is still in flight", slog.String("name", name))
+
+		return false
+	}
+
 	r.logger.Debug("remove app", slog.String("namespace", namespace), slog.String("instance", instance))
 
-	name := apps.BuildName(namespace, instance)
 	r.scheduler.RemoveNode(name)
 
 	// A removed application no longer reconciles anything, so drop its maintenance gauge.
@@ -187,7 +206,7 @@ func (r *Runtime) RemoveApp(namespace, instance string) {
 
 	ctx := r.packages.HandleEvent(lifecycle.EventRemove, name)
 	if ctx == nil {
-		return
+		return true
 	}
 
 	if pkg := r.apps[name]; pkg != nil {
@@ -208,4 +227,6 @@ func (r *Runtime) RemoveApp(namespace, instance string) {
 	})
 
 	r.queueService.Enqueue(ctx, name, taskundeploy.NewAppTask(name, r.appDeployer, r.logger), cleanup)
+
+	return false
 }

--- a/deckhouse-controller/internal/packages/runtime/apps.go
+++ b/deckhouse-controller/internal/packages/runtime/apps.go
@@ -33,6 +33,7 @@ import (
 	taskdisable "github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/runtime/tasks/disable"
 	taskload "github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/runtime/tasks/load"
 	taskundeploy "github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/runtime/tasks/undeploy"
+	taskuninstall "github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/runtime/tasks/uninstall"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/status"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/queue"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/registry"
@@ -177,9 +178,9 @@ func (r *Runtime) loadApp(ctx context.Context, repo registry.Remote, packagePath
 // queueService.Remove stops the queue — calling it synchronously from
 // within the queue's own processing loop would deadlock on WaitGroup.
 //
-// Store.Delete has a state guard: if UpdateApp re-created the package
-// between undeploy and cleanup, Delete is a no-op (version != "") and the removal reports
-// unfinished again, now for the re-created generation.
+// Store.Delete has a state guard: if UpdateApp re-created the package between undeploy and cleanup,
+// Update cleared the removal marker, so Delete is a no-op and removal reports unfinished again for
+// the re-created generation.
 func (r *Runtime) RemoveApp(namespace, instance string) bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -211,6 +212,9 @@ func (r *Runtime) RemoveApp(namespace, instance string) bool {
 
 	if pkg := r.apps[name]; pkg != nil {
 		r.queueService.Enqueue(ctx, name, taskdisable.NewTask(pkg, pkg.GetNamespace(), false, r.nelmService, r.queueService, r.logger))
+	} else {
+		// A failed Load may roll the instance out of r.apps while the previous release is still live.
+		r.queueService.Enqueue(ctx, name, taskuninstall.NewTask(name, namespace, r.nelmService, r.logger))
 	}
 
 	cleanup := queue.WithOnDone(func() {

--- a/deckhouse-controller/internal/packages/runtime/lifecycle/lifecycle.go
+++ b/deckhouse-controller/internal/packages/runtime/lifecycle/lifecycle.go
@@ -51,6 +51,7 @@ type Package struct {
 	settingsVersion int               // schema version of pending settings (from ModuleConfig.Spec.Version)
 	settings        addonutils.Values // pending settings, updated by Update, consumed by GetPendingSettings
 	maintenance     string            // pending maintenance mode, consumed by GetPendingMaintenance
+	removing        bool              // EventRemove was issued and its teardown has not finished
 
 	ctx    context.Context    // root context, cancelled on version change or remove
 	cancel context.CancelFunc // cancels root and all children

--- a/deckhouse-controller/internal/packages/runtime/lifecycle/store.go
+++ b/deckhouse-controller/internal/packages/runtime/lifecycle/store.go
@@ -192,6 +192,33 @@ func (s *Store) GetPendingMaintenance(name string) string {
 	return s.packages[name].maintenance
 }
 
+// RemovalState reports how far a package's teardown has got.
+type RemovalState int
+
+const (
+	// RemovalDone means nothing is tracked under the name, so nothing is left to tear down.
+	RemovalDone RemovalState = iota
+	// RemovalPending means the package is still tracked and no teardown has been issued yet.
+	RemovalPending
+	// RemovalInFlight means a teardown is already enqueued; re-issuing EventRemove would cancel it.
+	RemovalInFlight
+)
+
+// RemovalState reports the teardown state of a package. A cleared version is what marks a removal
+// as already issued — the same signal Delete guards on — so callers can wait instead of re-issuing.
+func (s *Store) RemovalState(name string) RemovalState {
+	pkg, ok := s.packages[name]
+	if !ok {
+		return RemovalDone
+	}
+
+	if pkg.version == "" {
+		return RemovalInFlight
+	}
+
+	return RemovalPending
+}
+
 // Delete removes a package entry from the store if it still exists and is in
 // the removed state (version cleared by HandleEvent(EventRemove)).
 // Returns true if the entry was deleted.

--- a/deckhouse-controller/internal/packages/runtime/lifecycle/store.go
+++ b/deckhouse-controller/internal/packages/runtime/lifecycle/store.go
@@ -38,13 +38,17 @@ func NewStore() *Store {
 }
 
 // NeedUpdate reports whether the package needs processing: true if the package
-// is new, the version changed, the settings checksum differs, the settings
-// schema version changed, or the maintenance mode changed.
+// is new or being removed, the version changed, the settings checksum differs,
+// the settings schema version changed, or the maintenance mode changed.
 // Used as a fast-path check before the more expensive Update call. It cannot see content
 // changes behind a mutable tag: those callers skip it and pass force to Update.
 func (s *Store) NeedUpdate(name, version, checksum string, settingsVersion int, maintenance string) bool {
 	pkg, ok := s.packages[name]
 	if !ok {
+		return true
+	}
+
+	if pkg.removing {
 		return true
 	}
 
@@ -74,6 +78,7 @@ func (s *Store) NeedUpdate(name, version, checksum string, settingsVersion int, 
 //  2. Version differs → cancels all in-flight tasks, returns new root context
 //  3. force is set → same as a version change, for callers that know the content behind
 //     an unchanged version is stale (a mutable tag re-pushed under the same version)
+//  4. Package is being removed → cancels teardown and starts the re-created generation
 //
 // Returns nil when only settings, settingsVersion or maintenance changed (no new
 // context needed — the new values are stored and will be picked up by the scheduler
@@ -97,11 +102,12 @@ func (s *Store) Update(name, version string, settingsVersion int, settings addon
 		return ctx
 	}
 
-	if force || pkg.version != version {
+	if force || pkg.removing || pkg.version != version {
 		pkg.version = version
 		pkg.settingsVersion = settingsVersion
 		pkg.settings = settings
 		pkg.maintenance = maintenance
+		pkg.removing = false
 
 		ctx := pkg.newContext(EventUpdate)
 		return ctx
@@ -159,10 +165,15 @@ func (s *Store) UpdateSettings(name string, settingsVersion int, settings addonu
 // For EventRemove: clears version and settings before renewing context, so a
 // subsequent Update sees the package as new (enabling re-create after remove).
 //
-// Returns nil if the package doesn't exist in the store.
+// Returns nil if the package doesn't exist in the store, or if EventSchedule
+// arrives after removal has started and must not supersede teardown.
 func (s *Store) HandleEvent(event int, name string) context.Context {
 	pkg, ok := s.packages[name]
 	if !ok {
+		return nil
+	}
+
+	if event == EventSchedule && pkg.removing {
 		return nil
 	}
 
@@ -171,6 +182,7 @@ func (s *Store) HandleEvent(event int, name string) context.Context {
 		pkg.settingsVersion = 0
 		pkg.settings = make(addonutils.Values)
 		pkg.maintenance = ""
+		pkg.removing = true
 	}
 
 	return pkg.newContext(event)
@@ -204,15 +216,15 @@ const (
 	RemovalInFlight
 )
 
-// RemovalState reports the teardown state of a package. A cleared version is what marks a removal
-// as already issued — the same signal Delete guards on — so callers can wait instead of re-issuing.
+// RemovalState reports the teardown state of a package. The explicit removal marker lets callers
+// wait instead of re-issuing EventRemove, independently of whether the package version is empty.
 func (s *Store) RemovalState(name string) RemovalState {
 	pkg, ok := s.packages[name]
 	if !ok {
 		return RemovalDone
 	}
 
-	if pkg.version == "" {
+	if pkg.removing {
 		return RemovalInFlight
 	}
 
@@ -220,15 +232,14 @@ func (s *Store) RemovalState(name string) RemovalState {
 }
 
 // Delete removes a package entry from the store if it still exists and is in
-// the removed state (version cleared by HandleEvent(EventRemove)).
+// the removed state set by HandleEvent(EventRemove).
 // Returns true if the entry was deleted.
 //
-// Safe against re-creation races: if Update has already set a new version
-// between the remove and this cleanup, the version is non-empty and Delete
-// returns false, preserving the re-created entry.
+// Safe against re-creation races: Update clears the removal marker before
+// this cleanup, so Delete returns false and preserves the re-created entry.
 func (s *Store) Delete(name string) bool {
 	pkg, ok := s.packages[name]
-	if !ok || pkg.version != "" {
+	if !ok || !pkg.removing {
 		return false
 	}
 

--- a/deckhouse-controller/internal/packages/runtime/modules.go
+++ b/deckhouse-controller/internal/packages/runtime/modules.go
@@ -34,6 +34,7 @@ import (
 	taskdummy "github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/runtime/tasks/dummy"
 	taskload "github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/runtime/tasks/load"
 	taskundeploy "github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/runtime/tasks/undeploy"
+	taskuninstall "github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/runtime/tasks/uninstall"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/status"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/queue"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/registry"
@@ -323,6 +324,9 @@ func (r *Runtime) RemoveModule(name string) bool {
 
 	if pkg := r.modules[name]; pkg != nil {
 		r.queueService.Enqueue(ctx, name, taskdisable.NewTask(pkg, app.NamespaceDeckhouse, false, r.nelmService, r.queueService, r.logger))
+	} else {
+		// A failed Load may roll the instance out of r.modules while the previous release is still live.
+		r.queueService.Enqueue(ctx, name, taskuninstall.NewTask(name, app.NamespaceDeckhouse, r.nelmService, r.logger))
 	}
 
 	cleanup := queue.WithOnDone(r.cleanupModule(name))
@@ -334,8 +338,8 @@ func (r *Runtime) RemoveModule(name string) bool {
 
 // RemoveEmbeddedModule removes an embedded module and cancels all its running operations.
 // It is RemoveModule without Undeploy: the image carries the files, so nothing was ever placed
-// on disk for the deployer to take back. The cleanup therefore rides on Disable, or runs on its
-// own when the module never loaded and there is nothing to disable.
+// on disk for the deployer to take back. Cleanup always rides on Dummy after Disable, or after
+// Uninstall when the module instance is unavailable.
 func (r *Runtime) RemoveEmbeddedModule(name string) bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -359,6 +363,9 @@ func (r *Runtime) RemoveEmbeddedModule(name string) bool {
 
 	if pkg := r.modules[name]; pkg != nil {
 		r.queueService.Enqueue(ctx, name, taskdisable.NewTask(pkg, app.NamespaceDeckhouse, false, r.nelmService, r.queueService, r.logger))
+	} else {
+		// A failed Load may roll the instance out of r.modules while the previous release is still live.
+		r.queueService.Enqueue(ctx, name, taskuninstall.NewTask(name, app.NamespaceDeckhouse, r.nelmService, r.logger))
 	}
 
 	// The teardown rides the last task in the package's queue, never runs inline: it stops that queue

--- a/deckhouse-controller/internal/packages/runtime/modules.go
+++ b/deckhouse-controller/internal/packages/runtime/modules.go
@@ -297,18 +297,28 @@ func (r *Runtime) registerModule(ctx context.Context, conf *modules.Config) (*mo
 	return module, nil
 }
 
-// RemoveModule removes a module and cancels all its running operations.
-// After undeploy, a cleanup goroutine removes the Store entry and stops the queue.
-// See RemoveApp for detailed rationale on the async cleanup pattern.
-func (r *Runtime) RemoveModule(name string) {
+// RemoveModule removes a module, cancels all its running operations and reports whether the
+// teardown has finished. After undeploy, a cleanup goroutine removes the Store entry and stops
+// the queue. See RemoveApp for the idempotence contract and the async cleanup rationale.
+func (r *Runtime) RemoveModule(name string) bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+
+	switch r.packages.RemovalState(name) {
+	case lifecycle.RemovalDone:
+		return true
+
+	case lifecycle.RemovalInFlight:
+		r.logger.Debug("module removal is still in flight", slog.String("name", name))
+
+		return false
+	}
 
 	r.scheduler.RemoveNode(name)
 
 	ctx := r.packages.HandleEvent(lifecycle.EventRemove, name)
 	if ctx == nil {
-		return
+		return true
 	}
 
 	if pkg := r.modules[name]; pkg != nil {
@@ -318,21 +328,33 @@ func (r *Runtime) RemoveModule(name string) {
 	cleanup := queue.WithOnDone(r.cleanupModule(name))
 
 	r.queueService.Enqueue(ctx, name, taskundeploy.NewModuleTask(name, r.moduleDeployer, r.logger), cleanup)
+
+	return false
 }
 
 // RemoveEmbeddedModule removes an embedded module and cancels all its running operations.
 // It is RemoveModule without Undeploy: the image carries the files, so nothing was ever placed
 // on disk for the deployer to take back. The cleanup therefore rides on Disable, or runs on its
 // own when the module never loaded and there is nothing to disable.
-func (r *Runtime) RemoveEmbeddedModule(name string) {
+func (r *Runtime) RemoveEmbeddedModule(name string) bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+
+	switch r.packages.RemovalState(name) {
+	case lifecycle.RemovalDone:
+		return true
+
+	case lifecycle.RemovalInFlight:
+		r.logger.Debug("embedded module removal is still in flight", slog.String("name", name))
+
+		return false
+	}
 
 	r.scheduler.RemoveNode(name)
 
 	ctx := r.packages.HandleEvent(lifecycle.EventRemove, name)
 	if ctx == nil {
-		return
+		return true
 	}
 
 	if pkg := r.modules[name]; pkg != nil {
@@ -344,6 +366,8 @@ func (r *Runtime) RemoveEmbeddedModule(name string) {
 	// running and about to want r.mu itself — it would deadlock both. RemoveModule anchors it on
 	// Undeploy; an embedded module has nothing to undeploy, so it anchors on a dummy task.
 	r.queueService.Enqueue(ctx, name, taskdummy.NewTask(name, r.logger), queue.WithOnDone(r.cleanupModule(name)))
+
+	return false
 }
 
 // cleanupModule returns the teardown that drops the Store entry, stops the queue and deletes the

--- a/deckhouse-controller/internal/packages/runtime/tasks/uninstall/task.go
+++ b/deckhouse-controller/internal/packages/runtime/tasks/uninstall/task.go
@@ -1,0 +1,82 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package uninstall
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/queue"
+	"github.com/deckhouse/deckhouse/pkg/log"
+)
+
+const (
+	// taskTracer identifies tracing and log records emitted by the uninstall task.
+	taskTracer = "package-uninstall"
+)
+
+// nelmI abstracts release operations needed when no loaded package is available.
+type nelmI interface {
+	// Delete uninstalls the named release and succeeds when it is already absent.
+	Delete(ctx context.Context, namespace, name string) error
+	// RemoveMonitor stops watching resources owned by the named release.
+	RemoveMonitor(name string)
+}
+
+// NewTask creates an uninstall task for a release whose loaded package is unavailable.
+// A missing release is successful because the Nelm delete operation is idempotent.
+func NewTask(name, namespace string, nelm nelmI, logger *log.Logger) queue.Task {
+	return &task{
+		name:      name,
+		namespace: namespace,
+		nelm:      nelm,
+		logger:    logger.Named(taskTracer).With("name", name),
+	}
+}
+
+// task removes a release without requiring its loaded package or lifecycle hooks.
+type task struct {
+	name      string
+	namespace string
+
+	nelm nelmI
+
+	logger *log.Logger
+}
+
+// String returns the stable queue identity of the task.
+func (t *task) String() string {
+	return "Uninstall"
+}
+
+// Execute stops release monitoring and deletes the release by namespace and name.
+func (t *task) Execute(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	t.logger.Debug("uninstall package release")
+	t.nelm.RemoveMonitor(t.name)
+
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	if err := t.nelm.Delete(ctx, t.namespace, t.name); err != nil {
+		return fmt.Errorf("delete release '%s': %w", t.name, err)
+	}
+
+	return nil
+}

--- a/deckhouse-controller/pkg/controller/packages/application/controller.go
+++ b/deckhouse-controller/pkg/controller/packages/application/controller.go
@@ -52,6 +52,10 @@ const (
 	// defaultRequeueAfter is the retry delay for states that need an external change to
 	// make progress, such as a missing package or a version still in draft.
 	defaultRequeueAfter = 30 * time.Second
+
+	// removalRequeueAfter is how often a running teardown is re-checked. It completes in a queue
+	// callback the API server never sees, so the only way to notice is to ask the runtime again.
+	removalRequeueAfter = 5 * time.Second
 )
 
 // RegisterController registers the Application controller with the manager.
@@ -105,7 +109,8 @@ type moduleManager interface {
 // packageManager registers and unregisters applications in the package runtime.
 type packageManager interface {
 	UpdateApp(repo registry.Remote, inst packageruntime.App)
-	RemoveApp(namespace, name string)
+	// RemoveApp tears the application down and reports whether the teardown has finished.
+	RemoveApp(namespace, name string) bool
 	GetStatus(name string) packagestatus.Status
 	GetAppStatusQueue() workqueue.TypedRateLimitingInterface[string]
 	Cleanup(ctx context.Context, preserve []packageruntime.PreservePackage)
@@ -130,6 +135,14 @@ func (r *reconciler) preflight(ctx context.Context) error {
 
 	preserve := make([]packageruntime.PreservePackage, 0, len(appsList.Items))
 	for _, app := range appsList.Items {
+		// An application already being deleted is not preserved. The runtime forgets its teardown
+		// across a restart, so handleDelete would find nothing left to tear down and release the
+		// finalizer; this cleanup is the last owner of the release, and skipping it here is what
+		// makes that answer true.
+		if !app.DeletionTimestamp.IsZero() {
+			continue
+		}
+
 		preserve = append(preserve, packageruntime.PreservePackage{
 			PackageName: app.Spec.PackageName,
 			Repository:  app.Spec.PackageRepositoryName,
@@ -170,11 +183,12 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	// handle delete event
 	if !app.DeletionTimestamp.IsZero() {
-		if err := r.handleDelete(ctx, app); err != nil {
+		res, err := r.handleDelete(ctx, app)
+		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("delete: %w", err)
 		}
 
-		return ctrl.Result{}, nil
+		return res, nil
 	}
 
 	// handle create/update events
@@ -274,14 +288,29 @@ func (r *reconciler) handleCreateOrUpdate(ctx context.Context, app *v1alpha1.App
 	return nil
 }
 
-// handleDelete detaches the application from its package and version, unregisters it
-// from the package runtime and releases the finalizer.
-func (r *reconciler) handleDelete(ctx context.Context, app *v1alpha1.Application) error {
+// handleDelete unregisters the application from the package runtime and, once the runtime reports
+// the teardown finished, detaches the application from its package and version and releases the
+// finalizer. The wait is unbounded on purpose: holding the finalizer is what keeps a Helm release
+// from outliving the CR that owns it, so a teardown the queue keeps retrying keeps the application
+// in Terminating rather than orphaning its resources.
+func (r *reconciler) handleDelete(ctx context.Context, app *v1alpha1.Application) (ctrl.Result, error) {
 	logger := r.logger.With(slog.String("name", app.Name), slog.String("namespace", app.Namespace))
 
 	logger.Debug("handle delete application")
 	defer logger.Debug("handle delete application complete")
 
+	// The runtime tears the application down asynchronously — the Disable task uninstalls the Helm
+	// release, Undeploy takes the files off disk, and the cleanup riding the last task drops the
+	// state — so RemoveApp is polled until it reports the teardown finished.
+	if !r.manager.RemoveApp(app.Namespace, app.Name) {
+		logger.Info("application is still being removed by the runtime")
+
+		return ctrl.Result{RequeueAfter: removalRequeueAfter}, nil
+	}
+
+	// Detach only after the teardown: releasing the version any earlier lets it be garbage
+	// collected — and its package files removed from disk — while the uninstall still needs them.
+	//
 	// Detach by owner reference, falling back to the spec: the reference names what the
 	// application was actually attached to, which a spec edit just before deletion would have
 	// changed, but it is written after the attach, so an attached application can lack it.
@@ -292,7 +321,7 @@ func (r *reconciler) handleDelete(ctx context.Context, app *v1alpha1.Application
 
 	if err := r.detachVersion(ctx, app, apvName); err != nil {
 		logger.Error("failed to detach the application package version", slog.String("apv", apvName), log.Err(err))
-		return err
+		return ctrl.Result{}, err
 	}
 
 	pkgName := ctrlutils.OwnerRefName(app, v1alpha1.ApplicationPackageKind)
@@ -302,14 +331,11 @@ func (r *reconciler) handleDelete(ctx context.Context, app *v1alpha1.Application
 
 	if err := r.detachPackage(ctx, app, pkgName); err != nil {
 		logger.Error("failed to detach the application package", slog.String("package", pkgName), log.Err(err))
-		return err
+		return ctrl.Result{}, err
 	}
 
-	// call PackageOperator method (PackageRemover interface)
-	r.manager.RemoveApp(app.Namespace, app.Name)
-
 	if !controllerutil.ContainsFinalizer(app, v1alpha1.ApplicationFinalizerStatisticRegistered) {
-		return nil
+		return ctrl.Result{}, nil
 	}
 
 	patch := client.MergeFrom(app.DeepCopy())
@@ -317,10 +343,10 @@ func (r *reconciler) handleDelete(ctx context.Context, app *v1alpha1.Application
 
 	if err := r.client.Patch(ctx, app, patch); err != nil {
 		logger.Error("failed to remove the application finalizer", log.Err(err))
-		return fmt.Errorf("patch application %s: %w", app.Name, err)
+		return ctrl.Result{}, fmt.Errorf("patch application %s: %w", app.Name, err)
 	}
 
-	return nil
+	return ctrl.Result{}, nil
 }
 
 // relink moves the application onto ap and apv, releasing the ones it switched away

--- a/deckhouse-controller/pkg/controller/packages/application/controller_test.go
+++ b/deckhouse-controller/pkg/controller/packages/application/controller_test.go
@@ -498,11 +498,39 @@ func TestDeleteFailureKeepsTheFinalizer(t *testing.T) {
 	_, err := ctr.Reconcile(context.Background(), request(appName, appNamespace))
 	require.ErrorIs(t, err, patchErr)
 
-	// Releasing the finalizer here would drop the application while the package still
-	// counts it as an installation, and nothing would ever come back to fix that.
+	// Runtime teardown has completed, but releasing the finalizer here would drop the
+	// application while the package still counts it as an installation.
 	require.NoError(t, cl.Get(context.Background(), objectKey(appName, appNamespace), app))
 	assert.Contains(t, app.Finalizers, v1alpha1.ApplicationFinalizerStatisticRegistered)
-	assert.Empty(t, manager.removed, "the runtime must keep the application until it is detached")
+	assert.Equal(t, []types.NamespacedName{{Namespace: appNamespace, Name: appName}}, manager.removed)
+}
+
+func TestDeleteWaitsForRuntimeTeardown(t *testing.T) {
+	cl := seedFakeClient(t, "delete-after-version-edit.yaml", interceptor.Funcs{})
+
+	app := new(v1alpha1.Application)
+	require.NoError(t, cl.Get(context.Background(), objectKey(appName, appNamespace), app))
+	require.NoError(t, cl.Delete(context.Background(), app))
+
+	manager := newPackageManagerStub(t)
+	manager.removalDone = false
+	ctr := reconcilerFor(t, cl, manager)
+
+	result, err := ctr.Reconcile(context.Background(), request(appName, appNamespace))
+	require.NoError(t, err)
+	assert.Equal(t, 5*time.Second, result.RequeueAfter)
+	assert.Equal(t, []types.NamespacedName{{Namespace: appNamespace, Name: appName}}, manager.removed)
+
+	require.NoError(t, cl.Get(context.Background(), objectKey(appName, appNamespace), app))
+	assert.Contains(t, app.Finalizers, v1alpha1.ApplicationFinalizerStatisticRegistered)
+
+	pkg := new(v1alpha1.ApplicationPackage)
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKey{Name: packageName}, pkg))
+	assert.True(t, pkg.IsAppInstalled(appNamespace, appName))
+
+	apv := new(v1alpha1.ApplicationPackageVersion)
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKey{Name: versionName}, apv))
+	assert.True(t, apv.IsAppInstalled(appNamespace, appName))
 }
 
 func TestDeleteDistinguishesAMissingVersionFromAnUnreadableOne(t *testing.T) {
@@ -528,7 +556,7 @@ func TestDeleteDistinguishesAMissingVersionFromAnUnreadableOne(t *testing.T) {
 	// gone: treating the two alike would leak the installation entry.
 	_, err := ctr.Reconcile(context.Background(), request(appName, appNamespace))
 	require.Error(t, err)
-	assert.Empty(t, manager.removed)
+	assert.Equal(t, []types.NamespacedName{{Namespace: appNamespace, Name: appName}}, manager.removed)
 }
 
 func TestPreflightPreservesEveryApplication(t *testing.T) {
@@ -653,9 +681,10 @@ func (m modulesInited) AreModulesInited() bool { return bool(m) }
 // RegisterController requires it to satisfy the package's manager interface, which is the
 // compile-time check that this stub still matches the real runtime.
 type packageManagerStub struct {
-	updated  []updatedApp
-	removed  []types.NamespacedName
-	cleanups [][]packageruntime.PreservePackage
+	updated     []updatedApp
+	removed     []types.NamespacedName
+	cleanups    [][]packageruntime.PreservePackage
+	removalDone bool
 
 	queue workqueue.TypedRateLimitingInterface[string]
 }
@@ -668,7 +697,10 @@ func newPackageManagerStub(t *testing.T) *packageManagerStub {
 	queue := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]())
 	t.Cleanup(queue.ShutDown)
 
-	return &packageManagerStub{queue: queue}
+	return &packageManagerStub{
+		queue:       queue,
+		removalDone: true,
+	}
 }
 
 type updatedApp struct {
@@ -680,8 +712,10 @@ func (s *packageManagerStub) UpdateApp(repo registry.Remote, app packageruntime.
 	s.updated = append(s.updated, updatedApp{repo: repo, app: app})
 }
 
-func (s *packageManagerStub) RemoveApp(namespace, name string) {
+func (s *packageManagerStub) RemoveApp(namespace, name string) bool {
 	s.removed = append(s.removed, types.NamespacedName{Namespace: namespace, Name: name})
+
+	return s.removalDone
 }
 
 func (s *packageManagerStub) GetStatus(string) packagestatus.Status {

--- a/deckhouse-controller/pkg/controller/packages/module/controller.go
+++ b/deckhouse-controller/pkg/controller/packages/module/controller.go
@@ -57,6 +57,9 @@ const (
 	// devRequeueAfter is how often a dev module's tag is re-resolved. A repush moves nothing
 	// in the API server, so the digest behind the tag is only ever seen by looking again.
 	devRequeueAfter = 15 * time.Second
+	// removalRequeueAfter is how often a running teardown is re-checked. It completes in a queue
+	// callback the API server never sees, so the only way to notice is to ask the runtime again.
+	removalRequeueAfter = 5 * time.Second
 )
 
 // RegisterController registers the Module controller with the manager.
@@ -106,8 +109,10 @@ type packageManager interface {
 	UpdateModule(repo registry.Remote, module packageruntime.Module, force bool)
 	GetModuleDigest(ctx context.Context, repo registry.Remote, name, tag string) (string, error)
 	UpdateEmbeddedModule(module packageruntime.Module)
-	RemoveModule(name string)
-	RemoveEmbeddedModule(name string)
+	// RemoveModule tears the module down and reports whether the teardown has finished.
+	RemoveModule(name string) bool
+	// RemoveEmbeddedModule is RemoveModule for a module the image ships; it undeploys nothing.
+	RemoveEmbeddedModule(name string) bool
 	GetStatus(name string) packagestatus.Status
 	GetModuleStatusQueue() workqueue.TypedRateLimitingInterface[string]
 }
@@ -132,11 +137,12 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	// handle delete event
 	if !module.DeletionTimestamp.IsZero() {
-		if err := r.handleDelete(ctx, module); err != nil {
+		res, err := r.handleDelete(ctx, module)
+		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("delete: %w", err)
 		}
 
-		return ctrl.Result{}, nil
+		return res, nil
 	}
 
 	// handle create/update events
@@ -361,36 +367,53 @@ func (r *reconciler) handleDev(ctx context.Context, module, original *v1alpha2.M
 	return nil
 }
 
-// handleDelete releases the module's package version, unregisters it from the package
-// runtime and releases the finalizer.
-func (r *reconciler) handleDelete(ctx context.Context, module *v1alpha2.Module) error {
+// handleDelete unregisters the module from the package runtime and, once the runtime reports the
+// teardown finished, releases the module's package version and the finalizer. The wait is unbounded
+// on purpose: holding the finalizer is what keeps a Helm release from outliving the CR that owns
+// it, so a teardown the queue keeps retrying keeps the module in Terminating rather than orphaning
+// its resources.
+func (r *reconciler) handleDelete(ctx context.Context, module *v1alpha2.Module) (ctrl.Result, error) {
 	logger := r.logger.With(slog.String("name", module.Name))
 
 	logger.Debug("handle delete module")
 	defer logger.Debug("handle delete module complete")
 
+	// An embedded module deployed nothing, so its removal enqueues no undeploy — but its hooks and
+	// its Helm release are still taken down by Disable, which is what this waits for.
+	remove := r.manager.RemoveModule
+	if module.IsEmbedded() {
+		remove = r.manager.RemoveEmbeddedModule
+	}
+
+	// The runtime tears the module down asynchronously — the Disable task uninstalls the Helm
+	// release, Undeploy takes the files off disk, and the cleanup riding the last task drops the
+	// state — so the remover is polled until it reports the teardown finished.
+	if !remove(module.Name) {
+		logger.Info("module is still being removed by the runtime")
+
+		return ctrl.Result{RequeueAfter: removalRequeueAfter}, nil
+	}
+
+	// The removal only holds until the next start: the image still ships the module, so the
+	// bootstrap recreates the resource and loads it again.
+	if module.IsEmbedded() {
+		logger.Info("embedded module is removed, it will be placed again on the next start")
+	}
+
+	// Detach only after the teardown: releasing the version any earlier lets it be garbage
+	// collected — and its package files removed from disk — while the uninstall still needs them.
+	//
 	// Detach by owner reference, not by spec: the reference names what the module was
 	// actually attached to, which a spec edit just before deletion would have changed.
 	if name := ctrlutils.OwnerRefName(module, v1alpha1.ModulePackageVersionKind); name != "" {
 		if err := r.detachVersion(ctx, name); err != nil {
 			logger.Error("failed to detach the module package version", slog.String("mpv", name), log.Err(err))
-			return err
+			return ctrl.Result{}, err
 		}
 	}
 
-	// An embedded module deployed nothing, so its removal enqueues no undeploy. The removal only
-	// holds until the next start: the image still ships the module, so the bootstrap recreates the
-	// resource and loads it again.
-	if module.IsEmbedded() {
-		logger.Info("embedded module is removed, it will be placed again on the next start")
-
-		r.manager.RemoveEmbeddedModule(module.Name)
-	} else {
-		r.manager.RemoveModule(module.Name)
-	}
-
 	if !controllerutil.ContainsFinalizer(module, v1alpha2.ModuleFinalizerStatisticRegistered) {
-		return nil
+		return ctrl.Result{}, nil
 	}
 
 	patch := client.MergeFrom(module.DeepCopy())
@@ -398,10 +421,10 @@ func (r *reconciler) handleDelete(ctx context.Context, module *v1alpha2.Module) 
 
 	if err := r.client.Patch(ctx, module, patch); err != nil {
 		logger.Error("failed to remove the module finalizer", log.Err(err))
-		return fmt.Errorf("patch module '%s': %w", module.Name, err)
+		return ctrl.Result{}, fmt.Errorf("patch module '%s': %w", module.Name, err)
 	}
 
-	return nil
+	return ctrl.Result{}, nil
 }
 
 // relink marks mpv as used by the module, releasing the version it switched away from.


### PR DESCRIPTION
## Description

`RemoveApp` / `RemoveModule` were fire-and-forget: the reconciler handed the package to the runtime and released the finalizer in the same reconcile, so the CR disappeared while the teardown was still running. Both removers now report whether the teardown has finished, and the reconciler holds the finalizer until they do.

- `lifecycle.Store.RemovalState` exposes explicit teardown state: no entry → nothing left to tear down; entry with `removing=true` → teardown in flight; any other entry → teardown not issued yet. `HandleEvent(EventRemove)` sets the marker, `Update` clears it on recreation, and `Store.Delete` guards on it. Removal state no longer depends on an empty package version.
- `RemoveApp`, `RemoveModule` and `RemoveEmbeddedModule` return `bool` and are idempotent by contract. A call made while a teardown runs returns `false` **without** re-issuing `EventRemove`: that event cancels the whole context tree, so re-issuing it would abort the very uninstall the caller is waiting for.
- A failed `Load` does **not** delete the previous release: the update path keeps it with `Disable(keep=true)`, so the user's workload stays running. Only if the `Application` / `Module` resource is later deleted and its instance is already absent from `r.apps` / `r.modules`, the remove path enqueues `Uninstall` by namespace and release name instead of skipping Helm deletion. The normal loaded-instance remove path still uses the unchanged `Disable` task and runs `beforeDeleteHelm` / `afterDeleteHelm` hooks.
- `HandleEvent(EventSchedule)` returns nil while removal is in flight. This prevents a scheduler event already read before `RemoveNode` from appending `Configure` / `Enable` / `Run` work after teardown has started.
- `handleDelete` polls the remover (`RequeueAfter: 5s`) and keeps the finalizer until it reports done. The teardown finishes in a queue callback the API server never sees, so asking again is the only way to observe it.
- Detaching the `ApplicationPackageVersion` / `ModulePackageVersion` moved **after** the teardown. Releasing it earlier let it be garbage collected — together with the package files on disk — while the uninstall still needed them.
- `preflight` no longer preserves an Application that is already terminating. The runtime forgets a teardown across a restart, and a terminating Application never reaches `handleCreateOrUpdate`, so it is never registered and `RemoveApp` would report that nothing is tracked; the boot cleanup is the only owner left of its release.

## Why do we need it, and what problem does it solve?

`kubectl delete application` returned immediately while the Helm release, its workloads and its hooks were still being torn down. Three consequences:

1. The object was gone from the API server while its resources were still running, so nothing downstream could tell deletion from completion.
2. A failing uninstall was invisible — the status had been deleted along with the CR, and the release stayed orphaned until some later restart's cleanup happened to pick it up.
3. The package version could be released, and its files removed from disk, in the middle of the uninstall.

When an `Application` / `Module` resource is deleted, its Helm release is normally uninstalled by the `Disable` task (`beforeDeleteHelm` → `nelm.Delete` → `afterDeleteHelm`). If no loaded package instance remains at that moment, the fallback `Uninstall` task stops the release monitor and calls `nelm.Delete` directly by namespace and name. The files are then taken off disk by `Undeploy` (or `Dummy` anchors cleanup for embedded modules), and the runtime state is dropped by the cleanup riding the last task's `OnDone` — which only fires on success. That callback is therefore the honest "fully removed" signal, and it is what the finalizer now waits for.

**Behaviour change to be aware of:** the wait is unbounded, deliberately. The queue retries a failed teardown with exponential backoff, so a stuck uninstall now keeps the object in `Terminating` instead of orphaning its resources. Deleting such an object means fixing the teardown or removing the finalizer by hand.

**Known limitation, unchanged by this PR:** module releases live in the namespace the boot cleanup deliberately skips, so a Module deleted while the controller was down still has its finalizer released without an uninstall. Applications are covered by the `preflight` change above.

## Verification

- `go test ./deckhouse-controller/internal/packages/runtime/... ./deckhouse-controller/pkg/controller/packages/application/... ./deckhouse-controller/pkg/controller/packages/module/... -race -count=1`
- `golangci-lint run ./deckhouse-controller/internal/packages/runtime/... ./deckhouse-controller/pkg/controller/packages/application/... ./deckhouse-controller/pkg/controller/packages/module/...` — 0 issues

## Checklist

- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: chore
summary: Unset a package finalizer when the package is fully deleted.
impact_level: low
```
