### PR TITLE
[registry] Save unmanaged fallback params before switching

### DIFF
--- a/modules/038-registry/hooks/orchestrator/state.go
+++ b/modules/038-registry/hooks/orchestrator/state.go
@@ -516,6 +516,16 @@ func (state *State) transitionToProxy(log go_hook.Logger, inputs Inputs) error {
 	// Registry service
 	state.RegistryService = registryservice.ModeNodeServices
 
+	// Params for fallback to the Legacy Unmanaged mode.
+	// Must be stored before updating the deckhouse-registry secret (next step).
+	state.Bashible.UnmanagedParams = &bashible.UnmanagedModeParams{
+		ImagesRepo: inputs.Params.ImagesRepo,
+		Scheme:     inputs.Params.Scheme,
+		CA:         string(encodeCertificateIfExist(inputs.Params.CA)),
+		Username:   inputs.Params.UserName,
+		Password:   inputs.Params.Password,
+	}
+
 	// Update Deckhouse-registry secret and wait
 	processedRegistrySwitcher, err := state.processRegistrySwitcher(registrySecretParams, inputs)
 	if err != nil {
@@ -556,13 +566,6 @@ func (state *State) transitionToProxy(log go_hook.Logger, inputs Inputs) error {
 
 	// All done
 	state.Mode = state.TargetMode
-	state.Bashible.UnmanagedParams = &bashible.UnmanagedModeParams{
-		ImagesRepo: inputs.Params.ImagesRepo,
-		Scheme:     inputs.Params.Scheme,
-		CA:         string(encodeCertificateIfExist(inputs.Params.CA)),
-		Username:   inputs.Params.UserName,
-		Password:   inputs.Params.Password,
-	}
 	state.setReadyCondition(true, inputs)
 
 	return nil
@@ -668,6 +671,16 @@ func (state *State) transitionToDirect(log go_hook.Logger, inputs Inputs) error 
 	// Registry service
 	state.RegistryService = registryservice.ModeInClusterProxy
 
+	// Params for fallback to the Legacy Unmanaged mode.
+	// Must be stored before updating the deckhouse-registry secret (next step).
+	state.Bashible.UnmanagedParams = &bashible.UnmanagedModeParams{
+		ImagesRepo: inputs.Params.ImagesRepo,
+		Scheme:     inputs.Params.Scheme,
+		CA:         string(encodeCertificateIfExist(inputs.Params.CA)),
+		Username:   inputs.Params.UserName,
+		Password:   inputs.Params.Password,
+	}
+
 	// Update Deckhouse-registry secret and wait
 	processedRegistrySwitcher, err := state.processRegistrySwitcher(registrySecretParams, inputs)
 	if err != nil {
@@ -705,13 +718,6 @@ func (state *State) transitionToDirect(log go_hook.Logger, inputs Inputs) error 
 
 	// All done
 	state.Mode = state.TargetMode
-	state.Bashible.UnmanagedParams = &bashible.UnmanagedModeParams{
-		ImagesRepo: inputs.Params.ImagesRepo,
-		Scheme:     inputs.Params.Scheme,
-		CA:         string(encodeCertificateIfExist(inputs.Params.CA)),
-		Username:   inputs.Params.UserName,
-		Password:   inputs.Params.Password,
-	}
 	state.setReadyCondition(true, inputs)
 
 	return nil
@@ -776,6 +782,16 @@ func (state *State) transitionToConfigurableUnmanaged(inputs Inputs) error {
 		return nil
 	}
 
+	// Params for fallback to the Legacy Unmanaged mode.
+	// Must be stored before updating the deckhouse-registry secret (next step).
+	state.Bashible.UnmanagedParams = &bashible.UnmanagedModeParams{
+		ImagesRepo: inputs.Params.ImagesRepo,
+		Scheme:     inputs.Params.Scheme,
+		CA:         string(encodeCertificateIfExist(inputs.Params.CA)),
+		Username:   inputs.Params.UserName,
+		Password:   inputs.Params.Password,
+	}
+
 	// Update Deckhouse-registry secret and wait
 	processedRegistrySwitcher, err := state.processRegistrySwitcher(registrySecretParams, inputs)
 	if err != nil {
@@ -822,13 +838,6 @@ func (state *State) transitionToConfigurableUnmanaged(inputs Inputs) error {
 
 	// All done
 	state.Mode = state.TargetMode
-	state.Bashible.UnmanagedParams = &bashible.UnmanagedModeParams{
-		ImagesRepo: inputs.Params.ImagesRepo,
-		Scheme:     inputs.Params.Scheme,
-		CA:         string(encodeCertificateIfExist(inputs.Params.CA)),
-		Username:   inputs.Params.UserName,
-		Password:   inputs.Params.Password,
-	}
 	state.setReadyCondition(true, inputs)
 
 	return nil


### PR DESCRIPTION
## Description

Fixes the order in which the Unmanaged params are stored, so that the fallback to the Legacy mode uses the right registry.

## Why do we need it, and what problem does it solve?

The params were stored after the deckhouse-registry secret had already been updated, so an interrupted transition left them pointing at the previous wrong registry.

## Why do we need it in the patch release (if we do)?

The params were stored after the deckhouse-registry secret had already been updated, so an interrupted transition left them pointing at the previous wrong registry.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: registry
type: fix
summary: Fix the order in which the Unmanaged params are stored for the fallback to the Legacy mode.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
