### PR TITLE
[istio] Reenable Gateway API controllers

### DIFF
--- a/modules/110-istio/openapi/config-values.yaml
+++ b/modules/110-istio/openapi/config-values.yaml
@@ -596,8 +596,6 @@ properties:
           - `ENABLE_ENHANCED_RESOURCE_SCOPING`
           - `PILOT_HTTP10`
           - `PILOT_ENABLE_AMBIENT`
-          - `PILOT_ENABLE_GATEWAY_API_DEPLOYMENT_CONTROLLER`
-          - `PILOT_ENABLE_GATEWAY_API_GATEWAYCLASS_CONTROLLER`
         x-examples:
         - GODEBUG: "gctrace=1"
         not:
@@ -606,8 +604,6 @@ properties:
           - required: ["ENABLE_ENHANCED_RESOURCE_SCOPING"]
           - required: ["PILOT_HTTP10"]
           - required: ["PILOT_ENABLE_AMBIENT"]
-          - required: ["PILOT_ENABLE_GATEWAY_API_DEPLOYMENT_CONTROLLER"]
-          - required: ["PILOT_ENABLE_GATEWAY_API_GATEWAYCLASS_CONTROLLER"]
       replicasManagement:
         description: |
           Replication management settings and scaling of istiod.

--- a/modules/110-istio/openapi/doc-ru-config-values.yaml
+++ b/modules/110-istio/openapi/doc-ru-config-values.yaml
@@ -275,8 +275,6 @@ properties:
           - `ENABLE_ENHANCED_RESOURCE_SCOPING`
           - `PILOT_HTTP10`
           - `PILOT_ENABLE_AMBIENT`
-          - `PILOT_ENABLE_GATEWAY_API_DEPLOYMENT_CONTROLLER`
-          - `PILOT_ENABLE_GATEWAY_API_GATEWAYCLASS_CONTROLLER`
       replicasManagement:
         description: |
           Настройки управления репликами и горизонтальным масштабированием istiod.

--- a/modules/110-istio/templates/control-plane/deployment.yaml
+++ b/modules/110-istio/templates/control-plane/deployment.yaml
@@ -142,10 +142,6 @@ spec:
           value: "true"
         - name: ENABLE_ENHANCED_RESOURCE_SCOPING
           value: "true"
-        - name: PILOT_ENABLE_GATEWAY_API_DEPLOYMENT_CONTROLLER
-          value: "false"
-        - name: PILOT_ENABLE_GATEWAY_API_GATEWAYCLASS_CONTROLLER
-          value: "false"
         {{- if $.Values.istio.dataPlane.enableHTTP10 }}
         - name: PILOT_HTTP10
           value: "1"

--- a/modules/110-istio/templates/control-plane/iop/istiod/_rules_v-1-27.tpl
+++ b/modules/110-istio/templates/control-plane/iop/istiod/_rules_v-1-27.tpl
@@ -12,6 +12,30 @@
   - create
   - delete
 - apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - watch
+  - list
+  - update
+  - patch
+  - create
+  - delete
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - get
+  - watch
+  - list
+  - update
+  - patch
+  - create
+  - delete
+- apiGroups:
   - ""
   resources:
   - services

--- a/modules/110-istio/templates/control-plane/iop/istiod/_rules_v-1-29.tpl
+++ b/modules/110-istio/templates/control-plane/iop/istiod/_rules_v-1-29.tpl
@@ -12,6 +12,30 @@
   - create
   - delete
 - apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - watch
+  - list
+  - update
+  - patch
+  - create
+  - delete
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - get
+  - watch
+  - list
+  - update
+  - patch
+  - create
+  - delete
+- apiGroups:
   - ""
   resources:
   - services


### PR DESCRIPTION
## Description

Stop forcing `PILOT_ENABLE_GATEWAY_API_DEPLOYMENT_CONTROLLER` and `PILOT_ENABLE_GATEWAY_API_GATEWAYCLASS_CONTROLLER` to `false` for the operator-free istiod (1.27, 1.29), so both controllers fall back to the Istio defaults (enabled). The matching entries are dropped from the `controlPlane.extraEnvs` reserved-key list, since the module no longer sets these variables itself.

## Why do we need it, and what problem does it solve?

These controllers were never meant to be off here. The disable was introduced for the old IstioOperator template and got copied into the new per-version istiod templates; the sail-operator path (1.25) never had it, so 1.27/1.29 were the outlier.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: fix
summary: Enable Istio Gateway API deployment and gatewayclass controllers for istiod 1.27 and 1.29.
impact_level: low
```