### PR TITLE
[dhctl,commander] Fix master replicas validation

### DIFF
--- a/dhctl/pkg/config/validation_rules.go
+++ b/dhctl/pkg/config/validation_rules.go
@@ -52,30 +52,15 @@ var xRulesValidators = map[string]func(oldValue json.RawMessage) error{
 }
 
 func UpdateReplicasRule(oldRaw, newRaw json.RawMessage) error {
-	var oldValue int
 	var newValue int
 
-	err := yaml.Unmarshal(oldRaw, &oldValue)
-	if err != nil {
-		return err
-	}
-
-	err = yaml.Unmarshal(newRaw, &newValue)
-	if err != nil {
+	if err := yaml.Unmarshal(newRaw, &newValue); err != nil {
 		return err
 	}
 
 	if newValue == 0 {
 		return fmt.Errorf("%w: the .masterNodeGroup.replicas zero value is not acceptable", ErrValidationRuleFailed)
 	}
-
-	if newValue < oldValue && newValue == 1 {
-		return fmt.Errorf(
-			"%w: can't reduce the number of master nodegroup replicas to 1, functionality will be available in future versions",
-			ErrValidationRuleFailed,
-		)
-	}
-
 	return nil
 }
 

--- a/dhctl/pkg/config/validation_rules_test.go
+++ b/dhctl/pkg/config/validation_rules_test.go
@@ -191,7 +191,7 @@ unsafeObject:
 			schema:      testSchemaStore(t),
 			errContains: `ChangesValidationFailed: unsafe field has been changed: .unsafeObject`,
 		},
-		"unsafe rule, ok: updateReplicas": {
+		"unsafe rule, ok: updateReplicas scales up": {
 			phase: phases.FinalizationPhase,
 			oldConfig: `
 apiVersion: deckhouse.io/v1
@@ -207,7 +207,7 @@ masterNodeGroup:
   replicas: 3`,
 			schema: testSchemaStore(t),
 		},
-		"unsafe rule, failed: updateReplicas": {
+		"unsafe rule, ok: updateReplicas scales down to one": {
 			phase: phases.FinalizationPhase,
 			oldConfig: `
 apiVersion: deckhouse.io/v1
@@ -221,8 +221,24 @@ kind: ClusterConfiguration
 clusterType: Static
 masterNodeGroup:
   replicas: 1`,
+			schema: testSchemaStore(t),
+		},
+		"unsafe rule, failed: updateReplicas scales down to zero": {
+			phase: phases.FinalizationPhase,
+			oldConfig: `
+apiVersion: deckhouse.io/v1
+kind: ClusterConfiguration
+clusterType: Static
+masterNodeGroup:
+  replicas: 3`,
+			newConfig: `
+apiVersion: deckhouse.io/v1
+kind: ClusterConfiguration
+clusterType: Static
+masterNodeGroup:
+  replicas: 0`,
 			schema:      testSchemaStore(t),
-			errContains: `ChangesValidationFailed: validation rule failed: can't reduce the number of master nodegroup replicas to 1, functionality will be available in future versions`,
+			errContains: `ChangesValidationFailed: validation rule failed: the .masterNodeGroup.replicas zero value is not acceptable`,
 		},
 		"unsafe rule, ok: deleteZones": {
 			phase: phases.FinalizationPhase,


### PR DESCRIPTION
## Description

`UpdateReplicasRule` no longer rejects reducing `.masterNodeGroup.replicas` to 1. The rule now only guards the zero value, so scaling a cluster down to a single master passes changes validation.

## Why do we need it, and what problem does it solve?

Scaling masters down is a supported operation — `dhctl converge` handles it. The validation rule, however, still failed the change with:

```
can't reduce the number of master nodegroup replicas to 1, functionality will be available in future versions
```

Because of that, users going through Commander could not scale a multi-master cluster down to a single master at all. The `replicas: 0` guard is kept.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: dhctl
type: fix
summary: Allow scaling the master node group down to one replica.
```
