### PR TITLE
[deckhouse] Reserve the d8a5e- object name prefix for the ansible module

### DIFF
--- a/modules/002-deckhouse/templates/validation.yaml
+++ b/modules/002-deckhouse/templates/validation.yaml
@@ -229,6 +229,58 @@ spec:
   - Deny
   - Audit
 
+---
+{{- $policyName := "d8a5e-prefix.deckhouse.io" }}
+apiVersion: {{ include "helm_lib_get_api_version_by_kind" (list . "ValidatingAdmissionPolicy") }}
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: {{ $policyName }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "deckhouse") ) | nindent 2 }}
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ["*"]
+        apiVersions: ["*"]
+        operations:  ["CREATE", "UPDATE", "DELETE"]
+        resources:   ["*"]
+  matchConditions:
+    - name: 'exclude-groups'
+      expression: '!(["system:nodes", "system:serviceaccounts:kube-system", "system:serviceaccounts:d8-system", "system:serviceaccounts:d8-cni-cilium"].exists(e, (e in request.userInfo.groups)))'
+    - name: 'exclude-users'
+      expression: '!(["system:sudouser", "system:apiserver", "system:kube-controller-manager", "system:kube-scheduler", "system:volume-scheduler", "dhctl"].exists(e, (e == request.userInfo.username)))'
+    # exclude SA from namespaces prefixed with `d8-`
+    # the ansible module creates these objects from its controller in `d8-ansible`
+    - name: 'exclude-d8-namespaces'
+      expression: '!(["system:serviceaccount:d8-"].exists(e, (request.userInfo.username.startsWith(e))))'
+    # allow users to delete runner pods
+    - name: 'exclude-delete-pods-operations'
+      expression: '!(request.operation == "DELETE" && request.resource.resource == "pods")'
+  validations:
+    # deny all operations with any objects with `d8a5e-` prefix, except for Pods deletions
+    - expression: |
+        !(
+          (has(object.metadata) && has(object.metadata.name) && object.metadata.name.startsWith("d8a5e-")) ||
+          (has(oldObject.metadata) && has(oldObject.metadata.name) && oldObject.metadata.name.startsWith("d8a5e-"))
+        )
+      messageExpression: "'Creating, updating and deleting objects with the ansible module prefix is forbidden'"
+      reason: Forbidden
+  auditAnnotations:
+    - key: 'source-user'
+      valueExpression: "'User: ' + string(request.userInfo.username) + ' tries to change object with the ansible module prefix'"
+
+---
+apiVersion: {{ include "helm_lib_get_api_version_by_kind" (list . "ValidatingAdmissionPolicyBinding") }}
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: {{ $policyName }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "deckhouse") ) | nindent 2 }}
+spec:
+  policyName: {{ $policyName }}
+  validationActions:
+  - Deny
+  - Audit
+
 {{- if ne .Values.global.deckhouseVersion "dev" }}
 
 {{- $policyName := "label-objects.deckhouse.io" }}


### PR DESCRIPTION
## Description
The `ansible` module creates two objects for every run — a runner Pod and a Secret with its input — in the namespace of the project the run belongs to. Their names start with `d8a5e-`, and this reserves that prefix the way `d8ms-` and `d8a-` are already reserved: nobody except the module's controller creates, updates or deletes an object whose name starts with it.

The new `ValidatingAdmissionPolicy` mirrors the `d8a-` one:

- service accounts of `d8-` namespaces are excluded — the controller runs in `d8-ansible` and creates these objects from there;
- deleting a Pod stays allowed, so the owner of a project can stop a run that is in the way;
- the exclusion for service accounts of `d8a-` namespaces is left out, because no namespace carries the `d8a5e-` prefix.

No behaviour changes for existing objects: nothing in the platform is named `d8a5e-*` today except the objects of this module.

## Why do we need it, and what problem does it solve?
Two reasons.

The module already names its objects this way, and without the policy anyone with write access to the namespace can rewrite or delete the input of a playbook that is currently running — the Secret holds the generated inventory and the playbook itself.

And prefixes need a single place where they are taken, so that two modules do not pick the same one. `d8a` turned out to be taken exactly this way, which is why the module moved to `d8a5e`.

## Why do we need it in the patch release (if we do)?
Not necessarily.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

The policy is a manifest, so there is no code to unit-test; the repository has no
tests over the policies of this module. Nothing user-facing is documented by it —
the prefix belongs to the `ansible` module, whose own documentation describes the
names of its objects. Cluster testing is described in a comment below.

## Changelog entries
```changes
section: deckhouse
type: feature
summary: The `d8a5e-` object name prefix is reserved for the ansible module.
```
