### PR TITLE
[node-manager] Read the CAPI instance-class checksum from helm, not from kept MachineTemplates

### DIFF
--- a/modules/040-node-manager/images/node-controller/src/internal/common/cache.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/common/cache.go
@@ -73,6 +73,16 @@ func CacheOptions() (cache.Options, client.Options) {
 					},
 				},
 			},
+			// Only the checksum ConfigMap is watched; every other ConfigMap is read through APIReader.
+			&corev1.ConfigMap{}: {
+				Namespaces: map[string]cache.Config{
+					MachineNamespace: {
+						FieldSelector: fields.SelectorFromSet(fields.Set{
+							"metadata.name": InstanceClassChecksumConfigMapName,
+						}),
+					},
+				},
+			},
 			&mcmv1alpha1.Machine{}: machineNS,
 			&capiv1beta2.Machine{}: machineNS,
 			newUnstructured("machine.sapcloud.io", "v1alpha1", "MachineDeployment"):                 machineNS,

--- a/modules/040-node-manager/images/node-controller/src/internal/common/constants.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/common/constants.go
@@ -19,4 +19,8 @@ package common
 const (
 	MachineNamespace                 = "d8-cloud-instance-manager"
 	ConfigurationChecksumsSecretName = "configuration-checksums"
+	// InstanceClassChecksumConfigMapName is rendered by helm with the current instance-class
+	// checksum of every CAPI NodeGroup. It is the only source of the checksum: the infrastructure
+	// templates are kept forever, so their annotations also carry every stale value.
+	InstanceClassChecksumConfigMapName = "d8-node-manager-capi-instance-class-checksum"
 )

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/capi/common.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/capi/common.go
@@ -37,6 +37,10 @@ const (
 	// MachineDeployments can advertise CPU/memory to the autoscaler. It carries every NodeGroup that
 	// can hold a machine, not only the scale-from-zero ones.
 	nodeCapacityConfigMapName = "d8-node-manager-capi-node-capacity"
+	// instanceClassChecksumConfigMapName is rendered by helm with the current instance-class
+	// checksum of every CAPI NodeGroup. It is the only source of the checksum: the infrastructure
+	// templates are kept forever, so their annotations also carry every stale value.
+	instanceClassChecksumConfigMapName = "d8-node-manager-capi-instance-class-checksum"
 )
 
 type BaseWithReader struct {

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/capi/common.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/capi/common.go
@@ -37,10 +37,6 @@ const (
 	// MachineDeployments can advertise CPU/memory to the autoscaler. It carries every NodeGroup that
 	// can hold a machine, not only the scale-from-zero ones.
 	nodeCapacityConfigMapName = "d8-node-manager-capi-node-capacity"
-	// instanceClassChecksumConfigMapName is rendered by helm with the current instance-class
-	// checksum of every CAPI NodeGroup. It is the only source of the checksum: the infrastructure
-	// templates are kept forever, so their annotations also carry every stale value.
-	instanceClassChecksumConfigMapName = "d8-node-manager-capi-instance-class-checksum"
 )
 
 type BaseWithReader struct {

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/capi/envtest_checksum_configmap_test.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/capi/envtest_checksum_configmap_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package capi
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	deckhousev1 "github.com/deckhouse/node-controller/api/deckhouse.io/v1"
+	"github.com/deckhouse/node-controller/internal/common"
+	"github.com/deckhouse/node-controller/internal/testenv"
+)
+
+var _ = Describe("instance-class checksum ConfigMap watch", func() {
+	var (
+		ngName string
+		ng     *deckhousev1.NodeGroup
+		cm     *corev1.ConfigMap
+	)
+
+	templateNameFor := func(checksum string) string {
+		return ngName + "-" + sha256Hash(envtestClusterUUID+envtestZone+checksum)
+	}
+
+	mdTemplateName := func() string {
+		md := &unstructured.Unstructured{}
+		md.SetGroupVersionKind(schema.GroupVersionKind{Group: "cluster.x-k8s.io", Version: "v1beta2", Kind: "MachineDeployment"})
+		mdName := ngName + "-" + sha256Hash(envtestClusterUUID+envtestZone)
+		if err := k8sClient.Get(suiteCtx, types.NamespacedName{Name: mdName, Namespace: common.MachineNamespace}, md); err != nil {
+			return ""
+		}
+		name, _, _ := unstructured.NestedString(md.Object, "spec", "template", "spec", "infrastructureRef", "name")
+		return name
+	}
+
+	BeforeEach(func() {
+		ngName = testenv.UniqueName("cm-watch")
+
+		// The ConfigMap exists before the NodeGroup so the very first reconcile already has a checksum.
+		cm = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: common.InstanceClassChecksumConfigMapName, Namespace: common.MachineNamespace},
+			Data:       map[string]string{ngName: "one"},
+		}
+		Expect(k8sClient.Create(suiteCtx, cm)).To(Succeed())
+
+		ng = &deckhousev1.NodeGroup{
+			ObjectMeta: metav1.ObjectMeta{Name: ngName},
+			Spec: deckhousev1.NodeGroupSpec{
+				NodeType: deckhousev1.NodeTypeCloudEphemeral,
+				CloudInstances: &deckhousev1.CloudInstancesSpec{
+					Zones:          []string{envtestZone},
+					MinPerZone:     1,
+					MaxPerZone:     1,
+					ClassReference: deckhousev1.ClassReference{Kind: "DVPInstanceClass", Name: "ubuntu"},
+				},
+			},
+		}
+		Expect(k8sClient.Create(suiteCtx, ng)).To(Succeed())
+		// A merge patch: the reconciler adds its finalizer concurrently, an Update would conflict.
+		base := ng.DeepCopy()
+		ng.Status.Engine = engineCAPI
+		Expect(k8sClient.Status().Patch(suiteCtx, ng, client.MergeFrom(base))).To(Succeed())
+
+		Eventually(mdTemplateName, 20*time.Second, 200*time.Millisecond).Should(Equal(templateNameFor("one")))
+	})
+
+	AfterEach(func() {
+		testenv.RemoveFinalizers(suiteCtx, k8sClient, ng)
+		Expect(client.IgnoreNotFound(k8sClient.Delete(suiteCtx, ng))).To(Succeed())
+		Expect(client.IgnoreNotFound(k8sClient.Delete(suiteCtx, cm))).To(Succeed())
+	})
+
+	It("moves the MachineDeployment to the new template when only the ConfigMap changes", func() {
+		Expect(k8sClient.Get(suiteCtx, client.ObjectKeyFromObject(cm), cm)).To(Succeed())
+		cm.Data[ngName] = "two"
+		Expect(k8sClient.Update(suiteCtx, cm)).To(Succeed())
+
+		// No NodeGroup event happens here: only the ConfigMap watch can wake the reconciler.
+		Eventually(mdTemplateName, 20*time.Second, 200*time.Millisecond).Should(Equal(templateNameFor("two")))
+	})
+})

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/capi/machinedeployment.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/capi/machinedeployment.go
@@ -231,7 +231,8 @@ func (r *MachineDeploymentReconciler) reconcileCloudMDs(ctx context.Context, ng 
 		return err
 	}
 	if instanceClassChecksum == "" {
-		logger.V(1).Info("skipping: instance-class checksum not published yet, waiting for helm")
+		logger.Info("skipping: instance-class checksum not published yet, waiting for helm",
+			"configMap", instanceClassChecksumConfigMapName)
 		return nil
 	}
 
@@ -585,7 +586,8 @@ func (r *MachineDeploymentReconciler) readInstanceClassChecksum(ctx context.Cont
 		}
 		return "", fmt.Errorf("get configmap %s: %w", instanceClassChecksumConfigMapName, err)
 	}
-	return strings.TrimSpace(cm.Data[ngName]), nil
+	// Returned as published: helm hashed this exact string into the template and Secret names.
+	return cm.Data[ngName], nil
 }
 
 func applyMachineDeploymentSpecPatch(spec map[string]interface{}, rawPatch string, vars map[string]string) error {

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/capi/machinedeployment.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/capi/machinedeployment.go
@@ -226,12 +226,12 @@ func (r *MachineDeploymentReconciler) reconcileCloudMDs(ctx context.Context, ng 
 		return nil
 	}
 
-	instanceClassChecksum, err := r.readInstanceClassChecksum(ctx, cloudConfig, ng.Name)
+	instanceClassChecksum, err := r.readInstanceClassChecksum(ctx, ng.Name)
 	if err != nil {
 		return err
 	}
 	if instanceClassChecksum == "" {
-		logger.V(1).Info("skipping: infrastructure template not found yet, waiting for helm")
+		logger.V(1).Info("skipping: instance-class checksum not published yet, waiting for helm")
 		return nil
 	}
 
@@ -571,33 +571,21 @@ func (r *MachineDeploymentReconciler) readInstancePrefix(ctx context.Context) (s
 	return cfg.Cloud.Prefix, nil
 }
 
-func (r *MachineDeploymentReconciler) readInstanceClassChecksum(ctx context.Context, cloudConfig *cloudProviderConfig, ngName string) (string, error) {
-	gv, err := schema.ParseGroupVersion(cloudConfig.capiMachineTemplateAPIVersion)
-	if err != nil {
-		return "", fmt.Errorf("parse capiMachineTemplateAPIVersion %q: %w", cloudConfig.capiMachineTemplateAPIVersion, err)
-	}
-
-	templateList := &unstructured.UnstructuredList{}
-	templateList.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   gv.Group,
-		Version: gv.Version,
-		Kind:    cloudConfig.capiMachineTemplateKind + "List",
-	})
-
-	if err := r.APIReader.List(ctx, templateList,
-		client.InNamespace(common.MachineNamespace),
-		client.MatchingLabels{"node-group": ngName},
-	); err != nil {
-		return "", fmt.Errorf("list infrastructure templates for %s: %w", ngName, err)
-	}
-
-	for i := range templateList.Items {
-		annotations := templateList.Items[i].GetAnnotations()
-		if v, ok := annotations["checksum/instance-class"]; ok && v != "" {
-			return v, nil
+// readInstanceClassChecksum returns the instance-class checksum helm computed for the NodeGroup
+// on its last render. Helm publishes it through a ConfigMap it owns outright, so the value follows
+// the InstanceClass in both directions; the infrastructure templates cannot serve as the source
+// because helm keeps every one of them and their annotations carry the stale checksums too.
+func (r *MachineDeploymentReconciler) readInstanceClassChecksum(ctx context.Context, ngName string) (string, error) {
+	cm := &corev1.ConfigMap{}
+	if err := r.APIReader.Get(ctx, types.NamespacedName{
+		Name: instanceClassChecksumConfigMapName, Namespace: common.MachineNamespace,
+	}, cm); err != nil {
+		if errors.IsNotFound(err) {
+			return "", nil
 		}
+		return "", fmt.Errorf("get configmap %s: %w", instanceClassChecksumConfigMapName, err)
 	}
-	return "", nil
+	return strings.TrimSpace(cm.Data[ngName]), nil
 }
 
 func applyMachineDeploymentSpecPatch(spec map[string]interface{}, rawPatch string, vars map[string]string) error {

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/capi/machinedeployment.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/capi/machinedeployment.go
@@ -633,7 +633,7 @@ type nodeCapacityValues struct {
 // that can hold a machine, not only for the scale-from-zero ones: the autoscaler needs a template
 // NodeInfo for every group it discovers, and a discovered group with neither a registered Node nor
 // a template makes ResourcesLeft fail cluster-wide with "No node info for: <group>".
-func (r *MachineDeploymentReconciler) readNodeCapacity(ctx context.Context, ngName string) (cpu, memory string) {
+func (r *MachineDeploymentReconciler) readNodeCapacity(ctx context.Context, ngName string) (string, string) {
 	cm := &corev1.ConfigMap{}
 	if err := r.APIReader.Get(ctx, types.NamespacedName{
 		Name: nodeCapacityConfigMapName, Namespace: common.MachineNamespace,

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/capi/machinedeployment.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/capi/machinedeployment.go
@@ -74,6 +74,25 @@ func (r *MachineDeploymentReconciler) SetupWatches(w register.Watcher) {
 		builder.WithPredicates(predicate.GenerationChangedPredicate{}))
 	w.Watches(&capiv1beta2.MachineDeployment{}, handler.EnqueueRequestsFromMapFunc(mdToNodeGroup),
 		builder.WithPredicates(predicate.GenerationChangedPredicate{}))
+	w.Watches(&corev1.ConfigMap{}, handler.EnqueueRequestsFromMapFunc(checksumConfigMapToNodeGroups))
+}
+
+// checksumConfigMapToNodeGroups enqueues every NodeGroup named in the checksum ConfigMap helm just
+// rewrote, so an InstanceClass change reaches the MachineDeployment without waiting for an
+// unrelated NodeGroup event. The cache holds only this ConfigMap (see common.CacheOptions).
+func checksumConfigMapToNodeGroups(_ context.Context, obj client.Object) []reconcile.Request {
+	if obj.GetNamespace() != common.MachineNamespace || obj.GetName() != common.InstanceClassChecksumConfigMapName {
+		return nil
+	}
+	cm, ok := obj.(*corev1.ConfigMap)
+	if !ok {
+		return nil
+	}
+	requests := make([]reconcile.Request, 0, len(cm.Data))
+	for ngName := range cm.Data {
+		requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: ngName}})
+	}
+	return requests
 }
 
 func mdToNodeGroup(_ context.Context, obj client.Object) []reconcile.Request {
@@ -232,7 +251,7 @@ func (r *MachineDeploymentReconciler) reconcileCloudMDs(ctx context.Context, ng 
 	}
 	if instanceClassChecksum == "" {
 		logger.Info("skipping: instance-class checksum not published yet, waiting for helm",
-			"configMap", instanceClassChecksumConfigMapName)
+			"configMap", common.InstanceClassChecksumConfigMapName)
 		return nil
 	}
 
@@ -579,12 +598,12 @@ func (r *MachineDeploymentReconciler) readInstancePrefix(ctx context.Context) (s
 func (r *MachineDeploymentReconciler) readInstanceClassChecksum(ctx context.Context, ngName string) (string, error) {
 	cm := &corev1.ConfigMap{}
 	if err := r.APIReader.Get(ctx, types.NamespacedName{
-		Name: instanceClassChecksumConfigMapName, Namespace: common.MachineNamespace,
+		Name: common.InstanceClassChecksumConfigMapName, Namespace: common.MachineNamespace,
 	}, cm); err != nil {
 		if errors.IsNotFound(err) {
 			return "", nil
 		}
-		return "", fmt.Errorf("get configmap %s: %w", instanceClassChecksumConfigMapName, err)
+		return "", fmt.Errorf("get configmap %s: %w", common.InstanceClassChecksumConfigMapName, err)
 	}
 	// Returned as published: helm hashed this exact string into the template and Secret names.
 	return cm.Data[ngName], nil

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/capi/machinedeployment_test.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/capi/machinedeployment_test.go
@@ -282,7 +282,7 @@ func TestReadInstanceClassChecksumIgnoresStaleTemplates(t *testing.T) {
 		return tmpl
 	}
 	checksums := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{Name: instanceClassChecksumConfigMapName, Namespace: common.MachineNamespace},
+		ObjectMeta: metav1.ObjectMeta{Name: common.InstanceClassChecksumConfigMapName, Namespace: common.MachineNamespace},
 		Data:       map[string]string{"worker": "current"},
 	}
 	cl := fakeclient.NewClientBuilder().WithScheme(scheme).

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/capi/machinedeployment_test.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/capi/machinedeployment_test.go
@@ -17,13 +17,20 @@ limitations under the License.
 package capi
 
 import (
+	"context"
 	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	deckhousev1 "github.com/deckhouse/node-controller/api/deckhouse.io/v1"
+	"github.com/deckhouse/node-controller/internal/common"
 )
 
 func ptr[T any](v T) *T { return &v }
@@ -250,5 +257,44 @@ func TestApplyMachineDeploymentSpecPatchInvalidYAML(t *testing.T) {
 	err := applyMachineDeploymentSpecPatch(spec, "template: [", nil)
 	if err == nil {
 		t.Fatal("expected invalid patch error, got nil")
+	}
+}
+
+// The current checksum comes from the ConfigMap helm renders; the annotations of the
+// infrastructure templates are not consulted, because helm keeps every template a NodeGroup ever
+// had and a stale one is as likely to be listed first as the current one.
+func TestReadInstanceClassChecksumIgnoresStaleTemplates(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1 scheme: %v", err)
+	}
+	templateGVK := schema.GroupVersionKind{Group: "infrastructure.cluster.x-k8s.io", Version: "v1alpha1", Kind: "DeckhouseMachineTemplate"}
+	scheme.AddKnownTypeWithName(templateGVK, &unstructured.Unstructured{})
+	scheme.AddKnownTypeWithName(templateGVK.GroupVersion().WithKind("DeckhouseMachineTemplateList"), &unstructured.UnstructuredList{})
+
+	staleTemplate := func(name string) *unstructured.Unstructured {
+		tmpl := &unstructured.Unstructured{}
+		tmpl.SetGroupVersionKind(templateGVK)
+		tmpl.SetNamespace(common.MachineNamespace)
+		tmpl.SetName(name)
+		tmpl.SetLabels(map[string]string{"node-group": "worker"})
+		tmpl.SetAnnotations(map[string]string{"checksum/instance-class": "stale"})
+		return tmpl
+	}
+	checksums := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: instanceClassChecksumConfigMapName, Namespace: common.MachineNamespace},
+		Data:       map[string]string{"worker": "current"},
+	}
+	cl := fakeclient.NewClientBuilder().WithScheme(scheme).
+		WithRuntimeObjects(checksums, staleTemplate("worker-aaaaaaaa"), staleTemplate("worker-bbbbbbbb")).
+		Build()
+	r := &MachineDeploymentReconciler{BaseWithReader: BaseWithReader{APIReader: cl}}
+
+	got, err := r.readInstanceClassChecksum(context.Background(), "worker")
+	if err != nil {
+		t.Fatalf("readInstanceClassChecksum: %v", err)
+	}
+	if got != "current" {
+		t.Fatalf("checksum = %q, want %q from the ConfigMap", got, "current")
 	}
 }

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/capi/suite_test.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/capi/suite_test.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package capi
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	capiv1beta2 "github.com/deckhouse/node-controller/api/cluster.x-k8s.io/v1beta2"
+	deckhousev1 "github.com/deckhouse/node-controller/api/deckhouse.io/v1"
+	"github.com/deckhouse/node-controller/internal/common"
+	"github.com/deckhouse/node-controller/internal/register"
+	"github.com/deckhouse/node-controller/internal/testenv"
+)
+
+const (
+	envtestClusterUUID = "f49dd1c3-a63a-4565-a06c-625e35587eab"
+	envtestZone        = "zone-a"
+)
+
+var (
+	testEnv   *envtest.Environment
+	cfg       *rest.Config
+	k8sClient client.Client
+	scheme    *k8sruntime.Scheme
+
+	suiteCtx    context.Context
+	suiteCancel context.CancelFunc
+)
+
+// TestCAPIMachineDeploymentControllerEnvtest runs the MachineDeployment reconciler inside a
+// manager against a real apiserver with the production cache scoping for core types, so the
+// ConfigMap watch is exercised end to end. The other capi controllers are disabled: their
+// CRDs (Cluster, MachineHealthCheck, DeckhouseControlPlane) are not part of this suite.
+func TestCAPIMachineDeploymentControllerEnvtest(t *testing.T) {
+	if !testenv.AssetsAvailable() {
+		t.Skip("envtest assets not found; run `make envtest` (or set KUBEBUILDER_ASSETS) to run the integration suite")
+	}
+
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CAPI MachineDeployment Controller Envtest Suite")
+}
+
+var _ = BeforeSuite(func() {
+	testenv.SetupLogger(GinkgoWriter)
+	suiteCtx, suiteCancel = context.WithCancel(context.Background())
+
+	scheme = k8sruntime.NewScheme()
+	Expect(clientgoscheme.AddToScheme(scheme)).To(Succeed())
+	Expect(deckhousev1.AddToScheme(scheme)).To(Succeed())
+	Expect(capiv1beta2.AddToScheme(scheme)).To(Succeed())
+
+	By("bootstrapping the envtest environment with the NodeGroup, MCM and MachineDeployment CRDs")
+	var err error
+	testEnv, cfg, k8sClient, err = testenv.Start(
+		scheme,
+		testenv.CRDPaths(
+			testenv.WithNodeGroupCRDFile(),
+			testenv.WithMCMCRDFile(),
+			testenv.WithMachineDeploymentCRDFile(),
+		)...,
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	By("creating the machine namespace and the cluster-wide inputs the reconciler reads")
+	ns := &corev1.Namespace{}
+	ns.Name = common.MachineNamespace
+	Expect(client.IgnoreAlreadyExists(k8sClient.Create(suiteCtx, ns))).To(Succeed())
+
+	Expect(k8sClient.Create(suiteCtx, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: clusterUUIDConfigMapName, Namespace: clusterUUIDConfigMapNS},
+		Data:       map[string]string{"cluster-uuid": envtestClusterUUID},
+	})).To(Succeed())
+	Expect(k8sClient.Create(suiteCtx, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: cloudProviderSecretName, Namespace: cloudProviderSecretNamespace},
+		StringData: map[string]string{
+			"capiClusterName":         "envtest",
+			"capiMachineTemplateKind": "DeckhouseMachineTemplate",
+			// envtest has no CAPI defaulting webhook, which fills spec.selector in a real cluster.
+			"capiMachineDeploymentSpecPatch": "selector:\n  matchLabels:\n    node-group: ${nodeGroupName}\n",
+		},
+	})).To(Succeed())
+
+	By("starting the manager with only the capi-machine-deployment controller")
+	cacheOpts, clientOpts := common.CacheOptions()
+	cacheOpts.ByObject = coreTypesOnly(cacheOpts)
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:         scheme,
+		Cache:          cacheOpts,
+		Client:         clientOpts,
+		Metrics:        metricsserver.Options{BindAddress: "0"},
+		LeaderElection: false,
+	})
+	Expect(err).NotTo(HaveOccurred())
+	disabled := "capi-api-version,capi-cluster-resources,capi-control-plane,capi-finalizer-cleanup,capi-md-metrics"
+	Expect(register.SetupAll(mgr, mgr.GetClient(), disabled, 1, nil)).To(Succeed())
+
+	go func() {
+		defer GinkgoRecover()
+		Expect(mgr.Start(suiteCtx)).To(Succeed())
+	}()
+})
+
+// coreTypesOnly keeps the production ByObject scoping for Secrets and ConfigMaps and drops the
+// CRD-backed entries: the manager refuses to start when a scoped type has no CRD installed.
+func coreTypesOnly(opts cache.Options) map[client.Object]cache.ByObject {
+	kept := make(map[client.Object]cache.ByObject)
+	for obj, byObject := range opts.ByObject {
+		switch obj.(type) {
+		case *corev1.Secret, *corev1.ConfigMap:
+			kept[obj] = byObject
+		}
+	}
+	return kept
+}
+
+var _ = AfterSuite(func() {
+	By("tearing down the envtest environment")
+	if suiteCancel != nil {
+		suiteCancel()
+	}
+	if testEnv != nil {
+		Expect(testEnv.Stop()).To(Succeed())
+	}
+})

--- a/modules/040-node-manager/template_tests/module_test.go
+++ b/modules/040-node-manager/template_tests/module_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package template_tests
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"sort"
@@ -1250,11 +1252,17 @@ ccc: ddd
 				Expect(f.RenderError).ShouldNot(HaveOccurred())
 
 				checksums := f.KubernetesResource("ConfigMap", "d8-cloud-instance-manager", "d8-node-manager-capi-instance-class-checksum")
-				openStackTemplate := f.KubernetesResource("OpenStackMachineTemplate", "d8-cloud-instance-manager", "worker-d03da7ca")
 				Expect(checksums.Exists()).To(BeTrue())
-				Expect(openStackTemplate.Exists()).To(BeTrue())
-				Expect(checksums.Field("data.worker").String()).ToNot(BeEmpty())
-				Expect(checksums.Field("data.worker").String()).To(Equal(openStackTemplate.Field("metadata.annotations.checksum/instance-class").String()))
+				checksum := checksums.Field("data.worker").String()
+				Expect(checksum).ToNot(BeEmpty())
+
+				// node-controller names the template sha256(clusterUUID+zone+checksum)[:8] from this
+				// value (capi/machinedeployment.go); a byte of difference from what node-group.yaml
+				// hashed would point the MachineDeployment at a template that does not exist.
+				sum := sha256.Sum256([]byte("f49dd1c3-a63a-4565-a06c-625e35587eab" + "zonea" + checksum))
+				templateName := "worker-" + hex.EncodeToString(sum[:])[:8]
+				Expect(templateName).To(Equal("worker-d03da7ca"))
+				Expect(f.KubernetesResource("OpenStackMachineTemplate", "d8-cloud-instance-manager", templateName).Exists()).To(BeTrue())
 			})
 
 			It("must render allowed address pairs for internal OpenStack networks", func() {

--- a/modules/040-node-manager/template_tests/module_test.go
+++ b/modules/040-node-manager/template_tests/module_test.go
@@ -1246,6 +1246,17 @@ ccc: ddd
 				Expect(machineDeployment.Exists()).To(BeFalse())
 			})
 
+			It("publishes the instance-class checksum node-controller names the template by", func() {
+				Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+				checksums := f.KubernetesResource("ConfigMap", "d8-cloud-instance-manager", "d8-node-manager-capi-instance-class-checksum")
+				openStackTemplate := f.KubernetesResource("OpenStackMachineTemplate", "d8-cloud-instance-manager", "worker-d03da7ca")
+				Expect(checksums.Exists()).To(BeTrue())
+				Expect(openStackTemplate.Exists()).To(BeTrue())
+				Expect(checksums.Field("data.worker").String()).ToNot(BeEmpty())
+				Expect(checksums.Field("data.worker").String()).To(Equal(openStackTemplate.Field("metadata.annotations.checksum/instance-class").String()))
+			})
+
 			It("must render allowed address pairs for internal OpenStack networks", func() {
 				Expect(f.RenderError).ShouldNot(HaveOccurred())
 

--- a/modules/040-node-manager/templates/node-controller/capi-instance-class-checksum.yaml
+++ b/modules/040-node-manager/templates/node-controller/capi-instance-class-checksum.yaml
@@ -4,7 +4,8 @@
   Helm names the CAPI infrastructure template and the bootstrap Secret after this checksum and
   keeps every one it ever rendered (helm.sh/resource-policy: keep), so node-controller cannot
   tell the current template from the stale ones by looking at them. This ConfigMap is not kept
-  and always carries the checksum of the last render.
+  and always carries the checksum of the last render, byte for byte as node-group.yaml hashed it
+  into the template and Secret names.
 */ -}}
 apiVersion: v1
 kind: ConfigMap
@@ -18,7 +19,7 @@ data:
     {{- if .Values.nodeManager.internal.cloudProvider.capiClusterKind }}
       {{- range $ng := .Values.nodeManager.internal.nodeGroups | default list }}
         {{- if and (or (eq $ng.nodeType "CloudEphemeral") (eq $ng.nodeType "Cloud")) (ne ($ng.engine | default "") "MCM") }}
-          {{- $checksum := include "capi_node_group_instance_class_checksum" (list $ $ng) | trim }}
+          {{- $checksum := include "capi_node_group_instance_class_checksum" (list $ $ng) }}
           {{- if $checksum }}
             {{- $published = true }}
   {{ $ng.name }}: {{ $checksum | quote }}

--- a/modules/040-node-manager/templates/node-controller/capi-instance-class-checksum.yaml
+++ b/modules/040-node-manager/templates/node-controller/capi-instance-class-checksum.yaml
@@ -1,0 +1,32 @@
+{{- /*
+  Bridge the instance-class checksum helm computes into node-controller.
+
+  Helm names the CAPI infrastructure template and the bootstrap Secret after this checksum and
+  keeps every one it ever rendered (helm.sh/resource-policy: keep), so node-controller cannot
+  tell the current template from the stale ones by looking at them. This ConfigMap is not kept
+  and always carries the checksum of the last render.
+*/ -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: d8-node-manager-capi-instance-class-checksum
+  namespace: d8-cloud-instance-manager
+  {{- include "helm_lib_module_labels" (list . (dict "app" "node-controller")) | nindent 2 }}
+data:
+  {{- $published := false }}
+  {{- if hasKey .Values.nodeManager.internal "cloudProvider" }}
+    {{- if .Values.nodeManager.internal.cloudProvider.capiClusterKind }}
+      {{- range $ng := .Values.nodeManager.internal.nodeGroups | default list }}
+        {{- if and (or (eq $ng.nodeType "CloudEphemeral") (eq $ng.nodeType "Cloud")) (ne ($ng.engine | default "") "MCM") }}
+          {{- $checksum := include "capi_node_group_instance_class_checksum" (list $ $ng) | trim }}
+          {{- if $checksum }}
+            {{- $published = true }}
+  {{ $ng.name }}: {{ $checksum | quote }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+  {{- if not $published }}
+  _placeholder: ""
+  {{- end }}


### PR DESCRIPTION
## Description

node-controller now reads the instance-class checksum of a CAPI NodeGroup from a ConfigMap rendered by helm (`d8-node-manager-capi-instance-class-checksum`). Before, it took the checksum from the first infrastructure MachineTemplate it found for the group.

Helm keeps every MachineTemplate and bootstrap Secret it ever rendered. After an InstanceClass change the group has two or more templates, and the first one in the list is often the old one. node-controller then pointed the MachineDeployment at the old template and the old bootstrap Secret. New machines got the old InstanceClass, and the Secret was no longer refreshed by helm, so its token expired after 4 hours and new machines could not join the cluster.

The ConfigMap is rewritten on every release and always holds the current checksum. node-controller hashes exactly the string helm hashed into the object names, so groups that already point at the current template are not touched.

node-controller also watches this ConfigMap and reconciles the NodeGroups named in it, so an InstanceClass change reaches the MachineDeployment right after helm writes the new checksum. The cache holds only this one ConfigMap; every other ConfigMap is still read through the API reader.

## Why do we need it, and what problem does it solve?

1.77 only. #20682 moved the MachineDeployment render into node-controller but left the checksum in helm. `main` fixed this in #21372, which is not in 1.77. 1.76 is not affected.

Affected: CAPI NodeGroups (dvp, vcd, zvirt, dynamix, huaweicloud, openstack) whose InstanceClass changed at least once. After this patch such a group moves to its current template and Secret, which replaces its machines within `maxSurgePerZone`/`maxUnavailablePerZone`.

The bootstrap Secret name is still derived from the checksum, so changing a field from the provider's `instance-class.checksum` still replaces the group's machines. Same as 1.76.

## Why do we need it in the patch release (if we do)?

The bug exists only in 1.77. Affected groups run the wrong InstanceClass and cannot scale up.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

The template test fails on the old code (no ConfigMap is rendered there): it derives the template name from the published checksum with node-controller's formula and checks that helm rendered that template. `TestReadInstanceClassChecksumIgnoresStaleTemplates` covers the new reader against a fake client.

The new envtest suite for the capi package (`TestCAPIMachineDeploymentControllerEnvtest`) runs the MachineDeployment reconciler with the production cache scoping and checks that changing only the ConfigMap moves the MachineDeployment to the new template. Without the watch it times out.

## Manual test (DVP, 3 kept templates for one NodeGroup)

Reproduced on plain `release-1.77`: changing the DVPInstanceClass made helm render `ubuntu-abf80b23`, but node-controller kept the MachineDeployment on `ubuntu-359ae2a3` (first template by name), even after a full node-controller restart. Helm kept refreshing the `abf80b23` bootstrap secret while the `359ae2a3` one stayed frozen. That is the broken state from the incident.

Switched the same cluster to this PR: the ConfigMap appeared with the `abf80b23` checksum, the MachineDeployment moved to `ubuntu-abf80b23`, three new machines joined with the refreshed secret, the old ones were drained.

Upgrade path was checked too: v1.76.0 to this PR with a stale template sorted first. The MachineDeployment kept its template and secret, MachineSet UIDs did not change, no machine was recreated.

## Changelog entries

```changes
section: node-manager
type: fix
summary: node-controller reads the CAPI instance-class checksum from a helm-rendered ConfigMap instead of a possibly stale MachineTemplate, so MachineDeployments follow InstanceClass changes and their bootstrap Secrets keep a valid token.
impact: CAPI NodeGroups whose MachineDeployment was stuck on an old MachineTemplate are rolled to the current InstanceClass after the update, within maxSurgePerZone/maxUnavailablePerZone. Groups already on the current template are not touched.
impact_level: high
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X3puQJbrQunnjvJR3iGEuW
