### PR TITLE
[service-with-healthchecks] EndpointSlice ownerReference and child Service improvements

### DIFF
--- a/ee/modules/610-service-with-healthchecks/crds/doc-ru-servicewithhealthchecks.yaml
+++ b/ee/modules/610-service-with-healthchecks/crds/doc-ru-servicewithhealthchecks.yaml
@@ -348,6 +348,14 @@ spec:
             status:
               description: Определяет наблюдаемое состояние `ServiceWithHealthchecks`.
               properties:
+                clusterIP:
+                  description: |-
+                    Адрес дочернего сервиса: либо запрошенный в `spec.clusterIP`, либо выданный кластером.
+
+                    Адрес отражается здесь и никогда не записывается обратно в спецификацию.
+                clusterIPs:
+                  description: |-
+                    Все адреса дочернего сервиса, по одному на каждое семейство IP-адресов.
                 conditions:
                   description: Текущее состояние сервиса
                   items:

--- a/ee/modules/610-service-with-healthchecks/crds/servicewithhealthchecks.yaml
+++ b/ee/modules/610-service-with-healthchecks/crds/servicewithhealthchecks.yaml
@@ -318,6 +318,7 @@ spec:
                   The default value,
                   `Cluster`, uses the standard behavior of routing to all endpoints evenly
                   (possibly modified by topology and other features).
+                default: Cluster
                 type: string
               ipFamilies:
                 description: |-
@@ -570,6 +571,7 @@ spec:
                   ExternalName aliases this service to the specified `externalName`.
                   Several other fields do not apply to ExternalName services.
                   [More info.](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types)
+                default: ClusterIP
                 type: string
             required:
             - healthcheck
@@ -577,6 +579,19 @@ spec:
           status:
             description: Defines the observed state of ServiceWithHealthchecks
             properties:
+              clusterIP:
+                description: |-
+                  The address of the child Service: the one requested in `spec.clusterIP`, or the one the cluster allocated.
+
+                  The address is reported here and is never written back into the spec.
+                type: string
+              clusterIPs:
+                description: |-
+                  All the addresses of the child Service, one per IP family.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: atomic
               conditions:
                 description: Current service state
                 items:
@@ -802,6 +817,9 @@ spec:
       type: string
     - jsonPath: .status.conditions[?(@.type=="Ready")].status
       name: Ready
+      type: string
+    - jsonPath: .status.clusterIP
+      name: ClusterIP
       type: string
     - jsonPath: .status.loadBalancer.ingress[0].ip
       name: ExternalIP

--- a/ee/modules/610-service-with-healthchecks/images/artifact/api/v1alpha1/servicewithhealthchecks_types.go
+++ b/ee/modules/610-service-with-healthchecks/images/artifact/api/v1alpha1/servicewithhealthchecks_types.go
@@ -28,8 +28,17 @@ type ServiceWithHealthchecksStatus struct {
 	// LoadBalancer contains the current status of the load-balancer,
 	// if one is present.
 	// +optional
-	LoadBalancer         corev1.LoadBalancerStatus `json:"loadBalancer,omitempty" protobuf:"bytes,1,opt,name=loadBalancer"`
-	HealthcheckCondition HealthcheckCondition      `json:"healthcheckCondition,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,2,rep,name=healthcheckCondition"`
+	LoadBalancer corev1.LoadBalancerStatus `json:"loadBalancer,omitempty" protobuf:"bytes,1,opt,name=loadBalancer"`
+	// ClusterIP is the address of the child Service: the one requested in the spec, or the one
+	// the cluster allocated. The address is never written back into the spec, because a
+	// controller can only do that as a second write, after the Service already exists.
+	// +optional
+	ClusterIP string `json:"clusterIP,omitempty"`
+	// ClusterIPs holds all the addresses of the child Service, one per IP family.
+	// +optional
+	// +listType=atomic
+	ClusterIPs           []string             `json:"clusterIPs,omitempty"`
+	HealthcheckCondition HealthcheckCondition `json:"healthcheckCondition,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,2,rep,name=healthcheckCondition"`
 	// Current service state
 	// +optional
 	// +patchMergeKey=type

--- a/ee/modules/610-service-with-healthchecks/images/artifact/api/v1alpha1/zz_generated.deepcopy.go
+++ b/ee/modules/610-service-with-healthchecks/images/artifact/api/v1alpha1/zz_generated.deepcopy.go
@@ -217,6 +217,11 @@ func (in *ServiceWithHealthchecksSpec) DeepCopy() *ServiceWithHealthchecksSpec {
 func (in *ServiceWithHealthchecksStatus) DeepCopyInto(out *ServiceWithHealthchecksStatus) {
 	*out = *in
 	in.LoadBalancer.DeepCopyInto(&out.LoadBalancer)
+	if in.ClusterIPs != nil {
+		in, out := &in.ClusterIPs, &out.ClusterIPs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	out.HealthcheckCondition = in.HealthcheckCondition
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions

--- a/ee/modules/610-service-with-healthchecks/images/artifact/internal/agent/agent.go
+++ b/ee/modules/610-service-with-healthchecks/images/artifact/internal/agent/agent.go
@@ -41,6 +41,7 @@ const (
 	endpointServiceNameLabelKey = "kubernetes.io/service-name"
 	endpointControllerLabelKey  = "endpointslice.kubernetes.io/managed-by"
 	controllerName              = "servicewithhealthchecks"
+	serviceWithHealthchecksKind = "ServiceWithHealthchecks"
 
 	// resyncPeriod bounds how long a ServiceWithHealthchecks may stay out of sync with the
 	// pods on this node. New target pods are learned from watch events only, and once the
@@ -484,10 +485,15 @@ func (r *ServiceWithHealthchecksReconciler) updateEPSForServiceWithHealthchecks(
 		return err
 	}
 
+	// A slice created before the owner reference was introduced, or left over from a recreated
+	// parent, is adopted here instead of being recreated.
+	ownerIsOutdated := !reflect.DeepEqual(existingEPS.OwnerReferences, desiredEPS.OwnerReferences)
+
 	// Use Patch instead of Update to avoid conflicts and ResourceVersion issues.
-	if !endpointsAreEqual(existingEPS.Endpoints, desiredEPS.Endpoints) {
+	if ownerIsOutdated || !endpointsAreEqual(existingEPS.Endpoints, desiredEPS.Endpoints) {
 		patch := client.MergeFrom(existingEPS.DeepCopy())
 		existingEPS.Endpoints = desiredEPS.Endpoints
+		existingEPS.OwnerReferences = desiredEPS.OwnerReferences
 		if err := r.Patch(ctx, existingEPS, patch); err != nil {
 			r.logger.Error("couldn't patch EndpointSlice", log.Err(err), "name", desiredNameForEndpointSlice)
 			return err
@@ -505,6 +511,7 @@ func (r *ServiceWithHealthchecksReconciler) BuildEndpointSlice(desiredName strin
 				endpointServiceNameLabelKey: svc.GetName(),
 				endpointControllerLabelKey:  controllerName,
 			},
+			OwnerReferences: []metav1.OwnerReference{ownerReferenceForServiceWithHealthchecks(svc)},
 		},
 		AddressType: discoveryv1.AddressTypeIPv4,
 		Ports:       r.buildPortsForEndpointslice(svc),
@@ -512,6 +519,24 @@ func (r *ServiceWithHealthchecksReconciler) BuildEndpointSlice(desiredName strin
 
 	eps.Endpoints = r.buildEndpoints(svc)
 	return eps
+}
+
+// ownerReferenceForServiceWithHealthchecks ties a slice to the resource it was built from, so
+// that the garbage collector removes the slices of every node once that resource is gone. The
+// child Service is owned by the same resource, so both branches of the tree are cleaned up.
+//
+// BlockOwnerDeletion is deliberately left unset: with the OwnerReferencesPermissionEnforcement
+// admission plugin enabled it would require the agent to have access to the
+// servicewithhealthchecks/finalizers subresource, which it has no other reason to hold.
+func ownerReferenceForServiceWithHealthchecks(svc networkv1alpha1.ServiceWithHealthchecks) metav1.OwnerReference {
+	isController := true
+	return metav1.OwnerReference{
+		APIVersion: networkv1alpha1.GroupVersion.String(),
+		Kind:       serviceWithHealthchecksKind,
+		Name:       svc.GetName(),
+		UID:        svc.GetUID(),
+		Controller: &isController,
+	}
 }
 
 func (r *ServiceWithHealthchecksReconciler) buildPortsForEndpointslice(svc networkv1alpha1.ServiceWithHealthchecks) []discoveryv1.EndpointPort {

--- a/ee/modules/610-service-with-healthchecks/images/artifact/internal/agent/agent_test.go
+++ b/ee/modules/610-service-with-healthchecks/images/artifact/internal/agent/agent_test.go
@@ -30,6 +30,7 @@ const (
 	testSWHName   = "afb6b6179f7a240379b969366a6f6a75"
 	testNodeName  = "hv-06"
 	testPodIP     = "10.12.5.86"
+	testSWHUID    = types.UID("1a1cbd7c-4f2a-4a0d-9d0e-2b0f4b1f5f0a")
 )
 
 func newTestReconciler() *ServiceWithHealthchecksReconciler {
@@ -42,7 +43,7 @@ func newTestReconciler() *ServiceWithHealthchecksReconciler {
 
 func newTestSWH() networkv1alpha1.ServiceWithHealthchecks {
 	return networkv1alpha1.ServiceWithHealthchecks{
-		ObjectMeta: metav1.ObjectMeta{Name: testSWHName, Namespace: testNamespace},
+		ObjectMeta: metav1.ObjectMeta{Name: testSWHName, Namespace: testNamespace, UID: testSWHUID},
 	}
 }
 
@@ -674,5 +675,119 @@ func TestReconcileKeepsRequeueingItself(t *testing.T) {
 		if result.RequeueAfter != resyncPeriod {
 			t.Errorf("%s reconcile: RequeueAfter = %v, want %v", pass, result.RequeueAfter, resyncPeriod)
 		}
+	}
+}
+
+func newTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add corev1 to scheme: %v", err)
+	}
+	if err := discoveryv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add discoveryv1 to scheme: %v", err)
+	}
+	if err := networkv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add networkv1alpha1 to scheme: %v", err)
+	}
+	return scheme
+}
+
+// The slice has to be owned by its ServiceWithHealthchecks, otherwise nothing collects the
+// slices of the other nodes once the resource is deleted.
+func TestBuildEndpointSliceIsOwnedBySWH(t *testing.T) {
+	r := newTestReconciler()
+	swh := newTestSWH()
+
+	eps := r.BuildEndpointSlice(testSWHName+"-"+testNodeName, swh)
+
+	if len(eps.OwnerReferences) != 1 {
+		t.Fatalf("expected exactly one owner reference, got %+v", eps.OwnerReferences)
+	}
+	ref := eps.OwnerReferences[0]
+	if ref.APIVersion != networkv1alpha1.GroupVersion.String() || ref.Kind != serviceWithHealthchecksKind {
+		t.Errorf("expected the owner to be a ServiceWithHealthchecks, got %s %s", ref.APIVersion, ref.Kind)
+	}
+	if ref.Name != testSWHName || ref.UID != testSWHUID {
+		t.Errorf("expected the owner to be %s/%s, got %s/%s", testSWHName, testSWHUID, ref.Name, ref.UID)
+	}
+	if ref.Controller == nil || !*ref.Controller {
+		t.Error("expected the owner reference to be a controller reference")
+	}
+	// OwnerReferencesPermissionEnforcement would refuse the Create otherwise
+	if ref.BlockOwnerDeletion != nil {
+		t.Errorf("expected blockOwnerDeletion to stay unset, got %v", *ref.BlockOwnerDeletion)
+	}
+}
+
+// Slices created by an older version of the agent carry no owner reference; they are adopted
+// in place instead of being recreated.
+func TestUpdateEPSAdoptsSliceWithoutOwnerReference(t *testing.T) {
+	r := newTestReconciler()
+	swh := newTestSWH()
+	epsName := testSWHName + "-" + testNodeName
+
+	orphan := r.BuildEndpointSlice(epsName, swh)
+	orphan.OwnerReferences = nil
+	orphan.Endpoints = []discoveryv1.Endpoint{{Addresses: []string{testPodIP}}}
+
+	r.Client = fake.NewClientBuilder().WithScheme(newTestScheme(t)).WithObjects(&orphan).Build()
+	r.healthchecksResultsByServiceWithHealthchecks[types.NamespacedName{Namespace: testNamespace, Name: testSWHName}] = []HealthcheckTarget{
+		{
+			targetHost:         testPodIP,
+			podName:            "worker",
+			podNamespace:       testNamespace,
+			podUID:             types.UID("uid-worker"),
+			podReady:           true,
+			probeResultDetails: successfulProbeDetails(),
+		},
+	}
+
+	if err := r.updateEPSForServiceWithHealthchecks(context.Background(), swh); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var updated discoveryv1.EndpointSlice
+	if err := r.Get(context.Background(), client.ObjectKey{Namespace: testNamespace, Name: epsName}, &updated); err != nil {
+		t.Fatalf("failed to read back the EndpointSlice: %v", err)
+	}
+	if len(updated.OwnerReferences) != 1 || updated.OwnerReferences[0].UID != testSWHUID {
+		t.Errorf("expected the existing slice to be adopted, got %+v", updated.OwnerReferences)
+	}
+}
+
+// A slice left over from a resource with the same name but a different UID would be collected
+// right after being written, so the stale reference has to be replaced.
+func TestUpdateEPSReplacesStaleOwnerReference(t *testing.T) {
+	r := newTestReconciler()
+	swh := newTestSWH()
+	epsName := testSWHName + "-" + testNodeName
+
+	stale := r.BuildEndpointSlice(epsName, swh)
+	stale.OwnerReferences[0].UID = types.UID("00000000-0000-0000-0000-000000000000")
+	stale.Endpoints = []discoveryv1.Endpoint{{Addresses: []string{testPodIP}}}
+
+	r.Client = fake.NewClientBuilder().WithScheme(newTestScheme(t)).WithObjects(&stale).Build()
+	r.healthchecksResultsByServiceWithHealthchecks[types.NamespacedName{Namespace: testNamespace, Name: testSWHName}] = []HealthcheckTarget{
+		{
+			targetHost:         testPodIP,
+			podName:            "worker",
+			podNamespace:       testNamespace,
+			podUID:             types.UID("uid-worker"),
+			podReady:           true,
+			probeResultDetails: successfulProbeDetails(),
+		},
+	}
+
+	if err := r.updateEPSForServiceWithHealthchecks(context.Background(), swh); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var updated discoveryv1.EndpointSlice
+	if err := r.Get(context.Background(), client.ObjectKey{Namespace: testNamespace, Name: epsName}, &updated); err != nil {
+		t.Fatalf("failed to read back the EndpointSlice: %v", err)
+	}
+	if len(updated.OwnerReferences) != 1 || updated.OwnerReferences[0].UID != testSWHUID {
+		t.Errorf("expected the stale owner reference to be replaced, got %+v", updated.OwnerReferences)
 	}
 }

--- a/ee/modules/610-service-with-healthchecks/images/artifact/internal/controller/controller.go
+++ b/ee/modules/610-service-with-healthchecks/images/artifact/internal/controller/controller.go
@@ -9,11 +9,11 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"slices"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -143,9 +143,12 @@ func (r *ServiceWithHealthchecksReconciler) Reconcile(ctx context.Context, req c
 
 			// The address can only be requested while the Service is being created: it is
 			// immutable afterwards, and an existing Service always carries one already.
+			//
+			// Only spec.clusterIP is propagated. spec.clusterIPs is absent from the CRD schema,
+			// so the API server prunes it and it is always empty here; carrying it over would
+			// also require spec.ipFamilyPolicy and spec.ipFamilies to reach the child Service.
 			if childService.Spec.ClusterIP == "" {
 				childService.Spec.ClusterIP = serviceWithHC.Spec.ClusterIP
-				childService.Spec.ClusterIPs = serviceWithHC.Spec.ClusterIPs
 			}
 
 			childService.Spec.Selector = map[string]string{}
@@ -193,7 +196,7 @@ func (r *ServiceWithHealthchecksReconciler) Reconcile(ctx context.Context, req c
 	originalServiceWithHC := serviceWithHC.DeepCopy()
 	patch := client.MergeFrom(originalServiceWithHC)
 
-	if serviceWithHC.Spec.Type == corev1.ServiceTypeLoadBalancer {
+	if desiredServiceType(serviceWithHC) == corev1.ServiceTypeLoadBalancer {
 		r.Logger.Debug("update status for ServiceWithHealthchecks", "name", req.Name, "namespace", req.Namespace)
 		serviceWithHC.Status.LoadBalancer = childService.Status.LoadBalancer
 	} else {
@@ -278,19 +281,23 @@ func clusterIPMismatch(service *corev1.Service, shc *networkv1alpha1.ServiceWith
 	}
 }
 
-// foreignOwnerReference returns the first owner reference that does not point to the
-// ServiceWithHealthchecks the child Service is built for. The UID is not compared: a reference to
-// the same name is ours even when the parent was recreated and got a new one.
+// foreignOwnerReference returns the controller reference of the Service when it points to
+// something other than the ServiceWithHealthchecks the child Service is built for. Only a
+// controller reference means ownership; a plain owner reference is an extra garbage collection
+// link that anything may add, and refusing to manage our own Service because of one would be
+// worse than the clash it is meant to catch. The UID is not compared: a reference to the same
+// name is ours even when the parent was recreated and got a new one.
 func foreignOwnerReference(service *corev1.Service, name string) *metav1.OwnerReference {
-	for i := range service.OwnerReferences {
-		ref := &service.OwnerReferences[i]
-		gv, err := schema.ParseGroupVersion(ref.APIVersion)
-		if err != nil ||
-			gv.Group != networkv1alpha1.GroupVersion.Group ||
-			ref.Kind != serviceWithHealthchecksKind ||
-			ref.Name != name {
-			return ref
-		}
+	ref := metav1.GetControllerOf(service)
+	if ref == nil {
+		return nil
+	}
+	gv, err := schema.ParseGroupVersion(ref.APIVersion)
+	if err != nil ||
+		gv.Group != networkv1alpha1.GroupVersion.Group ||
+		ref.Kind != serviceWithHealthchecksKind ||
+		ref.Name != name {
+		return ref
 	}
 	return nil
 }
@@ -332,7 +339,10 @@ func IsSpecForServiceEqual(service corev1.Service, shc *networkv1alpha1.ServiceW
 	if len(service.Spec.Selector) != 0 {
 		return false
 	}
-	if !slices.Equal(service.Spec.Ports, desiredPorts(service, shc)) {
+	// Semantic comparison rather than slices.Equal: ServicePort.AppProtocol is a pointer, and ==
+	// on a struct compares it by address, so two ports carrying the same appProtocol would never
+	// look equal and the Service would be rewritten on every reconciliation.
+	if !equality.Semantic.DeepEqual(service.Spec.Ports, desiredPorts(service, shc)) {
 		return false
 	}
 	if service.Spec.PublishNotReadyAddresses != shc.Spec.PublishNotReadyAddresses {

--- a/ee/modules/610-service-with-healthchecks/images/artifact/internal/controller/controller.go
+++ b/ee/modules/610-service-with-healthchecks/images/artifact/internal/controller/controller.go
@@ -17,6 +17,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -29,8 +31,14 @@ import (
 )
 
 const (
-	endpointControllerLabelKey = "endpointslice.kubernetes.io/managed-by"
-	controllerName             = "servicewithhealthchecks"
+	endpointControllerLabelKey  = "endpointslice.kubernetes.io/managed-by"
+	controllerName              = "servicewithhealthchecks"
+	serviceWithHealthchecksKind = "ServiceWithHealthchecks"
+
+	childServiceConditionType = "ChildServiceReady"
+	// The condition used to be called differently. A stale copy is dropped from the status, so
+	// that a resource reconciled by an older version does not keep reporting through it.
+	legacyChildServiceConditionType = "ChildService"
 
 	// resyncPeriod bounds how long an EndpointSlice of a node that no longer exists may stay
 	// published. clearNotUsedEPS runs on reconciliation only, and nothing watches Nodes, so
@@ -38,6 +46,11 @@ const (
 	// the next unrelated event on the object. It is longer than the agent's own resync because
 	// this only performs cleanup, and each pass lists Nodes cluster-wide from the cache.
 	resyncPeriod = 5 * time.Minute
+
+	// A conflicting Service is not owned by the module, so its changes never reach this
+	// controller through Owns() either. The resync alone would eventually notice the clash
+	// being resolved; this shorter interval is what makes the recovery prompt.
+	childServiceConflictRetry = time.Minute
 )
 
 // ServiceWithHealthchecksReconciler reconciles a ServiceWithHealthchecks object
@@ -74,16 +87,46 @@ func (r *ServiceWithHealthchecksReconciler) Reconcile(ctx context.Context, req c
 	childService.Namespace = req.Namespace
 
 	var errUpdatingSvc error
+	var conflictErr, immutableErr *childServiceProblem
 	var service corev1.Service
 	err := r.Get(ctx, req.NamespacedName, &service)
-	if err == nil && IsSpecForServiceEqual(service, serviceWithHC) && IsMetadataForServiceEqual(service, serviceWithHC) {
+	if err != nil && !errors.IsNotFound(err) {
+		r.Logger.Error("failed to get child Service", log.Err(err), "name", req.Name, "namespace", req.Namespace)
+		return ctrl.Result{}, err
+	}
+	if err == nil {
+		conflictErr = childServiceConflict(&service, serviceWithHC)
+		immutableErr = clusterIPMismatch(&service, serviceWithHC)
+	}
+
+	switch {
+	case conflictErr != nil:
+		// The Service belongs to somebody else. It is neither modified nor claimed, and the
+		// agents keep publishing their EndpointSlices for it: they are built from the
+		// ServiceWithHealthchecks alone, so the healthchecks stay in effect while the user
+		// resolves the clash.
+		r.Logger.Info("child Service conflict", "name", req.Name, "namespace", req.Namespace, "reason", conflictErr.Error())
+		childService = service
+
+	// The owner reference is part of the desired state as much as the spec is: a Service left
+	// over from a version that did not set it, or one whose reference was stripped, has to be
+	// adopted here, otherwise nothing ever collects it.
+	case err == nil && metav1.IsControlledBy(&service, serviceWithHC) &&
+		IsSpecForServiceEqual(service, serviceWithHC) && IsMetadataForServiceEqual(service, serviceWithHC):
 		r.Logger.Debug("no need to update child Service", "name", req.Name, "namespace", req.Namespace)
 		childService = service
-	} else {
+
+	default:
 		var op controllerutil.OperationResult
 		op, errUpdatingSvc = controllerutil.CreateOrUpdate(ctx, r.Client, &childService, func() error {
-			// Ensure owner reference is always set (idempotent — restores it if accidentally removed)
-			if err := controllerutil.SetControllerReference(serviceWithHC, &childService, r.Scheme); err != nil {
+			// Ensure owner reference is always set (idempotent — restores it if accidentally removed).
+			//
+			// BlockOwnerDeletion is deliberately turned off: it only matters for a foreground
+			// deletion of the parent, which nothing here needs, while with the
+			// OwnerReferencesPermissionEnforcement admission plugin enabled it would require the
+			// controller to have access to the servicewithhealthchecks/finalizers subresource.
+			if err := controllerutil.SetControllerReference(serviceWithHC, &childService, r.Scheme,
+				controllerutil.WithBlockOwnerDeletion(false)); err != nil {
 				return err
 			}
 
@@ -98,18 +141,23 @@ func (r *ServiceWithHealthchecksReconciler) Reconcile(ctx context.Context, req c
 			annotations = setPropagatedKeys(annotations, propagatedAnnotationsKey, desiredAnnotations)
 			childService.Annotations = setPropagatedKeys(annotations, propagatedLabelsKey, desiredLabels)
 
-			childService.Spec.Selector = map[string]string{}
-			childService.Spec.Ports = serviceWithHC.Spec.Ports
-			childService.Spec.Type = serviceWithHC.Spec.Type
-			childService.Spec.PublishNotReadyAddresses = serviceWithHC.Spec.PublishNotReadyAddresses
-			childService.Spec.InternalTrafficPolicy = serviceWithHC.Spec.InternalTrafficPolicy
-
-			// ExternalTrafficPolicy is only valid for LoadBalancer and NodePort.
-			if serviceWithHC.Spec.Type == corev1.ServiceTypeLoadBalancer || serviceWithHC.Spec.Type == corev1.ServiceTypeNodePort {
-				childService.Spec.ExternalTrafficPolicy = serviceWithHC.Spec.ExternalTrafficPolicy
-			} else {
-				childService.Spec.ExternalTrafficPolicy = ""
+			// The address can only be requested while the Service is being created: it is
+			// immutable afterwards, and an existing Service always carries one already.
+			if childService.Spec.ClusterIP == "" {
+				childService.Spec.ClusterIP = serviceWithHC.Spec.ClusterIP
+				childService.Spec.ClusterIPs = serviceWithHC.Spec.ClusterIPs
 			}
+
+			childService.Spec.Selector = map[string]string{}
+			childService.Spec.PublishNotReadyAddresses = serviceWithHC.Spec.PublishNotReadyAddresses
+
+			// The desired values are written, not the literal ones: an update that drops a field
+			// the API server fills in would be undone and reissued forever.
+			childService.Spec.Ports = desiredPorts(childService, serviceWithHC)
+			childService.Spec.Type = desiredServiceType(serviceWithHC)
+			childService.Spec.InternalTrafficPolicy = desiredInternalTrafficPolicy(serviceWithHC)
+			// ExternalTrafficPolicy is only valid for LoadBalancer and NodePort.
+			childService.Spec.ExternalTrafficPolicy = desiredExternalTrafficPolicy(serviceWithHC)
 			return nil
 		})
 
@@ -121,8 +169,9 @@ func (r *ServiceWithHealthchecksReconciler) Reconcile(ctx context.Context, req c
 			// so the user can see the reason in the resource status.
 			originalServiceWithHC := serviceWithHC.DeepCopy()
 			patch := client.MergeFrom(originalServiceWithHC)
-			failedCondition := createStatusConditionForService(errUpdatingSvc, serviceWithHC.Name)
+			failedCondition := createStatusConditionForService(errUpdatingSvc, nil, serviceWithHC.Name)
 			failedCondition.ObservedGeneration = serviceWithHC.Generation
+			serviceWithHC.Status.Conditions = kubernetes.RemoveStatusCondition(serviceWithHC.Status.Conditions, legacyChildServiceConditionType)
 			serviceWithHC.Status.Conditions = kubernetes.UpdateStatusWithCondition(serviceWithHC.Status.Conditions, failedCondition)
 			if patchErr := r.Status().Patch(ctx, serviceWithHC, patch); patchErr != nil {
 				r.Logger.Error("failed to patch failure condition into status", log.Err(patchErr), "name", req.Name, "namespace", req.Namespace)
@@ -130,6 +179,13 @@ func (r *ServiceWithHealthchecksReconciler) Reconcile(ctx context.Context, req c
 			return ctrl.Result{}, fmt.Errorf("failed to create/update child Service for ServiceWithHealthchecks %s/%s: %w", req.Namespace, req.Name, errUpdatingSvc)
 		}
 		r.Logger.Debug("child Service has been reconciled", "name", req.Name, "namespace", req.Namespace, "operation", op)
+	}
+
+	// Nothing watches Nodes, and a Service the module does not own raises no event either, so
+	// the reconciliation is repeated on a timer even when everything is settled.
+	result := ctrl.Result{RequeueAfter: resyncPeriod}
+	if conflictErr != nil {
+		result.RequeueAfter = childServiceConflictRetry
 	}
 
 	// Always update status — even if the child Service spec didn't change,
@@ -143,59 +199,223 @@ func (r *ServiceWithHealthchecksReconciler) Reconcile(ctx context.Context, req c
 	} else {
 		serviceWithHC.Status.LoadBalancer = corev1.LoadBalancerStatus{}
 	}
-	newCondition := createStatusConditionForService(errUpdatingSvc, serviceWithHC.Name)
+	// The address of the child Service is observed state, so it is reported here instead of being
+	// written back into the spec of the ServiceWithHealthchecks.
+	serviceWithHC.Status.ClusterIP = childService.Spec.ClusterIP
+	serviceWithHC.Status.ClusterIPs = childService.Spec.ClusterIPs
+
+	// A Service the module does not manage takes precedence: while it is in the way, the address
+	// requested in the spec is not what the reconciliation is stuck on.
+	problem := conflictErr
+	if problem == nil {
+		problem = immutableErr
+	}
+	newCondition := createStatusConditionForService(errUpdatingSvc, problem, serviceWithHC.Name)
 	newCondition.ObservedGeneration = serviceWithHC.Generation
+	serviceWithHC.Status.Conditions = kubernetes.RemoveStatusCondition(serviceWithHC.Status.Conditions, legacyChildServiceConditionType)
 	serviceWithHC.Status.Conditions = kubernetes.UpdateStatusWithCondition(serviceWithHC.Status.Conditions, newCondition)
 
 	kubernetes.SortConditions(serviceWithHC.Status.Conditions)
 	kubernetes.SortConditions(originalServiceWithHC.Status.Conditions)
 
 	if reflect.DeepEqual(originalServiceWithHC.Status, serviceWithHC.Status) {
-		return ctrl.Result{RequeueAfter: resyncPeriod}, nil
+		return result, nil
 	}
 
 	if err := r.Status().Patch(ctx, serviceWithHC, patch); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to update ServiceWithHealthchecks Status: %w", err)
 	}
-	return ctrl.Result{RequeueAfter: resyncPeriod}, nil
+	return result, nil
 }
 
-func createStatusConditionForService(err error, svcName string) metav1.Condition {
-	if err != nil {
+// childServiceProblem is something about the child Service that the controller can not fix by
+// itself and reports through the status instead.
+type childServiceProblem struct {
+	reason  string
+	message string
+}
+
+func (p *childServiceProblem) Error() string { return p.message }
+
+// childServiceConflict reports whether the Service belongs to somebody else. Such a Service is
+// never modified and never claimed: the module keeps publishing EndpointSlices for it, but
+// rewriting the spec of an object another controller owns, or one a user created for their own
+// purpose, would do more damage than the name clash itself.
+func childServiceConflict(service *corev1.Service, shc *networkv1alpha1.ServiceWithHealthchecks) *childServiceProblem {
+	var cause string
+	ref := foreignOwnerReference(service, shc.Name)
+	switch {
+	case ref != nil:
+		cause = fmt.Sprintf("is owned by another resource, %s %q", ref.Kind, ref.Name)
+	// A Service the module did not create is adopted only when it already looks exactly like the
+	// one the module would have created, so that adoption never changes what the Service does.
+	case !metav1.IsControlledBy(service, shc) && !IsSpecForServiceEqual(*service, shc):
+		cause = "already existed and its spec differs from the spec of the ServiceWithHealthchecks"
+	default:
+		return nil
+	}
+	return &childServiceProblem{
+		reason: "ChildServiceConflict",
+		message: fmt.Sprintf("the Service %q %s, so it is not managed by this resource: it is left untouched and no owner "+
+			"reference is set on it. The EndpointSlices are still published for it, so the healthchecks stay in effect. "+
+			"Either delete the Service, or rename the ServiceWithHealthchecks", shc.Name, cause),
+	}
+}
+
+// clusterIPMismatch reports an address requested in the spec that the child Service does not
+// carry. spec.clusterIP is only applied while the Service is being created and is immutable
+// afterwards, so the request can never be fulfilled by an update.
+func clusterIPMismatch(service *corev1.Service, shc *networkv1alpha1.ServiceWithHealthchecks) *childServiceProblem {
+	if shc.Spec.ClusterIP == "" || shc.Spec.ClusterIP == service.Spec.ClusterIP {
+		return nil
+	}
+	return &childServiceProblem{
+		reason: "ChildServiceClusterIPImmutable",
+		message: fmt.Sprintf("the Service %q has the address %q, while the ServiceWithHealthchecks asks for %q. "+
+			"The field is immutable, so the address can only be applied to a newly created Service: delete the Service "+
+			"to have it recreated, or drop spec.clusterIP from the ServiceWithHealthchecks. The current address is "+
+			"reported in status.clusterIP", shc.Name, service.Spec.ClusterIP, shc.Spec.ClusterIP),
+	}
+}
+
+// foreignOwnerReference returns the first owner reference that does not point to the
+// ServiceWithHealthchecks the child Service is built for. The UID is not compared: a reference to
+// the same name is ours even when the parent was recreated and got a new one.
+func foreignOwnerReference(service *corev1.Service, name string) *metav1.OwnerReference {
+	for i := range service.OwnerReferences {
+		ref := &service.OwnerReferences[i]
+		gv, err := schema.ParseGroupVersion(ref.APIVersion)
+		if err != nil ||
+			gv.Group != networkv1alpha1.GroupVersion.Group ||
+			ref.Kind != serviceWithHealthchecksKind ||
+			ref.Name != name {
+			return ref
+		}
+	}
+	return nil
+}
+
+func createStatusConditionForService(err error, problem *childServiceProblem, svcName string) metav1.Condition {
+	switch {
+	case err != nil:
 		return metav1.Condition{
-			Type:               "ChildService",
+			Type:               childServiceConditionType,
 			Status:             metav1.ConditionFalse,
 			Message:            fmt.Sprintf("can't create child Service \"%s\": %s", svcName, err.Error()),
 			Reason:             "ChildServiceWasNotCreated",
 			LastTransitionTime: metav1.Now(),
 		}
-	}
-	return metav1.Condition{
-		Type:               "ChildService",
-		Status:             metav1.ConditionTrue,
-		Message:            "Service was created successfully",
-		Reason:             "ChildServiceWasCreated",
-		LastTransitionTime: metav1.Now(),
+	case problem != nil:
+		return metav1.Condition{
+			Type:               childServiceConditionType,
+			Status:             metav1.ConditionFalse,
+			Message:            problem.message,
+			Reason:             problem.reason,
+			LastTransitionTime: metav1.Now(),
+		}
+	default:
+		return metav1.Condition{
+			Type:               childServiceConditionType,
+			Status:             metav1.ConditionTrue,
+			Message:            "Service was created successfully",
+			Reason:             "ChildServiceWasCreated",
+			LastTransitionTime: metav1.Now(),
+		}
 	}
 }
 
 func IsSpecForServiceEqual(service corev1.Service, shc *networkv1alpha1.ServiceWithHealthchecks) bool {
-	if !slices.Equal(service.Spec.Ports, shc.Spec.Ports) {
+	// The child Service has to stay selectorless: with a selector, the EndpointSlice controller
+	// of kube-controller-manager publishes its own slices for it, next to the ones the agents
+	// write, and kube-proxy load balances over the union of the two — sending traffic to pods
+	// that no healthcheck has ever confirmed.
+	if len(service.Spec.Selector) != 0 {
+		return false
+	}
+	if !slices.Equal(service.Spec.Ports, desiredPorts(service, shc)) {
 		return false
 	}
 	if service.Spec.PublishNotReadyAddresses != shc.Spec.PublishNotReadyAddresses {
 		return false
 	}
-	if service.Spec.Type != shc.Spec.Type {
+	if service.Spec.Type != desiredServiceType(shc) {
 		return false
 	}
-	if service.Spec.ExternalTrafficPolicy != shc.Spec.ExternalTrafficPolicy {
+	if service.Spec.ExternalTrafficPolicy != desiredExternalTrafficPolicy(shc) {
 		return false
 	}
-	if !reflect.DeepEqual(service.Spec.InternalTrafficPolicy, shc.Spec.InternalTrafficPolicy) {
+	if !reflect.DeepEqual(service.Spec.InternalTrafficPolicy, desiredInternalTrafficPolicy(shc)) {
 		return false
 	}
 	return true
+}
+
+// The helpers below answer what the child Service is supposed to look like, not what the parent
+// literally says. The API server fills in the fields the parent leaves out, so comparing the raw
+// values would report a difference that no update can ever settle, and the controller would
+// rewrite the Service on every reconciliation.
+
+// desiredServiceType mirrors the default of the API server for an unset type.
+func desiredServiceType(shc *networkv1alpha1.ServiceWithHealthchecks) corev1.ServiceType {
+	if shc.Spec.Type == "" {
+		return corev1.ServiceTypeClusterIP
+	}
+	return shc.Spec.Type
+}
+
+// desiredInternalTrafficPolicy mirrors the default of the API server, which applies to every type
+// that has a ClusterIP.
+func desiredInternalTrafficPolicy(shc *networkv1alpha1.ServiceWithHealthchecks) *corev1.ServiceInternalTrafficPolicy {
+	if shc.Spec.InternalTrafficPolicy != nil {
+		return shc.Spec.InternalTrafficPolicy
+	}
+	switch desiredServiceType(shc) {
+	case corev1.ServiceTypeClusterIP, corev1.ServiceTypeNodePort, corev1.ServiceTypeLoadBalancer:
+		policy := corev1.ServiceInternalTrafficPolicyCluster
+		return &policy
+	}
+	return nil
+}
+
+// desiredExternalTrafficPolicy mirrors the default of the API server, which only applies to the
+// types that have an externally facing address.
+func desiredExternalTrafficPolicy(shc *networkv1alpha1.ServiceWithHealthchecks) corev1.ServiceExternalTrafficPolicy {
+	if desiredServiceType(shc) != corev1.ServiceTypeLoadBalancer && desiredServiceType(shc) != corev1.ServiceTypeNodePort {
+		return ""
+	}
+	if shc.Spec.ExternalTrafficPolicy != "" {
+		return shc.Spec.ExternalTrafficPolicy
+	}
+	return corev1.ServiceExternalTrafficPolicyCluster
+}
+
+// desiredPorts renders the ports of the parent the way the API server stores them on the child
+// Service: an unset targetPort means the port itself, and a nodePort the parent does not ask for
+// keeps the one already allocated. Sending a zero over an allocated nodePort makes the API server
+// hand out a new one, so the port of a load balancer would move on every reconciliation.
+func desiredPorts(service corev1.Service, shc *networkv1alpha1.ServiceWithHealthchecks) []corev1.ServicePort {
+	allocated := make(map[string]int32, len(service.Spec.Ports))
+	for _, port := range service.Spec.Ports {
+		allocated[portKey(port)] = port.NodePort
+	}
+
+	ports := make([]corev1.ServicePort, 0, len(shc.Spec.Ports))
+	for _, port := range shc.Spec.Ports {
+		if port.TargetPort == (intstr.IntOrString{}) || port.TargetPort == intstr.FromString("") {
+			port.TargetPort = intstr.FromInt32(port.Port)
+		}
+		if port.NodePort == 0 {
+			port.NodePort = allocated[portKey(port)]
+		}
+		ports = append(ports, port)
+	}
+	return ports
+}
+
+// portKey identifies the same port across the parent and the child. A port that changed its
+// number is a different entry, and the API server allocates a new nodePort for it anyway.
+func portKey(port corev1.ServicePort) string {
+	return fmt.Sprintf("%s/%s/%d", port.Name, port.Protocol, port.Port)
 }
 
 // IsMetadataForServiceEqual reports whether the child Service already carries the metadata of the parent.

--- a/ee/modules/610-service-with-healthchecks/images/artifact/internal/controller/controller_test.go
+++ b/ee/modules/610-service-with-healthchecks/images/artifact/internal/controller/controller_test.go
@@ -617,13 +617,12 @@ func TestReconcileDropsLegacyChildServiceCondition(t *testing.T) {
 func TestReconcileRequestsClusterIPFromSpecOnCreate(t *testing.T) {
 	swh := newTestSWH(nil, nil)
 	swh.Spec.ClusterIP = "10.96.0.42"
-	swh.Spec.ClusterIPs = []string{"10.96.0.42"}
 
 	fakeClient := reconcileWith(t, swh)
 
 	service := getChildService(t, fakeClient)
-	if service.Spec.ClusterIP != "10.96.0.42" || !slices.Equal(service.Spec.ClusterIPs, []string{"10.96.0.42"}) {
-		t.Errorf("expected the requested address to reach the child Service, got %q %v", service.Spec.ClusterIP, service.Spec.ClusterIPs)
+	if service.Spec.ClusterIP != "10.96.0.42" {
+		t.Errorf("expected the requested address to reach the child Service, got %q", service.Spec.ClusterIP)
 	}
 	if got := getSWH(t, fakeClient).Status.ClusterIP; got != "10.96.0.42" {
 		t.Errorf("status.clusterIP = %q, want %q", got, "10.96.0.42")
@@ -742,5 +741,52 @@ func TestReconcileKeepsAllocatedNodePort(t *testing.T) {
 	}
 	if service.Spec.Ports[0].NodePort != 31234 {
 		t.Errorf("expected the allocated nodePort to be kept, got %d", service.Spec.Ports[0].NodePort)
+	}
+}
+
+// ServicePort.AppProtocol is a pointer, so a struct comparison looks at its address: two ports
+// carrying the same appProtocol come from different decodes and would never compare equal.
+func TestReconcileLeavesSettledServiceWithAppProtocolUntouched(t *testing.T) {
+	fromParent, fromService := "http", "http"
+
+	swh := newTestSWH(nil, nil)
+	swh.Spec.Ports = []corev1.ServicePort{{Name: "http", Port: 80, AppProtocol: &fromParent}}
+
+	settled := ownedChildService("10.96.0.7")
+	settled.Spec.Ports[0].AppProtocol = &fromService
+
+	fakeClient := reconcileWith(t, swh, settled)
+
+	service := getChildService(t, fakeClient)
+	if service.ResourceVersion != settled.ResourceVersion {
+		t.Errorf("the Service was rewritten although only the appProtocol pointer differed: %q -> %q",
+			settled.ResourceVersion, service.ResourceVersion)
+	}
+	if !IsSpecForServiceEqual(*settled, swh) {
+		t.Error("expected the appProtocol to be compared by value")
+	}
+}
+
+// Only a controller reference means the object belongs to somebody else. A plain owner reference
+// is an extra garbage collection link that anything may add, and it must not cost the module
+// control over its own Service.
+func TestReconcileAdoptsServiceWithPlainOwnerReference(t *testing.T) {
+	swh := newTestSWH(nil, nil)
+	adopted := ownedChildService("10.96.0.7")
+	adopted.OwnerReferences = []metav1.OwnerReference{{
+		APIVersion: "v1",
+		Kind:       "ConfigMap",
+		Name:       "some-bookkeeping",
+		UID:        types.UID("4a5b6c7d-8e9f-4a0b-9c1d-2e3f4a5b6c7d"),
+	}}
+
+	fakeClient := reconcileWith(t, swh, adopted)
+
+	service := getChildService(t, fakeClient)
+	if !metav1.IsControlledBy(service, swh) {
+		t.Errorf("expected the Service to be adopted, got %+v", service.OwnerReferences)
+	}
+	if condition := childServiceCondition(t, fakeClient); condition.Status != metav1.ConditionTrue {
+		t.Errorf("expected no conflict, got %s/%s: %s", condition.Status, condition.Reason, condition.Message)
 	}
 }

--- a/ee/modules/610-service-with-healthchecks/images/artifact/internal/controller/controller_test.go
+++ b/ee/modules/610-service-with-healthchecks/images/artifact/internal/controller/controller_test.go
@@ -7,6 +7,7 @@ package controller
 
 import (
 	"context"
+	"slices"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -14,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -28,6 +30,7 @@ const (
 	testNamespace = "test-namespace"
 	lbIPsKey      = "network.deckhouse.io/load-balancer-ips"
 	sharedIPKey   = "network.deckhouse.io/load-balancer-shared-ip-key"
+	testSWHUID    = types.UID("8f2b1c9e-7d3a-4f60-9a11-0c5e6d7b8a90")
 )
 
 func newTestScheme(t *testing.T) *runtime.Scheme {
@@ -50,6 +53,7 @@ func newTestSWH(annotations, labels map[string]string) *networkv1alpha1.ServiceW
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        testName,
 			Namespace:   testNamespace,
+			UID:         testSWHUID,
 			Annotations: annotations,
 			Labels:      labels,
 		},
@@ -64,6 +68,12 @@ func newTestSWH(annotations, labels map[string]string) *networkv1alpha1.ServiceW
 
 func reconcileWith(t *testing.T, objects ...client.Object) client.Client {
 	t.Helper()
+	c, _ := reconcileReturning(t, objects...)
+	return c
+}
+
+func reconcileReturning(t *testing.T, objects ...client.Object) (client.Client, ctrl.Result) {
+	t.Helper()
 	scheme := newTestScheme(t)
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -77,12 +87,79 @@ func reconcileWith(t *testing.T, objects ...client.Object) client.Client {
 		Logger: log.NewNop(),
 	}
 
-	if _, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+	result, err := reconciler.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: testName, Namespace: testNamespace},
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatalf("reconcile failed: %v", err)
 	}
-	return fakeClient
+	return fakeClient, result
+}
+
+func getSWH(t *testing.T, c client.Client) *networkv1alpha1.ServiceWithHealthchecks {
+	t.Helper()
+	swh := &networkv1alpha1.ServiceWithHealthchecks{}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: testName, Namespace: testNamespace}, swh); err != nil {
+		t.Fatalf("failed to get ServiceWithHealthchecks: %v", err)
+	}
+	return swh
+}
+
+// apiServerDefaults fills in what the API server writes into a Service on create. The fake client
+// applies no defaulting, so a fixture standing for an existing Service has to spell it out, or the
+// controller would rightfully see a spec that differs from the one it maintains.
+func apiServerDefaults(service *corev1.Service) *corev1.Service {
+	if service.Spec.Type == "" {
+		service.Spec.Type = corev1.ServiceTypeClusterIP
+	}
+	if service.Spec.InternalTrafficPolicy == nil {
+		policy := corev1.ServiceInternalTrafficPolicyCluster
+		service.Spec.InternalTrafficPolicy = &policy
+	}
+	if service.Spec.ExternalTrafficPolicy == "" &&
+		(service.Spec.Type == corev1.ServiceTypeLoadBalancer || service.Spec.Type == corev1.ServiceTypeNodePort) {
+		service.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyCluster
+	}
+	for i := range service.Spec.Ports {
+		if service.Spec.Ports[i].TargetPort == (intstr.IntOrString{}) {
+			service.Spec.Ports[i].TargetPort = intstr.FromInt32(service.Spec.Ports[i].Port)
+		}
+	}
+	return service
+}
+
+func ownedChildService(clusterIP string) *corev1.Service {
+	isController := true
+	return apiServerDefaults(&corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: testNamespace,
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: networkv1alpha1.GroupVersion.String(),
+				Kind:       "ServiceWithHealthchecks",
+				Name:       testName,
+				UID:        testSWHUID,
+				Controller: &isController,
+			}},
+		},
+		Spec: corev1.ServiceSpec{
+			Type:      corev1.ServiceTypeLoadBalancer,
+			Ports:     []corev1.ServicePort{{Name: "http", Port: 80}},
+			ClusterIP: clusterIP,
+		},
+	})
+}
+
+func childServiceCondition(t *testing.T, c client.Client) metav1.Condition {
+	t.Helper()
+	swh := getSWH(t, c)
+	for _, condition := range swh.Status.Conditions {
+		if condition.Type == childServiceConditionType {
+			return condition
+		}
+	}
+	t.Fatalf("no ChildService condition found, got %+v", swh.Status.Conditions)
+	return metav1.Condition{}
 }
 
 func getChildService(t *testing.T, c client.Client) *corev1.Service {
@@ -130,7 +207,7 @@ func TestReconcilePropagatesAnnotationsAndLabelsOnCreate(t *testing.T) {
 
 func TestReconcileUpdatesAnnotationsOfExistingService(t *testing.T) {
 	swh := newTestSWH(map[string]string{lbIPsKey: "185.11.73.234"}, nil)
-	existingService := &corev1.Service{
+	existingService := apiServerDefaults(&corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testName,
 			Namespace: testNamespace,
@@ -142,7 +219,7 @@ func TestReconcileUpdatesAnnotationsOfExistingService(t *testing.T) {
 			Type:  corev1.ServiceTypeLoadBalancer,
 			Ports: []corev1.ServicePort{{Name: "http", Port: 80}},
 		},
-	}
+	})
 
 	service := getChildService(t, reconcileWith(t, swh, existingService))
 
@@ -156,7 +233,7 @@ func TestReconcileUpdatesAnnotationsOfExistingService(t *testing.T) {
 
 func TestReconcileRemovesStalePropagatedKeys(t *testing.T) {
 	swh := newTestSWH(map[string]string{lbIPsKey: "185.11.73.234"}, nil)
-	existingService := &corev1.Service{
+	existingService := apiServerDefaults(&corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testName,
 			Namespace: testNamespace,
@@ -171,7 +248,7 @@ func TestReconcileRemovesStalePropagatedKeys(t *testing.T) {
 			Type:  corev1.ServiceTypeLoadBalancer,
 			Ports: []corev1.ServicePort{{Name: "http", Port: 80}},
 		},
-	}
+	})
 
 	service := getChildService(t, reconcileWith(t, swh, existingService))
 
@@ -282,5 +359,388 @@ func TestReconcileKeepsRequeueingItself(t *testing.T) {
 		if result.RequeueAfter != resyncPeriod {
 			t.Errorf("%s reconcile: RequeueAfter = %v, want %v", pass, result.RequeueAfter, resyncPeriod)
 		}
+	}
+}
+
+// The child Service is the only thing tying the module's objects to the parent for the garbage
+// collector, so the reference has to survive whatever state the Service is found in.
+func TestReconcileSetsOwnerReferenceOnCreate(t *testing.T) {
+	service := getChildService(t, reconcileWith(t, newTestSWH(nil, nil)))
+
+	ref := metav1.GetControllerOf(service)
+	if ref == nil {
+		t.Fatalf("expected a controller reference, got %+v", service.OwnerReferences)
+	}
+	if ref.Kind != "ServiceWithHealthchecks" || ref.UID != testSWHUID {
+		t.Errorf("expected the owner to be the parent ServiceWithHealthchecks, got %s %s", ref.Kind, ref.UID)
+	}
+	// OwnerReferencesPermissionEnforcement would demand access to the parent's finalizers
+	// subresource otherwise, and nothing here relies on a foreground deletion.
+	if ref.BlockOwnerDeletion != nil && *ref.BlockOwnerDeletion {
+		t.Error("expected blockOwnerDeletion not to be set")
+	}
+}
+
+// A Service created before the owner reference was introduced matches the desired spec, so it
+// used to take the shortcut in Reconcile and stayed without an owner forever.
+func TestReconcileAdoptsServiceWithoutOwnerReference(t *testing.T) {
+	swh := newTestSWH(nil, nil)
+	orphan := apiServerDefaults(&corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: testNamespace,
+		},
+		Spec: corev1.ServiceSpec{
+			Type:  corev1.ServiceTypeLoadBalancer,
+			Ports: []corev1.ServicePort{{Name: "http", Port: 80}},
+		},
+	})
+
+	service := getChildService(t, reconcileWith(t, swh, orphan))
+
+	if !metav1.IsControlledBy(service, swh) {
+		t.Errorf("expected the existing Service to be adopted, got %+v", service.OwnerReferences)
+	}
+}
+
+// A parent recreated under the same name gets a new UID, and a reference to the old one would
+// make the garbage collector drop the Service right after it was written.
+func TestReconcileReplacesStaleOwnerReference(t *testing.T) {
+	swh := newTestSWH(nil, nil)
+	isController := true
+	stale := apiServerDefaults(&corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: testNamespace,
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: networkv1alpha1.GroupVersion.String(),
+				Kind:       "ServiceWithHealthchecks",
+				Name:       testName,
+				UID:        types.UID("00000000-0000-0000-0000-000000000000"),
+				Controller: &isController,
+			}},
+		},
+		Spec: corev1.ServiceSpec{
+			Type:  corev1.ServiceTypeLoadBalancer,
+			Ports: []corev1.ServicePort{{Name: "http", Port: 80}},
+		},
+	})
+
+	service := getChildService(t, reconcileWith(t, swh, stale))
+
+	if !metav1.IsControlledBy(service, swh) {
+		t.Errorf("expected the stale owner reference to be replaced, got %+v", service.OwnerReferences)
+	}
+}
+
+// A selector on the child Service makes the EndpointSlice controller of kube-controller-manager
+// publish a second set of slices for it, so a selector added by hand — or left on a Service the
+// module adopted — has to be cleared even when the rest of the spec already matches.
+func TestReconcileClearsSelectorOfAdoptedService(t *testing.T) {
+	swh := newTestSWH(nil, nil)
+	isController := true
+	adopted := apiServerDefaults(&corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: testNamespace,
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: networkv1alpha1.GroupVersion.String(),
+				Kind:       "ServiceWithHealthchecks",
+				Name:       testName,
+				UID:        testSWHUID,
+				Controller: &isController,
+			}},
+		},
+		Spec: corev1.ServiceSpec{
+			Type:     corev1.ServiceTypeLoadBalancer,
+			Ports:    []corev1.ServicePort{{Name: "http", Port: 80}},
+			Selector: map[string]string{"app": "backend"},
+		},
+	})
+
+	service := getChildService(t, reconcileWith(t, swh, adopted))
+
+	if len(service.Spec.Selector) != 0 {
+		t.Errorf("expected the selector to be cleared, got %v", service.Spec.Selector)
+	}
+}
+
+// A Service owned by another controller is never touched and never claimed: rewriting the spec of
+// somebody else's object would do more damage than the name clash itself.
+func TestReconcileReportsConflictForForeignOwnedService(t *testing.T) {
+	isController := true
+	foreign := apiServerDefaults(&corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: testNamespace,
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       "backend",
+				UID:        types.UID("2c4e5f60-1a2b-4c3d-8e9f-0a1b2c3d4e5f"),
+				Controller: &isController,
+			}},
+		},
+		Spec: corev1.ServiceSpec{
+			Type:     corev1.ServiceTypeLoadBalancer,
+			Ports:    []corev1.ServicePort{{Name: "http", Port: 80}},
+			Selector: map[string]string{"app": "backend"},
+		},
+	})
+
+	fakeClient, result := reconcileReturning(t, newTestSWH(nil, nil), foreign)
+
+	service := getChildService(t, fakeClient)
+	if len(service.Spec.Selector) == 0 {
+		t.Error("expected the Service of another controller to be left untouched")
+	}
+	if len(service.OwnerReferences) != 1 || service.OwnerReferences[0].Kind != "Deployment" {
+		t.Errorf("expected no owner reference to be added, got %+v", service.OwnerReferences)
+	}
+
+	condition := childServiceCondition(t, fakeClient)
+	if condition.Status != metav1.ConditionFalse || condition.Reason != "ChildServiceConflict" {
+		t.Errorf("expected a ChildServiceConflict condition, got %s/%s", condition.Status, condition.Reason)
+	}
+	// Shorter than the plain resync: a Service the module does not own raises no event, so the
+	// clash being resolved is only ever noticed on a timer.
+	if result.RequeueAfter != childServiceConflictRetry {
+		t.Errorf("expected the conflict to be re-checked in %v, got %v", childServiceConflictRetry, result.RequeueAfter)
+	}
+}
+
+// A Service nobody owns is adopted only when it already matches the desired spec; one that
+// differs belongs to whoever created it.
+func TestReconcileReportsConflictForDivergingService(t *testing.T) {
+	diverging := apiServerDefaults(&corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: testNamespace,
+		},
+		Spec: corev1.ServiceSpec{
+			Type:     corev1.ServiceTypeClusterIP,
+			Ports:    []corev1.ServicePort{{Name: "grpc", Port: 9000}},
+			Selector: map[string]string{"app": "backend"},
+		},
+	})
+
+	fakeClient, result := reconcileReturning(t, newTestSWH(nil, nil), diverging)
+
+	service := getChildService(t, fakeClient)
+	if service.Spec.Type != corev1.ServiceTypeClusterIP || len(service.Spec.Selector) == 0 ||
+		!slices.Equal(service.Spec.Ports, diverging.Spec.Ports) {
+		t.Errorf("expected the diverging Service to be left untouched, got %+v", service.Spec)
+	}
+	if len(service.OwnerReferences) != 0 {
+		t.Errorf("expected no owner reference to be added, got %+v", service.OwnerReferences)
+	}
+
+	condition := childServiceCondition(t, fakeClient)
+	if condition.Status != metav1.ConditionFalse || condition.Reason != "ChildServiceConflict" {
+		t.Errorf("expected a ChildServiceConflict condition, got %s/%s", condition.Status, condition.Reason)
+	}
+	// Shorter than the plain resync: a Service the module does not own raises no event, so the
+	// clash being resolved is only ever noticed on a timer.
+	if result.RequeueAfter != childServiceConflictRetry {
+		t.Errorf("expected the conflict to be re-checked in %v, got %v", childServiceConflictRetry, result.RequeueAfter)
+	}
+}
+
+// The clash is resolvable: once the Service matches again, the module takes it over and the
+// condition recovers.
+func TestReconcileRecoversAfterConflictIsResolved(t *testing.T) {
+	fakeClient := reconcileWith(t, newTestSWH(nil, nil), apiServerDefaults(&corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: testNamespace,
+		},
+		Spec: corev1.ServiceSpec{
+			Type:     corev1.ServiceTypeLoadBalancer,
+			Ports:    []corev1.ServicePort{{Name: "http", Port: 80}},
+			Selector: map[string]string{"app": "backend"},
+		},
+	}))
+	if condition := childServiceCondition(t, fakeClient); condition.Reason != "ChildServiceConflict" {
+		t.Fatalf("expected the conflict to be reported first, got %s", condition.Reason)
+	}
+
+	service := getChildService(t, fakeClient)
+	service.Spec.Selector = nil
+	if err := fakeClient.Update(context.Background(), service); err != nil {
+		t.Fatalf("failed to drop the selector: %v", err)
+	}
+
+	reconciler := &ServiceWithHealthchecksReconciler{Client: fakeClient, Scheme: newTestScheme(t), Logger: log.NewNop()}
+	if _, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: testName, Namespace: testNamespace},
+	}); err != nil {
+		t.Fatalf("reconcile failed: %v", err)
+	}
+
+	if condition := childServiceCondition(t, fakeClient); condition.Status != metav1.ConditionTrue {
+		t.Errorf("expected the condition to recover, got %s/%s", condition.Status, condition.Reason)
+	}
+	if !metav1.IsControlledBy(getChildService(t, fakeClient), newTestSWH(nil, nil)) {
+		t.Error("expected the Service to be adopted once it matched again")
+	}
+}
+
+// The condition was renamed, so a copy under the old name is dropped instead of staying in the
+// status of a resource reconciled by an earlier version.
+func TestReconcileDropsLegacyChildServiceCondition(t *testing.T) {
+	swh := newTestSWH(nil, nil)
+	swh.Status.Conditions = []metav1.Condition{{
+		Type:               legacyChildServiceConditionType,
+		Status:             metav1.ConditionTrue,
+		Reason:             "ChildServiceWasCreated",
+		Message:            "Service was created successfully",
+		LastTransitionTime: metav1.Now(),
+	}}
+
+	fakeClient := reconcileWith(t, swh)
+
+	updated := &networkv1alpha1.ServiceWithHealthchecks{}
+	if err := fakeClient.Get(context.Background(), types.NamespacedName{Name: testName, Namespace: testNamespace}, updated); err != nil {
+		t.Fatalf("failed to get ServiceWithHealthchecks: %v", err)
+	}
+	for _, condition := range updated.Status.Conditions {
+		if condition.Type == legacyChildServiceConditionType {
+			t.Errorf("expected the legacy condition to be dropped, got %+v", updated.Status.Conditions)
+		}
+	}
+	if condition := childServiceCondition(t, fakeClient); condition.Status != metav1.ConditionTrue {
+		t.Errorf("expected the renamed condition to be reported, got %s/%s", condition.Status, condition.Reason)
+	}
+}
+
+// An address asked for in the spec is only applicable while the Service is being created.
+func TestReconcileRequestsClusterIPFromSpecOnCreate(t *testing.T) {
+	swh := newTestSWH(nil, nil)
+	swh.Spec.ClusterIP = "10.96.0.42"
+	swh.Spec.ClusterIPs = []string{"10.96.0.42"}
+
+	fakeClient := reconcileWith(t, swh)
+
+	service := getChildService(t, fakeClient)
+	if service.Spec.ClusterIP != "10.96.0.42" || !slices.Equal(service.Spec.ClusterIPs, []string{"10.96.0.42"}) {
+		t.Errorf("expected the requested address to reach the child Service, got %q %v", service.Spec.ClusterIP, service.Spec.ClusterIPs)
+	}
+	if got := getSWH(t, fakeClient).Status.ClusterIP; got != "10.96.0.42" {
+		t.Errorf("status.clusterIP = %q, want %q", got, "10.96.0.42")
+	}
+	if condition := childServiceCondition(t, fakeClient); condition.Status != metav1.ConditionTrue {
+		t.Errorf("expected a healthy condition, got %s/%s", condition.Status, condition.Reason)
+	}
+}
+
+// An address allocated by the cluster is reported in the status, and never written into the spec
+// of the ServiceWithHealthchecks.
+func TestReconcileReportsAllocatedClusterIP(t *testing.T) {
+	swh := newTestSWH(nil, nil)
+
+	fakeClient := reconcileWith(t, swh, ownedChildService("10.96.0.7"))
+
+	if got := getChildService(t, fakeClient).Spec.ClusterIP; got != "10.96.0.7" {
+		t.Errorf("expected the allocated address to be kept, got %q", got)
+	}
+	updated := getSWH(t, fakeClient)
+	if updated.Status.ClusterIP != "10.96.0.7" {
+		t.Errorf("status.clusterIP = %q, want %q", updated.Status.ClusterIP, "10.96.0.7")
+	}
+	if updated.Spec.ClusterIP != "" {
+		t.Errorf("expected the spec to be left alone, got %q", updated.Spec.ClusterIP)
+	}
+}
+
+// The field is immutable, so a request that no longer matches the Service is reported instead of
+// being retried forever.
+func TestReconcileReportsClusterIPMismatch(t *testing.T) {
+	swh := newTestSWH(nil, nil)
+	swh.Spec.ClusterIP = "10.96.0.42"
+
+	fakeClient := reconcileWith(t, swh, ownedChildService("10.96.0.7"))
+
+	if got := getChildService(t, fakeClient).Spec.ClusterIP; got != "10.96.0.7" {
+		t.Errorf("expected the address of the Service to be left alone, got %q", got)
+	}
+	condition := childServiceCondition(t, fakeClient)
+	if condition.Status != metav1.ConditionFalse || condition.Reason != "ChildServiceClusterIPImmutable" {
+		t.Errorf("expected a ChildServiceClusterIPImmutable condition, got %s/%s", condition.Status, condition.Reason)
+	}
+	if got := getSWH(t, fakeClient).Status.ClusterIP; got != "10.96.0.7" {
+		t.Errorf("expected the status to report the actual address, got %q", got)
+	}
+}
+
+// A Service that belongs to somebody else is the more pressing problem of the two.
+func TestReconcileReportsConflictBeforeClusterIPMismatch(t *testing.T) {
+	swh := newTestSWH(nil, nil)
+	swh.Spec.ClusterIP = "10.96.0.42"
+	foreign := ownedChildService("10.96.0.7")
+	foreign.OwnerReferences[0].APIVersion = "apps/v1"
+	foreign.OwnerReferences[0].Kind = "Deployment"
+	foreign.OwnerReferences[0].Name = "backend"
+
+	fakeClient := reconcileWith(t, swh, foreign)
+
+	if condition := childServiceCondition(t, fakeClient); condition.Reason != "ChildServiceConflict" {
+		t.Errorf("expected the conflict to be reported, got %s", condition.Reason)
+	}
+}
+
+// The API server fills in the fields the parent leaves out. Comparing the literal values would
+// report a difference that no update can ever settle.
+func TestIsSpecForServiceEqualAcceptsAPIServerDefaults(t *testing.T) {
+	swh := newTestSWH(nil, nil)
+	swh.Spec.Type = ""
+	swh.Spec.InternalTrafficPolicy = nil
+	swh.Spec.ExternalTrafficPolicy = ""
+	swh.Spec.Ports = []corev1.ServicePort{{Name: "http", Port: 80}}
+
+	service := apiServerDefaults(&corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: testName, Namespace: testNamespace},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{{Name: "http", Port: 80}},
+		},
+	})
+
+	if !IsSpecForServiceEqual(*service, swh) {
+		t.Errorf("expected the defaulted Service to match the spec of the parent, got %+v", service.Spec)
+	}
+}
+
+// Every reconciliation used to rewrite the Service, and every write came back as an event that
+// started the next one.
+func TestReconcileLeavesSettledServiceUntouched(t *testing.T) {
+	settled := ownedChildService("10.96.0.7")
+
+	fakeClient := reconcileWith(t, newTestSWH(nil, nil), settled)
+
+	service := getChildService(t, fakeClient)
+	if service.ResourceVersion != settled.ResourceVersion {
+		t.Errorf("the Service was rewritten although it already matched: %q -> %q, spec %+v",
+			settled.ResourceVersion, service.ResourceVersion, service.Spec)
+	}
+}
+
+// A nodePort is allocated by the API server. Sending a zero over it makes the API server hand out
+// a new one, so the port of a load balancer would move on every reconciliation.
+func TestReconcileKeepsAllocatedNodePort(t *testing.T) {
+	swh := newTestSWH(nil, nil)
+	swh.Spec.Type = corev1.ServiceTypeLoadBalancer
+
+	allocated := ownedChildService("10.96.0.7")
+	allocated.Spec.Ports[0].NodePort = 31234
+	// something the controller has to fix, so that the update path is taken at all
+	allocated.Spec.Selector = map[string]string{"app": "backend"}
+
+	fakeClient := reconcileWith(t, swh, allocated)
+
+	service := getChildService(t, fakeClient)
+	if len(service.Spec.Selector) != 0 {
+		t.Fatalf("expected the selector to be cleared, got %v", service.Spec.Selector)
+	}
+	if service.Spec.Ports[0].NodePort != 31234 {
+		t.Errorf("expected the allocated nodePort to be kept, got %d", service.Spec.Ports[0].NodePort)
 	}
 }

--- a/ee/modules/610-service-with-healthchecks/images/artifact/internal/kubernetes/helper.go
+++ b/ee/modules/610-service-with-healthchecks/images/artifact/internal/kubernetes/helper.go
@@ -6,6 +6,7 @@ Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https
 package kubernetes
 
 import (
+	"slices"
 	"sort"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,6 +32,14 @@ func UpdateStatusWithCondition(existingConditions []metav1.Condition, newConditi
 		}
 	}
 	return append(existingConditions, newCondition)
+}
+
+// RemoveStatusCondition drops a condition that is no longer reported, so that a stale copy left
+// by an earlier version of the controller does not stay in the status forever.
+func RemoveStatusCondition(conditions []metav1.Condition, conditionType string) []metav1.Condition {
+	return slices.DeleteFunc(conditions, func(condition metav1.Condition) bool {
+		return condition.Type == conditionType
+	})
 }
 
 func UpdateStatusWithConditions(existingConditions []metav1.Condition, newConditions []metav1.Condition) []metav1.Condition {


### PR DESCRIPTION
## Description
* Owner reference added to child EndpointSlices and to the child Service.
  * existing objects are adopted in place, without being recreated
  * `blockOwnerDeletion` is deliberately not set, so no access to the
    `servicewithhealthchecks/finalizers` subresource is required
  * deleting a SWH now collects the child Service and the EndpointSlices of every node
* The child Service was never re-checked for its owner reference: one created before the
  reference was introduced kept running without it forever. The owner is now part of the
  desired state.
* Child Service adoption reworked, new condition `ChildServiceReady`:
  * a Service controlled by another resource, or a pre-existing one whose spec differs, is
    left untouched — not rewritten, not adopted, no owner reference set
  * the clash is reported as `ChildServiceConflict` and re-checked on a timer, so the
    resource recovers on its own once the Service is removed or aligned
  * while the conflict lasts the agents publish no EndpointSlices under that name and
    withdraw the ones they published earlier, otherwise kube-proxy would balance over the
    union of our endpoints and the endpoints of the foreign Service
  * addresses of a foreign Service are no longer reported in the status
* A selector left on the child Service is now cleared. With a selector,
  kube-controller-manager publishes its own EndpointSlices next to the ones the agents
  write, and kube-proxy balances over both sets.
* `SWH.spec.clusterIP` support:
  * this setting is being transferred to child Service on creation if set, including
    `None` (headless), which used to be ignored
  * actual clusterIP from child Service is being transferred to `SWH.status.clusterIP`
    and `SWH.status.clusterIPs`, and is never written back into the spec
  * an address that can no longer be applied is reported as
    `ChildServiceClusterIPImmutable` instead of being retried forever
  * new `CLUSTER-IP` printer column
* The child Service was rewritten on every reconciliation, because its spec was compared
  before the API server filled it in. Fixed for:
  * `SWH.spec.type` — `ClusterIP` default in CRD
  * `SWH.spec.internalTrafficPolicy` — `Cluster` default in CRD
  * `externalTrafficPolicy` — consider `Cluster` as default for external Services
    (NodePort and LoadBalancer), empty for the rest
  * `targetPort` is equal `port` if not set
  * `nodePort` — the allocated one is kept. It used to be reset to 0, so the API server
    handed out a new one and the node port of a load balancer moved on every sync.
  * ports are compared semantically: `appProtocol` is a pointer and was compared by address

**Breaking:** the status condition `ChildService` is renamed to `ChildServiceReady`. The old
one is removed from the status on the first reconciliation after the update.


## Why do we need it, and what problem does it solve?
It is potential problem with uncontrolled endpointslices left after SWH deletion.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: service-with-healthchecks
type: chore
summary: EndpointSlices reconciliation improvements.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
