### PR TITLE
[cni-cilium] Add a VEX statement for GO-2026-5932 to the kube-rbac-proxy image

### DIFF
--- a/modules/021-cni-cilium/images/kube-rbac-proxy/known_vulnerabilities.vex
+++ b/modules/021-cni-cilium/images/kube-rbac-proxy/known_vulnerabilities.vex
@@ -2,7 +2,7 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-8e6d3533386852e2c517539fda233328ae5d160590273cc5a5bcc7698dcbbe9a",
   "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
-  "version": 1,
+  "version": 2,
   "statements": [
     {
       "vulnerability": {
@@ -17,7 +17,22 @@
       "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
       "impact_statement": "CVE-2024-28180 описывает переполнение ресурсов в go-jose, возникающее при попытке распаковать зашифрованные сообщения JWE (JSON Web Encryption - формат JOSE для шифрования полезной нагрузки). Kubernetes не создает и не обрабатывает JWE, используя библиотеку только для подписанных JWT, что подтверждено в обсуждении: https://github.com/kubernetes/kubernetes/pull/123253#issuecomment-1940379993 https://github.com/kubernetes/sig-security/issues/116#issuecomment-2197995745",
       "timestamp": "2025-10-13T12:24:00.293353Z"
+    },
+    {
+      "vulnerability": {
+        "name": "GO-2026-5932"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/crypto"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "GO-2026-5932 - информационная рекомендация Go vulndb: пакет golang.org/x/crypto/openpgp не сопровождается, небезопасен по дизайну и не имеет исправленной версии (Fixed in: N/A), поэтому обновление golang.org/x/crypto проблему не снимает. В kube-rbac-proxy модуль golang.org/x/crypto присутствует только как транзитивная зависимость библиотек Kubernetes; сам пакет openpgp не импортируется. Проверка графа импортов (go list -deps) показывает из golang.org/x/crypto только ssh/terminal, ed25519 и pbkdf2, ни одного пакета openpgp/*. В собранном как в сборочной инструкции бинарнике (GOOS=linux GOARCH=amd64 CGO_ENABLED=0) go tool nm не находит ни одного символа openpgp, а govulncheck -mode binary относит GO-2026-5932 только к разделу Module Results (наличие модуля в go.mod) и не находит уязвимость ни в Package, ни в Symbol Results. Компонент не выполняет операций OpenPGP, уязвимый код в артефакте отсутствует и недостижим.",
+      "timestamp": "2026-09-03T14:18:54Z"
     }
   ],
-  "timestamp": "2025-10-13T12:24:00Z"
+  "timestamp": "2025-10-13T12:24:00Z",
+  "last_updated": "2026-09-03T14:18:54Z"
 }


### PR DESCRIPTION
## Description

Add a `not_affected` VEX statement for the Go vulnerability database advisory GO-2026-5932 (`golang.org/x/crypto/openpgp`) to `modules/021-cni-cilium/images/kube-rbac-proxy/known_vulnerabilities.vex`, bump the document `version` to `2` and add the `last_updated` field.

The justification is `vulnerable_code_not_present` and is backed by the following checks:

- The import graph (`go list -deps`) pulls only `ssh/terminal`, `ed25519` and `pbkdf2` from `golang.org/x/crypto`; no `openpgp/*` package is imported.
- In the binary built exactly as the image build instruction does it (`GOOS=linux GOARCH=amd64 CGO_ENABLED=0`), `go tool nm` finds no `openpgp` symbols.
- `govulncheck -mode binary` reports GO-2026-5932 only under Module Results (the module is present in `go.mod`) and finds nothing in Package or Symbol Results.

The advisory has no fixed version (`Fixed in: N/A`) because the `golang.org/x/crypto/openpgp` package is deprecated and unmaintained, so updating `golang.org/x/crypto` does not remove the finding.

The change only affects the vulnerability metadata of the image. No code, no build instructions and no manifests are touched, so nothing is rebuilt or restarted in a cluster.

## Why do we need it, and what problem does it solve?

The security scanner reports GO-2026-5932 for the `kube-rbac-proxy` image of the `cni-cilium` module, although the vulnerable OpenPGP code is neither present in the resulting binary nor reachable. The VEX statement documents this analysis and removes the false positive from the scan results, so that the vulnerability reports for the module stay actionable and real findings are not lost among noise.

## Why do we need it in the patch release (if we do)?

The change is targeted at the `release-1.73` branch. Vulnerability reports are collected for supported releases, and the false positive keeps appearing in scans of already published `1.73` images. Delivering the VEX statement in the patch release keeps the vulnerability status of the shipped image accurate without waiting for the next minor release.

## Checklist

- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cni-cilium
type: chore
summary: Added a VEX statement for GO-2026-5932 to the kube-rbac-proxy image, marking it as not affected.
impact_level: low
```