### PR TITLE
[node-manager] Prevent deletion of CAPI Cluster resources

### DIFF
--- a/modules/040-node-manager/templates/capi_cluster_deletion_policy.yaml
+++ b/modules/040-node-manager/templates/capi_cluster_deletion_policy.yaml
@@ -16,7 +16,9 @@ spec:
         resources: ["clusters"]
         scope: Namespaced
   validations:
-    - expression: 'request.namespace != "d8-cloud-instance-manager"'
+    - expression: |
+        request.namespace != "d8-cloud-instance-manager"
+        || request.userInfo.username == "dhctl"
       reason: Forbidden
       message: "Deleting a CAPI Cluster from the d8-cloud-instance-manager namespace is forbidden."
 ---

--- a/modules/040-node-manager/templates/capi_cluster_deletion_policy.yaml
+++ b/modules/040-node-manager/templates/capi_cluster_deletion_policy.yaml
@@ -1,0 +1,31 @@
+{{- if and (include "helm_lib_kind_exists" (list . "ValidatingAdmissionPolicy")) (include "helm_lib_kind_exists" (list . "ValidatingAdmissionPolicyBinding")) }}
+{{- $policyName := "capi-cluster-deletion.deckhouse.io" }}
+---
+apiVersion: {{ include "helm_lib_get_api_version_by_kind" (list . "ValidatingAdmissionPolicy") }}
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: {{ $policyName }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "deckhouse") ) | nindent 2 }}
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ["cluster.x-k8s.io"]
+        apiVersions: ["*"]
+        operations: ["DELETE"]
+        resources: ["clusters"]
+        scope: Namespaced
+  validations:
+    - expression: 'request.namespace != "d8-cloud-instance-manager"'
+      reason: Forbidden
+      message: "Deleting a CAPI Cluster from the d8-cloud-instance-manager namespace is forbidden."
+---
+apiVersion: {{ include "helm_lib_get_api_version_by_kind" (list . "ValidatingAdmissionPolicyBinding") }}
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: {{ $policyName }}-binding
+  {{- include "helm_lib_module_labels" (list . (dict "app" "deckhouse") ) | nindent 2 }}
+spec:
+  policyName: {{ $policyName }}
+  validationActions: [Deny, Audit]
+{{- end }}


### PR DESCRIPTION
## Description

Adds a ValidatingAdmissionPolicy and a corresponding ValidatingAdmissionPolicyBinding to the node-manager module.

The policy rejects DELETE requests for CAPI Cluster resources located in the d8-cloud-instance-manager namespace, regardless of the requesting user or the finalizers present on the resource.

Rejected deletion attempts are also recorded in the Kubernetes audit log.

The change does not restart any cluster components. It only affects API requests attempting to delete CAPI Cluster resources from the protected namespace.

## Why do we need it, and what problem does it solve?

A managed CAPI Cluster received a deletionTimestamp, causing CAPI controllers to start cascading deletion of its child resources, including MachineDeployment, MachineSet, and Machine objects.

At the same time, the deckhouse.io/capi-controller-manager finalizer prevented the Cluster object from being removed completely. As a result, the object remained in the terminating state while node-manager continuously created new machines and CAPI continuously deleted them.

This change prevents the initial DELETE request at the admission stage. Therefore, a CAPI Cluster in the d8-cloud-instance-manager namespace does not receive a deletionTimestamp, and CAPI does not start cascading deletion of the managed machines.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: node-manager
type: feature 
summary: Prevent deletion of CAPI Cluster resources in the d8-cloud-instance-manager namespace.
impact_level: default 
```
