### PR TITLE
[helm_lib] Update lib-helm to 1.72.17 and drop the DRBD tolerations from template tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -648,7 +648,7 @@ CODE_GENERATOR_VERSION ?= v0.34.8
 YQ_VERSION ?= v4.47.2
 GOTESTSUM_VERSION ?= v1.13.0
 ## Pinned lib-helm version, mirrored from helm_lib/Chart.yaml by "make update-lib-helm".
-LIB_HELM_VERSION ?= 1.72.14
+LIB_HELM_VERSION ?= 1.72.17
 
 ## Generate werf
 .PHONY: generate-werf

--- a/ee/modules/030-cloud-provider-dynamix/template_tests/module_test.go
+++ b/ee/modules/030-cloud-provider-dynamix/template_tests/module_test.go
@@ -128,9 +128,6 @@ const tolerationsAnyNodeWithUninitialized = `
   operator: "Exists"
 - key: DeletionCandidateOfClusterAutoscaler
 - key: ToBeDeletedByClusterAutoscaler
-- key: drbd.linbit.com/lost-quorum
-- key: drbd.linbit.com/force-io-error
-- key: drbd.linbit.com/ignore-fail-over
 - effect: NoSchedule
   key: node.deckhouse.io/bashible-uninitialized
   operator: Exists

--- a/ee/modules/030-cloud-provider-huaweicloud/template_tests/module_test.go
+++ b/ee/modules/030-cloud-provider-huaweicloud/template_tests/module_test.go
@@ -148,9 +148,6 @@ const tolerationsAnyNodeWithUninitialized = `
   operator: "Exists"
 - key: DeletionCandidateOfClusterAutoscaler
 - key: ToBeDeletedByClusterAutoscaler
-- key: drbd.linbit.com/lost-quorum
-- key: drbd.linbit.com/force-io-error
-- key: drbd.linbit.com/ignore-fail-over
 - effect: NoSchedule
   key: node.deckhouse.io/bashible-uninitialized
   operator: Exists

--- a/ee/modules/030-cloud-provider-openstack/template_tests/module_test.go
+++ b/ee/modules/030-cloud-provider-openstack/template_tests/module_test.go
@@ -138,9 +138,6 @@ const tolerationsAnyNodeWithUninitialized = `
   operator: "Exists"
 - key: DeletionCandidateOfClusterAutoscaler
 - key: ToBeDeletedByClusterAutoscaler
-- key: drbd.linbit.com/lost-quorum
-- key: drbd.linbit.com/force-io-error
-- key: drbd.linbit.com/ignore-fail-over
 - effect: NoSchedule
   key: node.deckhouse.io/bashible-uninitialized
   operator: Exists

--- a/ee/modules/030-cloud-provider-vcd/template_tests/module_test.go
+++ b/ee/modules/030-cloud-provider-vcd/template_tests/module_test.go
@@ -279,9 +279,6 @@ const tolerationsAnyNodeWithUninitialized = `
   operator: "Exists"
 - key: DeletionCandidateOfClusterAutoscaler
 - key: ToBeDeletedByClusterAutoscaler
-- key: drbd.linbit.com/lost-quorum
-- key: drbd.linbit.com/force-io-error
-- key: drbd.linbit.com/ignore-fail-over
 - effect: NoSchedule
   key: node.deckhouse.io/bashible-uninitialized
   operator: Exists

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/template_tests/module_test.go
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/template_tests/module_test.go
@@ -584,9 +584,6 @@ const tolerationsAnyNodeWithUninitialized = `
   operator: "Exists"
 - key: DeletionCandidateOfClusterAutoscaler
 - key: ToBeDeletedByClusterAutoscaler
-- key: drbd.linbit.com/lost-quorum
-- key: drbd.linbit.com/force-io-error
-- key: drbd.linbit.com/ignore-fail-over
 - effect: NoSchedule
   key: node.deckhouse.io/bashible-uninitialized
   operator: Exists

--- a/ee/se-plus/modules/030-cloud-provider-zvirt/template_tests/module_test.go
+++ b/ee/se-plus/modules/030-cloud-provider-zvirt/template_tests/module_test.go
@@ -97,9 +97,6 @@ const tolerationsAnyNodeWithUninitialized = `
   operator: "Exists"
 - key: DeletionCandidateOfClusterAutoscaler
 - key: ToBeDeletedByClusterAutoscaler
-- key: drbd.linbit.com/lost-quorum
-- key: drbd.linbit.com/force-io-error
-- key: drbd.linbit.com/ignore-fail-over
 - effect: NoSchedule
   key: node.deckhouse.io/bashible-uninitialized
   operator: Exists

--- a/ee/se-plus/modules/030-csi-vsphere/template_tests/module_test.go
+++ b/ee/se-plus/modules/030-csi-vsphere/template_tests/module_test.go
@@ -185,9 +185,6 @@ const tolerationsAnyNodeWithUninitialized = `
   operator: "Exists"
 - key: DeletionCandidateOfClusterAutoscaler
 - key: ToBeDeletedByClusterAutoscaler
-- key: drbd.linbit.com/lost-quorum
-- key: drbd.linbit.com/force-io-error
-- key: drbd.linbit.com/ignore-fail-over
 - effect: NoSchedule
   key: node.deckhouse.io/bashible-uninitialized
   operator: Exists

--- a/helm_lib/Chart.lock
+++ b/helm_lib/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: deckhouse_lib_helm
   repository: https://deckhouse.github.io/lib-helm
-  version: 1.72.14
-digest: sha256:797db50685dd232d3125d740cdccb477ce5d23ea835fd8aefe3be5ddd12dc66c
-generated: "2026-08-10T17:29:32.276732+03:00"
+  version: 1.72.17
+digest: sha256:522c5966a9e704a980353045221158b35203ed61503eec1e494c59229341ea7f
+generated: "2026-09-07T16:35:44.050279838+03:00"

--- a/helm_lib/Chart.yaml
+++ b/helm_lib/Chart.yaml
@@ -5,5 +5,5 @@ version: 0.1.0
 description: Helm helpers
 dependencies:
   - name: deckhouse_lib_helm
-    version: "1.72.14"
+    version: "1.72.17"
     repository: https://deckhouse.github.io/lib-helm

--- a/helm_lib/charts/deckhouse_lib_helm/Chart.yaml
+++ b/helm_lib/charts/deckhouse_lib_helm/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: Helm utils template definitions for Deckhouse modules.
 name: deckhouse_lib_helm
 type: library
-version: 1.72.14
+version: 1.72.17

--- a/helm_lib/charts/deckhouse_lib_helm/README.md
+++ b/helm_lib/charts/deckhouse_lib_helm/README.md
@@ -1608,7 +1608,7 @@ list:
 
 #### Usage
 
-`{{ include "helm_lib_tolerations" (tuple . "any-node" "with-uninitialized" "without-storage-problems") }} `
+`{{ include "helm_lib_tolerations" (tuple . "any-node" "with-uninitialized") }} `
 
 #### Arguments
 
@@ -1704,11 +1704,11 @@ list:
 
 ### _helm_lib_additional_tolerations_storage_problems
 
- Additional strategy "storage-problems" - used for shedule critical components on nodes with drbd problems. This additional strategy enabled by default in any base strategy except "wildcard". 
+ Additional strategy "storage-problems" - deprecated, renders nothing. It used to tolerate the DRBD taints drbd.linbit.com/lost-quorum, drbd.linbit.com/force-io-error and drbd.linbit.com/ignore-fail-over on every base strategy except "wildcard". Nothing sets those taints anymore, so the strategy is kept as a no-op to let existing "with-storage-problems" and "without-storage-problems" call sites keep rendering, and will be removed once they are gone. 
 
 #### Usage
 
-`{{ include "helm_lib_tolerations" (tuple . "any-node" "without-storage-problems") }} `
+`{{ include "helm_lib_tolerations" (tuple . "any-node" "with-storage-problems") }} `
 
 
 

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_csi_controller.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_csi_controller.tpl
@@ -156,55 +156,63 @@ spec:
   updatePolicy:
     updateMode: "InPlaceOrRecreate"
   resourcePolicy:
+    {{- /* The recommender runs with --round-memory-bytes=67108864, so it never emits a memory
+           recommendation below 64Mi and always rounds up to a multiple of it. A maxAllowed.memory
+           that is not a multiple of 64Mi wastes the remainder; one below 64Mi caps every
+           recommendation unconditionally. It also splits --pod-recommendation-min-cpu-millicores=25
+           evenly across the containers of a pod, so a maxAllowed.cpu below 25m is always binding
+           for a single-container pod. Ceilings here are multiples of 64Mi covering the observed
+           7-day peaks with headroom; raising them reserves nothing, since container requests come
+           from minAllowed. */}}
     containerPolicies:
     - containerName: "provisioner"
       minAllowed:
         {{- include "provisioner_resources" $context | nindent 8 }}
       maxAllowed:
-        cpu: 20m
-        memory: 50Mi
+        cpu: 50m
+        memory: 128Mi
     - containerName: "attacher"
       minAllowed:
         {{- include "attacher_resources" $context | nindent 8 }}
       maxAllowed:
-        cpu: 20m
-        memory: 50Mi
+        cpu: 50m
+        memory: 128Mi
     {{- if $resizerEnabled }}
     - containerName: "resizer"
       minAllowed:
         {{- include "resizer_resources" $context | nindent 8 }}
       maxAllowed:
-        cpu: 20m
-        memory: 50Mi
+        cpu: 50m
+        memory: 128Mi
     {{- end }}
     {{- if and $syncerEnabled $syncerImage }}
     - containerName: "syncer"
       minAllowed:
         {{- include "syncer_resources" $context | nindent 8 }}
       maxAllowed:
-        cpu: 20m
-        memory: 50Mi
+        cpu: 50m
+        memory: 128Mi
     {{- end }}
     {{- if $snapshotterEnabled }}
     - containerName: "snapshotter"
       minAllowed:
         {{- include "snapshotter_resources" $context | nindent 8 }}
       maxAllowed:
-        cpu: 20m
-        memory: 50Mi
+        cpu: 50m
+        memory: 128Mi
     {{- end }}
     - containerName: "livenessprobe"
       minAllowed:
         {{- include "livenessprobe_resources" $context | nindent 8 }}
       maxAllowed:
-        cpu: 20m
-        memory: 50Mi
+        cpu: 25m
+        memory: 64Mi
     - containerName: "controller"
       minAllowed:
         {{- include "controller_resources" $context | nindent 8 }}
       maxAllowed:
-        cpu: 20m
-        memory: 100Mi
+        cpu: 100m
+        memory: 256Mi
     {{- if $additionalControllerVPA }}
     {{- $additionalControllerVPA | toYaml | nindent 4 }}
     {{- end }}

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_csi_node.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_csi_node.tpl
@@ -24,6 +24,7 @@ memory: 25Mi
   {{- $additionalNodeVolumeMounts := $config.additionalNodeVolumeMounts }}
   {{- $additionalNodeLivenessProbesCmd := $config.additionalNodeLivenessProbesCmd }}
   {{- $livenessProbePort := $config.livenessProbePort }}
+  {{- $nodeMetricsPort := $config.nodeMetricsPort }}
   {{- $additionalNodeSelectorTerms := $config.additionalNodeSelectorTerms }}
   {{- $customNodeSelector := $config.customNodeSelector }}
   {{- $forceCsiNodeAndStaticNodesDepoloy := $config.forceCsiNodeAndStaticNodesDepoloy | default false }}
@@ -68,13 +69,15 @@ spec:
         {{- include "node_driver_registrar_resources" $context | nindent 8 }}
       maxAllowed:
         cpu: 25m
-        memory: 50Mi
+        memory: 64Mi
+    {{- /* The node container is the driver itself, so its peak depends on the backend: the
+           observed 7-day peaks range from 24Mi/1m for csi-nfs to 84Mi/70m for csi-huawei. */}}
     - containerName: "node"
       minAllowed:
         {{- include "node_resources" $context | nindent 8 }}
       maxAllowed:
-        cpu: 25m
-        memory: 50Mi
+        cpu: 100m
+        memory: 128Mi
     {{- end }}
 ---
 kind: DaemonSet
@@ -205,6 +208,16 @@ spec:
       {{- if $additionalNodeEnvs }}
         env:
         {{- $additionalNodeEnvs | toYaml | nindent 8 }}
+      {{- end }}
+      {{- if $nodeMetricsPort }}
+        {{- /* Named so that a PodMonitor can select it by name. A DaemonSet has no
+               Service, so without a named containerPort the only way to scrape it
+               is a numeric targetPort, which silently follows the container's port
+               if it ever moves. */}}
+        ports:
+        - name: metrics
+          containerPort: {{ $nodeMetricsPort }}
+          protocol: TCP
       {{- end }}
       {{- if $csiNodeLifecycle }}
         lifecycle:

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_module_controller.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_module_controller.tpl
@@ -26,9 +26,9 @@ memory: 50Mi
   - podSecurityContext: "deckhouse" or "nobody" (default: "nobody")
   - additionalLabels: additional labels for VPA
   - controllerMaxCpu: max CPU for controller VPA (default: "200m")
-  - controllerMaxMemory: max memory for controller VPA (default: "100Mi")
-  - webhooksMaxCpu: max CPU for webhooks VPA (default: "20m")
-  - webhooksMaxMemory: max memory for webhooks VPA (default: "100Mi")
+  - controllerMaxMemory: max memory for controller VPA (default: "256Mi")
+  - webhooksMaxCpu: max CPU for webhooks VPA (default: "25m")
+  - webhooksMaxMemory: max memory for webhooks VPA (default: "128Mi")
   - additionalContainers: additional containers to add to the pod
   - additionalVolumes: additional volumes to add to the pod
   - additionalControllerVolumeMounts: additional volume mounts for controller
@@ -39,8 +39,15 @@ memory: 50Mi
   - webhooksPort: port for webhooks container (default: 8443)
   - webhooksCertMountPath: mount path for webhook certs (default: "/etc/webhook/certs")
   - webhooksCommand: command for webhooks container
+  - additionalWebhooksEnvs: additional environment variables for webhooks
   - controllerPort: port for controller probes (default: 8081)
   - controllerMetricsPort: port for controller metrics (optional, no port exposed if not set)
+  - controllerMetricsProxyPort: port for a kube-rbac-proxy in front of the metrics
+    (optional). When set, the controller's own metrics port is NOT declared as a
+    containerPort -- the controller is expected to bind it on 127.0.0.1 -- and the
+    only port on the pod is the proxy's, named "https-metrics". Scraping it requires
+    "get" on <resource>/prometheus-metrics, which the module grants to the Prometheus
+    scraper with a Role of its own.
 */ -}}
 {{- define "helm_lib_module_controller_manifests" }}
   {{- $context := index . 0 }}
@@ -55,9 +62,9 @@ memory: 50Mi
   {{- $podSecurityContext := $config.podSecurityContext | default "nobody" }}
   {{- $additionalLabels := $config.additionalLabels | default dict }}
   {{- $controllerMaxCpu := $config.controllerMaxCpu | default "200m" }}
-  {{- $controllerMaxMemory := $config.controllerMaxMemory | default "100Mi" }}
-  {{- $webhooksMaxCpu := $config.webhooksMaxCpu | default "20m" }}
-  {{- $webhooksMaxMemory := $config.webhooksMaxMemory | default "100Mi" }}
+  {{- $controllerMaxMemory := $config.controllerMaxMemory | default "256Mi" }}
+  {{- $webhooksMaxCpu := $config.webhooksMaxCpu | default "25m" }}
+  {{- $webhooksMaxMemory := $config.webhooksMaxMemory | default "128Mi" }}
   {{- $additionalContainers := $config.additionalContainers }}
   {{- $additionalVolumes := $config.additionalVolumes }}
   {{- $additionalControllerVolumeMounts := $config.additionalControllerVolumeMounts }}
@@ -68,8 +75,10 @@ memory: 50Mi
   {{- $webhooksPort := $config.webhooksPort | default 8443 }}
   {{- $webhooksCertMountPath := $config.webhooksCertMountPath | default "/etc/webhook/certs" }}
   {{- $webhooksCommand := $config.webhooksCommand }}
+  {{- $additionalWebhooksEnvs := $config.additionalWebhooksEnvs }}
   {{- $controllerPort := $config.controllerPort | default 8081 }}
   {{- $controllerMetricsPort := $config.controllerMetricsPort }}
+  {{- $controllerMetricsProxyPort := $config.controllerMetricsProxyPort }}
 
   {{- /* Get module values */ -}}
   {{- $moduleValues := index $context.Values $valuesKey }}
@@ -95,7 +104,7 @@ spec:
     kind: Deployment
     name: {{ $fullname }}
   updatePolicy:
-    updateMode: "Initial"
+    updateMode: "InPlaceOrRecreate"
   resourcePolicy:
     containerPolicies:
     - containerName: "controller"
@@ -111,6 +120,9 @@ spec:
       maxAllowed:
         cpu: {{ $webhooksMaxCpu }}
         memory: {{ $webhooksMaxMemory }}
+    {{- end }}
+    {{- if $controllerMetricsProxyPort }}
+    {{- include "helm_lib_vpa_kube_rbac_proxy_resources" $context | nindent 4 }}
     {{- end }}
   {{- end }}
 ---
@@ -197,7 +209,7 @@ spec:
               scheme: HTTP
             periodSeconds: 1
             failureThreshold: 3
-          {{- if $controllerMetricsPort }}
+          {{- if and $controllerMetricsPort (not $controllerMetricsProxyPort) }}
           ports:
             - name: metrics
               containerPort: {{ $controllerMetricsPort }}
@@ -237,6 +249,12 @@ spec:
           {{- end }}
           image: {{ include "helm_lib_module_image" (list $context $webhooksImageName) }}
           imagePullPolicy: IfNotPresent
+          env:
+            - name: LOG_LEVEL
+              value: {{ include "helm_lib_module_controller_log_level" (list $context $valuesKey) | quote }}
+            {{- if $additionalWebhooksEnvs }}
+            {{- $additionalWebhooksEnvs | toYaml | nindent 12 }}
+            {{- end }}
           volumeMounts:
             - name: webhook-certs
               mountPath: {{ $webhooksCertMountPath }}
@@ -265,6 +283,63 @@ spec:
               {{- include "helm_lib_module_ephemeral_storage_only_logs" $context | nindent 14 }}
 {{- if not ($context.Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
               {{- include "helm_lib_module_webhooks_resources" $context | nindent 14 }}
+{{- end }}
+        {{- end }}
+        {{- if $controllerMetricsProxyPort }}
+        {{- /* The metrics endpoint of a controller is unauthenticated, and a
+               containerPort is reachable from every pod in the cluster. This proxy
+               is what turns "reachable by anyone on the pod network" into "reachable
+               by whoever holds get on <resource>/prometheus-metrics", which is how
+               the DaemonSets of this fleet have always published theirs. */}}
+        - name: kube-rbac-proxy
+          {{- include "helm_lib_module_container_security_context_pss_restricted_flexible" dict | nindent 10 }}
+          image: {{ include "helm_lib_module_common_image" (list $context "kubeRbacProxy") }}
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--secure-listen-address=$(KUBE_RBAC_PROXY_LISTEN_ADDRESS):{{ $controllerMetricsProxyPort }}"
+            - "--v=2"
+            - "--logtostderr=true"
+            - "--stale-cache-interval=1h30m"
+            - "--livez-path=/livez"
+          env:
+            - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: KUBE_RBAC_PROXY_CONFIG
+              value: |
+                excludePaths:
+                - /livez
+                upstreams:
+                - upstream: http://127.0.0.1:{{ $controllerMetricsPort | required "controllerMetricsProxyPort needs controllerMetricsPort: the proxy has to know what to forward to" }}/metrics
+                  path: /metrics
+                  authorization:
+                    resourceAttributes:
+                      namespace: d8-{{ $context.Chart.Name }}
+                      apiGroup: apps
+                      apiVersion: v1
+                      resource: deployments
+                      subresource: prometheus-metrics
+                      name: {{ $fullname }}
+          ports:
+            - name: https-metrics
+              containerPort: {{ $controllerMetricsProxyPort }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: {{ $controllerMetricsProxyPort }}
+              scheme: HTTPS
+          readinessProbe:
+            httpGet:
+              path: /livez
+              port: {{ $controllerMetricsProxyPort }}
+              scheme: HTTPS
+          resources:
+            requests:
+              {{- include "helm_lib_module_ephemeral_storage_only_logs" $context | nindent 14 }}
+{{- if not ($context.Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
+              {{- include "helm_lib_container_kube_rbac_proxy_resources" $context | nindent 14 }}
 {{- end }}
         {{- end }}
         {{- if $additionalContainers }}

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_node_affinity.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_node_affinity.tpl
@@ -59,7 +59,7 @@ nodeSelector:
 
 
 {{- /* Returns tolerations for workloads depend on strategy. */ -}}
-{{- /* Usage: {{ include "helm_lib_tolerations" (tuple . "any-node" "with-uninitialized" "without-storage-problems") }} */ -}}
+{{- /* Usage: {{ include "helm_lib_tolerations" (tuple . "any-node" "with-uninitialized") }} */ -}}
 {{- define "helm_lib_tolerations" }}
   {{- $context := index . 0 }}  {{- /* Template context with .Values, .Chart, etc */ -}}
   {{- $strategy := index . 1 | include "helm_lib_internal_check_tolerations_strategy" }} {{- /* base strategy, one of "frontend" "monitoring" "system" any-node" "wildcard" */ -}}
@@ -68,8 +68,6 @@ nodeSelector:
     {{ if lt (len .) 3 }}
         {{- fail (print "additional strategies is required") }}
     {{- end }}
-  {{- else }}
-    {{- $additionalStrategies = tuple "storage-problems" }}
   {{- end }}
   {{- $module_values := (index $context.Values (include "helm_lib_module_camelcase_name" $context)) }}
   {{- if gt (len .) 2 }}
@@ -234,12 +232,9 @@ tolerations:
 - key: node.kubernetes.io/network-unavailable
 {{- end }}
 
-{{- /* Additional strategy "storage-problems" - used for shedule critical components on nodes with drbd problems. This additional strategy enabled by default in any base strategy except "wildcard". */ -}}
-{{- /* Usage: {{ include "helm_lib_tolerations" (tuple . "any-node" "without-storage-problems") }} */ -}}
+{{- /* Additional strategy "storage-problems" - deprecated, renders nothing. It used to tolerate the DRBD taints drbd.linbit.com/lost-quorum, drbd.linbit.com/force-io-error and drbd.linbit.com/ignore-fail-over on every base strategy except "wildcard". Nothing sets those taints anymore, so the strategy is kept as a no-op to let existing "with-storage-problems" and "without-storage-problems" call sites keep rendering, and will be removed once they are gone. */ -}}
+{{- /* Usage: {{ include "helm_lib_tolerations" (tuple . "any-node" "with-storage-problems") }} */ -}}
 {{- define "_helm_lib_additional_tolerations_storage_problems" }}
-- key: drbd.linbit.com/lost-quorum
-- key: drbd.linbit.com/force-io-error
-- key: drbd.linbit.com/ignore-fail-over
 {{- end }}
 
 {{- /* Additional strategy "no-csi" - used for any node with no CSI: any node, which was initialized by deckhouse, but have no csi-node driver registered on it. */ -}}

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_resources_management.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_resources_management.tpl
@@ -147,8 +147,8 @@ updatePolicy:
   minAllowed:
     {{- include "helm_lib_container_kube_rbac_proxy_resources" . | nindent 4 }}
   maxAllowed:
-    cpu: 20m
-    memory: 25Mi
+    cpu: 25m
+    memory: 64Mi
 {{- end }}
 
 {{- /* Usage: {{ include "helm_lib_container_kube_rbac_proxy_resources" . }} */ -}}

--- a/modules/030-cloud-provider-aws/template_tests/module_test.go
+++ b/modules/030-cloud-provider-aws/template_tests/module_test.go
@@ -117,9 +117,6 @@ const tolerationsAnyNodeWithUninitialized = `
   operator: "Exists"
 - key: DeletionCandidateOfClusterAutoscaler
 - key: ToBeDeletedByClusterAutoscaler
-- key: drbd.linbit.com/lost-quorum
-- key: drbd.linbit.com/force-io-error
-- key: drbd.linbit.com/ignore-fail-over
 - effect: NoSchedule
   key: node.deckhouse.io/bashible-uninitialized
   operator: Exists

--- a/modules/030-cloud-provider-azure/template_tests/module_test.go
+++ b/modules/030-cloud-provider-azure/template_tests/module_test.go
@@ -124,9 +124,6 @@ const tolerationsAnyNodeWithUninitialized = `
   operator: "Exists"
 - key: DeletionCandidateOfClusterAutoscaler
 - key: ToBeDeletedByClusterAutoscaler
-- key: drbd.linbit.com/lost-quorum
-- key: drbd.linbit.com/force-io-error
-- key: drbd.linbit.com/ignore-fail-over
 - effect: NoSchedule
   key: node.deckhouse.io/bashible-uninitialized
   operator: Exists

--- a/modules/030-cloud-provider-dvp/template_tests/module_test.go
+++ b/modules/030-cloud-provider-dvp/template_tests/module_test.go
@@ -369,9 +369,6 @@ const tolerationsAnyNodeWithUninitialized = `
   operator: "Exists"
 - key: DeletionCandidateOfClusterAutoscaler
 - key: ToBeDeletedByClusterAutoscaler
-- key: drbd.linbit.com/lost-quorum
-- key: drbd.linbit.com/force-io-error
-- key: drbd.linbit.com/ignore-fail-over
 - effect: NoSchedule
   key: node.deckhouse.io/bashible-uninitialized
   operator: Exists

--- a/modules/030-cloud-provider-gcp/template_tests/module_test.go
+++ b/modules/030-cloud-provider-gcp/template_tests/module_test.go
@@ -146,9 +146,6 @@ const tolerationsAnyNodeWithUninitialized = `
   operator: "Exists"
 - key: DeletionCandidateOfClusterAutoscaler
 - key: ToBeDeletedByClusterAutoscaler
-- key: drbd.linbit.com/lost-quorum
-- key: drbd.linbit.com/force-io-error
-- key: drbd.linbit.com/ignore-fail-over
 - effect: NoSchedule
   key: node.deckhouse.io/bashible-uninitialized
   operator: Exists

--- a/modules/030-cloud-provider-yandex/template_tests/module_test.go
+++ b/modules/030-cloud-provider-yandex/template_tests/module_test.go
@@ -134,9 +134,6 @@ const tolerationsAnyNodeWithUninitialized = `
   operator: "Exists"
 - key: DeletionCandidateOfClusterAutoscaler
 - key: ToBeDeletedByClusterAutoscaler
-- key: drbd.linbit.com/lost-quorum
-- key: drbd.linbit.com/force-io-error
-- key: drbd.linbit.com/ignore-fail-over
 - effect: NoSchedule
   key: node.deckhouse.io/bashible-uninitialized
   operator: Exists

--- a/modules/101-cert-manager/template_tests/module_test.go
+++ b/modules/101-cert-manager/template_tests/module_test.go
@@ -168,9 +168,6 @@ var _ = Describe("Module :: cert-manager :: helm template ::", func() {
   operator: Exists
 - key: DeletionCandidateOfClusterAutoscaler
 - key: ToBeDeletedByClusterAutoscaler
-- key: drbd.linbit.com/lost-quorum
-- key: drbd.linbit.com/force-io-error
-- key: drbd.linbit.com/ignore-fail-over
 - effect: NoSchedule
   key: node.deckhouse.io/bashible-uninitialized
   operator: Exists
@@ -198,9 +195,6 @@ var _ = Describe("Module :: cert-manager :: helm template ::", func() {
 - key: dedicated.deckhouse.io
   operator: Equal
   value: "system"
-- key: drbd.linbit.com/lost-quorum
-- key: drbd.linbit.com/force-io-error
-- key: drbd.linbit.com/ignore-fail-over
 `))
 			Expect(certManager.Field("spec.replicas").Int()).To(BeEquivalentTo(1))
 			Expect(certManager.Field("spec.strategy").Exists()).To(BeFalse())
@@ -239,9 +233,6 @@ var _ = Describe("Module :: cert-manager :: helm template ::", func() {
   operator: Exists
 - key: DeletionCandidateOfClusterAutoscaler
 - key: ToBeDeletedByClusterAutoscaler
-- key: drbd.linbit.com/lost-quorum
-- key: drbd.linbit.com/force-io-error
-- key: drbd.linbit.com/ignore-fail-over
 - effect: NoSchedule
   key: node.deckhouse.io/bashible-uninitialized
   operator: Exists
@@ -280,9 +271,6 @@ podAntiAffinity:
 - key: dedicated.deckhouse.io
   operator: Equal
   value: "system"
-- key: drbd.linbit.com/lost-quorum
-- key: drbd.linbit.com/force-io-error
-- key: drbd.linbit.com/ignore-fail-over
 `))
 			Expect(certManager.Field("spec.replicas").Int()).To(BeEquivalentTo(2))
 			Expect(certManager.Field("spec.strategy").String()).To(MatchYAML(`
@@ -349,9 +337,6 @@ podAntiAffinity:
   operator: Exists
 - key: DeletionCandidateOfClusterAutoscaler
 - key: ToBeDeletedByClusterAutoscaler
-- key: drbd.linbit.com/lost-quorum
-- key: drbd.linbit.com/force-io-error
-- key: drbd.linbit.com/ignore-fail-over
 - effect: NoSchedule
   key: node.deckhouse.io/bashible-uninitialized
   operator: Exists
@@ -379,9 +364,6 @@ podAntiAffinity:
 - key: dedicated.deckhouse.io
   operator: Equal
   value: "system"
-- key: drbd.linbit.com/lost-quorum
-- key: drbd.linbit.com/force-io-error
-- key: drbd.linbit.com/ignore-fail-over
 `))
 			Expect(certManager.Field("spec.replicas").Int()).To(BeEquivalentTo(1))
 			Expect(certManager.Field("spec.strategy").Exists()).To(BeFalse())
@@ -420,9 +402,6 @@ podAntiAffinity:
   operator: Exists
 - key: DeletionCandidateOfClusterAutoscaler
 - key: ToBeDeletedByClusterAutoscaler
-- key: drbd.linbit.com/lost-quorum
-- key: drbd.linbit.com/force-io-error
-- key: drbd.linbit.com/ignore-fail-over
 - effect: NoSchedule
   key: node.deckhouse.io/bashible-uninitialized
   operator: Exists
@@ -461,9 +440,6 @@ podAntiAffinity:
 - key: dedicated.deckhouse.io
   operator: Equal
   value: "system"
-- key: drbd.linbit.com/lost-quorum
-- key: drbd.linbit.com/force-io-error
-- key: drbd.linbit.com/ignore-fail-over
 `))
 			Expect(certManager.Field("spec.replicas").Int()).To(BeEquivalentTo(2))
 			Expect(certManager.Field("spec.strategy").String()).To(MatchYAML(`


### PR DESCRIPTION
## Description

lib-helm [#211](https://github.com/deckhouse/lib-helm/pull/211) (released as `deckhouse_lib_helm-1.72.17`) removed the `storage-problems` additional tolerations — `drbd.linbit.com/lost-quorum`, `drbd.linbit.com/force-io-error`, `drbd.linbit.com/ignore-fail-over` — and stopped applying that strategy by default to every base strategy. The rendered `tolerations` lists therefore no longer carry those three keys.

Thirteen template test suites still expect them in the middle of the expected YAML, so **any** lib-helm bump past 1.72.16 turns the `Tests` job red — see the failure on #22280, which bumps to 1.72.21: 13 failing packages, all of them the same three lines.

This PR:

* bumps the vendored `deckhouse_lib_helm` chart from 1.72.14 to 1.72.17 — the release that drops the keys, and the last one before the ingress/Gateway API refactor of [#213](https://github.com/deckhouse/lib-helm/pull/213), which needs coordinated module template changes and is out of scope here;
* removes the three toleration lines from the expected YAML in the affected `template_tests`.

Nothing else changes: no module template, no rendered manifest outside the tolerations list.

Affected suites: `cloud-provider-aws`, `cloud-provider-azure`, `cloud-provider-dvp`, `cloud-provider-dynamix`, `cloud-provider-gcp`, `cloud-provider-huaweicloud`, `cloud-provider-openstack`, `cloud-provider-vcd`, `cloud-provider-vsphere`, `cloud-provider-yandex`, `cloud-provider-zvirt`, `csi-vsphere`, `cert-manager`.

## Why do we need it, and what problem does it solve?

`main` is one lib-helm bump away from a red `Tests` job, and every open PR that touches the vendored chart is blocked on it. Fixing the expectations together with the bump that changes the rendering keeps both `main` and the pending bumps green: after this lands, #22280 can go straight to 1.72.21 without touching a single test.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist

- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: common
type: chore
summary: Update lib-helm to 1.72.17, which drops the dead DRBD taint tolerations from every workload.
impact_level: low
```
