### PR TITLE
[ci] Add REGCTL_CONFIG

### DIFF
--- a/.github/ci_templates/build.yml
+++ b/.github/ci_templates/build.yml
@@ -128,6 +128,7 @@ steps:
       VAULT_ROLE: "dh-signer_dh-signer"
       REGISTRY_USER: ${{ steps.secrets.outputs.DECKHOUSE_REGISTRY_STAGE_USER }}
       REGISTRY_PASSWORD: ${{ steps.secrets.outputs.DECKHOUSE_REGISTRY_STAGE_PASSWORD }}
+      REGCTL_CONFIG: "${{ runner.temp }}/regctl-${{ job.check_run_id }}.json"
 {!{- end }!}
     run: |
       # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.

--- a/.github/workflow_templates/build-and-test_pre-release.yml
+++ b/.github/workflow_templates/build-and-test_pre-release.yml
@@ -246,6 +246,7 @@ jobs:
           IMAGE_TO: "${{ steps.secrets.outputs.DECKHOUSE_REGISTRY_STAGE_HOST }}/sys/deckhouse-oss:${{ github.ref_name }}"
           COMPARE_MAX_ATTEMPTS: 10
           COMPARE_RETRY_DELAY: 30
+          REGCTL_CONFIG: "${{ runner.temp }}/regctl-${{ job.check_run_id }}.json"
         run: |
           # Tags from git are used and each tag is checked in the registry.
           # This is done because the regctl ls tag takes a long time to execute

--- a/.github/workflow_templates/build-and-test_release.yml
+++ b/.github/workflow_templates/build-and-test_release.yml
@@ -240,6 +240,7 @@ jobs:
           IMAGE_TO: "${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}/deckhouse/fe:${{ github.ref_name }}"
           COMPARE_MAX_ATTEMPTS: 10
           COMPARE_RETRY_DELAY: 30
+          REGCTL_CONFIG: "${{ runner.temp }}/regctl-${{ job.check_run_id }}.json"
         run: |
           RELEASE_BRANCH=$(echo $GITHUB_REF_NAME | awk -F '.' '{printf "%s.%s", $1, $2}')
           LAST_TWO_TAGS="$(git ls-remote --tags origin | grep -F tags/${RELEASE_BRANCH} | awk -F '/' '{print $3}' | sort -V | tail -n 2)"

--- a/.github/workflow_templates/compare-external-modules.yml
+++ b/.github/workflow_templates/compare-external-modules.yml
@@ -45,4 +45,5 @@ jobs:
           DECKHOUSE_REGISTRY: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
           EDITIONS_FILE: "./editions.yaml"
           VERSIONS_TO_COMPARE : ${{ inputs.versions_to_compare || 1 }}
+          REGCTL_CONFIG: "${{ runner.temp }}/regctl-${{ job.check_run_id }}.json"
         run: python .github/scripts/python/compare_external_modules.py

--- a/.github/workflow_templates/suspend-channel.multi.yml
+++ b/.github/workflow_templates/suspend-channel.multi.yml
@@ -141,6 +141,7 @@ Destination registries:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           WERF_ENV: {!{ $werfEnv }!}
           SKIP_PUSH_FOR_SUSPEND: ${{vars.SKIP_PUSH_FOR_SUSPEND}}
+          REGCTL_CONFIG: "${{ runner.temp }}/regctl-${{ job.check_run_id }}.json"
         run: |
           # SRC_NAME is a name of image from werf.yaml.
           # SRC is a source image name.

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -300,6 +300,7 @@ jobs:
           VAULT_ROLE: "dh-signer_dh-signer"
           REGISTRY_USER: ${{ steps.secrets.outputs.DECKHOUSE_REGISTRY_STAGE_USER }}
           REGISTRY_PASSWORD: ${{ steps.secrets.outputs.DECKHOUSE_REGISTRY_STAGE_PASSWORD }}
+          REGCTL_CONFIG: "${{ runner.temp }}/regctl-${{ job.check_run_id }}.json"
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
@@ -599,6 +600,7 @@ jobs:
           VAULT_ROLE: "dh-signer_dh-signer"
           REGISTRY_USER: ${{ steps.secrets.outputs.DECKHOUSE_REGISTRY_STAGE_USER }}
           REGISTRY_PASSWORD: ${{ steps.secrets.outputs.DECKHOUSE_REGISTRY_STAGE_PASSWORD }}
+          REGCTL_CONFIG: "${{ runner.temp }}/regctl-${{ job.check_run_id }}.json"
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
@@ -898,6 +900,7 @@ jobs:
           VAULT_ROLE: "dh-signer_dh-signer"
           REGISTRY_USER: ${{ steps.secrets.outputs.DECKHOUSE_REGISTRY_STAGE_USER }}
           REGISTRY_PASSWORD: ${{ steps.secrets.outputs.DECKHOUSE_REGISTRY_STAGE_PASSWORD }}
+          REGCTL_CONFIG: "${{ runner.temp }}/regctl-${{ job.check_run_id }}.json"
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
@@ -1197,6 +1200,7 @@ jobs:
           VAULT_ROLE: "dh-signer_dh-signer"
           REGISTRY_USER: ${{ steps.secrets.outputs.DECKHOUSE_REGISTRY_STAGE_USER }}
           REGISTRY_PASSWORD: ${{ steps.secrets.outputs.DECKHOUSE_REGISTRY_STAGE_PASSWORD }}
+          REGCTL_CONFIG: "${{ runner.temp }}/regctl-${{ job.check_run_id }}.json"
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
@@ -1496,6 +1500,7 @@ jobs:
           VAULT_ROLE: "dh-signer_dh-signer"
           REGISTRY_USER: ${{ steps.secrets.outputs.DECKHOUSE_REGISTRY_STAGE_USER }}
           REGISTRY_PASSWORD: ${{ steps.secrets.outputs.DECKHOUSE_REGISTRY_STAGE_PASSWORD }}
+          REGCTL_CONFIG: "${{ runner.temp }}/regctl-${{ job.check_run_id }}.json"
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
@@ -1795,6 +1800,7 @@ jobs:
           VAULT_ROLE: "dh-signer_dh-signer"
           REGISTRY_USER: ${{ steps.secrets.outputs.DECKHOUSE_REGISTRY_STAGE_USER }}
           REGISTRY_PASSWORD: ${{ steps.secrets.outputs.DECKHOUSE_REGISTRY_STAGE_PASSWORD }}
+          REGCTL_CONFIG: "${{ runner.temp }}/regctl-${{ job.check_run_id }}.json"
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
@@ -3232,6 +3238,7 @@ jobs:
           IMAGE_TO: "${{ steps.secrets.outputs.DECKHOUSE_REGISTRY_STAGE_HOST }}/sys/deckhouse-oss:${{ github.ref_name }}"
           COMPARE_MAX_ATTEMPTS: 10
           COMPARE_RETRY_DELAY: 30
+          REGCTL_CONFIG: "${{ runner.temp }}/regctl-${{ job.check_run_id }}.json"
         run: |
           # Tags from git are used and each tag is checked in the registry.
           # This is done because the regctl ls tag takes a long time to execute

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -464,6 +464,7 @@ jobs:
           VAULT_ROLE: "dh-signer_dh-signer"
           REGISTRY_USER: ${{ steps.secrets.outputs.DECKHOUSE_REGISTRY_STAGE_USER }}
           REGISTRY_PASSWORD: ${{ steps.secrets.outputs.DECKHOUSE_REGISTRY_STAGE_PASSWORD }}
+          REGCTL_CONFIG: "${{ runner.temp }}/regctl-${{ job.check_run_id }}.json"
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
@@ -847,6 +848,7 @@ jobs:
           VAULT_ROLE: "dh-signer_dh-signer"
           REGISTRY_USER: ${{ steps.secrets.outputs.DECKHOUSE_REGISTRY_STAGE_USER }}
           REGISTRY_PASSWORD: ${{ steps.secrets.outputs.DECKHOUSE_REGISTRY_STAGE_PASSWORD }}
+          REGCTL_CONFIG: "${{ runner.temp }}/regctl-${{ job.check_run_id }}.json"
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
@@ -1230,6 +1232,7 @@ jobs:
           VAULT_ROLE: "dh-signer_dh-signer"
           REGISTRY_USER: ${{ steps.secrets.outputs.DECKHOUSE_REGISTRY_STAGE_USER }}
           REGISTRY_PASSWORD: ${{ steps.secrets.outputs.DECKHOUSE_REGISTRY_STAGE_PASSWORD }}
+          REGCTL_CONFIG: "${{ runner.temp }}/regctl-${{ job.check_run_id }}.json"
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
@@ -1601,6 +1604,7 @@ jobs:
           VAULT_ROLE: "dh-signer_dh-signer"
           REGISTRY_USER: ${{ steps.secrets.outputs.DECKHOUSE_REGISTRY_STAGE_USER }}
           REGISTRY_PASSWORD: ${{ steps.secrets.outputs.DECKHOUSE_REGISTRY_STAGE_PASSWORD }}
+          REGCTL_CONFIG: "${{ runner.temp }}/regctl-${{ job.check_run_id }}.json"
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
@@ -1972,6 +1976,7 @@ jobs:
           VAULT_ROLE: "dh-signer_dh-signer"
           REGISTRY_USER: ${{ steps.secrets.outputs.DECKHOUSE_REGISTRY_STAGE_USER }}
           REGISTRY_PASSWORD: ${{ steps.secrets.outputs.DECKHOUSE_REGISTRY_STAGE_PASSWORD }}
+          REGCTL_CONFIG: "${{ runner.temp }}/regctl-${{ job.check_run_id }}.json"
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
@@ -2343,6 +2348,7 @@ jobs:
           VAULT_ROLE: "dh-signer_dh-signer"
           REGISTRY_USER: ${{ steps.secrets.outputs.DECKHOUSE_REGISTRY_STAGE_USER }}
           REGISTRY_PASSWORD: ${{ steps.secrets.outputs.DECKHOUSE_REGISTRY_STAGE_PASSWORD }}
+          REGCTL_CONFIG: "${{ runner.temp }}/regctl-${{ job.check_run_id }}.json"
         run: |
           # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
           REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
@@ -2592,6 +2598,7 @@ jobs:
           IMAGE_TO: "${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}/deckhouse/fe:${{ github.ref_name }}"
           COMPARE_MAX_ATTEMPTS: 10
           COMPARE_RETRY_DELAY: 30
+          REGCTL_CONFIG: "${{ runner.temp }}/regctl-${{ job.check_run_id }}.json"
         run: |
           RELEASE_BRANCH=$(echo $GITHUB_REF_NAME | awk -F '.' '{printf "%s.%s", $1, $2}')
           LAST_TWO_TAGS="$(git ls-remote --tags origin | grep -F tags/${RELEASE_BRANCH} | awk -F '/' '{print $3}' | sort -V | tail -n 2)"

--- a/.github/workflows/compare-external-modules.yml
+++ b/.github/workflows/compare-external-modules.yml
@@ -73,4 +73,5 @@ jobs:
           DECKHOUSE_REGISTRY: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
           EDITIONS_FILE: "./editions.yaml"
           VERSIONS_TO_COMPARE : ${{ inputs.versions_to_compare || 1 }}
+          REGCTL_CONFIG: "${{ runner.temp }}/regctl-${{ job.check_run_id }}.json"
         run: python .github/scripts/python/compare_external_modules.py

--- a/.github/workflows/suspend-alpha.yml
+++ b/.github/workflows/suspend-alpha.yml
@@ -253,6 +253,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           WERF_ENV: CE
           SKIP_PUSH_FOR_SUSPEND: ${{vars.SKIP_PUSH_FOR_SUSPEND}}
+          REGCTL_CONFIG: "${{ runner.temp }}/regctl-${{ job.check_run_id }}.json"
         run: |
           # SRC_NAME is a name of image from werf.yaml.
           # SRC is a source image name.
@@ -324,6 +325,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           WERF_ENV: EE
           SKIP_PUSH_FOR_SUSPEND: ${{vars.SKIP_PUSH_FOR_SUSPEND}}
+          REGCTL_CONFIG: "${{ runner.temp }}/regctl-${{ job.check_run_id }}.json"
         run: |
           # SRC_NAME is a name of image from werf.yaml.
           # SRC is a source image name.
@@ -395,6 +397,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           WERF_ENV: FE
           SKIP_PUSH_FOR_SUSPEND: ${{vars.SKIP_PUSH_FOR_SUSPEND}}
+          REGCTL_CONFIG: "${{ runner.temp }}/regctl-${{ job.check_run_id }}.json"
         run: |
           # SRC_NAME is a name of image from werf.yaml.
           # SRC is a source image name.
@@ -466,6 +469,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           WERF_ENV: BE
           SKIP_PUSH_FOR_SUSPEND: ${{vars.SKIP_PUSH_FOR_SUSPEND}}
+          REGCTL_CONFIG: "${{ runner.temp }}/regctl-${{ job.check_run_id }}.json"
         run: |
           # SRC_NAME is a name of image from werf.yaml.
           # SRC is a source image name.
@@ -537,6 +541,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           WERF_ENV: SE
           SKIP_PUSH_FOR_SUSPEND: ${{vars.SKIP_PUSH_FOR_SUSPEND}}
+          REGCTL_CONFIG: "${{ runner.temp }}/regctl-${{ job.check_run_id }}.json"
         run: |
           # SRC_NAME is a name of image from werf.yaml.
           # SRC is a source image name.
@@ -608,6 +613,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           WERF_ENV: SE-plus
           SKIP_PUSH_FOR_SUSPEND: ${{vars.SKIP_PUSH_FOR_SUSPEND}}
+          REGCTL_CONFIG: "${{ runner.temp }}/regctl-${{ job.check_run_id }}.json"
         run: |
           # SRC_NAME is a name of image from werf.yaml.
           # SRC is a source image name.

--- a/.github/workflows/suspend-beta.yml
+++ b/.github/workflows/suspend-beta.yml
@@ -253,6 +253,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           WERF_ENV: CE
           SKIP_PUSH_FOR_SUSPEND: ${{vars.SKIP_PUSH_FOR_SUSPEND}}
+          REGCTL_CONFIG: "${{ runner.temp }}/regctl-${{ job.check_run_id }}.json"
         run: |
           # SRC_NAME is a name of image from werf.yaml.
           # SRC is a source image name.
@@ -324,6 +325,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           WERF_ENV: EE
           SKIP_PUSH_FOR_SUSPEND: ${{vars.SKIP_PUSH_FOR_SUSPEND}}
+          REGCTL_CONFIG: "${{ runner.temp }}/regctl-${{ job.check_run_id }}.json"
         run: |
           # SRC_NAME is a name of image from werf.yaml.
           # SRC is a source image name.
@@ -395,6 +397,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           WERF_ENV: FE
           SKIP_PUSH_FOR_SUSPEND: ${{vars.SKIP_PUSH_FOR_SUSPEND}}
+          REGCTL_CONFIG: "${{ runner.temp }}/regctl-${{ job.check_run_id }}.json"
         run: |
           # SRC_NAME is a name of image from werf.yaml.
           # SRC is a source image name.
@@ -466,6 +469,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           WERF_ENV: BE
           SKIP_PUSH_FOR_SUSPEND: ${{vars.SKIP_PUSH_FOR_SUSPEND}}
+          REGCTL_CONFIG: "${{ runner.temp }}/regctl-${{ job.check_run_id }}.json"
         run: |
           # SRC_NAME is a name of image from werf.yaml.
           # SRC is a source image name.
@@ -537,6 +541,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           WERF_ENV: SE
           SKIP_PUSH_FOR_SUSPEND: ${{vars.SKIP_PUSH_FOR_SUSPEND}}
+          REGCTL_CONFIG: "${{ runner.temp }}/regctl-${{ job.check_run_id }}.json"
         run: |
           # SRC_NAME is a name of image from werf.yaml.
           # SRC is a source image name.
@@ -608,6 +613,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           WERF_ENV: SE-plus
           SKIP_PUSH_FOR_SUSPEND: ${{vars.SKIP_PUSH_FOR_SUSPEND}}
+          REGCTL_CONFIG: "${{ runner.temp }}/regctl-${{ job.check_run_id }}.json"
         run: |
           # SRC_NAME is a name of image from werf.yaml.
           # SRC is a source image name.

--- a/.github/workflows/suspend-early-access.yml
+++ b/.github/workflows/suspend-early-access.yml
@@ -253,6 +253,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           WERF_ENV: CE
           SKIP_PUSH_FOR_SUSPEND: ${{vars.SKIP_PUSH_FOR_SUSPEND}}
+          REGCTL_CONFIG: "${{ runner.temp }}/regctl-${{ job.check_run_id }}.json"
         run: |
           # SRC_NAME is a name of image from werf.yaml.
           # SRC is a source image name.
@@ -324,6 +325,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           WERF_ENV: EE
           SKIP_PUSH_FOR_SUSPEND: ${{vars.SKIP_PUSH_FOR_SUSPEND}}
+          REGCTL_CONFIG: "${{ runner.temp }}/regctl-${{ job.check_run_id }}.json"
         run: |
           # SRC_NAME is a name of image from werf.yaml.
           # SRC is a source image name.
@@ -395,6 +397,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           WERF_ENV: FE
           SKIP_PUSH_FOR_SUSPEND: ${{vars.SKIP_PUSH_FOR_SUSPEND}}
+          REGCTL_CONFIG: "${{ runner.temp }}/regctl-${{ job.check_run_id }}.json"
         run: |
           # SRC_NAME is a name of image from werf.yaml.
           # SRC is a source image name.
@@ -466,6 +469,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           WERF_ENV: BE
           SKIP_PUSH_FOR_SUSPEND: ${{vars.SKIP_PUSH_FOR_SUSPEND}}
+          REGCTL_CONFIG: "${{ runner.temp }}/regctl-${{ job.check_run_id }}.json"
         run: |
           # SRC_NAME is a name of image from werf.yaml.
           # SRC is a source image name.
@@ -537,6 +541,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           WERF_ENV: SE
           SKIP_PUSH_FOR_SUSPEND: ${{vars.SKIP_PUSH_FOR_SUSPEND}}
+          REGCTL_CONFIG: "${{ runner.temp }}/regctl-${{ job.check_run_id }}.json"
         run: |
           # SRC_NAME is a name of image from werf.yaml.
           # SRC is a source image name.
@@ -608,6 +613,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           WERF_ENV: SE-plus
           SKIP_PUSH_FOR_SUSPEND: ${{vars.SKIP_PUSH_FOR_SUSPEND}}
+          REGCTL_CONFIG: "${{ runner.temp }}/regctl-${{ job.check_run_id }}.json"
         run: |
           # SRC_NAME is a name of image from werf.yaml.
           # SRC is a source image name.

--- a/.github/workflows/suspend-rock-solid.yml
+++ b/.github/workflows/suspend-rock-solid.yml
@@ -253,6 +253,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           WERF_ENV: CE
           SKIP_PUSH_FOR_SUSPEND: ${{vars.SKIP_PUSH_FOR_SUSPEND}}
+          REGCTL_CONFIG: "${{ runner.temp }}/regctl-${{ job.check_run_id }}.json"
         run: |
           # SRC_NAME is a name of image from werf.yaml.
           # SRC is a source image name.
@@ -324,6 +325,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           WERF_ENV: EE
           SKIP_PUSH_FOR_SUSPEND: ${{vars.SKIP_PUSH_FOR_SUSPEND}}
+          REGCTL_CONFIG: "${{ runner.temp }}/regctl-${{ job.check_run_id }}.json"
         run: |
           # SRC_NAME is a name of image from werf.yaml.
           # SRC is a source image name.
@@ -395,6 +397,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           WERF_ENV: FE
           SKIP_PUSH_FOR_SUSPEND: ${{vars.SKIP_PUSH_FOR_SUSPEND}}
+          REGCTL_CONFIG: "${{ runner.temp }}/regctl-${{ job.check_run_id }}.json"
         run: |
           # SRC_NAME is a name of image from werf.yaml.
           # SRC is a source image name.
@@ -466,6 +469,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           WERF_ENV: BE
           SKIP_PUSH_FOR_SUSPEND: ${{vars.SKIP_PUSH_FOR_SUSPEND}}
+          REGCTL_CONFIG: "${{ runner.temp }}/regctl-${{ job.check_run_id }}.json"
         run: |
           # SRC_NAME is a name of image from werf.yaml.
           # SRC is a source image name.
@@ -537,6 +541,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           WERF_ENV: SE
           SKIP_PUSH_FOR_SUSPEND: ${{vars.SKIP_PUSH_FOR_SUSPEND}}
+          REGCTL_CONFIG: "${{ runner.temp }}/regctl-${{ job.check_run_id }}.json"
         run: |
           # SRC_NAME is a name of image from werf.yaml.
           # SRC is a source image name.
@@ -608,6 +613,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           WERF_ENV: SE-plus
           SKIP_PUSH_FOR_SUSPEND: ${{vars.SKIP_PUSH_FOR_SUSPEND}}
+          REGCTL_CONFIG: "${{ runner.temp }}/regctl-${{ job.check_run_id }}.json"
         run: |
           # SRC_NAME is a name of image from werf.yaml.
           # SRC is a source image name.

--- a/.github/workflows/suspend-stable.yml
+++ b/.github/workflows/suspend-stable.yml
@@ -253,6 +253,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           WERF_ENV: CE
           SKIP_PUSH_FOR_SUSPEND: ${{vars.SKIP_PUSH_FOR_SUSPEND}}
+          REGCTL_CONFIG: "${{ runner.temp }}/regctl-${{ job.check_run_id }}.json"
         run: |
           # SRC_NAME is a name of image from werf.yaml.
           # SRC is a source image name.
@@ -324,6 +325,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           WERF_ENV: EE
           SKIP_PUSH_FOR_SUSPEND: ${{vars.SKIP_PUSH_FOR_SUSPEND}}
+          REGCTL_CONFIG: "${{ runner.temp }}/regctl-${{ job.check_run_id }}.json"
         run: |
           # SRC_NAME is a name of image from werf.yaml.
           # SRC is a source image name.
@@ -395,6 +397,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           WERF_ENV: FE
           SKIP_PUSH_FOR_SUSPEND: ${{vars.SKIP_PUSH_FOR_SUSPEND}}
+          REGCTL_CONFIG: "${{ runner.temp }}/regctl-${{ job.check_run_id }}.json"
         run: |
           # SRC_NAME is a name of image from werf.yaml.
           # SRC is a source image name.
@@ -466,6 +469,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           WERF_ENV: BE
           SKIP_PUSH_FOR_SUSPEND: ${{vars.SKIP_PUSH_FOR_SUSPEND}}
+          REGCTL_CONFIG: "${{ runner.temp }}/regctl-${{ job.check_run_id }}.json"
         run: |
           # SRC_NAME is a name of image from werf.yaml.
           # SRC is a source image name.
@@ -537,6 +541,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           WERF_ENV: SE
           SKIP_PUSH_FOR_SUSPEND: ${{vars.SKIP_PUSH_FOR_SUSPEND}}
+          REGCTL_CONFIG: "${{ runner.temp }}/regctl-${{ job.check_run_id }}.json"
         run: |
           # SRC_NAME is a name of image from werf.yaml.
           # SRC is a source image name.
@@ -608,6 +613,7 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           WERF_ENV: SE-plus
           SKIP_PUSH_FOR_SUSPEND: ${{vars.SKIP_PUSH_FOR_SUSPEND}}
+          REGCTL_CONFIG: "${{ runner.temp }}/regctl-${{ job.check_run_id }}.json"
         run: |
           # SRC_NAME is a name of image from werf.yaml.
           # SRC is a source image name.


### PR DESCRIPTION
## Description
Add REGCTL_CONFIG environment variable to prevent other jobs on the same runner from polluting config file.
Backports #22699

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: ci
type: fix
summary: Add REGCTL_CONFIG
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
