### PR TITLE
[user-authn] Add VEX for GO-2026-5932 on user-authn-controller

### DIFF
--- a/modules/150-user-authn/images/user-authn-controller/known_vulnerabilities.vex
+++ b/modules/150-user-authn/images/user-authn-controller/known_vulnerabilities.vex
@@ -1,0 +1,29 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-user-authn-user-authn-controller-go-2026-5932",
+  "author": "Deckhouse <contact@deckhouse.io>",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "@id": "https://pkg.go.dev/vuln/GO-2026-5932",
+        "description": "The golang.org/x/crypto/openpgp package is unmaintained, unsafe by design, and has known security issues that will not be fixed.",
+        "name": "GO-2026-5932"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/crypto"
+        },
+        {
+          "@id": "pkg:golang/golang.org/x/crypto@v0.55.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "GO-2026-5932 affects unmaintained golang.org/x/crypto/openpgp with no fixed version. This binary only uses other x/crypto subpackages; openpgp is not imported or executed.",
+      "timestamp": "2026-08-25T12:00:00Z"
+    }
+  ],
+  "timestamp": "2026-08-25T12:00:00Z",
+  "last_updated": "2026-08-25T12:00:00Z"
+}

--- a/modules/150-user-authn/images/user-authn-controller/werf.inc.yaml
+++ b/modules/150-user-authn/images/user-authn-controller/werf.inc.yaml
@@ -51,3 +51,5 @@ shell:
       {{- include "image-build.build" $buildContext | indent 6 }}
     - chown 64535:64535 user-authn-controller
     - chmod 0700 user-authn-controller
+---
+{{- include "vex mitigation" (list $ (printf "%s/%s" $.ModuleName $.ImageName)) }}


### PR DESCRIPTION
## Description
Added OpenVEX `known_vulnerabilities.vex` for `GO-2026-5932` (`golang.org/x/crypto/openpgp`) on `user-authn-controller` and wired `vex mitigation` into the image build.

The binary only imports `golang.org/x/crypto/bcrypt`; `openpgp` is not imported or executed.

## Why do we need it, and what problem does it solve?
There is no Fixed Version for `GO-2026-5932`. VEX marks it `not_affected` so Trivy/DefectDojo stop treating it as an active finding for this image.

## Why do we need it in the patch release (if we do)?
Not necessarily

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authn
type: chore
summary: Add VEX for GO-2026-5932 (openpgp) on user-authn-controller
impact_level: low