### PR TITLE
[upmeter] Fix connection leak in the insecure HTTP client

### DIFF
--- a/modules/500-upmeter/images/upmeter/src/pkg/probe/checker/http.go
+++ b/modules/500-upmeter/images/upmeter/src/pkg/probe/checker/http.go
@@ -103,13 +103,20 @@ func doRequest(client *http.Client, req *http.Request) ([]byte, check.Error) {
 	return body, nil
 }
 
+// insecureTransport is shared by all insecure clients. A single connection pool with an idle
+// timeout keeps abandoned keep-alive connections from accumulating when clients are created
+// per request (e.g. in polling loops).
+var insecureTransport = &http.Transport{
+	TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	IdleConnTimeout: 90 * time.Second,
+	MaxIdleConns:    10,
+}
+
 // newInsecureClient creates http.Client omitting TLS verificaton. Useful for accessing APIs via
 // kube-rbac-proxy which has self-signed certificates.
 func newInsecureClient(timeout time.Duration) *http.Client {
 	return &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		},
-		Timeout: timeout,
+		Transport: insecureTransport,
+		Timeout:   timeout,
 	}
 }

--- a/modules/500-upmeter/images/upmeter/src/pkg/probe/checker/http.go
+++ b/modules/500-upmeter/images/upmeter/src/pkg/probe/checker/http.go
@@ -107,9 +107,10 @@ func doRequest(client *http.Client, req *http.Request) ([]byte, check.Error) {
 // timeout keeps abandoned keep-alive connections from accumulating when clients are created
 // per request (e.g. in polling loops).
 var insecureTransport = &http.Transport{
-	TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-	IdleConnTimeout: 90 * time.Second,
-	MaxIdleConns:    10,
+	TLSClientConfig:     &tls.Config{InsecureSkipVerify: true},
+	IdleConnTimeout:     90 * time.Second,
+	MaxIdleConns:        16,
+	MaxIdleConnsPerHost: 8,
 }
 
 // newInsecureClient creates http.Client omitting TLS verificaton. Useful for accessing APIs via


### PR DESCRIPTION
## Description

The observability lifecycle probes added in 1.76 (`observability-recording`, `observability-rules-group-alert`) call `queryEndpoint` in polling loops, and it creates a new insecure `http.Client` per request. Each client got its own `http.Transport` with the zero-value `IdleConnTimeout: 0` and `CloseIdleConnections()` was never called, so every polling iteration left a keep-alive TLS connection to Prometheus alive forever (2 goroutines + TLS buffers each). This leaks goroutines and memory in `upmeter-agent`; confirmed by a steadily growing number of ESTABLISHED connections to `prometheus.d8-monitoring:9090` in agent pods.

The fix shares a single `http.Transport` (with `IdleConnTimeout: 90s`) across all insecure clients, so per-request clients reuse one connection pool and idle connections are reaped.

## Why do we need it in the patch release (if we do)?

Memory of `upmeter-agent` pods on master nodes grows unboundedly in clusters with the observability module enabled; the only workaround is restarting the agents.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Fixed goroutine and memory leak in upmeter-agent caused by per-request HTTP clients leaving idle keep-alive connections to Prometheus open forever.
impact_level: default
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)