### PR TITLE
[ci] Lower registry storage usage

### DIFF
--- a/werf_cleanup.yaml
+++ b/werf_cleanup.yaml
@@ -4,18 +4,18 @@ cleanup:
   # All date calculations are based on the dates of the last commits in the branches.
   disableKubernetesBasedPolicy: true
   keepPolicies:
-  # keep 6 days dev builds
+  # keep 5 days dev builds
   - references:
       branch: /.*/
       limit:
-        in: 144h
+        in: 120h
     imagesPerReference:
       last: 1
-  # keep 7 pre-release builds
+  # keep 6 pre-release builds
   - references:
       branch: /release-[0-9]\.[0-9]+/
       limit:
-        last: 7
+        last: 6
     imagesPerReference:
       last: 1
   # keep 5 release builds


### PR DESCRIPTION
## Description
Lower registry storage usage.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Lower registry storage usage.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
