### PR TITLE
[deckhouse-controller] Skip unchanged module release channels with HEAD request

### DIFF
--- a/deckhouse-controller/pkg/controller/module-controllers/downloader/downloader.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/downloader/downloader.go
@@ -144,6 +144,34 @@ func (md *ModuleDownloader) DownloadMetadataFromReleaseChannel(ctx context.Conte
 	return res, nil
 }
 
+// GetReleaseChannelChecksum returns the digest of the module's release-channel image
+// (registry path .../<moduleName>/release:<releaseChannel>). It reads only the manifest
+// digest - via a cheap HEAD request when the registry supports it (see cr.Client.Digest),
+// falling back to a GET otherwise - without pulling and extracting the image layers.
+//
+// The returned value is the same digest that DownloadMetadataFromReleaseChannel stores as
+// Checksum, so it can be compared against the checksum recorded in the ModuleSource status
+// to detect whether the channel has moved before doing the full (expensive) metadata download.
+func (md *ModuleDownloader) GetReleaseChannelChecksum(ctx context.Context, moduleName, releaseChannel string) (string, error) {
+	ctx, span := otel.Tracer(tracerName).Start(ctx, "GetReleaseChannelChecksum")
+	defer span.End()
+
+	span.SetAttributes(attribute.String("module", moduleName))
+	span.SetAttributes(attribute.String("releaseChannel", releaseChannel))
+
+	regCli, err := md.dc.GetRegistryClient(path.Join(md.ms.Spec.Registry.Repo, moduleName, "release"), md.registryOptions...)
+	if err != nil {
+		return "", fmt.Errorf("get registry client: %w", err)
+	}
+
+	checksum, err := regCli.Digest(ctx, strcase.ToKebab(releaseChannel))
+	if err != nil {
+		return "", fmt.Errorf("get release channel digest: %w", err)
+	}
+
+	return checksum, nil
+}
+
 // DownloadReleaseImageInfoByVersion downloads only module release image with metadata: version.json
 // does not fetch and install the desired version on the module, only fetches its module definition
 func (md *ModuleDownloader) DownloadReleaseImageInfoByVersion(ctx context.Context, moduleName, moduleVersion string) (*ModuleDownloadResult, error) {

--- a/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
@@ -404,6 +404,44 @@ func (r *reconciler) processModules(ctx context.Context, source *v1alpha1.Module
 		metricModuleGroup := metrics.D8ModuleUpdatingGroup + "_" + strcase.ToSnake(moduleName) + "_" + strcase.ToSnake(source.GetName())
 		r.metricStorage.Grouped().ExpireGroupMetrics(metricModuleGroup)
 
+		// Cheaply probe the release channel before pulling the whole release image. The
+		// channel image digest is the module checksum recorded in the source status; when it
+		// has not moved, the version and the module definition inside the image are identical
+		// to what we already have, so there is nothing to download or process for the module.
+		//
+		// An unchanged checksum alone is not enough to skip: the target ModuleRelease may have
+		// been removed, or intermediate minor releases may have been mirrored into the registry
+		// after the target was first created (releaseUpToDate verifies both from the cache). On
+		// any probe/verify error we do not skip - we fall through to the full download below,
+		// which handles the module and its errors exactly as before.
+		if availableModule.Checksum != "" && availableModule.Version != "" && availableModule.Version != "unknown" {
+			channelChecksum, err := md.GetReleaseChannelChecksum(ctx, moduleName, policy.Spec.ReleaseChannel)
+			switch {
+			case err != nil:
+				logger.Debug("failed to probe release channel checksum, downloading metadata", log.Err(err))
+
+			case channelChecksum != availableModule.Checksum:
+				logger.Debug("release channel checksum changed, downloading metadata",
+					slog.String("old_checksum", availableModule.Checksum), slog.String("new_checksum", channelChecksum))
+
+			default:
+				upToDate, err := r.releaseUpToDate(ctx, source.Name, moduleName, availableModule.Checksum, availableModule.Version)
+				switch {
+				case err != nil:
+					logger.Debug("failed to verify release is up to date, downloading metadata", log.Err(err))
+
+				case upToDate:
+					logger.Debug("release channel unchanged and release up to date, skip module",
+						slog.String("checksum", availableModule.Checksum), slog.String("version", availableModule.Version))
+					availableModules = append(availableModules, availableModule)
+					continue
+
+				default:
+					logger.Debug("release channel unchanged but release chain is incomplete, downloading metadata")
+				}
+			}
+		}
+
 		logger.Debug("download module meta from release channel")
 
 		meta, err := md.DownloadMetadataFromReleaseChannel(ctx, moduleName, policy.Spec.ReleaseChannel)

--- a/deckhouse-controller/pkg/controller/module-controllers/source/controller_test.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/controller_test.go
@@ -894,6 +894,121 @@ status:
 	})
 }
 
+// TestSkipUnchangedReleaseChannel verifies the cheap HEAD probe short-circuit: once a
+// module's release-channel checksum is recorded in the ModuleSource status, a later scan
+// that sees the same channel digest must skip the module entirely and must not pull the
+// release image again.
+func (suite *ControllerTestSuite) TestSkipUnchangedReleaseChannel() {
+	suite.Run("unchanged channel digest skips the metadata pull on the next scan", func() {
+		const (
+			moduleName = "enabledmodule"
+			repo       = "dev-registry.deckhouse.io/deckhouse/modules"
+		)
+		channelDigest := "sha256:" + strings.Repeat("a", 64)
+
+		// counts every pull of the module's release repo (channel + version metadata) -
+		// exactly the expensive work the probe must avoid on an unchanged channel.
+		var releaseImagePulls int
+
+		newImage := func(version string) crv1.Image {
+			return &crfake.FakeImage{
+				ManifestStub: manifestStub,
+				LayersStub: func() ([]crv1.Layer, error) {
+					return []crv1.Layer{
+						&utils.FakeLayer{},
+						&utils.FakeLayer{FilesContent: map[string]string{
+							"module.yaml":  "name: " + moduleName + "\nweight: 900\n",
+							"version.json": `{"version": "` + version + `"}`,
+						}},
+					}, nil
+				},
+				DigestStub: func() (crv1.Hash, error) { return crv1.NewHash(channelDigest) },
+			}
+		}
+
+		releaseMock := cr.NewClientMock(suite.T())
+		// the cheap probe: the channel digest never moves between the two scans
+		releaseMock.DigestMock.Optional().Return(channelDigest, nil)
+		releaseMock.ImageMock.Optional().Set(func(_ context.Context, imageTag string) (crv1.Image, error) {
+			releaseImagePulls++
+			version := imageTag
+			if _, err := semver.NewVersion(imageTag); err != nil {
+				version = "v1.2.3" // a channel tag (e.g. "stable") resolves to the channel version
+			}
+			return newImage(version), nil
+		})
+
+		moduleMock := cr.NewClientMock(suite.T())
+		moduleMock.ListTagsMock.Optional().Return([]string{"v1.2.3"}, nil)
+		moduleMock.ImageMock.Optional().Set(func(_ context.Context, _ string) (crv1.Image, error) {
+			return newImage("v1.2.3"), nil
+		})
+
+		dc := dependency.NewMockedContainer()
+		dc.CRClientMap = map[string]cr.Client{
+			repo:                                 cr.NewClientMock(suite.T()).ListTagsMock.Optional().Return([]string{moduleName}, nil),
+			repo + "/" + moduleName:              moduleMock,
+			repo + "/" + moduleName + "/release": releaseMock,
+		}
+
+		manifest := `
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleSource
+metadata:
+  annotations:
+    modules.deckhouse.io/registry-spec-checksum: 912e02634dd8b7222cc42906e35f1e79
+    modules.deckhouse.io/default-source: "true"
+  name: test-source
+spec:
+  registry:
+    dockerCfg: YXNiCg==
+    repo: dev-registry.deckhouse.io/deckhouse/modules
+    scheme: HTTPS
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: Module
+metadata:
+  name: enabledmodule
+properties:
+  availableSources:
+    - test-source
+status:
+  phase: Available
+  conditions:
+    - type: EnabledByModuleConfig
+      status: "True"
+`
+		suite.setupTestControllerRaw(manifest, withDependencyContainer(dc))
+
+		// First scan: pulls the release channel metadata, records the checksum and creates
+		// the ModuleRelease.
+		_, err := suite.r.handleModuleSource(context.TODO(), suite.moduleSource("test-source"))
+		require.NoError(suite.T(), err)
+
+		source := suite.moduleSource("test-source")
+		require.Len(suite.T(), source.Status.AvailableModules, 1)
+		require.Equal(suite.T(), channelDigest, source.Status.AvailableModules[0].Checksum)
+		require.Equal(suite.T(), "v1.2.3", source.Status.AvailableModules[0].Version)
+
+		pullsAfterFirstScan := releaseImagePulls
+		require.Positive(suite.T(), pullsAfterFirstScan, "the first scan must pull the release channel image")
+
+		// Second scan: the cheap probe sees the same channel digest, so the module is
+		// skipped entirely - no further pulls of the release image.
+		_, err = suite.r.handleModuleSource(context.TODO(), suite.moduleSource("test-source"))
+		require.NoError(suite.T(), err)
+
+		assert.Equal(suite.T(), pullsAfterFirstScan, releaseImagePulls,
+			"an unchanged release channel must not pull the release image again")
+
+		// the recorded state survives the skipped scan
+		source = suite.moduleSource("test-source")
+		require.Len(suite.T(), source.Status.AvailableModules, 1)
+		assert.Equal(suite.T(), channelDigest, source.Status.AvailableModules[0].Checksum)
+		assert.Equal(suite.T(), "v1.2.3", source.Status.AvailableModules[0].Version)
+	})
+}
+
 // moduleDefinitionConfig holds configuration for mocking module definition.
 // All fields correspond to properties updated in updateModulePropertiesFromDefinition.
 type moduleDefinitionConfig struct {

--- a/deckhouse-controller/pkg/controller/module-controllers/source/helpers.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/helpers.go
@@ -170,6 +170,34 @@ func (r *reconciler) releaseExists(ctx context.Context, sourceName, moduleName, 
 	return true, nil
 }
 
+// releaseUpToDate reports whether the module already has everything the recorded
+// checksum implies: the target ModuleRelease is present in the cluster and the
+// step-by-step chain of ModuleReleases up to the recorded target version is complete.
+// It performs only cheap reads from the controller cache (no registry I/O), so it is
+// safe to call on the steady-state path to decide whether a module whose release channel
+// has not moved can be skipped entirely.
+//
+// version is the target version recorded in the ModuleSource status; it must be a valid
+// semver (releaseChainToTargetComplete returns an error otherwise). A false result means
+// the module must be re-processed even though its channel digest is unchanged - either the
+// target release is missing or intermediate releases were mirrored after it was created.
+func (r *reconciler) releaseUpToDate(ctx context.Context, sourceName, moduleName, checksum, version string) (bool, error) {
+	exists, err := r.releaseExists(ctx, sourceName, moduleName, checksum)
+	if err != nil {
+		return false, fmt.Errorf("check release exists: %w", err)
+	}
+	if !exists {
+		return false, nil
+	}
+
+	complete, err := r.releaseChainToTargetComplete(ctx, moduleName, version)
+	if err != nil {
+		return false, fmt.Errorf("check release chain to target: %w", err)
+	}
+
+	return complete, nil
+}
+
 // releaseEnsureAllowed reports whether a release for the module may be ensured from
 // the given source at all. It is a pure policy predicate over already-fetched data
 // (no cluster I/O): it does not decide whether there is actually something to fetch -

--- a/go_lib/dependency/cr/cr.go
+++ b/go_lib/dependency/cr/cr.go
@@ -194,6 +194,15 @@ func (r *client) ListTags(ctx context.Context) ([]string, error) {
 }
 
 func (r *client) Digest(ctx context.Context, tag string) (string, error) {
+	// Try a cheap HEAD request first: it returns the manifest digest via the
+	// Docker-Content-Digest header without transferring the manifest body or any layers.
+	// Not every registry answers HEAD on a manifest, so on any error fall back to the
+	// previous behaviour of pulling the manifest with a GET - this keeps the error
+	// semantics (e.g. a transport 404 for a missing image) identical for callers.
+	if digest, err := r.head(ctx, tag); err == nil {
+		return digest, nil
+	}
+
 	image, err := r.Image(ctx, tag)
 	if err != nil {
 		return "", fmt.Errorf("image: %w", err)
@@ -205,6 +214,61 @@ func (r *client) Digest(ctx context.Context, tag string) (string, error) {
 	}
 
 	return d.String(), nil
+}
+
+// head issues a HEAD request against the tag's manifest and returns its digest string.
+// It transfers only the manifest descriptor (no manifest body, no layers), so it is the
+// cheapest way to learn whether a tag has moved. Returns an error if the registry does
+// not support HEAD on the manifest, letting the caller fall back to a GET.
+func (r *client) head(ctx context.Context, tag string) (string, error) {
+	imageURL := r.registryURL + ":" + tag
+
+	var nameOpts []name.Option
+	if r.options.useHTTP {
+		nameOpts = append(nameOpts, name.Insecure)
+	}
+
+	ref, err := name.ParseReference(imageURL, nameOpts...)
+	if err != nil {
+		return "", fmt.Errorf("parse reference: %w", err)
+	}
+
+	headOptions := make([]remote.Option, 0)
+	headOptions = append(headOptions, remote.WithUserAgent(r.options.userAgent))
+	if !r.options.withoutAuth {
+		headOptions = append(headOptions, remote.WithAuth(authn.FromConfig(r.authConfig)))
+	}
+
+	if r.options.ca != "" {
+		headOptions = append(headOptions, remote.WithTransport(GetHTTPTransport(r.options.ca)))
+	}
+
+	if r.options.timeout > 0 {
+		// add default timeout to prevent an endless request; here we can defer cancel
+		// because we return a string, not a lazy *v1.Image that reads on demand.
+		ctxWTO, cancel := context.WithTimeout(ctx, r.options.timeout)
+		defer cancel()
+
+		headOptions = append(headOptions, remote.WithContext(ctxWTO))
+	} else {
+		headOptions = append(headOptions, remote.WithContext(ctx))
+	}
+
+	desc, err := remote.Head(ref, headOptions...)
+	if err != nil {
+		return "", fmt.Errorf("head: %w", err)
+	}
+
+	// A tag that points at a multi-arch index resolves under GET (remote.Image) to a
+	// platform-specific child manifest whose digest differs from the index digest that
+	// HEAD reports. To keep Digest's result identical to the GET path for every caller
+	// (e.g. the deckhouse-release restart check compares it against the running image
+	// hash), only trust HEAD for a single manifest and fall back to GET for an index.
+	if desc.MediaType.IsIndex() {
+		return "", fmt.Errorf("head: %s is an index, falling back to GET", desc.MediaType)
+	}
+
+	return desc.Digest.String(), nil
 }
 
 func readAuthConfig(repo, dockerCfg, login, password string) (authn.AuthConfig, error) {

--- a/go_lib/dependency/cr/cr_test.go
+++ b/go_lib/dependency/cr/cr_test.go
@@ -362,6 +362,134 @@ func TestClient_Image(t *testing.T) {
 	})
 }
 
+func TestClient_Digest(t *testing.T) {
+	testImage, err := random.Image(1024, 1)
+	require.NoError(t, err)
+
+	rawManifest, err := testImage.RawManifest()
+	require.NoError(t, err)
+	wantDigest, err := testImage.Digest()
+	require.NoError(t, err)
+	mediaType, err := testImage.MediaType()
+	require.NoError(t, err)
+
+	// a valid but distinct digest reported by HEAD for the "multiarch" index tag
+	indexDigest := "sha256:" + string(bytes.Repeat([]byte("b"), 64))
+
+	var headCount, getCount atomic.Int64
+
+	registryServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/":
+			w.WriteHeader(http.StatusOK)
+
+		// "headless" simulates a registry that does not answer HEAD on a manifest,
+		// forcing the GET fallback in Digest.
+		case "/v2/test/repo/manifests/headless":
+			if r.Method == http.MethodHead {
+				headCount.Add(1)
+				w.WriteHeader(http.StatusMethodNotAllowed)
+				return
+			}
+			getCount.Add(1)
+			w.Header().Set("Content-Type", string(mediaType))
+			w.Header().Set("Docker-Content-Digest", wantDigest.String())
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(rawManifest)
+
+		case "/v2/test/repo/manifests/notfound":
+			w.WriteHeader(http.StatusNotFound)
+
+		// "multiarch" answers HEAD with an image index; GET (remote.Image) resolves it to a
+		// platform child with a different digest, so Digest must not trust the HEAD result.
+		case "/v2/test/repo/manifests/multiarch":
+			if r.Method == http.MethodHead {
+				headCount.Add(1)
+				w.Header().Set("Content-Type", "application/vnd.oci.image.index.v1+json")
+				w.Header().Set("Docker-Content-Digest", indexDigest)
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			getCount.Add(1)
+			w.Header().Set("Content-Type", string(mediaType))
+			w.Header().Set("Docker-Content-Digest", wantDigest.String())
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(rawManifest)
+
+		case "/v2/test/repo/manifests/latest":
+			w.Header().Set("Content-Type", string(mediaType))
+			w.Header().Set("Docker-Content-Digest", wantDigest.String())
+			w.Header().Set("Content-Length", fmt.Sprint(len(rawManifest)))
+			if r.Method == http.MethodHead {
+				headCount.Add(1)
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			getCount.Add(1)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(rawManifest)
+
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("test-blob-content"))
+		}
+	}))
+	defer registryServer.Close()
+
+	registryHost := registryServer.URL[7:] // remove "http://"
+
+	newClient := func(t *testing.T) Client {
+		t.Helper()
+		client, err := NewClient(registryHost+"/test/repo", WithInsecureSchema(true))
+		require.NoError(t, err)
+		return client
+	}
+
+	t.Run("digest is fetched with a HEAD request, without a GET", func(t *testing.T) {
+		headCount.Store(0)
+		getCount.Store(0)
+
+		digest, err := newClient(t).Digest(context.Background(), "latest")
+		require.NoError(t, err)
+
+		assert.Equal(t, wantDigest.String(), digest)
+		assert.Positive(t, headCount.Load(), "HEAD should be used to fetch the digest")
+		assert.Zero(t, getCount.Load(), "no GET should be issued when HEAD succeeds")
+	})
+
+	t.Run("falls back to GET when the registry refuses HEAD", func(t *testing.T) {
+		headCount.Store(0)
+		getCount.Store(0)
+
+		digest, err := newClient(t).Digest(context.Background(), "headless")
+		require.NoError(t, err)
+
+		assert.Equal(t, wantDigest.String(), digest)
+		assert.Positive(t, headCount.Load(), "HEAD should be attempted first")
+		assert.Positive(t, getCount.Load(), "GET fallback should run after HEAD is refused")
+	})
+
+	t.Run("falls back to GET when HEAD reports an index", func(t *testing.T) {
+		headCount.Store(0)
+		getCount.Store(0)
+
+		digest, err := newClient(t).Digest(context.Background(), "multiarch")
+		require.NoError(t, err)
+
+		// GET resolves the index to a platform child, so Digest must return the GET
+		// digest, not the index digest that HEAD advertised.
+		assert.Equal(t, wantDigest.String(), digest)
+		assert.NotEqual(t, indexDigest, digest)
+		assert.Positive(t, headCount.Load(), "HEAD should be attempted first")
+		assert.Positive(t, getCount.Load(), "GET fallback should run when HEAD reports an index")
+	})
+
+	t.Run("returns an error for a missing image", func(t *testing.T) {
+		_, err := newClient(t).Digest(context.Background(), "notfound")
+		require.Error(t, err)
+	})
+}
+
 func TestClient_ListTags(t *testing.T) {
 	// Create a test HTTP server that acts as a registry
 	registryServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Description

The ModuleSource controller re-scans every module's release channel on each cycle (`defaultScanInterval`, 3 minutes). Until now every scan pulled the **whole** release-channel image — a manifest GET plus flattening and extracting all layers via `cr.Extract` — only to read `version.json` and compute the channel digest, **even when nothing on the channel had changed**.

This PR records the release-channel image digest (checksum) in the ModuleSource status (as it already did) and, on every subsequent scan, verifies it cheaply first:

- fetch only the manifest digest (`Docker-Content-Digest`) with `remote.Head` — no manifest body, no layers;
- if the digest equals the checksum stored in `ModuleSource.status.modules[].checksum` **and** the target `ModuleRelease` already exists with a complete update chain, the module is skipped entirely — no image pull, no processing;
- if the digest changed (or the release is missing / the chain is incomplete), fall back to the full metadata download and process the module exactly as before, then update the recorded checksum.

Registry-client change (`go_lib/dependency/cr`): `Client.Digest` now issues a HEAD first and falls back to GET when the registry does not answer HEAD on a manifest ("cheap when possible, correct always"). To keep the returned digest **identical** for every caller, HEAD is trusted only for a single manifest; for a multi-arch index — where a GET resolves to a platform-specific child with a different digest — it falls back to GET. This preserves the behaviour of the deckhouse-release restart check, which compares this digest against the running image hash.

The existing safety net is intentionally kept: a skip requires *digest unchanged* **and** *target release present* **and** *step-by-step release chain complete* (the last check guards against intermediate minor versions that are mirrored into the registry after the target release was first created). These are cache-only reads (no registry I/O), so they do not add registry load.

No CRD/API changes. No restarts of critical cluster components.

**Changed files**

- `go_lib/dependency/cr/cr.go` — HEAD-first `Digest` with GET fallback (+ index guard).
- `deckhouse-controller/.../downloader/downloader.go` — `GetReleaseChannelChecksum` (digest-only, no layer pull).
- `deckhouse-controller/.../source/controller.go` — early cheap probe + skip in `processModules`.
- `deckhouse-controller/.../source/helpers.go` — `releaseUpToDate` (release exists + chain complete, cache-only).

## Why do we need it, and what problem does it solve?

Every ModuleSource scan pulled and extracted the full release-channel image for **every module on every cycle**, producing constant registry traffic and load proportional to (modules × sources) even in the steady state where nothing changes. Reading only the manifest digest with HEAD lets the controller detect "channel unchanged" cheaply and skip all the expensive work, cutting registry requests, transferred bytes, and reconcile time — especially valuable for clusters with many modules and for rate-limited or mirrored registries.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist

- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse-controller
type: feature
summary: ModuleSource scans skip unchanged release channels using a cheap registry HEAD request instead of pulling the whole release image every cycle.
impact_level: low
```
