### PR TITLE
[istio] Restrict metadata discovery server-side request forgery and pin remote cluster UUID

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -1943,6 +1943,24 @@ alerts:
         Multicluster metadata endpoint failed.
       severity: "6"
       markupFormat: markdown
+    - name: D8IstioMulticlusterRemoteAPIHostDoesntWork
+      sourceFile: ee/modules/110-istio/monitoring/prometheus-rules/multicluster.yaml
+      moduleUrl: 110-istio
+      module: istio
+      edition: ee
+      description: |
+        The remote API host `{{$labels.api_host}}` for IstioMulticluster `{{$labels.multicluster_name}}` has failed the health check performed by the Deckhouse monitoring hook.
+
+        To reproduce the request (run from the `d8-system/deckhouse` pod), run the following:
+
+        ```bash
+        TOKEN="$(deckhouse-controller module values istio -o json | jq -r --arg ah {{$labels.api_host}} '.internal.multiclusters[]| select(.apiHost == $ah)| .apiJWT ')"
+        curl -H "Authorization: Bearer $TOKEN" https://{{$labels.api_host}}/version
+        ```
+      summary: |
+        Multicluster remote API host health check failed.
+      severity: "6"
+      markupFormat: markdown
     - name: D8IstioMulticlusterRemoteClusterUUIDMismatch
       sourceFile: ee/modules/110-istio/monitoring/prometheus-rules/multicluster.yaml
       moduleUrl: 110-istio
@@ -1966,24 +1984,6 @@ alerts:
       summary: |
         IstioMulticluster peer cluster UUID changed.
       severity: "4"
-      markupFormat: markdown
-    - name: D8IstioMulticlusterRemoteAPIHostDoesntWork
-      sourceFile: ee/modules/110-istio/monitoring/prometheus-rules/multicluster.yaml
-      moduleUrl: 110-istio
-      module: istio
-      edition: ee
-      description: |
-        The remote API host `{{$labels.api_host}}` for IstioMulticluster `{{$labels.multicluster_name}}` has failed the health check performed by the Deckhouse monitoring hook.
-
-        To reproduce the request (run from the `d8-system/deckhouse` pod), run the following:
-
-        ```bash
-        TOKEN="$(deckhouse-controller module values istio -o json | jq -r --arg ah {{$labels.api_host}} '.internal.multiclusters[]| select(.apiHost == $ah)| .apiJWT ')"
-        curl -H "Authorization: Bearer $TOKEN" https://{{$labels.api_host}}/version
-        ```
-      summary: |
-        Multicluster remote API host health check failed.
-      severity: "6"
       markupFormat: markdown
     - name: D8IstioOperatorReconcileError
       sourceFile: modules/110-istio/monitoring/prometheus-rules/operator.yaml

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -1873,6 +1873,30 @@ alerts:
         Federation metadata endpoint failed.
       severity: "6"
       markupFormat: markdown
+    - name: D8IstioFederationRemoteClusterUUIDMismatch
+      sourceFile: ee/modules/110-istio/monitoring/prometheus-rules/federation.yaml
+      moduleUrl: 110-istio
+      module: istio
+      edition: ee
+      description: |
+        Public metadata from `{{$labels.endpoint}}` for IstioFederation `{{$labels.federation_name}}` reports cluster UUID `{{$labels.actual_uuid}}`, but the previously pinned UUID is `{{$labels.pinned_uuid}}`.
+
+        Deckhouse stops private metadata exchange and does not send a federation JWT until the peer identity is confirmed again.
+
+        Check whether `spec.metadataEndpoint` was pointed to another cluster or the remote endpoint was replaced.
+
+        To inspect the resource:
+
+        ```bash
+        d8 k get istiofederation {{$labels.federation_name}} -o yaml
+        curl {{$labels.endpoint}}
+        ```
+
+        If the peer change is intentional, recreate the IstioFederation resource so a new UUID can be pinned.
+      summary: |
+        IstioFederation peer cluster UUID changed.
+      severity: "4"
+      markupFormat: markdown
     - name: D8IstioGlobalControlplaneDoesntWork
       sourceFile: modules/110-istio/monitoring/prometheus-rules/controlplane.yaml
       moduleUrl: 110-istio
@@ -1918,6 +1942,30 @@ alerts:
       summary: |
         Multicluster metadata endpoint failed.
       severity: "6"
+      markupFormat: markdown
+    - name: D8IstioMulticlusterRemoteClusterUUIDMismatch
+      sourceFile: ee/modules/110-istio/monitoring/prometheus-rules/multicluster.yaml
+      moduleUrl: 110-istio
+      module: istio
+      edition: ee
+      description: |
+        Public metadata from `{{$labels.endpoint}}` for IstioMulticluster `{{$labels.multicluster_name}}` reports cluster UUID `{{$labels.actual_uuid}}`, but the previously pinned UUID is `{{$labels.pinned_uuid}}`.
+
+        Deckhouse stops private metadata exchange and does not send a multicluster JWT until the peer identity is confirmed again.
+
+        Check whether `spec.metadataEndpoint` was pointed to another cluster or the remote endpoint was replaced.
+
+        To inspect the resource:
+
+        ```bash
+        d8 k get istiomulticluster {{$labels.multicluster_name}} -o yaml
+        curl {{$labels.endpoint}}
+        ```
+
+        If the peer change is intentional, recreate the IstioMulticluster resource so a new UUID can be pinned.
+      summary: |
+        IstioMulticluster peer cluster UUID changed.
+      severity: "4"
       markupFormat: markdown
     - name: D8IstioMulticlusterRemoteAPIHostDoesntWork
       sourceFile: ee/modules/110-istio/monitoring/prometheus-rules/multicluster.yaml

--- a/ee/modules/110-istio/crds/doc-ru-istiofederation.yaml
+++ b/ee/modules/110-istio/crds/doc-ru-istiofederation.yaml
@@ -25,3 +25,13 @@ spec:
                     ca:
                       description: |
                         Сертификат для проверки HTTPS URL, который используется для публикации метаданных удаленного кластера.
+            status:
+              properties:
+                conditions:
+                  description: |
+                    Готовность обмена метаданными с удалённым кластером.
+
+                    - `PublicMetadataExchangeReady` — удалённый `public.json` доступен и валиден.
+                      Если `status.metadataCache.public.clusterUUID` уже задан, UUID из ответа endpoint должен с ним совпадать; иначе condition переходит в `False` с reason `ClusterUUIDMismatch`.
+                    - `PrivateMetadataExchangeReady` — удалённые приватные метаданные доступны и валидны.
+                    - `DataplaneConnectionReady` — успешна межкластерная health-проверка dataplane к сервису `alliance-healthcheck`.

--- a/ee/modules/110-istio/crds/doc-ru-istiomulticluster.yaml
+++ b/ee/modules/110-istio/crds/doc-ru-istiomulticluster.yaml
@@ -26,3 +26,14 @@ spec:
                     insecureSkipVerify:
                       description: |
                         Включение или выключение проверки сертификата удостоверяющего центра для чтения метаданных удалённого кластера.
+            status:
+              properties:
+                conditions:
+                  description: |
+                    Готовность обмена метаданными с удалённым кластером.
+
+                    - `PublicMetadataExchangeReady` — удалённый `public.json` доступен и валиден.
+                      Если `status.metadataCache.public.clusterUUID` уже задан, UUID из ответа endpoint должен с ним совпадать; иначе condition переходит в `False` с reason `ClusterUUIDMismatch`.
+                    - `PrivateMetadataExchangeReady` — удалённые приватные метаданные доступны и валидны.
+                    - `RemoteAPIServerReady` — удалённый API-хост multicluster (`apiHost`) отвечает на аутентифицированный `/api`.
+                    - `DataplaneConnectionReady` — успешна межкластерная health-проверка dataplane к сервису `alliance-healthcheck`.

--- a/ee/modules/110-istio/crds/istiofederation.yaml
+++ b/ee/modules/110-istio/crds/istiofederation.yaml
@@ -99,6 +99,7 @@ spec:
                     Readiness of metadata exchange with the remote cluster.
 
                     - `PublicMetadataExchangeReady` — remote `public.json` is reachable and valid.
+                      When `status.metadataCache.public.clusterUUID` is already set, the UUID returned by the endpoint must match it; otherwise the condition becomes `False` with reason `ClusterUUIDMismatch`.
                     - `PrivateMetadataExchangeReady` — remote private metadata is reachable and valid.
                     - `DataplaneConnectionReady` — cross-cluster dataplane health probe to the remote `alliance-healthcheck` service succeeded.
                   x-kubernetes-list-map-keys:

--- a/ee/modules/110-istio/crds/istiomulticluster.yaml
+++ b/ee/modules/110-istio/crds/istiomulticluster.yaml
@@ -96,6 +96,7 @@ spec:
                     Readiness of metadata exchange with the remote cluster.
 
                     - `PublicMetadataExchangeReady` — remote `public.json` is reachable and valid.
+                      When `status.metadataCache.public.clusterUUID` is already set, the UUID returned by the endpoint must match it; otherwise the condition becomes `False` with reason `ClusterUUIDMismatch`.
                     - `PrivateMetadataExchangeReady` — remote private metadata is reachable and valid.
                     - `RemoteAPIServerReady` — remote multicluster API host (`apiHost`) serves the authenticated `/api` endpoint.
                     - `DataplaneConnectionReady` — cross-cluster dataplane health probe to the remote `alliance-healthcheck` service succeeded.

--- a/ee/modules/110-istio/hooks/ee/federation_discovery.go
+++ b/ee/modules/110-istio/hooks/ee/federation_discovery.go
@@ -35,8 +35,9 @@ import (
 )
 
 var (
-	federationMetricsGroup = "federation_discovery"
-	federationMetricName   = "d8_istio_federation_metadata_endpoints_fetch_error_count"
+	federationMetricsGroup           = "federation_discovery"
+	federationMetricName             = "d8_istio_federation_metadata_endpoints_fetch_error_count"
+	federationUUIDMismatchMetricName = "d8_istio_federation_remote_cluster_uuid_mismatch"
 )
 
 type IstioFederationDiscoveryCrdInfo struct {
@@ -57,6 +58,17 @@ func (i *IstioFederationDiscoveryCrdInfo) SetMetricMetadataEndpointError(mc sdkp
 	}
 
 	mc.Set(federationMetricName, isError, labels, metrics.WithGroup(federationMetricsGroup))
+}
+
+func (i *IstioFederationDiscoveryCrdInfo) SetMetricRemoteClusterUUIDMismatch(mc sdkpkg.MetricsCollector, pinnedUUID, actualUUID string) {
+	labels := map[string]string{
+		"federation_name": i.Name,
+		"endpoint":        i.PublicMetadataEndpoint,
+		"pinned_uuid":     pinnedUUID,
+		"actual_uuid":     actualUUID,
+	}
+
+	mc.Set(federationUUIDMismatchMetricName, 1, labels, metrics.WithGroup(federationMetricsGroup))
 }
 
 func (i *IstioFederationDiscoveryCrdInfo) PatchMetadataCache(pc go_hook.PatchCollector, scope string, meta interface{}) error {
@@ -142,7 +154,7 @@ func federationDiscovery(_ context.Context, input *go_hook.HookInput, dc depende
 
 		var publicMetadata eeCrd.AlliancePublicMetadata
 		var privateMetadata eeCrd.FederationPrivateMetadata
-		var httpOption []http.Option
+		httpOption := []http.Option{http.WithRestrictedNetworkAccess()}
 		protocolMap := map[string]string{
 			"https":    "TLS",
 			"tls":      "TLS",
@@ -196,6 +208,17 @@ func federationDiscovery(_ context.Context, input *go_hook.HookInput, dc depende
 			input.Logger.Warn("bad public metadata format in endpoint for IstioFederation", slog.String("endpoint", federationInfo.PublicMetadataEndpoint), slog.String("name", federationInfo.Name))
 			federationInfo.SetMetricMetadataEndpointError(input.MetricsCollector, federationInfo.PublicMetadataEndpoint, 1)
 			publicCondition := getCondition(AllianceConditionPublicMetadataExchangeReady, prior, metav1.ConditionFalse, "InvalidPublicMetadata", "clusterUUID, authnKeyPub, and rootCA must be non-empty", t)
+			pendingPrivateCondition := getCondition(AllianceConditionPrivateMetadataExchangeReady, prior, metav1.ConditionUnknown, "AwaitingPublic", "Public metadata exchange has not succeeded yet.", t)
+			patchAllianceDiscoveryConditions(input.PatchCollector, "IstioFederation", federationInfo.Name, federationInfo.PriorConditions, []metav1.Condition{publicCondition, pendingPrivateCondition}, t)
+			continue
+		}
+		if federationInfo.ClusterUUID != "" && publicMetadata.ClusterUUID != federationInfo.ClusterUUID {
+			t := timeNow()
+			msg := fmt.Sprintf("pinned cluster UUID %q does not match public metadata UUID %q", federationInfo.ClusterUUID, publicMetadata.ClusterUUID)
+			input.Logger.Warn("remote cluster UUID does not match pinned IstioFederation metadata", slog.String("endpoint", federationInfo.PublicMetadataEndpoint), slog.String("name", federationInfo.Name), slog.String("pinned_cluster_uuid", federationInfo.ClusterUUID), slog.String("actual_cluster_uuid", publicMetadata.ClusterUUID))
+			federationInfo.SetMetricMetadataEndpointError(input.MetricsCollector, federationInfo.PublicMetadataEndpoint, 1)
+			federationInfo.SetMetricRemoteClusterUUIDMismatch(input.MetricsCollector, federationInfo.ClusterUUID, publicMetadata.ClusterUUID)
+			publicCondition := getCondition(AllianceConditionPublicMetadataExchangeReady, prior, metav1.ConditionFalse, "ClusterUUIDMismatch", msg, t)
 			pendingPrivateCondition := getCondition(AllianceConditionPrivateMetadataExchangeReady, prior, metav1.ConditionUnknown, "AwaitingPublic", "Public metadata exchange has not succeeded yet.", t)
 			patchAllianceDiscoveryConditions(input.PatchCollector, "IstioFederation", federationInfo.Name, federationInfo.PriorConditions, []metav1.Condition{publicCondition, pendingPrivateCondition}, t)
 			continue

--- a/ee/modules/110-istio/hooks/ee/federation_discovery_test.go
+++ b/ee/modules/110-istio/hooks/ee/federation_discovery_test.go
@@ -106,7 +106,7 @@ status:
       publicServices:
       - {"hostame": "some-outdated.host", "ports": [{"name": "ppp", "port": 111}]} # must be overwritten by the new data
     public:
-      clusterUUID: bad-cluster-uuid # should be changed
+      clusterUUID: proper-uuid-1 # pinned after first successful discovery
       rootCA: bad-root-ca
       authnKeyPub: bad-authn-key-pub
 ---
@@ -817,6 +817,72 @@ status: {}
 					"endpoint":        "https://public-wrong-format/metadata/public/public.json",
 				},
 			}))
+		})
+	})
+
+	Context("Pinned remote cluster UUID", func() {
+		privateEndpointRequested := false
+
+		BeforeEach(func() {
+			privateEndpointRequested = false
+			f.ValuesSet("istio.federation.enabled", true)
+			f.KubeStateSet(`
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: IstioFederation
+metadata:
+  name: uuid-mismatch
+spec:
+  trustDomain: remote.cluster
+  metadataEndpoint: https://uuid-mismatch/metadata/
+status:
+  metadataCache:
+    public:
+      clusterUUID: pinned-uuid
+      authnKeyPub: pinned-authn-key
+      rootCA: pinned-root-ca
+`)
+			f.BindingContexts.Set(f.GenerateScheduleContext("* * * * *"))
+			dependency.TestDC.HTTPClient.DoMock.
+				Set(func(req *http.Request) (*http.Response, error) {
+					if req.URL.Path == "/metadata/private/federation.json" {
+						privateEndpointRequested = true
+					}
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body: io.NopCloser(bytes.NewBufferString(`{
+							"clusterUUID": "unexpected-uuid",
+							"authnKeyPub": "remote-authn-key",
+							"rootCA": "remote-root-ca"
+						}`)),
+					}, nil
+				})
+			f.RunHook()
+		})
+
+		It("does not issue a JWT or overwrite pinned public metadata when the UUID changes", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(privateEndpointRequested).To(BeFalse())
+			Expect(f.KubernetesGlobalResource("IstioFederation", "uuid-mismatch").Field("status.metadataCache.public.clusterUUID").String()).To(Equal("pinned-uuid"))
+
+			var conditions []discoveryConditionRow
+			Expect(json.Unmarshal([]byte(f.KubernetesGlobalResource("IstioFederation", "uuid-mismatch").Field("status.conditions").String()), &conditions)).To(Succeed())
+			Expect(discoveryConditionsByType(conditions)["PublicMetadataExchangeReady"].Reason).To(Equal("ClusterUUIDMismatch"))
+			Expect(discoveryConditionsByType(conditions)["PrivateMetadataExchangeReady"].Status).To(Equal("Unknown"))
+
+			m := f.MetricsCollector.CollectedMetrics()
+			Expect(m).To(ContainElement(BeEquivalentTo(operation.MetricOperation{
+				Name:   federationUUIDMismatchMetricName,
+				Group:  federationMetricsGroup,
+				Action: operation.ActionGaugeSet,
+				Value:  ptr.To(1.0),
+				Labels: map[string]string{
+					"federation_name": "uuid-mismatch",
+					"endpoint":        "https://uuid-mismatch/metadata/public/public.json",
+					"pinned_uuid":     "pinned-uuid",
+					"actual_uuid":     "unexpected-uuid",
+				},
+			})))
 		})
 	})
 })

--- a/ee/modules/110-istio/hooks/ee/multicluster_discovery.go
+++ b/ee/modules/110-istio/hooks/ee/multicluster_discovery.go
@@ -33,8 +33,9 @@ import (
 )
 
 var (
-	multiclusterMetricsGroup = "multicluster_discovery"
-	multiclusterMetricName   = "d8_istio_multicluster_metadata_endpoints_fetch_error_count"
+	multiclusterMetricsGroup           = "multicluster_discovery"
+	multiclusterMetricName             = "d8_istio_multicluster_metadata_endpoints_fetch_error_count"
+	multiclusterUUIDMismatchMetricName = "d8_istio_multicluster_remote_cluster_uuid_mismatch"
 )
 
 type IstioMulticlusterDiscoveryCrdInfo struct {
@@ -55,6 +56,17 @@ func (i *IstioMulticlusterDiscoveryCrdInfo) SetMetricMetadataEndpointError(mc sd
 	}
 
 	mc.Set(multiclusterMetricName, isError, labels, metrics.WithGroup(multiclusterMetricsGroup))
+}
+
+func (i *IstioMulticlusterDiscoveryCrdInfo) SetMetricRemoteClusterUUIDMismatch(mc sdkpkg.MetricsCollector, pinnedUUID, actualUUID string) {
+	labels := map[string]string{
+		"multicluster_name": i.Name,
+		"endpoint":          i.PublicMetadataEndpoint,
+		"pinned_uuid":       pinnedUUID,
+		"actual_uuid":       actualUUID,
+	}
+
+	mc.Set(multiclusterUUIDMismatchMetricName, 1, labels, metrics.WithGroup(multiclusterMetricsGroup))
 }
 
 func (i *IstioMulticlusterDiscoveryCrdInfo) PatchMetadataCache(pc go_hook.PatchCollector, scope string, meta interface{}) error {
@@ -133,7 +145,7 @@ func multiclusterDiscovery(_ context.Context, input *go_hook.HookInput, dc depen
 
 		var publicMetadata eeCrd.AlliancePublicMetadata
 		var privateMetadata eeCrd.MulticlusterPrivateMetadata
-		var httpOption []http.Option
+		httpOption := []http.Option{http.WithRestrictedNetworkAccess()}
 
 		if multiclusterInfo.MetadataExporterCA != "" {
 			caCerts := [][]byte{[]byte(multiclusterInfo.MetadataExporterCA)}
@@ -180,6 +192,18 @@ func multiclusterDiscovery(_ context.Context, input *go_hook.HookInput, dc depen
 			input.Logger.Warn("bad public metadata format in endpoint for IstioMulticluster", slog.String("endpoint", multiclusterInfo.PublicMetadataEndpoint), slog.String("name", multiclusterInfo.Name))
 			multiclusterInfo.SetMetricMetadataEndpointError(input.MetricsCollector, multiclusterInfo.PublicMetadataEndpoint, 1)
 			publicCondition := getCondition(AllianceConditionPublicMetadataExchangeReady, prior, metav1.ConditionFalse, "InvalidPublicMetadata", "clusterUUID, authnKeyPub, and rootCA must be non-empty", t)
+			pendingPrivateCondition := getCondition(AllianceConditionPrivateMetadataExchangeReady, prior, metav1.ConditionUnknown, "AwaitingPublic", "Public metadata exchange has not succeeded yet.", t)
+			pendingAPICondition := getCondition(AllianceConditionRemoteAPIServerReady, prior, metav1.ConditionUnknown, "AwaitingPrivate", "Private metadata exchange has not succeeded yet.", t)
+			patchAllianceDiscoveryConditions(input.PatchCollector, "IstioMulticluster", multiclusterInfo.Name, multiclusterInfo.PriorConditions, []metav1.Condition{publicCondition, pendingPrivateCondition, pendingAPICondition}, t)
+			continue
+		}
+		if multiclusterInfo.ClusterUUID != "" && publicMetadata.ClusterUUID != multiclusterInfo.ClusterUUID {
+			t := timeNow()
+			msg := fmt.Sprintf("pinned cluster UUID %q does not match public metadata UUID %q", multiclusterInfo.ClusterUUID, publicMetadata.ClusterUUID)
+			input.Logger.Warn("remote cluster UUID does not match pinned IstioMulticluster metadata", slog.String("endpoint", multiclusterInfo.PublicMetadataEndpoint), slog.String("name", multiclusterInfo.Name), slog.String("pinned_cluster_uuid", multiclusterInfo.ClusterUUID), slog.String("actual_cluster_uuid", publicMetadata.ClusterUUID))
+			multiclusterInfo.SetMetricMetadataEndpointError(input.MetricsCollector, multiclusterInfo.PublicMetadataEndpoint, 1)
+			multiclusterInfo.SetMetricRemoteClusterUUIDMismatch(input.MetricsCollector, multiclusterInfo.ClusterUUID, publicMetadata.ClusterUUID)
+			publicCondition := getCondition(AllianceConditionPublicMetadataExchangeReady, prior, metav1.ConditionFalse, "ClusterUUIDMismatch", msg, t)
 			pendingPrivateCondition := getCondition(AllianceConditionPrivateMetadataExchangeReady, prior, metav1.ConditionUnknown, "AwaitingPublic", "Public metadata exchange has not succeeded yet.", t)
 			pendingAPICondition := getCondition(AllianceConditionRemoteAPIServerReady, prior, metav1.ConditionUnknown, "AwaitingPrivate", "Private metadata exchange has not succeeded yet.", t)
 			patchAllianceDiscoveryConditions(input.PatchCollector, "IstioMulticluster", multiclusterInfo.Name, multiclusterInfo.PriorConditions, []metav1.Condition{publicCondition, pendingPrivateCondition, pendingAPICondition}, t)

--- a/ee/modules/110-istio/hooks/ee/multicluster_discovery_test.go
+++ b/ee/modules/110-istio/hooks/ee/multicluster_discovery_test.go
@@ -106,7 +106,7 @@ status:
       apiHost: some-outdatad-api.host
       networkName: some-outdated-networkname
     public:
-      clusterUUID: bad-cluster-uuid # should be changed
+      clusterUUID: proper-uuid-1 # pinned after first successful discovery
       rootCA: bad-root-ca
       authnKeyPub: bad-authn-key-pub
 ---
@@ -829,6 +829,71 @@ status: {}
 					"endpoint":          "https://public-wrong-format/metadata/public/public.json",
 				},
 			}))
+		})
+	})
+
+	Context("Pinned remote cluster UUID", func() {
+		privateEndpointRequested := false
+
+		BeforeEach(func() {
+			privateEndpointRequested = false
+			f.ValuesSet("istio.multicluster.enabled", true)
+			f.KubeStateSet(`
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: IstioMulticluster
+metadata:
+  name: uuid-mismatch
+spec:
+  metadataEndpoint: https://uuid-mismatch/metadata/
+status:
+  metadataCache:
+    public:
+      clusterUUID: pinned-uuid
+      authnKeyPub: pinned-authn-key
+      rootCA: pinned-root-ca
+`)
+			f.BindingContexts.Set(f.GenerateScheduleContext("* * * * *"))
+			dependency.TestDC.HTTPClient.DoMock.
+				Set(func(req *http.Request) (*http.Response, error) {
+					if req.URL.Path == "/metadata/private/multicluster.json" {
+						privateEndpointRequested = true
+					}
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body: io.NopCloser(bytes.NewBufferString(`{
+							"clusterUUID": "unexpected-uuid",
+							"authnKeyPub": "remote-authn-key",
+							"rootCA": "remote-root-ca"
+						}`)),
+					}, nil
+				})
+			f.RunHook()
+		})
+
+		It("does not issue a JWT or overwrite pinned public metadata when the UUID changes", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(privateEndpointRequested).To(BeFalse())
+			Expect(f.KubernetesGlobalResource("IstioMulticluster", "uuid-mismatch").Field("status.metadataCache.public.clusterUUID").String()).To(Equal("pinned-uuid"))
+
+			var conditions []discoveryConditionRow
+			Expect(json.Unmarshal([]byte(f.KubernetesGlobalResource("IstioMulticluster", "uuid-mismatch").Field("status.conditions").String()), &conditions)).To(Succeed())
+			Expect(discoveryConditionsByType(conditions)["PublicMetadataExchangeReady"].Reason).To(Equal("ClusterUUIDMismatch"))
+			Expect(discoveryConditionsByType(conditions)["PrivateMetadataExchangeReady"].Status).To(Equal("Unknown"))
+
+			m := f.MetricsCollector.CollectedMetrics()
+			Expect(m).To(ContainElement(BeEquivalentTo(operation.MetricOperation{
+				Name:   multiclusterUUIDMismatchMetricName,
+				Group:  multiclusterMetricsGroup,
+				Action: operation.ActionGaugeSet,
+				Value:  ptr.To(1.0),
+				Labels: map[string]string{
+					"multicluster_name": "uuid-mismatch",
+					"endpoint":          "https://uuid-mismatch/metadata/public/public.json",
+					"pinned_uuid":       "pinned-uuid",
+					"actual_uuid":       "unexpected-uuid",
+				},
+			})))
 		})
 	})
 })

--- a/ee/modules/110-istio/monitoring/prometheus-rules/federation.yaml
+++ b/ee/modules/110-istio/monitoring/prometheus-rules/federation.yaml
@@ -30,3 +30,31 @@
           TOKEN="$(deckhouse-controller helper gen-jwt --private-key-path <(echo "$KEY") --claim iss=d8-istio --claim sub=$LOCAL_CLUSTER_UUID --claim aud=$REMOTE_CLUSTER_UUID --claim scope=private-federation --ttl 1h)"
           curl -H "Authorization: Bearer $TOKEN" {{$labels.endpoint}}
           ```
+
+    - alert: D8IstioFederationRemoteClusterUUIDMismatch
+      expr: max by (federation_name, endpoint, pinned_uuid, actual_uuid) (d8_istio_federation_remote_cluster_uuid_mismatch == 1)
+      for: 5m
+      labels:
+        severity_level: "4"
+        tier: cluster
+      annotations:
+        plk_markup_format: "markdown"
+        plk_protocol_version: "1"
+        plk_create_group_if_not_exists__d8_istio_federation_remote_cluster_uuid_mismatch: D8IstioFederationRemoteClusterUUIDMismatchGroup,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+        plk_grouped_by__d8_istio_federation_remote_cluster_uuid_mismatch: D8IstioFederationRemoteClusterUUIDMismatchGroup,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+        summary: IstioFederation peer cluster UUID changed.
+        description: |
+          Public metadata from `{{$labels.endpoint}}` for IstioFederation `{{$labels.federation_name}}` reports cluster UUID `{{$labels.actual_uuid}}`, but the previously pinned UUID is `{{$labels.pinned_uuid}}`.
+
+          Deckhouse stops private metadata exchange and does not send a federation JWT until the peer identity is confirmed again.
+
+          Check whether `spec.metadataEndpoint` was pointed to another cluster or the remote endpoint was replaced.
+
+          To inspect the resource:
+
+          ```bash
+          d8 k get istiofederation {{$labels.federation_name}} -o yaml
+          curl {{$labels.endpoint}}
+          ```
+
+          If the peer change is intentional, recreate the IstioFederation resource so a new UUID can be pinned.

--- a/ee/modules/110-istio/monitoring/prometheus-rules/multicluster.yaml
+++ b/ee/modules/110-istio/monitoring/prometheus-rules/multicluster.yaml
@@ -54,6 +54,34 @@
           ```
 
 
+    - alert: D8IstioMulticlusterRemoteClusterUUIDMismatch
+      expr: max by (multicluster_name, endpoint, pinned_uuid, actual_uuid) (d8_istio_multicluster_remote_cluster_uuid_mismatch == 1)
+      for: 5m
+      labels:
+        severity_level: "4"
+        tier: cluster
+      annotations:
+        plk_markup_format: "markdown"
+        plk_protocol_version: "1"
+        plk_create_group_if_not_exists__d8_istio_multicluster_remote_cluster_uuid_mismatch: D8IstioMulticlusterRemoteClusterUUIDMismatchGroup,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+        plk_grouped_by__d8_istio_multicluster_remote_cluster_uuid_mismatch: D8IstioMulticlusterRemoteClusterUUIDMismatchGroup,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+        summary: IstioMulticluster peer cluster UUID changed.
+        description: |
+          Public metadata from `{{$labels.endpoint}}` for IstioMulticluster `{{$labels.multicluster_name}}` reports cluster UUID `{{$labels.actual_uuid}}`, but the previously pinned UUID is `{{$labels.pinned_uuid}}`.
+
+          Deckhouse stops private metadata exchange and does not send a multicluster JWT until the peer identity is confirmed again.
+
+          Check whether `spec.metadataEndpoint` was pointed to another cluster or the remote endpoint was replaced.
+
+          To inspect the resource:
+
+          ```bash
+          d8 k get istiomulticluster {{$labels.multicluster_name}} -o yaml
+          curl {{$labels.endpoint}}
+          ```
+
+          If the peer change is intentional, recreate the IstioMulticluster resource so a new UUID can be pinned.
+
     - alert: D8IstioRemoteClusterNotSynced
       expr:  min by (cluster_id, secret, istiod) (istio_remote_cluster_up) == 0
       for: 5m

--- a/go_lib/dependency/http/http.go
+++ b/go_lib/dependency/http/http.go
@@ -19,11 +19,13 @@ package http
 //go:generate minimock -i Client -o http_mock.go
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
 	"net"
 	"net/http"
+	"net/netip"
 	"os"
 	"time"
 
@@ -48,6 +50,12 @@ func NewClient(options ...Option) Client {
 	dialer := &net.Dialer{
 		Timeout: opts.timeout,
 	}
+	dialContext := dialer.DialContext
+	proxy := http.ProxyFromEnvironment
+	if opts.restrictedNetworkAccess {
+		dialContext = restrictedDialContext(dialer)
+		proxy = nil
+	}
 
 	tlsConf := &tls.Config{
 		InsecureSkipVerify: opts.insecure,
@@ -71,12 +79,12 @@ func NewClient(options ...Option) Client {
 	}
 
 	tr := &http.Transport{
-		Proxy:                 http.ProxyFromEnvironment,
+		Proxy:                 proxy,
 		TLSClientConfig:       tlsConf,
 		IdleConnTimeout:       5 * time.Minute,
 		TLSHandshakeTimeout:   5 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
-		DialContext:           dialer.DialContext,
+		DialContext:           dialContext,
 	}
 
 	otr := otelhttp.NewTransport(
@@ -90,17 +98,25 @@ func NewClient(options ...Option) Client {
 		}),
 	)
 
-	return &http.Client{
+	client := &http.Client{
 		Timeout:   opts.timeout,
 		Transport: otr,
 	}
+	if opts.restrictedNetworkAccess {
+		client.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+			return fmt.Errorf("redirects are disabled for restricted HTTP clients")
+		}
+	}
+
+	return client
 }
 
 type httpOptions struct {
-	timeout         time.Duration
-	insecure        bool
-	additionalTLSCA [][]byte
-	tlsServerName   string
+	timeout                 time.Duration
+	insecure                bool
+	additionalTLSCA         [][]byte
+	tlsServerName           string
+	restrictedNetworkAccess bool
 }
 
 type Option func(options *httpOptions)
@@ -129,6 +145,58 @@ func WithTLSServerName(name string) Option {
 	return func(options *httpOptions) {
 		options.tlsServerName = name
 	}
+}
+
+// WithRestrictedNetworkAccess prevents requests to loopback, link-local, unspecified and multicast
+// addresses and disables redirects. RFC1918, unique-local IPv6 and CGNAT destinations stay allowed
+// so federation/multicluster can use private networks. HTTP proxies are disabled so the destination
+// is validated and dialed directly.
+func WithRestrictedNetworkAccess() Option {
+	return func(options *httpOptions) {
+		options.restrictedNetworkAccess = true
+	}
+}
+
+func restrictedDialContext(dialer *net.Dialer) func(context.Context, string, string) (net.Conn, error) {
+	return func(ctx context.Context, network, address string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(address)
+		if err != nil {
+			return nil, fmt.Errorf("parse destination address %q: %w", address, err)
+		}
+
+		ips, err := net.DefaultResolver.LookupNetIP(ctx, "ip", host)
+		if err != nil {
+			return nil, fmt.Errorf("resolve destination host %q: %w", host, err)
+		}
+		if len(ips) == 0 {
+			return nil, fmt.Errorf("destination host %q has no IP addresses", host)
+		}
+
+		for _, ip := range ips {
+			if isRestrictedIP(ip) {
+				return nil, fmt.Errorf("destination host %q resolves to a restricted IP address %s", host, ip)
+			}
+		}
+
+		var dialErr error
+		for _, ip := range ips {
+			conn, err := dialer.DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
+			if err == nil {
+				return conn, nil
+			}
+			dialErr = err
+		}
+
+		return nil, fmt.Errorf("dial destination host %q: %w", host, dialErr)
+	}
+}
+
+func isRestrictedIP(ip netip.Addr) bool {
+	ip = ip.Unmap()
+	return ip.IsLoopback() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsUnspecified() ||
+		ip.IsMulticast()
 }
 
 func SetBearerToken(req *http.Request, token string) {

--- a/go_lib/dependency/http/http_test.go
+++ b/go_lib/dependency/http/http_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package http
+
+import (
+	"net/http"
+	"net/netip"
+	"strings"
+	"testing"
+)
+
+func TestIsRestrictedIP(t *testing.T) {
+	tests := []struct {
+		name       string
+		ip         string
+		restricted bool
+	}{
+		{name: "public IPv4", ip: "8.8.8.8", restricted: false},
+		{name: "public IPv6", ip: "2606:4700:4700::1111", restricted: false},
+		{name: "private IPv4", ip: "10.0.0.1", restricted: false},
+		{name: "mapped private IPv4", ip: "::ffff:10.0.0.1", restricted: false},
+		{name: "RFC1918 192.168", ip: "192.168.1.1", restricted: false},
+		{name: "carrier-grade NAT", ip: "100.64.0.1", restricted: false},
+		{name: "unique local IPv6", ip: "fd00::1", restricted: false},
+		{name: "loopback IPv4", ip: "127.0.0.1", restricted: true},
+		{name: "mapped loopback IPv4", ip: "::ffff:127.0.0.1", restricted: true},
+		{name: "link-local metadata", ip: "169.254.169.254", restricted: true},
+		{name: "loopback IPv6", ip: "::1", restricted: true},
+		{name: "link-local IPv6", ip: "fe80::1", restricted: true},
+		{name: "unspecified IPv4", ip: "0.0.0.0", restricted: true},
+		{name: "multicast IPv4", ip: "224.0.0.1", restricted: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isRestrictedIP(netip.MustParseAddr(tt.ip)); got != tt.restricted {
+				t.Fatalf("isRestrictedIP(%q) = %t, want %t", tt.ip, got, tt.restricted)
+			}
+		})
+	}
+}
+
+func TestRestrictedClientDisablesRedirects(t *testing.T) {
+	client, ok := NewClient(WithRestrictedNetworkAccess()).(*http.Client)
+	if !ok {
+		t.Fatal("NewClient returned an unexpected client implementation")
+	}
+	if client.CheckRedirect == nil {
+		t.Fatal("restricted client must define CheckRedirect")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "https://example.com/next", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := client.CheckRedirect(req, nil); err == nil {
+		t.Fatal("restricted client must reject redirects")
+	}
+}
+
+func TestRestrictedClientRejectsLiteralLoopbackAddress(t *testing.T) {
+	client := NewClient(WithRestrictedNetworkAccess()).(*http.Client)
+
+	_, err := client.Get("https://127.0.0.1:8443")
+	if err == nil {
+		t.Fatal("restricted client must reject a loopback destination")
+	}
+	if !strings.Contains(err.Error(), "restricted IP address") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/modules/110-istio/hooks/lib/common.go
+++ b/modules/110-istio/hooks/lib/common.go
@@ -28,6 +28,8 @@ import (
 
 const namespace = "d8-istio"
 
+const maxHTTPResponseBodySize = 1 << 20
+
 func Queue(name string) string {
 	return fmt.Sprintf("/modules/istio/%s", name)
 }
@@ -55,6 +57,15 @@ func HTTPGet(httpClient d8http.Client, url string, bearerToken string) ([]byte, 
 	if err != nil {
 		return nil, 0, err
 	}
+	if req.URL.Scheme != "https" {
+		return nil, 0, fmt.Errorf("only HTTPS URLs are allowed")
+	}
+	if req.URL.User != nil {
+		return nil, 0, fmt.Errorf("URL userinfo is not allowed")
+	}
+	if req.URL.RawQuery != "" || req.URL.Fragment != "" {
+		return nil, 0, fmt.Errorf("URL query parameters and fragments are not allowed")
+	}
 
 	if len(bearerToken) > 0 {
 		req.Header.Add("Authorization", "Bearer "+bearerToken)
@@ -66,9 +77,12 @@ func HTTPGet(httpClient d8http.Client, url string, bearerToken string) ([]byte, 
 	}
 	defer res.Body.Close()
 
-	dataBytes, err := io.ReadAll(res.Body)
+	dataBytes, err := io.ReadAll(io.LimitReader(res.Body, maxHTTPResponseBodySize+1))
 	if err != nil {
 		return nil, 0, err
+	}
+	if len(dataBytes) > maxHTTPResponseBodySize {
+		return nil, 0, fmt.Errorf("HTTP response body exceeds %d bytes", maxHTTPResponseBodySize)
 	}
 
 	return dataBytes, res.StatusCode, nil

--- a/modules/110-istio/hooks/lib/common_test.go
+++ b/modules/110-istio/hooks/lib/common_test.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lib
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+type roundTripClient func(*http.Request) (*http.Response, error)
+
+func (f roundTripClient) Do(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestHTTPGetRejectsOversizedResponse(t *testing.T) {
+	client := roundTripClient(func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(strings.Repeat("x", maxHTTPResponseBodySize+1))),
+		}, nil
+	})
+
+	if _, _, err := HTTPGet(client, "https://example.com", ""); err == nil {
+		t.Fatal("HTTPGet must reject an oversized response body")
+	}
+}


### PR DESCRIPTION
## Description

This PR hardens the Istio federation/multicluster metadata discovery hooks against server-side request forgery (SSRF) and remote peer substitution:

- **Restricted HTTP client** (`go_lib/dependency/http`): a new `WithRestrictedNetworkAccess()` option that:
  - resolves the destination host and rejects loopback, link-local, unspecified, and multicast IP addresses (RFC1918, unique-local IPv6, and CGNAT ranges remain allowed so federation/multicluster can operate over private networks);
  - dials the validated IP directly, bypassing HTTP proxies (`Proxy` is disabled);
  - disables HTTP redirects entirely.
- **Stricter URL validation in `HTTPGet`** (`modules/110-istio/hooks/lib`): only HTTPS URLs are allowed; URLs with userinfo, query parameters, or fragments are rejected. The response body size is now limited to 1 MiB.
- **Remote cluster UUID pinning** (`federation_discovery` / `multicluster_discovery` hooks): once `status.metadataCache.public.clusterUUID` is set, the UUID returned by the remote `public.json` endpoint must match it. On mismatch:
  - the `PublicMetadataExchangeReady` condition becomes `False` with reason `ClusterUUIDMismatch`;
  - private metadata exchange is halted and no JWT is sent to the unverified peer;
  - new metrics `d8_istio_federation_remote_cluster_uuid_mismatch` / `d8_istio_multicluster_remote_cluster_uuid_mismatch` are exposed.
- **New Prometheus alerts**: `D8IstioFederationRemoteClusterUUIDMismatch` and `D8IstioMulticlusterRemoteClusterUUIDMismatch` fire when the peer cluster UUID changes, with remediation steps in the alert description.
- Updated CRD documentation (`IstioFederation`, `IstioMulticluster`) and alert docs accordingly, including unit tests for the new behavior.

No restarts of critical cluster components (ingress-controllers, control-plane, Prometheus) are triggered by this change. Only the Deckhouse istio discovery hooks and Prometheus alerting rules are affected.


## Why do we need it, and what problem does it solve?

The federation/multicluster discovery hooks fetch metadata from remote endpoints defined in `IstioFederation`/`IstioMulticluster` custom resources and send bearer tokens (JWTs) to them. Previously this created two security problems:

1. **SSRF vulnerability.** A user able to create or modify `IstioFederation`/`IstioMulticluster` resources could point `spec.metadataEndpoint` at internal infrastructure (e.g., `127.0.0.1`, link-local metadata services such as `169.254.169.254`, or redirect chains), causing the Deckhouse hooks to issue authenticated requests to arbitrary internal targets. The restricted HTTP client, HTTPS-only URL validation, redirect prohibition, and response size limits close this attack vector.

2. **Peer cluster substitution.** If the remote metadata endpoint was silently replaced by a different cluster (DNS takeover, endpoint hijack, or misconfiguration), Deckhouse would trust the new peer and continue exchanging private metadata and JWTs with it. With UUID pinning, the peer's identity is fixed after the first successful exchange: any UUID change stops the private metadata exchange, marks the resource with the `ClusterUUIDMismatch` condition, and raises an alert so operators can verify whether the change is intentional (and recreate the resource to re-pin the new UUID if so).

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: fix
summary: Restrict metadata discovery server-side request forgery and pin remote cluster UUID
impact_level: default
```
