### PR TITLE
[docs] Fix links in conformance documentation

### DIFF
--- a/docs/documentation/pages/reference/KUBERNETES_CONFORMANCE.md
+++ b/docs/documentation/pages/reference/KUBERNETES_CONFORMANCE.md
@@ -12,7 +12,7 @@ Deckhouse Kubernetes Platform is tested against the Kubernetes conformance suite
 {% assign conformance_results = site.data.kubernetes_conformance.results %}
 {% if conformance_results.size > 0 %}
 {% for result in conformance_results %}
-- Kubernetes **{{ result.version }}** — <a href="{{ site.canonical_url_prefix_documentation }}{{ result.xml_path }}" download>Download JUnit XML report</a>
+- Kubernetes **{{ result.version }}** — <a href="{{ result.xml_path | true_relative_url }}" download>Download JUnit XML report</a>
 {% endfor %}
 {% else %}
 No conformance test results are available.

--- a/docs/documentation/pages/reference/KUBERNETES_CONFORMANCE_RU.md
+++ b/docs/documentation/pages/reference/KUBERNETES_CONFORMANCE_RU.md
@@ -13,7 +13,7 @@ Deckhouse Kubernetes Platform тестируется на соответстви
 {% assign conformance_results = site.data.kubernetes_conformance.results %}
 {% if conformance_results.size > 0 %}
 {% for result in conformance_results %}
-- Kubernetes **{{ result.version }}** — <a href="{{ site.canonical_url_prefix_documentation }}{{ result.xml_path }}" download>Скачать отчёт JUnit в формате XML</a>
+- Kubernetes **{{ result.version }}** — <a href="{{ result.xml_path | true_relative_url }}" download>Скачать отчёт JUnit в формате XML</a>
 {% endfor %}
 {% else %}
 Результаты conformance-тестов пока недоступны.


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Fix broken JUnit XML report links on the Kubernetes conformance page.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: fix
summary: Fix broken JUnit XML report links on the Kubernetes conformance page.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
