### PR TITLE
[deckhouse] fix application webhook

### DIFF
--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_application.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_application.go
@@ -40,7 +40,7 @@ import (
 // the application creates, and those must fit the 63-character Kubernetes name limit.
 const maxApplicationNameLength = 32
 
-// applicationValidationHandler validations for Application creation
+// applicationValidationHandler validates Application create and update requests.
 func applicationValidationHandler(cli client.Client, manager packageManager) http.Handler {
 	vf := kwhvalidating.ValidatorFunc(func(ctx context.Context, _ *kwhmodel.AdmissionReview, obj metav1.Object) (*kwhvalidating.ValidatorResult, error) {
 		app, ok := obj.(*v1alpha1.Application)
@@ -64,16 +64,21 @@ func applicationValidationHandler(cli client.Client, manager packageManager) htt
 
 		name := apps.BuildName(app.Namespace, app.Name)
 
-		res, err := manager.ValidatePackageSettings(ctx, name, 0, app.Spec.Settings.GetMap())
-		if err != nil {
-			return nil, err
+		var warnings []string
+		if app.Status.CurrentVersion != nil && app.Status.CurrentVersion.Version == app.Spec.PackageVersion {
+			res, err := manager.ValidatePackageSettings(ctx, name, 0, app.Spec.Settings.GetMap())
+			if err != nil {
+				return nil, err
+			}
+
+			if !res.Valid {
+				return rejectResult(res.Message)
+			}
+
+			warnings = res.Warnings
 		}
 
-		if !res.Valid {
-			return rejectResult(res.Message)
-		}
-
-		if err = validateAppAgainstApv(ctx, cli, manager, app); err != nil {
+		if err := validateAppAgainstApv(ctx, cli, manager, app); err != nil {
 			// The denial message is the only feedback `kubectl apply` prints, and
 			// it arrives without the object it belongs to: name the Application
 			// and the package version whose requirements were evaluated, so the
@@ -82,7 +87,7 @@ func applicationValidationHandler(cli client.Client, manager packageManager) htt
 				app.Namespace, app.Name, app.Spec.PackageName, app.Spec.PackageVersion, err))
 		}
 
-		return allowResult(res.Warnings)
+		return allowResult(warnings)
 	})
 
 	// Create webhook.

--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_application_test.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_application_test.go
@@ -24,6 +24,8 @@ import (
 	addonutils "github.com/flant/addon-operator/pkg/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -37,6 +39,7 @@ import (
 type fakePackageManager struct {
 	validateResult settingscheck.Result
 	validateErr    error
+	validateCalled bool
 
 	checkErr       error
 	checkCalled    bool
@@ -44,6 +47,8 @@ type fakePackageManager struct {
 }
 
 func (f *fakePackageManager) ValidatePackageSettings(_ context.Context, _ string, _ int, _ addonutils.Values) (settingscheck.Result, error) {
+	f.validateCalled = true
+
 	return f.validateResult, f.validateErr
 }
 
@@ -80,6 +85,61 @@ func newAPV(name string, draft bool, reqs *v1alpha1.PackageRequirements) *v1alph
 	}
 
 	return apv
+}
+
+// applicationValidationHandlerSuite exercises manager and APV validation selection.
+type applicationValidationHandlerSuite struct {
+	suite.Suite
+}
+
+// TestApplicationValidationHandler runs Application admission validation scenarios.
+func TestApplicationValidationHandler(t *testing.T) {
+	suite.Run(t, new(applicationValidationHandlerSuite))
+}
+
+// TestSettingsAreValidatedByManagerForCurrentVersion verifies loaded-schema validation.
+func (s *applicationValidationHandlerSuite) TestSettingsAreValidatedByManagerForCurrentVersion() {
+	const version = "v1.0.0"
+
+	app := newApplication("repo", "pkg", version)
+	app.Status.CurrentVersion = &v1alpha1.ApplicationStatusVersion{Version: version}
+	manager := &fakePackageManager{
+		validateResult: settingscheck.Result{Valid: false, Message: "settings rejected by the loaded schema"},
+	}
+
+	response := s.validate(app, manager)
+
+	s.False(response.Allowed)
+	s.True(manager.validateCalled)
+	s.False(manager.checkCalled)
+}
+
+// TestSettingsAreValidatedOnlyByAPVWhileVersionChanges verifies stale manager schemas are skipped.
+func (s *applicationValidationHandlerSuite) TestSettingsAreValidatedOnlyByAPVWhileVersionChanges() {
+	app := newApplication("repo", "pkg", "v2.0.0")
+	app.Status.CurrentVersion = &v1alpha1.ApplicationStatusVersion{Version: "v1.0.0"}
+	manager := &fakePackageManager{
+		validateResult: settingscheck.Result{Valid: false, Message: "settings rejected by the loaded schema"},
+	}
+
+	response := s.validate(app, manager)
+
+	s.True(response.Allowed)
+	s.False(manager.validateCalled)
+	s.True(manager.checkCalled)
+}
+
+// validate submits an Application update to the admission handler.
+func (s *applicationValidationHandlerSuite) validate(app *v1alpha1.Application, manager *fakePackageManager) *admissionv1.AdmissionResponse {
+	s.T().Helper()
+
+	ap := &v1alpha1.ApplicationPackage{ObjectMeta: metav1.ObjectMeta{Name: app.Spec.PackageName}}
+	apvName := v1alpha1.MakeApplicationPackageVersionName(app.Spec.PackageRepositoryName, app.Spec.PackageName, app.Spec.PackageVersion)
+	apv := newAPV(apvName, false, nil)
+	handler := applicationValidationHandler(newFakeClient(s.T(), ap, apv), manager)
+	review := newModuleConfigAdmissionReview("UPDATE", app, nil)
+
+	return callHandler(s.T(), handler, review)
 }
 
 func TestParsePackageDependencyConstraint(t *testing.T) {


### PR DESCRIPTION
## Description

- Run package-manager settings validation only when the currently installed Application version matches the requested package version.
- During a version transition, validate settings and package requirements only against the target ApplicationPackageVersion.
- Preserve package-manager validation warnings for updates that keep the current version.
- Add admission webhook tests for both validation paths.

## Why do we need it, and what problem does it solve?

The package manager validates settings using the schema loaded for the currently running Application version. During a version update, that schema belongs to the previous version and may reject settings that are valid for the requested version.

ApplicationPackageVersion contains the schema for the requested target version, so it remains the source of settings validation while the version is changing. Package-manager validation is retained for ordinary settings updates when the loaded and requested versions match.

## Testing

- go test ./deckhouse-controller/pkg/apis/deckhouse.io/validation/... -race -count=1

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Validate Application settings against the target package version during version updates.
impact_level: low
```