### PR TITLE
[ci] Fix permissons for importing secrets

### DIFF
--- a/.github/workflow_templates/k8s-autoupdate.yml
+++ b/.github/workflow_templates/k8s-autoupdate.yml
@@ -32,6 +32,9 @@ jobs:
     runs-on: [self-hosted, regular]
     needs:
     - skip_tests_repos
+    permissions:
+      contents: write
+      id-token: write
     steps:
 {!{ tmpl.Exec "checkout_step" . | strings.Indent 4 }!}
 {!{ tmpl.Exec "werf_setup_steps" . | strings.Indent 4 }!}
@@ -40,7 +43,7 @@ jobs:
 {!{ tmpl.Exec "import_secrets" $secrets | strings.Indent 4 }!}
     - uses: {!{ index (ds "actions") "actions/setup-go" }!}
       with:
-        go-version: '1.23.7'
+        go-version: '1.26.7'
         cache: false
     - name: Setup
       id: get_milestone

--- a/.github/workflows/k8s-autoupdate.yml
+++ b/.github/workflows/k8s-autoupdate.yml
@@ -34,6 +34,9 @@ jobs:
     runs-on: [self-hosted, regular]
     needs:
     - skip_tests_repos
+    permissions:
+      contents: write
+      id-token: write
     steps:
 
     # <template: checkout_step>
@@ -117,7 +120,7 @@ jobs:
     # </template: import_secrets>
     - uses: actions/setup-go@v5.4.0
       with:
-        go-version: '1.23.7'
+        go-version: '1.26.7'
         cache: false
     - name: Setup
       id: get_milestone


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix some import secrets issues in k8s-autoupdate job
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Now it is running right and correct. Without fix the job is not able be even send a failure report.
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
None
## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: fix
summary: Fix some import secrets issues in k8s-autoupdate job
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
