### PR TITLE
[control-plane-manager] Etcd-backup to use base images

### DIFF
--- a/modules/040-control-plane-manager/images/etcd-backup/entrypoint.sh
+++ b/modules/040-control-plane-manager/images/etcd-backup/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Copyright 2024 Flant JSC
 #

--- a/modules/040-control-plane-manager/images/etcd-backup/entrypoint.sh
+++ b/modules/040-control-plane-manager/images/etcd-backup/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Copyright 2024 Flant JSC
 #

--- a/modules/040-control-plane-manager/images/etcd-backup/werf.inc.yaml
+++ b/modules/040-control-plane-manager/images/etcd-backup/werf.inc.yaml
@@ -36,5 +36,7 @@ final: false
 shell:
   beforeInstall:
   - pm install bash gzip tar gawk gnu-glibc -d /out
-  - ln -sf /bin/bash /out/bin/sh
+  - mkdir -p /out/bin
+  - ln -sf /usr/bin/bash /out/bin/bash
+  - ln -sf /usr/bin/bash /out/bin/sh
 {{- include "vex mitigation" (list $ (printf "%s/%s" $.ModuleName $.ImageName)) }}

--- a/modules/040-control-plane-manager/images/etcd-backup/werf.inc.yaml
+++ b/modules/040-control-plane-manager/images/etcd-backup/werf.inc.yaml
@@ -13,24 +13,6 @@ import:
   add: /etcdctl
   to: /bin/etcdctl
   before: setup
-- from: {{ index $.Images "tools/bash" }}
-  add: /usr/bin/bash
-  to: /bin/bash
-  before: setup
-- from: {{ index $.Images "tools/bash" }}
-  add: /usr/bin/bash
-  to: /bin/sh
-  before: setup
-- from: {{ index $.Images "tools/gawk" }}
-  add: /
-  to: /
-  includePaths:
-  - usr/bin/awk
-  - usr/bin/gawk
-  before: setup
-- from: {{ index $.Images "tools/tar" }}
-  add: /usr/bin/tar
-  before: setup
 - from: {{ index $.Images "tools/coreutils" }}
   add: /
   to: /
@@ -53,5 +35,5 @@ from: {{ index $.Images "builder/distroless" }}
 final: false
 shell:
   beforeInstall:
-  - pm install gzip -d /out
+  - pm install bash gzip tar gawk -d /out
 {{- include "vex mitigation" (list $ (printf "%s/%s" $.ModuleName $.ImageName)) }}

--- a/modules/040-control-plane-manager/images/etcd-backup/werf.inc.yaml
+++ b/modules/040-control-plane-manager/images/etcd-backup/werf.inc.yaml
@@ -1,7 +1,6 @@
-{{- $binaries := "/bin/sh /bin/mv /bin/df /bin/du /bin/tail /bin/awk /bin/tar /bin/gzip /bin/chmod" }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/distroless
+from: {{ index $.Images "base/distroless" }}
 git:
 - add: /{{ $.ModulePath }}/modules/040-{{ $.ModuleName }}/images/{{ $.ImageName }}/entrypoint.sh
   to: /entrypoint.sh
@@ -14,24 +13,45 @@ import:
   add: /etcdctl
   to: /bin/etcdctl
   before: setup
-- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
-  add: /usr/lib/locale/C.utf8
+- from: {{ index $.Images "tools/bash" }}
+  add: /usr/bin/bash
+  to: /bin/bash
+  before: setup
+- from: {{ index $.Images "tools/bash" }}
+  add: /usr/bin/bash
+  to: /bin/sh
+  before: setup
+- from: {{ index $.Images "tools/gawk" }}
+  add: /
+  to: /
+  includePaths:
+  - usr/bin/awk
+  - usr/bin/gawk
+  before: setup
+- from: {{ index $.Images "tools/tar" }}
+  add: /usr/bin/tar
+  before: setup
+- from: {{ index $.Images "tools/coreutils" }}
+  add: /
+  to: /
+  includePaths:
+  - usr/bin/chmod
+  - usr/bin/df
+  - usr/bin/mv
+  - usr/bin/tail
   before: setup
 - image: {{ .ModuleName }}/{{ .ImageName }}-artifact
-  add: /relocate
+  add: /out
   to: /
   before: setup
-shell:
-  setup:
-  - set -e
 imageSpec:
   config:
     entrypoint: ["/entrypoint.sh"]
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
-fromImage: common/relocate-artifact
+from: {{ index $.Images "builder/distroless" }}
 final: false
 shell:
-  install:
-  - /binary_replace.sh -i "{{ $binaries }}" -o /relocate
+  beforeInstall:
+  - pm install gzip -d /out
 {{- include "vex mitigation" (list $ (printf "%s/%s" $.ModuleName $.ImageName)) }}

--- a/modules/040-control-plane-manager/images/etcd-backup/werf.inc.yaml
+++ b/modules/040-control-plane-manager/images/etcd-backup/werf.inc.yaml
@@ -35,5 +35,6 @@ from: {{ index $.Images "builder/distroless" }}
 final: false
 shell:
   beforeInstall:
-  - pm install bash gzip tar gawk -d /out
+  - pm install bash gzip tar gawk gnu-glibc -d /out
+  - ln -sf /bin/bash /out/bin/sh
 {{- include "vex mitigation" (list $ (printf "%s/%s" $.ModuleName $.ImageName)) }}

--- a/modules/040-control-plane-manager/images/etcd-backup/werf.inc.yaml
+++ b/modules/040-control-plane-manager/images/etcd-backup/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
-from: {{ index $.Images "base/distroless" }}
+from: {{ index $.Images "base/distroless-fin" }}
 git:
 - add: /{{ $.ModulePath }}/modules/040-{{ $.ModuleName }}/images/{{ $.ImageName }}/entrypoint.sh
   to: /entrypoint.sh
@@ -13,18 +13,18 @@ import:
   add: /etcdctl
   to: /bin/etcdctl
   before: setup
-- from: {{ index $.Images "tools/coreutils" }}
-  add: /
+- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+  add: /out
+  to: /
+  before: setup
+- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+  add: /coreutils
   to: /
   includePaths:
   - usr/bin/chmod
   - usr/bin/df
   - usr/bin/mv
   - usr/bin/tail
-  before: setup
-- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
-  add: /out
-  to: /
   before: setup
 imageSpec:
   config:
@@ -36,6 +36,7 @@ final: false
 shell:
   beforeInstall:
   - pm install bash gzip tar gawk gnu-glibc -d /out
+  - pm install coreutils -d /coreutils
   - mkdir -p /out/bin
   - ln -sf /usr/bin/bash /out/bin/bash
   - ln -sf /usr/bin/bash /out/bin/sh


### PR DESCRIPTION
## Description
Etcd-backup image now uses `base/distroless-fin`, installing required packages via `pm`.

## Why do we need it, and what problem does it solve?
Need to switch to newer base images.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: chore
summary: Etcd-backup image is now built using newer base images.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
