### PR TITLE
Backport: [cloud-provider-yandex] fix target group sync with unresolvable Nodes

### DIFF
--- a/modules/030-cloud-provider-yandex/oss.yaml
+++ b/modules/030-cloud-provider-yandex/oss.yaml
@@ -12,7 +12,7 @@
   logo: /images/logos/kubernetes.svg
   license: Apache License 2.0
   id: ccm-yandex
-  version: v0.33.4
+  version: v0.33.6
 
 - name: Yandex Cloud CSI driver
   link: https://github.com/deckhouse/yandex-csi-driver


### PR DESCRIPTION
Backport of #22310 to `release-1.77`.

## Description

Bumps `ccm-yandex` in `modules/030-cloud-provider-yandex/oss.yaml` from `v0.33.4` to `v0.33.6`.


## Why do we need it in the patch release (if we do)?

Load balancing is fully broken in hybrid clusters until this lands, and there is no workaround
short of removing the static Nodes from the cluster.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cloud-provider-yandex
type: fix
summary: A Node that cannot be resolved to a Yandex Instance no longer blocks target group synchronization for the whole cluster.
impact_level: default
```
