### PR TITLE
[common] [manual-backport] fix container memory resize validation in kubernetes for 1.77

### DIFF
--- a/modules/000-common/images/kubernetes/patches/1.34/014-fix-container-memory-usage-in-resize-validation.patch
+++ b/modules/000-common/images/kubernetes/patches/1.34/014-fix-container-memory-usage-in-resize-validation.patch
@@ -1,0 +1,13 @@
+diff --git a/pkg/kubelet/kuberuntime/kuberuntime_manager.go b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+index 7464cf6ddaa..1774968693e 100644
+--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
++++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+@@ -939,7 +939,7 @@ func (m *kubeGenericRuntimeManager) validateMemoryResizeAction(
+ 				errs = append(errs, fmt.Errorf("missing container %q memory usage", cStats.Name))
+ 			} else if *cStats.Memory.UsageBytes >= uint64(desiredLimit) {
+ 				errs = append(errs, fmt.Errorf("attempting to set container %q memory limit (%d) below current usage (%d)",
+-					cStats.Name, desiredLimit, *podUsageStats.Memory.UsageBytes))
++					cStats.Name, desiredLimit, *cStats.Memory.UsageBytes))
+ 			}
+ 		}
+ 	}

--- a/modules/000-common/images/kubernetes/patches/1.35/014-fix-container-memory-usage-in-resize-validation.patch
+++ b/modules/000-common/images/kubernetes/patches/1.35/014-fix-container-memory-usage-in-resize-validation.patch
@@ -1,0 +1,13 @@
+diff --git a/pkg/kubelet/kuberuntime/kuberuntime_manager.go b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+index c30377718e6..319815399fc 100644
+--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
++++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+@@ -1062,7 +1062,7 @@ func (m *kubeGenericRuntimeManager) validateMemoryResizeAction(
+ 				errs = append(errs, fmt.Errorf("missing container %q memory usage", cStats.Name))
+ 			} else if *cStats.Memory.UsageBytes >= uint64(desiredLimit) {
+ 				errs = append(errs, fmt.Errorf("attempting to set container %q memory limit (%d) below current usage (%d)",
+-					cStats.Name, desiredLimit, *podUsageStats.Memory.UsageBytes))
++					cStats.Name, desiredLimit, *cStats.Memory.UsageBytes))
+ 			}
+ 		}
+ 	}

--- a/modules/000-common/images/kubernetes/patches/1.36/013-fix-container-memory-usage-in-resize-validation.patch
+++ b/modules/000-common/images/kubernetes/patches/1.36/013-fix-container-memory-usage-in-resize-validation.patch
@@ -1,0 +1,13 @@
+diff --git a/pkg/kubelet/kuberuntime/kuberuntime_manager.go b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+index 619f3ec7a62..e7094ebe6d3 100644
+--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
++++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+@@ -1107,7 +1107,7 @@ func (m *kubeGenericRuntimeManager) validateMemoryResizeAction(
+ 				errs = append(errs, fmt.Errorf("missing container %q memory usage", cStats.Name))
+ 			} else if *cStats.Memory.UsageBytes >= uint64(desiredLimit) {
+ 				errs = append(errs, fmt.Errorf("attempting to set container %q memory limit (%d) below current usage (%d)",
+-					cStats.Name, desiredLimit, *podUsageStats.Memory.UsageBytes))
++					cStats.Name, desiredLimit, *cStats.Memory.UsageBytes))
+ 			}
+ 		}
+ 	}

--- a/modules/000-common/images/kubernetes/patches/README.md
+++ b/modules/000-common/images/kubernetes/patches/README.md
@@ -159,3 +159,19 @@ Added a 5s timeout context wrapping the Delete call in DeleteMirrorPod, that kub
 
 See issues:
 - https://github.com/kubernetes/kubernetes/issues/139502
+
+### fix-container-memory-usage-in-resize-validation.patch (1.34+)
+
+Fixes a kubelet panic in `validateMemoryResizeAction`
+(`pkg/kubelet/kuberuntime/kuberuntime_manager.go`): the per-container check
+dereferences `podUsageStats.Memory.UsageBytes` instead of
+`cStats.Memory.UsageBytes`. That pointer is nil-checked only in the
+`podLimitDecreasing` branch, so an in-place resize decreasing **only a
+container** memory limit panics kubelet when the runtime reports no pod-level
+memory stats.
+
+Only the source change is carried, the upstream test case is dropped.
+`validateMemoryResizeAction` does not exist in 1.32/1.33, so the patch is
+carried on 1.34 (`014`), 1.35 (`014`) and 1.36 (`013`) only.
+
+> Upstream PR https://github.com/kubernetes/kubernetes/pull/141100


### PR DESCRIPTION
## Description

Manual backport of https://github.com/deckhouse/deckhouse/pull/22608

## Why do we need it, and what problem does it solve?

In `validateMemoryResizeAction` the per-container check dereferences `podUsageStats.Memory.UsageBytes` instead of `cStats.Memory.UsageBytes`. That pointer is nil-checked only in the `podLimitDecreasing` branch, so an in-place resize decreasing **only a container** memory limit panics kubelet when the runtime reports no pod-level memory stats. 1.32/1.33 don't have this function and are unaffected.

## Why do we need it in the patch release (if we do)?

It is necessary to fix this bug.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: common
type: fix
summary: Fixed a kubelet panic when decreasing a container memory limit in place while pod-level memory usage stats are unavailable.
impact_level: default
```
