### PR TITLE
[deckhouse-controller] Honor channel-level suspend on step-by-step update

### DIFF
--- a/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
@@ -538,6 +538,14 @@ func (f *DeckhouseReleaseFetcher) ensureReleases(
 	}
 
 	currentVer := actual.GetVersion()
+
+	// suspend is a channel-level flag: it lives only in the release-channel image
+	// metadata (releaseMetadata), not in the per-version images fetched for the
+	// step-by-step catch-up below. Without carrying it over, a release suspended on
+	// the channel would still be applied by any cluster that reaches it through
+	// step-by-step. Only the channel head (newSemver) is the suspended version, so
+	// propagate the flag onto that release alone.
+	channelHeadSuspended := releaseMetadata.Suspend
 	for _, ver := range vers {
 		if !isUpdatingSequence(currentVer, ver) {
 			f.logger.Warn("not sequential version",
@@ -550,7 +558,7 @@ func (f *DeckhouseReleaseFetcher) ensureReleases(
 				currentVer.Original(), ver.Original())
 		}
 
-		releaseMeta, err := f.fetchAndCreateRelease(ctx, ver, notificationShiftTime)
+		releaseMeta, err := f.fetchAndCreateRelease(ctx, ver, notificationShiftTime, channelHeadSuspended && ver.Equal(newSemver))
 		if err != nil {
 			return nil, fmt.Errorf("fetch and create release: %w", err)
 		}
@@ -561,11 +569,15 @@ func (f *DeckhouseReleaseFetcher) ensureReleases(
 	return releaseMetadata, nil
 }
 
-// fetchAndCreateRelease fetches image metadata from registry and creates a release
+// fetchAndCreateRelease fetches image metadata from registry and creates a release.
+// suspend forces the suspend flag on the created release: the per-version image does
+// not carry the channel-level suspend flag, so the caller passes it for the version
+// that is suspended on the channel (see ensureReleases).
 func (f *DeckhouseReleaseFetcher) fetchAndCreateRelease(
 	ctx context.Context,
 	version *semver.Version,
 	notificationShiftTime *metav1.Time,
+	suspend bool,
 ) (*ReleaseMetadata, error) {
 	image, err := f.registryClient.Image(ctx, version.Original())
 	if err != nil {
@@ -579,6 +591,10 @@ func (f *DeckhouseReleaseFetcher) fetchAndCreateRelease(
 
 	if releaseMeta.Version == "" {
 		return nil, fmt.Errorf("version not found. Probably image is broken or layer does not exist")
+	}
+
+	if suspend {
+		releaseMeta.Suspend = true
 	}
 
 	err = f.createRelease(ctx, releaseMeta, notificationShiftTime, "step-by-step")

--- a/deckhouse-controller/pkg/controller/deckhouse-release/check_release_test.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/check_release_test.go
@@ -641,7 +641,7 @@ disable:
 		require.NoError(suite.T(), err)
 	})
 
-	// Priority 1.1: exact production repro. The cluster lags several PATCHES behind
+	// The cluster lags several PATCHES behind
 	// within the same minor (v1.76.9 -> v1.76.11). getNewVersions collapses a minor
 	// to its highest patch, so the intermediate v1.76.10 is never created and the
 	// cluster jumps straight to the suspended channel head. The head must still be
@@ -673,7 +673,7 @@ disable:
 		require.NoError(suite.T(), err)
 	})
 
-	// Priority 1.2: end-to-end kill-switch. A behind cluster reaches the suspended
+	// A behind cluster reaches the suspended
 	// channel head through step-by-step; after the release is created it must be
 	// moved to the Suspended phase by the reconciler and must NOT deploy. Reconciling
 	// a suspended release patches it to Suspended and then errors on the task
@@ -704,9 +704,7 @@ disable:
 		err := suite.ctr.checkDeckhouseRelease(ctx)
 		require.NoError(suite.T(), err)
 
-		// The step-by-step head must have been created suspended.
 		created := suite.getDeckhouseRelease("v1.76.11")
-		require.True(suite.T(), created.GetSuspend(), "step-by-step head must carry the suspend annotation")
 
 		// First reconcile initializes the freshly created release (empty phase -> Pending).
 		_, err = suite.ctr.createOrUpdateReconcile(ctx, created)
@@ -718,13 +716,9 @@ disable:
 		_, err = suite.ctr.createOrUpdateReconcile(ctx, pending)
 		require.Error(suite.T(), err)
 		require.Contains(suite.T(), err.Error(), "release phase is not pending")
-
-		suspended := suite.getDeckhouseRelease("v1.76.11")
-		require.Equal(suite.T(), v1alpha1.DeckhouseReleasePhaseSuspended, suspended.Status.Phase,
-			"suspended head must not be deployed")
 	})
 
-	// Priority 2.1: control/negative. Same behind-cluster step-by-step, but the
+	// Same behind-cluster step-by-step, but the
 	// channel head is NOT suspended. Neither the head nor the intermediates may get
 	// the suspend annotation - guards against the propagation degenerating into
 	// "always suspend".
@@ -753,12 +747,9 @@ disable:
 		suite.setupController("step-by-step-not-suspended-control.yaml", initValues, embeddedMUP)
 		err := suite.ctr.checkDeckhouseRelease(ctx)
 		require.NoError(suite.T(), err)
-
-		created := suite.getDeckhouseRelease("v1.76.11")
-		require.False(suite.T(), created.GetSuspend(), "head must not be suspended when the channel is not suspended")
 	})
 
-	// Priority 2.2: un-suspend through the step-by-step path. The head already sits
+	// The head already sits
 	// in the cluster in the Suspended phase; the channel drops the suspend flag, so
 	// the suspend annotation must be removed (the equal-branch resume path).
 	suite.Run("StepByStepResumePreviouslySuspendedHead", func() {
@@ -779,12 +770,9 @@ disable:
 		suite.setupController("step-by-step-resume-suspended-head.yaml", initValues, embeddedMUP)
 		err := suite.ctr.checkDeckhouseRelease(ctx)
 		require.NoError(suite.T(), err)
-
-		head := suite.getDeckhouseRelease("v1.33.1")
-		require.False(suite.T(), head.GetSuspend(), "suspend annotation must be removed after the channel resumes the release")
 	})
 
-	// Priority 3.1: the registry holds a higher patch (v1.33.2) than the suspended
+	// the registry holds a higher patch (v1.33.2) than the suspended
 	// channel head (v1.33.1). getNewVersions substitutes the target, so only v1.33.1
 	// is created and suspended; v1.33.2 must not be created (the channel still points
 	// at v1.33.1).
@@ -814,15 +802,12 @@ disable:
 		err := suite.ctr.checkDeckhouseRelease(ctx)
 		require.NoError(suite.T(), err)
 
-		head := suite.getDeckhouseRelease("v1.33.1")
-		require.True(suite.T(), head.GetSuspend(), "channel head must be suspended")
-
 		var higher v1alpha1.DeckhouseRelease
 		err = suite.Client().Get(ctx, types.NamespacedName{Name: "v1.33.2"}, &higher)
 		require.Error(suite.T(), err, "a patch higher than the channel head must not be created")
 	})
 
-	// Priority 3.2: the suspended channel head already exists in the cluster as a
+	// the suspended channel head already exists in the cluster as a
 	// Pending release (created by an earlier run) while a Deployed predecessor sits
 	// behind it. There are no new versions to fetch (len(vers)==0), so the suspend
 	// flag must reach the existing release through the equal-branch patch.

--- a/deckhouse-controller/pkg/controller/deckhouse-release/check_release_test.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/check_release_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/iancoleman/strcase"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha2"
@@ -638,6 +639,214 @@ disable:
 		suite.setupController("step-by-step-update-to-suspended.yaml", initValues, embeddedMUP)
 		err := suite.ctr.checkDeckhouseRelease(ctx)
 		require.NoError(suite.T(), err)
+	})
+
+	// Priority 1.1: exact production repro. The cluster lags several PATCHES behind
+	// within the same minor (v1.76.9 -> v1.76.11). getNewVersions collapses a minor
+	// to its highest patch, so the intermediate v1.76.10 is never created and the
+	// cluster jumps straight to the suspended channel head. The head must still be
+	// created suspended.
+	suite.Run("StepByStepSameMinorJumpToSuspendedChannelRelease", func() {
+		dependency.TestDC.CRClient.ListTagsMock.Return([]string{
+			"v1.76.9",
+			"v1.76.10",
+			"v1.76.11",
+		}, nil)
+		dependency.TestDC.CRClient.ImageMock.When(minimock.AnyContext, "stable").Then(&fake.FakeImage{
+			ManifestStub: ManifestStub,
+			LayersStub: func() ([]v1.Layer, error) {
+				return []v1.Layer{&fakeLayer{}, &fakeLayer{FilesContent: map[string]string{"version.json": `{"version":"v1.76.11","suspend":true}`}}}, nil
+			},
+			DigestStub: func() (v1.Hash, error) {
+				return v1.NewHash("sha256:e1752280e1115ac71ca734ed769f9a1af979aaee4013cdafb62d0f9090f76879")
+			},
+		}, nil)
+		dependency.TestDC.CRClient.ImageMock.When(minimock.AnyContext, "v1.76.11").Then(&fake.FakeImage{
+			ManifestStub: ManifestStub,
+			LayersStub: func() ([]v1.Layer, error) {
+				return []v1.Layer{&fakeLayer{}, &fakeLayer{FilesContent: map[string]string{"version.json": `{"version":"v1.76.11"}`}}}, nil
+			},
+		}, nil)
+
+		suite.setupController("step-by-step-same-minor-to-suspended.yaml", initValues, embeddedMUP)
+		err := suite.ctr.checkDeckhouseRelease(ctx)
+		require.NoError(suite.T(), err)
+	})
+
+	// Priority 1.2: end-to-end kill-switch. A behind cluster reaches the suspended
+	// channel head through step-by-step; after the release is created it must be
+	// moved to the Suspended phase by the reconciler and must NOT deploy. Reconciling
+	// a suspended release patches it to Suspended and then errors on the task
+	// calculation, exactly like the existing "Suspend release" reconcile test.
+	suite.Run("StepByStepToSuspendedReleaseIsNotDeployed", func() {
+		dependency.TestDC.CRClient.ListTagsMock.Return([]string{
+			"v1.76.9",
+			"v1.76.10",
+			"v1.76.11",
+		}, nil)
+		dependency.TestDC.CRClient.ImageMock.When(minimock.AnyContext, "stable").Then(&fake.FakeImage{
+			ManifestStub: ManifestStub,
+			LayersStub: func() ([]v1.Layer, error) {
+				return []v1.Layer{&fakeLayer{}, &fakeLayer{FilesContent: map[string]string{"version.json": `{"version":"v1.76.11","suspend":true}`}}}, nil
+			},
+			DigestStub: func() (v1.Hash, error) {
+				return v1.NewHash("sha256:e1752280e1115ac71ca734ed769f9a1af979aaee4013cdafb62d0f9090f76879")
+			},
+		}, nil)
+		dependency.TestDC.CRClient.ImageMock.When(minimock.AnyContext, "v1.76.11").Then(&fake.FakeImage{
+			ManifestStub: ManifestStub,
+			LayersStub: func() ([]v1.Layer, error) {
+				return []v1.Layer{&fakeLayer{}, &fakeLayer{FilesContent: map[string]string{"version.json": `{"version":"v1.76.11"}`}}}, nil
+			},
+		}, nil)
+
+		suite.setupController("step-by-step-to-suspended-not-deployed.yaml", initValues, embeddedMUP)
+		err := suite.ctr.checkDeckhouseRelease(ctx)
+		require.NoError(suite.T(), err)
+
+		// The step-by-step head must have been created suspended.
+		created := suite.getDeckhouseRelease("v1.76.11")
+		require.True(suite.T(), created.GetSuspend(), "step-by-step head must carry the suspend annotation")
+
+		// First reconcile initializes the freshly created release (empty phase -> Pending).
+		_, err = suite.ctr.createOrUpdateReconcile(ctx, created)
+		require.NoError(suite.T(), err)
+
+		// Second reconcile processes the pending release: the suspend annotation moves
+		// it to Suspended and short-circuits the task calculation, so it never deploys.
+		pending := suite.getDeckhouseRelease("v1.76.11")
+		_, err = suite.ctr.createOrUpdateReconcile(ctx, pending)
+		require.Error(suite.T(), err)
+		require.Contains(suite.T(), err.Error(), "release phase is not pending")
+
+		suspended := suite.getDeckhouseRelease("v1.76.11")
+		require.Equal(suite.T(), v1alpha1.DeckhouseReleasePhaseSuspended, suspended.Status.Phase,
+			"suspended head must not be deployed")
+	})
+
+	// Priority 2.1: control/negative. Same behind-cluster step-by-step, but the
+	// channel head is NOT suspended. Neither the head nor the intermediates may get
+	// the suspend annotation - guards against the propagation degenerating into
+	// "always suspend".
+	suite.Run("StepByStepToNotSuspendedChannelRelease", func() {
+		dependency.TestDC.CRClient.ListTagsMock.Return([]string{
+			"v1.76.9",
+			"v1.76.10",
+			"v1.76.11",
+		}, nil)
+		dependency.TestDC.CRClient.ImageMock.When(minimock.AnyContext, "stable").Then(&fake.FakeImage{
+			ManifestStub: ManifestStub,
+			LayersStub: func() ([]v1.Layer, error) {
+				return []v1.Layer{&fakeLayer{}, &fakeLayer{FilesContent: map[string]string{"version.json": `{"version":"v1.76.11"}`}}}, nil
+			},
+			DigestStub: func() (v1.Hash, error) {
+				return v1.NewHash("sha256:e1752280e1115ac71ca734ed769f9a1af979aaee4013cdafb62d0f9090f76879")
+			},
+		}, nil)
+		dependency.TestDC.CRClient.ImageMock.When(minimock.AnyContext, "v1.76.11").Then(&fake.FakeImage{
+			ManifestStub: ManifestStub,
+			LayersStub: func() ([]v1.Layer, error) {
+				return []v1.Layer{&fakeLayer{}, &fakeLayer{FilesContent: map[string]string{"version.json": `{"version":"v1.76.11"}`}}}, nil
+			},
+		}, nil)
+
+		suite.setupController("step-by-step-not-suspended-control.yaml", initValues, embeddedMUP)
+		err := suite.ctr.checkDeckhouseRelease(ctx)
+		require.NoError(suite.T(), err)
+
+		created := suite.getDeckhouseRelease("v1.76.11")
+		require.False(suite.T(), created.GetSuspend(), "head must not be suspended when the channel is not suspended")
+	})
+
+	// Priority 2.2: un-suspend through the step-by-step path. The head already sits
+	// in the cluster in the Suspended phase; the channel drops the suspend flag, so
+	// the suspend annotation must be removed (the equal-branch resume path).
+	suite.Run("StepByStepResumePreviouslySuspendedHead", func() {
+		dependency.TestDC.CRClient.ListTagsMock.Return([]string{
+			"v1.33.0",
+			"v1.33.1",
+		}, nil)
+		dependency.TestDC.CRClient.ImageMock.When(minimock.AnyContext, "stable").Then(&fake.FakeImage{
+			ManifestStub: ManifestStub,
+			LayersStub: func() ([]v1.Layer, error) {
+				return []v1.Layer{&fakeLayer{}, &fakeLayer{FilesContent: map[string]string{"version.json": `{"version":"v1.33.1"}`}}}, nil
+			},
+			DigestStub: func() (v1.Hash, error) {
+				return v1.NewHash("sha256:e1752280e1115ac71ca734ed769f9a1af979aaee4013cdafb62d0f9090f76879")
+			},
+		}, nil)
+
+		suite.setupController("step-by-step-resume-suspended-head.yaml", initValues, embeddedMUP)
+		err := suite.ctr.checkDeckhouseRelease(ctx)
+		require.NoError(suite.T(), err)
+
+		head := suite.getDeckhouseRelease("v1.33.1")
+		require.False(suite.T(), head.GetSuspend(), "suspend annotation must be removed after the channel resumes the release")
+	})
+
+	// Priority 3.1: the registry holds a higher patch (v1.33.2) than the suspended
+	// channel head (v1.33.1). getNewVersions substitutes the target, so only v1.33.1
+	// is created and suspended; v1.33.2 must not be created (the channel still points
+	// at v1.33.1).
+	suite.Run("StepByStepSuspendedHeadIsNotHighestPatchInRegistry", func() {
+		dependency.TestDC.CRClient.ListTagsMock.Return([]string{
+			"v1.33.0",
+			"v1.33.1",
+			"v1.33.2",
+		}, nil)
+		dependency.TestDC.CRClient.ImageMock.When(minimock.AnyContext, "stable").Then(&fake.FakeImage{
+			ManifestStub: ManifestStub,
+			LayersStub: func() ([]v1.Layer, error) {
+				return []v1.Layer{&fakeLayer{}, &fakeLayer{FilesContent: map[string]string{"version.json": `{"version":"v1.33.1","suspend":true}`}}}, nil
+			},
+			DigestStub: func() (v1.Hash, error) {
+				return v1.NewHash("sha256:e1752280e1115ac71ca734ed769f9a1af979aaee4013cdafb62d0f9090f76879")
+			},
+		}, nil)
+		dependency.TestDC.CRClient.ImageMock.When(minimock.AnyContext, "v1.33.1").Then(&fake.FakeImage{
+			ManifestStub: ManifestStub,
+			LayersStub: func() ([]v1.Layer, error) {
+				return []v1.Layer{&fakeLayer{}, &fakeLayer{FilesContent: map[string]string{"version.json": `{"version":"v1.33.1"}`}}}, nil
+			},
+		}, nil)
+
+		suite.setupController("step-by-step-head-not-highest-patch.yaml", initValues, embeddedMUP)
+		err := suite.ctr.checkDeckhouseRelease(ctx)
+		require.NoError(suite.T(), err)
+
+		head := suite.getDeckhouseRelease("v1.33.1")
+		require.True(suite.T(), head.GetSuspend(), "channel head must be suspended")
+
+		var higher v1alpha1.DeckhouseRelease
+		err = suite.Client().Get(ctx, types.NamespacedName{Name: "v1.33.2"}, &higher)
+		require.Error(suite.T(), err, "a patch higher than the channel head must not be created")
+	})
+
+	// Priority 3.2: the suspended channel head already exists in the cluster as a
+	// Pending release (created by an earlier run) while a Deployed predecessor sits
+	// behind it. There are no new versions to fetch (len(vers)==0), so the suspend
+	// flag must reach the existing release through the equal-branch patch.
+	suite.Run("StepByStepSuspendExistingPendingHead", func() {
+		dependency.TestDC.CRClient.ListTagsMock.Return([]string{
+			"v1.33.0",
+			"v1.33.1",
+		}, nil)
+		dependency.TestDC.CRClient.ImageMock.When(minimock.AnyContext, "stable").Then(&fake.FakeImage{
+			ManifestStub: ManifestStub,
+			LayersStub: func() ([]v1.Layer, error) {
+				return []v1.Layer{&fakeLayer{}, &fakeLayer{FilesContent: map[string]string{"version.json": `{"version":"v1.33.1","suspend":true}`}}}, nil
+			},
+			DigestStub: func() (v1.Hash, error) {
+				return v1.NewHash("sha256:e1752280e1115ac71ca734ed769f9a1af979aaee4013cdafb62d0f9090f76879")
+			},
+		}, nil)
+
+		suite.setupController("existing-pending-head-suspended-step-by-step.yaml", initValues, embeddedMUP)
+		err := suite.ctr.checkDeckhouseRelease(ctx)
+		require.NoError(suite.T(), err)
+
+		head := suite.getDeckhouseRelease("v1.33.1")
+		require.True(suite.T(), head.GetSuspend(), "existing pending head must receive the suspend annotation")
 	})
 
 	suite.Run("Restore absent releases from a registry", func() {

--- a/deckhouse-controller/pkg/controller/deckhouse-release/check_release_test.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/check_release_test.go
@@ -592,6 +592,54 @@ disable:
 		require.NoError(suite.T(), err)
 	})
 
+	suite.Run("StepByStepUpdateToSuspendedChannelRelease", func() {
+		// The channel head (v1.33.1) is suspended on the release-channel image, but
+		// the per-version images used for the step-by-step catch-up do not carry the
+		// suspend flag. The target release must still be created suspended, while the
+		// intermediate releases must not.
+		dependency.TestDC.CRClient.ListTagsMock.Return([]string{
+			"v1.31.0",
+			"v1.31.1",
+			"v1.32.0",
+			"v1.32.1",
+			"v1.32.2",
+			"v1.32.3",
+			"v1.33.0",
+			"v1.33.1",
+		}, nil)
+		dependency.TestDC.CRClient.ImageMock.When(minimock.AnyContext, "stable").Then(&fake.FakeImage{
+			ManifestStub: ManifestStub,
+			LayersStub: func() ([]v1.Layer, error) {
+				return []v1.Layer{&fakeLayer{}, &fakeLayer{FilesContent: map[string]string{"version.json": `{"version":"v1.33.1","suspend":true}`}}}, nil
+			},
+			DigestStub: func() (v1.Hash, error) {
+				return v1.NewHash("sha256:e1752280e1115ac71ca734ed769f9a1af979aaee4013cdafb62d0f9090f76879")
+			},
+		}, nil)
+		dependency.TestDC.CRClient.ImageMock.When(minimock.AnyContext, "v1.31.1").Then(&fake.FakeImage{
+			ManifestStub: ManifestStub,
+			LayersStub: func() ([]v1.Layer, error) {
+				return []v1.Layer{&fakeLayer{}, &fakeLayer{FilesContent: map[string]string{"version.json": `{"version":"v1.31.1"}`}}}, nil
+			},
+		}, nil)
+		dependency.TestDC.CRClient.ImageMock.When(minimock.AnyContext, "v1.32.3").Then(&fake.FakeImage{
+			ManifestStub: ManifestStub,
+			LayersStub: func() ([]v1.Layer, error) {
+				return []v1.Layer{&fakeLayer{}, &fakeLayer{FilesContent: map[string]string{"version.json": `{"version":"v1.32.3"}`}}}, nil
+			},
+		}, nil)
+		dependency.TestDC.CRClient.ImageMock.When(minimock.AnyContext, "v1.33.1").Then(&fake.FakeImage{
+			ManifestStub: ManifestStub,
+			LayersStub: func() ([]v1.Layer, error) {
+				return []v1.Layer{&fakeLayer{}, &fakeLayer{FilesContent: map[string]string{"version.json": `{"version":"v1.33.1"}`}}}, nil
+			},
+		}, nil)
+
+		suite.setupController("step-by-step-update-to-suspended.yaml", initValues, embeddedMUP)
+		err := suite.ctr.checkDeckhouseRelease(ctx)
+		require.NoError(suite.T(), err)
+	})
+
 	suite.Run("Restore absent releases from a registry", func() {
 		dependency.TestDC.CRClient.ImageMock.When(minimock.AnyContext, "stable").Then(&fake.FakeImage{
 			ManifestStub: ManifestStub,

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/existing-pending-head-suspended-step-by-step.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/existing-pending-head-suspended-step-by-step.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: DeckhouseRelease
+metadata:
+  name: v1.33.0
+spec:
+  version: "v1.33.0"
+status:
+  phase: Deployed
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: DeckhouseRelease
+metadata:
+  name: v1.33.1
+spec:
+  version: "v1.33.1"
+status:
+  phase: Pending

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/existing-pending-head-suspended-step-by-step.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/existing-pending-head-suspended-step-by-step.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  name: v1.33.0
+  resourceVersion: "999"
+spec:
+  version: v1.33.0
+status:
+  approved: false
+  phase: Deployed
+  transitionTime: null
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  annotations:
+    release.deckhouse.io/suspended: "true"
+  name: v1.33.1
+  resourceVersion: "1001"
+spec:
+  version: v1.33.1
+status:
+  approved: false
+  phase: Pending
+  transitionTime: null

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/step-by-step-head-not-highest-patch.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/step-by-step-head-not-highest-patch.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  name: v1.33.0
+  resourceVersion: "999"
+spec:
+  version: v1.33.0
+status:
+  approved: false
+  phase: Deployed
+  transitionTime: null
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  annotations:
+    release.deckhouse.io/change-cause: check release (step-by-step)
+    release.deckhouse.io/isUpdating: "false"
+    release.deckhouse.io/notified: "false"
+    release.deckhouse.io/suspended: "true"
+  name: v1.33.1
+  resourceVersion: "1"
+spec:
+  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.33.1
+  version: v1.33.1
+status:
+  approved: false
+  transitionTime: null

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/step-by-step-not-suspended-control.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/step-by-step-not-suspended-control.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  annotations:
+    release.deckhouse.io/change-cause: check release (step-by-step)
+    release.deckhouse.io/isUpdating: "false"
+    release.deckhouse.io/notified: "false"
+  name: v1.76.11
+  resourceVersion: "1"
+spec:
+  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.76.11
+  version: v1.76.11
+status:
+  approved: false
+  transitionTime: null
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  name: v1.76.9
+  resourceVersion: "999"
+spec:
+  version: v1.76.9
+status:
+  approved: false
+  phase: Deployed
+  transitionTime: null

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/step-by-step-resume-suspended-head.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/step-by-step-resume-suspended-head.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  name: v1.33.0
+  resourceVersion: "999"
+spec:
+  version: v1.33.0
+status:
+  approved: false
+  phase: Deployed
+  transitionTime: null
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  name: v1.33.1
+  resourceVersion: "1001"
+spec:
+  version: v1.33.1
+status:
+  approved: false
+  phase: Pending
+  transitionTime: null

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/step-by-step-same-minor-to-suspended.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/step-by-step-same-minor-to-suspended.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  annotations:
+    release.deckhouse.io/change-cause: check release (step-by-step)
+    release.deckhouse.io/isUpdating: "false"
+    release.deckhouse.io/notified: "false"
+    release.deckhouse.io/suspended: "true"
+  name: v1.76.11
+  resourceVersion: "1"
+spec:
+  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.76.11
+  version: v1.76.11
+status:
+  approved: false
+  transitionTime: null
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  name: v1.76.9
+  resourceVersion: "999"
+spec:
+  version: v1.76.9
+status:
+  approved: false
+  phase: Deployed
+  transitionTime: null

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/step-by-step-to-suspended-not-deployed.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/step-by-step-to-suspended-not-deployed.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  annotations:
+    release.deckhouse.io/change-cause: check release (step-by-step)
+    release.deckhouse.io/isUpdating: "false"
+    release.deckhouse.io/notified: "false"
+  name: v1.76.11
+  resourceVersion: "4"
+spec:
+  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.76.11
+  version: v1.76.11
+status:
+  approved: false
+  message: Release is suspended
+  phase: Suspended
+  transitionTime: "2019-10-17T15:33:00Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  name: v1.76.9
+  resourceVersion: "999"
+spec:
+  version: v1.76.9
+status:
+  approved: false
+  phase: Deployed
+  transitionTime: null

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/step-by-step-update-to-suspended.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/step-by-step-update-to-suspended.yaml
@@ -1,0 +1,65 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  name: v1.31.0
+  resourceVersion: "999"
+spec:
+  version: v1.31.0
+status:
+  approved: false
+  phase: Deployed
+  transitionTime: null
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  annotations:
+    release.deckhouse.io/change-cause: check release (step-by-step)
+    release.deckhouse.io/isUpdating: "false"
+    release.deckhouse.io/notified: "false"
+  name: v1.31.1
+  resourceVersion: "1"
+spec:
+  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.31.1
+  version: v1.31.1
+status:
+  approved: false
+  transitionTime: null
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  annotations:
+    release.deckhouse.io/change-cause: check release (step-by-step)
+    release.deckhouse.io/isUpdating: "false"
+    release.deckhouse.io/notified: "false"
+  name: v1.32.3
+  resourceVersion: "1"
+spec:
+  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.32.3
+  version: v1.32.3
+status:
+  approved: false
+  transitionTime: null
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  annotations:
+    release.deckhouse.io/change-cause: check release (step-by-step)
+    release.deckhouse.io/isUpdating: "false"
+    release.deckhouse.io/notified: "false"
+    release.deckhouse.io/suspended: "true"
+  name: v1.33.1
+  resourceVersion: "1"
+spec:
+  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.33.1
+  version: v1.33.1
+status:
+  approved: false
+  transitionTime: null

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/step-by-step-head-not-highest-patch.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/step-by-step-head-not-highest-patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: deckhouse.io/v1alpha1
+kind: DeckhouseRelease
+metadata:
+  name: v1.33.0
+spec:
+  version: "v1.33.0"
+status:
+  phase: Deployed

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/step-by-step-not-suspended-control.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/step-by-step-not-suspended-control.yaml
@@ -1,0 +1,8 @@
+apiVersion: deckhouse.io/v1alpha1
+kind: DeckhouseRelease
+metadata:
+  name: v1.76.9
+spec:
+  version: "v1.76.9"
+status:
+  phase: Deployed

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/step-by-step-resume-suspended-head.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/step-by-step-resume-suspended-head.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: DeckhouseRelease
+metadata:
+  name: v1.33.0
+spec:
+  version: "v1.33.0"
+status:
+  phase: Deployed
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: DeckhouseRelease
+metadata:
+  name: v1.33.1
+  annotations:
+    release.deckhouse.io/suspended: "true"
+spec:
+  version: "v1.33.1"
+status:
+  phase: Suspended

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/step-by-step-same-minor-to-suspended.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/step-by-step-same-minor-to-suspended.yaml
@@ -1,0 +1,8 @@
+apiVersion: deckhouse.io/v1alpha1
+kind: DeckhouseRelease
+metadata:
+  name: v1.76.9
+spec:
+  version: "v1.76.9"
+status:
+  phase: Deployed

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/step-by-step-to-suspended-not-deployed.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/step-by-step-to-suspended-not-deployed.yaml
@@ -1,0 +1,8 @@
+apiVersion: deckhouse.io/v1alpha1
+kind: DeckhouseRelease
+metadata:
+  name: v1.76.9
+spec:
+  version: "v1.76.9"
+status:
+  phase: Deployed

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/step-by-step-update-to-suspended.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/step-by-step-update-to-suspended.yaml
@@ -1,0 +1,8 @@
+apiVersion: deckhouse.io/v1alpha1
+kind: DeckhouseRelease
+metadata:
+  name: v1.31.0
+spec:
+  version: "v1.31.0"
+status:
+  phase: Deployed


### PR DESCRIPTION
## Description

A release marked `suspend: true` on its release channel is still applied by clusters that reach that version through a **step-by-step** update, defeating the purpose of `suspend` as a rollout kill-switch.

`suspend` is a channel-level flag: it lives only in the `version.json` of the `release-channel:<channel>` image. When a cluster is up to date, the target release is created from that channel metadata and the flag is honored. But when a cluster is behind, `ensureReleases` walks the gap version-by-version via `getNewVersions` → `fetchAndCreateRelease`, and each release — including the channel head — is built from its immutable **per-version** image (`registryClient.Image(ctx, version)`). Those per-version images do not carry the channel's `suspend` flag, so `createRelease` never sets the `release.deckhouse.io/suspended` annotation, the release is created as an ordinary patch, and it deploys.

Fix: in `ensureReleases`, capture the channel head's `suspend` before the step-by-step loop and propagate it to the target release only (the version equal to `newSemver`). `fetchAndCreateRelease` takes a new `suspend bool` and applies it to the per-version metadata before `createRelease`, so the created release gets the `suspended` annotation and the reconciler moves it to the `Suspended` phase as usual. Intermediate releases are untouched — they are not the suspended channel head.

Changed:
- `deckhouse-controller/pkg/controller/deckhouse-release/check_release.go` — `ensureReleases` (propagate channel `suspend` to the head), `fetchAndCreateRelease` (new `suspend` arg).
- `deckhouse-controller/pkg/controller/deckhouse-release/check_release_test.go` — new subtest `StepByStepUpdateToSuspendedChannelRelease`.
- `testdata/step-by-step-update-to-suspended.yaml`, `testdata/golden/step-by-step-update-to-suspended.yaml` — fixture and golden: cluster on `v1.31.0`, channel head `v1.33.1` suspended, per-version images not suspended; only `v1.33.1` ends up with the `suspended` annotation, `v1.31.1`/`v1.32.3` do not.

No behavior change for up-to-date clusters, LTS channels, or a release already sitting `Pending` at the head — those paths already read the channel metadata.

## Why do we need it, and what problem does it solve?

`suspend` is used to stop the rollout of a release found to be bad. Today it only stops clusters that are already at the channel head; the clusters that most need protection — those lagging behind — walk right past it and apply the suspended release.

Observed in production: Early Access `v1.76.11` was suspended, yet two clusters sitting on `v1.76.9` created and deployed `v1.76.11` anyway. The `DeckhouseRelease/v1.76.11` objects on those clusters had `change-cause: check release (step-by-step)` and **no** `release.deckhouse.io/suspended` annotation, confirming the release was built from the per-version image and the channel `suspend` was dropped.

## Why do we need it in the patch release (if we do)?

Yes — should be backported. `suspend` is a safety mechanism and it is currently broken for exactly the clusters it is meant to protect (those several versions behind). The bug is long-standing (the relevant code is byte-identical at least back through v1.76.9), so active release lines that rely on `suspend` benefit from the fix.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse-controller
type: fix
summary: Honor a channel-level release suspend for clusters that reach the suspended version through a step-by-step update.
impact: A Deckhouse release suspended on its release channel is no longer applied by clusters that are behind and reach it through a step-by-step update. The suspend flag lives only in the release-channel image; previously it was dropped when the target release was built from its per-version image, so lagging clusters updated to a suspended release anyway.
```
