### PR TITLE
Converge reaches an immutable cluster through a bastion

### DIFF
--- a/dhctl/cmd/dhctl/commands/converge.go
+++ b/dhctl/cmd/dhctl/commands/converge.go
@@ -63,6 +63,12 @@ func DefineConvergeCommand(cmd *kingpin.CmdClause, opts *options.Options) *kingp
 
 		defer providerinitializer.CleanupSSHProvider(ctx, sshProviderInitializer)
 
+		kubeProvider, stopBastionChannel, err := kubeProviderThroughBastion(ctx, opts, sshProviderInitializer, kubeProvider)
+		if err != nil {
+			return err
+		}
+		defer stopBastionChannel()
+
 		providerGetter := infrastructureprovider.CloudProviderGetter(infrastructureprovider.CloudProviderGetterParams{
 			TmpDir:           opts.Global.TmpDir,
 			AdditionalParams: cloud.ProviderAdditionalParams{},

--- a/dhctl/cmd/dhctl/commands/converge_bastion.go
+++ b/dhctl/cmd/dhctl/commands/converge_bastion.go
@@ -1,0 +1,80 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"context"
+	"fmt"
+
+	libcon "github.com/deckhouse/lib-connection/pkg"
+	"github.com/deckhouse/lib-connection/pkg/kube"
+	"github.com/deckhouse/lib-connection/pkg/provider"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/app/options"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/immutable"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/system/providerinitializer"
+)
+
+// kubeProviderThroughBastion replaces the Kubernetes provider with one that
+// reaches the API through the bastion, for a cluster whose nodes run no sshd and
+// whose kubeconfig therefore names an address only the cluster network resolves.
+// Returns the given provider unchanged, and a no-op closer, for every other run.
+func kubeProviderThroughBastion(
+	ctx context.Context,
+	opts *options.Options,
+	sshProviderInitializer *providerinitializer.SSHProviderInitializer,
+	kubeProvider libcon.KubeProvider,
+) (libcon.KubeProvider, func(), error) {
+	noop := func() {}
+
+	if opts.Kube.Config == "" {
+		return kubeProvider, noop, nil
+	}
+	if sshProviderInitializer == nil {
+		return kubeProvider, noop, nil
+	}
+	if immutable.BastionConfig(sshProviderInitializer.GetConfig()) == nil {
+		return kubeProvider, noop, nil
+	}
+	// An SSH host means the operator named a machine to work through, and that
+	// machine reaches the API itself. Only a run with no host at all is one where
+	// the kubeconfig is the sole way in.
+	if sshProviderInitializer.CheckHosts(ctx) {
+		return kubeProvider, noop, nil
+	}
+
+	path, stop, err := immutable.OpenKubeconfigChannel(
+		ctx,
+		sshProviderInitializer.GetConfig(),
+		sshProviderInitializer.GetSettings(),
+		opts.Kube.Config,
+		opts.Kube.ConfigContext,
+		opts.Global.TmpDir,
+	)
+	if err != nil {
+		return nil, noop, err
+	}
+
+	// Mirrors newKubeconfigKubeProvider of pkg/operations/bootstrap:
+	// a kubeconfig-backed client needs no SSH runner, hence the nil.
+	kubeConfig := &kube.Config{KubeConfig: path}
+	runner, err := provider.GetRunnerInterface(ctx, kubeConfig, sshProviderInitializer.GetSettings(), nil)
+	if err != nil {
+		stop()
+		return nil, noop, fmt.Errorf("build the Kubernetes runner interface: %w", err)
+	}
+
+	return provider.NewDefaultKubeProvider(sshProviderInitializer.GetSettings(), kubeConfig, runner), stop, nil
+}

--- a/dhctl/cmd/dhctl/commands/converge_bastion_test.go
+++ b/dhctl/cmd/dhctl/commands/converge_bastion_test.go
@@ -1,0 +1,46 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/app/options"
+)
+
+// The converge cache is keyed by the kubeconfig's PATH, not its content
+// (pkg/state/cache/init.go, GetCacheIdentityFromKubeconfig). Pointing the option
+// at the temporary copy would give every run a new identity and lose the state
+// an interrupted converge resumes from.
+func TestTheKubeconfigOptionSurvivesTheBastionChannel(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "admin.kubeconfig")
+	require.NoError(t, os.WriteFile(path, []byte("apiVersion: v1\nkind: Config\n"), 0o600))
+
+	opts := options.New()
+	opts.Kube.Config = path
+
+	// No SSH provider: the guards return the provider untouched, which is the
+	// only branch reachable without a bastion to dial.
+	_, stop, err := kubeProviderThroughBastion(t.Context(), opts, nil, nil)
+	require.NoError(t, err)
+	defer stop()
+
+	require.Equal(t, path, opts.Kube.Config, "the cache identity is derived from this path")
+}

--- a/dhctl/pkg/immutable/bastion_channel_test.go
+++ b/dhctl/pkg/immutable/bastion_channel_test.go
@@ -1,0 +1,225 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package immutable
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"io"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// fakeBastion accepts one SSH connection and serves direct-tcpip channels by
+// dialing the address it is asked for, counting every channel it opened.
+type fakeBastion struct {
+	address  string
+	channels atomic.Int64
+}
+
+func startFakeBastion(t *testing.T, hostKey ssh.Signer, target string) *fakeBastion {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { listener.Close() })
+
+	bastion := &fakeBastion{address: listener.Addr().String()}
+	serverConfig := &ssh.ServerConfig{NoClientAuth: true}
+	serverConfig.AddHostKey(hostKey)
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go bastion.serve(conn, serverConfig, target)
+		}
+	}()
+
+	return bastion
+}
+
+func (b *fakeBastion) serve(conn net.Conn, serverConfig *ssh.ServerConfig, target string) {
+	sshConn, newChannels, requests, err := ssh.NewServerConn(conn, serverConfig)
+	if err != nil {
+		return
+	}
+	defer sshConn.Close()
+	go ssh.DiscardRequests(requests)
+
+	for newChannel := range newChannels {
+		if newChannel.ChannelType() != "direct-tcpip" {
+			newChannel.Reject(ssh.UnknownChannelType, "only direct-tcpip")
+			continue
+		}
+		channel, channelRequests, err := newChannel.Accept()
+		if err != nil {
+			continue
+		}
+		b.channels.Add(1)
+		go ssh.DiscardRequests(channelRequests)
+		go b.pipe(channel, target)
+	}
+}
+
+func (b *fakeBastion) pipe(channel ssh.Channel, target string) {
+	defer channel.Close()
+	upstream, err := net.Dial("tcp", target)
+	if err != nil {
+		return
+	}
+	defer upstream.Close()
+	go io.Copy(upstream, channel)
+	io.Copy(channel, upstream)
+}
+
+// apiServerFor serves TLS under one name only: the name the kubeconfig gives.
+func apiServerFor(t *testing.T, serverName string) (*httptest.Server, *x509.CertPool) {
+	t.Helper()
+
+	public, private, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: serverName},
+		DNSNames:              []string{serverName},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, public, private)
+	require.NoError(t, err)
+
+	keyDER, err := x509.MarshalPKCS8PrivateKey(private)
+	require.NoError(t, err)
+	pair, err := tls.X509KeyPair(
+		pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}),
+		pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER}),
+	)
+	require.NoError(t, err)
+
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte("ok"))
+	}))
+	server.TLS = &tls.Config{Certificates: []tls.Certificate{pair}}
+	server.StartTLS()
+	t.Cleanup(server.Close)
+
+	pool := x509.NewCertPool()
+	certificate, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	pool.AddCert(certificate)
+
+	return server, pool
+}
+
+func testHostKey(t *testing.T) ssh.Signer {
+	t.Helper()
+	_, private, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	signer, err := ssh.NewSignerFromKey(private)
+	require.NoError(t, err)
+	return signer
+}
+
+// dialThroughBastion returns an http.Client whose every connection is a
+// direct-tcpip channel on the fake bastion, verified against serverName.
+func dialThroughBastion(t *testing.T, bastion *fakeBastion, target, serverName string, pool *x509.CertPool) *http.Client {
+	t.Helper()
+
+	client, err := ssh.Dial("tcp", bastion.address, &ssh.ClientConfig{
+		User:            "ubuntu",
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Timeout:         5 * time.Second,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { client.Close() })
+
+	return &http.Client{Transport: &http.Transport{
+		DialContext: func(ctx context.Context, network, _ string) (net.Conn, error) {
+			return client.Dial(network, target)
+		},
+		TLSClientConfig: &tls.Config{RootCAs: pool, ServerName: serverName},
+	}}
+}
+
+// The kubeconfig names an address only the cluster network resolves. Retargeted,
+// its server points at the local end of the forward while the name TLS is
+// verified against stays the one the certificate was issued for — anything else
+// and the operator's kubeconfig cannot be used through a bastion at all.
+func TestARetargetedKubeconfigReachesTheAPIThroughTheBastion(t *testing.T) {
+	const serverName = "master-0.example"
+
+	apiServer, pool := apiServerFor(t, serverName)
+	_, port, err := net.SplitHostPort(apiServer.Listener.Addr().String())
+	require.NoError(t, err)
+	bastion := startFakeBastion(t, testHostKey(t), apiServer.Listener.Addr().String())
+
+	original := kubeconfigFor("https://" + serverName + ":" + port)
+	host, remotePort, err := kubeconfigServer(original, "")
+	require.NoError(t, err)
+	require.Equal(t, serverName, host, "the forward must reach the address the kubeconfig names")
+
+	// What OpenKubeconfigChannel writes once the tunnel is up.
+	retargeted, err := RetargetKubeconfig(t.Context(), original, "https://127.0.0.1:1", host)
+	require.NoError(t, err)
+	parsed, err := clientcmd.Load(retargeted)
+	require.NoError(t, err)
+	cluster := parsed.Clusters["cluster"]
+	require.Equal(t, serverName, cluster.TLSServerName,
+		"the name TLS is verified against is the one the kubeconfig named, not a node name")
+
+	target := net.JoinHostPort(host, strconv.Itoa(remotePort))
+	response, err := dialThroughBastion(t, bastion, target, cluster.TLSServerName, pool).Get("https://127.0.0.1/")
+	require.NoError(t, err)
+	defer response.Body.Close()
+	require.Equal(t, http.StatusOK, response.StatusCode)
+	require.Equal(t, int64(1), bastion.channels.Load(), "the request must have travelled through the bastion")
+}
+
+// The bootstrap retargets to the node's name because it collected the kubeconfig
+// from that node. Converge has no node name, and using one here would fail every
+// handshake: this is the guard on that difference.
+func TestANodeNameWouldFailTheHandshake(t *testing.T) {
+	const serverName = "master-0.example"
+
+	apiServer, pool := apiServerFor(t, serverName)
+	bastion := startFakeBastion(t, testHostKey(t), apiServer.Listener.Addr().String())
+
+	client := dialThroughBastion(t, bastion, apiServer.Listener.Addr().String(), "immd-h-master-0", pool)
+	_, err := client.Get("https://127.0.0.1/")
+	require.ErrorContains(t, err, "certificate is valid for "+serverName)
+}

--- a/dhctl/pkg/immutable/kubeconfig_channel.go
+++ b/dhctl/pkg/immutable/kubeconfig_channel.go
@@ -1,0 +1,144 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package immutable
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"strconv"
+
+	"github.com/deckhouse/lib-connection/pkg/settings"
+	sshconfig "github.com/deckhouse/lib-connection/pkg/ssh/config"
+	dhlog "github.com/deckhouse/lib-dhctl/pkg/logger"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// defaultAPIServerPort is what an https URL without one means.
+const defaultAPIServerPort = 443
+
+// OpenKubeconfigChannel makes a kubeconfig whose server only exists inside the
+// cluster network usable from outside: it forwards that exact address through
+// the bastion and writes a copy pointed at the forward. Returns the copy's path
+// and the closer of both the tunnel and the copy.
+func OpenKubeconfigChannel(
+	ctx context.Context,
+	connectionConfig *sshconfig.ConnectionConfig,
+	sett settings.Settings,
+	kubeconfigPath, contextName, tmpDir string,
+) (string, func(), error) {
+	content, err := os.ReadFile(kubeconfigPath)
+	if err != nil {
+		return "", nil, fmt.Errorf("read the kubeconfig %s: %w", kubeconfigPath, err)
+	}
+
+	host, port, err := kubeconfigServer(content, contextName)
+	if err != nil {
+		return "", nil, err
+	}
+
+	address, stopTunnel, err := OpenBastionChannel(ctx, connectionConfig, sett, host, port, "Kubernetes API")
+	if err != nil {
+		return "", nil, err
+	}
+
+	// The name stays the host the kubeconfig already named, not a node name: the
+	// forward carries this one address, so the certificate it must match is the
+	// one that address is served with.
+	retargeted, err := RetargetKubeconfig(ctx, content, "https://"+address, host)
+	if err != nil {
+		stopTunnel()
+		return "", nil, err
+	}
+
+	path, err := WriteTemporaryKubeconfig(ctx, tmpDir, retargeted)
+	if err != nil {
+		stopTunnel()
+		return "", nil, err
+	}
+
+	return path, func() {
+		RemoveTemporaryKubeconfig(ctx, path)
+		stopTunnel()
+	}, nil
+}
+
+// kubeconfigServer is the address the kubeconfig's current cluster is reached
+// at. The port is explicit in every server URL dhctl writes, and 443 for one it
+// did not write.
+func kubeconfigServer(content []byte, contextName string) (string, int, error) {
+	kubeconfig, err := clientcmd.Load(content)
+	if err != nil {
+		return "", 0, fmt.Errorf("parse the kubeconfig: %w", err)
+	}
+
+	if contextName == "" {
+		contextName = kubeconfig.CurrentContext
+	}
+	kubeContext, ok := kubeconfig.Contexts[contextName]
+	if !ok {
+		return "", 0, fmt.Errorf("the kubeconfig has no context %q", contextName)
+	}
+	cluster, ok := kubeconfig.Clusters[kubeContext.Cluster]
+	if !ok {
+		return "", 0, fmt.Errorf("the kubeconfig has no cluster %q", kubeContext.Cluster)
+	}
+
+	parsed, err := url.Parse(cluster.Server)
+	if err != nil {
+		return "", 0, fmt.Errorf("parse the server URL %s: %w", cluster.Server, err)
+	}
+	if parsed.Hostname() == "" {
+		return "", 0, fmt.Errorf("the server URL %s names no host", cluster.Server)
+	}
+	if parsed.Port() == "" {
+		return parsed.Hostname(), defaultAPIServerPort, nil
+	}
+
+	port, err := strconv.Atoi(parsed.Port())
+	if err != nil {
+		return "", 0, fmt.Errorf("parse the port of the server URL %s: %w", cluster.Server, err)
+	}
+	return parsed.Hostname(), port, nil
+}
+
+// WriteTemporaryKubeconfig stores a kubeconfig in a file the Kubernetes client
+// can be built from. It holds cluster-admin credentials, so it is mode 0600 and
+// removed again once dhctl exits.
+func WriteTemporaryKubeconfig(ctx context.Context, dir string, content []byte) (string, error) {
+	file, err := os.CreateTemp(dir, "dhctl-immutable-kubeconfig-*.yaml")
+	if err != nil {
+		return "", fmt.Errorf("create a temporary kubeconfig: %w", err)
+	}
+	path := file.Name()
+	if err := file.Close(); err != nil {
+		return "", fmt.Errorf("create a temporary kubeconfig %s: %w", path, err)
+	}
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		return "", fmt.Errorf("write the temporary kubeconfig %s: %w", path, err)
+	}
+
+	return path, nil
+}
+
+// RemoveTemporaryKubeconfig deletes the file WriteTemporaryKubeconfig made.
+// Reported rather than returned: the caller is on its way out.
+func RemoveTemporaryKubeconfig(ctx context.Context, path string) {
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		dhlog.FromContext(ctx).WarnContext(ctx, fmt.Sprintf("remove %s: %v", path, err))
+	}
+}

--- a/dhctl/pkg/immutable/kubeconfig_channel_test.go
+++ b/dhctl/pkg/immutable/kubeconfig_channel_test.go
@@ -1,0 +1,113 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package immutable
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+const serverKubeconfig = `
+apiVersion: v1
+kind: Config
+current-context: ctx
+clusters:
+- name: cluster
+  cluster:
+    server: %s
+contexts:
+- name: ctx
+  context:
+    cluster: cluster
+    user: user
+users:
+- name: user
+  user: {}
+`
+
+func kubeconfigFor(server string) []byte {
+	return fmt.Appendf(nil, serverKubeconfig, server)
+}
+
+// The forward has to land on the address the kubeconfig itself names: that is
+// the address whose certificate the client then verifies against.
+func TestKubeconfigServerIsTheAddressTheForwardMustReach(t *testing.T) {
+	tests := []struct {
+		name     string
+		server   string
+		wantHost string
+		wantPort int
+	}{
+		{"an address", "https://10.12.5.24:6443", "10.12.5.24", 6443},
+		{"a name", "https://master-0.example:6443", "master-0.example", 6443},
+		{"IPv6", "https://[2001:db8::1]:6443", "2001:db8::1", 6443},
+		{"no port is 443", "https://master-0.example", "master-0.example", 443},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			host, port, err := kubeconfigServer(kubeconfigFor(tt.server), "")
+			require.NoError(t, err)
+			require.Equal(t, tt.wantHost, host)
+			require.Equal(t, tt.wantPort, port)
+		})
+	}
+}
+
+func TestKubeconfigServerRefusesWhatItCannotForwardTo(t *testing.T) {
+	_, _, err := kubeconfigServer(kubeconfigFor("https://"), "")
+	require.ErrorContains(t, err, "names no host")
+
+	_, _, err = kubeconfigServer(kubeconfigFor("https://master-0.example:6443"), "missing")
+	require.ErrorContains(t, err, `no context "missing"`)
+}
+
+// Without a bastion the channel is the address itself, so this drives the whole
+// of OpenKubeconfigChannel but the tunnel: the copy it writes must keep the name
+// TLS is verified against, or a converge through a bastion cannot handshake.
+func TestTheWrittenKubeconfigKeepsTheNameItWasIssuedFor(t *testing.T) {
+	const serverName = "master-0.example"
+
+	dir := t.TempDir()
+	original := filepath.Join(dir, "admin.kubeconfig")
+	require.NoError(t, os.WriteFile(original, kubeconfigFor("https://"+serverName+":6443"), 0o600))
+
+	path, stop, err := OpenKubeconfigChannel(t.Context(), nil, nil, original, "", dir)
+	require.NoError(t, err)
+	defer stop()
+
+	written, err := os.ReadFile(path)
+	require.NoError(t, err)
+	parsed, err := clientcmd.Load(written)
+	require.NoError(t, err)
+
+	require.Equal(t, serverName, parsed.Clusters["cluster"].TLSServerName,
+		"the copy must be verified against the name the kubeconfig named")
+	require.Equal(t, "https://"+serverName+":6443", parsed.Clusters["cluster"].Server,
+		"with no bastion the server is the address itself")
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o600), info.Mode().Perm(), "it holds cluster-admin credentials")
+
+	stop()
+	_, err = os.Stat(path)
+	require.ErrorIs(t, err, os.ErrNotExist, "the copy must not outlive the channel")
+}

--- a/dhctl/pkg/immutable/tunnel.go
+++ b/dhctl/pkg/immutable/tunnel.go
@@ -1,0 +1,167 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package immutable
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"strconv"
+
+	libcon "github.com/deckhouse/lib-connection/pkg"
+	"github.com/deckhouse/lib-connection/pkg/provider"
+	"github.com/deckhouse/lib-connection/pkg/settings"
+	sshconfig "github.com/deckhouse/lib-connection/pkg/ssh/config"
+	dhlog "github.com/deckhouse/lib-dhctl/pkg/logger"
+)
+
+// OpenBastionChannel returns the host:port dhctl reaches the given port of the
+// given machine on, and the closer of the tunnel behind it — a no-op without a
+// bastion. The forward is a direct-tcpip channel, so no sshd there is involved.
+func OpenBastionChannel(
+	ctx context.Context,
+	connectionConfig *sshconfig.ConnectionConfig,
+	sett settings.Settings,
+	host string,
+	remotePort int,
+	purpose string,
+) (string, func(), error) {
+	sshConfig := BastionConfig(connectionConfig)
+	if sshConfig == nil {
+		return net.JoinHostPort(host, strconv.Itoa(remotePort)), func() {}, nil
+	}
+
+	localPort, err := freeLocalPort()
+	if err != nil {
+		return "", nil, fmt.Errorf("reserve a local port for the %s tunnel: %w", purpose, err)
+	}
+
+	stop, err := openBastionTunnel(ctx, sshConfig, sett, host, remotePort, localPort, purpose)
+	if err != nil {
+		return "", nil, err
+	}
+
+	// 127.0.0.1 is always in the SAN list of a kube-apiserver certificate, and
+	// the handoff endpoint is verified by name rather than by address, so
+	// neither channel needs the local end to be nameable.
+	return net.JoinHostPort("127.0.0.1", strconv.Itoa(localPort)), stop, nil
+}
+
+// BastionConfig returns the SSH config a tunnel to the master is built from, or
+// nil when no bastion is configured and the master is reached directly.
+func BastionConfig(connectionConfig *sshconfig.ConnectionConfig) *sshconfig.Config {
+	if connectionConfig == nil || connectionConfig.Config == nil {
+		return nil
+	}
+	if connectionConfig.Config.BastionHost == "" {
+		return nil
+	}
+	return connectionConfig.Config
+}
+
+// openBastionTunnel forwards a local port to the given port of the master
+// through the bastion, and returns the closer of that forward.
+func openBastionTunnel(ctx context.Context, sshConfig *sshconfig.Config, sett settings.Settings, masterIP string, remotePort, localPort int, purpose string) (func(), error) {
+	// The SSH session is retargeted at the bastion itself instead of using it
+	// as a jump host: the forward has to originate on the bastion, because the
+	// master runs no sshd to originate it on.
+	bastionConfig := sshConfig.Clone()
+	bastionConfig.User = sshConfig.BastionUser
+	bastionConfig.Port = sshConfig.BastionPort
+	// gossh authenticates the target host with SudoPassword when no key
+	// matches, so the bastion password has to travel in that field.
+	bastionConfig.SudoPassword = sshConfig.BastionPassword
+	bastionConfig.BastionHost = ""
+	bastionConfig.BastionUser = ""
+	bastionConfig.BastionPassword = ""
+	// Only the gossh backend can forward without running a command on the
+	// target; the legacy clissh one keeps an interactive session open there.
+	bastionConfig.ForceLegacy = false
+	bastionConfig.ForceModern = true
+
+	// The provider narrates where this context narrates: a wait opens a channel
+	// every attempt, and the retry loop inside the provider prints three lines
+	// per open — on top of the one line that carries the node's own progress.
+	sshProvider := provider.NewDefaultSSHProvider(
+		channelSettings{Settings: sett, logger: dhlog.FromContext(ctx)},
+		&sshconfig.ConnectionConfig{
+			Config: bastionConfig,
+			Hosts:  []sshconfig.Host{{Host: sshConfig.BastionHost}},
+		},
+		provider.SSHClientWithStartAfterCreate(true),
+	)
+
+	sshClient, err := sshProvider.Client(ctx)
+	if err != nil {
+		cleanupSSHProvider(ctx, sshProvider)
+		return nil, fmt.Errorf("connect to the bastion host %s: %w", sshConfig.BastionHost, err)
+	}
+
+	tunnel := sshClient.Tunnel(fmt.Sprintf("%s:%d:127.0.0.1:%d", masterIP, remotePort, localPort))
+	if err := tunnel.Up(ctx); err != nil {
+		cleanupSSHProvider(ctx, sshProvider)
+		return nil, fmt.Errorf("forward %d to %s:%d through the bastion %s: %w", localPort, masterIP, remotePort, sshConfig.BastionHost, err)
+	}
+
+	// Debug: a wait rebuilds this channel per attempt — up to 360 of them over
+	// half an hour — and one line each would bury the node's own progress.
+	dhlog.FromContext(ctx).DebugContext(ctx, fmt.Sprintf(
+		"%s tunnel through the bastion is up: %s", purpose, tunnel.String(),
+	))
+
+	// Nothing drains the tunnel's error channel: gossh sends there non-blocking,
+	// so an unread channel cannot stall the accept loop, and a request that hits
+	// an error fails on its own and the caller retries.
+	return func() {
+		tunnel.Stop()
+		cleanupSSHProvider(ctx, sshProvider)
+	}, nil
+}
+
+// cleanupSSHProvider releases the connection to the bastion. Reported rather
+// than returned: every caller is already on its way out with something more
+// interesting to say, and a leaked control socket is worth a line in the log.
+func cleanupSSHProvider(ctx context.Context, sshProvider libcon.SSHProvider) {
+	if err := sshProvider.Cleanup(ctx); err != nil {
+		dhlog.FromContext(ctx).WarnContext(ctx, fmt.Sprintf("release the connection to the bastion: %v", err))
+	}
+}
+
+// freeLocalPort reserves an ephemeral port by binding and releasing it, so the
+// tunnel can bind it right after.
+func freeLocalPort() (int, error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	defer listener.Close()
+
+	addr, ok := listener.Addr().(*net.TCPAddr)
+	if !ok {
+		return 0, fmt.Errorf("unexpected listener address type %T", listener.Addr())
+	}
+	return addr.Port, nil
+}
+
+// channelSettings is the SSH settings of this bootstrap with one thing replaced:
+// the logger the plumbing narrates into. Embedded because every other setting
+// must stay exactly what the rest of dhctl was given.
+type channelSettings struct {
+	settings.Settings
+	logger *slog.Logger
+}
+
+func (s channelSettings) Logger() *slog.Logger { return s.logger }

--- a/dhctl/pkg/immutable/tunnel_test.go
+++ b/dhctl/pkg/immutable/tunnel_test.go
@@ -1,0 +1,39 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package immutable
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// A wait rebuilds this channel on every attempt, and the provider prints three
+// lines per open. Taking the logger from the context is what lets the caller
+// quiet the plumbing behind its own progress line.
+func TestTheTunnelNarratesWhereItsContextNarrates(t *testing.T) {
+	src, err := os.ReadFile("tunnel.go")
+	if err != nil {
+		t.Fatalf("read tunnel.go: %v", err)
+	}
+
+	body := string(src)
+	if !strings.Contains(body, "channelSettings{Settings: sett, logger: dhlog.FromContext(ctx)}") {
+		t.Error("the SSH provider must take its logger from the context, or a wait cannot quiet the plumbing behind it")
+	}
+	if strings.Contains(body, "provider.NewDefaultSSHProvider(\n\t\tsett,") {
+		t.Error("the bare settings narrate onto the screen whatever the caller asked for")
+	}
+}

--- a/dhctl/pkg/operations/bootstrap/connect_line.go
+++ b/dhctl/pkg/operations/bootstrap/connect_line.go
@@ -33,7 +33,7 @@ import (
 func (b *ClusterBootstrapper) printHowToReachTheCluster(ctx context.Context, kubeconfigPath string, bctx *bootstrapContext) {
 	logger := dhlog.FromContext(ctx)
 
-	tunnel := bastionTunnelCommand(bastionConfig(b.SSHProviderInitializer.GetConfig()))
+	tunnel := bastionTunnelCommand(immutable.BastionConfig(b.SSHProviderInitializer.GetConfig()))
 	if tunnel != "" {
 		logger.InfoContext(ctx, fmt.Sprintf(
 			"The master answers at %s:%d, an address that exists only inside the cluster network. "+

--- a/dhctl/pkg/operations/bootstrap/steps_immutable_handoff_test.go
+++ b/dhctl/pkg/operations/bootstrap/steps_immutable_handoff_test.go
@@ -242,21 +242,3 @@ func TestTheWaitRepeatsItselfWhileNothingChanges(t *testing.T) {
 		t.Errorf("a repeat must carry how long the wait has been running, got:\n%s", terminal.String())
 	}
 }
-
-// The provider's own retry loop prints three lines per channel, and a channel is
-// opened every attempt. Its logger comes from the settings, not from the context,
-// so muting the context alone leaves the screen exactly as noisy as before.
-func TestTheTunnelNarratesWhereItsContextNarrates(t *testing.T) {
-	src, err := os.ReadFile("steps_immutable_tunnel.go")
-	if err != nil {
-		t.Fatalf("read steps_immutable_tunnel.go: %v", err)
-	}
-
-	body := string(src)
-	if !strings.Contains(body, "channelSettings{Settings: b.SSHProviderInitializer.GetSettings(), logger: dhlog.FromContext(ctx)}") {
-		t.Error("the SSH provider must take its logger from the context, or a wait cannot quiet the plumbing behind it")
-	}
-	if strings.Contains(body, "provider.NewDefaultSSHProvider(\n\t\tb.SSHProviderInitializer.GetSettings(),") {
-		t.Error("the bare settings narrate onto the screen whatever the caller asked for")
-	}
-}

--- a/dhctl/pkg/operations/bootstrap/steps_immutable_tunnel.go
+++ b/dhctl/pkg/operations/bootstrap/steps_immutable_tunnel.go
@@ -16,16 +16,8 @@ package bootstrap
 
 import (
 	"context"
-	"fmt"
-	"log/slog"
-	"net"
-	"strconv"
 
-	libcon "github.com/deckhouse/lib-connection/pkg"
-	"github.com/deckhouse/lib-connection/pkg/provider"
-	"github.com/deckhouse/lib-connection/pkg/settings"
-	sshconfig "github.com/deckhouse/lib-connection/pkg/ssh/config"
-	dhlog "github.com/deckhouse/lib-dhctl/pkg/logger"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/immutable"
 )
 
 // openImmutableChannel reaches the first master, whose address the rest of the
@@ -40,132 +32,14 @@ func (b *ClusterBootstrapper) openImmutableChannel(ctx context.Context, bctx *bo
 }
 
 // openImmutableChannelTo returns the host:port dhctl reaches the given port of
-// the given machine on, and the closer of the tunnel behind it — a no-op
-// without a bastion. The forward is a direct-tcpip channel, so no sshd there.
+// the given machine on, and the closer of the tunnel behind it.
 func (b *ClusterBootstrapper) openImmutableChannelTo(ctx context.Context, host string, remotePort int, purpose string) (string, func(), error) {
-	sshConfig := bastionConfig(b.SSHProviderInitializer.GetConfig())
-	if sshConfig == nil {
-		return net.JoinHostPort(host, strconv.Itoa(remotePort)), func() {}, nil
-	}
-
-	localPort, err := freeLocalPort()
-	if err != nil {
-		return "", nil, fmt.Errorf("reserve a local port for the %s tunnel: %w", purpose, err)
-	}
-
-	stop, err := b.openBastionTunnel(ctx, sshConfig, host, remotePort, localPort, purpose)
-	if err != nil {
-		return "", nil, err
-	}
-
-	// 127.0.0.1 is always in the SAN list of a kube-apiserver certificate, and
-	// the handoff endpoint is verified by name rather than by address, so
-	// neither channel needs the local end to be nameable.
-	return net.JoinHostPort("127.0.0.1", strconv.Itoa(localPort)), stop, nil
-}
-
-// bastionConfig returns the SSH config a tunnel to the master is built from, or
-// nil when no bastion is configured and the master is reached directly.
-func bastionConfig(connectionConfig *sshconfig.ConnectionConfig) *sshconfig.Config {
-	if connectionConfig == nil || connectionConfig.Config == nil {
-		return nil
-	}
-	if connectionConfig.Config.BastionHost == "" {
-		return nil
-	}
-	return connectionConfig.Config
-}
-
-// openBastionTunnel forwards a local port to the given port of the master
-// through the bastion, and returns the closer of that forward.
-func (b *ClusterBootstrapper) openBastionTunnel(ctx context.Context, sshConfig *sshconfig.Config, masterIP string, remotePort, localPort int, purpose string) (func(), error) {
-	// The SSH session is retargeted at the bastion itself instead of using it
-	// as a jump host: the forward has to originate on the bastion, because the
-	// master runs no sshd to originate it on.
-	bastionConfig := sshConfig.Clone()
-	bastionConfig.User = sshConfig.BastionUser
-	bastionConfig.Port = sshConfig.BastionPort
-	// gossh authenticates the target host with SudoPassword when no key
-	// matches, so the bastion password has to travel in that field.
-	bastionConfig.SudoPassword = sshConfig.BastionPassword
-	bastionConfig.BastionHost = ""
-	bastionConfig.BastionUser = ""
-	bastionConfig.BastionPassword = ""
-	// Only the gossh backend can forward without running a command on the
-	// target; the legacy clissh one keeps an interactive session open there.
-	bastionConfig.ForceLegacy = false
-	bastionConfig.ForceModern = true
-
-	// The provider narrates where this context narrates: a wait opens a channel
-	// every attempt, and the retry loop inside the provider prints three lines
-	// per open — on top of the one line that carries the node's own progress.
-	sshProvider := provider.NewDefaultSSHProvider(
-		channelSettings{Settings: b.SSHProviderInitializer.GetSettings(), logger: dhlog.FromContext(ctx)},
-		&sshconfig.ConnectionConfig{
-			Config: bastionConfig,
-			Hosts:  []sshconfig.Host{{Host: sshConfig.BastionHost}},
-		},
-		provider.SSHClientWithStartAfterCreate(true),
+	return immutable.OpenBastionChannel(
+		ctx,
+		b.SSHProviderInitializer.GetConfig(),
+		b.SSHProviderInitializer.GetSettings(),
+		host,
+		remotePort,
+		purpose,
 	)
-
-	sshClient, err := sshProvider.Client(ctx)
-	if err != nil {
-		cleanupSSHProvider(ctx, sshProvider)
-		return nil, fmt.Errorf("connect to the bastion host %s: %w", sshConfig.BastionHost, err)
-	}
-
-	tunnel := sshClient.Tunnel(fmt.Sprintf("%s:%d:127.0.0.1:%d", masterIP, remotePort, localPort))
-	if err := tunnel.Up(ctx); err != nil {
-		cleanupSSHProvider(ctx, sshProvider)
-		return nil, fmt.Errorf("forward %d to %s:%d through the bastion %s: %w", localPort, masterIP, remotePort, sshConfig.BastionHost, err)
-	}
-
-	// Debug: a wait rebuilds this channel per attempt — up to 360 of them over
-	// half an hour — and one line each would bury the node's own progress.
-	dhlog.FromContext(ctx).DebugContext(ctx, fmt.Sprintf(
-		"%s tunnel through the bastion is up: %s", purpose, tunnel.String(),
-	))
-
-	// Nothing drains the tunnel's error channel: gossh sends there non-blocking,
-	// so an unread channel cannot stall the accept loop, and a request that hits
-	// an error fails on its own and the caller retries.
-	return func() {
-		tunnel.Stop()
-		cleanupSSHProvider(ctx, sshProvider)
-	}, nil
 }
-
-// cleanupSSHProvider releases the connection to the bastion. Reported rather
-// than returned: every caller is already on its way out with something more
-// interesting to say, and a leaked control socket is worth a line in the log.
-func cleanupSSHProvider(ctx context.Context, sshProvider libcon.SSHProvider) {
-	if err := sshProvider.Cleanup(ctx); err != nil {
-		dhlog.FromContext(ctx).WarnContext(ctx, fmt.Sprintf("release the connection to the bastion: %v", err))
-	}
-}
-
-// freeLocalPort reserves an ephemeral port by binding and releasing it, so the
-// tunnel can bind it right after.
-func freeLocalPort() (int, error) {
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		return 0, err
-	}
-	defer listener.Close()
-
-	addr, ok := listener.Addr().(*net.TCPAddr)
-	if !ok {
-		return 0, fmt.Errorf("unexpected listener address type %T", listener.Addr())
-	}
-	return addr.Port, nil
-}
-
-// channelSettings is the SSH settings of this bootstrap with one thing replaced:
-// the logger the plumbing narrates into. Embedded because every other setting
-// must stay exactly what the rest of dhctl was given.
-type channelSettings struct {
-	settings.Settings
-	logger *slog.Logger
-}
-
-func (s channelSettings) Logger() *slog.Logger { return s.logger }


### PR DESCRIPTION
Teaches `dhctl converge` to reach a cluster whose nodes run no sshd, using only the kubeconfig it was given and a bastion.

Stacked on #22212: the node phases of this cluster are skipped by the immutable gate that lands there, so this branch is based on `immutable-static-bootstrap` rather than `main`.

## The problem

An immutable node answers no sshd. Port 22 is closed, and the kubeconfig the bootstrap collected names an address that resolves only inside the cluster network. Today the operator opens a SOCKS tunnel by hand and exports `HTTPS_PROXY`; the documented `--ssh-host` path retries against a port nothing listens on and then fails.

## What lands here

- `immutable.OpenBastionChannel` — the bastion forward that `bootstrap` already used, lifted out of `ClusterBootstrapper` into a free function. It was a method only nominally: the receiver supplied `GetConfig()` and `GetSettings()` and nothing else. The five bootstrap call sites keep their signatures through thin wrappers.
- `immutable.OpenKubeconfigChannel` — reads the kubeconfig, takes the `host:port` its `server` names, forwards **that exact address** through the bastion, and writes a copy pointed at the local end. Returns the copy's path and one closer for both the tunnel and the copy.
- `converge` swaps in a Kubernetes provider built on that copy when, and only when, a kubeconfig is given, a bastion is configured, and no SSH host is known. No new flag.

## Two decisions worth reading

**`TLSServerName` is the host the kubeconfig named, not a node name.** The bootstrap retargets to the node's name because it collected the kubeconfig from that node; converge has no node name to use, and substituting one fails every handshake. Forwarding to exactly the address the kubeconfig names, and pinning that same name, makes a mismatch impossible by construction.

**`opts.Kube.Config` is never mutated.** `GetCacheIdentityFromKubeconfig` hashes the kubeconfig *path*, not its content. Pointing the option at the temporary copy would give every run a new cache identity and lose the state an interrupted converge resumes from.

## Rejected: a dialer in `rest.Config`

Injecting a custom `DialContext` would leave the kubeconfig untouched, but it is not the same mechanism as the SOCKS proxy it replaces. A proxy applies to every path; a `Dial` override does not reach SPDY and websocket round-trippers the same way, so `pod exec` and parts of watch would quietly bypass the bastion. A local port forward is indifferent to what travels through it. It also needs a type assertion into the concrete gossh client, since `GetClient()` is not on the `connection.SSHClient` interface.

## Tests

Nine, all green; two verified red by reverting the production change and capturing the failure.

- `TestTheWrittenKubeconfigKeepsTheNameItWasIssuedFor` drives all of `OpenKubeconfigChannel` without a bastion (with none configured the channel is the address itself, so no SSH plumbing is needed). Reverted to a node name: `expected: "master-0.example"`.
- `TestTheKubeconfigOptionSurvivesTheBastionChannel` guards the cache identity. Adding a mutation of `opts.Kube.Config` turns it red.
- `TestARetargetedKubeconfigReachesTheAPIThroughTheBastion` runs an in-process SSH bastion that counts the direct-tcpip channels it opens, against a TLS server whose certificate does not cover `127.0.0.1`. The request succeeds and the channel count is exactly one.
- `TestANodeNameWouldFailTheHandshake` is the same stand with a node name: `certificate is valid for master-0.example`.
- `TestKubeconfigServer*` cover an address, a name, IPv6, a URL with no port, and the refusals.

## Verified on a live cluster

Three immutable masters plus a CloudPermanent group on DVP, converge run with `--kubeconfig` and `--ssh-bastion-host` and **no** `HTTPS_PROXY`.

| | this branch | the same command without these commits |
|---|---|---|
| result | walks `master` and `front`, ends with "Cleanup skipped. Converge runs over the Kubernetes API, with no SSH access to nodes" | `Timeout while "Waiting for Kubernetes API to become Ready": Get "https://10.12.3.52:6443/version": EOF` after 703s |
| nodes | ages unchanged, nothing rolled | never reached a node |

## Checklist

- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: dhctl
type: feature
summary: Converge reaches a cluster of nodes that run no sshd through a bastion, using the kubeconfig's own address, so the operator no longer opens a SOCKS tunnel by hand.
impact_level: low
```
