### PR TITLE
Backport: [cloud-provider-yandex] fix target group sync with unresolvable Nodes

### DIFF
--- a/modules/030-cloud-provider-yandex/images/cloud-controller-manager/werf.inc.yaml
+++ b/modules/030-cloud-provider-yandex/images/cloud-controller-manager/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $version := "v0.33.2" }}
+{{- $version := "v0.33.6" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/distroless


### PR DESCRIPTION
Backport of #22310 to `release-1.76`.

## Description

Bumps the CCM version from `v0.33.2` to `v0.33.6`.

## Why do we need it in the patch release (if we do)?

Load balancing is fully broken in hybrid clusters until this lands, and there is no workaround
short of removing the static Nodes from the cluster.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cloud-provider-yandex
type: fix
summary: A Node that cannot be resolved to a Yandex Instance no longer blocks target group synchronization for the whole cluster.
impact_level: default
```
