### PR TITLE
[dhctl] Skip telemetry initialization for shell completion

### DIFF
--- a/dhctl/cmd/dhctl/main.go
+++ b/dhctl/cmd/dhctl/main.go
@@ -279,6 +279,10 @@ func registerOnShutdown(title string, action onShutdownFunc) {
 	tomb.RegisterOnShutdown(title, action)
 }
 
+func isCompletionInvocation(args []string) bool {
+	return len(args) > 0 && strings.HasPrefix(args[0], "--completion")
+}
+
 func main() {
 	appContext := context.Background()
 
@@ -286,9 +290,11 @@ func main() {
 
 	initGlobalVars()
 
-	if err := telemetry.Bootstrap(appContext); err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-		os.Exit(1)
+	if !isCompletionInvocation(os.Args[1:]) {
+		if err := telemetry.Bootstrap(appContext); err != nil {
+			fmt.Fprintln(os.Stderr, err.Error())
+			os.Exit(1)
+		}
 	}
 
 	registerOnShutdown("Restore terminal if needed", restoreTerminal())

--- a/dhctl/cmd/dhctl/main.go
+++ b/dhctl/cmd/dhctl/main.go
@@ -279,23 +279,12 @@ func registerOnShutdown(title string, action onShutdownFunc) {
 	tomb.RegisterOnShutdown(title, action)
 }
 
-func isCompletionInvocation(args []string) bool {
-	return len(args) > 0 && strings.HasPrefix(args[0], "--completion")
-}
-
 func main() {
 	appContext := context.Background()
 
 	opts := options.New()
 
 	initGlobalVars()
-
-	if !isCompletionInvocation(os.Args[1:]) {
-		if err := telemetry.Bootstrap(appContext); err != nil {
-			fmt.Fprintln(os.Stderr, err.Error())
-			os.Exit(1)
-		}
-	}
 
 	registerOnShutdown("Restore terminal if needed", restoreTerminal())
 	registerOnShutdown("Leave alternate screen if needed", logger.RestoreTerminal)
@@ -342,6 +331,10 @@ func runApplication(ctx context.Context, kpApp *kingpin.Application, opts *optio
 		return kpcontext.SetContextToAction(
 			providerinitializer.WithKubeAuthMode(ctx, &opts.Kube),
 		)(c)
+	})
+
+	kpApp.Action(func(c *kingpin.ParseContext) error {
+		return telemetry.Bootstrap(kpcontext.ExtractContext(c))
 	})
 
 	kpApp.Action(kptelemetry.StartCommand)

--- a/dhctl/pkg/telemetry/bootstrap.go
+++ b/dhctl/pkg/telemetry/bootstrap.go
@@ -82,7 +82,7 @@ func Bootstrap(ctx context.Context) error {
 		),
 	)
 	if err != nil {
-		dhlog.FromContext(ctx).WarnContext(ctx, strings.TrimRight(fmt.Sprintf("failed to initialize OTel resource completely: %v", err), "\n"))
+		dhlog.FromContext(ctx).DebugContext(ctx, strings.TrimRight(fmt.Sprintf("failed to initialize OTel resource completely: %v", err), "\n"))
 	}
 
 	tracesShutdown := initTraces(tracesExporter, otelResource)

--- a/dhctl/pkg/telemetry/exporters.go
+++ b/dhctl/pkg/telemetry/exporters.go
@@ -96,7 +96,7 @@ func configureLocalExporter(ctx context.Context) (sdktrace.SpanExporter, sdkmetr
 		return nil, nil, nil, fmt.Errorf("failed to initialize trace exporter for %q: %w", traceFileName, err)
 	}
 
-	dhlog.FromContext(ctx).InfoContext(ctx, fmt.Sprintf("Trace file: %s", traceFileName))
+	dhlog.FromContext(ctx).DebugContext(ctx, fmt.Sprintf("Trace file: %s", traceFileName))
 
 	return exporters.Trace, exporters.Metric, exporters.Log, nil
 }


### PR DESCRIPTION
## Description

Skip OpenTelemetry initialization when `dhctl` is invoked internally for shell completion.

Telemetry behavior for regular `dhctl` commands remains unchanged.

## Why do we need it, and what problem does it solve?

When `DHCTL_TRACE` is enabled, every shell completion invocation initializes telemetry. As a result, pressing `Tab` creates unnecessary trace files and prints telemetry-related messages directly into the interactive terminal:

- the trace file path;
- an OpenTelemetry schema conflict warning;
- a missing machine ID warning.

These messages interfere with the command being typed and make shell completion difficult to use.

The change moves telemetry initialization to the execution of a regular Kingpin command action. Shell completion invocations do not execute this action, while regular commands continue to initialize telemetry and produce trace files when `DHCTL_TRACE` is enabled.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist

- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested manually.

## Changelog entries

```changes
section: dhctl
type: fix
summary: Shell completion no longer initializes telemetry when tracing is enabled.
impact_level: low
```