### PR TITLE
[ci] Bump golangci-lint for golang 1.27

### DIFF
--- a/.werf/werf-golang-ci-lint.yaml
+++ b/.werf/werf-golang-ci-lint.yaml
@@ -14,7 +14,7 @@ shell:
   - mkdir -p ~/.ssh && echo "StrictHostKeyChecking accept-new" > ~/.ssh/config
   install:
   - export GOPROXY=$(cat /run/secrets/GOPROXY)
-  - export GOLANGCI_LINT_VERSION=v2.8.0
+  - export GOLANGCI_LINT_VERSION=v2.13.1
   - git clone --depth 1 $(cat /run/secrets/SOURCE_REPO)/golangci/golangci-lint --branch $GOLANGCI_LINT_VERSION
   - cd golangci-lint/
   - CGO_ENABLED=0 GOOS=linux go build -ldflags "-s -w -extldflags '-static' -X 'main.version=${GOLANGCI_LINT_VERSION}' -X 'main.date=$(date -u +%Y-%m-%d)'" -o /usr/local/bin/golangci-lint cmd/golangci-lint/main.go

--- a/Makefile
+++ b/Makefile
@@ -615,7 +615,7 @@ GOTESTSUM = $(LOCALBIN)/gotestsum
 
 ## TODO: remap in yaml file (version.yaml or smthng)
 ## Tool Versions
-GOLANGCI_LINT_VERSION = v2.8.0
+GOLANGCI_LINT_VERSION = v2.13.1
 DECKHOUSE_CLI_VERSION ?= v0.33.11
 CRD_ENRICHER_VERSION ?= v0.0.1
 DMT_VERSION ?= 0.1.95


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Bump golang-ci lint 2.8.0 → 2.13.1

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Bump golang-ci lint version for go 1.27 (2.13.1)
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
