### PR TITLE
fix: correct scheduler high-node-utilization profile

### DIFF
--- a/modules/040-control-plane-manager/templates/_scheduler_config.tpl
+++ b/modules/040-control-plane-manager/templates/_scheduler_config.tpl
@@ -5,16 +5,28 @@ clientConnection:
   kubeconfig: /etc/kubernetes/scheduler.conf
 profiles:
 - schedulerName: high-node-utilization
+  plugins:
+    score:
+      disabled:
+      - name: NodeResourcesBalancedAllocation
+      - name: ImageLocality
+      enabled:
+      - name: NodeResourcesFit
+        weight: 10
   pluginConfig:
-  - args:
+  - name: NodeResourcesFit
+    args:
       scoringStrategy:
+        type: MostAllocated
         resources:
         - name: cpu
           weight: 1
         - name: memory
           weight: 1
-        type: MostAllocated
-    name: NodeResourcesFit
+  - name: PodTopologySpread
+    args:
+      defaultingType: List
+      defaultConstraints: []
 - schedulerName: default-scheduler
   pluginConfig:
   - name: PodTopologySpread


### PR DESCRIPTION
## Description

Fixes the `high-node-utilization` kube-scheduler profile in
`modules/040-control-plane-manager/templates/_scheduler_config.tpl`, which did not
actually pack pods onto the most loaded nodes.

The profile previously declared only `pluginConfig` for `NodeResourcesFit`.
`pluginConfig` sets plugin **arguments**, but it does not change the set of score
plugins or their weights. As a result `MostAllocated` was applied, yet its vote was
outweighed by the default score plugins that every profile silently inherits.

Three changes to the profile:

1. **Neutralize the `PodTopologySpread` system defaults** — `defaultingType: List`
   with an empty `defaultConstraints`. Without an explicit `PodTopologySpreadArgs`,
   the profile falls back to `SystemDefaulting`, which injects
   `kubernetes.io/hostname` maxSkew 3 and `topology.kubernetes.io/zone` maxSkew 5
   (`ScheduleAnyway`). The hostname constraint spreads pods across nodes, which is
   exactly the opposite of what the profile is for.
   Done via `pluginConfig` rather than `plugins.score.disabled` on purpose, so that
   `topologySpreadConstraints` declared in a pod spec keep working.
2. **Raise the `NodeResourcesFit` score weight** from the default `1` to `10`.
3. **Disable `NodeResourcesBalancedAllocation` and `ImageLocality`** at the `score`
   extension point of this profile.

`plugins.score.disabled` affects only the `score` extension point of this single
profile — `Filter`/`PreFilter` of the same plugins and the `default-scheduler`
profile are untouched.

### Impact on critical cluster components

`kube-scheduler`'s config checksum depends on `extra-file-scheduler-config.yaml`
(see `componentChecksumDeps` in
`modules/040-control-plane-manager/images/control-plane-manager/src/internal/checksum/checksum.go`),
so applying this change re-renders the kube-scheduler manifest and **restarts
kube-scheduler on every control-plane node**, one node at a time, as the
control-plane-manager DaemonSet rolls out.

Pod placement changes only for pods that explicitly set
`schedulerName: high-node-utilization`. The `default-scheduler` profile, and
therefore the vast majority of workloads, is not affected.

## Why do we need it, and what problem does it solve?

The profile is documented as placing pods on the most loaded nodes
(`modules/040-control-plane-manager/docs/FAQ.md`,
`docs/documentation/pages/admin/configuration/app-scaling/pod-eviction/SCHEDULER.md`)
and is a hard prerequisite for the descheduler `HighNodeUtilization` strategy —
that strategy evicts pods from underutilized nodes and relies on the scheduler to
consolidate them elsewhere. With the broken profile the evicted pods were spread
back out, so the strategy could not converge and unused nodes were never freed for
shutdown or reuse.

### Evidence

Captured from `kube-scheduler v1.32.13` with `-v=10`. A 10-replica Deployment using
`schedulerName: high-node-utilization` on a cluster with 5 feasible nodes: the first
five pods landed on **five different nodes**.

Score breakdown for the second pod (values as logged, i.e. already multiplied by the
plugin weight):

| node | TaintToleration | NodeResourcesFit | PodTopologySpread | BalancedAllocation | ImageLocality | total |
|---|---|---|---|---|---|---|
| A (already took pod #1) | 300 | **91** | **100** | 81 | 0 | 572 |
| B | 300 | 74 | 200 | 75 | 0 | **649** ← picked |
| C | 300 | 73 | 200 | 74 | 0 | 647 |
| D | 300 | 71 | 200 | 70 | 0 | 641 |
| E | 300 | 71 | 200 | 68 | 0 | 639 |

`NodeResourcesFit` correctly identified the most loaded node (91 vs 71–74), but:

- `PodTopologySpread` penalized that very node by **100 points** because it already
  hosted a replica, while the entire spread of `NodeResourcesFit` across all nodes
  was only ~20 points;
- with the default weight of `1`, `NodeResourcesFit` contributed at most 100 out of
  the 1200 points available across all default score plugins (~8 %);
- `NodeResourcesBalancedAllocation` scores
  `(1 − |cpuFraction − memFraction| / 2) × 100` (range 50–100), i.e. it measures the
  CPU/memory skew rather than how full a node is. A node packed on CPU and half
  empty on memory — the normal outcome of bin packing — gets its lowest score from
  this plugin, so it systematically penalizes the nodes the profile is meant to pick.

### Rationale for `weight: 10`

The final node score is a plain weighted sum with no normalization, so what decides
the winner is the *spread* between nodes, not the absolute value. `MostAllocated` is
linear (`requested × 100 / capacity`), which means the raw difference between two
nodes equals the difference in their utilization percentage, and the weighted
advantage of bin packing is `weight × Δutilization%`.

To reliably outweigh `ImageLocality` (up to 100 points for a node that already has a
≥1000 MB image cached) the weight has to satisfy:

| Δutilization between nodes | required weight |
|---|---|
| 20 % | ≥ 5 |
| 10 % | ≥ 10 |
| 5 % | ≥ 20 |

In the captured log the gap between the leader and the runner-up was 17 points, so a
weight of 5 would yield 85 — below `ImageLocality`'s worst case. It only worked there
because the image was not cached on any node.

Raising the weight further is not the answer: dominating a 2 % gap would need a weight
of 50+, at which point bin packing would start overriding explicit
`preferredDuringSchedulingIgnoredDuringExecution` rules from pod specs. Hence the
combination of a moderate weight and removing the two resource-agnostic score plugins
that carry no user intent. `TaintToleration`, `NodeAffinity`, `InterPodAffinity` and
the `PodTopologySpread` plugin itself are deliberately left enabled, because
disabling them would silently break workloads that rely on those pod-level settings.

## Why do we need it in the patch release (if we do)?

The profile has been non-functional since it was introduced in
[#10954](https://github.com/deckhouse/deckhouse/pull/10954) (v1.67), and every user of
the descheduler `HighNodeUtilization` strategy is affected: the documented behavior
simply does not happen. That argues for a backport.

The counter-argument is that applying the fix restarts kube-scheduler on all
control-plane nodes, so it is not a zero-impact patch.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: control-plane-manager
type: fix
summary: Fix the `high-node-utilization` kube-scheduler profile, which spread pods across nodes instead of packing them onto the most loaded ones.
impact: |
  kube-scheduler will be restarted on all control-plane nodes.

  Pod placement changes only for pods that explicitly set `schedulerName: high-node-utilization`;
  the `default-scheduler` profile is not affected. Pods using this profile must declare resource
  `requests` — the scheduler scores nodes using `NonZeroRequested`, substituting 100m CPU / 200Mi
  memory for containers without requests, which makes bin packing operate on synthetic numbers.
impact_level: high
```
