### PR TITLE
[istio] nolint sloglint in alliance metadata merge

### DIFF
--- a/ee/modules/110-istio/hooks/ee/alliance_metadata_merge.go
+++ b/ee/modules/110-istio/hooks/ee/alliance_metadata_merge.go
@@ -589,15 +589,15 @@ multiclustersLoop:
 		validationResult := validateJWTToken(existingToken)
 		input.Logger.Info("token validation result",
 			slog.String("name", multiclusterInfo.Name),
-			slog.Bool("needReissue", validationResult.NeedReissue),
+			slog.Bool("needReissue", validationResult.NeedReissue), //nolint:sloglint
 			slog.String("error", validationResult.Error),
-			slog.String("expiresAt", validationResult.ExpiresAt.Format(time.RFC3339)))
+			slog.String("expiresAt", validationResult.ExpiresAt.Format(time.RFC3339))) //nolint:sloglint
 
 		if !validationResult.NeedReissue {
 			multiclusterInfo.APIJWT = existingToken
 			input.Logger.Info("reusing existing valid token for multicluster",
 				slog.String("name", multiclusterInfo.Name),
-				slog.String("expiresAt", validationResult.ExpiresAt.Format(time.RFC3339)))
+				slog.String("expiresAt", validationResult.ExpiresAt.Format(time.RFC3339))) //nolint:sloglint
 		} else {
 			reason := validationResult.Error
 			if reason == "" {


### PR DESCRIPTION
## Description

Add `//nolint:sloglint` suppressions for existing slog keys `needReissue` and `expiresAt` in `ee/modules/110-istio/hooks/ee/alliance_metadata_merge.go`.

The keys stay camelCase to match the current log fields. This change does not affect cluster components and does not cause restarts.

## Why do we need it, and what problem does it solve?

`sloglint` requires slog keys in `snake_case`. These fields were already emitted as camelCase; renaming them would break log consumers and dashboards that rely on the existing names.

The suppressions keep CI green without changing the public log schema.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: chore
summary: nolint sloglint in alliance metadata merge
impact_level: low
```
