### PR TITLE
[user-authz] Exempt platform identities from the identity collision check

### DIFF
--- a/modules/140-user-authz/webhooks/validating/identity_collision.py
+++ b/modules/140-user-authz/webhooks/validating/identity_collision.py
@@ -37,8 +37,19 @@
 # would take the whole hook down in a cluster where user-authz is disabled. Here the dependency is
 # the other way round and is harmless: the validating rules below name resources owned by
 # user-authn, and if that module is disabled its CRDs are absent, the rules simply never match.
+#
+# The check is about a requester who may create a User or a Group but does not own the rules that
+# would pick it up. The identities that install and operate the platform are not that requester:
+# the installer applies the initial ClusterAuthorizationRule and the User it names from one manifest,
+# in whatever order the objects land, and on a retried bootstrap the rule already exists when the
+# User is created again, so the check would refuse the installer for granting privileges to itself.
+# Those identities are excluded twice: in matchConditions, so the API server does not call the hook
+# for them at all (and keeps them working while the hook is unavailable, which matters under
+# failurePolicy: Fail), and again inside the hook, because matchConditions are a pre-filter and not
+# the authority. The list is the platform's own break-glass set, the same one the heritage
+# ValidatingAdmissionPolicies exclude (modules/002-deckhouse/templates/validation.yaml).
 
-from typing import Callable, NamedTuple, Optional
+from typing import Any, Callable, NamedTuple, Optional
 
 from deckhouse import hook
 from dotmap import DotMap
@@ -46,11 +57,65 @@ from dotmap import DotMap
 CLUSTER_RULES_SNAPSHOT_NAME = "d8-user-authz-collision-cluster-authorization-rules"
 NAMESPACED_RULES_SNAPSHOT_NAME = "d8-user-authz-collision-authorization-rules"
 
+EXEMPT_USERS = frozenset({
+    "system:apiserver",
+    "system:sudouser",
+    "system:kube-controller-manager",
+    "system:kube-scheduler",
+    "system:volume-scheduler",
+    "dhctl",
+    "observability",
+    "system:serviceaccount:d8-system:deckhouse",
+    # Commander's cluster-manager applies the initial User and rule the same way the installer
+    # does. The service account only, not the d8-commander group: backend, sidekiq and the rest of
+    # that namespace stay subject to the check (same skip as user-authn's allow-access-to-kubernetes
+    # policy, modules/150-user-authn/templates/validation.yaml).
+    "system:serviceaccount:d8-commander:cluster-manager",
+})
+
+EXEMPT_GROUPS = frozenset({
+    "system:masters",
+    "system:serviceaccounts:kube-system",
+    "system:serviceaccounts:d8-system",
+})
+
+# One condition per identity, in the form the admission documentation guarantees: a CEL expression
+# that fails to compile invalidates the whole ValidatingWebhookConfiguration. Kept in step with
+# EXEMPT_USERS / EXEMPT_GROUPS above by the config contract test.
+MATCH_CONDITIONS = """
+  - expression: ("system:apiserver" != request.userInfo.username)
+    name: exclude-kube-apiserver
+  - expression: ("system:sudouser" != request.userInfo.username)
+    name: exclude-sudouser
+  - expression: ("system:kube-controller-manager" != request.userInfo.username)
+    name: exclude-kube-controller-manager
+  - expression: ("system:kube-scheduler" != request.userInfo.username)
+    name: exclude-kube-scheduler
+  - expression: ("system:volume-scheduler" != request.userInfo.username)
+    name: exclude-volume-scheduler
+  - expression: ("dhctl" != request.userInfo.username)
+    name: exclude-dhctl
+  - expression: ("observability" != request.userInfo.username)
+    name: exclude-observability
+  - expression: ("system:serviceaccount:d8-system:deckhouse" != request.userInfo.username)
+    name: exclude-deckhouse
+  - expression: ("system:serviceaccount:d8-commander:cluster-manager" != request.userInfo.username)
+    name: exclude-commander-cluster-manager
+  - expression: '!("system:masters" in request.userInfo.groups)'
+    name: exclude-system-masters
+  - expression: '!("system:serviceaccounts:kube-system" in request.userInfo.groups)'
+    name: exclude-kube-system-serviceaccounts
+  - expression: '!("system:serviceaccounts:d8-system" in request.userInfo.groups)'
+    name: exclude-d8-system-serviceaccounts
+""".strip("\n")
+
 CONFIG = f"""
 configVersion: v1
 kubernetesValidating:
 - name: d8-user-authz-group-authorization-rule-collision.deckhouse.io
   includeSnapshotsFrom: ["{CLUSTER_RULES_SNAPSHOT_NAME}", "{NAMESPACED_RULES_SNAPSHOT_NAME}"]
+  matchConditions:
+{MATCH_CONDITIONS}
   rules:
   - apiGroups:   ["deckhouse.io"]
     apiVersions: ["*"]
@@ -59,6 +124,8 @@ kubernetesValidating:
     scope:       "Cluster"
 - name: d8-user-authz-user-authorization-rule-collision.deckhouse.io
   includeSnapshotsFrom: ["{CLUSTER_RULES_SNAPSHOT_NAME}", "{NAMESPACED_RULES_SNAPSHOT_NAME}"]
+  matchConditions:
+{MATCH_CONDITIONS}
   rules:
   - apiGroups:   ["deckhouse.io"]
     apiVersions: ["*"]
@@ -148,8 +215,20 @@ def main(ctx: hook.Context):
         ctx.output.validations.error(str(e))
 
 
+def is_exempt(user_info: Any) -> bool:
+    """Whether the requester is one of the platform identities the check does not apply to."""
+    info = user_info.toDict() if hasattr(user_info, "toDict") else (user_info or {})
+    if info.get("username") in EXEMPT_USERS:
+        return True
+    groups = info.get("groups") or []
+    return any(isinstance(g, str) and g in EXEMPT_GROUPS for g in groups)
+
+
 def validate(ctx: DotMap) -> tuple[Optional[str], list[str]]:
     req = ctx.review.request
+    if is_exempt(req.userInfo):
+        return None, []
+
     identity = IDENTITY_KINDS.get(req.kind.kind.lower())
     if identity is None:
         return None, []

--- a/modules/140-user-authz/webhooks/validating/identity_collision_test.py
+++ b/modules/140-user-authz/webhooks/validating/identity_collision_test.py
@@ -238,6 +238,87 @@ class TestIdentityCollisionWithAuthorizationRules(unittest.TestCase):
 
 
 @unittest.skipUnless(shutil.which("jq"), "jq is required to execute the hook's jqFilter programs")
+class TestPlatformIdentitiesAreExempt(unittest.TestCase):
+    """
+    The installer applies the initial rule and the User it names from one manifest, and on a
+    retried bootstrap the rule is already there when the User is created again. The platform's
+    own identities are therefore not subject to the check, neither in the API server pre-filter
+    nor in the hook itself.
+    """
+
+    def run_hook(self, context_json: str):
+        return hook.testrun(identity_collision.main, [DotMap(json.loads(context_json))])
+
+    def assert_silently_allowed(self, out):
+        self.assertEqual(len(out.validations.data), 1)
+        self.assertTrue(out.validations.data[0]["allowed"])
+        self.assertNotIn("warnings", out.validations.data[0])
+
+    INSTALLER = {"username": "dhctl", "groups": ["system:masters", "system:authenticated"]}
+    ADMIN_CONF = {"username": "kubernetes-admin", "groups": ["system:masters"]}
+    DECKHOUSE = {"username": "system:serviceaccount:d8-system:deckhouse",
+                 "groups": ["system:serviceaccounts", "system:serviceaccounts:d8-system"]}
+    KUBE_SYSTEM_SA = {"username": "system:serviceaccount:kube-system:argocd",
+                      "groups": ["system:serviceaccounts:kube-system"]}
+    COMMANDER = {"username": "system:serviceaccount:d8-commander:cluster-manager",
+                 "groups": ["system:serviceaccounts", "system:serviceaccounts:d8-commander"]}
+    COMMANDER_BACKEND = {"username": "system:serviceaccount:d8-commander:backend",
+                         "groups": ["system:serviceaccounts", "system:serviceaccounts:d8-commander"]}
+
+    def test_installer_recreates_user_named_by_an_existing_rule(self):
+        out = self.run_hook(factories.prepare_user_binding_context(
+            factories.CLUSTER_RULE_USER_SUBJECT, user_info=self.INSTALLER))
+        self.assert_silently_allowed(out)
+
+    def test_installer_recreates_group_named_by_an_existing_rule(self):
+        out = self.run_hook(factories.prepare_group_binding_context(
+            factories.CLUSTER_RULE_GROUP_SUBJECT, user_info=self.INSTALLER))
+        self.assert_silently_allowed(out)
+
+    def test_admin_kubeconfig_is_exempt_by_group(self):
+        out = self.run_hook(factories.prepare_user_binding_context(
+            factories.CLUSTER_RULE_USER_SUBJECT, user_info=self.ADMIN_CONF))
+        self.assert_silently_allowed(out)
+
+    def test_deckhouse_and_kube_system_serviceaccounts_are_exempt(self):
+        for info in (self.DECKHOUSE, self.KUBE_SYSTEM_SA):
+            out = self.run_hook(factories.prepare_user_binding_context(
+                factories.CLUSTER_RULE_USER_SUBJECT, user_info=info))
+            self.assert_silently_allowed(out)
+
+    def test_commander_cluster_manager_is_exempt_but_not_its_namespace(self):
+        out = self.run_hook(factories.prepare_user_binding_context(
+            factories.CLUSTER_RULE_USER_SUBJECT, user_info=self.COMMANDER))
+        self.assert_silently_allowed(out)
+        out = self.run_hook(factories.prepare_user_binding_context(
+            factories.CLUSTER_RULE_USER_SUBJECT, user_info=self.COMMANDER_BACKEND))
+        self.assertFalse(out.validations.data[0]["allowed"])
+
+    def test_exempt_delete_raises_no_warning(self):
+        out = self.run_hook(factories.prepare_user_binding_context(
+            factories.CLUSTER_RULE_USER_SUBJECT, operation="DELETE", user_info=self.INSTALLER))
+        self.assert_silently_allowed(out)
+
+    def test_ordinary_requester_is_still_denied(self):
+        out = self.run_hook(factories.prepare_user_binding_context(
+            factories.CLUSTER_RULE_USER_SUBJECT,
+            user_info={"username": "helpdesk@example.com", "groups": ["system:authenticated"]}))
+        self.assertFalse(out.validations.data[0]["allowed"])
+
+    def test_match_conditions_mirror_the_in_hook_list(self):
+        config = yaml.safe_load(identity_collision.CONFIG)
+        for webhook in config["kubernetesValidating"]:
+            conditions = {c["name"]: c["expression"] for c in webhook["matchConditions"]}
+            self.assertEqual(len(conditions), len(webhook["matchConditions"]), "duplicate names")
+            joined = " ".join(conditions.values())
+            for user in identity_collision.EXEMPT_USERS:
+                self.assertIn(f'("{user}" != request.userInfo.username)', joined, user)
+            for group in identity_collision.EXEMPT_GROUPS:
+                self.assertIn(f'!("{group}" in request.userInfo.groups)', joined, group)
+            self.assertEqual(len(conditions),
+                             len(identity_collision.EXEMPT_USERS) + len(identity_collision.EXEMPT_GROUPS))
+
+
 class TestSnapshotJQFilters(unittest.TestCase):
     """
     Run the jqFilter programs from CONFIG the way shell-operator would.

--- a/modules/140-user-authz/webhooks/validating/identity_collision_test_factories.py
+++ b/modules/140-user-authz/webhooks/validating/identity_collision_test_factories.py
@@ -77,7 +77,8 @@ def _binding_context(kind: str, resource: str, webhook: str, operation: str,
                      spec: typing.Optional[dict], old_spec: typing.Optional[dict],
                      acknowledged: bool, with_rules: bool,
                      cluster_rule_group_subjects: typing.Optional[list] = None,
-                     cluster_rule_user_subjects: typing.Optional[list] = None) -> str:
+                     cluster_rule_user_subjects: typing.Optional[list] = None,
+                     user_info: typing.Optional[dict] = None) -> str:
     metadata = {"name": "test-object"}
     if acknowledged:
         metadata["annotations"] = {COLLISION_ANNOTATION: "true"}
@@ -104,7 +105,9 @@ def _binding_context(kind: str, resource: str, webhook: str, operation: str,
                 "resource": {"group": "deckhouse.io", "version": "v1", "resource": resource},
                 "name": "test-object",
                 "operation": operation,
-                "userInfo": {"username": "kubernetes-admin", "groups": ["system:masters"]},
+                # An ordinary requester with rights on the CRD, not one of the platform
+                # identities the check excludes. Tests that need those pass user_info.
+                "userInfo": user_info or {"username": "helpdesk@example.com", "groups": []},
                 "object": obj,
                 "oldObject": old_obj,
                 "dryRun": False,
@@ -121,14 +124,15 @@ def prepare_group_binding_context(group_name: str, operation: str = "CREATE",
                                   acknowledged: bool = False,
                                   with_rules: bool = True,
                                   with_old_object: bool = True,
-                                  cluster_rule_group_subjects: typing.Optional[list] = None) -> str:
+                                  cluster_rule_group_subjects: typing.Optional[list] = None,
+                                  user_info: typing.Optional[dict] = None) -> str:
     if operation == "DELETE":
         return _binding_context(
             kind="Group", resource="groups",
             webhook="d8-user-authz-group-authorization-rule-collision.deckhouse.io",
             operation=operation, spec=None, old_spec={"name": group_name, "members": []},
             acknowledged=acknowledged, with_rules=with_rules,
-            cluster_rule_group_subjects=cluster_rule_group_subjects,
+            cluster_rule_group_subjects=cluster_rule_group_subjects, user_info=user_info,
         )
 
     # with_old_object=False models an UPDATE whose oldObject the hook cannot read.
@@ -141,7 +145,7 @@ def prepare_group_binding_context(group_name: str, operation: str = "CREATE",
         spec={"name": group_name, "members": []},
         old_spec=old_spec,
         acknowledged=acknowledged, with_rules=with_rules,
-        cluster_rule_group_subjects=cluster_rule_group_subjects,
+        cluster_rule_group_subjects=cluster_rule_group_subjects, user_info=user_info,
     )
 
 
@@ -150,14 +154,15 @@ def prepare_user_binding_context(email: str, operation: str = "CREATE",
                                  acknowledged: bool = False,
                                  with_rules: bool = True,
                                  with_old_object: bool = True,
-                                 cluster_rule_user_subjects: typing.Optional[list] = None) -> str:
+                                 cluster_rule_user_subjects: typing.Optional[list] = None,
+                                 user_info: typing.Optional[dict] = None) -> str:
     if operation == "DELETE":
         return _binding_context(
             kind="User", resource="users",
             webhook="d8-user-authz-user-authorization-rule-collision.deckhouse.io",
             operation=operation, spec=None, old_spec={"email": email},
             acknowledged=acknowledged, with_rules=with_rules,
-            cluster_rule_user_subjects=cluster_rule_user_subjects,
+            cluster_rule_user_subjects=cluster_rule_user_subjects, user_info=user_info,
         )
 
     old_spec = None if operation == "CREATE" or not with_old_object else {"email": old_email}
@@ -166,7 +171,7 @@ def prepare_user_binding_context(email: str, operation: str = "CREATE",
         webhook="d8-user-authz-user-authorization-rule-collision.deckhouse.io",
         operation=operation, spec={"email": email}, old_spec=old_spec,
         acknowledged=acknowledged, with_rules=with_rules,
-        cluster_rule_user_subjects=cluster_rule_user_subjects,
+        cluster_rule_user_subjects=cluster_rule_user_subjects, user_info=user_info,
     )
 
 


### PR DESCRIPTION
## Description

The `identity_collision` webhook (`d8-user-authz-*-authorization-rule-collision.deckhouse.io`) refuses to create a `User` or a `Group` whose identity is already a subject of a `ClusterAuthorizationRule` / `AuthorizationRule`, unless the collision is acknowledged with an annotation. It applied to every requester, including the platform itself.

This PR excludes the platform's own identities from the check, in two places:

- `matchConditions` on both webhooks, so the API server does not call the hook for them at all and they keep working while the hook is unavailable (`failurePolicy: Fail`);
- the same list inside the hook, since `matchConditions` are a pre-filter and not the authority.

The set is the platform's break-glass list, the same one the heritage ValidatingAdmissionPolicies exclude: `system:apiserver`, `system:sudouser`, `system:kube-controller-manager`, `system:kube-scheduler`, `system:volume-scheduler`, `dhctl`, `observability`, the `d8-system:deckhouse` ServiceAccount, Commander's `d8-commander:cluster-manager` ServiceAccount (the service account only; the rest of that namespace stays subject to the check), and the groups `system:masters`, `system:serviceaccounts:kube-system`, `system:serviceaccounts:d8-system`. Every other webhook of the module already has such a list; this one was the only exception.

Test fixtures used to run every case as `kubernetes-admin` in `system:masters`; they now run as an ordinary requester, and the exempt identities are covered explicitly, including a config contract test that keeps `matchConditions` in step with the in-hook list.

## Why do we need it, and what problem does it solve?

The installer applies the initial `ClusterAuthorizationRule` and the `User` it names from one manifest. On a first bootstrap the User usually lands before the rule reaches the webhook's snapshot, so it passes. On a retried bootstrap (for example after nodes were late to join) the rule from the previous attempt already exists, and the webhook refuses the installer's `User` for granting privileges to itself:

```
admission webhook "d8-user-authz-user-authorization-rule-collision.deckhouse.io" denied the request:
users.deckhouse.io ".spec.email" "admin@example.com" is already granted privileges by
clusterauthorizationrules.deckhouse.io "admin"; use a different value or set the
"user-authz.deckhouse.io/allow-authorization-rule-collision: true" annotation to confirm the collision
```

The installer runs as `dhctl` in `system:masters` and by design treats admission denials as transient, so the bootstrap ends in a ten-minute `Timeout while "Create deckhouse.io/v1, Kind=User resources"` instead of a clear error. The getting-started manifests and cluster-management tooling that drive the installer carry no annotation, so every retried installation on 1.76.11+ / 1.77.0+ hits this.

Excluding the installer does not weaken the check: `system:masters` is the API server's superuser and can create the same rule itself. The protection against an ordinary requester quietly attaching a local identity to someone else's rule stays for everyone else.

## Why do we need it in the patch release (if we do)?

The check was introduced in 1.76.11 and 1.77.0 (#22218, #22359, #22352). Since then a retried bootstrap of a new cluster fails without manual intervention on every release carrying it.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authz
type: fix
summary: The identity collision check no longer applies to the platform's own identities, so a retried bootstrap creates the initial User again instead of timing out.
impact: |
  The installer, the deckhouse ServiceAccount, holders of the cluster
  administrator kubeconfig and the kube-system / d8-system ServiceAccounts
  can create a User or a Group named by an existing authorization rule
  without the acknowledgement annotation. Every other requester is checked
  as before.
impact_level: low
```
