### PR TITLE
[node-manager] Fix NodeCapacity calculation

### DIFF
--- a/modules/040-node-manager/images/node-controller/src/internal/controller/capi/capi_cloud.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/capi/capi_cloud.go
@@ -69,7 +69,12 @@ func buildCAPIMachineDeployment(in capiMDInput) *unstructured.Unstructured {
 	if s := serializeNodeGroupTaints(in.ng); s != "" {
 		annotations["capacity.cluster-autoscaler.kubernetes.io/taints"] = s
 	}
-	if nodeCapacity := in.resolved.NodeCapacity; nodeCapacity != nil {
+	// TemplateCapacity, not NodeCapacity: the autoscaler's clusterapi provider builds its template
+	// NodeInfo from these two annotations and needs one for every group it discovers, including the
+	// groups that never scale from zero. A discovered group with neither a registered Node nor a
+	// template makes ResourcesLeft fail with "No node info for: <group>", which aborts scale-up for
+	// every other group in the cluster as well.
+	if nodeCapacity := in.resolved.TemplateCapacity; nodeCapacity != nil {
 		annotations["capacity.cluster-autoscaler.kubernetes.io/cpu"] = nodeCapacity.CPU.String()
 		annotations["capacity.cluster-autoscaler.kubernetes.io/memory"] = nodeCapacity.Memory.String()
 	}

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/capi/machinedeployment_test.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/capi/machinedeployment_test.go
@@ -195,14 +195,20 @@ func TestSerializeNodeGroupTaints(t *testing.T) {
 	})
 }
 
-func TestBuildCAPIMachineDeploymentScaleFromZeroCapacity(t *testing.T) {
+// The autoscaler's clusterapi provider builds its template NodeInfo from these annotations, and it
+// needs one for every group it discovers — not only the ones that scale from zero. TemplateCapacity
+// is resolved for every group that can hold a machine, so a fixed-size group carries them too.
+func TestBuildCAPIMachineDeploymentCapacityAnnotations(t *testing.T) {
 	ng := &deckhousev1.NodeGroup{}
 	ng.Name = "worker"
 	resolved := derived_status.ResolvedNodeGroup{
-		NodeCapacity: &capacity.InstanceType{CPU: resource.MustParse("4"), Memory: resource.MustParse("8Gi")},
+		TemplateCapacity: &capacity.InstanceType{CPU: resource.MustParse("4"), Memory: resource.MustParse("8Gi")},
 	}
 
-	md := buildCAPIMachineDeployment(capiMDInput{ng: ng, resolved: resolved})
+	// minReplicas 1: a group that never scales from zero must still be annotated, otherwise the
+	// autoscaler fails cluster-wide with "No node info for: <group>" whenever the group's only
+	// Node is missing.
+	md := buildCAPIMachineDeployment(capiMDInput{ng: ng, resolved: resolved, minReplicas: 1, maxReplicas: 1})
 	annotations := md.Object["metadata"].(map[string]interface{})["annotations"].(map[string]interface{})
 
 	for key, want := range map[string]string{
@@ -215,6 +221,28 @@ func TestBuildCAPIMachineDeploymentScaleFromZeroCapacity(t *testing.T) {
 		}
 		if _, err := resource.ParseQuantity(got); err != nil {
 			t.Fatalf("annotation %q has invalid Kubernetes quantity %q: %v", key, got, err)
+		}
+	}
+}
+
+// NodeCapacity is the scale-from-zero value published into the NodeGroup element; it must not be
+// what the annotations are read from, or fixed-size groups lose them again.
+func TestBuildCAPIMachineDeploymentIgnoresNodeCapacity(t *testing.T) {
+	ng := &deckhousev1.NodeGroup{}
+	ng.Name = "worker"
+	resolved := derived_status.ResolvedNodeGroup{
+		NodeCapacity: &capacity.InstanceType{CPU: resource.MustParse("4"), Memory: resource.MustParse("8Gi")},
+	}
+
+	md := buildCAPIMachineDeployment(capiMDInput{ng: ng, resolved: resolved})
+	annotations := md.Object["metadata"].(map[string]interface{})["annotations"].(map[string]interface{})
+
+	for _, key := range []string{
+		"capacity.cluster-autoscaler.kubernetes.io/cpu",
+		"capacity.cluster-autoscaler.kubernetes.io/memory",
+	} {
+		if got, ok := annotations[key]; ok {
+			t.Fatalf("annotation %q = %v, want absent", key, got)
 		}
 	}
 }

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/nodegroup/derived_status/derive.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/nodegroup/derived_status/derive.go
@@ -71,6 +71,10 @@ func Derive(ctx context.Context, ng *v1.NodeGroup, snap Snapshot) (Result, error
 func deriveCloudFields(logger logr.Logger, ng *v1.NodeGroup, snap Snapshot, result *Result) {
 	result.Zones = resolveZones(ng, snap.DefaultZones)
 
+	// Not gated on CapacityErr: that error is the scale-from-zero diagnostic, and a failed
+	// calculation leaves the value nil anyway.
+	result.TemplateCapacity = snap.TemplateCapacity
+
 	if snap.CapacityErr != nil {
 		logger.Error(snap.CapacityErr, "failed to calculate node capacity", "nodeGroup", ng.Name)
 	} else {

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/nodegroup/derived_status/resolved_nodegroup.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/nodegroup/derived_status/resolved_nodegroup.go
@@ -79,6 +79,12 @@ type ResolvedNodeGroup struct {
 	// not: the schema belongs to a cloud-provider module and unknown keys must survive verbatim.
 	InstanceClass map[string]any
 	NodeCapacity  *capacity.InstanceType
+
+	// TemplateCapacity is what the MachineDeployment's capacity.cluster-autoscaler.kubernetes.io
+	// annotations are built from. Unlike NodeCapacity it is resolved for every NodeGroup that can
+	// hold a machine, and ToMap deliberately does not publish it: the element it would land in is
+	// hashed into every node's configurationChecksum.
+	TemplateCapacity *capacity.InstanceType
 }
 
 func ResolveNodeGroup(in ResolveInput, r Result) ResolvedNodeGroup {
@@ -104,6 +110,7 @@ func ResolveNodeGroup(in ResolveInput, r Result) ResolvedNodeGroup {
 		resolved.Zones = r.Zones
 		resolved.InstanceClass = r.InstanceClass
 		resolved.NodeCapacity = r.NodeCapacity
+		resolved.TemplateCapacity = r.TemplateCapacity
 	}
 
 	return resolved

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/nodegroup/derived_status/service.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/nodegroup/derived_status/service.go
@@ -53,6 +53,7 @@ type Result struct {
 	CRIType           string
 	Zones             []string
 	NodeCapacity      *capacity.InstanceType
+	TemplateCapacity  *capacity.InstanceType
 	InstanceClass     map[string]any
 	SerializedLabels  string
 	SerializedTaints  string

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/nodegroup/derived_status/snapshot.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/nodegroup/derived_status/snapshot.go
@@ -39,11 +39,18 @@ type Snapshot struct {
 	APIServerMin  *semver.Version
 
 	// DefaultZones is read for every CloudEphemeral NodeGroup; InstanceClass, KnownClassNames and
-	// Capacity only once the provider named an InstanceClass kind and the NodeGroup references it.
+	// the two capacities only once the provider named an InstanceClass kind and the NodeGroup
+	// references it.
 	DefaultZones    []string
 	InstanceClass   map[string]any
 	KnownClassNames []string
 	Capacity        *capacity.InstanceType
+
+	// TemplateCapacity is the same calculation as Capacity, kept for every NodeGroup that can hold
+	// a machine instead of for scale-from-zero only. It feeds the MachineDeployment's
+	// capacity.cluster-autoscaler.kubernetes.io/{cpu,memory} annotations and is deliberately never
+	// published into the NodeGroup element — see the comment at its assignment below.
+	TemplateCapacity *capacity.InstanceType
 
 	// CapacityErr is the outcome of the single capacity calculation: check #3 needs the error and
 	// Derive needs the value, and computing it twice is what the old two-pass shape did.
@@ -159,14 +166,31 @@ func (s *Service) BuildSnapshot(ctx context.Context, ng *v1.NodeGroup) (Snapshot
 	}
 	snap.InstanceClass = spec
 
-	// nodeCapacity is only needed for scale-from-zero (min==0 && max>0), which is also the only
-	// case check #3 asks about — so the calculation happens once and both halves read the result.
-	if classRef.MinPerZone == 0 && classRef.MaxPerZone > 0 {
+	// The autoscaler needs a template NodeInfo for every node group it discovers, not only for the
+	// ones that scale from zero: while a group has no registered Node — a single-replica group whose
+	// Node is still booting, or any group mid-churn — the clusterapi provider has nothing to build a
+	// NodeInfo from, and ResourcesLeft then fails with "No node info for: <group>", which aborts
+	// scale-up for every other group in the cluster too. So the capacity is calculated for every
+	// NodeGroup that can hold a machine, and still calculated only once.
+	if classRef.MaxPerZone > 0 {
 		catalog, err := s.readInstanceTypesCatalog(ctx)
 		if err != nil {
 			return Snapshot{}, err
 		}
-		snap.Capacity, snap.CapacityErr = capacity.CalculateNodeTemplateCapacity(kind, spec, catalog)
+		templateCapacity, capacityErr := capacity.CalculateNodeTemplateCapacity(kind, spec, catalog)
+		snap.TemplateCapacity = templateCapacity
+
+		// Scale-from-zero alone publishes the value into the NodeGroup element and treats a failure
+		// as a NodeGroup error (check #3). Publishing it for the rest would add a key to the element
+		// bashible-apiserver hashes into every node's configurationChecksum — AddToChecksum excludes
+		// only the replica counters under cloudInstances — re-running node configuration across the
+		// fleet for a value no node reads.
+		if classRef.MinPerZone == 0 {
+			snap.Capacity, snap.CapacityErr = templateCapacity, capacityErr
+		} else if capacityErr != nil {
+			logger.V(1).Info("node capacity unresolved, MachineDeployment will carry no capacity annotations",
+				"nodeGroup", ng.Name, "kind", kind, "name", name, "err", capacityErr.Error())
+		}
 	}
 
 	return snap, nil

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/nodegroup/derived_status/snapshot_test.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/nodegroup/derived_status/snapshot_test.go
@@ -143,6 +143,103 @@ func TestBuildSnapshot_ClassDeletedMidPassIsRecorded(t *testing.T) {
 	require.NotEmpty(t, check.Error)
 }
 
+// The autoscaler needs a template NodeInfo for every node group it discovers. A group with
+// minPerZone above zero never scales from zero, but it still spends time with no registered Node —
+// while its only Node boots, or mid-churn — and with no template the clusterapi provider fails
+// ResourcesLeft with "No node info for: <group>", which aborts scale-up for every other group in
+// the cluster. So TemplateCapacity is resolved regardless of minPerZone.
+//
+// What must not follow is publishing it: nodeCapacity is a top-level key of the NodeGroup element,
+// and bashible-apiserver's AddToChecksum excludes only the replica counters under cloudInstances —
+// so a newly published key changes configurationChecksum and re-runs node configuration fleet-wide.
+func TestBuildSnapshot_TemplateCapacityIsResolvedAboveZeroMinButNotPublished(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		minPerZone    int32
+		wantPublished bool
+	}{
+		{name: "scale from zero publishes", minPerZone: 0, wantPublished: true},
+		{name: "fixed size does not publish", minPerZone: 1, wantPublished: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newDVPTestService(t, "worker", 4, "8Gi")
+
+			ng := &v1.NodeGroup{}
+			ng.Name = "worker"
+			ng.Spec.NodeType = v1.NodeTypeCloudEphemeral
+			ng.Spec.CloudInstances = &v1.CloudInstancesSpec{
+				ClassReference: v1.ClassReference{Kind: "DVPInstanceClass", Name: "worker"},
+				MinPerZone:     tc.minPerZone,
+				MaxPerZone:     3,
+			}
+
+			snap, err := s.BuildSnapshot(t.Context(), ng)
+			require.NoError(t, err)
+			require.NoError(t, snap.CapacityErr)
+
+			require.NotNil(t, snap.TemplateCapacity, "the MachineDeployment annotations have no other source")
+			require.Equal(t, "4", snap.TemplateCapacity.CPU.String())
+			require.Equal(t, "8Gi", snap.TemplateCapacity.Memory.String())
+
+			result, err := Derive(t.Context(), ng, snap)
+			require.NoError(t, err)
+			require.NotNil(t, result.TemplateCapacity)
+
+			element := ResolveNodeGroup(ResolveInput{
+				Name:           ng.Name,
+				NodeType:       ng.Spec.NodeType,
+				Spec:           ng.Spec,
+				CloudProcessed: true,
+			}, result).ToMap()
+
+			if tc.wantPublished {
+				require.NotNil(t, snap.Capacity)
+				require.Contains(t, element, "nodeCapacity", "scale-from-zero has always published it")
+			} else {
+				require.Nil(t, snap.Capacity, "only scale-from-zero publishes the value")
+				require.Nil(t, result.NodeCapacity)
+				require.NotContains(t, element, "nodeCapacity",
+					"publishing it here changes configurationChecksum and re-runs bashible on every node")
+			}
+		})
+	}
+}
+
+// newDVPTestService serves one DVPInstanceClass whose spec carries its own capacity, so the test
+// does not depend on the InstanceTypesCatalog being present.
+func newDVPTestService(t *testing.T, className string, cores int64, memory string) *Service {
+	t.Helper()
+
+	const kind = "DVPInstanceClass"
+
+	scheme := newTestScheme(t)
+	gvk := schema.GroupVersionKind{Group: instanceClassGroup, Version: "v1", Kind: kind}
+	scheme.AddKnownTypeWithName(gvk, &unstructured.Unstructured{})
+	scheme.AddKnownTypeWithName(gvk.GroupVersion().WithKind(kind+"List"), &unstructured.UnstructuredList{})
+
+	ic := &unstructured.Unstructured{Object: map[string]interface{}{
+		"spec": map[string]interface{}{
+			"virtualMachine": map[string]interface{}{
+				"cpu":    map[string]interface{}{"cores": cores},
+				"memory": map[string]interface{}{"size": memory},
+			},
+		},
+	}}
+	ic.SetGroupVersionKind(gvk)
+	ic.SetName(className)
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(ic, testSecret(cloudProviderSecretNamespace, cloudProviderSecretName, map[string][]byte{
+			"type":                    []byte(`dvp`),
+			"instanceClassKind":       []byte(kind),
+			"instanceClassAPIVersion": []byte(`v1`),
+		})).
+		Build()
+
+	return &Service{Client: c}
+}
+
 // An unreadable source must abort the pass: an empty provider reads as "no cloud", which drops
 // instanceClass from the published element and re-runs bashible on every node.
 func TestBuildSnapshot_UnreadableProviderAborts(t *testing.T) {


### PR DESCRIPTION
## Description

Cluster API `MachineDeployments` now always carry the `capacity.cluster-autoscaler.kubernetes.io/cpu` and `.../memory` annotations, not only when the NodeGroup is configured for scale-from-zero (`minPerZone: 0`).

`derived_status` previously computed the node capacity under `minPerZone == 0 && maxPerZone > 0`, on the assumption that a group with at least one replica always has a registered Node the autoscaler can read a NodeInfo from. The calculation is now performed for every NodeGroup that can hold a machine (`maxPerZone > 0`), and the result reaches the `MachineDeployment` annotations through a new, separate value.

The two concerns are deliberately split rather than merged:

- `NodeCapacity` — unchanged. Resolved for scale-from-zero only, published into the NodeGroup element, and a failed calculation still marks the NodeGroup invalid (cloud check #3).
- `TemplateCapacity` — new. Resolved for every NodeGroup that can hold a machine, never published into the NodeGroup element, and is the only source of the two `MachineDeployment` annotations. A failed calculation logs at `V(1)` and leaves the annotations absent, exactly as today.

The split is what keeps this safe. `nodeCapacity` is a top-level key of the NodeGroup element, and `bashible-apiserver`'s `AddToChecksum` excludes only the replica counters under `cloudInstances` — so simply widening the existing gate would have added a key to the element for every fixed-size NodeGroup, changed its configurationChecksum, and re-run node configuration across the whole fleet for a value no bashible step reads.

Impact on critical cluster components: none.

- No node restarts and no bashible re-run. The published NodeGroup element is byte-identical; the existing `checksum_golden_test.go`, `resolved_golden_test.go` and `livecluster_parity_test.go` pass without any golden updates, which is the independent proof.
- No machine rollout. Existing MachineDeployments gain two metadata annotations; CAPI derives the MachineSet template hash from spec.template, so no `MachineSet` is recreated and no `Machine` is replaced.
- MCM is untouched. `mcm_machinedeployment.go` still reads `NodeCapacity`, so MCM-based clusters get no new `scale-from-zero` annotations and no MachineDeployment diff at all. The same class of problem probably exists in the MCM provider's `GetMachineDeploymentNodeTemplate` fallback, but that is a separate change.
- Only the `node-controller` Deployment restarts, as with any change to its image.
Tests: two new cases in `snapshot_test.go` (capacity resolved at `minPerZone: 1`, and the element still not carrying `nodeCapacity` there), plus `TestBuildCAPIMachineDeploymentCapacityAnnotations` reworked to assert a fixed-size group is annotated and `TestBuildCAPIMachineDeploymentIgnoresNodeCapacity` added to catch a regression back to the old field.

## Why do we need it, and what problem does it solve?

Without these annotations the autoscaler's clusterapi provider has no template NodeInfo for a node group whose Nodes are momentarily all absent — and that aborts scale-up for the entire cluster, not just for that group.

`ResourcesLeft` computes cluster-wide CPU/memory limits across every discovered node group and needs a `NodeInfo` for each one, whether or not the pending Pods have anything to do with it. A group with neither a registered Node nor a capacity template is missing from nodeInfos, and the whole `ScaleUp` call fails for that iteration:

```
E0831 07:41:09.527556  1 static_autoscaler.go:513] Failed to scale up: could not compute total resources:
  No node info for: MachineDeployment/d8-cloud-instance-manager/code-runners-frontend-bd841fd9
```

Node groups are discovered from the `cluster.x-k8s.io/cluster-api-autoscaler-node-group-{min,max}-size` annotations, which are written unconditionally — so a group is always discovered, while its capacity template was only written for `minPerZone: 0`. Every fixed-size group was therefore a latent cluster-wide scale-up outage for as long as it happened to have no registered Node.

Observed on a v1.76.12 DVP cluster running GitLab runners. The `frontend` NodeGroup (`minPerZone: 1, maxPerZone: 1` — a group the autoscaler cannot scale at all) spent roughly eight minutes with its single Node still booting, and for that entire window the error above repeated every ~19 seconds and no scale-up happened anywhere in the cluster, including for gitlab-worker (`minPerZone: 4, maxPerZone: 6`), the group that actually needed to grow for the queued CI jobs. Confirmed on the affected cluster — all three `MachineDeployments` were missing both annotations, and all three NodeGroups had `minPerZone >= 1`:

```
code-runners-frontend-bd841fd9        MISSING  MISSING
code-runners-gitlab-worker-bd841fd9   MISSING  MISSING
code-runners-worker-bd841fd9          MISSING  MISSING
```

The failure needs nothing exotic to reproduce — any group whose Nodes are all simultaneously booting, draining, or being replaced hits it, which for an autoscaled runner fleet is a routine state. It is also silent: the affected symptom is Pods staying `Pending` while the cluster looks healthy, and the only evidence is this error line in the cluster-autoscaler log (visible at the hardcoded `--v=5`).

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: Fix NodeCapacity calculation.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
