### PR TITLE
[istio] Move update-crd helper

### DIFF
--- a/docs/documentation/werf-git-section-modules.inc.yaml
+++ b/docs/documentation/werf-git-section-modules.inc.yaml
@@ -18,7 +18,6 @@
   - '040-node-manager/crds/staticmachine*.yaml'
   - '040-node-manager/crds/nfd-api-*.yaml'
   - '110-istio/crds/vendor'
-  - '110-istio/crds/update'
   includePaths: ['*/docs/','*/openapi/*.yaml','*/crds/', '*/oss.yaml']
 {{- if or (eq .Edition "BE") (eq .Edition "SE-plus") (eq .Edition "SE") (eq .Edition "EE") (eq .Edition "FE") (eq .Edition "CSE") (eq .Mode "development") }}
 - add: /ee/be/modules

--- a/modules/110-istio/crds/vendor/README.md
+++ b/modules/110-istio/crds/vendor/README.md
@@ -23,10 +23,11 @@ manually edit that status.
 
 ## Updating
 
-From the repository root, run:
+From the repository root:
 
 ```shell
-go run ./modules/110-istio/crds/update
+cd modules/110-istio/tools
+go run ./update-crds
 ```
 
 The updater downloads the Istio and Sail Operator CRDs at the versions listed
@@ -36,10 +37,12 @@ Remote sources are pinned rather than read from a moving branch such as `main`.
 When changing a source version, update its URL and checksum in the updater and
 carefully review the generated diff.
 
-Validate the checked-in bundle without downloading upstream sources with:
+Validate the checked-in bundle without downloading upstream sources, again from
+the repository root:
 
 ```shell
-go run ./modules/110-istio/crds/update --check
+cd modules/110-istio/tools
+go run ./update-crds --check
 ```
 
 The updater splits multi-document YAML without changing object semantics,

--- a/modules/110-istio/docs/internal/DEVELOPMENT.md
+++ b/modules/110-istio/docs/internal/DEVELOPMENT.md
@@ -1,0 +1,136 @@
+---
+title: Istio module maintenance
+searchable: false
+---
+
+Upstream Istio ships as a Helm chart, which we converted to our own format, dropping unnecessary parts and replacing their crutches with ours.
+
+Each Istio release contains:
+
+* The `istioctl` binary with embedded Helm charts (not used by Deckhouse for deployment, but handy for utilities).
+* An image with the Sail operator and the `Istio` CR (`sailoperator.io/v1`) — **only for versions below 1.27.9** (`supportsOperator: true`), i.e. currently only for Istio 1.25. The legacy `IstioOperator` CR (`install.istio.io/v1alpha1`) is no longer created: it remains only to clean up objects inherited from the discontinued version 1.21.
+* A set of images with Istio components (istiod, proxyv2, cni, …).
+* Upstream Helm charts.
+
+## Adding a new Istio version
+
+### Common steps (any version)
+
+1. Images in `images/` — following the example of the previous minor.
+2. The version in `oss.yaml`.
+3. The shared set of CRDs in `crds/vendor/`. Configuration CRDs are taken from Istio 1.29.6, while operator/Sail CRDs are kept for compatibility with Istio 1.25. To update them, run `go run ./update-crds` from `modules/110-istio/tools`; the parameters are described in [`crds/vendor/README.md`](../../crds/vendor/README.md).
+4. Validating the CRD bundle — a mandatory step after any changes in `crds/vendor/`, including manual edits of the files:
+
+   ```shell
+   cd modules/110-istio/tools
+   go run ./update-crds --check
+   ```
+
+   The check does not access the network and validates the already committed bundle: one object per file, the complete set of CRD names, exactly one storage version per CRD, and the preservation of legacy versions in `served`.
+5. **Without the operator:** `_rules_v-<major>-<minor>.tpl` + a branch in `_istiod_clusterroles.tpl`.
+6. Grafana — [`istio-grafana-dashboards.sh`](istio-grafana-dashboards.sh).
+7. **Without the operator:** the `files/<revision>/` directory — see below.
+8. [`template_tests/module_test.go`](../../template_tests/module_test.go).
+
+---
+
+## Version without the operator: the `files/<revision>/` directory
+
+Read this only if `supportsOperator: false`. Otherwise injection happens via the IOP/Istio CR ([`istios.yaml`](../../templates/control-plane/iop/istios.yaml)).
+
+`<revision>` = `versionMap.<ver>.revision` (1.29.x → `v1x29`).
+
+### What it is
+
+Deckhouse creates the **`istio-sidecar-injector-<revision>`** ConfigMap ([`configmap-inject.yaml`](../../templates/control-plane/configmap-inject.yaml)) from the directory:
+
+```none
+files/<revision>/
+├── static/   sidecar-injection-template.yaml, gateway-injection-template.yaml
+└── templates/   sidecar-injection-values.yaml, sidecar-injection-config.yaml
+        │                    │
+        └─► data.values (JSON)   data.config (YAML)
+```
+
+The mesh (`istio-<revision>`) lives in [`configmap-mesh.yaml`](../../templates/control-plane/configmap-mesh.yaml), **not** in `files/`.
+
+The sample to copy from is **`files/v1x29/`**.
+
+### How to add a new revision (1.30 as an example)
+
+**A. The module as a whole** — images, oss, CRDs, hooks, `_rules_v-1-30.tpl`, tests (as in the common steps above).
+
+**B. The `files/<revision>` directory** — usually 3 commands and that's it
+
+```bash
+# 1. Clone the required Istio tag
+git clone --depth 1 --branch 1.30.0 <ISTIO_REPO.git> /tmp/istio
+UP=/tmp/istio/manifests/charts/istio-control/istio-discovery
+
+# 2. Copy the whole previous revision
+cp -r files/v1x29 files/v1x30
+
+# 3. Replace only the upstream template bodies (no edits)
+cp "$UP/files/injection-template.yaml"         files/v1x30/static/sidecar-injection-template.yaml
+cp "$UP/files/gateway-injection-template.yaml" files/v1x30/static/gateway-injection-template.yaml
+```
+
+**For most minor bumps, this is enough.**
+`templates/sidecar-injection-values.yaml` and `sidecar-injection-config.yaml` are already present in the copy — **leave them alone** unless the static templates require new settings.
+
+**C. Control plane** (not `files/`) — istiod, webhooks, mesh: the templates in `templates/control-plane/`, the env in [`deployment.yaml`](../../templates/control-plane/deployment.yaml).
+
+### When to edit `templates/` (rarely)
+
+| File | When to change it |
+|------|----------------|
+| `sidecar-injection-values.yaml` | A new static template references a `.Values.…` that is missing from our JSON. Or the D8 logic is being changed deliberately (images, CNI, sidecar ranges). |
+| `sidecar-injection-config.yaml` | Upstream changed `defaultTemplates`, the inject selectors, or new template names are needed. The **`d8-*`** blocks are Deckhouse-only and are usually copied as is. |
+
+**How to check whether values need updating:** after `cp`-ing the static files, open the new `static/*.yaml` and search for `.Values.` — if a field is used without a fallback default in the template, add it to `sidecar-injection-values.yaml` (with the D8 helpers, as in `v1x29`).
+
+**How to check the config:** open the upstream
+`$UP/templates/istiod-injector-configmap.yaml`, the `config:` section (up to `templates:`) — and compare it with the top of our `sidecar-injection-config.yaml`. If Istio hasn't changed the policy/selectors, leave it alone.
+
+### Important: don't compare our JSON with the upstream JSON
+
+In `istiod-injector-configmap.yaml`, upstream assembles a **broad** `data.values` (almost the entire `global` from the chart values + `gateways` + `sidecarInjectorWebhook`).
+
+Ours is a **narrow** JSON: only what the inject templates need plus Deckhouse settings (registry, the `d8-istio` namespace, CNI, …). The webhook config lives in **`config`**, and the mesh lives in a **separate CM**.
+
+That's why the diff between the "upstream render" and "our render" for the **same tag** is always large — **this is normal**, not a sign of an error and not a checklist of things to fix.
+
+When doing a bump, look at:
+1. **The diff of the two static files** (the old vs. the new upstream one) — what changed in inject.
+2. **New `.Values.*` in the static files** — whether `values` needs to be extended.
+3. **The tests** — `go test` in `template_tests/`.
+
+### Where things come from upstream
+
+Istio tag → `manifests/charts/istio-control/istio-discovery/`:
+
+| What we need | Upstream file |
+|-----------|---------------|
+| static sidecar | `files/injection-template.yaml` |
+| static gateway | `files/gateway-injection-template.yaml` |
+| for reference: what Istio puts into the CM | `templates/istiod-injector-configmap.yaml` |
+
+[`istios.yaml`](../../templates/control-plane/iop/istios.yaml) — how it used to be with the operator; for the operator-free case, **do not copy it as a whole**, just take a look at the D8 logic.
+
+### `files/` checklist
+
+- [ ] `cp -r files/<prev> files/<revision>`
+- [ ] `static/` — 2 files from upstream as-is
+- [ ] if necessary — edits in `templates/` (see the table above)
+- [ ] `template_tests/module_test.go`
+
+---
+
+## Grafana dashboards
+
+The [`istio-grafana-dashboards.sh`](istio-grafana-dashboards.sh) script → JSON in `monitoring/grafana-dashboards/istio/`:
+
+* Clones the required Istio version.
+* `irate` → `rate`, `Resolution` → `1/1`, removes Min Step.
+* Graphs → Staircase (Stack+Percent may need manual fixing).
+* datasource → null, fixes the links to dashboards.

--- a/modules/110-istio/docs/internal/DEVELOPMENT_RU.md
+++ b/modules/110-istio/docs/internal/DEVELOPMENT_RU.md
@@ -36,9 +36,9 @@ searchable: false
 
 ## Версия без оператора: каталог `files/<revision>/`
 
-Читать только если `supportsOperator: false`. Иначе inject через IOP/Istio CR ([`istios.yaml`](../../templates/control-plane/istios.yaml)).
+Читать только если `supportsOperator: false`. Иначе inject через IOP/Istio CR ([`istios.yaml`](../../templates/control-plane/iop/istios.yaml)).
 
-`<revision>` = `versionMap.<ver>.revision` (1.27.x → `v1x27`).
+`<revision>` = `versionMap.<ver>.revision` (1.29.x → `v1x29`).
 
 ### Что это
 
@@ -54,28 +54,28 @@ files/<revision>/
 
 Mesh (`istio-<revision>`) — в [`configmap-mesh.yaml`](../../templates/control-plane/configmap-mesh.yaml), **не** в `files/`.
 
-Образец для копирования: **`files/v1x27/`**.
+Образец для копирования: **`files/v1x29/`**.
 
-### Как добавить новую revision (пример 1.28)
+### Как добавить новую revision (пример 1.30)
 
-**A. Модуль в целом** — images, oss, CRD, hooks, `_rules_v-1-28.tpl`, тесты (как в общих шагах выше).
+**A. Модуль в целом** — images, oss, CRD, hooks, `_rules_v-1-30.tpl`, тесты (как в общих шагах выше).
 
-**B. Каталог files/<revision>** — обычно 3 команды и всё
+**B. Каталог `files/<revision>`** — обычно 3 команды и всё
 
 ```bash
 # 1. Клон нужного тега Istio
-git clone --depth 1 --branch 1.28.0 <ISTIO_REPO.git> /tmp/istio
+git clone --depth 1 --branch 1.30.0 <ISTIO_REPO.git> /tmp/istio
 UP=/tmp/istio/manifests/charts/istio-control/istio-discovery
 
 # 2. Скопировать предыдущую revision целиком
-cp -r files/v1x27 files/v1x28
+cp -r files/v1x29 files/v1x30
 
 # 3. Заменить только upstream-тела шаблонов (без правок)
-cp "$UP/files/injection-template.yaml"         files/v1x28/static/sidecar-injection-template.yaml
-cp "$UP/files/gateway-injection-template.yaml" files/v1x28/static/gateway-injection-template.yaml
+cp "$UP/files/injection-template.yaml"         files/v1x30/static/sidecar-injection-template.yaml
+cp "$UP/files/gateway-injection-template.yaml" files/v1x30/static/gateway-injection-template.yaml
 ```
 
-**На этом для большинства minor bump достаточно.**  
+**На этом для большинства minor bump достаточно.**
 `templates/sidecar-injection-values.yaml` и `sidecar-injection-config.yaml` уже лежат в копии — **не трогаем**, если static не требует новых настроек.
 
 **C. Control plane** (не `files/`) — istiod, webhooks, mesh: шаблоны в `templates/control-plane/`, env в [`deployment.yaml`](../../templates/control-plane/deployment.yaml).
@@ -87,9 +87,9 @@ cp "$UP/files/gateway-injection-template.yaml" files/v1x28/static/gateway-inject
 | `sidecar-injection-values.yaml` | Новый static-шаблон ссылается на `.Values.…`, которого нет в нашем JSON. Или осознанно меняется D8-логика (образы, CNI, sidecar ranges). |
 | `sidecar-injection-config.yaml` | Upstream изменил `defaultTemplates`, селекторы inject, или нужны новые имена шаблонов. Блоки **`d8-*`** — только Deckhouse, обычно копируются как есть. |
 
-**Как проверить, нужен ли values:** после `cp` static откройте новые `static/*.yaml`, поищите `.Values.` — если поле используется без запасного default в шаблоне, добавьте его в `sidecar-injection-values.yaml` (с D8-хелперами, как в `v1x27`).
+**Как проверить, нужен ли values:** после `cp` static откройте новые `static/*.yaml`, поищите `.Values.` — если поле используется без запасного default в шаблоне, добавьте его в `sidecar-injection-values.yaml` (с D8-хелперами, как в `v1x29`).
 
-**Как проверить config:** откройте upstream  
+**Как проверить config:** откройте upstream
 `$UP/templates/istiod-injector-configmap.yaml`, секция `config:` (до `templates:`) — сравните с верхом нашего `sidecar-injection-config.yaml`. Если Istio не менял policy/селекторы — не трогайте.
 
 ### Важно: не сравнивать наш JSON с upstream JSON

--- a/modules/110-istio/docs/internal/DEVELOPMENT_RU.md
+++ b/modules/110-istio/docs/internal/DEVELOPMENT_RU.md
@@ -18,11 +18,19 @@ searchable: false
 
 1. Images в `images/` — по аналогии с предыдущим minor.
 2. Версия в `oss.yaml`.
-3. Общий набор CRD в `crds/vendor/`. Конфигурационные CRD берутся из Istio 1.29.6, а operator/Sail CRD сохраняются для совместимости с Istio 1.25. Для обновления из корня репозитория используйте `go run ./modules/110-istio/crds/update`; параметры описаны в [`crds/vendor/README.md`](../../crds/vendor/README.md).
-4. **Без оператора:** `_rules_v-<major>-<minor>.tpl` + ветка в `_istiod_clusterroles.tpl`.
-5. Grafana — [`istio-grafana-dashboards.sh`](istio-grafana-dashboards.sh).
-6. **Без оператора:** каталог `files/<revision>/` — см. ниже.
-7. [`template_tests/module_test.go`](../../template_tests/module_test.go).
+3. Общий набор CRD в `crds/vendor/`. Конфигурационные CRD берутся из Istio 1.29.6, а operator/Sail CRD сохраняются для совместимости с Istio 1.25. Для обновления выполните `go run ./update-crds` из `modules/110-istio/tools`; параметры описаны в [`crds/vendor/README.md`](../../crds/vendor/README.md).
+4. Проверка бандла CRD — обязательный шаг после любых изменений в `crds/vendor/`, в том числе после правки файлов вручную:
+
+   ```shell
+   cd modules/110-istio/tools
+   go run ./update-crds --check
+   ```
+
+   Проверка не ходит в сеть и валидирует уже закоммиченный бандл: по одному объекту на файл, полный набор имён CRD, ровно одна storage-версия у каждого CRD и сохранение legacy-версий в `served`.
+5. **Без оператора:** `_rules_v-<major>-<minor>.tpl` + ветка в `_istiod_clusterroles.tpl`.
+6. Grafana — [`istio-grafana-dashboards.sh`](istio-grafana-dashboards.sh).
+7. **Без оператора:** каталог `files/<revision>/` — см. ниже.
+8. [`template_tests/module_test.go`](../../template_tests/module_test.go).
 
 ---
 

--- a/modules/110-istio/tools/go.mod
+++ b/modules/110-istio/tools/go.mod
@@ -1,3 +1,10 @@
 module istio-tools
 
 go 1.26.4
+
+require (
+	gopkg.in/yaml.v3 v3.0.1
+	sigs.k8s.io/yaml v1.6.0
+)
+
+require go.yaml.in/yaml/v2 v2.4.2 // indirect

--- a/modules/110-istio/tools/go.sum
+++ b/modules/110-istio/tools/go.sum
@@ -1,0 +1,12 @@
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+go.yaml.in/yaml/v2 v2.4.2 h1:DzmwEr2rDGHl7lsFgAHxmNz/1NlQ7xLIrlN2h5d1eGI=
+go.yaml.in/yaml/v2 v2.4.2/go.mod h1:081UH+NErpNdqlCXm3TtEran0rJZGxAYx9hb/ELlsPU=
+go.yaml.in/yaml/v3 v3.0.3 h1:bXOww4E/J3f66rav3pX3m8w6jDE4knZjGOw8b5Y6iNE=
+go.yaml.in/yaml/v3 v3.0.3/go.mod h1:tBHosrYAkRZjRAOREWbDnBXUf08JOwYq++0QNwQiWzI=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=
+sigs.k8s.io/yaml v1.6.0/go.mod h1:796bPqUfzR/0jLAl6XjHl3Ck7MiyVv8dbTdyT3/pMf4=

--- a/modules/110-istio/tools/update-crds/main.go
+++ b/modules/110-istio/tools/update-crds/main.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Command update splits upstream Istio CRD bundles into the installed
+// Command update-crds splits upstream Istio CRD bundles into the installed
 // compatibility bundle and validates the result.
 package main
 
@@ -36,10 +36,12 @@ import (
 )
 
 const (
-	defaultOutputDir = "modules/110-istio/crds/vendor"
-	maxDownloadSize  = 16 << 20
-	istioVersion     = "1.29.6"
-	sailVersion      = "1.25.2"
+	toolsModulePath          = "istio-tools"
+	bundleDirFromToolsModule = "../crds/vendor"
+
+	maxDownloadSize = 16 << 20
+	istioVersion    = "1.29.6"
+	sailVersion     = "1.25.2"
 
 	// This compatibility CRD was retained by Deckhouse when upstream Istio
 	// removed the in-cluster operator chart. Keep it embedded so regeneration
@@ -192,17 +194,25 @@ func main() {
 }
 
 func run(args []string) error {
-	flags := flag.NewFlagSet("istio-crd-update", flag.ContinueOnError)
+	flags := flag.NewFlagSet("update-crds", flag.ContinueOnError)
 	flags.SetOutput(io.Discard)
 
 	var opts options
 	flags.BoolVar(&opts.check, "check", false, "validate the installed bundle")
-	flags.StringVar(&opts.outputDir, "output-dir", defaultOutputDir, "installed compatibility bundle directory")
+	flags.StringVar(&opts.outputDir, "output-dir", "", "installed compatibility bundle directory (default: crds/vendor next to the istio-tools module)")
 	if err := flags.Parse(args); err != nil {
 		return err
 	}
 	if flags.NArg() != 0 {
 		return fmt.Errorf("unexpected positional arguments: %s", strings.Join(flags.Args(), " "))
+	}
+
+	if opts.outputDir == "" {
+		dir, err := defaultOutputDir()
+		if err != nil {
+			return err
+		}
+		opts.outputDir = dir
 	}
 
 	if opts.check {
@@ -218,6 +228,65 @@ func run(args []string) error {
 		return err
 	}
 	return replaceBundle(opts.outputDir, objects)
+}
+
+func defaultOutputDir() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("determine working directory: %w", err)
+	}
+
+	current := dir
+	for {
+		if isToolsModuleRoot(current) {
+			// The module root is unambiguous, so a missing bundle is a
+			// broken checkout rather than a reason to keep searching.
+			bundleDir := filepath.Join(current, bundleDirFromToolsModule)
+			if !isDir(bundleDir) {
+				return "", fmt.Errorf("found the %s module at %s, but its bundle directory %s is missing: restore it or pass --output-dir", toolsModulePath, current, bundleDir)
+			}
+			return bundleDir, nil
+		}
+
+		parent := filepath.Dir(current)
+		if parent == current {
+			return "", fmt.Errorf("no %s module found at or above %s: run the command from modules/110-istio/tools or pass --output-dir", toolsModulePath, dir)
+		}
+		current = parent
+	}
+}
+
+func isToolsModuleRoot(dir string) bool {
+	data, err := os.ReadFile(filepath.Join(dir, "go.mod"))
+	if err != nil {
+		return false
+	}
+	return modulePath(data) == toolsModulePath
+}
+
+func modulePath(goMod []byte) string {
+	for line := range strings.SplitSeq(string(goMod), "\n") {
+		if comment := strings.Index(line, "//"); comment >= 0 {
+			line = line[:comment]
+		}
+		rest, ok := strings.CutPrefix(strings.TrimSpace(line), "module")
+		if !ok || rest == "" {
+			continue
+		}
+		path := strings.TrimSpace(rest)
+		if path == rest {
+			// No separator after the directive: this is some other token
+			// starting with "module", not the module directive.
+			continue
+		}
+		return strings.Trim(path, `"`)
+	}
+	return ""
+}
+
+func isDir(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
 }
 
 func sailURL(name string) string {

--- a/modules/110-istio/tools/update-crds/main_test.go
+++ b/modules/110-istio/tools/update-crds/main_test.go
@@ -28,12 +28,50 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func TestCheckedInBundle(t *testing.T) {
-	if err := checkBundle("../vendor"); err != nil {
+const bundleDir = "../../crds/vendor"
+
+func TestDefaultOutputDirResolvesCheckedInBundle(t *testing.T) {
+	got, err := defaultOutputDir()
+	if err != nil {
 		t.Fatal(err)
 	}
 
-	paths, err := filepath.Glob("../vendor/*.yaml")
+	want, err := filepath.Abs(bundleDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Errorf("defaultOutputDir() = %q, want %q", got, want)
+	}
+}
+
+func TestModulePath(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		goMod string
+		want  string
+	}{
+		{name: "plain", goMod: "module istio-tools\n\ngo 1.26.4\n", want: "istio-tools"},
+		{name: "quoted", goMod: "module \"istio-tools\"\n", want: "istio-tools"},
+		{name: "trailing comment", goMod: "module istio-tools // tools\n", want: "istio-tools"},
+		{name: "commented out", goMod: "// module istio-tools\n", want: ""},
+		{name: "no directive", goMod: "go 1.26.4\n", want: ""},
+		{name: "lookalike token", goMod: "modules\n", want: ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := modulePath([]byte(tc.goMod)); got != tc.want {
+				t.Errorf("modulePath(%q) = %q, want %q", tc.goMod, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCheckedInBundle(t *testing.T) {
+	if err := checkBundle(bundleDir); err != nil {
+		t.Fatal(err)
+	}
+
+	paths, err := filepath.Glob(filepath.Join(bundleDir, "*.yaml"))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Description

Move the Istio CRD bundle updater from `modules/110-istio/crds/update` to `modules/110-istio/tools/update-crds`, renaming the command along the way.

## Why do we need it, and what problem does it solve?

`tools/` was added recently together with `build-envoy-artifacts`, a developer helper of exactly the same shape - run by hand, never compiled into an image, pinned versions in the source. With two of them, the module has a natural home for dev helpers, and grouping them means one `go.mod`, one Dependabot entry, and one place to look.

`crds/` is a delivery directory: everything else in it is a CRD manifest installed into the cluster, and the werf docs image adds `*/crds/` wholesale. Go source there needed an explicit `excludePaths` entry that existed only because the file was in the wrong place.

Moving it out of the root module also stops the updater's YAML dependencies from being root-module dependencies of Deckhouse itself.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: chore
summary: Move the Istio CRD bundle updater from `crds/update` to `tools/update-crds`.
impact_level: low
```