### PR TITLE
[network-policy-engine] Add VEX waivers for unreachable docker/docker CVEs in kube-router

### DIFF
--- a/modules/050-network-policy-engine/images/kube-router/known_vulnerabilities.vex
+++ b/modules/050-network-policy-engine/images/kube-router/known_vulnerabilities.vex
@@ -1,8 +1,8 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
-  "@id": "merged-vex-657cc8e24f379f9db5883959c6236cf22cb5d871f1bc036fbe9c8a7511586308",
-  "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
-  "version": 1,
+  "@id": "https://deckhouse.io/vex/network-policy-engine/kube-router",
+  "author": "Deckhouse <contact@deckhouse.io>",
+  "version": 2,
   "statements": [
     {
       "vulnerability": {
@@ -31,7 +31,49 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "kube-router использует только клиентский SDK Docker (client.NewClientWithOpts и ContainerInspect) в pkg/controllers/proxy/linux_networking.go для подготовки DSR-эндпоинтов. CVE-2026-34040 затрагивает серверную часть Docker daemon — пересылку запросов к AuthZ-плагинам (GHSA-x744-4wpc-v9h2). В advisory указано: If you don't use AuthZ plugins, you are not affected. kube-router не запускает Docker daemon, уязвимый серверный код недостижим.",
       "timestamp": "2026-04-07T13:59:56.480049Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-41567"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/docker/docker"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "CVE-2026-41567 (GHSA-x86f-5xw2-fm2r) затрагивает серверную обработку запроса PUT /containers/{id}/archive в Docker daemon, приводящую к выполнению бинаря контейнера на хосте. kube-router использует Docker SDK исключительно как клиент — вызовы client.NewClientWithOpts() и ContainerInspect() в pkg/controllers/proxy/linux_networking.go для чтения сетевого namespace контейнера. Анализ графа вызовов govulncheck (GOOS=linux) подтверждает, что из уязвимого пакета достигаются только клиентские символы, серверный код архивирования не исполняется.",
+      "timestamp": "2026-04-07T14:05:00.000000Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-41568"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/docker/docker"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "CVE-2026-41568 (GHSA-vp62-88p7-qqf5) — состояние гонки в серверной реализации docker cp в Docker daemon, позволяющее создание произвольных файлов. kube-router не запускает Docker daemon и не вызывает операции копирования: используется только клиентский вызов ContainerInspect() в pkg/controllers/proxy/linux_networking.go. Анализ графа вызовов govulncheck (GOOS=linux) подтверждает достижимость только клиентских символов Docker SDK, серверный путь docker cp недостижим.",
+      "timestamp": "2026-04-07T14:05:30.000000Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-42306"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/docker/docker"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "CVE-2026-42306 (GHSA-rg2x-37c3-w2rh) — состояние гонки в серверной реализации docker cp в Docker daemon, приводящее к перенаправлению bind mount. kube-router обращается к Docker только клиентски через ContainerInspect() в pkg/controllers/proxy/linux_networking.go и не выполняет операций копирования. Анализ графа вызовов govulncheck (GOOS=linux) подтверждает достижимость только клиентских символов Docker SDK, серверный код docker cp не исполняется.",
+      "timestamp": "2026-04-07T14:06:00.000000Z"
     }
   ],
-  "timestamp": "2026-04-07T14:00:18Z"
+  "timestamp": "2026-04-07T14:06:30.000000Z"
 }

--- a/modules/050-network-policy-engine/images/kube-router/known_vulnerabilities.vex
+++ b/modules/050-network-policy-engine/images/kube-router/known_vulnerabilities.vex
@@ -44,7 +44,7 @@
       "status": "not_affected",
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "CVE-2026-41567 (GHSA-x86f-5xw2-fm2r) затрагивает серверную обработку запроса PUT /containers/{id}/archive в Docker daemon, приводящую к выполнению бинаря контейнера на хосте. kube-router использует Docker SDK исключительно как клиент — вызовы client.NewClientWithOpts() и ContainerInspect() в pkg/controllers/proxy/linux_networking.go для чтения сетевого namespace контейнера. Анализ графа вызовов govulncheck (GOOS=linux) подтверждает, что из уязвимого пакета достигаются только клиентские символы, серверный код архивирования не исполняется.",
-      "timestamp": "2026-04-07T14:05:00.000000Z"
+      "timestamp": "2026-08-26T15:05:44.693939Z"
     },
     {
       "vulnerability": {
@@ -58,7 +58,7 @@
       "status": "not_affected",
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "CVE-2026-41568 (GHSA-vp62-88p7-qqf5) — состояние гонки в серверной реализации docker cp в Docker daemon, позволяющее создание произвольных файлов. kube-router не запускает Docker daemon и не вызывает операции копирования: используется только клиентский вызов ContainerInspect() в pkg/controllers/proxy/linux_networking.go. Анализ графа вызовов govulncheck (GOOS=linux) подтверждает достижимость только клиентских символов Docker SDK, серверный путь docker cp недостижим.",
-      "timestamp": "2026-04-07T14:05:30.000000Z"
+      "timestamp": "2026-08-26T15:05:44.693939Z"
     },
     {
       "vulnerability": {
@@ -72,8 +72,8 @@
       "status": "not_affected",
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "CVE-2026-42306 (GHSA-rg2x-37c3-w2rh) — состояние гонки в серверной реализации docker cp в Docker daemon, приводящее к перенаправлению bind mount. kube-router обращается к Docker только клиентски через ContainerInspect() в pkg/controllers/proxy/linux_networking.go и не выполняет операций копирования. Анализ графа вызовов govulncheck (GOOS=linux) подтверждает достижимость только клиентских символов Docker SDK, серверный код docker cp не исполняется.",
-      "timestamp": "2026-04-07T14:06:00.000000Z"
+      "timestamp": "2026-08-26T15:05:44.693939Z"
     }
   ],
-  "timestamp": "2026-04-07T14:06:30.000000Z"
+  "timestamp": "2026-08-26T15:05:44Z"
 }

--- a/modules/050-network-policy-engine/images/kube-router/werf.inc.yaml
+++ b/modules/050-network-policy-engine/images/kube-router/werf.inc.yaml
@@ -64,3 +64,4 @@ import:
 imageSpec:
   config:
     entrypoint: ["/opt/bin/kube-router"]
+{{- include "vex mitigation" (list $ (printf "%s/%s" $.ModuleName $.ImageName)) }}


### PR DESCRIPTION
## Description

Add VEX waivers for five `github.com/docker/docker` CVEs in the `kube-router` image and wire the VEX file into the build:

- Add three new `not_affected` statements to `known_vulnerabilities.vex` (CVE-2026-41567, CVE-2026-41568, CVE-2026-42306), alongside the existing CVE-2026-33997 and CVE-2026-34040 statements, and regenerate the document metadata (`@id`, `version`, `timestamp`).
- Enable the VEX mitigation include in `werf.inc.yaml` so the VEX file is applied during the image build.

All five CVEs live in the Docker daemon server-side code. `kube-router` uses only the Docker client SDK (`client.NewClientWithOpts` and `ContainerInspect` in `pkg/controllers/proxy/linux_networking.go`) to read a container's network namespace for DSR endpoint setup; it never runs a Docker daemon. A `govulncheck` (`GOOS=linux`) call-graph analysis confirms only client-side symbols are reachable, so the vulnerable server-side paths are not in the execute path. This is a waiver only — no dependency versions or runtime behavior change.

## Why do we need it, and what problem does it solve?

Scanners flag the `kube-router` image for `github.com/docker/docker` CVEs that are not exploitable in this image, because the vulnerable code is in the Docker daemon and kube-router only uses the client SDK. The VEX waivers document this as `not_affected` (justification `vulnerable_code_not_in_execute_path`) and remove the false positives from scan results for:

- CVE-2026-33997
- CVE-2026-34040
- CVE-2026-41567
- CVE-2026-41568
- CVE-2026-42306

## Why do we need it in the patch release (if we do)?

The change only adds VEX metadata and enables its inclusion in the build; it does not touch code or dependencies, so it is safe to backport to keep vulnerability scan results accurate for running clusters.

## Checklist

- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: network-policy-engine
type: fix
summary: Added VEX waivers for unreachable github.com/docker/docker CVEs (CVE-2026-33997, CVE-2026-34040, CVE-2026-41567, CVE-2026-41568, CVE-2026-42306) in the kube-router image.
impact_level: low
```