### PR TITLE
[cni-cilium] Fix agent startup on kernels restricting xlated instruction readback

### DIFF
--- a/modules/021-cni-cilium/images/bin-cilium/patches/022-probes-restricted-kernel.patch
+++ b/modules/021-cni-cilium/images/bin-cilium/patches/022-probes-restricted-kernel.patch
@@ -1,0 +1,14 @@
+diff --git a/pkg/datapath/linux/probes/probes.go b/pkg/datapath/linux/probes/probes.go
+--- a/pkg/datapath/linux/probes/probes.go
++++ b/pkg/datapath/linux/probes/probes.go
+@@ -671,7 +671,9 @@
+ 		return fmt.Errorf("get prog info: %w", err)
+ 	}
+ 	infoInst, err := info.Instructions()
+-	if err != nil {
++	if errors.Is(err, ebpf.ErrRestrictedKernel) {
++		return nil
++	} else if err != nil {
+ 		return fmt.Errorf("get instructions: %w", err)
+ 	}
+ 

--- a/modules/021-cni-cilium/images/bin-cilium/patches/README.md
+++ b/modules/021-cni-cilium/images/bin-cilium/patches/README.md
@@ -145,3 +145,31 @@ has this single call site as its only incompatibility.
 
 **Remove this patch when upgrading to a Cilium version that already targets
 ebpf >= v0.21.0**, where `applyConstants()` no longer uses the removed method.
+
+## 022-probes-restricted-kernel.patch
+
+Fixes `cilium-agent` refusing to start with
+`requirements failed: Require support for dead code elimination (Linux 5.1 or newer)`
+on kernels that restrict readback of xlated instructions.
+
+`HaveDeadCodeElim()` (`pkg/datapath/linux/probes/probes.go`) loads a small XDP program with
+a branch the verifier is expected to prune, then reads the loaded instructions back through
+`(*ebpf.ProgramInfo).Instructions()` and fails if a jump survived. ebpf v0.22.0 — pulled in
+by `000-go-mod.patch` — added a new failure mode to that call: when the kernel returns a nil
+`XlatedProgInsns` (it does so when `kernel.kptr_restrict` and `net.core.bpf_jit_harden` are
+set, aborting the readback), the info is marked restricted and `Instructions()` returns
+`ErrRestrictedKernel` instead of instructions. Cilium v1.17.17 predates that error and maps
+any error to "no dead code elimination", so the requirement fails and the agent exits ~7
+seconds into startup, then crash-loops.
+
+The bump alone is not enough to notice this: it is a runtime behavior change, not a
+compilation one, and it only surfaces on hardened kernels. Observed on Astra Linux
+(6.1.158-1-generic) and RED OS 8 (6.12.87-2.red80); Ubuntu 24.04 (6.8.0-106), RED OS MUROM
+(6.1.52-1.el7.3) and ALT SP Server (6.1.161-un-def-alt1) run the same image fine.
+
+The patch takes the upstream fix, already present in Cilium main: treat
+`ebpf.ErrRestrictedKernel` as "cannot verify, assume supported". `errors` and `ebpf` are
+already imported, so no import changes are needed.
+
+**Remove this patch when upgrading to a Cilium version whose `HaveDeadCodeElim()` already
+handles `ebpf.ErrRestrictedKernel`.**


### PR DESCRIPTION
## Overview

`cilium-agent` refuses to start on kernels that restrict readback of xlated BPF instructions, and crash-loops roughly once a minute:

```
Start hook failed  function="datapath.initDatapath.func1 (pkg/datapath/cells.go:188)"
  error="requirements failed: Require support for dead code elimination (Linux 5.1 or newer)"
```

The message is misleading — the affected kernels are 6.1 and newer. What actually fails is the probe.

`HaveDeadCodeElim()` loads a small XDP program with a branch the verifier is expected to prune, reads the loaded instructions back through `(*ebpf.ProgramInfo).Instructions()`, and fails if a jump survived. The ebpf v0.22.0 bump from #22418 added a new failure mode to that call: when the kernel aborts the xlated readback — it does when `kernel.kptr_restrict` and `net.core.bpf_jit_harden` are set — the info is marked restricted and `Instructions()` returns `ErrRestrictedKernel` instead of instructions. Cilium v1.17.17 predates that error and maps any error to "no dead code elimination".

This is a runtime behavior change, not a compilation one, which is why the bump passed review: `go build ./...` is clean, and the regression only appears on hardened kernels.

Consequence on an affected node: the agent exits ~7 seconds into startup, hangs ~56 seconds in the `agent.datapath.iptables` stop hook, and no new pod can be scheduled there:

```
FailedCreatePodSandBox ... failed to setup network for sandbox ... Is the agent running?
```

## What's changed

New patch `022-probes-restricted-kernel.patch`, taking the upstream fix already present in Cilium main — treat `ErrRestrictedKernel` as "cannot verify, assume supported":

```go
 infoInst, err := info.Instructions()
-if err != nil {
+if errors.Is(err, ebpf.ErrRestrictedKernel) {
+    return nil
+} else if err != nil {
     return fmt.Errorf("get instructions: %w", err)
 }
```

`errors` and `ebpf` are already imported, so no import changes are needed. The `patches/README.md` entry records the reasoning and the removal condition.

## Testing

Reproduced on a five-node stand where all nodes run the same agent image:

| node | OS | kernel | agent |
|---|---|---|---|
| storage-san-test-2 | Astra Linux | 6.1.158-1-generic | crash-loops |
| storage-san-test-4 | RED OS 8.0.2 | 6.12.87-2.red80 | crash-loops |
| storage-san-test-0 | Ubuntu 24.04.4 | 6.8.0-106-generic | healthy |
| storage-san-test-1 | RED OS MUROM | 6.1.52-1.el7.3 | healthy |
| storage-san-test-3 | ALT SP Server | 6.1.161-un-def-alt1 | healthy |

The regression appeared with the agent image built at 2026-08-27T11:29:15Z, one hour after #22588 backported #22418 to `release-1.77`. The previous image, built 2026-08-25, runs on all five nodes. No node was rebooted in between — kernels are unchanged since 5 August and 16 July, and BTF is present everywhere.

Both branches carrying the ebpf bump are affected: `main` and `release-1.77`.

## Changelog entries

```changes
section: cni-cilium
type: fix
summary: Fix cilium-agent failing to start on kernels that restrict readback of xlated BPF instructions.
```
