### PR TITLE
Backport: [user-authn] Add last-applied fuzz tests for Dex and dex-authenticator

### DIFF
--- a/modules/150-user-authn/images/dex-authenticator/patches/999-fuzz-handlers.patch
+++ b/modules/150-user-authn/images/dex-authenticator/patches/999-fuzz-handlers.patch
@@ -1,0 +1,405 @@
+diff --git a/fuzz_handlers_test.go b/fuzz_handlers_test.go
+new file mode 100644
+index 0000000..dfffb41
+--- /dev/null
++++ b/fuzz_handlers_test.go
+@@ -0,0 +1,274 @@
++package main
++
++import (
++	"encoding/json"
++	"io"
++	"net/http"
++	"net/http/httptest"
++	"net/url"
++	"strings"
++	"testing"
++
++	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
++	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/logger"
++	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/validation"
++)
++
++// Fuzz targets for oauth2-proxy HTTP handlers that accept user-controlled
++// input (path, query, headers, cookies, form, Authorization). Shipped as
++// Deckhouse patch 999-fuzz-handlers; *_test.go is not built into the image.
++
++func init() {
++	logger.SetOutput(io.Discard)
++}
++
++type fuzzSeedRequest struct {
++	Method   string              `json:"method"`
++	URL      string              `json:"url"`
++	Headers  map[string][]string `json:"headers"`
++	PostForm url.Values          `json:"postForm"`
++	Body     string              `json:"body"`
++	Cookie   string              `json:"cookie"`
++}
++
++func fuzzAbsURL(raw string) string {
++	if raw == "" {
++		return "http://127.0.0.1/"
++	}
++	if strings.HasPrefix(raw, "http://") || strings.HasPrefix(raw, "https://") {
++		return raw
++	}
++	if strings.HasPrefix(raw, "/") {
++		return "http://127.0.0.1" + raw
++	}
++	return "http://127.0.0.1/" + raw
++}
++
++func newFuzzRequest(t *testing.T, data []byte, defaultMethod, defaultURL string) *http.Request {
++	t.Helper()
++	if len(data) > 0 && data[0] == '{' {
++		var sr fuzzSeedRequest
++		if err := json.Unmarshal(data, &sr); err == nil {
++			method := sr.Method
++			if method == "" {
++				method = defaultMethod
++			}
++			rawURL := sr.URL
++			if rawURL == "" {
++				rawURL = defaultURL
++			}
++			u, err := url.Parse(fuzzAbsURL(rawURL))
++			if err != nil {
++				t.Skip(err)
++			}
++			var body io.Reader = strings.NewReader(sr.Body)
++			if sr.PostForm != nil && (method == http.MethodPost || method == http.MethodPut || method == http.MethodPatch) {
++				body = strings.NewReader(sr.PostForm.Encode())
++			}
++			req, err := http.NewRequestWithContext(t.Context(), method, u.String(), body)
++			if err != nil {
++				t.Skip(err)
++			}
++			if sr.Headers != nil {
++				req.Header = sr.Headers
++			}
++			if sr.Cookie != "" {
++				req.Header.Set("Cookie", sr.Cookie)
++			}
++			if sr.PostForm != nil && req.Header.Get("Content-Type") == "" {
++				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
++			}
++			if req.Host == "" {
++				req.Host = "127.0.0.1"
++			}
++			req.RemoteAddr = "127.0.0.1:1"
++			return req
++		}
++	}
++	method := defaultMethod
++	if len(data) > 0 {
++		switch data[0] % 5 {
++		case 1:
++			method = http.MethodPost
++		case 2:
++			method = http.MethodPut
++		case 3:
++			method = http.MethodHead
++		case 4:
++			method = http.MethodDelete
++		}
++	}
++	body := data
++	if len(data) > 1 {
++		body = data[1:]
++	}
++	req, err := http.NewRequestWithContext(t.Context(), method, fuzzAbsURL(defaultURL), strings.NewReader(string(body)))
++	if err != nil {
++		t.Skip(err)
++	}
++	req.Host = "127.0.0.1"
++	req.RemoteAddr = "127.0.0.1:1"
++	return req
++}
++
++func mustFuzzProxy(t *testing.T) *OAuthProxy {
++	t.Helper()
++	opts := options.NewOptions()
++	opts.Cookie.Secret = rawCookieSecret
++	opts.Providers[0].ID = "providerID"
++	opts.Providers[0].ClientID = clientID
++	opts.Providers[0].ClientSecret = clientSecret
++	opts.EmailDomains = []string{"*"}
++	staticCode := 200
++	opts.UpstreamServers = options.UpstreamConfig{
++		Upstreams: []options.Upstream{{
++			ID:   "static",
++			Path: "/",
++			// Static body avoids dialing a real backend while still
++			// exercising the proxy path after authentication.
++			Static:     true,
++			StaticCode: &staticCode,
++		}},
++	}
++	if err := validation.Validate(opts); err != nil {
++		t.Skip(err)
++	}
++	p, err := NewOAuthProxy(opts, func(string) bool { return true })
++	if err != nil {
++		t.Fatalf("NewOAuthProxy: %v", err)
++	}
++	return p
++}
++
++func fuzzProxyHandler(f *testing.F, seeds []string, method, path string) {
++	for _, seed := range seeds {
++		f.Add([]byte(seed))
++	}
++	f.Add([]byte{})
++	f.Add([]byte("{not-json"))
++	f.Fuzz(func(t *testing.T, data []byte) {
++		p := mustFuzzProxy(t)
++		// Always go through ServeHTTP so preAuth/session middleware injects
++		// RequestScope. Direct handler calls panic in ErrorPage when scope is nil.
++		p.ServeHTTP(httptest.NewRecorder(), newFuzzRequest(t, data, method, path))
++	})
++}
++
++func FuzzServeHTTP(f *testing.F) {
++	fuzzProxyHandler(f, []string{
++		`{"method":"GET","url":"/robots.txt"}`,
++		`{"method":"GET","url":"/ping"}`,
++		`{"method":"GET","url":"/ready"}`,
++		`{"method":"GET","url":"/oauth2/start"}`,
++		`{"method":"GET","url":"/oauth2/sign_in"}`,
++		`{"method":"POST","url":"/oauth2/sign_in","postForm":{"username":["a"],"password":["b"]}}`,
++		`{"method":"GET","url":"/oauth2/sign_out"}`,
++		`{"method":"GET","url":"/oauth2/callback?code=x&state=y"}`,
++		`{"method":"GET","url":"/oauth2/userinfo"}`,
++		`{"method":"GET","url":"/oauth2/auth"}`,
++		`{"method":"GET","url":"/","headers":{"Authorization":["Bearer eyJhbGciOiJub25lIn0.eyJzdWIiOiJ4In0.x"]}}`,
++		`{"method":"GET","url":"/","cookie":"_oauth2_proxy=not-a-ticket"}`,
++		`{"method":"GET","url":"/","headers":{"X-Forwarded-For":["10.0.0.1"],"X-Forwarded-Host":["evil.example"],"X-Forwarded-Proto":["https"]}}`,
++	}, http.MethodGet, "/")
++}
++
++func FuzzSignIn(f *testing.F) {
++	fuzzProxyHandler(f, []string{
++		`{"method":"GET","url":"/oauth2/sign_in"}`,
++		`{"method":"POST","url":"/oauth2/sign_in","postForm":{"username":["u"],"password":["p"]}}`,
++	}, http.MethodPost, "/oauth2/sign_in")
++}
++
++func FuzzSignOut(f *testing.F) {
++	fuzzProxyHandler(f, []string{
++		`{"method":"GET","url":"/oauth2/sign_out"}`,
++		`{"method":"GET","url":"/oauth2/sign_out?rd=https://evil.example/"}`,
++	}, http.MethodGet, "/oauth2/sign_out")
++}
++
++func FuzzOAuthStart(f *testing.F) {
++	fuzzProxyHandler(f, []string{
++		`{"method":"GET","url":"/oauth2/start"}`,
++		`{"method":"GET","url":"/oauth2/start?rd=/abs"}`,
++	}, http.MethodGet, "/oauth2/start")
++}
++
++func FuzzOAuthCallback(f *testing.F) {
++	fuzzProxyHandler(f, []string{
++		`{"method":"GET","url":"/oauth2/callback?error=access_denied&error_description=nope"}`,
++		`{"method":"GET","url":"/oauth2/callback?code=abc&state=xyz"}`,
++		`{"method":"POST","url":"/oauth2/callback","postForm":{"code":["abc"],"state":["xyz"]}}`,
++	}, http.MethodGet, "/oauth2/callback")
++}
++
++func FuzzAuthOnly(f *testing.F) {
++	fuzzProxyHandler(f, []string{
++		`{"method":"GET","url":"/oauth2/auth"}`,
++		`{"method":"GET","url":"/oauth2/auth","headers":{"Authorization":["Bearer x"]}}`,
++		`{"method":"GET","url":"/oauth2/auth","cookie":"_oauth2_proxy=x"}`,
++	}, http.MethodGet, "/oauth2/auth")
++}
++
++func FuzzProxy(f *testing.F) {
++	fuzzProxyHandler(f, []string{
++		`{"method":"GET","url":"/"}`,
++		`{"method":"GET","url":"/api?q=<script>"}`,
++		`{"method":"POST","url":"/","body":"{}","headers":{"Content-Type":["application/json"]}}`,
++	}, http.MethodGet, "/")
++}
++
++func FuzzUserInfo(f *testing.F) {
++	fuzzProxyHandler(f, []string{
++		`{"method":"GET","url":"/oauth2/userinfo"}`,
++		`{"method":"GET","url":"/oauth2/userinfo","headers":{"Authorization":["Bearer x"]}}`,
++	}, http.MethodGet, "/oauth2/userinfo")
++}
++
++func FuzzManualSignIn(f *testing.F) {
++	f.Add([]byte(`{"method":"POST","url":"/oauth2/sign_in","postForm":{"username":["u"],"password":["p"]}}`))
++	f.Fuzz(func(t *testing.T, data []byte) {
++		p := mustFuzzProxy(t)
++		_, _, _ = p.ManualSignIn(newFuzzRequest(t, data, http.MethodPost, "/oauth2/sign_in"))
++	})
++}
++
++func FuzzLoadCookiedSession(f *testing.F) {
++	f.Add([]byte(`{"method":"GET","url":"/","cookie":"_oauth2_proxy=not-valid"}`))
++	f.Add([]byte(`{"method":"GET","url":"/","cookie":"_oauth2_proxy="}`))
++	f.Fuzz(func(t *testing.T, data []byte) {
++		p := mustFuzzProxy(t)
++		_, _ = p.LoadCookiedSession(newFuzzRequest(t, data, http.MethodGet, "/"))
++	})
++}
++
++func FuzzRedeemCode(f *testing.F) {
++	f.Add("code")
++	f.Add("")
++	f.Add("../../../etc/passwd")
++	f.Fuzz(func(t *testing.T, code string) {
++		p := mustFuzzProxy(t)
++		req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1/oauth2/callback?code="+url.QueryEscape(code), nil)
++		_, _ = p.redeemCode(req.WithContext(t.Context()), code)
++	})
++}
++
++func FuzzAllHandlers(f *testing.F) {
++	f.Add([]byte(`{"method":"GET","url":"/oauth2/callback?code=x&state=y"}`))
++	f.Fuzz(func(t *testing.T, data []byte) {
++		p := mustFuzzProxy(t)
++		for _, path := range []string{
++			"/",
++			"/robots.txt",
++			"/oauth2/sign_in",
++			"/oauth2/sign_out",
++			"/oauth2/start",
++			"/oauth2/callback",
++			"/oauth2/auth",
++			"/oauth2/userinfo",
++		} {
++			p.ServeHTTP(httptest.NewRecorder(), newFuzzRequest(t, data, http.MethodGet, path))
++		}
++		_, _, _ = p.ManualSignIn(newFuzzRequest(t, data, http.MethodPost, "/oauth2/sign_in"))
++		_, _ = p.LoadCookiedSession(newFuzzRequest(t, data, http.MethodGet, "/"))
++	})
++}
+diff --git a/pkg/middleware/fuzz_jwt_session_test.go b/pkg/middleware/fuzz_jwt_session_test.go
+new file mode 100644
+index 0000000..1b4aa4a
+--- /dev/null
++++ b/pkg/middleware/fuzz_jwt_session_test.go
+@@ -0,0 +1,55 @@
++package middleware
++
++import (
++	"context"
++	"errors"
++	"net/http"
++	"net/http/httptest"
++	"regexp"
++	"testing"
++
++	"github.com/justinas/alice"
++	middlewareapi "github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/middleware"
++	sessionsapi "github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/sessions"
++)
++
++// JWT session loader parses Authorization (Bearer / Basic) as user input.
++
++func FuzzJwtSessionLoader(f *testing.F) {
++	f.Add("Bearer eyJhbGciOiJub25lIn0.eyJzdWIiOiJ4In0.x")
++	f.Add("Bearer eyJfoobar.eyJfoobar.12345asdf")
++	f.Add("Basic dXNlcjpwYXNz")
++	f.Add("Bearer ")
++	f.Add("")
++	f.Add("NotAScheme token")
++	f.Fuzz(func(t *testing.T, auth string) {
++		loader := NewJwtSessionLoader([]middlewareapi.TokenToSessionFunc{
++			func(_ context.Context, token string) (*sessionsapi.SessionState, error) {
++				if token == "" {
++					return nil, errors.New("empty")
++				}
++				return nil, errors.New("unverified")
++			},
++		})
++		handler := alice.New(NewScope(false, "X-Request-Id")).Then(loader(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})))
++		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://127.0.0.1/", nil)
++		if err != nil {
++			t.Skip(err)
++		}
++		if auth != "" {
++			req.Header.Set("Authorization", auth)
++		}
++		handler.ServeHTTP(httptest.NewRecorder(), req)
++	})
++}
++
++func FuzzFindTokenFromHeader(f *testing.F) {
++	j := &jwtSessionLoader{jwtRegex: regexp.MustCompile(jwtRegexFormat)}
++	f.Add("Bearer eyJhbGciOiJub25lIn0.eyJzdWIiOiJ4In0.x")
++	f.Add("Basic dXNlcjpwYXNz")
++	f.Add("")
++	f.Add("Bearer")
++	f.Fuzz(func(t *testing.T, header string) {
++		_, _ = j.findTokenFromHeader(header)
++	})
++}
+diff --git a/pkg/sessions/persistence/fuzz_ticket_test.go b/pkg/sessions/persistence/fuzz_ticket_test.go
+new file mode 100644
+index 0000000..c12e14e
+--- /dev/null
++++ b/pkg/sessions/persistence/fuzz_ticket_test.go
+@@ -0,0 +1,58 @@
++package persistence
++
++import (
++	"net/http"
++	"testing"
++
++	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
++)
++
++// decodeTicket / decodeTicketFromRequest parse the Deckhouse cookie-refresh
++// JSON blob that lives in the session cookie. That is user-controlled input.
++
++func fuzzCookieSecret() string {
++	b := make([]byte, 32)
++	for i := range b {
++		b[i] = byte('A' + i%26)
++	}
++	return string(b)
++}
++
++func fuzzCookieOpts() *options.Cookie {
++	return &options.Cookie{
++		Name:   "_oauth2_proxy",
++		Secret: fuzzCookieSecret(),
++		Expire: 0,
++	}
++}
++
++func FuzzDecodeTicket(f *testing.F) {
++	f.Add([]byte(`{"Ticket":"dummy-0123456789abcdef.MDEyMzQ1Njc4OWFiY2RlZg","RefreshToken":"rt"}`))
++	f.Add([]byte(`{"Ticket":"a.b","RefreshToken":""}`))
++	f.Add([]byte(`{"Ticket":"only-one-part","RefreshToken":"x"}`))
++	f.Add([]byte(`not-json`))
++	f.Add([]byte(`{}`))
++	f.Add([]byte(`[]`))
++	f.Add([]byte(`{"Ticket":null,"RefreshToken":null}`))
++	f.Fuzz(func(t *testing.T, data []byte) {
++		_, _, _ = decodeTicket(string(data), fuzzCookieOpts())
++	})
++}
++
++func FuzzDecodeTicketFromRequest(f *testing.F) {
++	f.Add("_oauth2_proxy=not-signed")
++	f.Add("_oauth2_proxy=")
++	f.Add("other=1")
++	f.Add("")
++	f.Add("_oauth2_proxy=" + string([]byte{0xff, 0xfe}))
++	f.Fuzz(func(t *testing.T, cookie string) {
++		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://127.0.0.1/", nil)
++		if err != nil {
++			t.Skip(err)
++		}
++		if cookie != "" {
++			req.Header.Set("Cookie", cookie)
++		}
++		_, _, _ = decodeTicketFromRequest(req, fuzzCookieOpts())
++	})
++}

--- a/modules/150-user-authn/images/dex-authenticator/patches/README.md
+++ b/modules/150-user-authn/images/dex-authenticator/patches/README.md
@@ -30,3 +30,26 @@ Fixes CVE-2025-30204 CVE-2025-22868 CVE-2024-28180
 ### 006-return-200-on-success-and-header-on-fail.patch
 
 Oauth2-proxy returns 200 (instead of 202) when the request is authenticated and adds "X-Auth-Request-Result" header on fail.
+
+
+### 999-fuzz-handlers.patch
+
+Go native fuzz tests for oauth2-proxy user-input surfaces. Applied last.
+
+Targets:
+
+- HTTP mux via `ServeHTTP`: `/`, `/robots.txt`, `/oauth2/sign_in`,
+  `/oauth2/sign_out`, `/oauth2/start`, `/oauth2/callback`, `/oauth2/auth`,
+  `/oauth2/userinfo`, cookies, `Authorization`, `X-Forwarded-*`
+- `ManualSignIn`, `LoadCookiedSession`, `redeemCode`
+- Deckhouse cookie-refresh JSON ticket parser (`decodeTicket`,
+  `decodeTicketFromRequest`)
+- JWT bearer/basic session loader
+
+`*_test.go` is not compiled into the image. Run from a patched source tree:
+
+```
+go test -run=^$ -fuzz=FuzzServeHTTP -fuzztime=12h .
+go test -run=^$ -fuzz=FuzzDecodeTicket$ -fuzztime=12h ./pkg/sessions/persistence
+go test -run=^$ -fuzz=FuzzJwtSessionLoader$ -fuzztime=12h ./pkg/middleware
+```

--- a/modules/150-user-authn/images/dex/patches/999-fuzz-handlers.patch
+++ b/modules/150-user-authn/images/dex/patches/999-fuzz-handlers.patch
@@ -1,0 +1,559 @@
+diff --git a/server/fuzz_handlers_test.go b/server/fuzz_handlers_test.go
+new file mode 100644
+index 0000000..89e28b2
+--- /dev/null
++++ b/server/fuzz_handlers_test.go
+@@ -0,0 +1,553 @@
++package server
++
++import (
++	"crypto/hmac"
++	"crypto/sha256"
++	"encoding/base64"
++	"encoding/json"
++	"io"
++	"log/slog"
++	"net/http"
++	"net/http/httptest"
++	"net/url"
++	"os"
++	"path/filepath"
++	"strings"
++	"testing"
++	"time"
++
++	gosundheit "github.com/AppsFlyer/go-sundheit"
++	"github.com/gorilla/mux"
++	"github.com/prometheus/client_golang/prometheus"
++	"golang.org/x/crypto/bcrypt"
++
++	"github.com/dexidp/dex/storage"
++	"github.com/dexidp/dex/storage/memory"
++)
++
++// Fuzz targets cover every Dex HTTP handler that accepts attacker-controlled
++// input: query, form, headers, cookies, tokens, and path parameters.
++//
++// These tests are shipped as the last Deckhouse patch (999-fuzz-handlers)
++// so they always compile against the fully patched tree. They are not
++// compiled into the production binary (*_test.go).
++
++type fuzzSeedRequest struct {
++	Method   string              `json:"method"`
++	URL      string              `json:"url"`
++	Headers  map[string][]string `json:"headers"`
++	Form     url.Values          `json:"form"`
++	PostForm url.Values          `json:"postForm"`
++	Body     string              `json:"body"`
++}
++
++type fuzzTokens struct {
++	Access  string
++	Refresh string
++}
++
++var fuzzPasswordHash = mustFuzzPasswordHash()
++
++func mustFuzzPasswordHash() []byte {
++	h, err := bcrypt.GenerateFromPassword([]byte("p"), bcrypt.MinCost)
++	if err != nil {
++		panic(err)
++	}
++	return h
++}
++
++func fuzzAbsURL(raw string) string {
++	if raw == "" {
++		return "http://127.0.0.1/"
++	}
++	if strings.HasPrefix(raw, "http://") || strings.HasPrefix(raw, "https://") {
++		return raw
++	}
++	if strings.HasPrefix(raw, "/") {
++		return "http://127.0.0.1" + raw
++	}
++	return "http://127.0.0.1/" + raw
++}
++
++func newFuzzRequest(t *testing.T, data []byte, defaultMethod, defaultURL string) *http.Request {
++	t.Helper()
++	if len(data) > 0 && data[0] == '{' {
++		var sr fuzzSeedRequest
++		if err := json.Unmarshal(data, &sr); err == nil {
++			method := sr.Method
++			if method == "" {
++				method = defaultMethod
++			}
++			rawURL := sr.URL
++			if rawURL == "" {
++				rawURL = defaultURL
++			}
++			u, err := url.Parse(fuzzAbsURL(rawURL))
++			if err != nil {
++				t.Skip(err)
++			}
++			if sr.Form != nil {
++				q := u.Query()
++				for k, vs := range sr.Form {
++					for _, v := range vs {
++						q.Add(k, v)
++					}
++				}
++				u.RawQuery = q.Encode()
++			}
++			var body io.Reader = strings.NewReader(sr.Body)
++			if sr.PostForm != nil && (method == http.MethodPost || method == http.MethodPut || method == http.MethodPatch) {
++				body = strings.NewReader(sr.PostForm.Encode())
++			}
++			req, err := http.NewRequestWithContext(t.Context(), method, u.String(), body)
++			if err != nil {
++				t.Skip(err)
++			}
++			if sr.Headers != nil {
++				req.Header = sr.Headers
++			}
++			if sr.PostForm != nil && req.Header.Get("Content-Type") == "" {
++				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
++			}
++			if req.Host == "" {
++				req.Host = "127.0.0.1"
++			}
++			req.RemoteAddr = "127.0.0.1:1"
++			return req
++		}
++	}
++
++	// Non-JSON corpus: first byte picks a method, the rest is the body.
++	method := defaultMethod
++	if len(data) > 0 {
++		switch data[0] % 6 {
++		case 1:
++			method = http.MethodPost
++		case 2:
++			method = http.MethodPut
++		case 3:
++			method = http.MethodPatch
++		case 4:
++			method = http.MethodHead
++		case 5:
++			method = http.MethodDelete
++		default:
++			method = defaultMethod
++		}
++	}
++	body := data
++	if len(data) > 1 {
++		body = data[1:]
++	}
++	req, err := http.NewRequestWithContext(t.Context(), method, fuzzAbsURL(defaultURL), strings.NewReader(string(body)))
++	if err != nil {
++		t.Skip(err)
++	}
++	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
++	req.Header.Set("X-Forwarded-For", "127.0.0.1")
++	req.Host = "127.0.0.1"
++	req.RemoteAddr = "127.0.0.1:1"
++	return req
++}
++
++func mustFuzzServer(t *testing.T) (*Server, fuzzTokens) {
++	t.Helper()
++	ctx := t.Context()
++	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
++
++	pp, err := NewPasswordPolicy("fuzz",
++		WithComplexityLevel("low"),
++		WithLockoutSettings(5, time.Minute),
++	)
++	if err != nil {
++		t.Fatalf("password policy: %v", err)
++	}
++
++	config := Config{
++		Issuer:             "http://127.0.0.1",
++		Storage:            memory.New(logger),
++		Web:                WebConfig{Dir: "../web"},
++		Logger:             logger,
++		PrometheusRegistry: prometheus.NewRegistry(),
++		HealthChecker:      gosundheit.New(),
++		SkipApprovalScreen: true,
++		PasswordConnector:  "mockpw",
++		PasswordPolicy:     pp,
++		RotateKeysAfter:    24 * time.Hour,
++		GCFrequency:        24 * time.Hour,
++		Now:                time.Now,
++		AllowedGrantTypes: []string{
++			grantTypeDeviceCode,
++			grantTypeAuthorizationCode,
++			grantTypeRefreshToken,
++			grantTypeTokenExchange,
++			grantTypeImplicit,
++			grantTypePassword,
++		},
++	}
++
++	for _, c := range []storage.Connector{
++		{ID: "mock", Type: "mockCallback", Name: "Mock", ResourceVersion: "1"},
++		{ID: "mockpw", Type: "mockPassword", Name: "MockPW", ResourceVersion: "1", Config: []byte(`{"username":"u","password":"p"}`)},
++	} {
++		if err := config.Storage.CreateConnector(ctx, c); err != nil && err != storage.ErrAlreadyExists {
++			t.Fatalf("create connector %s: %v", c.ID, err)
++		}
++	}
++
++	s, err := newServer(ctx, config, staticRotationStrategy(testKey))
++	if err != nil {
++		t.Fatalf("newServer: %v", err)
++	}
++	if s.refreshTokenPolicy == nil {
++		p, err := NewRefreshTokenPolicy(logger, false, "", "", "")
++		if err != nil {
++			t.Fatalf("refresh policy: %v", err)
++		}
++		p.now = config.Now
++		s.refreshTokenPolicy = p
++	}
++
++	now := time.Now()
++	if err := s.storage.CreateClient(ctx, storage.Client{
++		ID:           "client",
++		Secret:       "secret",
++		RedirectURIs: []string{"http://127.0.0.1/cb", deviceCallbackURI},
++		TrustedPeers: []string{"client"},
++		Public:       true,
++	}); err != nil && err != storage.ErrAlreadyExists {
++		t.Fatalf("create client: %v", err)
++	}
++
++	if err := s.storage.CreatePassword(ctx, storage.Password{
++		Email:         "u@example.com",
++		Username:      "u",
++		UserID:        "u",
++		Hash:          fuzzPasswordHash,
++		HashUpdatedAt: now,
++	}); err != nil && err != storage.ErrAlreadyExists {
++		t.Fatalf("create password: %v", err)
++	}
++
++	hmacKey := []byte("0123456789abcdef")
++	for _, ar := range []storage.AuthRequest{
++		{
++			ID: "s", ClientID: "client", ResponseTypes: []string{"code"},
++			Scopes: []string{"openid", "email", "offline_access"}, RedirectURI: "http://127.0.0.1/cb",
++			Nonce: "n", State: "s", ConnectorID: "mock", Expiry: now.Add(time.Hour), HMACKey: hmacKey,
++			PKCE: storage.PKCE{CodeChallengeMethod: "S256", CodeChallenge: "TJRIXgwhrmxBzh3-e2v6zupato5AokdvUCCOUm9QYIA"},
++		},
++		{
++			ID: "s_pw", ClientID: "client", ResponseTypes: []string{"code"},
++			Scopes: []string{"openid", "email", "offline_access"}, RedirectURI: "http://127.0.0.1/cb",
++			Nonce: "n", State: "s_pw", ConnectorID: "mockpw", Expiry: now.Add(time.Hour), HMACKey: hmacKey,
++		},
++		{
++			ID: "s_totp", ClientID: "client", ResponseTypes: []string{"code"},
++			Scopes: []string{"openid", "email", "offline_access"}, RedirectURI: "http://127.0.0.1/cb",
++			Nonce: "n", State: "s_totp", ConnectorID: "mockpw", Expiry: now.Add(time.Hour), HMACKey: hmacKey,
++			LoggedIn: true, Claims: storage.Claims{UserID: "u", Username: "u", Email: "u@example.com"},
++		},
++	} {
++		if err := s.storage.CreateAuthRequest(ctx, ar); err != nil && err != storage.ErrAlreadyExists {
++			t.Fatalf("create auth request %s: %v", ar.ID, err)
++		}
++	}
++
++	for _, code := range []storage.AuthCode{
++		{ID: "code-1", ClientID: "client", RedirectURI: "http://127.0.0.1/cb", Nonce: "n", Scopes: []string{"openid", "email", "offline_access"}, ConnectorID: "mock", Claims: storage.Claims{UserID: "u", Username: "u", Email: "u@example.com"}, Expiry: now.Add(30 * time.Minute)},
++		{ID: "code-pkce", ClientID: "client", RedirectURI: "http://127.0.0.1/cb", Nonce: "n", Scopes: []string{"openid", "email", "offline_access"}, ConnectorID: "mock", Claims: storage.Claims{UserID: "u2", Username: "u2"}, PKCE: storage.PKCE{CodeChallengeMethod: "S256", CodeChallenge: "TJRIXgwhrmxBzh3-e2v6zupato5AokdvUCCOUm9QYIA"}, Expiry: now.Add(30 * time.Minute)},
++		{ID: "code-plain", ClientID: "client", RedirectURI: "http://127.0.0.1/cb", Nonce: "n", Scopes: []string{"openid", "email", "offline_access"}, ConnectorID: "mock", Claims: storage.Claims{UserID: "u3", Username: "u3"}, PKCE: storage.PKCE{CodeChallengeMethod: "plain", CodeChallenge: "abc123"}, Expiry: now.Add(30 * time.Minute)},
++	} {
++		if err := s.storage.CreateAuthCode(ctx, code); err != nil && err != storage.ErrAlreadyExists {
++			t.Fatalf("create auth code %s: %v", code.ID, err)
++		}
++	}
++
++	if err := s.storage.CreateOfflineSessions(ctx, storage.OfflineSessions{
++		UserID: "u", ConnID: "mockpw",
++		TOTP:    "otpauth://totp/Example:u?secret=JBSWY3DPEHPK3PXP&issuer=Example",
++		Refresh: map[string]*storage.RefreshTokenRef{},
++	}); err != nil && err != storage.ErrAlreadyExists {
++		t.Fatalf("create offline session: %v", err)
++	}
++
++	form := url.Values{
++		"grant_type":   {"authorization_code"},
++		"code":         {"code-1"},
++		"redirect_uri": {"http://127.0.0.1/cb"},
++	}
++	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1/token", strings.NewReader(form.Encode())).WithContext(ctx)
++	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
++	req.Header.Set("Authorization", "Basic Y2xpZW50OnNlY3JldA==")
++	rr := httptest.NewRecorder()
++	s.handleToken(rr, req)
++	var out struct {
++		AccessToken  string `json:"access_token"`
++		RefreshToken string `json:"refresh_token"`
++	}
++	_ = json.Unmarshal(rr.Body.Bytes(), &out)
++	return s, fuzzTokens{Access: out.AccessToken, Refresh: out.RefreshToken}
++}
++
++func withConnector(req *http.Request, id string) *http.Request {
++	return mux.SetURLVars(req, map[string]string{"connector": id})
++}
++
++func addDiskSeeds(f *testing.F, name string) {
++	for _, dir := range []string{
++		filepath.Join("testdata", "seeds", name),
++		filepath.Join("testdata", "fuzz", name),
++	} {
++		entries, err := os.ReadDir(dir)
++		if err != nil {
++			continue
++		}
++		for _, e := range entries {
++			if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
++				continue
++			}
++			b, err := os.ReadFile(filepath.Join(dir, e.Name()))
++			if err == nil {
++				f.Add(b)
++			}
++		}
++	}
++}
++
++func fuzzHandler(f *testing.F, name string, seeds []string, method, path string, call func(*Server, http.ResponseWriter, *http.Request), prep func(*http.Request, fuzzTokens) *http.Request) {
++	for _, seed := range seeds {
++		f.Add([]byte(seed))
++	}
++	addDiskSeeds(f, name)
++	f.Add([]byte{})
++	f.Add([]byte("{not-json"))
++	f.Add([]byte("grant_type=password&username=u&password=p"))
++	f.Fuzz(func(t *testing.T, data []byte) {
++		s, toks := mustFuzzServer(t)
++		req := newFuzzRequest(t, data, method, path)
++		if prep != nil {
++			req = prep(req, toks)
++		}
++		if req.Header.Get("X-Forwarded-For") == "" {
++			req.Header.Set("X-Forwarded-For", "127.0.0.1")
++		}
++		call(s, httptest.NewRecorder(), req)
++	})
++}
++
++func FuzzHandleToken(f *testing.F) {
++	fuzzHandler(f, "FuzzHandleToken", []string{
++		`{"method":"POST","url":"/token","postForm":{"grant_type":["authorization_code"],"code":["code-1"],"redirect_uri":["http://127.0.0.1/cb"]},"headers":{"Authorization":["Basic Y2xpZW50OnNlY3JldA=="],"Content-Type":["application/x-www-form-urlencoded"]}}`,
++		`{"method":"POST","url":"/token","postForm":{"grant_type":["authorization_code"],"code":["code-pkce"],"redirect_uri":["http://127.0.0.1/cb"],"code_verifier":["dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"]},"headers":{"Authorization":["Basic Y2xpZW50OnNlY3JldA=="]}}`,
++		`{"method":"POST","url":"/token","postForm":{"grant_type":["password"],"username":["u"],"password":["p"],"scope":["openid email"]},"headers":{"Authorization":["Basic Y2xpZW50OnNlY3JldA=="]}}`,
++		`{"method":"POST","url":"/token","postForm":{"grant_type":["refresh_token"],"refresh_token":["x"]},"headers":{"Authorization":["Basic Y2xpZW50OnNlY3JldA=="]}}`,
++		`{"method":"POST","url":"/token","postForm":{"grant_type":["urn:ietf:params:oauth:grant-type:token-exchange"],"subject_token":["x"],"subject_token_type":["urn:ietf:params:oauth:token-type:access_token"]},"headers":{"Authorization":["Basic Y2xpZW50OnNlY3JldA=="]}}`,
++		`{"method":"POST","url":"/token","postForm":{"grant_type":["urn:ietf:params:oauth:grant-type:device_code"],"device_code":["d"],"client_id":["client"]}}`,
++	}, http.MethodPost, "/token", (*Server).handleToken, nil)
++}
++
++func FuzzHandlePublicKeys(f *testing.F) {
++	fuzzHandler(f, "FuzzHandlePublicKeys", []string{
++		`{"method":"GET","url":"/keys"}`,
++		`{"method":"HEAD","url":"/keys","headers":{"Accept":["application/jwk-set+json"]}}`,
++	}, http.MethodGet, "/keys", (*Server).handlePublicKeys, nil)
++}
++
++func FuzzHandleUserInfo(f *testing.F) {
++	fuzzHandler(f, "FuzzHandleUserInfo", []string{
++		`{"method":"GET","url":"/userinfo","headers":{"Authorization":["Bearer x"]}}`,
++		`{"method":"POST","url":"/userinfo","headers":{"Authorization":["Bearer "]}}`,
++	}, http.MethodGet, "/userinfo", (*Server).handleUserInfo, func(req *http.Request, toks fuzzTokens) *http.Request {
++		if req.Header.Get("Authorization") == "" && toks.Access != "" {
++			req.Header.Set("Authorization", "Bearer "+toks.Access)
++		}
++		return req
++	})
++}
++
++func FuzzHandleAuthorization(f *testing.F) {
++	fuzzHandler(f, "FuzzHandleAuthorization", []string{
++		`{"method":"GET","url":"/auth?response_type=code&client_id=client&redirect_uri=http://127.0.0.1/cb&scope=openid&state=zzz&nonce=n"}`,
++		`{"method":"GET","url":"/auth?response_type=token&client_id=client&redirect_uri=http://127.0.0.1/cb&scope=openid"}`,
++		`{"method":"GET","url":"/auth?response_type=code&client_id=client&redirect_uri=https://evil.example/cb&scope=openid"}`,
++	}, http.MethodGet, "/auth", (*Server).handleAuthorization, nil)
++}
++
++func FuzzHandleConnectorLogin(f *testing.F) {
++	fuzzHandler(f, "FuzzHandleConnectorLogin", []string{
++		`{"method":"GET","url":"/auth/mock?state=s"}`,
++		`{"method":"GET","url":"/auth/missing?state=s"}`,
++	}, http.MethodGet, "/auth/mock", (*Server).handleConnectorLogin, func(req *http.Request, _ fuzzTokens) *http.Request {
++		return withConnector(req, "mock")
++	})
++}
++
++func FuzzHandleConnectorCallback(f *testing.F) {
++	fuzzHandler(f, "FuzzHandleConnectorCallback", []string{
++		`{"method":"GET","url":"/callback?state=s&code=code-1"}`,
++		`{"method":"GET","url":"/callback?state=","headers":{"X-Remote-User":["admin"]}}`,
++		`{"method":"POST","url":"/callback","postForm":{"SAMLResponse":["PHNhbWw+"],"RelayState":["s"]}}`,
++	}, http.MethodGet, "/callback", (*Server).handleConnectorCallback, nil)
++}
++
++func FuzzHandlePasswordLogin(f *testing.F) {
++	fuzzHandler(f, "FuzzHandlePasswordLogin", []string{
++		`{"method":"POST","url":"/auth/mockpw/login?state=s_pw","postForm":{"login":["u"],"password":["p"]}}`,
++		`{"method":"POST","url":"/auth/mockpw/login?state=s_pw","postForm":{"login":[""],"password":[""]}}`,
++		`{"method":"POST","url":"/auth/mockpw/login?state=s_pw","postForm":{"login":["u"],"password":["wrong"]}}`,
++	}, http.MethodPost, "/auth/mockpw/login?state=s_pw", (*Server).handlePasswordLogin, func(req *http.Request, _ fuzzTokens) *http.Request {
++		return withConnector(req, "mockpw")
++	})
++}
++
++func FuzzHandleApproval(f *testing.F) {
++	fuzzHandler(f, "FuzzHandleApproval", []string{
++		`{"method":"POST","url":"/approval","postForm":{"req":["s"],"approval":["approve"]}}`,
++		`{"method":"POST","url":"/approval","postForm":{"req":["s"],"approval":["rejected"]}}`,
++		`{"method":"GET","url":"/approval?req=s"}`,
++	}, http.MethodPost, "/approval", (*Server).handleApproval, nil)
++}
++
++func FuzzHandleDeviceToken(f *testing.F) {
++	fuzzHandler(f, "FuzzHandleDeviceToken", []string{
++		`{"method":"POST","url":"/token","postForm":{"grant_type":["urn:ietf:params:oauth:grant-type:device_code"],"device_code":["d"],"client_id":["client"]}}`,
++	}, http.MethodPost, "/token", (*Server).handleDeviceToken, nil)
++}
++
++func FuzzHandleDeviceTokenDeprecated(f *testing.F) {
++	fuzzHandler(f, "FuzzHandleDeviceTokenDeprecated", []string{
++		`{"method":"POST","url":"/device/token","postForm":{"grant_type":["urn:ietf:params:oauth:grant-type:device_code"],"device_code":["d"],"client_id":["client"]}}`,
++	}, http.MethodPost, "/device/token", (*Server).handleDeviceTokenDeprecated, nil)
++}
++
++func FuzzHandleDeviceExchange(f *testing.F) {
++	fuzzHandler(f, "FuzzHandleDeviceExchange", []string{
++		`{"method":"GET","url":"/device"}`,
++		`{"method":"POST","url":"/device","postForm":{"user_code":["ABCD-EFGH"]}}`,
++		`{"method":"POST","url":"/device","postForm":{"user_code":["bad"]}}`,
++	}, http.MethodGet, "/device", (*Server).handleDeviceExchange, nil)
++}
++
++func FuzzVerifyUserCode(f *testing.F) {
++	fuzzHandler(f, "FuzzVerifyUserCode", []string{
++		`{"method":"POST","url":"/device/auth/verify_code","postForm":{"user_code":["ABCD-EFGH"]}}`,
++		`{"method":"POST","url":"/device/auth/verify_code","postForm":{"user_code":[""]}}`,
++	}, http.MethodPost, "/device/auth/verify_code", (*Server).verifyUserCode, nil)
++}
++
++func FuzzHandleDeviceCode(f *testing.F) {
++	fuzzHandler(f, "FuzzHandleDeviceCode", []string{
++		`{"method":"POST","url":"/device/code","postForm":{"client_id":["client"],"scope":["openid"]}}`,
++		`{"method":"POST","url":"/device/code","postForm":{"client_id":[""]}}`,
++	}, http.MethodPost, "/device/code", (*Server).handleDeviceCode, nil)
++}
++
++func FuzzHandleDeviceCallback(f *testing.F) {
++	fuzzHandler(f, "FuzzHandleDeviceCallback", []string{
++		`{"method":"GET","url":"/device/callback?state=u&code=code-1"}`,
++	}, http.MethodGet, "/device/callback?state=u&code=code-1", (*Server).handleDeviceCallback, nil)
++}
++
++func FuzzHandleIntrospect(f *testing.F) {
++	fuzzHandler(f, "FuzzHandleIntrospect", []string{
++		`{"method":"POST","url":"/token/introspect","postForm":{"token":["x"],"token_type_hint":["access_token"]},"headers":{"Authorization":["Basic Y2xpZW50OnNlY3JldA=="]}}`,
++		`{"method":"POST","url":"/token/introspect","postForm":{"token":[""]}}`,
++	}, http.MethodPost, "/token/introspect", (*Server).handleIntrospect, func(req *http.Request, toks fuzzTokens) *http.Request {
++		if req.Header.Get("Authorization") == "" {
++			req.Header.Set("Authorization", "Basic Y2xpZW50OnNlY3JldA==")
++		}
++		if toks.Access != "" && req.PostFormValue("token") == "" && req.FormValue("token") == "" {
++			// leave fuzzer-supplied body as-is; seed already has token=
++		}
++		return req
++	})
++}
++
++func FuzzHandleTOTPVerify(f *testing.F) {
++	mac := hmac.New(sha256.New, []byte("0123456789abcdef"))
++	mac.Write([]byte("s_totp"))
++	hmacVal := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
++	fuzzHandler(f, "FuzzHandleTOTPVerify", []string{
++		`{"method":"GET","url":"/totp?req=s_totp&hmac=` + hmacVal + `"}`,
++		`{"method":"POST","url":"/totp","postForm":{"req":["s_totp"],"hmac":["` + hmacVal + `"],"totp":["123456"]}}`,
++		`{"method":"POST","url":"/totp","postForm":{"req":["missing"],"hmac":["x"],"totp":[""]}}`,
++	}, http.MethodPost, "/totp", (*Server).handleTOTPVerify, nil)
++}
++
++func FuzzHandlePasswordChange(f *testing.F) {
++	fuzzHandler(f, "FuzzHandlePasswordChange", []string{
++		`{"method":"GET","url":"/password/change?username=u%40example.com&changeReason=expired"}`,
++		`{"method":"POST","url":"/password/change","postForm":{"username":["u@example.com"],"currentPassword":["p"],"newPassword":["Newpass1"],"changeReason":["expired"],"back":["http://127.0.0.1/auth"]}}`,
++		`{"method":"POST","url":"/password/change","postForm":{"username":["u@example.com"],"currentPassword":["p"],"newPassword":["p"]}}`,
++	}, http.MethodPost, passwordChangeURI, (*Server).handlePasswordChange, nil)
++}
++
++func FuzzServeHTTP(f *testing.F) {
++	addDiskSeeds(f, "FuzzServeHTTP")
++	for _, seed := range []string{
++		`{"method":"GET","url":"/.well-known/openid-configuration"}`,
++		`{"method":"GET","url":"/healthz"}`,
++		`{"method":"GET","url":"/robots.txt"}`,
++		`{"method":"GET","url":"/static/main.css"}`,
++		`{"method":"GET","url":"/auth?response_type=code&client_id=client&redirect_uri=http://127.0.0.1/cb&scope=openid"}`,
++		`{"method":"POST","url":"/token","postForm":{"grant_type":["authorization_code"],"code":["code-1"],"redirect_uri":["http://127.0.0.1/cb"]},"headers":{"Authorization":["Basic Y2xpZW50OnNlY3JldA=="]}}`,
++	} {
++		f.Add([]byte(seed))
++	}
++	f.Fuzz(func(t *testing.T, data []byte) {
++		s, _ := mustFuzzServer(t)
++		req := newFuzzRequest(t, data, http.MethodGet, "/")
++		if req.Header.Get("X-Forwarded-For") == "" {
++			req.Header.Set("X-Forwarded-For", "127.0.0.1")
++		}
++		s.ServeHTTP(httptest.NewRecorder(), req)
++	})
++}
++
++func FuzzAllHandlers(f *testing.F) {
++	addDiskSeeds(f, "FuzzAllHandlers")
++	addDiskSeeds(f, "FuzzHandleToken")
++	f.Add([]byte(`{"method":"POST","url":"/token","postForm":{"grant_type":["authorization_code"],"code":["code-1"],"redirect_uri":["http://127.0.0.1/cb"]},"headers":{"Authorization":["Basic Y2xpZW50OnNlY3JldA=="]}}`))
++	f.Add([]byte(`{"method":"GET","url":"/auth?response_type=code&client_id=client&redirect_uri=http://127.0.0.1/cb&scope=openid"}`))
++	f.Fuzz(func(t *testing.T, data []byte) {
++		s, toks := mustFuzzServer(t)
++		rr := httptest.NewRecorder
++
++		{
++			req := newFuzzRequest(t, data, http.MethodPost, "/token")
++			s.handleToken(rr(), req)
++		}
++		{
++			s.handlePublicKeys(rr(), newFuzzRequest(t, data, http.MethodGet, "/keys"))
++		}
++		{
++			req := newFuzzRequest(t, data, http.MethodGet, "/userinfo")
++			if req.Header.Get("Authorization") == "" && toks.Access != "" {
++				req.Header.Set("Authorization", "Bearer "+toks.Access)
++			}
++			s.handleUserInfo(rr(), req)
++		}
++		s.handleAuthorization(rr(), newFuzzRequest(t, data, http.MethodGet, "/auth"))
++		s.handleConnectorLogin(rr(), withConnector(newFuzzRequest(t, data, http.MethodGet, "/auth/mock"), "mock"))
++		s.handleConnectorCallback(rr(), newFuzzRequest(t, data, http.MethodGet, "/callback"))
++		s.handlePasswordLogin(rr(), withConnector(newFuzzRequest(t, data, http.MethodPost, "/auth/mockpw/login?state=s_pw"), "mockpw"))
++		s.handleApproval(rr(), newFuzzRequest(t, data, http.MethodPost, "/approval"))
++		s.handleDeviceTokenDeprecated(rr(), newFuzzRequest(t, data, http.MethodPost, "/device/token"))
++		s.handleDeviceToken(rr(), newFuzzRequest(t, data, http.MethodPost, "/token"))
++		s.handleDeviceExchange(rr(), newFuzzRequest(t, data, http.MethodGet, "/device"))
++		s.verifyUserCode(rr(), newFuzzRequest(t, data, http.MethodPost, "/device/auth/verify_code"))
++		s.handleDeviceCode(rr(), newFuzzRequest(t, data, http.MethodPost, "/device/code"))
++		s.handleDeviceCallback(rr(), newFuzzRequest(t, data, http.MethodGet, "/device/callback?state=u&code=code-1"))
++		{
++			req := newFuzzRequest(t, data, http.MethodPost, "/token/introspect")
++			if req.Header.Get("Authorization") == "" {
++				req.Header.Set("Authorization", "Basic Y2xpZW50OnNlY3JldA==")
++			}
++			s.handleIntrospect(rr(), req)
++		}
++		s.handleTOTPVerify(rr(), newFuzzRequest(t, data, http.MethodPost, "/totp"))
++		s.handlePasswordChange(rr(), newFuzzRequest(t, data, http.MethodPost, passwordChangeURI))
++		s.ServeHTTP(rr(), newFuzzRequest(t, data, http.MethodGet, "/.well-known/openid-configuration"))
++	})
++}

--- a/modules/150-user-authn/images/dex/patches/README.md
+++ b/modules/150-user-authn/images/dex/patches/README.md
@@ -161,3 +161,25 @@ Key changes:
 
 Upstream is affected as well, including `master`: an upstream PR is to be opened on top of this
 patch.
+
+### 999-fuzz-handlers.patch
+
+Go native fuzz tests for every Dex HTTP handler that accepts user-controlled
+input (query, form, headers, cookies, tokens, path parameters). Applied last
+so the tests always compile against the fully patched tree.
+
+Targets: `handleToken`, `handlePublicKeys`, `handleUserInfo`,
+`handleAuthorization`, `handleConnectorLogin`, `handleConnectorCallback`,
+`handlePasswordLogin`, `handleApproval`, `handleDeviceToken`,
+`handleDeviceTokenDeprecated`, `handleDeviceExchange`, `verifyUserCode`,
+`handleDeviceCode`, `handleDeviceCallback`, `handleIntrospect`,
+`handleTOTPVerify`, `handlePasswordChange`, plus `ServeHTTP` (discovery,
+healthz, static) and `FuzzAllHandlers`.
+
+On this branch the test does not set up the per-IP rate limiter and the lockout connector list: `015-ratelimit-lock-unlock-users.patch` is not part of release-1.76, so `NewIPRateLimiter`, the `RateLimiter`/`RealIPHeader`/`TrustedRealIPCIDRs` config fields, `WithLockoutApplyToConnectors` and `OfflineSessions.Email` do not exist here. Everything else is identical to the patch on `main`.
+
+`*_test.go` is not compiled into the Dex image. Run from a patched source tree:
+
+```
+go test -vet=off -run=^$ -fuzz=FuzzAllHandlers -fuzztime=12h ./server
+```


### PR DESCRIPTION
## Description

Backport of #22583 (`2641f7d51f`) to `release-1.76`.

Adds Go native fuzz tests for Dex and dex-authenticator as the last image patch (`999-fuzz-handlers`). The tests are `*_test.go` only: `go build` of the production binary is unchanged. Both patches add new files only, so they apply on the patch set of this branch.

Dex targets every HTTP handler that accepts user input, including Deckhouse-only paths (`/totp`, `/password/change`, password login). dex-authenticator covers the oauth2-proxy mux (cookies, `Authorization`, `X-Forwarded-*`), `redeemCode` / `LoadCookiedSession` / `ManualSignIn`, the cookie-refresh JSON ticket parser, and the JWT session loader.

Differences from the original change, because the patch set of this branch is older:

- The CVE patches are numbered differently here (`010-fix-cves` for Dex, `005-fix-cves` for dex-authenticator), so the `999-fix-cve` → `998-fix-cve` rename does not apply and the READMEs keep the patch list of this branch (the automatic backport failed on these conflicts).
- The Dex fuzz test is adapted to this branch: `015-ratelimit-lock-unlock-users.patch` is not part of release-1.76, so the test does not construct the per-IP rate limiter, does not set the `RateLimiter` / `RealIPHeader` / `TrustedRealIPCIDRs` config fields, the lockout connector list or `OfflineSessions.Email`. Everything else is identical to the patch on `main`; the README says so.

Verified by applying the full Dex and dex-authenticator patch sets of this branch onto clean Dex v2.44.0 and oauth2-proxy v7.5.1 checkouts (the versions this branch builds) and compiling the tests of the affected packages.

## Why do we need it, and what problem does it solve?

Deckhouse regulation now requires fuzz tests to live in the module patch set and to be applied last, so they always compile against the fully patched Dex / oauth2-proxy tree.

## Why do we need it in the patch release (if we do)?

So that the release branch carries the same fuzz targets as `main` and the fuzzing infrastructure can run against it.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authn
type: chore
summary: add last-applied fuzz tests for Dex and dex-authenticator
impact_level: low
```
