### PR TITLE
[cloud-provider-dvp] supress known CVE

### DIFF
--- a/modules/030-cloud-provider-dvp/images/terraform-manager/known_vulnerabilities.vex
+++ b/modules/030-cloud-provider-dvp/images/terraform-manager/known_vulnerabilities.vex
@@ -2,7 +2,7 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "merged-vex-819396348420854c54b988d825529cab830b81f6a05730951c9bec690dc551f1",
   "author": "Deckhouse <contact@deckhouse.io>",
-  "version": 2,
+  "version": 3,
   "statements": [
     {
       "vulnerability": {
@@ -59,6 +59,20 @@
       "justification": "vulnerable_code_not_present",
       "impact_statement": "Уязвимость связана с обработкой параметров content без указанной схемы в подпакете openapi3filter библиотеки kin-openapi. terraform-provider-kubernetes не импортирует этот подпакет, используя только openapi3 и openapi2 для чтения схем, поэтому уязвимый код не входит в состав скомпилированного бинарного файла",
       "timestamp": "2026-08-20T06:45:55.416197Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-76905"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/getkin/kin-openapi"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "Уязвимость вызвана паникой из-за разыменования нулевого указателя в openapi3filter.ConvertErrors/convertParseError при разборе multipart/form-data. Проверка патченного дерева исходников terraform-provider-kubernetes (grep по всем .go-файлам) не выявила ни одного импорта github.com/getkin/kin-openapi/openapi3filter, а go list -deps для главного пакета (main.go, собираемого командой go build ./ по werf.inc.yaml) показывает в графе зависимостей только kin-openapi/openapi3, openapi2 и jsoninfo - подпакет openapi3filter физически отсутствует в скомпилированном бинарном файле.",
+      "timestamp": "2026-08-24T00:00:00.000000Z"
     }
   ],
   "timestamp": "2025-10-10T07:23:24Z"


### PR DESCRIPTION
## Description
Added an OpenVEX statement for CVE-2026-76905 to `modules/030-cloud-provider-dvp/images/terraform-manager/known_vulnerabilities.vex`, marking it `not_affected` for the `terraform-manager` image.

## Why do we need it, and what problem does it solve?
Trivy flagged `github.com/getkin/kin-openapi` v0.111.0 (fixed in v0.141.0) for CVE-2026-76905, a nil-pointer panic in `openapi3filter.ConvertErrors`/`convertParseError`. Verification against the actual patched upstream source (`hashicorp/terraform-provider-kubernetes` v2.38.0 + all 7 carried patches) confirms the
  binary never imports `openapi3filter` — a full-tree grep and `go list -deps` on the compiled main package both show zero references to that subpackage. The finding is a false positive for this specific binary and would otherwise keep re-triggering scanner alerts with no actionable fix.

## Why do we need it in the patch release (if we do)?

CSE release.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: cloud-provider-dvp
type: chore
summary: Suppresses a false-positive CVE scanner finding for terraform-manager (kin-openapi openapi3filter is not compiled into the binary).
impact_level: low
```
<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
