### PR TITLE
[registrypackages] Add vex for CVE-2025-54410 in containerd [1.73]

### DIFF
--- a/modules/007-registrypackages/images/containerd/known_vulnerabilities.vex
+++ b/modules/007-registrypackages/images/containerd/known_vulnerabilities.vex
@@ -2,7 +2,7 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-0a7dee882b0213b53ce1f13791d223657afca21285b99e07e15b935fa0456093",
   "author": "Deckhouse <contact@deckhouse.io>",
-  "version": 13,
+  "version": 14,
   "statements": [
     {
       "vulnerability": {
@@ -204,8 +204,22 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "GO-2026-5932 относится к пакету golang.org/x/crypto/openpgp, который объявлен unmaintained и не имеет исправленной версии. В бинарнике containerd этот пакет присутствует: он приходит транзитивно через github.com/containerd/imgcrypt/images/encryption -> github.com/containers/ocicrypt, то есть вместе с поддержкой зашифрованных OCI-образов. Единственный вход в этот код со стороны containerd только при config.ImageDecryption.KeyModel == \"node\", а иначе возвращает nil. Deckhouse поставляет конфигурацию containerd с пустым key_model для обоих CRI-плагинов, поэтому опции расшифровки не создаются и код openpgp не вызывается ни при одной операции pull. В бинарники ctr и containerd-shim-runc-v2 пакет openpgp не влинкован вовсе.",
       "timestamp": "2026-08-19T07:55:26Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-54410"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/docker/docker"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Эта неэксплуатируемая уязвимость проявляется только в работе Docker-демона (dockerd), который не запускается containerd; взаимодействия с firewalld не происходит.",
+      "timestamp": "2026-08-25T10:25:34.399236Z"
     }
   ],
   "timestamp": "2026-03-04T12:00:38Z",
-  "last_updated": "2026-06-24T12:00:00Z"
+  "last_updated": "2026-08-25T10:25:34Z"
 }


### PR DESCRIPTION
## Description
Add VEX entry for CVE-2025-54410 in containerd v2.

## Why do we need it, and what problem does it solve?
CVE-2025-54410 in docker library used in containerd v2.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: registrypackages
type: chore
summary: Add VEX entry for CVE-2025-54410 in containerd.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
