### PR TITLE
[docs] Tune VPA resource policies for moduleslibrary

### DIFF
--- a/docs/site/.helm/templates/14-moduleslibrary.yaml
+++ b/docs/site/.helm/templates/14-moduleslibrary.yaml
@@ -206,7 +206,20 @@ spec:
     name: moduleslibrary
   updatePolicy:
     updateMode: {{ pluck .Values.werf.env .Values.vpa.updateMode | first | default .Values.vpa.updateMode._default | quote }}
-
+  resourcePolicy:
+    containerPolicies:
+      - containerName: web
+        minAllowed:
+          memory: {{ pluck .Values.web.env .Values.resources.requests.memory.moduleslibrary.web | first | default .Values.resources.requests.memory.moduleslibrary.web._default }}
+        maxAllowed:
+          cpu: {{ pluck .Values.web.env .Values.resources.limits.cpu.moduleslibrary.web | first | default .Values.resources.limits.cpu.moduleslibrary.web._default }}
+          memory: {{ pluck .Values.web.env .Values.resources.limits.memory.moduleslibrary.web | first | default .Values.resources.limits.memory.moduleslibrary.web._default }}
+      - containerName: builder
+        minAllowed:
+          memory: {{ pluck .Values.web.env .Values.resources.requests.memory.moduleslibrary.builder | first | default .Values.resources.requests.memory.moduleslibrary.builder._default }}
+        maxAllowed:
+          cpu: {{ pluck .Values.web.env .Values.resources.limits.cpu.moduleslibrary.builder | first | default .Values.resources.limits.cpu.moduleslibrary.builder._default }}
+          memory: {{ pluck .Values.web.env .Values.resources.limits.memory.moduleslibrary.builder | first | default .Values.resources.limits.memory.moduleslibrary.builder._default }}
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget

--- a/docs/site/.helm/values.yaml
+++ b/docs/site/.helm/values.yaml
@@ -94,6 +94,16 @@ resources:
           web-test: 512Mi
           web-test2: 512Mi
   limits:
+    cpu:
+      moduleslibrary:
+        # Explicit per-container CPU limits for the web container.
+        web:
+          _default: 50m
+          web-production: 500m
+        # Explicit per-container CPU limits for the builder container.
+        builder:
+          _default: 1
+          web-production: 2
     memory:
       moduleslibrary:
         # Explicit per-container limits for the web container.

--- a/modules/810-documentation/templates/vertical-pod-autoscaler.yaml
+++ b/modules/810-documentation/templates/vertical-pod-autoscaler.yaml
@@ -5,7 +5,7 @@ memory: 50Mi
 
 {{- define "builder_resources" }}
 cpu: 100m
-memory: 50Mi
+memory: 128Mi
 {{- end }}
 
 {{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler") }}


### PR DESCRIPTION
## Description

This pull request introduces explicit per-container resource policies for the website documentation pods:
- Introduce per-container CPU limit values for web and builder containers with environment-specific overrides to constrain vertical autoscaler recommendations
- Configure VPA container policies with minAllowed and maxAllowed boundaries derived from existing request and new limit values, preventing unbounded resource scaling by the autoscaler

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Tune VPA resource policies for moduleslibrary.
impact_level: low
```
