### PR TITLE
[run ci] [admission-policy-engine] Trigger image rebuild for CVE scan baseline

### DIFF
--- a/modules/015-admission-policy-engine/images/gatekeeper/patches/README.md
+++ b/modules/015-admission-policy-engine/images/gatekeeper/patches/README.md
@@ -1,5 +1,7 @@
 ## Patches
 
+Baseline change to trigger admission-policy-engine image rebuild for CVE scanning on release-1.73.
+
 ### 001-cve.patch
 
 Fixes:


### PR DESCRIPTION
## Summary

- Add a no-op update to `gatekeeper/patches/README.md` to trigger rebuild of `admission-policy-engine` images on `release-1.73`.
- This PR is a baseline for subsequent CVE scanning of module images in CI/stage registry.

## Test plan

- [ ] Wait for CI build of `admission-policy-engine` images (gatekeeper, constraint-exporter, etc.)
- [ ] Scan built images with Trivy after build completes
- [ ] Follow up with CVE fix PRs based on scan results

