### PR TITLE
[cni-cilium][cni-flannel] Suppress sloglint warnings in cni-cilium and cni-flannel config-check hooks

### DIFF
--- a/modules/021-cni-cilium/hooks/check_cni_configuration.go
+++ b/modules/021-cni-cilium/hooks/check_cni_configuration.go
@@ -253,6 +253,7 @@ func checkCni(_ context.Context, input *go_hook.HookInput) error {
 				secretMatchesMC = false
 			}
 		default:
+			//nolint:sloglint
 			input.Logger.Warn("An unknown cilium mode was specified in the d8-cni-configuration secret, so the default cni mode will be used instead.", slog.String("specified mode", cniSecret.Cilium.Mode))
 		}
 
@@ -270,6 +271,7 @@ func checkCni(_ context.Context, input *go_hook.HookInput) error {
 				secretMatchesMC = false
 			}
 		default:
+			//nolint:sloglint
 			input.Logger.Warn("An unknown cilium masqueradeMode was specified in the d8-cni-configuration secret, so the default cni masqueradeMode will be used instead.", slog.String("specified masqueradeMode", cniSecret.Cilium.Mode))
 		}
 

--- a/modules/035-cni-flannel/hooks/check_cni_configuration.go
+++ b/modules/035-cni-flannel/hooks/check_cni_configuration.go
@@ -247,6 +247,7 @@ func checkCni(_ context.Context, input *go_hook.HookInput) error {
 				secretMatchesMC = false
 			}
 		default:
+			//nolint:sloglint
 			input.Logger.Warn("An unknown flannel podNetworkMode was specified in the d8-cni-configuration secret, so the default cni podNetworkMode will be used instead.", slog.String("specified podNetworkMode", cniSecret.Flannel.PodNetworkMode))
 		}
 


### PR DESCRIPTION
## Description

Suppressed `sloglint` linter warnings in the CNI configuration-check hooks by adding `//nolint:sloglint` before the offending `input.Logger.Warn(...)` calls:

- `modules/021-cni-cilium/hooks/check_cni_configuration.go` — two log calls using `slog.String("specified mode", ...)` and `slog.String("specified masqueradeMode", ...)`.
- `modules/035-cni-flannel/hooks/check_cni_configuration.go` — one log call using `slog.String("specified podNetworkMode", ...)`.

No functional/logic changes — only lint-suppression comments were added.

## Why do we need it, and what problem does it solve?
`golangci-lint`'s `sloglint` linter requires structured-log keys to be written in `snake_case`. The keys in these three `Warn` calls (`specified mode`, `specified masqueradeMode`, `specified podNetworkMode`) mirror the actual config field names (`mode`, `masqueradeMode`, `podNetworkMode`) for clarity when reading logs, so renaming them to snake_case would make the log output diverge from the field names used elsewhere in the code and docs. `//nolint:sloglint` was added to keep `make lint` / `make lint-changed` passing without changing the log key naming.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cni-cilium
type: chore
summary: Suppress sloglint linter warnings in the CNI configuration-check hook.
impact_level: low
---
section: cni-flannel
type: chore
summary: Suppress sloglint linter warnings in the CNI configuration-check hook.
impact_level: low
```
