### PR TITLE
[control-plane-manager] Changes, policy exceptions for restricted PSS

### DIFF
--- a/candi/control-plane/etcd.yaml.tpl
+++ b/candi/control-plane/etcd.yaml.tpl
@@ -20,6 +20,7 @@ metadata:
   labels:
     component: etcd
     tier: control-plane
+    security.deckhouse.io/security-policy-exception: etcd
   name: etcd
   namespace: kube-system
 spec:

--- a/candi/control-plane/etcd.yaml.tpl
+++ b/candi/control-plane/etcd.yaml.tpl
@@ -96,6 +96,7 @@ spec:
         cpu: "{{ $c.milliCPU | default (div (mul $millicpu 35) 100) }}m"
         memory: "{{ $c.memoryBytes | default (div (mul $memory 35) 100) }}"
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/candi/control-plane/kube-apiserver.yaml.tpl
+++ b/candi/control-plane/kube-apiserver.yaml.tpl
@@ -257,6 +257,7 @@ spec:
         cpu: "{{ $c.milliCPU | default (div (mul $millicpu 45) 100) }}m"
         memory: "{{ $c.memoryBytes | default (div (mul $memory 45) 100) }}"
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/candi/control-plane/kube-apiserver.yaml.tpl
+++ b/candi/control-plane/kube-apiserver.yaml.tpl
@@ -93,6 +93,7 @@ metadata:
   labels:
     component: kube-apiserver
     tier: control-plane
+    security.deckhouse.io/security-policy-exception: kube-apiserver
   name: kube-apiserver
   namespace: kube-system
 spec:

--- a/candi/control-plane/kube-controller-manager.yaml.tpl
+++ b/candi/control-plane/kube-controller-manager.yaml.tpl
@@ -113,6 +113,7 @@ spec:
         cpu: "{{ $c.milliCPU | default (div (mul $millicpu 10) 100) }}m"
         memory: "{{ $c.memoryBytes | default (div (mul $memory 10) 100) }}"
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/candi/control-plane/kube-controller-manager.yaml.tpl
+++ b/candi/control-plane/kube-controller-manager.yaml.tpl
@@ -42,6 +42,7 @@ metadata:
   labels:
     component: kube-controller-manager
     tier: control-plane
+    security.deckhouse.io/security-policy-exception: kube-controller-manager
   name: kube-controller-manager
   namespace: kube-system
 spec:

--- a/candi/control-plane/kube-scheduler.yaml.tpl
+++ b/candi/control-plane/kube-scheduler.yaml.tpl
@@ -41,6 +41,7 @@ metadata:
   labels:
     component: kube-scheduler
     tier: control-plane
+    security.deckhouse.io/security-policy-exception: kube-scheduler
   name: kube-scheduler
   namespace: kube-system
 spec:

--- a/candi/control-plane/kube-scheduler.yaml.tpl
+++ b/candi/control-plane/kube-scheduler.yaml.tpl
@@ -94,6 +94,7 @@ spec:
         cpu: "{{ $c.milliCPU | default (div (mul $millicpu 10) 100) }}m"
         memory: "{{ $c.memoryBytes | default (div (mul $memory 10) 100) }}"
     securityContext:
+      allowPrivilegeEscalation: false
       capabilities:
         drop:
         - ALL

--- a/modules/040-control-plane-manager/images/etcd-backup/entrypoint.sh
+++ b/modules/040-control-plane-manager/images/etcd-backup/entrypoint.sh
@@ -19,8 +19,9 @@ cd /tmp/
 etcd=etcd-backup.snapshot
 archive=etcd-backup.tar.gz
 backup_dir_on_host=${HOSTPATH}
+etcd_endpoint=${NODEIP}
 etcdctl \
-    --endpoints=https://127.0.0.1:2379 \
+    --endpoints=https://$etcd_endpoint:2379 \
     --cacert=/etc/kubernetes/pki/etcd/ca.crt \
     --cert=/etc/kubernetes/pki/etcd/healthcheck-client.crt \
     --key=/etc/kubernetes/pki/etcd/healthcheck-client.key \

--- a/modules/040-control-plane-manager/template_tests/template_test.go
+++ b/modules/040-control-plane-manager/template_tests/template_test.go
@@ -1543,6 +1543,20 @@ apiserver:
 			})
 		})
 
+		Context("With audit log path customized", func() {
+			BeforeEach(func() {
+				f.ValuesSet("controlPlaneManager.internal.auditPolicy", base64.StdEncoding.EncodeToString([]byte("rules: []")))
+				f.ValuesSetFromYaml("controlPlaneManager.apiserver.auditLog", `{output: File, path: /custom/audit/path}`)
+				f.HelmRender()
+			})
+
+			It("should render the customized path as a kube-apiserver hostPath exception", func() {
+				Expect(f.RenderError).ShouldNot(HaveOccurred())
+				Expect(f.KubernetesResource("SecurityPolicyException", "kube-system", "kube-apiserver").Field("spec.volumes.hostPath.allowedValues").String()).
+					To(ContainSubstring("/custom/audit/path"))
+			})
+		})
+
 		Context("With prometheus enabled", func() {
 			BeforeEach(func() {
 				f.ValuesSetFromYaml("global.enabledModules", `["prometheus"]`)

--- a/modules/040-control-plane-manager/template_tests/template_test.go
+++ b/modules/040-control-plane-manager/template_tests/template_test.go
@@ -1514,4 +1514,78 @@ apiserver:
 			})
 		})
 	})
+
+	Context("SecurityPolicyException resources", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global.discovery.apiVersions", `["deckhouse.io/v1alpha1/SecurityPolicyException"]`)
+		})
+
+		Context("Always rendered exceptions", func() {
+			BeforeEach(func() {
+				f.HelmRender()
+			})
+
+			It("should render SecurityPolicyExceptions for control-plane components", func() {
+				Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+				Expect(f.KubernetesResource("SecurityPolicyException", "kube-system", "etcd").Exists()).To(BeTrue())
+				Expect(f.KubernetesResource("SecurityPolicyException", "kube-system", "kube-apiserver").Exists()).To(BeTrue())
+				Expect(f.KubernetesResource("SecurityPolicyException", "kube-system", "kube-controller-manager").Exists()).To(BeTrue())
+				Expect(f.KubernetesResource("SecurityPolicyException", "kube-system", "kube-scheduler").Exists()).To(BeTrue())
+				Expect(f.KubernetesResource("SecurityPolicyException", "kube-system", "d8-control-plane-manager").Exists()).To(BeTrue())
+			})
+
+			It("should not render control-plane-proxy or etcd-backup exceptions without their prerequisites", func() {
+				Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+				Expect(f.KubernetesResource("SecurityPolicyException", "kube-system", "control-plane-proxy").Exists()).To(BeFalse())
+				Expect(f.KubernetesResource("SecurityPolicyException", "kube-system", "d8-etcd-backup").Exists()).To(BeFalse())
+			})
+		})
+
+		Context("With prometheus enabled", func() {
+			BeforeEach(func() {
+				f.ValuesSetFromYaml("global.enabledModules", `["prometheus"]`)
+				f.HelmRender()
+			})
+
+			It("should render SecurityPolicyException for control-plane-proxy", func() {
+				Expect(f.RenderError).ShouldNot(HaveOccurred())
+				Expect(f.KubernetesResource("SecurityPolicyException", "kube-system", "control-plane-proxy").Exists()).To(BeTrue())
+			})
+		})
+
+		Context("With cluster bootstrapped", func() {
+			BeforeEach(func() {
+				f.ValuesSet("global.clusterIsBootstrapped", true)
+				f.HelmRender()
+			})
+
+			It("should render SecurityPolicyException for etcd-backup", func() {
+				Expect(f.RenderError).ShouldNot(HaveOccurred())
+				Expect(f.KubernetesResource("SecurityPolicyException", "kube-system", "d8-etcd-backup").Exists()).To(BeTrue())
+			})
+		})
+
+		Context("Without SecurityPolicyException API", func() {
+			BeforeEach(func() {
+				f.ValuesSetFromYaml("global.discovery.apiVersions", `[]`)
+				f.ValuesSetFromYaml("global.enabledModules", `["prometheus"]`)
+				f.ValuesSet("global.clusterIsBootstrapped", true)
+				f.HelmRender()
+			})
+
+			It("should not render any SecurityPolicyException", func() {
+				Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+				Expect(f.KubernetesResource("SecurityPolicyException", "kube-system", "etcd").Exists()).To(BeFalse())
+				Expect(f.KubernetesResource("SecurityPolicyException", "kube-system", "kube-apiserver").Exists()).To(BeFalse())
+				Expect(f.KubernetesResource("SecurityPolicyException", "kube-system", "kube-controller-manager").Exists()).To(BeFalse())
+				Expect(f.KubernetesResource("SecurityPolicyException", "kube-system", "kube-scheduler").Exists()).To(BeFalse())
+				Expect(f.KubernetesResource("SecurityPolicyException", "kube-system", "d8-control-plane-manager").Exists()).To(BeFalse())
+				Expect(f.KubernetesResource("SecurityPolicyException", "kube-system", "control-plane-proxy").Exists()).To(BeFalse())
+				Expect(f.KubernetesResource("SecurityPolicyException", "kube-system", "d8-etcd-backup").Exists()).To(BeFalse())
+			})
+		})
+	})
 })

--- a/modules/040-control-plane-manager/templates/control-plane-proxy/daemonset.yaml
+++ b/modules/040-control-plane-manager/templates/control-plane-proxy/daemonset.yaml
@@ -54,6 +54,7 @@ spec:
     metadata:
       labels:
         app: {{ $appLabel }}
+        security.deckhouse.io/security-policy-exception: control-plane-proxy
     spec:
       serviceAccountName: d8-control-plane-manager-control-plane-proxy
       automountServiceAccountToken: true

--- a/modules/040-control-plane-manager/templates/daemonset.yaml
+++ b/modules/040-control-plane-manager/templates/daemonset.yaml
@@ -281,7 +281,6 @@ spec:
       serviceAccountName: d8-control-plane-manager
       containers:
       - name: control-plane-manager
-        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all_and_add" (list $ (list "SYS_CHROOT")) | nindent 8 }}
         image: {{ include "helm_lib_module_image" (list $ "controlPlaneManager" ) }}
         volumeMounts:
         - mountPath: /var/lib/etcd
@@ -298,8 +297,6 @@ spec:
         - mountPath: /root/.kube/
           name: root-kube
         {{- end }}
-        - mountPath: /var/lib/kubelet/pki
-          name: var-lib-kubelet-pki
         - mountPath: /tmp
           name: tmp
         env:
@@ -417,10 +414,6 @@ spec:
       - name: etcd
         hostPath:
           path: /var/lib/etcd
-          type: DirectoryOrCreate
-      - name: var-lib-kubelet-pki
-        hostPath:
-          path: /var/lib/kubelet/pki/
           type: DirectoryOrCreate
       - name: tmp
         emptyDir: {}

--- a/modules/040-control-plane-manager/templates/daemonset.yaml
+++ b/modules/040-control-plane-manager/templates/daemonset.yaml
@@ -281,6 +281,7 @@ spec:
       serviceAccountName: d8-control-plane-manager
       containers:
       - name: control-plane-manager
+        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all" dict | nindent 8 }}
         image: {{ include "helm_lib_module_image" (list $ "controlPlaneManager" ) }}
         volumeMounts:
         - mountPath: /var/lib/etcd

--- a/modules/040-control-plane-manager/templates/daemonset.yaml
+++ b/modules/040-control-plane-manager/templates/daemonset.yaml
@@ -258,6 +258,7 @@ spec:
       labels:
         app: {{ $dsMode }}
         component: control-plane-manager
+        security.deckhouse.io/security-policy-exception: d8-control-plane-manager
     spec:
       {{- if eq $profile "main" }}
       {{- include "helm_lib_node_selector" (tuple $ "master") | nindent 6 }}

--- a/modules/040-control-plane-manager/templates/etcd-backup/cronjob.yaml
+++ b/modules/040-control-plane-manager/templates/etcd-backup/cronjob.yaml
@@ -116,7 +116,8 @@ spec:
               valueFrom:
                 fieldRef:
                   apiVersion: v1
-                  fieldPath: status.hostIP            resources:
+                  fieldPath: status.hostIP            
+            resources:
               requests:
               {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 50 | nindent 16 }}
               {{- if not ( $.Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}

--- a/modules/040-control-plane-manager/templates/etcd-backup/cronjob.yaml
+++ b/modules/040-control-plane-manager/templates/etcd-backup/cronjob.yaml
@@ -100,7 +100,7 @@ spec:
           imagePullSecrets:
           - name: deckhouse-registry
           restartPolicy: Never
-          hostNetwork: true
+          hostNetwork: false
           dnsPolicy: ClusterFirstWithHostNet
           containers:
           - name: backup
@@ -112,7 +112,11 @@ spec:
               value: {{ $etcdQuotaBackendBytes | quote }}
             - name: HOSTPATH
               value: {{ $backupHostPath | quote }}
-            resources:
+            - name: NODEIP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.hostIP            resources:
               requests:
               {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 50 | nindent 16 }}
               {{- if not ( $.Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}

--- a/modules/040-control-plane-manager/templates/etcd-backup/cronjob.yaml
+++ b/modules/040-control-plane-manager/templates/etcd-backup/cronjob.yaml
@@ -36,13 +36,6 @@ spec:
       metadata:
         description: |
           UID 0 is required for hostPath access to etcd data and certificates.
-  network:
-    hostNetwork:
-      allowedValue: true
-      metadata:
-        description: |
-          etcd-backup runs on the host network to reach the local etcd instance
-          on the same master node.
   volumes:
     types:
       allowedValues:

--- a/modules/040-control-plane-manager/templates/etcd-backup/cronjob.yaml
+++ b/modules/040-control-plane-manager/templates/etcd-backup/cronjob.yaml
@@ -13,15 +13,60 @@ memory: 40Mi
 {{- $backupHostPath := $etcdBackup.hostPath | default "/var/lib/etcd" -}}
 {{- $etcdQuotaBackendBytes := (.Values.controlPlaneManager.internal).etcdQuotaBackendBytes | default "2147483648" -}}
 
-{{- if $backupEnabled }}
-  {{- if .Values.global.clusterIsBootstrapped }}
-    {{- if hasKey .Values.controlPlaneManager.internal "mastersNode" }}
-      {{- $nodes := list }}
-      {{- $nodes = concat $nodes .Values.controlPlaneManager.internal.mastersNode }}
-      {{- if $.Values.controlPlaneManager.internal.hasEtcdArbiterNode }}
-        {{- $nodes = append $nodes "etcd-arbiter" }}
-      {{- end }}
-      {{- range $node := $nodes }}
+{{- if and $backupEnabled .Values.global.clusterIsBootstrapped (hasKey .Values.controlPlaneManager.internal "mastersNode") }}
+{{- if or (.Values.global.discovery.apiVersions | has "deckhouse.io/v1alpha1/SecurityPolicyException") (.Capabilities.APIVersions.Has "deckhouse.io/v1alpha1/SecurityPolicyException") }}
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: SecurityPolicyException
+metadata:
+  name: d8-etcd-backup
+  namespace: kube-system
+  {{- include "helm_lib_module_labels" (list . (dict "app" "d8-etcd-backup")) | nindent 2 }}
+spec:
+  securityContext:
+    runAsNonRoot:
+      allowedValue: false
+      metadata:
+        description: |
+          etcd-backup must run as root to read the etcd data directory and PKI
+          material from the master node filesystem.
+    runAsUser:
+      allowedValues:
+        - 0
+      metadata:
+        description: |
+          UID 0 is required for hostPath access to etcd data and certificates.
+  network:
+    hostNetwork:
+      allowedValue: true
+      metadata:
+        description: |
+          etcd-backup runs on the host network to reach the local etcd instance
+          on the same master node.
+  volumes:
+    types:
+      allowedValues:
+        - hostPath
+      metadata:
+        description: |
+          etcd-backup reads etcd data and certificates from the node filesystem.
+    hostPath:
+      allowedValues:
+        - path: {{ $backupHostPath | quote }}
+          readOnly: false
+          metadata:
+            description: Directory where etcd snapshots are written on the node.
+        - path: /etc/kubernetes/pki/etcd
+          readOnly: true
+          metadata:
+            description: etcd TLS certificates used to authenticate to the local etcd.
+{{- end }}
+{{- $nodes := list }}
+{{- $nodes = concat $nodes .Values.controlPlaneManager.internal.mastersNode }}
+{{- if .Values.controlPlaneManager.internal.hasEtcdArbiterNode }}
+  {{- $nodes = append $nodes "etcd-arbiter" }}
+{{- end }}
+{{- range $node := $nodes }}
 ---
 apiVersion: batch/v1
 kind: CronJob
@@ -38,6 +83,10 @@ spec:
     spec:
       backoffLimit: 0
       template:
+        metadata:
+          labels:
+            app: d8-etcd-backup
+            security.deckhouse.io/security-policy-exception: d8-etcd-backup
         spec:
           {{- include "helm_lib_module_pod_security_context_run_as_user_root" $ | nindent 10 }}
           {{- include "helm_lib_priority_class" (tuple $ "cluster-low") | nindent 10 }}
@@ -88,7 +137,5 @@ spec:
             name: backup-data
           - name: tmp
             emptyDir: {}
-      {{- end }}
-    {{- end }}
-  {{- end }}
+{{- end }}
 {{- end }}

--- a/modules/040-control-plane-manager/templates/security-policy-exceptions/control-plane-proxy.yaml
+++ b/modules/040-control-plane-manager/templates/security-policy-exceptions/control-plane-proxy.yaml
@@ -1,3 +1,4 @@
+{{- if (.Values.global.enabledModules | has "prometheus") }}
 {{- if or (.Values.global.discovery.apiVersions | has "deckhouse.io/v1alpha1/SecurityPolicyException") (.Capabilities.APIVersions.Has "deckhouse.io/v1alpha1/SecurityPolicyException") }}
 ---
 apiVersion: deckhouse.io/v1alpha1
@@ -19,4 +20,5 @@ spec:
         protocol: TCP
         metadata:
           description: HTTPS metrics endpoint exposed through kube-rbac-proxy.
+{{- end }}
 {{- end }}

--- a/modules/040-control-plane-manager/templates/security-policy-exceptions/control-plane-proxy.yaml
+++ b/modules/040-control-plane-manager/templates/security-policy-exceptions/control-plane-proxy.yaml
@@ -1,0 +1,22 @@
+{{- if or (.Values.global.discovery.apiVersions | has "deckhouse.io/v1alpha1/SecurityPolicyException") (.Capabilities.APIVersions.Has "deckhouse.io/v1alpha1/SecurityPolicyException") }}
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: SecurityPolicyException
+metadata:
+  name: control-plane-proxy
+  namespace: kube-system
+  {{- include "helm_lib_module_labels" (list . (dict "app" "control-plane-proxy")) | nindent 2 }}
+spec:
+  network:
+    hostNetwork:
+      allowedValue: true
+      metadata:
+        description: |
+          control-plane-proxy scrapes control-plane metrics from loopback endpoints
+          (controller-manager, scheduler, etcd) on the same node.
+    hostPorts:
+      - port: 4209
+        protocol: TCP
+        metadata:
+          description: HTTPS metrics endpoint exposed through kube-rbac-proxy.
+{{- end }}

--- a/modules/040-control-plane-manager/templates/security-policy-exceptions/d8-control-plane-manager.yaml
+++ b/modules/040-control-plane-manager/templates/security-policy-exceptions/d8-control-plane-manager.yaml
@@ -1,0 +1,72 @@
+{{- if or (.Values.global.discovery.apiVersions | has "deckhouse.io/v1alpha1/SecurityPolicyException") (.Capabilities.APIVersions.Has "deckhouse.io/v1alpha1/SecurityPolicyException") }}
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: SecurityPolicyException
+metadata:
+  name: d8-control-plane-manager
+  namespace: kube-system
+  {{- include "helm_lib_module_labels" (list . (dict "app" "d8-control-plane-manager")) | nindent 2 }}
+spec:
+  securityContext:
+    runAsNonRoot:
+      allowedValue: false
+      metadata:
+        description: |
+          control-plane-manager must run as root to manage host control-plane files
+          under /etc/kubernetes, /var/lib/etcd and kubelet PKI directories.
+    runAsUser:
+      allowedValues:
+        - 0
+      metadata:
+        description: |
+          UID 0 is required for hostPath writes used to render static-pod manifests
+          and manage etcd/PKI state on the node.
+    capabilities:
+      allowedValues:
+        add:
+          - SYS_CHROOT
+        drop:
+          - ALL
+      metadata:
+        description: |
+          SYS_CHROOT is required to enter the host filesystem namespace when managing
+          control-plane configuration on the master node.
+  network:
+    hostNetwork:
+      allowedValue: true
+      metadata:
+        description: |
+          control-plane-manager talks to the local kubernetes-api-proxy on 127.0.0.1
+          so it stays available while the cluster network is being configured.
+    hostPorts:
+      - port: 4296
+        protocol: TCP
+        metadata:
+          description: HTTPS metrics endpoint of control-plane-manager (containerPort with hostNetwork).
+  volumes:
+    types:
+      allowedValues:
+        - hostPath
+      metadata:
+        description: |
+          control-plane-manager manages control-plane files on the node and cannot
+          replace these mounts with pod-local storage.
+    hostPath:
+      allowedValues:
+        - path: /etc/kubernetes/
+          readOnly: false
+          metadata:
+            description: Control-plane manifests, kubeconfigs and related node state.
+        - path: /root/.kube/
+          readOnly: false
+          metadata:
+            description: Node-admin kubeconfig symlink directory on master nodes.
+        - path: /var/lib/etcd
+          readOnly: false
+          metadata:
+            description: etcd data directory managed during control-plane operations.
+        - path: /var/lib/kubelet/pki/
+          readOnly: false
+          metadata:
+            description: kubelet PKI directory used by control-plane certificate management.
+{{- end }}

--- a/modules/040-control-plane-manager/templates/security-policy-exceptions/d8-control-plane-manager.yaml
+++ b/modules/040-control-plane-manager/templates/security-policy-exceptions/d8-control-plane-manager.yaml
@@ -21,16 +21,6 @@ spec:
         description: |
           UID 0 is required for hostPath writes used to render static-pod manifests
           and manage etcd/PKI state on the node.
-    capabilities:
-      allowedValues:
-        add:
-          - SYS_CHROOT
-        drop:
-          - ALL
-      metadata:
-        description: |
-          SYS_CHROOT is required to enter the host filesystem namespace when managing
-          control-plane configuration on the master node.
   network:
     hostNetwork:
       allowedValue: true
@@ -65,8 +55,4 @@ spec:
           readOnly: false
           metadata:
             description: etcd data directory managed during control-plane operations.
-        - path: /var/lib/kubelet/pki/
-          readOnly: false
-          metadata:
-            description: kubelet PKI directory used by control-plane certificate management.
 {{- end }}

--- a/modules/040-control-plane-manager/templates/security-policy-exceptions/etcd.yaml
+++ b/modules/040-control-plane-manager/templates/security-policy-exceptions/etcd.yaml
@@ -1,0 +1,59 @@
+{{- if or (.Values.global.discovery.apiVersions | has "deckhouse.io/v1alpha1/SecurityPolicyException") (.Capabilities.APIVersions.Has "deckhouse.io/v1alpha1/SecurityPolicyException") }}
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: SecurityPolicyException
+metadata:
+  name: etcd
+  namespace: kube-system
+  {{- include "helm_lib_module_labels" (list . (dict "app" "etcd")) | nindent 2 }}
+spec:
+  securityContext:
+    allowPrivilegeEscalation:
+      allowedValue: true
+      metadata:
+        description: |
+          etcd does not set allowPrivilegeEscalation explicitly; the runtime default
+          is true. The static pod runs as root on the host network and cannot use
+          the restricted default of false without changing the control-plane image.
+    runAsNonRoot:
+      allowedValue: false
+      metadata:
+        description: |
+          etcd must run as root to manage its data directory under /var/lib/etcd and
+          read PKI material under /etc/kubernetes/pki/etcd on the master node.
+    runAsUser:
+      allowedValues:
+        - 0
+      metadata:
+        description: |
+          UID 0 is required for hostPath access to etcd data and certificates.
+  network:
+    hostNetwork:
+      allowedValue: true
+      metadata:
+        description: |
+          etcd is a static control-plane pod that advertises and listens on the node
+          IP for client and peer traffic.
+    hostPorts:
+      - port: 2381
+        protocol: TCP
+        metadata:
+          description: etcd metrics and health probe port (containerPort with hostNetwork).
+  volumes:
+    types:
+      allowedValues:
+        - hostPath
+      metadata:
+        description: |
+          etcd stores its database and certificates on the node filesystem.
+    hostPath:
+      allowedValues:
+        - path: /var/lib/etcd
+          readOnly: false
+          metadata:
+            description: etcd data directory on the master node.
+        - path: /etc/kubernetes/pki/etcd
+          readOnly: true
+          metadata:
+            description: etcd TLS certificates managed by control-plane-manager.
+{{- end }}

--- a/modules/040-control-plane-manager/templates/security-policy-exceptions/etcd.yaml
+++ b/modules/040-control-plane-manager/templates/security-policy-exceptions/etcd.yaml
@@ -8,13 +8,6 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "etcd")) | nindent 2 }}
 spec:
   securityContext:
-    allowPrivilegeEscalation:
-      allowedValue: true
-      metadata:
-        description: |
-          etcd does not set allowPrivilegeEscalation explicitly; the runtime default
-          is true. The static pod runs as root on the host network and cannot use
-          the restricted default of false without changing the control-plane image.
     runAsNonRoot:
       allowedValue: false
       metadata:

--- a/modules/040-control-plane-manager/templates/security-policy-exceptions/kube-apiserver.yaml
+++ b/modules/040-control-plane-manager/templates/security-policy-exceptions/kube-apiserver.yaml
@@ -8,13 +8,6 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "kube-apiserver")) | nindent 2 }}
 spec:
   securityContext:
-    allowPrivilegeEscalation:
-      allowedValue: true
-      metadata:
-        description: |
-          kube-apiserver does not set allowPrivilegeEscalation explicitly; the runtime
-          default is true. The static pod runs as root with host mounts and cannot use
-          the restricted default without changing the control-plane image.
     runAsNonRoot:
       allowedValue: false
       metadata:

--- a/modules/040-control-plane-manager/templates/security-policy-exceptions/kube-apiserver.yaml
+++ b/modules/040-control-plane-manager/templates/security-policy-exceptions/kube-apiserver.yaml
@@ -60,9 +60,9 @@ spec:
           readOnly: true
           metadata:
             description: Distribution CA certificates.
-        {{- if .apiserver.auditPolicy }}
-          {{- if eq .apiserver.auditLog.output "File" }}
-        - path: {{ .apiserver.auditLog.path }}
+        {{- if .Values.controlPlaneManager.internal.auditPolicy }}
+          {{- if eq .Values.controlPlaneManager.apiserver.auditLog.output "File" }}
+        - path: {{ .Values.controlPlaneManager.apiserver.auditLog.path }}
           readOnly: false
           metadata:
             description: Optional file-based audit log directory.

--- a/modules/040-control-plane-manager/templates/security-policy-exceptions/kube-apiserver.yaml
+++ b/modules/040-control-plane-manager/templates/security-policy-exceptions/kube-apiserver.yaml
@@ -60,8 +60,12 @@ spec:
           readOnly: true
           metadata:
             description: Distribution CA certificates.
-        - path: /var/log/kube-audit
+        {{- if .apiserver.auditPolicy }}
+          {{- if eq .apiserver.auditLog.output "File" }}
+        - path: {{ .apiserver.auditLog.path }}
           readOnly: false
           metadata:
             description: Optional file-based audit log directory.
+          {{- end }}
+        {{- end }}
 {{- end }}

--- a/modules/040-control-plane-manager/templates/security-policy-exceptions/kube-apiserver.yaml
+++ b/modules/040-control-plane-manager/templates/security-policy-exceptions/kube-apiserver.yaml
@@ -1,0 +1,74 @@
+{{- if or (.Values.global.discovery.apiVersions | has "deckhouse.io/v1alpha1/SecurityPolicyException") (.Capabilities.APIVersions.Has "deckhouse.io/v1alpha1/SecurityPolicyException") }}
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: SecurityPolicyException
+metadata:
+  name: kube-apiserver
+  namespace: kube-system
+  {{- include "helm_lib_module_labels" (list . (dict "app" "kube-apiserver")) | nindent 2 }}
+spec:
+  securityContext:
+    allowPrivilegeEscalation:
+      allowedValue: true
+      metadata:
+        description: |
+          kube-apiserver does not set allowPrivilegeEscalation explicitly; the runtime
+          default is true. The static pod runs as root with host mounts and cannot use
+          the restricted default without changing the control-plane image.
+    runAsNonRoot:
+      allowedValue: false
+      metadata:
+        description: |
+          kube-apiserver must run as root to read host PKI, CA bundles and optional
+          audit log directories on the master node.
+    runAsUser:
+      allowedValues:
+        - 0
+      metadata:
+        description: |
+          UID 0 is required for hostPath access to certificates and audit logs.
+  network:
+    hostNetwork:
+      allowedValue: true
+      metadata:
+        description: |
+          kube-apiserver is a static control-plane pod that listens on the node
+          network for Kubernetes API clients.
+  volumes:
+    types:
+      allowedValues:
+        - hostPath
+      metadata:
+        description: |
+          kube-apiserver mounts host PKI, CA trust stores and Deckhouse extra files.
+    hostPath:
+      allowedValues:
+        - path: /etc/kubernetes/deckhouse/extra-files
+          readOnly: true
+          metadata:
+            description: Deckhouse-managed apiserver configuration snippets.
+        - path: /etc/kubernetes/pki
+          readOnly: true
+          metadata:
+            description: Kubernetes control-plane PKI directory.
+        - path: /etc/pki
+          readOnly: true
+          metadata:
+            description: Host OS PKI trust store.
+        - path: /etc/ssl/certs
+          readOnly: true
+          metadata:
+            description: Host SSL certificate bundle.
+        - path: /usr/local/share/ca-certificates
+          readOnly: true
+          metadata:
+            description: Locally installed CA certificates.
+        - path: /usr/share/ca-certificates
+          readOnly: true
+          metadata:
+            description: Distribution CA certificates.
+        - path: /var/log/kube-audit
+          readOnly: false
+          metadata:
+            description: Optional file-based audit log directory.
+{{- end }}

--- a/modules/040-control-plane-manager/templates/security-policy-exceptions/kube-controller-manager.yaml
+++ b/modules/040-control-plane-manager/templates/security-policy-exceptions/kube-controller-manager.yaml
@@ -1,0 +1,72 @@
+{{- if or (.Values.global.discovery.apiVersions | has "deckhouse.io/v1alpha1/SecurityPolicyException") (.Capabilities.APIVersions.Has "deckhouse.io/v1alpha1/SecurityPolicyException") }}
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: SecurityPolicyException
+metadata:
+  name: kube-controller-manager
+  namespace: kube-system
+  {{- include "helm_lib_module_labels" (list . (dict "app" "kube-controller-manager")) | nindent 2 }}
+spec:
+  securityContext:
+    allowPrivilegeEscalation:
+      allowedValue: true
+      metadata:
+        description: |
+          kube-controller-manager does not set allowPrivilegeEscalation explicitly; the
+          runtime default is true. The static pod runs as root with host mounts and
+          cannot use the restricted default without changing the control-plane image.
+    runAsNonRoot:
+      allowedValue: false
+      metadata:
+        description: |
+          kube-controller-manager must run as root to read its kubeconfig, PKI and
+          CA trust stores from the master node filesystem.
+    runAsUser:
+      allowedValues:
+        - 0
+      metadata:
+        description: |
+          UID 0 is required for hostPath access to controller-manager configuration
+          and certificates.
+  network:
+    hostNetwork:
+      allowedValue: true
+      metadata:
+        description: |
+          kube-controller-manager is a static control-plane pod that serves secure
+          health and metrics endpoints on the node loopback/network.
+  volumes:
+    types:
+      allowedValues:
+        - hostPath
+      metadata:
+        description: |
+          kube-controller-manager mounts host kubeconfig, PKI, CA bundles and the
+          flexvolume plugin directory.
+    hostPath:
+      allowedValues:
+        - path: /etc/kubernetes/controller-manager.conf
+          readOnly: true
+          metadata:
+            description: controller-manager kubeconfig on the master node.
+        - path: /etc/kubernetes/deckhouse/extra-files
+          readOnly: true
+          metadata:
+            description: Deckhouse-managed controller-manager configuration snippets.
+        - path: /etc/kubernetes/pki
+          readOnly: true
+          metadata:
+            description: Kubernetes control-plane PKI directory.
+        - path: /etc/ssl/certs
+          readOnly: true
+          metadata:
+            description: Host SSL certificate bundle.
+        - path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
+          readOnly: false
+          metadata:
+            description: FlexVolume plugin directory used by volume controllers.
+        - path: /usr/share/ca-certificates
+          readOnly: true
+          metadata:
+            description: Distribution CA certificates.
+{{- end }}

--- a/modules/040-control-plane-manager/templates/security-policy-exceptions/kube-controller-manager.yaml
+++ b/modules/040-control-plane-manager/templates/security-policy-exceptions/kube-controller-manager.yaml
@@ -8,13 +8,6 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "kube-controller-manager")) | nindent 2 }}
 spec:
   securityContext:
-    allowPrivilegeEscalation:
-      allowedValue: true
-      metadata:
-        description: |
-          kube-controller-manager does not set allowPrivilegeEscalation explicitly; the
-          runtime default is true. The static pod runs as root with host mounts and
-          cannot use the restricted default without changing the control-plane image.
     runAsNonRoot:
       allowedValue: false
       metadata:

--- a/modules/040-control-plane-manager/templates/security-policy-exceptions/kube-scheduler.yaml
+++ b/modules/040-control-plane-manager/templates/security-policy-exceptions/kube-scheduler.yaml
@@ -1,0 +1,54 @@
+{{- if or (.Values.global.discovery.apiVersions | has "deckhouse.io/v1alpha1/SecurityPolicyException") (.Capabilities.APIVersions.Has "deckhouse.io/v1alpha1/SecurityPolicyException") }}
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: SecurityPolicyException
+metadata:
+  name: kube-scheduler
+  namespace: kube-system
+  {{- include "helm_lib_module_labels" (list . (dict "app" "kube-scheduler")) | nindent 2 }}
+spec:
+  securityContext:
+    allowPrivilegeEscalation:
+      allowedValue: true
+      metadata:
+        description: |
+          kube-scheduler does not set allowPrivilegeEscalation explicitly; the runtime
+          default is true. The static pod runs as root with host mounts and cannot use
+          the restricted default without changing the control-plane image.
+    runAsNonRoot:
+      allowedValue: false
+      metadata:
+        description: |
+          kube-scheduler must run as root to read its kubeconfig and Deckhouse extra
+          files from the master node filesystem.
+    runAsUser:
+      allowedValues:
+        - 0
+      metadata:
+        description: |
+          UID 0 is required for hostPath access to scheduler configuration.
+  network:
+    hostNetwork:
+      allowedValue: true
+      metadata:
+        description: |
+          kube-scheduler is a static control-plane pod that serves secure health and
+          metrics endpoints on the node loopback/network.
+  volumes:
+    types:
+      allowedValues:
+        - hostPath
+      metadata:
+        description: |
+          kube-scheduler mounts host kubeconfig and Deckhouse extra files.
+    hostPath:
+      allowedValues:
+        - path: /etc/kubernetes/deckhouse/extra-files
+          readOnly: true
+          metadata:
+            description: Deckhouse-managed scheduler configuration snippets.
+        - path: /etc/kubernetes/scheduler.conf
+          readOnly: true
+          metadata:
+            description: scheduler kubeconfig on the master node.
+{{- end }}

--- a/modules/040-control-plane-manager/templates/security-policy-exceptions/kube-scheduler.yaml
+++ b/modules/040-control-plane-manager/templates/security-policy-exceptions/kube-scheduler.yaml
@@ -8,13 +8,6 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "kube-scheduler")) | nindent 2 }}
 spec:
   securityContext:
-    allowPrivilegeEscalation:
-      allowedValue: true
-      metadata:
-        description: |
-          kube-scheduler does not set allowPrivilegeEscalation explicitly; the runtime
-          default is true. The static pod runs as root with host mounts and cannot use
-          the restricted default without changing the control-plane image.
     runAsNonRoot:
       allowedValue: false
       metadata:


### PR DESCRIPTION
## Description
Add SecurityPolicyExceptions for control-plane components in kube-system namespace, and drop some unused capabilites and mounts.

As a separate template files in `templates/security-policy-exceptions`:
- kube-apiserver
- kube-controller-manager
- kube-scheduler
- etcd
- d8-control-plane-manager
- control-plane-proxy

And for d8-etcd-backup in `templates/etcd-backup/cronjob.yaml`.

Removed capabilities and permissions:
- Set allowPrivilegeEscalation: false for all static pods;
- Remove unused SYS_CHROOT capab. and pki path mount from control-plane-manager;
- etcd-backup no longer uses hostNetwork, requests etcd using node IP address.
## Why do we need it, and what problem does it solve?
Restricted PSS is expected to be enforced in system namespaces.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: chore
summary: Add SecurityPolicyExceptions for control-plane components in kube-system namespace.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
