### PR TITLE
[istio] Stop unnecessarily labeling waypoints

### DIFF
--- a/ee/modules/110-istio/images/waypoint-controller/src/internal/waypointcontroller/controller_integration_test.go
+++ b/ee/modules/110-istio/images/waypoint-controller/src/internal/waypointcontroller/controller_integration_test.go
@@ -24,6 +24,7 @@ import (
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,7 +34,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	vpav1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -158,7 +158,7 @@ func setupEnv(t *testing.T) *testEnv {
 			repoCRDDir,
 			testCRDDir,
 		},
-		CRDs:                crdObjs,
+		CRDs:                  crdObjs,
 		ErrorIfCRDPathMissing: true,
 	}
 
@@ -350,6 +350,18 @@ func TestWaypointInstanceLifecycle(t *testing.T) {
 		err := reader.Get(ctx, key(baseName), hpa)
 		if !apierrors.IsNotFound(err) {
 			t.Fatalf("HPA should not exist in Static mode, got err=%v", err)
+		}
+	})
+
+	t.Run("create/Gateway-has-no-network-label", func(t *testing.T) {
+		gw := &gatewayv1.Gateway{}
+		if err := reader.Get(ctx, key(baseName), gw); err != nil {
+			t.Fatalf("get gateway: %v", err)
+		}
+		if v, ok := gw.Labels[TopologyNetworkLabelKey]; ok {
+			t.Errorf("Gateway must not carry %q (got %q): istiod would register it as a "+
+				"cross-network gateway at an in-cluster .svc address, and peer clusters "+
+				"import those entries", TopologyNetworkLabelKey, v)
 		}
 	})
 

--- a/ee/modules/110-istio/images/waypoint-controller/src/internal/waypointcontroller/gateway.go
+++ b/ee/modules/110-istio/images/waypoint-controller/src/internal/waypointcontroller/gateway.go
@@ -39,7 +39,7 @@ func (r *WaypointController) ensureWaypointGateway(ctx context.Context, instance
 		for k, v := range instanceLabels(instance) {
 			gateway.Labels[k] = v
 		}
-		for k, v := range istioLabels(instance, r.istioRevision, r.istioNetworkName) {
+		for k, v := range istioGatewayLabels(instance, r.istioRevision) {
 			gateway.Labels[k] = v
 		}
 		gateway.Labels["gateway.networking.k8s.io/gateway-name"] = resourceBaseName(instance.Name)

--- a/ee/modules/110-istio/images/waypoint-controller/src/internal/waypointcontroller/labels.go
+++ b/ee/modules/110-istio/images/waypoint-controller/src/internal/waypointcontroller/labels.go
@@ -21,6 +21,7 @@ const (
 	HeritageLabelValue        = "deckhouse"
 	WaypointFinalizer         = "network.deckhouse.io/waypoint-instance-cleanup"
 	ResourceNamePrefix        = "d8-waypoint-"
+	TopologyNetworkLabelKey   = "topology.istio.io/network"
 )
 
 func resourceBaseName(instanceName string) string {
@@ -36,16 +37,24 @@ func instanceLabels(instance *networkv1alpha1.WaypointInstance) map[string]strin
 }
 
 func istioLabels(instance *networkv1alpha1.WaypointInstance, revision, networkName string) map[string]string {
+	labels := istioGatewayLabels(instance, revision)
+	labels[TopologyNetworkLabelKey] = networkName
+
+	return labels
+}
+
+// The network label is deliberately omitted for istiod not to consider this
+// waypoint a cross-network gateway.
+func istioGatewayLabels(instance *networkv1alpha1.WaypointInstance, revision string) map[string]string {
 	waypointFor := "All"
 	if instance.Spec.WaypointFor != "" {
 		waypointFor = instance.Spec.WaypointFor
 	}
 
 	return map[string]string{
-		"gateway.istio.io/managed":  "istio.io-mesh-controller",
-		"istio.io/rev":              revision,
-		"istio.io/waypoint-for":     strings.ToLower(waypointFor),
-		"topology.istio.io/network": networkName,
+		"gateway.istio.io/managed": "istio.io-mesh-controller",
+		"istio.io/rev":             revision,
+		"istio.io/waypoint-for":    strings.ToLower(waypointFor),
 	}
 }
 

--- a/ee/modules/110-istio/images/waypoint-controller/src/internal/waypointcontroller/labels_test.go
+++ b/ee/modules/110-istio/images/waypoint-controller/src/internal/waypointcontroller/labels_test.go
@@ -158,3 +158,42 @@ func TestPodTemplateLabels_StaticKeys(t *testing.T) {
 		}
 	}
 }
+
+func TestIstioGatewayLabels_OmitsNetworkLabel(t *testing.T) {
+	inst := newInstance("main", "ns")
+
+	got := istioGatewayLabels(inst, "v1x29x6")
+
+	if v, ok := got[TopologyNetworkLabelKey]; ok {
+		t.Errorf("istioGatewayLabels must not set %q (got %q): istiod registers any Gateway "+
+			"carrying it as a cross-network gateway at the waypoint's in-cluster address, and "+
+			"peer clusters import those entries", TopologyNetworkLabelKey, v)
+	}
+
+	wantKeys := map[string]string{
+		"gateway.istio.io/managed": "istio.io-mesh-controller",
+		"istio.io/rev":             "v1x29x6",
+		"istio.io/waypoint-for":    "all",
+	}
+
+	for k, want := range wantKeys {
+		if got[k] != want {
+			t.Errorf("istioGatewayLabels[%q] = %q, want %q", k, got[k], want)
+		}
+	}
+
+	if len(got) != len(wantKeys) {
+		t.Errorf("istioGatewayLabels len = %d, want %d", len(got), len(wantKeys))
+	}
+}
+
+func TestPodTemplateLabels_KeepsNetworkLabel(t *testing.T) {
+	inst := newInstance("main", "ns")
+
+	got := podTemplateLabels(inst, "v1x29x6", "test-network")
+
+	if got[TopologyNetworkLabelKey] != "test-network" {
+		t.Errorf("podTemplateLabels[%q] = %q, want %q: the pod template is where "+
+			"ISTIO_META_NETWORK comes from", TopologyNetworkLabelKey, got[TopologyNetworkLabelKey], "test-network")
+	}
+}


### PR DESCRIPTION
## Description

`waypoint-controller` no longer sets the `topology.istio.io/network` label on the Gateway API `Gateway` object it creates for a `WaypointInstance`. The label stays on the Deployment, ServiceAccount, Service and pod template, so `ISTIO_META_NETWORK` is unchanged.

## Why do we need it, and what problem does it solve?

istiod's `networkManager` registers any `Gateway` that carries `topology.istio.io/network` together with an HBONE listener as a cross-network east-west gateway, taking the address from `spec.addresses` - which for a waypoint is an in-cluster `.svc` name. There is no gateway-class filter, so every `WaypointInstance` was being advertised as a network gateway.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: fix
summary: Waypoints are no longer advertised as cross-network east-west gateways.
impact_level: low
```