### PR TITLE
[cni-cilium] Tolerate ErrRestrictedKernel in Cilium eBPF probe

### DIFF
--- a/modules/021-cni-cilium/images/bin-cilium/patches/021-ebpf-api-compat.patch
+++ b/modules/021-cni-cilium/images/bin-cilium/patches/021-ebpf-api-compat.patch
@@ -13,3 +13,18 @@ index d961dae..48f32e4 100644
  		}
  
  		if err := setVariable(v, value); err != nil {
+diff --git a/pkg/datapath/linux/probes/probes.go b/pkg/datapath/linux/probes/probes.go
+index dcf0950d..dbfdd2ef 100644
+--- a/pkg/datapath/linux/probes/probes.go
++++ b/pkg/datapath/linux/probes/probes.go
+@@ -671,7 +671,9 @@ func HaveDeadCodeElim() error {
+ 		return fmt.Errorf("get prog info: %w", err)
+ 	}
+ 	infoInst, err := info.Instructions()
+-	if err != nil {
++	if errors.Is(err, ebpf.ErrRestrictedKernel) {
++		return nil
++	} else if err != nil {
+ 		return fmt.Errorf("get instructions: %w", err)
+ 	}
+

--- a/modules/021-cni-cilium/images/bin-cilium/patches/README.md
+++ b/modules/021-cni-cilium/images/bin-cilium/patches/README.md
@@ -139,9 +139,41 @@ in). Cilium v1.17.17 still pins ebpf v0.17.1 and calls `v.MapName()` in
 live in the `.rodata.config` section, so the bump alone breaks compilation.
 
 The patch replaces the two `v.MapName()` calls with `v.SectionName`, which
-returns the same value (the underlying map/section name). No datapath or other
-behavior changes: a full `go build ./...` of Cilium v1.17.17 with ebpf v0.22.0
-has this single call site as its only incompatibility.
+returns the same value (the underlying map/section name).
+
+The second hunk (`pkg/datapath/linux/probes/probes.go`) is a runtime
+compatibility fix for the same bump, backported from upstream commit
+`36f2b4a12` ("datapath/linux/probes: Tolerate ErrRestrictedKernel"). On nodes
+where BPF JIT hardening is on (`net.core.bpf_jit_harden=2`) together with
+restricted kernel pointers (`kernel.kptr_restrict=2`), `BPF_OBJ_GET_INFO_BY_FD`
+returns no xlated instructions. ebpf v0.20.0 started reporting this as
+`ebpf.ErrRestrictedKernel` (before, the caller silently got a zeroed buffer),
+so `HaveDeadCodeElim()` — which loads a test program and inspects its final
+instructions — began failing, and `CheckRequirements()` aborted agent startup
+with `requirements failed: Require support for dead code elimination (Linux 5.1
+or newer)`. The patch tolerates `ErrRestrictedKernel` and treats the probe as
+passed, restoring the pre-bump behavior. Deckhouse itself sets both sysctls in
+the CSE edition (`candi/bashible/common-steps/all/041_configure_sysctl_tuner.sh.tpl`),
+hence the failure only showed up on part of the clusters. Upstream's other two
+call sites (`HaveBPFJIT`, `verifyUnusedMaps`) do not exist in v1.17.17, and no
+other place in v1.17.17 reads xlated instructions, JIT size or BTF func/line
+info from `ProgramInfo`, so this single probe is the whole runtime impact.
+
+Upstream chain, in order:
+
+1. ebpf introduces `ErrRestrictedKernel` (in v0.20.0):
+   <https://github.com/cilium/ebpf/pull/1858>, commit
+   <https://github.com/cilium/ebpf/commit/1bfe0bc241d275b16f7ddaa9c4a1230106571e39>
+2. ebpf queries `xlated_prog_insns` in a separate syscall so the remaining info
+   survives on hardened kernels (in v0.21.0), commit
+   <https://github.com/cilium/ebpf/commit/5ac1d5a9f065adef5726b3969da8ef3a1626c603>
+3. Cilium hits the same probe failures on GKE COS (which also enables JIT
+   hardening) and reverts its own ebpf bump ("unbreak GKE workflows"):
+   <https://github.com/cilium/cilium/pull/42327>
+4. Cilium forward-fixes the probes and re-lands the bump (the commit backported
+   here): <https://github.com/cilium/cilium/pull/42361>, commit
+   <https://github.com/cilium/cilium/commit/36f2b4a127f07985a79b984cd603de3cbd9c1d0f>
 
 **Remove this patch when upgrading to a Cilium version that already targets
-ebpf >= v0.21.0**, where `applyConstants()` no longer uses the removed method.
+ebpf >= v0.21.0**, where `applyConstants()` no longer uses the removed method
+and the probes already tolerate `ErrRestrictedKernel`.

--- a/modules/021-cni-cilium/images/bin-cilium/patches/README.md
+++ b/modules/021-cni-cilium/images/bin-cilium/patches/README.md
@@ -129,50 +129,40 @@ already present (it was never backported to 1.17.x, up to and including v1.17.18
 
 ## 021-ebpf-api-compat.patch
 
-Adapts Cilium's eBPF loader to the `github.com/cilium/ebpf` v0.22.0 API, which
-`000-go-mod.patch` bumps to fix CVE-2026-10722 (the fix is only available in
-ebpf >= v0.22.0). ebpf v0.21.0 removed the `(*ebpf.VariableSpec).MapName()`
-method and replaced the previously private map reference with the exported
-`VariableSpec.SectionName` field (the section name a variable was allocated
-in). Cilium v1.17.17 still pins ebpf v0.17.1 and calls `v.MapName()` in
-`applyConstants()` (`pkg/bpf/collection.go`) to assert that config variables
-live in the `.rodata.config` section, so the bump alone breaks compilation.
+Two fixes Cilium v1.17.17 needs to work with `github.com/cilium/ebpf` v0.22.0,
+which `000-go-mod.patch` bumps from v0.17.1 to fix CVE-2026-10722 (fixed only in
+ebpf >= v0.22.0).
 
-The patch replaces the two `v.MapName()` calls with `v.SectionName`, which
-returns the same value (the underlying map/section name).
+1. Compile fix (`pkg/bpf/collection.go`): ebpf v0.21.0 removed
+   `(*ebpf.VariableSpec).MapName()` in favour of the exported
+   `VariableSpec.SectionName` (same value). `applyConstants()` called it to assert
+   config variables live in `.rodata.config`; both calls are replaced.
 
-The second hunk (`pkg/datapath/linux/probes/probes.go`) is a runtime
-compatibility fix for the same bump, backported from upstream commit
-`36f2b4a12` ("datapath/linux/probes: Tolerate ErrRestrictedKernel"). On nodes
-where BPF JIT hardening is on (`net.core.bpf_jit_harden=2`) together with
-restricted kernel pointers (`kernel.kptr_restrict=2`), `BPF_OBJ_GET_INFO_BY_FD`
-returns no xlated instructions. ebpf v0.20.0 started reporting this as
-`ebpf.ErrRestrictedKernel` (before, the caller silently got a zeroed buffer),
-so `HaveDeadCodeElim()` — which loads a test program and inspects its final
-instructions — began failing, and `CheckRequirements()` aborted agent startup
-with `requirements failed: Require support for dead code elimination (Linux 5.1
-or newer)`. The patch tolerates `ErrRestrictedKernel` and treats the probe as
-passed, restoring the pre-bump behavior. Deckhouse itself sets both sysctls in
-the CSE edition (`candi/bashible/common-steps/all/041_configure_sysctl_tuner.sh.tpl`),
-hence the failure only showed up on part of the clusters. Upstream's other two
-call sites (`HaveBPFJIT`, `verifyUnusedMaps`) do not exist in v1.17.17, and no
-other place in v1.17.17 reads xlated instructions, JIT size or BTF func/line
-info from `ProgramInfo`, so this single probe is the whole runtime impact.
+2. Runtime fix (`pkg/datapath/linux/probes/probes.go`), backported from upstream
+   `36f2b4a12`: with `net.core.bpf_jit_harden=2` the kernel blinds constants even
+   for privileged loaders and then hides xlated instructions from
+   `BPF_OBJ_GET_INFO_BY_FD`, unless the caller may read kernel pointers
+   (`kallsyms_show_value()`: `kptr_restrict=0` *and* `perf_event_paranoid<=1`, or
+   `CAP_SYSLOG` — the agent has neither). ebpf v0.20.0 turned that previously
+   silent empty response into `ebpf.ErrRestrictedKernel`, so `HaveDeadCodeElim()`
+   started failing and `CheckRequirements()` aborted agent startup with
+   `requirements failed: Require support for dead code elimination (Linux 5.1 or
+   newer)`. The probe now tolerates the error, as it effectively did before the
+   bump. Deckhouse sets `bpf_jit_harden=2` in the CSE edition
+   (`candi/bashible/common-steps/all/041_configure_sysctl_tuner.sh.tpl`) and some
+   hardened distros set it themselves, hence only part of the clusters broke
+   (seen with `kptr_restrict` both 2 and 0). Upstream's two other call sites
+   (`HaveBPFJIT`, `verifyUnusedMaps`) do not exist in v1.17.17, and nothing else
+   there reads xlated/JIT/BTF info from `ProgramInfo`.
 
-Upstream chain, in order:
-
-1. ebpf introduces `ErrRestrictedKernel` (in v0.20.0):
-   <https://github.com/cilium/ebpf/pull/1858>, commit
-   <https://github.com/cilium/ebpf/commit/1bfe0bc241d275b16f7ddaa9c4a1230106571e39>
-2. ebpf queries `xlated_prog_insns` in a separate syscall so the remaining info
-   survives on hardened kernels (in v0.21.0), commit
-   <https://github.com/cilium/ebpf/commit/5ac1d5a9f065adef5726b3969da8ef3a1626c603>
-3. Cilium hits the same probe failures on GKE COS (which also enables JIT
-   hardening) and reverts its own ebpf bump ("unbreak GKE workflows"):
-   <https://github.com/cilium/cilium/pull/42327>
-4. Cilium forward-fixes the probes and re-lands the bump (the commit backported
-   here): <https://github.com/cilium/cilium/pull/42361>, commit
-   <https://github.com/cilium/cilium/commit/36f2b4a127f07985a79b984cd603de3cbd9c1d0f>
+Upstream chain: ebpf adds `ErrRestrictedKernel`
+(<https://github.com/cilium/ebpf/pull/1858>, v0.20.0) -> ebpf queries xlated
+instructions separately so the rest of the info survives
+(<https://github.com/cilium/ebpf/commit/5ac1d5a9f065adef5726b3969da8ef3a1626c603>,
+v0.21.0) -> Cilium reverts its own bump over these probe failures on GKE COS
+(<https://github.com/cilium/cilium/pull/42327>) -> Cilium forward-fixes the probes
+and re-lands the bump (<https://github.com/cilium/cilium/pull/42361>,
+<https://github.com/cilium/cilium/commit/36f2b4a127f07985a79b984cd603de3cbd9c1d0f>).
 
 **Remove this patch when upgrading to a Cilium version that already targets
 ebpf >= v0.21.0**, where `applyConstants()` no longer uses the removed method


### PR DESCRIPTION
## Description

Extend the ebpf API compatibility patch for the `bin-cilium` image with a runtime fix for the `HaveDeadCodeElim()` probe.

On nodes where BPF JIT hardening (`net.core.bpf_jit_harden=2`) is enabled together with restricted kernel pointers (`kernel.kptr_restrict=2`), the `BPF_OBJ_GET_INFO_BY_FD` syscall returns no xlated instructions. Starting from ebpf v0.20.0 this is reported as `ebpf.ErrRestrictedKernel` instead of a silently zeroed buffer. As a result, `HaveDeadCodeElim()` started failing and `CheckRequirements()` aborted `cilium-agent` startup on the affected nodes.

The patch treats `ErrRestrictedKernel` as a passed probe, restoring the pre-bump behavior. The fix is backported from upstream commit `36f2b4a12`. Only `HaveDeadCodeElim()` reads xlated instructions in Cilium v1.17.17, so this single probe is the full scope of the runtime change.

This change modifies the build patch of the `bin-cilium` image, so updating triggers a rebuild and a restart of `cilium-agent` pods on all nodes.

## Why do we need it, and what problem does it solve?

Affected clusters cannot start `cilium-agent` after the ebpf bump: the agent aborts with `requirements failed: Require support for dead code elimination (Linux 5.1 or newer)`. Both sysctls that trigger the failure are set by Deckhouse itself in the CSE edition (`candi/bashible/common-steps/all/041_configure_sysctl_tuner.sh.tpl`), so the problem appears on part of the clusters and breaks cluster networking there. This patch restores agent startup on those nodes.

## Why do we need it in the patch release (if we do)?

The change fixes a regression that prevents `cilium-agent` from starting on clusters with BPF JIT hardening enabled, which breaks pod networking. Users on the affected configuration need the fix without waiting for the next feature release.

## Checklist

- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cni-cilium
type: fix
summary: Restore cilium-agent startup on nodes with BPF JIT hardening enabled by tolerating ErrRestrictedKernel in the eBPF probe.
impact: cilium-agent pods are restarted on all nodes.
impact_level: high
```