### PR TITLE
[registrypackages] Add VEX entries for d8 image CVEs

### DIFF
--- a/modules/007-registrypackages/images/d8/known_vulnerabilities.vex
+++ b/modules/007-registrypackages/images/d8/known_vulnerabilities.vex
@@ -827,7 +827,7 @@
       ],
       "status": "not_affected",
       "justification": "vulnerable_code_not_in_execute_path",
-      "impact_statement": "Пакет golang.org/x/crypto/openpgp попадает в бинарь транзитивно через containers/image (сборка с тегом containers_image_openpgp) в составе подкоманды d8 delivery-kit. d8 не выполняет OpenPGP-операций: верификация simple-signing подписей не используется в рамках текущих функциональных спецификаций и эксплуатационных процессов системы.",
+      "impact_statement": "Пакет golang.org/x/crypto/openpgp попадает в бинарь как зависимость werf в составе подкоманды d8 delivery-kit (импортируется кодом werf и containers/image при сборке с тегом containers_image_openpgp). Это advisory о неподдерживаемом пакете без исправленной версии, а не конкретная уязвимость; OpenPGP-операции не вызываются в сценариях работы d8.",
       "timestamp": "2026-08-28T12:00:00Z"
     },
     {

--- a/modules/007-registrypackages/images/d8/known_vulnerabilities.vex
+++ b/modules/007-registrypackages/images/d8/known_vulnerabilities.vex
@@ -2,7 +2,7 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-5a4509a04e8128126aee080324a6b663a7748bf44b58a9a4b9c74d4801844f53",
   "author": "Deckhouse <contact@deckhouse.io>",
-  "version": 15,
+  "version": 16,
   "statements": [
     {
       "vulnerability": {
@@ -255,8 +255,596 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Уязвимость CVE-2026-39883 невозможно эксплуатировать в рамках Deckhouse, поскольку она не оказывает влияния на системы под управлением Linux. Данная проблема безопасности связана с выполнением команды kenv, которая является специфичной для операционных систем на базе BSD и Solaris и отсутвует в Linux",
       "timestamp": "2026-04-10T08:22:34.246444Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-8869"
+      },
+      "products": [
+        {
+          "@id": "pip:25.3"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. d8 delivery-kit не использует функционал извлечения tar-архивов с уязвимым fallback pip. Все используемые версии Python соответствуют требованиям PEP 706.",
+      "timestamp": "2025-10-09T14:31:32.069712443Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39883"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/go.opentelemetry.io/otel/sdk"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость CVE-2026-39883 невозможно эксплуатировать в рамках Deckhouse, поскольку она не оказывает влияния на системы под управлением Linux. Данная проблема безопасности связана с выполнением команды kenv, которая является специфичной для операционных систем на базе BSD и Solaris и отсутвует в Linux.",
+      "timestamp": "2026-04-10T09:11:04.735812Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-15558"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/docker/cli@v25.0.6+incompatible"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Уязвимость CWE-427 (Uncontrolled Search Path Element) в Docker CLI затрагивает исключительно среду Microsoft Windows: поиск бинарных плагинов в каталоге C:\\ProgramData\\Docker\\cli-plugins может позволить подмену исполняемых файлов. Бинарник d8 поставляется и эксплуатируется в среде Linux; официальное описание CVE указывает, что уязвимость не затрагивает non-Windows binaries, что исключает возможность эксплуатации.",
+      "timestamp": "2026-04-22T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-33747"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/moby/buildkit@v0.13.1"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Зависимость github.com/moby/buildkit является транзитивной, поступающей через цепочку werf. d8 delivery-kit не использует BuildKit frontend напрямую и не обрабатывает недоверенные Dockerfile через BuildKit API, что исключает возможность эксплуатации уязвимости записи файлов за пределы state directory.",
+      "timestamp": "2026-04-22T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-33748"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/moby/buildkit@v0.13.1"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Зависимость github.com/moby/buildkit является транзитивной, поступающей через цепочку werf. d8 delivery-kit не обрабатывает произвольные Git URL с фрагментами #ref:subdir через BuildKit, что исключает возможность эксплуатации уязвимости path traversal.",
+      "timestamp": "2026-04-22T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-34040"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/docker/docker@v25.0.6+incompatible"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Зависимость github.com/docker/docker зафиксирована на версии v25.0.6 через replace-директиву в deckhouse-cli для обеспечения совместимости с цепочкой werf. d8 delivery-kit использует docker исключительно как клиентскую библиотеку Docker API, уязвимый функционал Docker Engine не входит в исполняемый путь.",
+      "timestamp": "2026-04-22T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-23831"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/sigstore/rekor@v1.3.6"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Уязвимость типа nil pointer dereference в Rekor, затрагивающая обработку записей формата COSE (COSE entry type), не достигается в рамках использования. Соответствующий уязвимый путь выполнения не вызывается при текущих сценариях работы и не используется в рамках функциональных спецификаций системы.",
+      "timestamp": "2026-04-22T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-24117"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/sigstore/rekor@v1.3.6"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Уязвимость SSRF в endpoint /api/v1/index/retrieve Rekor не применима, поскольку функционал не использует указанный API и не инициирует обращения к данному endpoint. В результате отсутствует исполняемый путь, позволяющий задействовать уязвимый функционал.",
+      "timestamp": "2026-04-22T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-24137"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/sigstore/sigstore@v1.8.8"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Уязвимость path traversal в TUF-клиенте библиотеки sigstore не затрагивает, поскольку соответствующий функционал в рамках текущих сценариев эксплуатации не используется. Механизмы кэширования/загрузки данных из недоверенных TUF-репозиториев не применяются, что исключает достижимость уязвимого кода.",
+      "timestamp": "2026-04-22T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-25934"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/go-git/go-git/v5@v5.16.2"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Уязвимость, связанная с проверкой целостности файлов .idx/.pack в go-git, формально присутствует в используемой версии зависимости. Однако реализация атаки требует подмены данных Git-репозитория на стороне источника. В типовой модели эксплуатации источники репозиториев определяются и контролируются администратором, что не предоставляет нарушителю возможности управлять входными данными в необходимом объёме и существенно снижает применимость сценария эксплуатации.",
+      "timestamp": "2026-04-22T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-33997"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/docker/docker@v25.0.6+incompatible"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Зависимость github.com/docker/docker зафиксирована на версии v25.0.6 через replace-директиву в deckhouse-cli для обеспечения совместимости с цепочкой werf. d8 delivery-kit использует docker исключительно как клиентскую библиотеку Docker API, уязвимый функционал Docker Engine не входит в исполняемый путь.",
+      "timestamp": "2026-04-22T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-34165"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/go-git/go-git/v5@v5.16.2"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Уязвимость связана с обработкой вредоносных .idx файлов, вызывающих асимметричное потребление памяти. В типовой модели эксплуатации источники Git-репозиториев контролируются администратором, что не предоставляет нарушителю возможности подменить .idx файлы.",
+      "timestamp": "2026-04-22T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39882"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp@v0.44.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Зависимость go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp приходит транзитивно через werf и github.com/docker/buildx/util/metricutil и используется исключительно для экспорта метрик BuildKit-бекенда. d8 delivery-kit по умолчанию использует стандартный Docker backend, путь с BuildKit-метриками не активируется, что исключает возможность эксплуатации данной уязвимости.",
+      "timestamp": "2026-04-22T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-32280"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/stdlib@v1.25.8"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость CWE-770 (Allocation of Resources Without Limits) в Go stdlib v1.25.8 не эксплуатируема в бинарнике d8: обработка внешних входных данных ограничена администраторскими сценариями, неограниченное потребление ресурсов не достигается. Бамп Go toolchain в d8-cli будет выполнен в рамках планового апгрейда.",
+      "timestamp": "2026-04-22T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-32281"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/stdlib@v1.25.8"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость CWE-295 (Improper Certificate Validation) в Go stdlib v1.25.8 не эксплуатируема в бинарнике d8: TLS-соединения устанавливаются только к заранее доверенным registry-эндпоинтам, список которых определяется администратором, что исключает возможность эксплуатации уязвимости валидации сертификатов. Бамп Go toolchain в d8-cli будет выполнен в рамках планового апгрейда.",
+      "timestamp": "2026-04-22T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-32282"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/stdlib@v1.25.8"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость CWE-59 (Improper Link Resolution Before File Access, symlink following) в Go stdlib v1.25.8 не эксплуатируема в бинарнике d8: d8 не обрабатывает произвольные пути файловой системы от недоверенных пользователей - работает только с путями, указанными администратором. Бамп Go toolchain в d8-cli будет выполнен в рамках планового апгрейда.",
+      "timestamp": "2026-04-22T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-32283"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/stdlib@v1.25.8"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость CWE-770 (Allocation of Resources Without Limits) в Go stdlib v1.25.8 не эксплуатируема в бинарнике d8: входные данные, приводящие к неограниченному потреблению ресурсов, не могут быть предоставлены недоверенной стороной - d8 запускается локально администратором. Бамп Go toolchain в d8-cli будет выполнен в рамках планового апгрейда.",
+      "timestamp": "2026-04-22T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-32288"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/stdlib@v1.25.8"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость CWE-770 (Allocation of Resources Without Limits) в Go stdlib v1.25.8 не эксплуатируема в бинарнике d8: поверхность атаки ограничена локальным запуском администратором, вектор подачи недоверенных данных в уязвимый путь отсутствует. Бамп Go toolchain в d8-cli будет выполнен в рамках планового апгрейда.",
+      "timestamp": "2026-04-22T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-32289"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/stdlib@v1.25.8"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость CWE-79 (Cross-site Scripting) в Go stdlib v1.25.8 не эксплуатируема в бинарнике d8: d8 - это CLI-инструмент, не рендерит HTML и не работает как веб-сервер, выводящий контент в браузер. XSS-уязвимости в стандартной библиотеке не достигаются в рамках исполнения d8. Бамп Go toolchain в d8-cli будет выполнен в рамках планового апгрейда.",
+      "timestamp": "2026-04-22T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-33762"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/go-git/go-git/v5@v5.16.2"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Уязвимость связана с отсутствием валидации длины префикса имени пути в декодере Index v4, вызывающей panic. В типовой модели эксплуатации источники Git-репозиториев контролируются администратором, что не предоставляет нарушителю возможности подменить индексные файлы.",
+      "timestamp": "2026-04-22T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "GHSA-3xc5-wrhm-f963"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/go-git/go-git/v5@v5.16.2"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Уязвимость связана с обработкой вредоносных данных Git-репозитория (pack/index файлов), приводящей к некорректному поведению парсера. В типовой модели эксплуатации источники Git-репозиториев определяются и контролируются администратором, что не предоставляет нарушителю возможности подменить входные данные и исключает достижимость уязвимого кода.",
+      "timestamp": "2026-04-22T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-35469"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/moby/spdystream@v0.5.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "Уязвимость в github.com/moby/spdystream v0.5.0 достигается исключительно через подкоманду d8 backup etcd, где spdystream приходит транзитивно из k8s.io/client-go/transport/spdy. Уязвимый код обрабатывает SPDY-фреймы от kube-apiserver, который в типовой модели эксплуатации является доверенным компонентом под управлением администратора кластера. Возможность подачи вредоносных SPDY-фреймов нарушителем исключена архитектурой взаимодействия d8 с Kubernetes API.",
+      "timestamp": "2026-04-22T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-32952"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/Azure/go-ntlmssp@v0.0.0-20221128193559-754e69321358"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Зависимость github.com/Azure/go-ntlmssp является транзитивной, поступающей в d8 через цепочку deckhouse-cli (stronghold/vault command) → vault-plugin-secrets-openldap → go-ldap/ldap/v3. Уязвимость связана с panic при парсинге специально сформированных NTLM Type 2 challenge-сообщений от вредоносного NTLM-сервера. Функционал NTLM-аутентификации против произвольных LDAP-серверов в d8 не используется — LDAP-операции выполняются только в контексте управления Stronghold/Vault администратором кластера через d8 stronghold, где NTLM bind не применяется. Уязвимый исполняемый путь недостижим в рамках текущих функциональных спецификаций и эксплуатационных процессов системы.",
+      "timestamp": "2026-06-02T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-41506"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/go-git/go-git/v5@v5.16.2"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Уязвимость в github.com/go-git/go-git/v5 v5.16.2 проявляется при обработке данных Git-репозитория (pack/index). В типовой модели эксплуатации источники Git-репозиториев определяются и контролируются администратором кластера, что не предоставляет нарушителю возможности подать вредоносные данные в уязвимый исполняемый путь.",
+      "timestamp": "2026-06-02T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45022"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/go-git/go-git/v5@v5.16.2"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Уязвимость в github.com/go-git/go-git/v5 v5.16.2 проявляется при обработке данных Git-репозитория. В типовой модели эксплуатации источники Git-репозиториев определяются и контролируются администратором кластера, что не предоставляет нарушителю возможности подать вредоносные данные в уязвимый исполняемый путь.",
+      "timestamp": "2026-06-02T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-44740"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/go-git/go-billy/v5@v5.6.2"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Уязвимость в github.com/go-git/go-billy/v5 v5.6.2 (файловая абстракция для go-git) проявляется при обработке данных Git-репозитория. В типовой модели эксплуатации источники Git-репозиториев определяются и контролируются администратором кластера, что не предоставляет нарушителю возможности подать вредоносные данные в уязвимый исполняемый путь.",
+      "timestamp": "2026-06-02T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-44973"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/go-git/go-billy/v5@v5.6.2"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Уязвимость в github.com/go-git/go-billy/v5 v5.6.2 (файловая абстракция для go-git) проявляется при обработке данных Git-репозитория. В типовой модели эксплуатации источники Git-репозиториев определяются и контролируются администратором кластера, что не предоставляет нарушителю возможности подать вредоносные данные в уязвимый исполняемый путь.",
+      "timestamp": "2026-06-02T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "GHSA-pmwq-pjrm-6p5r"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/in-toto/in-toto-golang@v0.9.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Уязвимость в github.com/in-toto/in-toto-golang v0.9.0 связана с верификацией supply-chain attestations (in-toto layout/link metadata) в составе цепочки cosign/sigstore. d8 не верифицирует недоверенные in-toto-аттестации в рамках текущих сценариев эксплуатации — соответствующий исполняемый путь не вызывается, что исключает возможность эксплуатации.",
+      "timestamp": "2026-06-02T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-46680"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/containerd/containerd@v1.7.27"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Использование github.com/containerd/containerd ограничено операциями с OCI-образами и манифестами, а не компонентами CRI или runtime, в которых проявляется уязвимость.",
+      "timestamp": "2026-06-24T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-41567"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/docker/docker@v25.0.6+incompatible"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Зависимость github.com/docker/docker зафиксирована на версии v25.0.6; демон Docker Engine не запускается, уязвимый код не в пути выполнения.",
+      "timestamp": "2026-06-24T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-42306"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/docker/docker@v25.0.6+incompatible"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Зависимость github.com/docker/docker зафиксирована на версии v25.0.6; демон Docker Engine не запускается, уязвимый код не в пути выполнения.",
+      "timestamp": "2026-06-24T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-41568"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/docker/docker@v25.0.6+incompatible"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Зависимость github.com/docker/docker зафиксирована на версии v25.0.6; демон Docker Engine не запускается, уязвимый код не в пути выполнения.",
+      "timestamp": "2026-06-24T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45571"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/go-git/go-git/v5@v5.16.2"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Уязвимость github.com/go-git/go-git/v5 v5.16.2 проявляется при обработке вредоносных Git-данных из недоверенного источника, недостижимых в штатных операциях d8.",
+      "timestamp": "2026-06-24T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45570"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/go-git/go-git/v5@v5.16.2"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Уязвимость github.com/go-git/go-git/v5 v5.16.2 проявляется при обработке вредоносных Git-данных из недоверенного источника, недостижимых в штатных операциях d8.",
+      "timestamp": "2026-06-30T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "GHSA-w5pp-99ch-qj29"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/go-git/go-git/v5@v5.16.2"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Уязвимость github.com/go-git/go-git/v5 v5.16.2 проявляется при обработке вредоносных Git-данных из недоверенного источника, недостижимых в штатных операциях d8.",
+      "timestamp": "2026-06-24T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-53488"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/containerd/containerd@v1.7.27"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Использование github.com/containerd/containerd ограничено операциями с OCI-образами и манифестами, а уязвимость проявляется в CRI-плагине containerd при передаче label из конфигурации образа в контейнер, что не входит в путь выполнения.",
+      "timestamp": "2026-08-28T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-47262"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/containerd/containerd@v1.7.27"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Использование github.com/containerd/containerd ограничено операциями с OCI-образами и манифестами, а уязвимость (DoS через OOM процесса containerd) проявляется в runtime-компонентах при создании контейнера из вредоносного образа, что не входит в путь выполнения.",
+      "timestamp": "2026-08-28T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-41579"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/opencontainers/runc@v1.1.14"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Она проявляется в runc при подготовке rootfs контейнера (setupPtmx/setupDevSymlinks), а d8 delivery-kit не вызывает runc напрямую и использует Docker API.",
+      "timestamp": "2026-08-28T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-49478"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/sigstore/fulcio@v1.4.5"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Уязвимость (SSRF и утечка ServiceAccount-токенов через OIDC Discovery) проявляется в серверной части Fulcio (CA-сервис). Функционал обработки OIDC токенов в библиотеке github.com/sigstore/fulcio не используется в рамках текущих функциональных спецификаций и эксплуатационных процессов системы, что исключает возможность эксплуатации данной уязвимости.",
+      "timestamp": "2026-08-28T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-48702"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/sigstore/rekor@v1.3.6"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Уязвимость (DoS через неограниченную gzip-декомпрессию при разборе APK-файлов в Package.Unmarshal) проявляется в серверной части Rekor и достигается только через его API-endpoint. Библиотека github.com/sigstore/rekor используется только как клиент при проверке подписей, разбор APK-записей не вызывается.",
+      "timestamp": "2026-08-28T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "GO-2026-5932"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/crypto@v0.54.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Пакет golang.org/x/crypto/openpgp попадает в бинарь транзитивно через containers/image (сборка с тегом containers_image_openpgp) в составе подкоманды d8 delivery-kit. d8 не выполняет OpenPGP-операций: верификация simple-signing подписей не используется в рамках текущих функциональных спецификаций и эксплуатационных процессов системы.",
+      "timestamp": "2026-08-28T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-48978"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/oras.land/oras-go@v1.2.5"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Библиотека oras.land/oras-go попадает в бинарь транзитивно через Helm-клиент. Уязвимость (SSRF и TLS-downgrade через realm в WWW-Authenticate) требует обращения к злонамеренному или скомпрометированному registry, тогда как адреса registry задаются явно оператором в конфигурации.",
+      "timestamp": "2026-08-28T12:00:00Z"
     }
   ],
   "timestamp": "2026-01-16T12:00:00Z",
-  "last_updated": "2026-04-10T08:22:34Z"
+  "last_updated": "2026-08-28T12:00:00Z"
 }


### PR DESCRIPTION

## Description

Updates `modules/007-registrypackages/images/d8/known_vulnerabilities.vex`:

- copies 35 statements from the release-1.73 file that main did not have (the d8 dependency versions are the same on both lines)
- adds 7 new statements for CVEs not covered by any branch yet:
  - `containerd`: CVE-2026-53488, CVE-2026-47262
  - `runc`: CVE-2026-41579
  - `sigstore/fulcio`: CVE-2026-49478
  - `sigstore/rekor`: CVE-2026-48702
  - `x/crypto` (openpgp): GO-2026-5932
  - `oras-go`: CVE-2026-48978

All of these live in werf/delivery-kit transitive dependencies that d8 cannot bump on its own. Each statement explains why the vulnerable code is not reachable from d8.

## Why do we need it, and what problem does it solve?

The CSE release-1-77 image scan shows 31 open findings on the d8 registrypackage. Every reachable CVE is already fixed in the pinned d8 v0.33.11, so what remains is unreachable transitive code. This file closes all 31 findings.

## Why do we need it in the patch release (if we do)?

Needed in release-1.77: the findings come from the CSE release-1-77 scan. A backport PR follows after merge.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: registrypackages
type: chore
summary: Add VEX entries for unreachable CVEs in the d8 image.
impact_level: low
```
