### PR TITLE
[cloud-provider-dvp] Migrate dvp-csi-driver dependencies to Container Factory PM

### DIFF
--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -3935,7 +3935,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:952e32d6731ae0e3a7b6890dd45e4861851c950635ff0e4dba2c1d4165d03869"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:ac408268f0687df0047f1a8df65415e9a10ae3c7a309f4b39f8a41a394c31426"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'
@@ -4050,7 +4050,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run node-controller tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:952e32d6731ae0e3a7b6890dd45e4861851c950635ff0e4dba2c1d4165d03869"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:ac408268f0687df0047f1a8df65415e9a10ae3c7a309f4b39f8a41a394c31426"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -3935,7 +3935,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:ac408268f0687df0047f1a8df65415e9a10ae3c7a309f4b39f8a41a394c31426"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:0a677cc92b4db66476061b464f48d0f7a914419adda6d13f83866aceae8eb4dd"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'
@@ -4050,7 +4050,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run node-controller tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:ac408268f0687df0047f1a8df65415e9a10ae3c7a309f4b39f8a41a394c31426"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:0a677cc92b4db66476061b464f48d0f7a914419adda6d13f83866aceae8eb4dd"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/.github/workflows/build-and-test_main.yml
+++ b/.github/workflows/build-and-test_main.yml
@@ -1281,7 +1281,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:952e32d6731ae0e3a7b6890dd45e4861851c950635ff0e4dba2c1d4165d03869"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:ac408268f0687df0047f1a8df65415e9a10ae3c7a309f4b39f8a41a394c31426"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/.github/workflows/build-and-test_main.yml
+++ b/.github/workflows/build-and-test_main.yml
@@ -1281,7 +1281,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:ac408268f0687df0047f1a8df65415e9a10ae3c7a309f4b39f8a41a394c31426"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:0a677cc92b4db66476061b464f48d0f7a914419adda6d13f83866aceae8eb4dd"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -3563,7 +3563,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:952e32d6731ae0e3a7b6890dd45e4861851c950635ff0e4dba2c1d4165d03869"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:ac408268f0687df0047f1a8df65415e9a10ae3c7a309f4b39f8a41a394c31426"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -3563,7 +3563,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:ac408268f0687df0047f1a8df65415e9a10ae3c7a309f4b39f8a41a394c31426"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:0a677cc92b4db66476061b464f48d0f7a914419adda6d13f83866aceae8eb4dd"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/candi/alt_base_images.yml
+++ b/candi/alt_base_images.yml
@@ -1,10 +1,10 @@
-# version=v2.1.7
+# version=v2.1.9
 REGISTRY_PATH: registry.deckhouse.io/container-factory
-base/distroless-fin: "sha256:612dc6d41604783fb8521ae40cf71207908866d5ad372e22f9902b1ca146b8b1" # from: scratch
-builder/distroless: "sha256:2f256419658a590ecebdd863335fae900b0a153dd08c0fa96ae87e2d3e5d4b5a" # from: scratch
-builder/golang-1.25: "sha256:605bb799560fc4d021ae8f1fc9205c662441bfd0bfaf77da6d5265a240dd0f44" # from: builder/distroless
-builder/golang-1.26: "sha256:952e32d6731ae0e3a7b6890dd45e4861851c950635ff0e4dba2c1d4165d03869" # from: builder/distroless
-builder/golang-1.27: "sha256:18e1d91b1dd5cc798f4f95b13a05eaa117c83aab0a967601c4ccc8a019a0775f" # from: builder/distroless
-builder/golang: "sha256:18e1d91b1dd5cc798f4f95b13a05eaa117c83aab0a967601c4ccc8a019a0775f" # from: builder/distroless
+base/distroless-fin: "sha256:3d7296b21d8e3a9aa40ba089b669a7f25a867f027b9c1c7e735fb0aa86b2b0e1" # from: scratch
+builder/distroless: "sha256:7bedc6b61654282b5a1cc53f10d51f4b7fa195ccb74f3b2b688433dde6927095" # from: scratch
+builder/golang-1.25: "sha256:c29ce9828f9ea15ac5c9b54fbc69ac8c51a53f90b938fdc6cb29deb24ebd514a" # from: builder/distroless
+builder/golang-1.26: "sha256:ac408268f0687df0047f1a8df65415e9a10ae3c7a309f4b39f8a41a394c31426" # from: builder/distroless
+builder/golang-1.27: "sha256:4e3d9e65a4b51eddca36bd854df8094e7052d31637c60f87c814d79ad155f17a" # from: builder/distroless
+builder/golang: "sha256:4e3d9e65a4b51eddca36bd854df8094e7052d31637c60f87c814d79ad155f17a" # from: builder/distroless
 minget-0.1: "sha256:2c4c67ddccd25bdf01ee0bc5ac77ca5eb0b8f826484250cc416fb7b0c47e4283" # from: base/scratch
 minget: "sha256:2c4c67ddccd25bdf01ee0bc5ac77ca5eb0b8f826484250cc416fb7b0c47e4283" # from: base/scratch

--- a/candi/alt_base_images.yml
+++ b/candi/alt_base_images.yml
@@ -1,10 +1,10 @@
-# version=v2.1.9
+# version=v2.1.10
 REGISTRY_PATH: registry.deckhouse.io/container-factory
-base/distroless-fin: "sha256:3d7296b21d8e3a9aa40ba089b669a7f25a867f027b9c1c7e735fb0aa86b2b0e1" # from: scratch
-builder/distroless: "sha256:7bedc6b61654282b5a1cc53f10d51f4b7fa195ccb74f3b2b688433dde6927095" # from: scratch
-builder/golang-1.25: "sha256:c29ce9828f9ea15ac5c9b54fbc69ac8c51a53f90b938fdc6cb29deb24ebd514a" # from: builder/distroless
-builder/golang-1.26: "sha256:ac408268f0687df0047f1a8df65415e9a10ae3c7a309f4b39f8a41a394c31426" # from: builder/distroless
-builder/golang-1.27: "sha256:4e3d9e65a4b51eddca36bd854df8094e7052d31637c60f87c814d79ad155f17a" # from: builder/distroless
-builder/golang: "sha256:4e3d9e65a4b51eddca36bd854df8094e7052d31637c60f87c814d79ad155f17a" # from: builder/distroless
+base/distroless-fin: "sha256:d16c3906c57753e2022cd1301c651527835c8b95029a4733d60e8e8e02af9c4e" # from: scratch
+builder/distroless: "sha256:f1e287571b1470f9114ad72cf4f39239a9794d87deba2320702f45770242d4fa" # from: scratch
+builder/golang-1.25: "sha256:2348e7e4e5e127cb400aa0cdae9f7b92780b3ca39f044076eba8801c020a75c3" # from: builder/distroless
+builder/golang-1.26: "sha256:0a677cc92b4db66476061b464f48d0f7a914419adda6d13f83866aceae8eb4dd" # from: builder/distroless
+builder/golang-1.27: "sha256:2ad9878a6f29b2dbfee7b209469647747fa9b5ef3dc33c1572fc5fa1d90990bb" # from: builder/distroless
+builder/golang: "sha256:2ad9878a6f29b2dbfee7b209469647747fa9b5ef3dc33c1572fc5fa1d90990bb" # from: builder/distroless
 minget-0.1: "sha256:2c4c67ddccd25bdf01ee0bc5ac77ca5eb0b8f826484250cc416fb7b0c47e4283" # from: base/scratch
 minget: "sha256:2c4c67ddccd25bdf01ee0bc5ac77ca5eb0b8f826484250cc416fb7b0c47e4283" # from: base/scratch

--- a/modules/030-cloud-provider-dvp/images/dvp-csi-driver/werf.inc.yaml
+++ b/modules/030-cloud-provider-dvp/images/dvp-csi-driver/werf.inc.yaml
@@ -1,6 +1,6 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/distroless
+from: {{ index $.Images "base/distroless-fin" }}
 import:
 {{- include "image mount points" . }}
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
@@ -8,25 +8,11 @@ import:
   to: /dvp-csi-driver
   before: setup
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
-  add: /relocate
+  add: /out
   to: /
   before: install
   includePaths:
   - '**/*'
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
-  add: /lib64
-  to: /lib64
-  before: install
-  includePaths:
-  - 'libresolv*'
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
-  add: /lib/udev/scsi_id
-  to: /lib/udev/scsi_id
-  before: setup
-- from: {{ index $.Images "tools/util-linux" }}
-  add: /bin/lsblk
-  to: /bin/lsblk
-  before: setup
 imageSpec:
   config:
     entrypoint: ["/dvp-csi-driver"]
@@ -80,14 +66,9 @@ shell:
   - chown 64535:64535 /dvp-csi-driver
   - chmod 0755 /dvp-csi-driver
 ---
-{{- $csiBinaries := "/bin/chmod /bin/mount /bin/mkdir /bin/rmdir /bin/umount /bin/findmnt /sbin/badblocks /sbin/blockdev /sbin/blk* /sbin/btrfs* /sbin/dumpe2fs /sbin/e2* /sbin/findfs /sbin/fsck* /sbin/fsfreeze /sbin/fstrim /sbin/mke2fs /sbin/mkfs* /sbin/resize2fs /sbin/xfs_repair /usr/sbin/nvme /usr/sbin/parted /usr/sbin/xfs*" }}
----
 image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
 final: false
-fromImage: common/relocate-artifact
+from: {{ index $.Images "builder/distroless" }}
 shell:
-  beforeInstall:
-  - apt-get update -y
-  - apt-get install -y e2fsprogs xfsprogs parted btrfs-progs nvme udev
   install:
-    - /binary_replace.sh -i "{{ $csiBinaries }}" -o /relocate
+  - pm install coreutils e2fsprogs xfsprogs util-linux parted nvme-cli btrfs-progs udev libc -d /out


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Migrated the `dvp-csi-driver` runtime dependencies to the Container Factory package manager.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
The `dvp-csi-driver` image previously received filesystem and block-device utilities from ALT-based images and manually relocated binaries and libraries.
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
This changes are required in CSE version
## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-dvp
type: chore
summary: migrated the DVP CSI driver system dependencies to the Container Factory package manager.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
