### PR TITLE
[deckhouse] add VEX entries for findings in the webhook-handler and dev images

### DIFF
--- a/deckhouse-controller/known_vulnerabilities.vex
+++ b/deckhouse-controller/known_vulnerabilities.vex
@@ -2,7 +2,7 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-5a4509a04e8128126aee080324a6b663a7748bf44b58a9a4b9c74d4801844f53",
   "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
-  "version": 23,
+  "version": 24,
   "statements": [
     {
       "vulnerability": {
@@ -652,6 +652,76 @@
       "status": "not_affected",
       "justification": "vulnerable_code_not_present",
       "impact_statement": "Уязвимая функция NewNTUnicodeString находится в golang.org/x/sys/windows. Образ собирается под Linux, поэтому пакет windows не компилируется ни в один из бинарей образа независимо от того, какой из них тянет модуль golang.org/x/sys.",
+      "timestamp": "2026-09-01T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-47262"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/containerd/containerd@v1.7.29"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Зависимость github.com/containerd/containerd поступает транзитивно через helm (go_lib/dependency/helm -> helm.sh/helm/v3/pkg/registry) и используется только как клиент OCI-реестра. Уязвимость — DoS рантайма при разборе групп во время запуска контейнера. В deckhouse-controller CRI-плагин containerd, его рантайм и механизм checkpoint/restore не собираются и не запускаются, уязвимый код не в пути выполнения.",
+      "timestamp": "2026-09-01T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-53488"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/containerd/containerd@v1.7.29"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Зависимость github.com/containerd/containerd поступает транзитивно через helm (go_lib/dependency/helm -> helm.sh/helm/v3/pkg/registry) и используется только как клиент OCI-реестра. Уязвимость — передача LABEL из конфига образа в restart-monitor CRI-плагина. В deckhouse-controller CRI-плагин containerd, его рантайм и механизм checkpoint/restore не собираются и не запускаются, уязвимый код не в пути выполнения.",
+      "timestamp": "2026-09-01T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-50195"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/containerd/containerd@v1.7.29"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Зависимость github.com/containerd/containerd поступает транзитивно через helm (go_lib/dependency/helm -> helm.sh/helm/v3/pkg/registry) и используется только как клиент OCI-реестра. Уязвимость — подмена тега образа при импорте CRI-checkpoint. В deckhouse-controller CRI-плагин containerd, его рантайм и механизм checkpoint/restore не собираются и не запускаются, уязвимый код не в пути выполнения.",
+      "timestamp": "2026-09-01T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-53489"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/containerd/containerd@v1.7.29"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Зависимость github.com/containerd/containerd поступает транзитивно через helm (go_lib/dependency/helm -> helm.sh/helm/v3/pkg/registry) и используется только как клиент OCI-реестра. Уязвимость — чтение произвольного файла лога через симлинк при CRI checkpoint restore. В deckhouse-controller CRI-плагин containerd, его рантайм и механизм checkpoint/restore не собираются и не запускаются, уязвимый код не в пути выполнения.",
+      "timestamp": "2026-09-01T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-53492"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/containerd/containerd@v1.7.29"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Зависимость github.com/containerd/containerd поступает транзитивно через helm (go_lib/dependency/helm -> helm.sh/helm/v3/pkg/registry) и используется только как клиент OCI-реестра. Уязвимость — подмена CDI-аннотаций при CRI checkpoint restore. В deckhouse-controller CRI-плагин containerd, его рантайм и механизм checkpoint/restore не собираются и не запускаются, уязвимый код не в пути выполнения.",
       "timestamp": "2026-09-01T12:00:00Z"
     }
   ],

--- a/deckhouse-controller/known_vulnerabilities.vex
+++ b/deckhouse-controller/known_vulnerabilities.vex
@@ -2,7 +2,7 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-5a4509a04e8128126aee080324a6b663a7748bf44b58a9a4b9c74d4801844f53",
   "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
-  "version": 25,
+  "version": 23,
   "statements": [
     {
       "vulnerability": {

--- a/deckhouse-controller/known_vulnerabilities.vex
+++ b/deckhouse-controller/known_vulnerabilities.vex
@@ -2,7 +2,7 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-5a4509a04e8128126aee080324a6b663a7748bf44b58a9a4b9c74d4801844f53",
   "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
-  "version": 22,
+  "version": 23,
   "statements": [
     {
       "vulnerability": {
@@ -457,8 +457,204 @@
       "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
       "impact_statement": "Исправленной версии в линейке oras-go v1.x не выпущено. Модуль поступает транзитивно через helm.sh/helm/v3/pkg/registry (go_lib/dependency/helm). Атака требует подконтрольного злоумышленнику OCI-реестра, тогда как адрес реестра задаётся конфигурацией кластера, а не недоверенным вводом.",
       "timestamp": "2026-08-27T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-47911"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net@v0.42.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Пакет попадает в образ с бинарём yq 4.47.1: base-образ tools/yq импортируется в common-base, от которого собирается dev-prebuild. Уязвимость находится в парсере golang.org/x/net/html. Из модуля golang.org/x/net yq импортирует единственный пакет — html/charset, и обращается к нему только в decoder_xml.go, где charset.NewReaderLabel назначается xml.Decoder.CharsetReader. Разбор XML в образе не выполняется, код не в пути выполнения.",
+      "timestamp": "2026-09-01T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-58190"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net@v0.42.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Пакет попадает в образ с бинарём yq 4.47.1: base-образ tools/yq импортируется в common-base, от которого собирается dev-prebuild. Уязвимость находится в парсере golang.org/x/net/html. Из модуля golang.org/x/net yq импортирует единственный пакет — html/charset, и обращается к нему только в decoder_xml.go, где charset.NewReaderLabel назначается xml.Decoder.CharsetReader. Разбор XML в образе не выполняется, код не в пути выполнения.",
+      "timestamp": "2026-09-01T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-25680"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net@v0.42.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Пакет попадает в образ с бинарём yq 4.47.1: base-образ tools/yq импортируется в common-base, от которого собирается dev-prebuild. Уязвимость находится в парсере golang.org/x/net/html. Из модуля golang.org/x/net yq импортирует единственный пакет — html/charset, и обращается к нему только в decoder_xml.go, где charset.NewReaderLabel назначается xml.Decoder.CharsetReader. Разбор XML в образе не выполняется, код не в пути выполнения.",
+      "timestamp": "2026-09-01T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-25681"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net@v0.42.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Пакет попадает в образ с бинарём yq 4.47.1: base-образ tools/yq импортируется в common-base, от которого собирается dev-prebuild. Уязвимость находится в парсере golang.org/x/net/html. Из модуля golang.org/x/net yq импортирует единственный пакет — html/charset, и обращается к нему только в decoder_xml.go, где charset.NewReaderLabel назначается xml.Decoder.CharsetReader. Разбор XML в образе не выполняется, код не в пути выполнения.",
+      "timestamp": "2026-09-01T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-27136"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net@v0.42.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Пакет попадает в образ с бинарём yq 4.47.1: base-образ tools/yq импортируется в common-base, от которого собирается dev-prebuild. Уязвимость находится в парсере golang.org/x/net/html. Из модуля golang.org/x/net yq импортирует единственный пакет — html/charset, и обращается к нему только в decoder_xml.go, где charset.NewReaderLabel назначается xml.Decoder.CharsetReader. Разбор XML в образе не выполняется, код не в пути выполнения.",
+      "timestamp": "2026-09-01T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-42502"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net@v0.42.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Пакет попадает в образ с бинарём yq 4.47.1: base-образ tools/yq импортируется в common-base, от которого собирается dev-prebuild. Уязвимость находится в парсере golang.org/x/net/html. Из модуля golang.org/x/net yq импортирует единственный пакет — html/charset, и обращается к нему только в decoder_xml.go, где charset.NewReaderLabel назначается xml.Decoder.CharsetReader. Разбор XML в образе не выполняется, код не в пути выполнения.",
+      "timestamp": "2026-09-01T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-42506"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net@v0.42.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Пакет попадает в образ с бинарём yq 4.47.1: base-образ tools/yq импортируется в common-base, от которого собирается dev-prebuild. Уязвимость находится в парсере golang.org/x/net/html. Из модуля golang.org/x/net yq импортирует единственный пакет — html/charset, и обращается к нему только в decoder_xml.go, где charset.NewReaderLabel назначается xml.Decoder.CharsetReader. Разбор XML в образе не выполняется, код не в пути выполнения.",
+      "timestamp": "2026-09-01T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-33814"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net@v0.42.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "Пакет попадает в образ с бинарём yq 4.47.1: base-образ tools/yq импортируется в common-base, от которого собирается dev-prebuild. Уязвимость находится в HTTP/2-транспорте golang.org/x/net/http2. Из модуля golang.org/x/net yq импортирует только html/charset; http2 в бинарь не попадает.",
+      "timestamp": "2026-09-01T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39821"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net@v0.42.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "Пакет попадает в образ с бинарём yq 4.47.1: base-образ tools/yq импортируется в common-base, от которого собирается dev-prebuild. Уязвимость находится в golang.org/x/net/idna, который подтягивается только через http2 и http/httpguts. Из модуля golang.org/x/net yq импортирует только html/charset; idna в бинарь не попадает.",
+      "timestamp": "2026-09-01T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-46600"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net@v0.42.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "Пакет попадает в образ с бинарём yq 4.47.1: base-образ tools/yq импортируется в common-base, от которого собирается dev-prebuild. Уязвимость находится в golang.org/x/net/dns/dnsmessage. Из модуля golang.org/x/net yq импортирует только html/charset; dnsmessage в бинарь не попадает.",
+      "timestamp": "2026-09-01T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-56852"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/text@v0.27.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Пакет попадает в образ с бинарём yq 4.47.1: base-образ tools/yq импортируется в common-base, от которого собирается dev-prebuild. Уязвимость находится в golang.org/x/text/unicode/norm. yq использует его единственный раз — в encoder_shellvariables.go для формата вывода shell, который в образе не применяется.",
+      "timestamp": "2026-09-01T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39824"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/sys@v0.34.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "Пакет попадает в образ с бинарём yq 4.47.1: base-образ tools/yq импортируется в common-base, от которого собирается dev-prebuild. Уязвимая функция NewNTUnicodeString находится в golang.org/x/sys/windows. Образ собирается под Linux, пакет windows не компилируется и в бинарь не попадает.",
+      "timestamp": "2026-09-01T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39824"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/sys@v0.35.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "Уязвимая функция NewNTUnicodeString находится в golang.org/x/sys/windows. Образ собирается под Linux, поэтому пакет windows не компилируется ни в один из бинарей образа независимо от того, какой из них тянет модуль golang.org/x/sys.",
+      "timestamp": "2026-09-01T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39824"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/sys@v0.38.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "Уязвимая функция NewNTUnicodeString находится в golang.org/x/sys/windows. Образ собирается под Linux, поэтому пакет windows не компилируется ни в один из бинарей образа независимо от того, какой из них тянет модуль golang.org/x/sys.",
+      "timestamp": "2026-09-01T12:00:00Z"
     }
   ],
   "timestamp": "2026-03-05T12:00:00Z",
-  "last_updated": "2026-08-27T12:00:00Z"
+  "last_updated": "2026-09-01T12:00:00Z"
 }

--- a/deckhouse-controller/known_vulnerabilities.vex
+++ b/deckhouse-controller/known_vulnerabilities.vex
@@ -2,7 +2,7 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-5a4509a04e8128126aee080324a6b663a7748bf44b58a9a4b9c74d4801844f53",
   "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
-  "version": 24,
+  "version": 25,
   "statements": [
     {
       "vulnerability": {
@@ -722,6 +722,104 @@
       "status": "not_affected",
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Зависимость github.com/containerd/containerd поступает транзитивно через helm (go_lib/dependency/helm -> helm.sh/helm/v3/pkg/registry) и используется только как клиент OCI-реестра. Уязвимость — подмена CDI-аннотаций при CRI checkpoint restore. В deckhouse-controller CRI-плагин containerd, его рантайм и механизм checkpoint/restore не собираются и не запускаются, уязвимый код не в пути выполнения.",
+      "timestamp": "2026-09-01T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-69725"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/go-chi/chi/v5@v5.2.2"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Модуль github.com/go-chi/chi/v5 приходит транзитивно через github.com/flant/addon-operator, который поднимает на нём свой HTTP-сервер. Уязвимость находится в middleware.RedirectSlashes пакета github.com/go-chi/chi/v5/middleware. Прогон govulncheck по бинарю deckhouse-controller показывает, что этот символ не вызывается: addon-operator не добавляет его в цепочку обработчиков. Код не в пути выполнения.",
+      "timestamp": "2026-09-01T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-72815"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/go-chi/chi/v5@v5.2.2"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Модуль github.com/go-chi/chi/v5 приходит транзитивно через github.com/flant/addon-operator, который поднимает на нём свой HTTP-сервер. Уязвимость находится в middleware.RealIP пакета github.com/go-chi/chi/v5/middleware. Прогон govulncheck по бинарю deckhouse-controller показывает, что этот символ не вызывается: addon-operator не добавляет его в цепочку обработчиков. Код не в пути выполнения.",
+      "timestamp": "2026-09-01T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-72816"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/go-chi/chi/v5@v5.2.2"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Модуль github.com/go-chi/chi/v5 приходит транзитивно через github.com/flant/addon-operator, который поднимает на нём свой HTTP-сервер. Уязвимость находится в middleware.RealIP пакета github.com/go-chi/chi/v5/middleware. Прогон govulncheck по бинарю deckhouse-controller показывает, что этот символ не вызывается: addon-operator не добавляет его в цепочку обработчиков. Код не в пути выполнения.",
+      "timestamp": "2026-09-01T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-72817"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/go-chi/chi/v5@v5.2.2"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Модуль github.com/go-chi/chi/v5 приходит транзитивно через github.com/flant/addon-operator, который поднимает на нём свой HTTP-сервер. Уязвимость находится в middleware.RealIP пакета github.com/go-chi/chi/v5/middleware. Прогон govulncheck по бинарю deckhouse-controller показывает, что этот символ не вызывается: addon-operator не добавляет его в цепочку обработчиков. Код не в пути выполнения.",
+      "timestamp": "2026-09-01T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-33813"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/image@v0.38.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "Модуль golang.org/x/image приходит транзитивно через github.com/flant/addon-operator -> github.com/goccy/go-graphviz. Из модуля используются только декодеры bmp и tiff и парсер шрифтов sfnt. Уязвимость находится в golang.org/x/image/webp, который не импортируется и в бинарь не попадает.",
+      "timestamp": "2026-09-01T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-46601"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/image@v0.38.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "Модуль golang.org/x/image приходит транзитивно через github.com/flant/addon-operator -> github.com/goccy/go-graphviz. Из модуля используются только декодеры bmp и tiff и парсер шрифтов sfnt. Уязвимость находится в golang.org/x/image/webp, который не импортируется и в бинарь не попадает.",
+      "timestamp": "2026-09-01T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-46603"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/image@v0.38.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "Модуль golang.org/x/image приходит транзитивно через github.com/flant/addon-operator -> github.com/goccy/go-graphviz. Из модуля используются только декодеры bmp и tiff и парсер шрифтов sfnt. Уязвимость находится в golang.org/x/image/vp8l, который не импортируется и в бинарь не попадает.",
       "timestamp": "2026-09-01T12:00:00Z"
     }
   ],

--- a/modules/002-deckhouse/images/webhook-handler/known_vulnerabilities.vex
+++ b/modules/002-deckhouse/images/webhook-handler/known_vulnerabilities.vex
@@ -2,7 +2,7 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-5a4509a04e8128126aee080324a6b663a7748bf44b58a9a4b9c74d4801844f53",
   "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
-  "version": 22,
+  "version": 23,
   "statements": [
     {
       "vulnerability": {
@@ -473,8 +473,134 @@
       "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
       "impact_statement": "Уязвимость находится в golang.org/x/text/unicode/norm. Модуль поступает с бинарём shell-operator v1.15.3 из базового образа common/shell-operator. Единственный путь до неё — отладочный клиент pkg/debug: его http.Client в DialContext всегда подключается к unix-сокету и игнорирует адрес из URL, а сами URL собираются с константной authority (http://unix/queue/list, http://unix/hook/..., http://unix/config/list). В нормализацию попадает неизменяемая строка unix, на которую злоумышленник повлиять не может.",
       "timestamp": "2026-08-27T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-25681"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net@v0.42.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Пакет попадает в образ с бинарём yq 4.47.1, который импортируется из base-образа tools/yq (digest зафиксирован в candi/base_images.yml). Уязвимость находится в парсере golang.org/x/net/html. yq обращается к нему единственный раз — через golang.org/x/net/html/charset в decoder_xml.go, где charset.NewReaderLabel назначается xml.Decoder.CharsetReader. Вебхуки webhook-handler вызывают yq только для YAML и JSON, разбор XML не выполняется, код не в пути выполнения.",
+      "timestamp": "2026-09-01T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-27136"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net@v0.42.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Пакет попадает в образ с бинарём yq 4.47.1, который импортируется из base-образа tools/yq (digest зафиксирован в candi/base_images.yml). Уязвимость находится в парсере golang.org/x/net/html. yq обращается к нему единственный раз — через golang.org/x/net/html/charset в decoder_xml.go, где charset.NewReaderLabel назначается xml.Decoder.CharsetReader. Вебхуки webhook-handler вызывают yq только для YAML и JSON, разбор XML не выполняется, код не в пути выполнения.",
+      "timestamp": "2026-09-01T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-33814"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net@v0.42.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "Пакет попадает в образ с бинарём yq 4.47.1, который импортируется из base-образа tools/yq (digest зафиксирован в candi/base_images.yml). Уязвимость находится в HTTP/2-транспорте golang.org/x/net/http2. Из модуля golang.org/x/net yq импортирует только html/charset; http2 в бинарь не попадает.",
+      "timestamp": "2026-09-01T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39821"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net@v0.42.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "Пакет попадает в образ с бинарём yq 4.47.1, который импортируется из base-образа tools/yq (digest зафиксирован в candi/base_images.yml). Уязвимость находится в golang.org/x/net/idna, который подтягивается только через http2 и http/httpguts. Из модуля golang.org/x/net yq импортирует только html/charset; idna в бинарь не попадает.",
+      "timestamp": "2026-09-01T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-25681"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net@v0.52.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Пакет попадает в образ с бинарём shell-operator v1.15.3 из базового образа common/shell-operator. Уязвимость находится в парсере golang.org/x/net/html. Он подтягивается транзитивно через github.com/kennygrant/sanitize, а shell-operator вызывает оттуда только sanitize.BaseName для нормализации имени хука — эта функция состоит из регулярных замен и HTML не разбирает. Парсер x/net/html не вызывается.",
+      "timestamp": "2026-09-01T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-27136"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net@v0.52.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Пакет попадает в образ с бинарём shell-operator v1.15.3 из базового образа common/shell-operator. Уязвимость находится в парсере golang.org/x/net/html. Он подтягивается транзитивно через github.com/kennygrant/sanitize, а shell-operator вызывает оттуда только sanitize.BaseName для нормализации имени хука — эта функция состоит из регулярных замен и HTML не разбирает. Парсер x/net/html не вызывается.",
+      "timestamp": "2026-09-01T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-33814"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net@v0.52.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "Пакет попадает в образ с бинарём shell-operator v1.15.3 из базового образа common/shell-operator. Уязвимость — зацикливание HTTP/2-транспорта при некорректном SETTINGS_MAX_FRAME_SIZE от сервера. Единственный путь до неё — отладочный клиент pkg/debug: его http.Client в DialContext всегда подключается к unix-сокету и игнорирует адрес из URL, а сами URL собираются с константной authority (http://unix/queue/list, http://unix/hook/...). Клиент обращается к отладочному серверу самого shell-operator внутри того же контейнера. Кадр SETTINGS приходит от него же, а не от внешней стороны, поэтому злоумышленник на вход повлиять не может.",
+      "timestamp": "2026-09-01T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39821"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net@v0.52.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "Пакет попадает в образ с бинарём shell-operator v1.15.3 из базового образа common/shell-operator. Уязвимость — отсутствие отбраковки ASCII-only Punycode-меток в golang.org/x/net/idna. Единственный путь до неё — отладочный клиент pkg/debug: его http.Client в DialContext всегда подключается к unix-сокету и игнорирует адрес из URL, а сами URL собираются с константной authority (http://unix/queue/list, http://unix/hook/...). Клиент обращается к отладочному серверу самого shell-operator внутри того же контейнера. В idna.ToASCII попадает неизменяемая строка unix, на которую злоумышленник повлиять не может.",
+      "timestamp": "2026-09-01T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "GHSA-537c-gmf6-5ccf"
+      },
+      "products": [
+        {
+          "@id": "pkg:pypi/cryptography@44.0.1"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость относится к копии OpenSSL, статически влинкованной в wheel-пакет cryptography 44.0.1 (закреплён в src/requirements.txt образа). Python-вебхуки используют cryptography только для локального разбора сертификатов X.509; TLS-соединения через встроенный OpenSSL не устанавливаются, уязвимый код не в пути выполнения.",
+      "timestamp": "2026-09-01T12:00:00Z"
     }
   ],
   "timestamp": "2026-03-04T12:00:00Z",
-  "last_updated": "2026-08-27T12:00:00Z"
+  "last_updated": "2026-09-01T12:00:00Z"
 }


### PR DESCRIPTION
## Description

Adds 35 VEX statements for findings the 1.73 scan reports against `webhook-handler` and `dev`. None can be closed by raising a version: the components come from base images or from upstream that has no fix.

Reachability was checked with `govulncheck` against each binary, so every statement names the package or symbol the advisory points at:

- **yq 4.47.1** (both images) — imports only `net/html/charset` and `text/unicode/norm`; `http2`, `idna` and `dnsmessage` are absent, and the XML decoder and shell encoder are never used
- **shell-operator v1.15.3** — the `x/net/html` parser is unreachable through `sanitize.BaseName`; the http2 and idna findings are reachable only from the `pkg/debug` client, which dials a unix socket with the constant authority `http://unix/...`
- **chi v5.2.2** — neither `middleware.RealIP` nor `middleware.RedirectSlashes` is called
- **containerd v1.7.29** — arrives through helm's OCI registry client; every advisory is about the CRI plugin, the runtime or checkpoint/restore
- **`x/image` webp and vp8l**, **`x/sys/windows`**, **cryptography's bundled OpenSSL** — not present in a Linux build or not imported at all

Note for review: `govulncheck` marks the containerd findings reachable. Those advisories carry no package data in OSV, so any call into the module counts; the real call sites are `remotes/docker` and `containerd/log`.

Unchanged: hook behaviour, image contents, build flow.

## Why do we need it, and what problem does it solve?

Without these statements the findings stay open on every rescan, and the remaining `x/image` bmp/tiff ones are left alone on purpose — they are reachable through `goccy/go-graphviz`, which pins `x/image` v0.21.0 in every release, so there is nothing to raise.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: add VEX entries for findings in the webhook-handler and dev images
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->




