### PR TITLE
[candi] Fix containerd auth when we use username with dollar symbol

### DIFF
--- a/candi/bashible/common-steps/cluster-bootstrap/020_install_registry_igniter.sh.tpl
+++ b/candi/bashible/common-steps/cluster-bootstrap/020_install_registry_igniter.sh.tpl
@@ -268,8 +268,8 @@ http:
 proxy:
   remoteurl: "{{ .scheme }}://{{ .host }}"
   {{- if .username }}
-  username: {{ .username | quote }}
-  password: {{ .password | quote }}
+  username: {{ .username | quote | replace "$" "\\$" }}
+  password: {{ .password | quote | replace "$" "\\$" }}
   {{- end }}
   remotepathonly: {{ .path | quote }}
   localpathalias: "/system/deckhouse"

--- a/candi/bashible/common-steps/cluster-bootstrap/070_install_registry.sh.tpl
+++ b/candi/bashible/common-steps/cluster-bootstrap/070_install_registry.sh.tpl
@@ -144,8 +144,8 @@ http:
 proxy:
   remoteurl: "{{ .scheme }}://{{ .host }}"
   {{- if .username }}
-  username: {{ .username | quote }}
-  password: {{ .password | quote }}
+  username: {{ .username | quote | replace "$" "\\$" }}
+  password: {{ .password | quote | replace "$" "\\$" }}
   {{- end }}
   remotepathonly: {{ .path | quote }}
   localpathalias: "/system/deckhouse"


### PR DESCRIPTION
## Description
Fix containerd auth when we use username with dollar symbol.

## Why do we need it, and what problem does it solve?
If we use `robot$robot+hello` (such as robot account in Harbor like in our private enviroment guide) - we lose it in auth file and have 401 error

## Why do we need it in the patch release (if we do)?
Cause it's bug

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Fix containerd auth when we use username with dollar symbol
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
