### PR TITLE
[docs] Add Markdown MIME type and charset support

### DIFF
--- a/docs/documentation/.werf/nginx.conf
+++ b/docs/documentation/.werf/nginx.conf
@@ -12,6 +12,13 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
+    # Add MIME type for ES modules (.mjs files)
+    # and for the per-page Markdown of the AI export (.md files).
+    types {
+      application/javascript mjs;
+      text/markdown md;
+    }
+
     log_format json_combined escape=json '{ "time_local": "$time_local", '
         '"host": "$host", '
         '"remote_addr": "$remote_addr", '
@@ -55,6 +62,10 @@ http {
         error_page 403 404 /$lang/404.html;
 
         charset utf-8;
+        # `charset` only appends the encoding to the types listed here, and the
+        # default list has no text/markdown: the per-page Markdown of the AI
+        # export would be served without a charset and a browser would guess it.
+        charset_types text/html text/xml text/plain text/vnd.wap.wml application/javascript application/rss+xml text/markdown;
         access_log     /dev/stdout json_combined;
 
         location = /healthz {

--- a/docs/site/.helm/templates/10-cm-frontend.yaml
+++ b/docs/site/.helm/templates/10-cm-frontend.yaml
@@ -19,8 +19,10 @@ data:
       default_type  application/octet-stream;
 
       # Add MIME type for ES modules (.mjs files)
+      # and for the per-page Markdown of the AI export (.md files).
       types {
         application/javascript mjs;
+        text/markdown md;
       }
 
       client_body_temp_path /tmp/client_temp;
@@ -93,6 +95,10 @@ data:
         proxy_intercept_errors on;
 
         charset utf-8;
+        # `charset` only appends the encoding to the types listed here, and the
+        # default list has no text/markdown: the per-page Markdown of the AI
+        # export would be served without a charset and a browser would guess it.
+        charset_types text/html text/xml text/plain text/vnd.wap.wml application/javascript application/rss+xml text/markdown;
         access_log     /dev/stdout json_combined;
 
         location /link_test_report.txt {


### PR DESCRIPTION
## Description
- Register text/markdown in the custom types block of both site and documentation nginx configurations so that per-page Markdown responses for the AI export are served with the correct content type instead of the default octet-stream fallback.
- Extend charset_types directive to include text/markdown, ensuring the UTF-8 encoding declaration is appended to Markdown responses and browsers do not fall back to heuristic charset detection.

Ref: https://github.com/deckhouse/deckhouse/pull/22604

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Add Markdown MIME type and charset support.
impact_level: low
```
