### PR TITLE
[candi] Fix pipe bug in installing containerd

### DIFF
--- a/candi/bashible/common-steps/all/031_install_containerd.sh.tpl
+++ b/candi/bashible/common-steps/all/031_install_containerd.sh.tpl
@@ -50,30 +50,58 @@ post-install() {
   fi
 }
 
+cntrd_safe_output() {
+  local out rc=0
+  out="$("$@" 2>&1)" || rc=$?
+  if [ "$rc" -ne 0 ] || [ -z "$out" ]; then
+    bb-log-warning "'$*' failed (exit $rc) or produced empty output, skipping check"
+    return 1
+  fi
+  printf '%s' "$out"
+}
+
 cntrd_version_change_check() {
-  local cur target
-  cur=$(containerd --version | awk '{print $3}' | grep -oE '[12]' | head -n1)
+  local cur target version_output
   target={{ if eq .cri "ContainerdV2" }}2{{ else }}1{{ end }}
+
+  version_output="$(cntrd_safe_output containerd --version)" || return 0
+
+  local -a fields
+  read -r -a fields <<< "$version_output"
+  cur="${fields[2]:-}"
+  cur="${cur#v}"
+  cur="${cur%%.*}"
+  [[ "$cur" =~ ^[12]$ ]] || cur=""
+
   if [[ -n $cur && $cur != $target ]]; then
     bb-flag-set cntrd-major-version-changed
     bb-deckhouse-get-disruptive-update-approval
   fi
 }
 
-command -v containerd &>/dev/null && cntrd_version_change_check
+cntrd_version_change_check
 
 {{- $integrityEditions := list "CSE" }}
 {{- if and (eq .cri "ContainerdV2") (has .deckhouse.edition $integrityEditions) }}
 cntrd_integrity_migration_check() {
-  if containerd --help 2>/dev/null | grep -q -- '--integrity-check-interval'; then
+  local migrated_marker="/var/lib/bashible/cntrd-integrity-migrated"
+  [ -f "$migrated_marker" ] && return 0
+
+  local help_output
+  help_output="$(cntrd_safe_output containerd --help)" || return 0
+
+  if [[ "$help_output" == *'--integrity-check-interval'* ]]; then
+    mkdir -p "$(dirname "$migrated_marker")"
+    touch "$migrated_marker"
     return 0
   fi
+
   bb-log-info "Switching to containerd with integrity checks, containerd state wipe is required"
   bb-flag-set cntrd-integrity-migration-required
   bb-deckhouse-get-disruptive-update-approval
 }
 
-command -v containerd &>/dev/null && cntrd_integrity_migration_check
+cntrd_integrity_migration_check
 
 if bb-flag? cntrd-integrity-migration-required; then
   bb-log-info "Pre-installing local image packages before containerd state wipe"

--- a/candi/bashible/common-steps/all/031_install_containerd.sh.tpl
+++ b/candi/bashible/common-steps/all/031_install_containerd.sh.tpl
@@ -52,9 +52,9 @@ post-install() {
 
 cntrd_safe_output() {
   local out rc=0
-  out="$("$@" 2>&1)" || rc=$?
+  out="$("$@")" || rc=$?
   if [ "$rc" -ne 0 ] || [ -z "$out" ]; then
-    bb-log-warning "'$*' failed (exit $rc) or produced empty output, skipping check"
+    bb-log-warning "'$*' produced no usable output (exit code $rc)"
     return 1
   fi
   printf '%s' "$out"
@@ -64,35 +64,44 @@ cntrd_version_change_check() {
   local cur target version_output
   target={{ if eq .cri "ContainerdV2" }}2{{ else }}1{{ end }}
 
-  version_output="$(cntrd_safe_output containerd --version)" || return 0
+  if ! version_output="$(cntrd_safe_output containerd --version)"; then
+    bb-log-error "Cannot determine the installed containerd version, refusing to continue"
+    exit 1
+  fi
 
   local -a fields
   read -r -a fields <<< "$version_output"
   cur="${fields[2]:-}"
-  cur="${cur#v}"
-  cur="${cur%%.*}"
-  [[ "$cur" =~ ^[12]$ ]] || cur=""
+  cur="${cur#v}"     # v1.7.34 -> 1.7.34
+  cur="${cur%%.*}"   # 1.7.34  -> 1
 
-  if [[ -n $cur && $cur != $target ]]; then
+  if [[ ! "$cur" =~ ^[0-9]+$ ]]; then
+    bb-log-error "Cannot parse the containerd version from '${version_output}', refusing to continue"
+    exit 1
+  fi
+
+  if [ "$cur" != "$target" ]; then
     bb-flag-set cntrd-major-version-changed
     bb-deckhouse-get-disruptive-update-approval
   fi
 }
 
-cntrd_version_change_check
+command -v containerd &>/dev/null && cntrd_version_change_check
 
 {{- $integrityEditions := list "CSE" }}
 {{- if and (eq .cri "ContainerdV2") (has .deckhouse.edition $integrityEditions) }}
 cntrd_integrity_migration_check() {
-  local migrated_marker="/var/lib/bashible/cntrd-integrity-migrated"
+  local migrated_marker="/var/lib/containerd/.cntrd-integrity-migrated"
   [ -f "$migrated_marker" ] && return 0
 
   local help_output
-  help_output="$(cntrd_safe_output containerd --help)" || return 0
+  if ! help_output="$(cntrd_safe_output containerd --help)"; then
+    bb-log-error "Cannot determine containerd integrity-check support, refusing to continue"
+    exit 1
+  fi
 
   if [[ "$help_output" == *'--integrity-check-interval'* ]]; then
-    mkdir -p "$(dirname "$migrated_marker")"
-    touch "$migrated_marker"
+    [ -d /var/lib/containerd ] && touch "$migrated_marker"
     return 0
   fi
 
@@ -101,7 +110,7 @@ cntrd_integrity_migration_check() {
   bb-deckhouse-get-disruptive-update-approval
 }
 
-cntrd_integrity_migration_check
+command -v containerd &>/dev/null && cntrd_integrity_migration_check
 
 if bb-flag? cntrd-integrity-migration-required; then
   bb-log-info "Pre-installing local image packages before containerd state wipe"


### PR DESCRIPTION
## Description

`031_install_containerd.sh.tpl`: dropped `cmd | grep -q` pipes for pipe-free capture-then-match. Added marker `/var/lib/containerd/.cntrd-integrity-migrated` (check runs once). Failed/empty containerd output now warns and skips, doesn't imply migration.

## Why do we need it, and what problem does it solve?

Under `pipefail`, `containerd --help | grep -q ...` can flip "supported" to "not supported" via a SIGPIPE race (grep exits early, ~5-10% reproduced). This check reruns every ~1 min forever, so any misfire — even on an already-migrated node — triggers `rm -rf /var/lib/containerd/*` + reboot. Fixes spontaneous wipes/reboots on healthy prod nodes.

## Why do we need it in the patch release?

It is necessary to fix this bug.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: candi
type: fix
summary: Fix a flaky containerd-integrity check that could trigger spurious full containerd wipes and reboots.
impact_level: default
```
