### PR TITLE
[user-authz] Create the controller's namespace regardless of MultiTenancy

### DIFF
--- a/modules/140-user-authz/template_tests/module_test.go
+++ b/modules/140-user-authz/template_tests/module_test.go
@@ -358,6 +358,31 @@ var _ = Describe("Module :: user-authz :: helm template ::", func() {
 		})
 	})
 
+	Context("Without enabledMultiTenancy", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global.enabledModules", `["operator-prometheus", "operator-prometheus-crd"]`)
+			f.HelmRender()
+		})
+
+		// user-authz-controller is rendered whether or not MultiTenancy is on, so the objects
+		// it needs — the namespace it lives in and the secret it pulls its image with — have
+		// to be unconditional as well. While they were gated, the release could not converge:
+		// server-side apply rejected the controller with `namespaces "d8-user-authz" not found`.
+		It("Should create the namespace and registry secret the controller needs", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			Expect(f.KubernetesGlobalResource("Namespace", "d8-user-authz").Exists()).To(BeTrue())
+			Expect(f.KubernetesResource("Secret", "d8-user-authz", "deckhouse-registry").Exists()).To(BeTrue())
+			Expect(f.KubernetesResource("Deployment", "d8-user-authz", "user-authz-controller").Exists()).To(BeTrue())
+			Expect(f.KubernetesResource("PodDisruptionBudget", "d8-user-authz", "user-authz-controller").Exists()).To(BeTrue())
+		})
+
+		It("Should not mirror the multitenancy state, so the webhook reads it as disabled", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+			Expect(f.KubernetesResource("ConfigMap", "d8-user-authz", "d8-user-authz-multitenancy-state").Exists()).To(BeFalse())
+		})
+	})
+
 	Context("Namespace access permissions based on edition", func() {
 		Context("EE edition (non-CE)", func() {
 			BeforeEach(func() {

--- a/modules/140-user-authz/templates/namespace.yaml
+++ b/modules/140-user-authz/templates/namespace.yaml
@@ -4,23 +4,28 @@ prometheus.deckhouse.io/rules-watcher-enabled: "true"
 security.deckhouse.io/pod-policy: "restricted"
 security.deckhouse.io/enable-security-policy-check: "true"
 {{- end }}
-{{- if .Values.userAuthz.enableMultiTenancy }}
 ---
+# Unconditional: the namespace holds user-authz-controller, which reconciles rule
+# bindings whether or not MultiTenancy is on. Gating it on enableMultiTenancy left the
+# release unable to converge — the controller's Deployment, PDB, ServiceAccount and VPA
+# are rendered unconditionally, and server-side apply refused them with
+# `namespaces "d8-user-authz" not found`.
 apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (fromYaml (include "labels" .))) | nindent 2 }}
+{{- if .Values.userAuthz.enableMultiTenancy }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s"  .Chart.Name)) }}
 ---
 # Mirrors userAuthz.enableMultiTenancy (already merged with the edition's config-schema
 # default) into a real Kubernetes object: the multitenancy.py validating webhook cannot
-# read module Values directly, only Kubernetes objects. Rendering it in the same block as
-# the namespace above means it only exists — and only ever needs to say "true" — exactly
-# when MultiTenancy is effectively enabled; its absence is read by the webhook as
-# "disabled", and it's created/removed atomically with the rest of this namespace, in the
-# same Helm apply, with no separate hook or bootstrap ordering to get wrong.
+# read module Values directly, only Kubernetes objects. Rendering it under this gate
+# means it only exists — and only ever needs to say "true" — exactly when MultiTenancy
+# is effectively enabled; its absence is read by the webhook as "disabled", and it's
+# created/removed in the same Helm apply as the rest of the multitenancy objects, with
+# no separate hook or bootstrap ordering to get wrong.
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/modules/140-user-authz/templates/registry-secret.yaml
+++ b/modules/140-user-authz/templates/registry-secret.yaml
@@ -1,5 +1,6 @@
-{{- if .Values.userAuthz.enableMultiTenancy }}
 ---
+# Unconditional, like the namespace: user-authz-controller pulls its image with this
+# secret in its imagePullSecrets, and it runs whether or not MultiTenancy is on.
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,4 +10,3 @@ metadata:
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ .Values.global.modulesImages.registry.dockercfg }}
-{{- end }}

--- a/modules/140-user-authz/webhooks/validating/multitenancy.py
+++ b/modules/140-user-authz/webhooks/validating/multitenancy.py
@@ -24,18 +24,20 @@
 # enableMultiTenancy defaults to true, and when the user has not set it
 # explicitly, the field is simply absent from ModuleConfig.spec.settings.
 #
-# templates/namespace.yaml bridges this gap: it's already gated on
-# `.Values.userAuthz.enableMultiTenancy` — the same defaults-merged value —
-# and it renders a small "d8-user-authz-multitenancy-state" ConfigMap in that
-# same block, alongside the d8-user-authz namespace itself. This hook reads
-# that ConfigMap instead of ModuleConfig or the Module CR.
+# templates/namespace.yaml bridges this gap: it renders a small
+# "d8-user-authz-multitenancy-state" ConfigMap behind a
+# `.Values.userAuthz.enableMultiTenancy` gate — the same defaults-merged
+# value. This hook reads that ConfigMap instead of ModuleConfig or the
+# Module CR.
 #
-# NB: d8-user-authz (and everything rendered in that block, including the
-# ConfigMap) only exists when enableMultiTenancy is true, so the ConfigMap is
-# simply absent when it's false — which is exactly the value we want to
-# assume in that case anyway. is_multitenancy_enabled() below treats "no
-# snapshot" the same as "enableMultiTenancy: false", so this falls out for
-# free, with no separate hook or bootstrap-ordering window to worry about.
+# NB: the ConfigMap is what carries the answer, not the namespace around it.
+# d8-user-authz itself is unconditional — user-authz-controller lives there
+# whether or not MultiTenancy is on — so its existence proves nothing. Only
+# the ConfigMap is gated, and it is simply absent when enableMultiTenancy is
+# false, which is exactly the value we want to assume in that case anyway.
+# is_multitenancy_enabled() below treats "no snapshot" the same as
+# "enableMultiTenancy: false", so this falls out for free, with no separate
+# hook or bootstrap-ordering window to worry about.
 #
 # (Do not go back to reading status.lastAppliedConfiguration from a Module CR
 # here — deckhouse.io/v1alpha2 Module is not a real, served API version for


### PR DESCRIPTION
## Description

`user-authz-controller` (added in #22828 and #22832) is rendered unconditionally, but two objects it depends on were left behind the `userAuthz.enableMultiTenancy` gate:

- `Namespace/d8-user-authz` — the namespace the controller's `Deployment`, `PodDisruptionBudget`, `ServiceAccount` and `VerticalPodAutoscaler` are placed in;
- `Secret/deckhouse-registry` — the pull secret in the controller's `imagePullSecrets`.

Both become unconditional. The gate stays on what genuinely belongs to MultiTenancy: the kube-rbac-proxy CA and the `d8-user-authz-multitenancy-state` ConfigMap, whose absence the `multitenancy.py` validating webhook already reads as "disabled".

## Why do we need it, and what problem does it solve?

With `enableMultiTenancy: false` the `user-authz` release cannot converge. Server-side apply rejects the controller's objects, the module retries indefinitely, and the whole cluster never finishes its first convergence:

```
run helm install: install nelm release "user-authz": failed release "user-authz"
(namespace: "d8-system"): execute release install plan: wait for operations completion:
execute operation: create resource: server-side apply resource
"PodDisruptionBudget/user-authz-controller (namespace=d8-user-authz)":
retryable on webhook error: server-side apply: namespaces "d8-user-authz" not found
```

Observed on a freshly bootstrapped cluster built from `main` (Kubernetes 1.34.11, `enableMultiTenancy: false`), 51 minutes after install:

| | |
| --- | --- |
| `ModuleRun:user-authz` | failed **49** times, requeued every 32 s |
| `main` queue | stuck on `ConvergeModules:main:::Operator-Startup` |
| `deploy/deckhouse` | `0/1` available, container `deckhouse` not ready |
| readiness probe | `HTTP probe failed with statuscode: 500`, ×623 |
| `ns/d8-user-authz` | absent |

Every node was `Ready` and every other module converged — the cluster looks healthy but `deckhouse` never reports `Available`, so anything gated on cluster readiness (CI e2e runs against `main`, for one) fails on that check rather than on its own subject.

Creating the namespace by hand is not enough to recover: without the gated pull secret the controller lands in `ImagePullBackOff`.

## Why do we need it in the patch release (if we do)?

Not necessarily — the affected code is only in `main`.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authz
type: fix
summary: Create the user-authz-controller namespace and registry secret regardless of MultiTenancy, so the module converges with MultiTenancy disabled.
```
