### PR TITLE
[deckhouse] add VEX entries for x/image and openpgp findings in the dev image

### DIFF
--- a/deckhouse-controller/known_vulnerabilities.vex
+++ b/deckhouse-controller/known_vulnerabilities.vex
@@ -2,7 +2,7 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-5a4509a04e8128126aee080324a6b663a7748bf44b58a9a4b9c74d4801844f53",
   "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
-  "version": 23,
+  "version": 24,
   "statements": [
     {
       "vulnerability": {
@@ -436,12 +436,18 @@
           "@id": "pkg:golang/golang.org/x/crypto@v0.45.0"
         },
         {
+          "@id": "pkg:golang/golang.org/x/crypto@v0.53.0"
+        },
+        {
           "@id": "pkg:golang/golang.org/x/crypto@v0.54.0"
+        },
+        {
+          "@id": "pkg:golang/golang.org/x/crypto@v0.55.0"
         }
       ],
       "status": "not_affected",
       "justification": "vulnerable_code_not_in_execute_path",
-      "impact_statement": "Пакет golang.org/x/crypto/openpgp признан неподдерживаемым, исправленной версии не существует. В deckhouse-controller он попадает только через helm.sh/helm/v3/pkg/provenance и github.com/werf/3p-helm/pkg/provenance. Проверка провенанс-подписей Helm-чартов не выполняется, код не в пути выполнения.",
+      "impact_statement": "Пакет golang.org/x/crypto/openpgp признан неподдерживаемым, исправленной версии не существует. В бинарнике deckhouse-controller (v0.45.0, v0.54.0) модуль приходит только через helm.sh/helm/v3/pkg/provenance и github.com/werf/3p-helm/pkg/provenance, проверка провенанс-подписей Helm-чартов не выполняется. Версии v0.53.0 и v0.55.0 приходят из бинарников хуков модулей, вложенных в образ, где golang.org/x/crypto тянется транзитивно через github.com/deckhouse/module-sdk -> github.com/cloudflare/cfssl и даёт только пакеты cryptobyte, ed25519, ocsp и pkcs12. Пакет openpgp не импортируется ни в один из бинарников, Trivy размечает модуль целиком по buildinfo.",
       "timestamp": "2026-08-27T12:00:00Z"
     },
     {
@@ -821,8 +827,78 @@
       "justification": "vulnerable_code_not_present",
       "impact_statement": "Модуль golang.org/x/image приходит транзитивно через github.com/flant/addon-operator -> github.com/goccy/go-graphviz. Из модуля используются только декодеры bmp и tiff и парсер шрифтов sfnt. Уязвимость находится в golang.org/x/image/vp8l, который не импортируется и в бинарь не попадает.",
       "timestamp": "2026-09-01T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-33812"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/image@v0.38.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "Модуль golang.org/x/image приходит транзитивно через github.com/flant/addon-operator -> github.com/goccy/go-graphviz. Парсер golang.org/x/image/font/sfnt вызывается при отрисовке подписей графа зависимостей модулей, но разбирает только вкомпилированные в бинарь шрифты golang.org/x/image/font/gofont/goregular и golang.org/x/image/font/basicfont; загрузка внешних шрифтов не предусмотрена. Содержимое шрифта не контролируется извне, поэтому уязвимость не эксплуатируема.",
+      "timestamp": "2026-09-07T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-42500"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/image@v0.38.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Модуль golang.org/x/image приходит транзитивно через github.com/flant/addon-operator -> github.com/goccy/go-graphviz. Уязвимость в golang.org/x/image/bmp достигается только при декодировании изображения, подключённого к графу атрибутом image=; DOT-описание формируется самим addon-operator из графа зависимостей модулей и внешних изображений не содержит. Отрисовка доступна только через debug-сервер addon-operator на unix-сокете внутри пода, функция bmp.Decode на недоверенных данных не вызывается.",
+      "timestamp": "2026-09-07T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-46599"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/image@v0.38.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Модуль golang.org/x/image приходит транзитивно через github.com/flant/addon-operator -> github.com/goccy/go-graphviz. Уязвимость в golang.org/x/image/tiff достигается только при декодировании изображения, подключённого к графу атрибутом image=; DOT-описание формируется самим addon-operator из графа зависимостей модулей и внешних изображений не содержит. Отрисовка доступна только через debug-сервер addon-operator на unix-сокете внутри пода, функция tiff.Decode на недоверенных данных не вызывается.",
+      "timestamp": "2026-09-07T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-46602"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/image@v0.38.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Модуль golang.org/x/image приходит транзитивно через github.com/flant/addon-operator -> github.com/goccy/go-graphviz. Уязвимость в golang.org/x/image/tiff достигается только при декодировании изображения, подключённого к графу атрибутом image=; DOT-описание формируется самим addon-operator из графа зависимостей модулей и внешних изображений не содержит. Отрисовка доступна только через debug-сервер addon-operator на unix-сокете внутри пода, функция tiff.Decode на недоверенных данных не вызывается.",
+      "timestamp": "2026-09-07T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-46604"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/image@v0.38.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Модуль golang.org/x/image приходит транзитивно через github.com/flant/addon-operator -> github.com/goccy/go-graphviz. Уязвимость в golang.org/x/image/tiff достигается только при декодировании изображения, подключённого к графу атрибутом image=; DOT-описание формируется самим addon-operator из графа зависимостей модулей и внешних изображений не содержит. Отрисовка доступна только через debug-сервер addon-operator на unix-сокете внутри пода, функция tiff.Decode на недоверенных данных не вызывается.",
+      "timestamp": "2026-09-07T12:00:00Z"
     }
   ],
   "timestamp": "2026-03-05T12:00:00Z",
-  "last_updated": "2026-09-01T12:00:00Z"
+  "last_updated": "2026-09-07T12:00:00Z"
 }


### PR DESCRIPTION
## Description

Two changes to `deckhouse-controller/known_vulnerabilities.vex`, the document `.werf/defines/vex.tmpl` attaches to the `dev` image.

**1. `golang.org/x/image` — five statements added.**

| CVE | vulnerable package | justification |
|---|---|---|
| CVE-2026-33812 | `font/sfnt` | `vulnerable_code_cannot_be_controlled_by_adversary` |
| CVE-2026-42500 | `bmp` | `vulnerable_code_not_in_execute_path` |
| CVE-2026-46599 | `tiff` | `vulnerable_code_not_in_execute_path` |
| CVE-2026-46602 | `tiff` | `vulnerable_code_not_in_execute_path` |
| CVE-2026-46604 | `tiff` | `vulnerable_code_not_in_execute_path` |

`bmp.Decode` and `tiff.Decode` are reachable only through a graphviz `image=` attribute. The DOT description is generated by addon-operator itself from the module dependency graph and carries no external images, and rendering is exposed only on the addon-operator debug server's unix socket. `font/sfnt` does execute, but parses only the fonts compiled into the binary (`font/gofont/goregular`, `font/basicfont`).

The three neighbouring `x/image` statements use `vulnerable_code_not_present`, which does not fit here: `go list -deps` shows `bmp`, `tiff` and `font/sfnt` are linked, while `webp` and `vp8l` — the packages those three cover — are not.

**2. `GO-2026-5932` — two purls added**, `x/crypto@v0.53.0` and `@v0.55.0`, next to the existing `@v0.45.0` and `@v0.54.0`. These versions come from the module hook binaries bundled in the image, where `x/crypto` arrives through `module-sdk` -> `cloudflare/cfssl` and yields only `cryptobyte`, `ed25519`, `ocsp` and `pkcs12`. The impact statement now names both sources instead of the Helm provenance path alone.

Unchanged: document `@id`, author, statement order, justifications of the existing statements.

## Why do we need it, and what problem does it solve?

Neither group can be closed by a version bump. `GO-2026-5932` has no fixed version at all — the `openpgp` subpackage is unmaintained upstream. `golang.org/x/image` is an indirect dependency, and `goccy/go-graphviz` still requires only `v0.21.0` as of its latest release, so there is no upstream bump to inherit.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: add VEX entries for x/image and openpgp findings in the dev image
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
