### PR TITLE
[cloud-provider-zvirt] Resize the boot disk of a recreated VM

### DIFF
--- a/ee/se-plus/modules/030-cloud-provider-zvirt/candi/terraform-modules/master-node/main.tf
+++ b/ee/se-plus/modules/030-cloud-provider-zvirt/candi/terraform-modules/master-node/main.tf
@@ -56,7 +56,11 @@ resource "ovirt_disk_resize" "master_boot_disk_resize" {
   size    = local.master_root_disk_size
 
   lifecycle {
-    ignore_changes = [disk_id]
+    # The disk is chosen when the VM is cloned, at the one moment nothing else is
+    # attached to it, and frozen here so that a volume attached later cannot take its
+    # place. It is chosen again only when there is a new VM to choose it from.
+    ignore_changes       = [disk_id]
+    replace_triggered_by = [ovirt_vm.master_vm]
   }
 }
 
@@ -81,6 +85,11 @@ resource "ovirt_disk_attachment" "master-kubernetes-data-attachment" {
   bootable       = false
   active         = true
 
+  # Attach the etcd disk only once the boot disk has been resized: the attachments data
+  # source is read on the way there, and it must see the disk the VM was cloned with as
+  # the only one.
+  depends_on = [ovirt_disk_resize.master_boot_disk_resize]
+
   lifecycle {
     ignore_changes = [disk_interface]
   }
@@ -88,8 +97,14 @@ resource "ovirt_disk_attachment" "master-kubernetes-data-attachment" {
 
 resource "ovirt_vm_start" "master_vm" {
   vm_id      = ovirt_vm.master_vm.id
-  #stop_behavior = "stop"
-  force_stop = true
+  # Power the VM off rather than asking the guest to shut itself down. Deckhouse holds
+  # a block inhibitor on handle-power-key and routes the key through a flow meant for a
+  # node still in the cluster, so an ACPI request from the engine is never acted on and
+  # the destroy waits for a machine that will not go down. Every other cloud provider
+  # ends a VM through its API the same way, and by this point the node has already been
+  # drained and taken out of etcd.
+  stop_behavior = "stop"
+  force_stop    = true
 
   depends_on = [ovirt_nic.master_vm_nic, ovirt_disk.master-kubernetes-data, ovirt_disk_attachment.master-kubernetes-data-attachment, ovirt_disk_resize.master_boot_disk_resize]
 }

--- a/ee/se-plus/modules/030-cloud-provider-zvirt/candi/terraform-modules/static-node/main.tf
+++ b/ee/se-plus/modules/030-cloud-provider-zvirt/candi/terraform-modules/static-node/main.tf
@@ -56,7 +56,11 @@ resource "ovirt_disk_resize" "node_boot_disk_resize" {
   size    = local.root_disk_size
 
   lifecycle {
-    ignore_changes = [disk_id]
+    # The disk is chosen when the VM is cloned, at the one moment nothing else is
+    # attached to it, and frozen here so that a volume attached later cannot take its
+    # place. It is chosen again only when there is a new VM to choose it from.
+    ignore_changes       = [disk_id]
+    replace_triggered_by = [ovirt_vm.node_vm]
   }
 }
 
@@ -68,8 +72,14 @@ resource "ovirt_nic" "node_vm_nic" {
 
 resource "ovirt_vm_start" "node_vm" {
   vm_id      = ovirt_vm.node_vm.id
-  #stop_behavior = "stop"
-  force_stop = true
+  # Power the VM off rather than asking the guest to shut itself down. Deckhouse holds
+  # a block inhibitor on handle-power-key and routes the key through a flow meant for a
+  # node still in the cluster, so an ACPI request from the engine is never acted on and
+  # the destroy waits for a machine that will not go down. Every other cloud provider
+  # ends a VM through its API the same way, and by this point the node has already been
+  # drained and taken out of etcd.
+  stop_behavior = "stop"
+  force_stop    = true
 
   depends_on = [ovirt_nic.node_vm_nic, ovirt_disk_resize.node_boot_disk_resize]
 }

--- a/ee/se-plus/modules/030-cloud-provider-zvirt/images/terraform-manager/patches/005-disk_resize_not_found.patch
+++ b/ee/se-plus/modules/030-cloud-provider-zvirt/images/terraform-manager/patches/005-disk_resize_not_found.patch
@@ -1,0 +1,29 @@
+Subject: [PATCH] Let go of a disk that no longer exists
+
+diskResizeRead returned a hard error when the disk it was told to read had been
+removed, so a VM replacement left the resource pointing at a disk that is gone and
+every refresh from then on failed. The plan could not be computed at all, which
+blocks apply and destroy along with it, and nothing short of editing the state by
+hand gets out of it.
+
+Every other resource in this provider answers a not-found by clearing the id, and
+resizeDisk in this very file already does. Do the same here, so the next plan
+creates the resource against the disk that exists now.
+
+---
+diff --git a/internal/ovirt/resource_ovirt_disk_resize.go b/internal/ovirt/resource_ovirt_disk_resize.go
+index 1827519..6a26ae2 100644
+--- a/internal/ovirt/resource_ovirt_disk_resize.go
++++ b/internal/ovirt/resource_ovirt_disk_resize.go
+@@ -53,6 +53,11 @@ func (p *provider) diskResizeRead(ctx context.Context, data *schema.ResourceData
+ 	diskID := data.Get("disk_id").(string)
+ 	disk, err := client.GetDisk(ovirtclient.DiskID(diskID))
+ 	if err != nil {
++		if isNotFound(err) {
++			data.SetId("")
++			return nil
++		}
++
+ 		return diag.Diagnostics{
+ 			diag.Diagnostic{
+ 				Severity: diag.Error,

--- a/ee/se-plus/modules/030-cloud-provider-zvirt/images/terraform-manager/patches/006-initialization_nic_forcenew.patch
+++ b/ee/se-plus/modules/030-cloud-provider-zvirt/images/terraform-manager/patches/006-initialization_nic_forcenew.patch
@@ -1,0 +1,79 @@
+Subject: [PATCH] Replace the VM when its NIC configuration changes
+
+initialization_nic carried ForceNew on the block alone, which in the SDK does not
+reach the attributes inside it, and vmUpdate sends only name and comment. Editing
+an address, netmask, gateway or interface name therefore planned as an in-place
+update that reached oVirt as nothing at all: the new value landed in state while
+the VM kept the old one.
+
+The configuration is applied when the VM is created, so every field of it now
+replaces the VM.
+
+---
+diff --git a/internal/ovirt/resource_ovirt_vm.go b/internal/ovirt/resource_ovirt_vm.go
+index a835d94..6eae976 100644
+--- a/internal/ovirt/resource_ovirt_vm.go
++++ b/internal/ovirt/resource_ovirt_vm.go
+@@ -188,24 +188,29 @@ var vmSchema = map[string]*schema.Schema{
+ 				"name": {
+ 					Type:     schema.TypeString,
+ 					Required: true,
++					ForceNew: true,
+ 				},
+ 				"ipv4": {
+ 					Type:     schema.TypeList,
+ 					Required: true,
+ 					MaxItems: 1,
++					ForceNew: true,
+ 					Elem: &schema.Resource{
+ 						Schema: map[string]*schema.Schema{
+ 							"address": {
+ 								Type:     schema.TypeString,
+ 								Optional: true,
++								ForceNew: true,
+ 							},
+ 							"netmask": {
+ 								Type:     schema.TypeString,
+ 								Optional: true,
++								ForceNew: true,
+ 							},
+ 							"gateway": {
+ 								Type:     schema.TypeString,
+ 								Optional: true,
++								ForceNew: true,
+ 							},
+ 						},
+ 					},
+@@ -214,26 +219,31 @@ var vmSchema = map[string]*schema.Schema{
+ 					Type:     schema.TypeList,
+ 					Optional: true,
+ 					MaxItems: 1,
++					ForceNew: true,
+ 					Elem: &schema.Resource{
+ 						Schema: map[string]*schema.Schema{
+ 							"address": {
+ 								Type:     schema.TypeString,
+ 								Optional: true,
++								ForceNew: true,
+ 							},
+ 							"netmask": {
+ 								Type:     schema.TypeString,
+ 								Optional: true,
++								ForceNew: true,
+ 							},
+ 							"gateway": {
+ 								Type:     schema.TypeString,
+ 								Optional: true,
++								ForceNew: true,
+ 							},
+ 						},
+ 					},
+ 				},
+ 			},
+ 		},
+-		Description: "Initial NIC configuration.",
++		Description: "Initial NIC configuration. Applied when the VM is created, so any " +
++			"change to it replaces the VM.",
+ 	},
+ 	"memory": {
+ 		Type:             schema.TypeInt,

--- a/ee/se-plus/modules/030-cloud-provider-zvirt/images/terraform-manager/patches/README.md
+++ b/ee/se-plus/modules/030-cloud-provider-zvirt/images/terraform-manager/patches/README.md
@@ -13,3 +13,19 @@ Bump go.mod dependencies to fix known CVEs.
 ## 004-initialization_dns.patch
 
 add vm.initialization_dns option
+
+## 005-disk_resize_not_found.patch
+
+Let `ovirt_disk_resize` clear its id when the disk it holds has been removed, instead of
+answering the 404 with a hard error that fails every refresh from then on and takes plan,
+apply and destroy with it. Every other resource in the provider already does this, and so
+does `resizeDisk` in the same file.
+
+## 006-initialization_nic_forcenew.patch
+
+Replace the VM on any change to `initialization_nic`. Upstream put `ForceNew` on the
+block only, which in the SDK does not reach the attributes inside it, and `vmUpdate`
+sends only `name` and `comment` — so editing an address, netmask, gateway or interface
+name planned as an in-place update that reached oVirt as nothing at all, leaving state
+claiming a value the VM never got. This is how `customNetworkConfig` is delivered, so
+every field of it now forces a destructive replacement.


### PR DESCRIPTION
## Description

Three fixes for VM replacement on zVirt — triggered by a template change, by `customNetworkConfig`, by anything that makes `ovirt_vm` `ForceNew`.

**The boot disk is not resized.** `ovirt_disk_resize` is pinned to a disk id frozen by `ignore_changes`, which keeps a volume attached later from taking the boot disk's place but also never re-points the resource at the new VM's disk. The node ends up on the template's disk size instead of `rootDiskSizeGb`, and `diskResizeRead` treats the resulting 404 as fatal, so every later refresh fails and converge for that node can no longer plan, apply or destroy. `replace_triggered_by` ties the resize to the lifetime of the VM; the provider now clears the id when its disk is gone, as its other resources already do, so nodes already stuck recover.

**The VM never powers off.** zVirt is the only provider that manages the power state as a resource of its own, and destroying it asked the guest to shut itself down over ACPI. Deckhouse holds a block inhibitor on `handle-power-key`, so the request is never acted on — and dhctl has drained the node and taken it out of etcd by then, so the cluster loses a master. Powering the VM off is what every other provider's API does.

**Edits to `customNetworkConfig` do nothing.** `initialization_nic` carries `ForceNew` on the block alone, which the SDK does not propagate to the attributes inside it, and `vmUpdate` sends only `name` and `comment`. An edited address landed in state while the VM kept the old one. Every field of it now replaces the VM.

## Why do we need it, and what problem does it solve?

Both halves fire on routine operations: changing the OS image in a template, or editing `customNetworkConfig`. On the cluster where this was found, 2 of 8 nodes were already blocked and a third was queued to break on the next converge; recovery without the fix means hand-editing the tofu state secret, or deleting the VM, its state secret and the `Node` object — which on a master also costs the etcd data disk.

An unchanged configuration is unaffected: `replace_triggered_by` fires only when the VM is replaced.

## Why do we need it in the patch release (if we do)?

Yes for any release carrying zVirt: affected nodes cannot converge at all, and the workaround is manual state surgery.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cloud-provider-zvirt
type: fix
summary: Resize the boot disk of a recreated VM, let a replaced VM actually power off, and recreate the VM when customNetworkConfig changes.
impact_level: default
```
