### PR TITLE
[docs] Added sdn module to CE, BE, SE and SE+ editions

### DIFF
--- a/docs/documentation/_data/modules/modules-addition.json
+++ b/docs/documentation/_data/modules/modules-addition.json
@@ -646,7 +646,19 @@
   },
   "sdn": {
     "editions": [
-      "ee"
+      "ce",
+      "be",
+      "se",
+      "se-plus",
+      "ee",
+      "cse-lite",
+      "cse-pro"
+    ],
+    "editionsWithRestrictions": [
+      "ce",
+      "be",
+      "se",
+      "se-plus"
     ],
     "external": "true",
     "path": "/modules/sdn/"

--- a/docs/site/backends/docs-builder-template/data/modules_all.json
+++ b/docs/site/backends/docs-builder-template/data/modules_all.json
@@ -726,7 +726,19 @@
   },
   "sdn": {
     "editions": [
-      "ee"
+      "ce",
+      "be",
+      "se",
+      "se-plus",
+      "ee",
+      "cse-lite",
+      "cse-pro"
+    ],
+    "editionsWithRestrictions": [
+      "ce",
+      "be",
+      "se",
+      "se-plus"
     ],
     "tags": [
       "network",


### PR DESCRIPTION
## Description
This PR adds the `sdn` module to the `CE`, `BE`, `SE`, and `SE+` editions

## Why do we need it, and what problem does it solve?
The `sdn` module is now available in the `CE`, `BE`, `SE`, and `SE+` editions. The documentation data files need to be updated accordingly so that customers are informed about the module's availability in these editions

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Added sdn module to CE, BE, SE and SE+ editions
impact_level: low
```