### PR TITLE
[user-authz] Drop node subresources from the RBACv2 viewer permission role

### DIFF
--- a/modules/140-user-authz/template_tests/module_test.go
+++ b/modules/140-user-authz/template_tests/module_test.go
@@ -674,4 +674,30 @@ var _ = Describe("Module :: user-authz :: helm template ::", func() {
 		})
 	})
 
+	Context("RBACv2 manage permission roles", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global.enabledModules", `["operator-prometheus", "operator-prometheus-crd"]`)
+			f.ValuesSet("global.deckhouseEdition", "EE")
+			f.HelmRender()
+		})
+
+		It("view_resources should not grant any node subresource", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			cr := f.KubernetesGlobalResource("ClusterRole", "d8:manage:permission:subsystem:kubernetes:view_resources")
+			Expect(cr.Exists()).To(BeTrue())
+
+			rules := cr.Field("rules").String()
+			// nodes/proxy is a raw passthrough to the privileged kubelet API: it allows running
+			// commands in any container on the node regardless of pods/exec permissions, and
+			// nodes/log allows reading arbitrary files under /var/log. Neither belongs in a role
+			// that aggregates into viewer. Upstream keeps them in system:kubelet-api-admin only.
+			Expect(rules).To(ContainSubstring(`"nodes"`))
+			Expect(rules).NotTo(ContainSubstring("nodes/proxy"))
+			Expect(rules).NotTo(ContainSubstring("nodes/log"))
+			Expect(rules).NotTo(ContainSubstring("nodes/metrics"))
+			Expect(rules).NotTo(ContainSubstring("nodes/stats"))
+		})
+	})
+
 })

--- a/modules/140-user-authz/templates/rbacv2/global/manage/permissions/view_common_resources.yaml
+++ b/modules/140-user-authz/templates/rbacv2/global/manage/permissions/view_common_resources.yaml
@@ -42,7 +42,9 @@ rules:
       - nodes/proxy
       - nodes/stats
     verbs:
-      - '*'
+      - get
+      - list
+      - watch
   - apiGroups:
       - node.k8s.io
     resources:

--- a/modules/140-user-authz/templates/rbacv2/global/manage/permissions/view_common_resources.yaml
+++ b/modules/140-user-authz/templates/rbacv2/global/manage/permissions/view_common_resources.yaml
@@ -35,17 +35,6 @@ rules:
       - list
       - watch
   - apiGroups:
-      - ""
-    resources:
-      - nodes/log
-      - nodes/metrics
-      - nodes/proxy
-      - nodes/stats
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
       - node.k8s.io
     resources:
       - runtimeclasses


### PR DESCRIPTION
## Description

`d8:manage:permission:subsystem:kubernetes:view_resources` granted `nodes/log`, `nodes/metrics`, `nodes/proxy` and `nodes/stats`, and this ClusterRole aggregates into both `d8:manage:kubernetes:viewer` and `d8:manage:infrastructure:viewer`. The whole rule is removed; plain `nodes` with `get/list/watch` stays, so node listing is unaffected.

A template test asserts that the rendered role keeps `nodes` and carries no node subresource.

## Why do we need it, and what problem does it solve?

`nodes/proxy` is not a read-only abstraction — it proxies to the privileged kubelet API on behalf of the API server. A holder of a read-only role can run a command in any existing container on the node without `create` on `pods/exec`, which escalates `infrastructure:viewer` to root on the node and, from there, to cluster-wide credentials.

Narrowing the verbs to `get/list/watch` is not sufficient:

* the API server maps HTTP methods to verbs, `GET` → `get` (`apiserver/pkg/endpoints/request/requestinfo.go`), so `get nodes/proxy` permits any GET through the proxy;
* kubelet registers `/exec/{ns}/{pod}/{container}`, `/attach` and `/portForward` on **GET** as well as POST (`pkg/kubelet/server/server.go`), only `/run` is POST-only;
* the kubelet authorizer derives the subresource from the request path and defaults to `proxy` (`pkg/kubelet/server/auth.go`), so `/exec` is checked as `get nodes/proxy`.

So `get` alone is enough for the escalation, and `GET .../proxy/pods` additionally exposes full PodSpecs of every namespace.

The other three subresources are only consulted by the kubelet authorizer for clients talking to port 10250 directly; through the API server they are unreachable without `nodes/proxy`. Keeping them in a viewer role buys nothing and leaves `nodes/log` — arbitrary file reads under `/var/log` on the node — available to anyone who can reach kubelet. Upstream Kubernetes keeps all four in `system:kubelet-api-admin`, which is not aggregated into `view`, `edit` or `admin` and is bound to no one by default.

`pods/exec` remains available through the explicit `use` capability `access_terminal`, which is bound deliberately and does not aggregate into viewer.

## Why do we need it in the patch release (if we do)?

Privilege escalation from a stock read-only role to root on a node. The grant has been present since RBAC v2 was introduced, so every supported release is affected and needs the backport.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authz
type: fix
summary: Remove node subresources from the RBACv2 viewer permission role
impact: |
  The `d8:manage:permission:subsystem:kubernetes:view_resources` role no longer grants `nodes/proxy`,
  `nodes/log`, `nodes/metrics` and `nodes/stats`. Users holding `d8:manage:kubernetes:viewer`,
  `d8:manage:infrastructure:viewer` or any role aggregating them lose access to the kubelet API through
  `/api/v1/nodes/<node>/proxy/...`. `nodes` themselves stay readable. Automation that relied on reaching
  the kubelet API with one of these roles must be granted a dedicated role explicitly.
impact_level: high
```
