### PR TITLE
[deckhouse] fix nelm tracking

### DIFF
--- a/deckhouse-controller/internal/nelm/client.go
+++ b/deckhouse-controller/internal/nelm/client.go
@@ -294,6 +294,8 @@ type InstallOptions struct {
 
 	ResourcesLabels map[string]string // Labels to apply to all resources
 
+	TrackingOptions common.TrackingOptions
+
 	// OnTrackingEvent is an optional callback invoked with progress updates
 	// as Kubernetes resources are being tracked for readiness during install.
 	OnTrackingEvent func(name string, report progrep.ProgressReport)
@@ -362,11 +364,7 @@ func (c *Client) Install(ctx context.Context, namespace, releaseName string, opt
 			ValuesFiles: opts.ValuesPaths,
 			RootSetJSON: valuesSet,
 		},
-		TrackingOptions: common.TrackingOptions{
-			NoPodLogs:                    true,
-			NoFinalTracking:              true,
-			LegacyHelmCompatibleTracking: true,
-		},
+		TrackingOptions:        opts.TrackingOptions,
 		Chart:                  opts.Path,
 		DefaultChartName:       releaseName,
 		DefaultChartVersion:    "0.2.0",

--- a/deckhouse-controller/internal/packages/apps/app.go
+++ b/deckhouse-controller/internal/packages/apps/app.go
@@ -287,6 +287,11 @@ func (a *Application) GetInstance() string {
 	return a.instance
 }
 
+// GetPackage returns the application package name.
+func (a *Application) GetPackage() string {
+	return a.definition.Name
+}
+
 // GetNamespace returns the application namespace.
 func (a *Application) GetNamespace() string {
 	return a.namespace

--- a/deckhouse-controller/internal/packages/apps/app.go
+++ b/deckhouse-controller/internal/packages/apps/app.go
@@ -282,6 +282,11 @@ func BuildName(namespace, name string) string {
 	return fmt.Sprintf("%s.%s", namespace, name)
 }
 
+// GetInstance returns the application instance name.
+func (a *Application) GetInstance() string {
+	return a.instance
+}
+
 // GetNamespace returns the application namespace.
 func (a *Application) GetNamespace() string {
 	return a.namespace

--- a/deckhouse-controller/internal/packages/modules/module.go
+++ b/deckhouse-controller/internal/packages/modules/module.go
@@ -231,6 +231,11 @@ func (m *Module) GetName() string {
 	return m.name
 }
 
+// GetPackage returns the module package name.
+func (m *Module) GetPackage() string {
+	return m.definition.Name
+}
+
 // GetVersion return the package version
 func (m *Module) GetVersion() *semver.Version {
 	return m.version

--- a/deckhouse-controller/internal/packages/nelm/service.go
+++ b/deckhouse-controller/internal/packages/nelm/service.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"os"
 	"path/filepath"
 	"slices"
@@ -29,6 +30,7 @@ import (
 	addonutils "github.com/flant/addon-operator/pkg/utils"
 	klient "github.com/flant/kube-client/client"
 	"github.com/google/uuid"
+	"github.com/werf/nelm/pkg/common"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -246,7 +248,7 @@ func (s *Service) Delete(ctx context.Context, namespace, name string) error {
 // policy stops guarding them against manual edits.
 //
 // Returns ErrPackageNotHelm if the package doesn't contain a valid Helm chart.
-func (s *Service) Upgrade(ctx context.Context, namespace string, pkg Package) error {
+func (s *Service) Upgrade(ctx context.Context, namespace string, pkg Package, extraLabels map[string]string, trackingOptions common.TrackingOptions) error {
 	ctx, span := otel.Tracer(nelmServiceTracer).Start(ctx, "Upgrade")
 	defer span.End()
 
@@ -302,6 +304,8 @@ func (s *Service) Upgrade(ctx context.Context, namespace string, pkg Package) er
 		resourcesLabels[nelm.ReleaseLabelMaintenance] = ""
 	}
 
+	maps.Copy(resourcesLabels, extraLabels)
+
 	s.logger.Debug("render nelm chart",
 		slog.String("path", pkg.GetPath()),
 		slog.String("name", pkg.GetName()),
@@ -344,6 +348,7 @@ func (s *Service) Upgrade(ctx context.Context, namespace string, pkg Package) er
 	// Install or upgrade the release
 	err = s.client.Install(ctx, namespace, pkg.GetName(), nelm.InstallOptions{
 		OnTrackingEvent: s.status.UpdateTracking,
+		TrackingOptions: trackingOptions,
 		Path:            pkg.GetPath(),
 		ValuesPaths:     []string{valuesPath},
 		RootValues:      pkg.GetRuntimeValues(),

--- a/deckhouse-controller/internal/packages/nelm/service.go
+++ b/deckhouse-controller/internal/packages/nelm/service.go
@@ -224,6 +224,12 @@ func (s *Service) Delete(ctx context.Context, namespace, name string) error {
 	return s.client.Delete(ctx, namespace, name)
 }
 
+// UpgradeOptions holds options for upgrading a Helm release.
+type UpgradeOptions struct {
+	TrackingOptions common.TrackingOptions
+	ExtraLabels     map[string]string
+}
+
 // Upgrade installs or upgrades a Helm release for a package.
 //
 // Smart upgrade logic:
@@ -248,7 +254,7 @@ func (s *Service) Delete(ctx context.Context, namespace, name string) error {
 // policy stops guarding them against manual edits.
 //
 // Returns ErrPackageNotHelm if the package doesn't contain a valid Helm chart.
-func (s *Service) Upgrade(ctx context.Context, namespace string, pkg Package, extraLabels map[string]string, trackingOptions common.TrackingOptions) error {
+func (s *Service) Upgrade(ctx context.Context, namespace string, pkg Package, opts UpgradeOptions) error {
 	ctx, span := otel.Tracer(nelmServiceTracer).Start(ctx, "Upgrade")
 	defer span.End()
 
@@ -304,7 +310,7 @@ func (s *Service) Upgrade(ctx context.Context, namespace string, pkg Package, ex
 		resourcesLabels[nelm.ReleaseLabelMaintenance] = ""
 	}
 
-	maps.Copy(resourcesLabels, extraLabels)
+	maps.Copy(resourcesLabels, opts.ExtraLabels)
 
 	s.logger.Debug("render nelm chart",
 		slog.String("path", pkg.GetPath()),
@@ -348,7 +354,7 @@ func (s *Service) Upgrade(ctx context.Context, namespace string, pkg Package, ex
 	// Install or upgrade the release
 	err = s.client.Install(ctx, namespace, pkg.GetName(), nelm.InstallOptions{
 		OnTrackingEvent: s.status.UpdateTracking,
-		TrackingOptions: trackingOptions,
+		TrackingOptions: opts.TrackingOptions,
 		Path:            pkg.GetPath(),
 		ValuesPaths:     []string{valuesPath},
 		RootValues:      pkg.GetRuntimeValues(),

--- a/deckhouse-controller/internal/packages/runtime/tasks/run/task.go
+++ b/deckhouse-controller/internal/packages/runtime/tasks/run/task.go
@@ -23,7 +23,7 @@ import (
 	addontypes "github.com/flant/addon-operator/pkg/hook/types"
 	addonutils "github.com/flant/addon-operator/pkg/utils"
 	shtypes "github.com/flant/shell-operator/pkg/hook/types"
-	"github.com/werf/nelm/pkg/common"
+	nelmcommon "github.com/werf/nelm/pkg/common"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -55,6 +55,7 @@ type packageI interface {
 	RunHooksByBinding(ctx context.Context, binding shtypes.BindingType) error
 }
 
+// application interface abstracts application operations needed for the run cycle.
 type application interface {
 	GetInstance() string
 }
@@ -67,7 +68,7 @@ type nelmI interface {
 	// ResumeMonitor restarts monitoring after run cycle completes.
 	ResumeMonitor(name string)
 	// Upgrade installs or upgrades the Helm release.
-	Upgrade(ctx context.Context, namespace string, pkg nelm.Package, extraLabels map[string]string, trackingOptions common.TrackingOptions) error
+	Upgrade(ctx context.Context, namespace string, pkg nelm.Package, extraLabels map[string]string, trackingOptions nelmcommon.TrackingOptions) error
 }
 
 // task executes the main package lifecycle: hooks and Helm release management.
@@ -149,13 +150,14 @@ func (t *task) runPackage(ctx context.Context) error {
 	}
 
 	// tracking options for the release
-	trackingOpts := common.TrackingOptions{
+	trackingOpts := nelmcommon.TrackingOptions{
 		NoPodLogs: true,
 	}
 
 	if app, ok := t.pkg.(application); ok {
 		extraLabels[instanceLabel] = app.GetInstance()
 	} else {
+		// options needed for modules
 		trackingOpts.NoFinalTracking = true
 		trackingOpts.LegacyHelmCompatibleTracking = true
 	}

--- a/deckhouse-controller/internal/packages/runtime/tasks/run/task.go
+++ b/deckhouse-controller/internal/packages/runtime/tasks/run/task.go
@@ -23,6 +23,7 @@ import (
 	addontypes "github.com/flant/addon-operator/pkg/hook/types"
 	addonutils "github.com/flant/addon-operator/pkg/utils"
 	shtypes "github.com/flant/shell-operator/pkg/hook/types"
+	"github.com/werf/nelm/pkg/common"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -35,6 +36,9 @@ import (
 
 const (
 	taskTracer = "package-run"
+
+	packageLabel  = "packages.deckhouse.io/package"
+	instanceLabel = "packages.deckhouse.io/instance-name"
 )
 
 // packageI abstracts package operations needed for the run cycle.
@@ -51,6 +55,10 @@ type packageI interface {
 	RunHooksByBinding(ctx context.Context, binding shtypes.BindingType) error
 }
 
+type application interface {
+	GetInstance() string
+}
+
 // nelmI abstracts Helm operations and release monitoring.
 type nelmI interface {
 	HasMonitor(name string) bool
@@ -59,7 +67,7 @@ type nelmI interface {
 	// ResumeMonitor restarts monitoring after run cycle completes.
 	ResumeMonitor(name string)
 	// Upgrade installs or upgrades the Helm release.
-	Upgrade(ctx context.Context, namespace string, pkg nelm.Package) error
+	Upgrade(ctx context.Context, namespace string, pkg nelm.Package, extraLabels map[string]string, trackingOptions common.TrackingOptions) error
 }
 
 // task executes the main package lifecycle: hooks and Helm release management.
@@ -135,8 +143,25 @@ func (t *task) runPackage(ctx context.Context) error {
 		return err
 	}
 
+	// labels that will be applied to the release resources
+	extraLabels := map[string]string{
+		packageLabel: t.pkg.GetName(),
+	}
+
+	// tracking options for the release
+	trackingOpts := common.TrackingOptions{
+		NoPodLogs: true,
+	}
+
+	if app, ok := t.pkg.(application); ok {
+		extraLabels[instanceLabel] = app.GetInstance()
+	} else {
+		trackingOpts.NoFinalTracking = true
+		trackingOpts.LegacyHelmCompatibleTracking = true
+	}
+
 	t.logger.Debug("run nelm upgrade")
-	if err := t.nelm.Upgrade(ctx, t.namespace, t.pkg); err != nil && !errors.Is(err, nelm.ErrPackageNotHelm) {
+	if err := t.nelm.Upgrade(ctx, t.namespace, t.pkg, extraLabels, trackingOpts); err != nil && !errors.Is(err, nelm.ErrPackageNotHelm) {
 		span.SetStatus(codes.Error, err.Error())
 		t.status.HandleError(t.pkg.GetName(), status.ConditionManifestsApplied, status.NewError("ManifestsApplyFailed", err))
 		return err
@@ -153,7 +178,7 @@ func (t *task) runPackage(ctx context.Context) error {
 	}
 
 	if oldChecksum != t.pkg.GetValuesChecksum() {
-		if err := t.nelm.Upgrade(ctx, t.namespace, t.pkg); err != nil && !errors.Is(err, nelm.ErrPackageNotHelm) {
+		if err := t.nelm.Upgrade(ctx, t.namespace, t.pkg, extraLabels, trackingOpts); err != nil && !errors.Is(err, nelm.ErrPackageNotHelm) {
 			span.SetStatus(codes.Error, err.Error())
 			t.status.HandleError(t.pkg.GetName(), status.ConditionManifestsApplied, status.NewError("ManifestsApplyFailed", err))
 			return err

--- a/deckhouse-controller/internal/packages/runtime/tasks/run/task.go
+++ b/deckhouse-controller/internal/packages/runtime/tasks/run/task.go
@@ -38,12 +38,13 @@ const (
 	taskTracer = "package-run"
 
 	packageLabel  = "packages.deckhouse.io/package"
-	instanceLabel = "packages.deckhouse.io/instance-name"
+	instanceLabel = "packages.deckhouse.io/instance"
 )
 
 // packageI abstracts package operations needed for the run cycle.
 type packageI interface {
 	GetName() string
+	GetPackage() string
 	// GetValuesChecksum returns hash of current values to detect changes by hooks.
 	GetValuesChecksum() string
 	GetPath() string
@@ -146,7 +147,7 @@ func (t *task) runPackage(ctx context.Context) error {
 
 	opts := nelm.UpgradeOptions{
 		ExtraLabels: map[string]string{
-			packageLabel: t.pkg.GetName(),
+			packageLabel: t.pkg.GetPackage(),
 		},
 		TrackingOptions: nelmcommon.TrackingOptions{
 			NoPodLogs: true,

--- a/deckhouse-controller/internal/packages/runtime/tasks/run/task.go
+++ b/deckhouse-controller/internal/packages/runtime/tasks/run/task.go
@@ -68,7 +68,7 @@ type nelmI interface {
 	// ResumeMonitor restarts monitoring after run cycle completes.
 	ResumeMonitor(name string)
 	// Upgrade installs or upgrades the Helm release.
-	Upgrade(ctx context.Context, namespace string, pkg nelm.Package, extraLabels map[string]string, trackingOptions nelmcommon.TrackingOptions) error
+	Upgrade(ctx context.Context, namespace string, pkg nelm.Package, opts nelm.UpgradeOptions) error
 }
 
 // task executes the main package lifecycle: hooks and Helm release management.
@@ -144,26 +144,25 @@ func (t *task) runPackage(ctx context.Context) error {
 		return err
 	}
 
-	// labels that will be applied to the release resources
-	extraLabels := map[string]string{
-		packageLabel: t.pkg.GetName(),
-	}
-
-	// tracking options for the release
-	trackingOpts := nelmcommon.TrackingOptions{
-		NoPodLogs: true,
+	opts := nelm.UpgradeOptions{
+		ExtraLabels: map[string]string{
+			packageLabel: t.pkg.GetName(),
+		},
+		TrackingOptions: nelmcommon.TrackingOptions{
+			NoPodLogs: true,
+		},
 	}
 
 	if app, ok := t.pkg.(application); ok {
-		extraLabels[instanceLabel] = app.GetInstance()
+		opts.ExtraLabels[instanceLabel] = app.GetInstance()
 	} else {
 		// options needed for modules
-		trackingOpts.NoFinalTracking = true
-		trackingOpts.LegacyHelmCompatibleTracking = true
+		opts.TrackingOptions.NoFinalTracking = true
+		opts.TrackingOptions.LegacyHelmCompatibleTracking = true
 	}
 
 	t.logger.Debug("run nelm upgrade")
-	if err := t.nelm.Upgrade(ctx, t.namespace, t.pkg, extraLabels, trackingOpts); err != nil && !errors.Is(err, nelm.ErrPackageNotHelm) {
+	if err := t.nelm.Upgrade(ctx, t.namespace, t.pkg, opts); err != nil && !errors.Is(err, nelm.ErrPackageNotHelm) {
 		span.SetStatus(codes.Error, err.Error())
 		t.status.HandleError(t.pkg.GetName(), status.ConditionManifestsApplied, status.NewError("ManifestsApplyFailed", err))
 		return err
@@ -180,7 +179,7 @@ func (t *task) runPackage(ctx context.Context) error {
 	}
 
 	if oldChecksum != t.pkg.GetValuesChecksum() {
-		if err := t.nelm.Upgrade(ctx, t.namespace, t.pkg, extraLabels, trackingOpts); err != nil && !errors.Is(err, nelm.ErrPackageNotHelm) {
+		if err := t.nelm.Upgrade(ctx, t.namespace, t.pkg, opts); err != nil && !errors.Is(err, nelm.ErrPackageNotHelm) {
 			span.SetStatus(codes.Error, err.Error())
 			t.status.HandleError(t.pkg.GetName(), status.ConditionManifestsApplied, status.NewError("ManifestsApplyFailed", err))
 			return err


### PR DESCRIPTION
## Description

Nelm tracking options were hardcoded inside `nelm.Client.Install`, so every release — module or
application — was installed with:

```go
TrackingOptions{
    NoPodLogs:                    true,
    NoFinalTracking:              true,
    LegacyHelmCompatibleTracking: true,
}
```

`NoFinalTracking: true` disables the phase that waits for resources to reach readiness, and
`LegacyHelmCompatibleTracking: true` narrows tracking to Job hooks only. That is the behaviour
modules inherited from the addon-operator era and need to keep, but it also meant applications
produced almost no tracking events — so the progress that `status.UpdateTracking` writes into the
`ManifestsApplied` condition never actually materialised for them.

This PR makes tracking a decision of the caller instead of a constant:

* `nelm.InstallOptions` gains a `TrackingOptions` field, and `Client.Install` passes it through
  instead of building its own.
* `packages/nelm.Service.Upgrade` takes a new `UpgradeOptions` struct (`TrackingOptions`,
  `ExtraLabels`) and forwards both — the labels merged into the release's `ResourcesLabels`.
* The `run` task builds those options per package kind and passes the same value to both of its
  `Upgrade` call sites (the initial upgrade and the re-upgrade after hooks change values):
  * **applications** — `NoPodLogs: true` only, so final tracking runs over all resources and real
    readiness progress reaches the `ManifestsApplied` condition;
  * **modules** — the previous legacy triple, so their behaviour is unchanged.

The kind is determined by a type assertion against a local one-method `application` interface
(`GetInstance() string`), which today only `*Application` satisfies.

Additionally, release resources are now stamped with two labels:

* `packages.deckhouse.io/package` — the package name, for every package;
* `packages.deckhouse.io/instance` — the application instance name, applications only.

To supply them, `GetPackage()` is added to both `Application` and `Module` (and to the `run` task's
`packageI` interface), and `Application.GetInstance()` is exported.

### Impact

Labels are applied via nelm's `ExtraLabels` (`NewExtraMetadataPatcher`), which patches top-level
resource metadata only — pod templates are untouched, so **no workload restarts**. However, the
labels are part of the rendered manifests that produce the upgrade checksum, so rolling out this
change re-applies **every** module and application release exactly once. No critical component is
restarted by it.

## Why do we need it, and what problem does it solve?

Applications had no usable deployment progress or readiness signal: with final tracking disabled,
`OnTrackingEvent` fired for practically nothing, so an application's `ManifestsApplied` condition
never reflected what was happening in the cluster. Applications are the flow where that feedback
matters — they are user-installed workloads whose rollout the user watches — while modules still
depend on Helm-compatible tracking semantics.

Hardcoding one tracking policy for both flows made it impossible to serve them differently. Moving
the options to the call site fixes application tracking without changing module behaviour, and the
new resource labels make a release's resources attributable to the package and application instance
that own them.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Fix nelm tracking for applications and modules.
impact_level: low
```
