### PR TITLE
[node-manager] Approve only kubelet-serving CSRs in kubelet_csr_approver

### DIFF
--- a/modules/040-node-manager/hooks/kubelet_csr_approver.go
+++ b/modules/040-node-manager/hooks/kubelet_csr_approver.go
@@ -82,23 +82,23 @@ func csrFilterFunc(obj *unstructured.Unstructured) (go_hook.FilterResult, error)
 		}
 	}
 
+	if csr.Spec.SignerName != cv1.KubeletServingSignerName {
+		return nil, nil
+	}
+
 	ret := &CsrInfo{
 		Name: csr.GetName(),
 	}
 
-	// Parse CSR
 	x509cr, err := parseCSR(csr)
 	if err != nil {
 		ret.ErrMsg = err.Error()
 		return ret, nil
 	}
 
-	if csr.Spec.SignerName == "kubernetes.io/kubelet-serving" {
-		err = nodeServingCert(csr, x509cr)
-		if err != nil {
-			ret.ErrMsg = err.Error()
-			return ret, nil
-		}
+	if err := nodeServingCert(csr, x509cr); err != nil {
+		ret.ErrMsg = err.Error()
+		return ret, nil
 	}
 
 	ret.Valid = true

--- a/modules/040-node-manager/hooks/kubelet_csr_approver_test.go
+++ b/modules/040-node-manager/hooks/kubelet_csr_approver_test.go
@@ -145,6 +145,27 @@ var _ = Describe("Modules :: nodeManager :: hooks :: kubelet_csr_approver ::", f
 		})
 	})
 
+	Context("Cluster with csr for another signer", func() {
+		BeforeEach(func() {
+			csrUsages := []cv1.KeyUsage{cv1.UsageDigitalSignature, cv1.UsageKeyEncipherment, cv1.UsageClientAuth}
+			csr := newKubeCSR("system:masters", "kubernetes-admin", nil, nil, csrUsages)
+			csr.Spec.SignerName = cv1.KubeAPIServerClientSignerName
+			csrYaml, _ := yaml.Marshal(csr)
+
+			f.BindingContexts.Set(f.KubeStateSet(string(csrYaml)))
+			_, _ = f.KubeClient().CertificatesV1().CertificateSigningRequests().Create(context.TODO(), csr, metav1.CreateOptions{})
+
+			f.RunHook()
+		})
+
+		It("Must be executed successfully and don't approve csr", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			csr, err := f.KubeClient().CertificatesV1().CertificateSigningRequests().Get(context.TODO(), "kubelet-csr", metav1.GetOptions{})
+			Expect(err).To(BeNil())
+			Expect(csr.Status.Conditions).To(BeNil())
+		})
+	})
+
 	Context("Cluster with wrong csr (Organization must match 'system:nodes')", func() {
 		BeforeEach(func() {
 			csrUsages := []cv1.KeyUsage{cv1.UsageDigitalSignature, cv1.UsageKeyEncipherment, cv1.UsageServerAuth}


### PR DESCRIPTION
## Description

`kubelet_csr_approver` now handles only `kubernetes.io/kubelet-serving` CSRs.

## Why do we need it, and what problem does it solve?

`ret.Valid` was set outside the signer check, so a CSR for any other signer was approved without validation. Anyone allowed to create a CSR could get a `kubernetes.io/kube-apiserver-client` certificate with an arbitrary subject signed by the cluster CA.

Before:
<img width="1323" height="87" alt="image" src="https://github.com/user-attachments/assets/457298d8-7755-47ed-9ac1-ddaec326a969" />

After:
<img width="1349" height="86" alt="image" src="https://github.com/user-attachments/assets/cbc19eee-e314-4a68-9f0d-a1c2e174bf46" />


## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: node-manager
type: fix
summary: Approve only kubelet-serving CSRs in the kubelet_csr_approver hook.
impact_level: default
```
