### PR TITLE
[network-gateway] Remove unused pip from the snat image

### DIFF
--- a/ee/modules/450-network-gateway/images/snat/werf.inc.yaml
+++ b/ee/modules/450-network-gateway/images/snat/werf.inc.yaml
@@ -5,6 +5,12 @@ from: {{ index $.Images "builder/distroless" }}
 shell:
   beforeInstall:
   - pm install python@3.12 gnu-glibc grep sed coreutils bash -d /out
+  # pip is not needed at runtime: iptables-loop.py uses only the Python stdlib
+  # (json, os, time). pip ships only as a side artifact of the python@3.12
+  # package. Remove it from the rootfs so no pip component reaches the final
+  # image (fixes CVE-2026-1703, CVE-2026-3219, CVE-2026-6357, CVE-2026-8643).
+  - rm -rf /out/usr/lib/python3.12/site-packages/pip /out/usr/lib/python3.12/site-packages/pip-*.dist-info
+  - rm -rf /out/usr/lib/python3.12/ensurepip/_bundled
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
 from: {{ index $.Images "base/distroless-fin" }}

--- a/ee/modules/450-network-gateway/images/snat/werf.inc.yaml
+++ b/ee/modules/450-network-gateway/images/snat/werf.inc.yaml
@@ -5,12 +5,7 @@ from: {{ index $.Images "builder/distroless" }}
 shell:
   beforeInstall:
   - pm install python@3.12 gnu-glibc grep sed coreutils bash -d /out
-  # pip is not needed at runtime: iptables-loop.py uses only the Python stdlib
-  # (json, os, time). pip ships only as a side artifact of the python@3.12
-  # package. Remove it from the rootfs so no pip component reaches the final
-  # image (fixes CVE-2026-1703, CVE-2026-3219, CVE-2026-6357, CVE-2026-8643).
-  - rm -rf /out/usr/lib/python3.12/site-packages/pip /out/usr/lib/python3.12/site-packages/pip-*.dist-info
-  - rm -rf /out/usr/lib/python3.12/ensurepip/_bundled
+  - rm -rf /out/usr/lib/python3*/site-packages/pip* /out/usr/bin/pip3*
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
 from: {{ index $.Images "base/distroless-fin" }}


### PR DESCRIPTION
## Description

Remove `pip` from the `snat` image rootfs during build. `pip` is not needed at runtime — `iptables-loop.py` uses only the Python standard library (`json`, `os`, `time`) — and it ships only as a side artifact of the `python@3.12` package. The `werf.inc.yaml` `beforeInstall` step now deletes the `pip` files (`site-packages/pip`, `pip-*.dist-info`) directory so no `pip` component reaches the final image.

There is no change to runtime behavior; the `snat` image is rebuilt and its pods are restarted on rollout.

## Why do we need it, and what problem does it solve?

The bundled `pip` pulled vulnerable components into the image even though it is never executed. Removing it eliminates the following CVEs from the `snat` image:

- CVE-2026-1703
- CVE-2026-3219
- CVE-2026-6357
- CVE-2026-8643

## Why do we need it in the patch release (if we do)?

The change only strips an unused build artifact and does not alter runtime behavior, so it is safe to backport to reduce the vulnerability exposure of running clusters.

## Checklist

- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: network-gateway
type: fix
summary: Removed the unused pip from the snat image to fix CVE-2026-1703, CVE-2026-3219, CVE-2026-6357 and CVE-2026-8643.
impact_level: low
```