### PR TITLE
[node-manager] Resume an interrupted static node bootstrap instead of refusing it

### DIFF
--- a/modules/040-node-manager/templates/node-group/_static_or_hybrid_script.tpl
+++ b/modules/040-node-manager/templates/node-group/_static_or_hybrid_script.tpl
@@ -4,15 +4,17 @@
   {{- $bootstrap_token := index . 2 -}}
 #!/bin/bash
 
-if [[ -f /var/lib/bashible/bootstrap-token ]]; then
-  echo "The node already have bootstrap-token and under bashible."
-  exit 1
-fi
-
 checkBashible=$(systemctl is-active bashible.timer)
 if [[ "$checkBashible" == "active" ]]; then
   echo "The node already exists in the cluster and under bashible."
   exit 2
+fi
+
+# 098_cleanup removes bootstrap-token as soon as bashible takes over, so a token on a
+# node whose timer is not active means an unfinished bootstrap, not a ready node.
+# Complete it: refusing leaves the node stuck until MachineHealthCheck wipes it.
+if [[ -f /var/lib/bashible/bootstrap-token ]]; then
+  echo "Bootstrap was interrupted before bashible took over, completing it."
 fi
 
 mkdir -p /var/lib/bashible


### PR DESCRIPTION
## Description

Drops the `bootstrap-token` guard from the Static/Hybrid node bootstrap script. A node that is already in the cluster is still rejected by the `bashible.timer` check above it, which keeps returning exit code 2, so nothing changes for a healthy node. A node whose bootstrap was interrupted is now driven to completion instead of being refused.

No restarts of critical cluster components. Affects only nodes that are being bootstrapped.

## Why do we need it, and what problem does it solve?

A CAPS bootstrap runs as a single foreground ssh session owned by `caps-controller-manager`. If that process goes away mid-install, the session dies after the script has written `/var/lib/bashible/bootstrap-token` but before bashible took over. Every following attempt then hit the guard and exited 1 within a second, so the node made no progress at all — there was no way to complete an interrupted bootstrap.

The only recovery was `MachineHealthCheck` reaching `nodeStartupTimeoutSeconds` (1200), wiping `/var/lib/bashible` and rebooting the node, after which the install ran from scratch.

Measured on a three-master static cluster (DKP over DVP, `sdn` + `virtualization`, one master at bootstrap time):

```
06:38:42  StaticInstance x3 -> Bootstrapping
06:41:27  kube-apiserver unavailable on the single master
          (control-plane-manager rewrites the static pod manifest during convergence)
06:42:44  caps-controller-manager restarted twice, leader lease not renewed
          -> ssh sessions of master-1 and master-2 killed mid-install
06:43:43  "failed to run ssh command: exit status 1" starts repeating once a minute
06:58:27  MachineMarkedUnhealthy -> Machines deleted -> rm -rf /var/lib/bashible + reboot
07:02:33  nodes Ready
07:03:29  StaticInstance -> Running
```

30 minutes 5 seconds for what takes about five minutes when nothing is interrupted. `dhctl` waits for resources for 15 minutes by default, so `dhctl bootstrap` fails even though the cluster heals itself minutes later. The same run with `--resources-timeout=30m` exited 1; only raising it to 60m let the bootstrap finish.

Two more observations that motivate the shape of the fix:

- The message the script prints (`The node already have bootstrap-token and under bashible.`) is wrong for this state: a node holding the token is precisely *not* under bashible.
- The token exists only between the script writing it and `candi/bashible/common-steps/all/098_cleanup.sh.tpl` removing it at the end of the first successful bashible run. So a token on a node whose `bashible.timer` is not active can only mean an interrupted bootstrap. Verified on live nodes: finished masters have neither `bootstrap-token` nor `first_run`, and their timer is active.

Rewriting the files is idempotent and hands the node a fresh token from the secret, which also avoids reusing a token that may have expired.

## Why do we need it in the patch release (if we do)?

It breaks `dhctl bootstrap` of a multi-master static cluster whenever the ssh session is interrupted, which on a single-master control plane happens through ordinary apiserver unavailability rather than a rare race. The workaround is a larger `--resources-timeout` plus a 20-minute stall per affected node. Backporting looks worthwhile, but the call is the team's.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

The defect above was reproduced and measured on a live cluster twice. The fix itself has **not** been verified in a cluster yet — that is why the PR is a draft. `modules/040-node-manager/template_tests` does not cover this template, and `grep` finds no other consumer of the removed message or of exit code 1.

## Changelog entries

```changes
section: node-manager
type: fix
summary: Complete an interrupted bootstrap of a static node instead of refusing every retry.
impact_level: default
```
