### PR TITLE
[user-authz] Fix permission-browser BulkSAR timeout for Editor

### DIFF
--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/README.md
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/README.md
@@ -145,13 +145,12 @@ The multi-tenancy engine applies the same restrictions as the `user-authz-webhoo
 
 ### Prerequisites
 
-- Go 1.23+
+- Go 1.25+ (see the `go` directive in `go.mod`)
 - Kubernetes cluster access (for in-cluster testing)
 
 ### Building
 
 ```bash
-cd src
 make build-local
 ```
 
@@ -179,6 +178,9 @@ make test
 
 ## Configuration
 
+Only `--user-authz-config` is defined by this server; the rest come from the
+generic apiserver's recommended options, so the list below is not exhaustive.
+
 | Flag | Description | Default |
 |------|-------------|---------|
 | `--secure-port` | HTTPS port | 443 |
@@ -196,21 +198,15 @@ make test
 ### AccessibleNamespace
 - **Watch NOT supported**: The `resourceVersion` is always empty (`""`). Clients must poll.
 - **Computed resource**: The list is calculated at request time, not stored. There's no etcd persistence.
-- **Best-effort discovery**: If the API discovery cannot determine whether a resource is namespaced, it assumes namespaced for safety.
+- **Best-effort discovery**: If discovery cannot say whether a resource is namespaced, it is assumed cluster-scoped. Assuming namespaced would make the resolver treat the caller as having namespaced access and list every namespace, so the unknown case is resolved the other way.
 
 ### General
-- The server caches RBAC rules and namespace information; changes may take up to 30 minutes to propagate
-- Multi-tenancy config is reloaded every second from the mounted ConfigMap
-
-## Metrics
-
-| Metric | Description |
-|--------|-------------|
-| `bulksar_requests_total` | Total number of BulkSubjectAccessReview requests |
-| `bulksar_checks_total` | Total number of individual permission checks |
-| `bulksar_request_duration_seconds` | Histogram of request durations |
+- RBAC rules and namespace information are served from watch-driven informers, so changes land within seconds. The 30-minute figure in the code is the informer resync interval — a periodic re-list that guards against a missed watch event, not the propagation delay.
+- The multi-tenancy config file is re-read every second. The file itself is a projected ConfigMap, and kubelet refreshes it on its own sync period, so a `ClusterAuthorizationRule` change takes up to about a minute to reach the running pod.
 
 ## Health Endpoints
 
-- `/readyz`: Returns 200 when informer caches are synced
+- `/readyz`: Returns 200 once the resource scope cache has been populated at least once, in addition to the generic apiserver's own readiness checks
 - `/livez`: Returns 200 when server is alive
+
+This component registers no custom Prometheus metrics. Request rates and latencies are available from the generic apiserver metrics it inherits, for example `apiserver_request_duration_seconds{resource="bulksubjectaccessreviews"}`.

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/README.md
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/README.md
@@ -45,7 +45,7 @@ A namespace is considered "accessible" if BOTH conditions are met:
 
 - **Watch NOT supported**: Clients must poll for updates. The `resourceVersion` is always empty.
 - **Computed at request time**: The list is calculated based on current RBAC and multi-tenancy rules. Changes propagate after informer cache sync (up to 30 minutes).
-- **Best-effort resource scope detection**: If a resource's scope can't be determined via discovery (transient errors / unavailable APIService), we treat it as namespaced.
+- **Best-effort resource scope detection**: If a resource's scope can't be determined via discovery, we treat it as namespaced. The scope cache is refreshed from discovery every 5 minutes; when discovery fails for some API groups (an unavailable APIService), the entries of those groups are kept from the previous refresh, so a transient outage does not turn a group's cluster-scoped resources into unknown ones.
 
 #### Security
 

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/apiserver/apiserver.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/apiserver/apiserver.go
@@ -154,7 +154,7 @@ func initAuthorizers(init *initResult, configPath string, scopeCache *resolver.R
 			configPath,
 			init.informerFactory.Core().V1().Namespaces().Lister(),
 			init.informerFactory.Core().V1().Namespaces().Informer().HasSynced,
-			init.clientset.Discovery(),
+			scopeCache,
 		)
 		if err != nil {
 			klog.Warningf("Failed to initialize multi-tenancy engine: %v. Multi-tenancy restrictions will not be applied.", err)

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/apiserver/apiserver.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/apiserver/apiserver.go
@@ -146,6 +146,13 @@ func initAuthorizers(init *initResult, configPath string, scopeCache *resolver.R
 		configPath = "/etc/user-authz-webhook/config.json"
 	}
 
+	// Same guard for the engine: a nil *ResourceScopeCache must arrive as a nil
+	// interface, not as a non-nil interface holding a nil pointer.
+	var resourceScope multitenancy.ResourceScope
+	if scopeCache != nil {
+		resourceScope = scopeCache
+	}
+
 	// Create multi-tenancy engine
 	var mtEngine *multitenancy.Engine
 	if init.clientset != nil {
@@ -154,7 +161,7 @@ func initAuthorizers(init *initResult, configPath string, scopeCache *resolver.R
 			configPath,
 			init.informerFactory.Core().V1().Namespaces().Lister(),
 			init.informerFactory.Core().V1().Namespaces().Informer().HasSynced,
-			scopeCache,
+			resourceScope,
 		)
 		if err != nil {
 			klog.Warningf("Failed to initialize multi-tenancy engine: %v. Multi-tenancy restrictions will not be applied.", err)

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/composite/composite.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/composite/composite.go
@@ -8,9 +8,14 @@ package composite
 import (
 	"context"
 
+	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/klog/v2"
 )
+
+type subjectBinder interface {
+	BindSubject(context.Context, user.Info) context.Context
+}
 
 // CompositeAuthorizer combines multi-tenancy and RBAC authorization
 // Order of operations:
@@ -27,6 +32,18 @@ func NewCompositeAuthorizer(mt, rbac authorizer.Authorizer) *CompositeAuthorizer
 		multitenancy: mt,
 		rbac:         rbac,
 	}
+}
+
+// BindSubject forwards a per-request RBAC snapshot to whichever inner
+// authorizer implements it (RBAC, and MT if it ever needs one).
+func (c *CompositeAuthorizer) BindSubject(ctx context.Context, u user.Info) context.Context {
+	if b, ok := c.rbac.(subjectBinder); ok {
+		ctx = b.BindSubject(ctx, u)
+	}
+	if b, ok := c.multitenancy.(subjectBinder); ok {
+		ctx = b.BindSubject(ctx, u)
+	}
+	return ctx
 }
 
 // Authorize implements authorizer.Authorizer

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/composite/composite_test.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/composite/composite_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 )
 
@@ -92,6 +93,28 @@ func TestCompositeAuthorizer_NilMultitenancy(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, authorizer.DecisionAllow, decision)
 	assert.Equal(t, "RBAC allowed", reason)
+}
+
+type bindSpy struct {
+	mockAuthorizer
+	bound user.Info
+}
+
+func (s *bindSpy) BindSubject(ctx context.Context, u user.Info) context.Context {
+	s.bound = u
+	return ctx
+}
+
+func TestCompositeAuthorizer_BindSubjectForwards(t *testing.T) {
+	mt := &bindSpy{}
+	rbac := &bindSpy{}
+	c := NewCompositeAuthorizer(mt, rbac)
+	u := &user.DefaultInfo{Name: "editor@example.io"}
+
+	c.BindSubject(context.Background(), u)
+
+	assert.Equal(t, u, mt.bound)
+	assert.Equal(t, u, rbac.bound)
 }
 
 func TestCompositeAuthorizer_BothNoOpinion(t *testing.T) {

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/multitenancy/coverage_test.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/multitenancy/coverage_test.go
@@ -90,7 +90,7 @@ func TestEngine_InitialConfigLoad(t *testing.T) {
 		configPath,
 		informerFactory.Core().V1().Namespaces().Lister(),
 		func() bool { return true },
-		fakeClient.Discovery(),
+		nil,
 	)
 	require.NoError(t, err)
 
@@ -167,7 +167,7 @@ func TestEngine_SystemNamespaces(t *testing.T) {
 		configPath,
 		informerFactory.Core().V1().Namespaces().Lister(),
 		func() bool { return true },
-		fakeClient.Discovery(),
+		nil,
 	)
 	require.NoError(t, err)
 
@@ -258,7 +258,7 @@ func TestEngine_GroupBasedRules(t *testing.T) {
 		configPath,
 		informerFactory.Core().V1().Namespaces().Lister(),
 		func() bool { return true },
-		fakeClient.Discovery(),
+		nil,
 	)
 	require.NoError(t, err)
 
@@ -364,7 +364,7 @@ func TestEngine_ServiceAccountRules(t *testing.T) {
 		configPath,
 		informerFactory.Core().V1().Namespaces().Lister(),
 		func() bool { return true },
-		fakeClient.Discovery(),
+		nil,
 	)
 	require.NoError(t, err)
 
@@ -472,7 +472,7 @@ func TestEngine_MatchAnySelector(t *testing.T) {
 		configPath,
 		informerFactory.Core().V1().Namespaces().Lister(),
 		func() bool { return true },
-		fakeClient.Discovery(),
+		nil,
 	)
 	require.NoError(t, err)
 
@@ -503,7 +503,7 @@ func TestEngine_NonResourceRequestSkipped(t *testing.T) {
 		configPath,
 		informerFactory.Core().V1().Namespaces().Lister(),
 		func() bool { return true },
-		fakeClient.Discovery(),
+		nil,
 	)
 	require.NoError(t, err)
 

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/multitenancy/coverage_test.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/multitenancy/coverage_test.go
@@ -90,7 +90,7 @@ func TestEngine_InitialConfigLoad(t *testing.T) {
 		configPath,
 		informerFactory.Core().V1().Namespaces().Lister(),
 		func() bool { return true },
-		nil,
+		coreResourceScope(),
 	)
 	require.NoError(t, err)
 
@@ -167,7 +167,7 @@ func TestEngine_SystemNamespaces(t *testing.T) {
 		configPath,
 		informerFactory.Core().V1().Namespaces().Lister(),
 		func() bool { return true },
-		nil,
+		coreResourceScope(),
 	)
 	require.NoError(t, err)
 
@@ -258,7 +258,7 @@ func TestEngine_GroupBasedRules(t *testing.T) {
 		configPath,
 		informerFactory.Core().V1().Namespaces().Lister(),
 		func() bool { return true },
-		nil,
+		coreResourceScope(),
 	)
 	require.NoError(t, err)
 
@@ -364,7 +364,7 @@ func TestEngine_ServiceAccountRules(t *testing.T) {
 		configPath,
 		informerFactory.Core().V1().Namespaces().Lister(),
 		func() bool { return true },
-		nil,
+		coreResourceScope(),
 	)
 	require.NoError(t, err)
 
@@ -472,7 +472,7 @@ func TestEngine_MatchAnySelector(t *testing.T) {
 		configPath,
 		informerFactory.Core().V1().Namespaces().Lister(),
 		func() bool { return true },
-		nil,
+		coreResourceScope(),
 	)
 	require.NoError(t, err)
 
@@ -503,7 +503,7 @@ func TestEngine_NonResourceRequestSkipped(t *testing.T) {
 		configPath,
 		informerFactory.Core().V1().Namespaces().Lister(),
 		func() bool { return true },
-		nil,
+		coreResourceScope(),
 	)
 	require.NoError(t, err)
 

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/multitenancy/engine.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/multitenancy/engine.go
@@ -66,7 +66,7 @@ type IndependentRBACChecker interface {
 // Implemented by resolver.ResourceScopeCache. This package must not import
 // resolver (resolver already imports multitenancy).
 type ResourceScope interface {
-	Scope(group, resource string) (namespaced, known bool)
+	Scope(group, resource string) (bool, bool)
 }
 
 // Engine implements the multi-tenancy authorization logic from user-authz webhook

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/multitenancy/engine.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/multitenancy/engine.go
@@ -265,11 +265,16 @@ func (e *Engine) combineDirEntries(entries []DirectoryEntry) DirectoryEntry {
 			combined.AllowAccessToSystemNamespaces = entry.AllowAccessToSystemNamespaces
 		}
 
-		if len(entry.NamespaceSelectors) > 0 {
-			combined.NamespaceSelectors = append(combined.NamespaceSelectors, entry.NamespaceSelectors...)
-		}
-		if len(entry.compiledSelectors) > 0 {
-			combined.compiledSelectors = append(combined.compiledSelectors, entry.compiledSelectors...)
+		// Both slices grow together so compiledSelectors stays index-aligned
+		// with NamespaceSelectors even when some entries carry no compiled
+		// form at all.
+		for i, namespaceSelector := range entry.NamespaceSelectors {
+			var compiled labels.Selector
+			if i < len(entry.compiledSelectors) {
+				compiled = entry.compiledSelectors[i]
+			}
+			combined.NamespaceSelectors = append(combined.NamespaceSelectors, namespaceSelector)
+			combined.compiledSelectors = append(combined.compiledSelectors, compiled)
 		}
 		if len(entry.LimitNamespaces) > 0 {
 			combined.LimitNamespaces = append(combined.LimitNamespaces, entry.LimitNamespaces...)
@@ -311,8 +316,27 @@ func (e *Engine) affectedDirs(userName string, groups []string) []DirectoryEntry
 	return dirEntriesAffected
 }
 
+// compileNamespaceSelector precompiles one CAR namespaceSelector for
+// renewDirectories. It returns nil when there is nothing to compile or the
+// selector is malformed, so a broken rule costs only its own precompilation
+// and never the rest of the directory.
+func compileNamespaceSelector(crdName string, namespaceSelector *NamespaceSelector) labels.Selector {
+	if namespaceSelector == nil || namespaceSelector.LabelSelector == nil {
+		return nil
+	}
+
+	selector, err := metav1.LabelSelectorAsSelector(namespaceSelector.LabelSelector)
+	if err != nil {
+		klog.Errorf("Cannot compile namespaceSelector from ClusterAuthorizationRule %q: %v", crdName, err)
+		return nil
+	}
+
+	return selector
+}
+
 // namespaceLabelsMatchSelector checks if labels of a namespace match the
-// entry's selectors. Prefer compiledSelectors (built in renewDirectories).
+// entry's selectors, walking NamespaceSelectors in order and using the
+// index-aligned compiledSelectors entry where renewDirectories produced one.
 func (e *Engine) namespaceLabelsMatchSelector(namespaceName string, entry *DirectoryEntry) (bool, error) {
 	if e.nsLister == nil || entry == nil {
 		return false, nil
@@ -328,24 +352,24 @@ func (e *Engine) namespaceLabelsMatchSelector(namespaceName string, entry *Direc
 		labelsSet = labels.Set{}
 	}
 
-	if len(entry.compiledSelectors) > 0 {
-		for _, selector := range entry.compiledSelectors {
-			if selector.Matches(labelsSet) {
-				return true, nil
-			}
+	for i, namespaceSelector := range entry.NamespaceSelectors {
+		if namespaceSelector.LabelSelector == nil {
+			continue
 		}
-		return false, nil
-	}
 
-	for _, namespaceSelector := range entry.NamespaceSelectors {
-		if namespaceSelector.LabelSelector != nil {
-			selector, err := metav1.LabelSelectorAsSelector(namespaceSelector.LabelSelector)
-			if err != nil {
-				return false, err
-			}
-			if selector.Matches(labelsSet) {
+		if i < len(entry.compiledSelectors) && entry.compiledSelectors[i] != nil {
+			if entry.compiledSelectors[i].Matches(labelsSet) {
 				return true, nil
 			}
+			continue
+		}
+
+		selector, err := metav1.LabelSelectorAsSelector(namespaceSelector.LabelSelector)
+		if err != nil {
+			return false, err
+		}
+		if selector.Matches(labelsSet) {
+			return true, nil
 		}
 	}
 	return false, nil
@@ -411,14 +435,7 @@ func (e *Engine) renewDirectories() {
 				}
 			} else {
 				dirEntry.NamespaceSelectors = append(dirEntry.NamespaceSelectors, crd.Spec.NamespaceSelector)
-				if crd.Spec.NamespaceSelector.LabelSelector != nil {
-					selector, err := metav1.LabelSelectorAsSelector(crd.Spec.NamespaceSelector.LabelSelector)
-					if err != nil {
-						klog.Errorf("Cannot compile namespaceSelector from ClusterAuthorizationRule %q: %v", crd.Name, err)
-						return
-					}
-					dirEntry.compiledSelectors = append(dirEntry.compiledSelectors, selector)
-				}
+				dirEntry.compiledSelectors = append(dirEntry.compiledSelectors, compileNamespaceSelector(crd.Name, crd.Spec.NamespaceSelector))
 			}
 
 			directory[kind][name] = dirEntry

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/multitenancy/engine.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/multitenancy/engine.go
@@ -8,7 +8,6 @@ package multitenancy
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"os"
 	"regexp"
 	"strings"
@@ -17,10 +16,8 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
-	"k8s.io/client-go/discovery"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
@@ -60,14 +57,26 @@ type IndependentRBACChecker interface {
 	AllowsIndependently(ctx context.Context, attrs authorizer.Attributes) bool
 }
 
+// ResourceScope reports whether a resource is namespaced. known is false when
+// the snapshot has never seen the group/resource (missing CRD, broken
+// APIService, empty cache). Callers that enforce namespace limits must treat
+// !known like namespaced: failing open would let a CAR ClusterRoleBinding
+// report Allow for a cluster-scoped list of a namespaced resource.
+//
+// Implemented by resolver.ResourceScopeCache. This package must not import
+// resolver (resolver already imports multitenancy).
+type ResourceScope interface {
+	Scope(group, resource string) (namespaced, known bool)
+}
+
 // Engine implements the multi-tenancy authorization logic from user-authz webhook
 type Engine struct {
 	configPath      string
 	lastAppliedStat os.FileInfo
 
-	nsLister        corev1listers.NamespaceLister
-	nsSynced        cache.InformerSynced
-	discoveryClient discovery.DiscoveryInterface
+	nsLister      corev1listers.NamespaceLister
+	nsSynced      cache.InformerSynced
+	resourceScope ResourceScope
 
 	// independentRBAC, when set, is consulted before returning Deny: requests
 	// explicitly granted by CAR-independent RBAC must not be denied by
@@ -76,10 +85,6 @@ type Engine struct {
 
 	mu        sync.RWMutex
 	directory map[string]map[string]DirectoryEntry
-
-	// Cache for namespaced resources
-	namespacedCache   map[string]bool
-	namespacedCacheMu sync.RWMutex
 }
 
 // SetIndependentRBACChecker wires the CAR-independent RBAC checker into the
@@ -88,15 +93,16 @@ func (e *Engine) SetIndependentRBACChecker(checker IndependentRBACChecker) {
 	e.independentRBAC = checker
 }
 
-// NewEngine creates a new multi-tenancy engine
-func NewEngine(configPath string, nsLister corev1listers.NamespaceLister, nsSynced cache.InformerSynced, discoveryClient discovery.DiscoveryInterface) (*Engine, error) {
+// NewEngine creates a new multi-tenancy engine. resourceScope may be nil: every
+// lookup then reports !known, which is fail-closed for filtered cluster-scoped
+// requests. Live discovery is never used on Authorize.
+func NewEngine(configPath string, nsLister corev1listers.NamespaceLister, nsSynced cache.InformerSynced, resourceScope ResourceScope) (*Engine, error) {
 	e := &Engine{
-		configPath:      configPath,
-		nsLister:        nsLister,
-		nsSynced:        nsSynced,
-		discoveryClient: discoveryClient,
-		directory:       make(map[string]map[string]DirectoryEntry),
-		namespacedCache: make(map[string]bool),
+		configPath:    configPath,
+		nsLister:      nsLister,
+		nsSynced:      nsSynced,
+		resourceScope: resourceScope,
+		directory:     make(map[string]map[string]DirectoryEntry),
 	}
 
 	// Initial config load
@@ -186,7 +192,7 @@ func (e *Engine) authorizeNamespacedRequest(ctx context.Context, attrs authorize
 
 	// Check namespace selectors
 	if denied && len(entry.NamespaceSelectors) > 0 {
-		match, err := e.namespaceLabelsMatchSelector(namespace, entry.NamespaceSelectors)
+		match, err := e.namespaceLabelsMatchSelector(namespace, entry)
 		if err != nil {
 			klog.Errorf("Error checking namespace labels: %v", err)
 		} else if match {
@@ -216,106 +222,22 @@ func (e *Engine) authorizeClusterScopedRequest(ctx context.Context, attrs author
 		return authorizer.DecisionNoOpinion, "", nil
 	}
 
-	group := attrs.GetAPIGroup()
-	version := attrs.GetAPIVersion()
-	resource := attrs.GetResource()
+	namespaced, known := false, false
+	if e.resourceScope != nil {
+		namespaced, known = e.resourceScope.Scope(attrs.GetAPIGroup(), attrs.GetResource())
+	}
 
-	// Check if resource is namespaced
-	namespaced, err := e.isResourceNamespaced(group, version, resource)
-	if err != nil {
-		klog.V(4).Infof("Could not determine if resource %s/%s/%s is namespaced: %v", group, version, resource, err)
+	// Known cluster-scoped resources are not limited by namespace filters.
+	// Everything else (namespaced, or unknown) is treated as namespaced so a
+	// discovery miss cannot fail-open through a CAR ClusterRoleBinding.
+	if known && !namespaced {
 		return authorizer.DecisionNoOpinion, "", nil
 	}
 
-	if namespaced {
-		// Cluster-scoped access to a namespaced resource granted by a non-CAR
-		// ClusterRoleBinding is a deliberate cluster-wide grant; do not deny it.
-		if e.independentRBAC != nil && e.independentRBAC.AllowsIndependently(ctx, attrs) {
-			return authorizer.DecisionNoOpinion, "", nil
-		}
-		return authorizer.DecisionDeny, namespaceLimitedAccessReason, nil
+	if e.independentRBAC != nil && e.independentRBAC.AllowsIndependently(ctx, attrs) {
+		return authorizer.DecisionNoOpinion, "", nil
 	}
-
-	return authorizer.DecisionNoOpinion, "", nil
-}
-
-// isResourceNamespaced checks if a resource is namespaced using discovery
-func (e *Engine) isResourceNamespaced(group, version, resource string) (bool, error) {
-	// Use schema.GroupVersionResource for type-safe cache key
-	gvr := schema.GroupVersionResource{
-		Group:    group,
-		Version:  version,
-		Resource: resource,
-	}
-	cacheKey := gvr.String()
-
-	// Check cache with proper defer unlock
-	var namespaced, ok bool
-	func() {
-		e.namespacedCacheMu.RLock()
-		defer e.namespacedCacheMu.RUnlock()
-		namespaced, ok = e.namespacedCache[cacheKey]
-	}()
-	if ok {
-		return namespaced, nil
-	}
-
-	// Query apiserver for preferred version of this API resource
-	gv, err := e.getPreferredGroupVersion(group, version)
-	if err != nil {
-		return false, err
-	}
-
-	resourceList, err := e.discoveryClient.ServerResourcesForGroupVersion(gv.String())
-	if err != nil {
-		return false, err
-	}
-
-	e.namespacedCacheMu.Lock()
-	defer e.namespacedCacheMu.Unlock()
-	for _, r := range resourceList.APIResources {
-		if r.Name == resource || strings.HasPrefix(r.Name, resource+"/") {
-			e.namespacedCache[cacheKey] = r.Namespaced
-			return r.Namespaced, nil
-		}
-	}
-
-	return false, nil
-}
-
-// getPreferredGroupVersion returns the preferred GroupVersion for a group.
-// Uses schema.GroupVersion for type-safe group/version handling.
-func (e *Engine) getPreferredGroupVersion(group, version string) (schema.GroupVersion, error) {
-	// If version is specified, use it
-	if version != "" {
-		return schema.GroupVersion{Group: group, Version: version}, nil
-	}
-
-	// For core API group
-	if group == "" {
-		return schema.GroupVersion{Version: "v1"}, nil
-	}
-
-	// Query apiserver for preferred version
-	apiGroupList, err := e.discoveryClient.ServerGroups()
-	if err != nil {
-		// Propagate discovery error. The caller will treat it as best-effort and return NoOpinion.
-		return schema.GroupVersion{}, fmt.Errorf("failed to discover server groups while resolving preferred version for group %q: %w", group, err)
-	}
-
-	for _, g := range apiGroupList.Groups {
-		if g.Name == group {
-			// Parse the preferred version string into GroupVersion
-			gv, parseErr := schema.ParseGroupVersion(g.PreferredVersion.GroupVersion)
-			if parseErr != nil {
-				return schema.GroupVersion{}, fmt.Errorf("failed to parse preferred version %q for group %q: %w", g.PreferredVersion.GroupVersion, group, parseErr)
-			}
-			return gv, nil
-		}
-	}
-
-	// Group not found - this should not happen in a properly functioning cluster
-	return schema.GroupVersion{}, fmt.Errorf("API group %q not found in server groups", group)
+	return authorizer.DecisionDeny, namespaceLimitedAccessReason, nil
 }
 
 // combineDirEntries combines multiple directory entries into one.
@@ -331,6 +253,9 @@ func (e *Engine) combineDirEntries(entries []DirectoryEntry) DirectoryEntry {
 
 		if len(entry.NamespaceSelectors) > 0 {
 			combined.NamespaceSelectors = append(combined.NamespaceSelectors, entry.NamespaceSelectors...)
+		}
+		if len(entry.compiledSelectors) > 0 {
+			combined.compiledSelectors = append(combined.compiledSelectors, entry.compiledSelectors...)
 		}
 		if len(entry.LimitNamespaces) > 0 {
 			combined.LimitNamespaces = append(combined.LimitNamespaces, entry.LimitNamespaces...)
@@ -372,9 +297,10 @@ func (e *Engine) affectedDirs(userName string, groups []string) []DirectoryEntry
 	return dirEntriesAffected
 }
 
-// namespaceLabelsMatchSelector checks if labels of a namespace match provided labelselector
-func (e *Engine) namespaceLabelsMatchSelector(namespaceName string, namespaceSelectors []*NamespaceSelector) (bool, error) {
-	if e.nsLister == nil {
+// namespaceLabelsMatchSelector checks if labels of a namespace match the
+// entry's selectors. Prefer compiledSelectors (built in renewDirectories).
+func (e *Engine) namespaceLabelsMatchSelector(namespaceName string, entry *DirectoryEntry) (bool, error) {
+	if e.nsLister == nil || entry == nil {
 		return false, nil
 	}
 
@@ -388,7 +314,16 @@ func (e *Engine) namespaceLabelsMatchSelector(namespaceName string, namespaceSel
 		labelsSet = labels.Set{}
 	}
 
-	for _, namespaceSelector := range namespaceSelectors {
+	if len(entry.compiledSelectors) > 0 {
+		for _, selector := range entry.compiledSelectors {
+			if selector.Matches(labelsSet) {
+				return true, nil
+			}
+		}
+		return false, nil
+	}
+
+	for _, namespaceSelector := range entry.NamespaceSelectors {
 		if namespaceSelector.LabelSelector != nil {
 			selector, err := metav1.LabelSelectorAsSelector(namespaceSelector.LabelSelector)
 			if err != nil {
@@ -462,6 +397,14 @@ func (e *Engine) renewDirectories() {
 				}
 			} else {
 				dirEntry.NamespaceSelectors = append(dirEntry.NamespaceSelectors, crd.Spec.NamespaceSelector)
+				if crd.Spec.NamespaceSelector.LabelSelector != nil {
+					selector, err := metav1.LabelSelectorAsSelector(crd.Spec.NamespaceSelector.LabelSelector)
+					if err != nil {
+						klog.Errorf("Cannot compile namespaceSelector from ClusterAuthorizationRule %q: %v", crd.Name, err)
+						return
+					}
+					dirEntry.compiledSelectors = append(dirEntry.compiledSelectors, selector)
+				}
 			}
 
 			directory[kind][name] = dirEntry
@@ -614,7 +557,7 @@ func (e *Engine) IsNamespaceAllowedWithFilter(namespace string, filter *Director
 
 	// Check namespace selectors if denied by patterns
 	if !allowed && len(filter.NamespaceSelectors) > 0 {
-		match, err := e.namespaceLabelsMatchSelector(namespace, filter.NamespaceSelectors)
+		match, err := e.namespaceLabelsMatchSelector(namespace, filter)
 		if err == nil && match {
 			allowed = true
 		}

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/multitenancy/engine.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/multitenancy/engine.go
@@ -59,14 +59,19 @@ type IndependentRBACChecker interface {
 
 // ResourceScope reports whether a resource is namespaced. known is false when
 // the snapshot has never seen the group/resource (missing CRD, broken
-// APIService, empty cache). Callers that enforce namespace limits must treat
+// APIService, empty cache). Callers that enforce namespace limits treat
 // !known like namespaced: failing open would let a CAR ClusterRoleBinding
 // report Allow for a cluster-scoped list of a namespaced resource.
+//
+// HasData separates "the snapshot exists and does not list this resource"
+// from "there is no snapshot at all". The webhook makes the same distinction,
+// and only the first case, for the core group, lets RBAC answer.
 //
 // Implemented by resolver.ResourceScopeCache. This package must not import
 // resolver (resolver already imports multitenancy).
 type ResourceScope interface {
 	Scope(group, resource string) (bool, bool)
+	HasData() bool
 }
 
 // Engine implements the multi-tenancy authorization logic from user-authz webhook
@@ -222,15 +227,24 @@ func (e *Engine) authorizeClusterScopedRequest(ctx context.Context, attrs author
 		return authorizer.DecisionNoOpinion, "", nil
 	}
 
-	namespaced, known := false, false
+	namespaced, known, populated := false, false, false
 	if e.resourceScope != nil {
 		namespaced, known = e.resourceScope.Scope(attrs.GetAPIGroup(), attrs.GetResource())
+		populated = e.resourceScope.HasData()
 	}
 
 	// Known cluster-scoped resources are not limited by namespace filters.
 	// Everything else (namespaced, or unknown) is treated as namespaced so a
 	// discovery miss cannot fail-open through a CAR ClusterRoleBinding.
 	if known && !namespaced {
+		return authorizer.DecisionNoOpinion, "", nil
+	}
+
+	// A core resource absent from a populated snapshot does not exist. The
+	// webhook lets RBAC answer that case instead of denying it, so BulkSAR
+	// must not report Deny where the webhook would not. Groups are excluded:
+	// there the webhook denies an unresolvable resource, and so do we.
+	if !known && populated && attrs.GetAPIGroup() == "" {
 		return authorizer.DecisionNoOpinion, "", nil
 	}
 

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/multitenancy/engine_clusterscoped_test.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/multitenancy/engine_clusterscoped_test.go
@@ -14,13 +14,16 @@ import (
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 )
 
-// staticResourceScope is a test ResourceScope. Missing keys are unknown.
+// staticResourceScope is a test ResourceScope. Missing keys are unknown, and
+// an empty map stands for a snapshot discovery never filled.
 type staticResourceScope map[string]bool
 
 func (s staticResourceScope) Scope(group, resource string) (namespaced, known bool) {
 	namespaced, known = s[group+"/"+resource]
 	return namespaced, known
 }
+
+func (s staticResourceScope) HasData() bool { return len(s) > 0 }
 
 func coreResourceScope() staticResourceScope {
 	return staticResourceScope{
@@ -210,12 +213,52 @@ func (c *clusterIndependentChecker) AllowsIndependently(_ context.Context, attrs
 	return ok
 }
 
-func TestEngine_Authorize_UnknownResourceIsDenied(t *testing.T) {
+// authorizeGroupedResource is authorizeResource for a resource that lives in
+// an API group. The webhook resolves group and core resources differently, so
+// the unknown-resource rows must state which one they mean.
+func authorizeGroupedResource(t *testing.T, e *Engine, userName, group, resource string) authorizer.Decision {
+	t.Helper()
+	decision, _, err := e.Authorize(context.Background(), &mockAttrs{
+		userInfo:   &mockUserInfo{name: userName},
+		verb:       "list",
+		apiGroup:   group,
+		resource:   resource,
+		isResource: true,
+	})
+	require.NoError(t, err)
+	return decision
+}
+
+func TestEngine_Authorize_UnknownGroupedResourceIsDenied(t *testing.T) {
 	editor := engineWithKnownScopes(t, editorCARConfig)
 
-	got := authorizeResource(t, editor, "editor@example.io", "list", "doesnotexist", "")
+	got := authorizeGroupedResource(t, editor, "editor@example.io", "example.io", "doesnotexist")
 	assert.Equal(t, authorizer.DecisionDeny, got,
-		"a resource absent from the scope snapshot must not fail-open")
+		"a grouped resource absent from the scope snapshot must not fail-open")
+}
+
+// TestEngine_Authorize_UnknownCoreResourceMatchesWebhook locks parity with
+// the enforcement webhook, which permits an unknown core resource so RBAC can
+// answer instead of denying it. Reporting Deny here would show a restriction
+// the cluster does not apply.
+func TestEngine_Authorize_UnknownCoreResourceMatchesWebhook(t *testing.T) {
+	editor := engineWithKnownScopes(t, editorCARConfig)
+
+	got := authorizeGroupedResource(t, editor, "editor@example.io", "", "doesnotexist")
+	assert.Equal(t, authorizer.DecisionNoOpinion, got,
+		"an unknown core resource is left to RBAC, exactly as the webhook does")
+}
+
+// TestEngine_Authorize_EmptySnapshotDeniesCoreResource guards the other side
+// of that carve-out: with no snapshot at all we cannot tell a missing
+// resource from missing discovery, and the webhook denies too.
+func TestEngine_Authorize_EmptySnapshotDeniesCoreResource(t *testing.T) {
+	editor, err := NewEngine(writeConfigJSON(t, editorCARConfig), nil, nil, staticResourceScope{})
+	require.NoError(t, err)
+
+	got := authorizeGroupedResource(t, editor, "editor@example.io", "", "pods")
+	assert.Equal(t, authorizer.DecisionDeny, got,
+		"an unpopulated snapshot must not turn every core resource into a pass")
 }
 
 func TestEngine_Authorize_NilScopeIsDenied(t *testing.T) {
@@ -228,11 +271,10 @@ func TestEngine_Authorize_NilScopeIsDenied(t *testing.T) {
 }
 
 func TestEngine_Authorize_UnknownResourceIndependentRBAC(t *testing.T) {
-	editor, err := NewEngine(writeConfigJSON(t, editorCARConfig), nil, nil, staticResourceScope{})
-	require.NoError(t, err)
+	editor := engineWithKnownScopes(t, editorCARConfig)
 	editor.SetIndependentRBACChecker(&clusterIndependentChecker{allowClusterScoped: true})
 
-	got := authorizeResource(t, editor, "editor@example.io", "list", "newcrds", "")
+	got := authorizeGroupedResource(t, editor, "editor@example.io", "example.io", "newcrds")
 	assert.Equal(t, authorizer.DecisionNoOpinion, got,
 		"independent cluster-wide grant still skips the unknown-resource deny")
 }

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/multitenancy/engine_clusterscoped_test.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/multitenancy/engine_clusterscoped_test.go
@@ -1,0 +1,276 @@
+/*
+Copyright 2025 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package multitenancy
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/client-go/discovery"
+)
+
+// stubDiscovery answers only the two methods Authorize uses on a cache miss.
+// Unused DiscoveryInterface methods panic via the nil embed — that is
+// deliberate: a new live call on the hot path must fail the test, not hide.
+type stubDiscovery struct {
+	discovery.DiscoveryInterface
+	err  error
+	list *metav1.APIResourceList
+}
+
+func (s *stubDiscovery) ServerResourcesForGroupVersion(string) (*metav1.APIResourceList, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	if s.list != nil {
+		return s.list, nil
+	}
+	return &metav1.APIResourceList{GroupVersion: "v1"}, nil
+}
+
+func (s *stubDiscovery) ServerGroups() (*metav1.APIGroupList, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return &metav1.APIGroupList{}, nil
+}
+
+func gvrCacheKey(group, version, resource string) string {
+	return schema.GroupVersionResource{Group: group, Version: version, Resource: resource}.String()
+}
+
+const (
+	editorCARConfig = `{
+		"crds": [{
+			"name": "editor",
+			"spec": {
+				"accessLevel": "Editor",
+				"limitNamespaces": ["ns-in"],
+				"subjects": [{"kind": "User", "name": "editor@example.io"}]
+			}
+		}]
+	}`
+	superAdminCARConfig = `{
+		"crds": [{
+			"name": "super",
+			"spec": {
+				"accessLevel": "SuperAdmin",
+				"allowAccessToSystemNamespaces": true,
+				"namespaceSelector": {"matchAny": true},
+				"subjects": [{"kind": "User", "name": "super@example.io"}]
+			}
+		}]
+	}`
+)
+
+func engineWithKnownScopes(t *testing.T, config string, disco discovery.DiscoveryInterface) *Engine {
+	t.Helper()
+	e, err := NewEngine(writeConfigJSON(t, config), nil, nil, disco)
+	require.NoError(t, err)
+	e.namespacedCacheMu.Lock()
+	e.namespacedCache[gvrCacheKey("", "", "pods")] = true
+	e.namespacedCache[gvrCacheKey("", "", "nodes")] = false
+	e.namespacedCacheMu.Unlock()
+	return e
+}
+
+func authorizeResource(t *testing.T, e *Engine, userName, verb, resource, namespace string) authorizer.Decision {
+	t.Helper()
+	decision, _, err := e.Authorize(context.Background(), &mockAttrs{
+		userInfo:   &mockUserInfo{name: userName},
+		verb:       verb,
+		resource:   resource,
+		namespace:  namespace,
+		isResource: true,
+	})
+	require.NoError(t, err)
+	return decision
+}
+
+// TestEngine_Authorize_ClusterScopedFilterContract locks the deny-only MT
+// answers that BulkSAR and the webhook must keep agreeing on for well-known
+// resources. Scope is injected via namespacedCache so this does not depend on
+// live discovery. A later ResourceScopeCache wiring must not change these
+// rows for pods/nodes.
+func TestEngine_Authorize_ClusterScopedFilterContract(t *testing.T) {
+	editor := engineWithKnownScopes(t, editorCARConfig, nil)
+	super := engineWithKnownScopes(t, superAdminCARConfig, nil)
+
+	tests := []struct {
+		name     string
+		engine   *Engine
+		user     string
+		verb     string
+		resource string
+		ns       string
+		want     authorizer.Decision
+	}{
+		{
+			name:     "editor cluster-scoped list of namespaced pods is denied",
+			engine:   editor,
+			user:     "editor@example.io",
+			verb:     "list",
+			resource: "pods",
+			want:     authorizer.DecisionDeny,
+		},
+		{
+			name:     "editor cluster-scoped watch of namespaced pods is denied",
+			engine:   editor,
+			user:     "editor@example.io",
+			verb:     "watch",
+			resource: "pods",
+			want:     authorizer.DecisionDeny,
+		},
+		{
+			name:     "editor get of cluster-scoped nodes is NoOpinion",
+			engine:   editor,
+			user:     "editor@example.io",
+			verb:     "get",
+			resource: "nodes",
+			want:     authorizer.DecisionNoOpinion,
+		},
+		{
+			name:     "editor get pods in CAR namespace is NoOpinion",
+			engine:   editor,
+			user:     "editor@example.io",
+			verb:     "get",
+			resource: "pods",
+			ns:       "ns-in",
+			want:     authorizer.DecisionNoOpinion,
+		},
+		{
+			name:     "editor get pods outside CAR namespace is denied",
+			engine:   editor,
+			user:     "editor@example.io",
+			verb:     "get",
+			resource: "pods",
+			ns:       "ns-out",
+			want:     authorizer.DecisionDeny,
+		},
+		{
+			name:     "editor get pods in kube-system is denied (no system access)",
+			engine:   editor,
+			user:     "editor@example.io",
+			verb:     "get",
+			resource: "pods",
+			ns:       "kube-system",
+			want:     authorizer.DecisionDeny,
+		},
+		{
+			name:     "superadmin cluster-scoped list of pods is NoOpinion (no MT filters)",
+			engine:   super,
+			user:     "super@example.io",
+			verb:     "list",
+			resource: "pods",
+			want:     authorizer.DecisionNoOpinion,
+		},
+		{
+			name:     "superadmin get pods in any namespace is NoOpinion",
+			engine:   super,
+			user:     "super@example.io",
+			verb:     "get",
+			resource: "pods",
+			ns:       "ns-out",
+			want:     authorizer.DecisionNoOpinion,
+		},
+		{
+			name:     "superadmin get pods in kube-system is NoOpinion",
+			engine:   super,
+			user:     "super@example.io",
+			verb:     "get",
+			resource: "pods",
+			ns:       "kube-system",
+			want:     authorizer.DecisionNoOpinion,
+		},
+		{
+			name:     "unknown user is NoOpinion (RBAC decides)",
+			engine:   editor,
+			user:     "nobody@example.io",
+			verb:     "list",
+			resource: "pods",
+			want:     authorizer.DecisionNoOpinion,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := authorizeResource(t, tt.engine, tt.user, tt.verb, tt.resource, tt.ns)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestEngine_Authorize_ClusterScopedIndependentRBAC locks the documented
+// exception: a non-CAR ClusterRoleBinding that grants cluster-wide list of a
+// namespaced resource must not be denied by the CAR namespace filter.
+func TestEngine_Authorize_ClusterScopedIndependentRBAC(t *testing.T) {
+	editor := engineWithKnownScopes(t, editorCARConfig, nil)
+	editor.SetIndependentRBACChecker(&clusterIndependentChecker{allowClusterScoped: true})
+
+	got := authorizeResource(t, editor, "editor@example.io", "list", "pods", "")
+	assert.Equal(t, authorizer.DecisionNoOpinion, got,
+		"independent cluster-wide grant must skip the namespaced-resource deny")
+}
+
+type clusterIndependentChecker struct {
+	allowClusterScoped bool
+	namespaces         map[string]struct{}
+}
+
+func (c *clusterIndependentChecker) AllowsIndependently(_ context.Context, attrs authorizer.Attributes) bool {
+	if attrs.GetNamespace() == "" {
+		return c.allowClusterScoped
+	}
+	_, ok := c.namespaces[attrs.GetNamespace()]
+	return ok
+}
+
+// TestEngine_Authorize_DiscoveryMissFailsOpen documents today's fail-open
+// on a live discovery error: MT returns NoOpinion, so a CAR Editor CRB can
+// report Allow for cluster-scoped list of an unknown resource. The webhook
+// Denies the same miss. The ResourceScopeCache wiring is allowed to change
+// this one case to Deny; do not treat it as filter-strictness.
+func TestEngine_Authorize_DiscoveryMissFailsOpen(t *testing.T) {
+	disco := &stubDiscovery{err: errors.New("discovery unavailable")}
+	editor, err := NewEngine(writeConfigJSON(t, editorCARConfig), nil, nil, disco)
+	require.NoError(t, err)
+
+	got := authorizeResource(t, editor, "editor@example.io", "list", "newcrds", "")
+	assert.Equal(t, authorizer.DecisionNoOpinion, got,
+		"current behavior: discovery error is NoOpinion (fail-open)")
+}
+
+func TestEngine_Authorize_UnknownResourceTreatedAsClusterScoped(t *testing.T) {
+	disco := &stubDiscovery{list: &metav1.APIResourceList{GroupVersion: "v1"}}
+	editor, err := NewEngine(writeConfigJSON(t, editorCARConfig), nil, nil, disco)
+	require.NoError(t, err)
+
+	got := authorizeResource(t, editor, "editor@example.io", "list", "doesnotexist", "")
+	assert.Equal(t, authorizer.DecisionNoOpinion, got,
+		"current behavior: resource absent from the GV list is treated as cluster-scoped")
+}
+
+func TestEngine_GetNamespaceAccessType_SuperAdminVsEditor(t *testing.T) {
+	editor := engineWithKnownScopes(t, editorCARConfig, nil)
+	super := engineWithKnownScopes(t, superAdminCARConfig, nil)
+
+	access, filter := editor.GetNamespaceAccessType(&mockUserInfo{name: "editor@example.io"})
+	assert.Equal(t, FilteredAccess, access)
+	require.NotNil(t, filter)
+	assert.True(t, editor.IsNamespaceAllowedWithFilter("ns-in", filter))
+	assert.False(t, editor.IsNamespaceAllowedWithFilter("ns-out", filter))
+	assert.False(t, editor.IsNamespaceAllowedWithFilter("kube-system", filter))
+
+	access, filter = super.GetNamespaceAccessType(&mockUserInfo{name: "super@example.io"})
+	assert.Equal(t, AllNamespacesAllowed, access)
+	assert.Nil(t, filter)
+}

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/multitenancy/engine_clusterscoped_test.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/multitenancy/engine_clusterscoped_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 Flant JSC
+Copyright 2026 Flant JSC
 Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
 */
 
@@ -7,45 +7,26 @@ package multitenancy
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
-	"k8s.io/client-go/discovery"
 )
 
-// stubDiscovery answers only the two methods Authorize uses on a cache miss.
-// Unused DiscoveryInterface methods panic via the nil embed — that is
-// deliberate: a new live call on the hot path must fail the test, not hide.
-type stubDiscovery struct {
-	discovery.DiscoveryInterface
-	err  error
-	list *metav1.APIResourceList
+// staticResourceScope is a test ResourceScope. Missing keys are unknown.
+type staticResourceScope map[string]bool
+
+func (s staticResourceScope) Scope(group, resource string) (namespaced, known bool) {
+	namespaced, known = s[group+"/"+resource]
+	return namespaced, known
 }
 
-func (s *stubDiscovery) ServerResourcesForGroupVersion(string) (*metav1.APIResourceList, error) {
-	if s.err != nil {
-		return nil, s.err
+func coreResourceScope() staticResourceScope {
+	return staticResourceScope{
+		"/pods":  true,
+		"/nodes": false,
 	}
-	if s.list != nil {
-		return s.list, nil
-	}
-	return &metav1.APIResourceList{GroupVersion: "v1"}, nil
-}
-
-func (s *stubDiscovery) ServerGroups() (*metav1.APIGroupList, error) {
-	if s.err != nil {
-		return nil, s.err
-	}
-	return &metav1.APIGroupList{}, nil
-}
-
-func gvrCacheKey(group, version, resource string) string {
-	return schema.GroupVersionResource{Group: group, Version: version, Resource: resource}.String()
 }
 
 const (
@@ -72,14 +53,10 @@ const (
 	}`
 )
 
-func engineWithKnownScopes(t *testing.T, config string, disco discovery.DiscoveryInterface) *Engine {
+func engineWithKnownScopes(t *testing.T, config string) *Engine {
 	t.Helper()
-	e, err := NewEngine(writeConfigJSON(t, config), nil, nil, disco)
+	e, err := NewEngine(writeConfigJSON(t, config), nil, nil, coreResourceScope())
 	require.NoError(t, err)
-	e.namespacedCacheMu.Lock()
-	e.namespacedCache[gvrCacheKey("", "", "pods")] = true
-	e.namespacedCache[gvrCacheKey("", "", "nodes")] = false
-	e.namespacedCacheMu.Unlock()
 	return e
 }
 
@@ -98,12 +75,11 @@ func authorizeResource(t *testing.T, e *Engine, userName, verb, resource, namesp
 
 // TestEngine_Authorize_ClusterScopedFilterContract locks the deny-only MT
 // answers that BulkSAR and the webhook must keep agreeing on for well-known
-// resources. Scope is injected via namespacedCache so this does not depend on
-// live discovery. A later ResourceScopeCache wiring must not change these
-// rows for pods/nodes.
+// resources. Scope is injected via ResourceScope so this does not depend on
+// live discovery.
 func TestEngine_Authorize_ClusterScopedFilterContract(t *testing.T) {
-	editor := engineWithKnownScopes(t, editorCARConfig, nil)
-	super := engineWithKnownScopes(t, superAdminCARConfig, nil)
+	editor := engineWithKnownScopes(t, editorCARConfig)
+	super := engineWithKnownScopes(t, superAdminCARConfig)
 
 	tests := []struct {
 		name     string
@@ -213,7 +189,7 @@ func TestEngine_Authorize_ClusterScopedFilterContract(t *testing.T) {
 // exception: a non-CAR ClusterRoleBinding that grants cluster-wide list of a
 // namespaced resource must not be denied by the CAR namespace filter.
 func TestEngine_Authorize_ClusterScopedIndependentRBAC(t *testing.T) {
-	editor := engineWithKnownScopes(t, editorCARConfig, nil)
+	editor := engineWithKnownScopes(t, editorCARConfig)
 	editor.SetIndependentRBACChecker(&clusterIndependentChecker{allowClusterScoped: true})
 
 	got := authorizeResource(t, editor, "editor@example.io", "list", "pods", "")
@@ -234,34 +210,36 @@ func (c *clusterIndependentChecker) AllowsIndependently(_ context.Context, attrs
 	return ok
 }
 
-// TestEngine_Authorize_DiscoveryMissFailsOpen documents today's fail-open
-// on a live discovery error: MT returns NoOpinion, so a CAR Editor CRB can
-// report Allow for cluster-scoped list of an unknown resource. The webhook
-// Denies the same miss. The ResourceScopeCache wiring is allowed to change
-// this one case to Deny; do not treat it as filter-strictness.
-func TestEngine_Authorize_DiscoveryMissFailsOpen(t *testing.T) {
-	disco := &stubDiscovery{err: errors.New("discovery unavailable")}
-	editor, err := NewEngine(writeConfigJSON(t, editorCARConfig), nil, nil, disco)
+func TestEngine_Authorize_UnknownResourceIsDenied(t *testing.T) {
+	editor := engineWithKnownScopes(t, editorCARConfig)
+
+	got := authorizeResource(t, editor, "editor@example.io", "list", "doesnotexist", "")
+	assert.Equal(t, authorizer.DecisionDeny, got,
+		"a resource absent from the scope snapshot must not fail-open")
+}
+
+func TestEngine_Authorize_NilScopeIsDenied(t *testing.T) {
+	editor, err := NewEngine(writeConfigJSON(t, editorCARConfig), nil, nil, nil)
 	require.NoError(t, err)
+
+	got := authorizeResource(t, editor, "editor@example.io", "list", "pods", "")
+	assert.Equal(t, authorizer.DecisionDeny, got,
+		"nil ResourceScope is !known and must Deny for a filtered user")
+}
+
+func TestEngine_Authorize_UnknownResourceIndependentRBAC(t *testing.T) {
+	editor, err := NewEngine(writeConfigJSON(t, editorCARConfig), nil, nil, staticResourceScope{})
+	require.NoError(t, err)
+	editor.SetIndependentRBACChecker(&clusterIndependentChecker{allowClusterScoped: true})
 
 	got := authorizeResource(t, editor, "editor@example.io", "list", "newcrds", "")
 	assert.Equal(t, authorizer.DecisionNoOpinion, got,
-		"current behavior: discovery error is NoOpinion (fail-open)")
-}
-
-func TestEngine_Authorize_UnknownResourceTreatedAsClusterScoped(t *testing.T) {
-	disco := &stubDiscovery{list: &metav1.APIResourceList{GroupVersion: "v1"}}
-	editor, err := NewEngine(writeConfigJSON(t, editorCARConfig), nil, nil, disco)
-	require.NoError(t, err)
-
-	got := authorizeResource(t, editor, "editor@example.io", "list", "doesnotexist", "")
-	assert.Equal(t, authorizer.DecisionNoOpinion, got,
-		"current behavior: resource absent from the GV list is treated as cluster-scoped")
+		"independent cluster-wide grant still skips the unknown-resource deny")
 }
 
 func TestEngine_GetNamespaceAccessType_SuperAdminVsEditor(t *testing.T) {
-	editor := engineWithKnownScopes(t, editorCARConfig, nil)
-	super := engineWithKnownScopes(t, superAdminCARConfig, nil)
+	editor := engineWithKnownScopes(t, editorCARConfig)
+	super := engineWithKnownScopes(t, superAdminCARConfig)
 
 	access, filter := editor.GetNamespaceAccessType(&mockUserInfo{name: "editor@example.io"})
 	assert.Equal(t, FilteredAccess, access)

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/multitenancy/engine_contract_test.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/multitenancy/engine_contract_test.go
@@ -1,0 +1,443 @@
+/*
+Copyright 2026 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package multitenancy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// consoleResourceScope is the GVR set the console BulkSAR payload actually
+// asks about. A miss here is !known and must Deny for a filtered user.
+func consoleResourceScope() staticResourceScope {
+	return staticResourceScope{
+		"/pods":                                  true,
+		"/services":                              true,
+		"/configmaps":                            true,
+		"/secrets":                               true,
+		"/namespaces":                            false,
+		"/nodes":                                 false,
+		"/persistentvolumes":                     false,
+		"apps/deployments":                       true,
+		"apps/replicasets":                       true,
+		"apps/statefulsets":                      true,
+		"batch/jobs":                             true,
+		"batch/cronjobs":                         true,
+		"networking.k8s.io/ingresses":            true,
+		"rbac.authorization.k8s.io/roles":        true,
+		"rbac.authorization.k8s.io/clusterroles": false,
+		"rbac.authorization.k8s.io/clusterrolebindings":  false,
+		"apiextensions.k8s.io/customresourcedefinitions": false,
+		"deckhouse.io/projects":                          false,
+		"metrics.k8s.io/pods":                            true,
+		"metrics.k8s.io/nodes":                           false,
+	}
+}
+
+const (
+	editorLabelSelectorCARConfig = `{
+		"crds": [{
+			"name": "editor-sel",
+			"spec": {
+				"accessLevel": "Editor",
+				"namespaceSelector": {"labelSelector": {"matchLabels": {"pba-perf": "true"}}},
+				"subjects": [{"kind": "User", "name": "editor@example.io"}]
+			}
+		}]
+	}`
+	editorMatchAnyCARConfig = `{
+		"crds": [{
+			"name": "editor-any",
+			"spec": {
+				"accessLevel": "Editor",
+				"namespaceSelector": {"matchAny": true},
+				"subjects": [{"kind": "User", "name": "editor-any@example.io"}]
+			}
+		}]
+	}`
+	superAdminLimitedCARConfig = `{
+		"crds": [{
+			"name": "super-limited",
+			"spec": {
+				"accessLevel": "SuperAdmin",
+				"allowAccessToSystemNamespaces": true,
+				"limitNamespaces": ["ns-in"],
+				"subjects": [{"kind": "User", "name": "super-limited@example.io"}]
+			}
+		}]
+	}`
+	clusterAdminMatchAnyCARConfig = `{
+		"crds": [{
+			"name": "ca-any",
+			"spec": {
+				"accessLevel": "ClusterAdmin",
+				"namespaceSelector": {"matchAny": true},
+				"subjects": [{"kind": "User", "name": "ca-any@example.io"}]
+			}
+		}]
+	}`
+	clusterAdminLimitedCARConfig = `{
+		"crds": [{
+			"name": "ca-lim",
+			"spec": {
+				"accessLevel": "ClusterAdmin",
+				"limitNamespaces": ["ns-in"],
+				"subjects": [{"kind": "User", "name": "ca-lim@example.io"}]
+			}
+		}]
+	}`
+	editorNoFilterCARConfig = `{
+		"crds": [{
+			"name": "editor-wide",
+			"spec": {
+				"accessLevel": "Editor",
+				"subjects": [{"kind": "User", "name": "editor-wide@example.io"}]
+			}
+		}]
+	}`
+	editorGroupCARConfig = `{
+		"crds": [{
+			"name": "editor-group",
+			"spec": {
+				"accessLevel": "Editor",
+				"limitNamespaces": ["ns-in"],
+				"subjects": [{"kind": "Group", "name": "editors"}]
+			}
+		}]
+	}`
+)
+
+func authorizeAs(t *testing.T, e *Engine, u user.Info, verb, group, resource, namespace string) (authorizer.Decision, string) {
+	t.Helper()
+	decision, reason, err := e.Authorize(context.Background(), &mockAttrs{
+		userInfo:   u,
+		verb:       verb,
+		apiGroup:   group,
+		resource:   resource,
+		namespace:  namespace,
+		isResource: true,
+	})
+	require.NoError(t, err)
+	return decision, reason
+}
+
+func engineWithConsoleScope(t *testing.T, config string) *Engine {
+	t.Helper()
+	e, err := NewEngine(writeConfigJSON(t, config), nil, nil, consoleResourceScope())
+	require.NoError(t, err)
+	return e
+}
+
+func labeledNamespaces() []runtime.Object {
+	return []runtime.Object{
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+			Name:   "ns-in",
+			Labels: map[string]string{"pba-perf": "true"},
+		}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns-out"}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kube-system"}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "d8-system"}},
+	}
+}
+
+func engineWithNamespaces(t *testing.T, config string, objs ...runtime.Object) *Engine {
+	t.Helper()
+	client := fake.NewSimpleClientset(objs...)
+	factory := informers.NewSharedInformerFactory(client, 0)
+	nsInformer := factory.Core().V1().Namespaces()
+	lister := nsInformer.Lister() // register before Start
+	stop := make(chan struct{})
+	t.Cleanup(func() { close(stop) })
+	factory.Start(stop)
+	for typ, ok := range factory.WaitForCacheSync(stop) {
+		require.True(t, ok, "informer %v failed to sync", typ)
+	}
+
+	e, err := NewEngine(writeConfigJSON(t, config), lister, func() bool { return true }, consoleResourceScope())
+	require.NoError(t, err)
+	return e
+}
+
+// TestEngine_Authorize_AccessLevelDoesNotGrant locks that SuperAdmin/Editor/
+// ClusterAdmin names are irrelevant to MT. Filters decide: matchAny is
+// NoOpinion, a real namespace limit Denies the same cluster-scoped list.
+func TestEngine_Authorize_AccessLevelDoesNotGrant(t *testing.T) {
+	editorLimited := engineWithConsoleScope(t, editorCARConfig)
+	editorAny := engineWithConsoleScope(t, editorMatchAnyCARConfig)
+	superLimited := engineWithConsoleScope(t, superAdminLimitedCARConfig)
+	superAny := engineWithConsoleScope(t, superAdminCARConfig)
+	caLimited := engineWithConsoleScope(t, clusterAdminLimitedCARConfig)
+	caAny := engineWithConsoleScope(t, clusterAdminMatchAnyCARConfig)
+
+	tests := []struct {
+		name   string
+		engine *Engine
+		user   string
+		want   authorizer.Decision
+	}{
+		{name: "Editor + limitNamespaces denies cluster-scoped list pods", engine: editorLimited, user: "editor@example.io", want: authorizer.DecisionDeny},
+		{name: "Editor + matchAny is NoOpinion on cluster-scoped list pods", engine: editorAny, user: "editor-any@example.io", want: authorizer.DecisionNoOpinion},
+		{name: "SuperAdmin + limitNamespaces denies cluster-scoped list pods", engine: superLimited, user: "super-limited@example.io", want: authorizer.DecisionDeny},
+		{name: "SuperAdmin + matchAny is NoOpinion on cluster-scoped list pods", engine: superAny, user: "super@example.io", want: authorizer.DecisionNoOpinion},
+		{name: "ClusterAdmin + limitNamespaces denies cluster-scoped list pods", engine: caLimited, user: "ca-lim@example.io", want: authorizer.DecisionDeny},
+		{name: "ClusterAdmin + matchAny is NoOpinion on cluster-scoped list pods", engine: caAny, user: "ca-any@example.io", want: authorizer.DecisionNoOpinion},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, reason := authorizeAs(t, tt.engine, &mockUserInfo{name: tt.user}, "list", "", "pods", "")
+			assert.Equal(t, tt.want, got, "reason=%q", reason)
+			if tt.want == authorizer.DecisionDeny {
+				assert.Equal(t, namespaceLimitedAccessReason, reason)
+			}
+		})
+	}
+}
+
+// TestEngine_Authorize_ConsoleResourceMatrix pins MT answers for every
+// decision class the console payload hits. RBAC is not in this test: Deny
+// stays Deny, NoOpinion is "RBAC decides".
+func TestEngine_Authorize_ConsoleResourceMatrix(t *testing.T) {
+	editor := engineWithConsoleScope(t, editorCARConfig)
+	super := engineWithConsoleScope(t, superAdminCARConfig)
+	wide := engineWithConsoleScope(t, editorNoFilterCARConfig)
+
+	type req struct {
+		verb, group, resource, ns string
+	}
+	filteredEditor := []struct {
+		name string
+		req  req
+		want authorizer.Decision
+	}{
+		{name: "list pods cluster-scoped", req: req{verb: "list", resource: "pods"}, want: authorizer.DecisionDeny},
+		{name: "watch pods cluster-scoped", req: req{verb: "watch", resource: "pods"}, want: authorizer.DecisionDeny},
+		{name: "create pods cluster-scoped", req: req{verb: "create", resource: "pods"}, want: authorizer.DecisionDeny},
+		{name: "list services cluster-scoped", req: req{verb: "list", resource: "services"}, want: authorizer.DecisionDeny},
+		{name: "list secrets cluster-scoped", req: req{verb: "list", resource: "secrets"}, want: authorizer.DecisionDeny},
+		{name: "list configmaps cluster-scoped", req: req{verb: "list", resource: "configmaps"}, want: authorizer.DecisionDeny},
+		{name: "list deployments cluster-scoped", req: req{verb: "list", group: "apps", resource: "deployments"}, want: authorizer.DecisionDeny},
+		{name: "list jobs cluster-scoped", req: req{verb: "list", group: "batch", resource: "jobs"}, want: authorizer.DecisionDeny},
+		{name: "list ingresses cluster-scoped", req: req{verb: "list", group: "networking.k8s.io", resource: "ingresses"}, want: authorizer.DecisionDeny},
+		{name: "list roles cluster-scoped", req: req{verb: "list", group: "rbac.authorization.k8s.io", resource: "roles"}, want: authorizer.DecisionDeny},
+		{name: "list metrics pods cluster-scoped", req: req{verb: "list", group: "metrics.k8s.io", resource: "pods"}, want: authorizer.DecisionDeny},
+		{name: "get nodes", req: req{verb: "get", resource: "nodes"}, want: authorizer.DecisionNoOpinion},
+		{name: "list nodes", req: req{verb: "list", resource: "nodes"}, want: authorizer.DecisionNoOpinion},
+		{name: "list namespaces", req: req{verb: "list", resource: "namespaces"}, want: authorizer.DecisionNoOpinion},
+		{name: "list clusterroles", req: req{verb: "list", group: "rbac.authorization.k8s.io", resource: "clusterroles"}, want: authorizer.DecisionNoOpinion},
+		{name: "list persistentvolumes", req: req{verb: "list", resource: "persistentvolumes"}, want: authorizer.DecisionNoOpinion},
+		{name: "list CRDs", req: req{verb: "list", group: "apiextensions.k8s.io", resource: "customresourcedefinitions"}, want: authorizer.DecisionNoOpinion},
+		{name: "list projects", req: req{verb: "list", group: "deckhouse.io", resource: "projects"}, want: authorizer.DecisionNoOpinion},
+		{name: "list metrics nodes", req: req{verb: "list", group: "metrics.k8s.io", resource: "nodes"}, want: authorizer.DecisionNoOpinion},
+		{name: "get pods in CAR ns", req: req{verb: "get", resource: "pods", ns: "ns-in"}, want: authorizer.DecisionNoOpinion},
+		{name: "list pods in CAR ns", req: req{verb: "list", resource: "pods", ns: "ns-in"}, want: authorizer.DecisionNoOpinion},
+		{name: "create pods in CAR ns", req: req{verb: "create", resource: "pods", ns: "ns-in"}, want: authorizer.DecisionNoOpinion},
+		{name: "delete deployments in CAR ns", req: req{verb: "delete", group: "apps", resource: "deployments", ns: "ns-in"}, want: authorizer.DecisionNoOpinion},
+		{name: "get pods outside CAR ns", req: req{verb: "get", resource: "pods", ns: "ns-out"}, want: authorizer.DecisionDeny},
+		{name: "create secrets outside CAR ns", req: req{verb: "create", resource: "secrets", ns: "ns-out"}, want: authorizer.DecisionDeny},
+		{name: "get pods in kube-system", req: req{verb: "get", resource: "pods", ns: "kube-system"}, want: authorizer.DecisionDeny},
+		{name: "get pods in d8-system", req: req{verb: "get", resource: "pods", ns: "d8-system"}, want: authorizer.DecisionDeny},
+		{name: "unknown GVR cluster-scoped", req: req{verb: "list", group: "example.com", resource: "newcrds"}, want: authorizer.DecisionDeny},
+	}
+
+	for _, tt := range filteredEditor {
+		t.Run("editor/"+tt.name, func(t *testing.T) {
+			got, reason := authorizeAs(t, editor, &mockUserInfo{name: "editor@example.io"}, tt.req.verb, tt.req.group, tt.req.resource, tt.req.ns)
+			assert.Equal(t, tt.want, got, "reason=%q", reason)
+			if tt.want == authorizer.DecisionDeny && tt.req.ns == "" {
+				assert.Equal(t, namespaceLimitedAccessReason, reason)
+			}
+			if tt.want == authorizer.DecisionDeny && tt.req.ns != "" {
+				assert.Equal(t, noNamespaceAccessReason, reason)
+			}
+		})
+		t.Run("super/"+tt.name, func(t *testing.T) {
+			got, reason := authorizeAs(t, super, &mockUserInfo{name: "super@example.io"}, tt.req.verb, tt.req.group, tt.req.resource, tt.req.ns)
+			assert.Equal(t, authorizer.DecisionNoOpinion, got, "SuperAdmin matchAny must never Deny; reason=%q", reason)
+			assert.Empty(t, reason)
+		})
+	}
+
+	t.Run("editor without namespace filters still denies cluster-scoped namespaced list", func(t *testing.T) {
+		got, reason := authorizeAs(t, wide, &mockUserInfo{name: "editor-wide@example.io"}, "list", "", "pods", "")
+		assert.Equal(t, authorizer.DecisionDeny, got)
+		assert.Equal(t, namespaceLimitedAccessReason, reason)
+	})
+	t.Run("editor without namespace filters allows non-system ns and denies kube-system", func(t *testing.T) {
+		got, _ := authorizeAs(t, wide, &mockUserInfo{name: "editor-wide@example.io"}, "get", "", "pods", "ns-out")
+		assert.Equal(t, authorizer.DecisionNoOpinion, got)
+		got, reason := authorizeAs(t, wide, &mockUserInfo{name: "editor-wide@example.io"}, "get", "", "pods", "kube-system")
+		assert.Equal(t, authorizer.DecisionDeny, got)
+		assert.Equal(t, noNamespaceAccessReason, reason)
+	})
+}
+
+// TestEngine_Authorize_LimitNamespacesEqualsLabelSelector locks that the two
+// CAR filter forms produce the same Deny/NoOpinion/reason for the same ns set.
+func TestEngine_Authorize_LimitNamespacesEqualsLabelSelector(t *testing.T) {
+	limited := engineWithNamespaces(t, editorCARConfig, labeledNamespaces()...)
+	selected := engineWithNamespaces(t, editorLabelSelectorCARConfig, labeledNamespaces()...)
+	user := &mockUserInfo{name: "editor@example.io"}
+
+	reqs := []struct {
+		name                      string
+		verb, group, resource, ns string
+		want                      authorizer.Decision
+	}{
+		{name: "list pods", verb: "list", resource: "pods", want: authorizer.DecisionDeny},
+		{name: "list deployments", verb: "list", group: "apps", resource: "deployments", want: authorizer.DecisionDeny},
+		{name: "get nodes", verb: "get", resource: "nodes", want: authorizer.DecisionNoOpinion},
+		{name: "get pods ns-in", verb: "get", resource: "pods", ns: "ns-in", want: authorizer.DecisionNoOpinion},
+		{name: "get pods ns-out", verb: "get", resource: "pods", ns: "ns-out", want: authorizer.DecisionDeny},
+		{name: "get pods kube-system", verb: "get", resource: "pods", ns: "kube-system", want: authorizer.DecisionDeny},
+		{name: "unknown GVR", verb: "list", group: "example.com", resource: "newcrds", want: authorizer.DecisionDeny},
+	}
+
+	for _, tt := range reqs {
+		t.Run(tt.name, func(t *testing.T) {
+			gotL, reasonL := authorizeAs(t, limited, user, tt.verb, tt.group, tt.resource, tt.ns)
+			gotS, reasonS := authorizeAs(t, selected, user, tt.verb, tt.group, tt.resource, tt.ns)
+			assert.Equal(t, tt.want, gotL, "limitNamespaces reason=%q", reasonL)
+			assert.Equal(t, gotL, gotS, "labelSelector diverged: limit=%v (%q) selector=%v (%q)", gotL, reasonL, gotS, reasonS)
+			assert.Equal(t, reasonL, reasonS)
+		})
+	}
+}
+
+func TestEngine_Authorize_WebhookReasonStrings(t *testing.T) {
+	editor := engineWithConsoleScope(t, editorCARConfig)
+	user := &mockUserInfo{name: "editor@example.io"}
+
+	_, reason := authorizeAs(t, editor, user, "list", "", "pods", "")
+	assert.Equal(t, "making cluster-scoped requests for namespaced resources is not allowed", reason)
+
+	_, reason = authorizeAs(t, editor, user, "get", "", "pods", "ns-out")
+	assert.Equal(t, "either you have no access to the namespace or the namespace does not exist", reason)
+
+	_, reason = authorizeAs(t, editor, user, "get", "", "pods", "missing-ns")
+	assert.Equal(t, "either you have no access to the namespace or the namespace does not exist", reason,
+		"a closed namespace must not be distinguishable from a missing one")
+}
+
+func TestEngine_Authorize_GroupSubjectUsesSameFilters(t *testing.T) {
+	e := engineWithConsoleScope(t, editorGroupCARConfig)
+	u := &mockUserInfo{name: "someone@example.io", groups: []string{"editors", "system:authenticated"}}
+
+	got, reason := authorizeAs(t, e, u, "list", "", "pods", "")
+	assert.Equal(t, authorizer.DecisionDeny, got)
+	assert.Equal(t, namespaceLimitedAccessReason, reason)
+
+	got, _ = authorizeAs(t, e, u, "get", "", "pods", "ns-in")
+	assert.Equal(t, authorizer.DecisionNoOpinion, got)
+
+	got, reason = authorizeAs(t, e, u, "get", "", "pods", "ns-out")
+	assert.Equal(t, authorizer.DecisionDeny, got)
+	assert.Equal(t, noNamespaceAccessReason, reason)
+}
+
+func TestEngine_Authorize_SubresourceUsesParentScope(t *testing.T) {
+	editor := engineWithConsoleScope(t, editorCARConfig)
+	user := &mockUserInfo{name: "editor@example.io"}
+
+	decision, reason, err := editor.Authorize(context.Background(), &mockAttrs{
+		userInfo:    user,
+		verb:        "get",
+		resource:    "pods",
+		subresource: "log",
+		isResource:  true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, authorizer.DecisionDeny, decision,
+		"pods/log is still the namespaced pods GVR; reason=%q", reason)
+	assert.Equal(t, namespaceLimitedAccessReason, reason)
+
+	decision, _, err = editor.Authorize(context.Background(), &mockAttrs{
+		userInfo:    user,
+		verb:        "get",
+		resource:    "pods",
+		subresource: "log",
+		namespace:   "ns-in",
+		isResource:  true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, authorizer.DecisionNoOpinion, decision)
+}
+
+func TestEngine_Authorize_NonResourceIsNoOpinion(t *testing.T) {
+	editor := engineWithConsoleScope(t, editorCARConfig)
+	decision, reason, err := editor.Authorize(context.Background(), &mockAttrs{
+		userInfo:   &mockUserInfo{name: "editor@example.io"},
+		verb:       "get",
+		path:       "/healthz",
+		isResource: false,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, authorizer.DecisionNoOpinion, decision)
+	assert.Empty(t, reason)
+}
+
+func TestEngine_Authorize_CARCRBDoesNotSkipFilter(t *testing.T) {
+	editor := engineWithConsoleScope(t, editorCARConfig)
+	editor.SetIndependentRBACChecker(&clusterIndependentChecker{})
+
+	got, reason := authorizeAs(t, editor, &mockUserInfo{name: "editor@example.io"}, "list", "", "pods", "")
+	assert.Equal(t, authorizer.DecisionDeny, got,
+		"AllowsIndependently=false must not rescue a cluster-scoped namespaced list")
+	assert.Equal(t, namespaceLimitedAccessReason, reason)
+}
+
+func TestEngine_GetNamespaceAccessType_PrivilegedDoesNotOverrideCAR(t *testing.T) {
+	editor := engineWithConsoleScope(t, editorCARConfig)
+
+	access, filter := editor.GetNamespaceAccessType(&mockUserInfo{
+		name:   "editor@example.io",
+		groups: []string{"system:masters"},
+	})
+	assert.Equal(t, FilteredAccess, access,
+		"a CAR on the user still filters even when the user is also in system:masters")
+	require.NotNil(t, filter)
+	assert.False(t, editor.IsNamespaceAllowedWithFilter("ns-out", filter))
+
+	access, filter = editor.GetNamespaceAccessType(&mockUserInfo{
+		name:   "nobody@example.io",
+		groups: []string{"system:masters"},
+	})
+	assert.Equal(t, AllNamespacesAllowed, access)
+	assert.Nil(t, filter)
+}
+
+func TestEngine_GetNamespaceAccessType_MatchAnyVsLimited(t *testing.T) {
+	any := engineWithConsoleScope(t, editorMatchAnyCARConfig)
+	limited := engineWithConsoleScope(t, editorCARConfig)
+	superLimited := engineWithConsoleScope(t, superAdminLimitedCARConfig)
+
+	access, filter := any.GetNamespaceAccessType(&mockUserInfo{name: "editor-any@example.io"})
+	assert.Equal(t, AllNamespacesAllowed, access)
+	assert.Nil(t, filter)
+
+	access, filter = limited.GetNamespaceAccessType(&mockUserInfo{name: "editor@example.io"})
+	assert.Equal(t, FilteredAccess, access)
+	require.NotNil(t, filter)
+
+	access, filter = superLimited.GetNamespaceAccessType(&mockUserInfo{name: "super-limited@example.io"})
+	assert.Equal(t, FilteredAccess, access,
+		"SuperAdmin + limitNamespaces is still FilteredAccess")
+	require.NotNil(t, filter)
+	assert.True(t, superLimited.IsNamespaceAllowedWithFilter("ns-in", filter))
+	assert.False(t, superLimited.IsNamespaceAllowedWithFilter("ns-out", filter))
+	assert.False(t, superLimited.IsNamespaceAllowedWithFilter("kube-system", filter),
+		"allowAccessToSystemNamespaces does not add a namespace that is outside limitNamespaces")
+}

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/multitenancy/engine_contract_test.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/multitenancy/engine_contract_test.go
@@ -419,6 +419,182 @@ func TestEngine_GetNamespaceAccessType_PrivilegedDoesNotOverrideCAR(t *testing.T
 	assert.Nil(t, filter)
 }
 
+func TestEngine_Authorize_TwoCARsUnionNamespaces(t *testing.T) {
+	e := engineWithConsoleScope(t, `{
+		"crds": [
+			{
+				"name": "a",
+				"spec": {
+					"limitNamespaces": ["ns-a"],
+					"subjects": [{"kind": "User", "name": "dual@example.io"}]
+				}
+			},
+			{
+				"name": "b",
+				"spec": {
+					"limitNamespaces": ["ns-b"],
+					"subjects": [{"kind": "User", "name": "dual@example.io"}]
+				}
+			}
+		]
+	}`)
+	u := &mockUserInfo{name: "dual@example.io"}
+	got, _ := authorizeAs(t, e, u, "get", "", "pods", "ns-a")
+	assert.Equal(t, authorizer.DecisionNoOpinion, got)
+	got, _ = authorizeAs(t, e, u, "get", "", "pods", "ns-b")
+	assert.Equal(t, authorizer.DecisionNoOpinion, got)
+	got, reason := authorizeAs(t, e, u, "get", "", "pods", "ns-out")
+	assert.Equal(t, authorizer.DecisionDeny, got)
+	assert.Equal(t, noNamespaceAccessReason, reason)
+	got, reason = authorizeAs(t, e, u, "list", "", "pods", "")
+	assert.Equal(t, authorizer.DecisionDeny, got)
+	assert.Equal(t, namespaceLimitedAccessReason, reason)
+}
+
+func TestEngine_Authorize_MatchAnyGroupOverridesUserLimit(t *testing.T) {
+	e := engineWithConsoleScope(t, `{
+		"crds": [
+			{
+				"name": "user-limit",
+				"spec": {
+					"limitNamespaces": ["ns-in"],
+					"subjects": [{"kind": "User", "name": "union@example.io"}]
+				}
+			},
+			{
+				"name": "ops-any",
+				"spec": {
+					"namespaceSelector": {"matchAny": true},
+					"subjects": [{"kind": "Group", "name": "ops"}]
+				}
+			}
+		]
+	}`)
+	userOnly := &mockUserInfo{name: "union@example.io"}
+	got, _ := authorizeAs(t, e, userOnly, "list", "", "pods", "")
+	assert.Equal(t, authorizer.DecisionDeny, got)
+
+	withOps := &mockUserInfo{name: "union@example.io", groups: []string{"ops"}}
+	got, reason := authorizeAs(t, e, withOps, "list", "", "pods", "")
+	assert.Equal(t, authorizer.DecisionNoOpinion, got, "reason=%q", reason)
+	got, _ = authorizeAs(t, e, withOps, "get", "", "pods", "kube-system")
+	assert.Equal(t, authorizer.DecisionNoOpinion, got)
+}
+
+func TestEngine_Authorize_SelectorIgnoresSiblingLimitNamespaces(t *testing.T) {
+	e := engineWithNamespaces(t, `{
+		"crds": [{
+			"name": "both",
+			"spec": {
+				"limitNamespaces": ["ns-out"],
+				"namespaceSelector": {"labelSelector": {"matchLabels": {"pba-perf": "true"}}},
+				"subjects": [{"kind": "User", "name": "editor@example.io"}]
+			}
+		}]
+	}`, labeledNamespaces()...)
+	u := &mockUserInfo{name: "editor@example.io"}
+	got, _ := authorizeAs(t, e, u, "get", "", "pods", "ns-in")
+	assert.Equal(t, authorizer.DecisionNoOpinion, got)
+	got, _ = authorizeAs(t, e, u, "get", "", "pods", "ns-out")
+	assert.Equal(t, authorizer.DecisionDeny, got,
+		"limitNamespaces must be ignored when the same CAR sets namespaceSelector")
+}
+
+func TestEngine_Authorize_LimitNamespacesRegex(t *testing.T) {
+	e := engineWithConsoleScope(t, `{
+		"crds": [{
+			"name": "re",
+			"spec": {
+				"limitNamespaces": ["app-.*"],
+				"subjects": [{"kind": "User", "name": "regex@example.io"}]
+			}
+		}]
+	}`)
+	u := &mockUserInfo{name: "regex@example.io"}
+	got, _ := authorizeAs(t, e, u, "get", "", "pods", "app-prod")
+	assert.Equal(t, authorizer.DecisionNoOpinion, got)
+	got, _ = authorizeAs(t, e, u, "get", "", "pods", "ns-in")
+	assert.Equal(t, authorizer.DecisionDeny, got)
+}
+
+func TestEngine_Authorize_MatchExpressionsEqualsMatchLabels(t *testing.T) {
+	labelsEngine := engineWithNamespaces(t, editorLabelSelectorCARConfig, labeledNamespaces()...)
+	exprEngine := engineWithNamespaces(t, `{
+		"crds": [{
+			"name": "editor-expr",
+			"spec": {
+				"accessLevel": "Editor",
+				"namespaceSelector": {"labelSelector": {"matchExpressions": [{"key": "pba-perf", "operator": "In", "values": ["true"]}]}},
+				"subjects": [{"kind": "User", "name": "editor@example.io"}]
+			}
+		}]
+	}`, labeledNamespaces()...)
+	u := &mockUserInfo{name: "editor@example.io"}
+	for _, ns := range []string{"ns-in", "ns-out", "kube-system"} {
+		gotL, reasonL := authorizeAs(t, labelsEngine, u, "get", "", "pods", ns)
+		gotE, reasonE := authorizeAs(t, exprEngine, u, "get", "", "pods", ns)
+		assert.Equal(t, gotL, gotE, "ns=%s", ns)
+		assert.Equal(t, reasonL, reasonE, "ns=%s", ns)
+	}
+}
+
+func TestEngine_Authorize_SystemNamespaceSet(t *testing.T) {
+	editor := engineWithConsoleScope(t, editorCARConfig)
+	u := &mockUserInfo{name: "editor@example.io"}
+	for _, ns := range []string{"default", "kube-system", "kube-public", "d8-system", "d8-monitoring"} {
+		got, reason := authorizeAs(t, editor, u, "get", "", "pods", ns)
+		assert.Equal(t, authorizer.DecisionDeny, got, "ns=%s", ns)
+		assert.Equal(t, noNamespaceAccessReason, reason, "ns=%s", ns)
+	}
+}
+
+func TestEngine_Authorize_LimitDefaultStillDeniedWithoutSystemAccess(t *testing.T) {
+	e := engineWithConsoleScope(t, `{
+		"crds": [{
+			"name": "def",
+			"spec": {
+				"limitNamespaces": ["default"],
+				"subjects": [{"kind": "User", "name": "def@example.io"}]
+			}
+		}]
+	}`)
+	got, reason := authorizeAs(t, e, &mockUserInfo{name: "def@example.io"}, "get", "", "pods", "default")
+	assert.Equal(t, authorizer.DecisionDeny, got)
+	assert.Equal(t, noNamespaceAccessReason, reason,
+		"listing default in limitNamespaces does not grant a system namespace")
+}
+
+func TestEngine_Authorize_MatchAnyWithoutSystemAccessIsNoOpinion(t *testing.T) {
+	e := engineWithConsoleScope(t, `{
+		"crds": [{
+			"name": "any",
+			"spec": {
+				"accessLevel": "Editor",
+				"namespaceSelector": {"matchAny": true},
+				"subjects": [{"kind": "User", "name": "any@example.io"}]
+			}
+		}]
+	}`)
+	u := &mockUserInfo{name: "any@example.io"}
+	got, _ := authorizeAs(t, e, u, "list", "", "pods", "")
+	assert.Equal(t, authorizer.DecisionNoOpinion, got)
+	got, _ = authorizeAs(t, e, u, "get", "", "pods", "kube-system")
+	assert.Equal(t, authorizer.DecisionNoOpinion, got,
+		"MatchAny short-circuits hasAnyFilters even without allowAccessToSystemNamespaces")
+}
+
+func TestEngine_Authorize_VerbsDoNotChangeClusterScopedFilter(t *testing.T) {
+	editor := engineWithConsoleScope(t, editorCARConfig)
+	u := &mockUserInfo{name: "editor@example.io"}
+	for _, verb := range []string{"get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"} {
+		got, reason := authorizeAs(t, editor, u, verb, "", "pods", "")
+		assert.Equal(t, authorizer.DecisionDeny, got, "verb=%s", verb)
+		assert.Equal(t, namespaceLimitedAccessReason, reason, "verb=%s", verb)
+		got, _ = authorizeAs(t, editor, u, verb, "", "nodes", "")
+		assert.Equal(t, authorizer.DecisionNoOpinion, got, "verb=%s nodes", verb)
+	}
+}
+
 func TestEngine_GetNamespaceAccessType_MatchAnyVsLimited(t *testing.T) {
 	any := engineWithConsoleScope(t, editorMatchAnyCARConfig)
 	limited := engineWithConsoleScope(t, editorCARConfig)

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/multitenancy/engine_test.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/multitenancy/engine_test.go
@@ -829,6 +829,96 @@ func TestEngine_RenewDirectories_InvalidRegexPreservesPreviousDirectory(t *testi
 	assert.Empty(t, e.affectedDirs("bob", nil))
 }
 
+// TestEngine_RenewDirectories_MalformedSelectorStaysLocal locks that an
+// uncompilable namespaceSelector costs only the rule that carries it.
+// Precompiling selectors must not turn one bad CAR into a cluster-wide loss
+// of multi-tenancy: an aborted reload leaves the directory empty, and an
+// empty directory means Authorize returns NoOpinion for everyone.
+func TestEngine_RenewDirectories_MalformedSelectorStaysLocal(t *testing.T) {
+	path := writeConfigJSON(t, `{
+		"crds": [
+			{
+				"name": "broken",
+				"spec": {
+					"namespaceSelector": {"labelSelector": {"matchExpressions": [{"key": "team", "operator": "Exists", "values": ["nope"]}]}},
+					"subjects": [{"kind": "User", "name": "bob"}]
+				}
+			},
+			{
+				"name": "healthy",
+				"spec": {
+					"limitNamespaces": ["team-a"],
+					"subjects": [{"kind": "User", "name": "alice"}]
+				}
+			}
+		]
+	}`)
+	e := &Engine{
+		configPath: path,
+		directory:  map[string]map[string]DirectoryEntry{},
+	}
+
+	e.renewDirectories()
+
+	require.Len(t, e.affectedDirs("alice", nil), 1, "a healthy CAR must survive a broken sibling")
+
+	entries := e.affectedDirs("bob", nil)
+	require.Len(t, entries, 1)
+	require.Len(t, entries[0].NamespaceSelectors, 1)
+	assert.Nil(t, entries[0].compiledSelectors[0],
+		"the malformed selector is left uncompiled and index-aligned, not dropped")
+}
+
+// TestEngine_Authorize_MalformedSelectorDeniesOnlyItsSubject is the Authorize
+// view of the same config: alice keeps her filter and bob, whose only rule
+// cannot be evaluated, is denied rather than waved through.
+func TestEngine_Authorize_MalformedSelectorDeniesOnlyItsSubject(t *testing.T) {
+	e, err := NewEngine(writeConfigJSON(t, `{
+		"crds": [
+			{
+				"name": "broken",
+				"spec": {
+					"namespaceSelector": {"labelSelector": {"matchExpressions": [{"key": "team", "operator": "Exists", "values": ["nope"]}]}},
+					"subjects": [{"kind": "User", "name": "bob"}]
+				}
+			},
+			{
+				"name": "healthy",
+				"spec": {
+					"limitNamespaces": ["team-a"],
+					"subjects": [{"kind": "User", "name": "alice"}]
+				}
+			}
+		]
+	}`), nil, nil, nil)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name string
+		user string
+		ns   string
+		want authorizer.Decision
+	}{
+		{name: "alice inside her limitNamespaces", user: "alice", ns: "team-a", want: authorizer.DecisionNoOpinion},
+		{name: "alice outside her limitNamespaces", user: "alice", ns: "team-b", want: authorizer.DecisionDeny},
+		{name: "bob under the malformed selector", user: "bob", ns: "team-a", want: authorizer.DecisionDeny},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			decision, _, err := e.Authorize(context.Background(), &mockAttrs{
+				userInfo:   &mockUserInfo{name: tt.user},
+				verb:       "get",
+				resource:   "pods",
+				namespace:  tt.ns,
+				isResource: true,
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, decision)
+		})
+	}
+}
+
 // fakeIndependentChecker simulates the CAR-independent RBAC check: it grants
 // requests only in the listed namespaces (e.g. as an AR's RoleBinding or a
 // plain RoleBinding would).

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/multitenancy/race_test.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/multitenancy/race_test.go
@@ -152,17 +152,27 @@ func TestEngine_ConcurrentDirectoryUpdate(t *testing.T) {
 	wg.Wait()
 }
 
-// TestEngine_ConcurrentNamespacedCacheAccess tests that namespaced cache access doesn't race
-func TestEngine_ConcurrentNamespacedCacheAccess(t *testing.T) {
+// TestEngine_ConcurrentClusterScopedAuthorize exercises cluster-scoped
+// Authorize against a shared ResourceScope from many goroutines.
+func TestEngine_ConcurrentClusterScopedAuthorize(t *testing.T) {
 	e := &Engine{
 		directory: map[string]map[string]DirectoryEntry{
-			"User":           {},
+			"User": {
+				"restricted": {
+					LimitNamespaces:        []*regexp.Regexp{regexp.MustCompile("^allowed-.*$")},
+					NamespaceFiltersAbsent: false,
+				},
+			},
 			"Group":          {},
 			"ServiceAccount": {},
 		},
-		namespacedCache: make(map[string]bool),
+		resourceScope: staticResourceScope{
+			"/pods":  true,
+			"/nodes": false,
+		},
 	}
 
+	ctx := context.Background()
 	const goroutines = 100
 	const iterations = 100
 
@@ -174,19 +184,20 @@ func TestEngine_ConcurrentNamespacedCacheAccess(t *testing.T) {
 			defer wg.Done()
 
 			for j := 0; j < iterations; j++ {
-				cacheKey := "apps/v1/deployments"
-
-				// Read
-				e.namespacedCacheMu.RLock()
-				_ = e.namespacedCache[cacheKey]
-				e.namespacedCacheMu.RUnlock()
-
-				// Write (every 10th iteration)
-				if j%10 == 0 {
-					e.namespacedCacheMu.Lock()
-					e.namespacedCache[cacheKey] = true
-					e.namespacedCacheMu.Unlock()
+				resource := "pods"
+				if id%2 == 0 {
+					resource = "nodes"
 				}
+
+				attrs := &mockAttrs{
+					userInfo:   &mockUserInfo{name: "restricted"},
+					resource:   resource,
+					verb:       "list",
+					isResource: true,
+				}
+
+				_, _, err := e.Authorize(ctx, attrs)
+				require.NoError(t, err)
 			}
 		}(i)
 	}

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/multitenancy/types.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/multitenancy/types.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 // NamespaceAccessType represents the result of namespace access evaluation.
@@ -28,6 +29,11 @@ type DirectoryEntry struct {
 	AllowAccessToSystemNamespaces bool
 	LimitNamespaces               []*regexp.Regexp
 	NamespaceSelectors            []*NamespaceSelector
+	// compiledSelectors are LabelSelectorAsSelector results from
+	// NamespaceSelectors, built once in renewDirectories. Tests that construct
+	// a DirectoryEntry by hand may leave this nil; the matcher then compiles
+	// on the fly.
+	compiledSelectors []labels.Selector
 	// If there is no LimitNamespaces nor NamespaceSelectors options, the user has access to all namespaces except system namespaces.
 	// If LimitNamespaces is present, we do not need to mind about allowed access to system namespaces.
 	// Thus presence of LimitNamespaces matters when we summarise rules from all CRs to get the allowed namespaces.

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/multitenancy/types.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/multitenancy/types.go
@@ -30,9 +30,11 @@ type DirectoryEntry struct {
 	LimitNamespaces               []*regexp.Regexp
 	NamespaceSelectors            []*NamespaceSelector
 	// compiledSelectors are LabelSelectorAsSelector results from
-	// NamespaceSelectors, built once in renewDirectories. Tests that construct
-	// a DirectoryEntry by hand may leave this nil; the matcher then compiles
-	// on the fly.
+	// NamespaceSelectors, built once in renewDirectories and index-aligned
+	// with it. A nil element means the selector carries no LabelSelector or
+	// failed to compile; the matcher then falls back to compiling that one
+	// entry on the fly, which keeps a malformed rule local to itself. Callers
+	// that build a DirectoryEntry by hand may leave the whole slice nil.
 	compiledSelectors []labels.Selector
 	// If there is no LimitNamespaces nor NamespaceSelectors options, the user has access to all namespaces except system namespaces.
 	// If LimitNamespaces is present, we do not need to mind about allowed access to system namespaces.

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/rbacadapter/rbac.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/rbacadapter/rbac.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 
 	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/client-go/informers"
 	rbaclisters "k8s.io/client-go/listers/rbac/v1"
@@ -62,26 +61,14 @@ func NewRBACAuthorizer(informerFactory informers.SharedInformerFactory) *RBACAut
 
 // Authorize implements authorizer.Authorizer
 func (r *RBACAuthorizer) Authorize(ctx context.Context, attrs authorizer.Attributes) (authorizer.Decision, string, error) {
-	user := attrs.GetUser()
-	if user == nil {
+	u := attrs.GetUser()
+	if u == nil {
 		return authorizer.DecisionNoOpinion, "", nil
 	}
 
-	userName := user.GetName()
-	userGroups := user.GetGroups()
-
-	// Check ClusterRoleBindings for cluster-scoped or namespaced requests
-	if allowed, reason := r.checkClusterRoleBindings(attrs, userName, userGroups); allowed {
-		klog.V(5).Infof("RBAC: allowed by ClusterRoleBinding: %s", reason)
+	if allowed, reason := r.rulesFor(ctx, u).allows(attrs, false); allowed {
+		klog.V(5).Infof("RBAC: allowed: %s", reason)
 		return authorizer.DecisionAllow, reason, nil
-	}
-
-	// Check RoleBindings for namespaced requests
-	if attrs.GetNamespace() != "" {
-		if allowed, reason := r.checkRoleBindings(attrs, userName, userGroups); allowed {
-			klog.V(5).Infof("RBAC: allowed by RoleBinding: %s", reason)
-			return authorizer.DecisionAllow, reason, nil
-		}
 	}
 
 	return authorizer.DecisionNoOpinion, "", nil
@@ -96,104 +83,14 @@ func (r *RBACAuthorizer) Authorize(ctx context.Context, attrs authorizer.Attribu
 // RBAC explicitly grants, while still denying access that would only be
 // possible through a CAR-generated cluster-wide binding outside the CAR's
 // limitNamespaces scope.
-func (r *RBACAuthorizer) AllowsIndependently(_ context.Context, attrs authorizer.Attributes) bool {
-	user := attrs.GetUser()
-	if user == nil {
+func (r *RBACAuthorizer) AllowsIndependently(ctx context.Context, attrs authorizer.Attributes) bool {
+	u := attrs.GetUser()
+	if u == nil {
 		return false
 	}
 
-	userName := user.GetName()
-	userGroups := user.GetGroups()
-
-	if allowed, _ := r.checkClusterRoleBindingsFiltered(attrs, userName, userGroups, true); allowed {
-		return true
-	}
-
-	if attrs.GetNamespace() != "" {
-		if allowed, _ := r.checkRoleBindings(attrs, userName, userGroups); allowed {
-			return true
-		}
-	}
-
-	return false
-}
-
-// checkClusterRoleBindings checks if the user has access via ClusterRoleBindings
-func (r *RBACAuthorizer) checkClusterRoleBindings(attrs authorizer.Attributes, userName string, userGroups []string) (bool, string) {
-	return r.checkClusterRoleBindingsFiltered(attrs, userName, userGroups, false)
-}
-
-// checkClusterRoleBindingsFiltered checks ClusterRoleBindings, optionally
-// skipping CAR-generated bindings (see IsCARManagedClusterRoleBinding).
-func (r *RBACAuthorizer) checkClusterRoleBindingsFiltered(attrs authorizer.Attributes, userName string, userGroups []string, skipCARManaged bool) (bool, string) {
-	bindings, err := r.clusterRoleBindingLister.List(labels.Everything())
-	if err != nil {
-		klog.Errorf("Failed to list ClusterRoleBindings: %v", err)
-		return false, ""
-	}
-
-	for _, binding := range bindings {
-		if skipCARManaged && IsCARManagedClusterRoleBinding(binding) {
-			continue
-		}
-		if !r.subjectMatches(binding.Subjects, userName, userGroups, "") {
-			continue
-		}
-
-		// Get the ClusterRole
-		role, err := r.clusterRoleLister.Get(binding.RoleRef.Name)
-		if err != nil {
-			klog.V(5).Infof("Failed to get ClusterRole %s: %v", binding.RoleRef.Name, err)
-			continue
-		}
-
-		if r.ruleAllows(role.Rules, attrs) {
-			return true, fmt.Sprintf("RBAC: allowed by ClusterRoleBinding %q of ClusterRole %q to user %q",
-				binding.Name, role.Name, userName)
-		}
-	}
-
-	return false, ""
-}
-
-// checkRoleBindings checks if the user has access via RoleBindings in the namespace
-func (r *RBACAuthorizer) checkRoleBindings(attrs authorizer.Attributes, userName string, userGroups []string) (bool, string) {
-	namespace := attrs.GetNamespace()
-	bindings, err := r.roleBindingLister.RoleBindings(namespace).List(labels.Everything())
-	if err != nil {
-		klog.Errorf("Failed to list RoleBindings in namespace %s: %v", namespace, err)
-		return false, ""
-	}
-
-	for _, binding := range bindings {
-		if !r.subjectMatches(binding.Subjects, userName, userGroups, namespace) {
-			continue
-		}
-
-		var rules []rbacv1.PolicyRule
-		if binding.RoleRef.Kind == "ClusterRole" {
-			role, err := r.clusterRoleLister.Get(binding.RoleRef.Name)
-			if err != nil {
-				klog.V(5).Infof("Failed to get ClusterRole %s: %v", binding.RoleRef.Name, err)
-				continue
-			}
-			rules = role.Rules
-		} else {
-			role, err := r.roleLister.Roles(namespace).Get(binding.RoleRef.Name)
-			if err != nil {
-				klog.V(5).Infof("Failed to get Role %s/%s: %v", namespace, binding.RoleRef.Name, err)
-				continue
-			}
-			rules = role.Rules
-		}
-
-		if r.ruleAllows(rules, attrs) {
-			return true, fmt.Sprintf("RBAC: allowed by RoleBinding %q of %s %q to user %q",
-				binding.Name, binding.RoleRef.Kind, binding.RoleRef.Name, userName)
-		}
-	}
-
-	return false, ""
+	allowed, _ := r.rulesFor(ctx, u).allows(attrs, true)
+	return allowed
 }
 
 // subjectMatches checks if any subject in the list matches the user

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/rbacadapter/rbac_bench_test.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/rbacadapter/rbac_bench_test.go
@@ -1,3 +1,8 @@
+/*
+Copyright 2026 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
 package rbacadapter
 
 import (

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/rbacadapter/rbac_bench_test.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/rbacadapter/rbac_bench_test.go
@@ -1,0 +1,160 @@
+package rbacadapter
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+const (
+	benchChecks      = 258
+	benchNoiseCRBs   = 940
+	benchClusterCRBs = 53
+)
+
+var benchResources = []struct {
+	group    string
+	resource string
+	verb     string
+}{
+	{"deckhouse.io", "modules", "list"},
+	{"deckhouse.io", "moduleconfigs", "watch"},
+	{"", "namespaces", "list"},
+	{"", "nodes", "watch"},
+	{"rbac.authorization.k8s.io", "clusterroles", "list"},
+	{"cert-manager.io", "clusterissuers", "watch"},
+	{"network.deckhouse.io", "egressgateways", "list"},
+	{"observability.deckhouse.io", "clusterobservabilitydashboards", "watch"},
+}
+
+func benchAuthorizer(b *testing.B, objs ...runtime.Object) *RBACAuthorizer {
+	b.Helper()
+	client := fake.NewSimpleClientset(objs...)
+	factory := informers.NewSharedInformerFactory(client, 0)
+	auth := NewRBACAuthorizer(factory)
+	stop := make(chan struct{})
+	b.Cleanup(func() { close(stop) })
+	factory.Start(stop)
+	factory.WaitForCacheSync(stop)
+	return auth
+}
+
+func carLabels() map[string]string {
+	return map[string]string{"heritage": "deckhouse", "module": "user-authz"}
+}
+
+func wildcardClusterRole(name string) *rbacv1.ClusterRole {
+	return &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Rules: []rbacv1.PolicyRule{
+			{APIGroups: []string{"*"}, Resources: []string{"*"}, Verbs: []string{"*"}},
+			{NonResourceURLs: []string{"*"}, Verbs: []string{"*"}},
+		},
+	}
+}
+
+func granularClusterRole(name string, n int) *rbacv1.ClusterRole {
+	rules := make([]rbacv1.PolicyRule, 0, n)
+	for i := 0; i < n; i++ {
+		rules = append(rules, rbacv1.PolicyRule{
+			APIGroups: []string{fmt.Sprintf("mod%d.deckhouse.io", i%7)},
+			Resources: []string{fmt.Sprintf("things%d", i), fmt.Sprintf("widgets%d", i)},
+			Verbs:     []string{"get", "list", "watch", "update"},
+		})
+	}
+	return &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: name}, Rules: rules}
+}
+
+func bind(name, role, userName string, car bool) *rbacv1.ClusterRoleBinding {
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Subjects:   []rbacv1.Subject{{Kind: rbacv1.UserKind, Name: userName}},
+		RoleRef:    rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: role},
+	}
+	if car {
+		crb.Labels = carLabels()
+	}
+	return crb
+}
+
+func noiseBindings(n int) []runtime.Object {
+	objs := make([]runtime.Object, 0, n*2)
+	for i := 0; i < n; i++ {
+		roleName := fmt.Sprintf("noise-role-%d", i)
+		objs = append(objs, granularClusterRole(roleName, 8))
+		objs = append(objs, bind(fmt.Sprintf("user-authz:noise-%d:cluster-admin", i), roleName, fmt.Sprintf("noise-%d@example.io", i), true))
+	}
+	return objs
+}
+
+func superAdminWorld() []runtime.Object {
+	objs := []runtime.Object{
+		wildcardClusterRole("user-authz:super-admin"),
+		bind("user-authz:super-admin:super-admin", "user-authz:super-admin", "super-admin@example.io", true),
+	}
+	return append(objs, noiseBindings(benchNoiseCRBs)...)
+}
+
+func clusterAdminWorld() []runtime.Object {
+	objs := []runtime.Object{
+		granularClusterRole("user-authz:cluster-admin", 45),
+		bind("user-authz:cluster-admin:cluster-admin", "user-authz:cluster-admin", "cluster-admin@example.io", true),
+	}
+	for i := 1; i < benchClusterCRBs; i++ {
+		roleName := fmt.Sprintf("d8:user-authz:module%d:cluster-admin", i)
+		objs = append(objs, granularClusterRole(roleName, 12))
+		objs = append(objs, bind(
+			fmt.Sprintf("user-authz:cluster-admin:custom-%d", i),
+			roleName,
+			"cluster-admin@example.io",
+			true,
+		))
+	}
+	return append(objs, noiseBindings(benchNoiseCRBs)...)
+}
+
+func runBulk(b *testing.B, auth *RBACAuthorizer, userName string) {
+	b.Helper()
+	u := &user.DefaultInfo{Name: userName}
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		for i := 0; i < benchChecks; i++ {
+			item := benchResources[i%len(benchResources)]
+			attrs := &mockAttrs{
+				user:       u,
+				verb:       item.verb,
+				resource:   item.resource,
+				apiGroup:   item.group,
+				isResource: true,
+			}
+			_, _, err := auth.Authorize(ctx, attrs)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+}
+
+func BenchmarkAuthorize_SuperAdmin_258(b *testing.B) {
+	auth := benchAuthorizer(b, superAdminWorld()...)
+	runBulk(b, auth, "super-admin@example.io")
+}
+
+func BenchmarkAuthorize_ClusterAdmin_258(b *testing.B) {
+	auth := benchAuthorizer(b, clusterAdminWorld()...)
+	runBulk(b, auth, "cluster-admin@example.io")
+}
+
+func BenchmarkAuthorize_Nobody_258(b *testing.B) {
+	auth := benchAuthorizer(b, clusterAdminWorld()...)
+	runBulk(b, auth, "nobody@example.io")
+}

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/rbacadapter/rbac_bench_test.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/rbacadapter/rbac_bench_test.go
@@ -141,7 +141,6 @@ func runBulkCtx(b *testing.B, auth *RBACAuthorizer, userName string, bind bool) 
 		ctx = auth.BindSubject(ctx, u)
 	}
 	b.ReportAllocs()
-	b.ResetTimer()
 	for b.Loop() {
 		for i := 0; i < benchChecks; i++ {
 			item := benchResources[i%len(benchResources)]

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/rbacadapter/rbac_bench_test.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/rbacadapter/rbac_bench_test.go
@@ -121,9 +121,20 @@ func clusterAdminWorld() []runtime.Object {
 }
 
 func runBulk(b *testing.B, auth *RBACAuthorizer, userName string) {
+	runBulkCtx(b, auth, userName, false)
+}
+
+func runBulkBound(b *testing.B, auth *RBACAuthorizer, userName string) {
+	runBulkCtx(b, auth, userName, true)
+}
+
+func runBulkCtx(b *testing.B, auth *RBACAuthorizer, userName string, bind bool) {
 	b.Helper()
 	u := &user.DefaultInfo{Name: userName}
 	ctx := context.Background()
+	if bind {
+		ctx = auth.BindSubject(ctx, u)
+	}
 	b.ReportAllocs()
 	b.ResetTimer()
 	for b.Loop() {
@@ -157,4 +168,32 @@ func BenchmarkAuthorize_ClusterAdmin_258(b *testing.B) {
 func BenchmarkAuthorize_Nobody_258(b *testing.B) {
 	auth := benchAuthorizer(b, clusterAdminWorld()...)
 	runBulk(b, auth, "nobody@example.io")
+}
+
+func BenchmarkAuthorize_SuperAdmin_258_Bound(b *testing.B) {
+	auth := benchAuthorizer(b, superAdminWorld()...)
+	runBulkBound(b, auth, "super-admin@example.io")
+}
+
+func BenchmarkAuthorize_ClusterAdmin_258_Bound(b *testing.B) {
+	auth := benchAuthorizer(b, clusterAdminWorld()...)
+	runBulkBound(b, auth, "cluster-admin@example.io")
+}
+
+func editorWorld() []runtime.Object {
+	objs := []runtime.Object{
+		granularClusterRole("user-authz:editor", 45),
+		bind("user-authz:editor:editor", "user-authz:editor", "editor@example.io", true),
+	}
+	return append(objs, noiseBindings(benchNoiseCRBs)...)
+}
+
+func BenchmarkAuthorize_Editor_258(b *testing.B) {
+	auth := benchAuthorizer(b, editorWorld()...)
+	runBulk(b, auth, "editor@example.io")
+}
+
+func BenchmarkAuthorize_Editor_258_Bound(b *testing.B) {
+	auth := benchAuthorizer(b, editorWorld()...)
+	runBulkBound(b, auth, "editor@example.io")
 }

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/rbacadapter/snapshot.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/rbacadapter/snapshot.go
@@ -1,0 +1,186 @@
+/*
+Copyright 2026 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package rbacadapter
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/klog/v2"
+)
+
+type subjectRulesKey struct{}
+
+// BindSubject attaches a one-request snapshot of u's RBAC rules to ctx.
+// Authorize and AllowsIndependently reuse it instead of listing
+// ClusterRoleBindings again. Do not bind the review subject before a
+// non-self gate that authorizes the caller.
+func (r *RBACAuthorizer) BindSubject(ctx context.Context, u user.Info) context.Context {
+	if u == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, subjectRulesKey{}, r.Snapshot(u))
+}
+
+func subjectRulesFrom(ctx context.Context) *SubjectRules {
+	s, _ := ctx.Value(subjectRulesKey{}).(*SubjectRules)
+	return s
+}
+
+type boundRuleSet struct {
+	rules  []rbacv1.PolicyRule
+	reason string
+}
+
+// SubjectRules is a per-request snapshot of the ClusterRoleBindings that
+// match a subject, plus a lazy per-namespace RoleBinding cache. It is not
+// shared across HTTP requests.
+type SubjectRules struct {
+	userName   string
+	userGroups []string
+	authorizer *RBACAuthorizer
+
+	cluster            []boundRuleSet
+	independentCluster []boundRuleSet
+
+	nsMu    sync.Mutex
+	nsRules map[string][]boundRuleSet
+}
+
+// Snapshot walks ClusterRoleBindings once and records two rule sets: every
+// matching binding, and the subset that is not CAR-managed (for
+// AllowsIndependently). RoleBindings are loaded later, per namespace.
+func (r *RBACAuthorizer) Snapshot(u user.Info) *SubjectRules {
+	s := &SubjectRules{
+		userName:   u.GetName(),
+		userGroups: u.GetGroups(),
+		authorizer: r,
+		nsRules:    make(map[string][]boundRuleSet),
+	}
+	if r.clusterRoleBindingLister == nil {
+		return s
+	}
+
+	bindings, err := r.clusterRoleBindingLister.List(labels.Everything())
+	if err != nil {
+		klog.Errorf("Failed to list ClusterRoleBindings: %v", err)
+		return s
+	}
+
+	for _, binding := range bindings {
+		if !r.subjectMatches(binding.Subjects, s.userName, s.userGroups, "") {
+			continue
+		}
+
+		role, err := r.clusterRoleLister.Get(binding.RoleRef.Name)
+		if err != nil {
+			klog.V(5).Infof("Failed to get ClusterRole %s: %v", binding.RoleRef.Name, err)
+			continue
+		}
+
+		set := boundRuleSet{
+			rules: role.Rules,
+			reason: fmt.Sprintf("RBAC: allowed by ClusterRoleBinding %q of ClusterRole %q to user %q",
+				binding.Name, role.Name, s.userName),
+		}
+		s.cluster = append(s.cluster, set)
+		if !IsCARManagedClusterRoleBinding(binding) {
+			s.independentCluster = append(s.independentCluster, set)
+		}
+	}
+
+	return s
+}
+
+func (r *RBACAuthorizer) rulesFor(ctx context.Context, u user.Info) *SubjectRules {
+	if s := subjectRulesFrom(ctx); s != nil && s.userName == u.GetName() {
+		return s
+	}
+	return r.Snapshot(u)
+}
+
+func (s *SubjectRules) allows(attrs authorizer.Attributes, independent bool) (bool, string) {
+	sets := s.cluster
+	if independent {
+		sets = s.independentCluster
+	}
+	for _, set := range sets {
+		if s.authorizer.ruleAllows(set.rules, attrs) {
+			return true, set.reason
+		}
+	}
+
+	namespace := attrs.GetNamespace()
+	if namespace == "" {
+		return false, ""
+	}
+	for _, set := range s.namespaceRules(namespace) {
+		if s.authorizer.ruleAllows(set.rules, attrs) {
+			return true, set.reason
+		}
+	}
+	return false, ""
+}
+
+func (s *SubjectRules) namespaceRules(namespace string) []boundRuleSet {
+	s.nsMu.Lock()
+	defer s.nsMu.Unlock()
+
+	if rules, ok := s.nsRules[namespace]; ok {
+		return rules
+	}
+	rules := s.authorizer.loadRoleBindingRules(namespace, s.userName, s.userGroups)
+	s.nsRules[namespace] = rules
+	return rules
+}
+
+func (r *RBACAuthorizer) loadRoleBindingRules(namespace, userName string, userGroups []string) []boundRuleSet {
+	if r.roleBindingLister == nil {
+		return nil
+	}
+
+	bindings, err := r.roleBindingLister.RoleBindings(namespace).List(labels.Everything())
+	if err != nil {
+		klog.Errorf("Failed to list RoleBindings in namespace %s: %v", namespace, err)
+		return nil
+	}
+
+	var out []boundRuleSet
+	for _, binding := range bindings {
+		if !r.subjectMatches(binding.Subjects, userName, userGroups, namespace) {
+			continue
+		}
+
+		var rules []rbacv1.PolicyRule
+		if binding.RoleRef.Kind == "ClusterRole" {
+			role, err := r.clusterRoleLister.Get(binding.RoleRef.Name)
+			if err != nil {
+				klog.V(5).Infof("Failed to get ClusterRole %s: %v", binding.RoleRef.Name, err)
+				continue
+			}
+			rules = role.Rules
+		} else {
+			role, err := r.roleLister.Roles(namespace).Get(binding.RoleRef.Name)
+			if err != nil {
+				klog.V(5).Infof("Failed to get Role %s/%s: %v", namespace, binding.RoleRef.Name, err)
+				continue
+			}
+			rules = role.Rules
+		}
+
+		out = append(out, boundRuleSet{
+			rules: rules,
+			reason: fmt.Sprintf("RBAC: allowed by RoleBinding %q of %s %q to user %q",
+				binding.Name, binding.RoleRef.Kind, binding.RoleRef.Name, userName),
+		})
+	}
+	return out
+}

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/rbacadapter/snapshot.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/rbacadapter/snapshot.go
@@ -8,6 +8,7 @@ package rbacadapter
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sync"
 
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -101,10 +102,18 @@ func (r *RBACAuthorizer) Snapshot(u user.Info) *SubjectRules {
 }
 
 func (r *RBACAuthorizer) rulesFor(ctx context.Context, u user.Info) *SubjectRules {
-	if s := subjectRulesFrom(ctx); s != nil && s.userName == u.GetName() {
+	if s := subjectRulesFrom(ctx); s != nil && s.matches(u) {
 		return s
 	}
 	return r.Snapshot(u)
+}
+
+// matches reports whether the snapshot was taken for exactly this subject.
+// Groups participate: two subjects can share a name and still resolve to
+// different bindings, and answering one from the other's snapshot would
+// report an access level the subject does not have.
+func (s *SubjectRules) matches(u user.Info) bool {
+	return s.userName == u.GetName() && slices.Equal(s.userGroups, u.GetGroups())
 }
 
 func (s *SubjectRules) allows(attrs authorizer.Attributes, independent bool) (bool, string) {

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/rbacadapter/snapshot_test.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/rbacadapter/snapshot_test.go
@@ -146,6 +146,36 @@ func TestBindSubject_IgnoresNilUser(t *testing.T) {
 	assert.Equal(t, ctx, auth.BindSubject(ctx, nil))
 }
 
+// TestSnapshot_NotReusedAcrossGroups guards the snapshot identity check. A
+// name alone does not identify a subject: bindings resolve through groups
+// too, so answering a differently-grouped subject from a bound snapshot would
+// report an access level that subject does not have.
+func TestSnapshot_NotReusedAcrossGroups(t *testing.T) {
+	auth := newTestRBACAuthorizer(t, append(snapshotWorld(),
+		&rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "viewers-secret-viewer"},
+			Subjects:   []rbacv1.Subject{{Kind: rbacv1.GroupKind, Name: "viewers"}},
+			RoleRef:    rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "ClusterRole", Name: "secret-viewer"},
+		},
+	)...)
+
+	plain := &user.DefaultInfo{Name: "carol"}
+	viewer := &user.DefaultInfo{Name: "carol", Groups: []string{"viewers"}}
+	attrs := &mockAttrs{user: plain, verb: "list", resource: "secrets", isResource: true}
+
+	viewerCtx := auth.BindSubject(context.Background(), viewer)
+	decision, _, err := auth.Authorize(viewerCtx, attrs)
+	require.NoError(t, err)
+	assert.Equal(t, authorizer.DecisionNoOpinion, decision,
+		"the ungrouped subject must not inherit the group snapshot")
+
+	attrs.user = viewer
+	decision, _, err = auth.Authorize(viewerCtx, attrs)
+	require.NoError(t, err)
+	assert.Equal(t, authorizer.DecisionAllow, decision,
+		"the subject the snapshot was taken for still resolves through it")
+}
+
 func TestSnapshot_ConsoleLikeAttrsMatchPerCall(t *testing.T) {
 	auth := newTestRBACAuthorizer(t, snapshotWorld()...)
 	alice := &user.DefaultInfo{Name: "alice"}

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/rbacadapter/snapshot_test.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/rbacadapter/snapshot_test.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2026 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package rbacadapter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+)
+
+func snapshotWorld() []runtime.Object {
+	deckhouseLabels := map[string]string{"heritage": "deckhouse", "module": "user-authz"}
+	return []runtime.Object{
+		&rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{Name: "user-authz:editor"},
+			Rules: []rbacv1.PolicyRule{
+				{APIGroups: []string{"*"}, Resources: []string{"*"}, Verbs: []string{"*"}},
+			},
+		},
+		&rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "user-authz:car0:editor", Labels: deckhouseLabels},
+			Subjects:   []rbacv1.Subject{{Kind: rbacv1.UserKind, Name: "alice"}},
+			RoleRef:    rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "ClusterRole", Name: "user-authz:editor"},
+		},
+		&rbacv1.Role{
+			ObjectMeta: metav1.ObjectMeta{Name: "pod-reader", Namespace: "ns-d"},
+			Rules: []rbacv1.PolicyRule{
+				{APIGroups: []string{""}, Resources: []string{"pods"}, Verbs: []string{"get", "list"}},
+			},
+		},
+		&rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "alice-pod-reader", Namespace: "ns-d"},
+			Subjects:   []rbacv1.Subject{{Kind: rbacv1.UserKind, Name: "alice"}},
+			RoleRef:    rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "Role", Name: "pod-reader"},
+		},
+		&rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{Name: "secret-viewer"},
+			Rules: []rbacv1.PolicyRule{
+				{APIGroups: []string{""}, Resources: []string{"secrets"}, Verbs: []string{"get", "list"}},
+			},
+		},
+		&rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "bob-secret-viewer"},
+			Subjects:   []rbacv1.Subject{{Kind: rbacv1.UserKind, Name: "bob"}},
+			RoleRef:    rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "ClusterRole", Name: "secret-viewer"},
+		},
+	}
+}
+
+func TestSnapshot_MatchesPerCallAuthorize(t *testing.T) {
+	auth := newTestRBACAuthorizer(t, snapshotWorld()...)
+
+	cases := []*mockAttrs{
+		{
+			user:       &user.DefaultInfo{Name: "alice"},
+			verb:       "list",
+			resource:   "pods",
+			isResource: true,
+		},
+		{
+			user:       &user.DefaultInfo{Name: "alice"},
+			verb:       "get",
+			resource:   "pods",
+			namespace:  "ns-d",
+			isResource: true,
+		},
+		{
+			user:       &user.DefaultInfo{Name: "alice"},
+			verb:       "delete",
+			resource:   "pods",
+			namespace:  "ns-d",
+			isResource: true,
+		},
+		{
+			user:       &user.DefaultInfo{Name: "bob"},
+			verb:       "list",
+			resource:   "secrets",
+			isResource: true,
+		},
+		{
+			user:       &user.DefaultInfo{Name: "nobody"},
+			verb:       "list",
+			resource:   "pods",
+			isResource: true,
+		},
+	}
+
+	for _, attrs := range cases {
+		unboundDecision, unboundReason, err := auth.Authorize(context.Background(), attrs)
+		require.NoError(t, err)
+		boundCtx := auth.BindSubject(context.Background(), attrs.user)
+		boundDecision, boundReason, err := auth.Authorize(boundCtx, attrs)
+		require.NoError(t, err)
+		assert.Equal(t, unboundDecision, boundDecision, "decision for %+v", attrs)
+		assert.Equal(t, unboundReason, boundReason, "reason for %+v", attrs)
+
+		assert.Equal(t,
+			auth.AllowsIndependently(context.Background(), attrs),
+			auth.AllowsIndependently(boundCtx, attrs),
+			"AllowsIndependently for %+v", attrs)
+	}
+}
+
+func TestSnapshot_AllowsIndependentlySkipsCAR(t *testing.T) {
+	auth := newTestRBACAuthorizer(t, snapshotWorld()...)
+	alice := &user.DefaultInfo{Name: "alice"}
+	ctx := auth.BindSubject(context.Background(), alice)
+
+	carOnly := &mockAttrs{
+		user:       alice,
+		verb:       "get",
+		resource:   "secrets",
+		namespace:  "ns-x",
+		isResource: true,
+	}
+	allow, reason, err := auth.Authorize(ctx, carOnly)
+	require.NoError(t, err)
+	assert.Equal(t, authorizer.DecisionAllow, allow)
+	assert.Contains(t, reason, "ClusterRoleBinding")
+	assert.False(t, auth.AllowsIndependently(ctx, carOnly),
+		"CAR-managed CRB must not count as an independent grant")
+
+	roleBinding := &mockAttrs{
+		user:       alice,
+		verb:       "get",
+		resource:   "pods",
+		namespace:  "ns-d",
+		isResource: true,
+	}
+	assert.True(t, auth.AllowsIndependently(ctx, roleBinding))
+}
+
+func TestBindSubject_IgnoresNilUser(t *testing.T) {
+	auth := newTestRBACAuthorizer(t)
+	ctx := context.Background()
+	assert.Equal(t, ctx, auth.BindSubject(ctx, nil))
+}

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/rbacadapter/snapshot_test.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/rbacadapter/snapshot_test.go
@@ -145,3 +145,38 @@ func TestBindSubject_IgnoresNilUser(t *testing.T) {
 	ctx := context.Background()
 	assert.Equal(t, ctx, auth.BindSubject(ctx, nil))
 }
+
+func TestSnapshot_ConsoleLikeAttrsMatchPerCall(t *testing.T) {
+	auth := newTestRBACAuthorizer(t, snapshotWorld()...)
+	alice := &user.DefaultInfo{Name: "alice"}
+	bob := &user.DefaultInfo{Name: "bob"}
+
+	cases := []*mockAttrs{
+		{user: alice, verb: "list", resource: "pods", isResource: true},
+		{user: alice, verb: "watch", resource: "pods", isResource: true},
+		{user: alice, verb: "get", resource: "pods", namespace: "ns-d", isResource: true},
+		{user: alice, verb: "list", resource: "pods", namespace: "ns-d", isResource: true},
+		{user: alice, verb: "delete", resource: "pods", namespace: "ns-d", isResource: true},
+		{user: alice, verb: "get", resource: "nodes", isResource: true},
+		{user: alice, verb: "list", apiGroup: "apps", resource: "deployments", isResource: true},
+		{user: alice, verb: "get", resource: "secrets", namespace: "ns-x", isResource: true},
+		{user: bob, verb: "list", resource: "secrets", isResource: true},
+		{user: bob, verb: "get", resource: "secrets", namespace: "ns-x", isResource: true},
+		{user: bob, verb: "list", resource: "pods", isResource: true},
+		{user: &user.DefaultInfo{Name: "nobody"}, verb: "list", resource: "pods", isResource: true},
+	}
+
+	for _, attrs := range cases {
+		unboundDecision, unboundReason, err := auth.Authorize(context.Background(), attrs)
+		require.NoError(t, err)
+		boundCtx := auth.BindSubject(context.Background(), attrs.user)
+		boundDecision, boundReason, err := auth.Authorize(boundCtx, attrs)
+		require.NoError(t, err)
+		assert.Equal(t, unboundDecision, boundDecision, "decision for %+v", attrs)
+		assert.Equal(t, unboundReason, boundReason, "reason for %+v", attrs)
+		assert.Equal(t,
+			auth.AllowsIndependently(context.Background(), attrs),
+			auth.AllowsIndependently(boundCtx, attrs),
+			"AllowsIndependently for %+v", attrs)
+	}
+}

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/scopefilter/identityread.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/scopefilter/identityread.go
@@ -14,8 +14,13 @@ import (
 	"context"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 )
+
+type subjectBinder interface {
+	BindSubject(context.Context, user.Info) context.Context
+}
 
 // filteredReadReason explains an allow that RBAC did not grant. It names the
 // mechanism so an operator reading a BulkSubjectAccessReview response can tell
@@ -66,6 +71,14 @@ var _ authorizer.Authorizer = (*IdentityReadAuthorizer)(nil)
 // cluster serves there is no ground to answer anything but plain RBAC.
 func NewIdentityReadAuthorizer(inner authorizer.Authorizer, registry ResourceRegistry) *IdentityReadAuthorizer {
 	return &IdentityReadAuthorizer{inner: inner, registry: registry}
+}
+
+// BindSubject forwards a per-request RBAC snapshot to the wrapped authorizer.
+func (a *IdentityReadAuthorizer) BindSubject(ctx context.Context, u user.Info) context.Context {
+	if b, ok := a.inner.(subjectBinder); ok {
+		return b.BindSubject(ctx, u)
+	}
+	return ctx
 }
 
 // Authorize implements authorizer.Authorizer.

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/scopefilter/identityread_test.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/scopefilter/identityread_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 )
 
@@ -185,4 +186,24 @@ func TestIdentityReadAuthorizerPassesThroughAllowAndError(t *testing.T) {
 	failing := NewIdentityReadAuthorizer(&stubAuthorizer{decision: authorizer.DecisionNoOpinion, err: errors.New("informer not synced")}, projectCRDInstalled())
 	_, _, err = failing.Authorize(context.Background(), projectAttributes("list"))
 	assert.Error(t, err)
+}
+
+type bindStub struct {
+	stubAuthorizer
+	bound user.Info
+}
+
+func (s *bindStub) BindSubject(ctx context.Context, u user.Info) context.Context {
+	s.bound = u
+	return ctx
+}
+
+func TestIdentityReadAuthorizer_BindSubjectForwards(t *testing.T) {
+	inner := &bindStub{}
+	auth := NewIdentityReadAuthorizer(inner, projectCRDInstalled())
+	u := &user.DefaultInfo{Name: "editor@example.io"}
+
+	auth.BindSubject(context.Background(), u)
+
+	assert.Equal(t, u, inner.bound)
 }

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/registry/storage.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/registry/storage.go
@@ -33,6 +33,10 @@ const (
 	nonSelfReviewSubresource = "nonself"
 )
 
+type subjectBinder interface {
+	BindSubject(context.Context, user.Info) context.Context
+}
+
 // GetStorage returns the storage map for the authorization API group (legacy, without namespace resolver)
 func GetStorage(auth authorizer.Authorizer) map[string]rest.Storage {
 	return map[string]rest.Storage{
@@ -103,7 +107,7 @@ func (s *BulkSARStorage) Create(ctx context.Context, obj runtime.Object, createV
 	}
 
 	// Get the authenticated user from context
-	userInfo, ok := request.UserFrom(ctx)
+	caller, ok := request.UserFrom(ctx)
 	if !ok {
 		// The generic apiserver always populates the user; its absence is a
 		// server-side invariant violation, not a client input error.
@@ -117,7 +121,7 @@ func (s *BulkSARStorage) Create(ctx context.Context, obj runtime.Object, createV
 	var subjectExtra map[string][]string
 
 	if bsar.Spec.User != "" {
-		if err := s.authorizeNonSelfReview(ctx, userInfo); err != nil {
+		if err := s.authorizeNonSelfReview(ctx, caller); err != nil {
 			return nil, err
 		}
 		// Non-self mode: use the provided subject
@@ -131,11 +135,22 @@ func (s *BulkSARStorage) Create(ctx context.Context, obj runtime.Object, createV
 		klog.V(4).Infof("Non-self mode: checking access for user=%s, groups=%v", subjectUser, subjectGroups)
 	} else {
 		// Self mode: use the authenticated user
-		subjectUser = userInfo.GetName()
-		subjectUID = userInfo.GetUID()
-		subjectGroups = userInfo.GetGroups()
-		subjectExtra = userInfo.GetExtra()
+		subjectUser = caller.GetName()
+		subjectUID = caller.GetUID()
+		subjectGroups = caller.GetGroups()
+		subjectExtra = caller.GetExtra()
 		klog.V(4).Infof("Self mode: checking access for user=%s, groups=%v", subjectUser, subjectGroups)
+	}
+
+	// Bind the review subject after the non-self gate so the caller's
+	// authorization is not evaluated against the subject's snapshot.
+	if b, ok := s.authorizer.(subjectBinder); ok {
+		ctx = b.BindSubject(ctx, &userInfo{
+			name:   subjectUser,
+			uid:    subjectUID,
+			groups: subjectGroups,
+			extra:  subjectExtra,
+		})
 	}
 
 	// Process all requests

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/registry/storage_contract_edges_test.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/registry/storage_contract_edges_test.go
@@ -1,0 +1,481 @@
+/*
+Copyright 2026 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package registry
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/endpoints/request"
+
+	"permission-browser-apiserver/pkg/apis/authorization/v1alpha1"
+)
+
+func extraContractNamespaces() []runtime.Object {
+	return []runtime.Object{
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns-a"}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns-b"}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "app-prod"}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kube-public"}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "d8-monitoring"}},
+	}
+}
+
+func narrowReviewerObjects() []runtime.Object {
+	return []runtime.Object{
+		clusterRole("pba-reviewer", []rbacv1.PolicyRule{{
+			APIGroups: []string{"authorization.deckhouse.io"},
+			Resources: []string{"bulksubjectaccessreviews/nonself"},
+			Verbs:     []string{"create"},
+		}}),
+		userCRB("pba-reviewer", "pba-reviewer", contractAdminUser),
+	}
+}
+
+func carCRBSA(name, role, saNS, saName string) *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Labels: carLabels},
+		Subjects:   []rbacv1.Subject{{Kind: rbacv1.ServiceAccountKind, Name: saName, Namespace: saNS}},
+		RoleRef:    rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "ClusterRole", Name: role},
+	}
+}
+
+const dualEditorCARConfig = `{
+	"crds": [
+		{
+			"name": "editor-a",
+			"spec": {
+				"accessLevel": "Editor",
+				"limitNamespaces": ["ns-a"],
+				"subjects": [{"kind": "User", "name": "dual@example.io"}]
+			}
+		},
+		{
+			"name": "editor-b",
+			"spec": {
+				"accessLevel": "Editor",
+				"limitNamespaces": ["ns-b"],
+				"subjects": [{"kind": "User", "name": "dual@example.io"}]
+			}
+		}
+	]
+}`
+
+const userLimitPlusGroupMatchAnyConfig = `{
+	"crds": [
+		{
+			"name": "editor",
+			"spec": {
+				"accessLevel": "Editor",
+				"limitNamespaces": ["ns-in"],
+				"subjects": [{"kind": "User", "name": "union@example.io"}]
+			}
+		},
+		{
+			"name": "ops",
+			"spec": {
+				"accessLevel": "SuperAdmin",
+				"namespaceSelector": {"matchAny": true},
+				"subjects": [{"kind": "Group", "name": "ops"}]
+			}
+		}
+	]
+}`
+
+const selectorIgnoresLimitConfig = `{
+	"crds": [{
+		"name": "editor-both",
+		"spec": {
+			"accessLevel": "Editor",
+			"limitNamespaces": ["ns-a"],
+			"namespaceSelector": {"labelSelector": {"matchLabels": {"pba-perf": "true"}}},
+			"subjects": [{"kind": "User", "name": "editor@example.io"}]
+		}
+	}]
+}`
+
+const editorRegexCARConfig = `{
+	"crds": [{
+		"name": "editor-re",
+		"spec": {
+			"accessLevel": "Editor",
+			"limitNamespaces": ["app-.*"],
+			"subjects": [{"kind": "User", "name": "regex@example.io"}]
+		}
+	}]
+}`
+
+const editorSACARConfig = `{
+	"crds": [{
+		"name": "editor-sa",
+		"spec": {
+			"accessLevel": "Editor",
+			"limitNamespaces": ["ns-in"],
+			"subjects": [{"kind": "ServiceAccount", "name": "app", "namespace": "ns-in"}]
+		}
+	}]
+}`
+
+const bothSubjectsConfig = `{
+	"crds": [
+		{
+			"name": "editor",
+			"spec": {
+				"accessLevel": "Editor",
+				"limitNamespaces": ["ns-in"],
+				"subjects": [{"kind": "User", "name": "editor@example.io"}]
+			}
+		},
+		{
+			"name": "super",
+			"spec": {
+				"accessLevel": "SuperAdmin",
+				"allowAccessToSystemNamespaces": true,
+				"namespaceSelector": {"matchAny": true},
+				"subjects": [{"kind": "User", "name": "super@example.io"}]
+			}
+		}
+	]
+}`
+
+// TestBulkSARStorage_Create_NarrowReviewerBindsSubject locks the non-self
+// gate: the caller may only create .../nonself. Item answers must come from
+// the subject's CAR CRB, not from the caller. If BindSubject is skipped or
+// applied before the gate, get pods in the CAR ns stops being Allowed.
+func TestBulkSARStorage_Create_NarrowReviewerBindsSubject(t *testing.T) {
+	objs := append(labeledNS(), narrowReviewerObjects()...)
+	objs = append(objs,
+		clusterRole("user-authz:editor", wildcardRules()),
+		carCRB("user-authz:editor:editor", "user-authz:editor", contractEditorUser),
+	)
+	stack := newContractStack(t, bulkSAREditorConfig, objs, contractScope())
+	got := assertBoundEqualsUnbound(t, stack, contractEditorUser, nil, sec40Requests())
+
+	assertOutcome(t, outcomeFromResult(got[0]), false, true, "making cluster-scoped requests for namespaced resources is not allowed")
+	assert.True(t, got[1].Allowed, "subject Editor must still get pods in ns-in: %+v", got[1])
+	assert.True(t, got[2].Denied, "subject Editor must not get pods in ns-out: %+v", got[2])
+	assert.True(t, got[3].Allowed, "wildcard Editor get nodes: %+v", got[3])
+}
+
+func TestBulkSARStorage_Create_RestrictedEditorCannotReviewOthers(t *testing.T) {
+	stack := newContractStack(t, bothSubjectsConfig, restrictedRBAC(contractEditorUser, contractSuperUser), contractScope())
+	ctx := request.WithUser(context.Background(), &user.DefaultInfo{Name: contractEditorUser})
+	_, err := stack.storage.Create(ctx, &v1alpha1.BulkSubjectAccessReview{
+		Spec: v1alpha1.BulkSubjectAccessReviewSpec{
+			User:     contractSuperUser,
+			Requests: sec40Requests(),
+		},
+	}, nil, nil)
+	require.Error(t, err)
+	assert.True(t, apierrors.IsForbidden(err), "restricted Editor must not non-self review SuperAdmin: %v", err)
+}
+
+func TestBulkSARStorage_Create_TwoCARsUnionNamespaces(t *testing.T) {
+	const user = "dual@example.io"
+	objs := append(labeledNS(), extraContractNamespaces()...)
+	objs = append(objs, reviewerObjects()...)
+	objs = append(objs,
+		clusterRole("user-authz:editor", wildcardRules()),
+		carCRB("user-authz:editor-a:editor", "user-authz:editor", user),
+		carCRB("user-authz:editor-b:editor", "user-authz:editor", user),
+	)
+	stack := newContractStack(t, dualEditorCARConfig, objs, contractScope())
+	reqs := []v1alpha1.SubjectAccessReviewRequest{
+		ra("list", "", "pods", ""),
+		ra("get", "", "pods", "ns-a"),
+		ra("get", "", "pods", "ns-b"),
+		ra("get", "", "pods", "ns-out"),
+		ra("get", "", "nodes", ""),
+	}
+	got := assertBoundEqualsUnbound(t, stack, user, nil, reqs)
+	assert.True(t, got[0].Denied)
+	assert.True(t, got[1].Allowed, "ns-a from first CAR: %+v", got[1])
+	assert.True(t, got[2].Allowed, "ns-b from second CAR: %+v", got[2])
+	assert.True(t, got[3].Denied, "union must not leak ns-out: %+v", got[3])
+	assert.True(t, got[4].Allowed)
+}
+
+func TestBulkSARStorage_Create_MatchAnyGroupOverridesUserLimit(t *testing.T) {
+	const user = "union@example.io"
+	objs := append(labeledNS(), reviewerObjects()...)
+	objs = append(objs,
+		clusterRole("user-authz:editor", wildcardRules()),
+		clusterRole("user-authz:super-admin", wildcardRules()),
+		carCRB("user-authz:union:editor", "user-authz:editor", user),
+	)
+	stack := newContractStack(t, userLimitPlusGroupMatchAnyConfig, objs, contractScope())
+
+	limited := createBulkSAR(t, stack.storage, user, nil, sec40Requests())
+	assert.True(t, limited[0].Denied, "user CAR alone stays filtered")
+	assert.True(t, limited[2].Denied)
+
+	withOps := createBulkSAR(t, stack.storage, user, []string{"ops"}, sec40Requests())
+	for i, r := range withOps {
+		assert.True(t, r.Allowed, "MatchAny on a group must clear filters, item %d: %+v", i, r)
+	}
+}
+
+func TestBulkSARStorage_Create_SelectorIgnoresSiblingLimitNamespaces(t *testing.T) {
+	objs := append(labeledNS(), extraContractNamespaces()...)
+	objs = append(objs, reviewerObjects()...)
+	objs = append(objs,
+		clusterRole("user-authz:editor", wildcardRules()),
+		carCRB("user-authz:editor:editor", "user-authz:editor", contractEditorUser),
+	)
+	stack := newContractStack(t, selectorIgnoresLimitConfig, objs, contractScope())
+	reqs := []v1alpha1.SubjectAccessReviewRequest{
+		ra("get", "", "pods", "ns-in"),
+		ra("get", "", "pods", "ns-a"),
+		ra("get", "", "pods", "ns-out"),
+	}
+	got := assertBoundEqualsUnbound(t, stack, contractEditorUser, nil, reqs)
+	assert.True(t, got[0].Allowed, "labelSelector ns-in: %+v", got[0])
+	assert.True(t, got[1].Denied, "limitNamespaces is ignored when namespaceSelector is set: %+v", got[1])
+	assert.True(t, got[2].Denied)
+}
+
+func TestBulkSARStorage_Create_LimitNamespacesRegex(t *testing.T) {
+	const user = "regex@example.io"
+	objs := append(labeledNS(), extraContractNamespaces()...)
+	objs = append(objs, reviewerObjects()...)
+	objs = append(objs,
+		clusterRole("user-authz:editor", wildcardRules()),
+		carCRB("user-authz:regex:editor", "user-authz:editor", user),
+	)
+	stack := newContractStack(t, editorRegexCARConfig, objs, contractScope())
+	reqs := []v1alpha1.SubjectAccessReviewRequest{
+		ra("get", "", "pods", "app-prod"),
+		ra("get", "", "pods", "ns-in"),
+		ra("list", "", "pods", ""),
+	}
+	got := assertBoundEqualsUnbound(t, stack, user, nil, reqs)
+	assert.True(t, got[0].Allowed, "app-.* must match app-prod: %+v", got[0])
+	assert.True(t, got[1].Denied, "ns-in is outside app-.*: %+v", got[1])
+	assert.True(t, got[2].Denied)
+}
+
+func TestBulkSARStorage_Create_ServiceAccountSubject(t *testing.T) {
+	sa := "system:serviceaccount:ns-in:app"
+	objs := append(labeledNS(), reviewerObjects()...)
+	objs = append(objs,
+		clusterRole("user-authz:editor", wildcardRules()),
+		carCRBSA("user-authz:editor-sa:editor", "user-authz:editor", "ns-in", "app"),
+	)
+	stack := newContractStack(t, editorSACARConfig, objs, contractScope())
+	got := assertBoundEqualsUnbound(t, stack, sa, nil, sec40Requests())
+	assert.True(t, got[0].Denied)
+	assert.True(t, got[1].Allowed, "SA in CAR ns: %+v", got[1])
+	assert.True(t, got[2].Denied)
+	assert.True(t, got[3].Allowed)
+}
+
+func TestBulkSARStorage_Create_SystemNamespacesAndDefault(t *testing.T) {
+	objs := append(wildcardRBAC(contractEditorUser, contractSuperUser), extraContractNamespaces()...)
+	stack := newContractStack(t, bothSubjectsConfig, objs, contractScope())
+	reqs := []v1alpha1.SubjectAccessReviewRequest{
+		ra("get", "", "pods", "default"),
+		ra("get", "", "pods", "kube-public"),
+		ra("get", "", "pods", "d8-monitoring"),
+		ra("get", "", "pods", "kube-system"),
+	}
+	editor := createBulkSAR(t, stack.storage, contractEditorUser, nil, reqs)
+	for i, r := range editor {
+		assert.True(t, r.Denied, "Editor must be denied system ns item %d: %+v", i, r)
+		assert.Equal(t, "either you have no access to the namespace or the namespace does not exist", r.Reason)
+	}
+	super := createBulkSAR(t, stack.storage, contractSuperUser, nil, reqs)
+	for i, r := range super {
+		assert.True(t, r.Allowed, "SuperAdmin matchAny item %d: %+v", i, r)
+	}
+}
+
+func TestBulkSARStorage_Create_VersionAndNameDoNotChangeDecision(t *testing.T) {
+	stack := newContractStack(t, bulkSAREditorConfig, wildcardRBAC(contractEditorUser, contractSuperUser), contractScope())
+	base := []v1alpha1.SubjectAccessReviewRequest{
+		ra("list", "", "pods", ""),
+		ra("get", "", "pods", "ns-in"),
+		ra("get", "", "pods", "ns-out"),
+		ra("get", "", "nodes", ""),
+	}
+	varied := []v1alpha1.SubjectAccessReviewRequest{
+		{ResourceAttributes: &v1alpha1.ResourceAttributes{Verb: "list", Version: "v1", Resource: "pods"}},
+		{ResourceAttributes: &v1alpha1.ResourceAttributes{Verb: "get", Version: "v1beta1", Resource: "pods", Namespace: "ns-in", Name: "web"}},
+		{ResourceAttributes: &v1alpha1.ResourceAttributes{Verb: "get", Version: "v1", Resource: "pods", Namespace: "ns-out", Name: "hidden"}},
+		{ResourceAttributes: &v1alpha1.ResourceAttributes{Verb: "get", Version: "v1", Resource: "nodes", Name: "node-1"}},
+	}
+	fromBase := createBulkSAR(t, stack.storage, contractEditorUser, nil, base)
+	fromVaried := createBulkSAR(t, stack.storage, contractEditorUser, nil, varied)
+	for i := range base {
+		assert.Equal(t, fromBase[i].Allowed, fromVaried[i].Allowed, "allowed item %d", i)
+		assert.Equal(t, fromBase[i].Denied, fromVaried[i].Denied, "denied item %d", i)
+		if fromBase[i].Denied {
+			assert.Equal(t, fromBase[i].Reason, fromVaried[i].Reason, "a named/versioned deny must keep the webhook reason")
+		}
+	}
+}
+
+func TestBulkSARStorage_Create_VerbsDoNotChangeMTFilter(t *testing.T) {
+	stack := newContractStack(t, bulkSAREditorConfig, wildcardRBAC(contractEditorUser, contractSuperUser), contractScope())
+	verbs := []string{"get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"}
+	var reqs []v1alpha1.SubjectAccessReviewRequest
+	for _, v := range verbs {
+		reqs = append(reqs, ra(v, "", "pods", ""), ra(v, "", "pods", "ns-out"), ra(v, "", "nodes", ""))
+	}
+	got := createBulkSAR(t, stack.storage, contractEditorUser, nil, reqs)
+	for i, v := range verbs {
+		assert.True(t, got[i*3].Denied, "%s pods cluster-scoped: %+v", v, got[i*3])
+		assert.True(t, got[i*3+1].Denied, "%s pods ns-out: %+v", v, got[i*3+1])
+		assert.True(t, got[i*3+2].Allowed, "%s nodes: %+v", v, got[i*3+2])
+	}
+}
+
+func TestBulkSARStorage_Create_ProjectsNeedTheCRD(t *testing.T) {
+	stack := newContractStackWithRegistry(t, bulkSAREditorConfig, restrictedRBAC(contractEditorUser, contractSuperUser), contractScope(), servedResources{})
+	got := createBulkSAR(t, stack.storage, contractEditorUser, nil, []v1alpha1.SubjectAccessReviewRequest{
+		ra("list", "deckhouse.io", "projects", ""),
+	})
+	assert.False(t, got[0].Allowed, "no Project CRD: %+v", got[0])
+	assert.False(t, got[0].Denied)
+}
+
+func TestBulkSARStorage_Create_ResourceNamesDoNotRescueList(t *testing.T) {
+	objs := append(restrictedRBAC(contractEditorUser, contractSuperUser),
+		clusterRole("named-secret", []rbacv1.PolicyRule{{
+			APIGroups: []string{""}, Resources: []string{"secrets"}, Verbs: []string{"get", "list"}, ResourceNames: []string{"only-this"},
+		}}),
+		userCRB("editor-named-secret", "named-secret", contractEditorUser),
+	)
+	stack := newContractStack(t, bulkSAREditorConfig, objs, contractScope())
+	got := createBulkSAR(t, stack.storage, contractEditorUser, nil, []v1alpha1.SubjectAccessReviewRequest{
+		ra("list", "", "secrets", ""),
+		{ResourceAttributes: &v1alpha1.ResourceAttributes{Verb: "get", Resource: "secrets", Name: "only-this"}},
+	})
+	assert.True(t, got[0].Denied, "resourceNames must not grant an unscoped list: %+v", got[0])
+	assert.True(t, got[1].Allowed, "named get via user CRB: %+v", got[1])
+}
+
+func TestBulkSARStorage_Create_GeneratedMatrixWildcardEditor(t *testing.T) {
+	stack := newContractStack(t, bothSubjectsConfig, wildcardRBAC(contractEditorUser, contractSuperUser), contractScope())
+	reqs, expectEditorAllow := generatedContractMatrix()
+	editor := createBulkSAR(t, stack.storage, contractEditorUser, nil, reqs)
+	super := createBulkSAR(t, stack.storage, contractSuperUser, nil, reqs)
+	require.Len(t, editor, len(reqs))
+	for i, req := range reqs {
+		assert.Equal(t, expectEditorAllow[i], editor[i].Allowed, "Editor allowed item %d %+v got=%+v", i, req, editor[i])
+		if !expectEditorAllow[i] {
+			assert.True(t, editor[i].Denied, "Editor should Deny item %d %+v", i, req)
+		}
+		assert.True(t, super[i].Allowed, "SuperAdmin item %d %+v: %+v", i, req, super[i])
+		assert.False(t, super[i].Denied)
+	}
+}
+
+func generatedContractMatrix() ([]v1alpha1.SubjectAccessReviewRequest, []bool) {
+	type gvr struct {
+		group, resource string
+		namespaced      bool
+	}
+	resources := []gvr{
+		{resource: "pods", namespaced: true},
+		{resource: "services", namespaced: true},
+		{resource: "secrets", namespaced: true},
+		{resource: "configmaps", namespaced: true},
+		{group: "apps", resource: "deployments", namespaced: true},
+		{group: "batch", resource: "jobs", namespaced: true},
+		{group: "networking.k8s.io", resource: "ingresses", namespaced: true},
+		{resource: "nodes", namespaced: false},
+		{resource: "namespaces", namespaced: false},
+		{group: "rbac.authorization.k8s.io", resource: "clusterroles", namespaced: false},
+		{group: "deckhouse.io", resource: "projects", namespaced: false},
+	}
+	nss := []string{"", "ns-in", "ns-out", "kube-system", "default"}
+	verbs := []string{"get", "list", "watch", "create"}
+
+	var reqs []v1alpha1.SubjectAccessReviewRequest
+	var allow []bool
+	for _, res := range resources {
+		for _, ns := range nss {
+			for _, verb := range verbs {
+				reqs = append(reqs, ra(verb, res.group, res.resource, ns))
+				switch {
+				case ns == "ns-in":
+					allow = append(allow, true)
+				case ns != "":
+					allow = append(allow, false)
+				case res.namespaced:
+					allow = append(allow, false)
+				default:
+					allow = append(allow, true)
+				}
+			}
+		}
+	}
+	return reqs, allow
+}
+
+func TestBulkSARStorage_Create_ConcurrentEditorAndSuperAdmin(t *testing.T) {
+	stack := newContractStack(t, bothSubjectsConfig, wildcardRBAC(contractEditorUser, contractSuperUser), contractScope())
+	wantEditor := createBulkSAR(t, stack.storage, contractEditorUser, nil, sec40Requests())
+	wantSuper := createBulkSAR(t, stack.storage, contractSuperUser, nil, sec40Requests())
+
+	const workers = 16
+	var wg sync.WaitGroup
+	errCh := make(chan string, workers*2)
+	wg.Add(workers * 2)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			got, err := createBulkSARResult(stack.storage, contractEditorUser, nil, sec40Requests())
+			if err != nil {
+				errCh <- err.Error()
+				return
+			}
+			if len(got) != len(wantEditor) {
+				errCh <- "editor result length drifted"
+				return
+			}
+			for j := range wantEditor {
+				if got[j].Allowed != wantEditor[j].Allowed || got[j].Denied != wantEditor[j].Denied {
+					errCh <- "editor result drifted"
+					return
+				}
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			got, err := createBulkSARResult(stack.storage, contractSuperUser, nil, sec40Requests())
+			if err != nil {
+				errCh <- err.Error()
+				return
+			}
+			if len(got) != len(wantSuper) {
+				errCh <- "superadmin result length drifted"
+				return
+			}
+			for j := range wantSuper {
+				if !got[j].Allowed || got[j].Denied {
+					errCh <- "superadmin result drifted"
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for msg := range errCh {
+		t.Error(msg)
+	}
+}

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/registry/storage_contract_test.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/registry/storage_contract_test.go
@@ -7,6 +7,7 @@ package registry
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -209,6 +210,11 @@ type contractStack struct {
 
 func newContractStack(t *testing.T, mtConfig string, objs []runtime.Object, scope staticResourceScope) contractStack {
 	t.Helper()
+	return newContractStackWithRegistry(t, mtConfig, objs, scope, projectRegistry())
+}
+
+func newContractStackWithRegistry(t *testing.T, mtConfig string, objs []runtime.Object, scope staticResourceScope, registry scopefilter.ResourceRegistry) contractStack {
+	t.Helper()
 	client := fake.NewSimpleClientset(objs...)
 	factory := informers.NewSharedInformerFactory(client, 0)
 	nsInformer := factory.Core().V1().Namespaces()
@@ -225,8 +231,7 @@ func newContractStack(t *testing.T, mtConfig string, objs []runtime.Object, scop
 	require.NoError(t, err)
 	engine.SetIndependentRBACChecker(rbac)
 
-	inner := composite.NewCompositeAuthorizer(engine, rbac)
-	auth := scopefilter.NewIdentityReadAuthorizer(inner, projectRegistry())
+	auth := scopefilter.NewIdentityReadAuthorizer(composite.NewCompositeAuthorizer(engine, rbac), registry)
 	return contractStack{
 		storage: NewBulkSARStorage(auth),
 		auth:    auth,
@@ -235,6 +240,13 @@ func newContractStack(t *testing.T, mtConfig string, objs []runtime.Object, scop
 
 func createBulkSAR(t *testing.T, storage *BulkSARStorage, subject string, groups []string, reqs []v1alpha1.SubjectAccessReviewRequest) []v1alpha1.SubjectAccessReviewResult {
 	t.Helper()
+	got, err := createBulkSARResult(storage, subject, groups, reqs)
+	require.NoError(t, err)
+	require.Len(t, got, len(reqs))
+	return got
+}
+
+func createBulkSARResult(storage *BulkSARStorage, subject string, groups []string, reqs []v1alpha1.SubjectAccessReviewRequest) ([]v1alpha1.SubjectAccessReviewResult, error) {
 	ctx := request.WithUser(context.Background(), &user.DefaultInfo{
 		Name:   contractAdminUser,
 		Groups: []string{"system:authenticated"},
@@ -246,11 +258,14 @@ func createBulkSAR(t *testing.T, storage *BulkSARStorage, subject string, groups
 			Requests: reqs,
 		},
 	}, nil, nil)
-	require.NoError(t, err)
+	if err != nil {
+		return nil, err
+	}
 	got, ok := out.(*v1alpha1.BulkSubjectAccessReview)
-	require.True(t, ok)
-	require.Len(t, got.Status.Results, len(reqs))
-	return got.Status.Results
+	if !ok {
+		return nil, errors.New("object is not a BulkSubjectAccessReview")
+	}
+	return got.Status.Results, nil
 }
 
 func authorizeUnbound(t *testing.T, auth authorizer.Authorizer, subject string, groups []string, reqs []v1alpha1.SubjectAccessReviewRequest) []reviewOutcome {

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/registry/storage_contract_test.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/registry/storage_contract_test.go
@@ -1,0 +1,554 @@
+/*
+Copyright 2026 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package registry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"permission-browser-apiserver/pkg/apis/authorization/v1alpha1"
+	"permission-browser-apiserver/pkg/authorizer/composite"
+	"permission-browser-apiserver/pkg/authorizer/multitenancy"
+	"permission-browser-apiserver/pkg/authorizer/rbacadapter"
+	"permission-browser-apiserver/pkg/authorizer/scopefilter"
+)
+
+// This file locks the BulkSAR HTTP contract: MT + real RBAC + IdentityRead +
+// BindSubject via storage.Create. Optimization (scope snapshot, rule snapshot)
+// must not change Allowed/Denied/Reason for any item.
+
+const (
+	contractEditorUser = "editor@example.io"
+	contractSuperUser  = "super@example.io"
+	contractAdminUser  = "pba-admin"
+	filteredReadReason = "the namespace ACL answers this read with the accessible subset instead of a denial"
+)
+
+var carLabels = map[string]string{"heritage": "deckhouse", "module": "user-authz"}
+
+func contractScope() staticResourceScope {
+	return staticResourceScope{
+		"/pods":                                  true,
+		"/services":                              true,
+		"/configmaps":                            true,
+		"/secrets":                               true,
+		"/namespaces":                            false,
+		"/nodes":                                 false,
+		"/persistentvolumes":                     false,
+		"apps/deployments":                       true,
+		"batch/jobs":                             true,
+		"networking.k8s.io/ingresses":            true,
+		"rbac.authorization.k8s.io/roles":        true,
+		"rbac.authorization.k8s.io/clusterroles": false,
+		"apiextensions.k8s.io/customresourcedefinitions": false,
+		"deckhouse.io/projects":                          false,
+	}
+}
+
+type servedResources map[string]struct{}
+
+func (s servedResources) HasResource(group, resource string) bool {
+	_, ok := s[group+"/"+resource]
+	return ok
+}
+
+func projectRegistry() servedResources {
+	return servedResources{"deckhouse.io/projects": {}}
+}
+
+func wildcardRules() []rbacv1.PolicyRule {
+	return []rbacv1.PolicyRule{
+		{APIGroups: []string{"*"}, Resources: []string{"*"}, Verbs: []string{"*"}},
+		{NonResourceURLs: []string{"*"}, Verbs: []string{"*"}},
+	}
+}
+
+// restrictedEditorRules is the e2e sec40 shape: namespaced workload reads,
+// no nodes, no clusterroles, no projects (IdentityRead must supply projects).
+func restrictedEditorRules() []rbacv1.PolicyRule {
+	return []rbacv1.PolicyRule{
+		{APIGroups: []string{""}, Resources: []string{"pods", "services", "configmaps", "secrets"}, Verbs: []string{"get", "list", "watch", "create", "update", "patch", "delete"}},
+		{APIGroups: []string{"apps"}, Resources: []string{"deployments"}, Verbs: []string{"get", "list", "watch", "create", "update", "patch", "delete"}},
+		{APIGroups: []string{"batch"}, Resources: []string{"jobs"}, Verbs: []string{"get", "list", "watch"}},
+		{APIGroups: []string{"networking.k8s.io"}, Resources: []string{"ingresses"}, Verbs: []string{"get", "list", "watch"}},
+	}
+}
+
+func clusterRole(name string, rules []rbacv1.PolicyRule) *rbacv1.ClusterRole {
+	return &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: name}, Rules: rules}
+}
+
+func carCRB(name, role, userName string) *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Labels: carLabels},
+		Subjects:   []rbacv1.Subject{{Kind: rbacv1.UserKind, Name: userName}},
+		RoleRef:    rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "ClusterRole", Name: role},
+	}
+}
+
+func userCRB(name, role, userName string) *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Subjects:   []rbacv1.Subject{{Kind: rbacv1.UserKind, Name: userName}},
+		RoleRef:    rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "ClusterRole", Name: role},
+	}
+}
+
+func reviewerObjects() []runtime.Object {
+	return []runtime.Object{
+		clusterRole("pba-reviewer", wildcardRules()),
+		userCRB("pba-reviewer", "pba-reviewer", contractAdminUser),
+	}
+}
+
+func labeledNS() []runtime.Object {
+	return []runtime.Object{
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+			Name:   "ns-in",
+			Labels: map[string]string{"pba-perf": "true"},
+		}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns-out"}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kube-system"}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "d8-system"}},
+	}
+}
+
+func ra(verb, group, resource, ns string) v1alpha1.SubjectAccessReviewRequest {
+	return v1alpha1.SubjectAccessReviewRequest{
+		ResourceAttributes: &v1alpha1.ResourceAttributes{
+			Verb:      verb,
+			Group:     group,
+			Resource:  resource,
+			Namespace: ns,
+		},
+	}
+}
+
+func consoleContractRequests() []v1alpha1.SubjectAccessReviewRequest {
+	return []v1alpha1.SubjectAccessReviewRequest{
+		ra("list", "", "pods", ""),
+		ra("watch", "", "pods", ""),
+		ra("list", "", "services", ""),
+		ra("list", "", "secrets", ""),
+		ra("list", "apps", "deployments", ""),
+		ra("list", "batch", "jobs", ""),
+		ra("list", "networking.k8s.io", "ingresses", ""),
+		ra("get", "", "nodes", ""),
+		ra("list", "", "nodes", ""),
+		ra("list", "", "namespaces", ""),
+		ra("list", "rbac.authorization.k8s.io", "clusterroles", ""),
+		ra("list", "apiextensions.k8s.io", "customresourcedefinitions", ""),
+		ra("list", "deckhouse.io", "projects", ""),
+		ra("create", "deckhouse.io", "projects", ""),
+		ra("get", "", "pods", "ns-in"),
+		ra("list", "", "pods", "ns-in"),
+		ra("create", "", "pods", "ns-in"),
+		ra("get", "apps", "deployments", "ns-in"),
+		ra("get", "", "secrets", "ns-in"),
+		ra("get", "", "pods", "ns-out"),
+		ra("get", "", "secrets", "ns-out"),
+		ra("create", "apps", "deployments", "ns-out"),
+		ra("get", "", "pods", "kube-system"),
+		ra("get", "", "pods", "d8-system"),
+		ra("list", "example.com", "newcrds", ""),
+		{ResourceAttributes: &v1alpha1.ResourceAttributes{Verb: "get", Resource: "pods", Subresource: "log"}},
+		{ResourceAttributes: &v1alpha1.ResourceAttributes{Verb: "get", Resource: "pods", Subresource: "log", Namespace: "ns-in"}},
+		{NonResourceAttributes: &v1alpha1.NonResourceAttributes{Verb: "get", Path: "/healthz"}},
+	}
+}
+
+func sec40Requests() []v1alpha1.SubjectAccessReviewRequest {
+	return []v1alpha1.SubjectAccessReviewRequest{
+		ra("list", "", "pods", ""),
+		ra("get", "", "pods", "ns-in"),
+		ra("get", "", "pods", "ns-out"),
+		ra("get", "", "nodes", ""),
+	}
+}
+
+type reviewOutcome struct {
+	Allowed bool
+	Denied  bool
+	Reason  string
+}
+
+func outcomeFromResult(r v1alpha1.SubjectAccessReviewResult) reviewOutcome {
+	return reviewOutcome{Allowed: r.Allowed, Denied: r.Denied, Reason: r.Reason}
+}
+
+func outcomeFromDecision(d authorizer.Decision, reason string) reviewOutcome {
+	switch d {
+	case authorizer.DecisionAllow:
+		return reviewOutcome{Allowed: true, Reason: reason}
+	case authorizer.DecisionDeny:
+		return reviewOutcome{Denied: true, Reason: reason}
+	default:
+		return reviewOutcome{Reason: reason}
+	}
+}
+
+type contractStack struct {
+	storage *BulkSARStorage
+	auth    authorizer.Authorizer
+}
+
+func newContractStack(t *testing.T, mtConfig string, objs []runtime.Object, scope staticResourceScope) contractStack {
+	t.Helper()
+	client := fake.NewSimpleClientset(objs...)
+	factory := informers.NewSharedInformerFactory(client, 0)
+	nsInformer := factory.Core().V1().Namespaces()
+	nsLister := nsInformer.Lister()
+	rbac := rbacadapter.NewRBACAuthorizer(factory)
+	stop := make(chan struct{})
+	t.Cleanup(func() { close(stop) })
+	factory.Start(stop)
+	for typ, ok := range factory.WaitForCacheSync(stop) {
+		require.True(t, ok, "informer %v failed to sync", typ)
+	}
+
+	engine, err := multitenancy.NewEngine(writeMTConfig(t, mtConfig), nsLister, func() bool { return true }, scope)
+	require.NoError(t, err)
+	engine.SetIndependentRBACChecker(rbac)
+
+	inner := composite.NewCompositeAuthorizer(engine, rbac)
+	auth := scopefilter.NewIdentityReadAuthorizer(inner, projectRegistry())
+	return contractStack{
+		storage: NewBulkSARStorage(auth),
+		auth:    auth,
+	}
+}
+
+func createBulkSAR(t *testing.T, storage *BulkSARStorage, subject string, groups []string, reqs []v1alpha1.SubjectAccessReviewRequest) []v1alpha1.SubjectAccessReviewResult {
+	t.Helper()
+	ctx := request.WithUser(context.Background(), &user.DefaultInfo{
+		Name:   contractAdminUser,
+		Groups: []string{"system:authenticated"},
+	})
+	out, err := storage.Create(ctx, &v1alpha1.BulkSubjectAccessReview{
+		Spec: v1alpha1.BulkSubjectAccessReviewSpec{
+			User:     subject,
+			Groups:   groups,
+			Requests: reqs,
+		},
+	}, nil, nil)
+	require.NoError(t, err)
+	got, ok := out.(*v1alpha1.BulkSubjectAccessReview)
+	require.True(t, ok)
+	require.Len(t, got.Status.Results, len(reqs))
+	return got.Status.Results
+}
+
+func authorizeUnbound(t *testing.T, auth authorizer.Authorizer, subject string, groups []string, reqs []v1alpha1.SubjectAccessReviewRequest) []reviewOutcome {
+	t.Helper()
+	out := make([]reviewOutcome, len(reqs))
+	subjectInfo := &user.DefaultInfo{Name: subject, Groups: groups}
+	for i := range reqs {
+		attrs := &accessAttributes{
+			user:                  subjectInfo,
+			resourceAttributes:    reqs[i].ResourceAttributes,
+			nonResourceAttributes: reqs[i].NonResourceAttributes,
+		}
+		d, reason, err := auth.Authorize(context.Background(), attrs)
+		require.NoError(t, err)
+		out[i] = outcomeFromDecision(d, reason)
+	}
+	return out
+}
+
+func assertBoundEqualsUnbound(t *testing.T, stack contractStack, subject string, groups []string, reqs []v1alpha1.SubjectAccessReviewRequest) []v1alpha1.SubjectAccessReviewResult {
+	t.Helper()
+	bound := createBulkSAR(t, stack.storage, subject, groups, reqs)
+	unbound := authorizeUnbound(t, stack.auth, subject, groups, reqs)
+	require.Len(t, unbound, len(bound))
+	for i := range bound {
+		got := outcomeFromResult(bound[i])
+		assert.Equal(t, unbound[i].Allowed, got.Allowed, "allowed item %d %+v bound=%+v unbound=%+v", i, reqs[i], got, unbound[i])
+		assert.Equal(t, unbound[i].Denied, got.Denied, "denied item %d %+v bound=%+v unbound=%+v", i, reqs[i], got, unbound[i])
+		if got.Denied || unbound[i].Denied {
+			assert.Equal(t, unbound[i].Reason, got.Reason, "deny reason item %d %+v", i, reqs[i])
+		}
+	}
+	return bound
+}
+
+func assertOutcome(t *testing.T, got reviewOutcome, allowed, denied bool, reason string) {
+	t.Helper()
+	assert.Equal(t, allowed, got.Allowed, "allowed: %+v", got)
+	assert.Equal(t, denied, got.Denied, "denied: %+v", got)
+	if reason != "" {
+		assert.Equal(t, reason, got.Reason)
+	}
+}
+
+func wildcardRBAC(editor, super string) []runtime.Object {
+	objs := append(labeledNS(), reviewerObjects()...)
+	objs = append(objs,
+		clusterRole("user-authz:editor", wildcardRules()),
+		clusterRole("user-authz:super-admin", wildcardRules()),
+		carCRB("user-authz:editor:editor", "user-authz:editor", editor),
+		carCRB("user-authz:super:super-admin", "user-authz:super-admin", super),
+	)
+	return objs
+}
+
+func restrictedRBAC(editor, super string) []runtime.Object {
+	objs := append(labeledNS(), reviewerObjects()...)
+	objs = append(objs,
+		clusterRole("user-authz:editor", restrictedEditorRules()),
+		clusterRole("user-authz:super-admin", wildcardRules()),
+		carCRB("user-authz:editor:editor", "user-authz:editor", editor),
+		carCRB("user-authz:super:super-admin", "user-authz:super-admin", super),
+	)
+	return objs
+}
+
+const editorLabelSelectorConfig = `{
+	"crds": [{
+		"name": "editor-sel",
+		"spec": {
+			"accessLevel": "Editor",
+			"namespaceSelector": {"labelSelector": {"matchLabels": {"pba-perf": "true"}}},
+			"subjects": [{"kind": "User", "name": "editor@example.io"}]
+		}
+	}]
+}`
+
+// TestBulkSARStorage_Create_Sec40RestrictedEditor locks the e2e sec40
+// four-item matrix against real Editor RBAC (no nodes). get nodes is
+// NoOpinion, not Deny: MT lets cluster-scoped nodes through, RBAC has no grant.
+func TestBulkSARStorage_Create_Sec40RestrictedEditor(t *testing.T) {
+	editorStack := newContractStack(t, bulkSAREditorConfig, restrictedRBAC(contractEditorUser, contractSuperUser), contractScope())
+	superStack := newContractStack(t, bulkSARSuperConfig, restrictedRBAC(contractEditorUser, contractSuperUser), contractScope())
+
+	editor := assertBoundEqualsUnbound(t, editorStack, contractEditorUser, nil, sec40Requests())
+	assertOutcome(t, outcomeFromResult(editor[0]), false, true, "making cluster-scoped requests for namespaced resources is not allowed")
+	assertOutcome(t, outcomeFromResult(editor[1]), true, false, "")
+	assertOutcome(t, outcomeFromResult(editor[2]), false, true, "either you have no access to the namespace or the namespace does not exist")
+	assert.False(t, editor[3].Allowed, "Editor RBAC has no nodes: %+v", editor[3])
+	assert.False(t, editor[3].Denied, "nodes are cluster-scoped, MT must not Deny: %+v", editor[3])
+
+	super := assertBoundEqualsUnbound(t, superStack, contractSuperUser, nil, sec40Requests())
+	for i, r := range super {
+		assert.True(t, r.Allowed, "SuperAdmin request %d: %+v", i, r)
+		assert.False(t, r.Denied)
+	}
+}
+
+// TestBulkSARStorage_Create_WildcardEditorClusterReality locks the live
+// cluster shape: user-authz:editor is effectively * * *, so MT is the only
+// deny. get nodes is Allowed via the CAR CRB.
+func TestBulkSARStorage_Create_WildcardEditorClusterReality(t *testing.T) {
+	editorStack := newContractStack(t, bulkSAREditorConfig, wildcardRBAC(contractEditorUser, contractSuperUser), contractScope())
+	superStack := newContractStack(t, bulkSARSuperConfig, wildcardRBAC(contractEditorUser, contractSuperUser), contractScope())
+	reqs := consoleContractRequests()
+
+	editor := assertBoundEqualsUnbound(t, editorStack, contractEditorUser, nil, reqs)
+	super := assertBoundEqualsUnbound(t, superStack, contractSuperUser, nil, reqs)
+	require.Len(t, editor, len(reqs))
+	require.Len(t, super, len(reqs))
+
+	denyClusterNamespaced := map[int]struct{}{
+		0: {}, 1: {}, 2: {}, 3: {}, 4: {}, 5: {}, 6: {}, 25: {},
+	}
+	denyOutsideNS := map[int]struct{}{
+		19: {}, 20: {}, 21: {}, 22: {}, 23: {},
+	}
+	unknownGVR := 24
+	projectsList := 12
+	projectsCreate := 13
+	nodesGet := 7
+	podsIn := 14
+	podsLogIn := 26
+	nonResource := 27
+
+	for i, r := range editor {
+		got := outcomeFromResult(r)
+		switch {
+		case i == unknownGVR:
+			assertOutcome(t, got, false, true, "making cluster-scoped requests for namespaced resources is not allowed")
+		case i == projectsList:
+			assert.True(t, got.Allowed, "list projects: %+v", got)
+			assert.False(t, got.Denied)
+		case i == projectsCreate:
+			assert.True(t, got.Allowed, "wildcard Editor create projects: %+v", got)
+		case i == nodesGet:
+			assert.True(t, got.Allowed, "wildcard Editor get nodes: %+v", got)
+			assert.False(t, got.Denied)
+		case i == podsIn || i == podsLogIn:
+			assert.True(t, got.Allowed, "item %d: %+v", i, got)
+			assert.False(t, got.Denied)
+		case i == nonResource:
+			assert.True(t, got.Allowed, "non-resource: %+v", got)
+		case func() bool { _, ok := denyClusterNamespaced[i]; return ok }():
+			assertOutcome(t, got, false, true, "making cluster-scoped requests for namespaced resources is not allowed")
+		case func() bool { _, ok := denyOutsideNS[i]; return ok }():
+			assertOutcome(t, got, false, true, "either you have no access to the namespace or the namespace does not exist")
+		default:
+			assert.True(t, got.Allowed, "item %d should be allowed for wildcard Editor: %+v req=%+v", i, got, reqs[i])
+			assert.False(t, got.Denied)
+		}
+	}
+
+	for i, r := range super {
+		assert.True(t, r.Allowed, "SuperAdmin item %d: %+v req=%+v", i, r, reqs[i])
+		assert.False(t, r.Denied)
+	}
+}
+
+func TestBulkSARStorage_Create_LimitNamespacesEqualsLabelSelector(t *testing.T) {
+	objs := wildcardRBAC(contractEditorUser, contractSuperUser)
+	limited := newContractStack(t, bulkSAREditorConfig, objs, contractScope())
+	selected := newContractStack(t, editorLabelSelectorConfig, objs, contractScope())
+	reqs := consoleContractRequests()
+
+	fromLimit := assertBoundEqualsUnbound(t, limited, contractEditorUser, nil, reqs)
+	fromSelector := assertBoundEqualsUnbound(t, selected, contractEditorUser, nil, reqs)
+	for i := range reqs {
+		assert.Equal(t, outcomeFromResult(fromLimit[i]), outcomeFromResult(fromSelector[i]),
+			"item %d %+v", i, reqs[i])
+	}
+}
+
+func TestBulkSARStorage_Create_RestrictedEditorIdentityReadAndNodes(t *testing.T) {
+	stack := newContractStack(t, bulkSAREditorConfig, restrictedRBAC(contractEditorUser, contractSuperUser), contractScope())
+	reqs := consoleContractRequests()
+	got := assertBoundEqualsUnbound(t, stack, contractEditorUser, nil, reqs)
+
+	assert.True(t, got[7].Allowed == false && got[7].Denied == false, "get nodes NoOpinion: %+v", got[7])
+	assert.True(t, got[8].Allowed == false && got[8].Denied == false, "list nodes NoOpinion: %+v", got[8])
+	assert.True(t, got[10].Allowed == false && got[10].Denied == false, "list clusterroles NoOpinion: %+v", got[10])
+
+	assert.True(t, got[12].Allowed, "list projects via IdentityRead: %+v", got[12])
+	assert.Equal(t, filteredReadReason, got[12].Reason)
+	assert.False(t, got[13].Allowed, "create projects is not an identity read: %+v", got[13])
+	assert.False(t, got[13].Denied)
+
+	assert.True(t, got[0].Denied)
+	assert.True(t, got[14].Allowed, "get pods ns-in: %+v", got[14])
+	assert.True(t, got[19].Denied, "get pods ns-out: %+v", got[19])
+	assert.True(t, got[24].Denied, "unknown GVR: %+v", got[24])
+}
+
+func TestBulkSARStorage_Create_IndependentRBACRescuesWithoutCARCRB(t *testing.T) {
+	objs := append(restrictedRBAC(contractEditorUser, contractSuperUser),
+		&rbacv1.Role{
+			ObjectMeta: metav1.ObjectMeta{Name: "pod-reader", Namespace: "ns-out"},
+			Rules:      []rbacv1.PolicyRule{{APIGroups: []string{""}, Resources: []string{"pods"}, Verbs: []string{"get", "list"}}},
+		},
+		&rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "editor-pod-reader", Namespace: "ns-out"},
+			Subjects:   []rbacv1.Subject{{Kind: rbacv1.UserKind, Name: contractEditorUser}},
+			RoleRef:    rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "Role", Name: "pod-reader"},
+		},
+		clusterRole("secret-viewer", []rbacv1.PolicyRule{
+			{APIGroups: []string{""}, Resources: []string{"secrets"}, Verbs: []string{"get", "list"}},
+		}),
+		userCRB("editor-secret-viewer", "secret-viewer", contractEditorUser),
+	)
+	stack := newContractStack(t, bulkSAREditorConfig, objs, contractScope())
+
+	reqs := []v1alpha1.SubjectAccessReviewRequest{
+		ra("list", "", "pods", ""),
+		ra("get", "", "pods", "ns-out"),
+		ra("delete", "", "pods", "ns-out"),
+		ra("list", "", "secrets", ""),
+		ra("get", "", "secrets", "ns-out"),
+		ra("get", "apps", "deployments", "ns-out"),
+	}
+	got := assertBoundEqualsUnbound(t, stack, contractEditorUser, nil, reqs)
+
+	assertOutcome(t, outcomeFromResult(got[0]), false, true, "making cluster-scoped requests for namespaced resources is not allowed")
+	assert.True(t, got[1].Allowed, "RoleBinding must rescue get pods in ns-out: %+v", got[1])
+	assertOutcome(t, outcomeFromResult(got[2]), false, true, "either you have no access to the namespace or the namespace does not exist")
+	assert.True(t, got[3].Allowed, "user CRB must rescue cluster-scoped list secrets: %+v", got[3])
+	assert.True(t, got[4].Allowed, "user CRB must rescue get secrets in ns-out: %+v", got[4])
+	assertOutcome(t, outcomeFromResult(got[5]), false, true, "either you have no access to the namespace or the namespace does not exist")
+}
+
+func TestBulkSARStorage_Create_SelfModeMatchesNonSelf(t *testing.T) {
+	stack := newContractStack(t, bulkSAREditorConfig, wildcardRBAC(contractEditorUser, contractSuperUser), contractScope())
+	reqs := sec40Requests()
+
+	nonSelf := createBulkSAR(t, stack.storage, contractEditorUser, nil, reqs)
+
+	ctx := request.WithUser(context.Background(), &user.DefaultInfo{Name: contractEditorUser})
+	out, err := stack.storage.Create(ctx, &v1alpha1.BulkSubjectAccessReview{
+		Spec: v1alpha1.BulkSubjectAccessReviewSpec{Requests: reqs},
+	}, nil, nil)
+	require.NoError(t, err)
+	self := out.(*v1alpha1.BulkSubjectAccessReview).Status.Results
+	require.Len(t, self, len(nonSelf))
+	for i := range nonSelf {
+		assert.Equal(t, outcomeFromResult(nonSelf[i]), outcomeFromResult(self[i]), "item %d", i)
+	}
+}
+
+func TestBulkSARStorage_Create_GroupSubjectMatchesUserSubject(t *testing.T) {
+	const groupConfig = `{
+		"crds": [{
+			"name": "editor-group",
+			"spec": {
+				"accessLevel": "Editor",
+				"limitNamespaces": ["ns-in"],
+				"subjects": [{"kind": "Group", "name": "editors"}]
+			}
+		}]
+	}`
+	member := "grouped@example.io"
+	objs := append(labeledNS(), reviewerObjects()...)
+	objs = append(objs,
+		clusterRole("user-authz:editor", wildcardRules()),
+		carCRB("user-authz:grouped:editor", "user-authz:editor", member),
+	)
+	groupStack := newContractStack(t, groupConfig, objs, contractScope())
+	userStack := newContractStack(t, bulkSAREditorConfig, wildcardRBAC(contractEditorUser, contractSuperUser), contractScope())
+
+	fromUser := createBulkSAR(t, userStack.storage, contractEditorUser, nil, sec40Requests())
+	fromGroup := createBulkSAR(t, groupStack.storage, member, []string{"editors"}, sec40Requests())
+	for i := range fromUser {
+		assert.Equal(t, fromUser[i].Allowed, fromGroup[i].Allowed, "allowed item %d", i)
+		assert.Equal(t, fromUser[i].Denied, fromGroup[i].Denied, "denied item %d", i)
+		if fromUser[i].Denied || fromGroup[i].Denied {
+			assert.Equal(t, fromUser[i].Reason, fromGroup[i].Reason, "deny reason item %d", i)
+		}
+	}
+}
+
+func TestBulkSARStorage_Create_UnknownScopeIsDeniedForFilteredUser(t *testing.T) {
+	stack := newContractStack(t, bulkSAREditorConfig, wildcardRBAC(contractEditorUser, contractSuperUser), staticResourceScope{})
+	got := createBulkSAR(t, stack.storage, contractEditorUser, nil, []v1alpha1.SubjectAccessReviewRequest{
+		ra("list", "", "pods", ""),
+		ra("get", "", "nodes", ""),
+	})
+	assertOutcome(t, outcomeFromResult(got[0]), false, true, "making cluster-scoped requests for namespaced resources is not allowed")
+	assertOutcome(t, outcomeFromResult(got[1]), false, true, "making cluster-scoped requests for namespaced resources is not allowed")
+}
+
+func TestBulkSARStorage_Create_EmptyScopeDoesNotChangeSuperAdmin(t *testing.T) {
+	empty := newContractStack(t, bulkSARSuperConfig, wildcardRBAC(contractEditorUser, contractSuperUser), staticResourceScope{})
+	full := newContractStack(t, bulkSARSuperConfig, wildcardRBAC(contractEditorUser, contractSuperUser), contractScope())
+	reqs := consoleContractRequests()
+
+	fromEmpty := createBulkSAR(t, empty.storage, contractSuperUser, nil, reqs)
+	fromFull := createBulkSAR(t, full.storage, contractSuperUser, nil, reqs)
+	for i := range reqs {
+		assert.Equal(t, fromFull[i].Allowed, fromEmpty[i].Allowed, "allowed item %d %+v", i, reqs[i])
+		assert.Equal(t, fromFull[i].Denied, fromEmpty[i].Denied, "denied item %d %+v", i, reqs[i])
+		assert.True(t, fromEmpty[i].Allowed, "SuperAdmin matchAny must Allow item %d: %+v", i, fromEmpty[i])
+	}
+}

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/registry/storage_mtfilter_test.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/registry/storage_mtfilter_test.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2025 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package registry
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/client-go/discovery"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	clienttesting "k8s.io/client-go/testing"
+
+	"permission-browser-apiserver/pkg/apis/authorization/v1alpha1"
+	"permission-browser-apiserver/pkg/authorizer/composite"
+	"permission-browser-apiserver/pkg/authorizer/multitenancy"
+)
+
+// allowAllAuthorizer grants every request. BulkSAR results then follow only
+// the multi-tenancy layer: Deny stays denied, NoOpinion becomes allowed. That
+// is the console cani shape once the subject has a CAR accessLevel binding.
+type allowAllAuthorizer struct{}
+
+func (allowAllAuthorizer) Authorize(context.Context, authorizer.Attributes) (authorizer.Decision, string, error) {
+	return authorizer.DecisionAllow, "rbac-allow-all", nil
+}
+
+type denyIndependent struct{}
+
+func (denyIndependent) AllowsIndependently(context.Context, authorizer.Attributes) bool {
+	return false
+}
+
+func writeMTConfig(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.json")
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o600))
+	return path
+}
+
+func newDiscoveryStub() discovery.DiscoveryInterface {
+	fake := &fakediscovery.FakeDiscovery{Fake: &clienttesting.Fake{}}
+	fake.Resources = []*metav1.APIResourceList{{
+		GroupVersion: "v1",
+		APIResources: []metav1.APIResource{
+			{Name: "pods", Namespaced: true},
+			{Name: "nodes", Namespaced: false},
+		},
+	}}
+	return fake
+}
+
+func mustMTEngine(t *testing.T, config string) *multitenancy.Engine {
+	t.Helper()
+	engine, err := multitenancy.NewEngine(writeMTConfig(t, config), nil, nil, newDiscoveryStub())
+	require.NoError(t, err)
+	engine.SetIndependentRBACChecker(denyIndependent{})
+	return engine
+}
+
+const (
+	bulkSAREditorConfig = `{
+		"crds": [{
+			"name": "editor",
+			"spec": {
+				"accessLevel": "Editor",
+				"limitNamespaces": ["ns-in"],
+				"subjects": [{"kind": "User", "name": "editor@example.io"}]
+			}
+		}]
+	}`
+	bulkSARSuperConfig = `{
+		"crds": [{
+			"name": "super",
+			"spec": {
+				"accessLevel": "SuperAdmin",
+				"allowAccessToSystemNamespaces": true,
+				"namespaceSelector": {"matchAny": true},
+				"subjects": [{"kind": "User", "name": "super@example.io"}]
+			}
+		}]
+	}`
+)
+
+func consoleLikeRequests() []v1alpha1.SubjectAccessReviewRequest {
+	return []v1alpha1.SubjectAccessReviewRequest{
+		{ResourceAttributes: &v1alpha1.ResourceAttributes{Verb: "list", Resource: "pods"}},
+		{ResourceAttributes: &v1alpha1.ResourceAttributes{Verb: "get", Resource: "pods", Namespace: "ns-in"}},
+		{ResourceAttributes: &v1alpha1.ResourceAttributes{Verb: "get", Resource: "pods", Namespace: "ns-out"}},
+		{ResourceAttributes: &v1alpha1.ResourceAttributes{Verb: "get", Resource: "nodes"}},
+	}
+}
+
+func evalBulkSAR(t *testing.T, engine *multitenancy.Engine, subject string) []v1alpha1.SubjectAccessReviewResult {
+	t.Helper()
+	storage := NewBulkSARStorage(composite.NewCompositeAuthorizer(engine, allowAllAuthorizer{}))
+	ctx := request.WithUser(context.Background(), &user.DefaultInfo{
+		Name:   "admin",
+		Groups: []string{"system:masters"},
+	})
+	out, err := storage.Create(ctx, &v1alpha1.BulkSubjectAccessReview{
+		Spec: v1alpha1.BulkSubjectAccessReviewSpec{
+			User:     subject,
+			Requests: consoleLikeRequests(),
+		},
+	}, nil, nil)
+	require.NoError(t, err)
+	got, ok := out.(*v1alpha1.BulkSubjectAccessReview)
+	require.True(t, ok)
+	require.Len(t, got.Status.Results, 4)
+	return got.Status.Results
+}
+
+// TestBulkSARStorage_Create_MTFilterContract is the BulkSAR view of the
+// Editor vs SuperAdmin matrix. RBAC is allow-all so each item is decided
+// only by multi-tenancy. Optimization must keep these four answers.
+func TestBulkSARStorage_Create_MTFilterContract(t *testing.T) {
+	editor := evalBulkSAR(t, mustMTEngine(t, bulkSAREditorConfig), "editor@example.io")
+	assert.True(t, editor[0].Denied, "editor list pods cluster-scoped: %+v", editor[0])
+	assert.False(t, editor[0].Allowed)
+	assert.Contains(t, editor[0].Reason, "cluster-scoped requests for namespaced resources")
+	assert.True(t, editor[1].Allowed, "editor get pods in CAR ns: %+v", editor[1])
+	assert.False(t, editor[1].Denied)
+	assert.True(t, editor[2].Denied, "editor get pods outside CAR ns: %+v", editor[2])
+	assert.False(t, editor[2].Allowed)
+	assert.True(t, editor[3].Allowed, "editor get nodes (cluster-scoped resource): %+v", editor[3])
+	assert.False(t, editor[3].Denied)
+
+	super := evalBulkSAR(t, mustMTEngine(t, bulkSARSuperConfig), "super@example.io")
+	for i, r := range super {
+		assert.True(t, r.Allowed, "superadmin request %d: %+v", i, r)
+		assert.False(t, r.Denied)
+	}
+}

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/registry/storage_mtfilter_test.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/registry/storage_mtfilter_test.go
@@ -44,6 +44,8 @@ func (s staticResourceScope) Scope(group, resource string) (namespaced, known bo
 	return namespaced, known
 }
 
+func (s staticResourceScope) HasData() bool { return len(s) > 0 }
+
 func writeMTConfig(t *testing.T, body string) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "config.json")

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/registry/storage_mtfilter_test.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/registry/storage_mtfilter_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 Flant JSC
+Copyright 2026 Flant JSC
 Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
 */
 
@@ -13,13 +13,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/apiserver/pkg/endpoints/request"
-	"k8s.io/client-go/discovery"
-	fakediscovery "k8s.io/client-go/discovery/fake"
-	clienttesting "k8s.io/client-go/testing"
 
 	"permission-browser-apiserver/pkg/apis/authorization/v1alpha1"
 	"permission-browser-apiserver/pkg/authorizer/composite"
@@ -41,6 +37,13 @@ func (denyIndependent) AllowsIndependently(context.Context, authorizer.Attribute
 	return false
 }
 
+type staticResourceScope map[string]bool
+
+func (s staticResourceScope) Scope(group, resource string) (namespaced, known bool) {
+	namespaced, known = s[group+"/"+resource]
+	return namespaced, known
+}
+
 func writeMTConfig(t *testing.T, body string) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "config.json")
@@ -48,21 +51,12 @@ func writeMTConfig(t *testing.T, body string) string {
 	return path
 }
 
-func newDiscoveryStub() discovery.DiscoveryInterface {
-	fake := &fakediscovery.FakeDiscovery{Fake: &clienttesting.Fake{}}
-	fake.Resources = []*metav1.APIResourceList{{
-		GroupVersion: "v1",
-		APIResources: []metav1.APIResource{
-			{Name: "pods", Namespaced: true},
-			{Name: "nodes", Namespaced: false},
-		},
-	}}
-	return fake
-}
-
 func mustMTEngine(t *testing.T, config string) *multitenancy.Engine {
 	t.Helper()
-	engine, err := multitenancy.NewEngine(writeMTConfig(t, config), nil, nil, newDiscoveryStub())
+	engine, err := multitenancy.NewEngine(writeMTConfig(t, config), nil, nil, staticResourceScope{
+		"/pods":  true,
+		"/nodes": false,
+	})
 	require.NoError(t, err)
 	engine.SetIndependentRBACChecker(denyIndependent{})
 	return engine

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/resolver/namespace_test.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/resolver/namespace_test.go
@@ -745,6 +745,89 @@ func TestResolveAccessibleNamespaces_CARLimitOnly_Unchanged(t *testing.T) {
 		"CAR-only user must see exactly the CAR's limited namespaces")
 }
 
+// TestResolveAccessibleNamespaces_SuperAdminVsEditor locks the AccessibleNamespaces
+// split that BulkSAR must stay consistent with: SuperAdmin (matchAny, system
+// access) sees every namespace the CAR CRB can reach, including kube-system;
+// Editor (limitNamespaces) sees only the CAR ns and never a system ns.
+func TestResolveAccessibleNamespaces_SuperAdminVsEditor(t *testing.T) {
+	deckhouseLabels := map[string]string{"heritage": "deckhouse", "module": "user-authz"}
+	wildcard := []rbacv1.PolicyRule{{
+		APIGroups: []string{"*"}, Resources: []string{"*"}, Verbs: []string{"*"},
+	}}
+	objs := []runtime.Object{
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns-in"}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns-out"}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kube-system"}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "d8-system"}},
+		&rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{Name: "user-authz:super-admin"},
+			Rules:      wildcard,
+		},
+		&rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{Name: "user-authz:editor"},
+			Rules:      wildcard,
+		},
+		&rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "user-authz:super:super-admin", Labels: deckhouseLabels},
+			Subjects:   []rbacv1.Subject{{Kind: rbacv1.UserKind, Name: "super@example.io"}},
+			RoleRef:    rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "ClusterRole", Name: "user-authz:super-admin"},
+		},
+		&rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "user-authz:editor:editor", Labels: deckhouseLabels},
+			Subjects:   []rbacv1.Subject{{Kind: rbacv1.UserKind, Name: "editor@example.io"}},
+			RoleRef:    rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "ClusterRole", Name: "user-authz:editor"},
+		},
+	}
+
+	superEngine := newMTEngineFromConfig(t, `{
+		"crds": [{
+			"name": "super",
+			"spec": {
+				"accessLevel": "SuperAdmin",
+				"allowAccessToSystemNamespaces": true,
+				"namespaceSelector": {"matchAny": true},
+				"subjects": [{"kind": "User", "name": "super@example.io"}]
+			}
+		}]
+	}`)
+	editorEngine := newMTEngineFromConfig(t, `{
+		"crds": [{
+			"name": "editor",
+			"spec": {
+				"accessLevel": "Editor",
+				"limitNamespaces": ["ns-in"],
+				"subjects": [{"kind": "User", "name": "editor@example.io"}]
+			}
+		}]
+	}`)
+
+	superNS, err := setupResolver(t, objs, superEngine).ResolveAccessibleNamespaces(
+		&user.DefaultInfo{Name: "super@example.io", Groups: []string{"system:authenticated"}},
+	)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"ns-in", "ns-out", "kube-system", "d8-system"}, superNS,
+		"SuperAdmin matchAny must list every namespace the CAR CRB can reach")
+
+	editorNS, err := setupResolver(t, objs, editorEngine).ResolveAccessibleNamespaces(
+		&user.DefaultInfo{Name: "editor@example.io", Groups: []string{"system:authenticated"}},
+	)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"ns-in"}, editorNS,
+		"Editor limitNamespaces must not leak ns-out or system namespaces")
+
+	editorResolver := setupResolver(t, objs, editorEngine)
+	editorUser := &user.DefaultInfo{Name: "editor@example.io", Groups: []string{"system:authenticated"}}
+	in, err := editorResolver.IsNamespaceAccessible(editorUser, "ns-in")
+	require.NoError(t, err)
+	assert.True(t, in)
+	out, err := editorResolver.IsNamespaceAccessible(editorUser, "ns-out")
+	require.NoError(t, err)
+	assert.False(t, out)
+	sys, err := editorResolver.IsNamespaceAccessible(editorUser, "kube-system")
+	require.NoError(t, err)
+	assert.False(t, sys)
+}
+
 // Helper functions
 
 // newMTEngineFromConfig writes a user-authz config.json with the supplied raw body

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/resolver/namespace_test.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/resolver/namespace_test.go
@@ -884,6 +884,79 @@ func TestResolveAccessibleNamespaces_LimitNamespacesEqualsLabelSelector(t *testi
 	assert.ElementsMatch(t, fromLimit, fromSelector)
 }
 
+func TestResolveAccessibleNamespaces_TwoCARsUnion(t *testing.T) {
+	deckhouseLabels := map[string]string{"heritage": "deckhouse", "module": "user-authz"}
+	wildcard := []rbacv1.PolicyRule{{
+		APIGroups: []string{"*"}, Resources: []string{"*"}, Verbs: []string{"*"},
+	}}
+	objs := []runtime.Object{
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns-a"}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns-b"}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns-out"}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
+		&rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{Name: "user-authz:editor"},
+			Rules:      wildcard,
+		},
+		&rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "user-authz:a:editor", Labels: deckhouseLabels},
+			Subjects:   []rbacv1.Subject{{Kind: rbacv1.UserKind, Name: "dual@example.io"}},
+			RoleRef:    rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "ClusterRole", Name: "user-authz:editor"},
+		},
+		&rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "user-authz:b:editor", Labels: deckhouseLabels},
+			Subjects:   []rbacv1.Subject{{Kind: rbacv1.UserKind, Name: "dual@example.io"}},
+			RoleRef:    rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "ClusterRole", Name: "user-authz:editor"},
+		},
+	}
+	engine := newMTEngineFromConfig(t, `{
+		"crds": [
+			{"name": "a", "spec": {"limitNamespaces": ["ns-a"], "subjects": [{"kind": "User", "name": "dual@example.io"}]}},
+			{"name": "b", "spec": {"limitNamespaces": ["ns-b"], "subjects": [{"kind": "User", "name": "dual@example.io"}]}}
+		]
+	}`)
+	got, err := setupResolver(t, objs, engine).ResolveAccessibleNamespaces(
+		&user.DefaultInfo{Name: "dual@example.io", Groups: []string{"system:authenticated"}},
+	)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"ns-a", "ns-b"}, got)
+}
+
+func TestResolveAccessibleNamespaces_DefaultIsSystem(t *testing.T) {
+	deckhouseLabels := map[string]string{"heritage": "deckhouse", "module": "user-authz"}
+	wildcard := []rbacv1.PolicyRule{{
+		APIGroups: []string{"*"}, Resources: []string{"*"}, Verbs: []string{"*"},
+	}}
+	objs := []runtime.Object{
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns-in"}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
+		&rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{Name: "user-authz:editor"},
+			Rules:      wildcard,
+		},
+		&rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "user-authz:editor:editor", Labels: deckhouseLabels},
+			Subjects:   []rbacv1.Subject{{Kind: rbacv1.UserKind, Name: "editor@example.io"}},
+			RoleRef:    rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "ClusterRole", Name: "user-authz:editor"},
+		},
+	}
+	engine := newMTEngineFromConfig(t, `{
+		"crds": [{
+			"name": "editor",
+			"spec": {
+				"limitNamespaces": ["ns-in", "default"],
+				"subjects": [{"kind": "User", "name": "editor@example.io"}]
+			}
+		}]
+	}`)
+	got, err := setupResolver(t, objs, engine).ResolveAccessibleNamespaces(
+		&user.DefaultInfo{Name: "editor@example.io"},
+	)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"ns-in"}, got,
+		"default is a system namespace and stays hidden without allowAccessToSystemNamespaces")
+}
+
 // Helper functions
 
 // newMTEngineFromConfig writes a user-authz config.json with the supplied raw body

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/resolver/namespace_test.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/resolver/namespace_test.go
@@ -828,6 +828,62 @@ func TestResolveAccessibleNamespaces_SuperAdminVsEditor(t *testing.T) {
 	assert.False(t, sys)
 }
 
+// TestResolveAccessibleNamespaces_LimitNamespacesEqualsLabelSelector locks
+// that the two CAR filter forms produce the same AccessibleNamespaces set.
+func TestResolveAccessibleNamespaces_LimitNamespacesEqualsLabelSelector(t *testing.T) {
+	deckhouseLabels := map[string]string{"heritage": "deckhouse", "module": "user-authz"}
+	wildcard := []rbacv1.PolicyRule{{
+		APIGroups: []string{"*"}, Resources: []string{"*"}, Verbs: []string{"*"},
+	}}
+	objs := []runtime.Object{
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+			Name:   "ns-in",
+			Labels: map[string]string{"pba-perf": "true"},
+		}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns-out"}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kube-system"}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "d8-system"}},
+		&rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{Name: "user-authz:editor"},
+			Rules:      wildcard,
+		},
+		&rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "user-authz:editor:editor", Labels: deckhouseLabels},
+			Subjects:   []rbacv1.Subject{{Kind: rbacv1.UserKind, Name: "editor@example.io"}},
+			RoleRef:    rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "ClusterRole", Name: "user-authz:editor"},
+		},
+	}
+
+	limitEngine := newMTEngineWithNamespaces(t, `{
+		"crds": [{
+			"name": "editor",
+			"spec": {
+				"accessLevel": "Editor",
+				"limitNamespaces": ["ns-in"],
+				"subjects": [{"kind": "User", "name": "editor@example.io"}]
+			}
+		}]
+	}`, objs)
+	selectorEngine := newMTEngineWithNamespaces(t, `{
+		"crds": [{
+			"name": "editor-sel",
+			"spec": {
+				"accessLevel": "Editor",
+				"namespaceSelector": {"labelSelector": {"matchLabels": {"pba-perf": "true"}}},
+				"subjects": [{"kind": "User", "name": "editor@example.io"}]
+			}
+		}]
+	}`, objs)
+
+	u := &user.DefaultInfo{Name: "editor@example.io", Groups: []string{"system:authenticated"}}
+	fromLimit, err := setupResolver(t, objs, limitEngine).ResolveAccessibleNamespaces(u)
+	require.NoError(t, err)
+	fromSelector, err := setupResolver(t, objs, selectorEngine).ResolveAccessibleNamespaces(u)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"ns-in"}, fromLimit)
+	assert.ElementsMatch(t, fromLimit, fromSelector)
+}
+
 // Helper functions
 
 // newMTEngineFromConfig writes a user-authz config.json with the supplied raw body
@@ -840,6 +896,31 @@ func newMTEngineFromConfig(t *testing.T, body string) *multitenancy.Engine {
 	path := filepath.Join(dir, "config.json")
 	require.NoError(t, os.WriteFile(path, []byte(body), 0o600))
 	engine, err := multitenancy.NewEngine(path, nil, nil, nil)
+	require.NoError(t, err)
+	return engine
+}
+
+// newMTEngineWithNamespaces is newMTEngineFromConfig plus a namespace lister
+// so namespaceSelector.matchLabels can resolve. The lister is backed by a
+// separate fake client populated from objs; setupResolver builds its own.
+func newMTEngineWithNamespaces(t *testing.T, body string, objs []runtime.Object) *multitenancy.Engine {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o600))
+
+	client := fake.NewSimpleClientset(objs...)
+	factory := informers.NewSharedInformerFactory(client, 0)
+	nsInformer := factory.Core().V1().Namespaces()
+	lister := nsInformer.Lister() // register before Start
+	stop := make(chan struct{})
+	t.Cleanup(func() { close(stop) })
+	factory.Start(stop)
+	for typ, ok := range factory.WaitForCacheSync(stop) {
+		require.True(t, ok, "informer %v failed to sync", typ)
+	}
+
+	engine, err := multitenancy.NewEngine(path, lister, func() bool { return true }, nil)
 	require.NoError(t, err)
 	return engine
 }

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/resolver/scope_cache.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/resolver/scope_cache.go
@@ -12,7 +12,11 @@ import (
 
 	"k8s.io/client-go/discovery"
 	"k8s.io/klog/v2"
+
+	"permission-browser-apiserver/pkg/authorizer/multitenancy"
 )
+
+var _ multitenancy.ResourceScope = (*ResourceScopeCache)(nil)
 
 const (
 	// defaultRefreshInterval is how often the scope cache refreshes from discovery.
@@ -74,6 +78,19 @@ func (c *ResourceScopeCache) IsNamespaced(group, resource string) bool {
 		return false
 	}
 	return namespaced
+}
+
+// Scope reports whether the resource is namespaced and whether the snapshot
+// contains it. Unlike IsNamespaced, a miss is not coerced to cluster-scoped:
+// multi-tenancy uses !known as "treat like namespaced" so a discovery hole
+// cannot fail-open. IsNamespaced stays fail-closed-as-cluster-scoped for
+// AccessibleNamespaces (a false namespaced=true would list every namespace).
+func (c *ResourceScopeCache) Scope(group, resource string) (namespaced, known bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	namespaced, known = c.scopeMap[group+"/"+resource]
+	return namespaced, known
 }
 
 // HasResource reports whether the discovery snapshot serves the resource at

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/resolver/scope_cache.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/resolver/scope_cache.go
@@ -85,11 +85,11 @@ func (c *ResourceScopeCache) IsNamespaced(group, resource string) bool {
 // multi-tenancy uses !known as "treat like namespaced" so a discovery hole
 // cannot fail-open. IsNamespaced stays fail-closed-as-cluster-scoped for
 // AccessibleNamespaces (a false namespaced=true would list every namespace).
-func (c *ResourceScopeCache) Scope(group, resource string) (namespaced, known bool) {
+func (c *ResourceScopeCache) Scope(group, resource string) (bool, bool) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	namespaced, known = c.scopeMap[group+"/"+resource]
+	namespaced, known := c.scopeMap[group+"/"+resource]
 	return namespaced, known
 }
 

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/resolver/scope_cache.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/resolver/scope_cache.go
@@ -85,7 +85,14 @@ func (c *ResourceScopeCache) IsNamespaced(group, resource string) bool {
 // multi-tenancy uses !known as "treat like namespaced" so a discovery hole
 // cannot fail-open. IsNamespaced stays fail-closed-as-cluster-scoped for
 // AccessibleNamespaces (a false namespaced=true would list every namespace).
+//
+// A nil *ResourceScopeCache answers like an empty one, so a typed nil handed to an interface value
+// is as safe as a nil interface.
 func (c *ResourceScopeCache) Scope(group, resource string) (bool, bool) {
+	if c == nil {
+		return false, false
+	}
+
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
@@ -98,6 +105,10 @@ func (c *ResourceScopeCache) Scope(group, resource string) (bool, bool) {
 // this to make a claim the plain RBAC answer would not support, and a claim
 // about a resource we have never seen is worse than no claim.
 func (c *ResourceScopeCache) HasResource(group, resource string) bool {
+	if c == nil {
+		return false
+	}
+
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
@@ -164,6 +175,10 @@ func matchesResource(ruleResources []string, resource string) bool {
 // This can be used for readiness checks: an empty cache means we could not
 // fetch discovery data yet and would treat all unknown resources as cluster-scoped.
 func (c *ResourceScopeCache) HasData() bool {
+	if c == nil {
+		return false
+	}
+
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return len(c.scopeMap) > 0
@@ -196,28 +211,48 @@ func (c *ResourceScopeCache) StartRefreshLoop(stopCh <-chan struct{}) {
 	}
 }
 
-// refresh fetches all API resources from discovery and rebuilds the scope map.
-// On error, the existing cache is preserved (stale data is better than no data).
+// refresh fetches the served resources from discovery and merges them into the scope map.
+//
+// ServerGroupsAndResources lists every version of every group, subresources included (the
+// preferred-resources call drops the names with a "/"), so HasNamespacedResourceMatching sees the
+// same resources RBAC does. On a partial failure the call returns the lists it did fetch together
+// with an ErrGroupDiscoveryFailed naming the GroupVersions it could not. The entries of those groups
+// are carried over from the previous snapshot: a miss in the map now decides an authorization
+// answer (Scope), so an APIService that is down for a minute must not evict its resources. A group
+// that is neither returned nor reported as failed has left the cluster and its entries go. Any other
+// error, or an empty result, preserves the whole snapshot.
 func (c *ResourceScopeCache) refresh() {
 	if c.discoveryClient == nil {
 		klog.V(4).Info("ResourceScopeCache: no discovery client, skipping refresh")
 		return
 	}
 
-	// ServerPreferredResources returns resources for all groups in one call.
-	// It may return partial results along with an error for some groups.
-	resourceLists, err := c.discoveryClient.ServerPreferredResources()
+	_, resourceLists, err := c.discoveryClient.ServerGroupsAndResources()
+
+	// failedGroups are the groups whose entries are kept from the previous snapshot.
+	failedGroups := map[string]struct{}{}
 	if err != nil {
-		// ServerPreferredResources may return partial results with an error.
-		// If we got some results, use them; otherwise preserve the old cache.
-		if len(resourceLists) == 0 {
-			klog.Warningf("ResourceScopeCache: discovery failed completely: %v, preserving existing cache", err)
+		failedVersions, partial := discovery.GroupDiscoveryFailedErrorGroups(err)
+		if !partial || len(resourceLists) == 0 {
+			klog.Warningf("ResourceScopeCache: discovery failed: %v, preserving existing cache", err)
 			return
 		}
-		klog.V(4).Infof("ResourceScopeCache: discovery returned partial results: %v", err)
+		for gv := range failedVersions {
+			failedGroups[gv.Group] = struct{}{}
+		}
+		klog.V(4).Infof("ResourceScopeCache: discovery returned partial results, keeping the previous entries of %d groups: %v", len(failedGroups), err)
 	}
 
 	newMap := make(map[string]bool)
+
+	c.mu.RLock()
+	for key, namespaced := range c.scopeMap {
+		group, _, _ := strings.Cut(key, "/")
+		if _, keep := failedGroups[group]; keep {
+			newMap[key] = namespaced
+		}
+	}
+	c.mu.RUnlock()
 
 	for _, resourceList := range resourceLists {
 		if resourceList == nil {

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/resolver/scope_cache_test.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/resolver/scope_cache_test.go
@@ -90,6 +90,31 @@ func TestIsNamespaced_UnknownResource(t *testing.T) {
 		"unknown core resource should be assumed cluster-scoped")
 }
 
+// TestScope_KnownVsUnknown pins the three-way answer used by multi-tenancy:
+// known namespaced, known cluster-scoped, and !known. IsNamespaced must keep
+// coercing !known to cluster-scoped so AccessibleNamespaces does not inflate.
+func TestScope_KnownVsUnknown(t *testing.T) {
+	cache := &ResourceScopeCache{
+		scopeMap: map[string]bool{
+			"/pods":  true,
+			"/nodes": false,
+		},
+	}
+
+	namespaced, known := cache.Scope("", "pods")
+	assert.True(t, namespaced)
+	assert.True(t, known)
+
+	namespaced, known = cache.Scope("", "nodes")
+	assert.False(t, namespaced)
+	assert.True(t, known)
+
+	namespaced, known = cache.Scope("custom.example.com", "unknownresource")
+	assert.False(t, namespaced)
+	assert.False(t, known)
+	assert.False(t, cache.IsNamespaced("custom.example.com", "unknownresource"))
+}
+
 // TestRefresh_UpdatesCache tests that refresh updates the cache with new data
 func TestRefresh_UpdatesCache(t *testing.T) {
 	client := newMockDiscovery(testAPIResources(), nil)

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/resolver/scope_cache_test.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/resolver/scope_cache_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/openapi"
@@ -151,7 +152,8 @@ func TestRefresh_DiscoveryError_PreservesCache(t *testing.T) {
 	assert.False(t, cache.IsNamespaced("", "namespaces"), "namespaces should still be in cache after failed refresh")
 }
 
-// TestRefresh_PartialDiscoveryError_UsesPartialResults tests that partial results are used
+// TestRefresh_PartialDiscoveryError_UsesPartialResults tests that the groups discovery did
+// return are taken even when other groups failed.
 func TestRefresh_PartialDiscoveryError_UsesPartialResults(t *testing.T) {
 	// Discovery returns partial results with an error
 	partialResources := []*metav1.APIResourceList{
@@ -163,8 +165,11 @@ func TestRefresh_PartialDiscoveryError_UsesPartialResults(t *testing.T) {
 			},
 		},
 	}
+	partialErr := &discovery.ErrGroupDiscoveryFailed{Groups: map[schema.GroupVersion]error{
+		{Group: "metrics.k8s.io", Version: "v1beta1"}: fmt.Errorf("the server is currently unable to handle the request"),
+	}}
 	cache := &ResourceScopeCache{
-		discoveryClient: newMockDiscovery(partialResources, fmt.Errorf("partial error")),
+		discoveryClient: newMockDiscovery(partialResources, partialErr),
 		scopeMap:        make(map[string]bool),
 	}
 
@@ -173,6 +178,85 @@ func TestRefresh_PartialDiscoveryError_UsesPartialResults(t *testing.T) {
 	// Should use partial results
 	assert.True(t, cache.IsNamespaced("", "pods"))
 	assert.False(t, cache.IsNamespaced("", "nodes"))
+}
+
+// TestRefresh_PartialDiscoveryError_KeepsTheFailedGroups tests that a group whose discovery
+// failed keeps its previous entries (a down APIService must not turn its cluster-scoped
+// resources into !known, which the multi-tenancy engine treats as namespaced), that a group
+// discovery did return is replaced, and that a group that is neither returned nor failed is gone.
+func TestRefresh_PartialDiscoveryError_KeepsTheFailedGroups(t *testing.T) {
+	cache := &ResourceScopeCache{
+		discoveryClient: newMockDiscovery(
+			[]*metav1.APIResourceList{
+				{
+					GroupVersion: "v1",
+					APIResources: []metav1.APIResource{{Name: "pods", Namespaced: true, Kind: "Pod"}},
+				},
+				{
+					GroupVersion: "apps/v1",
+					APIResources: []metav1.APIResource{{Name: "deployments", Namespaced: true, Kind: "Deployment"}},
+				},
+			},
+			&discovery.ErrGroupDiscoveryFailed{Groups: map[schema.GroupVersion]error{
+				{Group: "metrics.k8s.io", Version: "v1beta1"}: fmt.Errorf("the server is currently unable to handle the request"),
+			}},
+		),
+		scopeMap: map[string]bool{
+			"/pods":                       true,
+			"apps/deployments":            true,
+			"apps/gone-in-this-version":   true,  // apps was returned: its old entries are replaced
+			"metrics.k8s.io/nodes":        false, // metrics.k8s.io failed: its entries are kept
+			"metrics.k8s.io/pods":         true,
+			"removed.example.com/widgets": false, // neither returned nor failed: the group is gone
+		},
+	}
+
+	cache.refresh()
+
+	namespaced, known := cache.Scope("metrics.k8s.io", "nodes")
+	assert.True(t, known, "the failed group must keep its entries")
+	assert.False(t, namespaced)
+	_, known = cache.Scope("metrics.k8s.io", "pods")
+	assert.True(t, known)
+
+	_, known = cache.Scope("apps", "deployments")
+	assert.True(t, known)
+	_, known = cache.Scope("apps", "gone-in-this-version")
+	assert.False(t, known, "a returned group is replaced by what discovery returned")
+
+	_, known = cache.Scope("removed.example.com", "widgets")
+	assert.False(t, known, "a group that discovery neither returned nor reported as failed has left the cluster")
+}
+
+// TestRefresh_NonDiscoveryError_PreservesCache tests that an error other than a partial group
+// failure preserves the whole snapshot even if some lists came back with it.
+func TestRefresh_NonDiscoveryError_PreservesCache(t *testing.T) {
+	cache := &ResourceScopeCache{
+		discoveryClient: newMockDiscovery(
+			[]*metav1.APIResourceList{{GroupVersion: "v1", APIResources: []metav1.APIResource{{Name: "pods", Namespaced: true}}}},
+			fmt.Errorf("connection refused"),
+		),
+		scopeMap: map[string]bool{"/nodes": false},
+	}
+
+	cache.refresh()
+
+	_, known := cache.Scope("", "nodes")
+	assert.True(t, known, "the previous snapshot must survive an unclassified discovery error")
+	_, known = cache.Scope("", "pods")
+	assert.False(t, known)
+}
+
+// TestNilCache_AnswersLikeEmpty tests that a nil *ResourceScopeCache, which a caller may hand to
+// an interface value by mistake, behaves like an empty cache instead of panicking.
+func TestNilCache_AnswersLikeEmpty(t *testing.T) {
+	var cache *ResourceScopeCache
+
+	namespaced, known := cache.Scope("", "pods")
+	assert.False(t, namespaced)
+	assert.False(t, known)
+	assert.False(t, cache.HasData())
+	assert.False(t, cache.HasResource("", "pods"))
 }
 
 // TestRefresh_NilDiscovery tests refresh with nil discovery client


### PR DESCRIPTION
## Description

Console `cani` is proxied to permission-browser `BulkSubjectAccessReview` (~258 `resourceAttributes`). SuperAdmin-like users finish in a few hundred milliseconds. Editor / ClusterAdmin with a real `namespaceSelector` or `limitNamespaces` hit the handler timeout (~30s).

The timeout is live discovery on the multi-tenancy Authorize hot path, not CRB count. `hasAnyFilters` makes every cluster-scoped item call `ServerGroups` + `ServerResourcesForGroupVersion` with `context.TODO()` and a 32s client-go timeout. Negative lookups are not cached. `ResourceScopeCache` already existed for AccessibleNamespaces / IdentityRead and was not passed into `NewEngine`.

This PR:

1. Locks the Editor vs SuperAdmin BulkSAR / ANS contract in unit tests.
2. Wires `ResourceScopeCache` into the MT engine and treats unknown GVRs as namespaced (fail-closed, same as the webhook). Live discovery is gone from Authorize.
3. Snapshots the subject's ClusterRoleBinding rules once per BulkSAR and reuses them for `Authorize` / `AllowsIndependently`. Label selectors are compiled in `renewDirectories`.

CAR / AR filter decisions are not cached. Only "is this GVR namespaced?" is. `AllowsIndependently` still skips `user-authz:` + `heritage=deckhouse` + `module=user-authz` CRBs.

A new cluster-scoped CRD can show a false Deny in the console for up to the 5-minute scope-cache refresh. That is a reporting miss, not an access hole. An API group whose discovery fails (an unavailable APIService, a CRD group mid-restart) keeps its entries from the previous refresh, so an outage does not turn its cluster-scoped resources into Deny; only a group that discovery no longer lists at all is evicted. The cache reads `ServerGroupsAndResources`, so subresources are present and the RBAC wildcard matching of `HasNamespacedResourceMatching` sees them.

## Why do we need it, and what problem does it solve?

Editor console cani timed out. SuperAdmin on the same payload did not. The permission browser reported Allow for discovery misses (fail-open through a CAR CRB) while the webhook Denied them.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authz
type: fix
summary: Speed up permission-browser BulkSAR for users with namespace filters
impact_level: default
```

## Manual Kubernetes measurements

Measured against the same 258-resource console payload from the incident, with
`time.perf_counter()` around `kubectl create --raw` and a 90s request timeout.
The incident was reproduced under the same relevant conditions, then repeated
with the fixed PR image using the same payload and measurement procedure.

| Subject | Pre-fix (10 runs) | Fixed PR (30 runs) |
| --- | ---: | ---: |
| `pbtest-20260204-car@example.com` | p50 34.454s, p95 34.789s, p99 34.886s, 0/10 completed | p50 263ms, p95 321ms, p99 923ms, 30/30 completed |
| `watchtest1`, groups=`watchtest1` | p50 34.521s, p95 34.591s, p99 34.598s, 0/10 completed | p50 261ms, p95 295ms, p99 302ms, 30/30 completed |

The pre-fix requests consistently hit the handler timeout. The fixed PR
returned all 258 results; the one 923ms p99 sample was a cold/first-request
outlier, with the remaining requests around 250-340ms. A size sweep on the
fixed PR grew from 199ms at one item to 309ms at 258 items.

