### PR TITLE
[deckhouse-controller] Fix PackageRepository always use https scheme

### DIFF
--- a/deckhouse-controller/internal/registry/service/package_service.go
+++ b/deckhouse-controller/internal/registry/service/package_service.go
@@ -29,6 +29,7 @@ import (
 	"strings"
 
 	"github.com/goccy/go-yaml"
+	"github.com/google/go-containerregistry/pkg/authn"
 
 	registryClient "github.com/deckhouse/deckhouse/deckhouse-controller/internal/registry/client"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/controller/module-controllers/utils"
@@ -153,7 +154,8 @@ func (m *ServiceManager[T]) createAuthOptions(registryURL, dockerCFG, login, pas
 		opts = append(opts, opt)
 		m.logger.Debug("init auth from docker config")
 	default:
-		return nil, errors.New("there is no authorization data")
+		opts = append(opts, client.WithAuth(authn.Anonymous))
+		m.logger.Debug("init anonymous auth")
 	}
 
 	return opts, nil

--- a/deckhouse-controller/internal/registry/service/package_service.go
+++ b/deckhouse-controller/internal/registry/service/package_service.go
@@ -26,6 +26,7 @@ import (
 	"io"
 	"log/slog"
 	"reflect"
+	"strings"
 
 	"github.com/goccy/go-yaml"
 
@@ -117,7 +118,7 @@ func (m *ServiceManager[T]) Service(registryURL string, config utils.RegistryCon
 
 	c := registryClient.New(registryURL,
 		append(authOpts,
-			client.WithInsecure(config.Scheme == "http"),
+			client.WithInsecure(strings.ToLower(config.Scheme) == "http"),
 			client.WithCA(config.CA),
 			client.WithUserAgent(config.UserAgent),
 			client.WithLogger(m.logger),

--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/controller_test.go
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/controller_test.go
@@ -75,13 +75,6 @@ func createFakePSM(ic registry.Client) registryService.ServiceManagerInterface[r
 	return psm
 }
 
-// createFailingPSM creates a PackageServiceManager whose Service call fails,
-// simulating an error while creating the registry client.
-func createFailingPSM(err error) registryService.ServiceManagerInterface[registryService.PackagesService] {
-	psm := mock.NewServiceManagerMock[registryService.PackagesService](&testing.T{})
-	psm.ServiceMock.Return(nil, err)
-	return psm
-}
 
 // applicationVersionImage builds a version image with Application type label and package.yaml.
 func applicationVersionImage() *fakeRegistry.ImageBuilder {
@@ -284,11 +277,12 @@ func (suite *ControllerTestSuite) TestReconcile() {
 	})
 
 	suite.Run("registry client creation failed", func() {
-		// The service manager fails to create a registry client for the repository,
-		// so NewService returns a "create package service" error before any listing.
-		failingPSM := createFailingPSM(assert.AnError)
+		// The repository carries a malformed dockerCfg, so the real service manager
+		// fails to build the registry client (bad auth config) and NewService returns
+		// a "create package service" error before any listing happens.
+		psm := registryService.NewPackageServiceManager(log.NewNop())
 
-		suite.setupController("registry-client-failed.yaml", withPackageServiceManager(failingPSM))
+		suite.setupController("registry-client-failed.yaml", withPackageServiceManager(psm))
 		operation := suite.getPackageRepositoryOperation("deckhouse-scan-1571326380")
 
 		err := repeat(func() error {

--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/controller_test.go
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/controller_test.go
@@ -75,6 +75,14 @@ func createFakePSM(ic registry.Client) registryService.ServiceManagerInterface[r
 	return psm
 }
 
+// createFailingPSM creates a PackageServiceManager whose Service call fails,
+// simulating an error while creating the registry client.
+func createFailingPSM(err error) registryService.ServiceManagerInterface[registryService.PackagesService] {
+	psm := mock.NewServiceManagerMock[registryService.PackagesService](&testing.T{})
+	psm.ServiceMock.Return(nil, err)
+	return psm
+}
+
 // applicationVersionImage builds a version image with Application type label and package.yaml.
 func applicationVersionImage() *fakeRegistry.ImageBuilder {
 	return fakeRegistry.NewImageBuilder().
@@ -276,11 +284,11 @@ func (suite *ControllerTestSuite) TestReconcile() {
 	})
 
 	suite.Run("registry client creation failed", func() {
-		// Use an empty PSM (no pre-configured services) - PackagesService will fail
-		// because there's no service for the registry URL and it can't create one dynamically
-		emptyPSM := registryService.NewPackageServiceManager(log.NewNop())
+		// The service manager fails to create a registry client for the repository,
+		// so NewService returns a "create package service" error before any listing.
+		failingPSM := createFailingPSM(assert.AnError)
 
-		suite.setupController("registry-client-failed.yaml", withPackageServiceManager(emptyPSM))
+		suite.setupController("registry-client-failed.yaml", withPackageServiceManager(failingPSM))
 		operation := suite.getPackageRepositoryOperation("deckhouse-scan-1571326380")
 
 		err := repeat(func() error {

--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/registry-client-failed.yaml
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/registry-client-failed.yaml
@@ -24,8 +24,7 @@ status:
   completionTime: "2025-10-31T12:00:00Z"
   conditions:
   - lastTransitionTime: "2019-10-17T15:33:00Z"
-    message: 'failed to list packages: failed to list tags: Get "https://registry.example.com/v2/":
-      dial tcp: lookup registry.example.com: no such host'
+    message: 'create package service: assert.AnError general error for testing'
     reason: ScanFailed
     status: "True"
     type: Completed
@@ -38,12 +37,12 @@ metadata:
   resourceVersion: "2"
 spec:
   registry:
-    repo: registry.example.com/test
+    dockerCfg: test
+    repo: incorrect-registry.example.com/incorrect
 status:
   conditions:
   - lastTransitionTime: "2019-10-17T15:33:00Z"
-    message: 'failed to list packages: failed to list tags: Get "https://registry.example.com/v2/":
-      dial tcp: lookup registry.example.com: no such host'
+    message: 'create package service: assert.AnError general error for testing'
     reason: ScanFailed
     status: "False"
     type: LastScanSucceeded

--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/registry-client-failed.yaml
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/registry-client-failed.yaml
@@ -24,8 +24,8 @@ status:
   completionTime: "2025-10-31T12:00:00Z"
   conditions:
   - lastTransitionTime: "2019-10-17T15:33:00Z"
-    message: 'create package service: failed to get auth from docker config: there
-      is no authorization data'
+    message: 'failed to list packages: failed to list tags: Get "https://registry.example.com/v2/":
+      dial tcp: lookup registry.example.com: no such host'
     reason: ScanFailed
     status: "True"
     type: Completed
@@ -42,8 +42,8 @@ spec:
 status:
   conditions:
   - lastTransitionTime: "2019-10-17T15:33:00Z"
-    message: 'create package service: failed to get auth from docker config: there
-      is no authorization data'
+    message: 'failed to list packages: failed to list tags: Get "https://registry.example.com/v2/":
+      dial tcp: lookup registry.example.com: no such host'
     reason: ScanFailed
     status: "False"
     type: LastScanSucceeded

--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/registry-client-failed.yaml
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/registry-client-failed.yaml
@@ -24,7 +24,9 @@ status:
   completionTime: "2025-10-31T12:00:00Z"
   conditions:
   - lastTransitionTime: "2019-10-17T15:33:00Z"
-    message: 'create package service: assert.AnError general error for testing'
+    message: 'create package service: failed to get auth from docker config: failed
+      to get auth from docker config: withDockercfg: read auth config: unmarshal docker
+      config: invalid character ''i'' looking for beginning of value'
     reason: ScanFailed
     status: "True"
     type: Completed
@@ -37,12 +39,14 @@ metadata:
   resourceVersion: "2"
 spec:
   registry:
-    dockerCfg: test
-    repo: incorrect-registry.example.com/incorrect
+    dockerCfg: incorrect_base64_string
+    repo: registry.example.com/test
 status:
   conditions:
   - lastTransitionTime: "2019-10-17T15:33:00Z"
-    message: 'create package service: assert.AnError general error for testing'
+    message: 'create package service: failed to get auth from docker config: failed
+      to get auth from docker config: withDockercfg: read auth config: unmarshal docker
+      config: invalid character ''i'' looking for beginning of value'
     reason: ScanFailed
     status: "False"
     type: LastScanSucceeded

--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/registry-client-failed.yaml
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/registry-client-failed.yaml
@@ -26,4 +26,5 @@ metadata:
   name: deckhouse
 spec:
   registry:
-    repo: registry.example.com/test
+    repo: incorrect-registry.example.com/incorrect
+    dockerCfg: "test"

--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/registry-client-failed.yaml
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/registry-client-failed.yaml
@@ -26,5 +26,5 @@ metadata:
   name: deckhouse
 spec:
   registry:
-    repo: incorrect-registry.example.com/incorrect
-    dockerCfg: "test"
+    repo: registry.example.com/test
+    dockerCfg: "incorrect_base64_string"


### PR DESCRIPTION
## Description
This PR fixes behavior when PackageRepository ignores .spec.scheme=HTTP (but accepts "http") due to forgotten lowercase string conversion.
And also added a support for anonymous registry access as in ModuleSource logic.

How to test: 
Setup environment around deckhouse
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: registry
  namespace: registry
spec:
  replicas: 1
  revisionHistoryLimit: 2
  selector:
    matchLabels:
      app: registry 
  template:
    metadata:
      labels:
        app: registry 
    spec:
      containers:
        - name: registry 
          image: registry:3
          ports:
          - containerPort: 5000
            name: http
---
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  labels:
    app: svcregistry
  annotations:
    nginx.ingress.kubernetes.io/ssl-redirect: "false"
    nginx.ingress.kubernetes.io/proxy-body-size: "0"
    nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
    nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
  name: registry 
  namespace: registry
spec:
  ingressClassName: nginx
  rules:
  - host: svcregistry.example.com
    http:
      paths:
      - backend:
          service:
            name: registry 
            port:
              name: http
        path: /
        pathType: Prefix 
---
apiVersion: deckhouse.io/v1alpha1
kind: PackageRepository
metadata:
  name: svcregistry
spec:
  scanInterval: 30s
  registry:
    scheme: HTTP
    repo: svcregistry.example.com/deckhouse/modules
---
apiVersion: v1
kind: Service
metadata:
  labels:
    app: registry
  name: registry
  namespace: registry
spec:
  ports:
  - name: http
    port: 5000
    protocol: TCP
    targetPort: http
  selector:
    app: registry
```

Then we need to mirror some modules/packages to our internal registry like in https://deckhouse.io/products/kubernetes-platform/documentation/v1/cli/d8/reference/#d8-mirror

```bash
d8 k get packagerepository test -o yaml |yq .status
```

Before:
```yaml
status:
  conditions:
  - lastTransitionTime: "2026-08-26T10:43:23Z"
    message: 'failed to list packages: failed to list tags: Get "https://svcregistry.example.com":
      tls: failed to verify certificate: x509: certificate is valid for ingress.local,
      not svcregistry.example.com'
    observedGeneration: 1
    reason: ScanFailed
    status: "False"
    type: LastScanSucceeded
---
# and/or
  conditions:
  - lastTransitionTime: "2026-08-26T12:03:33Z"
    message: 'create package service: failed to get auth from docker config: there
      is no authorization data'
    observedGeneration: 1
    reason: ScanFailed
    status: "False"
    type: LastScanSucceeded
```

After:
```yaml
status:
  conditions:
  - lastTransitionTime: "2026-08-26T10:44:37Z"
    message: ""
    observedGeneration: 1
    reason: ScanSucceeded
    status: "True"
    type: LastScanSucceeded
  lastChangeTime: "2026-08-26T10:44:37Z"
  lastScanTime: "2026-08-26T10:45:37Z"
  packages:
  - name: virtualization
    type: Module
  packagesCount: 1
  phase: Active
```

## Why do we need it, and what problem does it solve?
It is necessary to maintain consistency between the modules and packages systems, as well as between their components.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: Fixed a bug when PackageRepository always used a HTTPS scheme.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
