### PR TITLE
[cloud-provider-dvp] fixed private build in cse

### DIFF
--- a/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/werf.inc.yaml
+++ b/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/werf.inc.yaml
@@ -37,8 +37,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 final: false
 from: {{ index $.Images "builder/golang" }}
 mount:
-  - fromPath: ~/go-pkg-cache
-    to: /go/pkg
+{{ include "mount points for golang builds" . }}
 import:
   - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
     add: /src
@@ -52,4 +51,3 @@ shell:
     - CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-s -w" -o /capdvp-controller-manager cmd/main.go
     - chown 64535:64535 /capdvp-controller-manager
     - chmod 0755 /capdvp-controller-manager
-

--- a/modules/030-cloud-provider-dvp/images/cloud-controller-manager/werf.inc.yaml
+++ b/modules/030-cloud-provider-dvp/images/cloud-controller-manager/werf.inc.yaml
@@ -37,8 +37,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 final: false
 from: {{ index $.Images "builder/golang" }}
 mount:
-  - fromPath: ~/go-pkg-cache
-    to: /go/pkg
+{{ include "mount points for golang builds" . }}
 import:
   - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
     add: /src
@@ -54,4 +53,3 @@ shell:
     - chmod 0755 /dvp-cloud-controller-manager
 ---
 {{- include "vex mitigation" (list $ (printf "%s/%s" $.ModuleName $.ImageName )) }}
-

--- a/modules/030-cloud-provider-dvp/images/cloud-data-discoverer/werf.inc.yaml
+++ b/modules/030-cloud-provider-dvp/images/cloud-data-discoverer/werf.inc.yaml
@@ -57,15 +57,12 @@ import:
   to: /src
   before: install
 mount:
-- fromPath: ~/go-pkg-cache
-  to: /go/pkg
+{{ include "mount points for golang builds" . }}
 shell:
   install:
   - cd /src/cloud-data-discoverer/src
   - export GOPROXY={{ $.GOPROXY }}
   - go mod download
-  setup:
-  - cd /src/cloud-data-discoverer/src
   - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o /discoverer
   - chown 64535:64535 /discoverer
   - chmod 0755 /discoverer

--- a/modules/030-cloud-provider-dvp/images/dvp-csi-driver/werf.inc.yaml
+++ b/modules/030-cloud-provider-dvp/images/dvp-csi-driver/werf.inc.yaml
@@ -64,8 +64,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 final: false
 from: {{ index $.Images "builder/golang" }}
 mount:
-- fromPath: ~/go-pkg-cache
-  to: /go/pkg
+{{ include "mount points for golang builds" . }}
 import:
   - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
     add: /src

--- a/modules/030-cloud-provider-dvp/images/terraform-manager/werf.inc.yaml
+++ b/modules/030-cloud-provider-dvp/images/terraform-manager/werf.inc.yaml
@@ -63,8 +63,7 @@ image: terraform-provider-kubernetes
 from: {{ index $.Images "builder/golang" }}
 final: false
 mount:
-- fromPath: ~/go-pkg-cache
-  to: /go/pkg
+{{ include "mount points for golang builds" . }}
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src

--- a/modules/030-cloud-provider-dvp/images/validation-webhook/werf.inc.yaml
+++ b/modules/030-cloud-provider-dvp/images/validation-webhook/werf.inc.yaml
@@ -93,8 +93,6 @@ shell:
   - export GOPROXY={{ $.GOPROXY }}
   - cd /src/validation-webhook/src
   - go mod download
-  setup:
-  - cd /src/validation-webhook/src
   - CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o /validation-webhook .
   - chown 64535:64535 /validation-webhook
   - chmod 0755 /validation-webhook


### PR DESCRIPTION
## Description
fixed private build in cse
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
private build in cse
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-dvp
type: chore
summary: fixed private build in cse
impact: 
impact_level:  low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
