### PR TITLE
[dhctl] fix(dhctl-for-commander): support bootstrap with http registry

### DIFF
--- a/dhctl/pkg/util/image/image.go
+++ b/dhctl/pkg/util/image/image.go
@@ -370,7 +370,7 @@ func getOptsFromRegistryConfig(ctx context.Context, ref name.Reference, cfg *Reg
 	}
 	opts = append(opts, remote.WithAuth(auth))
 	if cfg.ca != "" {
-		transport, err := registryutil.NewRegistryTransport(ctx, cfg.scheme, cfg.ca)
+		transport, err := registryutil.NewCARegistryTransport(ctx, cfg.ca)
 		if err != nil {
 			return nil, err
 		}
@@ -388,7 +388,7 @@ func DownloadAndUnpackImage(ctx context.Context, imageRef, destDir, cacheDir str
 		otattribute.String("image.destDir", destDir),
 	)
 
-	ref, err := name.ParseReference(imageRef)
+	ref, err := name.ParseReference(imageRef, registryutil.NameOptions(regConfig.scheme)...)
 	if err != nil {
 		return fmt.Errorf("parsing image reference %q: %w", imageRef, err)
 	}

--- a/dhctl/pkg/util/image/image_test.go
+++ b/dhctl/pkg/util/image/image_test.go
@@ -15,14 +15,20 @@
 package image
 
 import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/stretchr/testify/require"
 )
 
@@ -805,3 +811,95 @@ func TestPullImage(t *testing.T) {
 		}
 	})
 }
+
+// ggcr forgives HTTP for localhost and RFC1918, so the host must look public.
+const testSchemeHost = "nexus.example.com"
+
+// A plain-HTTP registry behind an ingress that answers 443 with a foreign cert.
+func TestDownloadAndUnpackImage_Scheme(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		scheme      string
+		ca          string
+		wantPlain   bool
+		wantErrLike string
+	}{
+		{name: "http without CA", scheme: "HTTP", wantPlain: true},
+		{name: "http with CA", scheme: "HTTP", ca: testSchemeCA, wantPlain: true},
+		{name: "https refuses the untrusted front", scheme: "HTTPS", wantErrLike: "certificate"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			plainHits, tlsHits := newTLSFrontedRegistry(t)
+			destDir := t.TempDir()
+
+			// the stub has no blobs; what matters is which leg was used
+			err := DownloadAndUnpackImage(t.Context(), testSchemeHost+"/deckhouse/ee:v1",
+				destDir, filepath.Join(destDir, "cache"),
+				RegistryConfig{scheme: tt.scheme, registry: testSchemeHost, ca: tt.ca}, false)
+
+			if tt.wantErrLike != "" {
+				require.ErrorContains(t, err, tt.wantErrLike)
+			}
+			require.Zero(t, tlsHits.Load(), "the untrusted TLS front must never serve the download")
+			require.Equal(t, tt.wantPlain, plainHits.Load() > 0, "served over plain HTTP")
+		})
+	}
+}
+
+// Serves testSchemeHost from a plain-HTTP server and an untrusted TLS front, and
+// points both transports ggcr may pick (remote.DefaultTransport without a CA,
+// http.DefaultTransport with one) at them. Do not add t.Parallel() to this package.
+func newTLSFrontedRegistry(t *testing.T) (plainHits, tlsHits *atomic.Int64) {
+	t.Helper()
+
+	plainHits, tlsHits = &atomic.Int64{}, &atomic.Int64{}
+	plain := httptest.NewServer(registryStub(plainHits))
+	tlsServer := httptest.NewTLSServer(registryStub(tlsHits))
+	t.Cleanup(plain.Close)
+	t.Cleanup(tlsServer.Close)
+
+	port := func(rawURL string) string {
+		_, p, err := net.SplitHostPort(strings.TrimPrefix(strings.TrimPrefix(rawURL, "https://"), "http://"))
+		require.NoError(t, err)
+		return p
+	}
+	plainPort, tlsPort := port(plain.URL), port(tlsServer.URL)
+
+	routing := &http.Transport{
+		DialContext: func(ctx context.Context, _, addr string) (net.Conn, error) {
+			target := plainPort
+			if _, p, _ := net.SplitHostPort(addr); p == "443" {
+				target = tlsPort
+			}
+			var d net.Dialer
+			return d.DialContext(ctx, "tcp", net.JoinHostPort("127.0.0.1", target))
+		},
+	}
+
+	originalRemote, originalDefault := remote.DefaultTransport, http.DefaultTransport
+	remote.DefaultTransport, http.DefaultTransport = routing, routing
+	t.Cleanup(func() {
+		remote.DefaultTransport, http.DefaultTransport = originalRemote, originalDefault
+	})
+
+	return plainHits, tlsHits
+}
+
+func registryStub(hits *atomic.Int64) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+const testSchemeCA = `-----BEGIN CERTIFICATE-----
+MIIBVDCB+6ADAgECAgEBMAoGCCqGSM49BAMCMBIxEDAOBgNVBAMTB3Rlc3QtY2Ew
+HhcNMjYwMTAxMDAwMDAwWhcNMzYwMTAxMDAwMDAwWjASMRAwDgYDVQQDEwd0ZXN0
+LWNhMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKKaMMINPRKyWO9Tu0BQGPMBk
+1lKs0EK0Mfo703X/ECvQnosTBbtytNeBSRWv5hxcBpBBPh2bW/PUDgxbIgRvlqNC
+MEAwDgYDVR0PAQH/BAQDAgIEMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFPra
+qZ7RKqtMutQAOq7uGZuVAnYOMAoGCCqGSM49BAMCA0gAMEUCIQCVrx1CY1SQTljc
+6JRqfqWzLJ1mBg5W6AVtEOBqqwtdYwIgQ9GeRIkVThfe4Y2oaDPVhGY+N+JihtTq
+/N35+Z0JuPg=
+-----END CERTIFICATE-----
+`

--- a/dhctl/pkg/util/registryutil/registry.go
+++ b/dhctl/pkg/util/registryutil/registry.go
@@ -22,6 +22,9 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/google/go-containerregistry/pkg/name"
+
+	constant "github.com/deckhouse/deckhouse/go_lib/registry/const"
 	dhlog "github.com/deckhouse/lib-dhctl/pkg/logger"
 )
 
@@ -34,13 +37,30 @@ func NewRegistryClient(ctx context.Context, scheme, ca string) (*http.Client, er
 	return &http.Client{Transport: transport}, nil
 }
 
-func NewRegistryTransport(ctx context.Context, scheme, ca string) (*http.Transport, error) {
-	transport := http.DefaultTransport.(*http.Transport).Clone()
+// NameOptions maps the registry scheme to go-containerregistry reference options.
+// Without name.Insecure the library never tries HTTP; it only permits it, so the
+// transport paired with these must still verify certificates.
+func NameOptions(scheme string) []name.Option {
+	if constant.ToScheme(scheme) == constant.SchemeHTTP {
+		return []name.Option{name.Insecure}
+	}
 
+	return nil
+}
+
+func NewRegistryTransport(ctx context.Context, scheme, ca string) (*http.Transport, error) {
 	if strings.EqualFold(scheme, "http") {
+		transport := http.DefaultTransport.(*http.Transport).Clone()
 		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // #nosec G402
 		return transport, nil
 	}
+
+	return NewCARegistryTransport(ctx, ca)
+}
+
+// NewCARegistryTransport verifies certificates, trusting ca on top of the system pool.
+func NewCARegistryTransport(ctx context.Context, ca string) (*http.Transport, error) {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
 
 	if ca == "" {
 		return transport, nil

--- a/dhctl/pkg/util/registryutil/registry_test.go
+++ b/dhctl/pkg/util/registryutil/registry_test.go
@@ -20,6 +20,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/stretchr/testify/require"
 )
 
@@ -108,6 +109,20 @@ func TestNewRegistryTransport_HTTP(t *testing.T) {
 func TestNewRegistryTransport_InvalidCA(t *testing.T) {
 	_, err := NewRegistryTransport(t.Context(), "HTTPS", "-----BEGIN CERTIFICATE-----")
 	require.EqualError(t, err, "invalid cert in CA PEM")
+}
+
+func TestNewCARegistryTransport_VerifiesWithoutCA(t *testing.T) {
+	transport, err := NewCARegistryTransport(t.Context(), "")
+	require.NoError(t, err)
+	require.False(t, transport.TLSClientConfig != nil && transport.TLSClientConfig.InsecureSkipVerify)
+}
+
+func TestNameOptions(t *testing.T) {
+	for scheme, want := range map[string]string{"HTTP": "http", "http": "http", "HTTPS": "https", "": "https"} {
+		ref, err := name.ParseReference("nexus.example.com/deckhouse/ee:v1", NameOptions(scheme)...)
+		require.NoError(t, err)
+		require.Equal(t, want, ref.Context().Registry.Scheme(), scheme)
+	}
 }
 
 func TestNewRegistryClient_WithCA(t *testing.T) {


### PR DESCRIPTION
## Description

`DownloadAndUnpackImage` parsed the image reference without `name.Insecure`, so
go-containerregistry resolved a public host over https only and never tried HTTP.
Bootstrapping from a registry with `scheme: HTTP` failed while downloading the
infrastructure provider bundle:

```
download provider bundle <registry>/sys/deckhouse-oss@sha256:353abda7…:
Get "https://<registry>/v2/": tls: failed to verify certificate:
x509: certificate is valid for ingress.local, not <registry>
```

`registryutil.NameOptions` now derives the reference options from the registry
scheme, via the canonical `constant.ToScheme`, and `DownloadAndUnpackImage`
applies them. The CA branch of `getOptsFromRegistryConfig` moves to a transport
that keeps verifying certificates: `name.Insecure` only *permits* HTTP — https is
still probed first — so an `InsecureSkipVerify` transport would let a TLS front in
front of the registry win that probe and receive the credentials over unverified
TLS. That also fixes `scheme: HTTP` with a CA configured, which previously ignored
the CA and sent the credentials to whatever answered on 443.

Verified on a stand: a plain-HTTP registry behind an ingress that also answers on
443 with a foreign certificate. The bundle now downloads over plain HTTP and the
cluster installs. The regression test reproduces that setup with two local servers
and asserts which one served the fetch.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: dhctl
type: fix
summary: dhctl can bootstrap a cluster from a registry served over plain HTTP
```