### PR TITLE
[deckhouse] gate the package status summary on the workload health report

### DIFF
--- a/deckhouse-controller/internal/packages/status/service.go
+++ b/deckhouse-controller/internal/packages/status/service.go
@@ -493,11 +493,15 @@ func (s *Status) IsConditionTrue(condType ConditionType) bool {
 	return false
 }
 
-// NewStatus creates a new status or resets conditions. If a health event
-// was buffered by UpdateHealth before this name was registered, it is
+// NewStatus creates a new status or resets conditions. ConditionScaled is carried
+// over instead: the health monitor owns it and reports only on transitions, so a
+// reset would leave the workload unobserved until it next changes state. If a
+// health event was buffered by UpdateHealth before this name was registered, it is
 // applied here and the buffer entry is dropped.
 func (s *Service) NewStatus(name string) {
 	s.mu.Lock()
+
+	scaled := s.observedScaledLocked(name)
 
 	s.statuses[name] = &Status{
 		Conditions: []Condition{
@@ -506,7 +510,7 @@ func (s *Service) NewStatus(name string) {
 			{Type: ConditionLoaded, Status: metav1.ConditionUnknown},
 			{Type: ConditionHooksProcessed, Status: metav1.ConditionUnknown},
 			{Type: ConditionManifestsApplied, Status: metav1.ConditionUnknown},
-			{Type: ConditionScaled, Status: metav1.ConditionUnknown},
+			scaled,
 			{Type: ConditionConfigured, Status: metav1.ConditionUnknown},
 			{Type: ConditionPending, Status: metav1.ConditionUnknown},
 			{Type: ConditionCustomResourcesApplied, Status: metav1.ConditionUnknown},
@@ -527,4 +531,28 @@ func (s *Service) NewStatus(name string) {
 	if notify {
 		s.queueFor(name).Add(name)
 	}
+}
+
+// observedScaledLocked returns the ConditionScaled to seed a fresh status with:
+// the value the health monitor last reported, or an Unknown placeholder
+// when it has not reported for this package. The caller must hold s.mu.
+func (s *Service) observedScaledLocked(name string) Condition {
+	if status, ok := s.statuses[name]; ok {
+		if cond, found := status.condition(ConditionScaled); found {
+			return cond
+		}
+	}
+
+	return Condition{Type: ConditionScaled, Status: metav1.ConditionUnknown}
+}
+
+// condition returns the condition of the given type.
+func (s *Status) condition(condType ConditionType) (Condition, bool) {
+	for _, cond := range s.Conditions {
+		if cond.Type == condType {
+			return cond, true
+		}
+	}
+
+	return Condition{}, false
 }

--- a/deckhouse-controller/pkg/controller/packages/application/status/summary.go
+++ b/deckhouse-controller/pkg/controller/packages/application/status/summary.go
@@ -53,6 +53,11 @@ type advice struct {
 	tip     string
 }
 
+// reasonHealthUnknown is a summary-local table key, not a reason the health monitor
+// writes: it stands for an intScaled the monitor has not confirmed, which carries no
+// reason of its own.
+const reasonHealthUnknown = "HealthUnknown"
+
 // summaryTable is the whole Summary policy in one place: phase → canonical
 // reason → what the user sees. It mirrors the scenarios enumerated in
 // summary_test.go one-to-one. The phase and the canonical reason both come
@@ -142,6 +147,25 @@ var summaryTable = map[phase]map[string]advice{
 			stateFailed,
 			"Update failed: Helm could not apply manifests for the new version; previous version is no longer serving",
 			"Resources in the cluster are inconsistent. Check helm history and events in the namespace. Resolve resource conflicts. If needed, roll back manually via helm rollback.",
+		},
+
+		// Workload gate. The manifests are applied, so the update is still in
+		// flight rather than failed — except a degraded workload, which is the
+		// health monitor's terminal verdict on the new version.
+		"Reconciling": {
+			stateUpdating,
+			"Update applied: the new version's workload is rolling out",
+			"Wait for the rollout to finish. If it stalls, check pod status and events.",
+		},
+		"Degraded": {
+			stateDegraded,
+			"Update applied but the workload health monitor reports degraded",
+			"Check pod status and logs to identify the root cause. Roll back the application version if the new one cannot start.",
+		},
+		reasonHealthUnknown: {
+			stateUpdating,
+			"Update applied: waiting for a workload the health monitor can confirm",
+			"Either no report has arrived yet, or the chart ships no Deployment or StatefulSet, the only kinds the health monitor watches.",
 		},
 	},
 
@@ -247,23 +271,21 @@ func summarize(state condmap.State) (string, string, string) {
 		return adviseFor(phaseInstall, reasonOf(state, blocker))
 
 	case phaseUpdate:
-		blocker, ok := pipelineBlocker(state, updatePipeline)
-		if !ok {
-			// "No blocker" is not the same as "update finished". firstFalse skips a
-			// transient ManifestsApplied=False/ApplyingManifests exactly as the
-			// mapper does, so the update pipeline reads clear during every re-apply
-			// window. But mapUpdateInstalled only flips UpdateInstalled (and mapReady
-			// only flips Ready) to True once ManifestsApplied is actually True; until
-			// then it returns empty and leaves the previous — possibly failed —
-			// conditions sticky. Mirror that success gate here, otherwise a mid-apply
-			// retry over a failed update would report Ready while the conditions a
-			// client also reads still say ManifestsApplyFailed.
-			if state.IntEqual(intManifestsApplied, metav1.ConditionTrue) {
-				return summaryReady.state, summaryReady.message, summaryReady.tip // update done
-			}
+		if blocker, ok := pipelineBlocker(state, updatePipeline); ok {
+			return adviseFor(phaseUpdate, reasonOf(state, blocker))
+		}
+		// "No blocker" is not the same as "update finished". firstFalse skips a
+		// transient ManifestsApplied=False/ApplyingManifests exactly as the mapper
+		// does, so the update pipeline reads clear during every re-apply window,
+		// while mapUpdateInstalled only flips UpdateInstalled to True once
+		// ManifestsApplied is actually True.
+		if !state.IntEqual(intManifestsApplied, metav1.ConditionTrue) {
 			return summaryUpdating.state, summaryUpdating.message, summaryUpdating.tip
 		}
-		return adviseFor(phaseUpdate, reasonOf(state, blocker))
+		if !state.IntEqual(intScaled, metav1.ConditionTrue) {
+			return adviseFor(phaseUpdate, workloadReason(state))
+		}
+		return summaryReady.state, summaryReady.message, summaryReady.tip
 
 	case phaseReconcile:
 		blocker, ok := firstFalse(state, reconcileSummaryChain)
@@ -293,6 +315,18 @@ var reconcileSummaryChain = []string{
 	intManifestsApplied,
 	intConfigured,
 	intScaled,
+}
+
+// workloadReason returns the health monitor's verdict on the package workload.
+// An absent or reasonless intScaled means the monitor has not reported at all,
+// which is not the same as reporting that there is nothing to observe.
+func workloadReason(state condmap.State) string {
+	reason, _ := state.GetIntReason(intScaled)
+	if reason == "" {
+		return reasonHealthUnknown
+	}
+
+	return reasonOf(state, intScaled)
 }
 
 // reasonOf returns the canonical external reason for a failing internal

--- a/deckhouse-controller/pkg/controller/packages/application/status/summary.go
+++ b/deckhouse-controller/pkg/controller/packages/application/status/summary.go
@@ -271,21 +271,28 @@ func summarize(state condmap.State) (string, string, string) {
 		return adviseFor(phaseInstall, reasonOf(state, blocker))
 
 	case phaseUpdate:
-		if blocker, ok := pipelineBlocker(state, updatePipeline); ok {
-			return adviseFor(phaseUpdate, reasonOf(state, blocker))
+		blocker, ok := pipelineBlocker(state, updatePipeline)
+		if !ok {
+			// "No blocker" is not the same as "update finished". firstFalse skips a
+			// transient ManifestsApplied=False/ApplyingManifests exactly as the
+			// mapper does, so the update pipeline reads clear during every re-apply
+			// window. But mapUpdateInstalled only flips UpdateInstalled (and mapReady
+			// only flips Ready) to True once ManifestsApplied is actually True; until
+			// then it returns empty and leaves the previous — possibly failed —
+			// conditions sticky. Mirror that success gate here, otherwise a mid-apply
+			// retry over a failed update would report Ready while the conditions a
+			// client also reads still say ManifestsApplyFailed.
+			if !state.IntEqual(intManifestsApplied, metav1.ConditionTrue) {
+				return summaryUpdating.state, summaryUpdating.message, summaryUpdating.tip
+			}
+			// The manifests landed, but only a positive health report makes the new
+			// version ready; anything else is still an update in flight.
+			if !state.IntEqual(intScaled, metav1.ConditionTrue) {
+				return adviseFor(phaseUpdate, workloadReason(state))
+			}
+			return summaryReady.state, summaryReady.message, summaryReady.tip
 		}
-		// "No blocker" is not the same as "update finished". firstFalse skips a
-		// transient ManifestsApplied=False/ApplyingManifests exactly as the mapper
-		// does, so the update pipeline reads clear during every re-apply window,
-		// while mapUpdateInstalled only flips UpdateInstalled to True once
-		// ManifestsApplied is actually True.
-		if !state.IntEqual(intManifestsApplied, metav1.ConditionTrue) {
-			return summaryUpdating.state, summaryUpdating.message, summaryUpdating.tip
-		}
-		if !state.IntEqual(intScaled, metav1.ConditionTrue) {
-			return adviseFor(phaseUpdate, workloadReason(state))
-		}
-		return summaryReady.state, summaryReady.message, summaryReady.tip
+		return adviseFor(phaseUpdate, reasonOf(state, blocker))
 
 	case phaseReconcile:
 		blocker, ok := firstFalse(state, reconcileSummaryChain)

--- a/deckhouse-controller/pkg/controller/packages/application/status/summary_test.go
+++ b/deckhouse-controller/pkg/controller/packages/application/status/summary_test.go
@@ -439,6 +439,23 @@ func TestSummarize_EdgeCases(t *testing.T) {
 		assert.Empty(t, tip)
 	})
 
+	t.Run("update with manifests applied is not ready until the workload is up", func(t *testing.T) {
+		// Regression: the update branch gated on ManifestsApplied alone, so the
+		// summary reported Ready while the health monitor was reporting a rollout
+		// on the very same object.
+		state, message, _ := summaryFor(updatingApp(intCond(intScaled, metav1.ConditionFalse, "Reconciling"))...)
+		assert.Equal(t, stateUpdating, state)
+		assert.Equal(t, "Update applied: the new version's workload is rolling out", message)
+	})
+
+	t.Run("update with manifests applied and no health report is not ready", func(t *testing.T) {
+		// What a version change used to produce: the status reset dropped Scaled
+		// and the edge-triggered monitor had nothing new to report.
+		state, message, _ := summaryFor(updatingApp(intCond(intScaled, metav1.ConditionUnknown, ""))...)
+		assert.Equal(t, stateUpdating, state)
+		assert.Equal(t, "Update applied: waiting for a workload the health monitor can confirm", message)
+	})
+
 	t.Run("manifests applying on a healthy app is ready, not degraded", func(t *testing.T) {
 		// ManifestsApplied=False/ApplyingManifests is a transient progress
 		// marker, not a failure: firstFalse skips it so a healthy app does not


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

During an update `.status.summary` reported `Ready` while the workload was still rolling out: the
update branch gated on `ManifestsApplied` alone. Readiness there now requires `Scaled=True`.

The gate needs a health report to exist. `ConditionScaled` is owned by the health monitor, which
reports only on transitions with no informer resync, and `NewStatus` reseeded it to `Unknown` on
every version change, leaving the workload unobserved until it next changed state. It is now carried
over, which is the other half of #20169.

Unchanged: the install and reconcile phases, `isInstallComplete`, the mappers, the condition
vocabulary. The same defect in the reconcile phase and in `module/status` is left for separate
changes.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

The CRD documents the summary as the single source of truth for the UI. Reporting `Ready` mid-rollout
means neither users nor the UI can tell a running application from one whose pods are not up yet.

### Manual testing

```
k -n default get application a-k-pkg -o jsonpath='{.status.summary.state}|{.status.summary.message}|Scaled={range .status.conditions[?(@.type=="Scaled")]}{.status}/{.reason}{end}|v={.status.currentVersion.version}'
k -n default get deploy d8a-a-k-pkg-server -o jsonpath='{.spec.replicas}/{.status.updatedReplicas}/{.status.availableReplicas}'
```

Version bump that does not touch the workload (`v0.0.2` → `v0.0.5`). Before this change the same bump
left `Scaled=Unknown` for the whole three minutes of sampling while the summary read `Ready`:

```
18:23:58 Ready||Scaled=True/Scaled|v=0.0.2 | want/upd/avail=1/1/1
18:24:01 Updating|Update in progress: the new version is being applied; the previous version is still serving|Scaled=True/Scaled|v=0.0.2 | want/upd/avail=1/1/1
18:24:04 Ready||Scaled=True/Scaled|v=0.0.5 | want/upd/avail=1/1/1
```

Version change together with a workload change. `Scaled` stays `True` throughout, so the new gate
never has to block here: applications install with nelm's final tracking on, which holds
`ManifestsApplied` until the workload is ready. This shows the path is not regressed, not that the
gate fires:

```
18:26:37 Updating|Update in progress: the new version is being applied; the previous version is still serving|Scaled=True/Scaled|v=0.0.5 | want/upd/avail=3/3/3
18:26:39 Updating|Update in progress: the new version is being applied; the previous version is still serving|Scaled=True/Scaled|v=0.0.5 | want/upd/avail=1/1/1
18:26:40 Ready||Scaled=True/Scaled|v=0.0.2 | want/upd/avail=1/1/1
```

Controller restart, watched for every transition so the seeded `Unknown` window cannot be missed. The
summary does not flap:

```
k -n default get application a-k-pkg -w -o jsonpath='{.status.summary.state}|Scaled={range .status.conditions[?(@.type=="Scaled")]}{.status}/{.reason}{end}{"\n"}'

18:54:59 Ready|Scaled=True/Scaled          # restart issued at 18:55:02, no further transitions
```

Not shown in the cluster: the gate actually blocking. On the application path `ManifestsApplied=True`
already implies a ready workload, and the phase where `Scaled` does go `False` mid-rollout is
reconcile, which this change leaves alone. Both blocking cases are covered by unit tests. No
controller errors during the run.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: Gate the package status summary on the workload health report
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->















