### PR TITLE
[control-plane-manager] Virtual control plane validation

### DIFF
--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_alb.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_alb.go
@@ -34,6 +34,18 @@ import (
 
 const albManifestKey = "alb.yaml.tpl"
 
+const packagesReferenceGrantNamespace = "d8-cloud-instance-manager"
+
+func packagesReferenceGrant(vcp *controlplanev1alpha1.VirtualControlPlane) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion("gateway.networking.k8s.io/v1beta1")
+	obj.SetKind("ReferenceGrant")
+	obj.SetNamespace(packagesReferenceGrantNamespace)
+	obj.SetName(fmt.Sprintf("vcp-%s-%s-packages", vcp.Namespace, vcp.Name))
+
+	return obj
+}
+
 // exposeHost builds a per-VCP hostname (example: api.<name>.<suffix>) used for ALB SNI routing
 func exposeHost(role string, vcp *controlplanev1alpha1.VirtualControlPlane) string {
 	return fmt.Sprintf("%s.%s.%s", role, vcp.Name, constants.VirtualExposeDomainSuffix)

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_finalizer.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_finalizer.go
@@ -63,7 +63,25 @@ func (r *reconciler) reconcileFinalizer(ctx context.Context, vcp *controlplanev1
 }
 
 func (r *reconciler) finalize(ctx context.Context, vcp *controlplanev1alpha1.VirtualControlPlane) (reconcile.Result, error) {
+	if err := r.deletePackagesReferenceGrant(ctx, vcp); err != nil {
+		return reconcile.Result{}, err
+	}
+
 	return r.deletePostgresArtifacts(ctx, vcp)
+}
+
+func (r *reconciler) deletePackagesReferenceGrant(ctx context.Context, vcp *controlplanev1alpha1.VirtualControlPlane) error {
+	obj := packagesReferenceGrant(vcp)
+
+	err := r.client.Delete(ctx, obj)
+	if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("delete packages ReferenceGrant: %w", err)
+	}
+
+	return nil
 }
 
 func (r *reconciler) deletePostgresArtifacts(ctx context.Context, vcp *controlplanev1alpha1.VirtualControlPlane) (reconcile.Result, error) {

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_finalizer.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/virtual-control-plane-configuration/reconcile_finalizer.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -91,7 +92,7 @@ func (r *reconciler) ensurePostgresDeleted(ctx context.Context, vcp *controlplan
 	obj.SetName(constants.VirtualResourceName(constants.VirtualDatastoreName, vcp.Name))
 
 	err := r.client.Get(ctx, client.ObjectKeyFromObject(obj), obj)
-	if apierrors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
 		return true, nil
 	}
 	if err != nil {

--- a/modules/040-control-plane-manager/templates/virtual-control-plane-validation-webhook.yaml
+++ b/modules/040-control-plane-manager/templates/virtual-control-plane-validation-webhook.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.controlPlaneManager.internal.hasVirtualControlPlane }}
 ---
 apiVersion: deckhouse.io/v1alpha1
 kind: ValidationWebhook
@@ -54,4 +53,3 @@ handler:
             f'Enable them via ModuleConfig and wait until their status.phase becomes "Ready".',
             False,
         )
-{{- end }}

--- a/modules/040-control-plane-manager/templates/virtual-control-plane-validation-webhook.yaml
+++ b/modules/040-control-plane-manager/templates/virtual-control-plane-validation-webhook.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ValidationWebhook
+metadata:
+  name: virtual-control-plane-required-modules
+  {{- include "helm_lib_module_labels" (list . (dict "app" "control-plane-manager")) | nindent 2 }}
+validationObject:
+  name: virtual-control-plane-required-modules.deckhouse.io
+  group: main
+  rules:
+  - apiGroups:   ["control-plane.deckhouse.io"]
+    apiVersions: ["*"]
+    operations:  ["CREATE"]
+    resources:   ["virtualcontrolplanes"]
+    scope:       "Namespaced"
+context:
+  - name: required-modules
+    kubernetes:
+      apiVersion: deckhouse.io/v1alpha1
+      kind: Module
+      nameSelector:
+        matchNames: ["managed-postgres", "alb"]
+      jqFilter: |-
+        {
+          "name": .metadata.name,
+          "phase": .status.phase,
+          "enabled": ((.status.conditions // []) | map(select(.type == "EnabledByModuleManager" and .status == "True")) | length > 0)
+        }
+handler:
+  python: |
+    REQUIRED_MODULES = {
+        "managed-postgres": "the tenant control plane datastore",
+        "alb": "publishing the tenant Kubernetes API",
+    }
+
+    def validate(ctx: DotMap) -> tuple[Optional[str], bool]:
+        ready = set()
+        for snap in ctx.snapshots.get("required-modules", []):
+            module = snap.filterResult
+            if module.get("enabled") and module.get("phase") == "Ready":
+                ready.add(module.get("name"))
+
+        missing = [name for name in REQUIRED_MODULES if name not in ready]
+        if not missing:
+            return None, True
+
+        vcp_name = ctx.review.request.object.metadata.name
+        details = ", ".join(
+            f'"{name}" (required for {REQUIRED_MODULES[name]})' for name in missing
+        )
+        return (
+            f'Cannot create VirtualControlPlane "{vcp_name}": module(s) not enabled or not ready: {details}. '
+            f'Enable them via ModuleConfig and wait until their status.phase becomes "Ready".',
+            False,
+        )

--- a/modules/040-control-plane-manager/templates/virtual-control-plane-validation-webhook.yaml
+++ b/modules/040-control-plane-manager/templates/virtual-control-plane-validation-webhook.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.controlPlaneManager.internal.hasVirtualControlPlane }}
 ---
 apiVersion: deckhouse.io/v1alpha1
 kind: ValidationWebhook
@@ -53,3 +54,4 @@ handler:
             f'Enable them via ModuleConfig and wait until their status.phase becomes "Ready".',
             False,
         )
+{{- end }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Webhook for module dependencies and vcp deletion fix
```
root@dev-master-0:~# kubectl apply -f vcpn2
Error from server: error when creating "vcpn2": admission webhook "virtual-control-plane-required-modules.deckhouse.io" denied the request: Cannot create VirtualControlPlane "test1": module(s) not enabled or not ready: "alb" (required for publishing the tenant Kubernetes API). Enable them via ModuleConfig and wait until their status.phase becomes "Ready".
....
root@dev-master-0:~# kubectl -n kube-system logs deploy/d8-virtual-control-plane-manager | grep -i "no matches"
E0903 14:40:26.514339       1 controller.go:474] "Reconciler error" err="get Postgres: no matches for kind \"Postgres\" in version \"managed-services.deckhouse.io/v1alpha1\"" controller="virtual-control-plane-configuration-controller" controllerGroup="control-plane.deckhouse.io" controllerKind="VirtualControlPlane" VirtualControlPlane="vcp-demo/test1" namespace="vcp-demo" name="test1" reconcileID="e60d2eac-871c-43f3-9d5c-1ad8c47f069c"
E0903 14:40:32.163644       1 controller.go:474] "Reconciler error" err="get Postgres: no matches for kind \"Postgres\" in version \"managed-services.deckhouse.io/v1alpha1\"" controller="virtual-control-plane-configuration-controller" controllerGroup="control-plane.deckhouse.io" controllerKind="VirtualControlPlane" VirtualControlPlane="vcp-demo/test1" namespace="vcp-demo" name="test1" reconcileID="0d3ba03e-38fe-43db-bfa7-04fd42774f25"
root@dev-master-0:~# kubectl -n vcp-demo delete vcp test1 --wait=true --timeout=120s
virtualcontrolplane.control-plane.deckhouse.io "test1" deleted from vcp-demo namespace
root@dev-master-0:~#
```
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
