### PR TITLE
[deckhouse] Fix an empty package status after a successful install 

### DIFF
--- a/deckhouse-controller/internal/nelm/client.go
+++ b/deckhouse-controller/internal/nelm/client.go
@@ -323,26 +323,38 @@ func (c *Client) Install(ctx context.Context, namespace, releaseName string, opt
 		maps.Copy(labels, opts.ResourcesLabels)
 	}
 
-	// reportCh receives progress reports from nelm during resource tracking.
-	// A background goroutine converts each report into a tracking event and
-	// forwards it to the caller's callback.
+	// reportCh receives progress reports from nelm during resource tracking; a
+	// background goroutine forwards each one to the caller's callback.
 	//
-	// We must NOT close reportCh: when a Timeout is set, nelm's ReleaseInstall
-	// returns on ctx.Done() without joining the goroutine that actually runs
-	// the install. That detached goroutine keeps sending progress reports via
-	// sendNonBlocking, so closing the channel here would panic it with
-	// "send on closed channel" and crash the process. Instead we stop the
-	// forwarder via done and let the buffered channel be garbage-collected.
+	// We must not close reportCh — ReleaseInstall closes it whenever it runs the
+	// install to completion, and the ok check is what makes the forwarder leave
+	// on that close instead of reading an endless stream of empty reports. done
+	// covers the paths that leave the channel open: a Timeout returns on
+	// ctx.Done() while the installing goroutine still runs, and an early failure
+	// never installs a reporter. The wait keeps a report from arriving after
+	// Install returned and the caller published the apply result.
 	reportCh := make(chan progrep.ProgressReport, 1)
 	done := make(chan struct{})
+
+	var wg sync.WaitGroup
+
+	// Deferred in this order so close(done) runs before the wait.
+	defer wg.Wait()
 	defer close(done)
 
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
+
 		for {
 			select {
 			case <-done:
 				return
-			case report := <-reportCh:
+			case report, ok := <-reportCh:
+				if !ok {
+					return
+				}
+
 				if opts.OnTrackingEvent != nil {
 					opts.OnTrackingEvent(releaseName, report)
 				}

--- a/deckhouse-controller/pkg/controller/packages/application/status/rules.go
+++ b/deckhouse-controller/pkg/controller/packages/application/status/rules.go
@@ -272,6 +272,13 @@ func pipelineBlocker(state condmap.State, chain []string) (string, bool) {
 	return firstFalse(state, chain)
 }
 
+// isInstallComplete reports whether the first install actually landed. intScaled
+// alone is not enough: the status service commits currentVersion, urls and
+// lastAppliedConfiguration under intManifestsApplied.
+func isInstallComplete(state condmap.State) bool {
+	return state.AllIntEqual(metav1.ConditionTrue, intManifestsApplied, intScaled)
+}
+
 // buildMapper returns the standard set of mappers in evaluation order.
 func buildMapper() condmap.Mapper {
 	return condmap.Mapper{
@@ -315,7 +322,7 @@ func mapInstalled(state condmap.State) metav1.Condition {
 	if cond, ok := pipelineBlocker(state, installPipeline); ok {
 		return emit(state, ConditionInstalled, metav1.ConditionFalse, cond)
 	}
-	if state.IntEqual(intScaled, metav1.ConditionTrue) {
+	if isInstallComplete(state) {
 		return emit(state, ConditionInstalled, metav1.ConditionTrue, intScaled)
 	}
 
@@ -385,6 +392,10 @@ func mapReady(state condmap.State) metav1.Condition {
 
 	if ok {
 		return emit(state, ConditionReady, metav1.ConditionFalse, blocker)
+	}
+	// On first install readiness tracks Installed, so it waits for the same gate.
+	if ph == phaseInstall && !isInstallComplete(state) {
+		return metav1.Condition{}
 	}
 	if state.IntEqual(intScaled, metav1.ConditionTrue) {
 		return emit(state, ConditionReady, metav1.ConditionTrue, intScaled)

--- a/deckhouse-controller/pkg/controller/packages/application/status/rules_test.go
+++ b/deckhouse-controller/pkg/controller/packages/application/status/rules_test.go
@@ -184,6 +184,17 @@ func TestInstalledRule(t *testing.T) {
 			},
 		},
 		{
+			// Scaled alone must not report a finished install: the version, URLs
+			// and settings are committed under ManifestsApplied.
+			name: "absent when Scaled arrives before manifests are applied",
+			opts: []mappingOption{
+				withInternalCondition(string(intstatus.ConditionScaled), metav1.ConditionTrue, "Scaled"),
+			},
+			expected: map[string]*expectedCondition{
+				ConditionInstalled: nil,
+			},
+		},
+		{
 			name: "sticky - not in result when already true externally",
 			opts: []mappingOption{
 				withExternalCondition(ConditionInstalled, metav1.ConditionTrue, "PreviouslyInstalled"),
@@ -284,6 +295,16 @@ func TestReadyRule(t *testing.T) {
 			name: "requirements passed does not explain readiness",
 			opts: []mappingOption{
 				withInternalCondition(string(intstatus.ConditionRequirementsMet), metav1.ConditionTrue, "RequirementsMet"),
+			},
+			expected: map[string]*expectedCondition{
+				ConditionReady: nil,
+			},
+		},
+		{
+			// On first install readiness tracks Installed, which waits for the apply.
+			name: "absent when Scaled arrives before manifests are applied",
+			opts: []mappingOption{
+				withInternalCondition(string(intstatus.ConditionScaled), metav1.ConditionTrue, "Scaled"),
 			},
 			expected: map[string]*expectedCondition{
 				ConditionReady: nil,

--- a/deckhouse-controller/pkg/controller/packages/application/status/summary.go
+++ b/deckhouse-controller/pkg/controller/packages/application/status/summary.go
@@ -239,7 +239,7 @@ func summarize(state condmap.State) (string, string, string) {
 			// Pipeline clear: install just completed (mirrors mapInstalled's
 			// success check) → ready; otherwise still waiting for dependent
 			// modules to converge.
-			if state.IntEqual(intScaled, metav1.ConditionTrue) {
+			if isInstallComplete(state) {
 				return summaryReady.state, summaryReady.message, summaryReady.tip
 			}
 			return adviseFor(phaseInstall, "Pending")

--- a/deckhouse-controller/pkg/controller/packages/application/status/summary_test.go
+++ b/deckhouse-controller/pkg/controller/packages/application/status/summary_test.go
@@ -415,6 +415,13 @@ func TestSummarize_EdgeCases(t *testing.T) {
 		assert.Empty(t, tip)
 	})
 
+	t.Run("scaled before the manifests are applied is not ready yet", func(t *testing.T) {
+		// The workload is ready while the run task is still inside the apply.
+		// Version, URLs and settings are committed under ManifestsApplied.
+		state, _, _ := summaryFor(intCond(intScaled, metav1.ConditionTrue, "Scaled"))
+		assert.Equal(t, statePending, state)
+	})
+
 	t.Run("workload reconciling during reconcile", func(t *testing.T) {
 		// The health monitor reports a rollout as Scaled=False/Reconciling.
 		state, message, tip := summaryFor(installed(), intCond(intScaled, metav1.ConditionFalse, "Reconciling"))


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Backport of #22504. The cherry-pick failed on two files: `pkg/controller/packages/module/status/{rules.go,summary.go}` do not exist on this branch, where `packages/module` is only `controller.go`. Those two are dropped; the rest applies unchanged — the nelm tracking forwarder and the Application condition gate.

`ReleaseInstall` closes the progress-report channel it is handed. The forwarder in `Client.Install` received from it without the ok check, so once the channel closed the goroutine looped on empty reports, and each one drove `UpdateTracking`, which sets `ManifestsApplied=False/ApplyingManifests`. The forwarder was never joined either, so one of those calls could land after the run task had set the condition True — and then it stayed False, with the run task finished and the queue empty. `currentVersion.version`, `urls` and `lastAppliedConfiguration` are committed under that condition.

`isInstallComplete` requires both conditions and now gates `mapInstalled` and the install branches of `mapReady` and `summarize` — the gate `mapManaged` and `mapConfigurationApplied` already used.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
An application reports `Installed=True`, `Ready=True` and summary `Ready` with no endpoint URLs, no current version and no applied configuration, so its published services stay invisible until a settings edit re-runs the apply.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: Fix an empty package status after a successful install
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
