### PR TITLE
[webhook-handler] fix: patch crd conversion without dropping schema

### DIFF
--- a/modules/000-common/images/shell-operator/werf.inc.yaml
+++ b/modules/000-common/images/shell-operator/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $shellOperatorVersion := "fix/patch-conversion-webhook"}}
+{{- $shellOperatorVersion := "v1.20.3"}}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 final: false

--- a/modules/000-common/images/shell-operator/werf.inc.yaml
+++ b/modules/000-common/images/shell-operator/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $shellOperatorVersion := "v1.20.3"}}
+{{- $shellOperatorVersion := "fix/patch-conversion-webhook"}}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 final: false

--- a/modules/002-deckhouse/images/webhook-handler/operator/cmd/main.go
+++ b/modules/002-deckhouse/images/webhook-handler/operator/cmd/main.go
@@ -39,6 +39,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -363,8 +364,8 @@ func syncConversionWebhookConfigurations(
 	}
 
 	for crdName, cfg := range shOp.ConversionWebhookManager.ClientConfigs {
-		if err := cfg.Update(ctx); err != nil {
-			return fmt.Errorf("update conversion client config for crd %q: %w", crdName, err)
+		if err := cfg.PatchConversion(ctx); err != nil {
+			return fmt.Errorf("patch conversion client config for crd %q: %w", crdName, err)
 		}
 	}
 
@@ -398,12 +399,10 @@ func resetCRDConversionToNone(ctx context.Context, shOp *shell_operator.ShellOpe
 		return nil
 	}
 
-	crd.Spec.Conversion = &apiextensionsv1.CustomResourceConversion{
-		Strategy: apiextensionsv1.NoneConverter,
-	}
-
-	if _, err := shOp.KubeClient.ApiExt().CustomResourceDefinitions().Update(ctx, crd, sh_pkg.DefaultUpdateOptions()); err != nil {
-		return fmt.Errorf("update CRD %q conversion strategy: %w", crdName, err)
+	if _, err := shOp.KubeClient.ApiExt().CustomResourceDefinitions().Patch(
+		ctx, crdName, types.JSONPatchType, controller.ConversionNonePatch, sh_pkg.DefaultPatchOptions(),
+	); err != nil {
+		return fmt.Errorf("patch CRD %q conversion strategy: %w", crdName, err)
 	}
 
 	return nil

--- a/modules/002-deckhouse/images/webhook-handler/operator/go.mod
+++ b/modules/002-deckhouse/images/webhook-handler/operator/go.mod
@@ -4,7 +4,7 @@ go 1.26.4
 
 require (
 	github.com/deckhouse/deckhouse/pkg/log v0.2.0
-	github.com/flant/shell-operator v1.20.3
+	github.com/flant/shell-operator v1.20.4-0.20260904115725-f8186f7809e4
 	github.com/stretchr/testify v1.11.1
 	k8s.io/api v0.34.8
 	k8s.io/apiextensions-apiserver v0.34.8

--- a/modules/002-deckhouse/images/webhook-handler/operator/go.mod
+++ b/modules/002-deckhouse/images/webhook-handler/operator/go.mod
@@ -4,7 +4,7 @@ go 1.26.4
 
 require (
 	github.com/deckhouse/deckhouse/pkg/log v0.2.0
-	github.com/flant/shell-operator v1.20.4-0.20260904115725-f8186f7809e4
+	github.com/flant/shell-operator v1.20.4
 	github.com/stretchr/testify v1.11.1
 	k8s.io/api v0.34.8
 	k8s.io/apiextensions-apiserver v0.34.8
@@ -31,7 +31,7 @@ require (
 	github.com/ettle/strcase v0.2.0 // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/flant/kube-client v1.9.1 // indirect
+	github.com/flant/kube-client v1.9.2 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.2 // indirect
 	github.com/go-chi/chi/v5 v5.3.0 // indirect

--- a/modules/002-deckhouse/images/webhook-handler/operator/go.sum
+++ b/modules/002-deckhouse/images/webhook-handler/operator/go.sum
@@ -55,8 +55,8 @@ github.com/flant/go-openapi-validate v0.19.12-flant.0 h1:xk6kvc9fHKMgUdB6J7kbpbL
 github.com/flant/go-openapi-validate v0.19.12-flant.0/go.mod h1:Rzou8hA/CBw8donlS6WNEUQupNvUZ0waH08tGe6kAQ4=
 github.com/flant/kube-client v1.9.1 h1:B5Sa++5arl3N/KBdL1KNMlUBtzQXKz1o2FIiFb4X+VA=
 github.com/flant/kube-client v1.9.1/go.mod h1:jAQ01+f5Q8UJJ4RYZlk5xqoA+OOalpr/QJ3e3Q/saqw=
-github.com/flant/shell-operator v1.20.3 h1:yna0aKNw07KmNaSLrknVF/loE2ruZu/ubW4aQsvQ3Dc=
-github.com/flant/shell-operator v1.20.3/go.mod h1:J720QPLkm/RDzMje8JePGkPUnHOI+4XNOA5/qiJtNfQ=
+github.com/flant/shell-operator v1.20.4-0.20260904115725-f8186f7809e4 h1:5iTHqwyMChjJEVtuY9wfGG/iW6SM60TfcM8Qd415i80=
+github.com/flant/shell-operator v1.20.4-0.20260904115725-f8186f7809e4/go.mod h1:J720QPLkm/RDzMje8JePGkPUnHOI+4XNOA5/qiJtNfQ=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fxamacker/cbor/v2 v2.9.2 h1:X4Ksno9+x3cz0TZv69ec1hxP/+tymuR8PXQJyDwfh78=

--- a/modules/002-deckhouse/images/webhook-handler/operator/go.sum
+++ b/modules/002-deckhouse/images/webhook-handler/operator/go.sum
@@ -53,10 +53,10 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/flant/go-openapi-validate v0.19.12-flant.0 h1:xk6kvc9fHKMgUdB6J7kbpbLR5vJOUzKAK8p3nrD7mDk=
 github.com/flant/go-openapi-validate v0.19.12-flant.0/go.mod h1:Rzou8hA/CBw8donlS6WNEUQupNvUZ0waH08tGe6kAQ4=
-github.com/flant/kube-client v1.9.1 h1:B5Sa++5arl3N/KBdL1KNMlUBtzQXKz1o2FIiFb4X+VA=
-github.com/flant/kube-client v1.9.1/go.mod h1:jAQ01+f5Q8UJJ4RYZlk5xqoA+OOalpr/QJ3e3Q/saqw=
-github.com/flant/shell-operator v1.20.4-0.20260904115725-f8186f7809e4 h1:5iTHqwyMChjJEVtuY9wfGG/iW6SM60TfcM8Qd415i80=
-github.com/flant/shell-operator v1.20.4-0.20260904115725-f8186f7809e4/go.mod h1:J720QPLkm/RDzMje8JePGkPUnHOI+4XNOA5/qiJtNfQ=
+github.com/flant/kube-client v1.9.2 h1:LA/RC4fvdyRcoJeXwmRZSDo/L0yoQ024BuaVqbDb5nA=
+github.com/flant/kube-client v1.9.2/go.mod h1:Q3rdJPkSlTZUaWGHX16g3/Fk3vDbl0Pr4EXf+j+UmgY=
+github.com/flant/shell-operator v1.20.4 h1:Kh/j9+GHN4kXV8oOrPLMNW5y7YiZA803yi7QrHrEoZY=
+github.com/flant/shell-operator v1.20.4/go.mod h1:yc4zUlXPdcndJ604qDUKgtcs3nchsqrlybrdZ5PrKo8=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fxamacker/cbor/v2 v2.9.2 h1:X4Ksno9+x3cz0TZv69ec1hxP/+tymuR8PXQJyDwfh78=

--- a/modules/002-deckhouse/images/webhook-handler/operator/internal/controller/conversionwebhook_controller.go
+++ b/modules/002-deckhouse/images/webhook-handler/operator/internal/controller/conversionwebhook_controller.go
@@ -47,6 +47,16 @@ const (
 	filePermissions      = 0755
 )
 
+// ConversionNonePatch clears the conversion webhook config that a shell-operator
+// registration installed, touching spec.conversion and nothing else.
+//
+// Writing the whole CRD back instead — Get into apiextensionsv1.CustomResourceDefinition,
+// mutate, Update — silently drops every openAPIV3Schema key those vendored types do not
+// declare (a Deckhouse apiserver serves x-kubernetes-sensitive-data) and stores the
+// truncated schema. "add" replaces the subtree rather than merging into it, so webhook is
+// removed along with the strategy, which the apiserver requires when strategy is None.
+var ConversionNonePatch = []byte(`[{"op":"add","path":"/spec/conversion","value":{"strategy":"None"}}]`)
+
 // ConversionWebhookReconciler reconciles a ConversionWebhook object
 type ConversionWebhookReconciler struct {
 	reloadFn       func(ctx context.Context) error
@@ -263,12 +273,9 @@ func (r *ConversionWebhookReconciler) cleanupCRDConversion(ctx context.Context, 
 	}
 
 	r.logger.Info("resetting CRD conversion strategy to None", slog.String("crd_name", crdName))
-	crd.Spec.Conversion = &apiextensionsv1.CustomResourceConversion{
-		Strategy: apiextensionsv1.NoneConverter,
-	}
 
-	if err := r.client.Update(ctx, crd); err != nil {
-		return fmt.Errorf("update CRD %s: %w", crdName, err)
+	if err := r.client.Patch(ctx, crd, client.RawPatch(types.JSONPatchType, ConversionNonePatch)); err != nil {
+		return fmt.Errorf("patch CRD %s conversion: %w", crdName, err)
 	}
 
 	return nil

--- a/modules/002-deckhouse/templates/webhook-handler/rbac-for-us.yaml
+++ b/modules/002-deckhouse/templates/webhook-handler/rbac-for-us.yaml
@@ -18,7 +18,7 @@ rules:
   verbs: ["create", "list", "update"]
 - apiGroups: ["apiextensions.k8s.io"]
   resources: ["customresourcedefinitions"]
-  verbs: ["get", "list", "update"]
+  verbs: ["get", "list", "update", "patch"]
 - apiGroups: ["deckhouse.io"]
   resources: ["*"] # We want to read all resources from the deckhouse.io group
   verbs: ["get","list","watch"]


### PR DESCRIPTION
## Description

`webhook-handler` writes a CRD in three places, and all three sent the **whole object** back to the apiserver when the only field they meant to change was `spec.conversion`. Each one now issues a JSON Patch scoped to that single field:

| Where | When it runs |
| --- | --- |
| `CrdClientConfig.PatchConversion` (shell-operator) | on every operator start and every hook reload, to register a conversion webhook |
| `resetCRDConversionToNone` (`cmd/main.go`) | when a conversion hook disappears from disk |
| `cleanupCRDConversion` (`internal/controller`) | when a `ConversionWebhook` resource is deleted |

The registration path lives in shell-operator and is fixed by [flant/shell-operator#930](https://github.com/flant/shell-operator/pull/930), which replaces the `Get` + full `Update` in `CrdClientConfig` with the same patch and renames the method `Update` → `PatchConversion` so the call site says what it does. This PR bumps the dependency to `v1.20.4` and follows the rename.

RBAC gains the `patch` verb on `customresourcedefinitions` — without it every call above fails with a 403.

The stored `spec.conversion` is identical to what the previous code produced. JSON Patch `add` replaces the whole subtree rather than merging into it, so a `clientConfig.url` left by an earlier registration is still removed, exactly as the old `URL: nil` assignment did.

No restarts of critical components: the only workload affected is `webhook-handler` in `d8-system`.

## Why do we need it, and what problem does it solve?

Adding `x-kubernetes-sensitive-data` to a CRD that has a `ConversionWebhook` had no effect: the marker was present in the module's manifest and applied to the cluster, then vanished a few seconds later. The same marker on a CRD **without** a conversion webhook worked fine.

The marker is served by the apiserver as part of `openAPIV3Schema` (the `CRDSensitiveData` feature adds `XSensitiveData` to `JSONSchemaProps`), but the upstream `k8s.io/apiextensions-apiserver` types every client vendors have no field for it. So a `Get` into `apiextensionsv1.CustomResourceDefinition` silently discards it — decoding into a Go struct ignores unknown keys, with no error and no warning — and the subsequent full `Update`
writes that truncated schema back. For the apiserver a `PUT` is the complete desired state, so a key missing from the request means "delete it".

The consequence is not cosmetic: fields marked sensitive stop being encrypted at rest in etcd, stop being filtered by RBAC on `get`/`list`/`watch`, and stop being masked in audit logs. Credentials that the module declared sensitive — registry passwords, Grafana datasource passwords — are silently stored and served in plain text.

This is deterministic, not a race between `deckhouse-controller` and `webhook-handler`. Ordering does not decide the outcome: whoever writes the truncated object wins whenever it writes, and it writes on every operator start and on every hook reload. `managedFields` shows it directly — the `webhook-operator` manager owns `f:versions`, and ownership on an `Update` is recorded only for fields whose value the request actually changed. Registering a conversion webhook has no business changing `spec.versions` at all.

Patching one field also removes the whole class of problem for any future schema extension this operator does not know about.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: Keep `x-kubernetes-sensitive-data` on CRDs that have a conversion webhook.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
