### PR TITLE
[admission-policy-engine] Restrict SecurityPolicyException write access to ClusterAdmin (backport #22412 to 1.76)

### DIFF
--- a/modules/015-admission-policy-engine/template_tests/user_authz_cluster_roles_test.go
+++ b/modules/015-admission-policy-engine/template_tests/user_authz_cluster_roles_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template_tests
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/helm"
+)
+
+var _ = Describe("Module :: admissionPolicyEngine :: user-authz cluster roles", func() {
+	f := SetupHelmConfig(`
+admissionPolicyEngine:
+  podSecurityStandards: {}
+  internal:
+    bootstrapped: true
+    ratify:
+      webhook:
+        ca: test-ca-placeholder
+        crt: test-crt-placeholder
+        key: test-key-placeholder
+    podSecurityStandards:
+      enforcementActions:
+        - deny
+    trackedConstraintResources: []
+    trackedMutateResources: []
+    webhook:
+      ca: test-ca-placeholder
+      crt: test-crt-placeholder
+      key: test-key-placeholder
+`)
+
+	BeforeEach(func() {
+		f.ValuesSetFromYaml("global", globalValues)
+		f.ValuesSet("global.modulesImages", GetModulesImages())
+		f.HelmRender()
+	})
+
+	// A SecurityPolicyException lifts the pod-security checks a SecurityPolicy enforces, so it must not
+	// be writable below ClusterAdmin: the Admin access level is bound per namespace by AuthorizationRule,
+	// and a namespace-scoped Admin able to create an exception can grant its own pods hostPath and
+	// privileged, escaping to the node.
+	It("must not grant any access level below ClusterAdmin write access to securitypolicyexceptions", func() {
+		Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+		Expect(f.KubernetesGlobalResource("ClusterRole", "d8:user-authz:admission-policy-engine:admin").Exists()).To(BeFalse())
+
+		user := f.KubernetesGlobalResource("ClusterRole", "d8:user-authz:admission-policy-engine:user")
+		Expect(user.Exists()).To(BeTrue())
+		Expect(user.Field("rules.0.verbs").String()).To(Equal(`["get","list","watch"]`))
+	})
+
+	It("must keep securitypolicyexceptions writable by ClusterAdmin", func() {
+		Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+		clusterAdmin := f.KubernetesGlobalResource("ClusterRole", "d8:user-authz:admission-policy-engine:cluster-admin")
+		Expect(clusterAdmin.Exists()).To(BeTrue())
+		Expect(clusterAdmin.Field("rules.0.resources").String()).
+			To(Equal(`["operationpolicies","securitypolicies","securitypolicyexceptions"]`))
+	})
+})

--- a/modules/015-admission-policy-engine/templates/user-authz-cluster-roles.yaml
+++ b/modules/015-admission-policy-engine/templates/user-authz-cluster-roles.yaml
@@ -107,34 +107,21 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   annotations:
-    user-authz.deckhouse.io/access-level: Admin
-  name: d8:user-authz:admission-policy-engine:admin
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
-rules:
-- apiGroups:
-  - deckhouse.io
-  resources:
-  - securitypolicyexceptions
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - patch
-  - update
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  annotations:
     user-authz.deckhouse.io/access-level: ClusterAdmin
   name: d8:user-authz:admission-policy-engine:cluster-admin
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 rules:
+{{/*
+  SecurityPolicyException lifts pod-security checks enforced by SecurityPolicy, so writing one is
+  equivalent to editing the policy itself: keep both at ClusterAdmin. A namespace-scoped Admin that
+  can create an exception can grant its own pods hostPath and privileged, which is a node escape.
+*/}}
 - apiGroups:
   - deckhouse.io
   resources:
   - operationpolicies
   - securitypolicies
+  - securitypolicyexceptions
   verbs:
   - create
   - delete


### PR DESCRIPTION
Backport of #22412 to `release-1.76`.

The automatic backport (bot) failed with a cherry-pick conflict in the generated user-authz role reference (`modules/140-user-authz/docs/README*.md`). On `release-1.76` that generated reference does not list `securitypolicyexceptions` at all, so the doc hunks from the main-branch commit do not apply and are not needed: regenerating the docs on the 1.76 base yields no change. This PR therefore carries only the code change and the regression test; the docs are intentionally left untouched (they already match `make generate` on 1.76).

## Description

`SecurityPolicyException` lifts the pod-security checks a `SecurityPolicy` enforces (`privileged`, `hostPath`, `hostNetwork`, `hostPID`, capabilities, `runAsUser`), so creating one is equivalent to editing the policy itself. `SecurityPolicy`/`OperationPolicy` were writable only by `ClusterAdmin`, but `SecurityPolicyException` was granted to the `Admin` access level. Since the resource is namespaced and resolved from the pod's own namespace by label, an `AuthorizationRule` with `accessLevel: Admin` let a project administrator create an exception, label a privileged pod mounting `hostPath: /`, and escape to root on the node.

The write verbs move from `Admin` to `ClusterAdmin`; the now-empty `Admin` ClusterRole is removed. Because custom cluster roles are collected cumulatively by access level, the permission is also dropped from `ClusterEditor`. Read access at `User` is unchanged. A template test asserts the `Admin` role is gone and `ClusterAdmin` keeps the verbs.

Reported via Bug Bounty (Standoff365 #32090), CWE-269.

## Why do we need it in the patch release?

The over-permissive grant is present in release-1.76; it is a tenant-to-node privilege escalation and must be fixed in the patch release. Already merged to main (#22412) and backported to release-1.77 (#22447).

## Checklist
- [x] The code is covered by unit tests.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: admission-policy-engine
type: fix
summary: Restrict SecurityPolicyException write access to ClusterAdmin, closing a tenant-to-node privilege escalation.
impact: Project administrators (user-authz Admin access level) can no longer create, update or delete SecurityPolicyException resources; the permission now requires ClusterAdmin. Clusters that granted accessLevel Admin to untrusted tenants over RBAC v1 were exposed to node-level privilege escalation. RBAC v2 use/manage roles were never affected.
impact_level: high
```
