### PR TITLE
[common, candi] Install pwru and yq from packages in debug-container

### DIFF
--- a/modules/000-common/images/debug-container/werf.inc.yaml
+++ b/modules/000-common/images/debug-container/werf.inc.yaml
@@ -31,6 +31,13 @@ shell:
       done
     done
 ---
+image: {{ $.ModuleName }}/{{ $.ImageName }}-pm-artifact
+final: false
+fromImage: builder/distroless
+shell:
+  install:
+  - pm -V v2.1.16 install pwru yq -d /out
+---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: base/distroless
 import:
@@ -52,9 +59,6 @@ import:
   before: install
 - image: tools/jq
   add: /usr/bin/jq
-  before: install
-- image: tools/yq
-  add: /usr/bin/yq
   before: install
 - image: tools/sed
   add: /usr/bin/sed
@@ -212,9 +216,13 @@ import:
   add: /usr/sbin/ethtool
   to: /usr/bin/ethtool
   before: install
-- image: tools/pwru
-  add: /usr/bin/pwru
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-pm-artifact
+  add: /out/usr/bin/pwru
   to: /usr/bin/pwru
+  before: install
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-pm-artifact
+  add: /out/usr/bin/yq
+  to: /usr/bin/yq
   before: install
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /usr/bin


### PR DESCRIPTION
## Description

Replace the prebuilt `tools/pwru` and `tools/yq` images with binaries installed by the package manager. A new intermediate artifact `common/debug-container-pm-artifact` is built on top of `builder/distroless` and installs both tools with `pm install pwru yq -d /out`; the resulting binaries are then imported into the final `debug-container` image as `/usr/bin/pwru` and `/usr/bin/yq`.

Update the alternative base images set in `candi/alt_base_images.yml` from `v1.0.39` to `v2.1.16`, which brings a `builder/distroless` image with the package manager required for the `pm install` step.

Only the `debug-container` image is rebuilt. No cluster workload is restarted: `debug-container` is used on demand for troubleshooting, so the new image is picked up the next time a debug container is started.

## Why do we need it, and what problem does it solve?

The `tools/*` images listed in `candi/base_images.yml` are no longer being updated, so the `tools/pwru` and `tools/yq` digests are frozen. Vulnerabilities found in these tools cannot be fixed there anymore: bumping a digest in `candi/base_images.yml` has no newer image to point to. The set in `candi/alt_base_images.yml` is the one that still receives updates, which is why both tools are moved to it.

For users this removes the known vulnerabilities reported for `pwru` and `yq` inside the `debug-container` image and keeps them fixable in the future, because the tools now come from an image set that is still maintained.

## Checklist

- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: common
type: fix
summary: Removed vulnerabilities in the pwru and yq tools of the debug-container image by installing them from packages instead of building them from upstream sources.
impact_level: low
---
section: candi
type: chore
summary: Updated the alternative base images set from v1.0.39 to v2.1.16.
impact_level: low
```