### PR TITLE
[dhctl] add support for initializing providers without connection config for API-driven clusters

### DIFF
--- a/dhctl/pkg/server/api/dhctl/bootstrap.proto
+++ b/dhctl/pkg/server/api/dhctl/bootstrap.proto
@@ -48,8 +48,8 @@ message BootstrapStart {
   string state = 7;
   string post_bootstrap_script = 8;
   BootstrapStartOptions options = 9;
-  // kubeconfig points the kube provider straight at the API server. connection_config is still
-  // required: this operation reaches the nodes over ssh.
+  // kubeconfig points the kube provider straight at the API server. connection_config may be
+  // empty: an immutable cluster is installed without ssh, every other one reaches its nodes over it.
   string kubeconfig = 10;
 }
 

--- a/dhctl/pkg/server/api/dhctl/converge.proto
+++ b/dhctl/pkg/server/api/dhctl/converge.proto
@@ -45,8 +45,10 @@ message ConvergeStart {
   string state = 4;
   string approve_destruction_change_id = 5;
   ConvergeStartOptions options = 6;
-  // kubeconfig points the kube provider straight at the API server. connection_config is still
-  // required: this operation reaches the nodes over ssh.
+  // kubeconfig points the kube provider straight at the API server. A request that sets it may
+  // leave connection_config empty: the cluster is then driven over the API server only and no
+  // SSH provider is created. A mutable master NodeGroup is still converged over ssh and needs
+  // connection_config.
   string kubeconfig = 7;
 }
 

--- a/dhctl/pkg/server/pb/dhctl/bootstrap.pb.go
+++ b/dhctl/pkg/server/pb/dhctl/bootstrap.pb.go
@@ -253,8 +253,8 @@ type BootstrapStart struct {
 	State                         string                 `protobuf:"bytes,7,opt,name=state,proto3" json:"state,omitempty"`
 	PostBootstrapScript           string                 `protobuf:"bytes,8,opt,name=post_bootstrap_script,json=postBootstrapScript,proto3" json:"post_bootstrap_script,omitempty"`
 	Options                       *BootstrapStartOptions `protobuf:"bytes,9,opt,name=options,proto3" json:"options,omitempty"`
-	// kubeconfig points the kube provider straight at the API server. connection_config is still
-	// required: this operation reaches the nodes over ssh.
+	// kubeconfig points the kube provider straight at the API server. connection_config may be
+	// empty: an immutable cluster is installed without ssh, every other one reaches its nodes over it.
 	Kubeconfig string `protobuf:"bytes,10,opt,name=kubeconfig,proto3" json:"kubeconfig,omitempty"`
 }
 

--- a/dhctl/pkg/server/pb/dhctl/converge.pb.go
+++ b/dhctl/pkg/server/pb/dhctl/converge.pb.go
@@ -250,8 +250,10 @@ type ConvergeStart struct {
 	State                         string                `protobuf:"bytes,4,opt,name=state,proto3" json:"state,omitempty"`
 	ApproveDestructionChangeId    string                `protobuf:"bytes,5,opt,name=approve_destruction_change_id,json=approveDestructionChangeId,proto3" json:"approve_destruction_change_id,omitempty"`
 	Options                       *ConvergeStartOptions `protobuf:"bytes,6,opt,name=options,proto3" json:"options,omitempty"`
-	// kubeconfig points the kube provider straight at the API server. connection_config is still
-	// required: this operation reaches the nodes over ssh.
+	// kubeconfig points the kube provider straight at the API server. A request that sets it may
+	// leave connection_config empty: the cluster is then driven over the API server only and no
+	// SSH provider is created. A mutable master NodeGroup is still converged over ssh and needs
+	// connection_config.
 	Kubeconfig string `protobuf:"bytes,7,opt,name=kubeconfig,proto3" json:"kubeconfig,omitempty"`
 }
 

--- a/dhctl/pkg/server/pkg/helper/ssh_kube_providers.go
+++ b/dhctl/pkg/server/pkg/helper/ssh_kube_providers.go
@@ -21,6 +21,7 @@ import (
 
 	libcon "github.com/deckhouse/lib-connection/pkg"
 	"github.com/deckhouse/lib-connection/pkg/settings"
+	sshconfig "github.com/deckhouse/lib-connection/pkg/ssh/config"
 	dhlog "github.com/deckhouse/lib-dhctl/pkg/logger"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
@@ -30,8 +31,9 @@ import (
 )
 
 type CreateProvidersOptions struct {
-	allowMissingHostsFromCache bool
-	kubeConfig                 string
+	allowMissingHostsFromCache   bool
+	allowMissingConnectionConfig bool
+	kubeConfig                   string
 }
 
 type CreateProvidersOption func(*CreateProvidersOptions)
@@ -45,6 +47,16 @@ func AllowMissingHostsFromCache() CreateProvidersOption {
 func WithKubeConfig(kubeConfig string) CreateProvidersOption {
 	return func(o *CreateProvidersOptions) {
 		o.kubeConfig = kubeConfig
+	}
+}
+
+// AllowMissingConnectionConfig hands out a hostless, keyless initializer instead of nil when
+// the request carries no connection config. Bootstrap is written against a present initializer:
+// cluster-bootstrapper.go takes its settings and config from it, and an immutable cluster is
+// installed without ssh at all, so the dhctl command line hands it a hostless initializer too.
+func AllowMissingConnectionConfig() CreateProvidersOption {
+	return func(o *CreateProvidersOptions) {
+		o.allowMissingConnectionConfig = true
 	}
 }
 
@@ -92,6 +104,15 @@ func CreateProviders(ctx context.Context, config string, isDebug bool, tmpDir st
 			return nil, nil, cleanuper.AsFunc(), fmt.Errorf("initializing providers: %w", err)
 		}
 	}
+
+	if sshProviderInitializer == nil && options.allowMissingConnectionConfig {
+		// Config must be non-nil: lib-connection dereferences it while cloning the connection.
+		sshProviderInitializer = providerinitializer.NewSSHProviderInitializer(
+			settings.NewBaseProviders(params),
+			&sshconfig.ConnectionConfig{Config: &sshconfig.Config{}},
+		)
+	}
+
 	if sshProviderInitializer != nil {
 		cleanuper.Add(func() error {
 			return sshProviderInitializer.Cleanup(ctx)

--- a/dhctl/pkg/server/pkg/helper/ssh_kube_providers_test.go
+++ b/dhctl/pkg/server/pkg/helper/ssh_kube_providers_test.go
@@ -163,3 +163,18 @@ func TestCreateProvidersKubeConfigWithoutConnectionConfig(t *testing.T) {
 	require.NotNil(t, kubeProvider)
 	require.NoError(t, cleanup())
 }
+
+func TestCreateProvidersAllowMissingConnectionConfig(t *testing.T) {
+	sshProviderInitializer, kubeProvider, cleanup, err := CreateProviders(
+		t.Context(), "", false, t.TempDir(),
+		AllowMissingConnectionConfig(),
+		WithKubeConfig(kubeconfigYAML),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, sshProviderInitializer)
+	require.NotNil(t, sshProviderInitializer.GetSettings())
+	require.NotNil(t, sshProviderInitializer.GetConfig())
+	require.False(t, sshProviderInitializer.CheckHosts(t.Context()))
+	require.NotNil(t, kubeProvider)
+	require.NoError(t, cleanup())
+}

--- a/dhctl/pkg/server/rpc/dhctl/bootstrap.go
+++ b/dhctl/pkg/server/rpc/dhctl/bootstrap.go
@@ -258,15 +258,11 @@ func (s *Service) bootstrap(ctx context.Context, p *bootstrapParams) *pb.Bootstr
 	var sshProviderInitializer *providerinitializer.SSHProviderInitializer
 	var kubeProvider libcon.KubeProvider
 	err = dhlog.RunProcess(ctx, dhlog.FromContext(ctx), "Preparing SSH client", func(ctx context.Context) error {
-		sshProviderInitializer, kubeProvider, cleanup, err = helper.CreateProviders(ctx, p.request.ConnectionConfig, s.params.IsDebug, s.params.TmpDir, helper.AllowMissingHostsFromCache(), helper.WithKubeConfig(p.request.Kubeconfig))
+		sshProviderInitializer, kubeProvider, cleanup, err = helper.CreateProviders(ctx, p.request.ConnectionConfig, s.params.IsDebug, s.params.TmpDir, helper.AllowMissingHostsFromCache(), helper.AllowMissingConnectionConfig(), helper.WithKubeConfig(p.request.Kubeconfig))
 		if err != nil {
 			return fmt.Errorf("preparing providers: %w", err)
 		}
 		cleanuper.Add(cleanup)
-
-		if sshProviderInitializer == nil {
-			return errors.New("connection config is required, bootstrap installs the cluster over ssh")
-		}
 
 		return nil
 	})

--- a/dhctl/pkg/server/rpc/dhctl/converge.go
+++ b/dhctl/pkg/server/rpc/dhctl/converge.go
@@ -319,10 +319,6 @@ func (s *Service) converge(ctx context.Context, p *convergeParams) *pb.ConvergeR
 			return fmt.Errorf("creating provider: %w", err)
 		}
 
-		if sshProviderInitializer == nil {
-			return errors.New("connection config is required, converge reaches the nodes over ssh")
-		}
-
 		return nil
 	})
 


### PR DESCRIPTION
## Description

dhctl-server no longer refuses a Bootstrap or Converge request that carries a kubeconfig but no `connection_config`.

- `helper.CreateProviders` gets a new option, `AllowMissingConnectionConfig()`. When the providers come back with a nil SSH initializer (kubeconfig set, connection config empty), the helper substitutes an initializer with an empty connection config: no hosts, no keys, a non-nil `Config` because lib-connection clones it. This is the same shape the dhctl CLI hands to bootstrap when it runs without ssh flags.
- The Bootstrap RPC passes that option and drops the `connection config is required, bootstrap installs the cluster over ssh` error.
- The Converge RPC drops its twin error and passes the nil initializer through. The converge operation already handles nil: the server runs it in commander mode, so the kube client switcher never touches ssh, and the master node group controller checks for a missing initializer itself and returns a readable error for a mutable master.
- The `kubeconfig` field comments in `bootstrap.proto` and `converge.proto` now say that `connection_config` may be empty. `bootstrap.pb.go` and `converge.pb.go` were regenerated with `make protoc`; only the comments changed.
- A unit test covers the new option.

The change is limited to request handling in dhctl-server. No impact on running components.

What still needs ssh: a cluster with a mutable master. Without a connection config such a bootstrap fails at the first ssh connection, after the base infrastructure and the first master exist, and such a converge stops in the master node group controller, after the base infrastructure step. Both match what the CLI does without ssh flags. Bootstrapping an immutable cluster through dhctl-server end to end is a separate task: the API has no `master_host` field, the server does not set `--kubeconfig-out`, and it always writes a post-bootstrap script file, which the `immutable-post-bootstrap-script` preflight rejects.

## Why do we need it, and what problem does it solve?

Since #22616 `helper.CreateProviders` returns a nil SSH initializer for a kubeconfig-only request. That is right for check, destroy, attach and detach, which treat nil as "no ssh". Bootstrap and converge got a precautionary refusal in the same PR, on the assumption that both always reach the nodes over ssh. The assumption is wrong: an immutable cluster is installed without ssh at all, and the bootstrap operation reads settings and config from the initializer, so it needs a present, hostless one rather than a refusal or a nil. A colleague hit the bootstrap refusal while bootstrapping without an ssh config.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: dhctl
type: fix
summary: dhctl-server accepts Bootstrap and Converge requests with a kubeconfig and an empty connection config instead of refusing them.
impact_level: low
```