### PR TITLE
[deckhouse] Backport: 1.77 - go lint fixes

### DIFF
--- a/deckhouse-controller/internal/packages/deployer/erofs/deployer.go
+++ b/deckhouse-controller/internal/packages/deployer/erofs/deployer.go
@@ -106,7 +106,7 @@ func (d *Deployer) Cleanup(ctx context.Context, preserve []deployer.PreservePack
 	span.SetAttributes(attribute.String("deployed", d.deployedRoot()))
 
 	logger := d.logger.With(
-		slog.String("workingDir", d.workingDir),
+		slog.String("working_dir", d.workingDir),
 		slog.String("deployed", d.deployedRoot()))
 
 	logger.Debug("cleanup packages")
@@ -337,7 +337,7 @@ func (d *Deployer) download(ctx context.Context, repo registry.Remote, packageDi
 	logger := d.logger.With(
 		slog.String("name", name),
 		slog.String("version", version),
-		slog.String("packageDir", packageDir),
+		slog.String("package_dir", packageDir),
 		slog.String("repository", repo.Name),
 		slog.String("registry", repo.Repository))
 
@@ -494,7 +494,7 @@ func (d *Deployer) mount(ctx context.Context, packageDir, deployed, name, versio
 	span.SetAttributes(attribute.String("version", version))
 
 	logger := d.logger.With(
-		slog.String("packageDir", packageDir),
+		slog.String("package_dir", packageDir),
 		slog.String("deployed", deployed),
 		slog.String("name", name),
 		slog.String("version", version))

--- a/deckhouse-controller/internal/packages/deployer/symlink/deployer.go
+++ b/deckhouse-controller/internal/packages/deployer/symlink/deployer.go
@@ -100,7 +100,7 @@ func (d *Deployer) Cleanup(ctx context.Context, preserve []deployer.PreservePack
 	span.SetAttributes(attribute.String("deployed", d.deployedRoot()))
 
 	logger := d.logger.With(
-		slog.String("workingDir", d.workingDir),
+		slog.String("working_dir", d.workingDir),
 		slog.String("deployed", d.deployedRoot()))
 
 	logger.Debug("cleanup packages")
@@ -351,7 +351,7 @@ func (d *Deployer) download(ctx context.Context, repo registry.Remote, packageDi
 	logger := d.logger.With(
 		slog.String("name", name),
 		slog.String("version", version),
-		slog.String("packageDir", packageDir),
+		slog.String("package_dir", packageDir),
 		slog.String("repository", repo.Name),
 		slog.String("registry", repo.Repository))
 
@@ -448,7 +448,7 @@ func (d *Deployer) symlink(ctx context.Context, packageDir, deployed, name, vers
 	span.SetAttributes(attribute.String("version", version))
 
 	logger := d.logger.With(
-		slog.String("packageDir", packageDir),
+		slog.String("package_dir", packageDir),
 		slog.String("deployed", deployed),
 		slog.String("name", name),
 		slog.String("version", version))

--- a/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
@@ -267,7 +267,7 @@ func (r *deckhouseReleaseReconciler) createOrUpdateReconcile(ctx context.Context
 			return res, fmt.Errorf("update: %w", err)
 		}
 
-		return ctrl.Result{Requeue: true}, nil // process to the next phase
+		return ctrl.Result{RequeueAfter: 1 * time.Second}, nil // process to the next phase
 
 	case v1alpha1.DeckhouseReleasePhaseSkipped, v1alpha1.DeckhouseReleasePhaseSuperseded, v1alpha1.DeckhouseReleasePhaseSuspended:
 		r.logger.Debug("release phase", slog.String("phase", dr.Status.Phase))

--- a/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
@@ -217,7 +217,7 @@ func (r *reconciler) handleModuleConfig(ctx context.Context, moduleConfig *v1alp
 	}
 
 	if err := r.refreshModuleConfig(ctx, moduleConfig.Name); err != nil {
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 	}
 
 	module := new(v1alpha1.Module)

--- a/deckhouse-controller/pkg/controller/module-controllers/override/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/override/controller.go
@@ -138,7 +138,7 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			return ctrl.Result{}, nil
 		}
 		r.log.Error("failed to get module pull override", slog.String("name", req.Name), log.Err(err))
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 	}
 
 	// handle delete event
@@ -254,7 +254,7 @@ func (r *reconciler) handleModuleOverride(ctx context.Context, mpo *v1alpha2.Mod
 	source := new(v1alpha1.ModuleSource)
 	if err = r.client.Get(ctx, client.ObjectKey{Name: module.Properties.Source}, source); err != nil {
 		if !apierrors.IsNotFound(err) {
-			r.log.Error("failed to get the module source for the module pull override", slog.String("source", module.Properties.Source), slog.String("target", mpo.Name), log.Err(err))
+			r.log.Error("failed to get the module source for the module pull override", slog.String("module_source", module.Properties.Source), slog.String("target", mpo.Name), log.Err(err))
 			return ctrl.Result{}, fmt.Errorf("get: %w", err)
 		}
 
@@ -415,13 +415,13 @@ func (r *reconciler) deleteModuleOverride(ctx context.Context, mpo *v1alpha2.Mod
 		if err := r.client.Get(ctx, client.ObjectKey{Name: mpo.GetName()}, module); err != nil {
 			if !apierrors.IsNotFound(err) {
 				r.log.Error("failed to get the module", slog.String("name", mpo.GetName()), log.Err(err))
-				return ctrl.Result{Requeue: true}, nil
+				return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 			}
 
 			controllerutil.RemoveFinalizer(mpo, v1alpha1.ModulePullOverrideFinalizer)
 			if err = r.client.Update(ctx, mpo); err != nil {
 				r.log.Error("failed to remove finalizer for the module pull override", slog.String("name", mpo.Name), log.Err(err))
-				return ctrl.Result{Requeue: true}, nil
+				return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 			}
 
 			return ctrl.Result{}, nil
@@ -433,13 +433,13 @@ func (r *reconciler) deleteModuleOverride(ctx context.Context, mpo *v1alpha2.Mod
 		})
 		if err != nil {
 			r.log.Error("failed to update the module status", slog.String("name", mpo.Name), log.Err(err))
-			return ctrl.Result{Requeue: true}, nil
+			return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 		}
 
 		controllerutil.RemoveFinalizer(mpo, v1alpha1.ModulePullOverrideFinalizer)
 		if err = r.client.Update(ctx, mpo); err != nil {
 			r.log.Error("failed to remove finalizer for the module pull override", slog.String("name", mpo.Name), log.Err(err))
-			return ctrl.Result{Requeue: true}, nil
+			return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 		}
 	}
 

--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -269,7 +269,7 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			return ctrl.Result{}, nil
 		}
 		r.log.Error("failed to get module release", slog.String("release", req.Name), log.Err(err))
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 	}
 
 	r.resetConfigurationErrorMetric(release)
@@ -303,7 +303,7 @@ func (r *reconciler) handleRelease(ctx context.Context, release *v1alpha1.Module
 	if err != nil {
 		r.log.Error("failed to update module release before handling", slog.String("release", release.GetName()), log.Err(err))
 
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 	}
 
 	if !res.IsZero() {
@@ -315,9 +315,9 @@ func (r *reconciler) handleRelease(ctx context.Context, release *v1alpha1.Module
 		controllerutil.AddFinalizer(release, v1alpha1.ModuleReleaseFinalizerMetricsRegistered)
 		if err := r.client.Update(ctx, release); err != nil {
 			r.log.Error("failed to add metrics finalizer to module release", slog.String("release", release.GetName()), log.Err(err))
-			return ctrl.Result{Requeue: true}, nil
+			return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 		}
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 	}
 
 	switch release.GetPhase() {
@@ -326,10 +326,10 @@ func (r *reconciler) handleRelease(ctx context.Context, release *v1alpha1.Module
 		release.Status.TransitionTime = metav1.NewTime(r.dependencyContainer.GetClock().Now().UTC())
 		if err = r.client.Status().Update(ctx, release); err != nil {
 			r.log.Error("failed to update module release status", slog.String("release", release.GetName()), log.Err(err))
-			return ctrl.Result{Requeue: true}, nil
+			return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 		}
 		// process to the next phase
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 
 	case v1alpha1.ModuleReleasePhaseSuperseded, v1alpha1.ModuleReleasePhaseSuspended, v1alpha1.ModuleReleasePhaseSkipped:
 		if len(release.Labels) == 0 || (release.Labels[v1alpha1.ModuleReleaseLabelStatus] != strings.ToLower(release.GetPhase())) {
@@ -339,7 +339,7 @@ func (r *reconciler) handleRelease(ctx context.Context, release *v1alpha1.Module
 			release.Labels[v1alpha1.ModuleReleaseLabelStatus] = strings.ToLower(release.GetPhase())
 			if err = r.client.Update(ctx, release); err != nil {
 				r.log.Error("failed to update module release status", slog.String("release", release.GetName()), log.Err(err))
-				return ctrl.Result{Requeue: true}, nil
+				return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 			}
 		}
 
@@ -351,7 +351,7 @@ func (r *reconciler) handleRelease(ctx context.Context, release *v1alpha1.Module
 			r.log.With(
 				slog.String("module_name", release.GetModuleName()),
 				slog.String("release_name", release.GetName()),
-				slog.String("source", release.GetModuleSource()),
+				slog.String("module_source", release.GetModuleSource()),
 			).Debug("result of handle deployed release", log.Err(err))
 
 			return res, err
@@ -364,7 +364,7 @@ func (r *reconciler) handleRelease(ctx context.Context, release *v1alpha1.Module
 	exists, err := utils.ModulePullOverrideExists(ctx, r.client, release.GetModuleName())
 	if err != nil {
 		r.log.Error("failed to get module pull override", slog.String("module", release.GetModuleName()), log.Err(err))
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 	}
 	if exists {
 		r.log.Info("module is overridden, skip release processing", slog.String("module", release.GetModuleName()))
@@ -377,7 +377,7 @@ func (r *reconciler) handleRelease(ctx context.Context, release *v1alpha1.Module
 		r.log.With(
 			slog.String("module_name", release.GetModuleName()),
 			slog.String("release_name", release.GetName()),
-			slog.String("source", release.GetModuleSource()),
+			slog.String("module_source", release.GetModuleSource()),
 		).Debug("result of handle pending release", log.Err(err))
 
 		return res, err
@@ -402,7 +402,7 @@ func (r *reconciler) preHandleCheck(ctx context.Context, release *v1alpha1.Modul
 			return ctrl.Result{}, fmt.Errorf("update with retry: %w", err)
 		}
 
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 	}
 
 	return ctrl.Result{}, nil
@@ -602,7 +602,7 @@ func (r *reconciler) handleDeployedRelease(ctx context.Context, release *v1alpha
 			return res, fmt.Errorf("update module release: %w", err)
 		}
 
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 	}
 
 	if !controllerutil.ContainsFinalizer(source, v1alpha1.ModuleSourceFinalizerReleaseExists) {
@@ -784,7 +784,7 @@ func (r *reconciler) handlePendingRelease(ctx context.Context, release *v1alpha1
 	logger := r.log.With(
 		slog.String("module_name", release.GetModuleName()),
 		slog.String("release_name", release.GetName()),
-		slog.String("source", release.GetModuleSource()),
+		slog.String("module_source", release.GetModuleSource()),
 	)
 
 	logger.Debug("handle pending release")
@@ -1832,7 +1832,7 @@ func (r *reconciler) deleteRelease(ctx context.Context, release *v1alpha1.Module
 			return ctrl.Result{}, fmt.Errorf("update: %w", err)
 		}
 
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 	}
 
 	// The metric is already reset in the handleRelease function, so we can release the finalizer

--- a/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
@@ -201,7 +201,7 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			return ctrl.Result{}, nil
 		}
 		r.logger.Error("failed to get module source", slog.String("name", req.Name), log.Err(err))
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 	}
 
 	// handle delete event
@@ -258,7 +258,7 @@ func (r *reconciler) handleModuleSource(ctx context.Context, source *v1alpha1.Mo
 		}
 		// requeue module source after modifying annotation
 		r.logger.Debug("module source will be requeued", slog.String("source_name", source.Name))
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 	}
 
 	span.AddEvent("fetch tags from the registry")
@@ -362,7 +362,7 @@ func (r *reconciler) processModules(ctx context.Context, source *v1alpha1.Module
 
 		availableModule.Policy = policy.Name
 
-		logger = logger.With(slog.String("release channel", policy.Spec.ReleaseChannel))
+		logger = logger.With(slog.String("release_channel", policy.Spec.ReleaseChannel))
 
 		// create or update module
 		module, err := r.ensureModule(ctx, source.Name, moduleName, policy.Spec.ReleaseChannel)

--- a/deckhouse-controller/pkg/controller/module-controllers/source/module_release_fetcher.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/module_release_fetcher.go
@@ -263,8 +263,8 @@ func (f *ModuleReleaseFetcher) ensureReleases(
 
 	logger.Debug("Checking release channel",
 		slog.String("channel", f.releaseChannel),
-		slog.String("ltsChannel", ltsReleaseChannel),
-		slog.Bool("isLTS", isLTSChannel))
+		slog.String("lts_channel", ltsReleaseChannel),
+		slog.Bool("is_lts", isLTSChannel))
 
 	if isLTSChannel {
 		logger.Debug("LTS channel detected, creating release directly without intermediate versions")

--- a/deckhouse-controller/pkg/controller/objectkeeper/controller.go
+++ b/deckhouse-controller/pkg/controller/objectkeeper/controller.go
@@ -305,8 +305,8 @@ func (r *ObjectKeeperController) reconcileFollowObject(ctx context.Context, obje
 		// Object was recreated with different UID - delete ObjectKeeper
 		r.logger.Info("FollowObject UID mismatch - deleting ObjectKeeper",
 			"objectkeeper", objectkeeper.Name,
-			"expectedUID", ref.UID,
-			"actualUID", objUID)
+			"expected_uid", ref.UID,
+			"actual_uid", objUID)
 		if err := r.Delete(ctx, objectkeeper); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to delete ObjectKeeper: %w", err)
 		}
@@ -502,7 +502,7 @@ func (r *ObjectKeeperController) reconcileFollowObjectWithTTL(ctx context.Contex
 				r.logger.Info("TTL expired - deleting ObjectKeeper",
 					"objectkeeper", objectkeeper.Name,
 					"ttl", objectkeeper.Spec.TTL.Duration.Round(time.Minute),
-					"lostAt", objectkeeper.Status.LostAt,
+					"lost_at", objectkeeper.Status.LostAt,
 					"expired", expiresAt.Format(time.RFC3339))
 				if err := r.Delete(ctx, objectkeeper); err != nil {
 					return ctrl.Result{}, fmt.Errorf("failed to delete ObjectKeeper: %w", err)

--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/controller.go
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/controller.go
@@ -241,7 +241,7 @@ func (r *reconciler) handlePendingState(ctx context.Context, op *v1alpha1.Packag
 		return ctrl.Result{}, fmt.Errorf("update operation status: %w", err)
 	}
 
-	return ctrl.Result{Requeue: true}, nil
+	return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 }
 
 // handleDiscoverState connects to the registry, lists packages, and records them in
@@ -286,7 +286,7 @@ func (r *reconciler) handleDiscoverState(ctx context.Context, op *v1alpha1.Packa
 		return ctrl.Result{}, fmt.Errorf("update operation status: %w", err)
 	}
 
-	return ctrl.Result{Requeue: true}, nil
+	return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 }
 
 // handleProcessingState drains the Discovered queue one package per reconcile.

--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/operation-service.go
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/operation-service.go
@@ -228,7 +228,7 @@ func (s *OperationService) performIncrementalScan(ctx context.Context, packageNa
 	if lastVersion != "" {
 		s.logger.Debug("found last processed version",
 			slog.String("package", packageName),
-			slog.String("lastVersion", lastVersion))
+			slog.String("last_version", lastVersion))
 	}
 
 	tags, err := s.listTagsFromVersion(ctx, packageName, lastVersion)
@@ -284,9 +284,9 @@ func (s *OperationService) listTagsFromVersion(ctx context.Context, packageName 
 	if len(newTags) != len(rawTags) {
 		s.logger.Info("looks like your registry does not support tag listing with filtering by last version",
 			slog.String("package", packageName),
-			slog.String("lastVersion", lastVersion),
-			slog.Int("allTagsCount", len(rawTags)),
-			slog.Int("newTagsCount", len(newTags)))
+			slog.String("last_version", lastVersion),
+			slog.Int("all_tags_count", len(rawTags)),
+			slog.Int("new_tags_count", len(newTags)))
 	}
 
 	return newTags, nil
@@ -626,7 +626,7 @@ type failedVersion struct {
 func (s *OperationService) ensureApplicationPackageVersion(ctx context.Context, packageName, version string) (bool, error) {
 	apvName := v1alpha1.MakeApplicationPackageVersionName(s.repo.Name, packageName, version)
 
-	logger := s.logger.With(slog.String("package version", apvName))
+	logger := s.logger.With(slog.String("package_version", apvName))
 
 	pkgVersion := &v1alpha1.ApplicationPackageVersion{}
 	err := s.client.Get(ctx, types.NamespacedName{Name: apvName}, pkgVersion)

--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/queue.go
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/queue.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"time"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -111,7 +112,7 @@ func (r *reconciler) dequeuePackageWithError(ctx context.Context, op *v1alpha1.P
 	if err := r.client.Status().Patch(ctx, op, client.MergeFrom(original)); err != nil {
 		return ctrl.Result{}, fmt.Errorf("update operation status: %w", err)
 	}
-	return ctrl.Result{Requeue: true}, nil
+	return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 }
 
 // dequeuePackageWithResult removes the head of the Discovered queue and records the
@@ -160,5 +161,5 @@ func (r *reconciler) dequeuePackageWithResult(ctx context.Context, op *v1alpha1.
 	if err := r.client.Status().Patch(ctx, op, client.MergeFrom(original)); err != nil {
 		return ctrl.Result{}, fmt.Errorf("update operation status: %w", err)
 	}
-	return ctrl.Result{Requeue: true}, nil
+	return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 }

--- a/global-hooks/discovery/virtualization_level.go
+++ b/global-hooks/discovery/virtualization_level.go
@@ -76,7 +76,7 @@ func applyMasterNodesFilter(obj *unstructured.Unstructured) (go_hook.FilterResul
 func setGlobalVirtualizationLevel(_ context.Context, input *go_hook.HookInput) error {
 	virtualizationLevel := getVirtualizationLevelFromMasterNodesLabels(input.Snapshots.Get("master_nodes"))
 	input.Values.Set("global.discovery.dvpNestingLevel", virtualizationLevel)
-	input.Logger.Info("set DVP nesting level", slog.Int("level", virtualizationLevel))
+	input.Logger.Info("set DVP nesting level", slog.Int("dvp_nesting_level", virtualizationLevel))
 
 	return nil
 }

--- a/go_lib/dependency/http/http.go
+++ b/go_lib/dependency/http/http.go
@@ -77,7 +77,6 @@ func NewClient(options ...Option) Client {
 		TLSHandshakeTimeout:   5 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 		DialContext:           dialer.DialContext,
-		Dial:                  dialer.Dial,
 	}
 
 	otr := otelhttp.NewTransport(

--- a/testing/controller/testclient/validator.go
+++ b/testing/controller/testclient/validator.go
@@ -81,7 +81,7 @@ func (v *Validator) GetValidatorFor(kind schema.ObjectKind) validation.SchemaVal
 	gvk := kind.GroupVersionKind()
 	gvkValidator := v.validators[gvk]
 	if gvkValidator == nil {
-		v.logger.Debug("validator for gvk not found", slog.Any("gvk", gvk), slog.Any("available validators", slices.Collect(maps.Keys(v.validators))))
+		v.logger.Debug("validator for gvk not found", slog.Any("gvk", gvk), slog.Any("available_validators", slices.Collect(maps.Keys(v.validators))))
 		return nil
 	}
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Backport: #22507

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: chore
summary: fix deckhouse lint
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
