### PR TITLE
[deckhouse] wait until nelm deletes resources

### DIFF
--- a/deckhouse-controller/internal/packages/runtime/apps.go
+++ b/deckhouse-controller/internal/packages/runtime/apps.go
@@ -16,6 +16,7 @@ package runtime
 
 import (
 	"context"
+	"log/slog"
 	"path/filepath"
 	"slices"
 
@@ -152,7 +153,13 @@ func (r *Runtime) loadApp(ctx context.Context, repo registry.Remote, packagePath
 	return app.GetVersion().String(), nil
 }
 
-// RemoveApp removes an application and cancels all its running operations.
+// RemoveApp removes an application, cancels all its running operations and reports whether the
+// teardown has finished. The caller polls it and holds the Application's finalizer until it
+// returns true, so the CR outlives the Helm release it owns.
+//
+// It is idempotent by contract: a call made while the teardown runs must not re-issue
+// EventRemove, because that cancels the whole context tree (lifecycle.Package.newContext) and
+// would restart the very uninstall the caller is waiting for.
 //
 // After the undeploy task succeeds, a cleanup goroutine removes the
 // Store entry and stops the queue. The goroutine is necessary because
@@ -160,12 +167,25 @@ func (r *Runtime) loadApp(ctx context.Context, repo registry.Remote, packagePath
 // within the queue's own processing loop would deadlock on WaitGroup.
 //
 // Store.Delete has a state guard: if UpdateApp re-created the package
-// between undeploy and cleanup, Delete is a no-op (version != "").
-func (r *Runtime) RemoveApp(namespace, instance string) {
+// between undeploy and cleanup, Delete is a no-op (version != "") and the removal reports
+// unfinished again, now for the re-created generation.
+func (r *Runtime) RemoveApp(namespace, instance string) bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	name := apps.BuildName(namespace, instance)
+
+	switch r.packages.RemovalState(name) {
+	case lifecycle.RemovalDone:
+		// nothing is tracked under the name: the teardown finished, or never had to run
+		return true
+
+	case lifecycle.RemovalInFlight:
+		r.logger.Debug("app removal is still in flight", slog.String("name", name))
+
+		return false
+	}
+
 	r.scheduler.RemoveNode(name)
 
 	// A removed application no longer reconciles anything, so drop its maintenance gauge.
@@ -173,7 +193,7 @@ func (r *Runtime) RemoveApp(namespace, instance string) {
 
 	ctx := r.packages.HandleEvent(lifecycle.EventRemove, name)
 	if ctx == nil {
-		return
+		return true
 	}
 
 	if pkg := r.apps[name]; pkg != nil {
@@ -194,4 +214,6 @@ func (r *Runtime) RemoveApp(namespace, instance string) {
 	})
 
 	r.queueService.Enqueue(ctx, name, taskundeploy.NewAppTask(name, r.appDeployer, r.logger), cleanup)
+
+	return false
 }

--- a/deckhouse-controller/internal/packages/runtime/apps.go
+++ b/deckhouse-controller/internal/packages/runtime/apps.go
@@ -33,6 +33,7 @@ import (
 	taskdisable "github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/runtime/tasks/disable"
 	taskload "github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/runtime/tasks/load"
 	taskundeploy "github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/runtime/tasks/undeploy"
+	taskuninstall "github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/runtime/tasks/uninstall"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/status"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/queue"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/registry"
@@ -166,9 +167,9 @@ func (r *Runtime) loadApp(ctx context.Context, repo registry.Remote, packagePath
 // queueService.Remove stops the queue — calling it synchronously from
 // within the queue's own processing loop would deadlock on WaitGroup.
 //
-// Store.Delete has a state guard: if UpdateApp re-created the package
-// between undeploy and cleanup, Delete is a no-op (version != "") and the removal reports
-// unfinished again, now for the re-created generation.
+// Store.Delete has a state guard: if UpdateApp re-created the package between undeploy and cleanup,
+// Update cleared the removal marker, so Delete is a no-op and removal reports unfinished again for
+// the re-created generation.
 func (r *Runtime) RemoveApp(namespace, instance string) bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -198,6 +199,9 @@ func (r *Runtime) RemoveApp(namespace, instance string) bool {
 
 	if pkg := r.apps[name]; pkg != nil {
 		r.queueService.Enqueue(ctx, name, taskdisable.NewTask(pkg, pkg.GetNamespace(), false, r.nelmService, r.queueService, r.logger))
+	} else {
+		// A failed Load may roll the instance out of r.apps while the previous release is still live.
+		r.queueService.Enqueue(ctx, name, taskuninstall.NewTask(name, namespace, r.nelmService, r.logger))
 	}
 
 	cleanup := queue.WithOnDone(func() {

--- a/deckhouse-controller/internal/packages/runtime/lifecycle/lifecycle.go
+++ b/deckhouse-controller/internal/packages/runtime/lifecycle/lifecycle.go
@@ -51,6 +51,7 @@ type Package struct {
 	settingsVersion int               // schema version of pending settings (from ModuleConfig.Spec.Version)
 	settings        addonutils.Values // pending settings, updated by Update, consumed by GetPendingSettings
 	maintenance     string            // pending maintenance mode, consumed by GetPendingMaintenance
+	removing        bool              // EventRemove was issued and its teardown has not finished
 
 	ctx    context.Context    // root context, cancelled on version change or remove
 	cancel context.CancelFunc // cancels root and all children

--- a/deckhouse-controller/internal/packages/runtime/lifecycle/store.go
+++ b/deckhouse-controller/internal/packages/runtime/lifecycle/store.go
@@ -38,12 +38,16 @@ func NewStore() *Store {
 }
 
 // NeedUpdate reports whether the package needs processing: true if the package
-// is new, the version changed, the settings checksum differs, the settings
-// schema version changed, or the maintenance mode changed.
+// is new or being removed, the version changed, the settings checksum differs,
+// the settings schema version changed, or the maintenance mode changed.
 // Used as a fast-path check before the more expensive Update call.
 func (s *Store) NeedUpdate(name, version, checksum string, settingsVersion int, maintenance string) bool {
 	pkg, ok := s.packages[name]
 	if !ok {
+		return true
+	}
+
+	if pkg.removing {
 		return true
 	}
 
@@ -71,6 +75,7 @@ func (s *Store) NeedUpdate(name, version, checksum string, settingsVersion int, 
 // Returns a new root context (EventUpdate) when:
 //  1. Package not in store → creates entry, returns root context
 //  2. Version differs → cancels all in-flight tasks, returns new root context
+//  3. Package is being removed → cancels teardown and starts the re-created generation
 //
 // Returns nil when only settings, settingsVersion or maintenance changed (no new
 // context needed — the new values are stored and will be picked up by the scheduler
@@ -94,11 +99,12 @@ func (s *Store) Update(name, version string, settingsVersion int, settings addon
 		return ctx
 	}
 
-	if pkg.version != version {
+	if pkg.removing || pkg.version != version {
 		pkg.version = version
 		pkg.settingsVersion = settingsVersion
 		pkg.settings = settings
 		pkg.maintenance = maintenance
+		pkg.removing = false
 
 		ctx := pkg.newContext(EventUpdate)
 		return ctx
@@ -155,10 +161,15 @@ func (s *Store) UpdateSettings(name string, settingsVersion int, settings addonu
 // For EventRemove: clears version and settings before renewing context, so a
 // subsequent Update sees the package as new (enabling re-create after remove).
 //
-// Returns nil if the package doesn't exist in the store.
+// Returns nil if the package doesn't exist in the store, or if EventSchedule
+// arrives after removal has started and must not supersede teardown.
 func (s *Store) HandleEvent(event int, name string) context.Context {
 	pkg, ok := s.packages[name]
 	if !ok {
+		return nil
+	}
+
+	if event == EventSchedule && pkg.removing {
 		return nil
 	}
 
@@ -167,6 +178,7 @@ func (s *Store) HandleEvent(event int, name string) context.Context {
 		pkg.settingsVersion = 0
 		pkg.settings = make(addonutils.Values)
 		pkg.maintenance = ""
+		pkg.removing = true
 	}
 
 	return pkg.newContext(event)
@@ -200,15 +212,15 @@ const (
 	RemovalInFlight
 )
 
-// RemovalState reports the teardown state of a package. A cleared version is what marks a removal
-// as already issued — the same signal Delete guards on — so callers can wait instead of re-issuing.
+// RemovalState reports the teardown state of a package. The explicit removal marker lets callers
+// wait instead of re-issuing EventRemove, independently of whether the package version is empty.
 func (s *Store) RemovalState(name string) RemovalState {
 	pkg, ok := s.packages[name]
 	if !ok {
 		return RemovalDone
 	}
 
-	if pkg.version == "" {
+	if pkg.removing {
 		return RemovalInFlight
 	}
 
@@ -216,15 +228,14 @@ func (s *Store) RemovalState(name string) RemovalState {
 }
 
 // Delete removes a package entry from the store if it still exists and is in
-// the removed state (version cleared by HandleEvent(EventRemove)).
+// the removed state set by HandleEvent(EventRemove).
 // Returns true if the entry was deleted.
 //
-// Safe against re-creation races: if Update has already set a new version
-// between the remove and this cleanup, the version is non-empty and Delete
-// returns false, preserving the re-created entry.
+// Safe against re-creation races: Update clears the removal marker before
+// this cleanup, so Delete returns false and preserves the re-created entry.
 func (s *Store) Delete(name string) bool {
 	pkg, ok := s.packages[name]
-	if !ok || pkg.version != "" {
+	if !ok || !pkg.removing {
 		return false
 	}
 

--- a/deckhouse-controller/internal/packages/runtime/lifecycle/store.go
+++ b/deckhouse-controller/internal/packages/runtime/lifecycle/store.go
@@ -188,6 +188,33 @@ func (s *Store) GetPendingMaintenance(name string) string {
 	return s.packages[name].maintenance
 }
 
+// RemovalState reports how far a package's teardown has got.
+type RemovalState int
+
+const (
+	// RemovalDone means nothing is tracked under the name, so nothing is left to tear down.
+	RemovalDone RemovalState = iota
+	// RemovalPending means the package is still tracked and no teardown has been issued yet.
+	RemovalPending
+	// RemovalInFlight means a teardown is already enqueued; re-issuing EventRemove would cancel it.
+	RemovalInFlight
+)
+
+// RemovalState reports the teardown state of a package. A cleared version is what marks a removal
+// as already issued — the same signal Delete guards on — so callers can wait instead of re-issuing.
+func (s *Store) RemovalState(name string) RemovalState {
+	pkg, ok := s.packages[name]
+	if !ok {
+		return RemovalDone
+	}
+
+	if pkg.version == "" {
+		return RemovalInFlight
+	}
+
+	return RemovalPending
+}
+
 // Delete removes a package entry from the store if it still exists and is in
 // the removed state (version cleared by HandleEvent(EventRemove)).
 // Returns true if the entry was deleted.

--- a/deckhouse-controller/internal/packages/runtime/modules.go
+++ b/deckhouse-controller/internal/packages/runtime/modules.go
@@ -32,6 +32,7 @@ import (
 	taskdisable "github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/runtime/tasks/disable"
 	taskload "github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/runtime/tasks/load"
 	taskundeploy "github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/runtime/tasks/undeploy"
+	taskuninstall "github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/runtime/tasks/uninstall"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/status"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/queue"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/registry"
@@ -199,6 +200,9 @@ func (r *Runtime) RemoveModule(name string) bool {
 
 	if pkg := r.modules[name]; pkg != nil {
 		r.queueService.Enqueue(ctx, name, taskdisable.NewTask(pkg, app.NamespaceDeckhouse, false, r.nelmService, r.queueService, r.logger))
+	} else {
+		// A failed Load may roll the instance out of r.modules while the previous release is still live.
+		r.queueService.Enqueue(ctx, name, taskuninstall.NewTask(name, app.NamespaceDeckhouse, r.nelmService, r.logger))
 	}
 
 	cleanup := queue.WithOnDone(func() {

--- a/deckhouse-controller/internal/packages/runtime/modules.go
+++ b/deckhouse-controller/internal/packages/runtime/modules.go
@@ -16,6 +16,7 @@ package runtime
 
 import (
 	"context"
+	"log/slog"
 	"slices"
 
 	addonutils "github.com/flant/addon-operator/pkg/utils"
@@ -172,18 +173,28 @@ func (r *Runtime) loadModule(ctx context.Context, repo registry.Remote, packageP
 	return module.GetVersion().String(), nil
 }
 
-// RemoveModule removes a module and cancels all its running operations.
-// After undeploy, a cleanup goroutine removes the Store entry and stops the queue.
-// See RemoveApp for detailed rationale on the async cleanup pattern.
-func (r *Runtime) RemoveModule(name string) {
+// RemoveModule removes a module, cancels all its running operations and reports whether the
+// teardown has finished. After undeploy, a cleanup goroutine removes the Store entry and stops
+// the queue. See RemoveApp for the idempotence contract and the async cleanup rationale.
+func (r *Runtime) RemoveModule(name string) bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+
+	switch r.packages.RemovalState(name) {
+	case lifecycle.RemovalDone:
+		return true
+
+	case lifecycle.RemovalInFlight:
+		r.logger.Debug("module removal is still in flight", slog.String("name", name))
+
+		return false
+	}
 
 	r.scheduler.RemoveNode(name)
 
 	ctx := r.packages.HandleEvent(lifecycle.EventRemove, name)
 	if ctx == nil {
-		return
+		return true
 	}
 
 	if pkg := r.modules[name]; pkg != nil {
@@ -204,4 +215,6 @@ func (r *Runtime) RemoveModule(name string) {
 	})
 
 	r.queueService.Enqueue(ctx, name, taskundeploy.NewModuleTask(name, r.moduleDeployer, r.logger), cleanup)
+
+	return false
 }

--- a/deckhouse-controller/internal/packages/runtime/tasks/uninstall/task.go
+++ b/deckhouse-controller/internal/packages/runtime/tasks/uninstall/task.go
@@ -1,0 +1,82 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package uninstall
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/queue"
+	"github.com/deckhouse/deckhouse/pkg/log"
+)
+
+const (
+	// taskTracer identifies tracing and log records emitted by the uninstall task.
+	taskTracer = "package-uninstall"
+)
+
+// nelmI abstracts release operations needed when no loaded package is available.
+type nelmI interface {
+	// Delete uninstalls the named release and succeeds when it is already absent.
+	Delete(ctx context.Context, namespace, name string) error
+	// RemoveMonitor stops watching resources owned by the named release.
+	RemoveMonitor(name string)
+}
+
+// NewTask creates an uninstall task for a release whose loaded package is unavailable.
+// A missing release is successful because the Nelm delete operation is idempotent.
+func NewTask(name, namespace string, nelm nelmI, logger *log.Logger) queue.Task {
+	return &task{
+		name:      name,
+		namespace: namespace,
+		nelm:      nelm,
+		logger:    logger.Named(taskTracer).With("name", name),
+	}
+}
+
+// task removes a release without requiring its loaded package or lifecycle hooks.
+type task struct {
+	name      string
+	namespace string
+
+	nelm nelmI
+
+	logger *log.Logger
+}
+
+// String returns the stable queue identity of the task.
+func (t *task) String() string {
+	return "Uninstall"
+}
+
+// Execute stops release monitoring and deletes the release by namespace and name.
+func (t *task) Execute(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	t.logger.Debug("uninstall package release")
+	t.nelm.RemoveMonitor(t.name)
+
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	if err := t.nelm.Delete(ctx, t.namespace, t.name); err != nil {
+		return fmt.Errorf("delete release '%s': %w", t.name, err)
+	}
+
+	return nil
+}

--- a/deckhouse-controller/pkg/controller/packages/application/controller.go
+++ b/deckhouse-controller/pkg/controller/packages/application/controller.go
@@ -52,6 +52,10 @@ const (
 	maxConcurrentReconciles = 1
 
 	defaultRequeueTime = 30 * time.Second
+
+	// removalRequeueAfter is how often a running teardown is re-checked. It completes in a queue
+	// callback the API server never sees, so the only way to notice is to ask the runtime again.
+	removalRequeueAfter = 5 * time.Second
 )
 
 type reconciler struct {
@@ -71,7 +75,8 @@ type moduleManager interface {
 
 type packageRuntime interface {
 	UpdateApp(repo registry.Remote, inst packageruntime.App)
-	RemoveApp(namespace, name string)
+	// RemoveApp tears the application down and reports whether the teardown has finished.
+	RemoveApp(namespace, name string) bool
 	GetStatus(name string) packagestatus.Status
 	GetStatusQueue() workqueue.TypedRateLimitingInterface[string]
 	Cleanup(ctx context.Context, preserve []packageruntime.PreservePackage)
@@ -129,6 +134,14 @@ func (r *reconciler) preflight(ctx context.Context) error {
 
 	preserve := make([]packageruntime.PreservePackage, 0, len(appsList.Items))
 	for _, app := range appsList.Items {
+		// An application already being deleted is not preserved. The runtime forgets its teardown
+		// across a restart, so handleDelete would find nothing left to tear down and release the
+		// finalizer; this cleanup is the last owner of the release, and skipping it here is what
+		// makes that answer true.
+		if !app.DeletionTimestamp.IsZero() {
+			continue
+		}
+
 		preserve = append(preserve, packageruntime.PreservePackage{
 			PackageName: app.Spec.PackageName,
 			Repository:  app.Spec.PackageRepositoryName,
@@ -167,11 +180,12 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	// handle delete event
 	if !app.DeletionTimestamp.IsZero() {
-		if err := r.handleDelete(ctx, app); err != nil {
+		res, err := r.handleDelete(ctx, app)
+		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("delete: %w", err)
 		}
 
-		return ctrl.Result{}, nil
+		return res, nil
 	}
 
 	// handle create/update events
@@ -341,18 +355,34 @@ func (r *reconciler) handleCreateOrUpdate(ctx context.Context, app *v1alpha1.App
 	return nil
 }
 
-func (r *reconciler) handleDelete(ctx context.Context, app *v1alpha1.Application) error {
+// handleDelete unregisters the application from the package runtime and, once the runtime reports
+// the teardown finished, detaches the application from its package and version and releases the
+// finalizer. The wait is unbounded on purpose: holding the finalizer is what keeps a Helm release
+// from outliving the CR that owns it, so a teardown the queue keeps retrying keeps the application
+// in Terminating rather than orphaning its resources.
+func (r *reconciler) handleDelete(ctx context.Context, app *v1alpha1.Application) (ctrl.Result, error) {
 	logger := r.logger.With(slog.String("name", app.Name), slog.String("namespace", app.Namespace))
 
 	logger.Debug("handle delete application")
 	defer logger.Debug("handle delete application complete")
 
+	// The runtime tears the application down asynchronously — the Disable task uninstalls the Helm
+	// release, Undeploy takes the files off disk, and the cleanup riding the last task drops the
+	// state — so RemoveApp is polled until it reports the teardown finished.
+	if !r.runtime.RemoveApp(app.Namespace, app.Name) {
+		logger.Info("application is still being removed by the runtime")
+
+		return ctrl.Result{RequeueAfter: removalRequeueAfter}, nil
+	}
+
+	// Detach only after the teardown: releasing the version any earlier lets it be garbage
+	// collected — and its package files removed from disk — while the uninstall still needs them.
 	logger.Debug("check if application package exists", slog.String("package", app.Spec.PackageName))
 
 	ap := new(v1alpha1.ApplicationPackage)
 	if err := r.client.Get(ctx, client.ObjectKey{Name: app.Spec.PackageName}, ap); err != nil && !apierrors.IsNotFound(err) {
 		logger.Warn("failed to get application package", slog.String("name", app.Spec.PackageName), log.Err(err))
-		return fmt.Errorf("get application package '%s': %w", app.Spec.PackageName, err)
+		return ctrl.Result{}, fmt.Errorf("get application package '%s': %w", app.Spec.PackageName, err)
 	}
 
 	if ap.IsAppInstalled(app.Namespace, app.Name) {
@@ -363,7 +393,7 @@ func (r *reconciler) handleDelete(ctx context.Context, app *v1alpha1.Application
 		ap = ap.RemoveInstalledApp(app.Namespace, app.Name)
 		if err := r.client.Status().Patch(ctx, ap, patch); err != nil {
 			logger.Error("failed to patch application package", log.Err(err))
-			return fmt.Errorf("patch ApplicationPackage status for %s: %w", app.Spec.PackageName, err)
+			return ctrl.Result{}, fmt.Errorf("patch ApplicationPackage status for %s: %w", app.Spec.PackageName, err)
 		}
 	}
 
@@ -373,7 +403,7 @@ func (r *reconciler) handleDelete(ctx context.Context, app *v1alpha1.Application
 	apv := new(v1alpha1.ApplicationPackageVersion)
 	if err := r.client.Get(ctx, client.ObjectKey{Name: apvName}, apv); err != nil && !apierrors.IsNotFound(err) {
 		logger.Warn("failed to get application package version", slog.String("name", apvName), log.Err(err))
-		return fmt.Errorf("get application package version '%s': %w", apvName, err)
+		return ctrl.Result{}, fmt.Errorf("get application package version '%s': %w", apvName, err)
 	}
 
 	if apv.IsAppInstalled(app.Namespace, app.Name) {
@@ -384,14 +414,9 @@ func (r *reconciler) handleDelete(ctx context.Context, app *v1alpha1.Application
 		apv = apv.RemoveInstalledApp(app.Namespace, app.Name)
 		if err := r.client.Status().Patch(ctx, apv, patch); err != nil {
 			logger.Error("failed to patch apv", log.Err(err))
-			return fmt.Errorf("patch application package version status '%s': %w", app.Spec.PackageName, err)
+			return ctrl.Result{}, fmt.Errorf("patch application package version status '%s': %w", app.Spec.PackageName, err)
 		}
 	}
-
-	logger.Debug("delete application")
-
-	// call PackageOperator method (PackageRemover interface)
-	r.runtime.RemoveApp(app.Namespace, app.Name)
 
 	patch := client.MergeFrom(app.DeepCopy())
 
@@ -402,11 +427,11 @@ func (r *reconciler) handleDelete(ctx context.Context, app *v1alpha1.Application
 	}
 
 	if err := r.client.Patch(ctx, app, patch); err != nil {
-		logger.Error("failed to patch application", log.Err(err))
-		return fmt.Errorf("patch application %s: %w", app.Name, err)
+		logger.Error("failed to remove the application finalizer", log.Err(err))
+		return ctrl.Result{}, fmt.Errorf("patch application %s: %w", app.Name, err)
 	}
 
-	return nil
+	return ctrl.Result{}, nil
 }
 
 func (r *reconciler) addOwnerReferences(app *v1alpha1.Application, apv *v1alpha1.ApplicationPackageVersion, ap *v1alpha1.ApplicationPackage) *v1alpha1.Application {

--- a/deckhouse-controller/pkg/controller/packages/application/controller_test.go
+++ b/deckhouse-controller/pkg/controller/packages/application/controller_test.go
@@ -263,7 +263,9 @@ type operatorStub struct{}
 func (o *operatorStub) UpdateApp(_ registry.Remote, _ packageoperator.App) {
 }
 
-func (o *operatorStub) RemoveApp(_, _ string) {
+// RemoveApp reports the teardown as finished: the stub tears nothing down.
+func (o *operatorStub) RemoveApp(_, _ string) bool {
+	return true
 }
 
 func (o *operatorStub) GetStatus(name string) packagestatus.Status {


### PR DESCRIPTION
## Description
Backport [this PR](https://github.com/deckhouse/deckhouse/pull/22372)

## Why do we need it, and what problem does it solve?


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: chore
summary: Unset a package finalizer when the package is fully deleted.
impact_level: low
```
