### PR TITLE
[istio] enable 1.27 in cse

### DIFF
--- a/modules/110-istio/images/cni-v1x27x9/werf.inc.yaml
+++ b/modules/110-istio/images/cni-v1x27x9/werf.inc.yaml
@@ -1,4 +1,3 @@
-{{- if ne $.Env "CSE" }}
 ---
 {{- $istioVersion := include "get_oss_version_by_id" (list "istio-1-27" $ ) }}
 {{- $istioImageVersion := (printf "v%s" (replace "." "x" $istioVersion)) }} {{- /* 1.27.9 -> v1x27x9 */}}
@@ -107,4 +106,3 @@ shell:
     done
 ---
 {{- include "vex mitigation" (list $ (printf "%s/%s" $.ModuleName $.ImageName)) }}
-{{- end }}

--- a/modules/110-istio/images/common-v1x27x9/werf.inc.yaml
+++ b/modules/110-istio/images/common-v1x27x9/werf.inc.yaml
@@ -1,4 +1,3 @@
-{{- if ne $.Env "CSE" }}
 ---
 {{- $istioVersion := include "get_oss_version_by_id" (list "istio-1-27" $ ) }}
 {{- $kialiVersion := printf "v%s" (include "get_oss_version_by_id" (list "kiali-for-istio-1-27" $ )) }}
@@ -52,4 +51,3 @@ shell:
   - yarn install --frozen-lockfile
   - KIALI_ENV=production yarn run build
   - rm -rf node_modules
-{{- end }}

--- a/modules/110-istio/images/istioctl-v1x27x9/werf.inc.yaml
+++ b/modules/110-istio/images/istioctl-v1x27x9/werf.inc.yaml
@@ -1,4 +1,3 @@
-{{- if ne $.Env "CSE" }}
 ---
 {{- $istioVersion := include "get_oss_version_by_id" (list "istio-1-27" $ ) }}
 {{- $istioImageVersion := (printf "v%s" (replace "." "x" $istioVersion)) }} {{- /* 1.27.9 -> v1x27x9 */}}
@@ -50,4 +49,3 @@ shell:
   - strip /src/istio/out/istioctl
   - chmod 0700 /src/istio/out/istioctl
   - chown 1337:1337 /src/istio/out/istioctl
-{{- end }}

--- a/modules/110-istio/images/kiali-v1x27x9/werf.inc.yaml
+++ b/modules/110-istio/images/kiali-v1x27x9/werf.inc.yaml
@@ -1,4 +1,3 @@
-{{- if ne $.Env "CSE" }}
 ---
 {{- $istioVersion := include "get_oss_version_by_id" (list "istio-1-27" $ ) }}
 {{- $istioImageVersion := (printf "v%s" (replace "." "x" $istioVersion)) }} {{- /* 1.27.9 -> v1x27x9 */}}
@@ -52,4 +51,3 @@ shell:
   - chmod 0755 /src/kiali/out/kiali
 ---
 {{- include "vex mitigation" (list $ (printf "%s/%s" $.ModuleName $.ImageName)) }}
-{{- end }}

--- a/modules/110-istio/images/pilot-v1x27x9/werf.inc.yaml
+++ b/modules/110-istio/images/pilot-v1x27x9/werf.inc.yaml
@@ -1,4 +1,3 @@
-{{- if ne $.Env "CSE" }}
 ---
 {{- $istioVersion := include "get_oss_version_by_id" (list "istio-1-27" $ ) }}
 {{- $istioImageVersion := (printf "v%s" (replace "." "x" $istioVersion)) }} {{- /* 1.27.9 -> v1x27x9 */}}
@@ -64,4 +63,3 @@ shell:
   - chown 64535:64535 /src/istio/out/pilot-discovery
 ---
 {{- include "vex mitigation" (list $ (printf "%s/%s" $.ModuleName $.ImageName)) }}
-{{- end }}

--- a/modules/110-istio/images/proxyv2-v1x27x9/werf.inc.yaml
+++ b/modules/110-istio/images/proxyv2-v1x27x9/werf.inc.yaml
@@ -1,4 +1,3 @@
-{{- if ne $.Env "CSE" }}
 ---
 {{- $istioVersion := include "get_oss_version_by_id" (list "istio-1-27" $ ) }}
 {{- $istioImageVersion := (printf "v%s" (replace "." "x" $istioVersion)) }} {{- /* 1.27.9 -> v1x27x9 */}}
@@ -359,4 +358,3 @@ shell:
   - cd /src/proxy/
 ---
 {{- include "vex mitigation" (list $ (printf "%s/%s" $.ModuleName $.ImageName)) }}
-{{- end }}


### PR DESCRIPTION
## Description
enable build istio 1.27 in cse
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
build istio 1.27 in cse
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: chore
summary: enable 1.27 in cse
impact: 
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
