### PR TITLE
[docs] Fix the runtime audit critical-events alert example

### DIFF
--- a/docs/documentation/pages/admin/configuration/security/RUNTIME-AUDIT.md
+++ b/docs/documentation/pages/admin/configuration/security/RUNTIME-AUDIT.md
@@ -281,7 +281,7 @@ spec:
               Check your events journal for more details.
             summary: Falco detected a critical security incident.
           expr: |
-            sum by (node) (rate(falcosecurity_falcosidekick_falco_events_total{priority="Critical"}[5m]) > 0)
+            sum by (node) (rate(falcosecurity_falcosidekick_falco_events_total{priority_raw="critical"}[5m]) > 0)
 ```
 
 {% endraw %}
@@ -294,6 +294,19 @@ To retrieve Prometheus metrics, use the PromQL query `falcosecurity_falcosidekic
 d8 k -n d8-monitoring exec -it prometheus-main-0 prometheus -- \
   curl -s "http://127.0.0.1:9090/api/v1/query?query=falcosecurity_falcosidekick_falco_events_total" | jq
 ```
+
+The event severity is carried by two labels: `priority` holds a numeric value, and `priority_raw` holds the lowercase severity name. Use `priority_raw` to filter events by severity:
+
+| `priority` | `priority_raw` |
+|---|---|
+| `8` | `emergency` |
+| `7` | `alert` |
+| `6` | `critical` |
+| `5` | `error` |
+| `4` | `warning` |
+| `3` | `notice` |
+| `2` | `informational` |
+| `1` | `debug` |
 
 ## Debugging and simulating events
 

--- a/docs/documentation/pages/admin/configuration/security/RUNTIME-AUDIT_RU.md
+++ b/docs/documentation/pages/admin/configuration/security/RUNTIME-AUDIT_RU.md
@@ -285,7 +285,7 @@ spec:
               Check your events journal for more details.
             summary: Falco detected a critical security incident.
           expr: |
-            sum by (node) (rate(falcosecurity_falcosidekick_falco_events_total{priority="Critical"}[5m]) > 0)
+            sum by (node) (rate(falcosecurity_falcosidekick_falco_events_total{priority_raw="critical"}[5m]) > 0)
 ```
 
 {% endraw %}
@@ -298,6 +298,19 @@ spec:
 d8 k -n d8-monitoring exec -it prometheus-main-0 prometheus -- \
   curl -s "http://127.0.0.1:9090/api/v1/query?query=falcosecurity_falcosidekick_falco_events_total" | jq
 ```
+
+Уровень важности события передаётся двумя лейблами: `priority` содержит числовое значение, а `priority_raw` — название уровня строчными буквами. Для фильтрации событий по уровню важности используйте лейбл `priority_raw`:
+
+| `priority` | `priority_raw` |
+|---|---|
+| `8` | `emergency` |
+| `7` | `alert` |
+| `6` | `critical` |
+| `5` | `error` |
+| `4` | `warning` |
+| `3` | `notice` |
+| `2` | `informational` |
+| `1` | `debug` |
 
 ## Отладка и эмуляция событий
 

--- a/docs/site/pages/virtualization-platform/documentation/admin/platform-management/security/RUNTIME-AUDIT.md
+++ b/docs/site/pages/virtualization-platform/documentation/admin/platform-management/security/RUNTIME-AUDIT.md
@@ -278,7 +278,7 @@ spec:
           Check your events journal for more details.
         summary: Falco detected a critical security incident.
       expr: |
-        sum by (node) (rate(falcosecurity_falcosidekick_falco_events_total{priority="Critical"}[5m]) > 0)
+        sum by (node) (rate(falcosecurity_falcosidekick_falco_events_total{priority_raw="critical"}[5m]) > 0)
 ```
 
 {% endraw %}
@@ -291,6 +291,19 @@ To retrieve Prometheus metrics, use the PromQL query `falcosecurity_falcosidekic
 d8 k -n d8-monitoring exec -it prometheus-main-0 prometheus -- \
   curl -s "http://127.0.0.1:9090/api/v1/query?query=falcosecurity_falcosidekick_falco_events_total" | jq
 ```
+
+The event severity is carried by two labels: `priority` holds a numeric value, and `priority_raw` holds the lowercase severity name. Use `priority_raw` to filter events by severity:
+
+| `priority` | `priority_raw` |
+|---|---|
+| `8` | `emergency` |
+| `7` | `alert` |
+| `6` | `critical` |
+| `5` | `error` |
+| `4` | `warning` |
+| `3` | `notice` |
+| `2` | `informational` |
+| `1` | `debug` |
 
 ## Debugging and simulating events
 

--- a/docs/site/pages/virtualization-platform/documentation/admin/platform-management/security/RUNTIME-AUDIT_RU.md
+++ b/docs/site/pages/virtualization-platform/documentation/admin/platform-management/security/RUNTIME-AUDIT_RU.md
@@ -282,7 +282,7 @@ spec:
           Check your events journal for more details.
         summary: Falco detected a critical security incident.
       expr: |
-        sum by (node) (rate(falcosecurity_falcosidekick_falco_events_total{priority="Critical"}[5m]) > 0)
+        sum by (node) (rate(falcosecurity_falcosidekick_falco_events_total{priority_raw="critical"}[5m]) > 0)
 ```
 
 {% endraw %}
@@ -295,6 +295,19 @@ spec:
 d8 k -n d8-monitoring exec -it prometheus-main-0 prometheus -- \
   curl -s "http://127.0.0.1:9090/api/v1/query?query=falcosecurity_falcosidekick_falco_events_total" | jq
 ```
+
+Уровень важности события передаётся двумя лейблами: `priority` содержит числовое значение, а `priority_raw` — название уровня строчными буквами. Для фильтрации событий по уровню важности используйте лейбл `priority_raw`:
+
+| `priority` | `priority_raw` |
+|---|---|
+| `8` | `emergency` |
+| `7` | `alert` |
+| `6` | `critical` |
+| `5` | `error` |
+| `4` | `warning` |
+| `3` | `notice` |
+| `2` | `informational` |
+| `1` | `debug` |
 
 ## Отладка и эмуляция событий
 


### PR DESCRIPTION
## Description

The runtime audit pages document an alert for critical Falco events built on this selector:

```promql
sum by (node) (rate(falcosecurity_falcosidekick_falco_events_total{priority="Critical"}[5m]) > 0)
```

The metric name is correct, but the label schema is not what the example assumes. `priority` carries a numeric severity, and the text name lives in `priority_raw` in lowercase, following falcosidekick's `types.PriorityType` enum (`Default=0`, `Debug=1` … `Emergency=8`).

The example now filters by `priority_raw="critical"`. The "Viewing metrics" section gains the mapping between the two labels — it is the section that introduces the metric, and its `jq` example already refers to `priority_raw`.

Four pages are updated, English and Russian for both products:

- `docs/documentation/pages/admin/configuration/security/RUNTIME-AUDIT.md` and `RUNTIME-AUDIT_RU.md`
- `docs/site/pages/virtualization-platform/documentation/admin/platform-management/security/RUNTIME-AUDIT.md` and `RUNTIME-AUDIT_RU.md`

## Why do we need it, and what problem does it solve?

A selector against a label value that no series carries does not fail — it matches nothing. An alert copied from the documentation is accepted, stays silent, and never reports that anything is wrong. Anyone who followed these pages to get notified about critical runtime events has an alert that cannot fire.

Verified against a live cluster: the metric exports `priority="4"` alongside `priority_raw="warning"`, and the documented selector returns an empty vector.

## Why do we need it in the patch release (if we do)?

Worth backporting. The pages describe a security alert that silently does not work, and the fix is confined to documentation.

## Checklist

- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: fix
summary: Fix the runtime audit alert example for critical events, which matched no metrics.
impact_level: low
```
