### PR TITLE
[istio] Fix cluster id and name divergence

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -2046,7 +2046,7 @@ alerts:
       module: istio
       edition: ee
       description: |
-        The Istio control plane instance `{{$labels.istiod}}` cannot synchronize with the remote cluster `{{$labels.cluster_id}}`.
+        {{ if $labels.multicluster_name }}The Istio control plane instance `{{$labels.istiod}}` cannot synchronize with the remote cluster described by IstioMulticluster `{{$labels.multicluster_name}}` (cluster ID `{{$labels.cluster_id}}`).{{ else }}The Istio control plane instance `{{$labels.istiod}}` cannot synchronize with the remote cluster `{{$labels.cluster_id}}`.{{ end }}
 
         Possible causes:
 
@@ -2055,8 +2055,20 @@ alerts:
         - The remote ServiceAccount token is invalid or expired.
         - There is a TLS or certificate issue between the clusters.
         - Remote and local Istio versions mismatch.
+
+        {{ if $labels.multicluster_name }}Inspect the resource:
+
+        ```bash
+        d8 k describe istiomulticluster {{$labels.multicluster_name}}
+        ```
+
+        `Root CA` should be set, `Public Last Fetch Timestamp` should be recent, and `Ingress Gateways` should list the remote cluster's IngressGateway addresses.
+
+        If there is no such resource, this cluster was registered by the secret `{{$labels.secret}}` alone — check the API address and the token in the kubeconfig it stores.
+        {{ else }}No IstioMulticluster resource registered this cluster, so check the API address and the token in the kubeconfig stored in the secret `{{$labels.secret}}`.
+        {{ end }}
       summary: |
-        Istio remote cluster {{$labels.cluster_id}} is not synchronized.
+        {{ if $labels.multicluster_name }}IstioMulticluster {{ $labels.multicluster_name }} is not synchronized.{{ else }}Istio remote cluster {{ $labels.cluster_id }} is not synchronized.{{ end }}
       severity: "4"
       markupFormat: markdown
     - name: D8IstioReservedUIDConflict

--- a/ee/modules/110-istio/crds/istiomulticluster.yaml
+++ b/ee/modules/110-istio/crds/istiomulticluster.yaml
@@ -148,6 +148,8 @@ spec:
                       properties:
                         apiHost:
                           type: string
+                        clusterID:
+                          type: string
                         networkName:
                           type: string
                         ingressGateways:

--- a/ee/modules/110-istio/hooks/ee/alliance_metadata_merge.go
+++ b/ee/modules/110-istio/hooks/ee/alliance_metadata_merge.go
@@ -48,6 +48,7 @@ type IstioFederationMergeCrdInfo struct {
 type IstioMulticlusterMergeCrdInfo struct {
 	APIHost                  string                               `json:"apiHost"`
 	APIJWT                   string                               `json:"apiJWT"`
+	ClusterID                string                               `json:"clusterID"`
 	ClusterUUID              string                               `json:"clusterUUID"`
 	EnableIngressGateway     bool                                 `json:"enableIngressGateway"`
 	EnableInsecureConnection bool                                 `json:"insecureSkipVerify"`
@@ -171,6 +172,7 @@ func applyMulticlusterMergeFilter(obj *unstructured.Unstructured) (go_hook.Filte
 	var (
 		igs         *[]eeCrd.MulticlusterIngressGateways
 		apiHost     string
+		clusterID   string
 		networkName string
 		p           *eeCrd.AlliancePublicMetadata
 		uuid        string
@@ -182,6 +184,7 @@ func applyMulticlusterMergeFilter(obj *unstructured.Unstructured) (go_hook.Filte
 			igs = multicluster.Status.MetadataCache.Private.IngressGateways
 		}
 		apiHost = multicluster.Status.MetadataCache.Private.APIHost
+		clusterID = multicluster.Status.MetadataCache.Private.ClusterIDOrDerived()
 		networkName = multicluster.Status.MetadataCache.Private.NetworkName
 	}
 	if multicluster.Status.MetadataCache.Public != nil {
@@ -192,6 +195,7 @@ func applyMulticlusterMergeFilter(obj *unstructured.Unstructured) (go_hook.Filte
 
 	return IstioMulticlusterMergeCrdInfo{
 		APIHost:                  apiHost,
+		ClusterID:                clusterID,
 		ClusterUUID:              uuid,
 		EnableIngressGateway:     multicluster.Spec.EnableIngressGateway,
 		EnableInsecureConnection: multicluster.Spec.Metadata.EnableInsecureConnection,
@@ -207,8 +211,8 @@ func applyMulticlusterMergeFilter(obj *unstructured.Unstructured) (go_hook.Filte
 
 // Simplified struct for storing only essential token data
 type IstioRemoteSecretToken struct {
-	MultiClusterName string `json:"multiClusterName"`
-	Token            string `json:"token"`
+	ClusterID string `json:"clusterID"`
+	Token     string `json:"token"`
 }
 
 // Kubeconfig represents the structure of a kubeconfig file
@@ -231,8 +235,10 @@ type TokenValidationResult struct {
 // If token expires sooner, it will be proactively reissued (hook runs once a month).
 const expiresSoonThreshold = 30 * 24 * time.Hour
 
-// validateJWTToken validates a JWT token and checks if it's expired or expires soon
-func validateJWTToken(tokenString string) TokenValidationResult {
+// validateJWTToken validates a JWT token: it must be addressed to
+// expectedAudience (the peer's clusterUUID) and must not be expired or about
+// to expire.
+func validateJWTToken(tokenString string, expectedAudience string) TokenValidationResult {
 	if tokenString == "" {
 		return TokenValidationResult{
 			NeedReissue: true,
@@ -258,6 +264,13 @@ func validateJWTToken(tokenString string) TokenValidationResult {
 		return TokenValidationResult{
 			NeedReissue: true,
 			Error:       fmt.Sprintf("failed to unmarshal claims: %v", err),
+		}
+	}
+
+	if aud, _ := claims["aud"].(string); aud != expectedAudience {
+		return TokenValidationResult{
+			NeedReissue: true,
+			Error:       fmt.Sprintf("token audience %q doesn't match the expected %q", aud, expectedAudience),
 		}
 	}
 
@@ -293,17 +306,17 @@ func applyIstioRemoteSecretFilter(obj *unstructured.Unstructured) (go_hook.Filte
 		return nil, fmt.Errorf("secret %s is not an istio remote secret", secretName)
 	}
 
-	// Extract cluster name from annotation instead of parsing from secret name
+	// Extract the cluster ID from the annotation instead of parsing from secret name
 	annotations := secret.GetAnnotations()
-	clusterName, exists := annotations["networking.istio.io/cluster"]
+	clusterID, exists := annotations["networking.istio.io/cluster"]
 	if !exists {
 		return nil, fmt.Errorf("secret %s does not have required annotation 'networking.istio.io/cluster'", secretName)
 	}
 
 	// Get the base64-encoded kubeconfig from the field named after the cluster
-	secData, exists := secret.Data[clusterName]
+	secData, exists := secret.Data[clusterID]
 	if !exists {
-		return nil, fmt.Errorf("secret %s does not contain '%s' field", secretName, clusterName)
+		return nil, fmt.Errorf("secret %s does not contain '%s' field", secretName, clusterID)
 	}
 
 	var kubeconfigBytes []byte
@@ -350,8 +363,8 @@ func applyIstioRemoteSecretFilter(obj *unstructured.Unstructured) (go_hook.Filte
 	}
 
 	return IstioRemoteSecretToken{
-		MultiClusterName: clusterName,
-		Token:            token,
+		ClusterID: clusterID,
+		Token:     token,
 	}, nil
 }
 
@@ -403,7 +416,7 @@ func metadataMerge(_ context.Context, input *go_hook.HookInput) error {
 	// Create a map of cluster names to tokens from remote secrets for quick lookup
 	secretTokens := make(map[string]string)
 	for secretInfo := range sdkobjectpatch.SnapshotIter[IstioRemoteSecretToken](input.Snapshots.Get("istioRemoteSecrets")) {
-		secretTokens[secretInfo.MultiClusterName] = secretInfo.Token
+		secretTokens[secretInfo.ClusterID] = secretInfo.Token
 	}
 
 federationsLoop:
@@ -570,23 +583,24 @@ multiclustersLoop:
 		}
 		remotePublicMetadata[multiclusterInfo.Public.ClusterUUID] = *multiclusterInfo.Public
 
-		if multiclusterInfo.APIHost == "" || multiclusterInfo.NetworkName == "" {
+		if multiclusterInfo.APIHost == "" || multiclusterInfo.NetworkName == "" || multiclusterInfo.ClusterID == "" {
 			input.Logger.Warn("private metadata for IstioMulticluster wasn't fetched yet", slog.String("name", multiclusterInfo.Name))
 			continue multiclustersLoop
 		}
+
 		if multiclusterInfo.EnableIngressGateway &&
 			(multiclusterInfo.IngressGateways == nil || len(*multiclusterInfo.IngressGateways) == 0) {
 			input.Logger.Warn("ingressGateways for IstioMulticluster weren't fetched yet", slog.String("name", multiclusterInfo.Name))
 			continue multiclustersLoop
 		}
 
-		// Check existing token from remote secrets and validate it
-		existingToken := secretTokens[multiclusterInfo.Name]
+		// Check existing token from remote secrets and validate it.
+		existingToken := secretTokens[multiclusterInfo.ClusterID]
 
 		input.Logger.Info("validating existing token",
 			slog.String("name", multiclusterInfo.Name))
 
-		validationResult := validateJWTToken(existingToken)
+		validationResult := validateJWTToken(existingToken, multiclusterInfo.ClusterUUID)
 		input.Logger.Info("token validation result",
 			slog.String("name", multiclusterInfo.Name),
 			slog.Bool("needReissue", validationResult.NeedReissue), //nolint:sloglint

--- a/ee/modules/110-istio/hooks/ee/alliance_metadata_merge_test.go
+++ b/ee/modules/110-istio/hooks/ee/alliance_metadata_merge_test.go
@@ -192,6 +192,7 @@ status:
   metadataCache:
     private:
       apiHost: istio-api-1.example.com
+      clusterID: xxx-cluster-id
       networkName: network-xxx-123
     public:
       clusterUUID: aaa-bbb-m1
@@ -373,6 +374,7 @@ status:
 			Expect(f.ValuesGet("istio.internal.multiclusters.0.spiffeEndpoint").String()).To(Equal("https://some-proper-host/public/spiffe-bundle-endpoint"))
 			Expect(f.ValuesGet("istio.internal.multiclusters.0.apiHost").String()).To(Equal("istio-api-0.example.com"))
 			Expect(f.ValuesGet("istio.internal.multiclusters.0.networkName").String()).To(Equal("network-qqq-123"))
+			Expect(f.ValuesGet("istio.internal.multiclusters.0.clusterID").String()).To(Equal("qqq-123"))
 			Expect(f.ValuesGet("istio.internal.multiclusters.0.metadataExporterCA").String()).To(Equal("custom-metadata-ca-m0"))
 			Expect(f.ValuesGet("istio.internal.multiclusters.0.clusterUUID").String()).To(Equal("aaa-bbb-m0"))
 			Expect(f.ValuesGet("istio.internal.multiclusters.0.rootCA").String()).To(Equal("abc-m0"))
@@ -388,6 +390,7 @@ status:
 			Expect(f.ValuesGet("istio.internal.multiclusters.1.spiffeEndpoint").String()).To(Equal("https://some-proper-host/public/spiffe-bundle-endpoint"))
 			Expect(f.ValuesGet("istio.internal.multiclusters.1.apiHost").String()).To(Equal("istio-api-1.example.com"))
 			Expect(f.ValuesGet("istio.internal.multiclusters.1.networkName").String()).To(Equal("network-xxx-123"))
+			Expect(f.ValuesGet("istio.internal.multiclusters.1.clusterID").String()).To(Equal("xxx-cluster-id"))
 			Expect(f.ValuesGet("istio.internal.multiclusters.1.metadataExporterCA").String()).To(Equal(""))
 			Expect(f.ValuesGet("istio.internal.multiclusters.1.clusterUUID").String()).To(Equal("aaa-bbb-m1"))
 			Expect(f.ValuesGet("istio.internal.multiclusters.1.rootCA").String()).To(Equal("abc-m1"))
@@ -1046,7 +1049,8 @@ status:
       ingressGateways:
       - {"address": "test-gateway", "port": 443}
       apiHost: test-cluster.example.com
-      networkName: test-network
+      clusterID: test-cluster-id
+      networkName: network-test-cluster-id
     public:
       clusterUUID: test-cluster-uuid
       rootCA: test-ca
@@ -1064,7 +1068,7 @@ status:
 			Expect(apiJWT).ToNot(BeEmpty())
 
 			// Verify the token is valid
-			validationResult := validateJWTToken(apiJWT)
+			validationResult := validateJWTToken(apiJWT, "test-cluster-uuid")
 			Expect(validationResult.NeedReissue).To(BeFalse())
 		})
 
@@ -1117,11 +1121,11 @@ metadata:
   name: istio-remote-secret-test-cluster
   namespace: d8-istio
   annotations:
-    networking.istio.io/cluster: test-cluster
+    networking.istio.io/cluster: test-cluster-id
   labels:
     istio/multiCluster: "true"
 data:
-  test-cluster: ` + base64.StdEncoding.EncodeToString([]byte(validKubeconfig)) + `
+  test-cluster-id: ` + base64.StdEncoding.EncodeToString([]byte(validKubeconfig)) + `
 ---
 apiVersion: deckhouse.io/v1alpha1
 kind: IstioMulticluster
@@ -1136,7 +1140,8 @@ status:
       ingressGateways:
       - {"address": "test-gateway", "port": 443}
       apiHost: test-cluster.example.com
-      networkName: test-network
+      clusterID: test-cluster-id
+      networkName: network-test-cluster-id
     public:
       clusterUUID: test-cluster-uuid
       rootCA: test-ca
@@ -1203,11 +1208,11 @@ metadata:
   name: istio-remote-secret-test-cluster
   namespace: d8-istio
   annotations:
-    networking.istio.io/cluster: test-cluster
+    networking.istio.io/cluster: test-cluster-id
   labels:
     istio/multiCluster: "true"
 data:
-  test-cluster: ` + base64.StdEncoding.EncodeToString([]byte(expiredKubeconfig)) + `
+  test-cluster-id: ` + base64.StdEncoding.EncodeToString([]byte(expiredKubeconfig)) + `
 ---
 apiVersion: deckhouse.io/v1alpha1
 kind: IstioMulticluster
@@ -1222,7 +1227,8 @@ status:
       ingressGateways:
       - {"address": "test-gateway", "port": 443}
       apiHost: test-cluster.example.com
-      networkName: test-network
+      clusterID: test-cluster-id
+      networkName: network-test-cluster-id
     public:
       clusterUUID: test-cluster-uuid
       rootCA: test-ca
@@ -1241,7 +1247,7 @@ status:
 			Expect(apiJWT).ToNot(BeEmpty())
 
 			// Verify the new token is valid
-			validationResult := validateJWTToken(apiJWT)
+			validationResult := validateJWTToken(apiJWT, "test-cluster-uuid")
 			Expect(validationResult.NeedReissue).To(BeFalse())
 		})
 
@@ -1293,11 +1299,11 @@ metadata:
   name: istio-remote-secret-test-cluster
   namespace: d8-istio
   annotations:
-    networking.istio.io/cluster: test-cluster
+    networking.istio.io/cluster: test-cluster-id
   labels:
     istio/multiCluster: "true"
 data:
-  test-cluster: ` + base64.StdEncoding.EncodeToString([]byte(validKubeconfig)) + `
+  test-cluster-id: ` + base64.StdEncoding.EncodeToString([]byte(validKubeconfig)) + `
 ---
 apiVersion: deckhouse.io/v1alpha1
 kind: IstioMulticluster
@@ -1312,7 +1318,8 @@ status:
       ingressGateways:
       - {"address": "test-gateway", "port": 443}
       apiHost: test-cluster.example.com
-      networkName: test-network
+      clusterID: test-cluster-id
+      networkName: network-test-cluster-id
     public:
       clusterUUID: test-cluster-uuid
       rootCA: test-ca
@@ -1331,8 +1338,210 @@ status:
 			Expect(apiJWT).ToNot(BeEmpty())
 
 			// Verify the new token is valid and has sufficient TTL
-			validationResult := validateJWTToken(apiJWT)
+			validationResult := validateJWTToken(apiJWT, "test-cluster-uuid")
 			Expect(validationResult.NeedReissue).To(BeFalse())
+		})
+
+		It("Checking that the existing-token lookup is keyed on the peer's cluster ID, not the CR name.", func() {
+			signer, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.HS256, Key: []byte("secret")}, nil)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			futureTime := time.Now().Add(35 * 24 * time.Hour).Unix()
+			claims := map[string]interface{}{
+				"exp":   futureTime,
+				"iat":   time.Now().Unix(),
+				"sub":   "test-user",
+				"iss":   "d8-istio",
+				"aud":   "test-cluster-uuid",
+				"scope": "api",
+			}
+			payload, err := json.Marshal(claims)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			token, err := signer.Sign(payload)
+			Expect(err).ShouldNot(HaveOccurred())
+			staleKeyedToken, err := token.CompactSerialize()
+			Expect(err).ShouldNot(HaveOccurred())
+
+			legacyKubeconfig := fmt.Sprintf(`apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://test-cluster.example.com
+  name: test-cluster
+contexts:
+- context:
+    cluster: test-cluster
+    user: test-user
+  name: test-context
+current-context: test-context
+users:
+- name: test-user
+  user:
+    token: %s
+`, staleKeyedToken)
+
+			f.BindingContexts.Set(f.KubeStateSet(`
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: istio-remote-secret-test-cluster
+  namespace: d8-istio
+  annotations:
+    networking.istio.io/cluster: test-cluster
+  labels:
+    istio/multiCluster: "true"
+data:
+  test-cluster: ` + base64.StdEncoding.EncodeToString([]byte(legacyKubeconfig)) + `
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: IstioMulticluster
+metadata:
+  name: test-cluster
+spec:
+  enableIngressGateway: true
+  metadataEndpoint: "https://test-cluster.example.com"
+status:
+  metadataCache:
+    private:
+      ingressGateways:
+      - {"address": "test-gateway", "port": 443}
+      apiHost: test-cluster.example.com
+      networkName: network-test-cluster-id
+      clusterID: test-cluster-id
+    public:
+      clusterUUID: test-cluster-uuid
+      rootCA: test-ca
+      authnKeyPub: test-key
+`))
+			f.RunHook()
+
+			Expect(f).To(ExecuteSuccessfully())
+
+			multiclusters := f.ValuesGet("istio.internal.multiclusters").Array()
+			Expect(multiclusters).To(HaveLen(1))
+			Expect(f.ValuesGet("istio.internal.multiclusters.0.clusterID").String()).To(Equal("test-cluster-id"))
+
+			apiJWT := f.ValuesGet("istio.internal.multiclusters.0.apiJWT").String()
+			Expect(apiJWT).ToNot(BeEmpty())
+			Expect(apiJWT).ToNot(Equal(staleKeyedToken))
+			Expect(validateJWTToken(apiJWT, "test-cluster-uuid").NeedReissue).To(BeFalse())
+		})
+
+		It("Checking that a token minted for another peer isn't reused.", func() {
+			signer, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.HS256, Key: []byte("secret")}, nil)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			futureTime := time.Now().Add(35 * 24 * time.Hour).Unix()
+			claims := map[string]interface{}{
+				"exp":   futureTime,
+				"iat":   time.Now().Unix(),
+				"sub":   "test-user",
+				"iss":   "d8-istio",
+				"aud":   "some-other-cluster-uuid",
+				"scope": "api",
+			}
+			payload, err := json.Marshal(claims)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			token, err := signer.Sign(payload)
+			Expect(err).ShouldNot(HaveOccurred())
+			foreignToken, err := token.CompactSerialize()
+			Expect(err).ShouldNot(HaveOccurred())
+
+			foreignKubeconfig := fmt.Sprintf(`apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://test-cluster.example.com
+  name: test-cluster-id
+contexts:
+- context:
+    cluster: test-cluster-id
+    user: test-user
+  name: test-context
+current-context: test-context
+users:
+- name: test-user
+  user:
+    token: %s
+`, foreignToken)
+
+			f.BindingContexts.Set(f.KubeStateSet(`
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: istio-remote-secret-test-cluster
+  namespace: d8-istio
+  annotations:
+    networking.istio.io/cluster: test-cluster-id
+  labels:
+    istio/multiCluster: "true"
+data:
+  test-cluster-id: ` + base64.StdEncoding.EncodeToString([]byte(foreignKubeconfig)) + `
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: IstioMulticluster
+metadata:
+  name: test-cluster
+spec:
+  enableIngressGateway: true
+  metadataEndpoint: "https://test-cluster.example.com"
+status:
+  metadataCache:
+    private:
+      ingressGateways:
+      - {"address": "test-gateway", "port": 443}
+      apiHost: test-cluster.example.com
+      clusterID: test-cluster-id
+      networkName: network-test-cluster-id
+    public:
+      clusterUUID: test-cluster-uuid
+      rootCA: test-ca
+      authnKeyPub: test-key
+`))
+			f.RunHook()
+
+			Expect(f).To(ExecuteSuccessfully())
+
+			multiclusters := f.ValuesGet("istio.internal.multiclusters").Array()
+			Expect(multiclusters).To(HaveLen(1))
+
+			apiJWT := f.ValuesGet("istio.internal.multiclusters.0.apiJWT").String()
+			Expect(apiJWT).ToNot(BeEmpty())
+			Expect(apiJWT).ToNot(Equal(foreignToken))
+			Expect(validateJWTToken(apiJWT, "test-cluster-uuid").NeedReissue).To(BeFalse())
+		})
+
+		It("Checking that a peer that reports no cluster ID falls back to deriving it from its networkName.", func() {
+			f.BindingContexts.Set(f.KubeStateSet(`
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: IstioMulticluster
+metadata:
+  name: test-cluster
+spec:
+  enableIngressGateway: true
+  metadataEndpoint: "https://test-cluster.example.com"
+status:
+  metadataCache:
+    private:
+      ingressGateways:
+      - {"address": "test-gateway", "port": 443}
+      apiHost: test-cluster.example.com
+      networkName: network-test-cluster-id
+    public:
+      clusterUUID: test-cluster-uuid
+      rootCA: test-ca
+      authnKeyPub: test-key
+`))
+			f.RunHook()
+
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("istio.internal.multiclusters").Array()).To(HaveLen(1))
+			Expect(f.ValuesGet("istio.internal.multiclusters.0.clusterID").String()).To(Equal("test-cluster-id"))
 		})
 	})
 })

--- a/ee/modules/110-istio/hooks/ee/lib/crd/istiomulticluster.go
+++ b/ee/modules/110-istio/hooks/ee/lib/crd/istiomulticluster.go
@@ -4,7 +4,11 @@ Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https
 */
 package crd
 
-import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+import (
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
 
 type IstioMulticluster struct {
 	metav1.TypeMeta `json:",inline"`
@@ -40,7 +44,24 @@ type IstioMulticlusterStatus struct {
 type MulticlusterPrivateMetadata struct {
 	IngressGateways *[]MulticlusterIngressGateways `json:"ingressGateways"`
 	APIHost         string                         `json:"apiHost,omitempty"`
+	ClusterID       string                         `json:"clusterID,omitempty"`
 	NetworkName     string                         `json:"networkName,omitempty"`
+}
+
+const NetworkNameClusterIDPrefix = "network-"
+
+func (m *MulticlusterPrivateMetadata) ClusterIDOrDerived() string {
+	if m == nil {
+		return ""
+	}
+	if m.ClusterID != "" {
+		return m.ClusterID
+	}
+	derived, ok := strings.CutPrefix(m.NetworkName, NetworkNameClusterIDPrefix)
+	if !ok {
+		return ""
+	}
+	return derived
 }
 
 type MulticlusterIngressGateways struct {

--- a/ee/modules/110-istio/hooks/ee/multicluster_discovery_test.go
+++ b/ee/modules/110-istio/hooks/ee/multicluster_discovery_test.go
@@ -143,6 +143,7 @@ status:
 							{"address": "1.2.3.4", "port": 234}
 						  ],
                           "apiHost": "api-host-0",
+                          "clusterID": "cluster-id-0",
                           "networkName": "network-name-0"
 						}`,
 						Code: http.StatusOK,
@@ -350,6 +351,9 @@ status:
 			Expect(f.KubernetesGlobalResource("IstioMulticluster", "proper-multicluster-0").Field("status.metadataCache.private.networkName").String()).To(Equal("network-name-0"))
 			Expect(f.KubernetesGlobalResource("IstioMulticluster", "proper-multicluster-1").Field("status.metadataCache.private.networkName").String()).To(Equal("network-name-1"))
 			Expect(f.KubernetesGlobalResource("IstioMulticluster", "proper-multicluster-2").Field("status.metadataCache.private.networkName").String()).To(Equal("network-name-2"))
+
+			Expect(f.KubernetesGlobalResource("IstioMulticluster", "proper-multicluster-0").Field("status.metadataCache.private.clusterID").String()).To(Equal("cluster-id-0"))
+			Expect(f.KubernetesGlobalResource("IstioMulticluster", "proper-multicluster-1").Field("status.metadataCache.private.clusterID").Exists()).To(BeFalse())
 
 			tokenPF0, errpf0p := jose.ParseSigned(bearerTokens["proper-hostname-0"])
 			Expect(errpf0p).ShouldNot(HaveOccurred())

--- a/ee/modules/110-istio/images/metadata-exporter/src/exporter.go
+++ b/ee/modules/110-istio/images/metadata-exporter/src/exporter.go
@@ -53,6 +53,7 @@ type Exporter struct {
 	inlet                                string
 	clusterDomain                        string
 	clusterUUID                          string
+	multiclusterClusterID                string
 	multicluserNetworkName               string
 	multiclusterAPIHost                  string
 	federationEnabled                    string
@@ -64,6 +65,7 @@ func New(namespace string, labelSelector string) (*Exporter, error) {
 	inlet := os.Getenv("INLET")
 	clusterDomain := os.Getenv("CLUSTER_DOMAIN")
 	clusterUUID := os.Getenv("CLUSTER_UUID")
+	multiclusterClusterID := os.Getenv("MULTICLUSTER_CLUSTER_ID")
 	multicluserNetworkName := os.Getenv("MULTICLUSTER_NETWORK_NAME")
 	multiclusterAPIHost := os.Getenv("MULTICLUSTER_API_HOST")
 	federationEnabled := os.Getenv("FEDERATION_ENABLED")
@@ -165,6 +167,7 @@ func New(namespace string, labelSelector string) (*Exporter, error) {
 			inlet:                           inlet,
 			clusterDomain:                   clusterDomain,
 			clusterUUID:                     clusterUUID,
+			multiclusterClusterID:           multiclusterClusterID,
 			multicluserNetworkName:          multicluserNetworkName,
 			multiclusterAPIHost:             multiclusterAPIHost,
 			federationEnabled:               federationEnabled,
@@ -662,6 +665,11 @@ func (exp *Exporter) RenderMulticlusterPrivateMetadataJSON() string {
 	}
 
 	pm.IngressGateways = &ingressGateways
+
+	pm.ClusterID = exp.multiclusterClusterID
+	if len(pm.ClusterID) == 0 {
+		panic("Error reading MULTICLUSTER_CLUSTER_ID from env")
+	}
 
 	pm.NetworkName = exp.multicluserNetworkName
 	if len(pm.NetworkName) == 0 {

--- a/ee/modules/110-istio/images/metadata-exporter/src/models.go
+++ b/ee/modules/110-istio/images/metadata-exporter/src/models.go
@@ -65,6 +65,7 @@ type FederationPrivateMetadata struct {
 type MulticlusterPrivateMetadata struct {
 	IngressGateways *[]IngressGateway `json:"ingressGateways,omitempty"`
 	APIHost         string            `json:"apiHost,omitempty"`
+	ClusterID       string            `json:"clusterID,omitempty"`
 	NetworkName     string            `json:"networkName,omitempty"`
 }
 

--- a/ee/modules/110-istio/images/metrics-exporter/src/prometheus.go
+++ b/ee/modules/110-istio/images/metrics-exporter/src/prometheus.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -35,7 +36,7 @@ func RegisterMetrics(clientSet *kubernetes.Clientset, reg prometheus.Registerer)
 				Name: "istio_remote_cluster_up",
 				Help: "Indicates if remote cluster is synced (1 = yes, 0 = no)",
 			},
-			[]string{"istiod", "cluster_id", "secret"},
+			[]string{"istiod", "cluster_id", "secret", "multicluster_name"},
 		),
 		clientSet: clientSet,
 	}
@@ -180,7 +181,28 @@ func (p *PrometheusExporterMetrics) setClusterStatus(istiod, clusterID, secretNa
 	if syncStatus == "synced" {
 		val = 1.0
 	}
-	p.clusterUp.WithLabelValues(istiod, clusterID, secretName).Set(val)
+	p.clusterUp.WithLabelValues(istiod, clusterID, secretName, multiclusterNameFromSecret(secretName)).Set(val)
+}
+
+const (
+	remoteSecretNamespace = "d8-istio"
+	remoteSecretPrefix    = "istio-remote-secret-"
+)
+
+func multiclusterNameFromSecret(secretName string) string {
+	namespace, name, hasNamespace := strings.Cut(secretName, "/")
+	if !hasNamespace {
+		name = secretName
+	} else if namespace != remoteSecretNamespace {
+		return ""
+	}
+
+	multiclusterName, found := strings.CutPrefix(name, remoteSecretPrefix)
+	if !found {
+		return ""
+	}
+
+	return multiclusterName
 }
 
 func (p *PrometheusExporterMetrics) DeleteIstiodMetrics(podName string) {

--- a/ee/modules/110-istio/images/metrics-exporter/src/prometheus_test.go
+++ b/ee/modules/110-istio/images/metrics-exporter/src/prometheus_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2026 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package main
+
+import "testing"
+
+func TestMulticlusterNameFromSecret(t *testing.T) {
+	tests := []struct {
+		name       string
+		secretName string
+		want       string
+	}{
+		{
+			name:       "namespaced remote secret",
+			secretName: "d8-istio/istio-remote-secret-neighbour-0",
+			want:       "neighbour-0",
+		},
+		{
+			name:       "bare remote secret name",
+			secretName: "istio-remote-secret-neighbour-0",
+			want:       "neighbour-0",
+		},
+		{
+			name:       "resource name that itself looks like a remote secret",
+			secretName: "d8-istio/istio-remote-secret-istio-remote-secret-x",
+			want:       "istio-remote-secret-x",
+		},
+		{
+			name:       "istiod's own cluster reports no secret",
+			secretName: "",
+			want:       "",
+		},
+		{
+			name:       "a remote secret we didn't render",
+			secretName: "other-ns/some-foreign-secret",
+			want:       "",
+		},
+		{
+			name:       "our naming, but in a namespace we don't render into",
+			secretName: "other-ns/istio-remote-secret-neighbour-0",
+			want:       "",
+		},
+		{
+			name:       "a secret in our namespace that isn't a remote secret",
+			secretName: "d8-istio/istio-ca-secret",
+			want:       "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := multiclusterNameFromSecret(tt.secretName); got != tt.want {
+				t.Errorf("multiclusterNameFromSecret(%q) = %q, want %q", tt.secretName, got, tt.want)
+			}
+		})
+	}
+}

--- a/ee/modules/110-istio/monitoring/prometheus-rules/multicluster.yaml
+++ b/ee/modules/110-istio/monitoring/prometheus-rules/multicluster.yaml
@@ -83,7 +83,8 @@
           If the peer change is intentional, recreate the IstioMulticluster resource so a new UUID can be pinned.
 
     - alert: D8IstioRemoteClusterNotSynced
-      expr:  min by (cluster_id, secret, istiod) (istio_remote_cluster_up) == 0
+      # An empty `secret` label marks istiod's own cluster, which is never "remote".
+      expr: min by (cluster_id, secret, istiod, multicluster_name) (istio_remote_cluster_up{secret!=""}) == 0
       for: 5m
       labels:
         severity_level: "4"
@@ -93,9 +94,9 @@
         plk_protocol_version: "1"
         plk_create_group_if_not_exists__d8_istio_remote_clusters_sync: D8IstioRemoteClustersSync,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
         plk_grouped_by__istio_remote__d8_clusters_sync: D8IstioRemoteClustersSync,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
-        summary: Istio remote cluster `{{$labels.cluster_id}}` is not synchronized.
+        summary: '{{ if $labels.multicluster_name }}IstioMulticluster `{{ $labels.multicluster_name }}` is not synchronized.{{ else }}Istio remote cluster `{{ $labels.cluster_id }}` is not synchronized.{{ end }}'
         description: |
-          The Istio control plane instance `{{$labels.istiod}}` cannot synchronize with the remote cluster `{{$labels.cluster_id}}`.
+          {{ if $labels.multicluster_name }}The Istio control plane instance `{{$labels.istiod}}` cannot synchronize with the remote cluster described by IstioMulticluster `{{$labels.multicluster_name}}` (cluster ID `{{$labels.cluster_id}}`).{{ else }}The Istio control plane instance `{{$labels.istiod}}` cannot synchronize with the remote cluster `{{$labels.cluster_id}}`.{{ end }}
 
           Possible causes:
 
@@ -104,3 +105,15 @@
           - The remote ServiceAccount token is invalid or expired.
           - There is a TLS or certificate issue between the clusters.
           - Remote and local Istio versions mismatch.
+
+          {{ if $labels.multicluster_name }}Inspect the resource:
+
+          ```bash
+          d8 k describe istiomulticluster {{$labels.multicluster_name}}
+          ```
+
+          `Root CA` should be set, `Public Last Fetch Timestamp` should be recent, and `Ingress Gateways` should list the remote cluster's IngressGateway addresses.
+
+          If there is no such resource, this cluster was registered by the secret `{{$labels.secret}}` alone — check the API address and the token in the kubeconfig it stores.
+          {{ else }}No IstioMulticluster resource registered this cluster, so check the API address and the token in the kubeconfig stored in the secret `{{$labels.secret}}`.
+          {{ end }}

--- a/ee/modules/110-istio/templates/alliance/ingressgateway/daemonset.yaml
+++ b/ee/modules/110-istio/templates/alliance/ingressgateway/daemonset.yaml
@@ -145,7 +145,7 @@ spec:
         - name: ISTIO_META_NETWORK
           value: {{ include "istioNetworkName" $ }}
         - name: ISTIO_META_CLUSTER_ID
-          value: {{ $.Values.global.discovery.clusterDomain | replace "." "-" }}-{{ adler32sum $.Values.global.discovery.clusterUUID }}
+          value: {{ include "istioClusterID" $ }}
   {{- if $.Values.istio.dataPlane.enableHTTP10 }}
         - name: ISTIO_META_HTTP10
           value: "1"

--- a/ee/modules/110-istio/templates/alliance/metadata-exporter/deployment.yaml
+++ b/ee/modules/110-istio/templates/alliance/metadata-exporter/deployment.yaml
@@ -79,6 +79,8 @@ spec:
           value: {{ include "helm_lib_module_public_domain" (list . "istio-api-proxy") }}
         - name: MULTICLUSTER_NETWORK_NAME
           value: {{ include "istioNetworkName" . | quote}}
+        - name: MULTICLUSTER_CLUSTER_ID
+          value: {{ include "istioClusterID" . | quote }}
   {{- end }}
   {{- if .Values.global.modules.publicDomainTemplate }}
         - name: ISTIO_METADATA_OLD_PUBLIC_HOST

--- a/ee/modules/110-istio/templates/multicluster/_kubeconfig.tpl
+++ b/ee/modules/110-istio/templates/multicluster/_kubeconfig.tpl
@@ -8,16 +8,16 @@ clusters:
     server: https://{{ $multicluster.apiHost }}
     certificate-authority-data: {{ $multicluster.metadataExporterCA | b64enc }}
     insecure-skip-tls-verify: {{ $multicluster.insecureSkipVerify }}
-  name: {{ $multicluster.name }}
+  name: {{ $multicluster.clusterID }}
 contexts:
 - context:
-    cluster: {{ $multicluster.name }}
-    user: {{ $multicluster.name }}
-  name: {{ $multicluster.name }}
-current-context: {{ $multicluster.name }}
+    cluster: {{ $multicluster.clusterID }}
+    user: {{ $multicluster.clusterID }}
+  name: {{ $multicluster.clusterID }}
+current-context: {{ $multicluster.clusterID }}
 preferences: {}
 users:
-- name: {{ $multicluster.name }}
+- name: {{ $multicluster.clusterID }}
   user:
     token: {{ $multicluster.apiJWT }}
 {{- end }}

--- a/ee/modules/110-istio/templates/multicluster/secrets-remote-kubeconfigs.yaml
+++ b/ee/modules/110-istio/templates/multicluster/secrets-remote-kubeconfigs.yaml
@@ -7,9 +7,9 @@ metadata:
   name: istio-remote-secret-{{ $multicluster.name }}
   namespace: d8-istio
   annotations:
-    networking.istio.io/cluster: {{ $multicluster.name }}
+    networking.istio.io/cluster: {{ $multicluster.clusterID }}
   {{- include "helm_lib_module_labels" (list $ (dict "app" "multicluster" "istio/multiCluster" "true")) | nindent 2 }}
 data:
-  {{ $multicluster.name }}: {{ include "istio_remote_kubeconfig" (list $multicluster) | b64enc }}
+  {{ $multicluster.clusterID }}: {{ include "istio_remote_kubeconfig" (list $multicluster) | b64enc }}
   {{- end }}
 {{- end }}

--- a/ee/modules/110-istio/templates/waypoint-controller/deployment.yaml
+++ b/ee/modules/110-istio/templates/waypoint-controller/deployment.yaml
@@ -53,7 +53,7 @@ spec:
         - name: ISTIO_CLOUD_PLATFORM
           value: {{ include "istioCloudPlatform" . }}
         - name: ISTIO_CLUSTER_ID
-          value: {{ .Values.global.discovery.clusterDomain | replace "." "-" }}-{{ adler32sum .Values.global.discovery.clusterUUID }}
+          value: {{ include "istioClusterID" . }}
         - name: VPA_ENABLED
           value: {{ if (.Values.global.enabledModules | has "vertical-pod-autoscaler") }}"true"{{ else }}"false"{{ end }}
         ports:

--- a/ee/modules/110-istio/templates/ztunnel/daemonset.yaml
+++ b/ee/modules/110-istio/templates/ztunnel/daemonset.yaml
@@ -85,7 +85,7 @@ spec:
         - name: RUST_BACKTRACE
           value: "1"
         - name: ISTIO_META_CLUSTER_ID
-          value: {{ .Values.global.discovery.clusterDomain | replace "." "-" }}-{{ adler32sum .Values.global.discovery.clusterUUID }}
+          value: {{ include "istioClusterID" . }}
         - name: INPOD_ENABLED
           value: "true"
         - name: TERMINATION_GRACE_PERIOD_SECONDS

--- a/modules/110-istio/docs/README.md
+++ b/modules/110-istio/docs/README.md
@@ -399,8 +399,8 @@ In case of issues when working with a multi-cluster, it is necessary to check in
 
    <!-- markdownlint-disable MD031 -->
    ```console
-   NAME          SECRET                                     STATUS     ISTIOD
-   cluster-b     d8-istio/istio-remote-secret-cluster-b     synced     istiod-v1x29-5c57d85b54-k8pl7
+   NAME                        SECRET                                     STATUS     ISTIOD
+   cluster-local-2451237693    d8-istio/istio-remote-secret-cluster-b     synced     istiod-v1x29-5c57d85b54-k8pl7
    ```
    {: .nowrap-default }
    <!-- markdownlint-enable MD031 -->

--- a/modules/110-istio/docs/README_RU.md
+++ b/modules/110-istio/docs/README_RU.md
@@ -404,8 +404,8 @@ Istio работает в режиме [multi-network](https://istio.io/latest/d
 
    <!-- markdownlint-disable MD031 -->
    ```console
-   NAME          SECRET                                     STATUS     ISTIOD
-   cluster-b     d8-istio/istio-remote-secret-cluster-b     synced     istiod-v1x29-5c57d85b54-k8pl7
+   NAME                        SECRET                                     STATUS     ISTIOD
+   cluster-local-2451237693    d8-istio/istio-remote-secret-cluster-b     synced     istiod-v1x29-5c57d85b54-k8pl7
    ```
    {: .nowrap-default }
    <!-- markdownlint-enable MD031 -->

--- a/modules/110-istio/files/v1x27/templates/sidecar-injection-values.yaml
+++ b/modules/110-istio/files/v1x27/templates/sidecar-injection-values.yaml
@@ -12,7 +12,7 @@
     "meshID": "d8-istio-mesh",
     "network": {{ include "istioNetworkName" $ | quote }},
     "multiCluster": {
-      "clusterName": {{ printf "%s-%s" ($.Values.global.discovery.clusterDomain | replace "." "-") ($.Values.global.discovery.clusterUUID | adler32sum) | quote }}
+      "clusterName": {{ include "istioClusterID" $ | quote }}
     },
     "externalIstiod": false,
     "jwtPolicy": {{ include "istioJWTPolicy" $ | quote }},

--- a/modules/110-istio/files/v1x29/templates/sidecar-injection-values.yaml
+++ b/modules/110-istio/files/v1x29/templates/sidecar-injection-values.yaml
@@ -12,7 +12,7 @@
     "meshID": "d8-istio-mesh",
     "network": {{ include "istioNetworkName" $ | quote }},
     "multiCluster": {
-      "clusterName": {{ printf "%s-%s" ($.Values.global.discovery.clusterDomain | replace "." "-") ($.Values.global.discovery.clusterUUID | adler32sum) | quote }}
+      "clusterName": {{ include "istioClusterID" $ | quote }}
     },
     "externalIstiod": false,
     "jwtPolicy": {{ include "istioJWTPolicy" $ | quote }},

--- a/modules/110-istio/openapi/values.yaml
+++ b/modules/110-istio/openapi/values.yaml
@@ -93,7 +93,7 @@ properties:
         type: array
         default: []
         x-examples:
-        - [{"name": "aaa", "clusterUUID": "uuid-aaa", "spiffeEndpoint": "ccc", "rootCA": "---ROOT CA---", "metadataExporterCA": "---METADATA CA---", "insecureSkipVerify": true, "enableIngressGateway": true, "apiHost": "aaa.sss.ddd", "networkName": "a-b-c-1-2-3", "apiJWT": "aAaA.bBbB.CcCc", "ingressGateways": [{"address": "1.2.3.4", "port": 1234}]}]
+        - [{"name": "aaa", "clusterUUID": "uuid-aaa", "spiffeEndpoint": "ccc", "rootCA": "---ROOT CA---", "metadataExporterCA": "---METADATA CA---", "insecureSkipVerify": true, "enableIngressGateway": true, "apiHost": "aaa.sss.ddd", "networkName": "network-a-b-c-1-2-3", "clusterID": "a-b-c-1-2-3", "apiJWT": "aAaA.bBbB.CcCc", "ingressGateways": [{"address": "1.2.3.4", "port": 1234}]}]
       remotePublicMetadata:
         type: object
         default: {}

--- a/modules/110-istio/template_tests/module_test.go
+++ b/modules/110-istio/template_tests/module_test.go
@@ -322,6 +322,129 @@ var _ = Describe("Module :: istio :: helm template :: main", func() {
 		})
 	})
 
+	Context("Local cluster identity", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", globalValues)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYamlWithOpenAPIDefaults("istio", istioValues)
+			f.ValuesSetFromYaml("istio.internal.versionMap", `
+"1.27":
+  revision: "v1x27"
+  fullVersion: "1.27.9"
+  imageSuffix: "V1x27x9"
+  supportsAmbient: true
+  supportsOperator: false
+`)
+			f.ValuesSetFromYaml("istio.internal.versionsToInstall", `["1.27"]`)
+			f.ValuesSet("istio.internal.globalVersion", "1.27")
+			f.HelmRender()
+		})
+
+		It("derives one cluster ID and uses it everywhere the cluster names itself", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			const clusterID = "my-domain-199688871"
+
+			istiod := f.KubernetesResource("Deployment", "d8-istio", "istiod-v1x27")
+			Expect(istiod.Exists()).To(BeTrue())
+			env := istiod.Field("spec.template.spec.containers.0.env").Array()
+			var clusterIDEnv string
+			for _, e := range env {
+				if e.Get("name").String() == "CLUSTER_ID" {
+					clusterIDEnv = e.Get("value").String()
+				}
+			}
+			Expect(clusterIDEnv).To(Equal(clusterID))
+
+			injectValues := f.KubernetesResource("ConfigMap", "d8-istio", "istio-sidecar-injector-v1x27").Field("data.values").String()
+			Expect(injectValues).To(ContainSubstring(`"clusterName": "` + clusterID + `"`))
+			Expect(injectValues).To(ContainSubstring(`"network": "network-` + clusterID + `"`))
+		})
+	})
+
+	Context("meshNetworks registry keying for an operator-free control plane", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", globalValues)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYamlWithOpenAPIDefaults("istio", istioValues)
+			f.ValuesSetFromYaml("istio.internal.versionMap", `
+"1.27":
+  revision: "v1x27"
+  fullVersion: "1.27.9"
+  imageSuffix: "V1x27x9"
+  supportsAmbient: true
+  supportsOperator: false
+`)
+			f.ValuesSetFromYaml("istio.internal.versionsToInstall", `["1.27"]`)
+			f.ValuesSet("istio.internal.globalVersion", "1.27")
+			f.ValuesSet("istio.multicluster.enabled", true)
+			f.ValuesSet("istio.internal.multiclustersNeedIngressGateway", true)
+		})
+
+		It("renders both the cluster ID and the CR name while the transitional entry stands", func() {
+			f.ValuesSetFromYaml("istio.internal.multiclusters", `
+- name: neighbour-renamed
+  apiHost: remote.api.example.com
+  apiJWT: aAaA.bBbB.CcCc
+  enableIngressGateway: true
+  insecureSkipVerify: false
+  ingressGateways:
+  - address: 1.1.1.1
+    port: 123
+  networkName: network-neigh-cluster-id
+  clusterID: neigh-cluster-id
+  metadataExporterCA: ""
+  rootCA: ---ROOT CA---
+  spiffeEndpoint: https://some-proper-host/spiffe-bundle-endpoint
+`)
+			f.HelmRender()
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			meshNetworks := f.KubernetesResource("ConfigMap", "d8-istio", "istio-v1x27").Field("data.meshNetworks").String()
+			Expect(meshNetworks).To(MatchYAML(`
+networks:
+  network-neigh-cluster-id:
+    endpoints:
+    - fromRegistry: neigh-cluster-id
+    - fromRegistry: neighbour-renamed
+    gateways:
+    - address: 1.1.1.1
+      port: 123
+`))
+		})
+
+		It("renders a single endpoint when the CR name already equals the cluster ID", func() {
+			f.ValuesSetFromYaml("istio.internal.multiclusters", `
+- name: neigh-cluster-id
+  apiHost: remote.api.example.com
+  apiJWT: aAaA.bBbB.CcCc
+  enableIngressGateway: true
+  insecureSkipVerify: false
+  ingressGateways:
+  - address: 1.1.1.1
+    port: 123
+  networkName: network-neigh-cluster-id
+  clusterID: neigh-cluster-id
+  metadataExporterCA: ""
+  rootCA: ---ROOT CA---
+  spiffeEndpoint: https://some-proper-host/spiffe-bundle-endpoint
+`)
+			f.HelmRender()
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			meshNetworks := f.KubernetesResource("ConfigMap", "d8-istio", "istio-v1x27").Field("data.meshNetworks").String()
+			Expect(meshNetworks).To(MatchYAML(`
+networks:
+  network-neigh-cluster-id:
+    endpoints:
+    - fromRegistry: neigh-cluster-id
+    gateways:
+    - address: 1.1.1.1
+      port: 123
+`))
+		})
+	})
+
 	Context("Telemetry mesh defaults for operator-free control plane 1.27", func() {
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global", globalValues)
@@ -1130,7 +1253,8 @@ cluster-b:
     ejEkdtt+SM9ao/txR3M/3t/IiAyY9lGT+N3VePEo6UNyfSRdSCT3c4Y/NUs4yXHS
     tQ==
     -----END CERTIFICATE-----
-  networkName: a-b-c-1-2-3
+  networkName: network-neigh-0-cluster-id
+  clusterID: neigh-0-cluster-id
   rootCA: ---ROOT CA---
   spiffeEndpoint: https://some-proper-host/spiffe-bundle-endpoint
 `)
@@ -1151,8 +1275,10 @@ neighbour-0:
 
 			kubeconfigSecret := f.KubernetesResource("Secret", "d8-istio", "istio-remote-secret-neighbour-0")
 			Expect(kubeconfigSecret.Exists()).To(BeTrue())
-			Expect(kubeconfigSecret.Field("data.neighbour-0").Exists()).To(BeTrue())
-			renderedKubeconfig, _ := base64.StdEncoding.DecodeString(kubeconfigSecret.Field("data.neighbour-0").String())
+			Expect(kubeconfigSecret.Field(`metadata.annotations.networking\.istio\.io/cluster`).String()).To(Equal("neigh-0-cluster-id"))
+			Expect(kubeconfigSecret.Field("data.neigh-0-cluster-id").Exists()).To(BeTrue())
+			Expect(kubeconfigSecret.Field("data.neighbour-0").Exists()).To(BeFalse())
+			renderedKubeconfig, _ := base64.StdEncoding.DecodeString(kubeconfigSecret.Field("data.neigh-0-cluster-id").String())
 			Expect(renderedKubeconfig).To(MatchYAML(`
 apiVersion: v1
 kind: Config
@@ -1161,16 +1287,16 @@ clusters:
     server: https://remote.api.example.com
     insecure-skip-tls-verify: false
     certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUZEVENDQXZXZ0F3SUJBZ0lVUmIrTDRkSDVxdjUzWlNEL3RCUlNkcTM3R280d0RRWUpLb1pJaHZjTkFRRUwKQlFBd0ZqRVVNQklHQTFVRUF3d0xZM1Z6ZEc5dExYSnZiM1F3SGhjTk1qUXhNVEkxTVRVeU56TXdXaGNOTXpReApNVEl6TVRVeU56TXdXakFXTVJRd0VnWURWUVFEREF0amRYTjBiMjB0Y205dmREQ0NBaUl3RFFZSktvWklodmNOCkFRRUJCUUFEZ2dJUEFEQ0NBZ29DZ2dJQkFKNEJOeDRFNWU5RUh6VklyejM3M0FPYW5Rc09NR0J3L1N4emZpUGUKOVBsTnR2RzlZWE10WWxqc29uYlpJNDIwYjhFOHlXQ0UrRXpSajBYdXQ4eXBuMXVCNytQdlZVZ2IyVENoSG5Xdgo2Q3ZFaGl5Q0JxdU9HS2Eybkt2TWxvdjVTR3Njai9DVXlqK3hEeHZvVHZQV28xVXhXdmpqaEM3elRHNUJHaUJ4Cmx0QkpiMm9Lc2dnM3pERzc0WDRodEJOVy9RTXV4WXBzOW1UTnV3STY5NzBlcUVaODF4NDMrNjZoR1dTbnlkM1kKM2Z6OFMvRXFLejNFdlBGVU40NG9NaVZSTlZKcTZxM3IwMXRRam1HUStoenRwUVpNNFRaU1pVQXpxS2ZScVh1egpHdHhoWXpRRFB0Mi9hUFdMVTJ5S0RpZzlibmV1NGxNQ2hERG5vd2sxWEhrT09aSzRRNWVRMkFjTTB0T2wzN0YyCnIzNFZtRUdEYlo4OW8zMTRFUGZVOGs5dk5jR2lTSUN4a25XMExEZFFYeEYvazhGWG1yVElnY0VRc0ZUa1ZyUEsKSDZVcFNVdkpaZlU0TFY2TGkzL1h6YStRVU5HVGxtcThSckUxdHpFZEZKZlhiZEh5YmhvZklxakRjdEEwdGx0NwpGcFBqRmU5Q1RCMlNkcXRtSk83WnNzSUoxSklUeFRsOUw3WjJCUHlqRnBYM3p3UlJBMG1KSDI3anJXNk14M01tCnVIdk9ncnFwOUQ4NUlaSTlRV3NZdXRhL2tLdWZTSGhIWWJlcldaUHQzR3JMQWRRbTF4Q3BUZ3U5Y0lRbVVpMHkKb1Q0R1BLNTR3bUVYeVVjMEhpZHhKQUd6SUJsdWpVR3JPbjA1bXB3NlZRcE9mZWpUejV4cWJ2WkFGaFVHMFFxdgpnQ2VIQWdNQkFBR2pVekJSTUIwR0ExVWREZ1FXQkJTOC9zVStNSTFUODBsbm5SWTduVnJaS0oxK1dUQWZCZ05WCkhTTUVHREFXZ0JTOC9zVStNSTFUODBsbm5SWTduVnJaS0oxK1dUQVBCZ05WSFJNQkFmOEVCVEFEQVFIL01BMEcKQ1NxR1NJYjNEUUVCQ3dVQUE0SUNBUUE4VmU4SjFDOUhNWnc2NklObVlhbnlDU2dZbDVJZUM3UXg3b3QyYXg0WQpveHJCSDFoVjVwRURvOFBRVU1PTlFpRVV1MEhMK1FPNnlaRVgxRHFiYjJsSXZHa1p2WkRPdVpuUUx1eVd2U0V0Ck51QWJKclFNeUZWcHhmdEt0OWFWTDBJL05LRFlrSnZDV2JJL1BhZVhkNDlIeVU3NTlIUzdudXJYdTR1R1NqR2EKWUJkcjBIWUFzZVQya0VZNWZQZzlqMDlvV0xZRkVnakJ5V1ZHY0xJd1paMXoxNEQ2OG9tZk1hL2trc0JPdFduUApTSklEbUZaSCtCODV5WSt3NnlLYjkvUmZDN0Q3TFlDRVRnK2dJSW11RXlJcXpMazVENHpHRXZWL0k5OVl3SlNJCm1rektJSi80Z2tBVk5xR1RVWjZNQnU3bENPY0JMZVFrY3JWaUpFREw2Wk1rbUV5ZVQwenJ2bitNY1NsNXF3L3gKVU5BVzUvalFoeU0vVjR0QWNHcUpqQnhJOWNRYlQ0K0ZiRHd3ZDlqUTV1NFlRcGxFUDVKTEtQVUcxaEtDS2RrNgpoTkJBRXdjSVB6M2lIK2hFS1pBdlZuYmxmWkt4cElNSGVMdHhtZjhLLzJKdkpWVEpuSG1ZeHZLMzRBK1hoRXJkCjhBeUlWcGRTWXdWMU5zU1RnTUhQZFBlUFpBK0gzbVJRT3RUdDFhZDhsRWcyTGFreHR1bjdrUU82MUs1eVRYY04KL1FQN3crR012ZHNxUW04RW9xRFhQejhDZm5vK2l0OTQyUmViMnptREdyR2ZoKy9pbm9NLzhBQ3ZoTkF6NFF5YwplakVrZHR0K1NNOWFvL3R4UjNNLzN0L0lpQXlZOWxHVCtOM1ZlUEVvNlVOeWZTUmRTQ1QzYzRZL05VczR5WEhTCnRRPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
-  name: neighbour-0
+  name: neigh-0-cluster-id
 contexts:
 - context:
-    cluster: neighbour-0
-    user: neighbour-0
-  name: neighbour-0
-current-context: neighbour-0
+    cluster: neigh-0-cluster-id
+    user: neigh-0-cluster-id
+  name: neigh-0-cluster-id
+current-context: neigh-0-cluster-id
 preferences: {}
 users:
-- name: neighbour-0
+- name: neigh-0-cluster-id
   user:
     token: aAaA.bBbB.CcCc
 `))
@@ -1213,8 +1339,9 @@ users:
   - my.domain
 `))
 			Expect(istio.Field("spec.values.global.meshNetworks").String()).To(MatchYAML(`
-a-b-c-1-2-3:
+network-neigh-0-cluster-id:
   endpoints:
+  - fromRegistry: neigh-0-cluster-id
   - fromRegistry: neighbour-0
   gateways:
   - address: 1.1.1.1

--- a/modules/110-istio/templates/_helpers.tpl
+++ b/modules/110-istio/templates/_helpers.tpl
@@ -33,8 +33,12 @@
   third-party-jwt
 {{- end -}}
 
+{{- define "istioClusterID" -}}
+  {{- .Values.global.discovery.clusterDomain | replace "." "-" }}-{{ adler32sum .Values.global.discovery.clusterUUID -}}
+{{- end -}}
+
 {{- define "istioNetworkName" -}}
-  network-{{ .Values.global.discovery.clusterDomain | replace "." "-" }}-{{ adler32sum $.Values.global.discovery.clusterUUID }}
+  network-{{ include "istioClusterID" . }}
 {{- end -}}
 
 {{- define "istioSupportsAmbient" -}}

--- a/modules/110-istio/templates/control-plane/configmap-mesh.yaml
+++ b/modules/110-istio/templates/control-plane/configmap-mesh.yaml
@@ -21,7 +21,16 @@ data:
     {{- if $multicluster.enableIngressGateway }}
       {{ $multicluster.networkName }}:
         endpoints:
+        {{- /*
+          We renamed the peer's registry from the CR name to the cluster ID.
+          Keep the old name here until istiod reloads the re-keyed remote secret.
+
+          TODO: drop the CR-name entry after 1.78.
+        */}}
+        - fromRegistry: {{ $multicluster.clusterID }}
+        {{- if ne $multicluster.name $multicluster.clusterID }}
         - fromRegistry: {{ $multicluster.name }}
+        {{- end }}
         gateways:
         {{- range $ingressGateway := $multicluster.ingressGateways }}
         - address: {{ $ingressGateway.address }}

--- a/modules/110-istio/templates/control-plane/deployment.yaml
+++ b/modules/110-istio/templates/control-plane/deployment.yaml
@@ -137,7 +137,7 @@ spec:
         - name: PILOT_ENABLE_ANALYSIS
           value: "false"
         - name: CLUSTER_ID
-          value: {{ printf "%s-%s" ($.Values.global.discovery.clusterDomain | replace "." "-") ($.Values.global.discovery.clusterUUID | adler32sum) | quote }}
+          value: {{ include "istioClusterID" $ | quote }}
         - name: ISTIO_MULTIROOT_MESH
           value: "true"
         - name: ENABLE_ENHANCED_RESOURCE_SCOPING

--- a/modules/110-istio/templates/control-plane/iop/istios.yaml
+++ b/modules/110-istio/templates/control-plane/iop/istios.yaml
@@ -51,14 +51,23 @@ spec:
       meshID: d8-istio-mesh
       network: {{ include "istioNetworkName" $ }}
       multiCluster:
-        clusterName: {{ $.Values.global.discovery.clusterDomain | replace "." "-" }}-{{ adler32sum $.Values.global.discovery.clusterUUID }}
+        clusterName: {{ include "istioClusterID" $ }}
   {{- if $.Values.istio.multicluster.enabled }}
       meshNetworks:
       {{- range $multicluster := $.Values.istio.internal.multiclusters }}
         {{- if $multicluster.enableIngressGateway }}
         {{ $multicluster.networkName }}:
           endpoints:
+          {{- /*
+            We renamed the peer's registry from the CR name to the cluster ID.
+            Keep the old name here until istiod reloads the re-keyed remote secret.
+
+            TODO: drop the CR-name entry after 1.78.
+          */}}
+          - fromRegistry: {{ $multicluster.clusterID }}
+          {{- if ne $multicluster.name $multicluster.clusterID }}
           - fromRegistry: {{ $multicluster.name }}
+          {{- end }}
           gateways:
           {{- range $ingressGateway := $multicluster.ingressGateways }}
           - address: {{ $ingressGateway.address }}

--- a/modules/110-istio/templates/ingressistiocontroller/daemonset.yaml
+++ b/modules/110-istio/templates/ingressistiocontroller/daemonset.yaml
@@ -158,7 +158,7 @@ spec:
           value: "1"
         {{- end }}
         - name: ISTIO_META_CLUSTER_ID
-          value: {{ $.Values.global.discovery.clusterDomain | replace "." "-" }}-{{ adler32sum $.Values.global.discovery.clusterUUID }}
+          value: {{ include "istioClusterID" $ }}
         - name: ISTIO_META_NETWORK
           value: {{ include "istioNetworkName" $ }}
         - name: JWT_POLICY


### PR DESCRIPTION
## Description

The module used two different names for the same peer cluster.

Every cluster names itself `{clusterDomain}-{adler32(clusterUUID)}`. This string is used as its istiod `CLUSTER_ID`, `ISTIO_META_CLUSTER_ID` and `global.multiCluster.clusterName`.

But `secrets-remote-kubeconfigs.yaml` annotated each remote secret with `networking.istio.io/cluster: {{ $multicluster.name }}`, which is the `IstioMulticluster` resource name. That name is only a local label. A third cluster can pick a different name for the same peer. Nothing made the two names match.

This PR makes the registry key of a peer be the cluster ID of that peer.

## Why do we need it, and what problem does it solve?

The mismatch stayed harmless while the cluster ID was only bookkeeping, and cross-cluster routing was keyed by network, not by cluster. Ambient changes that: to send traffic to a remote endpoint, istiod picks the east-west gateway by the pair (network, cluster), and ztunnel receives the same cluster ID as workload data. Both sides of that pair happen to match today, but only because both are read from the same registry, so both are the same name we invented locally. Nothing checks that they agree, so the mesh routes on a coincidence.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: fix
summary: |
  Align the cluster ID used for multicluster peers with the one used by the
  local cluster, for better support of ambient in multicluster setups.
impact: |
  Remote endpoints of multicluster peers may briefly disappear and come back
  during the upgrade.  Cross-cluster traffic served only by a remote peer can
  fail for a few seconds, so plan the upgrade accordingly if your multicluster
  setup is latency-sensitive.
impact_level: high
```