### PR TITLE
docs(ports): register the storage modules' node ports and name them correctly

### DIFF
--- a/docs/documentation/_data/deckhouse-ports.yml
+++ b/docs/documentation/_data/deckhouse-ports.yml
@@ -180,8 +180,13 @@ groups:
   - ports: "4216"
     protocol: TCP
     description:
+      en: "`storage-status` agent metrics, the address the proxy forwards to"
+      ru: "Метрики агента модуля `storage-status`, адрес, на который проксируется запрос"
+  - ports: "4217"
+    protocol: TCP
+    description:
       en: "`storage-status` agent metrics"
-      ru: "Метрики агента `storage-status`"
+      ru: "Метрики агента модуля `storage-status`"
   - ports: "4218"
     protocol: TCP/UDP
     description:
@@ -372,26 +377,46 @@ groups:
     description:
       en: "`service-with-healthchecks` module metrics"
       ru: "Метрики модуля `service-with-healthchecks`"
+  - ports: "4266"
+    protocol: TCP
+    description:
+      en: "`csi-scsi-generic` CSI controller metrics"
+      ru: "Метрики CSI-контроллера модуля `csi-scsi-generic`"
+  - ports: "4267"
+    protocol: TCP
+    description:
+      en: "`csi-scsi-generic` CSI node metrics"
+      ru: "Метрики CSI-агентов модуля `csi-scsi-generic`"
   - ports: "4269"
     protocol: TCP
     description:
-      en: "`sds-replicated-volume` CSI node healthcheck"
-      ru: "Healthcheck CSI-агентов модуля `sds-replicated-volume`"
+      en: "`sds-replicated-volume` agent healthcheck"
+      ru: "Healthcheck агента модуля `sds-replicated-volume`"
   - ports: "4270"
     protocol: TCP
     description:
-      en: "`sds-replicated-volume` CSI node metrics"
-      ru: "Метрики CSI-агентов модуля `sds-replicated-volume`"
+      en: "`sds-replicated-volume` agent metrics, the address the proxy forwards to"
+      ru: "Метрики агента модуля `sds-replicated-volume`, адрес, на который проксируется запрос"
   - ports: "4271"
     protocol: TCP
     description:
-      en: "`sds-replicated-volume` CSI controller healthcheck"
-      ru: "Healthcheck CSI-контроллера модуля `sds-replicated-volume`"
+      en: "`sds-replicated-volume` controller healthcheck"
+      ru: "Healthcheck контроллера модуля `sds-replicated-volume`"
   - ports: "4272"
     protocol: TCP
     description:
-      en: "`sds-replicated-volume` CSI controller metrics"
-      ru: "Метрики CSI-контроллера модуля `sds-replicated-volume`"
+      en: "`sds-replicated-volume` controller metrics"
+      ru: "Метрики контроллера модуля `sds-replicated-volume`"
+  - ports: "4273"
+    protocol: TCP
+    description:
+      en: "`sds-replicated-volume` DRBD metrics of the agent"
+      ru: "Метрики DRBD агента модуля `sds-replicated-volume`"
+  - ports: "4274"
+    protocol: TCP
+    description:
+      en: "`sds-replicated-volume` DRBD metrics of the agent, the address the proxy forwards to"
+      ru: "Метрики DRBD агента модуля `sds-replicated-volume`, адрес, на который проксируется запрос"
   - ports: "4135-4199"
     protocol: TCP
     description:


### PR DESCRIPTION
## Description

`docs/documentation/_data/deckhouse-ports.yml` only. Three kinds of change:

**Reserved** for `csi-scsi-generic`, whose CSI controller and CSI node are both `hostNetwork` and are about to serve CSI operation metrics:

| Port | |
|---|---|
| 4266 | `csi-scsi-generic` CSI controller metrics |
| 4267 | `csi-scsi-generic` CSI node metrics |

**Added** — in use today, missing from the list. Every one is a `hostPort` in a `hostNetwork` DaemonSet, so exactly the kind of port a second module can collide with:

| Port | |
|---|---|
| 4217 | `storage-status` agent metrics, published by its `kube-rbac-proxy` |
| 4273 | `sds-replicated-volume` DRBD metrics of the agent, published by its proxy |
| 4274 | the address that proxy forwards to |

**Corrected** — four entries that name the wrong component:

| Port | Said | Actually |
|---|---|---|
| 4269 | `sds-replicated-volume` CSI node healthcheck | the **agent's** health probe (`templates/agent/daemonset.yaml`) — 4262 is the real CSI node healthcheck |
| 4270 | `sds-replicated-volume` CSI node metrics | the **agent's** metrics, and the loopback upstream of its proxy rather than the published port, which is 4215 |
| 4271 | `sds-replicated-volume` CSI controller healthcheck | the **module controller's** health probe (`templates/controller/deployment.yaml`) — 4261 is the real one |
| 4272 | `sds-replicated-volume` CSI controller metrics | the **module controller's** metrics (`templates/controller/service-metrics.yaml`) |

Where a module has both a loopback endpoint and a proxy that publishes it, the upstream now says so instead of reading like the reachable one. That was ambiguous for `4216`/`4217` (storage-status) and for `4270`/`4215` (sds-replicated-volume).

No other file changes; the YAML parses and the numeric ordering inside `NodesToNodes` is preserved.

## Why do we need it, and what problem does it solve?

This file is the only place where node-level port allocation across modules is coordinated, and it is being used that way: a module author picks the next free number here. It currently gives the wrong answer twice over.

**It under-reports.** Picking "the next free numbers by this list" for `csi-scsi-generic` gives 4264 and 4265 — and both are already taken, by `node-local-dns`' `safe-updater` (`HealthProbeBindAddress = ":4264"`, `PprofBindAddress = ":4265"` in `ee/be/modules/350-node-local-dns/images/safe-updater/src/internal/constant/constant.go`, and `containerPort: 4264` in its Deployment). Three more ports of the storage modules are in the same state: taken in a chart, absent here. A collision between two `hostNetwork` DaemonSets does not fail at apply time — it fails when the second pod happens to land on a node that already runs the first, with `bind: address already in use` and no hint about who took the port.

**It mislabels.** Four `sds-replicated-volume` entries name a CSI component where the port belongs to the agent or to the module controller, and two of them duplicate the descriptions of 4261/4262, which are the real CSI ports. Anyone reading the list to size a firewall rule, or to find who owns a port they see bound on a node, is sent to the wrong component.

The corrections were verified against the module's `main`, not against the pending work: `4269`/`4270` appear only in `templates/agent/daemonset.yaml`, `4271` only in `templates/controller/deployment.yaml`, `4272` only in `templates/controller/service-metrics.yaml`.

## Why do we need it in the patch release (if we do)?

Not necessarily. Documentation only; nothing in the cluster changes.

## Checklist

- [ ] The code is covered by unit tests. <!-- data file for the docs site, no code -->
- [ ] e2e tests passed. <!-- not applicable -->
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually. <!-- not applicable; the port facts were verified by reading the charts that bind them -->

## Changelog entries

```changes
section: docs
type: fix
summary: Register the node ports of the storage modules and name their owners correctly in the ports reference.
impact_level: low
```
