### PR TITLE
[ci] fix fuzz werf cache

### DIFF
--- a/.github/ci_templates/build_fuzz.yml
+++ b/.github/ci_templates/build_fuzz.yml
@@ -109,6 +109,7 @@ steps:
 {!{- if $isDev }!}
       # PR/dev: build locally, do not push fuzz images; no build-report upload
       DEV_REGISTRY_PATH="${DECKHOUSE_DEV_REGISTRY_HOST}/${REGISTRY_PATH}"
+      export WERF_PROJECT_NAME="deckhouse-fuzz-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
       export WERF_SECONDARY_REPO_1="${DEV_REGISTRY_PATH}"
       unset WERF_REPO
       echo "dev fuzz build: local only, cache from ${WERF_SECONDARY_REPO_1} (no registry push, no build-report upload)"

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -1242,6 +1242,7 @@ jobs:
           echo "Corpus replay path prefix: anomaloys-materials/${FUZZ_S3_REPOSITORY}/${FUZZ_S3_BRANCH_SLUG}/"
           # PR/dev: build locally, do not push fuzz images; no build-report upload
           DEV_REGISTRY_PATH="${DECKHOUSE_DEV_REGISTRY_HOST}/${REGISTRY_PATH}"
+          export WERF_PROJECT_NAME="deckhouse-fuzz-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           export WERF_SECONDARY_REPO_1="${DEV_REGISTRY_PATH}"
           unset WERF_REPO
           echo "dev fuzz build: local only, cache from ${WERF_SECONDARY_REPO_1} (no registry push, no build-report upload)"


### PR DESCRIPTION
## Description

Assign each PR fuzz build a unique `WERF_PROJECT_NAME` based on `GITHUB_RUN_ID` and `GITHUB_RUN_ATTEMPT`. Regenerate the dev workflow.

This change affects CI only and does not restart cluster components.

## Why do we need it, and what problem does it solve?

Fuzz builds share the runner's local `deckhouse` stage cache with other jobs. Existing local stages can therefore bypass the intended secondary-registry lookup.

A unique project name gives each PR fuzz run a separate local stage cache. Matching stages are reused from the secondary registry, while newly built stages remain local because `WERF_REPO` is unset. No global runner cache cleanup is required.

Validated in deckhouse-test-2 with a change outside `user-authn`: the PR fuzz job reused stages from the secondary registry without publishing images. Both PR and main workflows completed successfully.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist

- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
- [x] PR and main CI workflows passed in the test repository.

Unit tests, e2e tests, documentation changes, and manual cluster testing are not applicable to this CI configuration change.

## Changelog entries

```changes
section: ci
type: fix
summary: Isolate the local stage cache for each PR fuzz build while preserving secondary registry cache reuse.
impact_level: low
```