### PR TITLE
[control-plane-manager] Fix tenant image pulls when the parent registry module is enabled

### DIFF
--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/manifest_render.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/manifest_render.go
@@ -83,10 +83,9 @@ func renderManifests(
 		return nil, fmt.Errorf("no images for kubernetes version %q", vcp.Spec.KubernetesVersion)
 	}
 
-	// konnectivity-agent is the only tenant-node image whose ref is VCP-baked (control-plane images run in the parent and keep the in-cluster base),
-	// and it has no imagePullSecret, so it must target the external registry those nodes reach.
-	// imageBaseOverride is set only in Direct/Proxy where the baked ref points at the unreachable in-cluster proxy;
-	// in Unmanaged it is empty and the baked ref is already external, so this is a no-op.
+	// konnectivity-agent is the only VCP-baked tenant-node ref (control-plane images run in the parent, keep the in-cluster base). Its baked ref hits the
+	// in-cluster proxy unreachable from tenant nodes, so rebase onto the external registry (the pod carries a matching deckhouse-registry imagePullSecret).
+	// imageBaseOverride is set only in Direct/Proxy; in Unmanaged it is empty and the baked ref is already external, so this is a no-op.
 	fixed := table.Fixed
 	fixed.KonnectivityAgent = rebaseImageRef(fixed.KonnectivityAgent, imageBaseOverride)
 

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/manifest_render.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/manifest_render.go
@@ -71,6 +71,7 @@ func renderManifests(
 	vcp *controlplanev1alpha1.VirtualControlPlane,
 	apiAdvertiseAddress string,
 	egressDestinations []string,
+	imageBaseOverride string,
 ) (map[string][]byte, error) {
 	table, err := parseImagesTable(globalData)
 	if err != nil {
@@ -82,10 +83,17 @@ func renderManifests(
 		return nil, fmt.Errorf("no images for kubernetes version %q", vcp.Spec.KubernetesVersion)
 	}
 
+	// konnectivity-agent is the only tenant-node image whose ref is VCP-baked (control-plane images run in the parent and keep the in-cluster base),
+	// and it has no imagePullSecret, so it must target the external registry those nodes reach.
+	// imageBaseOverride is set only in Direct/Proxy where the baked ref points at the unreachable in-cluster proxy;
+	// in Unmanaged it is empty and the baked ref is already external, so this is a no-op.
+	fixed := table.Fixed
+	fixed.KonnectivityAgent = rebaseImageRef(fixed.KonnectivityAgent, imageBaseOverride)
+
 	replacer := buildManifestReplacer(
 		vcp,
 		versioned,
-		table.Fixed,
+		fixed,
 		apiAdvertiseAddress,
 		string(globalData["cluster-uuid"]),
 		egressDestinations,

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_deckhouse.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_deckhouse.go
@@ -169,9 +169,8 @@ func (r *reconciler) reconcileTenantRegistrySecret(ctx context.Context, tc clien
 	}
 
 	target := buildTargetRegistrySecret(parent, deckhouseSystemNamespace, deckhouseRegistrySecretName)
-	// Seed the tenant with the real external upstream (registry-config) instead
-	// of the parent's in-cluster proxy address, which tenant worker nodes cannot
-	// reach. Falls back to the parent Secret when no external upstream exists.
+	// Seed the tenant from the external upstream (registry-config), not the parent in-cluster proxy address unreachable from tenant nodes.
+	// Falls back to the parent secret when there is no external upstream.
 	target.Data = r.resolveTenantRegistryData(ctx, parent)
 	// The deckhouse module's chart renders this secret too; without helm
 	// adoption metadata the release install fails with "invalid ownership

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_deckhouse.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_deckhouse.go
@@ -169,6 +169,10 @@ func (r *reconciler) reconcileTenantRegistrySecret(ctx context.Context, tc clien
 	}
 
 	target := buildTargetRegistrySecret(parent, deckhouseSystemNamespace, deckhouseRegistrySecretName)
+	// Seed the tenant with the real external upstream (registry-config) instead
+	// of the parent's in-cluster proxy address, which tenant worker nodes cannot
+	// reach. Falls back to the parent Secret when no external upstream exists.
+	target.Data = r.resolveTenantRegistryData(ctx, parent)
 	// The deckhouse module's chart renders this secret too; without helm
 	// adoption metadata the release install fails with "invalid ownership
 	// metadata" (same pattern as dhctl's DeckhouseRegistrySecret).

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_deckhouse.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_deckhouse.go
@@ -79,6 +79,7 @@ func (r *reconciler) reconcileDeckhouse(
 	vcp *controlplanev1alpha1.VirtualControlPlane,
 	albVIP string,
 	tenantCA []byte,
+	tr *tenantRegistry,
 ) (reconcile.Result, error) {
 	tcs, tc, err := r.tenantClients(ctx, vcp)
 	if err != nil {
@@ -91,7 +92,7 @@ func (r *reconciler) reconcileDeckhouse(
 	}
 
 	// 2. Tenant: registry secret (modules reference it for image pulls).
-	if err := r.reconcileTenantRegistrySecret(ctx, tc); err != nil {
+	if err := r.reconcileTenantRegistrySecret(ctx, tc, tr); err != nil {
 		return reconcile.Result{}, fmt.Errorf("reconcile tenant registry secret: %w", err)
 	}
 
@@ -158,7 +159,7 @@ func buildTargetTenantNamespace() *corev1.Namespace {
 	}
 }
 
-func (r *reconciler) reconcileTenantRegistrySecret(ctx context.Context, tc client.Client) error {
+func (r *reconciler) reconcileTenantRegistrySecret(ctx context.Context, tc client.Client, tr *tenantRegistry) error {
 	parent, err := r.getSecret(ctx, deckhouseSystemNamespace, deckhouseRegistrySecretName)
 	if apierrors.IsNotFound(err) {
 		// Nothing to copy (e.g. a registry-less dev install).
@@ -171,7 +172,7 @@ func (r *reconciler) reconcileTenantRegistrySecret(ctx context.Context, tc clien
 	target := buildTargetRegistrySecret(parent, deckhouseSystemNamespace, deckhouseRegistrySecretName)
 	// Seed the tenant from the external upstream (registry-config), not the parent in-cluster proxy address unreachable from tenant nodes.
 	// Falls back to the parent secret when there is no external upstream.
-	target.Data = r.resolveTenantRegistryData(ctx, parent)
+	target.Data = resolveTenantRegistryData(parent, tr)
 	// The deckhouse module's chart renders this secret too; without helm
 	// adoption metadata the release install fails with "invalid ownership
 	// metadata" (same pattern as dhctl's DeckhouseRegistrySecret).
@@ -190,14 +191,19 @@ func (r *reconciler) reconcileTenantRegistrySecret(ctx context.Context, tc clien
 		return err
 	}
 
-	if equality.Semantic.DeepEqual(current.Data, target.Data) &&
+	// Overlay only the registry fields we own: deckhouse re-renders this secret and adds its own keys
+	// (clusterIsBootstrapped, imagesRegistry) which must survive, otherwise the two writers churn it.
+	if isDataSubset(target.Data, current.Data) &&
 		isMetadataSubset(target.Labels, current.Labels) &&
 		isMetadataSubset(target.Annotations, current.Annotations) {
 		return nil
 	}
 
 	base := current.DeepCopy()
-	current.Data = target.Data
+	if current.Data == nil {
+		current.Data = map[string][]byte{}
+	}
+	maps.Copy(current.Data, target.Data)
 	current.Labels = mergeMetadata(current.Labels, target.Labels)
 	current.Annotations = mergeMetadata(current.Annotations, target.Annotations)
 
@@ -209,6 +215,16 @@ func (r *reconciler) reconcileTenantRegistrySecret(ctx context.Context, tc clien
 func isMetadataSubset(target, current map[string]string) bool {
 	for key, value := range target {
 		if current[key] != value {
+			return false
+		}
+	}
+	return true
+}
+
+// isDataSubset checks whether every target key is present in current with the same value.
+func isDataSubset(target, current map[string][]byte) bool {
+	for key, value := range target {
+		if cur, ok := current[key]; !ok || !bytes.Equal(cur, value) {
 			return false
 		}
 	}

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_deckhouse.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_deckhouse.go
@@ -193,7 +193,12 @@ func (r *reconciler) reconcileTenantRegistrySecret(ctx context.Context, tc clien
 
 	// Overlay only the registry fields we own: deckhouse re-renders this secret and adds its own keys
 	// (clusterIsBootstrapped, imagesRegistry) which must survive, otherwise the two writers churn it.
+	// An external upstream may carry no CA: drop a stale ca left by a prior clone or by deckhouse.
+	dropCA := tr != nil && tr.CA == ""
+	_, hasCA := current.Data["ca"]
+
 	if isDataSubset(target.Data, current.Data) &&
+		!(dropCA && hasCA) &&
 		isMetadataSubset(target.Labels, current.Labels) &&
 		isMetadataSubset(target.Annotations, current.Annotations) {
 		return nil
@@ -204,6 +209,9 @@ func (r *reconciler) reconcileTenantRegistrySecret(ctx context.Context, tc clien
 		current.Data = map[string][]byte{}
 	}
 	maps.Copy(current.Data, target.Data)
+	if dropCA {
+		delete(current.Data, "ca")
+	}
 	current.Labels = mergeMetadata(current.Labels, target.Labels)
 	current.Annotations = mergeMetadata(current.Annotations, target.Annotations)
 

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_registry_discovery.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_registry_discovery.go
@@ -27,7 +27,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const (
@@ -110,14 +109,8 @@ func (r *reconciler) discoverTenantRegistry(ctx context.Context) (*tenantRegistr
 	}, nil
 }
 
-// resolveTenantRegistryData returns deckhouse-registry .data: discovered external upstream if any, else a clone of the parent secret.
-// Discovery errors (incl. Local) are logged and fall back to the parent clone rather than failing the reconcile.
-func (r *reconciler) resolveTenantRegistryData(ctx context.Context, parent *corev1.Secret) map[string][]byte {
-	tr, err := r.discoverTenantRegistry(ctx)
-	if err != nil {
-		logf.FromContext(ctx).Error(err, "discover tenant registry; falling back to parent registry secret (tenant node image pull may fail)")
-		return maps.Clone(parent.Data)
-	}
+// resolveTenantRegistryData returns deckhouse-registry .data: discovered external upstream when tr is set, else a clone of the parent secret.
+func resolveTenantRegistryData(parent *corev1.Secret, tr *tenantRegistry) map[string][]byte {
 	if tr == nil {
 		return maps.Clone(parent.Data)
 	}

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_registry_discovery.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_registry_discovery.go
@@ -36,18 +36,14 @@ const (
 	registryModeLocal        = "Local"
 )
 
-// errRegistryLocalNoUpstream is returned when the parent runs the registry
-// module in Local mode: there is no external upstream reachable from tenant
-// worker nodes, so direct pull cannot work (this needs in-cluster routing).
+// Local mode has no external upstream reachable from tenant nodes; direct pull impossible.
 var errRegistryLocalNoUpstream = errors.New(
 	"registry mode Local has no external upstream reachable from tenant nodes; direct tenant pull is unsupported",
 )
 
-// tenantRegistry is the external upstream registry the tenant cluster and its
-// worker nodes pull Deckhouse images from directly, bypassing the parent's in-cluster registry proxy (module 038).
-//
-// It is discovered from the operator's registry input Secret d8-system/registry-config (rendered by the deckhouse module 002 from ModuleConfig/deckhouse .spec.settings.registry).
-// That Secret holds the real external upstream even when module 038 is Direct/Proxy, unlike global.modulesImages.registry, which points at the in-cluster proxy.
+// tenantRegistry is the external upstream tenant nodes pull from directly, bypassing the parent in-cluster proxy (module 038).
+// Discovered from d8-system/registry-config (operator input); holds the real external repo even when 038 is Direct/Proxy,
+// unlike global.modulesImages.registry, which points at the in-cluster proxy.
 type tenantRegistry struct {
 	Address          string // host[:port]
 	Path             string // "/deckhouse/ee"
@@ -56,12 +52,10 @@ type tenantRegistry struct {
 	DockerConfigJSON []byte
 }
 
-// Base returns "address/path", the image reference base (== imagesRepo).
+// Base = "address/path", the image ref base (== imagesRepo).
 func (t *tenantRegistry) Base() string { return t.Address + t.Path }
 
-// registrySecretData renders the tenant deckhouse-registry Secret .data.
-// Keys mirror what the global discovery hook expects (see
-// global-hooks/discovery/deckhouse_registry.go).
+// registrySecretData renders deckhouse-registry .data (keys per global-hooks/discovery/deckhouse_registry.go).
 func (t *tenantRegistry) registrySecretData() map[string][]byte {
 	data := map[string][]byte{
 		".dockerconfigjson": t.DockerConfigJSON,
@@ -75,9 +69,8 @@ func (t *tenantRegistry) registrySecretData() map[string][]byte {
 	return data
 }
 
-// discoverTenantRegistry reads d8-system/registry-config and returns the external upstream.
-// It returns (nil, nil) when the Secret is absent or does not describe an external upstream (deprecated non-configurable Unmanaged) so callers fall
-// back to cloning the parent deckhouse-registry Secret, which already points at the real registry in that case. Local mode returns errRegistryLocalNoUpstream.
+// discoverTenantRegistry reads d8-system/registry-config for the external upstream.
+// (nil, nil) when absent or no external repo (non-configurable Unmanaged) so callers clone the parent secret; Local returns errRegistryLocalNoUpstream.
 func (r *reconciler) discoverTenantRegistry(ctx context.Context) (*tenantRegistry, error) {
 	sec, err := r.getSecret(ctx, registryConfigSecretNS, registryConfigSecretName)
 	if apierrors.IsNotFound(err) {
@@ -93,7 +86,7 @@ func (r *reconciler) discoverTenantRegistry(ctx context.Context) (*tenantRegistr
 
 	imagesRepo := string(sec.Data["imagesRepo"])
 	if imagesRepo == "" {
-		// Non-configurable Unmanaged (no imagesRepo): fall back to parent clone.
+		// non-configurable Unmanaged: no imagesRepo -> fall back to parent clone.
 		return nil, nil
 	}
 
@@ -117,9 +110,8 @@ func (r *reconciler) discoverTenantRegistry(ctx context.Context) (*tenantRegistr
 	}, nil
 }
 
-// resolveTenantRegistryData returns the deckhouse-registry Secret .data for the tenant:
-// the discovered external upstream when available, otherwise a clone of the parent Secret.
-// Discovery errors (including Local mode) are logged and fall back to the parent clone rather than failing the reconcile.
+// resolveTenantRegistryData returns deckhouse-registry .data: discovered external upstream if any, else a clone of the parent secret.
+// Discovery errors (incl. Local) are logged and fall back to the parent clone rather than failing the reconcile.
 func (r *reconciler) resolveTenantRegistryData(ctx context.Context, parent *corev1.Secret) map[string][]byte {
 	tr, err := r.discoverTenantRegistry(ctx)
 	if err != nil {
@@ -132,8 +124,7 @@ func (r *reconciler) resolveTenantRegistryData(ctx context.Context, parent *core
 	return tr.registrySecretData()
 }
 
-// splitAddressAndPath splits "registry.example.com/deckhouse/ee" into
-// ("registry.example.com", "/deckhouse/ee").
+// splitAddressAndPath: "reg.io/a/b" -> ("reg.io", "/a/b").
 func splitAddressAndPath(ref string) (address, path string) {
 	parts := strings.SplitN(ref, "/", 2)
 	if len(parts) < 2 {
@@ -159,8 +150,7 @@ func buildDockerConfigJSON(address, username, password string) ([]byte, error) {
 	return json.Marshal(map[string]map[string]authEntry{"auths": {address: entry}})
 }
 
-// rebaseImageRef re-points a "<base>@<digest>" reference at newBase, preserving the digest.
-// Used to move VCP-baked tenant-node image refs off the parent in-cluster registry onto the discovered external upstream.
+// rebaseImageRef swaps the base of "<base>@<digest>", keeping the digest. Moves VCP-baked tenant-node refs off the in-cluster registry onto the external upstream.
 func rebaseImageRef(ref, newBase string) string {
 	at := strings.LastIndex(ref, "@")
 	if at < 0 || newBase == "" {

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_registry_discovery.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_registry_discovery.go
@@ -61,6 +61,7 @@ func (t *tenantRegistry) registrySecretData() map[string][]byte {
 		"address":           []byte(t.Address),
 		"path":              []byte(t.Path),
 		"scheme":            []byte(t.Scheme),
+		"imagesRegistry":    []byte(t.Base()),
 	}
 	if t.CA != "" {
 		data["ca"] = []byte(t.CA)

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_registry_discovery.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_registry_discovery.go
@@ -1,0 +1,170 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package virtualcontrolplaneconfiguration
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	registryConfigSecretNS   = "d8-system"
+	registryConfigSecretName = "registry-config"
+	registryModeLocal        = "Local"
+)
+
+// errRegistryLocalNoUpstream is returned when the parent runs the registry
+// module in Local mode: there is no external upstream reachable from tenant
+// worker nodes, so direct pull cannot work (this needs in-cluster routing).
+var errRegistryLocalNoUpstream = errors.New(
+	"registry mode Local has no external upstream reachable from tenant nodes; direct tenant pull is unsupported",
+)
+
+// tenantRegistry is the external upstream registry the tenant cluster and its
+// worker nodes pull Deckhouse images from directly, bypassing the parent's in-cluster registry proxy (module 038).
+//
+// It is discovered from the operator's registry input Secret d8-system/registry-config (rendered by the deckhouse module 002 from ModuleConfig/deckhouse .spec.settings.registry).
+// That Secret holds the real external upstream even when module 038 is Direct/Proxy, unlike global.modulesImages.registry, which points at the in-cluster proxy.
+type tenantRegistry struct {
+	Address          string // host[:port]
+	Path             string // "/deckhouse/ee"
+	Scheme           string // "https"/"http"
+	CA               string // PEM, optional
+	DockerConfigJSON []byte
+}
+
+// Base returns "address/path", the image reference base (== imagesRepo).
+func (t *tenantRegistry) Base() string { return t.Address + t.Path }
+
+// registrySecretData renders the tenant deckhouse-registry Secret .data.
+// Keys mirror what the global discovery hook expects (see
+// global-hooks/discovery/deckhouse_registry.go).
+func (t *tenantRegistry) registrySecretData() map[string][]byte {
+	data := map[string][]byte{
+		".dockerconfigjson": t.DockerConfigJSON,
+		"address":           []byte(t.Address),
+		"path":              []byte(t.Path),
+		"scheme":            []byte(t.Scheme),
+	}
+	if t.CA != "" {
+		data["ca"] = []byte(t.CA)
+	}
+	return data
+}
+
+// discoverTenantRegistry reads d8-system/registry-config and returns the external upstream.
+// It returns (nil, nil) when the Secret is absent or does not describe an external upstream (deprecated non-configurable Unmanaged) so callers fall
+// back to cloning the parent deckhouse-registry Secret, which already points at the real registry in that case. Local mode returns errRegistryLocalNoUpstream.
+func (r *reconciler) discoverTenantRegistry(ctx context.Context) (*tenantRegistry, error) {
+	sec, err := r.getSecret(ctx, registryConfigSecretNS, registryConfigSecretName)
+	if apierrors.IsNotFound(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get %s/%s: %w", registryConfigSecretNS, registryConfigSecretName, err)
+	}
+
+	if string(sec.Data["mode"]) == registryModeLocal {
+		return nil, errRegistryLocalNoUpstream
+	}
+
+	imagesRepo := string(sec.Data["imagesRepo"])
+	if imagesRepo == "" {
+		// Non-configurable Unmanaged (no imagesRepo): fall back to parent clone.
+		return nil, nil
+	}
+
+	address, path := splitAddressAndPath(imagesRepo)
+	scheme := strings.ToLower(string(sec.Data["scheme"]))
+	if scheme == "" {
+		scheme = "https"
+	}
+
+	dockerCfg, err := buildDockerConfigJSON(address, string(sec.Data["username"]), string(sec.Data["password"]))
+	if err != nil {
+		return nil, fmt.Errorf("build dockerconfigjson: %w", err)
+	}
+
+	return &tenantRegistry{
+		Address:          address,
+		Path:             path,
+		Scheme:           scheme,
+		CA:               string(sec.Data["ca"]),
+		DockerConfigJSON: dockerCfg,
+	}, nil
+}
+
+// resolveTenantRegistryData returns the deckhouse-registry Secret .data for the tenant:
+// the discovered external upstream when available, otherwise a clone of the parent Secret.
+// Discovery errors (including Local mode) are logged and fall back to the parent clone rather than failing the reconcile.
+func (r *reconciler) resolveTenantRegistryData(ctx context.Context, parent *corev1.Secret) map[string][]byte {
+	tr, err := r.discoverTenantRegistry(ctx)
+	if err != nil {
+		logf.FromContext(ctx).Error(err, "discover tenant registry; falling back to parent registry secret (tenant node image pull may fail)")
+		return maps.Clone(parent.Data)
+	}
+	if tr == nil {
+		return maps.Clone(parent.Data)
+	}
+	return tr.registrySecretData()
+}
+
+// splitAddressAndPath splits "registry.example.com/deckhouse/ee" into
+// ("registry.example.com", "/deckhouse/ee").
+func splitAddressAndPath(ref string) (address, path string) {
+	parts := strings.SplitN(ref, "/", 2)
+	if len(parts) < 2 {
+		return parts[0], ""
+	}
+	return parts[0], "/" + parts[1]
+}
+
+func buildDockerConfigJSON(address, username, password string) ([]byte, error) {
+	type authEntry struct {
+		Username string `json:"username,omitempty"`
+		Password string `json:"password,omitempty"`
+		Auth     string `json:"auth,omitempty"`
+	}
+
+	entry := authEntry{}
+	if username != "" || password != "" {
+		entry.Username = username
+		entry.Password = password
+		entry.Auth = base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
+	}
+
+	return json.Marshal(map[string]map[string]authEntry{"auths": {address: entry}})
+}
+
+// rebaseImageRef re-points a "<base>@<digest>" reference at newBase, preserving the digest.
+// Used to move VCP-baked tenant-node image refs off the parent in-cluster registry onto the discovered external upstream.
+func rebaseImageRef(ref, newBase string) string {
+	at := strings.LastIndex(ref, "@")
+	if at < 0 || newBase == "" {
+		return ref
+	}
+	return newBase + ref[at:]
+}

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconciler.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconciler.go
@@ -624,7 +624,7 @@ func (r *reconciler) reconcileConfigSecret(ctx context.Context, vcp *controlplan
 		return nil, reconcile.Result{}, fmt.Errorf("collect parent egress destinations: %w", err)
 	}
 
-	// Rebase tenant-node image refs onto the external upstream when the parent's registry module hides the real registry behind the in-cluster proxy.
+	// Rebase tenant-node refs onto the external upstream (Direct/Proxy hides the real registry behind the in-cluster proxy).
 	var imageBaseOverride string
 	if tr, terr := r.discoverTenantRegistry(ctx); terr != nil {
 		log.FromContext(ctx).Error(terr, "discover tenant registry for image rebase; keeping in-cluster refs")

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconciler.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconciler.go
@@ -88,7 +88,13 @@ func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return reconcile.Result{}, fmt.Errorf("resolve ALB VIP: %w", err)
 	}
 
-	configSecret, res, err := r.reconcileConfigSecret(ctx, vcp, albVIP)
+	tenantReg, err := r.discoverTenantRegistry(ctx)
+	if err != nil {
+		log.FromContext(ctx).Error(err, "discover tenant registry; using parent registry secret and in-cluster image refs")
+		tenantReg = nil
+	}
+
+	configSecret, res, err := r.reconcileConfigSecret(ctx, vcp, albVIP, tenantReg)
 	if err != nil || !res.IsZero() {
 		return res, err
 	}
@@ -163,7 +169,7 @@ func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return res, err
 	}
 
-	if res, err := r.reconcileDeckhouse(ctx, vcp, albVIP, pkiSecret.Data["ca.crt"]); err != nil || !res.IsZero() {
+	if res, err := r.reconcileDeckhouse(ctx, vcp, albVIP, pkiSecret.Data["ca.crt"], tenantReg); err != nil || !res.IsZero() {
 		return res, err
 	}
 
@@ -601,7 +607,7 @@ func readKubeconfigSecretData(outDir string, kubeconfigFiles []kubeconfig.File) 
 	return data, nil
 }
 
-func (r *reconciler) reconcileConfigSecret(ctx context.Context, vcp *controlplanev1alpha1.VirtualControlPlane, albVIP string) (*corev1.Secret, reconcile.Result, error) {
+func (r *reconciler) reconcileConfigSecret(ctx context.Context, vcp *controlplanev1alpha1.VirtualControlPlane, albVIP string, tr *tenantRegistry) (*corev1.Secret, reconcile.Result, error) {
 	global, err := r.getSecret(ctx, constants.KubeSystemNamespace, constants.VirtualControlPlaneConfigSecretName)
 	if apierrors.IsNotFound(err) {
 		return nil, reconcile.Result{RequeueAfter: requeueInterval}, nil
@@ -626,9 +632,7 @@ func (r *reconciler) reconcileConfigSecret(ctx context.Context, vcp *controlplan
 
 	// Rebase tenant-node refs onto the external upstream (Direct/Proxy hides the real registry behind the in-cluster proxy).
 	var imageBaseOverride string
-	if tr, terr := r.discoverTenantRegistry(ctx); terr != nil {
-		log.FromContext(ctx).Error(terr, "discover tenant registry for image rebase; keeping in-cluster refs")
-	} else if tr != nil {
+	if tr != nil {
 		imageBaseOverride = tr.Base()
 	}
 

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconciler.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconciler.go
@@ -624,7 +624,15 @@ func (r *reconciler) reconcileConfigSecret(ctx context.Context, vcp *controlplan
 		return nil, reconcile.Result{}, fmt.Errorf("collect parent egress destinations: %w", err)
 	}
 
-	data, err := renderManifests(global.Data, vcp, apiAdvertiseAddress, egressDestinations)
+	// Rebase tenant-node image refs onto the external upstream when the parent's registry module hides the real registry behind the in-cluster proxy.
+	var imageBaseOverride string
+	if tr, terr := r.discoverTenantRegistry(ctx); terr != nil {
+		log.FromContext(ctx).Error(terr, "discover tenant registry for image rebase; keeping in-cluster refs")
+	} else if tr != nil {
+		imageBaseOverride = tr.Base()
+	}
+
+	data, err := renderManifests(global.Data, vcp, apiAdvertiseAddress, egressDestinations, imageBaseOverride)
 	if err != nil {
 		return nil, reconcile.Result{}, fmt.Errorf("render manifests: %w", err)
 	}

--- a/modules/040-control-plane-manager/virtual-control-plane-templates/konnectivity-agent.yaml.tpl
+++ b/modules/040-control-plane-manager/virtual-control-plane-templates/konnectivity-agent.yaml.tpl
@@ -30,6 +30,8 @@ spec:
         k8s-app: konnectivity-agent
     spec:
       serviceAccountName: konnectivity-agent
+      imagePullSecrets:
+      - name: deckhouse-registry
       priorityClassName: system-cluster-critical
       hostNetwork: true
       tolerations:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

With the parent registry module in Direct/Proxy mode, VCP tenant-node pods (webhook-handler, d8-kube-dns, konnectivity-agent) hit ImagePullBackOff: image refs point at the in-cluster proxy registry.d8-system.svc:5001, which tenant nodes cannot reach.

Discover the real external upstream from d8-system/registry-config (operator input; still external in Direct/Proxy) and use it on the tenant:

1. Build the tenant deckhouse-registry Secret from the discovered upstream instead of cloning the parent's in-cluster one - fixes tenant-deckhouse workloads via their pull secret.
2. Rebase the VCP-baked konnectivity-agent ref onto the external imagesRepo, and give it imagePullSecrets: [deckhouse-registry] (it's VCP-injected, and node-level auth is inactive on containerd v1).

Falls back to the previous clone when registry-config has no external imagesRepo (Unmanaged).
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
