### PR TITLE
[pkg/registry] Enhance registry features

### DIFF
--- a/pkg/registry/README.md
+++ b/pkg/registry/README.md
@@ -212,11 +212,13 @@ Client
 ├── PushImage(ctx, tag, v1.Image, ...ImagePushOption) error
 ├── PushIndex(ctx, tag, v1.ImageIndex, ...ImagePushOption) error
 ├── GetDigest(ctx, tag) (*v1.Hash, error)
-├── GetManifest(ctx, tag) (ManifestResult, error)
+├── GetManifest(ctx, tag, ...ManifestGetOption) (ManifestResult, error)
 ├── GetImageConfig(ctx, tag) (*v1.ConfigFile, error)
 ├── CheckImageExists(ctx, tag) error
 ├── ListTags(ctx, ...ListTagsOption) ([]string, error)
+├── StreamTags(ctx, visit, ...ListTagsOption) error
 ├── ListRepositories(ctx, ...ListRepositoriesOption) ([]string, error)
+├── StreamRepositories(ctx, visit, ...ListRepositoriesOption) error
 ├── DeleteTag(ctx, tag) error
 ├── DeleteByDigest(ctx, v1.Hash) error
 ├── TagImage(ctx, sourceTag, destTag) error
@@ -717,6 +719,26 @@ than a concrete `*client.Client`, the image is pulled and re-pushed via `PushIma
 
 ### List Tags
 
+`ListTags` and `ListRepositories` walk the registry's `Link` cursor to the end, so the
+result is the complete list or an error - never a page, and never a silently truncated
+list. `StreamTags` and `StreamRepositories` are the same walk without buffering: `visit`
+is called once per page as it arrives, and returning `registry.ErrStopStreaming` ends the
+walk without being reported as a failure.
+
+```go
+err := registryClient.StreamTags(ctx, func(page []string) error {
+    for _, tag := range page {
+        fmt.Println(tag)
+    }
+
+    return nil
+})
+```
+
+`WithTagsLimit(n)` / `WithReposLimit(n)` opt out of the full walk and return one page of
+at most n entries; continue from it with `WithTagsLast` / `WithReposLast`.
+
+
 The `ListTags` method supports server-side pagination for large repositories:
 
 ```go
@@ -922,7 +944,22 @@ if err != nil {
 &v1.Platform{OS: "linux", Architecture: "arm", Variant: "v7"}
 ```
 
-**Note**: If no platform is specified, the registry typically returns the manifest for the host's native platform.
+> **Important**: if no platform is specified, you do **not** get the host's native platform.
+> `go-containerregistry` falls back to a hardcoded `linux/amd64`, so `GetImage` on a
+> multi-arch reference returns the amd64 child even on an arm64 machine. Pass
+> `WithPlatform` whenever the answer has to match the caller's architecture.
+>
+> `GetManifest` behaves differently on purpose: without a platform it returns the
+> reference **as served**, which for a multi-arch tag is the index itself rather than
+> any single image's manifest. Pass `WithPlatform` to resolve it to one child:
+>
+> ```go
+> res, err := registryClient.GetManifest(ctx, "v1.0.0",
+>     client.WithPlatform{Platform: &v1.Platform{OS: "linux", Architecture: "arm64"}})
+> ```
+>
+> A platform the index does not carry returns `registry.ErrImageNotFound`, and a
+> platform on a single-image reference is a no-op.
 
 ### Working with Context
 
@@ -1126,8 +1163,20 @@ registryClient = client.NewClientWithOptions("registry.example.com", opts)
 | Error | Package | Description |
 |---|---|---|
 | `ErrImageNotFound` | `registry` and `client` | Image tag or digest does not exist |
+| `ErrRepositoryNotFound` | `registry` | Repository is unknown to the registry (`NAME_UNKNOWN`). Unwraps to `ErrImageNotFound`, so code that only checks for a missing image keeps working |
+| `ErrAccessDenied` | `registry` | Registry refused the request for lack of rights: HTTP 401/403, or `UNAUTHORIZED`/`DENIED` |
+| `ErrCatalogNotSupported` | `registry` | Registry does not implement `/v2/_catalog` (Docker Hub, GCR, Artifact Registry) |
+| `ErrStopStreaming` | `registry` | Returned *by the caller* from a `StreamTags`/`StreamRepositories` visit function to end the walk early |
 | `ErrIsIndexManifest` | `client` | `GetManifest()` called on an index manifest |
 | `ErrIsNotIndexManifest` | `client` | `GetIndexManifest()` called on a non-index manifest |
+
+Classification happens once, inside the client, where the typed `*transport.Error` is
+still in hand - so `errors.Is` is enough downstream and callers never need to match on
+HTTP status codes or error-message substrings.
+
+`ErrAccessDenied` deliberately does **not** imply "not found": a token-auth registry
+denies anything outside the identity's scope whether or not the target exists, so a
+denied request says nothing about existence.
 
 ```go
 import (

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -54,7 +54,18 @@ type Client interface {
 	CheckImageExists(ctx context.Context, tag string) error
 
 	// ListTags returns tags for the repository built by WithSegment calls.
+	// The registry's Link-cursor chain is walked to the end, so the result is
+	// the complete list or an error - never a silently truncated page. Ask for
+	// a single page explicitly with WithTagsLimit / WithTagsLast.
 	ListTags(ctx context.Context, opts ...ListTagsOption) ([]string, error)
+
+	// StreamTags invokes visit once per page of tags as it arrives, so a caller
+	// can walk a repository with very many tags without buffering all of them.
+	// It is the non-accumulating form of ListTags and accepts the same options.
+	//
+	// Returning ErrStopStreaming from visit ends the walk without surfacing as
+	// an error; any other error from visit is returned to the caller as-is.
+	StreamTags(ctx context.Context, visit func(tags []string) error, opts ...ListTagsOption) error
 
 	// ListRepositories lists repositories visible from the registry.
 	ListRepositories(ctx context.Context, opts ...ListRepositoriesOption) ([]string, error)

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -38,6 +38,13 @@ type Client interface {
 	// not the host's platform - so an arm64 caller silently gets amd64.
 	GetImage(ctx context.Context, tag string, opts ...ImageGetOption) (Image, error)
 
+	// GetIndex retrieves a multi-arch index by tag or digest reference.
+	//
+	// Unlike GetImage it resolves nothing: the whole index comes back, which is
+	// what a caller copying or storing every platform needs. A reference that is
+	// a plain image rather than an index is an error.
+	GetIndex(ctx context.Context, tag string) (v1.ImageIndex, error)
+
 	// PushImage pushes a v1.Image to the registry at the specified tag.
 	PushImage(ctx context.Context, tag string, img v1.Image, opts ...ImagePushOption) error
 

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -32,6 +32,10 @@ type Client interface {
 	GetRegistry() string
 
 	// GetImage retrieves a remote image by tag or digest reference.
+	//
+	// For a multi-arch reference, pass WithPlatform to choose the child image.
+	// Without it the underlying library resolves to a hardcoded linux/amd64 -
+	// not the host's platform - so an arm64 caller silently gets amd64.
 	GetImage(ctx context.Context, tag string, opts ...ImageGetOption) (Image, error)
 
 	// PushImage pushes a v1.Image to the registry at the specified tag.
@@ -43,8 +47,14 @@ type Client interface {
 	// GetDigest returns the digest hash for the given tag or digest reference.
 	GetDigest(ctx context.Context, tag string) (*v1.Hash, error)
 
-	// GetManifest retrieves the manifest for a specific image reference.
-	GetManifest(ctx context.Context, tag string) (ManifestResult, error)
+	// GetManifest retrieves the manifest for a specific image reference, as the
+	// registry served it.
+	//
+	// For a multi-arch reference the result is the index itself. Pass
+	// WithPlatform to resolve it to one child image's manifest instead; unlike
+	// GetImage, omitting the platform resolves nothing rather than defaulting to
+	// linux/amd64.
+	GetManifest(ctx context.Context, tag string, opts ...ManifestGetOption) (ManifestResult, error)
 
 	// GetImageConfig retrieves the image config file containing labels and metadata.
 	GetImageConfig(ctx context.Context, tag string) (*v1.ConfigFile, error)
@@ -67,8 +77,17 @@ type Client interface {
 	// an error; any other error from visit is returned to the caller as-is.
 	StreamTags(ctx context.Context, visit func(tags []string) error, opts ...ListTagsOption) error
 
-	// ListRepositories lists repositories visible from the registry.
+	// ListRepositories lists repositories visible from the registry, walking the
+	// catalog cursor to the end so the result is complete or an error.
+	//
+	// Registries that do not implement /v2/_catalog - Docker Hub, GCR and
+	// Artifact Registry among them - report ErrCatalogNotSupported.
 	ListRepositories(ctx context.Context, opts ...ListRepositoriesOption) ([]string, error)
+
+	// StreamRepositories is to ListRepositories what StreamTags is to ListTags:
+	// visit is invoked once per page as it arrives, and ErrStopStreaming ends
+	// the walk without being reported as a failure.
+	StreamRepositories(ctx context.Context, visit func(repos []string) error, opts ...ListRepositoriesOption) error
 
 	// DeleteTag deletes a specific tag from the registry.
 	DeleteTag(ctx context.Context, tag string) error

--- a/pkg/registry/client/client.go
+++ b/pkg/registry/client/client.go
@@ -67,8 +67,14 @@ type Client struct {
 	// remote options for go-containerregistry
 	options []remote.Option
 	// auth is stored separately from remote options to build authenticated
-	// HTTP transports for direct registry requests (listTagsPage).
+	// HTTP transports for direct registry requests (StreamTags).
 	auth authn.Authenticator
+	// keychain is kept for the same reason as auth: the direct HTTP path has to
+	// resolve credentials itself, and a client built with WithKeychain has no
+	// explicit authenticator to fall back on.
+	keychain authn.Keychain
+	// userAgent is kept so direct requests carry the same header remote.* sends.
+	userAgent string
 	// baseTransport carries CA/TLS/proxy settings for direct HTTP requests.
 	baseTransport http.RoundTripper
 	// insecure flag for HTTP connections
@@ -114,6 +120,8 @@ func NewClientWithOptions(host string, opts *Options) *Client {
 		registryHost:  host,
 		options:       buildRemoteOptions(opts, logger, baseTransport),
 		auth:          opts.Auth,
+		keychain:      opts.Keychain,
+		userAgent:     opts.UserAgent,
 		baseTransport: baseTransport,
 		timeout:       opts.Timeout,
 		logger:        logger,
@@ -171,11 +179,16 @@ func (c *Client) WithSegment(segments ...string) registry.Client {
 		return c
 	}
 
+	// Every field is copied explicitly because Client embeds a sync.Once, which
+	// rules out `nc := *c` (go vet's copylocks). Any field added to Client has
+	// to be added here too, or it is silently dropped on the first chained call.
 	return &Client{
 		registryHost:  c.registryHost,
 		segments:      append(append([]string(nil), c.segments...), segments...),
 		options:       c.options,
 		auth:          c.auth,
+		keychain:      c.keychain,
+		userAgent:     c.userAgent,
 		baseTransport: c.baseTransport,
 		logger:        c.logger,
 		insecure:      c.insecure,
@@ -412,48 +425,18 @@ func (w *withTagsLimit) ApplyToListTags(opts *registry.ListTagsOptions) {
 
 // ListTags returns tags for the repository built by WithSegment calls.
 //
-// Without options, all tags are returned. WithTagsLimit(n) returns at most one page
-// of n tags. WithTagsLast(tag) returns tags lexicographically after tag.
-// Both options can be combined.
+// Without options every page of the registry's Link-cursor chain is walked and
+// the complete list is returned - never a partial one. WithTagsLimit(n) returns
+// at most one page of n tags and WithTagsLast(tag) starts after tag; both can be
+// combined. StreamTags is the same walk without accumulating the result.
 func (c *Client) ListTags(ctx context.Context, opts ...registry.ListTagsOption) ([]string, error) {
-	listOptions := &registry.ListTagsOptions{}
-	for _, opt := range opts {
-		opt.ApplyToListTags(listOptions)
-	}
+	var tags []string
 
-	c.logger.With(
-		slog.String("registry_host", c.registryHost),
-		slog.String("segments", c.constructedSegments),
-		slog.Int("limit", listOptions.N),
-		slog.String("last", listOptions.Last),
-	).Debug("Listing tags")
+	err := c.StreamTags(ctx, func(page []string) error {
+		tags = append(tags, page...)
 
-	ref, err := name.ParseReference(c.GetRegistry(), c.nameOptions()...)
-	if err != nil {
-		return nil, fmt.Errorf("parse reference: %w", err)
-	}
-
-	repo := ref.Context()
-
-	if listOptions.N > 0 || listOptions.Last != "" {
-		if c.timeout > 0 {
-			var cancel context.CancelFunc
-			ctx, cancel = context.WithTimeout(ctx, c.timeout)
-			defer cancel()
-		}
-
-		tags, err := c.listTagsPage(ctx, repo, listOptions.Last, listOptions.N)
-		if err != nil {
-			return nil, err
-		}
-
-		c.logger.Debug("Tags listed", slog.Int("count", len(tags)))
-
-		return tags, nil
-	}
-
-	remoteOpts := append(append([]remote.Option{}, c.options...), c.withContext(ctx))
-	tags, err := remote.List(repo, remoteOpts...)
+		return nil
+	}, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -463,38 +446,126 @@ func (c *Client) ListTags(ctx context.Context, opts ...registry.ListTagsOption) 
 	return tags, nil
 }
 
-// listTagsPage fetches a single page of tags (pageSize > 0) or all remaining pages via direct HTTP.
-// When pageSize is 0, the registry picks its own page size and all pages are collected via Link headers.
-func (c *Client) listTagsPage(ctx context.Context, repo name.Repository, last string, pageSize int) ([]string, error) {
+// StreamTags invokes visit once per page of tags as it arrives.
+//
+// This is the single tag-listing path: ListTags is a thin accumulator on top,
+// so both share the guarantees below.
+//
+// The `n` query parameter is sent only when WithTagsLimit asked for a page size.
+// Registries that reject an `n` they do not implement answer 400 and would fail
+// the whole listing, and asking for large pages buys nothing when the cursor is
+// followed to the end anyway.
+//
+// Returning ErrStopStreaming from visit ends the walk cleanly; any other error
+// from visit is propagated unchanged.
+func (c *Client) StreamTags(ctx context.Context, visit func(tags []string) error, opts ...registry.ListTagsOption) error {
+	listOptions := &registry.ListTagsOptions{}
+	for _, opt := range opts {
+		opt.ApplyToListTags(listOptions)
+	}
+
+	logentry := c.logger.With(
+		slog.String("registry_host", c.registryHost),
+		slog.String("segments", c.constructedSegments),
+		slog.Int("limit", listOptions.N),
+		slog.String("last", listOptions.Last),
+	)
+
+	logentry.Debug("Streaming tags")
+
+	ref, err := name.ParseReference(c.GetRegistry(), c.nameOptions()...)
+	if err != nil {
+		return fmt.Errorf("parse reference: %w", err)
+	}
+
+	repo := ref.Context()
+
+	if c.timeout > 0 {
+		var cancel context.CancelFunc
+
+		ctx, cancel = context.WithTimeout(ctx, c.timeout)
+		defer cancel()
+	}
+
 	httpClient, err := c.registryHTTPClient(ctx, repo)
 	if err != nil {
-		return nil, fmt.Errorf("create registry client: %w", err)
+		return fmt.Errorf("create registry client: %w", err)
 	}
 
-	nextURL := tagsURL(repo, last, pageSize)
-	var allTags []string
+	// A registry that ignores `last` and echoes the same Link cursor on every
+	// response keeps this walk going forever, re-delivering the same page. A
+	// cursor already followed cannot make progress, so refusing it turns a
+	// broken registry into an error instead of a hang.
+	seen := make(map[string]struct{})
 
-	for nextURL != "" {
-		tags, next, err := c.fetchTagsPage(ctx, httpClient, nextURL)
+	pageURL := tagsURL(repo, listOptions.Last, listOptions.N)
+	pages := 0
+
+	for pageURL != "" {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		tags, next, err := c.fetchTagsPage(ctx, httpClient, pageURL)
 		if err != nil {
-			return nil, err
+			return err
 		}
 
-		allTags = append(allTags, tags...)
+		pages++
 
-		if pageSize > 0 {
-			return allTags, nil
+		if err := visit(tags); err != nil {
+			if errors.Is(err, registry.ErrStopStreaming) {
+				logentry.Debug("Tag streaming stopped by caller", slog.Int("pages", pages))
+
+				return nil
+			}
+
+			return err
 		}
 
-		nextURL = next
+		// WithTagsLimit asks for exactly one page; continuing is the caller's
+		// business, via WithTagsLast on the next call.
+		if listOptions.N > 0 {
+			break
+		}
+
+		if next != "" {
+			if _, dup := seen[next]; dup {
+				return fmt.Errorf("list tags for %s: registry keeps returning the same pagination cursor %q, refusing to loop", repo, next)
+			}
+
+			seen[next] = struct{}{}
+		}
+
+		pageURL = next
 	}
 
-	return allTags, nil
+	logentry.Debug("Tag streaming finished", slog.Int("pages", pages))
+
+	return nil
 }
 
 // registryHTTPClient creates an authenticated HTTP client for direct registry requests.
+//
+// Credentials resolve the way buildRemoteOptions hands them to remote.*: an
+// explicit authenticator wins, otherwise the keychain is resolved for this
+// repository. Without the keychain branch the direct path went out anonymous
+// for every client built with WithKeychain, so a private registry answered 401.
+//
+// The transport is then wrapped the way remote.* wraps its own, so direct
+// requests keep retry-on-temporary-failure and the configured User-Agent.
 func (c *Client) registryHTTPClient(ctx context.Context, repo name.Repository) (*http.Client, error) {
 	auth := c.auth
+
+	if auth == nil && c.keychain != nil {
+		resolved, err := c.keychain.Resolve(repo)
+		if err != nil {
+			return nil, fmt.Errorf("resolve credentials for %s: %w", repo, err)
+		}
+
+		auth = resolved
+	}
+
 	if auth == nil {
 		auth = authn.Anonymous
 	}
@@ -502,6 +573,12 @@ func (c *Client) registryHTTPClient(ctx context.Context, repo name.Repository) (
 	rt, err := transport.NewWithContext(ctx, repo.Registry, auth, c.baseTransport, []string{repo.Scope(transport.PullScope)})
 	if err != nil {
 		return nil, fmt.Errorf("build transport: %w", err)
+	}
+
+	rt = transport.NewRetry(rt)
+
+	if c.userAgent != "" {
+		rt = transport.NewUserAgent(rt, c.userAgent)
 	}
 
 	return &http.Client{Transport: rt}, nil

--- a/pkg/registry/client/client.go
+++ b/pkg/registry/client/client.go
@@ -452,6 +452,49 @@ func (c *Client) GetImage(ctx context.Context, tag string, opts ...registry.Imag
 
 // PushImage pushes an image to the registry at the specified tag
 // The repository is determined by the chained WithSegment() calls
+// GetIndex retrieves a multi-arch index without resolving it to any platform.
+func (c *Client) GetIndex(ctx context.Context, tag string) (v1.ImageIndex, error) {
+	logentry := c.logger.With(
+		slog.String("registry_host", c.registryHost),
+		slog.String("segments", c.constructedSegments),
+		slog.String("tag", tag),
+	)
+
+	logentry.Debug("Getting index")
+
+	ref, err := name.ParseReference(c.buildReference(tag), c.nameOptions()...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse reference: %w", err)
+	}
+
+	remoteOpts := append([]remote.Option{}, c.options...)
+	remoteOpts = append(remoteOpts, c.withContext(ctx))
+
+	desc, err := remote.Get(ref, remoteOpts...)
+	if err != nil {
+		if sentinel := sentinelFor(err); sentinel != nil {
+			return nil, fmt.Errorf("%w: %w", sentinel, err)
+		}
+
+		return nil, fmt.Errorf("failed to get index: %w", err)
+	}
+
+	// remote.Descriptor.ImageIndex would wrap a plain image in a synthetic
+	// single-entry index, which is not what a caller asking for an index means.
+	if !desc.MediaType.IsIndex() {
+		return nil, fmt.Errorf("%s is not an index (mediaType %q)", ref, desc.MediaType)
+	}
+
+	idx, err := desc.ImageIndex()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read index: %w", err)
+	}
+
+	logentry.Debug("Index retrieved successfully")
+
+	return idx, nil
+}
+
 func (c *Client) PushImage(ctx context.Context, tag string, img v1.Image, opts ...registry.ImagePushOption) error {
 	putImageOptions := &registry.ImagePushOptions{}
 
@@ -473,6 +516,10 @@ func (c *Client) PushImage(ctx context.Context, tag string, img v1.Image, opts .
 	}
 
 	remoteOptions := append([]remote.Option{}, c.options...)
+
+	if putImageOptions.AllowNondistributableArtifacts {
+		remoteOptions = append(remoteOptions, remote.WithNondistributable)
+	}
 	remoteOptions = append(remoteOptions, c.withContext(ctx))
 
 	if err := remote.Write(ref, img, remoteOptions...); err != nil {
@@ -508,6 +555,18 @@ func (c *Client) GetImageConfig(ctx context.Context, tag string) (*v1.ConfigFile
 	logentry.Debug("Image config retrieved successfully")
 
 	return configFile, nil
+}
+
+// WithNondistributable uploads foreign (non-distributable) layers on push
+// instead of skipping them.
+func WithNondistributable() registry.ImagePushOption {
+	return &withNondistributable{}
+}
+
+type withNondistributable struct{}
+
+func (w *withNondistributable) ApplyToImagePush(opts *registry.ImagePushOptions) {
+	opts.AllowNondistributableArtifacts = true
 }
 
 // WithTagsLast sets the pagination cursor; only tags after last are returned.
@@ -1314,6 +1373,10 @@ func (c *Client) PushIndex(ctx context.Context, tag string, idx v1.ImageIndex, o
 
 	remoteOptions := append([]remote.Option{}, c.options...)
 	remoteOptions = append(remoteOptions, c.withContext(ctx))
+
+	if pushOptions.AllowNondistributableArtifacts {
+		remoteOptions = append(remoteOptions, remote.WithNondistributable)
+	}
 
 	if err := remote.WriteIndex(ref, idx, remoteOptions...); err != nil {
 		return fmt.Errorf("failed to push image index: %w", err)

--- a/pkg/registry/client/client.go
+++ b/pkg/registry/client/client.go
@@ -45,13 +45,63 @@ var _ registry.Client = (*Client)(nil)
 
 var ErrImageNotFound = registry.ErrImageNotFound
 
-// maxTagsResponseBytes limits the size of a single tags/list JSON response (8 MiB).
-const maxTagsResponseBytes = 8 << 20
+const (
+	// maxTagsResponseBytes limits the size of a single tags/list JSON response (8 MiB).
+	maxTagsResponseBytes = 8 << 20
 
-// isNotFound reports whether err is an HTTP 404 response from the registry.
-func isNotFound(err error) bool {
+	// forcedPageSize is the `n` asked for when a registry answered with a page
+	// too large to buffer. No `n` is sent otherwise: registries that reject an
+	// `n` they do not implement would fail the whole listing, and one that
+	// paginates on its own already keeps pages small.
+	forcedPageSize = 1000
+)
+
+// errPageTooLarge marks a response that exceeded maxTagsResponseBytes, so the
+// walk can tell "this registry handed us everything at once" apart from a
+// genuinely malformed body and react by demanding pagination.
+var errPageTooLarge = errors.New("response too large to buffer")
+
+// sentinelFor maps a registry response onto one of the package's sentinel
+// errors, or returns nil when nothing matches.
+//
+// Callers should not have to re-derive "was this an auth failure" from HTTP
+// status codes, OCI error codes and - as consumers ended up doing - substrings
+// of the error message. Classifying once, here, where the typed
+// *transport.Error is still in hand, keeps errors.Is enough downstream.
+//
+// Order matters: the OCI error codes are more specific than the status code, so
+// a 404 carrying NAME_UNKNOWN is a missing repository rather than a missing
+// image, and an authorization failure is never reported as "not found" - a
+// token-auth registry denies out-of-scope requests whether or not the target
+// exists.
+func sentinelFor(err error) error {
 	var transportErr *transport.Error
-	return errors.As(err, &transportErr) && transportErr.StatusCode == http.StatusNotFound
+	if !errors.As(err, &transportErr) {
+		return nil
+	}
+
+	if transportErr.StatusCode == http.StatusUnauthorized || transportErr.StatusCode == http.StatusForbidden {
+		return registry.ErrAccessDenied
+	}
+
+	for _, diag := range transportErr.Errors {
+		switch diag.Code {
+		case transport.UnauthorizedErrorCode, transport.DeniedErrorCode:
+			return registry.ErrAccessDenied
+		case transport.NameUnknownErrorCode:
+			return registry.ErrRepositoryNotFound
+		case transport.ManifestUnknownErrorCode:
+			return registry.ErrImageNotFound
+		}
+	}
+
+	// A bare 404 with no diagnostic body - what a HEAD response always looks
+	// like, since HTTP forbids a body there.
+	if transportErr.StatusCode == http.StatusNotFound {
+		return registry.ErrImageNotFound
+	}
+
+	return nil
 }
 
 // Client provides methods to interact with container registries
@@ -232,17 +282,18 @@ func (c *Client) GetDigest(ctx context.Context, tag string) (*v1.Hash, error) {
 		return &head.Digest, nil
 	}
 
-	// If HEAD returned 404, don't bother with GET — the image doesn't exist.
-	if isNotFound(err) {
-		return nil, fmt.Errorf("%w: %w", ErrImageNotFound, err)
+	// A classified HEAD failure needs no GET retry: a missing or denied target
+	// answers the same way to both verbs, so retrying only costs a round trip.
+	if sentinel := sentinelFor(err); sentinel != nil {
+		return nil, fmt.Errorf("%w: %w", sentinel, err)
 	}
 
 	logentry.Debug("HEAD failed, retrying with GET", slog.String("error", err.Error()))
 
 	desc, err := remote.Get(ref, opts...)
 	if err != nil {
-		if isNotFound(err) {
-			return nil, fmt.Errorf("%w: %w", ErrImageNotFound, err)
+		if sentinel := sentinelFor(err); sentinel != nil {
+			return nil, fmt.Errorf("%w: %w", sentinel, err)
 		}
 
 		return nil, fmt.Errorf("failed to get manifest: %w", err)
@@ -255,7 +306,12 @@ func (c *Client) GetDigest(ctx context.Context, tag string) (*v1.Hash, error) {
 
 // GetManifest retrieves the manifest for a specific image tag
 // The repository is determined by the chained WithSegment() calls
-func (c *Client) GetManifest(ctx context.Context, tag string) (registry.ManifestResult, error) {
+func (c *Client) GetManifest(ctx context.Context, tag string, opts ...registry.ManifestGetOption) (registry.ManifestResult, error) {
+	manifestOptions := &registry.ManifestGetOptions{}
+	for _, opt := range opts {
+		opt.ApplyToManifestGet(manifestOptions)
+	}
+
 	logentry := c.logger.With(
 		slog.String("registry_host", c.registryHost),
 		slog.String("segments", c.constructedSegments),
@@ -269,11 +325,23 @@ func (c *Client) GetManifest(ctx context.Context, tag string) (registry.Manifest
 		return nil, fmt.Errorf("failed to parse reference: %w", err)
 	}
 
-	opts := append([]remote.Option{}, c.options...)
-	opts = append(opts, c.withContext(ctx))
-	desc, err := remote.Get(ref, opts...)
+	remoteOpts := append([]remote.Option{}, c.options...)
+	remoteOpts = append(remoteOpts, c.withContext(ctx))
+
+	desc, err := remote.Get(ref, remoteOpts...)
 	if err != nil {
+		if sentinel := sentinelFor(err); sentinel != nil {
+			return nil, fmt.Errorf("%w: %w", sentinel, err)
+		}
+
 		return nil, fmt.Errorf("failed to get manifest: %w", err)
+	}
+
+	// A platform only means something for an index: remote.Get returns the
+	// reference as served, so without this the caller asking for linux/arm64
+	// would silently receive the index manifest and have to walk it by hand.
+	if manifestOptions.Platform != nil && desc.MediaType.IsIndex() {
+		return c.childManifest(desc, *manifestOptions.Platform, logentry)
 	}
 
 	logentry.Debug("Manifest retrieved successfully")
@@ -284,8 +352,53 @@ func (c *Client) GetManifest(ctx context.Context, tag string) (registry.Manifest
 	}, nil
 }
 
+// childManifest resolves an index descriptor down to the manifest of the child
+// image matching platform. ErrImageNotFound covers the index that simply has no
+// such platform, which is a normal answer rather than a transport failure.
+func (c *Client) childManifest(desc *remote.Descriptor, platform v1.Platform, logentry *log.Logger) (registry.ManifestResult, error) {
+	idx, err := desc.ImageIndex()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read index manifest: %w", err)
+	}
+
+	indexManifest, err := idx.IndexManifest()
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse index manifest: %w", err)
+	}
+
+	for _, child := range indexManifest.Manifests {
+		if child.Platform == nil || !child.Platform.Satisfies(platform) {
+			continue
+		}
+
+		img, err := idx.Image(child.Digest)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read image %s: %w", child.Digest, err)
+		}
+
+		raw, err := img.RawManifest()
+		if err != nil {
+			return nil, fmt.Errorf("failed to read manifest of %s: %w", child.Digest, err)
+		}
+
+		logentry.Debug("Manifest resolved to platform child",
+			slog.String("platform", platform.String()),
+			slog.String("digest", child.Digest.String()),
+		)
+
+		return &ManifestResult{rawManifest: raw, descriptor: &child}, nil
+	}
+
+	return nil, fmt.Errorf("%w: index has no manifest for platform %s", registry.ErrImageNotFound, platform.String())
+}
+
 type WithPlatform struct {
 	Platform *v1.Platform
+}
+
+// ApplyToManifestGet lets the same WithPlatform value scope a GetManifest call.
+func (w WithPlatform) ApplyToManifestGet(opts *registry.ManifestGetOptions) {
+	opts.Platform = w.Platform
 }
 
 func (w WithPlatform) ApplyToImageGet(opts *registry.ImageGetOptions) {
@@ -325,8 +438,8 @@ func (c *Client) GetImage(ctx context.Context, tag string, opts ...registry.Imag
 
 	img, err := remote.Image(ref, imageOptions...)
 	if err != nil {
-		if isNotFound(err) {
-			return nil, fmt.Errorf("%w: %w", ErrImageNotFound, err)
+		if sentinel := sentinelFor(err); sentinel != nil {
+			return nil, fmt.Errorf("%w: %w", sentinel, err)
 		}
 
 		return nil, fmt.Errorf("failed to get image: %w", err)
@@ -487,16 +600,18 @@ func (c *Client) StreamTags(ctx context.Context, visit func(tags []string) error
 		defer cancel()
 	}
 
-	httpClient, err := c.registryHTTPClient(ctx, repo)
+	httpClient, err := c.registryHTTPClient(ctx, repo.Registry, repo)
 	if err != nil {
+		// The /v2/ ping happens here, so this is where a rejected credential
+		// surfaces - classify it rather than burying a 401 in "create client".
+		if sentinel := sentinelFor(err); sentinel != nil {
+			return fmt.Errorf("%w: %w", sentinel, err)
+		}
+
 		return fmt.Errorf("create registry client: %w", err)
 	}
 
-	// A registry that ignores `last` and echoes the same Link cursor on every
-	// response keeps this walk going forever, re-delivering the same page. A
-	// cursor already followed cannot make progress, so refusing it turns a
-	// broken registry into an error instead of a hang.
-	seen := make(map[string]struct{})
+	var cursors cursorTracker
 
 	pageURL := tagsURL(repo, listOptions.Last, listOptions.N)
 	pages := 0
@@ -506,9 +621,13 @@ func (c *Client) StreamTags(ctx context.Context, visit func(tags []string) error
 			return err
 		}
 
-		tags, next, err := c.fetchTagsPage(ctx, httpClient, pageURL)
+		tags, next, err := c.fetchTagsPageBuffered(ctx, httpClient, pageURL, logentry)
 		if err != nil {
-			return err
+			if sentinel := sentinelFor(err); sentinel != nil {
+				return fmt.Errorf("%w: %w", sentinel, err)
+			}
+
+			return fmt.Errorf("list tags for %s: %w", repo, err)
 		}
 
 		pages++
@@ -529,12 +648,8 @@ func (c *Client) StreamTags(ctx context.Context, visit func(tags []string) error
 			break
 		}
 
-		if next != "" {
-			if _, dup := seen[next]; dup {
-				return fmt.Errorf("list tags for %s: registry keeps returning the same pagination cursor %q, refusing to loop", repo, next)
-			}
-
-			seen[next] = struct{}{}
+		if err := cursors.next(next); err != nil {
+			return fmt.Errorf("list tags for %s: %w", repo, err)
 		}
 
 		pageURL = next
@@ -543,6 +658,69 @@ func (c *Client) StreamTags(ctx context.Context, visit func(tags []string) error
 	logentry.Debug("Tag streaming finished", slog.Int("pages", pages))
 
 	return nil
+}
+
+// fetchTagsPageBuffered fetches one page, retrying with an explicit `n` when the
+// registry answered with more than this client can buffer.
+//
+// Ordering matters: the plain request comes first because it is the compatible
+// one, and `n` is added only once a registry has proved it needs to be told to
+// paginate. A registry that ignores `n` fails the retry too, and then the
+// original size error is what the caller sees.
+func (c *Client) fetchTagsPageBuffered(ctx context.Context, httpClient *http.Client, pageURL string, logentry *log.Logger) ([]string, string, error) {
+	tags, next, err := c.fetchTagsPage(ctx, httpClient, pageURL)
+	if !errors.Is(err, errPageTooLarge) {
+		return tags, next, err
+	}
+
+	paged, addErr := withPageSizeParam(pageURL, forcedPageSize)
+	if addErr != nil {
+		return nil, "", err
+	}
+
+	if paged == pageURL {
+		return nil, "", err
+	}
+
+	logentry.Debug("Tags page too large, asking the registry to paginate",
+		slog.Int("n", forcedPageSize),
+	)
+
+	tags, next, retryErr := c.fetchTagsPage(ctx, httpClient, paged)
+	if retryErr != nil {
+		// Report the original oversize failure: a registry that ignores `n`
+		// answers the retry the same way, and "response too large" names the
+		// actual problem better than a second copy of it.
+		return nil, "", err
+	}
+
+	return tags, next, nil
+}
+
+// withPageSizeParam returns pageURL with n set, or pageURL unchanged when it
+// already carries one.
+func withPageSizeParam(pageURL string, size int) (string, error) {
+	parsed, err := url.Parse(pageURL)
+	if err != nil {
+		return "", err
+	}
+
+	q := parsed.Query()
+	if q.Get("n") != "" {
+		return pageURL, nil
+	}
+
+	q.Set("n", strconv.Itoa(size))
+	parsed.RawQuery = q.Encode()
+
+	return parsed.String(), nil
+}
+
+// scopedResource is what both name.Repository and name.Registry satisfy: an
+// authn.Resource that can also name its own registry auth scope.
+type scopedResource interface {
+	authn.Resource
+	Scope(string) string
 }
 
 // registryHTTPClient creates an authenticated HTTP client for direct registry requests.
@@ -554,13 +732,13 @@ func (c *Client) StreamTags(ctx context.Context, visit func(tags []string) error
 //
 // The transport is then wrapped the way remote.* wraps its own, so direct
 // requests keep retry-on-temporary-failure and the configured User-Agent.
-func (c *Client) registryHTTPClient(ctx context.Context, repo name.Repository) (*http.Client, error) {
+func (c *Client) registryHTTPClient(ctx context.Context, reg name.Registry, target scopedResource) (*http.Client, error) {
 	auth := c.auth
 
 	if auth == nil && c.keychain != nil {
-		resolved, err := c.keychain.Resolve(repo)
+		resolved, err := c.keychain.Resolve(target)
 		if err != nil {
-			return nil, fmt.Errorf("resolve credentials for %s: %w", repo, err)
+			return nil, fmt.Errorf("resolve credentials for %s: %w", target, err)
 		}
 
 		auth = resolved
@@ -570,7 +748,10 @@ func (c *Client) registryHTTPClient(ctx context.Context, repo name.Repository) (
 		auth = authn.Anonymous
 	}
 
-	rt, err := transport.NewWithContext(ctx, repo.Registry, auth, c.baseTransport, []string{repo.Scope(transport.PullScope)})
+	// The scope comes from the target: a repository asks for repository:<name>:pull,
+	// a registry for registry:catalog:*. Asking for the wrong one gets a token
+	// the registry then refuses to honour.
+	rt, err := transport.NewWithContext(ctx, reg, auth, c.baseTransport, []string{target.Scope(transport.PullScope)})
 	if err != nil {
 		return nil, fmt.Errorf("build transport: %w", err)
 	}
@@ -582,6 +763,35 @@ func (c *Client) registryHTTPClient(ctx context.Context, repo name.Repository) (
 	}
 
 	return &http.Client{Transport: rt}, nil
+}
+
+// cursorTracker refuses a pagination cursor that has already been followed.
+//
+// A registry that ignores `last` and echoes the same Link cursor on every
+// response keeps a walk going forever, re-delivering the same page. A cursor
+// already followed cannot make progress, so refusing it turns a broken registry
+// into an error instead of a hang. Shared by the tag and catalog walks so the
+// two cannot drift apart on it.
+type cursorTracker struct {
+	seen map[string]struct{}
+}
+
+func (t *cursorTracker) next(cursor string) error {
+	if cursor == "" {
+		return nil
+	}
+
+	if t.seen == nil {
+		t.seen = make(map[string]struct{})
+	}
+
+	if _, dup := t.seen[cursor]; dup {
+		return fmt.Errorf("registry keeps returning the same pagination cursor %q, refusing to loop", cursor)
+	}
+
+	t.seen[cursor] = struct{}{}
+
+	return nil
 }
 
 // tagsURL builds the /v2/<repo>/tags/list URL with optional last and n query parameters.
@@ -629,37 +839,112 @@ func (c *Client) fetchTagsPage(ctx context.Context, httpClient *http.Client, pag
 		return nil, "", err
 	}
 
+	// Read with one byte of headroom so an oversized page is reported as such:
+	// decoding a stream cut at the limit fails with "unexpected EOF", which
+	// tells the user nothing about what actually went wrong.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxTagsResponseBytes+1))
+	if err != nil {
+		return nil, "", fmt.Errorf("read response: %w", err)
+	}
+
+	if int64(len(body)) > maxTagsResponseBytes {
+		return nil, "", fmt.Errorf("%w: tags response exceeds %d bytes", errPageTooLarge, maxTagsResponseBytes)
+	}
+
 	var parsed tagsResponse
-	if err := json.NewDecoder(io.LimitReader(resp.Body, maxTagsResponseBytes)).Decode(&parsed); err != nil {
+	if err := json.Unmarshal(body, &parsed); err != nil {
 		return nil, "", fmt.Errorf("decode response: %w", err)
 	}
 
 	return parsed.Tags, nextPageURL(resp), nil
 }
 
-// nextPageURL extracts the URL from a Link: <url>; rel="next" header.
-// Handles the common OCI registry format only; RFC 8288 multi-value headers are not supported.
+// nextPageURL extracts the rel="next" URL from a Link header.
+//
+// RFC 8288 permits several comma-separated values in one header, and registries
+// do use that - a page in the middle of a listing may advertise both prev and
+// next. Taking the first <...> would then follow prev and walk the listing
+// backwards, re-reading pages already seen, so each value is matched on its own
+// rel parameter.
 func nextPageURL(resp *http.Response) string {
-	link := resp.Header.Get("Link")
-	if link == "" || link[0] != '<' {
-		return ""
+	for _, value := range splitLinkValues(resp.Header.Get("Link")) {
+		target, ok := parseLinkValue(value)
+		if !ok {
+			continue
+		}
+
+		linkURL, err := url.Parse(target)
+		if err != nil {
+			continue
+		}
+
+		if resp.Request != nil && resp.Request.URL != nil {
+			linkURL = resp.Request.URL.ResolveReference(linkURL)
+		}
+
+		return linkURL.String()
 	}
 
-	end := strings.Index(link, ">")
+	return ""
+}
+
+// splitLinkValues splits a Link header on the commas that separate values,
+// ignoring those inside the angle-bracketed URI or a quoted parameter.
+func splitLinkValues(header string) []string {
+	var (
+		values   []string
+		start    int
+		inURI    bool
+		inQuotes bool
+	)
+
+	for i, r := range header {
+		switch r {
+		case '<':
+			inURI = true
+		case '>':
+			inURI = false
+		case '"':
+			inQuotes = !inQuotes
+		case ',':
+			if !inURI && !inQuotes {
+				values = append(values, header[start:i])
+				start = i + 1
+			}
+		}
+	}
+
+	return append(values, header[start:])
+}
+
+// parseLinkValue returns the URI of a single Link value when it carries
+// rel="next" (quoted or bare, per RFC 8288's case-insensitive rel matching).
+func parseLinkValue(value string) (string, bool) {
+	value = strings.TrimSpace(value)
+
+	if !strings.HasPrefix(value, "<") {
+		return "", false
+	}
+
+	end := strings.Index(value, ">")
 	if end == -1 {
-		return ""
+		return "", false
 	}
 
-	linkURL, err := url.Parse(link[1:end])
-	if err != nil {
-		return ""
+	uri, params := value[1:end], value[end+1:]
+
+	for _, param := range strings.Split(params, ";") {
+		key, val, found := strings.Cut(param, "=")
+		if !found || !strings.EqualFold(strings.TrimSpace(key), "rel") {
+			continue
+		}
+
+		if strings.EqualFold(strings.Trim(strings.TrimSpace(val), `"`), "next") {
+			return uri, true
+		}
 	}
 
-	if resp.Request != nil && resp.Request.URL != nil {
-		linkURL = resp.Request.URL.ResolveReference(linkURL)
-	}
-
-	return linkURL.String()
+	return "", false
 }
 
 // WithReposLast sets the pagination continuation token for repositories
@@ -692,13 +977,31 @@ func (w *withReposLimit) ApplyToListRepositories(opts *registry.ListRepositories
 // The scope is determined by the chained WithSegment() calls
 // Returns repository names under the current scope
 func (c *Client) ListRepositories(ctx context.Context, opts ...registry.ListRepositoriesOption) ([]string, error) {
-	listOptions := &registry.ListRepositoriesOptions{}
+	var repos []string
 
+	err := c.StreamRepositories(ctx, func(page []string) error {
+		repos = append(repos, page...)
+
+		return nil
+	}, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	c.logger.Debug("Repositories listed", slog.Int("count", len(repos)))
+
+	return repos, nil
+}
+
+// StreamRepositories invokes visit once per page of the registry catalog.
+//
+// It mirrors StreamTags, including the refusal to follow a cursor already seen
+// and the decision not to send `n` unless the caller asked for a page size.
+func (c *Client) StreamRepositories(ctx context.Context, visit func(repos []string) error, opts ...registry.ListRepositoriesOption) error {
+	listOptions := &registry.ListRepositoriesOptions{}
 	for _, opt := range opts {
 		opt.ApplyToListRepositories(listOptions)
 	}
-
-	fullRegistry := c.GetRegistry()
 
 	logentry := c.logger.With(
 		slog.String("registry_host", c.registryHost),
@@ -707,50 +1010,166 @@ func (c *Client) ListRepositories(ctx context.Context, opts ...registry.ListRepo
 		slog.String("last", listOptions.Last),
 	)
 
-	logentry.Debug("Listing repositories")
+	logentry.Debug("Streaming repositories")
 
-	ref, err := name.ParseReference(fullRegistry, c.nameOptions()...)
+	// The catalog is registry-wide, so the host is parsed as a registry. Going
+	// through name.ParseReference on host+segments - as this used to - reads a
+	// bare "host:port" as a repository:tag under the default registry, and the
+	// request then went to Docker Hub instead of the configured host.
+	reg, err := name.NewRegistry(c.registryHost, c.nameOptions()...)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse registry reference: %w", err)
+		return fmt.Errorf("failed to parse registry %q: %w", c.registryHost, err)
 	}
 
-	repo := ref.Context()
+	if c.timeout > 0 {
+		var cancel context.CancelFunc
 
-	logentry.Debug("Listing repositories for base repository", slog.String("repository", repo.String()))
+		ctx, cancel = context.WithTimeout(ctx, c.timeout)
+		defer cancel()
+	}
 
-	remoteOpts := append([]remote.Option{}, c.options...)
-	remoteOpts = append(remoteOpts, c.withContext(ctx))
-
-	// Use CatalogPage for server-side pagination if supported
-	if listOptions.N > 0 || listOptions.Last != "" {
-		repos, err := remote.CatalogPage(repo.Registry, listOptions.Last, listOptions.N, remoteOpts...)
-		if err != nil {
-			logentry.Debug("Failed to list repositories with pagination", slog.String("error", err.Error()))
-
-			return nil, fmt.Errorf("failed to list repositories: %w", err)
+	httpClient, err := c.registryHTTPClient(ctx, reg, reg)
+	if err != nil {
+		if sentinel := catalogSentinelFor(err); sentinel != nil {
+			return fmt.Errorf("%w: %w", sentinel, err)
 		}
 
-		logentry.Debug("Repositories retrieved with pagination", slog.Int("returned_count", len(repos)))
-
-		return repos, nil
+		return fmt.Errorf("create registry client: %w", err)
 	}
 
-	// Fallback to regular catalog listing
-	result, err := remote.Catalog(ctx, repo.Registry, remoteOpts...)
-	if err != nil {
-		logentry.Debug("Failed to list repositories", slog.String("error", err.Error()))
+	var cursors cursorTracker
 
-		return nil, fmt.Errorf("failed to list repositories: %w", err)
+	pageURL := catalogURL(reg, listOptions.Last, listOptions.N)
+	pages := 0
+
+	for pageURL != "" {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		repos, next, err := c.fetchCatalogPage(ctx, httpClient, pageURL)
+		if err != nil {
+			if sentinel := catalogSentinelFor(err); sentinel != nil {
+				return fmt.Errorf("%w: %w", sentinel, err)
+			}
+
+			return fmt.Errorf("failed to list repositories: %w", err)
+		}
+
+		pages++
+
+		if err := visit(repos); err != nil {
+			if errors.Is(err, registry.ErrStopStreaming) {
+				logentry.Debug("Repository streaming stopped by caller", slog.Int("pages", pages))
+
+				return nil
+			}
+
+			return err
+		}
+
+		if listOptions.N > 0 {
+			break
+		}
+
+		if err := cursors.next(next); err != nil {
+			return fmt.Errorf("list repositories for %s: %w", reg, err)
+		}
+
+		pageURL = next
 	}
 
-	logentry.Debug("Repositories retrieved", slog.Int("total_repositories", len(result)))
+	logentry.Debug("Repository streaming finished", slog.Int("pages", pages))
 
-	return result, nil
+	return nil
 }
 
-// CheckImageExists checks if a specific image exists in the registry
-// If image not found, return an error
-// The repository is determined by the chained WithSegment() calls
+// catalogSentinelFor classifies a /v2/_catalog failure.
+//
+// A registry that does not implement the endpoint answers 404 or UNSUPPORTED,
+// which the generic classifier would read as a missing image - a misleading
+// answer for a request that never named one.
+func catalogSentinelFor(err error) error {
+	var transportErr *transport.Error
+	if !errors.As(err, &transportErr) {
+		return nil
+	}
+
+	if transportErr.StatusCode == http.StatusNotFound {
+		return registry.ErrCatalogNotSupported
+	}
+
+	for _, diag := range transportErr.Errors {
+		if diag.Code == transport.UnsupportedErrorCode {
+			return registry.ErrCatalogNotSupported
+		}
+	}
+
+	return sentinelFor(err)
+}
+
+// catalogURL builds the /v2/_catalog URL with optional last and n parameters.
+func catalogURL(reg name.Registry, last string, pageSize int) string {
+	uri := &url.URL{
+		Scheme: reg.Scheme(),
+		Host:   reg.RegistryStr(),
+		Path:   "/v2/_catalog",
+	}
+
+	q := url.Values{}
+	if last != "" {
+		q.Set("last", last)
+	}
+
+	if pageSize > 0 {
+		q.Set("n", strconv.Itoa(pageSize))
+	}
+
+	uri.RawQuery = q.Encode()
+
+	return uri.String()
+}
+
+// catalogResponse represents the JSON body of GET /v2/_catalog.
+type catalogResponse struct {
+	Repositories []string `json:"repositories"`
+}
+
+// fetchCatalogPage performs a single GET and returns repositories with the
+// next-page URL from the Link header.
+func (c *Client) fetchCatalogPage(ctx context.Context, httpClient *http.Client, pageURL string) ([]string, string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, pageURL, nil)
+	if err != nil {
+		return nil, "", fmt.Errorf("create request: %w", err)
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, "", fmt.Errorf("execute request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if err := transport.CheckError(resp, http.StatusOK); err != nil {
+		return nil, "", err
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxTagsResponseBytes+1))
+	if err != nil {
+		return nil, "", fmt.Errorf("read response: %w", err)
+	}
+
+	if int64(len(body)) > maxTagsResponseBytes {
+		return nil, "", fmt.Errorf("%w: catalog response exceeds %d bytes", errPageTooLarge, maxTagsResponseBytes)
+	}
+
+	var parsed catalogResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return nil, "", fmt.Errorf("decode response: %w", err)
+	}
+
+	return parsed.Repositories, nextPageURL(resp), nil
+}
+
 func (c *Client) CheckImageExists(ctx context.Context, tag string) error {
 	logentry := c.logger.With(
 		slog.String("registry_host", c.registryHost),
@@ -770,8 +1189,8 @@ func (c *Client) CheckImageExists(ctx context.Context, tag string) error {
 
 	_, err = remote.Head(ref, opts...)
 	if err != nil {
-		if isNotFound(err) {
-			return fmt.Errorf("%w: %w", ErrImageNotFound, err)
+		if sentinel := sentinelFor(err); sentinel != nil {
+			return fmt.Errorf("%w: %w", sentinel, err)
 		}
 
 		logentry.Debug("HEAD failed, retrying with GET", log.Err(err))
@@ -780,8 +1199,8 @@ func (c *Client) CheckImageExists(ctx context.Context, tag string) error {
 	}
 
 	if err != nil {
-		if isNotFound(err) {
-			return fmt.Errorf("%w: %w", ErrImageNotFound, err)
+		if sentinel := sentinelFor(err); sentinel != nil {
+			return fmt.Errorf("%w: %w", sentinel, err)
 		}
 
 		return err
@@ -813,8 +1232,8 @@ func (c *Client) DeleteTag(ctx context.Context, tag string) error {
 	opts = append(opts, c.withContext(ctx))
 
 	if err := remote.Delete(ref, opts...); err != nil {
-		if isNotFound(err) {
-			return fmt.Errorf("%w: %w", ErrImageNotFound, err)
+		if sentinel := sentinelFor(err); sentinel != nil {
+			return fmt.Errorf("%w: %w", sentinel, err)
 		}
 
 		return fmt.Errorf("failed to delete tag: %w", err)
@@ -850,8 +1269,8 @@ func (c *Client) TagImage(ctx context.Context, sourceTag, destTag string) error 
 	// Fetch the manifest descriptor without downloading any layers.
 	desc, err := remote.Get(srcRef, opts...)
 	if err != nil {
-		if isNotFound(err) {
-			return fmt.Errorf("%w: %w", ErrImageNotFound, err)
+		if sentinel := sentinelFor(err); sentinel != nil {
+			return fmt.Errorf("%w: %w", sentinel, err)
 		}
 
 		return fmt.Errorf("failed to get source manifest: %w", err)
@@ -925,8 +1344,8 @@ func (c *Client) DeleteByDigest(ctx context.Context, digest v1.Hash) error {
 	opts = append(opts, c.withContext(ctx))
 
 	if err := remote.Delete(ref, opts...); err != nil {
-		if isNotFound(err) {
-			return fmt.Errorf("%w: %w", ErrImageNotFound, err)
+		if sentinel := sentinelFor(err); sentinel != nil {
+			return fmt.Errorf("%w: %w", sentinel, err)
 		}
 
 		return fmt.Errorf("failed to delete manifest: %w", err)
@@ -961,8 +1380,8 @@ func (c *Client) CopyImage(ctx context.Context, srcTag string, dest registry.Cli
 
 	desc, err := remote.Get(srcRef, opts...)
 	if err != nil {
-		if isNotFound(err) {
-			return fmt.Errorf("%w: %w", ErrImageNotFound, err)
+		if sentinel := sentinelFor(err); sentinel != nil {
+			return fmt.Errorf("%w: %w", sentinel, err)
 		}
 
 		return fmt.Errorf("failed to get source image: %w", err)

--- a/pkg/registry/client/client_test.go
+++ b/pkg/registry/client/client_test.go
@@ -21,6 +21,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/name"
@@ -531,175 +533,57 @@ func TestClient_TagImage(t *testing.T) {
 	})
 }
 
-// ---- isNotFound ----
+// ---- sentinelFor ----
 
-func TestIsNotFound(t *testing.T) {
-	t.Run("true for HTTP 404 transport error", func(t *testing.T) {
+func TestSentinelFor(t *testing.T) {
+	t.Run("bare 404 is a missing image", func(t *testing.T) {
 		err := &transport.Error{StatusCode: http.StatusNotFound}
-		assert.True(t, isNotFound(err))
+		assert.Equal(t, registry.ErrImageNotFound, sentinelFor(err))
 	})
 
-	t.Run("false for HTTP 403 transport error", func(t *testing.T) {
-		err := &transport.Error{StatusCode: http.StatusForbidden}
-		assert.False(t, isNotFound(err))
-	})
-
-	t.Run("false for non-transport error", func(t *testing.T) {
-		assert.False(t, isNotFound(errors.New("generic error")))
-	})
-
-	t.Run("false for nil", func(t *testing.T) {
-		assert.False(t, isNotFound(nil))
-	})
-
-	t.Run("true for wrapped 404 transport error", func(t *testing.T) {
+	t.Run("wrapped 404 is still classified", func(t *testing.T) {
 		inner := &transport.Error{StatusCode: http.StatusNotFound}
-		wrapped := fmt.Errorf("outer: %w", inner)
-		assert.True(t, isNotFound(wrapped))
-	})
-}
-
-// ---- buildReference ----
-
-func TestClient_BuildReference(t *testing.T) {
-	c := New("registry.example.com", WithInsecure(true)).WithSegment("repo").(*Client)
-
-	t.Run("tag reference", func(t *testing.T) {
-		ref := c.buildReference("v1.0.0")
-		assert.Equal(t, "registry.example.com/repo:v1.0.0", ref)
+		assert.Equal(t, registry.ErrImageNotFound, sentinelFor(fmt.Errorf("outer: %w", inner)))
 	})
 
-	t.Run("digest reference with @ prefix", func(t *testing.T) {
-		ref := c.buildReference("@sha256:abc123")
-		assert.Equal(t, "registry.example.com/repo@sha256:abc123", ref)
+	t.Run("401 and 403 are access denied", func(t *testing.T) {
+		for _, code := range []int{http.StatusUnauthorized, http.StatusForbidden} {
+			err := &transport.Error{StatusCode: code}
+			assert.Equal(t, registry.ErrAccessDenied, sentinelFor(err), "status %d", code)
+		}
 	})
 
-	t.Run("digest reference without @ prefix", func(t *testing.T) {
-		ref := c.buildReference("sha256:abc123")
-		assert.Equal(t, "registry.example.com/repo@sha256:abc123", ref)
+	t.Run("UNAUTHORIZED and DENIED codes are access denied", func(t *testing.T) {
+		for _, code := range []transport.ErrorCode{transport.UnauthorizedErrorCode, transport.DeniedErrorCode} {
+			err := &transport.Error{
+				StatusCode: http.StatusNotFound,
+				Errors:     []transport.Diagnostic{{Code: code}},
+			}
+			assert.Equal(t, registry.ErrAccessDenied, sentinelFor(err),
+				"an out-of-scope request must not be reported as not-found (%s)", code)
+		}
 	})
 
-	t.Run("latest tag", func(t *testing.T) {
-		ref := c.buildReference("latest")
-		assert.Equal(t, "registry.example.com/repo:latest", ref)
-	})
-}
-
-// ---- GetImage with digest ----
-
-func TestClient_GetImage_ByDigest(t *testing.T) {
-	t.Run("fetch image by digest reference", func(t *testing.T) {
-		_, c := newTestServer(t)
-		img := pushRandomImage(t, c, "repo", "v1")
-
-		wantDigest, err := img.Digest()
-		require.NoError(t, err)
-
-		fetched, err := c.WithSegment("repo").GetImage(context.Background(), "@"+wantDigest.String())
-		require.NoError(t, err)
-
-		gotDigest, err := fetched.Digest()
-		require.NoError(t, err)
-		assert.Equal(t, wantDigest, gotDigest)
-	})
-}
-
-// ---- GetDigest with 404 early return (fix 1.6) ----
-
-func TestClient_GetDigest_NotFound(t *testing.T) {
-	t.Run("returns ErrImageNotFound for missing image", func(t *testing.T) {
-		_, c := newTestServer(t)
-
-		_, err := c.WithSegment("repo").GetDigest(context.Background(), "nonexistent")
-		require.Error(t, err)
-		assert.True(t, errors.Is(err, ErrImageNotFound))
-	})
-}
-
-// ---- PushIndex ----
-
-func TestClient_PushIndex(t *testing.T) {
-	t.Run("pushed index is fetchable", func(t *testing.T) {
-		_, c := newTestServer(t)
-
-		idx, err := random.Index(512, 1, 2)
-		require.NoError(t, err)
-
-		require.NoError(t, c.WithSegment("repo").PushIndex(context.Background(), "multi-arch", idx))
-
-		// Verify the tag exists
-		err = c.WithSegment("repo").CheckImageExists(context.Background(), "multi-arch")
-		assert.NoError(t, err)
+	t.Run("NAME_UNKNOWN is a missing repository, not a missing image", func(t *testing.T) {
+		err := &transport.Error{
+			StatusCode: http.StatusNotFound,
+			Errors:     []transport.Diagnostic{{Code: transport.NameUnknownErrorCode}},
+		}
+		assert.Equal(t, registry.ErrRepositoryNotFound, sentinelFor(err))
 	})
 
-	t.Run("index digest matches after push", func(t *testing.T) {
-		_, c := newTestServer(t)
-
-		idx, err := random.Index(512, 1, 2)
-		require.NoError(t, err)
-
-		wantDigest, err := idx.Digest()
-		require.NoError(t, err)
-
-		require.NoError(t, c.WithSegment("repo").PushIndex(context.Background(), "idx-tag", idx))
-
-		gotDigest, err := c.WithSegment("repo").GetDigest(context.Background(), "idx-tag")
-		require.NoError(t, err)
-		assert.Equal(t, wantDigest, *gotDigest)
-	})
-}
-
-// ---- DeleteByDigest ----
-
-func TestClient_DeleteByDigest(t *testing.T) {
-	t.Run("delete by digest succeeds for existing manifest", func(t *testing.T) {
-		_, c := newTestServer(t)
-		img := pushRandomImage(t, c, "repo", "v1")
-
-		digest, err := img.Digest()
-		require.NoError(t, err)
-
-		// DeleteByDigest should not return an error for an existing manifest.
-		err = c.WithSegment("repo").DeleteByDigest(context.Background(), digest)
-		assert.NoError(t, err)
+	t.Run("MANIFEST_UNKNOWN is a missing image", func(t *testing.T) {
+		err := &transport.Error{
+			StatusCode: http.StatusNotFound,
+			Errors:     []transport.Diagnostic{{Code: transport.ManifestUnknownErrorCode}},
+		}
+		assert.Equal(t, registry.ErrImageNotFound, sentinelFor(err))
 	})
 
-	t.Run("deleting non-existent digest returns ErrImageNotFound", func(t *testing.T) {
-		_, c := newTestServer(t)
-
-		fakeDigest := v1.Hash{Algorithm: "sha256", Hex: "0000000000000000000000000000000000000000000000000000000000000000"}
-		err := c.WithSegment("repo").DeleteByDigest(context.Background(), fakeDigest)
-		require.Error(t, err)
-		assert.True(t, errors.Is(err, ErrImageNotFound))
-	})
-}
-
-// ---- CopyImage ----
-
-func TestClient_CopyImage(t *testing.T) {
-	t.Run("image exists in destination after copy", func(t *testing.T) {
-		_, c := newTestServer(t)
-		pushed := pushRandomImage(t, c, "src-repo", "v1")
-
-		wantDigest, err := pushed.Digest()
-		require.NoError(t, err)
-
-		// Copy from src-repo:v1 to dst-repo:copied
-		err = c.WithSegment("src-repo").CopyImage(context.Background(), "v1", c.WithSegment("dst-repo"), "copied")
-		require.NoError(t, err)
-
-		// Verify it exists
-		gotDigest, err := c.WithSegment("dst-repo").GetDigest(context.Background(), "copied")
-		require.NoError(t, err)
-		assert.Equal(t, wantDigest, *gotDigest)
-	})
-
-	t.Run("copy nonexistent source returns ErrImageNotFound", func(t *testing.T) {
-		_, c := newTestServer(t)
-
-		err := c.WithSegment("src-repo").CopyImage(context.Background(), "missing", c.WithSegment("dst-repo"), "dst")
-		require.Error(t, err)
-		assert.True(t, errors.Is(err, ErrImageNotFound))
+	t.Run("nil for unclassified responses", func(t *testing.T) {
+		assert.Nil(t, sentinelFor(nil))
+		assert.Nil(t, sentinelFor(errors.New("generic error")))
+		assert.Nil(t, sentinelFor(&transport.Error{StatusCode: http.StatusInternalServerError}))
 	})
 }
 
@@ -707,10 +591,13 @@ func TestClient_CopyImage(t *testing.T) {
 
 func TestClient_Middleware(t *testing.T) {
 	t.Run("middleware intercepts requests", func(t *testing.T) {
-		var requestCount int
+		// The counter is touched from net/http's request goroutines, so it needs
+		// synchronising - without it the whole package is unusable under -race.
+		var requestCount atomic.Int64
+
 		countingMiddleware := func(next http.RoundTripper) http.RoundTripper {
 			return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
-				requestCount++
+				requestCount.Add(1)
 				return next.RoundTrip(req)
 			})
 		}
@@ -724,20 +611,32 @@ func TestClient_Middleware(t *testing.T) {
 
 		pushRandomImage(t, c, "repo", "v1")
 
-		assert.Greater(t, requestCount, 0, "middleware should have intercepted at least one request")
+		assert.Greater(t, requestCount.Load(), int64(0), "middleware should have intercepted at least one request")
 	})
 
 	t.Run("multiple middlewares are applied in order", func(t *testing.T) {
-		var order []string
+		// Appended from request goroutines, so the slice needs a lock; see above.
+		var (
+			mu    sync.Mutex
+			order []string
+		)
+
+		record := func(name string) {
+			mu.Lock()
+			defer mu.Unlock()
+
+			order = append(order, name)
+		}
+
 		first := func(next http.RoundTripper) http.RoundTripper {
 			return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
-				order = append(order, "first")
+				record("first")
 				return next.RoundTrip(req)
 			})
 		}
 		second := func(next http.RoundTripper) http.RoundTripper {
 			return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
-				order = append(order, "second")
+				record("second")
 				return next.RoundTrip(req)
 			})
 		}
@@ -750,6 +649,9 @@ func TestClient_Middleware(t *testing.T) {
 		c := New(addr, WithInsecure(true), WithMiddleware(first, second))
 
 		pushRandomImage(t, c, "repo", "v1")
+
+		mu.Lock()
+		defer mu.Unlock()
 
 		require.GreaterOrEqual(t, len(order), 2)
 		// First middleware is outermost, so it runs first

--- a/pkg/registry/client/image.go
+++ b/pkg/registry/client/image.go
@@ -69,6 +69,11 @@ func (m *ManifestResult) IsIndex() bool {
 var ErrIsIndexManifest = fmt.Errorf("manifest is an index")
 var ErrIsNotIndexManifest = fmt.Errorf("manifest is not an index")
 
+// GetRaw returns the manifest bytes as served, without decoding them.
+func (m *ManifestResult) GetRaw() []byte {
+	return m.rawManifest
+}
+
 func (m *ManifestResult) GetDescriptor() registry.Descriptor {
 	if m.descriptor == nil {
 		return nil

--- a/pkg/registry/client/image.go
+++ b/pkg/registry/client/image.go
@@ -47,10 +47,39 @@ func (i *Image) GetPullReference() string {
 	return i.pullReference
 }
 
+// NewManifestResultFromBytes wraps raw manifest bytes.
+//
+// The descriptor is derived from the bytes rather than left unset: a manifest's
+// digest is by definition the hash of its own bytes, and its media type is a
+// field inside it. Without this, GetDescriptor returned nil and GetMediaType
+// returned "" for every result built this way - the in-memory fake, chiefly -
+// so callers reading a digest through the fake dereferenced nil instead of
+// getting the answer production gives them.
 func NewManifestResultFromBytes(manifestBytes []byte) *ManifestResult {
-	return &ManifestResult{
-		rawManifest: manifestBytes,
+	res := &ManifestResult{rawManifest: manifestBytes}
+
+	digest, size, err := v1.SHA256(bytes.NewReader(manifestBytes))
+	if err != nil {
+		// Hashing an in-memory slice cannot fail; on the impossible path leave
+		// the descriptor unset rather than inventing one.
+		return res
 	}
+
+	var probe struct {
+		MediaType types.MediaType `json:"mediaType"`
+	}
+
+	// A manifest without a mediaType is legal in older schemas; an empty media
+	// type is a truthful answer there, so a parse failure is not fatal either.
+	_ = json.Unmarshal(manifestBytes, &probe)
+
+	res.descriptor = &v1.Descriptor{
+		MediaType: probe.MediaType,
+		Size:      size,
+		Digest:    digest,
+	}
+
+	return res
 }
 
 type ManifestResult struct {

--- a/pkg/registry/client/tags_test.go
+++ b/pkg/registry/client/tags_test.go
@@ -1,0 +1,285 @@
+// Copyright 2025 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/deckhouse/deckhouse/pkg/registry"
+)
+
+// tagsServer serves /v2/ plus /v2/<repo>/tags/list through handler, recording
+// every tags/list request URI so tests can assert on round trips and on the
+// query parameters the client actually sent.
+type tagsServer struct {
+	addr     string
+	requests *[]string
+}
+
+func newTagsServer(t *testing.T, handler func(w http.ResponseWriter, r *http.Request, hit int)) *tagsServer {
+	t.Helper()
+
+	var (
+		hits     int32
+		requests []string
+	)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/", func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/tags/list") {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+
+			return
+		}
+
+		requests = append(requests, r.URL.RequestURI())
+		handler(w, r, int(atomic.AddInt32(&hits, 1)))
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	return &tagsServer{addr: strings.TrimPrefix(srv.URL, "http://"), requests: &requests}
+}
+
+func writeTagsPage(w http.ResponseWriter, tags []string) {
+	_, _ = fmt.Fprintf(w, `{"name":"repo","tags":["%s"]}`, strings.Join(tags, `","`))
+}
+
+// linkTo sets the Link header the way an OCI registry announces a next page.
+func linkTo(w http.ResponseWriter, last string) {
+	w.Header().Set("Link", fmt.Sprintf(`</v2/repo/tags/list?last=%s>; rel="next"`, last))
+}
+
+func TestClient_StreamTags(t *testing.T) {
+	t.Run("delivers one page per response as it arrives", func(t *testing.T) {
+		pages := [][]string{{"v1", "v2"}, {"v3", "v4"}, {"v5"}}
+
+		srv := newTagsServer(t, func(w http.ResponseWriter, _ *http.Request, hit int) {
+			page := pages[hit-1]
+			if hit < len(pages) {
+				linkTo(w, page[len(page)-1])
+			}
+
+			writeTagsPage(w, page)
+		})
+
+		c := New(srv.addr, WithInsecure(true))
+
+		var seen [][]string
+
+		err := c.WithSegment("repo").StreamTags(context.Background(), func(tags []string) error {
+			seen = append(seen, tags)
+
+			return nil
+		})
+		require.NoError(t, err)
+		assert.Equal(t, pages, seen, "visit must be called once per page, in order")
+	})
+
+	t.Run("ErrStopStreaming stops the walk without an error", func(t *testing.T) {
+		srv := newTagsServer(t, func(w http.ResponseWriter, _ *http.Request, hit int) {
+			linkTo(w, fmt.Sprintf("p%d", hit))
+			writeTagsPage(w, []string{fmt.Sprintf("t%d", hit)})
+		})
+
+		c := New(srv.addr, WithInsecure(true))
+
+		var seen int
+
+		err := c.WithSegment("repo").StreamTags(context.Background(), func([]string) error {
+			seen++
+
+			return registry.ErrStopStreaming
+		})
+		require.NoError(t, err, "ErrStopStreaming must not surface as a failure")
+		assert.Equal(t, 1, seen)
+		assert.Len(t, *srv.requests, 1, "the walk must stop instead of fetching further pages")
+	})
+
+	t.Run("an error from visit is propagated unchanged", func(t *testing.T) {
+		srv := newTagsServer(t, func(w http.ResponseWriter, _ *http.Request, _ int) {
+			writeTagsPage(w, []string{"v1"})
+		})
+
+		c := New(srv.addr, WithInsecure(true))
+		sentinel := fmt.Errorf("caller failed")
+
+		err := c.WithSegment("repo").StreamTags(context.Background(), func([]string) error {
+			return sentinel
+		})
+		assert.ErrorIs(t, err, sentinel)
+	})
+}
+
+func TestClient_ListTags_WalksEveryPage(t *testing.T) {
+	pages := [][]string{{"a", "b"}, {"c", "d"}, {"e"}}
+
+	srv := newTagsServer(t, func(w http.ResponseWriter, _ *http.Request, hit int) {
+		page := pages[hit-1]
+		if hit < len(pages) {
+			linkTo(w, page[len(page)-1])
+		}
+
+		writeTagsPage(w, page)
+	})
+
+	c := New(srv.addr, WithInsecure(true))
+
+	tags, err := c.WithSegment("repo").ListTags(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a", "b", "c", "d", "e"}, tags, "the accumulated result must be the complete list")
+}
+
+// Registries that do not implement the `n` query parameter answer 400 for it.
+// The unpaginated listing must not send `n` at all, since the cursor is walked
+// to the end regardless and a larger page size buys nothing.
+func TestClient_ListTags_OmitsPageSizeParamWhenUnbounded(t *testing.T) {
+	srv := newTagsServer(t, func(w http.ResponseWriter, r *http.Request, _ int) {
+		if r.URL.Query().Get("n") != "" {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"errors":[{"code":"UNSUPPORTED","message":"query param n is not supported"}]}`))
+
+			return
+		}
+
+		writeTagsPage(w, []string{"v1", "v2"})
+	})
+
+	c := New(srv.addr, WithInsecure(true))
+
+	tags, err := c.WithSegment("repo").ListTags(context.Background())
+	require.NoError(t, err, "a registry that rejects ?n= must still be listable")
+	assert.Equal(t, []string{"v1", "v2"}, tags)
+
+	for _, uri := range *srv.requests {
+		assert.NotContains(t, uri, "n=", "unbounded listing must not ask for a page size")
+	}
+}
+
+// WithTagsLimit is the one case where `n` is meaningful, because the caller
+// explicitly asked for a single page.
+func TestClient_ListTags_SendsPageSizeParamWhenLimited(t *testing.T) {
+	srv := newTagsServer(t, func(w http.ResponseWriter, _ *http.Request, _ int) {
+		linkTo(w, "v2")
+		writeTagsPage(w, []string{"v1", "v2"})
+	})
+
+	c := New(srv.addr, WithInsecure(true))
+
+	tags, err := c.WithSegment("repo").ListTags(context.Background(), WithTagsLimit(2))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"v1", "v2"}, tags)
+	require.Len(t, *srv.requests, 1, "a limited listing is a single page, the cursor is the caller's business")
+	assert.Contains(t, (*srv.requests)[0], "n=2")
+}
+
+// A registry that ignores `last` and echoes the same cursor forever would spin
+// the walk indefinitely, re-delivering the same page.
+func TestClient_ListTags_RefusesRepeatedCursor(t *testing.T) {
+	srv := newTagsServer(t, func(w http.ResponseWriter, _ *http.Request, _ int) {
+		linkTo(w, "v2")
+		writeTagsPage(w, []string{"v1", "v2"})
+	})
+
+	c := New(srv.addr, WithInsecure(true))
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := c.WithSegment("repo").ListTags(context.Background())
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "same pagination cursor")
+		assert.LessOrEqual(t, len(*srv.requests), 3, "the walk must stop almost immediately")
+	case <-time.After(10 * time.Second):
+		t.Fatal("ListTags looped instead of refusing the repeated cursor")
+	}
+}
+
+// The direct HTTP path has to resolve credentials itself. A client built with
+// WithKeychain used to go out anonymous there, so a private registry answered
+// 401 while the same client authenticated fine through remote.*.
+//
+// Both /v2/ and tags/list demand Basic auth here: go-containerregistry's
+// transport negotiates the scheme from the ping's WWW-Authenticate challenge,
+// so a ping that answers 200 would settle on "no auth" and never exercise the
+// credentials at all.
+func TestClient_ListTags_UsesKeychainForDirectRequests(t *testing.T) {
+	const (
+		user = "robot"
+		pass = "s3cret"
+	)
+
+	authorized := func(r *http.Request) bool {
+		u, p, ok := r.BasicAuth()
+
+		return ok && u == user && p == pass
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/", func(w http.ResponseWriter, r *http.Request) {
+		if !authorized(r) {
+			w.Header().Set("WWW-Authenticate", `Basic realm="test"`)
+			w.WriteHeader(http.StatusUnauthorized)
+
+			return
+		}
+
+		if strings.HasSuffix(r.URL.Path, "/tags/list") {
+			writeTagsPage(w, []string{"v1"})
+
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	c := New(strings.TrimPrefix(srv.URL, "http://"),
+		WithInsecure(true),
+		WithKeychain(staticKeychain{authn.FromConfig(authn.AuthConfig{Username: user, Password: pass})}),
+	)
+
+	tags, err := c.WithSegment("repo").ListTags(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"v1"}, tags)
+}
+
+type staticKeychain struct {
+	auth authn.Authenticator
+}
+
+func (k staticKeychain) Resolve(authn.Resource) (authn.Authenticator, error) {
+	return k.auth, nil
+}

--- a/pkg/registry/client/tags_test.go
+++ b/pkg/registry/client/tags_test.go
@@ -25,6 +25,12 @@ import (
 	"time"
 
 	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -282,4 +288,303 @@ type staticKeychain struct {
 
 func (k staticKeychain) Resolve(authn.Resource) (authn.Authenticator, error) {
 	return k.auth, nil
+}
+
+// ---- Link header parsing ----
+
+// RFC 8288 permits several comma-separated values in one Link header, and a
+// page in the middle of a listing may advertise both prev and next. Taking the
+// first <...> followed prev and walked the listing backwards.
+func TestClient_ListTags_PicksRelNextFromMultiValueLink(t *testing.T) {
+	srv := newTagsServer(t, func(w http.ResponseWriter, _ *http.Request, hit int) {
+		if hit == 1 {
+			w.Header().Set("Link",
+				`</v2/repo/tags/list?last=backwards>; rel="prev", </v2/repo/tags/list?last=v2>; rel=next`)
+			writeTagsPage(w, []string{"v1", "v2"})
+
+			return
+		}
+
+		writeTagsPage(w, []string{"v3"})
+	})
+
+	c := New(srv.addr, WithInsecure(true))
+
+	tags, err := c.WithSegment("repo").ListTags(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"v1", "v2", "v3"}, tags)
+
+	require.Len(t, *srv.requests, 2)
+	assert.Contains(t, (*srv.requests)[1], "last=v2", "the walk must follow rel=next, not rel=prev")
+}
+
+// ---- oversized pages ----
+
+// A registry that paginates only when asked returns the whole list at once.
+// Past the buffering limit that is a hard failure, so the walk asks for
+// pagination rather than giving up.
+func TestClient_ListTags_AsksForPaginationWhenPageTooLarge(t *testing.T) {
+	hugePage := func(w http.ResponseWriter) {
+		var b strings.Builder
+
+		b.WriteString(`{"name":"repo","tags":[`)
+
+		for i := 0; b.Len() < maxTagsResponseBytes+(1<<20); i++ {
+			if i > 0 {
+				b.WriteByte(',')
+			}
+
+			fmt.Fprintf(&b, `"tag-%08d-padding-padding-padding"`, i)
+		}
+
+		b.WriteString(`]}`)
+		_, _ = w.Write([]byte(b.String()))
+	}
+
+	t.Run("registry honours n on retry", func(t *testing.T) {
+		srv := newTagsServer(t, func(w http.ResponseWriter, r *http.Request, _ int) {
+			if r.URL.Query().Get("n") == "" {
+				hugePage(w)
+
+				return
+			}
+
+			writeTagsPage(w, []string{"v1", "v2"})
+		})
+
+		c := New(srv.addr, WithInsecure(true))
+
+		tags, err := c.WithSegment("repo").ListTags(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, []string{"v1", "v2"}, tags)
+		require.Len(t, *srv.requests, 2, "one plain request, then one that demands pagination")
+		assert.NotContains(t, (*srv.requests)[0], "n=")
+		assert.Contains(t, (*srv.requests)[1], fmt.Sprintf("n=%d", forcedPageSize))
+	})
+
+	t.Run("registry ignores n and the size error is reported", func(t *testing.T) {
+		srv := newTagsServer(t, func(w http.ResponseWriter, _ *http.Request, _ int) {
+			hugePage(w)
+		})
+
+		c := New(srv.addr, WithInsecure(true))
+
+		_, err := c.WithSegment("repo").ListTags(context.Background())
+		require.Error(t, err)
+		assert.ErrorIs(t, err, errPageTooLarge)
+		assert.Contains(t, err.Error(), "exceeds", "the error must name the real problem, not 'unexpected EOF'")
+	})
+}
+
+// ---- sentinels on real responses ----
+
+func TestClient_ListTags_ReportsAccessDenied(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("WWW-Authenticate", `Basic realm="test"`)
+		w.WriteHeader(http.StatusUnauthorized)
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	c := New(strings.TrimPrefix(srv.URL, "http://"), WithInsecure(true))
+
+	_, err := c.WithSegment("repo").ListTags(context.Background())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, registry.ErrAccessDenied)
+	assert.NotErrorIs(t, err, registry.ErrImageNotFound,
+		"a denied request says nothing about whether the target exists")
+}
+
+// ---- catalog ----
+
+func TestClient_ListRepositories(t *testing.T) {
+	catalogServer := func(t *testing.T, handler func(w http.ResponseWriter, r *http.Request, hit int)) (string, *[]string) {
+		t.Helper()
+
+		var (
+			hits     int32
+			requests []string
+		)
+
+		mux := http.NewServeMux()
+		mux.HandleFunc("/v2/", func(w http.ResponseWriter, r *http.Request) {
+			if !strings.HasSuffix(r.URL.Path, "/_catalog") {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte("{}"))
+
+				return
+			}
+
+			requests = append(requests, r.URL.RequestURI())
+			handler(w, r, int(atomic.AddInt32(&hits, 1)))
+		})
+
+		srv := httptest.NewServer(mux)
+		t.Cleanup(srv.Close)
+
+		return strings.TrimPrefix(srv.URL, "http://"), &requests
+	}
+
+	t.Run("walks every page", func(t *testing.T) {
+		addr, _ := catalogServer(t, func(w http.ResponseWriter, _ *http.Request, hit int) {
+			if hit == 1 {
+				w.Header().Set("Link", `</v2/_catalog?last=b>; rel="next"`)
+				_, _ = w.Write([]byte(`{"repositories":["a","b"]}`))
+
+				return
+			}
+
+			_, _ = w.Write([]byte(`{"repositories":["c"]}`))
+		})
+
+		repos, err := New(addr, WithInsecure(true)).ListRepositories(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, []string{"a", "b", "c"}, repos)
+	})
+
+	t.Run("refuses a repeated cursor", func(t *testing.T) {
+		addr, requests := catalogServer(t, func(w http.ResponseWriter, _ *http.Request, _ int) {
+			w.Header().Set("Link", `</v2/_catalog?last=b>; rel="next"`)
+			_, _ = w.Write([]byte(`{"repositories":["a","b"]}`))
+		})
+
+		done := make(chan error, 1)
+		go func() {
+			_, err := New(addr, WithInsecure(true)).ListRepositories(context.Background())
+			done <- err
+		}()
+
+		select {
+		case err := <-done:
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "same pagination cursor")
+			assert.LessOrEqual(t, len(*requests), 3)
+		case <-time.After(10 * time.Second):
+			t.Fatal("ListRepositories looped instead of refusing the repeated cursor")
+		}
+	})
+
+	t.Run("unimplemented catalog is reported as such", func(t *testing.T) {
+		addr, _ := catalogServer(t, func(w http.ResponseWriter, _ *http.Request, _ int) {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"errors":[{"code":"UNSUPPORTED","message":"catalog is not supported"}]}`))
+		})
+
+		_, err := New(addr, WithInsecure(true)).ListRepositories(context.Background())
+		require.Error(t, err)
+		assert.ErrorIs(t, err, registry.ErrCatalogNotSupported)
+		assert.NotErrorIs(t, err, registry.ErrImageNotFound,
+			"a registry without /v2/_catalog is not a missing image")
+	})
+
+	t.Run("streams one page per response", func(t *testing.T) {
+		addr, _ := catalogServer(t, func(w http.ResponseWriter, _ *http.Request, hit int) {
+			if hit == 1 {
+				w.Header().Set("Link", `</v2/_catalog?last=b>; rel="next"`)
+				_, _ = w.Write([]byte(`{"repositories":["a","b"]}`))
+
+				return
+			}
+
+			_, _ = w.Write([]byte(`{"repositories":["c"]}`))
+		})
+
+		var seen [][]string
+
+		err := New(addr, WithInsecure(true)).StreamRepositories(context.Background(), func(repos []string) error {
+			seen = append(seen, repos)
+
+			return nil
+		})
+		require.NoError(t, err)
+		assert.Equal(t, [][]string{{"a", "b"}, {"c"}}, seen)
+	})
+}
+
+// ---- GetManifest platform resolution ----
+
+func TestClient_GetManifest_Platform(t *testing.T) {
+	// pushIndex publishes a two-platform index and returns the child digests.
+	pushIndex := func(t *testing.T, c *Client, repo, tag string) map[string]string {
+		t.Helper()
+
+		idx := v1.ImageIndex(empty.Index)
+		digests := map[string]string{}
+
+		for _, arch := range []string{"amd64", "arm64"} {
+			img, err := random.Image(64, 1)
+			require.NoError(t, err)
+
+			cfg, err := img.ConfigFile()
+			require.NoError(t, err)
+
+			cfg.OS, cfg.Architecture = "linux", arch
+
+			img, err = mutate.ConfigFile(img, cfg)
+			require.NoError(t, err)
+
+			d, err := img.Digest()
+			require.NoError(t, err)
+
+			digests[arch] = d.String()
+
+			idx = mutate.AppendManifests(idx, mutate.IndexAddendum{
+				Add:        img,
+				Descriptor: v1.Descriptor{Platform: &v1.Platform{OS: "linux", Architecture: arch}},
+			})
+		}
+
+		ref, err := name.ParseReference(c.WithSegment(repo).(*Client).buildReference(tag), name.Insecure)
+		require.NoError(t, err)
+		require.NoError(t, remote.WriteIndex(ref, idx))
+
+		return digests
+	}
+
+	t.Run("without a platform the index is returned as served", func(t *testing.T) {
+		_, c := newTestServer(t)
+		pushIndex(t, c, "multi", "v1")
+
+		res, err := c.WithSegment("multi").GetManifest(context.Background(), "v1")
+		require.NoError(t, err)
+		assert.True(t, res.GetMediaType().IsIndex(), "a multi-arch reference is an index")
+	})
+
+	t.Run("with a platform the child manifest is returned", func(t *testing.T) {
+		_, c := newTestServer(t)
+		digests := pushIndex(t, c, "multi", "v1")
+
+		res, err := c.WithSegment("multi").GetManifest(context.Background(), "v1",
+			WithPlatform{Platform: &v1.Platform{OS: "linux", Architecture: "arm64"}})
+		require.NoError(t, err)
+
+		assert.False(t, res.GetMediaType().IsIndex(), "the platform must resolve past the index")
+		assert.Equal(t, digests["arm64"], res.GetDescriptor().GetDigest().String())
+
+		manifest, err := res.GetManifest()
+		require.NoError(t, err)
+		assert.NotEmpty(t, manifest.GetLayers())
+	})
+
+	t.Run("a platform the index does not carry is not found", func(t *testing.T) {
+		_, c := newTestServer(t)
+		pushIndex(t, c, "multi", "v1")
+
+		_, err := c.WithSegment("multi").GetManifest(context.Background(), "v1",
+			WithPlatform{Platform: &v1.Platform{OS: "windows", Architecture: "amd64"}})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, registry.ErrImageNotFound)
+	})
+
+	t.Run("a platform on a single-image reference changes nothing", func(t *testing.T) {
+		_, c := newTestServer(t)
+		pushRandomImage(t, c, "single", "v1")
+
+		res, err := c.WithSegment("single").GetManifest(context.Background(), "v1",
+			WithPlatform{Platform: &v1.Platform{OS: "linux", Architecture: "arm64"}})
+		require.NoError(t, err)
+		assert.False(t, res.GetMediaType().IsIndex())
+	})
 }

--- a/pkg/registry/errors.go
+++ b/pkg/registry/errors.go
@@ -14,13 +14,40 @@
 
 package registry
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 // Sentinel errors returned by Client implementations.
 var (
 	// ErrImageNotFound is returned when a requested image tag or digest does not
 	// exist in the registry.
 	ErrImageNotFound = errors.New("image not found")
+
+	// ErrRepositoryNotFound is returned when the repository itself is unknown to
+	// the registry (NAME_UNKNOWN), as opposed to a missing tag inside a
+	// repository that does exist.
+	//
+	// It unwraps to ErrImageNotFound: an absent repository holds no images, so
+	// callers that only branch on "the thing I asked for is not there" keep
+	// working unchanged, while callers that need to tell the two apart can test
+	// for this one first.
+	ErrRepositoryNotFound = fmt.Errorf("repository not found (%w)", ErrImageNotFound)
+
+	// ErrAccessDenied is returned when the registry refused the request for lack
+	// of rights: HTTP 401/403, or the UNAUTHORIZED/DENIED error codes.
+	//
+	// Token-auth registries answer this way for anything outside the identity's
+	// scope whether or not the target exists, so a denied request says nothing
+	// about existence - do not treat it as "not found".
+	ErrAccessDenied = errors.New("access denied")
+
+	// ErrCatalogNotSupported is returned when a registry does not implement
+	// /v2/_catalog. Docker Hub, GCR and Artifact Registry are the common cases,
+	// and they answer 404 or UNSUPPORTED, which is otherwise indistinguishable
+	// from a missing repository.
+	ErrCatalogNotSupported = errors.New("registry does not support catalog listing")
 
 	// ErrStopStreaming, returned from a StreamTags visit function, ends the walk
 	// early without being reported as a failure. Use it when the caller has seen

--- a/pkg/registry/errors.go
+++ b/pkg/registry/errors.go
@@ -21,4 +21,9 @@ var (
 	// ErrImageNotFound is returned when a requested image tag or digest does not
 	// exist in the registry.
 	ErrImageNotFound = errors.New("image not found")
+
+	// ErrStopStreaming, returned from a StreamTags visit function, ends the walk
+	// early without being reported as a failure. Use it when the caller has seen
+	// everything it needs and further pages would be wasted round trips.
+	ErrStopStreaming = errors.New("stop streaming")
 )

--- a/pkg/registry/fake/client.go
+++ b/pkg/registry/fake/client.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -122,7 +123,13 @@ func (c *Client) GetDigest(_ context.Context, tag string) (*v1.Hash, error) {
 }
 
 // GetManifest returns a ManifestResult for the image identified by tag.
-func (c *Client) GetManifest(_ context.Context, tag string) (dkpreg.ManifestResult, error) {
+// GetManifest returns the manifest of the image stored under tag.
+//
+// Platform options are accepted but have nothing to resolve: the fake stores
+// single-platform images, never indexes, and the real client only resolves a
+// platform when the reference is an index - so both return the manifest as
+// stored.
+func (c *Client) GetManifest(_ context.Context, tag string, _ ...dkpreg.ManifestGetOption) (dkpreg.ManifestResult, error) {
 	entry, err := c.findImage(tag)
 	if err != nil {
 		return nil, err
@@ -186,7 +193,12 @@ func (c *Client) PushImage(_ context.Context, tag string, img v1.Image, _ ...dkp
 }
 
 // ListTags returns all tags registered under the current path.
-func (c *Client) ListTags(_ context.Context, _ ...dkpreg.ListTagsOption) ([]string, error) {
+func (c *Client) ListTags(_ context.Context, opts ...dkpreg.ListTagsOption) ([]string, error) {
+	listOptions := &dkpreg.ListTagsOptions{}
+	for _, opt := range opts {
+		opt.ApplyToListTags(listOptions)
+	}
+
 	host, repo := c.splitHostRepo()
 	reg, ok := c.registries[host]
 	if !ok {
@@ -196,11 +208,61 @@ func (c *Client) ListTags(_ context.Context, _ ...dkpreg.ListTagsOption) ([]stri
 	if rs == nil {
 		return nil, nil
 	}
-	return rs.listTags(), nil
+	return applyListWindow(rs.listTags(), listOptions.Last, listOptions.N), nil
+}
+
+// applyListWindow reproduces what a registry does with the `last` and `n`
+// parameters: results are ordered lexicographically, everything up to and
+// including last is skipped, and at most n entries come back.
+//
+// The fake used to discard list options entirely, so a test asserting on
+// WithTagsLimit(2) saw every tag and passed while production returned one
+// page - the fake has to be at least as strict as the thing it stands in for.
+func applyListWindow(items []string, last string, n int) []string {
+	sorted := make([]string, len(items))
+	copy(sorted, items)
+	sort.Strings(sorted)
+
+	if last != "" {
+		cut := 0
+		for cut < len(sorted) && sorted[cut] <= last {
+			cut++
+		}
+		sorted = sorted[cut:]
+	}
+
+	if n > 0 && len(sorted) > n {
+		sorted = sorted[:n]
+	}
+
+	return sorted
 }
 
 // ListRepositories returns all repository paths registered under the host of
 // the current path.  The returned paths are relative to the host.
+// StreamRepositories delivers the catalog as a single page, for the same reason
+// as StreamTags: the fake has no cursor of its own to paginate.
+func (c *Client) StreamRepositories(ctx context.Context, visit func(repos []string) error, opts ...dkpreg.ListRepositoriesOption) error {
+	repos, err := c.ListRepositories(ctx, opts...)
+	if err != nil {
+		return err
+	}
+
+	if len(repos) == 0 {
+		return nil
+	}
+
+	if err := visit(repos); err != nil {
+		if errors.Is(err, dkpreg.ErrStopStreaming) {
+			return nil
+		}
+
+		return err
+	}
+
+	return nil
+}
+
 // StreamTags delivers the repository's tags as a single page. The fake stores
 // tags in memory with no cursor of its own, so there is nothing to paginate -
 // callers that accumulate pages still see the complete list, which is what the
@@ -226,7 +288,12 @@ func (c *Client) StreamTags(ctx context.Context, visit func(tags []string) error
 	return nil
 }
 
-func (c *Client) ListRepositories(_ context.Context, _ ...dkpreg.ListRepositoriesOption) ([]string, error) {
+func (c *Client) ListRepositories(_ context.Context, opts ...dkpreg.ListRepositoriesOption) ([]string, error) {
+	listOptions := &dkpreg.ListRepositoriesOptions{}
+	for _, opt := range opts {
+		opt.ApplyToListRepositories(listOptions)
+	}
+
 	host, repoPrefix := c.splitHostRepo()
 	reg, ok := c.registries[host]
 	if !ok {
@@ -234,18 +301,18 @@ func (c *Client) ListRepositories(_ context.Context, _ ...dkpreg.ListRepositorie
 	}
 
 	all := reg.listRepos()
-	if repoPrefix == "" {
-		return all, nil
+	if repoPrefix != "" {
+		prefix := repoPrefix + "/"
+		var filtered []string
+		for _, r := range all {
+			if strings.HasPrefix(r, prefix) || r == repoPrefix {
+				filtered = append(filtered, r)
+			}
+		}
+		all = filtered
 	}
 
-	prefix := repoPrefix + "/"
-	var filtered []string
-	for _, r := range all {
-		if strings.HasPrefix(r, prefix) || r == repoPrefix {
-			filtered = append(filtered, r)
-		}
-	}
-	return filtered, nil
+	return applyListWindow(all, listOptions.Last, listOptions.N), nil
 }
 
 // DeleteTag removes a tag from the current repository.

--- a/pkg/registry/fake/client.go
+++ b/pkg/registry/fake/client.go
@@ -141,6 +141,18 @@ func (c *Client) GetManifest(_ context.Context, tag string, _ ...dkpreg.Manifest
 	return dkpclient.NewManifestResultFromBytes(raw), nil
 }
 
+// GetIndex mirrors the real client's refusal to treat a plain image as an
+// index. The fake stores single images only - MustAddImage takes a v1.Image -
+// so a caller asking for an index always gets this error rather than a
+// synthetic one-entry wrapper.
+func (c *Client) GetIndex(_ context.Context, tag string) (v1.ImageIndex, error) {
+	if _, err := c.findImage(tag); err != nil {
+		return nil, err
+	}
+
+	return nil, fmt.Errorf("fake: GetIndex: %q is an image, not an index", tag)
+}
+
 // GetImageConfig returns the v1.ConfigFile for the image identified by tag.
 func (c *Client) GetImageConfig(_ context.Context, tag string) (*v1.ConfigFile, error) {
 	entry, err := c.findImage(tag)

--- a/pkg/registry/fake/client.go
+++ b/pkg/registry/fake/client.go
@@ -122,35 +122,59 @@ func (c *Client) GetDigest(_ context.Context, tag string) (*v1.Hash, error) {
 	return &h, nil
 }
 
-// GetManifest returns a ManifestResult for the image identified by tag.
-// GetManifest returns the manifest of the image stored under tag.
+// GetManifest returns the manifest stored under tag - the index manifest for an
+// entry added with AddIndex, the image manifest otherwise.
 //
-// Platform options are accepted but have nothing to resolve: the fake stores
-// single-platform images, never indexes, and the real client only resolves a
-// platform when the reference is an index - so both return the manifest as
-// stored.
-func (c *Client) GetManifest(_ context.Context, tag string, _ ...dkpreg.ManifestGetOption) (dkpreg.ManifestResult, error) {
+// A platform resolves an index down to that child's manifest, matching the real
+// client; on a plain image it is a no-op there too.
+func (c *Client) GetManifest(_ context.Context, tag string, opts ...dkpreg.ManifestGetOption) (dkpreg.ManifestResult, error) {
+	manifestOptions := &dkpreg.ManifestGetOptions{}
+	for _, opt := range opts {
+		opt.ApplyToManifestGet(manifestOptions)
+	}
+
 	entry, err := c.findImage(tag)
 	if err != nil {
 		return nil, err
 	}
-	raw, err := entry.img.RawManifest()
+
+	if manifestOptions.Platform != nil && entry.isIndex() {
+		img, err := entry.resolveImage(manifestOptions.Platform)
+		if err != nil {
+			return nil, fmt.Errorf("fake: %w: %w", dkpreg.ErrImageNotFound, err)
+		}
+
+		raw, err := img.RawManifest()
+		if err != nil {
+			return nil, fmt.Errorf("fake: raw manifest: %w", err)
+		}
+
+		return dkpclient.NewManifestResultFromBytes(raw), nil
+	}
+
+	raw, err := entry.rawManifest()
 	if err != nil {
 		return nil, fmt.Errorf("fake: raw manifest: %w", err)
 	}
+
 	return dkpclient.NewManifestResultFromBytes(raw), nil
 }
 
-// GetIndex mirrors the real client's refusal to treat a plain image as an
-// index. The fake stores single images only - MustAddImage takes a v1.Image -
-// so a caller asking for an index always gets this error rather than a
-// synthetic one-entry wrapper.
+// GetIndex returns the index stored under tag, resolving nothing.
+//
+// A plain image is an error, mirroring the real client: wrapping it in a
+// synthetic one-entry index is not what a caller asking for an index means.
 func (c *Client) GetIndex(_ context.Context, tag string) (v1.ImageIndex, error) {
-	if _, err := c.findImage(tag); err != nil {
+	entry, err := c.findImage(tag)
+	if err != nil {
 		return nil, err
 	}
 
-	return nil, fmt.Errorf("fake: GetIndex: %q is an image, not an index", tag)
+	if !entry.isIndex() {
+		return nil, fmt.Errorf("fake: GetIndex: %q is an image, not an index", tag)
+	}
+
+	return entry.idx, nil
 }
 
 // GetImageConfig returns the v1.ConfigFile for the image identified by tag.
@@ -159,7 +183,13 @@ func (c *Client) GetImageConfig(_ context.Context, tag string) (*v1.ConfigFile, 
 	if err != nil {
 		return nil, err
 	}
-	return entry.img.ConfigFile()
+
+	img, err := entry.resolveImage(nil)
+	if err != nil {
+		return nil, fmt.Errorf("fake: %w", err)
+	}
+
+	return img.ConfigFile()
 }
 
 // CheckImageExists returns nil if the image exists or
@@ -171,19 +201,35 @@ func (c *Client) CheckImageExists(_ context.Context, tag string) error {
 
 // GetImage returns a [dkpreg.Image] for the given tag or digest reference.
 // Digest references start with "@sha256:".
-func (c *Client) GetImage(_ context.Context, ref string, _ ...dkpreg.ImageGetOption) (dkpreg.Image, error) {
-	var entry *imageEntry
-	var err error
+func (c *Client) GetImage(_ context.Context, ref string, opts ...dkpreg.ImageGetOption) (dkpreg.Image, error) {
+	getOptions := &dkpreg.ImageGetOptions{}
+	for _, opt := range opts {
+		opt.ApplyToImageGet(getOptions)
+	}
+
+	var (
+		entry *imageEntry
+		err   error
+	)
 
 	if strings.HasPrefix(ref, "@sha256:") {
 		entry, err = c.findImageByDigest(strings.TrimPrefix(ref, "@"))
 	} else {
 		entry, err = c.findImage(ref)
 	}
+
 	if err != nil {
 		return nil, err
 	}
-	return &registryImage{Image: entry.img}, nil
+
+	// An index resolves to one child, as remote.Image does: without a platform
+	// that is linux/amd64, not the host's architecture.
+	img, err := entry.resolveImage(getOptions.Platform)
+	if err != nil {
+		return nil, fmt.Errorf("fake: %w: %w", dkpreg.ErrImageNotFound, err)
+	}
+
+	return &registryImage{Image: img}, nil
 }
 
 // PushImage stores the image under the current path with the given tag.
@@ -375,6 +421,13 @@ func (c *Client) CopyImage(ctx context.Context, srcTag string, dest dkpreg.Clien
 	if err != nil {
 		return err
 	}
+
+	// An index is copied whole, the way the real client does - flattening it to
+	// one child would silently drop every other platform.
+	if entry.isIndex() {
+		return dest.PushIndex(ctx, destTag, entry.idx)
+	}
+
 	return dest.PushImage(ctx, destTag, entry.img)
 }
 
@@ -393,6 +446,12 @@ func (c *Client) TagImage(_ context.Context, sourceTag, destTag string) error {
 	if !ok {
 		return fmt.Errorf("%w: tag %q", dkpclient.ErrImageNotFound, sourceTag)
 	}
+
+	// Retagging points a second tag at the same manifest, index or image.
+	if entry.isIndex() {
+		return rs.addIndex(destTag, entry.idx)
+	}
+
 	return rs.addImage(destTag, entry.img)
 }
 
@@ -444,6 +503,19 @@ func (c *Client) findImage(tag string) (*imageEntry, error) {
 	rs := reg.getRepo(repo)
 	if rs == nil {
 		return nil, fmt.Errorf("%w: repository %q not found in %q", dkpclient.ErrImageNotFound, repo, host)
+	}
+
+	// A digest identifier addresses the same manifest a tag does, and the real
+	// client resolves "repo@sha256:..." natively. Without this branch the fake
+	// looked a digest up as if it were a tag and reported it missing, so no
+	// test driving the fake could cover a digest reference at all.
+	if strings.HasPrefix(tag, "sha256:") {
+		entry, ok := rs.getByDigest(tag)
+		if !ok {
+			return nil, fmt.Errorf("%w: digest %q not found in %s/%s", dkpclient.ErrImageNotFound, tag, host, repo)
+		}
+
+		return entry, nil
 	}
 
 	entry, ok := rs.getByTag(tag)

--- a/pkg/registry/fake/client.go
+++ b/pkg/registry/fake/client.go
@@ -18,6 +18,7 @@ package fake
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -200,6 +201,31 @@ func (c *Client) ListTags(_ context.Context, _ ...dkpreg.ListTagsOption) ([]stri
 
 // ListRepositories returns all repository paths registered under the host of
 // the current path.  The returned paths are relative to the host.
+// StreamTags delivers the repository's tags as a single page. The fake stores
+// tags in memory with no cursor of its own, so there is nothing to paginate -
+// callers that accumulate pages still see the complete list, which is what the
+// real client guarantees.
+func (c *Client) StreamTags(ctx context.Context, visit func(tags []string) error, opts ...dkpreg.ListTagsOption) error {
+	tags, err := c.ListTags(ctx, opts...)
+	if err != nil {
+		return err
+	}
+
+	if len(tags) == 0 {
+		return nil
+	}
+
+	if err := visit(tags); err != nil {
+		if errors.Is(err, dkpreg.ErrStopStreaming) {
+			return nil
+		}
+
+		return err
+	}
+
+	return nil
+}
+
 func (c *Client) ListRepositories(_ context.Context, _ ...dkpreg.ListRepositoriesOption) ([]string, error) {
 	host, repoPrefix := c.splitHostRepo()
 	reg, ok := c.registries[host]

--- a/pkg/registry/fake/client_test.go
+++ b/pkg/registry/fake/client_test.go
@@ -17,10 +17,12 @@ limitations under the License.
 package fake_test
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"testing"
 
+	"github.com/deckhouse/deckhouse/pkg/registry"
 	dkpclient "github.com/deckhouse/deckhouse/pkg/registry/client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -343,4 +345,80 @@ func TestClient_CrossRegistryRouting(t *testing.T) {
 	tagsFromDst, err := clientDst.WithSegment("lib").ListTags(t.Context())
 	require.NoError(t, err)
 	assert.Contains(t, tagsFromDst, "v1")
+}
+
+// The fake used to discard list options, so a test asserting on WithTagsLimit
+// saw every tag and passed while production returned a single page. A fake that
+// is laxer than the thing it stands in for hides exactly the bugs it exists to
+// catch.
+func TestClient_ListOptionsAreHonoured(t *testing.T) {
+	reg := fake.NewRegistry("registry.example.com")
+	img := fake.NewImageBuilder().MustBuild()
+
+	for _, tag := range []string{"v3", "v1", "v4", "v2"} {
+		reg.MustAddImage("app", tag, img)
+	}
+
+	c := fake.NewClient(reg).WithSegment("app")
+
+	t.Run("results are ordered lexicographically", func(t *testing.T) {
+		tags, err := c.ListTags(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, []string{"v1", "v2", "v3", "v4"}, tags)
+	})
+
+	t.Run("limit returns a single page", func(t *testing.T) {
+		tags, err := c.ListTags(context.Background(), dkpclient.WithTagsLimit(2))
+		require.NoError(t, err)
+		assert.Equal(t, []string{"v1", "v2"}, tags)
+	})
+
+	t.Run("last skips up to and including the cursor", func(t *testing.T) {
+		tags, err := c.ListTags(context.Background(), dkpclient.WithTagsLast("v2"))
+		require.NoError(t, err)
+		assert.Equal(t, []string{"v3", "v4"}, tags)
+	})
+
+	t.Run("last and limit combine", func(t *testing.T) {
+		tags, err := c.ListTags(context.Background(), dkpclient.WithTagsLast("v1"), dkpclient.WithTagsLimit(2))
+		require.NoError(t, err)
+		assert.Equal(t, []string{"v2", "v3"}, tags)
+	})
+
+	t.Run("repository options are honoured too", func(t *testing.T) {
+		multi := fake.NewRegistry("registry.example.com")
+		for _, repo := range []string{"c-app", "a-app", "b-app"} {
+			multi.MustAddImage(repo, "v1", img)
+		}
+
+		repos, err := fake.NewClient(multi).ListRepositories(context.Background(), dkpclient.WithReposLimit(2))
+		require.NoError(t, err)
+		assert.Equal(t, []string{"a-app", "b-app"}, repos)
+	})
+}
+
+func TestClient_StreamTags(t *testing.T) {
+	reg := fake.NewRegistry("registry.example.com")
+	reg.MustAddImage("app", "v1", fake.NewImageBuilder().MustBuild())
+	reg.MustAddImage("app", "v2", fake.NewImageBuilder().MustBuild())
+
+	c := fake.NewClient(reg).WithSegment("app")
+
+	t.Run("delivers the stored tags", func(t *testing.T) {
+		var seen []string
+
+		require.NoError(t, c.StreamTags(context.Background(), func(tags []string) error {
+			seen = append(seen, tags...)
+
+			return nil
+		}))
+		assert.Equal(t, []string{"v1", "v2"}, seen)
+	})
+
+	t.Run("ErrStopStreaming is not a failure", func(t *testing.T) {
+		err := c.StreamTags(context.Background(), func([]string) error {
+			return registry.ErrStopStreaming
+		})
+		assert.NoError(t, err)
+	})
 }

--- a/pkg/registry/fake/registry.go
+++ b/pkg/registry/fake/registry.go
@@ -24,10 +24,64 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 )
 
-// imageEntry holds a single image and its pre-computed digest.
+// imageEntry holds a single manifest and its pre-computed digest. Exactly one
+// of img and idx is set: an entry added through AddIndex is a multi-arch index,
+// everything else is a plain image.
 type imageEntry struct {
 	img    v1.Image
+	idx    v1.ImageIndex
 	digest v1.Hash
+}
+
+// isIndex reports whether the entry holds a multi-arch index.
+func (e *imageEntry) isIndex() bool { return e.idx != nil }
+
+// rawManifest returns the manifest bytes the registry would serve for this
+// entry - the index manifest for an index, the image manifest otherwise.
+func (e *imageEntry) rawManifest() ([]byte, error) {
+	if e.isIndex() {
+		return e.idx.RawManifest()
+	}
+
+	return e.img.RawManifest()
+}
+
+// resolveImage returns the image this entry addresses, resolving an index to
+// the child matching platform.
+//
+// A nil platform picks linux/amd64 because that is what
+// go-containerregistry's remote.Image defaults to - not the host's platform.
+// The fake has to make the same choice or a test would disagree with
+// production about which child a platform-less request returns.
+func (e *imageEntry) resolveImage(platform *v1.Platform) (v1.Image, error) {
+	if !e.isIndex() {
+		return e.img, nil
+	}
+
+	want := v1.Platform{OS: "linux", Architecture: "amd64"}
+	if platform != nil {
+		want = *platform
+	}
+
+	manifest, err := e.idx.IndexManifest()
+	if err != nil {
+		return nil, fmt.Errorf("read index manifest: %w", err)
+	}
+
+	for _, child := range manifest.Manifests {
+		if child.Platform == nil || !child.Platform.Satisfies(want) {
+			continue
+		}
+
+		img, err := e.idx.Image(child.Digest)
+		if err != nil {
+			return nil, fmt.Errorf("read image %s: %w", child.Digest, err)
+		}
+
+		return img, nil
+	}
+
+	return nil, fmt.Errorf("index has no manifest for platform %s", want.String())
 }
 
 // repoStore stores the images for a single repository
@@ -62,6 +116,27 @@ func (rs *repoStore) addImage(tag string, img v1.Image) error {
 	}
 	rs.byTag[tag] = entry
 	rs.byDigest[digest.String()] = entry
+	return nil
+}
+
+func (rs *repoStore) addIndex(tag string, idx v1.ImageIndex) error {
+	digest, err := idx.Digest()
+	if err != nil {
+		return fmt.Errorf("compute digest: %w", err)
+	}
+
+	entry := &imageEntry{idx: idx, digest: digest}
+
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+
+	if _, exists := rs.byTag[tag]; !exists {
+		rs.tags = append(rs.tags, tag)
+	}
+
+	rs.byTag[tag] = entry
+	rs.byDigest[digest.String()] = entry
+
 	return nil
 }
 
@@ -186,6 +261,34 @@ func (r *Registry) AddImage(repoPath, tag string, img v1.Image) error {
 
 // MustAddImage is like [AddImage] but panics on error.  Intended for test
 // setup where error propagation is inconvenient.
+// AddIndex stores a multi-arch index under repoPath:tag, so a test can cover
+// the index paths - pull keeping every platform, --platform resolution,
+// classifying a reference as an index - which single images cannot exercise.
+func (r *Registry) AddIndex(repoPath, tag string, idx v1.ImageIndex) error {
+	if tag == "" {
+		return fmt.Errorf("stub: tag must not be empty")
+	}
+
+	repoPath = normPath(repoPath)
+
+	r.mu.Lock()
+	rs, ok := r.repos[repoPath]
+	if !ok {
+		rs = newRepoStore()
+		r.repos[repoPath] = rs
+	}
+	r.mu.Unlock()
+
+	return rs.addIndex(tag, idx)
+}
+
+// MustAddIndex is AddIndex for tests that treat a failure as fatal.
+func (r *Registry) MustAddIndex(repoPath, tag string, idx v1.ImageIndex) {
+	if err := r.AddIndex(repoPath, tag, idx); err != nil {
+		panic(fmt.Sprintf("stub.Registry.MustAddIndex: %v", err))
+	}
+}
+
 func (r *Registry) MustAddImage(repoPath, tag string, img v1.Image) {
 	if err := r.AddImage(repoPath, tag, img); err != nil {
 		panic(fmt.Sprintf("stub.Registry.MustAddImage: %v", err))

--- a/pkg/registry/image.go
+++ b/pkg/registry/image.go
@@ -31,6 +31,14 @@ type ManifestResult interface {
 	GetManifest() (Manifest, error)
 	GetIndexManifest() (IndexManifest, error)
 	GetDescriptor() Descriptor
+
+	// GetRaw returns the manifest exactly as the registry served it.
+	//
+	// Signature verification and audit trails need the original bytes: a
+	// manifest decoded and re-encoded through the typed getters no longer
+	// hashes to its own digest, so anything that pipes a manifest into cosign
+	// or stores it for later comparison has to read it from here.
+	GetRaw() []byte
 }
 
 // ManifestInterface defines methods for accessing manifest information

--- a/pkg/registry/options.go
+++ b/pkg/registry/options.go
@@ -56,6 +56,10 @@ type ImagePushOption interface {
 }
 
 type ImagePushOptions struct {
+	// AllowNondistributableArtifacts uploads foreign layers instead of skipping
+	// them. Registries that proxy Windows base images need it; for everything
+	// else it wastes bandwidth on blobs the client can fetch from their origin.
+	AllowNondistributableArtifacts bool
 }
 
 // ListTagsOption is some configuration that modifies options for a list tags request.

--- a/pkg/registry/options.go
+++ b/pkg/registry/options.go
@@ -25,6 +25,27 @@ type ImageGetOption interface {
 }
 
 type ImageGetOptions struct {
+	// Platform selects one image out of a multi-arch index.
+	//
+	// Leaving it nil does NOT mean "the host's platform": go-containerregistry
+	// falls back to a hardcoded linux/amd64, so an index resolves to its amd64
+	// child even on an arm64 machine. Set it explicitly whenever the answer
+	// must match the caller's architecture.
+	Platform *v1.Platform
+}
+
+// ManifestGetOption is some configuration that modifies options for a manifest
+// get request.
+type ManifestGetOption interface {
+	// ApplyToManifestGet applies this configuration to the given manifest get options.
+	ApplyToManifestGet(*ManifestGetOptions)
+}
+
+type ManifestGetOptions struct {
+	// Platform resolves a multi-arch index to the manifest of one child image.
+	//
+	// Leaving it nil returns the manifest as served, which for a multi-arch
+	// reference is the index itself - not any single image's manifest.
 	Platform *v1.Platform
 }
 


### PR DESCRIPTION
## Description

Reworks `pkg/registry` around a single, complete listing path and adds the pieces callers had to work around by hand: streaming, typed errors, index/platform handling and raw manifest bytes.

### Streaming and complete listings

- `StreamTags` / `StreamRepositories` invoke a `visit` callback once per page as it arrives, so a repository with very many tags can be walked without buffering all of them. Returning `registry.ErrStopStreaming` from `visit` ends the walk cleanly; any other error is propagated unchanged.
- `ListTags` / `ListRepositories` are now thin accumulators on top of the streaming path. They walk the registry's `Link`-cursor chain to the end, so the result is the complete list or an error — never a silently truncated page. A single page is still available explicitly via `WithTagsLimit` / `WithTagsLast` (and `WithReposLimit` / `WithReposLast`).
- The `n` query parameter is sent only when the caller asked for a page size. Registries that reject an `n` they do not implement answer 400 and would otherwise fail the whole listing.
- A page too large to buffer (> 8 MiB) is retried once with `n=1000` instead of failing; if the registry ignores `n`, the original "response too large" error is what the caller sees.
- A registry that keeps echoing the same pagination cursor is refused with an error instead of looping forever re-reading the same page (`cursorTracker`, shared by the tag and catalog walks).
- `Link` header parsing follows RFC 8288: comma-separated values are split (respecting angle brackets and quotes) and matched on their own `rel` parameter. Previously the first `<...>` was taken, so a page advertising both `prev` and `next` walked the listing backwards.

### Catalog listing fixes

- `ListRepositories` no longer goes through `name.ParseReference(host + segments)`, which reads a bare `host:port` as `repository:tag` under the *default* registry — requests were being sent to Docker Hub instead of the configured host. The host is now parsed with `name.NewRegistry`, and the catalog request asks for the `registry:catalog:*` scope rather than a repository scope.
- Catalog pages are fetched over the same direct-HTTP path as tags, with `ErrCatalogNotSupported` for registries that do not implement `/v2/_catalog` (Docker Hub, GCR, Artifact Registry answer 404/`UNSUPPORTED`, otherwise indistinguishable from a missing repository).

### Authentication on the direct HTTP path

- The direct path now resolves the keychain, mirroring how `buildRemoteOptions` hands credentials to `remote.*`: an explicit authenticator wins, otherwise the keychain is resolved for the target. Before this, a client built with `WithKeychain` went out **anonymous** on every direct request, so private registries answered 401.
- The transport is wrapped the way `remote.*` wraps its own, so direct requests keep retry-on-temporary-failure and the configured `User-Agent`.

### Error classification

`isNotFound` (HTTP 404 only) is replaced by `sentinelFor`, which classifies once — inside the client, where the typed `*transport.Error` is still in hand — so `errors.Is` is enough downstream and callers no longer match on status codes or error-message substrings.

| Sentinel | Meaning |
|---|---|
| `ErrRepositoryNotFound` | `NAME_UNKNOWN` — the repository itself is unknown. Unwraps to `ErrImageNotFound`, so existing "not there" checks keep working |
| `ErrAccessDenied` | HTTP 401/403, or `UNAUTHORIZED`/`DENIED` |
| `ErrCatalogNotSupported` | Registry does not implement `/v2/_catalog` |
| `ErrStopStreaming` | Returned *by the caller* from a `visit` function to end a walk early |

An authorization failure is deliberately never reported as "not found": a token-auth registry denies anything outside the identity's scope whether or not the target exists. `GetDigest` also skips its GET retry on any classified failure now, not just 404 — a missing or denied target answers both verbs the same way, so the retry only cost a round trip.

### Multi-arch

- `GetIndex(ctx, tag)` returns a multi-arch index without resolving it to any platform — what a caller copying or storing every platform needs. A plain image reference is an error rather than being wrapped in a synthetic one-entry index.
- `GetManifest` accepts `ManifestGetOption`; `WithPlatform` resolves an index to one child image's manifest. Without a platform it returns the reference **as served** (the index itself for a multi-arch tag). A platform the index does not carry returns `ErrImageNotFound`; a platform on a single-image reference is a no-op.
- Documented the trap in `GetImage`: omitting a platform does *not* mean the host's platform — `go-containerregistry` falls back to a hardcoded `linux/amd64`, so an arm64 caller silently gets amd64.

### Manifests and push

- `ManifestResult.GetRaw()` returns the manifest exactly as the registry served it. Signature verification and audit trails need the original bytes: a manifest decoded and re-encoded through the typed getters no longer hashes to its own digest.
- `NewManifestResultFromBytes` now derives the descriptor (digest, size, media type) from the bytes. Previously `GetDescriptor()` returned nil and `GetMediaType()` returned `""` for every result built this way — chiefly the in-memory fake — so callers reading a digest through the fake dereferenced nil.
- `WithNondistributable()` push option uploads foreign layers instead of skipping them, for registries that proxy Windows base images.

### Fake parity

The fake was laxer than the client it stands in for, which hid exactly the bugs it exists to catch:

- List options are honoured: results are ordered lexicographically, `last` skips up to and including the cursor, `n` caps the page. Previously the fake discarded them, so a test asserting on `WithTagsLimit(2)` saw every tag and passed while production returned one page.
- Index support: `AddIndex` / `MustAddIndex`, `GetIndex`, platform resolution in `GetImage`/`GetManifest` (defaulting to `linux/amd64`, as `remote.Image` does), and `CopyImage`/`TagImage` keep an index whole instead of flattening it to one child.
- Digest references (`sha256:...`) resolve in `findImage`, so tests can cover digest lookups at all.
- `StreamTags` / `StreamRepositories` implemented (single page — the fake has no cursor of its own).

### Tests

New `pkg/registry/client/tags_test.go` covers the streaming walk, `ErrStopStreaming`, cursor-loop refusal, `n` omission/inclusion, keychain use on direct requests, multi-value `Link` headers, oversized-page retry (both outcomes), access-denied classification, catalog walking and `GetManifest` platform resolution. Middleware tests were made race-safe (`atomic.Int64` / mutex) — without it the package was unusable under `-race`.

`go build`, `go vet`, `go test` and `go test -race` pass for the `pkg/registry` module.

## Why do we need it, and what problem does it solve?

Three concrete defects, plus the API surface consumers were compensating for:

1. **Silently wrong catalog target.** `ListRepositories` parsed `host:port` as a repository reference, so catalog requests went to Docker Hub rather than the configured registry.
2. **Silently anonymous requests.** The direct HTTP listing path ignored the keychain, so any client built with `WithKeychain` got 401 from a private registry while `remote.*`-based calls on the same client worked.
3. **Silently truncated / looping listings.** Only the first page was returned in some paths, `Link` parsing could follow `prev` and walk backwards, and a registry echoing one cursor looped forever.

On top of that, consumers were re-deriving "was this an auth failure or a missing image" from HTTP status codes and error-message substrings, had no way to fetch an index without flattening it, and had no access to raw manifest bytes for signature verification.

## Why do we need it in the patch release (if we do)?

Not necessarily. `pkg/registry` is a separate Go module and the main module still pins a published version, so nothing in the platform changes until that pin is bumped.

## Breaking changes

The `registry.Client` interface gained `GetIndex`, `StreamTags` and `StreamRepositories`, `GetManifest` became variadic, and `ManifestResult` gained `GetRaw`. Callers are source-compatible; **implementers** are not. In particular, `deckhouse-controller/internal/registry/client.Client` (the tracing wrapper) will need these methods added when the `pkg/registry` dependency is bumped in the root `go.mod`.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: pkg
type: feature
summary: Add tag/repository streaming, typed registry errors and multi-arch support to the registry library.
impact_level: low
```
