### PR TITLE
[candi] Fixed moduleSource vars injection in bashible steps

### DIFF
--- a/candi/bashible/common-steps/all/003_install_ms_ca_certificates.sh.tpl
+++ b/candi/bashible/common-steps/all/003_install_ms_ca_certificates.sh.tpl
@@ -20,8 +20,8 @@ mkdir -p /opt/deckhouse/share/ca-certificates/
 	{{- range $registryAddr,$ca := .normal.moduleSourcesCA }}
 		{{- if $ca }}
 
-bb-log-info "Sync moduleSource CA for {{ $registryAddr }}"
-bb-sync-file "/opt/deckhouse/share/ca-certificates/{{ $registryAddr | lower }}-ca.crt" - << "EOF"
+bb-log-info 'Sync moduleSource CA for {{ $registryAddr }}'
+bb-sync-file '/opt/deckhouse/share/ca-certificates/{{ $registryAddr | lower }}-ca.crt' - << "EOF"
 {{ $ca }}
 EOF
 		{{- end }}

--- a/candi/bashible/common-steps/all/030_configure_containerd_registry.sh.tpl
+++ b/candi/bashible/common-steps/all/030_configure_containerd_registry.sh.tpl
@@ -110,12 +110,12 @@ EOF
       {{- $exist_registry_host_list = append $exist_registry_host_list $host_name }}
 
 # Sync module sources host.toml and ca.crt
-mkdir -p "/etc/containerd/registry.d/{{ $host_name }}"
-bb-sync-file "/etc/containerd/registry.d/{{ $host_name }}/ca.crt" - << "EOF"
+mkdir -p '/etc/containerd/registry.d/{{ $host_name }}'
+bb-sync-file '/etc/containerd/registry.d/{{ $host_name }}/ca.crt' - << "EOF"
 {{ $CA }}
 EOF
 
-bb-sync-file "/etc/containerd/registry.d/{{ $host_name }}/hosts.toml" - << EOF
+bb-sync-file '/etc/containerd/registry.d/{{ $host_name }}/hosts.toml' - << "EOF"
 server = {{ $host_name | quote }}
 ca = ["/etc/containerd/registry.d/{{ $host_name }}/ca.crt"]
 capabilities = ["pull", "resolve"]


### PR DESCRIPTION
## Description

Fixed moduleSource vars injection in bashible steps.

## Why do we need it, and what problem does it solve?

Fixed moduleSource vars injection in bashible steps.

## Why do we need it in the patch release (if we do)?

Fixed moduleSource vars injection in bashible steps.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Fixed moduleSource vars injection in bashible steps.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
