### PR TITLE
[node-manager] Fix GPU dashboard rendering

### DIFF
--- a/ee/modules/040-node-manager/templates/monitoring.yaml
+++ b/ee/modules/040-node-manager/templates/monitoring.yaml
@@ -20,6 +20,14 @@
 
 {{- include "helm_lib_prometheus_rules" (list . "d8-cloud-instance-manager" $prometheusRules) }}
 
-{{- include "helm_lib_grafana_dashboard_definitions" . }}
+{{- if (.Values.global.enabledModules | has "prometheus-crd") }}
+  {{- include "helm_lib_grafana_dashboard_definitions_recursion" (list . "monitoring/grafana-dashboards" "monitoring/grafana-dashboards/kubernetes-cluster") }}
+
+  {{- if not (.Values.global.enabledModules | has "gpu") }}
+    {{- if include "nvidia_gpu_enabled" . }}
+      {{- include "helm_lib_grafana_dashboard_definitions_recursion" (list . "monitoring/grafana-dashboards" "monitoring/grafana-dashboards/nvidia-gpu") }}
+    {{- end }}
+  {{- end }}
+{{- end }}
 
 


### PR DESCRIPTION
## Description

Fixes Grafana dashboard rendering in the `node-manager` module by rendering the `kubernetes-cluster` and `nvidia-gpu` dashboard directories separately.

The `node-controller` dashboard remains available, while legacy NVIDIA GPU dashboards are rendered only when the `gpu` module is not enabled and NVIDIA GPU support is detected.

The change does not restart or otherwise affect critical cluster components.

## Why do we need it, and what problem does it solve?

This fixes a regression introduced by [#20246](https://github.com/deckhouse/deckhouse/pull/20246). The generic recursive dashboard helper rendered all dashboards from the `node-manager` module, including the legacy NVIDIA GPU dashboards, without respecting the existing `gpu` module conditions.

As a result, clusters with the `gpu` module enabled could receive two sets of NVIDIA GPU dashboards with matching Grafana UIDs, causing duplicate dashboard definition alerts. This change restores the previous conditional rendering behavior without disabling the newly added `node-controller` dashboard.

## Why do we need it in the patch release (if we do)?

The fix should be backported to Deckhouse 1.77 because the regression affects clusters using the `gpu` module and can cause duplicate NVIDIA GPU dashboards and corresponding alerts.

## Checklist

- [ ] The code is covered by unit tests. Not applicable: this is a Helm template-only change; targeted Helm rendering scenarios were verified locally.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes. Not applicable: no user-facing configuration or API was changed.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: node-manager
type: fix
summary: Fix duplicate NVIDIA GPU dashboards when the gpu module is enabled.
impact_level: low
```