### PR TITLE
[base-images] add golang 1.27 to base images

### DIFF
--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -3935,7 +3935,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:08071b109453731fe526a9325ee2e14262646f14906e2397ea3a33d819de6571"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:18e1d91b1dd5cc798f4f95b13a05eaa117c83aab0a967601c4ccc8a019a0775f"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'
@@ -4050,7 +4050,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run node-controller tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:08071b109453731fe526a9325ee2e14262646f14906e2397ea3a33d819de6571"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:18e1d91b1dd5cc798f4f95b13a05eaa117c83aab0a967601c4ccc8a019a0775f"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/.github/workflows/build-and-test_main.yml
+++ b/.github/workflows/build-and-test_main.yml
@@ -1281,7 +1281,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:08071b109453731fe526a9325ee2e14262646f14906e2397ea3a33d819de6571"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:18e1d91b1dd5cc798f4f95b13a05eaa117c83aab0a967601c4ccc8a019a0775f"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -3563,7 +3563,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:08071b109453731fe526a9325ee2e14262646f14906e2397ea3a33d819de6571"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:18e1d91b1dd5cc798f4f95b13a05eaa117c83aab0a967601c4ccc8a019a0775f"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/Makefile
+++ b/Makefile
@@ -446,6 +446,7 @@ BASE_LIMIT_KEYS := REGISTRY_PATH \
                 builder/distroless \
                 builder/golang-1.25 \
                 builder/golang-1.26 \
+                builder/golang-1.27 \
                 builder/golang \
                 minget-0.1 \
                 minget

--- a/candi/alt_base_images.yml
+++ b/candi/alt_base_images.yml
@@ -4,6 +4,7 @@ base/distroless-fin: "sha256:612dc6d41604783fb8521ae40cf71207908866d5ad372e22f99
 builder/distroless: "sha256:2f256419658a590ecebdd863335fae900b0a153dd08c0fa96ae87e2d3e5d4b5a" # from: scratch
 builder/golang-1.25: "sha256:605bb799560fc4d021ae8f1fc9205c662441bfd0bfaf77da6d5265a240dd0f44" # from: builder/distroless
 builder/golang-1.26: "sha256:952e32d6731ae0e3a7b6890dd45e4861851c950635ff0e4dba2c1d4165d03869" # from: builder/distroless
+builder/golang-1.27: "sha256:18e1d91b1dd5cc798f4f95b13a05eaa117c83aab0a967601c4ccc8a019a0775f" # from: builder/distroless
 builder/golang: "sha256:18e1d91b1dd5cc798f4f95b13a05eaa117c83aab0a967601c4ccc8a019a0775f" # from: builder/distroless
 minget-0.1: "sha256:2c4c67ddccd25bdf01ee0bc5ac77ca5eb0b8f826484250cc416fb7b0c47e4283" # from: base/scratch
 minget: "sha256:2c4c67ddccd25bdf01ee0bc5ac77ca5eb0b8f826484250cc416fb7b0c47e4283" # from: base/scratch

--- a/candi/alt_base_images.yml
+++ b/candi/alt_base_images.yml
@@ -1,9 +1,9 @@
-# version=v2.1.3
+# version=v2.1.7
 REGISTRY_PATH: registry.deckhouse.io/container-factory
-base/distroless-fin: "sha256:e24c06e0beeabf36e8d2f60c7edda31a5f2047c2fa6ae9d648d7fd6f7e5c0310" # from: scratch
-builder/distroless: "sha256:86ca0311d9335650bc5207bbe653b59475e39dd3a93a073ddfdc21180dd06e3b" # from: base/scratch
-builder/golang-1.25: "sha256:a5c0f098213eafce434dfb18533da45f192b72b8010e3e146ea73f037059ea9a" # from: builder/distroless
-builder/golang-1.26: "sha256:08071b109453731fe526a9325ee2e14262646f14906e2397ea3a33d819de6571" # from: builder/distroless
-builder/golang: "sha256:08071b109453731fe526a9325ee2e14262646f14906e2397ea3a33d819de6571" # from: builder/distroless
+base/distroless-fin: "sha256:612dc6d41604783fb8521ae40cf71207908866d5ad372e22f9902b1ca146b8b1" # from: scratch
+builder/distroless: "sha256:2f256419658a590ecebdd863335fae900b0a153dd08c0fa96ae87e2d3e5d4b5a" # from: scratch
+builder/golang-1.25: "sha256:605bb799560fc4d021ae8f1fc9205c662441bfd0bfaf77da6d5265a240dd0f44" # from: builder/distroless
+builder/golang-1.26: "sha256:952e32d6731ae0e3a7b6890dd45e4861851c950635ff0e4dba2c1d4165d03869" # from: builder/distroless
+builder/golang: "sha256:18e1d91b1dd5cc798f4f95b13a05eaa117c83aab0a967601c4ccc8a019a0775f" # from: builder/distroless
 minget-0.1: "sha256:2c4c67ddccd25bdf01ee0bc5ac77ca5eb0b8f826484250cc416fb7b0c47e4283" # from: base/scratch
 minget: "sha256:2c4c67ddccd25bdf01ee0bc5ac77ca5eb0b8f826484250cc416fb7b0c47e4283" # from: base/scratch

--- a/modules/030-cloud-provider-aws/images/terraform-manager/werf.inc.yaml
+++ b/modules/030-cloud-provider-aws/images/terraform-manager/werf.inc.yaml
@@ -61,6 +61,7 @@ shell:
   install:
   - export GOPROXY=$(cat /run/secrets/GOPROXY)
   - cd /src
+  - make fmt
   - GO_VER=go CGO_ENABLED=0 GOOS=linux GOARCH=amd64 make build LDFLAGS="-s -w -extldflags \"-static\" -X github.com/hashicorp/terraform-provider-aws/version.ProviderVersion={{ $version }}"
   - mv /go/bin/terraform-provider-aws /terraform-provider-aws
   - strip /terraform-provider-aws

--- a/modules/400-descheduler/images/descheduler/werf.inc.yaml
+++ b/modules/400-descheduler/images/descheduler/werf.inc.yaml
@@ -36,7 +36,7 @@ secrets:
   value: {{ .GOPROXY }}
 shell:
   install:
-  - export CGO_ENABLED=0 GOOS=linux GOARCH=amd64
+  - export CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GOEXPERIMENT=nojsonv2
   - cd /src
   - GOPROXY=$(cat /run/secrets/GOPROXY) go mod vendor
   - go build -ldflags "-s -w -X sigs.k8s.io/descheduler/pkg/version.version={{ $version }}" -o /descheduler sigs.k8s.io/descheduler/cmd/descheduler


### PR DESCRIPTION
Signed-off-by: Artem Fedorov <artem.fedorov@flant.com>

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Add golang v1.27.0
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
New features
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: feature
summary: Added golang v1.27.0
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
