### PR TITLE
[d8-shutdown-inhibitor] Rename drop-in to `zz-` for priority, improve log messages, and clean up old config files.

### DIFF
--- a/candi/bashible/cleanup_static_node.sh.tpl
+++ b/candi/bashible/cleanup_static_node.sh.tpl
@@ -68,7 +68,7 @@ SYSTEMD_FILES=(
   /lib/systemd/system/containerd-deckhouse*
   /etc/systemd/system/d8-shutdown-inhibitor*
   /lib/systemd/system/d8-shutdown-inhibitor*
-  /etc/systemd/logind.conf.d/99-node-d8-shutdown-inhibitor.conf
+  /etc/systemd/logind.conf.d/*d8-shutdown-inhibitor.conf
   /etc/systemd/system/kubelet*
   /lib/systemd/system/kubelet*
 )

--- a/candi/bashible/common-steps/all/076_install_d8_shutdown_inhibitor.sh.tpl
+++ b/candi/bashible/common-steps/all/076_install_d8_shutdown_inhibitor.sh.tpl
@@ -30,7 +30,8 @@
 bb-log-debug "shutdown inhibitor package={{ $inhibitorPackage }} present={{ $imagePresent }}"
 
 inhibitor_service_name="d8-shutdown-inhibitor.service"
-extra_logind_conf="/etc/systemd/logind.conf.d/99-node-d8-shutdown-inhibitor.conf"
+# Glob matches the current zz- drop-in and the legacy 99-node- one left by older releases.
+extra_logind_conf_glob="/etc/systemd/logind.conf.d/*d8-shutdown-inhibitor.conf"
 
 
 bb-event-on 'inhibitor-unit-changed' '_inhibitor-unit-changed'
@@ -56,7 +57,8 @@ _restart_inhibitor_if_needed() {
 
 bb-event-on 'd8-shutdown-inhibitor-cleanup' '_shutdown-inhibitor-cleanup'
 function _shutdown-inhibitor-cleanup() {
-  rm -rf "${extra_logind_conf}"
+  # Unquoted on purpose: the glob must expand.
+  rm -f ${extra_logind_conf_glob}
   # Send SIGHUP to logind to reload its configuration.
   systemctl -s SIGHUP kill systemd-logind
 }

--- a/ee/modules/040-node-manager/images/d8-shutdown-inhibitor/src/pkg/app/app.go
+++ b/ee/modules/040-node-manager/images/d8-shutdown-inhibitor/src/pkg/app/app.go
@@ -106,7 +106,17 @@ func (a *App) overrideInhibitDelayMax() error {
 	}
 
 	if currentInhibitDelay < a.config.InhibitDelayMax {
-		return fmt.Errorf("overrideInhibitDelayMax: unable to override inhibit delay to %s, current value of InhibitDelayMaxSec (%v) is less than requested", a.config.InhibitDelayMax.Truncate(time.Second).String(), currentInhibitDelay.Truncate(time.Second).String())
+		// Another logind drop-in sorts after ours and wins. Degrade instead of dying: the delay
+		// lock still buys currentInhibitDelay, and the power key inhibitor takes mode=block, which
+		// InhibitDelayMaxSec does not bound at all. Exiting here leaves the node with no protection
+		// and, with Restart=always/RestartSec=10, loops forever.
+		dlog.Warn(
+			"inhibit delay override lost to another logind drop-in, continuing with the lower value",
+			slog.String("current", currentInhibitDelay.Truncate(time.Second).String()),
+			slog.String("requested", a.config.InhibitDelayMax.Truncate(time.Second).String()),
+			slog.String("hint", "systemd-analyze cat-config systemd/logind.conf"),
+		)
+		return nil
 	}
 
 	dlog.Info(

--- a/ee/modules/040-node-manager/images/d8-shutdown-inhibitor/src/pkg/systemd/dbusconn.go
+++ b/ee/modules/040-node-manager/images/d8-shutdown-inhibitor/src/pkg/systemd/dbusconn.go
@@ -185,8 +185,13 @@ func (bus *DBusCon) CurrentInhibitDelay() (time.Duration, error) {
 }
 
 const (
-	logindConfigDirectory   = "/etc/systemd/logind.conf.d/"
-	d8ShutdownInhibitorConf = "99-node-d8-shutdown-inhibitor.conf" // "node" prefix to apply after 99-kubelet.conf
+	logindConfigDirectory = "/etc/systemd/logind.conf.d/"
+	// logind merges *.conf.d drop-ins from all search dirs sorted by FILE NAME (strcmp on the
+	// basename), and the last assignment of a value wins. The directory only breaks ties between
+	// identical names, so a file in /etc does not outrank a vendor file in /usr/lib. The "zz-"
+	// prefix sorts after kubelet's 99-kubelet.conf and after vendor drop-ins such as
+	// unattended-upgrades-logind-maxdelay.conf (InhibitDelayMaxSec=30 on Debian/Ubuntu).
+	d8ShutdownInhibitorConf = "zz-d8-shutdown-inhibitor.conf"
 )
 
 // OverrideInhibitDelay writes a config file to logind overriding InhibitDelayMaxSec to the value desired.

--- a/ee/modules/040-node-manager/images/d8-shutdown-inhibitor/src/pkg/systemd/dbusconn_test.go
+++ b/ee/modules/040-node-manager/images/d8-shutdown-inhibitor/src/pkg/systemd/dbusconn_test.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2025 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package systemd
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// logind merges *.conf.d drop-ins sorted by file name (strcmp on the basename) across all search
+// directories, and for a single-value option such as InhibitDelayMaxSec the last file wins. The
+// directory is consulted only to break ties between identical names, so our drop-in in /etc does
+// not automatically beat a vendor drop-in in /usr/lib: it wins only if its name sorts last. If it
+// does not, logind keeps a smaller InhibitDelayMaxSec than we wrote and node shutdown is no longer
+// delayed.
+func TestDropInNameSortsLast(t *testing.T) {
+	// Real drop-ins shipped by Debian/Ubuntu packages and by kubelet itself.
+	competitors := []string{
+		"99-kubelet.conf",                          // kubelet, InhibitDelayMaxSec=<shutdownGracePeriod>
+		"unattended-upgrades-logind-maxdelay.conf", // unattended-upgrades, InhibitDelayMaxSec=30
+		"ec2-hibinit-agent-ignore-powerkey.conf",   // ec2-hibinit-agent
+		"sxmo-utils.conf",                          // sxmo-utils
+		"mobile-tweaks.conf",                       // mobile-tweaks-common
+	}
+
+	for _, name := range competitors {
+		if d8ShutdownInhibitorConf <= name {
+			t.Errorf("drop-in %q does not sort after %q: logind would apply %q last and our InhibitDelayMaxSec would be overridden",
+				d8ShutdownInhibitorConf, name, name)
+		}
+	}
+
+	if !strings.HasSuffix(d8ShutdownInhibitorConf, ".conf") {
+		t.Errorf("drop-in %q must end in .conf or logind ignores it", d8ShutdownInhibitorConf)
+	}
+	if filepath.Base(d8ShutdownInhibitorConf) != d8ShutdownInhibitorConf {
+		t.Errorf("drop-in %q must be a bare file name", d8ShutdownInhibitorConf)
+	}
+}


### PR DESCRIPTION
## Description

Renames the logind drop-in from `99-node-d8-shutdown-inhibitor.conf` to `zz-d8-shutdown-inhibitor.conf`.

systemd sorts `*.conf.d` drop-ins by file name across all search directories and the last assignment wins; the directory only breaks ties between identical names. `unattended-upgrades` ships `/usr/lib/systemd/logind.conf.d/unattended-upgrades-logind-maxdelay.conf` with `InhibitDelayMaxSec=30`, and `'u'` sorts after `'9'`, so it overrode the Deckhouse value. `'z'` sorts after every drop-in shipped into `logind.conf.d` by any Ubuntu noble or Debian bookworm/trixie package, and after kubelet's `99-kubelet.conf`.

Also stops `pkg/app/app.go` from treating a lower-than-requested `InhibitDelayMaxSec` as fatal. That check ran as the first statement of `App.Start()`, so the process died before wiring any task and the unit (`Restart=always`, `RestartSec=10`, `StartLimitInterval=0`) restarted it forever. A lost sort only caps the `mode=delay` shutdown lock — it does not affect the `mode=block` lock on `handle-power-key`, node cordoning, the node condition or `wall` broadcasts — and a restart cannot change the outcome, so it is now a warning and startup continues. Transient failures in the same function (D-Bus connect, property read, file write, logind reload) stay fatal.

`076_install_d8_shutdown_inhibitor.sh.tpl` and `cleanup_static_node.sh.tpl` now remove the drop-in by the glob `*d8-shutdown-inhibitor.conf` so cleanup catches both the new and the legacy name. The legacy file is left in place on running nodes: it sorts before `zz-` and carries the same value.

No impact on running components. The only unit affected is `d8-shutdown-inhibitor.service` on nodes, restarted by the existing `inhibitor-need-restart` bashible flag on image digest change.

## Why do we need it, and what problem does it solve?

On Ubuntu 24.04 and Debian 12/13 with `unattended-upgrades` installed, `d8-shutdown-inhibitor` never started: logind reported 30 s against the requested 72 h and the process exited every 10 seconds. Pods labelled `pod.deckhouse.io/inhibit-node-shutdown` were not protected, the node was not cordoned and the graceful-shutdown node condition was never set. `StartLimitInterval=0` kept the unit out of the failed state, so it did not surface in degraded-unit alerting.

The same collision defeats kubelet's own graceful shutdown on these distributions (`99-kubelet.conf` also sorts before `unattended-upgrades-…`, cf. kubernetes/kubernetes#102818); the rename fixes that as a side effect.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: node-manager
type: fix
summary: Fix d8-shutdown-inhibitor failing to start on nodes where another package overrides the logind inhibit delay.
impact_level: default
```

```changes
section: candi
type: fix
summary: Node cleanup now removes the d8-shutdown-inhibitor logind drop-in under both its current and legacy names.
impact_level: low
```
