### PR TITLE
[deckhouse] fix: guard PodMonitors on CRD availability

### DIFF
--- a/modules/002-deckhouse/template_tests/module_test.go
+++ b/modules/002-deckhouse/template_tests/module_test.go
@@ -311,4 +311,46 @@ var _ = Describe("Module :: deckhouse :: helm template ::", func() {
 			}
 		})
 	})
+
+	// Both PodMonitors are guarded on two conditions at once: operator-prometheus being enabled,
+	// and the PodMonitor kind actually existing in the cluster. The module is external now, so it
+	// can appear in enabledModules before its CRDs are applied; rendering a PodMonitor then fails
+	// the whole deckhouse release with "no matches for kind PodMonitor", and Helm installs a
+	// release all-or-nothing, so one unguarded manifest is enough to wedge the module.
+	Context("PodMonitors", func() {
+		const podMonitorAPI = "monitoring.coreos.com/v1/PodMonitor"
+
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", globalValues)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYaml("deckhouse", moduleValuesForMasterNode)
+		})
+
+		It("are rendered when operator-prometheus is enabled and the CRD is present", func() {
+			f.HelmRender(WithAPIVersions(podMonitorAPI))
+
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+			Expect(f.KubernetesResource("PodMonitor", "d8-monitoring", "deckhouse").Exists()).To(BeTrue())
+			Expect(f.KubernetesResource("PodMonitor", "d8-monitoring", "webhook-handler").Exists()).To(BeTrue())
+		})
+
+		It("are skipped when the CRD is absent, even with operator-prometheus enabled", func() {
+			f.HelmRender()
+
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+			Expect(f.KubernetesResource("PodMonitor", "d8-monitoring", "deckhouse").Exists()).To(BeFalse())
+			Expect(f.KubernetesResource("PodMonitor", "d8-monitoring", "webhook-handler").Exists()).To(BeFalse())
+		})
+
+		// This is the case that separates `and` from `or` in the guard: with `or` the two tests
+		// above would still pass and this one would fail.
+		It("are skipped when operator-prometheus is disabled, even with the CRD present", func() {
+			f.ValuesSetFromYaml("global.enabledModules", `["vertical-pod-autoscaler", "prometheus"]`)
+			f.HelmRender(WithAPIVersions(podMonitorAPI))
+
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+			Expect(f.KubernetesResource("PodMonitor", "d8-monitoring", "deckhouse").Exists()).To(BeFalse())
+			Expect(f.KubernetesResource("PodMonitor", "d8-monitoring", "webhook-handler").Exists()).To(BeFalse())
+		})
+	})
 })

--- a/modules/002-deckhouse/templates/podmonitor.yaml
+++ b/modules/002-deckhouse/templates/podmonitor.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.global.enabledModules | has "operator-prometheus") }}
+{{- if and (.Values.global.enabledModules | has "operator-prometheus") (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/PodMonitor") }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor

--- a/modules/002-deckhouse/templates/webhook-handler/podmonitor.yaml
+++ b/modules/002-deckhouse/templates/webhook-handler/podmonitor.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.global.enabledModules | has "operator-prometheus") }}
+{{- if and (.Values.global.enabledModules | has "operator-prometheus") (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/PodMonitor") }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor


### PR DESCRIPTION
## Description

Tightens the guard on `002-deckhouse`'s two PodMonitors so they render only when the `PodMonitor` kind actually exists in the cluster:

```diff
-{{- if (.Values.global.enabledModules | has "operator-prometheus") }}
+{{- if and (.Values.global.enabledModules | has "operator-prometheus") (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/PodMonitor") }}
```

in `modules/002-deckhouse/templates/podmonitor.yaml` and `modules/002-deckhouse/templates/webhook-handler/podmonitor.yaml`.

Note it's `and`, not a replacement: enablement still gates the monitors, the capability check is an additional condition. Manifest bodies are untouched, so on a cluster where the CRDs are present the rendered output is byte-identical to before.

`module_test.go` gets a `PodMonitors` context covering all three states — CRD present + module enabled (rendered), CRD absent (skipped), module disabled + CRD present (skipped). The third case is what pins `and` down: with `or` the first two would still pass.

No restarts of critical components: the change only affects whether PodMonitor objects are rendered, not the workloads they scrape.

Scope is deliberately limited to `002-deckhouse`. ~38 other templates across the repo still guard PodMonitors on enablement alone and are untouched here.

## Why do we need it, and what problem does it solve?

`operator-prometheus` is an external module now, so being listed in `enabledModules` no longer implies its CRDs have been applied to the cluster. During that window the template
renders a `monitoring.coreos.com/v1` object into a cluster that has no such kinails with:

```
no matches for kind "PodMonitor" in version "monitoring.coreos.com/v1"
```

Helm installs a release all-or-nothing, so one unrenderable manifest wedges the whole `deckhouse` module — and since Deckhouse converges modules in sequence, a module stuck this wayholds up the rest of the install.

Enablement is the wrong signal on its own. What the template needs to know is whether the kind exists, and `.Capabilities.APIVersions` answers exactly that. The idiom is already in the repo — `registry-packages-proxy`, `node-manager`, and `terraform-manager` guard their PodMonitors this way on `main`.
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: Guard PodMonitors on CRD availability.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
