### PR TITLE
[istio] Block istioctl from managing the native default revision-tag webhook

### DIFF
--- a/modules/110-istio/templates/control-plane/validation-default-tag.yaml
+++ b/modules/110-istio/templates/control-plane/validation-default-tag.yaml
@@ -1,0 +1,31 @@
+{{- if and (include "helm_lib_kind_exists" (list . "ValidatingAdmissionPolicy")) (include "helm_lib_kind_exists" (list . "ValidatingAdmissionPolicyBinding")) }}
+{{- $policyName := "protect-istio-default-tag.deckhouse.io" }}
+---
+apiVersion: {{ include "helm_lib_get_api_version_by_kind" (list . "ValidatingAdmissionPolicy") }}
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: {{ $policyName }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "istiod") ) | nindent 2 }}
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ["admissionregistration.k8s.io"]
+        apiVersions: ["*"]
+        operations: ["CREATE", "UPDATE", "DELETE"]
+        resources: ["mutatingwebhookconfigurations"]
+        resourceNames: ["istio-revision-tag-default-d8-istio"]
+  validations:
+    - expression: 'false'
+      reason: Forbidden
+      message: 'istioctl revision tag "default" is not allowed; use ModuleConfig istio.settings.globalVersion'
+---
+apiVersion: {{ include "helm_lib_get_api_version_by_kind" (list . "ValidatingAdmissionPolicyBinding") }}
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: {{ $policyName }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "istiod") ) | nindent 2 }}
+spec:
+  policyName: {{ $policyName }}
+  validationActions: [Deny]
+{{- end }}

--- a/modules/110-istio/templates/control-plane/validation-default-tag.yaml
+++ b/modules/110-istio/templates/control-plane/validation-default-tag.yaml
@@ -1,5 +1,5 @@
 {{- if and (include "helm_lib_kind_exists" (list . "ValidatingAdmissionPolicy")) (include "helm_lib_kind_exists" (list . "ValidatingAdmissionPolicyBinding")) }}
-{{- $policyName := "protect-istio-default-tag.deckhouse.io" }}
+{{- $policyName := "d8-istio-protect-default-tag.deckhouse.io" }}
 ---
 apiVersion: {{ include "helm_lib_get_api_version_by_kind" (list . "ValidatingAdmissionPolicy") }}
 kind: ValidatingAdmissionPolicy


### PR DESCRIPTION
## Description
Adds a ValidatingAdmissionPolicy that denies CREATE/UPDATE/DELETE of the native istioctl revision-tag webhook `istio-revision-tag-default-d8-istio`.

Default sidecar injection stays on Deckhouse-managed `d8-istio-sidecar-injector-global` and continues to follow `ModuleConfig` `istio.settings.globalVersion`. 

## Why do we need it, and what problem does it solve?
`istioctl tag set default --revision …` can create/overwrite mutatingwebhookconfigurations `istio-revision-tag-default-d8-istio`, which fights Deckhouse ownership of the default revision and can diverge from `globalVersion`. Blocking that object keeps default injection under ModuleConfig control.


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: chore
summary: Block istioctl from managing the native default revision-tag webhook
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
