### PR TITLE
[cni-cilium, cilium-hubble] Bump golang.org/x/mod and cilium/ebpf to fix CVEs (1.77)

### DIFF
--- a/modules/021-cni-cilium/images/bin-cilium/patches/000-go-mod.patch
+++ b/modules/021-cni-cilium/images/bin-cilium/patches/000-go-mod.patch
@@ -1,7 +1,16 @@
 diff --git a/go.mod b/go.mod
-index 76739573..a4fce27d 100644
+index 76739573..9f9dff77 100644
 --- a/go.mod
 +++ b/go.mod
+@@ -20,7 +20,7 @@ require (
+ 	github.com/cilium/coverbee v0.3.3-0.20240723084546-664438750fce
+ 	github.com/cilium/deepequal-gen v0.0.0-20241016021505-f57df2fe2e62
+ 	github.com/cilium/dns v1.1.51-0.20240603182237-af788769786a
+-	github.com/cilium/ebpf v0.17.1
++	github.com/cilium/ebpf v0.22.0
+ 	github.com/cilium/endpointslice-controller v0.0.0-20240409203012-75cb5d61db1b
+ 	github.com/cilium/fake v0.6.1
+ 	github.com/cilium/hive v0.0.0-20250522145610-0734675df148
 @@ -36,7 +36,7 @@ require (
  	github.com/docker/docker v27.4.0+incompatible
  	github.com/docker/libnetwork v0.8.0-dev.2.0.20210525090646-64b7a4574d14
@@ -27,15 +36,22 @@ index 76739573..a4fce27d 100644
  	github.com/gorilla/mux v1.8.1
  	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.2.0
  	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
-@@ -85,7 +85,7 @@ require (
+@@ -84,11 +84,11 @@ require (
+ 	github.com/prometheus/procfs v0.15.1
  	github.com/russross/blackfriday/v2 v2.1.0
  	github.com/sasha-s/go-deadlock v0.3.5
- 	github.com/sirupsen/logrus v1.9.3
+-	github.com/sirupsen/logrus v1.9.3
 -	github.com/spf13/afero v1.11.0
++	github.com/sirupsen/logrus v1.9.4
 +	github.com/spf13/afero v1.15.0
  	github.com/spf13/cast v1.7.0
- 	github.com/spf13/cobra v1.8.1
- 	github.com/spf13/pflag v1.0.6-0.20210604193023-d5e0c0615ace
+-	github.com/spf13/cobra v1.8.1
+-	github.com/spf13/pflag v1.0.6-0.20210604193023-d5e0c0615ace
++	github.com/spf13/cobra v1.10.2
++	github.com/spf13/pflag v1.0.10
+ 	github.com/spf13/viper v1.19.0
+ 	github.com/spiffe/go-spiffe/v2 v2.6.0
+ 	github.com/spiffe/spire-api-sdk v1.11.1
 @@ -100,23 +100,23 @@ require (
  	go.etcd.io/etcd/api/v3 v3.5.17
  	go.etcd.io/etcd/client/pkg/v3 v3.5.17
@@ -81,7 +97,7 @@ index 76739573..a4fce27d 100644
  	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
  	github.com/aws/aws-sdk-go-v2/credentials v1.17.47 // indirect
  	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.25 // indirect
-@@ -161,7 +161,7 @@ require (
+@@ -161,10 +161,10 @@ require (
  	github.com/aws/aws-sdk-go-v2/service/sts v1.33.2 // indirect
  	github.com/beorn7/perks v1.0.1 // indirect
  	github.com/cilium/endpointslice v0.29.4-0.20240409195643-982ad68ab7ba // indirect
@@ -89,7 +105,11 @@ index 76739573..a4fce27d 100644
 +	github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 // indirect
  	github.com/containerd/log v0.1.0 // indirect
  	github.com/coreos/go-semver v0.3.1 // indirect
- 	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
+-	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
++	github.com/cpuguy83/go-md2man/v2 v2.0.6 // indirect
+ 	github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13 // indirect
+ 	github.com/dimchansky/utfbom v1.1.1 // indirect
+ 	github.com/distribution/reference v0.6.0 // indirect
 @@ -173,12 +173,12 @@ require (
  	github.com/eapache/channels v1.1.0 // indirect
  	github.com/eapache/queue v1.1.0 // indirect
@@ -105,7 +125,34 @@ index 76739573..a4fce27d 100644
  	github.com/go-logr/stdr v1.2.2 // indirect
  	github.com/go-openapi/analysis v0.23.0 // indirect
  	github.com/go-openapi/jsonpointer v0.21.0 // indirect
-@@ -240,31 +240,30 @@ require (
+@@ -201,7 +201,7 @@ require (
+ 	github.com/josharian/intern v1.0.0 // indirect
+ 	github.com/josharian/native v1.1.0 // indirect
+ 	github.com/k-sone/critbitgo v1.4.0 // indirect
+-	github.com/klauspost/compress v1.17.9 // indirect
++	github.com/klauspost/compress v1.18.0 // indirect
+ 	github.com/kylelemons/godebug v1.1.0 // indirect
+ 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
+ 	github.com/magiconair/properties v1.8.7 // indirect
+@@ -211,7 +211,7 @@ require (
+ 	github.com/mdlayher/genetlink v1.3.2 // indirect
+ 	github.com/mdlayher/netlink v1.7.2 // indirect
+ 	github.com/mdlayher/packet v1.1.2 // indirect
+-	github.com/mdlayher/socket v0.4.1 // indirect
++	github.com/mdlayher/socket v0.5.1 // indirect
+ 	github.com/miekg/dns v1.1.62 // indirect
+ 	github.com/mitchellh/go-homedir v1.1.0 // indirect
+ 	github.com/mitchellh/mapstructure v1.5.0 // indirect
+@@ -228,7 +228,7 @@ require (
+ 	github.com/nxadm/tail v1.4.8 // indirect
+ 	github.com/oklog/ulid v1.3.1 // indirect
+ 	github.com/opencontainers/go-digest v1.0.0 // indirect
+-	github.com/opencontainers/image-spec v1.1.0 // indirect
++	github.com/opencontainers/image-spec v1.1.1 // indirect
+ 	github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b // indirect
+ 	github.com/pelletier/go-toml v1.9.5 // indirect
+ 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
+@@ -240,36 +240,34 @@ require (
  	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
  	github.com/sergi/go-diff v1.3.1 // indirect
  	github.com/sourcegraph/conc v0.3.0 // indirect
@@ -146,10 +193,26 @@ index 76739573..a4fce27d 100644
  	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
  	gopkg.in/inf.v0 v0.9.1 // indirect
  	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
+ 	gopkg.in/yaml.v2 v2.4.0 // indirect
+-	gotest.tools/v3 v3.5.0 // indirect
+ 	k8s.io/apiserver v0.32.13 // indirect
+ 	k8s.io/gengo/v2 v2.0.0-20240911193312-2b36238f13e9 // indirect
+ 	k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f // indirect
 diff --git a/go.sum b/go.sum
-index 2b5021d6..058a2caa 100644
+index 2b5021d6..de5719a6 100644
 --- a/go.sum
 +++ b/go.sum
+@@ -36,8 +36,8 @@ github.com/Azure/go-autorest/logger v0.2.1/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZ
+ github.com/Azure/go-autorest/tracing v0.6.0 h1:TYi4+3m5t6K48TGI9AUdb+IzbnSxvnvUMfuitfgcfuo=
+ github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
+ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+-github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8=
+-github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
++github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
++github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+ github.com/HdrHistogram/hdrhistogram-go v1.1.2/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
+ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 @@ -56,8 +56,8 @@ github.com/aliyun/alibaba-cloud-sdk-go v1.63.68/go.mod h1:SOSDHfe1kX91v3W5QiBsWS
  github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=
  github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
@@ -161,6 +224,17 @@ index 2b5021d6..058a2caa 100644
  github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
  github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
  github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
+@@ -110,8 +110,8 @@ github.com/cilium/deepequal-gen v0.0.0-20241016021505-f57df2fe2e62 h1:MOWY9eqnrr
+ github.com/cilium/deepequal-gen v0.0.0-20241016021505-f57df2fe2e62/go.mod h1:9EU8oWNwEP6f98xJz/YjWw7yOLHK7p90MKmaPu1wBcE=
+ github.com/cilium/dns v1.1.51-0.20240603182237-af788769786a h1:PRGN7B+72mj3OtLL2DM3F/9jp+ItgqgNS7mecgCmwsQ=
+ github.com/cilium/dns v1.1.51-0.20240603182237-af788769786a/go.mod h1:/7LC2GOgyXJ7maupZlaVIumYQiGPIgllSf6mA9sg6RU=
+-github.com/cilium/ebpf v0.17.1 h1:G8mzU81R2JA1nE5/8SRubzqvBMmAmri2VL8BIZPWvV0=
+-github.com/cilium/ebpf v0.17.1/go.mod h1:vay2FaYSmIlv3r8dNACd4mW/OCaZLJKJOo+IHBvCIO8=
++github.com/cilium/ebpf v0.22.0 h1:v2ktp0roffpMOj2MMf3idtCQZOsAoC4BJbAJN+ke2bY=
++github.com/cilium/ebpf v0.22.0/go.mod h1:CDzZbe2hC5JjlDC+CY3KFCzlYwN4gbxppYM+Z10bQt4=
+ github.com/cilium/endpointslice v0.29.4-0.20240409195643-982ad68ab7ba h1:Ddc5e+pz0/nY0XiAEW/UcIlvnaHACSuF77ePyMNX510=
+ github.com/cilium/endpointslice v0.29.4-0.20240409195643-982ad68ab7ba/go.mod h1:9MPoeojWVEBLFnioKXTvRoqGWTs9Dt252r1ACFsi8K8=
+ github.com/cilium/endpointslice-controller v0.0.0-20240409203012-75cb5d61db1b h1:JxoccA9UQVXoQlJaMI7dtCXhg5R1ZPLPW+py376p1SA=
 @@ -141,8 +141,8 @@ github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XP
  github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
  github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
@@ -172,6 +246,17 @@ index 2b5021d6..058a2caa 100644
  github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
  github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
  github.com/containernetworking/cni v1.2.3 h1:hhOcjNVUQTnzdRJ6alC5XF+wd9mfGIUaj8FuJbEslXM=
+@@ -151,8 +151,8 @@ github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr
+ github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
+ github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=
+ github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
+-github.com/cpuguy83/go-md2man/v2 v2.0.4 h1:wfIWP927BUkWJb2NmU/kNDYIBTh/ziUX91+lVfRxZq4=
+-github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
++github.com/cpuguy83/go-md2man/v2 v2.0.6 h1:XJtiaUW6dEEqVuZiMTn1ldk455QWwEIsMIJlo5vtkx0=
++github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+ github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
+ github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 @@ -187,11 +187,11 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
  github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1/go.mod h1:KJwIaB5Mv44NWtYuAOFCVOjcI94vtpEz2JU/D2v6IjE=
  github.com/envoyproxy/go-control-plane/contrib v1.32.4 h1:/udV6s9xkDGe13WfrT2MHAxXTNDMBYBPxI1GkleCrmM=
@@ -199,6 +284,17 @@ index 2b5021d6..058a2caa 100644
  github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
  github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
  github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
+@@ -243,8 +243,8 @@ github.com/go-openapi/swag v0.23.0 h1:vsEVJDUo2hPJ2tu0/Xc+4noaxyEffXNIs3cOULZ+Gr
+ github.com/go-openapi/swag v0.23.0/go.mod h1:esZ8ITTYEsH1V2trKHjAN8Ai7xHb8RV+YSZ577vPjgQ=
+ github.com/go-openapi/validate v0.24.0 h1:LdfDKwNbpB6Vn40xhTdNZAnfLECL81w+VX3BumrGD58=
+ github.com/go-openapi/validate v0.24.0/go.mod h1:iyeX1sEufmv3nPbBdX3ieNviWnOZaJ1+zquzJEf2BAQ=
+-github.com/go-quicktest/qt v1.101.0 h1:O1K29Txy5P2OK0dGo59b7b0LR6wKfIhttaAhHUyn7eI=
+-github.com/go-quicktest/qt v1.101.0/go.mod h1:14Bz/f7NwaXPtdYEgzsx46kqSxVwTbzVZsDC26tQJow=
++github.com/go-quicktest/qt v1.101.1-0.20240301121107-c6c8733fa1e6 h1:teYtXy9B7y5lHTp8V9KPxpYRAVA7dozigQcMiBust1s=
++github.com/go-quicktest/qt v1.101.1-0.20240301121107-c6c8733fa1e6/go.mod h1:p4lGIVX+8Wa6ZPNDvqcxq36XpUDLh42FLetFU7odllI=
+ github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
+ github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
+ github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 @@ -287,8 +287,8 @@ github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek
  github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
  github.com/google/btree v1.1.3 h1:CVpQJjYgC4VbzxeGVHfvZrv1ctoYCAI8vbl07Fcxlyg=
@@ -232,8 +328,47 @@ index 2b5021d6..058a2caa 100644
  github.com/hashicorp/go-hclog v1.6.3 h1:Qr2kF+eVWjTiYmU7Y31tYlP1h0q/X3Nl3tPGdaB11/k=
  github.com/hashicorp/go-hclog v1.6.3/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
  github.com/hashicorp/go-immutable-radix/v2 v2.1.0 h1:CUW5RYIcysz+D3B+l1mDeXrQ7fUvGGCwJfdASSzbrfo=
-@@ -529,8 +529,8 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
- github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+@@ -386,8 +386,8 @@ github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4
+ github.com/kevinburke/ssh_config v1.2.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
+ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
+ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+-github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=
+-github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
++github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
++github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
+ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+ github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+ github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
+@@ -430,8 +430,8 @@ github.com/mdlayher/packet v1.0.0/go.mod h1:eE7/ctqDhoiRhQ44ko5JZU2zxB88g+JH/6jm
+ github.com/mdlayher/packet v1.1.2 h1:3Up1NG6LZrsgDVn6X4L9Ge/iyRyxFEFD9o6Pr3Q1nQY=
+ github.com/mdlayher/packet v1.1.2/go.mod h1:GEu1+n9sG5VtiRE4SydOmX5GTwyyYlteZiFU+x0kew4=
+ github.com/mdlayher/socket v0.2.1/go.mod h1:QLlNPkFR88mRUNQIzRBMfXxwKal8H7u1h3bL1CV+f0E=
+-github.com/mdlayher/socket v0.4.1 h1:eM9y2/jlbs1M615oshPQOHZzj6R6wMT7bX5NPiQvn2U=
+-github.com/mdlayher/socket v0.4.1/go.mod h1:cAqeGjoufqdxWkD7DkpyS+wcefOtmu5OQ8KuoJGIReA=
++github.com/mdlayher/socket v0.5.1 h1:VZaqt6RkGkt2OE9l3GcC6nZkqD3xKeQLyfleW/uBcos=
++github.com/mdlayher/socket v0.5.1/go.mod h1:TjPLHI1UgwEv5J1B5q0zTZq12A/6H7nKmtTanQE37IQ=
+ github.com/miekg/dns v1.1.62 h1:cN8OuEF1/x5Rq6Np+h1epln8OiyPWV+lROx9LxcGgIQ=
+ github.com/miekg/dns v1.1.62/go.mod h1:mvDlcItzm+br7MToIKqkglaGhlFMHJ9DTNNWONWXbNQ=
+ github.com/mikioh/ipaddr v0.0.0-20190404000644-d465c8ab6721 h1:RlZweED6sbSArvlE924+mUcZuXKLBHA35U7LN621Bws=
+@@ -481,8 +481,8 @@ github.com/onsi/gomega v1.36.1 h1:bJDPBO7ibjxcbHMgSCoo4Yj18UWbKDlLwX1x9sybDcw=
+ github.com/onsi/gomega v1.36.1/go.mod h1:PvZbdDc8J6XJEpDK4HCuRBm8a6Fzp9/DmhC9C7yFlog=
+ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
+ github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
+-github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQb2IpWsCzug=
+-github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
++github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
++github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
+ github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b h1:FfH+VrHHk6Lxt9HdVS0PXzSXFyS2NbZKXv33FYPol0A=
+ github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b/go.mod h1:AC62GU6hc0BrNm+9RK9VSiwa/EUe1bkIeFORAMcHvJU=
+ github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
+@@ -525,27 +525,25 @@ github.com/sasha-s/go-deadlock v0.3.5/go.mod h1:bugP6EGbdGYObIlx7pUZtWqlvo8k9H6v
+ github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
+ github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=
+ github.com/sergi/go-diff v1.3.1/go.mod h1:aMJSSKb2lpPvRNec0+w3fl7LP9IOFzdc9Pa4NFbPK1I=
+-github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
+-github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
++github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=
++github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
  github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
  github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 -github.com/spf13/afero v1.11.0 h1:WJQKhtpdm3v2IzqG8VMqrr6Rf3UYpEF239Jy9wNepM8=
@@ -242,8 +377,19 @@ index 2b5021d6..058a2caa 100644
 +github.com/spf13/afero v1.15.0/go.mod h1:NC2ByUVxtQs4b3sIUphxK0NioZnmxgyCrfzeuq8lxMg=
  github.com/spf13/cast v1.7.0 h1:ntdiHjuueXFgm5nzDRdOS4yfT43P5Fnud6DH50rz/7w=
  github.com/spf13/cast v1.7.0/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
- github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
-@@ -544,8 +544,6 @@ github.com/spiffe/go-spiffe/v2 v2.6.0 h1:l+DolpxNWYgruGQVV0xsfeya3CsC7m8iBzDnMps
+-github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
+-github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
+-github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+-github.com/spf13/pflag v1.0.6-0.20210604193023-d5e0c0615ace h1:9PNP1jnUjRhfmGMlkXHjYPishpcw4jpSt/V/xYY3FMA=
+-github.com/spf13/pflag v1.0.6-0.20210604193023-d5e0c0615ace/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
++github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
++github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
++github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
++github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
++github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+ github.com/spf13/viper v1.19.0 h1:RWq5SEjt8o25SROyN3z2OrDB9l7RPd3lwTWU8EcEdcI=
+ github.com/spf13/viper v1.19.0/go.mod h1:GQUN9bilAbhU/jgc1bKs99f/suXKeUMct8Adx5+Ntkg=
+ github.com/spiffe/go-spiffe/v2 v2.6.0 h1:l+DolpxNWYgruGQVV0xsfeya3CsC7m8iBzDnMpsbLuo=
  github.com/spiffe/go-spiffe/v2 v2.6.0/go.mod h1:gm2SeUoMZEtpnzPNs2Csc0D/gX33k1xIx7lEzqblHEs=
  github.com/spiffe/spire-api-sdk v1.11.1 h1:s5RWwBszfMYsRQTGeB6p93NfYBuwHP0tjHFEj5LHun0=
  github.com/spiffe/spire-api-sdk v1.11.1/go.mod h1:4uuhFlN6KBWjACRP3xXwrOTNnvaLp1zJs8Lribtr4fI=
@@ -372,7 +518,15 @@ index 2b5021d6..058a2caa 100644
  golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
  golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
  golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-@@ -742,17 +740,17 @@ golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+@@ -733,7 +731,6 @@ golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBc
+ golang.org/x/sys v0.0.0-20220209214540-3681064d5158/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+@@ -742,17 +739,17 @@ golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
  golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
  golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
  golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
@@ -396,7 +550,7 @@ index 2b5021d6..058a2caa 100644
  golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
  golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
  golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-@@ -760,8 +758,8 @@ golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+@@ -760,8 +757,8 @@ golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
  golang.org/x/text v0.7.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
  golang.org/x/text v0.9.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=
  golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
@@ -407,7 +561,7 @@ index 2b5021d6..058a2caa 100644
  golang.org/x/time v0.8.0 h1:9i3RxcPv3PZnitoVGMPDKZSq1xW1gK1Xy3ArNOGZfEg=
  golang.org/x/time v0.8.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
  golang.org/x/tools v0.0.0-20180525024113-a5b4c53f6e8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
-@@ -778,8 +776,8 @@ golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4f
+@@ -778,8 +775,8 @@ golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4f
  golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
  golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
  golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
@@ -418,7 +572,7 @@ index 2b5021d6..058a2caa 100644
  golang.org/x/tools/go/expect v0.1.0-deprecated h1:jY2C5HGYR5lqex3gEniOQL0r7Dq5+VGVgY1nudX5lXY=
  golang.org/x/tools/go/expect v0.1.0-deprecated/go.mod h1:eihoPOH+FgIqa3FpoTwguz/bVUSGBlGQU67vpBeOrBY=
  golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated h1:1h2MnaIAIXISqTFKdENegdpAgUXz6NrPEsbIeWaBRvM=
-@@ -796,8 +794,8 @@ gomodules.xyz/jsonpatch/v2 v2.4.0 h1:Ci3iUJyx9UeRx7CeFN8ARgGbkESwJK+KB9lLcWxY/Zw
+@@ -796,8 +793,8 @@ gomodules.xyz/jsonpatch/v2 v2.4.0 h1:Ci3iUJyx9UeRx7CeFN8ARgGbkESwJK+KB9lLcWxY/Zw
  gomodules.xyz/jsonpatch/v2 v2.4.0/go.mod h1:AH3dM2RI6uoBZxn3LVrfvJ3E0/9dG4cSrbuBJT4moAY=
  gonum.org/v1/gonum v0.0.0-20180816165407-929014505bf4/go.mod h1:Y+Yx5eoAFn32cQvJDxZx5Dpnq+c3wtXuadVZAcxbbBo=
  gonum.org/v1/gonum v0.8.2/go.mod h1:oe/vMfY3deqTw+1EZJhuvEW2iwGF1bW9wwu7XCu0+v0=
@@ -429,7 +583,7 @@ index 2b5021d6..058a2caa 100644
  gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=
  gonum.org/v1/plot v0.0.0-20190515093506-e2840ee46a6b/go.mod h1:Wt8AAjI+ypCyYX3nZBvf6cAIx93T+c/OS2HFAYskSZc=
  google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
-@@ -806,10 +804,10 @@ google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoA
+@@ -806,10 +803,10 @@ google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoA
  google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
  google.golang.org/genproto v0.0.0-20200513103714-09dca8ec2884/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
  google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
@@ -444,7 +598,7 @@ index 2b5021d6..058a2caa 100644
  google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
  google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
  google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
-@@ -818,8 +816,8 @@ google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTp
+@@ -818,8 +815,8 @@ google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTp
  google.golang.org/grpc v1.33.2/go.mod h1:JMHMWHQWaTccqQQlmk3MJZS+GWXOdAesneDmEnv2fbc=
  google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
  google.golang.org/grpc v1.48.0/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACuMGWk=
@@ -455,7 +609,7 @@ index 2b5021d6..058a2caa 100644
  google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
  google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
  google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=
-@@ -833,8 +831,8 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
+@@ -833,8 +830,8 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
  google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
  google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
  google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=

--- a/modules/021-cni-cilium/images/bin-cilium/patches/021-ebpf-api-compat.patch
+++ b/modules/021-cni-cilium/images/bin-cilium/patches/021-ebpf-api-compat.patch
@@ -1,0 +1,15 @@
+diff --git a/pkg/bpf/collection.go b/pkg/bpf/collection.go
+index d961dae..48f32e4 100644
+--- a/pkg/bpf/collection.go
++++ b/pkg/bpf/collection.go
+@@ -448,8 +448,8 @@ func applyConstants(spec *ebpf.CollectionSpec, constants map[string]uint64) erro
+ 			return fmt.Errorf("can't set non-existent Variable %s", name)
+ 		}
+ 
+-		if v.MapName() != configSection {
+-			return fmt.Errorf("can only set Cilium config variables in section %s (got %s:%s), ", configSection, v.MapName(), name)
++		if v.SectionName != configSection {
++			return fmt.Errorf("can only set Cilium config variables in section %s (got %s:%s), ", configSection, v.SectionName, name)
+ 		}
+ 
+ 		if err := setVariable(v, value); err != nil {

--- a/modules/021-cni-cilium/images/bin-cilium/patches/README.md
+++ b/modules/021-cni-cilium/images/bin-cilium/patches/README.md
@@ -8,6 +8,7 @@ shipped by upstream Cilium v1.17.17 to remediate known CVEs, e.g.:
 - `github.com/go-jose/go-jose/v4` -> `v4.1.4`
 - `github.com/envoyproxy/go-control-plane/envoy` -> `v1.37.0`
 - `go.mongodb.org/mongo-driver` -> `v1.17.7`
+- `github.com/cilium/ebpf` -> `v0.22.0` (CVE-2026-10722)
 
 Regenerate by cloning `cilium v1.17.17`, applying this patch, bumping the
 required module(s), then running `go mod tidy && go mod vendor && go mod verify`
@@ -90,4 +91,52 @@ An ICMP echo reply feature has been added to reply on LoadBalancer's service IP
 
 ## 018-fix-svacer.patch
 
-Fixed svacer DEREF_OF_NULL error in pkg/policy/api/icmp.go 
+Fixed svacer DEREF_OF_NULL error in pkg/policy/api/icmp.go
+
+## 019-ipcache-no-deadlock-on-label-injection.patch
+
+Backport for Cilium 1.17.x fixing an agent-wide deadlock in ipcache label injection:
+`doInjectLabels()` holds `ipc.mutex` while `UpdatePolicyMaps()` waits for all endpoints,
+yet endpoint regeneration acquires the same mutex (`GetDNSRules` → `LookupByIdentity`),
+so under identity churn regeneration stops node-wide, CNI requests pile up, the
+`endpoint-create` limiter returns `429 putEndpointIdTooManyRequests` and liveness stays
+green. The patch moves the delete-path `UpdatePolicyMaps()` call out of the critical
+section, as the add path above it already does, and bounds the previously unbounded wait
+with `ctx` and a 3-minute timeout.
+
+**Remove this patch when upgrading to Cilium 1.18 or newer**, where upstream fixed the
+same deadlock (`cilium#39970`, commit `47ace2de6`) by removing
+`IPCache.UpdatePolicyMaps()` altogether, so the patch is both unnecessary and will fail
+to apply.
+
+## 020-policy-nil-safe-selector-policy-detach.patch
+
+Fixes an agent crash (`SIGSEGV` in `selectorPolicy.detach`) that shows up once endpoint
+regeneration runs at full speed under heavy identity churn. `policyCache.delete()`
+dereferences `cip.getPolicy()` unconditionally, but a cache entry created by
+`lookupOrCreate()` has a nil policy until `updateSelectorPolicy()` finishes resolving it,
+and that resolution does not hold the cache lock — so an endpoint whose identity changes
+mid-regeneration can have its old identity removed while its policy is still being
+resolved. The patch adds the nil check, matching `pkg/policy/distillery.go` in 1.18.
+
+**Remove this patch when upgrading to Cilium 1.18 or newer**, where the same nil check is
+already present (it was never backported to 1.17.x, up to and including v1.17.18).
+
+## 021-ebpf-api-compat.patch
+
+Adapts Cilium's eBPF loader to the `github.com/cilium/ebpf` v0.22.0 API, which
+`000-go-mod.patch` bumps to fix CVE-2026-10722 (the fix is only available in
+ebpf >= v0.22.0). ebpf v0.21.0 removed the `(*ebpf.VariableSpec).MapName()`
+method and replaced the previously private map reference with the exported
+`VariableSpec.SectionName` field (the section name a variable was allocated
+in). Cilium v1.17.17 still pins ebpf v0.17.1 and calls `v.MapName()` in
+`applyConstants()` (`pkg/bpf/collection.go`) to assert that config variables
+live in the `.rodata.config` section, so the bump alone breaks compilation.
+
+The patch replaces the two `v.MapName()` calls with `v.SectionName`, which
+returns the same value (the underlying map/section name). No datapath or other
+behavior changes: a full `go build ./...` of Cilium v1.17.17 with ebpf v0.22.0
+has this single call site as its only incompatibility.
+
+**Remove this patch when upgrading to a Cilium version that already targets
+ebpf >= v0.21.0**, where `applyConstants()` no longer uses the removed method.

--- a/modules/021-cni-cilium/images/bin-cilium/patches/README.md
+++ b/modules/021-cni-cilium/images/bin-cilium/patches/README.md
@@ -93,35 +93,6 @@ An ICMP echo reply feature has been added to reply on LoadBalancer's service IP
 
 Fixed svacer DEREF_OF_NULL error in pkg/policy/api/icmp.go
 
-## 019-ipcache-no-deadlock-on-label-injection.patch
-
-Backport for Cilium 1.17.x fixing an agent-wide deadlock in ipcache label injection:
-`doInjectLabels()` holds `ipc.mutex` while `UpdatePolicyMaps()` waits for all endpoints,
-yet endpoint regeneration acquires the same mutex (`GetDNSRules` → `LookupByIdentity`),
-so under identity churn regeneration stops node-wide, CNI requests pile up, the
-`endpoint-create` limiter returns `429 putEndpointIdTooManyRequests` and liveness stays
-green. The patch moves the delete-path `UpdatePolicyMaps()` call out of the critical
-section, as the add path above it already does, and bounds the previously unbounded wait
-with `ctx` and a 3-minute timeout.
-
-**Remove this patch when upgrading to Cilium 1.18 or newer**, where upstream fixed the
-same deadlock (`cilium#39970`, commit `47ace2de6`) by removing
-`IPCache.UpdatePolicyMaps()` altogether, so the patch is both unnecessary and will fail
-to apply.
-
-## 020-policy-nil-safe-selector-policy-detach.patch
-
-Fixes an agent crash (`SIGSEGV` in `selectorPolicy.detach`) that shows up once endpoint
-regeneration runs at full speed under heavy identity churn. `policyCache.delete()`
-dereferences `cip.getPolicy()` unconditionally, but a cache entry created by
-`lookupOrCreate()` has a nil policy until `updateSelectorPolicy()` finishes resolving it,
-and that resolution does not hold the cache lock — so an endpoint whose identity changes
-mid-regeneration can have its old identity removed while its policy is still being
-resolved. The patch adds the nil check, matching `pkg/policy/distillery.go` in 1.18.
-
-**Remove this patch when upgrading to Cilium 1.18 or newer**, where the same nil check is
-already present (it was never backported to 1.17.x, up to and including v1.17.18).
-
 ## 021-ebpf-api-compat.patch
 
 Adapts Cilium's eBPF loader to the `github.com/cilium/ebpf` v0.22.0 API, which

--- a/modules/021-cni-cilium/images/safe-agent-updater/src/go.mod
+++ b/modules/021-cni-cilium/images/safe-agent-updater/src/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/sirupsen/logrus v1.9.3
-	golang.org/x/mod v0.37.0
+	golang.org/x/mod v0.40.0
 	k8s.io/api v0.29.1
 	k8s.io/apimachinery v0.29.1
 	k8s.io/client-go v0.29.1

--- a/modules/021-cni-cilium/images/safe-agent-updater/src/go.sum
+++ b/modules/021-cni-cilium/images/safe-agent-updater/src/go.sum
@@ -76,8 +76,8 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.37.0 h1:vF1DjpVEshcIqoEaauuHebaLk1O1forxjxBaVn884JQ=
-golang.org/x/mod v0.37.0/go.mod h1:m8S8VeM9r4dzDwjrKO0a1sZP3YjeMamRRlD+fmR2Q/0=
+golang.org/x/mod v0.40.0 h1:hUv+3cXcdRHz08UmSiOob7sadHig73uo5bkXxQ/tvUs=
+golang.org/x/mod v0.40.0/go.mod h1:0/weTWkPWGBikyTWAX3dkjVztMmBA5hM0DH6BElSupE=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -107,8 +107,8 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.47.0 h1:7Kn5x/d1svx/PzryTsqeoZN4TZwqeH5pGWjefhLi/1Q=
-golang.org/x/tools v0.47.0/go.mod h1:dFHnyTvFWY212G+h7ZY4Vsp/K3U4/7W9TyVaAul8uCA=
+golang.org/x/tools v0.49.0 h1:3NI7VXzL9+1WZD52Dx2ttoPwD5DWrFGpl9mFZDlmisI=
+golang.org/x/tools v0.49.0/go.mod h1:SJNXV9DBKT0UbdttsQjbfJlAE/q+y36++zo3uL3N0Oo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/modules/500-cilium-hubble/images/ui/patches/002--gomod-gosum.backend.patch
+++ b/modules/500-cilium-hubble/images/ui/patches/002--gomod-gosum.backend.patch
@@ -1,8 +1,8 @@
 diff --git a/backend/go.mod b/backend/go.mod
-index 1aad724..9686235 100644
+index 1aad724..bc16ebd 100644
 --- a/backend/go.mod
 +++ b/backend/go.mod
-@@ -4,17 +4,17 @@ module github.com/cilium/hubble-ui/backend
+@@ -4,17 +4,18 @@ module github.com/cilium/hubble-ui/backend
  go 1.26.2
  
  require (
@@ -14,6 +14,7 @@ index 1aad724..9686235 100644
  	github.com/pkg/errors v0.9.1
 -	golang.org/x/sys v0.43.0
 -	google.golang.org/grpc v1.80.0
++	golang.org/x/sync v0.21.0
 +	golang.org/x/sys v0.46.0
 +	google.golang.org/grpc v1.82.1
  	google.golang.org/protobuf v1.36.11
@@ -26,7 +27,16 @@ index 1aad724..9686235 100644
  )
  
  require (
-@@ -63,7 +63,7 @@ require (
+@@ -25,7 +26,7 @@ require (
+ 	github.com/beorn7/perks v1.0.1 // indirect
+ 	github.com/blang/semver/v4 v4.0.0 // indirect
+ 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+-	github.com/cilium/ebpf v0.21.0 // indirect
++	github.com/cilium/ebpf v0.22.0 // indirect
+ 	github.com/cilium/hive v0.0.0-20260108104938-97756f6ff54c // indirect
+ 	github.com/cilium/proxy v0.0.0-20260413123452-8fb1248202fd // indirect
+ 	github.com/cilium/statedb v0.5.6 // indirect
+@@ -63,7 +64,7 @@ require (
  	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
  	github.com/gogo/protobuf v1.3.2 // indirect
  	github.com/golang/protobuf v1.5.4 // indirect
@@ -35,7 +45,7 @@ index 1aad724..9686235 100644
  	github.com/google/gnostic-models v0.7.1 // indirect
  	github.com/google/go-cmp v0.7.0 // indirect
  	github.com/google/renameio/v2 v2.0.2 // indirect
-@@ -112,19 +112,19 @@ require (
+@@ -112,19 +113,18 @@ require (
  	go.yaml.in/yaml/v3 v3.0.4 // indirect
  	go4.org/netipx v0.0.0-20231129151722-fdeea329fbba // indirect
  	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
@@ -45,7 +55,6 @@ index 1aad724..9686235 100644
 -	golang.org/x/sync v0.20.0 // indirect
 -	golang.org/x/term v0.42.0 // indirect
 -	golang.org/x/text v0.36.0 // indirect
-+	golang.org/x/sync v0.21.0 // indirect
 +	golang.org/x/term v0.44.0 // indirect
 +	golang.org/x/text v0.39.0 // indirect
  	golang.org/x/time v0.15.0 // indirect
@@ -62,20 +71,24 @@ index 1aad724..9686235 100644
  	k8s.io/kube-openapi v0.0.0-20260330154417-16be699c7b31 // indirect
  	k8s.io/utils v0.0.0-20260319190234-28399d86e0b5 // indirect
 diff --git a/backend/go.sum b/backend/go.sum
-index f5f22a0..1216091 100644
+index f5f22a0..7983229 100644
 --- a/backend/go.sum
 +++ b/backend/go.sum
-@@ -19,8 +19,8 @@ github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2y
+@@ -19,10 +19,10 @@ github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2y
  github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
  github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
  github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 -github.com/cilium/cilium v1.19.2 h1:891hXerzal4vBVjjlCsyV47DQDI77+f9mzf1ulWF54E=
 -github.com/cilium/cilium v1.19.2/go.mod h1:BRn4WvJVo/V9clDdwE12uNCq4tdWSGm9hYjCL44LC5g=
+-github.com/cilium/ebpf v0.21.0 h1:4dpx1J/B/1apeTmWBH5BkVLayHTkFrMovVPnHEk+l3k=
+-github.com/cilium/ebpf v0.21.0/go.mod h1:1kHKv6Kvh5a6TePP5vvvoMa1bclRyzUXELSs272fmIQ=
 +github.com/cilium/cilium v1.19.4 h1:TxDZW+27NqLbuenPlWd8y8cnAmDNFga/FCMM8zP1qLQ=
 +github.com/cilium/cilium v1.19.4/go.mod h1:9j8LLVACyWe8bbtlUPCjPSARbmOS+tqo9GRNh5SHjJc=
- github.com/cilium/ebpf v0.21.0 h1:4dpx1J/B/1apeTmWBH5BkVLayHTkFrMovVPnHEk+l3k=
- github.com/cilium/ebpf v0.21.0/go.mod h1:1kHKv6Kvh5a6TePP5vvvoMa1bclRyzUXELSs272fmIQ=
++github.com/cilium/ebpf v0.22.0 h1:v2ktp0roffpMOj2MMf3idtCQZOsAoC4BJbAJN+ke2bY=
++github.com/cilium/ebpf v0.22.0/go.mod h1:CDzZbe2hC5JjlDC+CY3KFCzlYwN4gbxppYM+Z10bQt4=
  github.com/cilium/hive v0.0.0-20260108104938-97756f6ff54c h1:mP/Z+oVplgbg3oV1lwsAC86NPLWioN/TqlmZ6+BI2I0=
+ github.com/cilium/hive v0.0.0-20260108104938-97756f6ff54c/go.mod h1:4/8FBMcTjVdkrNNWaB7t3QqaU4kZDJLJ1leKVP9GjEI=
+ github.com/cilium/proxy v0.0.0-20260413123452-8fb1248202fd h1:Pn/JN7TLAhwBuOZh/QWeggc3lpeyC8yggukQ0YmUUbA=
 @@ -35,8 +35,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
  github.com/cloudflare/cfssl v1.6.5 h1:46zpNkm6dlNkMZH/wMW22ejih6gIaJbzL2du6vD7ZeI=
  github.com/cloudflare/cfssl v1.6.5/go.mod h1:Bk1si7sq8h2+yVEDrFJiz3d7Aw+pfjjJSZVaD+Taky4=

--- a/modules/500-cilium-hubble/images/ui/patches/README.md
+++ b/modules/500-cilium-hubble/images/ui/patches/README.md
@@ -13,7 +13,9 @@ Hubble UI:
 
 ## 002--gomod-gosum.backend.patch
 
-Updated go dependencies to fix vulnerabilities.
+Updated go dependencies to fix vulnerabilities, e.g.:
+
+- `github.com/cilium/ebpf` -> `v0.22.0` (CVE-2026-10722)
 
 ## 003--auth.backend.patch
 


### PR DESCRIPTION
## Description

Fix known CVEs across the Cilium modules:

- `modules/021-cni-cilium/images/safe-agent-updater` — bump `golang.org/x/mod` from `v0.37.0` to `v0.40.0` in `go.mod`/`go.sum`.
- `modules/500-cilium-hubble/images/ui` — update the Hubble UI backend patch (`002--gomod-gosum.backend.patch`) to bump `github.com/cilium/ebpf` to `v0.22.0`.
- `modules/021-cni-cilium/images/bin-cilium/patches` — bump `github.com/cilium/ebpf` from `v0.17.1` to `v0.22.0` in the Cilium `go.mod` patch (`000-go-mod.patch`), and add a compatibility patch (`021-ebpf-api-compat.patch`) that adapts Cilium's eBPF loader to the new ebpf API. ebpf 0.21.0 removed `(*ebpf.VariableSpec).MapName()`, which cilium 1.17.17 still calls in `applyConstants()` (`pkg/bpf/collection.go`); the patch replaces it with the exported `VariableSpec.SectionName` field, which returns the same value. Cilium itself stays at 1.17.17 — only its eBPF layer is adapted. A full `go build ./...` of cilium 1.17.17 with ebpf 0.22.0 confirmed this single call site is the only incompatibility (no datapath changes).

Only dependency versions and build-time patches change; there are no functional changes. The affected images are rebuilt, so their pods are restarted on rollout.

Since `agent-distroless`, `operator` and the Hubble `relay` all compile Cilium from the shared `bin-cilium` source artifact, the ebpf backport fixes CVE-2026-10722 in all of them at once. It also transitively fixes `common/cni-migration-controller`, which imports `cilium-dbg` from `agent-distroless` (verified by rescanning that image — no separate change needed).

This PR fixes:

- CVE-2026-56864 (`golang.org/x/mod`, safe-agent-updater)
- CVE-2026-56865 (`golang.org/x/mod`, safe-agent-updater)
- CVE-2026-10722 (`github.com/cilium/ebpf`) in agent-distroless, operator, hubble ui-backend, hubble relay, and transitively cni-migration-controller

## Why do we need it, and what problem does it solve?

The images shipped with vulnerable versions of `golang.org/x/mod` and `github.com/cilium/ebpf`. Bumping them (and adapting the cilium eBPF loader to the new ebpf API) removes CVE-2026-56864, CVE-2026-56865 and CVE-2026-10722 from the affected images.

## Why do we need it in the patch release (if we do)?

The change is a security fix with no behavior change and no migration steps, so it is safe to backport to reduce the vulnerability exposure of running clusters.

## Checklist

- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cni-cilium
type: fix
summary: Bumped golang.org/x/mod to v0.40.0 and github.com/cilium/ebpf to v0.22.0 (with an eBPF loader compat patch) to fix CVE-2026-56864, CVE-2026-56865 and CVE-2026-10722.
impact_level: low
---
section: cilium-hubble
type: fix
summary: Bumped github.com/cilium/ebpf to v0.22.0 in the Hubble UI backend and relay to fix CVE-2026-10722.
impact_level: low
```
