### PR TITLE
[testing] Update dhctl master cloud-init golden after restricted-PSS changes

### DIFF
--- a/dhctl/pkg/immutable/testdata/master-cloud-init.yaml
+++ b/dhctl/pkg/immutable/testdata/master-cloud-init.yaml
@@ -104,9 +104,10 @@ write_files:
       manifests:
       - content: "apiVersion: v1\nkind: Pod\nmetadata:\n  annotations:\n    control-plane-manager.deckhouse.io/etcd.advertise-client-urls:
           https://$MY_IP:2379\n  labels:\n    component: etcd\n    tier: control-plane\n
-          \ name: etcd\n  namespace: kube-system\nspec:\n  containers:\n  - command:\n
-          \   - etcd\n    - --advertise-client-urls=https://$MY_IP:2379\n    - --cert-file=/etc/kubernetes/pki/etcd/server.crt\n
-          \   - --client-cert-auth=true\n    - --data-dir=/var/lib/etcd\n    - --initial-advertise-peer-urls=https://$MY_IP:2380\n
+          \   security.deckhouse.io/security-policy-exception: etcd\n  name: etcd\n  namespace:
+          kube-system\nspec:\n  containers:\n  - command:\n    - etcd\n    - --advertise-client-urls=https://$MY_IP:2379\n
+          \   - --cert-file=/etc/kubernetes/pki/etcd/server.crt\n    - --client-cert-auth=true\n
+          \   - --data-dir=/var/lib/etcd\n    - --initial-advertise-peer-urls=https://$MY_IP:2380\n
           \   - --initial-cluster=example-master-0=https://$MY_IP:2380\n    - --watch-progress-notify-interval=5s\n
           \   - --quota-backend-bytes=2147483648\n    - --metrics=extensive\n    - --key-file=/etc/kubernetes/pki/etcd/server.key\n
           \   - --listen-client-urls=https://127.0.0.1:2379,https://$MY_IP:2379\n    -
@@ -125,11 +126,12 @@ write_files:
           3\n      httpGet:\n        host: 127.0.0.1\n        path: /health\n        port:
           2381\n        scheme: HTTP\n      periodSeconds: 1\n      timeoutSeconds: 15\n
           \   resources:\n      requests:\n        cpu: \"179m\"\n        memory: \"187904819\"\n
-          \   securityContext:\n      capabilities:\n        drop:\n        - ALL\n      readOnlyRootFilesystem:
-          true\n      runAsGroup: 0\n      runAsNonRoot: false\n      runAsUser: 0\n      seccompProfile:\n
-          \       type: RuntimeDefault\n    startupProbe:\n      failureThreshold: 24\n
-          \     httpGet:\n        host: 127.0.0.1\n        path: /readyz?exclude=non_learner\n
-          \       port: 2381\n        scheme: HTTP\n      initialDelaySeconds: 10\n      periodSeconds:
+          \   securityContext:\n      allowPrivilegeEscalation: false\n      capabilities:\n
+          \       drop:\n        - ALL\n      readOnlyRootFilesystem: true\n      runAsGroup:
+          0\n      runAsNonRoot: false\n      runAsUser: 0\n      seccompProfile:\n        type:
+          RuntimeDefault\n    startupProbe:\n      failureThreshold: 24\n      httpGet:\n
+          \       host: 127.0.0.1\n        path: /readyz?exclude=non_learner\n        port:
+          2381\n        scheme: HTTP\n      initialDelaySeconds: 10\n      periodSeconds:
           10\n      timeoutSeconds: 15\n    volumeMounts:\n    - mountPath: /var/lib/etcd\n
           \     name: etcd-data\n    - mountPath: /etc/kubernetes/pki/etcd\n      name:
           etcd-certs\n      readOnly: true\n  dnsPolicy: ClusterFirstWithHostNet\n  hostNetwork:
@@ -149,6 +151,7 @@ write_files:
             labels:
               component: kube-apiserver
               tier: control-plane
+              security.deckhouse.io/security-policy-exception: kube-apiserver
             name: kube-apiserver
             namespace: kube-system
           spec:
@@ -222,6 +225,7 @@ write_files:
                   cpu: "230m"
                   memory: "241591910"
               securityContext:
+                allowPrivilegeEscalation: false
                 capabilities:
                   drop:
                   - ALL
@@ -302,6 +306,7 @@ write_files:
             labels:
               component: kube-controller-manager
               tier: control-plane
+              security.deckhouse.io/security-policy-exception: kube-controller-manager
             name: kube-controller-manager
             namespace: kube-system
           spec:
@@ -358,6 +363,7 @@ write_files:
                   cpu: "51m"
                   memory: "53687091"
               securityContext:
+                allowPrivilegeEscalation: false
                 capabilities:
                   drop:
                   - ALL
@@ -438,6 +444,7 @@ write_files:
             labels:
               component: kube-scheduler
               tier: control-plane
+              security.deckhouse.io/security-policy-exception: kube-scheduler
             name: kube-scheduler
             namespace: kube-system
           spec:
@@ -481,6 +488,7 @@ write_files:
                   cpu: "51m"
                   memory: "53687091"
               securityContext:
+                allowPrivilegeEscalation: false
                 capabilities:
                   drop:
                   - ALL


### PR DESCRIPTION
## Description

Regenerate the dhctl golden payload `dhctl/pkg/immutable/testdata/master-cloud-init.yaml`.

#22460 added restricted-PSS bits to the static-pod templates in `candi/control-plane/` — the `security.deckhouse.io/security-policy-exception: <component>` label on etcd, kube-apiserver, kube-controller-manager and kube-scheduler, plus `allowPrivilegeEscalation: false` in their `securityContext` — but the golden file that `TestBuildCloudConfigGolden` compares against was not updated along with them.

The golden was regenerated with the test's own flag, nothing was hand-edited:

    cd dhctl && go test ./pkg/immutable/ -run TestBuildCloudConfigGolden -update-golden

The resulting diff is exactly those changes and nothing else: 4 exception labels and 4 `allowPrivilegeEscalation: false` lines (the remaining diff noise is YAML re-folding of the embedded document).

## Why do we need it, and what problem does it solve?

`main` is currently red. `TestBuildCloudConfigGolden` pins the exact cloud-init bytes a master VM boots with, so it fails for every PR rebased onto current `main` — the failure has nothing to do with the PRs that hit it. Examples: #22792, #22728.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: testing
type: fix
summary: Update the dhctl master cloud-init golden after the control-plane restricted-PSS changes.
impact_level: low