### PR TITLE
Backport: [admission-policy-engine] Verify image signatures of ephemeral containers

### DIFF
--- a/modules/015-admission-policy-engine/charts/constraint-templates/templates/security/verify-image-signature.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/templates/security/verify-image-signature.yaml
@@ -47,6 +47,11 @@ spec:
           imgs := input.review.object.spec.initContainers[_].image
         }
 
+        retrieve_images[imgs] {
+          count(input.review.object.spec.ephemeralContainers[_].image) > 0
+          imgs := input.review.object.spec.ephemeralContainers[_].image
+        }
+
         # Base Gatekeeper violation
         violation[{"msg": msg}] {
           not input.review.operation == "DELETE"

--- a/modules/015-admission-policy-engine/template_tests/module_test.go
+++ b/modules/015-admission-policy-engine/template_tests/module_test.go
@@ -280,7 +280,7 @@ var _ = Describe("Module :: admissionPolicyEngine :: helm template ::", func() {
 		})
 
 		It("Renders ValidatingWebhookConfiguration with main webhook, deny-exec-heritage webhook and security-policy-exception webhook", func() {
-			mainRules := `[{"apiGroups":[""],"apiVersions":["*"],"operations":["CREATE","UPDATE","DELETE"],"resources":["pods"]},{"apiGroups":["rbac.authorization.k8s.io"],"apiVersions":["*"],"operations":["CREATE","UPDATE","DELETE"],"resources":["roles","rolebindings"]},{"apiGroups":["constraints.gatekeeper.sh"],"apiVersions":["*"],"operations":["CREATE","UPDATE","DELETE"],"resources":["*"],"scope":"*"},{"apiGroups":[""],"apiVersions":["*"],"resources":["pods/exec","pods/attach"],"operations":["CONNECT"]}]`
+			mainRules := `[{"apiGroups":[""],"apiVersions":["*"],"operations":["CREATE","UPDATE","DELETE"],"resources":["pods"]},{"apiGroups":["rbac.authorization.k8s.io"],"apiVersions":["*"],"operations":["CREATE","UPDATE","DELETE"],"resources":["roles","rolebindings"]},{"apiGroups":["constraints.gatekeeper.sh"],"apiVersions":["*"],"operations":["CREATE","UPDATE","DELETE"],"resources":["*"],"scope":"*"},{"apiGroups":[""],"apiVersions":["*"],"resources":["pods/exec","pods/attach"],"operations":["CONNECT"]},{"apiGroups":[""],"apiVersions":["*"],"resources":["pods/ephemeralcontainers"],"operations":["UPDATE"]}]`
 			denyExecHeritageRules := `[{"apiGroups":[""],"apiVersions":["*"],"operations":["CONNECT"],"resources":["pods/exec","pods/attach"]}]`
 			securityPolicyExceptionRules := mainRules
 			checkVWC(f, 3, mainRules, denyExecHeritageRules, securityPolicyExceptionRules)

--- a/modules/015-admission-policy-engine/templates/validatingwebhookconfiguration.yaml
+++ b/modules/015-admission-policy-engine/templates/validatingwebhookconfiguration.yaml
@@ -82,6 +82,11 @@ webhooks:
     apiVersions: ["*"]
     resources: ["pods/exec", "pods/attach"]
     operations: ["CONNECT"]
+  {{/* Ephemeral containers are attached through a subresource, which the `pods` rule does not match */}}
+  - apiGroups: [""]
+    apiVersions: ["*"]
+    resources: ["pods/ephemeralcontainers"]
+    operations: ["UPDATE"]
 {{- if semverCompare ">= 1.27" .Values.global.discovery.kubernetesVersion }}
   matchConditions:
     - name: 'exclude-virtualization'
@@ -130,6 +135,11 @@ webhooks:
     apiVersions: ["*"]
     resources: ["pods/exec", "pods/attach"]
     operations: ["CONNECT"]
+  {{/* Ephemeral containers are attached through a subresource, which the `pods` rule does not match */}}
+  - apiGroups: [""]
+    apiVersions: ["*"]
+    resources: ["pods/ephemeralcontainers"]
+    operations: ["UPDATE"]
 {{- if semverCompare ">= 1.27" .Values.global.discovery.kubernetesVersion }}
   matchConditions:
     - name: 'exclude-virtualization'


### PR DESCRIPTION
Backport of #22398 to `release-1.76`. The automated cherry-pick failed; this is the manual one.

Cherry-pick needed manual resolution in two files, both dropped:

- `charts/constraint-templates/tests/test_cases/constraints/security/verify-image-signature/test-matrix.yaml`
- `charts/constraint-templates/tests/test_cases/constraints/security/verify-image-signature/test_fields.yaml`

This branch uses the older constraint-template test layout — `charts/constraint-templates/tests/<constraint>/`, with no `test_cases/`, no `constraint_testgen` and no test matrix. There is no `verify-image-signature` suite here at all, so there is nothing to port those changes onto. The same is true of the runtime template: this branch's `verify-image-signature.yaml` predates the `isTest` / `external_data_from_inventory` test-mode helpers, which is exactly why the gator external-data mock pattern does not exist on it.

Everything else applied unchanged. The `retrieve_images` rules, both `pods/exec`/`pods/attach` blocks in the webhook template and the `mainRules` expectation in `template_tests/module_test.go` are byte-identical to `main` on this branch, so both hunks and the updated expectation carried over without edits.

## Description

Two changes that close the same gap from opposite ends.

1. `charts/constraint-templates/templates/security/verify-image-signature.yaml` — `retrieve_images` collected images only from `spec.containers` and `spec.initContainers`. Added the `spec.ephemeralContainers` clause.

2. `templates/validatingwebhookconfiguration.yaml` — ephemeral containers are attached through the `pods/ephemeralcontainers` subresource. The webhook rule `resources: ["pods"]` does not match subresources (`matchPolicy: Exact`, and admissionregistration requires subresources to be listed explicitly), and `constraint-exporter` only ever emits one subresource, via the hardcoded `PodExecOptions` special case. So Gatekeeper never saw `kubectl debug` at all. Added `pods/ephemeralcontainers` / `UPDATE` to both webhooks that carry `trackedConstraintResources`.

The `deny-exec-heritage` webhook (namespaces prefixed `d8-` / `kube-`) is deliberately left alone: it has `failurePolicy: Fail` and no heritage exclusion, so adding the rule there would block debugging system pods whenever Gatekeeper is unavailable — including admission-policy-engine itself during an incident. The main webhook excludes system namespaces via `heritage NotIn deckhouse`, and that property is preserved.

## Why do we need it, and what problem does it solve?

Without this, no admission policy in the module is evaluated on the ephemeral-container path. Not just image signature verification — SecurityPolicy, OperationPolicy and the Pod Security Standards baseline/restricted profiles are all unenforced for containers added with `kubectl debug`. Deckhouse does not enable the built-in `PodSecurity` admission plugin and does not label namespaces with `pod-security.kubernetes.io/*`, so admission-policy-engine is the only pod-security control, and it had a hole.

Verified on a live cluster while preparing #22398 (DKP 1.78.0-main, Kubernetes 1.34.10):

- with a `SecurityPolicy` in `Deny` mode setting `readOnlyRootFilesystem: true` and `allowPrivilegeEscalation: false`, creating a violating Pod is rejected, while the same violating container attached with `kubectl debug` is admitted;
- with a policy setting `allowPrivileged: false`, creating a privileged Pod is rejected, while `kubectl debug --profile=sysadmin` is admitted and the resulting container runs with the full capability set (`CapEff: 000001ffffffffff`) and sees the node's block devices;
- with the `pods/ephemeralcontainers` rule added to the webhook, the same `kubectl debug` is rejected by the policy.

## Why do we need it in the patch release?

It closes a bypass of every admission policy the module enforces, including Pod Security Standards, on a branch that is still receiving patch releases.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

Unit coverage on this branch is `template_tests/module_test.go`, which asserts the rendered webhook rules. The gator case for the Rego change exists only on `main`, for the reason given above.

## Changelog entries

```changes
section: admission-policy-engine
type: fix
summary: Admission policies are now evaluated for ephemeral containers added with `kubectl debug`.
impact: |
  Containers attached through the `pods/ephemeralcontainers` subresource were not seen by
  the module's webhook, so no policy was evaluated for them: SecurityPolicy, OperationPolicy,
  Pod Security Standards and image signature verification were all bypassed by `kubectl debug`.
  After the update these requests are validated.

  On clusters with restricted Pod Security Standards, `deny-exec` or strict SecurityPolicy,
  typical debug images (root user, writable root filesystem, interactive `-it`) will now be
  rejected. Adjust the policies or use a SecurityPolicyException for the namespaces where
  debugging must stay available.

  The webhook uses `failurePolicy: Fail`, so while Gatekeeper is unavailable `kubectl debug`
  will not work in user namespaces. System namespaces are excluded from the webhook and are
  not affected.
impact_level: high
```
