### PR TITLE
[deckhouse] report deletion in the Application and Module status

### DIFF
--- a/deckhouse-controller/crds/application.yaml
+++ b/deckhouse-controller/crds/application.yaml
@@ -212,7 +212,7 @@ spec:
                   state:
                     description: |-
                       State is the high-level lifecycle state observed for the application.
-                      Always one of: Pending, Failed, Updating, Ready, Degraded, Suspended.
+                      Always one of: Pending, Failed, Updating, Ready, Degraded, Suspended, Deleting.
                     type: string
                     x-doc-examples:
                     - Pending
@@ -221,6 +221,7 @@ spec:
                     - Ready
                     - Degraded
                     - Suspended
+                    - Deleting
                   tip:
                     description: |-
                       Tip is a human-readable instruction on how to resolve the current

--- a/deckhouse-controller/crds/doc-ru-application.yaml
+++ b/deckhouse-controller/crds/doc-ru-application.yaml
@@ -69,7 +69,7 @@ spec:
                     state:
                       description: |
                         Высокоуровневое состояние жизненного цикла приложения.
-                        Всегда одно из: Pending, Failed, Updating, Ready, Degraded, Suspended.
+                        Всегда одно из: Pending, Failed, Updating, Ready, Degraded, Suspended, Deleting.
                     message:
                       description: |
                         Человеко-читаемое описание текущего состояния.

--- a/deckhouse-controller/internal/condmap/map.go
+++ b/deckhouse-controller/internal/condmap/map.go
@@ -15,26 +15,62 @@
 package condmap
 
 import (
+	"slices"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// Map computes at most one external condition from a mapping state.
-// Return an empty condition to leave that external condition unchanged.
-type Map func(state State) metav1.Condition
+// ReasonDeleting is the reason every external condition carries while its
+// package is being removed. The runtime keeps its own copy for the internal
+// conditions (packages/status.ConditionReasonDeleting); the two are the same
+// word by intent, not by reference — internal reasons are never exported as-is.
+const ReasonDeleting = "Deleting"
+
+// Map computes at most one external condition from a mapping state. Type names
+// the condition Fn produces, so a mapper knows its own vocabulary without
+// evaluating anything; Fn returns an empty condition to leave it unchanged.
+type Map struct {
+	Type string
+	Fn   func(state State) metav1.Condition
+}
 
 // Mapper applies condition maps to compute external conditions.
 type Mapper struct {
-	// Maps is the ordered list of condition maps. Order matters when callers
-	// care about deterministic condition update ordering.
-	Maps []Map
+	maps     []Map
+	deleting []metav1.Condition
+}
+
+// NewMapper builds a mapper from an ordered list of condition maps. Order
+// matters when callers care about deterministic condition update ordering.
+func NewMapper(maps ...Map) Mapper {
+	deleting := make([]metav1.Condition, 0, len(maps))
+	for _, m := range maps {
+		deleting = append(deleting, metav1.Condition{
+			Type:   m.Type,
+			Status: metav1.ConditionFalse,
+			Reason: ReasonDeleting,
+		})
+	}
+
+	return Mapper{maps: maps, deleting: deleting}
 }
 
 // Map evaluates all condition maps and returns non-empty external conditions.
+//
+// While the state reports a deletion it returns every condition the mapper can
+// produce as False/ReasonDeleting instead. The maps read a state that still
+// describes the last reconcile, and one that emits nothing would leave its
+// condition — the sticky Installed above all — claiming the package is still
+// there.
 func (m Mapper) Map(state State) []metav1.Condition {
-	result := make([]metav1.Condition, 0, len(m.Maps))
+	if state.IsDeleting() {
+		return slices.Clone(m.deleting)
+	}
 
-	for _, mapper := range m.Maps {
-		condition := mapper(state)
+	result := make([]metav1.Condition, 0, len(m.maps))
+
+	for _, mp := range m.maps {
+		condition := mp.Fn(state)
 		if condition.Type == "" {
 			continue
 		}

--- a/deckhouse-controller/internal/condmap/state.go
+++ b/deckhouse-controller/internal/condmap/state.go
@@ -23,6 +23,7 @@ import (
 // External holds user-facing conditions from the previous run; rules read it
 // to implement sticky and guard behavior (e.g. Installed stays True once set).
 type State struct {
+	Deleting bool                        // true when the package is being removed
 	Updating bool                        // true when a version change is in progress
 	Internal map[string]metav1.Condition // task-set conditions, keyed by condition type
 	External map[string]metav1.Condition // previously computed user-facing conditions, read-only during mapping
@@ -72,6 +73,11 @@ func (s *State) HasInt(cond string) bool {
 // IsUpdating reports whether this mapping run observes a version change.
 func (s *State) IsUpdating() bool {
 	return s.Updating
+}
+
+// IsDeleting reports whether this mapping run observes a package being removed.
+func (s *State) IsDeleting() bool {
+	return s.Deleting
 }
 
 // GetIntReason returns the Reason and Message of an internal condition.

--- a/deckhouse-controller/internal/packages/runtime/apps.go
+++ b/deckhouse-controller/internal/packages/runtime/apps.go
@@ -210,6 +210,8 @@ func (r *Runtime) RemoveApp(namespace, instance string) bool {
 		return true
 	}
 
+	r.status.SetDeleting(name)
+
 	if pkg := r.apps[name]; pkg != nil {
 		r.queueService.Enqueue(ctx, name, taskdisable.NewTask(pkg, pkg.GetNamespace(), false, r.nelmService, r.queueService, r.logger))
 	} else {

--- a/deckhouse-controller/internal/packages/runtime/modules.go
+++ b/deckhouse-controller/internal/packages/runtime/modules.go
@@ -323,6 +323,8 @@ func (r *Runtime) RemoveModule(name string) bool {
 		return true
 	}
 
+	r.status.SetDeleting(name)
+
 	if pkg := r.modules[name]; pkg != nil {
 		r.queueService.Enqueue(ctx, name, taskdisable.NewTask(pkg, app.NamespaceDeckhouse, false, r.nelmService, r.queueService, r.logger))
 	} else {
@@ -361,6 +363,8 @@ func (r *Runtime) RemoveEmbeddedModule(name string) bool {
 	if ctx == nil {
 		return true
 	}
+
+	r.status.SetDeleting(name)
 
 	if pkg := r.modules[name]; pkg != nil {
 		r.queueService.Enqueue(ctx, name, taskdisable.NewTask(pkg, app.NamespaceDeckhouse, false, r.nelmService, r.queueService, r.logger))

--- a/deckhouse-controller/internal/packages/status/service.go
+++ b/deckhouse-controller/internal/packages/status/service.go
@@ -53,6 +53,9 @@ const (
 
 	// ConditionReasonApplyingManifests indicates that nelm is applying manifests to the cluster
 	ConditionReasonApplyingManifests ConditionReason = "ApplyingManifests"
+	// ConditionReasonDeleting indicates that the package is being torn down. The
+	// mappers keep their own copy (condmap.ReasonDeleting): same word by intent, not by reference.
+	ConditionReasonDeleting ConditionReason = "Deleting"
 
 	// appQueueName labels the application notification workqueue for metrics.
 	appQueueName = "application-status"
@@ -118,6 +121,10 @@ type Status struct {
 
 	// URLs are application endpoints collected from the rendered manifests.
 	URLs []URL `json:"urls,omitempty"`
+
+	// deleting freezes the status once a removal is accepted: the teardown cancels
+	// the context, and the tasks unwinding from it would undo the Deleting conditions.
+	deleting bool
 }
 
 // URL is a single application endpoint collected from the rendered manifests.
@@ -186,6 +193,18 @@ func (s *Service) Shutdown() {
 	s.moduleQueue.ShutDown()
 }
 
+// mutableStatus returns the status a mutator may write to. A frozen one is
+// reported as absent, so every mutator refuses it exactly as it refuses an
+// unknown package. The caller must hold s.mu.
+func (s *Service) mutableStatus(name string) (*Status, bool) {
+	status, ok := s.statuses[name]
+	if !ok || status.deleting {
+		return nil, false
+	}
+
+	return status, true
+}
+
 // GetStatus retrieves a copy of the current status for a package by name ("namespace.name")
 // Returns a copy to prevent race conditions with concurrent modifications
 func (s *Service) GetStatus(name string) Status {
@@ -242,7 +261,7 @@ func (s *Service) IsConditionStatusTrue(name string, condition ConditionType) bo
 // SetConditionTrue marks a condition as successful and notifies listeners if changed
 func (s *Service) SetConditionTrue(name string, condition ConditionType) {
 	s.mu.Lock()
-	status, ok := s.statuses[name]
+	status, ok := s.mutableStatus(name)
 	if !ok {
 		s.mu.Unlock()
 		return
@@ -260,7 +279,7 @@ func (s *Service) SetConditionTrue(name string, condition ConditionType) {
 // SetConditionFalse marks a condition as successful and notifies listeners if changed
 func (s *Service) SetConditionFalse(name string, condition ConditionType, reason, message string) {
 	s.mu.Lock()
-	status, ok := s.statuses[name]
+	status, ok := s.mutableStatus(name)
 	if !ok {
 		s.mu.Unlock()
 		return
@@ -280,10 +299,44 @@ func (s *Service) SetConditionFalse(name string, condition ConditionType, reason
 	}
 }
 
+// SetDeleting marks every condition as failed with the Deleting reason, freezes
+// the status against further writes and notifies listeners once if anything
+// changed. Messages are kept — they are the last record of what the package was
+// doing, and the debug dump still serves them.
+func (s *Service) SetDeleting(name string) {
+	s.mu.Lock()
+	status, ok := s.statuses[name]
+	if !ok {
+		s.mu.Unlock()
+		return
+	}
+
+	var notify bool
+
+	// Every type already exists, so setCondition never appends and the range
+	// stays valid while it rewrites the elements in place.
+	for _, cond := range status.Conditions {
+		if status.setCondition(Condition{
+			Type:    cond.Type,
+			Status:  metav1.ConditionFalse,
+			Reason:  ConditionReasonDeleting,
+			Message: cond.Message,
+		}) {
+			notify = true
+		}
+	}
+	status.deleting = true
+	s.mu.Unlock()
+
+	if notify {
+		s.queueFor(name).Add(name)
+	}
+}
+
 // UpdateVersion sets the current version of package
 func (s *Service) UpdateVersion(name string, version string) {
 	s.mu.Lock()
-	status, ok := s.statuses[name]
+	status, ok := s.mutableStatus(name)
 	if !ok {
 		s.mu.Unlock()
 		return
@@ -301,7 +354,7 @@ func (s *Service) UpdateVersion(name string, version string) {
 // If the package is not tracked by the service, the update is silently ignored.
 func (s *Service) UpdateTracking(name string, report progrep.ProgressReport) {
 	s.mu.Lock()
-	status, ok := s.statuses[name]
+	status, ok := s.mutableStatus(name)
 	if !ok {
 		s.mu.Unlock()
 		return
@@ -337,7 +390,7 @@ func (s *Service) UpdateTracking(name string, report progrep.ProgressReport) {
 // If the package is not tracked by the service, the update is silently ignored.
 func (s *Service) UpdateURLs(name string, urls []URL) {
 	s.mu.Lock()
-	status, ok := s.statuses[name]
+	status, ok := s.mutableStatus(name)
 	if !ok {
 		s.mu.Unlock()
 		return
@@ -360,7 +413,7 @@ func (s *Service) UpdateSettings(name string, settings addonutils.Values) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	status, ok := s.statuses[name]
+	status, ok := s.mutableStatus(name)
 	if !ok {
 		return
 	}
@@ -385,6 +438,11 @@ func (s *Service) UpdateHealth(name string, event health.Event) {
 	status, ok := s.statuses[name]
 	if !ok {
 		s.pendingHealth[name] = event
+		s.mu.Unlock()
+		return
+	}
+
+	if status.deleting {
 		s.mu.Unlock()
 		return
 	}
@@ -425,7 +483,7 @@ func (s *Service) HandleError(name string, cond ConditionType, err error) {
 	}
 
 	s.mu.Lock()
-	status, ok := s.statuses[name]
+	status, ok := s.mutableStatus(name)
 	if !ok {
 		s.mu.Unlock()
 		return

--- a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/application.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/application.go
@@ -168,9 +168,9 @@ type ApplicationStatus struct {
 // machine on top of conditions.
 type ApplicationStatusSummary struct {
 	// State is the high-level lifecycle state observed for the application.
-	// Always one of: Pending, Failed, Updating, Ready, Degraded, Suspended.
+	// Always one of: Pending, Failed, Updating, Ready, Degraded, Suspended, Deleting.
 	// +optional
-	// +crd-enricher:deckhouse:documentation:examples=[Pending, Failed, Updating, Ready, Degraded, Suspended]
+	// +crd-enricher:deckhouse:documentation:examples=[Pending, Failed, Updating, Ready, Degraded, Suspended, Deleting]
 	State string `json:"state,omitempty"`
 
 	// Message is a human-readable description of the current state.

--- a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha2/module.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha2/module.go
@@ -170,9 +170,9 @@ type ModuleStatus struct {
 // machine on top of conditions.
 type ModuleStatusSummary struct {
 	// State is the high-level lifecycle state observed for the module.
-	// Always one of: Pending, Failed, Updating, Ready, Degraded, Suspended.
+	// Always one of: Pending, Failed, Updating, Ready, Degraded, Suspended, Deleting.
 	// +optional
-	// +crd-enricher:deckhouse:documentation:examples=[Pending, Failed, Updating, Ready, Degraded, Suspended]
+	// +crd-enricher:deckhouse:documentation:examples=[Pending, Failed, Updating, Ready, Degraded, Suspended, Deleting]
 	State string `json:"state,omitempty"`
 
 	// Message is a human-readable description of the current state.

--- a/deckhouse-controller/pkg/controller/packages/application/status/rules.go
+++ b/deckhouse-controller/pkg/controller/packages/application/status/rules.go
@@ -22,6 +22,12 @@ import (
 )
 
 // External condition types — what the user sees on the Application resource.
+//
+// The reason vocabulary documented per condition below describes a application that
+// exists. While one is being removed the mapper bypasses the rules entirely and
+// reports every condition here as False/Deleting, so each vocabulary gains that
+// reason and the guarantees stated below — Installed's stickiness, Scaled's
+// exclusive ownership by the health monitor — do not hold on that path.
 const (
 	// ConditionInstalled reflects the state of the first install of the application.
 	// True when the install pipeline completed; False while it is blocked or has failed
@@ -279,18 +285,18 @@ func isInstallComplete(state condmap.State) bool {
 	return state.AllIntEqual(metav1.ConditionTrue, intManifestsApplied, intScaled)
 }
 
-// buildMapper returns the standard set of mappers in evaluation order.
+// buildMapper returns the standard set of mappers in evaluation order. Each map
+// declares the condition it owns, which is also the set the mapper reports as
+// Deleting while the application is being removed.
 func buildMapper() condmap.Mapper {
-	return condmap.Mapper{
-		Maps: []condmap.Map{
-			mapInstalled,
-			mapUpdateInstalled,
-			mapReady,
-			mapScaled,
-			mapManaged,
-			mapConfigurationApplied,
-		},
-	}
+	return condmap.NewMapper(
+		condmap.Map{Type: ConditionInstalled, Fn: mapInstalled},
+		condmap.Map{Type: ConditionUpdateInstalled, Fn: mapUpdateInstalled},
+		condmap.Map{Type: ConditionReady, Fn: mapReady},
+		condmap.Map{Type: ConditionScaled, Fn: mapScaled},
+		condmap.Map{Type: ConditionManaged, Fn: mapManaged},
+		condmap.Map{Type: ConditionConfigurationApplied, Fn: mapConfigurationApplied},
+	)
 }
 
 // Convention for all mappers below: failure checks come BEFORE success checks.

--- a/deckhouse-controller/pkg/controller/packages/application/status/rules_test.go
+++ b/deckhouse-controller/pkg/controller/packages/application/status/rules_test.go
@@ -52,6 +52,12 @@ func withVersionChanged() mappingOption {
 	}
 }
 
+func withDeleting() mappingOption {
+	return func(state *condmap.State) {
+		state.Deleting = true
+	}
+}
+
 func withSuccessfulApply() []mappingOption {
 	return []mappingOption{
 		withInternalCondition(string(intstatus.ConditionRequirementsMet), metav1.ConditionTrue, "RequirementsMet"),

--- a/deckhouse-controller/pkg/controller/packages/application/status/service.go
+++ b/deckhouse-controller/pkg/controller/packages/application/status/service.go
@@ -122,6 +122,10 @@ func (s *Service) computeAndApplyConditions(ev string, app *v1alpha1.Application
 	versionChanged := app.Status.CurrentVersion.Version != "" && app.Status.CurrentVersion.Version != packageStatus.Version
 	mapperStatus := s.buildMapperStatus(versionChanged, app.Status.Conditions, packageStatus.Conditions)
 
+	// The CR is the authority here: the runtime status is dropped when the last
+	// teardown task drains, and never exists at all after a restart mid-deletion.
+	mapperStatus.Deleting = !app.DeletionTimestamp.IsZero()
+
 	// Apply mapped conditions (external user-facing conditions)
 	for _, cond := range s.mapper.Map(mapperStatus) {
 		// Reason is required by metav1.Condition contract
@@ -139,7 +143,10 @@ func (s *Service) computeAndApplyConditions(ev string, app *v1alpha1.Application
 		})
 	}
 
-	if packageStatus.IsConditionTrue(status.ConditionManifestsApplied) {
+	// Nothing about a live install is committed onto a resource on its way out.
+	// The runtime freezes its own status on removal, but the CR's timestamp is
+	// authoritative even for a package the runtime never tracked.
+	if !mapperStatus.IsDeleting() && packageStatus.IsConditionTrue(status.ConditionManifestsApplied) {
 		app.Status.CurrentVersion.Version = packageStatus.Version
 
 		app.Status.URLs = nil

--- a/deckhouse-controller/pkg/controller/packages/application/status/summary.go
+++ b/deckhouse-controller/pkg/controller/packages/application/status/summary.go
@@ -36,6 +36,9 @@ import (
 //   - Suspended: a hard dependency was disabled under a running app
 //     (Installed=False/RequirementsUnmet with the runtime conditions Unknown,
 //     which is what distinguishes it from a first-install Pending).
+//   - Deleting:  the runtime accepted the removal and is tearing the
+//     application down; every condition reports Deleting until the resource
+//     disappears.
 const (
 	statePending   = "Pending"
 	stateFailed    = "Failed"
@@ -43,6 +46,7 @@ const (
 	stateReady     = "Ready"
 	stateDegraded  = "Degraded"
 	stateSuspended = "Suspended"
+	stateDeleting  = "Deleting"
 )
 
 // advice is the user-facing Summary for one (phase, canonical reason) pair:
@@ -202,6 +206,14 @@ var summarySuspended = advice{
 	tip:     "Solve the application requirements. After it, the controller will automatically restore all conditions and resume operation.",
 }
 
+// summaryDeleting is the fixed Summary for an application the runtime is tearing
+// down.
+var summaryDeleting = advice{
+	state:   stateDeleting,
+	message: "Application is being deleted",
+	tip:     "No action is required. The resource disappears once its release and files are taken down.",
+}
+
 // summaryReady is the fixed Summary for a healthy application: install or update
 // completed and every primary condition is True. State alone conveys it, so
 // there is no message or tip.
@@ -226,6 +238,12 @@ var summaryUpdating = advice{
 // install-completion check below mirrors mapInstalled's success condition so
 // the freshly-installed run reports ready rather than pending.
 func summarize(state condmap.State) (string, string, string) {
+	// Deleting outranks every other signal: the conditions still describe the last
+	// reconcile, so reading them would report a problem the user cannot act on.
+	if state.IsDeleting() {
+		return summaryDeleting.state, summaryDeleting.message, summaryDeleting.tip
+	}
+
 	// Suspended — dependency disabled under a running app. Shares the mapper's
 	// definition exactly, so the two can never drift apart.
 	if isDependencyDisabled(state) {

--- a/deckhouse-controller/pkg/controller/packages/application/status/summary_test.go
+++ b/deckhouse-controller/pkg/controller/packages/application/status/summary_test.go
@@ -16,12 +16,14 @@ package status
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/condmap"
 	intstatus "github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/status"
+	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
 )
 
 // summaryFor builds the pre-mapping state from the given options and runs
@@ -369,6 +371,39 @@ func TestLifecycleScenarios(t *testing.T) {
 			message: "Application is suspended: requirements unmet",
 			tip:     "Solve the application requirements. After it, the controller will automatically restore all conditions and resume operation.",
 		},
+
+		// ── Deleting (teardown accepted by the runtime) ────────────────
+
+		{
+			name: "deleting: running application is torn down",
+			opts: running(withDeleting()),
+			wantConds: map[string]*expectedCondition{
+				ConditionInstalled:            {metav1.ConditionFalse, condmap.ReasonDeleting},
+				ConditionUpdateInstalled:      {metav1.ConditionFalse, condmap.ReasonDeleting},
+				ConditionReady:                {metav1.ConditionFalse, condmap.ReasonDeleting},
+				ConditionScaled:               {metav1.ConditionFalse, condmap.ReasonDeleting},
+				ConditionManaged:              {metav1.ConditionFalse, condmap.ReasonDeleting},
+				ConditionConfigurationApplied: {metav1.ConditionFalse, condmap.ReasonDeleting},
+			},
+			state:   stateDeleting,
+			message: "Application is being deleted",
+			tip:     "No action is required. The resource disappears once its release and files are taken down.",
+		},
+		{
+			// The internal conditions are gone once the last teardown task drains
+			// (the runtime drops the status), so an event arriving after that maps
+			// an empty state. Without the deleting branch it reads as an update in
+			// progress.
+			name: "deleting: internal conditions already dropped",
+			opts: []mappingOption{installed(), withVersionChanged(), withDeleting()},
+			wantConds: map[string]*expectedCondition{
+				ConditionInstalled: {metav1.ConditionFalse, condmap.ReasonDeleting},
+				ConditionReady:     {metav1.ConditionFalse, condmap.ReasonDeleting},
+			},
+			state:   stateDeleting,
+			message: "Application is being deleted",
+			tip:     "No action is required. The resource disappears once its release and files are taken down.",
+		},
 	}
 
 	for _, tc := range cases {
@@ -504,4 +539,39 @@ func TestSummarize_SuspendedVsPending(t *testing.T) {
 		assert.Equal(t, statePending, state)
 		assert.NotEqual(t, "Application is suspended: requirements unmet", message)
 	})
+}
+
+// TestComputeAndApplyConditionsOnDeletion covers this package's own deletionTimestamp
+// wiring: the cases above set condmap.State.Deleting directly and never reach it.
+func TestComputeAndApplyConditionsOnDeletion(t *testing.T) {
+	deleted := metav1.NewTime(time.Unix(0, 0))
+	app := &v1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "app", DeletionTimestamp: &deleted},
+	}
+
+	// A Run task that finished after the teardown started still reports
+	// ManifestsApplied, which is what would otherwise commit the version.
+	svc := &Service{
+		mapper: buildMapper(),
+		getter: func(string) intstatus.Status {
+			return intstatus.Status{
+				Version: "1.2.3",
+				Conditions: []intstatus.Condition{
+					{Type: intstatus.ConditionManifestsApplied, Status: metav1.ConditionTrue},
+					{Type: intstatus.ConditionScaled, Status: metav1.ConditionTrue},
+				},
+			}
+		},
+	}
+
+	svc.computeAndApplyConditions("ns.app", app)
+
+	assert.Len(t, app.Status.Conditions, 6)
+	for _, cond := range app.Status.Conditions {
+		assert.Equal(t, metav1.ConditionFalse, cond.Status, "condition %s status", cond.Type)
+		assert.Equal(t, condmap.ReasonDeleting, cond.Reason, "condition %s reason", cond.Type)
+	}
+	assert.Equal(t, stateDeleting, app.Status.Summary.State)
+	assert.Empty(t, app.Status.CurrentVersion.Version)
+	assert.Empty(t, app.Status.URLs)
 }

--- a/deckhouse-controller/pkg/controller/packages/module/status/rules.go
+++ b/deckhouse-controller/pkg/controller/packages/module/status/rules.go
@@ -22,6 +22,12 @@ import (
 )
 
 // External condition types — what the user sees on the Module resource.
+//
+// The reason vocabulary documented per condition below describes a module that
+// exists. While one is being removed the mapper bypasses the rules entirely and
+// reports every condition here as False/Deleting, so each vocabulary gains that
+// reason and the guarantees stated below — Installed's stickiness, Scaled's
+// exclusive ownership by the health monitor — do not hold on that path.
 const (
 	// ConditionEnabled reflects the scheduler's enablement verdict for the
 	// module — the folded decision over the explicit intent (spec.enabled or
@@ -298,19 +304,19 @@ func isInstallComplete(state condmap.State) bool {
 	return state.AllIntEqual(metav1.ConditionTrue, intManifestsApplied, intScaled)
 }
 
-// buildMapper returns the standard set of mappers in evaluation order.
+// buildMapper returns the standard set of mappers in evaluation order. Each map
+// declares the condition it owns, which is also the set the mapper reports as
+// Deleting while the module is being removed.
 func buildMapper() condmap.Mapper {
-	return condmap.Mapper{
-		Maps: []condmap.Map{
-			mapEnabled,
-			mapInstalled,
-			mapUpdateInstalled,
-			mapReady,
-			mapScaled,
-			mapManaged,
-			mapConfigurationApplied,
-		},
-	}
+	return condmap.NewMapper(
+		condmap.Map{Type: ConditionEnabled, Fn: mapEnabled},
+		condmap.Map{Type: ConditionInstalled, Fn: mapInstalled},
+		condmap.Map{Type: ConditionUpdateInstalled, Fn: mapUpdateInstalled},
+		condmap.Map{Type: ConditionReady, Fn: mapReady},
+		condmap.Map{Type: ConditionScaled, Fn: mapScaled},
+		condmap.Map{Type: ConditionManaged, Fn: mapManaged},
+		condmap.Map{Type: ConditionConfigurationApplied, Fn: mapConfigurationApplied},
+	)
 }
 
 // Convention for all mappers below: failure checks come BEFORE success checks.

--- a/deckhouse-controller/pkg/controller/packages/module/status/rules_test.go
+++ b/deckhouse-controller/pkg/controller/packages/module/status/rules_test.go
@@ -46,6 +46,12 @@ func withExternalCondition(cond string, status metav1.ConditionStatus, reason st
 	}
 }
 
+func withDeleting() mappingOption {
+	return func(state *condmap.State) {
+		state.Deleting = true
+	}
+}
+
 func withSuccessfulApply() []mappingOption {
 	return []mappingOption{
 		withInternalCondition(string(intstatus.ConditionRequirementsMet), metav1.ConditionTrue, "Enabled"),

--- a/deckhouse-controller/pkg/controller/packages/module/status/service.go
+++ b/deckhouse-controller/pkg/controller/packages/module/status/service.go
@@ -110,6 +110,10 @@ func (s *Service) computeAndApplyConditions(name string, module *v1alpha2.Module
 	versionChanged := module.Status.CurrentVersion.Version != "" && module.Status.CurrentVersion.Version != packageStatus.Version
 	mapperStatus := s.buildMapperStatus(versionChanged, module.Status.Conditions, packageStatus.Conditions)
 
+	// The CR is the authority here: the runtime status is dropped when the last
+	// teardown task drains, and never exists at all after a restart mid-deletion.
+	mapperStatus.Deleting = !module.DeletionTimestamp.IsZero()
+
 	// Apply mapped conditions (external user-facing conditions)
 	for _, cond := range s.mapper.Map(mapperStatus) {
 		// Reason is required by metav1.Condition contract
@@ -127,7 +131,10 @@ func (s *Service) computeAndApplyConditions(name string, module *v1alpha2.Module
 		})
 	}
 
-	if packageStatus.IsConditionTrue(status.ConditionManifestsApplied) {
+	// Nothing about a live install is committed onto a resource on its way out.
+	// The runtime freezes its own status on removal, but the CR's timestamp is
+	// authoritative even for a package the runtime never tracked.
+	if !mapperStatus.IsDeleting() && packageStatus.IsConditionTrue(status.ConditionManifestsApplied) {
 		module.Status.CurrentVersion.Version = packageStatus.Version
 
 		if packageStatus.Settings != nil {

--- a/deckhouse-controller/pkg/controller/packages/module/status/summary.go
+++ b/deckhouse-controller/pkg/controller/packages/module/status/summary.go
@@ -35,6 +35,8 @@ import (
 //     lost a requirement (Installed=False with the scheduler reason and the
 //     runtime conditions Unknown, which is what distinguishes it from a
 //     first-install Pending).
+//   - Deleting:  the runtime accepted the removal and is tearing the module
+//     down; every condition reports Deleting until the resource disappears.
 const (
 	statePending   = "Pending"
 	stateFailed    = "Failed"
@@ -42,6 +44,7 @@ const (
 	stateReady     = "Ready"
 	stateDegraded  = "Degraded"
 	stateSuspended = "Suspended"
+	stateDeleting  = "Deleting"
 )
 
 // Scheduler verdict reasons of the intentional-disable family (see the
@@ -265,6 +268,13 @@ var summarySuspendedRequirements = advice{
 	tip:     "Solve the module requirements. After it, the controller will automatically restore all conditions and resume operation.",
 }
 
+// summaryDeleting is the fixed Summary for a module the runtime is tearing down.
+var summaryDeleting = advice{
+	state:   stateDeleting,
+	message: "Module is being deleted",
+	tip:     "No action is required. The resource disappears once its release is taken down.",
+}
+
 // summaryReady is the fixed Summary for a healthy module: install or update
 // completed and every primary condition is True. State alone conveys it, so
 // there is no message or tip.
@@ -289,6 +299,12 @@ var summaryUpdating = advice{
 // install-completion check below mirrors mapInstalled's success condition so
 // the freshly-installed run reports ready rather than pending.
 func summarize(state condmap.State) (string, string, string) {
+	// Deleting outranks every other signal: the conditions still describe the last
+	// reconcile, so reading them would report a problem the user cannot act on.
+	if state.IsDeleting() {
+		return summaryDeleting.state, summaryDeleting.message, summaryDeleting.tip
+	}
+
 	// Suspended — the scheduler withdrew a running module. Shares the mapper's
 	// definition exactly, so the two can never drift apart. The wording splits
 	// on the verdict family: switched off vs lost a requirement.

--- a/deckhouse-controller/pkg/controller/packages/module/status/summary_test.go
+++ b/deckhouse-controller/pkg/controller/packages/module/status/summary_test.go
@@ -16,12 +16,14 @@ package status
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/condmap"
 	intstatus "github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/status"
+	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha2"
 )
 
 // summaryFor builds the pre-mapping state from the given options and runs
@@ -172,6 +174,26 @@ func TestModuleSummaryScenarios(t *testing.T) {
 			message: "",
 			tip:     "",
 		},
+
+		// ── Deleting (teardown accepted by the runtime) ────────────────
+
+		{
+			// A disabled module being deleted reports the teardown, not the
+			// scheduler verdict that would otherwise win.
+			name: "deleting: disabled module is torn down",
+			opts: []mappingOption{
+				installed(),
+				withInternalCondition(intRequirementsMet, metav1.ConditionFalse, reasonDisabled),
+				withDeleting(),
+			},
+			wantConds: map[string]*expectedCondition{
+				ConditionEnabled:   {metav1.ConditionFalse, condmap.ReasonDeleting},
+				ConditionInstalled: {metav1.ConditionFalse, condmap.ReasonDeleting},
+			},
+			state:   stateDeleting,
+			message: "Module is being deleted",
+			tip:     "No action is required. The resource disappears once its release is taken down.",
+		},
 	}
 
 	for _, tc := range cases {
@@ -196,4 +218,38 @@ func TestModuleSummaryScenarios(t *testing.T) {
 			assert.Equal(t, tc.tip, tip, "summary tip")
 		})
 	}
+}
+
+// TestComputeAndApplyConditionsOnDeletion covers this package's own deletionTimestamp
+// wiring: the cases above set condmap.State.Deleting directly and never reach it.
+func TestComputeAndApplyConditionsOnDeletion(t *testing.T) {
+	deleted := metav1.NewTime(time.Unix(0, 0))
+	module := &v1alpha2.Module{
+		ObjectMeta: metav1.ObjectMeta{Name: "mod", DeletionTimestamp: &deleted},
+	}
+
+	// A Run task that finished after the teardown started still reports
+	// ManifestsApplied, which is what would otherwise commit the version.
+	svc := &Service{
+		mapper: buildMapper(),
+		getter: func(string) intstatus.Status {
+			return intstatus.Status{
+				Version: "1.2.3",
+				Conditions: []intstatus.Condition{
+					{Type: intstatus.ConditionManifestsApplied, Status: metav1.ConditionTrue},
+					{Type: intstatus.ConditionScaled, Status: metav1.ConditionTrue},
+				},
+			}
+		},
+	}
+
+	svc.computeAndApplyConditions("mod", module)
+
+	assert.Len(t, module.Status.Conditions, 7)
+	for _, cond := range module.Status.Conditions {
+		assert.Equal(t, metav1.ConditionFalse, cond.Status, "condition %s status", cond.Type)
+		assert.Equal(t, condmap.ReasonDeleting, cond.Reason, "condition %s reason", cond.Type)
+	}
+	assert.Equal(t, stateDeleting, module.Status.Summary.State)
+	assert.Empty(t, module.Status.CurrentVersion.Version)
 }


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Nothing reported a package teardown on the resource that owns it: the teardown tasks carry no status handle, `handleDelete` never writes `.status`, and the in-memory status is dropped silently once the last task drains. An `Application` or `Module` therefore kept the conditions and summary of its last successful reconcile for the whole time it sat in `Terminating`.

**1. The runtime reports the removal it accepted, and freezes the status.** `status.Service.SetDeleting` flips every tracked condition to `False` with reason `Deleting` and blocks further writes, so a task unwinding from the cancelled teardown context cannot put a live condition back. Condition messages are kept — the debug dump still serves the last record of what the package was doing. Called from `RemoveApp`, `RemoveModule` and `RemoveEmbeddedModule` right after `EventRemove` is accepted.

**2. The mapper owns the deleting set.** Each `condmap.Map` now declares the condition it produces, so `Mapper.Map` reports every one of them as `False`/`Deleting` when the state says the package is being removed. There is no per-package list to keep in step with the mapper list.

**3. The status services key the decision off the CR's own `deletionTimestamp`,** and stop committing a live install onto a resource on its way out: `currentVersion`, `urls` and `lastAppliedConfiguration` are no longer refreshed by a task that finished after the teardown started. The CR is the authority rather than the runtime status, which is dropped when the last teardown task drains and never exists at all after a restart mid-deletion.

**4. `status.summary.state` gains `Deleting`,** documented in the API types and the generated CRD (EN + RU).

| Situation | Before | After |
|---|---|---|
| Teardown in flight | conditions frozen at the last reconcile, `State: Ready` | every condition `False`/`Deleting`, `State: Deleting` |
| Status event after the runtime dropped the package | `State: Updating`, "Update in progress" | `State: Deleting` |
| Run task completing into a teardown | version and URLs refreshed on a Terminating object | not committed |

Retracting the sticky `Installed=True` is deliberate: it is the second override of that stickiness after the dependency-disabled path. The reason vocabularies documented per condition are updated to say so.

Unchanged: the teardown itself, the finalizer flow, the reconcile loops, and every non-deleting status transition.

Note: `Module.status.summary` is not in a shipped CRD — `crds/module.yaml` is hand-written, serves `v1alpha1` only and carries no `summary` field — so the module half of this change is not observable until that gap is closed. That is pre-existing and applies to all six existing states equally.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

`k get application` reported `Ready` for an application that was being deleted, for as long as its uninstall took — unbounded, because the finalizer is held until the release is gone. Worse, a status event arriving after the runtime dropped the package mapped an empty state into the update phase and reported `Updating` with "Update in progress" on a resource on its way out.

### Manual testing

Verified on a dev cluster against an `Application` installed from a package repository. A second
instance of the same package was created for the run so the existing one stayed untouched.

```console
# a healthy application, before the delete
$ k get application a-k-pkg-del -o jsonpath='{"summary: "}{.status.summary.state}{"\n"}{range .status.conditions[*]}{.type}{"="}{.status}{"/"}{.reason}{"\n"}{end}'
summary: Ready
Installed=True/Installed
Ready=True/Ready
Scaled=True/Scaled
ConfigurationApplied=True/ConfigurationApplied
Managed=True/Managed

$ k delete application a-k-pkg-del --wait=false
application.deckhouse.io "a-k-pkg-del" deleted from default namespace

# while it is Terminating
$ k get application a-k-pkg-del -o jsonpath='{.metadata.deletionTimestamp}|{.status.summary.state}|{.status.summary.message}'
2026-09-03T12:25:00Z|Deleting|Application is being deleted

$ k get application a-k-pkg-del -o jsonpath='{range .status.conditions[*]}{.type}{"="}{.status}{"/"}{.reason}{"\n"}{end}'
Installed=False/Deleting
Ready=False/Deleting
Scaled=False/Deleting
ConfigurationApplied=False/Deleting
Managed=False/Deleting
UpdateInstalled=False/Deleting

# teardown finished, the finalizer is released
$ k get application a-k-pkg-del
Error from server (NotFound): applications.deckhouse.io "a-k-pkg-del" not found
```

`UpdateInstalled` is absent before the delete and present as `False`/`Deleting` after it: the deleting
set is the mapper's full vocabulary, not only the conditions the CR already carried.

The module path was not exercised — the cluster runs with `DECKHOUSE_ENABLE_MODULE_PACKAGES=false`, and
`Module.status.summary` has no CRD field to land in (see the note above).

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: chore
summary: Report deletion in the Application and Module status.
```

