### PR TITLE
[user-authz] Name the alert groups apart from their member alerts

### DIFF
--- a/modules/140-user-authz/monitoring/prometheus-rules/legacy-rbacv2-custom-roles.yaml
+++ b/modules/140-user-authz/monitoring/prometheus-rules/legacy-rbacv2-custom-roles.yaml
@@ -17,8 +17,8 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_user_authz_legacy_rbacv2_custom_roles: "D8UserAuthzLegacyRBACv2CustomRoleFound,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
-      plk_grouped_by__d8_user_authz_legacy_rbacv2_custom_roles: "D8UserAuthzLegacyRBACv2CustomRoleFound,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+      plk_create_group_if_not_exists__d8_user_authz_legacy_rbacv2_custom_roles: "D8UserAuthzLegacyRBACv2CustomRoles,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+      plk_grouped_by__d8_user_authz_legacy_rbacv2_custom_roles: "D8UserAuthzLegacyRBACv2CustomRoles,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
       summary: A legacy RBACv2 custom role is present in the cluster.
       description: |-
         The ClusterRole `{{ $labels.name }}` is a custom role or capability created with the legacy experimental RBACv2 scheme. Such roles have a `custom:*` name and use either the `rbac.deckhouse.io/kind: manage` or `use` labels, or aggregation selectors based on these labels.

--- a/modules/140-user-authz/monitoring/prometheus-rules/permission-browser-apiserver.yaml
+++ b/modules/140-user-authz/monitoring/prometheus-rules/permission-browser-apiserver.yaml
@@ -22,8 +22,8 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_user_authz_permission_browser_unavailable: "D8UserAuthzPermissionBrowserUnavailable,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
-      plk_grouped_by__d8_user_authz_permission_browser_unavailable: "D8UserAuthzPermissionBrowserUnavailable,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+      plk_create_group_if_not_exists__d8_user_authz_malfunctioning: "D8UserAuthzMalfunctioning,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+      plk_grouped_by__d8_user_authz_malfunctioning: "D8UserAuthzMalfunctioning,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
       summary: Permission Browser API server has unavailable replicas.
       description: |-
         Deckhouse has detected unavailable replicas in the `permission-browser-apiserver` deployment in the `d8-user-authz` namespace.

--- a/modules/140-user-authz/monitoring/prometheus-rules/release-duration.yaml
+++ b/modules/140-user-authz/monitoring/prometheus-rules/release-duration.yaml
@@ -16,8 +16,8 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_user_authz_release_slow: "D8UserAuthzReleaseSlow,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
-      plk_grouped_by__d8_user_authz_release_slow: "D8UserAuthzReleaseSlow,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+      plk_create_group_if_not_exists__d8_user_authz_malfunctioning: "D8UserAuthzMalfunctioning,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+      plk_grouped_by__d8_user_authz_malfunctioning: "D8UserAuthzMalfunctioning,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
       summary: The user-authz module release takes more than 5 minutes.
       description: |-
         Applying the `user-authz` Helm release took more than 5 minutes on average over the last 30 minutes. A release that does not finish within the module release timeout (20 minutes) fails, changes to ClusterAuthorizationRule and AuthorizationRule objects stop being applied and platform updates stall (the `D8DeckhouseCouldNotRunModule` alert fires in that case).
@@ -54,8 +54,8 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_user_authz_render_slow: "D8UserAuthzRenderSlow,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
-      plk_grouped_by__d8_user_authz_render_slow: "D8UserAuthzRenderSlow,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+      plk_create_group_if_not_exists__d8_user_authz_malfunctioning: "D8UserAuthzMalfunctioning,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+      plk_grouped_by__d8_user_authz_malfunctioning: "D8UserAuthzMalfunctioning,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
       summary: Rendering the user-authz module templates takes more than 30 seconds.
       description: |-
         Rendering the templates of the `user-authz` module took more than 30 seconds on average over the last 30 minutes; normally it takes about a second. Render time grows with the number of objects in the release, so this is an early sign that the release is getting too large and may stop fitting into the module release timeout.


### PR DESCRIPTION
## Description

Three `user-authz` alert rules grouped themselves under a group that carried the alert's own name (`plk_create_group_if_not_exists__…: "D8UserAuthzReleaseSlow,…"` on `D8UserAuthzReleaseSlow`, and likewise for `D8UserAuthzRenderSlow`, `D8UserAuthzPermissionBrowserUnavailable` and `D8UserAuthzLegacyRBACv2CustomRoleFound`). The incident shelf refuses such a group:

```
Couldn't create event due to error: Usage of current alert's trigger (D8UserAuthzRenderSlow) is forbidden in grouping to prevent circular dependencies!
```

The group is a virtual alert and has to be named apart from its members, the way `D8DeckhouseMalfunctioning` groups the `deckhouse` module alerts:

- `D8UserAuthzReleaseSlow`, `D8UserAuthzRenderSlow`, `D8UserAuthzPermissionBrowserUnavailable` → `D8UserAuthzMalfunctioning`;
- `D8UserAuthzLegacyRBACv2CustomRoleFound` → `D8UserAuthzLegacyRBACv2CustomRoles`.

Only the grouping annotations change; the expressions, labels, severities and descriptions stay as they are (`docs/documentation/_data/deckhouse-alerts.yml` regenerates without a diff).

## Why do we need it, and what problem does it solve?

With the self-referencing group the shelf cannot create the event for the alert, so a firing `D8UserAuthzRenderSlow` (and the other three) is not delivered.

## Why do we need it in the patch release (if we do)?

Together with the backport of #22824, which introduced two of the four alerts; the other two are already in the release branches.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authz
type: fix
summary: Group the module alerts under a group named apart from the alerts themselves, so the incident shelf accepts them.
```
