### PR TITLE
[ci] Fix reproducibility check checking out outdated commits

### DIFF
--- a/.github/workflow_templates/reproducibility-check.yml
+++ b/.github/workflow_templates/reproducibility-check.yml
@@ -20,7 +20,11 @@
 #
 # The baseline build_report_FE artifact is fetched from the matching
 # 'build-and-test_main.yml' (main commits) or 'build-and-test_dev.yml' (PR commits)
-# successful run. If no such run exists for the target SHA the workflow fails.
+# run whose 'Build FE' job succeeded and whose build_report_FE artifact has not
+# expired yet. The run-level conclusion is deliberately NOT part of that test:
+# those workflows have ~20 other jobs and a failure in any of them (doc build,
+# lint, a flaky test) leaves a perfectly usable FE baseline behind.
+# If no such run exists for the target SHA the workflow fails.
 #
 # Then the FE build is repeated for the same SHA in the same style as the
 # baseline (main-style or dev-style), and the two build_report_FE JSONs are
@@ -36,7 +40,7 @@ on:
   workflow_dispatch:
     inputs:
       commit_sha:
-        description: 'PR commit SHA that already has a successful build-and-test_dev.yml run (empty = newest main commit with a successful build)'
+        description: 'PR commit SHA that already has a build-and-test_dev.yml run with a successful Build FE job (empty = newest main commit with a usable FE baseline)'
         required: false
         type: string
 
@@ -83,9 +87,112 @@ jobs:
 
             const inputSha = ((context.payload.inputs || {}).commit_sha || '').trim();
 
+            // Job that produces the baseline report, and the artifact it uploads.
+            // Same names in build-and-test_main.yml and build-and-test_dev.yml.
+            const BUILD_JOB_NAME = 'Build FE';
+            const REPORT_ARTIFACT = 'build_report_FE';
+            // How far back along 'main' we are willing to look for a usable
+            // baseline. Doubles as a staleness guard: if nothing this recent
+            // qualifies, fail loudly instead of silently rebuilding an ancient
+            // commit (max 100, one listCommits page).
+            const MAIN_COMMIT_WINDOW = 60;
+            // Upper bound on runs we probe with 2 API calls each.
+            const MAX_PROBED_RUNS = 30;
+
+            let probedRuns = 0;
+
+            // A run is a usable baseline iff its 'Build FE' job succeeded AND the
+            // build_report_FE artifact is still downloadable.
+            //
+            // The run-level conclusion is intentionally not consulted:
+            // build-and-test_main.yml has ~20 jobs, so requiring a fully green run
+            // discards the newest commits whenever an unrelated job (doc web build,
+            // Go lint, a flaky test) fails, and drags the target commit backwards.
+            // Conversely a run still in progress is fine as soon as Build FE is done.
+            //
+            // The artifact check matters just as much: reports are garbage-collected
+            // after the retention period, and an expired one is fatal for
+            // compare_reports — better to skip the run here than to discover it
+            // after an hour-long rebuild.
+            async function isUsableBaseline(run) {
+              const tag = `run ${run.id} (${run.head_sha.slice(0, 8)}, created ${run.created_at})`;
+              if (probedRuns >= MAX_PROBED_RUNS) {
+                core.info(`  ${tag}: probe limit ${MAX_PROBED_RUNS} reached, not checking`);
+                return false;
+              }
+              probedRuns++;
+
+              let jobs;
+              try {
+                jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+                  owner, repo, run_id: run.id, per_page: 100,
+                });
+              } catch (e) {
+                core.info(`  ${tag}: cannot list jobs (${e.message}), skipping`);
+                return false;
+              }
+              const buildJob = jobs.find(j => j.name === BUILD_JOB_NAME);
+              if (!buildJob) {
+                core.info(`  ${tag}: no '${BUILD_JOB_NAME}' job, skipping`);
+                return false;
+              }
+              if (buildJob.conclusion !== 'success') {
+                core.info(
+                  `  ${tag}: '${BUILD_JOB_NAME}' is ` +
+                  `${buildJob.conclusion || buildJob.status}, skipping`
+                );
+                return false;
+              }
+
+              let artifacts;
+              try {
+                artifacts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
+                  owner, repo, run_id: run.id, per_page: 100,
+                });
+              } catch (e) {
+                core.info(`  ${tag}: cannot list artifacts (${e.message}), skipping`);
+                return false;
+              }
+              if (!artifacts.some(a => a.name === REPORT_ARTIFACT && !a.expired)) {
+                core.info(`  ${tag}: '${REPORT_ARTIFACT}' artifact missing or expired, skipping`);
+                return false;
+              }
+
+              core.info(`  ${tag}: usable baseline`);
+              return true;
+            }
+
+            // Runs for one exact commit, newest attempt first.
+            //
+            // Every lookup goes through the `head_sha` filter, and the order we act
+            // on is imposed here rather than taken from the response. Both matter:
+            // the workflow-runs LISTING is served by a search index that
+            // intermittently returns a stale, rotated page. Observed on
+            // deckhouse/deckhouse while debugging this: workflow_runs[0] of page 1
+            // was run 30807409796, created 2026-08-03, even though runs from
+            // 2026-09-07 existed — with and without a `status` filter, so
+            // dropping the filter alone is not enough. That single bad read is what
+            // sent the check off to rebuild month-old commits whose build_report_FE
+            // had already been garbage-collected. A `head_sha` query cannot go wrong
+            // that way: it asks about one commit instead of trusting a position in a
+            // list. Ordering therefore comes from git history (repos.listCommits),
+            // never from the Actions API.
+            async function runsForSha(workflowId, headSha) {
+              const res = await github.rest.actions.listWorkflowRuns({
+                owner, repo,
+                workflow_id: workflowId,
+                head_sha: headSha,
+                per_page: 100,
+              });
+              return (res.data.workflow_runs || []).slice().sort((a, b) =>
+                (b.run_attempt || 1) - (a.run_attempt || 1) ||
+                new Date(b.updated_at) - new Date(a.updated_at)
+              );
+            }
+
             // Baseline selection:
             //   schedule, or manual run WITHOUT a commit -> newest 'main' commit that
-            //     HAS a successful build (baseline in build-and-test_main.yml)
+            //     HAS a usable FE baseline (build-and-test_main.yml)
             //   manual run WITH a commit                 -> that exact commit, treated
             //     as a dev/PR build (baseline in build-and-test_dev.yml)
             const useMainBaseline = (eventName === 'schedule') || !inputSha;
@@ -98,33 +205,56 @@ jobs:
               baselineKind = 'main';
               baselineWorkflowId = 'build-and-test_main.yml';
               if (eventName === 'workflow_dispatch') {
-                core.notice(`Manual run without commit_sha: falling back to newest successful 'main' build.`);
+                core.notice(`Manual run without commit_sha: falling back to newest 'main' commit with a usable FE baseline.`);
               }
+
               // Do NOT pin to HEAD of 'main': the latest commit's build may still
-              // be running, may have failed, or may not be queued yet. Instead pick
-              // the most recent SUCCESSFUL build-and-test_main.yml run on 'main' and
-              // use its head commit. listWorkflowRuns returns runs newest-first, so
-              // the first success is the freshest 'main' commit with a usable
-              // build_report_FE artifact.
-              const runs = await github.rest.actions.listWorkflowRuns({
-                owner, repo,
-                workflow_id: baselineWorkflowId,
-                branch: 'main',
-                status: 'success',
-                per_page: 30,
-              });
-              baseline = (runs.data.workflow_runs || [])[0];
+              // be running, its Build FE may have failed, or it may not be queued
+              // yet. So walk 'main' backwards, newest commit first, and stop at the
+              // first commit that has a usable baseline. Ordering comes from git;
+              // each commit's runs are then looked up by head_sha (see runsForSha).
+              const commits = (await github.rest.repos.listCommits({
+                owner, repo, sha: 'main', per_page: MAIN_COMMIT_WINDOW,
+              })).data;
+              if (commits.length === 0) {
+                return core.setFailed(`Could not list commits of 'main' in ${owner}/${repo}.`);
+              }
+              core.info(`Walking the ${commits.length} newest 'main' commits, newest first.`);
+
+              let behind = 0;
+              for (const commit of commits) {
+                const candidates = await runsForSha(baselineWorkflowId, commit.sha);
+                if (candidates.length === 0) {
+                  core.info(`commit ${commit.sha.slice(0, 8)}: no '${baselineWorkflowId}' run`);
+                } else {
+                  core.info(`commit ${commit.sha.slice(0, 8)}: ${candidates.length} run(s)`);
+                  for (const run of candidates) {
+                    if (await isUsableBaseline(run)) { baseline = run; break; }
+                  }
+                }
+                if (baseline) break;
+                behind++;
+              }
               if (!baseline) {
                 return core.setFailed(
-                  `No successful '${baselineWorkflowId}' run found on 'main'. ` +
-                  `Reproducibility check requires an existing baseline build_report_FE artifact.`
+                  `No '${baselineWorkflowId}' run with a successful '${BUILD_JOB_NAME}' job and a ` +
+                  `non-expired '${REPORT_ARTIFACT}' artifact found in the newest ${commits.length} ` +
+                  `commits of 'main'. Reproducibility check requires an existing baseline ` +
+                  `${REPORT_ARTIFACT} artifact.`
                 );
               }
+
               sha = baseline.head_sha;
               core.notice(
-                `Using newest successful 'main' build for commit ${sha} ` +
-                `(run ${baseline.id}, ${baseline.html_url})`
+                `Using 'main' commit ${sha} (${behind} commit(s) behind main HEAD) ` +
+                `with baseline run ${baseline.id}, ${baseline.html_url}`
               );
+              if (behind > 10) {
+                core.warning(
+                  `Baseline commit is ${behind} commits behind main HEAD: recent 'main' commits ` +
+                  `have no usable '${REPORT_ARTIFACT}'. Check build-and-test_main.yml health.`
+                );
+              }
             } else {
               sha = inputSha;
               try {
@@ -137,22 +267,19 @@ jobs:
               baselineWorkflowId = 'build-and-test_dev.yml';
               core.notice(`Manual run: using commit ${sha}, baseline workflow=${baselineWorkflowId}`);
 
-              // Locate the latest successful baseline run for this exact SHA.
-              // API supports a server-side head_sha filter, so we only fetch matching runs.
-              const runs = await github.rest.actions.listWorkflowRuns({
-                owner, repo,
-                workflow_id: baselineWorkflowId,
-                head_sha: sha,
-                status: 'success',
-                per_page: 10,
-              });
-              // Runs are returned newest-first; pick the most recent success.
-              baseline = (runs.data.workflow_runs || [])[0];
+              // Locate a usable baseline run for this exact SHA. The commit is
+              // pinned by the input, so only the run choice is open.
+              const candidates = await runsForSha(baselineWorkflowId, sha);
+              core.info(`SHA ${sha}: ${candidates.length} '${baselineWorkflowId}' run(s)`);
+              for (const run of candidates) {
+                if (await isUsableBaseline(run)) { baseline = run; break; }
+              }
               if (!baseline) {
                 return core.setFailed(
-                  `No successful '${baselineWorkflowId}' run found for SHA ${sha}. ` +
-                  `Reproducibility check requires an existing baseline build_report_FE artifact. ` +
-                  `Ensure the regular build pipeline has completed for this commit first.`
+                  `No '${baselineWorkflowId}' run with a successful '${BUILD_JOB_NAME}' job and a ` +
+                  `non-expired '${REPORT_ARTIFACT}' artifact found for SHA ${sha}. ` +
+                  `Ensure the regular build pipeline has completed for this commit first, ` +
+                  `and that its ${REPORT_ARTIFACT} artifact has not been garbage-collected.`
                 );
               }
             }

--- a/.github/workflows/reproducibility-check.yml
+++ b/.github/workflows/reproducibility-check.yml
@@ -24,7 +24,11 @@
 #
 # The baseline build_report_FE artifact is fetched from the matching
 # 'build-and-test_main.yml' (main commits) or 'build-and-test_dev.yml' (PR commits)
-# successful run. If no such run exists for the target SHA the workflow fails.
+# run whose 'Build FE' job succeeded and whose build_report_FE artifact has not
+# expired yet. The run-level conclusion is deliberately NOT part of that test:
+# those workflows have ~20 other jobs and a failure in any of them (doc build,
+# lint, a flaky test) leaves a perfectly usable FE baseline behind.
+# If no such run exists for the target SHA the workflow fails.
 #
 # Then the FE build is repeated for the same SHA in the same style as the
 # baseline (main-style or dev-style), and the two build_report_FE JSONs are
@@ -40,7 +44,7 @@ on:
   workflow_dispatch:
     inputs:
       commit_sha:
-        description: 'PR commit SHA that already has a successful build-and-test_dev.yml run (empty = newest main commit with a successful build)'
+        description: 'PR commit SHA that already has a build-and-test_dev.yml run with a successful Build FE job (empty = newest main commit with a usable FE baseline)'
         required: false
         type: string
 
@@ -102,9 +106,112 @@ jobs:
 
             const inputSha = ((context.payload.inputs || {}).commit_sha || '').trim();
 
+            // Job that produces the baseline report, and the artifact it uploads.
+            // Same names in build-and-test_main.yml and build-and-test_dev.yml.
+            const BUILD_JOB_NAME = 'Build FE';
+            const REPORT_ARTIFACT = 'build_report_FE';
+            // How far back along 'main' we are willing to look for a usable
+            // baseline. Doubles as a staleness guard: if nothing this recent
+            // qualifies, fail loudly instead of silently rebuilding an ancient
+            // commit (max 100, one listCommits page).
+            const MAIN_COMMIT_WINDOW = 60;
+            // Upper bound on runs we probe with 2 API calls each.
+            const MAX_PROBED_RUNS = 30;
+
+            let probedRuns = 0;
+
+            // A run is a usable baseline iff its 'Build FE' job succeeded AND the
+            // build_report_FE artifact is still downloadable.
+            //
+            // The run-level conclusion is intentionally not consulted:
+            // build-and-test_main.yml has ~20 jobs, so requiring a fully green run
+            // discards the newest commits whenever an unrelated job (doc web build,
+            // Go lint, a flaky test) fails, and drags the target commit backwards.
+            // Conversely a run still in progress is fine as soon as Build FE is done.
+            //
+            // The artifact check matters just as much: reports are garbage-collected
+            // after the retention period, and an expired one is fatal for
+            // compare_reports — better to skip the run here than to discover it
+            // after an hour-long rebuild.
+            async function isUsableBaseline(run) {
+              const tag = `run ${run.id} (${run.head_sha.slice(0, 8)}, created ${run.created_at})`;
+              if (probedRuns >= MAX_PROBED_RUNS) {
+                core.info(`  ${tag}: probe limit ${MAX_PROBED_RUNS} reached, not checking`);
+                return false;
+              }
+              probedRuns++;
+
+              let jobs;
+              try {
+                jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+                  owner, repo, run_id: run.id, per_page: 100,
+                });
+              } catch (e) {
+                core.info(`  ${tag}: cannot list jobs (${e.message}), skipping`);
+                return false;
+              }
+              const buildJob = jobs.find(j => j.name === BUILD_JOB_NAME);
+              if (!buildJob) {
+                core.info(`  ${tag}: no '${BUILD_JOB_NAME}' job, skipping`);
+                return false;
+              }
+              if (buildJob.conclusion !== 'success') {
+                core.info(
+                  `  ${tag}: '${BUILD_JOB_NAME}' is ` +
+                  `${buildJob.conclusion || buildJob.status}, skipping`
+                );
+                return false;
+              }
+
+              let artifacts;
+              try {
+                artifacts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
+                  owner, repo, run_id: run.id, per_page: 100,
+                });
+              } catch (e) {
+                core.info(`  ${tag}: cannot list artifacts (${e.message}), skipping`);
+                return false;
+              }
+              if (!artifacts.some(a => a.name === REPORT_ARTIFACT && !a.expired)) {
+                core.info(`  ${tag}: '${REPORT_ARTIFACT}' artifact missing or expired, skipping`);
+                return false;
+              }
+
+              core.info(`  ${tag}: usable baseline`);
+              return true;
+            }
+
+            // Runs for one exact commit, newest attempt first.
+            //
+            // Every lookup goes through the `head_sha` filter, and the order we act
+            // on is imposed here rather than taken from the response. Both matter:
+            // the workflow-runs LISTING is served by a search index that
+            // intermittently returns a stale, rotated page. Observed on
+            // deckhouse/deckhouse while debugging this: workflow_runs[0] of page 1
+            // was run 30807409796, created 2026-08-03, even though runs from
+            // 2026-09-07 existed — with and without a `status` filter, so
+            // dropping the filter alone is not enough. That single bad read is what
+            // sent the check off to rebuild month-old commits whose build_report_FE
+            // had already been garbage-collected. A `head_sha` query cannot go wrong
+            // that way: it asks about one commit instead of trusting a position in a
+            // list. Ordering therefore comes from git history (repos.listCommits),
+            // never from the Actions API.
+            async function runsForSha(workflowId, headSha) {
+              const res = await github.rest.actions.listWorkflowRuns({
+                owner, repo,
+                workflow_id: workflowId,
+                head_sha: headSha,
+                per_page: 100,
+              });
+              return (res.data.workflow_runs || []).slice().sort((a, b) =>
+                (b.run_attempt || 1) - (a.run_attempt || 1) ||
+                new Date(b.updated_at) - new Date(a.updated_at)
+              );
+            }
+
             // Baseline selection:
             //   schedule, or manual run WITHOUT a commit -> newest 'main' commit that
-            //     HAS a successful build (baseline in build-and-test_main.yml)
+            //     HAS a usable FE baseline (build-and-test_main.yml)
             //   manual run WITH a commit                 -> that exact commit, treated
             //     as a dev/PR build (baseline in build-and-test_dev.yml)
             const useMainBaseline = (eventName === 'schedule') || !inputSha;
@@ -117,33 +224,56 @@ jobs:
               baselineKind = 'main';
               baselineWorkflowId = 'build-and-test_main.yml';
               if (eventName === 'workflow_dispatch') {
-                core.notice(`Manual run without commit_sha: falling back to newest successful 'main' build.`);
+                core.notice(`Manual run without commit_sha: falling back to newest 'main' commit with a usable FE baseline.`);
               }
+
               // Do NOT pin to HEAD of 'main': the latest commit's build may still
-              // be running, may have failed, or may not be queued yet. Instead pick
-              // the most recent SUCCESSFUL build-and-test_main.yml run on 'main' and
-              // use its head commit. listWorkflowRuns returns runs newest-first, so
-              // the first success is the freshest 'main' commit with a usable
-              // build_report_FE artifact.
-              const runs = await github.rest.actions.listWorkflowRuns({
-                owner, repo,
-                workflow_id: baselineWorkflowId,
-                branch: 'main',
-                status: 'success',
-                per_page: 30,
-              });
-              baseline = (runs.data.workflow_runs || [])[0];
+              // be running, its Build FE may have failed, or it may not be queued
+              // yet. So walk 'main' backwards, newest commit first, and stop at the
+              // first commit that has a usable baseline. Ordering comes from git;
+              // each commit's runs are then looked up by head_sha (see runsForSha).
+              const commits = (await github.rest.repos.listCommits({
+                owner, repo, sha: 'main', per_page: MAIN_COMMIT_WINDOW,
+              })).data;
+              if (commits.length === 0) {
+                return core.setFailed(`Could not list commits of 'main' in ${owner}/${repo}.`);
+              }
+              core.info(`Walking the ${commits.length} newest 'main' commits, newest first.`);
+
+              let behind = 0;
+              for (const commit of commits) {
+                const candidates = await runsForSha(baselineWorkflowId, commit.sha);
+                if (candidates.length === 0) {
+                  core.info(`commit ${commit.sha.slice(0, 8)}: no '${baselineWorkflowId}' run`);
+                } else {
+                  core.info(`commit ${commit.sha.slice(0, 8)}: ${candidates.length} run(s)`);
+                  for (const run of candidates) {
+                    if (await isUsableBaseline(run)) { baseline = run; break; }
+                  }
+                }
+                if (baseline) break;
+                behind++;
+              }
               if (!baseline) {
                 return core.setFailed(
-                  `No successful '${baselineWorkflowId}' run found on 'main'. ` +
-                  `Reproducibility check requires an existing baseline build_report_FE artifact.`
+                  `No '${baselineWorkflowId}' run with a successful '${BUILD_JOB_NAME}' job and a ` +
+                  `non-expired '${REPORT_ARTIFACT}' artifact found in the newest ${commits.length} ` +
+                  `commits of 'main'. Reproducibility check requires an existing baseline ` +
+                  `${REPORT_ARTIFACT} artifact.`
                 );
               }
+
               sha = baseline.head_sha;
               core.notice(
-                `Using newest successful 'main' build for commit ${sha} ` +
-                `(run ${baseline.id}, ${baseline.html_url})`
+                `Using 'main' commit ${sha} (${behind} commit(s) behind main HEAD) ` +
+                `with baseline run ${baseline.id}, ${baseline.html_url}`
               );
+              if (behind > 10) {
+                core.warning(
+                  `Baseline commit is ${behind} commits behind main HEAD: recent 'main' commits ` +
+                  `have no usable '${REPORT_ARTIFACT}'. Check build-and-test_main.yml health.`
+                );
+              }
             } else {
               sha = inputSha;
               try {
@@ -156,22 +286,19 @@ jobs:
               baselineWorkflowId = 'build-and-test_dev.yml';
               core.notice(`Manual run: using commit ${sha}, baseline workflow=${baselineWorkflowId}`);
 
-              // Locate the latest successful baseline run for this exact SHA.
-              // API supports a server-side head_sha filter, so we only fetch matching runs.
-              const runs = await github.rest.actions.listWorkflowRuns({
-                owner, repo,
-                workflow_id: baselineWorkflowId,
-                head_sha: sha,
-                status: 'success',
-                per_page: 10,
-              });
-              // Runs are returned newest-first; pick the most recent success.
-              baseline = (runs.data.workflow_runs || [])[0];
+              // Locate a usable baseline run for this exact SHA. The commit is
+              // pinned by the input, so only the run choice is open.
+              const candidates = await runsForSha(baselineWorkflowId, sha);
+              core.info(`SHA ${sha}: ${candidates.length} '${baselineWorkflowId}' run(s)`);
+              for (const run of candidates) {
+                if (await isUsableBaseline(run)) { baseline = run; break; }
+              }
               if (!baseline) {
                 return core.setFailed(
-                  `No successful '${baselineWorkflowId}' run found for SHA ${sha}. ` +
-                  `Reproducibility check requires an existing baseline build_report_FE artifact. ` +
-                  `Ensure the regular build pipeline has completed for this commit first.`
+                  `No '${baselineWorkflowId}' run with a successful '${BUILD_JOB_NAME}' job and a ` +
+                  `non-expired '${REPORT_ARTIFACT}' artifact found for SHA ${sha}. ` +
+                  `Ensure the regular build pipeline has completed for this commit first, ` +
+                  `and that its ${REPORT_ARTIFACT} artifact has not been garbage-collected.`
                 );
               }
             }


### PR DESCRIPTION
## Description
Fix baseline resolution in reproducibility-check.yml, which kept checking out wrong, often month-old commits. Commit order now comes from git (listCommits on main) with runs looked up by exact head_sha, instead of workflow_runs[0] of a listing that intermittently returns a stale page.
A run also qualifies now if only its Build FE job succeeded and build_report_FE has not expired — the run-level conclusion is ignored, so an unrelated job failure no longer disqualifies a usable baseline.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: fix
summary: Fix reproducibility check checking out outdated commits.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
