### PR TITLE
[deckhouse] validate the hardlink target when extracting module and package images

### DIFF
--- a/deckhouse-controller/internal/registry/service.go
+++ b/deckhouse-controller/internal/registry/service.go
@@ -23,7 +23,6 @@ import (
 	"io"
 	"log/slog"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -248,15 +247,14 @@ func (s *Service) download(_ context.Context, img crv1.Image, output string) err
 			return fmt.Errorf("read tar: %w", err)
 		}
 
-		if strings.Contains(hdr.Name, "..") {
-			// CWE-22 check, prevents path traversal
-			return fmt.Errorf("path traversal detected in the package archive: malicious path %v", hdr.Name)
+		target, err := safeJoin(output, hdr.Name)
+		if err != nil {
+			return err
 		}
 
-		target := filepath.Join(output, hdr.Name)
 		switch hdr.Typeflag {
 		case tar.TypeDir:
-			if err = os.MkdirAll(target, os.FileMode(hdr.Mode)); err != nil {
+			if err = os.MkdirAll(target, 0o700); err != nil {
 				return fmt.Errorf("mkdir: %w", err)
 			}
 
@@ -278,14 +276,16 @@ func (s *Service) download(_ context.Context, img crv1.Image, output string) err
 			}
 
 		case tar.TypeSymlink:
-			if isRel(hdr.Linkname, target) && isRel(hdr.Name, target) {
-				if err = os.Symlink(hdr.Linkname, target); err != nil {
-					return fmt.Errorf("create symlink: %w", err)
-				}
-			}
+			// Dropped, as they always have been here: the guard this branch used rejected every
+			// input. Materializing them changes what a published image unpacks to - separate change.
 
 		case tar.TypeLink:
-			if err = os.Link(path.Join(output, hdr.Linkname), target); err != nil {
+			linkTarget, err := safeJoin(output, hdr.Linkname)
+			if err != nil {
+				return fmt.Errorf("hardlink target: %w", err)
+			}
+
+			if err = os.Link(linkTarget, target); err != nil {
 				return fmt.Errorf("create hardlink: %w", err)
 			}
 		}
@@ -294,20 +294,18 @@ func (s *Service) download(_ context.Context, img crv1.Image, output string) err
 	return nil
 }
 
-func isRel(candidate, target string) bool {
-	// GOOD: resolves all symbolic links before checking
-	// that `candidate` does not escape from `target`
-	if filepath.IsAbs(candidate) {
-		return false
+// safeJoin resolves a path taken from the image archive against root and rejects one that
+// escapes it. CWE-22 check: both the entry name and a hardlink target go through it, because
+// both end up as arguments to filesystem calls.
+func safeJoin(root, name string) (string, error) {
+	target := filepath.Join(root, name)
+
+	rel, err := filepath.Rel(root, target)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("path traversal detected in the package archive: malicious path %v", name)
 	}
 
-	realpath, err := filepath.EvalSymlinks(filepath.Join(target, candidate))
-	if err != nil {
-		return false
-	}
-
-	relpath, err := filepath.Rel(target, realpath)
-	return err == nil && !strings.HasPrefix(filepath.Clean(relpath), "..")
+	return target, nil
 }
 
 type Registry struct {


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
The tar extractor that unpacks module and package images guarded `hdr.Name` against path traversal but passed `hdr.Linkname` straight into `os.Link`, so a `tar.TypeLink` entry could point at a file outside the extraction root.

Manual backport of #22628. The cherry-pick does not apply here: `download` on this branch unpacks straight into `output`, without the scratch sibling and the closing rename. The fix itself is the same - `safeJoin` replaces `isRel` and is applied to both fields.

Symlink entries stay dropped, as they always were under `isRel` - now stated in a comment instead of hidden behind a guard that never passed; materializing them is a separate change. `tar.TypeDir` no longer takes its mode from the archive, matching the `&0o700` mask the regular-file branch already applies.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
A module or package image could place a hardlink to a file outside its own extraction directory into the installed tree, sharing that file's inode across the boundary. The reachable set is the mount holding the downloaded modules and packages, since `link(2)` returns `EXDEV` across mounts.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: validate the hardlink target when extracting module and package images
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
