### PR TITLE
[istio] Remove unreachable code after 1.21

### DIFF
--- a/modules/110-istio/images/cni-v1x25x2/mount-points.yaml
+++ b/modules/110-istio/images/cni-v1x25x2/mount-points.yaml
@@ -2,8 +2,6 @@ dirs:
 - /host/opt/cni/bin
 - /host/etc/cni/net.d
 - /var/run/istio-cni
-- /run/istio-cni
-- /tmp/istio-cni
 - /host/proc
 - /var/run/ztunnel
 - /host/var/run/netns

--- a/modules/110-istio/images/cni-v1x27x9/mount-points.yaml
+++ b/modules/110-istio/images/cni-v1x27x9/mount-points.yaml
@@ -2,8 +2,6 @@ dirs:
 - /host/opt/cni/bin
 - /host/etc/cni/net.d
 - /var/run/istio-cni
-- /run/istio-cni
-- /tmp/istio-cni
 - /host/proc
 - /var/run/ztunnel
 - /host/var/run/netns

--- a/modules/110-istio/images/cni-v1x29x6/mount-points.yaml
+++ b/modules/110-istio/images/cni-v1x29x6/mount-points.yaml
@@ -2,8 +2,6 @@ dirs:
 - /host/opt/cni/bin
 - /host/etc/cni/net.d
 - /var/run/istio-cni
-- /run/istio-cni
-- /tmp/istio-cni
 - /host/proc
 - /var/run/ztunnel
 - /host/var/run/netns

--- a/modules/110-istio/templates/cni/daemonset.yaml
+++ b/modules/110-istio/templates/cni/daemonset.yaml
@@ -6,7 +6,6 @@ memory: 100Mi
 {{- if eq $.Values.istio.dataPlane.trafficRedirectionSetupMode "CNIPlugin" }}
 {{- $version := $.Values.istio.internal.globalVersion }}
 {{- $versionInfo := get $.Values.istio.internal.versionMap $version }}
-{{- $fullVersion := get $versionInfo "fullVersion" }}
 {{- $imageSuffix := get $versionInfo "imageSuffix" }}
 {{- $supportsAmbient := get $versionInfo "supportsAmbient" }}
 
@@ -60,18 +59,14 @@ spec:
         k8s-app: istio-cni-node
         sidecar.istio.io/inject: "false"
         security.deckhouse.io/security-policy-exception: istio-cni-node
-        {{- if (semverCompare ">= 1.25.0" $fullVersion) }}
         istio.io/dataplane-mode: none
-        {{- end }}
       annotations:
         {{ include "helm_lib_prevent_ds_eviction_annotation" . | nindent 8 }}
         sidecar.istio.io/inject: "false"
-        {{- if (semverCompare ">= 1.25.0" $fullVersion) }}
         prometheus.io/scrape: "true"
         prometheus.io/port: "15014"
         prometheus.io/path: "/metrics"
         container.apparmor.security.beta.kubernetes.io/install-cni: unconfined
-        {{- end }}
     spec:
       {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 6 }}
       automountServiceAccountToken: true
@@ -91,12 +86,10 @@ spec:
         - name: install-cni
           image: {{ include "helm_lib_module_image" (list $ (printf "cni%s" $imageSuffix)) }}
           imagePullPolicy: IfNotPresent
-          {{- if (semverCompare ">= 1.25.0" $fullVersion) }}
           ports:
             - containerPort: 15014
               name: metrics
               protocol: TCP
-          {{- end }}
           readinessProbe:
             failureThreshold: 3
             httpGet:
@@ -115,18 +108,6 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
-          {{- if semverCompare "< 1.25.0" $fullVersion }}
-          securityContext:
-            {{- if and $supportsAmbient $.Values.istio.ambient.enabled }}
-            privileged: true
-            {{- else }}
-            allowPrivilegeEscalation: false
-            {{- end }}
-            readOnlyRootFilesystem: true
-            runAsNonRoot: false
-            runAsUser: 0
-            runAsGroup: 0
-          {{- else }}
           securityContext:
             privileged: false
             readOnlyRootFilesystem: true
@@ -153,18 +134,9 @@ spec:
               # This can cause problems if the hostPath mounts we use, which we require write access into,
               # are owned by non-root. DAC_OVERRIDE bypasses these and gives us write access into any folder.
               - DAC_OVERRIDE
-          {{- end }}
           command: ["install-cni"]
           args:
             - --log_output_level=default:info
-            {{- if semverCompare "< 1.25.0" $fullVersion }}
-            # Before Istio 1.25: hostPath mounted under /tmp for readOnlyRootFilesystem + containerd v2.
-            # CNI JSON on the node still lists /var/run/istio-cni/*.sock.
-            - --log-uds-address=/tmp/istio-cni/log.sock
-            {{- if and $supportsAmbient $.Values.istio.ambient.enabled }}
-            - --cni-event-address=/tmp/istio-cni/pluginevent.sock
-            {{- end }}
-            {{- end }}
           envFrom:
           - configMapRef:
               name: cni-config
@@ -215,7 +187,7 @@ spec:
             {{- end }}
             - mountPath: /host/etc/cni/net.d
               name: cni-net-dir
-            - mountPath: {{ ternary "/tmp/istio-cni" "/var/run/istio-cni" (semverCompare "< 1.25.0" $fullVersion) }}
+            - mountPath: /var/run/istio-cni
               name: cni-socket-dir
             {{- if and $supportsAmbient $.Values.istio.ambient.enabled }}
             - mountPath: /host/var/run/netns
@@ -223,10 +195,6 @@ spec:
               name: cni-netns-dir
             - mountPath: /var/run/ztunnel
               name: cni-ztunnel-sock-dir
-            {{- end }}
-            {{- if semverCompare "< 1.25.0" $fullVersion }}
-            - mountPath: /run/istio-cni
-              name: cni-socket-dir
             {{- end }}
             - mountPath: /tmp
               name: install-cni-tmp

--- a/modules/110-istio/templates/kiali/configmap.yaml
+++ b/modules/110-istio/templates/kiali/configmap.yaml
@@ -1,6 +1,5 @@
 {{- $versionInfo := get .Values.istio.internal.versionMap .Values.istio.internal.globalVersion }}
 {{- $revision := get $versionInfo "revision" }}
-{{- $fullVersion := get $versionInfo "fullVersion" }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -34,9 +33,7 @@ data:
         istiod_deployment_name: istiod-{{ $revision }}
         config_map_name: istio-{{ $revision }}
         istio_sidecar_injector_config_map_name: istio-sidecar-injector-{{ $revision }}
-{{- if (semverCompare ">= 1.25.0" $fullVersion) }}
         validation_reconcile_interval: 5m
-{{- end }}
       prometheus:
         url: https://trickster.d8-monitoring/trickster/main
         auth:


### PR DESCRIPTION
## Description

Removes Helm template branches in the `istio` module that became unreachable after support for Istio versions below 1.25 was dropped, and simplifies conditions that are now always true for the currently supported versions (1.25 / 1.27 / 1.29).

- `templates/cni/daemonset.yaml`: removed the dead `< 1.25.0` branch for the `install-cni` container's `securityContext`, `args` and `volumeMounts`; made the `>= 1.25.0` label/annotations/`ports` blocks unconditional; dropped the now-unused `$fullVersion` variable.
- `templates/kiali/configmap.yaml`: made `validation_reconcile_interval` unconditional; dropped the now-unused `$fullVersion` variable.
- `images/cni-v1x25x2|v1x27x9|v1x29x6/mount-points.yaml`: removed `/run/istio-cni` and `/tmp/istio-cni`, which were only referenced by the now-removed branch.

Pure refactor / dead-code removal — no rendered manifest changes for any currently supported Istio version, no impact on running workloads or control-plane components.

## Why do we need it, and what problem does it solve?

Support for Istio versions below 1.25 was already removed from the module (only 1.25.2, 1.27.9 and 1.29.6 images/versionMap entries remain), but the `semverCompare "< 1.25.0"` / `">= 1.25.0"` template gates guarding version-specific behavior were left in place. This left dead code behind (a branch that can never execute) and redundant "always true" checks, making the templates harder to read and maintain. Cleaning this up keeps the templates in sync with the actual set of supported versions and removes stale `mount-points.yaml` entries that no longer correspond to any real mount

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: chore
summary: Removed unreachable code after 1.21
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
