### PR TITLE
[control-plane-manager] Enable node-controller for VCP

### DIFF
--- a/global-hooks/discovery/cluster_has_ready_nodes.go
+++ b/global-hooks/discovery/cluster_has_ready_nodes.go
@@ -1,0 +1,75 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hooks
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	v1core "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
+)
+
+const clusterHasReadyNodesPath = "global.discovery.clusterHasReadyNodes"
+
+const readyNodesSnapName = "ready_nodes"
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:       readyNodesSnapName,
+			ApiVersion: "v1",
+			Kind:       "Node",
+			FilterFunc: applyNodeReadyFilter,
+		},
+	},
+}, setClusterHasReadyNodes)
+
+func applyNodeReadyFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	var node v1core.Node
+	if err := sdk.FromUnstructured(obj, &node); err != nil {
+		return false, fmt.Errorf("from unstructured: %w", err)
+	}
+
+	for _, c := range node.Status.Conditions {
+		if c.Type == v1core.NodeReady {
+			return c.Status == v1core.ConditionTrue, nil
+		}
+	}
+
+	return false, nil
+}
+
+func setClusterHasReadyNodes(_ context.Context, input *go_hook.HookInput) error {
+	ready, err := sdkobjectpatch.UnmarshalToStruct[bool](input.Snapshots, readyNodesSnapName)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal %s snapshot: %w", readyNodesSnapName, err)
+	}
+
+	for _, isReady := range ready {
+		if isReady {
+			input.Values.Set(clusterHasReadyNodesPath, true)
+			return nil
+		}
+	}
+
+	input.Values.Set(clusterHasReadyNodesPath, false)
+
+	return nil
+}

--- a/global-hooks/openapi/values.yaml
+++ b/global-hooks/openapi/values.yaml
@@ -82,6 +82,12 @@ properties:
         type: boolean
         default: false
         x-examples: [ true, false ]
+      clusterHasReadyNodes:
+        type: boolean
+        default: false
+        description: |
+          Whether the cluster currently has at least one Ready node, masters included
+        x-examples: [ true, false ]
       clusterMasterCount:
         type: integer
         minimum: 0

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_bashible-apiserver.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_bashible-apiserver.go
@@ -66,10 +66,6 @@ const (
 	bashibleAPIServiceName = "v1alpha1.bashible.deckhouse.io"
 	bashibleAPIGroup       = "bashible.deckhouse.io"
 	bashibleAPIVersion     = "v1alpha1"
-
-	bashibleFirstRunFinishedLabel = "node.deckhouse.io/bashible-first-run-finished"
-	bashibleUninitializedTaintKey = "node.deckhouse.io/bashible-uninitialized"
-	nodeUninitializedTaintKey     = "node.deckhouse.io/uninitialized"
 )
 
 func (r *reconciler) reconcileBashibleApiserver(
@@ -120,11 +116,6 @@ func (r *reconciler) reconcileBashibleApiserver(
 
 	// 9. Nested: APIService
 	if res, err := r.reconcileBashibleAPIService(ctx, nestedClient, parentService, tlsSecret); err != nil || !res.IsZero() {
-		return res, err
-	}
-
-	// 10. Nested: node cleanup (no node-manager runs in the nested cluster to do it).
-	if res, err := r.reconcileNestedNodeCleanup(ctx, nestedClient); err != nil || !res.IsZero() {
 		return res, err
 	}
 
@@ -786,45 +777,4 @@ func applyNestedBashibleEndpoints(ep *corev1.Endpoints, namespace, address strin
 			Protocol: corev1.ProtocolTCP,
 		}},
 	}}
-}
-
-// reconcileNestedNodeCleanup ports node-controller bashiblecleanup for the nested cluster
-// once a node reports bashible-first-run-finished, drop that label and the uninitialized taints in one patch so it becomes schedulable and bashible does not re-apply the label.
-func (r *reconciler) reconcileNestedNodeCleanup(ctx context.Context, nestedClient client.Client) (reconcile.Result, error) {
-	nodes := &corev1.NodeList{}
-	if err := nestedClient.List(ctx, nodes, client.HasLabels{bashibleFirstRunFinishedLabel}); err != nil {
-		return reconcile.Result{}, fmt.Errorf("list nested nodes: %w", err)
-	}
-
-	for i := range nodes.Items {
-		node := &nodes.Items[i]
-		base := node.DeepCopy()
-
-		delete(node.Labels, bashibleFirstRunFinishedLabel)
-		node.Spec.Taints = filterTaints(node.Spec.Taints, nodeUninitializedTaintKey, bashibleUninitializedTaintKey)
-
-		if equality.Semantic.DeepEqual(base.Labels, node.Labels) &&
-			equality.Semantic.DeepEqual(base.Spec.Taints, node.Spec.Taints) {
-			continue
-		}
-		if err := nestedClient.Patch(ctx, node, client.MergeFrom(base)); err != nil {
-			return reconcile.Result{}, fmt.Errorf("cleanup nested node %s: %w", node.Name, err)
-		}
-	}
-
-	return reconcile.Result{}, nil
-}
-
-func filterTaints(taints []corev1.Taint, dropKeys ...string) []corev1.Taint {
-	drop := make(map[string]struct{}, len(dropKeys))
-	for _, k := range dropKeys {
-		drop[k] = struct{}{}
-	}
-	out := make([]corev1.Taint, 0, len(taints))
-	for _, t := range taints {
-		if _, ok := drop[t.Key]; !ok {
-			out = append(out, t)
-		}
-	}
-	return out
 }

--- a/modules/040-node-manager/hooks/create_vcp_worker_node_group.go
+++ b/modules/040-node-manager/hooks/create_vcp_worker_node_group.go
@@ -40,8 +40,13 @@ func getDefaultVCPWorkerNg() (*unstructured.Unstructured, error) {
 		"metadata": map[string]interface{}{
 			"name": "worker",
 		},
+		// Manual, not the Automatic default: a one-worker tenant would cordon its only node and
+		// evict kube-dns with nowhere to put it. No NeedDrainNode guard covers a group named worker.
 		"spec": map[string]interface{}{
 			"nodeType": "Static",
+			"disruptions": map[string]interface{}{
+				"approvalMode": "Manual",
+			},
 		},
 	}
 	return sdk.ToUnstructured(&ng)

--- a/modules/040-node-manager/hooks/create_vcp_worker_node_group.go
+++ b/modules/040-node-manager/hooks/create_vcp_worker_node_group.go
@@ -18,27 +18,41 @@ package hooks
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency"
 )
+
+const vcpWorkerNodeGroupName = "worker"
+
+var vcpNodeGroupGVR = schema.GroupVersionResource{
+	Group:    "deckhouse.io",
+	Version:  "v1",
+	Resource: "nodegroups",
+}
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	// Mirror of createMasterNodeGroup for a virtual control plane tenant:
 	// seed a default static `worker` NodeGroup so a fresh tenant renders a manual-bootstrap secret out of the box.
-	// It is idempotent (CreateIfNotExists) and never patches, so an operator can edit the NG freely.
+	// It never patches, so an operator can edit the NG freely.
 	Queue: "/modules/node-manager/create-vcp-worker-ng",
 	// Ensure crds hook has order 5, create the node group after it.
 	OnStartup: &go_hook.OrderedConfig{Order: 6},
-}, createVCPWorkerNodeGroup)
+}, dependency.WithExternalDependencies(createVCPWorkerNodeGroup))
 
 func getDefaultVCPWorkerNg() (*unstructured.Unstructured, error) {
 	ng := map[string]interface{}{
 		"apiVersion": "deckhouse.io/v1",
 		"kind":       "NodeGroup",
 		"metadata": map[string]interface{}{
-			"name": "worker",
+			"name": vcpWorkerNodeGroupName,
 		},
 		// Manual, not the Automatic default: a one-worker tenant would cordon its only node and
 		// evict kube-dns with nowhere to put it. No NeedDrainNode guard covers a group named worker.
@@ -52,9 +66,24 @@ func getDefaultVCPWorkerNg() (*unstructured.Unstructured, error) {
 	return sdk.ToUnstructured(&ng)
 }
 
-func createVCPWorkerNodeGroup(_ context.Context, input *go_hook.HookInput) error {
+// GET first: CreateIfNotExists still sends the CREATE, so the webhook rejects it when its backend has
+// nowhere to run, wedging the startup phase ahead of helm. No snapshot - onStartup precedes its sync.
+func createVCPWorkerNodeGroup(ctx context.Context, input *go_hook.HookInput, dc dependency.Container) error {
 	if !nestedControlPlane(input) {
 		return nil
+	}
+
+	kubeClient, err := dc.GetK8sClient()
+	if err != nil {
+		return fmt.Errorf("cannot init Kubernetes client: %w", err)
+	}
+
+	_, err = kubeClient.Dynamic().Resource(vcpNodeGroupGVR).Get(ctx, vcpWorkerNodeGroupName, metav1.GetOptions{})
+	if err == nil {
+		return nil
+	}
+	if !apierrors.IsNotFound(err) {
+		return fmt.Errorf("cannot get NodeGroup %q: %w", vcpWorkerNodeGroupName, err)
 	}
 
 	ng, err := getDefaultVCPWorkerNg()
@@ -62,7 +91,6 @@ func createVCPWorkerNodeGroup(_ context.Context, input *go_hook.HookInput) error
 		return err
 	}
 
-	// Do not patch the node group if it already exists, to avoid conflicts with user changes.
 	input.PatchCollector.CreateIfNotExists(ng)
 
 	return nil

--- a/modules/040-node-manager/template_tests/nested_control_plane_test.go
+++ b/modules/040-node-manager/template_tests/nested_control_plane_test.go
@@ -23,10 +23,9 @@ import (
 	. "github.com/deckhouse/deckhouse/testing/helm"
 )
 
-// In a virtual control plane tenant Deckhouse manages the cluster from the parent, which is what
-// global.deckhouseSelfHosted: false means. There the module owns the objects nodes bootstrap
-// against and nothing else — the workloads run in the parent, so a Pod rendered here would have
-// nowhere to run and would fight control-plane-manager for the same objects.
+// In a virtual control plane tenant Deckhouse manages the cluster from the parent
+// (global.deckhouseSelfHosted: false). bashible-apiserver stays there - it is an aggregated
+// APIService bound to the parent. node-controller runs here, where its NodeGroups and Nodes are.
 var _ = Describe("Module :: node-manager :: helm template :: nested control plane", func() {
 	f := SetupHelmConfig(``)
 
@@ -66,17 +65,51 @@ var _ = Describe("Module :: node-manager :: helm template :: nested control plan
 			Expect(f.KubernetesGlobalResource("ClusterRole", "d8:manage:permission:module:node-manager:edit").Exists()).To(BeTrue())
 		})
 
-		It("renders no workload of its own", func() {
+		It("renders none of the workloads that belong to the parent", func() {
 			Expect(f.RenderError).ShouldNot(HaveOccurred())
 
 			Expect(f.KubernetesResource("Deployment", "d8-cloud-instance-manager", "bashible-apiserver").Exists()).To(BeFalse())
 			Expect(f.KubernetesResource("Service", "d8-cloud-instance-manager", "bashible-api").Exists()).To(BeFalse())
 			Expect(f.KubernetesResource("Secret", "d8-cloud-instance-manager", "bashible-api-server-tls").Exists()).To(BeFalse())
-			Expect(f.KubernetesResource("Deployment", "d8-cloud-instance-manager", "node-controller").Exists()).To(BeFalse())
 			Expect(f.KubernetesResource("Deployment", "d8-cloud-instance-manager", "node-group-exporter").Exists()).To(BeFalse())
 			Expect(f.KubernetesResource("Deployment", "d8-cloud-instance-manager", "capi-controller-manager").Exists()).To(BeFalse())
 			Expect(f.KubernetesResource("Deployment", "d8-cloud-instance-manager", "machine-controller-manager").Exists()).To(BeFalse())
-			Expect(f.KubernetesResource("Secret", "d8-cloud-instance-manager", "deckhouse-registry").Exists()).To(BeFalse())
+		})
+
+		// The flag is asserted, not just the Deployment: losing it would start the cloud and olcedar
+		// controllers against a tenant that has neither.
+		It("renders node-controller with the tenant controller set", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			deployment := f.KubernetesResource("Deployment", "d8-cloud-instance-manager", "node-controller")
+			Expect(deployment.Exists()).To(BeTrue())
+			args := deployment.Field("spec.template.spec.containers.0.args").String()
+			Expect(args).To(ContainSubstring("--disable-controllers=bashible-context,"))
+			Expect(args).To(ContainSubstring("node-operation"))
+			Expect(args).NotTo(ContainSubstring("nodegroup-status"))
+			Expect(args).NotTo(ContainSubstring("bashible-cleanup"))
+
+			Expect(f.KubernetesResource("Secret", "d8-cloud-instance-manager", "deckhouse-registry").Exists()).To(BeTrue())
+			Expect(f.KubernetesResource("Secret", "d8-cloud-instance-manager", "node-controller-webhook-tls").Exists()).To(BeTrue())
+			Expect(f.KubernetesResource("Service", "d8-cloud-instance-manager", "node-controller-webhook").Exists()).To(BeTrue())
+			Expect(f.KubernetesGlobalResource("ClusterRole", "d8:node-manager:node-controller").Exists()).To(BeTrue())
+		})
+
+		// A tenant has no master, so the bootstrap-phase api-proxy plumbing must not be rendered.
+		It("does not render the self-hosted bootstrap plumbing", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			pod := f.KubernetesResource("Deployment", "d8-cloud-instance-manager", "node-controller").Field("spec.template.spec")
+			Expect(pod.Get("hostNetwork").Exists()).To(BeFalse())
+			Expect(pod.Get("containers.0.env").String()).NotTo(ContainSubstring("KUBERNETES_SERVICE_HOST"))
+		})
+
+		// The one grant in rbac-for-us.yaml that goes to every kubelet, unused in a tenant.
+		It("does not grant the on-node agent RBAC", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			Expect(f.KubernetesGlobalResource("ClusterRole", "d8:node-manager:node-agent").Exists()).To(BeFalse())
+			Expect(f.KubernetesGlobalResource("ClusterRoleBinding", "d8:node-manager:node-agent").Exists()).To(BeFalse())
 		})
 
 		// The context is assembled by bashible_context_vcp.go from the contract the host

--- a/modules/040-node-manager/templates/_helpers.yaml
+++ b/modules/040-node-manager/templates/_helpers.yaml
@@ -149,3 +149,10 @@ tenant issue their join token with the stock system:bootstrappers:d8-node-manage
   name: system:nodes
   apiGroup: rbac.authorization.k8s.io
 {{- end }}
+
+{{- /* Controllers a tenant has nothing for: no cloud provider, no CAPI, no immutable nodes.
+bashible-context is the load-bearing one - bashible_context_vcp.go writes that Secret with the host
+overlay, this controller would write it without. Remove a name to enable it, put it back to roll back. */ -}}
+{{- define "node_manager_nested_disabled_controllers" -}}
+bashible-context,instance,cluster-prefix-migration,capi-api-version,capi-cluster-resources,capi-control-plane,capi-crd-migration,capi-finalizer-cleanup,capi-machine-deployment,capi-md-metrics,node-config,node-bootstrap,node-operation
+{{- end }}

--- a/modules/040-node-manager/templates/_helpers.yaml
+++ b/modules/040-node-manager/templates/_helpers.yaml
@@ -156,3 +156,10 @@ overlay, this controller would write it without. Remove a name to enable it, put
 {{- define "node_manager_nested_disabled_controllers" -}}
 bashible-context,instance,cluster-prefix-migration,capi-api-version,capi-cluster-resources,capi-control-plane,capi-crd-migration,capi-finalizer-cleanup,capi-machine-deployment,capi-md-metrics,node-config,node-bootstrap,node-operation
 {{- end }}
+
+{{- /* Fail needs a backend that can be scheduled, and a tenant has nowhere to schedule it until a
+node joins - there Fail blocks the NodeGroup that the first node bootstraps from. The selfHosted
+term is what keeps an ordinary cluster's admission independent of this hook. */ -}}
+{{- define "node_manager_webhook_failure_policy" -}}
+{{- if or .Values.global.deckhouseSelfHosted .Values.global.discovery.clusterHasReadyNodes }}Fail{{ else }}Ignore{{ end }}
+{{- end }}

--- a/modules/040-node-manager/templates/bashible-apiserver/rbac-for-us.yaml
+++ b/modules/040-node-manager/templates/bashible-apiserver/rbac-for-us.yaml
@@ -182,6 +182,4 @@ roleRef:
   kind: Role
   name: d8:node-manager:bashible-apiserver:cloud-provider-steps
 subjects:
-  - kind: ServiceAccount
-    name: bashible-apiserver
-    namespace: d8-cloud-instance-manager
+  {{- include "node_manager_bashible_apiserver_subjects" . | nindent 2 }}

--- a/modules/040-node-manager/templates/node-controller/deployment.yaml
+++ b/modules/040-node-manager/templates/node-controller/deployment.yaml
@@ -2,8 +2,6 @@
 cpu: 10m
 memory: 50Mi
 {{- end }}
-{{- /* vcp-gate */ -}}
-{{- if .Values.global.deckhouseSelfHosted }}
 
 {{- if (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") }}
 ---
@@ -70,7 +68,9 @@ spec:
       automountServiceAccountToken: true
       serviceAccountName: node-controller
       terminationGracePeriodSeconds: 10
-{{- if not .Values.global.clusterIsBootstrapped }}
+{{- /* Self-hosted only: this rides the api-proxy on a master before kube-proxy exists. A tenant has
+no master, and its default/kubernetes already resolves to the ALB VIP the apiserver advertises. */ -}}
+{{- if and .Values.global.deckhouseSelfHosted (not .Values.global.clusterIsBootstrapped) }}
       hostNetwork: true
       dnsPolicy: Default
 {{- end }}
@@ -96,6 +96,9 @@ spec:
         itself in code (nodeconfig.Reconciler.MaxConcurrentReconciles) rather than depending on
         this string, where one typo in any segment discards the whole per-controller map. */}}
         - --max-concurrent-reconciles=10,bashible-context=1
+{{- if not .Values.global.deckhouseSelfHosted }}
+        - --disable-controllers={{ include "node_manager_nested_disabled_controllers" . }}
+{{- end }}
         - --leader-elect={{ include "helm_lib_is_ha_to_value" (list . "true" "false") }}
         - -v=2
         livenessProbe:
@@ -116,7 +119,7 @@ spec:
             {{- include "node_controller_resources" . | nindent 12 }}
         env:
       # KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to kubernetes-api-proxy are needed on the bootstrap phase to make node-controller work without kube-proxy
-  {{- if not .Values.global.clusterIsBootstrapped }}
+  {{- if and .Values.global.deckhouseSelfHosted (not .Values.global.clusterIsBootstrapped) }}
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
         - name: KUBERNETES_SERVICE_PORT
@@ -193,5 +196,3 @@ spec:
       - name: cert
         secret:
           secretName: node-controller-webhook-tls
-{{- end }}
-{{- /* /vcp-gate */ -}}

--- a/modules/040-node-manager/templates/node-controller/pod-monitor.yaml
+++ b/modules/040-node-manager/templates/node-controller/pod-monitor.yaml
@@ -1,5 +1,3 @@
-{{- /* vcp-gate */ -}}
-{{- if .Values.global.deckhouseSelfHosted }}
 {{- if (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/PodMonitor") }}
 ---
 apiVersion: monitoring.coreos.com/v1
@@ -33,5 +31,3 @@ spec:
     matchNames:
     - d8-cloud-instance-manager
 {{- end }}
-{{- end }}
-{{- /* /vcp-gate */ -}}

--- a/modules/040-node-manager/templates/node-controller/rbac-for-us.yaml
+++ b/modules/040-node-manager/templates/node-controller/rbac-for-us.yaml
@@ -1,5 +1,3 @@
-{{- /* vcp-gate */ -}}
-{{- if .Values.global.deckhouseSelfHosted }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -593,6 +591,10 @@ subjects:
   - kind: ServiceAccount
     name: deckhouse
     namespace: d8-system
+{{- /* olcedar-gate: agent RBAC, the only grant here that goes to every kubelet. A tenant runs no
+immutable node, so nobody uses it. Drop the gate with the first one; the bounding VAPs in
+validation.yaml are already unconditional. */ -}}
+{{- if .Values.global.deckhouseSelfHosted }}
 ---
 # The agent on an immutable node reaches the API with the kubelet's identity
 # (user system:node:<name>, group system:nodes). The Node authorizer does not
@@ -689,4 +691,4 @@ subjects:
   name: system:nodes
   apiGroup: rbac.authorization.k8s.io
 {{- end }}
-{{- /* /vcp-gate */ -}}
+{{- /* /olcedar-gate */ -}}

--- a/modules/040-node-manager/templates/node-controller/rbac-to-us.yaml
+++ b/modules/040-node-manager/templates/node-controller/rbac-to-us.yaml
@@ -1,5 +1,3 @@
-{{- /* vcp-gate */ -}}
-{{- if .Values.global.deckhouseSelfHosted }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -29,5 +27,3 @@ subjects:
 - kind: ServiceAccount
   name: prometheus
   namespace: d8-monitoring
-{{- end }}
-{{- /* /vcp-gate */ -}}

--- a/modules/040-node-manager/templates/node-controller/secret-tls.yaml
+++ b/modules/040-node-manager/templates/node-controller/secret-tls.yaml
@@ -1,5 +1,3 @@
-{{- /* vcp-gate */ -}}
-{{- if .Values.global.deckhouseSelfHosted }}
 ---
 apiVersion: v1
 kind: Secret
@@ -15,5 +13,3 @@ data:
   ca.crt: {{ .Values.nodeManager.internal.nodeControllerWebhookCert.ca | b64enc }}
   tls.crt: {{ .Values.nodeManager.internal.nodeControllerWebhookCert.crt | b64enc }}
   tls.key: {{ .Values.nodeManager.internal.nodeControllerWebhookCert.key | b64enc }}
-{{- end }}
-{{- /* /vcp-gate */ -}}

--- a/modules/040-node-manager/templates/node-controller/service.yaml
+++ b/modules/040-node-manager/templates/node-controller/service.yaml
@@ -1,5 +1,3 @@
-{{- /* vcp-gate */ -}}
-{{- if .Values.global.deckhouseSelfHosted }}
 ---
 apiVersion: v1
 kind: Service
@@ -17,5 +15,3 @@ spec:
     protocol: TCP
   selector:
     app: node-controller
-{{- end }}
-{{- /* /vcp-gate */ -}}

--- a/modules/040-node-manager/templates/node-controller/webhook.yaml
+++ b/modules/040-node-manager/templates/node-controller/webhook.yaml
@@ -1,5 +1,3 @@
-{{- /* vcp-gate */ -}}
-{{- if .Values.global.deckhouseSelfHosted }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -105,5 +103,3 @@ webhooks:
     - {{ .Values.global.clusterConfiguration.cloud.provider | lower }}instanceclasses
     scope: Cluster
 {{- end }}
-{{- end }}
-{{- /* /vcp-gate */ -}}

--- a/modules/040-node-manager/templates/node-controller/webhook.yaml
+++ b/modules/040-node-manager/templates/node-controller/webhook.yaml
@@ -19,7 +19,7 @@ webhooks:
       name: node-controller-webhook
       namespace: d8-cloud-instance-manager
       path: /validate-deckhouse-io-v1-nodegroup
-  failurePolicy: Fail
+  failurePolicy: {{ include "node_manager_webhook_failure_policy" . }}
   matchPolicy: Equivalent
   sideEffects: None
   rules:
@@ -42,7 +42,7 @@ webhooks:
       name: node-controller-webhook
       namespace: d8-cloud-instance-manager
       path: /validate-deckhouse-io-v1-nodeuser
-  failurePolicy: Fail
+  failurePolicy: {{ include "node_manager_webhook_failure_policy" . }}
   matchPolicy: Equivalent
   sideEffects: None
   rules:
@@ -65,7 +65,7 @@ webhooks:
       name: node-controller-webhook
       namespace: d8-cloud-instance-manager
       path: /validate-deckhouse-io-v1alpha1-staticinstance
-  failurePolicy: Fail
+  failurePolicy: {{ include "node_manager_webhook_failure_policy" . }}
   matchPolicy: Equivalent
   sideEffects: None
   rules:
@@ -89,7 +89,7 @@ webhooks:
       name: node-controller-webhook
       namespace: d8-cloud-instance-manager
       path: /validate-instanceclass-delete
-  failurePolicy: Fail
+  failurePolicy: {{ include "node_manager_webhook_failure_policy" . }}
   matchPolicy: Equivalent
   sideEffects: None
   rules:

--- a/modules/040-node-manager/templates/registry-secret.yaml
+++ b/modules/040-node-manager/templates/registry-secret.yaml
@@ -1,5 +1,3 @@
-{{- /* vcp-gate */ -}}
-{{- if .Values.global.deckhouseSelfHosted }}
 ---
 apiVersion: v1
 kind: Secret
@@ -10,5 +8,3 @@ metadata:
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ .Values.global.modulesImages.registry.dockercfg }}
-{{- end }}
-{{- /* /vcp-gate */ -}}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
  Runs the stock node-controller inside a virtual control plane tenant instead of hand-porting its behaviour into control-plane-manager.

  - Un-gates the node-controller templates (Deployment, Service, TLS Secret, webhook, RBAC, PodMonitor) and deckhouse-registry for a tenant.
  - Six controllers are enabled there - nodegroup-status, nodegroup-update-approval, node-draining, bashible-cleanup, node-template, static-provider-id. The other thirteen (cloud/CAPI, olcedar, bashible-context) are switched off with --disable-controllers; the list lives in one helm helper, so enabling a controller is removing a name from it and the rollback is putting it back.
  - bashible-context stays off deliberately: it writes the same context Secret as bashible_context_vcp.go but without the host overlay (ALB VIP, api-proxy certificates, kubernetes CA, packages proxy), so two writers would bootstrap nodes wrong.
  - Drops reconcileNestedNodeCleanup from control-plane-manager — the hand-written fork that cleared the uninitialized taints. bashible-cleanup and node-template do it now.
  - Narrows the bootstrap-phase plumbing (hostNetwork, KUBERNETES_SERVICE_HOST pointing at the api-proxy) to self-hosted clusters: a tenant has no master to run it on.
  - The default tenant worker NodeGroup is created with disruptions.approvalMode: Manual. On a one-worker tenant the automatic path would cordon the only node and evict kube-dns with nowhere to put it, and none of the NeedDrainNode guards covers a group named worker.
  - New global value global.discovery.clusterHasReadyNodes and the hook that fills it. The NodeGroup validating webhook renders failurePolicy: Ignore in a tenant that has no Ready node.
  - create_vcp_worker_node_group now checks the NodeGroup exists before creating it.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
