### PR TITLE
Backport: [user-authn] Prove authority over Kubernetes API access with a dedicated permission

### DIFF
--- a/modules/150-user-authn/template_tests/validation_test.go
+++ b/modules/150-user-authn/template_tests/validation_test.go
@@ -248,10 +248,29 @@ var _ = Describe("Module :: user-authn :: helm template :: validation", func() {
 					allowed:     true,
 				},
 				{
+					// The other half of the dynamic resource resolution: the grant has to admit the
+					// kind it was issued for, not just deny the kind it was not.
+					name:        "subject holding the allow-access subresource grants access on a dex authenticator",
+					resource:    "dexauthenticators",
+					kind:        "DexAuthenticator",
+					canGrant:    true,
+					annotations: map[string]string{dexAuthenticatorAnnotation: "true"},
+					allowed:     true,
+				},
+				{
 					name:            "subresource granted on the other kind does not carry over",
 					canGrant:        true,
 					grantedResource: "dexauthenticators",
 					annotations:     map[string]string{dexClientAnnotation: "true"},
+					allowed:         false,
+				},
+				{
+					name:            "subresource granted on dex clients does not admit a dex authenticator",
+					resource:        "dexauthenticators",
+					kind:            "DexAuthenticator",
+					canGrant:        true,
+					grantedResource: "dexclients",
+					annotations:     map[string]string{dexAuthenticatorAnnotation: "true"},
 					allowed:         false,
 				},
 				{
@@ -514,10 +533,19 @@ func compileRenderedPolicy(renderedPolicy string) compiledPolicy {
 		Expect(result.Error).To(BeNil(), "variable %q should compile", variable.Name)
 	}
 
+	// Match conditions are compiled by a compiler that holds no variables, because kube-apiserver
+	// rejects a match condition referring to them: they are evaluated before the rest of the policy.
+	// The authorizer, in contrast, is declared there as well. Sharing the compiler above would let a
+	// match condition using variables pass here and be refused by a real API server.
+	matchCompiler, err := admissioncel.NewCompositedCompiler(
+		environment.MustBaseEnvSet(minimalSupportedKubernetesVersion(), true),
+	)
+	Expect(err).ToNot(HaveOccurred())
+
 	matchConditions := make([]admissioncel.ExpressionAccessor, 0, len(policy.Spec.MatchConditions))
 	for _, condition := range policy.Spec.MatchConditions {
 		expression := boolExpression{expression: condition.Expression}
-		Expect(compiler.CompileCELExpression(expression, validationVars, environment.NewExpressions).Error).To(BeNil(),
+		Expect(matchCompiler.CompileCELExpression(expression, validationVars, environment.NewExpressions).Error).To(BeNil(),
 			"match condition %q should compile", condition.Name)
 
 		matchConditions = append(matchConditions, expression)
@@ -537,7 +565,7 @@ func compileRenderedPolicy(renderedPolicy string) compiledPolicy {
 	}
 
 	return compiledPolicy{
-		matchConditions: compiler.CompileCondition(matchConditions, validationVars, environment.NewExpressions),
+		matchConditions: matchCompiler.CompileCondition(matchConditions, validationVars, environment.NewExpressions),
 		validations:     compiler.CompileCondition(validations, validationVars, environment.NewExpressions),
 	}
 }

--- a/modules/150-user-authn/template_tests/validation_test.go
+++ b/modules/150-user-authn/template_tests/validation_test.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	celgo "github.com/google/cel-go/cel"
 	celtypes "github.com/google/cel-go/common/types"
@@ -56,9 +57,9 @@ const (
 	dexAuthenticatorAnnotation = "dexauthenticator.deckhouse.io/allow-access-to-kubernetes"
 
 	deckhouseServiceAccount = "system:serviceaccount:d8-system:deckhouse"
-	// A cluster provisioner running as a platform component. Deckhouse Commander patches DexClients
-	// in its own namespace during cluster bootstrap, which is what makes this case load-bearing.
-	commanderServiceAccount  = "system:serviceaccount:d8-commander:commander"
+	// The identity that patches DexClients during cluster bootstrap: a namespace-scoped service
+	// account outside the core namespaces, holding an enumerated Role rather than broad RBAC.
+	commanderServiceAccount  = "system:serviceaccount:d8-commander:cluster-manager"
 	kubeSystemServiceAccount = "system:serviceaccount:kube-system:some-controller"
 	tenantServiceAccount     = "system:serviceaccount:attacker-ns:tenant"
 	namespaceEditor          = "editor@example.com"
@@ -130,11 +131,13 @@ var _ = Describe("Module :: user-authn :: helm template :: validation", func() {
 				ContainSubstring("allow-access-to-kubernetes subresource"),
 			)
 
-			// Platform components have to be excluded, otherwise the gate denies the provisioning
-			// flows that create these objects on the cluster's behalf.
+			// The core namespaces have to be excluded, otherwise the gate denies the module charts
+			// that ship an annotated DexAuthenticator. Nothing wider: a namespace prefix must not
+			// confer the authority on whatever runs under it.
 			matchConditions := policy.Field("spec.matchConditions").String()
-			Expect(matchConditions).To(ContainSubstring("system:serviceaccount:d8-"))
-			Expect(matchConditions).To(ContainSubstring("system:serviceaccount:kube-"))
+			Expect(matchConditions).To(ContainSubstring("system:serviceaccounts:d8-system"))
+			Expect(matchConditions).To(ContainSubstring("system:serviceaccounts:kube-system"))
+			Expect(matchConditions).ToNot(ContainSubstring("startsWith"))
 
 			binding := hec.KubernetesGlobalResource("ValidatingAdmissionPolicyBinding", allowAccessPolicyName)
 			Expect(binding.Exists()).To(BeTrue())
@@ -208,34 +211,46 @@ var _ = Describe("Module :: user-authn :: helm template :: validation", func() {
 					allowed:     false,
 				},
 				{
-					name:        "deckhouse service account grants access",
-					username:    deckhouseServiceAccount,
-					annotations: map[string]string{dexClientAnnotation: "true"},
-					allowed:     true,
-				},
-				{
-					// Cluster provisioners run as platform components and patch these objects during
-					// bootstrap. Gating them buys nothing, and denying them breaks cluster creation.
-					name:        "platform service account provisioning a client grants access",
+					// A cluster provisioner outside the core namespaces is not exempt: it proves the
+					// authority with the permission, which is what the Commander chart's
+					// cluster-manager Role carries.
+					name:        "cluster provisioner without the permission grants access",
 					username:    commanderServiceAccount,
 					annotations: map[string]string{dexClientAnnotation: "true"},
+					allowed:     false,
+				},
+				{
+					name:        "cluster provisioner holding the permission grants access",
+					username:    commanderServiceAccount,
+					canGrant:    true,
+					annotations: map[string]string{dexClientAnnotation: "true"},
 					allowed:     true,
 				},
 				{
-					name:        "service account of a kube-prefixed namespace grants access",
+					// Only the core namespaces are exempt, and a service account of one of them is
+					// recognised through the groups kube-apiserver attaches, not through its name.
+					name:        "service account of kube-system grants access",
 					username:    kubeSystemServiceAccount,
 					annotations: map[string]string{dexClientAnnotation: "true"},
 					allowed:     true,
 				},
 				{
-					name:        "subject of a system group grants access",
-					groups:      []string{"system:authenticated", "system:serviceaccounts:d8-system"},
+					// The identity that applies the module charts shipping an annotated
+					// DexAuthenticator, kiali and the cilium-hubble UI.
+					name:        "deckhouse service account of d8-system grants access",
+					username:    deckhouseServiceAccount,
 					annotations: map[string]string{dexClientAnnotation: "true"},
 					allowed:     true,
 				},
 				{
-					// A tenant's own service account is not a platform component: the namespace
-					// prefix is what separates them, and this is the case the policy exists for.
+					// A module from a ModuleSource lands in d8-<module>, and the namespace prefix
+					// alone must not confer the authority.
+					name:        "service account of a module namespace grants access",
+					username:    "system:serviceaccount:d8-some-module:controller",
+					annotations: map[string]string{dexClientAnnotation: "true"},
+					allowed:     false,
+				},
+				{
 					name:        "tenant service account grants access",
 					username:    tenantServiceAccount,
 					annotations: map[string]string{dexClientAnnotation: "true"},
@@ -612,11 +627,11 @@ func repositoryRoot() string {
 }
 
 type dexAdmissionInput struct {
-	resource       string
-	kind           string
-	operation      admission.Operation
-	username       string
-	groups         []string
+	resource  string
+	kind      string
+	operation admission.Operation
+	username  string
+	groups    []string
 	// canGrant hands the subject the allow-access-to-kubernetes subresource on the resource it
 	// writes, in the namespace it writes to.
 	canGrant bool
@@ -649,7 +664,7 @@ func (p compiledPolicy) validate(input dexAdmissionInput) (bool, error) {
 
 	groups := input.groups
 	if groups == nil {
-		groups = []string{"system:authenticated"}
+		groups = defaultGroups(input.username)
 	}
 
 	attributes := admission.NewAttributesRecord(
@@ -673,6 +688,25 @@ func (p compiledPolicy) validate(input dexAdmissionInput) (bool, error) {
 	}
 
 	return p.evaluate(p.validations, versionedAttributes, request, bindings)
+}
+
+// defaultGroups returns the groups kube-apiserver attaches to the subject. Service accounts get
+// them for free, and the policy's exclusions are written against them, so a test that left them out
+// would exercise a subject the cluster never produces.
+func defaultGroups(username string) []string {
+	groups := []string{"system:authenticated"}
+
+	namespaced := strings.TrimPrefix(username, "system:serviceaccount:")
+	if namespaced == username {
+		return groups
+	}
+
+	namespace, _, found := strings.Cut(namespaced, ":")
+	if !found {
+		return groups
+	}
+
+	return append(groups, "system:serviceaccounts", "system:serviceaccounts:"+namespace)
 }
 
 // evaluate reports whether every expression of the evaluator holds for the request.

--- a/modules/150-user-authn/template_tests/validation_test.go
+++ b/modules/150-user-authn/template_tests/validation_test.go
@@ -28,6 +28,7 @@ import (
 	celtypes "github.com/google/cel-go/common/types"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	admissionv1 "k8s.io/api/admission/v1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -55,7 +56,14 @@ const (
 	dexAuthenticatorAnnotation = "dexauthenticator.deckhouse.io/allow-access-to-kubernetes"
 
 	deckhouseServiceAccount = "system:serviceaccount:d8-system:deckhouse"
-	namespaceEditor         = "editor@example.com"
+	// A cluster provisioner running as a platform component. Deckhouse Commander patches DexClients
+	// in its own namespace during cluster bootstrap, which is what makes this case load-bearing.
+	commanderServiceAccount  = "system:serviceaccount:d8-commander:commander"
+	kubeSystemServiceAccount = "system:serviceaccount:kube-system:some-controller"
+	tenantServiceAccount     = "system:serviceaccount:attacker-ns:tenant"
+	namespaceEditor          = "editor@example.com"
+
+	allowAccessSubresource = "allow-access-to-kubernetes"
 )
 
 var _ = Describe("Module :: user-authn :: helm template :: validation", func() {
@@ -119,8 +127,14 @@ var _ = Describe("Module :: user-authn :: helm template :: validation", func() {
 				ContainSubstring("controls access to the Kubernetes API"),
 			)
 			Expect(policy.Field("spec.validations.0.messageExpression").String()).To(
-				ContainSubstring("may only be introduced or widened by a cluster administrator"),
+				ContainSubstring("allow-access-to-kubernetes subresource"),
 			)
+
+			// Platform components have to be excluded, otherwise the gate denies the provisioning
+			// flows that create these objects on the cluster's behalf.
+			matchConditions := policy.Field("spec.matchConditions").String()
+			Expect(matchConditions).To(ContainSubstring("system:serviceaccount:d8-"))
+			Expect(matchConditions).To(ContainSubstring("system:serviceaccount:kube-"))
 
 			binding := hec.KubernetesGlobalResource("ValidatingAdmissionPolicyBinding", allowAccessPolicyName)
 			Expect(binding.Exists()).To(BeTrue())
@@ -140,15 +154,18 @@ var _ = Describe("Module :: user-authn :: helm template :: validation", func() {
 			)
 
 			cases := []struct {
-				name           string
-				resource       string
-				kind           string
-				operation      admission.Operation
-				username       string
-				canManage      bool
-				annotations    map[string]string
-				oldAnnotations map[string]string
-				allowed        bool
+				name             string
+				resource         string
+				kind             string
+				operation        admission.Operation
+				username         string
+				groups           []string
+				canGrant         bool
+				grantedResource  string
+				grantedNamespace string
+				annotations      map[string]string
+				oldAnnotations   map[string]string
+				allowed          bool
 			}{
 				{
 					name:        "unauthorised subject grants access on create",
@@ -197,10 +214,52 @@ var _ = Describe("Module :: user-authn :: helm template :: validation", func() {
 					allowed:     true,
 				},
 				{
-					name:        "subject allowed to update the user-authn ModuleConfig grants access",
-					canManage:   true,
+					// Cluster provisioners run as platform components and patch these objects during
+					// bootstrap. Gating them buys nothing, and denying them breaks cluster creation.
+					name:        "platform service account provisioning a client grants access",
+					username:    commanderServiceAccount,
 					annotations: map[string]string{dexClientAnnotation: "true"},
 					allowed:     true,
+				},
+				{
+					name:        "service account of a kube-prefixed namespace grants access",
+					username:    kubeSystemServiceAccount,
+					annotations: map[string]string{dexClientAnnotation: "true"},
+					allowed:     true,
+				},
+				{
+					name:        "subject of a system group grants access",
+					groups:      []string{"system:authenticated", "system:serviceaccounts:d8-system"},
+					annotations: map[string]string{dexClientAnnotation: "true"},
+					allowed:     true,
+				},
+				{
+					// A tenant's own service account is not a platform component: the namespace
+					// prefix is what separates them, and this is the case the policy exists for.
+					name:        "tenant service account grants access",
+					username:    tenantServiceAccount,
+					annotations: map[string]string{dexClientAnnotation: "true"},
+					allowed:     false,
+				},
+				{
+					name:        "subject holding the allow-access subresource grants access",
+					canGrant:    true,
+					annotations: map[string]string{dexClientAnnotation: "true"},
+					allowed:     true,
+				},
+				{
+					name:            "subresource granted on the other kind does not carry over",
+					canGrant:        true,
+					grantedResource: "dexauthenticators",
+					annotations:     map[string]string{dexClientAnnotation: "true"},
+					allowed:         false,
+				},
+				{
+					name:             "subresource granted in another namespace does not carry over",
+					canGrant:         true,
+					grantedNamespace: "other-ns",
+					annotations:      map[string]string{dexClientAnnotation: "true"},
+					allowed:          false,
 				},
 				{
 					name:           "existing grant is carried over unchanged",
@@ -312,13 +371,16 @@ var _ = Describe("Module :: user-authn :: helm template :: validation", func() {
 				}
 
 				allowed, err := policy.validate(dexAdmissionInput{
-					resource:       resource,
-					kind:           kind,
-					operation:      operation,
-					username:       username,
-					canManage:      tc.canManage,
-					annotations:    tc.annotations,
-					oldAnnotations: tc.oldAnnotations,
+					resource:         resource,
+					kind:             kind,
+					operation:        operation,
+					username:         username,
+					groups:           tc.groups,
+					canGrant:         tc.canGrant,
+					grantedResource:  tc.grantedResource,
+					grantedNamespace: tc.grantedNamespace,
+					annotations:      tc.annotations,
+					oldAnnotations:   tc.oldAnnotations,
 				})
 
 				Expect(err).ToNot(HaveOccurred(), tc.name)
@@ -356,7 +418,7 @@ var _ = Describe("Module :: user-authn :: helm template :: validation", func() {
 				})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(denied).To(BeFalse(),
-					"a subject without authority over the user-authn ModuleConfig must not set %q", value)
+					"a subject without the allow-access-to-kubernetes subresource must not set %q", value)
 
 				// The gate must stop the unauthorised subject only, otherwise the loop above would
 				// pass just as well against a policy that denies everything.
@@ -365,12 +427,12 @@ var _ = Describe("Module :: user-authn :: helm template :: validation", func() {
 					kind:        "DexClient",
 					operation:   admission.Create,
 					username:    namespaceEditor,
-					canManage:   true,
+					canGrant:    true,
 					annotations: annotations,
 				})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(granted).To(BeTrue(),
-					"a subject with authority over the user-authn ModuleConfig must be able to set %q", value)
+					"a subject holding the allow-access-to-kubernetes subresource must be able to set %q", value)
 			}
 		})
 	})
@@ -412,10 +474,12 @@ var annotationValueCorpus = []string{
 	"", " ", "yes", "no", "on", "off", "enabled", "2", "TrUe", "true ",
 }
 
-// compiledPolicy evaluates the validation expressions of a ValidatingAdmissionPolicy through the
-// same CEL machinery kube-apiserver uses, so the expressions the module ships are under test.
+// compiledPolicy evaluates the match conditions and the validation expressions of a
+// ValidatingAdmissionPolicy through the same CEL machinery kube-apiserver uses, so the expressions
+// the module ships are under test.
 type compiledPolicy struct {
-	validations admissioncel.ConditionEvaluator
+	matchConditions admissioncel.ConditionEvaluator
+	validations     admissioncel.ConditionEvaluator
 }
 
 func compileRenderedPolicy(renderedPolicy string) compiledPolicy {
@@ -450,6 +514,15 @@ func compileRenderedPolicy(renderedPolicy string) compiledPolicy {
 		Expect(result.Error).To(BeNil(), "variable %q should compile", variable.Name)
 	}
 
+	matchConditions := make([]admissioncel.ExpressionAccessor, 0, len(policy.Spec.MatchConditions))
+	for _, condition := range policy.Spec.MatchConditions {
+		expression := boolExpression{expression: condition.Expression}
+		Expect(compiler.CompileCELExpression(expression, validationVars, environment.NewExpressions).Error).To(BeNil(),
+			"match condition %q should compile", condition.Name)
+
+		matchConditions = append(matchConditions, expression)
+	}
+
 	validations := make([]admissioncel.ExpressionAccessor, 0, len(policy.Spec.Validations))
 	for _, validation := range policy.Spec.Validations {
 		condition := boolExpression{expression: validation.Expression}
@@ -464,7 +537,8 @@ func compileRenderedPolicy(renderedPolicy string) compiledPolicy {
 	}
 
 	return compiledPolicy{
-		validations: compiler.CompileCondition(validations, validationVars, environment.NewExpressions),
+		matchConditions: compiler.CompileCondition(matchConditions, validationVars, environment.NewExpressions),
+		validations:     compiler.CompileCondition(validations, validationVars, environment.NewExpressions),
 	}
 }
 
@@ -514,18 +588,27 @@ type dexAdmissionInput struct {
 	kind           string
 	operation      admission.Operation
 	username       string
-	canManage      bool
-	annotations    map[string]string
-	oldAnnotations map[string]string
+	groups         []string
+	// canGrant hands the subject the allow-access-to-kubernetes subresource on the resource it
+	// writes, in the namespace it writes to.
+	canGrant bool
+	// grantedResource and grantedNamespace narrow that permission, so that a grant issued for one
+	// kind or one namespace can be shown not to carry over to another.
+	grantedResource  string
+	grantedNamespace string
+	annotations      map[string]string
+	oldAnnotations   map[string]string
 }
 
-// validate reports whether every validation of the policy admits the request.
-func (p compiledPolicy) validate(input dexAdmissionInput) (bool, error) {
-	const (
-		namespace = "attacker-ns"
-		name      = "app"
-	)
+const (
+	admissionNamespace = "attacker-ns"
+	admissionName      = "app"
+)
 
+// validate reports whether the policy admits the request. Match conditions are evaluated first, the
+// way kube-apiserver does it: a request they do not select never reaches the validations at all, so
+// the policy leaves it alone.
+func (p compiledPolicy) validate(input dexAdmissionInput) (bool, error) {
 	gvk := schema.GroupVersionKind{Group: "deckhouse.io", Version: "v1", Kind: input.kind}
 	gvr := schema.GroupVersionResource{Group: "deckhouse.io", Version: "v1", Resource: input.resource}
 
@@ -533,24 +616,46 @@ func (p compiledPolicy) validate(input dexAdmissionInput) (bool, error) {
 	// present by the admission machinery.
 	var oldObject runtime.Object
 	if input.operation == admission.Update {
-		oldObject = dexObject(gvk, namespace, name, input.oldAnnotations)
+		oldObject = dexObject(gvk, admissionNamespace, admissionName, input.oldAnnotations)
+	}
+
+	groups := input.groups
+	if groups == nil {
+		groups = []string{"system:authenticated"}
 	}
 
 	attributes := admission.NewAttributesRecord(
-		dexObject(gvk, namespace, name, input.annotations), oldObject,
-		gvk, namespace, name, gvr, "", input.operation, nil, false,
-		&user.DefaultInfo{Name: input.username, Groups: []string{"system:authenticated"}},
+		dexObject(gvk, admissionNamespace, admissionName, input.annotations), oldObject,
+		gvk, admissionNamespace, admissionName, gvr, "", input.operation, nil, false,
+		&user.DefaultInfo{Name: input.username, Groups: groups},
 	)
 	versionedAttributes, err := admission.NewVersionedAttributes(attributes, gvk, nil)
 	if err != nil {
 		return false, err
 	}
 
-	results, _, err := p.validations.ForInput(
-		context.Background(), versionedAttributes,
-		admissioncel.CreateAdmissionRequest(attributes, metav1.GroupVersionResource(gvr), metav1.GroupVersionKind(gvk)),
-		admissioncel.OptionalVariableBindings{Authorizer: userAuthnModuleConfigAuthorizer(input.canManage)},
-		nil, celconfig.RuntimeCELCostBudget,
+	request := admissioncel.CreateAdmissionRequest(
+		attributes, metav1.GroupVersionResource(gvr), metav1.GroupVersionKind(gvk),
+	)
+	bindings := admissioncel.OptionalVariableBindings{Authorizer: allowAccessAuthorizer(input)}
+
+	selected, err := p.evaluate(p.matchConditions, versionedAttributes, request, bindings)
+	if err != nil || !selected {
+		return true, err
+	}
+
+	return p.evaluate(p.validations, versionedAttributes, request, bindings)
+}
+
+// evaluate reports whether every expression of the evaluator holds for the request.
+func (p compiledPolicy) evaluate(
+	evaluator admissioncel.ConditionEvaluator,
+	attributes *admission.VersionedAttributes,
+	request *admissionv1.AdmissionRequest,
+	bindings admissioncel.OptionalVariableBindings,
+) (bool, error) {
+	results, _, err := evaluator.ForInput(
+		context.Background(), attributes, request, bindings, nil, celconfig.RuntimeCELCostBudget,
 	)
 	if err != nil {
 		return false, err
@@ -581,15 +686,27 @@ func dexObject(gvk schema.GroupVersionKind, namespace, name string, annotations 
 	return object
 }
 
-// userAuthnModuleConfigAuthorizer mimics RBAC for a subject that either holds or lacks the right to
-// update the user-authn ModuleConfig, and holds nothing else.
-func userAuthnModuleConfigAuthorizer(canManage bool) authorizer.Authorizer {
+// allowAccessAuthorizer mimics RBAC for a subject that holds the allow-access-to-kubernetes
+// subresource on one resource in one namespace, and holds nothing else. Both are narrowed on
+// purpose: a grant on DexClients must not carry over to DexAuthenticators, and a grant in one
+// namespace must not carry over to another.
+func allowAccessAuthorizer(input dexAdmissionInput) authorizer.Authorizer {
+	grantedResource := input.grantedResource
+	if grantedResource == "" {
+		grantedResource = input.resource
+	}
+	grantedNamespace := input.grantedNamespace
+	if grantedNamespace == "" {
+		grantedNamespace = admissionNamespace
+	}
+
 	return authorizerFunc(func(attributes authorizer.Attributes) bool {
-		return canManage &&
+		return input.canGrant &&
 			attributes.GetAPIGroup() == "deckhouse.io" &&
-			attributes.GetResource() == "moduleconfigs" &&
-			attributes.GetName() == "user-authn" &&
-			attributes.GetVerb() == "update"
+			attributes.GetResource() == grantedResource &&
+			attributes.GetSubresource() == allowAccessSubresource &&
+			attributes.GetNamespace() == grantedNamespace &&
+			attributes.GetVerb() == "create"
 	})
 }
 

--- a/modules/150-user-authn/templates/rbacv2/manage/edit.yaml
+++ b/modules/150-user-authn/templates/rbacv2/manage/edit.yaml
@@ -42,3 +42,13 @@ rules:
   - update
   - patch
   - delete
+# No controller serves these subresources. They exist so that the authority to let an OAuth2 client
+# reach the Kubernetes API can be delegated on its own, and the admission policy that gates the
+# allow-access-to-kubernetes annotation checks exactly this permission.
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - dexauthenticators/allow-access-to-kubernetes
+  - dexclients/allow-access-to-kubernetes
+  verbs:
+  - create

--- a/modules/150-user-authn/templates/user-authz-cluster-roles.yaml
+++ b/modules/150-user-authn/templates/user-authz-cluster-roles.yaml
@@ -61,6 +61,15 @@ rules:
   - deletecollection
   - patch
   - update
+# No controller serves these subresources; they carry the authority to let an OAuth2 client reach
+# the Kubernetes API, which the admission policy for the allow-access-to-kubernetes annotation checks.
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - dexauthenticators/allow-access-to-kubernetes
+  - dexclients/allow-access-to-kubernetes
+  verbs:
+  - create
 # Read-only audit access to internal Dex storage CRDs. Deliberately without `get`:
 # `passwords` contain bcrypt-hashed credentials, `offlinesessionses` carry refresh tokens —
 # a named read would return the same secret material, so ClusterAdmin stays at the

--- a/modules/150-user-authn/templates/validation.yaml
+++ b/modules/150-user-authn/templates/validation.yaml
@@ -42,6 +42,16 @@ spec:
         apiVersions: ["*"]
         operations:  ["CREATE", "UPDATE"]
         resources:   ["dexclients", "dexauthenticators"]
+  # Platform components provision these objects on the cluster's behalf and are already privileged
+  # by virtue of running in a system namespace, so gating them buys nothing and only breaks
+  # provisioning flows. Tenants cannot place a workload in these namespaces to begin with.
+  matchConditions:
+    - name: 'exclude-groups'
+      expression: '!(["system:nodes", "system:serviceaccounts:kube-system", "system:serviceaccounts:d8-system"].exists(e, (e in request.userInfo.groups)))'
+    - name: 'exclude-users'
+      expression: '!(["system:sudouser", "system:apiserver", "system:kube-controller-manager", "system:kube-scheduler", "system:volume-scheduler", "dhctl", "observability"].exists(e, (e == request.userInfo.username)))'
+    - name: 'exclude-system-serviceaccounts'
+      expression: '!(request.userInfo.username.startsWith("system:serviceaccount:d8-") || request.userInfo.username.startsWith("system:serviceaccount:kube-"))'
   variables:
     # The annotation is named after the kind it belongs to, so the key depends on the matched resource.
     - name: annotation
@@ -70,15 +80,19 @@ spec:
         && variables.oldAnnotations[variables.annotation].lowerAscii() in ["1", "t", "true"]'
   validations:
     # Only a newly introduced or newly widened annotation is gated, so objects that already carry it
-    # stay editable by their owners. Authority is proven by the right to update the user-authn
-    # ModuleConfig, which only cluster-wide administrators of this module hold.
-    - expression: 'request.userInfo.username == "system:serviceaccount:d8-system:deckhouse"
-        || !variables.annotated
+    # stay editable by their owners. Authority is a dedicated permission on a subresource that no
+    # controller serves: it exists solely so that an administrator can delegate "may grant access to
+    # the Kubernetes API" on its own, the way pods/exec or the escalate verb are delegated. Deriving
+    # authority from write access to the user-authn ModuleConfig instead would demand ownership of
+    # the whole authentication stack from every cluster provisioner, and the platform's own role
+    # model keeps these apart: DexClient lives in use roles, ModuleConfig in manage roles.
+    - expression: '!variables.annotated
         || (variables.annotatedBefore && (!variables.grantsAccess || variables.grantedBefore))
-        || authorizer.group("deckhouse.io").resource("moduleconfigs").name("user-authn").check("update").allowed()'
+        || authorizer.group("deckhouse.io").resource(request.resource.resource).subresource("allow-access-to-kubernetes").namespace(request.namespace).check("create").allowed()'
       reason: Forbidden
       messageExpression: '"the " + variables.annotation + " annotation controls access to the Kubernetes API
-        and may only be introduced or widened by a cluster administrator who is allowed to manage the user-authn module"'
+        and may only be introduced or widened by a subject allowed to create the "
+        + request.resource.resource + "/allow-access-to-kubernetes subresource"'
 ---
 apiVersion: {{ include "helm_lib_get_api_version_by_kind" (list . "ValidatingAdmissionPolicyBinding") }}
 kind: ValidatingAdmissionPolicyBinding

--- a/modules/150-user-authn/templates/validation.yaml
+++ b/modules/150-user-authn/templates/validation.yaml
@@ -42,16 +42,19 @@ spec:
         apiVersions: ["*"]
         operations:  ["CREATE", "UPDATE"]
         resources:   ["dexclients", "dexauthenticators"]
-  # Platform components provision these objects on the cluster's behalf and are already privileged
-  # by virtue of running in a system namespace, so gating them buys nothing and only breaks
-  # provisioning flows. Tenants cannot place a workload in these namespaces to begin with.
+  # The platform's core namespaces are excluded because the module charts that ship an annotated
+  # DexAuthenticator, kiali in istio and the UI in cilium-hubble, are applied by the Deckhouse
+  # service account, and a request from d8-system or kube-system is privileged by construction:
+  # only that same service account and dhctl may create those namespaces in the first place
+  # (modules/002-deckhouse/templates/validation.yaml). Deliberately no exclusion by namespace
+  # prefix: a module from any ModuleSource gets a d8-<module> namespace, and it should have to
+  # declare this authority in its own RBAC like any other provisioner rather than inherit it from
+  # where it happens to run.
   matchConditions:
     - name: 'exclude-groups'
       expression: '!(["system:nodes", "system:serviceaccounts:kube-system", "system:serviceaccounts:d8-system"].exists(e, (e in request.userInfo.groups)))'
     - name: 'exclude-users'
       expression: '!(["system:sudouser", "system:apiserver", "system:kube-controller-manager", "system:kube-scheduler", "system:volume-scheduler", "dhctl", "observability"].exists(e, (e == request.userInfo.username)))'
-    - name: 'exclude-system-serviceaccounts'
-      expression: '!(request.userInfo.username.startsWith("system:serviceaccount:d8-") || request.userInfo.username.startsWith("system:serviceaccount:kube-"))'
   variables:
     # The annotation is named after the kind it belongs to, so the key depends on the matched resource.
     - name: annotation


### PR DESCRIPTION
Backport of #22388 to `release-1.76`. Blocked until that PR lands.

## Description

`dex-allow-access-to-kubernetes.deckhouse.io`, backported here by #22371, denies every writer that is neither the deckhouse service account nor allowed to update the `user-authn` ModuleConfig, and it carries no match conditions. Cluster provisioning trips over it: an agent patching a DexClient in its own namespace during bootstrap is denied and the bootstrap task fails. #22388 replaces the authority check with a `create` permission on an `allow-access-to-kubernetes` subresource that no controller serves, and excludes platform components outright.

Cherry-pick needed manual resolution in one file:

- `modules/150-user-authn/templates/user-authz-cluster-roles.yaml` — the `dex.coreos.com` grants for `passwords` and `offlinesessionses` are still present on this branch, because #22215 is deliberately not backported to 1.76. The branch's grants are kept as they are and the new subresource rule is added ahead of them; nothing else in the file changes.

The regenerated `user-authz` role reference from #22388 is not carried over. This branch's generator produces no output for a `create`-only subresource rule, so the committed docs already match what `make generate` yields here, and taking the main branch's rendering would have made the check fail instead.

## Why do we need it in the patch release?

#22371 is already on this branch under the same milestone and the tag is not cut yet, so the regression it introduces has to be fixed before users ever see it.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

`go test ./modules/150-user-authn/template_tests/` passes on this branch, including the CEL cases that evaluate the rendered policy's match conditions and validations.

## Changelog entries

```changes
section: user-authn
type: fix
summary: The policy gating the allow-access-to-kubernetes annotation no longer applies to platform components, and proves authority with a create permission on the dexclients/allow-access-to-kubernetes and dexauthenticators/allow-access-to-kubernetes subresources instead of write access to the user-authn ModuleConfig.
impact: |
  Setting the annotation no longer requires write access to the user-authn ModuleConfig. Module administrators are unaffected, as their roles already carry the new permission, and so are the platform's own components in `d8-system` and `kube-system`. Any other subject that sets the annotation, a cluster provisioner in particular, has to be granted `create` on the subresource, which for a single namespace is:

      apiVersion: rbac.authorization.k8s.io/v1
      kind: Role
      metadata:
        name: allow-access-to-kubernetes
        namespace: <namespace>
      rules:
      - apiGroups: ["deckhouse.io"]
        resources: ["dexclients/allow-access-to-kubernetes", "dexauthenticators/allow-access-to-kubernetes"]
        verbs: ["create"]

  bound to the subject with a RoleBinding in the same namespace, or with a ClusterRole and a ClusterRoleBinding to grant it cluster-wide.
impact_level: high
```
