### PR TITLE
[cloud-provider-dvp] feat: exclude storage classes via parameters

### DIFF
--- a/modules/030-cloud-provider-dvp/hooks/discover.go
+++ b/modules/030-cloud-provider-dvp/hooks/discover.go
@@ -20,31 +20,19 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log/slog"
-	"regexp"
-	"sort"
-	"strings"
-	"unicode"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
 	corev1 "k8s.io/api/core/v1"
-	storagev1 "k8s.io/api/storage/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/utils/ptr"
 
 	"github.com/deckhouse/lib-dhctl/pkg/yaml/validation"
-	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 
 	cloudDataV1 "github.com/deckhouse/deckhouse/go_lib/cloud-data/apis/v1"
-)
-
-const (
-	stableDefaultAnnotation  = "storageclass.kubernetes.io/is-default-class"
-	betaDefaultAnnotation    = "storageclass.beta.kubernetes.io/is-default-class"
-	defaultVolumeBindingMode = storagev1.VolumeBindingWaitForFirstConsumer
+	"github.com/deckhouse/deckhouse/modules/030-cloud-provider-dvp/hooks/internal"
 )
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
@@ -65,10 +53,10 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			FilterFunc: applyCloudProviderDiscoveryDataSecretFilter,
 		},
 		{
-			Name:       "storage_classes",
+			Name:       internal.StorageClassesSnapshotName,
 			ApiVersion: "storage.k8s.io/v1",
 			Kind:       "StorageClass",
-			FilterFunc: applyStorageClassFilter,
+			FilterFunc: internal.ApplyStorageClassFilter,
 			LabelSelector: &meta.LabelSelector{
 				MatchLabels: map[string]string{
 					"heritage": "deckhouse",
@@ -90,16 +78,6 @@ func applyCloudProviderDiscoveryDataSecretFilter(obj *unstructured.Unstructured)
 	return secret, nil
 }
 
-func applyStorageClassFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
-	storageClass := &storagev1.StorageClass{}
-	err := sdk.FromUnstructured(obj, storageClass)
-	if err != nil {
-		return nil, fmt.Errorf("failed to convert kubernetes object: %v", err)
-	}
-
-	return storageClass, nil
-}
-
 func handleCloudProviderDiscoveryDataSecret(_ context.Context, input *go_hook.HookInput) error {
 	// On fresh install without a ModuleConfig, nodes/provider are absent; any Values.Set
 	// triggers full-object schema validation which rejects the patch. Defer to OnBeforeHelm
@@ -109,34 +87,17 @@ func handleCloudProviderDiscoveryDataSecret(_ context.Context, input *go_hook.Ho
 		return nil
 	}
 
-	if len(input.Snapshots.Get("cloud_provider_discovery_data")) == 0 {
+	secrets := input.Snapshots.Get("cloud_provider_discovery_data")
+	if len(secrets) == 0 {
 		input.Logger.Warn("failed to find secret 'd8-cloud-provider-discovery-data' in namespace 'kube-system'")
 
-		if len(input.Snapshots.Get("storage_classes")) == 0 {
+		if len(input.Snapshots.Get(internal.StorageClassesSnapshotName)) == 0 {
 			input.Logger.Warn("failed to find storage classes for dvp provisioner")
 
 			return nil
 		}
 
-		storageClassesSnapshots := input.Snapshots.Get("storage_classes")
-		storageClasses := make([]storageClass, 0, len(storageClassesSnapshots))
-
-		for storageClassSnapshot, err := range sdkobjectpatch.SnapshotIter[storagev1.StorageClass](storageClassesSnapshots) {
-			if err != nil {
-				return fmt.Errorf("failed to iterate over 'storage_classes' snapshots: %v", err)
-			}
-			deleteOldStorageClass(input, &storageClassSnapshot)
-			storageClasses = append(storageClasses, storageClassToStorageClassValue(&storageClassSnapshot))
-		}
-		input.Logger.Info("Found DVP storage classes using StorageClass snapshots: %v", storageClasses)
-
-		setStorageClassesValues(input, storageClasses)
-		return nil
-	}
-
-	secrets := input.Snapshots.Get("cloud_provider_discovery_data")
-	if len(secrets) == 0 {
-		return fmt.Errorf("'cloud_provider_discovery_data' snapshot is empty")
+		return internal.HandleStorageClassesFromSnapshots(input)
 	}
 
 	secret := new(corev1.Secret)
@@ -159,164 +120,9 @@ func handleCloudProviderDiscoveryDataSecret(_ context.Context, input *go_hook.Ho
 
 	input.Values.Set("cloudProviderDvp.internal.providerDiscoveryData", discoveryData)
 
-	err = handleDiscoveryDataStorageClasses(input, discoveryData.StorageClassList)
-	if err != nil {
+	if err = internal.HandleStorageClassesFromDiscoveryData(input, discoveryData.StorageClassList); err != nil {
 		return fmt.Errorf("failed to handle discovery data storage classes: %v", err)
 	}
 
 	return nil
-}
-
-func handleDiscoveryDataStorageClasses(
-	input *go_hook.HookInput,
-	dvpStorageClassList []cloudDataV1.DVPStorageClass,
-) error {
-	dvpstorageClass := make(map[string]cloudDataV1.DVPStorageClass, len(dvpStorageClassList))
-
-	for _, sc := range dvpStorageClassList {
-		if !sc.IsEnabled {
-			continue
-		}
-
-		dvpstorageClass[getStorageClassName(sc.Name)] = sc
-	}
-
-	storageClasses := make([]storageClass, 0, len(dvpStorageClassList))
-	for sc, err := range sdkobjectpatch.SnapshotIter[storagev1.StorageClass](input.Snapshots.Get("storage_classes")) {
-		if err != nil {
-			return fmt.Errorf("failed to iterate over 'storage_classes' snapshots: %v", err)
-		}
-
-		deleteOldStorageClass(input, &sc)
-
-		if _, ok := dvpstorageClass[sc.Name]; !ok {
-			storageClasses = append(storageClasses, storageClassToStorageClassValue(&sc))
-		}
-	}
-
-	storageClassExcludes, ok := input.Values.GetOk("cloudProviderDvp.storageClass.exclude")
-	if ok {
-		for _, esc := range storageClassExcludes.Array() {
-			rg := regexp.MustCompile("^(" + esc.String() + ")$")
-			for class := range dvpstorageClass {
-				if rg.MatchString(class) {
-					delete(dvpstorageClass, class)
-				}
-			}
-		}
-	}
-
-	for name, sc := range dvpstorageClass {
-		sc := storageClass{
-			Name:                 name,
-			DVPStorageClass:      sc.Name,
-			VolumeBindingMode:    string(defaultVolumeBindingMode),
-			ReclaimPolicy:        sc.ReclaimPolicy,
-			AllowVolumeExpansion: sc.AllowVolumeExpansion,
-			IsDefault:            sc.IsDefault,
-		}
-		storageClasses = append(storageClasses, sc)
-	}
-
-	sort.SliceStable(storageClasses, func(i, j int) bool {
-		return storageClasses[i].Name < storageClasses[j].Name
-	})
-
-	input.Logger.Info("Found DVP storage classes using StorageClass snapshots, StorageClasses from discovery data: %v", storageClasses)
-
-	setStorageClassesValues(input, storageClasses)
-	return nil
-}
-
-// Get StorageClass name from Volume type name to match Kubernetes restrictions from https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names
-func getStorageClassName(value string) string {
-	mapFn := func(r rune) rune {
-		if r >= 'a' && r <= 'z' ||
-			r >= 'A' && r <= 'Z' ||
-			r >= '0' && r <= '9' ||
-			r == '-' || r == '.' {
-			return unicode.ToLower(r)
-		} else if r == ' ' {
-			return '-'
-		}
-		return rune(-1)
-	}
-
-	// a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.'
-	value = strings.Map(mapFn, value)
-
-	// must start and end with an alphanumeric character
-	return strings.Trim(value, "-.")
-}
-
-func setStorageClassesValues(input *go_hook.HookInput, storageClasses []storageClass) {
-	input.Values.Set("cloudProviderDvp.internal.storageClasses", storageClasses)
-
-	// Find and set default StorageClass in module internal values
-	var defaultSC string
-	for _, sc := range storageClasses {
-		if sc.IsDefault {
-			defaultSC = sc.Name
-			break
-		}
-	}
-
-	if defaultSC != "" {
-		input.Values.Set("cloudProviderDvp.internal.defaultStorageClass", defaultSC)
-		input.Logger.Info("Discovered default storage class from DVP cloud provider", slog.String("storage_class", defaultSC))
-	} else {
-		input.Logger.Info("No default storage class found in parent DVP cluster")
-		input.Values.Remove("cloudProviderDvp.internal.defaultStorageClass")
-	}
-}
-
-type storageClass struct {
-	Name                 string `json:"name"`
-	DVPStorageClass      string `json:"dvpStorageClass"`
-	VolumeBindingMode    string `json:"volumeBindingMode"`
-	ReclaimPolicy        string `json:"reclaimPolicy"`
-	AllowVolumeExpansion bool   `json:"allowVolumeExpansion"`
-	IsDefault            bool   `json:"isDefault"`
-}
-
-func storageClassToStorageClassValue(sc *storagev1.StorageClass) storageClass {
-	reclaimPolicy := corev1.PersistentVolumeReclaimDelete
-	if sc.ReclaimPolicy != nil {
-		reclaimPolicy = *sc.ReclaimPolicy
-	}
-
-	allowVolumeExpansion := false
-	if sc.AllowVolumeExpansion != nil {
-		allowVolumeExpansion = *sc.AllowVolumeExpansion
-	}
-
-	isDefault := false
-	if sc.Annotations != nil {
-		if val, ok := sc.Annotations[stableDefaultAnnotation]; ok && strings.ToLower(val) == "true" {
-			isDefault = true
-		} else if val, ok := sc.Annotations[betaDefaultAnnotation]; ok && strings.ToLower(val) == "true" {
-			isDefault = true
-		}
-	}
-
-	return storageClass{
-		Name:                 sc.Name,
-		DVPStorageClass:      sc.Parameters["dvpStorageClass"],
-		VolumeBindingMode:    string(defaultVolumeBindingMode),
-		ReclaimPolicy:        string(reclaimPolicy),
-		AllowVolumeExpansion: allowVolumeExpansion,
-		IsDefault:            isDefault,
-	}
-}
-
-func deleteOldStorageClass(input *go_hook.HookInput, sc *storagev1.StorageClass) {
-	if sc.VolumeBindingMode != nil && *sc.VolumeBindingMode == defaultVolumeBindingMode {
-		return
-	}
-
-	input.Logger.Info(
-		"Deleting storage class because volumeBindingMode must be WaitForFirstConsumer.",
-		slog.String("storage_class", sc.Name),
-	)
-	input.PatchCollector.Delete("storage.k8s.io/v1", "StorageClass", "", sc.Name)
 }

--- a/modules/030-cloud-provider-dvp/hooks/discover_test.go
+++ b/modules/030-cloud-provider-dvp/hooks/discover_test.go
@@ -21,11 +21,7 @@ import (
 	"fmt"
 
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
-	storagev1 "k8s.io/api/storage/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/deckhouse/deckhouse/testing/hooks"
 )
@@ -44,25 +40,29 @@ cloudProviderDvp:
   internal: {}
 `
 
-	const initValuesWithExclude = `
-cloudProviderDvp:
-  storageClass:
-    exclude:
-    - excluded-.*
-  internal:
-    defaultStorageClass: stale-default
-`
-
 	const initValuesWithExcludeAndProvider = `
 cloudProviderDvp:
   provider:
     parameters:
       namespace: test-ns
-  storageClass:
-    exclude:
-    - excluded-.*
+  storage:
+    parameters:
+      excludedStorageClasses:
+      - excluded-.*
   internal:
     defaultStorageClass: stale-default
+`
+
+	const initValuesWithBrokenExcludeAndProvider = `
+cloudProviderDvp:
+  provider:
+    parameters:
+      namespace: test-ns
+  storage:
+    parameters:
+      excludedStorageClasses:
+      - "excluded-([a-z"
+  internal: {}
 `
 
 	storageClassesOnly := `
@@ -94,6 +94,20 @@ provisioner: csi.dvp.deckhouse.io
 parameters:
   dvpStorageClass: secondary
 reclaimPolicy: Retain
+allowVolumeExpansion: false
+volumeBindingMode: WaitForFirstConsumer
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: excluded-legacy
+  labels:
+    heritage: deckhouse
+    module: cloud-provider-dvp
+provisioner: csi.dvp.deckhouse.io
+parameters:
+  dvpStorageClass: Excluded Legacy
+reclaimPolicy: Delete
 allowVolumeExpansion: false
 volumeBindingMode: WaitForFirstConsumer
 `
@@ -178,6 +192,25 @@ allowVolumeExpansion: false
 volumeBindingMode: WaitForFirstConsumer
 `
 
+	// A StorageClass created by the module before it was added to excludedStorageClasses.
+	// It is absent from the discovery data, so it only reaches the values through the snapshots.
+	existingExcludedStorageClass := `
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: excluded-legacy
+  labels:
+    heritage: deckhouse
+    module: cloud-provider-dvp
+provisioner: csi.dvp.deckhouse.io
+parameters:
+  dvpStorageClass: Excluded Legacy
+reclaimPolicy: Delete
+allowVolumeExpansion: false
+volumeBindingMode: WaitForFirstConsumer
+`
+
 	Context("When cluster state is empty", func() {
 		f := HookExecutionConfigInit(initValues, `{}`)
 		BeforeEach(func() {
@@ -204,6 +237,14 @@ volumeBindingMode: WaitForFirstConsumer
 			Expect(f.ValuesGet("cloudProviderDvp.internal.storageClasses").String()).To(MatchJSON(`
 [
   {
+    "name": "excluded-legacy",
+    "dvpStorageClass": "Excluded Legacy",
+    "volumeBindingMode": "WaitForFirstConsumer",
+    "reclaimPolicy": "Delete",
+    "allowVolumeExpansion": false,
+    "isDefault": false
+  },
+  {
     "name": "replicated",
     "dvpStorageClass": "replicated",
     "volumeBindingMode": "WaitForFirstConsumer",
@@ -227,12 +268,45 @@ volumeBindingMode: WaitForFirstConsumer
 		})
 	})
 
+	Context("When only managed StorageClass snapshots are present and excludes are set", func() {
+		f := HookExecutionConfigInit(initValuesWithExcludeAndProvider, `{}`)
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext(), f.KubeStateSet(storageClassesOnly))
+			f.RunHook()
+		})
+
+		It("Should apply excludes to the snapshot fallback as well", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("cloudProviderDvp.internal.storageClasses").String()).To(MatchJSON(`
+[
+  {
+    "name": "replicated",
+    "dvpStorageClass": "replicated",
+    "volumeBindingMode": "WaitForFirstConsumer",
+    "reclaimPolicy": "Delete",
+    "allowVolumeExpansion": true,
+    "isDefault": true
+  },
+  {
+    "name": "secondary",
+    "dvpStorageClass": "secondary",
+    "volumeBindingMode": "WaitForFirstConsumer",
+    "reclaimPolicy": "Retain",
+    "allowVolumeExpansion": false,
+    "isDefault": false
+  }
+]
+`))
+			Expect(f.ValuesGet("cloudProviderDvp.internal.defaultStorageClass").String()).To(Equal("replicated"))
+		})
+	})
+
 	Context("When discovery data and managed StorageClasses are present", func() {
 		f := HookExecutionConfigInit(initValuesWithExcludeAndProvider, `{}`)
 		BeforeEach(func() {
 			f.BindingContexts.Set(
 				f.GenerateBeforeHelmContext(),
-				f.KubeStateSet(discoverySecret+existingStorageClass+existingRetainedStorageClass),
+				f.KubeStateSet(discoverySecret+existingStorageClass+existingRetainedStorageClass+existingExcludedStorageClass),
 			)
 			f.RunHook()
 		})
@@ -265,6 +339,18 @@ volumeBindingMode: WaitForFirstConsumer
 			Expect(f.ValuesGet("cloudProviderDvp.internal.defaultStorageClass").String()).To(Equal("replicated"))
 			Expect(f.KubernetesGlobalResource("StorageClass", "replicated").Exists()).To(BeFalse())
 			Expect(f.KubernetesGlobalResource("StorageClass", "retained").Exists()).To(BeTrue())
+		})
+	})
+
+	Context("When excludedStorageClasses contains an invalid regular expression", func() {
+		f := HookExecutionConfigInit(initValuesWithBrokenExcludeAndProvider, `{}`)
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext(), f.KubeStateSet(storageClassesOnly))
+			f.RunHook()
+		})
+
+		It("Should fail instead of panicking", func() {
+			Expect(f).To(Not(ExecuteSuccessfully()))
 		})
 	})
 
@@ -335,86 +421,4 @@ data:
 			Expect(f).To(Not(ExecuteSuccessfully()))
 		})
 	})
-
-	DescribeTable("getStorageClassName",
-		func(input, expected string) {
-			Expect(getStorageClassName(input)).To(Equal(expected))
-		},
-		Entry("keeps valid name", "replicated", "replicated"),
-		Entry("normalizes spaces and case", "Excluded Fast", "excluded-fast"),
-		Entry("removes invalid symbols and trims ends", "-Xx__$()? -foo-", "xx--foo"),
-		Entry("trims dots and dashes", ".. YY fast SSD-foo.-", "yy-fast-ssd-foo"),
-	)
-
-	DescribeTable("storageClassToStorageClassValue",
-		func(input *storagev1.StorageClass, expected storageClass) {
-			Expect(storageClassToStorageClassValue(input)).To(Equal(expected))
-		},
-		Entry("uses defaults for nil optional fields",
-			&storagev1.StorageClass{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "replicated",
-				},
-				Parameters: map[string]string{
-					"dvpStorageClass": "replicated",
-				},
-			},
-			storageClass{
-				Name:                 "replicated",
-				DVPStorageClass:      "replicated",
-				VolumeBindingMode:    string(defaultVolumeBindingMode),
-				ReclaimPolicy:        string(corev1.PersistentVolumeReclaimDelete),
-				AllowVolumeExpansion: false,
-				IsDefault:            false,
-			},
-		),
-		Entry("reads stable default annotation and optional fields",
-			&storagev1.StorageClass{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "stable-default",
-					Annotations: map[string]string{
-						stableDefaultAnnotation: "TrUe",
-					},
-				},
-				Parameters: map[string]string{
-					"dvpStorageClass": "stable-default",
-				},
-				ReclaimPolicy:        ptrTo(corev1.PersistentVolumeReclaimRetain),
-				AllowVolumeExpansion: ptrTo(true),
-			},
-			storageClass{
-				Name:                 "stable-default",
-				DVPStorageClass:      "stable-default",
-				VolumeBindingMode:    string(defaultVolumeBindingMode),
-				ReclaimPolicy:        string(corev1.PersistentVolumeReclaimRetain),
-				AllowVolumeExpansion: true,
-				IsDefault:            true,
-			},
-		),
-		Entry("reads beta default annotation",
-			&storagev1.StorageClass{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "beta-default",
-					Annotations: map[string]string{
-						betaDefaultAnnotation: "true",
-					},
-				},
-				Parameters: map[string]string{
-					"dvpStorageClass": "beta-default",
-				},
-			},
-			storageClass{
-				Name:                 "beta-default",
-				DVPStorageClass:      "beta-default",
-				VolumeBindingMode:    string(defaultVolumeBindingMode),
-				ReclaimPolicy:        string(corev1.PersistentVolumeReclaimDelete),
-				AllowVolumeExpansion: false,
-				IsDefault:            true,
-			},
-		),
-	)
 })
-
-func ptrTo[T any](v T) *T {
-	return &v
-}

--- a/modules/030-cloud-provider-dvp/hooks/discover_test.go
+++ b/modules/030-cloud-provider-dvp/hooks/discover_test.go
@@ -53,6 +53,31 @@ cloudProviderDvp:
     defaultStorageClass: stale-default
 `
 
+	const initValuesWithExactExcludeAndProvider = `
+cloudProviderDvp:
+  provider:
+    parameters:
+      namespace: test-ns
+  storage:
+    parameters:
+      excludedStorageClasses:
+      - fast
+  internal: {}
+`
+
+	const initValuesWithDefaultExcludeAndProvider = `
+cloudProviderDvp:
+  provider:
+    parameters:
+      namespace: test-ns
+  storage:
+    parameters:
+      excludedStorageClasses:
+      - replicated
+  internal:
+    defaultStorageClass: replicated
+`
+
 	const initValuesWithBrokenExcludeAndProvider = `
 cloudProviderDvp:
   provider:
@@ -339,6 +364,97 @@ volumeBindingMode: WaitForFirstConsumer
 			Expect(f.ValuesGet("cloudProviderDvp.internal.defaultStorageClass").String()).To(Equal("replicated"))
 			Expect(f.KubernetesGlobalResource("StorageClass", "replicated").Exists()).To(BeFalse())
 			Expect(f.KubernetesGlobalResource("StorageClass", "retained").Exists()).To(BeTrue())
+		})
+	})
+
+	Context("When excludedStorageClasses contains a plain StorageClass name", func() {
+		similarlyNamedDiscoveryData := `
+{
+  "apiVersion": "deckhouse.io/v1",
+  "kind": "DVPCloudDiscoveryData",
+  "zones": ["default"],
+  "storageClasses": [
+    {
+      "name": "fast",
+      "volumeBindingMode": "Immediate",
+      "reclaimPolicy": "Delete",
+      "allowVolumeExpansion": false,
+      "isEnabled": true,
+      "isDefault": false
+    },
+    {
+      "name": "ultra-fast-ssd",
+      "volumeBindingMode": "Immediate",
+      "reclaimPolicy": "Delete",
+      "allowVolumeExpansion": false,
+      "isEnabled": true,
+      "isDefault": false
+    }
+  ]
+}
+`
+
+		similarlyNamedDiscoverySecret := fmt.Sprintf(`
+apiVersion: v1
+kind: Secret
+metadata:
+  name: d8-cloud-provider-discovery-data
+  namespace: kube-system
+data:
+  "discovery-data.json": %s
+`, base64.StdEncoding.EncodeToString([]byte(similarlyNamedDiscoveryData)))
+
+		f := HookExecutionConfigInit(initValuesWithExactExcludeAndProvider, `{}`)
+		BeforeEach(func() {
+			f.BindingContexts.Set(
+				f.GenerateBeforeHelmContext(),
+				f.KubeStateSet(similarlyNamedDiscoverySecret),
+			)
+			f.RunHook()
+		})
+
+		It("Should match the whole name and keep the classes it is only a part of", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("cloudProviderDvp.internal.storageClasses").String()).To(MatchJSON(`
+[
+  {
+    "name": "ultra-fast-ssd",
+    "dvpStorageClass": "ultra-fast-ssd",
+    "volumeBindingMode": "WaitForFirstConsumer",
+    "reclaimPolicy": "Delete",
+    "allowVolumeExpansion": false,
+    "isDefault": false
+  }
+]
+`))
+		})
+	})
+
+	Context("When excludedStorageClasses contains the default StorageClass", func() {
+		f := HookExecutionConfigInit(initValuesWithDefaultExcludeAndProvider, `{}`)
+		BeforeEach(func() {
+			f.BindingContexts.Set(
+				f.GenerateBeforeHelmContext(),
+				f.KubeStateSet(discoverySecret+existingStorageClass),
+			)
+			f.RunHook()
+		})
+
+		It("Should exclude the default class and drop defaultStorageClass", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("cloudProviderDvp.internal.storageClasses").String()).To(MatchJSON(`
+[
+  {
+    "name": "excluded-fast",
+    "dvpStorageClass": "Excluded Fast",
+    "volumeBindingMode": "WaitForFirstConsumer",
+    "reclaimPolicy": "Retain",
+    "allowVolumeExpansion": false,
+    "isDefault": false
+  }
+]
+`))
+			Expect(f.ValuesGet("cloudProviderDvp.internal.defaultStorageClass").Exists()).To(BeFalse())
 		})
 	})
 

--- a/modules/030-cloud-provider-dvp/hooks/internal/storage_classes.go
+++ b/modules/030-cloud-provider-dvp/hooks/internal/storage_classes.go
@@ -1,0 +1,254 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"fmt"
+	"log/slog"
+	"sort"
+	"strings"
+	"unicode"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
+
+	cloudDataV1 "github.com/deckhouse/deckhouse/go_lib/cloud-data/apis/v1"
+	"github.com/deckhouse/deckhouse/go_lib/regexpset"
+)
+
+const (
+	// StorageClassesSnapshotName is the name of the snapshot with the StorageClasses created by the module.
+	StorageClassesSnapshotName = "storage_classes"
+
+	StableDefaultAnnotation  = "storageclass.kubernetes.io/is-default-class"
+	BetaDefaultAnnotation    = "storageclass.beta.kubernetes.io/is-default-class"
+	DefaultVolumeBindingMode = storagev1.VolumeBindingWaitForFirstConsumer
+
+	storageClassesPath         = "cloudProviderDvp.internal.storageClasses"
+	defaultStorageClassPath    = "cloudProviderDvp.internal.defaultStorageClass"
+	excludedStorageClassesPath = "cloudProviderDvp.storage.parameters.excludedStorageClasses"
+)
+
+// StorageClass describes a StorageClass to create in the cluster.
+type StorageClass struct {
+	Name                 string `json:"name"`
+	DVPStorageClass      string `json:"dvpStorageClass"`
+	VolumeBindingMode    string `json:"volumeBindingMode"`
+	ReclaimPolicy        string `json:"reclaimPolicy"`
+	AllowVolumeExpansion bool   `json:"allowVolumeExpansion"`
+	IsDefault            bool   `json:"isDefault"`
+}
+
+// ApplyStorageClassFilter is a FilterFunc for the StorageClassesSnapshotName binding.
+func ApplyStorageClassFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	storageClass := &storagev1.StorageClass{}
+	err := sdk.FromUnstructured(obj, storageClass)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert kubernetes object: %v", err)
+	}
+
+	return storageClass, nil
+}
+
+// HandleStorageClassesFromSnapshots keeps the StorageClasses already created by the module when
+// the discovery data secret is missing. Values patches do not survive a Deckhouse restart, so the
+// StorageClasses present in the cluster are the only source of truth left in that case.
+func HandleStorageClassesFromSnapshots(input *go_hook.HookInput) error {
+	snapshots := input.Snapshots.Get(StorageClassesSnapshotName)
+	storageClasses := make([]StorageClass, 0, len(snapshots))
+
+	for sc, err := range sdkobjectpatch.SnapshotIter[storagev1.StorageClass](snapshots) {
+		if err != nil {
+			return fmt.Errorf("failed to iterate over '%s' snapshots: %v", StorageClassesSnapshotName, err)
+		}
+
+		deleteOldStorageClass(input, &sc)
+		storageClasses = append(storageClasses, StorageClassToValue(&sc))
+	}
+
+	input.Logger.Info("Found DVP storage classes using StorageClass snapshots", slog.Any("storage_classes", storageClasses))
+
+	return setStorageClassesValues(input, storageClasses)
+}
+
+// HandleStorageClassesFromDiscoveryData merges the StorageClasses discovered in the parent DVP
+// cluster with the ones already created by the module.
+func HandleStorageClassesFromDiscoveryData(
+	input *go_hook.HookInput,
+	dvpStorageClassList []cloudDataV1.DVPStorageClass,
+) error {
+	discovered := make(map[string]cloudDataV1.DVPStorageClass, len(dvpStorageClassList))
+
+	for _, sc := range dvpStorageClassList {
+		if !sc.IsEnabled {
+			continue
+		}
+
+		discovered[GetStorageClassName(sc.Name)] = sc
+	}
+
+	storageClasses := make([]StorageClass, 0, len(dvpStorageClassList))
+	for sc, err := range sdkobjectpatch.SnapshotIter[storagev1.StorageClass](input.Snapshots.Get(StorageClassesSnapshotName)) {
+		if err != nil {
+			return fmt.Errorf("failed to iterate over '%s' snapshots: %v", StorageClassesSnapshotName, err)
+		}
+
+		deleteOldStorageClass(input, &sc)
+
+		if _, ok := discovered[sc.Name]; !ok {
+			storageClasses = append(storageClasses, StorageClassToValue(&sc))
+		}
+	}
+
+	for name, sc := range discovered {
+		storageClasses = append(storageClasses, StorageClass{
+			Name:                 name,
+			DVPStorageClass:      sc.Name,
+			VolumeBindingMode:    string(DefaultVolumeBindingMode),
+			ReclaimPolicy:        sc.ReclaimPolicy,
+			AllowVolumeExpansion: sc.AllowVolumeExpansion,
+			IsDefault:            sc.IsDefault,
+		})
+	}
+
+	input.Logger.Info(
+		"Found DVP storage classes using StorageClass snapshots and discovery data",
+		slog.Any("storage_classes", storageClasses),
+	)
+
+	return setStorageClassesValues(input, storageClasses)
+}
+
+// setStorageClassesValues is the single place where StorageClasses reach the module values, so
+// every source of StorageClasses is filtered by `storage.parameters.excludedStorageClasses`.
+func setStorageClassesValues(input *go_hook.HookInput, storageClasses []StorageClass) error {
+	excludes, err := regexpset.NewFromValues(input.Values, excludedStorageClassesPath)
+	if err != nil {
+		return fmt.Errorf("failed to compile '%s': %v", excludedStorageClassesPath, err)
+	}
+
+	filtered := make([]StorageClass, 0, len(storageClasses))
+	for _, sc := range storageClasses {
+		if excludes.Match(sc.Name) {
+			input.Logger.Info(
+				"Excluding storage class because it matches storage.parameters.excludedStorageClasses",
+				slog.String("storage_class", sc.Name),
+			)
+
+			continue
+		}
+
+		filtered = append(filtered, sc)
+	}
+
+	sort.SliceStable(filtered, func(i, j int) bool {
+		return filtered[i].Name < filtered[j].Name
+	})
+
+	input.Values.Set(storageClassesPath, filtered)
+
+	// Find and set default StorageClass in module internal values
+	var defaultSC string
+	for _, sc := range filtered {
+		if sc.IsDefault {
+			defaultSC = sc.Name
+			break
+		}
+	}
+
+	if defaultSC == "" {
+		input.Logger.Info("No default storage class found in parent DVP cluster")
+		input.Values.Remove(defaultStorageClassPath)
+
+		return nil
+	}
+
+	input.Values.Set(defaultStorageClassPath, defaultSC)
+	input.Logger.Info("Discovered default storage class from DVP cloud provider", slog.String("storage_class", defaultSC))
+
+	return nil
+}
+
+// GetStorageClassName converts a DVP StorageClass name into a Kubernetes object name that satisfies
+// the restrictions from https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names
+func GetStorageClassName(value string) string {
+	mapFn := func(r rune) rune {
+		if r >= 'a' && r <= 'z' ||
+			r >= 'A' && r <= 'Z' ||
+			r >= '0' && r <= '9' ||
+			r == '-' || r == '.' {
+			return unicode.ToLower(r)
+		} else if r == ' ' {
+			return '-'
+		}
+		return rune(-1)
+	}
+
+	// a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.'
+	value = strings.Map(mapFn, value)
+
+	// must start and end with an alphanumeric character
+	return strings.Trim(value, "-.")
+}
+
+// StorageClassToValue converts a StorageClass object into its module values representation.
+func StorageClassToValue(sc *storagev1.StorageClass) StorageClass {
+	reclaimPolicy := corev1.PersistentVolumeReclaimDelete
+	if sc.ReclaimPolicy != nil {
+		reclaimPolicy = *sc.ReclaimPolicy
+	}
+
+	allowVolumeExpansion := false
+	if sc.AllowVolumeExpansion != nil {
+		allowVolumeExpansion = *sc.AllowVolumeExpansion
+	}
+
+	isDefault := false
+	if sc.Annotations != nil {
+		if val, ok := sc.Annotations[StableDefaultAnnotation]; ok && strings.ToLower(val) == "true" {
+			isDefault = true
+		} else if val, ok := sc.Annotations[BetaDefaultAnnotation]; ok && strings.ToLower(val) == "true" {
+			isDefault = true
+		}
+	}
+
+	return StorageClass{
+		Name:                 sc.Name,
+		DVPStorageClass:      sc.Parameters["dvpStorageClass"],
+		VolumeBindingMode:    string(DefaultVolumeBindingMode),
+		ReclaimPolicy:        string(reclaimPolicy),
+		AllowVolumeExpansion: allowVolumeExpansion,
+		IsDefault:            isDefault,
+	}
+}
+
+func deleteOldStorageClass(input *go_hook.HookInput, sc *storagev1.StorageClass) {
+	if sc.VolumeBindingMode != nil && *sc.VolumeBindingMode == DefaultVolumeBindingMode {
+		return
+	}
+
+	input.Logger.Info(
+		"Deleting storage class because volumeBindingMode must be WaitForFirstConsumer.",
+		slog.String("storage_class", sc.Name),
+	)
+	input.PatchCollector.Delete("storage.k8s.io/v1", "StorageClass", "", sc.Name)
+}

--- a/modules/030-cloud-provider-dvp/hooks/internal/storage_classes.go
+++ b/modules/030-cloud-provider-dvp/hooks/internal/storage_classes.go
@@ -141,7 +141,14 @@ func HandleStorageClassesFromDiscoveryData(
 // setStorageClassesValues is the single place where StorageClasses reach the module values, so
 // every source of StorageClasses is filtered by `storage.parameters.excludedStorageClasses`.
 func setStorageClassesValues(input *go_hook.HookInput, storageClasses []StorageClass) error {
-	excludes, err := regexpset.NewFromValues(input.Values, excludedStorageClassesPath)
+	patternValues := input.Values.Get(excludedStorageClassesPath).Array()
+
+	patterns := make([]string, 0, len(patternValues))
+	for _, pattern := range patternValues {
+		patterns = append(patterns, pattern.String())
+	}
+
+	excludes, err := NewExcludes(patterns)
 	if err != nil {
 		return fmt.Errorf("failed to compile '%s': %v", excludedStorageClassesPath, err)
 	}
@@ -186,6 +193,18 @@ func setStorageClassesValues(input *go_hook.HookInput, storageClasses []StorageC
 	input.Logger.Info("Discovered default storage class from DVP cloud provider", slog.String("storage_class", defaultSC))
 
 	return nil
+}
+
+// NewExcludes compiles `storage.parameters.excludedStorageClasses` patterns into a set of anchored
+// regular expressions: a pattern has to match the whole StorageClass name, so a plain name in the
+// list stays an exact name — `fast` excludes `fast` and not `ultra-fast-ssd`.
+func NewExcludes(patterns []string) (regexpset.RegExpSet, error) {
+	anchored := make([]string, 0, len(patterns))
+	for _, pattern := range patterns {
+		anchored = append(anchored, "^("+pattern+")$")
+	}
+
+	return regexpset.New(anchored...)
 }
 
 // GetStorageClassName converts a DVP StorageClass name into a Kubernetes object name that satisfies

--- a/modules/030-cloud-provider-dvp/hooks/internal/storage_classes_test.go
+++ b/modules/030-cloud-provider-dvp/hooks/internal/storage_classes_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "")
+}
+
+var _ = Describe("Modules :: cloud-provider-dvp :: hooks :: internal :: storage classes ::", func() {
+	DescribeTable("GetStorageClassName",
+		func(input, expected string) {
+			Expect(GetStorageClassName(input)).To(Equal(expected))
+		},
+		Entry("keeps valid name", "replicated", "replicated"),
+		Entry("normalizes spaces and case", "Excluded Fast", "excluded-fast"),
+		Entry("removes invalid symbols and trims ends", "-Xx__$()? -foo-", "xx--foo"),
+		Entry("trims dots and dashes", ".. YY fast SSD-foo.-", "yy-fast-ssd-foo"),
+	)
+
+	DescribeTable("StorageClassToValue",
+		func(input *storagev1.StorageClass, expected StorageClass) {
+			Expect(StorageClassToValue(input)).To(Equal(expected))
+		},
+		Entry("uses defaults for nil optional fields",
+			&storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "replicated",
+				},
+				Parameters: map[string]string{
+					"dvpStorageClass": "replicated",
+				},
+			},
+			StorageClass{
+				Name:                 "replicated",
+				DVPStorageClass:      "replicated",
+				VolumeBindingMode:    string(DefaultVolumeBindingMode),
+				ReclaimPolicy:        string(corev1.PersistentVolumeReclaimDelete),
+				AllowVolumeExpansion: false,
+				IsDefault:            false,
+			},
+		),
+		Entry("reads stable default annotation and optional fields",
+			&storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "stable-default",
+					Annotations: map[string]string{
+						StableDefaultAnnotation: "TrUe",
+					},
+				},
+				Parameters: map[string]string{
+					"dvpStorageClass": "stable-default",
+				},
+				ReclaimPolicy:        ptrTo(corev1.PersistentVolumeReclaimRetain),
+				AllowVolumeExpansion: ptrTo(true),
+			},
+			StorageClass{
+				Name:                 "stable-default",
+				DVPStorageClass:      "stable-default",
+				VolumeBindingMode:    string(DefaultVolumeBindingMode),
+				ReclaimPolicy:        string(corev1.PersistentVolumeReclaimRetain),
+				AllowVolumeExpansion: true,
+				IsDefault:            true,
+			},
+		),
+		Entry("reads beta default annotation",
+			&storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "beta-default",
+					Annotations: map[string]string{
+						BetaDefaultAnnotation: "true",
+					},
+				},
+				Parameters: map[string]string{
+					"dvpStorageClass": "beta-default",
+				},
+			},
+			StorageClass{
+				Name:                 "beta-default",
+				DVPStorageClass:      "beta-default",
+				VolumeBindingMode:    string(DefaultVolumeBindingMode),
+				ReclaimPolicy:        string(corev1.PersistentVolumeReclaimDelete),
+				AllowVolumeExpansion: false,
+				IsDefault:            true,
+			},
+		),
+	)
+})
+
+func ptrTo[T any](v T) *T {
+	return &v
+}

--- a/modules/030-cloud-provider-dvp/hooks/internal/storage_classes_test.go
+++ b/modules/030-cloud-provider-dvp/hooks/internal/storage_classes_test.go
@@ -43,6 +43,29 @@ var _ = Describe("Modules :: cloud-provider-dvp :: hooks :: internal :: storage 
 		Entry("trims dots and dashes", ".. YY fast SSD-foo.-", "yy-fast-ssd-foo"),
 	)
 
+	DescribeTable("NewExcludes",
+		func(patterns []string, name string, expected bool) {
+			excludes, err := NewExcludes(patterns)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(excludes.Match(name)).To(Equal(expected))
+		},
+		Entry("matches nothing when there are no patterns", nil, "fast", false),
+		Entry("matches an exact name", []string{"fast"}, "fast", true),
+		Entry("does not match a name containing the pattern", []string{"fast"}, "ultra-fast-ssd", false),
+		Entry("does not match a name the pattern starts with", []string{"fast"}, "fast-ssd", false),
+		Entry("matches the whole name with a wildcard pattern", []string{"excluded-.*"}, "excluded-legacy", true),
+		Entry("does not match a prefix with a wildcard pattern", []string{".*-fast"}, "ultra-fast-ssd", false),
+		Entry("keeps explicit anchors working", []string{"^fast$"}, "fast", true),
+		Entry("anchors alternations as a whole", []string{"fast|slow"}, "slow", true),
+		Entry("does not match a part of an alternation", []string{"fast|slow"}, "very-slow", false),
+		Entry("matches when any pattern matches", []string{"fast", "slow"}, "slow", true),
+	)
+
+	It("NewExcludes fails on an invalid pattern", func() {
+		_, err := NewExcludes([]string{"excluded-([a-z"})
+		Expect(err).Should(HaveOccurred())
+	})
+
 	DescribeTable("StorageClassToValue",
 		func(input *storagev1.StorageClass, expected StorageClass) {
 			Expect(StorageClassToValue(input)).To(Equal(expected))


### PR DESCRIPTION
## Description

Fixes handling of the `storage.parameters.excludedStorageClasses` ModuleConfig parameter in the `cloud-provider-dvp` module.

The discovery hook read the exclusion list from the values path `cloudProviderDvp.storageClass.exclude`, which does not exist in the module's configuration schema (neither in v1 nor in v2) — it was inherited from other cloud provider modules. As a result, the documented `storage.parameters.excludedStorageClasses` parameter was silently ignored and all StorageClasses discovered in the parent DVP cluster were created regardless of the exclusion list.

No manual actions are required on update. With an empty `excludedStorageClasses` list (the default) module behavior is unchanged. If the parameter is set, the matching `heritage: deckhouse` StorageClasses are now excluded from module values and removed from the cluster — which is exactly what the parameter is meant to do. No control-plane component restarts are involved.

## Why do we need it, and what problem does it solve?

`storage.parameters.excludedStorageClasses` was introduced together with the DVP ModuleConfig v2 migration and is documented in `openapi/config-values.yaml`, but the hook never read that path. Users who wanted to keep unwanted StorageClasses of the parent DVP cluster out of the tenant cluster had no working way to do so: the parameter was accepted by the ModuleConfig schema, produced no validation error, and had no effect.

This change makes the parameter behave as documented and applies it uniformly to every source of StorageClasses in the module.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cloud-provider-dvp
type: fix
summary: The `storage.parameters.excludedStorageClasses` parameter now actually excludes the matching StorageClasses from creation in the cluster.
impact_level: default
```