### PR TITLE
[docs] Add documentation for console module node placement behavior

### DIFF
--- a/docs/documentation/pages/admin/configuration/OVERVIEW.md
+++ b/docs/documentation/pages/admin/configuration/OVERVIEW.md
@@ -379,7 +379,12 @@ You cannot set `nodeSelector` and `tolerations` for modules:
 Below is the basic (general) logic for automatically selecting nodes to place module components when no explicit `nodeSelector` and `tolerations` values are set in the module settings. Some modules may extend or override this logic (for example, by using Kubernetes mechanisms such as [affinity/anti-affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity), [`topologySpreadConstraints`](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field), or their own node selection rules). See the relevant module documentation for details.
 {% endalert %}
 
+If `nodeSelector` is not explicitly set in the module configuration, Deckhouse determines the placement of components automatically. The order in which nodes are selected depends on the module type.
+
 {% raw %}
+* The `console` module:
+  * If `nodeSelector` is not explicitly set in the module configuration, module components are placed on control plane nodes.
+  * If control plane nodes are not available for such placement, nodes with the `node-role.deckhouse.io/system` label are used.
 * The *monitoring*-related modules ([`operator-prometheus`](/modules/operator-prometheus/), [`prometheus`](/modules/prometheus/) and [`vertical-pod-autoscaler`](/modules/vertical-pod-autoscaler/)):
   * Deckhouse examines nodes to determine a [`nodeSelector`](/modules/prometheus/configuration.html#parameters-nodeselector) in the following order:
     1. It checks if a node with the `node-role.deckhouse.io/MODULE_NAME` label is present in the cluster.

--- a/docs/documentation/pages/admin/configuration/OVERVIEW_RU.md
+++ b/docs/documentation/pages/admin/configuration/OVERVIEW_RU.md
@@ -376,7 +376,12 @@ Deckhouse Kubernetes Platform с набором модулей `Minimal` без 
 Ниже описана базовая (общая) логика автоматического выбора узлов для размещения компонентов модулей, когда в настройках модуля не заданы явные значения `nodeSelector` и `tolerations`. Некоторые модули могут дополнять или изменять эту логику (например, использовать механизмы Kubernetes, такие как [affinity/anti-affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity), [`topologySpreadConstraints`](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field), или собственные правила выбора узлов). Подробности см. в документации соответствующего модуля.
 {% endalert %}
 
+Если `nodeSelector` не задан явно в конфигурации модуля, Deckhouse определяет размещение компонентов автоматически. Порядок выбора узлов зависит от типа модуля.
+
 {% raw %}
+* Модуль `console`:
+  * Если `nodeSelector` не задан явно в конфигурации модуля, компоненты модуля размещаются на control-plane-узлах.
+  * Если control-plane-узлы недоступны для такого размещения, используются узлы с лейблом `node-role.deckhouse.io/system`.
 * Модули *monitoring* ([`operator-prometheus`](/modules/operator-prometheus/), [`prometheus`](/modules/prometheus/) и [`vertical-pod-autoscaler`](/modules/vertical-pod-autoscaler/)):
   * Порядок поиска узлов (для определения [`nodeSelector`](/modules/prometheus/configuration.html#parameters-nodeselector)):
     1. Наличие узла с лейблом `node-role.deckhouse.io/MODULE_NAME`.

--- a/docs/documentation/pages/admin/configuration/OVERVIEW_RU.md
+++ b/docs/documentation/pages/admin/configuration/OVERVIEW_RU.md
@@ -363,7 +363,7 @@ Deckhouse Kubernetes Platform с набором модулей `Minimal` без 
 1. Если параметр `nodeSelector` модуля не указан, то Deckhouse попытается вычислить `nodeSelector` автоматически. В этом случае, если в кластере присутствуют узлы с [лейблами из списка или лейблами определенного формата](#особенности-автоматики-зависящие-от-типа-модуля), Deckhouse укажет их в качестве `nodeSelector` ресурсам модуля.
 1. Если параметр `tolerations` модуля не указан, то подам модуля автоматически устанавливаются все возможные toleration'ы, ([подробнее](#особенности-автоматики-зависящие-от-типа-модуля)).
 1. Отключить автоматическое вычисление параметров `nodeSelector` или `tolerations` можно, указав значение `false`.
-1. При отсутствии в кластере [выделенных узлов](#особенности-автоматики-зависящие-от-типа-модуля) и автоматическом выборе `nodeSelector` (см. п. 1), `nodeSelector` в ресурсах модуля указан не будет. Модуль в таком случае будет использовать любой узел с не конфликтующими `taints`.
+1. При отсутствии в кластере [выделенных узлов](#особенности-автоматики-зависящие-от-типа-модуля) и автоматическом выборе `nodeSelector`, как описано в пункте 1, `nodeSelector` в ресурсах модуля указан не будет. Модуль в таком случае будет использовать любой узел с не конфликтующими `taints`.
 
 Возможность настройки `nodeSelector` и `tolerations` отключена для модулей:
 
@@ -373,7 +373,7 @@ Deckhouse Kubernetes Platform с набором модулей `Minimal` без 
 ### Особенности автоматики, зависящие от типа модуля
 
 {% alert level="info" %}
-Ниже описана базовая (общая) логика автоматического выбора узлов для размещения компонентов модулей, когда в настройках модуля не заданы явные значения `nodeSelector` и `tolerations`. Некоторые модули могут дополнять или изменять эту логику (например, использовать механизмы Kubernetes, такие как [affinity/anti-affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity), [`topologySpreadConstraints`](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field), или собственные правила выбора узлов). Подробности см. в документации соответствующего модуля.
+Ниже описана базовая (общая) логика автоматического выбора узлов для размещения компонентов модулей, когда в настройках модуля не заданы явные значения `nodeSelector` и `tolerations`. Некоторые модули могут дополнять или изменять эту логику (например, использовать механизмы Kubernetes, такие как [affinity/anti-affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity), [`topologySpreadConstraints`](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field), или собственные правила выбора узлов). Подробности приведены в документации соответствующего модуля.
 {% endalert %}
 
 Если `nodeSelector` не задан явно в конфигурации модуля, Deckhouse определяет размещение компонентов автоматически. Порядок выбора узлов зависит от типа модуля.


### PR DESCRIPTION
## Description

Add documentation for `console` module node placement behavior:
- Describe automatic node selection when `nodeSelector` is not explicitly set.
- Components are placed on control-plane nodes if available; otherwise, on nodes with the `node-role.deckhouse.io/system` label.

## Why do we need it, and what problem does it solve?

The `console` module's default node placement logic was not documented. This PR adds a clear explanation of how node selection works when `nodeSelector` is not specified, making it easier for users to understand and predict where components will be scheduled.

## Why do we need it in the patch release (if we do)?

Documentation only, no code changes.

## Checklist

- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: chore
summary: Add documentation for console module node placement behavior.
impact_level: low
```