### PR TITLE
docs(ports): list node-local-dns' safe-updater ports, reserve one for a CSI node

### DIFF
--- a/docs/documentation/_data/deckhouse-ports.yml
+++ b/docs/documentation/_data/deckhouse-ports.yml
@@ -377,6 +377,16 @@ groups:
     description:
       en: "`service-with-healthchecks` module metrics"
       ru: "Метрики модуля `service-with-healthchecks`"
+  - ports: "4264"
+    protocol: TCP
+    description:
+      en: "`node-local-dns` safe-updater healthcheck"
+      ru: "Healthcheck компонента safe-updater модуля `node-local-dns`"
+  - ports: "4265"
+    protocol: TCP
+    description:
+      en: "`node-local-dns` safe-updater pprof"
+      ru: "pprof компонента safe-updater модуля `node-local-dns`"
   - ports: "4266"
     protocol: TCP
     description:
@@ -387,6 +397,11 @@ groups:
     description:
       en: "`csi-scsi-generic` CSI node metrics"
       ru: "Метрики CSI-агентов модуля `csi-scsi-generic`"
+  - ports: "4268"
+    protocol: TCP
+    description:
+      en: "`sds-replicated-volume` CSI node metrics"
+      ru: "Метрики CSI-агентов модуля `sds-replicated-volume`"
   - ports: "4269"
     protocol: TCP
     description:


### PR DESCRIPTION
## Description

`docs/documentation/_data/deckhouse-ports.yml` only. Follow-up to #22426, which registered the storage modules' node ports and turned up two gaps it did not itself fix.

**Listed** — in use today, absent from the file:

| Port | |
|---|---|
| 4264 | `node-local-dns` safe-updater healthcheck |
| 4265 | `node-local-dns` safe-updater pprof |

Both are in `ee/be/modules/350-node-local-dns/images/safe-updater/src/internal/constant/constant.go` (`HealthProbeBindAddress = ":4264"`, `PprofBindAddress = ":4265"`) and in the component's Deployment, where 4264 is the port both probes hit and both numbers are declared as `containerPort`.

**Reserved:**

| Port | |
|---|---|
| 4268 | `sds-replicated-volume` CSI node metrics |

## Why do we need it, and what problem does it solve?

**4264/4265** are not a storage module, which is why #22426 left them alone — but they are the first two numbers a reader of this file would pick as free, which is exactly how they were found. A list whose purpose is to answer "which number can I take" has to contain the numbers that are taken, whoever owns them.

**One correction to what #22426 said about them.** That PR described these two as ports csi-scsi-generic would have collided with. That overstated it: the safe-updater Deployment is `hostNetwork: false`, so 4264/4265 are pod-network ports, and a pod IP and a node IP are different addresses — the bind would not have failed. The reason to keep the numbers distinct is that this file gives a reader no way to tell the two cases apart, not that there was a live conflict. The numbers csi-scsi-generic ended up with (4266/4267) are fine either way, and this entry is what lets the next reader make that judgement instead of guessing.

**4268** is for the `sds-replicated-volume` CSI node, whose DaemonSet is `hostNetwork` and is about to serve CSI operation metrics the way its CSI controller already does. Verified free before taking it: no hit in the charts, values, images or hooks of either repository, and no entry here.

## Why do we need it in the patch release (if we do)?

Not necessarily. Documentation only; nothing in the cluster changes.

## Checklist

- [ ] The code is covered by unit tests. <!-- data file for the docs site, no code -->
- [ ] e2e tests passed. <!-- not applicable -->
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually. <!-- not applicable; the port facts were verified by reading the code and charts that bind them -->

## Changelog entries

```changes
section: docs
type: fix
summary: List the safe-updater ports of node-local-dns and reserve a port for the sds-replicated-volume CSI node in the ports reference.
impact_level: low
```
