### PR TITLE
[cloud-provider-dvp] Add alias to known CVE

### DIFF
--- a/modules/030-cloud-provider-dvp/images/terraform-manager/known_vulnerabilities.vex
+++ b/modules/030-cloud-provider-dvp/images/terraform-manager/known_vulnerabilities.vex
@@ -2,7 +2,7 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "merged-vex-819396348420854c54b988d825529cab830b81f6a05730951c9bec690dc551f1",
   "author": "Deckhouse <contact@deckhouse.io>",
-  "version": 3,
+  "version": 4,
   "statements": [
     {
       "vulnerability": {
@@ -48,7 +48,10 @@
     },
     {
       "vulnerability": {
-        "name": "CVE-2026-73502"
+        "name": "CVE-2026-73502",
+        "aliases": [
+          "GHSA-jpcw-4wr7-c3vq"
+        ]
       },
       "products": [
         {


### PR DESCRIPTION
## Description
Added a GitHub Security Advisory alias (`GHSA-jpcw-4wr7-c3vq`) to the existing `CVE-2026-73502` VEX statement in `modules/030-cloud-provider-dvp/images/terraform-manager/known_vulnerabilities.vex` on `main`, and backported the same statement (previously missing entirely) to the `release-1.77` branch. No source, `go.mod`, or patch files were changed.

## Why do we need it, and what problem does it solve?
kin-openapi's `openapi3filter` nil-pointer panic is tracked by Trivy under two IDs for the same finding: `CVE-2026-73502` (current primary) and `GHSA-jpcw-4wr7-c3vq` (GitHub's advisory ID, listed as a vendor alias). The existing VEX statement matched only the CVE form. A downstream CSE scan pipeline, apparently running an older/pinned trivy-db snapshot from before MITRE assigned the CVE number, still reports the finding under the bare GHSA ID — which the VEX file didn't cover, so the suppression silently failed to apply there even though the underlying justification (the vulnerable `openapi3filter` subpackage is never imported) was already correct and verified. Adding the alias makes the same VEX statement match both ID forms regardless of which trivy-db snapshot a given pipeline uses.

## Why do we need it in the patch release (if we do)?
Yes — `release-1.77` had no VEX entry at all for this CVE (its `known_vulnerabilities.vex` predates the finding), so the CSE build on that branch reports it as an unaddressed vulnerability. Backporting closes that gap using the same, already-verified justification.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: cloud-provider-dvp
type: fix
summary: Extends the VEX suppression for a kin-openapi vulnerability to also match its GitHub advisory ID, so certified-build vulnerability scans stop flagging an already-analyzed, non-exploitable finding.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
