### PR TITLE
[istio] Add versions input validation

### DIFF
--- a/modules/110-istio/hooks/discovery_versions_to_install.go
+++ b/modules/110-istio/hooks/discovery_versions_to_install.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"log/slog"
 	"sort"
-	"strings"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
@@ -48,7 +47,6 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 func revisionsDiscovery(_ context.Context, input *go_hook.HookInput, dc dependency.Container) error {
 	var globalVersion string
 	var versionsToInstall = make([]string, 0)
-	var unsupportedVersions = make([]string, 0)
 	var supportedVersions = make([]string, 0) //nolint:prealloc
 
 	var supportedVersionsResult = input.Values.Get("istio.internal.versionMap").Map()
@@ -88,26 +86,11 @@ func revisionsDiscovery(_ context.Context, input *go_hook.HookInput, dc dependen
 
 	var additionalVersionsResult = input.ConfigValues.Get("istio.additionalVersions").Array()
 	for _, versionResult := range additionalVersionsResult {
-		if !lib.Contains(supportedVersions, versionResult.String()) {
-			unsupportedVersions = append(unsupportedVersions, versionResult.String())
-			continue
-		}
 		versionsToInstall = append(versionsToInstall, versionResult.String())
 	}
 
-	if !lib.Contains(supportedVersions, globalVersion) {
-		if !lib.Contains(unsupportedVersions, globalVersion) {
-			unsupportedVersions = append(unsupportedVersions, globalVersion)
-		}
-	} else {
-		if !lib.Contains(versionsToInstall, globalVersion) {
-			versionsToInstall = append(versionsToInstall, globalVersion)
-		}
-	}
-
-	if len(unsupportedVersions) > 0 {
-		sort.Strings(unsupportedVersions)
-		return fmt.Errorf("unsupported versions: [%s]", strings.Join(unsupportedVersions, ","))
+	if !lib.Contains(versionsToInstall, globalVersion) {
+		versionsToInstall = append(versionsToInstall, globalVersion)
 	}
 
 	sort.Strings(versionsToInstall) // to guarantee same order

--- a/modules/110-istio/hooks/discovery_versions_to_install.go
+++ b/modules/110-istio/hooks/discovery_versions_to_install.go
@@ -50,7 +50,7 @@ func revisionsDiscovery(_ context.Context, input *go_hook.HookInput, dc dependen
 
 	switch {
 	case input.ConfigValues.Exists("istio.globalVersion"):
-		// globalVersion is set in CM — use it
+		// globalVersion is set in ModuleConfig — use it
 		globalVersion = input.ConfigValues.Get("istio.globalVersion").String()
 	case input.Values.Exists("istio.internal.globalVersion"):
 		// globalVersion was previously discovered — use it

--- a/modules/110-istio/hooks/discovery_versions_to_install.go
+++ b/modules/110-istio/hooks/discovery_versions_to_install.go
@@ -47,12 +47,6 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 func revisionsDiscovery(_ context.Context, input *go_hook.HookInput, dc dependency.Container) error {
 	var globalVersion string
 	var versionsToInstall = make([]string, 0)
-	var supportedVersions = make([]string, 0) //nolint:prealloc
-
-	var supportedVersionsResult = input.Values.Get("istio.internal.versionMap").Map()
-	for versionResult := range supportedVersionsResult {
-		supportedVersions = append(supportedVersions, versionResult)
-	}
 
 	switch {
 	case input.ConfigValues.Exists("istio.globalVersion"):

--- a/modules/110-istio/hooks/discovery_versions_to_install_test.go
+++ b/modules/110-istio/hooks/discovery_versions_to_install_test.go
@@ -50,10 +50,10 @@ var _ = Describe("Istio hooks :: discovery_versions_to_install ::", func() {
 			values := `
 internal:
   versionMap: {
-    "1.1": {"fullVersion": "1.1.1"},
-    "1.2": {"fullVersion": "1.2.11"}
+    "1.25": {"fullVersion": "1.25.2"},
+    "1.27": {"fullVersion": "1.27.9"}
   }
-globalVersion: "1.2" # default version "from openapi/values.yaml"
+globalVersion: "1.27" # default version "from openapi/values.yaml"
 `
 			f.ValuesSetFromYaml("istio", []byte(values))
 
@@ -65,14 +65,14 @@ globalVersion: "1.2" # default version "from openapi/values.yaml"
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.LoggerOutput.Contents()).To(HaveLen(0))
 
-			Expect(f.ValuesGet("istio.internal.versionsToInstall").String()).To(MatchJSON(`["1.2"]`))
-			Expect(f.ValuesGet("istio.internal.globalVersion").String()).To(Equal("1.2"))
+			Expect(f.ValuesGet("istio.internal.versionsToInstall").String()).To(MatchJSON(`["1.27"]`))
+			Expect(f.ValuesGet("istio.internal.globalVersion").String()).To(Equal("1.27"))
 
 			value, exists := requirements.GetValue(minVersionValuesKey)
 			Expect(exists).To(BeTrue())
-			Expect(value).To(BeEquivalentTo("1.2"))
+			Expect(value).To(BeEquivalentTo("1.27"))
 
-			assertTelemetryMetrics(f, "1.2.11")
+			assertTelemetryMetrics(f, "1.27.9")
 		})
 	})
 
@@ -83,23 +83,22 @@ globalVersion: "1.2" # default version "from openapi/values.yaml"
 			values := `
 internal:
   versionMap: {
-    "1.10": {"fullVersion": "1.10.10"},
-    "1.3": {"fullVersion": "1.3.1"},
-    "1.4": {"fullVersion": "1.4.3"},
-    "1.42": {"fullVersion": "1.42.42"}
+    "1.25": {"fullVersion": "1.25.2"},
+    "1.27": {"fullVersion": "1.27.9"},
+    "1.29": {"fullVersion": "1.29.6"}
   }
-  globalVersion: "1.42"
-globalVersion: "1.4" # default version "from openapi/values.yaml"
+  globalVersion: "1.29"
+globalVersion: "1.27" # default version "from openapi/values.yaml"
 `
 			f.ValuesSetFromYaml("istio", []byte(values))
 			f.RunHook()
 		})
-		It("Previously discovered value 1.42 must be set", func() {
+		It("Previously discovered value 1.29 must be set", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.ValuesGet("istio.internal.versionsToInstall").AsStringSlice()).To(Equal([]string{"1.42"}))
-			Expect(f.ValuesGet("istio.internal.globalVersion").String()).To(Equal("1.42"))
+			Expect(f.ValuesGet("istio.internal.versionsToInstall").AsStringSlice()).To(Equal([]string{"1.29"}))
+			Expect(f.ValuesGet("istio.internal.globalVersion").String()).To(Equal("1.29"))
 
-			assertTelemetryMetrics(f, "1.42.42")
+			assertTelemetryMetrics(f, "1.29.6")
 		})
 	})
 
@@ -110,11 +109,11 @@ globalVersion: "1.4" # default version "from openapi/values.yaml"
 			values := `
 internal:
   versionMap: {
-    "1.10": {"fullVersion": "1.10.10"},
-    "1.3": {"fullVersion": "1.3.1"},
-    "1.4": {"fullVersion": "1.4.3"},
+    "1.25": {"fullVersion": "1.25.2"},
+    "1.27": {"fullVersion": "1.27.9"},
+    "1.29": {"fullVersion": "1.29.6"},
   }
-globalVersion: "1.4" # default version "from openapi/values.yaml"
+globalVersion: "1.27" # default version "from openapi/values.yaml"
 `
 			f.ValuesSetFromYaml("istio", []byte(values))
 
@@ -155,11 +154,11 @@ spec: {}
 			values := `
 internal:
   versionMap: {
-    "1.10": {"fullVersion": "1.10.10"},
-    "1.3": {"fullVersion": "1.3.1"},
-    "1.4": {"fullVersion": "1.4.3"},
+    "1.25": {"fullVersion": "1.25.2"},
+    "1.27": {"fullVersion": "1.27.9"},
+    "1.29": {"fullVersion": "1.29.6"},
   }
-globalVersion: "1.4" # default version "from openapi/values.yaml"
+globalVersion: "1.27" # default version "from openapi/values.yaml"
 `
 			f.ValuesSetFromYaml("istio", []byte(values))
 
@@ -171,7 +170,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    istio.deckhouse.io/global-version: "1.3"
+    istio.deckhouse.io/global-version: "1.29"
   name: istiod
   namespace: d8-istio
 spec: {}
@@ -188,10 +187,10 @@ spec: {}
 		})
 		It("globalVersion should be gathered from the Service", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.ValuesGet("istio.internal.versionsToInstall").AsStringSlice()).To(Equal([]string{"1.3"}))
-			Expect(f.ValuesGet("istio.internal.globalVersion").String()).To(Equal("1.3"))
+			Expect(f.ValuesGet("istio.internal.versionsToInstall").AsStringSlice()).To(Equal([]string{"1.29"}))
+			Expect(f.ValuesGet("istio.internal.globalVersion").String()).To(Equal("1.29"))
 
-			assertTelemetryMetrics(f, "1.3.1")
+			assertTelemetryMetrics(f, "1.29.6")
 		})
 	})
 
@@ -202,15 +201,14 @@ spec: {}
 			values := `
 internal:
   versionMap: {
-    "1.10": {"fullVersion": "1.10.10"},
-    "1.2": {"fullVersion": "1.2.4"},
-    "1.3": {"fullVersion": "1.3.1"},
-    "1.4": {"fullVersion": "1.4.3"},
+    "1.25": {"fullVersion": "1.25.2"},
+    "1.27": {"fullVersion": "1.27.9"},
+    "1.29": {"fullVersion": "1.29.6"}
   }
-globalVersion: "1.4" # default version "from openapi/values.yaml"
+globalVersion: "1.27" # default version "from openapi/values.yaml"
 `
 			f.ValuesSetFromYaml("istio", []byte(values))
-			f.ConfigValuesSet("istio.globalVersion", "1.2")
+			f.ConfigValuesSet("istio.globalVersion", "1.25")
 
 			var service v1.Service
 			var err error
@@ -220,7 +218,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    istio.deckhouse.io/global-version: "1.3"
+    istio.deckhouse.io/global-version: "1.29"
   name: istiod
   namespace: d8-istio
 spec: {}
@@ -237,37 +235,10 @@ spec: {}
 		})
 		It("globalVersion should be gathered from CM", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.ValuesGet("istio.internal.versionsToInstall").AsStringSlice()).To(Equal([]string{"1.2"}))
-			Expect(f.ValuesGet("istio.internal.globalVersion").String()).To(Equal("1.2"))
+			Expect(f.ValuesGet("istio.internal.versionsToInstall").AsStringSlice()).To(Equal([]string{"1.25"}))
+			Expect(f.ValuesGet("istio.internal.globalVersion").String()).To(Equal("1.25"))
 
-			assertTelemetryMetrics(f, "1.2.4")
-		})
-	})
-
-	Context("Unsupported versions", func() {
-		BeforeEach(func() {
-			f.KubeStateSet("") // to re-init fake api client (reset KubeState)
-
-			values := `
-internal:
-  versionMap: {
-    "1.1": {"fullVersion": "1.1.5"},
-    "1.2": {"fullVersion": "1.2.3"},
-    "1.3": {"fullVersion": "1.3.11"},
-  }
-globalVersion: "1.3" # default version "from openapi/values.yaml"
-`
-			f.ValuesSetFromYaml("istio", []byte(values))
-			f.ConfigValuesSet("istio.globalVersion", "2.0")
-			f.ConfigValuesSet("istio.additionalVersions", []string{"1.1", "1.3", "2.7", "2.8", "2.9"})
-			f.RunHook()
-		})
-		It("Should return errors", func() {
-			Expect(f).ToNot(ExecuteSuccessfully())
-
-			Expect(f.GoHookError).To(MatchError("unsupported versions: [2.0,2.7,2.8,2.9]"))
-
-			assertNoMetrics(f)
+			assertTelemetryMetrics(f, "1.25.2")
 		})
 	})
 
@@ -305,19 +276,19 @@ globalVersion: "1.25"
 internal:
   versionMap: {
     "1.27": {"fullVersion": "1.27.9"},
-    "1.28": {"fullVersion": "1.28.0"}
+    "1.29": {"fullVersion": "1.29.6"}
   }
 globalVersion: "1.27"
 `
 			f.ValuesSetFromYaml("istio", []byte(values))
 			f.ConfigValuesSet("istio.globalVersion", "1.27")
-			f.ConfigValuesSet("istio.additionalVersions", []string{"1.28"})
+			f.ConfigValuesSet("istio.additionalVersions", []string{"1.29"})
 			f.RunHook()
 		})
 
 		It("Should publish minimal version from versionsToInstall", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.ValuesGet("istio.internal.versionsToInstall").AsStringSlice()).To(Equal([]string{"1.27", "1.28"}))
+			Expect(f.ValuesGet("istio.internal.versionsToInstall").AsStringSlice()).To(Equal([]string{"1.27", "1.29"}))
 
 			value, exists := requirements.GetValue(minVersionValuesKey)
 			Expect(exists).To(BeTrue())
@@ -325,7 +296,7 @@ globalVersion: "1.27"
 
 			installedVersions, exists := requirements.GetValue(installedVersionsValuesKey)
 			Expect(exists).To(BeTrue())
-			Expect(installedVersions).To(BeEquivalentTo([]string{"1.27", "1.28"}))
+			Expect(installedVersions).To(BeEquivalentTo([]string{"1.27", "1.29"}))
 		})
 	})
 })

--- a/modules/110-istio/hooks/discovery_versions_to_install_test.go
+++ b/modules/110-istio/hooks/discovery_versions_to_install_test.go
@@ -76,7 +76,7 @@ globalVersion: "1.27" # default version "from openapi/values.yaml"
 		})
 	})
 
-	Context("No globalVersion in CM and globalVersion was previously discovered", func() {
+	Context("No globalVersion in ModuleConfig and globalVersion was previously discovered", func() {
 		BeforeEach(func() {
 			f.KubeStateSet("") // to re-init fake api client (reset KubeState)
 
@@ -102,7 +102,7 @@ globalVersion: "1.27" # default version "from openapi/values.yaml"
 		})
 	})
 
-	Context("No globalVersion in CM and the global service without annotation", func() {
+	Context("No globalVersion in ModuleConfig and the global service without annotation", func() {
 		BeforeEach(func() {
 			f.KubeStateSet("") // to re-init fake api client (reset KubeState)
 
@@ -147,7 +147,7 @@ spec: {}
 		})
 	})
 
-	Context("No globalVersion in CM and the global service with annotation", func() {
+	Context("No globalVersion in ModuleConfig and the global service with annotation", func() {
 		BeforeEach(func() {
 			f.KubeStateSet("") // to re-init fake api client (reset KubeState)
 
@@ -194,7 +194,7 @@ spec: {}
 		})
 	})
 
-	Context("globalVersion in CM and the global service with annotation", func() {
+	Context("globalVersion in ModuleConfig and the global service with annotation", func() {
 		BeforeEach(func() {
 			f.KubeStateSet("") // to re-init fake api client (reset KubeState)
 
@@ -233,7 +233,7 @@ spec: {}
 
 			f.RunHook()
 		})
-		It("globalVersion should be gathered from CM", func() {
+		It("globalVersion should be gathered from ModuleConfig", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.ValuesGet("istio.internal.versionsToInstall").AsStringSlice()).To(Equal([]string{"1.25"}))
 			Expect(f.ValuesGet("istio.internal.globalVersion").String()).To(Equal("1.25"))

--- a/modules/110-istio/openapi/config-values.yaml
+++ b/modules/110-istio/openapi/config-values.yaml
@@ -3,7 +3,7 @@ type: object
 properties:
   globalVersion:
     type: string
-    pattern: '^[0-9]+\.[0-9]+$'
+    enum: ["1.25", "1.27", "1.29"]
     description: Specific version of Istio control-plane which handles unspecific versions of data plane (namespaces with `istio-injection=enabled` label, not `istio.io/rev=`).
     examples: ["1.27"]
     default: "1.27"
@@ -16,7 +16,7 @@ properties:
     default: []
     items:
       type: string
-      pattern: '^[0-9]+\.[0-9]+$'
+      enum: ["1.25", "1.27", "1.29"]
   outboundTrafficPolicyMode:
     type: string
     enum: [AllowAny, RegistryOnly]

--- a/modules/110-istio/openapi/openapi-case-tests.yaml
+++ b/modules/110-istio/openapi/openapi-case-tests.yaml
@@ -72,6 +72,12 @@ positive:
     - {}
 negative:
   configValues:
+  # globalVersion with unsupported version
+    - globalVersion: "1.99"
+  # additionalVersions with unsupported version
+    - additionalVersions: ["1.5"]
+  # additionalVersions mixing supported and unsupported versions
+    - additionalVersions: ["1.29", "1.88"]
   #Bad cpu limit value
     - sidecar:
         resourcesManagement:


### PR DESCRIPTION
## Description
Validate `globalVersion` and `additionalVersions` via OpenAPI `enum` (`1.25`, `1.27`, `1.29`) instead of a loose version pattern.
Remove the redundant unsupported-versions check from the `discovery_versions_to_install` hook (validation now happens on ModuleConfig apply). Update hook tests to current versions and drop the old unsupported-versions case; add negative OpenAPI case tests.

## Why do we need it, and what problem does it solve?
Users could set any `X.Y` string for Istio versions; invalid values failed late in the discovery hook. OpenAPI enum rejects unsupported versions at ModuleConfig validation time and keeps allowed values aligned with the versions shipped in the module.


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: chore
summary: Validate globalVersion and additionalVersions against supported Istio versions in OpenAPI
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
