### PR TITLE
chore: change vpa memory round and add cpu round

### DIFF
--- a/modules/302-vertical-pod-autoscaler/templates/recommender/deployment.yaml
+++ b/modules/302-vertical-pod-autoscaler/templates/recommender/deployment.yaml
@@ -72,8 +72,9 @@ spec:
         - --stderrthreshold=0
         - --memory-saver=true
 {{/*        --humanize-memory is deprecated (https://github.com/kubernetes/autoscaler/pull/8400)*/}}
-{{/*        --round-memory-bytes replaces it and rounds recommendations up to the nearest 64Mi*/}}
-        - --round-memory-bytes=67108864
+{{/*        --round-memory-bytes replaces it and rounds recommendations up to the nearest 16Mi*/}}
+        - --round-memory-bytes=16777216
+        - --round-cpu-millicores=10
         - --storage=prometheus
         - --prometheus-address=https://aggregating-proxy.d8-monitoring.svc.{{ .Values.global.discovery.clusterDomain }}
         - --prometheus-insecure=true


### PR DESCRIPTION
## Description

Changed the rounding parameters of the VPA recommender (`modules/302-vertical-pod-autoscaler/templates/recommender/deployment.yaml`):

- `--round-memory-bytes` lowered from `67108864` (64Mi) to `16777216` (16Mi);
- added `--round-cpu-millicores=10` — CPU recommendations are rounded up to 10m.

The explanatory comment next to the flag was updated as well (64Mi → 16Mi).

Impact on cluster components: only the `vpa-recommender` Deployment in the `d8-vertical-pod-autoscaler` namespace is restarted. The restart itself is safe (the metric history is read from Prometheus), but after it recommendations are recalculated with the new granularity, so in namespaces with VPA objects in `updateMode: Auto` (or `Recreate`/`InPlaceOrRecreate`) a wave of pod evictions/recreations is possible while the new values are applied. Control plane, ingress controllers and Prometheus are not affected directly.

## Why do we need it, and what problem does it solve?

Rounding memory up to 64Mi produced noticeably inflated recommendations: any real usage slightly above a boundary pushed the recommendation up by a whole 64Mi (for example, 70Mi → 128Mi, almost a twofold headroom). For small and medium containers this resulted in systematic over-provisioning of requests, wasted memory headroom on nodes and worse pod packing density. A 16Mi step keeps the values human-readable (the `--round-memory-bytes` flag replaced the deprecated `--humanize-memory`) while reducing over-provisioning roughly fourfold.

CPU recommendations were not rounded at all and looked like arbitrary values such as `27m` or `113m`, which made them hard to read and to compare between revisions. Rounding up to 10m brings CPU recommendations to the same tidy form as memory with no practical loss of accuracy.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: vertical-pod-autoscaler
type: fix
summary: Reduce VPA memory recommendation rounding from 64Mi to 16Mi and round CPU recommendations up to 10m.
impact: |
  The `vpa-recommender` pod is restarted and recommendations are recalculated with the new granularity.
  Memory recommendations will generally become lower (less over-provisioning), CPU recommendations become
  multiples of 10m. VPA objects with `updateMode: Auto`/`Recreate` may evict and recreate pods to apply
  the updated requests.
impact_level: high
```