### PR TITLE
[docs] Update module library tags

### DIFF
--- a/docs/documentation/_data/modules/modules-addition.json
+++ b/docs/documentation/_data/modules/modules-addition.json
@@ -43,6 +43,15 @@
     "external": "true",
     "path": "/modules/ai-models/"
   },
+  "ansible": {
+    "editions": [
+      "ce",
+      "se-plus",
+      "ee"
+    ],
+    "external": "true",
+    "path": "/modules/ansible/"
+  },
   "cloud-provider-vsphere": {
     "editionFullyAvailable": [
       "se-plus",
@@ -209,6 +218,15 @@
     "external": "true",
     "path": "/modules/managed-postgres/"
   },
+  "managed-starrocks": {
+    "editions": [
+      "ee",
+      "se",
+      "se-plus"
+    ],
+    "external": "true",
+    "path": "/modules/managed-starrocks/"
+  },
   "managed-memcached": {
     "editions": [
       "ee",
@@ -246,6 +264,19 @@
     ],
     "external": "true",
     "path": "/modules/monitoring-custom/"
+  },
+  "monitoring-kubernetes": {
+    "editions": [
+      "ce",
+      "be",
+      "se",
+      "se-plus",
+      "ee",
+      "cse-lite",
+      "cse-pro"
+    ],
+    "external": "true",
+    "path": "/modules/monitoring-kubernetes/"
   },
   "monitoring-ping": {
     "editions": [
@@ -412,14 +443,6 @@
     ],
     "external": "true",
     "path": "/modules/dashboard/"
-  },
-  "delivery-kit": {
-    "editions": [
-      "cse-lite",
-      "cse-pro"
-    ],
-    "external": "true",
-    "path": ""
   },
   "log-shipper": {
     "editions": [
@@ -667,6 +690,13 @@
     ],
     "external": "true",
     "path": "/modules/sds-node-configurator/"
+  },
+  "sds-object": {
+    "editions": [
+      "ee"
+    ],
+    "external": "true",
+    "path": "/modules/sds-object/"
   },
   "sds-replicated-volume": {
     "editions": [

--- a/docs/site/backends/docs-builder-template/data/modules_all.json
+++ b/docs/site/backends/docs-builder-template/data/modules_all.json
@@ -34,6 +34,18 @@
       "ssdlc"
     ]
   },
+  "ansible": {
+    "editions": [
+      "ce",
+      "se-plus",
+      "ee"
+    ],
+    "tags": [
+      "helper",
+      "virtualization",
+      "ssdlc"
+    ]
+  },
   "code": {
     "editions": [
       "ee",
@@ -232,16 +244,6 @@
       "ssdlc"
     ]
   },
-  "delivery-kit": {
-    "editions": [
-      "cse-lite",
-      "cse-pro"
-    ],
-    "tags": [
-      "delivery",
-      "ssdlc"
-    ]
-  },
   "dashboard": {
     "editions": [
       "ce",
@@ -400,6 +402,17 @@
       "ssdlc"
     ]
   },
+  "managed-starrocks": {
+    "editions": [
+      "ee",
+      "se",
+      "se-plus"
+    ],
+    "tags": [
+      "managed services",
+      "ssdlc"
+    ]
+  },
   "managed-trino": {
     "editions": [
       "ee"
@@ -421,6 +434,36 @@
     ]
   },
   "monitoring-custom": {
+    "editions": [
+      "ce",
+      "be",
+      "se",
+      "se-plus",
+      "ee",
+      "cse-lite",
+      "cse-pro"
+    ],
+    "tags": [
+      "observability",
+      "ssdlc"
+    ]
+  },
+  "monitoring-applications": {
+    "editions": [
+      "ce",
+      "be",
+      "se",
+      "se-plus",
+      "ee",
+      "cse-lite",
+      "cse-pro"
+    ],
+    "tags": [
+      "observability",
+      "ssdlc"
+    ]
+  },
+  "monitoring-kubernetes": {
     "editions": [
       "ce",
       "be",
@@ -730,6 +773,15 @@
       "ee",
       "cse-lite",
       "cse-pro"
+    ],
+    "tags": [
+      "storage",
+      "ssdlc"
+    ]
+  },
+  "sds-object": {
+    "editions": [
+      "ee"
     ],
     "tags": [
       "storage",

--- a/docs/site/pages/404.md
+++ b/docs/site/pages/404.md
@@ -12,6 +12,7 @@ feedback: false
 
 You can find the documentation for previous versions at&nbsp;the links below:
 
+- [DKP v1.76 Documentation](/products/kubernetes-platform/documentation/v1.76/)
 - [DKP v1.75 Documentation](/products/kubernetes-platform/documentation/v1.75/)
 - [DKP v1.74 Documentation](/products/kubernetes-platform/documentation/v1.74/)
 - [DKP v1.73 Documentation](/products/kubernetes-platform/documentation/v1.73/)

--- a/docs/site/pages/404_RU.md
+++ b/docs/site/pages/404_RU.md
@@ -13,6 +13,7 @@ feedback: false
 
 Если вы&nbsp;искали предыдущие версии документации, они&nbsp;&mdash; по&nbsp;ссылкам ниже:
 
+- [Документация DKP v1.76](/products/kubernetes-platform/documentation/v1.76/)
 - [Документация DKP v1.75](/products/kubernetes-platform/documentation/v1.75/)
 - [Документация DKP v1.74](/products/kubernetes-platform/documentation/v1.74/)
 - [Документация DKP v1.73](/products/kubernetes-platform/documentation/v1.73/)


### PR DESCRIPTION
## Description

- Register new external modules in both documentation and site builder data sources: ansible, managed-starrocks, monitoring-kubernetes, monitoring-applications, and sds-object with their respective edition availability and category tags
- Remove the deprecated delivery-kit module entry from both module registry manifests
- Add DKP v1.76 documentation version reference to the 404 fallback pages


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Update module library tags.
impact_level: low
```
