### PR TITLE
[istio] Refactor proxyv2 image builds

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -808,6 +808,15 @@ updates:
   open-pull-requests-limit: 0
 
 - package-ecosystem: "gomod"
+  directory: "/modules/110-istio/tools"
+  labels:
+  - "type/dependencies"
+  - "status/ok-to-test"
+  schedule:
+    interval: "daily"
+  open-pull-requests-limit: 0
+
+- package-ecosystem: "gomod"
   directory: "/modules/150-user-authn/images/basic-auth-proxy/app"
   labels:
   - "type/dependencies"

--- a/ee/modules/110-istio/images/ztunnel-v1x25x2/werf.inc.yaml
+++ b/ee/modules/110-istio/images/ztunnel-v1x25x2/werf.inc.yaml
@@ -9,16 +9,16 @@ import:
     owner: 1337
     group: 1337
     before: install
-  - from: {{ index $.Images "libs/glibc-v2.41" }}
-    add: /lib64/libc.so.6
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-glibc-artifact
+    add: /out/lib64/libc.so.6
     to: /lib64/libc.so.6
     before: install
-  - from: {{ index $.Images "libs/glibc-v2.41" }}
-    add: /lib64/libm.so.6
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-glibc-artifact
+    add: /out/lib64/libm.so.6
     to: /lib64/libm.so.6
     before: install
-  - from: {{ index $.Images "libs/glibc-v2.41" }}
-    add: /lib64/ld-linux-x86-64.so.2
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-glibc-artifact
+    add: /out/lib64/ld-linux-x86-64.so.2
     to: /lib64/ld-linux-x86-64.so.2
     before: install
   - from: {{ index $.Images "libs/xz-v5.8.1" }}
@@ -81,4 +81,11 @@ git:
 - url: {{ .SOURCE_REPO }}/istio/ztunnel
   tag: {{ $istioVersion }}
   to: /src/ztunnel
+---
+image: {{ $.ModuleName }}/{{ $.ImageName }}-glibc-artifact
+final: false
+from: {{ index $.Images "builder/distroless" }}
+shell:
+  beforeInstall:
+  - pm install libc@2.43 -d /out
 ---

--- a/ee/modules/110-istio/images/ztunnel-v1x27x9/werf.inc.yaml
+++ b/ee/modules/110-istio/images/ztunnel-v1x27x9/werf.inc.yaml
@@ -10,16 +10,16 @@ import:
     owner: 1337
     group: 1337
     before: install
-  - from: {{ index $.Images "libs/glibc-v2.41" }}
-    add: /lib64/libc.so.6
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-glibc-artifact
+    add: /out/lib64/libc.so.6
     to: /lib64/libc.so.6
     before: install
-  - from: {{ index $.Images "libs/glibc-v2.41" }}
-    add: /lib64/libm.so.6
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-glibc-artifact
+    add: /out/lib64/libm.so.6
     to: /lib64/libm.so.6
     before: install
-  - from: {{ index $.Images "libs/glibc-v2.41" }}
-    add: /lib64/ld-linux-x86-64.so.2
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-glibc-artifact
+    add: /out/lib64/ld-linux-x86-64.so.2
     to: /lib64/ld-linux-x86-64.so.2
     before: install
   - from: {{ index $.Images "libs/xz-v5.8.1" }}
@@ -82,5 +82,12 @@ git:
 - url: {{ .SOURCE_REPO }}/istio/ztunnel
   tag: {{ $istioVersion }}
   to: /src/ztunnel
+---
+image: {{ $.ModuleName }}/{{ $.ImageName }}-glibc-artifact
+final: false
+from: {{ index $.Images "builder/distroless" }}
+shell:
+  beforeInstall:
+  - pm install libc@2.43 -d /out
 ---
 {{- end }}

--- a/modules/110-istio/.helmignore
+++ b/modules/110-istio/.helmignore
@@ -5,5 +5,6 @@ enabled
 openapi
 hooks
 images
+tools
 template_tests
 README.md

--- a/modules/110-istio/images/README.md
+++ b/modules/110-istio/images/README.md
@@ -41,38 +41,99 @@
       - templates for envoy bootstrap *(loaded from common-ver artifact)*
 
 ### Building proxy-v1x21x6 image
-  - final image based on `common/alt-p11` image
+  - final image based on `common/distroless` image
     - includes:
-      - package ca-certificates from repo:p11
-      - binaries iptables *(built from src)*
+      - `libc.so.6`, `libm.so.6` and `ld-linux-x86-64.so.2` *(from the `-glibc-artifact` image)*
+      - binaries iptables *(from registrypackages)*
       - binaries pilot-agent *(built from src)*
       - templates for envoy bootstrap *(loaded from common-ver artifact)*
       - binaries envoy *(built from src, see the description below)*
-  - image for build pilot-agent based on `builder/golang-alpine-1.23` image
+  - image for build pilot-agent based on `builder/golang` image
     - includes:
-        - src of istio/proxy *(loaded from fox)*
-        - patches in src of istio for fix CVE
+        - src of istio *(loaded from common-ver artifact)*
         - binaries pilot-agent *(built from src)*
 
 #### Building envoy for proxy-v1x21x6
 
-  - `build-image-artifact` image based on `common/alt-p11-artifact` image
-    - based on `cni-cilium/base-cilium-dev` adapted for the current envoy build (e.g. llvm and bazel versions)
-  - `build-libcxx-artifact` image based on `build-image-artifact` image (for build libcxxabi and libcxx)
-    - This library needs for build envoy. libcxxabi and libcxx from AltLinux:P11 are not compatible with our build.
-    - includes:
-      - src of llvm *(loaded from fox)*
-      - libraries libcxxabi and libcxx *(built from src)*
+  - `build-image-artifact` image based on `builder/golang-bookworm` image
+    - clang 14, lld 14 and libc++ 14 from Debian packages
+    - protoc, the protoc-gen-* plugins and bazel from internal mirrors
   - `build-envoy-artifact` image based on `build-image-artifact` image
     - includes:
       - src of istio/proxy *(loaded from fox)*
-      - libraries libcxxabi and libcxx *(built from src)*
       - build-cache of envoy *(loaded from fox)*
       - build-deps of envoy *(loaded from fox)*
       - some patches:
-        - using the self-built `libcxxabi` and `libcxxx` libraries,
         - in `WORKSPACE` we change `ENVOY_SHA` and `ENVOY_SHA256` which are links to the envoy repository version 1.29.12. Because the original tag is broken.
-        - `BAZEL_LINKOPTS=-lm:-pthread` -> `BAZEL_LINKOPTS=-lm:-lpthread` in `envoy.bazelrc` *(???)*
         - use bazel build options `--config=release` and target `//:envoy`. We found this method in ProwCI in repository istio/proxy. ([Original build job from Istio ProwCI](https://prow.istio.io/view/gs/istio-prow/pr-logs/pull/istio_release-builder/1944/build-warning_release-builder_release-1.21/1837269285437706240))
       - binaries envoy *(built from src)*
 
+  Envoy links libc++ statically, so the final image needs only the three glibc files
+  listed above.
+
+## Envoy bazel inputs: deps and cache
+
+The envoy build has no network access: it always runs `bazel build --nofetch`. Bazel
+gets two prepared inputs from git instead.
+
+|                     | `deps` (`external.tar.gz`)      | `cache` (bazel `--disk_cache`) |
+|---------------------|---------------------------------|--------------------------------|
+| repository          | `istio/envoy-build-deps`        | `istio/envoy-build-cache`      |
+| werf variable       | `$istioProxyDepsRev`            | `$istioProxyCacheRev`          |
+| what it is          | all external repos bazel needs  | compiled build results         |
+| needed for          | correctness                     | speed                          |
+| if missing or stale | the build fails                 | the build is slower            |
+| who makes it        | an engineer, locally (minutes)  | CI (~16 GB RAM, hours)         |
+
+Deps are always prepared. `$buildWithPreparedCache` controls the cache:
+
+- `true` (normal) — the cache is cloned from git to a `tmp_dir` mount, so it does not
+  end up in an image layer.
+- `false` — the build starts with an empty cache and keeps `/tmp/bazel-cache` in the
+  artifact image, so you can export it as a new cache revision.
+
+### Regenerating deps
+
+Do this when the list of external repos changes: a new istio version, a new
+`ENVOY_SHA`, or a patch that touches `WORKSPACE`, `go.mod` or `bazel/`. Also do it
+when CI fails with `fetching repository '@…' is disabled` — the message names the
+missing repo.
+
+```bash
+cd modules/110-istio/tools
+go run ./build-envoy-artifacts -version 1.21.6 -artifact deps -out ~/envoy-artifacts
+```
+
+The tool runs `bazel build --nobuild` in a container (analysis only, nothing is
+compiled) and writes `~/envoy-artifacts/external.tar.gz`. When it finishes it prints
+the branch name to use. Commit the tarball to that branch in
+`istio/envoy-build-deps` with git-lfs and update `$istioProxyDepsRev`.
+
+Two things to check before you commit it: the archive root must be the *contents* of
+`external/`, because the werf file extracts into that directory, and `local_jdk` must
+not be inside, because the build image has no JDK.
+
+Versions that build LLVM from source (1.27.9) also need
+`-source-repo "$SOURCE_REPO"`. That is an ssh remote, so pass a passphraseless key
+with `-ssh-key ~/.ssh/id_ed25519`. Without `-ssh-key` the tool forwards
+`$SSH_AUTH_SOCK`, which is what you need for a key with a passphrase.
+
+### Regenerating the cache
+
+Do this when the toolchain changes: another clang or LLVM version, another bazel
+version, or new flags in `user.bazelrc`. Bazel hashes all of them, so an old cache
+still works but never hits.
+
+1. Set `{{- $buildWithPreparedCache := false }}` in the version's `werf.inc.yaml`.
+2. Run the build in CI. It compiles everything.
+3. Extract `/tmp/bazel-cache` from the `…-build-envoy-artifact` image.
+4. Push it to a new branch in `istio/envoy-build-cache`, update
+   `$istioProxyCacheRev`, and set `$buildWithPreparedCache` back to `true`.
+
+Branch names look like `v<istio-version>-<envoy-commit>-<toolchain>-v<n>`. The
+toolchain is part of the name because the cache depends on it. The helper prints the
+whole name for you, so you only need to build it by hand for a cache made in CI.
+
+Keep the version profiles in `modules/110-istio/tools/build-envoy-artifacts` in sync
+with `$bazelVersion`, `$llvmRev`, `$llvmCacheRev` and the apt lists in these werf
+files. Change them in the same commit.

--- a/modules/110-istio/images/proxyv2-v1x21x6/werf.inc.yaml
+++ b/modules/110-istio/images/proxyv2-v1x21x6/werf.inc.yaml
@@ -1,14 +1,17 @@
 ---
 {{- $istioVersion := include "get_oss_version_by_id" (list "istio-1-21" $ ) }}
 {{- $istioImageVersion := (printf "v%s" (replace "." "x" $istioVersion)) }} {{- /* 1.21.6 -> v1x21x6 */}}
-{{- $istioProxyCacheRev := "v1.21.6-5c3dc559371181d5baa4a7533c36f2370fc97581-alt-v1" }}
-{{- $istioProxyDepsRev := "v1.21.6-5c3dc559371181d5baa4a7533c36f2370fc97581-alt-v1" }}
-{{- $llvmRev := "llvmorg-14.0.6" }}
-{{- $goVersion := "1.23.1" }}
+{{- $istioProxyCacheRev := "v1.21.6-5c3dc559371181d5baa4a7533c36f2370fc97581-bookworm-v1" }}
+{{- $istioProxyDepsRev := "v1.21.6-5c3dc559371181d5baa4a7533c36f2370fc97581-bookworm-v1" }}
 {{- $protocVersion := "22.3" }}
 {{- $bazelVersion := "6.3.2" }}
 {{- $iptables_version := "1.8.9" }}
 {{- $iptables_image_version := $iptables_version | replace "." "-" }}
+#  false - start from an empty bazel disk cache and keep /tmp/bazel-cache in the
+#  build-envoy-artifact image so it can be exported as a new cache revision.
+#  Deps are always prepared: the build runs with --nofetch and never fetches.
+#  See modules/110-istio/images/README.md for the regeneration procedure.
+{{- $buildWithPreparedCache := true }}
 ---
 # Based on https://github.com/istio/istio/blob/1.21.6/docker/Dockerfile.base
 #      and https://github.com/istio/istio/blob/1.21.6/pilot/docker/Dockerfile.proxyv2
@@ -39,18 +42,18 @@ import:
   owner: 1337
   group: 1337
   after: setup
-- from: {{ index $.Images "libs/glibc-v2.41" }}
-  add: /lib64/libm.so.6
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-glibc-artifact
+  add: /out/lib64/libm.so.6
   to: /lib64/libm.so.6
-  after: setup
-- from: {{ index $.Images "libs/glibc-v2.41" }}
-  add: /lib64/libc.so.6
+  before: install
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-glibc-artifact
+  add: /out/lib64/libc.so.6
   to: /lib64/libc.so.6
-  after: setup
-- from: {{ index $.Images "libs/glibc-v2.41" }}
-  add: /lib64/ld-linux-x86-64.so.2
+  before: install
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-glibc-artifact
+  add: /out/lib64/ld-linux-x86-64.so.2
   to: /lib64/ld-linux-x86-64.so.2
-  after: setup
+  before: install
 - image: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
   add: /relocate
   to: /
@@ -156,30 +159,14 @@ import:
   add: /src/proxy
   to: /src/proxy
   before: install
-- image: {{ .ModuleName }}/{{ .ImageName }}-build-libcxx-artifact
-  add: /opt/libcxx
-  to: /opt/libcxx
-  before: install
-- from: {{ index $.Images "libs/glibc-v2.41" }}
-  add: /lib64/libm.so.6
-  to: /lib64/libm.so.6
-  before: install
-- from: {{ index $.Images "libs/glibc-v2.41" }}
-  add: /lib64/libc.so.6
-  to: /lib64/libc.so.6
-  before: install
-- from: {{ index $.Images "libs/glibc-v2.41" }}
-  add: /lib64/ld-linux-x86-64.so.2
-  to: /lib64/ld-linux-x86-64.so.2
-  before: install
 mount:
 {{ include "mount points for golang builds" . }}
 - from: tmp_dir
   to: /root/.cache/bazel
+{{- if $buildWithPreparedCache }}
 - from: tmp_dir
   to: /tmp/bazel-cache
-- from: tmp_dir
-  to: /tmp/bazel-deps
+{{- end }}
 secrets:
 - id: GOPROXY
   value: {{ .GOPROXY }}
@@ -187,65 +174,46 @@ secrets:
   value: {{ .SOURCE_REPO }}
 shell:
   install:
-  - git clone --depth 1 --branch {{ $istioProxyCacheRev }} $(cat /run/secrets/SOURCE_REPO)/istio/envoy-build-cache.git /tmp/bazel-cache
-  - git clone --depth 1 --branch {{ $istioProxyDepsRev }} $(cat /run/secrets/SOURCE_REPO)/istio/envoy-build-deps.git /tmp/bazel-deps
-  #
-  - export GO_VERSION=${GOLANG_VERSION}
+  #envs
+  - export GOROOT=/usr/local/go GOPATH=/go
+  - export PATH=${PATH}:${GOROOT}/bin:${GOPATH}/bin
+  - export GO_VERSION=${GOLANG_VERSION} GOPROXY=$(cat /run/secrets/GOPROXY)
   - export GOOS=linux GOARCH=amd64 CGO_ENABLED=0
-  - export BAZEL_VERSION="6.3.2" USE_BAZEL_VERSION="6.3.2"
+  - export TARGETARCH=amd64 ARCH="x86_64"
+  - export BAZEL_VERSION="{{ $bazelVersion }}" USE_BAZEL_VERSION="{{ $bazelVersion }}"
+  # The upstream 1.21.6 tag of istio/proxy references a broken envoy revision, pin a working one.
   - cd /src/proxy
-  - GOPROXY=$(cat /run/secrets/GOPROXY) go mod download
-  - sed -i '/^build --enable_platform_specific_config/a build --linkopt=-L/opt/libcxx/lib'          envoy.bazelrc
-  - sed -i '/^build --enable_platform_specific_config/a build --linkopt=-Wl,-rpath,/opt/libcxx/lib' envoy.bazelrc
-  - sed -i 's|build:libc++ --action_env=BAZEL_LINKOPTS=-lm:-pthread|build:libc++ --action_env=BAZEL_LINKOPTS=-lm:-lpthread|' envoy.bazelrc
   - sed -i 's|ENVOY_SHA = "94aa5f7f82fb543e7fbc011ea398ac12cc396817"|ENVOY_SHA = "5c3dc559371181d5baa4a7533c36f2370fc97581"|' WORKSPACE
   - sed -i 's|ENVOY_SHA256 = "092784be59d19e99343afc095c1a65eca916b0b3f218d48545a6f0d43cdd5885"|ENVOY_SHA256 = "17f36c4267570e64123e3f08cdf8fc9442634572c5dc87f3f4192d953a4d29bf"|' WORKSPACE
-  #
   - export BAZEL_OUTPUT_BASE=$(bazel info output_base)
+  # deps: always prepared, so the build never needs the network
+  - git lfs install
+  - git clone --depth 1 --branch {{ $istioProxyDepsRev }} $(cat /run/secrets/SOURCE_REPO)/istio/envoy-build-deps.git /tmp/bazel-deps
   - mkdir -p ${BAZEL_OUTPUT_BASE}/external
   - tar -zxf /tmp/bazel-deps/external.tar.gz -C ${BAZEL_OUTPUT_BASE}/external
-  #
-  - bazel build --disk_cache=/tmp/bazel-cache --nofetch --stamp --config=release //:envoy
-  - mkdir /src/proxy/bin
-  - mv /src/proxy/bazel-bin/envoy /src/proxy/bin/
----
-image: {{ .ModuleName }}/{{ .ImageName }}-build-libcxx-artifact
-fromImage: {{ $.ModuleName }}/{{ .ImageName }}-build-image-artifact
-final: false
-import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
-  add: /src/llvm
-  to: /src/llvm
-  before: install
-shell:
-  install:
-  - export CCACHE_DIR="/tmp/ccache-dir"
-  - mkdir -p /opt/libcxx
-  - cd /tmp/
-  - ccache --zero-stats || true
-  - ccache --show-stats -v || true
+  - rm -rf /tmp/bazel-deps
+  # cache: prepared, or empty and kept for export
+  {{- if $buildWithPreparedCache }}
+  - git clone --depth 1 --branch {{ $istioProxyCacheRev }} $(cat /run/secrets/SOURCE_REPO)/istio/envoy-build-cache.git /tmp/bazel-cache
+  - rm -rf /tmp/bazel-cache/.git
+  {{- else }}
+  - mkdir -v -p /tmp/bazel-cache
+  {{- end }}
   - |
-    cmake \
-    -GNinja \
-    -DLLVM_ENABLE_PROJECTS="libcxxabi;libcxx" \
-    -DLLVM_USE_LINKER=lld \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_C_COMPILER=clang \
-    -DCMAKE_CXX_COMPILER=clang++ \
-    -DLLVM_INCLUDE_BENCHMARKS=OFF \
-    -DLLVM_CCACHE_BUILD="ON" \
-    -DLLVM_CCACHE_DIR="/tmp/ccache-dir" \
-    -DLLVM_CCACHE_MAXSIZE="0" \
-    -DCMAKE_INSTALL_PREFIX="/opt/libcxx" /src/llvm/llvm
+    cat >> /src/proxy/user.bazelrc <<'EOF'
+    build --nofetch
+    build --disk_cache=/tmp/bazel-cache
+    build --stamp
+    build --config=release
+    EOF
+  - go mod download
+  - bazel build //:envoy
+  # done while ${BAZEL_OUTPUT_BASE} is still in scope - each werf stage is a
+  # separate shell, so it is empty in setup
+  - mkdir /src/proxy/bin && mv /src/proxy/bazel-bin/envoy /src/proxy/bin/
   setup:
-  - export CCACHE_DIR="/tmp/ccache-dir"
-  - cd /tmp/
-  - ccache --show-stats -v || true
-  - ninja install-cxx install-cxxabi
-  - ccache --show-stats -v || true
-  #
-  - rm -rf /src/llvm
-  - rm -rf /opt/libcxx/include
+  - rm -rf /src/proxy/bazel-bin/envoy
+  - rm -rf /src/proxy/.git
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
 fromImage: common/relocate-artifact
@@ -275,21 +243,23 @@ shell:
 ---
 #=====================================================================================================
 ---
-image: {{ .ModuleName }}/golang-artifact
+image: {{ .ModuleName }}/{{ .ImageName }}-golang-artifact
 from: {{ index $.Images "builder/golang-alpine" }}
 final: false
 ---
 image: {{ $.ModuleName }}/{{ .ImageName }}-build-image-artifact
-from: {{ index $.Images "builder/alt" }}
+from: {{ index $.Images "builder/golang-bookworm" }}
 final: false
 mount:
 {{ include "mount points for golang builds" . }}
-- from: tmp_dir
-  to: /root/.cache/bazel
 import:
-- image: {{ .ModuleName }}/golang-artifact
+- image: {{ .ModuleName }}/{{ .ImageName }}-golang-artifact
   add: /usr/local/go
   to: /usr/local/go
+  before: install
+- image: common/alt-p11-artifact
+  add: /root/.ssh
+  to: /root/.ssh
   before: install
 secrets:
 - id: GOPROXY
@@ -298,38 +268,23 @@ secrets:
   value: {{ .SOURCE_REPO }}
 shell:
   beforeInstall:
-  {{- include "alt packages proxy" . | nindent 2 }}
+  {{- include "debian packages proxy" . | nindent 2 }}
   - export DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC
   - ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime && echo ${TZ} > /etc/timezone
   - |
     apt-get install -y \
-    apt-https curl jq tzdata \
-    ca-certificates bash-completion iproute2 arpd ipset kmod \
-    iptables iptables-ipv6 iptables-nft \
-    coreutils binutils git zip unzip wget mount patch patchelf \
-    make automake autoconf cmake ccache bison flex ninja-build pkg-config \
-    gcc gcc-c++ libstdc++-devel libstdc++-devel-static \
-    glibc glibc-devel glibc-devel-static \
-    python python3 python3-module-pip python3-module-virtualenv \
-    build-essential libtool \
-    libnetfilter_conntrack libnetfilter_conntrack-devel libnfnetlink-devel \
-    libmnl-devel libnftnl-devel elfutils-devel zlib-devel java-1.8.0-openjdk golangci-lint
-  # for debug
-  - apt-get install -y strace vim-console
-  - |
-    apt-get install -y \
-    sudo \
-    libcap-devel libpcap-devel \
-    clang14.0 clang14.0-tools lld14.0 llvm14.0-devel \
-    libcxxabi-devel \
-    libcxx libcxx-static libcxxabi-static lld14.0
+    clang-14 lld-14 \
+    git git-lfs cmake ninja-build \
+    libtool automake autoconf make \
+    curl gnupg lsb-release \
+    python3 python3-pip python3-venv \
+    libc++-14-dev libc++abi-14-dev \
+    libssl-dev libz-dev libunwind-14-dev unzip
   # apt clean
   - apt-get autoclean && apt-get clean
   install:
-  - update-alternatives --install /usr/bin/python python /usr/bin/python3 1
-  - ln -s -f /usr/lib/llvm-14.0/bin/clang /usr/bin/clang
-  - ln -s -f /usr/lib/llvm-14.0/bin/clang++ /usr/bin/clang++
-  - ln -s -f /usr/lib/llvm-14.0/bin/ld.lld /usr/bin/ld.lld
+  - ln -s -f /usr/lib/llvm-14/bin/clang /usr/bin/clang
+  - ln -s -f /usr/lib/llvm-14/bin/clang++ /usr/bin/clang++
   # Install Go
   - export GOROOT=/usr/local/go GOPATH=/go
   - export PATH=${PATH}:${GOROOT}/bin:${GOPATH}/bin
@@ -359,7 +314,7 @@ shell:
   - rm -r /tmp/bazel
 imageSpec:
   config:
-    env: {"GOROOT": "/usr/local/go", "GOPATH": "/go", "PATH": "${PATH}:/usr/local/go/bin:/go/bin", "GOOS": "linux", "GOARCH": "amd64"}
+    env: {"GOROOT": "/usr/local/go", "GOPATH": "/go", "PATH": "${PATH}:${GOROOT}/bin:${GOPATH}/bin", "GOOS": "linux", "GOARCH": "amd64"}
 ---
 #=====================================================================================================
 ---
@@ -377,13 +332,15 @@ secrets:
   value: {{ .SOURCE_REPO }}
 shell:
   install:
-  - git clone --depth 1 --branch {{ $llvmRev }} $(cat /run/secrets/SOURCE_REPO)/llvm/llvm-project.git /src/llvm
-  - rm -r /src/llvm/llvm/utils/git
-  - rm -r /src/llvm/mlir/utils/vscode
-  - rm -r /src/llvm/third-party/benchmark
   - git clone --depth 1 --branch {{ $istioVersion }} $(cat /run/secrets/SOURCE_REPO)/istio/proxy.git /src/proxy
   - cd /src/proxy/
   - git apply --verbose /patches/*.patch
-  - mkdir /src/llvm/third-party/benchmark && touch /src/llvm/third-party/benchmark/placeholder.txt
+---
+image: {{ $.ModuleName }}/{{ $.ImageName }}-glibc-artifact
+final: false
+from: {{ index $.Images "builder/distroless" }}
+shell:
+  beforeInstall:
+  - pm install libc@2.43 -d /out
 ---
 {{- include "vex mitigation" (list $ (printf "%s/%s" $.ModuleName $.ImageName)) }}

--- a/modules/110-istio/images/proxyv2-v1x25x2/werf.inc.yaml
+++ b/modules/110-istio/images/proxyv2-v1x25x2/werf.inc.yaml
@@ -3,12 +3,15 @@
 {{- $istioImageVersion := (printf "v%s" (replace "." "x" $istioVersion)) }} {{- /* 1.25.2 -> v1x25x2 */}}
 {{- $istioProxyCacheRev := "v1.25.2-abc32af61f354196bc8d1a011faf8dacc4dc12d7-v1" }}
 {{- $istioProxyDepsRev := "v1.25.2-abc32af61f354196bc8d1a011faf8dacc4dc12d7-v1" }}
-{{- $llvmRev := "llvmorg-14.0.6" }}
-{{- $goVersion := "1.23.1" }}
 {{- $protocVersion := "22.3" }}
 {{- $bazelVersion := "6.5.0" }}
 {{- $iptables_version := "1.8.9" }}
 {{- $iptables_image_version := $iptables_version | replace "." "-" }}
+#  false - start from an empty bazel disk cache and keep /tmp/bazel-cache in the
+#  build-envoy-artifact image so it can be exported as a new cache revision.
+#  Deps are always prepared: the build runs with --nofetch and never fetches.
+#  See modules/110-istio/images/README.md for the regeneration procedure.
+{{- $buildWithPreparedCache := true }}
 ---
 # Based on https://github.com/istio/istio/blob/1.25.2/docker/Dockerfile.base
 #      and https://github.com/istio/istio/blob/1.25.2/pilot/docker/Dockerfile.proxyv2
@@ -33,16 +36,16 @@ import:
   owner: 1337
   group: 1337
   after: setup
-- from: {{ index $.Images "libs/glibc-v2.41" }}
-  add: /lib64/libc.so.6
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-glibc-artifact
+  add: /out/lib64/libc.so.6
   to: /lib64/libc.so.6
   before: install
-- from: {{ index $.Images "libs/glibc-v2.41" }}
-  add: /lib64/libm.so.6
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-glibc-artifact
+  add: /out/lib64/libm.so.6
   to: /lib64/libm.so.6
   before: install
-- from: {{ index $.Images "libs/glibc-v2.41" }}
-  add: /lib64/ld-linux-x86-64.so.2
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-glibc-artifact
+  add: /out/lib64/ld-linux-x86-64.so.2
   to: /lib64/ld-linux-x86-64.so.2
   before: install
 - image: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
@@ -154,6 +157,12 @@ import:
   before: install
 mount:
 {{ include "mount points for golang builds" . }}
+- from: tmp_dir
+  to: /root/.cache/bazel
+{{- if $buildWithPreparedCache }}
+- from: tmp_dir
+  to: /tmp/bazel-cache
+{{- end }}
 secrets:
 - id: GOPROXY
   value: {{ .GOPROXY }}
@@ -161,32 +170,43 @@ secrets:
   value: {{ .SOURCE_REPO }}
 shell:
   install:
-  - mkdir -p /tmp/bazel-cache
-  - git clone --depth 1 --branch {{ $istioProxyCacheRev }} $(cat /run/secrets/SOURCE_REPO)/istio/envoy-build-cache.git /tmp/bazel-cache
-  - rm -rf /tmp/bazel-cache/.git
-  - mkdir -p /tmp/bazel-deps
-  - git lfs install
-  - git clone --depth 1 --branch {{ $istioProxyDepsRev }} $(cat /run/secrets/SOURCE_REPO)/istio/envoy-build-deps.git /tmp/bazel-deps
-  - rm -rf /tmp/bazel-deps/.git
-
+  #envs
   - export GOROOT=/usr/local/go GOPATH=/go
   - export PATH=${PATH}:${GOROOT}/bin:${GOPATH}/bin
-  - export GO_VERSION=${GOLANG_VERSION}
+  - export GO_VERSION=${GOLANG_VERSION} GOPROXY=$(cat /run/secrets/GOPROXY)
   - export GOOS=linux GOARCH=amd64 CGO_ENABLED=0
   - export TARGETARCH=amd64 ARCH="x86_64"
-  - export BAZEL_VERSION="6.5.0" USE_BAZEL_VERSION="6.5.0"
+  - export BAZEL_VERSION="{{ $bazelVersion }}" USE_BAZEL_VERSION="{{ $bazelVersion }}"
   - cd /src/proxy
-  - GOPROXY=$(cat /run/secrets/GOPROXY) go mod download
   - export BAZEL_OUTPUT_BASE=$(bazel info output_base)
+  # deps: always prepared, so the build never needs the network
+  - git lfs install
+  - git clone --depth 1 --branch {{ $istioProxyDepsRev }} $(cat /run/secrets/SOURCE_REPO)/istio/envoy-build-deps.git /tmp/bazel-deps
   - mkdir -p ${BAZEL_OUTPUT_BASE}/external
   - tar -zxf /tmp/bazel-deps/external.tar.gz -C ${BAZEL_OUTPUT_BASE}/external
   - rm -rf /tmp/bazel-deps
-
-  - bazel build --disk_cache=/tmp/bazel-cache --nofetch --stamp --config=release //:envoy
-  - mkdir /src/proxy/bin
-  - mv /src/proxy/bazel-bin/envoy /src/proxy/bin/
+  # cache: prepared, or empty and kept for export
+  {{- if $buildWithPreparedCache }}
+  - git clone --depth 1 --branch {{ $istioProxyCacheRev }} $(cat /run/secrets/SOURCE_REPO)/istio/envoy-build-cache.git /tmp/bazel-cache
+  - rm -rf /tmp/bazel-cache/.git
+  {{- else }}
+  - mkdir -v -p /tmp/bazel-cache
+  {{- end }}
+  - |
+    cat >> /src/proxy/user.bazelrc <<'EOF'
+    build --nofetch
+    build --disk_cache=/tmp/bazel-cache
+    build --stamp
+    build --config=release
+    EOF
+  - go mod download
+  - bazel build //:envoy
+  # done while ${BAZEL_OUTPUT_BASE} is still in scope - each werf stage is a
+  # separate shell, so it is empty in setup
+  - mkdir /src/proxy/bin && mv /src/proxy/bazel-bin/envoy /src/proxy/bin/
+  setup:
+  - rm -rf /src/proxy/bazel-bin/envoy
   - rm -rf /src/proxy/.git
-  - rm -rf /tmp/bazel-cache
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
 fromImage: common/relocate-artifact
@@ -301,5 +321,12 @@ shell:
   install:
   - git clone --depth 1 --branch {{ $istioVersion }} $(cat /run/secrets/SOURCE_REPO)/istio/proxy.git /src/proxy
   - cd /src/proxy/
+---
+image: {{ $.ModuleName }}/{{ $.ImageName }}-glibc-artifact
+final: false
+from: {{ index $.Images "builder/distroless" }}
+shell:
+  beforeInstall:
+  - pm install libc@2.43 -d /out
 ---
 {{- include "vex mitigation" (list $ (printf "%s/%s" $.ModuleName $.ImageName)) }}

--- a/modules/110-istio/images/proxyv2-v1x27x9/werf.inc.yaml
+++ b/modules/110-istio/images/proxyv2-v1x27x9/werf.inc.yaml
@@ -9,8 +9,11 @@
 {{- $llvmRev := "llvmorg-17.0.6" }}
 {{- $llvmCacheRev := "llvmorg-17.0.6-bookworm-gcc12-v1" }}
 {{- $iptables_image_version := "1.8.9" | replace "." "-" }}
-#  to force manual creation of fresh build cache. If false - /tmp/bazel-cache & /tmp/bazel-deps will stay in build-envoy-artifact image
-{{- $buildWithPreparedCacheAndDeps := true }}
+#  false - start from an empty bazel disk cache and keep /tmp/bazel-cache in the
+#  build-envoy-artifact image so it can be exported as a new cache revision.
+#  Deps are always prepared: the build runs with --nofetch and never fetches.
+#  See modules/110-istio/images/README.md for the regeneration procedure.
+{{- $buildWithPreparedCache := true }}
 #  keep /tmp/ccache-dir in build-image-artifact to export llvm ccache into llvm/llvm-build-cache repo
 {{- $buildWithPreparedLlvmCache := true }}
 ---
@@ -37,16 +40,16 @@ import:
   owner: 1337
   group: 1337
   after: setup
-- from: {{ index $.Images "libs/glibc-v2.41" }}
-  add: /lib64/libc.so.6
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-glibc-artifact
+  add: /out/lib64/libc.so.6
   to: /lib64/libc.so.6
   before: install
-- from: {{ index $.Images "libs/glibc-v2.41" }}
-  add: /lib64/libm.so.6
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-glibc-artifact
+  add: /out/lib64/libm.so.6
   to: /lib64/libm.so.6
   before: install
-- from: {{ index $.Images "libs/glibc-v2.41" }}
-  add: /lib64/ld-linux-x86-64.so.2
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-glibc-artifact
+  add: /out/lib64/ld-linux-x86-64.so.2
   to: /lib64/ld-linux-x86-64.so.2
   before: install
 - image: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
@@ -158,6 +161,12 @@ import:
   before: install
 mount:
 {{ include "mount points for golang builds" . }}
+- from: tmp_dir
+  to: /root/.cache/bazel
+{{- if $buildWithPreparedCache }}
+- from: tmp_dir
+  to: /tmp/bazel-cache
+{{- end }}
 secrets:
 - id: GOPROXY
   value: {{ .GOPROXY }}
@@ -171,26 +180,23 @@ shell:
   - export GO_VERSION=${GOLANG_VERSION} GOPROXY=$(cat /run/secrets/GOPROXY)
   - export GOOS=linux GOARCH=amd64 CGO_ENABLED=0
   - export TARGETARCH=amd64 ARCH="x86_64"
-  # cache
   - cd /src/proxy && export BAZEL_OUTPUT_BASE=$(bazel info output_base)
-  {{- if $buildWithPreparedCacheAndDeps }}
-  - git clone --depth 1 --branch {{ $istioProxyCacheRev }} $(cat /run/secrets/SOURCE_REPO)/istio/envoy-build-cache.git /tmp/bazel-cache
+  # deps: always prepared, so the build never needs the network
   - git lfs install
   - git clone --depth 1 --branch {{ $istioProxyDepsRev }} $(cat /run/secrets/SOURCE_REPO)/istio/envoy-build-deps.git /tmp/bazel-deps
   - mkdir -p ${BAZEL_OUTPUT_BASE}/external
   - tar -zxf /tmp/bazel-deps/external.tar.gz -C ${BAZEL_OUTPUT_BASE}/external
   - rm -rf /tmp/bazel-deps
+  # cache: prepared, or empty and kept for export
+  {{- if $buildWithPreparedCache }}
+  - git clone --depth 1 --branch {{ $istioProxyCacheRev }} $(cat /run/secrets/SOURCE_REPO)/istio/envoy-build-cache.git /tmp/bazel-cache
+  - rm -rf /tmp/bazel-cache/.git
+  {{- else }}
+  - mkdir -v -p /tmp/bazel-cache
+  {{- end }}
   - |
     cat >> /src/proxy/user.bazelrc <<'EOF'
     build --nofetch
-    EOF
-  {{- else }}
-  - mkdir -v -p /tmp/bazel-cache
-  - mkdir -p ${BAZEL_OUTPUT_BASE}/external
-  {{- end }}
-  - cd /src/proxy
-  - |
-    cat >> /src/proxy/user.bazelrc <<'EOF'
     build --disk_cache=/tmp/bazel-cache
     build --linkopt=-L/usr/lib/llvm-16/lib
     build --host_linkopt=-L/usr/lib/llvm-16/lib
@@ -199,12 +205,10 @@ shell:
     EOF
   - go mod download
   - bazel build //:envoy
-  setup:
+  # done while ${BAZEL_OUTPUT_BASE} is still in scope - each werf stage is a
+  # separate shell, so it is empty in setup
   - mkdir /src/proxy/bin && mv /src/proxy/bazel-bin/envoy /src/proxy/bin/
-  {{- if $buildWithPreparedCacheAndDeps }}
-  - rm -rf /tmp/bazel-cache
-  - rm -rf ${BAZEL_OUTPUT_BASE}/external
-  {{- end }}
+  setup:
   - rm -rf /src/proxy/bazel-bin/envoy
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
@@ -358,6 +362,13 @@ shell:
   install:
   - git clone --depth 1 --branch {{ $istioVersion }} $(cat /run/secrets/SOURCE_REPO)/istio/proxy.git /src/proxy
   - cd /src/proxy/
+---
+image: {{ $.ModuleName }}/{{ $.ImageName }}-glibc-artifact
+final: false
+from: {{ index $.Images "builder/distroless" }}
+shell:
+  beforeInstall:
+  - pm install libc@2.43 -d /out
 ---
 {{- include "vex mitigation" (list $ (printf "%s/%s" $.ModuleName $.ImageName)) }}
 {{- end }}

--- a/modules/110-istio/tools/build-envoy-artifacts/main.go
+++ b/modules/110-istio/tools/build-envoy-artifacts/main.go
@@ -1,0 +1,691 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Command build-envoy-artifacts builds the two prepared bazel inputs used by the
+// proxyv2 (envoy) images:
+//
+//	deps   external.tar.gz    -> istio/envoy-build-deps
+//	       All external repositories bazel needs. Required, because the image
+//	       build runs bazel with --nofetch. Fetch only, nothing is compiled.
+//
+//	cache  bazel-cache.tar.gz -> istio/envoy-build-cache
+//	       A filled bazel --disk_cache. Only makes the build faster. Needs a
+//	       full envoy compile: ~16 GB RAM and a few hours.
+//
+// The profiles below must match $bazelVersion, $llvmRev, $llvmCacheRev and the apt
+// lists in modules/110-istio/images/proxyv2-v1xNNxN/werf.inc.yaml. Change both in
+// the same commit, and rebuild the cache when the toolchain changes: bazel hashes
+// the compiler, the bazel version and the build flags.
+//
+// Needs docker. Versions that build LLVM from source also need -source-repo
+// (default $SOURCE_REPO). That is an ssh remote, so pass -ssh-key, or leave it
+// unset to forward your ssh-agent.
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+const (
+	// The container image is builder/golang-bookworm, resolved from
+	// candi/base_images.yml so it always matches what CI builds with.
+	// Anonymous pull works, no credentials needed.
+	baseImagesFile  = "candi/base_images.yml"
+	buildImageKey   = "builder/golang-bookworm"
+	registryPathKey = "REGISTRY_PATH"
+
+	// Bazel downloads with its own embedded JDK, so it needs its own trust store.
+	// The system one is not used.
+	cacertsImage   = "eclipse-temurin:21-jre"
+	cacertsInImage = "/opt/java/openjdk/lib/security/cacerts"
+	// anything smaller than this did not come out of the JDK image
+	minCacertsSize = 1024
+
+	// where -ssh-key is mounted before it is copied to /root/.ssh
+	sshKeyInContainer = "/tmp/ssh-key"
+
+	// used to check that a directory really is the deckhouse checkout
+	rootMarker = "modules/110-istio/images"
+
+	// the container script writes the suggested branch name here
+	branchNameFile = "branch-name"
+)
+
+var aptClang14 = []string{
+	"clang-14", "lld-14",
+	"git", "git-lfs", "cmake", "ninja-build",
+	"libtool", "automake", "autoconf", "make",
+	"curl", "gnupg", "lsb-release",
+	"python3", "python3-pip", "python3-venv",
+	"libc++-14-dev", "libc++abi-14-dev",
+	"libssl-dev", "libz-dev", "libunwind-14-dev", "unzip",
+}
+
+var aptLLVM17Source = []string{
+	"ca-certificates",
+	"git", "git-lfs", "cmake", "ninja-build", "ccache",
+	"build-essential",
+	"libtool", "automake", "autoconf", "make",
+	"curl",
+	"python3", "python3-pip", "python3-venv",
+	"libc++-16-dev", "libc++abi-16-dev",
+	"libssl-dev", "libz-dev", "unzip",
+}
+
+type llvmMode string
+
+const (
+	llvmAPT    llvmMode = "apt"
+	llvmSource llvmMode = "source"
+)
+
+type llvmSpec struct {
+	mode      llvmMode
+	rev       string // source mode: llvm-project tag
+	ccacheRev string // source mode: llvm-build-cache branch seeding the ccache
+	prefix    string
+}
+
+type replacement struct {
+	old, new string
+}
+
+type profile struct {
+	bazel string
+	apt   []string
+	llvm  llvmSpec
+	// toolchain goes into the artifact branch name. The cache is keyed on the
+	// compiler, so the name has to say which one built it.
+	toolchain     string
+	bazelrc       []string
+	workspaceSeds []replacement
+	patches       []string
+}
+
+var profiles = map[string]profile{
+	"1.21.6": {
+		bazel:     "6.3.2",
+		apt:       aptClang14,
+		llvm:      llvmSpec{mode: llvmAPT, prefix: "/usr/lib/llvm-14"},
+		toolchain: "bookworm",
+		// the upstream 1.21.6 tag points to a broken envoy revision
+		workspaceSeds: []replacement{
+			{
+				old: `ENVOY_SHA = "94aa5f7f82fb543e7fbc011ea398ac12cc396817"`,
+				new: `ENVOY_SHA = "5c3dc559371181d5baa4a7533c36f2370fc97581"`,
+			},
+			{
+				old: `ENVOY_SHA256 = "092784be59d19e99343afc095c1a65eca916b0b3f218d48545a6f0d43cdd5885"`,
+				new: `ENVOY_SHA256 = "17f36c4267570e64123e3f08cdf8fc9442634572c5dc87f3f4192d953a4d29bf"`,
+			},
+		},
+		patches: []string{"modules/110-istio/images/proxyv2-v1x21x6/patches/001-go-mod.patch"},
+	},
+	"1.25.2": {
+		bazel:     "6.5.0",
+		apt:       aptClang14,
+		llvm:      llvmSpec{mode: llvmAPT, prefix: "/usr/lib/llvm-14"},
+		toolchain: "bookworm",
+	},
+	"1.27.9": {
+		bazel: "7.7.1",
+		apt:   aptLLVM17Source,
+		llvm: llvmSpec{
+			mode:      llvmSource,
+			rev:       "llvmorg-17.0.6",
+			ccacheRev: "llvmorg-17.0.6-bookworm-gcc12-v1",
+			prefix:    "/usr/lib/llvm-17",
+		},
+		toolchain: "bookworm-llvm17",
+		bazelrc: []string{
+			"build --linkopt=-L/usr/lib/llvm-16/lib",
+			"build --host_linkopt=-L/usr/lib/llvm-16/lib",
+		},
+	},
+}
+
+func knownVersions() []string {
+	versions := make([]string, 0, len(profiles))
+	for v := range profiles {
+		versions = append(versions, v)
+	}
+	sort.Strings(versions)
+	return versions
+}
+
+var safeShellArg = regexp.MustCompile(`^[A-Za-z0-9_@%+=:,./-]+$`)
+
+// shellQuote quotes a string for use in the generated shell script.
+func shellQuote(s string) string {
+	if s == "" {
+		return "''"
+	}
+	if safeShellArg.MatchString(s) {
+		return s
+	}
+	return "'" + strings.ReplaceAll(s, "'", `'"'"'`) + "'"
+}
+
+// looksLikeSSH reports true for ssh:// and for remotes like git@host:path.
+func looksLikeSSH(url string) bool {
+	if url == "" {
+		return false
+	}
+	head, _, _ := strings.Cut(url, "/")
+	return strings.HasPrefix(url, "ssh://") || strings.Contains(head, "@")
+}
+
+// deckhouseRoot finds the checkout with the werf files and the patches.
+func deckhouseRoot(override string) (string, error) {
+	if override != "" {
+		root, err := filepath.Abs(override)
+		if err != nil {
+			return "", err
+		}
+		if _, err := os.Stat(filepath.Join(root, rootMarker)); err != nil {
+			return "", fmt.Errorf("%s does not look like a deckhouse checkout: no %s", root, rootMarker)
+		}
+		return root, nil
+	}
+
+	out, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		return "", errors.New("could not determine the deckhouse root from git; pass -deckhouse-root")
+	}
+	root := strings.TrimSpace(string(out))
+	if _, err := os.Stat(filepath.Join(root, rootMarker)); err != nil {
+		return "", fmt.Errorf("git reports %s, which has no %s; pass -deckhouse-root", root, rootMarker)
+	}
+	return root, nil
+}
+
+// baseImage resolves an image name from candi/base_images.yml into a pullable
+// reference. The file is a flat "name: digest" map with a REGISTRY_PATH key that
+// prefixes every entry, so a line scan is enough and the tool needs no yaml
+// dependency.
+func baseImage(root, key string) (string, error) {
+	path := filepath.Join(root, baseImagesFile)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("reading %s: %w", path, err)
+	}
+
+	var registry, digest string
+	for _, line := range strings.Split(string(data), "\n") {
+		// comments, blanks and any indented line: the map is flat, so an
+		// indented key belongs to something else and must not match.
+		if line == "" || strings.ContainsAny(line[:1], "# \t") {
+			continue
+		}
+		name, value, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		if name != registryPathKey && name != key {
+			continue
+		}
+		value = strings.TrimSpace(value)
+		if i := strings.Index(value, " #"); i >= 0 { // drop the "# from: ..." note
+			value = strings.TrimSpace(value[:i])
+		}
+		value = strings.Trim(value, `"`)
+		if name == registryPathKey {
+			registry = value
+		} else {
+			digest = value
+		}
+	}
+
+	switch {
+	case registry == "":
+		return "", fmt.Errorf("%s has no %s", path, registryPathKey)
+	case digest == "":
+		return "", fmt.Errorf("%s has no %s", path, key)
+	case !strings.HasPrefix(digest, "sha256:"):
+		return "", fmt.Errorf("%s: %s is %q, want a sha256 digest", path, key, digest)
+	}
+	return registry + "@" + digest, nil
+}
+
+type options struct {
+	version    string
+	artifact   string
+	out        string
+	sourceRepo string
+	deps       string
+	sshKey     string
+	bazelRoot  string
+	root       string
+	jobs       int
+	printOnly  bool
+}
+
+// buildScript builds the shell script that runs inside the container.
+func buildScript(o options, p profile, withDeps, withSSHKey bool) string {
+	var s []string
+	add := func(line string) {
+		s = append(s, line)
+	}
+	addf := func(format string, args ...any) {
+		s = append(s, fmt.Sprintf(format, args...))
+	}
+
+	add("set -euxo pipefail")
+	add("export DEBIAN_FRONTEND=noninteractive")
+
+	if withSSHKey {
+		// Copy the key instead of using the mount: ssh refuses a key that is
+		// not owned by the current user, and the mount keeps the host owner.
+		add("mkdir -p /root/.ssh && chmod 700 /root/.ssh")
+		addf("install -m 0600 %s /root/.ssh/id_ci", sshKeyInContainer)
+		add(`printf 'StrictHostKeyChecking accept-new\n' > /root/.ssh/config`)
+		add("export GIT_SSH_COMMAND='ssh -i /root/.ssh/id_ci -o IdentitiesOnly=yes " +
+			"-o StrictHostKeyChecking=accept-new'")
+	}
+
+	add("apt-get update")
+	addf("apt-get install -y --no-install-recommends %s", strings.Join(p.apt, " "))
+
+	if p.llvm.mode == llvmAPT {
+		addf("ln -sf %s/bin/clang   /usr/bin/clang", p.llvm.prefix)
+		addf("ln -sf %s/bin/clang++ /usr/bin/clang++", p.llvm.prefix)
+	} else {
+		// the same LLVM the werf file builds. The shared ccache makes this take
+		// minutes instead of hours.
+		addf("git clone --depth 1 --branch %s %s/llvm/llvm-build-cache.git /tmp/ccache-dir",
+			p.llvm.ccacheRev, o.sourceRepo)
+		add("rm -rf /tmp/ccache-dir/.git")
+		add("export CCACHE_DIR=/tmp/ccache-dir")
+		addf("git clone --depth 1 --branch %s %s/llvm/llvm-project.git /src/llvm",
+			p.llvm.rev, o.sourceRepo)
+		add("mkdir -p /src/llvm/llvm/build")
+		add("cd /src/llvm/llvm/build")
+		add("cmake -G Ninja " +
+			"-DCMAKE_BUILD_TYPE=Release " +
+			`-DLLVM_ENABLE_PROJECTS="clang;lld" ` +
+			`-DLLVM_TARGETS_TO_BUILD="X86" ` +
+			"-DCMAKE_INSTALL_PREFIX=" + p.llvm.prefix + " " +
+			"-DLLVM_INCLUDE_EXAMPLES=OFF -DLLVM_INCLUDE_TESTS=OFF " +
+			"-DLLVM_INCLUDE_BENCHMARKS=OFF " +
+			"-DLLVM_CCACHE_BUILD=ON -DLLVM_CCACHE_DIR=/tmp/ccache-dir " +
+			`-DLLVM_CCACHE_MAXSIZE="0" ..`)
+		add("ninja install")
+		addf("ln -sf %s/bin/clang   /usr/bin/clang", p.llvm.prefix)
+		addf("ln -sf %s/bin/clang++ /usr/bin/clang++", p.llvm.prefix)
+		add("cd / && rm -rf /src/llvm /tmp/ccache-dir")
+	}
+
+	addf("curl -fsSLo /usr/local/bin/bazel "+
+		"https://github.com/bazelbuild/bazel/releases/download/%s/bazel-%s-linux-x86_64",
+		p.bazel, p.bazel)
+	add("chmod +x /usr/local/bin/bazel")
+
+	proxyURL := "https://github.com/istio/proxy.git"
+	if o.sourceRepo != "" {
+		proxyURL = o.sourceRepo + "/istio/proxy.git"
+	}
+	addf("git clone --depth 1 --branch %s %s /src/proxy", o.version, proxyURL)
+	add("cd /src/proxy")
+
+	for _, patch := range p.patches {
+		addf("git apply --verbose /deckhouse/%s", patch)
+	}
+
+	for _, sed := range p.workspaceSeds {
+		addf("sed -i %s WORKSPACE", shellQuote("s|"+sed.old+"|"+sed.new+"|"))
+	}
+
+	// The artifact branch is named after the envoy revision, because that is what
+	// decides the content of both artifacts. Older versions of istio/proxy may not
+	// pin it, so fall back to the istio/proxy commit.
+	add(`ENVOY_SHA="$(sed -n 's/.*ENVOY_SHA *= *"\([0-9a-f]\{40\}\)".*/\1/p' WORKSPACE | head -1)"`)
+	add(`if [ -z "${ENVOY_SHA}" ]; then ENVOY_SHA="$(git rev-parse HEAD)"; fi`)
+	addf(`BRANCH_NAME="v%s-${ENVOY_SHA}-%s-v1"`, o.version, p.toolchain)
+
+	// --nofetch only works when external/ is filled from a deps tarball.
+	// Without it, bazel must be allowed to fetch.
+	var rc []string
+	if withDeps {
+		rc = append(rc, "build --nofetch")
+	}
+	rc = append(rc, "build --disk_cache=/tmp/bazel-cache")
+	rc = append(rc, p.bazelrc...)
+	rc = append(rc, "build --stamp", "build --config=release")
+	addf("cat >> user.bazelrc <<'EOF'\n%s\nEOF", strings.Join(rc, "\n"))
+
+	add("if [ -f /opt/cacerts ]; then\n" +
+		"  cat >> user.bazelrc <<'EOF'\n" +
+		"startup --host_jvm_args=-Djavax.net.ssl.trustStore=/opt/cacerts\n" +
+		"startup --host_jvm_args=-Djavax.net.ssl.trustStorePassword=changeit\n" +
+		"EOF\n" +
+		"fi")
+
+	add("export GOOS=linux GOARCH=amd64 CGO_ENABLED=0")
+	addf("export BAZEL_VERSION=%s USE_BAZEL_VERSION=%s", p.bazel, p.bazel)
+	add("go mod download")
+
+	if withDeps {
+		// same as the werf file: fill external/ so --nofetch works
+		add(`export BAZEL_OUTPUT_BASE="$(bazel info output_base)"`)
+		add(`mkdir -p "${BAZEL_OUTPUT_BASE}/external"`)
+		addf(`tar -zxf /deps/%s -C "${BAZEL_OUTPUT_BASE}/external"`,
+			shellQuote(filepath.Base(o.deps)))
+	}
+
+	jobsFlag := ""
+	if o.jobs > 0 {
+		jobsFlag = fmt.Sprintf(" --jobs=%d", o.jobs)
+	}
+	if o.artifact == "deps" {
+		// analysis only: fetches the repositories, compiles nothing
+		addf("bazel build --nobuild%s //:envoy", jobsFlag)
+		// local_jdk points at the JDK in this helper's build container. CI has no
+		// JDK, so carrying this generated repository into the prepared deps is
+		// both useless and potentially misleading.
+		add(`EXTERNAL_DIR="$(bazel info output_base)/external"`)
+		add(`rm -rf "${EXTERNAL_DIR}/local_jdk" "${EXTERNAL_DIR}/@local_jdk.marker"`)
+		add(`if find "${EXTERNAL_DIR}" -maxdepth 1 -iname '*local_jdk*' | grep -q .; then ` +
+			`echo "local_jdk entries remain after cleanup; refusing to create the archive" >&2; exit 1; fi`)
+		add(`tar -czf /out/external.tar.gz -C "${EXTERNAL_DIR}" .`)
+		add("ls -lh /out/external.tar.gz")
+		addf(`printf '%%s\n' "${BRANCH_NAME}" > /out/%s`, branchNameFile)
+	} else {
+		addf("bazel build%s //:envoy", jobsFlag)
+		add("tar -czf /out/bazel-cache.tar.gz -C /tmp/bazel-cache .")
+		add("ls -lh /out/bazel-cache.tar.gz")
+		addf(`printf '%%s\n' "${BRANCH_NAME}" > /out/%s`, branchNameFile)
+	}
+
+	return strings.Join(s, "\n") + "\n"
+}
+
+// werfDir returns the image directory for a version: 1.21.6 -> proxyv2-v1x21x6.
+func werfDir(version string) string {
+	return "proxyv2-v" + strings.ReplaceAll(version, ".", "x")
+}
+
+// printNextSteps says where the tarball is and what to do with it.
+func printNextSteps(o options, out string) {
+	tarball, repo, revVar := "external.tar.gz", "istio/envoy-build-deps", "$istioProxyDepsRev"
+	if o.artifact == "cache" {
+		tarball, repo, revVar = "bazel-cache.tar.gz", "istio/envoy-build-cache", "$istioProxyCacheRev"
+	}
+
+	nameFile := filepath.Join(out, branchNameFile)
+	name, err := os.ReadFile(nameFile)
+	if err != nil {
+		return
+	}
+	_ = os.Remove(nameFile)
+
+	branch := strings.TrimSpace(string(name))
+	artifactPath := filepath.Join(out, tarball)
+	if o.artifact == "cache" {
+		fmt.Fprintf(os.Stderr, `
+==> %s
+
+    Create branch %s in %s, then extract the archive at the repository root:
+
+        tar -xzf %s
+
+    Commit the extracted cache directories (not bazel-cache.tar.gz itself).
+    Add -v2, -v3 and so on if that branch already exists. Then set %s
+    to the branch name in modules/110-istio/images/%s/werf.inc.yaml.
+`, artifactPath, branch, repo, shellQuote(artifactPath), revVar, werfDir(o.version))
+		return
+	}
+
+	fmt.Fprintf(os.Stderr, `
+==> %s
+
+    Push it to %s as branch:
+
+        %s
+
+    Add -v2, -v3 and so on if that branch already exists. Then set %s
+    to the branch name in modules/110-istio/images/%s/werf.inc.yaml.
+`, artifactPath, repo, branch, revVar, werfDir(o.version))
+}
+
+// extractCacerts writes a JDK trust store to path if it is not there yet. A
+// leftover file from an interrupted run is re-extracted rather than trusted.
+func extractCacerts(path string) error {
+	if info, err := os.Stat(path); err == nil && info.Size() >= minCacertsSize {
+		return nil
+	}
+
+	fmt.Fprintf(os.Stderr, "==> extracting a JDK trust store from %s\n", cacertsImage)
+	fh, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer fh.Close()
+
+	cmd := exec.Command("docker", "run", "--rm", cacertsImage, "cat", cacertsInImage)
+	cmd.Stdout = fh
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("extracting %s from %s: %w", cacertsInImage, cacertsImage, err)
+	}
+
+	info, err := fh.Stat()
+	if err != nil {
+		return err
+	}
+	if info.Size() < minCacertsSize {
+		return errors.New("extracted trust store looks empty; refusing to continue")
+	}
+	return nil
+}
+
+func expandUser(path string) (string, error) {
+	if path == "~" || strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		path = filepath.Join(home, strings.TrimPrefix(path, "~"))
+	}
+	return filepath.Abs(path)
+}
+
+func usage() {
+	fmt.Fprintf(os.Stderr, `Usage: go run ./build-envoy-artifacts [flags]
+
+Builds the prepared bazel inputs used by the proxyv2 (envoy) images:
+
+  deps   external.tar.gz -> istio/envoy-build-deps. All external repositories
+         bazel needs. Fetch only, nothing is compiled.
+  cache  bazel-cache.tar.gz -> istio/envoy-build-cache. A filled bazel
+         --disk_cache. Needs a full envoy compile: ~16 GB RAM and a few hours.
+
+Run it from modules/110-istio/tools. Needs docker.
+
+Examples:
+  go run ./build-envoy-artifacts -version 1.21.6 -artifact deps
+  go run ./build-envoy-artifacts -version 1.27.9 -artifact deps \
+      -source-repo "$SOURCE_REPO" -ssh-key ~/.ssh/id_ed25519
+  go run ./build-envoy-artifacts -version 1.27.9 -artifact cache \
+      -deps ./out/external.tar.gz -source-repo "$SOURCE_REPO" -jobs 8
+  go run ./build-envoy-artifacts -version 1.25.2 -artifact deps -print-script
+
+Flags:
+`)
+	flag.PrintDefaults()
+}
+
+func run() error {
+	var o options
+	flag.StringVar(&o.version, "version", "",
+		"istio version to build artifacts for, one of "+strings.Join(knownVersions(), ", "))
+	flag.StringVar(&o.artifact, "artifact", "",
+		"deps: fetch only, cheap. cache: full envoy compile, needs ~16 GB RAM")
+	flag.StringVar(&o.out, "out", "./out", "host directory for the tarball")
+	flag.StringVar(&o.sourceRepo, "source-repo", os.Getenv("SOURCE_REPO"),
+		"internal mirror base (default $SOURCE_REPO). Needed when LLVM is built from source.")
+	flag.StringVar(&o.deps, "deps", "",
+		"external.tar.gz to fill external/ before the build. Turns on --nofetch, "+
+			"so the build works like CI. Use it with -artifact cache.")
+	flag.StringVar(&o.sshKey, "ssh-key", "",
+		"key for the internal mirrors, e.g. ~/.ssh/id_ed25519. It must have no "+
+			"passphrase. Leave it unset to forward your ssh-agent instead.")
+	flag.StringVar(&o.bazelRoot, "bazel-root", "./bazel-root",
+		"host directory for bazel's output base. It grows to tens of GB.")
+	flag.StringVar(&o.root, "deckhouse-root", "",
+		"deckhouse checkout to mount, read patches from and resolve the build image "+
+			"in "+baseImagesFile+" (default: git rev-parse --show-toplevel)")
+	flag.IntVar(&o.jobs, "jobs", 0, "bazel --jobs, use it to limit memory on a cache build")
+	flag.BoolVar(&o.printOnly, "print-script", false,
+		"print the container script and exit, running nothing")
+	flag.Usage = usage
+	flag.Parse()
+
+	p, ok := profiles[o.version]
+	if !ok {
+		return fmt.Errorf("-version: want one of %s, got %q",
+			strings.Join(knownVersions(), ", "), o.version)
+	}
+	if o.artifact != "deps" && o.artifact != "cache" {
+		return fmt.Errorf(`-artifact: want "deps" or "cache", got %q`, o.artifact)
+	}
+	if p.llvm.mode == llvmSource && o.sourceRepo == "" {
+		return fmt.Errorf("istio %s builds LLVM from source; pass -source-repo (or set $SOURCE_REPO)",
+			o.version)
+	}
+	if o.deps != "" && o.artifact == "deps" {
+		return errors.New("-deps makes no sense with -artifact deps")
+	}
+	if o.deps != "" {
+		if _, err := os.Stat(o.deps); err != nil {
+			return fmt.Errorf("-deps: %w", err)
+		}
+	}
+	if o.artifact == "cache" && o.deps == "" {
+		fmt.Fprintln(os.Stderr, "WARNING: no -deps given, so this build may fetch from "+
+			"the network, unlike CI")
+	}
+	if o.sshKey != "" {
+		key, err := expandUser(o.sshKey)
+		if err != nil {
+			return fmt.Errorf("-ssh-key: %w", err)
+		}
+		if _, err := os.Stat(key); err != nil {
+			return fmt.Errorf("-ssh-key: %w", err)
+		}
+		o.sshKey = key
+	}
+
+	agentSock := os.Getenv("SSH_AUTH_SOCK")
+	if looksLikeSSH(o.sourceRepo) && o.sshKey == "" && agentSock == "" {
+		fmt.Fprintf(os.Stderr, "WARNING: -source-repo %s looks like an ssh remote, but "+
+			"there is no -ssh-key and no $SSH_AUTH_SOCK, so clones will fail\n",
+			o.sourceRepo)
+	}
+
+	script := buildScript(o, p, o.deps != "", o.sshKey != "")
+	if o.printOnly {
+		fmt.Print(script)
+		return nil
+	}
+
+	root, err := deckhouseRoot(o.root)
+	if err != nil {
+		return err
+	}
+
+	out, err := filepath.Abs(o.out)
+	if err != nil {
+		return err
+	}
+	bazelRoot, err := filepath.Abs(o.bazelRoot)
+	if err != nil {
+		return err
+	}
+	for _, dir := range []string{out, bazelRoot} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return err
+		}
+	}
+
+	cacerts := filepath.Join(out, "cacerts")
+	if err := extractCacerts(cacerts); err != nil {
+		return err
+	}
+
+	args := []string{
+		"run", "--rm", "-i",
+		"-v", out + ":/out",
+		"-v", bazelRoot + ":/root/.cache/bazel",
+		"-v", cacerts + ":/opt/cacerts:ro",
+		"-v", root + ":/deckhouse:ro",
+	}
+	if o.deps != "" {
+		deps, err := filepath.Abs(o.deps)
+		if err != nil {
+			return err
+		}
+		args = append(args, "-v", filepath.Dir(deps)+":/deps:ro")
+	}
+	if o.sshKey != "" {
+		args = append(args, "-v", o.sshKey+":"+sshKeyInContainer+":ro")
+	} else if agentSock != "" {
+		// no key given: forward the caller's ssh-agent. This does not work on
+		// Docker Desktop, where the host socket cannot be mounted.
+		args = append(args, "-v", agentSock+":"+agentSock, "-e", "SSH_AUTH_SOCK="+agentSock)
+	}
+	buildImage, err := baseImage(root, buildImageKey)
+	if err != nil {
+		return err
+	}
+	args = append(args, buildImage, "bash", "-s")
+
+	quoted := make([]string, 0, len(args)+1)
+	quoted = append(quoted, "docker")
+	for _, a := range args {
+		quoted = append(quoted, shellQuote(a))
+	}
+	fmt.Fprintln(os.Stderr, "==> "+strings.Join(quoted, " "))
+
+	cmd := exec.Command("docker", args...)
+	cmd.Stdin = strings.NewReader(script)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	printNextSteps(o, out)
+	return nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			os.Exit(exitErr.ExitCode())
+		}
+		fmt.Fprintln(os.Stderr, "error: "+err.Error())
+		os.Exit(1)
+	}
+}

--- a/modules/110-istio/tools/go.mod
+++ b/modules/110-istio/tools/go.mod
@@ -1,0 +1,3 @@
+module istio-tools
+
+go 1.26.4


### PR DESCRIPTION
Logical backport of https://github.com/deckhouse/deckhouse/pull/22584

## Description

This PR reworks how the `istio` module builds the `proxyv2` (envoy) images and documents the procedure for regenerating their bazel inputs.

Build environment:
- moves the Istio 1.21.6 build image from `builder/alt` (ALT Linux P11) to `builder/golang-bookworm`, with clang 14, lld 14 and libc++ 14 taken from Debian packages
- drops the `build-libcxx-artifact` stage and the LLVM source checkout that Istio 1.21.6 needed to build `libcxxabi`/`libcxx` by hand, along with the envoy patches that pointed the build at those self-built libraries
- renames the shared `golang-artifact` image to a per-image `-golang-artifact` so it no longer collides between proxyv2 versions
- bumps the 1.21.6 bazel deps/cache revisions to the new `-bookworm-v1` branches

glibc in final images:
- replaces the `libs/glibc-v2.41` imports in `proxyv2-v1x21x6`, `proxyv2-v1x25x2`, `proxyv2-v1x27x9`, `ztunnel-v1x25x2` and `ztunnel-v1x27x9` with a per-image `-glibc-artifact` stage that installs `libc@2.43` from `builder/distroless` and exports only `libc.so.6`, `libm.so.6` and `ld-linux-x86-64.so.2`

Bazel deps and cache handling, unified across all three proxyv2 versions:
- deps (`external.tar.gz`) are always prepared and unpacked, and `build --nofetch` is always set, so the envoy build never touches the network
- the `$buildWithPreparedCacheAndDeps` toggle becomes `$buildWithPreparedCache` and now only controls the disk cache: `true` clones the prepared cache into a `tmp_dir` mount so it never lands in an image layer, `false` starts from an empty cache and keeps `/tmp/bazel-cache` in the artifact image for export as a new cache revision
- build flags move from ad-hoc `bazel build` arguments and `envoy.bazelrc` `sed` edits into a generated `user.bazelrc`
- the envoy binary is moved out of `bazel-bin` in the same shell that computed `BAZEL_OUTPUT_BASE`, since each werf stage runs its own shell

Tooling and docs:
- adds `modules/110-istio/tools/build-envoy-artifacts`, a Go helper that reproduces the CI build environment in a container and produces either the deps tarball (`bazel build --nobuild`, analysis only) or a filled bazel disk cache, with per-version profiles for 1.21.6, 1.25.2 and 1.27.9 and support for LLVM-from-source versions via `-source-repo`/`-ssh-key`
- adds `modules/110-istio/tools/go.mod`, registers that directory with Dependabot, and excludes `tools` from the module Helm chart via `.helmignore`
- rewrites `modules/110-istio/images/README.md` to describe the new 1.21.6 build, the difference between deps and cache, and step-by-step regeneration procedures for both

## Why do we need it, and what problem does it solve?

The Istio 1.21.6 proxyv2 image was the last one still built on ALT Linux, with a bespoke chain that compiled `libcxxabi`/`libcxx` from LLVM sources just to get an envoy toolchain the distribution packages could not provide. That stage was slow, fragile and unlike how the 1.25 and 1.27 images are built, so every change to the envoy build had to be made twice in two different shapes. Moving 1.21.6 onto the same Debian-based toolchain removes the custom libc++ build entirely and leaves one build pattern across all supported proxyv2 versions.

The deps/cache handling was also inconsistent: one version fetched during the build, another disabled fetching, and a single flag conflated "use a prepared cache" with "use prepared deps". Separating them makes the guarantee explicit — the build is always offline, and the cache only affects how long it takes — and prevents a stale cache from silently turning into a build failure.

Regenerating those bazel inputs was previously undocumented tribal knowledge that required assembling the build container by hand. The new helper and README make it a reproducible command and describe when each artifact has to be rebuilt.

The per-image `-glibc-artifact` stage takes the runtime glibc files from the same distroless package source the rest of the images use, instead of depending on a separate `libs/glibc-v2.41` image.

There are no functional changes to the resulting images: same Istio versions, same binaries, same contents.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: chore
summary: Rework proxyv2 image builds onto a common Debian-based toolchain and document envoy bazel artifact regeneration.
impact_level: low
```