### PR TITLE
[control-plane-manager] Fix Polk alert grouping in CPM

### DIFF
--- a/modules/040-control-plane-manager/monitoring/prometheus-rules/mc-migration.yaml
+++ b/modules/040-control-plane-manager/monitoring/prometheus-rules/mc-migration.yaml
@@ -12,8 +12,8 @@
       annotations:
         plk_protocol_version: "1"
         plk_markup_format: "markdown"
-        plk_create_group_if_not_exists__d8_obsolete_publishapi_in_user_authn: "D8ObsoletePublishAPIInUserAuthn,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
-        plk_grouped_by__d8_obsolete_publishapi_in_user_authn: "D8ObsoletePublishAPIInUserAuthn,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+        plk_create_group_if_not_exists__d8_control_plane_manager_migration: "D8ControlPlaneManagerMigrationAlerts,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+        plk_grouped_by__d8_control_plane_manager_migration: "D8ControlPlaneManagerMigrationAlerts,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
         summary: Obsolete Publish API settings in `user-authn` need to be migrated.
         description: |-
           Publish API ingress settings are being migrated from `mc user-authn` to `mc control-plane-manager`.
@@ -64,8 +64,8 @@
       annotations:
         plk_protocol_version: "1"
         plk_markup_format: "markdown"
-        plk_create_group_if_not_exists__d8_obsolete_global_control_plane_resources_requests: "D8ObsoleteGlobalControlPlaneResourcesRequests,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
-        plk_grouped_by__d8_obsolete_global_control_plane_resources_requests: "D8ObsoleteGlobalControlPlaneResourcesRequests,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+        plk_create_group_if_not_exists__d8_control_plane_manager_migration: "D8ControlPlaneManagerMigrationAlerts,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+        plk_grouped_by__d8_control_plane_manager_migration: "D8ControlPlaneManagerMigrationAlerts,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
         summary: Obsolete global control-plane resource requests need to be migrated.
         description: |-
           Control-plane resource requests are being migrated from global settings to `moduleconfig control-plane-manager`.
@@ -154,8 +154,8 @@
       annotations:
         plk_protocol_version: "1"
         plk_markup_format: "markdown"
-        plk_create_group_if_not_exists__d8_obsolete_encryption_algorithm_in_cluster_configuration: "D8ObsoleteEncryptionAlgorithmInClusterConfiguration,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
-        plk_grouped_by__d8_obsolete_encryption_algorithm_in_cluster_configuration: "D8ObsoleteEncryptionAlgorithmInClusterConfiguration,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+        plk_create_group_if_not_exists__d8_control_plane_manager_migration: "D8ControlPlaneManagerMigrationAlerts,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+        plk_grouped_by__d8_control_plane_manager_migration: "D8ControlPlaneManagerMigrationAlerts,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
         summary: Obsolete `encryptionAlgorithm` in ClusterConfiguration needs to be migrated to `control-plane-manager` ModuleConfig.
         description: |-
           The `encryptionAlgorithm` field is set to a non-default value in ClusterConfiguration but has not been migrated to ModuleConfig `control-plane-manager` yet.
@@ -200,8 +200,8 @@
       annotations:
         plk_protocol_version: "1"
         plk_markup_format: "markdown"
-        plk_create_group_if_not_exists__d8_obsolete_kubernetes_version_field_in_cluster_configuration: "D8ObsoleteKubernetesVersionFieldInClusterConfiguration,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
-        plk_grouped_by__d8_obsolete_kubernetes_version_field_in_cluster_configuration: "D8ObsoleteKubernetesVersionFieldInClusterConfiguration,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+        plk_create_group_if_not_exists__d8_control_plane_manager_migration: "D8ControlPlaneManagerMigrationAlerts,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+        plk_grouped_by__d8_control_plane_manager_migration: "D8ControlPlaneManagerMigrationAlerts,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
         summary: The obsolete `kubernetesVersion` field is still present in `ClusterConfiguration`.
         description: |-
           `ClusterConfiguration` still carries the obsolete `kubernetesVersion` field. The place to manage the cluster Kubernetes version is `settings.kubernetesVersion` in ModuleConfig `control-plane-manager`.
@@ -253,8 +253,8 @@
       annotations:
         plk_protocol_version: "1"
         plk_markup_format: "markdown"
-        plk_create_group_if_not_exists__d8_control_plane_default_version_drift: "D8ControlPlaneDefaultVersionDrift,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
-        plk_grouped_by__d8_control_plane_default_version_drift: "D8ControlPlaneDefaultVersionDrift,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+        plk_create_group_if_not_exists__d8_control_plane_manager_migration: "D8ControlPlaneManagerMigrationAlerts,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+        plk_grouped_by__d8_control_plane_manager_migration: "D8ControlPlaneManagerMigrationAlerts,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
         summary: Control plane Kubernetes version rollback is blocked (Default soft-guard freeze).
         description: |-
           The cluster tracks the Deckhouse default Kubernetes version (`kubernetesVersion: Default` in ModuleConfig `control-plane-manager`, or unset ModuleConfig with no ClusterConfiguration pin). That default is now more than 1 minor below the highest version this cluster has ever run (`maxUsed`).
@@ -290,8 +290,8 @@
       annotations:
         plk_protocol_version: "1"
         plk_markup_format: "markdown"
-        plk_create_group_if_not_exists__d8_control_plane_manager_obsolete_moduleconfig: "D8ControlPlaneManagerObsoleteMonitoringKubernetesControlPlaneModuleConfig,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
-        plk_grouped_by__d8_control_plane_manager_obsolete_moduleconfig: "D8ControlPlaneManagerObsoleteMonitoringKubernetesControlPlaneModuleConfig,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+        plk_create_group_if_not_exists__d8_control_plane_manager_migration: "D8ControlPlaneManagerMigrationAlerts,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+        plk_grouped_by__d8_control_plane_manager_migration: "D8ControlPlaneManagerMigrationAlerts,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
         summary: Obsolete `monitoring-kubernetes-control-plane` ModuleConfig should be removed.
         description: |-
           The `monitoring-kubernetes-control-plane` module was merged into the `control-plane-manager` module, but its ModuleConfig still exists in the cluster and is no longer used.


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Renamed the Polk alert grouping in the `control-plane-manager` migration rules so that the group name (`D8ControlPlaneManagerMigrationAlerts`) no longer repeats the alert's own name.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Without this, Polk treats the grouping as a circular dependency, rejects the annotations, and the incident for such an alert ends up broken.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: chore
summary: Fix Polk alert grouping in control-plane-manager migration rules
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
