### PR TITLE
[registrypackages]  Fix dm-verity devices that could never be closed (containerd 2.2.7, CSE)

### DIFF
--- a/modules/007-registrypackages/images/containerd/patches/containerd/2.2.7/000-gomod.patch
+++ b/modules/007-registrypackages/images/containerd/patches/containerd/2.2.7/000-gomod.patch
@@ -1,5 +1,5 @@
 diff --git a/go.mod b/go.mod
-index 8b0c19c..a8309d5 100644
+index 8b0c19c59..a8309d52f 100644
 --- a/go.mod
 +++ b/go.mod
 @@ -1,6 +1,6 @@
@@ -178,7 +178,7 @@ index 8b0c19c..a8309d5 100644
  	sigs.k8s.io/randfill v1.0.0 // indirect
  	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
 diff --git a/go.sum b/go.sum
-index 5b24fca..212dada 100644
+index 5b24fca81..212dadafb 100644
 --- a/go.sum
 +++ b/go.sum
 @@ -14,16 +14,22 @@ github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d h1:G0m3OIz70MZUW

--- a/modules/007-registrypackages/images/containerd/werf.inc.yaml
+++ b/modules/007-registrypackages/images/containerd/werf.inc.yaml
@@ -7,7 +7,7 @@
 {{- end }}
 {{- $runc_versions := list $runc_version }}
 {{- $containerd2runc := dict $containerd_v1_version $runc_version $containerd_v2_version $runc_version }}
-{{- $containerd_integrity_patches_version := .IntegrityPatchesVersion | default "1" }} # may be redefine in CSE
+{{- $containerd_integrity_patches_version := .IntegrityPatchesVersion | default "2" }} # may be redefine in CSE
 
 # calculate additional build options for containerd
 # skip for v1 and not CSE. Now we calculate namespaces for integrity check


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Bumped the containerd integrity patches version from `1` to `2` (`werf.inc.yaml`), CSE only.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
The new patch version fixes two bugs:

- A loop device was stacked on top of every dm-verity device, holding it open, so `veritysetup close` always failed with `Resource busy`.
- Snapshot GC propagated that failure as an error, which rolled back its whole bolt transaction, so stale devices kept accumulating.


## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: registrypackages
type: fix
summary: Fix dm-verity devices that could never be closed for containerd 2.2.7 (CSE only).
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
