### PR TITLE
fix: changelog by milestone filtering

### DIFF
--- a/.github/workflows/changelog-by-milestone.yml
+++ b/.github/workflows/changelog-by-milestone.yml
@@ -104,7 +104,7 @@ jobs:
             if [[ "$title" =~ ^v([0-9]+)\.([0-9]+)\.[0-9]+$ ]]; then
               branch="release-${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
               if gh api "repos/${{ github.repository }}/branches/${branch}" --silent 2>/dev/null; then
-                filtered="$(echo "$filtered" | jq --argjson m "$milestone" '. + [$m]')"
+                filtered="$(echo "$filtered" | jq -c --argjson m "$milestone" '. + [$m]')"
               else
                 echo "::notice::Skipping milestone ${title}: branch ${branch} does not exist yet"
               fi

--- a/.github/workflows/changelog-by-milestone.yml
+++ b/.github/workflows/changelog-by-milestone.yml
@@ -98,9 +98,24 @@ jobs:
         run: |
           milestones="$(gh api 'repos/${{ github.repository }}/milestones?state=open&per_page=100')"
 
-          count="$(echo $milestones | jq '. | length')"
+          filtered="[]"
+          while IFS= read -r milestone; do
+            title="$(echo "$milestone" | jq -r '.title')"
+            if [[ "$title" =~ ^v([0-9]+)\.([0-9]+)\.[0-9]+$ ]]; then
+              branch="release-${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+              if gh api "repos/${{ github.repository }}/branches/${branch}" --silent 2>/dev/null; then
+                filtered="$(echo "$filtered" | jq --argjson m "$milestone" '. + [$m]')"
+              else
+                echo "::notice::Skipping milestone ${title}: branch ${branch} does not exist yet"
+              fi
+            else
+              echo "::warning::Skipping milestone ${title}: title is not in vX.Y.Z format"
+            fi
+          done < <(echo "$milestones" | jq -c '.[]')
 
-          echo "list=${milestones}" >> $GITHUB_OUTPUT
+          count="$(echo "$filtered" | jq '. | length')"
+
+          echo "list=${filtered}" >> $GITHUB_OUTPUT
           echo "count=${count}" >> $GITHUB_OUTPUT
 
     outputs:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Creating a PR with a changelog fails if there is no cut release branch on the open milestone
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Don't try to create a PR if the release branch doesn't exist.
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Don't try to create a PR if the release branch doesn't exist.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
