### PR TITLE
[candi] Prevent command injection via proxy configuration

### DIFF
--- a/candi/bashible/bashbooster/61_proxy.sh.tpl
+++ b/candi/bashible/bashbooster/61_proxy.sh.tpl
@@ -17,18 +17,18 @@
 bb-set-proxy() {
 {{- if .proxy }}
   {{- if .proxy.httpProxy }}
-  export HTTP_PROXY={{ .proxy.httpProxy | quote }}
+  export HTTP_PROXY={{ .proxy.httpProxy | replace "'" "'\"'\"'" | squote }}
   export http_proxy=${HTTP_PROXY}
   {{- end }}
   {{- if .proxy.httpsProxy }}
-  export HTTPS_PROXY={{ .proxy.httpsProxy | quote }}
+  export HTTPS_PROXY={{ .proxy.httpsProxy | replace "'" "'\"'\"'" | squote }}
   export https_proxy=${HTTPS_PROXY}
   {{- end }}
   {{- $noProxy := list "127.0.0.1" "169.254.169.254" "registry.d8-system.svc" .Values.global.clusterConfiguration.clusterDomain .Values.global.clusterConfiguration.podSubnetCIDR .Values.global.clusterConfiguration.serviceSubnetCIDR }}
   {{- if .proxy.noProxy }}
     {{- $noProxy = concat $noProxy .proxy.noProxy }}
   {{- end }}
-  export NO_PROXY={{ $noProxy | join "," | quote }}
+  export NO_PROXY={{ $noProxy | join "," | replace "'" "'\"'\"'" | squote }}
   export no_proxy=${NO_PROXY}
 {{- else }}
   unset HTTP_PROXY http_proxy HTTPS_PROXY https_proxy NO_PROXY no_proxy

--- a/dhctl/pkg/template/bashbooster_test.go
+++ b/dhctl/pkg/template/bashbooster_test.go
@@ -16,6 +16,7 @@ package template
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -67,8 +68,55 @@ func TestRenderBashBooster(t *testing.T) {
 		t.Errorf("Rendering bash booster error: %v", err)
 	}
 
-	expectedString := `export HTTP_PROXY="http://10.130.0.31:8888"`
+	expectedString := `export HTTP_PROXY='http://10.130.0.31:8888'`
 	if !strings.Contains(data, expectedString) {
 		t.Errorf("Expected string not found in data: %q", expectedString)
+	}
+}
+
+func TestRenderBashBoosterEscapesProxyShellMetacharacters(t *testing.T) {
+	markerPath := filepath.Join(t.TempDir(), "proxy-command-executed")
+	proxy := "http://user:pa'ss$(touch$IFS" + markerPath + ")@proxy.example"
+
+	templatePath := filepath.Join("..", "..", "..", "candi", "bashible", "bashbooster", "61_proxy.sh.tpl")
+	templateContent, err := os.ReadFile(templatePath)
+	if err != nil {
+		t.Fatalf("ReadFile error: %v", err)
+	}
+
+	data := map[string]any{
+		"proxy": map[string]any{
+			"httpProxy": proxy,
+		},
+		"Values": map[string]any{
+			"global": map[string]any{
+				"clusterConfiguration": map[string]any{
+					"clusterDomain":     "cluster.local",
+					"podSubnetCIDR":     "10.112.0.0/16",
+					"serviceSubnetCIDR": "10.223.0.0/16",
+				},
+			},
+		},
+	}
+
+	rendered, err := RenderTemplate("61_proxy.sh.tpl", templateContent, data)
+	if err != nil {
+		t.Fatalf("RenderTemplate error: %v", err)
+	}
+
+	expectedString := "export HTTP_PROXY='http://user:pa'\"'\"'ss$(touch$IFS" + markerPath + ")@proxy.example'"
+	if !strings.Contains(rendered.Content.String(), expectedString) {
+		t.Fatalf("Expected shell-escaped proxy not found in data: %q", expectedString)
+	}
+
+	command := rendered.Content.String() + "\nbb-set-proxy\n"
+	if output, err := exec.Command("bash", "-c", command).CombinedOutput(); err != nil {
+		t.Fatalf("Execute rendered proxy function: %v: %s", err, output)
+	}
+
+	if _, err := os.Stat(markerPath); err == nil {
+		t.Fatal("proxy value was executed as a shell command")
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("Stat marker file: %v", err)
 	}
 }


### PR DESCRIPTION
## Description

This change prevents shell command injection through the httpProxy, httpsProxy, and noProxy fields of ClusterConfiguration.

It introduces a shellQuote template function in both dhctl and bashible-apiserver and uses it when rendering proxy environment variables into BashBooster scripts. Proxy values are now rendered as single POSIX shell tokens, including correct escaping of embedded single quotes.

Regression tests verify that shell metacharacters remain literal and cannot create a marker file.

The change does not introduce restarts of critical cluster components and does not change the proxy configuration API.

## Why do we need it, and what problem does it solve?

Proxy URLs may contain shell metacharacters in their authentication data. The existing template used the generic Sprig quote function, which produces double-quoted shell strings. Command substitutions such as $() are still evaluated inside double quotes when the generated Bash script is executed.

As a result, a specially crafted proxy value could execute arbitrary commands on a cluster node with the privileges of the Bashible process.

The new shell-specific quoting function renders the complete value as a single safe shell token while preserving valid proxy URLs and credentials.

## Why do we need it in the patch release (if we do)?

This security fix should be backported to supported patch releases because the existing behavior may allow arbitrary command execution on cluster nodes when an attacker can modify the cluster proxy configuration.

The change is backward-compatible and requires no user migration.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: candi
type: fix 
summary: Prevent shell command injection through proxy settings in ClusterConfiguration.
impact_level: default 
```

