### PR TITLE
[dhctl] refactor and extend kubeconfig support across commander

### DIFF
--- a/dhctl/pkg/operations/commander/attach/attacher.go
+++ b/dhctl/pkg/operations/commander/attach/attacher.go
@@ -279,9 +279,8 @@ func (i *Attacher) scan(
 		}
 		res.ProviderSpecificClusterConfiguration = string(providerConfiguration)
 
-		// No SSH provider means the request drove this attach through a kubeconfig and supplied
-		// no master hosts. There is no key to read back, so leave res.SSHPrivateKey empty - the
-		// same value this already produces for a client that carries no private keys.
+		// SSHProvider is nil when helper.SSHProviderOrNil tolerated a kubeconfig-driven request
+		// that supplied no master hosts.
 		if govalue.NotNil(i.Params.SSHProvider) {
 			sshCl, err := i.Params.SSHProvider.Client(ctx)
 			if err != nil {
@@ -294,6 +293,7 @@ func (i *Attacher) scan(
 				if err != nil {
 					return fmt.Errorf("unable to read ssh private key: %w", err)
 				}
+
 				res.SSHPrivateKey = string(sshPrivateKey)
 			}
 		}

--- a/dhctl/pkg/operations/destroy/destroy_phases_test.go
+++ b/dhctl/pkg/operations/destroy/destroy_phases_test.go
@@ -38,6 +38,29 @@ func (staticMetaConfigPopulator) PopulateMetaConfig(context.Context, *options.Gl
 	return &config.MetaConfig{ClusterType: config.StaticClusterType}, nil
 }
 
+type managedMetaConfigPopulator struct{}
+
+func (managedMetaConfigPopulator) PopulateMetaConfig(context.Context, *options.GlobalOptions) (*config.MetaConfig, error) {
+	return &config.MetaConfig{}, nil
+}
+
+// TestDestroy_ManagedClusterIsRefused pins the guard that stands between PopulateMetaConfig and the
+// cluster-type dispatch. The guard returns before ClusterDestroyer touches d8Destroyer or
+// infraProvider, so both may stay nil here.
+func TestDestroy_ManagedClusterIsRefused(t *testing.T) {
+	stateCache := cache.NewTestCache()
+	pec := phases.NewDefaultPhasedExecutionContext(phases.OperationDestroy, nil, nil)
+
+	destroyer := &ClusterDestroyer{
+		stateCache:       stateCache,
+		configPreparator: managedMetaConfigPopulator{},
+		pipeline:         phases.NewDefaultPipelineWithStateCache(pec, stateCache, phases.WithPipelineName("managed destroy")),
+	}
+
+	err := destroyer.DestroyCluster(t.Context(), true)
+	require.ErrorContains(t, err, "does not support managed Kubernetes clusters")
+}
+
 // TestDestroy_CommanderModeAnnouncesStaticPhases pins the order inside ClusterDestroyer.destroy:
 // the cluster type must reach the tracker before CheckCommanderUUID announces its phase, or the
 // phase list built with an empty cluster type — and shipped in every gRPC frame — loses every

--- a/dhctl/pkg/operations/destroy/kubecl.go
+++ b/dhctl/pkg/operations/destroy/kubecl.go
@@ -51,9 +51,8 @@ func (p *kubeClientProvider) KubeClientCtx(ctx context.Context) (*client.Kuberne
 }
 
 func (p *kubeClientProvider) Cleanup(ctx context.Context, stopSSH bool) {
-	// Either provider can legitimately be absent - a kubeconfig-driven destroy has no SSH
-	// connection to make - and Cleanup runs right between resource deletion and the
-	// infrastructure destroy, so a nil dereference here is the worst possible panic.
+	// Either provider can legitimately be absent: a kubeconfig-driven destroy builds no SSH
+	// provider, and a request that built no providers at all reaches this with neither.
 	if govalue.NotNil(p.kubeProvider) {
 		err := p.kubeProvider.Cleanup(ctx)
 		if err != nil {

--- a/dhctl/pkg/operations/destroy/kubecl_test.go
+++ b/dhctl/pkg/operations/destroy/kubecl_test.go
@@ -49,4 +49,9 @@ func TestCleanupsDoesNotPanic(t *testing.T) {
 	require.NotPanics(t, cleanupTest)
 	// double call not panic
 	require.NotPanics(t, cleanupTest)
+
+	// A managed cluster reaches destroy without an SSH provider, and a request that never built
+	// providers at all reaches it without either.
+	require.NotPanics(t, func() { newKubeClientProvider(kubeProvider, nil).Cleanup(t.Context(), true) })
+	require.NotPanics(t, func() { newKubeClientProvider(nil, nil).Cleanup(t.Context(), true) })
 }

--- a/dhctl/pkg/server/api/dhctl/bootstrap.proto
+++ b/dhctl/pkg/server/api/dhctl/bootstrap.proto
@@ -48,6 +48,8 @@ message BootstrapStart {
   string state = 7;
   string post_bootstrap_script = 8;
   BootstrapStartOptions options = 9;
+  // kubeconfig points the kube provider straight at the API server. connection_config is still
+  // required: this operation reaches the nodes over ssh.
   string kubeconfig = 10;
 }
 

--- a/dhctl/pkg/server/api/dhctl/check.proto
+++ b/dhctl/pkg/server/api/dhctl/check.proto
@@ -42,8 +42,9 @@ message CheckStart {
   string provider_specific_cluster_config = 3;
   string state = 4;
   CheckStartOptions options = 5;
-  // kubeconfig points the kube provider straight at the API server. connection_config is
-  // still required and must carry an SSHConfig document; its SSHHost documents may be omitted.
+  // kubeconfig points the kube provider straight at the API server. A request that sets it may
+  // leave connection_config empty: the cluster is then driven over the API server only and no
+  // SSH provider is created.
   string kubeconfig = 6;
 }
 

--- a/dhctl/pkg/server/api/dhctl/commander_attach.proto
+++ b/dhctl/pkg/server/api/dhctl/commander_attach.proto
@@ -45,8 +45,9 @@ message CommanderAttachStart {
   string resources_template = 3;
   google.protobuf.Struct resources_values = 4;
   CommanderAttachStartOptions options = 5;
-  // kubeconfig points the kube provider straight at the API server. connection_config is
-  // still required and must carry an SSHConfig document; its SSHHost documents may be omitted.
+  // kubeconfig points the kube provider straight at the API server. A request that sets it may
+  // leave connection_config empty: the cluster is then driven over the API server only and no
+  // SSH provider is created.
   string kubeconfig = 6;
 }
 

--- a/dhctl/pkg/server/api/dhctl/commander_detach.proto
+++ b/dhctl/pkg/server/api/dhctl/commander_detach.proto
@@ -47,8 +47,9 @@ message CommanderDetachStart {
   google.protobuf.Struct create_resources_values = 7;
   google.protobuf.Struct delete_resources_values = 8;
   CommanderDetachStartOptions options = 9;
-  // kubeconfig points the kube provider straight at the API server. connection_config is
-  // still required and must carry an SSHConfig document; its SSHHost documents may be omitted.
+  // kubeconfig points the kube provider straight at the API server. A request that sets it may
+  // leave connection_config empty: the cluster is then driven over the API server only and no
+  // SSH provider is created.
   string kubeconfig = 10;
 }
 

--- a/dhctl/pkg/server/api/dhctl/converge.proto
+++ b/dhctl/pkg/server/api/dhctl/converge.proto
@@ -45,8 +45,8 @@ message ConvergeStart {
   string state = 4;
   string approve_destruction_change_id = 5;
   ConvergeStartOptions options = 6;
-  // kubeconfig points the kube provider straight at the API server. connection_config is
-  // still required and must carry an SSHConfig document; its SSHHost documents may be omitted.
+  // kubeconfig points the kube provider straight at the API server. connection_config is still
+  // required: this operation reaches the nodes over ssh.
   string kubeconfig = 7;
 }
 

--- a/dhctl/pkg/server/api/dhctl/destroy.proto
+++ b/dhctl/pkg/server/api/dhctl/destroy.proto
@@ -45,8 +45,9 @@ message DestroyStart {
   string provider_specific_cluster_config = 4;
   string state = 5;
   DestroyStartOptions options = 6;
-  // kubeconfig points the kube provider straight at the API server. connection_config is
-  // still required and must carry an SSHConfig document; its SSHHost documents may be omitted.
+  // kubeconfig points the kube provider straight at the API server. A request that sets it may
+  // leave connection_config empty: the cluster is then driven over the API server only and no
+  // SSH provider is created.
   string kubeconfig = 7;
 }
 

--- a/dhctl/pkg/server/pb/dhctl/bootstrap.pb.go
+++ b/dhctl/pkg/server/pb/dhctl/bootstrap.pb.go
@@ -253,7 +253,9 @@ type BootstrapStart struct {
 	State                         string                 `protobuf:"bytes,7,opt,name=state,proto3" json:"state,omitempty"`
 	PostBootstrapScript           string                 `protobuf:"bytes,8,opt,name=post_bootstrap_script,json=postBootstrapScript,proto3" json:"post_bootstrap_script,omitempty"`
 	Options                       *BootstrapStartOptions `protobuf:"bytes,9,opt,name=options,proto3" json:"options,omitempty"`
-	Kubeconfig                    string                 `protobuf:"bytes,10,opt,name=kubeconfig,proto3" json:"kubeconfig,omitempty"`
+	// kubeconfig points the kube provider straight at the API server. connection_config is still
+	// required: this operation reaches the nodes over ssh.
+	Kubeconfig string `protobuf:"bytes,10,opt,name=kubeconfig,proto3" json:"kubeconfig,omitempty"`
 }
 
 func (x *BootstrapStart) Reset() {

--- a/dhctl/pkg/server/pb/dhctl/check.pb.go
+++ b/dhctl/pkg/server/pb/dhctl/check.pb.go
@@ -221,8 +221,9 @@ type CheckStart struct {
 	ProviderSpecificClusterConfig string             `protobuf:"bytes,3,opt,name=provider_specific_cluster_config,json=providerSpecificClusterConfig,proto3" json:"provider_specific_cluster_config,omitempty"`
 	State                         string             `protobuf:"bytes,4,opt,name=state,proto3" json:"state,omitempty"`
 	Options                       *CheckStartOptions `protobuf:"bytes,5,opt,name=options,proto3" json:"options,omitempty"`
-	// kubeconfig points the kube provider straight at the API server. connection_config is
-	// still required and must carry an SSHConfig document; its SSHHost documents may be omitted.
+	// kubeconfig points the kube provider straight at the API server. A request that sets it may
+	// leave connection_config empty: the cluster is then driven over the API server only and no
+	// SSH provider is created.
 	Kubeconfig string `protobuf:"bytes,6,opt,name=kubeconfig,proto3" json:"kubeconfig,omitempty"`
 }
 

--- a/dhctl/pkg/server/pb/dhctl/commander_attach.pb.go
+++ b/dhctl/pkg/server/pb/dhctl/commander_attach.pb.go
@@ -250,8 +250,9 @@ type CommanderAttachStart struct {
 	ResourcesTemplate string                       `protobuf:"bytes,3,opt,name=resources_template,json=resourcesTemplate,proto3" json:"resources_template,omitempty"`
 	ResourcesValues   *structpb.Struct             `protobuf:"bytes,4,opt,name=resources_values,json=resourcesValues,proto3" json:"resources_values,omitempty"`
 	Options           *CommanderAttachStartOptions `protobuf:"bytes,5,opt,name=options,proto3" json:"options,omitempty"`
-	// kubeconfig points the kube provider straight at the API server. connection_config is
-	// still required and must carry an SSHConfig document; its SSHHost documents may be omitted.
+	// kubeconfig points the kube provider straight at the API server. A request that sets it may
+	// leave connection_config empty: the cluster is then driven over the API server only and no
+	// SSH provider is created.
 	Kubeconfig string `protobuf:"bytes,6,opt,name=kubeconfig,proto3" json:"kubeconfig,omitempty"`
 }
 

--- a/dhctl/pkg/server/pb/dhctl/commander_detach.pb.go
+++ b/dhctl/pkg/server/pb/dhctl/commander_detach.pb.go
@@ -226,8 +226,9 @@ type CommanderDetachStart struct {
 	CreateResourcesValues         *structpb.Struct             `protobuf:"bytes,7,opt,name=create_resources_values,json=createResourcesValues,proto3" json:"create_resources_values,omitempty"`
 	DeleteResourcesValues         *structpb.Struct             `protobuf:"bytes,8,opt,name=delete_resources_values,json=deleteResourcesValues,proto3" json:"delete_resources_values,omitempty"`
 	Options                       *CommanderDetachStartOptions `protobuf:"bytes,9,opt,name=options,proto3" json:"options,omitempty"`
-	// kubeconfig points the kube provider straight at the API server. connection_config is
-	// still required and must carry an SSHConfig document; its SSHHost documents may be omitted.
+	// kubeconfig points the kube provider straight at the API server. A request that sets it may
+	// leave connection_config empty: the cluster is then driven over the API server only and no
+	// SSH provider is created.
 	Kubeconfig string `protobuf:"bytes,10,opt,name=kubeconfig,proto3" json:"kubeconfig,omitempty"`
 }
 

--- a/dhctl/pkg/server/pb/dhctl/converge.pb.go
+++ b/dhctl/pkg/server/pb/dhctl/converge.pb.go
@@ -250,8 +250,8 @@ type ConvergeStart struct {
 	State                         string                `protobuf:"bytes,4,opt,name=state,proto3" json:"state,omitempty"`
 	ApproveDestructionChangeId    string                `protobuf:"bytes,5,opt,name=approve_destruction_change_id,json=approveDestructionChangeId,proto3" json:"approve_destruction_change_id,omitempty"`
 	Options                       *ConvergeStartOptions `protobuf:"bytes,6,opt,name=options,proto3" json:"options,omitempty"`
-	// kubeconfig points the kube provider straight at the API server. connection_config is
-	// still required and must carry an SSHConfig document; its SSHHost documents may be omitted.
+	// kubeconfig points the kube provider straight at the API server. connection_config is still
+	// required: this operation reaches the nodes over ssh.
 	Kubeconfig string `protobuf:"bytes,7,opt,name=kubeconfig,proto3" json:"kubeconfig,omitempty"`
 }
 

--- a/dhctl/pkg/server/pb/dhctl/destroy.pb.go
+++ b/dhctl/pkg/server/pb/dhctl/destroy.pb.go
@@ -250,8 +250,9 @@ type DestroyStart struct {
 	ProviderSpecificClusterConfig string               `protobuf:"bytes,4,opt,name=provider_specific_cluster_config,json=providerSpecificClusterConfig,proto3" json:"provider_specific_cluster_config,omitempty"`
 	State                         string               `protobuf:"bytes,5,opt,name=state,proto3" json:"state,omitempty"`
 	Options                       *DestroyStartOptions `protobuf:"bytes,6,opt,name=options,proto3" json:"options,omitempty"`
-	// kubeconfig points the kube provider straight at the API server. connection_config is
-	// still required and must carry an SSHConfig document; its SSHHost documents may be omitted.
+	// kubeconfig points the kube provider straight at the API server. A request that sets it may
+	// leave connection_config empty: the cluster is then driven over the API server only and no
+	// SSH provider is created.
 	Kubeconfig string `protobuf:"bytes,7,opt,name=kubeconfig,proto3" json:"kubeconfig,omitempty"`
 }
 

--- a/dhctl/pkg/server/pkg/helper/ssh_kube_providers.go
+++ b/dhctl/pkg/server/pkg/helper/ssh_kube_providers.go
@@ -24,6 +24,7 @@ import (
 	dhlog "github.com/deckhouse/lib-dhctl/pkg/logger"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/server/pkg/util"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/server/pkg/util/callback"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/providerinitializer"
 )
@@ -41,23 +42,16 @@ func AllowMissingHostsFromCache() CreateProvidersOption {
 	}
 }
 
-// WithKubeConfig points the kube provider at an already existing API server through the
-// kubeconfig at the given path, the way the --kubeconfig flag does on the CLI. An empty path
-// keeps the previous behaviour: connect over SSH.
 func WithKubeConfig(kubeConfig string) CreateProvidersOption {
 	return func(o *CreateProvidersOptions) {
 		o.kubeConfig = kubeConfig
 	}
 }
 
-// SSHProviderOrNil resolves the SSH provider an operation should run with. A request that carries a
-// kubeconfig drives the cluster through the API server, so it may legitimately have no master hosts
-// to connect to; there the provider is nil and every consumer has to guard on it. Without a
-// kubeconfig, missing hosts are a real misconfiguration and stay an error.
-//
-// The nil matters: GetSSHProvider hands back a hostless provider alongside the sentinel, and that
-// value looks connectable to every govalue.IsNil guard downstream while failing deep inside
-// lib-connection once something dials it.
+// SSHProviderOrNil returns nil, not the provider GetSSHProvider hands back alongside the sentinel:
+// initializer.go pairs the error with a hostless provider that passes every govalue.IsNil guard
+// downstream and only fails deep inside lib-connection once something dials it. A nil initializer
+// is safe to call here - its methods guard the nil receiver in initializer.go.
 func SSHProviderOrNil(ctx context.Context, initializer *providerinitializer.SSHProviderInitializer, kubeConfig string) (libcon.SSHProvider, error) {
 	sshProvider, err := initializer.GetSSHProvider(ctx)
 	if err == nil {
@@ -87,18 +81,15 @@ func CreateProviders(ctx context.Context, config string, isDebug bool, tmpDir st
 		TmpDir:      tmpDir,
 	}
 
-	providerOpts := []providerinitializer.ProviderOptions{providerinitializer.WithConnectionConfig(config)}
-	if options.kubeConfig != "" {
-		providerOpts = append(providerOpts,
-			providerinitializer.WithKubeFlagsDefined(true),
-			providerinitializer.WithKubeConfig(options.kubeConfig, "", false),
-		)
+	providerOpts, err := providerOptions(config, options, cleanuper)
+	if err != nil {
+		return nil, nil, cleanuper.AsFunc(), err
 	}
 
 	sshProviderInitializer, kubeProvider, err := providerinitializer.GetProviders(ctx, params, providerOpts...)
 	if err != nil {
 		if !options.allowMissingHostsFromCache || !errors.Is(err, providerinitializer.ErrHostsFromCacheNotFound) {
-			return nil, nil, nil, fmt.Errorf("initializing providers: %w", err)
+			return nil, nil, cleanuper.AsFunc(), fmt.Errorf("initializing providers: %w", err)
 		}
 	}
 	if sshProviderInitializer != nil {
@@ -108,4 +99,25 @@ func CreateProviders(ctx context.Context, config string, isDebug bool, tmpDir st
 	}
 
 	return sshProviderInitializer, kubeProvider, cleanuper.AsFunc(), nil
+}
+
+func providerOptions(config string, options *CreateProvidersOptions, cleanuper *callback.Callback) ([]providerinitializer.ProviderOptions, error) {
+	if options.kubeConfig == "" {
+		return []providerinitializer.ProviderOptions{providerinitializer.WithConnectionConfig(config)}, nil
+	}
+
+	kubeConfigPath, cleanup, err := util.WriteDefaultTempFile([]byte(options.kubeConfig))
+	cleanuper.Add(cleanup)
+
+	if err != nil {
+		return nil, fmt.Errorf("writing kubeconfig: %w", err)
+	}
+
+	return []providerinitializer.ProviderOptions{
+		providerinitializer.WithConnectionConfig(config),
+		providerinitializer.WithConnectionConfigOnly(),
+		// The Commander generates the kubeconfig it sends, so its current-context is the only
+		// one that can be meant.
+		providerinitializer.WithKubeConfig(kubeConfigPath, "", false),
+	}, nil
 }

--- a/dhctl/pkg/server/pkg/helper/ssh_kube_providers_test.go
+++ b/dhctl/pkg/server/pkg/helper/ssh_kube_providers_test.go
@@ -1,0 +1,165 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helper
+
+import (
+	"crypto/ed25519"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+
+	"github.com/deckhouse/lib-connection/pkg/settings"
+	sshconfig "github.com/deckhouse/lib-connection/pkg/ssh/config"
+	dhlog "github.com/deckhouse/lib-dhctl/pkg/logger"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/app/options"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/system/providerinitializer"
+)
+
+const kubeconfigYAML = `
+apiVersion: v1
+kind: Config
+current-context: test
+clusters:
+- name: test
+  cluster:
+    server: https://127.0.0.1:6443
+contexts:
+- name: test
+  context:
+    cluster: test
+    user: test
+users:
+- name: test
+  user:
+    token: test
+`
+
+func newInitializer(t *testing.T, hosts []sshconfig.Host) *providerinitializer.SSHProviderInitializer {
+	t.Helper()
+
+	params := settings.ProviderParams{Logger: dhlog.Discard(), TmpDir: options.DefaultTmpDir()}
+
+	// Config must be non-nil: lib-connection dereferences it while cloning the connection.
+	return providerinitializer.NewSSHProviderInitializer(
+		settings.NewBaseProviders(params),
+		&sshconfig.ConnectionConfig{Config: &sshconfig.Config{}, Hosts: hosts},
+	)
+}
+
+func TestSSHProviderOrNil(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		hosts          []sshconfig.Host
+		nilInitializer bool
+		kubeConfig     string
+		wantProvider   bool
+		wantErr        error
+	}{
+		{
+			name:         "hosts from the connection config give a provider",
+			hosts:        []sshconfig.Host{{Host: "10.0.0.1"}},
+			wantProvider: true,
+		},
+		{
+			name:         "hosts win over a kubeconfig",
+			hosts:        []sshconfig.Host{{Host: "10.0.0.1"}},
+			kubeConfig:   kubeconfigYAML,
+			wantProvider: true,
+		},
+		{
+			name:    "no hosts and no kubeconfig is a misconfiguration",
+			wantErr: providerinitializer.ErrHostsFromCacheNotFound,
+		},
+		{
+			name:       "no hosts with a kubeconfig runs without ssh",
+			kubeConfig: kubeconfigYAML,
+		},
+		{
+			name:           "a nil initializer is ssh-less whatever the kubeconfig",
+			nilInitializer: true,
+			kubeConfig:     kubeconfigYAML,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var initializer *providerinitializer.SSHProviderInitializer
+			if !tt.nilInitializer {
+				initializer = newInitializer(t, tt.hosts)
+			}
+
+			sshProvider, err := SSHProviderOrNil(t.Context(), initializer, tt.kubeConfig)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				assert.Nil(t, sshProvider)
+
+				return
+			}
+
+			require.NoError(t, err)
+
+			if tt.wantProvider {
+				assert.NotNil(t, sshProvider)
+
+				return
+			}
+
+			assert.Nil(t, sshProvider)
+		})
+	}
+}
+
+// plantSSHKey gives the process a $HOME holding a usable private key, which is what the argv arm
+// of the provider initializer picks up when the caller passes no SSH flags. The key is what makes
+// the test below meaningful: with an unusable one that arm fails, and failing looks the same as
+// not being taken at all.
+func plantSSHKey(t *testing.T) {
+	t.Helper()
+
+	home := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(home, ".ssh"), 0o700))
+
+	_, key, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+
+	block, err := ssh.MarshalPrivateKey(key, "")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(home, ".ssh", "id_rsa"), pem.EncodeToMemory(block), 0o600))
+
+	t.Setenv("HOME", home)
+}
+
+func TestCreateProvidersKubeConfigWithoutConnectionConfig(t *testing.T) {
+	plantSSHKey(t)
+
+	sshProviderInitializer, kubeProvider, cleanup, err := CreateProviders(
+		t.Context(), "", false, t.TempDir(),
+		WithKubeConfig(kubeconfigYAML),
+	)
+	require.NoError(t, err)
+	require.Nil(t, sshProviderInitializer)
+	require.NotNil(t, kubeProvider)
+	require.NoError(t, cleanup())
+}

--- a/dhctl/pkg/server/rpc/dhctl/bootstrap.go
+++ b/dhctl/pkg/server/rpc/dhctl/bootstrap.go
@@ -197,7 +197,6 @@ func (s *Service) bootstrap(ctx context.Context, p *bootstrapParams) *pb.Bootstr
 	var (
 		configPaths             []string
 		configPath              string
-		kubeConfigPath          string
 		postBootstrapScriptPath string
 		cleanup                 func() error
 	)
@@ -220,16 +219,6 @@ func (s *Service) bootstrap(ctx context.Context, p *bootstrapParams) *pb.Bootstr
 			}
 
 			configPaths = append(configPaths, configPath)
-		}
-
-		// The kubeconfig arrives as contents, but every consumer down the chain wants a path,
-		// so spill it into the same 0600 temp file the configs above get. Never log the value.
-		if len(p.request.Kubeconfig) > 0 {
-			kubeConfigPath, cleanup, err = util.WriteDefaultTempFile([]byte(p.request.Kubeconfig))
-			cleanuper.Add(cleanup)
-			if err != nil {
-				return fmt.Errorf("failed to write kubeconfig: %w", err)
-			}
 		}
 
 		postBootstrapScriptPath, cleanup, err = util.WriteDefaultTempFile([]byte(p.request.PostBootstrapScript))
@@ -269,11 +258,15 @@ func (s *Service) bootstrap(ctx context.Context, p *bootstrapParams) *pb.Bootstr
 	var sshProviderInitializer *providerinitializer.SSHProviderInitializer
 	var kubeProvider libcon.KubeProvider
 	err = dhlog.RunProcess(ctx, dhlog.FromContext(ctx), "Preparing SSH client", func(ctx context.Context) error {
-		sshProviderInitializer, kubeProvider, cleanup, err = helper.CreateProviders(ctx, p.request.ConnectionConfig, s.params.IsDebug, s.params.TmpDir, helper.AllowMissingHostsFromCache(), helper.WithKubeConfig(kubeConfigPath))
+		sshProviderInitializer, kubeProvider, cleanup, err = helper.CreateProviders(ctx, p.request.ConnectionConfig, s.params.IsDebug, s.params.TmpDir, helper.AllowMissingHostsFromCache(), helper.WithKubeConfig(p.request.Kubeconfig))
 		if err != nil {
 			return fmt.Errorf("preparing providers: %w", err)
 		}
 		cleanuper.Add(cleanup)
+
+		if sshProviderInitializer == nil {
+			return errors.New("connection config is required, bootstrap installs the cluster over ssh")
+		}
 
 		return nil
 	})

--- a/dhctl/pkg/server/rpc/dhctl/check.go
+++ b/dhctl/pkg/server/rpc/dhctl/check.go
@@ -256,18 +256,7 @@ func (s *Service) check(ctx context.Context, p *checkParams) *pb.CheckResult {
 	var kubeProvider libcon.KubeProvider
 	err = dhlog.RunProcess(ctx, dhlog.FromContext(ctx), "Preparing SSH client", func(ctx context.Context) error {
 		var cleanup func() error
-		// The kubeconfig arrives as contents, but every consumer down the chain wants a path,
-		// so spill it into a 0600 temp file. Never log the value.
-		var kubeConfigPath string
-		if len(p.request.Kubeconfig) > 0 {
-			kubeConfigPath, cleanup, err = util.WriteDefaultTempFile([]byte(p.request.Kubeconfig))
-			cleanuper.Add(cleanup)
-			if err != nil {
-				return fmt.Errorf("failed to write kubeconfig: %w", err)
-			}
-		}
-
-		_, kubeProvider, cleanup, err = helper.CreateProviders(ctx, p.request.ConnectionConfig, s.params.IsDebug, s.params.TmpDir, helper.WithKubeConfig(kubeConfigPath))
+		_, kubeProvider, cleanup, err = helper.CreateProviders(ctx, p.request.ConnectionConfig, s.params.IsDebug, s.params.TmpDir, helper.WithKubeConfig(p.request.Kubeconfig))
 		cleanuper.Add(cleanup)
 		if err != nil {
 			return fmt.Errorf("creating provider: %w", err)

--- a/dhctl/pkg/server/rpc/dhctl/commander_attach.go
+++ b/dhctl/pkg/server/rpc/dhctl/commander_attach.go
@@ -186,24 +186,13 @@ func (s *Service) commanderAttach(ctx context.Context, p *attachParams) *pb.Comm
 	err = dhlog.RunProcess(ctx, dhlog.FromContext(ctx), "Preparing SSH client", func(ctx context.Context) error {
 		var cleanup func() error
 		var sshProviderInitializer *providerinitializer.SSHProviderInitializer
-		// The kubeconfig arrives as contents, but every consumer down the chain wants a path,
-		// so spill it into a 0600 temp file. Never log the value.
-		var kubeConfigPath string
-		if len(p.request.Kubeconfig) > 0 {
-			kubeConfigPath, cleanup, err = util.WriteDefaultTempFile([]byte(p.request.Kubeconfig))
-			cleanuper.Add(cleanup)
-			if err != nil {
-				return fmt.Errorf("failed to write kubeconfig: %w", err)
-			}
-		}
-
-		sshProviderInitializer, kubeProvider, cleanup, err = helper.CreateProviders(ctx, p.request.ConnectionConfig, s.params.IsDebug, s.params.TmpDir, helper.WithKubeConfig(kubeConfigPath))
+		sshProviderInitializer, kubeProvider, cleanup, err = helper.CreateProviders(ctx, p.request.ConnectionConfig, s.params.IsDebug, s.params.TmpDir, helper.WithKubeConfig(p.request.Kubeconfig))
 		cleanuper.Add(cleanup)
 		if err != nil {
 			return fmt.Errorf("creating provider: %w", err)
 		}
 
-		sshProvider, err = helper.SSHProviderOrNil(ctx, sshProviderInitializer, kubeConfigPath)
+		sshProvider, err = helper.SSHProviderOrNil(ctx, sshProviderInitializer, p.request.Kubeconfig)
 		if err != nil {
 			return fmt.Errorf("getting ssh provider: %w", err)
 		}

--- a/dhctl/pkg/server/rpc/dhctl/commander_detach.go
+++ b/dhctl/pkg/server/rpc/dhctl/commander_detach.go
@@ -222,24 +222,13 @@ func (s *Service) commanderDetach(ctx context.Context, p *detachParams) *pb.Comm
 	err = dhlog.RunProcess(ctx, dhlog.FromContext(ctx), "Preparing SSH client", func(ctx context.Context) error {
 		var cleanup func() error
 		var sshProviderInitializer *providerinitializer.SSHProviderInitializer
-		// The kubeconfig arrives as contents, but every consumer down the chain wants a path,
-		// so spill it into a 0600 temp file. Never log the value.
-		var kubeConfigPath string
-		if len(p.request.Kubeconfig) > 0 {
-			kubeConfigPath, cleanup, err = util.WriteDefaultTempFile([]byte(p.request.Kubeconfig))
-			cleanuper.Add(cleanup)
-			if err != nil {
-				return fmt.Errorf("failed to write kubeconfig: %w", err)
-			}
-		}
-
-		sshProviderInitializer, kubeProvider, cleanup, err = helper.CreateProviders(ctx, p.request.ConnectionConfig, s.params.IsDebug, s.params.TmpDir, helper.WithKubeConfig(kubeConfigPath))
+		sshProviderInitializer, kubeProvider, cleanup, err = helper.CreateProviders(ctx, p.request.ConnectionConfig, s.params.IsDebug, s.params.TmpDir, helper.WithKubeConfig(p.request.Kubeconfig))
 		cleanuper.Add(cleanup)
 		if err != nil {
 			return fmt.Errorf("creating provider: %w", err)
 		}
 
-		sshProvider, err = helper.SSHProviderOrNil(ctx, sshProviderInitializer, kubeConfigPath)
+		sshProvider, err = helper.SSHProviderOrNil(ctx, sshProviderInitializer, p.request.Kubeconfig)
 		if err != nil {
 			return fmt.Errorf("getting ssh provider: %w", err)
 		}

--- a/dhctl/pkg/server/rpc/dhctl/converge.go
+++ b/dhctl/pkg/server/rpc/dhctl/converge.go
@@ -313,21 +313,14 @@ func (s *Service) converge(ctx context.Context, p *convergeParams) *pb.ConvergeR
 	var kubeProvider libcon.KubeProvider
 	err = dhlog.RunProcess(ctx, dhlog.FromContext(ctx), "Preparing SSH client", func(ctx context.Context) error {
 		var cleanup func() error
-		// The kubeconfig arrives as contents, but every consumer down the chain wants a path,
-		// so spill it into a 0600 temp file. Never log the value.
-		var kubeConfigPath string
-		if len(p.request.Kubeconfig) > 0 {
-			kubeConfigPath, cleanup, err = util.WriteDefaultTempFile([]byte(p.request.Kubeconfig))
-			cleanuper.Add(cleanup)
-			if err != nil {
-				return fmt.Errorf("failed to write kubeconfig: %w", err)
-			}
-		}
-
-		sshProviderInitializer, kubeProvider, cleanup, err = helper.CreateProviders(ctx, p.request.ConnectionConfig, s.params.IsDebug, s.params.TmpDir, helper.WithKubeConfig(kubeConfigPath))
+		sshProviderInitializer, kubeProvider, cleanup, err = helper.CreateProviders(ctx, p.request.ConnectionConfig, s.params.IsDebug, s.params.TmpDir, helper.WithKubeConfig(p.request.Kubeconfig))
 		cleanuper.Add(cleanup)
 		if err != nil {
 			return fmt.Errorf("creating provider: %w", err)
+		}
+
+		if sshProviderInitializer == nil {
+			return errors.New("connection config is required, converge reaches the nodes over ssh")
 		}
 
 		return nil

--- a/dhctl/pkg/server/rpc/dhctl/destroy.go
+++ b/dhctl/pkg/server/rpc/dhctl/destroy.go
@@ -248,24 +248,13 @@ func (s *Service) destroy(ctx context.Context, p *destroyParams) *pb.DestroyResu
 	var kubeProvider libcon.KubeProvider
 	err = dhlog.RunProcess(ctx, dhlog.FromContext(ctx), "Preparing SSH client", func(ctx context.Context) error {
 		var cleanup func() error
-		// The kubeconfig arrives as contents, but every consumer down the chain wants a path,
-		// so spill it into a 0600 temp file. Never log the value.
-		var kubeConfigPath string
-		if len(p.request.Kubeconfig) > 0 {
-			kubeConfigPath, cleanup, err = util.WriteDefaultTempFile([]byte(p.request.Kubeconfig))
-			cleanuper.Add(cleanup)
-			if err != nil {
-				return fmt.Errorf("failed to write kubeconfig: %w", err)
-			}
-		}
-
-		sshProviderInitializer, kubeProvider, cleanup, err = helper.CreateProviders(ctx, p.request.ConnectionConfig, s.params.IsDebug, s.params.TmpDir, helper.WithKubeConfig(kubeConfigPath))
+		sshProviderInitializer, kubeProvider, cleanup, err = helper.CreateProviders(ctx, p.request.ConnectionConfig, s.params.IsDebug, s.params.TmpDir, helper.WithKubeConfig(p.request.Kubeconfig))
 		cleanuper.Add(cleanup)
 		if err != nil {
 			return fmt.Errorf("creating provider: %w", err)
 		}
 
-		sshProvider, err = helper.SSHProviderOrNil(ctx, sshProviderInitializer, kubeConfigPath)
+		sshProvider, err = helper.SSHProviderOrNil(ctx, sshProviderInitializer, p.request.Kubeconfig)
 		if err != nil {
 			return fmt.Errorf("getting ssh provider: %w", err)
 		}

--- a/dhctl/pkg/system/providerinitializer/providers.go
+++ b/dhctl/pkg/system/providerinitializer/providers.go
@@ -33,10 +33,11 @@ import (
 )
 
 type providerOptions struct {
-	connectionConfig    string
-	kubeFlagsDefined    bool
-	requireKubeProvider bool
-	kubeConfig          *kube.Config
+	connectionConfig     string
+	connectionConfigOnly bool
+	kubeFlagsDefined     bool
+	requireKubeProvider  bool
+	kubeConfig           *kube.Config
 }
 
 type ProviderOptions func(o *providerOptions)
@@ -44,6 +45,12 @@ type ProviderOptions func(o *providerOptions)
 func WithConnectionConfig(s string) ProviderOptions {
 	return func(o *providerOptions) {
 		o.connectionConfig = s
+	}
+}
+
+func WithConnectionConfigOnly() ProviderOptions {
+	return func(o *providerOptions) {
+		o.connectionConfigOnly = true
 	}
 }
 
@@ -79,7 +86,6 @@ func GetSSHProviderInitializer(ctx context.Context, params settings.ProviderPara
 	return getProviderInitializer(ctx, baseProviderSettings, opts...)
 }
 
-// func to initialize both SSHProviderInitializer and KubeProvider
 func GetProviders(ctx context.Context, params settings.ProviderParams, opts ...ProviderOptions) (*SSHProviderInitializer, libcon.KubeProvider, error) {
 	options := newProviderOptions(opts...)
 	baseProviderSettings := settings.NewBaseProviders(params)
@@ -136,6 +142,9 @@ func resolveKubeConfig(baseProviderSettings *settings.BaseProviders, options *pr
 
 func getProviderInitializer(ctx context.Context, baseProviderSettings *settings.BaseProviders, opts ...ProviderOptions) (*SSHProviderInitializer, error) {
 	options := newProviderOptions(opts...)
+	if options.connectionConfigOnly && options.connectionConfig == "" {
+		return nil, nil
+	}
 
 	var config *libcon_config.ConnectionConfig
 	var err error

--- a/dhctl/pkg/system/providerinitializer/providers_test.go
+++ b/dhctl/pkg/system/providerinitializer/providers_test.go
@@ -1,0 +1,98 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package providerinitializer
+
+import (
+	"crypto/ed25519"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+
+	"github.com/deckhouse/lib-connection/pkg/settings"
+	dhlog "github.com/deckhouse/lib-dhctl/pkg/logger"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/app/options"
+)
+
+const connectionConfigWithoutHosts = `
+apiVersion: dhctl.deckhouse.io/v1
+kind: SSHConfig
+sshUser: ubuntu
+sshPort: 22
+sudoPassword: test
+`
+
+// plantPrivateKey gives the process a $HOME holding a usable private key, which is what the argv
+// arm of getProviderInitializer picks up when no SSH flags are passed. Without it the outcome of
+// that arm depends on the keys the machine running the test happens to have.
+func plantPrivateKey(t *testing.T) {
+	t.Helper()
+
+	home := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(home, ".ssh"), 0o700))
+
+	_, key, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+
+	block, err := ssh.MarshalPrivateKey(key, "")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(home, ".ssh", "id_rsa"), pem.EncodeToMemory(block), 0o600))
+
+	t.Setenv("HOME", home)
+}
+
+func TestGetProviderInitializerConnectionConfigOnly(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    []ProviderOptions
+		wantNil bool
+	}{
+		{
+			name:    "connection config only, and none supplied, means the operation runs without ssh",
+			opts:    []ProviderOptions{WithConnectionConfig(""), WithConnectionConfigOnly()},
+			wantNil: true,
+		},
+		{
+			name: "connection config only still parses the config it is given",
+			opts: []ProviderOptions{WithConnectionConfig(connectionConfigWithoutHosts), WithConnectionConfigOnly()},
+		},
+		{
+			name: "without the option an empty config still falls back to the process arguments",
+			opts: []ProviderOptions{WithConnectionConfig("")},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plantPrivateKey(t)
+
+			params := settings.ProviderParams{Logger: dhlog.Discard(), TmpDir: options.DefaultTmpDir()}
+			initializer, err := getProviderInitializer(t.Context(), settings.NewBaseProviders(params), tt.opts...)
+			require.NoError(t, err)
+
+			if tt.wantNil {
+				require.Nil(t, initializer)
+
+				return
+			}
+
+			require.NotNil(t, initializer)
+		})
+	}
+}


### PR DESCRIPTION
## Description

Follow-up to [#22378](https://github.com/deckhouse/deckhouse/pull/22378), which added `kubeconfig`
to the six `*Start` messages. That PR left the field unusable on its own: `connection_config` still
had to carry an `SSHConfig` document. This PR drops that where nothing dials SSH.

- `CheckStart`, `DestroyStart`, `CommanderAttachStart`, `CommanderDetachStart` — `connection_config`
  may now be empty.
- `ConvergeStart`, `BootstrapStart` — still required; both reach the nodes over SSH.

Field numbers are unchanged. Only the contract moves.

**Why it was mandatory.** #22378 got its SSH-less path from `WithKubeFlagsDefined(true)`, which
enables a branch that matches on an error string (`providers.go:180`):

```go
if strings.Contains(err.Error(), "Failed to read private keys from flags") && options.kubeFlagsDefined {
```

That only fires after lib-connection has already fallen back to the dhctl server's own `os.Args`
and injected `$HOME/.ssh/id_rsa`. Without that key the request looked SSH-less; with it, the server
silently built a cluster connection out of its own identity. `WithConnectionConfigOnly()` replaces
it — an empty connection config returns a nil initializer before argv is read at all. The CLI is
untouched: it is the only legitimate user of the argv path and never sets the option.

**kubeconfig travels as contents, not a path.** #22378 spilled it into a temp file in each of the
six handlers. That path was never read at any call site, so `CreateProviders` now does the spill
once — `check.go`'s whole diff is one line. `CreateProviders` also returns its cleanup on the error
paths, where it used to return nil and drop it.

**bootstrap and converge refuse instead of panicking.** Both dereference the connection config
unconditionally downstream (`cluster-bootstrapper.go:1035`, `client_switcher.go:341`), so both now
reject a nil initializer at the RPC boundary.

Unit tests cover `WithConnectionConfigOnly` — including a control case proving the option is
load-bearing — `SSHProviderOrNil` across hosts / no-hosts / nil-initializer, and nil providers in
destroy's `Cleanup`.

No impact on running components — dhctl-server side only.

### Known limitations

- A managed control plane still will not attach: `config.ParseConfigInCluster` reads a
  `kube-system/d8-cluster-configuration` Secret it never had. What this enables is a Cloud or Static
  cluster with no reachable masters.
- Nothing checks that the kubeconfig belongs to the cluster the state describes. Cluster B's
  kubeconfig alongside cluster A's state is expressible over the API.
- `attacher.go`'s nil guard is untested — `scan()` needs a fake kube client, an in-cluster
  MetaConfig and an initialized global cache.

## Why do we need it, and what problem does it solve?

Commander manages clusters whose master nodes it cannot SSH into. #22378 got a kubeconfig into the
request; this makes the SSH half genuinely optional instead of conditionally optional. Before it, a
caller with no SSH access had to send a connection config describing a connection nobody would ever
open, and the operation succeeded only because the fallback parser failed in the right way on the
right machine.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: dhctl
type: feature
summary: dhctl gRPC operations that do not reach the nodes over SSH accept a kubeconfig with an empty connection config.
impact_level: low
```
