### PR TITLE
[cni-cilium] Fix airgapped build of cilium-envoy 

### DIFF
--- a/modules/021-cni-cilium/images/bin-cilium-envoy/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/bin-cilium-envoy/werf.inc.yaml
@@ -169,9 +169,14 @@ shell:
   - sudo -u cilium sed -i '33i )' WORKSPACE
   - sudo -u cilium sed -i '\#"/usr/include"#a \        "/usr/lib/llvm-18.1/lib64/clang/18/include",' bazel/toolchains/BUILD
   - sudo -u cilium sed -i '\#-Wno-deprecated-builtins#a \        "--gcc-install-dir=/usr/bin/../lib64/gcc/x86_64-alt-linux/13",' bazel/toolchains/BUILD
-  # For building envoy in isolate env need to set Rust crate_universe and disbale CARGO_BAZEL_REPIN
-  - sudo -u cilium bash -c 'printf "\ncommon --repo_env=CARGO_BAZEL_REPIN=1\n" >> .bazelrc'
+  # For building envoy in isolate env need to set Rust crate_universe and disable CARGO_BAZEL_REPIN
+  - sudo -u cilium bash -c 'printf "\ncommon --repo_env=CARGO_BAZEL_REPIN=0\n" >> .bazelrc'
   - sudo -u cilium sed -i 's/^\tCARGO_BAZEL_REPIN=true /\t/' Makefile
+  # envoy_dependency_imports_extra() unconditionally materializes the dynamic_modules_rust_sdk_crate_index
+  # crate_universe repo (Rust SDK for Envoy dynamic modules, unused by cilium-envoy), which requires network
+  # access unavailable under --nofetch and isn't part of the prepared bazel-deps snapshot.
+  # See https://github.com/envoyproxy/envoy/issues/38314
+  - sudo -u cilium sed -i '/envoy_dependency_imports_extra()/d;/dependency_imports_extra\.bzl", "envoy_dependency_imports_extra"/d' WORKSPACE
   #
   - export BAZEL_OUTPUT_BASE=$(sudo -u cilium PATH=${PATH} bazel info output_base)
   - sudo -u cilium PATH=${PATH} mkdir -p ${BAZEL_OUTPUT_BASE}/external


### PR DESCRIPTION
## Description

Building `cni-cilium/cilium-envoy-artifact` in an isolated (airgapped/hermetic) environment fails
during the Bazel build with `no such package '@@dynamic_modules_rust_sdk_crate_index//'` /
`fetching repositories is disabled`. Cause: `.bazelrc` forced `CARGO_BAZEL_REPIN=1` (fixed to `0`
to use the committed lockfile), and `cilium/proxy`'s `WORKSPACE` unconditionally calls
`envoy_dependency_imports_extra()`, which materializes a Rust `crate_universe` repo for Envoy's
Dynamic Modules Rust SDK — not present in the prepared `bazel-deps` cache and needing network,
which `--nofetch` disallows (known upstream issue, envoyproxy/envoy#38314).

That Rust SDK isn't actually needed: the `dynamic_modules` HTTP filter cilium enables only depends
on Envoy's C++ ABI loader, not the Rust crate index. So the fix also strips the
`envoy_dependency_imports_extra()` load/call from `WORKSPACE` during the build — no change to the
resulting binary or enabled extensions.

## Why do we need it, and what problem does it solve?

Without this fix, `cni-cilium/cilium-envoy-artifact` cannot be built at all in an airgapped
environment — it fails deterministically before any compilation starts.

## Why do we need it in the patch release (if we do)?

Required to be able to build in a closed (airgapped) environment.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cni-cilium
type: fix
summary: Fix cilium-envoy image build failing in airgapped/isolated environments on a missing Rust crate_universe dependency.
impact: Disable Rust crate repinning and skip Envoy's unused dynamic-modules Rust SDK repo to fix cilium-envoy builds in airgapped environments.
impact_level: low
```

