### PR TITLE
[candi] Fix hanging sysctl tuner on nodes with many loop and dm devices

### DIFF
--- a/candi/bashible/common-steps/all/041_configure_sysctl_tuner.sh.tpl
+++ b/candi/bashible/common-steps/all/041_configure_sysctl_tuner.sh.tpl
@@ -117,12 +117,9 @@ sysctl -w kernel.panic_on_oops=1
 {{- end }}
 sysctl -w kernel.panic={{ $fencingTime }}
 
-# Tune only physical devices: they have a ../device symlink, virtual ones (loop, dm, md,
-# ram, zram) do not. On stacked devices nr_requests is either absent or derived from the
-# devices below, and writing it freezes the queue until in-flight I/O drains, which hangs.
-# Iterate instead of globbing into tee: tee holds every target open at once and hits
-# RLIMIT_NOFILE on nodes with many loop devices (the containerd erofs snapshotter mounts
-# every image layer over one), so the real disks that sort after loop* got nothing.
+# Physical devices only (they have a ../device symlink): writing nr_requests freezes the
+# queue until in-flight I/O drains, which hangs on stacked devices (e.g. loop or dm). One
+# file at a time, because a glob into tee exhausts RLIMIT_NOFILE where loop devices are numerous.
 for queue in /sys/block/*/queue; do
   [ -e "${queue%/queue}/device" ] || continue
   echo 256 | timeout 5 tee "$queue/nr_requests" >/dev/null 2>&1 # put more in the request queue, increase throughput

--- a/candi/bashible/common-steps/all/041_configure_sysctl_tuner.sh.tpl
+++ b/candi/bashible/common-steps/all/041_configure_sysctl_tuner.sh.tpl
@@ -117,9 +117,17 @@ sysctl -w kernel.panic_on_oops=1
 {{- end }}
 sysctl -w kernel.panic={{ $fencingTime }}
 
-# we use tee for work with globs
-echo 256 | tee /sys/block/*/queue/nr_requests >/dev/null 2>&1 # put more in the request queue, increase throughput
-echo 256 | tee /sys/block/*/queue/read_ahead_kb >/dev/null # the most controversial thing, Netflix recommends increasing a little, but you need to test on different setups, this number looks safe
+# Tune only physical devices: they have a ../device symlink, virtual ones (loop, dm, md,
+# ram, zram) do not. On stacked devices nr_requests is either absent or derived from the
+# devices below, and writing it freezes the queue until in-flight I/O drains, which hangs.
+# Iterate instead of globbing into tee: tee holds every target open at once and hits
+# RLIMIT_NOFILE on nodes with many loop devices (the containerd erofs snapshotter mounts
+# every image layer over one), so the real disks that sort after loop* got nothing.
+for queue in /sys/block/*/queue; do
+  [ -e "${queue%/queue}/device" ] || continue
+  echo 256 | timeout 5 tee "$queue/nr_requests" >/dev/null 2>&1 # put more in the request queue, increase throughput
+  echo 256 | timeout 5 tee "$queue/read_ahead_kb" >/dev/null 2>&1 # the most controversial thing, Netflix recommends increasing a little, but you need to test on different setups, this number looks safe
+done
 transparent_hugepage_current=$(grep -o '\[.*\]' /sys/kernel/mm/transparent_hugepage/enabled | tr -d '[]')
 if [ "$transparent_hugepage_current" != "never" ]; then
   echo never | tee /sys/kernel/mm/transparent_hugepage/enabled >/dev/null


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

`041_configure_sysctl_tuner.sh` now tunes `nr_requests` and `read_ahead_kb` only for physical block devices,  instead of globbing every `/sys/block/*/queue` into a single `tee`.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

On nodes with many `loop` and `dm` devices the step took a very long time and delayed the `kubelet` start:


before:
 
```bash
~# time /opt/deckhouse/bin/sysctl-tuner
real	4m41,276s
user	0m0,177s
sys	0m0,715s
```

after:
 
```bash
~# time /opt/deckhouse/bin/sysctl-tuner
real	0m0,573s
user	0m0,207s
sys	0m0,378s
```

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

On affected nodes `kubelet` could not start because the sysctl tuner step took too long to complete.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Fix hanging sysctl tuner on nodes with many loop and dm devices
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
