### PR TITLE
[candi] Fix node bootstrap hanging forever when a swap unit is regenerated

### DIFF
--- a/candi/bashible/common-steps/all/004_configure_swap.sh.tpl
+++ b/candi/bashible/common-steps/all/004_configure_swap.sh.tpl
@@ -32,13 +32,21 @@ has_cgroup2() {
 #  CASE 1: swapBehavior is empty or == NoSwap
 ###############################################
 
-# zram-generator generates swap units for zram devices (dev-zram0.swap and friends), and
-# swap.target pulls them back in. Neutralize it before touching the units: a unit that is
+# Both generator blocks below must run before the swap units are touched. A unit that is
 # regenerated and reactivated while it is being stopped never reaches a final state, and
-# `systemctl stop` waits for that state forever.
+# `systemctl stop` then waits for that state forever.
+#
+# zram-generator generates swap units for zram devices (dev-zram0.swap and friends), and
+# swap.target pulls them back in.
 if [ -f /lib/systemd/system-generators/zram-generator ] && ( [ ! -L /etc/systemd/system-generators/zram-generator ] || [ "$(readlink -f /etc/systemd/system-generators/zram-generator)" != "/dev/null" ] ); then
   mkdir -p /etc/systemd/system-generators
   ln -sf /dev/null /etc/systemd/system-generators/zram-generator
+fi
+
+# systemd-gpt-auto-generator automatically detects swap partition in GPT and activates it
+if [ -f /lib/systemd/system-generators/systemd-gpt-auto-generator ] && ( [ ! -L /etc/systemd/system-generators/systemd-gpt-auto-generator ] || [ "$(readlink -f /etc/systemd/system-generators/systemd-gpt-auto-generator)" != "/dev/null" ] ); then
+  mkdir -p /etc/systemd/system-generators
+  ln -sf /dev/null /etc/systemd/system-generators/systemd-gpt-auto-generator
 fi
 
 # Mask systemd swap units before stopping them, so that nothing can reactivate a unit
@@ -49,12 +57,6 @@ for swapunit in $(systemctl list-units --no-legend --plain --no-pager --type swa
   systemctl mask "$swapunit" || true
   timeout 30 systemctl stop "$swapunit" || true
 done
-
-# systemd-gpt-auto-generator automatically detects swap partition in GPT and activates it
-if [ -f /lib/systemd/system-generators/systemd-gpt-auto-generator ] && ( [ ! -L /etc/systemd/system-generators/systemd-gpt-auto-generator ] || [ "$(readlink -f /etc/systemd/system-generators/systemd-gpt-auto-generator)" != "/dev/null" ] ); then
-  mkdir -p /etc/systemd/system-generators
-  ln -sf /dev/null /etc/systemd/system-generators/systemd-gpt-auto-generator
-fi
 
 # Disable any active swap, no need to restart kubelet
 if ! swapoff -a; then

--- a/candi/bashible/common-steps/all/004_configure_swap.sh.tpl
+++ b/candi/bashible/common-steps/all/004_configure_swap.sh.tpl
@@ -32,10 +32,22 @@ has_cgroup2() {
 #  CASE 1: swapBehavior is empty or == NoSwap
 ###############################################
 
-# Stop and mask systemd swap units
+# zram-generator generates swap units for zram devices (dev-zram0.swap and friends), and
+# swap.target pulls them back in. Neutralize it before touching the units: a unit that is
+# regenerated and reactivated while it is being stopped never reaches a final state, and
+# `systemctl stop` waits for that state forever.
+if [ -f /lib/systemd/system-generators/zram-generator ] && ( [ ! -L /etc/systemd/system-generators/zram-generator ] || [ "$(readlink -f /etc/systemd/system-generators/zram-generator)" != "/dev/null" ] ); then
+  mkdir -p /etc/systemd/system-generators
+  ln -sf /dev/null /etc/systemd/system-generators/zram-generator
+fi
+
+# Mask systemd swap units before stopping them, so that nothing can reactivate a unit
+# while it is being stopped. The timeout is what makes `|| true` effective: it catches a
+# non-zero exit, not a hang, and a hanging `systemctl stop` blocks bashible - and with it
+# cloud-init and the node join - indefinitely.
 for swapunit in $(systemctl list-units --no-legend --plain --no-pager --type swap | cut -f1 -d" "); do
-  systemctl stop "$swapunit" || true
   systemctl mask "$swapunit" || true
+  timeout 30 systemctl stop "$swapunit" || true
 done
 
 # systemd-gpt-auto-generator automatically detects swap partition in GPT and activates it


### PR DESCRIPTION
## Overview

A node whose swap unit is regenerated never finishes bootstrap, so it never joins the cluster. `dhctl` then sits in `Waiting for NodeGroups ... to become Ready` until the phase gives up, because the expected node count is never reached.

`004_configure_swap.sh` stops systemd swap units before masking them:

```bash
for swapunit in $(systemctl list-units ... --type swap | cut -f1 -d" "); do
  systemctl stop "$swapunit" || true
  systemctl mask "$swapunit" || true
done
```

On a node where the swap unit comes from `zram-generator` (`dev-zram0.swap`, e.g. RED OS 8) and is pulled in by `swap.target`, the unit is reactivated in the same second it is stopped:

```
22:15:09 cloud-init[1274]: === Step: /var/lib/bashible/bundle_steps/004_configure_swap.sh
22:15:10 systemd[1]: Deactivating swap dev-zram0.swap - Compressed Swap on /dev/zram0...
22:15:10 systemd[1]: dev-zram0.swap: Deactivated successfully.
22:15:10 systemd[1]: Activating swap dev-zram0.swap - Compressed Swap on /dev/zram0...
22:15:10 systemd[1]: Activated swap dev-zram0.swap.
```

`systemctl stop` then waits for a final state that never arrives, and `|| true` does not help: it catches a non-zero exit, not a hang. `bashible` blocks on the call, `cloud-init` stays in `modules-final`, and the node never registers.

Measured on a stuck node (RED OS 8, kernel `6.6.26-1.red80`):

| | |
| --- | --- |
| `systemctl stop dev-zram0.swap` | state `S`, **9h44m** |
| `cloud-init status` | `running`, stage `modules-final` |
| `swapon --show` | `/dev/zram0`, 7.8G, **0B used** |
| free memory | 3.6G of 7.9G |
| `systemctl list-jobs` | no stop job queued for the unit |
| `dev-zram0.swap` | still `active`, 9h |

Swap is empty and memory is free, so this is not `swapoff` doing I/O — and systemd has no pending job, so the call is not waiting on queued work either.

The failure is **intermittent**, because it is a race between the stop and the reactivation: on the same cluster one RED OS node joined and another did not. That is what makes it look like a flaky node rather than a bug.

## What's changed

Three changes to the `NoSwap` branch of `004_configure_swap.sh.tpl`:

- **`mask` before `stop`.** A masked unit cannot be reactivated, so the stop settles instead of racing.
- **`timeout 30` on the stop.** This is what makes the existing `|| true` effective — it turns a hang into the non-zero exit the code already expects, so a pathological node degrades into a logged error instead of blocking bootstrap forever.
- **`zram-generator` neutralized** by symlinking it to `/dev/null`, exactly the way the step already neutralizes `systemd-gpt-auto-generator` a few lines below — that block was added for this same class of problem, but only covers GPT-detected swap, not zram.

## Testing

Diagnosed on a live stuck node: the hang was traced to the running `systemctl stop dev-zram0.swap` child of the bashible step, with the journal above showing the deactivate/reactivate pair, and the counters in the table ruling out `swapoff` I/O and queued systemd work.

Shell syntax of the rendered template verified with `bash -n` (template directives stripped).

Not verified end to end: I have not run a full node bootstrap from a build containing this patch, so the fix is argued from the mechanism rather than from a green run. The three changes are independent and each is safe on nodes without zram — masking before stopping is equivalent where nothing reactivates the unit, the timeout only bounds a call that is expected to return immediately, and the generator symlink is a no-op where `zram-generator` is not installed.

## Changelog entries

```changes
section: candi
type: fix
summary: Fix node bootstrap hanging forever when a systemd swap unit is regenerated while being stopped (zram-generator).
```
