### PR TITLE
[docs] Reserved sdn agent healthcheck port

### DIFF
--- a/docs/documentation/_data/deckhouse-ports.yml
+++ b/docs/documentation/_data/deckhouse-ports.yml
@@ -432,6 +432,11 @@ groups:
     description:
       en: "`sds-replicated-volume` DRBD metrics of the agent, the address the proxy forwards to"
       ru: "Метрики DRBD агента модуля `sds-replicated-volume`, адрес, на который проксируется запрос"
+  - ports: "4275"
+    protocol: TCP
+    description:
+      en: "`sdn` agent healthcheck"
+      ru: "Healthcheck компонента agent модуля `sdn`"
   - ports: "4135-4199"
     protocol: TCP
     description:


### PR DESCRIPTION
## Description
This PR reserves port `4275` in `docs/documentation/_data/deckhouse-ports.yml` for the `sdn` module's agent health check

## Why do we need it, and what problem does it solve?
The `sdn` agent uses port `4275` for its health check. Reserving the port in the Deckhouse port registry prevents it from being allocated by other modules and avoids potential port conflicts

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: chore
summary: Reserved sdn agent healthcheck port
impact_level: low
```