### PR TITLE
fix(operator-trivy): CVE-2025-15558 VEX and trivy patch pin

### DIFF
--- a/ee/modules/500-operator-trivy/images/operator/known_vulnerabilities.vex
+++ b/ee/modules/500-operator-trivy/images/operator/known_vulnerabilities.vex
@@ -64,6 +64,15 @@
         },
         {
           "@id": "pkg:golang/github.com/docker/cli@v27.2.1+incompatible"
+        },
+        {
+          "@id": "pkg:golang/github.com/docker/cli@v29.0.3+incompatible"
+        },
+        {
+          "@id": "pkg:golang/github.com/docker/cli@v29.0.3%2Bincompatible"
+        },
+        {
+          "@id": "pkg:golang/github.com/docker/cli"
         }
       ],
       "status": "not_affected",

--- a/ee/modules/500-operator-trivy/images/trivy/known_vulnerabilities.vex
+++ b/ee/modules/500-operator-trivy/images/trivy/known_vulnerabilities.vex
@@ -64,6 +64,15 @@
         },
         {
           "@id": "pkg:golang/github.com/docker/cli@v27.1.1+incompatible"
+        },
+        {
+          "@id": "pkg:golang/github.com/docker/cli@v29.0.3+incompatible"
+        },
+        {
+          "@id": "pkg:golang/github.com/docker/cli@v29.0.3%2Bincompatible"
+        },
+        {
+          "@id": "pkg:golang/github.com/docker/cli"
         }
       ],
       "status": "not_affected",

--- a/ee/modules/500-operator-trivy/images/trivy/werf.inc.yaml
+++ b/ee/modules/500-operator-trivy/images/trivy/werf.inc.yaml
@@ -35,7 +35,7 @@ shell:
   - git clone $(cat /run/secrets/SOURCE_REPO)/aquasecurity/trivy.git /src/trivy
   - cd /src/trivy && git checkout {{ $trivyCommitSHA }}
   - git clone git@$(cat /run/secrets/DECKHOUSE_PRIVATE_REPO):deckhouse/trivy.git /src/trivy-patch
-  - cd /src/trivy-patch && git checkout 50eb1d127131f10aa65e85c2db0166a1a1844321 # last commit from branch main. Werf trigger for rebuild
+  - cd /src/trivy-patch && git checkout 8a9fabf7d5ca027a9d568182cafec2f37442dec7 # last commit from branch main. Werf trigger for rebuild
   - cd /src/trivy-db && git apply --verbose --whitespace=fix /src/trivy-db-patch/patches/{{ $trivyVersion }}/*.patch
   - cd /src/trivy && git apply --verbose --whitespace=fix /src/trivy-patch/patches/{{ $trivyVersion }}/*.patch
   - rm -rf /src/trivy/docs /src/trivy/integration


### PR DESCRIPTION
## Description

Fix CVE findings for `operator-trivy` on `release-1.73`:

- Extend OpenVEX for **CVE-2025-15558** 

## Why do we need it, and what problem does it solve?

## Why do we need it in the patch release (if we do)?

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: operator-trivy
type: fix
summary: Suppress CVE-2025-15558 for docker/cli on operator/trivy and update trivy patch pin.
impact_level: low
```