### PR TITLE
[docs] Rename a title in getting-started guide

### DIFF
--- a/docs/site/_includes/getting_started/global/partials/FINISH_CARDS.md
+++ b/docs/site/_includes/getting_started/global/partials/FINISH_CARDS.md
@@ -129,7 +129,7 @@ Other features
 ⚖ <span class="cards-item__title-text">Managing nodes</span>
 </h3>
 <div class="cards-item__text" markdown="1">
-Run the following command to list nodegroups created in the cluster during the deployment process: `kubectl get nodegroups`. For more information, see the node-manager's [documentation](/modules/node-manager/).
+Run the following command to list nodegroups created in the cluster during the deployment process: `d8 k get nodegroups`. For more information, see the node-manager's [documentation](/modules/node-manager/).
 
 You only need to make changes to `minPerZone` and `maxPerZone` parameters to scale the existing groups. If these two parameters are not equal, Deckhouse will automatically launch an autoscaler.
 
@@ -145,9 +145,9 @@ You need to create a new
 {% endif %}
 
 <div markdown="1">
-## What's next?
+## Next steps
 
 Detailed information about the system and the Deckhouse Kubernetes Platform components is available in the [documentation](/products/kubernetes-platform/documentation/v1/).
 
-Please, reach us via our [online community](/community/about.html#online-community) if you have any questions.
+Contact our [online community](/community/about.html#online-community) if you have any questions.
 </div>

--- a/docs/site/_includes/getting_started/global/partials/FINISH_CARDS.md
+++ b/docs/site/_includes/getting_started/global/partials/FINISH_CARDS.md
@@ -1,7 +1,7 @@
 <section class="cards-blocks">
 <div class="cards-blocks__content">
 <h2 class="cards-blocks__title text_h2">
-Essentials
+Getting started with the cluster
 </h2>
 <div class="cards-blocks__cards">
 

--- a/docs/site/_includes/getting_started/global/partials/FINISH_CARDS_RU.md
+++ b/docs/site/_includes/getting_started/global/partials/FINISH_CARDS_RU.md
@@ -1,7 +1,7 @@
 <section class="cards-blocks">
 <div class="cards-blocks__content">
 <h2 class="cards-blocks__title text_h2">
-Главное
+Начало работы с кластером
 </h2>
 <div class="cards-blocks__cards">
 

--- a/docs/site/_includes/getting_started/global/partials/FINISH_CARDS_RU.md
+++ b/docs/site/_includes/getting_started/global/partials/FINISH_CARDS_RU.md
@@ -44,7 +44,7 @@
 
 <div class="cards-item cards-item_inverse">
 <h3 class="cards-item__title text_h3">
-👌 <span class="cards-item__title-text">Status page</span>
+👌 <span class="cards-item__title-text">Страница состояния</span>
 </h3>
 <div class="cards-item__text">
 <p>Узнайте общий статус Deckhouse и его компонентов.<br />
@@ -61,9 +61,9 @@
 🏭 <span class="cards-item__title-text">Подготовка к production</span>
 </h3>
 <div class="cards-item__text" markdown="1">
-Подготовьте ваш кластер к приему трафика.
+Подготовьте кластер к приёму трафика.
 
-Воспользуйтесь нашим [чек-листом](/products/kubernetes-platform/guides/production.html), чтобы убедиться, что вы ничего не забыли.
+Воспользуйтесь [чек-листом](/products/kubernetes-platform/guides/production.html), чтобы ничего не упустить.
 </div>
 </div>
 {%- endif %}
@@ -131,7 +131,7 @@ Service'у.
 </h3>
 <div class="cards-item__text" markdown="1">
 {% if page.platform_type == 'cloud' %}
-При создании кластера были созданы две группы узлов. Чтобы увидеть их в кластере, выполните команду `kubectl get
+При создании кластера были созданы две группы узлов. Чтобы увидеть их в кластере, выполните команду `d8 k get
 nodegroups`. Подробнее об этом в [документации](/modules/node-manager/) по модулю управления узлами.
 
 Чтобы отмасштабировать существующие группы, вам достаточно изменить параметры `minPerZone` и `maxPerZone`. При этом,
@@ -152,9 +152,9 @@ nodegroups`. Подробнее об этом в [документации](/mod
 {% endif %}
 
 <div markdown="1">
-## Что дальше?
+## Следующие шаги
 
 Подробная информация о системе в целом и по каждому компоненту Deckhouse Kubernetes Platform расположена в [документации](/products/kubernetes-platform/documentation/v1/).
 
-По всем возникающим вопросам вы всегда можете связаться с нашим [онлайн-сообществом](/community/about.html#online-community).
+По всем возникающим вопросам вы можете связаться с [онлайн-сообществом](/community/about.html#online-community).
 </div>

--- a/docs/site/_includes/getting_started/stronghold/global/partials/FINISH_CARDS.md
+++ b/docs/site/_includes/getting_started/stronghold/global/partials/FINISH_CARDS.md
@@ -128,7 +128,7 @@ Other features
 ⚖ <span class="cards-item__title-text">Managing nodes</span>
 </h3>
 <div class="cards-item__text" markdown="1">
-Run the following command to list nodegroups created in the cluster during the deployment process: `kubectl get nodegroups`. For more information, see the node-manager's [documentation](/modules/node-manager/).
+Run the following command to list nodegroups created in the cluster during the deployment process: `d8 k get nodegroups`. For more information, see the node-manager's [documentation](/modules/node-manager/).
 
 You only need to make changes to `minPerZone` and `maxPerZone` parameters to scale the existing groups. If these two parameters are not equal, Deckhouse will automatically launch an autoscaler.
 
@@ -144,9 +144,9 @@ You need to create a new
 {% endif %}
 
 <div markdown="1">
-## What's next?
+## Next steps
 
 Detailed information about the system and components is available in the [documentation](/products/stronghold/documentation/admin/overview.html).
 
-Please, reach us via our [online community](/community/about.html#online-community) if you have any questions.
+Contact our [online community](/community/about.html#online-community) if you have any questions.
 </div>

--- a/docs/site/_includes/getting_started/stronghold/global/partials/FINISH_CARDS.md
+++ b/docs/site/_includes/getting_started/stronghold/global/partials/FINISH_CARDS.md
@@ -1,7 +1,7 @@
 <section class="cards-blocks">
 <div class="cards-blocks__content">
 <h2 class="cards-blocks__title text_h2">
-Essentials
+Getting started with the cluster
 </h2>
 <div class="cards-blocks__cards">
 

--- a/docs/site/_includes/getting_started/stronghold/global/partials/FINISH_CARDS_RU.md
+++ b/docs/site/_includes/getting_started/stronghold/global/partials/FINISH_CARDS_RU.md
@@ -1,7 +1,7 @@
 <section class="cards-blocks">
 <div class="cards-blocks__content">
 <h2 class="cards-blocks__title text_h2">
-Главное
+Начало работы с кластером
 </h2>
 <div class="cards-blocks__cards">
 

--- a/docs/site/_includes/getting_started/stronghold/global/partials/FINISH_CARDS_RU.md
+++ b/docs/site/_includes/getting_started/stronghold/global/partials/FINISH_CARDS_RU.md
@@ -33,7 +33,7 @@
 
 <div class="cards-item cards-item_inverse">
 <h3 class="cards-item__title text_h3">
-☸ <span class="cards-item__title-text">Dashboard</span>
+☸ <span class="cards-item__title-text">Kubernetes Dashboard</span>
 </h3>
 <div class="cards-item__text">
 <p>Получите доступ к Kubernetes Dashboard</p>

--- a/docs/site/_includes/getting_started/stronghold/global/partials/FINISH_CARDS_RU.md
+++ b/docs/site/_includes/getting_started/stronghold/global/partials/FINISH_CARDS_RU.md
@@ -43,7 +43,7 @@
 
 <div class="cards-item cards-item_inverse">
 <h3 class="cards-item__title text_h3">
-👌 <span class="cards-item__title-text">Status page</span>
+👌 <span class="cards-item__title-text">Страница состояния</span>
 </h3>
 <div class="cards-item__text">
 <p>Узнайте общий статус Deckhouse и его компонентов.<br />

--- a/docs/site/_includes/getting_started/stronghold/global/partials/FINISH_CARDS_RU.md
+++ b/docs/site/_includes/getting_started/stronghold/global/partials/FINISH_CARDS_RU.md
@@ -60,9 +60,9 @@
 🏭 <span class="cards-item__title-text">Подготовка к production</span>
 </h3>
 <div class="cards-item__text" markdown="1">
-Подготовьте ваш кластер к приему трафика.
+Подготовьте кластер к приёму трафика.
 
-Воспользуйтесь нашим [чек-листом](/products/kubernetes-platform/guides/production.html), чтобы убедиться, что вы ничего не забыли.
+Воспользуйтесь [чек-листом](/products/kubernetes-platform/guides/production.html), чтобы ничего не упустить.
 </div>
 </div>
 {%- endif %}
@@ -130,7 +130,7 @@ Service'у.
 </h3>
 <div class="cards-item__text" markdown="1">
 {% if page.platform_type == 'cloud' %}
-При создании кластера были созданы две группы узлов. Чтобы увидеть их в кластере, выполните команду `kubectl get
+При создании кластера были созданы две группы узлов. Чтобы увидеть их в кластере, выполните команду `d8 k get
 nodegroups`. Подробнее об этом в [документации](/modules/node-manager/) по модулю управления узлами.
 
 Чтобы отмасштабировать существующие группы, вам достаточно изменить параметры `minPerZone` и `maxPerZone`. При этом,
@@ -151,9 +151,9 @@ nodegroups`. Подробнее об этом в [документации](/mod
 {% endif %}
 
 <div markdown="1">
-## Что дальше?
+## Следующие шаги
 
 Подробная информация о системе в целом и по каждому компоненту расположена в [документации](/products/stronghold/documentation/admin/overview.html).
 
-По всем возникающим вопросам вы всегда можете связаться с нашим [онлайн-сообществом](/community/about.html#online-community).
+По всем возникающим вопросам вы можете связаться с [онлайн-сообществом](/community/about.html#online-community).
 </div>


### PR DESCRIPTION
## Description

This PR renames a title on the getting-started page to make it clearer what the section contains.

## Changelog entries

```changes
section: docs
type: chore
summary: Renamed a title in getting started guide.
impact_level: low
```