### PR TITLE
[docs] Add application deployment options to the getting started page

### DIFF
--- a/docs/site/_includes/getting_started/global/partials/FINISH_CARDS.md
+++ b/docs/site/_includes/getting_started/global/partials/FINISH_CARDS.md
@@ -76,39 +76,101 @@ Use our [checklist](/products/kubernetes-platform/guides/production.html) to mak
 <h2 class="cards-blocks__title text_h2">
 Deploying your first application
 </h2>
+<p class="cards-blocks__lead">Your cluster is up and still empty. Below are the ways to get an application into it — from a single command to a full GitOps pipeline. If you just want to see something running, start with the first one.</p>
 <div class="cards-blocks__cards">
 
 <div class="cards-item cards-item_inverse">
 <h3 class="cards-item__title text_h3">
-⟳ <span class="cards-item__title-text">Setting up a CI/CD system</span>
+⌨ <span class="cards-item__title-text">Start here: plain manifests</span>
 </h3>
 <div class="cards-item__text" markdown="1">
-[Create](/modules/user-authz/usage.html#creating-a-serviceaccount-for-a-machine-and-granting-it-access)
-a ServiceAccount to use for deploying to the cluster and grant it all the necessary privileges.
+No extra tooling to install — everything you need is already in `d8`. The `d8 k` command is a built-in `kubectl`: apply your application manifests, and a minute later it is running in the cluster.
 
-You can use the generated `kubeconfig` file in Kubernetes with any deployment system.
+<!-- TODO: link -->
+[Deploy your first application](#TODO)
 </div>
 </div>
 
 <div class="cards-item cards-item_inverse">
 <h3 class="cards-item__title text_h3">
-🔀 <span class="cards-item__title-text">Routing traffic</span>
+🧩 <span class="cards-item__title-text">An application from the Marketplace</span>
 </h3>
 <div class="cards-item__text" markdown="1">
-Create a `Service` and `Ingress` for your application.
+Pick a ready-made application from the catalog and install it into your namespace — no hunting for charts and figuring out their values. Your cluster administrator fills the catalog; the Marketplace is available from DKP 1.76.
 
-[Learn more](/modules/ingress-nginx/) about the capabilities of the `ingress-nginx` module.
+<!-- TODO: link -->
+[More about the Marketplace](/products/kubernetes-platform/documentation/latest/admin/configuration/marketplace/)
 </div>
 </div>
 
 <div class="cards-item cards-item_inverse">
 <h3 class="cards-item__title text_h3">
-🔍 <span class="cards-item__title-text">Monitoring your application</span>
+🗄 <span class="cards-item__title-text">Managed services</span>
 </h3>
 <div class="cards-item__text" markdown="1">
-Add `prometheus.deckhouse.io/custom-target: "my-app"` and `prometheus.deckhouse.io/port: "80"` annotations to the Service created.
+Bring up PostgreSQL, Kafka, ClickHouse, RabbitMQ, OpenSearch, or another service with Deckhouse modules — scaling, backups, and upgrades are the platform's job.
 
-For more information, see the `monitoring-custom` module's [documentation](/modules/monitoring-custom/).
+<!-- TODO: link -->
+[More about managed services](/products/kubernetes-platform/features/managed-services/)
+</div>
+</div>
+
+<div class="cards-item cards-item_inverse">
+<h3 class="cards-item__title text_h3">
+🚢 <span class="cards-item__title-text">Building and shipping your own application</span>
+</h3>
+<div class="cards-item__text" markdown="1">
+Build your images, push them to the registry, and deploy the application to the cluster — with one tool, `d8 delivery-kit`, instead of three.
+
+<!-- TODO: link -->
+[More about Delivery Kit](/products/delivery-kit/)
+</div>
+</div>
+
+<div class="cards-item cards-item_inverse">
+<h3 class="cards-item__title text_h3">
+🔁 <span class="cards-item__title-text">GitOps: deploy with Argo CD</span>
+</h3>
+<div class="cards-item__text" markdown="1">
+Keep your application manifests in Git — Argo CD brings the cluster in line with what they describe. Argo CD itself is deployed and maintained by the platform, so you never install it by hand.
+
+<!-- TODO: link -->
+[More about the operator-argo module](/products/kubernetes-platform/documentation/latest/admin/configuration/delivery/argocd/)
+</div>
+</div>
+
+<div class="cards-item cards-item_inverse">
+<h3 class="cards-item__title text_h3">
+⎈ <span class="cards-item__title-text">Helm charts without <code>helm install</code></span>
+</h3>
+<div class="cards-item__text" markdown="1">
+Add a Helm or OCI repository, pick a chart and a version — the platform installs the release and maintains it.
+
+<!-- TODO: link -->
+[More about the operator-helm module](/modules/operator-helm/stable/)
+</div>
+</div>
+
+<div class="cards-item cards-item_inverse">
+<h3 class="cards-item__title text_h3">
+⟳ <span class="cards-item__title-text">Integration with your existing CI/CD system</span>
+</h3>
+<div class="cards-item__text" markdown="1">
+Create a ServiceAccount with deploy permissions for the cluster — you get a `kubeconfig` that suits any delivery system for Kubernetes.
+
+[More about service access to the cluster](/modules/user-authz/usage.html#creating-a-serviceaccount-for-a-machine-and-granting-it-access)
+</div>
+</div>
+
+<div class="cards-item cards-item_inverse">
+<h3 class="cards-item__title text_h3">
+🖥 <span class="cards-item__title-text">Legacy applications in a virtual machine</span>
+</h3>
+<div class="cards-item__text" markdown="1">
+Can't containerize an application? Run it as a virtual machine in this same cluster: the same API, the same permissions, the same practices as for containers.
+
+<!-- TODO: link -->
+[More about Deckhouse Virtualization Platform](/products/virtualization-platform/documentation/)
 </div>
 </div>
 

--- a/docs/site/_includes/getting_started/global/partials/FINISH_CARDS_RU.md
+++ b/docs/site/_includes/getting_started/global/partials/FINISH_CARDS_RU.md
@@ -76,40 +76,101 @@
 <h2 class="cards-blocks__title text_h2">
 Деплой первого приложения
 </h2>
+<p class="cards-blocks__lead">Кластер готов и пока пуст. Ниже — способы выкатить в него приложение: от одной команды в терминале до полноценного GitOps. Если просто хотите убедиться, что всё работает, начните с первого.</p>
 <div class="cards-blocks__cards">
 
 <div class="cards-item cards-item_inverse">
 <h3 class="cards-item__title text_h3">
-⟳ <span class="cards-item__title-text">Настройка CI/CD-системы</span>
+⌨ <span class="cards-item__title-text">Начните здесь: обычные манифесты</span>
 </h3>
 <div class="cards-item__text" markdown="1">
-[Создайте](/modules/user-authz/usage.html#создание-serviceaccount-для-сервера-и-предоставление-ему-доступа) ServiceAccount, который будет осуществлять деплой в кластер, и выделите ему права.
+Устанавливать дополнительные утилиты не нужно — всё необходимое уже есть в `d8`. Команда `d8 k` — это встроенный `kubectl`: примените манифесты приложения, и через минуту оно работает в кластере.
 
-Результатом станет `kubeconfig`, который можно использовать во всех системах деплоя в Kubernetes.
+<!-- TODO: ссылка -->
+[Развернуть первое приложение](#TODO)
 </div>
 </div>
 
 <div class="cards-item cards-item_inverse">
 <h3 class="cards-item__title text_h3">
-🔀 <span class="cards-item__title-text">Направляем трафик на приложение</span>
+🧩 <span class="cards-item__title-text">Приложение из Marketplace</span>
 </h3>
 <div class="cards-item__text" markdown="1">
-Создайте `Service` и `Ingress` для вашего приложения.
+Выберите готовое приложение в каталоге и поставьте в свой namespace — искать чарты и разбираться с их параметрами не придётся. Каталог наполняет администратор кластера, Marketplace доступен с DKP 1.76.
 
-[Подробнее](/modules/ingress-nginx/) о возможностях `ingress-nginx`
-модуля.
+<!-- TODO: ссылка -->
+[Подробнее о Marketplace](/products/kubernetes-platform/documentation/latest/admin/configuration/marketplace/)
 </div>
 </div>
 
 <div class="cards-item cards-item_inverse">
 <h3 class="cards-item__title text_h3">
-🔍 <span class="cards-item__title-text">Мониторинг приложения</span>
+🗄 <span class="cards-item__title-text">Управляемые сервисы</span>
 </h3>
 <div class="cards-item__text" markdown="1">
-Добавьте аннотации `prometheus.deckhouse.io/custom-target: "my-app"` и `prometheus.deckhouse.io/port: "80"` к созданному
-Service'у.
+Поднимите PostgreSQL, Kafka, ClickHouse, RabbitMQ, OpenSearch или другой сервис модулями Deckhouse — масштабирование, резервное копирование и обновления платформа возьмёт на себя.
 
-[Подробнее](/modules/monitoring-custom/) о модуле `monitoring-custom`.
+<!-- TODO: ссылка -->
+[Подробнее об управляемых сервисах](/products/kubernetes-platform/features/managed-services/)
+</div>
+</div>
+
+<div class="cards-item cards-item_inverse">
+<h3 class="cards-item__title text_h3">
+🚢 <span class="cards-item__title-text">Сборка и доставка своего приложения</span>
+</h3>
+<div class="cards-item__text" markdown="1">
+Соберите образы, опубликуйте их в реестр и разверните приложение в кластере — одним инструментом `d8 delivery-kit`, а не тремя.
+
+<!-- TODO: ссылка -->
+[Подробнее о Delivery Kit](/products/delivery-kit/)
+</div>
+</div>
+
+<div class="cards-item cards-item_inverse">
+<h3 class="cards-item__title text_h3">
+🔁 <span class="cards-item__title-text">GitOps: деплой с помощью Argo CD</span>
+</h3>
+<div class="cards-item__text" markdown="1">
+Держите манифесты приложения в Git — Argo CD приведёт кластер к описанному состоянию. Сам Argo CD разворачивает и обслуживает платформа, ставить его руками не нужно.
+
+<!-- TODO: ссылка -->
+[Подробнее о модуле operator-argo](/products/kubernetes-platform/documentation/latest/admin/configuration/delivery/argocd/)
+</div>
+</div>
+
+<div class="cards-item cards-item_inverse">
+<h3 class="cards-item__title text_h3">
+⎈ <span class="cards-item__title-text">Helm-чарты без <code>helm install</code></span>
+</h3>
+<div class="cards-item__text" markdown="1">
+Добавьте Helm- или OCI-репозиторий, выберите чарт и версию — платформа сама поставит релиз и будет обслуживать его.
+
+<!-- TODO: ссылка -->
+[Подробнее о модуле operator-helm](/modules/operator-helm/stable/)
+</div>
+</div>
+
+<div class="cards-item cards-item_inverse">
+<h3 class="cards-item__title text_h3">
+⟳ <span class="cards-item__title-text">Интеграция с существующей CI/CD-системой</span>
+</h3>
+<div class="cards-item__text" markdown="1">
+Создайте ServiceAccount с правами на деплой в кластер — получите `kubeconfig`, который подойдёт любой системе доставки в Kubernetes.
+
+[Подробнее о сервисном доступе в кластер](/modules/user-authz/usage.html#создание-serviceaccount-для-сервера-и-предоставление-ему-доступа)
+</div>
+</div>
+
+<div class="cards-item cards-item_inverse">
+<h3 class="cards-item__title text_h3">
+🖥 <span class="cards-item__title-text">Legacy-приложение в виртуальной машине</span>
+</h3>
+<div class="cards-item__text" markdown="1">
+Приложение нельзя контейнеризовать? Запустите его в виртуальной машине в этом же кластере: тот же API, те же права, те же практики, что и у контейнеров.
+
+<!-- TODO: ссылка -->
+[Подробнее о Deckhouse Virtualization Platform](/products/virtualization-platform/documentation/)
 </div>
 </div>
 

--- a/docs/site/_sass/components/_cards.scss
+++ b/docs/site/_sass/components/_cards.scss
@@ -12,6 +12,17 @@
             margin-bottom: 20px !important;
         }
     }
+
+    &__lead {
+        max-width: 800px;
+        margin: -10px 0 30px;
+        color: variables.$color-text-secondary;
+        line-height: 1.5;
+
+        @include breakpoints.max-w(m) {
+            margin-bottom: 20px;
+        }
+    }
 }
 
 .cards-text {
@@ -94,6 +105,20 @@
 
     &__title-text {
         color: variables.$color-main;
+    }
+
+    &__badge {
+        display: inline-block;
+        vertical-align: middle;
+        margin-left: 8px;
+        padding: 2px 8px;
+        border-radius: 10px;
+        background: variables.$color-smooth;
+        color: variables.$color-text-secondary;
+        font-size: 12px;
+        font-weight: normal;
+        line-height: 18px;
+        white-space: nowrap;
     }
 
     &_smooth {


### PR DESCRIPTION
## Description

The final step of the getting started guide (`gs/<platform>/step6.html` and `gs/installer/<platform>/step7.html`) had a "Deploying your first application" section that did not actually tell users how to deploy anything. It listed three cards: creating a CI/CD ServiceAccount, routing traffic with Ingress, and `monitoring-custom` annotations.

The section now presents eight ways to get an application into the cluster, ordered from ready-made to your own:

| Card | Links to |
|---|---|
| Start here: plain manifests | placeholder, see below |
| An application from the Marketplace | `admin/configuration/marketplace/` |
| Managed services | `features/managed-services/` |
| Building and shipping your own application | `/products/delivery-kit/` |
| GitOps: deploy with Argo CD | `admin/configuration/delivery/argocd/` |
| Helm charts without `helm install` | `/modules/operator-helm/stable/` |
| Integration with your existing CI/CD system | `user-authz/usage.html` (the original card, kept) |
| Legacy applications in a virtual machine | `/products/virtualization-platform/documentation/` |

A lead paragraph above the grid helps the reader choose, and points first-time users at the first card.

Both language versions are updated. One new style rule is added to `_sass/components/_cards.scss` for the lead paragraph (`.cards-blocks__lead`); `.cards-item__badge` is also added there but currently unused.

The partial is shared, so the section renders for every DKP platform (`global`, `existing`, `kind`) in both the regular and the installer flow. DVP and Stronghold have their own partials and are not affected.

## Why do we need it, and what problem does it solve?

A user who has just finished installing the platform asks one question: how do I run something here? The old section answered a different one — how to wire up traffic and monitoring for an application that already exists. Meanwhile the platform offers a whole range of delivery options (Marketplace, managed services, Delivery Kit, `operator-argo`, `operator-helm`, virtualization) that the getting started guide never mentioned, so users had no way to discover them at the moment they were most receptive.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: feature
summary: The getting started guide now shows the ways to deploy an application to the cluster.
impact_level: low
```

## Open items before this leaves draft

- **The first card's link is a placeholder** (`#TODO`). It needs a page describing a plain-manifest deployment; I could not find an existing one.
- **Marketplace card has no examples.** It says "a ready-made application" without naming any, unlike the managed services card which lists five. Real catalog examples would help.
