### PR TITLE
[ci] Fuzz build soft exit

### DIFF
--- a/.github/ci_templates/build_fuzz.yml
+++ b/.github/ci_templates/build_fuzz.yml
@@ -122,8 +122,8 @@ steps:
 
       FUZZ_IMAGES="$(werf config list --env "${WERF_ENV}" | grep -- '-fuzz$' || true)"
       if [[ -z "${FUZZ_IMAGES}" ]]; then
-        echo "No fuzz images found"
-        exit 1
+        echo "No fuzz images found; skipping fuzz build"
+        exit 0
       fi
 
       echo "Building fuzz images:"

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -1249,8 +1249,8 @@ jobs:
 
           FUZZ_IMAGES="$(werf config list --env "${WERF_ENV}" | grep -- '-fuzz$' || true)"
           if [[ -z "${FUZZ_IMAGES}" ]]; then
-            echo "No fuzz images found"
-            exit 1
+            echo "No fuzz images found; skipping fuzz build"
+            exit 0
           fi
 
           echo "Building fuzz images:"

--- a/.github/workflows/build-and-test_main.yml
+++ b/.github/workflows/build-and-test_main.yml
@@ -986,8 +986,8 @@ jobs:
 
           FUZZ_IMAGES="$(werf config list --env "${WERF_ENV}" | grep -- '-fuzz$' || true)"
           if [[ -z "${FUZZ_IMAGES}" ]]; then
-            echo "No fuzz images found"
-            exit 1
+            echo "No fuzz images found; skipping fuzz build"
+            exit 0
           fi
 
           echo "Building fuzz images:"


### PR DESCRIPTION
## Description

Make the fuzz image build finish successfully when the current werf configuration contains no images ending with `-fuzz`.

Instead of failing with exit code 1, the job now logs that no fuzz images were found and exits with code 0. Generated development and main workflows were regenerated.

This change affects CI only and does not restart or modify any cluster components.

## Why do we need it, and what problem does it solve?

The fuzz build job can run for configurations that do not contain fuzz images. Previously, this situation caused the entire job to fail with `No fuzz images found`, although there was nothing to build.

An empty fuzz image list is a valid condition and should result in the build being skipped successfully rather than reported as a CI failure.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist

- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
- [x] Generated GitHub workflows were regenerated.

Unit tests, e2e tests, documentation changes, and manual Kubernetes testing are not applicable to this CI-only change.

## Changelog entries

```changes
section: ci
type: fix
summary: Skip the fuzz image build successfully when no fuzz images are configured.
impact_level: low