### PR TITLE
[docs] Render long d8 command descriptions

### DIFF
--- a/docs/documentation/_plugins/reference_generator.rb
+++ b/docs/documentation/_plugins/reference_generator.rb
@@ -55,6 +55,12 @@ module ReferenceGenerator
       "d8 #{parts.join(' ')}"
     end
 
+    def build_long_description_id(parent_titles, current_name)
+      command_path = build_header_title(parent_titles, current_name)
+      command_slug = command_path.downcase.gsub(/[^a-z0-9]+/, '-').gsub(/\A-|-+\z/, '')
+      "#{command_slug}-long-description"
+    end
+
     def prepare_signature(signature)
       escaped = CGI.escapeHTML(signature)
       escaped += ' [options]' unless escaped.include?('[options]')
@@ -145,6 +151,13 @@ module ReferenceGenerator
       if data['description']
         description = escape_liquid_tags(data['description'])
         result += "<p>#{description}</p>\n"
+      end
+      if depth > 1 && data['longDescription'].to_s.strip != ''
+        long_description = CGI.escapeHTML(data['longDescription'].to_s)
+        long_description = escape_liquid_tags(long_description)
+        long_description = long_description.gsub(/\r\n?|\n/, '&#10;')
+        long_description_id = build_long_description_id(parent_titles, data['name'])
+        result += %Q(<div id="#{long_description_id}" markdown="0" class="details"><p class="details__lnk"><a href="javascript:void(0)" class="details__summary">{{ site.data.i18n.common['show_more'][page.lang] }}</a></p><div class="details__content"><div class="expand" style="white-space: pre-wrap;">#{long_description}</div></div></div>\n)
       end
       if data['version'].to_s.strip != ''
         version = escape_liquid_tags(data['version'].to_s)

--- a/docs/documentation/_plugins/reference_generator.rb
+++ b/docs/documentation/_plugins/reference_generator.rb
@@ -157,7 +157,7 @@ module ReferenceGenerator
         long_description = escape_liquid_tags(long_description)
         long_description = long_description.gsub(/\r\n?|\n/, '&#10;')
         long_description_id = build_long_description_id(parent_titles, data['name'])
-        result += %Q(<div id="#{long_description_id}" markdown="0" class="details"><p class="details__lnk"><a href="javascript:void(0)" class="details__summary">{{ site.data.i18n.common['show_more'][page.lang] }}</a></p><div class="details__content"><div class="expand" style="white-space: pre-wrap;">#{long_description}</div></div></div>\n)
+        result += %Q(<div id="#{long_description_id}" markdown="0" class="details"><p class="details__lnk"><a href="javascript:void(0)" class="details__summary">{{ site.data.i18n.common['show_more'][page.lang] }}...</a></p><div class="details__content"><div class="expand" style="white-space: pre-wrap;">#{long_description}</div></div></div>\n)
       end
       if data['version'].to_s.strip != ''
         version = escape_liquid_tags(data['version'].to_s)


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Extend the generated command reference data with optional long descriptions alongside the existing short descriptions.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Render long d8 command descriptions
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
