### PR TITLE
[deckhouse] Fix ModuleConfig admission rejecting a module with a disabled conditional dependency

### DIFF
--- a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -454,25 +453,6 @@ func (m *Module) IsExperimental() bool {
 
 func (m *Module) IsDeprecated() bool {
 	return m.Properties.Stage == DeprecatedModuleStage
-}
-
-// legacyOptionalSuffix marks a parent module dependency as conditional: such a parent may be
-// disabled or absent, only its version is constrained while it is enabled.
-const legacyOptionalSuffix = "!optional"
-
-// MandatoryParentModules returns the parent modules that must be enabled, skipping the
-// conditional ones.
-func (r *ModuleRequirements) MandatoryParentModules() []string {
-	mandatory := make([]string, 0, len(r.ParentModules))
-	for parent, constraint := range r.ParentModules {
-		if strings.HasSuffix(constraint, legacyOptionalSuffix) {
-			continue
-		}
-
-		mandatory = append(mandatory, parent)
-	}
-
-	return mandatory
 }
 
 // +kubebuilder:object:root=true

--- a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -453,6 +454,25 @@ func (m *Module) IsExperimental() bool {
 
 func (m *Module) IsDeprecated() bool {
 	return m.Properties.Stage == DeprecatedModuleStage
+}
+
+// legacyOptionalSuffix marks a parent module dependency as conditional: such a parent may be
+// disabled or absent, only its version is constrained while it is enabled.
+const legacyOptionalSuffix = "!optional"
+
+// MandatoryParentModules returns the parent modules that must be enabled, skipping the
+// conditional ones.
+func (r *ModuleRequirements) MandatoryParentModules() []string {
+	mandatory := make([]string, 0, len(r.ParentModules))
+	for parent, constraint := range r.ParentModules {
+		if strings.HasSuffix(constraint, legacyOptionalSuffix) {
+			continue
+		}
+
+		mandatory = append(mandatory, parent)
+	}
+
+	return mandatory
 }
 
 // +kubebuilder:object:root=true

--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module_config.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module_config.go
@@ -314,10 +314,6 @@ func (v *moduleConfigValidator) validateModuleEnabling(ctx context.Context, cfg 
 		return rejectResult(experimentalRejectMessage(cfg.Name))
 	}
 
-	// Fallback for the dependency extender: enforce the parent-module
-	// requirements declared on the Module CR when the extender has no registered
-	// constraints for the module (e.g. the module is not yet downloaded to disk,
-	// so its module.yaml requirements were never loaded into the extender).
 	if res, err := v.checkDependenciesFromModuleCR(module); res != nil || err != nil {
 		return res, err
 	}
@@ -325,20 +321,19 @@ func (v *moduleConfigValidator) validateModuleEnabling(ctx context.Context, cfg 
 	return nil, nil
 }
 
-// checkDependenciesFromModuleCR enforces the "parent module must be enabled" part
-// of the requirements declared on the Module CR. It is a fallback for the
-// dependency extender, which only knows about modules whose module.yaml has been
-// loaded from disk; a module whose requirements are synced from the registry but
-// not yet downloaded would otherwise pass the extender's CheckEnabling silently.
-// Version constraints are intentionally not validated here: they are enforced by
-// the extender once the module is downloaded and its constraints are registered.
+// checkDependenciesFromModuleCR enforces the "parent module must be enabled" part of the
+// requirements declared on the Module CR, which the dependency extender cannot check for a
+// module whose module.yaml has not been loaded from disk yet. Conditional parents and version
+// constraints are left to the extender.
 func (v *moduleConfigValidator) checkDependenciesFromModuleCR(module *v1alpha1.Module) (*kwhvalidating.ValidatorResult, error) {
 	if module.Properties.Requirements == nil || len(module.Properties.Requirements.ParentModules) == 0 {
 		return nil, nil
 	}
 
-	missing := make([]string, 0, len(module.Properties.Requirements.ParentModules))
-	for parent := range module.Properties.Requirements.ParentModules {
+	parents := module.Properties.Requirements.MandatoryParentModules()
+
+	missing := make([]string, 0, len(parents))
+	for _, parent := range parents {
 		if parent == module.Name {
 			continue
 		}

--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module_config.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module_config.go
@@ -330,11 +330,9 @@ func (v *moduleConfigValidator) checkDependenciesFromModuleCR(module *v1alpha1.M
 		return nil, nil
 	}
 
-	parents := module.Properties.Requirements.MandatoryParentModules()
-
-	missing := make([]string, 0, len(parents))
-	for _, parent := range parents {
-		if parent == module.Name {
+	missing := make([]string, 0, len(module.Properties.Requirements.ParentModules))
+	for parent, constraint := range module.Properties.Requirements.ParentModules {
+		if parent == module.Name || strings.HasSuffix(constraint, "!optional") {
 			continue
 		}
 		if !v.moduleManager.IsModuleEnabled(parent) {

--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module_config_test.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module_config_test.go
@@ -1330,6 +1330,23 @@ func TestModuleConfigValidationHandler_DependencyFallbackFromModuleCR(t *testing
 			wantMessage:    "depends on disabled module(s): log-shipper",
 		},
 		{
+			name:           "create: disabled conditional parent is skipped",
+			operation:      "CREATE",
+			newConfig:      newModuleConfig(moduleName, boolPtr(true), nil),
+			moduleCR:       newModuleCRWithRequirements(moduleName, []string{"deckhouse"}, "", map[string]string{"loki": ">= 0.0.0 !optional"}),
+			enabledParents: map[string]bool{},
+			wantAllowed:    true,
+		},
+		{
+			name:           "create: disabled mandatory parent is rejected next to a conditional one",
+			operation:      "CREATE",
+			newConfig:      newModuleConfig(moduleName, boolPtr(true), nil),
+			moduleCR:       newModuleCRWithRequirements(moduleName, []string{"deckhouse"}, "", map[string]string{"loki": ">= 0.0.0 !optional", "log-shipper": ">= 0.0.0"}),
+			enabledParents: map[string]bool{},
+			wantAllowed:    false,
+			wantMessage:    "depends on disabled module(s): log-shipper",
+		},
+		{
 			name:           "create: all required parents enabled is allowed",
 			operation:      "CREATE",
 			newConfig:      newModuleConfig(moduleName, boolPtr(true), nil),

--- a/go_lib/dependency/extenders/moduledependency/moduledependency.go
+++ b/go_lib/dependency/extenders/moduledependency/moduledependency.go
@@ -386,6 +386,11 @@ func (e *Extender) CheckEnabling(moduleName string) error {
 	if req, found := e.modules[moduleName]; found {
 		for _, parentModule := range req.matcher.GetConstraintsNames() {
 			parentVersion, err := e.modulesVersionHelper(parentModule)
+			_, isOptional := req.optional[parentModule]
+			// if the parent module is optional and not found, skip it
+			if err != nil && apierrors.IsNotFound(err) && isOptional {
+				continue
+			}
 			if err != nil {
 				validateErr = multierror.Append(validateErr, fmt.Errorf("could not get the '%s' module version: %s", parentModule, err.Error()))
 				if apierrors.IsNotFound(err) {
@@ -396,7 +401,7 @@ func (e *Extender) CheckEnabling(moduleName string) error {
 			// check if the parent module is disabled/absent
 			if parentVersion == "" || !slices.Contains(enabledModules, parentModule) {
 				// if parent req is optional and disabled just skip it
-				if _, ok := req.optional[parentModule]; ok {
+				if isOptional {
 					e.logger.Debug("module`s requirement not met, but its optional",
 						slog.String("module", moduleName), slog.String("required", parentModule))
 					continue

--- a/go_lib/dependency/extenders/moduledependency/moduledependency_blackbox_test.go
+++ b/go_lib/dependency/extenders/moduledependency/moduledependency_blackbox_test.go
@@ -539,6 +539,27 @@ func TestCheckEnabling(t *testing.T) {
 	}
 }
 
+// TestCheckEnablingWithOptionalMissingDependency tests that a module can be enabled when its
+// optional dependency has no Module resource (NotFound)
+func TestCheckEnablingWithOptionalMissingDependency(t *testing.T) {
+	const moduleName = "moduleWithOptionalMissingDep"
+
+	extender := moduledependency.Instance()
+
+	// Set up version helper that returns not found error, simulating an absent Module resource
+	extender.SetModulesVersionHelper(func(name string) (string, error) {
+		return "", apierrors.NewNotFound(schema.GroupResource{Group: "modules", Resource: "module"}, name)
+	})
+	extender.SetModulesStateHelper(func() []string { return nil })
+
+	require.NoError(t, extender.AddConstraint(moduleName, map[string]string{
+		"missingOptionalDep": ">= 1.0.0 !optional",
+	}))
+	t.Cleanup(func() { extender.DeleteConstraint(moduleName) })
+
+	assert.NoError(t, extender.CheckEnabling(moduleName), "CheckEnabling should not fail on optional missing dependency")
+}
+
 // TestVersionHandlingWithPrereleaseAndMetadata tests the handling of prerelease and metadata in versions
 func TestVersionHandlingWithPrereleaseAndMetadata(t *testing.T) {
 	extender := moduledependency.Instance()


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

The ModuleConfig admission webhook read only the keys of `properties.requirements.modules`, so the
`!optional` marker in the map value was invisible and every parent was treated as mandatory. The
loop now binds the constraint and skips the parents carrying the marker.

`CheckEnabling` was optional-blind the same way for a parent whose Module resource is absent, and
now mirrors the fix applied to `ValidateRelease` in #21888.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

A module could not be enabled while its conditional dependency was disabled or not installed, the
case `!optional` exists for and where the requirement must be skipped. Added in #20827, shipped in
v1.77.0.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: Fix ModuleConfig admission rejecting a module with a disabled conditional dependency
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->


