### PR TITLE
[fuzzing] add fuzz build for user-authn

### DIFF
--- a/.github/ci_templates/build_fuzz.yml
+++ b/.github/ci_templates/build_fuzz.yml
@@ -1,0 +1,184 @@
+# Copyright 2026 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0
+
+{!{/* build_fuzz_template
+     A focused werf build of fuzzing images (*-fuzz).
+
+     FUZZ_S3_* are always loaded: werf passes them into the image as secrets
+     for in-image corpus sync / replay (see fuzz.tmpl).
+
+     Corpus path: s3://anomaloys-materials/<repository>/<branch slug>/...
+     _dev always uses branch slug "main" (PR builds never publish corpus).
+
+     buildType "dev":
+       - local build only (no registry push)
+       - no build-report upload to S3
+       - FUZZ_S3_BRANCH_SLUG=main
+     buildType "main":
+       - push built images to dev-registry
+       - upload images_fuzz_tags_werf.json to fuzz S3
+       - FUZZ_S3_BRANCH_SLUG from CI_COMMIT_REF_SLUG
+
+     Optional single-target fuzz (FuzzRun/FuzzPkg/FuzzTarget/FuzzTime)
+     is set in module werf.inc.yaml, not here. */}!}
+{!{ define "build_fuzz_template" }!}
+{!{- $ctx := index . 0 -}!}
+{!{- $buildType := index . 1 -}!}
+{!{- $isDev := eq $buildType "dev" -}!}
+# <template: build_fuzz_template>
+runs-on: [self-hosted, large]
+steps:
+{!{ tmpl.Exec "docker_config_isolation" | strings.Indent 2 }!}
+
+  {!{- $secrets := slice -}!}
+  {!{- $secrets = append ( slice "projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/registry_host" "DECKHOUSE_DEV_REGISTRY_HOST" "DECKHOUSE_DEV_REGISTRY_HOST" ) $secrets -}!}
+  {!{- $secrets = append ( slice "projects/data/101ceaca-97cd-462f-aed5-070d9b9de175/dev-registry/writetoken" "login" "DECKHOUSE_DEV_REGISTRY_USER" ) $secrets -}!}
+  {!{- $secrets = append ( slice "projects/data/101ceaca-97cd-462f-aed5-070d9b9de175/dev-registry/writetoken" "password" "DECKHOUSE_DEV_REGISTRY_PASSWORD" ) $secrets -}!}
+  {!{- $secrets = append ( slice "projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/fox_pull_secret" "SOURCE_REPO_GIT" "SOURCE_REPO_GIT" ) $secrets -}!}
+  {!{- $secrets = append ( slice "projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/fox_pull_secret" "CLOUD_PROVIDERS_SOURCE_REPO" "CLOUD_PROVIDERS_SOURCE_REPO" ) $secrets -}!}
+  {!{- $secrets = append ( slice "projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/fox_pull_secret" "OBSERVABILITY_SOURCE_REPO" "OBSERVABILITY_SOURCE_REPO" ) $secrets -}!}
+  {!{- $secrets = append ( slice "projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/fox_pull_secret" "DECKHOUSE_PRIVATE_REPO" "DECKHOUSE_PRIVATE_REPO" ) $secrets -}!}
+  {!{- $secrets = append ( slice "projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/fox_pull_secret" "SOURCE_REPO_SSH_KEY" "SOURCE_REPO_SSH_KEY" ) $secrets -}!}
+  {!{- $secrets = append ( slice "projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/team-ssdlc/fuzzing-s3" "FUZZ_S3_ENDPOINT" "FUZZ_S3_ENDPOINT" ) $secrets -}!}
+  {!{- $secrets = append ( slice "projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/team-ssdlc/fuzzing-s3" "FUZZ_S3_ACCESS_KEY" "FUZZ_S3_ACCESS_KEY" ) $secrets -}!}
+  {!{- $secrets = append ( slice "projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/team-ssdlc/fuzzing-s3" "FUZZ_S3_SECRET_KEY" "FUZZ_S3_SECRET_KEY" ) $secrets -}!}
+  {!{ tmpl.Exec "import_secrets" $secrets | strings.Indent 2 }!}
+
+  {!{ tmpl.Exec "checkout_full_step" $ctx | strings.Indent 2 }!}
+  {!{ tmpl.Exec "read_werf_version_step" $ctx | strings.Indent 2 }!}
+  {!{ tmpl.Exec "login_dev_registry_step" $ctx | strings.Indent 2 }!}
+  {!{ tmpl.Exec "werf_install_step" $ctx | strings.Indent 2 }!}
+  {!{ tmpl.Exec "add_ssh_keys" $ctx | strings.Indent 2 }!}
+
+  - name: Build fuzz images
+    id: build
+    env:
+      WERF_ENV: CE
+      # *-fuzz images are intermediate (final: false); ci-env may force FINAL_IMAGES_ONLY=true
+      WERF_FINAL_IMAGES_ONLY: "false"
+      WERF_EXPERIMENTAL_IMPORT_BY_SOURCE_IMAGE_TAG: 1
+      WERF_DISABLE_PUBLISH_TAG_CACHE_SYNC: 1
+      DECKHOUSE_DEV_REGISTRY_USER: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_USER }}
+      DECKHOUSE_DEV_REGISTRY_PASSWORD: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
+      DEV_REGISTRY_HOST: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_HOST }}
+      SOURCE_REPO: "${{ steps.secrets.outputs.SOURCE_REPO_GIT }}"
+      CLOUD_PROVIDERS_SOURCE_REPO: "${{ steps.secrets.outputs.CLOUD_PROVIDERS_SOURCE_REPO }}"
+      OBSERVABILITY_SOURCE_REPO: "${{ steps.secrets.outputs.OBSERVABILITY_SOURCE_REPO }}"
+      DECKHOUSE_PRIVATE_REPO: "${{ steps.secrets.outputs.DECKHOUSE_PRIVATE_REPO }}"
+      REGISTRY_USER: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_USER }}
+      REGISTRY_PASSWORD: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
+      CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+      CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+      CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+      FUZZ_S3_ENDPOINT: ${{ steps.secrets.outputs.FUZZ_S3_ENDPOINT }}
+      FUZZ_S3_ACCESS_KEY: ${{ steps.secrets.outputs.FUZZ_S3_ACCESS_KEY }}
+      FUZZ_S3_SECRET_KEY: ${{ steps.secrets.outputs.FUZZ_S3_SECRET_KEY }}
+{!{- if $isDev }!}
+      CI_COMMIT_REF_SLUG: ${{needs.pull_request_info.outputs.ref_slug}}
+{!{- else }!}
+      CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+{!{- end }!}
+    run: |
+      set -euo pipefail
+
+      type werf && source "$(werf ci-env github --as-file)"
+
+      # ci-env re-exports FINAL_IMAGES_ONLY=true from werf_envs.yml — drop it for *-fuzz
+      unset WERF_FINAL_IMAGES_ONLY
+
+      if [[ -z "${FUZZ_S3_ENDPOINT:-}" || -z "${FUZZ_S3_ACCESS_KEY:-}" || -z "${FUZZ_S3_SECRET_KEY:-}" ]]; then
+        echo "Fuzz S3 secrets are not set (required for in-image corpus sync)"
+        exit 1
+      fi
+
+      # Corpus lives under s3://anomaloys-materials/<repository>/<branch slug>/...
+      export FUZZ_S3_REPOSITORY="${GITHUB_REPOSITORY##*/}"
+{!{- if $isDev }!}
+      # PR builds never publish corpus — always replay from main
+      export FUZZ_S3_BRANCH_SLUG="main"
+{!{- else }!}
+      export FUZZ_S3_BRANCH_SLUG="${CI_COMMIT_REF_SLUG}"
+{!{- end }!}
+      if [[ -z "${FUZZ_S3_REPOSITORY}" || -z "${FUZZ_S3_BRANCH_SLUG}" ]]; then
+        echo "FUZZ_S3_REPOSITORY / FUZZ_S3_BRANCH_SLUG could not be determined"
+        exit 1
+      fi
+      echo "Corpus replay path prefix: anomaloys-materials/${FUZZ_S3_REPOSITORY}/${FUZZ_S3_BRANCH_SLUG}/"
+
+{!{- if $isDev }!}
+      # PR/dev: build locally, do not push fuzz images; no build-report upload
+      unset WERF_REPO
+      echo "dev fuzz build: local only (no registry push, no build-report upload)"
+{!{- else }!}
+      DEV_REGISTRY_PATH="${DECKHOUSE_DEV_REGISTRY_HOST}/${REGISTRY_PATH}"
+      export REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+      export WERF_REPO="${DEV_REGISTRY_PATH}"
+      echo "main fuzz build: push to ${WERF_REPO}"
+{!{- end }!}
+
+      FUZZ_IMAGES="$(werf config list --env "${WERF_ENV}" | grep -- '-fuzz$' || true)"
+      if [[ -z "${FUZZ_IMAGES}" ]]; then
+        echo "No fuzz images found"
+        exit 1
+      fi
+
+      echo "Building fuzz images:"
+      echo "${FUZZ_IMAGES}"
+
+      # shellcheck disable=SC2086
+      werf build ${FUZZ_IMAGES} \
+        --insecure-registry \
+        --parallel=true --parallel-tasks-limit=10 \
+        --save-build-report=true \
+        --build-report-path images_fuzz_tags_werf.json
+
+{!{- if not $isDev }!}
+      command -v jq >/dev/null 2>&1 || {
+        echo "jq is required"
+        exit 1
+      }
+
+      REPOSITORY="${GITHUB_REPOSITORY##*/}"
+      BRANCH="${CI_COMMIT_REF_NAME}"
+      BRANCH_SLUG="${CI_COMMIT_REF_SLUG}"
+      COMMIT="${GITHUB_SHA}"
+
+      if [[ -z "${REPOSITORY}" || -z "${BRANCH}" || -z "${BRANCH_SLUG}" ]]; then
+        echo "Cannot determine repository/branch for fuzz build report upload"
+        exit 1
+      fi
+
+      jq \
+        --arg repository "${REPOSITORY}" \
+        --arg branch "${BRANCH}" \
+        --arg branchSlug "${BRANCH_SLUG}" \
+        --arg commit "${COMMIT}" \
+        '
+        .Source = {
+          Repository: $repository,
+          Branch: $branch,
+          BranchSlug: $branchSlug,
+          Commit: $commit
+        }
+        ' \
+        images_fuzz_tags_werf.json \
+        > images_fuzz_tags_werf.tmp.json
+      mv images_fuzz_tags_werf.tmp.json images_fuzz_tags_werf.json
+
+      MC=/tmp/mc
+      curl -fsSL -o "${MC}" https://dl.min.io/client/mc/release/linux-amd64/mc
+      chmod +x "${MC}"
+
+      "${MC}" alias set fuzz-s3 \
+        "${FUZZ_S3_ENDPOINT}" \
+        "${FUZZ_S3_ACCESS_KEY}" \
+        "${FUZZ_S3_SECRET_KEY}"
+
+      "${MC}" cp \
+        "images_fuzz_tags_werf.json" \
+        "fuzz-s3/anomaloys-materials/build-reports/${REPOSITORY}/${BRANCH_SLUG}/images_fuzz_tags_werf.json"
+{!{- end }!}
+
+# </template: build_fuzz_template>
+{!{ end }!}

--- a/.github/ci_templates/build_fuzz.yml
+++ b/.github/ci_templates/build_fuzz.yml
@@ -54,7 +54,6 @@ steps:
   - name: Build fuzz images
     id: build
     env:
-      WERF_ENV: CE
       # *-fuzz images are intermediate (final: false); ci-env may force FINAL_IMAGES_ONLY=true
       WERF_FINAL_IMAGES_ONLY: "false"
       WERF_EXPERIMENTAL_IMPORT_BY_SOURCE_IMAGE_TAG: 1

--- a/.github/ci_templates/build_fuzz.yml
+++ b/.github/ci_templates/build_fuzz.yml
@@ -13,6 +13,7 @@
 
      buildType "dev":
        - local build only (no registry push)
+       - reuse build cache from dev-registry via secondary repo
        - no build-report upload to S3
        - FUZZ_S3_BRANCH_SLUG=main
      buildType "main":
@@ -107,8 +108,10 @@ steps:
 
 {!{- if $isDev }!}
       # PR/dev: build locally, do not push fuzz images; no build-report upload
+      DEV_REGISTRY_PATH="${DECKHOUSE_DEV_REGISTRY_HOST}/${REGISTRY_PATH}"
+      export WERF_SECONDARY_REPO_1="${DEV_REGISTRY_PATH}"
       unset WERF_REPO
-      echo "dev fuzz build: local only (no registry push, no build-report upload)"
+      echo "dev fuzz build: local only, cache from ${WERF_SECONDARY_REPO_1} (no registry push, no build-report upload)"
 {!{- else }!}
       DEV_REGISTRY_PATH="${DECKHOUSE_DEV_REGISTRY_HOST}/${REGISTRY_PATH}"
       export REGISTRY_PATH="${DEV_REGISTRY_PATH}"

--- a/.github/workflow_templates/build-and-test_dev.yml
+++ b/.github/workflow_templates/build-and-test_dev.yml
@@ -59,6 +59,14 @@ jobs:
       - pull_request_info
 {!{ tmpl.Exec "build_tests_template" (slice $ctx "dev") | strings.Indent 4 }!}
 
+  build_fuzz:
+    if: ${{ needs.pull_request_info.outputs.changes_not_markdown == 'true' }}
+    name: Build fuzz images
+    needs:
+      - git_info
+      - pull_request_info
+{!{ tmpl.Exec "build_fuzz_template" (slice $ctx "dev") | strings.Indent 4 }!}
+
   go_generate:
     name: Go Generate
     needs:

--- a/.github/workflow_templates/build-and-test_main.yml
+++ b/.github/workflow_templates/build-and-test_main.yml
@@ -53,6 +53,12 @@ jobs:
       - git_info
 {!{ tmpl.Exec "build_tests_template" (slice $ctx "main") | strings.Indent 4 }!}
 
+  build_fuzz:
+    name: Build fuzz images
+    needs:
+      - git_info
+{!{ tmpl.Exec "build_fuzz_template" (slice $ctx "main") | strings.Indent 4 }!}
+
   go_generate:
     name: Go Generate
     needs:

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -1021,6 +1021,250 @@ jobs:
     # </template: build_tests_template>
 
 
++  build_fuzz:
+    if: ${{ needs.pull_request_info.outputs.changes_not_markdown == 'true' }}
+    name: Build fuzz images
+    needs:
+      - git_info
+      - pull_request_info
+    # <template: build_fuzz_template>
+    runs-on: [self-hosted, large]
+    steps:
+
+      # </template: docker-config-isolation>
+      - name: Isolate docker config
+        id: docker-config-isolation
+        run: |
+          mkdir -p $RUNNER_TEMP/.docker
+          echo "DOCKER_CONFIG=$RUNNER_TEMP/.docker" >> $GITHUB_ENV
+
+      # </template: docker_config_isolation>
+      # <template: import_secrets>
+      - name: Split repository name
+        id: split
+        env:
+          REPO: ${{ github.repository }}
+        run: |
+          if [ $REPO == "deckhouse/deckhouse" ]; then
+            echo "name=deckhouse" >> $GITHUB_OUTPUT
+          else
+            echo "name=deckhouse-test" >> $GITHUB_OUTPUT
+          fi
+      - name: Import secrets
+        id: secrets
+        uses: hashicorp/vault-action@v2
+        with:
+          url: https://seguro.flant.com
+          path: github
+          role: "${{ steps.split.outputs.name }}"
+          method: jwt
+          jwtGithubAudience: github-access-aud
+          secrets: |
+            projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/registry_host DECKHOUSE_DEV_REGISTRY_HOST | DECKHOUSE_DEV_REGISTRY_HOST ;
+            projects/data/101ceaca-97cd-462f-aed5-070d9b9de175/dev-registry/writetoken login | DECKHOUSE_DEV_REGISTRY_USER ;
+            projects/data/101ceaca-97cd-462f-aed5-070d9b9de175/dev-registry/writetoken password | DECKHOUSE_DEV_REGISTRY_PASSWORD ;
+            projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/fox_pull_secret SOURCE_REPO_GIT | SOURCE_REPO_GIT ;
+            projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/fox_pull_secret CLOUD_PROVIDERS_SOURCE_REPO | CLOUD_PROVIDERS_SOURCE_REPO ;
+            projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/fox_pull_secret OBSERVABILITY_SOURCE_REPO | OBSERVABILITY_SOURCE_REPO ;
+            projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/fox_pull_secret DECKHOUSE_PRIVATE_REPO | DECKHOUSE_PRIVATE_REPO ;
+            projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/fox_pull_secret SOURCE_REPO_SSH_KEY | SOURCE_REPO_SSH_KEY ;
+            projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/team-ssdlc/fuzzing-s3 FUZZ_S3_ENDPOINT | FUZZ_S3_ENDPOINT ;
+            projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/team-ssdlc/fuzzing-s3 FUZZ_S3_ACCESS_KEY | FUZZ_S3_ACCESS_KEY ;
+            projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/team-ssdlc/fuzzing-s3 FUZZ_S3_SECRET_KEY | FUZZ_S3_SECRET_KEY ;
+
+      # </template: import_secrets>
+
+
+      # <template: checkout_full_step>
+      - name: Checkout sources
+        uses: actions/checkout@v3.5.2
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.pull_request_info.outputs.ref }}
+      # </template: checkout_full_step>
+
+      # <template: read_werf_version_step>
+      - name: Read werf version from werf_envs.yml
+        id: read_werf_version
+        run: |
+          set -euo pipefail
+          WERF_ENVS_FILE=".github/ci_includes/werf_envs.yml"
+          if [[ ! -f "$WERF_ENVS_FILE" ]]; then
+            echo "::error title=WERF version::File ${WERF_ENVS_FILE} not found"
+            exit 1
+          fi
+          WERF_VERSION="$(grep -E '^[[:space:]]*WERF_VERSION:' "$WERF_ENVS_FILE" | head -1 | sed -E 's/^[[:space:]]*WERF_VERSION:[[:space:]]*"?([^"#[:space:]]+)"?.*/\1/')"
+          echo "Detected WERF_VERSION=${WERF_VERSION}"
+          echo "WERF_VERSION=${WERF_VERSION}" >> "$GITHUB_ENV"
+          echo "werf_version=${WERF_VERSION}" >> "$GITHUB_OUTPUT"
+      # </template: read_werf_version_step>
+
+      # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then
+            echo "has_credentials=true" >> $GITHUB_OUTPUT
+            echo "web_registry_path=${{steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_HOST }}/deckhouse/site" >> $GITHUB_OUTPUT
+          fi
+      - name: Login to dev registry
+        uses: docker/login-action@v2.1.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
+        with:
+          registry: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_HOST }}
+          username: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_USER }}
+          password: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
+          logout: false
+      # </template: login_dev_registry_step>
+
+      # <template: werf_install_step>
+      - name: Install werf-dk CLI
+        run: |
+          if [[ -z "${WERF_VERSION:-}" ]]; then
+            echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
+            exit 1
+          fi
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
+            werf_fallback=false
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
+          fi
+          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
+          echo "$WERF_PATH" >> "$GITHUB_PATH"
+          CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
+          if [[ "${WERF_VERSION}" != "$CACHED_VERSION" && $werf_fallback == "false" ]]; then
+            echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}";
+            mkdir -p "$WERF_PATH"
+            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}/werf
+            chmod +x "$WERF_PATH/werf"
+          elif [[ "${WERF_VERSION}" != "$CACHED_VERSION" && $werf_fallback == "true" ]]; then
+            echo "Current werf is $CACHED_VERSION, fallback to ${WERF_VERSION}";
+            mkdir -p "$WERF_PATH"
+            curl -Lsfo "$WERF_PATH/werf" https://tuf.werf.io/targets/releases/${WERF_VERSION#v}/linux-amd64/bin/werf
+            chmod +x "$WERF_PATH/werf"
+          else
+            echo "Current werf is $CACHED_VERSION, skipping download"
+          fi
+      # </template: werf_install_step>
+
+      # <template: add_ssh_keys>
+      - name: Start ssh-agent
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: |
+            ${{ steps.secrets.outputs.SOURCE_REPO_SSH_KEY }}
+            ${{ steps.secrets.outputs.SVACE_ANALYZE_SSH_PRIVATE_KEY }}
+      - name: Add ssh_known_hosts
+        run: |
+          HOST=$(grep -oP '(?<=@)[^/:]+' <<< ${{ steps.secrets.outputs.SOURCE_REPO_GIT }})
+          echo "::add-mask::$HOST"
+          IPS=$(nslookup "$HOST" | awk '/^Address: / { print $2 }')
+          for IP in $IPS; do
+            echo "::add-mask::$IP"
+          done
+          mkdir -p ~/.ssh
+          touch ~/.ssh/known_hosts
+          HOST_KEYS=$(ssh-keyscan -H "$HOST" 2>/dev/null)
+          while IFS= read -r KEY_LINE; do
+            CONSTANT_PART=$(awk '{print $2, $3}' <<< "$KEY_LINE")
+            if ! grep -q "$CONSTANT_PART" ~/.ssh/known_hosts; then
+              echo "$KEY_LINE" >> ~/.ssh/known_hosts
+            fi
+          done <<< "$HOST_KEYS"
+      - name: Add svace analyze server to ssh_known_hosts
+        continue-on-error: true
+        run: |
+          host=${{ steps.secrets.outputs.SVACE_ANALYZE_HOST }}
+          host_ip=$(nslookup "$host" | awk '/^Address: / { print $2 }')
+          echo "::add-mask::$host_ip"
+          mkdir -p ~/.ssh
+          touch ~/.ssh/known_hosts
+          HOST_KEYS=$(ssh-keyscan -H "$host" 2>/dev/null)
+          while IFS= read -r KEY_LINE; do
+              CONSTANT_PART=$(awk '{print $2, $3}' <<< "$KEY_LINE")
+              if grep -q "$CONSTANT_PART" ~/.ssh/known_hosts; then
+                  ssh-keygen -R $host
+                  ssh-keygen -R $host_ip
+              fi
+              echo "$KEY_LINE" >> ~/.ssh/known_hosts
+          done <<< "$HOST_KEYS"
+      # </template: add_ssh_keys>
+
+      - name: Build fuzz images
+        id: build
+        env:
+          WERF_ENV: CE
+          # *-fuzz images are intermediate (final: false); ci-env may force FINAL_IMAGES_ONLY=true
+          WERF_FINAL_IMAGES_ONLY: "false"
+          WERF_EXPERIMENTAL_IMPORT_BY_SOURCE_IMAGE_TAG: 1
+          WERF_DISABLE_PUBLISH_TAG_CACHE_SYNC: 1
+          DECKHOUSE_DEV_REGISTRY_USER: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_USER }}
+          DECKHOUSE_DEV_REGISTRY_PASSWORD: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
+          DEV_REGISTRY_HOST: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_HOST }}
+          SOURCE_REPO: "${{ steps.secrets.outputs.SOURCE_REPO_GIT }}"
+          CLOUD_PROVIDERS_SOURCE_REPO: "${{ steps.secrets.outputs.CLOUD_PROVIDERS_SOURCE_REPO }}"
+          OBSERVABILITY_SOURCE_REPO: "${{ steps.secrets.outputs.OBSERVABILITY_SOURCE_REPO }}"
+          DECKHOUSE_PRIVATE_REPO: "${{ steps.secrets.outputs.DECKHOUSE_PRIVATE_REPO }}"
+          REGISTRY_USER: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_USER }}
+          REGISTRY_PASSWORD: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+          FUZZ_S3_ENDPOINT: ${{ steps.secrets.outputs.FUZZ_S3_ENDPOINT }}
+          FUZZ_S3_ACCESS_KEY: ${{ steps.secrets.outputs.FUZZ_S3_ACCESS_KEY }}
+          FUZZ_S3_SECRET_KEY: ${{ steps.secrets.outputs.FUZZ_S3_SECRET_KEY }}
+          CI_COMMIT_REF_SLUG: ${{needs.pull_request_info.outputs.ref_slug}}
+        run: |
+          set -euo pipefail
+
+          type werf && source "$(werf ci-env github --as-file)"
+
+          # ci-env re-exports FINAL_IMAGES_ONLY=true from werf_envs.yml — drop it for *-fuzz
+          unset WERF_FINAL_IMAGES_ONLY
+
+          if [[ -z "${FUZZ_S3_ENDPOINT:-}" || -z "${FUZZ_S3_ACCESS_KEY:-}" || -z "${FUZZ_S3_SECRET_KEY:-}" ]]; then
+            echo "Fuzz S3 secrets are not set (required for in-image corpus sync)"
+            exit 1
+          fi
+
+          # Corpus lives under s3://anomaloys-materials/<repository>/<branch slug>/...
+          export FUZZ_S3_REPOSITORY="${GITHUB_REPOSITORY##*/}"
+          # PR builds never publish corpus — always replay from main
+          export FUZZ_S3_BRANCH_SLUG="main"
+          if [[ -z "${FUZZ_S3_REPOSITORY}" || -z "${FUZZ_S3_BRANCH_SLUG}" ]]; then
+            echo "FUZZ_S3_REPOSITORY / FUZZ_S3_BRANCH_SLUG could not be determined"
+            exit 1
+          fi
+          echo "Corpus replay path prefix: anomaloys-materials/${FUZZ_S3_REPOSITORY}/${FUZZ_S3_BRANCH_SLUG}/"
+          # PR/dev: build locally, do not push fuzz images; no build-report upload
+          unset WERF_REPO
+          echo "dev fuzz build: local only (no registry push, no build-report upload)"
+
+          FUZZ_IMAGES="$(werf config list --env "${WERF_ENV}" | grep -- '-fuzz$' || true)"
+          if [[ -z "${FUZZ_IMAGES}" ]]; then
+            echo "No fuzz images found"
+            exit 1
+          fi
+
+          echo "Building fuzz images:"
+          echo "${FUZZ_IMAGES}"
+
+          # shellcheck disable=SC2086
+          werf build ${FUZZ_IMAGES} \
+            --insecure-registry \
+            --parallel=true --parallel-tasks-limit=10 \
+            --save-build-report=true \
+            --build-report-path images_fuzz_tags_werf.json
+
+    # </template: build_fuzz_template>
+
+
+
   go_generate:
     name: Go Generate
     needs:

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -1021,7 +1021,7 @@ jobs:
     # </template: build_tests_template>
 
 
-+  build_fuzz:
+  build_fuzz:
     if: ${{ needs.pull_request_info.outputs.changes_not_markdown == 'true' }}
     name: Build fuzz images
     needs:
@@ -1154,7 +1154,7 @@ jobs:
 
       # <template: add_ssh_keys>
       - name: Start ssh-agent
-        uses: webfactory/ssh-agent@v0.9.0
+        uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: |
             ${{ steps.secrets.outputs.SOURCE_REPO_SSH_KEY }}
@@ -1262,7 +1262,6 @@ jobs:
             --build-report-path images_fuzz_tags_werf.json
 
     # </template: build_fuzz_template>
-
 
 
   go_generate:

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -1241,8 +1241,10 @@ jobs:
           fi
           echo "Corpus replay path prefix: anomaloys-materials/${FUZZ_S3_REPOSITORY}/${FUZZ_S3_BRANCH_SLUG}/"
           # PR/dev: build locally, do not push fuzz images; no build-report upload
+          DEV_REGISTRY_PATH="${DECKHOUSE_DEV_REGISTRY_HOST}/${REGISTRY_PATH}"
+          export WERF_SECONDARY_REPO_1="${DEV_REGISTRY_PATH}"
           unset WERF_REPO
-          echo "dev fuzz build: local only (no registry push, no build-report upload)"
+          echo "dev fuzz build: local only, cache from ${WERF_SECONDARY_REPO_1} (no registry push, no build-report upload)"
 
           FUZZ_IMAGES="$(werf config list --env "${WERF_ENV}" | grep -- '-fuzz$' || true)"
           if [[ -z "${FUZZ_IMAGES}" ]]; then

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -1198,7 +1198,6 @@ jobs:
       - name: Build fuzz images
         id: build
         env:
-          WERF_ENV: CE
           # *-fuzz images are intermediate (final: false); ci-env may force FINAL_IMAGES_ONLY=true
           WERF_FINAL_IMAGES_ONLY: "false"
           WERF_EXPERIMENTAL_IMPORT_BY_SOURCE_IMAGE_TAG: 1

--- a/.github/workflows/build-and-test_main.yml
+++ b/.github/workflows/build-and-test_main.yml
@@ -764,7 +764,7 @@ jobs:
     # </template: build_tests_template>
 
 
-+  build_fuzz:
+  build_fuzz:
     name: Build fuzz images
     needs:
       - git_info
@@ -894,7 +894,7 @@ jobs:
 
       # <template: add_ssh_keys>
       - name: Start ssh-agent
-        uses: webfactory/ssh-agent@v0.9.0
+        uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: |
             ${{ steps.secrets.outputs.SOURCE_REPO_SSH_KEY }}
@@ -1046,7 +1046,6 @@ jobs:
             "fuzz-s3/anomaloys-materials/build-reports/${REPOSITORY}/${BRANCH_SLUG}/images_fuzz_tags_werf.json"
 
     # </template: build_fuzz_template>
-
 
 
   go_generate:

--- a/.github/workflows/build-and-test_main.yml
+++ b/.github/workflows/build-and-test_main.yml
@@ -764,6 +764,291 @@ jobs:
     # </template: build_tests_template>
 
 
++  build_fuzz:
+    name: Build fuzz images
+    needs:
+      - git_info
+    # <template: build_fuzz_template>
+    runs-on: [self-hosted, large]
+    steps:
+
+      # </template: docker-config-isolation>
+      - name: Isolate docker config
+        id: docker-config-isolation
+        run: |
+          mkdir -p $RUNNER_TEMP/.docker
+          echo "DOCKER_CONFIG=$RUNNER_TEMP/.docker" >> $GITHUB_ENV
+
+      # </template: docker_config_isolation>
+      # <template: import_secrets>
+      - name: Split repository name
+        id: split
+        env:
+          REPO: ${{ github.repository }}
+        run: |
+          if [ $REPO == "deckhouse/deckhouse" ]; then
+            echo "name=deckhouse" >> $GITHUB_OUTPUT
+          else
+            echo "name=deckhouse-test" >> $GITHUB_OUTPUT
+          fi
+      - name: Import secrets
+        id: secrets
+        uses: hashicorp/vault-action@v2
+        with:
+          url: https://seguro.flant.com
+          path: github
+          role: "${{ steps.split.outputs.name }}"
+          method: jwt
+          jwtGithubAudience: github-access-aud
+          secrets: |
+            projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/registry_host DECKHOUSE_DEV_REGISTRY_HOST | DECKHOUSE_DEV_REGISTRY_HOST ;
+            projects/data/101ceaca-97cd-462f-aed5-070d9b9de175/dev-registry/writetoken login | DECKHOUSE_DEV_REGISTRY_USER ;
+            projects/data/101ceaca-97cd-462f-aed5-070d9b9de175/dev-registry/writetoken password | DECKHOUSE_DEV_REGISTRY_PASSWORD ;
+            projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/fox_pull_secret SOURCE_REPO_GIT | SOURCE_REPO_GIT ;
+            projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/fox_pull_secret CLOUD_PROVIDERS_SOURCE_REPO | CLOUD_PROVIDERS_SOURCE_REPO ;
+            projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/fox_pull_secret OBSERVABILITY_SOURCE_REPO | OBSERVABILITY_SOURCE_REPO ;
+            projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/fox_pull_secret DECKHOUSE_PRIVATE_REPO | DECKHOUSE_PRIVATE_REPO ;
+            projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/github/fox_pull_secret SOURCE_REPO_SSH_KEY | SOURCE_REPO_SSH_KEY ;
+            projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/team-ssdlc/fuzzing-s3 FUZZ_S3_ENDPOINT | FUZZ_S3_ENDPOINT ;
+            projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/team-ssdlc/fuzzing-s3 FUZZ_S3_ACCESS_KEY | FUZZ_S3_ACCESS_KEY ;
+            projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/team-ssdlc/fuzzing-s3 FUZZ_S3_SECRET_KEY | FUZZ_S3_SECRET_KEY ;
+
+      # </template: import_secrets>
+
+
+      # <template: checkout_full_step>
+      - name: Checkout sources
+        uses: actions/checkout@v3.5.2
+        with:
+          fetch-depth: 0
+      # </template: checkout_full_step>
+
+      # <template: read_werf_version_step>
+      - name: Read werf version from werf_envs.yml
+        id: read_werf_version
+        run: |
+          set -euo pipefail
+          WERF_ENVS_FILE=".github/ci_includes/werf_envs.yml"
+          if [[ ! -f "$WERF_ENVS_FILE" ]]; then
+            echo "::error title=WERF version::File ${WERF_ENVS_FILE} not found"
+            exit 1
+          fi
+          WERF_VERSION="$(grep -E '^[[:space:]]*WERF_VERSION:' "$WERF_ENVS_FILE" | head -1 | sed -E 's/^[[:space:]]*WERF_VERSION:[[:space:]]*"?([^"#[:space:]]+)"?.*/\1/')"
+          echo "Detected WERF_VERSION=${WERF_VERSION}"
+          echo "WERF_VERSION=${WERF_VERSION}" >> "$GITHUB_ENV"
+          echo "werf_version=${WERF_VERSION}" >> "$GITHUB_OUTPUT"
+      # </template: read_werf_version_step>
+
+      # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then
+            echo "has_credentials=true" >> $GITHUB_OUTPUT
+            echo "web_registry_path=${{steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_HOST }}/deckhouse/site" >> $GITHUB_OUTPUT
+          fi
+      - name: Login to dev registry
+        uses: docker/login-action@v2.1.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
+        with:
+          registry: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_HOST }}
+          username: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_USER }}
+          password: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
+          logout: false
+      # </template: login_dev_registry_step>
+
+      # <template: werf_install_step>
+      - name: Install werf-dk CLI
+        run: |
+          if [[ -z "${WERF_VERSION:-}" ]]; then
+            echo "::error title=WERF version::WERF_VERSION is not set. Run read_werf_version_step before werf_install_step."
+            exit 1
+          fi
+          if [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+-dk(\.*)? ]]; then
+            werf_fallback=false
+          elif [[ ${WERF_VERSION} =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            werf_fallback=true
+          else
+            echo "::error title=WERF version::Invalid WERF_VERSION '${WERF_VERSION}' in ${WERF_ENVS_FILE}, expected format vX.Y.Z or vX.Y.Z-dk.W"
+            exit 1
+          fi
+          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}"
+          echo "$WERF_PATH" >> "$GITHUB_PATH"
+          CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
+          if [[ "${WERF_VERSION}" != "$CACHED_VERSION" && $werf_fallback == "false" ]]; then
+            echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}";
+            mkdir -p "$WERF_PATH"
+            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}/werf
+            chmod +x "$WERF_PATH/werf"
+          elif [[ "${WERF_VERSION}" != "$CACHED_VERSION" && $werf_fallback == "true" ]]; then
+            echo "Current werf is $CACHED_VERSION, fallback to ${WERF_VERSION}";
+            mkdir -p "$WERF_PATH"
+            curl -Lsfo "$WERF_PATH/werf" https://tuf.werf.io/targets/releases/${WERF_VERSION#v}/linux-amd64/bin/werf
+            chmod +x "$WERF_PATH/werf"
+          else
+            echo "Current werf is $CACHED_VERSION, skipping download"
+          fi
+      # </template: werf_install_step>
+
+      # <template: add_ssh_keys>
+      - name: Start ssh-agent
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: |
+            ${{ steps.secrets.outputs.SOURCE_REPO_SSH_KEY }}
+            ${{ steps.secrets.outputs.SVACE_ANALYZE_SSH_PRIVATE_KEY }}
+      - name: Add ssh_known_hosts
+        run: |
+          HOST=$(grep -oP '(?<=@)[^/:]+' <<< ${{ steps.secrets.outputs.SOURCE_REPO_GIT }})
+          echo "::add-mask::$HOST"
+          IPS=$(nslookup "$HOST" | awk '/^Address: / { print $2 }')
+          for IP in $IPS; do
+            echo "::add-mask::$IP"
+          done
+          mkdir -p ~/.ssh
+          touch ~/.ssh/known_hosts
+          HOST_KEYS=$(ssh-keyscan -H "$HOST" 2>/dev/null)
+          while IFS= read -r KEY_LINE; do
+            CONSTANT_PART=$(awk '{print $2, $3}' <<< "$KEY_LINE")
+            if ! grep -q "$CONSTANT_PART" ~/.ssh/known_hosts; then
+              echo "$KEY_LINE" >> ~/.ssh/known_hosts
+            fi
+          done <<< "$HOST_KEYS"
+      - name: Add svace analyze server to ssh_known_hosts
+        continue-on-error: true
+        run: |
+          host=${{ steps.secrets.outputs.SVACE_ANALYZE_HOST }}
+          host_ip=$(nslookup "$host" | awk '/^Address: / { print $2 }')
+          echo "::add-mask::$host_ip"
+          mkdir -p ~/.ssh
+          touch ~/.ssh/known_hosts
+          HOST_KEYS=$(ssh-keyscan -H "$host" 2>/dev/null)
+          while IFS= read -r KEY_LINE; do
+              CONSTANT_PART=$(awk '{print $2, $3}' <<< "$KEY_LINE")
+              if grep -q "$CONSTANT_PART" ~/.ssh/known_hosts; then
+                  ssh-keygen -R $host
+                  ssh-keygen -R $host_ip
+              fi
+              echo "$KEY_LINE" >> ~/.ssh/known_hosts
+          done <<< "$HOST_KEYS"
+      # </template: add_ssh_keys>
+
+      - name: Build fuzz images
+        id: build
+        env:
+          WERF_ENV: CE
+          # *-fuzz images are intermediate (final: false); ci-env may force FINAL_IMAGES_ONLY=true
+          WERF_FINAL_IMAGES_ONLY: "false"
+          WERF_EXPERIMENTAL_IMPORT_BY_SOURCE_IMAGE_TAG: 1
+          WERF_DISABLE_PUBLISH_TAG_CACHE_SYNC: 1
+          DECKHOUSE_DEV_REGISTRY_USER: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_USER }}
+          DECKHOUSE_DEV_REGISTRY_PASSWORD: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
+          DEV_REGISTRY_HOST: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_HOST }}
+          SOURCE_REPO: "${{ steps.secrets.outputs.SOURCE_REPO_GIT }}"
+          CLOUD_PROVIDERS_SOURCE_REPO: "${{ steps.secrets.outputs.CLOUD_PROVIDERS_SOURCE_REPO }}"
+          OBSERVABILITY_SOURCE_REPO: "${{ steps.secrets.outputs.OBSERVABILITY_SOURCE_REPO }}"
+          DECKHOUSE_PRIVATE_REPO: "${{ steps.secrets.outputs.DECKHOUSE_PRIVATE_REPO }}"
+          REGISTRY_USER: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_USER }}
+          REGISTRY_PASSWORD: ${{ steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+          FUZZ_S3_ENDPOINT: ${{ steps.secrets.outputs.FUZZ_S3_ENDPOINT }}
+          FUZZ_S3_ACCESS_KEY: ${{ steps.secrets.outputs.FUZZ_S3_ACCESS_KEY }}
+          FUZZ_S3_SECRET_KEY: ${{ steps.secrets.outputs.FUZZ_S3_SECRET_KEY }}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+        run: |
+          set -euo pipefail
+
+          type werf && source "$(werf ci-env github --as-file)"
+
+          # ci-env re-exports FINAL_IMAGES_ONLY=true from werf_envs.yml — drop it for *-fuzz
+          unset WERF_FINAL_IMAGES_ONLY
+
+          if [[ -z "${FUZZ_S3_ENDPOINT:-}" || -z "${FUZZ_S3_ACCESS_KEY:-}" || -z "${FUZZ_S3_SECRET_KEY:-}" ]]; then
+            echo "Fuzz S3 secrets are not set (required for in-image corpus sync)"
+            exit 1
+          fi
+
+          # Corpus lives under s3://anomaloys-materials/<repository>/<branch slug>/...
+          export FUZZ_S3_REPOSITORY="${GITHUB_REPOSITORY##*/}"
+          export FUZZ_S3_BRANCH_SLUG="${CI_COMMIT_REF_SLUG}"
+          if [[ -z "${FUZZ_S3_REPOSITORY}" || -z "${FUZZ_S3_BRANCH_SLUG}" ]]; then
+            echo "FUZZ_S3_REPOSITORY / FUZZ_S3_BRANCH_SLUG could not be determined"
+            exit 1
+          fi
+          echo "Corpus replay path prefix: anomaloys-materials/${FUZZ_S3_REPOSITORY}/${FUZZ_S3_BRANCH_SLUG}/"
+          DEV_REGISTRY_PATH="${DECKHOUSE_DEV_REGISTRY_HOST}/${REGISTRY_PATH}"
+          export REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          export WERF_REPO="${DEV_REGISTRY_PATH}"
+          echo "main fuzz build: push to ${WERF_REPO}"
+
+          FUZZ_IMAGES="$(werf config list --env "${WERF_ENV}" | grep -- '-fuzz$' || true)"
+          if [[ -z "${FUZZ_IMAGES}" ]]; then
+            echo "No fuzz images found"
+            exit 1
+          fi
+
+          echo "Building fuzz images:"
+          echo "${FUZZ_IMAGES}"
+
+          # shellcheck disable=SC2086
+          werf build ${FUZZ_IMAGES} \
+            --insecure-registry \
+            --parallel=true --parallel-tasks-limit=10 \
+            --save-build-report=true \
+            --build-report-path images_fuzz_tags_werf.json
+          command -v jq >/dev/null 2>&1 || {
+            echo "jq is required"
+            exit 1
+          }
+
+          REPOSITORY="${GITHUB_REPOSITORY##*/}"
+          BRANCH="${CI_COMMIT_REF_NAME}"
+          BRANCH_SLUG="${CI_COMMIT_REF_SLUG}"
+          COMMIT="${GITHUB_SHA}"
+
+          if [[ -z "${REPOSITORY}" || -z "${BRANCH}" || -z "${BRANCH_SLUG}" ]]; then
+            echo "Cannot determine repository/branch for fuzz build report upload"
+            exit 1
+          fi
+
+          jq \
+            --arg repository "${REPOSITORY}" \
+            --arg branch "${BRANCH}" \
+            --arg branchSlug "${BRANCH_SLUG}" \
+            --arg commit "${COMMIT}" \
+            '
+            .Source = {
+              Repository: $repository,
+              Branch: $branch,
+              BranchSlug: $branchSlug,
+              Commit: $commit
+            }
+            ' \
+            images_fuzz_tags_werf.json \
+            > images_fuzz_tags_werf.tmp.json
+          mv images_fuzz_tags_werf.tmp.json images_fuzz_tags_werf.json
+
+          MC=/tmp/mc
+          curl -fsSL -o "${MC}" https://dl.min.io/client/mc/release/linux-amd64/mc
+          chmod +x "${MC}"
+
+          "${MC}" alias set fuzz-s3 \
+            "${FUZZ_S3_ENDPOINT}" \
+            "${FUZZ_S3_ACCESS_KEY}" \
+            "${FUZZ_S3_SECRET_KEY}"
+
+          "${MC}" cp \
+            "images_fuzz_tags_werf.json" \
+            "fuzz-s3/anomaloys-materials/build-reports/${REPOSITORY}/${BRANCH_SLUG}/images_fuzz_tags_werf.json"
+
+    # </template: build_fuzz_template>
+
+
+
   go_generate:
     name: Go Generate
     needs:

--- a/.github/workflows/build-and-test_main.yml
+++ b/.github/workflows/build-and-test_main.yml
@@ -938,7 +938,6 @@ jobs:
       - name: Build fuzz images
         id: build
         env:
-          WERF_ENV: CE
           # *-fuzz images are intermediate (final: false); ci-env may force FINAL_IMAGES_ONLY=true
           WERF_FINAL_IMAGES_ONLY: "false"
           WERF_EXPERIMENTAL_IMPORT_BY_SOURCE_IMAGE_TAG: 1

--- a/.werf/defines/fuzz.tmpl
+++ b/.werf/defines/fuzz.tmpl
@@ -1,0 +1,363 @@
+# Go fuzz image consumed by fuzzing-compliance.
+# The dedicated CI job sets FUZZ_S3_ENDPOINT, so regular Deckhouse builds do
+# not render these intermediate images.
+# Required caller fields: FuzzEngine and FuzzSrcImage.
+# Optional caller fields: FuzzPackages, FuzzCGOEnabled, FuzzImageName and
+# FuzzSrcAdd.
+{{- define "fuzz image" }}
+{{- if env "FUZZ_S3_ENDPOINT" "" }}
+{{- if not .FuzzEngine }}
+  {{- fail "fuzz image: FuzzEngine is required (set .FuzzEngine before include)" }}
+{{- end }}
+{{- $engine := .FuzzEngine }}
+{{- $prefix := printf "%s/" .ModuleName }}
+{{- $fuzzRun := .FuzzRun | default (env "FUZZ_ENABLE_RUN" "false") }}
+{{- $fuzzPkg := .FuzzPkg | default (env "FUZZ_PKG" "") }}
+{{- $fuzzTarget := .FuzzTarget | default (env "FUZZ_TARGET" "") }}
+{{- $fuzzTime := .FuzzTime | default (env "FUZZ_TIME" "") }}
+{{- $fuzzCGOEnabled := .FuzzCGOEnabled | default "0" }}
+{{- $fuzzPackages := .FuzzPackages | default "./..." }}
+{{- $fuzzBase := .FuzzImageName | default "" }}
+{{- if not $fuzzBase }}
+  {{- $fuzzBase = .ImageName }}
+{{- end }}
+{{- $fuzzBase = trimSuffix "-fuzz" $fuzzBase }}
+{{- $fuzzImage := printf "%s%s-fuzz" $prefix $fuzzBase }}
+{{- $fuzzSrcImage := .FuzzSrcImage | default "" }}
+{{- if not $fuzzSrcImage }}
+  {{- if hasSuffix $fuzzBase "-golang-artifact" }}
+    {{- $fuzzSrcImage = printf "%s%s" $prefix $fuzzBase }}
+  {{- else if hasSuffix $fuzzBase "-artifact" }}
+    {{- $fuzzSrcImage = printf "%s%s" $prefix $fuzzBase }}
+  {{- else }}
+    {{- $inc := "" }}
+    {{- if .Files }}
+      {{- $inc = .Files.Get (printf "images/%s/werf.inc.yaml" .ImageName) }}
+    {{- end }}
+    {{- if contains "-golang-artifact" $inc }}
+      {{- $fuzzSrcImage = printf "%s%s-golang-artifact" $prefix .ImageName }}
+    {{- else }}
+      {{- $fuzzSrcImage = printf "%s%s-artifact" $prefix .ImageName }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- $fuzzSrcAdd := .FuzzSrcAdd | default "/src" }}
+image: {{ $fuzzImage }}
+fromImage: {{ $fuzzSrcImage }}
+final: false
+imageSpec:
+  config:
+    workingDir: {{ $fuzzSrcAdd | quote }}
+    labels:
+      io.deckhouse.fuzz.engine: {{ $engine | quote }}
+    env:
+      GOMODCACHE: "/fuzz/gomod"
+      CGO_ENABLED: {{ $fuzzCGOEnabled | quote }}
+      FUZZ_PACKAGES: {{ $fuzzPackages | quote }}
+git:
+  - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/Taskfile.fuzz.yml
+    to: {{ $fuzzSrcAdd }}/Taskfile.yml
+    stageDependencies:
+      install:
+        - Taskfile.fuzz.yml
+import:
+  - image: {{ $fuzzSrcImage }}
+    add: {{ $fuzzSrcAdd }}
+    to: {{ $fuzzSrcAdd }}
+    before: install
+mount:
+{{ include "mount points for golang builds" . }}
+secrets:
+  - id: GOPROXY
+    value: {{ .GOPROXY }}
+  - id: FUZZ_S3_ENDPOINT
+    env: FUZZ_S3_ENDPOINT
+  - id: FUZZ_S3_ACCESS_KEY
+    env: FUZZ_S3_ACCESS_KEY
+  - id: FUZZ_S3_SECRET_KEY
+    env: FUZZ_S3_SECRET_KEY
+  - id: FUZZ_S3_REPOSITORY
+    env: FUZZ_S3_REPOSITORY
+  - id: FUZZ_S3_BRANCH_SLUG
+    env: FUZZ_S3_BRANCH_SLUG
+  - id: FUZZ_ENABLE_RUN
+    value: {{ $fuzzRun | quote }}
+  {{- if $fuzzPkg }}
+  - id: FUZZ_PKG
+    value: {{ $fuzzPkg | quote }}
+  {{- end }}
+  {{- if $fuzzTarget }}
+  - id: FUZZ_TARGET
+    value: {{ $fuzzTarget | quote }}
+  {{- end }}
+  {{- if $fuzzTime }}
+  - id: FUZZ_TIME
+    value: {{ $fuzzTime | quote }}
+  {{- end }}
+shell:
+  install:
+  - |
+    set -eu
+    export GOPROXY=$(cat /run/secrets/GOPROXY) CGO_ENABLED={{ $fuzzCGOEnabled }} GOOS=linux GOARCH=amd64
+    cd {{ $fuzzSrcAdd | quote }}
+    export FUZZ_PACKAGES={{ $fuzzPackages | quote }}
+
+    has_gnu_bash() {
+      command -v bash >/dev/null 2>&1 \
+        && bash -c 'test -n "${BASH_VERSION:-}"' >/dev/null 2>&1
+    }
+
+    if ! command -v curl >/dev/null 2>&1 \
+      || ! command -v git >/dev/null 2>&1 \
+      || ! command -v python3 >/dev/null 2>&1 \
+      || ! command -v jq >/dev/null 2>&1 \
+      || ! command -v unzip >/dev/null 2>&1 \
+      || ! has_gnu_bash; then
+      if command -v pm >/dev/null 2>&1; then
+        pm install git curl python ca-certificates jq unzip gnu-glibc bash
+      elif command -v apk >/dev/null 2>&1; then
+        apk add --no-cache git curl python3 ca-certificates jq unzip bash
+      elif command -v apt-get >/dev/null 2>&1; then
+        apt-get update -y
+        apt-get install -y git curl python3 ca-certificates jq unzip bash
+      else
+        echo "git, curl, python3, jq, unzip and GNU Bash are required on the fuzz base image" >&2
+        exit 1
+      fi
+    fi
+
+    if ! has_gnu_bash; then
+      echo "GNU Bash installation did not provide a compatible bash executable" >&2
+      exit 1
+    fi
+
+    if ! command -v aws >/dev/null 2>&1; then
+      AWS_CLI_DIR=/tmp/aws-cli-install
+      rm -rf "${AWS_CLI_DIR}"
+      mkdir -p "${AWS_CLI_DIR}"
+      curl -fsSL \
+        -o "${AWS_CLI_DIR}/awscliv2.zip" \
+        "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"
+      unzip -q "${AWS_CLI_DIR}/awscliv2.zip" -d "${AWS_CLI_DIR}"
+      chmod +x "${AWS_CLI_DIR}/aws/install"
+      "${AWS_CLI_DIR}/aws/install" \
+        --bin-dir /usr/local/bin \
+        --install-dir /usr/local/aws-cli
+      rm -rf "${AWS_CLI_DIR}"
+    fi
+
+    jq --version
+    aws --version
+
+    export GOMODCACHE=/fuzz/gomod
+    mkdir -p "${GOMODCACHE}"
+
+    go mod download
+
+    GOBIN=/usr/local/bin go install github.com/go-task/task/v3/cmd/task@v3.50.0
+
+    echo "Download fuzz corpus overlay from S3"
+
+    MC=/tmp/mc
+    curl -fsSL -o "${MC}" https://dl.min.io/client/mc/release/linux-amd64/mc
+    chmod +x "${MC}"
+
+    "${MC}" alias set fuzz-s3 \
+      "$(cat /run/secrets/FUZZ_S3_ENDPOINT)" \
+      "$(cat /run/secrets/FUZZ_S3_ACCESS_KEY)" \
+      "$(cat /run/secrets/FUZZ_S3_SECRET_KEY)"
+
+    FUZZ_S3_REPOSITORY="$(cat /run/secrets/FUZZ_S3_REPOSITORY)"
+    FUZZ_S3_BRANCH_SLUG="$(cat /run/secrets/FUZZ_S3_BRANCH_SLUG)"
+    if [ -z "${FUZZ_S3_REPOSITORY}" ] || [ -z "${FUZZ_S3_BRANCH_SLUG}" ]; then
+      echo "FUZZ_S3_REPOSITORY and FUZZ_S3_BRANCH_SLUG are required for corpus sync" >&2
+      exit 1
+    fi
+
+    S3_FUZZING_PATH="fuzz-s3/anomaloys-materials/${FUZZ_S3_REPOSITORY}/${FUZZ_S3_BRANCH_SLUG}/"
+    echo "Corpus S3 path: ${S3_FUZZING_PATH}"
+    TMP_CORPUS="/tmp/fuzzing-s3"
+    RESTORED_FILES="/tmp/fuzz-restored-files.txt"
+
+    rm -rf "${TMP_CORPUS}"
+    mkdir -p "${TMP_CORPUS}"
+    : > "${RESTORED_FILES}"
+
+    if "${MC}" ls "${S3_FUZZING_PATH}" 2>/dev/null | grep -q .; then
+      echo "Fuzz corpus found in S3, download overlay"
+
+      if "${MC}" --quiet mirror "${S3_FUZZING_PATH}" "${TMP_CORPUS}/" >/dev/null; then
+        MODULE_PATH="$(GOWORK=off go list -m)"
+        echo "module path: ${MODULE_PATH}"
+
+        find "${TMP_CORPUS}" \
+          -type d \
+          -path "*/corpus/gocache-fuzz/${MODULE_PATH}/*" \
+          > /tmp/fuzz-target-dirs.txt || true
+
+        restored=0
+
+        while IFS= read -r target_dir; do
+          target="$(basename "${target_dir}")"
+
+          case "${target}" in
+            Fuzz*) ;;
+            *) continue ;;
+          esac
+
+          if ! find "${target_dir}" -maxdepth 1 -type f | grep -q .; then
+            continue
+          fi
+
+          prefix="/corpus/gocache-fuzz/${MODULE_PATH}/"
+          case "${target_dir}" in
+            *"${prefix}"*) rel="${target_dir##*${prefix}}" ;;
+            *) echo "skip: no module prefix in ${target_dir}"; continue ;;
+          esac
+          pkg_rel="${rel%"${target}"}"; pkg_rel="${pkg_rel}"
+          if [ -n "${pkg_rel}" ]; then
+            seed_dir="${pkg_rel}/testdata/fuzz/${target}"
+          else
+            seed_dir="testdata/fuzz/${target}"
+          fi
+
+          echo "restore corpus"
+          echo "from: ${target_dir}"
+          echo "to: ${seed_dir}"
+
+          mkdir -p "${seed_dir}"
+
+          copied=0
+
+          for corpus_file in "${target_dir}"/*; do
+            if [ ! -f "${corpus_file}" ]; then
+              continue
+            fi
+
+            dst="${seed_dir}/$(basename "${corpus_file}")"
+
+            if [ -e "${dst}" ]; then
+              continue
+            fi
+
+            cp "${corpus_file}" "${dst}"
+            printf '%s\n' "${dst}" >> "${RESTORED_FILES}"
+
+            copied=$((copied + 1))
+          done
+
+          echo "copied corpus files for ${target}: ${copied}"
+          restored=$((restored + copied))
+        done < /tmp/fuzz-target-dirs.txt
+
+        echo "restored corpus files: ${restored}"
+        echo "restored file list: ${RESTORED_FILES}"
+      else
+        echo "Failed to download fuzz corpus overlay, continue without it"
+      fi
+    else
+      echo "No fuzz corpus found in S3 yet, continue without it"
+    fi
+
+    echo "Run fuzz replay"
+    for bad in test/e2e tests/e2e tests/ginkgo; do
+      if [ -d "${bad}" ]; then
+        echo "remove ${bad} before fuzz replay"
+        rm -rf "${bad}"
+      fi
+    done
+    git config --global user.name "fuzz"
+    git config --global user.email "fuzz@local"
+    FUZZ_LIST_LOG=/tmp/fuzz-list.log
+    FUZZ_TARGETS_FILE=/tmp/fuzz-targets.txt
+    list_rc=0
+    task fuzz:list > "${FUZZ_LIST_LOG}" 2>&1 || list_rc=$?
+    cat "${FUZZ_LIST_LOG}"
+
+    awk '
+      /^Fuzz[[:alnum:]_]*$/ { targets[++count] = $0; next }
+      /^(ok|FAIL|\?)[[:space:]]+/ {
+        package = $2
+        for (i = 1; i <= count; i++) print package "|" targets[i]
+        delete targets
+        count = 0
+      }
+      END { if (count != 0) exit 2 }
+    ' "${FUZZ_LIST_LOG}" > "${FUZZ_TARGETS_FILE}"
+
+    if [ ! -s "${FUZZ_TARGETS_FILE}" ]; then
+      echo "fuzz:list returned no Go fuzz targets (rc=${list_rc})" >&2
+      exit 1
+    fi
+    if [ "${list_rc}" -ne 0 ]; then
+      echo "fuzz:list exited ${list_rc}, but valid targets were parsed; continue replay"
+    fi
+
+    while IFS='|' read -r fuzz_pkg fuzz_target; do
+      echo "Replay fuzz corpus: package=${fuzz_pkg} target=${fuzz_target}"
+      FUZZ_PKG="${fuzz_pkg}" FUZZ_TARGET="${fuzz_target}" task fuzz:replay
+    done < "${FUZZ_TARGETS_FILE}"
+    rm -f "${FUZZ_LIST_LOG}" "${FUZZ_TARGETS_FILE}"
+
+    FUZZ_ENABLE_RUN="$(cat /run/secrets/FUZZ_ENABLE_RUN 2>/dev/null || true)"
+    FUZZ_PKG="$(cat /run/secrets/FUZZ_PKG 2>/dev/null || true)"
+    FUZZ_TARGET="$(cat /run/secrets/FUZZ_TARGET 2>/dev/null || true)"
+    FUZZ_TIME="$(cat /run/secrets/FUZZ_TIME 2>/dev/null || true)"
+    export FUZZ_PKG FUZZ_TARGET
+    if [ -n "${FUZZ_TIME}" ]; then
+      export FUZZ_TIME
+    fi
+
+    case "${FUZZ_ENABLE_RUN}" in
+      true|TRUE|1|yes|YES)
+        if [ -z "${FUZZ_PKG}" ] || [ -z "${FUZZ_TARGET}" ]; then
+          echo "FUZZ_ENABLE_RUN is set, but FUZZ_PKG and FUZZ_TARGET are required" >&2
+          exit 1
+        fi
+        echo "FUZZ_ENABLE_RUN=${FUZZ_ENABLE_RUN}: fuzz:run pkg=${FUZZ_PKG} target=${FUZZ_TARGET} time=${FUZZ_TIME:-until-stop}"
+        task fuzz:run
+        ;;
+      *)
+        echo "FUZZ_ENABLE_RUN=${FUZZ_ENABLE_RUN:-false}: skip active fuzzing"
+        ;;
+    esac
+
+    echo "Cleanup restored fuzz corpus"
+
+    if [ -f "${RESTORED_FILES}" ]; then
+      while IFS= read -r restored_file; do
+        if [ -n "${restored_file}" ] && [ -f "${restored_file}" ]; then
+          echo "remove restored corpus file: ${restored_file}"
+          rm -f "${restored_file}"
+        fi
+      done < "${RESTORED_FILES}"
+    else
+      echo "No restored fuzz corpus file list found, skip cleanup"
+    fi
+
+    find . \
+      -type d \
+      -path "*/testdata/fuzz/Fuzz*" \
+      -empty \
+      -exec rmdir {} \; 2>/dev/null || true
+
+    find . \
+      -type d \
+      -path "*/testdata/fuzz" \
+      -empty \
+      -exec rmdir {} \; 2>/dev/null || true
+
+    rm -rf "${TMP_CORPUS}"
+    rm -f /tmp/fuzz-target-dirs.txt
+    rm -f "${RESTORED_FILES}"
+
+    go clean -cache -testcache -fuzzcache 2>/dev/null || true
+
+    echo "restored fuzz corpus cleanup done"
+
+    echo "Make fuzz sources writable for non-root fuzz / testdata"
+    chmod -R a+rwX .
+
+    chmod -R a+rwX /fuzz/gomod
+{{- end }}
+{{- end }}

--- a/modules/150-user-authn/Taskfile.fuzz.yml
+++ b/modules/150-user-authn/Taskfile.fuzz.yml
@@ -1,0 +1,34 @@
+version: "3"
+
+tasks:
+  fuzz:list:
+    cmds:
+      - go test -vet=off ${FUZZ_PACKAGES:-./...} -list '^Fuzz'
+
+  fuzz:run:
+    cmds:
+      - |
+        go test -vet=off "${FUZZ_PKG}" \
+          -run '^$' \
+          -fuzz "^${FUZZ_TARGET}$" \
+          -parallel="${FUZZ_WORKERS}" \
+          -count=1 \
+          -v
+
+  fuzz:coverage:
+    cmds:
+      - |
+        go test -vet=off "${FUZZ_PKG}" \
+          -run "^${FUZZ_TARGET}$" \
+          -count=1 \
+          -covermode=atomic \
+          -coverpkg=./... \
+          -coverprofile="${FUZZ_COVERAGE_FILE}"
+
+  fuzz:replay:
+    cmds:
+      - |
+        go test -vet=off "${FUZZ_PKG}" \
+          -run "^${FUZZ_TARGET}$" \
+          -count=1 \
+          -v

--- a/modules/150-user-authn/images/dex-authenticator/werf.inc.yaml
+++ b/modules/150-user-authn/images/dex-authenticator/werf.inc.yaml
@@ -99,4 +99,9 @@ shell:
     - chown 64535:64535 url-exec-prober
     - chmod 0700 url-exec-prober
 ---
+{{- $_ := set . "FuzzEngine" "go" }}
+{{- $_ := set . "FuzzSrcImage" (printf "%s/%s-oauth2-proxy-artifact" .ModuleName .ImageName) }}
+{{- $_ := set . "FuzzPackages" ". ./pkg/middleware ./pkg/sessions/persistence" }}
+{{- include "fuzz image" . }}
+---
 {{- include "vex mitigation" (list $ (printf "%s/%s" $.ModuleName $.ImageName)) }}

--- a/modules/150-user-authn/images/dex/werf.inc.yaml
+++ b/modules/150-user-authn/images/dex/werf.inc.yaml
@@ -77,4 +77,9 @@ shell:
     - chown 64535:64535 dex
     - chmod 0700 dex
 ---
+{{- $_ := set . "FuzzEngine" "go" }}
+{{- $_ := set . "FuzzSrcImage" (printf "%s/%s-dex-artifact" .ModuleName .ImageName) }}
+{{- $_ := set . "FuzzPackages" "./server" }}
+{{- include "fuzz image" . }}
+---
 {{- include "vex mitigation" (list $ (printf "%s/%s" $.ModuleName $.ImageName)) }}

--- a/werf-giterminism.yaml
+++ b/werf-giterminism.yaml
@@ -17,6 +17,15 @@ config:
       - ACTIONS_ID_TOKEN_REQUEST_TOKEN
       - VAULT_KEY
       - WERF_SIGN_KEY
+      - FUZZ_S3_ENDPOINT
+      - FUZZ_S3_ACCESS_KEY
+      - FUZZ_S3_SECRET_KEY
+      - FUZZ_S3_REPOSITORY
+      - FUZZ_S3_BRANCH_SLUG
+      - FUZZ_ENABLE_RUN
+      - FUZZ_PKG
+      - FUZZ_TARGET
+      - FUZZ_TIME
       - WERF_OLCEDAR_SYSEXT_SIGN_ENABLED
     allowUncommittedFiles: ["tools/build_includes/*"]
   secrets:
@@ -33,12 +42,21 @@ config:
       - WERF_VAULT_AUTH_JWT
       - WERF_SIGN_KEY
       - WERF_OLCEDAR_VAULT_AUTH_ROLE
+      - FUZZ_S3_ENDPOINT
+      - FUZZ_S3_ACCESS_KEY
+      - FUZZ_S3_SECRET_KEY
+      - FUZZ_S3_REPOSITORY
+      - FUZZ_S3_BRANCH_SLUG
     allowValueIds:
       - SOURCE_REPO
       - GOPROXY
       - CLOUD_PROVIDERS_SOURCE_REPO
       - CARGO_PROXY
       - DECKHOUSE_PRIVATE_REPO
+      - FUZZ_ENABLE_RUN
+      - FUZZ_PKG
+      - FUZZ_TARGET
+      - FUZZ_TIME
   stapel:
     mount:
       allowBuildDir: true


### PR DESCRIPTION
## Description

Adds fuzzing-compliance integration for the existing Go fuzz targets in the `user-authn` module.

The change:

- adds dedicated `user-authn/dex-fuzz` and `user-authn/dex-authenticator-fuzz` images;
- implements the `fuzz:list`, `fuzz:run`, `fuzz:coverage`, and `fuzz:replay` Taskfile contract;
- adds the required fuzz engine label and runtime dependencies;
- adds CI jobs for building fuzz images and publishing the main-branch build report to S3;
- allows the required fuzzing variables in `werf-giterminism.yaml`.

No runtime Deckhouse components or Kubernetes resources are changed.

## Why do we need it, and what problem does it solve?

Dex and dex-authenticator already contain Go fuzz targets supplied through the last-applied upstream patches, but these targets were not exposed to the fuzzing-compliance infrastructure.

Without dedicated fuzz images, the dispatcher cannot discover, execute, measure coverage for, or retain the corpus of these targets. This change adds the image, Taskfile, and build-report contracts required to run them regularly through fuzzing-compliance.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist

- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authn
type: chore
summary: Add fuzzing-compliance integration for Dex and dex-authenticator fuzz targets.
impact_level: low
```