### PR TITLE
[ci] check for an already open pull request from `chore/k8s-autoupdate` before doing anything with PR  

### DIFF
--- a/.github/workflow_templates/k8s-autoupdate.yml
+++ b/.github/workflow_templates/k8s-autoupdate.yml
@@ -41,6 +41,36 @@ jobs:
 {!{- $secrets := slice -}!}
 {!{- $secrets = append ( slice "projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/team-ssdlc/loop" "webhook_url" "LOOP_SERVICE_NOTIFICATIONS" ) $secrets -}!}
 {!{ tmpl.Exec "import_secrets" $secrets | strings.Indent 4 }!}
+    - name: Find an open autoupdate pull request
+      id: open_pr
+      uses: {!{ index (ds "actions") "actions/github-script" }!}
+      with:
+        github-token: ${{ secrets.BOATSWAIN_GITHUB_TOKEN }}
+        script: |
+          const branch = 'chore/k8s-autoupdate';
+
+          const pulls = await github.rest.pulls.list({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            head: `${context.repo.owner}:${branch}`,
+            state: 'open',
+          });
+
+          if (pulls.data.length === 0) {
+            core.setOutput('number', '');
+            core.setOutput('commits', '0');
+            return;
+          }
+
+          // The list endpoint does not report the number of commits, the get one does.
+          const pull = await github.rest.pulls.get({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: pulls.data[0].number,
+          });
+
+          core.setOutput('number', String(pull.data.number));
+          core.setOutput('commits', String(pull.data.commits));
     - uses: {!{ index (ds "actions") "actions/setup-go" }!}
       with:
         go-version: '1.26.7'
@@ -90,8 +120,58 @@ jobs:
         make generate
         echo "Updated versions: $(cat /tmp/updated-versions)"
         echo "::set-output name=k8sVersions::$(cat /tmp/updated-versions)" && rm -f /tmp/updated-versions
+    # peter-evans/create-pull-request rebuilds the pull request branch on every run
+    # (base branch plus a single generated commit) and force-pushes it, so a scheduled
+    # run can silently drop commits somebody added to an open pull request by hand.
+    # Touch the branch only when there is something new to offer and nothing manual
+    # would be lost.
+    - name: Check whether the pull request branch can be updated
+      id: guard
+      env:
+        BRANCH: chore/k8s-autoupdate
+        PR_NUMBER: ${{ steps.open_pr.outputs.number }}
+        PR_COMMITS: ${{ steps.open_pr.outputs.commits }}
+        EVENT_NAME: ${{ github.event_name }}
+      run: |
+        set -euo pipefail
+
+        # No pull request to protect, or a human asked for the update explicitly.
+        if [[ -z "${PR_NUMBER}" || "${EVENT_NAME}" != "schedule" ]]; then
+          echo "update=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        git fetch --no-tags --depth=1 origin "${BRANCH}"
+
+        mapfile -t changed < <(git diff --name-only)
+        untracked="$(git ls-files --others --exclude-standard)"
+
+        if [[ ${#changed[@]} -eq 0 && -z "${untracked}" ]]; then
+          echo "::notice::Nothing was regenerated, leaving pull request #${PR_NUMBER} alone."
+          echo "update=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        # The open pull request already offers exactly these versions.
+        if [[ -z "${untracked}" ]] && git diff --quiet FETCH_HEAD -- "${changed[@]}"; then
+          echo "::notice::Pull request #${PR_NUMBER} already carries these versions, nothing to update."
+          echo "update=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        # A branch built by the action holds exactly one commit. Anything on top of it
+        # was added by hand and would be lost on the next force push.
+        if [[ "${PR_COMMITS}" -gt 1 ]]; then
+          echo "::warning::New Kubernetes patch versions are available, but pull request #${PR_NUMBER} has ${PR_COMMITS} commits and would lose manual changes. The branch was left untouched."
+          echo "stalled=true" >> "$GITHUB_OUTPUT"
+          echo "update=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        echo "update=true" >> "$GITHUB_OUTPUT"
     - name: Create Pull Request
       id: create-pull-request
+      if: ${{ steps.guard.outputs.update == 'true' }}
       uses: {!{ index (ds "actions") "peter-evans/create-pull-request" }!}
       with:
         commit-message: "Automated Change: Update k8s patch version"
@@ -111,6 +191,13 @@ jobs:
       run: |
         PULL_REQUEST_URL="${{ steps.create-pull-request.outputs.pull-request-url }}"
         bash ./.github/scripts/send-report.sh --webhook "k8s_update" "✅Kubernetes has been automatically updated✅\n[URL]($PULL_REQUEST_URL)"
+    - name: Send stalled pull request report
+      if: ${{ steps.guard.outputs.stalled == 'true' && github.repository == 'deckhouse/deckhouse' }}
+      env:
+        LOOP_SERVICE_NOTIFICATIONS: ${{ steps.secrets.outputs.LOOP_SERVICE_NOTIFICATIONS }}
+      run: |
+        PULL_REQUEST_URL="${{ github.server_url }}/${{ github.repository }}/pull/${{ steps.open_pr.outputs.number }}"
+        bash ./.github/scripts/send-report.sh --webhook "k8s_update" "⚠️New Kubernetes patch versions are available, but the open pull request has manual commits and was not updated⚠️\n[URL]($PULL_REQUEST_URL)"
     - name: Send failure report
       if: ${{ failure() && github.repository == 'deckhouse/deckhouse' }}
       env:

--- a/.github/workflows/k8s-autoupdate.yml
+++ b/.github/workflows/k8s-autoupdate.yml
@@ -118,6 +118,36 @@ jobs:
           projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/team-ssdlc/loop webhook_url | LOOP_SERVICE_NOTIFICATIONS ;
 
     # </template: import_secrets>
+    - name: Find an open autoupdate pull request
+      id: open_pr
+      uses: actions/github-script@v6.4.1
+      with:
+        github-token: ${{ secrets.BOATSWAIN_GITHUB_TOKEN }}
+        script: |
+          const branch = 'chore/k8s-autoupdate';
+
+          const pulls = await github.rest.pulls.list({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            head: `${context.repo.owner}:${branch}`,
+            state: 'open',
+          });
+
+          if (pulls.data.length === 0) {
+            core.setOutput('number', '');
+            core.setOutput('commits', '0');
+            return;
+          }
+
+          // The list endpoint does not report the number of commits, the get one does.
+          const pull = await github.rest.pulls.get({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: pulls.data[0].number,
+          });
+
+          core.setOutput('number', String(pull.data.number));
+          core.setOutput('commits', String(pull.data.commits));
     - uses: actions/setup-go@v5.4.0
       with:
         go-version: '1.26.7'
@@ -167,8 +197,58 @@ jobs:
         make generate
         echo "Updated versions: $(cat /tmp/updated-versions)"
         echo "::set-output name=k8sVersions::$(cat /tmp/updated-versions)" && rm -f /tmp/updated-versions
+    # peter-evans/create-pull-request rebuilds the pull request branch on every run
+    # (base branch plus a single generated commit) and force-pushes it, so a scheduled
+    # run can silently drop commits somebody added to an open pull request by hand.
+    # Touch the branch only when there is something new to offer and nothing manual
+    # would be lost.
+    - name: Check whether the pull request branch can be updated
+      id: guard
+      env:
+        BRANCH: chore/k8s-autoupdate
+        PR_NUMBER: ${{ steps.open_pr.outputs.number }}
+        PR_COMMITS: ${{ steps.open_pr.outputs.commits }}
+        EVENT_NAME: ${{ github.event_name }}
+      run: |
+        set -euo pipefail
+
+        # No pull request to protect, or a human asked for the update explicitly.
+        if [[ -z "${PR_NUMBER}" || "${EVENT_NAME}" != "schedule" ]]; then
+          echo "update=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        git fetch --no-tags --depth=1 origin "${BRANCH}"
+
+        mapfile -t changed < <(git diff --name-only)
+        untracked="$(git ls-files --others --exclude-standard)"
+
+        if [[ ${#changed[@]} -eq 0 && -z "${untracked}" ]]; then
+          echo "::notice::Nothing was regenerated, leaving pull request #${PR_NUMBER} alone."
+          echo "update=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        # The open pull request already offers exactly these versions.
+        if [[ -z "${untracked}" ]] && git diff --quiet FETCH_HEAD -- "${changed[@]}"; then
+          echo "::notice::Pull request #${PR_NUMBER} already carries these versions, nothing to update."
+          echo "update=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        # A branch built by the action holds exactly one commit. Anything on top of it
+        # was added by hand and would be lost on the next force push.
+        if [[ "${PR_COMMITS}" -gt 1 ]]; then
+          echo "::warning::New Kubernetes patch versions are available, but pull request #${PR_NUMBER} has ${PR_COMMITS} commits and would lose manual changes. The branch was left untouched."
+          echo "stalled=true" >> "$GITHUB_OUTPUT"
+          echo "update=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        echo "update=true" >> "$GITHUB_OUTPUT"
     - name: Create Pull Request
       id: create-pull-request
+      if: ${{ steps.guard.outputs.update == 'true' }}
       uses: peter-evans/create-pull-request@v7.0.8
       with:
         commit-message: "Automated Change: Update k8s patch version"
@@ -188,6 +268,13 @@ jobs:
       run: |
         PULL_REQUEST_URL="${{ steps.create-pull-request.outputs.pull-request-url }}"
         bash ./.github/scripts/send-report.sh --webhook "k8s_update" "✅Kubernetes has been automatically updated✅\n[URL]($PULL_REQUEST_URL)"
+    - name: Send stalled pull request report
+      if: ${{ steps.guard.outputs.stalled == 'true' && github.repository == 'deckhouse/deckhouse' }}
+      env:
+        LOOP_SERVICE_NOTIFICATIONS: ${{ steps.secrets.outputs.LOOP_SERVICE_NOTIFICATIONS }}
+      run: |
+        PULL_REQUEST_URL="${{ github.server_url }}/${{ github.repository }}/pull/${{ steps.open_pr.outputs.number }}"
+        bash ./.github/scripts/send-report.sh --webhook "k8s_update" "⚠️New Kubernetes patch versions are available, but the open pull request has manual commits and was not updated⚠️\n[URL]($PULL_REQUEST_URL)"
     - name: Send failure report
       if: ${{ failure() && github.repository == 'deckhouse/deckhouse' }}
       env:


### PR DESCRIPTION
## Description

The K8S autoupdate workflow now looks up the open pull request from
`chore/k8s-autoupdate` before handing the branch over to
`peter-evans/create-pull-request`, and on scheduled runs it leaves the branch
alone in two cases:

* the branch already carries exactly the versions that were just generated —
  there is nothing to offer, so there is no reason to rewrite it;
* new patch versions are available, but the branch holds more than the single
  commit the action itself makes, which means someone added changes by hand
  that a force push would destroy. This case is reported to Loop so a stalled
  pull request does not go unnoticed.

In every other case — no open pull request, or an open one with nothing but the
bot's own commit — the behaviour is unchanged, so new patch versions keep
landing in the open pull request as before. Manual `workflow_dispatch` runs are
deliberately not gated and stay available to force the branch to be rebuilt.

Changes are made in `.github/workflow_templates/k8s-autoupdate.yml`;
`.github/workflows/k8s-autoupdate.yml` is regenerated with
`.github/render-workflows.sh`.

## Why do we need it, and what problem does it solve?

`peter-evans/create-pull-request` does not append to an existing branch. On every
run it checks out the base branch, applies the generated changes as a single
commit and resets the pull request branch to it with `git push --force-with-lease`.
Since the autoupdate pull request stays open for days, a scheduled run rebuilds
the branch even when it produces the very same bump, and silently discards any
commit a human added on top.

That is what happened in https://github.com/deckhouse/deckhouse/pull/22553. The
generated versions were identical to the ones already in the pull request, but
the trees differed because of a manual `fix go imports` commit, so the branch was
reset and the commit had to be restored by hand:

```
Resetting 'chore/k8s-autoupdate'
git push --force-with-lease origin chore/k8s-autoupdate:refs/heads/chore/k8s-autoupdate
 + 08ed992709...478ff7fc96 chore/k8s-autoupdate -> chore/k8s-autoupdate (forced update)
```

Rescheduling the cron does not help. GitHub delays scheduled events under load —
that run started 10 hours late, at 13:13 UTC instead of 03:00 — and the collision
comes from the pull request outliving a day, not from the time of day.

No patch version can be missed because of this. `candi/tools/update_kubernetes_patchversions.sh`
reads the current latest patch from the upstream changelog on every run and is
idempotent, so nothing queues up: once the open pull request is merged, the next
run picks up the newest versions straight away.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: ci
type: fix
summary: The scheduled k8s autoupdate run no longer force-pushes over manual commits in its open pull request.
```