### PR TITLE
[docs] Unify modules section heading in AI export

### DIFF
--- a/docs/documentation/_data/i18n.yml
+++ b/docs/documentation/_data/i18n.yml
@@ -322,9 +322,6 @@ common:
   modules:
     en: modules
     ru: модули
-  modules_embedded:
-    en: embedded modules
-    ru: встроенные модули
   modules_of_a_scope:
     en: The modules within the scope
     ru: Модули, входящие в область

--- a/docs/documentation/_plugins/ai_export.rb
+++ b/docs/documentation/_plugins/ai_export.rb
@@ -368,7 +368,7 @@ module Jekyll
         end
 
         if @root
-          lines << "## #{@site.data.dig("i18n", "common", "modules_embedded", lang).to_s.capitalize} (llms.txt)"
+          lines << "## #{@site.data.dig("i18n", "common", "modules", lang).to_s.capitalize} (llms.txt)"
           lines << ""
           lines << "- [embedded-llms.txt](#{absolute(lang, "/modules/embedded-llms.txt")}): #{@site.data.dig("i18n", "common", "aiLlmsRefDescriptionEmbeddedModules", lang).to_s}"
           lines << "- [external-llms.txt](#{absolute(lang, "/modules/external-llms.txt")}): #{@site.data.dig("i18n", "common", "aiLlmsRefDescriptionExternalModules", lang).to_s}"


### PR DESCRIPTION
## Description

Updates https://github.com/deckhouse/deckhouse/pull/22660

Documentation AI generation updates:
- Remove redundant embedded-specific translation key and reuse the generic modules key for the LLM export heading
- Simplify localisation data by eliminating an unnecessary distinction between embedded and general module labels

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Documentation AI generation updates.
impact_level: low
```
