### PR TITLE
[deckhouse] Compile the reserved public hosts into the policies instead of a paramKind

### DIFF
--- a/modules/002-deckhouse/hooks/snapshot_reserved_public_hosts.go
+++ b/modules/002-deckhouse/hooks/snapshot_reserved_public_hosts.go
@@ -92,6 +92,14 @@ const (
 	// The pages a cluster-wide read is taken in. Large enough that a cluster of any ordinary size is
 	// one or two requests, small enough that no single response has to be held whole.
 	reservedPublicHostsPageLimit = 500
+
+	// The most hostnames the record holds. It is rendered into every policy as a CEL literal, so this
+	// is what bounds their size, and openapi/values.yaml carries the same number as maxItems.
+	//
+	// Only what a tenant already serves under the platform's own domain is ever recorded, so an
+	// ordinary cluster is orders of magnitude below this, and a full record is tens of kilobytes in an
+	// object whose limit is measured in megabytes.
+	reservedPublicHostsRecordLimit = 1000
 )
 
 var namespaceResource = schema.GroupVersionResource{Version: "v1", Resource: "namespaces"}
@@ -190,7 +198,7 @@ func snapshotReservedPublicHosts(ctx context.Context, input *go_hook.HookInput, 
 		// every time Deckhouse restarts.
 		input.Values.Set(reservedPublicHostsValuePath, reservedPublicHostsSnapshot{
 			Recorded: true,
-			Hosts:    hostsFromRecord(recorded[0].Hosts, input),
+			Hosts:    hostsWithinTheLimit(hostsFromRecord(recorded[0].Hosts, input), input),
 		})
 		return nil
 	}
@@ -225,6 +233,7 @@ func snapshotReservedPublicHosts(ctx context.Context, input *go_hook.HookInput, 
 	if err != nil {
 		return err
 	}
+	hosts = hostsWithinTheLimit(hosts, input)
 
 	input.Logger.Info("recorded the hostnames tenants already serve under the platform's domain",
 		slog.Int("count", len(hosts)),
@@ -266,6 +275,28 @@ func hostsFromRecord(recorded []string, input *go_hook.HookInput) []string {
 	}
 
 	return hosts.Slice()
+}
+
+// hostsWithinTheLimit bounds what goes into values, and with it what every policy carries. Both
+// records are sorted, which is what makes the entries kept the same ones on every converge rather
+// than whichever a map iteration offered first.
+//
+// Truncating rather than letting the schema reject the value is the choice hostsFromRecord makes for
+// a malformed entry, for the same reason: a dropped entry un-grandfathers one object, whose next
+// write is denied with a message naming the hostname, while a rejected value stops the module that
+// renders Deckhouse from converging at all.
+func hostsWithinTheLimit(hosts []string, input *go_hook.HookInput) []string {
+	if len(hosts) <= reservedPublicHostsRecordLimit {
+		return hosts
+	}
+
+	dropped := hosts[reservedPublicHostsRecordLimit:]
+	input.Logger.Warn("truncated the record of what tenants already serve, which un-grandfathers the entries dropped",
+		slog.Int("limit", reservedPublicHostsRecordLimit),
+		slog.Int("count", len(dropped)),
+		slog.Any("dropped", dropped))
+
+	return hosts[:reservedPublicHostsRecordLimit]
 }
 
 // collectTenantHosts reads every hostname claimed outside the namespaces the platform owns and keeps

--- a/modules/002-deckhouse/hooks/snapshot_reserved_public_hosts.go
+++ b/modules/002-deckhouse/hooks/snapshot_reserved_public_hosts.go
@@ -58,7 +58,7 @@ that would grandfather none of what appeared in between. Which mode is in force 
 publicdomain.EffectiveMode, the same decision the template publishes in the ConfigMap's mode key.
 
 That record lives in the d8-reserved-public-hosts ConfigMap in d8-system, the same object the
-policies read their parameters from, and Helm is its only writer. The hook reads the grandfather keys
+template publishes the reserved set in, and Helm is its only writer. The hook reads the grandfather keys
 back out of it and puts them in values, Helm renders them from values, and the two agree on a fixed
 point instead of arguing over the object -- the flow this repository already uses for a hook that has
 to produce something a template owns (go_lib/hooks/tls_certificate/internal_tls.go, where a

--- a/modules/002-deckhouse/hooks/snapshot_reserved_public_hosts_test.go
+++ b/modules/002-deckhouse/hooks/snapshot_reserved_public_hosts_test.go
@@ -17,15 +17,18 @@ limitations under the License.
 package hooks
 
 import (
+	"fmt"
 	"os"
 	"regexp"
 	"sort"
+	"strings"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/tidwall/gjson"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
 
 	"github.com/deckhouse/deckhouse/go_lib/set"
 	"github.com/deckhouse/deckhouse/modules/002-deckhouse/hooks/lib/sharedgateway"
@@ -73,6 +76,30 @@ func TestTheSnapshotReadsEveryResourceThePoliciesDeny(t *testing.T) {
 			t.Errorf("the policies deny %v, the snapshot reads %v", denied, read)
 			break
 		}
+	}
+}
+
+// TestTheRecordLimitMatchesTheSchema keeps the number the hook truncates to and the number the
+// schema declares the same one. A schema capping lower would reject a record the hook considers
+// valid and stop the module that renders Deckhouse from converging, which is the failure truncating
+// exists to avoid; a schema capping higher would leave the bound on the policies unstated.
+func TestTheRecordLimitMatchesTheSchema(t *testing.T) {
+	values, err := os.ReadFile("../openapi/values.yaml")
+	if err != nil {
+		t.Fatalf("read the values schema: %v", err)
+	}
+
+	asJSON, err := yaml.YAMLToJSON(values)
+	if err != nil {
+		t.Fatalf("parse the values schema: %v", err)
+	}
+
+	declared := gjson.GetBytes(asJSON, "properties.internal.properties.reservedPublicHosts.properties.hosts.maxItems")
+	if !declared.Exists() {
+		t.Fatal("the record has no maxItems in the values schema, so nothing bounds what the policies carry")
+	}
+	if declared.Int() != reservedPublicHostsRecordLimit {
+		t.Errorf("the hook truncates to %d, the schema caps at %d", reservedPublicHostsRecordLimit, declared.Int())
 	}
 }
 
@@ -470,6 +497,31 @@ spec:
 				"recorded": true,
 				"hosts": ["shop.example.com", "store.example.com"]
 			}`))
+		})
+	})
+
+	Context("An operator hand-edited the record longer than the policies can carry", func() {
+		BeforeEach(func() {
+			record := strings.Builder{}
+			for i := 0; i < reservedPublicHostsRecordLimit+500; i++ {
+				fmt.Fprintf(&record, "    host-%06d.example.com\n", i)
+			}
+			run("%s.example.com", tenantObjects+paramsConfigMap("true", record.String()))
+		})
+
+		// The record goes into every policy as a CEL literal, so its length is what bounds their
+		// size, and openapi/values.yaml caps the same key. Truncating keeps a record over the cap
+		// converging, where validation would reject it and stop the module outright.
+		It("keeps the cap's worth and drops the rest rather than failing values validation", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			hosts := f.ValuesGet(reservedPublicHostsValuePath + ".hosts").Array()
+			Expect(hosts).To(HaveLen(reservedPublicHostsRecordLimit))
+			// The record is sorted before it is cut, so which entries survive is the same on every
+			// converge rather than whichever a map iteration offered first.
+			Expect(hosts[0].String()).To(Equal("host-000000.example.com"))
+			Expect(hosts[len(hosts)-1].String()).
+				To(Equal(fmt.Sprintf("host-%06d.example.com", reservedPublicHostsRecordLimit-1)))
 		})
 	})
 

--- a/modules/002-deckhouse/hooks/snapshot_reserved_public_hosts_test.go
+++ b/modules/002-deckhouse/hooks/snapshot_reserved_public_hosts_test.go
@@ -35,7 +35,7 @@ import (
 // policyResources pulls the group and the resource out of every call the template makes to its
 // policy definition, which is the list of what the admission policies deny.
 var policyResources = regexp.MustCompile(
-	`reserved_public_hosts_policy" \(list \. \$\w+ "[a-z]+" "([a-z0-9.]+)" "([a-z]+)"`)
+	`reserved_public_hosts_policy" \(list \. \$reserved "[a-z]+" "([a-z0-9.]+)" "([a-z]+)"`)
 
 // TestTheSnapshotReadsEveryResourceThePoliciesDeny keeps the two sides of the grandfathering in
 // step. Whatever the policies deny, the snapshot has to be able to record: a resource on one side

--- a/modules/002-deckhouse/hooks/snapshot_reserved_public_hosts_test.go
+++ b/modules/002-deckhouse/hooks/snapshot_reserved_public_hosts_test.go
@@ -35,7 +35,7 @@ import (
 // policyResources pulls the group and the resource out of every call the template makes to its
 // policy definition, which is the list of what the admission policies deny.
 var policyResources = regexp.MustCompile(
-	`reserved_public_hosts_policy" \(list \. \$paramsName "[a-z]+" "([a-z0-9.]+)" "([a-z]+)"`)
+	`reserved_public_hosts_policy" \(list \. \$\w+ "[a-z]+" "([a-z0-9.]+)" "([a-z]+)"`)
 
 // TestTheSnapshotReadsEveryResourceThePoliciesDeny keeps the two sides of the grandfathering in
 // step. Whatever the policies deny, the snapshot has to be able to record: a resource on one side

--- a/modules/002-deckhouse/openapi/values.yaml
+++ b/modules/002-deckhouse/openapi/values.yaml
@@ -46,6 +46,12 @@ properties:
               leaves it out, because the wildcard form is reserved by exact match and the allowlist
               this record feeds cannot lift it. The pattern stays permissive so that a record written
               by an earlier build, when the wildcard was still recorded, still validates.
+
+              The bound is what keeps the policies bounded, since the record is rendered into each of
+              them as a CEL literal. The hook truncates to the same number before it writes, so this
+              is a contract on the value rather than a way for a long record to fail validation and
+              stop the module from converging.
+            maxItems: 1000
             items:
               type: string
               pattern: '^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'

--- a/modules/002-deckhouse/template_tests/reserved_public_hosts_cel_test.go
+++ b/modules/002-deckhouse/template_tests/reserved_public_hosts_cel_test.go
@@ -44,7 +44,7 @@ var (
 // match conditions first, then the variables in declaration order, then the validation. Compiling
 // against a bare CEL environment is enough to catch the mistakes worth catching here, syntax and
 // operations that do not exist, without standing up an apiserver.
-func evaluatePolicy(policy object_store.KubeObject, params, object, request map[string]interface{}) verdict {
+func evaluatePolicy(policy object_store.KubeObject, object, request map[string]interface{}) verdict {
 	env, err := cel.NewEnv(
 		// The apiserver puts the string extension in the base environment of every admission
 		// policy, at version 0 up to Kubernetes 1.29 and version 2 after it
@@ -53,16 +53,18 @@ func evaluatePolicy(policy object_store.KubeObject, params, object, request map[
 		cel.Variable("object", cel.DynType),
 		cel.Variable("oldObject", cel.DynType),
 		cel.Variable("request", cel.DynType),
-		cel.Variable("params", cel.DynType),
 		cel.Variable("variables", cel.DynType),
 	)
 	Expect(err).ShouldNot(HaveOccurred())
 
+	// No params variable, deliberately: the policies declare no paramKind, and the apiserver only
+	// puts params in the environment of one that does. An expression that reaches for it fails to
+	// compile here rather than working in this harness and taking out every aggregated apiserver in
+	// a real cluster, which is what a paramKind on a core type does.
 	activation := map[string]interface{}{
 		"object":    object,
 		"oldObject": nil,
 		"request":   request,
-		"params":    params,
 		"variables": map[string]interface{}{},
 	}
 
@@ -147,14 +149,22 @@ func requestFor(username, namespace, name string) map[string]interface{} {
 	}
 }
 
-// paramsFrom hands the policies the whole data map of the ConfigMap that was actually rendered, so
-// that a key the template stops writing, or writes in a shape the CEL cannot read, shows up here
-// rather than being papered over by a map the test built itself.
-func paramsFrom(cm object_store.KubeObject) map[string]interface{} {
-	Expect(cm.Exists()).To(BeTrue(), "the parameters ConfigMap should be rendered")
-	data, ok := cm["data"].(map[string]interface{})
-	Expect(ok).To(BeTrue(), "the parameters ConfigMap should carry a data map")
-	return map[string]interface{}{"data": data}
+// policyExpressions is every CEL expression a rendered policy carries, wherever it keeps it.
+func policyExpressions(policy object_store.KubeObject) []string {
+	expressions := []string{}
+	for _, field := range []string{"spec.matchConditions", "spec.variables"} {
+		for _, entry := range policy.Field(field).Array() {
+			expressions = append(expressions, entry.Get("expression").String())
+		}
+	}
+	for _, validation := range policy.Field("spec.validations").Array() {
+		expressions = append(expressions,
+			validation.Get("expression").String(), validation.Get("messageExpression").String())
+	}
+	for _, annotation := range policy.Field("spec.auditAnnotations").Array() {
+		expressions = append(expressions, annotation.Get("valueExpression").String())
+	}
+	return expressions
 }
 
 var _ = Describe("Module :: deckhouse :: reserved public hosts :: CEL ::", func() {
@@ -176,7 +186,6 @@ var _ = Describe("Module :: deckhouse :: reserved public hosts :: CEL ::", func(
 		ingressPolicy object_store.KubeObject
 		gatewayPolicy object_store.KubeObject
 		everyKind     []kindUnderPolicy
-		params        map[string]interface{}
 
 		// The deckhouse ModuleConfig section under test and the recorded snapshot, both empty for a
 		// cluster that never set one. Contexts assign them in a BeforeEach; the render happens in
@@ -232,8 +241,6 @@ var _ = Describe("Module :: deckhouse :: reserved public hosts :: CEL ::", func(
 			{name: "ListenerSet", policy: policy(reservedHostsListenerSetPolicy), object: listenersWithHosts, listeners: true},
 			{name: "Gateway", policy: policy(reservedHostsGatewayPolicy), object: listenersWithHosts, listeners: true},
 		}
-
-		params = paramsFrom(f.KubernetesResource("ConfigMap", "d8-system", reservedHostsConfigMapName))
 	})
 
 	tenant := requestFrom("tenant@example.com")
@@ -257,7 +264,7 @@ var _ = Describe("Module :: deckhouse :: reserved public hosts :: CEL ::", func(
 			Expect(kind.policy.Exists()).To(BeTrue(), kind.name)
 
 			for _, c := range cases {
-				Expect(evaluatePolicy(kind.policy, params, kind.object(c.host), tenant)).
+				Expect(evaluatePolicy(kind.policy, kind.object(c.host), tenant)).
 					To(Equal(c.want), "%s hostname %q: %s", kind.name, c.host, c.why)
 			}
 		}
@@ -267,25 +274,25 @@ var _ = Describe("Module :: deckhouse :: reserved public hosts :: CEL ::", func(
 		// The three verdicts the reservation is about, checked on Ingress alone so that a failure
 		// here is the verdict and not a missing policy for some other kind.
 		It("denies a single-label hostname the platform does not publish today", func() {
-			Expect(evaluatePolicy(ingressPolicy, params, ingressWithHosts("shop.example.com"), tenant)).
+			Expect(evaluatePolicy(ingressPolicy, ingressWithHosts("shop.example.com"), tenant)).
 				To(Equal(verdictDenied), "the template could render this for a service named shop, which is "+
 					"what a hand-maintained list of the names Deckhouse happens to publish can never cover")
 		})
 
 		It("denies the wildcard form of the namespace", func() {
-			Expect(evaluatePolicy(ingressPolicy, params, ingressWithHosts("*.example.com"), tenant)).
+			Expect(evaluatePolicy(ingressPolicy, ingressWithHosts("*.example.com"), tenant)).
 				To(Equal(verdictDenied), "a tenant holding this shadows every platform hostname at once, "+
 					"which is worse than the single-host takeover the reservation is about")
 		})
 
 		It("denies a hostname written with a root dot", func() {
-			Expect(evaluatePolicy(ingressPolicy, params, ingressWithHosts("CONSOLE.EXAMPLE.COM."), tenant)).
+			Expect(evaluatePolicy(ingressPolicy, ingressWithHosts("CONSOLE.EXAMPLE.COM."), tenant)).
 				To(Equal(verdictDenied), "the API server rejects a trailing dot on its own, but the policy "+
 					"must not be the reason it is allowed")
 		})
 
 		It("allows a two-label hostname, the shape an ecosystem application takes", func() {
-			Expect(evaluatePolicy(ingressPolicy, params, ingressWithHosts("app.ns.example.com"), tenant)).
+			Expect(evaluatePolicy(ingressPolicy, ingressWithHosts("app.ns.example.com"), tenant)).
 				To(Equal(verdictAllowed), "applications.publicDomainTemplate puts the instance and its "+
 					"namespace in two labels, so it can never collide with the platform's one")
 		})
@@ -327,14 +334,14 @@ var _ = Describe("Module :: deckhouse :: reserved public hosts :: CEL ::", func(
 
 		It("denies a request that hides a reserved hostname among its own", func() {
 			for _, kind := range everyKind {
-				Expect(evaluatePolicy(kind.policy, params, kind.object("shop.example.org", "console.example.com"), tenant)).
+				Expect(evaluatePolicy(kind.policy, kind.object("shop.example.org", "console.example.com"), tenant)).
 					To(Equal(verdictDenied), kind.name)
 			}
 		})
 
 		It("allows a request that claims no hostname at all", func() {
 			for _, kind := range everyKind {
-				Expect(evaluatePolicy(kind.policy, params, map[string]interface{}{"spec": map[string]interface{}{}}, tenant)).
+				Expect(evaluatePolicy(kind.policy, map[string]interface{}{"spec": map[string]interface{}{}}, tenant)).
 					To(Equal(verdictAllowed), "%s with an empty spec", kind.name)
 			}
 			// A listener that names no hostname accepts any, and is a different shape from a spec
@@ -343,7 +350,7 @@ var _ = Describe("Module :: deckhouse :: reserved public hosts :: CEL ::", func(
 				if !kind.listeners {
 					continue
 				}
-				Expect(evaluatePolicy(kind.policy, params, kind.object(""), tenant)).
+				Expect(evaluatePolicy(kind.policy, kind.object(""), tenant)).
 					To(Equal(verdictAllowed), "%s with a listener that names no hostname", kind.name)
 			}
 		})
@@ -355,28 +362,29 @@ var _ = Describe("Module :: deckhouse :: reserved public hosts :: CEL ::", func(
 				"system:serviceaccount:kube-system:some-controller",
 				"dhctl",
 			} {
-				Expect(evaluatePolicy(ingressPolicy, params, ingressWithHosts("console.example.com"), requestFrom(username))).
+				Expect(evaluatePolicy(ingressPolicy, ingressWithHosts("console.example.com"), requestFrom(username))).
 					To(Equal(verdictSkipped), "user %q", username)
 			}
 		})
 
-		It("reserves nothing when the parameters are there but say nothing", func() {
-			for name, broken := range map[string]map[string]interface{}{
-				"no data at all":     {"data": map[string]interface{}{}},
-				"an empty pattern":   {"data": map[string]interface{}{"hostPattern": "", "hosts": ""}},
-				"an empty host list": {"data": map[string]interface{}{"hosts": ""}},
-			} {
-				Expect(evaluatePolicy(ingressPolicy, broken, ingressWithHosts("console.example.com"), tenant)).
-					To(Equal(verdictAllowed), "with %s the policy must not deny everything", name)
-				// The Gateway policy reads one key more, and reads it in a match condition, where
-				// an expression that errors is a denial rather than a skip: failurePolicy is Fail.
-				Expect(evaluatePolicy(gatewayPolicy, broken, listenersWithHosts("console.example.com"), tenant)).
-					To(Equal(verdictAllowed), "with %s the Gateway policy must still evaluate", name)
+		// What is reserved is compiled into the policy, so a request is decided from the request
+		// alone and there is no object whose loss could turn the reservation into a denial of
+		// everything under failurePolicy: Fail. The harness declares no params variable, so an
+		// expression that went back to fetching them would fail to compile above; this says so
+		// where a reader looks for it, and says it for all six kinds at once.
+		It("decides from the request alone, with nothing fetched from the cluster", func() {
+			for _, kind := range everyKind {
+				expressions := policyExpressions(kind.policy)
+				Expect(expressions).ToNot(BeEmpty(), kind.name)
+				for _, expression := range expressions {
+					Expect(expression).ToNot(ContainSubstring("params"),
+						"%s reaches for params, which needs a paramKind back: %s", kind.name, expression)
+				}
 			}
 		})
 
 		It("exempts no object while no shared Gateway is configured", func() {
-			Expect(evaluatePolicy(gatewayPolicy, params, listenersWithHosts("console.example.com"),
+			Expect(evaluatePolicy(gatewayPolicy, listenersWithHosts("console.example.com"),
 				requestFor("tenant@example.com", "infra", "shared"))).
 				To(Equal(verdictDenied), "an empty sharedGateway key exempts nothing, not everything")
 		})
@@ -396,7 +404,7 @@ var _ = Describe("Module :: deckhouse :: reserved public hosts :: CEL ::", func(
 
 		It("never reaches the validation for that object, whatever its listeners claim", func() {
 			for _, host := range []string{"*.example.com", "console.example.com", "shop.example.com"} {
-				Expect(evaluatePolicy(gatewayPolicy, params, listenersWithHosts(host), operator)).
+				Expect(evaluatePolicy(gatewayPolicy, listenersWithHosts(host), operator)).
 					To(Equal(verdictSkipped), "hostname %q: the exemption is on the object, not on what it claims", host)
 			}
 		})
@@ -406,7 +414,7 @@ var _ = Describe("Module :: deckhouse :: reserved public hosts :: CEL ::", func(
 				{"infra", "other", "another Gateway in the namespace the shared one lives in"},
 				{"tenant", "shared", "the same name in a namespace of a tenant's own"},
 			} {
-				Expect(evaluatePolicy(gatewayPolicy, params, listenersWithHosts("console.example.com"),
+				Expect(evaluatePolicy(gatewayPolicy, listenersWithHosts("console.example.com"),
 					requestFor("tenant@example.com", tc.namespace, tc.name))).
 					To(Equal(verdictDenied), tc.why)
 			}
@@ -417,7 +425,7 @@ var _ = Describe("Module :: deckhouse :: reserved public hosts :: CEL ::", func(
 				if kind.name == "Gateway" {
 					continue
 				}
-				Expect(evaluatePolicy(kind.policy, params, kind.object("console.example.com"), operator)).
+				Expect(evaluatePolicy(kind.policy, kind.object("console.example.com"), operator)).
 					To(Equal(verdictDenied), "%s of the same namespace and name as the shared Gateway", kind.name)
 			}
 		})
@@ -479,7 +487,7 @@ var _ = Describe("Module :: deckhouse :: reserved public hosts :: CEL ::", func(
 		})
 
 		It("still denies a request that hides a reserved hostname behind a freed one", func() {
-			Expect(evaluatePolicy(ingressPolicy, params, ingressWithHosts("grafana.example.com", "console.example.com"), tenant)).
+			Expect(evaluatePolicy(ingressPolicy, ingressWithHosts("grafana.example.com", "console.example.com"), tenant)).
 				To(Equal(verdictDenied))
 		})
 	})
@@ -522,9 +530,8 @@ var _ = Describe("Module :: deckhouse :: reserved public hosts :: CEL ::", func(
 			f.HelmRender(WithAPIVersions(validatingAdmissionPolicyAPI, validatingAdmissionPolicyBindingAPI))
 			Expect(f.RenderError).ShouldNot(HaveOccurred())
 
-			cm := f.KubernetesResource("ConfigMap", "d8-system", reservedHostsConfigMapName)
 			policy := f.KubernetesGlobalResource("ValidatingAdmissionPolicy", reservedHostsIngressPolicy)
-			Expect(evaluatePolicy(policy, paramsFrom(cm), ingressWithHosts("console.example.com"), tenant)).
+			Expect(evaluatePolicy(policy, ingressWithHosts("console.example.com"), tenant)).
 				To(Equal(verdictDenied))
 		})
 

--- a/modules/002-deckhouse/template_tests/reserved_public_hosts_test.go
+++ b/modules/002-deckhouse/template_tests/reserved_public_hosts_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package template_tests
 
 import (
+	"encoding/json"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -155,6 +156,27 @@ func matchConditionNames(policy object_store.KubeObject) []string {
 		names = append(names, condition.Get("name").String())
 	}
 	return names
+}
+
+// The reserved set reaches the policies as CEL literals rendered by toJson, so a literal parses back
+// as the JSON it was rendered from. Reading it that way rather than by substring keeps the
+// assertions about what is reserved, not about how the template spells it.
+func celVariable(policy object_store.KubeObject, name string, into any) {
+	expression := policy.Field(`spec.variables.#(name=="` + name + `").expression`).String()
+	Expect(json.Unmarshal([]byte(expression), into)).ShouldNot(HaveOccurred(),
+		"variable %s should be a JSON-compatible CEL literal, got %q", name, expression)
+}
+
+func celStringLiteral(policy object_store.KubeObject, name string) string {
+	var value string
+	celVariable(policy, name, &value)
+	return value
+}
+
+func celStringList(policy object_store.KubeObject, name string) []string {
+	values := []string{}
+	celVariable(policy, name, &values)
+	return values
 }
 
 // gatewayValues is the shape both places that name a Gateway take, global.modules.gatewayAPIGateway
@@ -426,7 +448,6 @@ var _ = Describe("Module :: deckhouse :: reserved public hosts ::", func() {
 			vap := f.KubernetesGlobalResource("ValidatingAdmissionPolicy", reservedHostsIngressPolicy)
 			Expect(vap.Exists()).To(BeTrue())
 			Expect(vap.Field("spec.failurePolicy").String()).To(Equal("Fail"))
-			Expect(vap.Field("spec.paramKind.kind").String()).To(Equal("ConfigMap"))
 			Expect(vap.Field("spec.matchConstraints.resourceRules.0.apiGroups").String()).To(MatchJSON(`["networking.k8s.io"]`))
 			Expect(vap.Field("spec.matchConstraints.resourceRules.0.resources").String()).To(MatchJSON(`["ingresses"]`))
 			// DELETE is deliberately absent: an Ingress that predates the policy stays routable
@@ -444,16 +465,29 @@ var _ = Describe("Module :: deckhouse :: reserved public hosts ::", func() {
 				To(ContainSubstring("system:serviceaccount:d8-"))
 		})
 
-		It("binds the policy to the parameters and skips the platform's own namespaces", func() {
+		// The reserved set is compiled into the policy instead of being read through paramKind, so
+		// that no apiserver has to hold a cluster-wide read on the parameter type to enforce it. Any
+		// aggregated apiserver runs the ValidatingAdmissionPolicy plugin out of the default admission
+		// chain, and one that cannot list the type fails its own informer-sync readiness check for
+		// good -- which is how a policy over Ingress hostnames stopped namespace deletion cluster-wide.
+		It("carries the reserved set as literals rather than reading it from the ConfigMap", func() {
+			vap := f.KubernetesGlobalResource("ValidatingAdmissionPolicy", reservedHostsIngressPolicy)
+			cm := configMap()
+
+			Expect(vap.Field("spec.paramKind").Exists()).To(BeFalse())
+			// The same values the ConfigMap publishes, so what an operator reads there and what the
+			// apiserver enforces cannot drift apart.
+			Expect(celStringLiteral(vap, "reservedPattern")).To(Equal(cm.Field("data.hostPattern").String()))
+			Expect(celStringList(vap, "reservedHosts")).To(Equal(strings.Fields(cm.Field("data.hosts").String())))
+			Expect(celStringList(vap, "allowedHosts")).To(Equal(strings.Fields(cm.Field("data.allowedHosts").String())))
+		})
+
+		It("skips the platform's own namespaces and references no parameters", func() {
 			binding := f.KubernetesGlobalResource("ValidatingAdmissionPolicyBinding", reservedHostsIngressPolicy)
 			Expect(binding.Exists()).To(BeTrue())
 			Expect(binding.Field("spec.policyName").String()).To(Equal(reservedHostsIngressPolicy))
 			Expect(binding.Field("spec.validationActions").String()).To(MatchJSON(`["Deny","Audit"]`))
-			Expect(binding.Field("spec.paramRef.name").String()).To(Equal(reservedHostsConfigMapName))
-			Expect(binding.Field("spec.paramRef.namespace").String()).To(Equal("d8-system"))
-			// Without this, losing the ConfigMap would take every Ingress write in the cluster
-			// down with it.
-			Expect(binding.Field("spec.paramRef.parameterNotFoundAction").String()).To(Equal("Allow"))
+			Expect(binding.Field("spec.paramRef").Exists()).To(BeFalse())
 			Expect(binding.Field("spec.matchResources.namespaceSelector.matchExpressions").String()).To(MatchJSON(`[
 				{"key": "heritage", "operator": "NotIn", "values": ["deckhouse"]},
 				{"key": "security.deckhouse.io/reserved-hosts-bypass", "operator": "NotIn", "values": ["true"]}
@@ -525,7 +559,7 @@ var _ = Describe("Module :: deckhouse :: reserved public hosts ::", func() {
 				binding := f.KubernetesGlobalResource("ValidatingAdmissionPolicyBinding", expected.policy)
 				Expect(binding.Exists()).To(BeTrue(), name)
 				ingressBinding := f.KubernetesGlobalResource("ValidatingAdmissionPolicyBinding", reservedHostsIngressPolicy)
-				for _, field := range []string{"spec.validationActions", "spec.paramRef", "spec.matchResources"} {
+				for _, field := range []string{"spec.validationActions", "spec.matchResources"} {
 					Expect(binding.Field(field).String()).To(Equal(ingressBinding.Field(field).String()),
 						"%s must not differ between the %s binding and the Ingress one", field, expected.policy)
 				}
@@ -619,14 +653,17 @@ var _ = Describe("Module :: deckhouse :: reserved public hosts ::", func() {
 			})
 			Expect(f.RenderError).ShouldNot(HaveOccurred())
 
-			expression := f.KubernetesGlobalResource("ValidatingAdmissionPolicy", reservedHostsGatewayPolicy).
-				Field(`spec.matchConditions.#(name=="exclude-shared-gateway").expression`).String()
-			Expect(expression).To(ContainSubstring("params.data['sharedGateway'] == request.namespace + '/' + request.name"))
-			// The guards every other parameter gets: a ConfigMap that lost the key must leave the
-			// policy evaluating rather than fail every Gateway write under failurePolicy: Fail, and
-			// an empty key must exempt nothing rather than everything.
-			Expect(expression).To(ContainSubstring("'sharedGateway' in params.data"))
-			Expect(expression).To(ContainSubstring("params.data['sharedGateway'] != ''"))
+			sharedGatewayExemption := func() string {
+				return f.KubernetesGlobalResource("ValidatingAdmissionPolicy", reservedHostsGatewayPolicy).
+					Field(`spec.matchConditions.#(name=="exclude-shared-gateway").expression`).String()
+			}
+			Expect(sharedGatewayExemption()).To(Equal(`"infra/shared" != request.namespace + '/' + request.name`))
+
+			// Where nothing names a gateway the reference renders empty, and an empty string cannot
+			// equal namespace + '/' + name, so the condition is left in place and exempts nothing.
+			renderWithGateway(func() {})
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+			Expect(sharedGatewayExemption()).To(Equal(`"" != request.namespace + '/' + request.name`))
 		})
 	})
 

--- a/modules/002-deckhouse/template_tests/reserved_public_hosts_test.go
+++ b/modules/002-deckhouse/template_tests/reserved_public_hosts_test.go
@@ -288,6 +288,27 @@ var _ = Describe("Module :: deckhouse :: reserved public hosts ::", func() {
 		return f.KubernetesResource("ConfigMap", "d8-system", reservedHostsConfigMapName)
 	}
 
+	// The reserved set is compiled into the policy instead of being read through paramKind, so that
+	// no apiserver has to hold a cluster-wide read on the parameter type to enforce it. Any
+	// aggregated apiserver runs the ValidatingAdmissionPolicy plugin out of the default admission
+	// chain, and one that cannot list the type fails its own informer-sync readiness check for good
+	// -- which is how a policy over Ingress hostnames stopped namespace deletion cluster-wide.
+	//
+	// What is compiled in has to stay what the ConfigMap publishes, so that what an operator reads
+	// there and what the apiserver enforces cannot drift apart. Called from every context that fills
+	// a different combination of the three, because a mistake in one of them is invisible in a render
+	// where the other two are empty.
+	expectPolicyCarriesConfigMap := func() {
+		vap := f.KubernetesGlobalResource("ValidatingAdmissionPolicy", reservedHostsIngressPolicy)
+		Expect(vap.Exists()).To(BeTrue())
+		cm := configMap()
+
+		Expect(vap.Field("spec.paramKind").Exists()).To(BeFalse())
+		Expect(celStringLiteral(vap, "reservedPattern")).To(Equal(cm.Field("data.hostPattern").String()))
+		Expect(celStringList(vap, "reservedHosts")).To(Equal(strings.Fields(cm.Field("data.hosts").String())))
+		Expect(celStringList(vap, "allowedHosts")).To(Equal(strings.Fields(cm.Field("data.allowedHosts").String())))
+	}
+
 	// Which reservation a cluster gets when its ModuleConfig says nothing is decided by the schema
 	// default, because addon-operator fills the section in before Helm sees it. The template carries
 	// a fallback for the same choice, which is what a bare render without that defaulting uses. The
@@ -465,21 +486,8 @@ var _ = Describe("Module :: deckhouse :: reserved public hosts ::", func() {
 				To(ContainSubstring("system:serviceaccount:d8-"))
 		})
 
-		// The reserved set is compiled into the policy instead of being read through paramKind, so
-		// that no apiserver has to hold a cluster-wide read on the parameter type to enforce it. Any
-		// aggregated apiserver runs the ValidatingAdmissionPolicy plugin out of the default admission
-		// chain, and one that cannot list the type fails its own informer-sync readiness check for
-		// good -- which is how a policy over Ingress hostnames stopped namespace deletion cluster-wide.
 		It("carries the reserved set as literals rather than reading it from the ConfigMap", func() {
-			vap := f.KubernetesGlobalResource("ValidatingAdmissionPolicy", reservedHostsIngressPolicy)
-			cm := configMap()
-
-			Expect(vap.Field("spec.paramKind").Exists()).To(BeFalse())
-			// The same values the ConfigMap publishes, so what an operator reads there and what the
-			// apiserver enforces cannot drift apart.
-			Expect(celStringLiteral(vap, "reservedPattern")).To(Equal(cm.Field("data.hostPattern").String()))
-			Expect(celStringList(vap, "reservedHosts")).To(Equal(strings.Fields(cm.Field("data.hosts").String())))
-			Expect(celStringList(vap, "allowedHosts")).To(Equal(strings.Fields(cm.Field("data.allowedHosts").String())))
+			expectPolicyCarriesConfigMap()
 		})
 
 		It("skips the platform's own namespaces and references no parameters", func() {
@@ -816,6 +824,10 @@ var _ = Describe("Module :: deckhouse :: reserved public hosts ::", func() {
 			Expect(configMap().Field("data.hosts").String()).
 				To(Equal("*.example.com\nadmin.corp.example.org\nbilling.corp.example.com\n"))
 		})
+
+		It("carries what an operator added into the policy too", func() {
+			expectPolicyCarriesConfigMap()
+		})
 	})
 
 	Context("An operator gives a hostname back to a tenant", func() {
@@ -887,6 +899,10 @@ var _ = Describe("Module :: deckhouse :: reserved public hosts ::", func() {
 			Expect(strings.Fields(cm.Field("data.unknownExcludedServices").String())).To(BeEmpty())
 			Expect(strings.Fields(cm.Field("data.allowedHosts").String())).To(ContainElement("grafana.example.com"))
 		})
+
+		It("carries the allowlist into the policy too", func() {
+			expectPolicyCarriesConfigMap()
+		})
 	})
 
 	Context("The upgrade recorded what tenants already served", func() {
@@ -904,6 +920,10 @@ var _ = Describe("Module :: deckhouse :: reserved public hosts ::", func() {
 			Expect(strings.Fields(cm.Field("data.allowedHosts").String())).
 				To(Equal([]string{"grafana.example.com", "shop.example.com", "store.example.com"}),
 					"the policies read one key, but which of the two put a hostname there stays readable")
+		})
+
+		It("carries the recorded hostnames into the policy too", func() {
+			expectPolicyCarriesConfigMap()
 		})
 	})
 
@@ -929,6 +949,12 @@ var _ = Describe("Module :: deckhouse :: reserved public hosts ::", func() {
 				"with no setting applied, List reserves exactly what the platform publishes")
 			Expect(hosts).NotTo(ContainElement("*.example.com"),
 				"wildcards were out of scope of the list, and List has to stay what it was")
+		})
+
+		// The one render where the pattern is empty, which is the case an equality against a
+		// non-empty pattern elsewhere would not catch.
+		It("carries the whole list and the empty pattern into the policy too", func() {
+			expectPolicyCarriesConfigMap()
 		})
 
 		It("still answers whether the literal covers the repository", func() {

--- a/modules/002-deckhouse/templates/reserved-public-hosts.yaml
+++ b/modules/002-deckhouse/templates/reserved-public-hosts.yaml
@@ -20,8 +20,18 @@
             the reservation was before Template mode and stays available for a cluster where the
             wider reservation is not wanted.
 
-  The parameters live in a ConfigMap so that all policies read the same ones and a cluster admin can
-  see what is reserved with a single kubectl get.
+  The reservation is compiled into the policies rather than read from a ConfigMap through paramKind.
+  A paramKind naming a core type makes every apiserver that runs the policy open a cluster-wide
+  informer on that type, and that includes every aggregated apiserver, which runs the
+  ValidatingAdmissionPolicy plugin out of the default RecommendedOptions admission chain and holds no
+  such permission. permission-browser-apiserver in d8-user-authz was the first one on a library where
+  the plugin is GA rather than gated off: it failed the built-in informer-sync readiness check for
+  good, its APIService went unavailable, and namespace deletion stopped cluster-wide on stale
+  discovery -- for policies whose matchConstraints name resources it does not even serve.
+
+  The d8-reserved-public-hosts ConfigMap below is rendered from the same values, so a cluster admin
+  still sees what is reserved with a single kubectl get, and the grandfather record still comes back
+  out of it through hooks/snapshot_reserved_public_hosts.go.
 */}}
 
 {{- /*
@@ -225,6 +235,13 @@
 {{- if $sharedGateway }}
   {{- $sharedGatewayRef = printf "%s/%s" $sharedGateway.namespace $sharedGateway.name }}
 {{- end }}
+
+{{- /*
+  What is reserved, in one object an operator can read. No policy reads it -- they carry the same
+  values compiled in, from the same variables -- so a key that goes missing here changes nothing
+  about what is enforced. The grandfather keys are the exception in the other direction: the snapshot
+  hook reads those back out of this object and into values, and Helm renders them from there.
+*/}}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -236,10 +253,10 @@ data:
   # Which of the two reservations is in force. It is the effective mode: a publicDomainTemplate that
   # cannot be split into a prefix and a suffix reads List here whatever the ModuleConfig asked for.
   mode: {{ $mode | quote }}
-  # The namespace the template carves out, as a regex the policies match the claimed hostname
-  # against. Empty under List, and empty means "reserve nothing by pattern" rather than "match
-  # everything", which is what the policies check before using it. A quoted scalar and not a block
-  # one: a block scalar would append a newline and leave a regex that can never match.
+  # The namespace the template carves out, as a regex, compiled into the policies as reservedPattern.
+  # Empty under List, and empty means "reserve nothing by pattern" rather than "match everything",
+  # which is what the policies check before using it. A quoted scalar and not a block one: a block
+  # scalar would append a newline and leave a regex that can never match.
   hostPattern: {{ $hostPattern | quote }}
   # Hostnames reserved by exact, case-insensitive match, on top of whatever the pattern covers.
   hosts: |
@@ -247,8 +264,8 @@ data:
     {{ $host }}
 {{- end }}
   # Hostnames the pattern covers but that are not reserved: excludedHosts and grandfatheredHosts
-  # together, which is what the policies read. The two are also published separately below, because
-  # this key alone cannot say which of them put a hostname here.
+  # together, the same value the policies carry as allowedHosts. The two are also published
+  # separately below, because this key alone cannot say which of them put a hostname here.
   allowedHosts: |
 {{- range $host := $allowedHosts }}
     {{ $host }}
@@ -314,13 +331,19 @@ data:
 
   request.namespace is the namespace of the request path and request.name is filled from the object
   on a create (k8s.io/apiserver/pkg/endpoints/handlers/create.go), while object.metadata carries
-  neither reliably before the storage layer defaults them. The guards are the ones every other
-  parameter here gets: a ConfigMap that lost the key must leave the policy evaluating rather than
-  fail every Gateway write under failurePolicy: Fail, and an empty key must exempt nothing.
+  neither reliably before the storage layer defaults them. No guard for an absent reference: where
+  nothing names a gateway the reference renders empty, and an empty string cannot equal
+  namespace + '/' + name, so the condition exempts nothing on its own.
 */}}
-{{- $sharedGatewayExempt := "!(params != null && has(params.data) && 'sharedGateway' in params.data && params.data['sharedGateway'] != '' && params.data['sharedGateway'] == request.namespace + '/' + request.name)" }}
+{{- $sharedGatewayExempt := printf "%s != request.namespace + '/' + request.name" ($sharedGatewayRef | toJson) }}
 
-{{- include "reserved_public_hosts_policy" (list . $paramsName "ingress" "networking.k8s.io" "ingresses" "has(object.spec) && has(object.spec.rules) ? object.spec.rules.filter(r, has(r.host) && r.host != '').map(r, r.host) : []") }}
+{{- /*
+  The reserved set, as the policies carry it. Same three variables the ConfigMap above publishes, so
+  the two can never disagree about what is reserved.
+*/}}
+{{- $policyParams := dict "hostPattern" $hostPattern "hosts" $reservedHosts "allowedHosts" $allowedHosts }}
+
+{{- include "reserved_public_hosts_policy" (list . $policyParams "ingress" "networking.k8s.io" "ingresses" "has(object.spec) && has(object.spec.rules) ? object.spec.rules.filter(r, has(r.host) && r.host != '').map(r, r.host) : []") }}
 
 {{- /*
   Each Gateway API kind is matched on its group as well as on its name. helm_lib_kind_exists matches
@@ -336,23 +359,23 @@ data:
   apiVersions ["*"].
 */}}
 {{- if (include "reserved_public_hosts_gateway_api_kind_exists" (list . "HTTPRoute")) }}
-{{- include "reserved_public_hosts_policy" (list . $paramsName "httproute" "gateway.networking.k8s.io" "httproutes" $routeHosts) }}
+{{- include "reserved_public_hosts_policy" (list . $policyParams "httproute" "gateway.networking.k8s.io" "httproutes" $routeHosts) }}
 {{- end }}
 
 {{- if (include "reserved_public_hosts_gateway_api_kind_exists" (list . "GRPCRoute")) }}
-{{- include "reserved_public_hosts_policy" (list . $paramsName "grpcroute" "gateway.networking.k8s.io" "grpcroutes" $routeHosts) }}
+{{- include "reserved_public_hosts_policy" (list . $policyParams "grpcroute" "gateway.networking.k8s.io" "grpcroutes" $routeHosts) }}
 {{- end }}
 
 {{- if (include "reserved_public_hosts_gateway_api_kind_exists" (list . "TLSRoute")) }}
-{{- include "reserved_public_hosts_policy" (list . $paramsName "tlsroute" "gateway.networking.k8s.io" "tlsroutes" $routeHosts) }}
+{{- include "reserved_public_hosts_policy" (list . $policyParams "tlsroute" "gateway.networking.k8s.io" "tlsroutes" $routeHosts) }}
 {{- end }}
 
 {{- if (include "reserved_public_hosts_gateway_api_kind_exists" (list . "ListenerSet")) }}
-{{- include "reserved_public_hosts_policy" (list . $paramsName "listenerset" "gateway.networking.k8s.io" "listenersets" $listenerHosts) }}
+{{- include "reserved_public_hosts_policy" (list . $policyParams "listenerset" "gateway.networking.k8s.io" "listenersets" $listenerHosts) }}
 {{- end }}
 
 {{- if (include "reserved_public_hosts_gateway_api_kind_exists" (list . "Gateway")) }}
-{{- include "reserved_public_hosts_policy" (list . $paramsName "gateway" "gateway.networking.k8s.io" "gateways" $listenerHosts $sharedGatewayExempt) }}
+{{- include "reserved_public_hosts_policy" (list . $policyParams "gateway" "gateway.networking.k8s.io" "gateways" $listenerHosts $sharedGatewayExempt) }}
 {{- end }}
 
 {{- end }}
@@ -370,7 +393,7 @@ data:
 
 {{- define "reserved_public_hosts_policy" }}
   {{- $context      := index . 0 }}
-  {{- $paramsName   := index . 1 }}
+  {{- $params       := index . 1 }}
   {{- $suffix       := index . 2 }}
   {{- $apiGroup     := index . 3 }}
   {{- $resource     := index . 4 }}
@@ -389,9 +412,6 @@ metadata:
   {{- include "helm_lib_module_labels" (list $context (dict "app" "deckhouse")) | nindent 2 }}
 spec:
   failurePolicy: Fail
-  paramKind:
-    apiVersion: v1
-    kind: ConfigMap
   matchConstraints:
     resourceRules:
       - apiGroups:   [{{ $apiGroup | quote }}]
@@ -416,22 +436,15 @@ spec:
       expression: |
         ({{ $claimedHosts }}).map(h, h.lowerAscii()).map(h, h.endsWith('.') ? h.substring(0, h.size() - 1) : h)
     - name: reservedHosts
-      # A missing ConfigMap never reaches these expressions, the binding is skipped instead
-      # (parameterNotFoundAction: Allow); the guards are for a ConfigMap that lost a key.
-      expression: |
-        params != null && has(params.data) && 'hosts' in params.data
-          ? params.data['hosts'].split('\n').filter(h, h != '')
-          : []
+      # Two layers of quoting, and both are load-bearing. toJson renders the CEL literal, so a
+      # hostname is data and never source -- a backslash in the pattern survives as one, and nothing
+      # an operator writes in additionalHosts can be read as an expression. quote then wraps that
+      # literal for YAML, without which the list would parse as a YAML sequence instead of a string.
+      expression: {{ $params.hosts | toJson | quote }}
     - name: reservedPattern
-      expression: |
-        params != null && has(params.data) && 'hostPattern' in params.data
-          ? params.data['hostPattern']
-          : ''
+      expression: {{ $params.hostPattern | toJson | quote }}
     - name: allowedHosts
-      expression: |
-        params != null && has(params.data) && 'allowedHosts' in params.data
-          ? params.data['allowedHosts'].split('\n').filter(h, h != '')
-          : []
+      expression: {{ $params.allowedHosts | toJson | quote }}
     - name: conflicts
       # An empty pattern reserves nothing: a cluster that publishes no public domain, or one under
       # mode: List, must not have every hostname in it match.
@@ -463,10 +476,6 @@ metadata:
 spec:
   policyName: {{ $policyName }}
   validationActions: [Deny, Audit]
-  paramRef:
-    name: {{ $paramsName }}
-    namespace: d8-system
-    parameterNotFoundAction: Allow
   matchResources:
     namespaceSelector:
       matchExpressions:

--- a/modules/002-deckhouse/templates/reserved-public-hosts.yaml
+++ b/modules/002-deckhouse/templates/reserved-public-hosts.yaml
@@ -91,7 +91,7 @@
 {{- $mode := ternary "Template" "List" (and (ne ($settings.mode | default "Template") "List") $templateSplits) }}
 
 {{- if and (or $domainTemplate $additionalHosts) (include "helm_lib_kind_exists" (list . "ValidatingAdmissionPolicy")) (include "helm_lib_kind_exists" (list . "ValidatingAdmissionPolicyBinding")) }}
-{{- $paramsName := "d8-reserved-public-hosts" }}
+{{- $configMapName := "d8-reserved-public-hosts" }}
 
 {{- /*
   The regex for the namespace the template carves out: its literal parts quoted, and the label the
@@ -246,7 +246,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ $paramsName }}
+  name: {{ $configMapName }}
   namespace: d8-system
   {{- include "helm_lib_module_labels" (list . (dict "app" "deckhouse")) | nindent 2 }}
 data:
@@ -309,7 +309,7 @@ data:
 {{- /*
   The policies differ in one expression, where the kind keeps its hostnames, so they are one
   definition called once per kind. Everything else -- the match conditions copied from the other
-  policies in this module, the parameters, the binding -- has to stay identical between them, because
+  policies in this module, the reserved set, the binding -- has to stay identical between them, because
   a tenant only needs one kind that is treated more leniently than the rest.
 
   Every kind here is one modules/140-user-authz/templates/cluster-roles.yaml grants create and update
@@ -341,9 +341,9 @@ data:
   The reserved set, as the policies carry it. Same three variables the ConfigMap above publishes, so
   the two can never disagree about what is reserved.
 */}}
-{{- $policyParams := dict "hostPattern" $hostPattern "hosts" $reservedHosts "allowedHosts" $allowedHosts }}
+{{- $reserved := dict "hostPattern" $hostPattern "hosts" $reservedHosts "allowedHosts" $allowedHosts }}
 
-{{- include "reserved_public_hosts_policy" (list . $policyParams "ingress" "networking.k8s.io" "ingresses" "has(object.spec) && has(object.spec.rules) ? object.spec.rules.filter(r, has(r.host) && r.host != '').map(r, r.host) : []") }}
+{{- include "reserved_public_hosts_policy" (list . $reserved "ingress" "networking.k8s.io" "ingresses" "has(object.spec) && has(object.spec.rules) ? object.spec.rules.filter(r, has(r.host) && r.host != '').map(r, r.host) : []") }}
 
 {{- /*
   Each Gateway API kind is matched on its group as well as on its name. helm_lib_kind_exists matches
@@ -359,23 +359,23 @@ data:
   apiVersions ["*"].
 */}}
 {{- if (include "reserved_public_hosts_gateway_api_kind_exists" (list . "HTTPRoute")) }}
-{{- include "reserved_public_hosts_policy" (list . $policyParams "httproute" "gateway.networking.k8s.io" "httproutes" $routeHosts) }}
+{{- include "reserved_public_hosts_policy" (list . $reserved "httproute" "gateway.networking.k8s.io" "httproutes" $routeHosts) }}
 {{- end }}
 
 {{- if (include "reserved_public_hosts_gateway_api_kind_exists" (list . "GRPCRoute")) }}
-{{- include "reserved_public_hosts_policy" (list . $policyParams "grpcroute" "gateway.networking.k8s.io" "grpcroutes" $routeHosts) }}
+{{- include "reserved_public_hosts_policy" (list . $reserved "grpcroute" "gateway.networking.k8s.io" "grpcroutes" $routeHosts) }}
 {{- end }}
 
 {{- if (include "reserved_public_hosts_gateway_api_kind_exists" (list . "TLSRoute")) }}
-{{- include "reserved_public_hosts_policy" (list . $policyParams "tlsroute" "gateway.networking.k8s.io" "tlsroutes" $routeHosts) }}
+{{- include "reserved_public_hosts_policy" (list . $reserved "tlsroute" "gateway.networking.k8s.io" "tlsroutes" $routeHosts) }}
 {{- end }}
 
 {{- if (include "reserved_public_hosts_gateway_api_kind_exists" (list . "ListenerSet")) }}
-{{- include "reserved_public_hosts_policy" (list . $policyParams "listenerset" "gateway.networking.k8s.io" "listenersets" $listenerHosts) }}
+{{- include "reserved_public_hosts_policy" (list . $reserved "listenerset" "gateway.networking.k8s.io" "listenersets" $listenerHosts) }}
 {{- end }}
 
 {{- if (include "reserved_public_hosts_gateway_api_kind_exists" (list . "Gateway")) }}
-{{- include "reserved_public_hosts_policy" (list . $policyParams "gateway" "gateway.networking.k8s.io" "gateways" $listenerHosts $sharedGatewayExempt) }}
+{{- include "reserved_public_hosts_policy" (list . $reserved "gateway" "gateway.networking.k8s.io" "gateways" $listenerHosts $sharedGatewayExempt) }}
 {{- end }}
 
 {{- end }}
@@ -393,7 +393,7 @@ data:
 
 {{- define "reserved_public_hosts_policy" }}
   {{- $context      := index . 0 }}
-  {{- $params       := index . 1 }}
+  {{- $reserved     := index . 1 }}
   {{- $suffix       := index . 2 }}
   {{- $apiGroup     := index . 3 }}
   {{- $resource     := index . 4 }}
@@ -440,11 +440,11 @@ spec:
       # hostname is data and never source -- a backslash in the pattern survives as one, and nothing
       # an operator writes in additionalHosts can be read as an expression. quote then wraps that
       # literal for YAML, without which the list would parse as a YAML sequence instead of a string.
-      expression: {{ $params.hosts | toJson | quote }}
+      expression: {{ $reserved.hosts | toJson | quote }}
     - name: reservedPattern
-      expression: {{ $params.hostPattern | toJson | quote }}
+      expression: {{ $reserved.hostPattern | toJson | quote }}
     - name: allowedHosts
-      expression: {{ $params.allowedHosts | toJson | quote }}
+      expression: {{ $reserved.allowedHosts | toJson | quote }}
     - name: conflicts
       # An empty pattern reserves nothing: a cluster that publishes no public domain, or one under
       # mode: List, must not have every hostname in it match.


### PR DESCRIPTION
## Description

The `reserved-public-hosts-*` ValidatingAdmissionPolicies no longer declare `paramKind: v1/ConfigMap`, and their bindings no longer carry a `paramRef`. The reserved hostnames, the pattern and the allowlist are rendered into `spec.variables` as CEL literals instead.

The `d8-reserved-public-hosts` ConfigMap is still rendered from the same values, so what an operator reads there and what the apiserver enforces cannot drift apart, and it still carries the grandfather record `hooks/snapshot_reserved_public_hosts.go` reads back. What is reserved does not change on any mode or setting.

No user-facing behaviour changes for tenants: the same hostnames are denied on the same six kinds.

**An apiserver already stuck in this state is not released by the manifest change alone and has to be restarted.** `informer-sync` asks the shared informer factory, and the factory only ever adds to `startedInformers` — dropping the last `paramKind` cancels the informer (`admission/plugin/policy/generic/policy_source.go`) but leaves it registered as started with `HasSynced` false, so the check stays red for the life of the process. An upgrade does the restart on its own, because the pod template's image is a per-build digest and the Deployment rolls. Both halves of this were verified in a cluster: correcting the policies under a running `permission-browser-apiserver` left it `0/1` with no change for two minutes, and deleting the pod brought it back `1/1` with the APIService `Available=True`.

## Why do we need it, and what problem does it solve?

A `paramKind` makes the apiserver that runs the policy open a cluster-wide informer on that type. `paramRef` narrows nothing at that stage — it is applied later, when the policy is evaluated. And the `validatingadmissionpolicy` plugin is part of the default `RecommendedOptions` admission chain, so **every aggregated apiserver** runs these policies too, not just kube-apiserver.

`permission-browser-apiserver` in `d8-user-authz` holds no read on `configmaps`, so in a cluster with multitenancy enabled:

- `failed to list *v1.ConfigMap: configmaps is forbidden: User "system:serviceaccount:d8-user-authz:permission-browser-apiserver" cannot list resource "configmaps" in API group "" at the cluster scope`
- `[-]informer-sync failed: 1 informers not started yet: [*v1.ConfigMap]`, so the pod stays `0/1`. It is a readiness check, so nothing restarts the container, and while the policies are in place a restart would not help either — the new process opens the same informer.
- `v1alpha1.authorization.deckhouse.io` goes `Available=False` on missing endpoints
- the namespace controller stops deleting namespaces **cluster-wide**: `NamespaceDeletionDiscoveryFailure=True`, `stale GroupVersion discovery: authorization.deckhouse.io/v1alpha1`
- module installs then time out against namespaces stuck in `Terminating`

None of it is doing any work: the `matchConstraints` of these policies name ingresses, gateways and routes, which `permission-browser-apiserver` does not serve. Granting it `configmaps` would fix the symptom by making that informer succeed — a permanent cluster-wide ConfigMap cache and watch in an apiserver that answers RBAC questions — and would leave the same mine for the next aggregated apiserver. `bashible-apiserver` is unaffected only because it is built on `k8s.io/apiserver` v0.29, where the feature gate is off by default.

The parameters are Helm-rendered and static within a converge, so reading them through the API bought nothing in the first place. `reserved-public-hosts.yaml` was the only `paramKind` in the repository.

## Why do we need it in the patch release (if we do)?

It stops namespace garbage collection cluster-wide and stalls converge, on any release that ships both these policies and an aggregated apiserver built on `k8s.io/apiserver` >= 1.30, where the plugin is GA and always on. Cherry-picks cleanly onto `release-1.77` and `release-1.76`; the touched files are identical on all three branches and the module tests pass on each.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: The reserved public hosts policies no longer make every aggregated apiserver in the cluster watch all ConfigMaps, which left permission-browser-apiserver permanently unready and stopped namespace deletion cluster-wide.
```
