### PR TITLE
[openvpn] Bump golang.org/x/sys to v0.44.0 to fix CVE-2026-39824

### DIFF
--- a/modules/500-openvpn/images/openvpn/entrypoint/go.mod
+++ b/modules/500-openvpn/images/openvpn/entrypoint/go.mod
@@ -1,11 +1,11 @@
 module entrypoint
 
-go 1.25
+go 1.25.0
 
 require (
 	github.com/coreos/go-iptables v0.8.0
 	github.com/vishvananda/netlink v1.1.0
-	golang.org/x/sys v0.13.0
+	golang.org/x/sys v0.44.0
 )
 
 require github.com/vishvananda/netns v0.0.4 // indirect

--- a/modules/500-openvpn/images/openvpn/entrypoint/go.sum
+++ b/modules/500-openvpn/images/openvpn/entrypoint/go.sum
@@ -6,5 +6,5 @@ github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17
 github.com/vishvananda/netns v0.0.4 h1:Oeaw1EM2JMxD51g9uhtC0D7erkIjgmj8+JZc26m1YX8=
 github.com/vishvananda/netns v0.0.4/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
 golang.org/x/sys v0.0.0-20190606203320-7fc4e5ec1444/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
-golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
+golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=


### PR DESCRIPTION
## Description

Bump `golang.org/x/sys` from `v0.13.0` to `v0.44.0` in the OpenVPN Go entrypoint (`modules/500-openvpn/images/openvpn/entrypoint`). The `go` directive is also normalized from `1.25` to `1.25.0`. Only the dependency version changes; there are no functional changes to the entrypoint. The `openvpn` image is rebuilt and its pods are restarted on rollout.

## Why do we need it, and what problem does it solve?

The entrypoint shipped with a vulnerable version of `golang.org/x/sys`. Bumping it removes CVE-2026-39824 from the image.

## Why do we need it in the patch release (if we do)?

The change is a security fix with no behavior change and no migration steps, so it is safe to backport to reduce the vulnerability exposure of running clusters.

## Checklist

- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: openvpn
type: fix
summary: Bumped golang.org/x/sys to v0.44.0 in the openvpn entrypoint to fix CVE-2026-39824.
impact_level: low
```