### PR TITLE
Replace unsafe Ingress annotations

### DIFF
--- a/ee/modules/110-istio/templates/alliance/metadata-exporter/ingress.yaml
+++ b/ee/modules/110-istio/templates/alliance/metadata-exporter/ingress.yaml
@@ -11,8 +11,9 @@ metadata:
   namespace: d8-{{ $.Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "metadata-exporter")) | nindent 2 }}
   annotations:
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      {{- include "helm_lib_module_ingress_configuration_snippet" $ | nindent 6 }}
+  {{- if or (eq (include "helm_lib_module_https_mode" .) "CertManager") (eq (include "helm_lib_module_https_mode" .) "CustomCertificate") }}
+    nginx.ingress.kubernetes.io/ingress-nginx-hsts: "true"
+  {{- end }}
 spec:
   ingressClassName: {{ include "helm_lib_module_ingress_class" . | quote }}
   rules:

--- a/ee/modules/110-istio/templates/multicluster/api-proxy/ingress.yaml
+++ b/ee/modules/110-istio/templates/multicluster/api-proxy/ingress.yaml
@@ -13,12 +13,10 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/proxy-body-size: 2m
     nginx.ingress.kubernetes.io/backend-protocol: HTTPS
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      proxy_ssl_certificate /etc/nginx/ssl/client.crt;
-      proxy_ssl_certificate_key /etc/nginx/ssl/client.key;
-      proxy_ssl_protocols TLSv1.2;
-      proxy_ssl_session_reuse on;
-      {{- include "helm_lib_module_ingress_configuration_snippet" . | nindent 6 }}
+    nginx.ingress.kubernetes.io/proxy-ssl-use-controller-certificate: "true"
+  {{- if or (eq (include "helm_lib_module_https_mode" .) "CertManager") (eq (include "helm_lib_module_https_mode" .) "CustomCertificate") }}
+    nginx.ingress.kubernetes.io/ingress-nginx-hsts: "true"
+  {{- end }}
 spec:
   ingressClassName: {{ include "helm_lib_module_ingress_class" . | quote }}
   rules:

--- a/modules/038-registry/template_tests/copy_custom_certificate_test.go
+++ b/modules/038-registry/template_tests/copy_custom_certificate_test.go
@@ -78,6 +78,11 @@ var _ = Describe("Module :: registry :: helm template :: custom-certificate", fu
 			createdSecret := f.KubernetesResource("Secret", "d8-system", "registry-ingress-tls-customcertificate")
 			Expect(createdSecret.Exists()).To(BeTrue())
 			Expect(createdSecret.Field("data").String()).To(Equal(`{"tls.crt":"Q1JUQ1JUQ1JU","tls.key":"S0VZS0VZS0VZ"}`))
+
+			ingress := f.KubernetesResource("Ingress", "d8-system", "registry")
+			Expect(ingress.Field("metadata.annotations.nginx\\.ingress\\.kubernetes\\.io/proxy-ssl-use-controller-certificate").String()).To(Equal("true"))
+			Expect(ingress.Field("metadata.annotations.nginx\\.ingress\\.kubernetes\\.io/ingress-nginx-hsts").String()).To(Equal("true"))
+			Expect(ingress.Field("metadata.annotations.nginx\\.ingress\\.kubernetes\\.io/configuration-snippet").Exists()).To(BeFalse())
 		})
 
 	})

--- a/modules/038-registry/templates/ingress/ingress.yaml
+++ b/modules/038-registry/templates/ingress/ingress.yaml
@@ -32,12 +32,10 @@ metadata:
     nginx.ingress.kubernetes.io/backend-protocol: HTTPS
     nginx.ingress.kubernetes.io/upstream-hash-by: "$remote_addr"
     nginx.ingress.kubernetes.io/proxy-body-size: "0"
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      proxy_ssl_certificate /etc/nginx/ssl/client.crt;
-      proxy_ssl_certificate_key /etc/nginx/ssl/client.key;
-      proxy_ssl_protocols TLSv1.2;
-      proxy_ssl_session_reuse on;
-      {{- include "helm_lib_module_ingress_configuration_snippet" $ | nindent 6 }}
+    nginx.ingress.kubernetes.io/proxy-ssl-use-controller-certificate: "true"
+    {{- if or (eq (include "helm_lib_module_https_mode" .) "CertManager") (eq (include "helm_lib_module_https_mode" .) "CustomCertificate") }}
+    nginx.ingress.kubernetes.io/ingress-nginx-hsts: "true"
+    {{- end }}
     {{- if .Values.registry.whitelistSourceRanges }}
     nginx.ingress.kubernetes.io/whitelist-source-range: {{ .Values.registry.whitelistSourceRanges | join "," }}
     {{- end }}

--- a/modules/039-registry-packages-proxy/template_tests/copy_custom_certificate_test.go
+++ b/modules/039-registry-packages-proxy/template_tests/copy_custom_certificate_test.go
@@ -85,6 +85,10 @@ var _ = Describe("Module :: registry-packages-proxy :: helm template :: custom-c
 			created := f.KubernetesResource("Secret", "d8-cloud-instance-manager", "ingress-tls-customcertificate")
 			Expect(created.Exists()).To(BeTrue())
 			Expect(created.Field("data").String()).To(Equal(`{"tls.crt":"Q1JUQ1JUQ1JU","tls.key":"S0VZS0VZS0VZ"}`))
+
+			ingress := f.KubernetesResource("Ingress", "d8-cloud-instance-manager", "registry-packages-proxy")
+			Expect(ingress.Field("metadata.annotations.nginx\\.ingress\\.kubernetes\\.io/ingress-nginx-hsts").String()).To(Equal("true"))
+			Expect(ingress.Field("metadata.annotations.nginx\\.ingress\\.kubernetes\\.io/configuration-snippet").Exists()).To(BeFalse())
 		})
 	})
 

--- a/modules/039-registry-packages-proxy/templates/ingress.yaml
+++ b/modules/039-registry-packages-proxy/templates/ingress.yaml
@@ -12,8 +12,9 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-buffering: "off"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      {{- include "helm_lib_module_ingress_configuration_snippet" $ | nindent 6 }}
+  {{- if or (eq (include "helm_lib_module_https_mode" .) "CertManager") (eq (include "helm_lib_module_https_mode" .) "CustomCertificate") }}
+    nginx.ingress.kubernetes.io/ingress-nginx-hsts: "true"
+  {{- end }}
 spec:
   ingressClassName: {{ include "helm_lib_module_ingress_class" . | quote }}
   rules:

--- a/modules/040-control-plane-manager/template_tests/publish_api_test.go
+++ b/modules/040-control-plane-manager/template_tests/publish_api_test.go
@@ -200,19 +200,60 @@ tls.key: KEYKEYKEY
 		})
 		It("Should deploy basic auth access infrastructure", func() {
 			Expect(hec.RenderError).ToNot(HaveOccurred())
-			Expect(hec.KubernetesResource("Ingress", "kube-system", "kubernetes-api").Field(
-				"metadata.annotations.nginx\\.ingress\\.kubernetes\\.io/configuration-snippet").String()).To(
-				Equal("if ($http_authorization ~ \"^(.*)Basic(.*)$\") {\n  rewrite ^(.*)$ /basic-auth$1;\n}\nlocation ~ ^/(healthz|livez|readyz) {\n  deny all;\n  return 403;\n}\n"))
+			apiIngress := hec.KubernetesResource("Ingress", "kube-system", "kubernetes-api")
+			Expect(apiIngress.Field(
+				"metadata.annotations.nginx\\.ingress\\.kubernetes\\.io/configuration-snippet").Exists()).To(BeFalse())
+			Expect(apiIngress.Field(
+				"metadata.annotations.nginx\\.ingress\\.kubernetes\\.io/ingress-nginx-hsts").String()).To(Equal("true"))
+			Expect(apiIngress.Field("spec.rules.0.http.paths.0.path").String()).To(Equal("/"))
 			Expect(hec.KubernetesResource("Ingress", "kube-system", "kubernetes-api").Field(
 				"metadata.annotations.nginx\\.ingress\\.kubernetes\\.io/whitelist-source-range").String()).To(
 				Equal("1.1.1.1,192.168.0.0/24"))
+
+			healthIngress := hec.KubernetesResource("Ingress", "kube-system", "kubernetes-api-health-endpoints")
+			Expect(healthIngress.Exists()).To(BeTrue())
+			Expect(healthIngress.Field("metadata.annotations.nginx\\.ingress\\.kubernetes\\.io/denylist-source-range").String()).To(Equal("0.0.0.0/0,::/0"))
+			Expect(healthIngress.Field("spec.rules.0.http.paths.0.path").String()).To(Equal("/healthz"))
+			Expect(healthIngress.Field("spec.rules.0.http.paths.0.pathType").String()).To(Equal("Exact"))
+			Expect(healthIngress.Field("spec.rules.0.http.paths.1.path").String()).To(Equal("/livez"))
+			Expect(healthIngress.Field("spec.rules.0.http.paths.1.pathType").String()).To(Equal("Exact"))
+			Expect(healthIngress.Field("spec.rules.0.http.paths.2.path").String()).To(Equal("/readyz"))
+			Expect(healthIngress.Field("spec.rules.0.http.paths.2.pathType").String()).To(Equal("Exact"))
+
 			Expect(hec.KubernetesResource("Secret", "kube-system", "d8-publish-api-config").Field("data.whitelistSourceRanges").String()).To(Equal("WzEuMS4xLjEgMTkyLjE2OC4wLjAvMjRd"))
-			Expect(hec.KubernetesResource("Ingress", "kube-system", "basic-auth-proxy").Field(
-				"metadata.annotations.nginx\\.ingress\\.kubernetes\\.io/whitelist-source-range").String()).To(
-				Equal("1.1.1.1,192.168.0.0/24"))
+			basicAuthIngress := hec.KubernetesResource("Ingress", "kube-system", "basic-auth-proxy")
+			Expect(basicAuthIngress.Field(
+				"metadata.annotations.nginx\\.ingress\\.kubernetes\\.io/whitelist-source-range").Exists()).To(BeFalse())
+			Expect(basicAuthIngress.Field(
+				"metadata.annotations.nginx\\.ingress\\.kubernetes\\.io/configuration-snippet").Exists()).To(BeFalse())
+			Expect(basicAuthIngress.Field(
+				"metadata.annotations.nginx\\.ingress\\.kubernetes\\.io/backend-protocol").String()).To(Equal("HTTP"))
+			Expect(basicAuthIngress.Field(
+				"metadata.annotations.nginx\\.ingress\\.kubernetes\\.io/canary").String()).To(Equal("true"))
+			Expect(basicAuthIngress.Field(
+				"metadata.annotations.nginx\\.ingress\\.kubernetes\\.io/canary-by-header").String()).To(Equal("Authorization"))
+			Expect(basicAuthIngress.Field(
+				"metadata.annotations.nginx\\.ingress\\.kubernetes\\.io/canary-by-header-pattern").String()).To(Equal("^(.*)Basic(.*)$"))
+			Expect(basicAuthIngress.Field(
+				"metadata.annotations.nginx\\.ingress\\.kubernetes\\.io/rewrite-target").Exists()).To(BeFalse())
+			Expect(basicAuthIngress.Field("spec.rules.0.http.paths.0.path").String()).To(Equal("/"))
 			Expect(hec.KubernetesResource("Service", "kube-system", "basic-auth-proxy").Field("spec.type").String()).To(Equal("ExternalName"))
 			Expect(hec.KubernetesResource("Service", "kube-system", "basic-auth-proxy").Field("spec.externalName").String()).To(Equal("basic-auth-proxy.d8-user-authn.svc.cluster.local"))
 
+		})
+	})
+
+	Context("Without basic auth", func() {
+		BeforeEach(func() {
+			hec.ValuesSet("controlPlaneManager.internal.authn.enableBasicAuth", false)
+			hec.HelmRender()
+		})
+
+		It("Should expose health endpoints only through the denylist ingress", func() {
+			Expect(hec.RenderError).ToNot(HaveOccurred())
+			Expect(hec.KubernetesResource("Ingress", "kube-system", "kubernetes-api").Field(
+				"metadata.annotations.nginx\\.ingress\\.kubernetes\\.io/configuration-snippet").Exists()).To(BeFalse())
+			Expect(hec.KubernetesResource("Ingress", "kube-system", "kubernetes-api-health-endpoints").Exists()).To(BeTrue())
 		})
 	})
 

--- a/modules/040-control-plane-manager/templates/kubernetes-api/basic-auth-proxy.yaml
+++ b/modules/040-control-plane-manager/templates/kubernetes-api/basic-auth-proxy.yaml
@@ -6,15 +6,10 @@ metadata:
   name: basic-auth-proxy
   namespace: kube-system
   annotations:
-  {{- if or (.Values.global.enabledModules | has "cert-manager") (eq .Values.global.modules.https.mode "CustomCertificate") }}
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      {{ include "helm_lib_module_ingress_configuration_snippet" $ | nindent 6 }}
-  {{- end }}
-    nginx.ingress.kubernetes.io/rewrite-target: "/$2"
-    nginx.ingress.kubernetes.io/proxy-body-size: 10m
-  {{- if .Values.controlPlaneManager.apiserver.publishAPI.ingress.whitelistSourceRanges }}
-    nginx.ingress.kubernetes.io/whitelist-source-range: {{ .Values.controlPlaneManager.apiserver.publishAPI.ingress.whitelistSourceRanges | join "," }}
-  {{- end }}
+    nginx.ingress.kubernetes.io/backend-protocol: HTTP
+    nginx.ingress.kubernetes.io/canary: "true"
+    nginx.ingress.kubernetes.io/canary-by-header: Authorization
+    nginx.ingress.kubernetes.io/canary-by-header-pattern: "^(.*)Basic(.*)$"
   {{- include "helm_lib_module_labels" (list . (dict "app" "basic-auth-proxy")) | nindent 2 }}
 spec:
   ingressClassName: {{ .Values.controlPlaneManager.apiserver.publishAPI.ingress.ingressClass | default (include "helm_lib_module_ingress_class" . | quote ) }}
@@ -22,25 +17,13 @@ spec:
   - host: {{ include "helm_lib_module_public_domain" (list . "api") }}
     http:
       paths:
-      - path: /basic-auth(\/?)(.*)
+      - path: /
         pathType: ImplementationSpecific
         backend:
           service:
             name: basic-auth-proxy
             port:
               number: 7332
-{{- if and
-      (or
-        (.Values.global.enabledModules | has "cert-manager")
-        (eq .Values.global.modules.https.mode "CustomCertificate")
-      )
-      (include "helm_lib_module_https_ingress_tls_enabled" .)
-}}
-  tls:
-  - hosts:
-    - {{ include "helm_lib_module_public_domain" (list . "api") }}
-    secretName: {{ include "publish_api_certificate_name" . }}
-  {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/modules/040-control-plane-manager/templates/kubernetes-api/kubernetes-api.yaml
+++ b/modules/040-control-plane-manager/templates/kubernetes-api/kubernetes-api.yaml
@@ -9,21 +9,8 @@ metadata:
   {{- if .Values.controlPlaneManager.apiserver.publishAPI.ingress.whitelistSourceRanges }}
     nginx.ingress.kubernetes.io/whitelist-source-range: {{ .Values.controlPlaneManager.apiserver.publishAPI.ingress.whitelistSourceRanges | join "," }}
   {{- end }}
-  {{- if .Values.controlPlaneManager.internal.authn.enableBasicAuth }}
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      if ($http_authorization ~ "^(.*)Basic(.*)$") {
-        rewrite ^(.*)$ /basic-auth$1;
-      }
-      location ~ ^/(healthz|livez|readyz) {
-        deny all;
-        return 403;
-      }
-  {{- else }}
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      location ~ ^/(healthz|livez|readyz) {
-        deny all;
-        return 403;
-      }
+  {{- if or (.Values.global.enabledModules | has "cert-manager") (eq .Values.global.modules.https.mode "CustomCertificate") }}
+    nginx.ingress.kubernetes.io/ingress-nginx-hsts: "true"
   {{- end }}
   name: kubernetes-api
   namespace: kube-system
@@ -46,10 +33,48 @@ spec:
   - host: {{ include "helm_lib_module_public_domain" (list . "api") }}
     http:
       paths:
-      - backend:
+      - path: /
+        backend:
           service:
             name: kubernetes
             port:
               number: 443
         pathType: ImplementationSpecific
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: kubernetes-api-health-endpoints
+  namespace: kube-system
+  annotations:
+    nginx.ingress.kubernetes.io/backend-protocol: HTTPS
+    nginx.ingress.kubernetes.io/denylist-source-range: "0.0.0.0/0,::/0"
+  {{- include "helm_lib_module_labels" (list . (dict "app" "kubernetes-configurator")) | nindent 2 }}
+spec:
+  ingressClassName: {{ .Values.controlPlaneManager.apiserver.publishAPI.ingress.ingressClass | default (include "helm_lib_module_ingress_class" . | quote ) }}
+  rules:
+  - host: {{ include "helm_lib_module_public_domain" (list . "api") }}
+    http:
+      paths:
+      - path: /healthz
+        pathType: Exact
+        backend:
+          service:
+            name: kubernetes
+            port:
+              number: 443
+      - path: /livez
+        pathType: Exact
+        backend:
+          service:
+            name: kubernetes
+            port:
+              number: 443
+      - path: /readyz
+        pathType: Exact
+        backend:
+          service:
+            name: kubernetes
+            port:
+              number: 443
 {{- end }}

--- a/modules/110-istio/templates/kiali/ingress.yaml
+++ b/modules/110-istio/templates/kiali/ingress.yaml
@@ -23,12 +23,10 @@ metadata:
   {{- end }}
     nginx.ingress.kubernetes.io/proxy-buffer-size: 32k
     nginx.ingress.kubernetes.io/backend-protocol: HTTPS
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      proxy_ssl_certificate /etc/nginx/ssl/client.crt;
-      proxy_ssl_certificate_key /etc/nginx/ssl/client.key;
-      proxy_ssl_protocols TLSv1.2;
-      proxy_ssl_session_reuse on;
-      {{- include "helm_lib_module_ingress_configuration_snippet" . | nindent 6 }}
+    nginx.ingress.kubernetes.io/proxy-ssl-use-controller-certificate: "true"
+  {{- if or (eq (include "helm_lib_module_https_mode" .) "CertManager") (eq (include "helm_lib_module_https_mode" .) "CustomCertificate") }}
+    nginx.ingress.kubernetes.io/ingress-nginx-hsts: "true"
+  {{- end }}
 spec:
   ingressClassName: {{ include "helm_lib_module_ingress_class" . | quote }}
   rules:

--- a/modules/150-user-authn/templates/dex-authenticator/ingress.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/ingress.yaml
@@ -29,8 +29,9 @@ metadata:
   {{- if $app.whitelistSourceRanges }}
     nginx.ingress.kubernetes.io/whitelist-source-range: {{ $app.whitelistSourceRanges | join "," }}
   {{- end }}
-    nginx.ingress.kubernetes.io/configuration-snippet: |-
-      {{- include "helm_lib_module_ingress_configuration_snippet" $ | nindent 6 }}
+  {{- if or (eq (include "helm_lib_module_https_mode" $context) "CertManager") (eq (include "helm_lib_module_https_mode" $context) "CustomCertificate") }}
+    nginx.ingress.kubernetes.io/ingress-nginx-hsts: "true"
+  {{- end }}
   name: {{ $ingName }}
   namespace: {{ $crd.namespace | quote }}
   {{- $labels := dict "app" "dex-authenticator" "deckhouse.io/dex-authenticator-for" $crd.name }}
@@ -73,8 +74,9 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/backend-protocol: HTTPS
     nginx.ingress.kubernetes.io/rewrite-target: /dex-authenticator/sign_out
-    nginx.ingress.kubernetes.io/configuration-snippet: |-
-      {{- include "helm_lib_module_ingress_configuration_snippet" $ | nindent 6 }}
+  {{- if or (eq (include "helm_lib_module_https_mode" $context) "CertManager") (eq (include "helm_lib_module_https_mode" $context) "CustomCertificate") }}
+    nginx.ingress.kubernetes.io/ingress-nginx-hsts: "true"
+  {{- end }}
   name: {{ $signOutIngressName }}
   namespace: {{ $crd.namespace | quote }}
   {{- $labels := dict "app" "dex-authenticator" "deckhouse.io/dex-authenticator-for" $crd.name }}

--- a/modules/150-user-authn/templates/dex/ingress.yaml
+++ b/modules/150-user-authn/templates/dex/ingress.yaml
@@ -5,9 +5,10 @@ metadata:
   name: dex
   namespace: d8-{{ .Chart.Name }}
   annotations:
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      {{- include "helm_lib_module_ingress_configuration_snippet" $ | nindent 6 }}
     nginx.ingress.kubernetes.io/backend-protocol: HTTPS
+  {{- if or (eq (include "helm_lib_module_https_mode" .) "CertManager") (eq (include "helm_lib_module_https_mode" .) "CustomCertificate") }}
+    nginx.ingress.kubernetes.io/ingress-nginx-hsts: "true"
+  {{- end }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "dex")) | nindent 2 }}
 spec:
   ingressClassName: {{ include "helm_lib_module_ingress_class" . | quote }}
@@ -36,8 +37,9 @@ metadata:
   namespace: d8-{{ .Chart.Name }}
   annotations:
     nginx.ingress.kubernetes.io/backend-protocol: HTTPS
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      {{- include "helm_lib_module_ingress_configuration_snippet" $ | nindent 6 }}
+  {{- if or (eq (include "helm_lib_module_https_mode" .) "CertManager") (eq (include "helm_lib_module_https_mode" .) "CustomCertificate") }}
+    nginx.ingress.kubernetes.io/ingress-nginx-hsts: "true"
+  {{- end }}
     nginx.ingress.kubernetes.io/limit-rpm: "1000"
     # Works only for ingress-controllers >=0.40. It is here to not forget to add the annotation after upgrading ingress controller.
     nginx.ingress.kubernetes.io/limit-burst-multiplier: "2"

--- a/modules/150-user-authn/templates/kubeconfig-generator/ingress.yaml
+++ b/modules/150-user-authn/templates/kubeconfig-generator/ingress.yaml
@@ -8,8 +8,9 @@ metadata:
   annotations:
     web.deckhouse.io/export-name: "kubeconfig"
     web.deckhouse.io/export-icon: "/public/img/kubeconfig-generator.jpeg"
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      {{ include "helm_lib_module_ingress_configuration_snippet" $ | nindent 6 }}
+  {{- if or (eq (include "helm_lib_module_https_mode" .) "CertManager") (eq (include "helm_lib_module_https_mode" .) "CustomCertificate") }}
+    nginx.ingress.kubernetes.io/ingress-nginx-hsts: "true"
+  {{- end }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "kubernetes-configurator")) | nindent 2 }}
 spec:
   ingressClassName: {{ include "helm_lib_module_ingress_class" . | quote }}

--- a/modules/500-cilium-hubble/templates/ui/ingress.yaml
+++ b/modules/500-cilium-hubble/templates/ui/ingress.yaml
@@ -23,12 +23,10 @@ metadata:
     nginx.ingress.kubernetes.io/auth-realm: "Authentication Required"
     {{- end }}
     nginx.ingress.kubernetes.io/backend-protocol: HTTPS
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      proxy_ssl_certificate /etc/nginx/ssl/client.crt;
-      proxy_ssl_certificate_key /etc/nginx/ssl/client.key;
-      proxy_ssl_protocols TLSv1.2;
-      proxy_ssl_session_reuse on;
-      {{- include "helm_lib_module_ingress_configuration_snippet" . | nindent 6 }}
+    nginx.ingress.kubernetes.io/proxy-ssl-use-controller-certificate: "true"
+    {{- if or (eq (include "helm_lib_module_https_mode" .) "CertManager") (eq (include "helm_lib_module_https_mode" .) "CustomCertificate") }}
+    nginx.ingress.kubernetes.io/ingress-nginx-hsts: "true"
+    {{- end }}
     {{- if .Values.ciliumHubble.auth.whitelistSourceRanges }}
     nginx.ingress.kubernetes.io/whitelist-source-range: {{ .Values.ciliumHubble.auth.whitelistSourceRanges | join "," }}
     {{- end }}

--- a/modules/500-openvpn/template_tests/copy_custom_certificate_test.go
+++ b/modules/500-openvpn/template_tests/copy_custom_certificate_test.go
@@ -72,6 +72,11 @@ var _ = Describe("Module :: openvpn :: helm template :: custom-certificate", fun
 			createdSecret := f.KubernetesResource("Secret", "d8-openvpn", "ingress-tls-customcertificate")
 			Expect(createdSecret.Exists()).To(BeTrue())
 			Expect(createdSecret.Field("data").String()).To(Equal(`{"tls.crt":"Q1JUQ1JUQ1JU","tls.key":"S0VZS0VZS0VZ"}`))
+
+			ingress := f.KubernetesResource("Ingress", "d8-openvpn", "admin")
+			Expect(ingress.Field("metadata.annotations.nginx\\.ingress\\.kubernetes\\.io/proxy-ssl-use-controller-certificate").String()).To(Equal("true"))
+			Expect(ingress.Field("metadata.annotations.nginx\\.ingress\\.kubernetes\\.io/ingress-nginx-hsts").String()).To(Equal("true"))
+			Expect(ingress.Field("metadata.annotations.nginx\\.ingress\\.kubernetes\\.io/configuration-snippet").Exists()).To(BeFalse())
 		})
 
 	})

--- a/modules/500-openvpn/templates/openvpn/ingress.yaml
+++ b/modules/500-openvpn/templates/openvpn/ingress.yaml
@@ -23,12 +23,10 @@ metadata:
     nginx.ingress.kubernetes.io/whitelist-source-range: {{ .Values.openvpn.auth.whitelistSourceRanges | join "," }}
 {{- end }}
     nginx.ingress.kubernetes.io/backend-protocol: HTTPS
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      proxy_ssl_certificate /etc/nginx/ssl/client.crt;
-      proxy_ssl_certificate_key /etc/nginx/ssl/client.key;
-      proxy_ssl_protocols TLSv1.2;
-      proxy_ssl_session_reuse on;
-      {{- include "helm_lib_module_ingress_configuration_snippet" . | nindent 6 }}
+    nginx.ingress.kubernetes.io/proxy-ssl-use-controller-certificate: "true"
+{{- if or (eq (include "helm_lib_module_https_mode" .) "CertManager") (eq (include "helm_lib_module_https_mode" .) "CustomCertificate") }}
+    nginx.ingress.kubernetes.io/ingress-nginx-hsts: "true"
+{{- end }}
 spec:
   ingressClassName: {{ include "helm_lib_module_ingress_class" . | quote }}
   {{- if (include "helm_lib_module_https_ingress_tls_enabled" .) }}

--- a/modules/800-deckhouse-tools/.dmtlint.yaml
+++ b/modules/800-deckhouse-tools/.dmtlint.yaml
@@ -2,11 +2,6 @@ linters-settings:
   module:
     oss:
       disable: true
-  templates:
-    exclude-rules:
-      ingress:
-        - kind: Ingress
-          name: deckhouse-tools
   container:
     exclude-rules:
       read-only-root-filesystem:

--- a/modules/800-deckhouse-tools/templates/ingress.yaml
+++ b/modules/800-deckhouse-tools/templates/ingress.yaml
@@ -13,17 +13,13 @@ metadata:
   {{- if and (ne (include "helm_lib_module_https_mode" .) "Disabled") .Values.deckhouseTools.auth.externalAuthentication }}
     nginx.ingress.kubernetes.io/auth-signin: {{ .Values.deckhouseTools.auth.externalAuthentication.authSignInURL | quote }}
     nginx.ingress.kubernetes.io/auth-url: {{ .Values.deckhouseTools.auth.externalAuthentication.authURL | quote }}
-    nginx.ingress.kubernetes.io/configuration-snippet: |
   {{- else }}
     nginx.ingress.kubernetes.io/auth-type: basic
     nginx.ingress.kubernetes.io/auth-secret: tools-basic-auth
     nginx.ingress.kubernetes.io/auth-realm: "Authentication Required"
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      proxy_ssl_certificate /etc/nginx/ssl/client.crt;
-      proxy_ssl_certificate_key /etc/nginx/ssl/client.key;
-      proxy_ssl_protocols TLSv1.2;
-      proxy_ssl_session_reuse on;
-      {{- include "helm_lib_module_ingress_configuration_snippet" . | nindent 6 }}
+    {{- if or (eq (include "helm_lib_module_https_mode" .) "CertManager") (eq (include "helm_lib_module_https_mode" .) "CustomCertificate") }}
+    nginx.ingress.kubernetes.io/ingress-nginx-hsts: "true"
+    {{- end }}
   {{- end }}
   {{- if $satisfyAny }}
     nginx.ingress.kubernetes.io/satisfy: "any"

--- a/modules/810-documentation/templates/ingress.yaml
+++ b/modules/810-documentation/templates/ingress.yaml
@@ -8,12 +8,10 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/use-regex: "true"
     nginx.ingress.kubernetes.io/backend-protocol: HTTPS
-    nginx.ingress.kubernetes.io/configuration-snippet: |-
-      proxy_ssl_certificate /etc/nginx/ssl/client.crt;
-      proxy_ssl_certificate_key /etc/nginx/ssl/client.key;
-      proxy_ssl_protocols TLSv1.2;
-      proxy_ssl_session_reuse on;
-      {{- include "helm_lib_module_ingress_configuration_snippet" $ | nindent 6 }}
+    nginx.ingress.kubernetes.io/proxy-ssl-use-controller-certificate: "true"
+  {{- if or (eq (include "helm_lib_module_https_mode" .) "CertManager") (eq (include "helm_lib_module_https_mode" .) "CustomCertificate") }}
+    nginx.ingress.kubernetes.io/ingress-nginx-hsts: "true"
+  {{- end }}
 spec:
   ingressClassName: {{ include "helm_lib_module_ingress_class" . | quote }}
   rules:
@@ -66,14 +64,10 @@ metadata:
     nginx.ingress.kubernetes.io/auth-realm: "Authentication Required"
   {{- end }}
     nginx.ingress.kubernetes.io/backend-protocol: HTTPS
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      proxy_ssl_certificate /etc/nginx/ssl/client.crt;
-      proxy_ssl_certificate_key /etc/nginx/ssl/client.key;
-      proxy_ssl_protocols TLSv1.2;
-      proxy_ssl_session_reuse on;
-      # The old naming
-      #rewrite ^/(ru|en)/(platform/)?modules/[0-9]+-([^/]+/.*)$ /$1/platform/modules/$3 redirect;
-      {{- include "helm_lib_module_ingress_configuration_snippet" $ | nindent 6 }}
+    nginx.ingress.kubernetes.io/proxy-ssl-use-controller-certificate: "true"
+  {{- if or (eq (include "helm_lib_module_https_mode" .) "CertManager") (eq (include "helm_lib_module_https_mode" .) "CustomCertificate") }}
+    nginx.ingress.kubernetes.io/ingress-nginx-hsts: "true"
+  {{- end }}
   {{- if .Values.documentation.auth.satisfyAny }}
     nginx.ingress.kubernetes.io/satisfy: "any"
   {{- end }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Replaces unsafe `configuration-snippet` annotations in Deckhouse module Ingresses with dedicated safe annotations and standard ingress-nginx features.

The migration preserves HSTS, controller client certificates, authentication routing, and access restrictions without allowing arbitrary NGINX configuration.


## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Snippet annotations allow arbitrary NGINX directives and require unsafe ingress-nginx controller settings.

Migrating Deckhouse modules away from these annotations allows controllers to run with snippets disabled while preserving existing module behavior and reducing the risk of NGINX configuration injection.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Manual test

<details>
<summary>Check kube api</summary>

<img width="713" height="397" alt="image" src="https://github.com/user-attachments/assets/036047ad-2668-4d00-9679-a04a7ec74039" />

</details>

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: registry
type: chore
summary: module Ingress resources migrated from unsafe NGINX snippet annotations
impact_level: default
---
section: registry-packages-proxy
type: chore
summary: module Ingress resources migrated from unsafe NGINX snippet annotations
impact_level: default
---
section: control-plane-manager
type: chore
summary: module Ingress resources migrated from unsafe NGINX snippet annotations
impact_level: default
---
section: istio
type: chore
summary: module Ingress resources migrated from unsafe NGINX snippet annotations
impact_level: default
---
section: user-authn
type: chore
summary: module Ingress resources migrated from unsafe NGINX snippet annotations
impact_level: default
---
section: cilium-hubble
type: chore
summary: module Ingress resources migrated from unsafe NGINX snippet annotations
impact_level: default
---
section: openvpn
type: chore
summary: module Ingress resources migrated from unsafe NGINX snippet annotations
impact_level: default
---
section: deckhouse-tools
type: chore
summary: module Ingress resources migrated from unsafe NGINX snippet annotations
impact_level: default
---
section: documentation
type: chore
summary: module Ingress resources migrated from unsafe NGINX snippet annotations
impact_level: default 
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
