### PR TITLE
[service-with-healthchecks] Fix publishing of terminal and terminating pods in EndpointSlices

### DIFF
--- a/ee/modules/610-service-with-healthchecks/images/artifact/internal/agent/agent.go
+++ b/ee/modules/610-service-with-healthchecks/images/artifact/internal/agent/agent.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -303,8 +304,8 @@ func (r *ServiceWithHealthchecksReconciler) RunTasksScheduler(ctx context.Contex
 			for swhName := range r.healthchecksResultsByServiceWithHealthchecks {
 				for i := range r.healthchecksResultsByServiceWithHealthchecks[swhName] {
 					healthcheckTarget := r.healthchecksResultsByServiceWithHealthchecks[swhName][i]
-					if !healthcheckTarget.podReady {
-						// skip pods which are not ready
+					if !healthcheckTarget.podReady && !healthcheckTarget.podTerminating {
+						// skip pods which are neither ready nor shutting down gracefully
 						continue
 					}
 					value, ok := r.servicesWithHealthchecks.Load(swhName)
@@ -517,39 +518,89 @@ func (r *ServiceWithHealthchecksReconciler) buildEndpoints(svc networkv1alpha1.S
 	defer r.mu.RUnlock()
 
 	for _, probeResult := range r.healthchecksResultsByServiceWithHealthchecks[types.NamespacedName{Name: svc.GetName(), Namespace: svc.GetNamespace()}] {
-		if svc.Spec.PublishNotReadyAddresses || *areAllProbesSucceed(probeResult.probeResultDetails) {
-			isReady := probeResult.podReady && *areAllProbesSucceed(probeResult.probeResultDetails)
-			endpoint := discoveryv1.Endpoint{
-				Addresses: []string{probeResult.targetHost},
-				NodeName:  &r.nodeName,
-				TargetRef: &corev1.ObjectReference{
-					Kind:      "Pod",
-					Name:      probeResult.podName,
-					Namespace: svc.GetNamespace(), UID: probeResult.podUID,
-				},
-				Conditions: discoveryv1.EndpointConditions{
-					Ready: &isReady,
-				},
-			}
-			endpoints = append(endpoints, endpoint)
+		probesSucceed := *areAllProbesSucceed(probeResult.probeResultDetails)
+
+		// a terminating pod stays published until it disappears, so that consumers may fall
+		// back to it while no ready endpoint is left
+		if !svc.Spec.PublishNotReadyAddresses && !probesSucceed && !probeResult.podTerminating {
+			continue
 		}
+
+		// a terminating pod is never ready, but may still serve traffic while shutting down
+		serving := probeResult.podReady && probesSucceed
+		if probeResult.podTerminating {
+			serving = probesSucceed
+		}
+		ready := serving && !probeResult.podTerminating
+		terminating := probeResult.podTerminating
+
+		endpoint := discoveryv1.Endpoint{
+			Addresses: []string{probeResult.targetHost},
+			NodeName:  &r.nodeName,
+			TargetRef: &corev1.ObjectReference{
+				Kind:      "Pod",
+				Name:      probeResult.podName,
+				Namespace: svc.GetNamespace(), UID: probeResult.podUID,
+			},
+			Conditions: discoveryv1.EndpointConditions{
+				Ready:       &ready,
+				Serving:     &serving,
+				Terminating: &terminating,
+			},
+		}
+		endpoints = append(endpoints, endpoint)
 	}
 	return endpoints
 }
 
-func getPodsReadinessMap(podList corev1.PodList) map[types.NamespacedName]bool {
-	podsReadinessMap := make(map[types.NamespacedName]bool)
-	for _, pod := range podList.Items {
-		podIsReady := true
-		for _, containerStatus := range pod.Status.ContainerStatuses {
-			if !containerStatus.Ready {
-				podIsReady = false
-				break
-			}
-		}
-		podsReadinessMap[types.NamespacedName{Name: pod.GetName(), Namespace: pod.GetNamespace()}] = podIsReady
+// podShouldBeTracked reports whether the pod may be published as an endpoint. Pods in a
+// terminal phase keep their podIP, which in DVP clusters may already be served by another
+// pod on another node. Pods being deleted are still published, as terminating endpoints.
+func podShouldBeTracked(pod *corev1.Pod) bool {
+	if pod.Status.PodIP == "" {
+		return false
 	}
-	return podsReadinessMap
+	return pod.Status.Phase != corev1.PodFailed && pod.Status.Phase != corev1.PodSucceeded
+}
+
+func isPodTerminating(pod *corev1.Pod) bool {
+	return pod.DeletionTimestamp != nil
+}
+
+// isPodReady relies on the PodReady condition instead of container statuses: the latter is
+// empty for pods that failed before their containers started, so they would look ready.
+func isPodReady(pod *corev1.Pod) bool {
+	if pod.Status.Phase != corev1.PodRunning {
+		return false
+	}
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodReady {
+			return condition.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}
+
+type podState struct {
+	ready       bool
+	terminating bool
+}
+
+// getPodsStateMap returns the state of the pods eligible for publishing. The pods left out
+// are absent from the map, so syncResultsMapWithPodList drops them from the targets.
+func getPodsStateMap(podList corev1.PodList) map[types.NamespacedName]podState {
+	podsStateMap := make(map[types.NamespacedName]podState)
+	for i := range podList.Items {
+		pod := &podList.Items[i]
+		if !podShouldBeTracked(pod) {
+			continue
+		}
+		podsStateMap[types.NamespacedName{Name: pod.GetName(), Namespace: pod.GetNamespace()}] = podState{
+			ready:       isPodReady(pod),
+			terminating: isPodTerminating(pod),
+		}
+	}
+	return podsStateMap
 }
 
 func (r *ServiceWithHealthchecksReconciler) deleteServiceWithHealthchecks(swhName types.NamespacedName) {
@@ -616,12 +667,12 @@ func (r *ServiceWithHealthchecksReconciler) getPostgreSQLCredentials(sqlHandler 
 
 func (r *ServiceWithHealthchecksReconciler) syncResultsMapWithPodList(hc networkv1alpha1.ServiceWithHealthchecks, podList corev1.PodList) {
 	serviceWithHCKey := types.NamespacedName{Namespace: hc.Namespace, Name: hc.Name}
-	podsReadinessMap := getPodsReadinessMap(podList)
+	podsStateMap := getPodsStateMap(podList)
 	r.mu.Lock()
 	// clean unused pod IPs from result slice
 	n := 0
 	for _, target := range r.healthchecksResultsByServiceWithHealthchecks[serviceWithHCKey] {
-		if _, exists := podsReadinessMap[types.NamespacedName{Namespace: hc.Namespace, Name: target.podName}]; exists {
+		if _, exists := podsStateMap[types.NamespacedName{Namespace: hc.Namespace, Name: target.podName}]; exists {
 			r.healthchecksResultsByServiceWithHealthchecks[serviceWithHCKey][n] = target
 			n++
 		}
@@ -634,11 +685,12 @@ func (r *ServiceWithHealthchecksReconciler) syncResultsMapWithPodList(hc network
 
 	// add new pods IPs to targets slice
 	for _, pod := range podList.Items {
-		if pod.Status.PodIP == "" {
-			// pod has no IP address (for example, it's in pending state), skipping
-			r.logger.Debug("pod has no IP address, skipping", "pod_name", pod.GetName(), "swh_name", hc.Name, "namespace", hc.Namespace)
+		if !podShouldBeTracked(&pod) {
+			// pod has no IP address or has already reached a terminal phase
+			r.logger.Debug("pod is not eligible for publishing, skipping", "pod_name", pod.GetName(), "pod_phase", pod.Status.Phase, "swh_name", hc.Name, "namespace", hc.Namespace)
 			continue
 		}
+		state := podsStateMap[types.NamespacedName{Name: pod.GetName(), Namespace: pod.GetNamespace()}]
 		targetNotFound := true
 		var oldIndex int
 		for i, target := range r.healthchecksResultsByServiceWithHealthchecks[serviceWithHCKey] {
@@ -659,14 +711,24 @@ func (r *ServiceWithHealthchecksReconciler) syncResultsMapWithPodList(hc network
 				podName:            pod.GetName(),
 				podNamespace:       pod.GetNamespace(),
 				podUID:             pod.GetUID(),
-				podReady:           podsReadinessMap[types.NamespacedName{Name: pod.GetName(), Namespace: pod.GetNamespace()}],
+				podReady:           state.ready,
+				podTerminating:     state.terminating,
 			})
 		} else {
 			// or update existing one
-			r.healthchecksResultsByServiceWithHealthchecks[serviceWithHCKey][oldIndex].podUID = pod.GetUID()
-			r.healthchecksResultsByServiceWithHealthchecks[serviceWithHCKey][oldIndex].podReady = podsReadinessMap[types.NamespacedName{Name: pod.GetName(), Namespace: pod.GetNamespace()}]
-			r.healthchecksResultsByServiceWithHealthchecks[serviceWithHCKey][oldIndex].targetHost = pod.Status.PodIP
-			r.healthchecksResultsByServiceWithHealthchecks[serviceWithHCKey][oldIndex].creationTime = pod.CreationTimestamp.Time
+			target := &r.healthchecksResultsByServiceWithHealthchecks[serviceWithHCKey][oldIndex]
+
+			// probes run for ready and terminating pods only, and their results belong to a
+			// particular pod instance and IP, so stale ones must not keep the endpoint published
+			if (!state.ready && !state.terminating) || target.podUID != pod.GetUID() || target.targetHost != pod.Status.PodIP {
+				target.probeResultDetails = []ProbeResultDetail{}
+			}
+
+			target.podUID = pod.GetUID()
+			target.podReady = state.ready
+			target.podTerminating = state.terminating
+			target.targetHost = pod.Status.PodIP
+			target.creationTime = pod.CreationTimestamp.Time
 			r.logger.Debug("update target pod for service", "pod_name", pod.GetName(), "swh_name", hc.Name, "namespace", hc.Namespace)
 		}
 	}
@@ -721,21 +783,62 @@ func MakeSliceCopy[T any](originalSlice []T) []T {
 	return newSlice
 }
 
+// endpointKey identifies an endpoint for sorting, falling back to the addresses because
+// TargetRef may be absent in slices written by another actor.
+func endpointKey(endpoint discoveryv1.Endpoint) string {
+	if endpoint.TargetRef != nil {
+		return string(endpoint.TargetRef.UID)
+	}
+	return strings.Join(endpoint.Addresses, ",")
+}
+
+// The three helpers below follow the EndpointSlice API defaults for unset conditions.
+func endpointIsReady(endpoint discoveryv1.Endpoint) bool {
+	return endpoint.Conditions.Ready == nil || *endpoint.Conditions.Ready
+}
+
+func endpointIsServing(endpoint discoveryv1.Endpoint) bool {
+	if endpoint.Conditions.Serving == nil {
+		return endpointIsReady(endpoint)
+	}
+	return *endpoint.Conditions.Serving
+}
+
+func endpointIsTerminating(endpoint discoveryv1.Endpoint) bool {
+	return endpoint.Conditions.Terminating != nil && *endpoint.Conditions.Terminating
+}
+
 func endpointsAreEqual(old, new []discoveryv1.Endpoint) bool {
-	sort.Slice(old, func(i, j int) bool {
-		return old[i].TargetRef.UID < old[j].TargetRef.UID
-	})
-	sort.Slice(new, func(i, j int) bool {
-		return new[i].TargetRef.UID < new[j].TargetRef.UID
-	})
 	if len(old) != len(new) {
 		return false
 	}
-	for i := range old {
-		if old[i].TargetRef.UID != new[i].TargetRef.UID {
+
+	// sort copies to keep the caller's slices intact
+	oldSorted := MakeSliceCopy(old)
+	newSorted := MakeSliceCopy(new)
+	sort.Slice(oldSorted, func(i, j int) bool {
+		return endpointKey(oldSorted[i]) < endpointKey(oldSorted[j])
+	})
+	sort.Slice(newSorted, func(i, j int) bool {
+		return endpointKey(newSorted[i]) < endpointKey(newSorted[j])
+	})
+
+	for i := range oldSorted {
+		if endpointKey(oldSorted[i]) != endpointKey(newSorted[i]) {
 			return false
 		}
-		if strings.Join(old[i].Addresses, "") != strings.Join(new[i].Addresses, "") {
+		if !slices.Equal(oldSorted[i].Addresses, newSorted[i].Addresses) {
+			return false
+		}
+		// without comparing the conditions an endpoint which became not ready would stay
+		// published as ready until the set of endpoints itself changes
+		if endpointIsReady(oldSorted[i]) != endpointIsReady(newSorted[i]) {
+			return false
+		}
+		if endpointIsServing(oldSorted[i]) != endpointIsServing(newSorted[i]) {
+			return false
+		}
+		if endpointIsTerminating(oldSorted[i]) != endpointIsTerminating(newSorted[i]) {
 			return false
 		}
 	}

--- a/ee/modules/610-service-with-healthchecks/images/artifact/internal/agent/agent_test.go
+++ b/ee/modules/610-service-with-healthchecks/images/artifact/internal/agent/agent_test.go
@@ -1,0 +1,529 @@
+/*
+Copyright 2026 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package agent
+
+import (
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/deckhouse/deckhouse/pkg/log"
+
+	networkv1alpha1 "service-with-healthchecks/api/v1alpha1"
+)
+
+const (
+	testNamespace = "team-d8-ui-demo"
+	testSWHName   = "afb6b6179f7a240379b969366a6f6a75"
+	testNodeName  = "hv-06"
+	testPodIP     = "10.12.5.86"
+)
+
+func newTestReconciler() *ServiceWithHealthchecksReconciler {
+	return &ServiceWithHealthchecksReconciler{
+		nodeName: testNodeName,
+		logger:   log.NewNop(),
+		healthchecksResultsByServiceWithHealthchecks: make(map[types.NamespacedName][]HealthcheckTarget),
+	}
+}
+
+func newTestSWH() networkv1alpha1.ServiceWithHealthchecks {
+	return networkv1alpha1.ServiceWithHealthchecks{
+		ObjectMeta: metav1.ObjectMeta{Name: testSWHName, Namespace: testNamespace},
+	}
+}
+
+func newPod(name string, phase corev1.PodPhase, ready bool, ip string) corev1.Pod {
+	readyStatus := corev1.ConditionFalse
+	if ready {
+		readyStatus = corev1.ConditionTrue
+	}
+	return corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         testNamespace,
+			UID:               types.UID("uid-" + name),
+			CreationTimestamp: metav1.Time{Time: time.Now().Add(-time.Hour)},
+		},
+		Status: corev1.PodStatus{
+			Phase:  phase,
+			PodIP:  ip,
+			PodIPs: []corev1.PodIP{{IP: ip}},
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: readyStatus},
+			},
+			ContainerStatuses: []corev1.ContainerStatus{{Ready: ready}},
+		},
+	}
+}
+
+func newTerminatingPod(name string, ip string) corev1.Pod {
+	pod := newPod(name, corev1.PodRunning, true, ip)
+	now := metav1.Now()
+	pod.DeletionTimestamp = &now
+	pod.Finalizers = []string{"test.deckhouse.io/keep"}
+	return pod
+}
+
+func successfulProbeDetails() []ProbeResultDetail {
+	return []ProbeResultDetail{
+		{
+			id:               "tcp:" + testPodIP + ":32412",
+			mode:             "tcp",
+			targetPort:       32412,
+			successful:       true,
+			successCount:     1,
+			successThreshold: 1,
+			failureThreshold: 3,
+		},
+	}
+}
+
+func TestPodShouldBeTracked(t *testing.T) {
+	tests := []struct {
+		name string
+		pod  func() corev1.Pod
+		want bool
+	}{
+		{
+			name: "running pod with IP is tracked",
+			pod:  func() corev1.Pod { return newPod("running", corev1.PodRunning, true, testPodIP) },
+			want: true,
+		},
+		{
+			name: "failed pod is not tracked even though it keeps its IP",
+			pod:  func() corev1.Pod { return newPod("failed", corev1.PodFailed, false, testPodIP) },
+			want: false,
+		},
+		{
+			name: "succeeded pod is not tracked",
+			pod:  func() corev1.Pod { return newPod("succeeded", corev1.PodSucceeded, false, testPodIP) },
+			want: false,
+		},
+		{
+			name: "pod without IP is not tracked",
+			pod:  func() corev1.Pod { return newPod("pending", corev1.PodPending, false, "") },
+			want: false,
+		},
+		{
+			name: "terminating pod is still tracked to be published as terminating endpoint",
+			pod: func() corev1.Pod {
+				return newTerminatingPod("terminating", testPodIP)
+			},
+			want: true,
+		},
+		{
+			name: "terminating pod which already failed is not tracked",
+			pod: func() corev1.Pod {
+				pod := newTerminatingPod("terminating-failed", testPodIP)
+				pod.Status.Phase = corev1.PodFailed
+				return pod
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := tt.pod()
+			if got := podShouldBeTracked(&pod); got != tt.want {
+				t.Errorf("podShouldBeTracked() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsPodReady(t *testing.T) {
+	tests := []struct {
+		name string
+		pod  func() corev1.Pod
+		want bool
+	}{
+		{
+			name: "running pod with Ready condition",
+			pod:  func() corev1.Pod { return newPod("ready", corev1.PodRunning, true, testPodIP) },
+			want: true,
+		},
+		{
+			name: "running pod without Ready condition",
+			pod:  func() corev1.Pod { return newPod("not-ready", corev1.PodRunning, false, testPodIP) },
+			want: false,
+		},
+		{
+			name: "pod in Error phase is never ready",
+			pod:  func() corev1.Pod { return newPod("error", corev1.PodFailed, false, testPodIP) },
+			want: false,
+		},
+		{
+			name: "evicted pod without container statuses is not ready",
+			pod: func() corev1.Pod {
+				pod := newPod("evicted", corev1.PodFailed, false, testPodIP)
+				pod.Status.ContainerStatuses = nil
+				pod.Status.Conditions = nil
+				return pod
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := tt.pod()
+			if got := isPodReady(&pod); got != tt.want {
+				t.Errorf("isPodReady() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetPodsStateMapSkipsNotPublishablePods(t *testing.T) {
+	podList := corev1.PodList{Items: []corev1.Pod{
+		newPod("running", corev1.PodRunning, true, testPodIP),
+		newTerminatingPod("terminating", testPodIP),
+		newPod("error", corev1.PodFailed, false, testPodIP),
+		newPod("pending", corev1.PodPending, false, ""),
+	}}
+
+	stateMap := getPodsStateMap(podList)
+
+	if len(stateMap) != 2 {
+		t.Fatalf("expected the running and the terminating pods in the map, got %d entries: %v", len(stateMap), stateMap)
+	}
+	if got := stateMap[types.NamespacedName{Namespace: testNamespace, Name: "running"}]; !got.ready || got.terminating {
+		t.Errorf("running pod state = %+v, want {ready: true, terminating: false}", got)
+	}
+	if got := stateMap[types.NamespacedName{Namespace: testNamespace, Name: "terminating"}]; !got.terminating {
+		t.Errorf("terminating pod state = %+v, want terminating: true", got)
+	}
+}
+
+// The reported case: a VM pod failed on this node while another pod serves the very same IP
+// on another node, so its probes keep succeeding and only the phase check removes it.
+func TestSyncDropsTerminalPodWithStaleSuccessfulProbes(t *testing.T) {
+	r := newTestReconciler()
+	swh := newTestSWH()
+	swhKey := types.NamespacedName{Namespace: testNamespace, Name: testSWHName}
+
+	errorPod := newPod("d8v-vm-commander-demo-worker-gmgrd", corev1.PodFailed, false, testPodIP)
+
+	// the pod used to be ready with all its probes succeeding
+	r.healthchecksResultsByServiceWithHealthchecks[swhKey] = []HealthcheckTarget{
+		{
+			targetHost:         testPodIP,
+			podName:            errorPod.Name,
+			podNamespace:       testNamespace,
+			podUID:             errorPod.UID,
+			podReady:           true,
+			creationTime:       errorPod.CreationTimestamp.Time,
+			lastCheck:          time.Now(),
+			probeResultDetails: successfulProbeDetails(),
+		},
+	}
+
+	r.syncResultsMapWithPodList(swh, corev1.PodList{Items: []corev1.Pod{errorPod}})
+
+	if got := len(r.healthchecksResultsByServiceWithHealthchecks[swhKey]); got != 0 {
+		t.Fatalf("expected the terminal pod to be dropped from targets, got %d targets", got)
+	}
+
+	if endpoints := r.buildEndpoints(swh); len(endpoints) != 0 {
+		t.Fatalf("expected no endpoints for the terminal pod, got %+v", endpoints)
+	}
+}
+
+// A still-running pod which lost its readiness is no longer probed, so the previous results
+// must not keep it published.
+func TestSyncResetsProbeResultsForNotReadyPod(t *testing.T) {
+	r := newTestReconciler()
+	swh := newTestSWH()
+	swhKey := types.NamespacedName{Namespace: testNamespace, Name: testSWHName}
+
+	pod := newPod("worker", corev1.PodRunning, false, testPodIP)
+	r.healthchecksResultsByServiceWithHealthchecks[swhKey] = []HealthcheckTarget{
+		{
+			targetHost:         testPodIP,
+			podName:            pod.Name,
+			podNamespace:       testNamespace,
+			podUID:             pod.UID,
+			podReady:           true,
+			creationTime:       pod.CreationTimestamp.Time,
+			probeResultDetails: successfulProbeDetails(),
+		},
+	}
+
+	r.syncResultsMapWithPodList(swh, corev1.PodList{Items: []corev1.Pod{pod}})
+
+	targets := r.healthchecksResultsByServiceWithHealthchecks[swhKey]
+	if len(targets) != 1 {
+		t.Fatalf("expected the pod to stay in targets, got %d targets", len(targets))
+	}
+	if targets[0].podReady {
+		t.Error("expected the target to become not ready")
+	}
+	if len(targets[0].probeResultDetails) != 0 {
+		t.Errorf("expected stale probe results to be reset, got %+v", targets[0].probeResultDetails)
+	}
+	if endpoints := r.buildEndpoints(swh); len(endpoints) != 0 {
+		t.Fatalf("expected no endpoints for the not ready pod, got %+v", endpoints)
+	}
+}
+
+func TestSyncResetsProbeResultsOnPodRecreation(t *testing.T) {
+	r := newTestReconciler()
+	swh := newTestSWH()
+	swhKey := types.NamespacedName{Namespace: testNamespace, Name: testSWHName}
+
+	pod := newPod("worker", corev1.PodRunning, true, testPodIP)
+	r.healthchecksResultsByServiceWithHealthchecks[swhKey] = []HealthcheckTarget{
+		{
+			targetHost:         "10.12.5.10",
+			podName:            pod.Name,
+			podNamespace:       testNamespace,
+			podUID:             "old-uid",
+			podReady:           true,
+			creationTime:       pod.CreationTimestamp.Time,
+			probeResultDetails: successfulProbeDetails(),
+		},
+	}
+
+	r.syncResultsMapWithPodList(swh, corev1.PodList{Items: []corev1.Pod{pod}})
+
+	targets := r.healthchecksResultsByServiceWithHealthchecks[swhKey]
+	if len(targets) != 1 {
+		t.Fatalf("expected a single target, got %d", len(targets))
+	}
+	if targets[0].targetHost != testPodIP || targets[0].podUID != pod.UID {
+		t.Errorf("expected the target to be updated, got host %q uid %q", targets[0].targetHost, targets[0].podUID)
+	}
+	if len(targets[0].probeResultDetails) != 0 {
+		t.Errorf("expected probe results of the previous pod instance to be reset, got %+v", targets[0].probeResultDetails)
+	}
+}
+
+func TestBuildEndpointsPublishesReadyPod(t *testing.T) {
+	r := newTestReconciler()
+	swh := newTestSWH()
+	swhKey := types.NamespacedName{Namespace: testNamespace, Name: testSWHName}
+
+	pod := newPod("worker", corev1.PodRunning, true, testPodIP)
+	r.healthchecksResultsByServiceWithHealthchecks[swhKey] = []HealthcheckTarget{
+		{
+			targetHost:         testPodIP,
+			podName:            pod.Name,
+			podNamespace:       testNamespace,
+			podUID:             pod.UID,
+			podReady:           true,
+			probeResultDetails: successfulProbeDetails(),
+		},
+	}
+
+	endpoints := r.buildEndpoints(swh)
+	if len(endpoints) != 1 {
+		t.Fatalf("expected the ready pod to be published, got %d endpoints", len(endpoints))
+	}
+	if !endpointIsReady(endpoints[0]) {
+		t.Error("expected the endpoint to be ready")
+	}
+}
+
+// Graceful shutdown: a pod being deleted keeps serving traffic until it disappears.
+func TestTerminatingPodStaysPublishedAsServing(t *testing.T) {
+	r := newTestReconciler()
+	swh := newTestSWH()
+	swhKey := types.NamespacedName{Namespace: testNamespace, Name: testSWHName}
+
+	pod := newTerminatingPod("worker", testPodIP)
+	r.healthchecksResultsByServiceWithHealthchecks[swhKey] = []HealthcheckTarget{
+		{
+			targetHost:         testPodIP,
+			podName:            pod.Name,
+			podNamespace:       testNamespace,
+			podUID:             pod.UID,
+			podReady:           true,
+			probeResultDetails: successfulProbeDetails(),
+		},
+	}
+
+	r.syncResultsMapWithPodList(swh, corev1.PodList{Items: []corev1.Pod{pod}})
+
+	targets := r.healthchecksResultsByServiceWithHealthchecks[swhKey]
+	if len(targets) != 1 {
+		t.Fatalf("expected the terminating pod to stay in targets, got %d targets", len(targets))
+	}
+	if !targets[0].podTerminating {
+		t.Error("expected the target to be marked as terminating")
+	}
+	if len(targets[0].probeResultDetails) == 0 {
+		t.Error("expected probe results of the terminating pod to be preserved")
+	}
+
+	endpoints := r.buildEndpoints(swh)
+	if len(endpoints) != 1 {
+		t.Fatalf("expected the terminating pod to stay published, got %d endpoints", len(endpoints))
+	}
+	if endpointIsReady(endpoints[0]) {
+		t.Error("terminating endpoint must not be ready")
+	}
+	if !endpointIsServing(endpoints[0]) {
+		t.Error("terminating endpoint with succeeding probes must be serving")
+	}
+	if !endpointIsTerminating(endpoints[0]) {
+		t.Error("terminating endpoint must be marked as terminating")
+	}
+}
+
+// The shutting down pod stopped accepting connections: still published, but not serving.
+func TestTerminatingPodStopsServingWhenProbesFail(t *testing.T) {
+	r := newTestReconciler()
+	swh := newTestSWH()
+	swhKey := types.NamespacedName{Namespace: testNamespace, Name: testSWHName}
+
+	r.healthchecksResultsByServiceWithHealthchecks[swhKey] = []HealthcheckTarget{
+		{
+			targetHost:         testPodIP,
+			podName:            "worker",
+			podNamespace:       testNamespace,
+			podUID:             "uid-worker",
+			podReady:           false,
+			podTerminating:     true,
+			probeResultDetails: []ProbeResultDetail{},
+		},
+	}
+
+	endpoints := r.buildEndpoints(swh)
+	if len(endpoints) != 1 {
+		t.Fatalf("expected the terminating pod to stay published, got %d endpoints", len(endpoints))
+	}
+	if endpointIsServing(endpoints[0]) || endpointIsReady(endpoints[0]) {
+		t.Error("terminating endpoint with failing probes must be neither serving nor ready")
+	}
+	if !endpointIsTerminating(endpoints[0]) {
+		t.Error("terminating endpoint must be marked as terminating")
+	}
+}
+
+func newEndpoint(uid types.UID, address string, ready bool) discoveryv1.Endpoint {
+	terminating := false
+	return discoveryv1.Endpoint{
+		Addresses: []string{address},
+		TargetRef: &corev1.ObjectReference{Kind: "Pod", Name: string(uid), Namespace: testNamespace, UID: uid},
+		Conditions: discoveryv1.EndpointConditions{
+			Ready:       &ready,
+			Serving:     &ready,
+			Terminating: &terminating,
+		},
+	}
+}
+
+func newTerminatingEndpoint(uid types.UID, address string, serving bool) discoveryv1.Endpoint {
+	endpoint := newEndpoint(uid, address, false)
+	endpoint.Conditions.Serving = &serving
+	endpoint.Conditions.Terminating = ptrTo(true)
+	return endpoint
+}
+
+func TestEndpointsAreEqual(t *testing.T) {
+	tests := []struct {
+		name string
+		old  []discoveryv1.Endpoint
+		new  []discoveryv1.Endpoint
+		want bool
+	}{
+		{
+			name: "identical endpoints",
+			old:  []discoveryv1.Endpoint{newEndpoint("uid-a", testPodIP, true)},
+			new:  []discoveryv1.Endpoint{newEndpoint("uid-a", testPodIP, true)},
+			want: true,
+		},
+		{
+			name: "readiness change is detected",
+			old:  []discoveryv1.Endpoint{newEndpoint("uid-a", testPodIP, true)},
+			new:  []discoveryv1.Endpoint{newEndpoint("uid-a", testPodIP, false)},
+			want: false,
+		},
+		{
+			name: "serving change of a terminating endpoint is detected",
+			old:  []discoveryv1.Endpoint{newTerminatingEndpoint("uid-a", testPodIP, true)},
+			new:  []discoveryv1.Endpoint{newTerminatingEndpoint("uid-a", testPodIP, false)},
+			want: false,
+		},
+		{
+			name: "terminating change is detected",
+			old:  []discoveryv1.Endpoint{newEndpoint("uid-a", testPodIP, false)},
+			new:  []discoveryv1.Endpoint{newTerminatingEndpoint("uid-a", testPodIP, false)},
+			want: false,
+		},
+		{
+			name: "address change is detected",
+			old:  []discoveryv1.Endpoint{newEndpoint("uid-a", testPodIP, true)},
+			new:  []discoveryv1.Endpoint{newEndpoint("uid-a", "10.12.5.87", true)},
+			want: false,
+		},
+		{
+			name: "endpoints count change is detected",
+			old:  []discoveryv1.Endpoint{newEndpoint("uid-a", testPodIP, true)},
+			new:  []discoveryv1.Endpoint{},
+			want: false,
+		},
+		{
+			name: "order does not matter",
+			old: []discoveryv1.Endpoint{
+				newEndpoint("uid-b", "10.12.5.87", true),
+				newEndpoint("uid-a", testPodIP, true),
+			},
+			new: []discoveryv1.Endpoint{
+				newEndpoint("uid-a", testPodIP, true),
+				newEndpoint("uid-b", "10.12.5.87", true),
+			},
+			want: true,
+		},
+		{
+			name: "missing Ready condition is treated as ready",
+			old:  []discoveryv1.Endpoint{{Addresses: []string{testPodIP}}},
+			new:  []discoveryv1.Endpoint{{Addresses: []string{testPodIP}, Conditions: discoveryv1.EndpointConditions{Ready: ptrTo(true)}}},
+			want: true,
+		},
+		{
+			name: "endpoints without TargetRef do not panic",
+			old:  []discoveryv1.Endpoint{{Addresses: []string{testPodIP}, Conditions: discoveryv1.EndpointConditions{Ready: ptrTo(true)}}},
+			new:  []discoveryv1.Endpoint{{Addresses: []string{testPodIP}, Conditions: discoveryv1.EndpointConditions{Ready: ptrTo(false)}}},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := endpointsAreEqual(tt.old, tt.new); got != tt.want {
+				t.Errorf("endpointsAreEqual() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEndpointsAreEqualKeepsArgumentsIntact(t *testing.T) {
+	old := []discoveryv1.Endpoint{
+		newEndpoint("uid-b", "10.12.5.87", true),
+		newEndpoint("uid-a", testPodIP, true),
+	}
+	new := []discoveryv1.Endpoint{
+		newEndpoint("uid-a", testPodIP, true),
+		newEndpoint("uid-b", "10.12.5.87", true),
+	}
+
+	endpointsAreEqual(old, new)
+
+	if old[0].TargetRef.UID != "uid-b" || new[0].TargetRef.UID != "uid-a" {
+		t.Error("endpointsAreEqual() must not reorder its arguments")
+	}
+}
+
+func ptrTo[T any](v T) *T {
+	return &v
+}

--- a/ee/modules/610-service-with-healthchecks/images/artifact/internal/agent/types.go
+++ b/ee/modules/610-service-with-healthchecks/images/artifact/internal/agent/types.go
@@ -37,6 +37,7 @@ type HealthcheckTarget struct {
 	podNamespace       string
 	podUID             types.UID
 	podReady           bool
+	podTerminating     bool
 	probeResultDetails []ProbeResultDetail
 }
 


### PR DESCRIPTION
## Description

Change how the service-with-healthchecks agent decides which pods to publish in EndpointSlices:

- Exclude pods that are in a terminal phase (`Failed`/`Succeeded`). Such pods keep their `status.podIP`, but in DVP clusters that IP belongs to the VirtualMachine and may already be served by another pod on another node, so they must never appear as endpoints.
- Publish pods being deleted (having a `deletionTimestamp`) as terminating endpoints instead of dropping them: the `terminating` condition is set, `serving` reflects the probes results, and `ready` is `serving` and not `terminating`, as the EndpointSlice API requires. Probes keep running for such pods, so a workload that still accepts connections while shutting down remains usable for consumers supporting graceful shutdown. Previously the module set the `ready` condition only, and the other conditions were left unset.
- Determine pod readiness from the `PodReady` condition maintained by kubelet instead of walking container statuses. Container statuses are empty for pods that failed before their containers started (evicted pods, admission errors), and such pods were previously treated as ready by mistake.
- Reset stale probe results when a pod becomes not ready, is recreated, or changes its IP address. Otherwise the old successful probe results kept the endpoint published.
- Fix endpoint comparison so that changes of the `ready`, `serving` and `terminating` conditions are propagated, endpoints without a `TargetRef` are handled via their addresses, and the caller's slices are no longer mutated during sorting.

These changes affect only the service-with-healthchecks agent and do not restart critical cluster components.

## Why do we need it, and what problem does it solve?

The agent published pods that had already reached a terminal phase. Because a terminated pod keeps its `status.podIP`, and in DVP clusters that IP is reassigned to the VirtualMachine and can be reused by another running pod on another node, traffic directed to a service could be routed to the wrong workload or to an address that no longer serves the intended pod.

Additionally, pods that failed before their containers started were treated as ready because their container statuses list was empty, and stale probe results could keep an endpoint published after the pod was no longer ready. Together these issues led to traffic being sent to endpoints that should not have received it.

At the same time the module set the `ready` condition only, so the graceful shutdown flow was not supported at all: a pod being deleted stayed published as fully ready until it disappeared. Now such a pod is published as a terminating endpoint, and consumers may fall back to it while no ready endpoint is left.

## Why do we need it in the patch release (if we do)?

The bug causes traffic to be routed to terminated or recreated pods in existing clusters, which is a correctness and availability problem for services managed by the module. It should be backported so that current users receive the fix without waiting for the next release.

## Manual testing in a cluster

<details>
<summary>Test setup</summary>

Two pods with `restartPolicy: Never` on different nodes and a `ServiceWithHealthchecks` on top of them. The pod `swh-demo-b` terminates with a non-zero exit code once `/tmp/die` appears, which moves it to the `Failed` phase while keeping its `status.podIP`:

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: swh-demo-b
  namespace: test-swh
  labels: {app: swh-demo}
spec:
  restartPolicy: Never
  nodeName: plodder-worker-eef1d15b-ktkcz-mwnlq
  containers:
  - name: web
    image: nginx:alpine
    command: ["/bin/sh", "-c"]
    args:
      - |
        nginx -g 'daemon off;' &
        NGINX_PID=$!
        while [ ! -f /tmp/die ]; do sleep 1; done
        kill -9 $NGINX_PID
        exit 1
    readinessProbe:
      httpGet: {path: /index.html, port: 80}
      periodSeconds: 2
---
apiVersion: network.deckhouse.io/v1alpha1
kind: ServiceWithHealthchecks
metadata:
  name: swh-demo
  namespace: test-swh
spec:
  ports:
  - port: 80
    protocol: TCP
    targetPort: 80
  selector: {app: swh-demo}
  healthcheck:
    probes:
    - mode: TCP
      tcp: {targetPort: 80}
```

The pod is then terminated with `kubectl -n test-swh exec swh-demo-b -- touch /tmp/die`.

</details>

<details>
<summary>Scenario 1, before the fix: the endpoint of the failed pod stays published as ready</summary>

```bash
# kubectl -n test-swh get pod -o wide
NAME         READY   STATUS    RESTARTS   AGE     IP             NODE                                  NOMINATED NODE   READINESS GATES
swh-demo-a   1/1     Running   0          4m32s   10.111.2.21    plodder-worker-eef1d15b-ktkcz-hcgrm   <none>           <none>
swh-demo-b   0/1     Error     0          34s     10.111.1.160   plodder-worker-eef1d15b-ktkcz-mwnlq   <none>           <none>

# kubectl -n test-swh get endpointslices -l kubernetes.io/service-name=swh-demo \
    -o custom-columns=NAME:.metadata.name,NODE:.endpoints[*].nodeName,IP:.endpoints[*].addresses,READY:.endpoints[*].conditions.ready
NAME                                           NODE                                  IP               READY
swh-demo-plodder-worker-eef1d15b-ktkcz-hcgrm   plodder-worker-eef1d15b-ktkcz-hcgrm   [10.111.2.21]    true
swh-demo-plodder-worker-eef1d15b-ktkcz-mwnlq   plodder-worker-eef1d15b-ktkcz-mwnlq   [10.111.1.160]   true
```

The pod `swh-demo-b` has reached the `Failed` phase, but its EndpointSlice is still there and the endpoint is still marked as `ready: true`, so the pod keeps receiving traffic. The state does not recover over time.

Note that the address in the slice is the one of the recreated pod, so patching itself works: the agent does react to changes of the endpoints set and of their addresses. Only the readiness change is never propagated, because the endpoints comparison ignores `conditions.ready`.

</details>

<details>
<summary>Scenario 1, after the fix: the failed pod is not published</summary>

```bash
# d8 k -n test-swh exec swh-demo-b -- touch /tmp/die

swh-demo-a   1/1   Running   0     33s   10.112.1.139   tarabrin-1-worker-1
swh-demo-b   0/1   Error     0     33s   10.112.2.227   tarabrin-1-worker-2

swh-demo-tarabrin-1-worker-1
  ["10.112.1.139"] ready=true serving=true terminating=false
```

The failed pod is not a healthcheck target anymore, so the last endpoint of its node disappears and the whole EndpointSlice is deleted. All the conditions are now set explicitly.

</details>

<details>
<summary>Scenario 2, before the fix: a pod which lost its readiness stays published as ready</summary>

The pod stays in `Running`, only its readiness probe starts failing, so neither the set of the endpoints nor their addresses change.

```bash
# kubectl -n test-swh exec swh-demo-a -- rm /usr/share/nginx/html/index.html

# kubectl -n test-swh get pod -o wide
NAME         READY   STATUS    RESTARTS   AGE     IP             NODE                                  NOMINATED NODE   READINESS GATES
swh-demo-a   0/1     Running   0          4m12s   10.111.2.136   plodder-worker-eef1d15b-ktkcz-hcgrm   <none>           <none>
swh-demo-b   0/1     Error     0          4m12s   10.111.1.42    plodder-worker-eef1d15b-ktkcz-mwnlq   <none>           <none>

# kubectl -n test-swh get endpointslice -l kubernetes.io/service-name=swh-demo -o jsonpath=...
swh-demo-plodder-worker-eef1d15b-ktkcz-hcgrm
  ["10.111.2.136"] ready=true serving= terminating=
swh-demo-plodder-worker-eef1d15b-ktkcz-mwnlq
  ["10.111.1.42"] ready=true serving= terminating=
```

Both endpoints stay `ready=true`, although neither pod is ready. This is the case the endpoints comparison used to miss entirely.

</details>

<details>
<summary>Scenario 3, before the fix: a terminating pod stays published as fully ready</summary>

The pod has a `preStop` hook, so it keeps serving traffic while being deleted.

```bash
# kubectl -n test-swh delete pod swh-demo-a --wait=false

# measurement 1
swh-demo-a   1/1   Terminating   0     23s   10.111.2.86   plodder-worker-eef1d15b-ktkcz-hcgrm
swh-demo-plodder-worker-eef1d15b-ktkcz-hcgrm
  ["10.111.2.86"] ready=true serving= terminating=

# measurement 4, 50 seconds after the deletion
swh-demo-a   1/1   Terminating   0     50s   10.111.2.86   plodder-worker-eef1d15b-ktkcz-hcgrm
swh-demo-plodder-worker-eef1d15b-ktkcz-hcgrm
  ["10.111.2.86"] ready=true serving= terminating=
```

The endpoint of the pod being deleted stays `ready=true` for the whole grace period, and the `serving` and `terminating` conditions are not set at all, so consumers have no way to tell that the pod is shutting down.

</details>

<details>
<summary>Scenario 2, after the fix: the pod which lost its readiness is unpublished</summary>

```bash
# d8 k -n test-swh exec swh-demo-a -- rm /usr/share/nginx/html/index.html

swh-demo-a   0/1   Running   0     60s   10.112.1.139   tarabrin-1-worker-1
swh-demo-b   0/1   Error     0     60s   10.112.2.227   tarabrin-1-worker-2

# no EndpointSlices left
```

The endpoint is withdrawn although neither the set of the endpoints nor their addresses changed, which the previous comparison used to miss.

</details>

<details>
<summary>Scenario 3, after the fix: the terminating pod is published as serving</summary>

```bash
# d8 k -n test-swh delete pod swh-demo-a --wait=false

swh-demo-a   1/1   Terminating   0     20s   10.112.1.249   tarabrin-1-worker-1
swh-demo-tarabrin-1-worker-1
  ["10.112.1.249"] ready=false serving=true terminating=true
swh-demo-tarabrin-1-worker-2
  ["10.112.2.80"] ready=true serving=true terminating=false

# the shutting down pod stops accepting connections
# d8 k -n test-swh exec swh-demo-a -- pkill -9 nginx

swh-demo-a   0/1   Terminating   0     33s   10.112.1.249   tarabrin-1-worker-1
swh-demo-tarabrin-1-worker-1
  ["10.112.1.249"] ready=false serving=false terminating=true
swh-demo-tarabrin-1-worker-2
  ["10.112.2.80"] ready=true serving=true terminating=false
```

While the pod is shutting down and still accepts connections, its endpoint is `serving` but not `ready`, so consumers may fall back to it. Once it stops answering, `serving` turns to `false`. The endpoint disappears together with the pod.

</details>

## Checklist

- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: service-with-healthchecks
type: fix
summary: Stopped publishing terminated pods in EndpointSlices and started publishing pods being deleted as terminating endpoints.
impact: Endpoints for pods in a terminal phase (Failed/Succeeded) are no longer published. In DVP clusters this prevents traffic from being routed to a VirtualMachine IP that has been reused by another pod. Pods being deleted are now published with the serving and terminating conditions, which enables the graceful shutdown flow for consumers. Pod readiness is derived from the PodReady condition, and stale probe results are reset when a pod becomes not ready, is recreated, or changes its IP.
impact_level: high
```