### PR TITLE
[candi] add required plugins erofs snapshotter  for cv2

### DIFF
--- a/candi/bashible/common-steps/all/032_configure_containerd.sh.tpl
+++ b/candi/bashible/common-steps/all/032_configure_containerd.sh.tpl
@@ -73,7 +73,7 @@ root = "/var/lib/containerd"
 state = "/run/containerd"
 plugin_dir = ""
 disabled_plugins = []
-required_plugins = []
+required_plugins = ["io.containerd.snapshotter.v1.erofs"]
 oom_score = 0
 
 [grpc]

--- a/modules/007-registrypackages/images/containerd/scripts/containerd.service
+++ b/modules/007-registrypackages/images/containerd/scripts/containerd.service
@@ -2,10 +2,12 @@
 Description=containerd container runtime
 Documentation=https://containerd.io
 After=network.target local-fs.target
+StartLimitIntervalSec=0
 
 [Service]
 Environment="PATH=/opt/deckhouse/bin:/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin"
 ExecStartPre=-/sbin/modprobe overlay
+ExecStartPre=-/sbin/modprobe erofs
 ExecStartPost=-/opt/deckhouse/bin/ctr -n k8s.io images import /opt/deckhouse/images/pause.tar
 ExecStartPost=-/opt/deckhouse/bin/ctr -n k8s.io images label deckhouse.local/images:pause io.cri-containerd.pinned=pinned
 ExecStartPost=-/opt/deckhouse/bin/ctr -n k8s.io images import /opt/deckhouse/images/kubernetes-api-proxy.tar


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

`io.containerd.snapshotter.v1.erofs` is now listed in `required_plugins` of the containerd v2 config, and `containerd-deckhouse.service` loads the module in `ExecStartPre` with the systemd start rate limit disabled.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Without the `erofs` module containerd v2 loses its CRI plugin but keeps running, so the node breaks silently and surfaces as `kubelet` failing with `validate CRI v1 runtime API for endpoint` until someone runs `modprobe erofs` manually.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

Nodes running `ContainerdV2` can silently end up without CRI after a reboot and require manual intervention to recover.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: containerd v2 no longer starts without the `erofs` snapshotter, and loads the `erofs` module before start.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
