### PR TITLE
fix(common): add VEX for GO-2026-5932 on kube-rbac-proxy

### DIFF
--- a/modules/000-common/images/kube-rbac-proxy/known_vulnerabilities.vex
+++ b/modules/000-common/images/kube-rbac-proxy/known_vulnerabilities.vex
@@ -15,7 +15,7 @@
       ],
       "status": "not_affected",
       "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
-      "impact_statement": "В рамках платформы не передаются скомпрессированные данные, эксплуатация невозможна.",
+      "impact_statement": "The platform does not transmit compressed data, so exploitation is not possible.",
       "timestamp": "2025-10-09T11:31:17.452121Z"
     },
     {

--- a/modules/000-common/images/kube-rbac-proxy/known_vulnerabilities.vex
+++ b/modules/000-common/images/kube-rbac-proxy/known_vulnerabilities.vex
@@ -2,7 +2,7 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-4967f958f1248545eec7a13485884e349b6110e4acb5fe1825953bd6a8abef98",
   "author": "Deckhouse <contact@deckhouse.io>",
-  "version": 1,
+  "version": 2,
   "statements": [
     {
       "vulnerability": {
@@ -17,7 +17,27 @@
       "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
       "impact_statement": "В рамках платформы не передаются скомпрессированные данные, эксплуатация невозможна.",
       "timestamp": "2025-10-09T11:31:17.452121Z"
+    },
+    {
+      "vulnerability": {
+        "@id": "https://pkg.go.dev/vuln/GO-2026-5932",
+        "description": "The golang.org/x/crypto/openpgp package is unmaintained, unsafe by design, and has known security issues that will not be fixed.",
+        "name": "GO-2026-5932"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/crypto"
+        },
+        {
+          "@id": "pkg:golang/golang.org/x/crypto@v0.53.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "GO-2026-5932 affects unmaintained golang.org/x/crypto/openpgp with no fixed version. In the kube-rbac-proxy image, openpgp is present only as a transitive dependency of golang.org/x/crypto; the kube-rbac-proxy binary does not use OpenPGP functionality. openpgp code is not in the execute path, so the vulnerability is not reachable for this image.",
+      "timestamp": "2026-09-04T06:40:00Z"
     }
   ],
-  "timestamp": "2025-10-09T11:54:36Z"
+  "timestamp": "2025-10-09T11:54:36Z",
+  "last_updated": "2026-09-04T06:40:00Z"
 }


### PR DESCRIPTION
## Description
Add VEX for GO-2026-5932 in kube-rbac-proxy
## Why do we need it, and what problem does it solve?
## Why do we need it in the patch release (if we do)?
## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
## Changelog entries
```changes
section: common
type: fix
summary: Add VEX for GO-2026-5932 in kube-rbac-proxy
impact_level: low
```