### PR TITLE
[istio] limited version in cse

### DIFF
--- a/ee/cse/modules/110-istio/.build.yaml
+++ b/ee/cse/modules/110-istio/.build.yaml
@@ -1,0 +1,1 @@
+openapi/values.yaml

--- a/ee/cse/modules/110-istio/README.md
+++ b/ee/cse/modules/110-istio/README.md
@@ -1,0 +1,7 @@
+# CSE edit
+
+## openapi/values.yaml
+
+1. rm 1.27 in istioToK8sCompatibilityMap.default
+
+2. set kube version list ["1.31", "1.32", "1.33", "1.34"]

--- a/ee/cse/modules/110-istio/openapi/openapi-case-tests.yaml
+++ b/ee/cse/modules/110-istio/openapi/openapi-case-tests.yaml
@@ -1,0 +1,6 @@
+# Test stub. The directory does not contain config-values.yaml, but the tests require a check for all openapi directories.
+positive:
+  configValues:
+  - {}
+  values:
+  - { internal: {} }

--- a/ee/cse/modules/110-istio/openapi/values.yaml
+++ b/ee/cse/modules/110-istio/openapi/values.yaml
@@ -1,0 +1,338 @@
+x-extend:
+  schema: config-values.yaml
+type: object
+properties:
+  registry:
+    type: object
+    default: {}
+    properties:
+      dockercfg:
+        type: string
+  internal:
+    type: object
+    default: {}
+    properties:
+      versionMap:
+        type: object
+        default: {}
+        x-examples:
+          - {"1.25": { "fullVersion": "1.25.2", "revision": "1x25", "imageSuffix": "V1x25x2", "isReady": false, "supportsAmbient": false, "supportsOperator": true } } # must be real
+        additionalProperties:
+          type: object
+          properties:
+            fullVersion:
+              type: string
+              x-examples: ["1.25.2"]
+            revision:
+              type: string
+              x-examples: ["v1x25"]
+            imageSuffix:
+              type: string
+              x-examples: ["V1x25x2"]
+            isReady:
+              type: boolean
+              x-examples: [false]
+            supportsAmbient:
+              type: boolean
+              x-examples: [false]
+            supportsOperator:
+              type: boolean
+              x-examples: [true]
+      kialiSigningKey:
+        type: string
+        x-examples:
+        - "FD9Q24PwNZkg4pV9cxTOV1Se5R0RD1sT"
+      istioToK8sCompatibilityMap:
+        type: object
+        default:
+          "1.21": ["1.31", "1.32", "1.33", "1.34"]
+          "1.25": ["1.31", "1.32", "1.33", "1.34"]
+        additionalProperties:
+          type: array
+          items:
+            type: string
+      deployDexAuthenticator:
+        type: boolean
+        x-examples: [true]
+      ca:
+        type: object
+        default: {}
+        properties:
+          cert:
+            type: string
+            x-examples: ["---CERT PEM---"]
+          key:
+            type: string
+            x-examples: ["---KEY PEM---"]
+          chain:
+            type: string
+            x-examples: ["---CHAIN PEM---"]
+          root:
+            type: string
+            x-examples: ["---ROOT PEM---"]
+      federations:
+        type: array
+        default: []
+        x-examples:
+        - [{"name": "aaa", "clusterUUID": "uuid-aaa", "trustDomain": "bbb", "rootCA": "---ROOT CA---", "spiffeEndpoint": "ccc", "ingressGateways": [{"address": "1.2.3.4", "port": 1234}], "publicServices": [{"hostname": "zzz.xxx.ccc", "ports": [{"name": "ddd", "port": 2345, "protocol": "TCP"}]}]}]
+      federationServiceEntries:
+        type: array
+        default: []
+        x-examples:
+        - [{"name": "zzz-xxx-ccc-a1b2c3d4", "hostname": "zzz.xxx.ccc", "resolution": "STATIC", "ports": [{"name": "ddd", "port": 2345, "protocol": "TCP"}], "endpoints": [{"address": "1.2.3.4", "port": 15443}]}]
+      multiclusters:
+        type: array
+        default: []
+        x-examples:
+        - [{"name": "aaa", "clusterUUID": "uuid-aaa", "spiffeEndpoint": "ccc", "rootCA": "---ROOT CA---", "metadataExporterCA": "---METADATA CA---", "insecureSkipVerify": true, "enableIngressGateway": true, "apiHost": "aaa.sss.ddd", "networkName": "a-b-c-1-2-3", "apiJWT": "aAaA.bBbB.CcCc", "ingressGateways": [{"address": "1.2.3.4", "port": 1234}]}]
+      remotePublicMetadata:
+        type: object
+        default: {}
+        additionalProperties:
+          type: object
+          properties:
+            name:
+              type: string
+            spiffeEndpoint:
+              type: string
+            enableIngressGateway:
+              type: bool
+            apiHost:
+              type: string
+            networkName:
+              type: string
+            apiJWT:
+              type: string
+            ingressGateways:
+              type: array
+              default: []
+              items:
+                type: object
+                properties:
+                  address:
+                    type: string
+                  port:
+                    type: integer
+            public:
+              type: object
+              default: {}
+              properties:
+                clusterUUID:
+                  type: string
+                authnKeyPub:
+                  type: string
+                rootCA:
+                  type: string
+      remoteAuthnKeypair:
+        type: object
+        default: {}
+        properties:
+          pub:
+            type: string
+            x-examples: ["---PUB KEY---"]
+          priv:
+            type: string
+            x-examples: ["---PRIV KEY---"]
+      deprecatedVersions:
+        type: array
+        items:
+          type: object
+          required:
+          - version
+          - alertSeverity
+          properties:
+            version:
+              type: string
+            alertSeverity:
+              type: integer
+              minimum: 1
+              maximum: 9
+        default:
+          - version: "1.21"
+            alertSeverity: 4
+      globalVersion:
+        type: string
+        x-examples: ["1.25"] # must be real
+      isGlobalVersionIstiodReady:
+        type: boolean
+        default: false
+        x-examples: [true]
+      versionsToInstall:
+        type: array
+        items:
+          type: string
+        default: []
+        x-examples:
+        - ["1.25"] # must be real
+      operatorVersionsToInstall:
+        type: array
+        items:
+          type: string
+        default: []
+        x-examples:
+        - ["1.25"] # must be real
+      applicationNamespaces:
+        type: array
+        items:
+          type: string
+        default: []
+        x-examples:
+        - ["myns"]
+      applicationNamespacesToMonitor:
+        type: array
+        items:
+          type: string
+        default: [ ]
+        x-examples:
+          - [ "myns" ]
+      multiclustersNeedIngressGateway:
+        type: boolean
+        default: false
+        x-examples: [true]
+      customCertificateData:
+        type: object
+        properties:
+          tls.crt:
+            type: string
+            x-examples:
+              - plainstring
+          tls.key:
+            type: string
+            x-examples:
+              - plainstring
+          ca.crt:
+            type: string
+            x-examples:
+              - plainstring
+      auth:
+        type: object
+        default: {}
+        properties:
+          password:
+            type: string
+            x-examples: ["p4ssw0rd"]
+      ingressControllers:
+        type: array
+        default: []
+        items:
+          type: object
+          properties:
+            name:
+              type: string
+              x-examples: ["test"]
+            spec:
+              type: object
+              default: {}
+              properties:
+                ingressGatewayClass:
+                  type: string
+                  x-examples: ["istio"]
+                inlet:
+                  type: string
+                  x-examples:  ["HostPort", "LoadBalancer"]
+                networkTopology:
+                  type: object
+                  properties:
+                    numTrustedProxies:
+                      type: integer
+                      x-examples: [2]
+                    proxyProtocol:
+                      type: boolean
+                      x-examples: [true]
+                nodeSelector:
+                  type: object
+                  additionalProperties:
+                    type: string
+                  description: |
+                    The same as the `spec.nodeSelector` pod parameter in Kubernetes.
+
+                    If the parameter is omitted or `false`, it will be determined [automatically](/products/kubernetes-platform/documentation/v1/#advanced-scheduling).
+                tolerations:
+                  type: array
+                  description: |
+                    The same as `spec.tolerations` for the Kubernetes pod.
+
+                    Use [automatic](/products/kubernetes-platform/documentation/v1/#advanced-scheduling) if not specified. Set `false` to turn off automatic.
+                  items:
+                    type: object
+                    properties:
+                      effect:
+                        type: string
+                      key:
+                        type: string
+                      operator:
+                        type: string
+                      tolerationSeconds:
+                        type: integer
+                        format: int64
+                      value:
+                        type: string
+                loadBalancer:
+                  type: object
+                  default: {}
+                  properties:
+                    sourceRanges:
+                      type: array
+                      items:
+                        type: string
+                    annotations:
+                      type: object
+                      additionalProperties: true
+                    loadBalancerClass:
+                      type: string
+                nodePort:
+                  type: object
+                  default: {}
+                  properties:
+                    httpPort:
+                      type: integer
+                    httpsPort:
+                      type: integer
+                hostPort:
+                  type: object
+                  default: {}
+                  properties:
+                    httpPort:
+                      type: integer
+                    httpsPort:
+                      type: integer
+                resourcesRequests:
+                  type: object
+                  default: {}
+                  properties:
+                    mode:
+                      type: string
+                      x-examples: ["VPA", "Static"]
+                    vpa:
+                      type: object
+                      default: {}
+                      properties:
+                        mode:
+                          type: string
+                        cpu:
+                          type: object
+                          default: {}
+                          properties:
+                            max:
+                              type: string
+                              x-examples: ["200m"]
+                            min:
+                              type: string
+                        memory:
+                          type: object
+                          default: {}
+                          properties:
+                            max:
+                              type: string
+                            min:
+                              type: string
+                              x-examples: ["100Mi"]
+                    static:
+                      type: object
+                      default: {}
+                      properties:
+                        cpu:
+                          type: string
+                          x-examples: ["100m"]
+                        memory:
+                          type: string

--- a/tools/build_includes/modules-tests-CSE.yaml
+++ b/tools/build_includes/modules-tests-CSE.yaml
@@ -860,6 +860,11 @@
   stageDependencies:
     install:
         - '**/*'
+- add: /ee/cse/modules/110-istio/openapi/values.yaml
+  to: /deckhouse/modules/110-istio/openapi/values.yaml
+  stageDependencies:
+    install:
+        - '**/*'
 - add: /ee/cse/modules/140-user-authz/openapi/config-values.yaml
   to: /deckhouse/modules/140-user-authz/openapi/config-values.yaml
   stageDependencies:

--- a/tools/build_includes/modules-with-exclude-CSE.yaml
+++ b/tools/build_includes/modules-with-exclude-CSE.yaml
@@ -1275,6 +1275,11 @@
   stageDependencies:
     install:
         - '**/*'
+- add: /ee/cse/modules/110-istio/openapi/values.yaml
+  to: /deckhouse/modules/110-istio/openapi/values.yaml
+  stageDependencies:
+    install:
+        - '**/*'
 - add: /ee/cse/modules/140-user-authz/openapi/config-values.yaml
   to: /deckhouse/modules/140-user-authz/openapi/config-values.yaml
   stageDependencies:


### PR DESCRIPTION
## Description
disable istio 1.27 in CSE
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
The CSE edition should only include Istio versions 1.21 and 1.25.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: chore
summary: limited version in cse
impact: 
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
