### PR TITLE
[deckhouse] Put the package sync of the old module stack under its own feature flag

### DIFF
--- a/deckhouse-controller/internal/app/features.go
+++ b/deckhouse-controller/internal/app/features.go
@@ -19,14 +19,21 @@ import "os"
 // Feature-gate environment variables. Each turns on a block of controllers in
 // pkg/controller when set to the literal "true".
 const (
-	EnvEnablePackageSystem  = "DECKHOUSE_ENABLE_PACKAGE_SYSTEM"
-	EnvEnableModulePackages = "DECKHOUSE_ENABLE_MODULE_PACKAGES"
+	EnvEnablePackageSystem     = "DECKHOUSE_ENABLE_PACKAGE_SYSTEM"
+	EnvEnableModulePackageSync = "DECKHOUSE_ENABLE_MODULE_PACKAGE_SYNC"
+	EnvEnableModulePackages    = "DECKHOUSE_ENABLE_MODULE_PACKAGES"
 )
 
 // PackageSystemEnabled reports whether the package-system controllers
 // (PackageRepository, Application, ApplicationPackageVersion) are enabled.
 func PackageSystemEnabled() bool { return os.Getenv(EnvEnablePackageSystem) == "true" }
 
-// ModulePackagesEnabled reports whether the module-package controllers
-// (ModulePackage, ModulePackageVersion, Module v2) are enabled.
+// ModulePackageSyncEnabled reports whether the module packages of the old
+// module stack are synced into the package system: the startup sync records
+// them as PackageRepository and ModulePackageVersion objects, and the
+// ModulePackageVersion controller completes the drafts it leaves.
+func ModulePackageSyncEnabled() bool { return os.Getenv(EnvEnableModulePackageSync) == "true" }
+
+// ModulePackagesEnabled reports whether the Module v2 controller is enabled.
+// It runs the module packages the sync above records.
 func ModulePackagesEnabled() bool { return os.Getenv(EnvEnableModulePackages) == "true" }

--- a/deckhouse-controller/internal/controller/pkgsync/module_package_test.go
+++ b/deckhouse-controller/internal/controller/pkgsync/module_package_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
 )
 
-func getPackage(t *testing.T, cl client.Client, name string) *v1alpha1.ModulePackage {
+func getModulePackage(t *testing.T, cl client.Client, name string) *v1alpha1.ModulePackage {
 	t.Helper()
 
 	pkg := new(v1alpha1.ModulePackage)
@@ -46,7 +46,7 @@ func TestSyncModulePackages(t *testing.T) {
 		s, cl := newTestSyncer(t, "v1.80.0", dir)
 		require.NoError(t, s.sync(ctx))
 
-		pkg := getPackage(t, cl, "echo")
+		pkg := getModulePackage(t, cl, "echo")
 		assert.Equal(t, map[string]string{"heritage": "deckhouse"}, pkg.Labels)
 		assert.Empty(t, pkg.OwnerReferences, "no owner: no repository offers an embedded package")
 		assert.Empty(t, pkg.Status.AvailableRepositories, "the entry stays empty until a scan fills it")
@@ -69,18 +69,18 @@ func TestSyncModulePackages(t *testing.T) {
 		s, cl := newTestSyncer(t, "v1.80.0", dir, existing)
 		require.NoError(t, s.sync(ctx))
 
-		pkg := getPackage(t, cl, "echo")
+		pkg := getModulePackage(t, cl, "echo")
 		assert.Equal(t, map[string]string{"user": "label"}, pkg.Labels)
 		assert.Equal(t, []string{"deckhouse-modules"}, pkg.Status.AvailableRepositories)
 	})
 
 	t.Run("a release stub creates no package", func(t *testing.T) {
 		s, cl := newTestSyncer(t, "v1.80.0", t.TempDir(),
-			testRelease("parca", "deckhouse", "1.4.3", v1alpha1.ModuleReleasePhaseDeployed),
+			testModuleRelease("parca", "deckhouse", "1.4.3", v1alpha1.ModuleReleasePhaseDeployed),
 		)
 
 		require.NoError(t, s.sync(ctx))
 
-		assert.Empty(t, listModulePackageNames(t, cl), "the repository scan builds the catalog of sourced packages")
+		assert.Empty(t, listModulePackageNamesExceptGlobal(t, cl), "the repository scan builds the catalog of sourced packages")
 	})
 }

--- a/deckhouse-controller/internal/controller/pkgsync/module_package_version.go
+++ b/deckhouse-controller/internal/controller/pkgsync/module_package_version.go
@@ -41,20 +41,20 @@ import (
 // with the disk metadata and schemas, deployed and pending releases become
 // draft stubs.
 func (s *syncer) syncModulePackageVersions(ctx context.Context) error {
-	if err := s.syncVersionsFromImage(ctx); err != nil {
+	if err := s.syncModulePackageVersionsFromImage(ctx); err != nil {
 		return err
 	}
 
-	if err := s.syncGlobalVersion(ctx); err != nil {
+	if err := s.syncGlobalModulePackageVersion(ctx); err != nil {
 		return err
 	}
 
-	return s.syncVersionsFromReleases(ctx)
+	return s.syncModulePackageVersionsFromModuleReleases(ctx)
 }
 
-// syncVersionsFromImage walks the embedded modules dir and ensures a complete
+// syncModulePackageVersionsFromImage walks the embedded modules dir and ensures a complete
 // version for every module the running image ships.
-func (s *syncer) syncVersionsFromImage(ctx context.Context) error {
+func (s *syncer) syncModulePackageVersionsFromImage(ctx context.Context) error {
 	version := app.EmbeddedPackageVersion(s.deckhouseVersion)
 
 	entries, err := os.ReadDir(s.embeddedModulesDir)
@@ -67,7 +67,7 @@ func (s *syncer) syncVersionsFromImage(ctx context.Context) error {
 			continue
 		}
 
-		if err := s.ensureEmbeddedVersion(ctx, entry.Name(), version); err != nil {
+		if err := s.ensureEmbeddedModulePackageVersion(ctx, entry.Name(), version); err != nil {
 			return err
 		}
 	}
@@ -75,10 +75,10 @@ func (s *syncer) syncVersionsFromImage(ctx context.Context) error {
 	return nil
 }
 
-// ensureEmbeddedVersion ensures the complete version of one module shipped in
+// ensureEmbeddedModulePackageVersion ensures the complete version of one module shipped in
 // the image; the metadata and the settings/values schemas come from the
 // module files on disk.
-func (s *syncer) ensureEmbeddedVersion(ctx context.Context, dirName, version string) error {
+func (s *syncer) ensureEmbeddedModulePackageVersion(ctx context.Context, dirName, version string) error {
 	moduleDir := filepath.Join(s.embeddedModulesDir, dirName)
 
 	def, err := loader.LoadEmbeddedDefinition(moduleDir)
@@ -90,7 +90,7 @@ func (s *syncer) ensureEmbeddedVersion(ctx context.Context, dirName, version str
 	}
 
 	name := v1alpha1.MakeModulePackageVersionName(repositoryNameEmbedded, def.Name, version)
-	if !s.validName(name, def.Name) {
+	if !s.validModulePackageVersionName(name, def.Name) {
 		return nil
 	}
 
@@ -124,10 +124,10 @@ func (s *syncer) ensureEmbeddedVersion(ctx context.Context, dirName, version str
 		PackageVersion:        version,
 	}
 
-	return s.ensureFilled(ctx, name, spec, meta, schemas)
+	return s.ensureFilledModulePackageVersion(ctx, name, spec, meta, schemas)
 }
 
-// syncGlobalVersion ensures the complete version of the global module, which
+// syncGlobalModulePackageVersion ensures the complete version of the global module, which
 // the image ships like an embedded one and names the same way.
 //
 // It differs from an embedded module in what disk can tell about it: the global
@@ -139,11 +139,11 @@ func (s *syncer) ensureEmbeddedVersion(ctx context.Context, dirName, version str
 // all: the image always ships them, and the package and the version are what
 // the module controller gates registration on, so withholding them over an
 // unreadable dir would strand the global Module rather than degrade it.
-func (s *syncer) syncGlobalVersion(ctx context.Context) error {
+func (s *syncer) syncGlobalModulePackageVersion(ctx context.Context) error {
 	version := app.EmbeddedPackageVersion(s.deckhouseVersion)
 
 	name := v1alpha1.MakeModulePackageVersionName(repositoryNameEmbedded, packageNameGlobal, version)
-	if !s.validName(name, packageNameGlobal) {
+	if !s.validModulePackageVersionName(name, packageNameGlobal) {
 		return nil
 	}
 
@@ -174,11 +174,11 @@ func (s *syncer) syncGlobalVersion(ctx context.Context) error {
 		PackageVersion:        version,
 	}
 
-	return s.ensureFilled(ctx, name, spec, new(v1alpha1.ModulePackageVersionStatusMetadata), schemas)
+	return s.ensureFilledModulePackageVersion(ctx, name, spec, new(v1alpha1.ModulePackageVersionStatusMetadata), schemas)
 }
 
-// syncVersionsFromReleases ensures a draft stub for every deployed or pending release.
-func (s *syncer) syncVersionsFromReleases(ctx context.Context) error {
+// syncModulePackageVersionsFromModuleReleases ensures a draft stub for every deployed or pending release.
+func (s *syncer) syncModulePackageVersionsFromModuleReleases(ctx context.Context) error {
 	releases := new(v1alpha1.ModuleReleaseList)
 	if err := s.reader.List(ctx, releases); err != nil {
 		return fmt.Errorf("list module releases: %w", err)
@@ -191,12 +191,12 @@ func (s *syncer) syncVersionsFromReleases(ctx context.Context) error {
 			continue
 		}
 
-		name, spec, ok := s.specForRelease(release)
+		name, spec, ok := s.modulePackageVersionSpecForModuleRelease(release)
 		if !ok {
 			continue
 		}
 
-		if err := s.ensureStub(ctx, name, spec); err != nil {
+		if err := s.ensureModulePackageVersionStub(ctx, name, spec); err != nil {
 			return err
 		}
 	}
@@ -204,10 +204,10 @@ func (s *syncer) syncVersionsFromReleases(ctx context.Context) error {
 	return nil
 }
 
-// specForRelease derives the version name and spec from a release. A release
+// modulePackageVersionSpecForModuleRelease derives the version name and spec from a release. A release
 // without a source or with an unparsable version names no package version and
 // is skipped with a warning.
-func (s *syncer) specForRelease(release *v1alpha1.ModuleRelease) (string, v1alpha1.ModulePackageVersionSpec, bool) {
+func (s *syncer) modulePackageVersionSpecForModuleRelease(release *v1alpha1.ModuleRelease) (string, v1alpha1.ModulePackageVersionSpec, bool) {
 	moduleName := release.GetModuleName()
 
 	source := release.GetModuleSource()
@@ -227,10 +227,10 @@ func (s *syncer) specForRelease(release *v1alpha1.ModuleRelease) (string, v1alph
 	}
 
 	version := "v" + parsed.String()
-	repository := RepositoryNameForSource(source)
+	repository := PackageRepositoryNameForModuleSource(source)
 
 	name := v1alpha1.MakeModulePackageVersionName(repository, moduleName, version)
-	if !s.validName(name, moduleName) {
+	if !s.validModulePackageVersionName(name, moduleName) {
 		return "", v1alpha1.ModulePackageVersionSpec{}, false
 	}
 
@@ -241,9 +241,9 @@ func (s *syncer) specForRelease(release *v1alpha1.ModuleRelease) (string, v1alph
 	}, true
 }
 
-// validName reports whether the composed object name is legal, warning when it
+// validModulePackageVersionName reports whether the composed object name is legal, warning when it
 // is not: the spec fields are immutable, so a bad name must never be created.
-func (s *syncer) validName(name, moduleName string) bool {
+func (s *syncer) validModulePackageVersionName(name, moduleName string) bool {
 	if errs := validation.IsDNS1123Subdomain(name); len(errs) > 0 {
 		s.logger.Warn("package version name is not a valid object name, skip it",
 			slog.String("name", name), slog.String("module", moduleName), slog.String("error", errs[0]))
@@ -254,14 +254,14 @@ func (s *syncer) validName(name, moduleName string) bool {
 	return true
 }
 
-// ensureFilled converges the version to the disk content: created if missing,
+// ensureFilledModulePackageVersion converges the version to the disk content: created if missing,
 // the metadata and schemas brought to what the module files hold, no draft
 // label. One version name spans every rebuild of a release, so a complete
 // version whose status drifted from the disk is refreshed in place; a
 // matching one is left untouched. An existing draft, either a stub of an
 // older build or a leftover of an interrupted fill, is completed the same
 // way.
-func (s *syncer) ensureFilled(ctx context.Context, name string, spec v1alpha1.ModulePackageVersionSpec, meta *v1alpha1.ModulePackageVersionStatusMetadata, schemas *v1alpha1.PackageVersionStatusSchemas) error {
+func (s *syncer) ensureFilledModulePackageVersion(ctx context.Context, name string, spec v1alpha1.ModulePackageVersionSpec, meta *v1alpha1.ModulePackageVersionStatusMetadata, schemas *v1alpha1.PackageVersionStatusSchemas) error {
 	mpv := new(v1alpha1.ModulePackageVersion)
 
 	err := s.reader.Get(ctx, client.ObjectKey{Name: name}, mpv)
@@ -272,7 +272,7 @@ func (s *syncer) ensureFilled(ctx context.Context, name string, spec v1alpha1.Mo
 	if apierrors.IsNotFound(err) {
 		// the draft label holds until the metadata lands, so no observer can
 		// take a half-created version for a complete one
-		mpv, err = s.createStub(ctx, name, spec)
+		mpv, err = s.createModulePackageVersionStub(ctx, name, spec)
 		if err != nil {
 			return err
 		}
@@ -284,7 +284,7 @@ func (s *syncer) ensureFilled(ctx context.Context, name string, spec v1alpha1.Mo
 		return nil
 	}
 
-	if err := s.fillMetadata(ctx, mpv, meta, schemas); err != nil {
+	if err := s.fillModulePackageVersionMetadata(ctx, mpv, meta, schemas); err != nil {
 		return err
 	}
 
@@ -294,12 +294,12 @@ func (s *syncer) ensureFilled(ctx context.Context, name string, spec v1alpha1.Mo
 		return nil
 	}
 
-	return s.removeDraft(ctx, mpv)
+	return s.removeModulePackageVersionDraft(ctx, mpv)
 }
 
-// ensureStub makes sure the version exists at least as a draft stub; any
+// ensureModulePackageVersionStub makes sure the version exists at least as a draft stub; any
 // existing object, draft or complete, is left as is.
-func (s *syncer) ensureStub(ctx context.Context, name string, spec v1alpha1.ModulePackageVersionSpec) error {
+func (s *syncer) ensureModulePackageVersionStub(ctx context.Context, name string, spec v1alpha1.ModulePackageVersionSpec) error {
 	err := s.reader.Get(ctx, client.ObjectKey{Name: name}, new(v1alpha1.ModulePackageVersion))
 	if err == nil {
 		return nil
@@ -309,16 +309,16 @@ func (s *syncer) ensureStub(ctx context.Context, name string, spec v1alpha1.Modu
 		return fmt.Errorf("get module package version '%s': %w", name, err)
 	}
 
-	if _, err := s.createStub(ctx, name, spec); err != nil {
+	if _, err := s.createModulePackageVersionStub(ctx, name, spec); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-// createStub creates the version as a draft with the labels the repository
+// createModulePackageVersionStub creates the version as a draft with the labels the repository
 // scan puts on the versions it creates itself.
-func (s *syncer) createStub(ctx context.Context, name string, spec v1alpha1.ModulePackageVersionSpec) (*v1alpha1.ModulePackageVersion, error) {
+func (s *syncer) createModulePackageVersionStub(ctx context.Context, name string, spec v1alpha1.ModulePackageVersionSpec) (*v1alpha1.ModulePackageVersion, error) {
 	mpv := &v1alpha1.ModulePackageVersion{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: v1alpha1.ModulePackageVersionGVK.GroupVersion().String(),
@@ -354,8 +354,8 @@ func (s *syncer) createStub(ctx context.Context, name string, spec v1alpha1.Modu
 	return mpv, nil
 }
 
-// fillMetadata writes the disk-sourced metadata and schemas into the version status.
-func (s *syncer) fillMetadata(ctx context.Context, mpv *v1alpha1.ModulePackageVersion, meta *v1alpha1.ModulePackageVersionStatusMetadata, schemas *v1alpha1.PackageVersionStatusSchemas) error {
+// fillModulePackageVersionMetadata writes the disk-sourced metadata and schemas into the version status.
+func (s *syncer) fillModulePackageVersionMetadata(ctx context.Context, mpv *v1alpha1.ModulePackageVersion, meta *v1alpha1.ModulePackageVersionStatusMetadata, schemas *v1alpha1.PackageVersionStatusSchemas) error {
 	original := mpv.DeepCopy()
 
 	mpv.Status.PackageMetadata = meta
@@ -377,9 +377,9 @@ func (s *syncer) fillMetadata(ctx context.Context, mpv *v1alpha1.ModulePackageVe
 	return nil
 }
 
-// removeDraft completes the version: without the draft label every observer may
+// removeModulePackageVersionDraft completes the version: without the draft label every observer may
 // treat the metadata as final.
-func (s *syncer) removeDraft(ctx context.Context, mpv *v1alpha1.ModulePackageVersion) error {
+func (s *syncer) removeModulePackageVersionDraft(ctx context.Context, mpv *v1alpha1.ModulePackageVersion) error {
 	original := mpv.DeepCopy()
 
 	delete(mpv.Labels, v1alpha1.ModulePackageVersionLabelDraft)

--- a/deckhouse-controller/internal/controller/pkgsync/module_package_version.go
+++ b/deckhouse-controller/internal/controller/pkgsync/module_package_version.go
@@ -284,7 +284,7 @@ func (s *syncer) ensureFilledModulePackageVersion(ctx context.Context, name stri
 		return nil
 	}
 
-	if err := s.fillModulePackageVersionMetadata(ctx, mpv, meta, schemas); err != nil {
+	if err := s.fillModulePackageVersionStatus(ctx, mpv, meta, schemas); err != nil {
 		return err
 	}
 
@@ -354,8 +354,8 @@ func (s *syncer) createModulePackageVersionStub(ctx context.Context, name string
 	return mpv, nil
 }
 
-// fillModulePackageVersionMetadata writes the disk-sourced metadata and schemas into the version status.
-func (s *syncer) fillModulePackageVersionMetadata(ctx context.Context, mpv *v1alpha1.ModulePackageVersion, meta *v1alpha1.ModulePackageVersionStatusMetadata, schemas *v1alpha1.PackageVersionStatusSchemas) error {
+// fillModulePackageVersionStatus writes the disk-sourced metadata and schemas into the version status.
+func (s *syncer) fillModulePackageVersionStatus(ctx context.Context, mpv *v1alpha1.ModulePackageVersion, meta *v1alpha1.ModulePackageVersionStatusMetadata, schemas *v1alpha1.PackageVersionStatusSchemas) error {
 	original := mpv.DeepCopy()
 
 	mpv.Status.PackageMetadata = meta

--- a/deckhouse-controller/internal/controller/pkgsync/module_package_version_test.go
+++ b/deckhouse-controller/internal/controller/pkgsync/module_package_version_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
 )
 
-func TestSyncVersionsFromImage(t *testing.T) {
+func TestSyncModulePackageVersionsFromImage(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("creates a complete version from package.yaml", func(t *testing.T) {
@@ -40,7 +40,7 @@ func TestSyncVersionsFromImage(t *testing.T) {
 		s, cl := newTestSyncer(t, "v1.80.0", dir)
 		require.NoError(t, s.sync(ctx))
 
-		mpv := getVersion(t, cl, "embedded-echo-v1.80.0")
+		mpv := getModulePackageVersion(t, cl, "embedded-echo-v1.80.0")
 		assert.Equal(t, "echo", mpv.Spec.PackageName)
 		assert.Equal(t, "embedded", mpv.Spec.PackageRepositoryName)
 		assert.Equal(t, "v1.80.0", mpv.Spec.PackageVersion)
@@ -71,7 +71,7 @@ func TestSyncVersionsFromImage(t *testing.T) {
 		s, cl := newTestSyncer(t, "v1.80.0", dir)
 		require.NoError(t, s.sync(ctx))
 
-		mpv := getVersion(t, cl, "embedded-echo-v1.80.0")
+		mpv := getModulePackageVersion(t, cl, "embedded-echo-v1.80.0")
 		require.NotNil(t, mpv.Status.PackageSchemas)
 		require.NotNil(t, mpv.Status.PackageSchemas.SettingsSchema)
 		assert.Contains(t, mpv.Status.PackageSchemas.SettingsSchema.OpenAPIV3Schema.Properties, "logLevel")
@@ -87,7 +87,7 @@ func TestSyncVersionsFromImage(t *testing.T) {
 		s, cl := newTestSyncer(t, "v1.80.0", dir)
 		require.NoError(t, s.sync(ctx))
 
-		assert.Empty(t, listModuleVersionNames(t, cl))
+		assert.Empty(t, listModulePackageVersionNamesExceptGlobal(t, cl))
 	})
 
 	t.Run("multi-type schema fields parse", func(t *testing.T) {
@@ -101,7 +101,7 @@ func TestSyncVersionsFromImage(t *testing.T) {
 		s, cl := newTestSyncer(t, "v1.80.0", dir)
 		require.NoError(t, s.sync(ctx))
 
-		mpv := getVersion(t, cl, "embedded-echo-v1.80.0")
+		mpv := getModulePackageVersion(t, cl, "embedded-echo-v1.80.0")
 		require.NotNil(t, mpv.Status.PackageSchemas, "a multi-type field is valid JSON Schema, the version must not be skipped")
 		timeout := mpv.Status.PackageSchemas.SettingsSchema.OpenAPIV3Schema.Properties["timeout"]
 		assert.Equal(t, openapi.StringOrArray{"integer", "string"}, timeout.Type)
@@ -119,7 +119,7 @@ func TestSyncVersionsFromImage(t *testing.T) {
 		s, cl := newTestSyncer(t, "v1.80.0", dir)
 		require.NoError(t, s.sync(ctx))
 
-		mpv := getVersion(t, cl, "embedded-echo-v1.80.0")
+		mpv := getModulePackageVersion(t, cl, "embedded-echo-v1.80.0")
 		require.NotNil(t, mpv.Status.PackageSchemas)
 		rules := mpv.Status.PackageSchemas.SettingsSchema.OpenAPIV3Schema.XValidations
 		require.Len(t, rules, 1)
@@ -135,7 +135,7 @@ func TestSyncVersionsFromImage(t *testing.T) {
 		s, cl := newTestSyncer(t, "v1.80.0", dir)
 		require.NoError(t, s.sync(ctx))
 
-		mpv := getVersion(t, cl, "embedded-echo-v1.80.0")
+		mpv := getModulePackageVersion(t, cl, "embedded-echo-v1.80.0")
 		opts := mpv.Status.PackageMetadata.DisableOptions
 		require.NotNil(t, opts, "the module.yaml disable section must survive")
 		assert.True(t, opts.Confirmation)
@@ -152,7 +152,7 @@ func TestSyncVersionsFromImage(t *testing.T) {
 		s, cl := newTestSyncer(t, "v1.80.0", dir)
 		require.NoError(t, s.sync(ctx))
 
-		mpv := getVersion(t, cl, "embedded-echo-v1.80.0")
+		mpv := getModulePackageVersion(t, cl, "embedded-echo-v1.80.0")
 		require.NotNil(t, mpv.Status.PackageMetadata.Requirements)
 		require.NotNil(t, mpv.Status.PackageMetadata.Requirements.Modules)
 		names := make([]string, 0, 4)
@@ -170,7 +170,7 @@ func TestSyncVersionsFromImage(t *testing.T) {
 		s, cl := newTestSyncer(t, "v1.80.0", dir)
 		require.NoError(t, s.sync(ctx))
 
-		mpv := getVersion(t, cl, "embedded-parca-v1.80.0")
+		mpv := getModulePackageVersion(t, cl, "embedded-parca-v1.80.0")
 		assert.False(t, mpv.IsDraft())
 		require.NotNil(t, mpv.Status.PackageMetadata)
 		assert.Equal(t, "Experimental", mpv.Status.PackageMetadata.Stage)
@@ -184,7 +184,7 @@ func TestSyncVersionsFromImage(t *testing.T) {
 		s, cl := newTestSyncer(t, "v1.78.0-pr22453+1b47ed2", dir)
 		require.NoError(t, s.sync(ctx))
 
-		mpv := getVersion(t, cl, "embedded-echo-v1.78.0")
+		mpv := getModulePackageVersion(t, cl, "embedded-echo-v1.78.0")
 		assert.Equal(t, "v1.78.0", mpv.Spec.PackageVersion, "prerelease and metadata are dropped")
 	})
 
@@ -195,7 +195,7 @@ func TestSyncVersionsFromImage(t *testing.T) {
 		s, cl := newTestSyncer(t, "dev", dir)
 		require.NoError(t, s.sync(ctx))
 
-		mpv := getVersion(t, cl, "embedded-echo-v2.0.0")
+		mpv := getModulePackageVersion(t, cl, "embedded-echo-v2.0.0")
 		assert.Equal(t, "v2.0.0", mpv.Spec.PackageVersion)
 	})
 
@@ -207,7 +207,7 @@ func TestSyncVersionsFromImage(t *testing.T) {
 		require.NoError(t, s.sync(ctx))
 
 		// the bootstrap places the module on the same string, so both sides still agree
-		mpv := getVersion(t, cl, "embedded-echo-latest")
+		mpv := getModulePackageVersion(t, cl, "embedded-echo-latest")
 		assert.Equal(t, "latest", mpv.Spec.PackageVersion)
 	})
 
@@ -218,7 +218,7 @@ func TestSyncVersionsFromImage(t *testing.T) {
 		s, cl := newTestSyncer(t, "Latest_Build", dir)
 		require.NoError(t, s.sync(ctx))
 
-		assert.Empty(t, listVersionNames(t, cl))
+		assert.Empty(t, listModulePackageVersionNames(t, cl))
 	})
 
 	t.Run("skips dummy and unreadable dirs", func(t *testing.T) {
@@ -229,7 +229,7 @@ func TestSyncVersionsFromImage(t *testing.T) {
 		s, cl := newTestSyncer(t, "v1.80.0", dir)
 		require.NoError(t, s.sync(ctx))
 
-		assert.Empty(t, listModuleVersionNames(t, cl))
+		assert.Empty(t, listModulePackageVersionNamesExceptGlobal(t, cl))
 	})
 
 	t.Run("completes an existing draft in place", func(t *testing.T) {
@@ -254,7 +254,7 @@ func TestSyncVersionsFromImage(t *testing.T) {
 		s, cl := newTestSyncer(t, "v1.80.0", dir, stub)
 		require.NoError(t, s.sync(ctx))
 
-		mpv := getVersion(t, cl, stub.Name)
+		mpv := getModulePackageVersion(t, cl, stub.Name)
 		assert.False(t, mpv.IsDraft(), "the leftover draft must be completed")
 		require.NotNil(t, mpv.Status.PackageMetadata)
 		assert.Equal(t, "General Availability", mpv.Status.PackageMetadata.Stage)
@@ -281,7 +281,7 @@ func TestSyncVersionsFromImage(t *testing.T) {
 
 		require.NoError(t, s.sync(ctx))
 
-		after := getVersion(t, cl, existing.Name)
+		after := getModulePackageVersion(t, cl, existing.Name)
 		assert.False(t, after.IsDraft(), "a refresh must not bring the draft label back")
 		assert.Equal(t, "Experimental", after.Status.PackageMetadata.Stage, "the status follows the disk")
 		require.NotNil(t, after.Status.PackageSchemas, "the refresh brings the schemas along")
@@ -295,16 +295,16 @@ func TestSyncVersionsFromImage(t *testing.T) {
 
 		s, cl := newTestSyncer(t, "v1.80.0", dir)
 		require.NoError(t, s.sync(ctx))
-		before := getVersion(t, cl, "embedded-echo-v1.80.0")
+		before := getModulePackageVersion(t, cl, "embedded-echo-v1.80.0")
 
 		require.NoError(t, s.sync(ctx))
 
-		after := getVersion(t, cl, before.Name)
+		after := getModulePackageVersion(t, cl, before.Name)
 		assert.Equal(t, before.ResourceVersion, after.ResourceVersion, "a no-change pass rewrites nothing")
 	})
 }
 
-func TestSyncGlobalVersion(t *testing.T) {
+func TestSyncGlobalModulePackageVersion(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("creates a complete version from the legacy openapi files", func(t *testing.T) {
@@ -316,7 +316,7 @@ func TestSyncGlobalVersion(t *testing.T) {
 		s, cl := newTestSyncerWithGlobal(t, "v1.80.0", t.TempDir(), globalDir)
 		require.NoError(t, s.sync(ctx))
 
-		mpv := getVersion(t, cl, "embedded-global-v1.80.0")
+		mpv := getModulePackageVersion(t, cl, "embedded-global-v1.80.0")
 		assert.Equal(t, "global", mpv.Spec.PackageName)
 		assert.Equal(t, "embedded", mpv.Spec.PackageRepositoryName)
 		assert.Equal(t, "v1.80.0", mpv.Spec.PackageVersion)
@@ -341,7 +341,7 @@ func TestSyncGlobalVersion(t *testing.T) {
 		s, cl := newTestSyncerWithGlobal(t, "v1.80.0", t.TempDir(), globalDir)
 		require.NoError(t, s.sync(ctx))
 
-		mpv := getVersion(t, cl, "embedded-global-v1.80.0")
+		mpv := getModulePackageVersion(t, cl, "embedded-global-v1.80.0")
 		require.NotNil(t, mpv.Status.PackageMetadata, "an empty object, not none: readers reach into it")
 		assert.Equal(t, new(v1alpha1.ModulePackageVersionStatusMetadata), mpv.Status.PackageMetadata,
 			"the global hooks dir holds no definition to fill any of it from")
@@ -354,7 +354,7 @@ func TestSyncGlobalVersion(t *testing.T) {
 		s, cl := newTestSyncerWithGlobal(t, "v1.80.0", t.TempDir(), globalDir)
 		require.NoError(t, s.sync(ctx))
 
-		pkg := getPackage(t, cl, "global")
+		pkg := getModulePackage(t, cl, "global")
 		assert.Equal(t, map[string]string{"heritage": "deckhouse"}, pkg.Labels)
 	})
 
@@ -366,7 +366,7 @@ func TestSyncGlobalVersion(t *testing.T) {
 		s, cl := newTestSyncerWithGlobal(t, "v1.80.0", t.TempDir(), globalDir)
 		require.NoError(t, s.sync(ctx))
 
-		mpv := getVersion(t, cl, "embedded-global-v1.80.0")
+		mpv := getModulePackageVersion(t, cl, "embedded-global-v1.80.0")
 		require.NotNil(t, mpv.Status.PackageSchemas.SettingsSchema)
 		assert.Contains(t, mpv.Status.PackageSchemas.SettingsSchema.OpenAPIV3Schema.Properties, "modern")
 	})
@@ -377,17 +377,17 @@ func TestSyncGlobalVersion(t *testing.T) {
 
 		// the image always ships the schemas; withholding the objects over a dir that
 		// somehow holds none would leave the module controller unable to register global
-		mpv := getVersion(t, cl, "embedded-global-v1.80.0")
+		mpv := getModulePackageVersion(t, cl, "embedded-global-v1.80.0")
 		assert.Nil(t, mpv.Status.PackageSchemas, "no schemas on disk, none in the status")
 		assert.False(t, mpv.IsDraft(), "nothing is left to fill in, so the version is complete")
-		assert.NotEmpty(t, getPackage(t, cl, "global"))
+		assert.NotEmpty(t, getModulePackage(t, cl, "global"))
 	})
 
 	t.Run("a missing global hooks dir still names the package and the version", func(t *testing.T) {
 		s, cl := newTestSyncerWithGlobal(t, "v1.80.0", t.TempDir(), filepath.Join(t.TempDir(), "absent"))
 		require.NoError(t, s.sync(ctx))
 
-		mpv := getVersion(t, cl, "embedded-global-v1.80.0")
+		mpv := getModulePackageVersion(t, cl, "embedded-global-v1.80.0")
 		assert.Nil(t, mpv.Status.PackageSchemas)
 	})
 
@@ -398,8 +398,8 @@ func TestSyncGlobalVersion(t *testing.T) {
 		s, cl := newTestSyncerWithGlobal(t, "v1.80.0", t.TempDir(), globalDir)
 		require.NoError(t, s.sync(ctx))
 
-		assert.Empty(t, listVersionNames(t, cl), "an unparsable schema is a broken image, not an empty one")
-		assert.Empty(t, listPackageNames(t, cl), "no version, no catalog entry either")
+		assert.Empty(t, listModulePackageVersionNames(t, cl), "an unparsable schema is a broken image, not an empty one")
+		assert.Empty(t, listModulePackageNames(t, cl), "no version, no catalog entry either")
 	})
 
 	t.Run("keeps a version matching the disk untouched", func(t *testing.T) {
@@ -408,23 +408,23 @@ func TestSyncGlobalVersion(t *testing.T) {
 
 		s, cl := newTestSyncerWithGlobal(t, "v1.80.0", t.TempDir(), globalDir)
 		require.NoError(t, s.sync(ctx))
-		before := getVersion(t, cl, "embedded-global-v1.80.0")
+		before := getModulePackageVersion(t, cl, "embedded-global-v1.80.0")
 
 		require.NoError(t, s.sync(ctx))
 
-		after := getVersion(t, cl, before.Name)
+		after := getModulePackageVersion(t, cl, before.Name)
 		assert.Equal(t, before.ResourceVersion, after.ResourceVersion, "a no-change pass rewrites nothing")
 	})
 }
 
-func TestSyncVersionsFromReleases(t *testing.T) {
+func TestSyncModulePackageVersionsFromModuleReleases(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("creates a draft stub for deployed and pending releases", func(t *testing.T) {
 		s, cl := newTestSyncer(t, "v1.80.0", t.TempDir(),
-			testRelease("parca", "deckhouse", "1.4.3", v1alpha1.ModuleReleasePhaseDeployed),
-			testRelease("console", "deckhouse", "1.60.1", v1alpha1.ModuleReleasePhasePending),
-			testRelease("foo", "external", "2.0.0", v1alpha1.ModuleReleasePhaseDeployed),
+			testModuleRelease("parca", "deckhouse", "1.4.3", v1alpha1.ModuleReleasePhaseDeployed),
+			testModuleRelease("console", "deckhouse", "1.60.1", v1alpha1.ModuleReleasePhasePending),
+			testModuleRelease("foo", "external", "2.0.0", v1alpha1.ModuleReleasePhaseDeployed),
 		)
 
 		require.NoError(t, s.sync(ctx))
@@ -433,9 +433,9 @@ func TestSyncVersionsFromReleases(t *testing.T) {
 			"deckhouse-modules-parca-v1.4.3",
 			"deckhouse-modules-console-v1.60.1",
 			"external-foo-v2.0.0",
-		}, listModuleVersionNames(t, cl))
+		}, listModulePackageVersionNamesExceptGlobal(t, cl))
 
-		mpv := getVersion(t, cl, "deckhouse-modules-parca-v1.4.3")
+		mpv := getModulePackageVersion(t, cl, "deckhouse-modules-parca-v1.4.3")
 		assert.Equal(t, "parca", mpv.Spec.PackageName)
 		assert.Equal(t, "deckhouse-modules", mpv.Spec.PackageRepositoryName)
 		assert.Equal(t, "v1.4.3", mpv.Spec.PackageVersion)
@@ -450,15 +450,15 @@ func TestSyncVersionsFromReleases(t *testing.T) {
 
 	t.Run("skips what names no version", func(t *testing.T) {
 		s, cl := newTestSyncer(t, "v1.80.0", t.TempDir(),
-			testRelease("parca", "deckhouse", "1.4.2", v1alpha1.ModuleReleasePhaseSuperseded),
-			testRelease("console", "deckhouse", "1.60.1", v1alpha1.ModuleReleasePhaseSuspended),
-			testRelease("orphan", "", "1.0.0", v1alpha1.ModuleReleasePhaseDeployed),
-			testRelease("bad", "deckhouse", "latest", v1alpha1.ModuleReleasePhaseDeployed),
+			testModuleRelease("parca", "deckhouse", "1.4.2", v1alpha1.ModuleReleasePhaseSuperseded),
+			testModuleRelease("console", "deckhouse", "1.60.1", v1alpha1.ModuleReleasePhaseSuspended),
+			testModuleRelease("orphan", "", "1.0.0", v1alpha1.ModuleReleasePhaseDeployed),
+			testModuleRelease("bad", "deckhouse", "latest", v1alpha1.ModuleReleasePhaseDeployed),
 		)
 
 		require.NoError(t, s.sync(ctx))
 
-		assert.Empty(t, listModuleVersionNames(t, cl))
+		assert.Empty(t, listModulePackageVersionNamesExceptGlobal(t, cl))
 	})
 
 	t.Run("keeps an existing version untouched", func(t *testing.T) {
@@ -478,13 +478,13 @@ func TestSyncVersionsFromReleases(t *testing.T) {
 		}
 
 		s, cl := newTestSyncer(t, "v1.80.0", t.TempDir(), existing,
-			testRelease("parca", "deckhouse", "1.4.3", v1alpha1.ModuleReleasePhaseDeployed),
+			testModuleRelease("parca", "deckhouse", "1.4.3", v1alpha1.ModuleReleasePhaseDeployed),
 		)
-		before := getVersion(t, cl, existing.Name)
+		before := getModulePackageVersion(t, cl, existing.Name)
 
 		require.NoError(t, s.sync(ctx))
 
-		after := getVersion(t, cl, existing.Name)
+		after := getModulePackageVersion(t, cl, existing.Name)
 		assert.Equal(t, before.ResourceVersion, after.ResourceVersion)
 		assert.False(t, after.IsDraft(), "a complete version must not become a draft")
 	})

--- a/deckhouse-controller/internal/controller/pkgsync/package_repository.go
+++ b/deckhouse-controller/internal/controller/pkgsync/package_repository.go
@@ -66,7 +66,7 @@ func (s *syncer) syncPackageRepositories(ctx context.Context) error {
 // login, password) are never touched, so user edits to them survive a restart.
 func (s *syncer) ensurePackageRepository(ctx context.Context, source *v1alpha1.ModuleSource) error {
 	name := PackageRepositoryNameForModuleSource(source.Name)
-	desired := registryFromModuleSource(source)
+	desired := packageRepositoryRegistryFromModuleSource(source)
 	owner := moduleSourceOwnerReference(source)
 
 	repo := new(v1alpha1.PackageRepository)
@@ -104,7 +104,7 @@ func (s *syncer) ensurePackageRepository(ctx context.Context, source *v1alpha1.M
 	}
 
 	original := repo.DeepCopy()
-	changed := setModuleSourceOwner(repo, owner)
+	changed := setModuleSourceAsPackageRepositoryOwner(repo, owner)
 
 	current := repo.Spec.Registry
 	current.Login, current.Password = "", ""
@@ -138,11 +138,11 @@ func moduleSourceOwnerReference(source *v1alpha1.ModuleSource) metav1.OwnerRefer
 	}
 }
 
-// setModuleSourceOwner puts the module source among the owners of the repository. A reference to
+// setModuleSourceAsPackageRepositoryOwner puts the module source among the owners of the repository. A reference to
 // a source of the same name but another UID is one to a source deleted and created again: it
 // is replaced, or the garbage collector would take the repository away from the new source.
 // Reports whether anything changed.
-func setModuleSourceOwner(repo *v1alpha1.PackageRepository, owner metav1.OwnerReference) bool {
+func setModuleSourceAsPackageRepositoryOwner(repo *v1alpha1.PackageRepository, owner metav1.OwnerReference) bool {
 	for idx, ref := range repo.OwnerReferences {
 		if ref.Kind != owner.Kind || ref.APIVersion != owner.APIVersion || ref.Name != owner.Name {
 			continue
@@ -162,9 +162,9 @@ func setModuleSourceOwner(repo *v1alpha1.PackageRepository, owner metav1.OwnerRe
 	return true
 }
 
-// registryFromModuleSource maps the source registry block onto the repository shape.
+// packageRepositoryRegistryFromModuleSource maps the source registry block onto the repository shape.
 // Login and password have no source counterpart and stay zero.
-func registryFromModuleSource(source *v1alpha1.ModuleSource) v1alpha1.PackageRepositorySpecRegistry {
+func packageRepositoryRegistryFromModuleSource(source *v1alpha1.ModuleSource) v1alpha1.PackageRepositorySpecRegistry {
 	return v1alpha1.PackageRepositorySpecRegistry{
 		Scheme:    source.Spec.Registry.Scheme,
 		Repo:      source.Spec.Registry.Repo,

--- a/deckhouse-controller/internal/controller/pkgsync/package_repository.go
+++ b/deckhouse-controller/internal/controller/pkgsync/package_repository.go
@@ -58,13 +58,16 @@ func (s *syncer) syncPackageRepositories(ctx context.Context) error {
 
 // ensurePackageRepository converges the repository serving the source registry
 // to the source: created if missing, the registry settings brought to what the
-// source holds. The module source stays the place where users manage the
-// credentials of a source-backed repository while the old stack lives. The
-// fields the source does not carry (scan interval, login, password) are never
-// touched, so user edits to them survive a restart.
+// source holds, the source set as its owner. The module source stays the place
+// where users manage the credentials of a source-backed repository while the old
+// stack lives, and the repository goes with the source: the garbage collector
+// deletes it, and the package-repository controller then drops it from every
+// package it offered. The fields the source does not carry (scan interval,
+// login, password) are never touched, so user edits to them survive a restart.
 func (s *syncer) ensurePackageRepository(ctx context.Context, source *v1alpha1.ModuleSource) error {
 	name := RepositoryNameForSource(source.Name)
 	desired := registryFromSource(source)
+	owner := sourceOwnerReference(source)
 
 	repo := new(v1alpha1.PackageRepository)
 	err := s.reader.Get(ctx, client.ObjectKey{Name: name}, repo)
@@ -79,7 +82,8 @@ func (s *syncer) ensurePackageRepository(ctx context.Context, source *v1alpha1.M
 				Kind:       v1alpha1.PackageRepositoryKind,
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name: name,
+				Name:            name,
+				OwnerReferences: []metav1.OwnerReference{owner},
 			},
 			Spec: v1alpha1.PackageRepositorySpec{Registry: desired},
 		}
@@ -99,24 +103,63 @@ func (s *syncer) ensurePackageRepository(ctx context.Context, source *v1alpha1.M
 		return nil
 	}
 
+	original := repo.DeepCopy()
+	changed := setSourceOwner(repo, owner)
+
 	current := repo.Spec.Registry
 	current.Login, current.Password = "", ""
-	if current == desired {
-		return nil
+	if current != desired {
+		desired.Login = repo.Spec.Registry.Login
+		desired.Password = repo.Spec.Registry.Password
+		repo.Spec.Registry = desired
+		changed = true
 	}
 
-	original := repo.DeepCopy()
-	desired.Login = repo.Spec.Registry.Login
-	desired.Password = repo.Spec.Registry.Password
-	repo.Spec.Registry = desired
+	if !changed {
+		return nil
+	}
 
 	if err := s.writer.Patch(ctx, repo, client.MergeFrom(original)); err != nil {
 		return fmt.Errorf("patch package repository '%s': %w", name, err)
 	}
 
-	s.logger.Debug("package repository registry refreshed from the module source", slog.String("name", name))
+	s.logger.Debug("package repository converged to the module source", slog.String("name", name))
 
 	return nil
+}
+
+// sourceOwnerReference names the module source as the owner of its repository.
+func sourceOwnerReference(source *v1alpha1.ModuleSource) metav1.OwnerReference {
+	return metav1.OwnerReference{
+		APIVersion: v1alpha1.ModuleSourceGVK.GroupVersion().String(),
+		Kind:       v1alpha1.ModuleSourceKind,
+		Name:       source.Name,
+		UID:        source.UID,
+	}
+}
+
+// setSourceOwner puts the module source among the owners of the repository. A reference to
+// a source of the same name but another UID is one to a source deleted and created again: it
+// is replaced, or the garbage collector would take the repository away from the new source.
+// Reports whether anything changed.
+func setSourceOwner(repo *v1alpha1.PackageRepository, owner metav1.OwnerReference) bool {
+	for idx, ref := range repo.OwnerReferences {
+		if ref.Kind != owner.Kind || ref.APIVersion != owner.APIVersion || ref.Name != owner.Name {
+			continue
+		}
+
+		if ref.UID == owner.UID {
+			return false
+		}
+
+		repo.OwnerReferences[idx] = owner
+
+		return true
+	}
+
+	repo.OwnerReferences = append(repo.OwnerReferences, owner)
+
+	return true
 }
 
 // registryFromSource maps the source registry block onto the repository shape.

--- a/deckhouse-controller/internal/controller/pkgsync/package_repository.go
+++ b/deckhouse-controller/internal/controller/pkgsync/package_repository.go
@@ -58,16 +58,15 @@ func (s *syncer) syncPackageRepositories(ctx context.Context) error {
 
 // ensurePackageRepository converges the repository serving the source registry
 // to the source: created if missing, the registry settings brought to what the
-// source holds, the source set as its owner. The module source stays the place
-// where users manage the credentials of a source-backed repository while the old
-// stack lives, and the repository goes with the source: the garbage collector
-// deletes it, and the package-repository controller then drops it from every
-// package it offered. The fields the source does not carry (scan interval,
-// login, password) are never touched, so user edits to them survive a restart.
+// source holds. The module source stays the place where users manage the
+// credentials of a source-backed repository while the old stack lives. The
+// repository is not owned by the source: the sync is a one-off migration, and
+// the repository outlives the source it was made from. The fields the source
+// does not carry (scan interval, login, password) are never touched, so user
+// edits to them survive a restart.
 func (s *syncer) ensurePackageRepository(ctx context.Context, source *v1alpha1.ModuleSource) error {
 	name := PackageRepositoryNameForModuleSource(source.Name)
 	desired := packageRepositoryRegistryFromModuleSource(source)
-	owner := moduleSourceOwnerReference(source)
 
 	repo := new(v1alpha1.PackageRepository)
 	err := s.reader.Get(ctx, client.ObjectKey{Name: name}, repo)
@@ -82,8 +81,7 @@ func (s *syncer) ensurePackageRepository(ctx context.Context, source *v1alpha1.M
 				Kind:       v1alpha1.PackageRepositoryKind,
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            name,
-				OwnerReferences: []metav1.OwnerReference{owner},
+				Name: name,
 			},
 			Spec: v1alpha1.PackageRepositorySpec{Registry: desired},
 		}
@@ -103,63 +101,24 @@ func (s *syncer) ensurePackageRepository(ctx context.Context, source *v1alpha1.M
 		return nil
 	}
 
-	original := repo.DeepCopy()
-	changed := setModuleSourceAsPackageRepositoryOwner(repo, owner)
-
 	current := repo.Spec.Registry
 	current.Login, current.Password = "", ""
-	if current != desired {
-		desired.Login = repo.Spec.Registry.Login
-		desired.Password = repo.Spec.Registry.Password
-		repo.Spec.Registry = desired
-		changed = true
-	}
-
-	if !changed {
+	if current == desired {
 		return nil
 	}
+
+	original := repo.DeepCopy()
+	desired.Login = repo.Spec.Registry.Login
+	desired.Password = repo.Spec.Registry.Password
+	repo.Spec.Registry = desired
 
 	if err := s.writer.Patch(ctx, repo, client.MergeFrom(original)); err != nil {
 		return fmt.Errorf("patch package repository '%s': %w", name, err)
 	}
 
-	s.logger.Debug("package repository converged to the module source", slog.String("name", name))
+	s.logger.Debug("package repository registry refreshed from the module source", slog.String("name", name))
 
 	return nil
-}
-
-// moduleSourceOwnerReference names the module source as the owner of its repository.
-func moduleSourceOwnerReference(source *v1alpha1.ModuleSource) metav1.OwnerReference {
-	return metav1.OwnerReference{
-		APIVersion: v1alpha1.ModuleSourceGVK.GroupVersion().String(),
-		Kind:       v1alpha1.ModuleSourceKind,
-		Name:       source.Name,
-		UID:        source.UID,
-	}
-}
-
-// setModuleSourceAsPackageRepositoryOwner puts the module source among the owners of the repository. A reference to
-// a source of the same name but another UID is one to a source deleted and created again: it
-// is replaced, or the garbage collector would take the repository away from the new source.
-// Reports whether anything changed.
-func setModuleSourceAsPackageRepositoryOwner(repo *v1alpha1.PackageRepository, owner metav1.OwnerReference) bool {
-	for idx, ref := range repo.OwnerReferences {
-		if ref.Kind != owner.Kind || ref.APIVersion != owner.APIVersion || ref.Name != owner.Name {
-			continue
-		}
-
-		if ref.UID == owner.UID {
-			return false
-		}
-
-		repo.OwnerReferences[idx] = owner
-
-		return true
-	}
-
-	repo.OwnerReferences = append(repo.OwnerReferences, owner)
-
-	return true
 }
 
 // packageRepositoryRegistryFromModuleSource maps the source registry block onto the repository shape.

--- a/deckhouse-controller/internal/controller/pkgsync/package_repository.go
+++ b/deckhouse-controller/internal/controller/pkgsync/package_repository.go
@@ -65,9 +65,9 @@ func (s *syncer) syncPackageRepositories(ctx context.Context) error {
 // package it offered. The fields the source does not carry (scan interval,
 // login, password) are never touched, so user edits to them survive a restart.
 func (s *syncer) ensurePackageRepository(ctx context.Context, source *v1alpha1.ModuleSource) error {
-	name := RepositoryNameForSource(source.Name)
-	desired := registryFromSource(source)
-	owner := sourceOwnerReference(source)
+	name := PackageRepositoryNameForModuleSource(source.Name)
+	desired := registryFromModuleSource(source)
+	owner := moduleSourceOwnerReference(source)
 
 	repo := new(v1alpha1.PackageRepository)
 	err := s.reader.Get(ctx, client.ObjectKey{Name: name}, repo)
@@ -104,7 +104,7 @@ func (s *syncer) ensurePackageRepository(ctx context.Context, source *v1alpha1.M
 	}
 
 	original := repo.DeepCopy()
-	changed := setSourceOwner(repo, owner)
+	changed := setModuleSourceOwner(repo, owner)
 
 	current := repo.Spec.Registry
 	current.Login, current.Password = "", ""
@@ -128,8 +128,8 @@ func (s *syncer) ensurePackageRepository(ctx context.Context, source *v1alpha1.M
 	return nil
 }
 
-// sourceOwnerReference names the module source as the owner of its repository.
-func sourceOwnerReference(source *v1alpha1.ModuleSource) metav1.OwnerReference {
+// moduleSourceOwnerReference names the module source as the owner of its repository.
+func moduleSourceOwnerReference(source *v1alpha1.ModuleSource) metav1.OwnerReference {
 	return metav1.OwnerReference{
 		APIVersion: v1alpha1.ModuleSourceGVK.GroupVersion().String(),
 		Kind:       v1alpha1.ModuleSourceKind,
@@ -138,11 +138,11 @@ func sourceOwnerReference(source *v1alpha1.ModuleSource) metav1.OwnerReference {
 	}
 }
 
-// setSourceOwner puts the module source among the owners of the repository. A reference to
+// setModuleSourceOwner puts the module source among the owners of the repository. A reference to
 // a source of the same name but another UID is one to a source deleted and created again: it
 // is replaced, or the garbage collector would take the repository away from the new source.
 // Reports whether anything changed.
-func setSourceOwner(repo *v1alpha1.PackageRepository, owner metav1.OwnerReference) bool {
+func setModuleSourceOwner(repo *v1alpha1.PackageRepository, owner metav1.OwnerReference) bool {
 	for idx, ref := range repo.OwnerReferences {
 		if ref.Kind != owner.Kind || ref.APIVersion != owner.APIVersion || ref.Name != owner.Name {
 			continue
@@ -162,9 +162,9 @@ func setSourceOwner(repo *v1alpha1.PackageRepository, owner metav1.OwnerReferenc
 	return true
 }
 
-// registryFromSource maps the source registry block onto the repository shape.
+// registryFromModuleSource maps the source registry block onto the repository shape.
 // Login and password have no source counterpart and stay zero.
-func registryFromSource(source *v1alpha1.ModuleSource) v1alpha1.PackageRepositorySpecRegistry {
+func registryFromModuleSource(source *v1alpha1.ModuleSource) v1alpha1.PackageRepositorySpecRegistry {
 	return v1alpha1.PackageRepositorySpecRegistry{
 		Scheme:    source.Spec.Registry.Scheme,
 		Repo:      source.Spec.Registry.Repo,

--- a/deckhouse-controller/internal/controller/pkgsync/package_repository_test.go
+++ b/deckhouse-controller/internal/controller/pkgsync/package_repository_test.go
@@ -38,7 +38,7 @@ func TestSyncPackageRepositories(t *testing.T) {
 
 		repo := getPackageRepository(t, cl, "external")
 		assert.NotContains(t, repo.Labels, "heritage", "the repository mirrors a user's module source, it is not deckhouse-owned")
-		assert.Equal(t, []metav1.OwnerReference{moduleSourceOwnerReference(testModuleSource("external", ""))}, repo.OwnerReferences, "the source owns the repository")
+		assert.Empty(t, repo.OwnerReferences, "the repository outlives its source: the sync is a one-off migration")
 		assert.Equal(t, "HTTPS", repo.Spec.Registry.Scheme)
 		assert.Equal(t, "registry.example.io/external", repo.Spec.Registry.Repo)
 		assert.Equal(t, "ZG9ja2VyY2Zn", repo.Spec.Registry.DockerCFG)
@@ -105,29 +105,9 @@ func TestSyncPackageRepositories(t *testing.T) {
 		assert.Equal(t, 30*time.Minute, after.Spec.ScanInterval.Duration, "the scan interval survives")
 	})
 
-	t.Run("adopts an existing repository", func(t *testing.T) {
-		source := testModuleSource("external", "registry.example.io/external")
-		stale := moduleSourceOwnerReference(source)
-		stale.UID = "external-old-uid"
-		existing := &v1alpha1.PackageRepository{
-			ObjectMeta: metav1.ObjectMeta{Name: "external", OwnerReferences: []metav1.OwnerReference{stale}},
-			Spec:       v1alpha1.PackageRepositorySpec{Registry: packageRepositoryRegistryFromModuleSource(source)},
-		}
-
-		s, cl := newTestSyncer(t, "v1.80.0", t.TempDir(), existing, source)
-
-		require.NoError(t, s.sync(ctx))
-
-		after := getPackageRepository(t, cl, existing.Name)
-		assert.Equal(t, []metav1.OwnerReference{moduleSourceOwnerReference(source)}, after.OwnerReferences, "the reference to the source created again is replaced")
-	})
-
 	t.Run("keeps a repository matching the source untouched", func(t *testing.T) {
 		existing := &v1alpha1.PackageRepository{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:            "external",
-				OwnerReferences: []metav1.OwnerReference{moduleSourceOwnerReference(testModuleSource("external", ""))},
-			},
+			ObjectMeta: metav1.ObjectMeta{Name: "external"},
 			Spec: v1alpha1.PackageRepositorySpec{
 				Registry: v1alpha1.PackageRepositorySpecRegistry{
 					Scheme:    "HTTPS",

--- a/deckhouse-controller/internal/controller/pkgsync/package_repository_test.go
+++ b/deckhouse-controller/internal/controller/pkgsync/package_repository_test.go
@@ -38,6 +38,7 @@ func TestSyncPackageRepositories(t *testing.T) {
 
 		repo := getRepository(t, cl, "external")
 		assert.NotContains(t, repo.Labels, "heritage", "the repository mirrors a user's module source, it is not deckhouse-owned")
+		assert.Equal(t, []metav1.OwnerReference{sourceOwnerReference(testModuleSource("external", ""))}, repo.OwnerReferences, "the source owns the repository")
 		assert.Equal(t, "HTTPS", repo.Spec.Registry.Scheme)
 		assert.Equal(t, "registry.example.io/external", repo.Spec.Registry.Repo)
 		assert.Equal(t, "ZG9ja2VyY2Zn", repo.Spec.Registry.DockerCFG)
@@ -104,9 +105,29 @@ func TestSyncPackageRepositories(t *testing.T) {
 		assert.Equal(t, 30*time.Minute, after.Spec.ScanInterval.Duration, "the scan interval survives")
 	})
 
+	t.Run("adopts an existing repository", func(t *testing.T) {
+		source := testModuleSource("external", "registry.example.io/external")
+		stale := sourceOwnerReference(source)
+		stale.UID = "external-old-uid"
+		existing := &v1alpha1.PackageRepository{
+			ObjectMeta: metav1.ObjectMeta{Name: "external", OwnerReferences: []metav1.OwnerReference{stale}},
+			Spec:       v1alpha1.PackageRepositorySpec{Registry: registryFromSource(source)},
+		}
+
+		s, cl := newTestSyncer(t, "v1.80.0", t.TempDir(), existing, source)
+
+		require.NoError(t, s.sync(ctx))
+
+		after := getRepository(t, cl, existing.Name)
+		assert.Equal(t, []metav1.OwnerReference{sourceOwnerReference(source)}, after.OwnerReferences, "the reference to the source created again is replaced")
+	})
+
 	t.Run("keeps a repository matching the source untouched", func(t *testing.T) {
 		existing := &v1alpha1.PackageRepository{
-			ObjectMeta: metav1.ObjectMeta{Name: "external"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "external",
+				OwnerReferences: []metav1.OwnerReference{sourceOwnerReference(testModuleSource("external", ""))},
+			},
 			Spec: v1alpha1.PackageRepositorySpec{
 				Registry: v1alpha1.PackageRepositorySpecRegistry{
 					Scheme:    "HTTPS",

--- a/deckhouse-controller/internal/controller/pkgsync/package_repository_test.go
+++ b/deckhouse-controller/internal/controller/pkgsync/package_repository_test.go
@@ -111,7 +111,7 @@ func TestSyncPackageRepositories(t *testing.T) {
 		stale.UID = "external-old-uid"
 		existing := &v1alpha1.PackageRepository{
 			ObjectMeta: metav1.ObjectMeta{Name: "external", OwnerReferences: []metav1.OwnerReference{stale}},
-			Spec:       v1alpha1.PackageRepositorySpec{Registry: registryFromModuleSource(source)},
+			Spec:       v1alpha1.PackageRepositorySpec{Registry: packageRepositoryRegistryFromModuleSource(source)},
 		}
 
 		s, cl := newTestSyncer(t, "v1.80.0", t.TempDir(), existing, source)

--- a/deckhouse-controller/internal/controller/pkgsync/package_repository_test.go
+++ b/deckhouse-controller/internal/controller/pkgsync/package_repository_test.go
@@ -36,9 +36,9 @@ func TestSyncPackageRepositories(t *testing.T) {
 
 		require.NoError(t, s.sync(ctx))
 
-		repo := getRepository(t, cl, "external")
+		repo := getPackageRepository(t, cl, "external")
 		assert.NotContains(t, repo.Labels, "heritage", "the repository mirrors a user's module source, it is not deckhouse-owned")
-		assert.Equal(t, []metav1.OwnerReference{sourceOwnerReference(testModuleSource("external", ""))}, repo.OwnerReferences, "the source owns the repository")
+		assert.Equal(t, []metav1.OwnerReference{moduleSourceOwnerReference(testModuleSource("external", ""))}, repo.OwnerReferences, "the source owns the repository")
 		assert.Equal(t, "HTTPS", repo.Spec.Registry.Scheme)
 		assert.Equal(t, "registry.example.io/external", repo.Spec.Registry.Repo)
 		assert.Equal(t, "ZG9ja2VyY2Zn", repo.Spec.Registry.DockerCFG)
@@ -56,7 +56,7 @@ func TestSyncPackageRepositories(t *testing.T) {
 
 		require.NoError(t, s.sync(ctx))
 
-		assert.Empty(t, listRepositoryNames(t, cl))
+		assert.Empty(t, listPackageRepositoryNames(t, cl))
 	})
 
 	t.Run("skips a source being deleted", func(t *testing.T) {
@@ -69,7 +69,7 @@ func TestSyncPackageRepositories(t *testing.T) {
 
 		require.NoError(t, s.sync(ctx))
 
-		assert.Empty(t, listRepositoryNames(t, cl))
+		assert.Empty(t, listPackageRepositoryNames(t, cl))
 	})
 
 	t.Run("refreshes the registry of an existing repository from the source", func(t *testing.T) {
@@ -94,7 +94,7 @@ func TestSyncPackageRepositories(t *testing.T) {
 
 		require.NoError(t, s.sync(ctx))
 
-		after := getRepository(t, cl, existing.Name)
+		after := getPackageRepository(t, cl, existing.Name)
 		assert.Equal(t, "registry.example.io/external", after.Spec.Registry.Repo, "the registry follows the source")
 		assert.Equal(t, "HTTPS", after.Spec.Registry.Scheme)
 		assert.Equal(t, "ZG9ja2VyY2Zn", after.Spec.Registry.DockerCFG)
@@ -107,26 +107,26 @@ func TestSyncPackageRepositories(t *testing.T) {
 
 	t.Run("adopts an existing repository", func(t *testing.T) {
 		source := testModuleSource("external", "registry.example.io/external")
-		stale := sourceOwnerReference(source)
+		stale := moduleSourceOwnerReference(source)
 		stale.UID = "external-old-uid"
 		existing := &v1alpha1.PackageRepository{
 			ObjectMeta: metav1.ObjectMeta{Name: "external", OwnerReferences: []metav1.OwnerReference{stale}},
-			Spec:       v1alpha1.PackageRepositorySpec{Registry: registryFromSource(source)},
+			Spec:       v1alpha1.PackageRepositorySpec{Registry: registryFromModuleSource(source)},
 		}
 
 		s, cl := newTestSyncer(t, "v1.80.0", t.TempDir(), existing, source)
 
 		require.NoError(t, s.sync(ctx))
 
-		after := getRepository(t, cl, existing.Name)
-		assert.Equal(t, []metav1.OwnerReference{sourceOwnerReference(source)}, after.OwnerReferences, "the reference to the source created again is replaced")
+		after := getPackageRepository(t, cl, existing.Name)
+		assert.Equal(t, []metav1.OwnerReference{moduleSourceOwnerReference(source)}, after.OwnerReferences, "the reference to the source created again is replaced")
 	})
 
 	t.Run("keeps a repository matching the source untouched", func(t *testing.T) {
 		existing := &v1alpha1.PackageRepository{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            "external",
-				OwnerReferences: []metav1.OwnerReference{sourceOwnerReference(testModuleSource("external", ""))},
+				OwnerReferences: []metav1.OwnerReference{moduleSourceOwnerReference(testModuleSource("external", ""))},
 			},
 			Spec: v1alpha1.PackageRepositorySpec{
 				Registry: v1alpha1.PackageRepositorySpecRegistry{
@@ -142,11 +142,11 @@ func TestSyncPackageRepositories(t *testing.T) {
 		s, cl := newTestSyncer(t, "v1.80.0", t.TempDir(), existing,
 			testModuleSource("external", "registry.example.io/external"),
 		)
-		before := getRepository(t, cl, existing.Name)
+		before := getPackageRepository(t, cl, existing.Name)
 
 		require.NoError(t, s.sync(ctx))
 
-		after := getRepository(t, cl, existing.Name)
+		after := getPackageRepository(t, cl, existing.Name)
 		assert.Equal(t, before.ResourceVersion, after.ResourceVersion, "a matching repository is not rewritten")
 	})
 }

--- a/deckhouse-controller/internal/controller/pkgsync/pkgsync.go
+++ b/deckhouse-controller/internal/controller/pkgsync/pkgsync.go
@@ -117,7 +117,7 @@ type syncer struct {
 // illegal object name, an unreadable module dir, broken or missing schema
 // files) is skipped with a warning; an API failure stops the sync. An embedded
 // module skipped here reconciles nowhere, since the Module reconciler resolves
-// the same version - see known-hazards.md.
+// the same version.
 func Sync(ctx context.Context, reader client.Reader, writer client.Client, dc dependency.Container, deckhouseVersion, embeddedModulesDir, globalHooksDir string, logger *log.Logger) error {
 	return newSyncer(reader, writer, dc, deckhouseVersion, embeddedModulesDir, globalHooksDir, logger).sync(ctx)
 }

--- a/deckhouse-controller/internal/controller/pkgsync/pkgsync.go
+++ b/deckhouse-controller/internal/controller/pkgsync/pkgsync.go
@@ -147,9 +147,9 @@ func (s *syncer) sync(ctx context.Context) error {
 	return s.syncModulePackageVersions(ctx)
 }
 
-// RepositoryNameForSource maps a ModuleSource name to the name of the
+// PackageRepositoryNameForModuleSource maps a ModuleSource name to the name of the
 // PackageRepository serving the same registry path.
-func RepositoryNameForSource(sourceName string) string {
+func PackageRepositoryNameForModuleSource(sourceName string) string {
 	if sourceName == moduleSourceNameDeckhouse {
 		return repositoryNameDeckhouseModules
 	}

--- a/deckhouse-controller/internal/controller/pkgsync/pkgsync_test.go
+++ b/deckhouse-controller/internal/controller/pkgsync/pkgsync_test.go
@@ -111,7 +111,7 @@ func testModuleSource(name, repo string) *v1alpha1.ModuleSource {
 	}
 }
 
-func testRelease(module, source, version, phase string) *v1alpha1.ModuleRelease {
+func testModuleRelease(module, source, version, phase string) *v1alpha1.ModuleRelease {
 	return &v1alpha1.ModuleRelease{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   module + "-v" + version,
@@ -122,7 +122,7 @@ func testRelease(module, source, version, phase string) *v1alpha1.ModuleRelease 
 	}
 }
 
-func listVersionNames(t *testing.T, cl client.Client) []string {
+func listModulePackageVersionNames(t *testing.T, cl client.Client) []string {
 	t.Helper()
 
 	list := new(v1alpha1.ModulePackageVersionList)
@@ -136,7 +136,7 @@ func listVersionNames(t *testing.T, cl client.Client) []string {
 	return names
 }
 
-func listPackageNames(t *testing.T, cl client.Client) []string {
+func listModulePackageNames(t *testing.T, cl client.Client) []string {
 	t.Helper()
 
 	list := new(v1alpha1.ModulePackageList)
@@ -150,28 +150,28 @@ func listPackageNames(t *testing.T, cl client.Client) []string {
 	return names
 }
 
-// listModuleVersionNames lists every version except the global module's, whose name carries
+// listModulePackageVersionNamesExceptGlobal lists every version except the global module's, whose name carries
 // the running Deckhouse version and so is matched by prefix. Every sync writes that one, so a
 // test about the embedded modules dir or the releases drops it to keep asserting only on its
-// own producer; TestSyncGlobalVersion covers it directly.
-func listModuleVersionNames(t *testing.T, cl client.Client) []string {
+// own producer; TestSyncGlobalModulePackageVersion covers it directly.
+func listModulePackageVersionNamesExceptGlobal(t *testing.T, cl client.Client) []string {
 	t.Helper()
 
-	return slices.DeleteFunc(listVersionNames(t, cl), func(name string) bool {
+	return slices.DeleteFunc(listModulePackageVersionNames(t, cl), func(name string) bool {
 		return strings.HasPrefix(name, repositoryNameEmbedded+"-"+packageNameGlobal+"-")
 	})
 }
 
-// listModulePackageNames is listModuleVersionNames for the catalog entries.
-func listModulePackageNames(t *testing.T, cl client.Client) []string {
+// listModulePackageNamesExceptGlobal is listModulePackageVersionNamesExceptGlobal for the catalog entries.
+func listModulePackageNamesExceptGlobal(t *testing.T, cl client.Client) []string {
 	t.Helper()
 
-	return slices.DeleteFunc(listPackageNames(t, cl), func(name string) bool {
+	return slices.DeleteFunc(listModulePackageNames(t, cl), func(name string) bool {
 		return name == packageNameGlobal
 	})
 }
 
-func getVersion(t *testing.T, cl client.Client, name string) *v1alpha1.ModulePackageVersion {
+func getModulePackageVersion(t *testing.T, cl client.Client, name string) *v1alpha1.ModulePackageVersion {
 	t.Helper()
 
 	mpv := new(v1alpha1.ModulePackageVersion)
@@ -180,7 +180,7 @@ func getVersion(t *testing.T, cl client.Client, name string) *v1alpha1.ModulePac
 	return mpv
 }
 
-func getRepository(t *testing.T, cl client.Client, name string) *v1alpha1.PackageRepository {
+func getPackageRepository(t *testing.T, cl client.Client, name string) *v1alpha1.PackageRepository {
 	t.Helper()
 
 	repo := new(v1alpha1.PackageRepository)
@@ -189,7 +189,7 @@ func getRepository(t *testing.T, cl client.Client, name string) *v1alpha1.Packag
 	return repo
 }
 
-func listRepositoryNames(t *testing.T, cl client.Client) []string {
+func listPackageRepositoryNames(t *testing.T, cl client.Client) []string {
 	t.Helper()
 
 	list := new(v1alpha1.PackageRepositoryList)
@@ -203,7 +203,7 @@ func listRepositoryNames(t *testing.T, cl client.Client) []string {
 	return names
 }
 
-func TestRepositoryNameForSource(t *testing.T) {
+func TestPackageRepositoryNameForModuleSource(t *testing.T) {
 	cases := []struct {
 		source string
 		want   string
@@ -215,7 +215,7 @@ func TestRepositoryNameForSource(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		assert.Equal(t, c.want, RepositoryNameForSource(c.source), c.source)
+		assert.Equal(t, c.want, PackageRepositoryNameForModuleSource(c.source), c.source)
 	}
 }
 
@@ -227,24 +227,24 @@ func TestSyncIsIdempotent(t *testing.T) {
 
 	s, cl := newTestSyncer(t, "v1.80.0", dir,
 		testModuleSource("external", "registry.example.io/external"),
-		testRelease("parca", "deckhouse", "1.4.3", v1alpha1.ModuleReleasePhaseDeployed),
-		testRelease("console", "deckhouse", "1.60.1", v1alpha1.ModuleReleasePhasePending),
+		testModuleRelease("parca", "deckhouse", "1.4.3", v1alpha1.ModuleReleasePhaseDeployed),
+		testModuleRelease("console", "deckhouse", "1.60.1", v1alpha1.ModuleReleasePhasePending),
 	)
 
 	require.NoError(t, s.sync(ctx))
 
 	versions := make(map[string]string)
-	for _, name := range listVersionNames(t, cl) {
-		versions[name] = getVersion(t, cl, name).ResourceVersion
+	for _, name := range listModulePackageVersionNames(t, cl) {
+		versions[name] = getModulePackageVersion(t, cl, name).ResourceVersion
 	}
 	require.Len(t, versions, 4, "two releases, one embedded module and the global one")
-	repositoryRV := getRepository(t, cl, "external").ResourceVersion
+	repositoryRV := getPackageRepository(t, cl, "external").ResourceVersion
 
 	require.NoError(t, s.sync(ctx))
 
-	assert.Len(t, listVersionNames(t, cl), 4)
+	assert.Len(t, listModulePackageVersionNames(t, cl), 4)
 	for name, rv := range versions {
-		assert.Equal(t, rv, getVersion(t, cl, name).ResourceVersion, name)
+		assert.Equal(t, rv, getModulePackageVersion(t, cl, name).ResourceVersion, name)
 	}
-	assert.Equal(t, repositoryRV, getRepository(t, cl, "external").ResourceVersion)
+	assert.Equal(t, repositoryRV, getPackageRepository(t, cl, "external").ResourceVersion)
 }

--- a/deckhouse-controller/internal/controller/pkgsync/pkgsync_test.go
+++ b/deckhouse-controller/internal/controller/pkgsync/pkgsync_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -98,7 +99,7 @@ func writeOpenAPI(t *testing.T, dir, settings, values string) {
 
 func testModuleSource(name, repo string) *v1alpha1.ModuleSource {
 	return &v1alpha1.ModuleSource{
-		ObjectMeta: metav1.ObjectMeta{Name: name},
+		ObjectMeta: metav1.ObjectMeta{Name: name, UID: types.UID(name + "-uid")},
 		Spec: v1alpha1.ModuleSourceSpec{
 			Registry: v1alpha1.ModuleSourceSpecRegistry{
 				Scheme:    "HTTPS",

--- a/deckhouse-controller/internal/controller/pkgsync/pkgsync_test.go
+++ b/deckhouse-controller/internal/controller/pkgsync/pkgsync_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -99,7 +98,7 @@ func writeOpenAPI(t *testing.T, dir, settings, values string) {
 
 func testModuleSource(name, repo string) *v1alpha1.ModuleSource {
 	return &v1alpha1.ModuleSource{
-		ObjectMeta: metav1.ObjectMeta{Name: name, UID: types.UID(name + "-uid")},
+		ObjectMeta: metav1.ObjectMeta{Name: name},
 		Spec: v1alpha1.ModuleSourceSpec{
 			Registry: v1alpha1.ModuleSourceSpecRegistry{
 				Scheme:    "HTTPS",

--- a/deckhouse-controller/internal/controller/sync.go
+++ b/deckhouse-controller/internal/controller/sync.go
@@ -230,7 +230,7 @@ func (c *Controller) releasePlacements(ctx context.Context) (map[string]placemen
 		}
 
 		placements[name] = placement{
-			repository: pkgsync.RepositoryNameForSource(release.GetModuleSource()),
+			repository: pkgsync.PackageRepositoryNameForModuleSource(release.GetModuleSource()),
 			version:    release.GetModuleVersion(),
 		}
 	}

--- a/deckhouse-controller/pkg/controller/controller.go
+++ b/deckhouse-controller/pkg/controller/controller.go
@@ -221,10 +221,14 @@ func NewDeckhouseController(
 		opts.Cache.ByObject[&v1alpha1.Application{}] = cache.ByObject{}
 	}
 
-	// Module package controllers (feature flag)
-	if app.ModulePackagesEnabled() {
+	// Module package sync (feature flag)
+	if app.ModulePackageSyncEnabled() {
 		opts.Cache.ByObject[&v1alpha1.ModulePackage{}] = cache.ByObject{}
 		opts.Cache.ByObject[&v1alpha1.ModulePackageVersion{}] = cache.ByObject{}
+	}
+
+	// Module v2 controller (feature flag)
+	if app.ModulePackagesEnabled() {
 		opts.Cache.ByObject[&v1alpha2.Module{}] = cache.ByObject{}
 	}
 
@@ -414,14 +418,19 @@ func NewDeckhouseController(
 		}
 	}
 
-	// Module package controllers (feature flag)
-	if app.ModulePackagesEnabled() {
-		logger.Info("Module package controllers are enabled")
+	// Module package sync (feature flag)
+	if app.ModulePackageSyncEnabled() {
+		logger.Info("Module package sync is enabled")
 
 		err = modulepackageversion.RegisterController(preflightCountDown, runtimeManager, dc, logger)
 		if err != nil {
 			return nil, fmt.Errorf("register module package version controller: %w", err)
 		}
+	}
+
+	// Module v2 controller (feature flag)
+	if app.ModulePackagesEnabled() {
+		logger.Info("Module v2 controller is enabled")
 
 		err = module.RegisterController(preflightCountDown, runtimeManager, pkgRuntime, logger)
 		if err != nil {
@@ -474,8 +483,10 @@ func (c *DeckhouseController) Start(ctx context.Context) error {
 	// give the old module stack its package system objects before any
 	// controller runs; the sync reads through the API reader, so it does not
 	// need the manager cache
-	if err := pkgsync.Sync(ctx, c.runtimeManager.GetAPIReader(), c.runtimeManager.GetClient(), c.dc, app.Version, app.EmbeddedModulesDir, app.GlobalHooksDir, c.log.Named("pkgsync")); err != nil {
-		return fmt.Errorf("sync package objects: %w", err)
+	if app.ModulePackageSyncEnabled() {
+		if err := pkgsync.Sync(ctx, c.runtimeManager.GetAPIReader(), c.runtimeManager.GetClient(), c.dc, app.Version, app.EmbeddedModulesDir, app.GlobalHooksDir, c.log.Named("pkgsync")); err != nil {
+			return fmt.Errorf("sync package objects: %w", err)
+		}
 	}
 
 	// run preflight check

--- a/modules/002-deckhouse/templates/deployment.yaml
+++ b/modules/002-deckhouse/templates/deployment.yaml
@@ -196,6 +196,8 @@ spec:
               value: {{ .Values.deckhouse.logLevel }}
             - name: DECKHOUSE_ENABLE_PACKAGE_SYSTEM
               value: "true"
+            - name: DECKHOUSE_ENABLE_MODULE_PACKAGE_SYNC
+              value: "false"
             - name: DECKHOUSE_ENABLE_MODULE_PACKAGES
               value: "false"
             - name: USE_NELM


### PR DESCRIPTION
## Description

Phase 1 of splitting `feat/introduce-module-v2` into small PRs. Module v2 is not touched: no CRD change, its controller stays off.

New flag `DECKHOUSE_ENABLE_MODULE_PACKAGE_SYNC` (`app.ModulePackageSyncEnabled()`). It turns on:
- the startup sync `pkgsync`: a PackageRepository for every user ModuleSource, a ModulePackageVersion for every embedded module and every ModuleRelease;
- the ModulePackageVersion controller that fills the drafts;
- the manager cache for ModulePackage and ModulePackageVersion.

`DECKHOUSE_ENABLE_MODULE_PACKAGES` now covers only the Module v2 controller and its cache.

The deployment template ships the new flag off.

Unchanged:
- source to repository name mapping: `deckhouse` -> `deckhouse-modules`, other sources keep their name;
- the `deckhouse` and `flant` sources are skipped, their repositories come from the templates;
- login, password and scan interval of an existing repository are never touched.
- the repository is not owned by the source and stays when the source is deleted: the sync is a one-off migration, it never deletes.

## Why do we need it, and what problem does it solve?

On main the sync runs on every cluster with no flag. The controller that fills its drafts sits behind the same flag as the Module v2 controller. That flag cannot be turned on: the v2 controller watches `v1alpha2.Module`, the CRD serves only v1alpha1, and the manager fails on cache sync.

With separate flags we can turn on the package objects of the old stack (repositories and versions) and check them on their own, before Module v2 becomes primary.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse-controller
type: feature
summary: Gate the startup sync of module sources and releases into package objects behind DECKHOUSE_ENABLE_MODULE_PACKAGE_SYNC
impact_level: low
```

