### PR TITLE
[cloud-provider-dvp][cloud-provider-azure][cloud-provider-aws][cloud-provider-gcp] Fix GetCapacity not implemented error spam in logs

### DIFF
--- a/modules/030-cloud-provider-aws/template_tests/module_test.go
+++ b/modules/030-cloud-provider-aws/template_tests/module_test.go
@@ -290,6 +290,8 @@ var _ = Describe("Module :: cloud-provider-aws :: helm template ::", func() {
 			Expect(ccmClusterRoleBinding.Exists()).To(BeTrue())
 			Expect(ccmSecret.Exists()).To(BeTrue())
 			Expect(ebsControllerPluginDeployment.Exists()).To(BeTrue())
+			Expect(ebsControllerPluginDeployment.Field("spec.template.spec.containers.0.args").String()).ToNot(ContainSubstring("--enable-capacity"))
+			Expect(ebsControllerPluginDeployment.Field("spec.template.spec.containers.0.args").String()).ToNot(ContainSubstring("--capacity-ownerref-level=2"))
 			Expect(ebsControllerPluginDeployment.Field("spec.template.spec.dnsPolicy").String()).To(Equal("ClusterFirstWithHostNet"))
 			Expect(ebsCSIDriver.Exists()).To(BeTrue())
 			Expect(ebsNodePluginDaemonSet.Exists()).To(BeTrue())

--- a/modules/030-cloud-provider-aws/templates/csi/controller.yaml
+++ b/modules/030-cloud-provider-aws/templates/csi/controller.yaml
@@ -35,6 +35,7 @@
 
   {{- $csiControllerConfig := dict }}
   {{- $_ := set $csiControllerConfig "controllerImage" $csiControllerImage }}
+  {{- $_ := set $csiControllerConfig "capacityEnabled" false }}
   {{- $_ := set $csiControllerConfig "additionalControllerArgs" (include "csi_controller_args" . | fromYamlArray) }}
   {{- $_ := set $csiControllerConfig "additionalControllerEnvs" (include "csi_controller_envs" . | fromYamlArray) }}
   {{- $_ := set $csiControllerConfig "dnsPolicy" (include "helm_lib_dns_policy_bootstraping_state" (list . "Default" "ClusterFirstWithHostNet")) }}

--- a/modules/030-cloud-provider-azure/template_tests/module_test.go
+++ b/modules/030-cloud-provider-azure/template_tests/module_test.go
@@ -306,6 +306,8 @@ var _ = Describe("Module :: cloud-provider-azure :: helm template ::", func() {
 			Expect(azureNodePluginDS.Field("spec.template.spec.dnsPolicy").String()).To(Equal("ClusterFirstWithHostNet"))
 			Expect(azureControllerPluginSA.Exists()).To(BeTrue())
 			Expect(azureControllerPluginSS.Exists()).To(BeTrue())
+			Expect(azureControllerPluginSS.Field("spec.template.spec.containers.0.args").String()).ToNot(ContainSubstring("--enable-capacity"))
+			Expect(azureControllerPluginSS.Field("spec.template.spec.containers.0.args").String()).ToNot(ContainSubstring("--capacity-ownerref-level=2"))
 			Expect(azureControllerPluginSS.Field("spec.template.spec.dnsPolicy").String()).To(Equal("ClusterFirstWithHostNet"))
 			Expect(azureAttacherCR.Exists()).To(BeTrue())
 			Expect(azureAttacherCRB.Exists()).To(BeTrue())

--- a/modules/030-cloud-provider-azure/templates/csi/controller.yaml
+++ b/modules/030-cloud-provider-azure/templates/csi/controller.yaml
@@ -37,6 +37,7 @@
 
   {{- $csiControllerConfig := dict }}
   {{- $_ := set $csiControllerConfig "controllerImage" $csiControllerImage }}
+  {{- $_ := set $csiControllerConfig "capacityEnabled" false }}
   {{- $_ := set $csiControllerConfig "securityPolicyExceptionEnabled" true }}
   {{- $_ := set $csiControllerConfig "additionalControllerArgs" (include "csi_controller_args" . | fromYamlArray) }}
   {{- $_ := set $csiControllerConfig "additionalControllerEnvs" (include "csi_controller_envs" . | fromYamlArray) }}

--- a/modules/030-cloud-provider-dvp/template_tests/module_test.go
+++ b/modules/030-cloud-provider-dvp/template_tests/module_test.go
@@ -418,6 +418,8 @@ var _ = Describe("Module :: cloud-provider-dvp :: helm template ::", func() {
 
 			csiController := f.KubernetesResource("Deployment", moduleNamespace, "csi-controller")
 			Expect(csiController.Exists()).To(BeTrue())
+			Expect(csiController.Field("spec.template.spec.containers.0.args").String()).ToNot(ContainSubstring("--enable-capacity"))
+			Expect(csiController.Field("spec.template.spec.containers.0.args").String()).ToNot(ContainSubstring("--capacity-ownerref-level=2"))
 			Expect(csiController.Field("spec.template.spec.dnsPolicy").String()).To(Equal("ClusterFirstWithHostNet"))
 
 			csiNode := f.KubernetesResource("DaemonSet", moduleNamespace, "csi-node")

--- a/modules/030-cloud-provider-dvp/templates/csi/controller.yaml
+++ b/modules/030-cloud-provider-dvp/templates/csi/controller.yaml
@@ -75,6 +75,7 @@
 
   {{- $csiControllerConfig := dict }}
   {{- $_ := set $csiControllerConfig "controllerImage" $csiControllerImage }}
+  {{- $_ := set $csiControllerConfig "capacityEnabled" false }}
   {{- $_ := set $csiControllerConfig "snapshotterEnabled" false }}
   {{- $_ := set $csiControllerConfig "resizerEnabled" true }}
   {{- $_ := set $csiControllerConfig "topologyEnabled" false }}

--- a/modules/030-cloud-provider-gcp/template_tests/module_test.go
+++ b/modules/030-cloud-provider-gcp/template_tests/module_test.go
@@ -321,6 +321,8 @@ var _ = Describe("Module :: cloud-provider-gcp :: helm template ::", func() {
 
 			Expect(pdCSICSIDriver.Exists()).To(BeTrue())
 			Expect(pdCSISS.Exists()).To(BeTrue())
+			Expect(pdCSISS.Field("spec.template.spec.containers.0.args").String()).ToNot(ContainSubstring("--enable-capacity"))
+			Expect(pdCSISS.Field("spec.template.spec.containers.0.args").String()).ToNot(ContainSubstring("--capacity-ownerref-level=2"))
 			Expect(pdCSISS.Field("spec.template.spec.dnsPolicy").String()).To(Equal("ClusterFirstWithHostNet"))
 			Expect(pdCSIDS.Exists()).To(BeTrue())
 			Expect(pdCSIDS.Field("spec.template.spec.dnsPolicy").String()).To(Equal("ClusterFirstWithHostNet"))

--- a/modules/030-cloud-provider-gcp/templates/csi/controller.yaml
+++ b/modules/030-cloud-provider-gcp/templates/csi/controller.yaml
@@ -32,6 +32,7 @@
 
   {{- $csiControllerConfig := dict }}
   {{- $_ := set $csiControllerConfig "controllerImage" $csiControllerImage }}
+  {{- $_ := set $csiControllerConfig "capacityEnabled" false }}
   {{- $_ := set $csiControllerConfig "additionalControllerArgs" (include "csi_controller_args" . | fromYamlArray) }}
   {{- $_ := set $csiControllerConfig "additionalControllerEnvs" (include "csi_controller_envs" . | fromYamlArray) }}
   {{- $_ := set $csiControllerConfig "additionalControllerVolumes" (include "csi_controller_volumes" . | fromYamlArray) }}

--- a/modules/030-cloud-provider-yandex/template_tests/module_test.go
+++ b/modules/030-cloud-provider-yandex/template_tests/module_test.go
@@ -405,6 +405,8 @@ var _ = Describe("Module :: cloud-provider-yandex :: helm template ::", func() {
 			// user story #2
 			Expect(csiDriver.Exists()).To(BeTrue())
 			Expect(csiControllerSS.Exists()).To(BeTrue())
+			Expect(csiControllerSS.Field("spec.template.spec.containers.0.args").String()).ToNot(ContainSubstring("--enable-capacity"))
+			Expect(csiControllerSS.Field("spec.template.spec.containers.0.args").String()).ToNot(ContainSubstring("--capacity-ownerref-level=2"))
 			Expect(csiControllerSS.Field("spec.template.spec.dnsPolicy").String()).To(Equal("ClusterFirstWithHostNet"))
 			Expect(csiNodeDS.Exists()).To(BeTrue())
 			Expect(csiNodeDS.Field("spec.template.spec.dnsPolicy").String()).To(Equal("ClusterFirstWithHostNet"))

--- a/modules/030-cloud-provider-yandex/templates/csi/controller.yaml
+++ b/modules/030-cloud-provider-yandex/templates/csi/controller.yaml
@@ -29,6 +29,7 @@
 
   {{- $csiControllerConfig := dict }}
   {{- $_ := set $csiControllerConfig "controllerImage" $csiControllerImage }}
+  {{- $_ := set $csiControllerConfig "capacityEnabled" false }}
   {{- $_ := set $csiControllerConfig "snapshotterEnabled" false }}
   {{- $_ := set $csiControllerConfig "securityPolicyExceptionEnabled" true }}
   {{- $_ := set $csiControllerConfig "additionalControllerArgs" (include "csi_controller_args" . | fromYamlArray) }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
  Disable CSIStorageCapacity support for CSI external-provisioner in the following cloud provider modules:

  - cloud-provider-aws
  - cloud-provider-azure
  - cloud-provider-dvp
  - cloud-provider-gcp
  - cloud-provider-yandex

The CSI controller configuration now sets `capacityEnabled: false`, so the shared CSI controller template does not pass `--enable-capacity` and `--capacity-ownerref-level=2` to the external-provisioner. Template tests were updated to verify that these arguments are not rendered.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Some CSI drivers used by these cloud providers do not implement the `GetCapacity` CSI call. When CSIStorageCapacity is enabled in the external-provisioner, it periodically calls `GetCapacity`, which produces repeated `GetCapacity not implemented` errors in logs.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-dvp
type: fix
summary: fix GetCapacity not implemented error spam in logs
impact_level: default
---
section: cloud-provider-aws
type: fix
summary: fix GetCapacity not implemented error spam in logs
impact_level: default
---
section: cloud-provider-azure
type: fix
summary: fix GetCapacity not implemented error spam in logs
impact_level: default
---
section: cloud-provider-gcp
type: fix
summary: fix GetCapacity not implemented error spam in logs
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
