### PR TITLE
[common]  fix container memory resize validation in kubernetes

### DIFF
--- a/modules/000-common/images/kubernetes/patches/1.34/014-fix-container-memory-usage-in-resize-validation.patch
+++ b/modules/000-common/images/kubernetes/patches/1.34/014-fix-container-memory-usage-in-resize-validation.patch
@@ -1,0 +1,13 @@
+diff --git a/pkg/kubelet/kuberuntime/kuberuntime_manager.go b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+index 7464cf6ddaa..1774968693e 100644
+--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
++++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+@@ -939,7 +939,7 @@ func (m *kubeGenericRuntimeManager) validateMemoryResizeAction(
+ 				errs = append(errs, fmt.Errorf("missing container %q memory usage", cStats.Name))
+ 			} else if *cStats.Memory.UsageBytes >= uint64(desiredLimit) {
+ 				errs = append(errs, fmt.Errorf("attempting to set container %q memory limit (%d) below current usage (%d)",
+-					cStats.Name, desiredLimit, *podUsageStats.Memory.UsageBytes))
++					cStats.Name, desiredLimit, *cStats.Memory.UsageBytes))
+ 			}
+ 		}
+ 	}

--- a/modules/000-common/images/kubernetes/patches/1.35/014-fix-container-memory-usage-in-resize-validation.patch
+++ b/modules/000-common/images/kubernetes/patches/1.35/014-fix-container-memory-usage-in-resize-validation.patch
@@ -1,0 +1,13 @@
+diff --git a/pkg/kubelet/kuberuntime/kuberuntime_manager.go b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+index c30377718e6..319815399fc 100644
+--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
++++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+@@ -1062,7 +1062,7 @@ func (m *kubeGenericRuntimeManager) validateMemoryResizeAction(
+ 				errs = append(errs, fmt.Errorf("missing container %q memory usage", cStats.Name))
+ 			} else if *cStats.Memory.UsageBytes >= uint64(desiredLimit) {
+ 				errs = append(errs, fmt.Errorf("attempting to set container %q memory limit (%d) below current usage (%d)",
+-					cStats.Name, desiredLimit, *podUsageStats.Memory.UsageBytes))
++					cStats.Name, desiredLimit, *cStats.Memory.UsageBytes))
+ 			}
+ 		}
+ 	}

--- a/modules/000-common/images/kubernetes/patches/1.36/013-fix-container-memory-usage-in-resize-validation.patch
+++ b/modules/000-common/images/kubernetes/patches/1.36/013-fix-container-memory-usage-in-resize-validation.patch
@@ -1,0 +1,13 @@
+diff --git a/pkg/kubelet/kuberuntime/kuberuntime_manager.go b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+index 619f3ec7a62..e7094ebe6d3 100644
+--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
++++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+@@ -1107,7 +1107,7 @@ func (m *kubeGenericRuntimeManager) validateMemoryResizeAction(
+ 				errs = append(errs, fmt.Errorf("missing container %q memory usage", cStats.Name))
+ 			} else if *cStats.Memory.UsageBytes >= uint64(desiredLimit) {
+ 				errs = append(errs, fmt.Errorf("attempting to set container %q memory limit (%d) below current usage (%d)",
+-					cStats.Name, desiredLimit, *podUsageStats.Memory.UsageBytes))
++					cStats.Name, desiredLimit, *cStats.Memory.UsageBytes))
+ 			}
+ 		}
+ 	}

--- a/modules/000-common/images/kubernetes/patches/README.md
+++ b/modules/000-common/images/kubernetes/patches/README.md
@@ -163,3 +163,19 @@ See issues:
 ### 014-cel-go-two-var-comprehensions.patch (1.32 only)
 
 Adapts `staging/src/k8s.io/apiserver/pkg/cel/environment/base.go` to `github.com/google/cel-go` v0.29.0, which is required to fix GHSA-gcjh-h69q-9w9g. In v0.29.0 `ext.TwoVarComprehensions` became variadic (`func(...TwoVarComprehensionsOption) cel.EnvOption`), so the `UnversionedLib(ext.TwoVarComprehensions)` tripwire no longer compiles. The call is replaced with a direct `ext.TwoVarComprehensions()` invocation, mirroring the upstream change from commit 8a3d0d68a20 ("Update the env option."), part of the k8s PR "Bump cel-go to v0.23.2" ([kubernetes/kubernetes#129844](https://github.com/kubernetes/kubernetes/pull/129844)), which introduced the variadic API and switched `base.go` to the direct call. Only 1.32 needs this patch; k8s 1.33+ already ship the adapted code.
+
+### fix-container-memory-usage-in-resize-validation.patch (1.34+)
+
+Fixes a kubelet panic in `validateMemoryResizeAction`
+(`pkg/kubelet/kuberuntime/kuberuntime_manager.go`): the per-container check
+dereferences `podUsageStats.Memory.UsageBytes` instead of
+`cStats.Memory.UsageBytes`. That pointer is nil-checked only in the
+`podLimitDecreasing` branch, so an in-place resize decreasing **only a
+container** memory limit panics kubelet when the runtime reports no pod-level
+memory stats.
+
+Only the source change is carried, the upstream test case is dropped.
+`validateMemoryResizeAction` does not exist in 1.32/1.33, so the patch is
+carried on 1.34 (`014`), 1.35 (`014`) and 1.36 (`013`) only.
+
+> Upstream PR https://github.com/kubernetes/kubernetes/pull/141100


### PR DESCRIPTION
## Description

Backport of https://github.com/kubernetes/kubernetes/pull/141100 as a kubelet patch for k8s 1.34 / 1.35 / 1.36 (source change only, tests dropped).

## Why do we need it, and what problem does it solve?

In `validateMemoryResizeAction` the per-container check dereferences `podUsageStats.Memory.UsageBytes` instead of `cStats.Memory.UsageBytes`. That pointer is nil-checked only in the `podLimitDecreasing` branch, so an in-place resize decreasing **only a container** memory limit panics kubelet when the runtime reports no pod-level memory stats. 1.32/1.33 don't have this function and are unaffected.

## Why do we need it in the patch release (if we do)?

It is necessary to fix this bug.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: common
type: fix
summary: Fixed a kubelet panic when decreasing a container memory limit in place while pod-level memory usage stats are unavailable.
impact_level: default
```
