### PR TITLE
[base-images] fix cosign CVEs

### DIFF
--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -3943,7 +3943,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:0a677cc92b4db66476061b464f48d0f7a914419adda6d13f83866aceae8eb4dd"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:0a16e548966abb3a695dce005516604e7f307a962ae811d2a94103e70a3067cd"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'
@@ -4058,7 +4058,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run node-controller tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:0a677cc92b4db66476061b464f48d0f7a914419adda6d13f83866aceae8eb4dd"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:0a16e548966abb3a695dce005516604e7f307a962ae811d2a94103e70a3067cd"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/.github/workflows/build-and-test_main.yml
+++ b/.github/workflows/build-and-test_main.yml
@@ -1282,7 +1282,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:0a677cc92b4db66476061b464f48d0f7a914419adda6d13f83866aceae8eb4dd"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:0a16e548966abb3a695dce005516604e7f307a962ae811d2a94103e70a3067cd"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -3570,7 +3570,7 @@ jobs:
       # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:0a677cc92b4db66476061b464f48d0f7a914419adda6d13f83866aceae8eb4dd"
+          TESTS_IMAGE_NAME: "registry.deckhouse.io/container-factory@sha256:0a16e548966abb3a695dce005516604e7f307a962ae811d2a94103e70a3067cd"
         run: |
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
           echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'

--- a/candi/alt_base_images.yml
+++ b/candi/alt_base_images.yml
@@ -1,8 +1,8 @@
-# version=v2.1.10
+# version=v2.1.11
 REGISTRY_PATH: registry.deckhouse.io/container-factory
-base/distroless-fin: "sha256:d16c3906c57753e2022cd1301c651527835c8b95029a4733d60e8e8e02af9c4e" # from: scratch
-builder/distroless: "sha256:f1e287571b1470f9114ad72cf4f39239a9794d87deba2320702f45770242d4fa" # from: scratch
-builder/golang-1.25: "sha256:2348e7e4e5e127cb400aa0cdae9f7b92780b3ca39f044076eba8801c020a75c3" # from: builder/distroless
-builder/golang-1.26: "sha256:0a677cc92b4db66476061b464f48d0f7a914419adda6d13f83866aceae8eb4dd" # from: builder/distroless
-builder/golang-1.27: "sha256:2ad9878a6f29b2dbfee7b209469647747fa9b5ef3dc33c1572fc5fa1d90990bb" # from: builder/distroless
-builder/golang: "sha256:2ad9878a6f29b2dbfee7b209469647747fa9b5ef3dc33c1572fc5fa1d90990bb" # from: builder/distroless
+base/distroless-fin: "sha256:1b6a967cb923accc9c8e3647469455aa4ba060edd433e9ef980a4d489447f938" # from: scratch
+builder/distroless: "sha256:da7c9c269f30c73cb2ebb3be1f9e0f17fe5f8faa948f29a93be95ae10bf6540d" # from: scratch
+builder/golang-1.25: "sha256:307a70a9845dc20e151310a86dd37bbba31834b8719e3d07c04bda67d0d7d5cd" # from: builder/distroless
+builder/golang-1.26: "sha256:0a16e548966abb3a695dce005516604e7f307a962ae811d2a94103e70a3067cd" # from: builder/distroless
+builder/golang-1.27: "sha256:487b9b76c6a6141daaa38c93013c167a772da028696fdeb68d800e5ebdd7ee5e" # from: builder/distroless
+builder/golang: "sha256:487b9b76c6a6141daaa38c93013c167a772da028696fdeb68d800e5ebdd7ee5e" # from: builder/distroless

--- a/ee/cse/modules/007-registrypackages/images/cosign/scripts/install
+++ b/ee/cse/modules/007-registrypackages/images/cosign/scripts/install
@@ -4,4 +4,4 @@
 
 set -Eeo pipefail
 mkdir -p /opt/deckhouse/bin
-cp -f cosign /opt/deckhouse/bin
+cp -f /usr/bin/cosign /opt/deckhouse/bin

--- a/ee/cse/modules/007-registrypackages/images/cosign/scripts/install
+++ b/ee/cse/modules/007-registrypackages/images/cosign/scripts/install
@@ -4,4 +4,4 @@
 
 set -Eeo pipefail
 mkdir -p /opt/deckhouse/bin
-cp -f /usr/bin/cosign /opt/deckhouse/bin
+cp -f cosign /opt/deckhouse/bin

--- a/ee/cse/modules/007-registrypackages/images/cosign/werf.inc.yaml
+++ b/ee/cse/modules/007-registrypackages/images/cosign/werf.inc.yaml
@@ -23,6 +23,9 @@ imageSpec:
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 final: false
 from: {{ index $.Images "builder/distroless" }}
+git:
+- add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/scripts
+  to: /
 shell:
   install:
-   - pm install cosign@2.6.5 -d /cosign
+   - pm install cosign@{{ $version }}

--- a/ee/cse/modules/007-registrypackages/images/cosign/werf.inc.yaml
+++ b/ee/cse/modules/007-registrypackages/images/cosign/werf.inc.yaml
@@ -7,9 +7,12 @@ import:
   add: /
   to: /
   includePaths:
-  - cosign
   - install
   - uninstall
+  before: setup
+- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+  add: /usr/bin/cosign
+  to: /cosign
   before: setup
 imageSpec:
   config:

--- a/ee/cse/modules/007-registrypackages/images/cosign/werf.inc.yaml
+++ b/ee/cse/modules/007-registrypackages/images/cosign/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $version := "v2.4.3" }}
+{{- $version := "v2.6.5" }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
 from: {{ index $.Images "builder/scratch" }}
@@ -23,15 +23,6 @@ imageSpec:
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 final: false
 from: {{ index $.Images "builder/distroless" }}
-git:
-- add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/scripts
-  to: /
-import:
-- image: {{ index $.Images "tools/cosign" }} 
-  add: /usr/bin/cosign
-  to: /cosign
-  before: install
-# usage after update to cosign 3
-#shell:
-#  install:
-#   - pm install cosign
+shell:
+  install:
+   - pm install cosign@2.6.5 -d /cosign


### PR DESCRIPTION
Signed-off-by: Artem Fedorov <artem.fedorov@flant.com>

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Bump cosign version to 2.6.5/3.1.3
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
CVE fixes

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: chore
summary: bump cosign to 3.1.3/2.6.5
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
