### PR TITLE
[tools] crd-enricher: add unset:<key> and stop dropping markers silently

### DIFF
--- a/.github/ci_templates/tests.yml
+++ b/.github/ci_templates/tests.yml
@@ -1,7 +1,11 @@
+{!{/* tests-controller covers ./deckhouse-controller/... and tests-modules the
+     module hooks and templates. Neither crosses a nested go.mod boundary, so a
+     tool module under pkg/ needs naming here explicitly or its tests never run
+     on a pull request -- test-crd-enricher is the crd-enricher module's. */}!}
 {!{ define "unit_run_args" }!}
 # <template: unit_run_args>
 setup_cmd: 'pm install git'
-args: 'sh -c "git config --global --add safe.directory /deckhouse && make tests-controller tests-modules"'
+args: 'sh -c "git config --global --add safe.directory /deckhouse && make tests-controller tests-modules test-crd-enricher"'
 docker_options: '-w /deckhouse -v ${{github.workspace}}:/deckhouse --tmpfs /tmp:mode=1777,exec -e HOME=/tmp -e "TERM=xterm-256color" -v ~/go-pkg-cache:/go/pkg'
 exec_options: '-u $(id -u):$(id -g) -e HOME=/tmp -w /deckhouse'
 # </template: unit_run_args>

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -3944,7 +3944,7 @@ jobs:
           echo "⚓️ 🏎 [$(date -u)] Run tests..."
           CONTAINER_ID=$(docker run -d -w /deckhouse -v ${{github.workspace}}:/deckhouse --tmpfs /tmp:mode=1777,exec -e HOME=/tmp -e "TERM=xterm-256color" -v ~/go-pkg-cache:/go/pkg ${TESTS_IMAGE_NAME} sleep infinity)
           docker exec -u 0:0 ${CONTAINER_ID} pm install git
-          docker exec -u $(id -u):$(id -g) -e HOME=/tmp -w /deckhouse ${CONTAINER_ID} sh -c "git config --global --add safe.directory /deckhouse && make tests-controller tests-modules"
+          docker exec -u $(id -u):$(id -g) -e HOME=/tmp -w /deckhouse ${CONTAINER_ID} sh -c "git config --global --add safe.directory /deckhouse && make tests-controller tests-modules test-crd-enricher"
           docker rm -f ${CONTAINER_ID}
     # </template: tests_before_build_template>
 

--- a/.github/workflows/build-and-test_main.yml
+++ b/.github/workflows/build-and-test_main.yml
@@ -1290,7 +1290,7 @@ jobs:
           echo "⚓️ 🏎 [$(date -u)] Run tests..."
           CONTAINER_ID=$(docker run -d -w /deckhouse -v ${{github.workspace}}:/deckhouse --tmpfs /tmp:mode=1777,exec -e HOME=/tmp -e "TERM=xterm-256color" -v ~/go-pkg-cache:/go/pkg ${TESTS_IMAGE_NAME} sleep infinity)
           docker exec -u 0:0 ${CONTAINER_ID} pm install git
-          docker exec -u $(id -u):$(id -g) -e HOME=/tmp -w /deckhouse ${CONTAINER_ID} sh -c "git config --global --add safe.directory /deckhouse && make tests-controller tests-modules"
+          docker exec -u $(id -u):$(id -g) -e HOME=/tmp -w /deckhouse ${CONTAINER_ID} sh -c "git config --global --add safe.directory /deckhouse && make tests-controller tests-modules test-crd-enricher"
           docker rm -f ${CONTAINER_ID}
     # </template: tests_before_build_template>
 

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -3572,7 +3572,7 @@ jobs:
           echo "⚓️ 🏎 [$(date -u)] Run tests..."
           CONTAINER_ID=$(docker run -d -w /deckhouse -v ${{github.workspace}}:/deckhouse --tmpfs /tmp:mode=1777,exec -e HOME=/tmp -e "TERM=xterm-256color" -v ~/go-pkg-cache:/go/pkg ${TESTS_IMAGE_NAME} sleep infinity)
           docker exec -u 0:0 ${CONTAINER_ID} pm install git
-          docker exec -u $(id -u):$(id -g) -e HOME=/tmp -w /deckhouse ${CONTAINER_ID} sh -c "git config --global --add safe.directory /deckhouse && make tests-controller tests-modules"
+          docker exec -u $(id -u):$(id -g) -e HOME=/tmp -w /deckhouse ${CONTAINER_ID} sh -c "git config --global --add safe.directory /deckhouse && make tests-controller tests-modules test-crd-enricher"
           docker rm -f ${CONTAINER_ID}
     # </template: tests_before_build_template>
 

--- a/Makefile
+++ b/Makefile
@@ -733,7 +733,7 @@ enrich-crds-local: generate-crds crd-enricher-local ## Enrich CRDs with the loca
 .PHONY: test-crd-enricher
 test-crd-enricher: ## Run crd-enricher unit/golden tests (CRD_ENRICHER_TEST_FLAGS=-golden regenerates goldens).
 	@echo "Running crd-enricher tests..."
-	@cd $(CRD_ENRICHER_SRC) && go test ./... $(CRD_ENRICHER_TEST_FLAGS)
+	@cd $(CRD_ENRICHER_SRC) && go test -race -cover -timeout=${TESTS_TIMEOUT} ./... $(CRD_ENRICHER_TEST_FLAGS)
 
 ## Generate clientset
 .PHONY: client-gen-generate

--- a/Makefile
+++ b/Makefile
@@ -605,6 +605,16 @@ DECKHOUSE_CLI ?= $(LOCALBIN)/d8
 CRD_ENRICHER ?= $(LOCALBIN)/crd-enricher
 CRD_ENRICHER_LOCAL ?= $(LOCALBIN)/crd-enricher-local
 CRD_ENRICHER_SRC ?= $(CURDIR)/pkg/crd-enricher
+## Fail the enrichment when any marker did not do what it was written to do. The
+## crds/ re-render check cannot stand in for this: it catches a marker that used
+## to work and stopped, never one that never worked, because the committed
+## manifest matches the broken render. Set CRD_ENRICHER_STRICT= to opt out while
+## debugging a marker.
+##
+## Only enrich-crds-local passes it: enrich-crds runs the released
+## $(CRD_ENRICHER_VERSION) binary, which predates the flag and would reject it as
+## an unknown argument.
+CRD_ENRICHER_STRICT ?= strict
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 CLIENT_GEN ?= $(LOCALBIN)/client-gen
 INFORMER_GEN ?= $(LOCALBIN)/informer-gen
@@ -704,6 +714,7 @@ enrich-crds: generate-crds crd-enricher ## Add custom x-doc-* fields to the gene
 ##
 ##   make enrich-crds-local
 ##   make enrich-crds-local CRD_ENRICHER_FLAGS=auto-examples
+##   make enrich-crds-local CRD_ENRICHER_STRICT=       # tolerate warnings
 .PHONY: enrich-crds-local
 enrich-crds-local: generate-crds crd-enricher-local ## Enrich CRDs with the local (branch) crd-enricher build.
 	@echo "Enriching CRDs with the local crd-enricher$(if $(CRD_ENRICHER_FLAGS), (flags: $(CRD_ENRICHER_FLAGS)),)..."
@@ -711,6 +722,7 @@ enrich-crds-local: generate-crds crd-enricher-local ## Enrich CRDs with the loca
 		paths="./deckhouse-controller/pkg/apis/deckhouse.io/..." \
 		crds=$(CURDIR)/bin/crd/bases \
 		dir=$(CURDIR) \
+		$(CRD_ENRICHER_STRICT) \
 		$(CRD_ENRICHER_FLAGS)
 
 ## Run the crd-enricher module's unit and golden tests. Pass

--- a/pkg/crd-enricher/README.md
+++ b/pkg/crd-enricher/README.md
@@ -562,10 +562,20 @@ changed, err := crdenricher.Run(crdenricher.Options{
 })
 ```
 
-`Run` returns the list of modified files. Non-fatal problems (markers pointing at
-schema nodes that don't exist, unresolvable `raw:` and `unset:` paths,
-sensitive-data on the root) are collected as warnings; use `RunWithWarnings` to
-get them alongside the file list. The CLI prints them to stderr.
+`RunWithWarnings` is the same call returning the non-fatal problems as well
+(markers pointing at schema nodes that don't exist, unresolvable `raw:` and
+`unset:` paths, sensitive-data on the root). Prefer it: every warning means a
+marker did not do what its author wrote it to do, and nothing else in the run says
+so. `Run` keeps the older two-value signature and drops them.
+
+```go
+changed, warnings, err := crdenricher.RunWithWarnings(opts)
+```
+
+Each warning names the manifest and the Go declaration it came from
+(`things.yaml: ThingStatus.Conditions: unset path … is not present in the
+schema`), and repeats are collapsed — the same marker is visited once per version
+of every document naming its kind.
 
 ## Output layout
 

--- a/pkg/crd-enricher/README.md
+++ b/pkg/crd-enricher/README.md
@@ -520,9 +520,9 @@ changed, err := crdenricher.Run(crdenricher.Options{
 ```
 
 `Run` returns the list of modified files. Non-fatal problems (markers pointing at
-schema nodes that don't exist, unresolvable `raw:` and `unset:` paths, sensitive-data on the
-root) are collected as warnings — construct an `Enricher` directly if you want to
-inspect `Enricher.Warnings()`.
+schema nodes that don't exist, unresolvable `raw:` and `unset:` paths,
+sensitive-data on the root) are collected as warnings; use `RunWithWarnings` to
+get them alongside the file list. The CLI prints them to stderr.
 
 ## Output layout
 

--- a/pkg/crd-enricher/README.md
+++ b/pkg/crd-enricher/README.md
@@ -166,16 +166,35 @@ that is `openAPIV3Schema`).
 
 The enricher starts from the **root types** and follows the fields from there, so
 a type that is not reachable from a root is never visited and its markers never
-applied. A root is a type that carries either spelling controller-gen accepts:
+applied. A root is any type that **embeds both `metav1.TypeMeta` and
+`metav1.ObjectMeta`**:
 
 ```go
-// +kubebuilder:object:root=true                                        // the kubebuilder marker
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object  // the pre-kubebuilder one
+type SCSIStorageClass struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	// ...
+}
 ```
 
-`+kubebuilder:object:root=false` opts a type out, and
-`+k8s:deepcopy-gen=true` on its own is not enough — it asks for `DeepCopy`, not
-for a CRD.
+That is the rule and the whole rule, because it is the one controller-gen's CRD
+generator uses — [`FindKubeKinds`](https://github.com/kubernetes-sigs/controller-tools/blob/v0.19.0/pkg/crd/gen.go#L265)
+*"locates all types that contain TypeMeta and ObjectMeta (and thus may be a
+Kubernetes object)"* and renders a CRD for every one of them.
+
+> **The root markers do not gate CRD generation.** Neither
+> `+kubebuilder:object:root=true` nor the pre-kubebuilder
+> `+k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object` is read by
+> the CRD generator at all — they are read by controller-gen's *deepcopy*
+> generator and decide whether the type gets a `DeepCopyObject` method. In
+> particular **`+kubebuilder:object:root=false` is not an opt-out from getting a
+> CRD**: a type embedding both metav1 structs gets its manifest regardless, and
+> its `crd-enricher` markers have to be applied to it.
+>
+> The enricher does accept either marker as a **fallback**, for a type that
+> declares itself an object without embedding the metav1 structs. A spurious root
+> is harmless: roots are matched against the `kind` of an actual CRD document, so
+> a type no manifest names is never visited.
 
 ### `examples` — sample values
 

--- a/pkg/crd-enricher/README.md
+++ b/pkg/crd-enricher/README.md
@@ -454,7 +454,7 @@ written to remove something, so a marker that has outlived its target — becaus
 the vendored godoc changed, or the path was mistyped — is worth hearing about
 rather than accepting silently.
 
-Two more things it will not do quietly:
+Three more things it will not do quietly:
 
 - **`type` and `items` are refused.** A structural schema must declare the `type`
   of every node and the `items` of every array, so removing one produces a
@@ -462,10 +462,18 @@ Two more things it will not do quietly:
   value: must be specified`) — with nothing in the refusal pointing back at the
   marker. `unset:items` and `unset:<path>.type` therefore warn and change
   nothing.
-- **Emptying a node is reported.** `unset:items.description` on an `items` whose
-  only key was `description` leaves `items: {}`, which is a different schema from
-  no `items` at all. The removal still happens — you asked for it — but you hear
-  about it.
+- **Emptying a node is refused.** `unset:items.description` on an `items` whose
+  only key was `description` would leave `items: {}`, which the apiserver rejects
+  the same way (`must not be empty for specified object fields`). Same reasoning
+  as above, so the same answer: the marker warns and the schema is left alone.
+  Warnings are not fatal unless `strict` is passed, so obeying here would ship a
+  document that fails at apply time.
+- **Removing a validation key is reported.** `required`, `enum`, `pattern`,
+  `maxLength`, `x-kubernetes-validations` and the rest of that vocabulary are
+  *obeyed* — the resulting document applies cleanly — and that is exactly why the
+  removal is worth a line: the API then admits values it used to reject, and a
+  re-render gate over a committed `crds/` cannot see it, because the committed
+  manifest and the render both come from the same marker.
 
 ### `crd:<key>` — CRD-level settings (type-level only)
 

--- a/pkg/crd-enricher/README.md
+++ b/pkg/crd-enricher/README.md
@@ -162,6 +162,21 @@ Markers can be attached to **struct fields** and to **struct types**. A
 type-level marker applies to the schema node of that type (for the root type,
 that is `openAPIV3Schema`).
 
+### Which types the enricher walks
+
+The enricher starts from the **root types** and follows the fields from there, so
+a type that is not reachable from a root is never visited and its markers never
+applied. A root is a type that carries either spelling controller-gen accepts:
+
+```go
+// +kubebuilder:object:root=true                                        // the kubebuilder marker
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object  // the pre-kubebuilder one
+```
+
+`+kubebuilder:object:root=false` opts a type out, and
+`+k8s:deepcopy-gen=true` on its own is not enough — it asks for `DeepCopy`, not
+for a CRD.
+
 ### `examples` — sample values
 
 Rendered as `x-doc-examples`. The marker may be **repeated**; each value is
@@ -444,6 +459,15 @@ annotation and switches the file to the curated style (no leading `---`).
 > natively by controller-gen from `+kubebuilder:metadata:labels` and
 > `+kubebuilder:metadata:annotations`.
 
+**Moving a hand-written `crds/` to generation?** `minimal=true` plus
+`preserveUnknownFields=false` is the pair that reproduces the shape a curated
+Deckhouse CRD already has. Without them the rendered file gains `listKind`, the
+implicit `apiVersion`/`kind`/`metadata` root properties and the generator-version
+annotation — all of which then show up on the module's public API reference page,
+turning a refactor into a documentation change. `stripFormat` is the one to leave
+alone unless the committed manifest carries no `format` at all: dropping every
+`int32` also drops the ones the manifest does declare.
+
 ## Automatic example generation
 
 > **Opt-in.** This is **off by default**. Without it, the enricher only applies
@@ -595,6 +619,20 @@ indentation.
 - **Values are YAML, not strings.** `examples=1` yields the integer `1`;
   `examples="1"` yields the string `"1"`; `stripFormat=[int32]` yields a list.
   Quote when you need a string.
+- **Prose containing `: ` has to be quoted.** A description like
+  ``raw:description=Ready is False while deleting (`reason: Deleting`)`` parses as
+  a *mapping*, not a string, and the mapping is what lands in the schema. The
+  enricher warns (`the value contains ": " and parsed as a mapping, not a
+  string`), but the manifest is already wrong by then — quote the value:
+  ``raw:description="Ready is False while deleting (`reason: Deleting`)"``. A
+  multi-line value is the same double-quoted form with `\n` in it; the renderer
+  turns it into a `|-` block.
+- **gofmt rewrites some quotes inside doc comments.** The doc-comment formatter
+  turns a doubled ASCII quote `''` into `”` and a doubled backtick into `“`, so a
+  CEL rule written as `self.x != ''` is silently corrupted the next time anyone
+  runs `gofmt`. Spell the empty string `\"\"` instead, and keep `gofmt -l` clean
+  *before* diffing the rendered manifests — otherwise the formatter edits text you
+  have already checked.
 - **Example generation is opt-in.** Without the `auto-examples` flag only the
   `x-doc-examples` you write explicitly are emitted; the synthesized root/tree
   examples are not.

--- a/pkg/crd-enricher/README.md
+++ b/pkg/crd-enricher/README.md
@@ -58,6 +58,7 @@ exception of `x-kubernetes-sensitive-data`, which the apiserver acts on.
 | `x-doc-deprecated` | `deckhouse:documentation:deprecated` | Marks a field as deprecated in the docs (renders a deprecation badge). |
 | `x-kubernetes-sensitive-data` | `deckhouse:sensitive-data` | **Behavioral**, not documentation. Tells the apiserver's `CRDSensitiveData` feature to encrypt the value in etcd, filter it by RBAC and mask it in audit logs. |
 | *(arbitrary standard field)* | `raw:<key>` | Injects a plain schema field controller-gen cannot produce for a given Go type (e.g. `pattern` on a `metav1.Duration`, or an overridden `description`). |
+| *(arbitrary standard field, removed)* | `unset:<key>` | Deletes a plain schema field controller-gen emitted and the manifest is not supposed to carry (e.g. the `items.description` it renders from the `metav1.Condition` godoc). Takes no value. |
 
 Why not just use `kubebuilder:default` / native `example`?
 
@@ -153,6 +154,7 @@ The value after `=` is parsed as **YAML**, so scalars, lists and maps all work.
 +crd-enricher:deckhouse:documentation:<entity>[=<value>]   # documentation fields
 +crd-enricher:deckhouse:sensitive-data                     # sensitive field flag
 +crd-enricher:raw:<key>[=<value>]                          # raw schema injection
++crd-enricher:unset:<key>                                   # raw schema removal
 +crd-enricher:crd:<key>[=<value>]                          # CRD-level setting (type-level only)
 ```
 
@@ -379,6 +381,39 @@ This also works to override a shared item description on a slice field, e.g.
 `raw:items.description` or `raw:items.properties.reason.description` on a
 `[]metav1.Condition` field.
 
+### `unset:<key>` — remove a standard schema field
+
+`raw:<key>` can only overwrite. `unset:<key>` is its mirror: it deletes `<key>`,
+walking a **dotted** path into nested nodes exactly as `raw:` does. It takes no
+value — a field set to `null` is a different schema from a field that is not
+there.
+
+It exists for the nodes controller-gen fills in from vendored types.
+controller-gen writes a `description` for every node it can reach, so a
+`[]metav1.Condition` field gets `items.description` from the `metav1.Condition`
+godoc of whatever `k8s.io/apimachinery` the API module happens to pin. A manifest
+that never carried that text cannot be reproduced from the Go types while `raw:`
+is the only tool available — the best you can do is pin the upstream sentence in
+a marker, which puts a generic *"Condition contains details for one aspect of the
+current state of this API Resource"* on the reference page and leaves it to be
+translated in every doc-ru overlay.
+
+```go
+// +optional
+// +listType=map
+// +listMapKey=type
+// +crd-enricher:unset:items.description
+// +crd-enricher:raw:items.properties.type.description=Condition type. `Ready` is `True` once the StorageClass is in place.
+Conditions []metav1.Condition `json:"conditions,omitempty"`
+```
+
+→ `items.description` is gone; the descriptions the module does want stay.
+
+A `<key>` that is already absent is **a warning, not a no-op**: the marker was
+written to remove something, so a marker that has outlived its target — because
+the vendored godoc changed, or the path was mistyped — is worth hearing about
+rather than accepting silently.
+
 ### `crd:<key>` — CRD-level settings (type-level only)
 
 Placed on the **root type**, these configure the CRD document itself — things
@@ -485,7 +520,7 @@ changed, err := crdenricher.Run(crdenricher.Options{
 ```
 
 `Run` returns the list of modified files. Non-fatal problems (markers pointing at
-schema nodes that don't exist, unresolvable `raw:` paths, sensitive-data on the
+schema nodes that don't exist, unresolvable `raw:` and `unset:` paths, sensitive-data on the
 root) are collected as warnings — construct an `Enricher` directly if you want to
 inspect `Enricher.Warnings()`.
 
@@ -552,6 +587,9 @@ indentation.
 - **Dotted `raw:` paths must already exist.** `raw:items.description` only works
   if controller-gen already produced `items`; otherwise it warns rather than
   creating the node.
+- **`unset:` must find something to remove.** `unset:items.description` warns if
+  `items` was never emitted *or* if it carries no `description` — the marker
+  removing nothing is the case you want to be told about.
 - **`sensitive-data` on the root type is dropped** with a warning — put it on
   `spec` or a specific field.
 - **Values are YAML, not strings.** `examples=1` yields the integer `1`;

--- a/pkg/crd-enricher/README.md
+++ b/pkg/crd-enricher/README.md
@@ -153,8 +153,8 @@ The value after `=` is parsed as **YAML**, so scalars, lists and maps all work.
 ```
 +crd-enricher:deckhouse:documentation:<entity>[=<value>]   # documentation fields
 +crd-enricher:deckhouse:sensitive-data                     # sensitive field flag
-+crd-enricher:raw:<key>[=<value>]                          # raw schema injection
-+crd-enricher:unset:<key>                                   # raw schema removal
++crd-enricher:raw:<key>=<value>                            # raw schema injection
++crd-enricher:unset:<key>                                  # raw schema removal
 +crd-enricher:crd:<key>[=<value>]                          # CRD-level setting (type-level only)
 ```
 
@@ -386,10 +386,16 @@ type PackageRepositorySpecRegistry struct {
 ### `raw:<key>` — inject an arbitrary standard schema field
 
 Some standard schema fields cannot be produced by controller-gen for certain Go
-types. `raw:<key>` sets `<key>` **directly** (not under an `x-doc-*` prefix). A
-**dotted** `<key>` walks into nested schema nodes; the intermediate nodes must
-already exist (controller-gen must have emitted them), otherwise you get a
-warning instead of a silently grown schema.
+types. `raw:<key>=<value>` sets `<key>` **directly** (not under an `x-doc-*`
+prefix). A **dotted** `<key>` walks into nested schema nodes; the intermediate
+nodes must already exist (controller-gen must have emitted them), otherwise you
+get a warning instead of a silently grown schema.
+
+The value is **required**. `raw:<key>` with no `=` would decode to `null` and
+write `<key>: null`, which is never a valid schema for the fields anyone reaches
+for this marker with — and the one thing its author might have meant by it,
+taking the field out, is what [`unset:<key>`](#unsetkey--remove-a-standard-schema-field)
+is for. So it is refused with a warning naming that marker.
 
 Set a `pattern` on a `metav1.Duration` (which controller-gen renders as an
 opaque string):
@@ -447,6 +453,19 @@ A `<key>` that is already absent is **a warning, not a no-op**: the marker was
 written to remove something, so a marker that has outlived its target — because
 the vendored godoc changed, or the path was mistyped — is worth hearing about
 rather than accepting silently.
+
+Two more things it will not do quietly:
+
+- **`type` and `items` are refused.** A structural schema must declare the `type`
+  of every node and the `items` of every array, so removing one produces a
+  manifest the apiserver rejects at `kubectl apply` time (`items: Required
+  value: must be specified`) — with nothing in the refusal pointing back at the
+  marker. `unset:items` and `unset:<path>.type` therefore warn and change
+  nothing.
+- **Emptying a node is reported.** `unset:items.description` on an `items` whose
+  only key was `description` leaves `items: {}`, which is a different schema from
+  no `items` at all. The removal still happens — you asked for it — but you hear
+  about it.
 
 ### `crd:<key>` — CRD-level settings (type-level only)
 
@@ -640,9 +659,16 @@ indentation.
 - **Dotted `raw:` paths must already exist.** `raw:items.description` only works
   if controller-gen already produced `items`; otherwise it warns rather than
   creating the node.
+- **`raw:` needs a value.** `raw:items.description` with no `=` is refused: it
+  would write `description: null`. Use `unset:items.description` to take the field
+  out.
 - **`unset:` must find something to remove.** `unset:items.description` warns if
   `items` was never emitted *or* if it carries no `description` — the marker
   removing nothing is the case you want to be told about.
+- **`unset:` will not break the structural schema.** `unset:type` and
+  `unset:items` are refused, because the apiserver requires both and would reject
+  the manifest with a message that says nothing about the marker. Emptying a node
+  (`items: {}`) is allowed but reported.
 - **`sensitive-data` on the root type is dropped** with a warning — put it on
   `spec` or a specific field.
 - **Values are YAML, not strings.** `examples=1` yields the integer `1`;
@@ -655,7 +681,10 @@ indentation.
   string`), but the manifest is already wrong by then — quote the value:
   ``raw:description="Ready is False while deleting (`reason: Deleting`)"``. A
   multi-line value is the same double-quoted form with `\n` in it; the renderer
-  turns it into a `|-` block.
+  turns it into a `|-` block. The check cannot tell this from a *deliberate*
+  single-pair mapping written bare, so if you really do want one, write it in the
+  flow form — `raw:x-kubernetes-validations={rule: self != \"\"}` — which is left
+  alone.
 - **gofmt rewrites some quotes inside doc comments.** The doc-comment formatter
   turns a doubled ASCII quote `''` into `”` and a doubled backtick into `“`, so a
   CEL rule written as `self.x != ''` is silently corrupted the next time anyone
@@ -671,5 +700,3 @@ indentation.
   marker is ignored with a warning.
 - **Run order matters.** Always run `crd-enricher` *after* controller-gen against
   the *same* directory and package paths. It edits in place and is idempotent.
-</content>
-</invoke>

--- a/pkg/crd-enricher/README.md
+++ b/pkg/crd-enricher/README.md
@@ -541,7 +541,7 @@ never overwritten by generation.
 ## CLI reference
 
 ```
-crd-enricher paths=<go-packages> crds=<crd-dir> [dir=<workdir>] [auto-examples] [reindent]
+crd-enricher paths=<go-packages> crds=<crd-dir> [dir=<workdir>] [auto-examples] [reindent] [strict]
 ```
 
 | Argument | Meaning |
@@ -552,6 +552,7 @@ crd-enricher paths=<go-packages> crds=<crd-dir> [dir=<workdir>] [auto-examples] 
 | `dir=` | Optional working directory used to resolve the package patterns. Defaults to the current directory. |
 | `auto-examples`, `--auto-examples`, `auto-examples=<bool>` | Enable [automatic example generation](#automatic-example-generation) (**off by default**). Explicit `examples` markers are applied regardless. |
 | `reindent`, `--reindent`, `reindent=<bool>` | Encode the output with **indented** block sequences (the `goyaml.v3` layout) instead of the default flush `sigs.k8s.io/yaml` layout (**off by default**). Key ordering is unaffected. See [Output layout](#output-layout). |
+| `strict`, `--strict`, `strict=<bool>` | Exit non-zero when any warning was printed (**off by default**). See [Warnings and gotchas](#warnings-and-gotchas). |
 | `-h`, `--help`, `help` | Print usage. |
 
 Example:
@@ -565,7 +566,8 @@ crd-enricher \
 
 On success it prints one `enriched <file>` line per modified file, or
 `no CRDs required enrichment` when nothing changed. It exits non-zero on error
-(e.g. unloadable packages or an unknown argument).
+(e.g. unloadable packages or an unknown argument), and — with `strict` — when
+anything was warned about.
 
 ### Using it as a library
 
@@ -700,3 +702,9 @@ indentation.
   marker is ignored with a warning.
 - **Run order matters.** Always run `crd-enricher` *after* controller-gen against
   the *same* directory and package paths. It edits in place and is idempotent.
+- **Warnings are not fatal unless you ask.** They always go to stderr and the run
+  exits 0, so adopting the tool cannot turn a generation step red on its own. Pass
+  `strict` in CI once the warnings are clean. A re-render gate over a committed
+  `crds/` is **not** a substitute: it catches a marker that used to work and
+  stopped, but never one that never worked — the committed manifest matches the
+  broken render, and the gate stays green for as long as nobody reads stderr.

--- a/pkg/crd-enricher/cmd/crd-enricher/main.go
+++ b/pkg/crd-enricher/cmd/crd-enricher/main.go
@@ -96,9 +96,18 @@ func run(args []string) error {
 		}
 	}
 
-	changed, err := crdenricher.Run(opts)
+	changed, warnings, err := crdenricher.RunWithWarnings(opts)
 	if err != nil {
 		return err
+	}
+
+	// Warnings go to stderr rather than being dropped: each one is a marker that
+	// did not do what its author wrote it to do -- a path that does not resolve,
+	// a field the schema has no property for -- and the enrichment carries on
+	// regardless, so nothing else would say so. They are not fatal: a repository
+	// that gates its crds/ on a re-render still sees the real difference there.
+	for _, w := range warnings {
+		fmt.Fprintf(os.Stderr, "warning: %s\n", w)
 	}
 
 	for _, file := range changed {

--- a/pkg/crd-enricher/cmd/crd-enricher/main.go
+++ b/pkg/crd-enricher/cmd/crd-enricher/main.go
@@ -40,6 +40,7 @@ func main() {
 
 func run(args []string) error {
 	var opts crdenricher.Options
+	var strict bool
 
 	for _, arg := range args {
 		switch {
@@ -79,6 +80,19 @@ func run(args []string) error {
 			}
 			opts.GenerateExamples = value
 
+		// Strictness is opt-in so existing invocations keep their exit code.
+		// Accept the value-less flag forms and an explicit boolean, like the
+		// others.
+		case arg == "strict", arg == "--strict":
+			strict = true
+
+		case strings.HasPrefix(arg, "strict="):
+			value, err := parseBool(trimQuotes(strings.TrimPrefix(arg, "strict=")))
+			if err != nil {
+				return err
+			}
+			strict = value
+
 		// Indented output is opt-in. Accept the value-less flag forms (reindent /
 		// --reindent) and an explicit boolean (reindent=true).
 		case arg == "reindent", arg == "--reindent":
@@ -104,8 +118,7 @@ func run(args []string) error {
 	// Warnings go to stderr rather than being dropped: each one is a marker that
 	// did not do what its author wrote it to do -- a path that does not resolve,
 	// a field the schema has no property for -- and the enrichment carries on
-	// regardless, so nothing else would say so. They are not fatal: a repository
-	// that gates its crds/ on a re-render still sees the real difference there.
+	// regardless, so nothing else would say so.
 	for _, w := range warnings {
 		fmt.Fprintf(os.Stderr, "warning: %s\n", w)
 	}
@@ -115,6 +128,16 @@ func run(args []string) error {
 	}
 	if len(changed) == 0 {
 		fmt.Println("no CRDs required enrichment")
+	}
+
+	// Warnings are not fatal by default, so a repository can adopt the tool
+	// without its generation step turning red. They have to be able to become
+	// fatal, though: a re-render gate over a committed crds/ catches a marker
+	// that used to work and stopped, but never one that never worked at all --
+	// the committed manifest matches the broken render, and the gate stays green
+	// for as long as nobody looks at stderr.
+	if strict && len(warnings) > 0 {
+		return fmt.Errorf("%d warning(s) with strict enabled", len(warnings))
 	}
 
 	return nil
@@ -142,7 +165,7 @@ func usage() {
 	fmt.Print(`crd-enricher enriches controller-gen CRDs with custom x-doc-* schema fields.
 
 Usage:
-  crd-enricher paths=<go-packages> crds=<crd-dir> [dir=<workdir>] [auto-examples] [reindent]
+  crd-enricher paths=<go-packages> crds=<crd-dir> [dir=<workdir>] [auto-examples] [reindent] [strict]
 
 Arguments:
   paths=        Comma separated Go package patterns with the API structs (repeatable).
@@ -156,6 +179,11 @@ Arguments:
   reindent      Encode the output with indented block sequences (the goyaml.v3
                 layout) instead of the flush sigs.k8s.io/yaml layout. Off by
                 default. Accepts reindent, --reindent or reindent=<bool>.
+  strict        Exit non-zero when any warning was printed. Off by default.
+                Warnings always go to stderr; this makes a CI job able to fail
+                on a marker that did nothing, which a re-render gate over a
+                committed crds/ cannot see if the marker never worked.
+                Accepts strict, --strict or strict=<bool>.
 
 Example:
   crd-enricher paths="./deckhouse-controller/pkg/apis/deckhouse.io/..." crds=bin/crd/bases auto-examples

--- a/pkg/crd-enricher/cmd/crd-enricher/main_test.go
+++ b/pkg/crd-enricher/cmd/crd-enricher/main_test.go
@@ -1,0 +1,221 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The library is covered by its own tests; what is covered here is the half the
+// modules actually consume. Every repository using this tool invokes the binary
+// through `go tool`, never the package, so the CLI's stderr and its exit code are
+// the only channels they have.
+
+// fixtureRoot is the enricher package directory, which holds the testdata the
+// library tests use. The command lives one level down, so paths are relative to
+// it.
+const fixtureRoot = "../.."
+
+// captureStderr runs fn with os.Stderr redirected and returns what it wrote.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	saved := os.Stderr
+	os.Stderr = w
+	t.Cleanup(func() { os.Stderr = saved })
+
+	done := make(chan string, 1)
+	go func() {
+		out, _ := io.ReadAll(r)
+		done <- string(out)
+	}()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close pipe: %v", err)
+	}
+	os.Stderr = saved
+	return <-done
+}
+
+// crdDirWith copies one CRD fixture into a fresh directory, since the enricher
+// rewrites files in place.
+func crdDirWith(t *testing.T, fixture string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	src, err := os.ReadFile(filepath.Join(fixtureRoot, "testdata", "crd", fixture))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, fixture), src, 0o644); err != nil {
+		t.Fatalf("write fixture copy: %v", err)
+	}
+	return dir
+}
+
+// baseArgs points the command at the library's fixture package and the given CRD
+// directory.
+func baseArgs(crdDir string) []string {
+	return []string{
+		"paths=./testdata/api/v1alpha1",
+		"crds=" + crdDir,
+		"dir=" + fixtureRoot,
+	}
+}
+
+// TestRunPrintsWarningsAndSucceeds pins the contract of the warning channel: the
+// problem reaches stderr, and the run still succeeds so adopting the tool cannot
+// turn a generation step red on its own.
+func TestRunPrintsWarningsAndSucceeds(t *testing.T) {
+	crdDir := crdDirWith(t, "quoting.yaml")
+
+	var err error
+	stderr := captureStderr(t, func() { err = run(baseArgs(crdDir)) })
+
+	if err != nil {
+		t.Fatalf("run() = %v, want nil: a warning must not be fatal by default", err)
+	}
+	if !strings.Contains(stderr, "warning: ") {
+		t.Fatalf("stderr carried no warning: %q", stderr)
+	}
+	if !strings.Contains(stderr, "parsed as a mapping") {
+		t.Errorf("stderr does not name the problem: %q", stderr)
+	}
+	// Without the location the message cannot be acted on in a repository where
+	// the same marker appears in a dozen CRDs.
+	if !strings.Contains(stderr, "quoting.yaml") {
+		t.Errorf("stderr does not name the manifest: %q", stderr)
+	}
+	if !strings.Contains(stderr, "QuotingSpec.Phase") {
+		t.Errorf("stderr does not name the Go declaration: %q", stderr)
+	}
+}
+
+// TestRunStrictFailsOnWarnings pins the opt-in exit code. A re-render gate over a
+// committed crds/ cannot see a marker that never worked, so this is the only way
+// for CI to fail on one.
+func TestRunStrictFailsOnWarnings(t *testing.T) {
+	crdDir := crdDirWith(t, "quoting.yaml")
+
+	var err error
+	stderr := captureStderr(t, func() { err = run(append(baseArgs(crdDir), "strict")) })
+
+	if err == nil {
+		t.Fatal("run() = nil, want an error: strict must fail when a warning was printed")
+	}
+	if !strings.Contains(stderr, "parsed as a mapping") {
+		t.Errorf("strict must still print the warning it failed on: %q", stderr)
+	}
+}
+
+// TestRunStrictSucceedsWithoutWarnings keeps strict from becoming a blanket
+// failure: a clean run passes with it on, which is what makes it usable in CI.
+func TestRunStrictSucceedsWithoutWarnings(t *testing.T) {
+	crdDir := crdDirWith(t, "bare.yaml")
+
+	var err error
+	stderr := captureStderr(t, func() { err = run(append(baseArgs(crdDir), "strict")) })
+
+	if err != nil {
+		t.Fatalf("run() = %v, want nil: nothing warned about this fixture", err)
+	}
+	if strings.Contains(stderr, "warning: ") {
+		t.Errorf("unexpected warning: %q", stderr)
+	}
+}
+
+// TestRunArgumentParsing covers the argument table, which had no tests at all:
+// every branch either sets an option or is a usage error, and a silent
+// misparse would look like the tool doing nothing.
+func TestRunArgumentParsing(t *testing.T) {
+	crdDir := crdDirWith(t, "bare.yaml")
+
+	for _, tc := range []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name: "the controller-gen output alias is accepted for crds=",
+			args: []string{"paths=./testdata/api/v1alpha1", "dir=" + fixtureRoot,
+				"output:crd:artifacts:config=" + crdDir},
+		},
+		{
+			name: "quoted values are unwrapped",
+			args: []string{`paths="./testdata/api/v1alpha1"`, `dir="` + fixtureRoot + `"`,
+				`crds="` + crdDir + `"`},
+		},
+		{
+			name: "comma separated paths",
+			args: append(baseArgs(crdDir), "auto-examples=false", "reindent=false", "strict=false"),
+		},
+		{
+			name:    "an unknown argument is refused rather than ignored",
+			args:    append(baseArgs(crdDir), "nonsense=1"),
+			wantErr: `unknown argument "nonsense=1"`,
+		},
+		{
+			name:    "a malformed boolean is refused",
+			args:    append(baseArgs(crdDir), "reindent=perhaps"),
+			wantErr: `invalid boolean value "perhaps"`,
+		},
+		{
+			name:    "paths is required",
+			args:    []string{"crds=" + crdDir},
+			wantErr: "no package paths provided",
+		},
+		{
+			name:    "crds is required",
+			args:    []string{"paths=./testdata/api/v1alpha1", "dir=" + fixtureRoot},
+			wantErr: "no CRD directory provided",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var err error
+			captureStderr(t, func() { err = run(tc.args) })
+
+			switch {
+			case tc.wantErr == "" && err != nil:
+				t.Fatalf("run() = %v, want nil", err)
+			case tc.wantErr != "" && err == nil:
+				t.Fatalf("run() = nil, want an error containing %q", tc.wantErr)
+			case tc.wantErr != "" && !strings.Contains(err.Error(), tc.wantErr):
+				t.Errorf("run() = %v, want an error containing %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestRunHelp keeps the help path from reaching the enricher: it takes no
+// arguments and must not need them.
+func TestRunHelp(t *testing.T) {
+	for _, arg := range []string{"-h", "--help", "help"} {
+		t.Run(arg, func(t *testing.T) {
+			if err := run([]string{arg}); err != nil {
+				t.Errorf("run(%q) = %v, want nil", arg, err)
+			}
+		})
+	}
+}

--- a/pkg/crd-enricher/doc.go
+++ b/pkg/crd-enricher/doc.go
@@ -28,12 +28,13 @@
 // with the canonical "crd-enricher:" prefix and comes in two shapes:
 //
 //	+crd-enricher:raw:<key>[=<value>]                        // raw schema injection
+//	+crd-enricher:unset:<key>                                // raw schema removal
 //	+crd-enricher:deckhouse:documentation:<entity>[=<value>] // documentation entity
 //	+crd-enricher:crd:<key>[=<value>]                        // CRD-level setting
 //	+crd-enricher:deckhouse:sensitive-data                   // sensitive field flag
 //
-// The raw entity injects a standard schema field and lives directly under the
-// prefix; the documentation entities (examples, deprecated, default) carry the
+// The raw and unset entities inject and remove a standard schema field and live
+// directly under the prefix; the documentation entities (examples, deprecated, default) carry the
 // extra "deckhouse:documentation" sub-namespace; the crd entity configures the
 // CRD itself and carries the shorter "deckhouse" sub-namespace. No bare or
 // legacy form is recognised:
@@ -69,6 +70,17 @@
 //
 //   - raw:<key> — injects an arbitrary standard schema field named <key>
 //     directly (a dotted <key> walks into nested schema nodes);
+//
+//   - unset:<key> — deletes the standard schema field named <key>, the mirror of
+//     raw:<key> and the only way to take a node out rather than overwrite it.
+//     controller-gen renders a description for every node it can reach, the
+//     vendored ones included: items.description on a []metav1.Condition field
+//     comes from the metav1.Condition godoc of whatever apimachinery the API
+//     module pins, and a manifest that is not supposed to carry it cannot be
+//     reproduced from the Go types while raw: is the only tool. The marker takes
+//     no value, since a field set to null is not the same schema as a field that
+//     is absent, and a <key> that is already missing is reported as a warning so
+//     a marker that has outlived its target does not pass for a working one;
 //
 //   - sensitive-data — a schema-level flag rendered as
 //     x-kubernetes-sensitive-data: true. It marks a field (or an object/array

--- a/pkg/crd-enricher/doc.go
+++ b/pkg/crd-enricher/doc.go
@@ -84,8 +84,13 @@
 //     is absent, and a <key> that is already missing is reported as a warning so
 //     a marker that has outlived its target does not pass for a working one. A
 //     <key> naming a field the structural schema requires (type, items) is
-//     refused outright: obeying would produce a manifest the apiserver rejects,
-//     with nothing in the refusal pointing back at the marker;
+//     refused outright, and so is a removal that would leave the parent node an
+//     empty mapping: obeying either would produce a manifest the apiserver
+//     rejects, with nothing in the refusal pointing back at the marker. Removing
+//     a validation key (required, enum, pattern, x-kubernetes-validations and the
+//     rest of that vocabulary) is obeyed but reported, because the result applies
+//     cleanly while the API starts admitting values it used to reject, and a
+//     re-render gate cannot see it;
 //
 //   - sensitive-data — a schema-level flag rendered as
 //     x-kubernetes-sensitive-data: true. It marks a field (or an object/array

--- a/pkg/crd-enricher/doc.go
+++ b/pkg/crd-enricher/doc.go
@@ -25,19 +25,19 @@
 //
 // Markers are regular Go comments that start with a plus sign, exactly like
 // the markers consumed by controller-gen. Every enricher marker is namespaced
-// with the canonical "crd-enricher:" prefix and comes in two shapes:
+// with the canonical "crd-enricher:" prefix and comes in one of these shapes:
 //
-//	+crd-enricher:raw:<key>[=<value>]                        // raw schema injection
+//	+crd-enricher:raw:<key>=<value>                          // raw schema injection
 //	+crd-enricher:unset:<key>                                // raw schema removal
 //	+crd-enricher:deckhouse:documentation:<entity>[=<value>] // documentation entity
 //	+crd-enricher:crd:<key>[=<value>]                        // CRD-level setting
 //	+crd-enricher:deckhouse:sensitive-data                   // sensitive field flag
 //
 // The raw and unset entities inject and remove a standard schema field and live
-// directly under the prefix; the documentation entities (examples, deprecated, default) carry the
-// extra "deckhouse:documentation" sub-namespace; the crd entity configures the
-// CRD itself and carries the shorter "deckhouse" sub-namespace. No bare or
-// legacy form is recognised:
+// directly under the prefix, as does the crd entity, which configures the CRD
+// document itself; the documentation entities (examples, deprecated, default)
+// carry the extra "deckhouse:documentation" sub-namespace, and sensitive-data
+// carries the shorter "deckhouse" one. No bare or legacy form is recognised:
 //
 //	type ModuleSourceSpec struct {
 //		// +crd-enricher:deckhouse:documentation:default=3m
@@ -68,8 +68,10 @@
 //   - default — rendered as x-doc-default set to the parsed YAML value (any
 //     valued simple entity becomes x-doc-<entity>);
 //
-//   - raw:<key> — injects an arbitrary standard schema field named <key>
-//     directly (a dotted <key> walks into nested schema nodes);
+//   - raw:<key>=<value> — injects an arbitrary standard schema field named <key>
+//     directly (a dotted <key> walks into nested schema nodes). The value is
+//     required: without one the marker would write null, and the one thing its
+//     author might have meant by that is what unset:<key> is for;
 //
 //   - unset:<key> — deletes the standard schema field named <key>, the mirror of
 //     raw:<key> and the only way to take a node out rather than overwrite it.
@@ -80,7 +82,10 @@
 //     reproduced from the Go types while raw: is the only tool. The marker takes
 //     no value, since a field set to null is not the same schema as a field that
 //     is absent, and a <key> that is already missing is reported as a warning so
-//     a marker that has outlived its target does not pass for a working one;
+//     a marker that has outlived its target does not pass for a working one. A
+//     <key> naming a field the structural schema requires (type, items) is
+//     refused outright: obeying would produce a manifest the apiserver rejects,
+//     with nothing in the refusal pointing back at the marker;
 //
 //   - sensitive-data — a schema-level flag rendered as
 //     x-kubernetes-sensitive-data: true. It marks a field (or an object/array

--- a/pkg/crd-enricher/doc.go
+++ b/pkg/crd-enricher/doc.go
@@ -116,6 +116,17 @@
 // themselves. Type-level markers are applied to the schema node of the type
 // (for the root type this is openAPIV3Schema).
 //
+// The enricher walks the root types and the fields reachable from them, so a
+// type no root reaches is never visited. A root is one that carries either
+// spelling controller-gen accepts: +kubebuilder:object:root=true, or the
+// pre-kubebuilder +k8s:deepcopy-gen:interfaces naming
+// k8s.io/apimachinery/pkg/runtime.Object. An explicit object:root=false opts
+// out.
+//
+// The value after "=" is YAML, which means prose containing a colon followed by
+// a space parses as a mapping rather than a string; such a value has to be
+// quoted, and the enricher warns when it sees one that was not.
+//
 // # Example generation
 //
 // Beyond the explicit examples markers, the enricher can synthesize

--- a/pkg/crd-enricher/doc.go
+++ b/pkg/crd-enricher/doc.go
@@ -117,11 +117,18 @@
 // (for the root type this is openAPIV3Schema).
 //
 // The enricher walks the root types and the fields reachable from them, so a
-// type no root reaches is never visited. A root is one that carries either
-// spelling controller-gen accepts: +kubebuilder:object:root=true, or the
-// pre-kubebuilder +k8s:deepcopy-gen:interfaces naming
-// k8s.io/apimachinery/pkg/runtime.Object. An explicit object:root=false opts
-// out.
+// type no root reaches is never visited. A root is any type that embeds both
+// metav1.TypeMeta and metav1.ObjectMeta, which is the only thing
+// controller-gen's CRD generator looks at (FindKubeKinds, "locates all types
+// that contain TypeMeta and ObjectMeta"). The root markers --
+// +kubebuilder:object:root=true and the pre-kubebuilder
+// +k8s:deepcopy-gen:interfaces naming k8s.io/apimachinery/pkg/runtime.Object --
+// are read by controller-gen's deepcopy generator, not its CRD one, so they
+// decide whether the type gets a DeepCopyObject method and nothing else. The
+// enricher accepts them as a fallback for types that declare themselves objects
+// without embedding the metav1 structs, but neither of them, and in particular
+// not object:root=false, keeps a type that embeds both structs from getting a
+// CRD -- and therefore from having its markers applied.
 //
 // The value after "=" is YAML, which means prose containing a colon followed by
 // a space parses as a mapping rather than a string; such a value has to be

--- a/pkg/crd-enricher/enricher.go
+++ b/pkg/crd-enricher/enricher.go
@@ -160,6 +160,21 @@ func (e *Enricher) Warnings() []string {
 	return e.warnings
 }
 
+// decodeMarkerValue decodes a marker value and records the non-fatal problems
+// worth telling the author about. The boolean result is false when the value
+// could not be decoded at all, in which case the marker has to be skipped.
+func (e *Enricher) decodeMarkerValue(m marker) (any, bool) {
+	value, err := decodeValue(m.rawValue)
+	if err != nil {
+		e.warnings = append(e.warnings, err.Error())
+		return nil, false
+	}
+	if warn := unquotedMappingWarning(m.name, m.rawValue, value); warn != "" {
+		e.warnings = append(e.warnings, warn)
+	}
+	return value, true
+}
+
 // crdFiles returns the sorted list of YAML files in a directory.
 func crdFiles(dir string) ([]string, error) {
 	entries, err := os.ReadDir(dir)
@@ -334,9 +349,8 @@ func (e *Enricher) applyCRDMarkers(crd map[string]any, markers []marker) {
 		}
 		var value any = true
 		if m.hasValue {
-			decoded, err := decodeValue(m.rawValue)
-			if err != nil {
-				e.warnings = append(e.warnings, err.Error())
+			decoded, valid := e.decodeMarkerValue(m)
+			if !valid {
 				continue
 			}
 			value = decoded
@@ -649,9 +663,8 @@ func (e *Enricher) applyMarkers(schema map[string]any, markers []marker) {
 					"%s marker has no preceding %s marker to attach to", examplesDescriptionMarker, examplesMarker))
 				continue
 			}
-			value, err := decodeValue(m.rawValue)
-			if err != nil {
-				e.warnings = append(e.warnings, err.Error())
+			value, ok := e.decodeMarkerValue(m)
+			if !ok {
 				continue
 			}
 			last := &examples[len(examples)-1]
@@ -670,9 +683,8 @@ func (e *Enricher) applyMarkers(schema map[string]any, markers []marker) {
 					"%s marker has no preceding %s marker to attach to", examplesNameMarker, examplesMarker))
 				continue
 			}
-			value, err := decodeValue(m.rawValue)
-			if err != nil {
-				e.warnings = append(e.warnings, err.Error())
+			value, ok := e.decodeMarkerValue(m)
+			if !ok {
 				continue
 			}
 			last := &examples[len(examples)-1]
@@ -684,9 +696,8 @@ func (e *Enricher) applyMarkers(schema map[string]any, markers []marker) {
 			last.hasName = true
 
 		case strings.HasPrefix(m.name, rawMarkerPrefix):
-			value, err := decodeValue(m.rawValue)
-			if err != nil {
-				e.warnings = append(e.warnings, err.Error())
+			value, ok := e.decodeMarkerValue(m)
+			if !ok {
 				continue
 			}
 			// raw:<key> injects a standard schema field named <key> directly
@@ -725,9 +736,8 @@ func (e *Enricher) applyMarkers(schema map[string]any, markers []marker) {
 			// object or array node it marks the whole subtree as sensitive. It
 			// is a value-less flag by default but accepts an explicit boolean.
 			if m.hasValue {
-				value, err := decodeValue(m.rawValue)
-				if err != nil {
-					e.warnings = append(e.warnings, err.Error())
+				value, ok := e.decodeMarkerValue(m)
+				if !ok {
 					continue
 				}
 				schema[sensitiveDataKey] = value
@@ -743,9 +753,8 @@ func (e *Enricher) applyMarkers(schema map[string]any, markers []marker) {
 		default:
 			// A valued simple entity (for example default) stores its parsed
 			// YAML value under x-doc-<entity>.
-			value, err := decodeValue(m.rawValue)
-			if err != nil {
-				e.warnings = append(e.warnings, err.Error())
+			value, ok := e.decodeMarkerValue(m)
+			if !ok {
 				continue
 			}
 			schema[docKeyPrefix+m.name] = value

--- a/pkg/crd-enricher/enricher.go
+++ b/pkg/crd-enricher/enricher.go
@@ -798,10 +798,6 @@ func (e *Enricher) applyMarkers(schema map[string]any, markers []marker, ctx nod
 			last.hasName = true
 
 		case strings.HasPrefix(m.name, rawMarkerPrefix):
-			value, ok := e.decodeMarkerValue(m, ctx)
-			if !ok {
-				continue
-			}
 			// raw:<key> injects a standard schema field named <key> directly
 			// (not under an x-doc-* key). It is used for fields controller-gen
 			// cannot emit on some types (for example a pattern on a Duration).
@@ -809,6 +805,21 @@ func (e *Enricher) applyMarkers(schema map[string]any, markers []marker, ctx nod
 			// override descriptions that controller-gen pulls from a shared type
 			// (for example items.description on a []metav1.Condition field).
 			key := strings.TrimPrefix(m.name, rawMarkerPrefix)
+			if key == "" {
+				e.warnf(ctx, "raw marker has no key; write raw:<field>=<value> or raw:<node>.<field>=<value>")
+				continue
+			}
+			// A value-less raw: marker would decode to null and write it, which is
+			// never what its author meant -- and the one thing they might have
+			// meant, taking the field out, is what unset: is for.
+			if !m.hasValue {
+				e.warnf(ctx, "raw marker for %q has no value and would write null; use unset:%s to remove the field", key, key)
+				continue
+			}
+			value, ok := e.decodeMarkerValue(m, ctx)
+			if !ok {
+				continue
+			}
 			if strings.Contains(key, ".") {
 				if !setNested(schema, strings.Split(key, "."), value) {
 					e.warnf(ctx, "raw path %q does not resolve to a schema node", key)
@@ -824,11 +835,26 @@ func (e *Enricher) applyMarkers(schema map[string]any, markers []marker, ctx nod
 			// which raw: can only overwrite, never remove. It carries no value: a
 			// key set to null is not the same schema as a key that is not there.
 			key := strings.TrimPrefix(m.name, unsetMarkerPrefix)
+			if key == "" {
+				e.warnf(ctx, "unset marker has no key; write unset:<field> or unset:<node>.<field>")
+				continue
+			}
 			if m.hasValue {
 				e.warnf(ctx, "unset marker for %q takes no value, ignoring %q", key, m.rawValue)
 			}
-			if !deleteNested(schema, strings.Split(key, ".")) {
+			path := strings.Split(key, ".")
+			// Refuse to remove a field the structural schema requires. Obeying
+			// would produce a manifest the apiserver rejects at apply time, with
+			// nothing to connect the refusal back to this marker.
+			if last := path[len(path)-1]; structuralKeys[last] {
+				e.warnf(ctx, "unset path %q would remove %q, which a structural schema requires; the apiserver would reject the CRD", key, last)
+				continue
+			}
+			switch deleteNested(schema, path) {
+			case unsetNotFound:
 				e.warnf(ctx, "unset path %q is not present in the schema", key)
+			case unsetEmptiedParent:
+				e.warnf(ctx, "unset path %q left its parent node empty, which is a different schema from an absent one", key)
 			}
 
 		case m.name == sensitiveDataMarker:
@@ -930,6 +956,9 @@ func (e *Enricher) buildExamples(entries []exampleEntry, ctx nodeCtx) []any {
 // nodes controller-gen emitted); it returns false otherwise so a mistyped path
 // surfaces as a warning rather than silently growing the schema.
 func setNested(schema map[string]any, path []string, value any) bool {
+	if len(path) == 0 {
+		return false
+	}
 	node := schema
 	for _, key := range path[:len(path)-1] {
 		child, ok := node[key].(map[string]any)
@@ -942,27 +971,50 @@ func setNested(schema map[string]any, path []string, value any) bool {
 	return true
 }
 
+// unsetOutcome is what deleteNested did. The three cases each want saying
+// differently, and as a type the impossible fourth -- emptied a parent without
+// removing anything -- cannot be spelled.
+type unsetOutcome int
+
+const (
+	// unsetNotFound means the path did not resolve, or the field was not there,
+	// and nothing changed. The caller wants to hear about it: the marker was
+	// written to remove something, so removing nothing means it has outlived its
+	// target -- the vendored godoc changed, or the path was mistyped.
+	unsetNotFound unsetOutcome = iota
+	// unsetRemoved means the field is gone and its parent still has other keys.
+	unsetRemoved
+	// unsetEmptiedParent means the field is gone and its parent is now an empty
+	// mapping. An empty node is not the same schema as an absent one, and for the
+	// nodes apiextensions constrains it is not a valid one either.
+	unsetEmptiedParent
+)
+
 // deleteNested removes the field named by the last path element, walking the
-// mappings named by the ones before it. It reports false and changes nothing
-// when the path does not resolve or the field is not there, so the caller can
-// tell a marker that did something from one that has gone stale -- a
-// no-longer-emitted node is exactly the case worth hearing about, since the
-// marker was written to remove it.
-func deleteNested(schema map[string]any, path []string) bool {
+// mappings named by the ones before it. path must be non-empty.
+func deleteNested(schema map[string]any, path []string) unsetOutcome {
+	if len(path) == 0 {
+		return unsetNotFound
+	}
 	node := schema
 	for _, key := range path[:len(path)-1] {
 		child, ok := node[key].(map[string]any)
 		if !ok {
-			return false
+			return unsetNotFound
 		}
 		node = child
 	}
 	last := path[len(path)-1]
 	if _, ok := node[last]; !ok {
-		return false
+		return unsetNotFound
 	}
 	delete(node, last)
-	return true
+	// The schema root is not a "parent node" in this sense: emptying it means the
+	// document has no schema left, which a single-element path cannot express.
+	if len(path) > 1 && len(node) == 0 {
+		return unsetEmptiedParent
+	}
+	return unsetRemoved
 }
 
 // infoFor returns the packageInfo of a named type, or nil when the type lives

--- a/pkg/crd-enricher/enricher.go
+++ b/pkg/crd-enricher/enricher.go
@@ -67,37 +67,107 @@ type Enricher struct {
 	// schema node controller-gen did not emit.
 	warnings []string
 
-	// curatedStyle is set per file when the CRD opts into the hand-curated
-	// deckhouse style via the x-doc-crd marker. Such files omit the leading
-	// document separator.
-	curatedStyle bool
-
-	// exampleScope is set per file from the crd:exampleScope marker. It controls
-	// where generated composite examples are attached: the default empty value
-	// (and "root") attaches a single synthesized example to the CRD root, while
-	// "tree" attaches a composite example to every object node as well.
-	exampleScope string
-
 	// generateExamplesEnabled turns the automatic example synthesis on. It mirrors
 	// Options.GenerateExamples and is off by default, so composite examples are
 	// only produced when the caller opts in.
 	generateExamplesEnabled bool
-
-	// orderedExamples is set per file when an example marker produced an
-	// order-preserving orderedMap. Such files are encoded with the
-	// order-preserving marshaller so the authored field order survives; files
-	// without ordered examples keep the default sigs.k8s.io/yaml encoding.
-	orderedExamples bool
 
 	// reindent mirrors Options.Reindent. When set, every document is encoded with
 	// the goyaml.v3 indented layout instead of the flush sigs.k8s.io/yaml one.
 	reindent bool
 }
 
+// fileState is the part of an enrichment that belongs to one CRD document: the
+// switches its crd: markers flip, and the identity a warning needs to be worth
+// reading. It is built per file in enrichFile, so a switch cannot leak into the
+// next document -- which a hand-written reset block on the Enricher stopped
+// guaranteeing the moment anyone added a switch and forgot to list it there.
+type fileState struct {
+	// path is the manifest being enriched. Warnings quote its base name.
+	// The CRD kind needs no field of its own: a root type only matches a
+	// document whose names.kind equals the type's own name, so nodeCtx.typeName
+	// already carries it.
+	path string
+
+	// curatedStyle is set when the CRD opts into the hand-curated deckhouse
+	// style via crd:minimal. Such files omit the leading document separator.
+	curatedStyle bool
+
+	// exampleScope is set from the crd:exampleScope marker. It controls where
+	// generated composite examples are attached: the default empty value (and
+	// "root") attaches a single synthesized example to the CRD root, while
+	// "tree" attaches a composite example to every object node as well.
+	exampleScope string
+
+	// orderedExamples is set when an example marker produced an
+	// order-preserving orderedMap. Such files are encoded with the
+	// order-preserving marshaller so the authored field order survives; files
+	// without ordered examples keep the default sigs.k8s.io/yaml encoding.
+	orderedExamples bool
+}
+
+// nodeCtx is where the walk currently is. The file half is shared by pointer
+// (the switches are flipped deep in the tree and read back in enrichFile); the
+// Go type and field are copied as the walk descends, so a warning can name the
+// declaration the marker was written on instead of leaving the reader to grep a
+// field name that occurs in nine CRDs.
+//
+// The zero value is usable and simply produces unprefixed warnings.
+type nodeCtx struct {
+	file     *fileState
+	typeName string
+	field    string
+}
+
+// onType returns the context of a type's own schema node, dropping any field.
+func (c nodeCtx) onType(typeName string) nodeCtx {
+	c.typeName = typeName
+	c.field = ""
+	return c
+}
+
+// at returns the context of one field of the current type.
+func (c nodeCtx) at(typeName, field string) nodeCtx {
+	c.typeName = typeName
+	c.field = field
+	return c
+}
+
+// where renders the location prefix of a warning: the manifest, and the Go
+// declaration the markers came from once the walk knows it.
+func (c nodeCtx) where() string {
+	var parts []string
+	if c.file != nil && c.file.path != "" {
+		parts = append(parts, filepath.Base(c.file.path))
+	}
+	switch {
+	case c.typeName != "" && c.field != "":
+		parts = append(parts, c.typeName+"."+c.field)
+	case c.typeName != "":
+		parts = append(parts, c.typeName)
+	}
+	return strings.Join(parts, ": ")
+}
+
+// warnf records a non-fatal problem together with where it was found. Every
+// warning goes through here: a message that does not say which manifest, kind
+// and field it is about cannot be acted on when the same marker appears in a
+// dozen CRDs, which is the normal case.
+func (e *Enricher) warnf(ctx nodeCtx, format string, args ...any) {
+	msg := fmt.Sprintf(format, args...)
+	if where := ctx.where(); where != "" {
+		msg = where + ": " + msg
+	}
+	e.warnings = append(e.warnings, msg)
+}
+
 // Run loads the API packages, then walks and enriches every CRD file in the
 // configured directory. It returns the list of files that were modified.
 //
-// Warnings collected along the way are dropped; use RunWithWarnings to see them.
+// Warnings collected along the way are dropped, so new code should reach for
+// RunWithWarnings instead: every warning means a marker did not do what its
+// author wrote it to do, and nothing else in the run says so. Run is kept for
+// callers that already depend on this signature.
 func Run(opts Options) ([]string, error) {
 	changed, _, err := RunWithWarnings(opts)
 	return changed, err
@@ -155,22 +225,37 @@ func RunWithWarnings(opts Options) ([]string, []string, error) {
 	return changed, enr.Warnings(), nil
 }
 
-// Warnings returns the non-fatal problems collected during the last Run.
+// Warnings returns the non-fatal problems collected during the last Run, in the
+// order they were found, with duplicates removed: the same marker is visited once
+// per version of every CRD document that names its kind, so an unfiltered list
+// repeats each problem as many times as there are versions.
+//
+// The result is a copy, so a caller sorting or trimming it cannot disturb a run
+// still in progress.
 func (e *Enricher) Warnings() []string {
-	return e.warnings
+	seen := make(map[string]struct{}, len(e.warnings))
+	out := make([]string, 0, len(e.warnings))
+	for _, w := range e.warnings {
+		if _, dup := seen[w]; dup {
+			continue
+		}
+		seen[w] = struct{}{}
+		out = append(out, w)
+	}
+	return out
 }
 
 // decodeMarkerValue decodes a marker value and records the non-fatal problems
 // worth telling the author about. The boolean result is false when the value
 // could not be decoded at all, in which case the marker has to be skipped.
-func (e *Enricher) decodeMarkerValue(m marker) (any, bool) {
+func (e *Enricher) decodeMarkerValue(m marker, ctx nodeCtx) (any, bool) {
 	value, err := decodeValue(m.rawValue)
 	if err != nil {
-		e.warnings = append(e.warnings, err.Error())
+		e.warnf(ctx, "%s", err.Error())
 		return nil, false
 	}
 	if warn := unquotedMappingWarning(m.name, m.rawValue, value); warn != "" {
-		e.warnings = append(e.warnings, warn)
+		e.warnf(ctx, "%s", warn)
 	}
 	return value, true
 }
@@ -215,10 +300,10 @@ func (e *Enricher) enrichFile(path string) (bool, error) {
 		return false, nil
 	}
 
-	e.curatedStyle = false
-	e.exampleScope = ""
-	e.orderedExamples = false
-	e.enrichCRD(crd)
+	// Every switch this document flips lives on its own fileState, so nothing
+	// carries over into the next file and adding a switch cannot reopen that.
+	fs := &fileState{path: path}
+	e.enrichCRD(crd, fs)
 
 	// Documents that carry authored (ordered) examples are encoded with the
 	// order-preserving marshaller so the example fields keep their authored
@@ -230,7 +315,7 @@ func (e *Enricher) enrichFile(path string) (bool, error) {
 	switch {
 	case e.reindent:
 		marshal = marshalIndented
-	case e.orderedExamples:
+	case fs.orderedExamples:
 		marshal = marshalOrdered
 	}
 	out, err := marshal(crd)
@@ -241,7 +326,7 @@ func (e *Enricher) enrichFile(path string) (bool, error) {
 	// controller-gen prefixes every CRD document with an explicit start marker;
 	// keep the same shape so the diff stays minimal. Hand-curated CRDs (those
 	// using the x-doc-crd marker) omit the separator, so drop it for them.
-	if !e.curatedStyle && bytes.HasPrefix(original, []byte("---")) {
+	if !fs.curatedStyle && bytes.HasPrefix(original, []byte("---")) {
 		out = append([]byte("---\n"), out...)
 	}
 
@@ -257,7 +342,7 @@ func (e *Enricher) enrichFile(path string) (bool, error) {
 
 // enrichCRD walks every version schema of a CRD whose kind has a matching Go
 // root type.
-func (e *Enricher) enrichCRD(crd map[string]any) {
+func (e *Enricher) enrichCRD(crd map[string]any, fs *fileState) {
 	spec := childMap(crd, "spec")
 	if spec == nil {
 		return
@@ -277,6 +362,7 @@ func (e *Enricher) enrichCRD(crd map[string]any) {
 		return
 	}
 
+	ctx := nodeCtx{file: fs}
 	crdApplied := false
 	for _, raw := range versions {
 		version, ok := raw.(map[string]any)
@@ -293,7 +379,8 @@ func (e *Enricher) enrichCRD(crd map[string]any) {
 		// applied once from the root type markers.
 		if !crdApplied {
 			if info := e.infoFor(named); info != nil {
-				e.applyCRDMarkers(crd, info.typeMarkers[named.Obj().Name()])
+				rootName := named.Obj().Name()
+				e.applyCRDMarkers(crd, info.typeMarkers[rootName], ctx.onType(rootName))
 			}
 			crdApplied = true
 		}
@@ -307,7 +394,7 @@ func (e *Enricher) enrichCRD(crd map[string]any) {
 			continue
 		}
 
-		e.enrichType(openAPISchema, named)
+		e.enrichType(openAPISchema, named, ctx)
 
 		// x-kubernetes-sensitive-data must not sit on the schema root: the root
 		// also covers the system apiVersion, kind and metadata fields, which the
@@ -315,15 +402,15 @@ func (e *Enricher) enrichCRD(crd map[string]any) {
 		// the marker by mistake.
 		if _, ok := openAPISchema[sensitiveDataKey]; ok {
 			delete(openAPISchema, sensitiveDataKey)
-			e.warnings = append(e.warnings, fmt.Sprintf(
-				"%s: sensitive-data marker is not allowed on the root type; apply it to spec or a field", kind))
+			e.warnf(ctx.onType(named.Obj().Name()),
+				"sensitive-data marker is not allowed on the root type; apply it to spec or a field")
 		}
 
 		// Examples are generated bottom-up after every marker has been applied,
 		// so explicit examples, defaults and enums are already in place. This is
 		// opt-in: without the flag only the explicit examples markers survive.
 		if e.generateExamplesEnabled {
-			e.generateExamples(spec, names, name, openAPISchema)
+			e.generateExamples(spec, names, name, openAPISchema, fs)
 		}
 	}
 }
@@ -333,7 +420,15 @@ func (e *Enricher) enrichCRD(crd map[string]any) {
 // the root type carries an x-doc-crd marker. Labels and annotations are not
 // handled here: they are emitted natively by controller-gen through the
 // +kubebuilder:metadata:labels and +kubebuilder:metadata:annotations markers.
-func (e *Enricher) applyCRDMarkers(crd map[string]any, markers []marker) {
+func (e *Enricher) applyCRDMarkers(crd map[string]any, markers []marker, ctx nodeCtx) {
+	// The two settings below are file switches. A caller outside enrichFile has
+	// no file to flip them on, so give it a throwaway one rather than
+	// dereferencing nil: the settings then go nowhere, which is what such a
+	// caller wants.
+	if ctx.file == nil {
+		ctx.file = &fileState{}
+	}
+
 	// Each CRD setting arrives as its own "crd:<key>=<value>" marker, mirroring
 	// the kubebuilder marker style. The values are collected into a single
 	// config map so the rest of the function can stay value-driven. A value-less
@@ -349,7 +444,7 @@ func (e *Enricher) applyCRDMarkers(crd map[string]any, markers []marker) {
 		}
 		var value any = true
 		if m.hasValue {
-			decoded, valid := e.decodeMarkerValue(m)
+			decoded, valid := e.decodeMarkerValue(m, ctx)
 			if !valid {
 				continue
 			}
@@ -364,7 +459,7 @@ func (e *Enricher) applyCRDMarkers(crd map[string]any, markers []marker) {
 	// exampleScope selects where generated examples are attached and is consumed
 	// later by generateExamples; it is not written onto the CRD itself.
 	if scope, ok := config["exampleScope"].(string); ok {
-		e.exampleScope = scope
+		ctx.file.exampleScope = scope
 	}
 
 	metadata := childMap(crd, "metadata")
@@ -387,7 +482,7 @@ func (e *Enricher) applyCRDMarkers(crd map[string]any, markers []marker) {
 	// root properties and the leading document separator. CRDs that keep the
 	// full controller-gen schema (only adding labels) leave minimal unset.
 	if minimal, _ := config["minimal"].(bool); minimal && spec != nil {
-		e.curatedStyle = true
+		ctx.file.curatedStyle = true
 		if names := childMap(spec, "names"); names != nil {
 			delete(names, "listKind")
 		}
@@ -510,17 +605,18 @@ func (e *Enricher) stripRootMeta(spec map[string]any) {
 
 // enrichType applies the type-level markers of a named type to the given
 // schema node and then descends into its struct fields.
-func (e *Enricher) enrichType(schema map[string]any, named *types.Named) {
+func (e *Enricher) enrichType(schema map[string]any, named *types.Named, ctx nodeCtx) {
+	name := named.Obj().Name()
 	info := e.infoFor(named)
 	if info != nil {
-		e.applyMarkers(schema, info.typeMarkers[named.Obj().Name()])
+		e.applyMarkers(schema, info.typeMarkers[name], ctx.onType(name))
 	}
-	e.enrichStruct(schema, named)
+	e.enrichStruct(schema, named, ctx)
 }
 
 // enrichStruct walks the fields of a struct type, applying field markers and
 // recursing into the matching schema children.
-func (e *Enricher) enrichStruct(schema map[string]any, named *types.Named) {
+func (e *Enricher) enrichStruct(schema map[string]any, named *types.Named, ctx nodeCtx) {
 	structType, ok := named.Underlying().(*types.Struct)
 	if !ok {
 		return
@@ -540,7 +636,7 @@ func (e *Enricher) enrichStruct(schema map[string]any, named *types.Named) {
 		// all) merge their fields into the current schema node.
 		if field.Embedded() && (inline || jsonName == "") {
 			if embedded := namedOf(field.Type()); embedded != nil {
-				e.enrichStruct(schema, embedded)
+				e.enrichStruct(schema, embedded, ctx)
 			}
 			continue
 		}
@@ -551,21 +647,28 @@ func (e *Enricher) enrichStruct(schema map[string]any, named *types.Named) {
 
 		child := childMap(properties, jsonName)
 
+		fieldCtx := ctx.at(named.Obj().Name(), field.Name())
+
 		if info != nil {
 			markers := info.fieldMarkers[named.Obj().Name()][field.Name()]
 			if len(markers) > 0 {
-				if child == nil {
-					e.warnings = append(e.warnings, fmt.Sprintf(
-						"%s.%s: marker present but schema has no property %q",
-						named.Obj().Name(), field.Name(), jsonName))
-				} else {
-					e.applyMarkers(child, markers)
+				// Only the enricher's own markers are worth complaining about. A
+				// field carrying nothing but +optional or a kubebuilder marker
+				// loses nothing when controller-gen emits no property for it --
+				// which is the normal case for the ObjectMeta a curated CRD
+				// strips -- and warning about it teaches everyone to ignore the
+				// channel.
+				switch {
+				case child != nil:
+					e.applyMarkers(child, markers, fieldCtx)
+				case hasEnricherMarker(markers):
+					e.warnf(fieldCtx, "marker present but schema has no property %q", jsonName)
 				}
 			}
 		}
 
 		if child != nil {
-			e.enrichValue(child, field.Type())
+			e.enrichValue(child, field.Type(), fieldCtx)
 		}
 	}
 }
@@ -573,7 +676,7 @@ func (e *Enricher) enrichStruct(schema map[string]any, named *types.Named) {
 // enrichValue follows the structure of a Go field type into the schema:
 // pointers are dereferenced, slices descend into "items", maps into
 // "additionalProperties" and named structs into their nested properties.
-func (e *Enricher) enrichValue(schema map[string]any, typ types.Type) {
+func (e *Enricher) enrichValue(schema map[string]any, typ types.Type, ctx nodeCtx) {
 	for {
 		switch t := typ.(type) {
 		case *types.Pointer:
@@ -581,24 +684,24 @@ func (e *Enricher) enrichValue(schema map[string]any, typ types.Type) {
 		case *types.Named:
 			switch t.Underlying().(type) {
 			case *types.Struct:
-				e.enrichType(schema, t)
+				e.enrichType(schema, t, ctx)
 				return
 			default:
 				typ = t.Underlying()
 			}
 		case *types.Slice:
 			if items := childMap(schema, "items"); items != nil {
-				e.enrichValue(items, t.Elem())
+				e.enrichValue(items, t.Elem(), ctx)
 			}
 			return
 		case *types.Array:
 			if items := childMap(schema, "items"); items != nil {
-				e.enrichValue(items, t.Elem())
+				e.enrichValue(items, t.Elem(), ctx)
 			}
 			return
 		case *types.Map:
 			if additional := childMap(schema, "additionalProperties"); additional != nil {
-				e.enrichValue(additional, t.Elem())
+				e.enrichValue(additional, t.Elem(), ctx)
 			}
 			return
 		default:
@@ -611,7 +714,7 @@ func (e *Enricher) enrichValue(schema map[string]any, typ types.Type) {
 // node. examplesMarker accumulates a list (each entry optionally described by a
 // following examples-description marker), value-less markers become boolean
 // flags and everything else stores its parsed YAML value.
-func (e *Enricher) applyMarkers(schema map[string]any, markers []marker) {
+func (e *Enricher) applyMarkers(schema map[string]any, markers []marker, ctx nodeCtx) {
 	if schema == nil {
 		return
 	}
@@ -635,7 +738,7 @@ func (e *Enricher) applyMarkers(schema map[string]any, markers []marker) {
 			// marker can attach to it.
 			value, err := decodeOrderedValue(m.rawValue)
 			if err != nil {
-				e.warnings = append(e.warnings, err.Error())
+				e.warnf(ctx, "%s", err.Error())
 				continue
 			}
 			// An example authored in ascending key order renders identically
@@ -659,18 +762,18 @@ func (e *Enricher) applyMarkers(schema map[string]any, markers []marker) {
 			// A description attaches to the example introduced by the preceding
 			// examples marker. Without one there is nothing to describe.
 			if len(examples) == 0 {
-				e.warnings = append(e.warnings, fmt.Sprintf(
-					"%s marker has no preceding %s marker to attach to", examplesDescriptionMarker, examplesMarker))
+				e.warnf(ctx, "%s marker has no preceding %s marker to attach to",
+					examplesDescriptionMarker, examplesMarker)
 				continue
 			}
-			value, ok := e.decodeMarkerValue(m)
+			value, ok := e.decodeMarkerValue(m, ctx)
 			if !ok {
 				continue
 			}
 			last := &examples[len(examples)-1]
 			if last.hasDescription {
-				e.warnings = append(e.warnings, fmt.Sprintf(
-					"%s marker overrides an earlier description for the same example", examplesDescriptionMarker))
+				e.warnf(ctx, "%s marker overrides an earlier description for the same example",
+					examplesDescriptionMarker)
 			}
 			last.description = value
 			last.hasDescription = true
@@ -679,24 +782,23 @@ func (e *Enricher) applyMarkers(schema map[string]any, markers []marker) {
 			// A name attaches to the example introduced by the preceding examples
 			// marker, exactly like a description.
 			if len(examples) == 0 {
-				e.warnings = append(e.warnings, fmt.Sprintf(
-					"%s marker has no preceding %s marker to attach to", examplesNameMarker, examplesMarker))
+				e.warnf(ctx, "%s marker has no preceding %s marker to attach to",
+					examplesNameMarker, examplesMarker)
 				continue
 			}
-			value, ok := e.decodeMarkerValue(m)
+			value, ok := e.decodeMarkerValue(m, ctx)
 			if !ok {
 				continue
 			}
 			last := &examples[len(examples)-1]
 			if last.hasName {
-				e.warnings = append(e.warnings, fmt.Sprintf(
-					"%s marker overrides an earlier name for the same example", examplesNameMarker))
+				e.warnf(ctx, "%s marker overrides an earlier name for the same example", examplesNameMarker)
 			}
 			last.name = value
 			last.hasName = true
 
 		case strings.HasPrefix(m.name, rawMarkerPrefix):
-			value, ok := e.decodeMarkerValue(m)
+			value, ok := e.decodeMarkerValue(m, ctx)
 			if !ok {
 				continue
 			}
@@ -709,7 +811,7 @@ func (e *Enricher) applyMarkers(schema map[string]any, markers []marker) {
 			key := strings.TrimPrefix(m.name, rawMarkerPrefix)
 			if strings.Contains(key, ".") {
 				if !setNested(schema, strings.Split(key, "."), value) {
-					e.warnings = append(e.warnings, fmt.Sprintf("raw path %q does not resolve to a schema node", key))
+					e.warnf(ctx, "raw path %q does not resolve to a schema node", key)
 				}
 			} else {
 				schema[key] = value
@@ -723,11 +825,10 @@ func (e *Enricher) applyMarkers(schema map[string]any, markers []marker) {
 			// key set to null is not the same schema as a key that is not there.
 			key := strings.TrimPrefix(m.name, unsetMarkerPrefix)
 			if m.hasValue {
-				e.warnings = append(e.warnings, fmt.Sprintf(
-					"unset marker for %q takes no value, ignoring %q", key, m.rawValue))
+				e.warnf(ctx, "unset marker for %q takes no value, ignoring %q", key, m.rawValue)
 			}
 			if !deleteNested(schema, strings.Split(key, ".")) {
-				e.warnings = append(e.warnings, fmt.Sprintf("unset path %q is not present in the schema", key))
+				e.warnf(ctx, "unset path %q is not present in the schema", key)
 			}
 
 		case m.name == sensitiveDataMarker:
@@ -736,7 +837,7 @@ func (e *Enricher) applyMarkers(schema map[string]any, markers []marker) {
 			// object or array node it marks the whole subtree as sensitive. It
 			// is a value-less flag by default but accepts an explicit boolean.
 			if m.hasValue {
-				value, ok := e.decodeMarkerValue(m)
+				value, ok := e.decodeMarkerValue(m, ctx)
 				if !ok {
 					continue
 				}
@@ -753,7 +854,7 @@ func (e *Enricher) applyMarkers(schema map[string]any, markers []marker) {
 		default:
 			// A valued simple entity (for example default) stores its parsed
 			// YAML value under x-doc-<entity>.
-			value, ok := e.decodeMarkerValue(m)
+			value, ok := e.decodeMarkerValue(m, ctx)
 			if !ok {
 				continue
 			}
@@ -762,7 +863,7 @@ func (e *Enricher) applyMarkers(schema map[string]any, markers []marker) {
 	}
 
 	if len(examples) > 0 {
-		schema[docKeyPrefix+examplesMarker] = e.buildExamples(examples)
+		schema[docKeyPrefix+examplesMarker] = e.buildExamples(examples, ctx)
 	}
 }
 
@@ -785,7 +886,13 @@ type exampleEntry struct {
 // homogeneous for consumers. Wrapping (and any ordered example value) forces the
 // order-preserving encoder so the attributes keep their place ahead of the
 // example.
-func (e *Enricher) buildExamples(entries []exampleEntry) []any {
+func (e *Enricher) buildExamples(entries []exampleEntry, ctx nodeCtx) []any {
+	// As in applyCRDMarkers: a caller outside enrichFile has no file to flip the
+	// encoder switch on, and a throwaway one keeps that harmless.
+	if ctx.file == nil {
+		ctx.file = &fileState{}
+	}
+
 	wrap := false
 	for _, entry := range entries {
 		if entry.hasName || entry.hasDescription {
@@ -797,14 +904,14 @@ func (e *Enricher) buildExamples(entries []exampleEntry) []any {
 	out := make([]any, 0, len(entries))
 	for _, entry := range entries {
 		if containsOrdered(entry.value) {
-			e.orderedExamples = true
+			ctx.file.orderedExamples = true
 		}
 		if !wrap {
 			out = append(out, entry.value)
 			continue
 		}
 
-		e.orderedExamples = true
+		ctx.file.orderedExamples = true
 		wrapper := make(orderedMap, 0, 3)
 		if entry.hasDescription {
 			wrapper = append(wrapper, orderedEntry{key: docDescriptionKey, val: entry.description})

--- a/pkg/crd-enricher/enricher.go
+++ b/pkg/crd-enricher/enricher.go
@@ -846,15 +846,23 @@ func (e *Enricher) applyMarkers(schema map[string]any, markers []marker, ctx nod
 			// Refuse to remove a field the structural schema requires. Obeying
 			// would produce a manifest the apiserver rejects at apply time, with
 			// nothing to connect the refusal back to this marker.
-			if last := path[len(path)-1]; structuralKeys[last] {
+			last := path[len(path)-1]
+			if structuralKeys[last] {
 				e.warnf(ctx, "unset path %q would remove %q, which a structural schema requires; the apiserver would reject the CRD", key, last)
 				continue
+			}
+			// Removing a validation key is legal and the apiserver will accept the
+			// result, which is exactly why it is worth a line: the API then admits
+			// values it used to reject, and the crds/ re-render gate cannot see it
+			// -- both sides of that comparison come from this same marker.
+			if validationKeys[last] {
+				e.warnf(ctx, "unset path %q removes the validation key %q; the apiserver will accept values it rejected before", key, last)
 			}
 			switch deleteNested(schema, path) {
 			case unsetNotFound:
 				e.warnf(ctx, "unset path %q is not present in the schema", key)
-			case unsetEmptiedParent:
-				e.warnf(ctx, "unset path %q left its parent node empty, which is a different schema from an absent one", key)
+			case unsetWouldEmptyParent:
+				e.warnf(ctx, "unset path %q would leave its parent node empty, which the apiserver rejects (\"must not be empty for specified object fields\"); refusing", key)
 			}
 
 		case m.name == sensitiveDataMarker:
@@ -984,14 +992,20 @@ const (
 	unsetNotFound unsetOutcome = iota
 	// unsetRemoved means the field is gone and its parent still has other keys.
 	unsetRemoved
-	// unsetEmptiedParent means the field is gone and its parent is now an empty
-	// mapping. An empty node is not the same schema as an absent one, and for the
-	// nodes apiextensions constrains it is not a valid one either.
-	unsetEmptiedParent
+	// unsetWouldEmptyParent means the removal was refused: it would have left the
+	// parent an empty mapping. An empty node is not the same schema as an absent
+	// one, and for the nodes apiextensions constrains it is not a valid one
+	// either -- the apiserver answers "must not be empty for specified object
+	// fields" at apply time, with nothing in the failure pointing back at the
+	// marker. Refused rather than done-and-warned for the same reason
+	// structuralKeys are: a warning is not fatal by default, so obeying would ship
+	// a document the apiserver rejects.
+	unsetWouldEmptyParent
 )
 
 // deleteNested removes the field named by the last path element, walking the
-// mappings named by the ones before it. path must be non-empty.
+// mappings named by the ones before it. path must be non-empty. The schema is
+// left untouched unless the outcome is unsetRemoved.
 func deleteNested(schema map[string]any, path []string) unsetOutcome {
 	if len(path) == 0 {
 		return unsetNotFound
@@ -1008,12 +1022,12 @@ func deleteNested(schema map[string]any, path []string) unsetOutcome {
 	if _, ok := node[last]; !ok {
 		return unsetNotFound
 	}
-	delete(node, last)
 	// The schema root is not a "parent node" in this sense: emptying it means the
 	// document has no schema left, which a single-element path cannot express.
-	if len(path) > 1 && len(node) == 0 {
-		return unsetEmptiedParent
+	if len(path) > 1 && len(node) == 1 {
+		return unsetWouldEmptyParent
 	}
+	delete(node, last)
 	return unsetRemoved
 }
 

--- a/pkg/crd-enricher/enricher.go
+++ b/pkg/crd-enricher/enricher.go
@@ -692,6 +692,21 @@ func (e *Enricher) applyMarkers(schema map[string]any, markers []marker) {
 				schema[key] = value
 			}
 
+		case strings.HasPrefix(m.name, unsetMarkerPrefix):
+			// unset:<key> deletes a standard schema field, the mirror of raw:<key>.
+			// It is how a field takes out a node controller-gen filled in from a
+			// vendored type -- items.description on a []metav1.Condition field --
+			// which raw: can only overwrite, never remove. It carries no value: a
+			// key set to null is not the same schema as a key that is not there.
+			key := strings.TrimPrefix(m.name, unsetMarkerPrefix)
+			if m.hasValue {
+				e.warnings = append(e.warnings, fmt.Sprintf(
+					"unset marker for %q takes no value, ignoring %q", key, m.rawValue))
+			}
+			if !deleteNested(schema, strings.Split(key, ".")) {
+				e.warnings = append(e.warnings, fmt.Sprintf("unset path %q is not present in the schema", key))
+			}
+
 		case m.name == sensitiveDataMarker:
 			// sensitive-data renders to the kube-apiserver flag
 			// x-kubernetes-sensitive-data rather than an x-doc-* key. On an
@@ -796,6 +811,29 @@ func setNested(schema map[string]any, path []string, value any) bool {
 		node = child
 	}
 	node[path[len(path)-1]] = value
+	return true
+}
+
+// deleteNested removes the field named by the last path element, walking the
+// mappings named by the ones before it. It reports false and changes nothing
+// when the path does not resolve or the field is not there, so the caller can
+// tell a marker that did something from one that has gone stale -- a
+// no-longer-emitted node is exactly the case worth hearing about, since the
+// marker was written to remove it.
+func deleteNested(schema map[string]any, path []string) bool {
+	node := schema
+	for _, key := range path[:len(path)-1] {
+		child, ok := node[key].(map[string]any)
+		if !ok {
+			return false
+		}
+		node = child
+	}
+	last := path[len(path)-1]
+	if _, ok := node[last]; !ok {
+		return false
+	}
+	delete(node, last)
 	return true
 }
 

--- a/pkg/crd-enricher/enricher.go
+++ b/pkg/crd-enricher/enricher.go
@@ -96,17 +96,29 @@ type Enricher struct {
 
 // Run loads the API packages, then walks and enriches every CRD file in the
 // configured directory. It returns the list of files that were modified.
+//
+// Warnings collected along the way are dropped; use RunWithWarnings to see them.
 func Run(opts Options) ([]string, error) {
+	changed, _, err := RunWithWarnings(opts)
+	return changed, err
+}
+
+// RunWithWarnings is Run, returning the non-fatal problems it collected as well:
+// markers naming a field the schema has no property for, raw and unset paths
+// that do not resolve, sensitive-data on a root type. None of them stops the
+// enrichment, and every one of them means a marker did not do what its author
+// wrote it to do, so a caller that has somewhere to print them should.
+func RunWithWarnings(opts Options) ([]string, []string, error) {
 	if len(opts.Paths) == 0 {
-		return nil, fmt.Errorf("no package paths provided")
+		return nil, nil, fmt.Errorf("no package paths provided")
 	}
 	if opts.CRDDir == "" {
-		return nil, fmt.Errorf("no CRD directory provided")
+		return nil, nil, fmt.Errorf("no CRD directory provided")
 	}
 
 	pkgByPath, err := loadPackages(opts.Dir, opts.Paths...)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	enr := &Enricher{
@@ -126,21 +138,21 @@ func Run(opts Options) ([]string, error) {
 
 	files, err := crdFiles(opts.CRDDir)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	var changed []string
 	for _, file := range files {
 		modified, err := enr.enrichFile(file)
 		if err != nil {
-			return nil, fmt.Errorf("enrich %s: %w", file, err)
+			return nil, nil, fmt.Errorf("enrich %s: %w", file, err)
 		}
 		if modified {
 			changed = append(changed, file)
 		}
 	}
 
-	return changed, nil
+	return changed, enr.Warnings(), nil
 }
 
 // Warnings returns the non-fatal problems collected during the last Run.

--- a/pkg/crd-enricher/enricher_test.go
+++ b/pkg/crd-enricher/enricher_test.go
@@ -41,6 +41,7 @@ func TestParseMarkerLine(t *testing.T) {
 		{"crd subkey flag", "+crd-enricher:crd:minimal", marker{name: "crd:minimal", enricher: true}, true},
 		{"sensitive-data", "+crd-enricher:deckhouse:sensitive-data", marker{name: "sensitive-data", enricher: true}, true},
 		{"raw", "+crd-enricher:raw:pattern=^a$", marker{name: "raw:pattern", rawValue: "^a$", hasValue: true, enricher: true}, true},
+		{"unset", "+crd-enricher:unset:items.description", marker{name: "unset:items.description", enricher: true}, true},
 	}
 
 	for _, tc := range cases {
@@ -347,6 +348,100 @@ func TestApplyMarkersRawNestedKey(t *testing.T) {
 	}
 	if len(e2.warnings) == 0 {
 		t.Errorf("expected a warning for unresolved path")
+	}
+}
+
+func TestApplyMarkersUnsetKey(t *testing.T) {
+	e := &Enricher{}
+	schema := map[string]any{
+		"type":        "array",
+		"description": "field description",
+		"items": map[string]any{
+			"type":        "object",
+			"description": "vendored type description",
+			"properties": map[string]any{
+				"reason": map[string]any{"type": "string", "description": "vendored reason"},
+			},
+		},
+	}
+
+	e.applyMarkers(schema, []marker{
+		{name: "unset:items.description", enricher: true},
+		{name: "unset:items.properties.reason.description", enricher: true},
+	})
+
+	items := schema["items"].(map[string]any)
+	if _, ok := items["description"]; ok {
+		t.Errorf("items.description survived the unset marker")
+	}
+	if got := items["type"]; got != "object" {
+		t.Errorf("items.type = %#v, want the node left otherwise intact", got)
+	}
+	reason := items["properties"].(map[string]any)["reason"].(map[string]any)
+	if _, ok := reason["description"]; ok {
+		t.Errorf("items.properties.reason.description survived the unset marker")
+	}
+	if got := schema["description"]; got != "field description" {
+		t.Errorf("the field's own description = %#v, want it untouched", got)
+	}
+	if len(e.warnings) != 0 {
+		t.Errorf("unexpected warnings: %v", e.warnings)
+	}
+
+	// A single-element key addresses the node itself.
+	e2 := &Enricher{}
+	s2 := map[string]any{"type": "string", "description": "text"}
+	e2.applyMarkers(s2, []marker{{name: "unset:description", enricher: true}})
+	if _, ok := s2["description"]; ok {
+		t.Errorf("description survived the unset marker")
+	}
+	if len(e2.warnings) != 0 {
+		t.Errorf("unexpected warnings: %v", e2.warnings)
+	}
+}
+
+func TestApplyMarkersUnsetMissingWarns(t *testing.T) {
+	// A path whose parent is not there, and a key that is already absent, are
+	// both warnings: the marker was written to remove something, so removing
+	// nothing means it has outlived its target.
+	cases := []struct {
+		name   string
+		schema map[string]any
+		key    string
+	}{
+		{"missing parent", map[string]any{"type": "string"}, "unset:items.description"},
+		{"missing key", map[string]any{"type": "object", "items": map[string]any{"type": "object"}}, "unset:items.description"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := &Enricher{}
+			e.applyMarkers(tc.schema, []marker{{name: tc.key, enricher: true}})
+			if len(e.warnings) == 0 {
+				t.Fatalf("expected a warning for %q", tc.key)
+			}
+			if _, ok := tc.schema["description"]; ok {
+				t.Errorf("the marker must not touch the node it does not address")
+			}
+		})
+	}
+}
+
+func TestApplyMarkersUnsetIgnoresValue(t *testing.T) {
+	// unset carries no value. A marker written with one still removes the key,
+	// but says so rather than letting the author believe the value did anything.
+	e := &Enricher{}
+	schema := map[string]any{"type": "string", "description": "text"}
+
+	e.applyMarkers(schema, []marker{
+		{name: "unset:description", rawValue: "whatever", hasValue: true, enricher: true},
+	})
+
+	if _, ok := schema["description"]; ok {
+		t.Errorf("description survived the unset marker")
+	}
+	if len(e.warnings) != 1 {
+		t.Fatalf("warnings = %v, want exactly one about the ignored value", e.warnings)
 	}
 }
 

--- a/pkg/crd-enricher/enricher_test.go
+++ b/pkg/crd-enricher/enricher_test.go
@@ -16,6 +16,7 @@ package crdenricher
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -89,7 +90,7 @@ func TestApplyMarkersScalarAndFlag(t *testing.T) {
 		{name: "default", rawValue: "3m", hasValue: true, enricher: true},
 		{name: "deprecated", enricher: true},
 		{name: "kubebuilder:validation:Required"}, // not an enricher marker, ignored
-	})
+	}, nodeCtx{})
 
 	if got := schema["x-doc-default"]; got != "3m" {
 		t.Errorf("x-doc-default = %#v, want %q", got, "3m")
@@ -108,7 +109,7 @@ func TestApplyMarkersSensitiveData(t *testing.T) {
 
 	e.applyMarkers(schema, []marker{
 		{name: "sensitive-data", enricher: true},
-	})
+	}, nodeCtx{})
 
 	if got := schema["x-kubernetes-sensitive-data"]; got != true {
 		t.Errorf("x-kubernetes-sensitive-data = %#v, want true", got)
@@ -126,7 +127,7 @@ func TestApplyMarkersExamplesAccumulate(t *testing.T) {
 		{name: "examples", rawValue: "5m", hasValue: true, enricher: true},
 		{name: "examples", rawValue: "1h", hasValue: true, enricher: true},
 		{name: "examples", rawValue: "[10m, 20m]", hasValue: true, enricher: true},
-	})
+	}, nodeCtx{})
 
 	want := []any{"5m", "1h", "10m", "20m"}
 	if got := schema["x-doc-examples"]; !reflect.DeepEqual(got, want) {
@@ -136,15 +137,16 @@ func TestApplyMarkersExamplesAccumulate(t *testing.T) {
 
 func TestApplyMarkersExampleObject(t *testing.T) {
 	e := &Enricher{}
+	fs := &fileState{}
 	schema := map[string]any{"type": "object"}
 
 	// The keys are authored out of alphabetical order on purpose: an example
 	// object must keep the authored order instead of being sorted.
 	e.applyMarkers(schema, []marker{
 		{name: "examples", rawValue: "{kind: ModuleSource, spec: {registry: {repo: example.io, dockerCfg: secret}}}", hasValue: true, enricher: true},
-	})
+	}, nodeCtx{file: fs})
 
-	if !e.orderedExamples {
+	if !fs.orderedExamples {
 		t.Error("orderedExamples flag not set for an object example")
 	}
 
@@ -166,6 +168,7 @@ func TestApplyMarkersExampleObject(t *testing.T) {
 
 func TestApplyMarkersExamplesDescription(t *testing.T) {
 	e := &Enricher{}
+	fs := &fileState{}
 	schema := map[string]any{"type": "object"}
 
 	// Each examples marker is followed by its description; the pairs must render
@@ -175,9 +178,9 @@ func TestApplyMarkersExamplesDescription(t *testing.T) {
 		{name: "examples-description", rawValue: "my super example", hasValue: true, enricher: true},
 		{name: "examples", rawValue: "{field: value2}", hasValue: true, enricher: true},
 		{name: "examples-description", rawValue: "my super example two", hasValue: true, enricher: true},
-	})
+	}, nodeCtx{file: fs})
 
-	if !e.orderedExamples {
+	if !fs.orderedExamples {
 		t.Error("orderedExamples flag not set for described examples")
 	}
 
@@ -201,6 +204,7 @@ func TestApplyMarkersExamplesDescription(t *testing.T) {
 
 func TestApplyMarkersExamplesName(t *testing.T) {
 	e := &Enricher{}
+	fs := &fileState{}
 	schema := map[string]any{"type": "object"}
 
 	// A name alone (no description) switches to the wrapper form; the wrapper
@@ -208,9 +212,9 @@ func TestApplyMarkersExamplesName(t *testing.T) {
 	e.applyMarkers(schema, []marker{
 		{name: "examples", rawValue: "{field: value}", hasValue: true, enricher: true},
 		{name: "examples-name", rawValue: "My example", hasValue: true, enricher: true},
-	})
+	}, nodeCtx{file: fs})
 
-	if !e.orderedExamples {
+	if !fs.orderedExamples {
 		t.Error("orderedExamples flag not set for a named example")
 	}
 
@@ -235,7 +239,7 @@ func TestApplyMarkersExamplesNameAndDescription(t *testing.T) {
 		{name: "examples", rawValue: "5m", hasValue: true, enricher: true},
 		{name: "examples-name", rawValue: "five minutes", hasValue: true, enricher: true},
 		{name: "examples-description", rawValue: "a short interval", hasValue: true, enricher: true},
-	})
+	}, nodeCtx{})
 
 	want := []any{
 		orderedMap{
@@ -259,7 +263,7 @@ func TestApplyMarkersExamplesDescriptionMixed(t *testing.T) {
 		{name: "examples", rawValue: "5m", hasValue: true, enricher: true},
 		{name: "examples", rawValue: "1h", hasValue: true, enricher: true},
 		{name: "examples-description", rawValue: "one hour", hasValue: true, enricher: true},
-	})
+	}, nodeCtx{})
 
 	want := []any{
 		orderedMap{
@@ -282,7 +286,7 @@ func TestApplyMarkersExamplesDescriptionWithoutExample(t *testing.T) {
 	// A dangling description with no preceding example must warn and be dropped.
 	e.applyMarkers(schema, []marker{
 		{name: "examples-description", rawValue: "orphan", hasValue: true, enricher: true},
-	})
+	}, nodeCtx{})
 
 	if _, ok := schema["x-doc-examples"]; ok {
 		t.Errorf("x-doc-examples must stay unset: %#v", schema["x-doc-examples"])
@@ -298,7 +302,7 @@ func TestApplyMarkersRawKey(t *testing.T) {
 
 	e.applyMarkers(schema, []marker{
 		{name: "raw:pattern", rawValue: `^(\d+h)?(\d+m)?(\d+s)?$`, hasValue: true, enricher: true},
-	})
+	}, nodeCtx{})
 
 	if got := schema["pattern"]; got != `^(\d+h)?(\d+m)?(\d+s)?$` {
 		t.Errorf("pattern = %#v, want the regex", got)
@@ -325,7 +329,7 @@ func TestApplyMarkersRawNestedKey(t *testing.T) {
 	e.applyMarkers(schema, []marker{
 		{name: "raw:items.description", rawValue: "custom item description", hasValue: true, enricher: true},
 		{name: "raw:items.properties.reason.description", rawValue: "custom reason", hasValue: true, enricher: true},
-	})
+	}, nodeCtx{})
 
 	items := schema["items"].(map[string]any)
 	if got := items["description"]; got != "custom item description" {
@@ -342,7 +346,7 @@ func TestApplyMarkersRawNestedKey(t *testing.T) {
 	// A path that does not resolve must warn instead of growing the schema.
 	e2 := &Enricher{}
 	s2 := map[string]any{"type": "string"}
-	e2.applyMarkers(s2, []marker{{name: "raw:items.description", rawValue: "x", hasValue: true, enricher: true}})
+	e2.applyMarkers(s2, []marker{{name: "raw:items.description", rawValue: "x", hasValue: true, enricher: true}}, nodeCtx{})
 	if _, ok := s2["items"]; ok {
 		t.Errorf("nonexistent path should not be created")
 	}
@@ -368,7 +372,7 @@ func TestApplyMarkersUnsetKey(t *testing.T) {
 	e.applyMarkers(schema, []marker{
 		{name: "unset:items.description", enricher: true},
 		{name: "unset:items.properties.reason.description", enricher: true},
-	})
+	}, nodeCtx{})
 
 	items := schema["items"].(map[string]any)
 	if _, ok := items["description"]; ok {
@@ -391,7 +395,7 @@ func TestApplyMarkersUnsetKey(t *testing.T) {
 	// A single-element key addresses the node itself.
 	e2 := &Enricher{}
 	s2 := map[string]any{"type": "string", "description": "text"}
-	e2.applyMarkers(s2, []marker{{name: "unset:description", enricher: true}})
+	e2.applyMarkers(s2, []marker{{name: "unset:description", enricher: true}}, nodeCtx{})
 	if _, ok := s2["description"]; ok {
 		t.Errorf("description survived the unset marker")
 	}
@@ -416,7 +420,7 @@ func TestApplyMarkersUnsetMissingWarns(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			e := &Enricher{}
-			e.applyMarkers(tc.schema, []marker{{name: tc.key, enricher: true}})
+			e.applyMarkers(tc.schema, []marker{{name: tc.key, enricher: true}}, nodeCtx{})
 			if len(e.warnings) == 0 {
 				t.Fatalf("expected a warning for %q", tc.key)
 			}
@@ -435,7 +439,7 @@ func TestApplyMarkersUnsetIgnoresValue(t *testing.T) {
 
 	e.applyMarkers(schema, []marker{
 		{name: "unset:description", rawValue: "whatever", hasValue: true, enricher: true},
-	})
+	}, nodeCtx{})
 
 	if _, ok := schema["description"]; ok {
 		t.Errorf("description survived the unset marker")
@@ -445,8 +449,58 @@ func TestApplyMarkersUnsetIgnoresValue(t *testing.T) {
 	}
 }
 
+func TestWarningsCarryTheirLocation(t *testing.T) {
+	// A warning that does not say which manifest and which declaration it is
+	// about cannot be acted on: raw:description and unset:items.description are
+	// the most common markers in the set, and they recur across every CRD.
+	e := &Enricher{}
+	fs := &fileState{path: "/tmp/bin/crd/bases/storage.deckhouse.io_things.yaml"}
+	ctx := nodeCtx{file: fs}.at("ThingStatus", "Conditions")
+
+	e.applyMarkers(map[string]any{"type": "array"},
+		[]marker{{name: "unset:items.description", enricher: true}}, ctx)
+
+	if len(e.warnings) != 1 {
+		t.Fatalf("warnings = %v, want exactly one", e.warnings)
+	}
+	got := e.warnings[0]
+	for _, want := range []string{
+		"storage.deckhouse.io_things.yaml", // the manifest, by base name only
+		"ThingStatus.Conditions",           // the Go declaration the marker sat on
+		"items.description",                // the marker's own subject
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("warning %q does not carry %q", got, want)
+		}
+	}
+	if strings.Contains(got, "/tmp/bin/crd/bases") {
+		t.Errorf("warning %q spells the whole path; the base name is what identifies the file", got)
+	}
+}
+
+func TestWarningsAreDeduplicated(t *testing.T) {
+	// The same marker is visited once per version of every document naming its
+	// kind, so an unfiltered list repeats each problem and buries the distinct
+	// ones.
+	e := &Enricher{}
+	ctx := nodeCtx{file: &fileState{path: "things.yaml"}}.at("ThingSpec", "Phase")
+
+	for range 3 {
+		e.applyMarkers(map[string]any{"type": "string"},
+			[]marker{{name: "unset:absent", enricher: true}}, ctx)
+	}
+
+	if got := e.Warnings(); len(got) != 1 {
+		t.Errorf("Warnings() = %v, want the repeats collapsed to one", got)
+	}
+	if len(e.warnings) != 3 {
+		t.Errorf("the raw list should keep every occurrence, got %v", e.warnings)
+	}
+}
+
 func TestApplyCRDMarkers(t *testing.T) {
 	e := &Enricher{}
+	fs := &fileState{}
 	crd := map[string]any{
 		"metadata": map[string]any{
 			"annotations": map[string]any{"controller-gen.kubebuilder.io/version": "v0.19.0"},
@@ -479,9 +533,9 @@ func TestApplyCRDMarkers(t *testing.T) {
 		{name: "crd:preserveUnknownFields", rawValue: "false", hasValue: true, enricher: true},
 		{name: "crd:minimal", rawValue: "true", hasValue: true, enricher: true},
 		{name: "crd:stripFormat", rawValue: "true", hasValue: true, enricher: true},
-	})
+	}, nodeCtx{file: fs})
 
-	if !e.curatedStyle {
+	if !fs.curatedStyle {
 		t.Error("curatedStyle not set")
 	}
 

--- a/pkg/crd-enricher/enricher_test.go
+++ b/pkg/crd-enricher/enricher_test.go
@@ -495,10 +495,12 @@ func TestApplyMarkersUnsetRefusesStructuralKeys(t *testing.T) {
 	}
 }
 
-func TestApplyMarkersUnsetReportsEmptiedParent(t *testing.T) {
+func TestApplyMarkersUnsetRefusesToEmptyParent(t *testing.T) {
 	// items: {} is not the same schema as no items at all, and under type: array
-	// it is not a valid one either. The removal still happens -- the author asked
-	// for it -- but silence here is what would send them to a stand to find out.
+	// the apiserver rejects it outright ("must not be empty for specified object
+	// fields"). Refused rather than done-and-warned, because a warning is not fatal
+	// by default: obeying would ship a document that fails at apply time, with
+	// nothing in the failure naming the marker that caused it.
 	e := &Enricher{}
 	schema := map[string]any{
 		"type":  "array",
@@ -508,11 +510,57 @@ func TestApplyMarkersUnsetReportsEmptiedParent(t *testing.T) {
 	e.applyMarkers(schema, []marker{{name: "unset:items.description", enricher: true}}, nodeCtx{})
 
 	items := schema["items"].(map[string]any)
-	if len(items) != 0 {
-		t.Errorf("items = %#v, want it emptied", items)
+	if len(items) != 1 || items["description"] != "the only key" {
+		t.Errorf("items = %#v, want it left alone", items)
 	}
-	if len(e.warnings) != 1 || !strings.Contains(e.warnings[0], "left its parent node empty") {
-		t.Errorf("warnings = %v, want one about the emptied parent", e.warnings)
+	if len(e.warnings) != 1 || !strings.Contains(e.warnings[0], "would leave its parent node empty") {
+		t.Errorf("warnings = %v, want one about refusing to empty the parent", e.warnings)
+	}
+}
+
+func TestApplyMarkersUnsetWarnsOnValidationKeys(t *testing.T) {
+	// Removing a validation key is legal and applies cleanly, which is exactly why
+	// it needs saying: the API then admits values it used to reject, and the crds/
+	// re-render gate cannot notice -- the committed manifest and the render both
+	// come from this marker.
+	for _, key := range []string{"enum", "required", "maxLength", "x-kubernetes-validations"} {
+		t.Run(key, func(t *testing.T) {
+			e := &Enricher{}
+			schema := map[string]any{
+				"type": "string",
+				key:    "whatever the key holds",
+				"keep": "so the parent does not end up empty",
+			}
+
+			e.applyMarkers(schema, []marker{{name: "unset:" + key, enricher: true}}, nodeCtx{})
+
+			if _, still := schema[key]; still {
+				t.Errorf("%s survived; unset: is expected to obey here, only to say so", key)
+			}
+			if len(e.warnings) != 1 || !strings.Contains(e.warnings[0], "removes the validation key") {
+				t.Errorf("warnings = %v, want one naming the validation key", e.warnings)
+			}
+		})
+	}
+}
+
+func TestApplyMarkersUnsetStaysQuietOnDescription(t *testing.T) {
+	// The motivating case must not become noisy: items.description is what unset:
+	// exists for.
+	e := &Enricher{}
+	schema := map[string]any{
+		"type":        "string",
+		"description": "from a vendored type",
+		"keep":        "so the parent does not end up empty",
+	}
+
+	e.applyMarkers(schema, []marker{{name: "unset:description", enricher: true}}, nodeCtx{})
+
+	if _, still := schema["description"]; still {
+		t.Error("description survived")
+	}
+	if len(e.warnings) != 0 {
+		t.Errorf("warnings = %v, want none", e.warnings)
 	}
 }
 

--- a/pkg/crd-enricher/enricher_test.go
+++ b/pkg/crd-enricher/enricher_test.go
@@ -15,6 +15,7 @@
 package crdenricher
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -446,6 +447,118 @@ func TestApplyMarkersUnsetIgnoresValue(t *testing.T) {
 	}
 	if len(e.warnings) != 1 {
 		t.Fatalf("warnings = %v, want exactly one about the ignored value", e.warnings)
+	}
+}
+
+func TestApplyMarkersUnsetRefusesStructuralKeys(t *testing.T) {
+	// Removing "items" from an array node, or "type" from any node, produces a
+	// manifest the apiserver rejects with a message that says nothing about the
+	// marker that caused it. Refusing keeps the document applicable and puts the
+	// complaint where the author can act on it.
+	for _, tc := range []struct {
+		name   string
+		schema map[string]any
+		key    string
+	}{
+		{
+			name:   "items on an array node",
+			schema: map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
+			key:    "unset:items",
+		},
+		{
+			name:   "type on the node itself",
+			schema: map[string]any{"type": "string", "description": "text"},
+			key:    "unset:type",
+		},
+		{
+			name: "type of a nested node",
+			schema: map[string]any{
+				"type":  "array",
+				"items": map[string]any{"type": "object", "description": "text"},
+			},
+			key: "unset:items.type",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			e := &Enricher{}
+			before := fmt.Sprintf("%v", tc.schema)
+
+			e.applyMarkers(tc.schema, []marker{{name: tc.key, enricher: true}}, nodeCtx{})
+
+			if got := fmt.Sprintf("%v", tc.schema); got != before {
+				t.Errorf("schema changed: %s", got)
+			}
+			if len(e.warnings) != 1 || !strings.Contains(e.warnings[0], "structural schema requires") {
+				t.Errorf("warnings = %v, want one naming the structural requirement", e.warnings)
+			}
+		})
+	}
+}
+
+func TestApplyMarkersUnsetReportsEmptiedParent(t *testing.T) {
+	// items: {} is not the same schema as no items at all, and under type: array
+	// it is not a valid one either. The removal still happens -- the author asked
+	// for it -- but silence here is what would send them to a stand to find out.
+	e := &Enricher{}
+	schema := map[string]any{
+		"type":  "array",
+		"items": map[string]any{"description": "the only key"},
+	}
+
+	e.applyMarkers(schema, []marker{{name: "unset:items.description", enricher: true}}, nodeCtx{})
+
+	items := schema["items"].(map[string]any)
+	if len(items) != 0 {
+		t.Errorf("items = %#v, want it emptied", items)
+	}
+	if len(e.warnings) != 1 || !strings.Contains(e.warnings[0], "left its parent node empty") {
+		t.Errorf("warnings = %v, want one about the emptied parent", e.warnings)
+	}
+}
+
+func TestApplyMarkersKeylessMarkersWarn(t *testing.T) {
+	// "raw:" and "unset:" with nothing after the colon used to be reported as a
+	// path that is missing from the schema, sending the author to look for a node
+	// instead of at their own typo.
+	for _, tc := range []struct {
+		name string
+		key  string
+		want string
+	}{
+		{name: "raw", key: "raw:", want: "raw marker has no key"},
+		{name: "unset", key: "unset:", want: "unset marker has no key"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			e := &Enricher{}
+			schema := map[string]any{"type": "string"}
+
+			e.applyMarkers(schema, []marker{{name: tc.key, enricher: true}}, nodeCtx{})
+
+			if len(e.warnings) != 1 || !strings.Contains(e.warnings[0], tc.want) {
+				t.Errorf("warnings = %v, want one containing %q", e.warnings, tc.want)
+			}
+		})
+	}
+}
+
+func TestApplyMarkersRawWithoutValueRefused(t *testing.T) {
+	// A value-less raw: marker decoded to null and wrote it, producing a
+	// description the apiserver rejects. The only thing its author could have
+	// meant is the removal unset: now does, so the marker is refused and says so.
+	e := &Enricher{}
+	schema := map[string]any{
+		"type":  "array",
+		"items": map[string]any{"type": "object", "description": "vendored"},
+	}
+
+	e.applyMarkers(schema, []marker{{name: "raw:items.description", enricher: true}}, nodeCtx{})
+
+	items := schema["items"].(map[string]any)
+	if got := items["description"]; got != "vendored" {
+		t.Errorf("items.description = %#v, want it left alone rather than nulled", got)
+	}
+	if len(e.warnings) != 1 || !strings.Contains(e.warnings[0], "unset:items.description") {
+		t.Errorf("warnings = %v, want one pointing at the unset marker", e.warnings)
 	}
 }
 

--- a/pkg/crd-enricher/examples.go
+++ b/pkg/crd-enricher/examples.go
@@ -45,12 +45,12 @@ const (
 // case the CRD root receives a synthesized example carrying apiVersion, kind and
 // metadata. A node that already has an explicit examples marker is left
 // untouched: explicit examples always win over generated ones.
-func (e *Enricher) generateExamples(spec, names map[string]any, version string, root map[string]any) {
+func (e *Enricher) generateExamples(spec, names map[string]any, version string, root map[string]any, fs *fileState) {
 	if root == nil {
 		return
 	}
 
-	if e.exampleScope == exampleScopeTree {
+	if fs != nil && fs.exampleScope == exampleScopeTree {
 		e.attachTreeExamples(root)
 	}
 

--- a/pkg/crd-enricher/examples_test.go
+++ b/pkg/crd-enricher/examples_test.go
@@ -123,7 +123,7 @@ func TestGenerateExamplesRoot(t *testing.T) {
 		},
 	}
 
-	e.generateExamples(spec, names, "v1alpha1", root)
+	e.generateExamples(spec, names, "v1alpha1", root, nil)
 
 	examples, ok := root["x-doc-examples"].([]any)
 	if !ok || len(examples) != 1 {
@@ -162,7 +162,7 @@ func TestGenerateExamplesExplicitRootWins(t *testing.T) {
 		},
 	}
 
-	e.generateExamples(spec, names, "v1", root)
+	e.generateExamples(spec, names, "v1", root, nil)
 
 	if !reflect.DeepEqual(root["x-doc-examples"], hand) {
 		t.Fatalf("explicit root example overwritten: %#v", root["x-doc-examples"])
@@ -170,7 +170,8 @@ func TestGenerateExamplesExplicitRootWins(t *testing.T) {
 }
 
 func TestGenerateExamplesTreeScope(t *testing.T) {
-	e := &Enricher{exampleScope: exampleScopeTree}
+	e := &Enricher{}
+	fs := &fileState{exampleScope: exampleScopeTree}
 	spec := map[string]any{"group": "deckhouse.io"}
 	names := map[string]any{"kind": "Foo"}
 	registry := map[string]any{
@@ -186,7 +187,7 @@ func TestGenerateExamplesTreeScope(t *testing.T) {
 		"properties": map[string]any{"spec": specNode},
 	}
 
-	e.generateExamples(spec, names, "v1", root)
+	e.generateExamples(spec, names, "v1", root, fs)
 
 	if _, ok := registry["x-doc-examples"]; !ok {
 		t.Error("nested registry node did not receive a composite example")

--- a/pkg/crd-enricher/kuberoot_test.go
+++ b/pkg/crd-enricher/kuberoot_test.go
@@ -1,0 +1,184 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crdenricher
+
+import (
+	"go/token"
+	"go/types"
+	"testing"
+)
+
+// The types here are synthesized rather than loaded from a fixture package on
+// purpose: the rule under test is keyed on the *import path* of the embedded
+// structs, and a fixture would have to pull k8s.io/apimachinery into this tool
+// module's go.mod (or add a stub module under testdata, of which this repository
+// has none) just to spell that path. Building the types directly pins the rule
+// exactly -- embedded, right package, both names -- with nothing in between.
+
+// metaStruct builds a stand-in for one of the metav1 structs: only its name and
+// package path matter to embedsObjectMeta.
+func metaStruct(pkg *types.Package, name string) *types.Named {
+	obj := types.NewTypeName(token.NoPos, pkg, name, nil)
+	return types.NewNamed(obj, types.NewStruct(nil, nil), nil)
+}
+
+// objectLike builds a named struct type embedding (or merely holding) the given
+// metav1 stand-ins, the way a Kubernetes API type does.
+func objectLike(name string, embedded bool, metas ...*types.Named) *types.Named {
+	apiPkg := types.NewPackage("example.io/api/v1alpha1", "v1alpha1")
+
+	fields := make([]*types.Var, 0, len(metas))
+	tags := make([]string, 0, len(metas))
+	for _, meta := range metas {
+		fields = append(fields, types.NewField(token.NoPos, apiPkg, meta.Obj().Name(), meta, embedded))
+		tags = append(tags, `json:",inline"`)
+	}
+
+	obj := types.NewTypeName(token.NoPos, apiPkg, name, nil)
+	return types.NewNamed(obj, types.NewStruct(fields, tags), nil)
+}
+
+// TestEmbedsObjectMeta pins the rule controller-gen's CRD generator applies:
+// FindKubeKinds selects a type by the metav1 structs it embeds, and nothing else.
+func TestEmbedsObjectMeta(t *testing.T) {
+	metav1Pkg := types.NewPackage(metav1PkgPath, "v1")
+	vendored := types.NewPackage("example.io/mod/vendor/"+metav1PkgPath, "v1")
+	lookalike := types.NewPackage("example.io/api/meta/v1", "v1")
+
+	typeMeta := metaStruct(metav1Pkg, "TypeMeta")
+	objectMeta := metaStruct(metav1Pkg, "ObjectMeta")
+
+	notAStruct := types.NewNamed(
+		types.NewTypeName(token.NoPos, metav1Pkg, "Duration", nil), types.Typ[types.String], nil)
+
+	for _, tc := range []struct {
+		name string
+		typ  *types.Named
+		want bool
+		why  string
+	}{
+		{
+			name: "both structs embedded",
+			typ:  objectLike("Thing", true, typeMeta, objectMeta),
+			want: true,
+			why:  "this is exactly what FindKubeKinds looks for",
+		},
+		{
+			name: "only TypeMeta embedded",
+			typ:  objectLike("ThingList", true, typeMeta),
+			want: false,
+			why:  "a List embeds TypeMeta and ListMeta, and gets no CRD of its own",
+		},
+		{
+			name: "only ObjectMeta embedded",
+			typ:  objectLike("Partial", true, objectMeta),
+			want: false,
+			why:  "both are required, as in FindKubeKinds",
+		},
+		{
+			name: "both present but as named fields",
+			typ:  objectLike("Wrapper", false, typeMeta, objectMeta),
+			want: false,
+			why:  "FindKubeKinds skips fields that carry a name",
+		},
+		{
+			name: "vendored apimachinery",
+			typ: objectLike("Vendored", true,
+				metaStruct(vendored, "TypeMeta"), metaStruct(vendored, "ObjectMeta")),
+			want: true,
+			why:  "a vendored path names the same structs",
+		},
+		{
+			name: "same names from another package",
+			typ: objectLike("Impostor", true,
+				metaStruct(lookalike, "TypeMeta"), metaStruct(lookalike, "ObjectMeta")),
+			want: false,
+			why:  "controller-gen compares the metav1 package, not the type names",
+		},
+		{
+			name: "not a struct at all",
+			typ:  notAStruct,
+			want: false,
+			why:  "a named scalar has no fields to embed",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := embedsObjectMeta(tc.typ); got != tc.want {
+				t.Errorf("embedsObjectMeta() = %v, want %v: %s", got, tc.want, tc.why)
+			}
+		})
+	}
+}
+
+// TestIsCRDRoot pins the regression that made this rule necessary: a type that
+// embeds the metav1 structs gets a CRD from controller-gen whatever its root
+// marker says, so its crd-enricher markers have a manifest to land in. Keying the
+// root set on the marker alone dropped every one of them without a word.
+func TestIsCRDRoot(t *testing.T) {
+	metav1Pkg := types.NewPackage(metav1PkgPath, "v1")
+	object := objectLike("Thing", true,
+		metaStruct(metav1Pkg, "TypeMeta"), metaStruct(metav1Pkg, "ObjectMeta"))
+	plain := objectLike("Plain", true)
+
+	for _, tc := range []struct {
+		name    string
+		markers []marker
+		typ     *types.Named
+		want    bool
+		why     string
+	}{
+		{
+			name:    "object:root=false does not opt out of CRD generation",
+			markers: []marker{{name: rootMarker, rawValue: "false", hasValue: true}},
+			typ:     object,
+			want:    true,
+			why:     "controller-gen renders the CRD regardless; the markers must be applied",
+		},
+		{
+			name:    "no root marker at all",
+			markers: nil,
+			typ:     object,
+			want:    true,
+			why:     "FindKubeKinds needs no marker, and neither may the enricher",
+		},
+		{
+			name:    "the kubebuilder marker without the embedding",
+			markers: []marker{{name: rootMarker}},
+			typ:     plain,
+			want:    true,
+			why:     "the marker stays a fallback for types that declare themselves objects",
+		},
+		{
+			name:    "the legacy marker without the embedding",
+			markers: []marker{{name: legacyRootMarker, rawValue: runtimeObject, hasValue: true}},
+			typ:     plain,
+			want:    true,
+			why:     "same fallback, pre-kubebuilder spelling",
+		},
+		{
+			name:    "neither the embedding nor a marker",
+			markers: []marker{{name: "k8s:deepcopy-gen", rawValue: "true", hasValue: true}},
+			typ:     plain,
+			want:    false,
+			why:     "nothing here gets a CRD",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isCRDRoot(tc.markers, tc.typ); got != tc.want {
+				t.Errorf("isCRDRoot() = %v, want %v: %s", got, tc.want, tc.why)
+			}
+		})
+	}
+}

--- a/pkg/crd-enricher/legacyroot_test.go
+++ b/pkg/crd-enricher/legacyroot_test.go
@@ -1,0 +1,77 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crdenricher
+
+import "testing"
+
+// TestLegacyRootGolden captures the pre-kubebuilder root marker: a type that
+// only declares the runtime.Object deepcopy interface is a CRD root for
+// controller-gen, so its crd-enricher markers -- the CRD-level setting and the
+// field example alike -- have to be applied rather than dropped.
+func TestLegacyRootGolden(t *testing.T) {
+	assertGolden(t, "legacyroot.yaml", runFixture(t, "legacyroot.yaml", false))
+}
+
+// TestIsRootObject pins the two spellings controller-gen accepts, and the two
+// that look close enough to be mistaken for them.
+func TestIsRootObject(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		markers []marker
+		want    bool
+	}{
+		{
+			name:    "kubebuilder marker without a value",
+			markers: []marker{{name: rootMarker}},
+			want:    true,
+		},
+		{
+			name:    "kubebuilder marker set to true",
+			markers: []marker{{name: rootMarker, rawValue: "true", hasValue: true}},
+			want:    true,
+		},
+		{
+			name:    "kubebuilder marker set to false opts out",
+			markers: []marker{{name: rootMarker, rawValue: "false", hasValue: true}},
+			want:    false,
+		},
+		{
+			name:    "legacy marker naming runtime.Object",
+			markers: []marker{{name: legacyRootMarker, rawValue: runtimeObject, hasValue: true}},
+			want:    true,
+		},
+		{
+			name:    "legacy marker naming another interface",
+			markers: []marker{{name: legacyRootMarker, rawValue: "example.io/api.Copier", hasValue: true}},
+			want:    false,
+		},
+		{
+			name:    "deepcopy-gen alone is not a root",
+			markers: []marker{{name: "k8s:deepcopy-gen", rawValue: "true", hasValue: true}},
+			want:    false,
+		},
+		{
+			name:    "no markers at all",
+			markers: nil,
+			want:    false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isRootObject(tc.markers); got != tc.want {
+				t.Errorf("isRootObject() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/crd-enricher/legacyroot_test.go
+++ b/pkg/crd-enricher/legacyroot_test.go
@@ -14,14 +14,62 @@
 
 package crdenricher
 
-import "testing"
+import (
+	"testing"
 
-// TestLegacyRootGolden captures the pre-kubebuilder root marker: a type that
-// only declares the runtime.Object deepcopy interface is a CRD root for
-// controller-gen, so its crd-enricher markers -- the CRD-level setting and the
-// field example alike -- have to be applied rather than dropped.
+	"sigs.k8s.io/yaml"
+)
+
+// TestLegacyRootGolden captures the marker fallback: a type declaring only the
+// pre-kubebuilder runtime.Object deepcopy interface is still treated as a root,
+// so its crd-enricher markers are applied rather than dropped.
+//
+// The golden pins what was actually lost in the real case, not just that
+// something was applied: crd:minimal has to strip the listKind, the implicit
+// apiVersion/kind/metadata root properties and the generator-version annotation,
+// because all of them would otherwise reach a module's public API reference page.
 func TestLegacyRootGolden(t *testing.T) {
-	assertGolden(t, "legacyroot.yaml", runFixture(t, "legacyroot.yaml", false))
+	got := runFixture(t, "legacyroot.yaml", false)
+	assertGolden(t, "legacyroot.yaml", got)
+
+	var crd map[string]any
+	if err := yaml.Unmarshal(got, &crd); err != nil {
+		t.Fatalf("parse enriched manifest: %v", err)
+	}
+
+	spec := childMap(crd, "spec")
+	if names := childMap(spec, "names"); names != nil {
+		if _, ok := names["listKind"]; ok {
+			t.Error("crd:minimal left names.listKind in the manifest")
+		}
+	}
+	if annotations := childMap(childMap(crd, "metadata"), "annotations"); annotations != nil {
+		if _, ok := annotations["controller-gen.kubebuilder.io/version"]; ok {
+			t.Error("crd:minimal left the generator-version annotation in the manifest")
+		}
+	}
+	if pres, ok := spec["preserveUnknownFields"]; !ok || pres != false {
+		t.Errorf("spec.preserveUnknownFields = %#v, want false", pres)
+	}
+
+	versions, _ := spec["versions"].([]any)
+	if len(versions) != 1 {
+		t.Fatalf("versions = %#v, want exactly one", versions)
+	}
+	version, _ := versions[0].(map[string]any)
+	root := childMap(childMap(version, "schema"), "openAPIV3Schema")
+	props := childMap(root, "properties")
+	for _, implicit := range []string{"apiVersion", "kind", "metadata"} {
+		if _, ok := props[implicit]; ok {
+			t.Errorf("crd:minimal left the implicit root property %q in the schema", implicit)
+		}
+	}
+	// The field marker has to have landed too: the CRD-level half working on its
+	// own would not prove the type entered the root set the walk descends from.
+	name := childMap(childMap(props, "spec"), "properties")
+	if _, ok := childMap(name, "name")["x-doc-examples"]; !ok {
+		t.Error("the field example marker was not applied")
+	}
 }
 
 // TestIsRootObject pins the two spellings controller-gen accepts, and the two

--- a/pkg/crd-enricher/loader.go
+++ b/pkg/crd-enricher/loader.go
@@ -19,6 +19,7 @@ import (
 	"go/ast"
 	"go/token"
 	"go/types"
+	"strings"
 
 	"golang.org/x/tools/go/packages"
 )
@@ -158,11 +159,81 @@ func (info *packageInfo) collectType(pkg *packages.Package, typeSpec *ast.TypeSp
 		info.collectFields(name, structType)
 	}
 
-	if isRootObject(markers) {
-		if named := lookupNamed(pkg.Types, name); named != nil {
-			info.roots[name] = named
+	if named := lookupNamed(pkg.Types, name); named != nil && isCRDRoot(markers, named) {
+		info.roots[name] = named
+	}
+}
+
+// metav1PkgPath is the import path of the package whose TypeMeta and ObjectMeta
+// structs are what makes a Go type a Kubernetes object.
+const metav1PkgPath = "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+// isCRDRoot reports whether a type gets a CRD from controller-gen, and therefore
+// whether its crd-enricher markers have a manifest to be applied to.
+//
+// The decisive half is the embedding, not the markers. controller-gen's CRD
+// generator never looks at +kubebuilder:object:root: FindKubeKinds
+// (controller-tools pkg/crd/gen.go) "locates all types that contain TypeMeta and
+// ObjectMeta (and thus may be a Kubernetes object)" and renders a CRD for every
+// one of them. The root markers are read by a different generator -- the deepcopy
+// one -- and only decide whether the type gets a DeepCopyObject method.
+//
+// Keying the root set on the marker alone is what let a whole CRD's settings be
+// dropped without a word: a type embedding both structs but spelling
+// object:root=false, or spelling no root marker at all, still gets a manifest,
+// and every marker on it used to be silently ignored because the type never
+// entered packageInfo.roots.
+//
+// isRootObject stays as a fallback for types that declare themselves objects
+// without embedding the metav1 structs. It can only add roots, never remove
+// them, so a spurious one is inert: enrichCRD matches a root against the kind of
+// an actual CRD document, and a type no manifest names is never visited.
+func isCRDRoot(markers []marker, named *types.Named) bool {
+	return embedsObjectMeta(named) || isRootObject(markers)
+}
+
+// embedsObjectMeta reports whether a struct embeds both metav1.TypeMeta and
+// metav1.ObjectMeta, mirroring controller-gen's FindKubeKinds. Only embedded
+// fields count, exactly as there: a named field of either type does not make the
+// enclosing struct an object.
+func embedsObjectMeta(named *types.Named) bool {
+	structType, ok := named.Underlying().(*types.Struct)
+	if !ok {
+		return false
+	}
+
+	var hasTypeMeta, hasObjectMeta bool
+	for i := 0; i < structType.NumFields(); i++ {
+		field := structType.Field(i)
+		if !field.Embedded() {
+			continue
+		}
+		embedded := namedOf(field.Type())
+		if embedded == nil {
+			continue
+		}
+		obj := embedded.Obj()
+		if obj.Pkg() == nil || nonVendorPath(obj.Pkg().Path()) != metav1PkgPath {
+			continue
+		}
+		switch obj.Name() {
+		case "TypeMeta":
+			hasTypeMeta = true
+		case "ObjectMeta":
+			hasObjectMeta = true
 		}
 	}
+	return hasTypeMeta && hasObjectMeta
+}
+
+// nonVendorPath strips the vendor prefix from an import path so a vendored
+// apimachinery compares equal to the module-cache one, the way controller-gen's
+// loader.NonVendorPath does.
+func nonVendorPath(path string) string {
+	if idx := strings.LastIndex(path, "/vendor/"); idx >= 0 {
+		return path[idx+len("/vendor/"):]
+	}
+	return strings.TrimPrefix(path, "vendor/")
 }
 
 // collectFields records the markers attached to every field of a struct,

--- a/pkg/crd-enricher/loader.go
+++ b/pkg/crd-enricher/loader.go
@@ -158,7 +158,7 @@ func (info *packageInfo) collectType(pkg *packages.Package, typeSpec *ast.TypeSp
 		info.collectFields(name, structType)
 	}
 
-	if hasMarker(markers, rootMarker) {
+	if isRootObject(markers) {
 		if named := lookupNamed(pkg.Types, name); named != nil {
 			info.roots[name] = named
 		}

--- a/pkg/crd-enricher/markers.go
+++ b/pkg/crd-enricher/markers.go
@@ -244,6 +244,18 @@ func (m marker) isDoc() bool {
 	return m.enricher
 }
 
+// hasEnricherMarker reports whether the slice holds a marker the enricher acts
+// on. Everything else in it -- +optional, the kubebuilder markers -- belongs to
+// another generator, so its presence is not a reason to say anything.
+func hasEnricherMarker(markers []marker) bool {
+	for _, m := range markers {
+		if m.isDoc() {
+			return true
+		}
+	}
+	return false
+}
+
 // parseMarkerLine turns a single trimmed comment line into a marker. The
 // boolean result is false when the line is not a marker (does not start with a
 // plus sign).

--- a/pkg/crd-enricher/markers.go
+++ b/pkg/crd-enricher/markers.go
@@ -21,24 +21,27 @@ import (
 
 // markerPrefix namespaces every marker owned by the enricher. It is the single,
 // canonical root every enricher marker carries; no bare or legacy forms are
-// honoured. Three shapes are recognised:
+// honoured. These shapes are recognised:
 //
 //	+crd-enricher:raw:<key>[=<value>]                        // raw schema injection
+//	+crd-enricher:unset:<key>                                // raw schema removal
 //	+crd-enricher:deckhouse:documentation:<entity>[=<value>] // documentation entity
 //	+crd-enricher:crd:<key>[=<value>]                        // CRD-level setting
 //	+crd-enricher:deckhouse:sensitive-data                   // sensitive field flag
 //
-// The raw entity lives directly under the prefix because it injects a standard
-// schema field rather than deckhouse-specific documentation. The documentation
-// entities (examples, deprecated, default) carry the extra
-// "deckhouse:documentation" sub-namespace. The sensitive-data entity configures
-// the schema and carries the shorter "deckhouse" sub-namespace. The crd entity
-// lives directly under the prefix (no sub-namespace). Every shape is reduced to
-// the bare entity name during parsing so the rest of the enricher matches on it.
+// The raw and unset entities live directly under the prefix because they inject
+// and remove a standard schema field rather than deckhouse-specific
+// documentation. The documentation entities (examples, deprecated, default)
+// carry the extra "deckhouse:documentation" sub-namespace. The sensitive-data
+// entity configures the schema and carries the shorter "deckhouse"
+// sub-namespace. The crd entity lives directly under the prefix (no
+// sub-namespace). Every shape is reduced to the bare entity name during parsing
+// so the rest of the enricher matches on it.
 const markerPrefix = "crd-enricher:"
 
 // docSubPrefix is the "deckhouse:documentation" sub-namespace stripped from the
-// documentation entities after markerPrefix. The raw entity does not carry it.
+// documentation entities after markerPrefix. The raw and unset entities do not
+// carry it.
 const docSubPrefix = "deckhouse:documentation:"
 
 // deckhouseSubPrefix is the "deckhouse" sub-namespace stripped from the
@@ -100,6 +103,21 @@ const (
 // directly (such as a regex pattern on a metav1.Duration). A dotted <key> walks
 // into nested schema nodes.
 const rawMarkerPrefix = "raw:"
+
+// unsetMarkerPrefix is the entity that deletes a standard schema field named by
+// the <key> that follows it, the mirror of rawMarkerPrefix. It takes no value:
+//
+//	+crd-enricher:unset:items.description
+//
+// It exists because raw: can only overwrite. A node controller-gen fills in from
+// a vendored type -- items.description on a []metav1.Condition field is the
+// worked example -- can be given different text with raw:, but not taken out, and
+// a hand-curated manifest that never carried the field cannot be reproduced from
+// the Go types while the field is there. A dotted <key> walks into nested schema
+// nodes, exactly as raw: does, and a key that is already absent is reported as a
+// warning rather than silently accepted, so a marker left behind by a generator
+// bump does not pass for a working one.
+const unsetMarkerPrefix = "unset:"
 
 // crdMarker is the type-level entity that configures CRD-level settings that
 // controller-gen cannot express (preserveUnknownFields, the minimal style and

--- a/pkg/crd-enricher/markers.go
+++ b/pkg/crd-enricher/markers.go
@@ -165,29 +165,31 @@ const sensitiveDataMarker = "sensitive-data"
 // sensitiveDataKey is the schema field the sensitiveDataMarker renders to.
 const sensitiveDataKey = "x-kubernetes-sensitive-data"
 
-// rootMarker is the controller-gen marker that designates a Go type as the
-// root object of a CRD. The enricher relies on it to know which types map to a
-// generated CRD.
+// rootMarker is the controller-gen marker that declares a Go type an object
+// root. Beware: it does NOT gate CRD generation -- see isCRDRoot for the rule
+// controller-gen's CRD generator actually applies. It is honoured here only as a
+// secondary signal, for types that announce themselves as objects without
+// embedding the metav1 structs (the enricher's own fixtures, for one).
 const rootMarker = "kubebuilder:object:root"
 
-// legacyRootMarker is the pre-kubebuilder marker that designates a root object,
-// by declaring that deepcopy-gen should give the type a DeepCopyObject method.
-// controller-gen still honours it and renders a CRD for such a type, so the
-// enricher has to recognise it too: a package that carries only this form used
-// to have every crd-enricher marker on its root type silently ignored, because
-// the type never made it into packageInfo.roots.
+// legacyRootMarker is the pre-kubebuilder spelling of rootMarker, declaring that
+// deepcopy-gen should give the type a DeepCopyObject method. controller-gen's
+// deepcopy generator still honours it (pkg/deepcopy/gen.go, genObjectInterface),
+// so the enricher recognises it for the same reason it recognises rootMarker.
 const legacyRootMarker = "k8s:deepcopy-gen:interfaces"
 
 // runtimeObject is the interface the legacy marker has to name for the type to
-// be a root object rather than merely deep-copyable.
+// be an object root rather than merely deep-copyable. controller-gen compares
+// the whole marker value against this path, so a comma-separated list of
+// interfaces does not match there either -- matching it here would diverge.
 const runtimeObject = "k8s.io/apimachinery/pkg/runtime.Object"
 
-// isRootObject reports whether the markers designate a CRD root type, by either
+// isRootObject reports whether the markers declare an object root, by either
 // spelling controller-gen accepts.
 //
-// The value of the kubebuilder marker is honoured: "object:root=false" is how a
-// type opts out, and treating it as a root would apply CRD-level settings to a
-// kind that has no CRD.
+// The value of the kubebuilder marker is honoured, so "object:root=false" makes
+// this return false -- but that is not an opt-out from CRD generation, and
+// isCRDRoot is where that distinction is handled.
 func isRootObject(markers []marker) bool {
 	for _, m := range markers {
 		switch m.name {

--- a/pkg/crd-enricher/markers.go
+++ b/pkg/crd-enricher/markers.go
@@ -129,6 +129,33 @@ var structuralKeys = map[string]bool{
 	"items": true,
 }
 
+// validationKeys are the schema fields that decide what the apiserver accepts.
+// Removing one is legal -- the resulting document applies cleanly -- and that is
+// the problem: the API silently starts admitting values it used to reject, and the
+// crds/ re-render gate cannot notice, because the committed manifest and the render
+// both come from the same marker. So unset: obeys here and says so, rather than
+// refusing as it does for structuralKeys.
+var validationKeys = map[string]bool{
+	"enum":                     true,
+	"exclusiveMaximum":         true,
+	"exclusiveMinimum":         true,
+	"format":                   true,
+	"maxItems":                 true,
+	"maxLength":                true,
+	"maxProperties":            true,
+	"maximum":                  true,
+	"minItems":                 true,
+	"minLength":                true,
+	"minProperties":            true,
+	"minimum":                  true,
+	"multipleOf":               true,
+	"nullable":                 true,
+	"pattern":                  true,
+	"required":                 true,
+	"uniqueItems":              true,
+	"x-kubernetes-validations": true,
+}
+
 // crdMarker is the type-level entity that configures CRD-level settings that
 // controller-gen cannot express (preserveUnknownFields, the minimal style and
 // schema format stripping) and switches the document to the hand-curated
@@ -217,15 +244,19 @@ func isRootObject(markers []marker) bool {
 	return false
 }
 
-// isTrue reports whether a marker value spells the boolean true. controller-gen
-// accepts the Go literals, and a value-less marker is true by convention, which
-// isRootObject handles before calling this.
+// isTrue reports whether a marker value spells the boolean true.
+//
+// Only the lowercase spelling counts, because that is the only one that can reach
+// here: controller-tools' own marker scanner (pkg/markers) parses a bool as the Go
+// literal "true" or "false" and errors on anything else, so a type written
+// "object:root=True" fails generation before the enricher sees the document.
+// Accepting more would make this the only place in the toolchain where such a
+// value means something.
+//
+// A value-less marker is true by convention, which isRootObject handles before
+// calling this.
 func isTrue(raw string) bool {
-	switch strings.TrimSpace(raw) {
-	case "true", "True", "TRUE":
-		return true
-	}
-	return false
+	return strings.TrimSpace(raw) == "true"
 }
 
 // marker is a single parsed comment marker, for example

--- a/pkg/crd-enricher/markers.go
+++ b/pkg/crd-enricher/markers.go
@@ -23,7 +23,7 @@ import (
 // canonical root every enricher marker carries; no bare or legacy forms are
 // honoured. These shapes are recognised:
 //
-//	+crd-enricher:raw:<key>[=<value>]                        // raw schema injection
+//	+crd-enricher:raw:<key>=<value>                          // raw schema injection
 //	+crd-enricher:unset:<key>                                // raw schema removal
 //	+crd-enricher:deckhouse:documentation:<entity>[=<value>] // documentation entity
 //	+crd-enricher:crd:<key>[=<value>]                        // CRD-level setting
@@ -118,6 +118,16 @@ const rawMarkerPrefix = "raw:"
 // warning rather than silently accepted, so a marker left behind by a generator
 // bump does not pass for a working one.
 const unsetMarkerPrefix = "unset:"
+
+// structuralKeys are the schema fields apiextensions requires to be there: an
+// array node must declare its items, and every node must declare its type.
+// Removing one produces a document the apiserver rejects at apply time
+// ("must be specified"), with nothing in the failure to point back at the marker
+// that caused it -- so unset: refuses these rather than obeying.
+var structuralKeys = map[string]bool{
+	"type":  true,
+	"items": true,
+}
 
 // crdMarker is the type-level entity that configures CRD-level settings that
 // controller-gen cannot express (preserveUnknownFields, the minimal style and

--- a/pkg/crd-enricher/markers.go
+++ b/pkg/crd-enricher/markers.go
@@ -170,6 +170,52 @@ const sensitiveDataKey = "x-kubernetes-sensitive-data"
 // generated CRD.
 const rootMarker = "kubebuilder:object:root"
 
+// legacyRootMarker is the pre-kubebuilder marker that designates a root object,
+// by declaring that deepcopy-gen should give the type a DeepCopyObject method.
+// controller-gen still honours it and renders a CRD for such a type, so the
+// enricher has to recognise it too: a package that carries only this form used
+// to have every crd-enricher marker on its root type silently ignored, because
+// the type never made it into packageInfo.roots.
+const legacyRootMarker = "k8s:deepcopy-gen:interfaces"
+
+// runtimeObject is the interface the legacy marker has to name for the type to
+// be a root object rather than merely deep-copyable.
+const runtimeObject = "k8s.io/apimachinery/pkg/runtime.Object"
+
+// isRootObject reports whether the markers designate a CRD root type, by either
+// spelling controller-gen accepts.
+//
+// The value of the kubebuilder marker is honoured: "object:root=false" is how a
+// type opts out, and treating it as a root would apply CRD-level settings to a
+// kind that has no CRD.
+func isRootObject(markers []marker) bool {
+	for _, m := range markers {
+		switch m.name {
+		case rootMarker:
+			if m.hasValue && !isTrue(m.rawValue) {
+				continue
+			}
+			return true
+		case legacyRootMarker:
+			if strings.TrimSpace(m.rawValue) == runtimeObject {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// isTrue reports whether a marker value spells the boolean true. controller-gen
+// accepts the Go literals, and a value-less marker is true by convention, which
+// isRootObject handles before calling this.
+func isTrue(raw string) bool {
+	switch strings.TrimSpace(raw) {
+	case "true", "True", "TRUE":
+		return true
+	}
+	return false
+}
+
 // marker is a single parsed comment marker, for example
 // "+crd-enricher:deckhouse:documentation:default=3m".
 type marker struct {
@@ -275,14 +321,4 @@ func commentLines(text string) []string {
 	default:
 		return []string{text}
 	}
-}
-
-// hasMarker reports whether the slice contains a marker with the given name.
-func hasMarker(markers []marker, name string) bool {
-	for _, m := range markers {
-		if m.name == name {
-			return true
-		}
-	}
-	return false
 }

--- a/pkg/crd-enricher/quoting_test.go
+++ b/pkg/crd-enricher/quoting_test.go
@@ -1,0 +1,106 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crdenricher
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestUnquotedMappingWarning pins the shape of value that silently stops being
+// text: prose with a colon and a space in it, which YAML reads as a mapping.
+func TestUnquotedMappingWarning(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		raw  string
+		warn bool
+	}{
+		{
+			name: "prose with a colon parses as a mapping",
+			raw:  "Condition type. `Ready` is `False` while deleting (`reason: Deleting`).",
+			warn: true,
+		},
+		{
+			name: "the same prose quoted stays text",
+			raw:  "\"Condition type. `Ready` is `False` while deleting (`reason: Deleting`).\"",
+			warn: false,
+		},
+		{
+			name: "a colon without a following space is not a mapping",
+			raw:  "https://example.io/docs",
+			warn: false,
+		},
+		{
+			name: "a deliberate flow mapping is left alone",
+			raw:  "{field: value}",
+			warn: false,
+		},
+		{
+			name: "plain prose",
+			raw:  "Current status of the condition.",
+			warn: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			decoded, err := decodeValue(tc.raw)
+			if err != nil {
+				t.Fatalf("decodeValue(%q): %v", tc.raw, err)
+			}
+			got := unquotedMappingWarning("raw:description", tc.raw, decoded)
+			if tc.warn && got == "" {
+				t.Errorf("expected a warning for %q, got none (decoded as %T)", tc.raw, decoded)
+			}
+			if !tc.warn && got != "" {
+				t.Errorf("unexpected warning for %q: %s", tc.raw, got)
+			}
+		})
+	}
+}
+
+// TestUnquotedMappingWarningReachesTheCaller runs the enricher over a fixture
+// whose marker value is prose with a colon in it, and checks the warning comes
+// back out: the marker is accepted, the schema node is not the string the author
+// wrote, and without the warning nothing says so.
+func TestUnquotedMappingWarningReachesTheCaller(t *testing.T) {
+	crdDir := t.TempDir()
+	src, err := os.ReadFile(filepath.Join("testdata", "crd", "quoting.yaml"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(crdDir, "quoting.yaml"), src, 0o644); err != nil {
+		t.Fatalf("write fixture copy: %v", err)
+	}
+
+	_, warnings, err := RunWithWarnings(Options{Paths: []string{testFixturePaths}, CRDDir: crdDir})
+	if err != nil {
+		t.Fatalf("RunWithWarnings: %v", err)
+	}
+
+	var found string
+	for _, w := range warnings {
+		if strings.Contains(w, "parsed as a mapping") {
+			found = w
+			break
+		}
+	}
+	if found == "" {
+		t.Fatalf("no warning about the unquoted value, got %v", warnings)
+	}
+	if !strings.Contains(found, "raw:description") {
+		t.Errorf("warning does not name the marker: %s", found)
+	}
+}

--- a/pkg/crd-enricher/testdata/api/v1alpha1/legacyroot.go
+++ b/pkg/crd-enricher/testdata/api/v1alpha1/legacyroot.go
@@ -1,0 +1,37 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+// LegacyRoot exercises the pre-kubebuilder root marker. controller-gen renders a
+// CRD for a type that only declares deepcopy-gen should give it a
+// DeepCopyObject method, so a package written that way -- and several of the
+// storage modules are -- gets a manifest without ever spelling
+// kubebuilder:object:root. Every crd-enricher marker on such a type used to be
+// dropped, because the type never entered the root set the enricher walks.
+//
+// +k8s:deepcopy-gen=true
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +crd-enricher:crd:preserveUnknownFields=false
+type LegacyRoot struct {
+	Spec LegacyRootSpec `json:"spec"`
+}
+
+type LegacyRootSpec struct {
+	// Name carries a field marker as well, so the fixture shows both halves
+	// reaching the schema: the CRD-level setting above and this one.
+	//
+	// +crd-enricher:deckhouse:documentation:examples=first
+	Name string `json:"name"`
+}

--- a/pkg/crd-enricher/testdata/api/v1alpha1/legacyroot.go
+++ b/pkg/crd-enricher/testdata/api/v1alpha1/legacyroot.go
@@ -14,15 +14,21 @@
 
 package v1alpha1
 
-// LegacyRoot exercises the pre-kubebuilder root marker. controller-gen renders a
-// CRD for a type that only declares deepcopy-gen should give it a
-// DeepCopyObject method, so a package written that way -- and several of the
-// storage modules are -- gets a manifest without ever spelling
-// kubebuilder:object:root. Every crd-enricher marker on such a type used to be
-// dropped, because the type never entered the root set the enricher walks.
+// LegacyRoot exercises the marker fallback in isCRDRoot: a type that names no
+// kubebuilder:object:root, only the pre-kubebuilder spelling, and does not embed
+// the metav1 structs either (this module has no apimachinery dependency, which is
+// why the embedding rule is pinned separately in kuberoot_test.go).
+//
+// Every crd-enricher marker on such a type used to be dropped, because the type
+// never entered the root set the enricher walks. The settings below are the ones
+// that were lost in the real case -- crd:minimal is what strips the listKind, the
+// implicit apiVersion/kind/metadata root properties and the generator-version
+// annotation, all of which would otherwise reach the module's public API
+// reference page.
 //
 // +k8s:deepcopy-gen=true
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +crd-enricher:crd:minimal=true
 // +crd-enricher:crd:preserveUnknownFields=false
 type LegacyRoot struct {
 	Spec LegacyRootSpec `json:"spec"`

--- a/pkg/crd-enricher/testdata/api/v1alpha1/quoting.go
+++ b/pkg/crd-enricher/testdata/api/v1alpha1/quoting.go
@@ -1,0 +1,32 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+// Quoting exercises the one way a marker value stops being what its author
+// wrote: the value is YAML, so prose containing a colon and a space parses as a
+// mapping instead of a string.
+//
+// +kubebuilder:object:root=true
+type Quoting struct {
+	Spec QuotingSpec `json:"spec"`
+}
+
+type QuotingSpec struct {
+	// Phase: the override below is written unquoted, so it never reaches the
+	// schema as text.
+	//
+	// +crd-enricher:raw:description=Phase of the resource (`reason: Deleting` while it is torn down).
+	Phase string `json:"phase"`
+}

--- a/pkg/crd-enricher/testdata/api/v1alpha1/unset.go
+++ b/pkg/crd-enricher/testdata/api/v1alpha1/unset.go
@@ -1,0 +1,45 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+// Unset exercises unset:<key>: controller-gen writes a description for every
+// node it can reach, the ones it renders from a vendored type included, and a
+// manifest that is not supposed to carry that text has no way to drop it with
+// raw: alone.
+//
+// +kubebuilder:object:root=true
+type Unset struct {
+	Spec UnsetSpec `json:"spec"`
+}
+
+type UnsetSpec struct {
+	// Conditions: the item description comes from the shared condition type and
+	// is dropped, while the descriptions this API does want are set as usual, so
+	// the two markers are shown working on the same node.
+	//
+	// +crd-enricher:unset:items.description
+	// +crd-enricher:raw:items.properties.type.description=Condition type. `Ready` is `True` once the resource is in place.
+	Conditions []Condition `json:"conditions"`
+
+	// Retries keeps its own description: unset addresses one node, not a subtree.
+	Retries int `json:"retries"`
+}
+
+// Condition stands in for a vendored condition type, whose godoc controller-gen
+// renders into items.description.
+type Condition struct {
+	Type   string `json:"type"`
+	Status string `json:"status"`
+}

--- a/pkg/crd-enricher/testdata/crd/legacyroot.yaml
+++ b/pkg/crd-enricher/testdata/crd/legacyroot.yaml
@@ -3,6 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: legacyroots.example.io
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
 spec:
   group: example.io
   names:

--- a/pkg/crd-enricher/testdata/crd/legacyroot.yaml
+++ b/pkg/crd-enricher/testdata/crd/legacyroot.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: legacyroots.example.io
+spec:
+  group: example.io
+  names:
+    kind: LegacyRoot
+    listKind: LegacyRootList
+    plural: legacyroots
+    singular: legacyroot
+  scope: Cluster
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: Name carries a field marker as well.

--- a/pkg/crd-enricher/testdata/crd/quoting.yaml
+++ b/pkg/crd-enricher/testdata/crd/quoting.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: quotings.example.io
+spec:
+  group: example.io
+  names:
+    kind: Quoting
+    listKind: QuotingList
+    plural: quotings
+    singular: quoting
+  scope: Cluster
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                phase:
+                  type: string
+                  description: Phase of the resource.

--- a/pkg/crd-enricher/testdata/crd/unset.yaml
+++ b/pkg/crd-enricher/testdata/crd/unset.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: unsets.example.io
+spec:
+  group: example.io
+  names:
+    kind: Unset
+    listKind: UnsetList
+    plural: unsets
+    singular: unset
+  scope: Cluster
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              properties:
+                conditions:
+                  type: array
+                  description: Conditions of the resource.
+                  items:
+                    type: object
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      type:
+                        type: string
+                        description: type of condition in CamelCase.
+                      status:
+                        type: string
+                        description: status of the condition, one of True, False, Unknown.
+                retries:
+                  type: integer
+                  description: Retries keeps its own description.

--- a/pkg/crd-enricher/testdata/golden/legacyroot.yaml
+++ b/pkg/crd-enricher/testdata/golden/legacyroot.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -7,7 +6,6 @@ spec:
   group: example.io
   names:
     kind: LegacyRoot
-    listKind: LegacyRootList
     plural: legacyroots
     singular: legacyroot
   preserveUnknownFields: false
@@ -17,12 +15,6 @@ spec:
     schema:
       openAPIV3Schema:
         properties:
-          apiVersion:
-            type: string
-          kind:
-            type: string
-          metadata:
-            type: object
           spec:
             properties:
               name:

--- a/pkg/crd-enricher/testdata/golden/legacyroot.yaml
+++ b/pkg/crd-enricher/testdata/golden/legacyroot.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: legacyroots.example.io
+spec:
+  group: example.io
+  names:
+    kind: LegacyRoot
+    listKind: LegacyRootList
+    plural: legacyroots
+    singular: legacyroot
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              name:
+                description: Name carries a field marker as well.
+                type: string
+                x-doc-examples:
+                - first
+            type: object
+        type: object
+    served: true
+    storage: true

--- a/pkg/crd-enricher/testdata/golden/unset.yaml
+++ b/pkg/crd-enricher/testdata/golden/unset.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: unsets.example.io
+spec:
+  group: example.io
+  names:
+    kind: Unset
+    listKind: UnsetList
+    plural: unsets
+    singular: unset
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              conditions:
+                description: Conditions of the resource.
+                items:
+                  properties:
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Condition type. `Ready` is `True` once the resource
+                        is in place.
+                      type: string
+                  type: object
+                type: array
+              retries:
+                description: Retries keeps its own description.
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true

--- a/pkg/crd-enricher/unset_test.go
+++ b/pkg/crd-enricher/unset_test.go
@@ -1,0 +1,25 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crdenricher
+
+import "testing"
+
+// TestUnsetGolden captures unset:<key>: the item description controller-gen
+// renders from the shared condition type is removed, the sibling descriptions
+// set with raw: on the same node are applied, and every node the markers do not
+// address is left alone.
+func TestUnsetGolden(t *testing.T) {
+	assertGolden(t, "unset.yaml", runFixture(t, "unset.yaml", false))
+}

--- a/pkg/crd-enricher/yaml.go
+++ b/pkg/crd-enricher/yaml.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"fmt"
 	"sort"
+	"strings"
 
 	"sigs.k8s.io/yaml"
 	goyaml2 "sigs.k8s.io/yaml/goyaml.v2"
@@ -46,6 +47,31 @@ func decodeValue(raw string) (any, error) {
 		return nil, fmt.Errorf("decode value %q: %w", raw, err)
 	}
 	return out, nil
+}
+
+// unquotedMappingWarning reports the marker value that was written as prose but
+// parsed as a mapping, or an empty string when the value is fine.
+//
+// A marker value is YAML, so a description that contains a colon followed by a
+// space -- "(`reason: ReconcileFailed`)" -- turns into a single-entry map unless
+// it is quoted. The map is then written into the schema in place of the string
+// the author meant, or rejected by the node that expected a scalar, and either
+// way the override is lost without an error. The heuristic is deliberately
+// narrow: an author writing a real mapping in a marker reaches for the flow form
+// or quotes the value.
+func unquotedMappingWarning(name, raw string, decoded any) string {
+	if _, ok := decoded.(map[string]any); !ok {
+		return ""
+	}
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" || strings.HasPrefix(trimmed, "{") || strings.HasPrefix(trimmed, `"`) || strings.HasPrefix(trimmed, "'") {
+		return ""
+	}
+	if !strings.Contains(trimmed, ": ") {
+		return ""
+	}
+	return fmt.Sprintf(
+		"marker %q: the value contains %q and parsed as a mapping, not a string; quote it to keep it text", name, ": ")
 }
 
 // orderedEntry is a single key/value pair of an orderedMap.

--- a/pkg/crd-enricher/yaml.go
+++ b/pkg/crd-enricher/yaml.go
@@ -59,6 +59,11 @@ func decodeValue(raw string) (any, error) {
 // way the override is lost without an error. The heuristic is deliberately
 // narrow: an author writing a real mapping in a marker reaches for the flow form
 // or quotes the value.
+//
+// It does fire on a genuine single-pair mapping written as bare "k: v", because
+// in one line that is indistinguishable from prose with a colon in it. That is
+// the deliberate cost of catching the prose case, so the message names the flow
+// form as well -- an author who meant a mapping has a way to say so.
 func unquotedMappingWarning(name, raw string, decoded any) string {
 	if _, ok := decoded.(map[string]any); !ok {
 		return ""
@@ -71,7 +76,8 @@ func unquotedMappingWarning(name, raw string, decoded any) string {
 		return ""
 	}
 	return fmt.Sprintf(
-		"marker %q: the value contains %q and parsed as a mapping, not a string; quote it to keep it text", name, ": ")
+		"marker %q: the value contains %q and parsed as a mapping, not a string; "+
+			"quote it to keep it text, or write it as {k: v} if a mapping was intended", name, ": ")
 }
 
 // orderedEntry is a single key/value pair of an orderedMap.

--- a/tools/docs/spelling/filesignore
+++ b/tools/docs/spelling/filesignore
@@ -20,6 +20,7 @@ werf-giterminism.yaml
 ^go_lib/.+$
 ^helm_lib/.+$
 ^jq_lib/.+$
+^pkg/.+$
 ^python_lib/.+$
 ^shell_lib/.+$
 ^testing/.+$


### PR DESCRIPTION
## Description

Five commits on `pkg/crd-enricher`, each one droppable without the others.

**1. `unset:<key>`** — the mirror of the existing `raw:<key>`. Where `raw:` sets a plain schema field, `unset:` removes it, walking the same dotted path into nested nodes. It takes no value, and a `<key>` that is already absent is reported as a warning rather than accepted silently.

**2. Warnings reach the caller.** `Enricher.Warnings()` had no reachable caller — `Run` builds the enricher itself and returns only the file list — so every warning the enricher collects was thrown away and the CLI had no way to reach them. `RunWithWarnings` returns them alongside the modified files, `Run` keeps its signature and delegates, and the command prints them to stderr and still exits 0.

**3. The pre-kubebuilder root marker is recognised.** The enricher found a root type only by `+kubebuilder:object:root=true`. controller-gen also honours `+k8s:deepcopy-gen:interfaces` naming `runtime.Object` and renders a CRD for a type carrying only that, so such a package got its manifest and **none of its enricher markers** — the type never entered the root set, nothing below it was visited, and nothing said so. `isRootObject` accepts both spellings and honours the value of the kubebuilder one, so `object:root=false` stays an opt-out.

**4. A marker value that parses as a mapping is reported.** Marker values are YAML, which is documented; the consequence for prose is not obvious. A description containing a colon followed by a space parses as a single-entry mapping, and the mapping is written into the schema in place of the string its author meant.

**5. Documentation** — which types the enricher walks, the quoting rule, the gofmt hazard below, and what `crd:minimal` is for.

## Why do we need it, and what problem does it solve?

Four of the five share one thread: **a marker is accepted, does not do what its author wrote it to do, and nothing says so.** All of them surfaced while moving `crds/` to generation in seventeen storage modules (18 MRs, one repository at a time), where every manifest had to come out semantically identical to the reviewed and shipped one — which is the only reason they were noticed at all.

### `raw:` can only overwrite

A `[]metav1.Condition` field gets an `items.description` rendered from the `metav1.Condition` godoc of whatever `k8s.io/apimachinery` the API module happens to pin:

```
Condition contains details for one aspect of the current state of this API Resource.
```

Every storage module whose `crds/` was hand-written before it was generated has manifests that never carried that sentence. Rendering them from the Go types puts it in, and there was no marker that takes it out. The best `raw:` could do is pin the upstream text in a marker next to the field, which:

- publishes a generic apimachinery sentence on the module's API reference page, where it says nothing a user of that CRD needs;
- has to be translated into every `doc-ru-*.yaml` overlay to keep the Russian page from showing English mid-page;
- moves whenever the apimachinery pin moves, so a routine dependency bump rewrites `crds/` and fails the CRD drift check inside an unrelated MR.

With `unset:` the node simply goes. Verified end to end against `csi-ceph`: replacing the pinned `raw:items.description=…` with `unset:items.description` and re-rendering leaves `status.conditions.items` with `properties`, `required` and `type` and nothing else — byte-identical to the hand-written manifest.

### The legacy root marker cost a whole CRD's settings

`SCSIStorageClass` in `csi-scsi-generic` carries only `+k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object`. controller-gen renders its CRD; the enricher never saw it as a root, so `crd:minimal` and `crd:preserveUnknownFields=false` on that type did nothing and the manifest came out in the full controller-gen shape — with `listKind`, the implicit `apiVersion`/`kind`/`metadata` root properties and the generator-version annotation, all of which would have landed on the module's public API reference page.

There was no warning, and no way to get one: the type simply is not in `packageInfo.roots`. It was found by diffing the rendered manifest against the committed one field by field.

### Prose with a colon in it stops being prose

Condition texts collect these: `` `reason: ReconcileFailed` ``, `` `reason: Deleting` ``. Written unquoted, the value parses as a mapping and that is what lands in the schema:

```yaml
description:
  'Phase of the resource (`reason': 'Deleting` while it is torn down).'
```

A `description` that is a mapping is not a valid schema, and nothing on the way there objected. The new warning names the marker:

```
warning: marker "raw:description": the value contains ": " and parsed as a mapping, not a string; quote it to keep it text
```

The heuristic is deliberately narrow — a value starting with `{`, a quoted value, or one with no `": "` in it is left alone — so an author writing a real mapping is not nagged.

### And one hazard that is not the enricher's fault but belongs in its README

gofmt's doc-comment formatter rewrites a doubled ASCII quote into a Unicode quotation mark, so a CEL rule written as `self.x != ''` is silently corrupted the next time anyone formats the file. It bit `sds-object`. The README now says to spell the empty string `\"\"` and to keep `gofmt -l` clean *before* diffing rendered manifests, because otherwise the formatter edits text that was already checked.

## Why do we need it in the patch release (if we do)?

Not necessarily. It unblocks 12 storage modules that are moving `crds/` to generation from `api/` (csi-ceph, csi-nfs, csi-s3, csi-hpe, csi-huawei, csi-netapp, csi-scsi-generic, csi-yadro-tatlin-unified, sds-local-volume, sds-elastic, sds-object, sds-replicated-volume) — each currently carries the pinned condition sentence plus its translation, and both go away once this is released — but none of them is blocked on a patch.

Note for whoever cuts the release: the root `Makefile` still pins `CRD_ENRICHER_VERSION ?= v0.0.1` while `v0.0.2` is published. Deliberately not touched here, since the pin will want moving to whatever tag carries these commits.

## Checklist

- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

Unit tests cover the nested delete, the single-key delete, the warning when `unset:` removes nothing, both root-marker spellings and the two that look like them, and the mapping warning end to end through `RunWithWarnings`. Each of the three new behaviours has a test that fails without its change — the root fixture and the quoting test were both checked against a reverted tree.

Beyond the unit tests, the whole set was exercised by rendering the CRDs of seventeen storage modules and comparing every one against the manifest it replaces, node by node.


## Changelog entries

```changes
section: tools
type: feature
summary: "crd-enricher takes `unset:<key>`, recognises the pre-kubebuilder root marker, and reports the markers it cannot apply instead of dropping them silently."
impact_level: low
```
