### PR TITLE
[cni-simple-bridge] Remove unused pip from the simple-bridge image

### DIFF
--- a/modules/035-cni-simple-bridge/images/simple-bridge/werf.inc.yaml
+++ b/modules/035-cni-simple-bridge/images/simple-bridge/werf.inc.yaml
@@ -8,10 +8,7 @@ git:
 shell:
   beforeInstall:
   - pm install python@3.12 jq gnu-glibc gawk coreutils grep bash iproute2 bridge-utils procps util-linux findutils curl -d /out
-  # pip is not used at runtime (the entrypoint only needs the Python stdlib, e.g.
-  # `python3 -c 'import ipaddress'`); it ships only as a byproduct of installing
-  # python@3.12. Drop it so it does not reach the final image and surface CVEs.
-  - rm -rf /out/usr/lib/python3.12/site-packages/pip /out/usr/lib/python3.12/site-packages/pip-*.dist-info /out/usr/lib/python3.12/ensurepip /out/usr/bin/pip3 /out/usr/bin/pip3.12
+  - rm -rf /out/usr/lib/python3*/site-packages/pip* /out/usr/bin/pip3*
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 from: {{ index $.Images "base/distroless-fin" }}

--- a/modules/035-cni-simple-bridge/images/simple-bridge/werf.inc.yaml
+++ b/modules/035-cni-simple-bridge/images/simple-bridge/werf.inc.yaml
@@ -8,6 +8,10 @@ git:
 shell:
   beforeInstall:
   - pm install python@3.12 jq gnu-glibc gawk coreutils grep bash iproute2 bridge-utils procps util-linux findutils curl -d /out
+  # pip is not used at runtime (the entrypoint only needs the Python stdlib, e.g.
+  # `python3 -c 'import ipaddress'`); it ships only as a byproduct of installing
+  # python@3.12. Drop it so it does not reach the final image and surface CVEs.
+  - rm -rf /out/usr/lib/python3.12/site-packages/pip /out/usr/lib/python3.12/site-packages/pip-*.dist-info /out/usr/lib/python3.12/ensurepip /out/usr/bin/pip3 /out/usr/bin/pip3.12
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 from: {{ index $.Images "base/distroless-fin" }}


### PR DESCRIPTION
## Description

Remove `pip` and its accompanying files from the `simple-bridge` image rootfs during build. `pip` is not used at runtime — the entrypoint only needs the Python standard library (e.g. `python3 -c 'import ipaddress'`) — and it ships only as a byproduct of installing the `python@3.12` package. The `werf.inc.yaml` `beforeInstall` step now deletes the `pip` files (`site-packages/pip`, `pip-*.dist-info`, `/usr/bin/pip3`, `/usr/bin/pip3.12`) so they never reach the final image.

There is no change to runtime behavior; the `simple-bridge` image is rebuilt and its pods are restarted on rollout.

## Why do we need it, and what problem does it solve?

The bundled `pip` pulled vulnerable components into the image even though it is never executed. Removing it eliminates the following CVEs from the `simple-bridge` image:

- CVE-2026-1703
- CVE-2026-3219
- CVE-2026-6357
- CVE-2026-8643

## Why do we need it in the patch release (if we do)?

The change only strips an unused build artifact and does not alter runtime behavior, so it is safe to backport to reduce the vulnerability exposure of running clusters.

## Checklist

- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cni-simple-bridge
type: fix
summary: Removed the unused pip from the simple-bridge image to fix CVE-2026-1703, CVE-2026-3219, CVE-2026-6357 and CVE-2026-8643.
impact_level: low
```