### PR TITLE
[admission-policy-engine] Restrict SecurityPolicyException write access to ClusterAdmin

### DIFF
--- a/modules/015-admission-policy-engine/template_tests/user_authz_cluster_roles_test.go
+++ b/modules/015-admission-policy-engine/template_tests/user_authz_cluster_roles_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template_tests
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/helm"
+)
+
+var _ = Describe("Module :: admissionPolicyEngine :: user-authz cluster roles", func() {
+	f := SetupHelmConfig(`
+admissionPolicyEngine:
+  podSecurityStandards: {}
+  internal:
+    bootstrapped: true
+    ratify:
+      webhook:
+        ca: test-ca-placeholder
+        crt: test-crt-placeholder
+        key: test-key-placeholder
+    podSecurityStandards:
+      enforcementActions:
+        - deny
+    trackedConstraintResources: []
+    trackedMutateResources: []
+    webhook:
+      ca: test-ca-placeholder
+      crt: test-crt-placeholder
+      key: test-key-placeholder
+`)
+
+	BeforeEach(func() {
+		f.ValuesSetFromYaml("global", globalValues)
+		f.ValuesSet("global.modulesImages", GetModulesImages())
+		f.HelmRender()
+	})
+
+	// A SecurityPolicyException lifts the pod-security checks a SecurityPolicy enforces, so it must not
+	// be writable below ClusterAdmin: the Admin access level is bound per namespace by AuthorizationRule,
+	// and a namespace-scoped Admin able to create an exception can grant its own pods hostPath and
+	// privileged, escaping to the node.
+	It("must not grant any access level below ClusterAdmin write access to securitypolicyexceptions", func() {
+		Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+		Expect(f.KubernetesGlobalResource("ClusterRole", "d8:user-authz:admission-policy-engine:admin").Exists()).To(BeFalse())
+
+		user := f.KubernetesGlobalResource("ClusterRole", "d8:user-authz:admission-policy-engine:user")
+		Expect(user.Exists()).To(BeTrue())
+		Expect(user.Field("rules.0.verbs").String()).To(Equal(`["get","list","watch"]`))
+	})
+
+	It("must keep securitypolicyexceptions writable by ClusterAdmin", func() {
+		Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+		clusterAdmin := f.KubernetesGlobalResource("ClusterRole", "d8:user-authz:admission-policy-engine:cluster-admin")
+		Expect(clusterAdmin.Exists()).To(BeTrue())
+		Expect(clusterAdmin.Field("rules.0.resources").String()).
+			To(Equal(`["operationpolicies","securitypolicies","securitypolicyexceptions"]`))
+	})
+})

--- a/modules/015-admission-policy-engine/templates/user-authz-cluster-roles.yaml
+++ b/modules/015-admission-policy-engine/templates/user-authz-cluster-roles.yaml
@@ -107,34 +107,21 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   annotations:
-    user-authz.deckhouse.io/access-level: Admin
-  name: d8:user-authz:admission-policy-engine:admin
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
-rules:
-- apiGroups:
-  - deckhouse.io
-  resources:
-  - securitypolicyexceptions
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - patch
-  - update
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  annotations:
     user-authz.deckhouse.io/access-level: ClusterAdmin
   name: d8:user-authz:admission-policy-engine:cluster-admin
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 rules:
+{{/*
+  SecurityPolicyException lifts pod-security checks enforced by SecurityPolicy, so writing one is
+  equivalent to editing the policy itself: keep both at ClusterAdmin. A namespace-scoped Admin that
+  can create an exception can grant its own pods hostPath and privileged, which is a node escape.
+*/}}
 - apiGroups:
   - deckhouse.io
   resources:
   - operationpolicies
   - securitypolicies
+  - securitypolicyexceptions
   verbs:
   - create
   - delete

--- a/modules/140-user-authz/docs/README.md
+++ b/modules/140-user-authz/docs/README.md
@@ -419,7 +419,6 @@ read-write:
 write:
     - autoscaling.k8s.io/verticalpodautoscalercheckpoints
     - deckhouse.io/applications
-    - deckhouse.io/securitypolicyexceptions
     - extensions.istio.io/wasmplugins
     - rbac.authorization.k8s.io/rolebindings
     - rbac.authorization.k8s.io/roles
@@ -466,7 +465,6 @@ write:
     - deckhouse.io/instances
     - deckhouse.io/keepalivedinstances
     - deckhouse.io/nodegroups
-    - deckhouse.io/securitypolicyexceptions
     - extensions.istio.io/wasmplugins
     - extensions/daemonsets
     - gateway.networking.k8s.io/gatewayclasses
@@ -561,6 +559,7 @@ write:
     - deckhouse.io/projects
     - deckhouse.io/projecttemplates
     - deckhouse.io/securitypolicies
+    - deckhouse.io/securitypolicyexceptions
     - deckhouse.io/vcdinstanceclasses
     - deckhouse.io/vsphereinstanceclasses
     - deckhouse.io/yandexinstanceclasses

--- a/modules/140-user-authz/docs/README_RU.md
+++ b/modules/140-user-authz/docs/README_RU.md
@@ -425,7 +425,6 @@ read-write:
 write:
     - autoscaling.k8s.io/verticalpodautoscalercheckpoints
     - deckhouse.io/applications
-    - deckhouse.io/securitypolicyexceptions
     - extensions.istio.io/wasmplugins
     - rbac.authorization.k8s.io/rolebindings
     - rbac.authorization.k8s.io/roles
@@ -472,7 +471,6 @@ write:
     - deckhouse.io/instances
     - deckhouse.io/keepalivedinstances
     - deckhouse.io/nodegroups
-    - deckhouse.io/securitypolicyexceptions
     - extensions.istio.io/wasmplugins
     - extensions/daemonsets
     - gateway.networking.k8s.io/gatewayclasses
@@ -567,6 +565,7 @@ write:
     - deckhouse.io/projects
     - deckhouse.io/projecttemplates
     - deckhouse.io/securitypolicies
+    - deckhouse.io/securitypolicyexceptions
     - deckhouse.io/vcdinstanceclasses
     - deckhouse.io/vsphereinstanceclasses
     - deckhouse.io/yandexinstanceclasses


### PR DESCRIPTION
## Description

`SecurityPolicyException` (SPE) lifts the pod-security checks a `SecurityPolicy` enforces — `privileged`, `hostPath`, `hostNetwork`, `hostPID`, capabilities, `runAsUser`. Creating an SPE is therefore equivalent to editing the policy itself, yet `SecurityPolicy` and `OperationPolicy` were writable only by `ClusterAdmin`, while `SecurityPolicyException` was granted to the `Admin` access level.

This moves the SPE write verbs from the `Admin` role to `ClusterAdmin` in `modules/015-admission-policy-engine/templates/user-authz-cluster-roles.yaml`, and removes the now-empty `Admin` ClusterRole. Custom cluster roles are collected cumulatively by access level (`140-user-authz/hooks/handle_custom_cluster_roles.go`), so the permission is also dropped from `ClusterEditor`, which inherited it from `Admin`. Read access at the `User` level is unchanged. The generated user-authz role reference (`modules/140-user-authz/docs/README*.md`) is regenerated accordingly, and a template test asserts the `Admin` role is gone while `ClusterAdmin` keeps the verbs.

## Why do we need it, and what problem does it solve?

The resource is namespaced, and the exception is resolved from the namespace of the pod that references it by label. So an `AuthorizationRule` with `accessLevel: Admin` gave a project administrator the full chain within its own namespace: create an exception, label a pod with it, and schedule a privileged pod mounting `hostPath: /`. That escapes the tenant boundary and yields root on the node. Reported via Bug Bounty (Standoff365 #32090), CWE-269, CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H (9.9).

RBAC v2 (`use`/`manage` roles) is not affected: no role grants SPE write. Affected setups are RBAC v1 multitenancy where untrusted tenants receive `accessLevel: Admin`.

## Why do we need it in the patch release (if we do)?

Yes. The over-permissive grant is present in release-1.76 and release-1.77; the fix should be backported to both.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: admission-policy-engine
type: fix
summary: Restrict SecurityPolicyException write access to ClusterAdmin, closing a tenant-to-node privilege escalation.
impact: Project administrators (user-authz Admin access level) can no longer create, update or delete SecurityPolicyException resources; the permission now requires ClusterAdmin. Clusters that granted accessLevel Admin to untrusted tenants over RBAC v1 were exposed to node-level privilege escalation. RBAC v2 use/manage roles were never affected.
impact_level: high
```
