### PR TITLE
[dhctl][deckhouse] Configure Pod Security for system namespaces

### DIFF
--- a/dhctl/pkg/kubernetes/actions/deckhouse/install_test.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/install_test.go
@@ -206,6 +206,24 @@ func TestDeckhouseInstall(t *testing.T) {
 	}
 }
 
+func TestDeckhouseNamespaceTask(t *testing.T) {
+	fakeClient := client.NewFakeKubernetesClient()
+
+	err := getNSTask(fakeClient).CreateOrUpdate(t.Context())
+	require.NoError(t, err)
+
+	namespace, err := fakeClient.
+		CoreV1().
+		Namespaces().
+		Get(t.Context(), "d8-system", metav1.GetOptions{})
+	require.NoError(t, err)
+
+	require.Equal(t, "deckhouse", namespace.Labels["heritage"])
+	require.Equal(t, "", namespace.Labels["extended-monitoring.deckhouse.io/enabled"])
+	require.Equal(t, "privileged", namespace.Labels["pod-security.kubernetes.io/enforce"])
+	require.Equal(t, "latest", namespace.Labels["pod-security.kubernetes.io/enforce-version"])
+}
+
 func TestDeckhouseInstallWithDevBranch(t *testing.T) {
 	ctx := t.Context()
 	err := os.Setenv("DHCTL_TEST", "yes")

--- a/dhctl/pkg/kubernetes/actions/deckhouse/install_test.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/install_test.go
@@ -208,8 +208,9 @@ func TestDeckhouseInstall(t *testing.T) {
 
 func TestDeckhouseNamespaceTask(t *testing.T) {
 	fakeClient := client.NewFakeKubernetesClient()
+	task := getNSTask(fakeClient)
 
-	err := getNSTask(fakeClient).CreateOrUpdate(t.Context())
+	err := task.CreateOrUpdate(t.Context())
 	require.NoError(t, err)
 
 	namespace, err := fakeClient.

--- a/dhctl/pkg/kubernetes/actions/manifests/manifests.go
+++ b/dhctl/pkg/kubernetes/actions/manifests/manifests.go
@@ -500,7 +500,9 @@ func DeckhouseNamespace(name string) *apiv1.Namespace {
 			Name: name,
 			Labels: map[string]string{
 				"heritage": "deckhouse",
-				"extended-monitoring.deckhouse.io/enabled": "",
+				"extended-monitoring.deckhouse.io/enabled":   "",
+				"pod-security.kubernetes.io/enforce":         "privileged",
+				"pod-security.kubernetes.io/enforce-version": "latest",
 			},
 		},
 		Spec: apiv1.NamespaceSpec{

--- a/modules/002-deckhouse/hooks/ensure_system_namespace_labels.go
+++ b/modules/002-deckhouse/hooks/ensure_system_namespace_labels.go
@@ -45,6 +45,8 @@ func enableExtendedMonitoring(_ context.Context, input *go_hook.HookInput) error
 				"heritage": "deckhouse",
 				"extended-monitoring.deckhouse.io/enabled":           "",
 				"prometheus.deckhouse.io/rules-watcher-enabled":      "true",
+				"pod-security.kubernetes.io/enforce":                 "privileged",
+				"pod-security.kubernetes.io/enforce-version":         "latest",
 				"security.deckhouse.io/pod-policy":                   "restricted",
 				"security.deckhouse.io/pod-policy-action":            "warn",
 				"security.deckhouse.io/enable-security-policy-check": "true",

--- a/modules/002-deckhouse/hooks/ensure_system_namespace_labels_test.go
+++ b/modules/002-deckhouse/hooks/ensure_system_namespace_labels_test.go
@@ -94,6 +94,8 @@ metadata:
 
 			ns := f.KubernetesGlobalResource("Namespace", "d8-system")
 			for name, value := range map[string]string{
+				`pod-security\.kubernetes\.io/enforce`:                 "privileged",
+				`pod-security\.kubernetes\.io/enforce-version`:         "latest",
 				`security\.deckhouse\.io/pod-policy`:                   "restricted",
 				`security\.deckhouse\.io/pod-policy-action`:            "warn",
 				`security\.deckhouse\.io/enable-security-policy-check`: "true",

--- a/modules/002-deckhouse/template_tests/module_test.go
+++ b/modules/002-deckhouse/template_tests/module_test.go
@@ -148,6 +148,15 @@ var _ = Describe("Module :: deckhouse :: helm template ::", func() {
   - operator: Exists
 `))
 		})
+
+		It("Should configure Pod Security for d8-monitoring namespace", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			namespace := f.KubernetesGlobalResource("Namespace", "d8-monitoring")
+			Expect(namespace.Exists()).To(BeTrue())
+			Expect(namespace.Field(`metadata.labels.pod-security\.kubernetes\.io/enforce`).String()).To(Equal("privileged"))
+			Expect(namespace.Field(`metadata.labels.pod-security\.kubernetes\.io/enforce-version`).String()).To(Equal("latest"))
+		})
 	})
 
 	Context("Cluster with deckhouse on system node", func() {

--- a/modules/002-deckhouse/templates/namespace.yaml
+++ b/modules/002-deckhouse/templates/namespace.yaml
@@ -10,6 +10,8 @@ metadata:
     "extended-monitoring.deckhouse.io/enabled" ""
     "prometheus.deckhouse.io/rules-watcher-enabled" "true"
     "prometheus.deckhouse.io/scrape-configs-watcher-enabled" "true"
+    "pod-security.kubernetes.io/enforce" "privileged"
+    "pod-security.kubernetes.io/enforce-version" "latest"
     "security.deckhouse.io/pod-policy" "restricted"
     "security.deckhouse.io/pod-policy-action" "warn"
     "security.deckhouse.io/enable-security-policy-check" "true"


### PR DESCRIPTION
## Description

This PR configures Kubernetes Pod Security Admission for the Deckhouse system namespaces that run workloads requiring access to host-level resources.

The following changes are included:

- `dhctl` creates `d8-system` with:
  - `pod-security.kubernetes.io/enforce: privileged`;
  - `pod-security.kubernetes.io/enforce-version: latest`.
- The Deckhouse namespace reconciliation hook maintains these labels on `d8-system`.
- The `d8-monitoring` namespace is created with the same Pod Security labels.
- Unit tests verify the labels created by `dhctl`, the Deckhouse hook, and the Helm template.

The change only updates Namespace labels. It does not restart control-plane components, Deckhouse, Prometheus, or other workloads.

## Why do we need it, and what problem does it solve?

Talos enables Kubernetes Pod Security Admission with the `baseline` enforcement level for namespaces that are not explicitly exempted. By default, only `kube-system` is exempted.

Deckhouse system workloads use functionality prohibited by the `baseline` policy, including `hostNetwork`, `hostPort`, `hostPath`, `hostPID`, and privileged containers.

As a result:

- the Deckhouse Pod cannot be created in `d8-system`;
- host-level monitoring workloads cannot be created in `d8-monitoring`;
- Deckhouse installation into an existing Talos cluster requires users to configure the Namespace labels manually.

This PR makes the required Pod Security configuration part of the desired state of these system namespaces. Users no longer need to apply the labels manually before or during installation.

The `privileged` enforcement level does not make every container privileged automatically. It only prevents Pod Security Admission from rejecting the Pod specification. Actual container privileges are still controlled by `securityContext`, Linux capabilities, volume mounts, and RBAC.

Access to create arbitrary workloads in these trusted system namespaces must remain restricted.

The `d8-upmeter` namespace is managed by the external Upmeter module and will be handled in a separate PR.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist

- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: dhctl
type: fix
summary: Configure the d8-system namespace with the privileged Pod Security enforcement level during Deckhouse bootstrap.
impact_level: default
```

```changes
section: deckhouse
type: fix
summary: Configure the d8-system and d8-monitoring namespaces with the privileged Pod Security enforcement level.
impact: The d8-system and d8-monitoring namespaces will use the privileged Kubernetes Pod Security enforcement level. Access to create workloads in these namespaces must remain restricted.
impact_level: high
```