### PR TITLE
[docs] Fix the visibility of the table header

### DIFF
--- a/docs/site/_sass/components/_table-supported.scss
+++ b/docs/site/_sass/components/_table-supported.scss
@@ -148,10 +148,9 @@
     transition: margin-top .15s ease;
 
     &.sticky {
-        padding: 9px;
+        padding: 0 9px;
         margin: -10px;
         overflow: hidden;
-        transform: translateY(-10px);
         background: none;
     }
 }

--- a/docs/site/assets/js/table-sticky.js
+++ b/docs/site/assets/js/table-sticky.js
@@ -243,6 +243,17 @@ class StickyHeaderTable {
     this.tableElement.addEventListener('disabledStickiness.stickyThead', () => this.disableStickiness());
 
     this.tableContainer.addEventListener('scroll', () => this.syncScroll(this.tableContainer, this.tableHeaderCopy));
+
+    window.addEventListener('scroll', () => this.updateStickyVisibility());
+  }
+
+  updateStickyVisibility() {
+    if (!this.isSticky || !this.tableHeaderCopy) return;
+
+    const tableBottom = this.tableElement.getBoundingClientRect().bottom;
+    const stickyHeaderBottom = this.TopOffset + this.tableHeaderCopy.offsetHeight;
+
+    this.tableHeaderCopy.style.visibility = tableBottom <= stickyHeaderBottom ? 'hidden' : '';
   }
 
   initStickyThead(evt = 'default') {
@@ -255,6 +266,7 @@ class StickyHeaderTable {
       cachedHeaderHeight: true,
     });
     this.syncHeadersWidth();
+    this.updateStickyVisibility();
   }
 
   syncHeadersWidth(){
@@ -335,7 +347,10 @@ class StickyHeaderTable {
         this.waitForHeaderCopyReady(this.tableHeaderCopy, () => {
           this.tableHeaderCopy.scrollLeft = this.tableContainer.scrollLeft;
           this.tableHeaderCopy.style.visibility = '';
+          this.updateStickyVisibility();
         });
+      } else {
+        this.updateStickyVisibility();
       }
     }
   }
@@ -344,6 +359,7 @@ class StickyHeaderTable {
     this.isSticky = false;
     if (this.tableHeaderCopy) {
       this.tableHeaderCopy.classList.remove('sticky');
+      this.tableHeaderCopy.style.visibility = '';
     }
   }
 }


### PR DESCRIPTION
## Description

This pull request improves the sticky table header behavior on documentation pages, particularly ensuring the sticky header hides when the table is scrolled out of view and refining its appearance. The main changes are grouped into JavaScript logic enhancements and CSS adjustments.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Fix the visibility of the table header.
impact_level: low
```
