### PR TITLE
[node-manager] Refactor bootstrap scripts to handle interrupted bootstraps and improve guards

### DIFF
--- a/modules/040-node-manager/images/node-controller/src/internal/bootstrap/cloudconfig.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/bootstrap/cloudconfig.go
@@ -84,15 +84,18 @@ func RenderStaticScript(in Input) ([]byte, error) {
 	var out bytes.Buffer
 	out.WriteString(`#!/bin/bash
 
-if [[ -f /var/lib/bashible/bootstrap-token ]]; then
-  echo "The node already have bootstrap-token and under bashible."
-  exit 1
-fi
-
 checkBashible=$(systemctl is-active bashible.timer)
 if [[ "$checkBashible" == "active" ]]; then
   echo "The node already exists in the cluster and under bashible."
   exit 2
+fi
+
+if [[ -f /var/lib/bashible/bootstrap-token ]]; then
+  if [[ -f /etc/kubernetes/kubelet.conf ]]; then
+    echo "The node has already joined the cluster, its bootstrap cannot be resumed here."
+    exit 1
+  fi
+  echo "Bootstrap was interrupted before bashible took over, resuming it."
 fi
 
 mkdir -p /var/lib/bashible

--- a/modules/040-node-manager/images/node-controller/src/internal/bootstrap/render_test.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/bootstrap/render_test.go
@@ -19,6 +19,7 @@ package bootstrap
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,7 +30,10 @@ import (
 // verbatim in testdata/helm-values.yaml. Taking them from our own render would be
 // pointless: such a golden guards nothing but its own drift — and the templates are gone,
 // so there is no oracle to regenerate from either. Every Input below mirrors the values
-// its golden was rendered from.
+// its golden was rendered from. The two bootstrap.sh goldens are the one exception: their
+// preamble was rewritten on purpose after the port, so a bootstrap CAPS interrupted resumes
+// instead of failing with exit 1 until the machine-health-check wipes /var/lib/bashible
+// twenty minutes later, and it no longer matches what helm emitted.
 func TestRenderMatchesHelmGoldens(t *testing.T) {
 	files := frozenFiles(t)
 
@@ -86,6 +90,63 @@ func TestRenderMatchesHelmGoldens(t *testing.T) {
 			require.NoError(t, err)
 
 			assert.Equal(t, string(want), string(got))
+		})
+	}
+}
+
+// The golden freezes these bytes but says nothing about which of them carry weight.
+// caps-controller-manager reads only the exit code, and reads it inverted: exit 2 is the
+// answer it accepts as success (internal/client/bootstrap.go), any other code is a failed
+// bootstrap it retries until the machine-health-check wipes the node. So the timer has to
+// be tested before the token — a node that is already under bashible must answer 2, not 1 —
+// and a node whose bootstrap merely broke off must fall through to the install.
+func TestStaticScriptPreambleGuards(t *testing.T) {
+	script, err := RenderStaticScript(staticInput(frozenFiles(t)))
+	require.NoError(t, err)
+
+	preamble, _, ok := strings.Cut(string(script), `cat > /var/lib/bashible/bootstrap.sh`)
+	require.True(t, ok, "the preamble no longer ends at the bootstrap.sh heredoc")
+
+	timerGuard, tokenGuard, ok := strings.Cut(preamble, `if [[ -f /var/lib/bashible/bootstrap-token ]]; then`)
+	require.True(t, ok, "the bootstrap-token guard is gone")
+
+	joinedGate, resumePath, ok := strings.Cut(tokenGuard, "\n  fi\n")
+	require.True(t, ok, "the gate nested in the bootstrap-token guard is gone")
+
+	cases := []struct {
+		name        string
+		segment     string
+		contains    []string
+		notContains []string
+	}{
+		{
+			name:        "a node under bashible is answered before the token is looked at",
+			segment:     timerGuard,
+			contains:    []string{`systemctl is-active bashible.timer`, "exit 2"},
+			notContains: []string{"exit 1"},
+		},
+		{
+			name:     "a node that has joined the cluster is refused",
+			segment:  joinedGate,
+			contains: []string{`if [[ -f /etc/kubernetes/kubelet.conf ]]; then`, "exit 1"},
+		},
+		{
+			name:        "an interrupted bootstrap resumes instead of exiting",
+			segment:     resumePath,
+			contains:    []string{`mkdir -p /var/lib/bashible`},
+			notContains: []string{"exit"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, want := range tc.contains {
+				assert.Contains(t, tc.segment, want)
+			}
+
+			for _, unwanted := range tc.notContains {
+				assert.NotContains(t, tc.segment, unwanted)
+			}
 		})
 	}
 }

--- a/modules/040-node-manager/images/node-controller/src/internal/bootstrap/testdata/golden/cloud-permanent-bootstrap-sh.txt
+++ b/modules/040-node-manager/images/node-controller/src/internal/bootstrap/testdata/golden/cloud-permanent-bootstrap-sh.txt
@@ -1,14 +1,17 @@
 #!/bin/bash
 
-if [[ -f /var/lib/bashible/bootstrap-token ]]; then
-  echo "The node already have bootstrap-token and under bashible."
-  exit 1
-fi
-
 checkBashible=$(systemctl is-active bashible.timer)
 if [[ "$checkBashible" == "active" ]]; then
   echo "The node already exists in the cluster and under bashible."
   exit 2
+fi
+
+if [[ -f /var/lib/bashible/bootstrap-token ]]; then
+  if [[ -f /etc/kubernetes/kubelet.conf ]]; then
+    echo "The node has already joined the cluster, its bootstrap cannot be resumed here."
+    exit 1
+  fi
+  echo "Bootstrap was interrupted before bashible took over, resuming it."
 fi
 
 mkdir -p /var/lib/bashible

--- a/modules/040-node-manager/images/node-controller/src/internal/bootstrap/testdata/golden/static-instances-bootstrap-sh.txt
+++ b/modules/040-node-manager/images/node-controller/src/internal/bootstrap/testdata/golden/static-instances-bootstrap-sh.txt
@@ -1,14 +1,17 @@
 #!/bin/bash
 
-if [[ -f /var/lib/bashible/bootstrap-token ]]; then
-  echo "The node already have bootstrap-token and under bashible."
-  exit 1
-fi
-
 checkBashible=$(systemctl is-active bashible.timer)
 if [[ "$checkBashible" == "active" ]]; then
   echo "The node already exists in the cluster and under bashible."
   exit 2
+fi
+
+if [[ -f /var/lib/bashible/bootstrap-token ]]; then
+  if [[ -f /etc/kubernetes/kubelet.conf ]]; then
+    echo "The node has already joined the cluster, its bootstrap cannot be resumed here."
+    exit 1
+  fi
+  echo "Bootstrap was interrupted before bashible took over, resuming it."
 fi
 
 mkdir -p /var/lib/bashible


### PR DESCRIPTION
## Description

The bootstrap script that node-controller renders for manually bootstrapped node groups no longer refuses a node whose bootstrap was interrupted.

Two things changed in the guard preamble of `RenderStaticScript`:

- The `bashible.timer` check runs first. A node that is already under bashible still answers exit 2, which is the code caps-controller-manager reads as success.
- The `bootstrap-token` check moved below it and no longer refuses on its own. A node holding a token is refused with exit 1 only when `/etc/kubernetes/kubelet.conf` shows it has already joined the cluster. Otherwise the script reports an interrupted bootstrap and completes it.

This is the `bootstrap.sh` key of the `manual-bootstrap-for-<ng>` secret, so the change reaches Static, CloudStatic, CloudPermanent and hybrid node groups, `manual-bootstrap-for-master` included. CloudEphemeral goes through the CAPI path and is untouched.

Both `bootstrap.sh` goldens were updated and a unit test now pins the order of the guards, the kubelet.conf gate and the two exit codes.

No restarts of critical cluster components. Only nodes that are being bootstrapped are affected.

## Why do we need it, and what problem does it solve?

A CAPS bootstrap runs as a foreground ssh session owned by caps-controller-manager. While the cluster has a single master, kube-apiserver drops out whenever control-plane-manager rewrites its static pod manifest. caps-controller-manager gets 50 seconds to renew its leader lease (`--leader-elect-renew-deadline=50s`); when it cannot, the process exits and the ssh session dies with it. The install stops after `/var/lib/bashible/bootstrap-token` has been written and before bashible takes over.

Every later attempt then hit the token guard and exited 1 within a second, so the node made no progress at all. The only recovery was MachineHealthCheck reaching `nodeStartupTimeoutSeconds` (1200), wiping `/var/lib/bashible` and rebooting the node for a bootstrap from scratch. That is about 27 minutes for what takes five when nothing is interrupted, and `dhctl bootstrap` waits 15 minutes for resources by default.

Two details shape the fix.

The token alone does not tell the two cases apart, and the old message was wrong about the state it described: a node holding the token is precisely the one that is *not* under bashible yet. `bashible.timer` goes active at step 080 (`080_setup_timer_to_run_bashible.sh.tpl`) and the token is removed at step 098 (`098_cleanup.sh.tpl`), so a token next to an active timer is an ordinary state that lasts minutes. Testing the timer first keeps that state answering exit 2.

What does separate a resumable node from one that must not be touched is `/etc/kubernetes/kubelet.conf`. Under `runType: Normal` no bashible step writes it: 061 writes `bootstrap-kubelet.conf` and skips when `kubelet.conf` exists, 065 only rewrites a file that is already there, and 068 merely names it as kubelet's `--kubeconfig`. kubelet creates it once TLS bootstrap succeeds, so its presence means the node has authenticated to the apiserver and registered. Resuming past that point is not safe: `069_check_hostname_uniqueness.sh.tpl` would find the node's own Node object and exit 1, and phase 2 runs `bashible.sh` without `--max-retries`, so its `until` loop would keep retrying that step forever. The one step that copies `kubelet.conf` into place is `cluster-bootstrap/062_generate_kubeconfig_for_kubelet.sh.tpl`, rendered only by dhctl (`dhctl/pkg/template/bundle.go`) and excluded from bashible-apiserver, and that flow does not use this script.

Every documented cleanup removes `/etc/kubernetes` (`cleanup_static_node.sh.tpl`), including the one caps-controller-manager runs when a Machine is deleted, so a node that was cleaned up bootstraps again as before.

## Why do we need it in the patch release (if we do)?

Any interrupted ssh session leaves a static node stalled for 20 minutes, and on a single-master control plane the interruption comes from ordinary apiserver unavailability rather than a rare race. `dhctl bootstrap` of a multi-master static cluster fails on the default `--resources-timeout` because of it.

One note on ordering. On main the script is rendered in Go by node-controller, which is what this PR changes. Release branches still carry the helm template `_static_or_hybrid_script.tpl`, untouched here. Merge this first, then backport the same preamble to the template, otherwise an upgrade silently restores the old behaviour: the bootstrap secret is written with `Apply` and `ForceOwnership` on a 30 minute resync.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

No documentation change: nothing in the docs mentions the exit codes or the removed message. The fix has not been verified on a live cluster yet. What needs testing there: killing the caps-controller-manager pod during a static install and confirming the node reaches Ready without a `MachineMarkedUnhealthy` event, an interruption after the Node has registered (the node must be refused, not looped), and an interruption between steps 080 and 098.

## Changelog entries

```changes
section: node-manager
type: fix
summary: An interrupted bootstrap of a static node is completed on the next attempt instead of being refused.
impact_level: default
```
