### PR TITLE
[deckhouse-controller] add x-deckhouse-immutable type to package settings schemas

### DIFF
--- a/deckhouse-controller/pkg/apis/deckhouse.io/openapi/types.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/openapi/types.go
@@ -99,6 +99,11 @@ type OpenAPIV3Schema struct {
 	// +optional
 	XUIAdvanced bool `json:"x-deckhouse-ui-advanced,omitempty"`
 
+	// x-deckhouse-immutable marks a settings field as editable only when the
+	// application is created: the web console renders it read-only when editing.
+	// +optional
+	XImmutable bool `json:"x-deckhouse-immutable,omitempty"`
+
 	// x-deckhouse-ui-order sets the display order of a settings field in the
 	// web console UI: fields with lower values are shown first.
 	// +optional

--- a/deckhouse-controller/pkg/apis/deckhouse.io/openapi/types_test.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/openapi/types_test.go
@@ -175,6 +175,7 @@ func TestMarshalRoundtrip_xDeckhouseExtensions(t *testing.T) {
 			"storageClass": {
 				Type:                 StringOrArray{"string"},
 				XGrant:               "storageclasses",
+				XImmutable:           true,
 				XUIOrder:             int64Ptr(0),
 				XUIValidationMessage: "must reference an existing StorageClass",
 			},
@@ -222,6 +223,9 @@ func TestMarshalRoundtrip_xDeckhouseExtensions(t *testing.T) {
 	}
 	if sc.XUIValidationMessage != "must reference an existing StorageClass" {
 		t.Errorf("x-deckhouse-ui-validation-message: got %q", sc.XUIValidationMessage)
+	}
+	if !sc.XImmutable {
+		t.Errorf("x-deckhouse-immutable: got false, want true")
 	}
 
 	rep, ok := restored.Properties["replicas"]
@@ -475,10 +479,10 @@ func realModuleSchema() *OpenAPIV3Schema {
 				XUIOrder:    int64Ptr(2),
 				XValidations: []ValidationRule{
 					{
-						Expression:      "self >= 1 && self <= 10",
-						Message:   "replicas must be between 1 and 10",
-						Reason:    stringPtr("FieldValueInvalid"),
-						FieldPath: ".replicas",
+						Expression: "self >= 1 && self <= 10",
+						Message:    "replicas must be between 1 and 10",
+						Reason:     stringPtr("FieldValueInvalid"),
+						FieldPath:  ".replicas",
 					},
 				},
 			},
@@ -554,8 +558,8 @@ func realModuleSchema() *OpenAPIV3Schema {
 		},
 		XValidations: []ValidationRule{
 			{
-				Expression:    "has(self.storageClass) && self.storageClass != ''",
-				Message: "storageClass is required",
+				Expression: "has(self.storageClass) && self.storageClass != ''",
+				Message:    "storageClass is required",
 			},
 		},
 	}


### PR DESCRIPTION
## Description
Adds a new vendor extension `x-deckhouse-immutable` (`XImmutable` field) to the `OpenAPIV3Schema` type in `deckhouse-controller/pkg/apis/deckhouse.io/openapi`.

The extension marks a settings field as editable only at application creation time: the web console renders such a field as read-only when editing an existing application.

The marshal/unmarshal roundtrip test is extended to cover the new extension. No behavior of existing fields is changed; the diff also includes a minor gofmt realignment in the test file.

## Why do we need it, and what problem does it solve?
Some settings fields cannot be safely changed after an application is created (for example, `storageClass`: changing it after PVCs are provisioned has no effect or breaks the application). Module authors need a declarative way to express this in the settings schema so the web console can prevent editing such fields instead of letting users make changes that will not be applied.

## Why do we need it in the patch release (if we do)?
Not necessarily.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse-controller
type: feature
summary: Add the `x-deckhouse-immutable` OpenAPI extension to mark settings fields as editable only at application creation.
```