### PR TITLE
[docs] Fix alert rendering in OpenAPI specs

### DIFF
--- a/docs/documentation/_plugins/render-jsonschema.rb
+++ b/docs/documentation/_plugins/render-jsonschema.rb
@@ -11,6 +11,12 @@ module JSONSchemaRenderer
       '%' => '&#37;'
     }
 
+    # The `alert` Liquid block (see _plugins/alert.rb) with its content.
+    @@ALERT_BLOCK_REGEX = /\{%-?\s*alert(?:\s[^%]*?)?\s*-?%\}.*?\{%-?\s*endalert\s*-?%\}/m
+    # Temporary substitute of an alert in a description. Must survive the Markdown
+    # conversion and the escaping of the Liquid characters, hence letters and digits only.
+    @@ALERT_PLACEHOLDER = 'xjekyllalertplaceholder%dx'
+
     def convert(content)
       if @converter.nil?
         @converter = @site.find_converter_instance(::Jekyll::Converters::Markdown)
@@ -23,6 +29,44 @@ module JSONSchemaRenderer
         input = input.gsub(char, escaped_char)
       end
       input
+    end
+
+    # Converts a description of a resource or a parameter to HTML rendering the `alert`
+    # Liquid blocks it contains.
+    #
+    # A description can't be passed to Liquid as a whole, because it may contain Go
+    # templates (e.g. `{{ .projectName }}`) which have to be shown as is. That's why the
+    # alerts are cut out, rendered separately and put back after the Markdown conversion.
+    def convert_description(content)
+      alerts = []
+
+      content = content.to_s.gsub(@@ALERT_BLOCK_REGEX) do |block|
+        rendered = render_liquid_block(block)
+        # Leave the block as is if it can't be rendered.
+        next block if rendered.nil?
+
+        alerts.push(rendered)
+        # An alert is a block element, so isolate it from the surrounding text.
+        %Q(\n\n#{format(@@ALERT_PLACEHOLDER, alerts.length - 1)}\n\n)
+      end
+
+      result = escape_chars(convert(content))
+
+      alerts.each_with_index do |alert, index|
+        placeholder = format(@@ALERT_PLACEHOLDER, index)
+        # Get rid of the paragraph the placeholder has been wrapped into.
+        result = result.sub(%r{<p>\s*#{placeholder}\s*</p>}) { alert }
+        result = result.sub(placeholder) { alert }
+      end
+
+      result
+    end
+
+    def render_liquid_block(block)
+      Liquid::Template.parse(block).render!(@site.site_payload, { :registers => { :site => @site, :page => @page } })
+    rescue StandardError => e
+      puts "[WARN] Can't render the Liquid block in a description (#{@page ? @page['url'] : ''}): #{e.message}"
+      nil
     end
 
     # TODO: Refactor this according to the new data structure - x-doc-d8Editions instead of x-doc-d8Revision
@@ -477,7 +521,7 @@ module JSONSchemaRenderer
         end
 
         if attributes['description']
-          result.push(sprintf(%q(<div class="resources__prop_description">%s%s</div>),editionsString,escape_chars(convert(get_i18n_description(primaryLanguage, fallbackLanguage, attributes)))))
+          result.push(sprintf(%q(<div class="resources__prop_description">%s%s</div>),editionsString,convert_description(get_i18n_description(primaryLanguage, fallbackLanguage, attributes))))
 
         elsif editionsString and editionsString.size > 0
           result.push(sprintf(%q(<div class="resources__prop_description">%s</div>),editionsString))
@@ -1006,15 +1050,15 @@ module JSONSchemaRenderer
                    searchKeywords = get_search_keywords(input['i18n'][@lang],"spec","validation","openAPIV3Schema", input['i18n'][fallbackLanguageName],"spec","validation","openAPIV3Schema")
 
                    if get_hash_value(input['i18n'][@lang],"spec","validation","openAPIV3Schema","description") then
-                       description = escape_chars(convert(get_hash_value(input['i18n'][@lang],"spec","validation","openAPIV3Schema","description")))
+                       description = convert_description(get_hash_value(input['i18n'][@lang],"spec","validation","openAPIV3Schema","description"))
                        result.push(description)
                        AppendResource2Search(input["spec"]["names"]["kind"], @moduleName, @page["url"].sub(%r{^(/?ru/|/?en/)}, ''), '', description, searchKeywords)
                    elsif get_hash_value(input['i18n'][fallbackLanguageName],"spec","validation","openAPIV3Schema","description") then
-                       description = escape_chars(convert(input['i18n'][fallbackLanguageName]["spec"]["validation"]["openAPIV3Schema"]["description"]))
+                       description = convert_description(input['i18n'][fallbackLanguageName]["spec"]["validation"]["openAPIV3Schema"]["description"])
                        result.push(description)
                        AppendResource2Search(input["spec"]["names"]["kind"], @moduleName, @page["url"].sub(%r{^(/?ru/|/?en/)}, ''), '', description, searchKeywords)
                    else
-                       description = escape_chars(convert(input["spec"]["validation"]["openAPIV3Schema"]["description"]))
+                       description = convert_description(input["spec"]["validation"]["openAPIV3Schema"]["description"])
                        result.push(description)
                        AppendResource2Search(input["spec"]["names"]["kind"], @moduleName, @page["url"].sub(%r{^(/?ru/|/?en/)}, ''), '', description, searchKeywords)
                    end
@@ -1109,15 +1153,15 @@ module JSONSchemaRenderer
                        if    input['i18n'][@lang] and
                              get_hash_value(input['i18n'][@lang],"spec","versions") and
                              input['i18n'][@lang]["spec"]["versions"].select {|i| i['name'].to_s == item['name'].to_s; }[0] then
-                           description = convert(input['i18n'][@lang]["spec"]["versions"].select {|i| i['name'].to_s == item['name'].to_s; }[0]["schema"]["openAPIV3Schema"]["description"])
-                           result.push(escape_chars(description))
+                           description = convert_description(input['i18n'][@lang]["spec"]["versions"].select {|i| i['name'].to_s == item['name'].to_s; }[0]["schema"]["openAPIV3Schema"]["description"])
+                           result.push(description)
                        elsif input['i18n'][fallbackLanguageName] and
                              get_hash_value(input['i18n'][fallbackLanguageName],"spec","versions") and
                              input['i18n'][fallbackLanguageName]["spec"]["versions"].select {|i| i['name'].to_s == item['name'].to_s; }[0] then
-                           description = convert(input['i18n'][fallbackLanguageName]["spec"]["versions"].select {|i| i['name'].to_s == item['name'].to_s; }[0]["schema"]["openAPIV3Schema"]["description"])
-                           result.push(escape_chars(description))
+                           description = convert_description(input['i18n'][fallbackLanguageName]["spec"]["versions"].select {|i| i['name'].to_s == item['name'].to_s; }[0]["schema"]["openAPIV3Schema"]["description"])
+                           result.push(description)
                        else
-                           description = escape_chars(convert(item["schema"]["openAPIV3Schema"]["description"]))
+                           description = convert_description(item["schema"]["openAPIV3Schema"]["description"])
                            result.push('<div class="resources__prop_description">' + description + '</div>')
                        end
                     end
@@ -1351,13 +1395,13 @@ module JSONSchemaRenderer
           description = ''
           if get_hash_value(item, 'description')
              if get_hash_value(item['i18n'][@lang],"description") then
-                 description = convert(get_hash_value(item['i18n'][@lang],"description"))
+                 description = convert_description(get_hash_value(item['i18n'][@lang],"description"))
              elsif get_hash_value(item['i18n'][fallbackLanguageName],"description") then
-                 description = convert(item['i18n'][fallbackLanguageName]["description"])
+                 description = convert_description(item['i18n'][fallbackLanguageName]["description"])
              else
-                 description = convert(item["description"])
+                 description = convert_description(item["description"])
              end
-             result.push(escape_chars(description))
+             result.push(description)
           end
 
           searchKeywords = get_search_keywords(item['i18n'][@lang], item['i18n'][fallbackLanguageName])

--- a/docs/site/_plugins/render-jsonschema.rb
+++ b/docs/site/_plugins/render-jsonschema.rb
@@ -11,6 +11,12 @@ module JSONSchemaRenderer
       '%' => '&#37;'
     }
 
+    # The `alert` Liquid block (see _plugins/alert.rb) with its content.
+    @@ALERT_BLOCK_REGEX = /\{%-?\s*alert(?:\s[^%]*?)?\s*-?%\}.*?\{%-?\s*endalert\s*-?%\}/m
+    # Temporary substitute of an alert in a description. Must survive the Markdown
+    # conversion and the escaping of the Liquid characters, hence letters and digits only.
+    @@ALERT_PLACEHOLDER = 'xjekyllalertplaceholder%dx'
+
     def convert(content)
       if @converter.nil?
         @converter = @site.find_converter_instance(::Jekyll::Converters::Markdown)
@@ -23,6 +29,44 @@ module JSONSchemaRenderer
         input = input.gsub(char, escaped_char)
       end
       input
+    end
+
+    # Converts a description of a resource or a parameter to HTML rendering the `alert`
+    # Liquid blocks it contains.
+    #
+    # A description can't be passed to Liquid as a whole, because it may contain Go
+    # templates (e.g. `{{ .projectName }}`) which have to be shown as is. That's why the
+    # alerts are cut out, rendered separately and put back after the Markdown conversion.
+    def convert_description(content)
+      alerts = []
+
+      content = content.to_s.gsub(@@ALERT_BLOCK_REGEX) do |block|
+        rendered = render_liquid_block(block)
+        # Leave the block as is if it can't be rendered.
+        next block if rendered.nil?
+
+        alerts.push(rendered)
+        # An alert is a block element, so isolate it from the surrounding text.
+        %Q(\n\n#{format(@@ALERT_PLACEHOLDER, alerts.length - 1)}\n\n)
+      end
+
+      result = escape_chars(convert(content))
+
+      alerts.each_with_index do |alert, index|
+        placeholder = format(@@ALERT_PLACEHOLDER, index)
+        # Get rid of the paragraph the placeholder has been wrapped into.
+        result = result.sub(%r{<p>\s*#{placeholder}\s*</p>}) { alert }
+        result = result.sub(placeholder) { alert }
+      end
+
+      result
+    end
+
+    def render_liquid_block(block)
+      Liquid::Template.parse(block).render!(@site.site_payload, { :registers => { :site => @site, :page => @page } })
+    rescue StandardError => e
+      puts "[WARN] Can't render the Liquid block in a description (#{@page ? @page['url'] : ''}): #{e.message}"
+      nil
     end
 
     # moduleName
@@ -417,7 +461,7 @@ module JSONSchemaRenderer
             # result.push(convert('**' + get_i18n_term('not_required_value_sentence')  + '**'))
         end
 
-        result.push(sprintf(%q(<div class="resources__prop_description">%s</div>),escape_chars(convert(get_i18n_description(primaryLanguage, fallbackLanguage, attributes))))) if attributes['description']
+        result.push(sprintf(%q(<div class="resources__prop_description">%s</div>),convert_description(get_i18n_description(primaryLanguage, fallbackLanguage, attributes)))) if attributes['description']
 
         if attributes.has_key?('x-doc-default')
             if attributes['x-doc-default'].is_a?(Array) or attributes['x-doc-default'].is_a?(Hash)
@@ -926,15 +970,15 @@ module JSONSchemaRenderer
                    searchKeywords = get_search_keywords(input['i18n'][@lang],"spec","validation","openAPIV3Schema", input['i18n'][fallbackLanguageName],"spec","validation","openAPIV3Schema")
 
                    if get_hash_value(input['i18n'][@lang],"spec","validation","openAPIV3Schema","description") then
-                       description = escape_chars(convert(get_hash_value(input['i18n'][@lang],"spec","validation","openAPIV3Schema","description")))
+                       description = convert_description(get_hash_value(input['i18n'][@lang],"spec","validation","openAPIV3Schema","description"))
                        result.push(description)
                        AppendResource2Search(input["spec"]["names"]["kind"], moduleName, @path.sub(%r{^(/?ru/|/?en/)}, ''), '', description, searchKeywords)
                    elsif get_hash_value(input['i18n'][fallbackLanguageName],"spec","validation","openAPIV3Schema","description") then
-                       description = escape_chars(convert(input['i18n'][fallbackLanguageName]["spec"]["validation"]["openAPIV3Schema"]["description"]))
+                       description = convert_description(input['i18n'][fallbackLanguageName]["spec"]["validation"]["openAPIV3Schema"]["description"])
                        result.push(description)
                        AppendResource2Search(input["spec"]["names"]["kind"], moduleName, @path.sub(%r{^(/?ru/|/?en/)}, ''), '', description, searchKeywords)
                    else
-                       description = escape_chars(convert(input["spec"]["validation"]["openAPIV3Schema"]["description"]))
+                       description = convert_description(input["spec"]["validation"]["openAPIV3Schema"]["description"])
                        result.push(description)
                        AppendResource2Search(input["spec"]["names"]["kind"], moduleName, @path.sub(%r{^(/?ru/|/?en/)}, ''), '', description, searchKeywords)
                    end
@@ -1027,15 +1071,15 @@ module JSONSchemaRenderer
                        if    input['i18n'][@lang] and
                              get_hash_value(input['i18n'][@lang],"spec","versions") and
                              input['i18n'][@lang]["spec"]["versions"].select {|i| i['name'].to_s == item['name'].to_s; }[0] then
-                           description = convert(input['i18n'][@lang]["spec"]["versions"].select {|i| i['name'].to_s == item['name'].to_s; }[0]["schema"]["openAPIV3Schema"]["description"])
-                           result.push(escape_chars(description))
+                           description = convert_description(input['i18n'][@lang]["spec"]["versions"].select {|i| i['name'].to_s == item['name'].to_s; }[0]["schema"]["openAPIV3Schema"]["description"])
+                           result.push(description)
                        elsif input['i18n'][fallbackLanguageName] and
                              get_hash_value(input['i18n'][fallbackLanguageName],"spec","versions") and
                              input['i18n'][fallbackLanguageName]["spec"]["versions"].select {|i| i['name'].to_s == item['name'].to_s; }[0] then
-                           description = convert(input['i18n'][fallbackLanguageName]["spec"]["versions"].select {|i| i['name'].to_s == item['name'].to_s; }[0]["schema"]["openAPIV3Schema"]["description"])
-                           result.push(escape_chars(description))
+                           description = convert_description(input['i18n'][fallbackLanguageName]["spec"]["versions"].select {|i| i['name'].to_s == item['name'].to_s; }[0]["schema"]["openAPIV3Schema"]["description"])
+                           result.push(description)
                        else
-                           description = escape_chars(convert(item["schema"]["openAPIV3Schema"]["description"]))
+                           description = convert_description(item["schema"]["openAPIV3Schema"]["description"])
                            result.push('<div class="resources__prop_description">' + description + '</div>')
                        end
                     end
@@ -1249,13 +1293,13 @@ module JSONSchemaRenderer
           description = ''
           if get_hash_value(item, 'description')
              if get_hash_value(item['i18n'][@lang],"description") then
-                 description = convert(get_hash_value(item['i18n'][@lang],"description"))
+                 description = convert_description(get_hash_value(item['i18n'][@lang],"description"))
              elsif get_hash_value(item['i18n'][fallbackLanguageName],"description") then
-                 description = convert(item['i18n'][fallbackLanguageName]["description"])
+                 description = convert_description(item['i18n'][fallbackLanguageName]["description"])
              else
-                 description = convert(item["description"])
+                 description = convert_description(item["description"])
              end
-             result.push(escape_chars(description))
+             result.push(description)
           end
 
           searchKeywords = get_search_keywords(item['i18n'][@lang], item['i18n'][fallbackLanguageName])

--- a/docs/site/_sass/components/_guides.scss
+++ b/docs/site/_sass/components/_guides.scss
@@ -24,6 +24,34 @@ div.alert__wrap {
     }
   }
 
+  // On module configuration and CRD pages the alert sits inside `ul.resources`,
+  // where `.resources li p` zeroes out paragraph margins. The alert takes its
+  // vertical rhythm from those margins, so without them it collapses onto its
+  // border and the 52px icon overflows it. Restore the spacing in that context
+  // only; selectors have to outweigh `.resources li p:not(.resources__attrs)`.
+  .resources & > div {
+    min-height: 24px;
+    padding-top: 14px;
+    padding-bottom: 14px;
+
+    & > p:not(.resources__attrs) {
+      margin: 0 0 14px;
+      padding: 0;
+
+      &:last-child {
+        margin-bottom: 0;
+      }
+    }
+
+    & > *:last-child {
+      margin-bottom: 0;
+    }
+
+    @include breakpoints.max-w(s) {
+      padding-top: 48px;
+    }
+  }
+
   & a {
     color: variables.$primary-700;
   }

--- a/docs/site/backends/docs-builder-template/layouts/_partials/alert.html
+++ b/docs/site/backends/docs-builder-template/layouts/_partials/alert.html
@@ -1,6 +1,6 @@
 {{- $levels :=  slice "info" "warning" "warn" "danger" }}
 {{- $level :=  "info" }}
-{{- $content := trim  .content " \n" | markdownify }}
+{{- $content := trim  .content " \n" | page.RenderString (dict "display" "block") }}
 {{- if and .level (in $levels (lower .level) ) }}{{ $level = lower .level }}{{ end }}
 {{- if eq $level "warn" }}{{ $level = "warning" }}{{ end }}
 
@@ -9,6 +9,6 @@
   <svg class="alert__icon icon--{{ $level }}">
     <use xlink:href="/images/sprite.svg#{{ $level }}-icon"></use>
   </svg>
-  <div><p>{{ $content }}</p></div>
+  <div>{{ $content }}</div>
 </div>
 {{ end }}

--- a/docs/site/backends/docs-builder-template/layouts/_partials/module-stage-badge.html
+++ b/docs/site/backends/docs-builder-template/layouts/_partials/module-stage-badge.html
@@ -32,7 +32,7 @@
     {{- $stageLink := partial "helpers/rewrite-link" (dict "href" (T "module_lifecycle_stage_link") "inner" (T "module_lifecycle_stage")) }}
     {{- $content := printf "%s: <span data-tippy-content='%s' class='alert__info'>%s</span>" $stageLink (T (printf "module_alert_%s_long" $statusKey )) $moduleStage }}
     {{- if $hasRequirements }}
-      {{- $content = printf "%s <p>%s</p>" $content (T "requirements_for_alert") }}
+      {{- $content = printf "%s\n\n%s" $content (T "requirements_for_alert") }}
     {{- end }}
     {{- partial "alert" ( dict "level" $alertLevel "content" $content ) }}
   {{- end }}

--- a/docs/site/backends/docs-builder-template/layouts/_shortcodes/alert.html
+++ b/docs/site/backends/docs-builder-template/layouts/_shortcodes/alert.html
@@ -1,1 +1,1 @@
-{{ partial "alert.html" (dict "level" (.Get "level") "content" .Inner ) }}
+{{ partial "alert.html" (dict "level" (.Get "level") "content" .InnerDeindent ) }}


### PR DESCRIPTION
## Description

This pull request improves the handling and rendering of alert blocks within resource and parameter descriptions in both the Ruby-based and Hugo-based documentation generators. The main goal is to ensure that alerts (special callouts) are correctly processed and displayed, even when descriptions contain Go templates or are rendered inside lists, and to maintain proper spacing and formatting across all documentation pages.

**Key changes include:**

### Ruby-based documentation generator (`render-jsonschema.rb`):

* Added a new `convert_description` method to extract, render, and re-insert `alert` Liquid blocks in descriptions, ensuring that Go template syntax is preserved and alerts are rendered as intended. (`docs/documentation/_plugins/render-jsonschema.rb`, `docs/site/_plugins/render-jsonschema.rb`) [[1]](diffhunk://#diff-696cb9f252987baae272e44d1f2a51b1eed7b3adac7363ae5d0e7a38872bcf47R34-R71) [[2]](diffhunk://#diff-4e6e251e011db769355b2a9838476054126facf43d33993c74717196a6ad785bR34-R71)
* Updated all places where descriptions are rendered (e.g., in CRD and configuration formatters) to use `convert_description` instead of passing the whole description through Markdown and escaping, improving alert rendering and preventing double-escaping. [[1]](diffhunk://#diff-696cb9f252987baae272e44d1f2a51b1eed7b3adac7363ae5d0e7a38872bcf47L480-R524) [[2]](diffhunk://#diff-696cb9f252987baae272e44d1f2a51b1eed7b3adac7363ae5d0e7a38872bcf47L1009-R1061) [[3]](diffhunk://#diff-696cb9f252987baae272e44d1f2a51b1eed7b3adac7363ae5d0e7a38872bcf47L1112-R1164) [[4]](diffhunk://#diff-696cb9f252987baae272e44d1f2a51b1eed7b3adac7363ae5d0e7a38872bcf47L1354-R1404) [[5]](diffhunk://#diff-4e6e251e011db769355b2a9838476054126facf43d33993c74717196a6ad785bL420-R464) [[6]](diffhunk://#diff-4e6e251e011db769355b2a9838476054126facf43d33993c74717196a6ad785bL929-R981) [[7]](diffhunk://#diff-4e6e251e011db769355b2a9838476054126facf43d33993c74717196a6ad785bL1030-R1082) [[8]](diffhunk://#diff-4e6e251e011db769355b2a9838476054126facf43d33993c74717196a6ad785bL1252-R1302)

### Hugo-based documentation generator (partials and shortcodes):

* Changed the alert partial to use Hugo's `page.RenderString` for block-level rendering, and removed the forced `<p>` wrapper around alert content, allowing for more flexible and correct HTML structure. (`layouts/_partials/alert.html`) [[1]](diffhunk://#diff-cb760aae3a04e51fe112be62bd6a4452887bfe27b7f545dfe6be0309b18a530aL3-R3) [[2]](diffhunk://#diff-cb760aae3a04e51fe112be62bd6a4452887bfe27b7f545dfe6be0309b18a530aL12-R12)
* Updated the alert shortcode to use `.InnerDeindent`, preserving intended formatting and indentation. (`layouts/_shortcodes/alert.html`)
* Adjusted the module stage badge partial to avoid unnecessary paragraph tags in alert content, improving alert rendering consistency. (`layouts/_partials/module-stage-badge.html`)

### Styling improvements:

* Added targeted CSS to restore vertical spacing for alerts inside resource lists, preventing visual collapse and icon overflow on module configuration and CRD pages. (`_guides.scss`)

These changes together ensure that alerts are robustly and consistently rendered in all documentation contexts, with correct formatting and spacing, regardless of the underlying generator or the presence of embedded template syntax.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: fix
summary: Fix alert rendering in OpenAPI specs.
impact_level: low
```
