### PR TITLE
[docs][documentation] Update 404 error pages to reflect module availability in the cluster

### DIFF
--- a/docs/documentation/pages/404.md
+++ b/docs/documentation/pages/404.md
@@ -12,7 +12,6 @@ feedback: false
 
 {% if site.mode == "module" %}
 Perhaps the required module is not enabled in the cluster and its documentation is not available.
-Возможно, в кластере не включен нужный модуль и документация к нему недоступна.
 {% else %}
 You can find the documentation for previous versions at&nbsp;the links below:
 

--- a/docs/documentation/pages/404.md
+++ b/docs/documentation/pages/404.md
@@ -10,9 +10,13 @@ breadcrumbs: false
 feedback: false
 ---
 
-{% unless site.mode == "module" %}
+{% if site.mode == "module" %}
+Perhaps the required module is not enabled in the cluster and its documentation is not available.
+Возможно, в кластере не включен нужный модуль и документация к нему недоступна.
+{% else %}
 You can find the documentation for previous versions at&nbsp;the links below:
 
+- [DKP v1.76 Documentation](/products/kubernetes-platform/documentation/v1.76/)
 - [DKP v1.75 Documentation](/products/kubernetes-platform/documentation/v1.75/)
 - [DKP v1.74 Documentation](/products/kubernetes-platform/documentation/v1.74/)
 - [DKP v1.73 Documentation](/products/kubernetes-platform/documentation/v1.73/)
@@ -20,4 +24,4 @@ You can find the documentation for previous versions at&nbsp;the links below:
 - [DKP v1.71 Documentation](/products/kubernetes-platform/documentation/v1.71/deckhouse-overview.html)
 - [DKP v1.70 Documentation](/products/kubernetes-platform/documentation/v1.70/deckhouse-overview.html)
 - [DKP v1.69 Documentation](/products/kubernetes-platform/documentation/v1.69/deckhouse-overview.html)
-{% endunless %}
+{% endif %}

--- a/docs/documentation/pages/404_RU.md
+++ b/docs/documentation/pages/404_RU.md
@@ -11,9 +11,12 @@ breadcrumbs: false
 feedback: false
 ---
 
-{% unless site.mode == "module" %}
+{% if site.mode == "module" %}
+Возможно, в кластере не включен нужный модуль и его документация недоступна.
+{% else %}
 Если вы&nbsp;искали предыдущие версии документации, они&nbsp;&mdash; по&nbsp;ссылкам ниже:
 
+- [Документация DKP v1.76](/products/kubernetes-platform/documentation/v1.76/)
 - [Документация DKP v1.75](/products/kubernetes-platform/documentation/v1.75/)
 - [Документация DKP v1.74](/products/kubernetes-platform/documentation/v1.74/)
 - [Документация DKP v1.73](/products/kubernetes-platform/documentation/v1.73/)
@@ -21,4 +24,4 @@ feedback: false
 - [Документация DKP v1.71](/products/kubernetes-platform/documentation/v1.71/deckhouse-overview.html)
 - [Документация DKP v1.70](/products/kubernetes-platform/documentation/v1.70/deckhouse-overview.html)
 - [Документация DKP v1.69](/products/kubernetes-platform/documentation/v1.69/deckhouse-overview.html)
-{% endunless %}
+{% endif %}


### PR DESCRIPTION
## Description

This pull request updates the 404 error pages in the intra-cluster documentation to provide more relevant messages depending on whether the requested documentation is for a module.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: documentation
type: chore
summary: Update 404 error pages to reflect module availability in the cluster.
impact_level: low
```
