### PR TITLE
[node-manager] Fix NodeCapacity calculation

### DIFF
--- a/modules/040-node-manager/hooks/get_crds.go
+++ b/modules/040-node-manager/hooks/get_crds.go
@@ -399,21 +399,40 @@ func getCRDsHandler(_ context.Context, input *go_hook.HookInput) error {
 				continue
 			}
 
-			// check #3 - node capacity planning: scale from zero check
+			// check #3 - node capacity planning
+			//
+			// The autoscaler needs a template NodeInfo for every node group it discovers, not only for
+			// the ones that scale from zero. Groups are discovered from the
+			// cluster-api-autoscaler-node-group-{min,max}-size annotations, which are written
+			// unconditionally, so while a discovered group has no registered Node — a single-replica
+			// group whose Node is still booting, or any group mid-churn — the clusterapi provider has
+			// nothing to build a NodeInfo from. ResourcesLeft then fails with "No node info for:
+			// <group>", which aborts scale-up for every other group in the cluster as well. So the
+			// capacity is resolved for every group that can hold a machine.
 			instanceClassSpec := instanceClasses[nodeGroupInstanceClassName]
 			if nodeGroup.Spec.CloudInstances.MinPerZone != nil && nodeGroup.Spec.CloudInstances.MaxPerZone != nil {
-				if *nodeGroup.Spec.CloudInstances.MinPerZone == 0 && *nodeGroup.Spec.CloudInstances.MaxPerZone > 0 {
-					// capacity calculation required only for scaling from zero, we can save some time in the other cases
+				if *nodeGroup.Spec.CloudInstances.MaxPerZone > 0 {
+					scaleFromZero := *nodeGroup.Spec.CloudInstances.MinPerZone == 0
 					nodeCapacity, err := capacity.CalculateNodeTemplateCapacity(nodeGroupInstanceClassKind, instanceClassSpec, instanceTypeCatalog)
 					if err != nil {
-						errorMsg := fmt.Sprintf("Capacity calculation failed for instance class '%s'. The instance type is not found in built-in types and no capacity is set. ScaleFromZero will not work. Please set capacity in the %s '%s' or use a supported instance type.", nodeGroupInstanceClassKind, nodeGroupInstanceClassKind, nodeGroup.Spec.CloudInstances.ClassReference.Name)
-						input.Logger.Error("Calculate capacity failed", slog.String("node_group", nodeGroupInstanceClassKind), slog.Any("spec", instanceClassSpec), log.Err(err))
-						setNodeGroupStatus(input.PatchCollector, nodeGroup.Name, errorStatusField, errorMsg)
-						nodeGroupErrors = append(nodeGroupErrors, fmt.Sprintf("• NodeGroup '%s': %s", nodeGroup.Name, errorMsg))
-						continue
+						// Scale-from-zero alone still rejects the NodeGroup: there an unresolved capacity
+						// means the group can never be scaled up at all.
+						if scaleFromZero {
+							errorMsg := fmt.Sprintf("Capacity calculation failed for instance class '%s'. The instance type is not found in built-in types and no capacity is set. ScaleFromZero will not work. Please set capacity in the %s '%s' or use a supported instance type.", nodeGroupInstanceClassKind, nodeGroupInstanceClassKind, nodeGroup.Spec.CloudInstances.ClassReference.Name)
+							input.Logger.Error("Calculate capacity failed", slog.String("node_group", nodeGroupInstanceClassKind), slog.Any("spec", instanceClassSpec), log.Err(err))
+							setNodeGroupStatus(input.PatchCollector, nodeGroup.Name, errorStatusField, errorMsg)
+							nodeGroupErrors = append(nodeGroupErrors, fmt.Sprintf("• NodeGroup '%s': %s", nodeGroup.Name, errorMsg))
+							continue
+						}
+						// Everywhere else it is not fatal: the group keeps working and its
+						// MachineDeployment carries no capacity annotations, exactly as before this
+						// calculation was widened.
+						input.Logger.Warn("Calculate capacity failed, MachineDeployment will carry no capacity annotations",
+							slog.String("node_group", nodeGroup.Name),
+							slog.String("instance_class_kind", nodeGroupInstanceClassKind), log.Err(err))
+					} else {
+						ngForValues["nodeCapacity"] = nodeCapacity
 					}
-
-					ngForValues["nodeCapacity"] = nodeCapacity
 				}
 			}
 

--- a/modules/040-node-manager/hooks/get_crds_test.go
+++ b/modules/040-node-manager/hooks/get_crds_test.go
@@ -1381,6 +1381,86 @@ spec:
 		})
 	})
 
+	// The autoscaler needs a template NodeInfo for every node group it discovers, not only for the
+	// ones that scale from zero: a discovered group with no registered Node and no template makes
+	// ResourcesLeft fail with "No node info for: <group>", aborting scale-up cluster-wide.
+	Context("Fixed size group: with a capacity", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(`
+---
+apiVersion: deckhouse.io/v1
+kind: NodeGroup
+metadata:
+  name: test
+spec:
+  nodeType: CloudEphemeral
+  cloudInstances:
+    minPerZone: 1
+    maxPerZone: 1
+    classReference:
+      kind: D8TestInstanceClass
+      name: cap
+    zones: [a,b]
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: D8TestInstanceClass
+metadata:
+  name: cap
+spec:
+  type: test
+  capacity:
+    cpu: 4
+    memory: 8Gi
+`))
+			f.RunHook()
+		})
+
+		It("must publish nodeCapacity even though the group never scales from zero", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			assertNodeCapacity(f, v1alpha1.InstanceType{
+				CPU:    resource.MustParse("4"),
+				Memory: resource.MustParse("8Gi"),
+			})
+		})
+	})
+
+	// Outside scale-from-zero an unresolved capacity must stay non-fatal: the group keeps working and
+	// its MachineDeployment simply carries no capacity annotations, exactly as before the calculation
+	// was widened.
+	Context("Fixed size group: can't find a capacity", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(`
+---
+apiVersion: deckhouse.io/v1
+kind: NodeGroup
+metadata:
+  name: test
+spec:
+  nodeType: CloudEphemeral
+  cloudInstances:
+    minPerZone: 1
+    maxPerZone: 3
+    classReference:
+      kind: D8TestInstanceClass
+      name: caperror
+    zones: [a,b]
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: D8TestInstanceClass
+metadata:
+  name: caperror
+spec: {}
+`))
+			f.RunHook()
+		})
+
+		It("must not reject the NodeGroup", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("nodeManager.internal.nodeGroups.0.cloudInstances").Exists()).To(BeTrue())
+			Expect(f.ValuesGet("nodeManager.internal.nodeGroups.0.nodeCapacity").Exists()).To(BeFalse())
+		})
+	})
+
 	const (
 		staticNodeGroupWithStaticInstances = `
 ---

--- a/modules/040-node-manager/images/bashible-apiserver/src/pkg/template/context_builder.go
+++ b/modules/040-node-manager/images/bashible-apiserver/src/pkg/template/context_builder.go
@@ -401,6 +401,12 @@ func (bc *bashibleContext) AddToChecksum(checksumCollector hash.Hash) error {
 		}
 	}
 
+	// nodeCapacity is metadata for the autoscaler's template NodeInfo, not node configuration: no
+	// bashible step reads it. Excluding it keeps configurationChecksum stable now that get_crds
+	// resolves it for every node group and not only for the scale-from-zero ones — otherwise the
+	// newly published key would re-run node configuration across the whole fleet.
+	delete(bcCopy.NodeGroup, "nodeCapacity")
+
 	bcData, err := yaml.Marshal(bcCopy)
 	if err != nil {
 		return errors.Wrap(err, "marshal bashibleContext for checksum collect failed")

--- a/modules/040-node-manager/images/bashible-apiserver/src/pkg/template/context_builder_test.go
+++ b/modules/040-node-manager/images/bashible-apiserver/src/pkg/template/context_builder_test.go
@@ -157,4 +157,19 @@ updateEpoch: "1680009541"
 			return
 		}
 	})
+
+	// nodeCapacity is resolved for every node group and not only for the ones that scale from zero.
+	// It is metadata for the autoscaler's template NodeInfo that no bashible step reads, so it must
+	// stay out of the checksum: otherwise publishing it for a group with minPerZone above zero
+	// re-runs node configuration on every node of that group.
+	t.Run("nodeCapacity does not affect checksum", func(t *testing.T) {
+		bc.NodeGroup["nodeCapacity"] = map[string]interface{}{"cpu": "4", "memory": "8Gi"}
+
+		newHash := hash(t, &bc)
+
+		if expectedHash != newHash {
+			t.Errorf("%s != %s", expectedHash, newHash)
+			return
+		}
+	})
 }

--- a/modules/040-node-manager/template_tests/module_test.go
+++ b/modules/040-node-manager/template_tests/module_test.go
@@ -1763,6 +1763,59 @@ ccc: ddd
 		})
 	})
 
+	// nodeCapacity is resolved for every node group now, not only for the ones that scale from zero.
+	// The MCM MachineDeployment keeps these annotations gated on minPerZone: widening the MCM
+	// provider's node template is a separate change from the clusterapi capacity fix.
+	Context("MCM scale-from-zero annotations", func() {
+		const mdName = "myprefix-worker-02320933"
+
+		assertAnnotations := func(present bool) {
+			md := f.KubernetesResource("MachineDeployment", "d8-cloud-instance-manager", mdName)
+			Expect(md.Exists()).To(BeTrue())
+
+			annotations := md.Field("metadata.annotations").Map()
+			if present {
+				Expect(annotations["cluster-autoscaler.kubernetes.io/scale-from-zero"].String()).To(Equal("true"))
+				Expect(annotations["cluster-autoscaler.kubernetes.io/node-cpu"].String()).To(Equal("2"))
+				Expect(annotations["cluster-autoscaler.kubernetes.io/node-memory"].String()).To(Equal("2Gi"))
+			} else {
+				Expect(annotations).ToNot(HaveKey("cluster-autoscaler.kubernetes.io/scale-from-zero"))
+				Expect(annotations).ToNot(HaveKey("cluster-autoscaler.kubernetes.io/node-cpu"))
+				Expect(annotations).ToNot(HaveKey("cluster-autoscaler.kubernetes.io/node-memory"))
+			}
+		}
+
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("nodeManager", nodeManagerConfigValues+nodeManagerAWS)
+			f.ValuesSetFromYaml("nodeManager.internal.nodeGroups.0.nodeCapacity", `{cpu: "2", memory: "2Gi"}`)
+			setBashibleAPIServerTLSValues(f)
+		})
+
+		Context("minPerZone is zero", func() {
+			BeforeEach(func() {
+				f.ValuesSet("nodeManager.internal.nodeGroups.0.cloudInstances.minPerZone", 0)
+				f.HelmRender()
+			})
+
+			It("annotates the MachineDeployment", func() {
+				Expect(f.RenderError).ShouldNot(HaveOccurred())
+				assertAnnotations(true)
+			})
+		})
+
+		Context("minPerZone is above zero", func() {
+			BeforeEach(func() {
+				f.ValuesSet("nodeManager.internal.nodeGroups.0.cloudInstances.minPerZone", 2)
+				f.HelmRender()
+			})
+
+			It("does not annotate the MachineDeployment", func() {
+				Expect(f.RenderError).ShouldNot(HaveOccurred())
+				assertAnnotations(false)
+			})
+		})
+	})
+
 	Context("CAPI", func() {
 		assertClusterResources := func(f *Config, clusterName string) {
 			cluster := f.KubernetesResource("Cluster", "d8-cloud-instance-manager", clusterName)

--- a/modules/040-node-manager/templates/node-group/_machine_deployment.tpl
+++ b/modules/040-node-manager/templates/node-group/_machine_deployment.tpl
@@ -16,7 +16,10 @@ metadata:
   name: {{ $machineDeploymentName }}
   annotations:
     zone: {{ $zone_name | quote }}
-    {{- if $ng.nodeCapacity }}
+    {{- /* nodeCapacity is now resolved for every group; these annotations stay scale-from-zero only,
+           because widening the MCM provider's node template is a separate change from the
+           clusterapi capacity fix. */ -}}
+    {{- if and $ng.nodeCapacity (eq (int $ng.cloudInstances.minPerZone) 0) }}
     cluster-autoscaler.kubernetes.io/scale-from-zero: "true"
     cluster-autoscaler.kubernetes.io/node-region: {{ $context.Values.nodeManager.internal.cloudProvider.region | quote }}
     cluster-autoscaler.kubernetes.io/node-cpu: {{ $ng.nodeCapacity.cpu | quote }}


### PR DESCRIPTION
## Description

#22675 for release-1.76 and release-1.77

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

This behavior is broken on v1.76.12/v.1.77.x too.,

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: Fix NodeCapacity calculation.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
