### PR TITLE
[user-authn] Keep Commander older than 1.18 able to grant Kubernetes API access

### DIFF
--- a/modules/150-user-authn/template_tests/validation_test.go
+++ b/modules/150-user-authn/template_tests/validation_test.go
@@ -57,9 +57,11 @@ const (
 	dexAuthenticatorAnnotation = "dexauthenticator.deckhouse.io/allow-access-to-kubernetes"
 
 	deckhouseServiceAccount = "system:serviceaccount:d8-system:deckhouse"
-	// The identity that patches DexClients during cluster bootstrap: a namespace-scoped service
-	// account outside the core namespaces, holding an enumerated Role rather than broad RBAC.
+	// The identity that patches DexClients during cluster bootstrap. Commander charts older
+	// than 1.18 do not hold the allow-access-to-kubernetes subresource, so the policy skips
+	// this service account by name. Nothing else in d8-commander is skipped with it.
 	commanderServiceAccount  = "system:serviceaccount:d8-commander:cluster-manager"
+	commanderBackendAccount  = "system:serviceaccount:d8-commander:backend"
 	kubeSystemServiceAccount = "system:serviceaccount:kube-system:some-controller"
 	tenantServiceAccount     = "system:serviceaccount:attacker-ns:tenant"
 	namespaceEditor          = "editor@example.com"
@@ -132,11 +134,14 @@ var _ = Describe("Module :: user-authn :: helm template :: validation", func() {
 			)
 
 			// The core namespaces have to be excluded, otherwise the gate denies the module charts
-			// that ship an annotated DexAuthenticator. Nothing wider: a namespace prefix must not
-			// confer the authority on whatever runs under it.
+			// that ship an annotated DexAuthenticator. Commander cluster-manager is skipped by
+			// name so charts older than 1.18 keep bootstrapping. Nothing wider: a namespace
+			// prefix must not confer the authority on whatever runs under it.
 			matchConditions := policy.Field("spec.matchConditions").String()
 			Expect(matchConditions).To(ContainSubstring("system:serviceaccounts:d8-system"))
 			Expect(matchConditions).To(ContainSubstring("system:serviceaccounts:kube-system"))
+			Expect(matchConditions).To(ContainSubstring(commanderServiceAccount))
+			Expect(matchConditions).ToNot(ContainSubstring("system:serviceaccounts:d8-commander"))
 			Expect(matchConditions).ToNot(ContainSubstring("startsWith"))
 
 			binding := hec.KubernetesGlobalResource("ValidatingAdmissionPolicyBinding", allowAccessPolicyName)
@@ -211,17 +216,25 @@ var _ = Describe("Module :: user-authn :: helm template :: validation", func() {
 					allowed:     false,
 				},
 				{
-					// A cluster provisioner outside the core namespaces is not exempt: it proves the
-					// authority with the permission, which is what the Commander chart's
-					// cluster-manager Role carries.
-					name:        "cluster provisioner without the permission grants access",
+					// Commander releases older than 1.18 write this annotation and do not hold
+					// the subresource. The policy skips that one service account so those
+					// charts keep working after Deckhouse 1.76.
+					name:        "commander cluster-manager without the permission grants access",
 					username:    commanderServiceAccount,
+					annotations: map[string]string{dexClientAnnotation: "true"},
+					allowed:     true,
+				},
+				{
+					// The skip is the cluster-manager service account, not everyone in
+					// d8-commander. The rest of that namespace still has to prove the grant.
+					name:        "other commander service account without the permission grants access",
+					username:    commanderBackendAccount,
 					annotations: map[string]string{dexClientAnnotation: "true"},
 					allowed:     false,
 				},
 				{
 					name:        "cluster provisioner holding the permission grants access",
-					username:    commanderServiceAccount,
+					username:    "system:serviceaccount:provisioner-ns:controller",
 					canGrant:    true,
 					annotations: map[string]string{dexClientAnnotation: "true"},
 					allowed:     true,

--- a/modules/150-user-authn/templates/validation.yaml
+++ b/modules/150-user-authn/templates/validation.yaml
@@ -50,11 +50,22 @@ spec:
   # prefix: a module from any ModuleSource gets a d8-<module> namespace, and it should have to
   # declare this authority in its own RBAC like any other provisioner rather than inherit it from
   # where it happens to run.
+  #
+  # Commander cluster-manager is the one named exception outside those groups. It has written
+  # DexClient cluster-<uuid> with this annotation since before the gate existed, and Commander
+  # releases older than 1.18 do not carry the allow-access-to-kubernetes subresource on the
+  # cluster-manager Role. The gate shipped in Deckhouse 1.76, so without this skip every
+  # Commander still on <= 1.18 fails bootstrap. The skip is the service account, not the
+  # d8-commander group: backend, sidekiq and the rest of that namespace stay subject to the
+  # gate. Current Commander already declares the subresource; the skip is what keeps the
+  # older charts working until they are upgraded.
   matchConditions:
     - name: 'exclude-groups'
       expression: '!(["system:nodes", "system:serviceaccounts:kube-system", "system:serviceaccounts:d8-system"].exists(e, (e in request.userInfo.groups)))'
     - name: 'exclude-users'
       expression: '!(["system:sudouser", "system:apiserver", "system:kube-controller-manager", "system:kube-scheduler", "system:volume-scheduler", "dhctl", "observability"].exists(e, (e == request.userInfo.username)))'
+    - name: 'exclude-commander-cluster-manager'
+      expression: 'request.userInfo.username != "system:serviceaccount:d8-commander:cluster-manager"'
   variables:
     # The annotation is named after the kind it belongs to, so the key depends on the matched resource.
     - name: annotation


### PR DESCRIPTION
## Description

The `dex-allow-access-to-kubernetes.deckhouse.io` policy skips `system:serviceaccount:d8-commander:cluster-manager`. Other identities in `d8-commander` stay subject to the gate.

## Why do we need it, and what problem does it solve?

The gate shipped in Deckhouse 1.76. Commander charts only gained `create` on `dexclients/allow-access-to-kubernetes` in 1.18. Until those charts are deployed, `cluster-manager` cannot create `DexClient` `cluster-<uuid>` and bootstrap fails.

Skipping the named service account restores older Commanders without opening the whole `d8-commander` namespace. dhctl is already excluded by username and is not the writer of this DexClient.

## Why do we need it in the patch release (if we do)?

Yes. The policy is already in 1.76 and 1.77. Without a backport, every Commander still on ≤ 1.18 fails to bootstrap after those Deckhouse versions.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authn
type: fix
summary: Commander releases older than 1.18 can grant Kubernetes API access on DexClient again.
impact_level: default
```