### PR TITLE
[istio] Fix api-proxy RBAC

### DIFF
--- a/ee/modules/110-istio/templates/multicluster/api-proxy/rbac-for-us.yaml
+++ b/ee/modules/110-istio/templates/multicluster/api-proxy/rbac-for-us.yaml
@@ -115,4 +115,30 @@ subjects:
 - kind: ServiceAccount
   name: multicluster-api-proxy
   namespace: d8-{{ $.Chart.Name }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: multicluster:api-proxy
+  namespace: d8-{{ $.Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "api-proxy")) | nindent 2 }}
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: multicluster:api-proxy
+  namespace: d8-{{ $.Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "api-proxy")) | nindent 2 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: multicluster:api-proxy
+subjects:
+- kind: ServiceAccount
+  name: multicluster-api-proxy
+  namespace: d8-{{ $.Chart.Name }}
 {{- end }}

--- a/modules/110-istio/template_tests/module_test.go
+++ b/modules/110-istio/template_tests/module_test.go
@@ -1182,6 +1182,8 @@ users:
 			Expect(f.KubernetesResource("ServiceAccount", "d8-istio", "multicluster-api-proxy").Exists()).To(BeTrue())
 			Expect(f.KubernetesGlobalResource("ClusterRole", "d8:istio:multicluster:api-proxy").Exists()).To(BeTrue())
 			Expect(f.KubernetesGlobalResource("ClusterRoleBinding", "d8:istio:multicluster:api-proxy").Exists()).To(BeTrue())
+			Expect(f.KubernetesResource("Role", "d8-istio", "multicluster:api-proxy").Exists()).To(BeTrue())
+			Expect(f.KubernetesResource("RoleBinding", "d8-istio", "multicluster:api-proxy").Exists()).To(BeTrue())
 
 			Expect(f.KubernetesResource("Deployment", "d8-istio", "metadata-exporter").Exists()).To(BeTrue())
 			Expect(f.KubernetesResource("VerticalPodAutoscaler", "d8-istio", "metadata-exporter").Exists()).To(BeTrue())


### PR DESCRIPTION
## Description

Grant the `multicluster-api-proxy` service account read access to ConfigMaps in the `d8-istio` namespace.

## Why do we need it, and what problem does it solve?

Since Istio 1.29, istiod reads the mesh config ConfigMap (`istio-<revision>`) of every remote cluster to get its trust domain. The same upstream change added `configmaps` to the `istio-reader` ClusterRole, but our hand-copied api-proxy role was not updated when revision 1.29.6 was added.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: fix
summary: Allow multicluster api-proxy to read ConfigMaps in `d8-istio`, so istiod can read the mesh config of remote clusters with Istio 1.29.
impact_level: default
```