### PR TITLE
[node-manager] Make node drain cancellable

### DIFF
--- a/modules/040-node-manager/images/node-controller/src/Makefile
+++ b/modules/040-node-manager/images/node-controller/src/Makefile
@@ -80,13 +80,6 @@ test: envtest gotestfmt ## Run unit + envtest in two labeled sections with GitHu
 		rm -f $(GOTEST_JSON_UNIT) $(GOTEST_JSON_ENVTEST); \
 		test $$urc -eq 0 && test $$erc -eq 0
 
-.PHONY: test-race
-test-race: envtest ## Run every test under the race detector (unit + envtest).
-	@echo "==> [test-race] running the whole suite with -race..."
-	@assets="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)"; \
-		KUBEBUILDER_ASSETS="$$assets" go test -race -count=1 ./...
-	@echo "==> [test-race] done."
-
 .PHONY: test-envtest
 test-envtest: envtest ## Run every controller's envtest suite (ENVTEST_DEBUG=1 dumps state before/after each spec; ENVTEST_LOGS=1 adds controller logs).
 	@echo "==> [test-envtest] running each controller envtest suite live (ENVTEST_DEBUG=1 = state dumps, ENVTEST_LOGS=1 = controller logs)..."

--- a/modules/040-node-manager/images/node-controller/src/Makefile
+++ b/modules/040-node-manager/images/node-controller/src/Makefile
@@ -80,6 +80,13 @@ test: envtest gotestfmt ## Run unit + envtest in two labeled sections with GitHu
 		rm -f $(GOTEST_JSON_UNIT) $(GOTEST_JSON_ENVTEST); \
 		test $$urc -eq 0 && test $$erc -eq 0
 
+.PHONY: test-race
+test-race: envtest ## Run every test under the race detector (unit + envtest).
+	@echo "==> [test-race] running the whole suite with -race..."
+	@assets="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)"; \
+		KUBEBUILDER_ASSETS="$$assets" go test -race -count=1 ./...
+	@echo "==> [test-race] done."
+
 .PHONY: test-envtest
 test-envtest: envtest ## Run every controller's envtest suite (ENVTEST_DEBUG=1 dumps state before/after each spec; ENVTEST_LOGS=1 adds controller logs).
 	@echo "==> [test-envtest] running each controller envtest suite live (ENVTEST_DEBUG=1 = state dumps, ENVTEST_LOGS=1 = controller logs)..."

--- a/modules/040-node-manager/images/node-controller/src/docs/controller-draining.md
+++ b/modules/040-node-manager/images/node-controller/src/docs/controller-draining.md
@@ -7,57 +7,94 @@
 ## Purpose
 
 Handles the node drain lifecycle. When a node receives the annotation
-`update.node.deckhouse.io/draining`, this controller cordons the node,
-evicts all pods (respecting PDBs and timeouts), and marks the node as drained.
+`update.node.deckhouse.io/draining`, this controller cordons the node, evicts its
+pods (respecting PDBs and timeouts), and records the result.
+
+The eviction runs as **one background task per node** (`internal/task`), under a
+context the controller can cancel. A reconcile never sits inside it: the task hands
+the node back to the workqueue when it ends.
 
 ## Watched Resources
 
 | Resource | Trigger | Filter |
 |----------|---------|--------|
 | `Node` | Any change (primary) | Only nodes with label `node.deckhouse.io/group` |
+| wake channel | An eviction finished | none |
 
-The event filter ensures only managed nodes (those assigned to a NodeGroup)
-trigger reconciliation.
+The label filter is a `WithEventFilter` predicate. It does not reach the wake channel:
+a raw source is exempt from it by design, which is just as well, since the `Node` that
+channel carries has a name and nothing else.
 
 ## Reconciliation Logic
 
 ```
-Node changed
+Node changed, or an eviction finished
   │
-  ├─ No "draining" and no "drained" annotation? → skip
+  ├─ Node is gone? → clear the metric, cancel the eviction → done
   │
-  ├─ No "draining" but "drained=user" and node is schedulable?
-  │   └─ Remove stale "drained" annotation → done
+  ├─ "drained=user"? → remove it → done
+  │     Unconditional: a hand drain records no result, so the value is always a
+  │     leftover, cordoned node or not.
   │
-  ├─ No "draining" annotation? → skip
+  ├─ No "draining" annotation →
+  │    ├─ clear the metric
+  │    ├─ no eviction running? → done (the cordon belongs to updateapproval)
+  │    └─ an eviction is running → cancel it, wait for it to stop, uncordon
   │
-  └─ Has "draining" annotation →
-       ├─ Remove existing "drained=user" annotation if present
-       ├─ Resolve drain timeout from NodeGroup.spec.nodeDrainTimeoutSecond
-       │   (default: 10 minutes)
-       ├─ Cordon node (set spec.unschedulable=true)
-       ├─ Drain: evict all pods (parallel, skip DaemonSet + mirror pods)
-       │   ├─ Respects PDB (retries on TooManyRequests)
-       │   ├─ Waits for pod deletion
-       │   └─ On timeout: marks as drained anyway
-       ├─ Remove "draining" annotation
-       └─ Set "drained=<source>" annotation
+  ├─ The eviction has finished →
+  │    ├─ succeeded → clear the metric
+  │    ├─ hit its own deadline → event + gauge, recorded as drained anyway
+  │    ├─ failed otherwise → event + gauge, return the error (retried)
+  │    └─ remove "draining", set "drained=<source>" unless the source is "user"
+  │
+  └─ Otherwise →
+       ├─ node still schedulable? → cordon it → done, the cordon's own event
+       │   brings us back (pods must stop arriving before anything empties the node)
+       └─ already cordoned → start the eviction
 ```
+
+Every branch edits the node in memory; a single deferred patch at the end of the
+reconcile is the only write.
+
+## One Task Per Node
+
+`internal/task.Manager` keys tasks by node name, so a node never runs two background
+operations at once — a second one is refused with `ErrExists`. A finished task is kept
+until its result is collected, which is what lets the reconcile decide the outcome.
+Cancelling waits for the goroutine to return before the caller undoes anything, so an
+uncordon never races an eviction still in flight.
+
+The registry lives in memory. A controller restart therefore forgets that an eviction
+was running: a request withdrawn while the controller is down leaves the node cordoned
+until someone runs `kubectl uncordon`.
 
 ## Drain Timeout Resolution
 
-1. Read `node.deckhouse.io/group` label from the node
+1. Read the `node.deckhouse.io/group` label from the node
 2. Fetch the NodeGroup object
 3. Use `spec.nodeDrainTimeoutSecond` if set, otherwise 10 minutes
+
+Resolved in `startDrain` and passed into the task, which turns it into the eviction's
+own deadline.
 
 ## Key Annotations
 
 | Annotation | Meaning |
 |------------|---------|
-| `update.node.deckhouse.io/draining` | Drain requested (value = source, e.g. "bashible") |
-| `update.node.deckhouse.io/drained` | Drain completed (value = source) |
+| `update.node.deckhouse.io/draining` | Drain requested (value = source, e.g. "bashible"; an empty value means "bashible"). **Removing it cancels an eviction in flight** |
+| `update.node.deckhouse.io/drained` | Drain completed (value = source). Never written for source "user", and removed from any node carrying that value |
+
+## Events
+
+| Reason | When |
+|--------|------|
+| `DrainSucceeded` | The eviction ended and the annotations were flipped |
+| `DrainFailed` | The eviction failed, or ran out of its timeout |
+| `DrainCancelled` | The request was withdrawn mid-eviction and the node was uncordoned |
 
 ## Files
 
-- `controller.go` — reconciler, cordon, timeout resolution
-- `drain.go` — pod eviction logic (parallel eviction, PDB retry, deletion wait)
+- `controller.go` — reconciler and the four situations a node can be in
+- `drainer.go` — the background eviction: task registry, wake channel, `kubedrain` call
+- `metrics.go` — the `d8_node_draining` failure gauge
+- `../../task/manager.go` — one background task per subject, with cancellation

--- a/modules/040-node-manager/images/node-controller/src/docs/controller-draining.md
+++ b/modules/040-node-manager/images/node-controller/src/docs/controller-draining.md
@@ -34,7 +34,7 @@ Node changed, or an eviction finished
   │
   ├─ No "draining" annotation →
   │    ├─ clear the metric
-  │    ├─ an eviction is running? → cancel it, wait for it to stop, uncordon
+  │    ├─ an eviction is running? → cancel it and wait for it to stop
   │    ├─ "drained=user" on a schedulable node? → remove the stale marker
   │    └─ done (a cordon with no eviction behind it belongs to updateapproval)
   │
@@ -61,12 +61,11 @@ reconcile is the only write.
 `internal/task.Manager` keys tasks by node name, so a node never runs two background
 operations at once — a second one is refused with `ErrExists`. A finished task is kept
 until its result is collected, which is what lets the reconcile decide the outcome.
-Cancelling waits for the goroutine to return before the caller undoes anything, so an
-uncordon never races an eviction still in flight.
+Cancelling waits for the goroutine to return before the caller does anything else, so
+nothing races an eviction still in flight.
 
 The registry lives in memory. A controller restart therefore forgets that an eviction
-was running: a request withdrawn while the controller is down leaves the node cordoned
-until someone runs `kubectl uncordon`.
+was running, and a request withdrawn while the controller is down goes unnoticed.
 
 ## Drain Timeout Resolution
 
@@ -90,7 +89,7 @@ own deadline.
 |--------|------|
 | `DrainSucceeded` | The eviction ended and the annotations were flipped |
 | `DrainFailed` | The eviction failed, or ran out of its timeout |
-| `DrainCancelled` | The request was withdrawn mid-eviction and the node was uncordoned |
+| `DrainCancelled` | The request was withdrawn and an eviction in flight was stopped |
 
 ## Files
 

--- a/modules/040-node-manager/images/node-controller/src/docs/controller-draining.md
+++ b/modules/040-node-manager/images/node-controller/src/docs/controller-draining.md
@@ -32,20 +32,20 @@ Node changed, or an eviction finished
   │
   ├─ Node is gone? → clear the metric, cancel the eviction → done
   │
-  ├─ "drained=user"? → remove it → done
-  │     Unconditional: a hand drain records no result, so the value is always a
-  │     leftover, cordoned node or not.
-  │
   ├─ No "draining" annotation →
   │    ├─ clear the metric
-  │    ├─ no eviction running? → done (the cordon belongs to updateapproval)
-  │    └─ an eviction is running → cancel it, wait for it to stop, uncordon
+  │    ├─ an eviction is running? → cancel it, wait for it to stop, uncordon
+  │    ├─ "drained=user" on a schedulable node? → remove the stale marker
+  │    └─ done (a cordon with no eviction behind it belongs to updateapproval)
+  │
+  ├─ "drained=user" while a new drain is requested? → remove it, so the new
+  │     drain's own result is what the node ends up carrying
   │
   ├─ The eviction has finished →
   │    ├─ succeeded → clear the metric
   │    ├─ hit its own deadline → event + gauge, recorded as drained anyway
   │    ├─ failed otherwise → event + gauge, return the error (retried)
-  │    └─ remove "draining", set "drained=<source>" unless the source is "user"
+  │    └─ remove "draining", set "drained=<source>"
   │
   └─ Otherwise →
        ├─ node still schedulable? → cordon it → done, the cordon's own event
@@ -82,7 +82,7 @@ own deadline.
 | Annotation | Meaning |
 |------------|---------|
 | `update.node.deckhouse.io/draining` | Drain requested (value = source, e.g. "bashible"; an empty value means "bashible"). **Removing it cancels an eviction in flight** |
-| `update.node.deckhouse.io/drained` | Drain completed (value = source). Never written for source "user", and removed from any node carrying that value |
+| `update.node.deckhouse.io/drained` | Drain completed (value = source). `drained=user` marks a hand drain and is cleaned up in two places: off a schedulable node with no request, and before a new drain starts |
 
 ## Events
 

--- a/modules/040-node-manager/images/node-controller/src/go.mod
+++ b/modules/040-node-manager/images/node-controller/src/go.mod
@@ -51,6 +51,7 @@ require (
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/go-openapi/swag/jsonname v0.25.1 // indirect
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
+	github.com/gobuffalo/flect v1.0.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect

--- a/modules/040-node-manager/images/node-controller/src/go.sum
+++ b/modules/040-node-manager/images/node-controller/src/go.sum
@@ -65,6 +65,8 @@ github.com/go-openapi/swag/jsonname v0.25.1 h1:Sgx+qbwa4ej6AomWC6pEfXrA6uP2RkaNj
 github.com/go-openapi/swag/jsonname v0.25.1/go.mod h1:71Tekow6UOLBD3wS7XhdT98g5J5GR13NOTQ9/6Q11Zo=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
+github.com/gobuffalo/flect v1.0.3 h1:xeWBM2nui+qnVvNM4S3foBhCAL2XgPU+a7FdpelbTq4=
+github.com/gobuffalo/flect v1.0.3/go.mod h1:A5msMlrHtLqh9umBSnvabjsMrCcCpAyzglnDvkbYKHs=
 github.com/goccy/go-yaml v1.18.0 h1:8W7wMFS12Pcas7KU+VVkaiCng+kG8QiFeFwzFb+rwuw=
 github.com/goccy/go-yaml v1.18.0/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
@@ -173,11 +175,16 @@ github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/draining/controller.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/draining/controller.go
@@ -162,14 +162,9 @@ func (r *Reconciler) cleanupDeletedNode(ctx context.Context, nodeName string) er
 	return err
 }
 
-// cancelDrainIfExist gives the node back when its request disappears.
-//
-// Only a running eviction is undone. A drain that succeeds consumes its own
-// request, so every node passes through here — uncordoning them all would
-// return half-updated nodes to service, and past that point the cordon belongs
-// to updateapproval. A restart forgets the eviction, and such a node keeps its
-// cordon until someone runs kubectl uncordon.
-func (r *Reconciler) cancelDrainIfExist(ctx context.Context, logger logr.Logger, node *corev1.Node) error {
+// cancelDrainIfExist stops the eviction when its request disappears, so a drain
+// nobody asked for any more does not run to completion and record a result.
+func (r *Reconciler) cancelDrainIfExist(ctx context.Context, _ logr.Logger, node *corev1.Node) error {
 	clearDrainMetric(node.Name)
 
 	cancelled, err := r.drains.cancel(ctx, node.Name)
@@ -180,10 +175,8 @@ func (r *Reconciler) cancelDrainIfExist(ctx context.Context, logger logr.Logger,
 		return nil
 	}
 
-	logger.Info("request withdrawn, node going back into service")
-	node.Spec.Unschedulable = false
 	r.Recorder.Eventf(node, corev1.EventTypeNormal, "DrainCancelled",
-		"drain of node %q was cancelled, node is schedulable again", node.Name)
+		"drain of node %q was cancelled", node.Name)
 	return nil
 }
 

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/draining/controller.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/draining/controller.go
@@ -106,8 +106,8 @@ func inNodeGroup(obj client.Object) bool {
 
 func stateFromNode(node *corev1.Node) state {
 	return state{
-		requestedBy:   node.Annotations[nodecommon.DrainingAnnotation],
-		recordedFor:   node.Annotations[nodecommon.DrainedAnnotation],
+		requestedBy:   drainSource(node, nodecommon.DrainingAnnotation),
+		recordedFor:   drainSource(node, nodecommon.DrainedAnnotation),
 		unschedulable: node.Spec.Unschedulable,
 	}
 }

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/draining/controller.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/draining/controller.go
@@ -150,17 +150,24 @@ func (r *Reconciler) reconcileNode(ctx context.Context, node *corev1.Node) (_ ct
 
 	state := stateFromNode(node)
 
-	// drained=user is never written any more, so it can only be a leftover: an
-	// upgraded cluster, or somebody setting it by hand.
-	if state.recordedFor == userSource {
-		logger.Info("removing an orphan drain result")
-		delete(node.Annotations, nodecommon.DrainedAnnotation)
+	if state.requestedBy == "" {
+		if err := r.cancelDrainIfExist(ctx, logger, node); err != nil {
+			return ctrl.Result{}, err
+		}
+		if state.recordedFor == userSource && !state.unschedulable {
+			logger.Info("removing a stale drained=user annotation")
+			delete(node.Annotations, nodecommon.DrainedAnnotation)
+		}
 		return ctrl.Result{}, nil
 	}
 
-	// The request is gone: whoever asked has changed their mind.
-	if state.requestedBy == "" {
-		return ctrl.Result{}, r.cancelDrain(ctx, logger, node)
+	// A hand drain's marker is cleared before a new drain starts. Left there it
+	// would read as the new drain's own result, and a second hand drain would
+	// never overwrite it — finishDrain records nothing for the user source.
+	if state.recordedFor == userSource {
+		logger.Info("removing an existing drained=user annotation before a new drain")
+		delete(node.Annotations, nodecommon.DrainedAnnotation)
+		return ctrl.Result{}, nil
 	}
 
 	// The eviction's outcome decides what is written, so it is collected first.
@@ -193,14 +200,14 @@ func (r *Reconciler) cleanupDeletedNode(ctx context.Context, nodeName string) er
 	return err
 }
 
-// cancelDrain gives the node back when its request disappears.
+// cancelDrainIfExist gives the node back when its request disappears.
 //
 // Only a running eviction is undone. A drain that succeeds consumes its own
 // request, so every node passes through here — uncordoning them all would
 // return half-updated nodes to service, and past that point the cordon belongs
 // to updateapproval. A restart forgets the eviction, and such a node keeps its
 // cordon until someone runs kubectl uncordon.
-func (r *Reconciler) cancelDrain(ctx context.Context, logger logr.Logger, node *corev1.Node) error {
+func (r *Reconciler) cancelDrainIfExist(ctx context.Context, logger logr.Logger, node *corev1.Node) error {
 	clearDrainMetric(node.Name)
 
 	cancelled, err := r.drains.cancel(ctx, node.Name)
@@ -244,10 +251,7 @@ func (r *Reconciler) finishDrain(_ context.Context, logger logr.Logger, node *co
 	}
 
 	delete(node.Annotations, nodecommon.DrainingAnnotation)
-	if source != userSource {
-		node.Annotations[nodecommon.DrainedAnnotation] = source
-	}
-
+	node.Annotations[nodecommon.DrainedAnnotation] = source
 	logger.Info("drain finished")
 	r.Recorder.Eventf(node, corev1.EventTypeNormal, "DrainSucceeded", "node %q drained successfully", node.Name)
 	return nil

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/draining/controller.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/draining/controller.go
@@ -99,29 +99,6 @@ func (r *Reconciler) SetupWatches(w register.Watcher) {
 	w.WatchesRawSource(r.drains.wakeSource())
 }
 
-func inNodeGroup(obj client.Object) bool {
-	_, hasGroup := obj.GetLabels()[nodecommon.NodeGroupLabel]
-	return hasGroup
-}
-
-func stateFromNode(node *corev1.Node) state {
-	return state{
-		requestedBy:   drainSource(node, nodecommon.DrainingAnnotation),
-		recordedFor:   drainSource(node, nodecommon.DrainedAnnotation),
-		unschedulable: node.Spec.Unschedulable,
-	}
-}
-
-type state struct {
-	requestedBy   string
-	recordedFor   string
-	unschedulable bool
-}
-
-func (s state) equal(other state) bool {
-	return s == other
-}
-
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	node := &corev1.Node{}
 	if err := r.Client.Get(ctx, req.NamespacedName, node); err != nil {
@@ -176,21 +153,6 @@ func (r *Reconciler) reconcileNode(ctx context.Context, node *corev1.Node) (_ ct
 	}
 
 	return ctrl.Result{}, r.startDrain(ctx, logger, node, state.requestedBy)
-}
-
-// drainSource reads the drain request off a node, empty when nobody asked. A
-// bare annotation means bashible: that is how the original hook behaved, and old
-// scripts still set it.
-func drainSource(node *corev1.Node, annotation string) string {
-	source, ok := node.Annotations[annotation]
-	if !ok {
-		return ""
-	}
-	if source == "" {
-		return bashibleSource
-	}
-
-	return source
 }
 
 // cleanupDeletedNode stops an eviction running for an object nobody can see.
@@ -275,4 +237,42 @@ func (r *Reconciler) startDrain(ctx context.Context, logger logr.Logger, node *c
 	timeout := nodecommon.DrainTimeout(ctx, r.Client, node.Labels[nodecommon.NodeGroupLabel])
 
 	return r.drains.start(logger, node.Name, timeout)
+}
+
+// drainSource reads the drain request off a node, empty when nobody asked. A
+// bare annotation means bashible: that is how the original hook behaved, and old
+// scripts still set it.
+func drainSource(node *corev1.Node, annotation string) string {
+	source, ok := node.Annotations[annotation]
+	if !ok {
+		return ""
+	}
+	if source == "" {
+		return bashibleSource
+	}
+
+	return source
+}
+
+func inNodeGroup(obj client.Object) bool {
+	_, hasGroup := obj.GetLabels()[nodecommon.NodeGroupLabel]
+	return hasGroup
+}
+
+func stateFromNode(node *corev1.Node) state {
+	return state{
+		requestedBy:   drainSource(node, nodecommon.DrainingAnnotation),
+		recordedFor:   drainSource(node, nodecommon.DrainedAnnotation),
+		unschedulable: node.Spec.Unschedulable,
+	}
+}
+
+type state struct {
+	requestedBy   string
+	recordedFor   string
+	unschedulable bool
+}
+
+func (s state) equal(other state) bool {
+	return s == other
 }

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/draining/controller.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/draining/controller.go
@@ -18,20 +18,18 @@ package draining
 
 import (
 	"context"
-	"encoding/json"
-	"time"
+	"errors"
+	"fmt"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
-
-	kubedrain "github.com/deckhouse/deckhouse/go_lib/dependency/k8s/drain"
 
 	nodecommon "github.com/deckhouse/node-controller/internal/common"
 	"github.com/deckhouse/node-controller/internal/register"
@@ -41,164 +39,188 @@ func init() {
 	register.RegisterController("node-draining", &corev1.Node{}, &Reconciler{})
 }
 
+const (
+	bashibleSource = "bashible"
+	userSource     = "user"
+)
+
+// Reconciler empties a node when somebody annotates it, and answers with a
+// second annotation naming whoever asked. The requesters — bashible, cloud
+// hooks, updateapproval, an operator — cannot evict pods themselves.
 type Reconciler struct {
 	register.Base
-	kubeClient kubernetes.Interface
+
+	drains *drainer
 }
 
-func (r *Reconciler) Setup(_ context.Context, mgr ctrl.Manager) error {
-	var err error
-	r.kubeClient, err = kubernetes.NewForConfig(mgr.GetConfig())
-	return err
+func (r *Reconciler) Setup(ctx context.Context, mgr ctrl.Manager) error {
+	kubeClient, err := kubernetes.NewForConfig(mgr.GetConfig())
+	if err != nil {
+		return fmt.Errorf("create the kubernetes client: %w", err)
+	}
+
+	r.drains = newDrainer(ctx, kubeClient)
+	return nil
+}
+
+// ForPredicates admits only nodes in a NodeGroup. Deliberately not
+// WithEventFilter, which applies to every source and would drop the name-only
+// Node a finished eviction sends down the wake channel.
+func (r *Reconciler) ForPredicates() []predicate.Predicate {
+	return []predicate.Predicate{
+		predicate.NewPredicateFuncs(func(obj client.Object) bool {
+			_, hasGroup := obj.GetLabels()[nodecommon.NodeGroupLabel]
+			return hasGroup
+		}),
+	}
 }
 
 func (r *Reconciler) SetupWatches(w register.Watcher) {
-	w.WithEventFilter(predicate.NewPredicateFuncs(func(obj client.Object) bool {
-		_, hasGroup := obj.GetLabels()[nodecommon.NodeGroupLabel]
-		return hasGroup
-	}))
+	w.WatchesRawSource(r.drains.wakeSource())
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	logger := log.FromContext(ctx)
-
 	node := &corev1.Node{}
 	if err := r.Client.Get(ctx, req.NamespacedName, node); err != nil {
 		if apierrors.IsNotFound(err) {
-			clearDrainMetric(req.Name)
-			return ctrl.Result{}, nil
+			return ctrl.Result{}, r.cleanupDeletedNode(ctx, req.Name)
 		}
 		return ctrl.Result{}, err
 	}
 
-	// Backward compatibility: treat empty annotation value as "bashible" (original hook behavior).
-	var drainingSource, drainedSource string
-	if source, ok := node.Annotations[nodecommon.DrainingAnnotation]; ok {
-		if source == "" {
-			drainingSource = "bashible"
-		} else {
-			drainingSource = source
-		}
-	}
-	if source, ok := node.Annotations[nodecommon.DrainedAnnotation]; ok {
-		if source == "" {
-			drainedSource = "bashible"
-		} else {
-			drainedSource = source
-		}
+	return r.reconcileNode(ctx, node)
+}
+
+func (r *Reconciler) reconcileNode(ctx context.Context, node *corev1.Node) (_ ctrl.Result, resErr error) {
+	logger := log.FromContext(ctx).WithValues("node", node.Name)
+
+	patchHelper, err := patch.NewHelper(node, r.Client)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to init patch helper: %w", err)
 	}
 
-	if drainingSource == "" {
-		clearDrainMetric(node.Name)
-
-		if drainedSource == "user" && !node.Spec.Unschedulable {
-			logger.Info("removing stale drained=user annotation from schedulable node", "node", node.Name)
-			return ctrl.Result{}, r.patchAnnotations(ctx, node.Name, map[string]interface{}{
-				nodecommon.DrainedAnnotation: nil,
-			})
+	defer func() {
+		if err := patchHelper.Patch(ctx, node); err != nil {
+			resErr = errors.Join(resErr, fmt.Errorf("failed to patch Node %s: %w", node.Name, err))
 		}
+	}()
 
-		logger.V(1).Info("skipping: no draining annotation", "node", node.Name, "drainedSource", drainedSource)
+	requestedBy := drainSource(node, nodecommon.DrainingAnnotation)
+	recordedFor := drainSource(node, nodecommon.DrainedAnnotation)
+
+	// drained=user is never written any more, so it can only be a leftover: an
+	// upgraded cluster, or somebody setting it by hand.
+	if recordedFor == userSource {
+		logger.Info("removing an orphan drain result")
+		delete(node.Annotations, nodecommon.DrainedAnnotation)
 		return ctrl.Result{}, nil
 	}
 
-	logger.Info("node drain requested", "node", node.Name, "source", drainingSource, "nodeGroup", node.Labels[nodecommon.NodeGroupLabel])
-
-	if drainedSource == "user" {
-		logger.Info("removing existing drained=user annotation before new drain", "node", node.Name)
-		if err := r.patchAnnotations(ctx, node.Name, map[string]interface{}{
-			nodecommon.DrainedAnnotation: nil,
-		}); err != nil {
-			return ctrl.Result{}, err
-		}
+	// The request is gone: whoever asked has changed their mind.
+	if requestedBy == "" {
+		return ctrl.Result{}, r.cancelDrain(ctx, logger, node)
 	}
 
-	drainTimeout := nodecommon.DrainTimeout(ctx, r.Client, node.Labels[nodecommon.NodeGroupLabel])
-	logger.V(1).Info("drain timeout resolved", "node", node.Name, "timeout", drainTimeout)
-
-	if node.Spec.Unschedulable {
-		logger.V(1).Info("node already cordoned", "node", node.Name)
-	} else {
-		logger.Info("cordoning node", "node", node.Name)
-	}
-	if err := r.cordonNode(ctx, node); err != nil {
-		logger.Error(err, "failed to cordon node", "node", node.Name)
-		return ctrl.Result{}, err
+	// The eviction's outcome decides what is written, so it is collected first.
+	if finished, drainErr := r.drains.result(node.Name); finished {
+		return ctrl.Result{}, r.finishDrain(ctx, logger, node, requestedBy, drainErr)
 	}
 
-	logger.Info("draining node pods", "node", node.Name, "timeout", drainTimeout)
-	drainCtx, cancel := context.WithTimeout(ctx, drainTimeout)
-	defer cancel()
-
-	err := r.drainNode(drainCtx, node.Name)
-	if err != nil {
-		logger.Error(err, "node drain failed", "node", node.Name)
-		r.Recorder.Eventf(node, corev1.EventTypeWarning, "DrainFailed", "drain failed: %v", err)
-		nodeDrainingGauge.WithLabelValues(node.Name, err.Error()).Set(1)
-
-		if drainCtx.Err() != nil {
-			logger.Info("drain timed out, marking as drained anyway", "node", node.Name, "timeout", drainTimeout)
-		} else {
-			return ctrl.Result{}, err
-		}
-	} else {
-		clearDrainMetric(node.Name)
-	}
-
-	if err := r.patchAnnotations(ctx, node.Name, map[string]interface{}{
-		nodecommon.DrainingAnnotation: nil,
-		nodecommon.DrainedAnnotation:  drainingSource,
-	}); err != nil {
-		return ctrl.Result{}, err
-	}
-
-	logger.Info("drain completed, annotations updated",
-		"node", node.Name,
-		"source", drainingSource,
-	)
-	r.Recorder.Eventf(node, corev1.EventTypeNormal, "DrainSucceeded", "node %q drained successfully", node.Name)
-
-	return ctrl.Result{}, nil
+	return ctrl.Result{}, r.startDrain(ctx, logger, node, requestedBy)
 }
 
-func (r *Reconciler) cordonNode(ctx context.Context, node *corev1.Node) error {
-	if node.Spec.Unschedulable {
+// drainSource reads one drain annotation, empty when the node does not carry it.
+func drainSource(node *corev1.Node, annotation string) string {
+	source, ok := node.Annotations[annotation]
+	if !ok {
+		return ""
+	}
+	if source == "" {
+		return bashibleSource
+	}
+
+	return source
+}
+
+// cleanupDeletedNode stops an eviction running for an object nobody can see.
+func (r *Reconciler) cleanupDeletedNode(ctx context.Context, nodeName string) error {
+	clearDrainMetric(nodeName)
+	_, err := r.drains.cancel(ctx, nodeName)
+	return err
+}
+
+// cancelDrain gives the node back when its request disappears.
+//
+// Only a running eviction is undone. A drain that succeeds consumes its own
+// request, so every node passes through here — uncordoning them all would
+// return half-updated nodes to service, and past that point the cordon belongs
+// to updateapproval. A restart forgets the eviction, and such a node keeps its
+// cordon until someone runs kubectl uncordon.
+func (r *Reconciler) cancelDrain(ctx context.Context, logger logr.Logger, node *corev1.Node) error {
+	clearDrainMetric(node.Name)
+
+	cancelled, err := r.drains.cancel(ctx, node.Name)
+	if err != nil {
+		return err
+	}
+	if !cancelled {
 		return nil
 	}
 
-	patch, err := json.Marshal(map[string]interface{}{
-		"spec": map[string]interface{}{
-			"unschedulable": true,
-		},
-	})
-	if err != nil {
-		return err
-	}
-
-	return r.Client.Patch(ctx, node, client.RawPatch(types.MergePatchType, patch))
+	logger.Info("request withdrawn, node going back into service")
+	node.Spec.Unschedulable = false
+	r.Recorder.Eventf(node, corev1.EventTypeNormal, "DrainCancelled",
+		"drain of node %q was cancelled, node is schedulable again", node.Name)
+	return nil
 }
 
-func (r *Reconciler) drainNode(ctx context.Context, nodeName string) error {
-	timeout := time.Duration(0) // 0 means infinite; actual timeout is controlled by ctx
-	drainer := kubedrain.NewDrainer(kubedrain.HelperConfig{
-		Client:  r.kubeClient,
-		Timeout: &timeout,
-	})
-	drainer.Ctx = ctx
+// finishDrain writes down how the eviction ended. The request is consumed
+// either way; only a source that polls for a result gets one.
+func (r *Reconciler) finishDrain(_ context.Context, logger logr.Logger, node *corev1.Node, source string, drainErr error) error {
+	logger = logger.WithValues("source", source)
 
-	return kubedrain.RunNodeDrain(drainer, nodeName)
-}
+	switch {
+	case drainErr == nil:
+		clearDrainMetric(node.Name)
 
-func (r *Reconciler) patchAnnotations(ctx context.Context, nodeName string, annotations map[string]interface{}) error {
-	patch, err := json.Marshal(map[string]interface{}{
-		"metadata": map[string]interface{}{
-			"annotations": annotations,
-		},
-	})
-	if err != nil {
-		return err
+	case errors.Is(drainErr, errDrainDeadline):
+		// Recorded as drained anyway: the cause is durable, a retry gets no
+		// further, and the node's update must not wedge. The gauge stays at 1
+		// for NodeStuckInDraining.
+		logger.Info("eviction timed out, recording it as done anyway", "error", drainErr.Error())
+		r.Recorder.Eventf(node, corev1.EventTypeWarning, "DrainFailed", "drain failed: %v", drainErr)
+		nodeDrainingGauge.WithLabelValues(node.Name, drainErr.Error()).Set(1)
+
+	default:
+		logger.Error(drainErr, "eviction failed")
+		r.Recorder.Eventf(node, corev1.EventTypeWarning, "DrainFailed", "drain failed: %v", drainErr)
+		nodeDrainingGauge.WithLabelValues(node.Name, drainErr.Error()).Set(1)
+		// The request stays, so the requeue starts a fresh eviction.
+		return drainErr
 	}
 
-	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}}
-	return r.Client.Patch(ctx, node, client.RawPatch(types.MergePatchType, patch))
+	delete(node.Annotations, nodecommon.DrainingAnnotation)
+	if source != userSource {
+		node.Annotations[nodecommon.DrainedAnnotation] = source
+	}
+
+	logger.Info("drain finished")
+	r.Recorder.Eventf(node, corev1.EventTypeNormal, "DrainSucceeded", "node %q drained successfully", node.Name)
+	return nil
+}
+
+// startDrain cordons the node, then starts the eviction on the pass that sees
+// the cordon. Not both at once: this reconcile's patch is still unsent, and
+// pods must stop arriving before anything empties the node. The cordon's own
+// event brings us back.
+func (r *Reconciler) startDrain(ctx context.Context, logger logr.Logger, node *corev1.Node, source string) error {
+	timeout := nodecommon.DrainTimeout(ctx, r.Client, node.Labels[nodecommon.NodeGroupLabel])
+
+	if !node.Spec.Unschedulable {
+		logger.Info("cordoning node", "source", source)
+		node.Spec.Unschedulable = true
+		return nil
+	}
+
+	return r.drains.start(logger, node.Name, timeout)
 }

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/draining/controller.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/draining/controller.go
@@ -147,7 +147,7 @@ func (r *Reconciler) reconcileNode(ctx context.Context, node *corev1.Node) (_ ct
 		return ctrl.Result{}, nil
 	}
 
-	// The eviction's outcome decides what is written, so it is collected first.
+	// The drain's outcome decides what is written, so it is collected first.
 	if finished, drainErr := r.drains.result(node.Name); finished {
 		return ctrl.Result{}, r.finishDrain(ctx, logger, node, state.requestedBy, drainErr)
 	}
@@ -155,16 +155,16 @@ func (r *Reconciler) reconcileNode(ctx context.Context, node *corev1.Node) (_ ct
 	return ctrl.Result{}, r.startDrain(ctx, logger, node, state.requestedBy)
 }
 
-// cleanupDeletedNode stops an eviction running for an object nobody can see.
+// cleanupDeletedNode stops a drain running for an object nobody can see.
 func (r *Reconciler) cleanupDeletedNode(ctx context.Context, nodeName string) error {
 	clearDrainMetric(nodeName)
 	_, err := r.drains.cancel(ctx, nodeName)
 	return err
 }
 
-// cancelDrainIfExist stops the eviction when its request disappears, so a drain
+// cancelDrainIfExist stops the drain when its request disappears, so a drain
 // nobody asked for any more does not run to completion and record a result.
-func (r *Reconciler) cancelDrainIfExist(ctx context.Context, _ logr.Logger, node *corev1.Node) error {
+func (r *Reconciler) cancelDrainIfExist(ctx context.Context, logger logr.Logger, node *corev1.Node) error {
 	clearDrainMetric(node.Name)
 
 	cancelled, err := r.drains.cancel(ctx, node.Name)
@@ -175,12 +175,13 @@ func (r *Reconciler) cancelDrainIfExist(ctx context.Context, _ logr.Logger, node
 		return nil
 	}
 
+	logger.Info("drain canceled")
 	r.Recorder.Eventf(node, corev1.EventTypeNormal, "DrainCancelled",
 		"drain of node %q was cancelled", node.Name)
 	return nil
 }
 
-// finishDrain writes down how the eviction ended. The request is consumed
+// finishDrain writes down how the drain ended. The request is consumed
 // either way; only a source that polls for a result gets one.
 func (r *Reconciler) finishDrain(_ context.Context, logger logr.Logger, node *corev1.Node, source string, drainErr error) error {
 	logger = logger.WithValues("source", source)
@@ -193,15 +194,15 @@ func (r *Reconciler) finishDrain(_ context.Context, logger logr.Logger, node *co
 		// Recorded as drained anyway: the cause is durable, a retry gets no
 		// further, and the node's update must not wedge. The gauge stays at 1
 		// for NodeStuckInDraining.
-		logger.Info("eviction timed out, recording it as done anyway", "error", drainErr.Error())
+		logger.Info("drain timed out, recording it as done anyway", "error", drainErr.Error())
 		r.Recorder.Eventf(node, corev1.EventTypeWarning, "DrainFailed", "drain failed: %v", drainErr)
 		nodeDrainingGauge.WithLabelValues(node.Name, drainErr.Error()).Set(1)
 
 	default:
-		logger.Error(drainErr, "eviction failed")
+		logger.Error(drainErr, "drain failed")
 		r.Recorder.Eventf(node, corev1.EventTypeWarning, "DrainFailed", "drain failed: %v", drainErr)
 		nodeDrainingGauge.WithLabelValues(node.Name, drainErr.Error()).Set(1)
-		// The request stays, so the requeue starts a fresh eviction.
+		// The request stays, so the requeue starts a fresh drain.
 		return drainErr
 	}
 
@@ -212,7 +213,7 @@ func (r *Reconciler) finishDrain(_ context.Context, logger logr.Logger, node *co
 	return nil
 }
 
-// startDrain cordons the node, then starts the eviction on the pass that sees
+// startDrain cordons the node, then starts the drain on the pass that sees
 // the cordon. Not both at once: this reconcile's patch is still unsent, and
 // pods must stop arriving before anything empties the node. The cordon's own
 // event brings us back.
@@ -221,7 +222,7 @@ func (r *Reconciler) startDrain(ctx context.Context, logger logr.Logger, node *c
 		logger.Info("cordoning node", "source", source)
 		node.Spec.Unschedulable = true
 
-		// The eviction starts on the pass this reconcile's own patch brings
+		// The drain starts on the pass this reconcile's own patch brings
 		// about: writing spec.unschedulable is one of the changes the watch
 		// admits, so nothing has to be requeued to come back.
 		return nil

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/draining/controller.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/draining/controller.go
@@ -63,19 +63,13 @@ func (r *Reconciler) Setup(ctx context.Context, mgr ctrl.Manager) error {
 	return nil
 }
 
-// ForPredicates admits only nodes in a NodeGroup. Deliberately not
-// WithEventFilter, which applies to every source and would drop the name-only
-// Node a finished eviction sends down the wake channel.
-func (r *Reconciler) ForPredicates() []predicate.Predicate {
-	return []predicate.Predicate{
-		predicate.NewPredicateFuncs(func(obj client.Object) bool {
-			_, hasGroup := obj.GetLabels()[nodecommon.NodeGroupLabel]
-			return hasGroup
-		}),
-	}
-}
-
+// SetupWatches subscribes to nodes that belong to a NodeGroup, and to the wake
+// channel a finished eviction writes to.
 func (r *Reconciler) SetupWatches(w register.Watcher) {
+	w.WithEventFilter(predicate.NewPredicateFuncs(func(obj client.Object) bool {
+		_, hasGroup := obj.GetLabels()[nodecommon.NodeGroupLabel]
+		return hasGroup
+	}))
 	w.WatchesRawSource(r.drains.wakeSource())
 }
 

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/draining/controller.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/draining/controller.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
@@ -63,14 +64,62 @@ func (r *Reconciler) Setup(ctx context.Context, mgr ctrl.Manager) error {
 	return nil
 }
 
-// SetupWatches subscribes to nodes that belong to a NodeGroup, and to the wake
-// channel a finished eviction writes to.
 func (r *Reconciler) SetupWatches(w register.Watcher) {
-	w.WithEventFilter(predicate.NewPredicateFuncs(func(obj client.Object) bool {
-		_, hasGroup := obj.GetLabels()[nodecommon.NodeGroupLabel]
-		return hasGroup
-	}))
+	w.WithEventFilter(predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return inNodeGroup(e.Object)
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return inNodeGroup(e.Object)
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return inNodeGroup(e.Object)
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if !inNodeGroup(e.ObjectNew) {
+				return false
+			}
+
+			oldNode, ok := e.ObjectOld.(*corev1.Node)
+			if !ok {
+				return false
+			}
+
+			newNode, ok := e.ObjectNew.(*corev1.Node)
+			if !ok {
+				return false
+			}
+
+			old := stateFromNode(oldNode)
+			new := stateFromNode(newNode)
+			return !new.equal(old)
+		},
+	})
+
 	w.WatchesRawSource(r.drains.wakeSource())
+}
+
+func inNodeGroup(obj client.Object) bool {
+	_, hasGroup := obj.GetLabels()[nodecommon.NodeGroupLabel]
+	return hasGroup
+}
+
+func stateFromNode(node *corev1.Node) state {
+	return state{
+		requestedBy:   node.Annotations[nodecommon.DrainingAnnotation],
+		recordedFor:   node.Annotations[nodecommon.DrainedAnnotation],
+		unschedulable: node.Spec.Unschedulable,
+	}
+}
+
+type state struct {
+	requestedBy   string
+	recordedFor   string
+	unschedulable bool
+}
+
+func (s state) equal(other state) bool {
+	return s == other
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -99,31 +148,32 @@ func (r *Reconciler) reconcileNode(ctx context.Context, node *corev1.Node) (_ ct
 		}
 	}()
 
-	requestedBy := drainSource(node, nodecommon.DrainingAnnotation)
-	recordedFor := drainSource(node, nodecommon.DrainedAnnotation)
+	state := stateFromNode(node)
 
 	// drained=user is never written any more, so it can only be a leftover: an
 	// upgraded cluster, or somebody setting it by hand.
-	if recordedFor == userSource {
+	if state.recordedFor == userSource {
 		logger.Info("removing an orphan drain result")
 		delete(node.Annotations, nodecommon.DrainedAnnotation)
 		return ctrl.Result{}, nil
 	}
 
 	// The request is gone: whoever asked has changed their mind.
-	if requestedBy == "" {
+	if state.requestedBy == "" {
 		return ctrl.Result{}, r.cancelDrain(ctx, logger, node)
 	}
 
 	// The eviction's outcome decides what is written, so it is collected first.
 	if finished, drainErr := r.drains.result(node.Name); finished {
-		return ctrl.Result{}, r.finishDrain(ctx, logger, node, requestedBy, drainErr)
+		return ctrl.Result{}, r.finishDrain(ctx, logger, node, state.requestedBy, drainErr)
 	}
 
-	return ctrl.Result{}, r.startDrain(ctx, logger, node, requestedBy)
+	return ctrl.Result{}, r.startDrain(ctx, logger, node, state.requestedBy)
 }
 
-// drainSource reads one drain annotation, empty when the node does not carry it.
+// drainSource reads the drain request off a node, empty when nobody asked. A
+// bare annotation means bashible: that is how the original hook behaved, and old
+// scripts still set it.
 func drainSource(node *corev1.Node, annotation string) string {
 	source, ok := node.Annotations[annotation]
 	if !ok {
@@ -208,13 +258,17 @@ func (r *Reconciler) finishDrain(_ context.Context, logger logr.Logger, node *co
 // pods must stop arriving before anything empties the node. The cordon's own
 // event brings us back.
 func (r *Reconciler) startDrain(ctx context.Context, logger logr.Logger, node *corev1.Node, source string) error {
-	timeout := nodecommon.DrainTimeout(ctx, r.Client, node.Labels[nodecommon.NodeGroupLabel])
-
 	if !node.Spec.Unschedulable {
 		logger.Info("cordoning node", "source", source)
 		node.Spec.Unschedulable = true
+
+		// The eviction starts on the pass this reconcile's own patch brings
+		// about: writing spec.unschedulable is one of the changes the watch
+		// admits, so nothing has to be requeued to come back.
 		return nil
 	}
+
+	timeout := nodecommon.DrainTimeout(ctx, r.Client, node.Labels[nodecommon.NodeGroupLabel])
 
 	return r.drains.start(logger, node.Name, timeout)
 }

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/draining/controller_test.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/draining/controller_test.go
@@ -457,9 +457,9 @@ func TestReconcile_DeletedNodeCancelsItsEviction(t *testing.T) {
 	}
 }
 
-// TestSetupWatches covers both halves of the subscription: only nodes in a
-// NodeGroup are admitted, and the wake channel a finished eviction writes to is
-// registered as a raw source, which WithEventFilter deliberately does not reach.
+// TestSetupWatches covers the subscription: the wake channel is registered as a
+// raw source, only nodes in a NodeGroup are admitted, and an update is admitted
+// only when something a drain depends on has changed.
 func TestSetupWatches(t *testing.T) {
 	w := &captureWatcher{}
 	(&Reconciler{drains: newDrainer(t.Context(), nil)}).SetupWatches(w)
@@ -471,21 +471,88 @@ func TestSetupWatches(t *testing.T) {
 		t.Fatal("no event filter was registered")
 	}
 
-	for _, tc := range []struct {
-		name   string
-		labels map[string]string
-		want   bool
-	}{
-		{name: "a node in a group", labels: map[string]string{nodecommon.NodeGroupLabel: nodeGroupName}, want: true},
-		{name: "a node in no group", want: false},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			obj := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName, Labels: tc.labels}}
-			if got := w.predicate.Create(event.CreateEvent{Object: obj}); got != tc.want {
-				t.Fatalf("admitted = %v, want %v", got, tc.want)
-			}
-		})
-	}
+	t.Run("create", func(t *testing.T) {
+		for _, tc := range []struct {
+			name   string
+			labels map[string]string
+			want   bool
+		}{
+			{name: "a node in a group", labels: map[string]string{nodecommon.NodeGroupLabel: nodeGroupName}, want: true},
+			{name: "a node in no group", want: false},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				obj := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName, Labels: tc.labels}}
+				if got := w.predicate.Create(event.CreateEvent{Object: obj}); got != tc.want {
+					t.Fatalf("admitted = %v, want %v", got, tc.want)
+				}
+			})
+		}
+	})
+
+	// A node is written constantly — kubelet refreshes its status every few
+	// seconds — and reconciling all of that would be one wake-up per node per
+	// heartbeat, for a controller with nothing to do about any of it.
+	t.Run("update", func(t *testing.T) {
+		for _, tc := range []struct {
+			name          string
+			before, after *corev1.Node
+			want          bool
+		}{
+			{
+				name:   "a status-only change is ignored",
+				before: node(map[string]string{nodecommon.DrainingAnnotation: bashibleSource}, false),
+				after:  withReady(node(map[string]string{nodecommon.DrainingAnnotation: bashibleSource}, false)),
+			},
+			{
+				name:   "a request appearing is admitted",
+				before: node(nil, false),
+				after:  node(map[string]string{nodecommon.DrainingAnnotation: bashibleSource}, false),
+				want:   true,
+			},
+			{
+				name:   "a request being withdrawn is admitted",
+				before: node(map[string]string{nodecommon.DrainingAnnotation: bashibleSource}, true),
+				after:  node(nil, true),
+				want:   true,
+			},
+			{
+				name:   "a recorded result is admitted",
+				before: node(map[string]string{nodecommon.DrainingAnnotation: bashibleSource}, true),
+				after:  node(map[string]string{nodecommon.DrainedAnnotation: bashibleSource}, true),
+				want:   true,
+			},
+			{
+				// This is what brings the eviction's own pass about.
+				name:   "the cordon being written is admitted",
+				before: node(map[string]string{nodecommon.DrainingAnnotation: bashibleSource}, false),
+				after:  node(map[string]string{nodecommon.DrainingAnnotation: bashibleSource}, true),
+				want:   true,
+			},
+			{
+				name:   "a node in no group is never admitted",
+				before: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}},
+				after: &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+					Name:        nodeName,
+					Annotations: map[string]string{nodecommon.DrainingAnnotation: bashibleSource},
+				}},
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				got := w.predicate.Update(event.UpdateEvent{ObjectOld: tc.before, ObjectNew: tc.after})
+				if got != tc.want {
+					t.Fatalf("admitted = %v, want %v", got, tc.want)
+				}
+			})
+		}
+	})
+}
+
+// withReady marks the node Ready, standing in for the status churn a kubelet
+// produces without touching anything a drain reads.
+func withReady(n *corev1.Node) *corev1.Node {
+	n.Status.Conditions = []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}}
+
+	return n
 }
 
 // metricValue reads the current d8_node_draining gauge value for a node, summing

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/draining/controller_test.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/draining/controller_test.go
@@ -56,6 +56,11 @@ const (
 	nodeName      = "node-1"
 	nodeGroupName = "worker"
 	taskWait      = 10 * time.Second
+
+	// drainPasses caps how many reconciles a drain is given to get going, and
+	// wakePoll is how long each one waits for the eviction to report back.
+	drainPasses = 6
+	wakePoll    = 500 * time.Millisecond
 )
 
 // harness is a Reconciler wired to fake clients, plus the two channels the tests
@@ -130,28 +135,30 @@ func (h *harness) node(t *testing.T) *corev1.Node {
 	return fresh
 }
 
-// drain runs the reconciles a background eviction takes and returns the error of
-// the last one, because that is where a failed eviction surfaces. A node that
-// arrives schedulable needs one pass more: the pass that writes the cordon is
-// not the pass that starts the eviction.
+// drain drives a full drain and returns the error of the pass that collects the
+// result, because that is where a failed eviction surfaces.
+//
+// The flow spends a pass or two getting the node ready — a stale drained=user to
+// strip, a cordon to write — so this reconciles until the eviction reports back
+// instead of assuming a fixed number of passes.
 func (h *harness) drain(t *testing.T) error {
 	t.Helper()
 
-	cordoned := h.node(t).Spec.Unschedulable
-	h.reconcile(t)
-	if !cordoned {
+	for range drainPasses {
 		h.reconcile(t)
+
+		select {
+		case <-h.drains.wake:
+			_, err := h.Reconcile(context.Background(), request())
+
+			return err
+		case <-time.After(wakePoll):
+		}
 	}
 
-	select {
-	case <-h.drains.wake:
-	case <-time.After(taskWait):
-		t.Fatal("timed out waiting for the eviction to finish")
-	}
+	t.Fatal("the eviction never reported back")
 
-	_, err := h.Reconcile(context.Background(), request())
-
-	return err
+	return nil
 }
 
 func (h *harness) mustDrain(t *testing.T) {
@@ -221,9 +228,9 @@ func TestReconcile_Drain(t *testing.T) {
 			want:        map[string]string{nodecommon.DrainedAnnotation: "machine-controller"},
 		},
 		{
-			name:        "a hand drain records nothing, since nobody polls for it",
+			name:        "a hand drain records its own source",
 			annotations: map[string]string{nodecommon.DrainingAnnotation: userSource},
-			want:        nil,
+			want:        map[string]string{nodecommon.DrainedAnnotation: userSource},
 		},
 		{
 			name:          "an already cordoned node still drains",
@@ -236,6 +243,14 @@ func TestReconcile_Drain(t *testing.T) {
 			annotations: map[string]string{
 				nodecommon.DrainingAnnotation: bashibleSource,
 				nodecommon.DrainedAnnotation:  "",
+			},
+			want: map[string]string{nodecommon.DrainedAnnotation: bashibleSource},
+		},
+		{
+			name: "a stale drained=user is replaced by the new drain's own result",
+			annotations: map[string]string{
+				nodecommon.DrainingAnnotation: bashibleSource,
+				nodecommon.DrainedAnnotation:  userSource,
 			},
 			want: map[string]string{nodecommon.DrainedAnnotation: bashibleSource},
 		},
@@ -262,7 +277,8 @@ func TestReconcile_Drain(t *testing.T) {
 }
 
 // TestReconcile_NoLiveRequest covers what a node without a request in flight
-// gets from a single pass: nothing, except an orphan result being dropped.
+// gets from a single pass: nothing, except a stale drained=user being dropped
+// once the node is back in service.
 func TestReconcile_NoLiveRequest(t *testing.T) {
 	for _, tc := range []struct {
 		name              string
@@ -275,22 +291,17 @@ func TestReconcile_NoLiveRequest(t *testing.T) {
 			name: "a node nobody asked about is left alone",
 		},
 		{
-			name:        "an orphan result is dropped from a schedulable node",
+			name:        "a stale drained=user is dropped from a schedulable node",
 			annotations: map[string]string{nodecommon.DrainedAnnotation: userSource},
 		},
 		{
-			name:              "an orphan result is dropped from a cordoned node too",
+			// On a cordoned node it still marks a drain somebody is dealing
+			// with, so it is left where it is.
+			name:              "drained=user stays on a cordoned node",
 			annotations:       map[string]string{nodecommon.DrainedAnnotation: userSource},
 			unschedulable:     true,
+			want:              map[string]string{nodecommon.DrainedAnnotation: userSource},
 			wantUnschedulable: true,
-		},
-		{
-			name: "an orphan result is dropped before a new request is looked at",
-			annotations: map[string]string{
-				nodecommon.DrainingAnnotation: bashibleSource,
-				nodecommon.DrainedAnnotation:  userSource,
-			},
-			want: map[string]string{nodecommon.DrainingAnnotation: bashibleSource},
 		},
 		{
 			name:        "a recorded bashible result is left alone",
@@ -367,6 +378,30 @@ func TestReconcile_EvictionEndsBadly(t *testing.T) {
 				t.Fatalf("failure gauge = %v, want 1", got)
 			}
 		})
+	}
+}
+
+// The stale marker is stripped on a pass of its own, before the cordon: left
+// there it would read as the new drain's own result, and a second hand drain
+// would never overwrite it.
+func TestReconcile_StaleUserResultIsClearedBeforeTheDrain(t *testing.T) {
+	h := newHarness(t, fake.NewSimpleClientset(), nodeGroup(nil), node(map[string]string{
+		nodecommon.DrainingAnnotation: userSource,
+		nodecommon.DrainedAnnotation:  userSource,
+	}, false))
+
+	h.reconcile(t)
+
+	afterFirst := h.node(t)
+	assertAnnotations(t, afterFirst, map[string]string{nodecommon.DrainingAnnotation: userSource})
+	if afterFirst.Spec.Unschedulable {
+		t.Fatal("the pass that strips the marker should not also cordon the node")
+	}
+
+	h.reconcile(t)
+
+	if !h.node(t).Spec.Unschedulable {
+		t.Fatal("the next pass should have cordoned the node")
 	}
 }
 

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/draining/controller_test.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/draining/controller_test.go
@@ -457,10 +457,18 @@ func TestReconcile_DeletedNodeCancelsItsEviction(t *testing.T) {
 	}
 }
 
-func TestForPredicates_AdmitsOnlyNodesInANodeGroup(t *testing.T) {
-	predicates := (&Reconciler{}).ForPredicates()
-	if len(predicates) != 1 {
-		t.Fatalf("got %d predicates, want 1", len(predicates))
+// TestSetupWatches covers both halves of the subscription: only nodes in a
+// NodeGroup are admitted, and the wake channel a finished eviction writes to is
+// registered as a raw source, which WithEventFilter deliberately does not reach.
+func TestSetupWatches(t *testing.T) {
+	w := &captureWatcher{}
+	(&Reconciler{drains: newDrainer(t.Context(), nil)}).SetupWatches(w)
+
+	if len(w.rawSources) != 1 {
+		t.Fatalf("got %d raw sources, want the wake channel", len(w.rawSources))
+	}
+	if w.predicate == nil {
+		t.Fatal("no event filter was registered")
 	}
 
 	for _, tc := range []struct {
@@ -473,27 +481,10 @@ func TestForPredicates_AdmitsOnlyNodesInANodeGroup(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			obj := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName, Labels: tc.labels}}
-			if got := predicates[0].Create(event.CreateEvent{Object: obj}); got != tc.want {
+			if got := w.predicate.Create(event.CreateEvent{Object: obj}); got != tc.want {
 				t.Fatalf("admitted = %v, want %v", got, tc.want)
 			}
 		})
-	}
-}
-
-// The wake channel must be a raw source and the group filter must not be a
-// global event filter: a global one would also drop the name-only Node that
-// carries a finished eviction back into the workqueue.
-func TestSetupWatches_RegistersTheWakeChannelWithoutAGlobalFilter(t *testing.T) {
-	r := &Reconciler{drains: newDrainer(t.Context(), nil)}
-	w := &captureWatcher{}
-
-	r.SetupWatches(w)
-
-	if len(w.rawSources) != 1 {
-		t.Fatalf("got %d raw sources, want 1", len(w.rawSources))
-	}
-	if w.predicate != nil {
-		t.Fatal("the group filter must not be registered as a global event filter")
 	}
 }
 

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/draining/controller_test.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/draining/controller_test.go
@@ -58,13 +58,13 @@ const (
 	taskWait      = 10 * time.Second
 
 	// drainPasses caps how many reconciles a drain is given to get going, and
-	// wakePoll is how long each one waits for the eviction to report back.
+	// wakePoll is how long each one waits for the drain to report back.
 	drainPasses = 6
 	wakePoll    = 500 * time.Millisecond
 )
 
 // harness is a Reconciler wired to fake clients, plus the two channels the tests
-// read: the wake channel a finished eviction writes to, and the recorded events.
+// read: the wake channel a finished drain writes to, and the recorded events.
 type harness struct {
 	*Reconciler
 	events chan string
@@ -136,10 +136,10 @@ func (h *harness) node(t *testing.T) *corev1.Node {
 }
 
 // drain drives a full drain and returns the error of the pass that collects the
-// result, because that is where a failed eviction surfaces.
+// result, because that is where a failed drain surfaces.
 //
 // The flow spends a pass or two getting the node ready — a stale drained=user to
-// strip, a cordon to write — so this reconciles until the eviction reports back
+// strip, a cordon to write — so this reconciles until the drain reports back
 // instead of assuming a fixed number of passes.
 func (h *harness) drain(t *testing.T) error {
 	t.Helper()
@@ -168,7 +168,7 @@ func (h *harness) mustDrain(t *testing.T) {
 	}
 }
 
-// blockUntilCancelled registers an eviction that does nothing but wait to be
+// blockUntilCancelled registers a drain that does nothing but wait to be
 // cancelled — the in-memory state a reconcile sees while a real one is in
 // flight, without having to stall a fake clientset to get there.
 func (h *harness) blockUntilCancelled(t *testing.T) {
@@ -202,8 +202,8 @@ func assertAnnotations(t *testing.T, got *corev1.Node, want map[string]string) {
 	}
 }
 
-// TestReconcile_Drain walks a request from the annotation that asks for an
-// eviction to the annotations that record it.
+// TestReconcile_Drain walks a request from the annotation that asks for a
+// drain to the annotations that record it.
 func TestReconcile_Drain(t *testing.T) {
 	for _, tc := range []struct {
 		name          string
@@ -332,7 +332,7 @@ func TestReconcile_NoLiveRequest(t *testing.T) {
 	}
 }
 
-// TestReconcile_EvictionEndsBadly covers the two ways an eviction fails, which
+// TestReconcile_EvictionEndsBadly covers the two ways a drain fails, which
 // are handled differently: a failure is retried, a deadline is not.
 func TestReconcile_EvictionEndsBadly(t *testing.T) {
 	for _, tc := range []struct {
@@ -405,7 +405,7 @@ func TestReconcile_StaleUserResultIsClearedBeforeTheDrain(t *testing.T) {
 	}
 }
 
-// The cordon has to be durable before the eviction starts: pods must stop being
+// The cordon has to be durable before the drain starts: pods must stop being
 // scheduled onto the node before anything begins emptying it.
 func TestReconcile_CordonIsWrittenBeforeTheEvictionStarts(t *testing.T) {
 	h := newHarness(t, fake.NewSimpleClientset(),
@@ -421,7 +421,7 @@ func TestReconcile_CordonIsWrittenBeforeTheEvictionStarts(t *testing.T) {
 	}
 }
 
-// Withdrawing the request stops the eviction instead of letting it run to
+// Withdrawing the request stops the drain instead of letting it run to
 // completion and record a result nobody asked for.
 func TestReconcile_WithdrawnRequestCancelsEviction(t *testing.T) {
 	h := newHarness(t, fake.NewSimpleClientset(), node(nil, true))
@@ -439,7 +439,7 @@ func TestReconcile_WithdrawnRequestCancelsEviction(t *testing.T) {
 	h.awaitEvent(t, "DrainCancelled")
 }
 
-// A reconcile arriving while the eviction runs must not disturb it.
+// A reconcile arriving while the drain runs must not disturb it.
 func TestReconcile_RunningEvictionIsLeftAlone(t *testing.T) {
 	h := newHarness(t, fake.NewSimpleClientset(),
 		node(map[string]string{nodecommon.DrainingAnnotation: bashibleSource}, true))
@@ -453,7 +453,7 @@ func TestReconcile_RunningEvictionIsLeftAlone(t *testing.T) {
 	}
 }
 
-// A collected result frees the id, so a failed eviction is followed by a fresh
+// A collected result frees the id, so a failed drain is followed by a fresh
 // one rather than by the same result for ever.
 func TestReconcile_FailedEvictionIsRetriedWithAFreshTask(t *testing.T) {
 	cs := fake.NewSimpleClientset()
@@ -471,7 +471,7 @@ func TestReconcile_FailedEvictionIsRetriedWithAFreshTask(t *testing.T) {
 	}
 }
 
-// A deleted node's eviction is abandoned rather than left evicting pods on
+// A deleted node's drain is abandoned rather than left evicting pods on
 // behalf of an object nobody can see.
 func TestReconcile_DeletedNodeCancelsItsEviction(t *testing.T) {
 	h := newHarness(t, fake.NewSimpleClientset())
@@ -554,7 +554,7 @@ func TestSetupWatches(t *testing.T) {
 				want:   true,
 			},
 			{
-				// This is what brings the eviction's own pass about.
+				// This is what brings the drain's own pass about.
 				name:   "the cordon being written is admitted",
 				before: node(map[string]string{nodecommon.DrainingAnnotation: bashibleSource}, false),
 				after:  node(map[string]string{nodecommon.DrainingAnnotation: bashibleSource}, true),
@@ -587,7 +587,7 @@ func withReady(n *corev1.Node) *corev1.Node {
 	return n
 }
 
-// The eviction's context tells the drainer why the task ended: a cancelled one
+// The drain's context tells the drainer why the task ended: a cancelled one
 // is skipped, a deadline still has to bring the node back to be recorded.
 func TestWakeNode_SkipsOnlyCancelledEvictions(t *testing.T) {
 	for _, tc := range []struct {

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/draining/controller_test.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/draining/controller_test.go
@@ -19,7 +19,10 @@ package draining
 import (
 	"context"
 	"errors"
+	"maps"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
@@ -27,30 +30,44 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/rest"
 	k8stesting "k8s.io/client-go/testing"
-	"k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	v1 "github.com/deckhouse/node-controller/api/deckhouse.io/v1"
 	nodecommon "github.com/deckhouse/node-controller/internal/common"
 	"github.com/deckhouse/node-controller/internal/register"
+	"github.com/deckhouse/node-controller/internal/task"
 )
 
 var errBoom = errors.New("boom")
 
-func newReconciler(t *testing.T, objs ...runtime.Object) *Reconciler {
+const (
+	nodeName      = "node-1"
+	nodeGroupName = "worker"
+	taskWait      = 10 * time.Second
+)
+
+// harness is a Reconciler wired to fake clients, plus the two channels the tests
+// read: the wake channel a finished eviction writes to, and the recorded events.
+type harness struct {
+	*Reconciler
+	events chan string
+}
+
+func newHarness(t *testing.T, kubeClient kubernetes.Interface, objs ...runtime.Object) *harness {
 	t.Helper()
+
 	scheme := runtime.NewScheme()
 	if err := corev1.AddToScheme(scheme); err != nil {
 		t.Fatalf("add corev1 scheme: %v", err)
@@ -59,403 +76,430 @@ func newReconciler(t *testing.T, objs ...runtime.Object) *Reconciler {
 		t.Fatalf("add v1 scheme: %v", err)
 	}
 	cl := fakeclient.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).Build()
-	return &Reconciler{
-		Base:       register.Base{Client: cl, Recorder: record.NewFakeRecorder(10)},
-		kubeClient: fake.NewSimpleClientset(),
-	}
-}
 
-func getNode(t *testing.T, r *Reconciler, name string) *corev1.Node {
-	t.Helper()
-	node := &corev1.Node{}
-	if err := r.Client.Get(context.Background(), types.NamespacedName{Name: name}, node); err != nil {
-		t.Fatalf("get node %s: %v", name, err)
-	}
-	return node
-}
+	recorder := record.NewFakeRecorder(10)
 
-func reconcile(t *testing.T, r *Reconciler, name string) ctrl.Result {
-	t.Helper()
-	res, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: name}})
-	if err != nil {
-		t.Fatalf("reconcile %s: %v", name, err)
-	}
-	return res
-}
-
-func TestReconcile_NoAnnotations_Noop(t *testing.T) {
-	node := &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   "node-1",
-			Labels: map[string]string{nodecommon.NodeGroupLabel: "worker"},
+	return &harness{
+		Reconciler: &Reconciler{
+			Base:   register.Base{Client: cl, Recorder: recorder},
+			drains: newDrainer(t.Context(), kubeClient),
 		},
-	}
-
-	r := newReconciler(t, node)
-	reconcile(t, r, "node-1")
-
-	updated := getNode(t, r, "node-1")
-	if updated.Spec.Unschedulable {
-		t.Fatal("node should not be cordoned without draining annotation")
+		events: recorder.Events,
 	}
 }
 
-func TestReconcile_DrainingAnnotation_CordonsAndDrains(t *testing.T) {
-	node := &corev1.Node{
+// node builds a node the controller's predicate admits.
+func node(annotations map[string]string, unschedulable bool) *corev1.Node {
+	return &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "node-1",
-			Labels:      map[string]string{nodecommon.NodeGroupLabel: "worker"},
-			Annotations: map[string]string{nodecommon.DrainingAnnotation: "bashible"},
+			Name:        nodeName,
+			Labels:      map[string]string{nodecommon.NodeGroupLabel: nodeGroupName},
+			Annotations: annotations,
 		},
-	}
-
-	r := newReconciler(t, node)
-	reconcile(t, r, "node-1")
-
-	updated := getNode(t, r, "node-1")
-
-	// Should be cordoned
-	if !updated.Spec.Unschedulable {
-		t.Fatal("node should be cordoned after draining")
-	}
-
-	// Draining annotation should be removed, drained should be set
-	if _, exists := updated.Annotations[nodecommon.DrainingAnnotation]; exists {
-		t.Fatal("draining annotation should be removed")
-	}
-	if updated.Annotations[nodecommon.DrainedAnnotation] != "bashible" {
-		t.Fatalf("expected drained annotation 'bashible', got %q", updated.Annotations[nodecommon.DrainedAnnotation])
+		Spec: corev1.NodeSpec{Unschedulable: unschedulable},
 	}
 }
 
-func TestReconcile_DrainedUserSchedulable_RemovesDrained(t *testing.T) {
-	node := &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        "node-1",
-			Labels:      map[string]string{nodecommon.NodeGroupLabel: "worker"},
-			Annotations: map[string]string{nodecommon.DrainedAnnotation: "user"},
-		},
-		Spec: corev1.NodeSpec{Unschedulable: false},
-	}
-
-	r := newReconciler(t, node)
-	reconcile(t, r, "node-1")
-
-	updated := getNode(t, r, "node-1")
-	if _, exists := updated.Annotations[nodecommon.DrainedAnnotation]; exists {
-		t.Fatal("drained annotation should be removed for schedulable node with user source")
-	}
-}
-
-func TestReconcile_DrainedNonUser_Noop(t *testing.T) {
-	node := &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        "node-1",
-			Labels:      map[string]string{nodecommon.NodeGroupLabel: "worker"},
-			Annotations: map[string]string{nodecommon.DrainedAnnotation: "bashible"},
-		},
-		Spec: corev1.NodeSpec{Unschedulable: false},
-	}
-
-	r := newReconciler(t, node)
-	reconcile(t, r, "node-1")
-
-	updated := getNode(t, r, "node-1")
-	if updated.Annotations[nodecommon.DrainedAnnotation] != "bashible" {
-		t.Fatal("drained annotation should remain for non-user source")
-	}
-}
-
-func TestReconcile_AlreadyCordoned_StillDrains(t *testing.T) {
-	node := &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        "node-1",
-			Labels:      map[string]string{nodecommon.NodeGroupLabel: "worker"},
-			Annotations: map[string]string{nodecommon.DrainingAnnotation: "bashible"},
-		},
-		Spec: corev1.NodeSpec{Unschedulable: true},
-	}
-
-	r := newReconciler(t, node)
-	reconcile(t, r, "node-1")
-
-	updated := getNode(t, r, "node-1")
-	if _, exists := updated.Annotations[nodecommon.DrainingAnnotation]; exists {
-		t.Fatal("draining annotation should be removed")
-	}
-	if updated.Annotations[nodecommon.DrainedAnnotation] != "bashible" {
-		t.Fatalf("expected drained annotation 'bashible', got %q", updated.Annotations[nodecommon.DrainedAnnotation])
-	}
-}
-
-func TestReconcile_DrainingWithUserDrained_RemovesDrainedFirst(t *testing.T) {
-	node := &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   "node-1",
-			Labels: map[string]string{nodecommon.NodeGroupLabel: "worker"},
-			Annotations: map[string]string{
-				nodecommon.DrainingAnnotation: "bashible",
-				nodecommon.DrainedAnnotation:  "user",
-			},
-		},
-	}
-
-	r := newReconciler(t, node)
-	reconcile(t, r, "node-1")
-
-	updated := getNode(t, r, "node-1")
-	if updated.Annotations[nodecommon.DrainedAnnotation] != "bashible" {
-		t.Fatalf("expected drained annotation to be set to 'bashible', got %q", updated.Annotations[nodecommon.DrainedAnnotation])
-	}
-}
-
-func TestReconcile_NodeNotFound_NoError(t *testing.T) {
-	r := newReconciler(t)
-	reconcile(t, r, "nonexistent")
-}
-
-func TestReconcile_DrainTimeoutFromNodeGroup_DrainsWithConfiguredTimeout(t *testing.T) {
-	timeout := 42
-	ng := &v1.NodeGroup{
-		ObjectMeta: metav1.ObjectMeta{Name: "worker"},
+func nodeGroup(drainTimeout *int) *v1.NodeGroup {
+	return &v1.NodeGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: nodeGroupName},
 		Spec: v1.NodeGroupSpec{
 			NodeType:               v1.NodeTypeStatic,
-			NodeDrainTimeoutSecond: &timeout,
+			NodeDrainTimeoutSecond: drainTimeout,
 		},
-	}
-	node := &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        "node-1",
-			Labels:      map[string]string{nodecommon.NodeGroupLabel: "worker"},
-			Annotations: map[string]string{nodecommon.DrainingAnnotation: "bashible"},
-		},
-	}
-
-	r := newReconciler(t, ng, node)
-	reconcile(t, r, "node-1")
-
-	updated := getNode(t, r, "node-1")
-	if updated.Annotations[nodecommon.DrainedAnnotation] != "bashible" {
-		t.Fatalf("expected drained=bashible, got %q", updated.Annotations[nodecommon.DrainedAnnotation])
 	}
 }
 
-// Empty draining annotation value is treated as "bashible" for backward compatibility.
-func TestReconcile_EmptyDrainingAnnotation_TreatedAsBashible(t *testing.T) {
-	node := &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        "node-1",
-			Labels:      map[string]string{nodecommon.NodeGroupLabel: "worker"},
-			Annotations: map[string]string{nodecommon.DrainingAnnotation: ""},
-		},
-	}
-
-	r := newReconciler(t, node)
-	reconcile(t, r, "node-1")
-
-	updated := getNode(t, r, "node-1")
-	if !updated.Spec.Unschedulable {
-		t.Fatal("node should be cordoned for empty draining annotation")
-	}
-	if updated.Annotations[nodecommon.DrainedAnnotation] != "bashible" {
-		t.Fatalf("expected drained=bashible, got %q", updated.Annotations[nodecommon.DrainedAnnotation])
+func (h *harness) reconcile(t *testing.T) {
+	t.Helper()
+	if _, err := h.Reconcile(context.Background(), request()); err != nil {
+		t.Fatalf("reconcile: %v", err)
 	}
 }
 
-// Custom source is preserved verbatim into the drained annotation.
-func TestReconcile_CustomSource_PreservedInDrained(t *testing.T) {
-	node := &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        "node-1",
-			Labels:      map[string]string{nodecommon.NodeGroupLabel: "worker"},
-			Annotations: map[string]string{nodecommon.DrainingAnnotation: "machine-controller"},
-		},
+func request() ctrl.Request {
+	return ctrl.Request{NamespacedName: types.NamespacedName{Name: nodeName}}
+}
+
+func (h *harness) node(t *testing.T) *corev1.Node {
+	t.Helper()
+	fresh := &corev1.Node{}
+	if err := h.Client.Get(context.Background(), types.NamespacedName{Name: nodeName}, fresh); err != nil {
+		t.Fatalf("get node: %v", err)
+	}
+	return fresh
+}
+
+// drain runs the reconciles a background eviction takes and returns the error of
+// the last one, because that is where a failed eviction surfaces. A node that
+// arrives schedulable needs one pass more: the pass that writes the cordon is
+// not the pass that starts the eviction.
+func (h *harness) drain(t *testing.T) error {
+	t.Helper()
+
+	cordoned := h.node(t).Spec.Unschedulable
+	h.reconcile(t)
+	if !cordoned {
+		h.reconcile(t)
 	}
 
-	r := newReconciler(t, node)
-	reconcile(t, r, "node-1")
+	select {
+	case <-h.drains.wake:
+	case <-time.After(taskWait):
+		t.Fatal("timed out waiting for the eviction to finish")
+	}
 
-	updated := getNode(t, r, "node-1")
-	if updated.Annotations[nodecommon.DrainedAnnotation] != "machine-controller" {
-		t.Fatalf("expected drained=machine-controller, got %q", updated.Annotations[nodecommon.DrainedAnnotation])
+	_, err := h.Reconcile(context.Background(), request())
+
+	return err
+}
+
+func (h *harness) mustDrain(t *testing.T) {
+	t.Helper()
+	if err := h.drain(t); err != nil {
+		t.Fatalf("drain: %v", err)
 	}
 }
 
-// An empty drained annotation value is normalized to "bashible", so it is not
-// treated as a user drain and the pre-drain removal step is skipped.
-func TestReconcile_EmptyDrainedAnnotation_NormalizedNotUser(t *testing.T) {
-	node := &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   "node-1",
-			Labels: map[string]string{nodecommon.NodeGroupLabel: "worker"},
-			Annotations: map[string]string{
-				nodecommon.DrainingAnnotation: "bashible",
+// blockUntilCancelled registers an eviction that does nothing but wait to be
+// cancelled — the in-memory state a reconcile sees while a real one is in
+// flight, without having to stall a fake clientset to get there.
+func (h *harness) blockUntilCancelled(t *testing.T) {
+	t.Helper()
+	err := h.drains.tasks.Start(t.Context(), task.TaskID(nodeName),
+		func(ctx context.Context) error {
+			<-ctx.Done()
+			return ctx.Err()
+		}, nil)
+	if err != nil {
+		t.Fatalf("start a blocking eviction: %v", err)
+	}
+}
+
+func (h *harness) awaitEvent(t *testing.T, reason string) {
+	t.Helper()
+	select {
+	case ev := <-h.events:
+		if !strings.Contains(ev, reason) {
+			t.Fatalf("got event %q, want one mentioning %q", ev, reason)
+		}
+	case <-time.After(taskWait):
+		t.Fatalf("no %s event was recorded", reason)
+	}
+}
+
+func assertAnnotations(t *testing.T, got *corev1.Node, want map[string]string) {
+	t.Helper()
+	if !maps.Equal(got.Annotations, want) {
+		t.Fatalf("annotations = %v, want %v", got.Annotations, want)
+	}
+}
+
+// TestReconcile_Drain walks a request from the annotation that asks for an
+// eviction to the annotations that record it.
+func TestReconcile_Drain(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		annotations   map[string]string
+		unschedulable bool
+		drainTimeout  *int
+		want          map[string]string
+	}{
+		{
+			name:        "a bashible request is recorded",
+			annotations: map[string]string{nodecommon.DrainingAnnotation: bashibleSource},
+			want:        map[string]string{nodecommon.DrainedAnnotation: bashibleSource},
+		},
+		{
+			name:        "an empty request value means bashible",
+			annotations: map[string]string{nodecommon.DrainingAnnotation: ""},
+			want:        map[string]string{nodecommon.DrainedAnnotation: bashibleSource},
+		},
+		{
+			name:        "a custom source is preserved",
+			annotations: map[string]string{nodecommon.DrainingAnnotation: "machine-controller"},
+			want:        map[string]string{nodecommon.DrainedAnnotation: "machine-controller"},
+		},
+		{
+			name:        "a hand drain records nothing, since nobody polls for it",
+			annotations: map[string]string{nodecommon.DrainingAnnotation: userSource},
+			want:        nil,
+		},
+		{
+			name:          "an already cordoned node still drains",
+			annotations:   map[string]string{nodecommon.DrainingAnnotation: bashibleSource},
+			unschedulable: true,
+			want:          map[string]string{nodecommon.DrainedAnnotation: bashibleSource},
+		},
+		{
+			name: "an empty result value is not the user source, so it is overwritten",
+			annotations: map[string]string{
+				nodecommon.DrainingAnnotation: bashibleSource,
 				nodecommon.DrainedAnnotation:  "",
 			},
+			want: map[string]string{nodecommon.DrainedAnnotation: bashibleSource},
 		},
-	}
+		{
+			name:         "the node group's drain timeout is honoured",
+			annotations:  map[string]string{nodecommon.DrainingAnnotation: bashibleSource},
+			drainTimeout: ptr.To(42),
+			want:         map[string]string{nodecommon.DrainedAnnotation: bashibleSource},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newHarness(t, fake.NewSimpleClientset(),
+				nodeGroup(tc.drainTimeout), node(tc.annotations, tc.unschedulable))
 
-	r := newReconciler(t, node)
-	reconcile(t, r, "node-1")
+			h.mustDrain(t)
 
-	updated := getNode(t, r, "node-1")
-	if updated.Annotations[nodecommon.DrainedAnnotation] != "bashible" {
-		t.Fatalf("expected drained=bashible, got %q", updated.Annotations[nodecommon.DrainedAnnotation])
-	}
-	if !updated.Spec.Unschedulable {
-		t.Fatal("node should be cordoned")
+			updated := h.node(t)
+			assertAnnotations(t, updated, tc.want)
+			if !updated.Spec.Unschedulable {
+				t.Fatal("a drained node must stay cordoned")
+			}
+		})
 	}
 }
 
-// A non-timeout drain failure must return the error, set the failure gauge, and
-// leave the draining annotation untouched (no drained annotation written).
-func TestReconcile_DrainFails_ReturnsErrorAndSetsMetric(t *testing.T) {
-	node := &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        "node-1",
-			Labels:      map[string]string{nodecommon.NodeGroupLabel: "worker"},
-			Annotations: map[string]string{nodecommon.DrainingAnnotation: "bashible"},
+// TestReconcile_NoLiveRequest covers what a node without a request in flight
+// gets from a single pass: nothing, except an orphan result being dropped.
+func TestReconcile_NoLiveRequest(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		annotations       map[string]string
+		unschedulable     bool
+		want              map[string]string
+		wantUnschedulable bool
+	}{
+		{
+			name: "a node nobody asked about is left alone",
 		},
-	}
+		{
+			name:        "an orphan result is dropped from a schedulable node",
+			annotations: map[string]string{nodecommon.DrainedAnnotation: userSource},
+		},
+		{
+			name:              "an orphan result is dropped from a cordoned node too",
+			annotations:       map[string]string{nodecommon.DrainedAnnotation: userSource},
+			unschedulable:     true,
+			wantUnschedulable: true,
+		},
+		{
+			name: "an orphan result is dropped before a new request is looked at",
+			annotations: map[string]string{
+				nodecommon.DrainingAnnotation: bashibleSource,
+				nodecommon.DrainedAnnotation:  userSource,
+			},
+			want: map[string]string{nodecommon.DrainingAnnotation: bashibleSource},
+		},
+		{
+			name:        "a recorded bashible result is left alone",
+			annotations: map[string]string{nodecommon.DrainedAnnotation: bashibleSource},
+			want:        map[string]string{nodecommon.DrainedAnnotation: bashibleSource},
+		},
+		{
+			// The cordon of a drained node belongs to updateapproval until the
+			// configuration checksums match, so it must survive this controller.
+			name:              "a cordon with no eviction behind it is left alone",
+			annotations:       map[string]string{nodecommon.DrainedAnnotation: bashibleSource},
+			unschedulable:     true,
+			want:              map[string]string{nodecommon.DrainedAnnotation: bashibleSource},
+			wantUnschedulable: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newHarness(t, fake.NewSimpleClientset(), node(tc.annotations, tc.unschedulable))
 
-	scheme := runtime.NewScheme()
-	if err := corev1.AddToScheme(scheme); err != nil {
-		t.Fatalf("add scheme: %v", err)
-	}
-	cl := fakeclient.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(node).Build()
+			h.reconcile(t)
 
+			updated := h.node(t)
+			assertAnnotations(t, updated, tc.want)
+			if updated.Spec.Unschedulable != tc.wantUnschedulable {
+				t.Fatalf("unschedulable = %v, want %v", updated.Spec.Unschedulable, tc.wantUnschedulable)
+			}
+		})
+	}
+}
+
+// TestReconcile_EvictionEndsBadly covers the two ways an eviction fails, which
+// are handled differently: a failure is retried, a deadline is not.
+func TestReconcile_EvictionEndsBadly(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		drainTimeout *int
+		wantErr      bool
+		want         map[string]string
+	}{
+		{
+			name:    "a failure keeps the request, so the requeue retries it",
+			wantErr: true,
+			want:    map[string]string{nodecommon.DrainingAnnotation: bashibleSource},
+		},
+		{
+			// Retrying would get no further and the node's update must not
+			// wedge, so the request is consumed and the result recorded.
+			name:         "a deadline is recorded as drained anyway",
+			drainTimeout: ptr.To(0),
+			want:         map[string]string{nodecommon.DrainedAnnotation: bashibleSource},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cs := fake.NewSimpleClientset()
+			cs.PrependReactor("list", "pods", func(k8stesting.Action) (bool, runtime.Object, error) {
+				return true, nil, errBoom
+			})
+			h := newHarness(t, cs, nodeGroup(tc.drainTimeout),
+				node(map[string]string{nodecommon.DrainingAnnotation: bashibleSource}, false))
+			t.Cleanup(func() { clearDrainMetric(nodeName) })
+
+			err := h.drain(t)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("drain err = %v, want error: %v", err, tc.wantErr)
+			}
+
+			updated := h.node(t)
+			assertAnnotations(t, updated, tc.want)
+			if !updated.Spec.Unschedulable {
+				t.Fatal("a node whose eviction failed must stay cordoned")
+			}
+			// Both outcomes have to reach NodeStuckInDraining.
+			if got := metricValue(t, nodeName); got != 1 {
+				t.Fatalf("failure gauge = %v, want 1", got)
+			}
+		})
+	}
+}
+
+// The cordon has to be durable before the eviction starts: pods must stop being
+// scheduled onto the node before anything begins emptying it.
+func TestReconcile_CordonIsWrittenBeforeTheEvictionStarts(t *testing.T) {
+	h := newHarness(t, fake.NewSimpleClientset(),
+		node(map[string]string{nodecommon.DrainingAnnotation: bashibleSource}, false))
+
+	h.reconcile(t)
+
+	if !h.node(t).Spec.Unschedulable {
+		t.Fatal("the first pass should have written the cordon")
+	}
+	if running, err := h.drains.cancel(t.Context(), nodeName); err != nil || running {
+		t.Fatalf("cancel = (%v, %v): no eviction should have started yet", running, err)
+	}
+}
+
+// Withdrawing the request stops the eviction and gives the node back, instead of
+// letting it run to completion and recording a result nobody asked for.
+func TestReconcile_WithdrawnRequestCancelsAndUncordons(t *testing.T) {
+	h := newHarness(t, fake.NewSimpleClientset(), node(nil, true))
+	nodeDrainingGauge.WithLabelValues(nodeName, "boom").Set(1)
+	t.Cleanup(func() { clearDrainMetric(nodeName) })
+
+	h.blockUntilCancelled(t)
+	h.reconcile(t)
+
+	updated := h.node(t)
+	if updated.Spec.Unschedulable {
+		t.Fatal("a cancelled eviction should have uncordoned the node")
+	}
+	assertAnnotations(t, updated, nil)
+	if got := metricValue(t, nodeName); got != 0 {
+		t.Fatalf("failure gauge = %v, want it cleared", got)
+	}
+	h.awaitEvent(t, "DrainCancelled")
+}
+
+// A reconcile arriving while the eviction runs must not disturb it.
+func TestReconcile_RunningEvictionIsLeftAlone(t *testing.T) {
+	h := newHarness(t, fake.NewSimpleClientset(),
+		node(map[string]string{nodecommon.DrainingAnnotation: bashibleSource}, true))
+
+	h.blockUntilCancelled(t)
+	h.reconcile(t)
+
+	assertAnnotations(t, h.node(t), map[string]string{nodecommon.DrainingAnnotation: bashibleSource})
+	if running, err := h.drains.cancel(t.Context(), nodeName); err != nil || !running {
+		t.Fatalf("cancel = (%v, %v): the running eviction should still be there", running, err)
+	}
+}
+
+// A collected result frees the id, so a failed eviction is followed by a fresh
+// one rather than by the same result for ever.
+func TestReconcile_FailedEvictionIsRetriedWithAFreshTask(t *testing.T) {
 	cs := fake.NewSimpleClientset()
-	cs.PrependReactor("list", "pods", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+	cs.PrependReactor("list", "pods", func(k8stesting.Action) (bool, runtime.Object, error) {
 		return true, nil, errBoom
 	})
-	r := &Reconciler{Base: register.Base{Client: cl, Recorder: record.NewFakeRecorder(10)}, kubeClient: cs}
+	h := newHarness(t, cs, node(map[string]string{nodecommon.DrainingAnnotation: bashibleSource}, false))
+	t.Cleanup(func() { clearDrainMetric(nodeName) })
 
-	t.Cleanup(func() { clearDrainMetric("node-1") })
-
-	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "node-1"}})
-	if err == nil {
-		t.Fatal("expected drain error, got nil")
+	if err := h.drain(t); err == nil {
+		t.Fatal("expected the first eviction to fail")
 	}
-
-	if got := metricValue(t, "node-1"); got != 1 {
-		t.Fatalf("expected drain failure gauge=1, got %v", got)
-	}
-
-	updated := getNode(t, r, "node-1")
-	if updated.Annotations[nodecommon.DrainingAnnotation] != "bashible" {
-		t.Fatal("draining annotation should remain after failed drain")
-	}
-	if _, exists := updated.Annotations[nodecommon.DrainedAnnotation]; exists {
-		t.Fatal("drained annotation should not be set after failed drain")
-	}
-	if !updated.Spec.Unschedulable {
-		t.Fatal("node should remain cordoned after failed drain")
+	if err := h.drain(t); err == nil {
+		t.Fatal("expected the retried eviction to fail too")
 	}
 }
 
-// When the drain context is already expired, a drain failure is tolerated: the
-// node is marked drained anyway and the draining annotation is removed.
-func TestReconcile_DrainTimesOut_MarksDrainedAnyway(t *testing.T) {
-	node := &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        "node-1",
-			Labels:      map[string]string{nodecommon.NodeGroupLabel: "worker"},
-			Annotations: map[string]string{nodecommon.DrainingAnnotation: "bashible"},
-		},
-	}
+// A deleted node's eviction is abandoned rather than left evicting pods on
+// behalf of an object nobody can see.
+func TestReconcile_DeletedNodeCancelsItsEviction(t *testing.T) {
+	h := newHarness(t, fake.NewSimpleClientset())
+	nodeDrainingGauge.WithLabelValues(nodeName, "boom").Set(1)
+	t.Cleanup(func() { clearDrainMetric(nodeName) })
 
-	scheme := runtime.NewScheme()
-	if err := corev1.AddToScheme(scheme); err != nil {
-		t.Fatalf("add scheme: %v", err)
-	}
-	cl := fakeclient.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(node).Build()
+	h.blockUntilCancelled(t)
+	h.reconcile(t)
 
-	cs := fake.NewSimpleClientset()
-	cs.PrependReactor("list", "pods", func(_ k8stesting.Action) (bool, runtime.Object, error) {
-		return true, nil, errBoom
-	})
-	r := &Reconciler{Base: register.Base{Client: cl, Recorder: record.NewFakeRecorder(10)}, kubeClient: cs}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: "node-1"}})
-	if err != nil {
-		t.Fatalf("expected no error on drain timeout, got %v", err)
+	if got := metricValue(t, nodeName); got != 0 {
+		t.Fatalf("failure gauge = %v, want it cleared", got)
 	}
-	if res != (ctrl.Result{}) {
-		t.Fatalf("expected empty result, got %v", res)
-	}
-
-	updated := getNode(t, r, "node-1")
-	if _, exists := updated.Annotations[nodecommon.DrainingAnnotation]; exists {
-		t.Fatal("draining annotation should be removed after timeout")
-	}
-	if updated.Annotations[nodecommon.DrainedAnnotation] != "bashible" {
-		t.Fatalf("expected drained=bashible after timeout, got %q", updated.Annotations[nodecommon.DrainedAnnotation])
+	if running, err := h.drains.cancel(t.Context(), nodeName); err != nil || running {
+		t.Fatalf("cancel = (%v, %v): the eviction should already be gone", running, err)
 	}
 }
 
-// Node deletion clears the per-node drain failure metric.
-func TestReconcile_NodeNotFound_ClearsMetric(t *testing.T) {
-	nodeDrainingGauge.WithLabelValues("gone", "boom").Set(1)
-	t.Cleanup(func() { clearDrainMetric("gone") })
+func TestForPredicates_AdmitsOnlyNodesInANodeGroup(t *testing.T) {
+	predicates := (&Reconciler{}).ForPredicates()
+	if len(predicates) != 1 {
+		t.Fatalf("got %d predicates, want 1", len(predicates))
+	}
 
-	r := newReconciler(t)
-	reconcile(t, r, "gone")
-
-	if got := metricValue(t, "gone"); got != 0 {
-		t.Fatalf("expected gauge cleared for deleted node, got %v", got)
+	for _, tc := range []struct {
+		name   string
+		labels map[string]string
+		want   bool
+	}{
+		{name: "a node in a group", labels: map[string]string{nodecommon.NodeGroupLabel: nodeGroupName}, want: true},
+		{name: "a node in no group", want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			obj := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName, Labels: tc.labels}}
+			if got := predicates[0].Create(event.CreateEvent{Object: obj}); got != tc.want {
+				t.Fatalf("admitted = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }
 
-func TestSetup_BuildsKubeClientFromManagerConfig(t *testing.T) {
-	mgr := &configOnlyManager{cfg: &rest.Config{Host: "https://127.0.0.1:6443"}}
-	r := &Reconciler{}
-
-	if err := r.Setup(t.Context(), mgr); err != nil {
-		t.Fatalf("setup: %v", err)
-	}
-	if r.kubeClient == nil {
-		t.Fatal("Setup did not initialize kubeClient")
-	}
-}
-
-func TestSetup_InvalidConfig_ReturnsError(t *testing.T) {
-	mgr := &configOnlyManager{cfg: &rest.Config{Host: "https://example.com", ExecProvider: &api.ExecConfig{}, AuthProvider: &api.AuthProviderConfig{}}}
-	r := &Reconciler{}
-
-	if err := r.Setup(t.Context(), mgr); err == nil {
-		t.Fatal("expected error from invalid rest.Config, got nil")
-	}
-}
-
-func TestSetupWatches_FiltersNodesByGroupLabel(t *testing.T) {
-	r := &Reconciler{}
+// The wake channel must be a raw source and the group filter must not be a
+// global event filter: a global one would also drop the name-only Node that
+// carries a finished eviction back into the workqueue.
+func TestSetupWatches_RegistersTheWakeChannelWithoutAGlobalFilter(t *testing.T) {
+	r := &Reconciler{drains: newDrainer(t.Context(), nil)}
 	w := &captureWatcher{}
+
 	r.SetupWatches(w)
 
-	if w.predicate == nil {
-		t.Fatal("SetupWatches did not register an event filter predicate")
+	if len(w.rawSources) != 1 {
+		t.Fatalf("got %d raw sources, want 1", len(w.rawSources))
 	}
-
-	withLabel := &corev1.Node{ObjectMeta: metav1.ObjectMeta{
-		Name:   "with",
-		Labels: map[string]string{nodecommon.NodeGroupLabel: "worker"},
-	}}
-	withoutLabel := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "without"}}
-
-	if !w.predicate.Create(event.CreateEvent{Object: withLabel}) {
-		t.Fatal("expected node with group label to pass the filter")
-	}
-	if w.predicate.Create(event.CreateEvent{Object: withoutLabel}) {
-		t.Fatal("expected node without group label to be filtered out")
+	if w.predicate != nil {
+		t.Fatal("the group filter must not be registered as a global event filter")
 	}
 }
 
 // metricValue reads the current d8_node_draining gauge value for a node, summing
 // across whatever message label is attached. Returns 0 when no series exists.
-func metricValue(t *testing.T, nodeName string) float64 {
+func metricValue(t *testing.T, name string) float64 {
 	t.Helper()
 	ch := make(chan prometheus.Metric, 16)
 	nodeDrainingGauge.Collect(ch)
@@ -468,7 +512,7 @@ func metricValue(t *testing.T, nodeName string) float64 {
 			t.Fatalf("write metric: %v", err)
 		}
 		for _, lp := range m.GetLabel() {
-			if lp.GetName() == "node" && lp.GetValue() == nodeName {
+			if lp.GetName() == "node" && lp.GetValue() == name {
 				total += m.GetGauge().GetValue()
 			}
 		}
@@ -477,22 +521,16 @@ func metricValue(t *testing.T, nodeName string) float64 {
 }
 
 type captureWatcher struct {
-	predicate predicate.Predicate
+	predicate  predicate.Predicate
+	rawSources []source.Source
 }
 
 func (w *captureWatcher) Owns(_ client.Object, _ ...builder.OwnsOption) {}
 func (w *captureWatcher) Watches(_ client.Object, _ handler.EventHandler, _ ...builder.WatchesOption) {
 }
-func (w *captureWatcher) WatchesRawSource(_ source.Source) {}
+func (w *captureWatcher) WatchesRawSource(src source.Source) {
+	w.rawSources = append(w.rawSources, src)
+}
 func (w *captureWatcher) WithEventFilter(p predicate.Predicate) {
 	w.predicate = p
 }
-
-// configOnlyManager is a ctrl.Manager that only serves a rest.Config; every other
-// method is inherited (and unused) from the embedded nil interface.
-type configOnlyManager struct {
-	manager.Manager
-	cfg *rest.Config
-}
-
-func (m *configOnlyManager) GetConfig() *rest.Config { return m.cfg }

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/draining/controller_test.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/draining/controller_test.go
@@ -421,9 +421,9 @@ func TestReconcile_CordonIsWrittenBeforeTheEvictionStarts(t *testing.T) {
 	}
 }
 
-// Withdrawing the request stops the eviction and gives the node back, instead of
-// letting it run to completion and recording a result nobody asked for.
-func TestReconcile_WithdrawnRequestCancelsAndUncordons(t *testing.T) {
+// Withdrawing the request stops the eviction instead of letting it run to
+// completion and record a result nobody asked for.
+func TestReconcile_WithdrawnRequestCancelsEviction(t *testing.T) {
 	h := newHarness(t, fake.NewSimpleClientset(), node(nil, true))
 	nodeDrainingGauge.WithLabelValues(nodeName, "boom").Set(1)
 	t.Cleanup(func() { clearDrainMetric(nodeName) })
@@ -432,9 +432,6 @@ func TestReconcile_WithdrawnRequestCancelsAndUncordons(t *testing.T) {
 	h.reconcile(t)
 
 	updated := h.node(t)
-	if updated.Spec.Unschedulable {
-		t.Fatal("a cancelled eviction should have uncordoned the node")
-	}
 	assertAnnotations(t, updated, nil)
 	if got := metricValue(t, nodeName); got != 0 {
 		t.Fatalf("failure gauge = %v, want it cleared", got)

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/draining/controller_test.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/draining/controller_test.go
@@ -555,6 +555,54 @@ func withReady(n *corev1.Node) *corev1.Node {
 	return n
 }
 
+// The eviction's context tells the drainer why the task ended: a cancelled one
+// is skipped, a deadline still has to bring the node back to be recorded.
+func TestWakeNode_SkipsOnlyCancelledEvictions(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		deadline bool
+		cancel   bool
+		wantWake bool
+	}{
+		{name: "a finished eviction wakes the node", wantWake: true},
+		{name: "an eviction that ran out of its deadline wakes the node", deadline: true, wantWake: true},
+		{name: "a cancelled eviction does not", cancel: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d := newDrainer(t.Context(), nil)
+
+			ctx := t.Context()
+			switch {
+			case tc.deadline:
+				expired, stop := context.WithTimeout(context.Background(), 0)
+				defer stop()
+				<-expired.Done()
+				ctx = expired
+			case tc.cancel:
+				cancelled, stop := context.WithCancel(context.Background())
+				stop()
+				ctx = cancelled
+			}
+
+			d.wakeNode(ctx, nodeName)
+
+			select {
+			case ev := <-d.wake:
+				if !tc.wantWake {
+					t.Fatalf("woken for %q, want no wake-up", ev.Object.GetName())
+				}
+				if ev.Object.GetName() != nodeName {
+					t.Fatalf("woken for %q, want %q", ev.Object.GetName(), nodeName)
+				}
+			default:
+				if tc.wantWake {
+					t.Fatal("the eviction ended without waking the node")
+				}
+			}
+		})
+	}
+}
+
 // metricValue reads the current d8_node_draining gauge value for a node, summing
 // across whatever message label is attached. Returns 0 when no series exists.
 func metricValue(t *testing.T, name string) float64 {

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/draining/drainer.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/draining/drainer.go
@@ -50,15 +50,15 @@ type drainer struct {
 	tasks      *task.Manager
 	kubeClient kubernetes.Interface
 	wake       chan event.GenericEvent
-	parent     context.Context
+	ctx        context.Context
 }
 
-func newDrainer(parent context.Context, kubeClient kubernetes.Interface) *drainer {
+func newDrainer(ctx context.Context, kubeClient kubernetes.Interface) *drainer {
 	return &drainer{
 		tasks:      task.NewManager(),
 		kubeClient: kubeClient,
 		wake:       make(chan event.GenericEvent, wakeBuffer),
-		parent:     parent,
+		ctx:        ctx,
 	}
 }
 
@@ -67,7 +67,7 @@ func (d *drainer) wakeSource() source.Source {
 }
 
 func (d *drainer) start(logger logr.Logger, nodeName string, timeout time.Duration) error {
-	err := d.tasks.Start(d.parent, task.TaskID(nodeName),
+	err := d.tasks.Start(d.ctx, task.TaskID(nodeName),
 		func(ctx context.Context) error { return d.evict(ctx, nodeName, timeout) },
 		func(ctx context.Context) { d.wakeNode(ctx, nodeName) },
 	)
@@ -103,7 +103,7 @@ func (d *drainer) wakeNode(ctx context.Context, nodeName string) {
 	// branches would be ready and select would drop the send half the time.
 	select {
 	case d.wake <- event.GenericEvent{Object: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}}}:
-	case <-d.parent.Done():
+	case <-d.ctx.Done():
 	}
 }
 

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/draining/drainer.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/draining/drainer.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package draining
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	kubedrain "github.com/deckhouse/deckhouse/go_lib/dependency/k8s/drain"
+
+	"github.com/deckhouse/node-controller/internal/task"
+)
+
+// wakeBuffer sizes the channel carrying finished evictions back into the queue.
+const wakeBuffer = 128
+
+// errDrainDeadline marks an eviction that ran out of its timeout rather than
+// failing. A failure is retried; a deadline is not, because its cause is
+// durable — a budget that never allows eviction, a pod that never terminates.
+var errDrainDeadline = errors.New("drain deadline exceeded")
+
+// drainer runs one eviction per node in the background and hands the node back
+// to the workqueue when it is done. It is the only place that knows an eviction
+// is a goroutine.
+type drainer struct {
+	tasks      *task.Manager
+	kubeClient kubernetes.Interface
+	wake       chan event.GenericEvent
+	parent     context.Context
+}
+
+func newDrainer(parent context.Context, kubeClient kubernetes.Interface) *drainer {
+	return &drainer{
+		tasks:      task.NewManager(),
+		kubeClient: kubeClient,
+		wake:       make(chan event.GenericEvent, wakeBuffer),
+		parent:     parent,
+	}
+}
+
+func (d *drainer) wakeSource() source.Source {
+	return source.Channel(d.wake, &handler.EnqueueRequestForObject{})
+}
+
+func (d *drainer) start(logger logr.Logger, nodeName string, timeout time.Duration) error {
+	err := d.tasks.Start(d.parent, task.TaskID(nodeName),
+		func(ctx context.Context) error { return d.evict(ctx, nodeName, timeout) },
+		func(ctx context.Context) { d.wakeNode(ctx, nodeName) },
+	)
+	if errors.Is(err, task.ErrExists) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	logger.Info("eviction started")
+	return nil
+}
+
+func (d *drainer) result(nodeName string) (bool, error) {
+	return d.tasks.Result(task.TaskID(nodeName))
+}
+
+func (d *drainer) cancel(ctx context.Context, nodeName string) (bool, error) {
+	return d.tasks.Cancel(ctx, task.TaskID(nodeName))
+}
+
+func (d *drainer) wakeNode(ctx context.Context, nodeName string) {
+	select {
+	case d.wake <- event.GenericEvent{Object: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}}}:
+	case <-ctx.Done():
+	}
+}
+
+func (d *drainer) evict(ctx context.Context, nodeName string, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	helper := kubedrain.NewDrainer(kubedrain.HelperConfig{
+		Client:  d.kubeClient,
+		Timeout: &timeout,
+	})
+	helper.Ctx = ctx
+
+	if err := kubedrain.RunNodeDrain(helper, nodeName); err != nil {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return fmt.Errorf("%w after %s: %w", errDrainDeadline, timeout, err)
+		}
+		return err
+	}
+	return nil
+}

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/draining/drainer.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/draining/drainer.go
@@ -90,6 +90,10 @@ func (d *drainer) cancel(ctx context.Context, nodeName string) (bool, error) {
 	return d.tasks.Cancel(ctx, task.TaskID(nodeName))
 }
 
+// wakeNode hands the node back to the workqueue now that its eviction is over,
+// however it ended. The context here is the manager's, not the eviction's, so
+// the only thing that abandons the send is the process going away — a send that
+// blocks is a node whose finished eviction nobody has collected yet.
 func (d *drainer) wakeNode(ctx context.Context, nodeName string) {
 	select {
 	case d.wake <- event.GenericEvent{Object: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}}}:

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/draining/drainer.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/draining/drainer.go
@@ -35,16 +35,16 @@ import (
 	"github.com/deckhouse/node-controller/internal/task"
 )
 
-// wakeBuffer sizes the channel carrying finished evictions back into the queue.
+// wakeBuffer sizes the channel carrying finished drains back into the queue.
 const wakeBuffer = 128
 
-// errDrainDeadline marks an eviction that ran out of its timeout rather than
+// errDrainDeadline marks a drain that ran out of its timeout rather than
 // failing. A failure is retried; a deadline is not, because its cause is
 // durable — a budget that never allows eviction, a pod that never terminates.
 var errDrainDeadline = errors.New("drain deadline exceeded")
 
-// drainer runs one eviction per node in the background and hands the node back
-// to the workqueue when it is done. It is the only place that knows an eviction
+// drainer runs one drain per node in the background and hands the node back
+// to the workqueue when it is done. It is the only place that knows a drain
 // is a goroutine.
 type drainer struct {
 	tasks      *task.Manager
@@ -78,7 +78,7 @@ func (d *drainer) start(logger logr.Logger, nodeName string, timeout time.Durati
 		return err
 	}
 
-	logger.Info("eviction started")
+	logger.Info("drain started")
 	return nil
 }
 
@@ -90,7 +90,7 @@ func (d *drainer) cancel(ctx context.Context, nodeName string) (bool, error) {
 	return d.tasks.Cancel(ctx, task.TaskID(nodeName))
 }
 
-// wakeNode hands the node back to the workqueue now that its eviction is over.
+// wakeNode hands the node back to the workqueue now that its drain is over.
 // A cancelled one is skipped: whoever cancelled it waited for the goroutine and
 // moved on. Canceled specifically, not "context is done" — a deadline still has
 // a result to record.
@@ -99,7 +99,7 @@ func (d *drainer) wakeNode(ctx context.Context, nodeName string) {
 		return
 	}
 
-	// The manager's context, not the eviction's: on an expired deadline both
+	// The manager's context, not the drain's: on an expired deadline both
 	// branches would be ready and select would drop the send half the time.
 	select {
 	case d.wake <- event.GenericEvent{Object: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}}}:

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/draining/drainer.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/draining/drainer.go
@@ -90,14 +90,20 @@ func (d *drainer) cancel(ctx context.Context, nodeName string) (bool, error) {
 	return d.tasks.Cancel(ctx, task.TaskID(nodeName))
 }
 
-// wakeNode hands the node back to the workqueue now that its eviction is over,
-// however it ended. The context here is the manager's, not the eviction's, so
-// the only thing that abandons the send is the process going away — a send that
-// blocks is a node whose finished eviction nobody has collected yet.
+// wakeNode hands the node back to the workqueue now that its eviction is over.
+// A cancelled one is skipped: whoever cancelled it waited for the goroutine and
+// moved on. Canceled specifically, not "context is done" — a deadline still has
+// a result to record.
 func (d *drainer) wakeNode(ctx context.Context, nodeName string) {
+	if errors.Is(ctx.Err(), context.Canceled) {
+		return
+	}
+
+	// The manager's context, not the eviction's: on an expired deadline both
+	// branches would be ready and select would drop the send half the time.
 	select {
 	case d.wake <- event.GenericEvent{Object: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}}}:
-	case <-ctx.Done():
+	case <-d.parent.Done():
 	}
 }
 

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/draining/drainer.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/draining/drainer.go
@@ -112,8 +112,11 @@ func (d *drainer) evict(ctx context.Context, nodeName string, timeout time.Durat
 	defer cancel()
 
 	helper := kubedrain.NewDrainer(kubedrain.HelperConfig{
-		Client:  d.kubeClient,
-		Timeout: &timeout,
+		Client: d.kubeClient,
+		Timeout: func() *time.Duration {
+			timeout := time.Duration(0) // 0 means infinite; actual timeout is controlled by ctx
+			return &timeout
+		}(),
 	})
 	helper.Ctx = ctx
 

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/draining/e2e_draining_test.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/draining/e2e_draining_test.go
@@ -248,10 +248,9 @@ var _ = Describe("Draining a node on the draining annotation", func() {
 		}, eventuallyTimeout, eventuallyPoll).Should(Succeed())
 	})
 
-	// A hand drain records no result any more, so drained=user is always a
-	// leftover — including on the cordoned nodes a hand drain actually produces,
-	// which the old "schedulable only" rule left it sitting on forever.
-	It("removes a drained=user annotation whether the node is cordoned or not", func() {
+	// A hand drain is closed out by an operator: the stale marker goes once the
+	// node is back in service, and stays while it is still cordoned.
+	It("removes a stale drained=user annotation only from a schedulable node", func() {
 		schedulable := testenv.UniqueName("user-schedulable")
 		createGroupNode(schedulable, schedulable, map[string]string{nodecommon.DrainedAnnotation: "user"})
 
@@ -260,17 +259,15 @@ var _ = Describe("Draining a node on the draining annotation", func() {
 			map[string]string{nodecommon.DrainedAnnotation: "user"},
 			corev1.NodeSpec{Unschedulable: true})
 
-		for _, name := range []string{schedulable, cordoned} {
-			Eventually(func(g Gomega) {
-				g.Expect(getNodeState(name).Annotations).NotTo(HaveKey(nodecommon.DrainedAnnotation))
-			}, eventuallyTimeout, eventuallyPoll).Should(Succeed())
-		}
+		Eventually(func(g Gomega) {
+			g.Expect(getNodeState(schedulable).Annotations).NotTo(HaveKey(nodecommon.DrainedAnnotation))
+		}, eventuallyTimeout, eventuallyPoll).Should(Succeed())
 
-		// Removing the annotation is not uncordoning: only an interrupted drain
-		// puts a node back into service.
-		Consistently(func() bool {
-			return getNodeState(cordoned).Spec.Unschedulable
-		}, negativeCheckDuration, eventuallyPoll).Should(BeTrue())
+		Consistently(func(g Gomega) {
+			node := getNodeState(cordoned)
+			g.Expect(node.Annotations).To(HaveKeyWithValue(nodecommon.DrainedAnnotation, "user"))
+			g.Expect(node.Spec.Unschedulable).To(BeTrue())
+		}, negativeCheckDuration, eventuallyPoll).Should(Succeed())
 	})
 
 	// User story: as a cluster operator who changed my mind, I want removing the

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/draining/e2e_draining_test.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/draining/e2e_draining_test.go
@@ -284,7 +284,7 @@ var _ = Describe("Draining a node on the draining annotation", func() {
 	})
 
 	// User story: as a cluster operator who changed my mind, I want removing the
-	// draining annotation to stop the eviction, instead of having to wait the
+	// draining annotation to stop the drain, instead of having to wait the
 	// drain out.
 	It("cancels an in-flight drain when the request is withdrawn", func() {
 		name := testenv.UniqueName("drain-cancel")
@@ -294,9 +294,9 @@ var _ = Describe("Draining a node on the draining annotation", func() {
 		createStuckPod("stuck-"+name, name)
 		createGroupNode(name, name, map[string]string{nodecommon.DrainingAnnotation: "bashible"})
 
-		// The pod going into termination is proof the eviction is under way — the
+		// The pod going into termination is proof the drain is under way — the
 		// cordon alone is not, since it is written a pass earlier. The finalizer
-		// then guarantees the eviction cannot finish on its own.
+		// then guarantees the drain cannot finish on its own.
 		Eventually(func() bool {
 			return podExists("stuck-" + name)
 		}, eventuallyTimeout, eventuallyPoll).Should(BeFalse())
@@ -305,7 +305,7 @@ var _ = Describe("Draining a node on the draining annotation", func() {
 		Expect(k8sClient.Patch(suiteCtx, getNodeState(name), client.RawPatch(types.MergePatchType,
 			[]byte(`{"metadata":{"annotations":{"`+nodecommon.DrainingAnnotation+`":null}}}`)))).To(Succeed())
 
-		// The event is the only visible proof the eviction was stopped: the node
+		// The event is the only visible proof the drain was stopped: the node
 		// itself is left exactly as the drain found it.
 		Eventually(func() bool {
 			return eventExists(name, "DrainCancelled")

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/draining/e2e_draining_test.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/draining/e2e_draining_test.go
@@ -155,6 +155,19 @@ func createStuckPod(name, nodeName string) *corev1.Pod {
 	return pod
 }
 
+func eventExists(nodeName, reason string) bool {
+	var events corev1.EventList
+	if err := k8sClient.List(suiteCtx, &events); err != nil {
+		return false
+	}
+	for _, e := range events.Items {
+		if e.InvolvedObject.Name == nodeName && e.Reason == reason {
+			return true
+		}
+	}
+	return false
+}
+
 func podExists(name string) bool {
 	pod := &corev1.Pod{}
 	err := k8sClient.Get(suiteCtx, types.NamespacedName{Namespace: metav1.NamespaceDefault, Name: name}, pod)
@@ -271,9 +284,9 @@ var _ = Describe("Draining a node on the draining annotation", func() {
 	})
 
 	// User story: as a cluster operator who changed my mind, I want removing the
-	// draining annotation to stop the eviction and give me my node back, instead
-	// of having to wait the drain out and uncordon by hand.
-	It("cancels an in-flight drain and uncordons the node when the request is withdrawn", func() {
+	// draining annotation to stop the eviction, instead of having to wait the
+	// drain out.
+	It("cancels an in-flight drain when the request is withdrawn", func() {
 		name := testenv.UniqueName("drain-cancel")
 
 		// The pod comes first: a drain that starts before it exists has nothing
@@ -292,11 +305,16 @@ var _ = Describe("Draining a node on the draining annotation", func() {
 		Expect(k8sClient.Patch(suiteCtx, getNodeState(name), client.RawPatch(types.MergePatchType,
 			[]byte(`{"metadata":{"annotations":{"`+nodecommon.DrainingAnnotation+`":null}}}`)))).To(Succeed())
 
-		Eventually(func(g Gomega) {
-			node := getNodeState(name)
-			g.Expect(node.Spec.Unschedulable).To(BeFalse(), "a cancelled drain must uncordon the node")
-			g.Expect(node.Annotations).NotTo(HaveKey(nodecommon.DrainedAnnotation), "a cancelled drain must not be recorded as done")
-		}, eventuallyTimeout, eventuallyPoll).Should(Succeed())
+		// The event is the only visible proof the eviction was stopped: the node
+		// itself is left exactly as the drain found it.
+		Eventually(func() bool {
+			return eventExists(name, "DrainCancelled")
+		}, eventuallyTimeout, eventuallyPoll).Should(BeTrue())
+
+		Consistently(func(g Gomega) {
+			g.Expect(getNodeState(name).Annotations).NotTo(HaveKey(nodecommon.DrainedAnnotation),
+				"a cancelled drain must not be recorded as done")
+		}, negativeCheckDuration, eventuallyPoll).Should(Succeed())
 	})
 
 	It("does not cordon a node that has no draining annotation", func() {

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/draining/e2e_draining_test.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/draining/e2e_draining_test.go
@@ -19,7 +19,6 @@ package draining
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -49,12 +48,20 @@ func getNodeState(name string) *corev1.Node {
 // admits it) plus the given annotations. The group is also a real NodeGroup name when ngName is
 // non-empty; callers that need a NodeGroup create it separately.
 func createGroupNode(name, ngName string, annotations map[string]string) *corev1.Node {
+	return createGroupNodeWithSpec(name, ngName, annotations, corev1.NodeSpec{})
+}
+
+// createGroupNodeWithSpec is createGroupNode for the cases that need the node to
+// already be in a given state — cordoned, typically — before the controller ever
+// sees it, rather than patched into it afterwards in a race with the reconcile.
+func createGroupNodeWithSpec(name, ngName string, annotations map[string]string, spec corev1.NodeSpec) *corev1.Node {
 	node := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
 			Labels:      map[string]string{nodecommon.NodeGroupLabel: ngName},
 			Annotations: annotations,
 		},
+		Spec: spec,
 	}
 	Expect(k8sClient.Create(suiteCtx, node)).To(Succeed())
 	return node
@@ -117,6 +124,35 @@ func createDaemonSet(name string) *appsv1.DaemonSet {
 	}
 	Expect(k8sClient.Create(suiteCtx, ds)).To(Succeed())
 	return ds
+}
+
+// createStuckPod creates a pod on the node that can be evicted but never goes
+// away: the finalizer keeps the object alive after its deletion is requested,
+// and the drain waits once a second for it to disappear, indefinitely. That is
+// the whole of a hard-stuck drain, without depending on a disruption controller
+// envtest does not run.
+//
+// The finalizer is dropped again when the spec ends, or the pod outlives the
+// suite.
+func createStuckPod(name, nodeName string) *corev1.Pod {
+	pod := createBoundPod(name, nodeName, "")
+	pod.Finalizers = []string{"node-controller.test/hold"}
+	Expect(k8sClient.Update(suiteCtx, pod)).To(Succeed())
+
+	DeferCleanup(func() {
+		Eventually(func(g Gomega) {
+			fresh := &corev1.Pod{}
+			err := k8sClient.Get(suiteCtx, client.ObjectKeyFromObject(pod), fresh)
+			if apierrors.IsNotFound(err) {
+				return
+			}
+			g.Expect(err).NotTo(HaveOccurred())
+			fresh.Finalizers = nil
+			g.Expect(client.IgnoreNotFound(k8sClient.Update(suiteCtx, fresh))).To(Succeed())
+		}, eventuallyTimeout, eventuallyPoll).Should(Succeed())
+	})
+
+	return pod
 }
 
 func podExists(name string) bool {
@@ -212,13 +248,57 @@ var _ = Describe("Draining a node on the draining annotation", func() {
 		}, eventuallyTimeout, eventuallyPoll).Should(Succeed())
 	})
 
-	It("removes a stale drained=user annotation from a schedulable node", func() {
-		name := testenv.UniqueName("stale-user")
-		createGroupNode(name, name, map[string]string{nodecommon.DrainedAnnotation: "user"})
+	// A hand drain records no result any more, so drained=user is always a
+	// leftover — including on the cordoned nodes a hand drain actually produces,
+	// which the old "schedulable only" rule left it sitting on forever.
+	It("removes a drained=user annotation whether the node is cordoned or not", func() {
+		schedulable := testenv.UniqueName("user-schedulable")
+		createGroupNode(schedulable, schedulable, map[string]string{nodecommon.DrainedAnnotation: "user"})
+
+		cordoned := testenv.UniqueName("user-cordoned")
+		createGroupNodeWithSpec(cordoned, cordoned,
+			map[string]string{nodecommon.DrainedAnnotation: "user"},
+			corev1.NodeSpec{Unschedulable: true})
+
+		for _, name := range []string{schedulable, cordoned} {
+			Eventually(func(g Gomega) {
+				g.Expect(getNodeState(name).Annotations).NotTo(HaveKey(nodecommon.DrainedAnnotation))
+			}, eventuallyTimeout, eventuallyPoll).Should(Succeed())
+		}
+
+		// Removing the annotation is not uncordoning: only an interrupted drain
+		// puts a node back into service.
+		Consistently(func() bool {
+			return getNodeState(cordoned).Spec.Unschedulable
+		}, negativeCheckDuration, eventuallyPoll).Should(BeTrue())
+	})
+
+	// User story: as a cluster operator who changed my mind, I want removing the
+	// draining annotation to stop the eviction and give me my node back, instead
+	// of having to wait the drain out and uncordon by hand.
+	It("cancels an in-flight drain and uncordons the node when the request is withdrawn", func() {
+		name := testenv.UniqueName("drain-cancel")
+
+		// The pod comes first: a drain that starts before it exists has nothing
+		// to evict and simply succeeds.
+		createStuckPod("stuck-"+name, name)
+		createGroupNode(name, name, map[string]string{nodecommon.DrainingAnnotation: "bashible"})
+
+		// The pod going into termination is proof the eviction is under way — the
+		// cordon alone is not, since it is written a pass earlier. The finalizer
+		// then guarantees the eviction cannot finish on its own.
+		Eventually(func() bool {
+			return podExists("stuck-" + name)
+		}, eventuallyTimeout, eventuallyPoll).Should(BeFalse())
+		Expect(getNodeState(name).Spec.Unschedulable).To(BeTrue())
+
+		Expect(k8sClient.Patch(suiteCtx, getNodeState(name), client.RawPatch(types.MergePatchType,
+			[]byte(`{"metadata":{"annotations":{"`+nodecommon.DrainingAnnotation+`":null}}}`)))).To(Succeed())
 
 		Eventually(func(g Gomega) {
 			node := getNodeState(name)
-			g.Expect(node.Annotations).NotTo(HaveKey(nodecommon.DrainedAnnotation))
+			g.Expect(node.Spec.Unschedulable).To(BeFalse(), "a cancelled drain must uncordon the node")
+			g.Expect(node.Annotations).NotTo(HaveKey(nodecommon.DrainedAnnotation), "a cancelled drain must not be recorded as done")
 		}, eventuallyTimeout, eventuallyPoll).Should(Succeed())
 	})
 

--- a/modules/040-node-manager/images/node-controller/src/internal/task/manager.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/task/manager.go
@@ -56,10 +56,8 @@ func NewManager() *Manager {
 // ctx is the parent of the task's own context — pass the long-lived one, not a
 // reconcile's, or the task dies with the call that started it.
 //
-// notifyFn runs on parent, deliberately not on the task's own context: it reports
-// that the task ended, and has to fire whichever way it ended. Handing it the
-// task's context instead would make a cancelled or timed-out task skip its own
-// notification, and a caller waiting for that notification would wait for ever.
+// notifyFn fires on every ending and gets the task's own context, whose Err()
+// tells the endings apart: Canceled means stopped from outside.
 func (m *Manager) Start(ctx context.Context, id TaskID, taskFn TaskFn, notifyFn NotifyFn) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -90,7 +88,7 @@ func (m *Manager) Start(ctx context.Context, id TaskID, taskFn TaskFn, notifyFn 
 		m.mu.Unlock()
 
 		if notifyFn != nil {
-			notifyFn(ctx)
+			notifyFn(taskCtx)
 		}
 	}()
 

--- a/modules/040-node-manager/images/node-controller/src/internal/task/manager.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/task/manager.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package task runs long operations in the background: one per subject at a
+// time, kept until its result is collected, with a notification when it ends.
+// A reconciler starts the work, returns, and is woken to read the outcome.
+package task
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+var ErrExists = errors.New("task already exists")
+
+type (
+	TaskID   string
+	TaskFn   func(ctx context.Context) error
+	NotifyFn func(ctx context.Context)
+)
+
+type task struct {
+	cancel context.CancelFunc
+	done   chan struct{}
+	err    error
+}
+
+type Manager struct {
+	mu    sync.Mutex
+	tasks map[TaskID]*task
+}
+
+func NewManager() *Manager {
+	return &Manager{
+		tasks: make(map[TaskID]*task),
+	}
+}
+
+// Start launches a background task.
+// Returns ErrExists if the id already has a task, running or finished.
+//
+// ctx is the parent of the task's own context — pass the long-lived one, not a
+// reconcile's, or the task dies with the call that started it.
+func (m *Manager) Start(ctx context.Context, id TaskID, taskFn TaskFn, notifyFn NotifyFn) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, exists := m.tasks[id]; exists {
+		return ErrExists
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	t := &task{
+		cancel: cancel,
+		done:   make(chan struct{}),
+	}
+	m.tasks[id] = t
+
+	go func() {
+		defer cancel()
+
+		var err error
+		if taskFn != nil {
+			err = taskFn(ctx)
+		}
+
+		// Published before anybody is told to come and read it.
+		m.mu.Lock()
+		t.err = err
+		close(t.done)
+		m.mu.Unlock()
+
+		if notifyFn != nil {
+			notifyFn(ctx)
+		}
+	}()
+
+	return nil
+}
+
+// Result reports whether the task for id has finished and, if so, its error,
+// forgetting it so the next Start runs afresh. Still running or absent is not
+// finished.
+func (m *Manager) Result(id TaskID) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	t, exists := m.tasks[id]
+	if !exists {
+		return false, nil
+	}
+
+	select {
+	case <-t.done:
+		delete(m.tasks, id)
+		return true, t.err
+	default:
+		return false, nil
+	}
+}
+
+// Cancel stops the task for id and waits for its goroutine to return, so the
+// caller may undo its side effects without racing it, and reports whether there
+// was one. A ctx that expires first returns its error; the task is forgotten
+// either way.
+//
+// ponytail: the wait is bounded only by ctx. A drain stops within ~6s (a budget
+// retry sleeps a flat 5s); give Cancel its own deadline if a future task cannot
+// promise that.
+func (m *Manager) Cancel(ctx context.Context, id TaskID) (bool, error) {
+	m.mu.Lock()
+	t, exists := m.tasks[id]
+	if !exists {
+		m.mu.Unlock()
+		return false, nil
+	}
+	delete(m.tasks, id)
+	m.mu.Unlock()
+
+	t.cancel()
+
+	select {
+	case <-t.done:
+		return true, nil
+	case <-ctx.Done():
+		return false, ctx.Err()
+	}
+}

--- a/modules/040-node-manager/images/node-controller/src/internal/task/manager.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/task/manager.go
@@ -55,6 +55,11 @@ func NewManager() *Manager {
 //
 // ctx is the parent of the task's own context — pass the long-lived one, not a
 // reconcile's, or the task dies with the call that started it.
+//
+// notifyFn runs on parent, deliberately not on the task's own context: it reports
+// that the task ended, and has to fire whichever way it ended. Handing it the
+// task's context instead would make a cancelled or timed-out task skip its own
+// notification, and a caller waiting for that notification would wait for ever.
 func (m *Manager) Start(ctx context.Context, id TaskID, taskFn TaskFn, notifyFn NotifyFn) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -63,7 +68,7 @@ func (m *Manager) Start(ctx context.Context, id TaskID, taskFn TaskFn, notifyFn 
 		return ErrExists
 	}
 
-	ctx, cancel := context.WithCancel(ctx)
+	taskCtx, cancel := context.WithCancel(ctx)
 	t := &task{
 		cancel: cancel,
 		done:   make(chan struct{}),
@@ -75,7 +80,7 @@ func (m *Manager) Start(ctx context.Context, id TaskID, taskFn TaskFn, notifyFn 
 
 		var err error
 		if taskFn != nil {
-			err = taskFn(ctx)
+			err = taskFn(taskCtx)
 		}
 
 		// Published before anybody is told to come and read it.

--- a/modules/040-node-manager/images/node-controller/src/internal/task/manager_test.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/task/manager_test.go
@@ -22,7 +22,12 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 )
+
+// notifyWait only expires when a notification is genuinely lost; the tasks here
+// end at once.
+const notifyWait = 10 * time.Second
 
 // The tests synchronise on channels rather than on sleeps: a task waits to be
 // released, and a notify callback reports completion. A manager whose whole job
@@ -123,6 +128,54 @@ func TestManager_ResultReportsTheOutcomeOnce(t *testing.T) {
 	t.Cleanup(func() { close(release) })
 	if err := m.Start(t.Context(), "node-1", func(context.Context) error { <-release; return nil }, nil); err != nil {
 		t.Fatalf("start after the result was read: %v", err)
+	}
+}
+
+// TestManager_NotifiesHoweverTheTaskEnded pins the notification to the task
+// ending, not to how it ended. It runs on the parent context rather than the
+// task's own, so moving a timeout onto the task cannot silently swallow it — a
+// caller waiting for the notification would otherwise wait for ever.
+func TestManager_NotifiesHoweverTheTaskEnded(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		cancel bool
+	}{
+		{name: "the task returns on its own"},
+		{name: "the task is cancelled", cancel: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			release := make(chan struct{})
+			notified := make(chan struct{}, 1)
+			m := NewManager()
+
+			err := m.Start(context.Background(), "node-1",
+				func(ctx context.Context) error {
+					select {
+					case <-release:
+						return nil
+					case <-ctx.Done():
+						return ctx.Err()
+					}
+				},
+				func(context.Context) { notified <- struct{}{} })
+			if err != nil {
+				t.Fatalf("start: %v", err)
+			}
+
+			if tc.cancel {
+				if _, err := m.Cancel(t.Context(), "node-1"); err != nil {
+					t.Fatalf("cancel: %v", err)
+				}
+			} else {
+				close(release)
+			}
+
+			select {
+			case <-notified:
+			case <-time.After(notifyWait):
+				t.Fatal("the task ended without notifying")
+			}
+		})
 	}
 }
 

--- a/modules/040-node-manager/images/node-controller/src/internal/task/manager_test.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/task/manager_test.go
@@ -1,0 +1,253 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package task
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// The tests synchronise on channels rather than on sleeps: a task waits to be
+// released, and a notify callback reports completion. A manager whose whole job
+// is goroutine bookkeeping cannot be tested by a stopwatch without going flaky
+// on a loaded machine.
+
+// held is the size of the registry, which is what every leak would show up in.
+func held(m *Manager) int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return len(m.tasks)
+}
+
+// TestManager_RegistryIsEmptiedAgain walks a task through every way it can end
+// and checks what the registry is left holding. A task that outlives its own
+// completion is a node that never gets a second eviction.
+func TestManager_RegistryIsEmptiedAgain(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		finish   bool // let the task return
+		collect  bool // read the result
+		cancel   bool // stop it instead
+		wantHeld int
+	}{
+		{name: "a running task is held", wantHeld: 1},
+		{name: "a finished task is held until its result is read", finish: true, wantHeld: 1},
+		{name: "reading the result forgets the task", finish: true, collect: true, wantHeld: 0},
+		{name: "cancelling forgets the task", cancel: true, wantHeld: 0},
+		{name: "cancelling a finished task forgets it too", finish: true, cancel: true, wantHeld: 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			release := make(chan struct{})
+			done := make(chan struct{}, 1)
+			m := NewManager()
+
+			err := m.Start(t.Context(), "node-1",
+				func(ctx context.Context) error {
+					select {
+					case <-release:
+						return nil
+					case <-ctx.Done():
+						return ctx.Err()
+					}
+				},
+				func(context.Context) { done <- struct{}{} })
+			if err != nil {
+				t.Fatalf("start: %v", err)
+			}
+
+			if tc.finish {
+				close(release)
+				<-done
+			} else {
+				t.Cleanup(func() { close(release) })
+			}
+
+			if tc.collect {
+				if finished, err := m.Result("node-1"); !finished || err != nil {
+					t.Fatalf("result = (%v, %v), want (true, nil)", finished, err)
+				}
+			}
+			if tc.cancel {
+				if _, err := m.Cancel(t.Context(), "node-1"); err != nil {
+					t.Fatalf("cancel: %v", err)
+				}
+			}
+
+			if got := held(m); got != tc.wantHeld {
+				t.Fatalf("registry holds %d tasks, want %d", got, tc.wantHeld)
+			}
+		})
+	}
+}
+
+// TestManager_ResultReportsTheOutcomeOnce is the other half of forgetting a
+// task: the result is handed over exactly once, and the id is free afterwards.
+func TestManager_ResultReportsTheOutcomeOnce(t *testing.T) {
+	boom := errors.New("boom")
+	done := make(chan struct{}, 1)
+	m := NewManager()
+
+	if err := m.Start(t.Context(), "node-1",
+		func(context.Context) error { return boom },
+		func(context.Context) { done <- struct{}{} }); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	<-done
+
+	if finished, err := m.Result("node-1"); !finished || !errors.Is(err, boom) {
+		t.Fatalf("first result = (%v, %v), want (true, boom)", finished, err)
+	}
+	if finished, err := m.Result("node-1"); finished || err != nil {
+		t.Fatalf("second result = (%v, %v), want (false, nil)", finished, err)
+	}
+
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	if err := m.Start(t.Context(), "node-1", func(context.Context) error { <-release; return nil }, nil); err != nil {
+		t.Fatalf("start after the result was read: %v", err)
+	}
+}
+
+// TestManager_StartsOneTaskPerID is the invariant the whole manager exists for.
+func TestManager_StartsOneTaskPerID(t *testing.T) {
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	m := NewManager()
+
+	var runs atomic.Int32
+	fn := func(context.Context) error {
+		runs.Add(1)
+		<-release
+		return nil
+	}
+
+	var started atomic.Int32
+	var wg sync.WaitGroup
+	for range 10 {
+		wg.Go(func() {
+			switch err := m.Start(t.Context(), "node-1", fn, nil); {
+			case err == nil:
+				started.Add(1)
+			case errors.Is(err, ErrExists):
+			default:
+				t.Errorf("start: %v", err)
+			}
+		})
+	}
+	wg.Wait()
+
+	if got := started.Load(); got != 1 {
+		t.Fatalf("%d calls started a task, want 1", got)
+	}
+	if got := held(m); got != 1 {
+		t.Fatalf("registry holds %d tasks, want 1", got)
+	}
+}
+
+func TestManager_DifferentIDsRunAtTheSameTime(t *testing.T) {
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	started := make(chan TaskID, 2)
+	m := NewManager()
+
+	for _, id := range []TaskID{"node-1", "node-2"} {
+		if err := m.Start(t.Context(), id, func(context.Context) error {
+			started <- id
+			<-release
+			return nil
+		}, nil); err != nil {
+			t.Fatalf("start %s: %v", id, err)
+		}
+	}
+
+	seen := map[TaskID]bool{<-started: true}
+	seen[<-started] = true
+	if !seen["node-1"] || !seen["node-2"] {
+		t.Fatalf("both tasks should be running, saw %v", seen)
+	}
+}
+
+// TestManager_CancelWaitsForTheGoroutine is the contract a caller undoing a
+// task's side effects depends on: by the time Cancel returns, nothing is left
+// running to race with.
+func TestManager_CancelWaitsForTheGoroutine(t *testing.T) {
+	started := make(chan struct{}, 1)
+	stopped := make(chan struct{})
+	m := NewManager()
+
+	err := m.Start(context.Background(), "node-1", func(ctx context.Context) error {
+		started <- struct{}{}
+		<-ctx.Done()
+		close(stopped)
+		return ctx.Err()
+	}, nil)
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	<-started
+
+	cancelled, err := m.Cancel(t.Context(), "node-1")
+	if err != nil || !cancelled {
+		t.Fatalf("cancel = (%v, %v), want (true, nil)", cancelled, err)
+	}
+
+	select {
+	case <-stopped:
+	default:
+		t.Fatal("Cancel returned while the task was still running")
+	}
+}
+
+// TestManager_CancelBoundaries covers the two edges of cancelling: nothing to
+// cancel, and a task that will not stop before the caller's context does.
+func TestManager_CancelBoundaries(t *testing.T) {
+	t.Run("nothing is running", func(t *testing.T) {
+		m := NewManager()
+
+		cancelled, err := m.Cancel(t.Context(), "node-1")
+		if cancelled || err != nil {
+			t.Fatalf("cancel = (%v, %v), want (false, nil)", cancelled, err)
+		}
+	})
+
+	t.Run("the caller's context expires first", func(t *testing.T) {
+		release := make(chan struct{})
+		t.Cleanup(func() { close(release) })
+		m := NewManager()
+
+		// A task that ignores its own context is the one Cancel cannot wait out.
+		if err := m.Start(context.Background(), "node-1",
+			func(context.Context) error { <-release; return nil }, nil); err != nil {
+			t.Fatalf("start: %v", err)
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		cancelled, err := m.Cancel(ctx, "node-1")
+		if !errors.Is(err, context.Canceled) || cancelled {
+			t.Fatalf("cancel = (%v, %v), want (false, context.Canceled)", cancelled, err)
+		}
+		if got := held(m); got != 0 {
+			t.Fatalf("a task Cancel gave up on is still held: %d", got)
+		}
+	})
+}

--- a/modules/040-node-manager/images/node-controller/src/internal/task/manager_test.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/task/manager_test.go
@@ -131,25 +131,36 @@ func TestManager_ResultReportsTheOutcomeOnce(t *testing.T) {
 	}
 }
 
-// TestManager_NotifiesHoweverTheTaskEnded pins the notification to the task
-// ending, not to how it ended. It runs on the parent context rather than the
-// task's own, so moving a timeout onto the task cannot silently swallow it — a
-// caller waiting for the notification would otherwise wait for ever.
-func TestManager_NotifiesHoweverTheTaskEnded(t *testing.T) {
+// TestManager_NotifiesWithTheTaskContext pins the contract a caller decides on:
+// every ending is reported, and the context says which one it was.
+func TestManager_NotifiesWithTheTaskContext(t *testing.T) {
 	for _, tc := range []struct {
-		name   string
-		cancel bool
+		name     string
+		deadline bool // the task ends on a deadline of its own
+		cancel   bool // the task is stopped from outside
+		wantErr  error
 	}{
-		{name: "the task returns on its own"},
-		{name: "the task is cancelled", cancel: true},
+		{name: "the task returns on its own", wantErr: nil},
+		{name: "the task runs out of its own deadline", deadline: true, wantErr: nil},
+		{name: "the task is cancelled", cancel: true, wantErr: context.Canceled},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			release := make(chan struct{})
-			notified := make(chan struct{}, 1)
+			notified := make(chan error, 1)
 			m := NewManager()
 
 			err := m.Start(context.Background(), "node-1",
 				func(ctx context.Context) error {
+					if tc.deadline {
+						// The task's own deadline, the way an eviction bounds
+						// itself: the task context stays untouched.
+						withDeadline, stop := context.WithTimeout(ctx, 0)
+						defer stop()
+						<-withDeadline.Done()
+
+						return withDeadline.Err()
+					}
+
 					select {
 					case <-release:
 						return nil
@@ -157,21 +168,25 @@ func TestManager_NotifiesHoweverTheTaskEnded(t *testing.T) {
 						return ctx.Err()
 					}
 				},
-				func(context.Context) { notified <- struct{}{} })
+				func(ctx context.Context) { notified <- ctx.Err() })
 			if err != nil {
 				t.Fatalf("start: %v", err)
 			}
 
-			if tc.cancel {
+			switch {
+			case tc.cancel:
 				if _, err := m.Cancel(t.Context(), "node-1"); err != nil {
 					t.Fatalf("cancel: %v", err)
 				}
-			} else {
+			case !tc.deadline:
 				close(release)
 			}
 
 			select {
-			case <-notified:
+			case got := <-notified:
+				if !errors.Is(got, tc.wantErr) {
+					t.Fatalf("notified with %v, want %v", got, tc.wantErr)
+				}
 			case <-time.After(notifyWait):
 				t.Fatal("the task ended without notifying")
 			}


### PR DESCRIPTION
## Description

A node drain now runs under a context the controller can cancel.

- The eviction moved out of `Reconcile` into one background task per node (`internal/task`), which is what gives it a context to cancel.
- Removing the `update.node.deckhouse.io/draining` annotation cancels that context, waits for the goroutine to return, and uncordons the node.
- The cordon is written on its own pass, before the eviction starts.

## Why do we need it, and what problem does it solve?

A drain could not be called off: withdrawing the request left the eviction running and the node stamped `drained` for a request that no longer existed. The same eviction held a controller worker for up to `nodeDrainTimeoutSecond`, so several draining nodes at once stalled every other node the controller is responsible for.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist

- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: node-manager
type: fix
summary: Node drain runs under a cancellable context — removing the `draining` annotation stops the eviction and returns the node to the scheduler.
impact_level: low
```
